### PR TITLE
[Perf] Raise the MOSS-Transcribe-Diarize concurrent-request cap to 32

### DIFF
--- a/sglang_omni/models/moss_transcribe_diarize/config.py
+++ b/sglang_omni/models/moss_transcribe_diarize/config.py
@@ -20,6 +20,7 @@ from sglang_omni.models.moss_transcribe_diarize import (  # noqa: F401
 from sglang_omni.utils.cpu import bounded_intraop_threads
 
 _PKG = "sglang_omni.models.moss_transcribe_diarize"
+_MAX_RUNNING_REQUESTS = 32
 _REQUEST_BUILD_MAX_WORKERS = 8
 _ENCODER_MAX_BATCH_SIZE = 2
 _ENCODER_CACHE_SIZE_BYTES = 4 * 1024**3
@@ -67,7 +68,7 @@ class MossTranscribeDiarizePipelineConfig(PipelineConfig):
                 prefill_coalesce_after_builds_during_decode=True,
             ),
             engine=EngineArgs(
-                max_running_requests=16,
+                max_running_requests=_MAX_RUNNING_REQUESTS,
                 enable_torch_compile=True,
                 torch_compile_max_bs=4,
             ),

--- a/sglang_omni/models/moss_transcribe_diarize/stages.py
+++ b/sglang_omni/models/moss_transcribe_diarize/stages.py
@@ -73,7 +73,7 @@ def create_sglang_moss_transcribe_diarize_executor(
     *,
     device: str = "cuda:0",
     dtype: str = "bfloat16",
-    max_running_requests: int = 16,
+    max_running_requests: int = 32,
     max_new_tokens: int | None = None,
     context_length: int | None = None,
     mem_fraction_static: float | None = 0.80,

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -68,7 +68,7 @@ def test_moss_transcribe_diarize_config_uses_single_batched_stage() -> None:
     factory = config.stages[0].factory
     engine = config.stages[0].engine
     assert factory.device == "cuda:0"
-    assert engine.max_running_requests == 16
+    assert engine.max_running_requests == 32
     assert engine.enable_torch_compile is True
     assert engine.torch_compile_max_bs == 4
     assert factory.encoder_max_batch_size == 2
@@ -191,7 +191,7 @@ def test_moss_transcribe_diarize_preserves_explicit_omp_default(
 def test_moss_transcribe_diarize_stage_reserves_encoder_headroom() -> None:
     signature = inspect.signature(create_sglang_moss_transcribe_diarize_executor)
 
-    assert signature.parameters["max_running_requests"].default == 16
+    assert signature.parameters["max_running_requests"].default == 32
     assert signature.parameters["mem_fraction_static"].default == 0.80
     assert signature.parameters["enable_torch_compile"].default is False
     assert signature.parameters["torch_compile_max_bs"].default == 4


### PR DESCRIPTION
## Motivation

MOSS-Transcribe-Diarize currently defaults the ASR stage to 16 running requests. At client concurrency 32, that leaves half of the offered work waiting outside the running batch. This PR raises the default to the measured healthy operating point while preserving the existing per-stage runtime override.

MOSS-TD is a single-stage pipeline, so this is a single-replica admission change; it does not use DP, MPS, NPS, or stage replicas.

## Modifications

- Raise the pipeline `asr` default `max_running_requests` from 16 to 32.
- Keep the direct stage-factory default aligned at 32.
- Update the two unit-contract assertions.

An explicit `runtime_overrides.asr.max_running_requests=16` remains the fallback for tail-sensitive or pathological workloads.

## Current-main verification

The branch is updated through `main` at `d346c46f`; PR head is `f1a47e09`. The net diff remains 3 files, +5/-4.

- `python -m pytest -p no:cacheprovider tests/unit_test/moss_transcribe_diarize -q`: **91 passed, 14 skipped**
- Changed-file pre-commit: passed
- `git diff --check origin/main...HEAD`: passed

## Current-main H200 screen

One H200 GPU, single replica, no MPS/DP/NPS, SGLang 0.5.18, model revision `e8681d68`, and a frozen 128-row Movies800Time manifest at revision `382168da`. Client concurrency was 32 with 16 warmup requests. Each leg used a fresh server after a clean GPU window; the order was cap16 -> cap32 -> cap16.

| Arm | QPS | vs first control | mean / p95 / p99 latency (s) | vs first control | CER / cpCER / DER |
|---|---:|---:|---:|---:|---:|
| cap16 before | 36.638 | — | 0.796 / 1.278 / 1.544 | — | 5.42 / 13.74 / 20.99 |
| **cap32** | **54.302** | **1.48× (+48.2%)** | **0.528 / 1.132 / 1.340** | **-33.7% / -11.4% / -13.2%** | **5.45 / 13.77 / 20.89** |
| cap16 after | 33.303 | 0.91× (-9.1% drift) | 0.883 / 1.530 / 1.648 | +10.9% / +19.7% / +6.7% | 5.42 / 13.74 / 20.99 |

All three legs completed 128/128 requests with zero failures. Cap32 improved QPS by **1.48× (+48.21%)** versus the first control and **1.63× (+63.05%)** versus the reverse control (**1.55× / +55.28%** versus their mean). Against the first control, mean/p95/p99 latency changed by -33.7%/-11.4%/-13.2%.

The cap16 controls drifted by 9.10%, so this screen confirms a large win against both bracketing controls but is not a precise final effect-size estimate. Quality was stable within normal restart variation: CER +0.03 pp, cpCER +0.03 pp, and DER -0.10 pp versus the first control.

## Repeated qualification and scope

An earlier three-pair H200 qualification on the same 128-sample workload measured cap32 gains of +39.4%, +24.9%, and +45.2% (mean +36.4%). An independent H100 sweep measured +34.5% on its two-round mean.

This does not solve abnormal output termination. In a separate full-800 stress run, two silent clips produced runaway marker loops and erased the healthy-workload gain (makespan -2.59% at cap32). No-progress/marker-loop termination remains a separate follow-up; the explicit cap16 override is retained until that is hardened.

## Checklist

- [x] Format code with pre-commit.
- [x] Follow repository code-style guidance.
- [x] Add or update behavior-contract tests.
- [x] Record benchmark configuration, quality, and limitations.
