### PR TITLE
[Qwen3-Omni Perf] Add lookahead decision/launch/resolve events

### DIFF
--- a/docs/developer_reference/profiler.md
+++ b/docs/developer_reference/profiler.md
@@ -75,10 +75,19 @@ Supporting events used for finer-grained breakdown:
 | Stage | `stage_stream_chunk_received` | Each stream chunk materialized and ready for the receiver scheduler, including coordinator terminal chunks |
 | AR scheduler | `scheduler_queue_enter` | Built request entered the scheduler queue |
 | AR scheduler | `scheduler_first_emit` | First `stream_output_builder` emission per request |
+| AR scheduler | `thinker_lookahead_decision` | Async-decode routing decision per decode batch (metadata `use_lookahead`, `bs`, `min_bs`) |
+| AR scheduler | `thinker_lookahead_launch` | Lookahead step launched on the GPU (metadata `bs`) |
+| AR scheduler | `thinker_lookahead_resolve` | Launched step resolved (metadata `bs`, cumulative `query_hit_total` / `query_miss_total` — per-step blocking is the delta between consecutive events) |
 | Code2Wav | `code2wav_decode_start` | Serial decode start: trigger, start/end/new/context/window frames, active and threshold-ready requests, inbox depth |
 | Code2Wav | `code2wav_decode_end` | Repeats the start metadata and adds audio samples plus execution metadata |
 | Code2Wav | `code2wav_batch_start` | Coalesced step start: batch and bucket shape, new/window frames, active requests, inbox depth, oldest wait, fire reason, due-bucket count, and sub-batch decomposition |
 | Code2Wav | `code2wav_batch_end` | Repeats the start metadata and adds audio samples, execution mode, graph key, and fallback reason |
+
+The lookahead events are gated on `recorder.is_active()` at the call site (in
+addition to the recorder's own no-op behavior) so the async decode hot loop
+pays a single boolean check when profiling is off. Note that an **active**
+recorder has a measurable throughput cost on this path — do not benchmark with
+the recorder on.
 
 Custom callsites can call `sglang_omni.profiler.event_recorder.emit(...)` to
 add domain-specific events. Events from inactive recorders are no-ops, so

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -33,6 +33,7 @@ from sglang.srt.utils import broadcast_pyobj
 
 from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.profiler.event_recorder import get_active_stage as _get_active_stage
+from sglang_omni.profiler.event_recorder import get_recorder as _get_event_recorder
 from sglang_omni.proto.admin import (
     ADMIN_CONTINUE_GENERATION,
     ADMIN_DESTROY_WEIGHTS_UPDATE_GROUP,
@@ -954,6 +955,13 @@ class OmniScheduler:
         self.forward_ct = getattr(self, "forward_ct", 0) + 1
         sched_output = self._build_sched_output(batch)
         pending_step = self._model_runner.execute_launch(sched_output)
+        if _get_event_recorder().is_active() and batch.reqs:
+            _emit_event(
+                request_id=str(getattr(batch.reqs[0], "rid", "")),
+                stage=None,
+                event_name="thinker_lookahead_launch",
+                metadata={"bs": len(batch.reqs)},
+            )
         return sched_output, pending_step
 
     def _run_batch_resolve(self, batch, sched_output, pending_step, skip_rids=()):
@@ -970,6 +978,23 @@ class OmniScheduler:
         mr_output = self._model_runner.execute_resolve(pending_step)
         if mr_output is None:
             return _FAILED_BATCH_RESULT
+        if _get_event_recorder().is_active() and batch.reqs:
+            _emit_event(
+                request_id=str(getattr(batch.reqs[0], "rid", "")),
+                stage=None,
+                event_name="thinker_lookahead_resolve",
+                metadata={
+                    "bs": len(batch.reqs),
+                    # Cumulative counters (base.py increments per resolve): the
+                    # per-step hit/miss is the delta between consecutive events.
+                    "query_hit_total": getattr(
+                        self._model_runner, "_async_query_hit", None
+                    ),
+                    "query_miss_total": getattr(
+                        self._model_runner, "_async_query_miss", None
+                    ),
+                },
+            )
         self._emit_stream_output(sched_output, mr_output, skip_rids=skip_rids)
         return GenerationBatchResult(
             logits_output=None,
@@ -1960,6 +1985,22 @@ class OmniScheduler:
                 and self._batch_is_decode(batch)
                 and (runner is None or runner.lookahead_eligible(batch))
             )
+            if (
+                _get_event_recorder().is_active()
+                and batch is not None
+                and batch.reqs
+                and self._batch_is_decode(batch)
+            ):
+                _emit_event(
+                    request_id=str(getattr(batch.reqs[0], "rid", "")),
+                    stage=None,
+                    event_name="thinker_lookahead_decision",
+                    metadata={
+                        "use_lookahead": use_lookahead,
+                        "bs": len(batch.reqs),
+                        "min_bs": self.async_decode_min_batch_size,
+                    },
+                )
 
             if use_lookahead:
                 try:

--- a/tests/unit_test/pipeline/test_lookahead_telemetry_events.py
+++ b/tests/unit_test/pipeline/test_lookahead_telemetry_events.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the thinker lookahead telemetry events.
+
+Drives the real ``_event_loop_async_decode`` / ``_run_batch_launch`` /
+``_run_batch_resolve`` with stubbed heavy deps (same pattern as
+``test_async_decode.py``) and asserts the three event types reach the
+request-event recorder — and that nothing is emitted when the recorder
+is inactive.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import threading
+import types
+
+import pytest
+
+from sglang_omni.profiler.event_recorder import get_recorder
+from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+
+class _FakeBatch:
+    def __init__(self, n):
+        self.reqs = [
+            types.SimpleNamespace(rid=f"req-{i}", finished=lambda: False)
+            for i in range(n)
+        ]
+
+    def copy(self):
+        return self
+
+
+def _read_events(tmp_path):
+    events = []
+    for f in tmp_path.glob("events_*.jsonl"):
+        for line in f.read_text().splitlines():
+            events.append(json.loads(line))
+    return events
+
+
+@pytest.fixture
+def recorder(tmp_path):
+    rec = get_recorder()
+    rec.start("test", str(tmp_path), "thinker")
+    yield tmp_path
+    rec.stop()
+
+
+def _new_loop_scheduler(events_taken, min_bs=2):
+    s = OmniScheduler.__new__(OmniScheduler)
+    s._admin_lock = threading.Lock()
+    s._admin_queue = queue.Queue()
+    s.chunked_req = None
+    s.is_mixed_chunk = False
+    s.page_size = 1
+    s.running_batch = types.SimpleNamespace(batch_is_full=False)
+    s.server_args = types.SimpleNamespace(disable_radix_cache=False)
+    s.token_to_kv_pool_allocator = types.SimpleNamespace(free=lambda _: None)
+    s.waiting_queue = []
+    s._running = True
+    s._engine_paused = False
+    s._async_pending = None
+    s.async_decode_min_batch_size = min_bs
+    s.cur_batch = None
+    s.last_batch = None
+    s.recv_requests = lambda: []
+    s._take_deferred_request_payloads = lambda: []
+    s.process_input_requests = lambda r: None
+    s._batch_is_decode = lambda b: True
+    s.self_check_during_idle = lambda: events_taken.append("idle")
+    s.self_check_during_busy = lambda: None
+    s._run_batch_launch = lambda b: ("sched_output", "pending_step")
+    s._resolve_and_process = lambda pb, ps, pstep: events_taken.append("resolve")
+    s._resolve_pending_async = OmniScheduler._resolve_pending_async.__get__(s)
+    s.run_batch = lambda b: object()
+    s.process_batch_result = lambda b, r: None
+    return s
+
+
+def _drive(s, seq):
+    batches = [None if n is None else _FakeBatch(n) for n in seq]
+    state = {"i": 0}
+
+    def gnb():
+        i = state["i"]
+        state["i"] += 1
+        if i >= len(batches) - 1:
+            s._running = False
+        return batches[i] if i < len(batches) else None
+
+    s.get_next_batch_to_run = gnb
+    s._event_loop_async_decode()
+
+
+def test_decision_events_emitted_with_routing_outcome(recorder):
+    taken = []
+    s = _new_loop_scheduler(taken, min_bs=2)
+    _drive(s, [1, 2, 2, None])
+
+    decisions = [
+        e
+        for e in _read_events(recorder)
+        if e["event_name"] == "thinker_lookahead_decision"
+    ]
+    # one decision per decode batch (idle iteration emits nothing)
+    assert [d["metadata"]["bs"] for d in decisions] == [1, 2, 2]
+    assert [d["metadata"]["use_lookahead"] for d in decisions] == [
+        False,  # bs1 below min_bs -> fast path
+        True,
+        True,
+    ]
+    assert all(d["metadata"]["min_bs"] == 2 for d in decisions)
+    assert all(d["stage"] == "thinker" for d in decisions)
+    assert decisions[0]["request_id"] == "req-0"
+
+
+def test_launch_and_resolve_events_carry_bs_and_query_counters(recorder):
+    s = OmniScheduler.__new__(OmniScheduler)
+    s.forward_ct = 0
+    s._emit_prefill_start_for_batch = lambda b: None  # not under test
+    s._build_sched_output = lambda b: "sched_output"
+    s._emit_stream_output = lambda so, mo, skip_rids=(): None
+    s._req_is_retracted = lambda r: False
+    s._model_runner = types.SimpleNamespace(
+        execute_launch=lambda so: "pending_step",
+        execute_resolve=lambda p: types.SimpleNamespace(can_run_cuda_graph=True),
+        _async_query_hit=7,
+        _async_query_miss=3,
+    )
+    batch = _FakeBatch(4)
+    sched_output, pending = s._run_batch_launch(batch)
+    pending = types.SimpleNamespace(
+        batch_result=types.SimpleNamespace(next_token_ids=object()),
+        scheduler_output=types.SimpleNamespace(requests=[]),
+    )
+    s._run_batch_resolve(batch, sched_output, pending)
+
+    events = _read_events(recorder)
+    launches = [e for e in events if e["event_name"] == "thinker_lookahead_launch"]
+    resolves = [e for e in events if e["event_name"] == "thinker_lookahead_resolve"]
+    assert len(launches) == 1 and launches[0]["metadata"]["bs"] == 4
+    assert len(resolves) == 1
+    assert resolves[0]["metadata"]["query_hit_total"] == 7
+    assert resolves[0]["metadata"]["query_miss_total"] == 3
+
+
+def test_no_events_and_no_errors_when_recorder_inactive(tmp_path):
+    assert not get_recorder().is_active()
+    taken = []
+    s = _new_loop_scheduler(taken, min_bs=2)
+    _drive(s, [1, 2, None])  # must not raise, must not write anything
+    assert list(tmp_path.glob("events_*.jsonl")) == []


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

#1018 item 1.2 asks admission measurements to "Record actual lookahead decision, launch, and resolve events" — but the async decode path emits no events or logs today, and the `_async_query_hit/_miss` counters in `ModelRunner` are incremented yet never read. While running the 1.2 measurements (#1210 ) we needed this evidence and wrote the minimal instrumentation.

One measured caveat shaped the design: an **active** event recorder costs 25–39% output throughput on this path (the emit sits on the launch/resolve critical path and consumes the async-lookahead host-overlap margin — data in the linked issue, finding 2). These emits are therefore explicitly gated on `recorder.is_active()`: with profiling off the hot loop pays a single boolean check.

## Modifications

Three `_emit_event` call sites in `omni_scheduler.py`, all recorder-gated and defensively accessed:

- `thinker_lookahead_decision` `{use_lookahead, bs, min_bs}` at the `use_lookahead` predicate (decode batches only);
- `thinker_lookahead_launch` `{bs}` in `_run_batch_launch` after `execute_launch`;
- `thinker_lookahead_resolve` `{bs, query_hit_total, query_miss_total}` in `_run_batch_resolve` — the cumulative counters make per-step blocking behavior recoverable by differencing consecutive events.

No behavior change; no new dependencies.

## Related Issues

Part of #1022. Produces the lookahead evidence #1018 item 1.2 records.

## Accuracy Test

Telemetry-only; no model-side code touched. Async unit suites pass: `tests/unit_test/pipeline/test_async_decode.py`, `tests/unit_test/qwen3_omni/test_thinker_lookahead_eligible.py`, `tests/unit_test/qwen3_omni/test_thinker_async_decode_flag.py` (45 passed).

## Benchmark & Profiling

With the patch on the tree and the recorder off, cap64 c32 measures 2252 tok/s vs 2210–2264 for clean main on the same box — within run-to-run noise (data: #1210 ). Event samples produced under load (all three event types, `use_lookahead=true` at c≥16) are in the gist linked from the same issue.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
