### PR TITLE
[Benchmark] MOSS-Transcribe-Diarize RTX 5090 (32 GB) profiles and validation

### DIFF
--- a/docs/cookbook/moss_transcribe_diarize.md
+++ b/docs/cookbook/moss_transcribe_diarize.md
@@ -248,3 +248,29 @@ Thanks for the joint effort of the OpenMOSS team and SGLang Omni team.
 MOSS Team: Donghua Yu, Zhengyuan Lin, Hanfu Chen, Yiyang Zhang, Yang Gao, Zhaoye Fei, Qinyuan Cheng, Shimin Li, Xipeng Qiu
 
 SGLang Omni Team: Yijiang Tian, Xinli Jing, Xiangrui Ke, Zhihao Guo, Ruoqi Zhang, Lifan Shen, Jintao Qu, Xuxiang Tian, Kaige Li, Ratish P, Haoguang Cai, Zijie Xia, Chenchen Hong, Xuesong Ye, Jingwen Gu,  Jiaxin Deng, Jiaxuan Luo, Xinyu Lu, Hao Jin, Chenyang Zhao, Yichi Zhang
+
+## Consumer GPU: RTX 5090 (32 GB) profiles
+
+Validated on a single RTX 5090 (SM120, driver 595.71.05, CUDA 13.2, BF16,
+FlashInfer attention). Accuracy matches the H100 CI references on both
+movies800 (CER 5.77–5.83% vs 5.806%) and AISHELL4-Long (CER 13.76–13.86%
+vs 13.80%) with zero failed requests.
+
+Two profiles, selected by audio duration:
+
+| Profile | Config | Audio length | Concurrency |
+|---|---|---|---|
+| Default | `examples/configs/moss_transcribe_diarize_rtx5090.yaml` | ≤ ~30 min | up to 16; **throughput peaks at 8 on this GPU** |
+| Long audio | `examples/configs/moss_transcribe_diarize_rtx5090_long_audio.yaml` | up to ~90 min | 1 (up to 2 for ≤ ~40 min) |
+
+The split exists because the binding constraint for long audio is the
+transient encoder activation (measured 2.66–3.10 GiB per long-audio encode),
+not KV-cache capacity: the default `mem_fraction_static=0.80` pool leaves too
+little free memory for the encode of items beyond ~30 min, which then fails
+as a request-level OOM. The long-audio profile trades pool size for encoder
+headroom; a 90-min request peaks at 31.6 GiB.
+
+24 GB (RTX 4090) note — extrapolated, needs owner validation: measured
+non-pool footprint reaches ~8.4 GiB (60 min) to ~14.4 GiB (90 min), so
+90-min items should be considered a 32 GB-class capability; ≤30-min audio is
+plausible on 24 GB at a reduced fraction.

--- a/docs/cookbook/moss_transcribe_diarize.md
+++ b/docs/cookbook/moss_transcribe_diarize.md
@@ -261,7 +261,7 @@ Two profiles, selected by audio duration:
 | Profile | Config | Audio length | Concurrency |
 |---|---|---|---|
 | Default | `examples/configs/moss_transcribe_diarize_rtx5090.yaml` | ≤ ~30 min | up to 16; **throughput peaks at 8 on this GPU** |
-| Long audio | `examples/configs/moss_transcribe_diarize_rtx5090_long_audio.yaml` | up to ~90 min | 1 (up to 2 for ≤ ~40 min) |
+| Long audio | `examples/configs/moss_transcribe_diarize_rtx5090_long_audio.yaml` | up to ~90 min | ≤2 validated to ~39-min sessions; 60–90 min validated at c=1 |
 
 The split exists because the binding constraint for long audio is the
 transient encoder activation (measured 2.66–3.10 GiB per long-audio encode),

--- a/examples/configs/moss_transcribe_diarize_rtx5090.yaml
+++ b/examples/configs/moss_transcribe_diarize_rtx5090.yaml
@@ -11,10 +11,11 @@ runtime_overrides:
   asr:
     dtype: bfloat16
     max_running_requests: 16
+    server_args_overrides:
+      cuda_graph_max_bs: 16
 
 stage_overrides:
   asr:
     runtime:
       sglang_server_args:
         mem_fraction_static: 0.80
-        cuda_graph_max_bs: 16

--- a/examples/configs/moss_transcribe_diarize_rtx5090.yaml
+++ b/examples/configs/moss_transcribe_diarize_rtx5090.yaml
@@ -1,0 +1,20 @@
+# Default single-GPU profile validated on one RTX 5090 (SM120, 32 GB).
+# Covers short/medium audio up to ~30 min per request; peak throughput at
+# concurrency 8 on this GPU. For >30 min items use
+# moss_transcribe_diarize_rtx5090_long_audio.yaml (the binding constraint is
+# transient encoder activation memory, not KV cache).
+config_cls: MossTranscribeDiarizePipelineConfig
+name: moss-transcribe-diarize-rtx5090
+model_path: OpenMOSS-Team/MOSS-Transcribe-Diarize
+
+runtime_overrides:
+  asr:
+    dtype: bfloat16
+    max_running_requests: 16
+
+stage_overrides:
+  asr:
+    runtime:
+      sglang_server_args:
+        mem_fraction_static: 0.80
+        cuda_graph_max_bs: 16

--- a/examples/configs/moss_transcribe_diarize_rtx5090_long_audio.yaml
+++ b/examples/configs/moss_transcribe_diarize_rtx5090_long_audio.yaml
@@ -1,6 +1,6 @@
 # Long-audio single-GPU profile validated on one RTX 5090 (SM120, 32 GB).
-# Serves the full advertised ~90-min range at concurrency 1 (peak 31.6 GiB)
-# and ~39-min sessions at concurrency 2. The reduced memory fraction leaves
+# Concurrency <=2 validated to ~39-min sessions; 60-90 min validated at c=1
+# (90-min peak 31.6 GiB). The reduced memory fraction leaves
 # headroom for the transient encoder activation (measured 2.66-3.10 GiB per
 # long-audio encode), which is what fails first under the default profile.
 config_cls: MossTranscribeDiarizePipelineConfig

--- a/examples/configs/moss_transcribe_diarize_rtx5090_long_audio.yaml
+++ b/examples/configs/moss_transcribe_diarize_rtx5090_long_audio.yaml
@@ -11,10 +11,11 @@ runtime_overrides:
   asr:
     dtype: bfloat16
     max_running_requests: 4
+    server_args_overrides:
+      cuda_graph_max_bs: 4
 
 stage_overrides:
   asr:
     runtime:
       sglang_server_args:
         mem_fraction_static: 0.55
-        cuda_graph_max_bs: 4

--- a/examples/configs/moss_transcribe_diarize_rtx5090_long_audio.yaml
+++ b/examples/configs/moss_transcribe_diarize_rtx5090_long_audio.yaml
@@ -1,0 +1,20 @@
+# Long-audio single-GPU profile validated on one RTX 5090 (SM120, 32 GB).
+# Serves the full advertised ~90-min range at concurrency 1 (peak 31.6 GiB)
+# and ~39-min sessions at concurrency 2. The reduced memory fraction leaves
+# headroom for the transient encoder activation (measured 2.66-3.10 GiB per
+# long-audio encode), which is what fails first under the default profile.
+config_cls: MossTranscribeDiarizePipelineConfig
+name: moss-transcribe-diarize-rtx5090-long-audio
+model_path: OpenMOSS-Team/MOSS-Transcribe-Diarize
+
+runtime_overrides:
+  asr:
+    dtype: bfloat16
+    max_running_requests: 4
+
+stage_overrides:
+  asr:
+    runtime:
+      sglang_server_args:
+        mem_fraction_static: 0.55
+        cuda_graph_max_bs: 4

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import inspect
+from pathlib import Path
 
 import httpx
 import pytest
 import torch
 from huggingface_hub.errors import RepositoryNotFoundError
 
+from sglang_omni.config.manager import ConfigManager
+from sglang_omni.config.runtime import resolve_stage_static_factory_args
 from sglang_omni.models.moss_transcribe_diarize.config import (
     MossTranscribeDiarizePipelineConfig,
 )
@@ -105,6 +108,36 @@ def test_moss_transcribe_diarize_preserves_explicit_omp_default(
     )
 
     assert config.env_defaults["OMP_NUM_THREADS"] == "3"
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_max_running", "expected_mem_fraction", "expected_graph_bs"),
+    [
+        ("moss_transcribe_diarize_rtx5090.yaml", 16, 0.80, 16),
+        ("moss_transcribe_diarize_rtx5090_long_audio.yaml", 4, 0.55, 4),
+    ],
+)
+def test_rtx5090_profiles_resolve_validated_runtime(
+    filename: str,
+    expected_max_running: int,
+    expected_mem_fraction: float,
+    expected_graph_bs: int,
+) -> None:
+    config_path = Path(__file__).parents[3] / "examples" / "configs" / filename
+    config = ConfigManager.from_file(str(config_path)).config
+    assert config is not None
+
+    args = resolve_stage_static_factory_args(config.stages[0], config)
+    inspect.signature(create_sglang_moss_transcribe_diarize_executor).bind_partial(
+        **args
+    )
+
+    assert args["max_running_requests"] == expected_max_running
+    assert args["server_args_overrides"]["mem_fraction_static"] == pytest.approx(
+        expected_mem_fraction
+    )
+    assert args["server_args_overrides"]["cuda_graph_max_bs"] == expected_graph_bs
+    assert "cuda_graph_max_bs" not in args
 
 
 def test_moss_transcribe_diarize_stage_reserves_encoder_headroom() -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Part of #1120 (consumer-GPU roadmap). MOSS-Transcribe-Diarize validation on a single RTX 5090 (SM120, 32 GB) is complete — benchmark report and exit-criteria results in #1189. This PR contributes the validated serving profiles and documentation.

Headline: accuracy matches the H100 CI references on movies800 (CER 5.77–5.83% vs 5.806%) and AISHELL4-Long (CER 13.76–13.86% vs 13.80%) with zero failed requests (7,320 + supplements); throughput peaks at concurrency 8 on this GPU; long audio serves under a dedicated reduced-fraction profile — concurrency ≤2 validated to ~39-min sessions; 60–90 min validated at c=1 (90-min peak 31.6 GiB).

## Modifications

- `examples/configs/moss_transcribe_diarize_rtx5090.yaml` — default profile (≤ ~30 min audio, mem_fraction_static 0.80, mrr 16)
- `examples/configs/moss_transcribe_diarize_rtx5090_long_audio.yaml` — long-audio profile (fraction 0.55, mrr 4; concurrency ≤2 validated to ~39-min sessions, 60–90 min validated at c=1)
- `docs/cookbook/moss_transcribe_diarize.md` — consumer-GPU section: profile selection table, encoder-activation constraint explanation, 24 GB feasibility note (90-min is 32 GB-class; boundary estimated between 45–60 min pending 4090 measurement)

## Related Issues

Part of #1120. Detailed benchmark and exit-criteria results: #1189.

## Implementation and review

- Benchmark report: #1189
- Raw JSON artifacts: https://gist.github.com/ChaoyuWang04/d3105c53889740f038d6477dbf112b94
- Findings filed separately: encoder-OOM stage crash (#1201 ), SIGTERM worker cleanup corroboration (#1153), malformed-input hardening gap (vs #1154).

## Accuracy Test

movies800 800/800 ×3 repeats per concurrency {1,8,16}: CER 5.77–5.83% / DER 21.0% vs H100 CI refs 5.806% / 21.01%. AISHELL4-Long ×3 (long-audio profile, c2): CER 13.76–13.86% / DER 9.44–9.71% vs refs 13.80% / 9.56%. These compare against the CI-calibrated sglang-omni references; the #959 framework-versus-vanilla question is orthogonal and out of scope.

## Benchmark & Profiling

Full details in #1189: per-concurrency throughput/latency/RTF tables, duration×concurrency peak-memory map with profile-convergence evidence (0.80 ❌ → 0.65 ❌ → 0.55 ✅), 30-min mixed soak (51,408/51,408 normal requests, malformed-lane counts split by class).

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests. — N/A (config + docs only)
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
