### PR TITLE
[Qwen3-Omni] Async hidden-state capture and lookahead fixes

### DIFF
--- a/sglang_omni/model_runner/thinker_model_runner.py
+++ b/sglang_omni/model_runner/thinker_model_runner.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import contextlib
 import logging
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -18,6 +19,13 @@ from sglang_omni.model_runner.base import ModelRunner
 from sglang_omni.model_runner.sglang_execution import attn_forward_context
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _ThinkerDecodeLaunch:
+    token_ids: torch.Tensor
+    aux_hidden_states: tuple[torch.Tensor, ...] | None
+    stream_hidden_states: torch.Tensor | None
 
 
 class ThinkerModelRunner(ModelRunner):
@@ -39,6 +47,8 @@ class ThinkerModelRunner(ModelRunner):
         self._embed_tokens = self._text_model.embed_tokens
         self._th_host_bufs = None
         self._th_slot = 0
+        self._th_capture_bufs: list[tuple[torch.Tensor, ...] | None] = [None, None]
+        self._th_capture_slot = 0
 
         thinker_cfg = tp_worker.model_runner.model_config.hf_config.thinker_config
         self._image_token_id = thinker_cfg.image_token_id
@@ -336,26 +346,18 @@ class ThinkerModelRunner(ModelRunner):
 
     def lookahead_eligible(self, batch: Any) -> bool:
         """Route to sync where the one-step lag would diverge from sync. A request
-        that emits audio captures hidden states for the talker; the per-forward
-        _captured_aux_hidden_states side channel would be overwritten by a lookahead
-        launch(N) before resolve(N-1) collects it, so those requests route to sync
-        per batch. Sampling that reads the lagged output history (repetition /
-        presence / frequency penalty, min_new_tokens), a fixed seed, or
-        return_logprob (the lookahead sampler skips the base logprob path) also
-        diverges; logit_bias / custom_params are routed conservatively.
+        Sampling that reads the lagged output history (repetition / presence /
+        frequency penalty, min_new_tokens), a fixed seed, or return_logprob (the
+        lookahead sampler skips the base logprob path) diverges; logit_bias /
+        custom_params are routed conservatively. Speech hidden states are copied
+        into per-launch double buffers and do not restrict eligibility.
         """
-        from sglang_omni.models.qwen3_omni.request_builders import (
-            should_generate_audio_output,
-        )
-
         for req in batch.reqs:
-            # note (jiaxin deng): fail closed if the request data is missing or None
-            # so a hidden-capture batch can never slip onto the async path.
             try:
                 data = req._omni_data
             except AttributeError:
                 data = None
-            if data is None or should_generate_audio_output(data.stage_payload):
+            if data is None:
                 return False
             try:
                 needs_logprob = data.return_logprob
@@ -389,6 +391,45 @@ class ThinkerModelRunner(ModelRunner):
         self._th_slot ^= 1
         return buf
 
+    def _async_hidden_capture(
+        self, result: Any
+    ) -> tuple[tuple[torch.Tensor, ...] | None, torch.Tensor | None]:
+        captured = self.model._captured_aux_hidden_states
+        self.model._captured_aux_hidden_states = None
+        if captured is None:
+            return None, None
+
+        logits_output = result.logits_output
+        stream_hidden = getattr(logits_output, "hidden_states", None)
+        sources = tuple(captured)
+        if isinstance(stream_hidden, torch.Tensor):
+            sources += (stream_hidden,)
+
+        # Note (Akazaakane): Graph replay can reuse capture storage before the
+        # lagged step resolves, so each in-flight step needs a distinct snapshot.
+        slot = self._th_capture_slot
+        buffers = self._th_capture_bufs[slot]
+        if (
+            buffers is None
+            or len(buffers) != len(sources)
+            or any(
+                buffer.shape != source.shape
+                or buffer.dtype != source.dtype
+                or buffer.device != source.device
+                for buffer, source in zip(buffers or (), sources)
+            )
+        ):
+            buffers = tuple(torch.empty_like(source) for source in sources)
+            self._th_capture_bufs[slot] = buffers
+        for buffer, source in zip(buffers, sources):
+            buffer.copy_(source, non_blocking=True)
+        self._th_capture_slot ^= 1
+
+        num_aux = len(captured)
+        aux_hidden = buffers[:num_aux]
+        captured_stream = buffers[num_aux] if len(buffers) > num_aux else None
+        return aux_hidden, captured_stream
+
     def _sample_lookahead(self, logits_output, forward_batch, requests):
         # note (jiaxin deng): penalties never reach here (lookahead_eligible routes
         # those batches to sync); only static suppress tokens are lag-safe.
@@ -408,13 +449,17 @@ class ThinkerModelRunner(ModelRunner):
         nt = result.next_token_ids
         host_buf = self._async_host_buf(nt, n)
         host_buf[:n].copy_(nt[:n], non_blocking=True)
-        return host_buf
+        aux_hidden, stream_hidden = self._async_hidden_capture(result)
+        return _ThinkerDecodeLaunch(host_buf, aux_hidden, stream_hidden)
 
     def post_decode_resolve(
-        self, launch_buf, result, forward_batch, schedule_batch, requests
+        self, launch_state, result, forward_batch, schedule_batch, requests
     ):
         del forward_batch, schedule_batch
-        if len(requests) == 0 or launch_buf is None:
+        if len(requests) == 0 or launch_state is None:
             return
         n = len(requests)
-        result.next_token_ids = launch_buf[:n].to(torch.long).clone()
+        result.next_token_ids = launch_state.token_ids[:n].to(torch.long).clone()
+        self.model._captured_aux_hidden_states = launch_state.aux_hidden_states
+        if launch_state.stream_hidden_states is not None:
+            result.logits_output.hidden_states = launch_state.stream_hidden_states

--- a/tests/unit_test/qwen3_omni/test_thinker_lookahead_eligible.py
+++ b/tests/unit_test/qwen3_omni/test_thinker_lookahead_eligible.py
@@ -1,26 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Unit tests for ThinkerModelRunner.lookahead_eligible.
+"""Unit tests for ThinkerModelRunner async-decode behavior.
 
 lookahead_eligible reads only per-request flags (never other instance state), so it
 is exercised on a bare instance built with ``object.__new__`` and stand-in requests.
-Audio-output detection (should_generate_audio_output) is stubbed on the stand-in
-stage_payload.
 """
 from __future__ import annotations
 
 import types
 
-import pytest
+import torch
 
 from sglang_omni.model_runner.thinker_model_runner import ThinkerModelRunner
-
-
-@pytest.fixture(autouse=True)
-def _stub_audio_output(monkeypatch):
-    monkeypatch.setattr(
-        "sglang_omni.models.qwen3_omni.request_builders.should_generate_audio_output",
-        lambda payload: payload == "audio",
-    )
 
 
 def _runner() -> ThinkerModelRunner:
@@ -62,9 +52,8 @@ def test_empty_batch_is_eligible():
     assert _runner().lookahead_eligible(_batch()) is True
 
 
-def test_audio_output_disables_lookahead():
-    # an audio-output request captures hidden for the talker -> route to sync.
-    assert _runner().lookahead_eligible(_batch(_req(stage_payload="audio"))) is False
+def test_audio_output_is_eligible():
+    assert _runner().lookahead_eligible(_batch(_req(stage_payload="audio"))) is True
 
 
 def test_return_logprob_disables_lookahead():
@@ -95,6 +84,48 @@ def test_each_gated_sampling_param_disables_lookahead():
 
 def test_one_gated_request_disables_whole_batch():
     audio_mix = _batch(_req(), _req(stage_payload="audio"), _req())
-    assert _runner().lookahead_eligible(audio_mix) is False
+    assert _runner().lookahead_eligible(audio_mix) is True
     param_mix = _batch(_req(), _req(repetition_penalty=1.3), _req())
     assert _runner().lookahead_eligible(param_mix) is False
+
+
+def test_async_speech_capture_is_double_buffered(monkeypatch):
+    runner = _runner()
+    runner.model = types.SimpleNamespace(_captured_aux_hidden_states=None)
+    runner._th_capture_bufs = [None, None]
+    runner._th_capture_slot = 0
+    monkeypatch.setattr(
+        runner,
+        "_async_host_buf",
+        lambda like, n: torch.empty(n, dtype=like.dtype),
+    )
+
+    def launch(token_id, aux_value, stream_value):
+        runner.model._captured_aux_hidden_states = [
+            torch.tensor([[aux_value]], dtype=torch.float32)
+        ]
+        result = types.SimpleNamespace(
+            next_token_ids=torch.tensor([token_id]),
+            logits_output=types.SimpleNamespace(
+                hidden_states=torch.tensor([[stream_value]], dtype=torch.float32)
+            ),
+        )
+        state = runner.post_decode_launch(result, object(), [object()])
+        return result, state
+
+    result_1, state_1 = launch(11, 1.0, 10.0)
+    result_2, state_2 = launch(22, 2.0, 20.0)
+
+    assert state_1.aux_hidden_states[0].data_ptr() != (
+        state_2.aux_hidden_states[0].data_ptr()
+    )
+    runner.post_decode_resolve(state_1, result_1, object(), object(), [object()])
+    assert result_1.next_token_ids.tolist() == [11]
+    assert runner.model._captured_aux_hidden_states[0].item() == 1.0
+    assert result_1.logits_output.hidden_states.item() == 10.0
+
+    runner.model._captured_aux_hidden_states = None
+    runner.post_decode_resolve(state_2, result_2, object(), object(), [object()])
+    assert result_2.next_token_ids.tolist() == [22]
+    assert runner.model._captured_aux_hidden_states[0].item() == 2.0
+    assert result_2.logits_output.hidden_states.item() == 20.0


### PR DESCRIPTION
Add _ThinkerDecodeLaunch dataclass and implement double-buffered async hidden-state capture to snapshot aux and stream hidden states per in-flight decode. Introduce _async_hidden_capture, wire post_decode_launch to return launch state, and update post_decode_resolve to restore token ids and captured hidden states. Relax lookahead_eligible so speech-capture no longer blocks async path (speech states are now safely double-buffered). Update unit tests to reflect eligibility change and add a test verifying the double-buffering/capture behavior.

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues

#1018 

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
