### PR TITLE
[Fix] Add MOSS preprocessing GPU budget

### DIFF
--- a/sglang_omni/config/topology.py
+++ b/sglang_omni/config/topology.py
@@ -234,6 +234,8 @@ def _validate_gpu_process_colocation(
 ) -> None:
     stage_by_name = {stage.name: stage for stage in stages}
     gpu_processes: dict[int, set[str]] = defaultdict(set)
+    process_stages: dict[tuple[int, str], set[str]] = defaultdict(set)
+    processes_with_fraction: set[tuple[int, str]] = set()
     missing_fraction: dict[int, set[str]] = defaultdict(set)
 
     for group in topology_plan.groups:
@@ -243,8 +245,10 @@ def _validate_gpu_process_colocation(
                 if gpu_id is None:
                     continue
                 gpu_processes[gpu_id].add(group.name)
-                if stage.runtime.resources.total_gpu_memory_fraction is None:
-                    missing_fraction[gpu_id].add(stage.name)
+                process_key = (gpu_id, group.name)
+                process_stages[process_key].add(stage.name)
+                if stage.runtime.resources.total_gpu_memory_fraction is not None:
+                    processes_with_fraction.add(process_key)
 
     for stage in stages:
         if stage.tp_size <= 1:
@@ -252,11 +256,16 @@ def _validate_gpu_process_colocation(
         for rank, gpu_id in enumerate(_stage_gpu_ids(gpu_placement, stage)):
             if gpu_id is None:
                 continue
-            gpu_processes[gpu_id].add(
-                topology_plan.tp_stage_to_processes[stage.name][rank]
-            )
-            if stage.runtime.resources.total_gpu_memory_fraction is None:
-                missing_fraction[gpu_id].add(stage.name)
+            process_name = topology_plan.tp_stage_to_processes[stage.name][rank]
+            gpu_processes[gpu_id].add(process_name)
+            process_key = (gpu_id, process_name)
+            process_stages[process_key].add(stage.name)
+            if stage.runtime.resources.total_gpu_memory_fraction is not None:
+                processes_with_fraction.add(process_key)
+
+    for (gpu_id, process_name), stage_names in process_stages.items():
+        if (gpu_id, process_name) not in processes_with_fraction:
+            missing_fraction[gpu_id].update(stage_names)
 
     require = config.placement.require_memory_fraction_for_colocation
     limit = config.placement.max_total_gpu_memory_fraction_per_gpu

--- a/sglang_omni/config/topology.py
+++ b/sglang_omni/config/topology.py
@@ -234,8 +234,6 @@ def _validate_gpu_process_colocation(
 ) -> None:
     stage_by_name = {stage.name: stage for stage in stages}
     gpu_processes: dict[int, set[str]] = defaultdict(set)
-    process_stages: dict[tuple[int, str], set[str]] = defaultdict(set)
-    processes_with_fraction: set[tuple[int, str]] = set()
     missing_fraction: dict[int, set[str]] = defaultdict(set)
 
     for group in topology_plan.groups:
@@ -245,10 +243,8 @@ def _validate_gpu_process_colocation(
                 if gpu_id is None:
                     continue
                 gpu_processes[gpu_id].add(group.name)
-                process_key = (gpu_id, group.name)
-                process_stages[process_key].add(stage.name)
-                if stage.runtime.resources.total_gpu_memory_fraction is not None:
-                    processes_with_fraction.add(process_key)
+                if stage.runtime.resources.total_gpu_memory_fraction is None:
+                    missing_fraction[gpu_id].add(stage.name)
 
     for stage in stages:
         if stage.tp_size <= 1:
@@ -256,16 +252,11 @@ def _validate_gpu_process_colocation(
         for rank, gpu_id in enumerate(_stage_gpu_ids(gpu_placement, stage)):
             if gpu_id is None:
                 continue
-            process_name = topology_plan.tp_stage_to_processes[stage.name][rank]
-            gpu_processes[gpu_id].add(process_name)
-            process_key = (gpu_id, process_name)
-            process_stages[process_key].add(stage.name)
-            if stage.runtime.resources.total_gpu_memory_fraction is not None:
-                processes_with_fraction.add(process_key)
-
-    for (gpu_id, process_name), stage_names in process_stages.items():
-        if (gpu_id, process_name) not in processes_with_fraction:
-            missing_fraction[gpu_id].update(stage_names)
+            gpu_processes[gpu_id].add(
+                topology_plan.tp_stage_to_processes[stage.name][rank]
+            )
+            if stage.runtime.resources.total_gpu_memory_fraction is None:
+                missing_fraction[gpu_id].add(stage.name)
 
     require = config.placement.require_memory_fraction_for_colocation
     limit = config.placement.max_total_gpu_memory_fraction_per_gpu

--- a/sglang_omni/models/moss_transcribe_diarize/config.py
+++ b/sglang_omni/models/moss_transcribe_diarize/config.py
@@ -11,6 +11,7 @@ from sglang_omni.models.moss_transcribe_diarize import (  # noqa: F401
 )
 
 _PKG = "sglang_omni.models.moss_transcribe_diarize"
+_ENCODER_MAX_BATCH_SIZE = 2
 
 
 class MossTranscribeDiarizePipelineConfig(PipelineConfig):
@@ -37,6 +38,7 @@ class MossTranscribeDiarizePipelineConfig(PipelineConfig):
                 "device": "cuda:0",
                 "max_running_requests": 16,
                 "encoder_cache_size_bytes": 4 * 1024**3,
+                "encoder_max_batch_size": _ENCODER_MAX_BATCH_SIZE,
                 "request_build_max_workers": 8,
                 "request_build_max_pending": 16,
             },

--- a/sglang_omni/models/moss_transcribe_diarize/encoder_service.py
+++ b/sglang_omni/models/moss_transcribe_diarize/encoder_service.py
@@ -26,8 +26,11 @@ _CACHE_MAX_BYTES = 2 * 1024**3
 class BatchedAudioEncoderService:
     ENCODE_TIMEOUT_S = 300.0
 
-    def __init__(self, model: Any) -> None:
+    def __init__(self, model: Any, *, max_batch_size: int = 2) -> None:
+        if max_batch_size < 1:
+            raise ValueError("max_batch_size must be >= 1")
         self._model = model
+        self._max_batch_size = int(max_batch_size)
         self._device = next(model.whisper_encoder.parameters()).device
         self._stream = torch.cuda.Stream(device=self._device)
         self._cache = StageOutputCache(
@@ -60,7 +63,7 @@ class BatchedAudioEncoderService:
     def _drain_batch(self) -> list[tuple[Any, concurrent.futures.Future]]:
         # note (yichi): never wait — a window costs 8~16ms at low concurrency, buys <=5ms at high.
         batch = [self._queue.get()]
-        while True:
+        for _ in range(self._max_batch_size - 1):
             try:
                 batch.append(self._queue.get_nowait())
             except queue.Empty:

--- a/sglang_omni/models/moss_transcribe_diarize/stages.py
+++ b/sglang_omni/models/moss_transcribe_diarize/stages.py
@@ -106,6 +106,7 @@ def create_sglang_moss_transcribe_diarize_executor(
     async_decode_min_batch_size: int = 2,
     encoder_chunk_buckets: list[int] | None = None,
     encoder_torch_compile: bool = False,
+    encoder_max_batch_size: int = 2,
     # note (yichi): 8 parallel mel extractions measured optimal; fewer starve
     # the encoder feed, more oversubscribe the CPU.
     request_build_max_workers: int = 8,
@@ -189,7 +190,10 @@ def create_sglang_moss_transcribe_diarize_executor(
         capture_hidden_layers=None,
         model=model_worker.model_runner.model,
     )
-    audio_encoder_service = BatchedAudioEncoderService(model_worker.model_runner.model)
+    audio_encoder_service = BatchedAudioEncoderService(
+        model_worker.model_runner.model,
+        max_batch_size=encoder_max_batch_size,
+    )
 
     request_builder, result_adapter = make_moss_transcribe_diarize_scheduler_adapters(
         processor=processor,

--- a/sglang_omni/models/moss_tts/config.py
+++ b/sglang_omni/models/moss_tts/config.py
@@ -48,6 +48,7 @@ class MossTTSPipelineConfig(PipelineConfig):
     ) -> dict[tuple[str, str], dict[str, float]]:
         return {
             ("tts_engine", "vocoder"): {
+                "preprocessing": 0.05,
                 "tts_engine": 0.85,
                 "vocoder": 0.10,
             }

--- a/tests/unit_test/moss_transcribe_diarize/test_encoder_service.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_encoder_service.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import concurrent.futures
+import queue
+
+import pytest
+
+from sglang_omni.models.moss_transcribe_diarize.encoder_service import (
+    BatchedAudioEncoderService,
+)
+
+
+def test_drain_batch_respects_gpu_microbatch_limit() -> None:
+    service = object.__new__(BatchedAudioEncoderService)
+    service._max_batch_size = 2
+    service._queue = queue.Queue()
+    entries = [
+        (object(), concurrent.futures.Future())
+        for _ in range(service._max_batch_size + 2)
+    ]
+    for entry in entries:
+        service._queue.put(entry)
+
+    assert service._drain_batch() == entries[:2]
+    assert service._queue.qsize() == 2
+
+
+def test_encoder_microbatch_limit_must_be_positive() -> None:
+    with pytest.raises(ValueError, match="max_batch_size must be >= 1"):
+        BatchedAudioEncoderService(object(), max_batch_size=0)

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -33,6 +33,7 @@ def test_moss_transcribe_diarize_config_uses_single_batched_stage() -> None:
     )
     assert config.stages[0].factory_args["device"] == "cuda:0"
     assert config.stages[0].factory_args["max_running_requests"] == 16
+    assert config.stages[0].factory_args["encoder_max_batch_size"] == 2
     assert config.stages[0].factory_args["request_build_max_workers"] == 8
     assert config.stages[0].factory_args["request_build_max_pending"] == 16
     assert (
@@ -56,6 +57,7 @@ def test_moss_transcribe_diarize_stage_reserves_encoder_headroom() -> None:
     assert signature.parameters["mem_fraction_static"].default == 0.80
     assert signature.parameters["request_build_max_workers"].default == 8
     assert signature.parameters["request_build_max_pending"].default == 16
+    assert signature.parameters["encoder_max_batch_size"].default == 2
     assert signature.parameters["mm_embedding_cache_size_bytes"].default == 0
     assert signature.parameters["encoder_chunk_buckets"].default is None
     assert signature.parameters["encoder_torch_compile"].default is False
@@ -138,6 +140,7 @@ def _stub_factory_env(monkeypatch: pytest.MonkeyPatch, *, want_cuda_graph: bool)
         "init_device_graphs": 0,
         "compile_encoder": [],
         "init_encoder_graphs": [],
+        "encoder_services": [],
     }
     model = SimpleNamespace(
         compile_encoder=lambda buckets, feat_len: calls["compile_encoder"].append(
@@ -177,7 +180,12 @@ def _stub_factory_env(monkeypatch: pytest.MonkeyPatch, *, want_cuda_graph: bool)
         stages, "create_sglang_infrastructure_defer_cuda_graph", lambda *a, **k: infra
     )
     monkeypatch.setattr(stages, "init_mm_embedding_cache", lambda n: None)
-    monkeypatch.setattr(stages, "BatchedAudioEncoderService", lambda model: object())
+
+    def _make_encoder_service(model, *, max_batch_size):
+        calls["encoder_services"].append((model, max_batch_size))
+        return object()
+
+    monkeypatch.setattr(stages, "BatchedAudioEncoderService", _make_encoder_service)
     monkeypatch.setattr(
         stages,
         "make_moss_transcribe_diarize_scheduler_adapters",
@@ -206,6 +214,8 @@ def test_factory_compiles_encoder_and_skips_cuda_graph_when_flag_on(
     assert len(calls["compile_encoder"]) == 1
     assert calls["init_encoder_graphs"] == []
     assert calls["init_device_graphs"] == 1
+    assert len(calls["encoder_services"]) == 1
+    assert calls["encoder_services"][0][1] == 2
 
 
 def _repo_not_found(url: str) -> RepositoryNotFoundError:

--- a/tests/unit_test/pipeline/test_topology.py
+++ b/tests/unit_test/pipeline/test_topology.py
@@ -553,14 +553,15 @@ def test_moss_split_rejects_vocoder_isolation_as_not_process_safe() -> None:
 
 
 @pytest.mark.parametrize(
-    "config_path",
+    ("config_path", "expected_memory_fraction"),
     [
-        "sglang_omni.models.qwen3_tts.config.Qwen3TTSPipelineConfig",
-        "sglang_omni.models.moss_tts.config.MossTTSPipelineConfig",
+        ("sglang_omni.models.qwen3_tts.config.Qwen3TTSPipelineConfig", 0.95),
+        ("sglang_omni.models.moss_tts.config.MossTTSPipelineConfig", 1.0),
     ],
 )
 def test_ar_to_vocoder_boundary_isolates_with_declared_contract(
     config_path: str,
+    expected_memory_fraction: float,
 ) -> None:
     """Preprocessing is process-local for these models but the vocoder is not."""
     from sglang_omni.utils.imports import import_string
@@ -578,7 +579,7 @@ def test_ar_to_vocoder_boundary_isolates_with_declared_contract(
     ]
     assert build_stage_placement_plan(isolated).gpus[
         0
-    ].total_gpu_memory_fraction == pytest.approx(0.95)
+    ].total_gpu_memory_fraction == pytest.approx(expected_memory_fraction)
 
 
 def test_stage_process_singleton_matches_isolate_stage_resources() -> None:
@@ -1132,26 +1133,6 @@ def test_same_gpu_multiple_processes_accepts_explicit_budgets() -> None:
         model_path="dummy",
         stages=[
             _stage("a", gpu=0, fraction=0.20, process="p0", next_stage="b"),
-            _stage("b", gpu=0, fraction=0.30, process="p0", next_stage="c"),
-            _stage("c", gpu=0, fraction=0.40, process="p1", terminal=True),
-        ],
-    )
-
-    topology = _topology(config)
-
-    assert [
-        (group.name, group.stage_names, group.gpu_id) for group in topology.groups
-    ] == [
-        ("p0", ("a", "b"), 0),
-        ("p1", ("c",), 0),
-    ]
-
-
-def test_same_gpu_multiple_processes_accepts_one_budget_per_process() -> None:
-    config = PipelineConfig(
-        model_path="dummy",
-        stages=[
-            _stage("a", gpu=0, process="p0", next_stage="b"),
             _stage("b", gpu=0, fraction=0.30, process="p0", next_stage="c"),
             _stage("c", gpu=0, fraction=0.40, process="p1", terminal=True),
         ],

--- a/tests/unit_test/pipeline/test_topology.py
+++ b/tests/unit_test/pipeline/test_topology.py
@@ -1147,6 +1147,26 @@ def test_same_gpu_multiple_processes_accepts_explicit_budgets() -> None:
     ]
 
 
+def test_same_gpu_multiple_processes_accepts_one_budget_per_process() -> None:
+    config = PipelineConfig(
+        model_path="dummy",
+        stages=[
+            _stage("a", gpu=0, process="p0", next_stage="b"),
+            _stage("b", gpu=0, fraction=0.30, process="p0", next_stage="c"),
+            _stage("c", gpu=0, fraction=0.40, process="p1", terminal=True),
+        ],
+    )
+
+    topology = _topology(config)
+
+    assert [
+        (group.name, group.stage_names, group.gpu_id) for group in topology.groups
+    ] == [
+        ("p0", ("a", "b"), 0),
+        ("p1", ("c",), 0),
+    ]
+
+
 def test_same_gpu_multiple_processes_rejects_missing_budget() -> None:
     config = PipelineConfig(
         model_path="dummy",


### PR DESCRIPTION
## Summary
- add the missing `0.05` preprocessing GPU budget to the MOSS-TTS process-edge resource contract
- keep generic topology validation strict
- update the isolation regression test for MOSS's complete `1.0` GPU budget

Fixes the integration regression between #1125 and #1222.

## Test plan
- [x] `pre-commit run --files sglang_omni/config/topology.py sglang_omni/models/moss_tts/config.py tests/unit_test/pipeline/test_topology.py`
- [ ] PR unit-test CI