### PR TITLE
[Perf] Run the MOSS-TTS-Local vocoder in its own process

### DIFF
--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -38,6 +38,21 @@ def _stages(*, codec_device: str, colocated: bool) -> list[StageConfig]:
             mem_fraction_static=None if colocated else _AR_MEM_FRACTION_STATIC
         ),
     )
+
+    # Note: (Jiaxin Deng) the codec stages carry the same budgets
+    # process_edge_resources prescribes for the split, so the isolated topology
+    # is the declared one rather than an override applied at startup. Each stage
+    # needs its own instance: pydantic assigns these by reference, and
+    # _apply_process_edge_resources rebinds stage.runtime.resources in place.
+    def codec_runtime() -> StageRuntimeConfig:
+        return StageRuntimeConfig(
+            resources=StageResourceConfig(
+                total_gpu_memory_fraction=(
+                    _COLOCATED_CODEC_GPU_MEMORY_FRACTION if colocated else None
+                )
+            )
+        )
+
     tts_engine_args: dict[str, Any] = {"dtype": "bfloat16"}
     if colocated:
         tts_engine_args["codec_mem_reserve"] = _COLOCATED_CODEC_MEM_RESERVE
@@ -49,6 +64,7 @@ def _stages(*, codec_device: str, colocated: bool) -> list[StageConfig]:
             factory=f"{_PKG}.stages.create_preprocessing_executor",
             factory_args={"device": codec_device},
             gpu=0,
+            runtime=codec_runtime(),
             next="tts_engine",
         ),
         StageConfig(
@@ -63,10 +79,11 @@ def _stages(*, codec_device: str, colocated: bool) -> list[StageConfig]:
         ),
         StageConfig(
             name="vocoder",
-            process="pipeline",
+            process="vocoder" if colocated else "pipeline",
             factory=f"{_PKG}.stages.create_vocoder_executor",
             factory_args={"device": codec_device},
             gpu=0,
+            runtime=codec_runtime(),
             terminal=True,
             can_accept_stream_before_payload=True,
         ),

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -398,7 +398,9 @@ def test_pipeline_stage_wiring():
     assert stages["preprocessing"].factory_args["device"] == "cuda:0"
     assert stages["preprocessing"].factory_args["ref_audio_cache"] is True
     assert stages["preprocessing"].factory_args["ref_audio_cache_max_items"] == 8192
-    assert stages["preprocessing"].runtime.resources.total_gpu_memory_fraction is None
+    assert stages[
+        "preprocessing"
+    ].runtime.resources.total_gpu_memory_fraction == pytest.approx(0.05)
     assert config.supports_uploaded_voice_references() is True
     assert stages["tts_engine"].process == "pipeline"
     assert stages["tts_engine"].gpu == 0
@@ -406,10 +408,18 @@ def test_pipeline_stage_wiring():
     assert tts_engine_runtime.resources.total_gpu_memory_fraction == pytest.approx(0.90)
     assert tts_engine_runtime.sglang_server_args.mem_fraction_static is None
     assert stages["tts_engine"].factory_args["codec_mem_reserve"] == pytest.approx(0.15)
-    assert stages["vocoder"].process == "pipeline"
+    assert stages["vocoder"].process == "vocoder"
     assert stages["vocoder"].gpu == 0
     assert stages["vocoder"].factory_args["device"] == "cuda:0"
-    assert stages["vocoder"].runtime.resources.total_gpu_memory_fraction is None
+    assert stages[
+        "vocoder"
+    ].runtime.resources.total_gpu_memory_fraction == pytest.approx(0.05)
+
+    topology = build_process_topology_plan(config, build_stage_placement_plan(config))
+    assert [(group.name, group.stage_names) for group in topology.groups] == [
+        ("pipeline", ("preprocessing", "tts_engine")),
+        ("vocoder", ("vocoder",)),
+    ]
 
     placement = build_stage_placement_plan(config)
     assert placement.stages["tts_engine"].gpu_ids == (0,)

--- a/tests/unit_test/pipeline/test_topology.py
+++ b/tests/unit_test/pipeline/test_topology.py
@@ -339,7 +339,7 @@ def test_process_override_rejects_fused_stage_component() -> None:
         apply_stage_process_overrides(config, isolate_stages=["b"])
 
 
-def test_moss_tts_local_preserves_default_and_can_isolate_vocoder() -> None:
+def test_moss_tts_local_isolates_vocoder_by_default() -> None:
     from sglang_omni.models.moss_tts_local.config import MossTTSLocalPipelineConfig
 
     config = MossTTSLocalPipelineConfig(model_path="dummy")
@@ -348,49 +348,56 @@ def test_moss_tts_local_preserves_default_and_can_isolate_vocoder() -> None:
         for stage in config.stages
         if stage.gpu is not None
     } == {
-        "preprocessing": None,
+        "preprocessing": 0.05,
         "tts_engine": 0.90,
-        "vocoder": None,
+        "vocoder": 0.05,
     }
     assert [stage.process for stage in config.stages] == [
         "pipeline",
         "pipeline",
-        "pipeline",
-    ]
-    assert _topology(config).groups[0].stage_names == (
-        "preprocessing",
-        "tts_engine",
         "vocoder",
-    )
-
-    isolated = apply_stage_process_overrides(config, isolate_stages=["vocoder"])
-
-    assert [stage.process for stage in config.stages] == [
-        "pipeline",
-        "pipeline",
-        "pipeline",
     ]
-    assert [
-        (group.name, group.stage_names) for group in _topology(isolated).groups
-    ] == [
+    assert [(group.name, group.stage_names) for group in _topology(config).groups] == [
         ("pipeline", ("preprocessing", "tts_engine")),
         ("vocoder", ("vocoder",)),
     ]
     assert build_stage_placement_plan(config).gpus[
         0
-    ].total_gpu_memory_fraction == pytest.approx(0.90)
-    assert {
-        stage.name: stage.runtime.resources.total_gpu_memory_fraction
-        for stage in isolated.stages
-        if stage.gpu is not None
-    } == {
-        "preprocessing": 0.05,
-        "tts_engine": 0.90,
-        "vocoder": 0.05,
-    }
-    assert build_stage_placement_plan(isolated).gpus[
-        0
     ].total_gpu_memory_fraction == pytest.approx(1.0)
+
+    # The new default is exactly what --isolate-stage vocoder used to produce.
+    # Rebuild the pre-change topology and run the flag over it. Comparing the
+    # new config against itself would prove nothing: the override early-returns
+    # for a stage that already runs alone.
+    legacy = config.model_copy(deep=True)
+    for name in ("preprocessing", "vocoder"):
+        stage = next(item for item in legacy.stages if item.name == name)
+        stage.process = "pipeline"
+        stage.runtime.resources = StageResourceConfig()
+    assert [stage.process for stage in legacy.stages] == ["pipeline"] * 3
+    assert (
+        apply_stage_process_overrides(legacy, isolate_stages=["vocoder"]).model_dump()
+        == config.model_dump()
+    )
+
+    # --isolate-stage vocoder stays accepted on the new default and changes
+    # nothing, so existing launch commands keep working.
+    assert (
+        apply_stage_process_overrides(config, isolate_stages=["vocoder"]).model_dump()
+        == config.model_dump()
+    )
+
+    # The codec stages must not share one runtime block: pydantic assigns it by
+    # reference, and _apply_process_edge_resources rebinds stage.runtime.resources
+    # in place, so a shared instance would let one budget overwrite the other.
+    stages = {stage.name: stage for stage in config.stages}
+    assert stages["preprocessing"].runtime is not stages["vocoder"].runtime
+    stages["preprocessing"].runtime.resources = StageResourceConfig(
+        total_gpu_memory_fraction=0.42
+    )
+    assert stages[
+        "vocoder"
+    ].runtime.resources.total_gpu_memory_fraction == pytest.approx(0.05)
 
 
 def test_ming_tts_preserves_default_and_can_isolate_vocoder_role() -> None:


### PR DESCRIPTION
## Motivation

MOSS-TTS-Local's colocated pipeline runs `preprocessing`, `tts_engine` and
`vocoder` in a single process group (`process="pipeline"`). The AR decode loop
and the codec are both Python-side kernel launchers, so on one card they contend
for one GIL while the GPU sits at roughly 63% utilisation. Higgs-TTS already
ships the vocoder in its own process group; this brings MOSS-TTS-Local in line.

The split itself is not new: `--isolate-stage vocoder` (#1125) has been able to
produce it since that PR landed, and `process_safe_edges()` /
`process_edge_resources()` for the `(tts_engine, vocoder)` edge are already
declared. What changes here is the default.

## Modifications

`_stages()` in `models/moss_tts_local/config.py`:

* `vocoder` gets `process="vocoder"` when the topology is colocated. The `split`
  variant, which runs the codec on a second card and declares no per-stage
  budgets, keeps the shared process.
* `preprocessing` and `vocoder` each declare
  `total_gpu_memory_fraction=0.05` when colocated, the values
  `process_edge_resources()` already prescribes for that edge.
* Each codec stage gets its own `StageRuntimeConfig` instance. Pydantic assigns
  these by reference, and `_apply_process_edge_resources` rebinds
  `stage.runtime.resources` in place, so a single shared instance would let one
  stage's budget silently overwrite the other's. A test covers this.

`--isolate-stage vocoder` remains accepted and becomes a no-op, so existing
launch commands keep working.

## Benchmarking

One H100, `OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5`,
`--max-running-requests 64 --cuda-graph-max-bs 64 --decode-mode async`. SeedTTS
EN, 256 samples, streaming, `--generate-only`. Server pinned to cores 0-23,
client to 24-31, `--membind=0`. ABAB with the server restarted between every
leg and the card drained below 300 MiB in between. This is a shared host, so
box loadavg was recorded per leg and contaminated rounds were discarded and
re-run rather than averaged in.

### Throughput (req/s)

| Concurrency | Round | Before | After | Change |
|---|---|---|---|---|
| 32 | 1 | 8.745 | 11.923 | +36.3% |
| 32 | 2 | 8.826 | 11.926 | +35.1% |
| 32 | 3 | 8.753 | 11.885 | +35.8% |
| 8 | 1 | 6.491 | 7.043 | +8.5% |
| 8 | 2 | 6.370 | 7.056 | +10.8% |
| 8 | 3 | 6.571 | 7.034 | +7.0% |

### Latency and utilisation at c=32

| Metric | Before | After |
|---|---|---|
| Latency mean (s) | 3.553 / 3.530 | 2.569 / 2.579 |
| Latency p95 (s) | 4.251 / 4.367 | 3.374 / 3.316 |
| Latency p99 (s) | 4.730 / 4.646 | 3.807 / 3.805 |
| Audio seconds per second | 37.21 / 37.55 | 50.73 / 50.73 |
| GPU util mean | 63.5% / 70.4% | 69.4% / 73.4% |
| Failed requests | 0 | 0 |

### The default itself, not just the flag

Launching each build with no flags at all:

| Build | Stage groups | req/s | Latency mean (s) | Card memory |
|---|---|---|---|---|
| main | 1 | 8.862 | 3.509 | 69725 MiB |
| this PR | 2 | 11.920 | 2.580 | 70803 MiB |

### Quality

WER over the audio those runs already produced, via `--transcribe-only` against
one Qwen3-ASR-1.7B server. 256/256 evaluated, 0 skipped on every arm.

| Arm | corpus WER | excluding >50% outliers |
|---|---|---|
| c32 before, rounds 1/2/3 | 1.53% / 1.93% / 1.60% | 1.53% / 1.54% / 1.60% |
| c32 after, rounds 1/2/3 | 1.53% / 1.24% / 1.93% | 1.53% / 1.10% / 1.28% |
| c8 before / after, round 1 | 1.78% / 2.44% | 1.57% / 1.72% |

No regression. The before column sits on the 1.54% this repo documents for
MOSS-TTS EN on the full set; on a 256-sample subset one bad sample moves the raw
micro-average by about 0.4 points, which is what the raw column shows.

### Controls

* **Not a memory-budget effect.** Both topologies allocate the same KV pool
  (`KV Cache is allocated. #tokens: 337459`) and log the same
  `effective_total_gpu_memory_fraction=0.75 codec_mem_reserve=0.150`. The extra
  0.05 + 0.05 goes to the codec stages, outside the AR engine's budget.
* **Cost.** One extra process and 1078 MiB of card memory for its CUDA context
  and graphs.
* **Where it does not pay.** The gain tracks how much the two stages actually
  contend, so it has to be measured per pipeline rather than assumed. Voxtral,
  which already runs at 15.7 req/s with the GPU a third busy, gains about 2.5%.
  Qwen3-TTS and MOSS-TTS delay measured as noise around zero across three rounds
  each. This PR therefore changes one model's default, not everyone's.
* **It needs spare host cores.** During a spike that took box loadavg from 22 to
  149, the isolated arm fell below the shared-process baseline. On a
  CPU-saturated host this buys nothing.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
