### PR TITLE
[CI] Recalibrate Fun-ASR SeedTTS thresholds

### DIFF
--- a/.claude/skills/tune-ci-thresholds/models/asr/stages.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/asr/stages.yaml
@@ -8,7 +8,7 @@ multi_speaker_diarization:
     - MOSS_TD_CI_SAMPLES
     - MOSS_TD_LONG_MAX_NEW_TOKENS
   test_file_sha256: e1001853547eaa6c32bed89b65e705b8ecd9eda10bb2af864219d5cde47ce8be
-  last_discovered_at: 2026-07-21T22:24:08Z
+  last_discovered_at: 2026-07-29T04:37:10Z
   expected_samples: 800
   sample_counts:
     total:
@@ -127,7 +127,7 @@ multi_speaker_speed:
     - MOSS_TD_CI_SAMPLES
     - MOSS_TD_LONG_MAX_NEW_TOKENS
   test_file_sha256: e1001853547eaa6c32bed89b65e705b8ecd9eda10bb2af864219d5cde47ce8be
-  last_discovered_at: 2026-07-21T22:24:08Z
+  last_discovered_at: 2026-07-29T04:37:10Z
   expected_samples: 800
   sample_counts:
     total:
@@ -195,7 +195,7 @@ aishell4_long_diarization:
   context_vars:
     - MOSS_TD_AISHELL4_LONG_CI_SAMPLES
   test_file_sha256: e1001853547eaa6c32bed89b65e705b8ecd9eda10bb2af864219d5cde47ce8be
-  last_discovered_at: 2026-07-21T22:24:08Z
+  last_discovered_at: 2026-07-29T04:37:10Z
   expected_samples: 20
   sample_counts:
     total:
@@ -263,7 +263,7 @@ aishell4_long_speed:
   context_vars:
     - MOSS_TD_AISHELL4_LONG_CI_SAMPLES
   test_file_sha256: e1001853547eaa6c32bed89b65e705b8ecd9eda10bb2af864219d5cde47ce8be
-  last_discovered_at: 2026-07-21T22:24:08Z
+  last_discovered_at: 2026-07-29T04:37:10Z
   expected_samples: 20
   sample_counts:
     total:
@@ -331,7 +331,7 @@ googletime_diarization:
   context_vars:
     - MOSS_TD_GOOGLETIME_CI_SAMPLES
   test_file_sha256: e1001853547eaa6c32bed89b65e705b8ecd9eda10bb2af864219d5cde47ce8be
-  last_discovered_at: 2026-07-21T22:24:08Z
+  last_discovered_at: 2026-07-29T04:37:10Z
   expected_samples: 25
   sample_counts:
     total:
@@ -419,7 +419,7 @@ googletime_speed:
   context_vars:
     - MOSS_TD_GOOGLETIME_CI_SAMPLES
   test_file_sha256: e1001853547eaa6c32bed89b65e705b8ecd9eda10bb2af864219d5cde47ce8be
-  last_discovered_at: 2026-07-21T22:24:08Z
+  last_discovered_at: 2026-07-29T04:37:10Z
   expected_samples: 25
   sample_counts:
     total:
@@ -488,7 +488,7 @@ multi_speaker_stream_diarization:
     - MOSS_TD_CI_SAMPLES
   variant: "stream"
   test_file_sha256: e1001853547eaa6c32bed89b65e705b8ecd9eda10bb2af864219d5cde47ce8be
-  last_discovered_at: 2026-07-21T22:24:08Z
+  last_discovered_at: 2026-07-29T04:37:10Z
   expected_samples: 800
   sample_counts:
     total:
@@ -597,7 +597,7 @@ multi_speaker_stream_speed:
     - MOSS_TD_CI_SAMPLES
   variant: "stream"
   test_file_sha256: e1001853547eaa6c32bed89b65e705b8ecd9eda10bb2af864219d5cde47ce8be
-  last_discovered_at: 2026-07-21T22:24:08Z
+  last_discovered_at: 2026-07-29T04:37:10Z
   expected_samples: 800
   sample_counts:
     total:
@@ -685,8 +685,8 @@ fun_asr_en_wer:
   context_vars:
     - SEEDTTS_FUN_ASR_EN_SAMPLES
   variant: "en"
-  test_file_sha256: 4606d6c47207ce55f63b89f58ef86e6939cd8af3413be3d957780e24466d5241
-  last_discovered_at: 2026-07-21T22:24:08Z
+  test_file_sha256: 38c9ca219131f2d60c5d25c5c45465c7e9e95708ef5f1023ae90374e9366e670
+  last_discovered_at: 2026-07-29T04:37:11Z
   expected_samples: 1088
   sample_counts:
     total:
@@ -724,8 +724,8 @@ fun_asr_en_speed:
   context_vars:
     - SEEDTTS_FUN_ASR_EN_SAMPLES
   variant: "en"
-  test_file_sha256: 4606d6c47207ce55f63b89f58ef86e6939cd8af3413be3d957780e24466d5241
-  last_discovered_at: 2026-07-21T22:24:08Z
+  test_file_sha256: 38c9ca219131f2d60c5d25c5c45465c7e9e95708ef5f1023ae90374e9366e670
+  last_discovered_at: 2026-07-29T04:37:11Z
   expected_samples: 1088
   sample_counts:
     total:
@@ -793,8 +793,8 @@ fun_asr_zh_wer:
   context_vars:
     - SEEDTTS_FUN_ASR_ZH_SAMPLES
   variant: "zh"
-  test_file_sha256: 4606d6c47207ce55f63b89f58ef86e6939cd8af3413be3d957780e24466d5241
-  last_discovered_at: 2026-07-21T22:24:08Z
+  test_file_sha256: 38c9ca219131f2d60c5d25c5c45465c7e9e95708ef5f1023ae90374e9366e670
+  last_discovered_at: 2026-07-29T04:37:11Z
   expected_samples: 2020
   sample_counts:
     total:

--- a/tests/test_model/test_asr_ci_fun_asr.py
+++ b/tests/test_model/test_asr_ci_fun_asr.py
@@ -46,26 +46,15 @@ SEEDTTS_ASR_DATASET_LABEL = format_benchmark_dataset_label(
     repo_id=DATASETS["seedtts"],
 )
 
-# note (db-ol): references are the strict worst-of-5 from the official
-# tune-ci-thresholds calibration run 20260719T2302Z_asr_fun_g25 on idle
-# GPUs of the CI host (2x H100 80GB, DP=2 managed router, concurrency 32).
-# EN WER was identical across all five repeats and speed CV stayed under
-# 7 percent with no outliers. Two caveats the numbers alone do not show:
-# heavily contended CI runs have measured 16 to 20 percent below the idle
-# speed references, beyond the 10 percent slack, so a loaded runner leans
-# on the flaky-pytest retry wrapper. The ZH per-sample bound keeps the more
-# conservative worst of the two strict calibrations because that single
-# utterance metric drifted between runs (0.75 in this run, 0.8333 in the
-# previous strict worst-of-5 on the same topology).
 FUN_ASR_EN_CORPUS_WER_MAX = 0.0172
-FUN_ASR_EN_SAMPLE_WER_MAX = 0.2858
-FUN_ASR_ZH_CORPUS_WER_MAX = 0.0136
+FUN_ASR_EN_SAMPLE_WER_MAX = 0.3077
+FUN_ASR_ZH_CORPUS_WER_MAX = 0.0139
 FUN_ASR_ZH_SAMPLE_WER_MAX = 0.8334
-FUN_ASR_THROUGHPUT_MIN = 64.27181519213258
-FUN_ASR_LATENCY_MEAN_MAX_S = 0.49501860166257006
-FUN_ASR_LATENCY_P95_MAX_S = 0.715
-FUN_ASR_RTF_MEAN_MAX = 0.1076
-FUN_ASR_RTF_P95_MAX = 0.1597
+FUN_ASR_THROUGHPUT_MIN = 86.35693277974542
+FUN_ASR_LATENCY_MEAN_MAX_S = 0.36614295910519157
+FUN_ASR_LATENCY_P95_MAX_S = 0.47548172677634254
+FUN_ASR_RTF_MEAN_MAX = 0.08054177265047294
+FUN_ASR_RTF_P95_MAX = 0.1218
 
 THRESHOLD_SLACK_HIGHER = 0.9
 THRESHOLD_SLACK_LOWER = 1.1


### PR DESCRIPTION

## Motivation

Recalibrate the Fun-ASR SeedTTS CI references against a fresh strict worst-of-five observation set.

## Modifications
The final reference changes below are shown before the existing 10% slack:

| Reference | Previous | New | 
|---|---:|---|
| EN corpus WER | 0.0172 | 0.0172 | 
| EN max per-sample WER | 0.2858 | 0.3077 | 
| ZH corpus WER | 0.0136 | 0.0139 |
| ZH max per-sample WER | 0.8334 | 0.8334 | 
| Throughput (samples/s) | 64.271815 | 86.356933 |
| Mean latency (s) | 0.495019 | 0.366143 |
| p95 latency (s) | 0.715000 | 0.475482 | 
| Mean RTF | 0.107600 | 0.080542 | 
| p95 RTF | 0.159700 | 0.121800 | 

## Related Issues
#924 

## Accuracy Test

### Setup
- main: `@ 7e837c22420c32e8894756feabb1dbfb224ab8fc`
- Model: `FunAudioLLM/Fun-ASR-Nano-2512-hf`
- Dataset: `zhaochenyang20/seed-tts-eval-arrow`
- Scope: 1088 EN samples and 2020 ZH samples, 5 repeats
- Topology: 2 managed workers (DP=2), concurrency 32, warmup 64
- Hardware: 2x NVIDIA H100 80GB on physical GPUs 0 and 1

### Results

| Metric | Run 1 | Run 2 | Run 3 | Run 4 | Run 5 | Strict worst-of-5 |
|---|---:|---:|---:|---:|---:|---:|
| EN corpus WER | 1.72% | 1.72% | 1.72% | 1.72% | 1.72% | 1.72% |
| EN max per-sample WER | 30.77% | 30.77% | 30.77% | 30.77% | 30.77% | 30.77% |
| ZH corpus WER | 1.36% | 1.37% | 1.38% | 1.38% | 1.38% | 1.38% |
| ZH max per-sample WER | 83.33% | 83.33% | 83.33% | 83.33% | 83.33% | 83.33% |

## Benchmark & Profiling

| Metric | Run 1 | Run 2 | Run 3 | Run 4 | Run 5 | Median | Std | Strict worst |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| Throughput (samples/s) | 89.018 | 86.357 | 89.757 | 91.160 | 92.511 | 89.757 | 2.327 | 86.357 |
| Mean latency (s) | 0.354 | 0.366 | 0.353 | 0.347 | 0.339 | 0.353 | 0.010 | 0.366 |
| p95 latency (s) | 0.455 | 0.472 | 0.469 | 0.475 | 0.434 | 0.469 | 0.017 | 0.475 |
| Mean RTF | 0.0779 | 0.0805 | 0.0775 | 0.0762 | 0.0746 | 0.0775 | 0.0022 | 0.0805 |
| p95 RTF | 0.1171 | 0.1218 | 0.1200 | 0.1200 | 0.1131 | 0.1200 | 0.0034 | 0.1218 |


## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
