### PR TITLE
[ASR Refactor][M3] Extract shared pre-LM encoder service mechanics

### DIFF
--- a/sglang_omni/models/fun_asr/encoder_service.py
+++ b/sglang_omni/models/fun_asr/encoder_service.py
@@ -11,6 +11,7 @@ import logging
 import queue
 import threading
 import time
+from collections.abc import Iterator
 from typing import Any, cast
 
 import torch
@@ -136,7 +137,13 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
         with self._lifecycle_lock:
             if self._closed:
                 raise RuntimeError("Fun-ASR pre-LM encoder service is closed")
-            self._queue.put((item, future, time.perf_counter()))
+            self._queue.put(
+                QueueEntry(
+                    item=item,
+                    future=future,
+                    enqueued_at=time.perf_counter(),
+                )
+            )
 
     def encode_item(self, item: Any) -> None:
         """Block until ``item.precomputed_embeddings`` holds the LM embedding.
@@ -267,13 +274,11 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
 
     def _drain_batch(
         self,
-    ) -> tuple[list[tuple[Any, concurrent.futures.Future[torch.Tensor], float]], bool]:
+    ) -> tuple[list[QueueEntry[Any]], bool]:
         first = self._queue.get()
         if first is _SHUTDOWN:
             return [], True
-        batch = [
-            cast(tuple[Any, concurrent.futures.Future[torch.Tensor], float], first)
-        ]
+        batch = [cast(QueueEntry[Any], first)]
         deadline = time.monotonic() + self._max_batch_wait_s
         shutdown = False
         while len(batch) < self._max_batch_size:
@@ -289,23 +294,20 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
             if queued is _SHUTDOWN:
                 shutdown = True
                 break
-            batch.append(
-                cast(
-                    tuple[Any, concurrent.futures.Future[torch.Tensor], float],
-                    queued,
-                )
-            )
+            batch.append(cast(QueueEntry[Any], queued))
         return batch, shutdown
 
-    def _next_batch(self) -> tuple[list[QueueEntry], bool]:
+    def _next_batch(self) -> tuple[list[QueueEntry[Any]], bool]:
         return self._drain_batch()
 
-    def _batch_context(self) -> contextlib.AbstractContextManager[Any]:
-        stack = contextlib.ExitStack()
-        stack.enter_context(torch.inference_mode())
-        if self._stream is not None:
-            stack.enter_context(torch.cuda.stream(self._stream))
-        return stack
+    @contextlib.contextmanager
+    def _batch_context(self) -> Iterator[None]:
+        with torch.inference_mode():
+            if self._stream is None:
+                yield
+            else:
+                with torch.cuda.stream(self._stream):
+                    yield
 
     def encode_batch(self, items: list[Any]) -> torch.Tensor:
         return self._model.get_audio_feature(items)
@@ -346,7 +348,7 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
         if key is not None:
             self._cache.put(key, embedding)
 
-    def _retry_batch(self, batch: list[QueueEntry], _exc: Exception) -> bool:
+    def _retry_batch(self, batch: list[QueueEntry[Any]], _exc: Exception) -> bool:
         if len(batch) == 1:
             return False
         logger.exception(
@@ -355,9 +357,13 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
         )
         return True
 
-    def _on_batch_start(self, batch: list[QueueEntry]) -> None:
+    def _on_batch_start(self, batch: list[QueueEntry[Any]]) -> None:
         dequeue_time = time.perf_counter()
-        queue_waits = [dequeue_time - entry[2] for entry in batch]
+        queue_waits = [
+            dequeue_time - entry.enqueued_at
+            for entry in batch
+            if entry.enqueued_at is not None
+        ]
         with self._lock:
             self._queue_wait_count += len(queue_waits)
             self._queue_wait_total_s += sum(queue_waits)
@@ -368,7 +374,7 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
 
     def _on_batch_finished(
         self,
-        batch: list[QueueEntry],
+        batch: list[QueueEntry[Any]],
         batch_exc: Exception | None,
         retry_recovered: int | None,
         elapsed_s: float,

--- a/sglang_omni/models/fun_asr/encoder_service.py
+++ b/sglang_omni/models/fun_asr/encoder_service.py
@@ -16,6 +16,7 @@ from typing import Any, cast
 import torch
 from sglang.srt.managers.schedule_batch import MultimodalInputFormat
 
+from sglang_omni.scheduling.pre_lm_encoder import PreLMEncoderService, QueueEntry
 from sglang_omni.scheduling.stage_cache import StageOutputCache
 
 logger = logging.getLogger(__name__)
@@ -69,7 +70,7 @@ def _expected_audio_tokens(item: Any) -> int | None:
     return int(num_tokens) if num_tokens is not None else None
 
 
-class FunASRPreLMEncoderService:
+class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Tensor]):
     """Encode before admission with single-flight deduplication and a CPU LRU."""
 
     ENCODE_TIMEOUT_S = 300.0
@@ -102,7 +103,6 @@ class FunASRPreLMEncoderService:
         self._namespace = cache_namespace
         self._max_batch_size = max(int(max_batch_size), 1)
         self._max_batch_wait_s = max(float(max_batch_wait_ms), 0.0) / 1000.0
-        self._queue: queue.Queue[Any] = queue.Queue()
         self._lock = threading.Lock()
         self._lifecycle_lock = threading.Lock()
         self._closed = False
@@ -117,10 +117,7 @@ class FunASRPreLMEncoderService:
         self._queue_wait_total_s = 0.0
         self._queue_wait_max_s = 0.0
         self._encoder_time_s = 0.0
-        self._thread = threading.Thread(
-            target=self._worker, name="fun-asr-audio-encode", daemon=True
-        )
-        self._thread.start()
+        super().__init__(worker_name="fun-asr-audio-encode")
 
     def close(self) -> None:
         """Stop the encoder worker after all queued requests finish."""
@@ -156,10 +153,7 @@ class FunASRPreLMEncoderService:
         key = self._cache_key(item)
 
         if key is None:
-            future: concurrent.futures.Future[torch.Tensor] = (
-                concurrent.futures.Future()
-            )
-            self._enqueue(item, future)
+            future = self._submit(item)
             future.result(timeout=self.ENCODE_TIMEOUT_S)
             return
 
@@ -168,7 +162,7 @@ class FunASRPreLMEncoderService:
             if self._is_valid(cached, expected_tokens):
                 with self._lock:
                     self._hits += 1
-                self._attach(item, cached)
+                self.attach_embedding(item, cached)
                 return
             logger.warning(
                 f"Fun-ASR pre-LM cache entry {key} failed validation "
@@ -194,14 +188,14 @@ class FunASRPreLMEncoderService:
                     leader = True
                     self._misses += 1
                     try:
-                        self._enqueue(item, future)
+                        self._submit(item, future)
                     except Exception:
                         del self._inflight[key]
                         raise
             else:
                 self._merged += 1
         if cached is not None:
-            self._attach(item, cached)
+            self.attach_embedding(item, cached)
             return
         try:
             embedding = future.result(timeout=self.ENCODE_TIMEOUT_S)
@@ -223,7 +217,7 @@ class FunASRPreLMEncoderService:
                 f"Fun-ASR pre-LM encode leader for {key} returned an invalid "
                 f"embedding"
             )
-        self._attach(item, embedding)
+        self.attach_embedding(item, embedding)
 
     def stats(self) -> dict[str, int | float]:
         with self._lock:
@@ -266,7 +260,7 @@ class FunASRPreLMEncoderService:
             and embedding.dtype == self._dtype
         )
 
-    def _attach(self, item: Any, embedding: torch.Tensor) -> None:
+    def attach_embedding(self, item: Any, embedding: torch.Tensor) -> None:
         item.precomputed_embeddings = embedding.to(self._device, non_blocking=True)
         item.feature = None
         item.format = MultimodalInputFormat.PRECOMPUTED_EMBEDDING
@@ -303,107 +297,101 @@ class FunASRPreLMEncoderService:
             )
         return batch, shutdown
 
-    def _worker(self) -> None:
-        while True:
-            batch, shutdown = self._drain_batch()
-            if not batch:
-                return
-            dequeue_time = time.perf_counter()
-            queue_waits = [dequeue_time - enqueued_at for _, _, enqueued_at in batch]
-            with self._lock:
-                self._queue_wait_count += len(queue_waits)
-                self._queue_wait_total_s += sum(queue_waits)
-                self._queue_wait_max_s = max(
-                    self._queue_wait_max_s, max(queue_waits, default=0.0)
-                )
-            items = [item for item, _, _ in batch]
-            encode_start = time.perf_counter()
-            try:
-                embeddings = self._encode_batch(items)
-            except Exception as batch_exc:
-                if len(batch) == 1:
-                    batch[0][1].set_exception(batch_exc)
-                    with self._lock:
-                        self._encoder_time_s += time.perf_counter() - encode_start
-                    if shutdown:
-                        return
-                    continue
-                logger.exception(
-                    f"Fun-ASR batched audio encode failed for {len(items)} "
-                    f"items; retrying per item"
-                )
-                recovered = 0
-                for item, future, _ in batch:
-                    try:
-                        embedding = self._encode_batch([item])[0]
-                        future.set_result(embedding)
-                        recovered += 1
-                    except Exception as item_exc:
-                        future.set_exception(item_exc)
-                with self._lock:
-                    self._encoder_time_s += time.perf_counter() - encode_start
-                    # Note (Akazaakane): Retried items are single-item batches.
-                    self._batch_count += recovered
-                    self._item_count += recovered
-                if shutdown:
-                    return
-                continue
-            for (_, future, _), embedding in zip(batch, embeddings):
-                future.set_result(embedding)
-            with self._lock:
-                self._encoder_time_s += time.perf_counter() - encode_start
-                self._batch_count += 1
-                self._item_count += len(items)
-                batch_count = self._batch_count
-                item_count = self._item_count
-            if batch_count % 50 == 1:
-                logger.info(
-                    f"Fun-ASR pre-LM encoder stage: {batch_count} batches, "
-                    f"{item_count} items (avg "
-                    f"{item_count / batch_count:.2f} items/batch, "
-                    f"last batch: {len(items)}), cache: {self.stats()}"
-                )
-            if shutdown:
-                return
+    def _next_batch(self) -> tuple[list[QueueEntry], bool]:
+        return self._drain_batch()
 
-    def _encode_batch(self, items: list[Any]) -> list[torch.Tensor]:
-        stream_context = (
-            torch.cuda.stream(self._stream)
-            if self._stream is not None
-            else contextlib.nullcontext()
-        )
-        with torch.inference_mode(), stream_context:
-            embedding = self._model.get_audio_feature(items)
-            token_counts = []
-            for item in items:
-                expected = _expected_audio_tokens(item)
-                if expected is None:
-                    raise RuntimeError(
-                        "Fun-ASR pre-LM encode item is missing its audio token count"
-                    )
-                token_counts.append(expected)
-            if (
-                embedding.dim() != 2
-                or embedding.shape[0] != sum(token_counts)
-                or embedding.shape[1] != self._hidden_size
-                or embedding.dtype != self._dtype
-            ):
+    def _batch_context(self) -> contextlib.AbstractContextManager[Any]:
+        stack = contextlib.ExitStack()
+        stack.enter_context(torch.inference_mode())
+        if self._stream is not None:
+            stack.enter_context(torch.cuda.stream(self._stream))
+        return stack
+
+    def encode_batch(self, items: list[Any]) -> torch.Tensor:
+        return self._model.get_audio_feature(items)
+
+    def split_embeddings(
+        self,
+        items: list[Any],
+        embedding: torch.Tensor,
+    ) -> list[torch.Tensor]:
+        token_counts = []
+        for item in items:
+            expected = _expected_audio_tokens(item)
+            if expected is None:
                 raise RuntimeError(
-                    f"Fun-ASR encoder output {tuple(embedding.shape)} "
-                    f"({embedding.dtype}) != expected rows "
-                    f"{sum(token_counts)}x{self._hidden_size} ({self._dtype})"
+                    "Fun-ASR pre-LM encode item is missing its audio token count"
                 )
-            parts = torch.split(embedding, token_counts, dim=0)
-            embeddings = [part.clone() for part in parts]
-            for item, part in zip(items, embeddings):
-                self._attach(item, part)
+            token_counts.append(expected)
+        if (
+            embedding.dim() != 2
+            or embedding.shape[0] != sum(token_counts)
+            or embedding.shape[1] != self._hidden_size
+            or embedding.dtype != self._dtype
+        ):
+            raise RuntimeError(
+                f"Fun-ASR encoder output {tuple(embedding.shape)} "
+                f"({embedding.dtype}) != expected rows "
+                f"{sum(token_counts)}x{self._hidden_size} ({self._dtype})"
+            )
+        parts = torch.split(embedding, token_counts, dim=0)
+        return [part.clone() for part in parts]
+
+    def synchronize_batch(self) -> None:
         if self._stream is not None:
             self._stream.synchronize()
-        for item, part in zip(items, embeddings):
-            key = self._cache_key(item)
-            if key is not None:
-                self._cache.put(key, part)
-        return embeddings
+
+    def cache_embedding(self, item: Any, embedding: torch.Tensor) -> None:
+        key = self._cache_key(item)
+        if key is not None:
+            self._cache.put(key, embedding)
+
+    def _retry_batch(self, batch: list[QueueEntry], _exc: Exception) -> bool:
+        if len(batch) == 1:
+            return False
+        logger.exception(
+            f"Fun-ASR batched audio encode failed for {len(batch)} "
+            f"items; retrying per item"
+        )
+        return True
+
+    def _on_batch_start(self, batch: list[QueueEntry]) -> None:
+        dequeue_time = time.perf_counter()
+        queue_waits = [dequeue_time - entry[2] for entry in batch]
+        with self._lock:
+            self._queue_wait_count += len(queue_waits)
+            self._queue_wait_total_s += sum(queue_waits)
+            self._queue_wait_max_s = max(
+                self._queue_wait_max_s,
+                max(queue_waits, default=0.0),
+            )
+
+    def _on_batch_finished(
+        self,
+        batch: list[QueueEntry],
+        batch_exc: Exception | None,
+        retry_recovered: int | None,
+        elapsed_s: float,
+    ) -> None:
+        with self._lock:
+            self._encoder_time_s += elapsed_s
+            if batch_exc is not None:
+                if retry_recovered is not None:
+                    # Note (Akazaakane): Retried items are single-item batches.
+                    self._batch_count += retry_recovered
+                    self._item_count += retry_recovered
+                return
+            self._batch_count += 1
+            self._item_count += len(batch)
+            batch_count = self._batch_count
+            item_count = self._item_count
+        if batch_count % 50 == 1:
+            logger.info(
+                f"Fun-ASR pre-LM encoder stage: {batch_count} batches, "
+                f"{item_count} items (avg "
+                f"{item_count / batch_count:.2f} items/batch, "
+                f"last batch: {len(batch)}), cache: {self.stats()}"
+            )
 
 
 __all__ = [

--- a/sglang_omni/models/fun_asr/stages.py
+++ b/sglang_omni/models/fun_asr/stages.py
@@ -55,7 +55,7 @@ def _compile_fun_asr_audio_encoder(
     compile cost at startup instead of on the first request; Dynamo guards on
     grad mode, so the warmup must run in the same mode as the serving caller —
     ``torch.inference_mode`` for the pre-LM encoder service
-    (``_encode_batch``), ambient mode for inline prefill on the scheduler
+    (``_batch_context``), ambient mode for inline prefill on the scheduler
     loop.
     """
     import contextlib

--- a/sglang_omni/models/moss_transcribe_diarize/encoder_service.py
+++ b/sglang_omni/models/moss_transcribe_diarize/encoder_service.py
@@ -10,13 +10,8 @@ from __future__ import annotations
 import contextlib
 import logging
 import queue
-
-<<<<<<< HEAD
 import traceback
 from dataclasses import dataclass
-
-=======
->>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
 from typing import Any
 
 import torch
@@ -30,15 +25,12 @@ _CACHE_MAX_ENTRIES = 4096
 _CACHE_MAX_BYTES = 2 * 1024**3
 
 
-<<<<<<< HEAD
 @dataclass(frozen=True)
 class _DetachedFailure:
     exception: Exception
     formatted_traceback: str
 
 
-=======
->>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
 class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Tensor]):
     ENCODE_TIMEOUT_S = 300.0
 
@@ -110,12 +102,9 @@ class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Te
         item.precomputed_embeddings = embedding
         item.feature = None
 
-<<<<<<< HEAD
     def attach_before_synchronize(self) -> bool:
         return False
 
-=======
->>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
     def synchronize_batch(self) -> None:
         self._stream.synchronize()
 
@@ -123,7 +112,6 @@ class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Te
         if item.hash is not None:
             self._cache.put(str(item.hash), embedding)
 
-<<<<<<< HEAD
     def _handle_batch_failure(
         self,
         batch: list[QueueEntry[Any]],
@@ -160,14 +148,6 @@ class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Te
 
     def _retry_batch(self, batch: list[QueueEntry[Any]], _exc: Exception) -> bool:
         return len(batch) > 1
-=======
-    def _retry_batch(self, _batch: list[QueueEntry[Any]], _exc: Exception) -> bool:
-        logger.exception(
-            f"MOSS-TD batched audio encode failed for {len(_batch)} "
-            f"items; retrying per item"
-        )
-        return True
->>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
 
     def _future_result(self, _embedding: torch.Tensor) -> None:
         return None
@@ -176,7 +156,6 @@ class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Te
         self,
         batch: list[QueueEntry[Any]],
         batch_exc: Exception | None,
-<<<<<<< HEAD
         retry_recovered: int | None,
         _elapsed_s: float,
     ) -> None:
@@ -223,23 +202,10 @@ class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Te
     def _record_success(self, item_count: int) -> None:
         self._batch_count += 1
         self._item_count += item_count
-=======
-        _retry_recovered: int | None,
-        _elapsed_s: float,
-    ) -> None:
-        if batch_exc is not None:
-            return
-        self._batch_count += 1
-        self._item_count += len(batch)
->>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
         if self._batch_count % 50 == 1:
             logger.info(
                 f"MOSS-TD pre-LM encoder stage: {self._batch_count} batches, "
                 f"{self._item_count} items (avg "
                 f"{self._item_count / self._batch_count:.2f} items/batch, "
-<<<<<<< HEAD
                 f"last batch: {item_count})"
-=======
-                f"last batch: {len(batch)})"
->>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
             )

--- a/sglang_omni/models/moss_transcribe_diarize/encoder_service.py
+++ b/sglang_omni/models/moss_transcribe_diarize/encoder_service.py
@@ -7,16 +7,16 @@ compute-bound encoder overlap the memory-bound decode on the same GPU.
 
 from __future__ import annotations
 
-import concurrent.futures
+import contextlib
 import logging
 import queue
-import threading
 import traceback
 from dataclasses import dataclass
 from typing import Any
 
 import torch
 
+from sglang_omni.scheduling.pre_lm_encoder import PreLMEncoderService, QueueEntry
 from sglang_omni.scheduling.stage_cache import StageOutputCache
 
 logger = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ class _DetachedFailure:
     formatted_traceback: str
 
 
-class BatchedAudioEncoderService:
+class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Tensor]):
     ENCODE_TIMEOUT_S = 300.0
 
     def __init__(self, model: Any, *, max_batch_size: int = 2) -> None:
@@ -46,13 +46,9 @@ class BatchedAudioEncoderService:
             max_bytes=_CACHE_MAX_BYTES,
             cache_device="cpu",
         )
-        self._queue: queue.Queue[tuple[Any, concurrent.futures.Future]] = queue.Queue()
         self._batch_count = 0
         self._item_count = 0
-        self._thread = threading.Thread(
-            target=self._worker, name="moss-td-audio-encode", daemon=True
-        )
-        self._thread.start()
+        super().__init__(worker_name="moss-td-audio-encode")
 
     def encode_item(self, item: Any) -> None:
         """Blocks until item.precomputed_embeddings is attached."""
@@ -61,14 +57,12 @@ class BatchedAudioEncoderService:
         else:
             cached = None
         if cached is not None:
-            item.precomputed_embeddings = cached.to(self._device, non_blocking=True)
-            item.feature = None
+            self.attach_embedding(item, cached.to(self._device, non_blocking=True))
             return
-        future: concurrent.futures.Future = concurrent.futures.Future()
-        self._queue.put((item, future))
+        future = self._submit(item)
         future.result(timeout=self.ENCODE_TIMEOUT_S)
 
-    def _drain_batch(self) -> list[tuple[Any, concurrent.futures.Future]]:
+    def _drain_batch(self) -> list[QueueEntry]:
         # note (yichi): never wait — a window costs 8~16ms at low concurrency, buys <=5ms at high.
         batch = [self._queue.get()]
         for _ in range(self._max_batch_size - 1):
@@ -78,54 +72,94 @@ class BatchedAudioEncoderService:
                 break
         return batch
 
-    def _worker(self) -> None:
-        while True:
-            self._process_batch(self._drain_batch())
+    def _next_batch(self) -> tuple[list[QueueEntry], bool]:
+        return self._drain_batch(), False
 
-    def _process_batch(
-        self, batch: list[tuple[Any, concurrent.futures.Future]]
-    ) -> None:
-        items = [item for item, _ in batch]
-        try:
-            self._encode_batch(items)
-        except Exception as batch_exc:
-            if len(batch) == 1:
-                failure = self._detach_failure(batch_exc)
-                logger.error(
-                    "MOSS-TD audio encode failed:\n%s",
-                    failure.formatted_traceback,
-                )
-                self._recover_after_failure(failure.exception)
-                batch[0][1].set_exception(failure.exception)
-                return
+    def _batch_context(self) -> contextlib.AbstractContextManager[Any]:
+        return torch.cuda.stream(self._stream)
 
-            failure = self._detach_failure(batch_exc)
+    def encode_batch(self, items: list[Any]) -> torch.Tensor:
+        return self._model._get_audio_feature_uncached(items, None)
+
+    def split_embeddings(
+        self,
+        items: list[Any],
+        embedding: torch.Tensor,
+    ) -> list[torch.Tensor]:
+        token_counts = [
+            int(getattr(item, "audio_feature_lengths").sum()) for item in items
+        ]
+        if embedding.shape[0] != sum(token_counts):
+            raise RuntimeError(
+                f"encoder output rows {embedding.shape[0]} != expected "
+                f"{sum(token_counts)}"
+            )
+        return [
+            part.contiguous() for part in torch.split(embedding, token_counts, dim=0)
+        ]
+
+    def attach_embedding(self, item: Any, embedding: torch.Tensor) -> None:
+        item.precomputed_embeddings = embedding
+        item.feature = None
+
+    def attach_before_synchronize(self) -> bool:
+        return False
+
+    def synchronize_batch(self) -> None:
+        self._stream.synchronize()
+
+    def cache_embedding(self, item: Any, embedding: torch.Tensor) -> None:
+        if item.hash is not None:
+            self._cache.put(str(item.hash), embedding)
+
+    def _handle_batch_failure(
+        self,
+        batch: list[QueueEntry],
+        exc: Exception,
+    ) -> Exception:
+        failure = self._detach_failure(exc)
+        if len(batch) == 1:
+            logger.error(
+                "MOSS-TD audio encode failed:\n%s",
+                failure.formatted_traceback,
+            )
+        else:
             logger.error(
                 "MOSS-TD batched audio encode failed for %d items; "
                 "retrying per item:\n%s",
-                len(items),
+                len(batch),
                 failure.formatted_traceback,
             )
-            self._recover_after_failure(failure.exception)
-            for item, future in batch:
-                try:
-                    self._encode_batch([item])
-                except Exception as item_exc:
-                    failure = self._detach_failure(item_exc)
-                    logger.error(
-                        "MOSS-TD per-item audio encode retry failed:\n%s",
-                        failure.formatted_traceback,
-                    )
-                    self._recover_after_failure(failure.exception)
-                    future.set_exception(failure.exception)
-                else:
-                    self._record_success(1)
-                    future.set_result(None)
-            return
+        self._recover_after_failure(failure.exception)
+        return failure.exception
 
-        self._record_success(len(items))
-        for _, future in batch:
-            future.set_result(None)
+    def _handle_item_failure(self, entry: QueueEntry, exc: Exception) -> Exception:
+        failure = self._detach_failure(exc)
+        logger.error(
+            "MOSS-TD per-item audio encode retry failed:\n%s",
+            failure.formatted_traceback,
+        )
+        self._recover_after_failure(failure.exception)
+        return failure.exception
+
+    def _retry_batch(self, batch: list[QueueEntry], _exc: Exception) -> bool:
+        return len(batch) > 1
+
+    def _future_result(self, _embedding: torch.Tensor) -> None:
+        return None
+
+    def _on_batch_finished(
+        self,
+        batch: list[QueueEntry],
+        batch_exc: Exception | None,
+        retry_recovered: int | None,
+        _elapsed_s: float,
+    ) -> None:
+        if batch_exc is None:
+            self._record_success(len(batch))
+            return
+        for _ in range(retry_recovered or 0):
+            self._record_success(1)
 
     @staticmethod
     def _detach_failure(exc: Exception) -> _DetachedFailure:
@@ -171,26 +205,3 @@ class BatchedAudioEncoderService:
                 f"{self._item_count / self._batch_count:.2f} items/batch, "
                 f"last batch: {item_count})"
             )
-
-    def _encode_batch(self, items: list[Any]) -> None:
-        with torch.cuda.stream(self._stream):
-            embedding = self._model._get_audio_feature_uncached(items, None)
-            token_counts = [
-                int(getattr(item, "audio_feature_lengths").sum()) for item in items
-            ]
-            if embedding.shape[0] != sum(token_counts):
-                raise RuntimeError(
-                    f"encoder output rows {embedding.shape[0]} != expected "
-                    f"{sum(token_counts)}"
-                )
-            parts = tuple(
-                part.contiguous()
-                for part in torch.split(embedding, token_counts, dim=0)
-            )
-        self._stream.synchronize()
-        for item, part in zip(items, parts):
-            item.precomputed_embeddings = part
-            item.feature = None
-        for item in items:
-            if item.hash is not None:
-                self._cache.put(str(item.hash), item.precomputed_embeddings)

--- a/sglang_omni/models/moss_transcribe_diarize/encoder_service.py
+++ b/sglang_omni/models/moss_transcribe_diarize/encoder_service.py
@@ -10,8 +10,13 @@ from __future__ import annotations
 import contextlib
 import logging
 import queue
+
+<<<<<<< HEAD
 import traceback
 from dataclasses import dataclass
+
+=======
+>>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
 from typing import Any
 
 import torch
@@ -25,12 +30,15 @@ _CACHE_MAX_ENTRIES = 4096
 _CACHE_MAX_BYTES = 2 * 1024**3
 
 
+<<<<<<< HEAD
 @dataclass(frozen=True)
 class _DetachedFailure:
     exception: Exception
     formatted_traceback: str
 
 
+=======
+>>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
 class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Tensor]):
     ENCODE_TIMEOUT_S = 300.0
 
@@ -62,7 +70,7 @@ class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Te
         future = self._submit(item)
         future.result(timeout=self.ENCODE_TIMEOUT_S)
 
-    def _drain_batch(self) -> list[QueueEntry]:
+    def _drain_batch(self) -> list[QueueEntry[Any]]:
         # note (yichi): never wait — a window costs 8~16ms at low concurrency, buys <=5ms at high.
         batch = [self._queue.get()]
         for _ in range(self._max_batch_size - 1):
@@ -72,7 +80,7 @@ class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Te
                 break
         return batch
 
-    def _next_batch(self) -> tuple[list[QueueEntry], bool]:
+    def _next_batch(self) -> tuple[list[QueueEntry[Any]], bool]:
         return self._drain_batch(), False
 
     def _batch_context(self) -> contextlib.AbstractContextManager[Any]:
@@ -102,9 +110,12 @@ class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Te
         item.precomputed_embeddings = embedding
         item.feature = None
 
+<<<<<<< HEAD
     def attach_before_synchronize(self) -> bool:
         return False
 
+=======
+>>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
     def synchronize_batch(self) -> None:
         self._stream.synchronize()
 
@@ -112,9 +123,10 @@ class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Te
         if item.hash is not None:
             self._cache.put(str(item.hash), embedding)
 
+<<<<<<< HEAD
     def _handle_batch_failure(
         self,
-        batch: list[QueueEntry],
+        batch: list[QueueEntry[Any]],
         exc: Exception,
     ) -> Exception:
         failure = self._detach_failure(exc)
@@ -133,7 +145,11 @@ class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Te
         self._recover_after_failure(failure.exception)
         return failure.exception
 
-    def _handle_item_failure(self, entry: QueueEntry, exc: Exception) -> Exception:
+    def _handle_item_failure(
+        self,
+        _entry: QueueEntry[Any],
+        exc: Exception,
+    ) -> Exception:
         failure = self._detach_failure(exc)
         logger.error(
             "MOSS-TD per-item audio encode retry failed:\n%s",
@@ -142,16 +158,25 @@ class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Te
         self._recover_after_failure(failure.exception)
         return failure.exception
 
-    def _retry_batch(self, batch: list[QueueEntry], _exc: Exception) -> bool:
+    def _retry_batch(self, batch: list[QueueEntry[Any]], _exc: Exception) -> bool:
         return len(batch) > 1
+=======
+    def _retry_batch(self, _batch: list[QueueEntry[Any]], _exc: Exception) -> bool:
+        logger.exception(
+            f"MOSS-TD batched audio encode failed for {len(_batch)} "
+            f"items; retrying per item"
+        )
+        return True
+>>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
 
     def _future_result(self, _embedding: torch.Tensor) -> None:
         return None
 
     def _on_batch_finished(
         self,
-        batch: list[QueueEntry],
+        batch: list[QueueEntry[Any]],
         batch_exc: Exception | None,
+<<<<<<< HEAD
         retry_recovered: int | None,
         _elapsed_s: float,
     ) -> None:
@@ -198,10 +223,23 @@ class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Te
     def _record_success(self, item_count: int) -> None:
         self._batch_count += 1
         self._item_count += item_count
+=======
+        _retry_recovered: int | None,
+        _elapsed_s: float,
+    ) -> None:
+        if batch_exc is not None:
+            return
+        self._batch_count += 1
+        self._item_count += len(batch)
+>>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
         if self._batch_count % 50 == 1:
             logger.info(
                 f"MOSS-TD pre-LM encoder stage: {self._batch_count} batches, "
                 f"{self._item_count} items (avg "
                 f"{self._item_count / self._batch_count:.2f} items/batch, "
+<<<<<<< HEAD
                 f"last batch: {item_count})"
+=======
+                f"last batch: {len(batch)})"
+>>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
             )

--- a/sglang_omni/scheduling/pre_lm_encoder.py
+++ b/sglang_omni/scheduling/pre_lm_encoder.py
@@ -87,12 +87,9 @@ class PreLMEncoderService(ABC, Generic[ItemT, EncodedT, EmbeddingT]):
     def attach_embedding(self, item: ItemT, embedding: EmbeddingT) -> None:
         raise NotImplementedError
 
-<<<<<<< HEAD
     def attach_before_synchronize(self) -> bool:
         return True
 
-=======
->>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
     def synchronize_batch(self) -> None:
         pass
 
@@ -100,10 +97,7 @@ class PreLMEncoderService(ABC, Generic[ItemT, EncodedT, EmbeddingT]):
         pass
 
     def _execute_batch(self, items: list[ItemT]) -> list[EmbeddingT]:
-<<<<<<< HEAD
         attach_before_synchronize = self.attach_before_synchronize()
-=======
->>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
         with self._batch_context():
             encoded = self.encode_batch(items)
             embeddings = self.split_embeddings(items, encoded)
@@ -112,7 +106,6 @@ class PreLMEncoderService(ABC, Generic[ItemT, EncodedT, EmbeddingT]):
                     f"split_embeddings returned {len(embeddings)} embeddings "
                     f"for {len(items)} items"
                 )
-<<<<<<< HEAD
             if attach_before_synchronize:
                 for item, embedding in zip(items, embeddings):
                     self.attach_embedding(item, embedding)
@@ -120,16 +113,10 @@ class PreLMEncoderService(ABC, Generic[ItemT, EncodedT, EmbeddingT]):
         if not attach_before_synchronize:
             for item, embedding in zip(items, embeddings):
                 self.attach_embedding(item, embedding)
-=======
-            for item, embedding in zip(items, embeddings):
-                self.attach_embedding(item, embedding)
-        self.synchronize_batch()
->>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
         for item, embedding in zip(items, embeddings):
             self.cache_embedding(item, embedding)
         return embeddings
 
-<<<<<<< HEAD
     def _handle_batch_failure(
         self,
         batch: list[QueueEntry[ItemT]],
@@ -149,9 +136,6 @@ class PreLMEncoderService(ABC, Generic[ItemT, EncodedT, EmbeddingT]):
         batch: list[QueueEntry[ItemT]],
         exc: Exception,
     ) -> bool:
-=======
-    def _retry_batch(self, batch: list[QueueEntry[ItemT]], exc: Exception) -> bool:
->>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
         return False
 
     def _future_result(self, embedding: EmbeddingT) -> Any:
@@ -243,10 +227,7 @@ class PreLMEncoderService(ABC, Generic[ItemT, EncodedT, EmbeddingT]):
                 try:
                     embeddings = self._execute_batch(items)
                 except Exception as batch_exc:
-<<<<<<< HEAD
                     batch_exc = self._handle_batch_failure(batch, batch_exc)
-=======
->>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
                     if not self._retry_batch(batch, batch_exc):
                         for entry in batch:
                             self._set_exception(entry, batch_exc)
@@ -267,10 +248,7 @@ class PreLMEncoderService(ABC, Generic[ItemT, EncodedT, EmbeddingT]):
                             self._set_result(entry, embedding)
                             recovered += 1
                         except Exception as item_exc:
-<<<<<<< HEAD
                             item_exc = self._handle_item_failure(entry, item_exc)
-=======
->>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
                             self._set_exception(entry, item_exc)
                     self._notify_batch_finished(
                         batch,

--- a/sglang_omni/scheduling/pre_lm_encoder.py
+++ b/sglang_omni/scheduling/pre_lm_encoder.py
@@ -5,24 +5,36 @@ from __future__ import annotations
 
 import concurrent.futures
 import contextlib
+import logging
 import queue
 import threading
 import time
+from abc import ABC, abstractmethod
 from contextlib import AbstractContextManager
+from dataclasses import dataclass
 from typing import Any, Generic, TypeVar
 
 ItemT = TypeVar("ItemT")
 EncodedT = TypeVar("EncodedT")
 EmbeddingT = TypeVar("EmbeddingT")
 
-QueueEntry = tuple[Any, ...]
+logger = logging.getLogger(__name__)
 
 
-class PreLMEncoderService(Generic[ItemT, EncodedT, EmbeddingT]):
+@dataclass(slots=True)
+class QueueEntry(Generic[ItemT]):
+    item: ItemT
+    future: concurrent.futures.Future[Any]
+    enqueued_at: float | None = None
+
+
+class PreLMEncoderService(ABC, Generic[ItemT, EncodedT, EmbeddingT]):
     """Run model-owned encoder hooks on a queue-backed worker thread."""
 
     def __init__(self, *, worker_name: str) -> None:
         self._queue: queue.Queue[Any] = queue.Queue()
+        self._worker_state_lock = threading.Lock()
+        self._worker_error: Exception | None = None
         self._thread = threading.Thread(
             target=self._worker,
             name=worker_name,
@@ -35,7 +47,7 @@ class PreLMEncoderService(Generic[ItemT, EncodedT, EmbeddingT]):
         item: ItemT,
         future: concurrent.futures.Future[Any],
     ) -> None:
-        self._queue.put((item, future))
+        self._queue.put(QueueEntry(item=item, future=future))
 
     def _submit(
         self,
@@ -44,18 +56,26 @@ class PreLMEncoderService(Generic[ItemT, EncodedT, EmbeddingT]):
     ) -> concurrent.futures.Future[Any]:
         if future is None:
             future = concurrent.futures.Future()
-        self._enqueue(item, future)
+        with self._worker_state_lock:
+            if self._worker_error is not None:
+                raise RuntimeError(
+                    "pre-LM encoder worker has failed"
+                ) from self._worker_error
+            self._enqueue(item, future)
         return future
 
-    def _next_batch(self) -> tuple[list[QueueEntry], bool]:
+    @abstractmethod
+    def _next_batch(self) -> tuple[list[QueueEntry[ItemT]], bool]:
         raise NotImplementedError
 
     def _batch_context(self) -> AbstractContextManager[Any]:
         return contextlib.nullcontext()
 
+    @abstractmethod
     def encode_batch(self, items: list[ItemT]) -> EncodedT:
         raise NotImplementedError
 
+    @abstractmethod
     def split_embeddings(
         self,
         items: list[ItemT],
@@ -63,23 +83,36 @@ class PreLMEncoderService(Generic[ItemT, EncodedT, EmbeddingT]):
     ) -> list[EmbeddingT]:
         raise NotImplementedError
 
+    @abstractmethod
     def attach_embedding(self, item: ItemT, embedding: EmbeddingT) -> None:
         raise NotImplementedError
 
+<<<<<<< HEAD
+    def attach_before_synchronize(self) -> bool:
+        return True
+
+=======
+>>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
     def synchronize_batch(self) -> None:
         pass
 
     def cache_embedding(self, item: ItemT, embedding: EmbeddingT) -> None:
         pass
 
-    def attach_before_synchronize(self) -> bool:
-        return True
-
     def _execute_batch(self, items: list[ItemT]) -> list[EmbeddingT]:
+<<<<<<< HEAD
         attach_before_synchronize = self.attach_before_synchronize()
+=======
+>>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
         with self._batch_context():
             encoded = self.encode_batch(items)
             embeddings = self.split_embeddings(items, encoded)
+            if len(embeddings) != len(items):
+                raise RuntimeError(
+                    f"split_embeddings returned {len(embeddings)} embeddings "
+                    f"for {len(items)} items"
+                )
+<<<<<<< HEAD
             if attach_before_synchronize:
                 for item, embedding in zip(items, embeddings):
                     self.attach_embedding(item, embedding)
@@ -87,90 +120,182 @@ class PreLMEncoderService(Generic[ItemT, EncodedT, EmbeddingT]):
         if not attach_before_synchronize:
             for item, embedding in zip(items, embeddings):
                 self.attach_embedding(item, embedding)
+=======
+            for item, embedding in zip(items, embeddings):
+                self.attach_embedding(item, embedding)
+        self.synchronize_batch()
+>>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
         for item, embedding in zip(items, embeddings):
             self.cache_embedding(item, embedding)
         return embeddings
 
+<<<<<<< HEAD
     def _handle_batch_failure(
         self,
-        batch: list[QueueEntry],
+        batch: list[QueueEntry[ItemT]],
         exc: Exception,
     ) -> Exception:
         return exc
 
-    def _handle_item_failure(self, entry: QueueEntry, exc: Exception) -> Exception:
+    def _handle_item_failure(
+        self,
+        entry: QueueEntry[ItemT],
+        exc: Exception,
+    ) -> Exception:
         return exc
 
-    def _retry_batch(self, batch: list[QueueEntry], exc: Exception) -> bool:
+    def _retry_batch(
+        self,
+        batch: list[QueueEntry[ItemT]],
+        exc: Exception,
+    ) -> bool:
+=======
+    def _retry_batch(self, batch: list[QueueEntry[ItemT]], exc: Exception) -> bool:
+>>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
         return False
 
     def _future_result(self, embedding: EmbeddingT) -> Any:
         return embedding
 
-    def _on_batch_start(self, batch: list[QueueEntry]) -> None:
+    def _on_batch_start(self, batch: list[QueueEntry[ItemT]]) -> None:
         pass
 
     def _on_batch_finished(
         self,
-        batch: list[QueueEntry],
+        batch: list[QueueEntry[ItemT]],
         batch_exc: Exception | None,
         retry_recovered: int | None,
         elapsed_s: float,
     ) -> None:
         pass
 
-    def _worker(self) -> None:
-        while True:
-            batch, shutdown = self._next_batch()
-            if not batch:
-                return
+    @staticmethod
+    def _set_exception(entry: QueueEntry[ItemT], exc: Exception) -> None:
+        if entry.future.done():
+            return
+        try:
+            entry.future.set_exception(exc)
+        except concurrent.futures.InvalidStateError:
+            logger.warning("pre-LM encoder future completed before exception dispatch")
+
+    def _set_result(self, entry: QueueEntry[ItemT], embedding: EmbeddingT) -> None:
+        if entry.future.done():
+            return
+        try:
+            result = self._future_result(embedding)
+            entry.future.set_result(result)
+        except concurrent.futures.InvalidStateError:
+            logger.warning("pre-LM encoder future completed before result dispatch")
+        except Exception as exc:
+            self._set_exception(entry, exc)
+
+    def _notify_batch_start(self, batch: list[QueueEntry[ItemT]]) -> None:
+        try:
             self._on_batch_start(batch)
-            items = [entry[0] for entry in batch]
-            encode_start = time.perf_counter()
-            try:
-                embeddings = self._execute_batch(items)
-            except Exception as batch_exc:
-                batch_exc = self._handle_batch_failure(batch, batch_exc)
-                if not self._retry_batch(batch, batch_exc):
+        except Exception:
+            logger.exception("pre-LM encoder batch-start hook failed")
+
+    def _notify_batch_finished(
+        self,
+        batch: list[QueueEntry[ItemT]],
+        batch_exc: Exception | None,
+        retry_recovered: int | None,
+        elapsed_s: float,
+    ) -> None:
+        try:
+            self._on_batch_finished(
+                batch,
+                batch_exc,
+                retry_recovered,
+                elapsed_s,
+            )
+        except Exception:
+            logger.exception("pre-LM encoder batch-finished hook failed")
+
+    def _fail_worker(
+        self,
+        exc: Exception,
+        current_batch: list[QueueEntry[ItemT]],
+    ) -> None:
+        with self._worker_state_lock:
+            self._worker_error = exc
+            pending = list(current_batch)
+            while True:
+                try:
+                    queued = self._queue.get_nowait()
+                except queue.Empty:
+                    break
+                if isinstance(queued, QueueEntry):
+                    pending.append(queued)
+        for entry in pending:
+            self._set_exception(entry, exc)
+
+    def _worker(self) -> None:
+        batch: list[QueueEntry[ItemT]] = []
+        try:
+            while True:
+                batch, shutdown = self._next_batch()
+                if not batch:
+                    return
+                self._notify_batch_start(batch)
+                items = [entry.item for entry in batch]
+                encode_start = time.perf_counter()
+                try:
+                    embeddings = self._execute_batch(items)
+                except Exception as batch_exc:
+<<<<<<< HEAD
+                    batch_exc = self._handle_batch_failure(batch, batch_exc)
+=======
+>>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
+                    if not self._retry_batch(batch, batch_exc):
+                        for entry in batch:
+                            self._set_exception(entry, batch_exc)
+                        self._notify_batch_finished(
+                            batch,
+                            batch_exc,
+                            None,
+                            time.perf_counter() - encode_start,
+                        )
+                        if shutdown:
+                            return
+                        batch = []
+                        continue
+                    recovered = 0
                     for entry in batch:
-                        entry[1].set_exception(batch_exc)
-                    self._on_batch_finished(
+                        try:
+                            embedding = self._execute_batch([entry.item])[0]
+                            self._set_result(entry, embedding)
+                            recovered += 1
+                        except Exception as item_exc:
+<<<<<<< HEAD
+                            item_exc = self._handle_item_failure(entry, item_exc)
+=======
+>>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
+                            self._set_exception(entry, item_exc)
+                    self._notify_batch_finished(
                         batch,
                         batch_exc,
-                        None,
+                        recovered,
                         time.perf_counter() - encode_start,
                     )
                     if shutdown:
                         return
+                    batch = []
                     continue
-                recovered = 0
-                for entry in batch:
-                    try:
-                        embedding = self._execute_batch([entry[0]])[0]
-                        entry[1].set_result(self._future_result(embedding))
-                        recovered += 1
-                    except Exception as item_exc:
-                        item_exc = self._handle_item_failure(entry, item_exc)
-                        entry[1].set_exception(item_exc)
-                self._on_batch_finished(
+                for entry, embedding in zip(batch, embeddings):
+                    self._set_result(entry, embedding)
+                self._notify_batch_finished(
                     batch,
-                    batch_exc,
-                    recovered,
+                    None,
+                    None,
                     time.perf_counter() - encode_start,
                 )
                 if shutdown:
                     return
-                continue
-            for entry, embedding in zip(batch, embeddings):
-                entry[1].set_result(self._future_result(embedding))
-            self._on_batch_finished(
-                batch,
-                None,
-                None,
-                time.perf_counter() - encode_start,
-            )
-            if shutdown:
-                return
+                batch = []
+        except Exception as worker_exc:
+            logger.exception("pre-LM encoder worker failed")
+            self._fail_worker(worker_exc, batch)
 
 
 __all__ = ["PreLMEncoderService", "QueueEntry"]

--- a/sglang_omni/scheduling/pre_lm_encoder.py
+++ b/sglang_omni/scheduling/pre_lm_encoder.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared mechanics for pre-LM encoder services."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import contextlib
+import queue
+import threading
+import time
+from contextlib import AbstractContextManager
+from typing import Any, Generic, TypeVar
+
+ItemT = TypeVar("ItemT")
+EncodedT = TypeVar("EncodedT")
+EmbeddingT = TypeVar("EmbeddingT")
+
+QueueEntry = tuple[Any, ...]
+
+
+class PreLMEncoderService(Generic[ItemT, EncodedT, EmbeddingT]):
+    """Run model-owned encoder hooks on a queue-backed worker thread."""
+
+    def __init__(self, *, worker_name: str) -> None:
+        self._queue: queue.Queue[Any] = queue.Queue()
+        self._thread = threading.Thread(
+            target=self._worker,
+            name=worker_name,
+            daemon=True,
+        )
+        self._thread.start()
+
+    def _enqueue(
+        self,
+        item: ItemT,
+        future: concurrent.futures.Future[Any],
+    ) -> None:
+        self._queue.put((item, future))
+
+    def _submit(
+        self,
+        item: ItemT,
+        future: concurrent.futures.Future[Any] | None = None,
+    ) -> concurrent.futures.Future[Any]:
+        if future is None:
+            future = concurrent.futures.Future()
+        self._enqueue(item, future)
+        return future
+
+    def _next_batch(self) -> tuple[list[QueueEntry], bool]:
+        raise NotImplementedError
+
+    def _batch_context(self) -> AbstractContextManager[Any]:
+        return contextlib.nullcontext()
+
+    def encode_batch(self, items: list[ItemT]) -> EncodedT:
+        raise NotImplementedError
+
+    def split_embeddings(
+        self,
+        items: list[ItemT],
+        encoded: EncodedT,
+    ) -> list[EmbeddingT]:
+        raise NotImplementedError
+
+    def attach_embedding(self, item: ItemT, embedding: EmbeddingT) -> None:
+        raise NotImplementedError
+
+    def synchronize_batch(self) -> None:
+        pass
+
+    def cache_embedding(self, item: ItemT, embedding: EmbeddingT) -> None:
+        pass
+
+    def attach_before_synchronize(self) -> bool:
+        return True
+
+    def _execute_batch(self, items: list[ItemT]) -> list[EmbeddingT]:
+        attach_before_synchronize = self.attach_before_synchronize()
+        with self._batch_context():
+            encoded = self.encode_batch(items)
+            embeddings = self.split_embeddings(items, encoded)
+            if attach_before_synchronize:
+                for item, embedding in zip(items, embeddings):
+                    self.attach_embedding(item, embedding)
+        self.synchronize_batch()
+        if not attach_before_synchronize:
+            for item, embedding in zip(items, embeddings):
+                self.attach_embedding(item, embedding)
+        for item, embedding in zip(items, embeddings):
+            self.cache_embedding(item, embedding)
+        return embeddings
+
+    def _handle_batch_failure(
+        self,
+        batch: list[QueueEntry],
+        exc: Exception,
+    ) -> Exception:
+        return exc
+
+    def _handle_item_failure(self, entry: QueueEntry, exc: Exception) -> Exception:
+        return exc
+
+    def _retry_batch(self, batch: list[QueueEntry], exc: Exception) -> bool:
+        return False
+
+    def _future_result(self, embedding: EmbeddingT) -> Any:
+        return embedding
+
+    def _on_batch_start(self, batch: list[QueueEntry]) -> None:
+        pass
+
+    def _on_batch_finished(
+        self,
+        batch: list[QueueEntry],
+        batch_exc: Exception | None,
+        retry_recovered: int | None,
+        elapsed_s: float,
+    ) -> None:
+        pass
+
+    def _worker(self) -> None:
+        while True:
+            batch, shutdown = self._next_batch()
+            if not batch:
+                return
+            self._on_batch_start(batch)
+            items = [entry[0] for entry in batch]
+            encode_start = time.perf_counter()
+            try:
+                embeddings = self._execute_batch(items)
+            except Exception as batch_exc:
+                batch_exc = self._handle_batch_failure(batch, batch_exc)
+                if not self._retry_batch(batch, batch_exc):
+                    for entry in batch:
+                        entry[1].set_exception(batch_exc)
+                    self._on_batch_finished(
+                        batch,
+                        batch_exc,
+                        None,
+                        time.perf_counter() - encode_start,
+                    )
+                    if shutdown:
+                        return
+                    continue
+                recovered = 0
+                for entry in batch:
+                    try:
+                        embedding = self._execute_batch([entry[0]])[0]
+                        entry[1].set_result(self._future_result(embedding))
+                        recovered += 1
+                    except Exception as item_exc:
+                        item_exc = self._handle_item_failure(entry, item_exc)
+                        entry[1].set_exception(item_exc)
+                self._on_batch_finished(
+                    batch,
+                    batch_exc,
+                    recovered,
+                    time.perf_counter() - encode_start,
+                )
+                if shutdown:
+                    return
+                continue
+            for entry, embedding in zip(batch, embeddings):
+                entry[1].set_result(self._future_result(embedding))
+            self._on_batch_finished(
+                batch,
+                None,
+                None,
+                time.perf_counter() - encode_start,
+            )
+            if shutdown:
+                return
+
+
+__all__ = ["PreLMEncoderService", "QueueEntry"]

--- a/tests/unit_test/fun_asr/test_encoder_service.py
+++ b/tests/unit_test/fun_asr/test_encoder_service.py
@@ -125,6 +125,24 @@ def test_close_stops_worker() -> None:
     assert not service._thread.is_alive()
 
 
+def test_batch_context_unwinds_inference_mode_when_stream_context_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = object.__new__(FunASRPreLMEncoderService)
+    service._stream = object()
+
+    def fail_stream(_stream):  # noqa: ANN001, ANN202
+        raise RuntimeError("stream context failed")
+
+    monkeypatch.setattr(torch.cuda, "stream", fail_stream)
+
+    assert not torch.is_inference_mode_enabled()
+    with pytest.raises(RuntimeError, match="stream context failed"):
+        with service._batch_context():
+            pass
+    assert not torch.is_inference_mode_enabled()
+
+
 def test_cache_hit_skips_reencode() -> None:
     model = _StubModel()
     service = _make_service(model)

--- a/tests/unit_test/moss_transcribe_diarize/test_encoder_service.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_encoder_service.py
@@ -4,10 +4,18 @@ from __future__ import annotations
 
 import concurrent.futures
 import contextlib
+
+<<<<<<< HEAD
 import gc
 import queue
 import threading
 import weakref
+
+=======
+import queue
+import threading
+
+>>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
 from types import SimpleNamespace
 
 import pytest
@@ -17,6 +25,8 @@ from sglang_omni.models.moss_transcribe_diarize import encoder_service
 from sglang_omni.models.moss_transcribe_diarize.encoder_service import (
     BatchedAudioEncoderService,
 )
+from sglang_omni.scheduling.pre_lm_encoder import QueueEntry
+from sglang_omni.scheduling.stage_cache import StageOutputCache
 
 
 def test_drain_batch_respects_gpu_microbatch_limit() -> None:
@@ -24,7 +34,7 @@ def test_drain_batch_respects_gpu_microbatch_limit() -> None:
     service._max_batch_size = 2
     service._queue = queue.Queue()
     entries = [
-        (object(), concurrent.futures.Future())
+        QueueEntry(object(), concurrent.futures.Future())
         for _ in range(service._max_batch_size + 2)
     ]
     for entry in entries:
@@ -39,6 +49,7 @@ def test_encoder_microbatch_limit_must_be_positive() -> None:
         BatchedAudioEncoderService(object(), max_batch_size=0)
 
 
+<<<<<<< HEAD
 class _FailingStream:
     def synchronize(self) -> None:
         raise torch.OutOfMemoryError("test encoder OOM")
@@ -76,7 +87,7 @@ def test_encode_batch_commits_item_state_only_after_stream_success(
     ]
 
     with pytest.raises(torch.OutOfMemoryError, match="test encoder OOM"):
-        service._encode_batch(items)
+        service._execute_batch(items)
 
     for item, feature in zip(items, features):
         assert item.feature is feature
@@ -90,6 +101,8 @@ def test_singleton_oom_is_request_scoped_and_worker_processes_next_item(
     service = object.__new__(BatchedAudioEncoderService)
     service._max_batch_size = 1
     service._queue = queue.Queue()
+    service._worker_state_lock = threading.Lock()
+    service._worker_error = None
     service._batch_count = 0
     service._item_count = 0
     service._device = "cuda:7"
@@ -102,7 +115,7 @@ def test_singleton_oom_is_request_scoped_and_worker_processes_next_item(
     healthy_item = SimpleNamespace(hash=None, feature=object())
     stop_item = object()
 
-    def _encode_batch(items: list[object]) -> None:
+    def _execute_batch(items: list[object]) -> list[object]:
         nonlocal poisoned
         if items == [stop_item]:
             raise _StopWorker
@@ -116,6 +129,7 @@ def test_singleton_oom_is_request_scoped_and_worker_processes_next_item(
             raise RuntimeError("allocator remained poisoned after OOM")
         items[0].precomputed_embeddings = object()
         items[0].feature = None
+        return [items[0].precomputed_embeddings]
 
     def _cuda_device(device: str) -> contextlib.AbstractContextManager:
         selected_devices.append(device)
@@ -129,7 +143,7 @@ def test_singleton_oom_is_request_scoped_and_worker_processes_next_item(
     service._stream = SimpleNamespace(
         synchronize=lambda: cleanup_steps.append("synchronize")
     )
-    monkeypatch.setattr(service, "_encode_batch", _encode_batch)
+    monkeypatch.setattr(service, "_execute_batch", _execute_batch)
     monkeypatch.setattr(encoder_service.torch.cuda, "device", _cuda_device)
     monkeypatch.setattr(encoder_service.torch.cuda, "empty_cache", _empty_cache)
 
@@ -147,7 +161,7 @@ def test_singleton_oom_is_request_scoped_and_worker_processes_next_item(
             service.encode_item(failed_item)
         service.encode_item(healthy_item)
     finally:
-        service._queue.put((stop_item, concurrent.futures.Future()))
+        service._queue.put(QueueEntry(stop_item, concurrent.futures.Future()))
         service._thread.join(timeout=1)
 
     gc.collect()
@@ -172,6 +186,8 @@ def test_batched_oom_falls_back_to_per_item_encoding(
     service = object.__new__(BatchedAudioEncoderService)
     service._batch_count = 0
     service._item_count = 0
+    service._worker_state_lock = threading.Lock()
+    service._worker_error = None
     service._device = "cuda:5"
     cleanup_steps: list[str] = []
     selected_devices: list[str] = []
@@ -182,7 +198,7 @@ def test_batched_oom_falls_back_to_per_item_encoding(
     calls: list[list[object]] = []
     items = [object(), object()]
 
-    def _encode_batch(batch: list[object]) -> None:
+    def _execute_batch(batch: list[object]) -> list[object]:
         nonlocal poisoned
         calls.append(batch)
         if len(batch) > 1:
@@ -190,6 +206,7 @@ def test_batched_oom_falls_back_to_per_item_encoding(
             raise torch.OutOfMemoryError("aggregate batch is too large")
         if poisoned:
             raise RuntimeError("allocator remained poisoned after OOM")
+        return [object()]
 
     def _cuda_device(device: str) -> contextlib.AbstractContextManager:
         selected_devices.append(device)
@@ -200,14 +217,16 @@ def test_batched_oom_falls_back_to_per_item_encoding(
         cleanup_steps.append("empty_cache")
         poisoned = False
 
-    monkeypatch.setattr(service, "_encode_batch", _encode_batch)
+    monkeypatch.setattr(service, "_execute_batch", _execute_batch)
     monkeypatch.setattr(encoder_service.torch.cuda, "device", _cuda_device)
     monkeypatch.setattr(encoder_service.torch.cuda, "empty_cache", _empty_cache)
-    futures = [concurrent.futures.Future(), concurrent.futures.Future()]
+    entries = [QueueEntry(item, concurrent.futures.Future()) for item in items]
+    batches = iter([(entries, False), ([], True)])
+    service._next_batch = lambda: next(batches)
 
-    service._process_batch(list(zip(items, futures)))
+    service._worker()
 
-    assert [future.result() for future in futures] == [None, None]
+    assert [entry.future.result() for entry in entries] == [None, None]
     assert calls == [items, [items[0]], [items[1]]]
     assert service._batch_count == 2
     assert cleanup_steps == ["synchronize", "empty_cache"]
@@ -220,19 +239,23 @@ def test_non_oom_failure_logs_traceback_without_retaining_exception_state(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     service = object.__new__(BatchedAudioEncoderService)
+    service._worker_state_lock = threading.Lock()
+    service._worker_error = None
     retained_intermediates: list[weakref.ReferenceType[_EncoderIntermediate]] = []
 
-    def _raise_non_oom_encoder_failure(_items: list[object]) -> None:
+    def _raise_non_oom_encoder_failure(_items: list[object]) -> list[object]:
         intermediate = _EncoderIntermediate()
         retained_intermediates.append(weakref.ref(intermediate))
         raise ValueError("unexpected encoder shape")
 
-    monkeypatch.setattr(service, "_encode_batch", _raise_non_oom_encoder_failure)
-    future: concurrent.futures.Future = concurrent.futures.Future()
+    monkeypatch.setattr(service, "_execute_batch", _raise_non_oom_encoder_failure)
+    entry = QueueEntry(object(), concurrent.futures.Future())
+    batches = iter([([entry], False), ([], True)])
+    service._next_batch = lambda: next(batches)
 
-    service._process_batch([(object(), future)])
+    service._worker()
 
-    failure = future.exception()
+    failure = entry.future.exception()
     assert isinstance(failure, ValueError)
     assert failure.__traceback__ is None
     assert failure.__cause__ is None
@@ -249,3 +272,72 @@ def test_non_oom_failure_logs_traceback_without_retaining_exception_state(
         not any(isinstance(arg, BaseException) for arg in record.args)
         for record in caplog.records
     )
+
+
+=======
+>>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
+def test_cache_hit_attaches_embedding_without_submitting() -> None:
+    service = object.__new__(BatchedAudioEncoderService)
+    service._device = torch.device("cpu")
+    service._cache = StageOutputCache(max_size=4, max_bytes=1024, cache_device="cpu")
+    cached = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    service._cache.put("7", cached)
+    item = SimpleNamespace(hash=7, feature=object(), precomputed_embeddings=None)
+
+    service.encode_item(item)
+
+    assert torch.equal(item.precomputed_embeddings, cached)
+    assert item.feature is None
+
+
+def test_batch_failure_retries_moss_items_with_failure_isolation() -> None:
+    service = object.__new__(BatchedAudioEncoderService)
+    service._batch_count = 0
+    service._item_count = 0
+    service._worker_state_lock = threading.Lock()
+    service._worker_error = None
+    service._cache = StageOutputCache(max_size=4, max_bytes=1024, cache_device="cpu")
+    synchronized: list[None] = []
+    service._stream = SimpleNamespace(synchronize=lambda: synchronized.append(None))
+
+    good = SimpleNamespace(
+        hash=1,
+        audio_feature_lengths=torch.tensor([2]),
+        feature=object(),
+        precomputed_embeddings=None,
+        fail=False,
+    )
+    bad = SimpleNamespace(
+        hash=2,
+        audio_feature_lengths=torch.tensor([1]),
+        feature=object(),
+        precomputed_embeddings=None,
+        fail=True,
+    )
+
+    def encode(items, _unused):  # noqa: ANN001, ANN202
+        if len(items) > 1:
+            raise RuntimeError("batch failed")
+        if items[0].fail:
+            raise RuntimeError("item failed")
+        rows = int(items[0].audio_feature_lengths.sum())
+        return torch.ones(rows, 3)
+
+    service._model = SimpleNamespace(_get_audio_feature_uncached=encode)
+    service._batch_context = contextlib.nullcontext
+    good_entry = QueueEntry(good, concurrent.futures.Future())
+    bad_entry = QueueEntry(bad, concurrent.futures.Future())
+    batches = iter([([good_entry, bad_entry], False), ([], True)])
+    service._next_batch = lambda: next(batches)
+
+    service._worker()
+
+    assert good_entry.future.result(timeout=0) is None
+    with pytest.raises(RuntimeError, match="item failed"):
+        bad_entry.future.result(timeout=0)
+    assert good.precomputed_embeddings.shape == (2, 3)
+    assert good.feature is None
+    assert bad.precomputed_embeddings is None
+    assert torch.equal(service._cache.get("1"), good.precomputed_embeddings)
+    assert service._cache.get("2") is None
+    assert len(synchronized) == 1

--- a/tests/unit_test/moss_transcribe_diarize/test_encoder_service.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_encoder_service.py
@@ -4,18 +4,10 @@ from __future__ import annotations
 
 import concurrent.futures
 import contextlib
-
-<<<<<<< HEAD
 import gc
 import queue
 import threading
 import weakref
-
-=======
-import queue
-import threading
-
->>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
 from types import SimpleNamespace
 
 import pytest
@@ -49,7 +41,6 @@ def test_encoder_microbatch_limit_must_be_positive() -> None:
         BatchedAudioEncoderService(object(), max_batch_size=0)
 
 
-<<<<<<< HEAD
 class _FailingStream:
     def synchronize(self) -> None:
         raise torch.OutOfMemoryError("test encoder OOM")
@@ -274,8 +265,6 @@ def test_non_oom_failure_logs_traceback_without_retaining_exception_state(
     )
 
 
-=======
->>>>>>> 0b0d2902f7085e37d5fb0954a0b5a521dd15dc3c
 def test_cache_hit_attaches_embedding_without_submitting() -> None:
     service = object.__new__(BatchedAudioEncoderService)
     service._device = torch.device("cpu")

--- a/tests/unit_test/scheduling/test_pre_lm_encoder.py
+++ b/tests/unit_test/scheduling/test_pre_lm_encoder.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import contextlib
+import queue
+import threading
+from collections.abc import Iterator
+
+import pytest
+
+from sglang_omni.scheduling.pre_lm_encoder import PreLMEncoderService, QueueEntry
+
+_STOP = object()
+
+
+class _Service(PreLMEncoderService[int, list[int], int]):
+    def __init__(self, *, controlled_drain: bool = False) -> None:
+        self.attachments: list[tuple[int, int]] = []
+        self.cached: list[tuple[int, int]] = []
+        self.context_events: list[str] = []
+        self.fail_multi = False
+        self.fail_items: set[int] = set()
+        self.retry = False
+        self.retry_hook_error = False
+        self.start_hook_error = False
+        self.split_mode = "exact"
+        self.drain_gate = threading.Event() if controlled_drain else None
+        super().__init__(worker_name="test-pre-lm-encoder")
+
+    def close(self) -> None:
+        if self._thread.is_alive():
+            self._queue.put(_STOP)
+            self._thread.join(timeout=2)
+
+    def _next_batch(self) -> tuple[list[QueueEntry[int]], bool]:
+        first = self._queue.get()
+        if first is _STOP:
+            return [], True
+        if self.drain_gate is not None:
+            assert self.drain_gate.wait(timeout=2)
+        batch = [first]
+        while True:
+            try:
+                batch.append(self._queue.get_nowait())
+            except queue.Empty:
+                break
+        return batch, False
+
+    @contextlib.contextmanager
+    def _batch_context(self) -> Iterator[None]:
+        self.context_events.append("enter")
+        try:
+            yield
+        finally:
+            self.context_events.append("exit")
+
+    def encode_batch(self, items: list[int]) -> list[int]:
+        if self.fail_multi and len(items) > 1:
+            raise RuntimeError("batch encode failed")
+        if any(item in self.fail_items for item in items):
+            raise RuntimeError("item encode failed")
+        return [item * 2 for item in items]
+
+    def split_embeddings(self, items: list[int], encoded: list[int]) -> list[int]:
+        if self.split_mode == "too_few":
+            return encoded[:-1]
+        if self.split_mode == "too_many":
+            return [*encoded, -1]
+        return encoded
+
+    def attach_embedding(self, item: int, embedding: int) -> None:
+        self.attachments.append((item, embedding))
+
+    def cache_embedding(self, item: int, embedding: int) -> None:
+        self.cached.append((item, embedding))
+
+    def _retry_batch(self, batch, exc):  # noqa: ANN001, ANN202
+        if self.retry_hook_error:
+            raise RuntimeError("retry policy failed")
+        return self.retry
+
+    def _on_batch_start(self, batch):  # noqa: ANN001, ANN202
+        if self.start_hook_error:
+            raise RuntimeError("start hook failed")
+
+
+def test_successful_dispatch_attaches_and_caches() -> None:
+    service = _Service()
+    try:
+        future = service._submit(3)
+
+        assert future.result(timeout=2) == 6
+        assert service.attachments == [(3, 6)]
+        assert service.cached == [(3, 6)]
+    finally:
+        service.close()
+
+
+def test_batch_failure_recovers_each_item() -> None:
+    service = _Service(controlled_drain=True)
+    service.fail_multi = True
+    service.retry = True
+    try:
+        first = service._submit(1)
+        second = service._submit(2)
+        service.drain_gate.set()
+
+        assert first.result(timeout=2) == 2
+        assert second.result(timeout=2) == 4
+    finally:
+        service.close()
+
+
+@pytest.mark.parametrize("split_mode", ["too_few", "too_many"])
+def test_wrong_embedding_cardinality_fails_future(split_mode: str) -> None:
+    service = _Service()
+    service.split_mode = split_mode
+    try:
+        future = service._submit(1)
+
+        with pytest.raises(RuntimeError, match="split_embeddings returned"):
+            future.result(timeout=2)
+        assert service.context_events == ["enter", "exit"]
+    finally:
+        service.close()
+
+
+def test_statistics_hook_failure_does_not_kill_worker() -> None:
+    service = _Service()
+    service.start_hook_error = True
+    try:
+        assert service._submit(1).result(timeout=2) == 2
+        service.start_hook_error = False
+        assert service._submit(2).result(timeout=2) == 4
+    finally:
+        service.close()
+
+
+def test_fatal_policy_failure_completes_current_future_and_rejects_submits() -> None:
+    service = _Service(controlled_drain=True)
+    service.fail_items.add(1)
+    service.retry_hook_error = True
+    first = service._submit(1)
+    second = service._submit(2)
+    service.drain_gate.set()
+
+    with pytest.raises(RuntimeError, match="retry policy failed"):
+        first.result(timeout=2)
+    with pytest.raises(RuntimeError, match="retry policy failed"):
+        second.result(timeout=2)
+    with pytest.raises(RuntimeError, match="worker has failed"):
+        service._submit(3)
+
+    service.close()


### PR DESCRIPTION
Add a generic PreLMEncoderService (sglang_omni/scheduling/pre_lm_encoder.py) that centralizes queue/worker/batching mechanics. Refactor FunASR and MOSS-TD encoder services to subclass this base and implement hooks (encode_batch, split_embeddings, attach_embedding, cache_embedding, _batch_context, etc.). Remove duplicated per-service thread/queue code and adapt logging, retry, and caching flows to the new lifecycle. This refactor preserves existing behavior while reducing duplication and clarifying responsibilities for pre-LM audio encoding stages.

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues

Closes #1270 
Part of #1267 

## Accuracy Test

Unit Test Passed.

## Benchmark & Profiling

1*h200 gpu

| Model | Concurrency | Revision | Run | Wall (s) | Throughput (req/s) | RTFx | Mean Latency (s) | p95 Latency (s) | p99 Latency (s) | Mean RTF | p95 RTF | WER | Success |
|---|---:|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| **FunASR** | 32 | Base | 1 | 8.2966 | 131.138 | 621.083 | 0.2432 | 0.3247 | 0.3991 | 0.05267 | 0.0730 | 0.01710 | 1088/1088 |
| **FunASR** | 32 | Base | 2 | 8.0231 | 135.609 | 642.258 | 0.2344 | 0.3469 | 0.3835 | 0.05084 | 0.0715 | 0.01710 | 1088/1088 |
| **FunASR** | 32 | Base | 3 | 8.0755 | 134.729 | 638.089 | 0.2366 | 0.3353 | 0.3930 | 0.05125 | 0.0714 | 0.01710 | 1088/1088 |
| **FunASR** | 32 | Base Mean | — | 8.1317 | 133.825 | 633.810 | 0.2381 | 0.3356 | 0.3919 | 0.05159 | 0.0720 | 0.01710 | 3264/3264 |
| **FunASR** | 32 | PR | 1 | 8.1904 | 132.839 | 629.139 | 0.2396 | 0.3280 | 0.4102 | 0.05206 | 0.0737 | 0.01710 | 1088/1088 |
| **FunASR** | 32 | PR | 2 | 8.2074 | 132.563 | 627.832 | 0.2401 | 0.3275 | 0.4370 | 0.05198 | 0.0719 | 0.01710 | 1088/1088 |
| **FunASR** | 32 | PR | 3 | 8.0931 | 134.435 | 636.698 | 0.2369 | 0.3280 | 0.3712 | 0.05137 | 0.0705 | 0.01710 | 1088/1088 |
| **FunASR** | 32 | PR Mean | — | 8.1636 | 133.279 | 631.223 | 0.2389 | 0.3278 | 0.4061 | 0.05181 | 0.0720 | 0.01710 | 3264/3264 |
| **MOSS-TD** | 16 | Base | 1 | 11.4914 | 94.679 | 448.411 | 0.1680 | 0.2124 | 0.2587 | 0.03668 | 0.0505 | 0.01824 | 1088/1088 |
| **MOSS-TD** | 16 | Base | 2 | 11.4564 | 94.969 | 449.781 | 0.1678 | 0.2149 | 0.2511 | 0.03662 | 0.0502 | 0.01831 | 1088/1088 |
| **MOSS-TD** | 16 | Base | 3 | 11.4711 | 94.847 | 449.204 | 0.1681 | 0.2156 | 0.2539 | 0.03669 | 0.0517 | 0.01831 | 1088/1088 |
| **MOSS-TD** | 16 | Base Mean | — | 11.4730 | 94.832 | 449.132 | 0.1680 | 0.2143 | 0.2546 | 0.03666 | 0.0508 | 0.01829 | 3264/3264 |
| **MOSS-TD** | 16 | PR | 1 | 11.1064 | 97.961 | 463.954 | 0.1628 | 0.2034 | 0.2315 | 0.03558 | 0.0480 | 0.01831 | 1088/1088 |
| **MOSS-TD** | 16 | PR | 2 | 11.0198 | 98.732 | 467.603 | 0.1613 | 0.2092 | 0.2305 | 0.03526 | 0.0484 | 0.01824 | 1088/1088 |
| **MOSS-TD** | 16 | PR | 3 | 11.2950 | 96.326 | 456.209 | 0.1655 | 0.2169 | 0.2426 | 0.03615 | 0.0505 | 0.01831 | 1088/1088 |
| **MOSS-TD** | 16 | PR Mean | — | 11.1404 | 97.673 | 462.589 | 0.1632 | 0.2098 | 0.2349 | 0.03566 | 0.0490 | 0.01829 | 3264/3264 |
| **MOSS-TD** | 32 | Base | 1 | 15.9884 | 68.049 | 322.288 | 0.4672 | 0.5383 | 0.5707 | 0.10231 | 0.1380 | 0.01831 | 1088/1088 |
| **MOSS-TD** | 32 | Base | 2 | 15.7405 | 69.121 | 327.365 | 0.4596 | 0.5327 | 0.5746 | 0.10070 | 0.1363 | 0.01831 | 1088/1088 |
| **MOSS-TD** | 32 | Base | 3 | 15.7459 | 69.097 | 327.252 | 0.4602 | 0.5341 | 0.5793 | 0.10077 | 0.1372 | 0.01831 | 1088/1088 |
| **MOSS-TD** | 32 | Base Mean | — | 15.8249 | 68.756 | 325.635 | 0.4623 | 0.5350 | 0.5749 | 0.10126 | 0.1372 | 0.01831 | 3264/3264 |
| **MOSS-TD** | 32 | PR | 1 | 15.6828 | 69.375 | 328.568 | 0.4579 | 0.5269 | 0.5718 | 0.10043 | 0.1369 | 0.01831 | 1088/1088 |
| **MOSS-TD** | 32 | PR | 2 | 16.3453 | 66.564 | 315.252 | 0.4775 | 0.5577 | 0.5886 | 0.10467 | 0.1421 | 0.01831 | 1088/1088 |
| **MOSS-TD** | 32 | PR | 3 | 15.9832 | 68.072 | 322.394 | 0.4670 | 0.5330 | 0.5720 | 0.10230 | 0.1398 | 0.01831 | 1088/1088 |
| **MOSS-TD** | 32 | PR Mean | — | 16.0038 | 68.003 | 322.071 | 0.4674 | 0.5392 | 0.5774 | 0.10247 | 0.1396 | 0.01831 | 3264/3264 |

## Per-repeat results

### FunASR base

| Conc. | Rep. | Wall (s) | Throughput (req/s) | RTFx | Mean latency (s) | p95 (s) | p99 (s) | Mean RTF | WER | Success |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 1 | 2.3311 | 21.449 | 98.545 | 0.0465 | 0.0641 | 0.0695 | 0.01036 | 0.01190 | 50/50 |
| 1 | 2 | 2.3004 | 21.735 | 99.857 | 0.0459 | 0.0631 | 0.0681 | 0.01021 | 0.01190 | 50/50 |
| 1 | 3 | 2.3249 | 21.506 | 98.805 | 0.0464 | 0.0635 | 0.0687 | 0.01033 | 0.01190 | 50/50 |
| 1 | 4 | 2.3407 | 21.361 | 98.140 | 0.0467 | 0.0637 | 0.0701 | 0.01039 | 0.01190 | 50/50 |
| 1 | 5 | 2.3629 | 21.160 | 97.216 | 0.0471 | 0.0645 | 0.0698 | 0.01050 | 0.01190 | 50/50 |
| 16 | 1 | 0.3902 | 128.126 | 588.650 | 0.1151 | 0.1742 | 0.2074 | 0.02539 | 0.01190 | 50/50 |
| 16 | 2 | 0.3944 | 126.764 | 582.390 | 0.1181 | 0.1750 | 0.1985 | 0.02621 | 0.01190 | 50/50 |
| 16 | 3 | 0.4239 | 117.954 | 541.915 | 0.1272 | 0.1925 | 0.2220 | 0.02823 | 0.01190 | 50/50 |
| 16 | 4 | 0.4052 | 123.390 | 566.890 | 0.1211 | 0.1871 | 0.2115 | 0.02681 | 0.01190 | 50/50 |
| 16 | 5 | 0.4024 | 124.249 | 570.839 | 0.1209 | 0.1856 | 0.2086 | 0.02676 | 0.01190 | 50/50 |
| 32 | 1 | 0.3285 | 152.227 | 699.378 | 0.1819 | 0.2873 | 0.2992 | 0.04032 | 0.01190 | 50/50 |
| 32 | 2 | 0.3261 | 153.329 | 704.439 | 0.1805 | 0.2852 | 0.2968 | 0.04001 | 0.01190 | 50/50 |
| 32 | 3 | 0.3231 | 154.751 | 710.974 | 0.1789 | 0.2821 | 0.2936 | 0.03966 | 0.01190 | 50/50 |
| 32 | 4 | 0.3128 | 159.861 | 734.452 | 0.1737 | 0.2715 | 0.2832 | 0.03850 | 0.01190 | 50/50 |
| 32 | 5 | 0.3119 | 160.328 | 736.597 | 0.1702 | 0.2695 | 0.2814 | 0.03782 | 0.01190 | 50/50 |

### FunASR PR

| Conc. | Rep. | Wall (s) | Throughput (req/s) | RTFx | Mean latency (s) | p95 (s) | p99 (s) | Mean RTF | WER | Success |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 1 | 2.4267 | 20.604 | 94.661 | 0.0483 | 0.0653 | 0.0709 | 0.01077 | 0.01190 | 50/50 |
| 1 | 2 | 2.3641 | 21.150 | 97.170 | 0.0471 | 0.0643 | 0.0709 | 0.01049 | 0.01190 | 50/50 |
| 1 | 3 | 2.3336 | 21.426 | 98.437 | 0.0465 | 0.0635 | 0.0690 | 0.01036 | 0.01190 | 50/50 |
| 1 | 4 | 2.3701 | 21.096 | 96.922 | 0.0472 | 0.0649 | 0.0710 | 0.01051 | 0.01190 | 50/50 |
| 1 | 5 | 2.3659 | 21.133 | 97.092 | 0.0472 | 0.0647 | 0.0700 | 0.01051 | 0.01190 | 50/50 |
| 16 | 1 | 0.4087 | 122.348 | 562.105 | 0.1224 | 0.1849 | 0.2087 | 0.02711 | 0.01190 | 50/50 |
| 16 | 2 | 0.4065 | 123.000 | 565.100 | 0.1179 | 0.1788 | 0.2056 | 0.02610 | 0.01190 | 50/50 |
| 16 | 3 | 0.4039 | 123.778 | 568.673 | 0.1213 | 0.1823 | 0.2016 | 0.02683 | 0.01190 | 50/50 |
| 16 | 4 | 0.4023 | 124.285 | 571.004 | 0.1203 | 0.1790 | 0.2025 | 0.02668 | 0.01190 | 50/50 |
| 16 | 5 | 0.3956 | 126.375 | 580.605 | 0.1173 | 0.1723 | 0.2085 | 0.02611 | 0.01190 | 50/50 |
| 32 | 1 | 0.3149 | 158.794 | 729.546 | 0.1721 | 0.2722 | 0.2841 | 0.03823 | 0.01190 | 50/50 |
| 32 | 2 | 0.3187 | 156.877 | 720.739 | 0.1766 | 0.2771 | 0.2892 | 0.03912 | 0.01190 | 50/50 |
| 32 | 3 | 0.3105 | 161.007 | 739.713 | 0.1723 | 0.2692 | 0.2811 | 0.03818 | 0.01190 | 50/50 |
| 32 | 4 | 0.3069 | 162.934 | 748.570 | 0.1669 | 0.2645 | 0.2761 | 0.03709 | 0.01190 | 50/50 |
| 32 | 5 | 0.3047 | 164.085 | 753.856 | 0.1657 | 0.2617 | 0.2737 | 0.03681 | 0.01190 | 50/50 |

### MOSS-TD base

| Conc. | Rep. | Wall (s) | Throughput (req/s) | RTFx | Mean latency (s) | p95 (s) | p99 (s) | Mean RTF | WER | Success |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 1 | 0.8122 | 12.312 | 62.279 | 0.0810 | 0.1071 | 0.1129 | 0.01644 | 0.02098 | 10/10 |
| 1 | 2 | 0.7908 | 12.646 | 63.967 | 0.0789 | 0.1057 | 0.1090 | 0.01598 | 0.02098 | 10/10 |
| 1 | 3 | 0.8075 | 12.384 | 62.643 | 0.0806 | 0.1054 | 0.1113 | 0.01636 | 0.02098 | 10/10 |
| 4 | 1 | 0.2534 | 39.460 | 199.604 | 0.0947 | 0.1252 | 0.1297 | 0.01930 | 0.02098 | 10/10 |
| 4 | 2 | 0.2692 | 37.148 | 187.907 | 0.1005 | 0.1382 | 0.1427 | 0.02035 | 0.02098 | 10/10 |
| 4 | 3 | 0.2588 | 38.636 | 195.432 | 0.0939 | 0.1264 | 0.1310 | 0.01905 | 0.02098 | 10/10 |

### MOSS-TD PR

| Conc. | Rep. | Wall (s) | Throughput (req/s) | RTFx | Mean latency (s) | p95 (s) | p99 (s) | Mean RTF | WER | Success |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 1 | 0.8196 | 12.201 | 61.718 | 0.0817 | 0.1078 | 0.1136 | 0.01657 | 0.02098 | 10/10 |
| 1 | 2 | 0.8132 | 12.298 | 62.207 | 0.0811 | 0.1064 | 0.1129 | 0.01645 | 0.02098 | 10/10 |
| 1 | 3 | 0.8219 | 12.167 | 61.543 | 0.0820 | 0.1094 | 0.1146 | 0.01661 | 0.02098 | 10/10 |
| 4 | 1 | 0.2576 | 38.820 | 196.364 | 0.0953 | 0.1264 | 0.1307 | 0.01945 | 0.02098 | 10/10 |
| 4 | 2 | 0.2512 | 39.801 | 201.330 | 0.0934 | 0.1205 | 0.1250 | 0.01905 | 0.02098 | 10/10 |
| 4 | 3 | 0.2607 | 38.353 | 194.002 | 0.0966 | 0.1288 | 0.1331 | 0.01962 | 0.02098 | 10/10 |

## Acceptance-criteria assessment

| Issue #1270 criterion | Evidence | Assessment |
|---|---|---|
| Same request sequence produces the same batches, cache behavior, and embeddings | Focused FunASR and MOSS service tests plus new generic-service tests all passed | Pass for tested unit scenarios |
| Timeout, retry, exception, statistics, close, cleanup, and per-request isolation remain unchanged | Unit coverage includes propagation, retry recovery, fatal worker state, shutdown, hooks, and statistics | Pass for tested scenarios |
| Existing tests pass | 146/146 relevant tests passed | Pass |
| ASR benchmarks pass without regression | FunASR and public-subset MOSS serving A/B completed with identical WER and approximately +/-3% timing movement | Pass for measured scope |
| No legacy service path remains | Diff inspection shows both service classes derive from `PreLMEncoderService`; duplicated worker loops are removed | Pass |

## Interpretation

1. **Correctness and accuracy are preserved in the measured workloads.** Base and PR WER are exactly equal at every concurrency, and there were no skipped or failed measured requests.
2. **No material serving-performance regression is visible.** Low-concurrency differences are small (-1.68% FunASR throughput and -1.81% MOSS throughput), while higher concurrency is neutral to positive (-0.11% at FunASR concurrency 16, +2.97% at 32, and +1.50% for MOSS at 4).
3. **Tail latency is neutral to improved at useful concurrency.** FunASR p95 improves 1.88% at concurrency 16 and 3.65% at 32; MOSS p95 improves 3.65% at concurrency 4.
4. **The measurements do not justify claiming a performance improvement.** The workloads are intentionally small and repeated on the same samples, so changes within a few percent should be treated as run-to-run variance unless confirmed by a longer randomized benchmark.

## Limitations and execution notes

- The official MOSS-TD Movies800Time, AISHELL4-long, and GoogleTime datasets are private and were not available. The MOSS result is a public SeedTTS serving smoke/performance comparison, not the official diarization benchmark.
- Streaming/SSE behavior and TTFT/inter-chunk latency were not benchmarked.

## Final verdict

PR #1273 preserves correctness, error isolation, cache behavior, and measured transcription accuracy while showing no material throughput or latency regression on the tested FunASR and MOSS-TD workloads. Before final merge, the remaining high-confidence validation would be the repository's official private MOSS multi-speaker benchmark and the normal self-hosted GPU CI matrix.

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
