### PR TITLE
[ARK-ASR] enable async decode for ARK-ASR

### DIFF
--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -33,10 +33,11 @@ _ASYNC_DECODE_FACTORIES = frozenset(
         "sglang_omni.models.moss_transcribe_diarize.stages."
         "create_sglang_moss_transcribe_diarize_executor",
         "sglang_omni.models.fun_asr.stages.create_sglang_fun_asr_executor",
+        "sglang_omni.models.arkasr.stages.create_sglang_arkasr_executor",
     }
 )
 _ASYNC_DECODE_SUPPORTED_MODELS = (
-    "Higgs TTS, MOSS-TTS-Local, MOSS-Transcribe-Diarize, and Fun-ASR"
+    "Higgs TTS, MOSS-TTS-Local, MOSS-Transcribe-Diarize, Fun-ASR, and ARK-ASR"
 )
 _QWEN_PARTIAL_START_TALKER_FACTORY = (
     "sglang_omni.models.qwen3_omni.stages.create_talker_ar_executor_from_config"
@@ -1182,7 +1183,7 @@ def serve(
                 "default. Async mode enables one-step lookahead, "
                 "which can overlap the previous step's host-side collect with "
                 "the next GPU forward. Available for Higgs TTS, MOSS-TTS-Local, "
-                "MOSS-Transcribe-Diarize, and Fun-ASR."
+                "MOSS-Transcribe-Diarize, Fun-ASR, and ARK-ASR."
             ),
         ),
     ] = None,

--- a/sglang_omni/models/arkasr/stages.py
+++ b/sglang_omni/models/arkasr/stages.py
@@ -35,6 +35,8 @@ def create_sglang_arkasr_executor(
     mem_fraction_static: float | None = None,
     mm_embedding_cache_size_bytes: int = 0,
     enable_torch_compile: bool = False,
+    enable_async_decode: bool = True,
+    async_decode_min_batch_size: int = 2,
     mm_attention_backend: str | None = None,
     request_build_max_workers: int = 2,
     request_build_max_pending: int | None = 16,
@@ -123,6 +125,8 @@ def create_sglang_arkasr_executor(
         model_runner=ModelRunner(model_worker, output_proc),
         request_builder=request_builder,
         result_adapter=result_adapter,
+        enable_async_decode=enable_async_decode,
+        async_decode_min_batch_size=async_decode_min_batch_size,
         request_build_max_workers=request_build_max_workers,
         request_build_max_pending=request_build_max_pending,
     )

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -60,6 +60,9 @@ def test_arkasr_stage_defaults():
     assert signature.parameters["max_running_requests"].default == 32
     assert signature.parameters["request_build_max_workers"].default == 2
     assert signature.parameters["request_build_max_pending"].default == 16
+    # async decode (one-step lookahead) on by default, same as Fun-ASR / MOSS-TD
+    assert signature.parameters["enable_async_decode"].default is True
+    assert signature.parameters["async_decode_min_batch_size"].default == 2
 
 
 @pytest.mark.parametrize("want_cuda_graph", [True, False])
@@ -113,13 +116,22 @@ def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
         stages, "make_arkasr_scheduler_adapters", lambda **k: (object(), object())
     )
     monkeypatch.setattr(stages, "ModelRunner", lambda *a, **k: object())
-    monkeypatch.setattr(stages, "OmniScheduler", lambda **k: SimpleNamespace())
+    scheduler_kwargs: dict = {}
+
+    def _capture_scheduler(**kwargs):
+        scheduler_kwargs.update(kwargs)
+        return SimpleNamespace()
+
+    monkeypatch.setattr(stages, "OmniScheduler", _capture_scheduler)
 
     create_sglang_arkasr_executor(
         "AutoArk-AI/ARK-ASR-3B", mm_attention_backend="triton_attn"
     )
 
     assert calls["init_cuda_graphs"] == (1 if want_cuda_graph else 0)
+    # async decode flags must reach the scheduler with their defaults
+    assert scheduler_kwargs["enable_async_decode"] is True
+    assert scheduler_kwargs["async_decode_min_batch_size"] == 2
 
 
 def test_arkasr_audio_token_count():

--- a/tests/unit_test/higgs_tts/test_cli_decode_mode.py
+++ b/tests/unit_test/higgs_tts/test_cli_decode_mode.py
@@ -13,6 +13,7 @@ import typer
 
 from sglang_omni.cli.serve import apply_decode_mode_cli_overrides
 from sglang_omni.config import PipelineConfig, StageConfig, resolve_stage_factory_args
+from sglang_omni.models.arkasr.config import ArkasrPipelineConfig
 from sglang_omni.models.fun_asr.config import FunASRPipelineConfig
 from sglang_omni.models.higgs_tts.config import HiggsTtsPipelineConfig
 from sglang_omni.models.moss_transcribe_diarize.config import (
@@ -91,7 +92,8 @@ def test_decode_mode_cli_rejects_unsupported_config():
     config = Qwen3TTSPipelineConfig(model_path="dummy")
     with pytest.raises(
         typer.BadParameter,
-        match="Higgs TTS, MOSS-TTS-Local, MOSS-Transcribe-Diarize, and Fun-ASR",
+        match="Higgs TTS, MOSS-TTS-Local, MOSS-Transcribe-Diarize, Fun-ASR, "
+        "and ARK-ASR",
     ):
         apply_decode_mode_cli_overrides(
             config, decode_mode="sync", async_lookahead_min_batch_size=None
@@ -113,6 +115,23 @@ def test_decode_mode_cli_applies_to_moss_transcribe_diarize_asr_stage():
 
 def test_decode_mode_cli_applies_to_fun_asr_stage():
     config = FunASRPipelineConfig(model_path="dummy")
+    apply_decode_mode_cli_overrides(
+        config, decode_mode="async", async_lookahead_min_batch_size=4
+    )
+    stage = next(s for s in config.stages if s.name == "asr")
+    args = resolve_stage_factory_args(stage, config)
+    assert args["enable_async_decode"] is True
+    assert args["async_decode_min_batch_size"] == 4
+
+    apply_decode_mode_cli_overrides(
+        config, decode_mode="sync", async_lookahead_min_batch_size=None
+    )
+    args = resolve_stage_factory_args(stage, config)
+    assert args["enable_async_decode"] is False
+
+
+def test_decode_mode_cli_applies_to_arkasr_stage():
+    config = ArkasrPipelineConfig(model_path="dummy")
     apply_decode_mode_cli_overrides(
         config, decode_mode="async", async_lookahead_min_batch_size=4
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Async decode for ARK-ASR.
This PR is pre-refactor, just a sanity check + for LOC changed comparison

**+7 / -2** not counting tests

## Related Issues

#924

## Benchmark & Profiling

## benchmark (H200)

- server
```python
CUDA_VISIBLE_DEVICES=7 python -m sglang_omni.cli serve \
  --model-path AutoArk-AI/ARK-ASR-3B \
  --port 8000 \
  --decode-mode async or sync
```
- client
```python
python -m benchmarks.eval.benchmark_asr_seedtts \
  --model-path AutoArk-AI/ARK-ASR-3B --port 8000 \
  --concurrencies 1,2,4,8,16,32,64 --repeats 3 --warmup \
  --output results/ark_asr_{async or sync}_full.json
```

- async vs sync

conc | thrpt sync → async | Δ thrpt | lat sync → async | Δ lat | rtf Δ | WER
-- | -- | -- | -- | -- | -- | --
1 | 13.8 → 13.6 /s | −1.3% | 0.072 → 0.073 | +1.3% | +1.3% | 1.12%
2 | 22.8 → 24.2 /s | +6.2% | 0.088 → 0.082 | −5.8% | −5.7% | 1.12%
4 | 35.5 → 40.3 /s | +13.6% | 0.112 → 0.099 | −12.1% | −11.7% | 1.12%
8 | 52.5 → 63.0 /s | +20.0% | 0.152 → 0.127 | −16.6% | −16.5% | 1.12%
16 | 75.4 → 94.0 /s | +24.7% | 0.211 → 0.170 | −19.8% | −19.5% | 1.12%
32 | 97.2 → 114.1 /s | +17.4% | 0.327 → 0.278 | −14.9% | −14.8% | 1.12%
64\* | 100.0 → 106.4 /s | +6.4% | 0.627 → 0.590 | −5.9% | −5.8% | 1.14%

\* c=64 is past saturation for both arms — throughput is below each arm's own c=32 figure and the client drops samples (91/3264 sync, 104/3264 async). The WER cells differ in the 4th decimal only because the evaluated subsets differ; treat c=64 as a saturation data point, not a like-for-like WER comparison.

- Detailed data

*sync*
| conc | reps | wall(s) mean | thrpt mean | thrpt best | lat mean(s) | lat p95(s) | rtf mean | rtf p95 | corpus WER | max WER | evaluated |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 3 | 78.902 | 13.794 | 14.049 | 0.072 | 0.090 | 0.0157 | 0.0204 | 0.0112 | 0.2857 | 3264/3264 |
| 2 | 3 | 47.724 | 22.798 | 22.820 | 0.088 | 0.107 | 0.0190 | 0.0249 | 0.0112 | 0.2857 | 3264/3264 |
| 4 | 3 | 30.685 | 35.468 | 36.169 | 0.112 | 0.151 | 0.0244 | 0.0335 | 0.0112 | 0.2857 | 3264/3264 |
| 8 | 3 | 20.739 | 52.471 | 53.477 | 0.152 | 0.201 | 0.0330 | 0.0452 | 0.0112 | 0.2857 | 3264/3264 |
| 16 | 3 | 14.433 | 75.391 | 76.177 | 0.211 | 0.283 | 0.0457 | 0.0621 | 0.0112 | 0.2857 | 3264/3264 |
| 32 | 3 | 11.193 | 97.245 | 99.514 | 0.327 | 0.445 | 0.0707 | 0.0988 | 0.0112 | 0.2857 | 3264/3264 |
| 64 | 3 | 10.574 | 100.037 | 101.335 | 0.627 | 0.755 | 0.1369 | 0.1825 | 0.0114 | 0.2857 | 3173/3264 |

*async*
| conc | reps | wall(s) mean | thrpt mean | thrpt best | lat mean(s) | lat p95(s) | rtf mean | rtf p95 | corpus WER | max WER | evaluated |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 3 | 79.949 | 13.609 | 13.616 | 0.073 | 0.089 | 0.0159 | 0.0202 | 0.0112 | 0.2857 | 3264/3264 |
| 2 | 3 | 44.956 | 24.205 | 24.451 | 0.082 | 0.103 | 0.0179 | 0.0239 | 0.0112 | 0.2857 | 3264/3264 |
| 4 | 3 | 26.999 | 40.302 | 40.907 | 0.099 | 0.127 | 0.0215 | 0.0299 | 0.0112 | 0.2857 | 3264/3264 |
| 8 | 3 | 17.288 | 62.961 | 63.978 | 0.127 | 0.170 | 0.0275 | 0.0388 | 0.0112 | 0.2857 | 3264/3264 |
| 16 | 3 | 11.581 | 94.010 | 97.330 | 0.170 | 0.234 | 0.0368 | 0.0517 | 0.0112 | 0.2857 | 3264/3264 |
| 32 | 3 | 9.534 | 114.131 | 115.290 | 0.278 | 0.378 | 0.0603 | 0.0839 | 0.0112 | 0.2857 | 3264/3264 |
| 64 | 3 | 9.901 | 106.390 | 107.514 | 0.590 | 0.717 | 0.1289 | 0.1740 | 0.0114 | 0.2857 | 3160/3264 |

SeedTTS EN, 1088 samples per repeat, 3 repeats, one discarded warmup pass per concurrency.

## Summarize
- Gains scale with batch depth and peak at c=16: throughput +20.0% / +24.7% / +17.4% at c=8/16/32, with latency and RTF down 15–20% across the same range. Peak served throughput rises from 97.2/s (sync, c=32) to 114.1/s (async, c=32).
- c=1 shows −1.3% throughput, i.e. no effect beyond run-to-run noise — async's c=1 mean (13.61/s) sits inside sync's own repeat spread (13.43–14.05/s), and the lookahead self-gates below `async_decode_min_batch_size=2` so bs=1 takes the same synchronous path in both arms.
- WER is bit-identical wherever the arms evaluate the same samples (corpus 1.12%, max 28.57%, c=1 through c=32) — decoding is greedy with no history-dependent sampling terms, so the one-step lag cannot change the token stream.
