### PR TITLE
[WIP][Perf][MOSS] Fused sampling for moss tts local

### DIFF
--- a/sglang_omni/models/moss_tts_local/local_transformer.py
+++ b/sglang_omni/models/moss_tts_local/local_transformer.py
@@ -7,6 +7,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from sglang_omni.models.moss_tts_local.sampling_kernels import sample_seeded_full_vocab
+
 
 def sample_seeded_branchless(
     logits: torch.Tensor,
@@ -17,7 +19,37 @@ def sample_seeded_branchless(
     seeds: torch.Tensor,
     positions: torch.Tensor,
 ) -> torch.Tensor:
-    """Seeded temperature/top-k/top-p sampling without host control flow."""
+    """Use fused seeded sampling when supported, otherwise the eager reference."""
+    fused = sample_seeded_full_vocab(
+        logits,
+        temperature,
+        top_p,
+        top_k,
+        seeds,
+        positions,
+    )
+    if fused is not None:
+        return fused
+    return _sample_seeded_branchless_eager(
+        logits,
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+        seeds=seeds,
+        positions=positions,
+    )
+
+
+def _sample_seeded_branchless_eager(
+    logits: torch.Tensor,
+    *,
+    temperature: torch.Tensor,
+    top_p: torch.Tensor,
+    top_k: torch.Tensor,
+    seeds: torch.Tensor,
+    positions: torch.Tensor,
+) -> torch.Tensor:
+    """PyTorch reference for seeded temperature/top-k/top-p sampling."""
     from sglang.srt.layers.sampler import multinomial_with_seed
 
     vocab = logits.shape[-1]

--- a/sglang_omni/models/moss_tts_local/sampling_kernels.py
+++ b/sglang_omni/models/moss_tts_local/sampling_kernels.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Optional fused sampling kernels for MOSS-TTS-Local."""
+
+from __future__ import annotations
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    from sglang_omni.sampling.triton.hash import murmur_hash_seed_position_key
+except ImportError:  # pragma: no cover - depends on the runtime image
+    triton = None
+    tl = None
+
+
+if triton is not None:
+
+    @triton.jit
+    def _sample_seeded_full_vocab_kernel(
+        logits,
+        temperatures,
+        top_ps,
+        top_ks,
+        seeds,
+        positions,
+        out,
+        vocab_size: tl.constexpr,
+        logits_stride_b: tl.constexpr,
+        block_size: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        offsets = tl.arange(0, block_size)
+        valid_col = offsets < vocab_size
+
+        raw_scores = tl.load(
+            logits + row * logits_stride_b + offsets,
+            mask=valid_col,
+            other=-float("inf"),
+        ).to(tl.float32)
+        temperature = tl.load(temperatures + row).to(tl.float32)
+        do_sample = temperature > 0.0
+        safe_temperature = tl.where(do_sample, temperature, 1.0)
+        scores = raw_scores / safe_temperature
+
+        # Match the eager threshold form of top-k: values tied with the kth
+        # score remain eligible, even when that retains more than k tokens.
+        sorted_scores = tl.sort(scores, dim=0, descending=True)
+        top_k = tl.load(top_ks + row)
+        active_top_k = (top_k > 0) & (top_k < vocab_size)
+        clamped_top_k = tl.minimum(tl.maximum(top_k, 1), vocab_size)
+        kth_score = tl.sum(
+            tl.where(offsets == clamped_top_k - 1, sorted_scores, 0.0),
+            axis=0,
+        )
+        top_k_threshold = tl.where(active_top_k, kth_score, -float("inf"))
+        keep_top_k = valid_col & (scores >= top_k_threshold)
+
+        # Compute nucleus probabilities in sorted order after top-k. The eager
+        # path shifts its removal mask right, so rank i is retained while the
+        # cumulative probability through rank i-1 is <= top_p.
+        sorted_masked = tl.where(
+            sorted_scores >= top_k_threshold,
+            sorted_scores,
+            -float("inf"),
+        )
+        max_score = tl.max(sorted_masked, axis=0)
+        exp_scores = tl.exp(sorted_masked - max_score)
+        probs = exp_scores / tl.sum(exp_scores, axis=0)
+        cumulative_before = tl.cumsum(probs, axis=0) - probs
+        top_p = tl.load(top_ps + row).to(tl.float32)
+        active_top_p = (top_p > 0.0) & (top_p < 1.0)
+        keep_sorted_top_p = (
+            (offsets == 0) | (cumulative_before <= top_p) | (~active_top_p)
+        )
+        top_p_threshold = tl.min(
+            tl.where(
+                keep_sorted_top_p & (sorted_masked != -float("inf")),
+                sorted_masked,
+                float("inf"),
+            ),
+            axis=0,
+        )
+        keep = keep_top_k & ((scores >= top_p_threshold) | (~active_top_p))
+
+        seed = tl.load(seeds + row)
+        position = tl.load(positions + row)
+        hashes = murmur_hash_seed_position_key(seed, position, offsets)
+        u = hashes.to(tl.float64) / 4294967295.0
+        u = tl.maximum(u, 2.2250738585072014e-308)
+        gumbel = -tl.log(-tl.log(u))
+        sampled_scores = tl.where(
+            keep,
+            scores.to(tl.float64) + gumbel,
+            -float("inf"),
+        )
+        sampled_token = tl.argmax(sampled_scores, axis=0, tie_break_left=True)
+        greedy_token = tl.argmax(raw_scores, axis=0, tie_break_left=True)
+
+        allowed_max = tl.max(
+            tl.where(keep, scores, -float("inf")),
+            axis=0,
+        )
+        valid_distribution = (
+            (allowed_max == allowed_max)
+            & (allowed_max != -float("inf"))
+            & (allowed_max != float("inf"))
+        )
+        token = tl.where(do_sample & valid_distribution, sampled_token, greedy_token)
+        tl.store(out + row, token)
+
+else:
+    _sample_seeded_full_vocab_kernel = None
+
+
+def _next_power_of_2(value: int) -> int:
+    return 1 << (int(value) - 1).bit_length()
+
+
+def fused_sampler_available() -> bool:
+    return _sample_seeded_full_vocab_kernel is not None
+
+
+def sample_seeded_full_vocab(
+    logits: torch.Tensor,
+    temperatures: torch.Tensor,
+    top_ps: torch.Tensor,
+    top_ks: torch.Tensor,
+    seeds: torch.Tensor,
+    positions: torch.Tensor,
+) -> torch.Tensor | None:
+    """Sample ``[batch, vocab]`` logits, or return ``None`` for eager fallback."""
+
+    tensors = (logits, temperatures, top_ps, top_ks, seeds, positions)
+    if _sample_seeded_full_vocab_kernel is None or any(
+        not tensor.is_cuda for tensor in tensors
+    ):
+        return None
+    if logits.ndim != 2:
+        return None
+    batch_size, vocab_size = logits.shape
+    if any(tensor.ndim != 1 for tensor in tensors[1:]):
+        return None
+    if any(int(tensor.shape[0]) != batch_size for tensor in tensors[1:]):
+        return None
+    if batch_size == 0:
+        return torch.empty(0, dtype=torch.long, device=logits.device)
+    if vocab_size <= 0 or vocab_size > 1024:
+        return None
+    if any(tensor.device != logits.device for tensor in tensors[1:]):
+        return None
+    if any(not tensor.is_contiguous() for tensor in tensors):
+        return None
+
+    block_size = _next_power_of_2(vocab_size)
+    out = torch.empty(batch_size, dtype=torch.long, device=logits.device)
+    _sample_seeded_full_vocab_kernel[(batch_size,)](
+        logits,
+        temperatures,
+        top_ps,
+        top_ks,
+        seeds,
+        positions,
+        out,
+        int(vocab_size),
+        logits.stride(0),
+        block_size,
+    )
+    return out
+
+
+__all__ = [
+    "fused_sampler_available",
+    "sample_seeded_full_vocab",
+]

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -32,11 +32,13 @@ from sglang.srt.utils import add_prefix
 
 from sglang_omni.models.moss_tts_local.local_transformer import (
     MossTTSLocalTransformer,
+    _sample_seeded_branchless_eager,
     sample_seeded_branchless,
 )
 from sglang_omni.models.moss_tts_local.payload_types import (
     moss_tts_local_special_token_defaults,
 )
+from sglang_omni.models.moss_tts_local.sampling_kernels import fused_sampler_available
 from sglang_omni.models.moss_tts_local.state_pool import MossTTSLocalDecodeStatePool
 
 logger = logging.getLogger(__name__)
@@ -370,12 +372,17 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
 
     def _ensure_frame_sampler_compile(self) -> None:
         if self._compiled_frame_sampler is None:
+            if fused_sampler_available():
+                self._compiled_frame_sampler = sample_seeded_branchless
+                self._sample_seeded_branchless = sample_seeded_branchless
+                logger.info("Enabled fused MOSS-TTS Local frame sampler")
+                return
             compile_mode = os.environ.get(
                 "SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs"
             )
             self._ensure_frame_compile_config()
             self._compiled_frame_sampler = torch.compile(
-                sample_seeded_branchless,
+                _sample_seeded_branchless_eager,
                 mode=compile_mode,
             )
             self._sample_seeded_branchless = self._compiled_frame_sampler

--- a/sglang_omni/sampling/triton/__init__.py
+++ b/sglang_omni/sampling/triton/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared Triton utilities for sampling kernels."""

--- a/sglang_omni/sampling/triton/hash.py
+++ b/sglang_omni/sampling/triton/hash.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Triton hashing primitives for seeded GPU sampling."""
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def rotl32(x, r: tl.constexpr) -> tl.uint32:
+    x = x.to(tl.uint64)
+    return ((x << r) | (x >> (32 - r))) & 0xFFFFFFFF
+
+
+@triton.jit
+def fmix32(h: tl.uint32) -> tl.uint32:
+    h ^= h >> 16
+    h = (h * 0x85EBCA6B) & 0xFFFFFFFF
+    h ^= h >> 13
+    h = (h * 0xC2B2AE35) & 0xFFFFFFFF
+    h ^= h >> 16
+    return h
+
+
+@triton.jit
+def murmur3_mix(h: tl.uint32, k: tl.uint32) -> tl.uint32:
+    k = (k * 0xCC9E2D51) & 0xFFFFFFFF
+    k = rotl32(k, 15)
+    k = (k * 0x1B873593) & 0xFFFFFFFF
+    h ^= k
+    h = rotl32(h, 13)
+    h = (h * 5 + 0xE6546B64) & 0xFFFFFFFF
+    return h
+
+
+@triton.jit
+def murmur_hash_seed_position_key(seed, position, key) -> tl.uint32:
+    """Hash one sampling key from seed, generation position, and token id."""
+
+    seed = seed.to(tl.uint64)
+    h: tl.uint32 = 0
+    h = murmur3_mix(h, (seed & 0xFFFFFFFF).to(tl.uint32))
+    h = murmur3_mix(h, ((seed >> 32) & 0xFFFFFFFF).to(tl.uint32))
+    h = murmur3_mix(h, position.to(tl.uint32))
+    h = murmur3_mix(h, key.to(tl.uint32))
+    h ^= 16
+    return fmix32(h)
+
+
+__all__ = [
+    "fmix32",
+    "murmur3_mix",
+    "murmur_hash_seed_position_key",
+    "rotl32",
+]

--- a/tests/unit_test/moss_tts_local/test_sampling_kernels.py
+++ b/tests/unit_test/moss_tts_local/test_sampling_kernels.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MOSS-TTS-Local fused sampling kernel tests."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+
+def test_fused_sampler_falls_back_on_cpu() -> None:
+    from sglang_omni.models.moss_tts_local.sampling_kernels import (
+        sample_seeded_full_vocab,
+    )
+
+    rows = 2
+    result = sample_seeded_full_vocab(
+        torch.randn(rows, 16),
+        torch.ones(rows),
+        torch.ones(rows),
+        torch.full((rows,), 8, dtype=torch.long),
+        torch.arange(rows, dtype=torch.long),
+        torch.arange(rows, dtype=torch.long),
+    )
+    assert result is None
+
+
+@pytest.mark.gpu
+def test_fused_sampler_randomized_parity_gpu() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    from sglang_omni.models.moss_tts_local import local_transformer
+    from sglang_omni.models.moss_tts_local.sampling_kernels import (
+        sample_seeded_full_vocab,
+    )
+
+    device = torch.device("cuda")
+    rows = 512
+    vocab = 1024
+    generator = torch.Generator(device=device).manual_seed(20260729)
+    logits = torch.randn(
+        rows,
+        vocab,
+        generator=generator,
+        device=device,
+        dtype=torch.float32,
+    )
+    row_ids = torch.arange(rows, device=device)
+    temperature_values = torch.tensor(
+        [0.0, 0.5, 1.0, 1.7],
+        device=device,
+        dtype=torch.float32,
+    )
+    top_p_values = torch.tensor(
+        [0.2, 0.8, 0.95, 1.0],
+        device=device,
+        dtype=torch.float32,
+    )
+    top_k_values = torch.tensor(
+        [-1, 1, 25, 50, 1024],
+        device=device,
+        dtype=torch.long,
+    )
+    temperatures = temperature_values[row_ids.remainder(temperature_values.numel())]
+    top_ps = top_p_values[
+        (row_ids // temperature_values.numel()).remainder(top_p_values.numel())
+    ]
+    top_ks = top_k_values[
+        (row_ids // (temperature_values.numel() * top_p_values.numel())).remainder(
+            top_k_values.numel()
+        )
+    ]
+    seeds = torch.randint(
+        0,
+        1 << 31,
+        (rows,),
+        generator=generator,
+        device=device,
+        dtype=torch.long,
+    )
+    positions = torch.randint(
+        0,
+        1 << 30,
+        (rows,),
+        generator=generator,
+        device=device,
+        dtype=torch.long,
+    )
+
+    actual = sample_seeded_full_vocab(
+        logits,
+        temperatures,
+        top_ps,
+        top_ks,
+        seeds,
+        positions,
+    )
+    if actual is None:
+        pytest.skip("Triton fused sampling kernel is unavailable")
+
+    expected = local_transformer._sample_seeded_branchless_eager(
+        logits,
+        temperature=temperatures,
+        top_p=top_ps,
+        top_k=top_ks,
+        seeds=seeds,
+        positions=positions,
+    )
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.gpu
+def test_fused_sampler_preserves_top_k_boundary_ties_gpu() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+
+    from sglang_omni.models.moss_tts_local import local_transformer
+    from sglang_omni.models.moss_tts_local.sampling_kernels import (
+        sample_seeded_full_vocab,
+    )
+
+    device = torch.device("cuda")
+    rows = 128
+    logits = (
+        torch.tensor(
+            [[5.0, 4.0, 4.0, 1.0]],
+            device=device,
+        )
+        .expand(rows, -1)
+        .contiguous()
+    )
+    temperatures = torch.ones(rows, device=device)
+    top_ps = torch.ones(rows, device=device)
+    top_ks = torch.full((rows,), 2, dtype=torch.long, device=device)
+    seeds = torch.arange(rows, dtype=torch.long, device=device)
+    positions = torch.arange(rows, dtype=torch.long, device=device)
+
+    actual = sample_seeded_full_vocab(
+        logits,
+        temperatures,
+        top_ps,
+        top_ks,
+        seeds,
+        positions,
+    )
+    if actual is None:
+        pytest.skip("Triton fused sampling kernel is unavailable")
+
+    expected = local_transformer._sample_seeded_branchless_eager(
+        logits,
+        temperature=temperatures,
+        top_p=top_ps,
+        top_k=top_ks,
+        seeds=seeds,
+        positions=positions,
+    )
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)


### PR DESCRIPTION
## Motivation
Follow up on https://github.com/sgl-project/sglang-omni/pull/1223

Reduce per-frame sampling overhead in MOSS-TTS-Local. Existing PyTorch sampler consists of multiple operations (sorting, top-k/top-p filtering, seeded sampling, and greedy fallback). Profiling showed that the existing compiled PyTorch sampler takes approximately 41–43 µs under CUDA Graph execution and can potentially gain 1.7x speedup (22 µs) if fused. Considering this is on the autoregressive hot path, such optimization worthwhile (proves to get 15% throughput boost e2e)

## Modifications

- Add a fused Triton kernel for MOSS-TTS-Local full-vocabulary sampling.
- Fuse the following operations:
    - Temperature scaling
    - Dynamic top-k filtering
    - Top-p filtering
    - Seeded Murmur3 hashing and Gumbel sampling
    - Greedy fallback
    - Final token selection

## Related Issues

N/A

## Accuracy Test

All existing tests pass.
Add randomized GPU parity tests for numerical parity comparison.


## Benchmark & Profiling
All tested on GPU: NVIDIA RTX PRO 6000.
### Microbenchmark

Benchmarked against CUDA Graph under different batch size
- graph: existing implementation under CUDA Graph replay
- fused: fused Triton implementation

Batch | Graph (µs) | Fused (µs)
-- | -- | --
1 | 41.12 | 23.76
4 | 43.13 | 23.72
8 | 43.12 | 23.74
16 | 43.14 | 23.73


### End-to-end production benchmark
```
  sgl-omni serve \
    --model-path OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5 \
    --port 8000 \
    --allowed-local-media-path /tmp

  python -m benchmarks.eval.benchmark_tts_seedtts \
    --use-existing-server \
    --generate-only \
    --meta zhaochenyang20/seed-tts-eval-arrow \
    --model OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5 \
    --port 8000 \
    --ref-format references \
    --token-count auto \
    --lang en \
    --seed 20260729 \
    --warmup 8 \
    --max-samples 200 \
    --max-concurrency 16 \
    --output-dir results/moss_local_fused_c16

```


Metric | Fused | Eager | Diff | Change
-- | -- | -- | -- | --
Model | OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5 | OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5 | — | —
Concurrency | 16 | 16 | 0 | 0.00%
Completed requests | 200 | 200 | 0 | 0.00%
Failed requests | 0 | 0 | 0 | —
Latency mean (s) | 3.053 | 3.513 | +0.460 | +15.07%
Latency median (s) | 3.146 | 3.635 | +0.489 | +15.54%
Latency p95 (s) | 3.621 | 4.225 | +0.604 | +16.68%
Latency p99 (s) | 4.002 | 4.569 | +0.567 | +14.17%
RTF mean | 0.7956 | 0.9174 | +0.1218 | +15.31%
RTF median | 0.7639 | 0.8992 | +0.1353 | +17.71%
RTF p95 | 1.2215 | 1.4062 | +0.1847 | +15.12%
RTF p99 | 1.2787 | 1.5011 | +0.2224 | +17.39%
Audio duration mean (s) | 4.127 | 4.127 | 0.000 | 0.00%
Audio throughput (s/s) | 21.310 | 18.536 | −2.774 | −13.02%
Output throughput (tok/s) | 266.4 | 231.7 | −34.7 | −13.03%
Output tokens/request-s | 56.5 | 55.1 | −1.4 | −2.48%
Output tokens (mean) | 52 | 52 | 0 | 0.00%
Output tokens (total) | 10318 | 10318 | 0 | 0.00%
Prompt tokens (mean) | 131 | 131 | 0 | 0.00%
Prompt tokens (total) | 26215 | 26215 | 0 | 0.00%
Throughput (req/s) | 5.163 | 4.491 | −0.672 | −13.02%


## Checklist

- [x] Format code according to pre-commit.
- [x] Add unit tests.
- [ ] Update documentation, docstrings, or example tutorials as needed.
- [x] Provide kernel benchmark and accuracy results.
- [ ] Provide end-to-end throughput and latency results.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please
  remove yourself as a co-author when merging the PR.
