### PR TITLE
[Pipeline] Support replicated entry stages and logical replica sources

### DIFF
--- a/docs/developer_reference/config.md
+++ b/docs/developer_reference/config.md
@@ -79,6 +79,8 @@ stages = [
 | `route_fn` | `str` or `None` | `None` | Dotted function path for request-aware result routing. The function receives `(request_id, stage_output)` and returns a downstream stage name or list of stage names. |
 | `gpu` | `int`, `list[int]`, or `None` | `None` | GPU id for the stage. `None` means CPU placement. A list is used for tensor parallel ranks. |
 | `tp_size` | `int` | `1` | Number of tensor-parallel ranks. Must match `len(gpu)` when `gpu` is a list. |
+| `num_replicas` | `int` | `1` | Number of runtime instances for this logical stage. Entry stages may be replicated; fused stages may not. |
+| `replica_devices` | `str`, `list[int]`, or `None` | `None` | Explicit GPU assignment for replica TP ranks. GPU stages require exactly `num_replicas * tp_size` entries. |
 | `process` | `str` or `None` | `None` | OS process group identifier. Non-TP stages with the same `process` value share a single OS process; today every non-TP stage must declare one explicitly (see also `_validate_general`). For TP stages, `process` is optional and acts as a prefix for the derived rank-process names (`{process}_tp{rank}`); if unset, the stage name is used as the prefix. |
 | `wait_for` | `list[str]` or `None` | `None` | Upstream stages required before this stage can execute a request. |
 | `wait_for_fn` | `str` or `None` | `None` | Dotted function path for request-aware fan-in source selection. The function receives `(request_id, from_stage, payload)` and returns the active subset of `wait_for`, or `None` when the payload does not determine the subset yet. |
@@ -99,6 +101,30 @@ per-request subset. The returned subset must be non-empty and contained in
 payload can resolve the active set.
 When using `stream_done_to_fn`, keep `stream_to` as the static superset because
 runtime prep derives stream receivers and same-GPU stream paths from it.
+
+### Stage replicas
+
+For `N = num_replicas` and `T = tp_size`, a replicated GPU stage must provide
+exactly `N * T` ids in `replica_devices`. Each consecutive group of `T` ids is
+assigned to one replica. For example, `N=2`, `T=2`, and
+`replica_devices="0,1,2,3"` produce `[0, 1]` for replica 0 and `[2, 3]` for
+replica 1. CPU-only replicated stages do not require `replica_devices`.
+
+GPU ids must be non-negative and within the launcher's visible device range.
+Ids within one replica's TP group must be unique, but different replicas may
+reuse a GPU; for example, `N=2`, `T=1`, and `replica_devices="0,0"` place both
+replicas on GPU 0. Separate processes sharing a GPU must declare
+`runtime.resources.total_gpu_memory_fraction` values accepted by the placement
+budget checks.
+
+The runtime expands a logical stage `name` into `name@r0`, `name@r1`, and so on.
+Model configuration continues to use logical names in `next`, `wait_for`,
+`stream_to`, and `project_payload`. At receive boundaries, transport messages,
+ACK routing, ordering lanes, and profiler events retain the concrete source
+name, while `wait_for_fn`, merge-input keys, `StreamItem.from_stage`, and
+`StreamSignal.from_stage` receive the logical name. The coordinator applies the
+same request-sticky binding to a replicated entry stage before submitting the
+request.
 
 Derived from stages:
 

--- a/examples/configs/qwen3_omni_speech_replica2.yaml
+++ b/examples/configs/qwen3_omni_speech_replica2.yaml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Qwen3-Omni speech pipeline with 2 replicas of talker_ar + code2wav.
+#
+# Layout (3 GPUs):
+#   GPU 0: thinker (single instance)
+#   GPU 1: talker_ar@r0 + code2wav@r0
+#   GPU 2: talker_ar@r1 + code2wav@r1
+#
+# Requests are bound to one replica per stage at admission (round-robin) and
+# stay sticky for their lifetime. With equal counts the talker/code2wav
+# indices align, so each request's codec stream stays on one GPU.
+#
+# Serve:
+#   sgl-omni serve --config examples/configs/qwen3_omni_speech_replica2.yaml --port 8091
+#
+# Baseline A/B counterpart: the default speech pipeline (no --config needed),
+# which runs one talker_ar + code2wav pair on GPU 1.
+
+config_cls: Qwen3OmniSpeechPipelineConfig
+name: qwen3-omni-speech-replica2
+model_path: Qwen/Qwen3-Omni-30B-A3B-Instruct
+
+stage_overrides:
+  talker_ar:
+    num_replicas: 2
+    replica_devices: "1,2"
+
+  code2wav:
+    num_replicas: 2
+    replica_devices: "1,2"

--- a/sglang_omni/comm/engine.py
+++ b/sglang_omni/comm/engine.py
@@ -39,6 +39,7 @@ class _PayloadSendJob(msgspec.Struct, frozen=True):
     target_endpoint: str
     ready: asyncio.Future[DataRef]
     enqueued_ns: int
+    replica_bindings: dict[str, int] | None = None
 
 
 class _StreamSendJob(msgspec.Struct, frozen=True):
@@ -54,6 +55,7 @@ class _StreamSendJob(msgspec.Struct, frozen=True):
     transport: TransportKind
     ready: asyncio.Future[DataRef]
     enqueued_ns: int
+    replica_bindings: dict[str, int] | None = None
 
 
 class CommEngine:
@@ -126,6 +128,7 @@ class CommEngine:
         from_stage: str,
         to_stage: str,
         target_endpoint: str,
+        replica_bindings: dict[str, int] | None = None,
     ) -> DataRef:
         if not isinstance(payload, StagePayload):
             raise TypeError(
@@ -147,6 +150,7 @@ class CommEngine:
                 target_endpoint=target_endpoint,
                 ready=ready,
                 enqueued_ns=enqueue_start,
+                replica_bindings=replica_bindings,
             )
         )
         _comm_trace(
@@ -183,6 +187,7 @@ class CommEngine:
         chunk_id: int,
         metadata: dict[str, Any] | None,
         transport: TransportKind,
+        replica_bindings: dict[str, int] | None = None,
     ) -> None:
         queue = self._send_queue_for(target_stage)
         loop = asyncio.get_running_loop()
@@ -202,6 +207,7 @@ class CommEngine:
                 transport=transport,
                 ready=ready,
                 enqueued_ns=enqueue_start,
+                replica_bindings=replica_bindings,
             )
         )
         _comm_trace(
@@ -321,6 +327,7 @@ class CommEngine:
                     from_stage=job.from_stage,
                     to_stage=job.to_stage,
                     data_ref=data_ref.to_dict(),
+                    replica_bindings=job.replica_bindings,
                 ),
             )
             control_ms = _comm_elapsed_ms(control_start)
@@ -374,6 +381,7 @@ class CommEngine:
                     to_stage=job.target_stage,
                     data_ref=data_ref.to_dict(),
                     chunk_id=job.chunk_id,
+                    replica_bindings=job.replica_bindings,
                 ),
             )
             control_ms = _comm_elapsed_ms(control_start)

--- a/sglang_omni/comm/stage_io.py
+++ b/sglang_omni/comm/stage_io.py
@@ -478,6 +478,7 @@ async def send_stream_signal(
     from_stage: str,
     is_done: bool = False,
     error: str | None = None,
+    replica_bindings: dict[str, int] | None = None,
 ) -> None:
     await control_plane.send_to_stage(
         target_stage,
@@ -489,6 +490,7 @@ async def send_stream_signal(
             data_ref=None,
             is_done=is_done,
             error=error,
+            replica_bindings=replica_bindings,
         ),
     )
 

--- a/sglang_omni/config/manager.py
+++ b/sglang_omni/config/manager.py
@@ -165,19 +165,25 @@ def _apply_stage_overrides(
         if not isinstance(override, dict):
             raise ValueError(f"stage_overrides.{stage_name} must be a mapping")
 
-        unsupported = sorted(set(override) - {"runtime"})
+        supported = {"runtime", "num_replicas", "replica_devices"}
+        unsupported = sorted(set(override) - supported)
         if unsupported:
             raise ValueError(
-                f"stage_overrides.{stage_name} supports only runtime overrides; "
-                f"got unsupported keys {unsupported}"
+                f"stage_overrides.{stage_name} supports only "
+                f"{sorted(supported)} overrides; got unsupported keys "
+                f"{unsupported}"
             )
+
+        stage = stage_by_name[stage_name]
+        for scalar_key in ("num_replicas", "replica_devices"):
+            if scalar_key in override:
+                stage[scalar_key] = override[scalar_key]
 
         if "runtime" not in override:
             continue
         runtime_override = override["runtime"]
         if not isinstance(runtime_override, dict):
             raise ValueError(f"stage_overrides.{stage_name}.runtime must be a mapping")
-        stage = stage_by_name[stage_name]
         stage["runtime"] = _deep_merge_dict(
             stage.get("runtime", {}),
             runtime_override,

--- a/sglang_omni/config/placement.py
+++ b/sglang_omni/config/placement.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import inspect
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Protocol
 
 from sglang_omni.config.runtime import reject_untyped_total_gpu_memory_fraction
@@ -34,6 +34,16 @@ class GpuPlacement:
 class StagePlacementPlan:
     stages: dict[str, StagePlacement]
     gpus: dict[int, GpuPlacement]
+    replica_instances: dict[str, tuple[str, ...]] = field(default_factory=dict)
+
+    def instances_of(self, logical_name: str) -> list[StagePlacement]:
+        """Placements of every replica instance behind *logical_name*.
+
+        Unreplicated stages resolve to their own placement; CPU-only stages
+        (absent from the plan) resolve to an empty list.
+        """
+        names = self.replica_instances.get(logical_name, (logical_name,))
+        return [self.stages[name] for name in names if name in self.stages]
 
 
 class PlacementPolicy(Protocol):
@@ -51,6 +61,7 @@ class StagePlacementPlanner:
         *,
         stages_cfg: list[StageConfig] | None = None,
         apply_policy: bool = True,
+        replica_instances: dict[str, tuple[str, ...]] | None = None,
     ) -> StagePlacementPlan:
         stages = stages_cfg if stages_cfg is not None else self._config.stages
         placements: dict[str, StagePlacement] = {}
@@ -83,6 +94,7 @@ class StagePlacementPlanner:
         plan = StagePlacementPlan(
             stages=placements,
             gpus=gpu_plans,
+            replica_instances=dict(replica_instances or {}),
         )
         self._validate_memory_budgets(plan)
         if apply_policy:
@@ -105,10 +117,12 @@ def build_stage_placement_plan(
     *,
     stages_cfg: list[StageConfig] | None = None,
     apply_policy: bool = True,
+    replica_instances: dict[str, tuple[str, ...]] | None = None,
 ) -> StagePlacementPlan:
     return StagePlacementPlanner(config).build(
         stages_cfg=stages_cfg,
         apply_policy=apply_policy,
+        replica_instances=replica_instances,
     )
 
 

--- a/sglang_omni/config/runtime.py
+++ b/sglang_omni/config/runtime.py
@@ -7,7 +7,11 @@ import inspect
 from collections.abc import Callable, Mapping
 from typing import Any
 
-from sglang_omni.config.schema import PipelineConfig, StageConfig
+from sglang_omni.config.schema import (
+    PipelineConfig,
+    StageConfig,
+    parse_replica_instance_name,
+)
 from sglang_omni.utils.imports import import_string
 
 
@@ -37,6 +41,24 @@ def resolve_stage_factory_args(
     )
 
 
+def _runtime_overrides_for(
+    stage_name: str,
+    global_cfg: PipelineConfig,
+) -> dict[str, Any]:
+    """Overrides for *stage_name*, falling back to its logical stage.
+
+    Replica expansion renames stages to ``talker_ar@r0``, but
+    ``runtime_overrides`` stays keyed by the logical name the user wrote.
+    """
+    override = global_cfg.runtime_overrides.get(stage_name)
+    if override is not None:
+        return override
+    logical, replica_id = parse_replica_instance_name(stage_name)
+    if replica_id is None:
+        return {}
+    return global_cfg.runtime_overrides.get(logical, {})
+
+
 def resolve_stage_static_factory_args(
     stage_cfg: StageConfig,
     global_cfg: PipelineConfig,
@@ -44,7 +66,7 @@ def resolve_stage_static_factory_args(
     """Resolve factory kwargs that do not require importing the factory."""
 
     args = dict(stage_cfg.factory_args)
-    runtime_overrides = global_cfg.runtime_overrides.get(stage_cfg.name, {})
+    runtime_overrides = _runtime_overrides_for(stage_cfg.name, global_cfg)
     _validate_runtime_sources(stage_cfg, args, runtime_overrides)
     _merge_factory_arg_overrides(args, runtime_overrides)
     _apply_typed_runtime_args(args, stage_cfg)

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -446,10 +446,6 @@ class PipelineConfig(BaseModel):
                         f"Stage {s.name!r} project_payload references unknown stage {t!r}"
                     )
 
-        replicated = [s.name for s in self.stages if s.num_replicas > 1]
-        if replicated and entry in replicated:
-            raise ValueError(f"Entry stage {entry!r} cannot be replicated")
-
         for s in self.stages:
             if parse_replica_instance_name(s.name)[1] is not None:
                 raise ValueError(

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -163,6 +163,10 @@ class StageConfig(BaseModel):
     parallelism: ParallelismConfig = Field(default_factory=ParallelismConfig)
     process: str | None = None
 
+    # --- Replicas ---
+    num_replicas: int = 1
+    replica_devices: str | list[int] | None = None
+
     # --- Runtime intent ---
     runtime: StageRuntimeConfig = Field(default_factory=StageRuntimeConfig)
     runtime_arg_map: dict[str, str] = Field(default_factory=dict)
@@ -195,6 +199,8 @@ class StageConfig(BaseModel):
         parallelism_set = "parallelism" in fields_set
         if self.tp_size < 1:
             raise ValueError(f"Stage {self.name!r} must have tp_size >= 1")
+        if self.num_replicas < 1:
+            raise ValueError(f"Stage {self.name!r} must have num_replicas >= 1")
         if self.process is not None:
             self.process = self.process.strip()
             if not self.process:
@@ -426,6 +432,10 @@ class PipelineConfig(BaseModel):
                         f"Stage {s.name!r} project_payload references unknown stage {t!r}"
                     )
 
+        replicated = [s.name for s in self.stages if s.num_replicas > 1]
+        if replicated and entry in replicated:
+            raise ValueError(f"Entry stage {entry!r} cannot be replicated")
+
         for stage_name in self.runtime_overrides:
             if stage_name not in names:
                 raise ValueError(
@@ -474,6 +484,11 @@ class PipelineConfig(BaseModel):
             if stage.tp_size != 1:
                 raise ValueError(
                     f"fused group {group} cannot include TP stage {stage.name!r}"
+                )
+            if stage.num_replicas > 1:
+                raise ValueError(
+                    f"fused group {group} cannot include replicated stage "
+                    f"{stage.name!r}"
                 )
 
         gpu_ids = {

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -7,6 +7,20 @@ from typing import Any, ClassVar
 
 from pydantic import BaseModel, ConfigDict, Field
 
+REPLICA_SEPARATOR = "@r"
+
+
+def replica_instance_name(logical_name: str, replica_id: int) -> str:
+    return f"{logical_name}{REPLICA_SEPARATOR}{replica_id}"
+
+
+def parse_replica_instance_name(name: str) -> tuple[str, int | None]:
+    """Split ``stage@rN`` into ``(stage, N)``; plain names get ``None``."""
+    logical, sep, suffix = name.rpartition(REPLICA_SEPARATOR)
+    if not sep or not suffix.isdigit():
+        return name, None
+    return logical, int(suffix)
+
 
 class CommConfig(BaseModel):
     """Per-stage communication buffer and Mooncake options.
@@ -435,6 +449,13 @@ class PipelineConfig(BaseModel):
         replicated = [s.name for s in self.stages if s.num_replicas > 1]
         if replicated and entry in replicated:
             raise ValueError(f"Entry stage {entry!r} cannot be replicated")
+
+        for s in self.stages:
+            if parse_replica_instance_name(s.name)[1] is not None:
+                raise ValueError(
+                    f"Stage name {s.name!r} uses the '@r<N>' suffix reserved "
+                    "for replica instances"
+                )
 
         for stage_name in self.runtime_overrides:
             if stage_name not in names:

--- a/sglang_omni/models/qwen3_omni/placement.py
+++ b/sglang_omni/models/qwen3_omni/placement.py
@@ -52,19 +52,16 @@ class Qwen3OmniPlacementPolicy:
             self._validate_colocated_qwen_runtime(stage_map)
             return
 
-        thinker = plan.stages.get("thinker")
-        talker = plan.stages.get("talker_ar")
-        if thinker is None or talker is None:
-            return
-        if thinker.tp_size != 1 or talker.tp_size != 1:
-            return
-        if not set(thinker.gpu_ids).intersection(talker.gpu_ids):
-            return
-
-        raise ValueError(
-            "Qwen thinker and talker_ar may share a GPU only with "
-            f"{_COLOCATED_CONFIG_CLASS}"
-        )
+        for thinker in plan.instances_of("thinker"):
+            for talker in plan.instances_of("talker_ar"):
+                if thinker.tp_size != 1 or talker.tp_size != 1:
+                    continue
+                if not set(thinker.gpu_ids).intersection(talker.gpu_ids):
+                    continue
+                raise ValueError(
+                    f"Qwen thinker and talker_ar ({talker.stage_name!r}) may "
+                    f"share a GPU only with {_COLOCATED_CONFIG_CLASS}"
+                )
 
     def _validate_colocated_qwen_replicas(self, stage_map) -> None:
         replicated = sorted(

--- a/sglang_omni/models/qwen3_omni/placement.py
+++ b/sglang_omni/models/qwen3_omni/placement.py
@@ -46,6 +46,7 @@ class Qwen3OmniPlacementPolicy:
             return
 
         if type(config).__name__ == _COLOCATED_CONFIG_CLASS:
+            self._validate_colocated_qwen_replicas(stage_map)
             self._validate_colocated_qwen_parallelism(stage_map)
             self._validate_colocated_qwen_topology(plan)
             self._validate_colocated_qwen_runtime(stage_map)
@@ -64,6 +65,16 @@ class Qwen3OmniPlacementPolicy:
             "Qwen thinker and talker_ar may share a GPU only with "
             f"{_COLOCATED_CONFIG_CLASS}"
         )
+
+    def _validate_colocated_qwen_replicas(self, stage_map) -> None:
+        replicated = sorted(
+            name for name, stage in stage_map.items() if stage.num_replicas > 1
+        )
+        if replicated:
+            raise ValueError(
+                "Qwen colocated speech does not support stage replicas; "
+                f"got num_replicas > 1 for {replicated}"
+            )
 
     def _validate_colocated_qwen_parallelism(self, stage_map) -> None:
         for stage_name in _AR_STAGES:

--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -392,18 +392,47 @@ class Coordinator:
         if self._request_id_is_reserved(request_id):
             raise ValueError(f"Request {request_id} already exists")
 
-        if self.entry_stage not in self._stages:
-            raise ValueError(f"Entry stage {self.entry_stage} not registered")
+        missing_entry_instances = [
+            instance
+            for instance in self._replica_topology.instances(self.entry_stage)
+            if instance not in self._stages
+        ]
+        if missing_entry_instances:
+            missing = ", ".join(repr(instance) for instance in missing_entry_instances)
+            raise ValueError(
+                f"Entry stage {self.entry_stage!r} has unregistered instance(s): "
+                f"{missing}"
+            )
 
         if not isinstance(request, OmniRequest):
             request = OmniRequest(inputs=request)
+
+        terminal_stages = self._resolve_terminal_stages(request)
+        replica_bindings = assign_replica_bindings(
+            self._replica_topology, self._binding_policy, request_id
+        )
+        try:
+            entry_instance = self._replica_topology.resolve_bound(
+                self.entry_stage,
+                replica_bindings,
+            )
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Failed to resolve entry stage {self.entry_stage!r}: {exc}"
+            ) from exc
+        entry_info = self._stages.get(entry_instance)
+        if entry_info is None:
+            raise ValueError(
+                f"Entry stage {self.entry_stage!r} resolved to unregistered "
+                f"instance {entry_instance!r}"
+            )
 
         # Track request
         self._requests[request_id] = RequestInfo(
             request_id=request_id,
             state=RequestState.PENDING,
             current_stage=self.entry_stage,
-            terminal_stages=self._resolve_terminal_stages(request),
+            terminal_stages=terminal_stages,
         )
 
         # Create future for completion
@@ -423,17 +452,15 @@ class Coordinator:
             request_id=request_id,
             stage="coordinator",
             event_name="request_admission",
-            metadata={"entry_stage": self.entry_stage},
-        )
-
-        replica_bindings = assign_replica_bindings(
-            self._replica_topology, self._binding_policy, request_id
+            metadata={
+                "entry_stage": self.entry_stage,
+                "entry_instance": entry_instance,
+            },
         )
 
         # Submit to entry stage
-        entry_info = self._stages[self.entry_stage]
         await self.control_plane.submit_to_stage(
-            self.entry_stage,
+            entry_instance,
             entry_info.control_endpoint,
             SubmitMessage(
                 request_id=request_id,
@@ -448,9 +475,10 @@ class Coordinator:
             info.state = RequestState.RUNNING
 
         logger.info(
-            "Coordinator submitted req=%s to %s at %s bindings=%s",
+            "Coordinator submitted req=%s to entry=%s instance=%s at %s bindings=%s",
             request_id,
             self.entry_stage,
+            entry_instance,
             entry_info.control_endpoint,
             replica_bindings,
         )
@@ -846,6 +874,8 @@ async def run_coordinator(
     stages: dict[str, str],  # name -> endpoint
     terminal_stages: list[str] | None = None,
     terminal_stages_resolver: Callable[[OmniRequest], list[str] | None] | None = None,
+    replica_topology: ReplicaTopology | None = None,
+    binding_policy: BindingPolicy | None = None,
 ) -> Coordinator:
     """Create and start a coordinator.
 
@@ -855,6 +885,8 @@ async def run_coordinator(
         entry_stage: Name of the entry stage
         stages: Dict of stage_name -> stage_endpoint
         terminal_stages: Optional list of terminal stage names for multi-terminal merge
+        replica_topology: Optional logical-to-instance replica mapping
+        binding_policy: Optional per-request replica selection policy
 
     Returns:
         Started Coordinator instance
@@ -865,6 +897,8 @@ async def run_coordinator(
         entry_stage=entry_stage,
         terminal_stages=terminal_stages,
         terminal_stages_resolver=terminal_stages_resolver,
+        replica_topology=replica_topology,
+        binding_policy=binding_policy,
     )
 
     # Register stages

--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -5,7 +5,7 @@ import asyncio
 import logging
 import uuid
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, AsyncIterator
 
 from sglang_omni.pipeline.control_plane import CoordinatorControlPlane
@@ -448,10 +448,11 @@ class Coordinator:
             info.state = RequestState.RUNNING
 
         logger.info(
-            "Coordinator submitted req=%s to %s at %s",
+            "Coordinator submitted req=%s to %s at %s bindings=%s",
             request_id,
             self.entry_stage,
             entry_info.control_endpoint,
+            replica_bindings,
         )
 
     def _request_id_is_reserved(self, request_id: str) -> bool:
@@ -610,6 +611,12 @@ class Coordinator:
 
         info = self._requests[request_id]
 
+        # Note (wenyao): the client reads ``from_stage`` off the completion.
+        # Observability emits above keep the instance name.
+        from_stage = self._replica_topology.logical_name(msg.from_stage)
+        if from_stage != msg.from_stage:
+            msg = replace(msg, from_stage=from_stage)
+
         # Fail-fast: any terminal failure -> fail entire request
         if not msg.success:
             info.state = RequestState.FAILED
@@ -626,7 +633,6 @@ class Coordinator:
             self._requests.pop(request_id, None)
             return
 
-        from_stage = self._replica_topology.logical_name(msg.from_stage)
         expected_terminal_stages = self._expected_terminal_stages(request_id)
         if expected_terminal_stages and from_stage not in expected_terminal_stages:
             logger.debug(
@@ -699,6 +705,17 @@ class Coordinator:
                 "modality": msg.modality,
             },
         )
+        # Note (wenyao): normalize both fields -- the client falls back to
+        # ``stage_name or from_stage``. Observability emits above keep the
+        # instance name.
+        logical = self._replica_topology.logical_name(msg.from_stage)
+        stage_name = (
+            self._replica_topology.logical_name(msg.stage_name)
+            if msg.stage_name is not None
+            else msg.stage_name
+        )
+        if logical != msg.from_stage or stage_name != msg.stage_name:
+            msg = replace(msg, from_stage=logical, stage_name=stage_name)
         await self._stream_queues[request_id].put(msg)
 
     def _handle_admin_result(self, result: AdminResult) -> None:
@@ -721,7 +738,13 @@ class Coordinator:
     def _resolve_admin_stages(self, stages: Sequence[str] | None) -> list[str]:
         if stages is None:
             return sorted(self._stages)
-        resolved = list(stages)
+        # Note (wenyao): dedup preserving order so a caller passing both a
+        # logical name and one of its instances does not double-send admin ops.
+        resolved: list[str] = []
+        for name in stages:
+            for instance in self._replica_topology.instances(name):
+                if instance not in resolved:
+                    resolved.append(instance)
         unknown = sorted(set(resolved) - set(self._stages))
         if unknown:
             raise ValueError(f"Unknown admin target stage(s): {unknown}")

--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -9,6 +9,12 @@ from dataclasses import dataclass, field
 from typing import Any, AsyncIterator
 
 from sglang_omni.pipeline.control_plane import CoordinatorControlPlane
+from sglang_omni.pipeline.replicas import (
+    BindingPolicy,
+    ReplicaTopology,
+    RoundRobinBindingPolicy,
+    assign_replica_bindings,
+)
 from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.proto import (
     AbortMessage,
@@ -58,6 +64,8 @@ class Coordinator:
         terminal_stages_resolver: (
             Callable[[OmniRequest], list[str] | None] | None
         ) = None,
+        replica_topology: ReplicaTopology | None = None,
+        binding_policy: BindingPolicy | None = None,
     ):
         """Initialize coordinator.
 
@@ -74,6 +82,8 @@ class Coordinator:
         )
         self._terminal_stages_resolver = terminal_stages_resolver
         self._partial_results: dict[str, dict[str, Any]] = {}
+        self._replica_topology = replica_topology or ReplicaTopology()
+        self._binding_policy = binding_policy or RoundRobinBindingPolicy()
 
         # Control plane
         self.control_plane = CoordinatorControlPlane(
@@ -344,7 +354,9 @@ class Coordinator:
                     if not msg.success:
                         raise RuntimeError(msg.error or "Unknown error")
                     yield msg
-                    completed_stages.add(msg.from_stage)
+                    completed_stages.add(
+                        self._replica_topology.logical_name(msg.from_stage)
+                    )
                     if (
                         not expected_terminal_stages
                         or completed_stages >= expected_terminal_stages
@@ -414,12 +426,20 @@ class Coordinator:
             metadata={"entry_stage": self.entry_stage},
         )
 
+        replica_bindings = assign_replica_bindings(
+            self._replica_topology, self._binding_policy, request_id
+        )
+
         # Submit to entry stage
         entry_info = self._stages[self.entry_stage]
         await self.control_plane.submit_to_stage(
             self.entry_stage,
             entry_info.control_endpoint,
-            SubmitMessage(request_id=request_id, data=payload),
+            SubmitMessage(
+                request_id=request_id,
+                data=payload,
+                replica_bindings=replica_bindings,
+            ),
         )
 
         # Update state
@@ -606,8 +626,9 @@ class Coordinator:
             self._requests.pop(request_id, None)
             return
 
+        from_stage = self._replica_topology.logical_name(msg.from_stage)
         expected_terminal_stages = self._expected_terminal_stages(request_id)
-        if expected_terminal_stages and msg.from_stage not in expected_terminal_stages:
+        if expected_terminal_stages and from_stage not in expected_terminal_stages:
             logger.debug(
                 "Coordinator ignoring completion from inactive terminal: "
                 "req=%s stage=%s expected=%s",
@@ -632,7 +653,7 @@ class Coordinator:
 
         # Multi-terminal: collect partial results
         partials = self._partial_results.setdefault(request_id, {})
-        partials[msg.from_stage] = msg.result
+        partials[from_stage] = msg.result
 
         # Forward stream completion per-stage
         if request_id in self._stream_queues:

--- a/sglang_omni/pipeline/local_dispatch.py
+++ b/sglang_omni/pipeline/local_dispatch.py
@@ -40,9 +40,12 @@ class LocalStageDispatcher:
         to_stage: str,
         request_id: str,
         payload: Any,
+        replica_bindings: dict[str, int] | None = None,
     ) -> None:
         target = self._get_stage(from_stage, to_stage)
-        await target.receive_local_payload(request_id, from_stage, payload)
+        await target.receive_local_payload(
+            request_id, from_stage, payload, replica_bindings
+        )
 
     async def send_stream_chunk(
         self,
@@ -53,6 +56,7 @@ class LocalStageDispatcher:
         chunk_id: int,
         data: Any,
         metadata: dict[str, Any] | None = None,
+        replica_bindings: dict[str, int] | None = None,
     ) -> None:
         target = self._get_stage(from_stage, to_stage)
         await target.receive_local_stream_chunk(
@@ -61,6 +65,7 @@ class LocalStageDispatcher:
             chunk_id,
             data,
             metadata,
+            replica_bindings,
         )
 
     async def send_stream_signal(
@@ -71,6 +76,7 @@ class LocalStageDispatcher:
         request_id: str,
         is_done: bool = False,
         error: str | None = None,
+        replica_bindings: dict[str, int] | None = None,
     ) -> None:
         target = self._get_stage(from_stage, to_stage)
         await target.receive_local_stream_signal(
@@ -78,4 +84,5 @@ class LocalStageDispatcher:
             from_stage,
             is_done=is_done,
             error=error,
+            replica_bindings=replica_bindings,
         )

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -101,6 +101,7 @@ def _build_stage_groups(
             stage_cfg_by_name,
             name_map,
             process_plan,
+            replica_topology,
         )
 
         # Avoid importing stage factories in the parent process. The child
@@ -121,9 +122,7 @@ def _build_stage_groups(
             project_payload={
                 instance: dotted_path
                 for target, dotted_path in stage_cfg.project_payload.items()
-                for instance in replica_topology.instances(
-                    name_map.get(target, target)
-                )
+                for instance in replica_topology.instances(name_map.get(target, target))
             },
             coordinator_endpoint=endpoints["completion"],
             abort_endpoint=endpoints["abort"],
@@ -228,12 +227,15 @@ def _resolve_same_process_targets(
     stage_cfg_by_name: dict[str, StageConfig],
     name_map: dict[str, str],
     process_plan: ProcessTopologyPlan,
+    replica_topology: ReplicaTopology | None = None,
 ) -> set[str]:
     if stage_cfg.tp_size > 1:
         return set()
     source_process = process_plan.stage_to_process.get(stage_cfg.name)
     if source_process is None:
         return set()
+    if replica_topology is None:
+        replica_topology = ReplicaTopology()
 
     raw_targets: list[str] = []
     if stage_cfg.next is not None:
@@ -244,12 +246,13 @@ def _resolve_same_process_targets(
 
     same_process_targets: set[str] = set()
     for raw_target in raw_targets:
-        target = name_map.get(raw_target, raw_target)
-        target_cfg = stage_cfg_by_name.get(target)
-        if target_cfg is None or target_cfg.tp_size > 1:
-            continue
-        if process_plan.stage_to_process.get(target) == source_process:
-            same_process_targets.add(target)
+        logical = name_map.get(raw_target, raw_target)
+        for target in replica_topology.instances(logical):
+            target_cfg = stage_cfg_by_name.get(target)
+            if target_cfg is None or target_cfg.tp_size > 1:
+                continue
+            if process_plan.stage_to_process.get(target) == source_process:
+                same_process_targets.add(target)
     return same_process_targets
 
 

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -25,6 +25,7 @@ from sglang_omni.config.runtime import (
 from sglang_omni.config.schema import PipelineConfig, StageConfig
 from sglang_omni.config.topology import ProcessTopologyPlan
 from sglang_omni.pipeline import Coordinator
+from sglang_omni.pipeline.replicas import ReplicaTopology
 from sglang_omni.pipeline.runtime_config import (
     IpcRuntimeDir,
     PipelineRuntimePrep,
@@ -50,6 +51,7 @@ def _build_stage_groups(
     endpoints: dict[str, str],
     placement_plan: StagePlacementPlan,
     process_plan: ProcessTopologyPlan,
+    replica_topology: ReplicaTopology | None = None,
 ) -> list[StageGroup]:
     """Build lifecycle groups from prepared endpoints and process topology.
 
@@ -58,12 +60,15 @@ def _build_stage_groups(
     """
     if ctx is None:
         ctx = multiprocessing.get_context("spawn")
+    if replica_topology is None:
+        replica_topology = ReplicaTopology()
 
     stage_endpoints = {s.name: endpoints[f"stage_{s.name}"] for s in stages_cfg}
     stream_receivers: set[str] = set()
     for scfg in stages_cfg:
         for target in scfg.stream_to:
-            stream_receivers.add(target)
+            canonical = name_map.get(target, target)
+            stream_receivers.update(replica_topology.instances(canonical))
     stage_cfg_by_name = {stage.name: stage for stage in stages_cfg}
 
     nccl_port_counter = _NcclPortAllocator()
@@ -114,8 +119,11 @@ def _build_stage_groups(
             wait_for_fn=stage_cfg.wait_for_fn,
             merge_fn=stage_cfg.merge_fn,
             project_payload={
-                name_map.get(target, target): dotted_path
+                instance: dotted_path
                 for target, dotted_path in stage_cfg.project_payload.items()
+                for instance in replica_topology.instances(
+                    name_map.get(target, target)
+                )
             },
             coordinator_endpoint=endpoints["completion"],
             abort_endpoint=endpoints["abort"],
@@ -129,6 +137,7 @@ def _build_stage_groups(
             can_accept_stream_before_payload=stage_cfg.can_accept_stream_before_payload,
             disable_direct_cuda_ipc_payload=stage_cfg.disable_direct_cuda_ipc_payload,
             name_map=name_map,
+            replica_topology=replica_topology.to_dict(),
         )
         if tp_size == 1:
             single_stage_specs[stage_cfg.name] = _build_single_stage_spec(
@@ -437,6 +446,7 @@ class MultiProcessPipelineRunner:
                 endpoints=prep.endpoints,
                 placement_plan=prep.placement_plan,
                 process_plan=prep.process_plan,
+                replica_topology=prep.replica_topology,
             )
 
             terminal_stages_resolver = (
@@ -450,6 +460,7 @@ class MultiProcessPipelineRunner:
                 entry_stage=prep.entry_stage,
                 terminal_stages=self._config.terminal_stages or None,
                 terminal_stages_resolver=terminal_stages_resolver,
+                replica_topology=prep.replica_topology,
             )
             await self._coordinator.start()
             self._completion_task = asyncio.create_task(

--- a/sglang_omni/pipeline/replicas.py
+++ b/sglang_omni/pipeline/replicas.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime-level stage replicas.
+
+A logical stage with ``num_replicas = N`` is expanded into N replica instance
+stages before placement/endpoint allocation. Model code, route hooks, and
+placement policies keep referring to the logical stage name; the runtime
+resolves ``(logical name, request binding) -> instance`` at every send site.
+Bindings are assigned once per request by the coordinator at admission and
+propagate on the message envelope.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from sglang_omni.config.schema import StageConfig
+
+REPLICA_SEPARATOR = "@r"
+
+
+def replica_instance_name(logical_name: str, replica_id: int) -> str:
+    return f"{logical_name}{REPLICA_SEPARATOR}{replica_id}"
+
+
+def parse_replica_instance_name(name: str) -> tuple[str, int | None]:
+    logical, sep, suffix = name.rpartition(REPLICA_SEPARATOR)
+    if not sep or not suffix.isdigit():
+        return name, None
+    return logical, int(suffix)
+
+
+@dataclass(frozen=True)
+class ReplicaTopology:
+
+    replicas: dict[str, tuple[str, ...]] = field(default_factory=dict)
+
+    def __bool__(self) -> bool:
+        return bool(self.replicas)
+
+    def is_replicated(self, logical_name: str) -> bool:
+        return logical_name in self.replicas
+
+    def num_replicas(self, logical_name: str) -> int:
+        instances = self.replicas.get(logical_name)
+        return len(instances) if instances is not None else 1
+
+    def instances(self, logical_name: str) -> tuple[str, ...]:
+        instances = self.replicas.get(logical_name)
+        if instances is None:
+            return (logical_name,)
+        return instances
+
+    def resolve(self, logical_name: str, replica_id: int) -> str:
+        instances = self.replicas.get(logical_name)
+        if instances is None:
+            if replica_id != 0:
+                raise ValueError(
+                    f"Stage {logical_name!r} is not replicated; got replica_id="
+                    f"{replica_id}"
+                )
+            return logical_name
+        if not 0 <= replica_id < len(instances):
+            raise ValueError(
+                f"Stage {logical_name!r} has {len(instances)} replicas; got "
+                f"replica_id={replica_id}"
+            )
+        return instances[replica_id]
+
+    def logical_name(self, name: str) -> str:
+        logical, replica_id = parse_replica_instance_name(name)
+        if replica_id is None:
+            return name
+        instances = self.replicas.get(logical)
+        if instances is None or name not in instances:
+            return name
+        return logical
+
+    def replicated_logical_names(self) -> list[str]:
+        return sorted(self.replicas)
+
+    def to_dict(self) -> dict[str, list[str]]:
+        return {name: list(instances) for name, instances in self.replicas.items()}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> "ReplicaTopology":
+        if not data:
+            return cls()
+        return cls(
+            replicas={
+                name: tuple(str(i) for i in instances)
+                for name, instances in data.items()
+            }
+        )
+
+
+def split_replica_devices(
+    replica_devices: str | list[int] | None,
+    *,
+    stage_name: str,
+    num_replicas: int,
+    tp_size: int,
+) -> list[list[int] | None]:
+    if replica_devices is None:
+        return [None] * num_replicas
+
+    if isinstance(replica_devices, str):
+        ids = [int(part) for part in replica_devices.split(",") if part.strip()]
+    else:
+        ids = [int(part) for part in replica_devices]
+
+    if len(ids) == num_replicas * tp_size:
+        return [ids[r * tp_size : (r + 1) * tp_size] for r in range(num_replicas)]
+    if len(ids) == tp_size:
+        return [[gpu_id + r * tp_size for gpu_id in ids] for r in range(num_replicas)]
+    raise ValueError(
+        f"Stage {stage_name!r}: replica_devices has {len(ids)} id(s); expected "
+        f"{tp_size} (template) or {num_replicas * tp_size} (pool) for "
+        f"num_replicas={num_replicas}, tp_size={tp_size}"
+    )
+
+
+def expand_replica_stages(
+    stages_cfg: list[StageConfig],
+) -> tuple[list[StageConfig], ReplicaTopology]:
+    """Expand replicated logical stages into per-replica instance stages.
+
+    Instance stages keep logical names in their wiring (``next``,
+    ``stream_to``, ``wait_for``, ``project_payload``); resolution to a
+    concrete instance happens at send time from the request's bindings.
+    """
+    replicas: dict[str, tuple[str, ...]] = {}
+    expanded: list[StageConfig] = []
+
+    for stage_cfg in stages_cfg:
+        if stage_cfg.num_replicas <= 1:
+            expanded.append(stage_cfg)
+            continue
+
+        per_replica_gpus = split_replica_devices(
+            stage_cfg.replica_devices
+            if stage_cfg.replica_devices is not None
+            else stage_cfg.gpu,
+            stage_name=stage_cfg.name,
+            num_replicas=stage_cfg.num_replicas,
+            tp_size=stage_cfg.tp_size,
+        )
+
+        instance_names = []
+        for replica_id in range(stage_cfg.num_replicas):
+            instance = replica_instance_name(stage_cfg.name, replica_id)
+            instance_names.append(instance)
+            gpu_ids = per_replica_gpus[replica_id]
+            gpu: int | list[int] | None
+            if gpu_ids is None:
+                gpu = None
+            elif stage_cfg.tp_size == 1:
+                gpu = gpu_ids[0]
+            else:
+                gpu = list(gpu_ids)
+            process = stage_cfg.process
+            if process is not None:
+                process = f"{process}{REPLICA_SEPARATOR}{replica_id}"
+            expanded.append(
+                stage_cfg.model_copy(
+                    update={
+                        "name": instance,
+                        "gpu": gpu,
+                        "process": process,
+                        "num_replicas": 1,
+                        "replica_devices": None,
+                    }
+                )
+            )
+        replicas[stage_cfg.name] = tuple(instance_names)
+
+    return expanded, ReplicaTopology(replicas=replicas)
+
+
+class BindingPolicy(Protocol):
+    """Selects a replica for one (logical stage, request) at admission."""
+
+    def bind(self, logical_name: str, num_replicas: int, request_id: str) -> int: ...
+
+
+class RoundRobinBindingPolicy:
+    """Per-stage round-robin selection; thread-safe."""
+
+    def __init__(self) -> None:
+        self._counters: dict[str, int] = {}
+        self._lock = threading.Lock()
+
+    def bind(self, logical_name: str, num_replicas: int, request_id: str) -> int:
+        del request_id
+        with self._lock:
+            index = self._counters.get(logical_name, 0)
+            self._counters[logical_name] = index + 1
+        return index % num_replicas
+
+
+def assign_replica_bindings(
+    topology: ReplicaTopology,
+    policy: BindingPolicy,
+    request_id: str,
+) -> dict[str, int] | None:
+    """Return per-logical-stage replica bindings for one request."""
+    if not topology:
+        return None
+    return {
+        logical_name: policy.bind(
+            logical_name, topology.num_replicas(logical_name), request_id
+        )
+        for logical_name in topology.replicated_logical_names()
+    }

--- a/sglang_omni/pipeline/replicas.py
+++ b/sglang_omni/pipeline/replicas.py
@@ -107,6 +107,8 @@ def split_replica_devices(
 
     if isinstance(replica_devices, str):
         ids = [int(part) for part in replica_devices.split(",") if part.strip()]
+    elif isinstance(replica_devices, int):
+        ids = [replica_devices]
     else:
         ids = [int(part) for part in replica_devices]
 

--- a/sglang_omni/pipeline/replicas.py
+++ b/sglang_omni/pipeline/replicas.py
@@ -75,6 +75,20 @@ class ReplicaTopology:
             )
         return instances[replica_id]
 
+    def resolve_bound(
+        self,
+        logical_name: str,
+        bindings: dict[str, int] | None,
+    ) -> str:
+        if not self.is_replicated(logical_name):
+            return logical_name
+        replica_id = None if bindings is None else bindings.get(logical_name)
+        if replica_id is None:
+            raise ValueError(
+                f"no replica binding for replicated stage {logical_name!r}"
+            )
+        return self.resolve(logical_name, replica_id)
+
     def logical_name(self, name: str) -> str:
         logical, replica_id = parse_replica_instance_name(name)
         if replica_id is None:

--- a/sglang_omni/pipeline/replicas.py
+++ b/sglang_omni/pipeline/replicas.py
@@ -11,24 +11,31 @@ propagate on the message envelope.
 
 from __future__ import annotations
 
+import logging
 import threading
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
-from sglang_omni.config.schema import StageConfig
+from sglang_omni.config.schema import (
+    REPLICA_SEPARATOR,
+    StageConfig,
+    parse_replica_instance_name,
+    replica_instance_name,
+)
 
-REPLICA_SEPARATOR = "@r"
+logger = logging.getLogger(__name__)
 
-
-def replica_instance_name(logical_name: str, replica_id: int) -> str:
-    return f"{logical_name}{REPLICA_SEPARATOR}{replica_id}"
-
-
-def parse_replica_instance_name(name: str) -> tuple[str, int | None]:
-    logical, sep, suffix = name.rpartition(REPLICA_SEPARATOR)
-    if not sep or not suffix.isdigit():
-        return name, None
-    return logical, int(suffix)
+__all__ = [
+    "REPLICA_SEPARATOR",
+    "replica_instance_name",
+    "parse_replica_instance_name",
+    "ReplicaTopology",
+    "split_replica_devices",
+    "expand_replica_stages",
+    "BindingPolicy",
+    "RoundRobinBindingPolicy",
+    "assign_replica_bindings",
+]
 
 
 @dataclass(frozen=True)
@@ -96,7 +103,7 @@ class ReplicaTopology:
 
 
 def split_replica_devices(
-    replica_devices: str | list[int] | None,
+    replica_devices: str | list[int] | int | None,
     *,
     stage_name: str,
     num_replicas: int,
@@ -141,9 +148,11 @@ def expand_replica_stages(
             continue
 
         per_replica_gpus = split_replica_devices(
-            stage_cfg.replica_devices
-            if stage_cfg.replica_devices is not None
-            else stage_cfg.gpu,
+            (
+                stage_cfg.replica_devices
+                if stage_cfg.replica_devices is not None
+                else stage_cfg.gpu
+            ),
             stage_name=stage_cfg.name,
             num_replicas=stage_cfg.num_replicas,
             tp_size=stage_cfg.tp_size,
@@ -176,6 +185,15 @@ def expand_replica_stages(
                 )
             )
         replicas[stage_cfg.name] = tuple(instance_names)
+        logger.info(
+            "Replicated stage %r -> %s (replica_devices=%s)",
+            stage_cfg.name,
+            {
+                instance: gpus
+                for instance, gpus in zip(instance_names, per_replica_gpus)
+            },
+            stage_cfg.replica_devices,
+        )
 
     return expanded, ReplicaTopology(replicas=replicas)
 

--- a/sglang_omni/pipeline/replicas.py
+++ b/sglang_omni/pipeline/replicas.py
@@ -121,11 +121,9 @@ def split_replica_devices(
 
     if len(ids) == num_replicas * tp_size:
         return [ids[r * tp_size : (r + 1) * tp_size] for r in range(num_replicas)]
-    if len(ids) == tp_size:
-        return [[gpu_id + r * tp_size for gpu_id in ids] for r in range(num_replicas)]
     raise ValueError(
         f"Stage {stage_name!r}: replica_devices has {len(ids)} id(s); expected "
-        f"{tp_size} (template) or {num_replicas * tp_size} (pool) for "
+        f"{num_replicas * tp_size} (one per replica x tp rank) for "
         f"num_replicas={num_replicas}, tp_size={tp_size}"
     )
 
@@ -147,12 +145,15 @@ def expand_replica_stages(
             expanded.append(stage_cfg)
             continue
 
+        if stage_cfg.replica_devices is None and stage_cfg.gpu is not None:
+            raise ValueError(
+                f"Stage {stage_cfg.name!r}: num_replicas="
+                f"{stage_cfg.num_replicas} on a GPU stage requires explicit "
+                f"replica_devices with "
+                f"{stage_cfg.num_replicas * stage_cfg.tp_size} GPU id(s)"
+            )
         per_replica_gpus = split_replica_devices(
-            (
-                stage_cfg.replica_devices
-                if stage_cfg.replica_devices is not None
-                else stage_cfg.gpu
-            ),
+            stage_cfg.replica_devices,
             stage_name=stage_cfg.name,
             num_replicas=stage_cfg.num_replicas,
             tp_size=stage_cfg.tp_size,
@@ -196,6 +197,37 @@ def expand_replica_stages(
         )
 
     return expanded, ReplicaTopology(replicas=replicas)
+
+
+def validate_device_assignment(
+    stages_cfg: list[StageConfig],
+    *,
+    device_count: int | None,
+) -> None:
+    """Fail fast on GPU ids that cannot exist on this host.
+
+    Ids are indices into the launcher's visible devices, so the caller must
+    pass ``device_count`` from the launcher process. ``None`` (CUDA
+    unavailable or count unknown) skips the range check but still rejects
+    negative and duplicate ids.
+    """
+    for stage_cfg in stages_cfg:
+        gpu = stage_cfg.gpu
+        if gpu is None:
+            continue
+        ids = [gpu] if isinstance(gpu, int) else [int(part) for part in gpu]
+        for gpu_id in ids:
+            if gpu_id < 0:
+                raise ValueError(f"Stage {stage_cfg.name!r}: GPU id {gpu_id} is negative")
+            if device_count is not None and gpu_id >= device_count:
+                raise ValueError(
+                    f"Stage {stage_cfg.name!r}: GPU id {gpu_id} out of range; "
+                    f"only {device_count} visible device(s)"
+                )
+        if len(set(ids)) != len(ids):
+            raise ValueError(
+                f"Stage {stage_cfg.name!r}: duplicate GPU id in tp group {ids}"
+            )
 
 
 class BindingPolicy(Protocol):

--- a/sglang_omni/pipeline/runtime_config.py
+++ b/sglang_omni/pipeline/runtime_config.py
@@ -15,6 +15,7 @@ import zmq
 from sglang_omni.config.placement import StagePlacementPlan, build_stage_placement_plan
 from sglang_omni.config.schema import PipelineConfig, StageConfig
 from sglang_omni.config.topology import ProcessTopologyPlan, build_process_topology_plan
+from sglang_omni.pipeline.replicas import ReplicaTopology, expand_replica_stages
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +64,7 @@ class PipelineRuntimePrep:
     process_plan: ProcessTopologyPlan
     runtime_dir: IpcRuntimeDir
     runtime_dir_created_here: bool
+    replica_topology: ReplicaTopology
 
 
 def create_ipc_runtime_dir(
@@ -96,6 +98,7 @@ def prepare_pipeline_runtime(
 ) -> PipelineRuntimePrep:
     """Prepare fused stages, endpoint allocation, and process topology."""
     stages_cfg, name_map, entry_stage = config.apply_fusion()
+    stages_cfg, replica_topology = expand_replica_stages(stages_cfg)
     runtime_dir = ipc_runtime_dir
     if runtime_dir is None:
         runtime_dir = create_ipc_runtime_dir(config, stages=stages_cfg)
@@ -128,6 +131,7 @@ def prepare_pipeline_runtime(
         process_plan=process_plan,
         runtime_dir=runtime_dir,
         runtime_dir_created_here=runtime_dir_created_here,
+        replica_topology=replica_topology,
     )
 
 

--- a/sglang_omni/pipeline/runtime_config.py
+++ b/sglang_omni/pipeline/runtime_config.py
@@ -107,7 +107,11 @@ def prepare_pipeline_runtime(
         runtime_dir_created_here = False
 
     try:
-        placement_plan = build_stage_placement_plan(config, stages_cfg=stages_cfg)
+        placement_plan = build_stage_placement_plan(
+            config,
+            stages_cfg=stages_cfg,
+            replica_instances=replica_topology.replicas,
+        )
         process_plan = build_process_topology_plan(
             config,
             placement_plan,

--- a/sglang_omni/pipeline/runtime_config.py
+++ b/sglang_omni/pipeline/runtime_config.py
@@ -15,9 +15,24 @@ import zmq
 from sglang_omni.config.placement import StagePlacementPlan, build_stage_placement_plan
 from sglang_omni.config.schema import PipelineConfig, StageConfig
 from sglang_omni.config.topology import ProcessTopologyPlan, build_process_topology_plan
-from sglang_omni.pipeline.replicas import ReplicaTopology, expand_replica_stages
+from sglang_omni.pipeline.replicas import (
+    ReplicaTopology,
+    expand_replica_stages,
+    validate_device_assignment,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def _visible_device_count() -> int | None:
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return None
+        return torch.cuda.device_count()
+    except Exception:
+        return None
 
 # PyZMQ checks the filesystem path after ``ipc://`` against this budget.
 _IPC_SUN_PATH_BUDGET = getattr(zmq, "IPC_PATH_MAX_LEN", 100)
@@ -99,6 +114,7 @@ def prepare_pipeline_runtime(
     """Prepare fused stages, endpoint allocation, and process topology."""
     stages_cfg, name_map, entry_stage = config.apply_fusion()
     stages_cfg, replica_topology = expand_replica_stages(stages_cfg)
+    validate_device_assignment(stages_cfg, device_count=_visible_device_count())
     runtime_dir = ipc_runtime_dir
     if runtime_dir is None:
         runtime_dir = create_ipc_runtime_dir(config, stages=stages_cfg)

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -167,16 +167,15 @@ class Stage:
         self._replica_bindings.setdefault(request_id, {}).update(bindings)
 
     def _resolve_target_instance(self, request_id: str, target: str) -> str:
-        if not self._replica_topology.is_replicated(target):
-            return target
         bindings = self._replica_bindings.get(request_id)
-        replica_id = None if bindings is None else bindings.get(target)
-        if replica_id is None:
-            raise RuntimeError(
-                f"Stage {self.name}: no replica binding for target {target!r} "
-                f"(req={request_id})"
-            )
-        return self._replica_topology.resolve(target, replica_id)
+        try:
+            return self._replica_topology.resolve_bound(target, bindings)
+        except ValueError as exc:
+            raise RuntimeError(f"Stage {self.name}: {exc} (req={request_id})") from exc
+
+    def _logical_source_name(self, source_instance: str) -> str:
+        """Return the model-facing logical name for a transport source."""
+        return self._replica_topology.logical_name(source_instance)
 
     async def start(self) -> None:
         if self._running:
@@ -486,10 +485,11 @@ class Stage:
             return
         self._record_replica_bindings(request_id, replica_bindings)
         self._active_requests.add(request_id)
+        logical_from_stage = self._logical_source_name(from_stage)
         item = StreamItem(
             chunk_id=chunk_id,
             data=data,
-            from_stage=from_stage,
+            from_stage=logical_from_stage,
             metadata=metadata,
         )
         self._emit_stream_chunk_received(
@@ -534,7 +534,8 @@ class Stage:
             event_name="stage_input_received",
             metadata={"from_stage": from_stage, "kind": "payload"},
         )
-        merged = self.input_handler.receive(request_id, from_stage, payload)
+        logical_from_stage = self._logical_source_name(from_stage)
+        merged = self.input_handler.receive(request_id, logical_from_stage, payload)
         if merged is not None:
             _emit_event(
                 request_id=request_id,
@@ -576,7 +577,7 @@ class Stage:
             item = StreamItem(
                 chunk_id=msg.chunk_id,
                 data=data,
-                from_stage=msg.from_stage,
+                from_stage=self._logical_source_name(msg.from_stage),
                 metadata=metadata,
             )
             self._emit_stream_chunk_received(
@@ -616,7 +617,7 @@ class Stage:
         item = StreamItem(
             chunk_id=msg.chunk_id,
             data=data,
-            from_stage=msg.from_stage,
+            from_stage=self._logical_source_name(msg.from_stage),
             metadata=metadata,
         )
         self._emit_stream_chunk_received(
@@ -805,7 +806,11 @@ class Stage:
                     ),
                 )
                 return
-            self._stream_queue.put_done(request_id, from_stage=from_stage)
+            logical_from_stage = self._logical_source_name(from_stage)
+            self._stream_queue.put_done(
+                request_id,
+                from_stage=logical_from_stage,
+            )
             self.scheduler.inbox.put(
                 IncomingMessage(
                     request_id=request_id,

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -141,6 +141,7 @@ class Stage:
 
         self._running = False
         self._aborted: set[str] = set()
+        self._finished_requests: set[str] = set()
         self._active_requests: set[str] = set()
         self._stream_queue: StreamQueue | None = None
         self._stream_chunk_counters: dict[tuple[str, str], int] = {}
@@ -157,8 +158,13 @@ class Stage:
     def _record_replica_bindings(
         self, request_id: str, bindings: dict[str, int] | None
     ) -> None:
-        if bindings:
-            self._replica_bindings.setdefault(request_id, {}).update(bindings)
+        # Note (wenyao): a late message would otherwise resurrect an entry
+        # nothing clears again.
+        if not bindings:
+            return
+        if request_id in self._aborted or request_id in self._finished_requests:
+            return
+        self._replica_bindings.setdefault(request_id, {}).update(bindings)
 
     def _resolve_target_instance(self, request_id: str, target: str) -> str:
         if not self._replica_topology.is_replicated(target):
@@ -462,7 +468,9 @@ class Stage:
         request_id: str,
         from_stage: str,
         payload: Any,
+        replica_bindings: dict[str, int] | None = None,
     ) -> None:
+        self._record_replica_bindings(request_id, replica_bindings)
         await self._receive_payload_from_stage(request_id, from_stage, payload)
 
     async def receive_local_stream_chunk(
@@ -472,9 +480,11 @@ class Stage:
         chunk_id: int,
         data: Any,
         metadata: dict[str, Any] | None = None,
+        replica_bindings: dict[str, int] | None = None,
     ) -> None:
         if request_id in self._aborted:
             return
+        self._record_replica_bindings(request_id, replica_bindings)
         self._active_requests.add(request_id)
         item = StreamItem(
             chunk_id=chunk_id,
@@ -496,7 +506,9 @@ class Stage:
         *,
         is_done: bool = False,
         error: str | None = None,
+        replica_bindings: dict[str, int] | None = None,
     ) -> None:
+        self._record_replica_bindings(request_id, replica_bindings)
         await self._receive_stream_signal(
             request_id,
             from_stage,
@@ -1148,6 +1160,7 @@ class Stage:
                 to_stage=target,
                 request_id=request_id,
                 payload=projected_payload,
+                replica_bindings=self._replica_bindings.get(request_id),
             )
             return
 
@@ -1353,6 +1366,7 @@ class Stage:
                 chunk_id=chunk_id,
                 data=data,
                 metadata=metadata,
+                replica_bindings=self._replica_bindings.get(request_id),
             )
             return
         self._record_nonlocal_stream_target(request_id, target)
@@ -1443,6 +1457,7 @@ class Stage:
                 request_id=request_id,
                 is_done=is_done,
                 error=error,
+                replica_bindings=self._replica_bindings.get(request_id),
             )
             return
         self._record_nonlocal_stream_target(request_id, target)
@@ -1528,6 +1543,7 @@ class Stage:
         self._clear_request_state(request_id)
 
     def _clear_request_state(self, request_id: str) -> None:
+        self._record_bounded_request_id(self._finished_requests, request_id)
         self._active_requests.discard(request_id)
         self.input_handler.cancel(request_id)
         if self._stream_queue is not None:
@@ -1577,12 +1593,16 @@ class Stage:
                 logger.exception("Stage %s abort listener crashed", self.name)
 
     def _record_aborted_request_id(self, request_id: str) -> None:
-        self._aborted.add(request_id)
-        if len(self._aborted) > 10000:
-            excess = len(self._aborted) - 5000
-            it = iter(self._aborted)
+        self._record_bounded_request_id(self._aborted, request_id)
+
+    @staticmethod
+    def _record_bounded_request_id(ids: set[str], request_id: str) -> None:
+        ids.add(request_id)
+        if len(ids) > 10000:
+            excess = len(ids) - 5000
+            it = iter(ids)
             to_remove = [next(it) for _ in range(excess)]
-            self._aborted -= set(to_remove)
+            ids -= set(to_remove)
 
     def _on_abort(self, request_id: str) -> None:
         self._record_aborted_request_id(request_id)

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -23,6 +23,7 @@ from sglang_omni.comm import stage_io
 from sglang_omni.comm.data_ref import DataRef
 from sglang_omni.comm.engine import CommEngine
 from sglang_omni.comm.router import CommRouter
+from sglang_omni.pipeline.replicas import ReplicaTopology
 from sglang_omni.pipeline.stage.input import DirectInput, InputHandler
 from sglang_omni.pipeline.stage.stream_queue import StreamItem, StreamQueue
 from sglang_omni.pipeline.tp_control import TPLeaderFanout, TPWorkMessage
@@ -100,6 +101,7 @@ class Stage:
         disable_direct_cuda_ipc_payload: bool = False,
         tp_fanout: TPLeaderFanout | None = None,
         is_terminal: bool = False,
+        replica_topology: dict[str, list[str]] | None = None,
     ):
         self.name = name
         self.role = role
@@ -119,6 +121,8 @@ class Stage:
         self._tp_fanout = tp_fanout
         self._is_terminal = is_terminal
         self._owns_external_io = role in {"single", "leader"}
+        self._replica_topology = ReplicaTopology.from_dict(replica_topology)
+        self._replica_bindings: dict[str, dict[str, int]] = {}
 
         self._comm = CommEngine(
             CommRouter(
@@ -149,6 +153,24 @@ class Stage:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._scheduler_crash_error: BaseException | None = None
         self._background_task_error: BaseException | None = None
+
+    def _record_replica_bindings(
+        self, request_id: str, bindings: dict[str, int] | None
+    ) -> None:
+        if bindings:
+            self._replica_bindings.setdefault(request_id, {}).update(bindings)
+
+    def _resolve_target_instance(self, request_id: str, target: str) -> str:
+        if not self._replica_topology.is_replicated(target):
+            return target
+        bindings = self._replica_bindings.get(request_id)
+        replica_id = None if bindings is None else bindings.get(target)
+        if replica_id is None:
+            raise RuntimeError(
+                f"Stage {self.name}: no replica binding for target {target!r} "
+                f"(req={request_id})"
+            )
+        return self._replica_topology.resolve(target, replica_id)
 
     async def start(self) -> None:
         if self._running:
@@ -311,6 +333,7 @@ class Stage:
         self,
         msg: DataReadyMessage,
     ) -> None:
+        self._record_replica_bindings(msg.request_id, msg.replica_bindings)
         if msg.is_done or msg.error is not None:
             handler = self._on_stream_signal
             label = f"stream signal {msg.request_id}:{msg.from_stage}"
@@ -365,6 +388,7 @@ class Stage:
         request_id = msg.request_id
         if request_id in self._aborted:
             return
+        self._record_replica_bindings(request_id, msg.replica_bindings)
         self._active_requests.add(request_id)
         if self._stream_queue is not None and not self._stream_queue.has(request_id):
             self._stream_queue.open(request_id)
@@ -1077,6 +1101,7 @@ class Stage:
             raise RuntimeError(
                 f"Follower stage {self.name} cannot send downstream data"
             )
+        target = self._resolve_target_instance(request_id, target)
         endpoint = self.endpoints.get(target)
         if endpoint is None:
             raise RuntimeError(
@@ -1148,6 +1173,7 @@ class Stage:
                         from_stage=self.name,
                         to_stage=target,
                         data_ref=direct_ref,
+                        replica_bindings=self._replica_bindings.get(request_id),
                     ),
                 )
                 _emit_event(
@@ -1170,6 +1196,7 @@ class Stage:
             from_stage=self.name,
             to_stage=target,
             target_endpoint=endpoint,
+            replica_bindings=self._replica_bindings.get(request_id),
         )
         _emit_event(
             request_id=request_id,
@@ -1280,6 +1307,7 @@ class Stage:
     ) -> None:
         if not self._owns_external_io:
             return
+        target = self._resolve_target_instance(request_id, target)
         endpoint = self.endpoints.get(target)
         if endpoint is None:
             raise RuntimeError(
@@ -1355,6 +1383,7 @@ class Stage:
                     to_stage=target,
                     data_ref=direct_ref,
                     chunk_id=chunk_id,
+                    replica_bindings=self._replica_bindings.get(request_id),
                 ),
             )
             return
@@ -1381,6 +1410,7 @@ class Stage:
             chunk_id=chunk_id,
             metadata=metadata,
             transport=transport_kind,
+            replica_bindings=self._replica_bindings.get(request_id),
         )
 
     async def _send_stream_signal_to_target(
@@ -1393,6 +1423,7 @@ class Stage:
     ) -> None:
         if not self._owns_external_io:
             return
+        target = self._resolve_target_instance(request_id, target)
         endpoint = self.endpoints.get(target)
         if endpoint is None:
             raise RuntimeError(
@@ -1423,6 +1454,7 @@ class Stage:
             from_stage=self.name,
             is_done=is_done,
             error=error,
+            replica_bindings=self._replica_bindings.get(request_id),
         )
 
     async def _send_stream_to_coordinator(
@@ -1508,6 +1540,7 @@ class Stage:
         self._first_stream_chunk_seen.discard(request_id)
         self._local_stream_targets.pop(request_id, None)
         self._nonlocal_stream_targets.pop(request_id, None)
+        self._replica_bindings.pop(request_id, None)
 
     async def _handle_scheduler_crash(self, exc: BaseException) -> None:
         if self._scheduler_crash_error is not None:

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -97,6 +97,9 @@ class StageLaunchConfig:
     # Fusion name map
     name_map: dict[str, str] = field(default_factory=dict)
 
+    # Replica topology (logical stage name -> instance names)
+    replica_topology: dict[str, list[str]] = field(default_factory=dict)
+
     # TP internal control (leader -> followers)
     follower_work_queues: list[Any] = field(default_factory=list)
     follower_abort_queues: list[Any] = field(default_factory=list)
@@ -761,6 +764,7 @@ def _construct_stage(
         disable_direct_cuda_ipc_payload=spec.disable_direct_cuda_ipc_payload,
         tp_fanout=tp_fanout,
         is_terminal=spec.is_terminal,
+        replica_topology=spec.replica_topology or None,
     )
 
     if spec.is_stream_receiver:

--- a/sglang_omni/proto/messages.py
+++ b/sglang_omni/proto/messages.py
@@ -21,6 +21,7 @@ class DataReadyMessage:
     chunk_id: int | None = None
     is_done: bool = False
     error: str | None = None
+    replica_bindings: dict[str, int] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         _require_str(self.request_id, "request_id")
@@ -55,6 +56,8 @@ class DataReadyMessage:
         if self.error is not None:
             _require_str(self.error, "error")
             d["error"] = self.error
+        if self.replica_bindings:
+            d["replica_bindings"] = dict(self.replica_bindings)
         return d
 
     @classmethod
@@ -92,6 +95,7 @@ class DataReadyMessage:
             chunk_id=chunk_id,
             is_done=is_done,
             error=error,
+            replica_bindings=d.get("replica_bindings"),
         )
 
 
@@ -240,19 +244,27 @@ class SubmitMessage:
 
     request_id: str
     data: Any
+    replica_bindings: dict[str, int] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         data = self.data
         if isinstance(self.data, StagePayload):
             data = self.data.to_dict()
-        return {"type": "submit", "request_id": self.request_id, "data": data}
+        d = {"type": "submit", "request_id": self.request_id, "data": data}
+        if self.replica_bindings:
+            d["replica_bindings"] = dict(self.replica_bindings)
+        return d
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "SubmitMessage":
         data = d["data"]
         if isinstance(data, dict) and data.get("_type") == "StagePayload":
             data = StagePayload.from_dict(data)
-        return cls(request_id=d["request_id"], data=data)
+        return cls(
+            request_id=d["request_id"],
+            data=data,
+            replica_bindings=d.get("replica_bindings"),
+        )
 
 
 @dataclass

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,6 +38,7 @@ tests/
     │   ├── test_gpu_memory.py
     │   ├── test_ipc.py
     │   ├── test_placement.py
+    │   ├── test_replicas.py
     │   ├── test_runtime_adapter.py
     │   ├── test_runtime_schema.py
     │   ├── test_scheduler.py
@@ -324,6 +325,9 @@ that happened to contain an older version of the test.
   - runtime wiring
   - runtime schema/adapter behavior
   - coordinator behavior
+  - stage replicas: instance naming, device splitting, stage expansion,
+    round-robin binding assignment, and placement/override resolution for
+    replica instances
   - stage routing
   - centralized comm router selection, data-reference serialization, ack
     lifecycle, and sender backpressure release

--- a/tests/test_model/test_qwen3_omni_stage_replicas.py
+++ b/tests/test_model/test_qwen3_omni_stage_replicas.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stage-replica smoke test for the Qwen3-Omni speech pipeline.
+
+Launches the 2-replica speech deployment (thinker on GPU 0, one
+talker_ar + code2wav pair each on GPU 1 and GPU 2) and drives enough
+audio requests through it that round-robin admission covers every
+replica. Asserts every request returns audio and that both replica
+instances of each speech stage actually served traffic.
+
+Requires 3 GPUs.
+
+Usage:
+    pytest tests/test_model/test_qwen3_omni_stage_replicas.py -s -x
+"""
+
+from __future__ import annotations
+
+import base64
+import sys
+from pathlib import Path
+
+import pytest
+import requests
+
+from sglang_omni.utils import find_available_port
+from tests.utils import (
+    no_proxy_env,
+    server_log_file,
+    start_server_from_cmd,
+    stop_server,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
+REPLICA_CONFIG = "examples/configs/qwen3_omni_speech_replica2.yaml"
+STARTUP_TIMEOUT = 900
+REQUEST_TIMEOUT = 300
+
+# Even requests bind to replica 0, odd to replica 1 (round-robin admission),
+# so 4 requests exercise every replica twice.
+NUM_REQUESTS = 4
+REPLICA_INSTANCES = (
+    "talker_ar@r0",
+    "talker_ar@r1",
+    "code2wav@r0",
+    "code2wav@r1",
+)
+
+PROMPTS = [
+    "Please answer briefly: what is the capital of France?",
+    "Count from one to five.",
+    "Say hello in English.",
+    "Name one primary color.",
+]
+
+
+@pytest.fixture(scope="module")
+def replica_server(tmp_path_factory: pytest.TempPathFactory):
+    port = find_available_port()
+    log_file = server_log_file(tmp_path_factory, "stage_replica_logs")
+    cmd = [
+        sys.executable,
+        "-m",
+        "sglang_omni.cli",
+        "serve",
+        "--config",
+        str(PROJECT_ROOT / REPLICA_CONFIG),
+        "--model-path",
+        MODEL_PATH,
+        "--port",
+        str(port),
+    ]
+    proc = start_server_from_cmd(cmd, log_file, port, timeout=STARTUP_TIMEOUT)
+    proc.port = port  # type: ignore[attr-defined]
+    proc.log_file = log_file  # type: ignore[attr-defined]
+    yield proc
+    stop_server(proc)
+
+
+def _post_audio_request(port: int, prompt: str) -> dict:
+    payload = {
+        "model": MODEL_PATH,
+        "messages": [{"role": "user", "content": prompt}],
+        "modalities": ["text", "audio"],
+        "audio": {"format": "wav"},
+        "max_tokens": 256,
+        "temperature": 0.0,
+        "stream": False,
+    }
+    with no_proxy_env():
+        response = requests.post(
+            f"http://localhost:{port}/v1/chat/completions",
+            json=payload,
+            timeout=REQUEST_TIMEOUT,
+        )
+    response.raise_for_status()
+    return response.json()
+
+
+def test_every_replica_serves_audio(replica_server):
+    port: int = replica_server.port
+    log_file: Path = replica_server.log_file
+
+    for index in range(NUM_REQUESTS):
+        body = _post_audio_request(port, PROMPTS[index % len(PROMPTS)])
+        choice = body["choices"][0]
+        audio = choice["message"].get("audio") or {}
+        audio_b64 = audio.get("data")
+        assert audio_b64, f"request {index}: no audio in response: {body}"
+        audio_bytes = base64.b64decode(audio_b64)
+        assert len(audio_bytes) > 1000, (
+            f"request {index}: audio payload suspiciously small "
+            f"({len(audio_bytes)} bytes)"
+        )
+
+    # Round-robin admission alternates replicas, so all requests succeeding
+    # above already proves both replicas served traffic. The log check below
+    # only guards topology: all four instances were actually spawned.
+    log_text = log_file.read_text()
+    missing = [name for name in REPLICA_INSTANCES if name not in log_text]
+    assert not missing, (
+        f"replica instances never appeared in server log: {missing}; "
+        "expected all four instance stages to be spawned and registered"
+    )

--- a/tests/test_model/test_qwen3_omni_stage_replicas.py
+++ b/tests/test_model/test_qwen3_omni_stage_replicas.py
@@ -2,10 +2,10 @@
 """Stage-replica smoke test for the Qwen3-Omni speech pipeline.
 
 Launches the 2-replica speech deployment (thinker on GPU 0, one
-talker_ar + code2wav pair each on GPU 1 and GPU 2) and drives enough
-audio requests through it that round-robin admission covers every
-replica. Asserts every request returns audio and that both replica
-instances of each speech stage actually served traffic.
+talker_ar + code2wav pair each on GPU 1 and GPU 2) and drives audio
+requests through it. Asserts every request returns audio, that all four
+replica instances were spawned and registered, and that admission
+round-robined across both replicas of each replicated stage.
 
 Requires 3 GPUs.
 
@@ -15,12 +15,15 @@ Usage:
 
 from __future__ import annotations
 
+import ast
 import base64
+import re
 import sys
 from pathlib import Path
 
 import pytest
 import requests
+import torch
 
 from sglang_omni.utils import find_available_port
 from tests.utils import (
@@ -30,6 +33,13 @@ from tests.utils import (
     stop_server,
 )
 
+REQUIRED_GPUS = 3
+
+pytestmark = pytest.mark.skipif(
+    torch.cuda.device_count() < REQUIRED_GPUS,
+    reason=f"requires {REQUIRED_GPUS} GPUs",
+)
+
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
@@ -37,9 +47,8 @@ REPLICA_CONFIG = "examples/configs/qwen3_omni_speech_replica2.yaml"
 STARTUP_TIMEOUT = 900
 REQUEST_TIMEOUT = 300
 
-# Even requests bind to replica 0, odd to replica 1 (round-robin admission),
-# so 4 requests exercise every replica twice.
 NUM_REQUESTS = 4
+REPLICATED_STAGES = ("talker_ar", "code2wav")
 REPLICA_INSTANCES = (
     "talker_ar@r0",
     "talker_ar@r1",
@@ -58,9 +67,8 @@ PROMPTS = [
 @pytest.fixture(scope="module")
 def replica_server(tmp_path_factory: pytest.TempPathFactory):
     port = find_available_port()
-    # The log file is load-bearing here (the test greps it for replica
-    # instance names), so create one even locally where server_log_file
-    # returns None.
+    # Note (wenyao): the test greps this log, so it must exist even locally
+    # where server_log_file returns None.
     log_file = server_log_file(tmp_path_factory, "stage_replica_logs") or (
         tmp_path_factory.mktemp("stage_replica_logs") / "server.log"
     )
@@ -119,12 +127,23 @@ def test_every_replica_serves_audio(replica_server):
             f"({len(audio_bytes)} bytes)"
         )
 
-    # Round-robin admission alternates replicas, so all requests succeeding
-    # above already proves both replicas served traffic. The log check below
-    # only guards topology: all four instances were actually spawned.
     log_text = log_file.read_text()
     missing = [name for name in REPLICA_INSTANCES if name not in log_text]
     assert not missing, (
         f"replica instances never appeared in server log: {missing}; "
         "expected all four instance stages to be spawned and registered"
     )
+
+    admitted = re.findall(r"bindings=(\{.*?\})", log_text)
+    assert (
+        len(admitted) >= NUM_REQUESTS
+    ), f"expected at least {NUM_REQUESTS} admission log lines, got {len(admitted)}"
+    bound: dict[str, set[int]] = {}
+    for raw in admitted:
+        for stage, replica_id in ast.literal_eval(raw).items():
+            bound.setdefault(stage, set()).add(replica_id)
+    for stage in REPLICATED_STAGES:
+        assert bound.get(stage) == {
+            0,
+            1,
+        }, f"{stage} did not round-robin across both replicas: {bound.get(stage)}"

--- a/tests/test_model/test_qwen3_omni_stage_replicas.py
+++ b/tests/test_model/test_qwen3_omni_stage_replicas.py
@@ -24,7 +24,7 @@ import requests
 
 from sglang_omni.utils import find_available_port
 from tests.utils import (
-    no_proxy_env,
+    disable_proxy,
     server_log_file,
     start_server_from_cmd,
     stop_server,
@@ -88,7 +88,7 @@ def _post_audio_request(port: int, prompt: str) -> dict:
         "temperature": 0.0,
         "stream": False,
     }
-    with no_proxy_env():
+    with disable_proxy():
         response = requests.post(
             f"http://localhost:{port}/v1/chat/completions",
             json=payload,

--- a/tests/test_model/test_qwen3_omni_stage_replicas.py
+++ b/tests/test_model/test_qwen3_omni_stage_replicas.py
@@ -58,7 +58,12 @@ PROMPTS = [
 @pytest.fixture(scope="module")
 def replica_server(tmp_path_factory: pytest.TempPathFactory):
     port = find_available_port()
-    log_file = server_log_file(tmp_path_factory, "stage_replica_logs")
+    # The log file is load-bearing here (the test greps it for replica
+    # instance names), so create one even locally where server_log_file
+    # returns None.
+    log_file = server_log_file(tmp_path_factory, "stage_replica_logs") or (
+        tmp_path_factory.mktemp("stage_replica_logs") / "server.log"
+    )
     cmd = [
         sys.executable,
         "-m",
@@ -71,7 +76,7 @@ def replica_server(tmp_path_factory: pytest.TempPathFactory):
         "--port",
         str(port),
     ]
-    proc = start_server_from_cmd(cmd, log_file, port, timeout=STARTUP_TIMEOUT)
+    proc = start_server_from_cmd(cmd, log_file, port, timeout=STARTUP_TIMEOUT, tee=True)
     proc.port = port  # type: ignore[attr-defined]
     proc.log_file = log_file  # type: ignore[attr-defined]
     yield proc

--- a/tests/unit_test/pipeline/test_compile.py
+++ b/tests/unit_test/pipeline/test_compile.py
@@ -457,6 +457,43 @@ def test_runner_wires_same_process_targets_across_colocated_replicas() -> None:
     assert resolve("gen@r1") == {"wav@r1"}
 
 
+def test_prepare_runtime_expands_replicated_tp_entry_stage() -> None:
+    config = PipelineConfig(
+        model_path="model",
+        entry_stage="entry",
+        stages=[
+            stage(
+                "entry",
+                next="sink",
+                gpu=[0, 1],
+                tp_size=2,
+                num_replicas=2,
+                replica_devices="0,1,2,3",
+            ),
+            stage("sink", terminal=True),
+        ],
+    )
+
+    prep = prepare_pipeline_runtime(config)
+    try:
+        assert prep.entry_stage == "entry"
+        assert prep.replica_topology.instances("entry") == (
+            "entry@r0",
+            "entry@r1",
+        )
+        assert [stage_cfg.name for stage_cfg in prep.stages_cfg] == [
+            "entry@r0",
+            "entry@r1",
+            "sink",
+        ]
+        assert prep.placement_plan.stages["entry@r0"].gpu_ids == (0, 1)
+        assert prep.placement_plan.stages["entry@r1"].gpu_ids == (2, 3)
+        assert "stage_entry@r0" in prep.endpoints
+        assert "stage_entry@r1" in prep.endpoints
+    finally:
+        prep.runtime_dir.close()
+
+
 def test_fused_stages_reject_unsupported_internal_stage_contracts() -> None:
     with pytest.raises(ValueError, match="cannot include TP stage"):
         PipelineConfig(

--- a/tests/unit_test/pipeline/test_compile.py
+++ b/tests/unit_test/pipeline/test_compile.py
@@ -420,6 +420,43 @@ def test_runner_specs_do_not_wire_same_process_targets_to_tp_stages() -> None:
     )
 
 
+def test_runner_wires_same_process_targets_across_colocated_replicas() -> None:
+    config = PipelineConfig(
+        model_path="model",
+        stages=[
+            stage("src", next="gen"),
+            stage(
+                "gen",
+                next="wav",
+                process="speech",
+                num_replicas=2,
+                replica_devices="1,2",
+            ),
+            stage(
+                "wav",
+                terminal=True,
+                process="speech",
+                num_replicas=2,
+                replica_devices="1,2",
+            ),
+        ],
+    )
+    prep = prepare_pipeline_runtime(config)
+    by_name = {stage_cfg.name: stage_cfg for stage_cfg in prep.stages_cfg}
+
+    def resolve(name: str) -> set[str]:
+        return _resolve_same_process_targets(
+            by_name[name],
+            by_name,
+            prep.name_map,
+            prep.process_plan,
+            prep.replica_topology,
+        )
+
+    assert resolve("gen@r0") == {"wav@r0"}
+    assert resolve("gen@r1") == {"wav@r1"}
+
+
 def test_fused_stages_reject_unsupported_internal_stage_contracts() -> None:
     with pytest.raises(ValueError, match="cannot include TP stage"):
         PipelineConfig(

--- a/tests/unit_test/pipeline/test_coordinator.py
+++ b/tests/unit_test/pipeline/test_coordinator.py
@@ -802,6 +802,87 @@ def test_admin_resolves_logical_replica_target_to_all_instances() -> None:
         coordinator._resolve_admin_stages(["nope"])
 
 
+def test_coordinator_routes_requests_to_replicated_entry_instances() -> None:
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["preprocess"],
+            replica_topology=ReplicaTopology(
+                replicas={"preprocess": ("preprocess@r0", "preprocess@r1")}
+            ),
+        )
+        control_plane = RecordingCoordinatorControlPlane()
+        coordinator.control_plane = control_plane
+        coordinator.register_stage("preprocess@r0", "inproc://preprocess-r0")
+        coordinator.register_stage("preprocess@r1", "inproc://preprocess-r1")
+
+        await coordinator._submit_request("req-0", {"text": "first"})
+        await coordinator._submit_request("req-1", {"text": "second"})
+
+        assert [
+            (target, endpoint) for target, endpoint, _ in control_plane.submitted
+        ] == [
+            ("preprocess@r0", "inproc://preprocess-r0"),
+            ("preprocess@r1", "inproc://preprocess-r1"),
+        ]
+        assert [
+            message.replica_bindings for _, _, message in control_plane.submitted
+        ] == [{"preprocess": 0}, {"preprocess": 1}]
+        assert coordinator._requests["req-0"].current_stage == "preprocess"
+        assert coordinator._requests["req-1"].current_stage == "preprocess"
+
+        req0 = coordinator._completion_futures["req-0"]
+        req1 = coordinator._completion_futures["req-1"]
+        await coordinator._handle_completion(
+            CompleteMessage("req-0", "preprocess@r0", True, result={"id": 0})
+        )
+        await coordinator._handle_completion(
+            CompleteMessage("req-1", "preprocess@r1", True, result={"id": 1})
+        )
+        assert req0.result() == {"id": 0}
+        assert req1.result() == {"id": 1}
+
+    asyncio.run(_run())
+
+
+def test_replicated_entry_must_register_selected_instance_before_admission() -> None:
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["decode"],
+            replica_topology=ReplicaTopology(
+                replicas={"preprocess": ("preprocess@r0", "preprocess@r1")}
+            ),
+        )
+        control_plane = RecordingCoordinatorControlPlane()
+        coordinator.control_plane = control_plane
+        coordinator.register_stage("preprocess@r1", "inproc://preprocess-r1")
+
+        with pytest.raises(
+            ValueError,
+            match="unregistered instance.*'preprocess@r0'",
+        ):
+            await coordinator._submit_request("req-0", {"text": "hello"})
+
+        assert coordinator._requests == {}
+        assert coordinator._completion_futures == {}
+        assert coordinator._stream_queues == {}
+        assert control_plane.submitted == []
+
+        coordinator.register_stage("preprocess@r0", "inproc://preprocess-r0")
+        await coordinator._submit_request("req-0", {"text": "hello"})
+        assert control_plane.submitted[0][:2] == (
+            "preprocess@r0",
+            "inproc://preprocess-r0",
+        )
+
+    asyncio.run(_run())
+
+
 def test_coordinator_normalizes_replica_instance_name_on_stream_chunk() -> None:
     async def _run() -> None:
         coordinator = Coordinator(

--- a/tests/unit_test/pipeline/test_coordinator.py
+++ b/tests/unit_test/pipeline/test_coordinator.py
@@ -8,6 +8,7 @@ import gc
 import pytest
 
 from sglang_omni.pipeline.coordinator import Coordinator
+from sglang_omni.pipeline.replicas import ReplicaTopology
 from sglang_omni.proto import CompleteMessage, OmniRequest, StreamMessage
 from tests.unit_test.fixtures.pipeline_fakes import RecordingCoordinatorControlPlane
 
@@ -767,5 +768,103 @@ def test_coordinator_stream_stage_failure_cancels_future() -> None:
         assert error_sink == ["boom"]
         assert future.cancelled() is True
         assert "req-1" not in coordinator._completion_futures
+
+    asyncio.run(_run())
+
+
+def test_admin_resolves_logical_replica_target_to_all_instances() -> None:
+    coordinator = Coordinator(
+        "inproc://complete",
+        "inproc://abort",
+        entry_stage="preprocess",
+        replica_topology=ReplicaTopology(
+            replicas={"talker_ar": ("talker_ar@r0", "talker_ar@r1")}
+        ),
+    )
+    coordinator.control_plane = RecordingCoordinatorControlPlane()
+    coordinator.register_stage("talker_ar@r0", "inproc://t0")
+    coordinator.register_stage("talker_ar@r1", "inproc://t1")
+    coordinator.register_stage("thinker", "inproc://thinker")
+
+    assert coordinator._resolve_admin_stages(["talker_ar"]) == [
+        "talker_ar@r0",
+        "talker_ar@r1",
+    ]
+    assert coordinator._resolve_admin_stages(
+        ["talker_ar", "talker_ar@r0", "thinker"]
+    ) == ["talker_ar@r0", "talker_ar@r1", "thinker"]
+    assert coordinator._resolve_admin_stages(None) == [
+        "talker_ar@r0",
+        "talker_ar@r1",
+        "thinker",
+    ]
+    with pytest.raises(ValueError, match="Unknown admin target"):
+        coordinator._resolve_admin_stages(["nope"])
+
+
+def test_coordinator_normalizes_replica_instance_name_on_stream_chunk() -> None:
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["code2wav"],
+            replica_topology=ReplicaTopology(
+                replicas={"code2wav": ("code2wav@r0", "code2wav@r1")}
+            ),
+        )
+        queue: asyncio.Queue = asyncio.Queue()
+        coordinator._stream_queues["req-1"] = queue
+
+        await coordinator._handle_stream(
+            StreamMessage(
+                request_id="req-1",
+                from_stage="code2wav@r1",
+                chunk={"audio": "x"},
+                stage_name="code2wav@r1",
+                modality="audio",
+                chunk_id=0,
+            )
+        )
+
+        routed = queue.get_nowait()
+        assert routed.from_stage == "code2wav"
+        assert routed.stage_name == "code2wav"
+
+    asyncio.run(_run())
+
+
+@pytest.mark.parametrize("success", [True, False])
+def test_coordinator_normalizes_replica_instance_name_on_completion(
+    success: bool,
+) -> None:
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["code2wav"],
+            replica_topology=ReplicaTopology(
+                replicas={"code2wav": ("code2wav@r0", "code2wav@r1")}
+            ),
+        )
+        coordinator.control_plane = RecordingCoordinatorControlPlane()
+        coordinator.register_stage("preprocess", "inproc://preprocess")
+
+        queue: asyncio.Queue = asyncio.Queue()
+        coordinator._stream_queues["req-1"] = queue
+        await coordinator._submit_request("req-1", {"text": "hello"})
+
+        await coordinator._handle_completion(
+            CompleteMessage(
+                "req-1",
+                "code2wav@r1",
+                success,
+                result={"audio": "ok"} if success else None,
+                error=None if success else "boom",
+            )
+        )
+
+        assert queue.get_nowait().from_stage == "code2wav"
 
     asyncio.run(_run())

--- a/tests/unit_test/pipeline/test_replicas.py
+++ b/tests/unit_test/pipeline/test_replicas.py
@@ -177,17 +177,42 @@ class TestBinding:
         )
 
 
-class TestColocatedReplicaRejection:
-    _SPEECH_STAGES = (
-        "preprocessing",
-        "image_encoder",
-        "audio_encoder",
-        "mm_aggregate",
-        "thinker",
-        "decode",
-        "talker_ar",
-        "code2wav",
+_SPEECH_STAGES = (
+    "preprocessing",
+    "image_encoder",
+    "audio_encoder",
+    "mm_aggregate",
+    "thinker",
+    "decode",
+    "talker_ar",
+    "code2wav",
+)
+
+
+def _speech_config(config_cls_name: str | None = None) -> PipelineConfig:
+    cls = (
+        type(config_cls_name, (PipelineConfig,), {})
+        if config_cls_name
+        else PipelineConfig
     )
+    return cls(
+        model_path="m",
+        stages=[
+            _stage(
+                name,
+                **(
+                    {"num_replicas": 2, "replica_devices": "1,2", "gpu": 1}
+                    if name == "talker_ar"
+                    else {}
+                ),
+            )
+            for name in _SPEECH_STAGES
+        ],
+    )
+
+
+class TestColocatedReplicaRejection:
+    _SPEECH_STAGES = _SPEECH_STAGES
 
     def test_colocated_rejects_replicated_stage(self):
         from sglang_omni.models.qwen3_omni.placement import Qwen3OmniPlacementPolicy
@@ -211,6 +236,53 @@ class TestColocatedReplicaRejection:
         )
         with pytest.raises(ValueError, match="does not support stage replicas"):
             Qwen3OmniPlacementPolicy().validate(config, plan=None)
+
+
+class TestPlacementLogicalView:
+    def _plan(self, talker_r0_gpu: int) -> "StagePlacementPlan":
+        from sglang_omni.config.placement import StagePlacement, StagePlacementPlan
+
+        def placement(name: str, gpu: int) -> StagePlacement:
+            return StagePlacement(
+                stage_name=name,
+                gpu_ids=(gpu,),
+                tp_size=1,
+                total_gpu_memory_fraction=None,
+            )
+
+        return StagePlacementPlan(
+            stages={
+                "thinker": placement("thinker", 0),
+                "talker_ar@r0": placement("talker_ar@r0", talker_r0_gpu),
+                "talker_ar@r1": placement("talker_ar@r1", 2),
+            },
+            gpus={},
+            replica_instances={"talker_ar": ("talker_ar@r0", "talker_ar@r1")},
+        )
+
+    def test_instances_of(self):
+        plan = self._plan(talker_r0_gpu=1)
+        assert [p.stage_name for p in plan.instances_of("talker_ar")] == [
+            "talker_ar@r0",
+            "talker_ar@r1",
+        ]
+        assert [p.stage_name for p in plan.instances_of("thinker")] == ["thinker"]
+        assert plan.instances_of("preprocessing") == []
+
+    def test_policy_catches_replica_sharing_gpu_with_thinker(self):
+        from sglang_omni.models.qwen3_omni.placement import Qwen3OmniPlacementPolicy
+
+        with pytest.raises(ValueError, match="talker_ar@r0"):
+            Qwen3OmniPlacementPolicy().validate(
+                _speech_config(), self._plan(talker_r0_gpu=0)
+            )
+
+    def test_policy_passes_disjoint_replicas(self):
+        from sglang_omni.models.qwen3_omni.placement import Qwen3OmniPlacementPolicy
+
+        Qwen3OmniPlacementPolicy().validate(
+            _speech_config(), self._plan(talker_r0_gpu=1)
+        )
 
 
 class TestSchemaValidation:

--- a/tests/unit_test/pipeline/test_replicas.py
+++ b/tests/unit_test/pipeline/test_replicas.py
@@ -177,6 +177,42 @@ class TestBinding:
         )
 
 
+class TestColocatedReplicaRejection:
+    _SPEECH_STAGES = (
+        "preprocessing",
+        "image_encoder",
+        "audio_encoder",
+        "mm_aggregate",
+        "thinker",
+        "decode",
+        "talker_ar",
+        "code2wav",
+    )
+
+    def test_colocated_rejects_replicated_stage(self):
+        from sglang_omni.models.qwen3_omni.placement import Qwen3OmniPlacementPolicy
+
+        colocated_cls = type(
+            "Qwen3OmniSpeechColocatedPipelineConfig", (PipelineConfig,), {}
+        )
+        config = colocated_cls(
+            model_path="m",
+            stages=[
+                _stage(
+                    name,
+                    **(
+                        {"num_replicas": 2, "replica_devices": "0,1", "gpu": 0}
+                        if name == "talker_ar"
+                        else {}
+                    ),
+                )
+                for name in self._SPEECH_STAGES
+            ],
+        )
+        with pytest.raises(ValueError, match="does not support stage replicas"):
+            Qwen3OmniPlacementPolicy().validate(config, plan=None)
+
+
 class TestSchemaValidation:
     def test_num_replicas_must_be_positive(self):
         with pytest.raises(ValueError, match="num_replicas >= 1"):

--- a/tests/unit_test/pipeline/test_replicas.py
+++ b/tests/unit_test/pipeline/test_replicas.py
@@ -285,6 +285,32 @@ class TestPlacementLogicalView:
         )
 
 
+class TestStageOverrides:
+    def _manager(self):
+        pytest.importorskip("transformers")
+        from sglang_omni.config import manager
+
+        return manager
+
+    def test_replica_fields_pass_through(self):
+        manager = self._manager()
+        config = _speech_config()
+        overridden = manager._apply_stage_overrides(
+            config,
+            {"code2wav": {"num_replicas": 3, "replica_devices": "1,2,3"}},
+        )
+        stage = {s.name: s for s in overridden.stages}["code2wav"]
+        assert stage.num_replicas == 3
+        assert stage.replica_devices == "1,2,3"
+
+    def test_unsupported_key_still_rejected(self):
+        manager = self._manager()
+        with pytest.raises(ValueError, match="unsupported keys"):
+            manager._apply_stage_overrides(
+                _speech_config(), {"code2wav": {"gpu": 3}}
+            )
+
+
 class TestSchemaValidation:
     def test_num_replicas_must_be_positive(self):
         with pytest.raises(ValueError, match="num_replicas >= 1"):

--- a/tests/unit_test/pipeline/test_replicas.py
+++ b/tests/unit_test/pipeline/test_replicas.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for runtime-level stage replicas."""
+
+import pytest
+
+from sglang_omni.config.schema import PipelineConfig, StageConfig
+from sglang_omni.pipeline.replicas import (
+    ReplicaTopology,
+    RoundRobinBindingPolicy,
+    assign_replica_bindings,
+    expand_replica_stages,
+    parse_replica_instance_name,
+    replica_instance_name,
+    split_replica_devices,
+)
+
+
+def _stage(name: str, **kwargs) -> StageConfig:
+    defaults = dict(factory="pkg.mod.create", terminal=True, process=name)
+    defaults.update(kwargs)
+    return StageConfig(name=name, **defaults)
+
+
+class TestInstanceNaming:
+    def test_round_trip(self):
+        name = replica_instance_name("talker_ar", 1)
+        assert name == "talker_ar@r1"
+        assert parse_replica_instance_name(name) == ("talker_ar", 1)
+
+    def test_plain_name_passthrough(self):
+        assert parse_replica_instance_name("thinker") == ("thinker", None)
+
+    def test_non_numeric_suffix_is_not_replica(self):
+        assert parse_replica_instance_name("stage@rx") == ("stage@rx", None)
+
+
+class TestSplitReplicaDevices:
+    def test_pool_mode_tp1(self):
+        assert split_replica_devices(
+            "1,2", stage_name="s", num_replicas=2, tp_size=1
+        ) == [[1], [2]]
+
+    def test_pool_mode_tp2(self):
+        assert split_replica_devices(
+            "0,1,2,3", stage_name="s", num_replicas=2, tp_size=2
+        ) == [[0, 1], [2, 3]]
+
+    def test_template_mode_tp1(self):
+        assert split_replica_devices(
+            "0", stage_name="s", num_replicas=4, tp_size=1
+        ) == [[0], [1], [2], [3]]
+
+    def test_template_mode_tp2(self):
+        assert split_replica_devices(
+            "0,1", stage_name="s", num_replicas=2, tp_size=2
+        ) == [[0, 1], [2, 3]]
+
+    def test_list_input(self):
+        assert split_replica_devices(
+            [1, 2], stage_name="s", num_replicas=2, tp_size=1
+        ) == [[1], [2]]
+
+    def test_none_for_cpu_stage(self):
+        assert split_replica_devices(
+            None, stage_name="s", num_replicas=3, tp_size=1
+        ) == [None, None, None]
+
+    def test_invalid_length_raises(self):
+        with pytest.raises(ValueError, match="replica_devices has 3"):
+            split_replica_devices("0,1,2", stage_name="s", num_replicas=2, tp_size=2)
+
+
+class TestExpandReplicaStages:
+    def test_no_replicas_is_identity(self):
+        stages = [_stage("a"), _stage("b")]
+        expanded, topo = expand_replica_stages(stages)
+        assert expanded == stages
+        assert not topo
+        assert topo.to_dict() == {}
+
+    def test_expansion_names_gpus_processes(self):
+        stages = [
+            _stage(
+                "talker_ar",
+                terminal=False,
+                next="code2wav",
+                stream_to=["code2wav"],
+                gpu=1,
+                num_replicas=2,
+                replica_devices="1,2",
+            ),
+            _stage("code2wav"),
+        ]
+        expanded, topo = expand_replica_stages(stages)
+        names = [s.name for s in expanded]
+        assert names == ["talker_ar@r0", "talker_ar@r1", "code2wav"]
+        r0, r1 = expanded[0], expanded[1]
+        assert (r0.gpu, r1.gpu) == (1, 2)
+        assert r0.process == "talker_ar@r0"
+        assert r0.num_replicas == 1 and r0.replica_devices is None
+        # Wiring keeps logical names.
+        assert r0.next == "code2wav" and r0.stream_to == ["code2wav"]
+        assert topo.to_dict() == {"talker_ar": ["talker_ar@r0", "talker_ar@r1"]}
+
+    def test_gpu_field_fallback_as_template(self):
+        stages = [_stage("s", gpu=1, num_replicas=2)]
+        expanded, _ = expand_replica_stages(stages)
+        assert [s.gpu for s in expanded] == [1, 2]
+
+
+class TestReplicaTopology:
+    def _topo(self) -> ReplicaTopology:
+        _, topo = expand_replica_stages(
+            [
+                _stage("talker_ar", num_replicas=2, replica_devices="1,2", gpu=1),
+                _stage("code2wav", num_replicas=2, replica_devices="1,2", gpu=1),
+                _stage("thinker"),
+            ]
+        )
+        return topo
+
+    def test_resolve_and_logical_name(self):
+        topo = self._topo()
+        assert topo.resolve("talker_ar", 1) == "talker_ar@r1"
+        assert topo.logical_name("talker_ar@r1") == "talker_ar"
+        assert topo.logical_name("thinker") == "thinker"
+
+    def test_resolve_out_of_range(self):
+        with pytest.raises(ValueError, match="has 2 replicas"):
+            self._topo().resolve("talker_ar", 5)
+
+    def test_resolve_unreplicated(self):
+        topo = self._topo()
+        assert topo.resolve("thinker", 0) == "thinker"
+        with pytest.raises(ValueError, match="not replicated"):
+            topo.resolve("thinker", 1)
+
+    def test_instances(self):
+        topo = self._topo()
+        assert topo.instances("code2wav") == ("code2wav@r0", "code2wav@r1")
+        assert topo.instances("thinker") == ("thinker",)
+
+    def test_unregistered_suffix_name_is_not_normalized(self):
+        assert self._topo().logical_name("other@r0") == "other@r0"
+
+    def test_dict_round_trip(self):
+        topo = self._topo()
+        restored = ReplicaTopology.from_dict(topo.to_dict())
+        assert restored == topo
+        assert not ReplicaTopology.from_dict(None)
+
+
+class TestBinding:
+    def test_round_robin_cycles_per_stage(self):
+        policy = RoundRobinBindingPolicy()
+        picks = [policy.bind("talker_ar", 2, f"req{i}") for i in range(4)]
+        assert picks == [0, 1, 0, 1]
+        assert policy.bind("code2wav", 3, "reqx") == 0
+
+    def test_assign_bindings(self):
+        _, topo = expand_replica_stages(
+            [
+                _stage("talker_ar", num_replicas=2, replica_devices="1,2", gpu=1),
+                _stage("code2wav", num_replicas=2, replica_devices="1,2", gpu=1),
+            ]
+        )
+        policy = RoundRobinBindingPolicy()
+        first = assign_replica_bindings(topo, policy, "req0")
+        second = assign_replica_bindings(topo, policy, "req1")
+        assert first == {"talker_ar": 0, "code2wav": 0}
+        assert second == {"talker_ar": 1, "code2wav": 1}
+
+    def test_empty_topology_binds_none(self):
+        assert (
+            assign_replica_bindings(ReplicaTopology(), RoundRobinBindingPolicy(), "r")
+            is None
+        )
+
+
+class TestSchemaValidation:
+    def test_num_replicas_must_be_positive(self):
+        with pytest.raises(ValueError, match="num_replicas >= 1"):
+            _stage("s", num_replicas=0)
+
+    def test_entry_stage_cannot_be_replicated(self):
+        with pytest.raises(ValueError, match="cannot be replicated"):
+            PipelineConfig(
+                model_path="m",
+                stages=[
+                    _stage("entry", terminal=False, next="sink", num_replicas=2),
+                    _stage("sink"),
+                ],
+            )
+
+    def test_fused_group_cannot_include_replicated_stage(self):
+        with pytest.raises(ValueError, match="cannot include replicated"):
+            PipelineConfig(
+                model_path="m",
+                stages=[
+                    _stage("a", terminal=False, next="b"),
+                    _stage("b", terminal=False, next="c", num_replicas=2),
+                    _stage("c"),
+                ],
+                fused_stages=[["a", "b"]],
+            )

--- a/tests/unit_test/pipeline/test_replicas.py
+++ b/tests/unit_test/pipeline/test_replicas.py
@@ -166,8 +166,14 @@ class TestReplicaTopology:
     def test_resolve_and_logical_name(self):
         topo = self._topo()
         assert topo.resolve("talker_ar", 1) == "talker_ar@r1"
+        assert topo.resolve_bound("talker_ar", {"talker_ar": 1}) == "talker_ar@r1"
+        assert topo.resolve_bound("thinker", None) == "thinker"
         assert topo.logical_name("talker_ar@r1") == "talker_ar"
         assert topo.logical_name("thinker") == "thinker"
+
+    def test_resolve_bound_requires_replica_binding(self):
+        with pytest.raises(ValueError, match="no replica binding"):
+            self._topo().resolve_bound("talker_ar", None)
 
     def test_resolve_out_of_range(self):
         with pytest.raises(ValueError, match="has 2 replicas"):
@@ -358,15 +364,15 @@ class TestSchemaValidation:
         with pytest.raises(ValueError, match="num_replicas >= 1"):
             _stage("s", num_replicas=0)
 
-    def test_entry_stage_cannot_be_replicated(self):
-        with pytest.raises(ValueError, match="cannot be replicated"):
-            PipelineConfig(
-                model_path="m",
-                stages=[
-                    _stage("entry", terminal=False, next="sink", num_replicas=2),
-                    _stage("sink"),
-                ],
-            )
+    def test_entry_stage_can_be_replicated(self):
+        config = PipelineConfig(
+            model_path="m",
+            stages=[
+                _stage("entry", terminal=False, next="sink", num_replicas=2),
+                _stage("sink"),
+            ],
+        )
+        assert config.resolved_entry_stage == "entry"
 
     def test_fused_group_cannot_include_replicated_stage(self):
         with pytest.raises(ValueError, match="cannot include replicated"):

--- a/tests/unit_test/pipeline/test_replicas.py
+++ b/tests/unit_test/pipeline/test_replicas.py
@@ -12,6 +12,7 @@ from sglang_omni.pipeline.replicas import (
     parse_replica_instance_name,
     replica_instance_name,
     split_replica_devices,
+    validate_device_assignment,
 )
 
 
@@ -45,15 +46,21 @@ class TestSplitReplicaDevices:
             "0,1,2,3", stage_name="s", num_replicas=2, tp_size=2
         ) == [[0, 1], [2, 3]]
 
-    def test_template_mode_tp1(self):
+    def test_non_contiguous_pool(self):
         assert split_replica_devices(
-            "0", stage_name="s", num_replicas=4, tp_size=1
-        ) == [[0], [1], [2], [3]]
+            "1,5", stage_name="s", num_replicas=2, tp_size=1
+        ) == [[1], [5]]
 
-    def test_template_mode_tp2(self):
+    def test_same_gpu_pool(self):
         assert split_replica_devices(
-            "0,1", stage_name="s", num_replicas=2, tp_size=2
-        ) == [[0, 1], [2, 3]]
+            "0,0", stage_name="s", num_replicas=2, tp_size=1
+        ) == [[0], [0]]
+
+    def test_partial_list_raises(self):
+        with pytest.raises(ValueError, match="expected 4"):
+            split_replica_devices("0", stage_name="s", num_replicas=4, tp_size=1)
+        with pytest.raises(ValueError, match="expected 4"):
+            split_replica_devices("0,1", stage_name="s", num_replicas=2, tp_size=2)
 
     def test_list_input(self):
         assert split_replica_devices(
@@ -102,10 +109,47 @@ class TestExpandReplicaStages:
         assert r0.next == "code2wav" and r0.stream_to == ["code2wav"]
         assert topo.to_dict() == {"talker_ar": ["talker_ar@r0", "talker_ar@r1"]}
 
-    def test_gpu_field_fallback_as_template(self):
+    def test_gpu_stage_requires_explicit_replica_devices(self):
         stages = [_stage("s", gpu=1, num_replicas=2)]
-        expanded, _ = expand_replica_stages(stages)
-        assert [s.gpu for s in expanded] == [1, 2]
+        with pytest.raises(ValueError, match="replica_devices"):
+            expand_replica_stages(stages)
+
+    def test_cpu_stage_needs_no_devices(self):
+        stages = [_stage("s", num_replicas=2)]
+        expanded, topo = expand_replica_stages(stages)
+        assert [s.gpu for s in expanded] == [None, None]
+        assert topo.to_dict() == {"s": ["s@r0", "s@r1"]}
+
+
+class TestValidateDeviceAssignment:
+    def test_valid_ids_pass(self):
+        stages, _ = expand_replica_stages(
+            [_stage("s", gpu=1, num_replicas=2, replica_devices="1,2")]
+        )
+        validate_device_assignment(stages, device_count=4)
+
+    def test_out_of_range_id_raises(self):
+        stages, _ = expand_replica_stages(
+            [_stage("s", gpu=3, num_replicas=2, replica_devices="3,4")]
+        )
+        with pytest.raises(ValueError, match="GPU id 4"):
+            validate_device_assignment(stages, device_count=4)
+
+    def test_negative_id_raises(self):
+        with pytest.raises(ValueError, match="GPU id -1"):
+            validate_device_assignment([_stage("s", gpu=-1)], device_count=4)
+
+    def test_duplicate_id_within_tp_group_raises(self):
+        with pytest.raises(ValueError, match="duplicate"):
+            validate_device_assignment(
+                [_stage("s", gpu=[0, 0], tp_size=2)], device_count=4
+            )
+
+    def test_cpu_stages_are_skipped(self):
+        validate_device_assignment([_stage("s")], device_count=0)
+
+    def test_unknown_device_count_skips_range_check(self):
+        validate_device_assignment([_stage("s", gpu=7)], device_count=None)
 
 
 class TestReplicaTopology:

--- a/tests/unit_test/pipeline/test_replicas.py
+++ b/tests/unit_test/pipeline/test_replicas.py
@@ -306,9 +306,7 @@ class TestStageOverrides:
     def test_unsupported_key_still_rejected(self):
         manager = self._manager()
         with pytest.raises(ValueError, match="unsupported keys"):
-            manager._apply_stage_overrides(
-                _speech_config(), {"code2wav": {"gpu": 3}}
-            )
+            manager._apply_stage_overrides(_speech_config(), {"code2wav": {"gpu": 3}})
 
 
 class TestSchemaValidation:
@@ -337,3 +335,67 @@ class TestSchemaValidation:
                 ],
                 fused_stages=[["a", "b"]],
             )
+
+
+class TestUnequalReplicaCounts:
+    def test_bindings_cycle_independently_and_resolve(self):
+        _, topo = expand_replica_stages(
+            [
+                _stage("talker_ar", num_replicas=3, replica_devices="1,2,3", gpu=1),
+                _stage("code2wav", num_replicas=2, replica_devices="1,2", gpu=1),
+            ]
+        )
+        policy = RoundRobinBindingPolicy()
+        bindings = [assign_replica_bindings(topo, policy, f"req{i}") for i in range(6)]
+        assert [b["talker_ar"] for b in bindings] == [0, 1, 2, 0, 1, 2]
+        assert [b["code2wav"] for b in bindings] == [0, 1, 0, 1, 0, 1]
+        for b in bindings:
+            assert (
+                topo.resolve("talker_ar", b["talker_ar"])
+                == f"talker_ar@r{b['talker_ar']}"
+            )
+            assert (
+                topo.resolve("code2wav", b["code2wav"]) == f"code2wav@r{b['code2wav']}"
+            )
+
+
+class TestReservedStageNames:
+    def test_reserved_instance_suffix_rejected(self):
+        with pytest.raises(ValueError, match="reserved"):
+            PipelineConfig(model_path="m", stages=[_stage("foo@r0")])
+
+    def test_non_numeric_suffix_allowed(self):
+        PipelineConfig(model_path="m", stages=[_stage("foo@rx")])
+
+
+class TestRuntimeOverridesOnReplicas:
+    def _config(self) -> PipelineConfig:
+        return PipelineConfig(
+            model_path="m",
+            stages=[
+                _stage("src", terminal=False, next="gen"),
+                _stage("gen", num_replicas=2, replica_devices="1,2", gpu=1),
+            ],
+            runtime_overrides={"gen": {"max_seq_len": 4096}},
+        )
+
+    def test_replica_instances_inherit_logical_overrides(self):
+        from sglang_omni.config.runtime import resolve_stage_static_factory_args
+
+        config = self._config()
+        expanded, topo = expand_replica_stages(list(config.stages))
+        assert topo.instances("gen") == ("gen@r0", "gen@r1")
+
+        for stage_cfg in expanded:
+            if stage_cfg.name.startswith("gen@r"):
+                args = resolve_stage_static_factory_args(stage_cfg, config)
+                assert (
+                    args.get("max_seq_len") == 4096
+                ), f"{stage_cfg.name} lost the override configured for 'gen'"
+
+    def test_unreplicated_stage_does_not_borrow_overrides(self):
+        from sglang_omni.config.runtime import resolve_stage_static_factory_args
+
+        config = self._config()
+        src = {s.name: s for s in config.stages}["src"]
+        assert "max_seq_len" not in resolve_stage_static_factory_args(src, config)

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -470,10 +470,23 @@ def test_stage_applies_projector_before_local_object_send() -> None:
     asyncio.run(_run())
 
 
-def test_stage_local_object_preserves_fan_in_semantics() -> None:
+def test_stage_local_object_preserves_fan_in_semantics(monkeypatch) -> None:
+    events: list[dict] = []
+    monkeypatch.setattr(
+        "sglang_omni.pipeline.stage.runtime._emit_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+
     async def _run() -> None:
         dispatcher = LocalStageDispatcher()
         receiver_scheduler = FakeScheduler()
+        resolved_sources: list[str] = []
+
+        def expected_sources(request_id, from_stage, payload):
+            del request_id, payload
+            resolved_sources.append(from_stage)
+            return {"preprocess", "thinker"}
+
         receiver = make_stage(
             name="aggregate",
             scheduler=receiver_scheduler,
@@ -488,10 +501,12 @@ def test_stage_local_object_preserves_fan_in_semantics() -> None:
                         },
                     },
                 ),
+                expected_sources_fn=expected_sources,
             ),
+            replica_topology={"preprocess": ["preprocess@r0", "preprocess@r1"]},
         )
         preprocess = make_stage(
-            name="preprocess",
+            name="preprocess@r1",
             endpoints={"aggregate": "inproc://aggregate"},
             same_process_targets={"aggregate"},
             local_dispatcher=dispatcher,
@@ -526,6 +541,109 @@ def test_stage_local_object_preserves_fan_in_semantics() -> None:
             "preprocess": {"p": 1},
             "thinker": {"t": 2},
         }
+        assert resolved_sources == ["preprocess"]
+
+    asyncio.run(_run())
+
+    input_events = [
+        event["metadata"]
+        for event in events
+        if event["stage"] == "aggregate"
+        and event["event_name"] == "stage_input_received"
+    ]
+    assert input_events == [
+        {"from_stage": "preprocess@r1", "kind": "payload"},
+        {"from_stage": "thinker", "kind": "payload"},
+    ]
+
+
+def test_stage_exposes_logical_source_names_to_stream_consumers(monkeypatch) -> None:
+    events: list[dict] = []
+    monkeypatch.setattr(
+        "sglang_omni.pipeline.stage.runtime._emit_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+
+    async def _run() -> None:
+        scheduler = FakeScheduler()
+        receiver = make_stage(
+            name="decode",
+            scheduler=scheduler,
+            can_accept_stream_before_payload=True,
+            replica_topology={"talker": ["talker@r0", "talker@r1"]},
+        )
+        receiver._stream_queue = StreamQueue()
+
+        await receiver.receive_local_stream_chunk(
+            "req-stream",
+            "talker@r1",
+            0,
+            "chunk",
+        )
+        chunk = scheduler.inbox.get_nowait()
+        assert chunk.type == "stream_chunk"
+        assert chunk.data.from_stage == "talker"
+
+        await receiver.receive_local_stream_signal(
+            "req-stream",
+            "talker@r1",
+            is_done=True,
+        )
+        done = scheduler.inbox.get_nowait()
+        assert done.type == "stream_done"
+        signal = await receiver._stream_queue.get_with_source("req-stream")
+        assert signal.from_stage == "talker"
+
+    asyncio.run(_run())
+
+    stream_events = [
+        event["metadata"]
+        for event in events
+        if event["stage"] == "decode"
+        and event["event_name"] == "stage_stream_chunk_received"
+    ]
+    assert stream_events == [{"from_stage": "talker@r1", "chunk_id": 0}]
+
+
+def test_stage_normalizes_direct_cuda_ipc_stream_source(monkeypatch) -> None:
+    monkeypatch.setattr(
+        stage_io,
+        "deserialize_direct_cuda_ipc_stream_chunk",
+        lambda data_ref: ("chunk", {"modality": "audio"}),
+    )
+
+    async def _run() -> None:
+        scheduler = FakeScheduler()
+        control_plane = RecordingStageControlPlane()
+        receiver = make_stage(
+            name="decode",
+            scheduler=scheduler,
+            control_plane=control_plane,
+            can_accept_stream_before_payload=True,
+            replica_topology={"talker": ["talker@r0", "talker@r1"]},
+        )
+        receiver._stream_queue = StreamQueue()
+
+        await receiver._on_stream_chunk(
+            DataReadyMessage(
+                request_id="req-direct-stream",
+                from_stage="talker@r1",
+                to_stage="decode",
+                data_ref={
+                    "_type": "TorchCudaIpcStreamChunk",
+                    "version": 1,
+                    "tensor_bytes": b"handle",
+                    "metadata": {"modality": "audio"},
+                },
+                chunk_id=0,
+            )
+        )
+
+        queued = scheduler.inbox.get_nowait()
+        assert queued.type == "stream_chunk"
+        assert queued.data.data == "chunk"
+        assert queued.data.from_stage == "talker"
+        assert control_plane.sent_to_stage == []
 
     asyncio.run(_run())
 
@@ -1079,12 +1197,17 @@ def test_stage_receives_same_gpu_direct_cuda_ipc_payload(monkeypatch) -> None:
             name="mm_aggregate",
             scheduler=scheduler,
             control_plane=control_plane,
+            input_handler=AggregatedInput(
+                {"encoder"},
+                lambda payloads: payloads["encoder"],
+            ),
+            replica_topology={"encoder": ["encoder@r0", "encoder@r1"]},
         )
 
         await receiver._on_data_ready(
             DataReadyMessage(
                 request_id="req-direct",
-                from_stage="encoder",
+                from_stage="encoder@r1",
                 to_stage="mm_aggregate",
                 data_ref={
                     "_type": "TorchCudaIpcPayload",
@@ -1097,8 +1220,58 @@ def test_stage_receives_same_gpu_direct_cuda_ipc_payload(monkeypatch) -> None:
 
         queued = scheduler.inbox.get_nowait()
         assert queued.type == "new_request"
-        assert queued.data is payload
+        assert queued.data.request_id == payload.request_id
+        assert queued.data.data == payload.data
         assert control_plane.sent_to_stage == []
+
+    asyncio.run(_run())
+
+
+def test_stage_keeps_remote_payload_ack_physical_and_model_source_logical() -> None:
+    async def _run() -> None:
+        relay = FakeRelay()
+        control_plane = RecordingStageControlPlane()
+        scheduler = FakeScheduler()
+        receiver = make_stage(
+            name="mm_aggregate",
+            scheduler=scheduler,
+            relay=relay,
+            control_plane=control_plane,
+            endpoints={"encoder@r1": "inproc://encoder-r1"},
+            input_handler=AggregatedInput(
+                {"encoder"},
+                lambda payloads: payloads["encoder"],
+            ),
+            replica_topology={"encoder": ["encoder@r0", "encoder@r1"]},
+        )
+        payload = make_stage_payload(
+            request_id="req-relay-replica",
+            data={"answer": 7},
+        )
+        data_ref, _ = await stage_io.write_payload(
+            relay,
+            "req-relay-replica",
+            payload,
+            transport=TransportKind.SHM,
+        )
+
+        await receiver._on_data_ready(
+            DataReadyMessage(
+                request_id="req-relay-replica",
+                from_stage="encoder@r1",
+                to_stage="mm_aggregate",
+                data_ref=data_ref.to_dict(),
+            )
+        )
+
+        queued = scheduler.inbox.get_nowait()
+        assert queued.type == "new_request"
+        assert queued.data.request_id == payload.request_id
+        assert queued.data.data == payload.data
+        target, endpoint, ack = control_plane.sent_to_stage[0]
+        assert target == "encoder@r1"
+        assert endpoint == "inproc://encoder-r1"
+        assert ack.to_stage == "encoder@r1"
 
     asyncio.run(_run())
 

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -1286,3 +1286,59 @@ def test_stage_local_object_requires_registered_target() -> None:
             )
 
     asyncio.run(_run())
+
+
+def test_local_dispatch_propagates_replica_bindings_to_receiver() -> None:
+    async def _run() -> None:
+        dispatcher = LocalStageDispatcher()
+        receiver = make_stage(
+            name="thinker",
+            scheduler=FakeScheduler(),
+            replica_topology={"decode": ["decode@r0", "decode@r1"]},
+        )
+        sender = make_stage(
+            name="mm_aggregate",
+            endpoints={"thinker": "inproc://thinker"},
+            same_process_targets={"thinker"},
+            local_dispatcher=dispatcher,
+        )
+        sender._record_replica_bindings("req-local", {"decode": 1})
+        dispatcher.register_many([sender, receiver])
+
+        await sender._send_to_stage(
+            "req-local",
+            "thinker",
+            make_stage_payload(request_id="req-local", data={"x": 1}),
+            allow_local_object=True,
+        )
+
+        assert receiver._replica_bindings["req-local"] == {"decode": 1}
+        assert receiver._resolve_target_instance("req-local", "decode") == "decode@r1"
+
+    asyncio.run(_run())
+
+
+def test_resolve_target_instance_without_binding_raises() -> None:
+    stage = make_stage(
+        name="talker_ar",
+        replica_topology={"code2wav": ["code2wav@r0", "code2wav@r1"]},
+    )
+    with pytest.raises(RuntimeError, match="no replica binding"):
+        stage._resolve_target_instance("req-x", "code2wav")
+
+
+def test_replica_bindings_not_recorded_after_finish_or_abort() -> None:
+    stage = make_stage(
+        name="thinker",
+        replica_topology={"decode": ["decode@r0", "decode@r1"]},
+    )
+    stage._record_replica_bindings("req-1", {"decode": 0})
+    assert "req-1" in stage._replica_bindings
+
+    stage._clear_request_state("req-1")
+    stage._record_replica_bindings("req-1", {"decode": 0})
+    assert "req-1" not in stage._replica_bindings
+
+    stage._record_aborted_request_id("req-2")
+    stage._record_replica_bindings("req-2", {"decode": 1})
+    assert "req-2" not in stage._replica_bindings

--- a/tests/unit_test/pipeline/test_stage_streaming.py
+++ b/tests/unit_test/pipeline/test_stage_streaming.py
@@ -94,6 +94,33 @@ class _AbortOnReadRelay(_FakeRelay):
         return _CallbackOp(self._on_wait)
 
 
+class _LoopbackRelay(_FakeRelay):
+    def __init__(self) -> None:
+        super().__init__()
+        self.storage = {}
+
+    async def put_async(
+        self,
+        tensor,
+        request_id=None,
+        dst_rank=None,
+        receiver_id=None,
+    ):
+        op = await super().put_async(
+            tensor,
+            request_id=request_id,
+            dst_rank=dst_rank,
+            receiver_id=receiver_id,
+        )
+        self.storage[request_id] = tensor.detach().clone()
+        return op
+
+    async def get_async(self, metadata, dest_tensor, request_id):
+        del metadata
+        dest_tensor.copy_(self.storage[request_id].reshape_as(dest_tensor))
+        return _DoneOp(dest_tensor.numel())
+
+
 class _CallbackOp:
     def __init__(self, on_wait) -> None:
         self._on_wait = on_wait
@@ -780,6 +807,57 @@ def test_stage_routes_relay_stream_chunk_to_scheduler() -> None:
         assert queued.type == "stream_chunk"
         assert torch.equal(queued.data.data, codes)
         assert queued.data.metadata == {"modality": "audio_codes"}
+
+    asyncio.run(_run())
+
+
+def test_stage_keeps_remote_stream_ack_physical_and_model_source_logical() -> None:
+    async def _run() -> None:
+        control_plane = _FakeControlPlane()
+        scheduler = SimpleNamespace(
+            outbox=queue.Queue(),
+            inbox=queue.Queue(),
+            abort=lambda request_id: None,
+        )
+        relay = _LoopbackRelay()
+        stage = Stage(
+            name="vocoder",
+            role="single",
+            get_next=lambda request_id, output: None,
+            gpu_id=None,
+            endpoints={"tts_engine@r1": "inproc://tts_engine-r1"},
+            control_plane=control_plane,
+            relay=relay,
+            scheduler=scheduler,
+            replica_topology={
+                "tts_engine": ["tts_engine@r0", "tts_engine@r1"],
+            },
+        )
+        stage._stream_queue = StreamQueue(max_pending=4096)
+        stage._stream_queue.open("req-replica")
+        codes = torch.arange(8, dtype=torch.float32)
+
+        await stage._on_stream_chunk(
+            await _make_relay_chunk(
+                relay,
+                request_id="req-replica",
+                from_stage="tts_engine@r1",
+                to_stage="vocoder",
+                chunk_id=0,
+                data=codes,
+                metadata={"modality": "audio_codes"},
+            )
+        )
+
+        queued = scheduler.inbox.get_nowait()
+        assert queued.request_id == "req-replica"
+        assert queued.type == "stream_chunk"
+        assert torch.equal(queued.data.data, codes)
+        assert queued.data.from_stage == "tts_engine"
+        target, endpoint, ack = control_plane.stage_messages[0]
+        assert target == "tts_engine@r1"
+        assert endpoint == "inproc://tts_engine-r1"
+        assert ack.to_stage == "tts_engine@r1"
 
     asyncio.run(_run())
 


### PR DESCRIPTION
Depends on #1175

## Motivation

#1175 adds runtime-level replicas for non-entry stages. Two gaps remain for pipelines that need to replicate a complete frontend (e.g. tts_frontend of higgs-tts):

1. The entry stage is explicitly prohibited from using `num_replicas`, and the coordinator always submits requests to the logical entry-stage endpoint.
2. Messages from a replicated upstream stage expose concrete names such as `preprocessing@r0` to model-facing fan-in and streaming APIs, even though model configuration continues to use the logical name `preprocessing`.

The first limitation prevents pipelines such as Higgs TTS from replicating the complete `preprocessing → audio_encoder` frontend.

The second breaks the logical-stage abstraction introduced by #1175. For example, `wait_for=["preprocessing"]`, merge-input keys, and stream consumers should not need to know which physical replica produced the data. At the same time, transport routing and ACKs must retain the concrete instance name.

This PR extends #1175 to support replicated entry stages and consistently restores logical source names at model-facing receive boundaries.

## Modifications

### Replicated entry-stage admission

This PR removes the entry-stage replication restriction introduced in #1175. The coordinator now assigns request-sticky replica bindings before admission, resolves the logical entry stage to its selected concrete instance, verifies that all entry replicas are registered, and submits the request directly to that instance. Non-replicated entry stages retain the existing behavior.

### Logical source names at model boundaries

Concrete replica names are normalized back to logical stage names before payloads, fan-in inputs, stream chunks, and stream-completion signals reach model code. Transport routing, ACKs, ordering, logs, and profiler events continue using concrete instance names, preserving both the logical model-facing topology and the physical identity required by the runtime.

### Documentation and tests

The configuration documentation now covers entry-stage replicas and logical-versus-concrete naming semantics. New tests validate replicated CPU and TP entry stages, coordinator admission and registration checks, and source-name handling across local dispatch, relay, direct CUDA IPC, fan-in, streaming, and ACK paths.
## Related Issues

#1131 

## Accuracy Test

Not related

## Benchmark & Profiling

see #1276 

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
