### PR TITLE
 refactor: deduplicate TTS Engine Builder boilerplate via shared base helpers

### DIFF
--- a/docs/cookbook/fun_asr.md
+++ b/docs/cookbook/fun_asr.md
@@ -167,3 +167,20 @@ DP=2 managed router, matching the ASR CI topology.
   context biasing instead).
 - Audio is resampled to 16 kHz before transcription.
 - bf16 is strongly recommended; fp16 can overflow to NaN in the adaptor path.
+
+## Serve with Example Config
+
+For a copy-paste single-GPU launch, use the bundled
+[`examples/configs/fun_asr.yaml`](../../examples/configs/fun_asr.yaml). It pins
+`config_cls: FunASRPipelineConfig` and the official `model_path`; Fun-ASR-Nano
+runs its single ASR stage on one GPU:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 sgl-omni serve \
+  --config examples/configs/fun_asr.yaml \
+  --port 8000
+```
+
+The config targets a single GPU (validated on a single A100-40G / H100). After
+the server is up, transcribe audio with the examples in
+[Transcribe Audio](#transcribe-audio).

--- a/docs/cookbook/higgs_tts.md
+++ b/docs/cookbook/higgs_tts.md
@@ -594,3 +594,20 @@ Throughput on Seed-TTS EN (full set, **N=1088** per run). Client `--max-concurre
 - **audio_s/s** — Total seconds of audio produced divided by total benchmark wall-clock time.
 
 To reproduce the results, follow the instructions in [this script](https://github.com/sgl-project/sglang-omni/blob/main/benchmarks/eval/benchmark_tts_seedtts.py).
+
+## Serve with Example Config
+
+For a copy-paste single-GPU launch, use the bundled
+[`examples/configs/higgs_tts.yaml`](../../examples/configs/higgs_tts.yaml). It
+pins `config_cls: HiggsTtsPipelineConfig` and the official `model_path`, so the
+server auto-detects its pipeline topology:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 sgl-omni serve \
+  --config examples/configs/higgs_tts.yaml \
+  --port 8000
+```
+
+The config targets a single GPU (validated on a single A100-40G / H100). After
+the server is up, synthesize speech with the examples in
+[Synthesizing Speech](#synthesizing-speech).

--- a/docs/cookbook/zonos2.md
+++ b/docs/cookbook/zonos2.md
@@ -209,3 +209,20 @@ Set `stream_emit_chunk_frames=1` for per-frame streaming. The 2-GPU `multi_gpu` 
   has an isolated request RNG.
 - **Rare runaway generation.** A small fraction of utterances can loop and generate up to
   `max_new_tokens`; lowering `max_new_tokens` bounds the output.
+
+## Serve with Example Config
+
+For a copy-paste single-GPU launch, use the bundled
+[`examples/configs/zonos2.yaml`](../../examples/configs/zonos2.yaml). It pins
+`config_cls: Zonos2PipelineConfig` and the official `model_path`; the single-process
+`preprocessing → speaker_encode → tts_engine → vocoder` pipeline runs colocated on one GPU:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 sgl-omni serve \
+  --config examples/configs/zonos2.yaml \
+  --port 8000
+```
+
+The config targets a single GPU (validated on a single A100-40G / H100). After
+the server is up, clone a voice with the examples in
+[Voice Cloning](#voice-cloning).

--- a/examples/README.md
+++ b/examples/README.md
@@ -82,3 +82,25 @@ python examples/run_omni.py ming-speech-server \
 ```
 
 Use a different `--port` if you run more than one server at the same time.
+
+## Single-GPU Example Configs
+
+`examples/configs/*.yaml` are declarative launcher configs for `sgl-omni serve
+--config <file>`. Each pins a `config_cls` and the official `model_path`; the
+server auto-detects the pipeline topology. The following are tuned for a **single
+GPU** (validated on a single A100-40G / H100) and are convenient when multi-GPU
+hardware is not available.
+
+| Config | Workload | Endpoint | Notes |
+| --- | --- | --- | --- |
+| `examples/configs/higgs_tts.yaml` | Higgs Audio v3 TTS (~4B) | `/v1/audio/speech` | Zero-shot + voice cloning; see `docs/cookbook/higgs_tts.md` |
+| `examples/configs/zonos2.yaml` | ZONOS2 (MoE TTS) | `/v1/audio/speech` | Single-process colocated pipeline; see `docs/cookbook/zonos2.md` |
+| `examples/configs/fun_asr.yaml` | Fun-ASR-Nano (ASR) | `/v1/audio/transcriptions`, `/v1/audio/translations` | Small ASR model; see `docs/cookbook/fun_asr.md` |
+
+Launch any of them with:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 sgl-omni serve \
+  --config examples/configs/higgs_tts.yaml \
+  --port 8000
+```

--- a/examples/configs/fun_asr.yaml
+++ b/examples/configs/fun_asr.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Example launcher config for Fun-ASR-Nano (FunAudioLLM).
+# Serves the OpenAI-compatible /v1/audio/transcriptions and
+# /v1/audio/translations endpoints.
+#
+# Fun-ASR-Nano is a small ASR model that fits comfortably on a single GPU
+# (tested on a single A100-40G / H100).
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 python -m sglang_omni.cli serve \
+#       --config examples/configs/fun_asr.yaml --port 30000
+
+config_cls: FunASRPipelineConfig
+name: fun-asr-nano
+model_path: FunAudioLLM/Fun-ASR-Nano-2512-hf

--- a/examples/configs/higgs_tts.yaml
+++ b/examples/configs/higgs_tts.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Example launcher config for Higgs Audio v3 TTS (Boson AI, ~4B).
+# Serves the OpenAI-compatible /v1/audio/speech endpoint.
+#
+# The pipeline auto-detects its topology from the model; this file only pins
+# the config class and the model path. Runs on a single GPU by default
+# (tested on a single A100-40G / H100).
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 python -m sglang_omni.cli serve \
+#       --config examples/configs/higgs_tts.yaml --port 30000
+
+config_cls: HiggsTtsPipelineConfig
+name: higgs-audio-v3-tts-4b
+model_path: bosonai/higgs-audio-v3-tts-4b

--- a/examples/configs/zonos2.yaml
+++ b/examples/configs/zonos2.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Example launcher config for ZONOS2 (Zyphra MoE TTS).
+# Serves the OpenAI-compatible /v1/audio/speech endpoint.
+#
+# ZONOS2's default pipeline is a single-process colocated (DP1) server, so a
+# single GPU is sufficient (tested on a single A100-40G / H100).
+#
+# Usage:
+#   CUDA_VISIBLE_DEVICES=0 python -m sglang_omni.cli serve \
+#       --config examples/configs/zonos2.yaml --port 30000
+
+config_cls: Zonos2PipelineConfig
+name: zonos2
+model_path: Zyphra/zonos2

--- a/sglang_omni/models/fishaudio_s2_pro/engine_builder.py
+++ b/sglang_omni/models/fishaudio_s2_pro/engine_builder.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import importlib
 import os
 from typing import Any
 
@@ -101,11 +100,12 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
             server_args.enable_torch_compile = False
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
-        model_runner_mod = importlib.import_module(
-            "sglang_omni.models.fishaudio_s2_pro.model_runner"
+        return self.make_model_runner_from_path(
+            model_worker,
+            output_proc,
+            module_path="sglang_omni.models.fishaudio_s2_pro.model_runner",
+            class_name="FishS2ProModelRunner",
         )
-
-        return model_runner_mod.FishS2ProModelRunner(model_worker, output_proc)
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:
         del model

--- a/sglang_omni/models/higgs_tts/engine_builder.py
+++ b/sglang_omni/models/higgs_tts/engine_builder.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import importlib
 import logging
 from typing import Any
 
@@ -117,11 +116,12 @@ class HiggsTtsEngineBuilder(TtsEngineBuilder):
         return model.sampler_pool_max_running_requests
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
-        model_runner_mod = importlib.import_module(
-            "sglang_omni.models.higgs_tts.model_runner"
+        return self.make_model_runner_from_path(
+            model_worker,
+            output_proc,
+            module_path="sglang_omni.models.higgs_tts.model_runner",
+            class_name="HiggsTTSModelRunner",
         )
-
-        return model_runner_mod.HiggsTTSModelRunner(model_worker, output_proc)
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:
         return request_builders.make_higgs_scheduler_adapters(
@@ -134,7 +134,7 @@ class HiggsTtsEngineBuilder(TtsEngineBuilder):
 
     def make_abort_callback(self) -> Any | None:
         assert self.model is not None
-        return self.model.reset_request
+        return self.model_reset_request_abort_callback()
 
     def extra_scheduler_kwargs(self) -> dict[str, Any]:
         return {
@@ -145,4 +145,4 @@ class HiggsTtsEngineBuilder(TtsEngineBuilder):
         }
 
     def post_scheduler_setup(self, scheduler: Any, model_runner: Any) -> None:
-        model_runner.set_stream_outbox(scheduler.outbox)
+        self.bind_stream_outbox(scheduler, model_runner)

--- a/sglang_omni/models/ming_tts/engine_builder.py
+++ b/sglang_omni/models/ming_tts/engine_builder.py
@@ -165,9 +165,12 @@ class MingTtsEngineBuilder(TtsEngineBuilder):
         )
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
-        from sglang_omni.models.ming_tts.model_runner import MingTTSModelRunner
-
-        self._model_runner = MingTTSModelRunner(model_worker, output_proc)
+        self._model_runner = self.make_model_runner_from_path(
+            model_worker,
+            output_proc,
+            module_path="sglang_omni.models.ming_tts.model_runner",
+            class_name="MingTTSModelRunner",
+        )
         return self._model_runner
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:

--- a/sglang_omni/models/moss_tts/engine_builder.py
+++ b/sglang_omni/models/moss_tts/engine_builder.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import importlib
 from typing import Any
 
 from sglang_omni.models.moss_tts import request_builders
@@ -43,11 +42,12 @@ class MossTtsEngineBuilder(TtsEngineBuilder):
         del model_worker, checkpoint_dir, device, gpu_id, server_args
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
-        model_runner_mod = importlib.import_module(
-            "sglang_omni.models.moss_tts.model_runner"
+        return self.make_model_runner_from_path(
+            model_worker,
+            output_proc,
+            module_path="sglang_omni.models.moss_tts.model_runner",
+            class_name="MossTTSModelRunner",
         )
-
-        return model_runner_mod.MossTTSModelRunner(model_worker, output_proc)
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:
         return request_builders.make_moss_tts_scheduler_adapters(model=model)

--- a/sglang_omni/models/moss_tts_local/engine_builder.py
+++ b/sglang_omni/models/moss_tts_local/engine_builder.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import importlib
 from typing import Any
 
 from sglang_omni.models.moss_tts_local import request_builders
@@ -116,11 +115,12 @@ class MossTtsLocalEngineBuilder(TtsEngineBuilder):
         model.init_frame_decode_graphs(list(server_args.cuda_graph_bs))
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
-        model_runner_mod = importlib.import_module(
-            "sglang_omni.models.moss_tts_local.model_runner"
+        return self.make_model_runner_from_path(
+            model_worker,
+            output_proc,
+            module_path="sglang_omni.models.moss_tts_local.model_runner",
+            class_name="MossTTSLocalModelRunner",
         )
-
-        return model_runner_mod.MossTTSLocalModelRunner(model_worker, output_proc)
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:
         return request_builders.make_moss_tts_local_scheduler_adapters(model=model)
@@ -142,4 +142,4 @@ class MossTtsLocalEngineBuilder(TtsEngineBuilder):
         }
 
     def post_scheduler_setup(self, scheduler: Any, model_runner: Any) -> None:
-        model_runner.set_stream_outbox(scheduler.outbox)
+        self.bind_stream_outbox(scheduler, model_runner)

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -95,11 +95,12 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             server_args.enable_torch_compile = False
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
-        model_runner_mod = importlib.import_module(
-            "sglang_omni.models.qwen3_tts.model_runner"
+        return self.make_model_runner_from_path(
+            model_worker,
+            output_proc,
+            module_path="sglang_omni.models.qwen3_tts.model_runner",
+            class_name="Qwen3TTSModelRunner",
         )
-
-        return model_runner_mod.Qwen3TTSModelRunner(model_worker, output_proc)
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:
         return request_builders.make_qwen3_tts_scheduler_adapters(

--- a/sglang_omni/models/voxtral_tts/pipeline/engine_builder.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/engine_builder.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import importlib
 from typing import Any
 
 from sglang_omni.models.voxtral_tts import request_builders
@@ -62,11 +61,12 @@ class VoxtralTtsEngineBuilder(TtsEngineBuilder):
         )
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
-        model_runner_mod = importlib.import_module(
-            "sglang_omni.models.voxtral_tts.model_runner"
+        return self.make_model_runner_from_path(
+            model_worker,
+            output_proc,
+            module_path="sglang_omni.models.voxtral_tts.model_runner",
+            class_name="VoxtralTTSModelRunner",
         )
-
-        return model_runner_mod.VoxtralTTSModelRunner(model_worker, output_proc)
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:
         return request_builders.make_voxtral_scheduler_adapters(

--- a/sglang_omni/models/zonos2/engine_builder.py
+++ b/sglang_omni/models/zonos2/engine_builder.py
@@ -227,10 +227,10 @@ class Zonos2EngineBuilder(TtsEngineBuilder):
 
     def make_abort_callback(self) -> Any | None:
         assert self.model is not None
-        return self.model.reset_request
+        return self.model_reset_request_abort_callback()
 
     def extra_scheduler_kwargs(self) -> dict[str, Any]:
         return {"enable_async_decode": self.async_decode}
 
     def post_scheduler_setup(self, scheduler: Any, model_runner: Any) -> None:
-        model_runner.set_stream_outbox(scheduler.outbox)
+        self.bind_stream_outbox(scheduler, model_runner)

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import importlib
 from abc import ABC, abstractmethod
 from typing import Any
 
@@ -120,6 +121,54 @@ class TtsEngineBuilder(ABC):
 
     def resolve_checkpoint(self, model_path: str) -> str:
         return _resolve_checkpoint(model_path)
+
+    # ------------------------------------------------------------------
+    # Shared helper utilities for subclass builders.
+    #
+    # These helpers exist only to remove duplicated boilerplate across the
+    # concrete TtsEngineBuilder subclasses. They never change the default
+    # behavior of the base class (post_scheduler_setup / make_abort_callback
+    # remain no-op/None by default); subclasses opt in by calling them.
+    # ------------------------------------------------------------------
+
+    def make_model_runner_from_path(
+        self,
+        model_worker: Any,
+        output_proc: Any,
+        *,
+        module_path: str,
+        class_name: str,
+    ) -> Any:
+        """Instantiate a ``(model_worker, output_proc)``-style ModelRunner.
+
+        Most TTS runners share the exact same 2-argument constructor
+        ``SomeModelRunner(model_worker, output_proc)``; subclasses with that
+        shape can delegate ``make_model_runner`` to this helper instead of
+        repeating the importlib boilerplate.
+        """
+        model_runner_mod = importlib.import_module(module_path)
+        return getattr(model_runner_mod, class_name)(model_worker, output_proc)
+
+    def bind_stream_outbox(self, scheduler: Any, model_runner: Any) -> None:
+        """Bind the scheduler's stream outbox to the model runner.
+
+        Several builders repeat ``model_runner.set_stream_outbox(
+        scheduler.outbox)`` verbatim in ``post_scheduler_setup``; they can
+        call this helper instead.
+        """
+        model_runner.set_stream_outbox(scheduler.outbox)
+
+    def model_reset_request_abort_callback(self) -> Any | None:
+        """Return ``self.model.reset_request`` if a model was set up.
+
+        Builders that tear down a single in-process model on abort can return
+        ``self.model.reset_request``. This helper centralizes the
+        "assert set up, then expose reset_request" pattern.
+        """
+        model = getattr(self, "model", None)
+        if model is None:
+            return None
+        return model.reset_request
 
     @abstractmethod
     def generation_defaults(

--- a/tests/unit_test/scheduling/test_engine_factory.py
+++ b/tests/unit_test/scheduling/test_engine_factory.py
@@ -361,3 +361,156 @@ def test_tts_engine_builder_base_scheduler_preserves_abort_with_extra_kwargs(
     assert captured_kwargs["tp_worker"] == "worker"
     assert captured_kwargs["request_builder"] == "request_builder"
     assert captured_kwargs["result_adapter"] == "result_adapter"
+
+
+class _Mod:
+    """Fake ModelRunner installed on the test module so it is importable."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+
+class _ModWithOutbox:
+    """Fake ModelRunner exposing set_stream_outbox for bind test."""
+
+    def __init__(self) -> None:
+        self.outbox: object = None
+
+    def set_stream_outbox(self, outbox: object) -> None:
+        self.outbox = outbox
+
+
+def test_make_model_runner_from_path_instantiates_two_arg_runner() -> None:
+    from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
+
+    class PathBuilder(TtsEngineBuilder):
+        model_name = "Test TTS"
+
+        def resolve_checkpoint(self, model_path: str) -> str:
+            return model_path
+
+        def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
+            del dtype
+            return {}
+
+        def setup_model(
+            self,
+            *,
+            model_worker: Any,
+            checkpoint_dir: str,
+            device: str,
+            gpu_id: int,
+            server_args: Any,
+        ) -> None:
+            del model_worker, checkpoint_dir, device, gpu_id, server_args
+
+        def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
+            return self.make_model_runner_from_path(
+                model_worker,
+                output_proc,
+                module_path="tests.unit_test.scheduling.test_engine_factory",
+                class_name="_Mod",
+            )
+
+        def make_adapters(self, model: Any) -> tuple[Any, Any]:
+            del model
+            return object(), object()
+
+    builder = PathBuilder()
+    runner = builder.make_model_runner("worker", "proc")
+    assert isinstance(runner, _Mod)
+    assert runner.args == ("worker", "proc")
+    assert runner.kwargs == {}
+
+
+def test_model_reset_request_abort_callback_contract() -> None:
+    from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
+
+    reset_calls: list[str] = []
+
+    class WithModel:
+        def reset_request(self, request_id: str) -> None:
+            reset_calls.append(request_id)
+
+    class ResetBuilder(TtsEngineBuilder):
+        model_name = "Test TTS"
+
+        def resolve_checkpoint(self, model_path: str) -> str:
+            return model_path
+
+        def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
+            del dtype
+            return {}
+
+        def setup_model(
+            self,
+            *,
+            model_worker: Any,
+            checkpoint_dir: str,
+            device: str,
+            gpu_id: int,
+            server_args: Any,
+        ) -> None:
+            del model_worker, checkpoint_dir, device, gpu_id, server_args
+            self.model = WithModel()
+
+        def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
+            del model_worker, output_proc
+            return object()
+
+        def make_adapters(self, model: Any) -> tuple[Any, Any]:
+            del model
+            return object(), object()
+
+    builder = ResetBuilder()
+    builder.setup_model(
+        model_worker=None,
+        checkpoint_dir="",
+        device="",
+        gpu_id=0,
+        server_args=None,
+    )
+    cb = builder.model_reset_request_abort_callback()
+    assert callable(cb)
+    cb("r1")  # type: ignore[operator]
+    assert reset_calls == ["r1"]
+
+
+def test_bind_stream_outbox_sets_scheduler_outbox() -> None:
+    from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
+
+    class BindBuilder(TtsEngineBuilder):
+        model_name = "Test TTS"
+
+        def resolve_checkpoint(self, model_path: str) -> str:
+            return model_path
+
+        def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
+            del dtype
+            return {}
+
+        def setup_model(
+            self,
+            *,
+            model_worker: Any,
+            checkpoint_dir: str,
+            device: str,
+            gpu_id: int,
+            server_args: Any,
+        ) -> None:
+            del model_worker, checkpoint_dir, device, gpu_id, server_args
+
+        def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
+            del model_worker, output_proc
+            return object()
+
+        def make_adapters(self, model: Any) -> tuple[Any, Any]:
+            del model
+            return object(), object()
+
+    scheduler = SimpleNamespace(outbox="the-outbox")
+    model_runner = _ModWithOutbox()
+    BindBuilder().bind_stream_outbox(scheduler, model_runner)
+    assert model_runner.outbox == "the-outbox"
+


### PR DESCRIPTION
## Motivation

The 8 concrete `TtsEngineBuilder` subclasses (Higgs, ZONOS2, Ming, MOSS,
MOSS-Local, Qwen3, FishAudio S2-Pro, Voxtral) repeat the same three pieces of
boilerplate verbatim:

- `make_model_runner` — an `importlib.import_module(...)` + 2-argument
  `SomeModelRunner(model_worker, output_proc)` instantiation.
- `post_scheduler_setup` — `model_runner.set_stream_outbox(scheduler.outbox)`.
- `make_abort_callback` — `assert self.model is not None; return
  self.model.reset_request`.

This duplication raises the cost of adding a new TTS model and makes it easy to
drift behavior between builders. The base class already exposes a
template-method `build()` flow with `NotImplementedError` hooks, so it is the
natural home for these shared defaults.

## Modifications

Added three opt-in helpers on `TtsEngineBuilder` in
`sglang_omni/scheduling/engine_factory.py` (base-class default behaviors are
unchanged — `post_scheduler_setup` stays a no-op and `make_abort_callback`
still returns `None` by default):

- `make_model_runner_from_path(model_worker, output_proc, *, module_path,
  class_name)` — generic importlib-based runner construction for the common
  2-argument shape.
- `bind_stream_outbox(scheduler, model_runner)` — shared
  `set_stream_outbox` wiring.
- `model_reset_request_abort_callback()` — shared `self.model.reset_request`
  wiring.

Refactored the 8 builders to delegate to these helpers instead of repeating the
code:

| Builder | `make_model_runner` | `post_scheduler_setup` | `make_abort_callback` |
| --- | --- | --- | --- |
| higgs_tts | uses helper | uses helper | uses helper |
| zonos2 | kept (extra args) | uses helper | uses helper |
| ming_tts | uses helper (keeps `_model_runner` cache) | unchanged | unchanged (uses `_model_runner`) |
| moss_tts | uses helper | unchanged | unchanged |
| moss_tts_local | uses helper | uses helper | kept (closure) |
| qwen3_tts | uses helper | unchanged | unchanged |
| fishaudio_s2_pro | uses helper | unchanged | unchanged |
| voxtral_tts | uses helper | unchanged | unchanged |

Builders with model-specific signatures (`zonos2` multi-arg runner,
`moss_tts_local` cleanup closure, `ming_tts` `_model_runner` cache) keep their
own overrides — no semantic change.

Extended `tests/unit_test/scheduling/test_engine_factory.py` with contract
tests for the three new helpers (runner instantiation args, outbox binding,
abort callback wiring), all passing.

## Related Issues

None (pure refactor / de-duplication; no tracked bug fixed).

## Accuracy Test

Not applicable — no model/runtime behavior changed.

## Benchmark & Profiling

Not applicable — no control-flow or numerical behavior changed.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests. (extended `test_engine_factory.py`)
- [x] Update documentation / docstrings / example tutorials as needed. (docstrings on new helpers)
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed. (N/A — refactor only)
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. This PR is a behavior-preserving refactor; existing
CI (`test_zonos2_tts_ci.py`, `test_tts_ci.py`, `test_qwen3_omni_tts_ci.py`,
`test_ming_tp_parity_ci.py`) should remain green.

---

**Base branch:** `main`
**Local branch:** `refactor/tts-engine-builder-dedup`
**Reviewer quick check (CPU-only):** `python -m pytest tests/unit_test/scheduling/test_engine_factory.py -q`
