### PR TITLE
[Benchmark][ASR] Report RTFx and repeat coverage

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -209,8 +209,10 @@ docstring (sequential phases on CI to reduce OOM risk).
 `benchmark_asr_seedtts.py` is a standalone ASR fan-out sweep (issue #646): it
 transcribes the SeedTTS *reference* clips directly against a running Qwen3-ASR
 or Fun-ASR router and reports WER + speed + per-worker routing balance per
-concurrency level. Use it to measure how ASR concurrency affects throughput,
-latency, and WER for a given workload.
+concurrency level. It reports evaluation coverage and RTFx (successful
+input-audio seconds per wall-clock second) alongside the existing RTF. Use it
+to measure how ASR concurrency affects capacity, latency, and WER for a given
+workload.
 
 Both `*_seedtts.py` scripts also support speech quality and similarity evaluation via UTMOS and WavLM speaker verification metrics. Running with `--utmos-only` or `--similarity-only` loads the respective pre-trained predictor and computes scores on the previously generated audio in the output directory without requiring the TTS/ASR servers to be running.
 

--- a/benchmarks/eval/benchmark_asr_seedtts.py
+++ b/benchmarks/eval/benchmark_asr_seedtts.py
@@ -250,8 +250,8 @@ def _aggregate(repeats: list[dict]) -> dict:
     }
 
 
-def _format_metric(value: float | None, digits: int) -> str:
-    return "n/a" if value is None else f"{value:.{digits}f}"
+def _format_metric(value: float | None, digits: int, suffix: str = "") -> str:
+    return "n/a" if value is None else f"{value:.{digits}f}{suffix}"
 
 
 def _print_table(aggregates: list[dict]) -> None:
@@ -354,8 +354,8 @@ async def _sweep(args, samples, concurrencies: list[int]) -> list[dict]:
                 f"wall={result['wall_clock_s']:.3f}s "
                 f"thrpt={result['throughput_samples_per_s']:.3f}/s "
                 f"rtfx={result['rtfx']:.3f} "
-                f"lat_mean={_format_metric(result['latency_mean_s'], 3)}s "
-                f"lat_p95={_format_metric(result['latency_p95_s'], 3)}s "
+                f"lat_mean={_format_metric(result['latency_mean_s'], 3, 's')} "
+                f"lat_p95={_format_metric(result['latency_p95_s'], 3, 's')} "
                 f"rtf_mean={_format_metric(result['rtf_mean'], 4)} "
                 f"corpus_wer={_format_metric(result['corpus_wer'], 4)} "
                 f"evaluated={result['evaluated']}/{result['total']}"

--- a/benchmarks/eval/benchmark_asr_seedtts.py
+++ b/benchmarks/eval/benchmark_asr_seedtts.py
@@ -5,8 +5,9 @@
 """ASR concurrency benchmark on SeedTTS reference audio (issue #646).
 
 This script transcribes SeedTTS reference clips directly through a running ASR
-router and reports WER, throughput, latency, RTF, and worker routing balance.
-It supports both Qwen3-ASR and Fun-ASR-Nano through ``--model-path``.
+router and reports WER, request throughput, RTFx, RTF, latency, and worker
+routing balance. It supports both Qwen3-ASR and Fun-ASR-Nano through
+``--model-path``.
 
 Usage:
 
@@ -185,46 +186,61 @@ async def _run_repeat(args, samples, concurrency: int, repeat: int) -> dict:
     )
     summary = benchmark_result["summary"]
     speed = benchmark_result["speed"]
+    has_evaluated_samples = summary["evaluated"] > 0
+    has_rtf = speed["rtf_p95"] is not None
     return {
         "concurrency": concurrency,
         "repeat": repeat,
         "evaluated": summary["evaluated"],
         "total": summary["total_samples"],
         "skipped": summary["skipped"],
-        "corpus_wer": summary["corpus_wer"],
-        "per_sample_wer_max": summary["wer_per_sample_max"],
+        "corpus_wer": summary["corpus_wer"] if has_evaluated_samples else None,
+        "per_sample_wer_max": (
+            summary["wer_per_sample_max"] if has_evaluated_samples else None
+        ),
         "wall_clock_s": benchmark_result["wall_clock_s"],
         "throughput_samples_per_s": speed["throughput_samples_per_s"],
-        "latency_mean_s": speed["latency_mean_s"],
-        "latency_p95_s": speed["latency_p95_s"],
-        "latency_p99_s": speed["latency_p99_s"],
-        "rtf_mean": speed["rtf_mean"],
+        "rtfx": speed["rtfx"],
+        "latency_mean_s": (speed["latency_mean_s"] if has_evaluated_samples else None),
+        "latency_p95_s": (speed["latency_p95_s"] if has_evaluated_samples else None),
+        "latency_p99_s": (speed["latency_p99_s"] if has_evaluated_samples else None),
+        "rtf_mean": speed["rtf_mean"] if has_rtf else None,
         "rtf_p95": speed["rtf_p95"],
         "worker": benchmark_result["worker"],
     }
 
 
 def _aggregate(repeats: list[dict]) -> dict:
-    """Mean/best/worst across repeats for the headline metrics."""
+    """Aggregate repeat metrics without hiding failed or partial work."""
+    if not repeats:
+        raise ValueError("At least one repeat is required")
 
     def _stat(key: str) -> dict:
-        values = [r[key] for r in repeats]
+        values = [r[key] for r in repeats if r[key] is not None]
+        if not values:
+            return {"mean": None, "min": None, "max": None, "n": 0}
         return {
             "mean": statistics.mean(values),
             "min": min(values),
             "max": max(values),
+            "n": len(values),
         }
+
+    total_requests = sum(r["total"] for r in repeats)
+    evaluated = sum(r["evaluated"] for r in repeats)
+    skipped = sum(r["skipped"] for r in repeats)
 
     return {
         "concurrency": repeats[0]["concurrency"],
         "repeats": len(repeats),
-        "evaluated": repeats[0]["evaluated"],
-        "total": repeats[0]["total"],
-        "skipped": repeats[0]["skipped"],
+        "evaluated": evaluated,
+        "total": total_requests,
+        "skipped": skipped,
         "corpus_wer": _stat("corpus_wer"),
         "per_sample_wer_max": _stat("per_sample_wer_max"),
         "wall_clock_s": _stat("wall_clock_s"),
         "throughput_samples_per_s": _stat("throughput_samples_per_s"),
+        "rtfx": _stat("rtfx"),
         "latency_mean_s": _stat("latency_mean_s"),
         "latency_p95_s": _stat("latency_p95_s"),
         "latency_p99_s": _stat("latency_p99_s"),
@@ -234,26 +250,36 @@ def _aggregate(repeats: list[dict]) -> dict:
     }
 
 
+def _format_metric(value: float | None, digits: int) -> str:
+    return "n/a" if value is None else f"{value:.{digits}f}"
+
+
 def _print_table(aggregates: list[dict]) -> None:
     header = (
-        "| conc | reps | wall(s) mean | thrpt mean | thrpt best | "
-        "lat mean(s) | lat p95(s) | rtf mean | rtf p95 | corpus WER | max WER |"
+        "| conc | valid reps (lat/RTF/WER) | evaluated/requests | "
+        "wall(s) mean | req/s mean | req/s best | RTFx mean | lat mean(s) | "
+        "lat p95(s) | RTF mean | RTF p95 | corpus WER | max WER |"
     )
-    sep = "|---:" * 11 + "|"
+    sep = "|---:" * 13 + "|"
     print("\n" + header)
     print(sep)
     for agg in aggregates:
         print(
-            f"| {agg['concurrency']} | {agg['repeats']} "
-            f"| {agg['wall_clock_s']['mean']:.3f} "
-            f"| {agg['throughput_samples_per_s']['mean']:.3f} "
-            f"| {agg['throughput_samples_per_s']['max']:.3f} "
-            f"| {agg['latency_mean_s']['mean']:.3f} "
-            f"| {agg['latency_p95_s']['mean']:.3f} "
-            f"| {agg['rtf_mean']['mean']:.4f} "
-            f"| {agg['rtf_p95']['mean']:.4f} "
-            f"| {agg['corpus_wer']['max']:.4f} "
-            f"| {agg['per_sample_wer_max']['max']:.4f} |"
+            f"| {agg['concurrency']} "
+            f"| {agg['latency_mean_s']['n']}/{agg['repeats']} / "
+            f"{agg['rtf_mean']['n']}/{agg['repeats']} / "
+            f"{agg['corpus_wer']['n']}/{agg['repeats']} "
+            f"| {agg['evaluated']}/{agg['total']} "
+            f"| {_format_metric(agg['wall_clock_s']['mean'], 3)} "
+            f"| {_format_metric(agg['throughput_samples_per_s']['mean'], 3)} "
+            f"| {_format_metric(agg['throughput_samples_per_s']['max'], 3)} "
+            f"| {_format_metric(agg['rtfx']['mean'], 3)} "
+            f"| {_format_metric(agg['latency_mean_s']['mean'], 3)} "
+            f"| {_format_metric(agg['latency_p95_s']['mean'], 3)} "
+            f"| {_format_metric(agg['rtf_mean']['mean'], 4)} "
+            f"| {_format_metric(agg['rtf_p95']['mean'], 4)} "
+            f"| {_format_metric(agg['corpus_wer']['max'], 4)} "
+            f"| {_format_metric(agg['per_sample_wer_max']['max'], 4)} |"
         )
 
 
@@ -327,11 +353,12 @@ async def _sweep(args, samples, concurrencies: list[int]) -> list[dict]:
                 f"[conc={concurrency} rep={repeat}] "
                 f"wall={result['wall_clock_s']:.3f}s "
                 f"thrpt={result['throughput_samples_per_s']:.3f}/s "
-                f"lat_mean={result['latency_mean_s']:.3f}s "
-                f"lat_p95={result['latency_p95_s']:.3f}s "
-                f"rtf_mean={result['rtf_mean']:.4f} "
-                f"corpus_wer={result['corpus_wer']:.4f} "
-                f"skipped={result['skipped']}"
+                f"rtfx={result['rtfx']:.3f} "
+                f"lat_mean={_format_metric(result['latency_mean_s'], 3)}s "
+                f"lat_p95={_format_metric(result['latency_p95_s'], 3)}s "
+                f"rtf_mean={_format_metric(result['rtf_mean'], 4)} "
+                f"corpus_wer={_format_metric(result['corpus_wer'], 4)} "
+                f"evaluated={result['evaluated']}/{result['total']}"
             )
             if result["worker"].get("per_worker_routed"):
                 print(f"    routed per worker: {result['worker']['per_worker_routed']}")

--- a/benchmarks/tasks/asr.py
+++ b/benchmarks/tasks/asr.py
@@ -459,6 +459,7 @@ def build_asr_eval_results(
         "asr_model": model_path,
         "asr_concurrency": concurrency,
         "asr_rtf_p95": perf.get("rtf_p95"),
+        "rtfx": perf.get("audio_throughput_s_per_s", 0.0),
         # note (Yue Yin): plain calibration keys read by tune-ci-thresholds + gate
         "throughput_samples_per_s": asr_speed["asr_throughput_samples_per_s"],
         "latency_mean_s": asr_speed["asr_latency_mean_s"],

--- a/docs/cookbook/fun_asr.md
+++ b/docs/cookbook/fun_asr.md
@@ -93,13 +93,13 @@ python -m benchmarks.eval.benchmark_asr_seedtts \
 Measured on a single H100 80 GB (bf16, DP=1, default server settings)
 against the full SeedTTS sets. Each row is the mean of 3 runs with one
 discarded warmup pass per level. RTF is processing time divided by audio
-duration (lower is better). audio_s/s is seconds of audio transcribed per
-wall-clock second.
+duration (lower is better). RTFx is successful input-audio seconds divided by
+wall-clock seconds (higher is better).
 
 SeedTTS EN (1088 clips, mean clip length 4.69 s). Corpus WER was 0.0171 at
 every level through concurrency 32:
 
-| Concurrency | Throughput (samples/s) | Mean latency (s) | p95 latency (s) | RTF mean | audio_s/s |
+| Concurrency | Throughput (samples/s) | Mean latency (s) | p95 latency (s) | RTF mean | RTFx |
 |---:|---:|---:|---:|---:|---:|
 | 1 | 26.44 | 0.038 | 0.047 | 0.0082 | 124 |
 | 2 | 42.55 | 0.047 | 0.058 | 0.0102 | 200 |
@@ -113,7 +113,7 @@ SeedTTS ZH (2020 clips, mean clip length 4.68 s). Corpus WER, effectively
 character level after normalization, was 0.0135 at every level through
 concurrency 32:
 
-| Concurrency | Throughput (samples/s) | Mean latency (s) | p95 latency (s) | RTF mean | audio_s/s |
+| Concurrency | Throughput (samples/s) | Mean latency (s) | p95 latency (s) | RTF mean | RTFx |
 |---:|---:|---:|---:|---:|---:|
 | 1 | 26.96 | 0.037 | 0.048 | 0.0080 | 126 |
 | 2 | 45.97 | 0.043 | 0.056 | 0.0094 | 215 |

--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -70,6 +70,8 @@ Use `benchmarks/eval/benchmark_asr_seedtts.py` to sweep ASR concurrency on
 SeedTTS reference audio through `/v1/audio/transcriptions`. It defaults to
 `--model-path Qwen/Qwen3-ASR-1.7B`; the shared request and metric logic lives in
 `benchmarks.tasks.asr` and also supports Fun-ASR through `--model-path`.
+The report includes RTF (processing time divided by audio duration) and RTFx
+(successful input-audio seconds divided by wall-clock seconds).
 
 ```bash
 sgl-omni serve --model-path Qwen/Qwen3-ASR-1.7B --port 8000


### PR DESCRIPTION
## Motivation

The SeedTTS ASR sweep already records successful input-audio duration and benchmark wall time, but its result assembly did not expose the resulting audio throughput. Its repeat summary also assumed every repeat produced WER, latency, and RTF values, which could fail formatting or obscure coverage when requests were skipped.

## Modifications

- Expose successful input-audio seconds per wall-clock second as `rtfx` in the shared ASR speed result while preserving the existing per-request RTF metrics.
- Represent unavailable WER, latency, and RTF values explicitly, aggregate only valid repeat values, and report each metric's valid-repeat count.
- Sum evaluated, total, and skipped requests across repeats and show `evaluated/requests` in the concurrency table so partial work remains visible.
- Print RTFx in per-repeat and aggregate benchmark output and document its ASR semantics for the SeedTTS, Fun-ASR, and Qwen3-ASR benchmark paths.

## H100 Validation

Full SeedTTS EN sweep with Fun-ASR-Nano, using 1,088 samples and three measured repeats per concurrency:

| Concurrency | RTFx | Requests/s | Evaluated | Corpus WER |
|---:|---:|---:|---:|---:|
| 1 | 117.552 | 24.820 | 3264/3264 | 1.71% |
| 2 | 202.273 | 42.709 | 3264/3264 | 1.71% |
| 4 | 333.948 | 70.511 | 3264/3264 | 1.71% |
| 8 | 496.598 | 104.854 | 3264/3264 | 1.71% |
| 16 | 663.429 | 140.079 | 3264/3264 | 1.71% |
| 32 | 775.889 | 163.824 | 3264/3264 | 1.71% |

All 19,584 measured requests completed, and corpus WER remained stable across the sweep.
