### PR TITLE
[Consumer GPU] Add 24 GB TTS memory fallbacks

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,35 @@
+FROM hongccc/sglang-omni@sha256:6a8f60af7ca868dc266c118249d12fc73ba85e2e8075e5e31473bd25d349acfa
+
+ENV TRITON_LIBCUDA_PATH="/usr/lib/x86_64-linux-gnu"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends sox \
+    && ln -sfn libcuda.so.1 /usr/lib/x86_64-linux-gnu/libcuda.so \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir \
+        accelerate==1.14.0 \
+        hydra-core==1.3.4 \
+        jiwer==4.0.0 \
+        librosa==0.11.0 \
+        "mistral_common[audio]==1.11.2" \
+        modelscope==1.37.1 \
+        msgpack==1.2.1 \
+        numba==0.63.1 \
+        onnxruntime==1.28.0 \
+        pytest-asyncio==1.4.0 \
+        qwen-vl-utils==0.0.11 \
+        silero-vad==6.2.1 \
+        socksio==1.0.0 \
+        websockets==16.1.1 \
+        x-transformers==2.24.0 \
+        zhon==2.1.1 \
+    && pip install --no-cache-dir \
+        descript-audio-codec==1.0.0 \
+        descript-audiotools==0.7.2 \
+    && pip install --no-cache-dir --no-deps qwen-tts==0.1.1 \
+    && pip install --no-cache-dir "protobuf>=6.31.1,<7"
+
+WORKDIR /opt/sglang-omni
+COPY . .
+RUN pip install --no-cache-dir --no-deps -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "fastapi>=0.110.0",       # OpenAI-compatible API adapter
     "uvicorn>=0.23.0",        # ASGI server for FastAPI
     "sglang==0.5.12.post1",
-    "flash-attn-4>=4.0.0b9,<4.0.0b16",  # Avoid cutlass-dsl>=4.5.2 conflict
     "kernels>=0.14.0,<0.15",  # Match Transformers 5.6 / SGLang 0.5.12.post1 stack (ships kernels 0.14.1)
     "nixl-cu13>=1.1.0",  # CUDA 13 relay wheel; the generic nixl/-cu12 wheel breaks on cu130
     "mooncake-transfer-engine-cuda13>=0.3.10",  # CUDA 13 relay wheel; generic mooncake-transfer-engine pulls cu12 and breaks import mooncake on cu130
@@ -80,6 +79,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+flash-attn-4 = [
+    "flash-attn-4>=4.0.0b9,<4.0.0b16",  # SM100 only; avoid cutlass-dsl>=4.5.2 conflict
+]
 audar-tts = [
     "llama-cpp-python==0.3.34",
     "neucodec==0.0.6",
@@ -92,6 +94,11 @@ sgl-omni-router = "sglang_omni_router.serve:main"
 [tool.uv]
 override-dependencies = [
     "protobuf>=6.31.1,<7.0.0",
+]
+exclude-dependencies = [
+    # FA4 only supports datacenter Blackwell (SM100). Install the
+    # `flash-attn-4` extra explicitly with pip on that architecture.
+    "flash-attn-4",
 ]
 
 [tool.pytest.ini_options]

--- a/sglang_omni/models/fishaudio_s2_pro/config.py
+++ b/sglang_omni/models/fishaudio_s2_pro/config.py
@@ -17,6 +17,10 @@ class S2ProPipelineConfig(PipelineConfig):
     requires_model_capabilities: ClassVar[bool] = True
 
     @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"talker": "tts_engine"}
+
+    @classmethod
     def talker_sglang_role_to_stage(cls) -> dict[str, str]:
         return {"talker": "tts_engine"}
 

--- a/sglang_omni/models/fishaudio_s2_pro/engine_builder.py
+++ b/sglang_omni/models/fishaudio_s2_pro/engine_builder.py
@@ -10,6 +10,10 @@ from typing import Any
 from sglang_omni.models.fishaudio_s2_pro import request_builders
 from sglang_omni.models.fishaudio_s2_pro import stages as fish_stages
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
+from sglang_omni.utils.gpu_compat import (
+    get_visible_gpu_sm_version,
+    preferred_sglang_attention_backend,
+)
 
 
 class FishS2ProEngineBuilder(TtsEngineBuilder):
@@ -52,7 +56,9 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
     def customize_server_args(self, server_args: Any) -> None:
         server_args.disable_overlap_schedule = True
         if getattr(server_args, "attention_backend", None) is None:
-            server_args.attention_backend = "fa3"
+            server_args.attention_backend = preferred_sglang_attention_backend(
+                get_visible_gpu_sm_version(0)
+            )
 
     def setup_model(
         self,

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 import torch
@@ -50,6 +51,19 @@ def store_state(payload: StagePayload, state: MossTTSState) -> StagePayload:
 
 def _torch_dtype(dtype: str | torch.dtype) -> torch.dtype:
     return getattr(torch, dtype) if isinstance(dtype, str) else dtype
+
+
+def _resolve_vocoder_dtype(device: str, dtype: str) -> str:
+    override = os.getenv("MOSS_TTS_VOCODER_DTYPE")
+    if override:
+        return override
+    if (
+        dtype == "float32"
+        and device.startswith("cuda")
+        and torch.cuda.get_device_properties(device).total_memory < 32 * 1024**3
+    ):
+        return "bfloat16"
+    return dtype
 
 
 def _normalize_moss_processor_config(processor: Any) -> None:
@@ -135,9 +149,10 @@ create_tts_engine_executor = create_sglang_tts_engine_executor
 
 
 class _MossTTSVocoder(BatchVocoderBase):
-    def __init__(self, processor: Any, device: str) -> None:
+    def __init__(self, processor: Any, device: str, dtype: str) -> None:
         self._processor = processor
         self._device = device
+        self._dtype = dtype
 
     def prepare_item(self, payload: StagePayload) -> tuple[MossTTSState, torch.Tensor]:
         state = load_state(payload)
@@ -168,7 +183,12 @@ class _MossTTSVocoder(BatchVocoderBase):
         )
         decoded = []
         for segment in segments:
-            decoded.extend(self._processor.decode_audio_codes([segment]))
+            with torch.autocast(
+                device_type="cuda",
+                dtype=_torch_dtype(self._dtype),
+                enabled=self._device.startswith("cuda") and self._dtype != "float32",
+            ):
+                decoded.extend(self._processor.decode_audio_codes([segment]))
         if not decoded:
             raise RuntimeError("MOSS-TTS vocoder decoded no audio segments")
         waveforms = [
@@ -225,9 +245,10 @@ def create_vocoder_executor(
 ) -> SimpleScheduler:
     if gpu_id is not None:
         device = f"cuda:{gpu_id}"
+    dtype = _resolve_vocoder_dtype(device, dtype)
     processor = _load_moss_processor(model_path, device=device, dtype=dtype)
 
-    return _MossTTSVocoder(processor, device).build_scheduler(
+    return _MossTTSVocoder(processor, device, dtype).build_scheduler(
         max_batch_size=max_batch_size,
         max_batch_wait_ms=max_batch_wait_ms,
     )

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -161,6 +161,21 @@ def _resolve_codec_device(device: str | None, gpu_id: int | None) -> str:
     return "cuda:0"
 
 
+def _resolve_preprocessing_codec_device(device: str) -> str:
+    override = os.environ.get("MOSS_TTS_LOCAL_PREPROCESSING_DEVICE")
+    if override:
+        return override
+    if device.startswith("cuda"):
+        device_index = torch.device(device).index or 0
+        if torch.cuda.get_device_properties(device_index).total_memory < 32 * 1024**3:
+            logger.info(
+                "Using CPU for MOSS-TTS Local reference encoding on a GPU with "
+                "<32 GiB VRAM; set MOSS_TTS_LOCAL_PREPROCESSING_DEVICE to override"
+            )
+            return "cpu"
+    return device
+
+
 def _load_moss_tts_local_processor(model_path: str) -> Any:
     checkpoint_dir = resolve_moss_checkpoint(model_path)
     logger.info(f"Loading MOSS-TTS Local processor from {checkpoint_dir} without codec")
@@ -505,7 +520,7 @@ def create_preprocessing_executor(
             "off",
             "",
         )
-    device = _resolve_codec_device(device, gpu_id)
+    device = _resolve_preprocessing_codec_device(_resolve_codec_device(device, gpu_id))
     processor = _load_moss_tts_local_processor(model_path)
     audio_tokenizer = load_moss_tts_local_audio_tokenizer(
         _resolve_audio_tokenizer_model_path(processor, codec_model_path),

--- a/sglang_omni/models/voxtral_tts/config.py
+++ b/sglang_omni/models/voxtral_tts/config.py
@@ -20,6 +20,10 @@ class VoxtralTTSPipelineConfig(PipelineConfig):
     requires_model_capabilities: ClassVar[bool] = True
 
     @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"talker": GENERATION_STAGE}
+
+    @classmethod
     def generation_sglang_role_to_stage(cls) -> dict[str, str]:
         return {"generation": "tts_generation"}
 

--- a/sglang_omni/utils/gpu_compat.py
+++ b/sglang_omni/utils/gpu_compat.py
@@ -20,6 +20,37 @@ logger = logging.getLogger(__name__)
 
 _FLASHINFER_USE_CUDA_NORM = "FLASHINFER_USE_CUDA_NORM"
 
+_GPU_ARCHITECTURES = {
+    89: "ada",
+    90: "hopper",
+    100: "blackwell-datacenter",
+    120: "blackwell-consumer",
+}
+
+
+def gpu_architecture_for_sm(sm_version: int | None) -> str:
+    """Return the CUDA architecture family without conflating SM100 and SM120."""
+    if sm_version is None:
+        return "unknown"
+    return _GPU_ARCHITECTURES.get(sm_version, f"sm{sm_version}")
+
+
+def architecture_supports_flash_attention_3(sm_version: int | None) -> bool:
+    """Return whether the GPU architecture can run the FA3 backend."""
+    return sm_version == 90
+
+
+def architecture_supports_flash_attention_4(sm_version: int | None) -> bool:
+    """Return whether the GPU architecture can run the FA4 backend."""
+    return sm_version == 100
+
+
+def preferred_sglang_attention_backend(sm_version: int | None) -> str:
+    """Choose a backend by architecture; package availability is checked downstream."""
+    return (
+        "fa3" if architecture_supports_flash_attention_3(sm_version) else "flashinfer"
+    )
+
 
 def _get_compute_capability(
     logical_gpu_id: int,

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -16,6 +16,7 @@ import typer
 
 from sglang_omni.cli.serve import apply_torch_compile_cli_overrides
 from sglang_omni.models.fishaudio_s2_pro.config import S2ProPipelineConfig
+from sglang_omni.models.fishaudio_s2_pro.engine_builder import FishS2ProEngineBuilder
 from sglang_omni.models.fishaudio_s2_pro.fish_speech.tokenizer import (
     IM_END_TOKEN,
     IM_START_TOKEN,
@@ -101,6 +102,26 @@ def test_fish_config_state_and_tokenizer_prompt_contracts() -> None:
     assert prompt["vq_mask_tokens"].sum().item() == 2
     assert torch.equal(prompt["vq_parts"][0], torch.tensor([[0, 1], [10, 11]]))
     assert any("<|speaker:alice|>target" in text for text in tokenizer.encoded_texts)
+
+
+@pytest.mark.parametrize("sm_version,expected", [(89, "flashinfer"), (90, "fa3")])
+def test_fish_attention_backend_follows_gpu_capability(
+    monkeypatch: pytest.MonkeyPatch,
+    sm_version: int,
+    expected: str,
+) -> None:
+    monkeypatch.setattr(
+        "sglang_omni.models.fishaudio_s2_pro.engine_builder.get_visible_gpu_sm_version",
+        lambda _gpu_id: sm_version,
+    )
+    server_args = SimpleNamespace(attention_backend=None)
+
+    FishS2ProEngineBuilder(max_new_tokens=32, ras_window=0).customize_server_args(
+        server_args
+    )
+
+    assert server_args.attention_backend == expected
+    assert server_args.disable_overlap_schedule is True
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -272,6 +272,21 @@ def test_moss_tts_talker_torch_compile_cli_override_targets_tts_engine() -> None
     assert server_args_overrides["torch_compile_max_bs"] == 4
 
 
+def test_moss_tts_vocoder_uses_bfloat16_on_low_vram(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    monkeypatch.delenv("MOSS_TTS_VOCODER_DTYPE", raising=False)
+    monkeypatch.setattr(
+        stages.torch.cuda,
+        "get_device_properties",
+        lambda _device: SimpleNamespace(total_memory=24 * 1024**3),
+    )
+    assert stages._resolve_vocoder_dtype("cuda:0", "float32") == "bfloat16"
+    assert stages._resolve_vocoder_dtype("cpu", "float32") == "float32"
+
+
 def test_moss_tts_vocoder_uses_batch_base_path(monkeypatch: pytest.MonkeyPatch) -> None:
     from sglang_omni.models.moss_tts import stages
 

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -765,6 +765,20 @@ def _payload(text: str = "hello") -> StagePayload:
     )
 
 
+def test_preprocessing_codec_uses_cpu_on_low_vram(monkeypatch):
+    from sglang_omni.models.moss_tts_local import stages
+
+    monkeypatch.setattr(
+        stages.torch.cuda,
+        "get_device_properties",
+        lambda _device: types.SimpleNamespace(total_memory=24 * 1024**3),
+    )
+    assert stages._resolve_preprocessing_codec_device("cuda:0") == "cpu"
+
+    monkeypatch.setenv("MOSS_TTS_LOCAL_PREPROCESSING_DEVICE", "cuda:0")
+    assert stages._resolve_preprocessing_codec_device("cuda:0") == "cuda:0"
+
+
 def test_create_preprocessing_executor_cache_toggles(monkeypatch):
     from sglang_omni.models.moss_tts_local import request_builders as rb
     from sglang_omni.models.moss_tts_local import stages

--- a/tests/unit_test/pipeline/test_gpu_architecture.py
+++ b/tests/unit_test/pipeline/test_gpu_architecture.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from sglang_omni.utils.gpu_compat import (
+    architecture_supports_flash_attention_3,
+    architecture_supports_flash_attention_4,
+    gpu_architecture_for_sm,
+    preferred_sglang_attention_backend,
+)
+
+
+def test_gpu_architectures_do_not_conflate_blackwell_variants() -> None:
+    assert gpu_architecture_for_sm(89) == "ada"
+    assert gpu_architecture_for_sm(90) == "hopper"
+    assert gpu_architecture_for_sm(100) == "blackwell-datacenter"
+    assert gpu_architecture_for_sm(120) == "blackwell-consumer"
+    assert architecture_supports_flash_attention_3(90)
+    assert not architecture_supports_flash_attention_3(89)
+    assert architecture_supports_flash_attention_4(100)
+    assert not architecture_supports_flash_attention_4(120)
+    assert preferred_sglang_attention_backend(89) == "flashinfer"
+    assert preferred_sglang_attention_backend(90) == "fa3"


### PR DESCRIPTION
## Summary

- add conservative low-memory fallbacks for MOSS-TTS and MOSS-TTS Local
- add memory-role mappings for FishAudio S2-Pro and Voxtral TTS
- preserve explicit environment overrides for users who want GPU preprocessing or float32 vocoding

## Dependency

Stacked on #1199. Merge #1199 first, then rebase this PR onto `main`. This PR contains only the low-memory model changes.

## Why

On 24 GB RTX 4090/4090D cards, colocated reference codecs and float32 vocoders consume enough memory to prevent otherwise viable pipelines from starting. The defaults use BF16 for the MOSS-TTS vocoder and CPU reference preprocessing for MOSS-TTS Local only on GPUs below 32 GiB.

## Validation

- RTX 4090D using `hongccc/sglang-omni:4090D`
- newly added behavior: 5 passed
- affected model suites: 140 passed; three unrelated Triton compilation tests were separately verified after correcting the server container runtime mount

Related to #1120.
