### PR TITLE
[TTS] Improve Fish S2-Pro streaming continuity

### DIFF
--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -334,7 +334,7 @@ def create_vocoder_executor(
     gpu_id: int | None = None,
     max_batch_size: int = 8,
     max_batch_wait_ms: int = 2,
-    stream_stride: int = 10,
+    stream_stride: int = 50,
     stream_followup_stride: int = 90,
     stream_overlap_tokens: int | None = 20,
     stream_crossfade_samples: int = 512,

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -334,7 +334,7 @@ def create_vocoder_executor(
     gpu_id: int | None = None,
     max_batch_size: int = 8,
     max_batch_wait_ms: int = 2,
-    stream_stride: int = 50,
+    stream_stride: int = 40,
     stream_followup_stride: int = 90,
     stream_overlap_tokens: int | None = 20,
     stream_crossfade_samples: int = 512,

--- a/sglang_omni/models/fishaudio_s2_pro/streaming_vocoder.py
+++ b/sglang_omni/models/fishaudio_s2_pro/streaming_vocoder.py
@@ -282,7 +282,7 @@ class S2ProVocoderScheduler(StreamingSimpleScheduler):
         codec: Any,
         *,
         device: str,
-        stream_stride: int = 10,
+        stream_stride: int = 50,
         stream_followup_stride: int = 90,
         stream_overlap_tokens: int | None = 20,
         stream_crossfade_samples: int = 512,

--- a/sglang_omni/models/fishaudio_s2_pro/streaming_vocoder.py
+++ b/sglang_omni/models/fishaudio_s2_pro/streaming_vocoder.py
@@ -282,7 +282,7 @@ class S2ProVocoderScheduler(StreamingSimpleScheduler):
         codec: Any,
         *,
         device: str,
-        stream_stride: int = 50,
+        stream_stride: int = 40,
         stream_followup_stride: int = 90,
         stream_overlap_tokens: int | None = 20,
         stream_crossfade_samples: int = 512,

--- a/tests/unit_test/fishaudio_s2_pro/test_vocoder.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_vocoder.py
@@ -25,6 +25,7 @@ def test_fish_vocoder_batches_and_trims_audio_by_code_length(
         max_batch_size=4,
         max_batch_wait_ms=50,
     )
+    assert scheduler._stream_stride == 50
 
     def payload(request_id: str, code_len: int) -> object:
         return make_s2pro_payload(

--- a/tests/unit_test/fishaudio_s2_pro/test_vocoder.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_vocoder.py
@@ -25,7 +25,7 @@ def test_fish_vocoder_batches_and_trims_audio_by_code_length(
         max_batch_size=4,
         max_batch_wait_ms=50,
     )
-    assert scheduler._stream_stride == 50
+    assert scheduler._stream_stride == 40
 
     def payload(request_id: str, code_len: int) -> object:
         return make_s2pro_payload(


### PR DESCRIPTION
Closes #1208.

Changes Fish S2-Pro vocoder cadence from 10/90 to 40/90 tokens.

| H100 result | Before | After |
| --- | ---: | ---: |
| C16 QPS | 5.392 | 5.288 |
| TTFA p50 | 0.760s | 1.482s |
| Underrun p95 | 1.908s | 0.264s |
| Continuity within 100ms | 6.25% | 90.32% |
| EN continuity / WER | 7.54% / 1.063% | 97.76% / 1.055% |
| ZH continuity / CER | 0.50% / 0.731% | 91.63% / 0.684% |
| ZH hardcase continuity / CER | 0% / 10.42%-10.92% | 52.56% / 11.04%-11.20% |

Tests: 37 passed.
