### PR TITLE
[ZONOS2] Release decode state at request termination

### DIFF
--- a/sglang_omni/models/zonos2/engine_builder.py
+++ b/sglang_omni/models/zonos2/engine_builder.py
@@ -220,6 +220,10 @@ class Zonos2EngineBuilder(TtsEngineBuilder):
 
         return make_zonos2_scheduler_adapters(model=model)
 
+    def make_abort_callback(self) -> Any | None:
+        assert self.model is not None
+        return self.model.reset_request
+
     def extra_scheduler_kwargs(self) -> dict[str, Any]:
         return {"enable_async_decode": self.async_decode}
 

--- a/sglang_omni/models/zonos2/model_runner.py
+++ b/sglang_omni/models/zonos2/model_runner.py
@@ -273,30 +273,30 @@ class Zonos2ModelRunner(ModelRunner):
             schedule_batch.output_ids = next_ids
 
         # launch_buf snapshots what the (lagged) resolve reads. Pack codes +
-        # the per-row EOS/finished state into one fresh int64 tensor (advanced
-        # indexing already copies, and cat makes a fresh tensor, so it is a
-        # snapshot even though the next launch mutates these pool rows). Record a
-        # CUDA event right after, so resolve's side-stream D2H waits only for this
-        # (codes ready), not the next forward. next_ids is cloned: the base
-        # aliases it onto output_ids, overwritten in place before this resolve.
+        # per-row EOS metadata into one fresh int64 tensor (advanced indexing
+        # already copies, and cat makes a fresh tensor, so it remains stable
+        # while the next launch mutates these pool rows). Record a CUDA event
+        # right after, so resolve's side-stream D2H waits only for this (codes
+        # ready), not the next forward. next_ids is cloned: the base aliases it
+        # onto output_ids, overwritten in place before this resolve.
         meta = torch.stack(
             (
                 pool.eos_frame_set[row_t].to(torch.int64),
                 pool.eos_frame_val[row_t],
-                finished.to(torch.int64),
             ),
             dim=1,
         )
-        packed = torch.cat((codes, meta), dim=1)  # [B, n+3] int64
+        packed = torch.cat((codes, meta), dim=1)  # [B, n+2] int64
         ev = torch.cuda.Event()
         ev.record()
         return (requests, packed, n, next_ids.clone(), ev)
 
     def _collect_resolve(self, launch_buf, result) -> None:
         # Host half (runs lagged under async, overlapping the next decode forward):
-        # the deferred codes.to('cpu') -> per-request output_codes + eos_frame, and
-        # release-on-finish. Restores next_ids to the launch-time (un-clobbered)
-        # value for the shared finalize tail.
+        # the deferred codes.to('cpu') -> per-request output_codes + eos_frame.
+        # Restores next_ids to the launch-time (un-clobbered) value for the
+        # shared finalize tail. Request release belongs to the scheduler's
+        # terminal result / abort adapters, which cover every finish reason.
         if launch_buf is None:
             return
         requests, packed, n, next_ids_snap, ev = launch_buf
@@ -305,7 +305,7 @@ class Zonos2ModelRunner(ModelRunner):
         # Copy on a side stream gated by the launch event: the copy starts as soon
         # as codes(N) is ready (event recorded before the next forward was queued)
         # and runs on a separate stream, so this no longer whole-stream-syncs on
-        # forward(N+1). One D2H of the packed [B, n+3] snapshot.
+        # forward(N+1). One D2H of the packed [B, n+2] snapshot.
         if self._copy_stream is None:
             self._copy_stream = torch.cuda.Stream(device=packed.device)
         self._copy_stream.wait_event(ev)
@@ -315,14 +315,10 @@ class Zonos2ModelRunner(ModelRunner):
         codes_cpu = packed_cpu[:, :n]
         eos_set_cpu = packed_cpu[:, n]
         eos_val_cpu = packed_cpu[:, n + 1]
-        finished_cpu = packed_cpu[:, n + 2]
-        pool = self.model._decode_state_pool
         for i, sr in enumerate(requests):
             data = sr.data
             data.output_codes.append(codes_cpu[i].clone())
             data.eos_frame = int(eos_val_cpu[i]) if bool(eos_set_cpu[i]) else None
-            if bool(finished_cpu[i]):
-                pool.release_row(sr.request_id)
 
     def _rep_window(self, row_t, n, cb_size, params):
         # Vectorized rep-penalty token window from the on-device history ring.

--- a/sglang_omni/models/zonos2/request_builders.py
+++ b/sglang_omni/models/zonos2/request_builders.py
@@ -252,6 +252,12 @@ def make_zonos2_scheduler_adapters(*, model: Any):
         return build_sglang_zonos2_request(payload, model=model)
 
     def result_adapter(data: Zonos2SGLangRequestData) -> StagePayload:
-        return apply_sglang_zonos2_result(data.stage_payload, data)
+        try:
+            return apply_sglang_zonos2_result(data.stage_payload, data)
+        finally:
+            # Terminal adapters own decode-state lifetime. Release for every
+            # finish reason, including length limits and adapter failures, rather
+            # than relying on the model sampler to observe its own EOS.
+            model.reset_request(data.stage_payload.request_id)
 
     return request_builder, result_adapter

--- a/sglang_omni/models/zonos2/request_builders.py
+++ b/sglang_omni/models/zonos2/request_builders.py
@@ -255,9 +255,9 @@ def make_zonos2_scheduler_adapters(*, model: Any):
         try:
             return apply_sglang_zonos2_result(data.stage_payload, data)
         finally:
-            # Terminal adapters own decode-state lifetime. Release for every
-            # finish reason, including length limits and adapter failures, rather
-            # than relying on the model sampler to observe its own EOS.
+            # note(ratish): For completed requests, scheduler terminalization—not
+            # sampler EOS—is the ownership boundary; finally prevents adapter
+            # errors from stranding the row.
             model.reset_request(data.stage_payload.request_id)
 
     return request_builder, result_adapter

--- a/sglang_omni/models/zonos2/sglang_model.py
+++ b/sglang_omni/models/zonos2/sglang_model.py
@@ -280,6 +280,10 @@ class Zonos2SGLangModel(nn.Module):
     def dtype(self) -> torch.dtype:
         return self.embedders[0].weight.dtype
 
+    def reset_request(self, rid: str) -> None:
+        """Release decode state for a finished or aborted request."""
+        self._decode_state_pool.release_row(rid)
+
     def embed_frames(self, rows: torch.Tensor) -> torch.Tensor:
         """Sum the per-column embeddings of ``(T, frame_width)`` int rows."""
         out = self.embedders[0](rows[:, 0].contiguous())

--- a/sglang_omni/models/zonos2/state_pool.py
+++ b/sglang_omni/models/zonos2/state_pool.py
@@ -1,16 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-"""On-device per-request decode state for ZONOS2 (RTF: removes the per-step D2H
-syncs + Python EOS loop in model_runner._collect_frame).
+"""On-device per-request decode state for ZONOS2.
 
 Each in-flight request holds a fixed row; per-step feedback, the EOS state
 machine and the generation step live in pre-allocated GPU tensors indexed by
-row, so the decode tail can run as pure device math without ``codes.to('cpu')``
-/ ``keys.tolist()``. Modelled on ``moss_tts_local.state_pool``. A reserved
-padding row (``P-1``) is never handed out, giving graph replay a stable index
-for padded batch slots.
-
-Step 1 of the eager-tail plan: this is allocated but NOT yet read by the runner,
-so the decode output is byte-identical until the wiring lands.
+row, so the decode tail can update state as device math. Modelled on
+``moss_tts_local.state_pool``. A reserved padding row (``P-1``) is never handed
+out, giving graph replay a stable index for padded batch slots.
 """
 
 from __future__ import annotations
@@ -96,6 +91,11 @@ class Zonos2DecodeStatePool:
         row_idx = self._rid_to_row.pop(rid, None)
         if row_idx is None:
             return
+        # The cached tensor is valid only while every request-to-row mapping
+        # used to build it is still owned. Invalidate it before recycling a row
+        # so an immediately reused request id cannot bypass acquire_row().
+        self._active_ids = None
+        self._active_rows = None
         self.reset_row(row_idx)
         self._free_rows.append(row_idx)
 
@@ -131,11 +131,12 @@ class Zonos2DecodeStatePool:
         return rows
 
     def release_inactive(self, active_rids) -> None:
-        """Free rows whose request is no longer in the batch (finished/dropped).
+        """Reconcile row ownership with the current decode batch.
 
-        The base runner has no per-request finish hook; reconciling against the
-        live batch each decode step self-cleans the pool without one. A request
-        that comes back (retraction/re-prefill) re-acquires a freshly reset row.
+        Terminal result and abort adapters are the primary cleanup paths. This
+        fallback handles batch removal such as retraction and recovers any
+        stranded older row before the next decode. A request that comes back
+        after retraction/re-prefill acquires a freshly reset row.
         """
         stale = [rid for rid in self._rid_to_row if rid not in active_rids]
         for rid in stale:

--- a/tests/README.md
+++ b/tests/README.md
@@ -486,6 +486,12 @@ that happened to contain an older version of the test.
     equivalence, CUDA bf16 packed-vs-SDPA parity, zero-length handling, and
     flash-unavailable fallback.
 
+- `unit_test/zonos2/`: ZONOS2 unit tests:
+  - pipeline configuration, text normalization, and speaker/component caches
+  - streaming vocoder chunking and flush behavior
+  - scheduler terminal/abort cleanup, complete row reset and reuse, mixed-batch
+    ownership, and async resolve contracts.
+
 - `unit_test/router/`: SGLang-Omni Router unit tests:
   - router CLI/config behavior
   - worker metadata and health-state contracts

--- a/tests/unit_test/zonos2/test_state_lifecycle.py
+++ b/tests/unit_test/zonos2/test_state_lifecycle.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import contextlib
 import time
+from queue import Queue
 from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 import torch
 
 from sglang_omni.models.zonos2 import request_builders
 from sglang_omni.models.zonos2.engine_builder import Zonos2EngineBuilder
+from sglang_omni.models.zonos2.model_runner import Zonos2ModelRunner
 from sglang_omni.models.zonos2.payload_types import (
     FRAME_WIDTH,
     N_CODEBOOKS,
@@ -19,8 +23,56 @@ from sglang_omni.models.zonos2.request_builders import (
     Zonos2SGLangRequestData,
     make_zonos2_scheduler_adapters,
 )
+from sglang_omni.models.zonos2.sglang_model import Zonos2SGLangModel
 from sglang_omni.models.zonos2.state_pool import Zonos2DecodeStatePool
 from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+
+class _ModelHarness:
+    reset_request = Zonos2SGLangModel.reset_request
+
+    def __init__(self, pool: Zonos2DecodeStatePool) -> None:
+        self._decode_state_pool = pool
+
+
+class _FakeCopyStream:
+    def wait_event(self, _event) -> None:
+        pass
+
+    def synchronize(self) -> None:
+        pass
+
+
+def _model_and_pool() -> tuple[_ModelHarness, Zonos2DecodeStatePool]:
+    pool_owner = SimpleNamespace(
+        _decode_input_embedding=SimpleNamespace(
+            weight=torch.zeros((2, 3), dtype=torch.float32)
+        ),
+        n_codebooks=N_CODEBOOKS,
+    )
+    pool = Zonos2DecodeStatePool(pool_owner)
+    return _ModelHarness(pool), pool
+
+
+def _poison_row(pool: Zonos2DecodeStatePool, row: int, value: int = 7) -> None:
+    pool.feedback_embeds[row].fill_(value)
+    pool.eos_frame_set[row] = True
+    pool.eos_frame_val[row] = value
+    pool.eos_countdown[row] = value
+    pool.generation_step[row] = value
+    pool.rep_hist[row].fill_(value)
+    pool.rep_len[row] = value
+
+
+def _assert_row_reset(pool: Zonos2DecodeStatePool, row: int) -> None:
+    assert torch.count_nonzero(pool.feedback_embeds[row]) == 0
+    assert not bool(pool.eos_frame_set[row])
+    assert int(pool.eos_frame_val[row]) == 0
+    assert int(pool.eos_countdown[row]) == 0
+    assert int(pool.generation_step[row]) == 0
+    assert torch.all(pool.rep_hist[row] == -1)
+    assert int(pool.rep_len[row]) == 0
 
 
 def _terminal_data(request_id: str = "req-zonos2") -> Zonos2SGLangRequestData:
@@ -37,21 +89,56 @@ def _terminal_data(request_id: str = "req-zonos2") -> Zonos2SGLangRequestData:
     )
 
 
-def test_result_adapter_releases_terminal_request_state() -> None:
-    reset_calls: list[str] = []
-    model = SimpleNamespace(reset_request=reset_calls.append)
+def test_length_terminal_releases_pool_row_through_scheduler_result_path() -> None:
+    from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.sampling.sampling_params import SamplingParams
+
+    request_id = "req-length"
+    model, pool = _model_and_pool()
     _, result_adapter = make_zonos2_scheduler_adapters(model=model)
+    data = _terminal_data(request_id)
+    row = pool.acquire_row(request_id)
+    _poison_row(pool, row)
 
-    result = result_adapter(_terminal_data())
+    sampling_params = SamplingParams(max_new_tokens=1, temperature=0.0)
+    sampling_params.normalize(tokenizer=None)
+    req = Req(
+        rid=request_id,
+        origin_input_text="",
+        origin_input_ids=[1],
+        sampling_params=sampling_params,
+        vocab_size=2,
+    )
+    req._omni_data = data
+    req.output_ids.append(1)
+    req.check_finished()
+    assert req.finished_reason.to_json()["type"] == "length"
 
-    assert result.data["completion_tokens"] == 1
-    assert reset_calls == ["req-zonos2"]
+    scheduler = object.__new__(OmniScheduler)
+    scheduler.outbox = Queue()
+    scheduler._aborted_request_ids = set()
+    scheduler._first_emit_done = {request_id}
+    scheduler._prefill_start_done = {request_id}
+    scheduler._result_adapter = result_adapter
+    scheduler.server_args = SimpleNamespace(weight_version=None)
+
+    scheduler.stream_output([req])
+
+    result = scheduler.outbox.get_nowait()
+    assert result.type == "result"
+    assert data.finish_reason == "length"
+    assert result.data.data["completion_tokens"] == 1
+    assert request_id not in pool._rid_to_row
+    assert len(pool._free_rows) == pool.padding_row
+    _assert_row_reset(pool, row)
 
 
 def test_result_adapter_releases_state_when_serialization_fails(monkeypatch) -> None:
-    reset_calls: list[str] = []
-    model = SimpleNamespace(reset_request=reset_calls.append)
+    request_id = "req-adapter-error"
+    model, pool = _model_and_pool()
     _, result_adapter = make_zonos2_scheduler_adapters(model=model)
+    row = pool.acquire_row(request_id)
+    _poison_row(pool, row)
 
     def fail_result(*_args, **_kwargs):
         raise RuntimeError("serialization failed")
@@ -59,49 +146,98 @@ def test_result_adapter_releases_state_when_serialization_fails(monkeypatch) -> 
     monkeypatch.setattr(request_builders, "apply_sglang_zonos2_result", fail_result)
 
     with pytest.raises(RuntimeError, match="serialization failed"):
-        result_adapter(_terminal_data())
+        result_adapter(_terminal_data(request_id))
 
-    assert reset_calls == ["req-zonos2"]
+    assert request_id not in pool._rid_to_row
+    assert len(pool._free_rows) == pool.padding_row
+    _assert_row_reset(pool, row)
 
 
-def test_engine_builder_abort_callback_releases_request_state() -> None:
+def test_engine_builder_abort_callback_is_safe_before_and_after_allocation() -> None:
+    request_id = "req-abort"
+    model, pool = _model_and_pool()
     builder = Zonos2EngineBuilder()
-    with pytest.raises(AssertionError):
-        builder.make_abort_callback()
-
-    reset_calls: list[str] = []
-    builder.model = SimpleNamespace(reset_request=reset_calls.append)
+    builder.model = model
     abort_callback = builder.make_abort_callback()
     builder.model = None
 
-    abort_callback("req-zonos2")
+    free_rows = list(pool._free_rows)
+    abort_callback(request_id)
+    assert pool._free_rows == free_rows
 
-    assert reset_calls == ["req-zonos2"]
+    row = pool.acquire_row(request_id)
+    _poison_row(pool, row)
+    abort_callback(request_id)
+    abort_callback(request_id)
+
+    assert request_id not in pool._rid_to_row
+    assert len(pool._free_rows) == pool.padding_row
+    assert len(set(pool._free_rows)) == pool.padding_row
+    _assert_row_reset(pool, row)
 
 
-def test_release_invalidates_cached_active_rows_before_request_id_reuse() -> None:
-    model = SimpleNamespace(
-        _decode_input_embedding=SimpleNamespace(
-            weight=torch.zeros((2, 3), dtype=torch.float32)
-        ),
-        n_codebooks=2,
+def test_release_resets_reused_row_without_touching_mixed_batch_survivor() -> None:
+    model, pool = _model_and_pool()
+    done = SimpleNamespace(request_id="done")
+    live = SimpleNamespace(request_id="live")
+    done_row, live_row = (
+        int(row) for row in pool.prepare_active_rows([done, live]).tolist()
     )
-    pool = Zonos2DecodeStatePool(model)
-    request = SimpleNamespace(request_id="reused-rid")
+    _poison_row(pool, done_row, value=3)
+    _poison_row(pool, live_row, value=11)
 
-    first_row = int(pool.prepare_active_rows([request])[0])
-    pool.feedback_embeds[first_row].fill_(1)
-    pool.release_row(request.request_id)
+    model.reset_request(done.request_id)
     free_rows_after_release = len(pool._free_rows)
-    pool.release_row(request.request_id)
+    model.reset_request(done.request_id)
 
-    assert request.request_id not in pool._rid_to_row
+    assert done.request_id not in pool._rid_to_row
+    assert pool.row_for(live.request_id) == live_row
     assert pool._active_ids is None
     assert pool._active_rows is None
-    assert torch.count_nonzero(pool.feedback_embeds[first_row]) == 0
+    _assert_row_reset(pool, done_row)
+    assert torch.all(pool.feedback_embeds[live_row] == 11)
+    assert bool(pool.eos_frame_set[live_row])
+    assert int(pool.eos_frame_val[live_row]) == 11
+    assert int(pool.eos_countdown[live_row]) == 11
+    assert int(pool.generation_step[live_row]) == 11
+    assert torch.all(pool.rep_hist[live_row] == 11)
+    assert int(pool.rep_len[live_row]) == 11
     assert len(pool._free_rows) == free_rows_after_release
+    assert len(set(pool._free_rows)) == len(pool._free_rows)
 
-    reused_row = int(pool.prepare_active_rows([request])[0])
+    active_rows = pool.prepare_active_rows([live, done])
 
-    assert pool._rid_to_row[request.request_id] == reused_row
-    assert len(pool._free_rows) == pool.padding_row - 1
+    assert active_rows.tolist() == [live_row, done_row]
+    _assert_row_reset(pool, done_row)
+    owned_rows = set(pool._rid_to_row.values())
+    free_rows = set(pool._free_rows)
+    assert len(owned_rows) == len(pool._rid_to_row)
+    assert len(free_rows) == len(pool._free_rows)
+    assert owned_rows.isdisjoint(free_rows)
+    assert len(owned_rows) + len(free_rows) == pool.padding_row
+
+
+def test_resolve_collects_compact_metadata_without_releasing_state() -> None:
+    request_id = "req-resolve"
+    model, pool = _model_and_pool()
+    row = pool.acquire_row(request_id)
+
+    runner = Zonos2ModelRunner.__new__(Zonos2ModelRunner)
+    runner.model = model
+    runner._copy_stream = _FakeCopyStream()
+    data = SimpleNamespace(output_codes=[], eos_frame=None)
+    request = SimpleNamespace(request_id=request_id, data=data)
+    codes = list(range(N_CODEBOOKS))
+    packed = torch.tensor([codes + [1, 5]], dtype=torch.int64)
+    next_ids = torch.tensor([123], dtype=torch.int64)
+    result = SimpleNamespace(next_token_ids=None)
+    launch_buf = ([request], packed, N_CODEBOOKS, next_ids, object())
+
+    with mock.patch("torch.cuda.stream", lambda _stream: contextlib.nullcontext()):
+        runner._collect_resolve(launch_buf, result)
+
+    assert data.output_codes[0].tolist() == codes
+    assert data.eos_frame == 5
+    assert torch.equal(result.next_token_ids, next_ids)
+    assert pool.row_for(request_id) == row
+    assert row not in pool._free_rows

--- a/tests/unit_test/zonos2/test_state_lifecycle.py
+++ b/tests/unit_test/zonos2/test_state_lifecycle.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.zonos2 import request_builders
+from sglang_omni.models.zonos2.engine_builder import Zonos2EngineBuilder
+from sglang_omni.models.zonos2.payload_types import (
+    FRAME_WIDTH,
+    N_CODEBOOKS,
+    Zonos2State,
+)
+from sglang_omni.models.zonos2.request_builders import (
+    Zonos2SGLangRequestData,
+    make_zonos2_scheduler_adapters,
+)
+from sglang_omni.models.zonos2.state_pool import Zonos2DecodeStatePool
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+def _terminal_data(request_id: str = "req-zonos2") -> Zonos2SGLangRequestData:
+    payload = StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs={}),
+        data=Zonos2State().to_dict(),
+    )
+    return Zonos2SGLangRequestData(
+        prompt_rows=torch.zeros((1, FRAME_WIDTH), dtype=torch.long),
+        output_codes=[torch.zeros(N_CODEBOOKS, dtype=torch.long)],
+        engine_start_s=time.perf_counter(),
+        stage_payload=payload,
+    )
+
+
+def test_result_adapter_releases_terminal_request_state() -> None:
+    reset_calls: list[str] = []
+    model = SimpleNamespace(reset_request=reset_calls.append)
+    _, result_adapter = make_zonos2_scheduler_adapters(model=model)
+
+    result = result_adapter(_terminal_data())
+
+    assert result.data["completion_tokens"] == 1
+    assert reset_calls == ["req-zonos2"]
+
+
+def test_result_adapter_releases_state_when_serialization_fails(monkeypatch) -> None:
+    reset_calls: list[str] = []
+    model = SimpleNamespace(reset_request=reset_calls.append)
+    _, result_adapter = make_zonos2_scheduler_adapters(model=model)
+
+    def fail_result(*_args, **_kwargs):
+        raise RuntimeError("serialization failed")
+
+    monkeypatch.setattr(request_builders, "apply_sglang_zonos2_result", fail_result)
+
+    with pytest.raises(RuntimeError, match="serialization failed"):
+        result_adapter(_terminal_data())
+
+    assert reset_calls == ["req-zonos2"]
+
+
+def test_engine_builder_abort_callback_releases_request_state() -> None:
+    builder = Zonos2EngineBuilder()
+    with pytest.raises(AssertionError):
+        builder.make_abort_callback()
+
+    reset_calls: list[str] = []
+    builder.model = SimpleNamespace(reset_request=reset_calls.append)
+    abort_callback = builder.make_abort_callback()
+    builder.model = None
+
+    abort_callback("req-zonos2")
+
+    assert reset_calls == ["req-zonos2"]
+
+
+def test_release_invalidates_cached_active_rows_before_request_id_reuse() -> None:
+    model = SimpleNamespace(
+        _decode_input_embedding=SimpleNamespace(
+            weight=torch.zeros((2, 3), dtype=torch.float32)
+        ),
+        n_codebooks=2,
+    )
+    pool = Zonos2DecodeStatePool(model)
+    request = SimpleNamespace(request_id="reused-rid")
+
+    first_row = int(pool.prepare_active_rows([request])[0])
+    pool.feedback_embeds[first_row].fill_(1)
+    pool.release_row(request.request_id)
+    free_rows_after_release = len(pool._free_rows)
+    pool.release_row(request.request_id)
+
+    assert request.request_id not in pool._rid_to_row
+    assert pool._active_ids is None
+    assert pool._active_rows is None
+    assert torch.count_nonzero(pool.feedback_embeds[first_row]) == 0
+    assert len(pool._free_rows) == free_rows_after_release
+
+    reused_row = int(pool.prepare_active_rows([request])[0])
+
+    assert pool._rid_to_row[request.request_id] == reused_row
+    assert len(pool._free_rows) == pool.padding_row - 1


### PR DESCRIPTION
## Motivation

ZONOS2 kept one decode-state row owned after the final request was terminated by the scheduler's length limit. The next decode batch happened to reclaim the stale row through `release_inactive()`, masking the leak during sustained traffic, but an idle server retained the last request indefinitely. Abort paths had the same missing model-state cleanup boundary.

## Modifications

- Move decode-state release out of the model runner and into the scheduler's terminal result adapter, using `finally` so result-conversion failures also release the row.
- Register `model.reset_request` as the scheduler abort callback. `release_row` remains idempotent, making abort-before-allocation and duplicate cleanup safe.
- Invalidate the cached active-row tensor whenever ownership changes, so a released request ID cannot reuse a stale row mapping.
- Keep sampler completion semantics on-device: `finished` still selects `EOS_SENTINEL` exactly as before. Remove only its host copy from async resolve metadata (`[B, n+3]` to `[B, n+2]`), which was used solely for model-runner-owned row reclamation; the scheduler's terminal and abort boundaries now own request lifetime.
- Add focused lifecycle tests covering a real SGLang `FINISH_LENGTH` result path, adapter failure, abort before/after allocation, complete row reset and mixed-batch reuse, and async resolve ownership.

## Root Cause

ZONOS2 treated the model sampler's internal EOS signal as the request-lifetime completion signal. The model runner released rows only when that signal became true. Scheduler termination is broader: a request can finish because of maximum length, abort, failure, or model EOS. In particular, `FINISH_LENGTH` completed downstream without releasing the ZONOS2 row.

`release_inactive()` ran before a later decode and therefore reclaimed request N when request N+1 arrived. It could not reclaim the final request after the server became idle.

## Accuracy Test

Tested on one NVIDIA H100 80GB with `Zyphra/ZONOS2` revision `65f1e80f94b599d474bb6af9094a803dc52f60bd`, PyTorch `2.11.0+cu130`, and async and sync decode.

| Case | Result |
|---|---|
| Exact parent `dc64a6b2`, four sequential `FINISH_LENGTH` requests | Reproduced: 4 terminals, 3 releases, final `held=1`, `free=63/64` |
| Candidate, same four-request reproduction | 4 releases, final `held=0`, `free=64/64` |
| Async/sync × streaming/non-streaming, `max_new_tokens=17/64/297` | 48/48 requests succeeded; valid audio; final `held=0`, `free=64/64` in every mode |
| Abort before state allocation | Cleanup was a no-op; free count remained 64 |
| Streaming abort after the first 4,096 PCM bytes | Owned row released immediately; no later request required; canary succeeded |
| Async mixed batch, lengths 17 and 297 | Short request released while the survivor completed 297 tokens; final `held=0`, `free=64/64` |
| 1,000 sequential requests alternating lengths 17/64 | 1,000/1,000 succeeded; final idle state `held=0`, `free=64/64` |

Across the instrumented runs, all 1,055 allocated rows were released, with one expected no-op for abort-before-allocation. Every successful release zeroed feedback, EOS/countdown, generation, and repetition state; ownership/free-list invariants had zero failures. The terminal set included both scheduler length completion and model EOS completion.

The 1,088 saved Fix EN outputs were scored without regeneration using `Qwen/Qwen3-ASR-1.7B` on physical GPU 0:

| Metric | Result |
|---|---:|
| Evaluated / skipped | 1,088 / 0 |
| Corpus WER | **1.34%** |
| Per-sample mean / median WER | 1.34% / 0.00% |
| Per-sample p95 / maximum WER | 9.09% / 66.67% |
| Corpus WER excluding samples above 50% | 1.29% |
| Samples above 50% WER | 1/1,088 (0.092%) |

The production lifecycle audit ran against `e1c3eb4d`; `f99e9ccb` changes tests only. The original test run at `e1c3eb4d` reported 44 passed and one test-design failure because it called `make_abort_callback()` before the builder's production setup sequence. The follow-up removes that unsupported pre-setup call and replaces the mock-only lifecycle checks with the focused production-boundary tests described above.

## Benchmark & Profiling

Full 1,088-sample SeedTTS EN comparison on the same H100, async decode, concurrency 16:

| Metric | Main `dc64a6b2` | Fix `e1c3eb4d` |
|---|---:|---:|
| Completed / failed | 1,088 / 0 | 1,088 / 0 |
| Throughput | 6.287 req/s | 6.345 req/s |
| Mean latency | 2.526 s | 2.508 s |
| Mean RTF | 0.6808 | 0.6724 |
| Corpus WER | 1.38% | 1.34% |
| WER excluding >50% outliers | 1.29% | 1.29% |
| >50% WER samples | 2 | 1 |

The lifecycle fix showed no throughput, latency, RTF, or aggregate WER regression in this matched full-corpus run.

## Checklist

- [x] Format the code according to pre-commit.
- [x] Add focused unit tests.
- [x] Update documentation and docstrings as needed; there is no public API or configuration change.
- [x] Provide H100 lifecycle, output, and performance results.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
