### PR TITLE
[Perf] Run the Ming-TTS audio decode stage in its own process

### DIFF
--- a/sglang_omni/models/ming_tts/config.py
+++ b/sglang_omni/models/ming_tts/config.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
-from sglang_omni.config import PipelineConfig, StageConfig
+from sglang_omni.config import (
+    PipelineConfig,
+    StageConfig,
+    StageResourceConfig,
+    StageRuntimeConfig,
+)
 
 _PKG = "sglang_omni.models.ming_tts"
 
@@ -13,6 +18,18 @@ PREPROCESSING_STAGE = "preprocessing"
 REFERENCE_ENCODE_STAGE = "reference_encode"
 TTS_ENGINE_STAGE = "tts_engine"
 AUDIO_DECODE_STAGE = "audio_decode"
+
+_REFERENCE_ENCODE_GPU_MEMORY_FRACTION = 0.08
+_TTS_ENGINE_GPU_MEMORY_FRACTION = 0.72
+_AUDIO_DECODE_GPU_MEMORY_FRACTION = 0.12
+
+
+def _gpu_budget(fraction: float) -> StageRuntimeConfig:
+    # A fresh instance per stage: pydantic assigns these by reference and
+    # _apply_process_edge_resources rebinds runtime.resources in place.
+    return StageRuntimeConfig(
+        resources=StageResourceConfig(total_gpu_memory_fraction=fraction)
+    )
 
 
 class MingTTSPipelineConfig(PipelineConfig):
@@ -52,9 +69,9 @@ class MingTTSPipelineConfig(PipelineConfig):
     ) -> dict[tuple[str, str], dict[str, float]]:
         return {
             (TTS_ENGINE_STAGE, AUDIO_DECODE_STAGE): {
-                REFERENCE_ENCODE_STAGE: 0.08,
-                TTS_ENGINE_STAGE: 0.72,
-                AUDIO_DECODE_STAGE: 0.12,
+                REFERENCE_ENCODE_STAGE: _REFERENCE_ENCODE_GPU_MEMORY_FRACTION,
+                TTS_ENGINE_STAGE: _TTS_ENGINE_GPU_MEMORY_FRACTION,
+                AUDIO_DECODE_STAGE: _AUDIO_DECODE_GPU_MEMORY_FRACTION,
             }
         }
 
@@ -73,6 +90,7 @@ class MingTTSPipelineConfig(PipelineConfig):
             factory=f"{_PKG}.stages.create_reference_encode_executor",
             factory_args={"dtype": "bfloat16"},
             gpu=0,
+            runtime=_gpu_budget(_REFERENCE_ENCODE_GPU_MEMORY_FRACTION),
             next=TTS_ENGINE_STAGE,
         ),
         StageConfig(
@@ -81,17 +99,19 @@ class MingTTSPipelineConfig(PipelineConfig):
             factory=f"{_PKG}.stages.create_sglang_tts_engine_executor",
             factory_args={"dtype": "bfloat16"},
             gpu=0,
+            runtime=_gpu_budget(_TTS_ENGINE_GPU_MEMORY_FRACTION),
             next=AUDIO_DECODE_STAGE,
         ),
         StageConfig(
             name=AUDIO_DECODE_STAGE,
-            process="pipeline",
+            process=AUDIO_DECODE_STAGE,
             factory=f"{_PKG}.stages.create_audio_decode_executor",
             factory_args={
                 "dtype": "bfloat16",
                 "decode_mode": "chunked",
             },
             gpu=0,
+            runtime=_gpu_budget(_AUDIO_DECODE_GPU_MEMORY_FRACTION),
             terminal=True,
         ),
     ]

--- a/tests/unit_test/pipeline/test_topology.py
+++ b/tests/unit_test/pipeline/test_topology.py
@@ -392,7 +392,7 @@ def test_moss_tts_local_default_already_isolates_vocoder() -> None:
     ].total_gpu_memory_fraction == pytest.approx(1.0)
 
 
-def test_ming_tts_preserves_default_and_can_isolate_vocoder_role() -> None:
+def test_ming_tts_isolates_audio_decode_by_default() -> None:
     from sglang_omni.models.ming_tts.config import MingTTSPipelineConfig
 
     config = MingTTSPipelineConfig(model_path="dummy")
@@ -401,18 +401,17 @@ def test_ming_tts_preserves_default_and_can_isolate_vocoder_role() -> None:
         for stage in config.stages
         if stage.gpu is not None
     } == {
-        "reference_encode": None,
-        "tts_engine": None,
-        "audio_decode": None,
+        "reference_encode": 0.08,
+        "tts_engine": 0.72,
+        "audio_decode": 0.12,
     }
-    assert [stage.process for stage in config.stages] == ["pipeline"] * 4
-
-    isolated = apply_stage_process_overrides(config, isolate_stages=["vocoder"])
-
-    assert [stage.process for stage in config.stages] == ["pipeline"] * 4
-    assert [
-        (group.name, group.stage_names) for group in _topology(isolated).groups
-    ] == [
+    assert [stage.process for stage in config.stages] == [
+        "pipeline",
+        "pipeline",
+        "pipeline",
+        "audio_decode",
+    ]
+    assert [(group.name, group.stage_names) for group in _topology(config).groups] == [
         (
             "pipeline",
             ("preprocessing", "reference_encode", "tts_engine"),
@@ -421,22 +420,57 @@ def test_ming_tts_preserves_default_and_can_isolate_vocoder_role() -> None:
     ]
     assert build_stage_placement_plan(config).gpus[
         0
-    ].total_gpu_memory_fraction == pytest.approx(0.0)
-    assert {
-        stage.name: stage.runtime.resources.total_gpu_memory_fraction
-        for stage in isolated.stages
-        if stage.gpu is not None
-    } == {
-        "reference_encode": 0.08,
-        "tts_engine": 0.72,
-        "audio_decode": 0.12,
-    }
-    assert build_stage_placement_plan(isolated).gpus[
-        0
     ].total_gpu_memory_fraction == pytest.approx(0.92)
 
+    # The new default is what --isolate-stage vocoder used to produce. Rebuild
+    # the pre-change topology and run the role over it; comparing the new config
+    # against itself proves nothing, since the override early-returns for a stage
+    # that already runs alone.
+    legacy = config.model_copy(deep=True)
+    for stage in legacy.stages:
+        stage.process = "pipeline"
+        stage.runtime.resources = StageResourceConfig()
+    assert (
+        apply_stage_process_overrides(legacy, isolate_stages=["vocoder"]).model_dump()
+        == config.model_dump()
+    )
 
-def test_ming_isolation_resources_do_not_change_default_placement_limit() -> None:
+    # Existing --isolate-stage vocoder launch commands stay accepted.
+    assert (
+        apply_stage_process_overrides(config, isolate_stages=["vocoder"]).model_dump()
+        == config.model_dump()
+    )
+
+    # Operators can opt back out to the single-process topology.
+    opted_out = apply_stage_process_overrides(
+        config, stage_processes=["audio_decode=pipeline"]
+    )
+    assert [stage.process for stage in opted_out.stages] == ["pipeline"] * 4
+    assert [
+        (group.name, group.stage_names) for group in _topology(opted_out).groups
+    ] == [
+        (
+            "pipeline",
+            ("preprocessing", "reference_encode", "tts_engine", "audio_decode"),
+        )
+    ]
+
+    # Each stage owns its runtime block: pydantic assigns by reference and
+    # _apply_process_edge_resources rebinds runtime.resources in place.
+    stages = {stage.name: stage for stage in config.stages}
+    assert len({id(stage.runtime) for stage in config.stages}) == len(config.stages)
+    stages["reference_encode"].runtime.resources = StageResourceConfig(
+        total_gpu_memory_fraction=0.42
+    )
+    assert stages[
+        "audio_decode"
+    ].runtime.resources.total_gpu_memory_fraction == pytest.approx(0.12)
+
+
+def test_ming_default_budgets_are_subject_to_the_placement_limit() -> None:
+    """The isolation budgets ship in the default topology, so a limit below
+    their total now rejects at startup instead of only on --isolate-stage.
+    moss_tts_local has behaved this way since its vocoder split landed."""
     from sglang_omni.config import PlacementConfig
     from sglang_omni.models.ming_tts.config import MingTTSPipelineConfig
 
@@ -445,10 +479,14 @@ def test_ming_isolation_resources_do_not_change_default_placement_limit() -> Non
         placement=PlacementConfig(max_total_gpu_memory_fraction_per_gpu=0.90),
     )
 
-    _topology(config)
-
     with pytest.raises(ValueError, match="exceeds placement limit 0.900"):
-        apply_stage_process_overrides(config, isolate_stages=["vocoder"])
+        _topology(config)
+
+    headroom = MingTTSPipelineConfig(
+        model_path="dummy",
+        placement=PlacementConfig(max_total_gpu_memory_fraction_per_gpu=0.95),
+    )
+    _topology(headroom)
 
 
 def test_fishaudio_preserves_default_and_can_isolate_vocoder() -> None:


### PR DESCRIPTION
## Motivation

All four Ming-TTS stages share one process group, so the Python-side chunked
audio decode contends with the AR scheduler thread for a single interpreter while
the card is not saturated. `moss_tts_local` and `higgs_tts` already ship the
vocoder-equivalent stage in its own process; this brings Ming-TTS in line.

The split is not new: `--isolate-stage vocoder` already produces it (the role
resolves to `audio_decode` through `isolation_role_to_stage`), and
`process_safe_edges()` / `process_edge_resources()` for the
`(tts_engine, audio_decode)` edge are already declared. What changes is the
default.

## Modifications

* `audio_decode` gets `process="audio_decode"`.
* `reference_encode`, `tts_engine` and `audio_decode` declare the
  `total_gpu_memory_fraction` values `process_edge_resources()` already
  prescribes for that edge: 0.08 / 0.72 / 0.12. `preprocessing` holds no GPU and
  keeps no budget.
* Each stage gets its own `StageRuntimeConfig` instance. Pydantic assigns these
  by reference and `_apply_process_edge_resources` rebinds
  `stage.runtime.resources` in place, so a shared instance would let one stage's
  budget silently overwrite another's. A test covers this.

`--isolate-stage vocoder` remains accepted and becomes a no-op.

### Behavior change worth calling out

Those budgets total 0.92 on GPU 0. An operator
`placement.max_total_gpu_memory_fraction_per_gpu` below that now rejects at
startup rather than only when `--isolate-stage` is passed. `moss_tts_local` has
behaved this way since its own vocoder split landed, where the default totals
1.00. The test that pinned the old Ming behavior is updated to pin the new one.

## Benchmarking

One H200, `inclusionAI/Ming-omni-tts-16.8B-A3B`, SeedTTS EN, 256 samples,
concurrency 32, `--generate-only`. Three pairs, all on the same GPU, `main` at
`95bd0d3e` against this branch, both launched with **no flags**, so this measures
the default the PR changes rather than a `--isolate-stage` proxy.

Every leg had to pass a cleanliness gate to count: the GPU is taken only after
six consecutive idle probes plus a 60 s canary, card memory and box loadavg are
sampled every 5 s for the whole run, and a leg is discarded and re-run if another
process appears on the card or loadavg leaves its band. Both legs of a pair run on
the same GPU and a pair is discarded as a unit if either leg fails. All six legs
below passed on the first attempt, and the process-group count is recorded per leg
(1 before, 2 after) so the topology change is confirmed to have taken effect.

### Throughput

| Pair | Before (req/s) | **After (req/s)** | **Change** |
|---|---|---|---|
| 1 | 1.507 | **2.141** | **+42.1%** |
| 2 | 1.497 | **2.209** | **+47.6%** |
| 3 | 1.583 | **2.222** | **+40.4%** |
| **mean** | **1.529** | **2.191** | **+43.3%** |

### Latency, memory, failures

| Metric | Before (r1 / r2 / r3) | After (r1 / r2 / r3) | Change on the mean |
|---|---|---|---|
| latency mean (s) | 19.97 / 20.12 / 19.04 | 14.08 / 13.61 / 13.58 | **-30.5%** |
| latency p95 (s) | 25.01 / 24.98 / 24.00 | 17.29 / 16.88 / 16.45 | **-31.6%** |
| card memory (MiB) | 132363 | 108107 | **-24256** |
| failed requests | 0 / 0 / 0 | 0 / 0 / 0 | |

**The throughput gain and the mean-latency drop are one result, not two.** The
benchmark is closed-loop, 32 requests outstanding at all times, so Little's law
ties them together and the measured numbers confirm it:

| | throughput λ | latency W | **λ × W** |
|---|---|---|---|
| before | 1.529 | 19.711 s | **30.14** |
| after | 2.191 | 13.758 s | **30.14** |

Unlike a queue-cap change, though, the tail moves with the mean here: p95 drops
31.6% consistently across all three pairs. That is the signal that the stage
really is serving faster rather than merely admitting more, since a change that
only drained a queue would leave per-request service time alone and show the
flat-to-worse tails that a cap increase does.

Card memory drops by 24 GB: the isolated topology gives audio decode its own
budget instead of letting it grow inside the AR process.

### Quality

WER over the audio those same runs produced, scored with one Qwen3-ASR-1.7B
server via `--transcribe-only`, so no TTS was re-run. 256/256 evaluated on every
leg, 0 skipped.

| Pair | Before | After |
|---|---|---|
| 1 | 1.06% | 1.06% |
| 2 | 0.87% | 1.13% |
| 3 | 1.10% | 1.06% |

Outlier-excluded corpus WER. The before range is 0.87-1.10 and the after range is
1.06-1.13; they interleave, so there is no regression. Raw micro-average tells the
same story with one more point of spread each way (before 1.06 / 0.87 / 1.46,
after 1.38 / 1.13 / 1.06), which is what a single bad sample does to a
256-sample subset.

### Where this does not pay

The gain tracks how much the two stages actually contend for the interpreter, so
it has to be measured per pipeline rather than assumed. Measured with the same
harness and rejected: MOSS-TTS delay and Qwen3-TTS both scatter around zero
across three rounds each, and Voxtral gains ~3% with its GPU only a third busy at
this concurrency. This PR changes one model's default.

An earlier sweep on an H100 measured +34.9% and +42.2% through the
`--isolate-stage` flag and +24.2% and +34.7% on the default, agreeing in
direction and magnitude with the +43.3% here on different hardware.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
