### PR TITLE
Add ASR stream edge-case tests

### DIFF
--- a/tests/unit_test/fun_asr/test_stream_output_builder.py
+++ b/tests/unit_test/fun_asr/test_stream_output_builder.py
@@ -110,19 +110,39 @@ def test_min_emit_interval_first_delta_immediate_then_eos_flushes() -> None:
 
     assert [m.data["text"] for m in builder("r", rd, _make_req_output(1))] == ["A"]
     assert builder("r", rd, _make_req_output(2)) == []
-    assert [m.data["text"] for m in builder("r", rd, _make_req_output(_EOS))] == ["B"]
+
+    msgs = builder("r", rd, _make_req_output(_EOS))
+
+    assert [m.data["text"] for m in msgs] == ["B"]
+    assert [m.metadata for m in msgs] == [{"modality": "text", "token_id": _EOS}]
 
 
 def test_terminal_finish_flushes_rate_limited_pending_tokens() -> None:
     builder = _builder({1: b"A", 2: b"B"}, interval_s=3600.0)
     rd = _make_req_data()
 
+    assert callable(builder.flush)
     assert [m.data["text"] for m in builder("r", rd, _make_req_output(1))] == ["A"]
     assert builder("r", rd, _make_req_output(2)) == []
 
     rd.req.finished = lambda: True
-    msgs = builder("r", rd, _make_req_output(None))
+    msgs = builder.flush("r", rd)
+
     assert [m.data["text"] for m in msgs] == ["B"]
+    assert [m.metadata for m in msgs] == [{"modality": "text", "token_id": None}]
+
+
+def test_terminal_finish_emits_incomplete_utf8_replacement() -> None:
+    builder = _builder({1: b"\xe4"})
+    rd = _make_req_data()
+
+    assert builder("r", rd, _make_req_output(1)) == []
+    rd.req.finished = lambda: True
+    msgs = builder.flush("r", rd)
+
+    assert [m.data["text"] for m in msgs] == ["\ufffd"]
+    assert [m.metadata for m in msgs] == [{"modality": "text", "token_id": None}]
+    assert rd.req._fun_asr_stream_pending_ids == []
 
 
 def test_missing_required_scheduler_contract_fails_visibly() -> None:

--- a/tests/unit_test/moss_transcribe_diarize/test_stream_output_builder.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_stream_output_builder.py
@@ -106,6 +106,12 @@ def test_silent_when_no_token_this_step():
     assert builder("req-1", rd, _make_req_output(None)) == []
 
 
+def test_no_terminal_flush_hook():
+    builder = _builder({1: b"A"})
+
+    assert not hasattr(builder, "flush")
+
+
 def test_silent_when_req_or_payload_missing():
     builder = _builder({1: b"A"})
 
@@ -215,7 +221,18 @@ def test_min_emit_interval_holds_then_eos_flushes():
     assert builder("r", rd, _make_req_output(3)) == []
 
     msgs = builder("r", rd, _make_req_output(_EOS))
+
     assert [m.data["text"] for m in msgs] == ["BC"]
+    assert [m.metadata for m in msgs] == [{"modality": "text", "token_id": _EOS}]
+
+
+def test_eos_holds_incomplete_utf8_replacement():
+    builder = _interval_builder({1: b"\xe4", _EOS: b"<eos>"}, interval_s=3600.0)
+    rd = _make_req_data()
+
+    assert builder("r", rd, _make_req_output(1)) == []
+    assert builder("r", rd, _make_req_output(_EOS)) == []
+    assert rd.req._moss_stream_pending_ids == [1]
 
 
 def test_min_emit_interval_elapsed_flushes_batch():


### PR DESCRIPTION
## Summary
- Convert this PR to a tests-only follow-up after #1275 merged the ASR token text streaming refactor for #1271.
- Add model-level regression coverage for Fun-ASR and MOSS-Transcribe-Diarize stream output builders around edge cases not directly asserted before:
  - EOS-triggered rate-limit flush preserves `metadata.token_id == eos_token_id`.
  - Fun-ASR exposes and uses the terminal `.flush` hook, with terminal flush metadata carrying `token_id: None`.
  - Fun-ASR terminal flush emits a trailing incomplete UTF-8 replacement and clears pending stream state.
  - MOSS-TD does not expose a terminal `.flush` hook and keeps incomplete UTF-8 pending on EOS.

Related to #1271 and follow-up to #1275.

## Validation
- `uvx ruff check tests/unit_test/fun_asr/test_stream_output_builder.py tests/unit_test/moss_transcribe_diarize/test_stream_output_builder.py`
- `uvx black --check --target-version py312 tests/unit_test/fun_asr/test_stream_output_builder.py tests/unit_test/moss_transcribe_diarize/test_stream_output_builder.py`
- CI-image focused ASR stream/request-builder tests: 58 passed.

  ```bash
  docker run --rm -v "$PWD":/workspace -w /workspace hongccc/sglang-omni:dev \
    bash -lc 'python -m pytest tests/unit_test/fun_asr/test_stream_output_builder.py tests/unit_test/moss_transcribe_diarize/test_stream_output_builder.py tests/unit_test/fun_asr/test_request_builders.py tests/unit_test/moss_transcribe_diarize/test_request_builders.py -q'
  ```
