### PR TITLE
[Cosmos02] Vision encoder for UND (AR backbone)

### DIFF
--- a/sglang_omni/models/cosmos3/bootstrap.py
+++ b/sglang_omni/models/cosmos3/bootstrap.py
@@ -62,6 +62,49 @@ def _refuse_weight_update(payload: dict[str, Any]) -> tuple[bool, str]:
     )
 
 
+def resolve_vision_encoder_path(
+    model_path: str,
+    *,
+    revision: str | None = None,
+) -> str:
+    """Resolve the standalone Qwen3-VL vision checkpoint."""
+
+    local_path = Path(model_path)
+    if local_path.exists():
+        vision_path = local_path / "vision_encoder"
+    else:
+        allow_patterns = [
+            "config.json",
+            "vision_encoder/*.json",
+            "vision_encoder/*.safetensors",
+        ]
+        try:
+            snapshot_path = snapshot_download(
+                model_path,
+                allow_patterns=allow_patterns,
+                revision=revision,
+                local_files_only=True,
+            )
+        except FileNotFoundError:
+            snapshot_path = None
+        vision_path = (
+            Path(snapshot_path) / "vision_encoder"
+            if snapshot_path is not None
+            else None
+        )
+        if not _has_transformer_weights(vision_path):
+            snapshot_path = snapshot_download(
+                model_path, allow_patterns=allow_patterns, revision=revision
+            )
+            vision_path = Path(snapshot_path) / "vision_encoder"
+
+    if vision_path is None or not _has_transformer_weights(vision_path):
+        raise FileNotFoundError(
+            f"Cosmos3 vision encoder weights not found under {model_path!r}"
+        )
+    return str(vision_path)
+
+
 def create_thinker_scheduler(
     server_args: Any,
     gpu_id: int = 0,
@@ -76,7 +119,7 @@ def create_thinker_scheduler(
 
     from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 
-    from sglang_omni.model_runner.base import ModelRunner
+    from sglang_omni.models.cosmos3.model_runner import Cosmos3ThinkerModelRunner
     from sglang_omni.models.cosmos3.request_builders import (
         make_text_scheduler_adapters,
         make_text_stream_output_builder,
@@ -118,7 +161,7 @@ def create_thinker_scheduler(
         setattr(model_worker, admin_method, _refuse_weight_update)
 
     output_processor = SGLangOutputProcessor(capture_hidden=False)
-    model_runner = ModelRunner(model_worker, output_processor)
+    model_runner = Cosmos3ThinkerModelRunner(model_worker, output_processor)
     tokenizer = get_tokenizer(
         server_args.model_path,
         trust_remote_code=True,
@@ -128,6 +171,7 @@ def create_thinker_scheduler(
         tokenizer=tokenizer,
         vocab_size=model_config.vocab_size,
         generation_config=model_config.hf_generation_config,
+        thinker_config=model_config.hf_config,
     )
 
     return OmniScheduler(
@@ -148,4 +192,8 @@ def create_thinker_scheduler(
     )
 
 
-__all__ = ["create_thinker_scheduler", "resolve_transformer_weights_path"]
+__all__ = [
+    "create_thinker_scheduler",
+    "resolve_transformer_weights_path",
+    "resolve_vision_encoder_path",
+]

--- a/sglang_omni/models/cosmos3/bootstrap.py
+++ b/sglang_omni/models/cosmos3/bootstrap.py
@@ -62,6 +62,49 @@ def _refuse_weight_update(payload: dict[str, Any]) -> tuple[bool, str]:
     )
 
 
+def resolve_vision_encoder_path(
+    model_path: str,
+    *,
+    revision: str | None = None,
+) -> str:
+    """Resolve the standalone Qwen3-VL vision checkpoint."""
+
+    local_path = Path(model_path)
+    if local_path.exists():
+        vision_path = local_path / "vision_encoder"
+    else:
+        allow_patterns = [
+            "config.json",
+            "vision_encoder/*.json",
+            "vision_encoder/*.safetensors",
+        ]
+        try:
+            snapshot_path = snapshot_download(
+                model_path,
+                allow_patterns=allow_patterns,
+                revision=revision,
+                local_files_only=True,
+            )
+        except FileNotFoundError:
+            snapshot_path = None
+        vision_path = (
+            Path(snapshot_path) / "vision_encoder"
+            if snapshot_path is not None
+            else None
+        )
+        if not _has_transformer_weights(vision_path):
+            snapshot_path = snapshot_download(
+                model_path, allow_patterns=allow_patterns, revision=revision
+            )
+            vision_path = Path(snapshot_path) / "vision_encoder"
+
+    if vision_path is None or not _has_transformer_weights(vision_path):
+        raise FileNotFoundError(
+            f"Cosmos3 vision encoder weights not found under {model_path!r}"
+        )
+    return str(vision_path)
+
+
 def create_thinker_scheduler(
     server_args: Any,
     gpu_id: int = 0,
@@ -76,7 +119,7 @@ def create_thinker_scheduler(
 
     from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 
-    from sglang_omni.model_runner.base import ModelRunner
+    from sglang_omni.models.cosmos3.model_runner import Cosmos3ThinkerModelRunner
     from sglang_omni.models.cosmos3.request_builders import (
         make_text_scheduler_adapters,
         make_text_stream_output_builder,
@@ -116,7 +159,7 @@ def create_thinker_scheduler(
         setattr(model_worker, admin_method, _refuse_weight_update)
 
     output_processor = SGLangOutputProcessor(capture_hidden=False)
-    model_runner = ModelRunner(model_worker, output_processor)
+    model_runner = Cosmos3ThinkerModelRunner(model_worker, output_processor)
     tokenizer = get_tokenizer(
         server_args.model_path,
         trust_remote_code=True,
@@ -126,6 +169,7 @@ def create_thinker_scheduler(
         tokenizer=tokenizer,
         vocab_size=model_config.vocab_size,
         generation_config=model_config.hf_generation_config,
+        thinker_config=model_config.hf_config,
     )
 
     return OmniScheduler(
@@ -144,4 +188,8 @@ def create_thinker_scheduler(
     )
 
 
-__all__ = ["create_thinker_scheduler", "resolve_transformer_weights_path"]
+__all__ = [
+    "create_thinker_scheduler",
+    "resolve_transformer_weights_path",
+    "resolve_vision_encoder_path",
+]

--- a/sglang_omni/models/cosmos3/components/sglang_text.py
+++ b/sglang_omni/models/cosmos3/components/sglang_text.py
@@ -7,9 +7,17 @@ from collections.abc import Iterable
 from typing import Any
 
 import torch
+from sglang.srt.distributed import get_pp_group
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.pooler import Pooler, PoolingType
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.utils import PPMissingLayer
+from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.models.qwen3 import Qwen3ForCausalLM
+from sglang.srt.models.qwen3_vl import Qwen3LLMModel
+from sglang.srt.runtime_context import get_server_args
+from sglang.srt.utils import add_prefix
 
 from sglang_omni.models.cosmos3.hf_config import Cosmos3OmniConfig
 
@@ -75,13 +83,35 @@ class Cosmos3TextForCausalLM(Qwen3ForCausalLM):
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ) -> None:
+        torch.nn.Module.__init__(self)
         text_config = config.text_config
         text_config.tie_word_embeddings = bool(config.tie_word_embeddings)
-        super().__init__(
-            text_config,
+        text_config.vision_config = config.vision_config
+
+        self.pp_group = get_pp_group()
+        self.config = text_config
+        self.quant_config = quant_config
+        self.model = Qwen3LLMModel(
+            config=text_config,
             quant_config=quant_config,
-            prefix=prefix,
+            prefix=add_prefix("model", prefix),
         )
+        if self.pp_group.is_last_rank:
+            if self.pp_group.world_size == 1 and text_config.tie_word_embeddings:
+                self.lm_head = self.model.embed_tokens
+            else:
+                self.lm_head = ParallelLMHead(
+                    text_config.vocab_size,
+                    text_config.hidden_size,
+                    quant_config=quant_config,
+                    use_attn_tp_group=get_server_args().enable_dp_lm_head,
+                    prefix=add_prefix("lm_head", prefix),
+                )
+        else:
+            self.lm_head = PPMissingLayer()
+        self.logits_processor = LogitsProcessor(text_config)
+        self.pooler = Pooler(pooling_type=PoolingType.LAST, normalize=True)
+        self.capture_aux_hidden_states = False
         self.root_config = config
 
     @torch.no_grad()
@@ -89,8 +119,9 @@ class Cosmos3TextForCausalLM(Qwen3ForCausalLM):
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,
-        forward_batch: Any,
+        forward_batch: ForwardBatch,
         input_embeds: torch.Tensor | None = None,
+        input_deepstack_embeds: torch.Tensor | None = None,
         get_embedding: bool = False,
         pp_proxy_tensors: Any = None,
     ) -> torch.Tensor:
@@ -98,13 +129,36 @@ class Cosmos3TextForCausalLM(Qwen3ForCausalLM):
         # Cosmos3 follows Qwen3-VL's explicit T/H/W text-position convention,
         # so route SGLang's computed mRoPE positions into every decoder layer.
         positions = resolve_cosmos3_text_positions(forward_batch)
-        return super().forward(
-            input_ids=input_ids,
-            positions=positions,
-            forward_batch=forward_batch,
-            input_embeds=input_embeds,
-            get_embedding=get_embedding,
+        if input_deepstack_embeds is None:
+            return super().forward(
+                input_ids=input_ids,
+                positions=positions,
+                forward_batch=forward_batch,
+                input_embeds=input_embeds,
+                get_embedding=get_embedding,
+                pp_proxy_tensors=pp_proxy_tensors,
+            )
+        hidden_states = self.model(
+            input_ids,
+            positions,
+            forward_batch,
+            input_embeds,
             pp_proxy_tensors=pp_proxy_tensors,
+            input_deepstack_embeds=input_deepstack_embeds,
+        )
+        aux_hidden_states = None
+        if self.capture_aux_hidden_states:
+            hidden_states, aux_hidden_states = hidden_states
+        if not self.pp_group.is_last_rank:
+            return hidden_states
+        if get_embedding:
+            return self.pooler(hidden_states, forward_batch)
+        return self.logits_processor(
+            input_ids,
+            hidden_states,
+            self.lm_head,
+            forward_batch,
+            aux_hidden_states,
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> Any:

--- a/sglang_omni/models/cosmos3/components/text_preprocessor.py
+++ b/sglang_omni/models/cosmos3/components/text_preprocessor.py
@@ -7,6 +7,7 @@ import asyncio
 import logging
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 import torch
 from transformers import AutoProcessor, AutoTokenizer
@@ -257,7 +258,7 @@ class Cosmos3TextPreprocessor:
     async def _tokenize_multimodal(
         self,
         inputs: dict[str, Any],
-    ) -> tuple[dict[str, torch.Tensor], str, str | None]:
+    ) -> tuple[dict[str, torch.Tensor], str, str | None, str | None]:
         if self.processor is None:
             raise ValueError("Cosmos3 media inputs require the checkpoint processor")
 
@@ -344,8 +345,13 @@ class Cosmos3TextPreprocessor:
                     f"total_pixels={video_total_pixels}",
                 )
             )
-        cache_parts = [part for part in (image_cache_key, video_cache_key) if part]
-        return dict(encoded), prompt_text, "|".join(cache_parts) or None
+
+        request_cache_id = uuid4().hex
+        if images and image_cache_key is None:
+            image_cache_key = f"image:request:{request_cache_id}"
+        if videos and video_cache_key is None:
+            video_cache_key = f"video:request:{request_cache_id}"
+        return dict(encoded), prompt_text, image_cache_key, video_cache_key
 
     @staticmethod
     def _use_pretokenized_inputs(inputs: Any) -> bool:
@@ -392,9 +398,12 @@ class Cosmos3TextPreprocessor:
                     raise ValueError(
                         "Cosmos3 text-only pipeline does not accept image/video input"
                     )
-                encoded, prompt_text, cache_key = await self._tokenize_multimodal(
-                    inputs
-                )
+                (
+                    encoded,
+                    prompt_text,
+                    image_cache_key,
+                    video_cache_key,
+                ) = await self._tokenize_multimodal(inputs)
                 input_ids = _flatten_single_batch(encoded["input_ids"])
                 raw_attention_mask = encoded.get("attention_mask")
                 attention_mask = (
@@ -423,8 +432,10 @@ class Cosmos3TextPreprocessor:
                     )
                     if isinstance(encoded.get(key), torch.Tensor)
                 }
-                if cache_key is not None:
-                    vision_inputs["cache_key"] = cache_key
+                if image_cache_key is not None:
+                    vision_inputs["image_cache_key"] = image_cache_key
+                if video_cache_key is not None:
+                    vision_inputs["video_cache_key"] = video_cache_key
             else:
                 input_ids, attention_mask, prompt_text = self._tokenize_messages(inputs)
                 mm_token_type_ids = torch.zeros_like(input_ids)

--- a/sglang_omni/models/cosmos3/components/text_preprocessor.py
+++ b/sglang_omni/models/cosmos3/components/text_preprocessor.py
@@ -1,23 +1,30 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Text-only preprocessing for Cosmos3-Nano."""
+"""Text and vision preprocessing for Cosmos3-Nano."""
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import Any
 
 import torch
-from transformers import AutoTokenizer
+from transformers import AutoProcessor, AutoTokenizer
 
 from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.preprocessing import (
+    compute_image_cache_key,
+    compute_video_cache_key,
+    ensure_image_list_async,
+    ensure_video_list_async,
+)
 from sglang_omni.preprocessing.text import ensure_chat_template
 from sglang_omni.proto import StagePayload
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_NEW_TOKENS = 2048
-_MEDIA_INPUT_KEYS = ("images", "videos", "audios")
+VISION_STAGE = "vision_encoder"
 
 
 def load_cosmos3_tokenizer(
@@ -45,9 +52,33 @@ def load_cosmos3_tokenizer(
     )
 
 
+def load_cosmos3_processor(
+    model_path: str,
+    revision: str | None = None,
+) -> Any:
+    """Load the Qwen3-VL processor shipped with Cosmos3-Nano."""
+
+    local_only = Path(model_path).exists()
+    if not local_only:
+        try:
+            return AutoProcessor.from_pretrained(
+                model_path,
+                trust_remote_code=True,
+                revision=revision,
+                local_files_only=True,
+            )
+        except (OSError, ValueError):
+            pass
+    return AutoProcessor.from_pretrained(
+        model_path,
+        trust_remote_code=True,
+        revision=revision,
+        local_files_only=local_only,
+    )
+
+
 def _normalize_text_messages(inputs: Any) -> list[dict[str, str]]:
     if isinstance(inputs, dict):
-        _reject_media_inputs(inputs)
         if "messages" not in inputs:
             raise ValueError("Cosmos3 text preprocessing expects a messages field")
         inputs = inputs["messages"]
@@ -87,19 +118,11 @@ def _normalize_text_messages(inputs: Any) -> list[dict[str, str]]:
         if not isinstance(content, str):
             raise TypeError(
                 f"Message {index} content must be a string or a list of text "
-                "parts; multimodal content will be added in a later Cosmos3 stage"
+                "parts; multimodal content must be passed with top-level "
+                "images/videos"
             )
         messages.append({"role": role, "content": content})
     return messages
-
-
-def _reject_media_inputs(container: dict[str, Any]) -> None:
-    populated_media = [key for key in _MEDIA_INPUT_KEYS if container.get(key)]
-    if populated_media:
-        raise ValueError(
-            "Cosmos3 text preprocessing does not support media inputs yet: "
-            + ", ".join(populated_media)
-        )
 
 
 def _flatten_single_batch(value: torch.Tensor) -> torch.Tensor:
@@ -147,7 +170,7 @@ def validate_prompt_seq_len(
 
 
 class Cosmos3TextPreprocessor:
-    """Build a tokenizer-only Cosmos3 pipeline state on CPU."""
+    """Build the Cosmos3 prompt and standalone vision-encoder inputs on CPU."""
 
     def __init__(
         self,
@@ -156,12 +179,18 @@ class Cosmos3TextPreprocessor:
         *,
         revision: str | None = None,
         tokenizer: Any | None = None,
+        processor: Any | None = None,
+        enable_vision: bool = True,
     ) -> None:
         self.model_path = model_path
         self.max_seq_len = max_seq_len
-        self.tokenizer = (
-            tokenizer
-            if tokenizer is not None
+        self.enable_vision = enable_vision
+        self.processor = processor
+        if self.processor is None and tokenizer is None and enable_vision:
+            self.processor = load_cosmos3_processor(model_path, revision=revision)
+        self.tokenizer = tokenizer or (
+            self.processor.tokenizer
+            if self.processor is not None
             else load_cosmos3_tokenizer(model_path, revision=revision)
         )
         ensure_chat_template(
@@ -196,6 +225,129 @@ class Cosmos3TextPreprocessor:
         return input_ids, attention_mask, prompt_text
 
     @staticmethod
+    def _multimodal_messages(
+        messages: list[dict[str, str]],
+        *,
+        num_images: int,
+        num_videos: int,
+    ) -> list[dict[str, Any]]:
+        if num_images == 0 and num_videos == 0:
+            return messages
+
+        result: list[dict[str, Any]] = []
+        target = max(
+            (
+                index
+                for index, message in enumerate(messages)
+                if message["role"] == "user"
+            ),
+            default=len(messages) - 1,
+        )
+        for index, message in enumerate(messages):
+            if index != target:
+                result.append(message)
+                continue
+            content: list[dict[str, str]] = []
+            content.extend({"type": "image"} for _ in range(num_images))
+            content.extend({"type": "video"} for _ in range(num_videos))
+            content.append({"type": "text", "text": message["content"]})
+            result.append({"role": message["role"], "content": content})
+        return result
+
+    async def _tokenize_multimodal(
+        self,
+        inputs: dict[str, Any],
+    ) -> tuple[dict[str, torch.Tensor], str, str | None]:
+        if self.processor is None:
+            raise ValueError("Cosmos3 media inputs require the checkpoint processor")
+
+        raw_images = inputs.get("images")
+        raw_videos = inputs.get("videos") or inputs.get("video")
+        video_fps = inputs.get("video_fps")
+        video_max_frames = inputs.get("video_max_frames")
+        video_min_pixels = inputs.get("video_min_pixels")
+        video_max_pixels = inputs.get("video_max_pixels")
+        video_total_pixels = inputs.get("video_total_pixels")
+        image_cache_key = compute_image_cache_key(raw_images)
+        video_cache_key = compute_video_cache_key(raw_videos)
+
+        images, video_result = await asyncio.gather(
+            ensure_image_list_async(raw_images),
+            ensure_video_list_async(
+                raw_videos,
+                fps=float(video_fps) if video_fps is not None else None,
+                max_frames=(
+                    int(video_max_frames) if video_max_frames is not None else None
+                ),
+                min_pixels=(
+                    int(video_min_pixels) if video_min_pixels is not None else None
+                ),
+                max_pixels=(
+                    int(video_max_pixels) if video_max_pixels is not None else None
+                ),
+                total_pixels=(
+                    int(video_total_pixels) if video_total_pixels is not None else None
+                ),
+            ),
+        )
+        videos, sampled_fps, _ = video_result
+        messages = _normalize_text_messages(inputs)
+        messages_mm = self._multimodal_messages(
+            messages,
+            num_images=len(images),
+            num_videos=len(videos),
+        )
+        prompt_text = self.processor.apply_chat_template(
+            messages_mm,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        processor_kwargs: dict[str, Any] = {}
+        if videos:
+            videos_kwargs: dict[str, Any] = {"device": "cpu"}
+            if sampled_fps:
+                videos_kwargs["fps"] = (
+                    sampled_fps[0] if len(sampled_fps) == 1 else sampled_fps
+                )
+            elif video_fps is not None:
+                videos_kwargs["fps"] = float(video_fps)
+            if video_max_frames is not None:
+                videos_kwargs["max_frames"] = int(video_max_frames)
+            if video_min_pixels is not None:
+                videos_kwargs["min_pixels"] = int(video_min_pixels)
+            if video_max_pixels is not None:
+                videos_kwargs["max_pixels"] = int(video_max_pixels)
+            if video_total_pixels is not None:
+                videos_kwargs["total_pixels"] = int(video_total_pixels)
+            processor_kwargs["videos_kwargs"] = videos_kwargs
+
+        encoded = self.processor(
+            text=prompt_text,
+            images=images or None,
+            videos=videos or None,
+            add_special_tokens=False,
+            return_tensors="pt",
+            **processor_kwargs,
+        )
+        if video_cache_key is not None:
+            effective_fps = tuple(sampled_fps or ()) or (
+                (float(video_fps),) if video_fps is not None else None
+            )
+            video_cache_key = "|".join(
+                str(part)
+                for part in (
+                    video_cache_key,
+                    f"fps={effective_fps}",
+                    f"max_frames={video_max_frames}",
+                    f"min_pixels={video_min_pixels}",
+                    f"max_pixels={video_max_pixels}",
+                    f"total_pixels={video_total_pixels}",
+                )
+            )
+        cache_parts = [part for part in (image_cache_key, video_cache_key) if part]
+        return dict(encoded), prompt_text, "|".join(cache_parts) or None
+
+    @staticmethod
     def _use_pretokenized_inputs(inputs: Any) -> bool:
         return (
             isinstance(inputs, list)
@@ -203,18 +355,81 @@ class Cosmos3TextPreprocessor:
             and all(isinstance(token_id, int) for token_id in inputs)
         )
 
-    def __call__(self, payload: StagePayload) -> StagePayload:
-        # The OpenAI adapter places top-level media fields in metadata rather
-        # than request.inputs. Keep the first Cosmos3 slice strictly text-only
-        # regardless of which entry point constructed the OmniRequest.
-        _reject_media_inputs(payload.request.metadata)
+    async def __call__(self, payload: StagePayload) -> StagePayload:
         inputs = payload.request.inputs
         if self._use_pretokenized_inputs(inputs):
             input_ids = torch.tensor(inputs, dtype=torch.long)
             attention_mask = torch.ones_like(input_ids)
             prompt_text = ""
+            mm_token_type_ids = torch.zeros_like(input_ids)
+            mm_inputs: dict[str, Any] = {}
+            vision_inputs: dict[str, Any] = {"_skip": True, "_result": {}}
         else:
-            input_ids, attention_mask, prompt_text = self._tokenize_messages(inputs)
+            if not isinstance(inputs, dict):
+                inputs = {"messages": inputs}
+            for key in (
+                "images",
+                "videos",
+                "video_fps",
+                "video_max_frames",
+                "video_min_pixels",
+                "video_max_pixels",
+                "video_total_pixels",
+            ):
+                if (
+                    inputs.get(key) is None
+                    and payload.request.metadata.get(key) is not None
+                ):
+                    inputs[key] = payload.request.metadata[key]
+
+            if inputs.get("audios") or inputs.get("audio"):
+                raise ValueError("Cosmos3 audio preprocessing is not implemented yet")
+            has_media = bool(
+                inputs.get("images") or inputs.get("videos") or inputs.get("video")
+            )
+            if has_media:
+                if not self.enable_vision:
+                    raise ValueError(
+                        "Cosmos3 text-only pipeline does not accept image/video input"
+                    )
+                encoded, prompt_text, cache_key = await self._tokenize_multimodal(
+                    inputs
+                )
+                input_ids = _flatten_single_batch(encoded["input_ids"])
+                raw_attention_mask = encoded.get("attention_mask")
+                attention_mask = (
+                    torch.ones_like(input_ids)
+                    if raw_attention_mask is None
+                    else _flatten_single_batch(raw_attention_mask)
+                )
+                raw_token_types = encoded.get("mm_token_type_ids")
+                if raw_token_types is None:
+                    raise ValueError(
+                        "Cosmos3 processor did not return mm_token_type_ids"
+                    )
+                mm_token_type_ids = _flatten_single_batch(raw_token_types)
+                mm_inputs = {
+                    key: encoded[key]
+                    for key in ("image_grid_thw", "video_grid_thw")
+                    if isinstance(encoded.get(key), torch.Tensor)
+                }
+                vision_inputs = {
+                    key: encoded[key]
+                    for key in (
+                        "pixel_values",
+                        "image_grid_thw",
+                        "pixel_values_videos",
+                        "video_grid_thw",
+                    )
+                    if isinstance(encoded.get(key), torch.Tensor)
+                }
+                if cache_key is not None:
+                    vision_inputs["cache_key"] = cache_key
+            else:
+                input_ids, attention_mask, prompt_text = self._tokenize_messages(inputs)
+                mm_token_type_ids = torch.zeros_like(input_ids)
+                mm_inputs = {}
+                vision_inputs = {"_skip": True, "_result": {}}
 
         max_new_tokens = payload.request.params.get(
             "max_new_tokens", DEFAULT_MAX_NEW_TOKENS
@@ -233,17 +448,23 @@ class Cosmos3TextPreprocessor:
                 "input_ids": input_ids,
                 "attention_mask": attention_mask,
                 "prompt_text": prompt_text,
+                "mm_token_type_ids": mm_token_type_ids,
             },
+            mm_inputs=mm_inputs,
+            encoder_inputs={VISION_STAGE: vision_inputs},
             stream_state={"token_ids": [], "text": ""},
         )
         payload.data = state.to_dict()
         payload.request.inputs = None
+        for key in ("images", "videos"):
+            payload.request.metadata.pop(key, None)
         return payload
 
 
 __all__ = [
     "DEFAULT_MAX_NEW_TOKENS",
     "Cosmos3TextPreprocessor",
+    "load_cosmos3_processor",
     "load_cosmos3_tokenizer",
     "validate_prompt_seq_len",
 ]

--- a/sglang_omni/models/cosmos3/components/vision_encoder.py
+++ b/sglang_omni/models/cosmos3/components/vision_encoder.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standalone Qwen3-VL vision encoder for Cosmos3-Nano."""
+
+from __future__ import annotations
+
+import logging
+import types
+from typing import Any
+
+import torch
+from torch import nn
+from transformers import Qwen3VLVisionModel
+from transformers.models.qwen3_vl import modeling_qwen3_vl as hf_modeling
+from transformers.processing_utils import Unpack
+from transformers.utils.generic import TransformersKwargs, merge_with_config_defaults
+from transformers.utils.output_capturing import capture_outputs
+
+from sglang_omni.models.cosmos3.bootstrap import resolve_vision_encoder_path
+from sglang_omni.models.weight_loader import load_module, resolve_dtype
+from sglang_omni.utils import instantiate_module, load_hf_config
+
+logger = logging.getLogger(__name__)
+
+
+class Cosmos3Qwen3VLVisionModelCompat(Qwen3VLVisionModel):
+    """Qwen3-VL tower with the interpolation arithmetic used by Nano's export."""
+
+    def _legacy_pos_embed_interpolate(
+        self,
+        grid_thw: torch.Tensor,
+    ) -> torch.Tensor:
+        grid_thw_list = grid_thw.tolist()
+        grid_ts = [row[0] for row in grid_thw_list]
+        grid_hs = [row[1] for row in grid_thw_list]
+        grid_ws = [row[2] for row in grid_thw_list]
+        device = self.pos_embed.weight.device
+
+        index_lists = [[] for _ in range(4)]
+        weight_lists = [[] for _ in range(4)]
+        for _, height, width in grid_thw_list:
+            height_indices = torch.linspace(0, self.num_grid_per_side - 1, height)
+            width_indices = torch.linspace(0, self.num_grid_per_side - 1, width)
+            height_floor = height_indices.int()
+            width_floor = width_indices.int()
+            height_ceil = (height_floor + 1).clip(max=self.num_grid_per_side - 1)
+            width_ceil = (width_floor + 1).clip(max=self.num_grid_per_side - 1)
+            delta_height = height_indices - height_floor
+            delta_width = width_indices - width_floor
+            base_height = height_floor * self.num_grid_per_side
+            base_height_ceil = height_ceil * self.num_grid_per_side
+
+            indices = [
+                (base_height[:, None] + width_floor[None]).flatten(),
+                (base_height[:, None] + width_ceil[None]).flatten(),
+                (base_height_ceil[:, None] + width_floor[None]).flatten(),
+                (base_height_ceil[:, None] + width_ceil[None]).flatten(),
+            ]
+            weights = [
+                ((1 - delta_height)[:, None] * (1 - delta_width)[None]).flatten(),
+                ((1 - delta_height)[:, None] * delta_width[None]).flatten(),
+                (delta_height[:, None] * (1 - delta_width)[None]).flatten(),
+                (delta_height[:, None] * delta_width[None]).flatten(),
+            ]
+            for corner in range(4):
+                index_lists[corner].extend(indices[corner].tolist())
+                weight_lists[corner].extend(weights[corner].tolist())
+
+        index_tensor = torch.tensor(index_lists, dtype=torch.long, device=device)
+        weight_tensor = torch.tensor(
+            weight_lists,
+            dtype=self.pos_embed.weight.dtype,
+            device=device,
+        )
+        corners = self.pos_embed(index_tensor) * weight_tensor[:, :, None]
+        position_embeds = corners.sum(dim=0)
+        split_embeds = position_embeds.split(
+            [height * width for height, width in zip(grid_hs, grid_ws)]
+        )
+
+        reordered = []
+        merge_size = self.config.spatial_merge_size
+        for position_embed, grid_t, grid_h, grid_w in zip(
+            split_embeds,
+            grid_ts,
+            grid_hs,
+            grid_ws,
+        ):
+            position_embed = position_embed.repeat(grid_t, 1)
+            position_embed = (
+                position_embed.view(
+                    grid_t,
+                    grid_h // merge_size,
+                    merge_size,
+                    grid_w // merge_size,
+                    merge_size,
+                    -1,
+                )
+                .permute(0, 1, 3, 2, 4, 5)
+                .flatten(0, 4)
+            )
+            reordered.append(position_embed)
+        return torch.cat(reordered)
+
+    @merge_with_config_defaults
+    @capture_outputs
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        grid_thw: torch.Tensor,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> tuple | hf_modeling.BaseModelOutputWithDeepstackFeatures:
+        kwargs.pop("bilinear_indices", None)
+        kwargs.pop("bilinear_weights", None)
+        position_ids = hf_modeling.get_vision_position_ids(
+            grid_thw,
+            self.spatial_merge_size,
+            kwargs=kwargs,
+        )
+        cu_seqlens = hf_modeling.get_vision_cu_seqlens(grid_thw, kwargs=kwargs)
+
+        hidden_states = self.patch_embed(hidden_states)
+        position_embeds = self._legacy_pos_embed_interpolate(grid_thw)
+        hidden_states = hidden_states + position_embeds.to(hidden_states.dtype)
+        rotary_pos_emb = self.rotary_pos_emb(position_ids)
+        rotary_pos_emb = rotary_pos_emb.reshape(hidden_states.shape[0], -1)
+        rotary_pos_emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
+        position_embeddings = (rotary_pos_emb.cos(), rotary_pos_emb.sin())
+
+        deepstack_features = []
+        for layer_index, block in enumerate(self.blocks):
+            hidden_states = block(
+                hidden_states,
+                cu_seqlens=cu_seqlens,
+                position_embeddings=position_embeddings,
+                **kwargs,
+            )
+            if layer_index in self.deepstack_visual_indexes:
+                merger_index = self.deepstack_visual_indexes.index(layer_index)
+                deepstack_features.append(
+                    self.deepstack_merger_list[merger_index](hidden_states)
+                )
+
+        return hf_modeling.BaseModelOutputWithDeepstackFeatures(
+            last_hidden_state=hidden_states,
+            pooler_output=self.merger(hidden_states),
+            deepstack_features=deepstack_features,
+        )
+
+
+def _linear_patch_embed_forward(
+    self: nn.Module,
+    hidden_states: torch.Tensor,
+) -> torch.Tensor:
+    return self.linear(hidden_states.to(dtype=self.linear.weight.dtype))
+
+
+def _optimize_patch_embed(visual: nn.Module) -> None:
+    """Replace the non-overlapping Conv3d patch projection with a Linear."""
+
+    patch_embed = getattr(visual, "patch_embed", None)
+    conv = getattr(patch_embed, "proj", None)
+    if not isinstance(conv, nn.Conv3d):
+        return
+    if list(conv.kernel_size) != list(conv.stride):
+        return
+    if conv.padding != (0, 0, 0) or conv.dilation != (1, 1, 1) or conv.groups != 1:
+        return
+
+    in_features = (
+        conv.in_channels
+        * conv.kernel_size[0]
+        * conv.kernel_size[1]
+        * conv.kernel_size[2]
+    )
+    linear = nn.Linear(
+        in_features,
+        conv.out_channels,
+        bias=conv.bias is not None,
+        dtype=conv.weight.dtype,
+        device=conv.weight.device,
+    )
+    with torch.no_grad():
+        linear.weight.copy_(conv.weight.view(conv.out_channels, -1))
+        if conv.bias is not None:
+            linear.bias.copy_(conv.bias)
+
+    del patch_embed.proj
+    patch_embed.linear = linear
+    patch_embed.forward = types.MethodType(_linear_patch_embed_forward, patch_embed)
+    logger.info("Cosmos3 vision patch projection replaced with Linear")
+
+
+class Cosmos3VisionEncoder(nn.Module):
+    """Vision tower split from the unified Cosmos3 checkpoint."""
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        revision: str | None = None,
+        device: str = "cuda",
+        dtype: str | torch.dtype | None = None,
+    ) -> None:
+        super().__init__()
+        root_config = load_hf_config(model_path, local_files_only=True)
+        vision_config = root_config.vision_config
+        torch_dtype = resolve_dtype(dtype)
+        visual = instantiate_module(Cosmos3Qwen3VLVisionModelCompat, vision_config)
+        self.visual = load_module(
+            visual,
+            resolve_vision_encoder_path(model_path, revision=revision),
+            prefix="",
+            dtype=torch_dtype,
+            device=device,
+            strict=True,
+        )
+        _optimize_patch_embed(self.visual)
+
+        self._device = torch.device(device)
+        self.spatial_merge_size = int(vision_config.spatial_merge_size)
+        self.out_hidden_size = int(vision_config.out_hidden_size)
+        self.deepstack_layers = len(vision_config.deepstack_visual_indexes)
+        self.visual_dtype_bytes = torch.empty(
+            (), dtype=self.visual.dtype
+        ).element_size()
+
+    def _encode(
+        self,
+        pixel_values: torch.Tensor,
+        grid_thw: torch.Tensor,
+    ) -> tuple[torch.Tensor, list[torch.Tensor]]:
+        grid_thw = grid_thw.to(self._device, dtype=torch.long)
+        pixel_values = pixel_values.to(
+            device=self._device,
+            dtype=self.visual.dtype,
+        )
+        output = self.visual(pixel_values, grid_thw=grid_thw, return_dict=True)
+        return output.pooler_output, list(output.deepstack_features)
+
+    def forward(
+        self,
+        *,
+        pixel_values: torch.Tensor | None = None,
+        image_grid_thw: torch.Tensor | None = None,
+        pixel_values_videos: torch.Tensor | None = None,
+        video_grid_thw: torch.Tensor | None = None,
+        **_: Any,
+    ) -> dict[str, Any]:
+        outputs: dict[str, Any] = {}
+        merge = self.spatial_merge_size**2
+
+        if isinstance(pixel_values, torch.Tensor) and isinstance(
+            image_grid_thw, torch.Tensor
+        ):
+            image_grid_thw = image_grid_thw.to(self._device, dtype=torch.long)
+            image_embeds, image_deepstack = self._encode(
+                pixel_values,
+                image_grid_thw,
+            )
+            outputs.update(
+                image_embeds=image_embeds,
+                image_grid_thw=image_grid_thw,
+                image_token_counts=image_grid_thw.prod(-1) // merge,
+                deepstack_visual_embeds_image=image_deepstack,
+            )
+
+        if isinstance(pixel_values_videos, torch.Tensor) and isinstance(
+            video_grid_thw, torch.Tensor
+        ):
+            video_grid_thw = video_grid_thw.to(self._device, dtype=torch.long)
+            video_embeds, video_deepstack = self._encode(
+                pixel_values_videos,
+                video_grid_thw,
+            )
+            outputs.update(
+                video_embeds=video_embeds,
+                video_grid_thw=video_grid_thw,
+                video_token_counts=video_grid_thw.prod(-1) // merge,
+                deepstack_visual_embeds_video=video_deepstack,
+            )
+
+        return outputs
+
+
+__all__ = ["Cosmos3Qwen3VLVisionModelCompat", "Cosmos3VisionEncoder"]

--- a/sglang_omni/models/cosmos3/config.py
+++ b/sglang_omni/models/cosmos3/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Text-only Cosmos3-Nano pipeline configuration."""
+"""Cosmos3-Nano thinker pipeline configuration."""
 
 from __future__ import annotations
 
@@ -12,8 +12,81 @@ from sglang_omni.config import PipelineConfig, StageConfig
 _PKG = "sglang_omni.models.cosmos3"
 
 PREPROCESSING_STAGE = "preprocessing"
+VISION_STAGE = "vision_encoder"
 THINKER_STAGE = "thinker"
 DECODE_STAGE = "decode"
+
+
+def _thinker_stage(*, aggregate_vision: bool = False) -> StageConfig:
+    stage = StageConfig(
+        name=THINKER_STAGE,
+        process="pipeline",
+        factory=f"{_PKG}.stages.create_sglang_text_executor_from_config",
+        factory_args={
+            "thinker_max_seq_len": 8192,
+            "enable_async_decode": False,
+        },
+        runtime_arg_map={"max_seq_len": "thinker_max_seq_len"},
+        gpu=0,
+        tp_size=1,
+        next=DECODE_STAGE,
+        stream_to=[DECODE_STAGE],
+        project_payload={
+            DECODE_STAGE: f"{_PKG}.request_builders.project_thinker_to_decode"
+        },
+    )
+    if aggregate_vision:
+        stage.wait_for = [PREPROCESSING_STAGE, VISION_STAGE]
+        stage.wait_for_fn = f"{_PKG}.request_builders.resolve_thinker_wait_sources"
+        stage.merge_fn = f"{_PKG}.merge.merge_for_thinker"
+    return stage
+
+
+def _decode_stage() -> StageConfig:
+    return StageConfig(
+        name=DECODE_STAGE,
+        process="pipeline",
+        factory=f"{_PKG}.stages.create_decode_executor",
+        terminal=True,
+        can_accept_stream_before_payload=True,
+    )
+
+
+def _vision_stages() -> list[StageConfig]:
+    return [
+        StageConfig(
+            name=PREPROCESSING_STAGE,
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_preprocessing_executor",
+            factory_args={"thinker_max_seq_len": 8192, "enable_vision": True},
+            runtime_arg_map={"max_seq_len": "thinker_max_seq_len"},
+            next=[VISION_STAGE, THINKER_STAGE],
+            route_fn=f"{_PKG}.request_builders.resolve_preprocessing_next_stages",
+            project_payload={
+                VISION_STAGE: (
+                    f"{_PKG}.request_builders.project_preprocessing_to_vision_encoder"
+                ),
+                THINKER_STAGE: (
+                    f"{_PKG}.request_builders.project_preprocessing_to_thinker"
+                ),
+            },
+        ),
+        StageConfig(
+            name=VISION_STAGE,
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_vision_encoder_executor",
+            factory_args={"device": "cuda", "dtype": None},
+            gpu=0,
+            next=THINKER_STAGE,
+            project_payload={
+                THINKER_STAGE: (
+                    f"{_PKG}.request_builders.project_vision_encoder_to_thinker"
+                )
+            },
+        ),
+        _thinker_stage(aggregate_vision=True),
+        _decode_stage(),
+    ]
 
 
 def _text_stages() -> list[StageConfig]:
@@ -22,46 +95,28 @@ def _text_stages() -> list[StageConfig]:
             name=PREPROCESSING_STAGE,
             process="pipeline",
             factory=f"{_PKG}.stages.create_preprocessing_executor",
-            factory_args={"thinker_max_seq_len": 8192},
+            factory_args={"thinker_max_seq_len": 8192, "enable_vision": False},
             runtime_arg_map={"max_seq_len": "thinker_max_seq_len"},
             next=THINKER_STAGE,
         ),
-        StageConfig(
-            name=THINKER_STAGE,
-            process="pipeline",
-            factory=f"{_PKG}.stages.create_sglang_text_executor_from_config",
-            factory_args={
-                "thinker_max_seq_len": 8192,
-                "enable_async_decode": False,
-            },
-            runtime_arg_map={"max_seq_len": "thinker_max_seq_len"},
-            gpu=0,
-            tp_size=1,
-            next=DECODE_STAGE,
-            stream_to=[DECODE_STAGE],
-        ),
-        StageConfig(
-            name=DECODE_STAGE,
-            process="pipeline",
-            factory=f"{_PKG}.stages.create_decode_executor",
-            terminal=True,
-            can_accept_stream_before_payload=True,
-        ),
+        _thinker_stage(),
+        _decode_stage(),
     ]
 
 
-class Cosmos3TextPipelineConfig(PipelineConfig):
-    """Three-stage MVP: preprocessing → text AR → detokenize."""
-
+class _Cosmos3PipelineConfig(PipelineConfig):
     architecture: ClassVar[str] = "Cosmos3ForConditionalGeneration"
 
     @classmethod
     def mem_fraction_role_to_stage(cls) -> dict[str, str]:
         return {THINKER_STAGE: THINKER_STAGE}
 
+    @classmethod
+    def generation_sglang_role_to_stage(cls) -> dict[str, str]:
+        return {"generation": THINKER_STAGE}
+
     model_path: str
     revision: str | None = None
-    stages: list[StageConfig] = Field(default_factory=_text_stages)
 
     def model_post_init(self, __context: Any = None, /) -> None:
         super().model_post_init(__context)
@@ -71,8 +126,25 @@ class Cosmos3TextPipelineConfig(PipelineConfig):
             stage.factory_args["revision"] = self.revision
 
 
-EntryClass = Cosmos3TextPipelineConfig
+class Cosmos3PipelineConfig(_Cosmos3PipelineConfig):
+    """Nano pipeline with a separately scheduled Qwen3-VL vision tower."""
+
+    stages: list[StageConfig] = Field(default_factory=_vision_stages)
+
+
+class Cosmos3TextPipelineConfig(_Cosmos3PipelineConfig):
+    """Tokenizer → thinker → decode variant without loading vision weights."""
+
+    stages: list[StageConfig] = Field(default_factory=_text_stages)
+
+
+EntryClass = Cosmos3PipelineConfig
 
 Variants = {"text": Cosmos3TextPipelineConfig}
 
-__all__ = ["Cosmos3TextPipelineConfig", "EntryClass", "Variants"]
+__all__ = [
+    "Cosmos3PipelineConfig",
+    "Cosmos3TextPipelineConfig",
+    "EntryClass",
+    "Variants",
+]

--- a/sglang_omni/models/cosmos3/config.py
+++ b/sglang_omni/models/cosmos3/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Text-only Cosmos3-Nano pipeline configuration."""
+"""Cosmos3-Nano thinker pipeline configuration."""
 
 from __future__ import annotations
 
@@ -17,8 +17,76 @@ from sglang_omni.config import (
 _PKG = "sglang_omni.models.cosmos3"
 
 PREPROCESSING_STAGE = "preprocessing"
+VISION_STAGE = "vision_encoder"
 THINKER_STAGE = "thinker"
 DECODE_STAGE = "decode"
+
+
+def _thinker_stage(*, aggregate_vision: bool = False) -> StageConfig:
+    stage = EngineStageConfig(
+        name=THINKER_STAGE,
+        process="pipeline",
+        factory_path=f"{_PKG}.stages.create_sglang_text_executor_from_config",
+        factory=FactoryArgs(max_seq_len=8192, enable_async_decode=False),
+        gpu=0,
+        tp_size=1,
+        next=DECODE_STAGE,
+        stream_to=[DECODE_STAGE],
+        project_payload={
+            DECODE_STAGE: f"{_PKG}.request_builders.project_thinker_to_decode"
+        },
+    )
+    if aggregate_vision:
+        stage.wait_for = [PREPROCESSING_STAGE, VISION_STAGE]
+        stage.wait_for_fn = f"{_PKG}.request_builders.resolve_thinker_wait_sources"
+        stage.merge_fn = f"{_PKG}.merge.merge_for_thinker"
+    return stage
+
+
+def _decode_stage() -> StageConfig:
+    return StageConfig(
+        name=DECODE_STAGE,
+        process="pipeline",
+        factory_path=f"{_PKG}.stages.create_decode_executor",
+        terminal=True,
+        can_accept_stream_before_payload=True,
+    )
+
+
+def _vision_stages() -> list[StageConfig]:
+    return [
+        StageConfig(
+            name=PREPROCESSING_STAGE,
+            process="pipeline",
+            factory_path=f"{_PKG}.stages.create_preprocessing_executor",
+            factory=FactoryArgs(max_seq_len=8192, enable_vision=True),
+            next=[VISION_STAGE, THINKER_STAGE],
+            route_fn=f"{_PKG}.request_builders.resolve_preprocessing_next_stages",
+            project_payload={
+                VISION_STAGE: (
+                    f"{_PKG}.request_builders.project_preprocessing_to_vision_encoder"
+                ),
+                THINKER_STAGE: (
+                    f"{_PKG}.request_builders.project_preprocessing_to_thinker"
+                ),
+            },
+        ),
+        StageConfig(
+            name=VISION_STAGE,
+            process="pipeline",
+            factory_path=f"{_PKG}.stages.create_vision_encoder_executor",
+            factory=FactoryArgs(device="cuda"),
+            gpu=0,
+            next=THINKER_STAGE,
+            project_payload={
+                THINKER_STAGE: (
+                    f"{_PKG}.request_builders.project_vision_encoder_to_thinker"
+                )
+            },
+        ),
+        _thinker_stage(aggregate_vision=True),
+        _decode_stage(),
+    ]
 
 
 def _text_stages() -> list[StageConfig]:
@@ -27,32 +95,15 @@ def _text_stages() -> list[StageConfig]:
             name=PREPROCESSING_STAGE,
             process="pipeline",
             factory_path=f"{_PKG}.stages.create_preprocessing_executor",
-            factory=FactoryArgs(max_seq_len=8192),
+            factory=FactoryArgs(max_seq_len=8192, enable_vision=False),
             next=THINKER_STAGE,
         ),
-        EngineStageConfig(
-            name=THINKER_STAGE,
-            process="pipeline",
-            factory_path=f"{_PKG}.stages.create_sglang_text_executor_from_config",
-            factory=FactoryArgs(max_seq_len=8192, enable_async_decode=False),
-            gpu=0,
-            tp_size=1,
-            next=DECODE_STAGE,
-            stream_to=[DECODE_STAGE],
-        ),
-        StageConfig(
-            name=DECODE_STAGE,
-            process="pipeline",
-            factory_path=f"{_PKG}.stages.create_decode_executor",
-            terminal=True,
-            can_accept_stream_before_payload=True,
-        ),
+        _thinker_stage(),
+        _decode_stage(),
     ]
 
 
-class Cosmos3TextPipelineConfig(PipelineConfig):
-    """Three-stage MVP: preprocessing → text AR → detokenize."""
-
+class _Cosmos3PipelineConfig(PipelineConfig):
     architecture: ClassVar[str] = "Cosmos3ForConditionalGeneration"
     stage_config_types: ClassVar[dict[str, type[StageConfig]]] = {
         THINKER_STAGE: EngineStageConfig,
@@ -62,17 +113,37 @@ class Cosmos3TextPipelineConfig(PipelineConfig):
     def mem_fraction_role_to_stage(cls) -> dict[str, str]:
         return {THINKER_STAGE: THINKER_STAGE}
 
+    @classmethod
+    def generation_sglang_role_to_stage(cls) -> dict[str, str]:
+        return {"generation": THINKER_STAGE}
+
     model_path: str
     revision: str | None = None
-    stages: list[StageConfig] = Field(default_factory=_text_stages)
 
     def stage_factory_kwargs(self, stage_name: str) -> dict[str, Any]:
         del stage_name
         return {"revision": self.revision} if self.revision is not None else {}
 
 
-EntryClass = Cosmos3TextPipelineConfig
+class Cosmos3PipelineConfig(_Cosmos3PipelineConfig):
+    """Nano pipeline with a separately scheduled Qwen3-VL vision tower."""
+
+    stages: list[StageConfig] = Field(default_factory=_vision_stages)
+
+
+class Cosmos3TextPipelineConfig(_Cosmos3PipelineConfig):
+    """Tokenizer → thinker → decode variant without loading vision weights."""
+
+    stages: list[StageConfig] = Field(default_factory=_text_stages)
+
+
+EntryClass = Cosmos3PipelineConfig
 
 Variants = {"text": Cosmos3TextPipelineConfig}
 
-__all__ = ["Cosmos3TextPipelineConfig", "EntryClass", "Variants"]
+__all__ = [
+    "Cosmos3PipelineConfig",
+    "Cosmos3TextPipelineConfig",
+    "EntryClass",
+    "Variants",
+]

--- a/sglang_omni/models/cosmos3/merge.py
+++ b/sglang_omni/models/cosmos3/merge.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Merge standalone Cosmos3 encoder outputs at the thinker boundary."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.models.cosmos3.request_builders import VISION_STAGE
+from sglang_omni.proto import StagePayload
+
+
+def _non_empty(value: Any) -> bool:
+    return isinstance(value, torch.Tensor) and value.numel() > 0
+
+
+def build_thinker_inputs(
+    state: Cosmos3PipelineState,
+    vision_out: dict[str, Any],
+) -> dict[str, Any]:
+    model_inputs: dict[str, Any] = {}
+    for key in ("image_embeds", "video_embeds"):
+        value = vision_out.get(key)
+        if _non_empty(value):
+            model_inputs[key] = value
+
+    image_deepstack = vision_out.get("deepstack_visual_embeds_image")
+    video_deepstack = vision_out.get("deepstack_visual_embeds_video")
+    if image_deepstack and video_deepstack:
+        model_inputs["image_deepstack_visual_embeds"] = image_deepstack
+        model_inputs["video_deepstack_visual_embeds"] = video_deepstack
+    elif image_deepstack:
+        model_inputs["deepstack_visual_embeds"] = image_deepstack
+    elif video_deepstack:
+        model_inputs["deepstack_visual_embeds"] = video_deepstack
+
+    for key in ("image_grid_thw", "video_grid_thw"):
+        value = vision_out.get(key)
+        if not _non_empty(value):
+            value = state.mm_inputs.get(key)
+        if _non_empty(value):
+            model_inputs[key] = value.to(dtype=torch.long)
+
+    result: dict[str, Any] = {"model_inputs": model_inputs}
+    cache_key = (state.encoder_inputs.get(VISION_STAGE) or {}).get("cache_key")
+    if cache_key is not None:
+        result["media_cache_key"] = str(cache_key)
+    return result
+
+
+def merge_for_thinker(payloads: dict[str, StagePayload]) -> StagePayload:
+    base = payloads.get("preprocessing") or next(iter(payloads.values()))
+    state = Cosmos3PipelineState.from_dict(base.data)
+    vision_out = dict(state.encoder_outs.get(VISION_STAGE, {}))
+
+    vision_payload = payloads.get(VISION_STAGE)
+    if vision_payload is not None:
+        vision_state = Cosmos3PipelineState.from_dict(vision_payload.data)
+        value = vision_state.encoder_outs.get(VISION_STAGE)
+        if isinstance(value, dict):
+            vision_out = value
+
+    state.thinker_inputs = build_thinker_inputs(state, vision_out)
+    state.encoder_inputs = {}
+    state.encoder_outs = {}
+    base.data = state.to_dict()
+    return base
+
+
+__all__ = ["build_thinker_inputs", "merge_for_thinker"]

--- a/sglang_omni/models/cosmos3/merge.py
+++ b/sglang_omni/models/cosmos3/merge.py
@@ -44,9 +44,10 @@ def build_thinker_inputs(
             model_inputs[key] = value.to(dtype=torch.long)
 
     result: dict[str, Any] = {"model_inputs": model_inputs}
-    cache_key = (state.encoder_inputs.get(VISION_STAGE) or {}).get("cache_key")
-    if cache_key is not None:
-        result["media_cache_key"] = str(cache_key)
+    encoder_inputs = state.encoder_inputs.get(VISION_STAGE) or {}
+    for key in ("image_cache_key", "video_cache_key"):
+        if encoder_inputs.get(key) is not None:
+            result[key] = str(encoder_inputs[key])
     return result
 
 

--- a/sglang_omni/models/cosmos3/model_runner.py
+++ b/sglang_omni/models/cosmos3/model_runner.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cosmos3 thinker runner with precomputed vision embedding injection."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.model_runner.thinker_model_runner import ThinkerModelRunner
+
+
+class Cosmos3ThinkerModelRunner(ThinkerModelRunner):
+    """Use the Qwen3-VL deepstack injection path with Cosmos3's model layout."""
+
+    def __init__(self, tp_worker: Any, output_processor: Any) -> None:
+        # ThinkerModelRunner's execution logic is architecture-agnostic, but its
+        # constructor unwraps Qwen3-Omni's ``model.thinker`` hierarchy. Cosmos3
+        # exposes the language model directly, so bind the same fields here.
+        ModelRunner.__init__(self, tp_worker, output_processor)
+        self._outer_model = self.model
+        self._text_model = self.model.model
+        self._embed_tokens = self._text_model.embed_tokens
+        self._th_host_bufs = None
+        self._th_slot = 0
+        self._should_capture_hidden = None
+
+        config = tp_worker.model_runner.model_config.hf_config
+        self._image_token_id = int(config.image_token_id)
+        self._video_token_id = int(config.video_token_id)
+        self._audio_token_id = -1
+
+    def lookahead_eligible(self, batch: Any) -> bool:
+        return ModelRunner.lookahead_eligible(self, batch)
+
+
+__all__ = ["Cosmos3ThinkerModelRunner"]

--- a/sglang_omni/models/cosmos3/payload_types.py
+++ b/sglang_omni/models/cosmos3/payload_types.py
@@ -11,11 +11,12 @@ from typing_extensions import NotRequired
 
 
 class PromptInputs(TypedDict):
-    """Tokenized text prompt passed to the Cosmos3 AR stage."""
+    """Tokenized prompt passed to the Cosmos3 AR stage."""
 
     input_ids: torch.Tensor
     attention_mask: torch.Tensor
     prompt_text: str
+    mm_token_type_ids: torch.Tensor
 
 
 class TextOutput(TypedDict):
@@ -34,6 +35,10 @@ class Cosmos3PipelineState:
     """Typed, process-safe state shared by Cosmos3 pipeline stages."""
 
     prompt: PromptInputs | None = None
+    mm_inputs: dict[str, Any] = field(default_factory=dict)
+    encoder_inputs: dict[str, dict[str, Any]] = field(default_factory=dict)
+    encoder_outs: dict[str, Any] = field(default_factory=dict)
+    thinker_inputs: dict[str, Any] = field(default_factory=dict)
     text_out: TextOutput | None = None
     engine_outputs: dict[str, Any] = field(default_factory=dict)
     stream_state: dict[str, Any] = field(default_factory=dict)
@@ -46,6 +51,14 @@ class Cosmos3PipelineState:
         data: dict[str, Any] = {}
         if self.prompt is not None:
             data["prompt"] = self.prompt
+        if self.mm_inputs:
+            data["mm_inputs"] = self.mm_inputs
+        if self.encoder_inputs:
+            data["encoder_inputs"] = self.encoder_inputs
+        if self.encoder_outs:
+            data["encoder_outs"] = self.encoder_outs
+        if self.thinker_inputs:
+            data["thinker_inputs"] = self.thinker_inputs
         if self.text_out is not None:
             data["text_out"] = self.text_out
         if self.engine_outputs:

--- a/sglang_omni/models/cosmos3/request_builders.py
+++ b/sglang_omni/models/cosmos3/request_builders.py
@@ -101,8 +101,9 @@ def project_preprocessing_to_thinker(payload: StagePayload) -> StagePayload:
     metadata: dict[str, Any] = {}
     vision_inputs = state.encoder_inputs.get(VISION_STAGE)
     if isinstance(vision_inputs, dict):
-        if vision_inputs.get("cache_key") is not None:
-            metadata["cache_key"] = vision_inputs["cache_key"]
+        for key in ("image_cache_key", "video_cache_key"):
+            if vision_inputs.get(key) is not None:
+                metadata[key] = vision_inputs[key]
         if _vision_encoder_is_active(state):
             metadata["_active"] = True
     projected = Cosmos3PipelineState(
@@ -151,14 +152,18 @@ def build_vision_encoder_request(
             model_inputs={},
             skip_result=result if isinstance(result, dict) else {},
         )
-    cache_key = inputs.get("cache_key")
+    cache_parts = [
+        str(inputs[key])
+        for key in ("image_cache_key", "video_cache_key")
+        if inputs.get(key) is not None
+    ]
     return VisionEncoderRequestData(
         model_inputs={
             key: value
             for key, value in inputs.items()
-            if key not in ("cache_key", "_active")
+            if key not in ("image_cache_key", "video_cache_key", "_active")
         },
-        cache_key=str(cache_key) if cache_key is not None else None,
+        cache_key="|".join(cache_parts) or None,
     )
 
 
@@ -381,17 +386,17 @@ def build_sglang_text_request(
     input_ids = original_input_ids
     thinker_inputs = state.thinker_inputs or {}
     model_inputs = dict(thinker_inputs.get("model_inputs", {}))
-    media_cache_key = thinker_inputs.get("media_cache_key")
-    if media_cache_key is not None and thinker_config is not None:
+    if thinker_config is not None:
         token_map: dict[int, int] = {}
         pad_values: dict[str, int] = {}
         for modality, token_id in (
             ("image", thinker_config.image_token_id),
             ("video", thinker_config.video_token_id),
         ):
-            if model_inputs.get(f"{modality}_embeds") is None:
+            cache_key = thinker_inputs.get(f"{modality}_cache_key")
+            if model_inputs.get(f"{modality}_embeds") is None or cache_key is None:
                 continue
-            digest = xxhash.xxh3_64(f"{modality}:{media_cache_key}".encode())
+            digest = xxhash.xxh3_64(f"{modality}:{cache_key}".encode())
             pad_value = vocab_size + digest.intdigest() % (1 << 62)
             pad_values[modality] = pad_value
             token_map[int(token_id)] = pad_value

--- a/sglang_omni/models/cosmos3/request_builders.py
+++ b/sglang_omni/models/cosmos3/request_builders.py
@@ -3,9 +3,12 @@
 
 from __future__ import annotations
 
+import itertools
+from dataclasses import dataclass
 from typing import Any, cast
 
 import torch
+import xxhash
 from transformers import GenerationConfig, PreTrainedTokenizerBase
 
 from sglang_omni.models.cosmos3.config import DECODE_STAGE, THINKER_STAGE
@@ -19,12 +22,153 @@ from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 from sglang_omni.scheduling.types import RequestOutput
 
+THINKER_STAGE = "thinker"
+DECODE_STAGE = "decode"
+VISION_STAGE = "vision_encoder"
+
 _TRANSPORT_SAMPLING_DEFAULTS: dict[str, Any] = {
     "temperature": 1.0,
     "top_p": 1.0,
     "top_k": -1,
     "repetition_penalty": 1.0,
 }
+
+
+def _payload_with_state(
+    payload: StagePayload,
+    state: Cosmos3PipelineState,
+) -> StagePayload:
+    return StagePayload(
+        request_id=payload.request_id,
+        request=payload.request,
+        data=state.to_dict(),
+    )
+
+
+def _vision_encoder_is_active(state: Cosmos3PipelineState) -> bool:
+    inputs = state.encoder_inputs.get(VISION_STAGE)
+    if not isinstance(inputs, dict) or inputs.get("_skip"):
+        return False
+    if inputs.get("_active") is not None:
+        return inputs["_active"] is True
+    return isinstance(inputs.get("pixel_values"), torch.Tensor) or isinstance(
+        inputs.get("pixel_values_videos"), torch.Tensor
+    )
+
+
+def resolve_preprocessing_next_stages(
+    request_id: str,
+    output: StagePayload,
+) -> list[str]:
+    del request_id
+    state = Cosmos3PipelineState.from_dict(output.data)
+    stages = [THINKER_STAGE]
+    if _vision_encoder_is_active(state):
+        stages.insert(0, VISION_STAGE)
+    return stages
+
+
+def resolve_thinker_wait_sources(
+    request_id: str,
+    from_stage: str,
+    payload: StagePayload,
+) -> list[str] | None:
+    del request_id
+    if from_stage != "preprocessing":
+        return None
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    sources = ["preprocessing"]
+    if _vision_encoder_is_active(state):
+        sources.append(VISION_STAGE)
+    return sources
+
+
+def project_preprocessing_to_vision_encoder(payload: StagePayload) -> StagePayload:
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    vision_inputs = state.encoder_inputs.get(VISION_STAGE)
+    projected = Cosmos3PipelineState(
+        encoder_inputs=(
+            {VISION_STAGE: dict(vision_inputs)}
+            if isinstance(vision_inputs, dict)
+            else {}
+        )
+    )
+    return _payload_with_state(payload, projected)
+
+
+def project_preprocessing_to_thinker(payload: StagePayload) -> StagePayload:
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    metadata: dict[str, Any] = {}
+    vision_inputs = state.encoder_inputs.get(VISION_STAGE)
+    if isinstance(vision_inputs, dict):
+        if vision_inputs.get("cache_key") is not None:
+            metadata["cache_key"] = vision_inputs["cache_key"]
+        if _vision_encoder_is_active(state):
+            metadata["_active"] = True
+    projected = Cosmos3PipelineState(
+        prompt=dict(state.prompt) if isinstance(state.prompt, dict) else None,
+        mm_inputs=dict(state.mm_inputs),
+        encoder_inputs={VISION_STAGE: metadata} if metadata else {},
+        stream_state=dict(state.stream_state),
+    )
+    return _payload_with_state(payload, projected)
+
+
+def project_vision_encoder_to_thinker(payload: StagePayload) -> StagePayload:
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    output = state.encoder_outs.get(VISION_STAGE, {})
+    return _payload_with_state(
+        payload,
+        Cosmos3PipelineState(encoder_outs={VISION_STAGE: output}),
+    )
+
+
+def project_thinker_to_decode(payload: StagePayload) -> StagePayload:
+    """Drop prefill-only visual tensors before the terminal decode hop."""
+
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    state.mm_inputs = {}
+    state.thinker_inputs = {}
+    return _payload_with_state(payload, state)
+
+
+@dataclass(slots=True)
+class VisionEncoderRequestData:
+    model_inputs: dict[str, Any]
+    cache_key: str | None = None
+    skip_result: dict[str, Any] | None = None
+
+
+def build_vision_encoder_request(
+    state: Cosmos3PipelineState,
+) -> VisionEncoderRequestData:
+    inputs = state.encoder_inputs.get(VISION_STAGE)
+    if not isinstance(inputs, dict) or not inputs:
+        return VisionEncoderRequestData(model_inputs={}, skip_result={})
+    if inputs.get("_skip"):
+        result = inputs.get("_result")
+        return VisionEncoderRequestData(
+            model_inputs={},
+            skip_result=result if isinstance(result, dict) else {},
+        )
+    cache_key = inputs.get("cache_key")
+    return VisionEncoderRequestData(
+        model_inputs={
+            key: value
+            for key, value in inputs.items()
+            if key not in ("cache_key", "_active")
+        },
+        cache_key=str(cache_key) if cache_key is not None else None,
+    )
+
+
+def apply_vision_encoder_result(
+    state: Cosmos3PipelineState,
+    result: Any,
+) -> None:
+    encoder_out = result if isinstance(result, dict) else {"result": result}
+    state.encoder_outs[VISION_STAGE] = encoder_out
+    state.engine_outputs[VISION_STAGE] = encoder_out
 
 
 def _value_or_default(value: Any, fallback: Any) -> Any:
@@ -131,6 +275,92 @@ def _eos_token_ids(
     return result or None
 
 
+def _vision_position_ids(
+    start_position: int,
+    grid_thw: torch.Tensor,
+    *,
+    spatial_merge_size: int,
+) -> torch.Tensor:
+    grid_t, grid_h, grid_w = (int(value) for value in grid_thw.tolist())
+    llm_h = grid_h // spatial_merge_size
+    llm_w = grid_w // spatial_merge_size
+    temporal = torch.arange(grid_t, dtype=torch.long).repeat_interleave(llm_h * llm_w)
+    height = torch.arange(llm_h, dtype=torch.long).repeat_interleave(llm_w)
+    height = height.repeat(grid_t)
+    width = torch.arange(llm_w, dtype=torch.long).repeat(llm_h * grid_t)
+    return torch.stack((temporal, height, width), dim=0) + start_position
+
+
+def compute_cosmos3_mrope_positions(
+    input_ids: torch.Tensor,
+    mm_token_type_ids: torch.Tensor,
+    *,
+    image_grid_thw: torch.Tensor | None,
+    video_grid_thw: torch.Tensor | None,
+    spatial_merge_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute Nano's text-filled T/H/W positions for one prompt."""
+
+    input_ids = input_ids.to(dtype=torch.long, device="cpu").flatten()
+    token_types = mm_token_type_ids.to(dtype=torch.long, device="cpu").flatten()
+    if token_types.shape != input_ids.shape:
+        raise ValueError("Cosmos3 mm_token_type_ids must match input_ids")
+
+    image_grids = (
+        image_grid_thw.to(dtype=torch.long, device="cpu")
+        if isinstance(image_grid_thw, torch.Tensor)
+        else torch.empty((0, 3), dtype=torch.long)
+    )
+    if isinstance(video_grid_thw, torch.Tensor):
+        video_grids = video_grid_thw.to(dtype=torch.long, device="cpu")
+        video_grids = torch.repeat_interleave(
+            video_grids,
+            video_grids[:, 0],
+            dim=0,
+        )
+        video_grids[:, 0] = 1
+    else:
+        video_grids = torch.empty((0, 3), dtype=torch.long)
+    grid_iters = {1: iter(image_grids), 2: iter(video_grids)}
+
+    current_position = 0
+    parts: list[torch.Tensor] = []
+    grouped = itertools.groupby(enumerate(token_types.tolist()), lambda item: item[1])
+    for modality, group in grouped:
+        group_len = sum(1 for _ in group)
+        if modality == 0:
+            positions = torch.arange(group_len, dtype=torch.long)
+            parts.append(positions.unsqueeze(0).expand(3, -1) + current_position)
+            current_position += group_len
+            continue
+        if modality not in grid_iters:
+            raise ValueError(f"Unsupported Cosmos3 token type {modality}")
+        try:
+            grid = next(grid_iters[modality])
+        except StopIteration as exc:
+            raise ValueError(
+                f"Cosmos3 token type {modality} has no matching vision grid"
+            ) from exc
+        positions = _vision_position_ids(
+            current_position,
+            grid,
+            spatial_merge_size=spatial_merge_size,
+        )
+        if positions.shape[1] != group_len:
+            raise ValueError(
+                "Cosmos3 vision positions do not match placeholder tokens: "
+                f"positions={positions.shape[1]}, tokens={group_len}"
+            )
+        parts.append(positions)
+        current_position += int(grid[1:].max().item()) // spatial_merge_size
+
+    positions = (
+        torch.cat(parts, dim=1) if parts else torch.empty((3, 0), dtype=torch.long)
+    )
+    delta = positions.max() + 1 - input_ids.numel() if positions.numel() else 0
+    return positions, torch.tensor([[int(delta)]], dtype=torch.long)
+
+
 def build_sglang_text_request(
     state: Cosmos3PipelineState,
     *,
@@ -139,6 +369,7 @@ def build_sglang_text_request(
     vocab_size: int,
     generation_config: GenerationConfig | None = None,
     request_id: str | None = None,
+    thinker_config: Any = None,
 ) -> SGLangARRequestData:
     """Build one SGLang request from the canonical preprocessing state."""
 
@@ -146,7 +377,29 @@ def build_sglang_text_request(
     from sglang.srt.sampling.sampling_params import SamplingParams
 
     prompt = cast(PromptInputs, state.prompt)
-    input_ids = prompt["input_ids"]
+    original_input_ids = prompt["input_ids"]
+    input_ids = original_input_ids
+    thinker_inputs = state.thinker_inputs or {}
+    model_inputs = dict(thinker_inputs.get("model_inputs", {}))
+    media_cache_key = thinker_inputs.get("media_cache_key")
+    if media_cache_key is not None and thinker_config is not None:
+        token_map: dict[int, int] = {}
+        pad_values: dict[str, int] = {}
+        for modality, token_id in (
+            ("image", thinker_config.image_token_id),
+            ("video", thinker_config.video_token_id),
+        ):
+            if model_inputs.get(f"{modality}_embeds") is None:
+                continue
+            digest = xxhash.xxh3_64(f"{modality}:{media_cache_key}".encode())
+            pad_value = vocab_size + digest.intdigest() % (1 << 62)
+            pad_values[modality] = pad_value
+            token_map[int(token_id)] = pad_value
+        if token_map:
+            input_ids = original_input_ids.clone()
+            for token_id, pad_value in token_map.items():
+                input_ids[input_ids == token_id] = pad_value
+            model_inputs["pad_values"] = pad_values
 
     sampling_kwargs = build_cosmos3_sampling_kwargs(
         params,
@@ -166,6 +419,24 @@ def build_sglang_text_request(
     )
     req.tokenizer = tokenizer
 
+    if model_inputs and thinker_config is not None:
+        from sglang.srt.managers.schedule_batch import MultimodalInputs
+
+        mrope_positions, mrope_delta = compute_cosmos3_mrope_positions(
+            original_input_ids,
+            prompt["mm_token_type_ids"],
+            image_grid_thw=model_inputs.get("image_grid_thw"),
+            video_grid_thw=model_inputs.get("video_grid_thw"),
+            spatial_merge_size=int(thinker_config.vision_config.spatial_merge_size),
+        )
+        multimodal_inputs = MultimodalInputs(mm_items=[])
+        multimodal_inputs.mrope_positions = mrope_positions
+        multimodal_inputs.mrope_position_delta = mrope_delta
+        req.multimodal_inputs = multimodal_inputs
+
+    req.omni_model_inputs = model_inputs if model_inputs else None
+    req._omni_consumed = None
+
     return SGLangARRequestData(
         input_ids=input_ids,
         attention_mask=prompt["attention_mask"],
@@ -174,6 +445,7 @@ def build_sglang_text_request(
         top_p=float(sampling_kwargs["top_p"]),
         top_k=int(sampling_kwargs["top_k"]),
         repetition_penalty=float(sampling_kwargs["repetition_penalty"]),
+        model_inputs=model_inputs,
         output_ids=req.output_ids,
         req=req,
     )
@@ -212,6 +484,7 @@ def make_text_scheduler_adapters(
     vocab_size: int,
     generation_config: GenerationConfig | None = None,
     stage_name: str = THINKER_STAGE,
+    thinker_config: Any = None,
 ):
     """Build StagePayload-to-SGLang adapters for the text thinker."""
 
@@ -228,6 +501,7 @@ def make_text_scheduler_adapters(
             vocab_size=vocab_size,
             generation_config=generation_config,
             request_id=payload.request_id,
+            thinker_config=thinker_config,
         )
         req_data.stage_payload = payload
         req_data.return_logprob = bool(payload.request.params.get("return_logprob"))
@@ -347,9 +621,19 @@ def make_text_stream_output_builder(*, decode_stage: str = DECODE_STAGE):
 __all__ = [
     "DECODE_STAGE",
     "THINKER_STAGE",
+    "VISION_STAGE",
     "apply_text_result",
+    "apply_vision_encoder_result",
     "build_cosmos3_sampling_kwargs",
     "build_sglang_text_request",
+    "build_vision_encoder_request",
+    "compute_cosmos3_mrope_positions",
     "make_text_scheduler_adapters",
     "make_text_stream_output_builder",
+    "project_preprocessing_to_thinker",
+    "project_preprocessing_to_vision_encoder",
+    "project_thinker_to_decode",
+    "project_vision_encoder_to_thinker",
+    "resolve_preprocessing_next_stages",
+    "resolve_thinker_wait_sources",
 ]

--- a/sglang_omni/models/cosmos3/request_builders.py
+++ b/sglang_omni/models/cosmos3/request_builders.py
@@ -3,9 +3,12 @@
 
 from __future__ import annotations
 
+import itertools
+from dataclasses import dataclass
 from typing import Any, cast
 
 import torch
+import xxhash
 from transformers import GenerationConfig, PreTrainedTokenizerBase
 
 from sglang_omni.models.cosmos3.config import DECODE_STAGE, THINKER_STAGE
@@ -19,12 +22,153 @@ from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 from sglang_omni.scheduling.types import RequestOutput
 
+THINKER_STAGE = "thinker"
+DECODE_STAGE = "decode"
+VISION_STAGE = "vision_encoder"
+
 _TRANSPORT_SAMPLING_DEFAULTS: dict[str, Any] = {
     "temperature": 1.0,
     "top_p": 1.0,
     "top_k": -1,
     "repetition_penalty": 1.0,
 }
+
+
+def _payload_with_state(
+    payload: StagePayload,
+    state: Cosmos3PipelineState,
+) -> StagePayload:
+    return StagePayload(
+        request_id=payload.request_id,
+        request=payload.request,
+        data=state.to_dict(),
+    )
+
+
+def _vision_encoder_is_active(state: Cosmos3PipelineState) -> bool:
+    inputs = state.encoder_inputs.get(VISION_STAGE)
+    if not isinstance(inputs, dict) or inputs.get("_skip"):
+        return False
+    if inputs.get("_active") is not None:
+        return inputs["_active"] is True
+    return isinstance(inputs.get("pixel_values"), torch.Tensor) or isinstance(
+        inputs.get("pixel_values_videos"), torch.Tensor
+    )
+
+
+def resolve_preprocessing_next_stages(
+    request_id: str,
+    output: StagePayload,
+) -> list[str]:
+    del request_id
+    state = Cosmos3PipelineState.from_dict(output.data)
+    stages = [THINKER_STAGE]
+    if _vision_encoder_is_active(state):
+        stages.insert(0, VISION_STAGE)
+    return stages
+
+
+def resolve_thinker_wait_sources(
+    request_id: str,
+    from_stage: str,
+    payload: StagePayload,
+) -> list[str] | None:
+    del request_id
+    if from_stage != "preprocessing":
+        return None
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    sources = ["preprocessing"]
+    if _vision_encoder_is_active(state):
+        sources.append(VISION_STAGE)
+    return sources
+
+
+def project_preprocessing_to_vision_encoder(payload: StagePayload) -> StagePayload:
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    vision_inputs = state.encoder_inputs.get(VISION_STAGE)
+    projected = Cosmos3PipelineState(
+        encoder_inputs=(
+            {VISION_STAGE: dict(vision_inputs)}
+            if isinstance(vision_inputs, dict)
+            else {}
+        )
+    )
+    return _payload_with_state(payload, projected)
+
+
+def project_preprocessing_to_thinker(payload: StagePayload) -> StagePayload:
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    metadata: dict[str, Any] = {}
+    vision_inputs = state.encoder_inputs.get(VISION_STAGE)
+    if isinstance(vision_inputs, dict):
+        if vision_inputs.get("cache_key") is not None:
+            metadata["cache_key"] = vision_inputs["cache_key"]
+        if _vision_encoder_is_active(state):
+            metadata["_active"] = True
+    projected = Cosmos3PipelineState(
+        prompt=dict(state.prompt) if isinstance(state.prompt, dict) else None,
+        mm_inputs=dict(state.mm_inputs),
+        encoder_inputs={VISION_STAGE: metadata} if metadata else {},
+        stream_state=dict(state.stream_state),
+    )
+    return _payload_with_state(payload, projected)
+
+
+def project_vision_encoder_to_thinker(payload: StagePayload) -> StagePayload:
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    output = state.encoder_outs.get(VISION_STAGE, {})
+    return _payload_with_state(
+        payload,
+        Cosmos3PipelineState(encoder_outs={VISION_STAGE: output}),
+    )
+
+
+def project_thinker_to_decode(payload: StagePayload) -> StagePayload:
+    """Drop prefill-only visual tensors before the terminal decode hop."""
+
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    state.mm_inputs = {}
+    state.thinker_inputs = {}
+    return _payload_with_state(payload, state)
+
+
+@dataclass(slots=True)
+class VisionEncoderRequestData:
+    model_inputs: dict[str, Any]
+    cache_key: str | None = None
+    skip_result: dict[str, Any] | None = None
+
+
+def build_vision_encoder_request(
+    state: Cosmos3PipelineState,
+) -> VisionEncoderRequestData:
+    inputs = state.encoder_inputs.get(VISION_STAGE)
+    if not isinstance(inputs, dict) or not inputs:
+        return VisionEncoderRequestData(model_inputs={}, skip_result={})
+    if inputs.get("_skip"):
+        result = inputs.get("_result")
+        return VisionEncoderRequestData(
+            model_inputs={},
+            skip_result=result if isinstance(result, dict) else {},
+        )
+    cache_key = inputs.get("cache_key")
+    return VisionEncoderRequestData(
+        model_inputs={
+            key: value
+            for key, value in inputs.items()
+            if key not in ("cache_key", "_active")
+        },
+        cache_key=str(cache_key) if cache_key is not None else None,
+    )
+
+
+def apply_vision_encoder_result(
+    state: Cosmos3PipelineState,
+    result: Any,
+) -> None:
+    encoder_out = result if isinstance(result, dict) else {"result": result}
+    state.encoder_outs[VISION_STAGE] = encoder_out
+    state.engine_outputs[VISION_STAGE] = encoder_out
 
 
 def _value_or_default(value: Any, fallback: Any) -> Any:
@@ -131,6 +275,92 @@ def _eos_token_ids(
     return result or None
 
 
+def _vision_position_ids(
+    start_position: int,
+    grid_thw: torch.Tensor,
+    *,
+    spatial_merge_size: int,
+) -> torch.Tensor:
+    grid_t, grid_h, grid_w = (int(value) for value in grid_thw.tolist())
+    llm_h = grid_h // spatial_merge_size
+    llm_w = grid_w // spatial_merge_size
+    temporal = torch.arange(grid_t, dtype=torch.long).repeat_interleave(llm_h * llm_w)
+    height = torch.arange(llm_h, dtype=torch.long).repeat_interleave(llm_w)
+    height = height.repeat(grid_t)
+    width = torch.arange(llm_w, dtype=torch.long).repeat(llm_h * grid_t)
+    return torch.stack((temporal, height, width), dim=0) + start_position
+
+
+def compute_cosmos3_mrope_positions(
+    input_ids: torch.Tensor,
+    mm_token_type_ids: torch.Tensor,
+    *,
+    image_grid_thw: torch.Tensor | None,
+    video_grid_thw: torch.Tensor | None,
+    spatial_merge_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute Nano's text-filled T/H/W positions for one prompt."""
+
+    input_ids = input_ids.to(dtype=torch.long, device="cpu").flatten()
+    token_types = mm_token_type_ids.to(dtype=torch.long, device="cpu").flatten()
+    if token_types.shape != input_ids.shape:
+        raise ValueError("Cosmos3 mm_token_type_ids must match input_ids")
+
+    image_grids = (
+        image_grid_thw.to(dtype=torch.long, device="cpu")
+        if isinstance(image_grid_thw, torch.Tensor)
+        else torch.empty((0, 3), dtype=torch.long)
+    )
+    if isinstance(video_grid_thw, torch.Tensor):
+        video_grids = video_grid_thw.to(dtype=torch.long, device="cpu")
+        video_grids = torch.repeat_interleave(
+            video_grids,
+            video_grids[:, 0],
+            dim=0,
+        )
+        video_grids[:, 0] = 1
+    else:
+        video_grids = torch.empty((0, 3), dtype=torch.long)
+    grid_iters = {1: iter(image_grids), 2: iter(video_grids)}
+
+    current_position = 0
+    parts: list[torch.Tensor] = []
+    grouped = itertools.groupby(enumerate(token_types.tolist()), lambda item: item[1])
+    for modality, group in grouped:
+        group_len = sum(1 for _ in group)
+        if modality == 0:
+            positions = torch.arange(group_len, dtype=torch.long)
+            parts.append(positions.unsqueeze(0).expand(3, -1) + current_position)
+            current_position += group_len
+            continue
+        if modality not in grid_iters:
+            raise ValueError(f"Unsupported Cosmos3 token type {modality}")
+        try:
+            grid = next(grid_iters[modality])
+        except StopIteration as exc:
+            raise ValueError(
+                f"Cosmos3 token type {modality} has no matching vision grid"
+            ) from exc
+        positions = _vision_position_ids(
+            current_position,
+            grid,
+            spatial_merge_size=spatial_merge_size,
+        )
+        if positions.shape[1] != group_len:
+            raise ValueError(
+                "Cosmos3 vision positions do not match placeholder tokens: "
+                f"positions={positions.shape[1]}, tokens={group_len}"
+            )
+        parts.append(positions)
+        current_position += int(grid[1:].max().item()) // spatial_merge_size
+
+    positions = (
+        torch.cat(parts, dim=1) if parts else torch.empty((3, 0), dtype=torch.long)
+    )
+    delta = positions.max() + 1 - input_ids.numel() if positions.numel() else 0
+    return positions, torch.tensor([[int(delta)]], dtype=torch.long)
+
+
 def build_sglang_text_request(
     state: Cosmos3PipelineState,
     *,
@@ -139,6 +369,7 @@ def build_sglang_text_request(
     vocab_size: int,
     generation_config: GenerationConfig | None = None,
     request_id: str | None = None,
+    thinker_config: Any = None,
 ) -> SGLangARRequestData:
     """Build one SGLang request from the canonical preprocessing state."""
 
@@ -146,7 +377,29 @@ def build_sglang_text_request(
     from sglang.srt.sampling.sampling_params import SamplingParams
 
     prompt = cast(PromptInputs, state.prompt)
-    input_ids = prompt["input_ids"]
+    original_input_ids = prompt["input_ids"]
+    input_ids = original_input_ids
+    thinker_inputs = state.thinker_inputs or {}
+    model_inputs = dict(thinker_inputs.get("model_inputs", {}))
+    media_cache_key = thinker_inputs.get("media_cache_key")
+    if media_cache_key is not None and thinker_config is not None:
+        token_map: dict[int, int] = {}
+        pad_values: dict[str, int] = {}
+        for modality, token_id in (
+            ("image", thinker_config.image_token_id),
+            ("video", thinker_config.video_token_id),
+        ):
+            if model_inputs.get(f"{modality}_embeds") is None:
+                continue
+            digest = xxhash.xxh3_64(f"{modality}:{media_cache_key}".encode())
+            pad_value = vocab_size + digest.intdigest() % (1 << 62)
+            pad_values[modality] = pad_value
+            token_map[int(token_id)] = pad_value
+        if token_map:
+            input_ids = original_input_ids.clone()
+            for token_id, pad_value in token_map.items():
+                input_ids[input_ids == token_id] = pad_value
+            model_inputs["pad_values"] = pad_values
 
     sampling_kwargs = build_cosmos3_sampling_kwargs(
         params,
@@ -166,6 +419,24 @@ def build_sglang_text_request(
     )
     req.tokenizer = tokenizer
 
+    if model_inputs and thinker_config is not None:
+        from sglang.srt.managers.schedule_batch import MultimodalInputs
+
+        mrope_positions, mrope_delta = compute_cosmos3_mrope_positions(
+            original_input_ids,
+            prompt["mm_token_type_ids"],
+            image_grid_thw=model_inputs.get("image_grid_thw"),
+            video_grid_thw=model_inputs.get("video_grid_thw"),
+            spatial_merge_size=int(thinker_config.vision_config.spatial_merge_size),
+        )
+        multimodal_inputs = MultimodalInputs(mm_items=[])
+        multimodal_inputs.mrope_positions = mrope_positions
+        multimodal_inputs.mrope_position_delta = mrope_delta
+        req.multimodal_inputs = multimodal_inputs
+
+    req.omni_model_inputs = model_inputs if model_inputs else None
+    req._omni_consumed = None
+
     return SGLangARRequestData(
         input_ids=input_ids,
         attention_mask=prompt["attention_mask"],
@@ -174,6 +445,7 @@ def build_sglang_text_request(
         top_p=float(sampling_kwargs["top_p"]),
         top_k=int(sampling_kwargs["top_k"]),
         repetition_penalty=float(sampling_kwargs["repetition_penalty"]),
+        model_inputs=model_inputs,
         output_ids=req.output_ids,
         req=req,
     )
@@ -217,6 +489,7 @@ def make_text_scheduler_adapters(
     vocab_size: int,
     generation_config: GenerationConfig | None = None,
     stage_name: str = THINKER_STAGE,
+    thinker_config: Any = None,
 ):
     """Build StagePayload-to-SGLang adapters for the text thinker."""
 
@@ -233,6 +506,7 @@ def make_text_scheduler_adapters(
             vocab_size=vocab_size,
             generation_config=generation_config,
             request_id=payload.request_id,
+            thinker_config=thinker_config,
         )
         req_data.stage_payload = payload
         req_data.return_logprob = bool(payload.request.params.get("return_logprob"))
@@ -352,9 +626,19 @@ def make_text_stream_output_builder(*, decode_stage: str = DECODE_STAGE):
 __all__ = [
     "DECODE_STAGE",
     "THINKER_STAGE",
+    "VISION_STAGE",
     "apply_text_result",
+    "apply_vision_encoder_result",
     "build_cosmos3_sampling_kwargs",
     "build_sglang_text_request",
+    "build_vision_encoder_request",
+    "compute_cosmos3_mrope_positions",
     "make_text_scheduler_adapters",
     "make_text_stream_output_builder",
+    "project_preprocessing_to_thinker",
+    "project_preprocessing_to_vision_encoder",
+    "project_thinker_to_decode",
+    "project_vision_encoder_to_thinker",
+    "resolve_preprocessing_next_stages",
+    "resolve_thinker_wait_sources",
 ]

--- a/sglang_omni/models/cosmos3/stages.py
+++ b/sglang_omni/models/cosmos3/stages.py
@@ -5,16 +5,31 @@ from __future__ import annotations
 
 from typing import Any
 
+import torch
+
 from sglang_omni.models.cosmos3.bootstrap import create_thinker_scheduler
 from sglang_omni.models.cosmos3.components.text_preprocessor import (
     Cosmos3TextPreprocessor,
 )
+from sglang_omni.models.cosmos3.components.vision_encoder import Cosmos3VisionEncoder
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.models.cosmos3.request_builders import (
+    apply_vision_encoder_result,
+    build_vision_encoder_request,
+)
+from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.generation_batch_policy import (
     build_generation_batch_overrides,
     validate_generation_batch_policy,
 )
 from sglang_omni.scheduling.sglang_backend import build_sglang_server_args
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni.scheduling.stage_cache import StageOutputCache
+
+VISION_ENCODER_CACHE_MAX_BYTES = 4 * 1024**3
+VISION_ENCODER_CACHE_MAX_ENTRIES = 64
+VISION_ENCODER_BATCH_BUDGET_BYTES = 10 * 1024**3
+VISION_ENCODER_ACTIVATION_MULTIPLIER = 5
 
 
 def create_preprocessing_executor(
@@ -22,6 +37,7 @@ def create_preprocessing_executor(
     *,
     revision: str | None = None,
     thinker_max_seq_len: int | None = None,
+    enable_vision: bool = True,
 ) -> SimpleScheduler:
     """Create the CPU-only text preprocessing stage."""
 
@@ -29,8 +45,238 @@ def create_preprocessing_executor(
         model_path=model_path,
         max_seq_len=thinker_max_seq_len,
         revision=revision,
+        enable_vision=enable_vision,
     )
     return SimpleScheduler(preprocessor)
+
+
+def _store_state(
+    payload: StagePayload,
+    state: Cosmos3PipelineState,
+) -> StagePayload:
+    payload.data = state.to_dict()
+    return payload
+
+
+def _run_vision_request(
+    payload: StagePayload,
+    *,
+    model: Cosmos3VisionEncoder,
+    cache: StageOutputCache,
+) -> StagePayload:
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    request = build_vision_encoder_request(state)
+    if request.skip_result is not None:
+        result = request.skip_result
+    else:
+        result = cache.get(request.cache_key)
+        if result is None:
+            with torch.no_grad():
+                result = model(**request.model_inputs)
+            cache.put(request.cache_key, result)
+    apply_vision_encoder_result(state, result)
+    return _store_state(payload, state)
+
+
+def _split_layers(
+    layers: list[torch.Tensor] | None,
+    start: int,
+    end: int,
+) -> list[torch.Tensor] | None:
+    if layers is None:
+        return None
+    return [layer[start:end] for layer in layers]
+
+
+def _batch_vision_requests(
+    payloads: list[StagePayload],
+    *,
+    model: Cosmos3VisionEncoder,
+    cache: StageOutputCache,
+) -> list[StagePayload]:
+    results: list[StagePayload | None] = [None] * len(payloads)
+    active: list[tuple[int, StagePayload, Cosmos3PipelineState, Any]] = []
+    leaders: dict[str, int] = {}
+    waiters: dict[int, list[tuple[int, StagePayload, Cosmos3PipelineState]]] = {}
+
+    for index, payload in enumerate(payloads):
+        state = Cosmos3PipelineState.from_dict(payload.data)
+        request = build_vision_encoder_request(state)
+        if request.skip_result is not None:
+            apply_vision_encoder_result(state, request.skip_result)
+            results[index] = _store_state(payload, state)
+            continue
+        cached = cache.get(request.cache_key)
+        if cached is not None:
+            apply_vision_encoder_result(state, cached)
+            results[index] = _store_state(payload, state)
+            continue
+        if request.cache_key is not None and request.cache_key in leaders:
+            leader = leaders[request.cache_key]
+            waiters.setdefault(leader, []).append((index, payload, state))
+            continue
+        leader = len(active)
+        active.append((index, payload, state, request))
+        if request.cache_key is not None:
+            leaders[request.cache_key] = leader
+
+    if active:
+        image_pixels: list[torch.Tensor] = []
+        image_grids: list[torch.Tensor] = []
+        video_pixels: list[torch.Tensor] = []
+        video_grids: list[torch.Tensor] = []
+        metadata: list[dict[str, int]] = []
+        merge = model.spatial_merge_size**2
+
+        for _, _, _, request in active:
+            values = request.model_inputs
+            image_grid = values.get("image_grid_thw")
+            video_grid = values.get("video_grid_thw")
+            image_rows = (
+                int(image_grid.shape[0]) if isinstance(image_grid, torch.Tensor) else 0
+            )
+            video_rows = (
+                int(video_grid.shape[0]) if isinstance(video_grid, torch.Tensor) else 0
+            )
+            image_tokens = (
+                int((image_grid.prod(-1) // merge).sum().item())
+                if isinstance(image_grid, torch.Tensor)
+                else 0
+            )
+            video_tokens = (
+                int((video_grid.prod(-1) // merge).sum().item())
+                if isinstance(video_grid, torch.Tensor)
+                else 0
+            )
+            if isinstance(values.get("pixel_values"), torch.Tensor):
+                image_pixels.append(values["pixel_values"])
+                image_grids.append(image_grid)
+            if isinstance(values.get("pixel_values_videos"), torch.Tensor):
+                video_pixels.append(values["pixel_values_videos"])
+                video_grids.append(video_grid)
+            metadata.append(
+                {
+                    "image_rows": image_rows,
+                    "video_rows": video_rows,
+                    "image_tokens": image_tokens,
+                    "video_tokens": video_tokens,
+                }
+            )
+
+        batched: dict[str, torch.Tensor] = {}
+        if image_pixels:
+            batched["pixel_values"] = torch.cat(image_pixels, dim=0)
+            batched["image_grid_thw"] = torch.cat(image_grids, dim=0)
+        if video_pixels:
+            batched["pixel_values_videos"] = torch.cat(video_pixels, dim=0)
+            batched["video_grid_thw"] = torch.cat(video_grids, dim=0)
+        with torch.no_grad():
+            combined = model(**batched)
+
+        image_row = image_token = video_row = video_token = 0
+        for leader, ((index, payload, state, request), meta) in enumerate(
+            zip(active, metadata)
+        ):
+            stage_result: dict[str, Any] = {}
+            if meta["image_rows"]:
+                row_end = image_row + meta["image_rows"]
+                token_end = image_token + meta["image_tokens"]
+                stage_result.update(
+                    image_embeds=combined["image_embeds"][image_token:token_end],
+                    image_grid_thw=combined["image_grid_thw"][image_row:row_end],
+                    image_token_counts=combined["image_token_counts"][
+                        image_row:row_end
+                    ],
+                    deepstack_visual_embeds_image=_split_layers(
+                        combined.get("deepstack_visual_embeds_image"),
+                        image_token,
+                        token_end,
+                    ),
+                )
+                image_row, image_token = row_end, token_end
+            if meta["video_rows"]:
+                row_end = video_row + meta["video_rows"]
+                token_end = video_token + meta["video_tokens"]
+                stage_result.update(
+                    video_embeds=combined["video_embeds"][video_token:token_end],
+                    video_grid_thw=combined["video_grid_thw"][video_row:row_end],
+                    video_token_counts=combined["video_token_counts"][
+                        video_row:row_end
+                    ],
+                    deepstack_visual_embeds_video=_split_layers(
+                        combined.get("deepstack_visual_embeds_video"),
+                        video_token,
+                        token_end,
+                    ),
+                )
+                video_row, video_token = row_end, token_end
+
+            cache.put(request.cache_key, stage_result)
+            apply_vision_encoder_result(state, stage_result)
+            results[index] = _store_state(payload, state)
+            for waiter_index, waiter_payload, waiter_state in waiters.get(leader, []):
+                apply_vision_encoder_result(waiter_state, stage_result)
+                results[waiter_index] = _store_state(waiter_payload, waiter_state)
+
+    if any(result is None for result in results):
+        raise RuntimeError("Cosmos3 vision batch did not produce every result")
+    return [result for result in results if result is not None]
+
+
+def _vision_request_cost(model: Cosmos3VisionEncoder):
+    merge = model.spatial_merge_size**2
+    output_width = model.out_hidden_size * (1 + model.deepstack_layers)
+    dtype_bytes = model.visual_dtype_bytes
+
+    def _cost(payload: StagePayload) -> int:
+        state = Cosmos3PipelineState.from_dict(payload.data)
+        request = build_vision_encoder_request(state)
+        if request.skip_result is not None:
+            return 0
+        inputs = request.model_inputs
+        raw_bytes = sum(
+            int(value.numel() * value.element_size())
+            for key in ("pixel_values", "pixel_values_videos")
+            if isinstance((value := inputs.get(key)), torch.Tensor)
+        )
+        visual_tokens = sum(
+            int((value.prod(-1) // merge).sum().item())
+            for key in ("image_grid_thw", "video_grid_thw")
+            if isinstance((value := inputs.get(key)), torch.Tensor)
+        )
+        output_bytes = visual_tokens * output_width * dtype_bytes
+        return (raw_bytes + output_bytes) * VISION_ENCODER_ACTIVATION_MULTIPLIER
+
+    return _cost
+
+
+def create_vision_encoder_executor(
+    model_path: str,
+    *,
+    revision: str | None = None,
+    device: str = "cuda",
+    dtype: str | None = None,
+) -> SimpleScheduler:
+    model = Cosmos3VisionEncoder(
+        model_path, revision=revision, device=device, dtype=dtype
+    )
+    cache = StageOutputCache(
+        max_size=VISION_ENCODER_CACHE_MAX_ENTRIES,
+        max_bytes=VISION_ENCODER_CACHE_MAX_BYTES,
+        cache_device="cpu",
+    )
+    return SimpleScheduler(
+        lambda payload: _run_vision_request(payload, model=model, cache=cache),
+        batch_compute_fn=lambda payloads: _batch_vision_requests(
+            payloads,
+            model=model,
+            cache=cache,
+        ),
+        max_batch_size=32,
+        max_batch_wait_ms=50,
+        request_cost_fn=_vision_request_cost(model),
+        max_batch_cost=VISION_ENCODER_BATCH_BUDGET_BYTES,
+    )
 
 
 def create_sglang_text_executor_from_config(
@@ -104,4 +350,5 @@ __all__ = [
     "create_decode_executor",
     "create_preprocessing_executor",
     "create_sglang_text_executor_from_config",
+    "create_vision_encoder_executor",
 ]

--- a/sglang_omni/models/cosmos3/stages.py
+++ b/sglang_omni/models/cosmos3/stages.py
@@ -5,31 +5,16 @@ from __future__ import annotations
 
 from typing import Any
 
-import torch
-
 from sglang_omni.models.cosmos3.bootstrap import create_thinker_scheduler
 from sglang_omni.models.cosmos3.components.text_preprocessor import (
     Cosmos3TextPreprocessor,
 )
-from sglang_omni.models.cosmos3.components.vision_encoder import Cosmos3VisionEncoder
-from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
-from sglang_omni.models.cosmos3.request_builders import (
-    apply_vision_encoder_result,
-    build_vision_encoder_request,
-)
-from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.generation_batch_policy import (
     build_generation_batch_overrides,
     validate_generation_batch_policy,
 )
 from sglang_omni.scheduling.sglang_backend import build_sglang_server_args
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
-from sglang_omni.scheduling.stage_cache import StageOutputCache
-
-VISION_ENCODER_CACHE_MAX_BYTES = 4 * 1024**3
-VISION_ENCODER_CACHE_MAX_ENTRIES = 64
-VISION_ENCODER_BATCH_BUDGET_BYTES = 10 * 1024**3
-VISION_ENCODER_ACTIVATION_MULTIPLIER = 5
 
 
 def create_preprocessing_executor(
@@ -50,206 +35,6 @@ def create_preprocessing_executor(
     return SimpleScheduler(preprocessor)
 
 
-def _store_state(
-    payload: StagePayload,
-    state: Cosmos3PipelineState,
-) -> StagePayload:
-    payload.data = state.to_dict()
-    return payload
-
-
-def _run_vision_request(
-    payload: StagePayload,
-    *,
-    model: Cosmos3VisionEncoder,
-    cache: StageOutputCache,
-) -> StagePayload:
-    state = Cosmos3PipelineState.from_dict(payload.data)
-    request = build_vision_encoder_request(state)
-    if request.skip_result is not None:
-        result = request.skip_result
-    else:
-        result = cache.get(request.cache_key)
-        if result is None:
-            with torch.no_grad():
-                result = model(**request.model_inputs)
-            cache.put(request.cache_key, result)
-    apply_vision_encoder_result(state, result)
-    return _store_state(payload, state)
-
-
-def _split_layers(
-    layers: list[torch.Tensor] | None,
-    start: int,
-    end: int,
-) -> list[torch.Tensor] | None:
-    if layers is None:
-        return None
-    return [layer[start:end] for layer in layers]
-
-
-def _batch_vision_requests(
-    payloads: list[StagePayload],
-    *,
-    model: Cosmos3VisionEncoder,
-    cache: StageOutputCache,
-) -> list[StagePayload]:
-    results: list[StagePayload | None] = [None] * len(payloads)
-    active: list[tuple[int, StagePayload, Cosmos3PipelineState, Any]] = []
-    leaders: dict[str, int] = {}
-    waiters: dict[int, list[tuple[int, StagePayload, Cosmos3PipelineState]]] = {}
-
-    for index, payload in enumerate(payloads):
-        state = Cosmos3PipelineState.from_dict(payload.data)
-        request = build_vision_encoder_request(state)
-        if request.skip_result is not None:
-            apply_vision_encoder_result(state, request.skip_result)
-            results[index] = _store_state(payload, state)
-            continue
-        cached = cache.get(request.cache_key)
-        if cached is not None:
-            apply_vision_encoder_result(state, cached)
-            results[index] = _store_state(payload, state)
-            continue
-        if request.cache_key is not None and request.cache_key in leaders:
-            leader = leaders[request.cache_key]
-            waiters.setdefault(leader, []).append((index, payload, state))
-            continue
-        leader = len(active)
-        active.append((index, payload, state, request))
-        if request.cache_key is not None:
-            leaders[request.cache_key] = leader
-
-    if active:
-        image_pixels: list[torch.Tensor] = []
-        image_grids: list[torch.Tensor] = []
-        video_pixels: list[torch.Tensor] = []
-        video_grids: list[torch.Tensor] = []
-        metadata: list[dict[str, int]] = []
-        merge = model.spatial_merge_size**2
-
-        for _, _, _, request in active:
-            values = request.model_inputs
-            image_grid = values.get("image_grid_thw")
-            video_grid = values.get("video_grid_thw")
-            image_rows = (
-                int(image_grid.shape[0]) if isinstance(image_grid, torch.Tensor) else 0
-            )
-            video_rows = (
-                int(video_grid.shape[0]) if isinstance(video_grid, torch.Tensor) else 0
-            )
-            image_tokens = (
-                int((image_grid.prod(-1) // merge).sum().item())
-                if isinstance(image_grid, torch.Tensor)
-                else 0
-            )
-            video_tokens = (
-                int((video_grid.prod(-1) // merge).sum().item())
-                if isinstance(video_grid, torch.Tensor)
-                else 0
-            )
-            if isinstance(values.get("pixel_values"), torch.Tensor):
-                image_pixels.append(values["pixel_values"])
-                image_grids.append(image_grid)
-            if isinstance(values.get("pixel_values_videos"), torch.Tensor):
-                video_pixels.append(values["pixel_values_videos"])
-                video_grids.append(video_grid)
-            metadata.append(
-                {
-                    "image_rows": image_rows,
-                    "video_rows": video_rows,
-                    "image_tokens": image_tokens,
-                    "video_tokens": video_tokens,
-                }
-            )
-
-        batched: dict[str, torch.Tensor] = {}
-        if image_pixels:
-            batched["pixel_values"] = torch.cat(image_pixels, dim=0)
-            batched["image_grid_thw"] = torch.cat(image_grids, dim=0)
-        if video_pixels:
-            batched["pixel_values_videos"] = torch.cat(video_pixels, dim=0)
-            batched["video_grid_thw"] = torch.cat(video_grids, dim=0)
-        with torch.no_grad():
-            combined = model(**batched)
-
-        image_row = image_token = video_row = video_token = 0
-        for leader, ((index, payload, state, request), meta) in enumerate(
-            zip(active, metadata)
-        ):
-            stage_result: dict[str, Any] = {}
-            if meta["image_rows"]:
-                row_end = image_row + meta["image_rows"]
-                token_end = image_token + meta["image_tokens"]
-                stage_result.update(
-                    image_embeds=combined["image_embeds"][image_token:token_end],
-                    image_grid_thw=combined["image_grid_thw"][image_row:row_end],
-                    image_token_counts=combined["image_token_counts"][
-                        image_row:row_end
-                    ],
-                    deepstack_visual_embeds_image=_split_layers(
-                        combined.get("deepstack_visual_embeds_image"),
-                        image_token,
-                        token_end,
-                    ),
-                )
-                image_row, image_token = row_end, token_end
-            if meta["video_rows"]:
-                row_end = video_row + meta["video_rows"]
-                token_end = video_token + meta["video_tokens"]
-                stage_result.update(
-                    video_embeds=combined["video_embeds"][video_token:token_end],
-                    video_grid_thw=combined["video_grid_thw"][video_row:row_end],
-                    video_token_counts=combined["video_token_counts"][
-                        video_row:row_end
-                    ],
-                    deepstack_visual_embeds_video=_split_layers(
-                        combined.get("deepstack_visual_embeds_video"),
-                        video_token,
-                        token_end,
-                    ),
-                )
-                video_row, video_token = row_end, token_end
-
-            cache.put(request.cache_key, stage_result)
-            apply_vision_encoder_result(state, stage_result)
-            results[index] = _store_state(payload, state)
-            for waiter_index, waiter_payload, waiter_state in waiters.get(leader, []):
-                apply_vision_encoder_result(waiter_state, stage_result)
-                results[waiter_index] = _store_state(waiter_payload, waiter_state)
-
-    if any(result is None for result in results):
-        raise RuntimeError("Cosmos3 vision batch did not produce every result")
-    return [result for result in results if result is not None]
-
-
-def _vision_request_cost(model: Cosmos3VisionEncoder):
-    merge = model.spatial_merge_size**2
-    output_width = model.out_hidden_size * (1 + model.deepstack_layers)
-    dtype_bytes = model.visual_dtype_bytes
-
-    def _cost(payload: StagePayload) -> int:
-        state = Cosmos3PipelineState.from_dict(payload.data)
-        request = build_vision_encoder_request(state)
-        if request.skip_result is not None:
-            return 0
-        inputs = request.model_inputs
-        raw_bytes = sum(
-            int(value.numel() * value.element_size())
-            for key in ("pixel_values", "pixel_values_videos")
-            if isinstance((value := inputs.get(key)), torch.Tensor)
-        )
-        visual_tokens = sum(
-            int((value.prod(-1) // merge).sum().item())
-            for key in ("image_grid_thw", "video_grid_thw")
-            if isinstance((value := inputs.get(key)), torch.Tensor)
-        )
-        output_bytes = visual_tokens * output_width * dtype_bytes
-        return (raw_bytes + output_bytes) * VISION_ENCODER_ACTIVATION_MULTIPLIER
-
-    return _cost
-
-
 def create_vision_encoder_executor(
     model_path: str,
     *,
@@ -257,25 +42,17 @@ def create_vision_encoder_executor(
     device: str = "cuda",
     dtype: str | None = None,
 ) -> SimpleScheduler:
-    model = Cosmos3VisionEncoder(
-        model_path, revision=revision, device=device, dtype=dtype
+    """Create the separately scheduled vision encoder stage."""
+
+    from sglang_omni.models.cosmos3.vision_encoder_scheduler import (
+        create_vision_encoder_scheduler,
     )
-    cache = StageOutputCache(
-        max_size=VISION_ENCODER_CACHE_MAX_ENTRIES,
-        max_bytes=VISION_ENCODER_CACHE_MAX_BYTES,
-        cache_device="cpu",
-    )
-    return SimpleScheduler(
-        lambda payload: _run_vision_request(payload, model=model, cache=cache),
-        batch_compute_fn=lambda payloads: _batch_vision_requests(
-            payloads,
-            model=model,
-            cache=cache,
-        ),
-        max_batch_size=32,
-        max_batch_wait_ms=50,
-        request_cost_fn=_vision_request_cost(model),
-        max_batch_cost=VISION_ENCODER_BATCH_BUDGET_BYTES,
+
+    return create_vision_encoder_scheduler(
+        model_path,
+        revision=revision,
+        device=device,
+        dtype=dtype,
     )
 
 

--- a/sglang_omni/models/cosmos3/stages.py
+++ b/sglang_omni/models/cosmos3/stages.py
@@ -5,16 +5,31 @@ from __future__ import annotations
 
 from typing import Any
 
+import torch
+
 from sglang_omni.models.cosmos3.bootstrap import create_thinker_scheduler
 from sglang_omni.models.cosmos3.components.text_preprocessor import (
     Cosmos3TextPreprocessor,
 )
+from sglang_omni.models.cosmos3.components.vision_encoder import Cosmos3VisionEncoder
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.models.cosmos3.request_builders import (
+    apply_vision_encoder_result,
+    build_vision_encoder_request,
+)
+from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.generation_batch_policy import (
     build_generation_batch_overrides,
     validate_generation_batch_policy,
 )
 from sglang_omni.scheduling.sglang_backend import build_sglang_server_args
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni.scheduling.stage_cache import StageOutputCache
+
+VISION_ENCODER_CACHE_MAX_BYTES = 4 * 1024**3
+VISION_ENCODER_CACHE_MAX_ENTRIES = 64
+VISION_ENCODER_BATCH_BUDGET_BYTES = 10 * 1024**3
+VISION_ENCODER_ACTIVATION_MULTIPLIER = 5
 
 
 def create_preprocessing_executor(
@@ -22,6 +37,7 @@ def create_preprocessing_executor(
     *,
     revision: str | None = None,
     max_seq_len: int | None = None,
+    enable_vision: bool = True,
 ) -> SimpleScheduler:
     """Create the CPU-only text preprocessing stage."""
 
@@ -29,8 +45,238 @@ def create_preprocessing_executor(
         model_path=model_path,
         max_seq_len=max_seq_len,
         revision=revision,
+        enable_vision=enable_vision,
     )
     return SimpleScheduler(preprocessor)
+
+
+def _store_state(
+    payload: StagePayload,
+    state: Cosmos3PipelineState,
+) -> StagePayload:
+    payload.data = state.to_dict()
+    return payload
+
+
+def _run_vision_request(
+    payload: StagePayload,
+    *,
+    model: Cosmos3VisionEncoder,
+    cache: StageOutputCache,
+) -> StagePayload:
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    request = build_vision_encoder_request(state)
+    if request.skip_result is not None:
+        result = request.skip_result
+    else:
+        result = cache.get(request.cache_key)
+        if result is None:
+            with torch.no_grad():
+                result = model(**request.model_inputs)
+            cache.put(request.cache_key, result)
+    apply_vision_encoder_result(state, result)
+    return _store_state(payload, state)
+
+
+def _split_layers(
+    layers: list[torch.Tensor] | None,
+    start: int,
+    end: int,
+) -> list[torch.Tensor] | None:
+    if layers is None:
+        return None
+    return [layer[start:end] for layer in layers]
+
+
+def _batch_vision_requests(
+    payloads: list[StagePayload],
+    *,
+    model: Cosmos3VisionEncoder,
+    cache: StageOutputCache,
+) -> list[StagePayload]:
+    results: list[StagePayload | None] = [None] * len(payloads)
+    active: list[tuple[int, StagePayload, Cosmos3PipelineState, Any]] = []
+    leaders: dict[str, int] = {}
+    waiters: dict[int, list[tuple[int, StagePayload, Cosmos3PipelineState]]] = {}
+
+    for index, payload in enumerate(payloads):
+        state = Cosmos3PipelineState.from_dict(payload.data)
+        request = build_vision_encoder_request(state)
+        if request.skip_result is not None:
+            apply_vision_encoder_result(state, request.skip_result)
+            results[index] = _store_state(payload, state)
+            continue
+        cached = cache.get(request.cache_key)
+        if cached is not None:
+            apply_vision_encoder_result(state, cached)
+            results[index] = _store_state(payload, state)
+            continue
+        if request.cache_key is not None and request.cache_key in leaders:
+            leader = leaders[request.cache_key]
+            waiters.setdefault(leader, []).append((index, payload, state))
+            continue
+        leader = len(active)
+        active.append((index, payload, state, request))
+        if request.cache_key is not None:
+            leaders[request.cache_key] = leader
+
+    if active:
+        image_pixels: list[torch.Tensor] = []
+        image_grids: list[torch.Tensor] = []
+        video_pixels: list[torch.Tensor] = []
+        video_grids: list[torch.Tensor] = []
+        metadata: list[dict[str, int]] = []
+        merge = model.spatial_merge_size**2
+
+        for _, _, _, request in active:
+            values = request.model_inputs
+            image_grid = values.get("image_grid_thw")
+            video_grid = values.get("video_grid_thw")
+            image_rows = (
+                int(image_grid.shape[0]) if isinstance(image_grid, torch.Tensor) else 0
+            )
+            video_rows = (
+                int(video_grid.shape[0]) if isinstance(video_grid, torch.Tensor) else 0
+            )
+            image_tokens = (
+                int((image_grid.prod(-1) // merge).sum().item())
+                if isinstance(image_grid, torch.Tensor)
+                else 0
+            )
+            video_tokens = (
+                int((video_grid.prod(-1) // merge).sum().item())
+                if isinstance(video_grid, torch.Tensor)
+                else 0
+            )
+            if isinstance(values.get("pixel_values"), torch.Tensor):
+                image_pixels.append(values["pixel_values"])
+                image_grids.append(image_grid)
+            if isinstance(values.get("pixel_values_videos"), torch.Tensor):
+                video_pixels.append(values["pixel_values_videos"])
+                video_grids.append(video_grid)
+            metadata.append(
+                {
+                    "image_rows": image_rows,
+                    "video_rows": video_rows,
+                    "image_tokens": image_tokens,
+                    "video_tokens": video_tokens,
+                }
+            )
+
+        batched: dict[str, torch.Tensor] = {}
+        if image_pixels:
+            batched["pixel_values"] = torch.cat(image_pixels, dim=0)
+            batched["image_grid_thw"] = torch.cat(image_grids, dim=0)
+        if video_pixels:
+            batched["pixel_values_videos"] = torch.cat(video_pixels, dim=0)
+            batched["video_grid_thw"] = torch.cat(video_grids, dim=0)
+        with torch.no_grad():
+            combined = model(**batched)
+
+        image_row = image_token = video_row = video_token = 0
+        for leader, ((index, payload, state, request), meta) in enumerate(
+            zip(active, metadata)
+        ):
+            stage_result: dict[str, Any] = {}
+            if meta["image_rows"]:
+                row_end = image_row + meta["image_rows"]
+                token_end = image_token + meta["image_tokens"]
+                stage_result.update(
+                    image_embeds=combined["image_embeds"][image_token:token_end],
+                    image_grid_thw=combined["image_grid_thw"][image_row:row_end],
+                    image_token_counts=combined["image_token_counts"][
+                        image_row:row_end
+                    ],
+                    deepstack_visual_embeds_image=_split_layers(
+                        combined.get("deepstack_visual_embeds_image"),
+                        image_token,
+                        token_end,
+                    ),
+                )
+                image_row, image_token = row_end, token_end
+            if meta["video_rows"]:
+                row_end = video_row + meta["video_rows"]
+                token_end = video_token + meta["video_tokens"]
+                stage_result.update(
+                    video_embeds=combined["video_embeds"][video_token:token_end],
+                    video_grid_thw=combined["video_grid_thw"][video_row:row_end],
+                    video_token_counts=combined["video_token_counts"][
+                        video_row:row_end
+                    ],
+                    deepstack_visual_embeds_video=_split_layers(
+                        combined.get("deepstack_visual_embeds_video"),
+                        video_token,
+                        token_end,
+                    ),
+                )
+                video_row, video_token = row_end, token_end
+
+            cache.put(request.cache_key, stage_result)
+            apply_vision_encoder_result(state, stage_result)
+            results[index] = _store_state(payload, state)
+            for waiter_index, waiter_payload, waiter_state in waiters.get(leader, []):
+                apply_vision_encoder_result(waiter_state, stage_result)
+                results[waiter_index] = _store_state(waiter_payload, waiter_state)
+
+    if any(result is None for result in results):
+        raise RuntimeError("Cosmos3 vision batch did not produce every result")
+    return [result for result in results if result is not None]
+
+
+def _vision_request_cost(model: Cosmos3VisionEncoder):
+    merge = model.spatial_merge_size**2
+    output_width = model.out_hidden_size * (1 + model.deepstack_layers)
+    dtype_bytes = model.visual_dtype_bytes
+
+    def _cost(payload: StagePayload) -> int:
+        state = Cosmos3PipelineState.from_dict(payload.data)
+        request = build_vision_encoder_request(state)
+        if request.skip_result is not None:
+            return 0
+        inputs = request.model_inputs
+        raw_bytes = sum(
+            int(value.numel() * value.element_size())
+            for key in ("pixel_values", "pixel_values_videos")
+            if isinstance((value := inputs.get(key)), torch.Tensor)
+        )
+        visual_tokens = sum(
+            int((value.prod(-1) // merge).sum().item())
+            for key in ("image_grid_thw", "video_grid_thw")
+            if isinstance((value := inputs.get(key)), torch.Tensor)
+        )
+        output_bytes = visual_tokens * output_width * dtype_bytes
+        return (raw_bytes + output_bytes) * VISION_ENCODER_ACTIVATION_MULTIPLIER
+
+    return _cost
+
+
+def create_vision_encoder_executor(
+    model_path: str,
+    *,
+    revision: str | None = None,
+    device: str = "cuda",
+    dtype: str | None = None,
+) -> SimpleScheduler:
+    model = Cosmos3VisionEncoder(
+        model_path, revision=revision, device=device, dtype=dtype
+    )
+    cache = StageOutputCache(
+        max_size=VISION_ENCODER_CACHE_MAX_ENTRIES,
+        max_bytes=VISION_ENCODER_CACHE_MAX_BYTES,
+        cache_device="cpu",
+    )
+    return SimpleScheduler(
+        lambda payload: _run_vision_request(payload, model=model, cache=cache),
+        batch_compute_fn=lambda payloads: _batch_vision_requests(
+            payloads,
+            model=model,
+            cache=cache,
+        ),
+        max_batch_size=32,
+        max_batch_wait_ms=50,
+        request_cost_fn=_vision_request_cost(model),
+        max_batch_cost=VISION_ENCODER_BATCH_BUDGET_BYTES,
+    )
 
 
 def create_sglang_text_executor_from_config(
@@ -104,4 +350,5 @@ __all__ = [
     "create_decode_executor",
     "create_preprocessing_executor",
     "create_sglang_text_executor_from_config",
+    "create_vision_encoder_executor",
 ]

--- a/sglang_omni/models/cosmos3/vision_encoder_scheduler.py
+++ b/sglang_omni/models/cosmos3/vision_encoder_scheduler.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Vision encoder scheduling, batching, and caching for Cosmos3."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from sglang_omni.models.cosmos3.components.vision_encoder import Cosmos3VisionEncoder
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.models.cosmos3.request_builders import (
+    apply_vision_encoder_result,
+    build_vision_encoder_request,
+)
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni.scheduling.stage_cache import StageOutputCache
+
+VISION_ENCODER_CACHE_MAX_BYTES = 4 * 1024**3
+VISION_ENCODER_CACHE_MAX_ENTRIES = 64
+VISION_ENCODER_BATCH_BUDGET_BYTES = 10 * 1024**3
+VISION_ENCODER_ACTIVATION_MULTIPLIER = 5
+
+
+def _store_state(
+    payload: StagePayload,
+    state: Cosmos3PipelineState,
+) -> StagePayload:
+    payload.data = state.to_dict()
+    return payload
+
+
+def _run_vision_request(
+    payload: StagePayload,
+    *,
+    model: Cosmos3VisionEncoder,
+    cache: StageOutputCache,
+) -> StagePayload:
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    request = build_vision_encoder_request(state)
+    if request.skip_result is not None:
+        result = request.skip_result
+    else:
+        result = cache.get(request.cache_key)
+        if result is None:
+            with torch.no_grad():
+                result = model(**request.model_inputs)
+            cache.put(request.cache_key, result)
+    apply_vision_encoder_result(state, result)
+    return _store_state(payload, state)
+
+
+def _split_layers(
+    layers: list[torch.Tensor] | None,
+    start: int,
+    end: int,
+) -> list[torch.Tensor] | None:
+    if layers is None:
+        return None
+    return [layer[start:end] for layer in layers]
+
+
+def _batch_vision_requests(
+    payloads: list[StagePayload],
+    *,
+    model: Cosmos3VisionEncoder,
+    cache: StageOutputCache,
+) -> list[StagePayload]:
+    results: list[StagePayload | None] = [None] * len(payloads)
+    active: list[tuple[int, StagePayload, Cosmos3PipelineState, Any]] = []
+    leaders: dict[str, int] = {}
+    waiters: dict[int, list[tuple[int, StagePayload, Cosmos3PipelineState]]] = {}
+
+    for index, payload in enumerate(payloads):
+        state = Cosmos3PipelineState.from_dict(payload.data)
+        request = build_vision_encoder_request(state)
+        if request.skip_result is not None:
+            apply_vision_encoder_result(state, request.skip_result)
+            results[index] = _store_state(payload, state)
+            continue
+        cached = cache.get(request.cache_key)
+        if cached is not None:
+            apply_vision_encoder_result(state, cached)
+            results[index] = _store_state(payload, state)
+            continue
+        if request.cache_key is not None and request.cache_key in leaders:
+            leader = leaders[request.cache_key]
+            waiters.setdefault(leader, []).append((index, payload, state))
+            continue
+        leader = len(active)
+        active.append((index, payload, state, request))
+        if request.cache_key is not None:
+            leaders[request.cache_key] = leader
+
+    if active:
+        image_pixels: list[torch.Tensor] = []
+        image_grids: list[torch.Tensor] = []
+        video_pixels: list[torch.Tensor] = []
+        video_grids: list[torch.Tensor] = []
+        metadata: list[dict[str, int]] = []
+        merge = model.spatial_merge_size**2
+
+        for _, _, _, request in active:
+            values = request.model_inputs
+            image_grid = values.get("image_grid_thw")
+            video_grid = values.get("video_grid_thw")
+            image_rows = (
+                int(image_grid.shape[0]) if isinstance(image_grid, torch.Tensor) else 0
+            )
+            video_rows = (
+                int(video_grid.shape[0]) if isinstance(video_grid, torch.Tensor) else 0
+            )
+            image_tokens = (
+                int((image_grid.prod(-1) // merge).sum().item())
+                if isinstance(image_grid, torch.Tensor)
+                else 0
+            )
+            video_tokens = (
+                int((video_grid.prod(-1) // merge).sum().item())
+                if isinstance(video_grid, torch.Tensor)
+                else 0
+            )
+            if isinstance(values.get("pixel_values"), torch.Tensor):
+                image_pixels.append(values["pixel_values"])
+                image_grids.append(image_grid)
+            if isinstance(values.get("pixel_values_videos"), torch.Tensor):
+                video_pixels.append(values["pixel_values_videos"])
+                video_grids.append(video_grid)
+            metadata.append(
+                {
+                    "image_rows": image_rows,
+                    "video_rows": video_rows,
+                    "image_tokens": image_tokens,
+                    "video_tokens": video_tokens,
+                }
+            )
+
+        batched: dict[str, torch.Tensor] = {}
+        if image_pixels:
+            batched["pixel_values"] = torch.cat(image_pixels, dim=0)
+            batched["image_grid_thw"] = torch.cat(image_grids, dim=0)
+        if video_pixels:
+            batched["pixel_values_videos"] = torch.cat(video_pixels, dim=0)
+            batched["video_grid_thw"] = torch.cat(video_grids, dim=0)
+        with torch.no_grad():
+            combined = model(**batched)
+
+        image_row = image_token = video_row = video_token = 0
+        for leader, ((index, payload, state, request), meta) in enumerate(
+            zip(active, metadata)
+        ):
+            stage_result: dict[str, Any] = {}
+            if meta["image_rows"]:
+                row_end = image_row + meta["image_rows"]
+                token_end = image_token + meta["image_tokens"]
+                stage_result.update(
+                    image_embeds=combined["image_embeds"][image_token:token_end],
+                    image_grid_thw=combined["image_grid_thw"][image_row:row_end],
+                    image_token_counts=combined["image_token_counts"][
+                        image_row:row_end
+                    ],
+                    deepstack_visual_embeds_image=_split_layers(
+                        combined.get("deepstack_visual_embeds_image"),
+                        image_token,
+                        token_end,
+                    ),
+                )
+                image_row, image_token = row_end, token_end
+            if meta["video_rows"]:
+                row_end = video_row + meta["video_rows"]
+                token_end = video_token + meta["video_tokens"]
+                stage_result.update(
+                    video_embeds=combined["video_embeds"][video_token:token_end],
+                    video_grid_thw=combined["video_grid_thw"][video_row:row_end],
+                    video_token_counts=combined["video_token_counts"][
+                        video_row:row_end
+                    ],
+                    deepstack_visual_embeds_video=_split_layers(
+                        combined.get("deepstack_visual_embeds_video"),
+                        video_token,
+                        token_end,
+                    ),
+                )
+                video_row, video_token = row_end, token_end
+
+            cache.put(request.cache_key, stage_result)
+            apply_vision_encoder_result(state, stage_result)
+            results[index] = _store_state(payload, state)
+            for waiter_index, waiter_payload, waiter_state in waiters.get(leader, []):
+                apply_vision_encoder_result(waiter_state, stage_result)
+                results[waiter_index] = _store_state(waiter_payload, waiter_state)
+
+    if any(result is None for result in results):
+        raise RuntimeError("Cosmos3 vision batch did not produce every result")
+    return [result for result in results if result is not None]
+
+
+def _vision_request_cost(model: Cosmos3VisionEncoder):
+    merge = model.spatial_merge_size**2
+    output_width = model.out_hidden_size * (1 + model.deepstack_layers)
+    dtype_bytes = model.visual_dtype_bytes
+
+    def _cost(payload: StagePayload) -> int:
+        state = Cosmos3PipelineState.from_dict(payload.data)
+        request = build_vision_encoder_request(state)
+        if request.skip_result is not None:
+            return 0
+        inputs = request.model_inputs
+        raw_bytes = sum(
+            int(value.numel() * value.element_size())
+            for key in ("pixel_values", "pixel_values_videos")
+            if isinstance((value := inputs.get(key)), torch.Tensor)
+        )
+        visual_tokens = sum(
+            int((value.prod(-1) // merge).sum().item())
+            for key in ("image_grid_thw", "video_grid_thw")
+            if isinstance((value := inputs.get(key)), torch.Tensor)
+        )
+        output_bytes = visual_tokens * output_width * dtype_bytes
+        return (raw_bytes + output_bytes) * VISION_ENCODER_ACTIVATION_MULTIPLIER
+
+    return _cost
+
+
+def create_vision_encoder_scheduler(
+    model_path: str,
+    *,
+    revision: str | None = None,
+    device: str = "cuda",
+    dtype: str | None = None,
+) -> SimpleScheduler:
+    """Create the cached, dynamically batched vision encoder scheduler."""
+
+    model = Cosmos3VisionEncoder(
+        model_path, revision=revision, device=device, dtype=dtype
+    )
+    cache = StageOutputCache(
+        max_size=VISION_ENCODER_CACHE_MAX_ENTRIES,
+        max_bytes=VISION_ENCODER_CACHE_MAX_BYTES,
+        cache_device="cpu",
+    )
+    return SimpleScheduler(
+        lambda payload: _run_vision_request(payload, model=model, cache=cache),
+        batch_compute_fn=lambda payloads: _batch_vision_requests(
+            payloads,
+            model=model,
+            cache=cache,
+        ),
+        max_batch_size=32,
+        max_batch_wait_ms=50,
+        request_cost_fn=_vision_request_cost(model),
+        max_batch_cost=VISION_ENCODER_BATCH_BUDGET_BYTES,
+    )
+
+
+__all__ = ["create_vision_encoder_scheduler"]

--- a/tests/unit_test/cosmos3/test_bootstrap.py
+++ b/tests/unit_test/cosmos3/test_bootstrap.py
@@ -6,8 +6,8 @@ from types import SimpleNamespace
 
 from sglang.srt.utils import hf_transformers_utils
 
-from sglang_omni.model_runner import base as model_runner_base
 from sglang_omni.models.cosmos3 import bootstrap, request_builders
+from sglang_omni.models.cosmos3 import model_runner as cosmos_model_runner
 from sglang_omni.models.cosmos3.bootstrap import resolve_transformer_weights_path
 from sglang_omni.scheduling import bootstrap as scheduling_bootstrap
 from sglang_omni.scheduling import omni_scheduler, sglang_backend
@@ -62,6 +62,7 @@ def test_thinker_loads_tokenizer_from_checkpoint_root(monkeypatch, tmp_path) -> 
         model_path=str(transformer_path),
         vocab_size=10,
         hf_generation_config=SimpleNamespace(),
+        hf_config=SimpleNamespace(),
     )
     tokenizer_calls: list[tuple[str, str | None]] = []
 
@@ -85,7 +86,11 @@ def test_thinker_loads_tokenizer_from_checkpoint_root(monkeypatch, tmp_path) -> 
             tokenizer_calls.append((path, kwargs.get("tokenizer_revision"))) or object()
         ),
     )
-    monkeypatch.setattr(model_runner_base, "ModelRunner", lambda *args: object())
+    monkeypatch.setattr(
+        cosmos_model_runner,
+        "Cosmos3ThinkerModelRunner",
+        lambda *args: object(),
+    )
     monkeypatch.setattr(
         request_builders,
         "make_text_scheduler_adapters",

--- a/tests/unit_test/cosmos3/test_bootstrap.py
+++ b/tests/unit_test/cosmos3/test_bootstrap.py
@@ -7,8 +7,9 @@ from types import SimpleNamespace
 
 from sglang.srt.utils import hf_transformers_utils
 
-from sglang_omni.models.cosmos3 import bootstrap, request_builders
+from sglang_omni.models.cosmos3 import bootstrap
 from sglang_omni.models.cosmos3 import model_runner as cosmos_model_runner
+from sglang_omni.models.cosmos3 import request_builders
 from sglang_omni.models.cosmos3.bootstrap import resolve_transformer_weights_path
 from sglang_omni.scheduling import bootstrap as scheduling_bootstrap
 from sglang_omni.scheduling import omni_scheduler, sglang_backend

--- a/tests/unit_test/cosmos3/test_bootstrap.py
+++ b/tests/unit_test/cosmos3/test_bootstrap.py
@@ -7,8 +7,8 @@ from types import SimpleNamespace
 
 from sglang.srt.utils import hf_transformers_utils
 
-from sglang_omni.model_runner import base as model_runner_base
 from sglang_omni.models.cosmos3 import bootstrap, request_builders
+from sglang_omni.models.cosmos3 import model_runner as cosmos_model_runner
 from sglang_omni.models.cosmos3.bootstrap import resolve_transformer_weights_path
 from sglang_omni.scheduling import bootstrap as scheduling_bootstrap
 from sglang_omni.scheduling import omni_scheduler, sglang_backend
@@ -63,6 +63,7 @@ def test_thinker_loads_tokenizer_from_checkpoint_root(monkeypatch, tmp_path) -> 
         model_path=str(transformer_path),
         vocab_size=10,
         hf_generation_config=SimpleNamespace(),
+        hf_config=SimpleNamespace(),
     )
     tokenizer_calls: list[tuple[str, str | None]] = []
     scheduler_signature = inspect.signature(omni_scheduler.OmniScheduler)
@@ -86,7 +87,11 @@ def test_thinker_loads_tokenizer_from_checkpoint_root(monkeypatch, tmp_path) -> 
             tokenizer_calls.append((path, kwargs.get("tokenizer_revision"))) or object()
         ),
     )
-    monkeypatch.setattr(model_runner_base, "ModelRunner", lambda *args: object())
+    monkeypatch.setattr(
+        cosmos_model_runner,
+        "Cosmos3ThinkerModelRunner",
+        lambda *args: object(),
+    )
     monkeypatch.setattr(
         request_builders,
         "make_text_scheduler_adapters",

--- a/tests/unit_test/cosmos3/test_config.py
+++ b/tests/unit_test/cosmos3/test_config.py
@@ -2,11 +2,42 @@
 
 from __future__ import annotations
 
-from sglang_omni.models.cosmos3.config import Cosmos3TextPipelineConfig
+from sglang_omni.models.cosmos3.config import (
+    Cosmos3PipelineConfig,
+    Cosmos3TextPipelineConfig,
+)
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 
 
-def test_text_pipeline_has_preprocess_ar_decode_topology() -> None:
+def test_pipeline_has_separate_vision_encoder_topology() -> None:
+    config = Cosmos3PipelineConfig(model_path="nvidia/Cosmos3-Nano")
+
+    assert [stage.name for stage in config.stages] == [
+        "preprocessing",
+        "vision_encoder",
+        "thinker",
+        "decode",
+    ]
+    assert config.stages[0].next == ["vision_encoder", "thinker"]
+    assert config.stages[1].next == "thinker"
+    assert config.stages[2].wait_for == ["preprocessing", "vision_encoder"]
+    assert config.stages[2].wait_for_fn.endswith(".resolve_thinker_wait_sources")
+    assert config.stages[2].merge_fn.endswith(".merge_for_thinker")
+    assert config.stages[2].tp_size == 1
+    assert config.stages[2].next == "decode"
+    assert config.stages[2].stream_to == ["decode"]
+    assert config.stages[3].terminal is True
+    assert config.stages[3].can_accept_stream_before_payload is True
+
+
+def test_cosmos_architecture_is_discoverable() -> None:
+    assert (
+        PIPELINE_CONFIG_REGISTRY.get_config("Cosmos3ForConditionalGeneration")
+        is Cosmos3PipelineConfig
+    )
+
+
+def test_text_variant_does_not_load_vision_stage() -> None:
     config = Cosmos3TextPipelineConfig(model_path="nvidia/Cosmos3-Nano")
 
     assert [stage.name for stage in config.stages] == [
@@ -18,24 +49,22 @@ def test_text_pipeline_has_preprocess_ar_decode_topology() -> None:
     assert config.stages[1].tp_size == 1
     assert config.stages[1].next == "decode"
     assert config.stages[1].stream_to == ["decode"]
+    assert config.stages[1].wait_for is None
+    assert config.stages[1].merge_fn is None
     assert config.stages[2].terminal is True
     assert config.stages[2].can_accept_stream_before_payload is True
-
-
-def test_cosmos_architecture_is_discoverable() -> None:
-    assert (
-        PIPELINE_CONFIG_REGISTRY.get_config("Cosmos3ForConditionalGeneration")
-        is Cosmos3TextPipelineConfig
-    )
+    assert config.generation_sglang_role_to_stage() == {"generation": "thinker"}
 
 
 def test_model_revision_is_shared_by_every_stage() -> None:
-    config = Cosmos3TextPipelineConfig(
-        model_path="nvidia/Cosmos3-Nano",
-        revision="cosmos-revision",
-    )
+    for config_cls in (Cosmos3PipelineConfig, Cosmos3TextPipelineConfig):
+        config = config_cls(
+            model_path="nvidia/Cosmos3-Nano",
+            revision="cosmos-revision",
+        )
 
-    assert config.revision == "cosmos-revision"
-    assert all(
-        stage.factory_args["revision"] == "cosmos-revision" for stage in config.stages
-    )
+        assert config.revision == "cosmos-revision"
+        assert all(
+            stage.factory_args["revision"] == "cosmos-revision"
+            for stage in config.stages
+        )

--- a/tests/unit_test/cosmos3/test_config.py
+++ b/tests/unit_test/cosmos3/test_config.py
@@ -2,11 +2,42 @@
 
 from __future__ import annotations
 
-from sglang_omni.models.cosmos3.config import Cosmos3TextPipelineConfig
+from sglang_omni.models.cosmos3.config import (
+    Cosmos3PipelineConfig,
+    Cosmos3TextPipelineConfig,
+)
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 
 
-def test_text_pipeline_has_preprocess_ar_decode_topology() -> None:
+def test_pipeline_has_separate_vision_encoder_topology() -> None:
+    config = Cosmos3PipelineConfig(model_path="nvidia/Cosmos3-Nano")
+
+    assert [stage.name for stage in config.stages] == [
+        "preprocessing",
+        "vision_encoder",
+        "thinker",
+        "decode",
+    ]
+    assert config.stages[0].next == ["vision_encoder", "thinker"]
+    assert config.stages[1].next == "thinker"
+    assert config.stages[2].wait_for == ["preprocessing", "vision_encoder"]
+    assert config.stages[2].wait_for_fn.endswith(".resolve_thinker_wait_sources")
+    assert config.stages[2].merge_fn.endswith(".merge_for_thinker")
+    assert config.stages[2].tp_size == 1
+    assert config.stages[2].next == "decode"
+    assert config.stages[2].stream_to == ["decode"]
+    assert config.stages[3].terminal is True
+    assert config.stages[3].can_accept_stream_before_payload is True
+
+
+def test_cosmos_architecture_is_discoverable() -> None:
+    assert (
+        PIPELINE_CONFIG_REGISTRY.get_config("Cosmos3ForConditionalGeneration")
+        is Cosmos3PipelineConfig
+    )
+
+
+def test_text_variant_does_not_load_vision_stage() -> None:
     config = Cosmos3TextPipelineConfig(model_path="nvidia/Cosmos3-Nano")
 
     assert [stage.name for stage in config.stages] == [
@@ -21,25 +52,23 @@ def test_text_pipeline_has_preprocess_ar_decode_topology() -> None:
     assert config.stages[1].engine is not None
     assert config.stages[1].next == "decode"
     assert config.stages[1].stream_to == ["decode"]
+    assert config.stages[1].wait_for is None
+    assert config.stages[1].merge_fn is None
     assert config.stages[2].terminal is True
     assert config.stages[2].can_accept_stream_before_payload is True
-
-
-def test_cosmos_architecture_is_discoverable() -> None:
-    assert (
-        PIPELINE_CONFIG_REGISTRY.get_config("Cosmos3ForConditionalGeneration")
-        is Cosmos3TextPipelineConfig
-    )
+    assert config.generation_sglang_role_to_stage() == {"generation": "thinker"}
 
 
 def test_model_revision_is_shared_by_every_stage() -> None:
-    config = Cosmos3TextPipelineConfig(
-        model_path="nvidia/Cosmos3-Nano",
-        revision="cosmos-revision",
-    )
+    for config_cls in (Cosmos3PipelineConfig, Cosmos3TextPipelineConfig):
+        config = config_cls(
+            model_path="nvidia/Cosmos3-Nano",
+            revision="cosmos-revision",
+        )
 
-    assert config.revision == "cosmos-revision"
-    assert all(
-        config.stage_factory_kwargs(stage.name)["revision"] == "cosmos-revision"
-        for stage in config.stages
-    )
+        assert config.revision == "cosmos-revision"
+        assert all(
+            config.stage_factory_kwargs(stage.name)["revision"]
+            == "cosmos-revision"
+            for stage in config.stages
+        )

--- a/tests/unit_test/cosmos3/test_config.py
+++ b/tests/unit_test/cosmos3/test_config.py
@@ -68,7 +68,6 @@ def test_model_revision_is_shared_by_every_stage() -> None:
 
         assert config.revision == "cosmos-revision"
         assert all(
-            config.stage_factory_kwargs(stage.name)["revision"]
-            == "cosmos-revision"
+            config.stage_factory_kwargs(stage.name)["revision"] == "cosmos-revision"
             for stage in config.stages
         )

--- a/tests/unit_test/cosmos3/test_merge.py
+++ b/tests/unit_test/cosmos3/test_merge.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+
+from sglang_omni.models.cosmos3.merge import merge_for_thinker
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+def _payload(stage: str, state: Cosmos3PipelineState) -> StagePayload:
+    return StagePayload(
+        request_id="merge",
+        request=OmniRequest(inputs=None),
+        data=state.to_dict(),
+    )
+
+
+def test_merge_builds_thinker_inputs_without_duplicate_encoder_payload() -> None:
+    prompt = {
+        "input_ids": torch.tensor([10, 151655, 11]),
+        "attention_mask": torch.ones(3, dtype=torch.long),
+        "prompt_text": "prompt",
+        "mm_token_type_ids": torch.tensor([0, 1, 0]),
+    }
+    preprocessing = Cosmos3PipelineState(
+        prompt=prompt,
+        mm_inputs={"image_grid_thw": torch.tensor([[1, 2, 2]])},
+        encoder_inputs={"vision_encoder": {"cache_key": "key", "_active": True}},
+    )
+    embeddings = torch.ones((1, 4))
+    deepstack = [torch.full((1, 4), index) for index in range(3)]
+    vision = Cosmos3PipelineState(
+        encoder_outs={
+            "vision_encoder": {
+                "image_embeds": embeddings,
+                "image_grid_thw": torch.tensor([[1, 2, 2]]),
+                "deepstack_visual_embeds_image": deepstack,
+            }
+        }
+    )
+
+    result = merge_for_thinker(
+        {
+            "preprocessing": _payload("preprocessing", preprocessing),
+            "vision_encoder": _payload("vision_encoder", vision),
+        }
+    )
+    state = Cosmos3PipelineState.from_dict(result.data)
+    model_inputs = state.thinker_inputs["model_inputs"]
+
+    assert model_inputs["image_embeds"] is embeddings
+    assert model_inputs["deepstack_visual_embeds"] is deepstack
+    assert state.thinker_inputs["media_cache_key"] == "key"
+    assert state.encoder_inputs == {}
+    assert state.encoder_outs == {}

--- a/tests/unit_test/cosmos3/test_merge.py
+++ b/tests/unit_test/cosmos3/test_merge.py
@@ -27,7 +27,7 @@ def test_merge_builds_thinker_inputs_without_duplicate_encoder_payload() -> None
     preprocessing = Cosmos3PipelineState(
         prompt=prompt,
         mm_inputs={"image_grid_thw": torch.tensor([[1, 2, 2]])},
-        encoder_inputs={"vision_encoder": {"cache_key": "key", "_active": True}},
+        encoder_inputs={"vision_encoder": {"image_cache_key": "key", "_active": True}},
     )
     embeddings = torch.ones((1, 4))
     deepstack = [torch.full((1, 4), index) for index in range(3)]
@@ -52,6 +52,6 @@ def test_merge_builds_thinker_inputs_without_duplicate_encoder_payload() -> None
 
     assert model_inputs["image_embeds"] is embeddings
     assert model_inputs["deepstack_visual_embeds"] is deepstack
-    assert state.thinker_inputs["media_cache_key"] == "key"
+    assert state.thinker_inputs["image_cache_key"] == "key"
     assert state.encoder_inputs == {}
     assert state.encoder_outs == {}

--- a/tests/unit_test/cosmos3/test_request_builders.py
+++ b/tests/unit_test/cosmos3/test_request_builders.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import torch
+import xxhash
 from transformers import GenerationConfig
 
 from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
@@ -13,6 +14,7 @@ from sglang_omni.models.cosmos3.request_builders import (
     apply_text_result,
     build_cosmos3_sampling_kwargs,
     build_sglang_text_request,
+    build_vision_encoder_request,
     compute_cosmos3_mrope_positions,
     make_text_scheduler_adapters,
     make_text_stream_output_builder,
@@ -407,7 +409,10 @@ def test_preprocessing_routes_vision_only_when_media_is_active() -> None:
         "vision_encoder": {
             "pixel_values": torch.ones((4, 6)),
             "image_grid_thw": torch.tensor([[1, 2, 2]]),
-            "cache_key": "image-key",
+            "pixel_values_videos": torch.ones((4, 6)),
+            "video_grid_thw": torch.tensor([[1, 2, 2]]),
+            "image_cache_key": "image-key",
+            "video_cache_key": "video-key",
         }
     }
     payload.data = state.to_dict()
@@ -427,25 +432,33 @@ def test_preprocessing_routes_vision_only_when_media_is_active() -> None:
     thinker_state = Cosmos3PipelineState.from_dict(thinker_payload.data)
     assert "pixel_values" in encoder_state.encoder_inputs["vision_encoder"]
     assert thinker_state.encoder_inputs == {
-        "vision_encoder": {"cache_key": "image-key", "_active": True}
+        "vision_encoder": {
+            "image_cache_key": "image-key",
+            "video_cache_key": "video-key",
+            "_active": True,
+        }
     }
+    encoder_request = build_vision_encoder_request(encoder_state)
+    assert encoder_request.cache_key == "image-key|video-key"
 
 
 def test_builds_multimodal_request_with_precomputed_vision_inputs() -> None:
     state = Cosmos3PipelineState(
         prompt={
-            "input_ids": torch.tensor([10, 151655, 11]),
-            "attention_mask": torch.ones(3, dtype=torch.long),
-            "prompt_text": "image prompt",
-            "mm_token_type_ids": torch.tensor([0, 1, 0]),
+            "input_ids": torch.tensor([10, 151655, 151656, 11]),
+            "attention_mask": torch.ones(4, dtype=torch.long),
+            "prompt_text": "media prompt",
+            "mm_token_type_ids": torch.tensor([0, 1, 2, 0]),
         },
         thinker_inputs={
             "model_inputs": {
                 "image_embeds": torch.ones((1, 4)),
-                "deepstack_visual_embeds": [torch.ones((1, 4)) for _ in range(3)],
+                "video_embeds": torch.ones((1, 4)),
                 "image_grid_thw": torch.tensor([[1, 2, 2]]),
+                "video_grid_thw": torch.tensor([[1, 2, 2]]),
             },
-            "media_cache_key": "image-key",
+            "image_cache_key": "image-key",
+            "video_cache_key": "video-key",
         },
     )
     config = SimpleNamespace(
@@ -463,16 +476,20 @@ def test_builds_multimodal_request_with_precomputed_vision_inputs() -> None:
     )
 
     assert data.req.multimodal_inputs.mrope_positions.tolist() == [
-        [0, 1, 2],
-        [0, 1, 2],
-        [0, 1, 2],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
     ]
     assert data.req.omni_model_inputs["image_embeds"].shape == (1, 4)
     assert data.req.origin_input_ids[1] > 151936
-    assert (
-        data.req.omni_model_inputs["pad_values"]["image"]
-        == (data.req.origin_input_ids[1])
-    )
+    for index, (modality, cache_key) in enumerate(
+        (("image", "image-key"), ("video", "video-key")), start=1
+    ):
+        expected = 151936 + xxhash.xxh3_64(
+            f"{modality}:{cache_key}".encode()
+        ).intdigest() % (1 << 62)
+        assert data.req.omni_model_inputs["pad_values"][modality] == expected
+        assert data.req.origin_input_ids[index] == expected
 
 
 def test_decode_projection_drops_prefill_only_vision_tensors() -> None:

--- a/tests/unit_test/cosmos3/test_request_builders.py
+++ b/tests/unit_test/cosmos3/test_request_builders.py
@@ -13,8 +13,14 @@ from sglang_omni.models.cosmos3.request_builders import (
     apply_text_result,
     build_cosmos3_sampling_kwargs,
     build_sglang_text_request,
+    compute_cosmos3_mrope_positions,
     make_text_scheduler_adapters,
     make_text_stream_output_builder,
+    project_preprocessing_to_thinker,
+    project_preprocessing_to_vision_encoder,
+    project_thinker_to_decode,
+    resolve_preprocessing_next_stages,
+    resolve_thinker_wait_sources,
 )
 from sglang_omni.proto import EXPLICIT_GENERATION_PARAMS_KEY, OmniRequest, StagePayload
 
@@ -365,3 +371,124 @@ def test_apply_text_result_preserves_optional_metadata() -> None:
     assert output["matched_stop"] == "###"
     assert output["output_token_logprobs"] == [-0.5]
     assert output["weight_version"] == "v1"
+
+
+def test_cosmos3_image_mrope_fills_text_axes_and_uses_visual_grid() -> None:
+    token_types = torch.tensor([0, 0, *([1] * 4), 0], dtype=torch.long)
+    positions, delta = compute_cosmos3_mrope_positions(
+        torch.arange(7),
+        token_types,
+        image_grid_thw=torch.tensor([[1, 4, 4]]),
+        video_grid_thw=None,
+        spatial_merge_size=2,
+    )
+
+    assert positions.tolist() == [
+        [0, 1, 2, 2, 2, 2, 4],
+        [0, 1, 2, 2, 3, 3, 4],
+        [0, 1, 2, 3, 2, 3, 4],
+    ]
+    assert delta.tolist() == [[-2]]
+
+
+def test_preprocessing_routes_vision_only_when_media_is_active() -> None:
+    payload = StagePayload(
+        request_id="route",
+        request=OmniRequest(inputs=None),
+        data=_state().to_dict(),
+    )
+    assert resolve_preprocessing_next_stages("route", payload) == ["thinker"]
+    assert resolve_thinker_wait_sources("route", "preprocessing", payload) == [
+        "preprocessing"
+    ]
+
+    state = _state()
+    state.encoder_inputs = {
+        "vision_encoder": {
+            "pixel_values": torch.ones((4, 6)),
+            "image_grid_thw": torch.tensor([[1, 2, 2]]),
+            "cache_key": "image-key",
+        }
+    }
+    payload.data = state.to_dict()
+
+    assert resolve_preprocessing_next_stages("route", payload) == [
+        "vision_encoder",
+        "thinker",
+    ]
+    assert resolve_thinker_wait_sources("route", "vision_encoder", payload) is None
+    assert resolve_thinker_wait_sources("route", "preprocessing", payload) == [
+        "preprocessing",
+        "vision_encoder",
+    ]
+    encoder_payload = project_preprocessing_to_vision_encoder(payload)
+    thinker_payload = project_preprocessing_to_thinker(payload)
+    encoder_state = Cosmos3PipelineState.from_dict(encoder_payload.data)
+    thinker_state = Cosmos3PipelineState.from_dict(thinker_payload.data)
+    assert "pixel_values" in encoder_state.encoder_inputs["vision_encoder"]
+    assert thinker_state.encoder_inputs == {
+        "vision_encoder": {"cache_key": "image-key", "_active": True}
+    }
+
+
+def test_builds_multimodal_request_with_precomputed_vision_inputs() -> None:
+    state = Cosmos3PipelineState(
+        prompt={
+            "input_ids": torch.tensor([10, 151655, 11]),
+            "attention_mask": torch.ones(3, dtype=torch.long),
+            "prompt_text": "image prompt",
+            "mm_token_type_ids": torch.tensor([0, 1, 0]),
+        },
+        thinker_inputs={
+            "model_inputs": {
+                "image_embeds": torch.ones((1, 4)),
+                "deepstack_visual_embeds": [torch.ones((1, 4)) for _ in range(3)],
+                "image_grid_thw": torch.tensor([[1, 2, 2]]),
+            },
+            "media_cache_key": "image-key",
+        },
+    )
+    config = SimpleNamespace(
+        image_token_id=151655,
+        video_token_id=151656,
+        vision_config=SimpleNamespace(spatial_merge_size=2),
+    )
+
+    data = build_sglang_text_request(
+        state,
+        params={"max_new_tokens": 2},
+        tokenizer=_FakeTokenizer(),
+        vocab_size=151936,
+        thinker_config=config,
+    )
+
+    assert data.req.multimodal_inputs.mrope_positions.tolist() == [
+        [0, 1, 2],
+        [0, 1, 2],
+        [0, 1, 2],
+    ]
+    assert data.req.omni_model_inputs["image_embeds"].shape == (1, 4)
+    assert data.req.origin_input_ids[1] > 151936
+    assert (
+        data.req.omni_model_inputs["pad_values"]["image"]
+        == (data.req.origin_input_ids[1])
+    )
+
+
+def test_decode_projection_drops_prefill_only_vision_tensors() -> None:
+    state = _state()
+    state.mm_inputs = {"image_grid_thw": torch.tensor([[1, 2, 2]])}
+    state.thinker_inputs = {"model_inputs": {"image_embeds": torch.ones((1, 4))}}
+    state.text_out = {"output_ids": [42], "is_final": True}
+    payload = StagePayload(
+        request_id="decode-projection",
+        request=OmniRequest(inputs=None),
+        data=state.to_dict(),
+    )
+
+    projected = Cosmos3PipelineState.from_dict(project_thinker_to_decode(payload).data)
+
+    assert projected.thinker_inputs == {}
+    assert projected.mm_inputs == {}
+    assert projected.text_out == {"output_ids": [42], "is_final": True}
+    assert projected.prompt is not None

--- a/tests/unit_test/cosmos3/test_request_builders.py
+++ b/tests/unit_test/cosmos3/test_request_builders.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import torch
+import xxhash
 from transformers import GenerationConfig
 
 from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
@@ -13,6 +14,7 @@ from sglang_omni.models.cosmos3.request_builders import (
     apply_text_result,
     build_cosmos3_sampling_kwargs,
     build_sglang_text_request,
+    build_vision_encoder_request,
     compute_cosmos3_mrope_positions,
     make_text_scheduler_adapters,
     make_text_stream_output_builder,
@@ -409,7 +411,10 @@ def test_preprocessing_routes_vision_only_when_media_is_active() -> None:
         "vision_encoder": {
             "pixel_values": torch.ones((4, 6)),
             "image_grid_thw": torch.tensor([[1, 2, 2]]),
-            "cache_key": "image-key",
+            "pixel_values_videos": torch.ones((4, 6)),
+            "video_grid_thw": torch.tensor([[1, 2, 2]]),
+            "image_cache_key": "image-key",
+            "video_cache_key": "video-key",
         }
     }
     payload.data = state.to_dict()
@@ -429,25 +434,33 @@ def test_preprocessing_routes_vision_only_when_media_is_active() -> None:
     thinker_state = Cosmos3PipelineState.from_dict(thinker_payload.data)
     assert "pixel_values" in encoder_state.encoder_inputs["vision_encoder"]
     assert thinker_state.encoder_inputs == {
-        "vision_encoder": {"cache_key": "image-key", "_active": True}
+        "vision_encoder": {
+            "image_cache_key": "image-key",
+            "video_cache_key": "video-key",
+            "_active": True,
+        }
     }
+    encoder_request = build_vision_encoder_request(encoder_state)
+    assert encoder_request.cache_key == "image-key|video-key"
 
 
 def test_builds_multimodal_request_with_precomputed_vision_inputs() -> None:
     state = Cosmos3PipelineState(
         prompt={
-            "input_ids": torch.tensor([10, 151655, 11]),
-            "attention_mask": torch.ones(3, dtype=torch.long),
-            "prompt_text": "image prompt",
-            "mm_token_type_ids": torch.tensor([0, 1, 0]),
+            "input_ids": torch.tensor([10, 151655, 151656, 11]),
+            "attention_mask": torch.ones(4, dtype=torch.long),
+            "prompt_text": "media prompt",
+            "mm_token_type_ids": torch.tensor([0, 1, 2, 0]),
         },
         thinker_inputs={
             "model_inputs": {
                 "image_embeds": torch.ones((1, 4)),
-                "deepstack_visual_embeds": [torch.ones((1, 4)) for _ in range(3)],
+                "video_embeds": torch.ones((1, 4)),
                 "image_grid_thw": torch.tensor([[1, 2, 2]]),
+                "video_grid_thw": torch.tensor([[1, 2, 2]]),
             },
-            "media_cache_key": "image-key",
+            "image_cache_key": "image-key",
+            "video_cache_key": "video-key",
         },
     )
     config = SimpleNamespace(
@@ -465,16 +478,20 @@ def test_builds_multimodal_request_with_precomputed_vision_inputs() -> None:
     )
 
     assert data.req.multimodal_inputs.mrope_positions.tolist() == [
-        [0, 1, 2],
-        [0, 1, 2],
-        [0, 1, 2],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
     ]
     assert data.req.omni_model_inputs["image_embeds"].shape == (1, 4)
     assert data.req.origin_input_ids[1] > 151936
-    assert (
-        data.req.omni_model_inputs["pad_values"]["image"]
-        == (data.req.origin_input_ids[1])
-    )
+    for index, (modality, cache_key) in enumerate(
+        (("image", "image-key"), ("video", "video-key")), start=1
+    ):
+        expected = 151936 + xxhash.xxh3_64(
+            f"{modality}:{cache_key}".encode()
+        ).intdigest() % (1 << 62)
+        assert data.req.omni_model_inputs["pad_values"][modality] == expected
+        assert data.req.origin_input_ids[index] == expected
 
 
 def test_decode_projection_drops_prefill_only_vision_tensors() -> None:

--- a/tests/unit_test/cosmos3/test_request_builders.py
+++ b/tests/unit_test/cosmos3/test_request_builders.py
@@ -13,8 +13,14 @@ from sglang_omni.models.cosmos3.request_builders import (
     apply_text_result,
     build_cosmos3_sampling_kwargs,
     build_sglang_text_request,
+    compute_cosmos3_mrope_positions,
     make_text_scheduler_adapters,
     make_text_stream_output_builder,
+    project_preprocessing_to_thinker,
+    project_preprocessing_to_vision_encoder,
+    project_thinker_to_decode,
+    resolve_preprocessing_next_stages,
+    resolve_thinker_wait_sources,
 )
 from sglang_omni.proto import EXPLICIT_GENERATION_PARAMS_KEY, OmniRequest, StagePayload
 
@@ -367,3 +373,124 @@ def test_apply_text_result_preserves_optional_metadata() -> None:
     assert output["matched_stop"] == "###"
     assert output["output_token_logprobs"] == [-0.5]
     assert output["weight_version"] == "v1"
+
+
+def test_cosmos3_image_mrope_fills_text_axes_and_uses_visual_grid() -> None:
+    token_types = torch.tensor([0, 0, *([1] * 4), 0], dtype=torch.long)
+    positions, delta = compute_cosmos3_mrope_positions(
+        torch.arange(7),
+        token_types,
+        image_grid_thw=torch.tensor([[1, 4, 4]]),
+        video_grid_thw=None,
+        spatial_merge_size=2,
+    )
+
+    assert positions.tolist() == [
+        [0, 1, 2, 2, 2, 2, 4],
+        [0, 1, 2, 2, 3, 3, 4],
+        [0, 1, 2, 3, 2, 3, 4],
+    ]
+    assert delta.tolist() == [[-2]]
+
+
+def test_preprocessing_routes_vision_only_when_media_is_active() -> None:
+    payload = StagePayload(
+        request_id="route",
+        request=OmniRequest(inputs=None),
+        data=_state().to_dict(),
+    )
+    assert resolve_preprocessing_next_stages("route", payload) == ["thinker"]
+    assert resolve_thinker_wait_sources("route", "preprocessing", payload) == [
+        "preprocessing"
+    ]
+
+    state = _state()
+    state.encoder_inputs = {
+        "vision_encoder": {
+            "pixel_values": torch.ones((4, 6)),
+            "image_grid_thw": torch.tensor([[1, 2, 2]]),
+            "cache_key": "image-key",
+        }
+    }
+    payload.data = state.to_dict()
+
+    assert resolve_preprocessing_next_stages("route", payload) == [
+        "vision_encoder",
+        "thinker",
+    ]
+    assert resolve_thinker_wait_sources("route", "vision_encoder", payload) is None
+    assert resolve_thinker_wait_sources("route", "preprocessing", payload) == [
+        "preprocessing",
+        "vision_encoder",
+    ]
+    encoder_payload = project_preprocessing_to_vision_encoder(payload)
+    thinker_payload = project_preprocessing_to_thinker(payload)
+    encoder_state = Cosmos3PipelineState.from_dict(encoder_payload.data)
+    thinker_state = Cosmos3PipelineState.from_dict(thinker_payload.data)
+    assert "pixel_values" in encoder_state.encoder_inputs["vision_encoder"]
+    assert thinker_state.encoder_inputs == {
+        "vision_encoder": {"cache_key": "image-key", "_active": True}
+    }
+
+
+def test_builds_multimodal_request_with_precomputed_vision_inputs() -> None:
+    state = Cosmos3PipelineState(
+        prompt={
+            "input_ids": torch.tensor([10, 151655, 11]),
+            "attention_mask": torch.ones(3, dtype=torch.long),
+            "prompt_text": "image prompt",
+            "mm_token_type_ids": torch.tensor([0, 1, 0]),
+        },
+        thinker_inputs={
+            "model_inputs": {
+                "image_embeds": torch.ones((1, 4)),
+                "deepstack_visual_embeds": [torch.ones((1, 4)) for _ in range(3)],
+                "image_grid_thw": torch.tensor([[1, 2, 2]]),
+            },
+            "media_cache_key": "image-key",
+        },
+    )
+    config = SimpleNamespace(
+        image_token_id=151655,
+        video_token_id=151656,
+        vision_config=SimpleNamespace(spatial_merge_size=2),
+    )
+
+    data = build_sglang_text_request(
+        state,
+        params={"max_new_tokens": 2},
+        tokenizer=_FakeTokenizer(),
+        vocab_size=151936,
+        thinker_config=config,
+    )
+
+    assert data.req.multimodal_inputs.mrope_positions.tolist() == [
+        [0, 1, 2],
+        [0, 1, 2],
+        [0, 1, 2],
+    ]
+    assert data.req.omni_model_inputs["image_embeds"].shape == (1, 4)
+    assert data.req.origin_input_ids[1] > 151936
+    assert (
+        data.req.omni_model_inputs["pad_values"]["image"]
+        == (data.req.origin_input_ids[1])
+    )
+
+
+def test_decode_projection_drops_prefill_only_vision_tensors() -> None:
+    state = _state()
+    state.mm_inputs = {"image_grid_thw": torch.tensor([[1, 2, 2]])}
+    state.thinker_inputs = {"model_inputs": {"image_embeds": torch.ones((1, 4))}}
+    state.text_out = {"output_ids": [42], "is_final": True}
+    payload = StagePayload(
+        request_id="decode-projection",
+        request=OmniRequest(inputs=None),
+        data=state.to_dict(),
+    )
+
+    projected = Cosmos3PipelineState.from_dict(project_thinker_to_decode(payload).data)
+
+    assert projected.thinker_inputs == {}
+    assert projected.mm_inputs == {}
+    assert projected.text_out == {"output_ids": [42], "is_final": True}
+    assert projected.prompt is not None

--- a/tests/unit_test/cosmos3/test_sglang_text.py
+++ b/tests/unit_test/cosmos3/test_sglang_text.py
@@ -6,7 +6,9 @@ from types import SimpleNamespace
 
 import torch
 from sglang.srt.models.qwen3 import Qwen3ForCausalLM
+from torch import nn
 
+from sglang_omni.models.cosmos3.components import sglang_text
 from sglang_omni.models.cosmos3.components.sglang_text import (
     Cosmos3TextForCausalLM,
     map_cosmos3_text_weight_name,
@@ -75,27 +77,51 @@ def test_load_weights_forwards_only_mapped_text_tensors(monkeypatch) -> None:
 def test_text_wrapper_uses_nested_text_config(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
-    def fake_init(self, config, quant_config=None, prefix=""):
+    class _FakeTextModel(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.embed_tokens = nn.Embedding(2, 2)
+
+    def fake_init(*, config, quant_config=None, prefix=""):
         captured.update(
             config=config,
             quant_config=quant_config,
             prefix=prefix,
         )
+        return _FakeTextModel()
 
-    monkeypatch.setattr(Qwen3ForCausalLM, "__init__", fake_init)
-    text_config = SimpleNamespace(tie_word_embeddings=True)
+    monkeypatch.setattr(sglang_text, "Qwen3LLMModel", fake_init)
+    monkeypatch.setattr(
+        sglang_text,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_last_rank=True, world_size=1),
+    )
+    monkeypatch.setattr(
+        sglang_text, "ParallelLMHead", lambda *args, **kwargs: nn.Identity()
+    )
+    monkeypatch.setattr(sglang_text, "LogitsProcessor", lambda config: object())
+    monkeypatch.setattr(sglang_text, "Pooler", lambda **kwargs: object())
+    monkeypatch.setattr(
+        sglang_text,
+        "get_server_args",
+        lambda: SimpleNamespace(enable_dp_lm_head=False),
+    )
+    text_config = SimpleNamespace(
+        tie_word_embeddings=True,
+        vocab_size=10,
+        hidden_size=4,
+    )
     root_config = SimpleNamespace(
         text_config=text_config,
+        vision_config=SimpleNamespace(deepstack_visual_indexes=[1, 2, 3]),
         tie_word_embeddings=False,
     )
 
     model = Cosmos3TextForCausalLM(root_config, quant_config="quant", prefix="p")
 
-    assert captured == {
-        "config": text_config,
-        "quant_config": "quant",
-        "prefix": "p",
-    }
+    assert captured["config"] is text_config
+    assert captured["quant_config"] == "quant"
+    assert captured["prefix"] == "p.model"
     assert text_config.tie_word_embeddings is False
     assert model.root_config is root_config
 
@@ -130,3 +156,36 @@ def test_text_forward_prefers_scheduler_mrope_positions(monkeypatch) -> None:
     assert result == "output"
     assert captured["positions"] is mrope_positions
     assert captured["forward_batch"] is forward_batch
+
+
+def test_multimodal_forward_passes_deepstack_to_qwen3_vl_text_model() -> None:
+    captured: dict[str, object] = {}
+
+    class _TextModel(nn.Module):
+        def forward(self, *args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return torch.ones((2, 4))
+
+    model = object.__new__(Cosmos3TextForCausalLM)
+    nn.Module.__init__(model)
+    model.model = _TextModel()
+    model.pp_group = SimpleNamespace(is_last_rank=True)
+    model.capture_aux_hidden_states = False
+    model.lm_head = nn.Identity()
+    model.logits_processor = lambda *args: "logits"
+    deepstack = torch.ones((2, 12))
+    positions = torch.arange(2).unsqueeze(0).expand(3, -1)
+    forward_batch = SimpleNamespace(mrope_positions=positions)
+
+    result = model.forward(
+        input_ids=torch.tensor([1, 2]),
+        positions=torch.tensor([0, 1]),
+        forward_batch=forward_batch,
+        input_embeds=torch.ones((2, 4)),
+        input_deepstack_embeds=deepstack,
+    )
+
+    assert result == "logits"
+    assert captured["kwargs"]["input_deepstack_embeds"] is deepstack
+    assert captured["args"][1] is positions

--- a/tests/unit_test/cosmos3/test_stages.py
+++ b/tests/unit_test/cosmos3/test_stages.py
@@ -4,20 +4,26 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import torch
+
 from sglang_omni.models.cosmos3 import stages
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni.scheduling.stage_cache import StageOutputCache
 
 
 def test_preprocessing_factory_returns_simple_scheduler(monkeypatch) -> None:
     sentinel = object()
-    calls: list[tuple[str, int | None, str | None]] = []
+    calls: list[tuple[str, int | None, str | None, bool]] = []
 
     def fake_preprocessor(
         model_path: str,
         max_seq_len: int | None,
         revision: str | None,
+        enable_vision: bool,
     ):
-        calls.append((model_path, max_seq_len, revision))
+        calls.append((model_path, max_seq_len, revision, enable_vision))
         return sentinel
 
     monkeypatch.setattr(stages, "Cosmos3TextPreprocessor", fake_preprocessor)
@@ -30,7 +36,7 @@ def test_preprocessing_factory_returns_simple_scheduler(monkeypatch) -> None:
 
     assert isinstance(scheduler, SimpleScheduler)
     assert scheduler._fn is sentinel
-    assert calls == [("nvidia/Cosmos3-Nano", 8192, "cosmos-revision")]
+    assert calls == [("nvidia/Cosmos3-Nano", 8192, "cosmos-revision", True)]
 
 
 def test_text_factory_passes_through_tensor_parallelism(
@@ -93,3 +99,65 @@ def test_text_factory_passes_through_tensor_parallelism(
     assert captured["server_args"] is server_args
     assert captured["gpu_id"] == 2
     assert captured["scheduler_kwargs"]["tp_rank"] == 1
+
+
+class _FakeVisionModel:
+    spatial_merge_size = 2
+    out_hidden_size = 4
+    deepstack_layers = 1
+    visual_dtype_bytes = 4
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, **inputs):
+        self.calls += 1
+        grid = inputs["image_grid_thw"]
+        token_count = grid.prod(-1) // 4
+        total = int(token_count.sum().item())
+        embeds = torch.arange(total * 4, dtype=torch.float32).reshape(total, 4)
+        return {
+            "image_embeds": embeds,
+            "image_grid_thw": grid,
+            "image_token_counts": token_count,
+            "deepstack_visual_embeds_image": [embeds + 1],
+        }
+
+
+def _vision_payload(request_id: str, cache_key: str) -> StagePayload:
+    state = Cosmos3PipelineState(
+        encoder_inputs={
+            "vision_encoder": {
+                "pixel_values": torch.ones((4, 6)),
+                "image_grid_thw": torch.tensor([[1, 2, 2]]),
+                "cache_key": cache_key,
+            }
+        }
+    )
+    return StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs=None),
+        data=state.to_dict(),
+    )
+
+
+def test_vision_encoder_batches_and_deduplicates_same_cache_key() -> None:
+    model = _FakeVisionModel()
+    cache = StageOutputCache(max_size=4, cache_device="cpu")
+    outputs = stages._batch_vision_requests(
+        [
+            _vision_payload("first", "same-image"),
+            _vision_payload("second", "same-image"),
+        ],
+        model=model,
+        cache=cache,
+    )
+
+    assert model.calls == 1
+    assert len(cache) == 1
+    first = Cosmos3PipelineState.from_dict(outputs[0].data)
+    second = Cosmos3PipelineState.from_dict(outputs[1].data)
+    assert torch.equal(
+        first.encoder_outs["vision_encoder"]["image_embeds"],
+        second.encoder_outs["vision_encoder"]["image_embeds"],
+    )

--- a/tests/unit_test/cosmos3/test_stages.py
+++ b/tests/unit_test/cosmos3/test_stages.py
@@ -4,13 +4,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-import torch
-
-from sglang_omni.models.cosmos3 import stages
-from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
-from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.models.cosmos3 import stages, vision_encoder_scheduler
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
-from sglang_omni.scheduling.stage_cache import StageOutputCache
 
 
 def test_preprocessing_factory_returns_simple_scheduler(monkeypatch) -> None:
@@ -37,6 +32,37 @@ def test_preprocessing_factory_returns_simple_scheduler(monkeypatch) -> None:
     assert isinstance(scheduler, SimpleScheduler)
     assert scheduler._fn is sentinel
     assert calls == [("nvidia/Cosmos3-Nano", 8192, "cosmos-revision", True)]
+
+
+def test_vision_encoder_factory_delegates_to_scheduler(monkeypatch) -> None:
+    sentinel = object()
+    calls: list[tuple[str, str | None, str, str | None]] = []
+
+    def fake_create(
+        model_path: str,
+        *,
+        revision: str | None = None,
+        device: str,
+        dtype: str | None,
+    ):
+        calls.append((model_path, revision, device, dtype))
+        return sentinel
+
+    monkeypatch.setattr(
+        vision_encoder_scheduler,
+        "create_vision_encoder_scheduler",
+        fake_create,
+    )
+
+    result = stages.create_vision_encoder_executor(
+        "nvidia/Cosmos3-Nano",
+        revision="cosmos-revision",
+        device="cuda:1",
+        dtype="bfloat16",
+    )
+
+    assert result is sentinel
+    assert calls == [("nvidia/Cosmos3-Nano", "cosmos-revision", "cuda:1", "bfloat16")]
 
 
 def test_text_factory_passes_through_tensor_parallelism(
@@ -99,65 +125,3 @@ def test_text_factory_passes_through_tensor_parallelism(
     assert captured["server_args"] is server_args
     assert captured["gpu_id"] == 2
     assert captured["scheduler_kwargs"]["tp_rank"] == 1
-
-
-class _FakeVisionModel:
-    spatial_merge_size = 2
-    out_hidden_size = 4
-    deepstack_layers = 1
-    visual_dtype_bytes = 4
-
-    def __init__(self) -> None:
-        self.calls = 0
-
-    def __call__(self, **inputs):
-        self.calls += 1
-        grid = inputs["image_grid_thw"]
-        token_count = grid.prod(-1) // 4
-        total = int(token_count.sum().item())
-        embeds = torch.arange(total * 4, dtype=torch.float32).reshape(total, 4)
-        return {
-            "image_embeds": embeds,
-            "image_grid_thw": grid,
-            "image_token_counts": token_count,
-            "deepstack_visual_embeds_image": [embeds + 1],
-        }
-
-
-def _vision_payload(request_id: str, cache_key: str) -> StagePayload:
-    state = Cosmos3PipelineState(
-        encoder_inputs={
-            "vision_encoder": {
-                "pixel_values": torch.ones((4, 6)),
-                "image_grid_thw": torch.tensor([[1, 2, 2]]),
-                "cache_key": cache_key,
-            }
-        }
-    )
-    return StagePayload(
-        request_id=request_id,
-        request=OmniRequest(inputs=None),
-        data=state.to_dict(),
-    )
-
-
-def test_vision_encoder_batches_and_deduplicates_same_cache_key() -> None:
-    model = _FakeVisionModel()
-    cache = StageOutputCache(max_size=4, cache_device="cpu")
-    outputs = stages._batch_vision_requests(
-        [
-            _vision_payload("first", "same-image"),
-            _vision_payload("second", "same-image"),
-        ],
-        model=model,
-        cache=cache,
-    )
-
-    assert model.calls == 1
-    assert len(cache) == 1
-    first = Cosmos3PipelineState.from_dict(outputs[0].data)
-    second = Cosmos3PipelineState.from_dict(outputs[1].data)
-    assert torch.equal(
-        first.encoder_outs["vision_encoder"]["image_embeds"],
-        second.encoder_outs["vision_encoder"]["image_embeds"],
-    )

--- a/tests/unit_test/cosmos3/test_text_preprocessor.py
+++ b/tests/unit_test/cosmos3/test_text_preprocessor.py
@@ -68,12 +68,15 @@ class _FakeProcessor:
 
     def __call__(self, **kwargs):
         assert kwargs["images"] == ["loaded-image"]
+        assert kwargs["videos"] == ["loaded-video"]
         return {
-            "input_ids": torch.tensor([[10, 151655, 11]]),
-            "attention_mask": torch.ones((1, 3), dtype=torch.long),
-            "mm_token_type_ids": torch.tensor([[0, 1, 0]]),
+            "input_ids": torch.tensor([[10, 151655, 151656, 11]]),
+            "attention_mask": torch.ones((1, 4), dtype=torch.long),
+            "mm_token_type_ids": torch.tensor([[0, 1, 2, 0]]),
             "pixel_values": torch.ones((4, 6)),
             "image_grid_thw": torch.tensor([[1, 2, 2]]),
+            "pixel_values_videos": torch.ones((4, 6)),
+            "video_grid_thw": torch.tensor([[1, 2, 2]]),
         }
 
 
@@ -191,21 +194,26 @@ async def test_pretokenized_prompt_bypasses_chat_template() -> None:
 
 
 @pytest.mark.asyncio
-async def test_preprocesses_image_for_standalone_encoder(monkeypatch) -> None:
+async def test_preprocesses_media_with_independent_cache_keys(monkeypatch) -> None:
     async def fake_images(value):
         assert value == ["image.png"]
         return ["loaded-image"]
 
     async def fake_videos(value, **kwargs):
-        assert value is None
-        return [], None, None
+        assert value == ["video.mp4"]
+        return ["loaded-video"], [24.0], None
 
     monkeypatch.setattr(text_preprocessor, "ensure_image_list_async", fake_images)
     monkeypatch.setattr(text_preprocessor, "ensure_video_list_async", fake_videos)
     monkeypatch.setattr(
         text_preprocessor,
         "compute_image_cache_key",
-        lambda value: "image-cache",
+        lambda value: None,
+    )
+    monkeypatch.setattr(
+        text_preprocessor,
+        "compute_video_cache_key",
+        lambda value: "video-cache",
     )
     tokenizer = _FakeTokenizer()
     processor = _FakeProcessor(tokenizer)
@@ -220,15 +228,18 @@ async def test_preprocesses_image_for_standalone_encoder(monkeypatch) -> None:
             {
                 "messages": [{"role": "user", "content": "describe"}],
                 "images": ["image.png"],
+                "videos": ["video.mp4"],
             },
             max_new_tokens=2,
         )
     )
     state = Cosmos3PipelineState.from_dict(result.data)
 
-    assert state.prompt["mm_token_type_ids"].tolist() == [0, 1, 0]
-    assert state.encoder_inputs["vision_encoder"]["cache_key"] == "image-cache"
-    assert state.encoder_inputs["vision_encoder"]["pixel_values"].shape == (4, 6)
+    assert state.prompt["mm_token_type_ids"].tolist() == [0, 1, 2, 0]
+    vision_inputs = state.encoder_inputs["vision_encoder"]
+    assert vision_inputs["image_cache_key"].startswith("image:request:")
+    assert vision_inputs["video_cache_key"].startswith("video-cache|")
+    assert vision_inputs["pixel_values"].shape == (4, 6)
     assert processor.messages[0]["content"][0] == {"type": "image"}
 
 

--- a/tests/unit_test/cosmos3/test_text_preprocessor.py
+++ b/tests/unit_test/cosmos3/test_text_preprocessor.py
@@ -56,6 +56,27 @@ class _FakeTokenizer:
         }
 
 
+class _FakeProcessor:
+    def __init__(self, tokenizer: _FakeTokenizer) -> None:
+        self.tokenizer = tokenizer
+        self.messages = None
+
+    def apply_chat_template(self, messages, **kwargs) -> str:
+        assert kwargs == {"tokenize": False, "add_generation_prompt": True}
+        self.messages = messages
+        return "multimodal prompt"
+
+    def __call__(self, **kwargs):
+        assert kwargs["images"] == ["loaded-image"]
+        return {
+            "input_ids": torch.tensor([[10, 151655, 11]]),
+            "attention_mask": torch.ones((1, 3), dtype=torch.long),
+            "mm_token_type_ids": torch.tensor([[0, 1, 0]]),
+            "pixel_values": torch.ones((4, 6)),
+            "image_grid_thw": torch.tensor([[1, 2, 2]]),
+        }
+
+
 def _payload(inputs: Any, **params: Any) -> StagePayload:
     return StagePayload(
         request_id="cosmos-request",
@@ -92,7 +113,8 @@ def test_tokenizer_loader_pins_local_and_remote_attempts(monkeypatch) -> None:
     assert [call["local_files_only"] for call in calls] == [True, False]
 
 
-def test_preprocesses_text_messages_into_canonical_state() -> None:
+@pytest.mark.asyncio
+async def test_preprocesses_text_messages_into_canonical_state() -> None:
     tokenizer = _FakeTokenizer()
     preprocessor = Cosmos3TextPreprocessor(
         "unused-model",
@@ -104,7 +126,7 @@ def test_preprocesses_text_messages_into_canonical_state() -> None:
         max_new_tokens=8,
     )
 
-    result = preprocessor(payload)
+    result = await preprocessor(payload)
     state = Cosmos3PipelineState.from_dict(result.data)
 
     assert result is payload
@@ -114,11 +136,13 @@ def test_preprocesses_text_messages_into_canonical_state() -> None:
     assert state.prompt["input_ids"].tolist() == [101, 102, 103]
     assert state.prompt["input_ids"].dtype == torch.long
     assert state.prompt["attention_mask"].tolist() == [1, 1, 1]
+    assert state.prompt["mm_token_type_ids"].tolist() == [0, 0, 0]
     assert state.prompt["prompt_text"].endswith("<|im_start|>assistant\n")
     assert state.stream_state == {"token_ids": [], "text": ""}
 
 
-def test_flattens_openai_text_content_parts() -> None:
+@pytest.mark.asyncio
+async def test_flattens_openai_text_content_parts() -> None:
     tokenizer = _FakeTokenizer()
     preprocessor = Cosmos3TextPreprocessor(
         "unused-model",
@@ -139,7 +163,7 @@ def test_flattens_openai_text_content_parts() -> None:
         max_new_tokens=8,
     )
 
-    result = preprocessor(payload)
+    result = await preprocessor(payload)
     state = Cosmos3PipelineState.from_dict(result.data)
 
     assert tokenizer.messages == [{"role": "user", "content": "hello world"}]
@@ -147,7 +171,8 @@ def test_flattens_openai_text_content_parts() -> None:
     assert state.prompt["input_ids"].tolist() == [101, 102, 103]
 
 
-def test_pretokenized_prompt_bypasses_chat_template() -> None:
+@pytest.mark.asyncio
+async def test_pretokenized_prompt_bypasses_chat_template() -> None:
     tokenizer = _FakeTokenizer()
     preprocessor = Cosmos3TextPreprocessor(
         "unused-model",
@@ -155,7 +180,7 @@ def test_pretokenized_prompt_bypasses_chat_template() -> None:
         tokenizer=tokenizer,
     )
 
-    result = preprocessor(_payload([7, 8, 9], max_new_tokens=2))
+    result = await preprocessor(_payload([7, 8, 9], max_new_tokens=2))
     state = Cosmos3PipelineState.from_dict(result.data)
 
     assert tokenizer.tokenize_calls == 0
@@ -165,13 +190,51 @@ def test_pretokenized_prompt_bypasses_chat_template() -> None:
     assert state.prompt["prompt_text"] == ""
 
 
+@pytest.mark.asyncio
+async def test_preprocesses_image_for_standalone_encoder(monkeypatch) -> None:
+    async def fake_images(value):
+        assert value == ["image.png"]
+        return ["loaded-image"]
+
+    async def fake_videos(value, **kwargs):
+        assert value is None
+        return [], None, None
+
+    monkeypatch.setattr(text_preprocessor, "ensure_image_list_async", fake_images)
+    monkeypatch.setattr(text_preprocessor, "ensure_video_list_async", fake_videos)
+    monkeypatch.setattr(
+        text_preprocessor,
+        "compute_image_cache_key",
+        lambda value: "image-cache",
+    )
+    tokenizer = _FakeTokenizer()
+    processor = _FakeProcessor(tokenizer)
+    preprocessor = Cosmos3TextPreprocessor(
+        "unused-model",
+        tokenizer=tokenizer,
+        processor=processor,
+    )
+
+    result = await preprocessor(
+        _payload(
+            {
+                "messages": [{"role": "user", "content": "describe"}],
+                "images": ["image.png"],
+            },
+            max_new_tokens=2,
+        )
+    )
+    state = Cosmos3PipelineState.from_dict(result.data)
+
+    assert state.prompt["mm_token_type_ids"].tolist() == [0, 1, 0]
+    assert state.encoder_inputs["vision_encoder"]["cache_key"] == "image-cache"
+    assert state.encoder_inputs["vision_encoder"]["pixel_values"].shape == (4, 6)
+    assert processor.messages[0]["content"][0] == {"type": "image"}
+
+
 @pytest.mark.parametrize(
     "inputs, expected",
     [
-        (
-            {"messages": [{"role": "user", "content": "hello"}], "images": [1]},
-            "does not support media inputs yet",
-        ),
         (
             [{"role": "user", "content": [{"type": "image"}]}],
             "does not support media inputs yet",
@@ -187,17 +250,19 @@ def test_pretokenized_prompt_bypasses_chat_template() -> None:
         ({"prompt": "hello"}, "expects a messages field"),
     ],
 )
-def test_rejects_inputs_outside_pr1_text_scope(inputs: Any, expected: str) -> None:
+@pytest.mark.asyncio
+async def test_rejects_invalid_message_inputs(inputs: Any, expected: str) -> None:
     preprocessor = Cosmos3TextPreprocessor(
         "unused-model",
         tokenizer=_FakeTokenizer(),
     )
 
     with pytest.raises((TypeError, ValueError), match=expected):
-        preprocessor(_payload(inputs, max_new_tokens=2))
+        await preprocessor(_payload(inputs, max_new_tokens=2))
 
 
-def test_openai_structured_text_content_reaches_inference() -> None:
+@pytest.mark.asyncio
+async def test_openai_structured_text_content_reaches_inference() -> None:
     req = ChatCompletionRequest(
         model="nvidia/Cosmos3-Nano",
         messages=[
@@ -211,7 +276,7 @@ def test_openai_structured_text_content_reaches_inference() -> None:
     tokenizer = _FakeTokenizer()
     preprocessor = Cosmos3TextPreprocessor("unused-model", tokenizer=tokenizer)
 
-    result = preprocessor(_payload(inputs, max_new_tokens=2))
+    result = await preprocessor(_payload(inputs, max_new_tokens=2))
     state = Cosmos3PipelineState.from_dict(result.data)
 
     assert tokenizer.messages == [{"role": "user", "content": "hello"}]
@@ -219,7 +284,8 @@ def test_openai_structured_text_content_reaches_inference() -> None:
     assert state.prompt["input_ids"].tolist() == [101, 102, 103]
 
 
-def test_openai_media_content_part_maps_to_bad_request() -> None:
+@pytest.mark.asyncio
+async def test_openai_media_content_part_maps_to_bad_request() -> None:
     req = ChatCompletionRequest(
         model="nvidia/Cosmos3-Nano",
         messages=[
@@ -244,13 +310,14 @@ def test_openai_media_content_part_maps_to_bad_request() -> None:
     with pytest.raises(
         ValueError, match="does not support media inputs yet"
     ) as exc_info:
-        preprocessor(_payload(inputs, max_new_tokens=2))
+        await preprocessor(_payload(inputs, max_new_tokens=2))
 
     assert is_bad_request_error(exc_info.value)
     assert "base64" not in str(exc_info.value)
 
 
-def test_rejects_media_from_openai_request_metadata() -> None:
+@pytest.mark.asyncio
+async def test_media_from_openai_metadata_uses_multimodal_path() -> None:
     preprocessor = Cosmos3TextPreprocessor(
         "unused-model",
         tokenizer=_FakeTokenizer(),
@@ -261,11 +328,31 @@ def test_rejects_media_from_openai_request_metadata() -> None:
     )
     payload.request.metadata["images"] = ["data:image/png;base64,abc"]
 
-    with pytest.raises(ValueError, match="does not support media inputs yet: images"):
-        preprocessor(payload)
+    with pytest.raises(ValueError, match="require the checkpoint processor"):
+        await preprocessor(payload)
 
 
-def test_rejects_prompt_and_completion_over_context_limit() -> None:
+@pytest.mark.asyncio
+async def test_text_only_preprocessor_rejects_media_before_loading_it() -> None:
+    preprocessor = Cosmos3TextPreprocessor(
+        "unused-model",
+        tokenizer=_FakeTokenizer(),
+        enable_vision=False,
+    )
+
+    with pytest.raises(ValueError, match="text-only pipeline"):
+        await preprocessor(
+            _payload(
+                {
+                    "messages": [{"role": "user", "content": "describe"}],
+                    "images": ["image.png"],
+                }
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_rejects_prompt_and_completion_over_context_limit() -> None:
     preprocessor = Cosmos3TextPreprocessor(
         "unused-model",
         max_seq_len=8,
@@ -273,7 +360,7 @@ def test_rejects_prompt_and_completion_over_context_limit() -> None:
     )
 
     with pytest.raises(ValueError, match="maximum context length"):
-        preprocessor(_payload([1, 2, 3], max_new_tokens=5))
+        await preprocessor(_payload([1, 2, 3], max_new_tokens=5))
 
 
 def test_pipeline_state_survives_stage_payload_round_trip() -> None:

--- a/tests/unit_test/cosmos3/test_vision_encoder.py
+++ b/tests/unit_test/cosmos3/test_vision_encoder.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+from safetensors.torch import save_file
+from transformers import Qwen3VLVisionConfig, Qwen3VLVisionModel
+
+from sglang_omni.models.cosmos3.components import vision_encoder
+from sglang_omni.models.cosmos3.components.vision_encoder import Cosmos3VisionEncoder
+
+
+def _tiny_vision_config() -> Qwen3VLVisionConfig:
+    return Qwen3VLVisionConfig(
+        depth=1,
+        hidden_size=16,
+        intermediate_size=32,
+        num_heads=4,
+        in_channels=3,
+        patch_size=2,
+        temporal_patch_size=2,
+        spatial_merge_size=2,
+        out_hidden_size=8,
+        num_position_embeddings=16,
+        deepstack_visual_indexes=[0],
+    )
+
+
+def test_vision_encoder_loads_standalone_hf_tower_and_returns_deepstack(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    config = _tiny_vision_config()
+    checkpoint = tmp_path / "vision_encoder"
+    checkpoint.mkdir()
+    reference = Qwen3VLVisionModel(config)
+    save_file(reference.state_dict(), checkpoint / "model.safetensors")
+
+    monkeypatch.setattr(
+        vision_encoder,
+        "load_hf_config",
+        lambda *args, **kwargs: SimpleNamespace(vision_config=config),
+    )
+    monkeypatch.setattr(
+        vision_encoder,
+        "resolve_vision_encoder_path",
+        lambda model_path, revision=None: str(checkpoint),
+    )
+    encoder = Cosmos3VisionEncoder(
+        "unused-model",
+        device="cpu",
+        dtype="float32",
+    )
+    output = encoder(
+        pixel_values=torch.randn(4, 24),
+        image_grid_thw=torch.tensor([[1, 2, 2]]),
+    )
+
+    assert output["image_embeds"].shape == (1, 8)
+    assert output["image_token_counts"].tolist() == [1]
+    assert len(output["deepstack_visual_embeds_image"]) == 1
+    assert output["deepstack_visual_embeds_image"][0].shape == (1, 8)
+    assert hasattr(encoder.visual.patch_embed, "linear")

--- a/tests/unit_test/cosmos3/test_vision_encoder_scheduler.py
+++ b/tests/unit_test/cosmos3/test_vision_encoder_scheduler.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+
+from sglang_omni.models.cosmos3 import vision_encoder_scheduler
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.scheduling.stage_cache import StageOutputCache
+
+
+class _FakeVisionModel:
+    spatial_merge_size = 2
+    out_hidden_size = 4
+    deepstack_layers = 1
+    visual_dtype_bytes = 4
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, **inputs):
+        self.calls += 1
+        grid = inputs["image_grid_thw"]
+        token_count = grid.prod(-1) // 4
+        total = int(token_count.sum().item())
+        embeds = torch.arange(total * 4, dtype=torch.float32).reshape(total, 4)
+        return {
+            "image_embeds": embeds,
+            "image_grid_thw": grid,
+            "image_token_counts": token_count,
+            "deepstack_visual_embeds_image": [embeds + 1],
+        }
+
+
+def _vision_payload(request_id: str, cache_key: str) -> StagePayload:
+    state = Cosmos3PipelineState(
+        encoder_inputs={
+            "vision_encoder": {
+                "pixel_values": torch.ones((4, 6)),
+                "image_grid_thw": torch.tensor([[1, 2, 2]]),
+                "cache_key": cache_key,
+            }
+        }
+    )
+    return StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs=None),
+        data=state.to_dict(),
+    )
+
+
+def test_vision_encoder_batches_and_deduplicates_same_cache_key() -> None:
+    model = _FakeVisionModel()
+    cache = StageOutputCache(max_size=4, cache_device="cpu")
+    outputs = vision_encoder_scheduler._batch_vision_requests(
+        [
+            _vision_payload("first", "same-image"),
+            _vision_payload("second", "same-image"),
+        ],
+        model=model,
+        cache=cache,
+    )
+
+    assert model.calls == 1
+    assert len(cache) == 1
+    first = Cosmos3PipelineState.from_dict(outputs[0].data)
+    second = Cosmos3PipelineState.from_dict(outputs[1].data)
+    assert torch.equal(
+        first.encoder_outs["vision_encoder"]["image_embeds"],
+        second.encoder_outs["vision_encoder"]["image_embeds"],
+    )

--- a/tests/unit_test/cosmos3/test_vision_encoder_scheduler.py
+++ b/tests/unit_test/cosmos3/test_vision_encoder_scheduler.py
@@ -39,7 +39,7 @@ def _vision_payload(request_id: str, cache_key: str) -> StagePayload:
             "vision_encoder": {
                 "pixel_values": torch.ones((4, 6)),
                 "image_grid_thw": torch.tensor([[1, 2, 2]]),
-                "cache_key": cache_key,
+                "image_cache_key": cache_key,
             }
         }
     )


### PR DESCRIPTION
Scope

- Extend the Nano thinker path from text-only generation to image/video input.
- Keep the vision tower in its own `vision_encoder` stage; diffusion
  infrastructure, GEN, and generation-side codecs/adapters remain out of scope.
- Preserve the Stack 1 text-only path and native thinker tensor parallelism.

## Architecture

- The checkpoint embeds `Qwen3VLVisionConfig` (`model_type=qwen3_vl_vision`).
- The corresponding HF class is `Qwen3VLVisionModel`; the standalone weights
  live in `vision_encoder/model.safetensors`.
- Nano returns one 4096-wide visual embedding plus three 4096-wide deepstack
  features captured at vision layers 8, 16, and 24.

## Pipeline

```text
preprocessing ─┬─> vision_encoder ─┐
               └───────────────────┴─> thinker -> decode
```

- Text-only requests route directly from preprocessing to `thinker`.
- Image/video requests send only processor tensors to `vision_encoder`; the
  thinker receives a lightweight prompt latch and encoder outputs, then merges
  them at its input boundary.
- There is no communication-only aggregation stage. Encoder embeddings cross
  stage transport once and use its direct CUDA IPC path into the thinker.

## Qwen-Omni patterns retained

- Non-overlapping Conv3d patch projection is replaced with an equivalent Linear.
- Vision requests use cost-bounded micro-batching (32 requests / 10 GiB budget).
- A 64-entry, 4 GiB CPU LRU caches encoder outputs and deduplicates identical
  media within one batch.
- Media-derived placeholder ids make SGLang's radix cache reusable for repeated
  media without allowing two different images/videos to share visual KV.
- Main visual embeddings and deepstack residual embeddings are injected only
  during prefill; decode continues through the ordinary SGLang KV-cache path.

## Correctness details

- The Nano export records Transformers 4.57.6. The vision wrapper retains its
  positional-interpolation arithmetic instead of silently taking the changed
  Transformers 5.12 path in the current container.
- Multimodal positions follow Cosmos3's own `mm_token_type_ids` algorithm. Text
  fills all three T/H/W axes; image/video spans use their merged visual grids.
- Video cache keys include FPS, frame cap, and pixel budgets because these alter
  the encoder input and output.
- Audio input is rejected explicitly. Nano Reasoner support in this stack is
  text plus image/video; sound latents belong to the later generation pipeline.

## Validation

- `44` Cosmos3 unit tests cover conditional routing, preprocessing, weight
  loading, batching/cache deduplication, thinker-side merging, mRoPE, and
  deepstack injection. The combined Cosmos3, registry, CLI, and pipeline
  selection is `152` tests; the complete unit collection needs optional packages
  absent from this container (`jiwer`, `x_transformers`, and `onnxruntime`).
- The real Nano vision checkpoint loaded on one H200. A 256x256 image produced
  64 main embeddings of shape `[64, 4096]` and three deepstack tensors with the
  same shape.
- The four-stage server completed image-to-text generation: a brown test image
  returned `Brown`, a blue image returned `Blue`, and the text-only bypass still
  returned `OK`.
- Repeating the same image reused 84 of 85 prompt KV tokens. Changing the image
  reused only the four-token text prefix, confirming media cache isolation.
- Decode CUDA graph captured batches `[1, 2, 4, 8, 12, 16]`; a 96-token
  multimodal generation reported `cuda graph: True` during decode.

### Full MMMU image-text benchmark

A single full-set run was recorded on 2026-08-01 against commit `e9f098e0`.
The server used one H200, TP=1, the four colocated stages above, and the Nano
snapshot `411f42a8fdfb8c5b2583cb8786e0938f49796eaa`. The benchmark used all 900
image-bearing samples from the 30-subject `MMMU/MMMU` validation split at
dataset revision `98e6ac0cb9b7b2cd2c991b85a50762edc4aedc68`, five warmups,
concurrency 8, greedy decoding, and `max_tokens=2048`.

| Metric | Result |
|---|---:|
| Accuracy | 57.44% (517/900) |
| Failed requests | 0/900 |
| Multiple-choice parse fallbacks | 23 |
| Request throughput | 2.265 req/s |
| Mean / median latency | 3.520 / 2.481 s |
| P95 / P99 latency | 10.413 / 14.759 s |
| Output throughput | 977.6 tok/s |
| Mean output tokens | 432 |

This is one directional accuracy-and-serving run, not a repeated performance
study. The environment used SGLang 0.5.16, Transformers 5.12.1, PyTorch
2.11.0+cu130, CUDA 13.0, and NVIDIA driver 595.71.05. All requests completed,
and server logs continued to report decode CUDA-graph execution. The raw JSON
was retained at `/tmp/cosmos3-mmmu-results.7NaOoe/mmmu_results.json` with SHA256
`e101159dc11cba45d10132f7b46e06906072f60f704855e093aa0230ea1719ac`.

### Official SGLang comparison

The same 900-sample run was repeated against the official SGLang Cosmos3
Reasoner implementation in
[sglang#30536](https://github.com/sgl-project/sglang/pull/30536), pinned to PR
head `80b2296eabd55fad910cf0efc5732156b8192e84`. The dataset revision, sample
order, prompts, answer parser, five warmups, concurrency 8, greedy decoding, and
`max_tokens=2048` were unchanged. Only the wire-format adapter changed: Omni's
top-level `images` field became standard OpenAI `image_url` content parts for
the upstream server.

| Backend | Accuracy | Failed | MC parse fallback |
|---|---:|---:|---:|
| SGLang-Omni, four stages | 57.44% (517/900) | 0 | 23 |
| Official SGLang PR #30536 | 57.22% (515/900) | 0 | 28 |
