### PR TITLE
ci: use Docker Hub omni image cache

### DIFF
--- a/.github/actions/omni-setup/action.yaml
+++ b/.github/actions/omni-setup/action.yaml
@@ -23,6 +23,9 @@ runs:
         echo "HOME=/github/home" >> "${GITHUB_ENV}"
         echo "HF_HOME=/github/home/.cache/huggingface" >> "${GITHUB_ENV}"
         echo "XDG_CACHE_HOME=${OMNI_CI_HOME}/.cache" >> "${GITHUB_ENV}"
+        # FlashInfer does not use XDG_CACHE_HOME. Keep it on the image's
+        # architecture-specific prewarmed cache under /root/.cache/flashinfer.
+        echo "FLASHINFER_WORKSPACE_BASE=/root" >> "${GITHUB_ENV}"
         echo "HF_HUB_DISABLE_XET=0" >> "${GITHUB_ENV}"
         echo "HF_ENDPOINT=${HF_ENDPOINT:-https://huggingface.co}" >> "${GITHUB_ENV}"
         # PyPI mirror + shared wheel cache (HF mirror does not accelerate pip/uv).
@@ -71,18 +74,6 @@ runs:
       env:
         VENV_NAME: ${{ inputs.venv-name }}
       run: bash .github/scripts/validate_omni_env_reusable.sh "${VENV_NAME}"
-
-    - name: Remove stale flashinfer JIT artifacts
-      shell: bash
-      run: |
-        # Note:(Chenchen Hong) On the hongccc/sglang-omni:dev (CUDA 13) image the
-        # flashinfer-python 0.6.11.post1 wheel JIT-compiles its kernels against the
-        # base image's matching cu13 toolkit. We no longer preinstall a
-        # flashinfer-jit-cache wheel: the only published jit-cache builds are
-        # 0.6.13 (cu128/cu129/cu130) and do not match the pinned 0.6.11.post1,
-        # and the prior cu128 pin mismatched the cu13 runtime. Wipe any stale
-        # JIT artifacts so the cu13 kernels compile cleanly on first use.
-        rm -rf "${OMNI_CI_HOME}/.cache/flashinfer"
 
     - name: Kill GPU processes
       shell: bash

--- a/.github/scripts/run_flaky_pytest.sh
+++ b/.github/scripts/run_flaky_pytest.sh
@@ -46,9 +46,6 @@ cleanup_between_attempts() {
     echo "::error::GPU cleanup failed before retry; not retrying with dirty GPU state"
     return 1
   fi
-  rm -rf "${XDG_CACHE_HOME:-/github/home/.cache}/flashinfer" || {
-    echo "::warning::Failed to remove FlashInfer cache before retry"
-  }
   if [ "${retry_delay_seconds}" -gt 0 ]; then
     sleep "${retry_delay_seconds}"
   fi

--- a/.github/workflows/cleanup-pr-ci-home-on-close.yaml
+++ b/.github/workflows/cleanup-pr-ci-home-on-close.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [self-hosted, h100]
     timeout-minutes: 5
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: --rm -e NVIDIA_VISIBLE_DEVICES -v /dev/shm:/dev/shm -v /data/omni-ci:/data/omni-ci
     steps:
       - name: Checkout code

--- a/.github/workflows/omni-ci.yaml
+++ b/.github/workflows/omni-ci.yaml
@@ -121,7 +121,7 @@ jobs:
     runs-on: [self-hosted, h100]
     timeout-minutes: 30
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
@@ -294,7 +294,7 @@ jobs:
     runs-on: [self-hosted, h100]
     timeout-minutes: 5
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES

--- a/.github/workflows/test-asr-ci.yaml
+++ b/.github/workflows/test-asr-ci.yaml
@@ -32,7 +32,7 @@ jobs:
     # movies800 + stream + aishell4_long + googletime on DP=2.
     timeout-minutes: 90
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
@@ -86,7 +86,7 @@ jobs:
     runs-on: [self-hosted, h100]
     timeout-minutes: 30
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: [self-hosted, h100]
     timeout-minutes: 20
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
@@ -75,7 +75,7 @@ jobs:
     runs-on: [self-hosted, h100]
     timeout-minutes: 25
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
@@ -133,7 +133,7 @@ jobs:
     runs-on: [self-hosted, h100]
     timeout-minutes: 20
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
@@ -178,7 +178,7 @@ jobs:
     runs-on: [self-hosted, h100]
     timeout-minutes: 15
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
@@ -223,7 +223,7 @@ jobs:
     runs-on: [self-hosted, h100]
     timeout-minutes: 20
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
@@ -269,7 +269,7 @@ jobs:
     runs-on: [self-hosted, h100]
     timeout-minutes: 15
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
@@ -314,7 +314,7 @@ jobs:
     runs-on: [self-hosted, h100]
     timeout-minutes: 30
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
@@ -359,7 +359,7 @@ jobs:
     runs-on: [self-hosted, h100]
     timeout-minutes: 30
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
@@ -404,7 +404,7 @@ jobs:
     runs-on: [self-hosted, h100]
     timeout-minutes: 30
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
@@ -449,7 +449,7 @@ jobs:
     runs-on: [self-hosted, h100]
     timeout-minutes: 35
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       # note (Yue Yin): TP=2 relay uses pidfd_getfd to pass fds between stage
       # processes; CAP_SYS_PTRACE is required (else every request 500s).
       options: >-

--- a/.github/workflows/test-tts-ci.yaml
+++ b/.github/workflows/test-tts-ci.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: [self-hosted, h100]
     timeout-minutes: 25
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
@@ -96,7 +96,7 @@ jobs:
     runs-on: [self-hosted, h100]
     timeout-minutes: 25
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
@@ -152,7 +152,7 @@ jobs:
     runs-on: [self-hosted, h100]
     timeout-minutes: 5
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
@@ -206,7 +206,7 @@ jobs:
     runs-on: [self-hosted, h100]
     timeout-minutes: 75
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
     name: unit-test
     runs-on: [self-hosted, h100]
     container:
-      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      image: hongccc/sglang-omni:dev
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES


### PR DESCRIPTION
## Summary
- switch all Omni GPU CI containers from the stale Aliyun mirror to `hongccc/sglang-omni:dev` on Docker Hub
- set `FLASHINFER_WORKSPACE_BASE=/root` so FlashInfer 0.6.14 uses the SM89/SM90 caches baked into the image
- remove stale FlashInfer cache deletion from setup and retry cleanup

## Cache ownership
FlashInfer 0.6.14 ignores `XDG_CACHE_HOME` and resolves its cache from `FLASHINFER_WORKSPACE_BASE`. CI previously set `HOME=/github/home`, while deleting `${OMNI_CI_HOME}/.cache/flashinfer`; that deletion did not target FlashInfer’s actual cache and the image cache under `/root/.cache/flashinfer` was bypassed.

## Validation
- repository pre-commit hooks
- `bash -n .github/scripts/run_flaky_pytest.sh`
- parsed all `.github/**/*.yaml` files
- asserted all 20 workflow container references use Docker Hub and no Aliyun Omni image references remain
- rebased onto `origin/main@95bd0d3e`