### PR TITLE
feat(serve): add Whisper audio translations endpoint

### DIFF
--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -1,6 +1,9 @@
 # Whisper ASR
 
-Whisper ASR checkpoints can be started through the OpenAI-compatible `/v1/audio/transcriptions` endpoint, but this path is experimental in the current SGLang-Omni tree. Prefer [Qwen3-ASR](qwen3_asr.md) for validated ASR serving.
+Whisper ASR checkpoints can transcribe audio through `/v1/audio/transcriptions`
+and translate supported source languages to English through
+`/v1/audio/translations`. This path is experimental in the current
+SGLang-Omni tree. Prefer [Qwen3-ASR](qwen3_asr.md) for validated ASR serving.
 
 ## Prerequisites
 
@@ -47,29 +50,42 @@ resp.raise_for_status()
 print(resp.json()["text"])
 ```
 
+## Translate Audio to English
+
+The translation route is available only for Whisper pipelines. Pass an
+explicit source-language hint until automatic language detection is implemented.
+
+```bash
+curl -X POST http://localhost:8000/v1/audio/translations \
+  -F model=openai/whisper-large-v3 \
+  -F file=@/path/to/french_audio.wav \
+  -F language=fr \
+  -F response_format=json
+```
+
 ## Request Parameters
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `file` | file | required | Audio file uploaded as multipart form data |
 | `model` | string | server default | Model identifier |
-| `language` | string | unset | Optional language hint |
-| `response_format` | string | `json` | Use `json` for the current Whisper path |
+| `language` | string | unset | Optional transcription hint; required as the source language for translation |
+| `response_format` | string | `json` | Non-streaming requests support `json`, `text`, and `verbose_json` |
 | `temperature` | float | `0.0` | Sampling temperature; defaults to greedy decoding |
 
-The request builder also supports `task` (`transcribe` by default) and
-`max_new_tokens`, but the public transcription endpoint currently exposes only
-the fields above. The route uses the ASR stage default unless the pipeline is
-configured another way. For smoke tests, keep the request minimal and use
-`response_format=json`.
+The server maps `/v1/audio/transcriptions` to the `transcribe` task and
+`/v1/audio/translations` to the `translate` task. The transcription route also
+accepts `max_new_tokens` and streaming; the translation route is non-streaming.
+The route uses the ASR stage default unless the pipeline is configured another
+way.
 
 ## Known Limitations
 
 - This path is experimental and not yet correctness-validated. Prefer Qwen3-ASR
   for validated ASR serving.
 - Keep Whisper ASR at encoder batch size 1.
-- Use `response_format=json`; other response formats are not validated for this
-  experimental path.
+- Translation is non-streaming and requires an explicit source language until
+  automatic language detection is implemented.
 - First startup can take several minutes.
 - The endpoint accepts one uploaded file per request.
 - Audio is resampled to 16 kHz before transcription.

--- a/examples/configs/whisper_asr_rtx4090.yaml
+++ b/examples/configs/whisper_asr_rtx4090.yaml
@@ -1,0 +1,16 @@
+# Conservative single-GPU profile for one RTX 4090 (SM89, 24 GB).
+config_cls: WhisperASRPipelineConfig
+name: whisper-asr-rtx4090
+model_path: openai/whisper-large-v3
+
+runtime_overrides:
+  asr:
+    dtype: bfloat16
+    max_running_requests: 16
+    enable_torch_compile: false
+
+stage_overrides:
+  asr:
+    runtime:
+      sglang_server_args:
+        mem_fraction_static: 0.65

--- a/sglang_omni/models/whisper_asr/request_builders.py
+++ b/sglang_omni/models/whisper_asr/request_builders.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 from dataclasses import dataclass
 from typing import Any, Callable
@@ -23,6 +24,9 @@ from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 from sglang_omni.utils.audio import audio_fingerprint, audio_fingerprint_int, load_audio
 
 _WHISPER_SAMPLE_RATE = 16000
+_MAX_AUDIO_DURATION_S = 30.0
+_SUPPORTED_TASKS = frozenset({"transcribe", "translate"})
+_PREFIX_TOKEN_LOCK = threading.Lock()
 _LANGUAGE_ALIASES = {
     "en": "english",
     "eng": "english",
@@ -35,7 +39,8 @@ class WhisperASRRequestData(SGLangARRequestData):
     prompt_token_ids: list[int] | None = None
     output_ids: list[int] | None = None
     audio_duration_s: float = 0.0
-    language: str = "en"
+    language: str | None = "english"
+    task: str = "transcribe"
     engine_start_s: float = 0.0
 
 
@@ -61,29 +66,102 @@ def _load_audio(source: Any) -> np.ndarray:
     )
 
 
-def _resolve_language(value: Any) -> str:
-    if value is None:
-        return "english"
-    language = str(value).strip().lower()
+def _resolve_task(value: Any) -> str:
+    task = str(value or "transcribe").strip().lower()
+    if task not in _SUPPORTED_TASKS:
+        raise ValueError(
+            f"Whisper task must be one of {sorted(_SUPPORTED_TASKS)}, got {task!r}"
+        )
+    return task
+
+
+def _resolve_language(value: Any, *, task: str) -> str:
+    language = "" if value is None else str(value).strip().lower()
     if not language:
+        if task == "translate":
+            raise ValueError(
+                "Whisper translation requires an explicit source language until "
+                "automatic language detection is implemented"
+            )
         return "english"
     return _LANGUAGE_ALIASES.get(language, language)
 
 
 def _build_logit_bias(generation_config: GenerationConfig) -> dict[str, float] | None:
-    suppress_tokens = getattr(generation_config, "suppress_tokens", None)
+    try:
+        suppress_tokens = generation_config.suppress_tokens
+    except AttributeError:
+        suppress_tokens = None
     if not suppress_tokens:
         return None
     return {str(int(token_id)): -1.0e9 for token_id in suppress_tokens if token_id >= 0}
 
 
-def _build_prefix_tokens(tokenizer: Any, *, language: str, task: str) -> list[int]:
-    tokenizer.set_prefix_tokens(
-        language=language,
-        task=task,
-        predict_timestamps=False,
-    )
-    return list(tokenizer.prefix_tokens)
+def _build_prefix_tokens(
+    tokenizer: Any, *, language: str | None, task: str
+) -> list[int]:
+    """Build a request-local prefix without leaking tokenizer state.
+
+    Whisper tokenizers store language/task as mutable attributes. Request
+    builders run concurrently, so serialize the short prefix construction and
+    restore the prior state before returning.
+    """
+
+    missing = object()
+    with _PREFIX_TOKEN_LOCK:
+        try:
+            previous_language = tokenizer.language
+        except AttributeError:
+            previous_language = missing
+        try:
+            previous_task = tokenizer.task
+        except AttributeError:
+            previous_task = missing
+        try:
+            previous_predict_timestamps = tokenizer.predict_timestamps
+        except AttributeError:
+            previous_predict_timestamps = missing
+
+        tokenizer.language = language
+        tokenizer.task = task
+        tokenizer.predict_timestamps = False
+        try:
+            return list(tokenizer.prefix_tokens)
+        finally:
+            if previous_language is missing:
+                del tokenizer.language
+            else:
+                tokenizer.language = previous_language
+            if previous_task is missing:
+                del tokenizer.task
+            else:
+                tokenizer.task = previous_task
+            if previous_predict_timestamps is missing:
+                del tokenizer.predict_timestamps
+            else:
+                tokenizer.predict_timestamps = previous_predict_timestamps
+
+
+def _request_token_budget(params: dict[str, Any], max_new_tokens: int) -> int:
+    explicit = params.get("max_new_tokens")
+    if explicit is None:
+        return max_new_tokens
+    if isinstance(explicit, bool):
+        raise ValueError("max_new_tokens must be an integer")
+    if isinstance(explicit, int):
+        requested = explicit
+    elif isinstance(explicit, str):
+        try:
+            requested = int(explicit)
+        except ValueError as exc:
+            raise ValueError("max_new_tokens must be an integer") from exc
+    else:
+        raise ValueError("max_new_tokens must be an integer")
+    if requested < 1 or requested > max_new_tokens:
+        raise ValueError(
+            f"max_new_tokens must be between 1 and {max_new_tokens}, got {requested}"
+        )
+    return requested
 
 
 def make_whisper_scheduler_adapters(
@@ -103,19 +181,39 @@ def make_whisper_scheduler_adapters(
 
     def request_builder(payload: StagePayload) -> WhisperASRRequestData:
         params = payload.request.params or {}
-        audio = _load_audio(_audio_source_from_payload(payload))
-        audio_duration_s = float(len(audio) / _WHISPER_SAMPLE_RATE)
-        fingerprint = audio_fingerprint(audio)
-
-        language = _resolve_language(params.get("language"))
-        task = str(params.get("task") or "transcribe")
+        task = _resolve_task(params.get("task"))
+        language = _resolve_language(params.get("language"), task=task)
+        request_max_new_tokens = _request_token_budget(params, max_new_tokens)
+        temperature = float(params.get("temperature") or 0.0)
         prompt_token_ids = _build_prefix_tokens(
             tokenizer,
             language=language,
             task=task,
         )
         input_ids = [pad_token_id] * encoder_token_count + prompt_token_ids
+        sampling_params = SamplingParams(
+            max_new_tokens=request_max_new_tokens,
+            temperature=temperature,
+            top_p=1.0,
+            stop_token_ids=[eos_token_id],
+            logit_bias=logit_bias,
+        )
+        sampling_params.normalize(tokenizer=None)
 
+        try:
+            audio = _load_audio(_audio_source_from_payload(payload))
+        except Exception as exc:
+            raise ValueError(
+                "Whisper ASR could not decode the uploaded audio; provide a valid "
+                "audio file."
+            ) from exc
+        audio_duration_s = float(len(audio) / _WHISPER_SAMPLE_RATE)
+        if audio_duration_s > _MAX_AUDIO_DURATION_S:
+            raise ValueError(
+                "Whisper ASR accepts audio up to 30.0 seconds; split longer audio "
+                "before inference."
+            )
+        fingerprint = audio_fingerprint(audio)
         features = processor.feature_extractor(
             audio,
             sampling_rate=_WHISPER_SAMPLE_RATE,
@@ -131,17 +229,6 @@ def make_whisper_scheduler_adapters(
             ],
             num_image_tokens=encoder_token_count,
         )
-
-        temperature = float(params.get("temperature") or 0.0)
-        request_max_new_tokens = int(params.get("max_new_tokens") or max_new_tokens)
-        sampling_params = SamplingParams(
-            max_new_tokens=request_max_new_tokens,
-            temperature=temperature,
-            top_p=1.0,
-            stop_token_ids=[eos_token_id],
-            logit_bias=logit_bias,
-        )
-        sampling_params.normalize(tokenizer=None)
 
         req = Req(
             rid=payload.request_id,
@@ -161,7 +248,8 @@ def make_whisper_scheduler_adapters(
             max_new_tokens=request_max_new_tokens,
             temperature=temperature,
             audio_duration_s=audio_duration_s,
-            language=language,
+            language="english" if task == "translate" else language,
+            task=task,
             engine_start_s=time.perf_counter(),
             stage_payload=payload,
         )
@@ -179,6 +267,7 @@ def make_whisper_scheduler_adapters(
             data={
                 "text": text,
                 "language": data.language,
+                "task": data.task,
                 "duration_s": data.audio_duration_s,
                 "asr_latency_s": engine_time_s,
                 "usage": {"engine_time_s": engine_time_s},

--- a/sglang_omni/models/whisper_asr/stages.py
+++ b/sglang_omni/models/whisper_asr/stages.py
@@ -3,7 +3,22 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+from sglang_omni.utils.gpu_compat import get_visible_gpu_sm_version
+from sglang_omni.utils.gpu_memory import format_bytes_gib, get_process_gpu_memory_bytes
+
+logger = logging.getLogger(__name__)
+
+
+def _log_memory_checkpoint(checkpoint: str, gpu_id: int) -> None:
+    logger.info(
+        "Whisper ASR memory checkpoint=%s gpu=%d process_gpu_memory=%s",
+        checkpoint,
+        gpu_id,
+        format_bytes_gib(get_process_gpu_memory_bytes(gpu_id)),
+    )
 
 
 def create_sglang_whisper_asr_executor(
@@ -14,6 +29,7 @@ def create_sglang_whisper_asr_executor(
     max_running_requests: int = 16,
     max_new_tokens: int = 256,
     mem_fraction_static: float = 0.85,
+    enable_torch_compile: bool = True,
     server_args_overrides: dict[str, Any] | None = None,
 ):
     from transformers import AutoProcessor, GenerationConfig
@@ -27,6 +43,7 @@ def create_sglang_whisper_asr_executor(
     )
     from sglang_omni.scheduling.generation_batch_policy import (
         build_generation_batch_overrides,
+        get_decode_cuda_graph_bs,
         validate_generation_batch_policy,
     )
     from sglang_omni.scheduling.omni_scheduler import OmniScheduler
@@ -40,13 +57,14 @@ def create_sglang_whisper_asr_executor(
     tokenizer = processor.tokenizer
     generation_config = GenerationConfig.from_pretrained(model_path)
     encoder_token_count = int(processor.feature_extractor.nb_max_frames // 2)
+    sm_version = get_visible_gpu_sm_version(gpu_id)
 
     overrides = build_generation_batch_overrides(
         max_running_requests=max_running_requests,
         server_args_overrides=server_args_overrides,
         disable_cuda_graph=False,
         disable_overlap_schedule=True,
-        enable_torch_compile=True,
+        enable_torch_compile=enable_torch_compile,
         mem_fraction_static=mem_fraction_static,
         max_prefill_tokens=4096,
         chunked_prefill_size=4096,
@@ -63,6 +81,21 @@ def create_sglang_whisper_asr_executor(
         model_name="Whisper ASR",
         server_args=server_args,
     )
+    logger.info(
+        "Whisper ASR runtime profile: sm=%s dtype=%s "
+        "attention_backend=%s encoder_attention_backend=torch_sdpa "
+        "cuda_graph=%s cuda_graph_bs=%s torch_compile=%s "
+        "max_running_requests=%s mem_fraction_static=%s",
+        sm_version,
+        server_args.dtype,
+        server_args.attention_backend,
+        not server_args.disable_cuda_graph,
+        get_decode_cuda_graph_bs(server_args),
+        server_args.enable_torch_compile,
+        server_args.max_running_requests,
+        server_args.mem_fraction_static,
+    )
+    _log_memory_checkpoint("pre_model_load", gpu_id)
 
     want_cuda_graph, (
         model_worker,
@@ -77,9 +110,11 @@ def create_sglang_whisper_asr_executor(
         gpu_id,
         model_arch_override="WhisperForConditionalGeneration",
     )
+    _log_memory_checkpoint("post_static_allocation", gpu_id)
 
     if want_cuda_graph:
         model_worker.model_runner.init_cuda_graphs()
+        _log_memory_checkpoint("post_cuda_graph_capture", gpu_id)
 
     output_proc = SGLangOutputProcessor(
         capture_hidden=False,

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -125,15 +125,17 @@ MAX_VOICE_UPLOAD_BODY_BYTES = (
 
 _BAD_REQUEST_MARKERS = (
     "longer than the model's context length",
-    "Requested token count exceeds the model's maximum context length",
+    "requested token count exceeds the model's maximum context length",
     "accepts audio up to",
+    "could not decode the uploaded audio",
     "max_new_tokens must be",
     "multimodal_train_inputs",
+    "unsupported language",
 )
 
 
 def _is_bad_request_error(exc: Exception) -> bool:
-    message = str(exc)
+    message = str(exc).casefold()
     return any(marker in message for marker in _BAD_REQUEST_MARKERS)
 
 
@@ -1596,107 +1598,181 @@ def _register_transcriptions(app: FastAPI) -> None:
         max_new_tokens: int | None = Form(default=None, ge=1),
         stream: bool = Form(default=False),
     ) -> Response:
-        client: Client = app.state.client
-        default_model: str = app.state.model_name
-        request_id = f"transcription-{uuid.uuid4()}"
-
-        # TODO(Ratish): add the same pre-parser body limit used by voice uploads
-        # once transcription upload limits are defined.
-        audio_bytes = await file.read()
-        if not audio_bytes:
-            raise HTTPException(status_code=400, detail="Uploaded audio file is empty")
-
-        normalized_response_format = response_format.strip().lower()
-        if stream:
-            if normalized_response_format not in {"json", "text"}:
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        "stream=true supports only response_format 'json' or "
-                        f"'text', got {response_format!r}"
-                    ),
-                )
-            gen_req = build_transcription_generate_request(
-                audio_bytes=audio_bytes,
-                filename=file.filename,
-                content_type=file.content_type,
-                model=model or default_model,
-                language=language,
-                prompt=prompt,
-                temperature=temperature,
-                max_new_tokens=max_new_tokens,
-                stream=True,
-            )
-            adapter = resolve_adapter(getattr(app.state, "architectures", None))
-            duration_s = _probe_audio_duration(audio_bytes)
-            return _ClosableStreamingResponse(
-                _transcription_stream(
-                    client,
-                    gen_req,
-                    request_id=request_id,
-                    adapter=adapter,
-                    duration_s=duration_s,
-                ),
-                media_type="text/event-stream",
-                headers={"Cache-Control": "no-cache", "X-Request-Id": request_id},
-            )
-
-        gen_req = build_transcription_generate_request(
-            audio_bytes=audio_bytes,
-            filename=file.filename,
-            content_type=file.content_type,
-            model=model or default_model,
+        return await _create_audio_text_response(
+            app,
+            file=file,
+            model=model,
             language=language,
             prompt=prompt,
+            response_format=response_format,
             temperature=temperature,
             max_new_tokens=max_new_tokens,
+            stream=stream,
+            task="transcribe",
         )
 
-        try:
-            result = await client.completion(gen_req, request_id=request_id)
-        except ClientError as exc:
-            if _is_bad_request_error(exc):
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-        except Exception as exc:
-            if _is_bad_request_error(exc):
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
-            logger.exception("Error transcribing audio for request %s", request_id)
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-        text = result.text
-        if normalized_response_format == "text":
-            return PlainTextResponse(text)
-        if normalized_response_format not in {"json", "verbose_json"}:
+    @app.post("/v1/audio/translations")
+    async def create_translation(
+        file: UploadFile = File(...),
+        model: str | None = Form(default=None),
+        language: str | None = Form(default=None),
+        prompt: str | None = Form(default=None),
+        response_format: str = Form(default="json"),
+        temperature: float | None = Form(default=None),
+    ) -> Response:
+        if not _supports_audio_translation(app):
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    "Unsupported response_format for /v1/audio/transcriptions: "
-                    f"{response_format!r}"
+                    "/v1/audio/translations requires a Whisper ASR pipeline; "
+                    f"the active model is {app.state.model_name!r}."
                 ),
             )
+        if language is None or not language.strip():
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Whisper translation requires an explicit source language "
+                    "until automatic language detection is implemented."
+                ),
+            )
+        return await _create_audio_text_response(
+            app,
+            file=file,
+            model=model,
+            language=language,
+            prompt=prompt,
+            response_format=response_format,
+            temperature=temperature,
+            max_new_tokens=None,
+            stream=False,
+            task="translate",
+        )
 
-        adapter = resolve_adapter(getattr(app.state, "architectures", None))
-        text = adapter.postprocess_text(text)
+
+def _supports_audio_translation(app: FastAPI) -> bool:
+    try:
+        architectures = app.state.architectures
+    except AttributeError:
+        architectures = None
+    if architectures:
+        return any(
+            architecture == "WhisperForConditionalGeneration"
+            for architecture in architectures
+        )
+    return "whisper" in str(app.state.model_name).lower()
+
+
+async def _create_audio_text_response(
+    app: FastAPI,
+    *,
+    file: UploadFile,
+    model: str | None,
+    language: str | None,
+    prompt: str | None,
+    response_format: str,
+    temperature: float | None,
+    max_new_tokens: int | None,
+    stream: bool,
+    task: str,
+) -> Response:
+    client: Client = app.state.client
+    default_model: str = app.state.model_name
+    try:
+        architectures = app.state.architectures
+    except AttributeError:
+        architectures = None
+    request_kind = "translation" if task == "translate" else "transcription"
+    request_id = f"{request_kind}-{uuid.uuid4()}"
+
+    # TODO(Ratish): add the same pre-parser body limit used by voice uploads
+    # once transcription upload limits are defined.
+    audio_bytes = await file.read()
+    if not audio_bytes:
+        raise HTTPException(status_code=400, detail="Uploaded audio file is empty")
+
+    normalized_response_format = response_format.strip().lower()
+    if stream and normalized_response_format not in {"json", "text"}:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "stream=true supports only response_format 'json' or "
+                f"'text', got {response_format!r}"
+            ),
+        )
+    gen_req = build_transcription_generate_request(
+        audio_bytes=audio_bytes,
+        filename=file.filename,
+        content_type=file.content_type,
+        model=model or default_model,
+        language=language,
+        prompt=prompt,
+        temperature=temperature,
+        max_new_tokens=max_new_tokens,
+        stream=stream,
+        task=task,
+    )
+    if stream:
+        adapter = resolve_adapter(architectures)
         duration_s = _probe_audio_duration(audio_bytes)
-        usage = (
-            TranscriptionUsage(seconds=math.ceil(duration_s))
-            if duration_s > 0
-            else None
+        return _ClosableStreamingResponse(
+            _transcription_stream(
+                client,
+                gen_req,
+                request_id=request_id,
+                adapter=adapter,
+                duration_s=duration_s,
+            ),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Request-Id": request_id},
         )
-        if normalized_response_format == "verbose_json":
-            response = adapter.build_verbose_response(
-                text=text,
-                language=language,
-                audio_duration_s=duration_s,
-            )
-            response.usage = usage
-            return JSONResponse(content=response.model_dump(exclude_none=True))
-        return JSONResponse(
-            content=TranscriptionResponse(text=text, usage=usage).model_dump(
-                exclude_none=True
-            )
+
+    try:
+        result = await client.completion(gen_req, request_id=request_id)
+    except ClientError as exc:
+        if _is_bad_request_error(exc):
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except Exception as exc:
+        if _is_bad_request_error(exc):
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        logger.exception("Error processing audio task=%s request=%s", task, request_id)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    text = result.text
+    if normalized_response_format == "text":
+        return PlainTextResponse(text)
+    if normalized_response_format not in {"json", "verbose_json"}:
+        endpoint = (
+            "/v1/audio/translations"
+            if task == "translate"
+            else "/v1/audio/transcriptions"
         )
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported response_format for {endpoint}: {response_format!r}",
+        )
+
+    adapter = resolve_adapter(architectures)
+    text = adapter.postprocess_text(text)
+    duration_s = _probe_audio_duration(audio_bytes)
+    usage = (
+        TranscriptionUsage(seconds=math.ceil(duration_s)) if duration_s > 0 else None
+    )
+    if normalized_response_format == "verbose_json":
+        response = adapter.build_verbose_response(
+            text=text,
+            language="english" if task == "translate" else language,
+            audio_duration_s=duration_s,
+        )
+        response.task = task
+        response.usage = usage
+        return JSONResponse(content=response.model_dump(exclude_none=True))
+    return JSONResponse(
+        content=TranscriptionResponse(text=text, usage=usage).model_dump(
+            exclude_none=True
+        )
+    )
 
 
 async def _transcription_stream(
@@ -1769,8 +1845,13 @@ def build_transcription_generate_request(
     temperature: float | None,
     max_new_tokens: int | None = None,
     stream: bool = False,
+    task: str = "transcribe",
 ) -> GenerateRequest:
-    params: dict[str, Any] = {"task": "transcribe"}
+    if task not in {"transcribe", "translate"}:
+        raise ValueError(
+            f"Unsupported audio text task {task!r}; expected 'transcribe' or 'translate'"
+        )
+    params: dict[str, Any] = {"task": task}
     metadata: dict[str, Any] = {"task": "asr"}
     explicit_fields: list[str] = []
     if language is not None:

--- a/tests/README.md
+++ b/tests/README.md
@@ -396,6 +396,14 @@ that happened to contain an older version of the test.
   - streaming output: request-contract validation, chunked-prefill gating,
     rate-limited and terminal flushes, UTF-8 boundaries, per-request state,
     and direct-client aggregation without repeating the terminal transcript.
+- `unit_test/whisper_asr/`: Whisper ASR unit tests:
+  - checked-in RTX 4090 profile loading plus current SGLang CUDA Graph batch
+    configuration and capture initialization
+  - request-local language/task prefix construction under concurrent traffic
+    with tokenizer-state restoration
+  - task and strict token-budget validation before audio loading, explicit
+    translation source-language enforcement, 30-second input limits, stable
+    decode errors, and transcription/translation outputs.
 - `unit_test/moss_transcribe_diarize/`: MOSS-Transcribe-Diarize unit tests:
   - pipeline config and stage factory default routing/memory contracts
   - request builder audio-source resolution, single-audio enforcement, audio

--- a/tests/README.md
+++ b/tests/README.md
@@ -532,8 +532,10 @@ that happened to contain an older version of the test.
   - managed launcher command construction and cleanup.
 
 - `unit_test/serve/`: In-process serving API unit tests:
-  - generation-stage SGLang server-args role mapping and CLI override capability boundaries
-  - OpenAI-compatible request/response behavior
+  - generation-stage SGLang server-args role mapping and CLI override capability
+    boundaries
+  - OpenAI-compatible request/response behavior, including Whisper-only audio
+    translation capability checks and source-language validation
   - streaming response framing and failure semantics.
 
 - `unit_test/fishaudio_s2_pro/`: FishAudio S2-Pro unit tests:

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -1298,6 +1298,37 @@ def test_transcription_request_builds_asr_generate_request() -> None:
     assert gen_req.stream is False
 
 
+def test_translation_request_builds_whisper_translate_request() -> None:
+    gen_req = build_transcription_generate_request(
+        audio_bytes=b"RIFF",
+        filename="sample.wav",
+        content_type="audio/wav",
+        model="openai/whisper-large-v3",
+        language=None,
+        prompt=None,
+        temperature=None,
+        task="translate",
+    )
+
+    assert gen_req.extra_params == {"task": "translate"}
+    assert gen_req.metadata == {"task": "asr"}
+    assert gen_req.output_modalities == ["text"]
+
+
+def test_audio_text_request_rejects_unknown_task() -> None:
+    with pytest.raises(ValueError, match="Unsupported audio text task"):
+        build_transcription_generate_request(
+            audio_bytes=b"RIFF",
+            filename="sample.wav",
+            content_type="audio/wav",
+            model="openai/whisper-large-v3",
+            language=None,
+            prompt=None,
+            temperature=None,
+            task="summarize",
+        )
+
+
 def test_transcription_request_passes_explicit_temperature() -> None:
     gen_req = build_transcription_generate_request(
         audio_bytes=b"RIFF",
@@ -1353,6 +1384,118 @@ def test_transcription_endpoint_returns_text_json() -> None:
     assert request.model == "openai/whisper-large-v3"
     assert request.prompt["filename"] == "sample.wav"
     assert request.extra_params["language"] == "en"
+
+
+def test_translation_endpoint_returns_english_text_json() -> None:
+    translation_client = SuccessfulTranscriptionClient()
+    client = TestClient(
+        create_app(
+            translation_client,
+            model_name="openai/whisper-large-v3",
+            architectures=["WhisperForConditionalGeneration"],
+        )
+    )
+
+    response = client.post(
+        "/v1/audio/translations",
+        data={"model": "openai/whisper-large-v3", "language": "zh"},
+        files={"file": ("sample.wav", b"RIFF", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"text": "hello world"}
+    assert translation_client.requests
+    request = translation_client.requests[0]
+    assert request.model == "openai/whisper-large-v3"
+    assert request.extra_params == {"task": "translate", "language": "zh"}
+
+
+def test_translation_endpoint_marks_verbose_response() -> None:
+    translation_client = SuccessfulTranscriptionClient()
+    client = TestClient(
+        create_app(
+            translation_client,
+            model_name="openai/whisper-large-v3",
+            architectures=["WhisperForConditionalGeneration"],
+        )
+    )
+
+    response = client.post(
+        "/v1/audio/translations",
+        data={
+            "model": "openai/whisper-large-v3",
+            "language": "zh",
+            "response_format": "verbose_json",
+        },
+        files={"file": ("sample.wav", b"RIFF", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["task"] == "translate"
+    assert response.json()["language"] == "english"
+    assert response.json()["text"] == "hello world"
+
+
+def test_translation_endpoint_requires_source_language() -> None:
+    translation_client = SuccessfulTranscriptionClient()
+    client = TestClient(
+        create_app(
+            translation_client,
+            model_name="openai/whisper-large-v3",
+            architectures=["WhisperForConditionalGeneration"],
+        )
+    )
+
+    response = client.post(
+        "/v1/audio/translations",
+        data={"model": "openai/whisper-large-v3"},
+        files={"file": ("sample.wav", b"RIFF", "audio/wav")},
+    )
+
+    assert response.status_code == 400
+    assert "explicit source language" in response.json()["detail"]
+    assert not translation_client.requests
+
+
+def test_translation_endpoint_rejects_non_whisper_pipeline() -> None:
+    translation_client = SuccessfulTranscriptionClient()
+    client = TestClient(
+        create_app(
+            translation_client,
+            model_name="FunAudioLLM/Fun-ASR-Nano-2512-hf",
+            architectures=["FunAsrNanoForConditionalGeneration"],
+        )
+    )
+
+    response = client.post(
+        "/v1/audio/translations",
+        data={"model": "FunAudioLLM/Fun-ASR-Nano-2512-hf"},
+        files={"file": ("sample.wav", b"RIFF", "audio/wav")},
+    )
+
+    assert response.status_code == 400
+    assert "requires a Whisper ASR pipeline" in response.json()["detail"]
+    assert not translation_client.requests
+
+
+def test_translation_endpoint_maps_unsupported_language_to_400() -> None:
+    error = "unsupported language 'klingon'"
+    client = TestClient(
+        create_app(
+            _fault_client("qwen3-omni", error=error),
+            model_name="openai/whisper-large-v3",
+            architectures=["WhisperForConditionalGeneration"],
+        )
+    )
+
+    response = client.post(
+        "/v1/audio/translations",
+        data={"model": "openai/whisper-large-v3", "language": "klingon"},
+        files={"file": ("sample.wav", b"RIFF", "audio/wav")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == error
 
 
 def test_transcription_endpoint_maps_bad_request_error_to_400() -> None:

--- a/tests/unit_test/whisper_asr/test_pipeline.py
+++ b/tests/unit_test/whisper_asr/test_pipeline.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import inspect
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import sglang_omni.model_runner.base as model_runner_base
@@ -10,6 +12,8 @@ import sglang_omni.models.whisper_asr.stages as whisper_asr_stages
 import sglang_omni.scheduling.bootstrap as bootstrap
 import sglang_omni.scheduling.omni_scheduler as omni_scheduler
 import sglang_omni.scheduling.sglang_backend as sglang_backend
+from sglang_omni.config.manager import ConfigManager
+from sglang_omni.config.runtime import resolve_stage_static_factory_args
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from sglang_omni.models.whisper_asr import request_builders as whisper_request_builders
 from sglang_omni.models.whisper_asr.config import WhisperASRPipelineConfig
@@ -25,14 +29,41 @@ def test_whisper_asr_config_uses_single_batched_stage() -> None:
     assert config.gpu_placement == {"asr": 0}
     assert config.stages[0].factory.endswith("create_sglang_whisper_asr_executor")
     assert config.stages[0].factory_args["device"] == "cuda:0"
+    assert WhisperASRPipelineConfig.mem_fraction_role_to_stage() == {"asr": "asr"}
+    assert WhisperASRPipelineConfig.generation_sglang_role_to_stage() == {
+        "generation": "asr"
+    }
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("WhisperForConditionalGeneration")
         is WhisperASRPipelineConfig
     )
 
 
+def test_whisper_asr_compile_default_is_configurable() -> None:
+    signature = inspect.signature(whisper_asr_stages.create_sglang_whisper_asr_executor)
+
+    assert signature.parameters["enable_torch_compile"].default is True
+
+
+def test_whisper_asr_rtx4090_profile_is_bf16_and_bounded() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    config = ConfigManager.from_file(
+        str(repo_root / "examples/configs/whisper_asr_rtx4090.yaml")
+    ).config
+    stage = config.stages[0]
+
+    factory_args = resolve_stage_static_factory_args(stage, config)
+
+    assert factory_args["dtype"] == "bfloat16"
+    assert factory_args["max_running_requests"] == 16
+    assert factory_args["enable_torch_compile"] is False
+    assert factory_args["server_args_overrides"]["mem_fraction_static"] == 0.65
+
+
 def test_whisper_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
     build_kwargs: dict[str, object] = {}
+    runtime_logs: list[tuple[str, tuple[object, ...]]] = []
+    cuda_graph_calls: list[None] = []
     fake_processor = SimpleNamespace(
         tokenizer=object(),
         feature_extractor=SimpleNamespace(nb_max_frames=3000),
@@ -55,6 +86,21 @@ def test_whisper_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
         lambda **kwargs: (object(), object()),
     )
     monkeypatch.setattr(
+        whisper_asr_stages,
+        "get_visible_gpu_sm_version",
+        lambda gpu_id: 89,
+    )
+    monkeypatch.setattr(
+        whisper_asr_stages,
+        "get_process_gpu_memory_bytes",
+        lambda gpu_id: 0,
+    )
+    monkeypatch.setattr(
+        whisper_asr_stages.logger,
+        "info",
+        lambda message, *args: runtime_logs.append((message, args)),
+    )
+    monkeypatch.setattr(
         model_runner_base,
         "ModelRunner",
         lambda *args, **kwargs: object(),
@@ -72,7 +118,10 @@ def test_whisper_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
 
     def _fake_server_args_builder(model_path, context_length, **overrides):
         build_kwargs.update(overrides)
-        server_args = FakeServerArgs(**overrides)
+        server_args = FakeServerArgs(
+            **{key: value for key, value in overrides.items() if key != "cuda_graph_bs"}
+        )
+        server_args.attention_backend = "flashinfer"
         server_args.cuda_graph_config = SimpleNamespace(
             decode=SimpleNamespace(
                 max_bs=overrides["cuda_graph_max_bs"],
@@ -82,8 +131,13 @@ def test_whisper_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
         return server_args
 
     def _fake_create_infrastructure(server_args, gpu_id, **kwargs):
-        model_worker = SimpleNamespace(model_runner=SimpleNamespace(model=object()))
-        return False, (
+        model_worker = SimpleNamespace(
+            model_runner=SimpleNamespace(
+                model=object(),
+                init_cuda_graphs=lambda: cuda_graph_calls.append(None),
+            )
+        )
+        return True, (
             model_worker,
             object(),
             object(),
@@ -108,3 +162,9 @@ def test_whisper_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
 
     assert build_kwargs["cuda_graph_max_bs"] == 16
     assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 12, 16]
+    assert build_kwargs["enable_torch_compile"] is True
+    assert cuda_graph_calls == [None]
+    runtime_log = next(
+        entry for entry in runtime_logs if entry[0].startswith("Whisper ASR runtime")
+    )
+    assert runtime_log[1][4] == [1, 2, 4, 8, 12, 16]

--- a/tests/unit_test/whisper_asr/test_request_builders.py
+++ b/tests/unit_test/whisper_asr/test_request_builders.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+import sglang_omni.models.whisper_asr.request_builders as request_builders
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+class _FakeTokenizer:
+    eos_token_id = 2
+    pad_token_id = 0
+    vocab_size = 100
+
+    def __init__(self) -> None:
+        self.language = "original"
+        self.task = "original"
+        self.predict_timestamps = True
+
+    @property
+    def prefix_tokens(self) -> list[int]:
+        tokens = [10]
+        if self.language is not None:
+            tokens.append({"english": 11, "chinese": 12}[self.language])
+        tokens.append({"transcribe": 20, "translate": 21}[self.task])
+        if not self.predict_timestamps:
+            tokens.append(30)
+        return tokens
+
+    def decode(self, token_ids, *, skip_special_tokens=False) -> str:
+        del skip_special_tokens
+        return " ".join(str(token_id) for token_id in token_ids)
+
+
+class _SlowFakeTokenizer(_FakeTokenizer):
+    @property
+    def prefix_tokens(self) -> list[int]:
+        language = self.language
+        time.sleep(0.001)
+        task = self.task
+        predict_timestamps = self.predict_timestamps
+        tokens = [10]
+        if language is not None:
+            tokens.append({"english": 11, "chinese": 12}[language])
+        tokens.append({"transcribe": 20, "translate": 21}[task])
+        if not predict_timestamps:
+            tokens.append(30)
+        return tokens
+
+
+class _FailingPrefixTokenizer(_FakeTokenizer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fail_next = True
+
+    @property
+    def prefix_tokens(self) -> list[int]:
+        if self.fail_next:
+            self.fail_next = False
+            raise ValueError("unsupported language")
+        return super().prefix_tokens
+
+
+def _processor() -> SimpleNamespace:
+    def _feature_extractor(audio, *, sampling_rate, return_tensors):
+        assert len(audio) > 0
+        assert sampling_rate == 16000
+        assert return_tensors == "pt"
+        return SimpleNamespace(input_features=torch.zeros((1, 80, 3000)))
+
+    return SimpleNamespace(feature_extractor=_feature_extractor)
+
+
+def _payload(params: dict | None = None) -> StagePayload:
+    return StagePayload(
+        request_id="whisper-request",
+        request=OmniRequest(
+            inputs={"audio_bytes": b"wav"},
+            params=params or {},
+        ),
+        data={},
+    )
+
+
+def _adapters(tokenizer: _FakeTokenizer | None = None):
+    tokenizer = tokenizer or _FakeTokenizer()
+    return request_builders.make_whisper_scheduler_adapters(
+        processor=_processor(),
+        tokenizer=tokenizer,
+        generation_config=SimpleNamespace(suppress_tokens=[]),
+        encoder_token_count=1500,
+        max_new_tokens=64,
+    )
+
+
+def test_whisper_transcription_defaults_to_english(monkeypatch) -> None:
+    monkeypatch.setattr(
+        request_builders,
+        "_load_audio",
+        lambda source: np.zeros(16000, dtype=np.float32),
+    )
+    tokenizer = _FakeTokenizer()
+    request_builder, _ = _adapters(tokenizer)
+
+    data = request_builder(_payload())
+
+    assert data.prompt_token_ids == [10, 11, 20, 30]
+    assert data.language == "english"
+    assert data.task == "transcribe"
+    assert data.req.sampling_params.max_new_tokens == 64
+    assert tokenizer.language == "original"
+    assert tokenizer.task == "original"
+    assert tokenizer.predict_timestamps is True
+
+
+def test_whisper_prefix_state_is_request_local_under_concurrency(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        request_builders,
+        "_load_audio",
+        lambda source: np.zeros(16000, dtype=np.float32),
+    )
+    tokenizer = _SlowFakeTokenizer()
+    request_builder, _ = _adapters(tokenizer)
+    params = [
+        {"task": "transcribe", "language": "english"},
+        {"task": "translate", "language": "chinese"},
+    ] * 16
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(request_builder, map(_payload, params)))
+
+    assert [result.prompt_token_ids for result in results] == [
+        [10, 11, 20, 30],
+        [10, 12, 21, 30],
+    ] * 16
+    assert tokenizer.language == "original"
+    assert tokenizer.task == "original"
+    assert tokenizer.predict_timestamps is True
+
+
+def test_whisper_prefix_restores_missing_optional_state() -> None:
+    tokenizer = _FakeTokenizer()
+    del tokenizer.language
+    del tokenizer.task
+    del tokenizer.predict_timestamps
+
+    assert request_builders._build_prefix_tokens(
+        tokenizer,
+        language="english",
+        task="transcribe",
+    ) == [10, 11, 20, 30]
+    with pytest.raises(AttributeError):
+        _ = tokenizer.language
+    with pytest.raises(AttributeError):
+        _ = tokenizer.task
+    with pytest.raises(AttributeError):
+        _ = tokenizer.predict_timestamps
+
+
+def test_whisper_prefix_restores_state_after_tokenizer_error() -> None:
+    tokenizer = _FailingPrefixTokenizer()
+
+    with pytest.raises(ValueError, match="unsupported language"):
+        request_builders._build_prefix_tokens(
+            tokenizer,
+            language="invalid",
+            task="translate",
+        )
+
+    assert tokenizer.language == "original"
+    assert tokenizer.task == "original"
+    assert tokenizer.predict_timestamps is True
+    assert request_builders._build_prefix_tokens(
+        tokenizer,
+        language="english",
+        task="transcribe",
+    ) == [10, 11, 20, 30]
+
+
+def test_whisper_logit_bias_treats_missing_suppress_tokens_as_optional() -> None:
+    assert request_builders._build_logit_bias(SimpleNamespace()) is None
+
+
+def test_whisper_translation_requires_source_language_before_audio_load(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        request_builders,
+        "_load_audio",
+        lambda source: (_ for _ in ()).throw(AssertionError("must not load audio")),
+    )
+    request_builder, _ = _adapters()
+
+    with pytest.raises(ValueError, match="requires an explicit source language"):
+        request_builder(_payload({"task": "translate"}))
+
+
+def test_whisper_translation_accepts_explicit_source_language(monkeypatch) -> None:
+    monkeypatch.setattr(
+        request_builders,
+        "_load_audio",
+        lambda source: np.zeros(16000, dtype=np.float32),
+    )
+    request_builder, result_adapter = _adapters()
+
+    data = request_builder(_payload({"task": "translate", "language": "chinese"}))
+
+    assert data.prompt_token_ids == [10, 12, 21, 30]
+    assert data.language == "english"
+    assert data.task == "translate"
+
+    data.output_ids = [40, 41]
+    result = result_adapter(data)
+    assert result.data["text"] == "40 41"
+    assert result.data["language"] == "english"
+    assert result.data["task"] == "translate"
+
+
+def test_whisper_request_rejects_unknown_task(monkeypatch) -> None:
+    monkeypatch.setattr(
+        request_builders,
+        "_load_audio",
+        lambda source: np.zeros(16000, dtype=np.float32),
+    )
+    request_builder, _ = _adapters()
+
+    with pytest.raises(ValueError, match="Whisper task must be one of"):
+        request_builder(_payload({"task": "summarize"}))
+
+
+def test_whisper_request_rejects_excessive_token_budget(monkeypatch) -> None:
+    monkeypatch.setattr(
+        request_builders,
+        "_load_audio",
+        lambda source: np.zeros(16000, dtype=np.float32),
+    )
+    request_builder, _ = _adapters()
+
+    with pytest.raises(ValueError, match="max_new_tokens must be between 1 and 64"):
+        request_builder(_payload({"max_new_tokens": 65}))
+
+
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        ({"task": "summarize"}, "Whisper task must be one of"),
+        ({"max_new_tokens": 65}, "max_new_tokens must be between 1 and 64"),
+        ({"task": "translate"}, "requires an explicit source language"),
+        ({"max_new_tokens": True}, "max_new_tokens must be an integer"),
+        ({"max_new_tokens": 3.9}, "max_new_tokens must be an integer"),
+    ],
+)
+def test_whisper_rejects_invalid_params_before_loading_audio(
+    monkeypatch, params, message
+) -> None:
+    monkeypatch.setattr(
+        request_builders,
+        "_load_audio",
+        lambda source: (_ for _ in ()).throw(AssertionError("audio load must not run")),
+    )
+    request_builder, _ = _adapters()
+
+    with pytest.raises(ValueError, match=message):
+        request_builder(_payload(params))
+
+
+def test_whisper_request_rejects_audio_over_30_seconds(monkeypatch) -> None:
+    monkeypatch.setattr(
+        request_builders,
+        "_load_audio",
+        lambda source: np.zeros(30 * 16000 + 1, dtype=np.float32),
+    )
+    request_builder, _ = _adapters()
+
+    with pytest.raises(ValueError, match="accepts audio up to 30.0 seconds"):
+        request_builder(_payload())
+
+
+def test_whisper_request_reports_audio_decode_failure(monkeypatch) -> None:
+    monkeypatch.setattr(
+        request_builders,
+        "_load_audio",
+        lambda source: (_ for _ in ()).throw(RuntimeError("decode failed")),
+    )
+    request_builder, _ = _adapters()
+
+    with pytest.raises(ValueError, match="could not decode the uploaded audio"):
+        request_builder(_payload())


### PR DESCRIPTION
## Summary

- migrate @wirybeaver's reviewed `/v1/audio/translations` slice from https://github.com/wirybeaver/sglang-omni/pull/3 onto current `main`
- expose Whisper speech-to-English translation through the shared audio-text request/response path while rejecting non-Whisper pipelines
- require an explicit source language until a language-detection decode step exists, matching the dependent Whisper request-builder contract in #1279
- preserve current transcription streaming cleanup through `_ClosableStreamingResponse`
- document the translation route and its current non-streaming/source-language limits

## Ownership and scope

The public multipart route, response formatting, and HTTP error mapping stay in `sglang_omni/serve/openai_api.py`. Whisper prefix construction and decode validation remain model-local under `sglang_omni/models/whisper_asr/` in #1279. There are no Stage, scheduler, relay, router, or lifecycle-control changes.

## Dependency

Stacked on #1279. Until #1279 merges, the GitHub comparison against `main` also shows that dependency's commit. The translation-only review range is `c7d7bea7..HEAD`; this branch will be rebased onto `main` after #1279 lands.

## Validation

- red phase: the migrated translation tests failed on the missing `task` parameter/route, the missing-language guard first returned HTTP 200, and an unsupported language first returned HTTP 500
- `python -m pytest tests/unit_test/serve/test_openai_api.py -q` - 62 passed on the local M4 using import-only torchaudio/MLX stubs
- production FastAPI/TestClient smoke call to `/v1/audio/translations` - HTTP 200, `{"text":"hello world"}`, backend params `{"task":"translate","language":"zh"}`
- changed-file Black/isort/AST hooks - passed
- `git diff --check` - passed

## Tracking

- parent roadmap: #1120
- validation report: #1170
- umbrella draft: #1171
- source review PR: https://github.com/wirybeaver/sglang-omni/pull/3
