### PR TITLE
[Perf] Unify torch.compile lifecycle for speech pipeline stages by StageCompileManager

### DIFF
--- a/sglang_omni/compilation/__init__.py
+++ b/sglang_omni/compilation/__init__.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared lifecycle for model-owned compiled callables."""
+
+from sglang_omni.compilation.stage_compile import (
+    CompilePhase,
+    CompilePlan,
+    CompileStats,
+    CompileTarget,
+    CompileWarmupCase,
+    StageCompileManager,
+    build_module_list_compile_plan,
+    compile_callable,
+    configure_sglang_torch_compile,
+    tensor_dim_bucket,
+)
+
+__all__ = [
+    "CompilePhase",
+    "CompilePlan",
+    "CompileStats",
+    "CompileTarget",
+    "CompileWarmupCase",
+    "StageCompileManager",
+    "build_module_list_compile_plan",
+    "compile_callable",
+    "configure_sglang_torch_compile",
+    "tensor_dim_bucket",
+]

--- a/sglang_omni/compilation/stage_compile.py
+++ b/sglang_omni/compilation/stage_compile.py
@@ -1,0 +1,523 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compile lifecycle shared by model-owned pipeline callables."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from collections.abc import Callable, Hashable, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class CompilePhase(str, Enum):
+    """Startup point at which a compile target must be installed."""
+
+    BEFORE_PRIMARY_CUDA_GRAPH = "before_primary_cuda_graph"
+    AFTER_PRIMARY_CUDA_GRAPH = "after_primary_cuda_graph"
+    BEFORE_STAGE_READY = "before_stage_ready"
+
+
+@dataclass(frozen=True)
+class CompileWarmupCase:
+    """One model-defined invocation used to warm a specialization."""
+
+    label: str
+    args: tuple[Any, ...] = ()
+    kwargs: Mapping[str, Any] = field(default_factory=dict)
+    bucket: Hashable | None = None
+    repeat: int = 1
+
+    def __post_init__(self) -> None:
+        if self.repeat < 1:
+            raise ValueError("CompileWarmupCase.repeat must be >= 1")
+
+
+@dataclass(frozen=True)
+class CompileTarget:
+    """Declarative compile policy for one model-owned callable."""
+
+    name: str
+    eager: Callable[..., Any]
+    install: Callable[[Callable[..., Any]], None]
+    phase: CompilePhase = CompilePhase.BEFORE_PRIMARY_CUDA_GRAPH
+    compile_kwargs: Mapping[str, Any] = field(default_factory=dict)
+    bucket_fn: Callable[..., Hashable | None] | None = None
+    warmup_cases: Sequence[CompileWarmupCase] = ()
+    restrict_to_warmed_buckets: bool = False
+
+
+@dataclass(frozen=True)
+class CompilePlan:
+    """A named collection of declarative targets for one stage."""
+
+    name: str
+    targets: Sequence[CompileTarget]
+
+
+@dataclass(frozen=True)
+class _CompileTargetStats:
+    setup_failures: int
+    compilation_count: int
+    recompilation_count: int
+    compile_time_s: float
+    warmup_time_s: float
+    warmup_failures: int
+    runtime_fallbacks: int
+
+
+@dataclass(frozen=True)
+class CompileStats:
+    name: str
+    target_count: int
+    setup_failures: int
+    compilation_count: int
+    recompilation_count: int
+    compile_time_s: float
+    warmup_time_s: float
+    warmup_failures: int
+    runtime_fallbacks: int
+
+
+CompilerFn = Callable[..., Callable[..., Any]]
+ConfigureFn = Callable[[], None]
+
+
+def configure_sglang_torch_compile() -> None:
+    from sglang.srt.model_executor.cuda_graph_runner import set_torch_compile_config
+
+    set_torch_compile_config()
+
+
+class StageCompileManager:
+    """Install and observe every target in one stage compile plan."""
+
+    def __init__(
+        self,
+        plan: CompilePlan,
+        *,
+        compile_fn: CompilerFn | None = None,
+        configure_fn: ConfigureFn | None = None,
+    ) -> None:
+        self.plan = plan
+        self._compile_fn = compile_fn
+        self._configure_fn = configure_fn
+        self._targets = tuple(plan.targets)
+        self._handles: dict[str, _CompiledCallable] = {}
+        self._applied_phases: set[CompilePhase] = set()
+        self._configured = False
+        self._configuration_error: Exception | None = None
+
+    def apply(self, phase: CompilePhase) -> None:
+        """Install all targets assigned to ``phase`` exactly once."""
+        if phase in self._applied_phases:
+            return
+
+        targets = [target for target in self._targets if target.phase is phase]
+        if targets:
+            self._configure_once()
+        for target in targets:
+            handle = _CompiledCallable(
+                target.name,
+                target.eager,
+                compile_kwargs=target.compile_kwargs,
+                bucket_fn=target.bucket_fn,
+                restrict_to_warmed_buckets=target.restrict_to_warmed_buckets,
+                compile_fn=self._compile_fn,
+                setup_error=self._configuration_error,
+            )
+            self._handles[target.name] = handle
+            target.install(handle if handle.available else target.eager)
+            if handle.available and target.warmup_cases:
+                handle.warmup(target.warmup_cases)
+
+        self._applied_phases.add(phase)
+
+    def finish_startup(self) -> CompileStats:
+        """Log one aggregate snapshot after the stage finishes startup work."""
+        snapshot = self.stats()
+        logger.info(
+            "Compile plan %s startup complete: targets=%d setup_failures=%d "
+            "compile_events=%d recompiles=%d compile_time=%.3fs "
+            "warmup_time=%.3fs warmup_failures=%d runtime_fallbacks=%d",
+            snapshot.name,
+            snapshot.target_count,
+            snapshot.setup_failures,
+            snapshot.compilation_count,
+            snapshot.recompilation_count,
+            snapshot.compile_time_s,
+            snapshot.warmup_time_s,
+            snapshot.warmup_failures,
+            snapshot.runtime_fallbacks,
+        )
+        return snapshot
+
+    def stats(self) -> CompileStats:
+        target_stats = [handle.stats() for handle in self._handles.values()]
+        return CompileStats(
+            name=self.plan.name,
+            target_count=len(self._handles),
+            setup_failures=sum(item.setup_failures for item in target_stats),
+            compilation_count=sum(item.compilation_count for item in target_stats),
+            recompilation_count=sum(item.recompilation_count for item in target_stats),
+            compile_time_s=sum(item.compile_time_s for item in target_stats),
+            warmup_time_s=sum(item.warmup_time_s for item in target_stats),
+            warmup_failures=sum(item.warmup_failures for item in target_stats),
+            runtime_fallbacks=sum(item.runtime_fallbacks for item in target_stats),
+        )
+
+    def _configure_once(self) -> None:
+        if self._configured:
+            return
+        self._configured = True
+        if self._configure_fn is None:
+            return
+        try:
+            self._configure_fn()
+        except Exception as exc:
+            self._configuration_error = exc
+            logger.warning(
+                "Compile plan %s setup failed; using eager execution",
+                self.plan.name,
+                exc_info=True,
+            )
+
+
+def compile_callable(
+    name: str,
+    eager: Callable[..., Any],
+    install: Callable[[Callable[..., Any]], None],
+    *,
+    phase: CompilePhase = CompilePhase.BEFORE_STAGE_READY,
+    compile_kwargs: Mapping[str, Any] | None = None,
+    bucket_fn: Callable[..., Hashable | None] | None = None,
+    warmup_cases: Sequence[CompileWarmupCase] = (),
+    restrict_to_warmed_buckets: bool = False,
+    configure_fn: ConfigureFn | None = None,
+) -> StageCompileManager:
+    """Compile and install one standalone stage callable."""
+    plan = CompilePlan(
+        name=name,
+        targets=(
+            CompileTarget(
+                name=name,
+                eager=eager,
+                install=install,
+                phase=phase,
+                compile_kwargs=dict(compile_kwargs or {}),
+                bucket_fn=bucket_fn,
+                warmup_cases=warmup_cases,
+                restrict_to_warmed_buckets=restrict_to_warmed_buckets,
+            ),
+        ),
+    )
+    manager = StageCompileManager(plan, configure_fn=configure_fn)
+    manager.apply(phase)
+    manager.finish_startup()
+    return manager
+
+
+def build_module_list_compile_plan(
+    name: str,
+    modules: Sequence[Callable[..., Any]],
+    *,
+    install: Callable[[list[Callable[..., Any]]], None],
+    phase: CompilePhase = CompilePhase.BEFORE_PRIMARY_CUDA_GRAPH,
+    compile_kwargs: Mapping[str, Any] | None = None,
+    bucket_fn: Callable[..., Hashable | None] | None = None,
+) -> CompilePlan:
+    """Build a plan that compiles each callable and installs a parallel list."""
+    eager_modules = list(modules)
+    if not eager_modules:
+        raise ValueError(f"Compile module list {name!r} has no callables")
+
+    installed_modules = list(eager_modules)
+    install(installed_modules)
+    options = (
+        {
+            "mode": os.environ.get(
+                "SGLANG_TORCH_COMPILE_MODE",
+                "max-autotune-no-cudagraphs",
+            )
+        }
+        if compile_kwargs is None
+        else dict(compile_kwargs)
+    )
+    return CompilePlan(
+        name=name,
+        targets=tuple(
+            CompileTarget(
+                name=f"{name}.layer_{index}",
+                eager=module,
+                install=lambda compiled, index=index: installed_modules.__setitem__(
+                    index, compiled
+                ),
+                phase=phase,
+                compile_kwargs=options,
+                bucket_fn=bucket_fn,
+            )
+            for index, module in enumerate(eager_modules)
+        ),
+    )
+
+
+def tensor_dim_bucket(
+    argument: str,
+    *,
+    dim: int = 0,
+    positional_index: int = 0,
+) -> Callable[..., int | None]:
+    """Return a bucket function for one tensor argument dimension."""
+
+    def _bucket(*args: Any, **kwargs: Any) -> int | None:
+        value = kwargs.get(argument)
+        if value is None and len(args) > positional_index:
+            value = args[positional_index]
+        if not isinstance(value, torch.Tensor) or value.ndim == 0:
+            return None
+        resolved_dim = dim if dim >= 0 else value.ndim + dim
+        if resolved_dim < 0 or resolved_dim >= value.ndim:
+            return None
+        return int(value.shape[resolved_dim])
+
+    return _bucket
+
+
+class _CompiledCallable:
+    """Private callable implementing lazy compile observation and fallback."""
+
+    def __init__(
+        self,
+        name: str,
+        eager: Callable[..., Any],
+        *,
+        compile_kwargs: Mapping[str, Any],
+        bucket_fn: Callable[..., Hashable | None] | None,
+        restrict_to_warmed_buckets: bool,
+        compile_fn: CompilerFn | None,
+        setup_error: Exception | None,
+    ) -> None:
+        self.name = name
+        self.eager = eager
+        self.bucket_fn = bucket_fn
+        self.restrict_to_warmed_buckets = restrict_to_warmed_buckets
+        self._compiled: Callable[..., Any] | None = None
+        self._lock = threading.Lock()
+        self._setup_failures = 0
+        self._compilation_count = 0
+        self._compile_trigger_count = 0
+        self._compile_time_s = 0.0
+        self._warmup_time_s = 0.0
+        self._warmup_failures = 0
+        self._runtime_fallbacks = 0
+        self._failed_buckets: set[Hashable] = set()
+        self._failed_without_bucket = False
+        self._observed_buckets: set[Hashable] = set()
+        self._observed_without_bucket = False
+        self._warmed_buckets: set[Hashable] = set()
+        self._warmed_without_bucket = False
+
+        if setup_error is not None:
+            self._setup_failures = 1
+            self._failed_without_bucket = True
+            return
+        compiler = torch.compile if compile_fn is None else compile_fn
+        try:
+            self._compiled = compiler(eager, **dict(compile_kwargs))
+        except Exception:
+            self._setup_failures = 1
+            self._failed_without_bucket = True
+            logger.warning(
+                "Compile target %s setup failed; using eager execution",
+                name,
+                exc_info=True,
+            )
+
+    @property
+    def available(self) -> bool:
+        return self._compiled is not None and not self._failed_without_bucket
+
+    def warmup(self, cases: Sequence[CompileWarmupCase]) -> None:
+        if not self.available:
+            return
+
+        started = time.perf_counter()
+        for case in cases:
+            bucket = case.bucket
+            if bucket is None:
+                bucket = self._resolve_bucket(case.args, case.kwargs)
+            succeeded = True
+            for _ in range(case.repeat):
+                try:
+                    self._call_compiled(
+                        case.args,
+                        case.kwargs,
+                        observe_compile=self._reserve_compile_observation(bucket),
+                    )
+                except Exception:
+                    with self._lock:
+                        self._warmup_failures += 1
+                        self._mark_failed_locked(bucket)
+                    logger.warning(
+                        "Compile target %s warmup failed for %s (bucket=%r); "
+                        "using eager execution for that bucket",
+                        self.name,
+                        case.label,
+                        bucket,
+                        exc_info=True,
+                    )
+                    succeeded = False
+                    break
+            if succeeded:
+                with self._lock:
+                    if bucket is None:
+                        self._warmed_without_bucket = True
+                    else:
+                        self._warmed_buckets.add(bucket)
+        with self._lock:
+            self._warmup_time_s += time.perf_counter() - started
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        bucket = self._resolve_bucket(args, kwargs)
+        if not self._should_use_compiled(bucket):
+            return self.eager(*args, **kwargs)
+
+        try:
+            return self._call_compiled(
+                args,
+                kwargs,
+                observe_compile=self._reserve_compile_observation(bucket),
+            )
+        except Exception:
+            with self._lock:
+                self._runtime_fallbacks += 1
+                self._mark_failed_locked(bucket)
+            logger.warning(
+                "Compile target %s failed at runtime for bucket=%r; "
+                "falling back to eager execution",
+                self.name,
+                bucket,
+                exc_info=True,
+            )
+            return self.eager(*args, **kwargs)
+
+    def stats(self) -> _CompileTargetStats:
+        with self._lock:
+            return _CompileTargetStats(
+                setup_failures=self._setup_failures,
+                compilation_count=self._compilation_count,
+                recompilation_count=max(0, self._compile_trigger_count - 1),
+                compile_time_s=self._compile_time_s,
+                warmup_time_s=self._warmup_time_s,
+                warmup_failures=self._warmup_failures,
+                runtime_fallbacks=self._runtime_fallbacks,
+            )
+
+    def _resolve_bucket(
+        self, args: tuple[Any, ...], kwargs: Mapping[str, Any]
+    ) -> Hashable | None:
+        if self.bucket_fn is None:
+            return None
+        return self.bucket_fn(*args, **kwargs)
+
+    def _should_use_compiled(self, bucket: Hashable | None) -> bool:
+        if not self.available:
+            return False
+        with self._lock:
+            if bucket is not None and bucket in self._failed_buckets:
+                return False
+            if self.restrict_to_warmed_buckets:
+                if bucket is None:
+                    return self._warmed_without_bucket
+                return bucket in self._warmed_buckets
+        return True
+
+    def _mark_failed_locked(self, bucket: Hashable | None) -> None:
+        if bucket is None:
+            self._failed_without_bucket = True
+        else:
+            self._failed_buckets.add(bucket)
+
+    def _reserve_compile_observation(self, bucket: Hashable | None) -> bool:
+        with self._lock:
+            if bucket is None:
+                if self._observed_without_bucket:
+                    return False
+                self._observed_without_bucket = True
+                return True
+            if bucket in self._observed_buckets:
+                return False
+            self._observed_buckets.add(bucket)
+            return True
+
+    def _call_compiled(
+        self,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+        *,
+        observe_compile: bool,
+    ) -> Any:
+        compiled = self._compiled
+        if compiled is None:
+            raise RuntimeError(f"Compile target {self.name} is unavailable")
+        if not observe_compile:
+            return compiled(*args, **kwargs)
+
+        events: list[float] = []
+        try:
+            with _observe_torch_compilations(events):
+                result = compiled(*args, **kwargs)
+        finally:
+            if events:
+                elapsed = sum(events)
+                with self._lock:
+                    self._compilation_count += len(events)
+                    self._compile_trigger_count += 1
+                    self._compile_time_s += elapsed
+                    count = self._compilation_count
+                    recompilations = max(0, self._compile_trigger_count - 1)
+                    total = self._compile_time_s
+                logger.info(
+                    "Compile target %s observed %d compile event(s): total=%d "
+                    "recompiles=%d compile_time=%.3fs",
+                    self.name,
+                    len(events),
+                    count,
+                    recompilations,
+                    total,
+                )
+        return result
+
+
+@contextmanager
+def _observe_torch_compilations(events: list[float]):
+    dynamo = getattr(torch, "_dynamo", None)
+    handler = getattr(dynamo, "callback_handler", None)
+    if handler is None:
+        yield
+        return
+
+    started: list[float] = []
+
+    def _on_start(_args: Any) -> None:
+        started.append(time.perf_counter())
+
+    def _on_end(_args: Any) -> None:
+        if started:
+            events.append(time.perf_counter() - started.pop())
+
+    handler.register_start_callback(_on_start)
+    handler.register_end_callback(_on_end)
+    try:
+        yield
+    finally:
+        handler.remove_start_callback(_on_start)
+        handler.remove_end_callback(_on_end)

--- a/sglang_omni/models/fishaudio_s2_pro/compile_plan.py
+++ b/sglang_omni/models/fishaudio_s2_pro/compile_plan.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compile plan for FishAudio S2-Pro."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sglang_omni.compilation import (
+    CompilePlan,
+    build_module_list_compile_plan,
+    tensor_dim_bucket,
+)
+
+
+def create_fish_s2pro_compile_plan(model: Any) -> CompilePlan:
+    audio_decoder = model._audio_decoder
+    return build_module_list_compile_plan(
+        "fishaudio_s2_pro.codebook_decoder",
+        [layer.forward_kvcached for layer in audio_decoder.layers],
+        install=lambda layers: audio_decoder.set_compiled_forward_kvcached_layers(
+            layers,
+            max_batch_size=audio_decoder.kv_cache_max_batch_size,
+        ),
+        bucket_fn=tensor_dim_bucket("x"),
+    )

--- a/sglang_omni/models/fishaudio_s2_pro/engine_builder.py
+++ b/sglang_omni/models/fishaudio_s2_pro/engine_builder.py
@@ -9,12 +9,16 @@ from typing import Any
 
 from sglang_omni.models.fishaudio_s2_pro import request_builders
 from sglang_omni.models.fishaudio_s2_pro import stages as fish_stages
+from sglang_omni.models.fishaudio_s2_pro.compile_plan import (
+    create_fish_s2pro_compile_plan,
+)
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
 
 
 class FishS2ProEngineBuilder(TtsEngineBuilder):
     model_name = "FishAudio S2-Pro"
     context_length = 4096
+    compile_plan_factory = create_fish_s2pro_compile_plan
 
     def __init__(
         self,
@@ -91,14 +95,6 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
 
     def get_model_buffer_bs(self, model: Any) -> int | None:
         return fish_stages._resolve_s2pro_model_buffer_bs(model)
-
-    def compile_model(self, model: Any, server_args: Any) -> None:
-        if bool(getattr(server_args, "enable_torch_compile", False)):
-            fish_stages._compile_s2pro_codebook_decoder(
-                model,
-                max_batch_size=server_args.torch_compile_max_bs,
-            )
-            server_args.enable_torch_compile = False
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
         model_runner_mod = importlib.import_module(

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -55,35 +55,6 @@ def _configure_preprocessing_threads(worker_count: int) -> int:
     return intraop_threads
 
 
-def _compile_s2pro_codebook_decoder(model: Any, *, max_batch_size: int) -> None:
-    """Compile Fast AR decoder layers while leaving sampling and loop control eager."""
-    from sglang.srt.model_executor.cuda_graph_runner import set_torch_compile_config
-
-    if max_batch_size < 1:
-        raise ValueError("max_batch_size must be >= 1")
-
-    set_torch_compile_config()
-    compile_mode = os.environ.get(
-        "SGLANG_TORCH_COMPILE_MODE",
-        "max-autotune-no-cudagraphs",
-    )
-    audio_decoder = model._audio_decoder
-    compiled_forward_kvcached_layers = [
-        torch.compile(layer.forward_kvcached, mode=compile_mode)
-        for layer in audio_decoder.layers
-    ]
-    audio_decoder.set_compiled_forward_kvcached_layers(
-        compiled_forward_kvcached_layers,
-        max_batch_size=max_batch_size,
-    )
-    logger.info(
-        "Compiled %d Fast AR decoder layers (mode=%s, max_batch_size=%d)",
-        len(compiled_forward_kvcached_layers),
-        compile_mode,
-        max_batch_size,
-    )
-
-
 def _resolve_s2pro_model_buffer_bs(model: Any) -> int:
     return min(
         int(model.vq_decode_max_batch_size),

--- a/sglang_omni/models/higgs_tts/compile_plan.py
+++ b/sglang_omni/models/higgs_tts/compile_plan.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compile plans for Higgs TTS standalone codec stages."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from sglang_omni.compilation import CompilePlan, CompileTarget, CompileWarmupCase
+
+
+def create_higgs_audio_encoder_compile_plan(codec: Any) -> CompilePlan:
+    acoustic_encoder = codec.model.acoustic_encoder
+    parameter = next(acoustic_encoder.parameters(), None)
+    warmup_device = parameter.device if parameter is not None else torch.device("cpu")
+    warmup_dtype = parameter.dtype if parameter is not None else torch.float32
+
+    return CompilePlan(
+        name="higgs_tts.audio_encoder",
+        targets=(
+            CompileTarget(
+                name="higgs_tts.audio_encoder",
+                eager=acoustic_encoder.forward,
+                install=lambda compiled: setattr(acoustic_encoder, "forward", compiled),
+                compile_kwargs={"mode": "default", "dynamic": True},
+                bucket_fn=lambda waveform, *args, **kwargs: tuple(waveform.shape),
+                warmup_cases=(
+                    CompileWarmupCase(
+                        "one-second-reference",
+                        args=(
+                            torch.zeros(
+                                1,
+                                1,
+                                codec.SAMPLE_RATE,
+                                device=warmup_device,
+                                dtype=warmup_dtype,
+                            ),
+                        ),
+                        bucket=(1, 1, codec.SAMPLE_RATE),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def create_higgs_vocoder_compile_plan(
+    codec: Any,
+    *,
+    warmup_frame_counts: tuple[int, ...],
+) -> CompilePlan:
+    eager_decode = codec.model.decode
+    num_quantizers = int(codec.model.config.num_quantizers)
+
+    return CompilePlan(
+        name="higgs_tts.vocoder_decode",
+        targets=(
+            CompileTarget(
+                name="higgs_tts.vocoder_decode",
+                eager=eager_decode,
+                install=lambda compiled: setattr(codec.model, "decode", compiled),
+                compile_kwargs={"dynamic": True},
+                bucket_fn=lambda codes, *args, **kwargs: (
+                    int(codes.shape[0]),
+                    int(codes.shape[-1]),
+                ),
+                warmup_cases=tuple(
+                    CompileWarmupCase(
+                        f"batch={batch_size},frames={frame_count}",
+                        args=(
+                            torch.zeros(
+                                batch_size,
+                                num_quantizers,
+                                frame_count,
+                                dtype=torch.long,
+                                device=codec.device,
+                            ),
+                        ),
+                        bucket=(batch_size, frame_count),
+                    )
+                    for frame_count in warmup_frame_counts
+                    for batch_size in (1, 2)
+                ),
+            ),
+        ),
+    )

--- a/sglang_omni/models/higgs_tts/config.py
+++ b/sglang_omni/models/higgs_tts/config.py
@@ -49,7 +49,7 @@ class HiggsTtsPipelineConfig(PipelineConfig):
             name="audio_encoder",
             process="pipeline",
             factory=f"{_PKG}.stages.create_audio_encoder_executor",
-            factory_args={"device": "cuda"},
+            factory_args={"device": "cuda", "compile_encoder": True},
             gpu=0,
             runtime=StageRuntimeConfig(
                 resources=StageResourceConfig(total_gpu_memory_fraction=0.03)

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -33,6 +33,11 @@ import torchaudio.functional as F_audio
 from tokenizers import Tokenizer
 from transformers import PreTrainedTokenizerFast
 
+from sglang_omni.compilation import CompilePhase, StageCompileManager
+from sglang_omni.models.higgs_tts.compile_plan import (
+    create_higgs_audio_encoder_compile_plan,
+    create_higgs_vocoder_compile_plan,
+)
 from sglang_omni.models.higgs_tts.payload_types import HiggsTtsState
 from sglang_omni.models.higgs_tts.text_tokenizer import HiggsTokenizerAdapter
 from sglang_omni.models.higgs_tts.utils import (
@@ -354,6 +359,7 @@ def create_audio_encoder_executor(
     device: str = "cuda:0",
     dtype: str = "bfloat16",
     num_codebooks: int = 8,
+    compile_encoder: bool = True,
 ):
     """GPU stage: codec-encode raw ref audio → delayed codes + prompt assembly.
 
@@ -367,12 +373,13 @@ def create_audio_encoder_executor(
     adapter = HiggsTokenizerAdapter(tokenizer)
 
     codec = get_or_load_codec(checkpoint_dir, device, dtype)
-    codec.model.acoustic_encoder = torch.compile(
-        codec.model.acoustic_encoder, mode="default", dynamic=True
-    )
-    codec.encode_reference(
-        torch.zeros(codec.SAMPLE_RATE), sample_rate=codec.SAMPLE_RATE
-    )
+    if compile_encoder:
+        compile_manager = StageCompileManager(
+            create_higgs_audio_encoder_compile_plan(codec)
+        )
+        compile_manager.apply(CompilePhase.BEFORE_PRIMARY_CUDA_GRAPH)
+        compile_manager.finish_startup()
+        codec._audio_encoder_compile_manager = compile_manager
     reference_service = ReferenceEncodeService(
         _HiggsReferenceEncodeHook(
             codec,
@@ -487,30 +494,15 @@ def create_vocoder_executor(
     checkpoint_dir = resolve_checkpoint(model_path)
     codec = get_or_load_codec(checkpoint_dir, device, dtype)
     if compile_decode:
-        eager_decode = codec.model.decode
-        try:
-            codec.model.decode = torch.compile(eager_decode, dynamic=True)
-            warm_codes_TN = torch.zeros(
-                (
-                    max(_VOCODER_COMPILE_WARMUP_FRAME_COUNTS),
-                    int(codec.model.config.num_quantizers),
-                ),
-                dtype=torch.long,
-                device="cpu",
+        compile_manager = StageCompileManager(
+            create_higgs_vocoder_compile_plan(
+                codec,
+                warmup_frame_counts=_VOCODER_COMPILE_WARMUP_FRAME_COUNTS,
             )
-            # Note: (stephenkgli) match serving's contiguous [T, N] layout and
-            # warm the zero-one-specialized batch and frame-count classes.
-            for frame_count in _VOCODER_COMPILE_WARMUP_FRAME_COUNTS:
-                frame_codes_TN = warm_codes_TN[:frame_count]
-                codec.decode(frame_codes_TN)
-                codec.decode_batch([frame_codes_TN, frame_codes_TN])
-        except Exception:
-            logger.warning(
-                "torch.compile of the codec decode failed; falling back to the "
-                "eager vocoder decode",
-                exc_info=True,
-            )
-            codec.model.decode = eager_decode
+        )
+        compile_manager.apply(CompilePhase.BEFORE_PRIMARY_CUDA_GRAPH)
+        compile_manager.finish_startup()
+        codec._vocoder_decode_compile_manager = compile_manager
 
     return HiggsStreamingVocoderScheduler(
         codec,

--- a/sglang_omni/models/moss_transcribe_diarize/compile_plan.py
+++ b/sglang_omni/models/moss_transcribe_diarize/compile_plan.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compile plans for MOSS-Transcribe-Diarize."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import torch
+
+from sglang_omni.compilation import CompilePlan, CompileTarget, CompileWarmupCase
+
+
+def create_moss_td_encoder_compile_plan(
+    model: Any,
+    *,
+    chunk_buckets: Sequence[int],
+    input_feature_len: int,
+) -> CompilePlan:
+    p = next(model.whisper_encoder.parameters())
+    frames = int(input_feature_len)
+    num_mel_bins = int(model.config.audio_config.num_mel_bins)
+    pos = torch.arange((frames - 1) // 2 + 1, device=p.device, dtype=torch.long)
+
+    return CompilePlan(
+        name="moss_transcribe_diarize.whisper_encoder",
+        targets=(
+            CompileTarget(
+                name="moss_transcribe_diarize.whisper_encoder",
+                eager=model.whisper_encoder,
+                install=lambda compiled: setattr(model, "_compiled_encoder", compiled),
+                compile_kwargs={"dynamic": False},
+                bucket_fn=lambda feats, *args, **kwargs: (
+                    int(feats.shape[0]),
+                    int(feats.shape[-1]),
+                ),
+                warmup_cases=tuple(
+                    CompileWarmupCase(
+                        f"chunks={n}",
+                        args=(
+                            torch.zeros(
+                                n,
+                                num_mel_bins,
+                                frames,
+                                device=p.device,
+                                dtype=p.dtype,
+                            ),
+                            pos,
+                            None,
+                        ),
+                        bucket=(n, frames),
+                        repeat=3,
+                    )
+                    for n in chunk_buckets
+                ),
+                restrict_to_warmed_buckets=True,
+            ),
+        ),
+    )

--- a/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
+++ b/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
@@ -18,13 +18,20 @@ from sglang.srt.managers.schedule_batch import (
     MultimodalDataItem,
     MultimodalInputs,
 )
-from sglang.srt.model_executor.cuda_graph_runner import set_torch_compile_config
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen3 import Qwen3ForCausalLM
 from sglang.srt.models.whisper import WhisperEncoder
 from sglang.srt.utils import add_prefix
 
+from sglang_omni.compilation import (
+    CompilePhase,
+    StageCompileManager,
+    configure_sglang_torch_compile,
+)
+from sglang_omni.models.moss_transcribe_diarize.compile_plan import (
+    create_moss_td_encoder_compile_plan,
+)
 from sglang_omni.models.moss_transcribe_diarize.encoder_cuda_graph import (
     WhisperEncoderCudaGraphRunner,
 )
@@ -93,8 +100,6 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
         self._encoder_cache: Optional[StageOutputCache] = None
         self._encoder_graph_runner = None
         self._compiled_encoder = None
-        self._compiled_chunk_buckets: frozenset[int] = frozenset()
-        self._compiled_input_feature_len = 0
 
     def init_encoder_cache(self, max_bytes: int) -> None:
         self._encoder_cache = (
@@ -149,31 +154,18 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
         buckets = sorted({int(b) for b in (chunk_buckets or []) if int(b) >= 1})
         if not buckets:
             return
-        set_torch_compile_config()
-        self._compiled_encoder = torch.compile(self.whisper_encoder, dynamic=False)
-        self._compiled_input_feature_len = int(input_feature_len)
-        p = next(self.whisper_encoder.parameters())
-        frames = int(input_feature_len)
-        num_mel_bins = int(self.config.audio_config.num_mel_bins)
-        pos = torch.arange((frames - 1) // 2 + 1, device=p.device, dtype=torch.long)
-        warmed: list[int] = []
         with torch.no_grad():
-            for n in buckets:
-                feats = torch.zeros(
-                    n, num_mel_bins, frames, device=p.device, dtype=p.dtype
-                )
-                try:
-                    for _ in range(3):
-                        self._compiled_encoder(feats, pos, None)
-                except Exception as exc:
-                    logger.warning(
-                        f"MOSS-TD encoder torch.compile warmup failed for "
-                        f"chunks={n}: {exc}; that chunk count will run eager"
-                    )
-                    continue
-                warmed.append(n)
-        self._compiled_chunk_buckets = frozenset(warmed)
-        logger.info(f"MOSS-TD encoder torch.compile warmed buckets={warmed}")
+            compile_manager = StageCompileManager(
+                create_moss_td_encoder_compile_plan(
+                    self,
+                    chunk_buckets=buckets,
+                    input_feature_len=input_feature_len,
+                ),
+                configure_fn=configure_sglang_torch_compile,
+            )
+            compile_manager.apply(CompilePhase.BEFORE_PRIMARY_CUDA_GRAPH)
+            compile_manager.finish_startup()
+        self._encoder_compile_manager = compile_manager
 
     def time_merge(self, features: torch.Tensor) -> torch.Tensor:
         batch_size, seq_len, hidden_size = features.shape
@@ -268,11 +260,7 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
             encoder_position_ids = torch.arange(
                 encoder_len, device=device, dtype=torch.long
             )
-            if (
-                self._compiled_encoder is not None
-                and batched_features.shape[0] in self._compiled_chunk_buckets
-                and batched_features.shape[-1] == self._compiled_input_feature_len
-            ):
+            if self._compiled_encoder is not None:
                 features = self._compiled_encoder(
                     batched_features, encoder_position_ids, forward_batch
                 )

--- a/sglang_omni/models/moss_tts_local/compile_plan.py
+++ b/sglang_omni/models/moss_tts_local/compile_plan.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compile plan for MOSS-TTS Local."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from sglang_omni.compilation import (
+    CompilePhase,
+    CompilePlan,
+    CompileTarget,
+    tensor_dim_bucket,
+)
+from sglang_omni.models.moss_tts_local.local_transformer import sample_seeded_branchless
+
+
+def create_moss_tts_local_compile_plan(model: Any) -> CompilePlan:
+    def install(compiled: Any) -> None:
+        model._compiled_frame_sampler = compiled
+        model._sample_seeded_branchless = compiled
+
+    return CompilePlan(
+        name="moss_tts_local.frame_sampler",
+        targets=(
+            CompileTarget(
+                name="moss_tts_local.frame_sampler",
+                eager=sample_seeded_branchless,
+                install=install,
+                phase=CompilePhase.AFTER_PRIMARY_CUDA_GRAPH,
+                compile_kwargs={
+                    "mode": os.environ.get(
+                        "SGLANG_TORCH_COMPILE_MODE",
+                        "max-autotune-no-cudagraphs",
+                    )
+                },
+                bucket_fn=tensor_dim_bucket("logits"),
+            ),
+        ),
+    )

--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -37,7 +37,10 @@ def _stages(*, codec_device: str, colocated: bool) -> list[StageConfig]:
             mem_fraction_static=None if colocated else _AR_MEM_FRACTION_STATIC
         ),
     )
-    tts_engine_args: dict[str, Any] = {"dtype": "bfloat16"}
+    tts_engine_args: dict[str, Any] = {
+        "dtype": "bfloat16",
+        "compile_frame_sampler": True,
+    }
     if colocated:
         tts_engine_args["codec_mem_reserve"] = _COLOCATED_CODEC_MEM_RESERVE
 

--- a/sglang_omni/models/moss_tts_local/engine_builder.py
+++ b/sglang_omni/models/moss_tts_local/engine_builder.py
@@ -8,6 +8,9 @@ from typing import Any
 
 from sglang_omni.models.moss_tts_local import request_builders
 from sglang_omni.models.moss_tts_local import stages as moss_local_stages
+from sglang_omni.models.moss_tts_local.compile_plan import (
+    create_moss_tts_local_compile_plan,
+)
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
 
 
@@ -15,6 +18,7 @@ class MossTtsLocalEngineBuilder(TtsEngineBuilder):
     model_name = "MOSS-TTS Local"
     context_length = 8192
     model_arch_override = "MossTTSLocalSGLangModel"
+    compile_plan_factory = create_moss_tts_local_compile_plan
 
     def __init__(
         self,
@@ -23,11 +27,13 @@ class MossTtsLocalEngineBuilder(TtsEngineBuilder):
         async_decode_min_batch_size: int,
         total_gpu_memory_fraction: float | None,
         codec_mem_reserve: float,
+        compile_frame_sampler: bool = True,
     ) -> None:
         self.enable_async_decode = enable_async_decode
         self.async_decode_min_batch_size = async_decode_min_batch_size
         self.total_gpu_memory_fraction = total_gpu_memory_fraction
         self.codec_mem_reserve = codec_mem_reserve
+        self.compile_frame_sampler = bool(compile_frame_sampler)
         self.memory_budget = moss_local_stages._ArMemoryBudget(
             effective_total_gpu_memory_fraction=None,
             applied_codec_mem_reserve=0.0,
@@ -45,7 +51,7 @@ class MossTtsLocalEngineBuilder(TtsEngineBuilder):
             "dtype": dtype,
             "disable_cuda_graph": False,
             "disable_overlap_schedule": True,
-            "enable_torch_compile": False,
+            "enable_torch_compile": self.compile_frame_sampler,
             "max_prefill_tokens": 8192,
             "sampling_backend": "pytorch",
             "trust_remote_code": True,

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -15,7 +15,6 @@ the model runner after each backbone step.
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any, Callable, Iterable, Optional, Tuple
 
 import torch
@@ -136,7 +135,6 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         # its addresses are fixed for the process lifetime.
         self._state_pool = MossTTSLocalDecodeStatePool(self)
         self._compiled_frame_sampler: Callable[..., torch.Tensor] | None = None
-        self._frame_compile_configured = False
 
     def acquire_row(self, rid: str) -> int:
         """Assign (or return the existing) decode-state pool row for ``rid``."""
@@ -360,27 +358,6 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
 
     _sample_seeded_branchless = staticmethod(sample_seeded_branchless)
 
-    def _ensure_frame_compile_config(self) -> None:
-        if self._frame_compile_configured:
-            return
-        from sglang.srt.model_executor.cuda_graph_runner import set_torch_compile_config
-
-        set_torch_compile_config()
-        self._frame_compile_configured = True
-
-    def _ensure_frame_sampler_compile(self) -> None:
-        if self._compiled_frame_sampler is None:
-            compile_mode = os.environ.get(
-                "SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs"
-            )
-            self._ensure_frame_compile_config()
-            self._compiled_frame_sampler = torch.compile(
-                sample_seeded_branchless,
-                mode=compile_mode,
-            )
-            self._sample_seeded_branchless = self._compiled_frame_sampler
-            logger.info(f"Compiled MOSS-TTS Local frame sampler (mode={compile_mode})")
-
     @torch.no_grad()
     def _decode_frame_graphable(
         self,
@@ -468,7 +445,6 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             max(max(buckets), max_eager_bs), device, self.dtype
         )
         self.local_transformer.freeze_kv_cache()
-        self._ensure_frame_sampler_compile()
         frame_decode = self._decode_frame_graphable
         self._frame_graphs: dict[
             int,

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -55,6 +55,7 @@ _MOSS_TTS_LOCAL_INSTALL_HINT = (
     "OpenMOSS-Team/MOSS-Audio-Tokenizer-v2."
 )
 _MAX_REFERENCE_SECONDS = 100.0
+_MOSS_TTS_LOCAL_MODEL_CONFIG_CACHE: dict[str, Any] = {}
 
 # NOTE: preprocessing and vocoder stages each load their own codec instance:
 # `model.streaming()` flips codec state, so a decode on a shared instance would
@@ -186,7 +187,31 @@ def _load_moss_tts_local_processor(model_path: str) -> Any:
         raise RuntimeError(_MOSS_TTS_LOCAL_INSTALL_HINT) from exc
 
     _normalize_processor_config(processor)
+    _MOSS_TTS_LOCAL_MODEL_CONFIG_CACHE[str(checkpoint_dir)] = processor.model_config
     return processor
+
+
+def _load_moss_tts_local_model_config(model_path: str) -> Any:
+    checkpoint_dir = resolve_moss_checkpoint(model_path)
+    cached = _MOSS_TTS_LOCAL_MODEL_CONFIG_CACHE.get(str(checkpoint_dir))
+    if cached is not None:
+        return cached
+    try:
+        from transformers import AutoConfig
+
+        with moss_transformers_processor_compat():
+            model_config = AutoConfig.from_pretrained(
+                checkpoint_dir,
+                trust_remote_code=True,
+            )
+    except Exception as exc:
+        raise RuntimeError(_MOSS_TTS_LOCAL_INSTALL_HINT) from exc
+
+    audio_vocab_size = int(getattr(model_config, "audio_vocab_size", 1024) or 1024)
+    for attr, default in moss_tts_local_special_token_defaults(audio_vocab_size):
+        if getattr(model_config, attr, None) is None:
+            setattr(model_config, attr, default)
+    return model_config
 
 
 def _resolve_audio_tokenizer_model_path(
@@ -548,6 +573,7 @@ def create_sglang_tts_engine_executor(
     async_decode_min_batch_size: int = 2,
     total_gpu_memory_fraction: float | None = None,
     codec_mem_reserve: float = 0.0,
+    compile_frame_sampler: bool = True,
 ) -> Any:
     from sglang_omni.models.moss_tts_local.engine_builder import (
         MossTtsLocalEngineBuilder,
@@ -558,6 +584,7 @@ def create_sglang_tts_engine_executor(
         async_decode_min_batch_size=async_decode_min_batch_size,
         total_gpu_memory_fraction=total_gpu_memory_fraction,
         codec_mem_reserve=codec_mem_reserve,
+        compile_frame_sampler=compile_frame_sampler,
     ).build(
         model_path,
         device=device,
@@ -589,14 +616,21 @@ def create_vocoder_executor(
     cuda_graph_min_free_gb: float = 3.0,
 ) -> MossTTSLocalStreamingVocoderScheduler:
     device = _resolve_codec_device(device, gpu_id)
-    processor = _load_moss_tts_local_processor(model_path)
+    model_config = _load_moss_tts_local_model_config(model_path)
     audio_tokenizer = load_moss_tts_local_audio_tokenizer(
-        _resolve_audio_tokenizer_model_path(processor, codec_model_path),
+        str(
+            codec_model_path
+            or getattr(
+                model_config,
+                "audio_tokenizer_name_or_path",
+                DEFAULT_MOSS_TTS_LOCAL_AUDIO_TOKENIZER,
+            )
+        ),
         device=device,
     )
     scheduler = MossTTSLocalStreamingVocoderScheduler(
         audio_tokenizer.model,
-        n_vq=int(processor.model_config.n_vq),
+        n_vq=int(model_config.n_vq),
         sample_rate=audio_tokenizer.sample_rate,
         stream_slots=stream_slots,
         stream_chunk_frames=stream_chunk_frames,

--- a/sglang_omni/models/qwen3_tts/compile_plan.py
+++ b/sglang_omni/models/qwen3_tts/compile_plan.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compile plan for the Qwen3-TTS decode backbone."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sglang_omni.compilation import (
+    CompilePlan,
+    build_module_list_compile_plan,
+    tensor_dim_bucket,
+)
+
+
+def create_qwen3_tts_compile_plan(model: Any) -> CompilePlan:
+    text_model = model.model
+    return build_module_list_compile_plan(
+        "qwen3_tts.decode_backbone",
+        text_model.layers,
+        install=lambda layers: setattr(
+            text_model,
+            "_compiled_decode_layers",
+            layers,
+        ),
+        bucket_fn=tensor_dim_bucket("hidden_states"),
+    )

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from sglang_omni.models.qwen3_tts import request_builders
 from sglang_omni.models.qwen3_tts import stages as qwen3_stages
+from sglang_omni.models.qwen3_tts.compile_plan import create_qwen3_tts_compile_plan
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
 
 
@@ -15,6 +16,7 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
     model_name = "Qwen3-TTS"
     context_length = 8192
     model_arch_override = "Qwen3TTSTalker"
+    compile_plan_factory = create_qwen3_tts_compile_plan
 
     def __init__(self, *, attn_implementation: str | None = None) -> None:
         self.attn_implementation = attn_implementation
@@ -52,6 +54,13 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             "trust_remote_code": True,
         }
 
+    def adjust_overrides(self, overrides: dict[str, Any]) -> None:
+        if overrides.get("enable_torch_compile"):
+            overrides["torch_compile_max_bs"] = max(
+                overrides["torch_compile_max_bs"],
+                overrides["max_running_requests"],
+            )
+
     def setup_model(
         self,
         *,
@@ -88,11 +97,6 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             model=model,
             wrapper=self.wrapper,
         )
-
-    def compile_model(self, model: Any, server_args: Any) -> None:
-        if bool(getattr(server_args, "enable_torch_compile", False)):
-            qwen3_stages._compile_qwen3_tts_backbone(model)
-            server_args.enable_torch_compile = False
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
         model_runner_mod = importlib.import_module(

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -105,24 +105,6 @@ def _load_qwen3_tts_generate_defaults(checkpoint_dir: str) -> dict[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
-def _compile_qwen3_tts_backbone(model: Any) -> None:
-    """Compile decoder blocks while leaving decode-input staging eager."""
-
-    text_model = model.model
-    layers = text_model.layers
-
-    from sglang.srt.model_executor.cuda_graph_runner import set_torch_compile_config
-
-    set_torch_compile_config()
-    compile_mode = os.environ.get(
-        "SGLANG_TORCH_COMPILE_MODE",
-        "max-autotune-no-cudagraphs",
-    )
-    text_model._compiled_decode_layers = [
-        torch.compile(layer, mode=compile_mode) for layer in layers
-    ]
-
-
 def create_preprocessing_executor(model_path: str) -> SimpleScheduler:
     del model_path
     return SimpleScheduler(

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -4,8 +4,15 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
+from collections.abc import Callable
+from typing import Any, ClassVar
 
+from sglang_omni.compilation import (
+    CompilePhase,
+    CompilePlan,
+    StageCompileManager,
+    configure_sglang_torch_compile,
+)
 from sglang_omni.scheduling.generation_batch_policy import (
     build_generation_batch_overrides,
     validate_generation_batch_policy,
@@ -19,6 +26,7 @@ class TtsEngineBuilder(ABC):
     model_name: str
     context_length: int
     model_arch_override: str | None = None
+    compile_plan_factory: ClassVar[Callable[[Any], CompilePlan] | None] = None
 
     def build(
         self,
@@ -89,10 +97,14 @@ class TtsEngineBuilder(ABC):
         )
 
         self.compile_model(model, server_args)
-
-        if want_cuda_graph:
-            model_worker.model_runner.init_device_graphs()
-            self.post_cuda_graph_setup(model, server_args)
+        compile_plan = self._create_compile_plan(model, server_args)
+        compile_manager = self._initialize_graphs_and_compile(
+            model_worker=model_worker,
+            model=model,
+            server_args=server_args,
+            want_cuda_graph=want_cuda_graph,
+            compile_plan=compile_plan,
+        )
 
         output_proc = sglang_backend.SGLangOutputProcessor(
             capture_hidden=False,
@@ -115,6 +127,8 @@ class TtsEngineBuilder(ABC):
             request_builder=request_builder,
             result_adapter=result_adapter,
         )
+        if compile_manager is not None:
+            scheduler._stage_compile_manager = compile_manager
         self.post_scheduler_setup(scheduler, model_runner)
         return scheduler
 
@@ -159,6 +173,53 @@ class TtsEngineBuilder(ABC):
 
     def compile_model(self, model: Any, server_args: Any) -> None:
         del model, server_args
+
+    def _create_compile_plan(self, model: Any, server_args: Any) -> CompilePlan | None:
+        factory = type(self).compile_plan_factory
+        if factory is None or not bool(
+            getattr(server_args, "enable_torch_compile", False)
+        ):
+            return None
+
+        plan = factory(model)
+        # The plan owns these callables, so the upstream full-model compiler must
+        # not try to compile the same model a second time.
+        server_args.enable_torch_compile = False
+        return plan
+
+    def _initialize_graphs_and_compile(
+        self,
+        *,
+        model_worker: Any,
+        model: Any,
+        server_args: Any,
+        want_cuda_graph: bool,
+        compile_plan: CompilePlan | None,
+    ) -> StageCompileManager | None:
+        compile_manager = (
+            StageCompileManager(
+                compile_plan,
+                configure_fn=configure_sglang_torch_compile,
+            )
+            if compile_plan is not None
+            else None
+        )
+        # Compile phases intentionally straddle primary and model-specific CUDA
+        # Graph setup because targets can require any one of these boundaries.
+        if compile_manager is not None:
+            compile_manager.apply(CompilePhase.BEFORE_PRIMARY_CUDA_GRAPH)
+
+        if want_cuda_graph:
+            model_worker.model_runner.init_device_graphs()
+        if compile_manager is not None:
+            compile_manager.apply(CompilePhase.AFTER_PRIMARY_CUDA_GRAPH)
+        if want_cuda_graph:
+            self.post_cuda_graph_setup(model, server_args)
+
+        if compile_manager is not None:
+            compile_manager.apply(CompilePhase.BEFORE_STAGE_READY)
+            compile_manager.finish_startup()
+        return compile_manager
 
     def post_cuda_graph_setup(self, model: Any, server_args: Any) -> None:
         del model, server_args

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -528,16 +528,13 @@ def test_s2pro_cli_talker_torch_compile_max_bs_rejects_non_positive() -> None:
         )
 
 
-def test_s2pro_compile_helper_targets_forward_kvcached(
+def test_s2pro_compile_plan_targets_forward_kvcached(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("HOME", "/tmp")
-    stages = importlib.import_module("sglang_omni.models.fishaudio_s2_pro.stages")
-
-    fake_runner = ModuleType("sglang.srt.model_executor.cuda_graph_runner")
-    fake_runner.set_torch_compile_config = lambda: None
-    monkeypatch.setitem(
-        sys.modules, "sglang.srt.model_executor.cuda_graph_runner", fake_runner
+    from sglang_omni.compilation import CompilePhase, StageCompileManager
+    from sglang_omni.models.fishaudio_s2_pro.compile_plan import (
+        create_fish_s2pro_compile_plan,
     )
 
     compile_calls: list[tuple[object, str | None, dict[str, object]]] = []
@@ -546,7 +543,7 @@ def test_s2pro_compile_helper_targets_forward_kvcached(
         target: object, *, mode: str | None = None, **kwargs: object
     ) -> object:
         compile_calls.append((target, mode, kwargs))
-        return f"compiled-{len(compile_calls)}"
+        return lambda *args: f"compiled-{len(compile_calls)}"
 
     monkeypatch.setattr(torch, "compile", fake_compile)
     monkeypatch.setenv("SGLANG_TORCH_COMPILE_MODE", "reduce-overhead")
@@ -561,6 +558,7 @@ def test_s2pro_compile_helper_targets_forward_kvcached(
     class _AudioDecoder:
         def __init__(self) -> None:
             self.layers = [_Layer()]
+            self.kv_cache_max_batch_size = 2
 
         def set_compiled_forward_kvcached_layers(
             self,
@@ -574,7 +572,11 @@ def test_s2pro_compile_helper_targets_forward_kvcached(
     audio_decoder = _AudioDecoder()
     model = SimpleNamespace(_audio_decoder=audio_decoder)
 
-    stages._compile_s2pro_codebook_decoder(model, max_batch_size=2)
+    manager = StageCompileManager(
+        create_fish_s2pro_compile_plan(model),
+        configure_fn=lambda: None,
+    )
+    manager.apply(CompilePhase.BEFORE_PRIMARY_CUDA_GRAPH)
 
     assert len(compile_calls) == 1
     target, mode, kwargs = compile_calls[0]
@@ -582,7 +584,12 @@ def test_s2pro_compile_helper_targets_forward_kvcached(
     assert getattr(target, "__name__", "") == "forward_kvcached"
     assert mode == "reduce-overhead"
     assert kwargs == {}
-    assert audio_decoder._compiled_forward_kvcached_layers == ["compiled-1"]
+    assert (
+        audio_decoder._compiled_forward_kvcached_layers[0](
+            torch.zeros(2, 1, 4), torch.zeros(1), torch.zeros(2)
+        )
+        == "compiled-1"
+    )
     assert audio_decoder._compiled_forward_kvcached_max_bs == 2
 
 
@@ -603,7 +610,7 @@ def _run_s2pro_engine_with_fake_buffers(
 
     build_kwargs: dict[str, object] = {}
     infrastructure_saw_graph_disabled: list[bool] = []
-    compile_calls: list[tuple[object, int]] = []
+    compile_calls: list[tuple[object, str | None]] = []
     init_graph_calls: list[bool] = []
 
     class _FakeSGLangRunner:
@@ -622,11 +629,30 @@ def _run_s2pro_engine_with_fake_buffers(
 
     monkeypatch.setattr(fish_bootstrap, "patch_fish_config_for_sglang", lambda: None)
     monkeypatch.setattr(fish_bootstrap, "truncate_rope_to_bf16", lambda model: None)
+
+    class _Layer:
+        def forward_kvcached(self, *args: object) -> object:
+            return args[0]
+
+    class _AudioDecoder:
+        def __init__(self) -> None:
+            self.layers = [_Layer()]
+            self.kv_cache_max_batch_size = -1
+
+        def set_compiled_forward_kvcached_layers(
+            self,
+            layers: list[object],
+            *,
+            max_batch_size: int,
+        ) -> None:
+            self.compiled_layers = layers
+            self.compiled_max_batch_size = max_batch_size
+
     monkeypatch.setattr(
         fish_bootstrap,
         "load_audio_decoder",
         lambda checkpoint_dir, device: (
-            SimpleNamespace(kv_cache_max_batch_size=-1),
+            _AudioDecoder(),
             10,
             4096,
             FakeFishTokenizer(),
@@ -737,10 +763,13 @@ def _run_s2pro_engine_with_fake_buffers(
         fake_model_runner,
     )
 
-    def fake_compile(model: object, *, max_batch_size: int) -> None:
-        compile_calls.append((model, max_batch_size))
+    monkeypatch.setattr(engine_factory, "configure_sglang_torch_compile", lambda: None)
 
-    monkeypatch.setattr(stages, "_compile_s2pro_codebook_decoder", fake_compile)
+    def fake_compile(target: object, *, mode: str | None = None) -> object:
+        compile_calls.append((target, mode))
+        return target
+
+    monkeypatch.setattr(torch, "compile", fake_compile)
 
     scheduler = stages.create_sglang_tts_engine_executor("model", device="cuda:0")
     return SimpleNamespace(
@@ -781,9 +810,9 @@ def test_s2pro_engine_disables_generic_compile_after_local_compile(
     ]
     assert build_kwargs["torch_compile_max_bs"] == 64
     assert result.infrastructure_saw_graph_disabled == [True]
-    assert result.compile_calls == [
-        (scheduler.model_runner.args[0].model_runner.model, 64)
-    ]
+    assert len(result.compile_calls) == 1
+    assert result.compile_calls[0][1] == "max-autotune-no-cudagraphs"
+    assert scheduler._stage_compile_manager.stats().target_count == 1
     assert result.init_graph_calls == [True]
     assert scheduler.server_args.disable_cuda_graph is False
     assert scheduler.server_args.enable_torch_compile is False

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -39,7 +39,27 @@ def test_higgs_streaming_pipeline_routes_chunks_to_vocoder() -> None:
 
     assert stages_by_name["tts_engine"].stream_to == ["vocoder"]
     assert "server_args_overrides" not in stages_by_name["tts_engine"].factory_args
+    assert stages_by_name["audio_encoder"].factory_args["compile_encoder"] is True
+    assert stages_by_name["vocoder"].factory_args["compile_decode"] is True
     assert stages_by_name["vocoder"].can_accept_stream_before_payload is True
+
+
+def test_higgs_compiled_stages_have_explicit_off_switches() -> None:
+    config = HiggsTtsPipelineConfig(
+        model_path="fake-model",
+        runtime_overrides={
+            "audio_encoder": {"compile_encoder": False},
+            "vocoder": {"compile_decode": False},
+        },
+    )
+    stages_by_name = {stage.name: stage for stage in config.stages}
+
+    encoder_args = resolve_stage_static_factory_args(
+        stages_by_name["audio_encoder"], config
+    )
+    vocoder_args = resolve_stage_static_factory_args(stages_by_name["vocoder"], config)
+    assert encoder_args["compile_encoder"] is False
+    assert vocoder_args["compile_decode"] is False
 
 
 def test_higgs_streaming_pipeline_shares_vocoder_stride_with_tts_engine() -> None:
@@ -413,6 +433,7 @@ def test_higgs_audio_encoder_uses_reference_code_cache(monkeypatch) -> None:
         "ckpt",
         device="cuda:0",
         num_codebooks=2,
+        compile_encoder=False,
     )
     # Ignore the construction-time codec warm-up call added by #612.
     fake_codec.calls = 0
@@ -490,6 +511,7 @@ def test_higgs_audio_encoder_uses_shared_cache_for_uploaded_voice(
         "ckpt",
         device="cuda:0",
         num_codebooks=2,
+        compile_encoder=False,
     )
     fake_codec.calls = 0
     encode = scheduler._fn

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -71,7 +71,7 @@ def test_compile_encoder_sets_runner_and_warms_each_bucket(
     )
 
     monkeypatch.setattr(
-        "sglang_omni.models.moss_transcribe_diarize.sglang_model.set_torch_compile_config",
+        "sglang_omni.models.moss_transcribe_diarize.sglang_model.configure_sglang_torch_compile",
         lambda: None,
     )
     warmups: list[tuple[int, ...]] = []
@@ -82,15 +82,13 @@ def test_compile_encoder_sets_runner_and_warms_each_bucket(
     model = SimpleNamespace(
         whisper_encoder=encoder,
         _compiled_encoder=None,
-        _compiled_chunk_buckets=frozenset(),
         config=SimpleNamespace(audio_config=SimpleNamespace(num_mel_bins=4)),
     )
 
     Model.compile_encoder(model, [2, 1, 1], input_feature_len=6)
 
-    assert model._compiled_encoder is runner
-    assert model._compiled_chunk_buckets == frozenset({1, 2})
-    assert model._compiled_input_feature_len == 6
+    assert callable(model._compiled_encoder)
+    assert model._encoder_compile_manager.stats().warmup_failures == 0
     assert len(warmups) == 6
     assert {shape[0] for shape in warmups} == {1, 2}
     assert all(shape[1:] == (4, 6) for shape in warmups)
@@ -106,7 +104,7 @@ def test_compile_encoder_drops_bucket_whose_warmup_fails(
     )
 
     monkeypatch.setattr(
-        "sglang_omni.models.moss_transcribe_diarize.sglang_model.set_torch_compile_config",
+        "sglang_omni.models.moss_transcribe_diarize.sglang_model.configure_sglang_torch_compile",
         lambda: None,
     )
 
@@ -119,14 +117,12 @@ def test_compile_encoder_drops_bucket_whose_warmup_fails(
     model = SimpleNamespace(
         whisper_encoder=torch.nn.Linear(4, 4),
         _compiled_encoder=None,
-        _compiled_chunk_buckets=frozenset(),
-        _compiled_input_feature_len=0,
         config=SimpleNamespace(audio_config=SimpleNamespace(num_mel_bins=4)),
     )
 
     Model.compile_encoder(model, [1, 2], input_feature_len=6)
 
-    assert model._compiled_chunk_buckets == frozenset({1})
+    assert model._encoder_compile_manager.stats().warmup_failures == 1
 
 
 def _stub_factory_env(monkeypatch: pytest.MonkeyPatch, *, want_cuda_graph: bool):

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -12,6 +12,7 @@ import torch
 
 from sglang_omni.client.audio import encode_audio, encode_wav
 from sglang_omni.config.placement import build_stage_placement_plan
+from sglang_omni.config.runtime import resolve_stage_static_factory_args
 from sglang_omni.models.moss_tts_local.audio_tokenizer import MossTTSLocalAudioTokenizer
 from sglang_omni.models.moss_tts_local.config import (
     MossTTSLocalColocatedPipelineConfig,
@@ -404,6 +405,7 @@ def test_pipeline_stage_wiring():
     assert tts_engine_runtime.resources.total_gpu_memory_fraction == pytest.approx(0.90)
     assert tts_engine_runtime.sglang_server_args.mem_fraction_static is None
     assert stages["tts_engine"].factory_args["codec_mem_reserve"] == pytest.approx(0.15)
+    assert stages["tts_engine"].factory_args["compile_frame_sampler"] is True
     assert stages["vocoder"].process == "pipeline"
     assert stages["vocoder"].gpu == 0
     assert stages["vocoder"].factory_args["device"] == "cuda:0"
@@ -432,6 +434,19 @@ def test_pipeline_stage_wiring():
     assert split_runtime.resources.total_gpu_memory_fraction is None
     assert split_runtime.sglang_server_args.mem_fraction_static == pytest.approx(0.85)
     assert split_stages["vocoder"].factory_args["device"] == "cuda:1"
+
+
+def test_moss_local_frame_sampler_compile_has_explicit_off_switch() -> None:
+    config = MossTTSLocalPipelineConfig(
+        model_path="OpenMOSS-Team/moss-local-test",
+        runtime_overrides={"tts_engine": {"compile_frame_sampler": False}},
+    )
+    stage = next(stage for stage in config.stages if stage.name == "tts_engine")
+
+    assert (
+        resolve_stage_static_factory_args(stage, config)["compile_frame_sampler"]
+        is False
+    )
 
 
 def test_pipeline_config_injects_reference_cache_factory_args():
@@ -584,6 +599,7 @@ def test_colocated_moss_ar_factory_threads_effective_budget(monkeypatch):
         server_args_overrides={"disable_cuda_graph": True},
         total_gpu_memory_fraction=0.90,
         codec_mem_reserve=0.05,
+        compile_frame_sampler=False,
     )
 
     assert infrastructure_calls == [
@@ -611,6 +627,7 @@ def test_colocated_moss_ar_factory_uses_upstream_profile_without_process_account
         server_args_overrides={"disable_cuda_graph": True},
         total_gpu_memory_fraction=0.90,
         codec_mem_reserve=0.05,
+        compile_frame_sampler=False,
     )
 
     assert infrastructure_calls == [
@@ -634,6 +651,7 @@ def test_colocated_moss_ar_abort_callback_requires_model(monkeypatch):
         async_decode_min_batch_size=2,
         total_gpu_memory_fraction=None,
         codec_mem_reserve=0.05,
+        compile_frame_sampler=True,
     )
 
     with pytest.raises(AssertionError):

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -1924,50 +1924,57 @@ def test_qwen3_tts_sampled_subtalker_requires_semantic_positions(
         )
 
 
-def test_qwen3_tts_compile_backbone_requires_text_layers(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    install_fake_sglang(monkeypatch)
-    from sglang_omni.models.qwen3_tts.stages import _compile_qwen3_tts_backbone
+def test_qwen3_tts_compile_backbone_requires_text_layers() -> None:
+    from sglang_omni.models.qwen3_tts.compile_plan import create_qwen3_tts_compile_plan
 
-    with pytest.raises(AttributeError):
-        _compile_qwen3_tts_backbone(SimpleNamespace())
+    with pytest.raises(ValueError, match="has no callables"):
+        create_qwen3_tts_compile_plan(SimpleNamespace(model=SimpleNamespace(layers=[])))
 
 
-def test_qwen3_tts_compile_backbone_compiles_every_layer(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    install_fake_sglang(monkeypatch)
-    from sglang_omni.models.qwen3_tts.stages import _compile_qwen3_tts_backbone
+def test_qwen3_tts_compile_backbone_compiles_every_layer() -> None:
+    from sglang_omni.compilation import CompilePhase, StageCompileManager
+    from sglang_omni.models.qwen3_tts.compile_plan import create_qwen3_tts_compile_plan
 
     set_config_calls = []
     compiled = []
-    cuda_graph_runner = types.ModuleType("sglang.srt.model_executor.cuda_graph_runner")
-    cuda_graph_runner.set_torch_compile_config = lambda: set_config_calls.append(True)
-    monkeypatch.setitem(
-        sys.modules,
-        "sglang.srt.model_executor.cuda_graph_runner",
-        cuda_graph_runner,
-    )
 
     def fake_compile(layer, *, mode):
         compiled.append((layer, mode))
-        return f"compiled-{len(compiled)}"
+        return lambda value: value
 
-    monkeypatch.setattr(torch, "compile", fake_compile)
     layers = [object(), object(), object()]
     text_model = SimpleNamespace(layers=layers)
-    model = SimpleNamespace(model=text_model)
+    plan = create_qwen3_tts_compile_plan(SimpleNamespace(model=text_model))
+    manager = StageCompileManager(
+        plan,
+        compile_fn=fake_compile,
+        configure_fn=lambda: set_config_calls.append(True),
+    )
 
-    _compile_qwen3_tts_backbone(model)
+    manager.apply(CompilePhase.BEFORE_PRIMARY_CUDA_GRAPH)
 
     assert set_config_calls == [True]
     assert compiled == [(layer, "max-autotune-no-cudagraphs") for layer in layers]
-    assert text_model._compiled_decode_layers == [
-        "compiled-1",
-        "compiled-2",
-        "compiled-3",
-    ]
+    assert len(text_model._compiled_decode_layers) == len(layers)
+    assert all(callable(layer) for layer in text_model._compiled_decode_layers)
+
+    bucket_fn = plan.targets[0].bucket_fn
+    assert bucket_fn is not None
+    assert bucket_fn(torch.zeros(4, 1, 8)) == 4
+
+
+def test_qwen3_tts_compile_limit_covers_requested_concurrency() -> None:
+    from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
+
+    overrides = {
+        "enable_torch_compile": True,
+        "max_running_requests": 64,
+        "torch_compile_max_bs": 32,
+    }
+
+    Qwen3TtsEngineBuilder().adjust_overrides(overrides)
+
+    assert overrides["torch_compile_max_bs"] == 64
 
 
 def test_qwen3_tts_engine_applies_compat_overrides_and_reenables_cuda_graph(
@@ -2002,9 +2009,13 @@ def test_qwen3_tts_engine_applies_compat_overrides_and_reenables_cuda_graph(
     build_kwargs: dict = {}
     infrastructure_saw_graph_disabled: list[bool] = []
     init_graph_calls: list[bool] = []
-    compile_calls: list[bool] = []
+    compile_calls: list[tuple[object, str]] = []
+    compile_config_calls: list[bool] = []
 
     class FakeModel:
+        def __init__(self) -> None:
+            self.model = SimpleNamespace(layers=[object(), object()])
+
         def load_speech_tokenizer(self, tokenizer) -> None:
             self.speech_tokenizer = tokenizer
 
@@ -2053,10 +2064,16 @@ def test_qwen3_tts_engine_applies_compat_overrides_and_reenables_cuda_graph(
         lambda **kwargs: (lambda payload: payload, lambda data: data),
     )
     monkeypatch.setattr(
-        stages,
-        "_compile_qwen3_tts_backbone",
-        lambda model: compile_calls.append(model),
+        engine_factory,
+        "configure_sglang_torch_compile",
+        lambda: compile_config_calls.append(True),
     )
+
+    def fake_compile(layer, *, mode):
+        compile_calls.append((layer, mode))
+        return layer
+
+    monkeypatch.setattr(torch, "compile", fake_compile)
 
     def fake_build_sglang_server_args(model_path, context_length, **kwargs):
         del model_path, context_length
@@ -2155,13 +2172,16 @@ def test_qwen3_tts_engine_applies_compat_overrides_and_reenables_cuda_graph(
     )
 
     assert infrastructure_saw_graph_disabled == [True]
-    assert len(compile_calls) == 1
+    assert compile_config_calls == [True]
+    assert len(compile_calls) == 2
+    assert all(mode == "max-autotune-no-cudagraphs" for _, mode in compile_calls)
     assert init_graph_calls == [True]
     assert scheduler.server_args.cuda_graph_bs == [1, 2, 4, 8, 12, 16, 24, 32]
     assert scheduler.server_args.cuda_graph_max_bs == 32
     assert scheduler.server_args.disable_cuda_graph is False
     assert scheduler.server_args.enable_torch_compile is False
     assert scheduler.server_args.torch_compile_max_bs == 32
+    assert scheduler._stage_compile_manager.stats().target_count == 2
     clear_qwen3_tts_preprocessing_context()
 
 

--- a/tests/unit_test/scheduling/test_engine_compile_plan.py
+++ b/tests/unit_test/scheduling/test_engine_compile_plan.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from sglang_omni.compilation import CompilePlan
+from sglang_omni.scheduling import bootstrap, engine_factory, sglang_backend
+from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
+
+
+def test_tts_engine_builder_runs_compile_plan_around_cuda_graph(
+    monkeypatch,
+) -> None:
+    events: list[str] = []
+    server_args = SimpleNamespace(
+        disable_cuda_graph=False,
+        enable_torch_compile=True,
+    )
+    model = object()
+    model_runner = SimpleNamespace(
+        model=model,
+        init_device_graphs=lambda: events.append("primary_cuda_graph"),
+    )
+    model_worker = SimpleNamespace(model_runner=model_runner)
+
+    def create_infrastructure(*args: Any, **kwargs: Any):
+        del args, kwargs
+        return True, (
+            model_worker,
+            "tree_cache",
+            "req_pool",
+            "kv_pool",
+            "prefill",
+            "decode",
+            "model_config",
+        )
+
+    monkeypatch.setattr(
+        bootstrap,
+        "create_sglang_infrastructure_defer_cuda_graph",
+        create_infrastructure,
+    )
+    monkeypatch.setattr(
+        sglang_backend,
+        "build_sglang_server_args",
+        lambda *args, **kwargs: server_args,
+    )
+    monkeypatch.setattr(
+        sglang_backend,
+        "SGLangOutputProcessor",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    monkeypatch.setattr(
+        engine_factory,
+        "validate_generation_batch_policy",
+        lambda **kwargs: None,
+    )
+
+    class FakeCompileManager:
+        def __init__(self, plan: CompilePlan, **kwargs: Any) -> None:
+            assert (
+                kwargs["configure_fn"] is engine_factory.configure_sglang_torch_compile
+            )
+            events.append("compile_manager")
+            self.plan = plan
+
+        def apply(self, phase: Any) -> None:
+            events.append(phase.value)
+
+        def finish_startup(self) -> None:
+            events.append("compile_finish")
+
+    monkeypatch.setattr(engine_factory, "StageCompileManager", FakeCompileManager)
+
+    def create_plan(model: Any) -> CompilePlan:
+        del model
+        events.append("create_compile_plan")
+        return CompilePlan(name="test.plan", targets=())
+
+    class Builder(TtsEngineBuilder):
+        model_name = "test"
+        context_length = 1
+        compile_plan_factory = create_plan
+
+        def resolve_checkpoint(self, model_path: str) -> str:
+            return model_path
+
+        def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
+            del dtype
+            return {"max_running_requests": 1}
+
+        def setup_model(self, **kwargs: Any) -> None:
+            del kwargs
+            events.append("setup_model")
+
+        def compile_model(self, model: Any, server_args: Any) -> None:
+            del model, server_args
+            events.append("legacy_compile_model")
+
+        def post_cuda_graph_setup(self, model: Any, server_args: Any) -> None:
+            del model, server_args
+            events.append("aux_cuda_graph")
+
+        def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
+            del model_worker, output_proc
+            return "runner"
+
+        def make_adapters(self, model: Any) -> tuple[Any, Any]:
+            del model
+            return "request_builder", "result_adapter"
+
+        def make_scheduler(self, **kwargs: Any) -> Any:
+            assert server_args.enable_torch_compile is False
+            del kwargs
+            return SimpleNamespace()
+
+    scheduler = Builder().build("model")
+
+    assert events == [
+        "setup_model",
+        "legacy_compile_model",
+        "create_compile_plan",
+        "compile_manager",
+        "before_primary_cuda_graph",
+        "primary_cuda_graph",
+        "after_primary_cuda_graph",
+        "aux_cuda_graph",
+        "before_stage_ready",
+        "compile_finish",
+    ]
+    assert scheduler._stage_compile_manager.plan.name == "test.plan"
+
+
+def test_compile_plan_only_consumes_enabled_custom_plan() -> None:
+    class BuilderWithoutPlan:
+        compile_plan_factory = None
+
+    class BuilderWithPlan:
+        def compile_plan_factory(model: Any) -> CompilePlan:
+            del model
+            return CompilePlan(name="test.plan", targets=())
+
+    upstream_args = SimpleNamespace(enable_torch_compile=True)
+    disabled_args = SimpleNamespace(enable_torch_compile=False)
+    enabled_args = SimpleNamespace(enable_torch_compile=True)
+
+    assert (
+        TtsEngineBuilder._create_compile_plan(
+            BuilderWithoutPlan(), object(), upstream_args
+        )
+        is None
+    )
+    assert (
+        TtsEngineBuilder._create_compile_plan(
+            BuilderWithPlan(), object(), disabled_args
+        )
+        is None
+    )
+    plan = TtsEngineBuilder._create_compile_plan(
+        BuilderWithPlan(), object(), enabled_args
+    )
+
+    assert plan is not None and plan.name == "test.plan"
+    assert upstream_args.enable_torch_compile is True
+    assert disabled_args.enable_torch_compile is False
+    assert enabled_args.enable_torch_compile is False

--- a/tests/unit_test/utils/test_stage_compile.py
+++ b/tests/unit_test/utils/test_stage_compile.py
@@ -1,0 +1,264 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+
+import sglang_omni.compilation.stage_compile as stage_compile
+from sglang_omni.compilation import (
+    CompilePhase,
+    CompilePlan,
+    CompileTarget,
+    CompileWarmupCase,
+    StageCompileManager,
+)
+
+
+def _plan(*targets: CompileTarget) -> CompilePlan:
+    return CompilePlan(name="test.plan", targets=targets)
+
+
+def test_manager_installs_compiled_callable_once_per_phase() -> None:
+    installed = []
+    configured = []
+    compile_calls = []
+
+    def eager(value: int) -> str:
+        return f"eager:{value}"
+
+    def compile_fn(fn, **kwargs):
+        compile_calls.append((fn, kwargs))
+        return lambda value: f"compiled:{value}"
+
+    manager = StageCompileManager(
+        _plan(
+            CompileTarget(
+                name="target",
+                eager=eager,
+                install=installed.append,
+                compile_kwargs={"mode": "default"},
+            )
+        ),
+        compile_fn=compile_fn,
+        configure_fn=lambda: configured.append(True),
+    )
+
+    manager.apply(CompilePhase.BEFORE_PRIMARY_CUDA_GRAPH)
+    manager.apply(CompilePhase.BEFORE_PRIMARY_CUDA_GRAPH)
+
+    assert configured == [True]
+    assert compile_calls == [(eager, {"mode": "default"})]
+    assert len(installed) == 1
+    assert installed[0](3) == "compiled:3"
+    assert manager.stats().target_count == 1
+
+
+def test_default_compiler_is_resolved_after_configuration(monkeypatch) -> None:
+    installed = []
+    compile_calls = []
+
+    def configured_compile(fn, **kwargs):
+        compile_calls.append((fn, kwargs))
+        return lambda value: value + 10
+
+    def configure_fn() -> None:
+        monkeypatch.setattr(stage_compile.torch, "compile", configured_compile)
+
+    manager = StageCompileManager(
+        _plan(
+            CompileTarget(
+                name="target",
+                eager=lambda value: value,
+                install=installed.append,
+            )
+        ),
+        configure_fn=configure_fn,
+    )
+
+    manager.apply(CompilePhase.BEFORE_PRIMARY_CUDA_GRAPH)
+
+    assert len(compile_calls) == 1
+    assert installed[0](2) == 12
+
+
+@pytest.mark.parametrize("failure_site", ["configure", "compile"])
+def test_setup_failure_installs_direct_eager_callable(failure_site: str) -> None:
+    installed = []
+
+    def eager(value: int) -> int:
+        return value + 1
+
+    def configure_fn() -> None:
+        if failure_site == "configure":
+            raise RuntimeError("configure failed")
+
+    def compile_fn(fn, **kwargs):
+        del fn, kwargs
+        if failure_site == "compile":
+            raise RuntimeError("compile failed")
+        raise AssertionError("compile_fn must not run after configuration failure")
+
+    manager = StageCompileManager(
+        _plan(
+            CompileTarget(
+                name="target",
+                eager=eager,
+                install=installed.append,
+            )
+        ),
+        compile_fn=compile_fn,
+        configure_fn=configure_fn,
+    )
+
+    manager.apply(CompilePhase.BEFORE_PRIMARY_CUDA_GRAPH)
+
+    assert installed == [eager]
+    assert installed[0](4) == 5
+    assert manager.stats().setup_failures == 1
+
+
+def test_warmup_failure_falls_back_only_for_failed_bucket() -> None:
+    installed = []
+    compiled_calls = []
+    eager_calls = []
+
+    def eager(value: int) -> str:
+        eager_calls.append(value)
+        return f"eager:{value}"
+
+    def compiled(value: int) -> str:
+        compiled_calls.append(value)
+        if value == 2:
+            raise RuntimeError("unsupported bucket")
+        return f"compiled:{value}"
+
+    target = CompileTarget(
+        name="target",
+        eager=eager,
+        install=installed.append,
+        bucket_fn=lambda value: value,
+        warmup_cases=(
+            CompileWarmupCase("one", args=(1,), bucket=1),
+            CompileWarmupCase("two", args=(2,), bucket=2),
+        ),
+    )
+    manager = StageCompileManager(
+        _plan(target),
+        compile_fn=lambda fn, **kwargs: compiled,
+        configure_fn=lambda: None,
+    )
+
+    manager.apply(CompilePhase.BEFORE_PRIMARY_CUDA_GRAPH)
+
+    assert installed[0](1) == "compiled:1"
+    assert installed[0](2) == "eager:2"
+    assert compiled_calls == [1, 2, 1]
+    assert eager_calls == [2]
+    assert manager.stats().warmup_failures == 1
+
+
+def test_warmup_repeat_and_restriction_keep_unwarmed_buckets_eager() -> None:
+    installed = []
+    compiled_calls = []
+    eager_calls = []
+
+    def eager(value: int) -> str:
+        eager_calls.append(value)
+        return f"eager:{value}"
+
+    def compiled(value: int) -> str:
+        compiled_calls.append(value)
+        return f"compiled:{value}"
+
+    manager = StageCompileManager(
+        _plan(
+            CompileTarget(
+                name="target",
+                eager=eager,
+                install=installed.append,
+                bucket_fn=lambda value: value,
+                warmup_cases=(CompileWarmupCase("one", args=(1,), repeat=3),),
+                restrict_to_warmed_buckets=True,
+            )
+        ),
+        compile_fn=lambda fn, **kwargs: compiled,
+        configure_fn=lambda: None,
+    )
+
+    manager.apply(CompilePhase.BEFORE_PRIMARY_CUDA_GRAPH)
+
+    assert installed[0](1) == "compiled:1"
+    assert installed[0](2) == "eager:2"
+    assert compiled_calls == [1, 1, 1, 1]
+    assert eager_calls == [2]
+
+
+def test_runtime_failure_disables_compiled_callable_for_that_bucket() -> None:
+    installed = []
+    compiled_calls = []
+    eager_calls = []
+
+    def eager(value: int) -> str:
+        eager_calls.append(value)
+        return f"eager:{value}"
+
+    def compiled(value: int) -> str:
+        compiled_calls.append(value)
+        if value == 2:
+            raise RuntimeError("runtime failure")
+        return f"compiled:{value}"
+
+    manager = StageCompileManager(
+        _plan(
+            CompileTarget(
+                name="target",
+                eager=eager,
+                install=installed.append,
+                bucket_fn=lambda value: value,
+            )
+        ),
+        compile_fn=lambda fn, **kwargs: compiled,
+        configure_fn=lambda: None,
+    )
+    manager.apply(CompilePhase.BEFORE_PRIMARY_CUDA_GRAPH)
+
+    assert installed[0](2) == "eager:2"
+    assert installed[0](2) == "eager:2"
+    assert compiled_calls == [2]
+    assert eager_calls == [2, 2]
+    assert manager.stats().runtime_fallbacks == 1
+
+
+def test_compile_events_are_observed_once_per_bucket(monkeypatch) -> None:
+    installed = []
+
+    @contextmanager
+    def fake_observer(events):
+        events.append(0.25)
+        yield
+
+    monkeypatch.setattr(stage_compile, "_observe_torch_compilations", fake_observer)
+    manager = StageCompileManager(
+        _plan(
+            CompileTarget(
+                name="target",
+                eager=lambda value: value,
+                install=installed.append,
+                bucket_fn=lambda value: value,
+            )
+        ),
+        compile_fn=lambda fn, **kwargs: fn,
+        configure_fn=lambda: None,
+    )
+    manager.apply(CompilePhase.BEFORE_PRIMARY_CUDA_GRAPH)
+
+    installed[0](1)
+    installed[0](1)
+    installed[0](2)
+
+    stats = manager.stats()
+    assert stats.compilation_count == 2
+    assert stats.recompilation_count == 1
+    assert stats.compile_time_s == pytest.approx(0.5)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

This PR refactors the model-owned `torch.compile` usage into a shared compile lifecycle so TTS and omni model stages can declare what should be compiled without duplicating setup, warmup, fallback, and logging logic in each model implementation.

The main goal is to make compile integration more maintainable and less invasive:

- keep model-specific compile targets, warmup shapes, and bucket policy in small `compile_plan.py` files;
- let the common lifecycle install compiled callables at well-defined startup phases;
- preserve eager fallback when compile setup, warmup, or runtime execution fails;
- avoid changing model behavior when compile is disabled;
- keep CUDA graph ordering explicit for models that depend on capture timing.

## Modifications

Added a shared compile lifecycle module under `sglang_omni.compilation`:

- `CompileTarget` describes one callable to compile, how to install it, compile kwargs, optional bucket selection, warmup cases, and warmed-bucket restrictions.
- `CompilePlan` groups one model or stage's compile targets.
- `StageCompileManager` applies compile targets at lifecycle phases, records setup/warmup/runtime fallback state, and logs aggregate compile stats.
- `CompileWarmupCase` provides declarative warmup invocations for fixed-shape or bucketed compile paths.
- Shared helpers cover SGLang compile configuration and tensor-shape bucket extraction.

Integrated the lifecycle into `TtsEngineBuilder` for SGLang-backed TTS engine stages:

- models that go through `TtsEngineBuilder` only need to expose `compile_plan_factory`;
- the builder creates the compile plan when `enable_torch_compile` is enabled;
- compile phases are applied around primary CUDA graph capture and model-specific post-CUDA-graph setup;
- the upstream full-model compile flag is disabled after creating a model-owned compile plan to avoid compiling the same path twice.

Added model-specific compile plans:

- Qwen3-TTS declares its compiled codec/predictor stages in `models/qwen3_tts/compile_plan.py`.
- FishAudio S2 Pro declares its compiled generation modules in `models/fishaudio_s2_pro/compile_plan.py`.
- MOSS-TTS-Local declares its frame sampler compile target in `models/moss_tts_local/compile_plan.py`.
- Higgs TTS declares standalone codec-stage compile targets in `models/higgs_tts/compile_plan.py`.
- MOSS-Transcribe-Diarize declares its Whisper encoder compile target in `models/moss_transcribe_diarize/compile_plan.py`.

Preserved the two lifecycle styles required by the current pipeline structure:

- SGLang-backed TTS engine stages use `compile_plan_factory` and are applied automatically by `TtsEngineBuilder`.
- Standalone non-`TtsEngineBuilder` stages, such as Higgs codec stages and MOSS-TD encoder setup, still create a `StageCompileManager` in their own lifecycle, but their target definitions now live in `compile_plan.py`.

Kept compile disable and fallback behavior explicit:

- model config or factory arguments decide whether compile is enabled;
- creating a compile manager means compile is requested;
- setup, warmup, and runtime failures fall back to eager execution through the shared manager;
- warmed-bucket restrictions remain available for shapes where uncaptured or unwarmed compile variants should not run online.

Also adjusted MOSS-TTS-Local startup behavior to avoid reloading slow remote-code model config in the colocated vocoder stage when preprocessing already loaded the same config in the same process. Split-process behavior still falls back to loading the config locally.

## Related Issues

Addresses the compile lifecycle refactor requested in #1121.

## Accuracy Test

To be filled after final accuracy runs are attached.

## Benchmark & Profiling

To be filled after final benchmark and profiling results are attached.

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
