### PR TITLE
[Qwen3-Omni] Fail fast when BF16 talker MoE kernel needs a source build

### DIFF
--- a/docs/cookbook/qwen3_omni.md
+++ b/docs/cookbook/qwen3_omni.md
@@ -19,6 +19,15 @@ uv pip install "sglang-omni==0.1.2"
 
 See [Installation](../get_started/installation.md) for Docker digests and source installs.
 
+The BF16 talker uses FlashInfer's CUTLASS fused-MoE kernel. The official
+SGLang-Omni image includes a compatible precompiled cache. Other environments
+must provide the matching cached kernel (for example, through a compatible
+`flashinfer-jit-cache` wheel) or explicitly select the talker's `triton` MoE
+runner. When the default CUTLASS runner is selected, startup fails fast if the
+kernel is absent instead of compiling it inside CUDA graph capture.
+Set `SGLANG_OMNI_MOE_AUTOTUNE_TALKER_TOKENS=<max_tokens>` to opt into one
+additional prefill-sized FlashInfer MoE tuning pass during talker startup.
+
 ## Server Configuration
 
 Use the selector below to generate the exact launch command for your configuration.

--- a/sglang_omni/model_runner/moe_prefill_autotune.py
+++ b/sglang_omni/model_runner/moe_prefill_autotune.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in FlashInfer MoE autotune pass at prefill-sized token counts.
+
+SGLang's built-in FlashInfer autotune warmup (``BaseRunner.warmup`` ->
+``_flashinfer_autotune``) runs a single decode-shaped dummy forward whose
+token count equals the decode runner's max batch size (32 for the current
+Qwen3-Omni talker stage). The trtllm-gen fused-MoE tuning buckets are
+generated from
+``tune_max_num_tokens = next_power_of_2(num_tokens)`` of the tuned forward
+(SGLang passes ``next_power_of_2(a_q.shape[0])`` per call), so only buckets
+up to that decode batch size ever get profiled. Runtime prefill / mixed-chunk
+extend batches (hundreds to thousands of tokens) then miss the autotune cache
+and fall back to the untuned default tactic (-1).
+
+This module adds an opt-in second autotune pass: one dummy EXTEND forward at
+a prefill-sized token count. FlashInfer's trtllm-gen MoE runner profiles its
+full hybrid bucket set up to that token count in a single ``choose_one`` pass,
+and, when cache reuse is enabled, the results merge into the same per-model
+autotune cache JSON the decode warmup wrote.
+
+Opt in with ``SGLANG_OMNI_MOE_AUTOTUNE_TALKER_TOKENS=<max_tokens>``. Zero or
+unset preserves current startup behavior.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+logger = logging.getLogger(__name__)
+
+MOE_AUTOTUNE_PREFILL_TOKENS_ENV = "SGLANG_OMNI_MOE_AUTOTUNE_PREFILL_TOKENS"
+MOE_AUTOTUNE_TALKER_TOKENS_ENV = "SGLANG_OMNI_MOE_AUTOTUNE_TALKER_TOKENS"
+
+
+def moe_autotune_prefill_tokens(
+    env_var: str = MOE_AUTOTUNE_PREFILL_TOKENS_ENV,
+) -> int:
+    """Parse the opt-in token-count knob; zero means disabled."""
+    raw = os.environ.get(env_var, "").strip()
+    if not raw:
+        return 0
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r; expected an integer, ignoring.",
+            env_var,
+            raw,
+        )
+        return 0
+
+
+def maybe_autotune_prefill_moe(
+    model_runner,
+    env_var: str = MOE_AUTOTUNE_PREFILL_TOKENS_ENV,
+) -> None:
+    """Run one prefill-sized dummy EXTEND forward under FlashInfer autotune.
+
+    This must run after normal model-runner warmup and on every TP rank at the
+    same point because the dummy forward participates in TP collectives.
+    """
+    tokens = moe_autotune_prefill_tokens(env_var)
+    if tokens <= 0:
+        return
+
+    from sglang.srt.model_executor.forward_batch_info import ForwardMode
+    from sglang.srt.model_executor.runner.flashinfer_autotune import (
+        flashinfer_autotune_context,
+        should_run_flashinfer_autotune,
+    )
+
+    mr = model_runner
+    if not should_run_flashinfer_autotune(mr):
+        logger.info(
+            "%s=%d set but FlashInfer autotune is not applicable to this "
+            "runner (device/backend); skipping prefill MoE autotune.",
+            env_var,
+            tokens,
+        )
+        return
+
+    runner = getattr(mr, "eager_runner", None)
+    if runner is None:
+        logger.warning(
+            "%s=%d set but eager_runner is unavailable; skipping prefill MoE "
+            "autotune.",
+            env_var,
+            tokens,
+        )
+        return
+
+    # Mirror pp_parallel_deep_gemm_warmup's shape alignment: _dummy_run does
+    # not pad like the real flow, so align to CP padding and attention TP.
+    import math
+
+    from sglang.srt.layers.cp.padding import get_cp_padding_align_size
+    from sglang.srt.runtime_context import get_parallel
+    from sglang.srt.utils.common import ceil_align, require_mlp_sync
+
+    align = max(get_cp_padding_align_size(), 1)
+    attn_tp_size = get_parallel().attn_tp_size
+    if require_mlp_sync(mr.server_args) and attn_tp_size > 1:
+        align = math.lcm(align, attn_tp_size)
+    tokens = ceil_align(tokens, align)
+
+    started_at = time.perf_counter()
+    logger.info(
+        "Prefill MoE autotune: dummy EXTEND forward at %d tokens (tp_rank=%d).",
+        tokens,
+        mr.ps.tp_rank,
+    )
+    buffers = runner._alloc_dummy_decode_buffers(tokens)
+    canary = getattr(mr, "canary_manager", None)
+    run_ctx = (
+        canary.with_active_single_forward_manager(0) if canary is not None else None
+    )
+    # SGLang represents this synthetic token shape as a request batch. The
+    # talker's nested backbone normally substitutes decode feedback for that
+    # axis, but its buffers are capped at max_running_requests. Real prefill
+    # supplies input_embeds and bypasses the feedback branch, so do the same
+    # only for this dummy forward and restore the live decode state afterward.
+    backbone = getattr(getattr(mr, "model", None), "model", None)
+    has_feedback_mode = hasattr(backbone, "_cp_enabled")
+    feedback_mode = getattr(backbone, "_cp_enabled", False)
+    if has_feedback_mode:
+        backbone._cp_enabled = False
+    try:
+        with flashinfer_autotune_context(mr, skip_logits=True):
+            runner._dummy_run(
+                batch_size=tokens,
+                run_ctx=run_ctx,
+                forward_mode_override=ForwardMode.EXTEND,
+                buffers=buffers,
+            )
+    finally:
+        if has_feedback_mode:
+            backbone._cp_enabled = feedback_mode
+    logger.info("Prefill MoE autotune done in %.2fs.", time.perf_counter() - started_at)

--- a/sglang_omni/models/qwen3_omni/bootstrap.py
+++ b/sglang_omni/models/qwen3_omni/bootstrap.py
@@ -226,6 +226,18 @@ def create_talker_scheduler(
         # prefill graphs later cannot silently miss the embeds view.
         init_sglang_cuda_graphs(model_worker)
 
+    # Opt in to a second, prefill-sized FlashInfer MoE autotune pass only after
+    # the talker's eager runner and deferred CUDA graphs are initialized.
+    from sglang_omni.model_runner.moe_prefill_autotune import (
+        MOE_AUTOTUNE_TALKER_TOKENS_ENV,
+        maybe_autotune_prefill_moe,
+    )
+
+    maybe_autotune_prefill_moe(
+        model_worker.model_runner,
+        env_var=MOE_AUTOTUNE_TALKER_TOKENS_ENV,
+    )
+
     output_proc = SGLangOutputProcessor(
         capture_hidden=False,
         capture_hidden_layers=None,

--- a/sglang_omni/platforms/cuda.py
+++ b/sglang_omni/platforms/cuda.py
@@ -33,6 +33,34 @@ def _is_h20_device() -> bool:
         return False
 
 
+def _is_flashinfer_cutlass_moe_prebuilt() -> bool:
+    """Return whether the current GPU's FlashInfer fused-MoE module is cached.
+
+    Detection failures intentionally pass through. This guard should reject only
+    environments known to require a source build, never block an otherwise valid
+    installation because FlashInfer changed an inspection detail.
+    """
+    try:
+        import torch
+        from flashinfer.jit import env as jit_env
+
+        if not torch.cuda.is_available():
+            return True
+        major, minor = torch.cuda.get_device_capability()
+        # Match FlashInfer's v0.6.14 CUTLASS dispatch aliases: these newer
+        # capabilities reuse the compatible lower-architecture module.
+        major, minor = {(11, 0): (10, 0), (12, 1): (12, 0)}.get(
+            (major, minor), (major, minor)
+        )
+        module_name = f"fused_moe_{major}{minor}"
+        return any(
+            (base / module_name / f"{module_name}.so").is_file()
+            for base in (jit_env.FLASHINFER_AOT_DIR, jit_env.FLASHINFER_JIT_DIR)
+        )
+    except Exception:
+        return True
+
+
 def _is_fp8_cutlass_moe_supported() -> bool:
     """Mirror SGLang 0.5.16's CUTLASS FP8 MoE assertions."""
     from sglang.srt.layers.quantization.fp8_utils import cutlass_fp8_supported
@@ -119,13 +147,30 @@ class CUDAOmniPlatform(CudaDeviceMixin, OmniPlatform):
         ):
             # Note:(Chenchen Hong) flashinfer_cutlass MoE deadlocks CUDA-graph
             # capture on H20 (no H20 kernel coverage); triton captures cleanly there.
-            override_server_args(
-                server_args,
-                "sglang-omni-qwen3-backend-policy",
-                moe_runner_backend=(
-                    "triton" if _is_h20_device() else "flashinfer_cutlass"
-                ),
-            )
+            if _is_h20_device():
+                override_server_args(
+                    server_args,
+                    "sglang-omni-qwen3-backend-policy",
+                    moe_runner_backend="triton",
+                )
+            else:
+                if not _is_flashinfer_cutlass_moe_prebuilt():
+                    raise ValueError(
+                        "BF16 Qwen3-Omni talker needs a prebuilt FlashInfer "
+                        "CUTLASS fused-MoE kernel, but the module is missing "
+                        "from this environment's AOT and JIT caches. Its first "
+                        "call runs inside talker CUDA graph capture, so building "
+                        "from source there can trip the startup timeout. Use the "
+                        "official SGLang-Omni image, provide a compatible "
+                        "precompiled FlashInfer cache, or set the talker's "
+                        "moe_runner_backend to 'triton' (triton changes talker "
+                        "audio output)."
+                    )
+                override_server_args(
+                    server_args,
+                    "sglang-omni-qwen3-backend-policy",
+                    moe_runner_backend="flashinfer_cutlass",
+                )
             moe_runner_backend = server_args.moe_runner_backend
 
         if (

--- a/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
+++ b/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -55,6 +56,7 @@ class BackendPolicyCase:
     expected_moe_backend: str | None = None
     expected_fp8_gemm_backend: str | None = None
     error_match: str | None = None
+    flashinfer_moe_prebuilt: bool = True
 
 
 def _server_args(
@@ -124,6 +126,53 @@ def _model_config(
             expected_quantization=None,
             expected_moe_backend="triton",
             expected_fp8_gemm_backend="auto",
+        ),
+        BackendPolicyCase(
+            name="bf16_talker_auto_rejects_missing_flashinfer_moe_kernel",
+            model_quantization=None,
+            server_quantization=None,
+            native_fp8_block_quant=False,
+            model_arch_override="Qwen3OmniTalker",
+            has_moe=True,
+            initial_moe_backend="auto",
+            initial_fp8_gemm_backend="auto",
+            ep_size=1,
+            cutlass_supported=True,
+            expected_quantization=None,
+            error_match="prebuilt FlashInfer CUTLASS fused-MoE kernel",
+            flashinfer_moe_prebuilt=False,
+        ),
+        BackendPolicyCase(
+            name="bf16_talker_explicit_triton_survives_missing_flashinfer_moe_kernel",
+            model_quantization=None,
+            server_quantization=None,
+            native_fp8_block_quant=False,
+            model_arch_override="Qwen3OmniTalker",
+            has_moe=True,
+            initial_moe_backend="triton",
+            initial_fp8_gemm_backend="auto",
+            ep_size=1,
+            cutlass_supported=True,
+            expected_quantization=None,
+            expected_moe_backend="triton",
+            expected_fp8_gemm_backend="auto",
+            flashinfer_moe_prebuilt=False,
+        ),
+        BackendPolicyCase(
+            name="fp8_talker_auto_ignores_missing_flashinfer_moe_kernel",
+            model_quantization="fp8",
+            server_quantization=None,
+            native_fp8_block_quant=True,
+            model_arch_override="Qwen3OmniTalker",
+            has_moe=True,
+            initial_moe_backend="auto",
+            initial_fp8_gemm_backend="auto",
+            ep_size=1,
+            cutlass_supported=True,
+            expected_quantization="fp8",
+            expected_moe_backend="cutlass",
+            expected_fp8_gemm_backend="triton",
+            flashinfer_moe_prebuilt=False,
         ),
         BackendPolicyCase(
             name="fp8_talker_auto_uses_cutlass_moe_and_triton_dense_gemm",
@@ -367,6 +416,12 @@ def test_model_worker_backend_policy_precedence(
         lambda: case.cutlass_supported,
     )
     monkeypatch.setattr(cuda, "_is_h20_device", lambda: False)
+    monkeypatch.setattr(
+        cuda,
+        "_is_flashinfer_cutlass_moe_prebuilt",
+        lambda: case.flashinfer_moe_prebuilt,
+        raising=False,
+    )
     server_args = _server_args(
         quantization=case.server_quantization,
         moe_runner_backend=case.initial_moe_backend,
@@ -559,6 +614,80 @@ def test_fp8_cutlass_moe_support_matches_sglang_0_5_16_contract(
     assert cuda._is_fp8_cutlass_moe_supported() is expected_supported
 
 
+@pytest.mark.parametrize(
+    ("device_capability", "module_name", "present_in", "expected"),
+    [
+        pytest.param(
+            (9, 0), "fused_moe_90", "aot", True, id="shipped_by_jit_cache_wheel"
+        ),
+        pytest.param((9, 0), "fused_moe_90", "jit", True, id="already_built_locally"),
+        pytest.param(
+            (11, 0),
+            "fused_moe_100",
+            "aot",
+            True,
+            id="sm110_reuses_sm100_module",
+        ),
+        pytest.param(
+            (12, 1),
+            "fused_moe_120",
+            "jit",
+            True,
+            id="sm121_reuses_sm120_module",
+        ),
+        pytest.param(
+            (9, 0),
+            "fused_moe_90",
+            "partial",
+            False,
+            id="failed_build_directory_is_not_enough",
+        ),
+        pytest.param(
+            (9, 0),
+            "fused_moe_90",
+            None,
+            False,
+            id="absent_needs_source_build",
+        ),
+    ],
+)
+def test_flashinfer_cutlass_moe_prebuilt_detection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    device_capability: tuple[int, int],
+    module_name: str,
+    present_in: str | None,
+    expected: bool,
+) -> None:
+    aot_dir = tmp_path / "aot"
+    jit_dir = tmp_path / "jit"
+    aot_dir.mkdir()
+    jit_dir.mkdir()
+    if present_in in ("aot", "jit"):
+        module_dir = {"aot": aot_dir, "jit": jit_dir}[present_in] / module_name
+        module_dir.mkdir()
+        (module_dir / f"{module_name}.so").touch()
+    elif present_in == "partial":
+        (jit_dir / module_name).mkdir()
+
+    _install_fake_flashinfer_jit_env(
+        monkeypatch,
+        aot_dir=aot_dir,
+        jit_dir=jit_dir,
+        device_capability=device_capability,
+    )
+
+    assert cuda._is_flashinfer_cutlass_moe_prebuilt() is expected
+
+
+def test_flashinfer_cutlass_moe_prebuilt_fails_open_when_undetectable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(sys.modules, "flashinfer.jit", None)
+
+    assert cuda._is_flashinfer_cutlass_moe_prebuilt() is True
+
+
 def test_backend_global_initialization_for_fp8_moe_model(monkeypatch) -> None:
     calls: list[str] = []
 
@@ -743,6 +872,31 @@ def _install_fake_cutlass_support_modules(
         is_sm100_supported=lambda: sm100_supported,
         is_sm120_supported=lambda: sm120_supported,
     )
+
+
+def _install_fake_flashinfer_jit_env(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    aot_dir: Path,
+    jit_dir: Path,
+    device_capability: tuple[int, int],
+) -> None:
+    _install_fake_module(
+        monkeypatch,
+        "torch",
+        cuda=SimpleNamespace(
+            is_available=lambda: True,
+            get_device_capability=lambda: device_capability,
+        ),
+    )
+    env_module = _install_fake_module(
+        monkeypatch,
+        "flashinfer.jit.env",
+        FLASHINFER_AOT_DIR=aot_dir,
+        FLASHINFER_JIT_DIR=jit_dir,
+    )
+    _install_fake_module(monkeypatch, "flashinfer")
+    _install_fake_module(monkeypatch, "flashinfer.jit", env=env_module)
 
 
 def _install_fake_module(

--- a/tests/unit_test/qwen3_omni/test_moe_prefill_autotune.py
+++ b/tests/unit_test/qwen3_omni/test_moe_prefill_autotune.py
@@ -1,0 +1,401 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import importlib.util
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+
+from tests.unit_test.fakes import FakeServerArgs
+
+AUTOTUNE_MODULE = "sglang_omni.model_runner.moe_prefill_autotune"
+
+
+def _autotune_module():
+    assert importlib.util.find_spec(AUTOTUNE_MODULE) is not None
+    return importlib.import_module(AUTOTUNE_MODULE)
+
+
+def _install_fake_module(
+    monkeypatch: pytest.MonkeyPatch,
+    name: str,
+    **attrs: object,
+) -> ModuleType:
+    module = ModuleType(name)
+    for attr_name, value in attrs.items():
+        setattr(module, attr_name, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _install_minimal_autotune_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    extend_mode: object,
+) -> None:
+    _install_fake_module(
+        monkeypatch,
+        "sglang.srt.model_executor.forward_batch_info",
+        ForwardMode=SimpleNamespace(EXTEND=extend_mode),
+    )
+
+    @contextlib.contextmanager
+    def flashinfer_autotune_context(model_runner: object, *, skip_logits: bool):
+        del model_runner
+        assert skip_logits is True
+        yield
+
+    _install_fake_module(
+        monkeypatch,
+        "sglang.srt.model_executor.runner.flashinfer_autotune",
+        should_run_flashinfer_autotune=lambda model_runner: True,
+        flashinfer_autotune_context=flashinfer_autotune_context,
+    )
+    _install_fake_module(
+        monkeypatch, "sglang.srt.layers.cp.padding", get_cp_padding_align_size=lambda: 1
+    )
+    _install_fake_module(
+        monkeypatch,
+        "sglang.srt.runtime_context",
+        get_parallel=lambda: SimpleNamespace(attn_tp_size=1),
+    )
+    _install_fake_module(
+        monkeypatch,
+        "sglang.srt.utils.common",
+        ceil_align=lambda value, align: ((value + align - 1) // align) * align,
+        require_mlp_sync=lambda server_args: False,
+    )
+
+
+class _TalkerFeedbackBackbone:
+    """Executable reproduction of the talker codec-feedback input branch."""
+
+    def __init__(self, *, max_running_requests: int, hidden_size: int) -> None:
+        self._cp_enabled = True
+        self._feedback_mask = torch.ones(max_running_requests, dtype=torch.bool)
+        self._feedback_buffer = torch.full(
+            (max_running_requests, hidden_size), 2.0, dtype=torch.float32
+        )
+        self.hidden_size = hidden_size
+
+    def synthetic_extend(self, num_tokens: int) -> torch.Tensor:
+        hidden_states = torch.ones(num_tokens, self.hidden_size)
+        if self._cp_enabled:
+            batch_size = hidden_states.shape[0]
+            feedback_mask = self._feedback_mask[:batch_size]
+            hidden_states = torch.where(
+                feedback_mask.unsqueeze(-1),
+                self._feedback_buffer[:batch_size],
+                hidden_states,
+            )
+            self._feedback_mask[:batch_size] = False
+        return hidden_states
+
+
+def test_moe_autotune_is_inert_when_talker_flag_is_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    autotune = _autotune_module()
+    monkeypatch.delenv(autotune.MOE_AUTOTUNE_TALKER_TOKENS_ENV, raising=False)
+
+    class UntouchableRunner:
+        def __getattribute__(self, name: str) -> object:
+            raise AssertionError(
+                f"disabled autotune touched model runner attribute {name}"
+            )
+
+    autotune.maybe_autotune_prefill_moe(
+        UntouchableRunner(),
+        env_var=autotune.MOE_AUTOTUNE_TALKER_TOKENS_ENV,
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param("", 0, id="empty_is_disabled"),
+        pytest.param("0", 0, id="zero_is_disabled"),
+        pytest.param(" 17 ", 17, id="integer_is_parsed"),
+        pytest.param("not-an-int", 0, id="invalid_is_disabled"),
+    ],
+)
+def test_moe_autotune_talker_flag_parsing(
+    monkeypatch: pytest.MonkeyPatch,
+    raw: str,
+    expected: int,
+) -> None:
+    autotune = _autotune_module()
+    monkeypatch.setenv(autotune.MOE_AUTOTUNE_TALKER_TOKENS_ENV, raw)
+
+    assert (
+        autotune.moe_autotune_prefill_tokens(autotune.MOE_AUTOTUNE_TALKER_TOKENS_ENV)
+        == expected
+    )
+
+
+def test_moe_autotune_opt_in_runs_one_aligned_extend_forward(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    autotune = _autotune_module()
+    monkeypatch.setenv(autotune.MOE_AUTOTUNE_TALKER_TOKENS_ENV, "5")
+    events: list[object] = []
+    extend_mode = object()
+
+    _install_fake_module(
+        monkeypatch,
+        "sglang.srt.model_executor.forward_batch_info",
+        ForwardMode=SimpleNamespace(EXTEND=extend_mode),
+    )
+
+    @contextlib.contextmanager
+    def flashinfer_autotune_context(model_runner: object, *, skip_logits: bool):
+        events.append(("autotune_enter", model_runner, skip_logits))
+        yield
+        events.append("autotune_exit")
+
+    _install_fake_module(
+        monkeypatch,
+        "sglang.srt.model_executor.runner.flashinfer_autotune",
+        should_run_flashinfer_autotune=lambda model_runner: (
+            events.append(("applicable", model_runner)) or True
+        ),
+        flashinfer_autotune_context=flashinfer_autotune_context,
+    )
+    _install_fake_module(
+        monkeypatch, "sglang.srt.layers.cp.padding", get_cp_padding_align_size=lambda: 4
+    )
+    _install_fake_module(
+        monkeypatch,
+        "sglang.srt.runtime_context",
+        get_parallel=lambda: SimpleNamespace(attn_tp_size=2),
+    )
+    _install_fake_module(
+        monkeypatch,
+        "sglang.srt.utils.common",
+        ceil_align=lambda value, align: ((value + align - 1) // align) * align,
+        require_mlp_sync=lambda server_args: True,
+    )
+
+    buffers = object()
+
+    @contextlib.contextmanager
+    def canary_context(index: int):
+        events.append(("canary_enter", index))
+        yield
+        events.append(("canary_exit", index))
+
+    eager_runner = SimpleNamespace()
+
+    def alloc_dummy_decode_buffers(tokens: int) -> object:
+        events.append(("alloc", tokens))
+        return buffers
+
+    def dummy_run(**kwargs: object) -> None:
+        with kwargs["run_ctx"]:
+            events.append(("dummy", kwargs))
+
+    eager_runner._alloc_dummy_decode_buffers = alloc_dummy_decode_buffers
+    eager_runner._dummy_run = dummy_run
+    model_runner = SimpleNamespace(
+        eager_runner=eager_runner,
+        server_args=object(),
+        ps=SimpleNamespace(tp_rank=3),
+        canary_manager=SimpleNamespace(
+            with_active_single_forward_manager=canary_context
+        ),
+    )
+
+    autotune.maybe_autotune_prefill_moe(
+        model_runner,
+        env_var=autotune.MOE_AUTOTUNE_TALKER_TOKENS_ENV,
+    )
+
+    assert events[0] == ("applicable", model_runner)
+    assert events[1] == ("alloc", 8)
+    assert events[2] == ("autotune_enter", model_runner, True)
+    assert events[3] == ("canary_enter", 0)
+    assert events[4][0] == "dummy"
+    dummy_kwargs = events[4][1]
+    assert dummy_kwargs["batch_size"] == 8
+    assert dummy_kwargs["forward_mode_override"] is extend_mode
+    assert dummy_kwargs["buffers"] is buffers
+    assert events[5:] == [("canary_exit", 0), "autotune_exit"]
+
+
+def test_moe_autotune_talker_oversized_extend_suspends_decode_feedback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    autotune = _autotune_module()
+    monkeypatch.setenv(autotune.MOE_AUTOTUNE_TALKER_TOKENS_ENV, "2048")
+    extend_mode = object()
+    _install_minimal_autotune_runtime(monkeypatch, extend_mode=extend_mode)
+
+    backbone = _TalkerFeedbackBackbone(max_running_requests=64, hidden_size=4)
+    original_mask = backbone._feedback_mask.clone()
+    enabled_during_dummy: list[bool] = []
+    buffers = object()
+
+    def dummy_run(**kwargs: object) -> None:
+        assert kwargs["batch_size"] == 2048
+        assert kwargs["forward_mode_override"] is extend_mode
+        assert kwargs["buffers"] is buffers
+        enabled_during_dummy.append(backbone._cp_enabled)
+        hidden_states = backbone.synthetic_extend(2048)
+        assert hidden_states.shape == (2048, 4)
+
+    eager_runner = SimpleNamespace(
+        _alloc_dummy_decode_buffers=lambda tokens: buffers,
+        _dummy_run=dummy_run,
+    )
+    model_runner = SimpleNamespace(
+        eager_runner=eager_runner,
+        model=SimpleNamespace(model=backbone, _cp_enabled=True),
+        server_args=object(),
+        ps=SimpleNamespace(tp_rank=0),
+        canary_manager=None,
+    )
+
+    autotune.maybe_autotune_prefill_moe(
+        model_runner,
+        env_var=autotune.MOE_AUTOTUNE_TALKER_TOKENS_ENV,
+    )
+
+    assert enabled_during_dummy == [False]
+    assert backbone._cp_enabled is True
+    assert torch.equal(backbone._feedback_mask, original_mask)
+
+
+def test_moe_autotune_talker_restores_decode_feedback_after_dummy_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    autotune = _autotune_module()
+    monkeypatch.setenv(autotune.MOE_AUTOTUNE_TALKER_TOKENS_ENV, "2048")
+    _install_minimal_autotune_runtime(monkeypatch, extend_mode=object())
+
+    class DummyFailure(RuntimeError):
+        pass
+
+    backbone = _TalkerFeedbackBackbone(max_running_requests=64, hidden_size=4)
+
+    def dummy_run(**kwargs: object) -> None:
+        del kwargs
+        assert backbone._cp_enabled is False
+        raise DummyFailure("synthetic forward failed")
+
+    model_runner = SimpleNamespace(
+        eager_runner=SimpleNamespace(
+            _alloc_dummy_decode_buffers=lambda tokens: object(),
+            _dummy_run=dummy_run,
+        ),
+        model=SimpleNamespace(model=backbone, _cp_enabled=True),
+        server_args=object(),
+        ps=SimpleNamespace(tp_rank=0),
+        canary_manager=None,
+    )
+
+    with pytest.raises(DummyFailure, match="synthetic forward failed"):
+        autotune.maybe_autotune_prefill_moe(
+            model_runner,
+            env_var=autotune.MOE_AUTOTUNE_TALKER_TOKENS_ENV,
+        )
+
+    assert backbone._cp_enabled is True
+
+
+def test_talker_bootstrap_propagates_autotune_flag_after_graph_init(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.qwen3_omni import bootstrap
+
+    class AutotuneReached(Exception):
+        pass
+
+    events: list[str] = []
+    talker_env = "SGLANG_OMNI_MOE_AUTOTUNE_TALKER_TOKENS"
+
+    _install_fake_module(
+        monkeypatch,
+        "sglang.srt.utils.hf_transformers_utils",
+        get_tokenizer=object,
+    )
+    _install_fake_module(
+        monkeypatch,
+        "sglang_omni.models.qwen3_omni.request_builders",
+        make_talker_scheduler_adapters=object,
+    )
+    _install_fake_module(
+        monkeypatch,
+        "sglang_omni.models.qwen3_omni.talker_model_runner",
+        QwenTalkerModelRunner=object,
+    )
+    _install_fake_module(
+        monkeypatch,
+        "sglang_omni.models.qwen3_omni.talker_scheduler",
+        QwenTalkerScheduler=object,
+        configure_talker_server_args=lambda *args, **kwargs: True,
+    )
+
+    model_config = SimpleNamespace(
+        vocab_size=100,
+        hf_config=SimpleNamespace(
+            talker_config=SimpleNamespace(text_config=SimpleNamespace(vocab_size=4096))
+        ),
+    )
+    raw_model_runner = SimpleNamespace(
+        model_config=model_config,
+        model=SimpleNamespace(_sampler=None),
+        sampler=object(),
+    )
+    model_worker = SimpleNamespace(model_runner=raw_model_runner)
+
+    def create_sglang_infrastructure(*args: object, **kwargs: object):
+        events.append("infrastructure")
+        return (
+            model_worker,
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            model_config,
+        )
+
+    def init_sglang_cuda_graphs(worker: object) -> None:
+        assert worker is model_worker
+        events.append("graph_init")
+
+    _install_fake_module(
+        monkeypatch,
+        "sglang_omni.scheduling.bootstrap",
+        create_sglang_infrastructure=create_sglang_infrastructure,
+        init_sglang_cuda_graphs=init_sglang_cuda_graphs,
+    )
+    _install_fake_module(
+        monkeypatch,
+        "sglang_omni.scheduling.sglang_backend",
+        SGLangOutputProcessor=object,
+    )
+
+    def maybe_autotune_prefill_moe(runner: object, env_var: str) -> None:
+        assert runner is raw_model_runner
+        assert env_var == talker_env
+        events.append("autotune")
+        raise AutotuneReached
+
+    _install_fake_module(
+        monkeypatch,
+        AUTOTUNE_MODULE,
+        MOE_AUTOTUNE_TALKER_TOKENS_ENV=talker_env,
+        maybe_autotune_prefill_moe=maybe_autotune_prefill_moe,
+    )
+
+    server_args = FakeServerArgs(disable_cuda_graph=True)
+    with pytest.raises(AutotuneReached):
+        bootstrap.create_talker_scheduler(server_args)
+
+    assert events == ["infrastructure", "graph_init", "autotune"]


### PR DESCRIPTION
## Motivation

BF16 Qwen3-Omni talker startup must not enter a source build for FlashInfer's CUTLASS fused-MoE kernel while CUDA-graph warmup holds the stage-startup lock. The optional prefill autotune path also needs its large-token dummy forward to be safe for the talker's feedback state.

## Modifications

- Reworked the fail-fast policy on the current CUDA-platform owner (`89c2b28b`).
- Detects the pinned FlashInfer aliases `SM110 → SM100` and `SM121 → SM120`, avoiding false missing-kernel failures.
- Adds an opt-in talker prefill autotune pass via `SGLANG_OMNI_MOE_AUTOTUNE_TALKER_TOKENS`; it is off by default.
- Suspends feedback substitution only during the synthetic EXTEND autotune forward and restores it in `finally`, fixing the `64 vs 2048` startup failure without changing real prefill behavior.

## Related Issues

Closes #1194.

## Accuracy Test

OFF and ON=2048 runs produced identical ordered generated-text MD5s at c1 and c8. All 48 smoke-run WAVs were valid mono 16-bit / 24 kHz outputs.

## Benchmark & Profiling

This is a correctness/startup smoke, not a full serving-performance claim. On H200 TP1:

- OFF: c1 n=8 and c8 n=16 both completed with zero failures.
- ON=2048: the second autotune pass completed in 3.81 s; cache coverage grew from 14 to 32 keys, including both GEMM operations through M=2048.
- No fallback, source build, traceback, or rank hang occurred. ON is opt-in; TP2 and a full performance matrix remain pending.

## Validation

- Official-image focused suite: 56 passed.
- Fresh OFF and ON cold boots: all four smoke cells completed with zero failures.
- Kernel, HF revision, config, harness, cache, and worktree provenance were attested; both teardown gates drained to 0 MiB.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.

## CI

Please add the `run-ci` label. Follow up with TP2 startup/parity coverage before treating the optional autotune path as broadly validated.
