### PR TITLE
fix(profiler): UnboundLocalError when restarting an active torch profiler

### DIFF
--- a/sglang_omni/profiler/torch_profiler.py
+++ b/sglang_omni/profiler/torch_profiler.py
@@ -43,6 +43,7 @@ class TorchProfiler(ProfilerBase):
         Start the profiler with the given trace path template.
         """
         with cls._lock:
+            rank = cls._get_rank()
 
             # 1. Cleanup any existing profiler
             if cls._profiler is not None:
@@ -64,8 +65,6 @@ class TorchProfiler(ProfilerBase):
                 cls._profiler = None
                 cls._active_run_id = None
                 cls._trace_template = ""
-
-            rank = cls._get_rank()
 
             # 2. Make path absolute
             trace_path_template = os.path.abspath(trace_path_template)

--- a/tests/unit_test/profiler/test_torch_profiler.py
+++ b/tests/unit_test/profiler/test_torch_profiler.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+import sglang_omni.profiler.torch_profiler as torch_profiler_module
+from sglang_omni.profiler.torch_profiler import TorchProfiler
+
+
+class _FakeProfile:
+    instances: list["_FakeProfile"] = []
+
+    def __init__(self, *args, **kwargs):
+        self.started = False
+        self.stopped = False
+        _FakeProfile.instances.append(self)
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def export_chrome_trace(self, path: str) -> None:  # pragma: no cover
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _isolated_profiler(monkeypatch):
+    monkeypatch.setattr(torch_profiler_module, "profile", _FakeProfile)
+    _FakeProfile.instances = []
+    TorchProfiler._profiler = None
+    TorchProfiler._active_run_id = None
+    TorchProfiler._trace_template = ""
+    yield
+    TorchProfiler._profiler = None
+    TorchProfiler._active_run_id = None
+    TorchProfiler._trace_template = ""
+
+
+def test_start_returns_rank_trace_path(tmp_path) -> None:
+    template = str(tmp_path / "run")
+
+    trace_path = TorchProfiler.start(template, run_id="run-a")
+
+    assert trace_path == f"{template}_rank0.trace.json.gz"
+    assert TorchProfiler.is_active()
+    assert TorchProfiler.get_active_run_id() == "run-a"
+    assert len(_FakeProfile.instances) == 1
+    assert _FakeProfile.instances[0].started
+
+
+def test_start_is_idempotent_for_same_run_id(tmp_path) -> None:
+    template = str(tmp_path / "run")
+    first_path = TorchProfiler.start(template, run_id="run-a")
+
+    second_path = TorchProfiler.start(template, run_id="run-a")
+
+    assert second_path == first_path
+    assert len(_FakeProfile.instances) == 1
+    assert not _FakeProfile.instances[0].stopped
+
+
+def test_start_restarts_for_different_run_id(tmp_path) -> None:
+    template = str(tmp_path / "run")
+    TorchProfiler.start(template, run_id="run-a")
+
+    TorchProfiler.start(template, run_id="run-b")
+
+    assert TorchProfiler.get_active_run_id() == "run-b"
+    assert len(_FakeProfile.instances) == 2
+    assert _FakeProfile.instances[0].stopped
+    assert _FakeProfile.instances[1].started


### PR DESCRIPTION
## Motivation

`TorchProfiler.start()` reads `rank` inside the "profiler already active" cleanup branch, but `rank` is only assigned after that branch. Any `start()` call while a profiler is active — the idempotent same-`run_id` return, and the restart-for-a-new-`run_id` path — raises `UnboundLocalError` instead of doing what the branch was written to do. Because the crash happens before `cls._profiler.stop()`, the old profiler is also leaked in the active state and keeps collecting. In practice this means `POST /start_profile` cannot recover an interrupted profiling session (e.g. a benchmark aborted before `/stop_profile`); the endpoint 500s until a manual `/stop_profile`. The ordering has been wrong since the file was introduced in #77; `stop()` in the same class shows the intended order.

## Reproduction

CPU-only, no server or GPU needed — two calls against the real torch profiler:

```python
from sglang_omni.profiler.torch_profiler import TorchProfiler

TorchProfiler.start("/tmp/prof/run", run_id="a")   # OK, profiler active
TorchProfiler.start("/tmp/prof/run", run_id="b")   # UnboundLocalError at torch_profiler.py:54
```

On current main the second call raises, and kineto reports a leaked callback handle from the still-running first profiler. With this fix the second call takes the intended path: logs the restart warning, stops and exports the old session, and starts the new one.

## Modifications

- `torch_profiler.py`: assign `rank = cls._get_rank()` before the cleanup branch (net -1 line).
- `tests/unit_test/profiler/test_torch_profiler.py` (new): unit tests for the start path, same-`run_id` idempotence, and different-`run_id` restart, with the profiler class monkeypatched so the tests are CPU-only. Against current main the two restart tests fail with exactly this `UnboundLocalError`; with the fix all three pass.

## Related Issues

None filed; found while reading the profiler control flow.

## Accuracy Test

N/A — dev tooling only, no model-side code.

## Benchmark & Profiling

N/A — no hot path; `start()` runs once per profiling session.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)