### PR TITLE
[Model] Add MiMo-Audio input-to-text inference

### DIFF
--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -231,6 +231,7 @@ class SGLModelRunner(ModelRunner):
             "Qwen3ASRForConditionalGeneration": "sglang_omni.models.qwen3_asr.sglang_model:Qwen3ASRForConditionalGeneration",
             "FunAsrNanoForConditionalGeneration": "sglang_omni.models.fun_asr.sglang_model:FunAsrNanoForConditionalGeneration",
             "ArkasrForConditionalGeneration": "sglang_omni.models.arkasr.sglang_model:ArkasrForConditionalGeneration",
+            "MiMoAudioModel": "sglang_omni.models.mimo_audio.sglang_model:MiMoAudioModel",
         }
         for arch, path in sglang_omni_models.items():
             module_path, _, attr = path.partition(":")

--- a/sglang_omni/models/mimo_audio/__init__.py
+++ b/sglang_omni/models/mimo_audio/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MiMo-Audio input-to-text support.
+
+Milestone 1 intentionally excludes the output patch decoder, delayed RVQ
+generation, audio-tokenizer decoder, and waveform output.
+"""

--- a/sglang_omni/models/mimo_audio/audio_tokenizer.py
+++ b/sglang_omni/models/mimo_audio/audio_tokenizer.py
@@ -1,0 +1,385 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Input-only MiMo audio tokenizer encoder.
+
+This module intentionally contains no audio decoder, vocoder, ISTFT, or
+waveform-generation code.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from safetensors import safe_open
+from sgl_kernel.flash_attn import flash_attn_varlen_func
+from torch import nn
+
+
+def _sequence_mask(
+    inputs: torch.Tensor, lengths: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    batch, target_len = inputs.shape[:2]
+    positions = torch.arange(target_len, device=inputs.device)
+    mask = positions < lengths.reshape(batch, 1)
+    mask = mask.unsqueeze(-1)
+    unpacking_index = torch.cumsum(mask.to(torch.int64).reshape(-1), dim=0) - 1
+    return mask, unpacking_index
+
+
+def _unpack_packed(packed: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+    batch = lengths.shape[0]
+    max_len = int(torch.max(lengths).item())
+    mask = (
+        torch.arange(max_len, device=packed.device)[None, :]
+        < lengths[:, None].to(packed.device)
+    ).unsqueeze(-1)
+    unpacking_index = torch.cumsum(mask.to(torch.int64).reshape(-1), dim=0) - 1
+    unpacked = torch.index_select(packed, 0, unpacking_index).view(
+        batch, max_len, packed.shape[-1]
+    )
+    return torch.where(mask, unpacked, 0)
+
+
+def _packed_position_ids(lengths: torch.Tensor) -> torch.Tensor:
+    offsets = torch.cat(
+        [torch.zeros(1, device=lengths.device, dtype=lengths.dtype), lengths[:-1]]
+    ).cumsum(0)
+    return torch.arange(lengths.sum(), device=lengths.device) - torch.repeat_interleave(
+        offsets, lengths
+    )
+
+
+def _rotate_half(value: torch.Tensor) -> torch.Tensor:
+    first, second = value.chunk(2, dim=-1)
+    return torch.cat([-second, first], dim=-1)
+
+
+class _RotaryEmbedding(nn.Module):
+    def __init__(self, theta: float, head_dim: int) -> None:
+        super().__init__()
+        inv_freq = 1.0 / (
+            theta
+            ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / float(head_dim))
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(
+        self, position_ids: torch.Tensor, dtype: torch.dtype
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        frequencies = torch.outer(
+            position_ids.float(), self.inv_freq.float().to(position_ids.device)
+        )
+        embedding = torch.cat([frequencies, frequencies], dim=-1)
+        return embedding.cos().to(dtype), embedding.sin().to(dtype)
+
+
+class _Codebook(nn.Module):
+    """Inference-only codebook with checkpoint-compatible buffer names."""
+
+    def __init__(self, size: int, dimension: int) -> None:
+        super().__init__()
+        self.register_buffer("inited", torch.ones(1))
+        self.register_buffer("cluster_size", torch.zeros(size))
+        self.register_buffer("embed", torch.empty(size, dimension))
+        self.register_buffer("embed_avg", torch.empty(size, dimension))
+
+    def encode(self, values: torch.Tensor) -> torch.Tensor:
+        codebook = self.embed.to(values)
+        distance = -(
+            values.pow(2).sum(1, keepdim=True)
+            - 2 * values @ codebook.T
+            + codebook.pow(2).sum(1, keepdim=False)[None, :]
+        )
+        return distance.argmax(dim=-1)
+
+    def decode(self, indices: torch.Tensor) -> torch.Tensor:
+        return F.embedding(indices, self.embed)
+
+
+class _VectorQuantization(nn.Module):
+    def __init__(self, size: int, dimension: int) -> None:
+        super().__init__()
+        self.project_in = nn.Identity()
+        self.project_out = nn.Identity()
+        self._codebook = _Codebook(size, dimension)
+
+    def encode(self, values: torch.Tensor) -> torch.Tensor:
+        return self._codebook.encode(values)
+
+    def decode(self, indices: torch.Tensor) -> torch.Tensor:
+        return self._codebook.decode(indices)
+
+
+class _ResidualVectorQuantization(nn.Module):
+    def __init__(self, sizes: Sequence[int], dimension: int) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [_VectorQuantization(size, dimension) for size in sizes]
+        )
+
+    def encode(self, values: torch.Tensor, n_q: int | None = None) -> torch.Tensor:
+        residual = values.float()
+        codes: list[torch.Tensor] = []
+        for layer in self.layers[: n_q or len(self.layers)]:
+            indices = layer.encode(residual)
+            residual = residual - layer.decode(indices)
+            codes.append(indices)
+        return torch.stack(codes)
+
+
+class _ResidualVectorQuantizer(nn.Module):
+    def __init__(self, sizes: Sequence[int], dimension: int) -> None:
+        super().__init__()
+        self.vq = _ResidualVectorQuantization(sizes, dimension)
+
+    def encode(self, values: torch.Tensor, n_q: int | None = None) -> torch.Tensor:
+        return self.vq.encode(values, n_q=n_q)
+
+
+class _Attention(nn.Module):
+    def __init__(
+        self,
+        dimension: int,
+        heads: int,
+        *,
+        causal: bool,
+        window_size: tuple[int, int],
+    ) -> None:
+        super().__init__()
+        self.dimension = dimension
+        self.heads = heads
+        self.head_dim = dimension // heads
+        self.window_size = window_size
+        self.causal = causal
+        self.k_proj = nn.Linear(dimension, dimension, bias=False)
+        self.v_proj = nn.Linear(dimension, dimension, bias=True)
+        self.q_proj = nn.Linear(dimension, dimension, bias=True)
+        self.out_proj = nn.Linear(dimension, dimension, bias=True)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        lengths: torch.Tensor,
+        rotary: tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        query = self.q_proj(hidden_states).view(-1, self.heads, self.head_dim)
+        key = self.k_proj(hidden_states).view(-1, self.heads, self.head_dim)
+        value = self.v_proj(hidden_states).view(-1, self.heads, self.head_dim)
+        cos, sin = rotary
+        cos = cos[:, None, :]
+        sin = sin[:, None, :]
+        query = query * cos + _rotate_half(query) * sin
+        key = key * cos + _rotate_half(key) * sin
+        cumulative = F.pad(lengths.cumsum(0), (1, 0)).to(torch.int32)
+        max_length = int(lengths.max().item())
+        output = flash_attn_varlen_func(
+            query,
+            key,
+            value,
+            cumulative,
+            cumulative,
+            max_length,
+            max_length,
+            causal=self.causal,
+            window_size=self.window_size,
+        )
+        return self.out_proj(output.reshape(-1, self.dimension))
+
+
+class _TransformerLayer(nn.Module):
+    def __init__(
+        self,
+        dimension: int,
+        heads: int,
+        feed_forward_dim: int,
+        *,
+        causal: bool,
+        window_size: tuple[int, int],
+    ) -> None:
+        super().__init__()
+        self.self_attn = _Attention(
+            dimension,
+            heads,
+            causal=causal,
+            window_size=window_size,
+        )
+        self.self_attn_layer_norm = nn.LayerNorm(dimension)
+        self.fc1 = nn.Linear(dimension, feed_forward_dim)
+        self.fc2 = nn.Linear(feed_forward_dim, dimension)
+        self.final_layer_norm = nn.LayerNorm(dimension)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        lengths: torch.Tensor,
+        rotary: tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.self_attn(
+            self.self_attn_layer_norm(hidden_states),
+            lengths,
+            rotary,
+        )
+        hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = self.fc2(F.gelu(self.fc1(self.final_layer_norm(hidden_states))))
+        return residual + hidden_states
+
+
+class MiMoAudioTokenizerEncoder(nn.Module):
+    """Native input encoder matching `MiMo-Audio-Tokenizer` weight names."""
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        super().__init__()
+        self.config = config
+        dimension = int(config["d_model"])
+        heads = int(config["encoder_attention_heads"])
+        self.skip_layer_idx = int(config["encoder_skip_layer_id"])
+        self.stride_size = int(config["stride_size"])
+        self.avg_pooler = int(config["avg_pooler"])
+        self.conv1 = nn.Conv1d(
+            int(config["n_mels"]),
+            dimension,
+            int(config["kernel_size"]),
+            padding=1,
+        )
+        self.conv2 = nn.Conv1d(
+            dimension,
+            dimension,
+            int(config["kernel_size"]),
+            stride=self.stride_size,
+            padding=1,
+        )
+        self.position_embedding = _RotaryEmbedding(
+            float(config["rope_theta"]),
+            dimension // heads,
+        )
+        window = tuple(int(value) for value in config["encoder_attn_window_size"])
+        self.layers = nn.ModuleList(
+            [
+                _TransformerLayer(
+                    dimension,
+                    heads,
+                    int(config["encoder_ffn_dim"]),
+                    causal=bool(config["encoder_causal"]),
+                    window_size=window,
+                )
+                for _ in range(int(config["encoder_layers"]))
+            ]
+        )
+        self.layer_norm = nn.LayerNorm(dimension)
+        self.down_sample_layer = nn.Sequential(
+            nn.Conv1d(
+                dimension,
+                dimension,
+                self.avg_pooler,
+                self.avg_pooler,
+                bias=False,
+            ),
+            nn.GELU(),
+        )
+        self.down_sample_norm = nn.LayerNorm(dimension)
+        self.quantizer = _ResidualVectorQuantizer(
+            [int(size) for size in config["codebook_size"]],
+            dimension,
+        )
+
+    def _output_lengths(self, mel_lengths: torch.Tensor) -> torch.Tensor:
+        kernel = int(self.config["kernel_size"])
+        target = mel_lengths + 3 - kernel
+        return (target + 2 - kernel) // self.stride_size + 1
+
+    @torch.no_grad()
+    def encode(
+        self,
+        *,
+        input_features: torch.Tensor,
+        input_lens: torch.Tensor,
+        return_codes_only: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if return_codes_only is not True:
+            raise ValueError("Milestone 1 tokenizer supports codes-only encoding")
+        input_lens = input_lens.to(input_features.device, dtype=torch.int64)
+        hidden = _unpack_packed(input_features, input_lens).transpose(1, 2)
+        hidden = F.gelu(self.conv1(hidden.to(self.conv1.weight)))
+        hidden = F.gelu(self.conv2(hidden)).transpose(1, 2)
+        output_lengths = self._output_lengths(input_lens)
+        mask, unpacking_index = _sequence_mask(hidden, output_lengths)
+        hidden = torch.masked_select(hidden, mask).view(
+            int(output_lengths.sum().item()), int(self.config["d_model"])
+        )
+        positions = _packed_position_ids(output_lengths).long()
+        rotary = self.position_embedding(positions, hidden.dtype)
+
+        skip: torch.Tensor | float = 0.0
+        for index, layer in enumerate(self.layers):
+            hidden = layer(hidden, output_lengths, rotary)
+            if index == self.skip_layer_idx - 1:
+                skip = hidden.clone()
+        hidden = self.layer_norm(hidden + skip)
+
+        batch, target_len = mask.shape[:2]
+        hidden = torch.index_select(hidden, 0, unpacking_index).view(
+            batch, target_len, int(self.config["d_model"])
+        )
+        if target_len % self.avg_pooler:
+            padding = self.avg_pooler - target_len % self.avg_pooler
+            hidden = F.pad(hidden, (0, 0, 0, padding))
+        hidden = self.down_sample_layer(hidden.transpose(1, 2)).transpose(1, 2)
+        output_lengths = output_lengths.div(self.avg_pooler, rounding_mode="floor") + (
+            output_lengths % self.avg_pooler != 0
+        ).to(output_lengths.dtype)
+        mask, _ = _sequence_mask(hidden, output_lengths)
+        hidden = torch.masked_select(hidden, mask).view(
+            int(output_lengths.sum().item()), int(self.config["d_model"])
+        )
+        hidden = self.down_sample_norm(hidden)
+        return self.quantizer.encode(hidden.float()), output_lengths
+
+    @classmethod
+    def from_checkpoint(
+        cls,
+        snapshot_path: str | Path,
+        *,
+        device: str | torch.device = "cuda:0",
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> MiMoAudioTokenizerEncoder:
+        snapshot = Path(snapshot_path)
+        config = json.loads((snapshot / "config.json").read_text())
+        model = cls(config).to(device=device, dtype=dtype).eval()
+        state = model.state_dict()
+        expected = set(state)
+        loaded: set[str] = set()
+        checkpoint = snapshot / "model.safetensors"
+        with safe_open(checkpoint, framework="pt", device="cpu") as tensors:
+            # `safe_open` is not iterable in the pinned safetensors build.
+            for checkpoint_name in tensors.keys():  # noqa: SIM118
+                if not checkpoint_name.startswith("encoder."):
+                    continue
+                name = checkpoint_name.removeprefix("encoder.")
+                if name not in state:
+                    raise ValueError(
+                        f"Unexpected MiMo tokenizer encoder weight {checkpoint_name}"
+                    )
+                destination = state[name]
+                destination.copy_(
+                    tensors.get_tensor(checkpoint_name).to(
+                        device=destination.device,
+                        dtype=destination.dtype,
+                    )
+                )
+                loaded.add(name)
+        missing = expected - loaded
+        if missing:
+            raise ValueError(
+                "Missing MiMo tokenizer encoder weights: "
+                + ", ".join(sorted(missing)[:10])
+            )
+        return model
+
+
+__all__ = ["MiMoAudioTokenizerEncoder"]

--- a/sglang_omni/models/mimo_audio/config.py
+++ b/sglang_omni/models/mimo_audio/config.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pipeline configuration for MiMo-Audio input-to-text inference."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pydantic import Field
+
+from sglang_omni.config import (
+    PipelineConfig,
+    StageConfig,
+    StageResourceConfig,
+    StageRuntimeConfig,
+)
+
+_PKG = "sglang_omni.models.mimo_audio"
+MIMO_AUDIO_TOKENIZER_PATH = "XiaomiMiMo/MiMo-Audio-Tokenizer"
+
+
+def _mimo_audio_stages() -> list[StageConfig]:
+    return [
+        StageConfig(
+            name="audio_tokenizer",
+            process="audio_tokenizer",
+            factory=f"{_PKG}.stages.create_audio_tokenizer_executor",
+            factory_args={
+                "tokenizer_path": MIMO_AUDIO_TOKENIZER_PATH,
+                "device": "cuda:0",
+            },
+            gpu=0,
+            runtime=StageRuntimeConfig(
+                resources=StageResourceConfig(total_gpu_memory_fraction=0.08)
+            ),
+            next="thinker",
+        ),
+        StageConfig(
+            name="thinker",
+            process="thinker",
+            factory=f"{_PKG}.stages.create_thinker_executor",
+            factory_args={
+                "device": "cuda:0",
+                "max_running_requests": 1,
+                "max_new_tokens": 256,
+            },
+            gpu=0,
+            runtime=StageRuntimeConfig(
+                resources=StageResourceConfig(total_gpu_memory_fraction=0.92)
+            ),
+            terminal=True,
+        ),
+    ]
+
+
+class MiMoAudioPipelineConfig(PipelineConfig):
+    """Two-stage, single-GPU MiMo audio-input-to-text pipeline.
+
+    The tokenizer stage converts a normalized real waveform into the official
+    eight-channel RVQ representation. The thinker stage owns the SGLang Qwen2
+    runtime and returns text. No output-audio stage is present.
+    """
+
+    architecture: ClassVar[str] = "MiMoAudioModel"
+
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"tokenizer": "audio_tokenizer", "thinker": "thinker"}
+
+    @classmethod
+    def generation_sglang_role_to_stage(cls) -> dict[str, str]:
+        return {"generation": "thinker"}
+
+    model_path: str
+    entry_stage: str = "audio_tokenizer"
+    stages: list[StageConfig] = Field(default_factory=_mimo_audio_stages)
+
+
+EntryClass = MiMoAudioPipelineConfig

--- a/sglang_omni/models/mimo_audio/preprocessor.py
+++ b/sglang_omni/models/mimo_audio/preprocessor.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Waveform-to-RVQ preprocessing for MiMo-Audio input."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+import numpy as np
+import torch
+import torchaudio
+
+from sglang_omni.models.mimo_audio.prompt import AUDIO_CHANNELS, pad_audio_codes
+from sglang_omni.utils.audio import load_audio
+
+
+@dataclass(frozen=True)
+class MiMoAudioTokenizerSettings:
+    sampling_rate: int = 24_000
+    n_fft: int = 960
+    hop_length: int = 240
+    window_size: int = 960
+    n_mels: int = 128
+    f_min: float = 0.0
+    f_max: float | None = None
+    segment_frames: int = 6_000
+
+    @classmethod
+    def from_config(cls, config: Any) -> MiMoAudioTokenizerSettings:
+        def value(name: str, default: Any) -> Any:
+            if isinstance(config, dict):
+                return config.get(name, default)
+            return getattr(config, name, default)
+
+        return cls(
+            sampling_rate=int(value("sampling_rate", cls.sampling_rate)),
+            n_fft=int(value("nfft", cls.n_fft)),
+            hop_length=int(value("hop_length", cls.hop_length)),
+            window_size=int(value("window_size", cls.window_size)),
+            n_mels=int(value("n_mels", cls.n_mels)),
+            f_min=float(value("fmin", cls.f_min)),
+            f_max=(
+                None
+                if value("fmax", cls.f_max) is None
+                else float(value("fmax", cls.f_max))
+            ),
+        )
+
+
+class MiMoAudioEncoder(Protocol):
+    def encode(
+        self,
+        *,
+        input_features: torch.Tensor,
+        input_lens: torch.Tensor,
+        return_codes_only: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor]: ...
+
+
+class MiMoAudioPreprocessor:
+    """Exact official log-mel preparation plus input-only RVQ encoding."""
+
+    def __init__(
+        self,
+        settings: MiMoAudioTokenizerSettings | None = None,
+        *,
+        device: str | torch.device = "cpu",
+    ) -> None:
+        self.settings = settings or MiMoAudioTokenizerSettings()
+        self.device = torch.device(device)
+        self.mel_transform = torchaudio.transforms.MelSpectrogram(
+            sample_rate=self.settings.sampling_rate,
+            n_fft=self.settings.n_fft,
+            hop_length=self.settings.hop_length,
+            win_length=self.settings.window_size,
+            f_min=self.settings.f_min,
+            f_max=self.settings.f_max,
+            n_mels=self.settings.n_mels,
+            power=1.0,
+            center=True,
+        ).to(self.device)
+
+    def load_waveform(self, source: Any) -> torch.Tensor:
+        waveform = load_audio(
+            source,
+            source_name="MiMo-Audio",
+            target_sample_rate=self.settings.sampling_rate,
+        )
+        if waveform.size == 0:
+            raise ValueError("MiMo-Audio input waveform is empty")
+        return torch.from_numpy(np.asarray(waveform, dtype=np.float32)).to(self.device)
+
+    def waveform_to_log_mel(self, waveform: torch.Tensor) -> torch.Tensor:
+        waveform = torch.as_tensor(
+            waveform,
+            dtype=torch.float32,
+            device=self.device,
+        ).reshape(-1)
+        if waveform.numel() == 0:
+            raise ValueError("MiMo-Audio input waveform is empty")
+        spectrogram = self.mel_transform(waveform[None, :])
+        return (
+            torch.log(torch.clamp(spectrogram, min=1.0e-7)).squeeze(0).transpose(0, 1)
+        )
+
+    def segment_lengths(self, mel_frame_count: int) -> torch.Tensor:
+        if mel_frame_count <= 0:
+            raise ValueError("MiMo-Audio log-mel input has no frames")
+        full, remainder = divmod(mel_frame_count, self.settings.segment_frames)
+        lengths = [self.settings.segment_frames] * full
+        if remainder:
+            lengths.append(remainder)
+        return torch.tensor(lengths, dtype=torch.int64)
+
+    @torch.no_grad()
+    def encode_log_mel(
+        self,
+        log_mel: torch.Tensor,
+        encoder: MiMoAudioEncoder,
+    ) -> torch.Tensor:
+        if log_mel.ndim != 2 or log_mel.shape[1] != self.settings.n_mels:
+            raise ValueError(
+                "MiMo-Audio log-mel tensor must have shape "
+                f"[frames, {self.settings.n_mels}], got {tuple(log_mel.shape)}"
+            )
+        lengths = self.segment_lengths(int(log_mel.shape[0]))
+        packed_codes, _ = encoder.encode(
+            input_features=log_mel.to(self.device),
+            input_lens=lengths.to(self.device),
+            return_codes_only=True,
+        )
+        if packed_codes.ndim != 2 or packed_codes.shape[0] < AUDIO_CHANNELS:
+            raise ValueError(
+                "MiMo-Audio tokenizer returned invalid codes with shape "
+                f"{tuple(packed_codes.shape)}"
+            )
+        codes = packed_codes[:AUDIO_CHANNELS].transpose(0, 1).detach().cpu().long()
+        return pad_audio_codes(codes)
+
+    def encode_source(
+        self,
+        source: Any,
+        encoder: MiMoAudioEncoder,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        waveform = self.load_waveform(source)
+        log_mel = self.waveform_to_log_mel(waveform)
+        return self.encode_log_mel(log_mel, encoder), log_mel
+
+
+def default_tokenizer_config_path(tokenizer_snapshot: str | Path) -> Path:
+    return Path(tokenizer_snapshot) / "config.json"
+
+
+__all__ = [
+    "MiMoAudioEncoder",
+    "MiMoAudioPreprocessor",
+    "MiMoAudioTokenizerSettings",
+    "default_tokenizer_config_path",
+]

--- a/sglang_omni/models/mimo_audio/prompt.py
+++ b/sglang_omni/models/mimo_audio/prompt.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Official-compatible MiMo input-channel and prompt construction."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+GROUP_SIZE = 4
+AUDIO_CHANNELS = 8
+SPEECH_EMPTY_IDS = (1024, 1024, 128, 128, 128, 128, 128, 128)
+
+SOSP = "<|sosp|>"
+EOSP = "<|eosp|>"
+EMPTY = "<|empty|>"
+
+
+@dataclass(frozen=True)
+class MiMoPrompt:
+    """Both the official nine-channel representation and SGLang projection."""
+
+    input_ids: list[int]
+    audio_codes: torch.Tensor
+    official_input_ids: torch.Tensor
+    audio_start: int
+    audio_end: int
+
+
+def _token_id(tokenizer: Any, token: str) -> int:
+    if hasattr(tokenizer, "convert_tokens_to_ids"):
+        token_id = tokenizer.convert_tokens_to_ids(token)
+    elif hasattr(tokenizer, "token_to_id"):
+        token_id = tokenizer.token_to_id(token)
+    else:
+        raise TypeError("MiMo tokenizer does not expose token ID lookup")
+    if token_id is None or int(token_id) < 0:
+        raise ValueError(f"MiMo tokenizer is missing required token {token!r}")
+    return int(token_id)
+
+
+def _encode_literal(tokenizer: Any, text: str) -> list[int]:
+    if hasattr(tokenizer, "encode"):
+        encoded = tokenizer.encode(text, add_special_tokens=False)
+        if hasattr(encoded, "ids"):
+            return [int(token_id) for token_id in encoded.ids]
+        return [int(token_id) for token_id in encoded]
+    encoded = tokenizer(text, add_special_tokens=False)
+    input_ids = (
+        encoded.input_ids if hasattr(encoded, "input_ids") else encoded["input_ids"]
+    )
+    if isinstance(input_ids, torch.Tensor):
+        input_ids = input_ids.reshape(-1).tolist()
+    elif input_ids and isinstance(input_ids[0], list):
+        input_ids = input_ids[0]
+    return [int(token_id) for token_id in input_ids]
+
+
+def _expand_text_ids(token_ids: Sequence[int], group_size: int) -> torch.Tensor:
+    """Expand each global token to `[token, -100, ...]` timesteps."""
+
+    expanded = torch.full(
+        (len(token_ids) * group_size,),
+        -100,
+        dtype=torch.int64,
+    )
+    expanded[::group_size] = torch.tensor(token_ids, dtype=torch.int64)
+    return expanded
+
+
+def _speech_empty_rows(length: int, speech_empty_ids: Sequence[int]) -> torch.Tensor:
+    return torch.tensor(speech_empty_ids, dtype=torch.int64)[:, None].expand(-1, length)
+
+
+def build_text_segment(
+    tokenizer: Any,
+    text: str,
+    *,
+    group_size: int = GROUP_SIZE,
+    speech_empty_ids: Sequence[int] = SPEECH_EMPTY_IDS,
+) -> torch.Tensor:
+    """Build an official `[1 + audio_channels, T]` text segment."""
+
+    text_row = _expand_text_ids(_encode_literal(tokenizer, text), group_size)
+    return torch.cat(
+        [text_row[None, :], _speech_empty_rows(text_row.numel(), speech_empty_ids)],
+        dim=0,
+    )
+
+
+def build_audio_segment(
+    tokenizer: Any,
+    audio_codes: torch.Tensor,
+    *,
+    group_size: int = GROUP_SIZE,
+    speech_empty_ids: Sequence[int] = SPEECH_EMPTY_IDS,
+) -> torch.Tensor:
+    """Build the official `<|sosp|> codes <|eosp|>` nine-channel segment."""
+
+    codes = torch.as_tensor(audio_codes, dtype=torch.int64)
+    audio_channels = len(speech_empty_ids)
+    if codes.ndim != 2 or codes.shape[1] != audio_channels:
+        raise ValueError(
+            "MiMo audio codes must have shape "
+            f"[frames, {audio_channels}], got {tuple(codes.shape)}"
+        )
+    if codes.shape[0] == 0:
+        raise ValueError("MiMo audio codes must contain at least one frame")
+    if codes.shape[0] % group_size:
+        raise ValueError(
+            f"MiMo audio-code frames must be divisible by group_size={group_size}, "
+            f"got {codes.shape[0]}"
+        )
+
+    audio_frames = codes.T.contiguous()
+    group_count = codes.shape[0] // group_size
+    text_tokens = [
+        _token_id(tokenizer, SOSP),
+        *([_token_id(tokenizer, EMPTY)] * group_count),
+        _token_id(tokenizer, EOSP),
+    ]
+    text_row = _expand_text_ids(text_tokens, group_size)
+    boundary = _speech_empty_rows(group_size, speech_empty_ids)
+    speech_rows = torch.cat([boundary, audio_frames, boundary], dim=1)
+    return torch.cat([text_row[None, :], speech_rows], dim=0)
+
+
+def pad_audio_codes(
+    audio_codes: torch.Tensor, *, group_size: int = GROUP_SIZE
+) -> torch.Tensor:
+    """Repeat the last official tokenizer frame to complete a patch group."""
+
+    codes = torch.as_tensor(audio_codes, dtype=torch.int64)
+    if codes.ndim != 2 or codes.shape[0] == 0:
+        raise ValueError("MiMo audio codes must be a non-empty rank-2 tensor")
+    remainder = codes.shape[0] % group_size
+    if remainder == 0:
+        return codes
+    return torch.cat(
+        [codes, codes[-1:].expand(group_size - remainder, -1)],
+        dim=0,
+    )
+
+
+def build_audio_understanding_prompt(
+    tokenizer: Any,
+    audio_codes: torch.Tensor,
+    instruction: str,
+    *,
+    thinking: bool = False,
+    group_size: int = GROUP_SIZE,
+    speech_empty_ids: Sequence[int] = SPEECH_EMPTY_IDS,
+) -> MiMoPrompt:
+    """Build the official SFT audio-understanding prompt and SGLang projection."""
+
+    if not instruction or not instruction.strip():
+        raise ValueError("MiMo audio-understanding instruction must not be empty")
+    codes = pad_audio_codes(audio_codes, group_size=group_size)
+    segments = [
+        build_text_segment(
+            tokenizer,
+            "<|im_start|>user\n",
+            group_size=group_size,
+            speech_empty_ids=speech_empty_ids,
+        ),
+        build_audio_segment(
+            tokenizer,
+            codes,
+            group_size=group_size,
+            speech_empty_ids=speech_empty_ids,
+        ),
+        build_text_segment(
+            tokenizer,
+            instruction,
+            group_size=group_size,
+            speech_empty_ids=speech_empty_ids,
+        ),
+        build_text_segment(
+            tokenizer,
+            "<|im_end|>\n",
+            group_size=group_size,
+            speech_empty_ids=speech_empty_ids,
+        ),
+        build_text_segment(
+            tokenizer,
+            "<|im_start|>assistant\n",
+            group_size=group_size,
+            speech_empty_ids=speech_empty_ids,
+        ),
+        build_text_segment(
+            tokenizer,
+            "<think>\n" if thinking else "<think>\n\n</think>\n",
+            group_size=group_size,
+            speech_empty_ids=speech_empty_ids,
+        ),
+    ]
+    official = torch.cat(segments, dim=1)
+    input_ids = [int(token_id) for token_id in official[0, ::group_size].tolist()]
+    audio_start = input_ids.index(_token_id(tokenizer, SOSP)) + 1
+    audio_end = input_ids.index(_token_id(tokenizer, EOSP), audio_start)
+    if audio_end - audio_start != codes.shape[0] // group_size:
+        raise AssertionError("MiMo prompt audio placeholders do not match code groups")
+    return MiMoPrompt(
+        input_ids=input_ids,
+        audio_codes=codes,
+        official_input_ids=official,
+        audio_start=audio_start,
+        audio_end=audio_end,
+    )
+
+
+__all__ = [
+    "AUDIO_CHANNELS",
+    "GROUP_SIZE",
+    "SPEECH_EMPTY_IDS",
+    "MiMoPrompt",
+    "build_audio_segment",
+    "build_audio_understanding_prompt",
+    "build_text_segment",
+    "pad_audio_codes",
+]

--- a/sglang_omni/models/mimo_audio/request_builders.py
+++ b/sglang_omni/models/mimo_audio/request_builders.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MiMo StagePayload adapters for tokenizer and SGLang thinker stages."""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+    Req,
+)
+from sglang.srt.sampling.sampling_params import SamplingParams
+
+from sglang_omni.models.mimo_audio.prompt import EMPTY, build_audio_understanding_prompt
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
+
+DEFAULT_ASR_INSTRUCTION = "Please transcribe this audio file"
+
+
+def audio_source_from_payload(payload: StagePayload) -> Any:
+    inputs = payload.request.inputs
+    if isinstance(inputs, dict):
+        for key in ("audio_bytes", "bytes", "file"):
+            if inputs.get(key) is not None:
+                return inputs[key]
+        for key in ("audio_path", "path", "url"):
+            if inputs.get(key) is not None:
+                return inputs[key]
+    if inputs is None:
+        raise ValueError("MiMo-Audio request is missing audio input")
+    return inputs
+
+
+def validate_text_only_request(payload: StagePayload) -> None:
+    modalities = payload.request.metadata.get("output_modalities", ["text"])
+    if isinstance(modalities, str):
+        modalities = [modalities]
+    normalized = {str(value).strip().lower() for value in modalities}
+    if "audio" in normalized or normalized - {"text"}:
+        raise ValueError(
+            "MiMo-Audio Milestone 1 supports text output only; audio output, "
+            "TTS, and waveform generation are not implemented"
+        )
+
+
+def instruction_from_payload(payload: StagePayload) -> str:
+    prompt = (payload.request.params or {}).get("prompt")
+    return str(prompt).strip() if prompt else DEFAULT_ASR_INSTRUCTION
+
+
+@dataclass
+class MiMoRequestData(SGLangARRequestData):
+    output_ids: list[int] | None = None
+    prompt_token_ids: list[int] | None = None
+    audio_duration_s: float = 0.0
+    language: str = "en"
+    engine_start_s: float = 0.0
+
+
+def make_mimo_scheduler_adapters(
+    *,
+    tokenizer: Any,
+    max_new_tokens: int,
+) -> tuple[
+    Callable[[StagePayload], MiMoRequestData],
+    Callable[[MiMoRequestData], StagePayload],
+]:
+    eos_id = int(tokenizer.eos_token_id)
+    im_end_id = int(tokenizer.convert_tokens_to_ids("<|im_end|>"))
+    empty_id = int(tokenizer.convert_tokens_to_ids(EMPTY))
+    vocab_size = int(getattr(tokenizer, "vocab_size", len(tokenizer)))
+
+    def request_builder(payload: StagePayload) -> MiMoRequestData:
+        validate_text_only_request(payload)
+        if not isinstance(payload.data, dict) or "audio_codes" not in payload.data:
+            raise ValueError("MiMo thinker requires preprocessed audio codes")
+        codes = torch.as_tensor(payload.data["audio_codes"], dtype=torch.long)
+        prompt = build_audio_understanding_prompt(
+            tokenizer,
+            codes,
+            instruction_from_payload(payload),
+            thinking=False,
+        )
+        input_ids = list(prompt.input_ids)
+        fingerprint = str(
+            payload.data.get(
+                "audio_fingerprint",
+                hashlib.sha256(codes.numpy().tobytes()).hexdigest(),
+            )
+        )
+        item = MultimodalDataItem(
+            modality=Modality.AUDIO,
+            hash=int(fingerprint[:16], 16),
+            feature=prompt.audio_codes,
+        )
+        item.set_pad_value()
+        for index in range(prompt.audio_start, prompt.audio_end):
+            input_ids[index] = item.pad_value
+        item.offsets = [(prompt.audio_start, prompt.audio_end - 1)]
+        mm_inputs = MultimodalInputs(
+            mm_items=[item],
+            num_image_tokens=prompt.audio_end - prompt.audio_start,
+        )
+        mm_inputs.audio_token_id = empty_id
+
+        params = payload.request.params or {}
+        temperature = float(params.get("temperature") or 0.0)
+        request_max_new_tokens = int(params.get("max_new_tokens") or max_new_tokens)
+        sampling = SamplingParams(
+            max_new_tokens=request_max_new_tokens,
+            temperature=temperature,
+            top_p=1.0,
+            stop_token_ids=[eos_id, im_end_id],
+            # `<|empty|>` selects official output-audio generation. Suppress it
+            # so Milestone 1 cannot enter a delayed-RVQ path.
+            logit_bias={str(empty_id): -1.0e9},
+        )
+        sampling.normalize(tokenizer=None)
+        req = Req(
+            rid=payload.request_id,
+            origin_input_text="",
+            origin_input_ids=input_ids,
+            sampling_params=sampling,
+            vocab_size=vocab_size,
+            extra_key=fingerprint,
+        )
+        req.multimodal_inputs = mm_inputs
+        req._codec_suppress_tokens = None
+        return MiMoRequestData(
+            input_ids=torch.tensor(input_ids, dtype=torch.long),
+            req=req,
+            prompt_token_ids=input_ids,
+            max_new_tokens=request_max_new_tokens,
+            temperature=temperature,
+            audio_duration_s=float(payload.data.get("audio_duration_s", 0.0)),
+            language=str(params.get("language") or "en"),
+            engine_start_s=time.perf_counter(),
+            stage_payload=payload,
+        )
+
+    def result_adapter(data: MiMoRequestData) -> StagePayload:
+        payload = data.stage_payload
+        output_ids = list(data.output_ids or [])
+        text = tokenizer.decode(
+            output_ids,
+            skip_special_tokens=False,
+            clean_up_tokenization_spaces=False,
+        )
+        for marker in (
+            "<|empty|>",
+            "<|eot|>",
+            "<|eostm|>",
+            "<|im_end|>",
+            "<|endoftext|>",
+        ):
+            text = text.replace(marker, "")
+        latency = (
+            time.perf_counter() - data.engine_start_s if data.engine_start_s else 0.0
+        )
+        return StagePayload(
+            request_id=payload.request_id,
+            request=payload.request,
+            data={
+                "text": text.strip(),
+                "language": data.language,
+                "duration_s": data.audio_duration_s,
+                "asr_latency_s": latency,
+                "usage": {"engine_time_s": latency},
+                "modality": "text",
+            },
+        )
+
+    return request_builder, result_adapter
+
+
+__all__ = [
+    "DEFAULT_ASR_INSTRUCTION",
+    "MiMoRequestData",
+    "audio_source_from_payload",
+    "instruction_from_payload",
+    "make_mimo_scheduler_adapters",
+    "validate_text_only_request",
+]

--- a/sglang_omni/models/mimo_audio/sglang_model.py
+++ b/sglang_omni/models/mimo_audio/sglang_model.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SGLang-native MiMo Qwen2 model for audio-input-to-text inference."""
+
+from __future__ import annotations
+
+import copy
+import logging
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+import torch
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.managers.mm_utils import (
+    MultiModalityDataPaddingPatternMultimodalTokens,
+    general_mm_embed_routine,
+)
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.qwen2 import Qwen2ForCausalLM
+from sglang.srt.utils import add_prefix
+from torch import nn
+from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
+from transformers.models.qwen2.modeling_qwen2 import Qwen2Model as HFQwen2Model
+
+from .prompt import AUDIO_CHANNELS, GROUP_SIZE, SPEECH_EMPTY_IDS
+
+logger = logging.getLogger(__name__)
+
+OUTPUT_ONLY_WEIGHT_PREFIXES = (
+    "local_transformer.",
+    "local_transformer_lm_heads.",
+    "hidden_states_downcast.",
+    "speech_embeddings_to_local.",
+)
+
+
+def parse_channel_values(
+    value: str | int | Sequence[int],
+    *,
+    channels: int = AUDIO_CHANNELS,
+) -> tuple[int, ...]:
+    if isinstance(value, str):
+        values = tuple(int(part) for part in value.split("-"))
+    elif isinstance(value, int):
+        values = (value,) * channels
+    else:
+        values = tuple(int(part) for part in value)
+    if len(values) != channels:
+        raise ValueError(f"expected {channels} channel values, got {len(values)}")
+    return values
+
+
+def is_output_only_weight(name: str) -> bool:
+    return name.startswith(OUTPUT_ONLY_WEIGHT_PREFIXES)
+
+
+def make_input_local_config(config: Qwen2Config) -> Qwen2Config:
+    local = copy.deepcopy(config)
+    local.hidden_size = int(getattr(config, "input_local_dim", 1024))
+    local.num_hidden_layers = int(getattr(config, "input_local_layers", 6))
+    local.num_attention_heads = int(getattr(config, "local_attn_heads", 64))
+    local.num_key_value_heads = local.num_attention_heads
+    local.head_dim = local.hidden_size // local.num_attention_heads
+    local.intermediate_size = local.hidden_size * 4
+    local.attention_dropout = float(getattr(config, "local_attn_dropout", 0.1))
+    local.vocab_size = 1
+    local.tie_word_embeddings = False
+    local.use_cache = False
+    local.layer_types = ["full_attention"] * local.num_hidden_layers
+    # Passing an explicit all-visible mask below is only unambiguously
+    # non-causal with eager attention across supported Transformers versions.
+    local._attn_implementation = "eager"
+    return local
+
+
+class MiMoInputPatchEncoder(nn.Module):
+    """Turn `[frames, 8]` RVQ codes into one global embedding per 4 frames."""
+
+    def __init__(self, config: Qwen2Config) -> None:
+        super().__init__()
+        self.group_size = int(getattr(config, "group_size", GROUP_SIZE))
+        self.audio_channels = int(getattr(config, "audio_channels", AUDIO_CHANNELS))
+        if self.group_size != GROUP_SIZE or self.audio_channels != AUDIO_CHANNELS:
+            raise ValueError(
+                "Milestone 1 supports MiMo group_size=4 and audio_channels=8, "
+                f"got {self.group_size} and {self.audio_channels}"
+            )
+
+        self.speech_vocab_sizes = parse_channel_values(
+            getattr(config, "speech_vocab_size", "1025-1025-129-129-129-129-129-129")
+        )
+        self.speech_empty_ids = parse_channel_values(
+            getattr(config, "speech_zeroemb_idx", SPEECH_EMPTY_IDS)
+        )
+        self.input_local_config = make_input_local_config(config)
+        self.input_local_transformer = HFQwen2Model(self.input_local_config)
+        # Official MiMo supplies `inputs_embeds`; this table has no checkpoint
+        # tensor and would waste memory.
+        self.input_local_transformer.embed_tokens = None
+        self.speech_embeddings = nn.ModuleList(
+            [
+                nn.Embedding(vocab_size, self.input_local_config.hidden_size)
+                for vocab_size in self.speech_vocab_sizes
+            ]
+        )
+        self.speech_group_downcast = nn.Linear(
+            self.input_local_config.hidden_size * self.group_size,
+            config.hidden_size,
+            bias=False,
+        )
+
+    def forward(self, audio_codes: torch.Tensor) -> torch.Tensor:
+        codes = torch.as_tensor(audio_codes, dtype=torch.long)
+        if codes.ndim != 2 or codes.shape[1] != self.audio_channels:
+            raise ValueError(
+                "MiMo audio codes must have shape "
+                f"[frames, {self.audio_channels}], got {tuple(codes.shape)}"
+            )
+        if codes.shape[0] == 0 or codes.shape[0] % self.group_size:
+            raise ValueError(
+                "MiMo audio-code frames must be non-empty and divisible by "
+                f"group_size={self.group_size}, got {codes.shape[0]}"
+            )
+        for channel, vocab_size in enumerate(self.speech_vocab_sizes):
+            if torch.any(codes[:, channel] < 0) or torch.any(
+                codes[:, channel] >= vocab_size
+            ):
+                raise ValueError(
+                    f"MiMo channel {channel} code is outside [0, {vocab_size})"
+                )
+
+        device = self.speech_embeddings[0].weight.device
+        codes = codes.to(device)
+        groups = codes.shape[0] // self.group_size
+        grouped = codes.reshape(groups, self.group_size, self.audio_channels)
+        speech_embeds = torch.zeros(
+            (groups, self.group_size, self.input_local_config.hidden_size),
+            device=device,
+            dtype=self.speech_embeddings[0].weight.dtype,
+        )
+        for channel, embedding in enumerate(self.speech_embeddings):
+            speech_embeds.add_(embedding(grouped[:, :, channel]))
+
+        # Each four-frame patch is a separate batch item. An explicit
+        # all-visible eager-attention mask reproduces official
+        # `input_full_attention=True`.
+        output = self.input_local_transformer(
+            inputs_embeds=speech_embeds,
+            attention_mask={"full_attention": None},
+            use_cache=False,
+            return_dict=True,
+        )
+        return self.speech_group_downcast(output.last_hidden_state.reshape(groups, -1))
+
+
+class MiMoAudioModel(nn.Module):
+    """MiMo global Qwen2 plus input-side patch encoder, with text-only output."""
+
+    default_bitsandbytes_target_modules = (
+        Qwen2ForCausalLM.default_bitsandbytes_target_modules
+    )
+    bitsandbytes_stacked_params_mapping = (
+        Qwen2ForCausalLM.bitsandbytes_stacked_params_mapping
+    )
+
+    def __init__(
+        self,
+        config: Qwen2Config,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.language_model = Qwen2ForCausalLM(
+            config,
+            quant_config=quant_config,
+            prefix=add_prefix("language_model", prefix),
+        )
+        self.input_patch_encoder = MiMoInputPatchEncoder(config)
+        self.pattern = MultiModalityDataPaddingPatternMultimodalTokens()
+        self.loaded_weight_names: set[str] = set()
+        self.skipped_output_weight_names: set[str] = set()
+        self.unexpected_weight_names: set[str] = set()
+
+    def pad_input_ids(
+        self, input_ids: list[int], mm_inputs: MultimodalInputs
+    ) -> list[int]:
+        return self.pattern.pad_input_tokens(input_ids, mm_inputs)
+
+    def get_audio_feature(self, items: list[MultimodalDataItem]) -> torch.Tensor:
+        return torch.cat(
+            [self.input_patch_encoder(item.feature) for item in items],
+            dim=0,
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        return general_mm_embed_routine(
+            input_ids=input_ids,
+            forward_batch=forward_batch,
+            language_model=self.language_model,
+            data_embedding_funcs={Modality.AUDIO: self.get_audio_feature},
+            positions=positions,
+        )
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        global_weights: list[tuple[str, torch.Tensor]] = []
+        custom_params = dict(
+            self.input_patch_encoder.named_parameters(remove_duplicate=False)
+        )
+        loaded_custom_params: set[str] = set()
+
+        for name, loaded_weight in weights:
+            if name.startswith(("model.", "lm_head.")):
+                global_weights.append((name, loaded_weight))
+                self.loaded_weight_names.add(name)
+                continue
+            if is_output_only_weight(name):
+                self.skipped_output_weight_names.add(name)
+                continue
+
+            custom_name = name
+            if custom_name.startswith("input_local_transformer."):
+                custom_name = "input_local_transformer." + custom_name.removeprefix(
+                    "input_local_transformer."
+                )
+            if custom_name not in custom_params:
+                self.unexpected_weight_names.add(name)
+                continue
+            param = custom_params[custom_name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded_custom_params.add(custom_name)
+            self.loaded_weight_names.add(name)
+
+        self.language_model.load_weights(global_weights)
+        missing_custom_params = set(custom_params) - loaded_custom_params
+        if missing_custom_params:
+            missing = ", ".join(sorted(missing_custom_params)[:10])
+            raise ValueError(f"Missing required MiMo input weights: {missing}")
+        if self.unexpected_weight_names:
+            unexpected = ", ".join(sorted(self.unexpected_weight_names)[:10])
+            raise ValueError(f"Unexpected MiMo checkpoint weights: {unexpected}")
+        logger.info(
+            "MiMo Milestone 1 loaded %d tensors and intentionally skipped "
+            "%d output-only tensors",
+            len(self.loaded_weight_names),
+            len(self.skipped_output_weight_names),
+        )
+        return self.loaded_weight_names
+
+
+EntryClass = MiMoAudioModel
+
+__all__ = [
+    "OUTPUT_ONLY_WEIGHT_PREFIXES",
+    "EntryClass",
+    "MiMoAudioModel",
+    "MiMoInputPatchEncoder",
+    "is_output_only_weight",
+    "make_input_local_config",
+    "parse_channel_values",
+]

--- a/sglang_omni/models/mimo_audio/stages.py
+++ b/sglang_omni/models/mimo_audio/stages.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stage factories for MiMo-Audio input-to-text inference."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import torch
+from huggingface_hub import snapshot_download
+from sglang.srt.managers.mm_utils import init_mm_embedding_cache
+
+from sglang_omni.models.mimo_audio.audio_tokenizer import MiMoAudioTokenizerEncoder
+from sglang_omni.models.mimo_audio.preprocessor import (
+    MiMoAudioPreprocessor,
+    MiMoAudioTokenizerSettings,
+)
+from sglang_omni.models.mimo_audio.request_builders import (
+    audio_source_from_payload,
+    make_mimo_scheduler_adapters,
+    validate_text_only_request,
+)
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+
+
+def _torch_dtype(value: str) -> torch.dtype:
+    normalized = value.strip().lower()
+    if normalized in {"bf16", "bfloat16"}:
+        return torch.bfloat16
+    if normalized in {"fp16", "float16", "half"}:
+        return torch.float16
+    if normalized in {"fp32", "float32"}:
+        return torch.float32
+    raise ValueError(f"Unsupported MiMo dtype {value!r}")
+
+
+def create_audio_tokenizer_executor(
+    model_path: str,
+    *,
+    tokenizer_path: str,
+    device: str = "cuda:0",
+    dtype: str = "bfloat16",
+) -> SimpleScheduler:
+    del model_path
+    snapshot = snapshot_download(
+        tokenizer_path,
+        allow_patterns=["config.json", "model.safetensors"],
+    )
+    encoder = MiMoAudioTokenizerEncoder.from_checkpoint(
+        snapshot,
+        device=device,
+        dtype=_torch_dtype(dtype),
+    )
+    preprocessor = MiMoAudioPreprocessor(
+        MiMoAudioTokenizerSettings.from_config(encoder.config),
+        device=device,
+    )
+
+    def _encode(payload: StagePayload) -> StagePayload:
+        validate_text_only_request(payload)
+        waveform = preprocessor.load_waveform(audio_source_from_payload(payload))
+        duration_s = waveform.numel() / preprocessor.settings.sampling_rate
+        log_mel = preprocessor.waveform_to_log_mel(waveform)
+        codes = preprocessor.encode_log_mel(log_mel, encoder)
+        payload.data = {
+            "audio_codes": codes,
+            "audio_duration_s": float(duration_s),
+            "audio_fingerprint": hashlib.sha256(
+                waveform.detach().cpu().numpy().tobytes()
+            ).hexdigest(),
+            "mel_shape": tuple(log_mel.shape),
+            "code_shape": tuple(codes.shape),
+            "modality": "audio_codes",
+        }
+        return payload
+
+    return SimpleScheduler(_encode)
+
+
+def create_thinker_executor(
+    model_path: str,
+    *,
+    device: str = "cuda:0",
+    dtype: str = "bfloat16",
+    max_running_requests: int = 1,
+    max_new_tokens: int = 256,
+    mem_fraction_static: float = 0.80,
+    mm_embedding_cache_size_bytes: int = 0,
+    server_args_overrides: dict[str, Any] | None = None,
+):
+    from transformers import AutoTokenizer
+
+    from sglang_omni.model_runner.base import ModelRunner
+    from sglang_omni.scheduling.bootstrap import (
+        create_sglang_infrastructure_defer_cuda_graph,
+    )
+    from sglang_omni.scheduling.generation_batch_policy import (
+        build_generation_batch_overrides,
+        validate_generation_batch_policy,
+    )
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+    from sglang_omni.scheduling.sglang_backend import (
+        SGLangOutputProcessor,
+        build_sglang_server_args,
+    )
+
+    gpu_id = int(device.split(":")[-1]) if ":" in device else 0
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=False)
+    overrides = build_generation_batch_overrides(
+        max_running_requests=max_running_requests,
+        server_args_overrides=server_args_overrides,
+        disable_cuda_graph=True,
+        disable_overlap_schedule=True,
+        mem_fraction_static=mem_fraction_static,
+        max_prefill_tokens=8192,
+        chunked_prefill_size=8192,
+        sampling_backend="pytorch",
+        dtype=dtype,
+    )
+    server_args = build_sglang_server_args(
+        model_path,
+        context_length=8192,
+        **overrides,
+    )
+    validate_generation_batch_policy(model_name="MiMo-Audio", server_args=server_args)
+    (
+        _,
+        (
+            model_worker,
+            tree_cache,
+            req_to_token_pool,
+            token_to_kv_pool_allocator,
+            prefill_mgr,
+            decode_mgr,
+            model_config,
+        ),
+    ) = create_sglang_infrastructure_defer_cuda_graph(
+        server_args,
+        gpu_id,
+        model_arch_override="MiMoAudioModel",
+    )
+    init_mm_embedding_cache(mm_embedding_cache_size_bytes)
+    output_processor = SGLangOutputProcessor(
+        capture_hidden=False,
+        capture_hidden_layers=None,
+        model=model_worker.model_runner.model,
+    )
+    request_builder, result_adapter = make_mimo_scheduler_adapters(
+        tokenizer=tokenizer,
+        max_new_tokens=max_new_tokens,
+    )
+    return OmniScheduler(
+        tp_worker=model_worker,
+        tree_cache=tree_cache,
+        req_to_token_pool=req_to_token_pool,
+        token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+        server_args=server_args,
+        model_config=model_config,
+        prefill_manager=prefill_mgr,
+        decode_manager=decode_mgr,
+        model_runner=ModelRunner(model_worker, output_processor),
+        request_builder=request_builder,
+        result_adapter=result_adapter,
+    )
+
+
+__all__ = ["create_audio_tokenizer_executor", "create_thinker_executor"]

--- a/tests/test_model/test_mimo_audio_e2e.py
+++ b/tests/test_model/test_mimo_audio_e2e.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in A100 MiMo-Audio real-file transcription validation."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import requests
+
+from tests.test_model.omni_router_utils import launch_managed_router
+
+MIMO_MODEL_ENV = "SGLANG_OMNI_TEST_MIMO_MODEL"
+MIMO_AUDIO_ENV = "SGLANG_OMNI_TEST_MIMO_AUDIO"
+MIMO_EXPECT_ENV = "SGLANG_OMNI_TEST_MIMO_EXPECT"
+DEFAULT_AUDIO = Path("/workspace/references/MiMo-Audio/examples/北京.mp3")
+
+
+def _required_path(
+    env_name: str,
+    default: Path | None = None,
+    *,
+    file_only: bool = False,
+) -> Path:
+    raw = os.environ.get(env_name)
+    path = Path(raw) if raw else default
+    valid = path is not None and (path.is_file() if file_only else path.exists())
+    if not valid:
+        kind = "file" if file_only else "path"
+        pytest.skip(f"set {env_name} to an existing local {kind}")
+    return path
+
+
+@pytest.mark.benchmark
+def test_mimo_audio_real_file_to_meaningful_text(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """Exercise real audio through `/v1/audio/transcriptions` on one GPU."""
+
+    if not os.environ.get(MIMO_MODEL_ENV):
+        pytest.skip(f"set {MIMO_MODEL_ENV} after approving the MiMo checkpoint")
+    model_path = _required_path(MIMO_MODEL_ENV)
+    audio_path = _required_path(MIMO_AUDIO_ENV, DEFAULT_AUDIO, file_only=True)
+
+    with (
+        launch_managed_router(
+            tmp_path_factory=tmp_path_factory,
+            model_path=str(model_path),
+            model_name="mimo-audio",
+            worker_extra_args="",
+            num_workers=1,
+            num_gpus_per_worker=1,
+            wait_timeout=900,
+            log_prefix="mimo_audio_e2e_logs",
+        ) as router,
+        audio_path.open("rb") as audio,
+    ):
+        response = requests.post(
+            f"http://127.0.0.1:{router.port}/v1/audio/transcriptions",
+            data={
+                "model": "mimo-audio",
+                "language": "zh",
+                "temperature": "0",
+                "max_new_tokens": "128",
+            },
+            files={"file": (audio_path.name, audio, "audio/mpeg")},
+            timeout=300,
+        )
+
+    assert response.status_code == 200, response.text
+    text = response.json()["text"].strip()
+    assert len(text) >= 2
+    assert "<|empty|>" not in text
+    assert "<|sostm|>" not in text
+    expected = os.environ.get(MIMO_EXPECT_ENV)
+    if expected:
+        assert expected.casefold() in text.casefold()

--- a/tests/unit_test/mimo_audio/test_audio_tokenizer.py
+++ b/tests/unit_test/mimo_audio/test_audio_tokenizer.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+
+from sglang_omni.models.mimo_audio.audio_tokenizer import MiMoAudioTokenizerEncoder
+
+
+def _tiny_config() -> dict:
+    return {
+        "d_model": 16,
+        "encoder_attention_heads": 4,
+        "encoder_skip_layer_id": 1,
+        "stride_size": 2,
+        "avg_pooler": 2,
+        "n_mels": 8,
+        "kernel_size": 3,
+        "rope_theta": 10_000,
+        "encoder_attn_window_size": [-1, -1],
+        "encoder_causal": False,
+        "encoder_ffn_dim": 32,
+        "encoder_layers": 1,
+        "codebook_size": [8, 8, 4, 4, 4, 4, 4, 4],
+    }
+
+
+def test_input_only_tokenizer_has_no_decoder_or_vocoder() -> None:
+    encoder = MiMoAudioTokenizerEncoder(_tiny_config())
+
+    assert not hasattr(encoder, "decoder")
+    assert not hasattr(encoder, "vocoder")
+    assert all(
+        forbidden not in name
+        for name, _ in encoder.named_modules()
+        for forbidden in ("decoder", "vocoder", "istft")
+    )
+
+
+def test_input_only_tokenizer_rejects_non_codes_mode() -> None:
+    encoder = MiMoAudioTokenizerEncoder(_tiny_config())
+
+    try:
+        encoder.encode(
+            input_features=torch.zeros((10, 8)),
+            input_lens=torch.tensor([10]),
+            return_codes_only=False,
+        )
+    except ValueError as exc:
+        assert "codes-only" in str(exc)
+    else:
+        raise AssertionError("non-codes tokenizer mode was accepted")

--- a/tests/unit_test/mimo_audio/test_config.py
+++ b/tests/unit_test/mimo_audio/test_config.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+from sglang_omni.config.manager import resolve_config_cls_for_model_path
+from sglang_omni.config.placement import StagePlacementPlanner
+from sglang_omni.config.topology import build_process_topology_plan
+from sglang_omni.models.mimo_audio.config import (
+    MIMO_AUDIO_TOKENIZER_PATH,
+    MiMoAudioPipelineConfig,
+)
+from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+
+
+def test_mimo_audio_pipeline_is_registered() -> None:
+    assert (
+        PIPELINE_CONFIG_REGISTRY.get_config("MiMoAudioModel") is MiMoAudioPipelineConfig
+    )
+
+
+def test_mimo_audio_pipeline_is_text_output_only() -> None:
+    config = MiMoAudioPipelineConfig(model_path="XiaomiMiMo/MiMo-Audio-7B-Instruct")
+
+    assert config.entry_stage == "audio_tokenizer"
+    assert [stage.name for stage in config.stages] == [
+        "audio_tokenizer",
+        "thinker",
+    ]
+    assert config.terminal_stages == ["thinker"]
+    assert config.gpu_placement == {"audio_tokenizer": 0, "thinker": 0}
+    assert config.stages[0].next == "thinker"
+    assert config.stages[0].factory_args["tokenizer_path"] == (
+        MIMO_AUDIO_TOKENIZER_PATH
+    )
+    fractions = {
+        stage.name: stage.runtime.resources.total_gpu_memory_fraction
+        for stage in config.stages
+    }
+    assert fractions == {"audio_tokenizer": 0.08, "thinker": 0.92}
+    placement = StagePlacementPlanner(config).build()
+    topology = build_process_topology_plan(config, placement)
+    assert topology.stage_to_process == {
+        "audio_tokenizer": "audio_tokenizer",
+        "thinker": "thinker",
+    }
+    assert all(
+        forbidden not in stage.name
+        for stage in config.stages
+        for forbidden in ("decoder", "vocoder", "code2wav", "patch_decoder")
+    )
+
+
+def test_checkpoint_architecture_resolves_to_mimo_pipeline(tmp_path) -> None:
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["MiMoAudioModel"],
+                "model_type": "qwen2",
+                "hidden_size": 4096,
+                "num_hidden_layers": 36,
+                "num_attention_heads": 32,
+                "num_key_value_heads": 8,
+                "vocab_size": 151680,
+            }
+        )
+    )
+
+    assert resolve_config_cls_for_model_path(str(tmp_path)) is MiMoAudioPipelineConfig

--- a/tests/unit_test/mimo_audio/test_preprocessor.py
+++ b/tests/unit_test/mimo_audio/test_preprocessor.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+import torchaudio
+
+from sglang_omni.models.mimo_audio.preprocessor import (
+    MiMoAudioPreprocessor,
+    MiMoAudioTokenizerSettings,
+)
+
+
+class _FakeEncoder:
+    def __init__(self, frames: int):
+        self.frames = frames
+        self.features_shape: tuple[int, ...] | None = None
+        self.lengths: torch.Tensor | None = None
+
+    def encode(
+        self,
+        *,
+        input_features: torch.Tensor,
+        input_lens: torch.Tensor,
+        return_codes_only: bool,
+    ):
+        self.features_shape = tuple(input_features.shape)
+        self.lengths = input_lens.detach().cpu()
+        assert return_codes_only is True
+        codes = torch.arange(20 * self.frames, device=input_features.device).reshape(
+            20, self.frames
+        )
+        return codes, torch.tensor([self.frames], device=input_features.device)
+
+
+def test_tokenizer_settings_match_official_checkpoint() -> None:
+    settings = MiMoAudioTokenizerSettings.from_config(
+        {
+            "sampling_rate": 24_000,
+            "nfft": 960,
+            "hop_length": 240,
+            "window_size": 960,
+            "n_mels": 128,
+            "fmin": 0,
+            "fmax": None,
+        }
+    )
+
+    assert settings == MiMoAudioTokenizerSettings()
+
+
+def test_log_mel_is_exact_official_torchaudio_contract() -> None:
+    settings = MiMoAudioTokenizerSettings()
+    preprocessor = MiMoAudioPreprocessor(settings)
+    waveform = torch.linspace(-0.5, 0.5, 24_000)
+
+    actual = preprocessor.waveform_to_log_mel(waveform)
+    official_transform = torchaudio.transforms.MelSpectrogram(
+        sample_rate=24_000,
+        n_fft=960,
+        hop_length=240,
+        win_length=960,
+        f_min=0,
+        f_max=None,
+        n_mels=128,
+        power=1.0,
+        center=True,
+    )
+    expected = (
+        torch.log(torch.clip(official_transform(waveform[None, :]), min=1.0e-7))
+        .squeeze()
+        .transpose(0, 1)
+    )
+
+    assert actual.shape == (101, 128)
+    assert actual.dtype == torch.float32
+    assert torch.equal(actual, expected)
+
+
+def test_encode_uses_first_eight_channels_and_pads_last_frame() -> None:
+    preprocessor = MiMoAudioPreprocessor()
+    log_mel = torch.zeros((6010, 128), dtype=torch.float32)
+    encoder = _FakeEncoder(frames=5)
+
+    codes = preprocessor.encode_log_mel(log_mel, encoder)
+
+    assert encoder.features_shape == (6010, 128)
+    assert encoder.lengths.tolist() == [6000, 10]
+    assert codes.shape == (8, 8)
+    assert torch.equal(codes[:5], torch.arange(20 * 5).reshape(20, 5)[:8].T)
+    assert torch.equal(codes[5:], codes[4:5].expand(3, -1))
+
+
+def test_real_official_audio_fixture_loads_and_produces_log_mel() -> None:
+    path = (
+        "/workspace/references/MiMo-Audio/examples/spoken_dialogue_assistant_turn_1.wav"
+    )
+    preprocessor = MiMoAudioPreprocessor()
+
+    waveform = preprocessor.load_waveform(path)
+    log_mel = preprocessor.waveform_to_log_mel(waveform)
+
+    assert waveform.ndim == 1
+    assert waveform.dtype == torch.float32
+    assert waveform.numel() > 0
+    assert log_mel.ndim == 2
+    assert log_mel.shape[0] > 0
+    assert log_mel.shape[1] == 128
+    assert torch.isfinite(log_mel).all()

--- a/tests/unit_test/mimo_audio/test_prompt.py
+++ b/tests/unit_test/mimo_audio/test_prompt.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+import torch
+from huggingface_hub.constants import HF_HUB_CACHE
+
+from sglang_omni.models.mimo_audio.prompt import (
+    SPEECH_EMPTY_IDS,
+    build_audio_understanding_prompt,
+    pad_audio_codes,
+)
+
+
+class _Encoding:
+    def __init__(self, ids: list[int]):
+        self.ids = ids
+
+
+class _CharacterTokenizer:
+    special: ClassVar[dict[str, int]] = {
+        "<|im_start|>": 151644,
+        "<|im_end|>": 151645,
+        "<|sosp|>": 151665,
+        "<|eosp|>": 151666,
+        "<|empty|>": 151667,
+    }
+
+    def convert_tokens_to_ids(self, token: str) -> int | None:
+        return self.special.get(token)
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> _Encoding:
+        del add_special_tokens
+        ids: list[int] = []
+        cursor = 0
+        tokens = sorted(self.special, key=len, reverse=True)
+        while cursor < len(text):
+            special = next(
+                (token for token in tokens if text.startswith(token, cursor)), None
+            )
+            if special is not None:
+                ids.append(self.special[special])
+                cursor += len(special)
+            else:
+                ids.append(1000 + ord(text[cursor]))
+                cursor += 1
+        return _Encoding(ids)
+
+
+def test_audio_understanding_prompt_has_official_channel_contract() -> None:
+    tokenizer = _CharacterTokenizer()
+    codes = torch.arange(5 * 8, dtype=torch.int64).reshape(5, 8)
+    prompt = build_audio_understanding_prompt(
+        tokenizer,
+        codes,
+        "Summarize the audio.",
+    )
+
+    assert prompt.official_input_ids.shape[0] == 9
+    assert prompt.audio_codes.shape == (8, 8)
+    assert torch.equal(prompt.audio_codes[5:], prompt.audio_codes[4:5].expand(3, -1))
+    assert prompt.audio_end - prompt.audio_start == 2
+    assert prompt.input_ids[prompt.audio_start : prompt.audio_end] == [151667, 151667]
+    assert torch.equal(
+        prompt.official_input_ids[1:, :4],
+        torch.tensor(SPEECH_EMPTY_IDS)[:, None].expand(-1, 4),
+    )
+
+
+def test_frozen_official_tokenizer_prompt_parity() -> None:
+    tokenizers = pytest.importorskip("tokenizers")
+    tokenizer_json = (
+        Path(HF_HUB_CACHE)
+        / "models--XiaomiMiMo--MiMo-Audio-7B-Instruct"
+        / "snapshots"
+        / "c359441c22c2a1c74be5f99a91e83392680e9cc8"
+        / "tokenizer.json"
+    )
+    try:
+        tokenizer = tokenizers.Tokenizer.from_file(str(tokenizer_json))
+    except (OSError, ValueError) as exc:
+        pytest.skip(f"fixed MiMo tokenizer metadata is unavailable: {exc}")
+
+    codes = torch.arange(8 * 8, dtype=torch.int64).reshape(8, 8)
+    prompt = build_audio_understanding_prompt(
+        tokenizer,
+        codes,
+        "Summarize the audio.",
+    )
+    digest = hashlib.sha256(
+        prompt.official_input_ids.numpy().tobytes(order="C")
+    ).hexdigest()
+
+    # Frozen from Xiaomi's InputSegment.to_input_id contract at official
+    # MiMo-Audio commit 691ce54144a6844cc641fd96046a6ba20776c8b0.
+    assert digest == "6679ff48431a953d3f858bc7916135885cf62f27309af5976cc61dd503ce8a7c"
+
+
+def test_prompt_rejects_missing_instruction() -> None:
+    with pytest.raises(ValueError, match="instruction"):
+        build_audio_understanding_prompt(
+            _CharacterTokenizer(),
+            torch.zeros((4, 8), dtype=torch.int64),
+            "",
+        )
+
+
+def test_pad_audio_codes_rejects_empty_input() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        pad_audio_codes(torch.empty((0, 8), dtype=torch.int64))

--- a/tests/unit_test/mimo_audio/test_request_builders.py
+++ b/tests/unit_test/mimo_audio/test_request_builders.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import torch
+
+from sglang_omni.models.mimo_audio.request_builders import (
+    audio_source_from_payload,
+    make_mimo_scheduler_adapters,
+    validate_text_only_request,
+)
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+class _Encoding:
+    def __init__(self, ids: list[int]):
+        self.ids = ids
+
+
+class _Tokenizer:
+    eos_token_id = 151643
+    vocab_size = 151680
+    special: ClassVar[dict[str, int]] = {
+        "<|im_start|>": 151644,
+        "<|im_end|>": 151645,
+        "<|sosp|>": 151665,
+        "<|eosp|>": 151666,
+        "<|empty|>": 151667,
+    }
+
+    def __len__(self):
+        return self.vocab_size
+
+    def convert_tokens_to_ids(self, token: str):
+        return self.special.get(token, 0)
+
+    def encode(self, text: str, add_special_tokens: bool = False):
+        del add_special_tokens
+        ids = []
+        for token, token_id in self.special.items():
+            text = text.replace(token, chr(token_id))
+        for char in text:
+            ids.append(ord(char))
+        return _Encoding(ids)
+
+    def decode(self, ids, **kwargs):
+        del kwargs
+        return "transcript<|im_end|>"
+
+
+def _payload(modalities=None) -> StagePayload:
+    return StagePayload(
+        request_id="mimo-test",
+        request=OmniRequest(
+            inputs={"audio_bytes": b"RIFF"},
+            params={"prompt": "Summarize the audio."},
+            metadata={"output_modalities": modalities or ["text"]},
+        ),
+        data={
+            "audio_codes": torch.zeros((8, 8), dtype=torch.long),
+            "audio_duration_s": 1.0,
+            "audio_fingerprint": "0" * 64,
+        },
+    )
+
+
+def test_request_builder_routes_codes_as_audio_embeddings_and_suppresses_audio() -> (
+    None
+):
+    tokenizer = _Tokenizer()
+    build, _ = make_mimo_scheduler_adapters(
+        tokenizer=tokenizer,
+        max_new_tokens=64,
+    )
+
+    data = build(_payload())
+
+    assert data.input_ids.ndim == 1
+    assert len(data.req.multimodal_inputs.mm_items) == 1
+    item = data.req.multimodal_inputs.mm_items[0]
+    assert item.feature.shape == (8, 8)
+    assert item.offsets[0][1] - item.offsets[0][0] + 1 == 2
+    assert data.req.sampling_params.logit_bias[str(151667)] < -1.0e8
+    assert set(data.req.sampling_params.stop_token_ids) == {151643, 151645}
+
+
+def test_audio_output_mode_is_rejected() -> None:
+    payload = _payload(["text", "audio"])
+    try:
+        validate_text_only_request(payload)
+    except ValueError as exc:
+        assert "text output only" in str(exc)
+    else:
+        raise AssertionError("MiMo audio output request was accepted")
+
+
+def test_missing_preprocessed_audio_is_rejected() -> None:
+    build, _ = make_mimo_scheduler_adapters(
+        tokenizer=_Tokenizer(),
+        max_new_tokens=64,
+    )
+    payload = _payload()
+    payload.data = None
+
+    try:
+        build(payload)
+    except ValueError as exc:
+        assert "preprocessed audio codes" in str(exc)
+    else:
+        raise AssertionError("missing MiMo codes were accepted")
+
+
+def test_missing_raw_audio_input_is_rejected() -> None:
+    payload = _payload()
+    payload.request.inputs = None
+
+    try:
+        audio_source_from_payload(payload)
+    except ValueError as exc:
+        assert "missing audio input" in str(exc)
+    else:
+        raise AssertionError("missing MiMo raw audio input was accepted")
+
+
+def test_result_adapter_strips_mimo_markers() -> None:
+    build, adapt = make_mimo_scheduler_adapters(
+        tokenizer=_Tokenizer(),
+        max_new_tokens=64,
+    )
+    data = build(_payload())
+    data.output_ids = [1, 2, 3]
+
+    result = adapt(data)
+
+    assert result.data["text"] == "transcript"
+    assert result.data["modality"] == "text"

--- a/tests/unit_test/mimo_audio/test_sglang_model.py
+++ b/tests/unit_test/mimo_audio/test_sglang_model.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
+
+from sglang_omni.models.mimo_audio.sglang_model import (
+    MiMoAudioModel,
+    MiMoInputPatchEncoder,
+    is_output_only_weight,
+    make_input_local_config,
+    parse_channel_values,
+)
+
+
+def _tiny_config() -> Qwen2Config:
+    config = Qwen2Config(
+        vocab_size=128,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        max_position_embeddings=64,
+        attention_dropout=0.0,
+    )
+    config.group_size = 4
+    config.audio_channels = 8
+    config.input_local_dim = 16
+    config.input_local_layers = 1
+    config.local_attn_heads = 4
+    config.local_attn_dropout = 0.0
+    config.speech_vocab_size = "17-17-9-9-9-9-9-9"
+    config.speech_zeroemb_idx = "16-16-8-8-8-8-8-8"
+    config.input_full_attention = True
+    return config
+
+
+def test_channel_config_parsing_is_exact() -> None:
+    assert parse_channel_values("1024-1024-128-128-128-128-128-128") == (
+        1024,
+        1024,
+        128,
+        128,
+        128,
+        128,
+        128,
+        128,
+    )
+
+
+def test_input_local_config_matches_checkpoint_contract() -> None:
+    local = make_input_local_config(_tiny_config())
+
+    assert local.hidden_size == 16
+    assert local.num_hidden_layers == 1
+    assert local.num_attention_heads == 4
+    assert local.num_key_value_heads == 4
+    assert local.head_dim == 4
+    assert local.intermediate_size == 64
+    assert local._attn_implementation == "eager"
+
+
+def test_patch_encoder_shape_dtype_and_full_attention() -> None:
+    torch.manual_seed(0)
+    encoder = MiMoInputPatchEncoder(_tiny_config()).eval()
+    codes = torch.zeros((8, 8), dtype=torch.long)
+    first = encoder(codes)
+
+    changed = codes.clone()
+    changed[3, 0] = 1
+    second = encoder(changed)
+
+    assert first.shape == (2, 32)
+    assert first.dtype == encoder.speech_embeddings[0].weight.dtype
+    # Frame 3 is in the future relative to frame 0. Under official full
+    # attention it can affect the entire first patch representation.
+    assert not torch.equal(first[0], second[0])
+    # It cannot affect the independently batched second patch.
+    assert torch.equal(first[1], second[1])
+
+
+def test_patch_encoder_rejects_out_of_range_codes() -> None:
+    encoder = MiMoInputPatchEncoder(_tiny_config())
+    codes = torch.zeros((4, 8), dtype=torch.long)
+    codes[0, 2] = 9
+
+    try:
+        encoder(codes)
+    except ValueError as exc:
+        assert "channel 2" in str(exc)
+    else:
+        raise AssertionError("out-of-range MiMo code was accepted")
+
+
+def test_audio_output_weights_are_explicitly_classified() -> None:
+    assert is_output_only_weight("local_transformer.layers.0.self_attn.q_proj.weight")
+    assert is_output_only_weight("local_transformer_lm_heads.0.weight")
+    assert is_output_only_weight("hidden_states_downcast.weight")
+    assert not is_output_only_weight("input_local_transformer.layers.0.norm.weight")
+    assert not is_output_only_weight("speech_group_downcast.weight")
+
+
+class _FakeLanguageModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.loaded: list[str] = []
+
+    def load_weights(self, weights) -> None:
+        self.loaded = [name for name, _ in weights]
+
+
+def _loader_fixture() -> MiMoAudioModel:
+    model = MiMoAudioModel.__new__(MiMoAudioModel)
+    nn.Module.__init__(model)
+    model.language_model = _FakeLanguageModel()
+    model.input_patch_encoder = nn.Module()
+    model.input_patch_encoder.input_local_transformer = nn.Linear(2, 2, bias=False)
+    model.input_patch_encoder.speech_embeddings = nn.ModuleList([nn.Embedding(2, 2)])
+    model.input_patch_encoder.speech_group_downcast = nn.Linear(2, 2, bias=False)
+    model.loaded_weight_names = set()
+    model.skipped_output_weight_names = set()
+    model.unexpected_weight_names = set()
+    return model
+
+
+def test_weight_mapping_loads_all_input_weights_and_skips_output_weights() -> None:
+    model = _loader_fixture()
+    weights = [
+        ("model.embed_tokens.weight", torch.zeros(2, 2)),
+        ("lm_head.weight", torch.zeros(2, 2)),
+        ("input_local_transformer.weight", torch.ones(2, 2)),
+        ("speech_embeddings.0.weight", torch.ones(2, 2)),
+        ("speech_group_downcast.weight", torch.ones(2, 2)),
+        ("local_transformer.layers.0.weight", torch.ones(2, 2)),
+    ]
+
+    loaded = model.load_weights(weights)
+
+    assert model.language_model.loaded == [
+        "model.embed_tokens.weight",
+        "lm_head.weight",
+    ]
+    assert model.skipped_output_weight_names == {"local_transformer.layers.0.weight"}
+    assert {
+        "input_local_transformer.weight",
+        "speech_embeddings.0.weight",
+        "speech_group_downcast.weight",
+    } <= loaded
+
+
+def test_weight_mapping_rejects_missing_required_input_weight() -> None:
+    model = _loader_fixture()
+    weights = [
+        ("model.embed_tokens.weight", torch.zeros(2, 2)),
+        ("input_local_transformer.weight", torch.ones(2, 2)),
+        ("speech_embeddings.0.weight", torch.ones(2, 2)),
+    ]
+
+    try:
+        model.load_weights(weights)
+    except ValueError as exc:
+        assert "Missing required MiMo input weights" in str(exc)
+        assert "speech_group_downcast.weight" in str(exc)
+    else:
+        raise AssertionError("incomplete MiMo input checkpoint was accepted")
+
+
+def test_weight_mapping_rejects_unexpected_input_weight() -> None:
+    model = _loader_fixture()
+    weights = [
+        ("model.embed_tokens.weight", torch.zeros(2, 2)),
+        ("input_local_transformer.weight", torch.ones(2, 2)),
+        ("speech_embeddings.0.weight", torch.ones(2, 2)),
+        ("speech_group_downcast.weight", torch.ones(2, 2)),
+        ("unknown_input_module.weight", torch.ones(2, 2)),
+    ]
+
+    try:
+        model.load_weights(weights)
+    except ValueError as exc:
+        assert "Unexpected MiMo checkpoint weights" in str(exc)
+        assert "unknown_input_module.weight" in str(exc)
+    else:
+        raise AssertionError("unexpected MiMo input weight was accepted")

--- a/tests/unit_test/mimo_audio/test_stages.py
+++ b/tests/unit_test/mimo_audio/test_stages.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import inspect
+
+from sglang_omni.models.mimo_audio.stages import create_thinker_executor
+
+
+def test_mimo_thinker_initializes_a_zero_sized_multimodal_cache_by_default() -> None:
+    signature = inspect.signature(create_thinker_executor)
+
+    assert signature.parameters["mm_embedding_cache_size_bytes"].default == 0


### PR DESCRIPTION
## Summary

Adds Milestone 1 support for `XiaomiMiMo/MiMo-Audio-7B-Instruct`:

```text
real audio
  -> native MiMo preprocessing and input-only audio tokenizer
  -> MiMo input-local patch encoder
  -> SGLang Qwen2 autoregressive inference
  -> text
```

The first and only interface in this PR is
`POST /v1/audio/transcriptions`.

Closes #249.

## Design

### Pipeline topology

The model registers `MiMoAudioModel` and resolves it to a two-stage
`MiMoAudioPipelineConfig` on one GPU:

```mermaid
flowchart TB
    Audio["Real audio waveform"] --> Gate["Text-only request validation"]

    subgraph GPU["GPU 0 — shared stage placement"]
        direction TB

        subgraph Tokenizer["audio_tokenizer — resource fraction 0.08"]
            direction TB
            Resample["Normalize to 24 kHz"] --> Mel["128-bin log-mel"]
            Mel --> Encoder["Input-only encoder + quantizer"]
            Encoder --> Codes["First 8 RVQ code channels<br/>int64 [frames, 8]"]
        end

        subgraph Thinker["thinker — resource fraction 0.92"]
            direction TB
            Pad["Pad frames to multiple of 4"] --> Prompt["Nine-channel prompt<br/>1 text + 8 audio"]
            Prompt --> Group["Each 4-frame group<br/>→ 1 MM placeholder"]
            Group --> Local["Input-local Qwen2 patch encoder<br/>+ 8 speech embedding tables"]
            Local --> Downcast["Group-downcast projection<br/>→ 1 [hidden_size] embedding"]
            Downcast --> Inject["Inject embeddings during prefill"]
            Inject --> Global["SGLang Qwen2ForCausalLM<br/>global language model"]
            Global --> Decode["Text decoding"]
        end
    end

    Gate --> Resample
    Codes --> Pad
    Decode --> Text["Transcription text"]

    Special["Official special-token layout<br/>sosp / empty / eosp"] -.-> Prompt
    Bias["Bias empty token away from<br/>audio-generation mode"] -.-> Decode

    Checkpoint["MiMo checkpoint"] --> Loader["Strict checkpoint loader"]
    Loader -->|"517 required tensors"| Local
    Loader -->|"Global Qwen2 + LM head"| Global
    Loader -.->|"Skip 202 output-only tensors"| Deferred["Not instantiated:<br/>output-local transformer<br/>patch decoder / delayed RVQ<br/>tokenizer decoder / vocoder"]

    AudioMode["Audio output requested"] --> Reject["Reject with text-only error"]
```

1. `audio_tokenizer`
   - loads only the encoder/quantizer side of
     `XiaomiMiMo/MiMo-Audio-Tokenizer`;
   - normalizes a real waveform to 24 kHz;
   - reproduces the official 128-bin log-mel contract;
   - emits the first eight RVQ code channels;
   - does not instantiate the tokenizer decoder or a vocoder.
2. `thinker`
   - reuses SGLang's native `Qwen2ForCausalLM` for the global language model;
   - adds MiMo's input-local Qwen2 patch encoder, eight speech-code embedding
     tables, and the group-downcast projection;
   - groups every four audio-code frames into one global LM embedding;
   - performs ordinary SGLang prefill and text decoding.

The stages use explicit shared-GPU resource fractions (`0.08` tokenizer,
`0.92` thinker). CUDA graphs and overlap scheduling are disabled for the
MiMo thinker in this initial correctness-focused implementation.

### Prompt and embedding contract

The model-local prompt builder reproduces Xiaomi's nine-channel input layout:
one text channel plus eight audio-code channels. It:

- pads audio-code frames to a multiple of four;
- places `<|sosp|>`, `<|empty|>`, and `<|eosp|>` exactly as in the official
  implementation;
- replaces each four-frame audio group with one SGLang multimodal placeholder;
- injects the corresponding `[hidden_size]` patch embedding during prefill.

For the frozen parity fixture, the official and local `[9, 96]` prompt-ID
matrices have the same SHA-256:

```text
6679ff48431a953d3f858bc7916135885cf62f27309af5976cc61dd503ce8a7c
```

### Text-only scope and weight loading

Milestone 1 deliberately excludes audio output. The request path rejects any
non-text output modality and applies a logit bias against `<|empty|>`, which
selects MiMo's audio-generation path.

The strict checkpoint loader:

- loads the global Qwen2, LM head, input-local transformer, speech embeddings,
  and group-downcast weights;
- rejects missing or unexpected input-side weights;
- intentionally skips the output-only `local_transformer`,
  `local_transformer_lm_heads`, `hidden_states_downcast`, and
  `speech_embeddings_to_local` tensors.

On the published checkpoint, 517 required tensors load and 202 output-only
tensors are skipped. No patch decoder, delayed-RVQ generator, tokenizer
decoder, vocoder, or waveform path is instantiated.

## E2E verification

Tested on one NVIDIA A100-SXM4-80GB with the exact revisions:

- `XiaomiMiMo/MiMo-Audio-7B-Instruct`
  `c359441c22c2a1c74be5f99a91e83392680e9cc8`
- `XiaomiMiMo/MiMo-Audio-Tokenizer`
  `5df9914f72d3acda1320d7fecde7d91622edb0c1`

### Automated A100 test

```bash
source /workspace/activate-sglang-omni.sh

git clone --depth=1 https://github.com/XiaomiMiMo/MiMo-Audio \
  /workspace/references/MiMo-Audio

export SGLANG_OMNI_TEST_MIMO_MODEL=/path/to/XiaomiMiMo/MiMo-Audio-7B-Instruct
export SGLANG_OMNI_TEST_MIMO_AUDIO=/workspace/references/MiMo-Audio/examples/北京.mp3
export SGLANG_OMNI_TEST_MIMO_EXPECT=北京
export SGLANG_OMNI_STARTUP_TIMEOUT=900

pytest -q tests/test_model/test_mimo_audio_e2e.py \
  -m benchmark -s --disable-warnings
```

Observed:

```text
1 passed in 400.91s
```

The test launches a managed SGLang-Omni router, posts the real MP3 to
`/v1/audio/transcriptions`, requires HTTP 200 and meaningful marker-free text,
and asserts that the output contains `北京`.

### Manual server verification

```bash
source /workspace/activate-sglang-omni.sh
export SGLANG_OMNI_STARTUP_TIMEOUT=900

sgl-omni serve \
  --model-path /path/to/XiaomiMiMo/MiMo-Audio-7B-Instruct \
  --model-name mimo-audio \
  --host 127.0.0.1 \
  --port 8009
```

In another shell:

```bash
curl --fail-with-body http://127.0.0.1:8009/v1/audio/transcriptions \
  -F model=mimo-audio \
  -F language=zh \
  -F temperature=0 \
  -F max_new_tokens=128 \
  -F 'file=@/workspace/references/MiMo-Audio/examples/北京.mp3;type=audio/mpeg'
```

Observed response:

```json
{"text":"北京","usage":{"type":"duration","seconds":1}}
```

Measurements from the first request:

- coordinator-to-ready startup: 272.28 s;
- first request: 34.75 s;
- warm request: 13.03 s;
- peak observed GPU process memory: 66,090 MiB.

The official Xiaomi `MimoAudio.asr_sft` path returned the same text, `北京`.
The FA2 official environment and FA3 SGLang environment differed at one
nearest-codebook decision, but the final generated text was identical.

## Tests

```text
27 passed — tests/unit_test/mimo_audio
37 passed — combined MiMo registration and transcription integration selection
92 passed — existing model registration, Qwen3-Omni config/pipeline, and CLI regression selection
1 passed  — checkpoint-backed managed-router A100 E2E
```

Scoped Ruff, Python byte-compilation, and `git diff --check` pass.

## Deferred

This PR does not implement TTS, spoken-dialogue audio output, delayed
multi-channel RVQ generation, patch decoding, tokenizer decoding, waveform
generation, audio streaming, or multi-GPU placement.
