### PR TITLE
feat(voxcpm): Add VoxCPM 1.x and 2 serving

### DIFF
--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -32,6 +32,12 @@ uv pip install --no-deps qwen-tts==0.1.1
 | VoxCPM 1.0 / 1.5 | `examples/configs/voxcpm1.yaml`, `examples/configs/voxcpm.yaml` | Text-only synthesis or continuation cloning; `ref_text` is optional when `ref_audio` is supplied |
 | VoxCPM2 | `examples/configs/voxcpm2.yaml` | Text-only synthesis, isolated cloning with `ref_audio`, or continuation with `ref_audio` + `ref_text`; outputs 48 kHz audio |
 
+VoxCPM enables AR and fixed-step CFM CUDA graphs by default. Requests that
+override `inference_timesteps` use the eager CFM fallback. Experimental VAE
+Snake compilation (`SGLANG_VOXCPM_ENABLE_VAE_COMPILE=1`) and one-step async
+decode (`SGLANG_VOXCPM_ENABLE_ASYNC_DECODE=1`) are opt-in because they can
+change numerical output or reduce throughput on some GPUs.
+
 ## Launch the Server
 
 The reference-audio examples below fetch clips from Hugging Face, so the

--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -29,7 +29,7 @@ uv pip install --no-deps qwen-tts==0.1.1
 | [Qwen3-TTS VoiceDesign](../cookbook/qwen3_tts.md) | `examples/configs/qwen3_tts_1_7b_voicedesign.yaml` | Requires `task_type="VoiceDesign"` and non-empty `instructions`. No reference audio is required |
 | [Ming-Omni-TTS](../cookbook/ming_tts.md) | `examples/configs/ming_omni_tts.yaml` | Text-only synthesis or one local reference clip with its transcript; TP1 is supported and the provided config uses TP2 |
 | [MOSS-TTS](../cookbook/moss_tts.md) | `examples/configs/moss_tts.yaml` | Voice cloning via `ref_audio` or `references[0].audio_path` (+ `text`). Duration via `${token:N}` or `token_count`. Benchmark at `--max-concurrency 8` |
-| VoxCPM1.5 | `examples/configs/voxcpm.yaml` | Text-only synthesis or continuation cloning; `ref_text` is optional when `ref_audio` is supplied |
+| VoxCPM 1.0 / 1.5 | `examples/configs/voxcpm1.yaml`, `examples/configs/voxcpm.yaml` | Text-only synthesis or continuation cloning; `ref_text` is optional when `ref_audio` is supplied |
 | VoxCPM2 | `examples/configs/voxcpm2.yaml` | Text-only synthesis, isolated cloning with `ref_audio`, or continuation with `ref_audio` + `ref_text`; outputs 48 kHz audio |
 
 ## Launch the Server

--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -29,6 +29,8 @@ uv pip install --no-deps qwen-tts==0.1.1
 | [Qwen3-TTS VoiceDesign](../cookbook/qwen3_tts.md) | `examples/configs/qwen3_tts_1_7b_voicedesign.yaml` | Requires `task_type="VoiceDesign"` and non-empty `instructions`. No reference audio is required |
 | [Ming-Omni-TTS](../cookbook/ming_tts.md) | `examples/configs/ming_omni_tts.yaml` | Text-only synthesis or one local reference clip with its transcript; TP1 is supported and the provided config uses TP2 |
 | [MOSS-TTS](../cookbook/moss_tts.md) | `examples/configs/moss_tts.yaml` | Voice cloning via `ref_audio` or `references[0].audio_path` (+ `text`). Duration via `${token:N}` or `token_count`. Benchmark at `--max-concurrency 8` |
+| VoxCPM1.5 | `examples/configs/voxcpm.yaml` | Text-only synthesis or continuation cloning; `ref_text` is optional when `ref_audio` is supplied |
+| VoxCPM2 | `examples/configs/voxcpm2.yaml` | Text-only synthesis, isolated cloning with `ref_audio`, or continuation with `ref_audio` + `ref_text`; outputs 48 kHz audio |
 
 ## Launch the Server
 
@@ -501,7 +503,11 @@ The table below lists all parameters accepted by the `/v1/audio/speech` endpoint
 | `top_p` | float | `null` | Top-p sampling |
 | `top_k` | int | `null` | Top-k sampling |
 | `repetition_penalty` | float | `null` | Repetition penalty |
-| `seed` | int | `null` | Model-specific. Qwen3-TTS Base accepts request-scoped seed, Voxtral TTS currently rejects seed |
+| `seed` | int | `null` | Model-specific. Qwen3-TTS Base and VoxCPM accept request-scoped seeds; Voxtral TTS currently rejects seed |
+| `cfg_value` | float | `null` | VoxCPM classifier-free guidance strength |
+| `inference_timesteps` | int | `null` | VoxCPM diffusion solver steps per generated latent patch |
+| `min_len` | int | `null` | Minimum VoxCPM latent patches before accepting the stop prediction |
+| `streaming_prefix_len` | int | `null` | Number of initial VoxCPM latent chunks buffered before streaming emission |
 
 Invalid speech requests return an OpenAI-style error envelope:
 

--- a/docs/benchmarks/voxcpm2_vllm_comparison.md
+++ b/docs/benchmarks/voxcpm2_vllm_comparison.md
@@ -1,0 +1,785 @@
+# VoxCPM2 Serving Performance Comparison
+
+This document defines a reproducible experiment for comparing
+SGLang-Omni and vLLM-Omni serving `openbmb/VoxCPM2`. It is intended to answer
+three separate questions:
+
+1. Which framework gives better user-visible latency and streaming behavior?
+2. Which framework delivers more useful audio per GPU while meeting an SLO?
+3. Which SGLang-Omni optimizations account for any difference?
+
+The experiment compares the common VoxCPM2 checkpoint only. Do not compare
+SGLang-Omni VoxCPM 1.0 or 1.5 results with vLLM-Omni VoxCPM2 results.
+
+## Rules for a Valid Comparison
+
+Use the same:
+
+- physical GPU, power limit, clocks, CUDA driver, and idle-host policy
+- `openbmb/VoxCPM2` checkpoint revision and local weight files
+- BF16 AR model and FP32-compatible output validation
+- client implementation, request order, dataset revision, and network path
+- reference audio bytes, reference transcript, and target text
+- request-generation parameters and maximum generation budget
+- 48 kHz, mono, PCM16 interpretation for VoxCPM2 output
+- warmup policy, measured sample count, timeout, and retry policy
+- server admission limit and KV-cache capacity for matched-configuration runs
+
+Run one server at a time. Running the two servers concurrently on the same GPU
+does not produce a valid comparison.
+
+Record the full Git state, including uncommitted changes. A commit SHA alone is
+not sufficient when benchmarking a dirty worktree.
+
+## Workloads
+
+Use `zhaochenyang20/seed-tts-eval-arrow` as the primary corpus. Download one
+specific dataset snapshot before the experiment and use that same read-only
+local snapshot for every run; the current benchmark CLI does not forward a
+Hugging Face dataset revision. Do the same for the model checkpoint. Record
+snapshot revisions and file hashes in the manifest. Report English and Chinese
+separately.
+
+The primary workload is continuation voice cloning:
+
+```text
+reference audio + reference transcript + target text
+```
+
+This is the shape used by the Seed-TTS benchmark. Report the following
+secondary workloads separately:
+
+- isolated cloning: reference audio without reference transcript
+- text-only synthesis: no reference audio or transcript
+
+Do not aggregate these modes. Their reference encoding and prompt construction
+costs differ.
+
+Use these sample budgets:
+
+| Purpose | Minimum workload |
+|---|---:|
+| Smoke test | 20 requests |
+| Serial latency | At least 1000 requests per language when reporting p99 |
+| Closed-loop throughput | 500 requests or 5 minutes per point, whichever is longer |
+| Open-loop capacity | 10 minutes per offered-load point |
+| Quality | Full language split; use at least 200 samples for development |
+| Soak | 30 minutes at 80% of the measured sustainable load |
+
+Preserve a fixed sample order for paired comparisons. Also report results by
+target-text length:
+
+- short: fewer than 50 characters
+- medium: 50-200 characters
+- long: more than 200 characters
+
+Add a separate synthetic long-input set at 500, 1000, and 2000 characters.
+Do not mix synthetic long-input results into the Seed-TTS aggregate.
+
+## Fixed Generation Semantics
+
+The matched comparison uses:
+
+| Parameter | Value |
+|---|---:|
+| CFM inference timesteps | 10 |
+| CFG value | 2.0 |
+| CFM temperature/noise scale | 1.0 |
+| Speech speed | 1.0 |
+| Maximum new tokens/decode steps | 2000 |
+| Output sample rate | 48000 Hz |
+| Output channels | 1 |
+| Output sample width | 16 bit |
+
+Do not use `top_p`, `top_k`, or `repetition_penalty` as comparison dimensions
+unless both implementations are first verified to consume them in the VoxCPM2
+generation path.
+
+The implementations do not have identical random-noise and stop semantics.
+Performance runs should not pass a request seed. Quality runs must use three
+independent generations and report their distribution. Always report output
+audio duration so that an implementation is not rewarded for stopping early.
+
+The current neutral benchmark CLI forwards `max_new_tokens` but does not expose
+all VoxCPM2 CFM parameters. vLLM-Omni also does not reliably apply the request
+`max_new_tokens` field in its VoxCPM2 adapter. Before Phase 1, save each
+server's resolved runtime configuration and assert the values in the table
+above. Set generation caps in the server configuration as well as the request.
+If a parameter cannot be set or verified on both sides, label it as an
+implementation difference rather than silently assuming equivalent defaults.
+
+## KV-Cache Capacity and High-Concurrency Admission
+
+### KV bytes per token
+
+VoxCPM2 has a 28-layer base LM and an 8-layer residual LM. With two KV heads,
+head dimension 128, and BF16 cache elements:
+
+```text
+KV bytes/token
+  = 2 (K and V)
+    * 36 cached layers
+    * 2 KV heads
+    * 128 head dimension
+    * 2 bytes
+  = 36,864 bytes
+  = 36 KiB/token
+```
+
+Do not omit the residual LM. Counting only 28 layers underestimates KV memory.
+
+### Request token estimate
+
+VoxCPM2 emits one AR patch for approximately 160 ms of audio:
+
+```text
+generated patch tokens ~= ceil(output audio seconds / 0.16)
+                       ~= ceil(6.25 * output audio seconds)
+```
+
+Reference audio has approximately the same patch rate. Estimate a request as:
+
+```text
+T_request =
+    text tokens
+  + special tokens
+  + reference patch tokens
+  + generated patch tokens
+```
+
+Measure this value from successful requests when token headers are available.
+Otherwise calculate it from the tokenizer and actual reference/output audio
+duration. Store p50, p95, p99, and maximum request lengths.
+
+### Capacity-derived admission
+
+Let:
+
+- `T_KV` be the actual KV token capacity reported after server startup
+- `T_req_p95` be the measured p95 total tokens per request
+- `alpha` be 0.80 for block rounding, fragmentation, and runtime variance
+
+The typical-workload admission estimate is:
+
+```text
+C_typical = floor(alpha * T_KV / T_req_p95)
+```
+
+The full-context safety bound for the matched 4096-token context is:
+
+```text
+C_worst = floor(alpha * T_KV / 4096)
+```
+
+`C_typical` estimates useful benchmark concurrency. `C_worst` is the admission
+limit that remains KV-safe if every request reaches 4096 tokens. Report both;
+do not present the typical estimate as a worst-case guarantee.
+
+For a matched-capacity run, choose a common token capacity first:
+
+```text
+T_common = min(T_KV_sglang, T_KV_vllm)
+vLLM KV bytes = T_common * 36,864
+SGLang max total tokens = T_common
+```
+
+Round the common capacity down to both frameworks' cache-block granularity.
+The actual capacities in startup logs, not nominal GiB labels, must match.
+
+KV capacity is not the only limit. LocDiT, CFM, AudioVAE, activations, request
+state pools, and CUDA Graph allocations are outside or partly outside KV-cache
+accounting. Every admission increase must pass an actual startup and load test.
+
+### H100 80 GB capacity tiers
+
+The following tiers use a 4096-token worst case and include approximately 20%
+headroom. Rounded budgets are useful for capacity planning but are not exact
+matched-capacity settings:
+
+| Maximum concurrency | Raw worst-case KV | Rounded allocation budget |
+|---:|---:|---:|
+| 32 | 4.5 GiB | 6 GiB |
+| 64 | 9 GiB | 12 GiB |
+| 96 | 13.5 GiB | 18 GiB |
+| 128 | 18 GiB | 24 GiB |
+
+Use the following closed-loop sweep:
+
+```text
+1, 2, 4, 8, 16, 32, 48, 64
+```
+
+If concurrency 64 is stable and `C_typical >= 96`, extend to:
+
+```text
+96, 128
+```
+
+Do not capture graphs for 128 immediately. Calibrate in ascending order and
+stop when any of the following occurs:
+
+- startup or CUDA Graph capture OOM
+- request failure rate exceeds 0.1%
+- p95 RTF reaches or exceeds 1.0
+- p95 first-audio latency grows by more than 2x from the preceding point
+- throughput improves by less than 5% across two successive points
+- queue depth grows for the duration of a fixed-load run
+
+Report three limits separately:
+
+- maximum stable concurrency: no OOM, crash, timeout burst, or growing queue
+- throughput saturation point: the first point after which two increases add
+  less than 5% throughput
+- maximum SLO-valid concurrency: the highest point meeting all declared SLOs
+
+Do not collapse these into one "failed concurrency."
+
+## Server Profiles
+
+Run two profiles. Do not combine them into one ranking.
+
+### Production-default profile
+
+Each framework uses its recommended optimizations. This answers which framework
+a user would deploy by default.
+
+Keep model semantics, dataset, generation limit, and output format fixed, but
+allow framework-specific graph, fusion, and batching implementations.
+
+Use the checked-in server configuration without capacity overrides:
+
+```bash
+export MODEL_PATH=/snapshots/openbmb-VoxCPM2/REVISION
+
+# SGLang-Omni production default
+sgl-omni serve \
+  --model-path "$MODEL_PATH" \
+  --config examples/configs/voxcpm2.yaml \
+  --port 8000
+
+# vLLM-Omni production default
+vllm serve "$MODEL_PATH" \
+  --omni \
+  --deploy-config vllm_omni/deploy/voxcpm2.yaml \
+  --port 8000
+```
+
+The checked-in defaults currently admit eight requests. Production-default
+results therefore describe those defaults; high-concurrency results belong to
+the capacity profiles below.
+
+### Matched-capacity profile
+
+Use identical:
+
+- maximum admitted requests
+- effective KV token capacity
+- 4096-token comparison context
+- maximum 2000 generated tokens
+- graph coverage through the tested admission point, or eager mode on both
+
+This profile helps separate scheduler/engine behavior from different memory
+budgets.
+
+## Starting SGLang-Omni
+
+For a 64-request matched tier, use a common capacity of 327680 tokens. This is
+the minimum theoretical capacity for 64 requests of 4096 tokens at `alpha=0.8`:
+
+```bash
+cd /path/to/sglang-omni
+
+sgl-omni serve \
+  --model-path "$MODEL_PATH" \
+  --config examples/configs/voxcpm2.yaml \
+  --max-running-requests 64 \
+  --cuda-graph-max-bs 64 \
+  --max-total-tokens 327680 \
+  --port 8000
+```
+
+`327680` is a matched token cap, not a promise that the runtime can allocate
+that many tokens. The server cannot raise the pool above its profiled capacity.
+Record the startup log's actual `max_total_num_tokens`.
+
+The VoxCPM preprocessing executor currently has a hard-coded concurrency of
+eight. Keep it unchanged for the production-default profile. Before claiming
+engine scaling above eight in the matched-capacity profile, make this limit
+configurable and set it to at least the tested admission limit; otherwise
+report it as an explicit front-end bottleneck. Record preprocessing queue time
+separately from generation-engine queue time.
+
+For 96 and 128, increase `max-running-requests`,
+`cuda-graph-max-bs`, and the token cap only after the preceding tier is stable.
+Use 491520 tokens for the 96 tier and 655360 for the 128 tier, subject to
+profiled capacity.
+
+SGLang-Omni VoxCPM diffusion graphs retain batches up to 8, multiples of 16,
+and the maximum requested batch. Prefer 16/32/48/64/96/128 as high-concurrency
+graph points.
+
+### SGLang optimization environment
+
+Record these variables explicitly:
+
+```bash
+export SGLANG_VOXCPM_ENABLE_VAE_COMPILE=0
+export SGLANG_VOXCPM_ENABLE_ASYNC_DECODE=0
+unset SGLANG_VOXCPM_DISABLE_DIFFUSION_GRAPH
+```
+
+Use the repository defaults for the production-default profile. Change one
+variable at a time for ablation. Async decode should be evaluated only at
+concurrency 16 or greater.
+
+## Starting vLLM-Omni
+
+Copy `vllm_omni/deploy/voxcpm2.yaml` to an experiment-specific file. For the
+64-request matched tier set:
+
+```yaml
+stages:
+  - stage_id: 0
+    max_num_seqs: 64
+    # 327680 tokens * 36864 bytes/token = 12079595520 bytes.
+    kv_cache_memory_bytes: 12079595520
+    max_num_batched_tokens: 4096
+    max_model_len: 4096
+    engine_extras:
+      hf_overrides:
+        voxcpm2_runtime_config:
+          enable_unified_decode_graph: true
+          unified_decode_graph_max_batch_size: 64
+    default_sampling_params:
+      max_tokens: 2000
+```
+
+Preserve the other VoxCPM2 defaults from the source YAML. Start with:
+
+```bash
+cd /path/to/vllm-omni
+
+vllm serve "$MODEL_PATH" \
+  --omni \
+  --deploy-config /path/to/voxcpm2-c64.yaml \
+  --port 8000
+```
+
+Use exactly 18119393280 bytes for 491520 tokens at concurrency 96 and
+24159191040 bytes for 655360 tokens at concurrency 128, then round both
+frameworks down if cache-block granularity requires it. Record the startup
+log's available KV memory/token capacity and graph-capture peak. Do not infer
+capacity from `gpu_memory_utilization` when `kv_cache_memory_bytes` is set.
+
+## Neutral Client
+
+Use one checkout and one version of
+`benchmarks.eval.benchmark_tts_seedtts` to drive both servers. Only the target
+server changes.
+
+Non-streaming comparison:
+
+```bash
+cd /path/to/sglang-omni
+
+export MODEL_PATH=/snapshots/openbmb-VoxCPM2/REVISION
+export DATASET_PATH=/snapshots/seed-tts-eval-arrow/REVISION
+export FRAMEWORK=sglang  # Set to vllm when targeting vLLM-Omni.
+
+python -m benchmarks.eval.benchmark_tts_seedtts \
+  --generate-only \
+  --use-existing-server \
+  --base-url http://127.0.0.1:8000 \
+  --model "$MODEL_PATH" \
+  --meta "$DATASET_PATH" \
+  --lang en \
+  --max-concurrency 64 \
+  --request-rate inf \
+  --warmup 10 \
+  --max-new-tokens 2000 \
+  --output-dir "results/voxcpm2/${FRAMEWORK}/en/nonstream/c64/run-1"
+```
+
+Set `FRAMEWORK` to `sglang` or `vllm`. Repeat with `--lang zh`.
+
+### Streaming compatibility requirement
+
+SGLang-Omni returns raw PCM for `stream=true` and `response_format=pcm`.
+vLLM-Omni requires `stream_format=audio` to select raw PCM instead of SSE.
+The current neutral client does not send `stream_format`, defaults missing PCM
+metadata to 24 kHz, and therefore is not yet valid for this cross-framework
+streaming comparison. Before publishing streaming results:
+
+1. add a target-independent `stream_format` client option
+2. make vLLM-Omni return `X-Sample-Rate`, `X-Channels`, and `X-Bit-Depth`
+3. change the neutral client to reject missing PCM metadata instead of falling
+   back to 24 kHz
+4. add per-stream playback-buffer/underrun calculation
+
+Send:
+
+```json
+{
+  "stream": true,
+  "stream_format": "audio",
+  "response_format": "pcm"
+}
+```
+
+Both targets must return `audio/pcm` and metadata corresponding to 48 kHz,
+mono, PCM16. The client must reject absent or inconsistent format metadata.
+
+Do not compare SGLang raw PCM TTFA against vLLM SSE TTFA. Do not use a 24 kHz
+fallback for VoxCPM2. If the vLLM benchmark client is used for an independent
+cross-check, set:
+
+```bash
+export VLLM_OMNI_BENCH_AUDIO_SAMPLE_RATE=48000
+```
+
+## Experiment Matrix
+
+### Phase 0: correctness and instrumentation
+
+Run 20 requests per language and framework.
+
+Verify:
+
+- all responses decode to non-empty 48 kHz mono PCM/WAV
+- the same dataset rows and reference bytes were sent
+- generation parameters were accepted and applied
+- actual prompt/completion lengths are recorded
+- output duration differs by no more than an explainable model variance
+- streaming chunk boundaries are preserved by the client
+- GPU telemetry and server logs cover the measured interval
+
+No performance claim is valid until this phase passes.
+
+### Phase 1: serial latency
+
+Use concurrency 1, at least 1000 requests per language when reporting p99, and
+six fresh server starts.
+Report:
+
+- end-to-end latency p50/p95/p99
+- streaming TTFA p50/p95/p99
+- RTF p50/p95/p99
+- output duration distribution
+- prompt and completion token distributions
+- reference preprocessing time if exposed
+
+### Phase 2: closed-loop concurrency
+
+For every framework and language, run:
+
+```text
+1, 2, 4, 8, 16, 32, 48, 64
+```
+
+Extend to 96 and 128 using the capacity criteria above. Use at least 500
+requests or five minutes at each point. The request source should always have
+enough work to keep the concurrency window full.
+
+The current Seed-TTS runner consumes its sample list once. For a duration-based
+run, materialize a deterministic repetition of the pinned sample-ID sequence
+before dispatch so the measured interval reaches five minutes. Do not restart
+the client repeatedly and then pool only the successful invocations.
+
+Primary outputs:
+
+- generated audio seconds per wall-clock second
+- successful requests per second
+- TTFA p95/p99
+- RTF p95/p99
+- end-to-end latency p95/p99
+- failure and timeout rate
+- average output audio duration
+- peak resident GPU memory
+
+Plot throughput and tail latency against concurrency on the same x-axis.
+
+### Phase 3: open-loop capacity
+
+Closed-loop testing measures maximum work conservation but hides queueing.
+Use Poisson arrivals to find sustainable offered load.
+
+The current Seed-TTS `BenchmarkRunner` is not a valid open-loop load generator:
+requests blocked by its client semaphore wait outside the measured latency, and
+it has no fixed-duration arrival loop. Do not use its `--request-rate` result
+for a sustainable-capacity claim.
+
+Before this phase, provide a neutral fixed-duration generator that:
+
+- schedules arrivals independently of request completion
+- records planned arrival, task creation, socket-send, first audio, and finish
+- includes client-side queue wait in end-to-end latency
+- reports load-generator lag and saturation
+- runs for a fixed duration and stops scheduling at the deadline
+- records server queue depth and running requests
+- uses the same Seed-TTS sample cycle for both frameworks
+
+First run a geometric sweep:
+
+```text
+0.5, 1, 2, 4, 8, 16 requests/s
+```
+
+After locating the knee, test intermediate points around it. Keep each point
+for ten minutes. Use an admission cap at or above the stable closed-loop
+concurrency.
+
+A point is sustainable only if:
+
+- success rate is at least 99.9%
+- queue depth does not grow throughout the run
+- p95 RTF is below 0.8
+- p95 TTFA is at most 500 ms and p99 TTFA is at most 1 s
+- at least 99% of streams meet the continuity threshold
+
+Report the maximum offered RPS satisfying all criteria, not merely the highest
+RPS that returns some successful responses.
+
+### Phase 4: streaming continuity
+
+For each successful stream collect:
+
+- first-audio latency
+- first audio payload bytes and playable duration
+- chunk count
+- inter-chunk p50/p95/p99
+- maximum playback-buffer underrun
+- continuity success using a 100 ms underrun threshold
+
+Calculate inter-chunk and underrun statistics per stream first, then aggregate
+the per-stream values. Pooling every chunk interval gives longer streams
+disproportionate weight.
+
+TTFA is not meaningful without first-payload size. A framework can report an
+artificially low TTFA by flushing a tiny, non-useful first chunk.
+
+### Phase 5: quality
+
+Generate the complete EN and ZH splits at concurrency 1. Generate three
+independent runs into their final quality directories:
+
+```bash
+for run in 1 2 3; do
+  python -m benchmarks.eval.benchmark_tts_seedtts \
+    --generate-only \
+    --use-existing-server \
+    --base-url http://127.0.0.1:8000 \
+    --model "$MODEL_PATH" \
+    --meta "$DATASET_PATH" \
+    --lang en \
+    --max-concurrency 1 \
+    --request-rate inf \
+    --warmup 10 \
+    --max-new-tokens 2000 \
+    --output-dir "results/voxcpm2/${FRAMEWORK}/en/quality/run-${run}"
+done
+```
+
+Repeat for Chinese. Run quality evaluation after stopping the TTS server so
+that ASR and similarity models do not contaminate serving measurements. Run
+each evaluator against each generated directory:
+
+```bash
+for run in 1 2 3; do
+  output_dir="results/voxcpm2/${FRAMEWORK}/en/quality/run-${run}"
+
+  python -m benchmarks.eval.benchmark_tts_seedtts \
+    --transcribe-only \
+    --model "$MODEL_PATH" \
+    --meta "$DATASET_PATH" \
+    --lang en \
+    --output-dir "$output_dir"
+
+  python -m benchmarks.eval.benchmark_tts_seedtts \
+    --similarity-only \
+    --model "$MODEL_PATH" \
+    --meta "$DATASET_PATH" \
+    --lang en \
+    --output-dir "$output_dir"
+
+  python -m benchmarks.eval.benchmark_tts_seedtts \
+    --utmos-only \
+    --model "$MODEL_PATH" \
+    --meta "$DATASET_PATH" \
+    --lang en \
+    --output-dir "$output_dir"
+done
+```
+
+Report WER/CER, speaker similarity, UTMOS, output duration, empty/truncated
+audio rate, and repeated-audio rate. Pre-register quality non-inferiority
+bounds before viewing performance results. Suggested development bounds are:
+
+- WER/CER: no more than 1 absolute percentage point worse
+- speaker similarity: no more than 0.01 lower
+- UTMOS: no more than 0.10 lower
+- empty/truncated audio: no increase above 0.1%
+
+For a publication or release gate, replace these suggested bounds with values
+validated by listening tests and the target product.
+
+### Phase 6: SGLang-Omni ablation
+
+Run ablations at concurrency 1, 32, 64, and the highest stable point:
+
+| Dimension | Values |
+|---|---|
+| Diffusion CUDA Graph | on, off |
+| VAE Snake compile | on, off |
+| Async decode | on, off at concurrency >=16 |
+| Streaming prefix length | 1, 2, 3, 4 |
+
+Change one dimension at a time. Then test the best combined configuration.
+
+Evaluate the quality/performance Pareto frontier separately:
+
+```text
+inference_timesteps = 4, 6, 8, 10, 12
+```
+
+Changing `inference_timesteps` can switch SGLang-Omni from a captured graph to
+the eager CFM path. Label the execution path in every result.
+
+## Resource Telemetry
+
+Collect at one-second intervals:
+
+- GPU utilization
+- memory used
+- SM and memory-clock frequency
+- power draw and enforced power limit
+- temperature and throttling reason
+- host CPU utilization and RSS
+- server queue/running request count, when available
+
+Example GPU capture:
+
+```bash
+nvidia-smi \
+  --query-gpu=timestamp,index,utilization.gpu,utilization.memory,memory.used,power.draw,power.limit,clocks.sm,clocks.mem,temperature.gpu,clocks_event_reasons.active \
+  --format=csv \
+  --loop=1 \
+  > results/gpu-telemetry.csv
+```
+
+Start telemetry before server startup and stop it after the measured run.
+Mark warmup and measurement timestamps in the manifest.
+
+Capture host and process telemetry separately, for example with
+`pidstat -durh 1 -p <server-pid>`. Export queue/running-request metrics from
+the server when available. If a driver does not expose
+`clocks_event_reasons.active`, record the supported `nvidia-smi --query-gpu`
+fields and use `nvidia-smi dmon` for throttling diagnostics.
+
+## Repetition and Run Order
+
+Use six fresh server starts per point. Randomize a balanced order within each
+pair to reduce thermal, cache, and host-state bias:
+
+```text
+pair 1: SGLang -> vLLM
+pair 2: vLLM -> SGLang
+pair 3: randomized, then run the reverse order
+```
+
+Warm up with at least ten requests and do not include graph capture, compile,
+or first model execution in measured results. Cold-start and first-request
+latency are separate experiments.
+
+For aggregate reporting:
+
+- preserve every per-request record
+- calculate percentiles independently for each repeat
+- report the median of the six repeat-level values
+- include the range and a bootstrap 95% confidence interval
+- use paired sample IDs when comparing quality and output duration
+
+Do not pool all repeats before computing p99; pooling hides run-to-run
+instability.
+
+Use a hierarchical bootstrap: resample server starts as clusters, then resample
+paired request IDs within each selected start. A six-start interval is still
+descriptive rather than definitive; preserve the repeat-level range and do not
+claim tiny differences as significant.
+
+## Required Artifacts
+
+Every run directory must contain:
+
+```text
+manifest.json
+speed_results.json
+generated_audio_metadata.json
+per-request records
+server.log
+client.log
+gpu-telemetry.csv
+environment.txt
+git-state/
+```
+
+The manifest must record:
+
+- framework and repository URL
+- commit SHA, `git status`, and patch hash
+- model ID, revision, and weight-file hashes
+- dataset ID, revision, split, sample IDs, and ordering seed
+- GPU name/UUID, driver, CUDA, PyTorch, and SGLang/vLLM versions
+- server command and effective resolved configuration
+- actual KV token capacity and KV byte budget
+- graph buckets/capture status
+- warmup and measured time range
+- all request-generation parameters
+- client commit and command
+
+The current benchmark command does not create this complete artifact set.
+Use an orchestration script to start telemetry, capture server/client logs,
+write the manifest and Git state, invoke the benchmark, and terminate all
+processes. Until such a script exists, treat this section as a mandatory manual
+checklist and reject incomplete runs.
+
+## Reporting
+
+The primary comparison table should contain:
+
+| Framework | Profile | Concurrency | Audio s/s | Req/s | TTFA p95 | TTFA p99 | RTF p95 | E2E p95 | Success |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
+
+Add:
+
+1. throughput and TTFA versus concurrency
+2. throughput and RTF versus concurrency
+3. sustainable RPS under the declared SLO
+4. GPU memory and power versus concurrency
+5. WER/CER, similarity, and UTMOS quality table
+6. SGLang-Omni optimization ablation table
+
+The headline system-efficiency metric is generated audio seconds per GPU
+second while satisfying the latency, continuity, success-rate, and quality
+guardrails. Requests per second is secondary because output duration varies.
+
+Before starting the experiment, save the chosen SLO and quality bounds in the
+manifest. The defaults in this document are p95 TTFA <=500 ms, p99 TTFA <=1 s,
+p95 RTF <0.8, continuity success >=99%, and request success >=99.9%.
+
+## Invalid Comparisons
+
+Do not publish a comparison when any of the following is true:
+
+- different checkpoint or dataset revisions
+- different request clients or request order
+- one side uses 24 kHz to interpret VoxCPM2 PCM
+- one side receives SSE while the other receives raw PCM
+- different maximum generation budgets or admission limits in the matched run
+- quality or output duration is omitted from a throughput claim
+- one result includes warmup/graph capture and the other does not
+- the load generator saturates before the server
+- p95/p99 is calculated from a 20-request smoke test
+- the SGLang-Omni result omits uncommitted optimization changes
+
+Treat existing repository baselines as framework-internal regression references,
+not as cross-framework comparison results.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,6 +101,7 @@ Supported Models
    :caption: Benchmarks
 
    benchmarks/relay.md
+   benchmarks/voxcpm2_vllm_comparison.md
 
 
 .. toctree::

--- a/examples/configs/voxcpm.yaml
+++ b/examples/configs/voxcpm.yaml
@@ -1,0 +1,2 @@
+config_cls: VoxCPMPipelineConfig
+model_path: OpenBMB/VoxCPM1.5

--- a/examples/configs/voxcpm1.yaml
+++ b/examples/configs/voxcpm1.yaml
@@ -1,0 +1,2 @@
+config_cls: VoxCPMPipelineConfig
+model_path: openbmb/VoxCPM-0.5B

--- a/examples/configs/voxcpm2.yaml
+++ b/examples/configs/voxcpm2.yaml
@@ -1,0 +1,2 @@
+config_cls: VoxCPM2PipelineConfig
+model_path: openbmb/VoxCPM2

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -39,6 +39,8 @@ _ARCH_CONFIG_MAP: dict[str, tuple[str, str | None]] = {
     "MossTTSDelaySGLangModel": ("language_config", None),
     "MossTTSLocalSGLangModel": ("language_config", None),
     "MossTranscribeDiarizeForConditionalGeneration": ("text_config", None),
+    "VoxCPMSGLangModel": ("lm_config", None),
+    "VoxCPM2SGLangModel": ("lm_config", None),
 }
 
 
@@ -86,6 +88,15 @@ class ModelWorker:
             )
 
             register_ming_tts_hf_config()
+        if self.model_arch_override in {
+            "VoxCPMSGLangModel",
+            "VoxCPM2SGLangModel",
+        }:
+            from sglang_omni.models.voxcpm_common.hf_config import (
+                register_voxcpm_configs,
+            )
+
+            register_voxcpm_configs()
 
         from sglang.srt.configs.model_config import ModelConfig
 
@@ -124,12 +135,44 @@ class ModelWorker:
         if sub_cfg is None:
             return
         text_cfg = getattr(sub_cfg, text_config_attr) if text_config_attr else sub_cfg
-        model_config.hf_text_config = text_cfg
-        model_config.num_attention_heads = text_cfg.num_attention_heads
-        model_config.num_key_value_heads = text_cfg.num_key_value_heads
-        model_config.hidden_size = text_cfg.hidden_size
-        model_config.num_hidden_layers = text_cfg.num_hidden_layers
-        if arch == "MingTTSSGLangModel":
+        value = (
+            (lambda name: text_cfg[name])
+            if isinstance(text_cfg, dict)
+            else (lambda name: getattr(text_cfg, name))
+        )
+        if isinstance(text_cfg, dict):
+            from types import SimpleNamespace
+
+            model_config.hf_text_config = SimpleNamespace(**text_cfg)
+        else:
+            model_config.hf_text_config = text_cfg
+        model_config.num_attention_heads = value("num_attention_heads")
+        model_config.num_key_value_heads = value("num_key_value_heads")
+        model_config.hidden_size = value("hidden_size")
+        model_config.num_hidden_layers = value("num_hidden_layers")
+        if arch in {
+            "VoxCPMSGLangModel",
+            "VoxCPM2SGLangModel",
+        }:
+            kv_channels = (
+                text_cfg.get("kv_channels")
+                if isinstance(text_cfg, dict)
+                else getattr(text_cfg, "kv_channels", None)
+            )
+            model_config.head_dim = int(
+                kv_channels
+                or int(value("hidden_size")) // int(value("num_attention_heads"))
+            )
+            model_config.v_head_dim = model_config.head_dim
+            model_config.vocab_size = int(value("vocab_size"))
+            model_config.context_len = int(value("max_position_embeddings"))
+            residual_layers = int(
+                getattr(model_config.hf_config, "residual_lm_num_layers", 0)
+            )
+            model_config.num_attention_layers = (
+                int(value("num_hidden_layers")) + residual_layers
+            )
+        elif arch == "MingTTSSGLangModel":
             model_config.head_dim = int(text_cfg.head_dim)
             model_config.v_head_dim = model_config.head_dim
             model_config.vocab_size = int(text_cfg.vocab_size)

--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -92,6 +92,8 @@ class SGLModelRunner(ModelRunner):
             "MossTTSLocalSGLangModel": "sglang_omni.models.moss_tts_local.sglang_model:MossTTSLocalSGLangModel",
             "MossTranscribeDiarizeForConditionalGeneration": "sglang_omni.models.moss_transcribe_diarize.sglang_model:MossTranscribeDiarizeForConditionalGeneration",
             "VoxtralSGLangTTSModel": "sglang_omni.models.voxtral_tts.sglang_model:VoxtralSGLangTTSModel",
+            "VoxCPMSGLangModel": "sglang_omni.models.voxcpm.sglang_model:VoxCPMSGLangModel",
+            "VoxCPM2SGLangModel": "sglang_omni.models.voxcpm2.sglang_model:VoxCPM2SGLangModel",
             "LLaDA2MoeModelLM": "sglang_omni.models.llada2_uni.components.thinker:LLaDA2MoeModelLM",
             "WhisperForConditionalGeneration": "sglang_omni.models.whisper_asr.sglang_model:WhisperForConditionalGeneration",
             "Qwen3ASRForConditionalGeneration": "sglang_omni.models.qwen3_asr.sglang_model:Qwen3ASRForConditionalGeneration",

--- a/sglang_omni/models/voxcpm/__init__.py
+++ b/sglang_omni/models/voxcpm/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+"""VoxCPM1.5 support."""
+
+from sglang_omni.models.model_capabilities import ModelCapabilities
+
+CAPABILITIES = ModelCapabilities(
+    supports_reference_audio=True,
+    supports_batch_vocoder=True,
+    supports_streaming_vocoder=True,
+    supports_cuda_graph=False,
+    supports_torch_compile=False,
+)
+
+__all__ = ["CAPABILITIES"]

--- a/sglang_omni/models/voxcpm/__init__.py
+++ b/sglang_omni/models/voxcpm/__init__.py
@@ -7,8 +7,8 @@ CAPABILITIES = ModelCapabilities(
     supports_reference_audio=True,
     supports_batch_vocoder=True,
     supports_streaming_vocoder=True,
-    supports_cuda_graph=False,
-    supports_torch_compile=False,
+    supports_cuda_graph=True,
+    supports_torch_compile=True,
 )
 
 __all__ = ["CAPABILITIES"]

--- a/sglang_omni/models/voxcpm/config.py
+++ b/sglang_omni/models/voxcpm/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Pipeline configuration for OpenBMB VoxCPM1.5."""
+"""Pipeline configuration for OpenBMB VoxCPM 1.x."""
 
 from __future__ import annotations
 
@@ -36,7 +36,9 @@ class VoxCPMPipelineConfig(PipelineConfig):
     architecture: ClassVar[str] = "voxcpm"
     architecture_aliases: ClassVar[tuple[str, ...]] = (
         "VoxCPM",
+        "VoxCPM1",
         "VoxCPMForConditionalGeneration",
+        "VoxCPM1ForConditionalGeneration",
     )
     requires_model_capabilities: ClassVar[bool] = True
 

--- a/sglang_omni/models/voxcpm/config.py
+++ b/sglang_omni/models/voxcpm/config.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pipeline configuration for OpenBMB VoxCPM1.5."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pydantic import Field
+
+from sglang_omni.config import PipelineConfig, StageConfig
+
+_PKG = "sglang_omni.models.voxcpm_common"
+
+
+def _stages() -> list[StageConfig]:
+    return [
+        StageConfig(
+            name="preprocessing",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_voxcpm_preprocessing_executor",
+            factory_args={"variant": "voxcpm"},
+            next="tts_engine",
+        ),
+        StageConfig(
+            name="tts_engine",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_voxcpm_tts_engine_executor",
+            factory_args={"variant": "voxcpm"},
+            gpu=0,
+            terminal=True,
+        ),
+    ]
+
+
+class VoxCPMPipelineConfig(PipelineConfig):
+    architecture: ClassVar[str] = "voxcpm"
+    architecture_aliases: ClassVar[tuple[str, ...]] = (
+        "VoxCPM",
+        "VoxCPMForConditionalGeneration",
+    )
+    requires_model_capabilities: ClassVar[bool] = True
+
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"talker": "tts_engine"}
+
+    @classmethod
+    def talker_sglang_role_to_stage(cls) -> dict[str, str]:
+        return {"talker": "tts_engine"}
+
+    @classmethod
+    def generation_sglang_role_to_stage(cls) -> dict[str, str]:
+        return {"generation": "tts_engine"}
+
+    model_path: str
+    stages: list[StageConfig] = Field(default_factory=_stages)
+
+    def supports_uploaded_voice_references(self) -> bool:
+        return True
+
+
+EntryClass = VoxCPMPipelineConfig

--- a/sglang_omni/models/voxcpm/sglang_model.py
+++ b/sglang_omni/models/voxcpm/sglang_model.py
@@ -122,6 +122,21 @@ class VoxCPMSGLangModel(nn.Module):
     ) -> dict[str, torch.Tensor]:
         return self.model.generate_batch(hidden_states, rows, **kwargs)
 
+    def init_diffusion_graphs(self, batch_sizes: list[int]) -> None:
+        self.model.init_diffusion_graphs(batch_sizes)
+
+    @property
+    def diffusion_graph_max_bs(self) -> int:
+        return self.model.diffusion_graph_max_bs
+
+    def generate_batch_graphed(
+        self,
+        hidden_states: torch.Tensor,
+        rows: torch.Tensor,
+        **kwargs: Any,
+    ) -> dict[str, torch.Tensor]:
+        return self.model.generate_batch_graphed(hidden_states, rows, **kwargs)
+
     def attach_vae(self, vae: nn.Module) -> None:
         self.model.attach_vae(vae)
 

--- a/sglang_omni/models/voxcpm/sglang_model.py
+++ b/sglang_omni/models/voxcpm/sglang_model.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SGLang-native VoxCPM (V1) synthesis model."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+from torch import nn
+
+from sglang_omni.models.voxcpm_common import (
+    VoxCPMCore,
+    load_audiovae_checkpoint,
+    load_audiovae_from_model_path,
+    load_voxcpm_weights,
+)
+
+try:
+    from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+    from sglang_omni.vendor.sglang.core import ForwardBatch
+except ModuleNotFoundError as error:
+    if error.name != "sglang":
+        raise
+    ForwardBatch = Any  # type: ignore[misc,assignment]
+
+    class LogitsProcessorOutput:  # type: ignore[no-redef]
+        def __init__(
+            self, *, next_token_logits: torch.Tensor, hidden_states: torch.Tensor
+        ) -> None:
+            self.next_token_logits = next_token_logits
+            self.hidden_states = hidden_states
+
+
+def _max_requests(default: int = 1) -> int:
+    try:
+        from sglang.srt.server_args import get_global_server_args
+
+        return int(get_global_server_args().max_running_requests)
+    except Exception:
+        return default
+
+
+class VoxCPMSGLangModel(nn.Module):
+    """V1 model with radix-cached base and residual MiniCPM4 LMs."""
+
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    def __init__(
+        self,
+        config: Any,
+        quant_config: Any = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        timesteps = int(getattr(config, "inference_timesteps", 10))
+        self.model = VoxCPMCore(
+            config,
+            version="v1",
+            inference_timesteps=timesteps,
+            max_requests=_max_requests(),
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+        self.config = config
+        self._load_runtime_audiovae_if_available()
+
+    def get_input_embeddings(self) -> nn.Module:
+        return self.model.base_lm.embed_tokens
+
+    def acquire(self, rid: str) -> int:
+        return self.model.acquire(rid)
+
+    acquire_row = acquire
+
+    def reset(self, rid: str) -> None:
+        self.model.reset(rid)
+
+    reset_request = reset
+    release_row = reset
+
+    def row_for(self, rid: str) -> int | None:
+        return self.model.row_for(rid)
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor | None = None,
+        *,
+        feat: torch.Tensor | None = None,
+        feat_mask: torch.Tensor | None = None,
+        row_ids: torch.Tensor | None = None,
+        **_: Any,
+    ) -> LogitsProcessorOutput:
+        hidden_states = self.model.forward_backbone(
+            input_ids,
+            positions,
+            forward_batch,
+            input_embeds=input_embeds,
+            feat=feat,
+            feat_mask=feat_mask,
+            row_ids=row_ids,
+        )
+        return LogitsProcessorOutput(
+            next_token_logits=hidden_states.new_empty((hidden_states.shape[0], 1)),
+            hidden_states=hidden_states,
+        )
+
+    @torch.no_grad()
+    def generate_batch(
+        self,
+        hidden_states: torch.Tensor,
+        rows: torch.Tensor,
+        **kwargs: Any,
+    ) -> dict[str, torch.Tensor]:
+        return self.model.generate_batch(hidden_states, rows, **kwargs)
+
+    def attach_vae(self, vae: nn.Module) -> None:
+        self.model.attach_vae(vae)
+
+    def _load_runtime_audiovae_if_available(self) -> None:
+        try:
+            from sglang.srt.server_args import get_global_server_args
+
+            model_path = get_global_server_args().model_path
+        except Exception:
+            return
+        if model_path and os.path.isfile(os.path.join(model_path, "audiovae.pth")):
+            self.load_audiovae(model_path)
+
+    def load_audiovae(
+        self,
+        vae_or_model_path: nn.Module | str,
+        model_path: str | None = None,
+        *,
+        strict: bool = True,
+    ) -> nn.Module:
+        if isinstance(vae_or_model_path, nn.Module):
+            if model_path is None:
+                raise ValueError("model_path is required when passing a VAE instance")
+            vae = load_audiovae_checkpoint(vae_or_model_path, model_path, strict=strict)
+        else:
+            if model_path is not None:
+                raise ValueError("pass either a model path or (vae, model_path)")
+            vae = load_audiovae_from_model_path(
+                self.config,
+                vae_or_model_path,
+                version="v1",
+                strict=strict,
+            )
+        device = next(self.model.parameters()).device
+        vae.to(device=device, dtype=torch.float32)
+        self.attach_vae(vae)
+        return vae
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        return load_voxcpm_weights(self, weights)
+
+
+EntryClass = VoxCPMSGLangModel

--- a/sglang_omni/models/voxcpm2/__init__.py
+++ b/sglang_omni/models/voxcpm2/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+"""VoxCPM2 support."""
+
+from sglang_omni.models.model_capabilities import ModelCapabilities
+
+CAPABILITIES = ModelCapabilities(
+    supports_reference_audio=True,
+    supports_batch_vocoder=True,
+    supports_streaming_vocoder=True,
+    supports_cuda_graph=False,
+    supports_torch_compile=False,
+)
+
+__all__ = ["CAPABILITIES"]

--- a/sglang_omni/models/voxcpm2/__init__.py
+++ b/sglang_omni/models/voxcpm2/__init__.py
@@ -7,8 +7,8 @@ CAPABILITIES = ModelCapabilities(
     supports_reference_audio=True,
     supports_batch_vocoder=True,
     supports_streaming_vocoder=True,
-    supports_cuda_graph=False,
-    supports_torch_compile=False,
+    supports_cuda_graph=True,
+    supports_torch_compile=True,
 )
 
 __all__ = ["CAPABILITIES"]

--- a/sglang_omni/models/voxcpm2/config.py
+++ b/sglang_omni/models/voxcpm2/config.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pipeline configuration for OpenBMB VoxCPM2."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pydantic import Field
+
+from sglang_omni.config import PipelineConfig, StageConfig
+
+_PKG = "sglang_omni.models.voxcpm_common"
+
+
+def _stages() -> list[StageConfig]:
+    return [
+        StageConfig(
+            name="preprocessing",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_voxcpm_preprocessing_executor",
+            factory_args={"variant": "voxcpm2"},
+            next="tts_engine",
+        ),
+        StageConfig(
+            name="tts_engine",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_voxcpm_tts_engine_executor",
+            factory_args={"variant": "voxcpm2"},
+            gpu=0,
+            terminal=True,
+        ),
+    ]
+
+
+class VoxCPM2PipelineConfig(PipelineConfig):
+    architecture: ClassVar[str] = "voxcpm2"
+    architecture_aliases: ClassVar[tuple[str, ...]] = (
+        "VoxCPM2",
+        "VoxCPM2ForConditionalGeneration",
+        "VoxCPM2TalkerForConditionalGeneration",
+    )
+    requires_model_capabilities: ClassVar[bool] = True
+
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"talker": "tts_engine"}
+
+    @classmethod
+    def talker_sglang_role_to_stage(cls) -> dict[str, str]:
+        return {"talker": "tts_engine"}
+
+    @classmethod
+    def generation_sglang_role_to_stage(cls) -> dict[str, str]:
+        return {"generation": "tts_engine"}
+
+    model_path: str
+    stages: list[StageConfig] = Field(default_factory=_stages)
+
+    def supports_uploaded_voice_references(self) -> bool:
+        return True
+
+
+EntryClass = VoxCPM2PipelineConfig

--- a/sglang_omni/models/voxcpm2/sglang_model.py
+++ b/sglang_omni/models/voxcpm2/sglang_model.py
@@ -122,6 +122,21 @@ class VoxCPM2SGLangModel(nn.Module):
     ) -> dict[str, torch.Tensor]:
         return self.model.generate_batch(hidden_states, rows, **kwargs)
 
+    def init_diffusion_graphs(self, batch_sizes: list[int]) -> None:
+        self.model.init_diffusion_graphs(batch_sizes)
+
+    @property
+    def diffusion_graph_max_bs(self) -> int:
+        return self.model.diffusion_graph_max_bs
+
+    def generate_batch_graphed(
+        self,
+        hidden_states: torch.Tensor,
+        rows: torch.Tensor,
+        **kwargs: Any,
+    ) -> dict[str, torch.Tensor]:
+        return self.model.generate_batch_graphed(hidden_states, rows, **kwargs)
+
     def attach_vae(self, vae: nn.Module) -> None:
         self.model.attach_vae(vae)
 

--- a/sglang_omni/models/voxcpm2/sglang_model.py
+++ b/sglang_omni/models/voxcpm2/sglang_model.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SGLang-native VoxCPM2 synthesis model."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+from torch import nn
+
+from sglang_omni.models.voxcpm_common import (
+    VoxCPMCore,
+    load_audiovae_checkpoint,
+    load_audiovae_from_model_path,
+    load_voxcpm_weights,
+)
+
+try:
+    from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+    from sglang_omni.vendor.sglang.core import ForwardBatch
+except ModuleNotFoundError as error:
+    if error.name != "sglang":
+        raise
+    ForwardBatch = Any  # type: ignore[misc,assignment]
+
+    class LogitsProcessorOutput:  # type: ignore[no-redef]
+        def __init__(
+            self, *, next_token_logits: torch.Tensor, hidden_states: torch.Tensor
+        ) -> None:
+            self.next_token_logits = next_token_logits
+            self.hidden_states = hidden_states
+
+
+def _max_requests(default: int = 1) -> int:
+    try:
+        from sglang.srt.server_args import get_global_server_args
+
+        return int(get_global_server_args().max_running_requests)
+    except Exception:
+        return default
+
+
+class VoxCPM2SGLangModel(nn.Module):
+    """V2 model, including residual-LM no-RoPE and two-token DiT conditioning."""
+
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    def __init__(
+        self,
+        config: Any,
+        quant_config: Any = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        timesteps = int(getattr(config, "inference_timesteps", 10))
+        self.model = VoxCPMCore(
+            config,
+            version="v2",
+            inference_timesteps=timesteps,
+            max_requests=_max_requests(),
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+        self.config = config
+        self._load_runtime_audiovae_if_available()
+
+    def get_input_embeddings(self) -> nn.Module:
+        return self.model.base_lm.embed_tokens
+
+    def acquire(self, rid: str) -> int:
+        return self.model.acquire(rid)
+
+    acquire_row = acquire
+
+    def reset(self, rid: str) -> None:
+        self.model.reset(rid)
+
+    reset_request = reset
+    release_row = reset
+
+    def row_for(self, rid: str) -> int | None:
+        return self.model.row_for(rid)
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor | None = None,
+        *,
+        feat: torch.Tensor | None = None,
+        feat_mask: torch.Tensor | None = None,
+        row_ids: torch.Tensor | None = None,
+        **_: Any,
+    ) -> LogitsProcessorOutput:
+        hidden_states = self.model.forward_backbone(
+            input_ids,
+            positions,
+            forward_batch,
+            input_embeds=input_embeds,
+            feat=feat,
+            feat_mask=feat_mask,
+            row_ids=row_ids,
+        )
+        return LogitsProcessorOutput(
+            next_token_logits=hidden_states.new_empty((hidden_states.shape[0], 1)),
+            hidden_states=hidden_states,
+        )
+
+    @torch.no_grad()
+    def generate_batch(
+        self,
+        hidden_states: torch.Tensor,
+        rows: torch.Tensor,
+        **kwargs: Any,
+    ) -> dict[str, torch.Tensor]:
+        return self.model.generate_batch(hidden_states, rows, **kwargs)
+
+    def attach_vae(self, vae: nn.Module) -> None:
+        self.model.attach_vae(vae)
+
+    def _load_runtime_audiovae_if_available(self) -> None:
+        try:
+            from sglang.srt.server_args import get_global_server_args
+
+            model_path = get_global_server_args().model_path
+        except Exception:
+            return
+        if model_path and os.path.isfile(os.path.join(model_path, "audiovae.pth")):
+            self.load_audiovae(model_path)
+
+    def load_audiovae(
+        self,
+        vae_or_model_path: nn.Module | str,
+        model_path: str | None = None,
+        *,
+        strict: bool = True,
+    ) -> nn.Module:
+        if isinstance(vae_or_model_path, nn.Module):
+            if model_path is None:
+                raise ValueError("model_path is required when passing a VAE instance")
+            vae = load_audiovae_checkpoint(vae_or_model_path, model_path, strict=strict)
+        else:
+            if model_path is not None:
+                raise ValueError("pass either a model path or (vae, model_path)")
+            vae = load_audiovae_from_model_path(
+                self.config,
+                vae_or_model_path,
+                version="v2",
+                strict=strict,
+            )
+        device = next(self.model.parameters()).device
+        vae.to(device=device, dtype=torch.float32)
+        self.attach_vae(vae)
+        return vae
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        return load_voxcpm_weights(self, weights)
+
+
+EntryClass = VoxCPM2SGLangModel

--- a/sglang_omni/models/voxcpm_common/__init__.py
+++ b/sglang_omni/models/voxcpm_common/__init__.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared VoxCPM runtime and model primitives."""
+
+from sglang_omni.models.voxcpm_common.audio_vae import (
+    AudioVAE,
+    AudioVAEV2,
+    create_audio_vae,
+)
+from sglang_omni.models.voxcpm_common.core import (
+    MiniCPMLongRoPE,
+    ScalarQuantizationLayer,
+    UnifiedCFM,
+    VoxCPMCore,
+    VoxCPMLocDiT,
+    VoxCPMLocEnc,
+)
+from sglang_omni.models.voxcpm_common.state_pool import VoxCPMRequestStatePool
+from sglang_omni.models.voxcpm_common.weights import (
+    load_audiovae_checkpoint,
+    load_audiovae_from_model_path,
+    load_voxcpm_weights,
+)
+
+__all__ = [
+    "AudioVAE",
+    "AudioVAEV2",
+    "MiniCPMLongRoPE",
+    "ScalarQuantizationLayer",
+    "UnifiedCFM",
+    "VoxCPMCore",
+    "VoxCPMLocDiT",
+    "VoxCPMLocEnc",
+    "VoxCPMRequestStatePool",
+    "create_audio_vae",
+    "load_audiovae_checkpoint",
+    "load_audiovae_from_model_path",
+    "load_voxcpm_weights",
+]

--- a/sglang_omni/models/voxcpm_common/audio_vae.py
+++ b/sglang_omni/models/voxcpm_common/audio_vae.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import math
+import os
 from typing import Any
 
 import torch
@@ -67,12 +68,25 @@ def _snake(x: torch.Tensor, alpha: torch.Tensor) -> torch.Tensor:
     return x.reshape(shape)
 
 
+_compiled_snake = (
+    torch.compile(
+        _snake,
+        dynamic=True,
+        mode="max-autotune-no-cudagraphs",
+    )
+    if os.environ.get("SGLANG_VOXCPM_ENABLE_VAE_COMPILE") == "1"
+    else None
+)
+
+
 class Snake1d(nn.Module):
     def __init__(self, channels: int) -> None:
         super().__init__()
         self.alpha = nn.Parameter(torch.ones(1, channels, 1))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if x.device.type == "cuda" and _compiled_snake is not None:
+            return _compiled_snake(x, self.alpha)
         return _snake(x, self.alpha)
 
 
@@ -314,15 +328,17 @@ class CausalDecoder(nn.Module):
             self.default_sr_idx = len(sr_boundaries)
             self.sr_cond_model = nn.ModuleList(
                 [
-                    SampleRateConditionLayer(
-                        layer.input_channels,
-                        buckets,
-                        cond_type=cond_type,
-                        cond_dim=cond_dim,
-                        out_layer=cond_out_layer,
+                    (
+                        SampleRateConditionLayer(
+                            layer.input_channels,
+                            buckets,
+                            cond_type=cond_type,
+                            cond_dim=cond_dim,
+                            out_layer=cond_out_layer,
+                        )
+                        if isinstance(layer, CausalDecoderBlock)
+                        else None
                     )
-                    if isinstance(layer, CausalDecoderBlock)
-                    else None
                     for layer in layers
                 ]
             )

--- a/sglang_omni/models/voxcpm_common/audio_vae.py
+++ b/sglang_omni/models/voxcpm_common/audio_vae.py
@@ -1,0 +1,499 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Checkpoint-compatible causal AudioVAEs used by VoxCPM1.5 and VoxCPM2."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch.nn.utils import weight_norm
+
+from sglang_omni.models.voxcpm_common.streaming_vae import (
+    BatchedStreamingVAEDecoder,
+)
+
+
+def _get(config: Any, name: str, default: Any) -> Any:
+    if config is None:
+        return default
+    if isinstance(config, dict):
+        return config.get(name, default)
+    return getattr(config, name, default)
+
+
+class CausalConv1d(nn.Conv1d):
+    def __init__(
+        self, *args: Any, padding: int = 0, output_padding: int = 0, **kwargs: Any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.__padding = padding
+        self.__output_padding = output_padding
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return super().forward(
+            F.pad(x, (self.__padding * 2 - self.__output_padding, 0))
+        )
+
+
+class CausalTransposeConv1d(nn.ConvTranspose1d):
+    def __init__(
+        self, *args: Any, padding: int = 0, output_padding: int = 0, **kwargs: Any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.__padding = padding
+        self.__output_padding = output_padding
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        trim = self.__padding * 2 - self.__output_padding
+        output = super().forward(x)
+        return output[..., :-trim] if trim else output
+
+
+def _conv(*args: Any, **kwargs: Any) -> nn.Conv1d:
+    return weight_norm(CausalConv1d(*args, **kwargs))
+
+
+def _transpose(*args: Any, **kwargs: Any) -> nn.ConvTranspose1d:
+    return weight_norm(CausalTransposeConv1d(*args, **kwargs))
+
+
+def _snake(x: torch.Tensor, alpha: torch.Tensor) -> torch.Tensor:
+    shape = x.shape
+    x = x.reshape(shape[0], shape[1], -1)
+    x = x + (alpha + 1e-9).reciprocal() * torch.sin(alpha * x).square()
+    return x.reshape(shape)
+
+
+class Snake1d(nn.Module):
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.alpha = nn.Parameter(torch.ones(1, channels, 1))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return _snake(x, self.alpha)
+
+
+class CausalResidualUnit(nn.Module):
+    def __init__(self, dim: int, dilation: int, groups: int) -> None:
+        super().__init__()
+        self.block = nn.Sequential(
+            Snake1d(dim),
+            _conv(
+                dim,
+                dim,
+                kernel_size=7,
+                dilation=dilation,
+                padding=3 * dilation,
+                groups=groups,
+            ),
+            Snake1d(dim),
+            _conv(dim, dim, kernel_size=1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + self.block(x)
+
+
+class CausalEncoderBlock(nn.Module):
+    def __init__(self, output_dim: int, stride: int, *, groups: int, v2: bool) -> None:
+        super().__init__()
+        input_dim = output_dim // 2
+        self.block = nn.Sequential(
+            *(
+                CausalResidualUnit(input_dim, dilation, groups)
+                for dilation in (1, 3, 9)
+            ),
+            Snake1d(input_dim),
+            _conv(
+                input_dim,
+                output_dim,
+                kernel_size=2 * stride,
+                stride=stride,
+                padding=math.ceil(stride / 2),
+                output_padding=stride % 2 if v2 else 0,
+            ),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.block(x)
+
+
+class CausalEncoder(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        latent_dim: int,
+        rates: list[int],
+        *,
+        depthwise: bool,
+        v2: bool,
+    ) -> None:
+        super().__init__()
+        layers: list[nn.Module] = [_conv(1, dim, kernel_size=7, padding=3)]
+        for stride in rates:
+            dim *= 2
+            layers.append(
+                CausalEncoderBlock(
+                    dim,
+                    stride,
+                    groups=dim // 2 if depthwise else 1,
+                    v2=v2,
+                )
+            )
+        self.block = nn.Sequential(*layers)
+        self.fc_mu = _conv(dim, latent_dim, kernel_size=3, padding=1)
+        self.fc_logvar = _conv(dim, latent_dim, kernel_size=3, padding=1)
+
+    def forward(self, x: torch.Tensor) -> dict[str, torch.Tensor]:
+        hidden = self.block(x)
+        return {
+            "hidden_state": hidden,
+            "mu": self.fc_mu(hidden),
+            "logvar": self.fc_logvar(hidden),
+        }
+
+
+class NoiseBlock(nn.Module):
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.linear = _conv(dim, dim, kernel_size=1, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        noise = torch.randn((x.shape[0], 1, x.shape[2]), device=x.device, dtype=x.dtype)
+        return x + noise * self.linear(x)
+
+
+class CausalDecoderBlock(nn.Module):
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        stride: int,
+        *,
+        groups: int,
+        use_noise_block: bool,
+    ) -> None:
+        super().__init__()
+        layers: list[nn.Module] = [
+            Snake1d(input_dim),
+            _transpose(
+                input_dim,
+                output_dim,
+                kernel_size=2 * stride,
+                stride=stride,
+                padding=math.ceil(stride / 2),
+                output_padding=stride % 2,
+            ),
+        ]
+        if use_noise_block:
+            layers.append(NoiseBlock(output_dim))
+        layers.extend(
+            CausalResidualUnit(output_dim, dilation, groups) for dilation in (1, 3, 9)
+        )
+        self.block = nn.Sequential(*layers)
+        self.input_channels = input_dim
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.block(x)
+
+
+class SampleRateConditionLayer(nn.Module):
+    def __init__(
+        self,
+        input_dim: int,
+        buckets: int,
+        *,
+        cond_type: str,
+        cond_dim: int,
+        out_layer: bool,
+    ) -> None:
+        super().__init__()
+        self.cond_type = cond_type
+        output_input = input_dim
+        if cond_type in {"scale_bias", "scale_bias_init"}:
+            self.scale_embed = nn.Embedding(buckets, input_dim)
+            self.bias_embed = nn.Embedding(buckets, input_dim)
+            if cond_type == "scale_bias":
+                nn.init.ones_(self.scale_embed.weight)
+                nn.init.zeros_(self.bias_embed.weight)
+            else:
+                nn.init.normal_(self.scale_embed.weight, mean=1)
+                nn.init.normal_(self.bias_embed.weight)
+        elif cond_type == "add":
+            self.cond_embed = nn.Embedding(buckets, input_dim)
+        elif cond_type == "concat":
+            if not out_layer:
+                raise ValueError("concat sample-rate conditioning needs out_layer")
+            self.cond_embed = nn.Embedding(buckets, cond_dim)
+            output_input += cond_dim
+        else:
+            raise ValueError(f"invalid AudioVAE conditioning type: {cond_type}")
+        self.out_layer = (
+            nn.Sequential(Snake1d(output_input), _conv(output_input, input_dim, 1))
+            if out_layer
+            else nn.Identity()
+        )
+
+    def forward(self, x: torch.Tensor, condition: torch.Tensor) -> torch.Tensor:
+        if self.cond_type in {"scale_bias", "scale_bias_init"}:
+            x = x * self.scale_embed(condition).unsqueeze(-1) + self.bias_embed(
+                condition
+            ).unsqueeze(-1)
+        elif self.cond_type == "add":
+            x = x + self.cond_embed(condition).unsqueeze(-1)
+        else:
+            cond = self.cond_embed(condition).unsqueeze(-1).expand(-1, -1, x.shape[-1])
+            x = torch.cat((x, cond), 1)
+        return self.out_layer(x)
+
+
+class CausalDecoder(nn.Module):
+    def __init__(
+        self,
+        latent_dim: int,
+        channels: int,
+        rates: list[int],
+        *,
+        depthwise: bool,
+        use_noise_block: bool,
+        sr_boundaries: list[int] | None,
+        cond_type: str,
+        cond_dim: int,
+        cond_out_layer: bool,
+    ) -> None:
+        super().__init__()
+        if depthwise:
+            layers: list[nn.Module] = [
+                _conv(
+                    latent_dim,
+                    latent_dim,
+                    kernel_size=7,
+                    padding=3,
+                    groups=latent_dim,
+                ),
+                _conv(latent_dim, channels, kernel_size=1),
+            ]
+        else:
+            layers = [_conv(latent_dim, channels, kernel_size=7, padding=3)]
+        for index, stride in enumerate(rates):
+            input_dim = channels // 2**index
+            output_dim = channels // 2 ** (index + 1)
+            layers.append(
+                CausalDecoderBlock(
+                    input_dim,
+                    output_dim,
+                    stride,
+                    groups=output_dim if depthwise else 1,
+                    use_noise_block=use_noise_block,
+                )
+            )
+        layers.extend(
+            (
+                Snake1d(output_dim),
+                _conv(output_dim, 1, kernel_size=7, padding=3),
+                nn.Tanh(),
+            )
+        )
+        if sr_boundaries is None:
+            self.sr_bin_boundaries = None
+            self.sr_bin_buckets = None
+            self.model: nn.Module = nn.Sequential(*layers)
+            self.sr_cond_model = None
+            self.default_sr_idx = None
+        else:
+            self.model = nn.ModuleList(layers)
+            self.register_buffer(
+                "sr_bin_boundaries",
+                torch.tensor(sr_boundaries, dtype=torch.int32),
+            )
+            buckets = len(sr_boundaries) + 1
+            self.sr_bin_buckets = buckets
+            self.default_sr_idx = len(sr_boundaries)
+            self.sr_cond_model = nn.ModuleList(
+                [
+                    SampleRateConditionLayer(
+                        layer.input_channels,
+                        buckets,
+                        cond_type=cond_type,
+                        cond_dim=cond_dim,
+                        out_layer=cond_out_layer,
+                    )
+                    if isinstance(layer, CausalDecoderBlock)
+                    else None
+                    for layer in layers
+                ]
+            )
+
+    def forward(
+        self, x: torch.Tensor, sr_cond: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        if self.sr_bin_boundaries is None:
+            return self.model(x)
+        if sr_cond is None:
+            sr_cond = torch.full(
+                (x.shape[0],),
+                self.default_sr_idx,
+                dtype=torch.long,
+                device=x.device,
+            )
+        for layer, conditioner in zip(self.model, self.sr_cond_model):
+            if conditioner is not None:
+                x = conditioner(x, sr_cond)
+            x = layer(x)
+        return x
+
+
+class AudioVAE(nn.Module):
+    """V1 AudioVAE. Defaults match the official VoxCPM1.5 checkpoint."""
+
+    def __init__(self, config: Any = None, **kwargs: Any) -> None:
+        super().__init__()
+        values = dict(kwargs)
+        encoder_dim = int(values.get("encoder_dim", _get(config, "encoder_dim", 128)))
+        encoder_rates = list(
+            values.get("encoder_rates", _get(config, "encoder_rates", [2, 5, 8, 8]))
+        )
+        self.latent_dim = int(values.get("latent_dim", _get(config, "latent_dim", 64)))
+        decoder_dim = int(values.get("decoder_dim", _get(config, "decoder_dim", 1536)))
+        decoder_rates = list(
+            values.get("decoder_rates", _get(config, "decoder_rates", [8, 8, 5, 2]))
+        )
+        depthwise = bool(values.get("depthwise", _get(config, "depthwise", True)))
+        use_noise = bool(
+            values.get("use_noise_block", _get(config, "use_noise_block", False))
+        )
+        self.sample_rate = int(
+            values.get("sample_rate", _get(config, "sample_rate", 16000))
+        )
+        self.out_sample_rate = self.sample_rate
+        self.encoder_chunk_size = math.prod(encoder_rates)
+        self.hop_length = self.encoder_chunk_size
+        self.decoder_chunk_size = math.prod(decoder_rates)
+        self.chunk_size = self.decoder_chunk_size
+        self.encoder = CausalEncoder(
+            encoder_dim,
+            self.latent_dim,
+            encoder_rates,
+            depthwise=depthwise,
+            v2=False,
+        )
+        self.decoder = CausalDecoder(
+            self.latent_dim,
+            decoder_dim,
+            decoder_rates,
+            depthwise=depthwise,
+            use_noise_block=use_noise,
+            sr_boundaries=None,
+            cond_type="scale_bias",
+            cond_dim=128,
+            cond_out_layer=False,
+        )
+
+    def preprocess(self, audio: torch.Tensor, sample_rate: int | None) -> torch.Tensor:
+        if sample_rate is not None and int(sample_rate) != self.sample_rate:
+            raise ValueError(f"AudioVAE expects {self.sample_rate} Hz audio")
+        pad = (-audio.shape[-1]) % self.encoder_chunk_size
+        return F.pad(audio, (0, pad))
+
+    @torch.inference_mode()
+    def encode(
+        self, audio: torch.Tensor, sample_rate: int | None = None
+    ) -> torch.Tensor:
+        if audio.ndim == 2:
+            audio = audio.unsqueeze(1)
+        return self.encoder(self.preprocess(audio, sample_rate))["mu"]
+
+    @torch.inference_mode()
+    def decode(self, latents: torch.Tensor) -> torch.Tensor:
+        return self.decoder(latents)
+
+    def streaming_decoder(self) -> BatchedStreamingVAEDecoder:
+        return BatchedStreamingVAEDecoder(self, CausalConv1d, CausalTransposeConv1d)
+
+
+class AudioVAEV2(AudioVAE):
+    """V2 AudioVAE with 48 kHz sample-rate-conditioned decoder."""
+
+    def __init__(self, config: Any = None, **kwargs: Any) -> None:
+        nn.Module.__init__(self)
+        values = dict(kwargs)
+        encoder_dim = int(values.get("encoder_dim", _get(config, "encoder_dim", 128)))
+        encoder_rates = list(
+            values.get("encoder_rates", _get(config, "encoder_rates", [2, 5, 8, 8]))
+        )
+        self.latent_dim = int(values.get("latent_dim", _get(config, "latent_dim", 64)))
+        decoder_dim = int(values.get("decoder_dim", _get(config, "decoder_dim", 2048)))
+        decoder_rates = list(
+            values.get(
+                "decoder_rates", _get(config, "decoder_rates", [8, 6, 5, 2, 2, 2])
+            )
+        )
+        depthwise = bool(values.get("depthwise", _get(config, "depthwise", True)))
+        use_noise = bool(
+            values.get("use_noise_block", _get(config, "use_noise_block", False))
+        )
+        self.sample_rate = int(
+            values.get("sample_rate", _get(config, "sample_rate", 16000))
+        )
+        self.out_sample_rate = int(
+            values.get("out_sample_rate", _get(config, "out_sample_rate", 48000))
+        )
+        self.sr_bin_boundaries = values.get(
+            "sr_bin_boundaries",
+            _get(config, "sr_bin_boundaries", [20000, 30000, 40000]),
+        )
+        self.encoder_chunk_size = math.prod(encoder_rates)
+        self.hop_length = self.encoder_chunk_size
+        self.decoder_chunk_size = math.prod(decoder_rates)
+        self.chunk_size = self.decoder_chunk_size
+        self.encoder = CausalEncoder(
+            encoder_dim,
+            self.latent_dim,
+            encoder_rates,
+            depthwise=depthwise,
+            v2=True,
+        )
+        self.decoder = CausalDecoder(
+            self.latent_dim,
+            decoder_dim,
+            decoder_rates,
+            depthwise=depthwise,
+            use_noise_block=use_noise,
+            sr_boundaries=self.sr_bin_boundaries,
+            cond_type=str(
+                values.get("cond_type", _get(config, "cond_type", "scale_bias"))
+            ),
+            cond_dim=int(values.get("cond_dim", _get(config, "cond_dim", 128))),
+            cond_out_layer=bool(
+                values.get("cond_out_layer", _get(config, "cond_out_layer", False))
+            ),
+        )
+
+    @torch.inference_mode()
+    def decode(
+        self, latents: torch.Tensor, sr_cond: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        return self.decoder(latents, sr_cond)
+
+
+def create_audio_vae(config: Any, *, version: str) -> AudioVAE:
+    """Construct the checkpoint-native VAE from a top-level official config."""
+
+    vae_config = _get(config, "audio_vae_config", None)
+    if version == "v1":
+        return AudioVAE(config=vae_config)
+    if version == "v2":
+        return AudioVAEV2(config=vae_config)
+    raise ValueError(f"unsupported VoxCPM version: {version!r}")
+
+
+__all__ = [
+    "AudioVAE",
+    "AudioVAEV2",
+    "CausalConv1d",
+    "CausalTransposeConv1d",
+    "create_audio_vae",
+]

--- a/sglang_omni/models/voxcpm_common/core.py
+++ b/sglang_omni/models/voxcpm_common/core.py
@@ -1,0 +1,1001 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared SGLang-native model core for VoxCPM and VoxCPM2."""
+
+from __future__ import annotations
+
+import copy
+import math
+from typing import Any, Literal
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from sglang_omni.models.voxcpm_common.state_pool import VoxCPMRequestStatePool
+
+try:
+    from sglang_omni.vendor.sglang.layers import (
+        MergedColumnParallelLinear,
+        QKVParallelLinear,
+        RMSNorm,
+        RadixAttention,
+        RowParallelLinear,
+        VocabParallelEmbedding,
+    )
+except ModuleNotFoundError as error:
+    if error.name != "sglang":
+        raise
+
+    class _FallbackLinear(nn.Linear):
+        def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, None]:
+            return super().forward(x), None
+
+    class QKVParallelLinear(_FallbackLinear):  # type: ignore[no-redef]
+        def __init__(
+            self,
+            hidden: int,
+            head_dim: int,
+            heads: int,
+            kv_heads: int,
+            **kwargs: Any,
+        ) -> None:
+            self.num_heads, self.num_kv_heads = heads, kv_heads
+            super().__init__(
+                hidden,
+                (heads + 2 * kv_heads) * head_dim,
+                bias=bool(kwargs.get("bias", False)),
+            )
+
+    class MergedColumnParallelLinear(_FallbackLinear):  # type: ignore[no-redef]
+        def __init__(self, in_features: int, outputs: list[int], **kwargs: Any) -> None:
+            super().__init__(
+                in_features, sum(outputs), bias=bool(kwargs.get("bias", False))
+            )
+
+    class RowParallelLinear(_FallbackLinear):  # type: ignore[no-redef]
+        def __init__(self, in_features: int, out_features: int, **kwargs: Any) -> None:
+            super().__init__(
+                in_features, out_features, bias=bool(kwargs.get("bias", False))
+            )
+
+    class VocabParallelEmbedding(nn.Embedding):  # type: ignore[no-redef]
+        def __init__(self, vocab: int, hidden: int, **_: Any) -> None:
+            super().__init__(vocab, hidden)
+
+    class RMSNorm(nn.Module):  # type: ignore[no-redef]
+        def __init__(self, hidden: int, eps: float = 1e-6) -> None:
+            super().__init__()
+            self.weight = nn.Parameter(torch.ones(hidden))
+            self.eps = eps
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            normalized = x.float() * torch.rsqrt(
+                x.float().square().mean(dim=-1, keepdim=True) + self.eps
+            )
+            return (normalized * self.weight.float()).to(x.dtype)
+
+    class RadixAttention(nn.Module):  # type: ignore[no-redef]
+        """CPU-only import/smoke fallback; it does not implement a radix cache."""
+
+        def __init__(
+            self,
+            heads: int,
+            head_dim: int,
+            scaling: float,
+            *,
+            num_kv_heads: int,
+            **_: Any,
+        ) -> None:
+            super().__init__()
+            self.heads, self.kv_heads, self.head_dim = heads, num_kv_heads, head_dim
+            self.scaling = scaling
+
+        def forward(
+            self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, _: Any
+        ) -> torch.Tensor:
+            tokens = q.shape[0]
+            q = q.view(tokens, self.heads, self.head_dim).transpose(0, 1)[None]
+            k = k.view(tokens, self.kv_heads, self.head_dim).transpose(0, 1)[None]
+            v = v.view(tokens, self.kv_heads, self.head_dim).transpose(0, 1)[None]
+            if self.kv_heads != self.heads:
+                repeat = self.heads // self.kv_heads
+                k, v = k.repeat_interleave(repeat, 1), v.repeat_interleave(repeat, 1)
+            output = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+            return output[0].transpose(0, 1).reshape(tokens, -1)
+
+
+VoxCPMVersion = Literal["v1", "v2"]
+
+
+def cfg_get(config: Any, name: str, default: Any = None) -> Any:
+    value = (
+        config.get(name, default)
+        if isinstance(config, dict)
+        else getattr(config, name, default)
+    )
+    return default if value is None else value
+
+
+def clone_config(config: Any, **updates: Any) -> Any:
+    if hasattr(config, "model_copy"):
+        result = config.model_copy(deep=True)
+    else:
+        result = copy.deepcopy(config)
+    for name, value in updates.items():
+        if isinstance(result, dict):
+            result[name] = value
+        else:
+            setattr(result, name, value)
+    return result
+
+
+def _rope_field(rope_scaling: Any, name: str, default: Any) -> Any:
+    if rope_scaling is None:
+        return default
+    return cfg_get(rope_scaling, name, default)
+
+
+class MiniCPMLongRoPE(nn.Module):
+    """LongRoPE preserving the checkpoint-specific V1/V2 cache math."""
+
+    def __init__(self, config: Any, *, version: VoxCPMVersion) -> None:
+        super().__init__()
+        heads = int(cfg_get(config, "num_attention_heads"))
+        self.dim = int(
+            cfg_get(config, "kv_channels", 0) or cfg_get(config, "hidden_size") // heads
+        )
+        self.max_position = int(cfg_get(config, "max_position_embeddings", 32768))
+        self.base = float(cfg_get(config, "rope_theta", 10000.0))
+        scaling = cfg_get(config, "rope_scaling")
+        original = int(
+            _rope_field(scaling, "original_max_position_embeddings", self.max_position)
+        )
+        short = _rope_field(scaling, "short_factor", [1.0] * (self.dim // 2))
+        long = _rope_field(scaling, "long_factor", [1.0] * (self.dim // 2))
+        if len(short) != self.dim // 2 or len(long) != self.dim // 2:
+            raise ValueError("LongRoPE factors must contain head_dim / 2 entries")
+        scale = self.max_position / original
+        amplitude = math.sqrt(1 + math.log(scale) / math.log(original))
+        inv_freq = 1.0 / (
+            self.base ** (torch.arange(0, self.dim, 2, dtype=torch.float32) / self.dim)
+        )
+        factors = torch.tensor(
+            long if self.max_position > original else short, dtype=torch.float32
+        )
+        positions = torch.arange(self.max_position, dtype=torch.float32)
+        if version == "v1":
+            # V1 casts inv_freq to the target cache dtype before multiplication.
+            freqs = torch.outer(positions, 1.0 / factors) * inv_freq.float()
+        else:
+            # Kept separate intentionally: official V2 first materializes the
+            # factor-adjusted outer product and then multiplies inv_freq.
+            freqs = torch.mul(torch.outer(positions, 1.0 / factors), inv_freq)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        self.register_buffer("cos_cached", emb.cos() * amplitude, persistent=False)
+        self.register_buffer("sin_cached", emb.sin() * amplitude, persistent=False)
+
+    def forward(
+        self, positions: torch.Tensor, query: torch.Tensor, key: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if positions.numel() and int(positions.max()) >= self.max_position:
+            raise ValueError("position exceeds configured LongRoPE cache")
+        cos = self.cos_cached[positions].unsqueeze(1)
+        sin = self.sin_cached[positions].unsqueeze(1)
+
+        def apply(x: torch.Tensor) -> torch.Tensor:
+            shape, dtype = x.shape, x.dtype
+            x = x.reshape(positions.numel(), -1, self.dim).float()
+            first, second = x.chunk(2, dim=-1)
+            rotated = torch.cat((-second, first), dim=-1)
+            return (x * cos + rotated * sin).to(dtype).reshape(shape)
+
+        return apply(query), apply(key)
+
+
+class CausalMiniCPMAttention(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        *,
+        layer_id: int,
+        version: VoxCPMVersion,
+        use_rope: bool,
+        prefix: str,
+        quant_config: Any = None,
+    ) -> None:
+        super().__init__()
+        hidden = int(cfg_get(config, "hidden_size"))
+        total_heads = int(cfg_get(config, "num_attention_heads"))
+        total_kv_heads = int(cfg_get(config, "num_key_value_heads", total_heads))
+        self.head_dim = int(cfg_get(config, "kv_channels", 0) or hidden // total_heads)
+        self.total_heads = total_heads
+        self.total_kv_heads = total_kv_heads
+        self.qkv_proj = QKVParallelLinear(
+            hidden,
+            self.head_dim,
+            total_heads,
+            total_kv_heads,
+            bias=bool(cfg_get(config, "attention_bias", False)),
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj",
+        )
+        self.o_proj = RowParallelLinear(
+            total_heads * self.head_dim,
+            hidden,
+            bias=bool(cfg_get(config, "attention_bias", False)),
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+        try:
+            from sglang.srt.distributed import get_tensor_model_parallel_world_size
+
+            tp_size = int(get_tensor_model_parallel_world_size())
+        except (ModuleNotFoundError, AssertionError):
+            # CPU config/tests may have SGLang installed without an initialized
+            # tensor-parallel process group.
+            tp_size = 1
+        if total_heads % tp_size or total_kv_heads % tp_size:
+            raise ValueError("MiniCPM attention heads must be divisible by TP size")
+        self.num_heads = total_heads // tp_size
+        self.num_kv_heads = total_kv_heads // tp_size
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.rotary_emb = MiniCPMLongRoPE(config, version=version) if use_rope else None
+        self.q_norm = (
+            RMSNorm(self.head_dim, eps=float(cfg_get(config, "rms_norm_eps", 1e-6)))
+            if bool(cfg_get(config, "apply_qk_norm", False))
+            else None
+        )
+        self.k_norm = (
+            RMSNorm(self.head_dim, eps=float(cfg_get(config, "rms_norm_eps", 1e-6)))
+            if self.q_norm is not None
+            else None
+        )
+        self.attn = RadixAttention(
+            self.num_heads,
+            self.head_dim,
+            self.head_dim**-0.5,
+            num_kv_heads=self.num_kv_heads,
+            layer_id=layer_id,
+            prefix=f"{prefix}.attn",
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: Any,
+    ) -> torch.Tensor:
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v = qkv.split((self.q_size, self.kv_size, self.kv_size), dim=-1)
+        if self.q_norm is not None:
+            q = self.q_norm(q.view(-1, self.num_heads, self.head_dim)).view_as(q)
+            k = self.k_norm(k.view(-1, self.num_kv_heads, self.head_dim)).view_as(k)
+        if self.rotary_emb is not None:
+            q, k = self.rotary_emb(positions, q, k)
+        output = self.attn(q, k, v, forward_batch)
+        output, _ = self.o_proj(output)
+        return output
+
+
+class CausalMiniCPMMLP(nn.Module):
+    def __init__(self, config: Any, *, prefix: str, quant_config: Any = None) -> None:
+        super().__init__()
+        hidden = int(cfg_get(config, "hidden_size"))
+        intermediate = int(cfg_get(config, "intermediate_size"))
+        self.gate_up_proj = MergedColumnParallelLinear(
+            hidden,
+            [intermediate, intermediate],
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj",
+        )
+        self.down_proj = RowParallelLinear(
+            intermediate,
+            hidden,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.down_proj",
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        gate_up, _ = self.gate_up_proj(hidden_states)
+        gate, up = gate_up.chunk(2, dim=-1)
+        output, _ = self.down_proj(F.silu(gate) * up)
+        return output
+
+
+class CausalMiniCPMLayer(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        *,
+        layer_id: int,
+        version: VoxCPMVersion,
+        use_rope: bool,
+        prefix: str,
+        quant_config: Any = None,
+    ) -> None:
+        super().__init__()
+        hidden = int(cfg_get(config, "hidden_size"))
+        eps = float(cfg_get(config, "rms_norm_eps", 1e-6))
+        self.self_attn = CausalMiniCPMAttention(
+            config,
+            layer_id=layer_id,
+            version=version,
+            use_rope=use_rope,
+            prefix=f"{prefix}.self_attn",
+            quant_config=quant_config,
+        )
+        self.mlp = CausalMiniCPMMLP(
+            config, prefix=f"{prefix}.mlp", quant_config=quant_config
+        )
+        self.input_layernorm = RMSNorm(hidden, eps=eps)
+        self.post_attention_layernorm = RMSNorm(hidden, eps=eps)
+
+    def forward(
+        self, positions: torch.Tensor, hidden_states: torch.Tensor, forward_batch: Any
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = residual + self.self_attn(
+            positions, hidden_states, forward_batch
+        )
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        return residual + self.mlp(hidden_states)
+
+
+class CausalMiniCPMModel(nn.Module):
+    """MiniCPM4 LM whose attention is entirely SGLang RadixAttention."""
+
+    def __init__(
+        self,
+        config: Any,
+        *,
+        version: VoxCPMVersion,
+        layer_offset: int,
+        use_rope: bool = True,
+        prefix: str,
+        quant_config: Any = None,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        vocab_size = int(cfg_get(config, "vocab_size", 0))
+        hidden = int(cfg_get(config, "hidden_size"))
+        self.embed_tokens: nn.Module = (
+            VocabParallelEmbedding(
+                vocab_size,
+                hidden,
+                quant_config=quant_config,
+                prefix=f"{prefix}.embed_tokens",
+            )
+            if vocab_size > 0
+            else nn.Identity()
+        )
+        self.layers = nn.ModuleList(
+            CausalMiniCPMLayer(
+                config,
+                layer_id=layer_offset + index,
+                version=version,
+                use_rope=use_rope,
+                prefix=f"{prefix}.layers.{index}",
+                quant_config=quant_config,
+            )
+            for index in range(int(cfg_get(config, "num_hidden_layers")))
+        )
+        self.norm = RMSNorm(hidden, eps=float(cfg_get(config, "rms_norm_eps", 1e-6)))
+
+    def forward(
+        self,
+        input_embeds: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: Any,
+    ) -> torch.Tensor:
+        hidden_states = input_embeds
+        for layer in self.layers:
+            hidden_states = layer(positions, hidden_states, forward_batch)
+        return self.norm(hidden_states)
+
+
+class LocalMiniCPMModel(nn.Module):
+    """Bidirectional MiniCPM block for LocEnc/DiT (outside radix KV cache)."""
+
+    def __init__(self, config: Any, *, version: VoxCPMVersion) -> None:
+        super().__init__()
+        hidden = int(cfg_get(config, "hidden_size"))
+        heads = int(cfg_get(config, "num_attention_heads"))
+        kv_heads = int(cfg_get(config, "num_key_value_heads", heads))
+        head_dim = int(cfg_get(config, "kv_channels", 0) or hidden // heads)
+        intermediate = int(cfg_get(config, "intermediate_size"))
+        eps = float(cfg_get(config, "rms_norm_eps", 1e-6))
+        self.layers = nn.ModuleList(
+            _LocalLayer(
+                config,
+                hidden,
+                heads,
+                kv_heads,
+                head_dim,
+                intermediate,
+                eps,
+                version=version,
+            )
+            for _ in range(int(cfg_get(config, "num_hidden_layers")))
+        )
+        self.norm = RMSNorm(hidden, eps=eps)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        for layer in self.layers:
+            hidden_states = layer(hidden_states)
+        return self.norm(hidden_states)
+
+
+class _LocalAttention(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        hidden: int,
+        heads: int,
+        kv_heads: int,
+        head_dim: int,
+        *,
+        version: VoxCPMVersion,
+    ) -> None:
+        super().__init__()
+        if heads % kv_heads:
+            raise ValueError("local attention heads must be divisible by KV heads")
+        self.heads, self.kv_heads, self.head_dim = heads, kv_heads, head_dim
+        self.q_proj = nn.Linear(hidden, heads * head_dim, bias=False)
+        self.k_proj = nn.Linear(hidden, kv_heads * head_dim, bias=False)
+        self.v_proj = nn.Linear(hidden, kv_heads * head_dim, bias=False)
+        self.o_proj = nn.Linear(heads * head_dim, hidden, bias=False)
+        self.rotary_emb = MiniCPMLongRoPE(config, version=version)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        batch, length, _ = x.shape
+        query = self.q_proj(x)
+        key = self.k_proj(x)
+        value = self.v_proj(x)
+        positions = torch.arange(length, device=x.device, dtype=torch.long).repeat(
+            batch
+        )
+        query, key = self.rotary_emb(
+            positions,
+            query.reshape(batch * length, -1),
+            key.reshape(batch * length, -1),
+        )
+        query = query.view(batch, length, self.heads, self.head_dim).transpose(1, 2)
+        key = key.view(batch, length, self.kv_heads, self.head_dim).transpose(1, 2)
+        value = value.view(batch, length, self.kv_heads, self.head_dim).transpose(1, 2)
+        if self.kv_heads != self.heads:
+            repeats = self.heads // self.kv_heads
+            key = key.repeat_interleave(repeats, dim=1)
+            value = value.repeat_interleave(repeats, dim=1)
+        value = F.scaled_dot_product_attention(query, key, value)
+        return self.o_proj(value.transpose(1, 2).reshape(batch, length, -1))
+
+
+class _LocalLayer(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        hidden: int,
+        heads: int,
+        kv_heads: int,
+        head_dim: int,
+        intermediate: int,
+        eps: float,
+        *,
+        version: VoxCPMVersion,
+    ) -> None:
+        super().__init__()
+        self.self_attn = _LocalAttention(
+            config,
+            hidden,
+            heads,
+            kv_heads,
+            head_dim,
+            version=version,
+        )
+        self.mlp = nn.Module()
+        self.mlp.gate_proj = nn.Linear(hidden, intermediate, bias=False)
+        self.mlp.up_proj = nn.Linear(hidden, intermediate, bias=False)
+        self.mlp.down_proj = nn.Linear(intermediate, hidden, bias=False)
+        self.input_layernorm = RMSNorm(hidden, eps=eps)
+        self.post_attention_layernorm = RMSNorm(hidden, eps=eps)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x + self.self_attn(self.input_layernorm(x))
+        normed = self.post_attention_layernorm(x)
+        return x + self.mlp.down_proj(
+            F.silu(self.mlp.gate_proj(normed)) * self.mlp.up_proj(normed)
+        )
+
+
+class VoxCPMLocEnc(nn.Module):
+    def __init__(self, config: Any, feat_dim: int, *, version: VoxCPMVersion) -> None:
+        super().__init__()
+        hidden = int(cfg_get(config, "hidden_size"))
+        self.special_token = nn.Parameter(torch.empty(1, 1, 1, hidden))
+        self.in_proj = nn.Linear(feat_dim, hidden)
+        self.encoder = LocalMiniCPMModel(config, version=version)
+
+    def forward(self, feat: torch.Tensor) -> torch.Tensor:
+        if feat.ndim != 3:
+            raise ValueError("features must have shape [tokens, patch, feat_dim]")
+        tokens = feat.shape[0]
+        special = self.special_token[0].expand(tokens, 1, -1)
+        hidden = torch.cat((special, self.in_proj(feat)), dim=1)
+        return self.encoder(hidden)[:, 0]
+
+
+class ScalarQuantizationLayer(nn.Module):
+    def __init__(self, hidden: int, latent_dim: int, scale: int) -> None:
+        super().__init__()
+        self.in_proj = nn.Linear(hidden, latent_dim)
+        self.out_proj = nn.Linear(latent_dim, hidden)
+        self.scale = scale
+
+    def forward(self, hidden: torch.Tensor) -> torch.Tensor:
+        quantized = (
+            torch.round(torch.tanh(self.in_proj(hidden)) * self.scale) / self.scale
+        )
+        return self.out_proj(quantized)
+
+
+class SinusoidalPosEmb(nn.Module):
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        if dim % 2:
+            raise ValueError("sinusoidal embedding dimension must be even")
+        self.dim = dim
+
+    def forward(self, value: torch.Tensor, scale: float = 1000.0) -> torch.Tensor:
+        value = value.reshape(-1)
+        half = self.dim // 2
+        frequencies = torch.exp(
+            torch.arange(half, device=value.device, dtype=value.dtype)
+            * -(math.log(10000.0) / (half - 1))
+        )
+        phase = scale * value[:, None] * frequencies[None]
+        return torch.cat((phase.sin(), phase.cos()), dim=-1)
+
+
+class _TimestepEmbedding(nn.Module):
+    def __init__(self, hidden: int) -> None:
+        super().__init__()
+        self.linear_1 = nn.Linear(hidden, hidden)
+        self.linear_2 = nn.Linear(hidden, hidden)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear_2(F.silu(self.linear_1(x)))
+
+
+class VoxCPMLocDiT(nn.Module):
+    def __init__(self, config: Any, feat_dim: int, *, version: VoxCPMVersion) -> None:
+        super().__init__()
+        hidden = int(cfg_get(config, "hidden_size"))
+        self.version = version
+        self.in_proj = nn.Linear(feat_dim, hidden)
+        self.cond_proj = nn.Linear(feat_dim, hidden)
+        self.out_proj = nn.Linear(hidden, feat_dim)
+        self.time_embeddings = SinusoidalPosEmb(hidden)
+        self.time_mlp = _TimestepEmbedding(hidden)
+        self.delta_time_mlp = _TimestepEmbedding(hidden)
+        self.decoder = LocalMiniCPMModel(config, version=version)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        mu: torch.Tensor,
+        time: torch.Tensor,
+        cond: torch.Tensor,
+        delta_time: torch.Tensor,
+    ) -> torch.Tensor:
+        x_hidden = self.in_proj(x.transpose(1, 2))
+        cond_hidden = self.cond_proj(cond.transpose(1, 2))
+        time_hidden = self.time_mlp(self.time_embeddings(time).to(x_hidden.dtype))
+        time_hidden += self.delta_time_mlp(
+            self.time_embeddings(delta_time).to(x_hidden.dtype)
+        )
+        mu = mu.view(x.shape[0], -1, x_hidden.shape[-1])
+        if self.version == "v1":
+            if mu.shape[1] != 1:
+                raise ValueError("V1 DiT expects one conditioning token")
+            prefix = (mu[:, 0] + time_hidden)[:, None]
+        else:
+            prefix = torch.cat((mu, time_hidden[:, None]), dim=1)
+        hidden = torch.cat((prefix, cond_hidden, x_hidden), dim=1)
+        hidden = self.decoder(hidden)
+        start = prefix.shape[1] + cond_hidden.shape[1]
+        return self.out_proj(hidden[:, start:]).transpose(1, 2).contiguous()
+
+
+class UnifiedCFM(nn.Module):
+    def __init__(
+        self,
+        estimator: VoxCPMLocDiT,
+        *,
+        feat_dim: int,
+        patch_size: int,
+        inference_timesteps: int,
+        mean_mode: bool,
+        version: VoxCPMVersion,
+    ) -> None:
+        super().__init__()
+        if inference_timesteps < 1:
+            raise ValueError("inference_timesteps must be positive")
+        self.estimator = estimator
+        self.feat_dim = feat_dim
+        self.patch_size = patch_size
+        self.inference_timesteps = inference_timesteps
+        self.mean_mode = mean_mode
+        self.version = version
+
+    def forward(
+        self,
+        mu: torch.Tensor,
+        cond: torch.Tensor,
+        temperature: torch.Tensor,
+        cfg_value: torch.Tensor,
+        z_noise: torch.Tensor | None = None,
+        *,
+        inference_timesteps: int | None = None,
+    ) -> torch.Tensor:
+        batch = mu.shape[0]
+        noise = (
+            torch.randn(
+                batch,
+                self.feat_dim,
+                self.patch_size,
+                device=mu.device,
+                dtype=mu.dtype,
+            )
+            if z_noise is None
+            else z_noise
+        )
+        x = noise * temperature[:, None, None]
+        solver_steps = int(inference_timesteps or self.inference_timesteps)
+        if solver_steps < 1:
+            raise ValueError("inference_timesteps must be positive")
+        t_span = torch.linspace(
+            1, 0, solver_steps + 1, device=mu.device, dtype=mu.dtype
+        )
+        t_span = t_span + (torch.cos(torch.pi / 2 * t_span) - 1 + t_span)
+        time, dt = t_span[0], t_span[0] - t_span[1]
+        zero_steps = max(1, int(len(t_span) * 0.04))
+        for step in range(1, len(t_span)):
+            if step > zero_steps:
+                x_in = torch.cat((x, x), dim=0)
+                mu_in = torch.cat((mu, torch.zeros_like(mu)), dim=0)
+                cond_in = torch.cat((cond, cond), dim=0)
+                time_in = time.expand(2 * batch)
+                dt_in = dt.expand(2 * batch)
+                if not self.mean_mode:
+                    dt_in = torch.zeros_like(dt_in)
+                positive, negative = self.estimator(
+                    x_in, mu_in, time_in, cond_in, dt_in
+                ).chunk(2)
+                pos_flat, neg_flat = positive.flatten(1), negative.flatten(1)
+                optimal = (pos_flat * neg_flat).sum(1) / (
+                    neg_flat.square().sum(1) + 1e-8
+                )
+                optimal = optimal[:, None, None]
+                velocity = negative * optimal + cfg_value[:, None, None] * (
+                    positive - negative * optimal
+                )
+            else:
+                velocity = 0.0
+            x = x - dt * velocity
+            time = time - dt
+            if step < len(t_span) - 1:
+                dt = time - t_span[step + 1]
+        return x
+
+
+class VoxCPMCore(nn.Module):
+    """Shared generation core; wrappers provide the SGLang public forward."""
+
+    def __init__(
+        self,
+        config: Any,
+        *,
+        version: VoxCPMVersion,
+        inference_timesteps: int,
+        max_requests: int,
+        quant_config: Any = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config, self.version = config, version
+        lm_cfg = cfg_get(config, "lm_config")
+        if bool(cfg_get(lm_cfg, "use_mup", False)):
+            raise ValueError("MiniCPM4 MuP inference is not supported")
+        self.hidden_size = int(cfg_get(lm_cfg, "hidden_size"))
+        self.feat_dim = int(cfg_get(config, "feat_dim", 64))
+        self.patch_size = int(
+            cfg_get(config, "patch_size", 2 if version == "v1" else 4)
+        )
+        base_layers = int(cfg_get(lm_cfg, "num_hidden_layers"))
+        self.base_lm = CausalMiniCPMModel(
+            lm_cfg,
+            version=version,
+            layer_offset=0,
+            prefix=f"{prefix}.base_lm".strip("."),
+            quant_config=quant_config,
+        )
+        residual_cfg = clone_config(
+            lm_cfg,
+            num_hidden_layers=int(cfg_get(config, "residual_lm_num_layers")),
+            vocab_size=0,
+        )
+        self.residual_lm = CausalMiniCPMModel(
+            residual_cfg,
+            version=version,
+            layer_offset=base_layers,
+            use_rope=not (
+                version == "v2" and bool(cfg_get(config, "residual_lm_no_rope", False))
+            ),
+            prefix=f"{prefix}.residual_lm".strip("."),
+            quant_config=quant_config,
+        )
+        enc_cfg_src = cfg_get(config, "encoder_config")
+        enc_cfg = clone_config(
+            lm_cfg,
+            hidden_size=int(cfg_get(enc_cfg_src, "hidden_dim")),
+            intermediate_size=int(cfg_get(enc_cfg_src, "ffn_dim")),
+            num_attention_heads=int(cfg_get(enc_cfg_src, "num_heads")),
+            num_key_value_heads=int(cfg_get(lm_cfg, "num_key_value_heads")),
+            num_hidden_layers=int(cfg_get(enc_cfg_src, "num_layers")),
+            kv_channels=cfg_get(enc_cfg_src, "kv_channels"),
+            vocab_size=0,
+        )
+        dit_cfg_src = cfg_get(config, "dit_config")
+        dit_hidden = int(cfg_get(dit_cfg_src, "hidden_dim"))
+        dit_cfg = clone_config(
+            lm_cfg,
+            hidden_size=dit_hidden,
+            intermediate_size=int(cfg_get(dit_cfg_src, "ffn_dim")),
+            num_attention_heads=int(cfg_get(dit_cfg_src, "num_heads")),
+            num_key_value_heads=int(cfg_get(lm_cfg, "num_key_value_heads")),
+            num_hidden_layers=int(cfg_get(dit_cfg_src, "num_layers")),
+            kv_channels=cfg_get(dit_cfg_src, "kv_channels"),
+            vocab_size=0,
+        )
+        self.feat_encoder = VoxCPMLocEnc(enc_cfg, self.feat_dim, version=version)
+        self.enc_to_lm_proj = nn.Linear(
+            int(cfg_get(enc_cfg_src, "hidden_dim")), self.hidden_size
+        )
+        self.fsq_layer = ScalarQuantizationLayer(
+            self.hidden_size,
+            int(cfg_get(config, "scalar_quantization_latent_dim")),
+            int(cfg_get(config, "scalar_quantization_scale", 9)),
+        )
+        self.lm_to_dit_proj = nn.Linear(self.hidden_size, dit_hidden)
+        self.res_to_dit_proj = nn.Linear(self.hidden_size, dit_hidden)
+        self.fusion_concat_proj = (
+            nn.Linear(2 * self.hidden_size, self.hidden_size)
+            if version == "v2"
+            else None
+        )
+        self.stop_proj = nn.Linear(self.hidden_size, self.hidden_size)
+        self.stop_actn = nn.SiLU()
+        self.stop_head = nn.Linear(self.hidden_size, 2, bias=False)
+        estimator = VoxCPMLocDiT(dit_cfg, self.feat_dim, version=version)
+        self.feat_decoder = UnifiedCFM(
+            estimator,
+            feat_dim=self.feat_dim,
+            patch_size=self.patch_size,
+            inference_timesteps=inference_timesteps,
+            mean_mode=bool(
+                cfg_get(
+                    dit_cfg_src,
+                    "mean_mode",
+                    cfg_get(config, "dit_mean_mode", False),
+                )
+            ),
+            version=version,
+        )
+        weight = next(self.base_lm.embed_tokens.parameters())
+        self.state_pool = VoxCPMRequestStatePool(
+            max_requests,
+            self.hidden_size,
+            self.patch_size,
+            self.feat_dim,
+            device=weight.device,
+            dtype=weight.dtype,
+        )
+        self.vae: nn.Module | None = None
+        self.vae_streaming_decoder: Any = None
+
+    def acquire(self, rid: str) -> int:
+        return self.state_pool.acquire(rid)
+
+    acquire_row = acquire
+
+    def reset(self, rid: str) -> None:
+        self.state_pool.reset(rid)
+
+    reset_request = reset
+    release_row = reset
+
+    def row_for(self, rid: str) -> int | None:
+        return self.state_pool.row_for(rid)
+
+    def forward_backbone(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: Any,
+        *,
+        input_embeds: torch.Tensor | None,
+        feat: torch.Tensor | None,
+        feat_mask: torch.Tensor | None,
+        row_ids: torch.Tensor | None,
+    ) -> torch.Tensor:
+        decode = bool(forward_batch.forward_mode.is_decode())
+        if decode:
+            rows = input_ids.reshape(-1) if row_ids is None else row_ids.reshape(-1)
+            rows = rows.to(device=self.state_pool.feedback.device, dtype=torch.long)
+            base_inputs = self.state_pool.feedback_for(rows)
+            feat = self.state_pool.latents.index_select(0, rows)
+            feat_mask = torch.ones(rows.numel(), device=feat.device, dtype=torch.bool)
+        else:
+            if input_embeds is None:
+                raise ValueError("VoxCPM prefill requires continuous input_embeds")
+            base_inputs = input_embeds
+            if feat is None:
+                feat = torch.zeros(
+                    base_inputs.shape[0],
+                    self.patch_size,
+                    self.feat_dim,
+                    device=base_inputs.device,
+                    dtype=base_inputs.dtype,
+                )
+            if feat_mask is None:
+                feat_mask = torch.zeros(
+                    feat.shape[0], device=feat.device, dtype=torch.bool
+                )
+        if feat.shape != (base_inputs.shape[0], self.patch_size, self.feat_dim):
+            raise ValueError("feat must have shape [tokens, patch_size, feat_dim]")
+        feat_embeds = self.enc_to_lm_proj(self.feat_encoder(feat))
+        feat_embeds = feat_embeds.masked_fill(~feat_mask[:, None], 0)
+        base_outputs = self.base_lm(base_inputs, positions, forward_batch)
+        base_outputs = torch.where(
+            feat_mask[:, None], self.fsq_layer(base_outputs), base_outputs
+        )
+        if self.version == "v1":
+            residual_inputs = base_outputs + feat_embeds
+        else:
+            residual_inputs = self.fusion_concat_proj(
+                torch.cat((base_outputs, feat_embeds), dim=-1)
+            )
+        residual_outputs = self.residual_lm(residual_inputs, positions, forward_batch)
+        sample_indices = self._sample_indices(forward_batch, base_outputs.device)
+        sampled_feat = feat.index_select(0, sample_indices)
+        sampled = torch.cat(
+            (
+                base_outputs.index_select(0, sample_indices),
+                residual_outputs.index_select(0, sample_indices),
+            ),
+            dim=-1,
+        )
+        if row_ids is not None:
+            rows = row_ids.reshape(-1).to(self.state_pool.latents.device, torch.long)
+            if rows.numel() != sampled.shape[0]:
+                raise ValueError("row_ids must match the number of sampled requests")
+            self.state_pool.latents.index_copy_(
+                0, rows, sampled_feat.to(self.state_pool.latents)
+            )
+        return sampled
+
+    @staticmethod
+    def _sample_indices(forward_batch: Any, device: torch.device) -> torch.Tensor:
+        if not bool(forward_batch.forward_mode.is_extend()):
+            batch = int(
+                getattr(forward_batch, "batch_size", 0) or len(forward_batch.seq_lens)
+            )
+            return torch.arange(batch, device=device)
+        lengths = getattr(forward_batch, "extend_seq_lens", None)
+        if lengths is None:
+            return torch.tensor([forward_batch.input_ids.numel() - 1], device=device)
+        return torch.cumsum(lengths.to(device=device, dtype=torch.long), dim=0) - 1
+
+    @torch.no_grad()
+    def generate_batch(
+        self,
+        hidden_states: torch.Tensor,
+        rows: torch.Tensor,
+        *,
+        temperature: torch.Tensor | None = None,
+        cfg_value: torch.Tensor | None = None,
+        z_noise: torch.Tensor | None = None,
+        inference_timesteps: torch.Tensor | None = None,
+        decode_vae: bool = False,
+    ) -> dict[str, torch.Tensor]:
+        rows = rows.to(self.state_pool.feedback.device, torch.long).reshape(-1)
+        if hidden_states.shape != (rows.numel(), 2 * self.hidden_size):
+            raise ValueError("hidden_states must be [batch, 2 * hidden_size]")
+        lm_hidden, residual_hidden = hidden_states.chunk(2, dim=-1)
+        mu_left = self.lm_to_dit_proj(lm_hidden)
+        mu_right = self.res_to_dit_proj(residual_hidden)
+        mu = (
+            mu_left + mu_right
+            if self.version == "v1"
+            else torch.cat((mu_left, mu_right), dim=-1)
+        )
+        temperature = (
+            self.state_pool.temperature.index_select(0, rows)
+            if temperature is None
+            else temperature.to(mu)
+        )
+        cfg_value = (
+            self.state_pool.cfg_value.index_select(0, rows)
+            if cfg_value is None
+            else cfg_value.to(mu)
+        )
+        cond = self.state_pool.latents.index_select(0, rows).transpose(1, 2)
+        if inference_timesteps is None:
+            decoded = self.feat_decoder(mu, cond, temperature, cfg_value, z_noise)
+        else:
+            step_counts = inference_timesteps.to(
+                device=mu.device, dtype=torch.long
+            ).reshape(-1)
+            if step_counts.numel() != rows.numel() or bool((step_counts < 1).any()):
+                raise ValueError(
+                    "inference_timesteps must be positive and match row count"
+                )
+            decoded = torch.empty(
+                rows.numel(),
+                self.feat_dim,
+                self.patch_size,
+                device=mu.device,
+                dtype=mu.dtype,
+            )
+            for step_count in torch.unique(step_counts).tolist():
+                indices = (step_counts == int(step_count)).nonzero(as_tuple=True)[0]
+                group_noise = (
+                    None if z_noise is None else z_noise.index_select(0, indices)
+                )
+                group = self.feat_decoder(
+                    mu.index_select(0, indices),
+                    cond.index_select(0, indices),
+                    temperature.index_select(0, indices),
+                    cfg_value.index_select(0, indices),
+                    group_noise,
+                    inference_timesteps=int(step_count),
+                )
+                decoded.index_copy_(0, indices, group)
+        latents = decoded.transpose(1, 2)
+        stop_flag = self.stop_head(self.stop_actn(self.stop_proj(lm_hidden))).argmax(-1)
+        feedback = self.enc_to_lm_proj(self.feat_encoder(latents))
+        self.state_pool.update(
+            rows, feedback=feedback, latents=latents, stop_flag=stop_flag
+        )
+        output = {"latents": latents, "stop_flag": stop_flag}
+        if decode_vae:
+            output["vae_chunk"] = self.decode_vae_chunks(latents, rows)
+        return output
+
+    def attach_vae(self, vae: nn.Module) -> None:
+        self.vae = vae
+        streaming = getattr(vae, "streaming_decoder", None)
+        self.vae_streaming_decoder = streaming() if callable(streaming) else None
+
+    @torch.no_grad()
+    def decode_vae_chunks(
+        self, latents: torch.Tensor, rows: torch.Tensor
+    ) -> torch.Tensor:
+        if self.vae is None:
+            raise RuntimeError("no AudioVAE has been attached")
+        decoder = self.vae_streaming_decoder
+        if decoder is not None and hasattr(decoder, "decode_chunks"):
+            request_ids = [f"row:{int(row)}" for row in rows.tolist()]
+            return decoder.decode_chunks(
+                latents.float().transpose(1, 2), request_ids, [None] * len(request_ids)
+            )
+        if not hasattr(self.vae, "decode"):
+            raise TypeError(
+                "attached AudioVAE has neither decode nor streaming decode_chunks"
+            )
+        return self.vae.decode(latents.float().transpose(1, 2))

--- a/sglang_omni/models/voxcpm_common/core.py
+++ b/sglang_omni/models/voxcpm_common/core.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import copy
+import logging
 import math
 from typing import Any, Literal
 
@@ -12,6 +13,8 @@ import torch.nn.functional as F
 from torch import nn
 
 from sglang_omni.models.voxcpm_common.state_pool import VoxCPMRequestStatePool
+
+logger = logging.getLogger(__name__)
 
 try:
     from sglang_omni.vendor.sglang.layers import (
@@ -177,7 +180,11 @@ class MiniCPMLongRoPE(nn.Module):
     def forward(
         self, positions: torch.Tensor, query: torch.Tensor, key: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if positions.numel() and int(positions.max()) >= self.max_position:
+        if (
+            positions.device.type == "cpu"
+            and positions.numel()
+            and int(positions.max()) >= self.max_position
+        ):
             raise ValueError("position exceeds configured LongRoPE cache")
         cos = self.cos_cached[positions].unsqueeze(1)
         sin = self.sin_cached[positions].unsqueeze(1)
@@ -902,6 +909,40 @@ class VoxCPMCore(nn.Module):
         return torch.cumsum(lengths.to(device=device, dtype=torch.long), dim=0) - 1
 
     @torch.no_grad()
+    def _run_diffusion(
+        self,
+        hidden_states: torch.Tensor,
+        cond: torch.Tensor,
+        *,
+        temperature: torch.Tensor,
+        cfg_value: torch.Tensor,
+        z_noise: torch.Tensor,
+        inference_timesteps: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if hidden_states.ndim != 2 or hidden_states.shape[1] != 2 * self.hidden_size:
+            raise ValueError("hidden_states must be [batch, 2 * hidden_size]")
+        lm_hidden, residual_hidden = hidden_states.chunk(2, dim=-1)
+        mu_left = self.lm_to_dit_proj(lm_hidden)
+        mu_right = self.res_to_dit_proj(residual_hidden)
+        mu = (
+            mu_left + mu_right
+            if self.version == "v1"
+            else torch.cat((mu_left, mu_right), dim=-1)
+        )
+        decoded = self.feat_decoder(
+            mu,
+            cond,
+            temperature.to(mu),
+            cfg_value.to(mu),
+            z_noise.to(mu),
+            inference_timesteps=inference_timesteps,
+        )
+        latents = decoded.transpose(1, 2)
+        stop_flag = self.stop_head(self.stop_actn(self.stop_proj(lm_hidden))).argmax(-1)
+        feedback = self.enc_to_lm_proj(self.feat_encoder(latents))
+        return latents, stop_flag, feedback
+
+    @torch.no_grad()
     def generate_batch(
         self,
         hidden_states: torch.Tensor,
@@ -916,59 +957,71 @@ class VoxCPMCore(nn.Module):
         rows = rows.to(self.state_pool.feedback.device, torch.long).reshape(-1)
         if hidden_states.shape != (rows.numel(), 2 * self.hidden_size):
             raise ValueError("hidden_states must be [batch, 2 * hidden_size]")
-        lm_hidden, residual_hidden = hidden_states.chunk(2, dim=-1)
-        mu_left = self.lm_to_dit_proj(lm_hidden)
-        mu_right = self.res_to_dit_proj(residual_hidden)
-        mu = (
-            mu_left + mu_right
-            if self.version == "v1"
-            else torch.cat((mu_left, mu_right), dim=-1)
-        )
         temperature = (
             self.state_pool.temperature.index_select(0, rows)
             if temperature is None
-            else temperature.to(mu)
+            else temperature.to(hidden_states)
         )
         cfg_value = (
             self.state_pool.cfg_value.index_select(0, rows)
             if cfg_value is None
-            else cfg_value.to(mu)
+            else cfg_value.to(hidden_states)
         )
         cond = self.state_pool.latents.index_select(0, rows).transpose(1, 2)
-        if inference_timesteps is None:
-            decoded = self.feat_decoder(mu, cond, temperature, cfg_value, z_noise)
-        else:
-            step_counts = inference_timesteps.to(
-                device=mu.device, dtype=torch.long
-            ).reshape(-1)
-            if step_counts.numel() != rows.numel() or bool((step_counts < 1).any()):
-                raise ValueError(
-                    "inference_timesteps must be positive and match row count"
-                )
-            decoded = torch.empty(
+        noise = (
+            torch.randn(
                 rows.numel(),
                 self.feat_dim,
                 self.patch_size,
-                device=mu.device,
-                dtype=mu.dtype,
+                device=hidden_states.device,
+                dtype=hidden_states.dtype,
             )
-            for step_count in torch.unique(step_counts).tolist():
-                indices = (step_counts == int(step_count)).nonzero(as_tuple=True)[0]
-                group_noise = (
-                    None if z_noise is None else z_noise.index_select(0, indices)
-                )
-                group = self.feat_decoder(
-                    mu.index_select(0, indices),
-                    cond.index_select(0, indices),
-                    temperature.index_select(0, indices),
-                    cfg_value.index_select(0, indices),
-                    group_noise,
-                    inference_timesteps=int(step_count),
-                )
-                decoded.index_copy_(0, indices, group)
-        latents = decoded.transpose(1, 2)
-        stop_flag = self.stop_head(self.stop_actn(self.stop_proj(lm_hidden))).argmax(-1)
-        feedback = self.enc_to_lm_proj(self.feat_encoder(latents))
+            if z_noise is None
+            else z_noise
+        )
+        step_counts = (
+            torch.full(
+                (rows.numel(),),
+                self.feat_decoder.inference_timesteps,
+                device=hidden_states.device,
+                dtype=torch.long,
+            )
+            if inference_timesteps is None
+            else inference_timesteps.to(
+                device=hidden_states.device, dtype=torch.long
+            ).reshape(-1)
+        )
+        if step_counts.numel() != rows.numel() or bool((step_counts < 1).any()):
+            raise ValueError("inference_timesteps must be positive and match row count")
+        latents = torch.empty(
+            rows.numel(),
+            self.patch_size,
+            self.feat_dim,
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+        stop_flag = torch.empty(
+            rows.numel(), device=hidden_states.device, dtype=torch.long
+        )
+        feedback = torch.empty(
+            rows.numel(),
+            self.hidden_size,
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
+        for step_count in torch.unique(step_counts).tolist():
+            indices = (step_counts == int(step_count)).nonzero(as_tuple=True)[0]
+            group_latents, group_stop, group_feedback = self._run_diffusion(
+                hidden_states.index_select(0, indices),
+                cond.index_select(0, indices),
+                temperature=temperature.index_select(0, indices),
+                cfg_value=cfg_value.index_select(0, indices),
+                z_noise=noise.index_select(0, indices),
+                inference_timesteps=int(step_count),
+            )
+            latents.index_copy_(0, indices, group_latents)
+            stop_flag.index_copy_(0, indices, group_stop)
+            feedback.index_copy_(0, indices, group_feedback)
         self.state_pool.update(
             rows, feedback=feedback, latents=latents, stop_flag=stop_flag
         )
@@ -976,6 +1029,130 @@ class VoxCPMCore(nn.Module):
         if decode_vae:
             output["vae_chunk"] = self.decode_vae_chunks(latents, rows)
         return output
+
+    @torch.no_grad()
+    def init_diffusion_graphs(self, batch_sizes: list[int]) -> None:
+        if self.state_pool.feedback.device.type != "cuda":
+            return
+        buckets = sorted({int(bs) for bs in batch_sizes if int(bs) > 0})
+        if not buckets:
+            return
+        device = self.state_pool.feedback.device
+        dtype = self.state_pool.feedback.dtype
+        steps = int(self.feat_decoder.inference_timesteps)
+        self._diffusion_graphs: dict[int, tuple[Any, ...]] = {}
+        graph_pool = None
+        for bucket in reversed(buckets):
+            inputs = {
+                "hidden_states": torch.zeros(
+                    bucket, 2 * self.hidden_size, device=device, dtype=dtype
+                ),
+                "cond": torch.zeros(
+                    bucket,
+                    self.feat_dim,
+                    self.patch_size,
+                    device=device,
+                    dtype=dtype,
+                ),
+                "temperature": torch.ones(bucket, device=device, dtype=dtype),
+                "cfg_value": torch.ones(bucket, device=device, dtype=dtype),
+                "z_noise": torch.zeros(
+                    bucket,
+                    self.feat_dim,
+                    self.patch_size,
+                    device=device,
+                    dtype=dtype,
+                ),
+            }
+            output_buffers = (
+                torch.empty(
+                    bucket,
+                    self.patch_size,
+                    self.feat_dim,
+                    device=device,
+                    dtype=dtype,
+                ),
+                torch.empty(bucket, device=device, dtype=torch.long),
+                torch.empty(bucket, self.hidden_size, device=device, dtype=dtype),
+            )
+            warmup_stream = torch.cuda.Stream()
+            warmup_stream.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(warmup_stream):
+                for _ in range(2):
+                    self._run_diffusion(
+                        **inputs,
+                        inference_timesteps=steps,
+                    )
+            torch.cuda.current_stream().wait_stream(warmup_stream)
+            torch.cuda.synchronize()
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph, pool=graph_pool):
+                generated = self._run_diffusion(
+                    **inputs,
+                    inference_timesteps=steps,
+                )
+                for output_buffer, output in zip(output_buffers, generated):
+                    output_buffer.copy_(output)
+            if graph_pool is None:
+                graph_pool = graph.pool()
+            self._diffusion_graphs[bucket] = (graph, inputs, *output_buffers)
+        self._diffusion_graph_pool = graph_pool
+        logger.info(
+            "VoxCPM diffusion CUDA graphs captured for bs=%s steps=%d",
+            buckets,
+            steps,
+        )
+
+    @property
+    def diffusion_graph_max_bs(self) -> int:
+        graphs = getattr(self, "_diffusion_graphs", None)
+        return max(graphs) if graphs else 0
+
+    @torch.no_grad()
+    def generate_batch_graphed(
+        self,
+        hidden_states: torch.Tensor,
+        rows: torch.Tensor,
+        *,
+        temperature: torch.Tensor,
+        cfg_value: torch.Tensor,
+        z_noise: torch.Tensor,
+    ) -> dict[str, torch.Tensor]:
+        batch_size = rows.numel()
+        graphs = getattr(self, "_diffusion_graphs", None)
+        if not graphs or batch_size > max(graphs):
+            return self.generate_batch(
+                hidden_states,
+                rows,
+                temperature=temperature,
+                cfg_value=cfg_value,
+                z_noise=z_noise,
+            )
+        bucket = min(bs for bs in graphs if bs >= batch_size)
+        graph, inputs, latents, stop_flag, feedback = graphs[bucket]
+        cond = self.state_pool.latents.index_select(0, rows).transpose(1, 2)
+        for name, value, pad_value in (
+            ("hidden_states", hidden_states, 0),
+            ("cond", cond, 0),
+            ("temperature", temperature, 1),
+            ("cfg_value", cfg_value, 1),
+            ("z_noise", z_noise, 0),
+        ):
+            buffer = inputs[name]
+            buffer[:batch_size].copy_(value)
+            if batch_size < bucket:
+                buffer[batch_size:].fill_(pad_value)
+        graph.replay()
+        active_latents = latents[:batch_size]
+        active_stop = stop_flag[:batch_size]
+        active_feedback = feedback[:batch_size]
+        self.state_pool.update(
+            rows,
+            feedback=active_feedback,
+            latents=active_latents,
+            stop_flag=active_stop,
+        )
+        return {"latents": active_latents, "stop_flag": active_stop}
 
     def attach_vae(self, vae: nn.Module) -> None:
         self.vae = vae

--- a/sglang_omni/models/voxcpm_common/engine_builder.py
+++ b/sglang_omni/models/voxcpm_common/engine_builder.py
@@ -91,7 +91,7 @@ class VoxCPMEngineBuilder(TtsEngineBuilder):
         defaults = {
             "max_running_requests": 8,
             "dtype": dtype,
-            "disable_cuda_graph": True,
+            "disable_cuda_graph": False,
             "disable_overlap_schedule": True,
             "disable_radix_cache": True,
             "enable_torch_compile": False,
@@ -126,7 +126,6 @@ class VoxCPMEngineBuilder(TtsEngineBuilder):
         overrides["disable_radix_cache"] = True
         overrides["chunked_prefill_size"] = 0
         overrides["disable_overlap_schedule"] = True
-        overrides["disable_cuda_graph"] = True
         overrides["enable_torch_compile"] = False
         overrides["tp_size"] = 1
 
@@ -155,9 +154,32 @@ class VoxCPMEngineBuilder(TtsEngineBuilder):
         # The causal vocoder is numerically sensitive and official weights are fp32.
         self.vae.to(device=device, dtype=__import__("torch").float32).eval()
         model.load_audiovae(self.vae, checkpoint_dir, strict=True)
+        if device.startswith("cuda"):
+            torch = __import__("torch")
+            with torch.inference_mode():
+                self.vae.decode(
+                    torch.zeros(
+                        1,
+                        int(self.vae.latent_dim),
+                        int(model.model.patch_size),
+                        device=device,
+                        dtype=torch.float32,
+                    )
+                )
+            torch.cuda.synchronize()
 
     def get_model_buffer_bs(self, model: Any) -> int | None:
         return int(model.model.state_pool.capacity)
+
+    def post_cuda_graph_setup(self, model: Any, server_args: Any) -> None:
+        if os.environ.get("SGLANG_VOXCPM_DISABLE_DIFFUSION_GRAPH") == "1":
+            return
+        requested = list(server_args.cuda_graph_bs)
+        max_bs = max(requested)
+        diffusion_buckets = [
+            bs for bs in requested if bs <= 8 or bs % 16 == 0 or bs == max_bs
+        ]
+        model.init_diffusion_graphs(diffusion_buckets)
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
         from sglang_omni.models.voxcpm_common.model_runner import VoxCPMModelRunner
@@ -182,6 +204,14 @@ class VoxCPMEngineBuilder(TtsEngineBuilder):
 
     def make_abort_callback(self) -> Any:
         return self._runner.reset_request
+
+    def extra_scheduler_kwargs(self) -> dict[str, Any]:
+        return {
+            "enable_async_decode": (
+                os.environ.get("SGLANG_VOXCPM_ENABLE_ASYNC_DECODE") == "1"
+            ),
+            "async_decode_min_batch_size": 16,
+        }
 
     def post_scheduler_setup(self, scheduler: Any, model_runner: Any) -> None:
         model_runner.set_stream_outbox(scheduler.outbox)

--- a/sglang_omni/models/voxcpm_common/engine_builder.py
+++ b/sglang_omni/models/voxcpm_common/engine_builder.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OmniScheduler/SGLang engine builder shared by both VoxCPM generations."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from typing import Any
+
+from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
+
+
+def _get(config: Any, name: str, default: Any = None) -> Any:
+    if config is None:
+        return default
+    value = (
+        config.get(name, default)
+        if isinstance(config, dict)
+        else getattr(config, name, default)
+    )
+    return default if value is None else value
+
+
+def _as_bool(value: Any, name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and value in (0, 1):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.lower().strip()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+    raise ValueError(f"{name} must be boolean")
+
+
+class VoxCPMEngineBuilder(TtsEngineBuilder):
+    model_name = "VoxCPM"
+    context_length = 32768
+
+    def __init__(
+        self, *, variant: str, total_gpu_memory_fraction: float | None = None
+    ) -> None:
+        if variant not in {"voxcpm", "voxcpm2"}:
+            raise ValueError(f"unsupported VoxCPM variant: {variant}")
+        self.variant = variant
+        self.model_name = "VoxCPM2" if variant == "voxcpm2" else "VoxCPM1.5"
+        self.model_arch_override = (
+            "VoxCPM2SGLangModel" if variant == "voxcpm2" else "VoxCPMSGLangModel"
+        )
+        self.total_gpu_memory_fraction = total_gpu_memory_fraction
+        self.config: Any = None
+        self.tokenizer: Any = None
+        self.vae: Any = None
+        self._runner: Any = None
+        self.decrypted_config_file: str | None = None
+
+    def pre_infra_setup(self, checkpoint_dir: str) -> None:
+        from sglang_omni.models.voxcpm_common.hf_config import (
+            VoxCPM2Config,
+            VoxCPMConfig,
+            register_voxcpm_configs,
+        )
+
+        register_voxcpm_configs()
+        config_path = os.path.join(checkpoint_dir, "config.json")
+        with open(config_path, encoding="utf-8") as config_file:
+            raw_config = json.load(config_file)
+        raw_config["model_type"] = self.variant
+        raw_config["architectures"] = [self.model_arch_override]
+        config_cls = VoxCPM2Config if self.variant == "voxcpm2" else VoxCPMConfig
+        self.config = config_cls.from_dict(raw_config)
+        self.decrypted_config_file = os.path.join(
+            tempfile.gettempdir(),
+            f"{self.variant}_sglang_config_{abs(hash(checkpoint_dir))}.json",
+        )
+        with open(self.decrypted_config_file, "w", encoding="utf-8") as config_file:
+            json.dump(raw_config, config_file)
+        lm_config = _get(self.config, "lm_config")
+        self.context_length = int(
+            _get(
+                lm_config,
+                "max_position_embeddings",
+                _get(self.config, "max_position_embeddings", 32768),
+            )
+        )
+
+    def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
+        defaults = {
+            "max_running_requests": 8,
+            "dtype": dtype,
+            "disable_cuda_graph": True,
+            "disable_overlap_schedule": True,
+            "disable_radix_cache": True,
+            "enable_torch_compile": False,
+            "chunked_prefill_size": 0,
+            "max_prefill_tokens": min(self.context_length, 8192),
+            "sampling_backend": "pytorch",
+            "trust_remote_code": False,
+            "decrypted_config_file": self.decrypted_config_file,
+        }
+        if self.total_gpu_memory_fraction is not None:
+            defaults["mem_fraction_static"] = float(self.total_gpu_memory_fraction)
+        return defaults
+
+    def adjust_overrides(self, overrides: dict[str, Any]) -> None:
+        if "disable_radix_cache" in overrides and not _as_bool(
+            overrides["disable_radix_cache"], "disable_radix_cache"
+        ):
+            raise ValueError(
+                "VoxCPM continuous latent prompts require disable_radix_cache=true"
+            )
+        if int(overrides.get("chunked_prefill_size", 0) or 0) != 0:
+            raise ValueError("VoxCPM does not support chunked prefill")
+        if not _as_bool(
+            overrides.get("disable_overlap_schedule", True),
+            "disable_overlap_schedule",
+        ):
+            raise ValueError("VoxCPM requires overlap scheduling to be disabled")
+        if _as_bool(
+            overrides.get("enable_torch_compile", False), "enable_torch_compile"
+        ):
+            raise ValueError("VoxCPM torch.compile is not supported")
+        overrides["disable_radix_cache"] = True
+        overrides["chunked_prefill_size"] = 0
+        overrides["disable_overlap_schedule"] = True
+        overrides["disable_cuda_graph"] = True
+        overrides["enable_torch_compile"] = False
+        overrides["tp_size"] = 1
+
+    def setup_model(
+        self,
+        *,
+        model_worker: Any,
+        checkpoint_dir: str,
+        device: str,
+        gpu_id: int,
+        server_args: Any,
+    ) -> None:
+        del gpu_id, server_args
+        from sglang_omni.models.voxcpm_common.audio_vae import AudioVAE, AudioVAEV2
+        from sglang_omni.models.voxcpm_common.engine_io import load_voxcpm_tokenizer
+
+        model = model_worker.model_runner.model
+        model.eval()
+        self.tokenizer = load_voxcpm_tokenizer(checkpoint_dir)
+        vae_config = _get(self.config, "audio_vae_config")
+        self.vae = (
+            AudioVAEV2(config=vae_config)
+            if self.variant == "voxcpm2"
+            else AudioVAE(config=vae_config)
+        )
+        # The causal vocoder is numerically sensitive and official weights are fp32.
+        self.vae.to(device=device, dtype=__import__("torch").float32).eval()
+        model.load_audiovae(self.vae, checkpoint_dir, strict=True)
+
+    def get_model_buffer_bs(self, model: Any) -> int | None:
+        return int(model.model.state_pool.capacity)
+
+    def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
+        from sglang_omni.models.voxcpm_common.model_runner import VoxCPMModelRunner
+
+        self._runner = VoxCPMModelRunner(
+            model_worker, output_proc, variant=self.variant
+        )
+        return self._runner
+
+    def make_adapters(self, model: Any) -> tuple[Any, Any]:
+        from sglang_omni.models.voxcpm_common.engine_io import (
+            make_voxcpm_scheduler_adapters,
+        )
+
+        return make_voxcpm_scheduler_adapters(
+            model=model,
+            tokenizer=self.tokenizer,
+            vae=self.vae,
+            variant=self.variant,
+            reset_request=self._runner.reset_request,
+        )
+
+    def make_abort_callback(self) -> Any:
+        return self._runner.reset_request
+
+    def post_scheduler_setup(self, scheduler: Any, model_runner: Any) -> None:
+        model_runner.set_stream_outbox(scheduler.outbox)
+
+
+__all__ = ["VoxCPMEngineBuilder"]

--- a/sglang_omni/models/voxcpm_common/engine_io.py
+++ b/sglang_omni/models/voxcpm_common/engine_io.py
@@ -14,6 +14,10 @@ import torch
 from sglang_omni.models.voxcpm_common.payload_types import VoxCPMState
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.pipeline_state import build_usage
+from sglang_omni.utils.audio_payload import audio_waveform_payload
+
+_MAX_AUDIO_TEXT_RATIO = 6
+_MAX_AUDIO_TEXT_SLACK = 10
 
 try:
     from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
@@ -38,9 +42,6 @@ except ModuleNotFoundError as error:
         decode_input_embeds: list[torch.Tensor] = field(default_factory=list)
         stage_payload: Any = None
         pending_feedback_queue: Any = field(default_factory=collections.deque)
-
-
-from sglang_omni.utils.audio_payload import audio_waveform_payload
 
 
 def _config_value(config: Any, name: str, default: Any = None) -> Any:
@@ -240,6 +241,16 @@ def validate_prompt_length(
         )
 
 
+def cap_generation_length(target_token_count: int, max_new_tokens: int) -> int:
+    """Apply the official VoxCPM text-relative generation safety bound."""
+    if target_token_count < 1:
+        raise ValueError("VoxCPM target_token_count must be positive")
+    return min(
+        int(max_new_tokens),
+        target_token_count * _MAX_AUDIO_TEXT_RATIO + _MAX_AUDIO_TEXT_SLACK,
+    )
+
+
 def make_voxcpm_scheduler_adapters(
     *,
     model: Any,
@@ -289,7 +300,11 @@ def make_voxcpm_scheduler_adapters(
 
         stop_id = int(getattr(tokenizer, "eos_token_id", None) or 2)
         continue_id = int(_config_value(config, "audio_start_token", 101))
-        max_new_tokens = int(kwargs["max_new_tokens"])
+        max_new_tokens = cap_generation_length(
+            len(tokenizer.encode(state.target_text)),
+            int(kwargs["max_new_tokens"]),
+        )
+        kwargs["max_new_tokens"] = max_new_tokens
         max_model_len = int(_config_value(config, "max_position_embeddings", 32768))
         validate_prompt_length(int(input_ids.shape[0]), max_new_tokens, max_model_len)
         sampling = SamplingParams(

--- a/sglang_omni/models/voxcpm_common/engine_io.py
+++ b/sglang_omni/models/voxcpm_common/engine_io.py
@@ -1,0 +1,380 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prompt construction and SGLang scheduler adapters for VoxCPM."""
+
+from __future__ import annotations
+
+import base64
+import collections
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+import torch
+
+from sglang_omni.models.voxcpm_common.payload_types import VoxCPMState
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.pipeline_state import build_usage
+
+try:
+    from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
+except ModuleNotFoundError as error:
+    if error.name != "sglang":
+        raise
+    from sglang_omni.scheduling.types import ARRequestData
+
+    @dataclass
+    class SGLangARRequestData(ARRequestData):  # type: ignore[no-redef]
+        """CPU import fallback; serving replaces this with the backend class."""
+
+        req: Any = None
+        synced: bool = False
+        generation_steps: int = 0
+        suppress_tokens: list[int] | None = None
+        top_p: float = 1.0
+        top_k: int = -1
+        repetition_penalty: float = 1.0
+        input_embeds_are_projected: bool = False
+        prefill_input_embeds: torch.Tensor | None = None
+        decode_input_embeds: list[torch.Tensor] = field(default_factory=list)
+        stage_payload: Any = None
+        pending_feedback_queue: Any = field(default_factory=collections.deque)
+
+
+from sglang_omni.utils.audio_payload import audio_waveform_payload
+
+
+def _config_value(config: Any, name: str, default: Any = None) -> Any:
+    if config is None:
+        return default
+    value = (
+        config.get(name, default)
+        if isinstance(config, dict)
+        else getattr(config, name, default)
+    )
+    return default if value is None else value
+
+
+class CJKSplitTokenizer:
+    """AutoTokenizer adapter that splits pure multi-CJK vocabulary entries."""
+
+    def __init__(self, tokenizer: Any) -> None:
+        self.tokenizer = tokenizer
+        vocabulary = tokenizer.get_vocab()
+        self.multichar_cjk = {
+            token
+            for token in vocabulary
+            if len(token.replace("▁", "")) >= 2
+            and all(_is_cjk(char) for char in token.replace("▁", ""))
+        }
+
+    def encode(self, text: str) -> list[int]:
+        tokens = self.tokenizer.tokenize(text)
+        split: list[str] = []
+        for token in tokens:
+            clean = token.replace("▁", "")
+            if token in self.multichar_cjk or clean in self.multichar_cjk:
+                split.extend(list(clean))
+            else:
+                split.append(token)
+        ids = self.tokenizer.convert_tokens_to_ids(split)
+        return [int(item) for item in ids]
+
+    def __len__(self) -> int:
+        return len(self.tokenizer)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.tokenizer, name)
+
+
+def _is_cjk(char: str) -> bool:
+    value = ord(char)
+    return (
+        0x3400 <= value <= 0x4DBF
+        or 0x4E00 <= value <= 0x9FFF
+        or 0xF900 <= value <= 0xFAFF
+        or 0x3040 <= value <= 0x30FF
+        or 0xAC00 <= value <= 0xD7AF
+    )
+
+
+def load_voxcpm_tokenizer(checkpoint_dir: str) -> CJKSplitTokenizer:
+    from transformers import AutoTokenizer
+
+    return CJKSplitTokenizer(
+        AutoTokenizer.from_pretrained(checkpoint_dir, trust_remote_code=True)
+    )
+
+
+@dataclass
+class VoxCPMSGLangRequestData(SGLangARRequestData):
+    enforce_request_limits: bool = True
+    state: VoxCPMState | None = None
+    feat: torch.Tensor | None = None
+    feat_mask: torch.Tensor | None = None
+    initial_decode_context: torch.Tensor | None = None
+    row_id: int | None = None
+    continue_token_id: int = 0
+    stop_token_id: int = 0
+    engine_start_s: float = 0.0
+    generated_latents: list[torch.Tensor] = field(default_factory=list)
+    generated_audio: list[torch.Tensor] = field(default_factory=list)
+    stop_step: int | None = None
+    finish_kind: str | None = None
+    is_streaming: bool = False
+
+
+def _audio_source(reference: Any) -> Any:
+    if not isinstance(reference, dict):
+        return reference
+    if reference.get("audio_path") is not None:
+        return reference["audio_path"]
+    if reference.get("bytes") is not None:
+        return bytes(reference["bytes"])
+    if reference.get("data") is not None:
+        return base64.b64decode(reference["data"], validate=True)
+    raise ValueError("VoxCPM reference audio is empty")
+
+
+def _encode_reference(
+    reference: Any,
+    *,
+    vae: Any,
+    device: torch.device,
+    patch_size: int,
+    feat_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from sglang_omni.utils.audio import load_audio
+
+    waveform = load_audio(
+        _audio_source(reference),
+        source_name="VoxCPM reference",
+        target_sample_rate=int(vae.sample_rate),
+        mono=True,
+    )
+    wav = torch.as_tensor(waveform, dtype=torch.float32, device=device).reshape(1, -1)
+    align = int(patch_size) * int(vae.encoder_chunk_size)
+    left_pad = (-int(wav.shape[-1])) % align
+    if left_pad:
+        wav = torch.nn.functional.pad(wav, (left_pad, 0))
+    with torch.inference_mode():
+        flat = (
+            vae.encode(wav, int(vae.sample_rate))
+            .transpose(1, 2)
+            .reshape(-1, feat_dim)
+            .float()
+        )
+    return flat.reshape(-1, patch_size, feat_dim), flat
+
+
+def build_prompt_tensors(
+    *,
+    variant: str,
+    tokenizer: CJKSplitTokenizer,
+    target_text: str,
+    reference_text: str | None,
+    reference_mode: str,
+    reference_latents: torch.Tensor | None,
+    patch_size: int,
+    feat_dim: int,
+    audio_start_token_id: int = 101,
+    ref_audio_start_token_id: int = 103,
+    ref_audio_end_token_id: int = 104,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    """Return exact text ids, aligned feature rows, masks and decoder context."""
+    continuation = reference_mode == "continuation" and reference_latents is not None
+    text = (reference_text or "") + target_text if continuation else target_text
+    text_ids = tokenizer.encode(text) + [int(audio_start_token_id)]
+    zeros = torch.zeros(len(text_ids), patch_size, feat_dim, dtype=torch.float32)
+    mask = torch.zeros(len(text_ids), dtype=torch.bool)
+    decode_context = None
+
+    if reference_latents is None:
+        ids = text_ids
+        feat = zeros
+    elif variant == "voxcpm2" and reference_mode == "isolated":
+        count = int(reference_latents.shape[0])
+        ids = (
+            [int(ref_audio_start_token_id)]
+            + [0] * count
+            + [int(ref_audio_end_token_id)]
+            + text_ids
+        )
+        padding = torch.zeros(1, patch_size, feat_dim, dtype=torch.float32)
+        feat = torch.cat((padding, reference_latents.cpu(), padding, zeros), 0)
+        mask = torch.cat(
+            (
+                torch.zeros(1, dtype=torch.bool),
+                torch.ones(count, dtype=torch.bool),
+                torch.zeros(1 + len(text_ids), dtype=torch.bool),
+            )
+        )
+    else:
+        count = int(reference_latents.shape[0])
+        ids = text_ids + [0] * count
+        feat = torch.cat((zeros, reference_latents.cpu()), 0)
+        mask = torch.cat(
+            (
+                torch.zeros(len(text_ids), dtype=torch.bool),
+                torch.ones(count, dtype=torch.bool),
+            )
+        )
+        context_frames = 4 if variant == "voxcpm" else 12
+        decode_context = reference_latents.reshape(-1, feat_dim)[
+            -context_frames:
+        ].contiguous()
+
+    if not (len(ids) == feat.shape[0] == mask.shape[0]):
+        raise RuntimeError("VoxCPM prompt ids/features/mask length mismatch")
+    return torch.tensor(ids, dtype=torch.long), feat, mask, decode_context
+
+
+def validate_prompt_length(
+    prompt_len: int, max_new_tokens: int, max_model_len: int
+) -> None:
+    if prompt_len > max_model_len:
+        raise ValueError(f"VoxCPM prompt is too long: {prompt_len} > {max_model_len}")
+    if prompt_len + max_new_tokens > max_model_len:
+        raise ValueError(
+            "VoxCPM prompt plus max_new_tokens exceeds model context: "
+            f"{prompt_len} + {max_new_tokens} > {max_model_len}"
+        )
+
+
+def make_voxcpm_scheduler_adapters(
+    *,
+    model: Any,
+    tokenizer: CJKSplitTokenizer,
+    vae: Any,
+    variant: str,
+    reset_request: Callable[[str], None],
+):
+    def request_builder(payload: StagePayload) -> VoxCPMSGLangRequestData:
+        from sglang.srt.managers.schedule_batch import Req
+        from sglang.srt.sampling.sampling_params import SamplingParams
+
+        state = VoxCPMState.from_dict(payload.data)
+        kwargs = state.generation_kwargs
+        patch_size = int(model.model.patch_size)
+        feat_dim = int(model.model.feat_dim)
+        device = next(model.parameters()).device
+        reference_latents = None
+        flat_reference = None
+        if state.reference_audio is not None:
+            reference_latents, flat_reference = _encode_reference(
+                state.reference_audio,
+                vae=vae,
+                device=device,
+                patch_size=patch_size,
+                feat_dim=feat_dim,
+            )
+        config = getattr(model, "config", None)
+        input_ids, feat, feat_mask, decode_context = build_prompt_tensors(
+            variant=variant,
+            tokenizer=tokenizer,
+            target_text=state.target_text,
+            reference_text=state.reference_text,
+            reference_mode=state.reference_mode,
+            reference_latents=reference_latents,
+            patch_size=patch_size,
+            feat_dim=feat_dim,
+            audio_start_token_id=int(_config_value(config, "audio_start_token", 101)),
+            ref_audio_start_token_id=int(
+                _config_value(config, "ref_audio_start_token", 103)
+            ),
+            ref_audio_end_token_id=int(
+                _config_value(config, "ref_audio_end_token", 104)
+            ),
+        )
+        del flat_reference
+
+        stop_id = int(getattr(tokenizer, "eos_token_id", None) or 2)
+        continue_id = int(_config_value(config, "audio_start_token", 101))
+        max_new_tokens = int(kwargs["max_new_tokens"])
+        max_model_len = int(_config_value(config, "max_position_embeddings", 32768))
+        validate_prompt_length(int(input_ids.shape[0]), max_new_tokens, max_model_len)
+        sampling = SamplingParams(
+            max_new_tokens=max_new_tokens,
+            temperature=0.0,
+            stop_token_ids=[stop_id],
+        )
+        sampling.normalize(None)
+        vocab_size = int(
+            _config_value(
+                _config_value(config, "lm_config", None), "vocab_size", len(tokenizer)
+            )
+        )
+        sampling.verify(vocab_size)
+        req = Req(
+            rid=payload.request_id,
+            origin_input_text="",
+            origin_input_ids=input_ids.tolist(),
+            sampling_params=sampling,
+            eos_token_ids={stop_id},
+            vocab_size=vocab_size,
+            extra_key=f"voxcpm-continuous:{payload.request_id}",
+        )
+        req.tokenizer = None
+        req._input_embeds_are_projected = True
+        data = VoxCPMSGLangRequestData(
+            input_ids=input_ids,
+            max_new_tokens=max_new_tokens,
+            temperature=0.0,
+            output_ids=req.output_ids,
+            req=req,
+            state=state,
+            feat=feat,
+            feat_mask=feat_mask,
+            initial_decode_context=decode_context,
+            continue_token_id=continue_id,
+            stop_token_id=stop_id,
+            engine_start_s=time.perf_counter(),
+            input_embeds_are_projected=True,
+            is_streaming=bool((payload.request.params or {}).get("stream", False)),
+        )
+        data.stage_payload = payload
+        return data
+
+    def result_adapter(data: VoxCPMSGLangRequestData) -> StagePayload:
+        request_id = data.stage_payload.request_id
+        try:
+            payload = data.stage_payload
+            state = data.state
+            waveform = (
+                torch.cat(data.generated_audio, dim=-1)
+                if data.generated_audio
+                else torch.empty(0, dtype=torch.float32)
+            )
+            sample_rate = int(vae.out_sample_rate)
+            state.audio_waveform = waveform
+            state.sample_rate = sample_rate
+            state.prompt_tokens = int(data.input_ids.shape[0])
+            state.completion_tokens = len(data.generated_latents)
+            state.engine_time_s = time.perf_counter() - data.engine_start_s
+            payload.data = state.to_dict()
+            payload.data.update(
+                audio_waveform_payload(
+                    waveform,
+                    sample_rate=sample_rate,
+                    modality="audio",
+                    source_hint="VoxCPM",
+                )
+            )
+            usage = build_usage(state)
+            if usage is not None:
+                payload.data["usage"] = usage
+            payload.data["finish_reason"] = data.finish_kind or "stop"
+            return payload
+        finally:
+            reset_request(request_id)
+
+    return request_builder, result_adapter
+
+
+__all__ = [
+    "CJKSplitTokenizer",
+    "VoxCPMSGLangRequestData",
+    "build_prompt_tensors",
+    "load_voxcpm_tokenizer",
+    "make_voxcpm_scheduler_adapters",
+    "validate_prompt_length",
+]

--- a/sglang_omni/models/voxcpm_common/hf_config.py
+++ b/sglang_omni/models/voxcpm_common/hf_config.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Transformers config adapters for official VoxCPM checkpoints."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from transformers import AutoConfig, PretrainedConfig
+
+
+def _config_object(value: Any) -> Any:
+    if isinstance(value, dict):
+        return PretrainedConfig.from_dict(
+            {key: _config_object(item) for key, item in value.items()}
+        )
+    if isinstance(value, list):
+        return [_config_object(item) for item in value]
+    return value
+
+
+class _VoxCPMConfigBase(PretrainedConfig):
+    architectures: list[str] | None = None
+    architecture: str | None = None
+    default_architecture: ClassVar[str] = ""
+
+    def __init__(self, **kwargs: Any) -> None:
+        raw_architectures = kwargs.pop("architectures", None)
+        raw_architecture = kwargs.pop("architecture", None)
+        lm_config = kwargs.get("lm_config")
+        if isinstance(lm_config, dict):
+            for field_name in (
+                "hidden_size",
+                "num_attention_heads",
+                "num_key_value_heads",
+                "num_hidden_layers",
+                "max_position_embeddings",
+                "vocab_size",
+                "rms_norm_eps",
+                "rope_theta",
+            ):
+                if field_name in lm_config:
+                    kwargs.setdefault(field_name, lm_config[field_name])
+            kwargs.setdefault(
+                "head_dim",
+                lm_config.get(
+                    "kv_channels",
+                    int(lm_config["hidden_size"])
+                    // int(lm_config["num_attention_heads"]),
+                ),
+            )
+        nested = {key: _config_object(value) for key, value in kwargs.items()}
+        super().__init__(**nested)
+        self.architecture = raw_architecture or self.model_type
+        self.architectures = list(raw_architectures or [self.default_architecture])
+
+    @classmethod
+    def from_dict(cls, config_dict: dict[str, Any], **kwargs: Any) -> Any:
+        values = dict(config_dict)
+        values.setdefault("architectures", [cls.default_architecture])
+        lm_config = values.get("lm_config")
+        if isinstance(lm_config, dict):
+            for field_name in (
+                "hidden_size",
+                "num_attention_heads",
+                "num_key_value_heads",
+                "num_hidden_layers",
+                "max_position_embeddings",
+                "vocab_size",
+                "rms_norm_eps",
+                "rope_theta",
+            ):
+                if field_name in lm_config:
+                    values.setdefault(field_name, lm_config[field_name])
+            values.setdefault(
+                "head_dim",
+                lm_config.get(
+                    "kv_channels",
+                    int(lm_config["hidden_size"])
+                    // int(lm_config["num_attention_heads"]),
+                ),
+            )
+        return super().from_dict(values, **kwargs)
+
+
+class VoxCPMConfig(_VoxCPMConfigBase):
+    model_type = "voxcpm"
+    default_architecture = "VoxCPMSGLangModel"
+
+
+class VoxCPM2Config(_VoxCPMConfigBase):
+    model_type = "voxcpm2"
+    default_architecture = "VoxCPM2SGLangModel"
+
+
+def register_voxcpm_configs() -> None:
+    for model_type, config_cls in (
+        ("voxcpm", VoxCPMConfig),
+        ("voxcpm2", VoxCPM2Config),
+    ):
+        try:
+            AutoConfig.register(model_type, config_cls)
+        except ValueError:
+            # Idempotent in worker processes and compatible with an upstream
+            # Transformers release that may learn the same model type.
+            pass
+
+
+__all__ = ["VoxCPM2Config", "VoxCPMConfig", "register_voxcpm_configs"]

--- a/sglang_omni/models/voxcpm_common/model_runner.py
+++ b/sglang_omni/models/voxcpm_common/model_runner.py
@@ -1,0 +1,370 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SGLang-native recurrent runner for VoxCPM continuous acoustic latents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.scheduling.messages import OutgoingMessage
+from sglang_omni.utils.audio_payload import audio_waveform_payload
+
+_MASK64 = (1 << 64) - 1
+
+
+def derive_step_seed(seed: int, step: int) -> int:
+    value = (int(seed) & _MASK64) ^ ((int(step) + 0x9E3779B97F4A7C15) & _MASK64)
+    value = (value + 0x9E3779B97F4A7C15) & _MASK64
+    value = ((value ^ (value >> 30)) * 0xBF58476D1CE4E5B9) & _MASK64
+    value = ((value ^ (value >> 27)) * 0x94D049BB133111EB) & _MASK64
+    return (value ^ (value >> 31)) & _MASK64
+
+
+@dataclass
+class _RequestRuntime:
+    row: int
+    generated: list[torch.Tensor] = field(default_factory=list)
+    audio: list[torch.Tensor] = field(default_factory=list)
+    stream_pending: list[torch.Tensor] = field(default_factory=list)
+    decoder_initialized: bool = False
+
+
+class VoxCPMModelRunner(ModelRunner):
+    """Runs one batched CFM sample and one incremental VAE decode per AR step."""
+
+    def __init__(self, tp_worker: Any, output_processor: Any, *, variant: str):
+        super().__init__(tp_worker, output_processor)
+        self.variant = variant
+        self._states: dict[str, _RequestRuntime] = {}
+        self._outbox: Any | None = None
+        self._vae = self.model.model.vae
+        self._decoder = self.model.model.vae_streaming_decoder
+        if self._vae is None or self._decoder is None:
+            raise RuntimeError("VoxCPM runner requires an attached streaming AudioVAE")
+
+    def set_stream_outbox(self, outbox: Any) -> None:
+        self._outbox = outbox
+
+    def reset_request(self, request_id: str) -> None:
+        runtime = self._states.pop(request_id, None)
+        if self._decoder is not None:
+            self._decoder.release(request_id)
+        self.model.reset_request(request_id)
+        del runtime
+
+    def before_prefill(
+        self, forward_batch: Any, schedule_batch: Any, requests: list
+    ) -> None:
+        del forward_batch, schedule_batch
+        for sched_req in requests:
+            if sched_req.request_id not in self._states:
+                row = int(self.model.acquire_row(sched_req.request_id))
+                self._states[sched_req.request_id] = _RequestRuntime(row=row)
+            sched_req.data.row_id = self._states[sched_req.request_id].row
+
+    def custom_prefill_forward(
+        self, forward_batch: Any, schedule_batch: Any, requests: list
+    ) -> Any:
+        del schedule_batch
+        embeddings: list[torch.Tensor] = []
+        features: list[torch.Tensor] = []
+        masks: list[torch.Tensor] = []
+        embedding = self.model.get_input_embeddings()
+        weight = next(embedding.parameters())
+
+        for sched_req in requests:
+            data = sched_req.data
+            req = data.req
+            prefix = len(req.prefix_indices)
+            extend = int(req.extend_input_len)
+            stop = prefix + extend
+            runtime = self._states[sched_req.request_id]
+
+            prompt_ids = data.input_ids
+            generated_count = len(runtime.generated)
+            generated_ids = torch.full(
+                (generated_count,),
+                int(data.continue_token_id),
+                dtype=torch.long,
+            )
+            all_ids = torch.cat((prompt_ids.cpu(), generated_ids), 0)
+            prompt_feat = data.feat
+            if runtime.generated:
+                generated_feat = torch.stack(runtime.generated, 0)
+                all_feat = torch.cat((prompt_feat, generated_feat), 0)
+                all_mask = torch.cat(
+                    (
+                        data.feat_mask,
+                        torch.ones(generated_count, dtype=torch.bool),
+                    ),
+                    0,
+                )
+            else:
+                all_feat, all_mask = prompt_feat, data.feat_mask
+            if stop > all_ids.shape[0]:
+                raise RuntimeError(
+                    f"VoxCPM re-prefill range exceeds request history for {sched_req.request_id}"
+                )
+            ids = all_ids[prefix:stop].to(weight.device)
+            embeddings.append(embedding(ids).to(dtype=weight.dtype))
+            features.append(all_feat[prefix:stop].to(weight.device, weight.dtype))
+            masks.append(all_mask[prefix:stop].to(weight.device))
+
+        input_embeds = torch.cat(embeddings, 0)
+        feat = torch.cat(features, 0)
+        feat_mask = torch.cat(masks, 0)
+        row_ids = torch.tensor(
+            [self._states[req.request_id].row for req in requests],
+            dtype=torch.long,
+            device=forward_batch.input_ids.device,
+        )
+        return self._forward(
+            forward_batch,
+            input_embeds=input_embeds,
+            feat=feat,
+            feat_mask=feat_mask,
+            row_ids=row_ids,
+        )
+
+    def _forward(
+        self,
+        forward_batch: Any,
+        *,
+        input_embeds: torch.Tensor,
+        feat: torch.Tensor,
+        feat_mask: torch.Tensor,
+        row_ids: torch.Tensor,
+    ) -> Any:
+        from sglang.srt.managers.scheduler import GenerationBatchResult
+
+        backend = self.tp_worker.model_runner.attn_backend
+        backend.init_forward_metadata(forward_batch)
+        positions = (
+            forward_batch.mrope_positions
+            if forward_batch.mrope_positions is not None
+            else forward_batch.positions
+        )
+        output = self.model(
+            input_ids=forward_batch.input_ids,
+            positions=positions,
+            forward_batch=forward_batch,
+            input_embeds=input_embeds,
+            feat=feat,
+            feat_mask=feat_mask,
+            row_ids=row_ids,
+        )
+        return GenerationBatchResult(logits_output=output, can_run_cuda_graph=False)
+
+    def before_decode(
+        self,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list,
+        *,
+        is_lookahead: bool = False,
+    ) -> None:
+        del schedule_batch
+        if is_lookahead:
+            raise RuntimeError("VoxCPM async lookahead is unsupported")
+        rows = torch.tensor(
+            [self._states[req.request_id].row for req in requests],
+            dtype=torch.long,
+            device=forward_batch.input_ids.device,
+        )
+        forward_batch.input_ids[: len(requests)].copy_(rows)
+
+    def post_prefill(
+        self, result: Any, forward_batch: Any, schedule_batch: Any, requests: list
+    ) -> None:
+        if bool(getattr(schedule_batch, "is_prefill_only", False)):
+            return
+        self._collect_step(result, forward_batch, schedule_batch, requests)
+
+    def post_decode(
+        self, result: Any, forward_batch: Any, schedule_batch: Any, requests: list
+    ) -> None:
+        self._collect_step(result, forward_batch, schedule_batch, requests)
+
+    def finalize_skip_rids(self, scheduler_output: Any) -> set[str]:
+        batch = getattr(scheduler_output, "batch_data", None)
+        if bool(getattr(batch, "is_prefill_only", False)):
+            return {req.request_id for req in scheduler_output.requests}
+        return set()
+
+    def _collect_step(
+        self,
+        result: Any,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list,
+    ) -> None:
+        del forward_batch
+        if not requests:
+            return
+        hidden = result.logits_output.hidden_states
+        if hidden.ndim == 3:
+            hidden = hidden[:, -1]
+        device, dtype = hidden.device, hidden.dtype
+        rows = torch.tensor(
+            [self._states[req.request_id].row for req in requests],
+            dtype=torch.long,
+            device=device,
+        )
+        temperatures = torch.tensor(
+            [
+                float(req.data.state.generation_kwargs["temperature"])
+                for req in requests
+            ],
+            dtype=dtype,
+            device=device,
+        )
+        cfg_values = torch.tensor(
+            [float(req.data.state.generation_kwargs["cfg_value"]) for req in requests],
+            dtype=dtype,
+            device=device,
+        )
+        noise = torch.empty(
+            len(requests),
+            int(self.model.model.feat_dim),
+            int(self.model.model.patch_size),
+            dtype=dtype,
+            device=device,
+        )
+        for index, sched_req in enumerate(requests):
+            values = sched_req.data.state.generation_kwargs
+            seed = values.get("seed")
+            if seed is None or int(seed) < 0:
+                noise[index].normal_()
+            else:
+                generator = torch.Generator(device=device)
+                generator.manual_seed(
+                    derive_step_seed(int(seed), int(sched_req.data.generation_steps))
+                )
+                noise[index].copy_(
+                    torch.randn(
+                        noise[index].shape,
+                        generator=generator,
+                        dtype=dtype,
+                        device=device,
+                    )
+                )
+        generated = self._generate_grouped(
+            hidden=hidden,
+            rows=rows,
+            temperatures=temperatures,
+            cfg_values=cfg_values,
+            noise=noise,
+            requests=requests,
+        )
+        latents = generated["latents"]
+        stop_flags = generated["stop_flag"].detach().cpu().tolist()
+        initial_contexts = []
+        for sched_req in requests:
+            runtime = self._states[sched_req.request_id]
+            context = sched_req.data.initial_decode_context
+            initial_contexts.append(
+                None
+                if runtime.decoder_initialized or context is None
+                else context.to(device=device, dtype=torch.float32)
+                .transpose(0, 1)
+                .unsqueeze(0)
+            )
+        audio_batch = (
+            self._decoder.decode_chunks(
+                latents.float().transpose(1, 2),
+                [req.request_id for req in requests],
+                initial_contexts,
+            )
+            .detach()
+            .to("cpu", torch.float32)
+        )
+
+        next_ids: list[int] = []
+        for index, sched_req in enumerate(requests):
+            data = sched_req.data
+            runtime = self._states[sched_req.request_id]
+            runtime.decoder_initialized = True
+            latent = latents[index].detach().to("cpu", torch.float32)
+            audio = audio_batch[index].reshape(-1).contiguous()
+            runtime.generated.append(latent)
+            runtime.audio.append(audio)
+            data.generated_latents.append(latent)
+            data.generated_audio.append(audio)
+            step_count = int(data.generation_steps) + 1
+            values = data.state.generation_kwargs
+            stopped = bool(stop_flags[index]) and step_count >= int(values["min_len"])
+            at_limit = step_count >= int(values["max_new_tokens"])
+            if stopped:
+                data.stop_step = step_count - 1
+                data.finish_kind = "stop"
+            elif at_limit:
+                data.finish_kind = "length"
+            next_ids.append(
+                int(data.stop_token_id)
+                if stopped or at_limit
+                else int(data.continue_token_id)
+            )
+            if data.is_streaming:
+                runtime.stream_pending.append(audio)
+                prefix = int(values.get("streaming_prefix_len", 1))
+                if len(runtime.audio) >= prefix or stopped or at_limit:
+                    self._emit_audio(sched_req.request_id, runtime.stream_pending)
+                    runtime.stream_pending.clear()
+
+        next_token_ids = torch.tensor(next_ids, dtype=torch.long, device=device)
+        result.next_token_ids = next_token_ids
+        schedule_batch.output_ids = next_token_ids
+
+    def _generate_grouped(
+        self,
+        *,
+        hidden: torch.Tensor,
+        rows: torch.Tensor,
+        temperatures: torch.Tensor,
+        cfg_values: torch.Tensor,
+        noise: torch.Tensor,
+        requests: list,
+    ) -> dict[str, torch.Tensor]:
+        """Honor mixed per-request CFM step counts without sharing mutable state."""
+        inference_timesteps = torch.tensor(
+            [
+                int(req.data.state.generation_kwargs["inference_timesteps"])
+                for req in requests
+            ],
+            dtype=torch.long,
+            device=hidden.device,
+        )
+        return self.model.generate_batch(
+            hidden,
+            rows,
+            temperature=temperatures,
+            cfg_value=cfg_values,
+            z_noise=noise,
+            inference_timesteps=inference_timesteps,
+        )
+
+    def _emit_audio(self, request_id: str, chunks: list[torch.Tensor]) -> None:
+        if self._outbox is None or not chunks:
+            return
+        sample_rate = int(self._vae.out_sample_rate)
+        waveform = torch.cat(chunks, -1)
+        self._outbox.put(
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                target=None,
+                data=audio_waveform_payload(
+                    waveform,
+                    sample_rate=sample_rate,
+                    modality="audio",
+                    source_hint="VoxCPM streaming",
+                ),
+                metadata={"modality": "audio"},
+            )
+        )
+
+
+__all__ = ["VoxCPMModelRunner", "derive_step_seed"]

--- a/sglang_omni/models/voxcpm_common/model_runner.py
+++ b/sglang_omni/models/voxcpm_common/model_runner.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -29,17 +30,32 @@ class _RequestRuntime:
     generated: list[torch.Tensor] = field(default_factory=list)
     audio: list[torch.Tensor] = field(default_factory=list)
     stream_pending: list[torch.Tensor] = field(default_factory=list)
+    pending_vae_latents: list[torch.Tensor] = field(default_factory=list)
     decoder_initialized: bool = False
+    launched_steps: int = 0
+
+
+@dataclass
+class _AsyncStep:
+    host_buffer: torch.Tensor
+    latent_shape: tuple[int, int]
+    audio_width: int
+    step_counts: list[int]
 
 
 class VoxCPMModelRunner(ModelRunner):
-    """Runs one batched CFM sample and one incremental VAE decode per AR step."""
+    """Runs batched CFM samples and configurable incremental VAE decode groups."""
 
     def __init__(self, tp_worker: Any, output_processor: Any, *, variant: str):
         super().__init__(tp_worker, output_processor)
         self.variant = variant
         self._states: dict[str, _RequestRuntime] = {}
         self._outbox: Any | None = None
+        self._collect_device_staging: torch.Tensor | None = None
+        self._latent_collect_staging: torch.Tensor | None = None
+        self._vae_decode_every = max(
+            1, int(os.getenv("SGLANG_VOXCPM_VAE_DECODE_EVERY", "1"))
+        )
         self._vae = self.model.model.vae
         self._decoder = self.model.model.vae_streaming_decoder
         if self._vae is None or self._decoder is None:
@@ -59,11 +75,34 @@ class VoxCPMModelRunner(ModelRunner):
         self, forward_batch: Any, schedule_batch: Any, requests: list
     ) -> None:
         del forward_batch, schedule_batch
+        rows = []
+        temperatures = []
+        cfg_values = []
+        seeds = []
         for sched_req in requests:
             if sched_req.request_id not in self._states:
                 row = int(self.model.acquire_row(sched_req.request_id))
                 self._states[sched_req.request_id] = _RequestRuntime(row=row)
-            sched_req.data.row_id = self._states[sched_req.request_id].row
+            row = self._states[sched_req.request_id].row
+            sched_req.data.row_id = row
+            values = sched_req.data.state.generation_kwargs
+            rows.append(row)
+            temperatures.append(float(values["temperature"]))
+            cfg_values.append(float(values["cfg_value"]))
+            seed = values.get("seed")
+            seeds.append(-1 if seed is None else int(seed))
+        if rows:
+            pool = self.model.model.state_pool
+            pool.configure(
+                rows,
+                temperature=torch.tensor(
+                    temperatures, device=pool.feedback.device, dtype=pool.feedback.dtype
+                ),
+                cfg_value=torch.tensor(
+                    cfg_values, device=pool.feedback.device, dtype=pool.feedback.dtype
+                ),
+                seed=torch.tensor(seeds, device=pool.feedback.device, dtype=torch.long),
+            )
 
     def custom_prefill_forward(
         self, forward_batch: Any, schedule_batch: Any, requests: list
@@ -167,14 +206,22 @@ class VoxCPMModelRunner(ModelRunner):
         is_lookahead: bool = False,
     ) -> None:
         del schedule_batch
-        if is_lookahead:
-            raise RuntimeError("VoxCPM async lookahead is unsupported")
         rows = torch.tensor(
             [self._states[req.request_id].row for req in requests],
             dtype=torch.long,
             device=forward_batch.input_ids.device,
         )
+        if is_lookahead and rows.numel():
+            pool = self.model.model.state_pool
+            done = pool.done.index_select(0, rows)
+            rows = torch.where(
+                done,
+                torch.full_like(rows, int(pool.padding_row)),
+                rows,
+            )
         forward_batch.input_ids[: len(requests)].copy_(rows)
+        forward_batch.input_ids = forward_batch.input_ids[: len(requests)]
+        forward_batch.voxcpm_rows = rows
 
     def post_prefill(
         self, result: Any, forward_batch: Any, schedule_batch: Any, requests: list
@@ -187,6 +234,76 @@ class VoxCPMModelRunner(ModelRunner):
         self, result: Any, forward_batch: Any, schedule_batch: Any, requests: list
     ) -> None:
         self._collect_step(result, forward_batch, schedule_batch, requests)
+
+    def post_decode_launch(
+        self, result: Any, forward_batch: Any, requests: list
+    ) -> _AsyncStep | None:
+        if not requests:
+            return None
+        generated, step_counts = self._generate_step(
+            result,
+            requests,
+            rows=getattr(forward_batch, "voxcpm_rows", None),
+        )
+        staging, latent_shape, audio_width = self._decode_pack_gpu(
+            latents=generated["latents"],
+            stop_flags=generated["stop_flag"],
+            requests=requests,
+        )
+        host_buffer = self._next_host_staging(staging.shape, staging.dtype)
+        host_buffer[: len(requests)].copy_(staging, non_blocking=True)
+        return _AsyncStep(
+            host_buffer=host_buffer,
+            latent_shape=latent_shape,
+            audio_width=audio_width,
+            step_counts=step_counts,
+        )
+
+    def post_decode_resolve(
+        self,
+        launch_buf: _AsyncStep | None,
+        result: Any,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list,
+    ) -> None:
+        del forward_batch, schedule_batch
+        if launch_buf is None:
+            return
+        active = [
+            index
+            for index, req in enumerate(requests)
+            if not req.data.req.finished()
+            and not bool(getattr(req.data.req, "is_retracted", False))
+        ]
+        if not active:
+            return
+        self._collect_host(
+            packed_cpu=launch_buf.host_buffer,
+            latent_shape=launch_buf.latent_shape,
+            audio_width=launch_buf.audio_width,
+            step_counts=[launch_buf.step_counts[index] for index in active],
+            requests=[requests[index] for index in active],
+            source_indices=active,
+        )
+
+    def lookahead_eligible(self, batch: Any) -> bool:
+        if self._vae_decode_every > 1:
+            return False
+        reqs = getattr(batch, "reqs", None) or []
+        if not reqs or len(reqs) > int(
+            getattr(self.model, "diffusion_graph_max_bs", 0)
+        ):
+            return False
+        default_steps = int(self.model.model.feat_decoder.inference_timesteps)
+        for req in reqs:
+            data = getattr(req, "_omni_data", None)
+            if data is None:
+                continue
+            steps = int(data.state.generation_kwargs["inference_timesteps"])
+            if steps != default_steps:
+                return False
+        return super().lookahead_eligible(batch)
 
     def finalize_skip_rids(self, scheduler_output: Any) -> set[str]:
         batch = getattr(scheduler_output, "batch_data", None)
@@ -201,31 +318,42 @@ class VoxCPMModelRunner(ModelRunner):
         schedule_batch: Any,
         requests: list,
     ) -> None:
-        del forward_batch
         if not requests:
             return
+        generated, step_counts = self._generate_step(
+            result,
+            requests,
+            rows=getattr(forward_batch, "voxcpm_rows", None),
+        )
+        self._decode_and_collect(
+            latents=generated["latents"],
+            stop_flags=generated["stop_flag"],
+            step_counts=step_counts,
+            requests=requests,
+        )
+        schedule_batch.output_ids = result.next_token_ids
+
+    def _generate_step(
+        self,
+        result: Any,
+        requests: list,
+        *,
+        rows: torch.Tensor | None = None,
+    ) -> tuple[dict[str, torch.Tensor], list[int]]:
         hidden = result.logits_output.hidden_states
         if hidden.ndim == 3:
             hidden = hidden[:, -1]
+        hidden = hidden[: len(requests)]
         device, dtype = hidden.device, hidden.dtype
-        rows = torch.tensor(
-            [self._states[req.request_id].row for req in requests],
-            dtype=torch.long,
-            device=device,
-        )
-        temperatures = torch.tensor(
-            [
-                float(req.data.state.generation_kwargs["temperature"])
-                for req in requests
-            ],
-            dtype=dtype,
-            device=device,
-        )
-        cfg_values = torch.tensor(
-            [float(req.data.state.generation_kwargs["cfg_value"]) for req in requests],
-            dtype=dtype,
-            device=device,
-        )
+        if rows is None:
+            rows = torch.tensor(
+                [self._states[req.request_id].row for req in requests],
+                dtype=torch.long,
+                device=device,
+            )
+        pool = self.model.model.state_pool
+        temperatures = pool.temperature.index_select(0, rows)
+        cfg_values = pool.cfg_value.index_select(0, rows)
         noise = torch.empty(
             len(requests),
             int(self.model.model.feat_dim),
@@ -233,24 +361,44 @@ class VoxCPMModelRunner(ModelRunner):
             dtype=dtype,
             device=device,
         )
+        unseeded = []
+        step_counts = []
         for index, sched_req in enumerate(requests):
             values = sched_req.data.state.generation_kwargs
+            runtime = self._states[sched_req.request_id]
+            step_count = (
+                max(int(runtime.launched_steps), int(sched_req.data.generation_steps))
+                + 1
+            )
+            runtime.launched_steps = step_count
+            step_counts.append(step_count)
             seed = values.get("seed")
             if seed is None or int(seed) < 0:
-                noise[index].normal_()
-            else:
-                generator = torch.Generator(device=device)
-                generator.manual_seed(
-                    derive_step_seed(int(seed), int(sched_req.data.generation_steps))
+                unseeded.append(index)
+                continue
+            generator = torch.Generator(device=device)
+            generator.manual_seed(derive_step_seed(int(seed), step_count - 1))
+            noise[index].copy_(
+                torch.randn(
+                    noise[index].shape,
+                    generator=generator,
+                    dtype=dtype,
+                    device=device,
                 )
-                noise[index].copy_(
-                    torch.randn(
-                        noise[index].shape,
-                        generator=generator,
-                        dtype=dtype,
-                        device=device,
-                    )
-                )
+            )
+        if unseeded:
+            indices = torch.tensor(unseeded, dtype=torch.long, device=device)
+            noise.index_copy_(
+                0,
+                indices,
+                torch.randn(
+                    len(unseeded),
+                    noise.shape[1],
+                    noise.shape[2],
+                    dtype=dtype,
+                    device=device,
+                ),
+            )
         generated = self._generate_grouped(
             hidden=hidden,
             rows=rows,
@@ -259,8 +407,184 @@ class VoxCPMModelRunner(ModelRunner):
             noise=noise,
             requests=requests,
         )
-        latents = generated["latents"]
-        stop_flags = generated["stop_flag"].detach().cpu().tolist()
+        raw_stop = generated["stop_flag"].bool()
+        min_lengths = torch.tensor(
+            [int(req.data.state.generation_kwargs["min_len"]) for req in requests],
+            device=device,
+            dtype=torch.long,
+        )
+        max_lengths = torch.tensor(
+            [
+                int(req.data.state.generation_kwargs["max_new_tokens"])
+                for req in requests
+            ],
+            device=device,
+            dtype=torch.long,
+        )
+        steps = torch.tensor(step_counts, device=device, dtype=torch.long)
+        finished = (raw_stop & (steps >= min_lengths)) | (steps >= max_lengths)
+        finished |= rows == int(pool.padding_row)
+        pool.done.index_copy_(0, rows, finished)
+        stop_ids = torch.tensor(
+            [int(req.data.stop_token_id) for req in requests],
+            device=device,
+            dtype=torch.long,
+        )
+        continue_ids = torch.tensor(
+            [int(req.data.continue_token_id) for req in requests],
+            device=device,
+            dtype=torch.long,
+        )
+        result.next_token_ids = torch.where(finished, stop_ids, continue_ids)
+        return generated, step_counts
+
+    def _decode_and_collect(
+        self,
+        *,
+        latents: torch.Tensor,
+        stop_flags: torch.Tensor,
+        step_counts: list[int],
+        requests: list,
+    ) -> None:
+        if not requests:
+            return
+        if self._vae_decode_every > 1:
+            self._decode_and_collect_buffered(
+                latents=latents,
+                stop_flags=stop_flags,
+                step_counts=step_counts,
+                requests=requests,
+            )
+            return
+        staging, latent_shape, audio_width = self._decode_pack_gpu(
+            latents=latents,
+            stop_flags=stop_flags,
+            requests=requests,
+        )
+        packed_cpu = staging.to("cpu").contiguous()
+        self._collect_host(
+            packed_cpu=packed_cpu,
+            latent_shape=latent_shape,
+            audio_width=audio_width,
+            step_counts=step_counts,
+            requests=requests,
+            clone_rows=False,
+        )
+
+    def _decode_and_collect_buffered(
+        self,
+        *,
+        latents: torch.Tensor,
+        stop_flags: torch.Tensor,
+        step_counts: list[int],
+        requests: list,
+    ) -> None:
+        device = latents.device
+        latent_shape = (int(latents.shape[1]), int(latents.shape[2]))
+        latent_width = latent_shape[0] * latent_shape[1]
+        capacity = int(self.model.model.state_pool.capacity)
+        staging = self._latent_collect_staging
+        if (
+            staging is None
+            or staging.device != device
+            or staging.shape != (capacity, latent_width + 1)
+        ):
+            staging = torch.empty(
+                capacity,
+                latent_width + 1,
+                device=device,
+                dtype=torch.float32,
+            )
+            self._latent_collect_staging = staging
+        active = staging[: len(requests)]
+        torch.cat(
+            (
+                latents.detach().float().reshape(len(requests), latent_width),
+                stop_flags.detach().float().reshape(-1, 1),
+            ),
+            dim=1,
+            out=active,
+        )
+        packed_cpu = active.to("cpu").contiguous()
+
+        ready_groups: dict[int, list[tuple[Any, _RequestRuntime, bool, bool]]] = {}
+        for index, (sched_req, step_count) in enumerate(zip(requests, step_counts)):
+            data = sched_req.data
+            runtime = self._states[sched_req.request_id]
+            latent = packed_cpu[index, :latent_width].reshape(latent_shape)
+            runtime.generated.append(latent)
+            data.generated_latents.append(latent)
+            runtime.pending_vae_latents.append(latents[index].detach())
+
+            values = data.state.generation_kwargs
+            stopped = bool(packed_cpu[index, -1]) and step_count >= int(
+                values["min_len"]
+            )
+            at_limit = step_count >= int(values["max_new_tokens"])
+            if stopped:
+                data.stop_step = step_count - 1
+                data.finish_kind = "stop"
+            elif at_limit:
+                data.finish_kind = "length"
+
+            pending_count = len(runtime.pending_vae_latents)
+            if pending_count >= self._vae_decode_every or stopped or at_limit:
+                ready_groups.setdefault(pending_count, []).append(
+                    (sched_req, runtime, stopped, at_limit)
+                )
+
+        for group in ready_groups.values():
+            vae_input = torch.stack(
+                [
+                    torch.cat(runtime.pending_vae_latents, dim=0)
+                    for _, runtime, _, _ in group
+                ],
+                dim=0,
+            ).float()
+            initial_contexts = []
+            for sched_req, runtime, _, _ in group:
+                context = sched_req.data.initial_decode_context
+                initial_contexts.append(
+                    None
+                    if runtime.decoder_initialized or context is None
+                    else context.to(device=device, dtype=torch.float32)
+                    .transpose(0, 1)
+                    .unsqueeze(0)
+                )
+                runtime.decoder_initialized = True
+            audio_device = self._decoder.decode_chunks(
+                vae_input.transpose(1, 2),
+                [sched_req.request_id for sched_req, _, _, _ in group],
+                initial_contexts,
+            )
+            audio_cpu = audio_device.detach().float().to("cpu").contiguous()
+            for index, (sched_req, runtime, stopped, at_limit) in enumerate(group):
+                runtime.pending_vae_latents.clear()
+                audio = audio_cpu[index]
+                runtime.audio.append(audio)
+                sched_req.data.generated_audio.append(audio)
+                if sched_req.data.is_streaming:
+                    runtime.stream_pending.append(audio)
+                    prefix = int(
+                        sched_req.data.state.generation_kwargs.get(
+                            "streaming_prefix_len", 1
+                        )
+                    )
+                    decoded_patches = len(runtime.generated)
+                    if decoded_patches >= prefix or stopped or at_limit:
+                        self._emit_audio(sched_req.request_id, runtime.stream_pending)
+                        runtime.stream_pending.clear()
+
+    def _decode_pack_gpu(
+        self,
+        *,
+        latents: torch.Tensor,
+        stop_flags: torch.Tensor,
+        requests: list,
+    ) -> tuple[torch.Tensor, tuple[int, int], int]:
+        if not requests:
+            raise ValueError("cannot pack an empty VoxCPM decode batch")
+        device = latents.device
         initial_contexts = []
         for sched_req in requests:
             runtime = self._states[sched_req.request_id]
@@ -272,51 +596,87 @@ class VoxCPMModelRunner(ModelRunner):
                 .transpose(0, 1)
                 .unsqueeze(0)
             )
-        audio_batch = (
-            self._decoder.decode_chunks(
-                latents.float().transpose(1, 2),
-                [req.request_id for req in requests],
-                initial_contexts,
-            )
-            .detach()
-            .to("cpu", torch.float32)
+            runtime.decoder_initialized = True
+        audio_device = self._decoder.decode_chunks(
+            latents.float().transpose(1, 2),
+            [req.request_id for req in requests],
+            initial_contexts,
         )
+        latent_shape = (int(latents.shape[1]), int(latents.shape[2]))
+        latent_width = latent_shape[0] * latent_shape[1]
+        audio_width = audio_device[0].numel()
+        packed_width = latent_width + audio_width + 1
+        capacity = int(self.model.model.state_pool.capacity)
+        staging = self._collect_device_staging
+        if (
+            staging is None
+            or staging.device != device
+            or staging.shape != (capacity, packed_width)
+        ):
+            staging = torch.empty(
+                capacity,
+                packed_width,
+                device=device,
+                dtype=torch.float32,
+            )
+            self._collect_device_staging = staging
+        active = staging[: len(requests)]
+        torch.cat(
+            (
+                latents.detach().float().reshape(len(requests), latent_width),
+                audio_device.detach().float().reshape(len(requests), audio_width),
+                stop_flags.detach().float().reshape(-1, 1),
+            ),
+            dim=1,
+            out=active,
+        )
+        return active, latent_shape, int(audio_width)
 
-        next_ids: list[int] = []
-        for index, sched_req in enumerate(requests):
+    def _collect_host(
+        self,
+        *,
+        packed_cpu: torch.Tensor,
+        latent_shape: tuple[int, int],
+        audio_width: int,
+        step_counts: list[int],
+        requests: list,
+        source_indices: list[int] | None = None,
+        clone_rows: bool = True,
+    ) -> None:
+        latent_width = latent_shape[0] * latent_shape[1]
+        if source_indices is None:
+            source_indices = list(range(len(requests)))
+        for index, (source_index, sched_req) in enumerate(
+            zip(source_indices, requests)
+        ):
             data = sched_req.data
             runtime = self._states[sched_req.request_id]
-            runtime.decoder_initialized = True
-            latent = latents[index].detach().to("cpu", torch.float32)
-            audio = audio_batch[index].reshape(-1).contiguous()
+            row = packed_cpu[source_index]
+            latent = row[:latent_width].reshape(latent_shape)
+            audio = row[latent_width : latent_width + audio_width]
+            if clone_rows:
+                latent = latent.clone()
+                audio = audio.clone()
+            stop_flag = bool(row[-1])
             runtime.generated.append(latent)
             runtime.audio.append(audio)
             data.generated_latents.append(latent)
             data.generated_audio.append(audio)
-            step_count = int(data.generation_steps) + 1
+            step_count = step_counts[index]
             values = data.state.generation_kwargs
-            stopped = bool(stop_flags[index]) and step_count >= int(values["min_len"])
+            stopped = stop_flag and step_count >= int(values["min_len"])
             at_limit = step_count >= int(values["max_new_tokens"])
             if stopped:
                 data.stop_step = step_count - 1
                 data.finish_kind = "stop"
             elif at_limit:
                 data.finish_kind = "length"
-            next_ids.append(
-                int(data.stop_token_id)
-                if stopped or at_limit
-                else int(data.continue_token_id)
-            )
             if data.is_streaming:
                 runtime.stream_pending.append(audio)
                 prefix = int(values.get("streaming_prefix_len", 1))
                 if len(runtime.audio) >= prefix or stopped or at_limit:
                     self._emit_audio(sched_req.request_id, runtime.stream_pending)
                     runtime.stream_pending.clear()
-
-        next_token_ids = torch.tensor(next_ids, dtype=torch.long, device=device)
-        result.next_token_ids = next_token_ids
-        schedule_batch.output_ids = next_token_ids
 
     def _generate_grouped(
         self,
@@ -329,11 +689,31 @@ class VoxCPMModelRunner(ModelRunner):
         requests: list,
     ) -> dict[str, torch.Tensor]:
         """Honor mixed per-request CFM step counts without sharing mutable state."""
+        step_counts = [
+            int(req.data.state.generation_kwargs["inference_timesteps"])
+            for req in requests
+        ]
+        core_model = getattr(self.model, "model", self.model)
+        feat_decoder = getattr(core_model, "feat_decoder", None)
+        default_steps = (
+            None if feat_decoder is None else int(feat_decoder.inference_timesteps)
+        )
+        graph_max_bs = int(getattr(self.model, "diffusion_graph_max_bs", 0))
+        if (
+            step_counts
+            and default_steps is not None
+            and all(steps == default_steps for steps in step_counts)
+            and len(requests) <= graph_max_bs
+        ):
+            return self.model.generate_batch_graphed(
+                hidden,
+                rows,
+                temperature=temperatures,
+                cfg_value=cfg_values,
+                z_noise=noise,
+            )
         inference_timesteps = torch.tensor(
-            [
-                int(req.data.state.generation_kwargs["inference_timesteps"])
-                for req in requests
-            ],
+            step_counts,
             dtype=torch.long,
             device=hidden.device,
         )

--- a/sglang_omni/models/voxcpm_common/payload_types.py
+++ b/sglang_omni/models/voxcpm_common/payload_types.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Wire state shared by VoxCPM generations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from sglang_omni.scheduling.pipeline_state import DeclarativeStateBase, wire
+
+
+@dataclass
+class VoxCPMState(DeclarativeStateBase):
+    variant: str = wire("voxcpm", codec="str_or")
+    target_text: str = wire("", emit="truthy", codec="str")
+    reference_text: str | None = None
+    reference_audio: Any | None = None
+    reference_mode: str = wire("none", codec="str_or")
+    generation_kwargs: dict[str, Any] = wire(default_factory=dict, codec="dict")
+    audio_waveform: Any | None = wire(None, codec="typed_tensor")
+    # Filled from the loaded AudioVAE config by the terminal adapter.
+    sample_rate: int = wire(0, codec="int_or")
+
+
+__all__ = ["VoxCPMState"]

--- a/sglang_omni/models/voxcpm_common/request_builders.py
+++ b/sglang_omni/models/voxcpm_common/request_builders.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OpenAI speech payload lowering shared by VoxCPM and VoxCPM2."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sglang_omni.models.voxcpm_common.payload_types import VoxCPMState
+from sglang_omni.proto import StagePayload
+
+
+def build_voxcpm_state(payload: StagePayload, *, variant: str) -> VoxCPMState:
+    inputs = payload.request.inputs or {}
+    params = payload.request.params or {}
+    metadata = payload.request.metadata or {}
+    tts_params = metadata.get("tts_params")
+    if not isinstance(tts_params, dict):
+        tts_params = {}
+
+    text, references = _normalize_inputs(inputs)
+    if not text.strip():
+        raise ValueError(f"{variant} requires non-empty input text")
+    if len(references) > 1:
+        raise ValueError(f"{variant} accepts at most one reference audio")
+
+    reference = references[0] if references else None
+    if reference is None and tts_params.get("ref_audio") is not None:
+        reference = _reference_from_value(tts_params["ref_audio"])
+    reference_text = (
+        reference.get("text") if reference is not None else None
+    ) or tts_params.get("ref_text")
+
+    if reference is None:
+        reference_mode = "none"
+        reference_audio = None
+    else:
+        reference_audio = _normalize_reference_audio(reference)
+        if variant == "voxcpm":
+            reference_mode = "continuation"
+        else:
+            reference_mode = (
+                "continuation"
+                if isinstance(reference_text, str) and reference_text.strip()
+                else "isolated"
+            )
+
+    return VoxCPMState(
+        variant=variant,
+        target_text=text,
+        reference_text=(
+            reference_text.strip()
+            if isinstance(reference_text, str) and reference_text.strip()
+            else None
+        ),
+        reference_audio=reference_audio,
+        reference_mode=reference_mode,
+        generation_kwargs=build_generation_kwargs(
+            params, tts_params=tts_params, variant=variant
+        ),
+        # The terminal adapter resolves this from the loaded AudioVAE config.
+        sample_rate=0,
+    )
+
+
+def build_generation_kwargs(
+    params: dict[str, Any], *, tts_params: dict[str, Any], variant: str
+) -> dict[str, Any]:
+    defaults = {
+        "max_new_tokens": 4096 if variant == "voxcpm" else 8192,
+        "min_len": 2,
+        "inference_timesteps": 10,
+        "cfg_value": 2.0,
+        "temperature": 1.0,
+        "streaming_prefix_len": 3,
+    }
+    values = dict(defaults)
+    aliases = {
+        "max_len": "max_new_tokens",
+        "max_tokens": "max_new_tokens",
+    }
+    for source in (tts_params, params):
+        for field in defaults:
+            if source.get(field) is not None:
+                values[field] = source[field]
+        for alias, field in aliases.items():
+            if source.get(alias) is not None:
+                values[field] = source[alias]
+        if source.get("seed") is not None:
+            values["seed"] = source["seed"]
+
+    values["max_new_tokens"] = int(values["max_new_tokens"])
+    values["min_len"] = int(values["min_len"])
+    values["inference_timesteps"] = int(values["inference_timesteps"])
+    values["streaming_prefix_len"] = int(values["streaming_prefix_len"])
+    values["cfg_value"] = float(values["cfg_value"])
+    values["temperature"] = float(values["temperature"])
+    if "seed" in values:
+        values["seed"] = int(values["seed"])
+    _validate_generation_kwargs(values)
+    return values
+
+
+def _normalize_inputs(inputs: Any) -> tuple[str, list[dict[str, Any]]]:
+    if isinstance(inputs, str):
+        return inputs, []
+    if not isinstance(inputs, dict):
+        return str(inputs) if inputs is not None else "", []
+    references = inputs.get("references") or []
+    if not isinstance(references, list):
+        raise ValueError("VoxCPM references must be a list")
+    if any(not isinstance(reference, dict) for reference in references):
+        raise ValueError("VoxCPM references must be objects")
+    return str(inputs.get("text", inputs.get("input", ""))), [
+        dict(reference) for reference in references
+    ]
+
+
+def _reference_from_value(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, str) and value.startswith("data:"):
+        header, separator, data = value.partition(",")
+        if not separator or ";base64" not in header:
+            raise ValueError("VoxCPM ref_audio data URI must be base64 encoded")
+        media_type = header.removeprefix("data:").split(";", 1)[0] or "audio/wav"
+        return {"data": data, "media_type": media_type}
+    return {"audio_path": str(value)}
+
+
+def _normalize_reference_audio(reference: dict[str, Any]) -> dict[str, Any]:
+    if reference.get("audio_path") is not None:
+        return {"audio_path": str(reference["audio_path"])}
+    for key in ("ref_audio", "audio"):
+        if reference.get(key) is not None:
+            return _reference_from_value(reference[key])
+    if reference.get("bytes") is not None:
+        return {"bytes": bytes(reference["bytes"])}
+    data = reference.get("base64") or reference.get("data")
+    if data is not None:
+        return {
+            "data": str(data),
+            "media_type": str(reference.get("media_type") or "audio/wav"),
+        }
+    raise ValueError("VoxCPM reference has no audio payload")
+
+
+def _validate_generation_kwargs(values: dict[str, Any]) -> None:
+    if values["max_new_tokens"] < 1:
+        raise ValueError("VoxCPM max_new_tokens must be positive")
+    if values["min_len"] < 0 or values["min_len"] >= values["max_new_tokens"]:
+        raise ValueError("VoxCPM min_len must be >= 0 and below max_new_tokens")
+    if values["inference_timesteps"] < 1:
+        raise ValueError("VoxCPM inference_timesteps must be positive")
+    if values["cfg_value"] <= 0:
+        raise ValueError("VoxCPM cfg_value must be positive")
+    if values["temperature"] < 0:
+        raise ValueError("VoxCPM temperature must be non-negative")
+    if values["streaming_prefix_len"] < 1:
+        raise ValueError("VoxCPM streaming_prefix_len must be positive")
+
+
+__all__ = ["build_generation_kwargs", "build_voxcpm_state"]

--- a/sglang_omni/models/voxcpm_common/stages.py
+++ b/sglang_omni/models/voxcpm_common/stages.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stage factories shared by VoxCPM1.5 and VoxCPM2."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sglang_omni.models.voxcpm_common.request_builders import build_voxcpm_state
+from sglang_omni.scheduling.pipeline_state import store_state
+from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+
+
+def create_voxcpm_preprocessing_executor(
+    model_path: str, *, variant: str
+) -> SimpleScheduler:
+    del model_path
+    if variant not in {"voxcpm", "voxcpm2"}:
+        raise ValueError(f"unsupported VoxCPM variant: {variant}")
+    return SimpleScheduler(
+        lambda payload: store_state(
+            payload, build_voxcpm_state(payload, variant=variant)
+        ),
+        max_concurrency=8,
+    )
+
+
+def create_voxcpm_tts_engine_executor(
+    model_path: str,
+    *,
+    variant: str,
+    device: str = "cuda:0",
+    gpu_id: int | None = None,
+    dtype: str = "bfloat16",
+    server_args_overrides: dict[str, Any] | None = None,
+    total_gpu_memory_fraction: float | None = None,
+) -> Any:
+    from sglang_omni.models.voxcpm_common.engine_builder import VoxCPMEngineBuilder
+
+    return VoxCPMEngineBuilder(
+        variant=variant,
+        total_gpu_memory_fraction=total_gpu_memory_fraction,
+    ).build(
+        model_path,
+        device=device,
+        gpu_id=gpu_id,
+        dtype=dtype,
+        server_args_overrides=server_args_overrides,
+    )
+
+
+__all__ = [
+    "create_voxcpm_preprocessing_executor",
+    "create_voxcpm_tts_engine_executor",
+]

--- a/sglang_omni/models/voxcpm_common/state_pool.py
+++ b/sglang_omni/models/voxcpm_common/state_pool.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fixed-address, row-indexed generation state for VoxCPM requests."""
+
+from __future__ import annotations
+
+import threading
+from typing import Iterable
+
+import torch
+
+
+class VoxCPMRequestStatePool:
+    """Owns graph-stable tensors used to feed generated audio back to the LM."""
+
+    def __init__(
+        self,
+        capacity: int,
+        hidden_size: int,
+        patch_size: int,
+        feat_dim: int,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> None:
+        if min(capacity, hidden_size, patch_size, feat_dim) <= 0:
+            raise ValueError("all VoxCPM state-pool dimensions must be positive")
+        self.capacity = capacity
+        self.feedback = torch.zeros(capacity, hidden_size, device=device, dtype=dtype)
+        self.latents = torch.zeros(
+            capacity, patch_size, feat_dim, device=device, dtype=dtype
+        )
+        self.temperature = torch.ones(capacity, device=device, dtype=dtype)
+        self.cfg_value = torch.ones(capacity, device=device, dtype=dtype)
+        self.stop_flag = torch.zeros(capacity, device=device, dtype=torch.long)
+        self.steps = torch.zeros(capacity, device=device, dtype=torch.long)
+        self.seeds = torch.full((capacity,), -1, device=device, dtype=torch.long)
+        self._rid_to_row: dict[str, int] = {}
+        self._free = list(range(capacity - 1, -1, -1))
+        self._lock = threading.RLock()
+
+    def acquire(self, rid: str) -> int:
+        if not rid:
+            raise ValueError("request id must be non-empty")
+        with self._lock:
+            existing = self._rid_to_row.get(rid)
+            if existing is not None:
+                return existing
+            if not self._free:
+                raise RuntimeError(
+                    f"VoxCPM request-state pool exhausted (capacity={self.capacity})"
+                )
+            row = self._free.pop()
+            self._rid_to_row[rid] = row
+            self._zero_rows(torch.tensor([row], device=self.feedback.device))
+            return row
+
+    acquire_row = acquire
+
+    def row_for(self, rid: str) -> int | None:
+        with self._lock:
+            return self._rid_to_row.get(rid)
+
+    def reset(self, rid: str) -> None:
+        with self._lock:
+            row = self._rid_to_row.pop(rid, None)
+            if row is None:
+                return
+            self._zero_rows(torch.tensor([row], device=self.feedback.device))
+            self._free.append(row)
+
+    reset_request = reset
+    release_row = reset
+
+    def reset_rows(self, rows: torch.Tensor | Iterable[int]) -> None:
+        rows = self._rows_tensor(rows)
+        self._check_rows(rows)
+        self._zero_rows(rows)
+
+    def configure(
+        self,
+        rows: torch.Tensor | Iterable[int],
+        *,
+        temperature: torch.Tensor | float | None = None,
+        cfg_value: torch.Tensor | float | None = None,
+        seed: torch.Tensor | int | None = None,
+    ) -> None:
+        rows = self._rows_tensor(rows)
+        self._check_rows(rows)
+        for target, value in (
+            (self.temperature, temperature),
+            (self.cfg_value, cfg_value),
+            (self.seeds, seed),
+        ):
+            if value is None:
+                continue
+            source = torch.as_tensor(value, device=target.device, dtype=target.dtype)
+            if source.ndim == 0:
+                source = source.expand(rows.numel())
+            if source.numel() != rows.numel():
+                raise ValueError("state values must be scalar or match row count")
+            target.index_copy_(0, rows, source.reshape(-1))
+
+    def feedback_for(self, rows: torch.Tensor) -> torch.Tensor:
+        rows = rows.to(device=self.feedback.device, dtype=torch.long)
+        self._check_rows(rows)
+        return self.feedback.index_select(0, rows)
+
+    def update(
+        self,
+        rows: torch.Tensor,
+        *,
+        feedback: torch.Tensor,
+        latents: torch.Tensor,
+        stop_flag: torch.Tensor,
+    ) -> None:
+        rows = rows.to(device=self.feedback.device, dtype=torch.long)
+        self._check_rows(rows)
+        batch = rows.numel()
+        if feedback.shape != (batch, self.feedback.shape[1]):
+            raise ValueError("feedback has an invalid shape")
+        if latents.shape != (batch, self.latents.shape[1], self.latents.shape[2]):
+            raise ValueError("latents have an invalid shape")
+        if stop_flag.numel() != batch:
+            raise ValueError("stop_flag must match row count")
+        self.feedback.index_copy_(0, rows, feedback.to(self.feedback))
+        self.latents.index_copy_(0, rows, latents.to(self.latents))
+        self.stop_flag.index_copy_(0, rows, stop_flag.reshape(-1).to(self.stop_flag))
+        self.steps.index_add_(0, rows, torch.ones_like(rows, dtype=self.steps.dtype))
+
+    def _rows_tensor(self, rows: torch.Tensor | Iterable[int]) -> torch.Tensor:
+        if isinstance(rows, torch.Tensor):
+            return rows.to(device=self.feedback.device, dtype=torch.long).reshape(-1)
+        return torch.tensor(list(rows), device=self.feedback.device, dtype=torch.long)
+
+    def _check_rows(self, rows: torch.Tensor) -> None:
+        if rows.ndim != 1:
+            raise ValueError("rows must be one-dimensional")
+        if rows.numel() and (
+            int(rows.min().item()) < 0 or int(rows.max().item()) >= self.capacity
+        ):
+            raise IndexError("VoxCPM state-pool row is out of range")
+
+    def _zero_rows(self, rows: torch.Tensor) -> None:
+        self.feedback.index_fill_(0, rows, 0)
+        self.latents.index_fill_(0, rows, 0)
+        self.temperature.index_fill_(0, rows, 1)
+        self.cfg_value.index_fill_(0, rows, 1)
+        self.stop_flag.index_fill_(0, rows, 0)
+        self.steps.index_fill_(0, rows, 0)
+        self.seeds.index_fill_(0, rows, -1)

--- a/sglang_omni/models/voxcpm_common/state_pool.py
+++ b/sglang_omni/models/voxcpm_common/state_pool.py
@@ -25,15 +25,20 @@ class VoxCPMRequestStatePool:
         if min(capacity, hidden_size, patch_size, feat_dim) <= 0:
             raise ValueError("all VoxCPM state-pool dimensions must be positive")
         self.capacity = capacity
-        self.feedback = torch.zeros(capacity, hidden_size, device=device, dtype=dtype)
-        self.latents = torch.zeros(
-            capacity, patch_size, feat_dim, device=device, dtype=dtype
+        self.num_rows = capacity + 1
+        self.padding_row = capacity
+        self.feedback = torch.zeros(
+            self.num_rows, hidden_size, device=device, dtype=dtype
         )
-        self.temperature = torch.ones(capacity, device=device, dtype=dtype)
-        self.cfg_value = torch.ones(capacity, device=device, dtype=dtype)
-        self.stop_flag = torch.zeros(capacity, device=device, dtype=torch.long)
-        self.steps = torch.zeros(capacity, device=device, dtype=torch.long)
-        self.seeds = torch.full((capacity,), -1, device=device, dtype=torch.long)
+        self.latents = torch.zeros(
+            self.num_rows, patch_size, feat_dim, device=device, dtype=dtype
+        )
+        self.temperature = torch.ones(self.num_rows, device=device, dtype=dtype)
+        self.cfg_value = torch.ones(self.num_rows, device=device, dtype=dtype)
+        self.stop_flag = torch.zeros(self.num_rows, device=device, dtype=torch.long)
+        self.done = torch.zeros(self.num_rows, device=device, dtype=torch.bool)
+        self.steps = torch.zeros(self.num_rows, device=device, dtype=torch.long)
+        self.seeds = torch.full((self.num_rows,), -1, device=device, dtype=torch.long)
         self._rid_to_row: dict[str, int] = {}
         self._free = list(range(capacity - 1, -1, -1))
         self._lock = threading.RLock()
@@ -135,8 +140,13 @@ class VoxCPMRequestStatePool:
     def _check_rows(self, rows: torch.Tensor) -> None:
         if rows.ndim != 1:
             raise ValueError("rows must be one-dimensional")
-        if rows.numel() and (
-            int(rows.min().item()) < 0 or int(rows.max().item()) >= self.capacity
+        # GPU row tensors are produced by the scheduler/model runner. Avoid
+        # value-dependent host reads here: .item() is illegal while SGLang is
+        # capturing the decode CUDA graph.
+        if (
+            rows.device.type == "cpu"
+            and rows.numel()
+            and (int(rows.min().item()) < 0 or int(rows.max().item()) >= self.num_rows)
         ):
             raise IndexError("VoxCPM state-pool row is out of range")
 
@@ -146,5 +156,6 @@ class VoxCPMRequestStatePool:
         self.temperature.index_fill_(0, rows, 1)
         self.cfg_value.index_fill_(0, rows, 1)
         self.stop_flag.index_fill_(0, rows, 0)
+        self.done.index_fill_(0, rows, False)
         self.steps.index_fill_(0, rows, 0)
         self.seeds.index_fill_(0, rows, -1)

--- a/sglang_omni/models/voxcpm_common/streaming_vae.py
+++ b/sglang_omni/models/voxcpm_common/streaming_vae.py
@@ -127,14 +127,18 @@ class BatchedStreamingVAEDecoder:
         ) -> torch.Tensor:
             if self._stream_ids is None:
                 return type(_module).forward(_module, x)
+            stream_ids = self._ids(x.shape[0])
             contexts = []
-            for index, rid in enumerate(self._ids(x.shape[0])):
+            for rid in stream_ids:
                 state = _states.get(rid)
                 if state is None:
                     state = x.new_zeros((x.shape[1], _padding))
                 contexts.append(state)
-                _states[rid] = torch.cat((state, x[index]), -1)[:, -_padding:].detach()
-            return nn.Conv1d.forward(_module, torch.cat((torch.stack(contexts), x), -1))
+            combined = torch.cat((torch.stack(contexts), x), -1)
+            next_states = combined[..., -_padding:].detach()
+            for index, rid in enumerate(stream_ids):
+                _states[rid] = next_states[index]
+            return nn.Conv1d.forward(_module, combined)
 
         module.forward = forward  # type: ignore[method-assign]
 
@@ -153,16 +157,18 @@ class BatchedStreamingVAEDecoder:
         ) -> torch.Tensor:
             if self._stream_ids is None:
                 return type(_module).forward(_module, x)
+            stream_ids = self._ids(x.shape[0])
             contexts = []
-            for index, rid in enumerate(self._ids(x.shape[0])):
+            for rid in stream_ids:
                 state = _states.get(rid)
                 if state is None:
                     state = x.new_zeros((x.shape[1], _context))
                 contexts.append(state)
-                _states[rid] = torch.cat((state, x[index]), -1)[:, -_context:].detach()
-            output = nn.ConvTranspose1d.forward(
-                _module, torch.cat((torch.stack(contexts), x), -1)
-            )
+            combined = torch.cat((torch.stack(contexts), x), -1)
+            next_states = combined[..., -_context:].detach()
+            for index, rid in enumerate(stream_ids):
+                _states[rid] = next_states[index]
+            output = nn.ConvTranspose1d.forward(_module, combined)
             left = _context * _module.stride[0]
             return output[..., left:-_trim] if _trim else output[..., left:]
 

--- a/sglang_omni/models/voxcpm_common/streaming_vae.py
+++ b/sglang_omni/models/voxcpm_common/streaming_vae.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Request-keyed incremental decoder for causal VoxCPM AudioVAEs."""
+
+from __future__ import annotations
+
+from collections.abc import Hashable, Sequence
+
+import torch
+from torch import nn
+
+
+class BatchedStreamingVAEDecoder:
+    """Patch causal layers so dynamically batched streams keep separate state."""
+
+    def __init__(
+        self,
+        vae: nn.Module,
+        causal_conv_type: type[nn.Conv1d],
+        causal_transpose_conv_type: type[nn.ConvTranspose1d],
+    ) -> None:
+        self._vae = vae
+        self._conv_type = causal_conv_type
+        self._transpose_type = causal_transpose_conv_type
+        self._states: dict[int, dict[Hashable, torch.Tensor]] = {}
+        self._stream_ids: Sequence[Hashable] | None = None
+        self._initialized: set[Hashable] = set()
+        self._install()
+
+    @torch.inference_mode()
+    def decode_chunks(
+        self,
+        chunks: torch.Tensor,
+        stream_ids: Sequence[Hashable],
+        initial_contexts: Sequence[torch.Tensor | None] | None = None,
+    ) -> torch.Tensor:
+        if chunks.ndim != 3:
+            raise ValueError("VAE chunks must have shape [batch, latent_dim, time]")
+        if len(stream_ids) != chunks.shape[0] or len(set(stream_ids)) != len(
+            stream_ids
+        ):
+            raise ValueError("stream_ids must be unique and match the VAE batch")
+        contexts = initial_contexts or [None] * len(stream_ids)
+        if len(contexts) != len(stream_ids):
+            raise ValueError("initial_contexts must match stream_ids")
+
+        missing = object()
+        snapshot = {
+            key: {rid: states.get(rid, missing) for rid in stream_ids}
+            for key, states in self._states.items()
+        }
+        initialized = self._initialized.intersection(stream_ids)
+        try:
+            for rid, context in zip(stream_ids, contexts):
+                if rid in self._initialized:
+                    continue
+                if context is not None and context.numel():
+                    if context.ndim != 3 or context.shape[0] != 1:
+                        raise ValueError(
+                            "initial VAE context must have shape [1, D, T]"
+                        )
+                    self._decode(context, [rid])
+                self._initialized.add(rid)
+            return self._decode(chunks, stream_ids)
+        except Exception:
+            for key, states in self._states.items():
+                for rid, old in snapshot[key].items():
+                    if old is missing:
+                        states.pop(rid, None)
+                    else:
+                        states[rid] = old
+            self._initialized.difference_update(stream_ids)
+            self._initialized.update(initialized)
+            raise
+
+    def release(self, stream_id: Hashable) -> None:
+        self._initialized.discard(stream_id)
+        for states in self._states.values():
+            states.pop(stream_id, None)
+
+    def clear(self) -> None:
+        self._initialized.clear()
+        for states in self._states.values():
+            states.clear()
+
+    def _decode(
+        self, chunks: torch.Tensor, stream_ids: Sequence[Hashable]
+    ) -> torch.Tensor:
+        if self._stream_ids is not None:
+            raise RuntimeError("streaming VAE decode is not reentrant")
+        self._stream_ids = stream_ids
+        try:
+            return self._vae.decode(chunks)
+        finally:
+            self._stream_ids = None
+
+    def _ids(self, batch: int) -> Sequence[Hashable]:
+        if self._stream_ids is None or len(self._stream_ids) != batch:
+            raise RuntimeError("causal VAE layer ran outside decode_chunks")
+        return self._stream_ids
+
+    def _install(self) -> None:
+        for module in self._vae.decoder.modules():
+            if isinstance(module, self._conv_type):
+                padding = module._CausalConv1d__padding * 2 - getattr(
+                    module, "_CausalConv1d__output_padding", 0
+                )
+                if padding > 0:
+                    self._patch_conv(module, padding)
+            elif isinstance(module, self._transpose_type):
+                trim = (
+                    module._CausalTransposeConv1d__padding * 2
+                    - module._CausalTransposeConv1d__output_padding
+                )
+                context = module.kernel_size[0] // module.stride[0] - 1
+                if context > 0:
+                    self._patch_transpose(module, context, trim)
+
+    def _patch_conv(self, module: nn.Conv1d, padding: int) -> None:
+        states = self._states.setdefault(id(module), {})
+
+        def forward(
+            x: torch.Tensor,
+            *,
+            _module: nn.Conv1d = module,
+            _padding: int = padding,
+            _states: dict[Hashable, torch.Tensor] = states,
+        ) -> torch.Tensor:
+            if self._stream_ids is None:
+                return type(_module).forward(_module, x)
+            contexts = []
+            for index, rid in enumerate(self._ids(x.shape[0])):
+                state = _states.get(rid)
+                if state is None:
+                    state = x.new_zeros((x.shape[1], _padding))
+                contexts.append(state)
+                _states[rid] = torch.cat((state, x[index]), -1)[:, -_padding:].detach()
+            return nn.Conv1d.forward(_module, torch.cat((torch.stack(contexts), x), -1))
+
+        module.forward = forward  # type: ignore[method-assign]
+
+    def _patch_transpose(
+        self, module: nn.ConvTranspose1d, context: int, trim: int
+    ) -> None:
+        states = self._states.setdefault(id(module), {})
+
+        def forward(
+            x: torch.Tensor,
+            *,
+            _module: nn.ConvTranspose1d = module,
+            _context: int = context,
+            _trim: int = trim,
+            _states: dict[Hashable, torch.Tensor] = states,
+        ) -> torch.Tensor:
+            if self._stream_ids is None:
+                return type(_module).forward(_module, x)
+            contexts = []
+            for index, rid in enumerate(self._ids(x.shape[0])):
+                state = _states.get(rid)
+                if state is None:
+                    state = x.new_zeros((x.shape[1], _context))
+                contexts.append(state)
+                _states[rid] = torch.cat((state, x[index]), -1)[:, -_context:].detach()
+            output = nn.ConvTranspose1d.forward(
+                _module, torch.cat((torch.stack(contexts), x), -1)
+            )
+            left = _context * _module.stride[0]
+            return output[..., left:-_trim] if _trim else output[..., left:]
+
+        module.forward = forward  # type: ignore[method-assign]
+
+
+__all__ = ["BatchedStreamingVAEDecoder"]

--- a/sglang_omni/models/voxcpm_common/weights.py
+++ b/sglang_omni/models/voxcpm_common/weights.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Official VoxCPM checkpoint loading helpers."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+from torch import nn
+
+try:
+    from sglang.srt.model_loader.weight_utils import default_weight_loader
+except ModuleNotFoundError as error:
+    if error.name != "sglang":
+        raise
+
+    def default_weight_loader(
+        parameter: nn.Parameter,
+        tensor: torch.Tensor,
+        shard_id: str | int | None = None,
+    ) -> None:
+        if shard_id is not None:
+            raise RuntimeError("packed official weights require SGLang to be installed")
+        parameter.data.copy_(tensor.to(device=parameter.device, dtype=parameter.dtype))
+
+
+_STACKED_MAPPING = (
+    ("qkv_proj", "q_proj", "q"),
+    ("qkv_proj", "k_proj", "k"),
+    ("qkv_proj", "v_proj", "v"),
+    ("gate_up_proj", "gate_proj", 0),
+    ("gate_up_proj", "up_proj", 1),
+)
+
+
+def load_voxcpm_weights(
+    module: nn.Module,
+    weights: Iterable[tuple[str, torch.Tensor]],
+    *,
+    strict: bool = False,
+) -> set[str]:
+    """Load official safetensors names into packed SGLang parameters.
+
+    Official checkpoints name the root modules directly (``base_lm.*``,
+    ``residual_lm.*``); wrappers in this repository keep them under ``model``.
+    Both forms, plus an optional ``module.`` prefix, are accepted.
+    """
+
+    params = dict(module.named_parameters())
+    loaded: set[str] = set()
+    unexpected: list[str] = []
+    for source_name, tensor in weights:
+        name = source_name.removeprefix("module.")
+        candidates = (name, f"model.{name}")
+        target_name = next((item for item in candidates if item in params), None)
+        if target_name is not None:
+            try:
+                _load(params[target_name], tensor)
+            except (AssertionError, RuntimeError) as exc:
+                raise RuntimeError(
+                    "VoxCPM weight shape mismatch: "
+                    f"{source_name} {tuple(tensor.shape)} -> "
+                    f"{target_name} {tuple(params[target_name].shape)}"
+                ) from exc
+            loaded.add(target_name)
+            continue
+
+        packed = False
+        for packed_name, shard_name, shard_id in _STACKED_MAPPING:
+            marker = f".{shard_name}."
+            if marker not in name:
+                continue
+            mapped = name.replace(marker, f".{packed_name}.")
+            target_name = next(
+                (item for item in (mapped, f"model.{mapped}") if item in params),
+                None,
+            )
+            if target_name is None:
+                # LocEnc and DiT intentionally retain unpacked nn.Linear names.
+                continue
+            loader = getattr(
+                params[target_name], "weight_loader", default_weight_loader
+            )
+            loader(params[target_name], tensor, shard_id)
+            loaded.add(target_name)
+            packed = True
+            break
+        if packed:
+            continue
+        if (
+            name.endswith("rotary_emb.inv_freq")
+            or name.endswith(".cos_cached")
+            or name.endswith(".sin_cached")
+        ):
+            continue
+        # Some official archives include tied/output heads unused by synthesis.
+        if name.startswith(("lm_head.", "base_lm.lm_head.")):
+            continue
+        unexpected.append(source_name)
+
+    if strict:
+        missing = set(params) - loaded
+        if missing or unexpected:
+            raise RuntimeError(
+                "VoxCPM checkpoint mismatch: "
+                f"missing={sorted(missing)[:20]}, unexpected={unexpected[:20]}"
+            )
+    return loaded
+
+
+def load_audiovae_checkpoint(
+    vae: nn.Module,
+    model_path: str,
+    *,
+    map_location: str | torch.device = "cpu",
+    strict: bool = True,
+) -> Any:
+    """Load ``audiovae.pth`` and return ``vae`` for convenient attachment."""
+
+    checkpoint_path = (
+        model_path
+        if os.path.basename(model_path) == "audiovae.pth"
+        else os.path.join(model_path, "audiovae.pth")
+    )
+    if not os.path.isfile(checkpoint_path):
+        raise FileNotFoundError(f"AudioVAE checkpoint not found: {checkpoint_path}")
+    try:
+        checkpoint = torch.load(
+            checkpoint_path, map_location=map_location, weights_only=True
+        )
+    except TypeError:
+        # PyTorch < 2.0 has no weights_only argument. Official audiovae.pth is
+        # a trusted project artifact, but callers should not pass arbitrary files.
+        checkpoint = torch.load(checkpoint_path, map_location=map_location)
+    if not isinstance(checkpoint, dict):
+        raise TypeError("audiovae.pth must contain a state-dict mapping")
+    state_dict = checkpoint.get("state_dict", checkpoint)
+    if not isinstance(state_dict, dict):
+        raise TypeError("audiovae.pth['state_dict'] must be a mapping")
+    vae.load_state_dict(state_dict, strict=strict)
+    return vae
+
+
+def load_audiovae_from_model_path(
+    config: Any,
+    model_path: str,
+    *,
+    version: str,
+    map_location: str | torch.device = "cpu",
+    strict: bool = True,
+) -> nn.Module:
+    """Instantiate V1/V2 AudioVAE from config and load its official pth."""
+
+    from sglang_omni.models.voxcpm_common.audio_vae import create_audio_vae
+
+    # SGLang commonly constructs model modules under a bf16 default dtype,
+    # while the official VAE is intentionally fp32.
+    previous_dtype = torch.get_default_dtype()
+    try:
+        torch.set_default_dtype(torch.float32)
+        vae = create_audio_vae(config, version=version)
+    finally:
+        torch.set_default_dtype(previous_dtype)
+    return load_audiovae_checkpoint(
+        vae, model_path, map_location=map_location, strict=strict
+    )
+
+
+def _load(parameter: nn.Parameter, tensor: torch.Tensor) -> None:
+    loader = getattr(parameter, "weight_loader", default_weight_loader)
+    loader(parameter, tensor)

--- a/sglang_omni/serve/protocol.py
+++ b/sglang_omni/serve/protocol.py
@@ -363,6 +363,10 @@ class CreateSpeechRequest(BaseModel):
     top_k: int | None = None
     repetition_penalty: float | None = None
     seed: int | None = None
+    cfg_value: float | None = Field(default=None, gt=0.0)
+    inference_timesteps: int | None = Field(default=None, ge=1)
+    min_len: int | None = Field(default=None, ge=0)
+    streaming_prefix_len: int | None = Field(default=None, ge=1)
 
     # Per-stage overrides (sglang-omni specific)
     stage_params: dict[str, dict[str, Any]] | None = None
@@ -398,6 +402,10 @@ class SpeechBatchItem(BaseModel):
     top_k: Any = None
     repetition_penalty: Any = None
     seed: Any = None
+    cfg_value: Any = None
+    inference_timesteps: Any = None
+    min_len: Any = None
+    streaming_prefix_len: Any = None
     stage_params: Any = None
 
 
@@ -431,6 +439,10 @@ class CreateSpeechBatchRequest(BaseModel):
     top_k: int | None = None
     repetition_penalty: float | None = None
     seed: int | None = None
+    cfg_value: float | None = Field(default=None, gt=0.0)
+    inference_timesteps: int | None = Field(default=None, ge=1)
+    min_len: int | None = Field(default=None, ge=0)
+    streaming_prefix_len: int | None = Field(default=None, ge=1)
     stage_params: dict[str, dict[str, Any]] | None = None
 
 
@@ -485,6 +497,10 @@ class SpeechStreamSessionConfig(BaseModel):
     top_k: int | None = None
     repetition_penalty: float | None = None
     seed: int | None = None
+    cfg_value: float | None = Field(default=None, gt=0.0)
+    inference_timesteps: int | None = Field(default=None, ge=1)
+    min_len: int | None = Field(default=None, ge=0)
+    streaming_prefix_len: int | None = Field(default=None, ge=1)
     stage_params: dict[str, dict[str, Any]] | None = None
 
 

--- a/sglang_omni/serve/speech_service.py
+++ b/sglang_omni/serve/speech_service.py
@@ -240,6 +240,13 @@ class SpeechRequestValidator:
             updates["language"] = self._normalize_language(request.language)
 
         _validate_positive_int(request.max_new_tokens, param="max_new_tokens")
+        _validate_positive_int(
+            request.inference_timesteps, param="inference_timesteps"
+        )
+        _validate_non_negative_int(request.min_len, param="min_len")
+        _validate_positive_int(
+            request.streaming_prefix_len, param="streaming_prefix_len"
+        )
         _validate_positive_int(request.token_count, param="token_count")
         _validate_positive_int(request.duration_tokens, param="duration_tokens")
         _validate_non_negative_int(
@@ -550,6 +557,13 @@ class SpeechRequestValidator:
         if batch.language is not None:
             self._normalize_language(batch.language)
         _validate_positive_int(batch.max_new_tokens, param="max_new_tokens")
+        _validate_positive_int(
+            batch.inference_timesteps, param="inference_timesteps"
+        )
+        _validate_non_negative_int(batch.min_len, param="min_len")
+        _validate_positive_int(
+            batch.streaming_prefix_len, param="streaming_prefix_len"
+        )
         _validate_positive_int(batch.token_count, param="token_count")
         _validate_positive_int(batch.duration_tokens, param="duration_tokens")
         _validate_non_negative_int(
@@ -634,6 +648,9 @@ class SpeechRequestValidator:
             "token_count",
             "duration_tokens",
             "seed",
+            "inference_timesteps",
+            "min_len",
+            "streaming_prefix_len",
         ):
             if field_name in payload and payload[field_name] is not None:
                 value = payload[field_name]
@@ -645,7 +662,13 @@ class SpeechRequestValidator:
             value = payload["top_k"]
             if isinstance(value, bool) or not isinstance(value, int):
                 raise bad_request("top_k must be an integer", param="top_k")
-        for field_name in ("speed", "temperature", "top_p", "repetition_penalty"):
+        for field_name in (
+            "speed",
+            "temperature",
+            "top_p",
+            "repetition_penalty",
+            "cfg_value",
+        ):
             if field_name in payload and payload[field_name] is not None:
                 value = payload[field_name]
                 if isinstance(value, bool) or not isinstance(value, (int, float)):
@@ -729,6 +752,10 @@ def _explicit_generation_params(request: CreateSpeechRequest) -> list[str]:
             "top_k",
             "repetition_penalty",
             "seed",
+            "cfg_value",
+            "inference_timesteps",
+            "min_len",
+            "streaming_prefix_len",
         )
         if field in request.model_fields_set
     )
@@ -776,6 +803,15 @@ def _build_tts_params(
         tts_params["duration_tokens"] = request.duration_tokens
     if request.seed is not None:
         tts_params["seed"] = request.seed
+    for field_name in (
+        "cfg_value",
+        "inference_timesteps",
+        "min_len",
+        "streaming_prefix_len",
+    ):
+        value = getattr(request, field_name)
+        if value is not None:
+            tts_params[field_name] = value
     return tts_params
 
 

--- a/sglang_omni/utils/hf.py
+++ b/sglang_omni/utils/hf.py
@@ -29,6 +29,8 @@ _CONFIG_MODEL_TYPE_TO_ARCH = {
     "moss_tts_delay_with_codec": "MossTTSDelayWithCodec",
     "moss_tts_local": "MossTTSLocalModel",
     "qwen3_tts": "Qwen3TTSForConditionalGeneration",
+    "voxcpm": "voxcpm",
+    "voxcpm2": "voxcpm2",
     "voxtral_tts": "VoxtralTTSForConditionalGeneration",
 }
 

--- a/tests/gpu/voxcpm/run_nano_reference.py
+++ b/tests/gpu/voxcpm/run_nano_reference.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Small fixed-seed nano-vLLM reference used by VoxCPM GPU parity jobs."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+
+import numpy as np
+
+
+async def _run(args: argparse.Namespace) -> None:
+    from nanovllm_voxcpm import VoxCPM
+
+    server = VoxCPM.from_pretrained(
+        args.model,
+        inference_timesteps=args.inference_timesteps,
+        max_num_batched_tokens=32768,
+        max_num_seqs=2,
+        max_model_len=32768,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        enforce_eager=True,
+        devices=[0],
+    )
+    await server.wait_for_ready()
+    try:
+        chunks = []
+        async for chunk in server.generate(
+            target_text=args.text,
+            max_generate_length=args.max_new_tokens,
+            temperature=args.temperature,
+            cfg_value=args.cfg_value,
+            seed=args.seed,
+        ):
+            chunks.append(chunk)
+        waveform = np.concatenate(chunks).astype(np.float32, copy=False)
+        print(
+            json.dumps(
+                {
+                    "shape": list(waveform.shape),
+                    "dtype": str(waveform.dtype),
+                    "mean": float(waveform.mean()),
+                    "std": float(waveform.std()),
+                    "max_abs": float(np.abs(waveform).max()),
+                },
+                sort_keys=True,
+            )
+        )
+    finally:
+        await server.stop()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--text", default="你好")
+    parser.add_argument("--inference-timesteps", type=int, default=2)
+    parser.add_argument("--max-new-tokens", type=int, default=2)
+    parser.add_argument("--temperature", type=float, default=1.0)
+    parser.add_argument("--cfg-value", type=float, default=2.0)
+    parser.add_argument("--seed", type=int, default=41)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.72)
+    asyncio.run(_run(parser.parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_test/models/test_model_capabilities.py
+++ b/tests/unit_test/models/test_model_capabilities.py
@@ -76,15 +76,15 @@ EXPECTED_TTS_CAPABILITIES = {
         supports_reference_audio=True,
         supports_batch_vocoder=True,
         supports_streaming_vocoder=True,
-        supports_cuda_graph=False,
-        supports_torch_compile=False,
+        supports_cuda_graph=True,
+        supports_torch_compile=True,
     ),
     "voxcpm2": ModelCapabilities(
         supports_reference_audio=True,
         supports_batch_vocoder=True,
         supports_streaming_vocoder=True,
-        supports_cuda_graph=False,
-        supports_torch_compile=False,
+        supports_cuda_graph=True,
+        supports_torch_compile=True,
     ),
 }
 

--- a/tests/unit_test/models/test_model_capabilities.py
+++ b/tests/unit_test/models/test_model_capabilities.py
@@ -72,6 +72,20 @@ EXPECTED_TTS_CAPABILITIES = {
         supports_cuda_graph=True,
         supports_torch_compile=True,
     ),
+    "voxcpm": ModelCapabilities(
+        supports_reference_audio=True,
+        supports_batch_vocoder=True,
+        supports_streaming_vocoder=True,
+        supports_cuda_graph=False,
+        supports_torch_compile=False,
+    ),
+    "voxcpm2": ModelCapabilities(
+        supports_reference_audio=True,
+        supports_batch_vocoder=True,
+        supports_streaming_vocoder=True,
+        supports_cuda_graph=False,
+        supports_torch_compile=False,
+    ),
 }
 
 

--- a/tests/unit_test/serve/test_speech_protocol.py
+++ b/tests/unit_test/serve/test_speech_protocol.py
@@ -51,6 +51,26 @@ def test_speech_generation_uses_served_model_and_default_voice() -> None:
     assert generate_request.metadata["tts_params"]["voice"] == "default"
 
 
+def test_speech_generation_lowers_voxcpm_parameters() -> None:
+    service = SpeechRequestValidator(default_model="voxcpm2")
+    prepared = service.parse_generation_request(
+        {
+            "input": "hello",
+            "cfg_value": 2.5,
+            "inference_timesteps": 12,
+            "min_len": 3,
+            "streaming_prefix_len": 4,
+        }
+    )
+    generate_request = service.build_generate_request(prepared.request, validate=False)
+
+    tts_params = generate_request.metadata["tts_params"]
+    assert tts_params["cfg_value"] == 2.5
+    assert tts_params["inference_timesteps"] == 12
+    assert tts_params["min_len"] == 3
+    assert tts_params["streaming_prefix_len"] == 4
+
+
 @pytest.mark.parametrize("stream", [False, True])
 def test_speech_generation_accepts_seedtts_reference_payload_without_voice(
     stream: bool,

--- a/tests/unit_test/voxcpm/test_model_core.py
+++ b/tests/unit_test/voxcpm/test_model_core.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from sglang_omni.models.voxcpm_common import core
+from sglang_omni.models.voxcpm_common.audio_vae import AudioVAE, AudioVAEV2
+from sglang_omni.models.voxcpm_common.core import (
+    CausalMiniCPMAttention,
+    MiniCPMLongRoPE,
+)
+from sglang_omni.models.voxcpm_common.state_pool import VoxCPMRequestStatePool
+from sglang_omni.models.voxcpm_common.weights import load_voxcpm_weights
+
+
+def test_state_pool_isolates_and_recycles_request_rows():
+    pool = VoxCPMRequestStatePool(
+        2, 4, 2, 3, device=torch.device("cpu"), dtype=torch.float32
+    )
+    first = pool.acquire("first")
+    second = pool.acquire("second")
+    assert first != second
+    pool.configure([first, second], temperature=torch.tensor([0.5, 0.9]))
+    pool.update(
+        torch.tensor([first]),
+        feedback=torch.ones(1, 4),
+        latents=torch.ones(1, 2, 3),
+        stop_flag=torch.ones(1, dtype=torch.long),
+    )
+    assert pool.feedback[second].count_nonzero() == 0
+    assert pool.steps.tolist() == [1, 0]
+
+    pool.reset("first")
+    recycled = pool.acquire("third")
+    assert recycled == first
+    assert pool.feedback[recycled].count_nonzero() == 0
+    assert pool.temperature[recycled] == 1
+    assert pool.row_for("first") is None
+
+
+def test_state_pool_exhaustion_and_idempotent_reset():
+    pool = VoxCPMRequestStatePool(
+        1, 2, 1, 2, device=torch.device("cpu"), dtype=torch.float32
+    )
+    assert pool.acquire("request") == pool.acquire("request")
+    with pytest.raises(RuntimeError, match="exhausted"):
+        pool.acquire("other")
+    pool.reset("missing")
+    pool.reset("request")
+    assert pool.acquire("other") == 0
+
+
+def test_long_rope_version_shapes_and_bounds():
+    config = SimpleNamespace(
+        hidden_size=8,
+        num_attention_heads=2,
+        max_position_embeddings=8,
+        rope_theta=10000.0,
+        rope_scaling={
+            "original_max_position_embeddings": 4,
+            "short_factor": [1.0, 1.0],
+            "long_factor": [2.0, 2.0],
+        },
+    )
+    positions = torch.tensor([0, 1, 2])
+    query = torch.randn(3, 8)
+    key = torch.randn(3, 8)
+    for version in ("v1", "v2"):
+        rope = MiniCPMLongRoPE(config, version=version)
+        output_query, output_key = rope(positions, query, key)
+        assert output_query.shape == query.shape
+        assert output_key.shape == key.shape
+        with pytest.raises(ValueError, match="position exceeds"):
+            rope(torch.tensor([8]), query[:1], key[:1])
+
+
+def test_voxcpm2_residual_attention_can_disable_rope(monkeypatch):
+    class _LayerStub(nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+    monkeypatch.setattr(core, "QKVParallelLinear", _LayerStub)
+    monkeypatch.setattr(core, "RowParallelLinear", _LayerStub)
+    monkeypatch.setattr(core, "RadixAttention", _LayerStub)
+    config = SimpleNamespace(
+        hidden_size=8,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        kv_channels=4,
+        max_position_embeddings=8,
+        rope_theta=10000.0,
+        rms_norm_eps=1e-6,
+    )
+    with_rope = CausalMiniCPMAttention(
+        config,
+        layer_id=0,
+        version="v2",
+        use_rope=True,
+        prefix="with_rope",
+    )
+    without_rope = CausalMiniCPMAttention(
+        config,
+        layer_id=1,
+        version="v2",
+        use_rope=False,
+        prefix="without_rope",
+    )
+    assert isinstance(with_rope.rotary_emb, MiniCPMLongRoPE)
+    assert without_rope.rotary_emb is None
+
+
+def test_weight_loader_accepts_official_root_names():
+    class Wrapper(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = nn.Module()
+            self.model.proj = nn.Linear(2, 2, bias=False)
+
+    module = Wrapper()
+    loaded = load_voxcpm_weights(module, [("proj.weight", torch.full((2, 2), 3.0))])
+    assert loaded == {"model.proj.weight"}
+    torch.testing.assert_close(module.model.proj.weight, torch.full((2, 2), 3.0))
+
+
+def test_audio_vae_sample_rates_come_from_model_config():
+    common = {
+        "encoder_dim": 32,
+        "encoder_rates": [2],
+        "latent_dim": 4,
+        "decoder_dim": 32,
+        "decoder_rates": [2],
+    }
+    assert AudioVAE(config={**common, "sample_rate": 44100}).out_sample_rate == 44100
+    v2 = AudioVAEV2(
+        config={
+            **common,
+            "sample_rate": 16000,
+            "out_sample_rate": 32000,
+            "sr_bin_boundaries": [12000, 24000],
+        }
+    )
+    assert v2.sample_rate == 16000
+    assert v2.out_sample_rate == 32000

--- a/tests/unit_test/voxcpm/test_model_core.py
+++ b/tests/unit_test/voxcpm/test_model_core.py
@@ -33,7 +33,10 @@ def test_state_pool_isolates_and_recycles_request_rows():
         stop_flag=torch.ones(1, dtype=torch.long),
     )
     assert pool.feedback[second].count_nonzero() == 0
-    assert pool.steps.tolist() == [1, 0]
+    assert pool.steps.tolist() == [1, 0, 0]
+    assert pool.padding_row == 2
+    assert pool.row_for("first") != pool.padding_row
+    assert pool.row_for("second") != pool.padding_row
 
     pool.reset("first")
     recycled = pool.acquire("third")

--- a/tests/unit_test/voxcpm/test_pipeline.py
+++ b/tests/unit_test/voxcpm/test_pipeline.py
@@ -12,6 +12,7 @@ from sglang_omni.models.voxcpm_common.request_builders import (
     build_voxcpm_state,
 )
 from sglang_omni.models.voxcpm_common.engine_builder import VoxCPMEngineBuilder
+from sglang_omni.models.voxcpm_common.hf_config import VoxCPMConfig
 from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.serve.protocol import CreateSpeechRequest
 from sglang_omni.utils.hf import try_resolve_arch_from_raw_config
@@ -44,6 +45,8 @@ def _payload(
     ("architecture", "expected"),
     [
         ("voxcpm", VoxCPMPipelineConfig),
+        ("VoxCPM1", VoxCPMPipelineConfig),
+        ("VoxCPM1ForConditionalGeneration", VoxCPMPipelineConfig),
         ("VoxCPMForConditionalGeneration", VoxCPMPipelineConfig),
         ("voxcpm2", VoxCPM2PipelineConfig),
         ("VoxCPM2TalkerForConditionalGeneration", VoxCPM2PipelineConfig),
@@ -96,6 +99,31 @@ def test_engine_builder_injects_missing_voxcpm_model_type(tmp_path):
     assert builder.config.model_type == "voxcpm"
     assert builder.config.architectures == ["VoxCPMSGLangModel"]
     assert builder.context_length == 128
+
+
+def test_voxcpm1_official_config_uses_shared_v1_adapter():
+    config = VoxCPMConfig.from_dict(
+        {
+            "architecture": "voxcpm",
+            "lm_config": {
+                "hidden_size": 16,
+                "intermediate_size": 32,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "num_hidden_layers": 2,
+                "max_position_embeddings": 128,
+                "vocab_size": 32,
+            },
+            "patch_size": 2,
+            "feat_dim": 64,
+            "residual_lm_num_layers": 6,
+        }
+    )
+    assert config.model_type == "voxcpm"
+    assert config.architecture == "voxcpm"
+    assert config.architectures == ["VoxCPMSGLangModel"]
+    assert config.patch_size == 2
+    assert getattr(config, "audio_vae_config", None) is None
 
 
 def test_voxcpm1_reference_allows_optional_transcript():

--- a/tests/unit_test/voxcpm/test_pipeline.py
+++ b/tests/unit_test/voxcpm/test_pipeline.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+from sglang_omni.models.voxcpm.config import VoxCPMPipelineConfig
+from sglang_omni.models.voxcpm2.config import VoxCPM2PipelineConfig
+from sglang_omni.models.voxcpm_common.request_builders import (
+    build_generation_kwargs,
+    build_voxcpm_state,
+)
+from sglang_omni.models.voxcpm_common.engine_builder import VoxCPMEngineBuilder
+from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.serve.protocol import CreateSpeechRequest
+from sglang_omni.utils.hf import try_resolve_arch_from_raw_config
+
+
+def _payload(
+    *,
+    text: str = "你好",
+    ref_audio: str | None = None,
+    ref_text: str | None = None,
+    params: dict | None = None,
+) -> StagePayload:
+    tts_params = {}
+    if ref_audio is not None:
+        tts_params["ref_audio"] = ref_audio
+    if ref_text is not None:
+        tts_params["ref_text"] = ref_text
+    return StagePayload(
+        request_id="r0",
+        request=OmniRequest(
+            inputs={"text": text},
+            params=params or {},
+            metadata={"tts_params": tts_params},
+        ),
+        data={},
+    )
+
+
+@pytest.mark.parametrize(
+    ("architecture", "expected"),
+    [
+        ("voxcpm", VoxCPMPipelineConfig),
+        ("VoxCPMForConditionalGeneration", VoxCPMPipelineConfig),
+        ("voxcpm2", VoxCPM2PipelineConfig),
+        ("VoxCPM2TalkerForConditionalGeneration", VoxCPM2PipelineConfig),
+    ],
+)
+def test_registry_resolves_voxcpm_architectures(architecture, expected):
+    assert PIPELINE_CONFIG_REGISTRY.get_config(architecture) is expected
+
+
+@pytest.mark.parametrize(
+    ("config_cls", "variant"),
+    [(VoxCPMPipelineConfig, "voxcpm"), (VoxCPM2PipelineConfig, "voxcpm2")],
+)
+def test_pipeline_wiring(config_cls, variant):
+    config = config_cls(model_path="checkpoint")
+    assert [stage.name for stage in config.stages] == [
+        "preprocessing",
+        "tts_engine",
+    ]
+    assert config.stages[0].next == "tts_engine"
+    assert config.stages[1].terminal
+    assert config.stages[0].factory_args["variant"] == variant
+    assert config.stages[1].factory_args["variant"] == variant
+    assert config_cls.mem_fraction_role_to_stage() == {"talker": "tts_engine"}
+    assert config_cls.generation_sglang_role_to_stage() == {"generation": "tts_engine"}
+
+
+def test_raw_model_type_resolution(tmp_path):
+    checkpoint = tmp_path / "model"
+    checkpoint.mkdir()
+    (checkpoint / "config.json").write_text('{"model_type":"voxcpm2"}')
+    assert try_resolve_arch_from_raw_config(str(checkpoint)) == "voxcpm2"
+
+
+def test_engine_builder_injects_missing_voxcpm_model_type(tmp_path):
+    config = {
+        "architecture": "voxcpm",
+        "lm_config": {
+            "hidden_size": 16,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "num_hidden_layers": 2,
+            "max_position_embeddings": 128,
+            "vocab_size": 32,
+        },
+    }
+    (tmp_path / "config.json").write_text(__import__("json").dumps(config))
+    builder = VoxCPMEngineBuilder(variant="voxcpm")
+    builder.pre_infra_setup(str(tmp_path))
+    assert builder.config.model_type == "voxcpm"
+    assert builder.config.architectures == ["VoxCPMSGLangModel"]
+    assert builder.context_length == 128
+
+
+def test_voxcpm1_reference_allows_optional_transcript():
+    without_text = build_voxcpm_state(
+        _payload(ref_audio="data:audio/wav;base64,AAAA"), variant="voxcpm"
+    )
+    with_text = build_voxcpm_state(
+        _payload(
+            ref_audio="data:audio/wav;base64,AAAA",
+            ref_text="reference",
+        ),
+        variant="voxcpm",
+    )
+    assert without_text.reference_mode == "continuation"
+    assert without_text.reference_text is None
+    assert with_text.reference_text == "reference"
+
+
+def test_voxcpm2_reference_modes():
+    isolated = build_voxcpm_state(
+        _payload(ref_audio="data:audio/wav;base64,AAAA"), variant="voxcpm2"
+    )
+    assert isolated.reference_mode == "isolated"
+    continuation = build_voxcpm_state(
+        _payload(
+            ref_audio="data:audio/wav;base64,AAAA",
+            ref_text="reference",
+        ),
+        variant="voxcpm2",
+    )
+    assert continuation.reference_mode == "continuation"
+
+
+def test_generation_parameters_and_validation():
+    values = build_generation_kwargs(
+        {"max_new_tokens": 100},
+        tts_params={
+            "cfg_value": 2.5,
+            "inference_timesteps": 12,
+            "min_len": 3,
+            "streaming_prefix_len": 4,
+            "seed": 7,
+        },
+        variant="voxcpm2",
+    )
+    assert values == {
+        "max_new_tokens": 100,
+        "min_len": 3,
+        "inference_timesteps": 12,
+        "cfg_value": 2.5,
+        "temperature": 1.0,
+        "streaming_prefix_len": 4,
+        "seed": 7,
+    }
+    with pytest.raises(ValueError, match="min_len"):
+        build_generation_kwargs(
+            {"max_new_tokens": 2},
+            tts_params={"min_len": 2},
+            variant="voxcpm",
+        )
+
+
+def test_speech_protocol_accepts_voxcpm_parameters():
+    request = CreateSpeechRequest(
+        input="hello",
+        cfg_value=2.5,
+        inference_timesteps=12,
+        min_len=2,
+        streaming_prefix_len=3,
+    )
+    assert request.cfg_value == 2.5
+    assert request.inference_timesteps == 12

--- a/tests/unit_test/voxcpm/test_runtime.py
+++ b/tests/unit_test/voxcpm/test_runtime.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from sglang_omni.models.voxcpm_common.audio_vae import (
+    CausalConv1d,
+    CausalTransposeConv1d,
+)
+from sglang_omni.models.voxcpm_common.engine_io import (
+    CJKSplitTokenizer,
+    build_prompt_tensors,
+    validate_prompt_length,
+)
+from sglang_omni.models.voxcpm_common.model_runner import (
+    VoxCPMModelRunner,
+    derive_step_seed,
+)
+from sglang_omni.models.voxcpm_common.streaming_vae import (
+    BatchedStreamingVAEDecoder,
+)
+
+
+class _Tokenizer:
+    eos_token_id = 2
+
+    def get_vocab(self):
+        return {"你好": 7, "你": 8, "好": 9, "x": 10}
+
+    def tokenize(self, text):
+        return ["你好"] if text == "你好" else list(text)
+
+    def convert_tokens_to_ids(self, tokens):
+        vocab = self.get_vocab()
+        return [vocab[token] for token in tokens]
+
+    def __len__(self):
+        return 16
+
+
+def test_cjk_multichar_tokens_are_split():
+    assert CJKSplitTokenizer(_Tokenizer()).encode("你好") == [8, 9]
+
+
+def test_voxcpm2_isolated_reference_prompt_layout():
+    ids, features, mask, context = build_prompt_tensors(
+        variant="voxcpm2",
+        tokenizer=CJKSplitTokenizer(_Tokenizer()),
+        target_text="x",
+        reference_text=None,
+        reference_mode="isolated",
+        reference_latents=torch.ones(2, 4, 3),
+        patch_size=4,
+        feat_dim=3,
+    )
+    assert ids.tolist() == [103, 0, 0, 104, 10, 101]
+    assert mask.tolist() == [False, True, True, False, False, False]
+    assert features.shape == (6, 4, 3)
+    assert context is None
+
+
+def test_continuation_retains_version_decode_history():
+    latents = torch.arange(16 * 3, dtype=torch.float32).reshape(4, 4, 3)
+    ids, _, mask, context = build_prompt_tensors(
+        variant="voxcpm2",
+        tokenizer=CJKSplitTokenizer(_Tokenizer()),
+        target_text="x",
+        reference_text="x",
+        reference_mode="continuation",
+        reference_latents=latents,
+        patch_size=4,
+        feat_dim=3,
+    )
+    assert len(ids) == len(mask) == 7
+    assert context.shape == (12, 3)
+    torch.testing.assert_close(context, latents.reshape(-1, 3)[-12:])
+
+
+def test_prompt_length_checks_prompt_and_generation_budget():
+    validate_prompt_length(8, 4, 12)
+    with pytest.raises(ValueError, match="prompt is too long"):
+        validate_prompt_length(13, 1, 12)
+    with pytest.raises(ValueError, match="max_new_tokens"):
+        validate_prompt_length(9, 4, 12)
+
+
+def test_step_seed_is_request_deterministic_and_step_distinct():
+    assert derive_step_seed(7, 3) == derive_step_seed(7, 3)
+    assert derive_step_seed(7, 3) != derive_step_seed(7, 4)
+    assert derive_step_seed(7, 3) != derive_step_seed(8, 3)
+
+
+class _TinyDecoder(nn.Module):
+    def __init__(self):
+        super().__init__()
+        conv = CausalConv1d(1, 1, 3, padding=1, bias=False)
+        nn.init.constant_(conv.weight, 1.0)
+        self.decoder = nn.Sequential(conv)
+
+    def decode(self, latents):
+        return self.decoder(latents)
+
+
+def test_streaming_vae_keeps_request_state_isolated():
+    vae = _TinyDecoder()
+    decoder = BatchedStreamingVAEDecoder(vae, CausalConv1d, CausalTransposeConv1d)
+    first = decoder.decode_chunks(torch.ones(2, 1, 2), ["a", "b"])
+    second = decoder.decode_chunks(torch.tensor([[[2.0]], [[3.0]]]), ["a", "b"])
+    assert first.shape == (2, 1, 2)
+    assert second.shape == (2, 1, 1)
+    assert second[0].item() != second[1].item()
+    decoder.release("a")
+    restarted = decoder.decode_chunks(torch.ones(1, 1, 1), ["a"])
+    assert restarted.shape == (1, 1, 1)
+
+
+def test_streaming_vae_chunks_match_full_causal_decode():
+    vae = _TinyDecoder()
+    decoder = BatchedStreamingVAEDecoder(vae, CausalConv1d, CausalTransposeConv1d)
+    latents = torch.arange(1, 6, dtype=torch.float32).reshape(1, 1, 5)
+    expected = vae.decode(latents)
+    actual = torch.cat(
+        (
+            decoder.decode_chunks(latents[..., :2], ["request"]),
+            decoder.decode_chunks(latents[..., 2:], ["request"]),
+        ),
+        -1,
+    )
+    torch.testing.assert_close(actual, expected)
+
+
+def test_runner_reset_releases_request_and_decoder_state():
+    released = []
+    model_resets = []
+    runner = object.__new__(VoxCPMModelRunner)
+    runner._states = {"request": SimpleNamespace(row=0)}
+    runner._decoder = SimpleNamespace(release=released.append)
+    runner.model = SimpleNamespace(reset_request=model_resets.append)
+
+    runner.reset_request("request")
+    runner.reset_request("request")
+
+    assert runner._states == {}
+    assert released == ["request", "request"]
+    assert model_resets == ["request", "request"]
+
+
+def test_runner_passes_mixed_cfm_step_counts_without_global_mutation():
+    captured = {}
+
+    class _Model:
+        def generate_batch(self, hidden, rows, **kwargs):
+            captured.update(kwargs)
+            return {
+                "latents": hidden.new_zeros((2, 1, 1)),
+                "stop_flag": torch.zeros(2, dtype=torch.long),
+            }
+
+    runner = object.__new__(VoxCPMModelRunner)
+    runner.model = _Model()
+    requests = [
+        SimpleNamespace(
+            data=SimpleNamespace(
+                state=SimpleNamespace(generation_kwargs={"inference_timesteps": steps})
+            )
+        )
+        for steps in (2, 5)
+    ]
+    output = runner._generate_grouped(
+        hidden=torch.ones(2, 3),
+        rows=torch.tensor([0, 1]),
+        temperatures=torch.ones(2),
+        cfg_values=torch.ones(2),
+        noise=torch.ones(2, 1, 1),
+        requests=requests,
+    )
+
+    assert output["latents"].shape == (2, 1, 1)
+    assert captured["inference_timesteps"].tolist() == [2, 5]

--- a/tests/unit_test/voxcpm/test_runtime.py
+++ b/tests/unit_test/voxcpm/test_runtime.py
@@ -15,10 +15,12 @@ from sglang_omni.models.voxcpm_common.audio_vae import (
 from sglang_omni.models.voxcpm_common.engine_io import (
     CJKSplitTokenizer,
     build_prompt_tensors,
+    cap_generation_length,
     validate_prompt_length,
 )
 from sglang_omni.models.voxcpm_common.model_runner import (
     VoxCPMModelRunner,
+    _RequestRuntime,
     derive_step_seed,
 )
 from sglang_omni.models.voxcpm_common.streaming_vae import (
@@ -89,6 +91,13 @@ def test_prompt_length_checks_prompt_and_generation_budget():
         validate_prompt_length(9, 4, 12)
 
 
+def test_generation_length_uses_official_text_relative_bound():
+    assert cap_generation_length(20, 2048) == 130
+    assert cap_generation_length(20, 64) == 64
+    with pytest.raises(ValueError, match="target_token_count"):
+        cap_generation_length(0, 64)
+
+
 def test_step_seed_is_request_deterministic_and_step_distinct():
     assert derive_step_seed(7, 3) == derive_step_seed(7, 3)
     assert derive_step_seed(7, 3) != derive_step_seed(7, 4)
@@ -150,6 +159,152 @@ def test_runner_reset_releases_request_and_decoder_state():
     assert model_resets == ["request", "request"]
 
 
+def test_async_lookahead_routes_done_rows_to_padding_and_trims_input():
+    runner = object.__new__(VoxCPMModelRunner)
+    runner._states = {
+        "done": SimpleNamespace(row=0),
+        "active": SimpleNamespace(row=1),
+    }
+    pool = SimpleNamespace(
+        done=torch.tensor([True, False, False]),
+        padding_row=2,
+    )
+    runner.model = SimpleNamespace(model=SimpleNamespace(state_pool=pool))
+    forward_batch = SimpleNamespace(input_ids=torch.tensor([9, 9, 9, 9]))
+    requests = [
+        SimpleNamespace(request_id="done"),
+        SimpleNamespace(request_id="active"),
+    ]
+
+    runner.before_decode(
+        forward_batch,
+        schedule_batch=None,
+        requests=requests,
+        is_lookahead=True,
+    )
+
+    assert forward_batch.input_ids.tolist() == [2, 1]
+    assert forward_batch.voxcpm_rows.tolist() == [2, 1]
+
+
+def test_runner_reuses_packed_collect_staging():
+    runner = object.__new__(VoxCPMModelRunner)
+    runner.model = SimpleNamespace(
+        model=SimpleNamespace(state_pool=SimpleNamespace(capacity=4))
+    )
+    runner._states = {
+        rid: SimpleNamespace(decoder_initialized=False) for rid in ("first", "second")
+    }
+    runner._collect_device_staging = None
+    runner._decoder = SimpleNamespace(
+        decode_chunks=lambda latents, request_ids, contexts: torch.tensor(
+            [[10.0, 11.0, 12.0], [20.0, 21.0, 22.0]]
+        )
+    )
+    requests = [
+        SimpleNamespace(
+            request_id=rid,
+            data=SimpleNamespace(initial_decode_context=None),
+        )
+        for rid in ("first", "second")
+    ]
+
+    first, latent_shape, audio_width = runner._decode_pack_gpu(
+        latents=torch.tensor([[[1.0, 2.0]], [[3.0, 4.0]]]),
+        stop_flags=torch.tensor([0, 1]),
+        requests=requests,
+    )
+    staging_ptr = runner._collect_device_staging.data_ptr()
+    second, _, _ = runner._decode_pack_gpu(
+        latents=torch.tensor([[[5.0, 6.0]], [[7.0, 8.0]]]),
+        stop_flags=torch.tensor([1, 0]),
+        requests=requests,
+    )
+
+    assert latent_shape == (1, 2)
+    assert audio_width == 3
+    assert runner._collect_device_staging.data_ptr() == staging_ptr
+    assert first.data_ptr() == second.data_ptr()
+    assert second.tolist() == [
+        [5.0, 6.0, 10.0, 11.0, 12.0, 1.0],
+        [7.0, 8.0, 20.0, 21.0, 22.0, 0.0],
+    ]
+
+
+def test_runner_buffers_three_vae_patches_and_flushes_on_stop():
+    decode_inputs = []
+
+    def decode_chunks(latents, request_ids, contexts):
+        decode_inputs.append((latents.clone(), request_ids, contexts))
+        return latents.squeeze(1)
+
+    runner = object.__new__(VoxCPMModelRunner)
+    runner.model = SimpleNamespace(
+        model=SimpleNamespace(state_pool=SimpleNamespace(capacity=4))
+    )
+    runner._states = {"request": _RequestRuntime(row=0)}
+    runner._latent_collect_staging = None
+    runner._vae_decode_every = 3
+    runner._decoder = SimpleNamespace(decode_chunks=decode_chunks)
+    data = SimpleNamespace(
+        initial_decode_context=None,
+        state=SimpleNamespace(
+            generation_kwargs={
+                "min_len": 0,
+                "max_new_tokens": 10,
+                "streaming_prefix_len": 1,
+            }
+        ),
+        generated_latents=[],
+        generated_audio=[],
+        stop_step=None,
+        finish_kind=None,
+        is_streaming=False,
+    )
+    request = SimpleNamespace(request_id="request", data=data)
+
+    for step in range(1, 4):
+        runner._decode_and_collect_buffered(
+            latents=torch.tensor([[[float(step)]]]),
+            stop_flags=torch.tensor([0]),
+            step_counts=[step],
+            requests=[request],
+        )
+
+    assert len(decode_inputs) == 1
+    assert decode_inputs[0][0].tolist() == [[[1.0, 2.0, 3.0]]]
+    assert len(data.generated_latents) == 3
+    assert data.generated_audio[0].tolist() == [1.0, 2.0, 3.0]
+
+    runner._decode_and_collect_buffered(
+        latents=torch.tensor([[[4.0]]]),
+        stop_flags=torch.tensor([1]),
+        step_counts=[4],
+        requests=[request],
+    )
+
+    assert len(decode_inputs) == 2
+    assert decode_inputs[1][0].tolist() == [[[4.0]]]
+    assert data.generated_audio[1].tolist() == [4.0]
+    assert data.stop_step == 3
+    assert data.finish_kind == "stop"
+
+
+def test_async_lookahead_rejects_nondefault_cfm_steps():
+    runner = object.__new__(VoxCPMModelRunner)
+    runner._vae_decode_every = 1
+    runner.model = SimpleNamespace(
+        diffusion_graph_max_bs=8,
+        model=SimpleNamespace(feat_decoder=SimpleNamespace(inference_timesteps=10)),
+    )
+    data = SimpleNamespace(
+        state=SimpleNamespace(generation_kwargs={"inference_timesteps": 4})
+    )
+    batch = SimpleNamespace(reqs=[SimpleNamespace(_omni_data=data)])
+
+    assert runner.lookahead_eligible(batch) is False
+
+
 def test_runner_passes_mixed_cfm_step_counts_without_global_mutation():
     captured = {}
 
@@ -182,3 +337,43 @@ def test_runner_passes_mixed_cfm_step_counts_without_global_mutation():
 
     assert output["latents"].shape == (2, 1, 1)
     assert captured["inference_timesteps"].tolist() == [2, 5]
+
+
+def test_runner_uses_diffusion_graph_for_default_step_count():
+    captured = {}
+
+    class _Model:
+        model = SimpleNamespace(feat_decoder=SimpleNamespace(inference_timesteps=10))
+        diffusion_graph_max_bs = 8
+
+        def generate_batch_graphed(self, hidden, rows, **kwargs):
+            captured.update(kwargs)
+            return {
+                "latents": hidden.new_zeros((2, 1, 1)),
+                "stop_flag": torch.zeros(2, dtype=torch.long),
+            }
+
+        def generate_batch(self, *_args, **_kwargs):
+            raise AssertionError("default step count should use the diffusion graph")
+
+    runner = object.__new__(VoxCPMModelRunner)
+    runner.model = _Model()
+    requests = [
+        SimpleNamespace(
+            data=SimpleNamespace(
+                state=SimpleNamespace(generation_kwargs={"inference_timesteps": 10})
+            )
+        )
+        for _ in range(2)
+    ]
+    output = runner._generate_grouped(
+        hidden=torch.ones(2, 3),
+        rows=torch.tensor([0, 1]),
+        temperatures=torch.ones(2),
+        cfg_values=torch.ones(2),
+        noise=torch.ones(2, 1, 1),
+        requests=requests,
+    )
+
+    assert output["latents"].shape == (2, 1, 1)
+    assert captured["z_noise"].shape == (2, 1, 1)


### PR DESCRIPTION
## Summary
- add SGLang-native VoxCPM 1.0, 1.5, and VoxCPM2 model cores with radix-cached MiniCPM backbones
- add request-scoped latent generation, streaming AudioVAE decoding, and official checkpoint/config loading
- integrate VoxCPM speech parameters, pipeline stages, runtime configuration, versioned examples, documentation, and tests

## Test plan
- [x] `python -m pytest -q tests/unit_test/voxcpm` (30 passed)
- [x] `python -m compileall -q sglang_omni/models/voxcpm_common sglang_omni/models/voxcpm sglang_omni/models/voxcpm2`
- [x] CPU smoke-test native V1/V2 AudioVAE construction, strict checkpoint reload, and decoding
- [ ] Run GPU parity against the nano-vllm reference checkpoints