### PR TITLE
feat(fun-asr): add RTX 4090 serving profile

### DIFF
--- a/examples/configs/fun_asr_rtx4090.yaml
+++ b/examples/configs/fun_asr_rtx4090.yaml
@@ -1,0 +1,16 @@
+# Conservative single-GPU profile for one RTX 4090 (SM89, 24 GB).
+config_cls: FunASRPipelineConfig
+name: fun-asr-rtx4090
+model_path: FunAudioLLM/Fun-ASR-Nano-2512-hf
+
+runtime_overrides:
+  asr:
+    dtype: bfloat16
+    max_running_requests: 16
+    enable_torch_compile: false
+
+stage_overrides:
+  asr:
+    runtime:
+      sglang_server_args:
+        mem_fraction_static: 0.65

--- a/sglang_omni/models/fun_asr/request_builders.py
+++ b/sglang_omni/models/fun_asr/request_builders.py
@@ -201,7 +201,13 @@ def make_fun_asr_scheduler_adapters(
 
     def request_builder(payload: StagePayload) -> FunASRRequestData:
         params = payload.request.params or {}
-        audio = _load_audio(_audio_source_from_payload(payload))
+        try:
+            audio = _load_audio(_audio_source_from_payload(payload))
+        except Exception as exc:
+            raise ValueError(
+                "Fun-ASR could not load or decode the audio input; provide a "
+                "reachable, valid audio file."
+            ) from exc
         audio_duration_s = float(len(audio) / _SAMPLE_RATE)
         if audio_duration_s > _MAX_AUDIO_DURATION_S:
             raise ValueError(

--- a/sglang_omni/models/fun_asr/stages.py
+++ b/sglang_omni/models/fun_asr/stages.py
@@ -29,6 +29,7 @@ from sglang_omni.scheduling.bootstrap import (
 )
 from sglang_omni.scheduling.generation_batch_policy import (
     build_generation_batch_overrides,
+    get_decode_cuda_graph_bs,
     validate_generation_batch_policy,
 )
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler
@@ -37,8 +38,18 @@ from sglang_omni.scheduling.sglang_backend import (
     build_sglang_server_args,
 )
 from sglang_omni.utils.gpu_compat import get_visible_gpu_sm_version
+from sglang_omni.utils.gpu_memory import format_bytes_gib, get_process_gpu_memory_bytes
 
 logger = logging.getLogger(__name__)
+
+
+def _log_memory_checkpoint(checkpoint: str, gpu_id: int) -> None:
+    logger.info(
+        "Fun-ASR memory checkpoint=%s gpu=%d process_gpu_memory=%s",
+        checkpoint,
+        gpu_id,
+        format_bytes_gib(get_process_gpu_memory_bytes(gpu_id)),
+    )
 
 
 def _compile_fun_asr_audio_encoder(
@@ -166,7 +177,15 @@ def create_sglang_fun_asr_executor(
     # (system/user/assistant wrappers + base prompt_text, no hotwords) instead
     # of a fixed guess, so context_length is accurate. Per-request hotword
     # overflow is guarded in the request builder against this context_length.
-    prompt_overhead_tokens = fun_asr_prompt_overhead_tokens(tokenizer)
+    prompt_overhead_tokens = max(
+        fun_asr_prompt_overhead_tokens(
+            tokenizer,
+            language=language,
+            itn=itn,
+        )
+        for language in (None, "英文")
+        for itn in (True, False)
+    )
     context_length = encoder_token_count + int(max_new_tokens) + prompt_overhead_tokens
 
     defaults: dict[str, Any] = {
@@ -179,12 +198,11 @@ def create_sglang_fun_asr_executor(
         "sampling_backend": "pytorch",
         "dtype": dtype,
     }
+    sm_version = get_visible_gpu_sm_version(gpu_id)
     if mm_attention_backend is not None:
         defaults["mm_attention_backend"] = mm_attention_backend
-    else:
-        sm_version = get_visible_gpu_sm_version(gpu_id)
-        if sm_version is not None and sm_version >= 100:
-            defaults["mm_attention_backend"] = "triton_attn"
+    elif sm_version is not None and sm_version >= 100:
+        defaults["mm_attention_backend"] = "triton_attn"
     overrides = build_generation_batch_overrides(
         max_running_requests=max_running_requests,
         server_args_overrides=server_args_overrides,
@@ -200,6 +218,22 @@ def create_sglang_fun_asr_executor(
         model_name="Fun-ASR",
         server_args=server_args,
     )
+    logger.info(
+        "Fun-ASR runtime profile: sm=%s dtype=%s attention_backend=%s "
+        "mm_attention_backend=%s cuda_graph=%s cuda_graph_bs=%s "
+        "torch_compile=%s max_running_requests=%s "
+        "mem_fraction_static=%s",
+        sm_version,
+        server_args.dtype,
+        server_args.attention_backend,
+        server_args.mm_attention_backend,
+        not server_args.disable_cuda_graph,
+        get_decode_cuda_graph_bs(server_args),
+        server_args.enable_torch_compile,
+        server_args.max_running_requests,
+        server_args.mem_fraction_static,
+    )
+    _log_memory_checkpoint("pre_model_load", gpu_id)
 
     want_cuda_graph, (
         model_worker,
@@ -214,9 +248,11 @@ def create_sglang_fun_asr_executor(
         gpu_id,
         model_arch_override="FunAsrNanoForConditionalGeneration",
     )
+    _log_memory_checkpoint("post_static_allocation", gpu_id)
 
     if want_cuda_graph:
         model_worker.model_runner.init_cuda_graphs()
+        _log_memory_checkpoint("post_cuda_graph_capture", gpu_id)
 
     if enable_encoder_torch_compile:
         _compile_fun_asr_audio_encoder(

--- a/tests/README.md
+++ b/tests/README.md
@@ -382,6 +382,7 @@ that happened to contain an older version of the test.
   - token-level result adapter marker handling, avoiding decode/encode
     text round-trips for byte-level BPE output.
 - `unit_test/fun_asr/`: Fun-ASR-Nano unit tests:
+  - checked-in RTX 4090 profile loading and runtime override resolution
   - pipeline config and stage factory: single `asr` stage, `max_running_requests=32`,
     auto static KV budget, pre-LM encoder/cache defaults, scheduler-owned
     shutdown, disabled multimodal embedding cache and torch.compile, and
@@ -391,8 +392,8 @@ that happened to contain an older version of the test.
     isolation, telemetry, and worker shutdown
   - model audio-feature shape and checkpoint weight-loading contracts
   - request builder: inclusive audio offset recording, language-prompt prefix
-    construction, encode-after-validation ordering, and result adapter
-    direct-transcript decoding and token telemetry
+    construction, encode-after-validation ordering, invalid-audio error
+    mapping, and result adapter direct-transcript decoding and token telemetry
   - streaming output: request-contract validation, chunked-prefill gating,
     rate-limited and terminal flushes, UTF-8 boundaries, per-request state,
     and direct-client aggregation without repeating the terminal transcript.

--- a/tests/unit_test/fun_asr/test_pipeline.py
+++ b/tests/unit_test/fun_asr/test_pipeline.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import inspect
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 import sglang_omni.models.fun_asr.stages as fun_asr_stages
+from sglang_omni.config.manager import ConfigManager
+from sglang_omni.config.runtime import resolve_stage_static_factory_args
 from sglang_omni.models.fun_asr.config import FunASRPipelineConfig
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from tests.unit_test.fakes import FakeServerArgs
@@ -31,6 +34,10 @@ def test_fun_asr_config_uses_batched_stage_with_32_running_requests() -> None:
     assert config.stages[0].factory_args["pre_lm_max_batch_wait_ms"] == 4
     assert config.stages[0].factory_args["request_build_max_workers"] == 8
     assert config.stages[0].factory_args["request_build_max_pending"] == 16
+    assert FunASRPipelineConfig.mem_fraction_role_to_stage() == {"asr": "asr"}
+    assert FunASRPipelineConfig.generation_sglang_role_to_stage() == {
+        "generation": "asr"
+    }
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("FunAsrNanoForConditionalGeneration")
         is FunASRPipelineConfig
@@ -97,6 +104,22 @@ def test_fun_asr_stage_default_enables_async_decode() -> None:
     assert signature.parameters["async_decode_min_batch_size"].default == 2
 
 
+def test_fun_asr_rtx4090_profile_is_bf16_and_bounded() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    config = ConfigManager.from_file(
+        str(repo_root / "examples/configs/fun_asr_rtx4090.yaml")
+    ).config
+    stage = config.stages[0]
+
+    factory_args = resolve_stage_static_factory_args(stage, config)
+
+    assert factory_args["dtype"] == "bfloat16"
+    assert factory_args["max_running_requests"] == 16
+    assert factory_args["enable_torch_compile"] is False
+    assert factory_args.get("mm_attention_backend") is None
+    assert factory_args["server_args_overrides"]["mem_fraction_static"] == 0.65
+
+
 def test_fun_asr_threads_generation_batch_and_request_build_policy(monkeypatch) -> None:
     build_kwargs: dict[str, object] = {}
     validations: list[dict[str, object]] = []
@@ -121,7 +144,12 @@ def test_fun_asr_threads_generation_batch_and_request_build_policy(monkeypatch) 
     monkeypatch.setattr(
         fun_asr_stages,
         "get_visible_gpu_sm_version",
-        lambda gpu_id: None,
+        lambda gpu_id: 89,
+    )
+    monkeypatch.setattr(
+        fun_asr_stages,
+        "get_process_gpu_memory_bytes",
+        lambda gpu_id: 0,
     )
     monkeypatch.setattr(fun_asr_stages, "init_mm_embedding_cache", lambda size: None)
     monkeypatch.setattr(
@@ -173,8 +201,17 @@ def test_fun_asr_threads_generation_batch_and_request_build_policy(monkeypatch) 
 
     def _fake_server_args_builder(model_path, context_length, **overrides):
         build_kwargs.update(overrides)
-        server_args = FakeServerArgs(**overrides)
-        server_args.mm_attention_backend = None
+        build_kwargs["context_length"] = context_length
+        server_args = FakeServerArgs(
+            **{key: value for key, value in overrides.items() if key != "cuda_graph_bs"}
+        )
+        server_args.cuda_graph_config = SimpleNamespace(
+            decode=SimpleNamespace(bs=overrides.get("cuda_graph_bs"))
+        )
+        server_args.mm_attention_backend = overrides.get(
+            "mm_attention_backend", "triton_attn"
+        )
+        server_args.attention_backend = "flashinfer"
         return server_args
 
     model_worker = SimpleNamespace(model_runner=SimpleNamespace(model=object()))
@@ -214,10 +251,27 @@ def test_fun_asr_threads_generation_batch_and_request_build_policy(monkeypatch) 
         raising=False,
     )
 
-    scheduler = fun_asr_stages.create_sglang_fun_asr_executor("dummy")
+    scheduler = fun_asr_stages.create_sglang_fun_asr_executor(
+        "dummy",
+        mm_attention_backend="flashinfer",
+        server_args_overrides={"mm_attention_backend": "triton_attn"},
+    )
 
     assert build_kwargs["cuda_graph_max_bs"] == 32
     assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 12, 16, 24, 32]
+    assert build_kwargs["mm_attention_backend"] == "triton_attn"
+    max_prompt_overhead = max(
+        fun_asr_stages.fun_asr_prompt_overhead_tokens(
+            tokenizer,
+            language=language,
+            itn=itn,
+        )
+        for language in (None, "英文")
+        for itn in (True, False)
+    )
+    assert build_kwargs["context_length"] == (
+        fun_asr_stages.fun_asr_low_frame_rate_length(500) + 200 + max_prompt_overhead
+    )
     assert validations == [
         {"model_name": "Fun-ASR", "server_args": scheduler.server_args}
     ]

--- a/tests/unit_test/fun_asr/test_request_builders.py
+++ b/tests/unit_test/fun_asr/test_request_builders.py
@@ -307,6 +307,27 @@ def test_fun_asr_request_builder_rejects_audio_over_vad_limit(monkeypatch) -> No
         request_builder(payload)
 
 
+def test_fun_asr_request_builder_reports_audio_decode_failure(monkeypatch) -> None:
+    monkeypatch.setattr(
+        request_builders,
+        "_load_audio",
+        lambda source: (_ for _ in ()).throw(RuntimeError("decode failed")),
+    )
+    request_builder, _ = request_builders.make_fun_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=200,
+        feature_extractor=_feature_extractor(17),
+    )
+    payload = StagePayload(
+        request_id="req-fun-asr-invalid-audio",
+        request=OmniRequest(inputs={"audio_bytes": b"invalid"}),
+        data={},
+    )
+
+    with pytest.raises(ValueError, match="could not load or decode the audio input"):
+        request_builder(payload)
+
+
 def test_fun_asr_request_builder_rejects_explicit_token_budget_over_cap(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- migrate @wirybeaver's reviewed Fun-ASR slice from https://github.com/wirybeaver/sglang-omni/pull/1 onto current `main`
- add a conservative BF16 single-RTX-4090 profile with 16-request admission
  and a 0.65 static-memory fraction; rely on SGLang 0.5.16's automatic SM89
  multimodal-backend selection instead of duplicating that policy
- size the SGLang context from the real tokenized Fun-ASR prompt variants instead of a fixed prompt-overhead guess, while retaining per-request overflow rejection for hotwords/custom language hints
- map audio load/decode failures to an actionable request error and log the resolved runtime profile plus truthful startup memory checkpoints

## Ownership and scope

All runtime changes stay under `models/fun_asr/`; there are no shared Stage, scheduler, relay, serve, or API changes. Generic lifecycle work remains in #1153, benchmark infrastructure remains in #1155, and the benchmark/docs capstone remains a separate incremental PR from #1171.

This validated profile supersedes the unqualified Fun-ASR config proposed as one part of #1244; that PR can retain its independent Higgs/ZONOS2 onboarding slices.

## Validated profile

- model: `FunAudioLLM/Fun-ASR-Nano-2512-hf`
- one RTX 4090, 24 GB, SM89
- BF16; no quantization
- `max_running_requests=16`
- `mem_fraction_static=0.65`
- CUDA Graph batches `[1, 2, 4, 8, 12, 16]`
- FlashInfer LM attention; SGLang automatic multimodal-attention selection
  (Triton on SM89)
- `torch.compile` disabled

The original RTX 4090 qualification used SGLang 0.5.12.post1. This migration updates the code to current SGLang 0.5.16 contracts (`init_cuda_graphs`, `cuda_graph_config.decode.bs`, current `ServerArgs`, current config resolution); the checked-in profile and full model-local unit suite are revalidated here. GPU CI is requested on the new head.

## Target-hardware evidence

Issue #1170 records:

- SeedTTS EN: 1,088/1,088 at every concurrency, zero skips; 114.26 samples/s at resident concurrency 16
- SeedTTS ZH: 2,020/2,020 at every concurrency, zero skips; 127.25 samples/s at resident concurrency 16
- 30-minute mixed soak: 105,067 successful requests, zero unexpected errors
- startup memory: 15.98 GiB after static allocation and 16.11 GiB after CUDA Graph capture
- minimum sampled free memory: 7,104 MiB; cooldown retention: 104 MiB
- 29.9-second audio completed; 30.1-second audio returned HTTP 400, matching the documented 30-second VAD boundary

Concurrency 32 in the report is queueing stress above the 16-request admission limit, not a 32-request resident configuration. The reported ZH CER is an absolute consumer result, not an H100 parity claim.

## Validation

- `python -m pytest tests/unit_test/fun_asr -q` — 69 passed on the local M4;
  import-only torchaudio/MLX stubs were used because those platform packages
  are unavailable on the host
- production `ConfigManager` load resolves BF16, 16-request admission, Triton multimodal attention, disabled torch compile, and `mem_fraction_static=0.65`
- changed-file format/AST hooks — passed
- `git diff --check` — passed
- benchmark report: #1170
- parent roadmap: #1120
- umbrella draft and split map: #1171
- raw artifacts: https://gist.github.com/wirybeaver/ffa8a07f89066654a271a45b21592d25
