### PR TITLE
feat(bench): add consumer ASR stability validation

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -186,7 +186,8 @@ python -m benchmarks.eval.benchmark_omni_seedtts \
 | `eval/benchmark_omni_mmmu.py` | MMMU (VLM accuracy + speed) | Qwen3-Omni | `/v1/chat/completions` |
 | `eval/benchmark_omni_videomme.py` | Video-MME (video understanding) | Qwen3-Omni | `/v1/chat/completions` |
 | `eval/benchmark_omni_videoamme.py` | Video-AMME (video + audio question understanding) | Qwen3-Omni | `/v1/chat/completions` |
-| `eval/benchmark_asr_seedtts.py` | ASR concurrency scaling on SeedTTS EN/ZH | Qwen3-ASR, Fun-ASR | `/v1/audio/transcriptions` |
+| `eval/benchmark_asr_seedtts.py` | ASR concurrency scaling on SeedTTS EN/ZH | Qwen3-ASR, Fun-ASR, Whisper | `/v1/audio/transcriptions` |
+| `eval/benchmark_asr_stability.py` | ASR functional, soak, chaos, and memory-retention validation | Qwen3-ASR, Fun-ASR, Whisper | `/v1/audio/transcriptions`, `/v1/audio/translations`, `/health` |
 
 See [tts_serving/README.md](tts_serving/README.md) for the TTS serving
 benchmark design, harness contract, scenario matrix, and Docker usage.
@@ -207,12 +208,12 @@ and MOSS-TTS. MOSS-TTS additionally supports duration control through
 docstring (sequential phases on CI to reduce OOM risk).
 
 `benchmark_asr_seedtts.py` is a standalone ASR fan-out sweep (issue #646): it
-transcribes the SeedTTS *reference* clips directly against a running Qwen3-ASR
-or Fun-ASR router and reports WER + speed + per-worker routing balance per
-concurrency level. It reports evaluation coverage and RTFx (successful
-input-audio seconds per wall-clock second) alongside the existing RTF. Use it
-to measure how ASR concurrency affects capacity, latency, and WER for a given
-workload.
+transcribes the SeedTTS *reference* clips directly against a running Qwen3-ASR,
+Fun-ASR, or Whisper router and reports WER, speed, per-sample evidence, and
+per-worker routing balance per concurrency level. It reports evaluation
+coverage and RTFx (successful input-audio seconds per wall-clock second)
+alongside the existing RTF. Use it to measure how ASR concurrency affects
+capacity, latency, and WER for a given workload.
 
 Add `--stream` to exercise the transcription SSE path and report text TTFT and
 inter-chunk latency while retaining the terminal transcript for WER:
@@ -222,6 +223,86 @@ python -m benchmarks.eval.benchmark_asr_seedtts \
   --model-path FunAudioLLM/Fun-ASR-Nano-2512-hf --port 8000 \
   --max-samples 20 --concurrencies 2 --repeats 1 --stream
 ```
+
+### Consumer ASR stability and memory-retention validation
+
+`benchmark_asr_stability.py` validates the running public server, rather than
+calling model code directly. It covers EN/ZH transcription, SSE terminal-text
+consistency, cancel/reconnect recovery, malformed-audio fault injection, staged
+load and `/health`. With explicit `--include-translation`, Whisper also mixes
+speech-to-English translation into Chinese traffic.
+
+Prepare the canonical bilingual SeedTTS dataset, then start the server in one
+terminal:
+
+```bash
+python -m benchmarks.dataset.prepare --dataset seedtts
+FUN_ASR_REVISION=854d88f94205cd17d2afdb24332130d86fbe654a
+FUN_ASR_PATH="$(hf download FunAudioLLM/Fun-ASR-Nano-2512-hf \
+  --revision "${FUN_ASR_REVISION}")"
+
+
+python -m sglang_omni.cli serve \
+  --model-path "${FUN_ASR_PATH}" \
+  --model-name FunAudioLLM/Fun-ASR-Nano-2512-hf --port 8000
+```
+
+Run the 30-minute consumer-GPU profile in a second terminal:
+
+```bash
+FUN_ASR_REVISION=854d88f94205cd17d2afdb24332130d86fbe654a
+FUN_ASR_PATH="$(hf download FunAudioLLM/Fun-ASR-Nano-2512-hf \
+  --revision "${FUN_ASR_REVISION}")"
+
+python -m benchmarks.eval.benchmark_asr_stability \
+  --model-path FunAudioLLM/Fun-ASR-Nano-2512-hf \
+  --model-revision 854d88f94205cd17d2afdb24332130d86fbe654a \
+  --dataset-revision 27f4c1adee83b5b29b7c4b375f6b976324bda308 \
+  --port 8000 --duration-s 1800 --concurrencies 1,4,8,16 \
+  --min-free-memory-mib 2048 --max-retained-memory-mib 256 \
+  --launch-command "python -m sglang_omni.cli serve \
+    --model-path ${FUN_ASR_PATH} \
+    --model-name FunAudioLLM/Fun-ASR-Nano-2512-hf --port 8000" \
+  --output results/fun-asr-stability.json
+```
+
+`--duration-s` is divided evenly across the requested concurrency stages. The
+concurrency value is an exact cap across normal load and injected fault
+requests, not a worker count with extra chaos traffic added on top. With
+translation enabled, one in every four Chinese requests is sent to
+`/v1/audio/translations`; the cadence is shared by the whole stage and the
+returned text must be predominantly Latin rather than untranslated Chinese.
+Every stage must complete normal requests and at least one chaos event, and
+translation stages must complete translation traffic, or the result fails.
+
+The memory gate requires working NVML and `psutil` sampling. It records
+device-wide used/free memory, GPU-process allocation, the host RSS and CPU use
+of the GPU process IDs, utilization, and power. Missing samples fail closed.
+`--min-free-memory-mib` applies to the minimum observed free device memory;
+`--max-retained-memory-mib` compares the post-cooldown device allocation with
+the pre-functional checkpoint. Use `--cooldown-s` to match the deployment's
+expected cache-release interval.
+
+The stability harness always loads distinct `en` and `zh` dataset splits. A
+single local `meta.lst` is rejected because reusing it for both languages would
+invalidate the bilingual evidence. HTTP JSON, health, and SSE reads are bounded;
+oversized or malformed responses become request failures instead of growing
+client memory without limit. The JSON result is written atomically and records
+the repository state, dependency inventory, effective input-content hash,
+declared server settings, exact/observed concurrency, translation cadence,
+latency reservoir method, chaos events, memory checkpoints, and final health.
+
+Validated revision references are Qwen3-ASR
+`7278e1e70fe206f11671096ffdd38061171dd6e5`, Fun-ASR
+`854d88f94205cd17d2afdb24332130d86fbe654a`, and Whisper
+`06f233fe06e710322aca913c1bc4249a0d71fce1`. The harness cannot inspect which
+checkpoint the server loaded, so `--model-revision` is required for auditable
+evidence. Whisper translation and boundary checks are explicit opt-ins until
+the running server exposes the matching contracts. Use `--include-translation`
+only with `/v1/audio/translations` support (tracked in #1280), and use
+`--check-audio-boundary` only with an over-limit rejection guard (tracked in
+#1279). Translation is non-streaming and requires
+`--translation-source-language` until automatic detection exists.
 
 Both `*_seedtts.py` scripts also support speech quality and similarity evaluation via UTMOS and WavLM speaker verification metrics. Running with `--utmos-only` or `--similarity-only` loads the respective pre-trained predictor and computes scores on the previously generated audio in the output directory without requiring the TTS/ASR servers to be running.
 

--- a/benchmarks/dataset/prepare.py
+++ b/benchmarks/dataset/prepare.py
@@ -23,8 +23,11 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+SEEDTTS_DATASET_ID = "zhaochenyang20/seed-tts-eval-arrow"
+SEEDTTS_DATASET_REVISION = "27f4c1adee83b5b29b7c4b375f6b976324bda308"
+
 DATASETS: dict[str, str] = {
-    "seedtts": "zhaochenyang20/seed-tts-eval-arrow",
+    "seedtts": SEEDTTS_DATASET_ID,
     "seedtts-mini": "zhaochenyang20/seed-tts-eval-mini-arrow",
     "seedtts-50": "zhaochenyang20/seed-tts-eval-50-arrow",
     "mmmu": "MMMU/MMMU",
@@ -41,21 +44,43 @@ DATASETS: dict[str, str] = {
 }
 
 
-def download_dataset(repo_id: str, *, quiet: bool = False) -> None:
+def download_dataset(
+    repo_id: str,
+    *,
+    revision: str | None = None,
+    quiet: bool = False,
+) -> None:
     """Pre-warm the HuggingFace ``datasets`` cache for *repo_id*."""
     from datasets import get_dataset_config_names, load_dataset
     from huggingface_hub import hf_hub_download
 
+    if revision is None and repo_id == SEEDTTS_DATASET_ID:
+        revision = SEEDTTS_DATASET_REVISION
+    revision_kwargs = {"revision": revision} if revision else {}
     if not quiet:
-        logger.info(f"Pre-warming HuggingFace cache for {repo_id} ...")
+        logger.info(
+            "Pre-warming HuggingFace cache for %s revision=%s ...",
+            repo_id,
+            revision or "default",
+        )
 
     if repo_id == "MMMU/MMMU":
-        config_names = get_dataset_config_names(repo_id)
+        config_names = get_dataset_config_names(repo_id, **revision_kwargs)
         for config_name in config_names:
-            load_dataset(repo_id, config_name, split="validation")
+            load_dataset(
+                repo_id,
+                config_name,
+                split="validation",
+                **revision_kwargs,
+            )
     elif repo_id == "BoJack/MMAR":
-        load_dataset(repo_id)
-        hf_hub_download(repo_id, "mmar-audio.tar.gz", repo_type="dataset")
+        load_dataset(repo_id, **revision_kwargs)
+        hf_hub_download(
+            repo_id,
+            "mmar-audio.tar.gz",
+            repo_type="dataset",
+            **revision_kwargs,
+        )
     elif repo_id.startswith("lmms-lab/mmau:"):
         dataset_id, split = repo_id.split(":", 1)
         load_dataset(
@@ -63,9 +88,10 @@ def download_dataset(repo_id: str, *, quiet: bool = False) -> None:
             split=split,
             data_files={split: f"data/{split}-*.parquet"},
             verification_mode="no_checks",
+            **revision_kwargs,
         )
     else:
-        load_dataset(repo_id)
+        load_dataset(repo_id, **revision_kwargs)
 
     if not quiet:
         logger.info(f"Dataset {repo_id} cached.")
@@ -79,10 +105,15 @@ def main() -> None:
         default="seedtts",
         help="Dataset to download.",
     )
+    parser.add_argument(
+        "--revision",
+        default=None,
+        help="Dataset revision; known evaluation datasets use a pinned default.",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
-    download_dataset(DATASETS[args.dataset])
+    download_dataset(DATASETS[args.dataset], revision=args.revision)
 
 
 if __name__ == "__main__":

--- a/benchmarks/dataset/seedtts.py
+++ b/benchmarks/dataset/seedtts.py
@@ -16,6 +16,8 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
+from benchmarks.dataset.prepare import SEEDTTS_DATASET_ID, SEEDTTS_DATASET_REVISION
+
 logger = logging.getLogger(__name__)
 
 _REQUIRED_COLUMNS = {
@@ -35,7 +37,7 @@ class SampleInput:
     target_text: str
 
 
-_STAGED_CACHE: dict[tuple[str, str, int | None], list[SampleInput]] = {}
+_STAGED_CACHE: dict[tuple[str, str, str | None, int | None], list[SampleInput]] = {}
 
 
 def _resolve_staged_audio_path(
@@ -80,6 +82,7 @@ def load_seedtts_samples(
     max_samples: int | None = None,
     *,
     split: str = "en",
+    revision: str | None = None,
 ) -> list[SampleInput]:
     """Load SeedTTS evaluation samples.
 
@@ -91,7 +94,9 @@ def load_seedtts_samples(
     """
     if os.path.isfile(source) or source.endswith(".lst"):
         return _load_from_meta_lst(source, max_samples)
-    return _load_from_arrow(source, split, max_samples)
+    if revision is None and source == SEEDTTS_DATASET_ID:
+        revision = SEEDTTS_DATASET_REVISION
+    return _load_from_arrow(source, split, revision, max_samples)
 
 
 def _load_from_meta_lst(path: str, max_samples: int | None) -> list[SampleInput]:
@@ -123,22 +128,31 @@ def _load_from_meta_lst(path: str, max_samples: int | None) -> list[SampleInput]
 
 
 def _load_from_arrow(
-    repo_id: str, split: str, max_samples: int | None
+    repo_id: str,
+    split: str,
+    revision: str | None,
+    max_samples: int | None,
 ) -> list[SampleInput]:
     """Load from a HuggingFace Arrow/Parquet dataset repo."""
-    full_cache_key = (repo_id, split, None)
+    full_cache_key = (repo_id, split, revision, None)
     if full_cache_key in _STAGED_CACHE:
         samples = _STAGED_CACHE[full_cache_key]
         return samples[:max_samples] if max_samples is not None else list(samples)
 
-    cache_key = (repo_id, split, max_samples)
+    cache_key = (repo_id, split, revision, max_samples)
     if cache_key in _STAGED_CACHE:
         return list(_STAGED_CACHE[cache_key])
 
     from datasets import Audio, load_dataset
 
-    logger.info("Loading %s split=%s from HuggingFace ...", repo_id, split)
-    ds = load_dataset(repo_id, split=split)
+    logger.info(
+        "Loading %s split=%s revision=%s from HuggingFace ...",
+        repo_id,
+        split,
+        revision or "default",
+    )
+    load_kwargs = {"revision": revision} if revision else {}
+    ds = load_dataset(repo_id, split=split, **load_kwargs)
 
     missing = _REQUIRED_COLUMNS - set(ds.column_names)
     if missing:

--- a/benchmarks/eval/benchmark_asr_seedtts.py
+++ b/benchmarks/eval/benchmark_asr_seedtts.py
@@ -6,7 +6,7 @@
 
 This script transcribes SeedTTS reference clips directly through a running ASR
 router and reports WER, request throughput, RTFx, RTF, latency, and worker
-routing balance. It supports both Qwen3-ASR and Fun-ASR-Nano through
+routing balance. It supports Qwen3-ASR, Fun-ASR-Nano, and Whisper through
 ``--model-path``.
 
 Usage:
@@ -87,6 +87,7 @@ import argparse
 import asyncio
 import hashlib
 import json
+import math
 import os
 import statistics
 
@@ -97,12 +98,15 @@ from benchmarks.dataset.seedtts import SampleInput, load_seedtts_samples
 from benchmarks.runtime_metrics import ResourceMonitor, collect_benchmark_provenance
 from benchmarks.tasks.asr import (
     FUN_ASR_MODEL_PATH,
+    OMNI_WHISPER_MODEL_PATH,
+    PINNED_ASR_MODEL_REVISIONS,
     QWEN3_ASR_MODEL_PATH,
     build_asr_eval_results,
     run_asr_transcription,
 )
 
 DEFAULT_CONCURRENCIES = "1,2,4,8,16,32,64"
+PINNED_MODEL_REVISIONS = PINNED_ASR_MODEL_REVISIONS
 
 
 def _positive_int(value: str) -> int:
@@ -112,6 +116,16 @@ def _positive_int(value: str) -> int:
         raise argparse.ArgumentTypeError(f"expected an integer, got {value!r}") from exc
     if parsed <= 0:
         raise argparse.ArgumentTypeError("value must be greater than zero")
+    return parsed
+
+
+def _positive_float(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected a number, got {value!r}") from exc
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be finite and greater than zero")
     return parsed
 
 
@@ -262,12 +276,14 @@ async def _run_repeat(args, samples, concurrency: int, repeat: int) -> dict:
         "wall_clock_s": benchmark_result["wall_clock_s"],
         "throughput_samples_per_s": speed["throughput_samples_per_s"],
         "rtfx": speed["rtfx"],
+        "audio_seconds_per_s": speed["rtfx"],
         "latency_mean_s": (speed["latency_mean_s"] if has_evaluated_samples else None),
         "latency_p95_s": (speed["latency_p95_s"] if has_evaluated_samples else None),
         "latency_p99_s": (speed["latency_p99_s"] if has_evaluated_samples else None),
         "rtf_mean": speed["rtf_mean"] if has_rtf else None,
         "rtf_p95": speed["rtf_p95"],
         "worker": benchmark_result["worker"],
+        "per_sample": benchmark_result["per_sample"],
         "resources": resources,
     }
     for key in (
@@ -335,6 +351,7 @@ def _aggregate(repeats: list[dict]) -> dict:
         "wall_clock_s": _stat("wall_clock_s"),
         "throughput_samples_per_s": _stat("throughput_samples_per_s"),
         "rtfx": _stat("rtfx"),
+        "audio_seconds_per_s": _stat("audio_seconds_per_s"),
         "latency_mean_s": _stat("latency_mean_s"),
         "latency_p95_s": _stat("latency_p95_s"),
         "latency_p99_s": _stat("latency_p99_s"),
@@ -454,8 +471,8 @@ def parse_args() -> argparse.Namespace:
         default=QWEN3_ASR_MODEL_PATH,
         help=(
             "ASR model id served by the router. Defaults to "
-            f"{QWEN3_ASR_MODEL_PATH}; use "
-            f"{FUN_ASR_MODEL_PATH} for Fun-ASR-Nano."
+            f"{QWEN3_ASR_MODEL_PATH}; other supported consumer models are "
+            f"{FUN_ASR_MODEL_PATH} and {OMNI_WHISPER_MODEL_PATH}."
         ),
     )
     parser.add_argument(
@@ -525,7 +542,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--monitor-interval-s",
-        type=float,
+        type=_positive_float,
         default=0.2,
         help="Resource monitor sampling interval.",
     )

--- a/benchmarks/eval/benchmark_asr_seedtts.py
+++ b/benchmarks/eval/benchmark_asr_seedtts.py
@@ -14,22 +14,21 @@ Usage:
     # Download the test set once:
     python -m benchmarks.dataset.prepare --dataset seedtts
 
-    # Launch Qwen3-ASR behind the router, matching ASR CI
-    python -m sglang_omni_router.serve \
-        --host 0.0.0.0 \
-        --port 8000 \
-        --launcher-config examples/configs/qwen3_asr_router.yaml \
-        --policy least_request \
-        --health-success-threshold 1 \
-        --health-failure-threshold 2 \
-        --health-check-interval-secs 2 \
-        --log-level info
+    # Pin and launch Qwen3-ASR:
+    MODEL_PATH=$(hf download Qwen/Qwen3-ASR-1.7B \
+        --revision 7278e1e70fe206f11671096ffdd38061171dd6e5)
+    sgl-omni serve \
+        --model-path "${MODEL_PATH}" \
+        --model-name Qwen/Qwen3-ASR-1.7B \
+        --port 8000
 
-    # Sweep the issue's matrix (3 repeats each) over the full SeedTTS EN set:
+    # Sweep the full SeedTTS EN set (3 repeats each):
     python -m benchmarks.eval.benchmark_asr_seedtts \
         --port 8000 \
         --concurrencies 1,2,4,8,16,32,64 \
-        --repeats 3
+        --repeats 3 --warmup \
+        --dataset-revision 27f4c1adee83b5b29b7c4b375f6b976324bda308 \
+        --model-revision 7278e1e70fe206f11671096ffdd38061171dd6e5
 
     # Quick local smoke on a 20-sample subset:
     python -m benchmarks.eval.benchmark_asr_seedtts \
@@ -86,14 +85,16 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
 import os
 import statistics
 
 import requests
 
-from benchmarks.dataset.prepare import DATASETS
+from benchmarks.dataset.prepare import DATASETS, SEEDTTS_DATASET_REVISION
 from benchmarks.dataset.seedtts import SampleInput, load_seedtts_samples
+from benchmarks.runtime_metrics import ResourceMonitor, collect_benchmark_provenance
 from benchmarks.tasks.asr import (
     FUN_ASR_MODEL_PATH,
     QWEN3_ASR_MODEL_PATH,
@@ -102,6 +103,40 @@ from benchmarks.tasks.asr import (
 )
 
 DEFAULT_CONCURRENCIES = "1,2,4,8,16,32,64"
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected an integer, got {value!r}") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be greater than zero")
+    return parsed
+
+
+def _parse_concurrencies(value: str) -> list[int]:
+    tokens = [token.strip() for token in value.split(",")]
+    if not tokens or any(not token for token in tokens):
+        raise argparse.ArgumentTypeError(
+            "concurrencies must be a non-empty comma-separated list"
+        )
+    return [_positive_int(token) for token in tokens]
+
+
+def _evaluation_input_sha256(samples: list[SampleInput]) -> str:
+    digest = hashlib.sha256(b"seedtts-evaluation-input-v1\0")
+    for sample in samples:
+        for value in (sample.sample_id, sample.ref_text, sample.target_text):
+            encoded = value.encode()
+            digest.update(len(encoded).to_bytes(8, "big"))
+            digest.update(encoded)
+        with open(sample.ref_audio, "rb") as audio:
+            size = os.fstat(audio.fileno()).st_size
+            digest.update(size.to_bytes(8, "big"))
+            while chunk := audio.read(1024 * 1024):
+                digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _fetch_worker_snapshot(host: str, port: int) -> dict | None:
@@ -183,15 +218,33 @@ async def run_asr_seedtts_once(
 
 
 async def _run_repeat(args, samples, concurrency: int, repeat: int) -> dict:
-    benchmark_result = await run_asr_seedtts_once(
-        samples,
-        host=args.host,
-        port=args.port,
-        model_path=args.model_path,
-        lang=args.lang,
-        concurrency=concurrency,
-        stream=args.stream,
+    monitor = (
+        None
+        if args.disable_resource_monitor
+        else ResourceMonitor(
+            gpu_index=args.gpu_index,
+            interval_s=args.monitor_interval_s,
+        ).start()
     )
+    try:
+        benchmark_result = await run_asr_seedtts_once(
+            samples,
+            host=args.host,
+            port=args.port,
+            model_path=args.model_path,
+            lang=args.lang,
+            concurrency=concurrency,
+            stream=args.stream,
+        )
+    finally:
+        resources = (
+            monitor.stop()
+            if monitor is not None
+            else {
+                "available": False,
+                "error": "resource monitoring disabled",
+            }
+        )
     summary = benchmark_result["summary"]
     speed = benchmark_result["speed"]
     has_evaluated_samples = summary["evaluated"] > 0
@@ -215,6 +268,7 @@ async def _run_repeat(args, samples, concurrency: int, repeat: int) -> dict:
         "rtf_mean": speed["rtf_mean"] if has_rtf else None,
         "rtf_p95": speed["rtf_p95"],
         "worker": benchmark_result["worker"],
+        "resources": resources,
     }
     for key in (
         "text_ttft_mean_s",
@@ -246,6 +300,26 @@ def _aggregate(repeats: list[dict]) -> dict:
             "n": len(values),
         }
 
+    def _resource_metric(*path: str) -> dict | None:
+        values: list[float] = []
+        for repeat in repeats:
+            current = repeat.get("resources")
+            for key in path:
+                if not isinstance(current, dict):
+                    current = None
+                    break
+                current = current.get(key)
+            if isinstance(current, (int, float)):
+                values.append(float(current))
+        if not values:
+            return None
+        return {
+            "per_repeat": values,
+            "mean": statistics.mean(values),
+            "min": min(values),
+            "max": max(values),
+        }
+
     total_requests = sum(r["total"] for r in repeats)
     evaluated = sum(r["evaluated"] for r in repeats)
     skipped = sum(r["skipped"] for r in repeats)
@@ -266,6 +340,25 @@ def _aggregate(repeats: list[dict]) -> dict:
         "latency_p99_s": _stat("latency_p99_s"),
         "rtf_mean": _stat("rtf_mean"),
         "rtf_p95": _stat("rtf_p95"),
+        "resources": {
+            "gpu_memory_used_peak_mib": _resource_metric("gpu_memory_used_mib", "max"),
+            "gpu_memory_used_steady_mib": _resource_metric(
+                "gpu_memory_used_mib", "steady_mean"
+            ),
+            "gpu_process_memory_peak_mib": _resource_metric(
+                "gpu_process_memory_mib", "max"
+            ),
+            "power_peak_w": _resource_metric("power_w", "max"),
+            "system_cpu_peak_percent": _resource_metric("system_cpu_percent", "max"),
+            "gpu_process_cpu_peak_percent": _resource_metric(
+                "gpu_process_cpu_percent", "max"
+            ),
+            "monitor_errors": [
+                repeat["resources"].get("error")
+                for repeat in repeats
+                if repeat.get("resources", {}).get("error")
+            ],
+        },
         "per_repeat": repeats,
     }
     for key in (
@@ -351,10 +444,11 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--concurrencies",
-        default=DEFAULT_CONCURRENCIES,
-        help="Comma-separated ASR concurrency levels to sweep.",
+        type=_parse_concurrencies,
+        default=_parse_concurrencies(DEFAULT_CONCURRENCIES),
+        help="Comma-separated positive ASR concurrency levels to sweep.",
     )
-    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--repeats", type=_positive_int, default=3)
     parser.add_argument(
         "--model-path",
         default=QWEN3_ASR_MODEL_PATH,
@@ -363,6 +457,82 @@ def parse_args() -> argparse.Namespace:
             f"{QWEN3_ASR_MODEL_PATH}; use "
             f"{FUN_ASR_MODEL_PATH} for Fun-ASR-Nano."
         ),
+    )
+    parser.add_argument(
+        "--model-revision",
+        default=None,
+        help="Declared model revision loaded by the running server.",
+    )
+    parser.add_argument(
+        "--dataset-revision",
+        default=None,
+        help="Exact dataset revision; canonical SeedTTS uses a pinned default.",
+    )
+    parser.add_argument(
+        "--dtype",
+        default=None,
+        help="Served dtype recorded as provenance (for example, bfloat16).",
+    )
+    parser.add_argument(
+        "--quantization",
+        default=None,
+        help="Selected model quantization recorded as declared provenance.",
+    )
+    parser.add_argument(
+        "--attention-backend",
+        default=None,
+        help="Selected language-model attention backend recorded as provenance.",
+    )
+    parser.add_argument(
+        "--mm-attention-backend",
+        default=None,
+        help="Selected multimodal attention backend recorded as provenance.",
+    )
+    parser.add_argument(
+        "--cuda-graph",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Whether the server uses CUDA Graphs, recorded as provenance.",
+    )
+    parser.add_argument(
+        "--torch-compile",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Whether the server uses torch.compile, recorded as provenance.",
+    )
+    parser.add_argument(
+        "--max-running-requests",
+        type=int,
+        default=None,
+        help="Server admission limit recorded as provenance.",
+    )
+    parser.add_argument(
+        "--mem-fraction-static",
+        type=float,
+        default=None,
+        help="Server static-memory fraction recorded as provenance.",
+    )
+    parser.add_argument(
+        "--launch-command",
+        default=os.environ.get("SGLANG_OMNI_BENCHMARK_LAUNCH_COMMAND"),
+        help="Exact server launch command stored in the result JSON.",
+    )
+    parser.add_argument(
+        "--gpu-index",
+        type=int,
+        default=0,
+        help="Logical local GPU index sampled for memory, utilization, and power.",
+    )
+    parser.add_argument(
+        "--monitor-interval-s",
+        type=float,
+        default=0.2,
+        help="Resource monitor sampling interval.",
+    )
+    parser.add_argument(
+        "--disable-resource-monitor",
+        action="store_true",
+        help="Disable local GPU/CPU resource sampling.",
     )
     parser.add_argument(
         "--warmup",
@@ -430,10 +600,28 @@ async def _sweep(args, samples, concurrencies: list[int]) -> list[dict]:
 
 def main() -> None:
     args = parse_args()
-    concurrencies = [int(c) for c in args.concurrencies.split(",") if c.strip()]
+    concurrencies = args.concurrencies
     max_samples = args.max_samples if args.max_samples > 0 else None
+    model_revision = args.model_revision
+    is_local_source = os.path.isfile(args.meta) or args.meta.endswith(".lst")
+    if is_local_source:
+        dataset_revision = None
+    elif args.dataset_revision is not None:
+        dataset_revision = args.dataset_revision
+    elif args.meta == DATASETS["seedtts"]:
+        dataset_revision = SEEDTTS_DATASET_REVISION
+    else:
+        dataset_revision = None
 
-    samples = load_seedtts_samples(args.meta, max_samples=max_samples, split=args.lang)
+    samples = load_seedtts_samples(
+        args.meta,
+        max_samples=max_samples,
+        split=args.lang,
+        revision=dataset_revision,
+    )
+    if not samples:
+        raise RuntimeError(f"No SeedTTS samples loaded from {args.meta!r}")
+    evaluation_input_sha256 = _evaluation_input_sha256(samples)
     print(
         f"Loaded {len(samples)} SeedTTS {args.lang} samples; "
         f"sweeping concurrency={concurrencies} x {args.repeats} repeats "
@@ -443,18 +631,46 @@ def main() -> None:
     aggregates = asyncio.run(_sweep(args, samples, concurrencies))
     _print_table(aggregates)
 
+    server_config = {
+        "dtype": args.dtype,
+        "quantization": args.quantization,
+        "attention_backend": args.attention_backend,
+        "mm_attention_backend": args.mm_attention_backend,
+        "cuda_graph": args.cuda_graph,
+        "torch_compile": args.torch_compile,
+        "max_running_requests": args.max_running_requests,
+        "mem_fraction_static": args.mem_fraction_static,
+    }
     payload = {
+        "schema_version": 2,
+        "provenance": collect_benchmark_provenance(
+            model_id=args.model_path,
+            model_revision=model_revision,
+            dataset_id=args.meta,
+            dataset_revision=dataset_revision,
+            launch_command=args.launch_command,
+            server_config=server_config,
+            evaluation_input_sha256=evaluation_input_sha256,
+        ),
         "config": {
             "host": args.host,
             "port": args.port,
             "meta": args.meta,
             "lang": args.lang,
             "model_path": args.model_path,
+            "declared_model_revision": model_revision,
+            "dataset_revision": dataset_revision,
             "num_samples": len(samples),
             "concurrencies": concurrencies,
             "repeats": args.repeats,
             "warmup": args.warmup,
             "stream": args.stream,
+            "declared_server": server_config,
+            "resource_monitor": {
+                "enabled": not args.disable_resource_monitor,
+                "gpu_index": args.gpu_index,
+                "interval_s": args.monitor_interval_s,
+            },
         },
         "results": aggregates,
     }

--- a/benchmarks/eval/benchmark_asr_stability.py
+++ b/benchmarks/eval/benchmark_asr_stability.py
@@ -1,0 +1,1285 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Functional and sustained-load validation for consumer ASR servers.
+
+The harness exercises Qwen3-ASR, Fun-ASR-Nano, or Whisper through the public
+OpenAI-compatible audio endpoints. It records functional, streaming, mixed-load,
+chaos, health, resource, and GPU-memory-retention evidence in one JSON artifact.
+Model revisions are references only: pass ``--model-revision`` to declare the
+checkpoint that the running server actually loaded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import io
+import json
+import math
+import os
+import random
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+import numpy as np
+import soundfile as sf
+
+from benchmarks.dataset.prepare import DATASETS, SEEDTTS_DATASET_REVISION
+from benchmarks.dataset.seedtts import SampleInput, load_seedtts_samples
+from benchmarks.runtime_metrics import ResourceMonitor, collect_benchmark_provenance
+from benchmarks.tasks.asr import (
+    FUN_ASR_MODEL_PATH,
+    OMNI_WHISPER_MODEL_PATH,
+    PINNED_ASR_MODEL_REVISIONS,
+    QWEN3_ASR_MODEL_PATH,
+)
+from benchmarks.tts_serving.http_contracts import (
+    MAX_HTTP_RESPONSE_BYTES,
+    ResponseBodyTooLarge,
+    read_response_body,
+)
+
+SAMPLE_RATE = 16000
+STREAM_ROUTE_HEADERS = {"x-sglang-omni-route-stream": "true"}
+DEFAULT_AUDIO_BOUNDARY_MODELS = {FUN_ASR_MODEL_PATH}
+PINNED_MODEL_REVISIONS = PINNED_ASR_MODEL_REVISIONS
+MAX_SSE_LINE_BYTES = 1024 * 1024
+MAX_SSE_EVENTS = 100_000
+LATENCY_RESERVOIR_SIZE = 8192
+
+
+@dataclass(frozen=True)
+class PreparedSample:
+    sample_id: str
+    language: str
+    audio_bytes: bytes
+    duration_s: float
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected an integer, got {value!r}") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be greater than zero")
+    return parsed
+
+
+def _positive_float(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected a number, got {value!r}") from exc
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be greater than zero")
+    return parsed
+
+
+def _nonnegative_float(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected a number, got {value!r}") from exc
+    if not math.isfinite(parsed) or parsed < 0:
+        raise argparse.ArgumentTypeError("value must be nonnegative")
+    return parsed
+
+
+def _parse_concurrencies(value: str) -> list[int]:
+    tokens = [token.strip() for token in value.split(",")]
+    if not tokens or any(not token for token in tokens):
+        raise ValueError("--concurrencies must contain positive integers")
+    try:
+        concurrencies = [int(token) for token in tokens]
+    except ValueError as exc:
+        raise ValueError("--concurrencies must contain positive integers") from exc
+    if any(concurrency <= 0 for concurrency in concurrencies):
+        raise ValueError("--concurrencies must contain positive integers")
+    return concurrencies
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument(
+        "--model-path",
+        default=FUN_ASR_MODEL_PATH,
+        help=(
+            "Served ASR model id. Supported consumer profiles: "
+            f"{QWEN3_ASR_MODEL_PATH}, {FUN_ASR_MODEL_PATH}, and "
+            f"{OMNI_WHISPER_MODEL_PATH}."
+        ),
+    )
+    parser.add_argument(
+        "--model-revision",
+        default=None,
+        help="Exact revision loaded by the server; never inferred.",
+    )
+    parser.add_argument("--meta", default=DATASETS["seedtts"])
+    parser.add_argument(
+        "--dataset-revision",
+        default=None,
+        help="Exact dataset revision; canonical SeedTTS uses a pinned default.",
+    )
+    parser.add_argument("--duration-s", type=_positive_float, default=1800.0)
+    parser.add_argument("--concurrencies", default="1,4,8,16")
+    parser.add_argument("--samples-per-language", type=_positive_int, default=20)
+    parser.add_argument("--request-timeout-s", type=_positive_float, default=60.0)
+    parser.add_argument("--max-audio-duration-s", type=_positive_float, default=30.0)
+    parser.add_argument(
+        "--check-audio-boundary",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Check just-under/just-over max audio duration. Defaults on for "
+            "Fun-ASR; enable explicitly for a Whisper server with a matching "
+            "over-limit rejection contract."
+        ),
+    )
+    parser.add_argument(
+        "--include-translation",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Exercise /v1/audio/translations. Defaults off; enable explicitly "
+            "for a Whisper server that exposes the translation route."
+        ),
+    )
+    parser.add_argument(
+        "--translation-source-language",
+        default="zh",
+        help="Required source-language hint used for translation checks.",
+    )
+    parser.add_argument("--dtype", default=None)
+    parser.add_argument("--quantization", default=None)
+    parser.add_argument("--attention-backend", default=None)
+    parser.add_argument("--mm-attention-backend", default=None)
+    parser.add_argument(
+        "--cuda-graph", action=argparse.BooleanOptionalAction, default=None
+    )
+    parser.add_argument(
+        "--torch-compile", action=argparse.BooleanOptionalAction, default=None
+    )
+    parser.add_argument("--max-running-requests", type=int, default=None)
+    parser.add_argument("--mem-fraction-static", type=float, default=None)
+    parser.add_argument(
+        "--min-free-memory-mib", type=_nonnegative_float, default=2048.0
+    )
+    parser.add_argument(
+        "--max-retained-memory-mib",
+        type=_nonnegative_float,
+        default=256.0,
+    )
+    parser.add_argument("--gpu-index", type=int, default=0)
+    parser.add_argument("--monitor-interval-s", type=_positive_float, default=0.2)
+    parser.add_argument("--chaos-interval-s", type=_positive_float, default=30.0)
+    parser.add_argument("--cooldown-s", type=_nonnegative_float, default=5.0)
+    parser.add_argument("--seed", type=int, default=123)
+    parser.add_argument(
+        "--launch-command",
+        default=os.environ.get("SGLANG_OMNI_BENCHMARK_LAUNCH_COMMAND"),
+    )
+    parser.add_argument("--output", default="asr_stability_results.json")
+    return parser.parse_args()
+
+
+def _resolve_dataset_revision(args: argparse.Namespace) -> str | None:
+    if _is_local_source(args.meta):
+        return None
+    if args.dataset_revision is not None:
+        return args.dataset_revision
+    if args.meta == DATASETS["seedtts"]:
+        return SEEDTTS_DATASET_REVISION
+    return None
+
+
+def _is_local_source(source: str) -> bool:
+    return os.path.isfile(source) or source.endswith(".lst")
+
+
+def _validate_args(args: argparse.Namespace) -> list[int]:
+    concurrencies = (
+        _parse_concurrencies(args.concurrencies)
+        if isinstance(args.concurrencies, str)
+        else list(args.concurrencies)
+    )
+    constraints = (
+        (
+            bool(concurrencies) and all(value > 0 for value in concurrencies),
+            "--concurrencies must contain positive integers",
+        ),
+        (
+            math.isfinite(args.duration_s) and args.duration_s > 0,
+            "--duration-s must be finite and > 0",
+        ),
+        (
+            args.samples_per_language > 0,
+            "--samples-per-language must be > 0",
+        ),
+        (
+            math.isfinite(args.request_timeout_s) and args.request_timeout_s > 0,
+            "--request-timeout-s must be finite and > 0",
+        ),
+        (
+            math.isfinite(args.max_audio_duration_s)
+            and args.max_audio_duration_s >= 0.2,
+            "--max-audio-duration-s must be finite and at least 0.2",
+        ),
+        (
+            math.isfinite(args.monitor_interval_s) and args.monitor_interval_s > 0,
+            "--monitor-interval-s must be finite and > 0",
+        ),
+        (
+            math.isfinite(args.chaos_interval_s) and args.chaos_interval_s > 0,
+            "--chaos-interval-s must be finite and > 0",
+        ),
+        (
+            math.isfinite(args.cooldown_s) and args.cooldown_s >= 0,
+            "--cooldown-s must be finite and nonnegative",
+        ),
+        (
+            math.isfinite(args.min_free_memory_mib) and args.min_free_memory_mib >= 0,
+            "--min-free-memory-mib must be finite and nonnegative",
+        ),
+        (
+            math.isfinite(args.max_retained_memory_mib)
+            and args.max_retained_memory_mib >= 0,
+            "--max-retained-memory-mib must be finite and nonnegative",
+        ),
+        (args.gpu_index >= 0, "--gpu-index must be nonnegative"),
+        (
+            not _is_local_source(args.meta),
+            "bilingual stability validation requires a dataset with distinct "
+            "en and zh splits; one local meta.lst cannot represent both",
+        ),
+    )
+    for valid, message in constraints:
+        if not valid:
+            raise ValueError(message)
+    if args.include_translation is None:
+        args.include_translation = False
+    if args.include_translation and not str(args.translation_source_language).strip():
+        raise ValueError(
+            "--translation-source-language is required when translation " "is enabled"
+        )
+    if args.check_audio_boundary is None:
+        args.check_audio_boundary = args.model_path in DEFAULT_AUDIO_BOUNDARY_MODELS
+    return concurrencies
+
+
+async def main_async(args: argparse.Namespace) -> dict[str, Any]:
+    concurrencies = _validate_args(args)
+    dataset_revision = _resolve_dataset_revision(args)
+    samples = _load_prepared_samples(args, dataset_revision)
+    evaluation_input_sha256 = _evaluation_input_sha256(samples)
+    timeout = aiohttp.ClientTimeout(total=args.request_timeout_s)
+    connector = aiohttp.TCPConnector(limit=max(concurrencies) + 8)
+    monitor = ResourceMonitor(
+        gpu_index=args.gpu_index,
+        interval_s=args.monitor_interval_s,
+    ).start()
+    memory_checkpoints: list[dict[str, Any]] = []
+    resources: dict[str, Any]
+
+    try:
+        await _wait_for_resource_sample(monitor)
+        memory_checkpoints.append(_memory_checkpoint("before_functional", monitor))
+        async with aiohttp.ClientSession(
+            timeout=timeout,
+            connector=connector,
+        ) as session:
+            functional = await _run_functional_checks(session, args, samples)
+            memory_checkpoints.append(_memory_checkpoint("after_functional", monitor))
+            stages, chaos = await _run_soak(
+                session,
+                args,
+                samples,
+                concurrencies=concurrencies,
+                monitor=monitor,
+            )
+            memory_checkpoints.append(_memory_checkpoint("after_soak", monitor))
+            await asyncio.sleep(args.cooldown_s)
+            memory_checkpoints.append(_memory_checkpoint("after_cooldown", monitor))
+            health_status = await _health_status(session, args)
+    finally:
+        resources = monitor.stop()
+
+    memory_validation = _validate_memory_retention(
+        memory_checkpoints,
+        resources,
+        min_free_memory_mib=args.min_free_memory_mib,
+        max_retained_memory_mib=args.max_retained_memory_mib,
+    )
+    unexpected_errors = sum(stage["unexpected_errors"] for stage in stages)
+    soak_exercised = all(
+        stage["requests"] > 0
+        and stage["chaos_events"] > 0
+        and (not args.include_translation or stage["translations"] > 0)
+        for stage in stages
+    )
+    passed = (
+        all(check["passed"] for check in functional)
+        and soak_exercised
+        and unexpected_errors == 0
+        and all(event["passed"] for event in chaos)
+        and health_status == 200
+        and memory_validation["passed"]
+    )
+    server_config = {
+        "dtype": args.dtype,
+        "quantization": args.quantization,
+        "attention_backend": args.attention_backend,
+        "mm_attention_backend": args.mm_attention_backend,
+        "cuda_graph": args.cuda_graph,
+        "torch_compile": args.torch_compile,
+        "max_running_requests": args.max_running_requests,
+        "mem_fraction_static": args.mem_fraction_static,
+    }
+    return {
+        "schema_version": 2,
+        "passed": passed,
+        "provenance": collect_benchmark_provenance(
+            model_id=args.model_path,
+            model_revision=args.model_revision,
+            dataset_id=args.meta,
+            dataset_revision=dataset_revision,
+            launch_command=args.launch_command,
+            server_config=server_config,
+            evaluation_input_sha256=evaluation_input_sha256,
+        ),
+        "config": {
+            "host": args.host,
+            "port": args.port,
+            "duration_s": args.duration_s,
+            "concurrencies": concurrencies,
+            "samples_per_language": args.samples_per_language,
+            "request_timeout_s": args.request_timeout_s,
+            "max_audio_duration_s": args.max_audio_duration_s,
+            "check_audio_boundary": args.check_audio_boundary,
+            "include_translation": args.include_translation,
+            "translation_source_language": (
+                args.translation_source_language if args.include_translation else None
+            ),
+            "min_free_memory_mib": args.min_free_memory_mib,
+            "max_retained_memory_mib": args.max_retained_memory_mib,
+            "gpu_index": args.gpu_index,
+            "monitor_interval_s": args.monitor_interval_s,
+            "chaos_interval_s": args.chaos_interval_s,
+            "cooldown_s": args.cooldown_s,
+            "seed": args.seed,
+            "model_path": args.model_path,
+            "declared_model_revision": args.model_revision,
+            "dataset_revision": dataset_revision,
+            "declared_server": server_config,
+        },
+        "functional": functional,
+        "soak_stages": stages,
+        "chaos_events": chaos,
+        "resources": resources,
+        "memory_checkpoints": memory_checkpoints,
+        "memory_validation": memory_validation,
+        "final_health_status": health_status,
+        "unexpected_errors": unexpected_errors,
+    }
+
+
+def _load_prepared_samples(
+    args: argparse.Namespace,
+    dataset_revision: str | None,
+) -> list[PreparedSample]:
+    samples_by_language: dict[str, list[PreparedSample]] = {}
+    for language in ("en", "zh"):
+        loaded = load_seedtts_samples(
+            args.meta,
+            max_samples=args.samples_per_language,
+            split=language,
+            revision=dataset_revision,
+        )
+        if not loaded:
+            raise RuntimeError(
+                f"No SeedTTS {language} samples loaded from {args.meta!r}"
+            )
+        samples_by_language[language] = [
+            _prepare_sample(sample, language) for sample in loaded
+        ]
+
+    prepared: list[PreparedSample] = []
+    sample_count = max(
+        len(language_samples) for language_samples in samples_by_language.values()
+    )
+    for index in range(sample_count):
+        for language in ("en", "zh"):
+            language_samples = samples_by_language[language]
+            if index < len(language_samples):
+                prepared.append(language_samples[index])
+    return prepared
+
+
+def _prepare_sample(sample: SampleInput, language: str) -> PreparedSample:
+    audio_bytes = Path(sample.ref_audio).read_bytes()
+    return PreparedSample(
+        sample_id=sample.sample_id,
+        language=language,
+        audio_bytes=audio_bytes,
+        duration_s=_duration_s(audio_bytes),
+    )
+
+
+def _evaluation_input_sha256(samples: list[PreparedSample]) -> str:
+    digest = hashlib.sha256(b"asr-stability-input-v1\0")
+    for sample in samples:
+        for value in (sample.sample_id, sample.language):
+            encoded = value.encode("utf-8")
+            digest.update(len(encoded).to_bytes(8, "big"))
+            digest.update(encoded)
+        digest.update(len(sample.audio_bytes).to_bytes(8, "big"))
+        digest.update(sample.audio_bytes)
+    return digest.hexdigest()
+
+
+async def _wait_for_resource_sample(monitor: ResourceMonitor) -> None:
+    deadline = time.monotonic() + max(1.0, monitor.interval_s * 5)
+    while not monitor.samples and monitor.error is None:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        await asyncio.sleep(min(0.01, remaining))
+
+
+async def _run_functional_checks(
+    session: aiohttp.ClientSession,
+    args: argparse.Namespace,
+    samples: list[PreparedSample],
+) -> list[dict[str, Any]]:
+    en_sample = next(sample for sample in samples if sample.language == "en")
+    zh_sample = next(sample for sample in samples if sample.language == "zh")
+    checks: list[dict[str, Any]] = []
+
+    en_result = await _post_transcription(session, args, en_sample)
+    checks.append(_expect_success("basic_en", en_result))
+    zh_result = await _post_transcription(session, args, zh_sample)
+    checks.append(_expect_success("basic_zh", zh_result))
+    if args.include_translation:
+        translation = await _post_translation(session, args, zh_sample)
+        checks.append(
+            _expect_translation_success(
+                "basic_zh_to_english",
+                translation,
+            )
+        )
+
+    stream_result = await _post_streaming_transcription(
+        session,
+        args,
+        en_sample,
+    )
+    checks.append(
+        {
+            "name": "streaming_consistency",
+            "passed": (
+                stream_result["status"] == 200
+                and stream_result["done"]
+                and stream_result["text"] == en_result["text"]
+            ),
+            "stream_text": stream_result["text"],
+            "non_stream_text": en_result["text"],
+            **{key: value for key, value in stream_result.items() if key != "text"},
+        }
+    )
+
+    cancellation = await _cancel_stream(session, args, en_sample)
+    await asyncio.sleep(0.5)
+    reconnect = await _post_streaming_transcription(session, args, en_sample)
+    checks.append(
+        {
+            "name": "stream_cancel_and_reconnect",
+            "passed": (
+                cancellation["status"] == 200
+                and cancellation["received_event"]
+                and reconnect["status"] == 200
+                and reconnect["done"]
+            ),
+            "cancel": cancellation,
+            "reconnect_status": reconnect["status"],
+            "reconnect_error": reconnect["error"],
+        }
+    )
+
+    checks.append(
+        _expect_status(
+            "empty_audio",
+            await _post_raw_audio(session, args, b"", "empty.wav", "en"),
+            400,
+        )
+    )
+    checks.append(
+        _expect_status(
+            "corrupt_audio",
+            await _post_raw_audio(
+                session,
+                args,
+                b"not-an-audio-file",
+                "corrupt.wav",
+                "en",
+            ),
+            400,
+        )
+    )
+
+    if args.check_audio_boundary:
+        near_limit = _resize_wav(
+            en_sample.audio_bytes,
+            args.max_audio_duration_s - 0.1,
+        )
+        checks.append(
+            _expect_success(
+                "near_limit_audio",
+                await _post_raw_audio(
+                    session,
+                    args,
+                    near_limit,
+                    "near-limit.wav",
+                    "en",
+                ),
+            )
+        )
+        over_limit = _resize_wav(
+            en_sample.audio_bytes,
+            args.max_audio_duration_s + 0.1,
+        )
+        checks.append(
+            _expect_status(
+                "over_limit_audio",
+                await _post_raw_audio(
+                    session,
+                    args,
+                    over_limit,
+                    "over-limit.wav",
+                    "en",
+                ),
+                400,
+            )
+        )
+    return checks
+
+
+async def _run_soak(
+    session: aiohttp.ClientSession,
+    args: argparse.Namespace,
+    samples: list[PreparedSample],
+    *,
+    concurrencies: list[int],
+    monitor: ResourceMonitor,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    randomizer = random.Random(args.seed)
+    stage_duration_s = args.duration_s / len(concurrencies)
+    stages: list[dict[str, Any]] = []
+    chaos_events: list[dict[str, Any]] = []
+
+    for concurrency in concurrencies:
+        deadline = time.monotonic() + stage_duration_s
+        counters: dict[str, int | float] = {
+            "requests_issued": 0,
+            "requests": 0,
+            "successes": 0,
+            "unexpected_errors": 0,
+            "en": 0,
+            "zh": 0,
+            "zh_requests_issued": 0,
+            "translations": 0,
+            "chaos_requests": 0,
+            "chaos_events": 0,
+            "successful_audio_s": 0.0,
+        }
+        latency_count = 0
+        latency_total_s = 0.0
+        latency_reservoir: list[float] = []
+        latency_randomizer = random.Random(args.seed ^ concurrency)
+        request_slots = asyncio.Semaphore(concurrency)
+        active_requests = 0
+        max_in_flight_observed = 0
+
+        def record_latency(value: float) -> None:
+            nonlocal latency_count, latency_total_s
+            latency_count += 1
+            latency_total_s += value
+            if len(latency_reservoir) < LATENCY_RESERVOIR_SIZE:
+                latency_reservoir.append(value)
+                return
+            replacement = latency_randomizer.randrange(latency_count)
+            if replacement < LATENCY_RESERVOIR_SIZE:
+                latency_reservoir[replacement] = value
+
+        async def limited_request(
+            call: Callable[..., Awaitable[dict[str, Any]]],
+            *call_args: Any,
+        ) -> dict[str, Any]:
+            nonlocal active_requests, max_in_flight_observed
+            async with request_slots:
+                active_requests += 1
+                max_in_flight_observed = max(
+                    max_in_flight_observed,
+                    active_requests,
+                )
+                try:
+                    return await call(*call_args)
+                finally:
+                    active_requests -= 1
+
+        async def worker(worker_id: int) -> None:
+            index = worker_id
+            while time.monotonic() < deadline:
+                sample = samples[index % len(samples)]
+                index += concurrency
+                counters["requests_issued"] += 1
+                translate = False
+                if sample.language == "zh":
+                    zh_sequence = int(counters["zh_requests_issued"])
+                    counters["zh_requests_issued"] += 1
+                    translate = args.include_translation and zh_sequence % 4 == 0
+                if translate:
+                    result = await limited_request(
+                        _post_translation,
+                        session,
+                        args,
+                        sample,
+                    )
+                    counters["translations"] += 1
+                else:
+                    result = await limited_request(
+                        _post_transcription,
+                        session,
+                        args,
+                        sample,
+                    )
+                counters["requests"] += 1
+                counters[sample.language] += 1
+                record_latency(result["latency_s"])
+                successful_text = bool(result["text"])
+                if translate:
+                    successful_text = _looks_like_english_translation(result["text"])
+                if result["status"] == 200 and successful_text:
+                    counters["successes"] += 1
+                    counters["successful_audio_s"] += sample.duration_s
+                else:
+                    counters["unexpected_errors"] += 1
+
+        async def chaos_worker() -> None:
+            event_number = 0
+            while True:
+                if event_number == 0:
+                    await asyncio.sleep(0)
+                else:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        return
+                    await asyncio.sleep(min(args.chaos_interval_s, remaining))
+                    if time.monotonic() >= deadline:
+                        return
+                sample = randomizer.choice(samples)
+                if event_number % 2 == 0:
+                    counters["chaos_requests"] += 1
+                    result = await limited_request(
+                        _post_raw_audio,
+                        session,
+                        args,
+                        b"invalid",
+                        "intentional-corrupt.wav",
+                        sample.language,
+                    )
+                    chaos_events.append(
+                        {
+                            "stage_concurrency": concurrency,
+                            "kind": "malformed",
+                            "status": result["status"],
+                            "passed": result["status"] == 400,
+                            "error": result["error"],
+                        }
+                    )
+                else:
+                    counters["chaos_requests"] += 1
+                    cancel = await limited_request(
+                        _cancel_stream,
+                        session,
+                        args,
+                        sample,
+                    )
+                    counters["chaos_requests"] += 1
+                    reconnect = await limited_request(
+                        _post_streaming_transcription,
+                        session,
+                        args,
+                        sample,
+                    )
+                    chaos_events.append(
+                        {
+                            "stage_concurrency": concurrency,
+                            "kind": "cancel_reconnect",
+                            "status": cancel["status"],
+                            "passed": (
+                                cancel["status"] == 200
+                                and cancel["received_event"]
+                                and reconnect["status"] == 200
+                                and reconnect["done"]
+                            ),
+                            "cancel_error": cancel["error"],
+                            "reconnect_error": reconnect["error"],
+                        }
+                    )
+                counters["chaos_events"] += 1
+                event_number += 1
+
+        started = time.monotonic()
+        tasks = [
+            asyncio.create_task(worker(worker_id)) for worker_id in range(concurrency)
+        ]
+        tasks.append(asyncio.create_task(chaos_worker()))
+        try:
+            await asyncio.gather(*tasks)
+        except BaseException:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
+        elapsed_s = time.monotonic() - started
+        zh_requests = int(counters["zh"])
+        stages.append(
+            {
+                "concurrency": concurrency,
+                "max_in_flight_observed": max_in_flight_observed,
+                "duration_s": elapsed_s,
+                **counters,
+                "total_http_requests": (
+                    int(counters["requests"]) + int(counters["chaos_requests"])
+                ),
+                "translation_target_ratio": (0.25 if args.include_translation else 0.0),
+                "translation_observed_ratio": (
+                    float(counters["translations"]) / zh_requests
+                    if zh_requests
+                    else None
+                ),
+                "throughput_requests_per_s": (
+                    float(counters["successes"]) / max(elapsed_s, 1e-9)
+                ),
+                "audio_seconds_per_s": (
+                    float(counters["successful_audio_s"]) / max(elapsed_s, 1e-9)
+                ),
+                "latency_mean_s": (
+                    latency_total_s / latency_count if latency_count else None
+                ),
+                "latency_p95_s": _percentile(latency_reservoir, 95),
+                "latency_samples_seen": latency_count,
+                "latency_reservoir_size": len(latency_reservoir),
+                "latency_percentile_method": "bounded_reservoir",
+                "memory": _memory_checkpoint(
+                    f"after_concurrency_{concurrency}", monitor
+                ),
+            }
+        )
+    return stages, chaos_events
+
+
+async def _post_transcription(
+    session: aiohttp.ClientSession,
+    args: argparse.Namespace,
+    sample: PreparedSample,
+) -> dict[str, Any]:
+    return await _post_raw_audio(
+        session,
+        args,
+        sample.audio_bytes,
+        f"{sample.sample_id}.wav",
+        sample.language,
+    )
+
+
+async def _post_translation(
+    session: aiohttp.ClientSession,
+    args: argparse.Namespace,
+    sample: PreparedSample,
+) -> dict[str, Any]:
+    return await _post_raw_audio(
+        session,
+        args,
+        sample.audio_bytes,
+        f"{sample.sample_id}.wav",
+        str(args.translation_source_language).strip(),
+        endpoint="translations",
+    )
+
+
+async def _post_raw_audio(
+    session: aiohttp.ClientSession,
+    args: argparse.Namespace,
+    audio_bytes: bytes,
+    filename: str,
+    language: str | None,
+    *,
+    endpoint: str = "transcriptions",
+) -> dict[str, Any]:
+    form = aiohttp.FormData()
+    form.add_field("model", args.model_path)
+    if language is not None:
+        form.add_field("language", language)
+    form.add_field("response_format", "json")
+    form.add_field(
+        "file",
+        audio_bytes,
+        filename=filename,
+        content_type="audio/wav",
+    )
+    started = time.perf_counter()
+    try:
+        async with session.post(_url(args, endpoint), data=form) as response:
+            try:
+                body_bytes = await read_response_body(response)
+            except ResponseBodyTooLarge as exc:
+                return {
+                    "status": response.status,
+                    "text": "",
+                    "body": "",
+                    "latency_s": time.perf_counter() - started,
+                    "error": str(exc),
+                }
+            body = body_bytes.decode("utf-8", errors="replace")
+            text = ""
+            error = None
+            if response.status == 200:
+                try:
+                    payload = json.loads(body)
+                except json.JSONDecodeError:
+                    error = "response body is not valid JSON"
+                else:
+                    if not isinstance(payload, dict):
+                        error = "response JSON must be an object"
+                    elif isinstance(payload.get("text"), str):
+                        text = payload["text"]
+                    else:
+                        error = "response JSON has no string text field"
+            return {
+                "status": response.status,
+                "text": text,
+                "body": body[:500],
+                "latency_s": time.perf_counter() - started,
+                "error": error,
+            }
+    except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+        return _transport_error_result(started, exc)
+
+
+async def _post_streaming_transcription(
+    session: aiohttp.ClientSession,
+    args: argparse.Namespace,
+    sample: PreparedSample,
+) -> dict[str, Any]:
+    event_count = 0
+    delta_event_count = 0
+    first_event_latency_s: float | None = None
+    seen_done_event = False
+    seen_done_sentinel = False
+    final_text = ""
+    status = 0
+    bytes_read = 0
+    started = time.perf_counter()
+    error: str | None = None
+    try:
+        async with session.post(
+            _url(args),
+            data=_stream_form(args, sample),
+            headers=STREAM_ROUTE_HEADERS,
+        ) as response:
+            status = response.status
+            async for raw_line in response.content:
+                bytes_read = _checked_stream_bytes(bytes_read, raw_line)
+                line = raw_line.decode(errors="replace").strip()
+                if not line.startswith("data:"):
+                    continue
+                payload = line[5:].strip()
+                if payload == "[DONE]":
+                    seen_done_sentinel = True
+                    break
+                try:
+                    event = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                event_count += 1
+                if event_count > MAX_SSE_EVENTS:
+                    raise ValueError(
+                        "SSE event count exceeded benchmark cap " f"({MAX_SSE_EVENTS})"
+                    )
+                if first_event_latency_s is None:
+                    first_event_latency_s = time.perf_counter() - started
+                event_type = event.get("type")
+                if event_type == "transcript.text.delta":
+                    delta_event_count += 1
+                elif event_type == "transcript.text.done":
+                    seen_done_event = True
+                    if isinstance(event.get("text"), str):
+                        final_text = event["text"]
+    except (
+        aiohttp.ClientError,
+        asyncio.TimeoutError,
+        ResponseBodyTooLarge,
+        ValueError,
+    ) as exc:
+        error = f"{type(exc).__name__}: {exc}"
+
+    return {
+        "status": status,
+        "events": event_count,
+        "delta_events": delta_event_count,
+        "response_bytes": bytes_read,
+        "first_event_latency_s": first_event_latency_s,
+        "done": seen_done_event and seen_done_sentinel,
+        "text": final_text,
+        "error": error,
+    }
+
+
+async def _read_first_stream_delta(
+    response: aiohttp.ClientResponse,
+) -> tuple[bool, int]:
+    bytes_read = 0
+    async for raw_line in response.content:
+        bytes_read = _checked_stream_bytes(bytes_read, raw_line)
+        line = raw_line.decode(errors="replace").strip()
+        if not line.startswith("data:"):
+            continue
+        payload = line[5:].strip()
+        if payload == "[DONE]":
+            return False, bytes_read
+        try:
+            event = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        event_type = event.get("type")
+        if event_type == "transcript.text.done":
+            return False, bytes_read
+        if (
+            event_type == "transcript.text.delta"
+            and isinstance(event.get("delta"), str)
+            and event["delta"]
+        ):
+            return True, bytes_read
+    return False, bytes_read
+
+
+async def _cancel_stream(
+    session: aiohttp.ClientSession,
+    args: argparse.Namespace,
+    sample: PreparedSample,
+) -> dict[str, Any]:
+    response: aiohttp.ClientResponse | None = None
+    status = 0
+    received_event = False
+    bytes_read = 0
+    error: str | None = None
+    try:
+        response = await session.post(
+            _url(args),
+            data=_stream_form(args, sample),
+            headers=STREAM_ROUTE_HEADERS,
+        )
+        status = response.status
+        received_event, bytes_read = await asyncio.wait_for(
+            _read_first_stream_delta(response),
+            timeout=min(10.0, args.request_timeout_s),
+        )
+    except (
+        aiohttp.ClientError,
+        asyncio.TimeoutError,
+        ResponseBodyTooLarge,
+        ValueError,
+    ) as exc:
+        error = f"{type(exc).__name__}: {exc}"
+    finally:
+        if response is not None:
+            response.close()
+    return {
+        "status": status,
+        "received_event": received_event,
+        "response_bytes": bytes_read,
+        "error": error,
+    }
+
+
+def _stream_form(
+    args: argparse.Namespace,
+    sample: PreparedSample,
+) -> aiohttp.FormData:
+    form = aiohttp.FormData()
+    form.add_field("model", args.model_path)
+    form.add_field("language", sample.language)
+    form.add_field("response_format", "json")
+    form.add_field("stream", "true")
+    form.add_field(
+        "file",
+        sample.audio_bytes,
+        filename=f"{sample.sample_id}.wav",
+        content_type="audio/wav",
+    )
+    return form
+
+
+async def _health_status(
+    session: aiohttp.ClientSession,
+    args: argparse.Namespace,
+) -> int:
+    try:
+        async with session.get(f"http://{args.host}:{args.port}/health") as response:
+            await read_response_body(response)
+            return response.status
+    except (
+        aiohttp.ClientError,
+        asyncio.TimeoutError,
+        ResponseBodyTooLarge,
+    ):
+        return 0
+
+
+def _checked_stream_bytes(total: int, line: bytes) -> int:
+    if len(line) > MAX_SSE_LINE_BYTES:
+        raise ResponseBodyTooLarge(
+            bytes_read=len(line),
+            max_bytes=MAX_SSE_LINE_BYTES,
+        )
+    next_total = total + len(line)
+    if next_total > MAX_HTTP_RESPONSE_BYTES:
+        raise ResponseBodyTooLarge(
+            bytes_read=next_total,
+            max_bytes=MAX_HTTP_RESPONSE_BYTES,
+        )
+    return next_total
+
+
+def _transport_error_result(
+    started: float,
+    exc: BaseException,
+) -> dict[str, Any]:
+    return {
+        "status": 0,
+        "text": "",
+        "body": "",
+        "latency_s": time.perf_counter() - started,
+        "error": f"{type(exc).__name__}: {exc}",
+    }
+
+
+def _looks_like_english_translation(text: str) -> bool:
+    latin_letters = sum("a" <= character.lower() <= "z" for character in text)
+    cjk_characters = sum(
+        "\u3400" <= character <= "\u4dbf"
+        or "\u4e00" <= character <= "\u9fff"
+        or "\uf900" <= character <= "\ufaff"
+        for character in text
+    )
+    return latin_letters > cjk_characters
+
+
+def _expect_translation_success(
+    name: str,
+    result: dict[str, Any],
+) -> dict[str, Any]:
+    text = result["text"] if isinstance(result.get("text"), str) else ""
+    return {
+        "name": name,
+        "passed": (result["status"] == 200 and _looks_like_english_translation(text)),
+        **result,
+    }
+
+
+def _expect_success(name: str, result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": name,
+        "passed": result["status"] == 200 and bool(result["text"]),
+        **result,
+    }
+
+
+def _expect_status(
+    name: str,
+    result: dict[str, Any],
+    expected_status: int,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "passed": result["status"] == expected_status,
+        "expected_status": expected_status,
+        **result,
+    }
+
+
+def _resize_wav(audio_bytes: bytes, duration_s: float) -> bytes:
+    audio, sample_rate = sf.read(io.BytesIO(audio_bytes), dtype="float32")
+    if audio.ndim == 2:
+        audio = audio.mean(axis=1)
+    if len(audio) == 0:
+        raise ValueError("cannot resize empty audio")
+    target_samples = round(duration_s * SAMPLE_RATE)
+    if sample_rate != SAMPLE_RATE:
+        old_positions = np.linspace(0.0, 1.0, num=len(audio), endpoint=False)
+        new_length = round(len(audio) * SAMPLE_RATE / sample_rate)
+        new_positions = np.linspace(0.0, 1.0, num=new_length, endpoint=False)
+        audio = np.interp(
+            new_positions,
+            old_positions,
+            audio,
+        ).astype(np.float32)
+    repeats = max(1, (target_samples + len(audio) - 1) // len(audio))
+    resized = np.tile(audio, repeats)[:target_samples]
+    buffer = io.BytesIO()
+    sf.write(buffer, resized, SAMPLE_RATE, format="WAV", subtype="PCM_16")
+    return buffer.getvalue()
+
+
+def _duration_s(audio_bytes: bytes) -> float:
+    info = sf.info(io.BytesIO(audio_bytes))
+    return info.frames / float(info.samplerate)
+
+
+def _percentile(values: list[float], percentile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = min(
+        len(ordered) - 1,
+        max(0, round((percentile / 100.0) * (len(ordered) - 1))),
+    )
+    return ordered[index]
+
+
+def _memory_checkpoint(
+    label: str,
+    monitor: ResourceMonitor,
+) -> dict[str, Any]:
+    if not monitor.samples:
+        return {
+            "label": label,
+            "monotonic_s": time.monotonic(),
+            "sample_elapsed_s": None,
+            "gpu_memory_used_mib": None,
+            "gpu_memory_free_mib": None,
+            "gpu_process_memory_mib": None,
+            "gpu_process_rss_mib": None,
+            "error": monitor.error or "resource monitor has no samples",
+        }
+    sample = monitor.samples[-1]
+    return {
+        "label": label,
+        "monotonic_s": time.monotonic(),
+        "sample_elapsed_s": sample.elapsed_s,
+        "gpu_memory_used_mib": sample.gpu_memory_used_mib,
+        "gpu_memory_free_mib": sample.gpu_memory_free_mib,
+        "gpu_process_memory_mib": sample.gpu_process_memory_mib,
+        "gpu_process_rss_mib": sample.gpu_process_rss_mib,
+        "error": monitor.error,
+    }
+
+
+def _validate_memory_retention(
+    checkpoints: list[dict[str, Any]],
+    resources: dict[str, Any],
+    *,
+    min_free_memory_mib: float,
+    max_retained_memory_mib: float,
+) -> dict[str, Any]:
+    checkpoint_memory = {
+        checkpoint["label"]: {
+            "used_mib": checkpoint.get("gpu_memory_used_mib"),
+            "free_mib": checkpoint.get("gpu_memory_free_mib"),
+            "process_mib": checkpoint.get("gpu_process_memory_mib"),
+            "process_rss_mib": checkpoint.get("gpu_process_rss_mib"),
+            "error": checkpoint.get("error"),
+        }
+        for checkpoint in checkpoints
+    }
+    before = checkpoint_memory.get("before_functional")
+    cooldown = checkpoint_memory.get("after_cooldown")
+    free_summary = resources.get("gpu_memory_free_mib")
+    minimum_free_raw = (
+        free_summary.get("min") if isinstance(free_summary, dict) else None
+    )
+    before_used_raw = before.get("used_mib") if before is not None else None
+    cooldown_used_raw = cooldown.get("used_mib") if cooldown is not None else None
+    telemetry_error = (
+        resources.get("error") is not None
+        or before is None
+        or before.get("error") is not None
+        or cooldown is None
+        or cooldown.get("error") is not None
+    )
+    required_values = (
+        minimum_free_raw,
+        before_used_raw,
+        cooldown_used_raw,
+    )
+    if telemetry_error or any(
+        isinstance(value, bool) or not isinstance(value, (int, float))
+        for value in required_values
+    ):
+        return {
+            "passed": False,
+            "error": "required GPU memory samples are unavailable",
+            "checkpoints": checkpoint_memory,
+        }
+    minimum_free, before_used, cooldown_used = (
+        float(value) for value in required_values
+    )
+    if not all(
+        math.isfinite(value) for value in (minimum_free, before_used, cooldown_used)
+    ):
+        return {
+            "passed": False,
+            "error": "required GPU memory samples are unavailable",
+            "checkpoints": checkpoint_memory,
+        }
+
+    retained_mib = cooldown_used - before_used
+    failures: list[str] = []
+    if minimum_free < min_free_memory_mib:
+        failures.append("minimum free GPU memory fell below the required floor")
+    if retained_mib > max_retained_memory_mib:
+        failures.append("GPU memory retained after cooldown exceeded the limit")
+    return {
+        "passed": not failures,
+        "error": "; ".join(failures) if failures else None,
+        "minimum_free_mib": minimum_free,
+        "required_free_mib": min_free_memory_mib,
+        "retained_after_cooldown_mib": retained_mib,
+        "maximum_retained_mib": max_retained_memory_mib,
+        "checkpoints": checkpoint_memory,
+    }
+
+
+def _url(args: argparse.Namespace, endpoint: str = "transcriptions") -> str:
+    return f"http://{args.host}:{args.port}/v1/audio/{endpoint}"
+
+
+def main() -> None:
+    args = parse_args()
+    result = asyncio.run(main_async(args))
+    output = Path(os.path.abspath(args.output))
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_name(f".{output.name}.tmp")
+    try:
+        temporary.write_text(json.dumps(result, indent=2) + "\n")
+        os.replace(temporary, output)
+    finally:
+        temporary.unlink(missing_ok=True)
+    print(json.dumps({"passed": result["passed"], "output": str(output)}, indent=2))
+    if not result["passed"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/runtime_metrics.py
+++ b/benchmarks/runtime_metrics.py
@@ -1,0 +1,461 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Best-effort provenance and host-resource sampling for local benchmarks."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import json
+import os
+import platform
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_NVML_SESSION_LOCK = threading.Lock()
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class ResourceSample:
+    elapsed_s: float
+    gpu_memory_used_mib: float
+    gpu_memory_free_mib: float
+    gpu_process_memory_mib: float | None
+    gpu_util_percent: float | None
+    power_w: float | None
+    system_cpu_percent: float | None
+    gpu_process_cpu_percent: float | None
+    gpu_process_pids: tuple[int, ...]
+
+
+class ResourceMonitor:
+    """Sample one local GPU and its compute processes in a background thread."""
+
+    def __init__(self, gpu_index: int = 0, interval_s: float = 0.2) -> None:
+        if gpu_index < 0:
+            raise ValueError("gpu_index must be >= 0")
+        if interval_s <= 0:
+            raise ValueError("interval_s must be > 0")
+        self.gpu_index = gpu_index
+        self.interval_s = interval_s
+        self.samples: list[ResourceSample] = []
+        self.error: str | None = None
+        self._ready_event = threading.Event()
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._started_at = 0.0
+        self._pynvml: Any = None
+        self._handle: Any = None
+        self._psutil: Any = None
+        self._processes: dict[int, Any] = {}
+
+    def start(self) -> "ResourceMonitor":
+        if not _NVML_SESSION_LOCK.acquire(blocking=False):
+            self.error = "another NVML resource monitor is still active"
+            self._ready_event.set()
+            return self
+        self._started_at = time.perf_counter()
+        self._thread = threading.Thread(
+            target=self._run,
+            name=f"benchmark-resource-monitor-gpu{self.gpu_index}",
+            daemon=True,
+        )
+        try:
+            self._thread.start()
+        except BaseException:
+            _NVML_SESSION_LOCK.release()
+            raise
+        if not self._ready_event.wait(timeout=max(5.0, self.interval_s * 5)):
+            self.error = "resource sampler initialization timed out"
+        return self
+
+    def stop(self) -> dict[str, Any]:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=max(5.0, self.interval_s * 5))
+            if self._thread.is_alive() and self.error is None:
+                self.error = "resource sampler did not stop before timeout"
+        return summarize_resource_samples(
+            list(self.samples),
+            interval_s=self.interval_s,
+            error=self.error,
+        )
+
+    def _run(self) -> None:
+        try:
+            try:
+                import psutil
+                import pynvml
+
+                pynvml.nvmlInit()
+                self._pynvml = pynvml
+                self._psutil = psutil
+                self._handle = _resolve_nvml_handle(pynvml, self.gpu_index)
+                psutil.cpu_percent(interval=None)
+            except Exception as exc:
+                self.error = f"{type(exc).__name__}: {exc}"
+                self._ready_event.set()
+                return
+
+            self._ready_event.set()
+            self._sample_once()
+            while not self._stop_event.wait(self.interval_s):
+                self._sample_once()
+            self._sample_once()
+        finally:
+            self._shutdown_nvml()
+            _NVML_SESSION_LOCK.release()
+
+    def _sample_once(self) -> None:
+        try:
+            pynvml = self._pynvml
+            memory = pynvml.nvmlDeviceGetMemoryInfo(self._handle)
+            nvml_processes = _nvml_compute_processes(pynvml, self._handle)
+            process_memory_bytes: int | None = 0 if nvml_processes is not None else None
+            process_pids: set[int] = set()
+            for process in nvml_processes or []:
+                process_pids.add(int(process.pid))
+                try:
+                    used = process.usedGpuMemory
+                except AttributeError:
+                    process_memory_bytes = None
+                    continue
+                if not isinstance(used, int) or not 0 <= used < 2**63:
+                    process_memory_bytes = None
+                    continue
+                if process_memory_bytes is not None:
+                    process_memory_bytes += used
+
+            utilization = _best_effort(
+                lambda: float(pynvml.nvmlDeviceGetUtilizationRates(self._handle).gpu)
+            )
+            power_w = _best_effort(
+                lambda: float(pynvml.nvmlDeviceGetPowerUsage(self._handle)) / 1000.0
+            )
+            system_cpu = _best_effort(
+                lambda: float(self._psutil.cpu_percent(interval=None))
+            )
+            process_cpu = (
+                self._gpu_process_cpu_percent(process_pids)
+                if nvml_processes is not None
+                else None
+            )
+            process_memory_mib = (
+                float(process_memory_bytes) / (1024**2)
+                if process_memory_bytes is not None
+                else None
+            )
+            self.samples.append(
+                ResourceSample(
+                    elapsed_s=time.perf_counter() - self._started_at,
+                    gpu_memory_used_mib=float(memory.used) / (1024**2),
+                    gpu_memory_free_mib=float(memory.free) / (1024**2),
+                    gpu_process_memory_mib=process_memory_mib,
+                    gpu_util_percent=utilization,
+                    power_w=power_w,
+                    system_cpu_percent=system_cpu,
+                    gpu_process_cpu_percent=process_cpu,
+                    gpu_process_pids=tuple(sorted(process_pids)),
+                )
+            )
+        except Exception as exc:
+            if self.error is None:
+                self.error = f"{type(exc).__name__}: {exc}"
+
+    def _gpu_process_cpu_percent(self, pids: set[int]) -> float | None:
+        if self._psutil is None:
+            return None
+        total = 0.0
+        observed = False
+        for pid in pids:
+            try:
+                process = self._processes.get(pid)
+                if process is None:
+                    process = self._psutil.Process(pid)
+                    self._processes[pid] = process
+                total += float(process.cpu_percent(interval=None))
+                observed = True
+            except (self._psutil.NoSuchProcess, self._psutil.AccessDenied):
+                self._processes.pop(pid, None)
+        return total if observed else None
+
+    def _shutdown_nvml(self) -> None:
+        if self._pynvml is None:
+            return
+        try:
+            self._pynvml.nvmlShutdown()
+        except Exception:
+            pass
+        self._pynvml = None
+        self._handle = None
+
+
+def summarize_resource_samples(
+    samples: list[ResourceSample],
+    *,
+    interval_s: float,
+    error: str | None = None,
+) -> dict[str, Any]:
+    if not samples:
+        return {
+            "available": False,
+            "sample_interval_s": interval_s,
+            "samples": 0,
+            "error": error,
+        }
+
+    steady_count = max(1, min(len(samples), round(5.0 / interval_s)))
+    steady = samples[-steady_count:]
+    return {
+        "available": True,
+        "sample_interval_s": interval_s,
+        "samples": len(samples),
+        "duration_s": samples[-1].elapsed_s,
+        "gpu_memory_used_mib": _series_summary(
+            [sample.gpu_memory_used_mib for sample in samples],
+            steady=[sample.gpu_memory_used_mib for sample in steady],
+        ),
+        "gpu_memory_free_mib": _series_summary(
+            [sample.gpu_memory_free_mib for sample in samples],
+            steady=[sample.gpu_memory_free_mib for sample in steady],
+        ),
+        "gpu_process_memory_mib": _optional_series_summary(
+            [sample.gpu_process_memory_mib for sample in samples]
+        ),
+        "gpu_util_percent": _optional_series_summary(
+            [sample.gpu_util_percent for sample in samples]
+        ),
+        "power_w": _optional_series_summary([sample.power_w for sample in samples]),
+        "system_cpu_percent": _optional_series_summary(
+            [sample.system_cpu_percent for sample in samples]
+        ),
+        "gpu_process_cpu_percent": _optional_series_summary(
+            [sample.gpu_process_cpu_percent for sample in samples]
+        ),
+        "gpu_process_pids": sorted(
+            {pid for sample in samples for pid in sample.gpu_process_pids}
+        ),
+        "error": error,
+    }
+
+
+def collect_benchmark_provenance(
+    *,
+    model_id: str,
+    model_revision: str | None,
+    dataset_id: str,
+    dataset_revision: str | None,
+    launch_command: str | None,
+    server_config: dict[str, Any],
+    evaluation_input_sha256: str | None = None,
+) -> dict[str, Any]:
+    dependency_inventory = _distribution_inventory()
+    package_payload = json.dumps(
+        dependency_inventory,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    repository_status = _git_command("status", "--porcelain")
+
+    try:
+        import torch
+
+        torch_cuda = torch.version.cuda
+        cudnn_version = torch.backends.cudnn.version()
+    except Exception:
+        torch_cuda = None
+        cudnn_version = None
+
+    return {
+        "schema_version": 1,
+        "repository": {
+            "commit": _git_command("rev-parse", "HEAD"),
+            "branch": _git_command("branch", "--show-current"),
+            "dirty": (None if repository_status is None else bool(repository_status)),
+        },
+        "host": {
+            "platform": platform.platform(),
+            "cpu_model": _first_prefixed_line("/proc/cpuinfo", "model name"),
+            "logical_cpus": os.cpu_count(),
+            "memory_total_kib": _first_prefixed_line("/proc/meminfo", "MemTotal"),
+        },
+        "gpu": {
+            "nvidia_smi_csv": _command(
+                "nvidia-smi",
+                "--query-gpu=index,name,uuid,memory.total,driver_version,pstate,"
+                "power.limit,clocks.sm,clocks.mem,compute_cap",
+                "--format=csv,noheader,nounits",
+            ),
+            "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+            "torch_cuda_build": torch_cuda,
+            "cudnn_version": cudnn_version,
+        },
+        "packages": {
+            name: _package_version(name)
+            for name in (
+                "torch",
+                "sglang",
+                "sglang-omni",
+                "transformers",
+                "flash-attn-4",
+                "flashinfer-python",
+                "sglang-kernel",
+            )
+        },
+        "dependency_inventory": dependency_inventory,
+        "dependency_freeze_sha256": hashlib.sha256(
+            package_payload.encode()
+        ).hexdigest(),
+        "artifacts": {
+            "requested_model_id": model_id,
+            "declared_model_revision": model_revision,
+            "dataset_id": dataset_id,
+            "dataset_revision": dataset_revision,
+            "evaluation_input_sha256": evaluation_input_sha256,
+        },
+        "launch_command": launch_command,
+        "declared_server_config": server_config,
+        "normalization": {
+            "en": "whisper.normalizers.EnglishTextNormalizer",
+            "zh": "strip zhon+ASCII punctuation, remove spaces, score characters",
+        },
+    }
+
+
+def _resolve_nvml_handle(pynvml: Any, logical_gpu_index: int):
+    visible_value = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if visible_value is not None and not visible_value.strip():
+        raise ValueError("CUDA_VISIBLE_DEVICES is empty")
+    visible = (
+        [token.strip() for token in visible_value.split(",") if token.strip()]
+        if visible_value is not None
+        else []
+    )
+    device: int | str = logical_gpu_index
+    if visible:
+        if logical_gpu_index >= len(visible):
+            raise ValueError(
+                f"logical GPU {logical_gpu_index} is not in CUDA_VISIBLE_DEVICES"
+            )
+        token = visible[logical_gpu_index]
+        device = int(token) if token.isdigit() else token
+    if isinstance(device, int):
+        return pynvml.nvmlDeviceGetHandleByIndex(device)
+    return pynvml.nvmlDeviceGetHandleByUUID(device.encode())
+
+
+def _nvml_compute_processes(pynvml: Any, handle: Any) -> list[Any] | None:
+    getters = []
+    try:
+        getters.append(pynvml.nvmlDeviceGetComputeRunningProcesses)
+    except AttributeError:
+        pass
+    try:
+        getters.append(pynvml.nvmlDeviceGetGraphicsRunningProcesses)
+    except AttributeError:
+        pass
+
+    available = False
+    processes: dict[int, Any] = {}
+    for getter in getters:
+        try:
+            current = getter(handle)
+        except Exception:
+            continue
+        available = True
+        for process in current:
+            processes[int(process.pid)] = process
+    return list(processes.values()) if available else None
+
+
+def _series_summary(values: list[float], *, steady: list[float]) -> dict[str, float]:
+    return {
+        "min": min(values),
+        "max": max(values),
+        "end": values[-1],
+        "steady_mean": sum(steady) / len(steady),
+    }
+
+
+def _optional_series_summary(values: list[float | None]) -> dict[str, float] | None:
+    present = [value for value in values if value is not None]
+    if not present:
+        return None
+    return {
+        "min": min(present),
+        "max": max(present),
+        "mean": sum(present) / len(present),
+    }
+
+
+def _best_effort(callback):
+    try:
+        return callback()
+    except Exception:
+        return None
+
+
+def _command(*args: str) -> str | None:
+    try:
+        return subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+
+
+def _git_command(*args: str) -> str | None:
+    return _command("git", "-C", str(_REPO_ROOT), *args)
+
+
+def _first_prefixed_line(path: str, prefix: str) -> str | None:
+    try:
+        for line in Path(path).read_text().splitlines():
+            if line.startswith(prefix):
+                return line.split(":", 1)[-1].strip()
+    except OSError:
+        return None
+    return None
+
+
+def _distribution_inventory() -> list[dict[str, Any]]:
+    inventory = []
+    for distribution in importlib.metadata.distributions():
+        entry: dict[str, Any] = {
+            "name": distribution.metadata.get("Name", "unknown"),
+            "version": distribution.version,
+        }
+        direct_url = distribution.read_text("direct_url.json")
+        if direct_url:
+            try:
+                entry["direct_url"] = json.loads(direct_url)
+            except json.JSONDecodeError:
+                entry["direct_url"] = direct_url
+        inventory.append(entry)
+    return sorted(
+        inventory,
+        key=lambda entry: (entry["name"].casefold(), entry["version"]),
+    )
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+__all__ = [
+    "ResourceMonitor",
+    "ResourceSample",
+    "collect_benchmark_provenance",
+    "summarize_resource_samples",
+]

--- a/benchmarks/runtime_metrics.py
+++ b/benchmarks/runtime_metrics.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import hashlib
 import importlib.metadata
 import json
+import math
 import os
 import platform
 import subprocess
@@ -25,6 +26,7 @@ class ResourceSample:
     gpu_memory_used_mib: float
     gpu_memory_free_mib: float
     gpu_process_memory_mib: float | None
+    gpu_process_rss_mib: float | None
     gpu_util_percent: float | None
     power_w: float | None
     system_cpu_percent: float | None
@@ -38,8 +40,8 @@ class ResourceMonitor:
     def __init__(self, gpu_index: int = 0, interval_s: float = 0.2) -> None:
         if gpu_index < 0:
             raise ValueError("gpu_index must be >= 0")
-        if interval_s <= 0:
-            raise ValueError("interval_s must be > 0")
+        if not math.isfinite(interval_s) or interval_s <= 0:
+            raise ValueError("interval_s must be finite and > 0")
         self.gpu_index = gpu_index
         self.interval_s = interval_s
         self.samples: list[ResourceSample] = []
@@ -139,10 +141,10 @@ class ResourceMonitor:
             system_cpu = _best_effort(
                 lambda: float(self._psutil.cpu_percent(interval=None))
             )
-            process_cpu = (
-                self._gpu_process_cpu_percent(process_pids)
+            process_cpu, process_rss_mib = (
+                self._gpu_process_host_metrics(process_pids)
                 if nvml_processes is not None
-                else None
+                else (None, None)
             )
             process_memory_mib = (
                 float(process_memory_bytes) / (1024**2)
@@ -155,6 +157,7 @@ class ResourceMonitor:
                     gpu_memory_used_mib=float(memory.used) / (1024**2),
                     gpu_memory_free_mib=float(memory.free) / (1024**2),
                     gpu_process_memory_mib=process_memory_mib,
+                    gpu_process_rss_mib=process_rss_mib,
                     gpu_util_percent=utilization,
                     power_w=power_w,
                     system_cpu_percent=system_cpu,
@@ -166,22 +169,31 @@ class ResourceMonitor:
             if self.error is None:
                 self.error = f"{type(exc).__name__}: {exc}"
 
-    def _gpu_process_cpu_percent(self, pids: set[int]) -> float | None:
+    def _gpu_process_host_metrics(
+        self,
+        pids: set[int],
+    ) -> tuple[float | None, float | None]:
         if self._psutil is None:
-            return None
-        total = 0.0
-        observed = False
+            return None, None
+        cpu_total = 0.0
+        rss_total_bytes = 0
+        cpu_observed = False
+        rss_observed = False
         for pid in pids:
             try:
                 process = self._processes.get(pid)
                 if process is None:
                     process = self._psutil.Process(pid)
                     self._processes[pid] = process
-                total += float(process.cpu_percent(interval=None))
-                observed = True
+                cpu_total += float(process.cpu_percent(interval=None))
+                cpu_observed = True
+                rss_total_bytes += int(process.memory_info().rss)
+                rss_observed = True
             except (self._psutil.NoSuchProcess, self._psutil.AccessDenied):
                 self._processes.pop(pid, None)
-        return total if observed else None
+        cpu_percent = cpu_total if cpu_observed else None
+        rss_mib = float(rss_total_bytes) / (1024**2) if rss_observed else None
+        return cpu_percent, rss_mib
 
     def _shutdown_nvml(self) -> None:
         if self._pynvml is None:
@@ -225,6 +237,9 @@ def summarize_resource_samples(
         ),
         "gpu_process_memory_mib": _optional_series_summary(
             [sample.gpu_process_memory_mib for sample in samples]
+        ),
+        "gpu_process_rss_mib": _optional_series_summary(
+            [sample.gpu_process_rss_mib for sample in samples]
         ),
         "gpu_util_percent": _optional_series_summary(
             [sample.gpu_util_percent for sample in samples]

--- a/benchmarks/tasks/asr.py
+++ b/benchmarks/tasks/asr.py
@@ -50,6 +50,11 @@ OMNI_WHISPER_SAMPLE_RATE = 16000
 QWEN3_ASR_MODEL_PATH = "Qwen/Qwen3-ASR-1.7B"
 QWEN3_ASR_REQUEST_TIMEOUT_S = 300
 FUN_ASR_MODEL_PATH = "FunAudioLLM/Fun-ASR-Nano-2512-hf"
+PINNED_ASR_MODEL_REVISIONS = {
+    QWEN3_ASR_MODEL_PATH: "7278e1e70fe206f11671096ffdd38061171dd6e5",
+    FUN_ASR_MODEL_PATH: "854d88f94205cd17d2afdb24332130d86fbe654a",
+    OMNI_WHISPER_MODEL_PATH: "06f233fe06e710322aca913c1bc4249a0d71fce1",
+}
 # note (aaron): ASR transcription fan-out for WER, not TTS generation concurrency.
 DEFAULT_ASR_TRANSCRIBE_CONCURRENCY = 32
 # note (aaron): warmup requests sent before the timed window, per unit of concurrency.

--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -7,7 +7,8 @@
 Install `sglang-omni` by following [Installation](../get_started/installation.md), then download the model:
 
 ```bash
-hf download Qwen/Qwen3-ASR-1.7B
+MODEL_REVISION=7278e1e70fe206f11671096ffdd38061171dd6e5
+MODEL_PATH=$(hf download Qwen/Qwen3-ASR-1.7B --revision "${MODEL_REVISION}")
 ```
 
 ## Server Configuration
@@ -16,7 +17,8 @@ Qwen3-ASR runs a single ASR stage on one GPU.
 
 ```bash
 sgl-omni serve \
-  --model-path Qwen/Qwen3-ASR-1.7B \
+  --model-path "${MODEL_PATH}" \
+  --model-name Qwen/Qwen3-ASR-1.7B \
   --port 8000
 ```
 
@@ -56,13 +58,14 @@ print(resp.json()["text"])
 | `file` | file | required | Audio file uploaded as multipart form data |
 | `model` | string | server default | Model identifier |
 | `language` | string | `en` | Language hint; `zh`/`cn` select Chinese, other values use English prompting |
+| `prompt` | string | none | Accepted for OpenAI compatibility; Qwen3-ASR currently ignores it |
 | `response_format` | string | `json` | `json`, `verbose_json`, or `text` |
 | `temperature` | float | `0.01` effective | Sampling temperature; `0` is converted to near-greedy `0.01` |
+| `max_new_tokens` | integer | server stage limit | Per-request generation-token limit |
+| `stream` | boolean | `false` | Return transcript events over SSE |
 
-`verbose_json` is accepted, but currently returns the same minimal JSON shape as `json`:
-`{"text": "..."}`.
-
-`max_new_tokens` is supported inside the model request builder, but the public transcription endpoint does not currently expose it as a form field. The route uses the ASR stage default unless the pipeline is configured another way.
+`verbose_json` uses the model adapter's verbose response schema and includes
+duration-based usage (rounded-up audio seconds) when duration probing succeeds.
 
 ## Benchmarking
 
@@ -74,12 +77,27 @@ The report includes RTF (processing time divided by audio duration) and RTFx
 (successful input-audio seconds divided by wall-clock seconds).
 
 ```bash
-sgl-omni serve --model-path Qwen/Qwen3-ASR-1.7B --port 8000
+sgl-omni serve \
+  --model-path "${MODEL_PATH}" \
+  --model-name Qwen/Qwen3-ASR-1.7B \
+  --port 8000
 
-# Sweep the full SeedTTS EN set (1088 clips) at 1..64 concurrency, 3 repeats:
+# Sweep the full SeedTTS EN set (1088 clips), 3 repeats per concurrency:
 python -m benchmarks.eval.benchmark_asr_seedtts \
-  --port 8000 --concurrencies 1,2,4,8,16,32,64 --repeats 3 --warmup
+  --port 8000 \
+  --dataset-revision 27f4c1adee83b5b29b7c4b375f6b976324bda308 \
+  --model-revision 7278e1e70fe206f11671096ffdd38061171dd6e5 \
+  --concurrencies 1,2,4,8,16,32,64 \
+  --repeats 3 --warmup
 ```
+
+The result JSON includes the applied dataset revision, declared model revision,
+an effective evaluation-input content hash, normalization, repository and
+dependency fingerprints, complete sample counts, and latency/RTF/throughput.
+When local NVML and `psutil` sampling are available, it also includes CPU use,
+power, and peak/steady GPU memory; unavailable metrics and monitor errors remain
+explicit. Optional server settings and an exact launch command can be declared
+with the benchmark's provenance flags.
 
 The ASR CI gate runs the selected ASR CI model preset on this same benchmark
 entry point (`tests/test_model/test_asr_ci_seedtts.py`). Qwen3-ASR remains

--- a/tests/README.md
+++ b/tests/README.md
@@ -361,6 +361,15 @@ that happened to contain an older version of the test.
   pytest tests/unit_test/test_tune_ci_thresholds.py -q
   ```
 
+- `unit_test/benchmarks/`: Benchmark data, provenance, and result-contract tests:
+  - canonical/local/custom SeedTTS revision and content-fingerprint behavior
+  - resource-monitor lifecycle, GPU-process host RSS, optional NVML metrics,
+    and sampler ownership
+  - ASR consumer-model revision references, bilingual sample separation,
+    finite argument validation, bounded HTTP/SSE reads, exact total
+    concurrency, global translation cadence and English-semantic gates,
+    Python 3.10 cancellation compatibility, child-task cleanup, transport
+    failures, and fail-closed GPU-memory-retention gates.
 - `unit_test/utils/`: Shared utility tests:
   - audio loading helpers for data URIs, file URIs, HTTP URLs, timeout fallback,
     and mono/channel preservation.

--- a/tests/unit_test/benchmarks/test_asr_consumer_benchmarks.py
+++ b/tests/unit_test/benchmarks/test_asr_consumer_benchmarks.py
@@ -1,0 +1,867 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Consumer-model ASR benchmark and stability-harness contracts."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import aiohttp
+import pytest
+
+from benchmarks.eval import benchmark_asr_seedtts, benchmark_asr_stability
+from benchmarks.tasks.asr import (
+    FUN_ASR_MODEL_PATH,
+    OMNI_WHISPER_MODEL_PATH,
+    QWEN3_ASR_MODEL_PATH,
+)
+from benchmarks.tts_serving.http_contracts import ResponseBodyTooLarge
+
+EXPECTED_MODEL_REVISIONS = {
+    QWEN3_ASR_MODEL_PATH: "7278e1e70fe206f11671096ffdd38061171dd6e5",
+    FUN_ASR_MODEL_PATH: "854d88f94205cd17d2afdb24332130d86fbe654a",
+    OMNI_WHISPER_MODEL_PATH: "06f233fe06e710322aca913c1bc4249a0d71fce1",
+}
+
+
+def test_consumer_model_revision_table_is_exact() -> None:
+    assert benchmark_asr_seedtts.PINNED_MODEL_REVISIONS == EXPECTED_MODEL_REVISIONS
+
+
+def _stability_args(
+    model_path: str,
+    **overrides,
+) -> SimpleNamespace:
+    values = {
+        "concurrencies": "1",
+        "duration_s": 1.0,
+        "samples_per_language": 1,
+        "request_timeout_s": 1.0,
+        "max_audio_duration_s": 30.0,
+        "monitor_interval_s": 0.2,
+        "chaos_interval_s": 30.0,
+        "cooldown_s": 0.0,
+        "min_free_memory_mib": 0.0,
+        "max_retained_memory_mib": 0.0,
+        "gpu_index": 0,
+        "model_path": model_path,
+        "model_revision": None,
+        "include_translation": None,
+        "translation_source_language": "zh",
+        "check_audio_boundary": None,
+        "meta": "dataset",
+        "dataset_revision": "revision",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+@pytest.mark.asyncio
+async def test_seedtts_repeat_keeps_per_sample_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    per_sample = [
+        {
+            "id": "sample-1",
+            "is_success": True,
+            "audio_duration_s": 4.0,
+            "text_ttft_s": 0.1,
+            "inter_chunk_s": [0.02],
+        }
+    ]
+
+    async def fake_run(*_args, **_kwargs):
+        return {
+            "summary": {
+                "evaluated": 1,
+                "total_samples": 1,
+                "skipped": 0,
+                "corpus_wer": 0.0,
+                "wer_per_sample_max": 0.0,
+            },
+            "speed": {
+                "throughput_samples_per_s": 0.5,
+                "rtfx": 2.0,
+                "latency_mean_s": 0.2,
+                "latency_p95_s": 0.2,
+                "latency_p99_s": 0.2,
+                "rtf_mean": 0.05,
+                "rtf_p95": 0.05,
+            },
+            "wall_clock_s": 2.0,
+            "worker": {},
+            "per_sample": per_sample,
+        }
+
+    monkeypatch.setattr(
+        benchmark_asr_seedtts,
+        "run_asr_seedtts_once",
+        fake_run,
+    )
+    args = SimpleNamespace(
+        disable_resource_monitor=True,
+        gpu_index=0,
+        monitor_interval_s=0.2,
+        host="127.0.0.1",
+        port=8000,
+        model_path=FUN_ASR_MODEL_PATH,
+        lang="en",
+        stream=False,
+    )
+
+    result = await benchmark_asr_seedtts._run_repeat(args, [], 1, 1)
+
+    assert result["rtfx"] == 2.0
+    assert result["audio_seconds_per_s"] == 2.0
+    assert result["per_sample"] == per_sample
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("1", [1]), ("1,4,16", [1, 4, 16])],
+)
+def test_stability_concurrency_parser_accepts_positive_values(
+    raw: str,
+    expected: list[int],
+) -> None:
+    assert benchmark_asr_stability._parse_concurrencies(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["", "0", "-1", "1,", "one"])
+def test_stability_concurrency_parser_rejects_invalid_values(raw: str) -> None:
+    with pytest.raises(ValueError, match="positive integers"):
+        benchmark_asr_stability._parse_concurrencies(raw)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["nan", "inf", "-inf", "0"],
+)
+def test_seedtts_monitor_interval_parser_requires_finite_positive_value(
+    raw: str,
+) -> None:
+    with pytest.raises(
+        benchmark_asr_seedtts.argparse.ArgumentTypeError,
+        match="finite and greater than zero",
+    ):
+        benchmark_asr_seedtts._positive_float(raw)
+
+
+@pytest.mark.parametrize(
+    (
+        "model_path",
+        "expected_translation",
+        "expected_boundary",
+    ),
+    [
+        (QWEN3_ASR_MODEL_PATH, False, False),
+        (FUN_ASR_MODEL_PATH, False, True),
+        (OMNI_WHISPER_MODEL_PATH, False, False),
+    ],
+)
+def test_stability_model_defaults_are_capability_specific(
+    model_path: str,
+    expected_translation: bool,
+    expected_boundary: bool,
+) -> None:
+    args = _stability_args(model_path)
+
+    benchmark_asr_stability._validate_args(args)
+
+    assert args.include_translation is expected_translation
+    assert args.check_audio_boundary is expected_boundary
+    assert args.model_revision is None
+
+
+def test_stability_memory_retention_requires_free_and_cooldown_headroom() -> None:
+    checkpoints = [
+        {
+            "label": "before_functional",
+            "gpu_memory_used_mib": 100.0,
+            "gpu_memory_free_mib": 23000.0,
+        },
+        {
+            "label": "after_cooldown",
+            "gpu_memory_used_mib": 300.0,
+            "gpu_memory_free_mib": 22800.0,
+        },
+    ]
+    resources = {"gpu_memory_free_mib": {"min": 2200.0}}
+
+    passed = benchmark_asr_stability._validate_memory_retention(
+        checkpoints,
+        resources,
+        min_free_memory_mib=2048.0,
+        max_retained_memory_mib=256.0,
+    )
+    low_free = benchmark_asr_stability._validate_memory_retention(
+        checkpoints,
+        resources,
+        min_free_memory_mib=4096.0,
+        max_retained_memory_mib=256.0,
+    )
+    retained = benchmark_asr_stability._validate_memory_retention(
+        checkpoints,
+        resources,
+        min_free_memory_mib=2048.0,
+        max_retained_memory_mib=128.0,
+    )
+
+    assert passed["passed"] is True
+    assert passed["retained_after_cooldown_mib"] == 200.0
+    assert low_free["passed"] is False
+    assert retained["passed"] is False
+
+
+def test_stability_memory_retention_fails_closed_without_samples() -> None:
+    result = benchmark_asr_stability._validate_memory_retention(
+        [],
+        {"available": False},
+        min_free_memory_mib=0.0,
+        max_retained_memory_mib=0.0,
+    )
+
+    assert result["passed"] is False
+    assert result["error"] == "required GPU memory samples are unavailable"
+
+
+def test_stability_memory_retention_rejects_nonfinite_samples() -> None:
+    result = benchmark_asr_stability._validate_memory_retention(
+        [
+            {
+                "label": "before_functional",
+                "gpu_memory_used_mib": 100.0,
+                "gpu_memory_free_mib": 23000.0,
+            },
+            {
+                "label": "after_cooldown",
+                "gpu_memory_used_mib": float("nan"),
+                "gpu_memory_free_mib": 23000.0,
+            },
+        ],
+        {"gpu_memory_free_mib": {"min": 23000.0}},
+        min_free_memory_mib=2048.0,
+        max_retained_memory_mib=256.0,
+    )
+
+    assert result["passed"] is False
+    assert result["error"] == "required GPU memory samples are unavailable"
+
+
+def test_stability_memory_retention_rejects_monitor_errors() -> None:
+    checkpoints = [
+        {
+            "label": "before_functional",
+            "gpu_memory_used_mib": 100.0,
+            "gpu_memory_free_mib": 23000.0,
+            "error": None,
+        },
+        {
+            "label": "after_cooldown",
+            "gpu_memory_used_mib": 100.0,
+            "gpu_memory_free_mib": 23000.0,
+            "error": None,
+        },
+    ]
+    resource_error = benchmark_asr_stability._validate_memory_retention(
+        checkpoints,
+        {
+            "gpu_memory_free_mib": {"min": 23000.0},
+            "error": "NVML sampling failed",
+        },
+        min_free_memory_mib=2048.0,
+        max_retained_memory_mib=256.0,
+    )
+    checkpoints[-1]["error"] = "checkpoint sampling failed"
+    checkpoint_error = benchmark_asr_stability._validate_memory_retention(
+        checkpoints,
+        {"gpu_memory_free_mib": {"min": 23000.0}, "error": None},
+        min_free_memory_mib=2048.0,
+        max_retained_memory_mib=256.0,
+    )
+
+    assert resource_error["passed"] is False
+    assert checkpoint_error["passed"] is False
+
+
+@pytest.mark.asyncio
+async def test_stability_transport_error_becomes_request_evidence() -> None:
+    class FailingSession:
+        def post(self, *_args, **_kwargs):
+            raise aiohttp.ClientConnectionError("connection refused")
+
+    args = SimpleNamespace(
+        host="127.0.0.1",
+        port=8000,
+        model_path=FUN_ASR_MODEL_PATH,
+    )
+
+    result = await benchmark_asr_stability._post_raw_audio(
+        FailingSession(),
+        args,
+        b"RIFF",
+        "sample.wav",
+        "en",
+    )
+
+    assert result["status"] == 0
+    assert result["text"] == ""
+    assert "connection refused" in result["error"]
+
+
+def test_stability_translation_requires_english_output() -> None:
+    english = benchmark_asr_stability._expect_translation_success(
+        "translation",
+        {"status": 200, "text": "hello world", "error": None},
+    )
+    untranslated = benchmark_asr_stability._expect_translation_success(
+        "translation",
+        {"status": 200, "text": "你好世界", "error": None},
+    )
+
+    assert english["passed"] is True
+    assert untranslated["passed"] is False
+
+
+@pytest.mark.asyncio
+async def test_stability_stream_uses_route_header_and_terminal_contract() -> None:
+    captured: dict = {}
+
+    async def content():
+        yield b'data: {"type":"transcript.text.delta","delta":"hi"}\n'
+        yield b'data: {"type":"transcript.text.done","text":"hi"}\n'
+        yield b"data: [DONE]\n"
+
+    class FakeResponse:
+        status = 200
+
+        def __init__(self) -> None:
+            self.content = content()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+    class FakeSession:
+        def post(self, _url, **kwargs):
+            captured.update(kwargs)
+            return FakeResponse()
+
+    args = SimpleNamespace(
+        host="127.0.0.1",
+        port=8000,
+        model_path=FUN_ASR_MODEL_PATH,
+    )
+    sample = benchmark_asr_stability.PreparedSample(
+        sample_id="sample",
+        language="en",
+        audio_bytes=b"RIFF",
+        duration_s=1.0,
+    )
+
+    result = await benchmark_asr_stability._post_streaming_transcription(
+        FakeSession(),
+        args,
+        sample,
+    )
+
+    assert captured["headers"] == {"x-sglang-omni-route-stream": "true"}
+    assert result["status"] == 200
+    assert result["done"] is True
+    assert result["delta_events"] == 1
+    assert result["first_event_latency_s"] is not None
+    assert result["text"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_stability_cancel_stream_is_python_310_compatible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def content():
+        yield b'data: {"type":"transcript.text.delta","delta":"hi"}\n'
+
+    class FakeResponse:
+        status = 200
+
+        def __init__(self) -> None:
+            self.content = content()
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    response = FakeResponse()
+
+    class FakeSession:
+        async def post(self, *_args, **_kwargs):
+            return response
+
+    monkeypatch.delattr(
+        benchmark_asr_stability.asyncio,
+        "timeout",
+        raising=False,
+    )
+    args = SimpleNamespace(
+        host="127.0.0.1",
+        port=8000,
+        model_path=FUN_ASR_MODEL_PATH,
+        request_timeout_s=1.0,
+    )
+    sample = benchmark_asr_stability.PreparedSample(
+        sample_id="sample",
+        language="en",
+        audio_bytes=b"RIFF",
+        duration_s=1.0,
+    )
+
+    result = await benchmark_asr_stability._cancel_stream(
+        FakeSession(),
+        args,
+        sample,
+    )
+
+    assert result["received_event"] is True
+    assert response.closed is True
+
+
+@pytest.mark.asyncio
+async def test_stability_cancel_stream_rejects_terminal_first_response() -> None:
+    async def content():
+        yield b'data: {"type":"transcript.text.done","text":"complete"}\n'
+        yield b"data: [DONE]\n"
+
+    class FakeResponse:
+        status = 200
+
+        def __init__(self) -> None:
+            self.content = content()
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    response = FakeResponse()
+
+    class FakeSession:
+        async def post(self, *_args, **_kwargs):
+            return response
+
+    args = SimpleNamespace(
+        host="127.0.0.1",
+        port=8000,
+        model_path=FUN_ASR_MODEL_PATH,
+        request_timeout_s=1.0,
+    )
+    sample = benchmark_asr_stability.PreparedSample(
+        sample_id="sample",
+        language="en",
+        audio_bytes=b"RIFF",
+        duration_s=1.0,
+    )
+
+    result = await benchmark_asr_stability._cancel_stream(
+        FakeSession(),
+        args,
+        sample,
+    )
+
+    assert result["received_event"] is False
+    assert response.closed is True
+
+
+@pytest.mark.asyncio
+async def test_stability_stops_resource_monitor_when_functional_phase_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stopped = False
+
+    class FakeMonitor:
+        def __init__(self, **_kwargs) -> None:
+            self.interval_s = 0.2
+            self.samples = [object()]
+            self.error = None
+
+        def start(self):
+            return self
+
+        def stop(self):
+            nonlocal stopped
+            stopped = True
+            return {"available": False, "error": "fake"}
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+    async def fail_functional(*_args, **_kwargs):
+        raise RuntimeError("functional failed")
+
+    sample = benchmark_asr_stability.PreparedSample(
+        sample_id="sample",
+        language="en",
+        audio_bytes=b"RIFF",
+        duration_s=1.0,
+    )
+    monkeypatch.setattr(benchmark_asr_stability, "ResourceMonitor", FakeMonitor)
+    monkeypatch.setattr(
+        benchmark_asr_stability,
+        "_load_prepared_samples",
+        lambda _args, _revision: [sample],
+    )
+    monkeypatch.setattr(
+        benchmark_asr_stability,
+        "_evaluation_input_sha256",
+        lambda _samples: "hash",
+    )
+    monkeypatch.setattr(
+        benchmark_asr_stability,
+        "_memory_checkpoint",
+        lambda *_args: {"label": "checkpoint"},
+    )
+    monkeypatch.setattr(
+        benchmark_asr_stability.aiohttp,
+        "TCPConnector",
+        lambda **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        benchmark_asr_stability.aiohttp,
+        "ClientSession",
+        lambda **_kwargs: FakeSession(),
+    )
+    monkeypatch.setattr(
+        benchmark_asr_stability,
+        "_run_functional_checks",
+        fail_functional,
+    )
+    args = _stability_args(
+        FUN_ASR_MODEL_PATH,
+        include_translation=False,
+        check_audio_boundary=False,
+    )
+
+    with pytest.raises(RuntimeError, match="functional failed"):
+        await benchmark_asr_stability.main_async(args)
+
+    assert stopped is True
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("duration_s", float("inf")),
+        ("request_timeout_s", float("nan")),
+        ("max_audio_duration_s", float("-inf")),
+        ("monitor_interval_s", float("inf")),
+        ("chaos_interval_s", float("nan")),
+        ("cooldown_s", float("inf")),
+        ("min_free_memory_mib", float("nan")),
+        ("max_retained_memory_mib", float("inf")),
+    ],
+)
+def test_stability_validation_rejects_nonfinite_operational_values(
+    field: str,
+    value: float,
+) -> None:
+    args = _stability_args(FUN_ASR_MODEL_PATH)
+    setattr(args, field, value)
+
+    with pytest.raises(ValueError, match="finite"):
+        benchmark_asr_stability._validate_args(args)
+
+
+def test_stability_rejects_one_local_meta_for_bilingual_soak() -> None:
+    args = _stability_args(
+        FUN_ASR_MODEL_PATH,
+        meta="local-seedtts.lst",
+    )
+
+    with pytest.raises(ValueError, match="distinct en and zh splits"):
+        benchmark_asr_stability._validate_args(args)
+
+
+def test_stability_prepared_samples_are_language_interleaved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested_splits: list[str] = []
+
+    def fake_load(
+        _meta,
+        *,
+        max_samples,
+        split,
+        revision,
+    ):
+        requested_splits.append(split)
+        return [
+            SimpleNamespace(sample_id=f"{split}-{index}")
+            for index in range(max_samples)
+        ]
+
+    def fake_prepare(sample, language):
+        return benchmark_asr_stability.PreparedSample(
+            sample_id=sample.sample_id,
+            language=language,
+            audio_bytes=b"RIFF",
+            duration_s=1.0,
+        )
+
+    monkeypatch.setattr(
+        benchmark_asr_stability,
+        "load_seedtts_samples",
+        fake_load,
+    )
+    monkeypatch.setattr(
+        benchmark_asr_stability,
+        "_prepare_sample",
+        fake_prepare,
+    )
+    args = _stability_args(
+        FUN_ASR_MODEL_PATH,
+        samples_per_language=2,
+    )
+
+    samples = benchmark_asr_stability._load_prepared_samples(
+        args,
+        "revision",
+    )
+
+    assert requested_splits == ["en", "zh"]
+    assert [sample.sample_id for sample in samples] == [
+        "en-0",
+        "zh-0",
+        "en-1",
+        "zh-1",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stability_response_cap_becomes_request_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def too_large(_response):
+        raise ResponseBodyTooLarge(bytes_read=65, max_bytes=64)
+
+    class FakeResponse:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+    class FakeSession:
+        def post(self, *_args, **_kwargs):
+            return FakeResponse()
+
+    monkeypatch.setattr(
+        benchmark_asr_stability,
+        "read_response_body",
+        too_large,
+    )
+    args = SimpleNamespace(
+        host="127.0.0.1",
+        port=8000,
+        model_path=FUN_ASR_MODEL_PATH,
+    )
+
+    result = await benchmark_asr_stability._post_raw_audio(
+        FakeSession(),
+        args,
+        b"RIFF",
+        "sample.wav",
+        "en",
+    )
+
+    assert result["status"] == 200
+    assert result["text"] == ""
+    assert "read cap" in result["error"]
+
+
+def test_stability_sse_caps_line_and_cumulative_bytes() -> None:
+    with pytest.raises(ResponseBodyTooLarge, match="read cap"):
+        benchmark_asr_stability._checked_stream_bytes(
+            0,
+            b"x" * (benchmark_asr_stability.MAX_SSE_LINE_BYTES + 1),
+        )
+    with pytest.raises(ResponseBodyTooLarge, match="read cap"):
+        benchmark_asr_stability._checked_stream_bytes(
+            benchmark_asr_stability.MAX_HTTP_RESPONSE_BYTES,
+            b"x",
+        )
+
+
+@pytest.mark.asyncio
+async def test_stability_soak_bounds_total_concurrency_and_global_cadence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    active = 0
+    max_active = 0
+
+    async def pulse() -> None:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        try:
+            await asyncio.sleep(0.002)
+        finally:
+            active -= 1
+
+    async def successful_request(*_args):
+        await pulse()
+        return {"status": 200, "text": "ok", "latency_s": 0.002}
+
+    async def malformed_request(*_args):
+        await pulse()
+        return {"status": 400, "error": None}
+
+    async def cancel_request(*_args):
+        await pulse()
+        return {"status": 200, "received_event": True, "error": None}
+
+    async def reconnect_request(*_args):
+        await pulse()
+        return {"status": 200, "done": True, "error": None}
+
+    monkeypatch.setattr(
+        benchmark_asr_stability,
+        "_post_transcription",
+        successful_request,
+    )
+    monkeypatch.setattr(
+        benchmark_asr_stability,
+        "_post_translation",
+        successful_request,
+    )
+    monkeypatch.setattr(
+        benchmark_asr_stability,
+        "_post_raw_audio",
+        malformed_request,
+    )
+    monkeypatch.setattr(
+        benchmark_asr_stability,
+        "_cancel_stream",
+        cancel_request,
+    )
+    monkeypatch.setattr(
+        benchmark_asr_stability,
+        "_post_streaming_transcription",
+        reconnect_request,
+    )
+    monkeypatch.setattr(
+        benchmark_asr_stability,
+        "_memory_checkpoint",
+        lambda *_args: {},
+    )
+    samples = [
+        benchmark_asr_stability.PreparedSample(
+            sample_id=f"{language}-{index}",
+            language=language,
+            audio_bytes=b"RIFF",
+            duration_s=1.0,
+        )
+        for index, language in enumerate(("en", "zh", "en", "zh"))
+    ]
+    args = SimpleNamespace(
+        seed=7,
+        duration_s=0.04,
+        include_translation=True,
+        chaos_interval_s=0.005,
+    )
+
+    stages, chaos = await benchmark_asr_stability._run_soak(
+        object(),
+        args,
+        samples,
+        concurrencies=[4],
+        monitor=object(),
+    )
+
+    stage = stages[0]
+    assert active == 0
+    assert max_active <= 4
+    assert stage["max_in_flight_observed"] == max_active
+    assert stage["chaos_events"] == len(chaos)
+    assert stage["chaos_events"] > 0
+    assert stage["total_http_requests"] == (stage["requests"] + stage["chaos_requests"])
+    assert stage["translations"] == (stage["zh_requests_issued"] + 3) // 4
+    assert stage["translation_observed_ratio"] == (stage["translations"] / stage["zh"])
+
+
+@pytest.mark.asyncio
+async def test_stability_soak_cancellation_cleans_up_all_child_tasks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = asyncio.Event()
+    active = 0
+
+    async def blocking_request(*_args):
+        nonlocal active
+        active += 1
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            active -= 1
+
+    for name in (
+        "_post_transcription",
+        "_post_translation",
+        "_post_raw_audio",
+        "_cancel_stream",
+        "_post_streaming_transcription",
+    ):
+        monkeypatch.setattr(
+            benchmark_asr_stability,
+            name,
+            blocking_request,
+        )
+    monkeypatch.setattr(
+        benchmark_asr_stability,
+        "_memory_checkpoint",
+        lambda *_args: {},
+    )
+    samples = [
+        benchmark_asr_stability.PreparedSample(
+            sample_id="en",
+            language="en",
+            audio_bytes=b"RIFF",
+            duration_s=1.0,
+        ),
+        benchmark_asr_stability.PreparedSample(
+            sample_id="zh",
+            language="zh",
+            audio_bytes=b"RIFF",
+            duration_s=1.0,
+        ),
+    ]
+    args = SimpleNamespace(
+        seed=7,
+        duration_s=10.0,
+        include_translation=False,
+        chaos_interval_s=30.0,
+    )
+    tasks_before = set(asyncio.all_tasks())
+    soak_task = asyncio.create_task(
+        benchmark_asr_stability._run_soak(
+            object(),
+            args,
+            samples,
+            concurrencies=[2],
+            monitor=object(),
+        )
+    )
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    soak_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await soak_task
+    await asyncio.sleep(0)
+
+    assert active == 0
+    assert set(asyncio.all_tasks()) <= tasks_before

--- a/tests/unit_test/benchmarks/test_dataset_regressions.py
+++ b/tests/unit_test/benchmarks/test_dataset_regressions.py
@@ -8,6 +8,7 @@ import pytest
 import yaml
 
 from benchmarks.dataset import prepare, seedtts
+from benchmarks.eval import benchmark_asr_seedtts
 
 _MODELS_DIR = (
     Path(__file__).resolve().parents[3] / ".claude/skills/tune-ci-thresholds/models"
@@ -64,6 +65,38 @@ def test_download_dataset_prewarms_all_mmmu_configs(monkeypatch) -> None:
     ]
 
 
+def test_download_seedtts_uses_pinned_revision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict = {}
+
+    def fake_load_dataset(repo_id: str, **kwargs):
+        observed["repo_id"] = repo_id
+        observed.update(kwargs)
+        return object()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "datasets",
+        types.SimpleNamespace(
+            get_dataset_config_names=lambda *_args, **_kwargs: [],
+            load_dataset=fake_load_dataset,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        types.SimpleNamespace(hf_hub_download=lambda *_args, **_kwargs: None),
+    )
+
+    prepare.download_dataset(prepare.SEEDTTS_DATASET_ID, quiet=True)
+
+    assert observed == {
+        "repo_id": prepare.SEEDTTS_DATASET_ID,
+        "revision": prepare.SEEDTTS_DATASET_REVISION,
+    }
+
+
 def test_load_seedtts_samples_accepts_local_meta_lst(tmp_path: Path) -> None:
     meta_dir = tmp_path / "en"
     meta_dir.mkdir()
@@ -81,6 +114,177 @@ def test_load_seedtts_samples_accepts_local_meta_lst(tmp_path: Path) -> None:
     assert samples[0].ref_text == "hello"
     assert samples[0].ref_audio == str(ref_audio)
     assert samples[0].target_text == "target one"
+
+
+def test_local_seedtts_source_does_not_claim_huggingface_revision(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    meta_path = tmp_path / "meta.lst"
+    meta_path.write_text("sample-1|hello|ref.wav|target one\n")
+    (tmp_path / "ref.wav").write_bytes(b"audio")
+    output_path = tmp_path / "result.json"
+    captured: dict = {}
+
+    async def empty_sweep(*_args, **_kwargs):
+        return []
+
+    def capture_provenance(**kwargs):
+        captured.update(kwargs)
+        return {}
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "benchmark_asr_seedtts",
+            "--port",
+            "8000",
+            "--meta",
+            str(meta_path),
+            "--output",
+            str(output_path),
+        ],
+    )
+    monkeypatch.setattr(benchmark_asr_seedtts, "_sweep", empty_sweep)
+    monkeypatch.setattr(
+        benchmark_asr_seedtts,
+        "collect_benchmark_provenance",
+        capture_provenance,
+    )
+
+    benchmark_asr_seedtts.main()
+    assert captured["dataset_revision"] is None
+    assert captured["model_revision"] is None
+    assert captured["server_config"]["quantization"] is None
+
+
+def test_custom_seedtts_repo_does_not_use_canonical_revision(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output_path = tmp_path / "result.json"
+    loaded: dict = {}
+    captured: dict = {}
+    audio_path = tmp_path / "custom.wav"
+    audio_path.write_bytes(b"audio")
+
+    def capture_load(source: str, **kwargs):
+        loaded["source"] = source
+        loaded.update(kwargs)
+        return [
+            seedtts.SampleInput(
+                sample_id="sample-1",
+                ref_text="reference",
+                ref_audio=str(audio_path),
+                target_text="target",
+            )
+        ]
+
+    async def empty_sweep(*_args, **_kwargs):
+        return []
+
+    def capture_provenance(**kwargs):
+        captured.update(kwargs)
+        return {}
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "benchmark_asr_seedtts",
+            "--port",
+            "8000",
+            "--meta",
+            "example/custom-seedtts",
+            "--output",
+            str(output_path),
+        ],
+    )
+    monkeypatch.setattr(
+        benchmark_asr_seedtts,
+        "load_seedtts_samples",
+        capture_load,
+    )
+    monkeypatch.setattr(benchmark_asr_seedtts, "_sweep", empty_sweep)
+    monkeypatch.setattr(
+        benchmark_asr_seedtts,
+        "collect_benchmark_provenance",
+        capture_provenance,
+    )
+
+    benchmark_asr_seedtts.main()
+
+    assert loaded["revision"] is None
+    assert captured["dataset_revision"] is None
+
+
+@pytest.mark.parametrize(
+    "extra_args",
+    [
+        ["--concurrencies", ""],
+        ["--concurrencies", "0"],
+        ["--repeats", "0"],
+    ],
+)
+def test_asr_benchmark_cli_rejects_empty_work(
+    monkeypatch: pytest.MonkeyPatch,
+    extra_args: list[str],
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["benchmark_asr_seedtts", "--port", "8000", *extra_args],
+    )
+
+    with pytest.raises(SystemExit):
+        benchmark_asr_seedtts.parse_args()
+
+
+def test_asr_benchmark_rejects_empty_dataset(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "benchmark_asr_seedtts",
+            "--port",
+            "8000",
+            "--meta",
+            "example/empty",
+            "--output",
+            str(tmp_path / "result.json"),
+        ],
+    )
+    monkeypatch.setattr(
+        benchmark_asr_seedtts,
+        "load_seedtts_samples",
+        lambda *_args, **_kwargs: [],
+    )
+
+    with pytest.raises(RuntimeError, match="No SeedTTS samples"):
+        benchmark_asr_seedtts.main()
+
+
+def test_evaluation_input_fingerprint_tracks_audio_content(tmp_path: Path) -> None:
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"first")
+    samples = [
+        seedtts.SampleInput(
+            sample_id="sample-1",
+            ref_text="reference",
+            ref_audio=str(audio_path),
+            target_text="target",
+        )
+    ]
+
+    before = benchmark_asr_seedtts._evaluation_input_sha256(samples)
+    audio_path.write_bytes(b"second")
+    after = benchmark_asr_seedtts._evaluation_input_sha256(samples)
+
+    assert before != after
 
 
 def test_load_seedtts_samples_stages_only_selected_rows(
@@ -102,9 +306,10 @@ def test_load_seedtts_samples_stages_only_selected_rows(
     stage_dir = tmp_path / "seedtts_stage"
     stage_dir.mkdir()
 
-    def fake_load_dataset(repo_id: str, split: str):
+    def fake_load_dataset(repo_id: str, split: str, revision: str | None = None):
         assert repo_id == "zhaochenyang20/seed-tts-eval-arrow"
         assert split == "en"
+        assert revision == prepare.SEEDTTS_DATASET_REVISION
         return dataset
 
     monkeypatch.setitem(
@@ -163,9 +368,10 @@ def test_load_seedtts_samples_rejects_unsafe_audio_paths(
         }
     ]
 
-    def fake_load_dataset(repo_id: str, split: str):
-        assert repo_id == "zhaochenyang20/seed-tts-eval-arrow"
+    def fake_load_dataset(repo_id: str, split: str, revision: str):
+        assert repo_id == prepare.SEEDTTS_DATASET_ID
         assert split == "en"
+        assert revision == prepare.SEEDTTS_DATASET_REVISION
         return _FakeDataset(rows)
 
     monkeypatch.setitem(

--- a/tests/unit_test/benchmarks/test_runtime_metrics.py
+++ b/tests/unit_test/benchmarks/test_runtime_metrics.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+import sys
+import threading
+import time
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from benchmarks import runtime_metrics
+from benchmarks.eval import benchmark_asr_seedtts
+from benchmarks.runtime_metrics import (
+    ResourceMonitor,
+    ResourceSample,
+    summarize_resource_samples,
+)
+
+
+def test_summarize_resource_samples_reports_peak_and_steady_values() -> None:
+    samples = [
+        ResourceSample(
+            elapsed_s=0.0,
+            gpu_memory_used_mib=100.0,
+            gpu_memory_free_mib=900.0,
+            gpu_process_memory_mib=80.0,
+            gpu_util_percent=10.0,
+            power_w=20.0,
+            system_cpu_percent=5.0,
+            gpu_process_cpu_percent=25.0,
+            gpu_process_pids=(11,),
+        ),
+        ResourceSample(
+            elapsed_s=1.0,
+            gpu_memory_used_mib=200.0,
+            gpu_memory_free_mib=800.0,
+            gpu_process_memory_mib=180.0,
+            gpu_util_percent=90.0,
+            power_w=120.0,
+            system_cpu_percent=15.0,
+            gpu_process_cpu_percent=125.0,
+            gpu_process_pids=(11, 22),
+        ),
+    ]
+
+    result = summarize_resource_samples(samples, interval_s=1.0)
+
+    assert result["available"] is True
+    assert result["gpu_memory_used_mib"] == {
+        "min": 100.0,
+        "max": 200.0,
+        "end": 200.0,
+        "steady_mean": 150.0,
+    }
+    assert result["gpu_process_memory_mib"]["max"] == 180.0
+    assert result["power_w"]["max"] == 120.0
+    assert result["gpu_process_cpu_percent"]["max"] == 125.0
+    assert result["gpu_process_pids"] == [11, 22]
+
+
+def test_summarize_resource_samples_reports_unavailable_monitor() -> None:
+    result = summarize_resource_samples([], interval_s=0.2, error="NVML unavailable")
+
+    assert result == {
+        "available": False,
+        "sample_interval_s": 0.2,
+        "samples": 0,
+        "error": "NVML unavailable",
+    }
+
+
+def test_provenance_labels_server_configuration_as_declared(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        runtime_metrics.importlib.metadata,
+        "distributions",
+        lambda: [],
+    )
+    monkeypatch.setattr(runtime_metrics, "_command", lambda *_args: None)
+    monkeypatch.setattr(
+        runtime_metrics,
+        "_first_prefixed_line",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(runtime_metrics, "_package_version", lambda _name: None)
+
+    result = runtime_metrics.collect_benchmark_provenance(
+        model_id="model",
+        model_revision=None,
+        dataset_id="dataset",
+        dataset_revision=None,
+        launch_command=None,
+        server_config={"dtype": "bfloat16"},
+    )
+
+    assert result["declared_server_config"] == {"dtype": "bfloat16"}
+    assert "server_config" not in result
+    assert result["artifacts"]["declared_model_revision"] is None
+    assert "model_revision" not in result["artifacts"]
+    assert result["repository"]["dirty"] is None
+    assert result["dependency_inventory"] == []
+
+
+def test_nvml_handle_respects_explicitly_hidden_gpus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+    pynvml = SimpleNamespace(
+        nvmlDeviceGetHandleByIndex=lambda index: f"gpu-{index}",
+    )
+
+    with pytest.raises(ValueError, match="CUDA_VISIBLE_DEVICES is empty"):
+        runtime_metrics._resolve_nvml_handle(pynvml, 0)
+
+
+def test_nvml_process_snapshot_marks_unsupported_getters_unavailable() -> None:
+    assert runtime_metrics._nvml_compute_processes(SimpleNamespace(), object()) is None
+
+
+def test_resource_monitor_refuses_overlapping_nvml_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    nvml_session_lock = threading.Lock()
+    nvml_session_lock.acquire()
+    monkeypatch.setattr(
+        runtime_metrics,
+        "_NVML_SESSION_LOCK",
+        nvml_session_lock,
+        raising=False,
+    )
+
+    result = ResourceMonitor().start().stop()
+
+    assert result["available"] is False
+    assert result["error"] == "another NVML resource monitor is still active"
+
+
+def test_resource_monitor_keeps_nvml_calls_on_sampler_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    caller_thread = threading.get_ident()
+    nvml_threads: list[int] = []
+
+    def record(value=None):
+        nvml_threads.append(threading.get_ident())
+        return value
+
+    pynvml = ModuleType("pynvml")
+    pynvml.nvmlInit = lambda: record()
+    pynvml.nvmlShutdown = lambda: record()
+    pynvml.nvmlDeviceGetHandleByIndex = lambda _index: record("gpu")
+    pynvml.nvmlDeviceGetMemoryInfo = lambda _handle: record(
+        SimpleNamespace(used=1024, free=2048)
+    )
+    pynvml.nvmlDeviceGetComputeRunningProcesses = lambda _handle: record([])
+    pynvml.nvmlDeviceGetGraphicsRunningProcesses = lambda _handle: record([])
+    pynvml.nvmlDeviceGetUtilizationRates = lambda _handle: record(
+        SimpleNamespace(gpu=50)
+    )
+    pynvml.nvmlDeviceGetPowerUsage = lambda _handle: record(1000)
+
+    psutil = ModuleType("psutil")
+    psutil.cpu_percent = lambda interval=None: 10.0
+    psutil.NoSuchProcess = RuntimeError
+    psutil.AccessDenied = PermissionError
+
+    monkeypatch.setitem(sys.modules, "pynvml", pynvml)
+    monkeypatch.setitem(sys.modules, "psutil", psutil)
+
+    monitor = ResourceMonitor(interval_s=0.01).start()
+    deadline = time.monotonic() + 1.0
+    while not monitor.samples and time.monotonic() < deadline:
+        time.sleep(0.01)
+    result = monitor.stop()
+
+    assert result["available"] is True
+    assert nvml_threads
+    assert caller_thread not in nvml_threads
+    assert len(set(nvml_threads)) == 1
+
+
+@pytest.mark.asyncio
+async def test_asr_repeat_stops_resource_monitor_when_request_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stopped = False
+
+    class FakeMonitor:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def start(self):
+            return self
+
+        def stop(self):
+            nonlocal stopped
+            stopped = True
+            return {}
+
+    async def fail_request(*_args, **_kwargs):
+        raise RuntimeError("request failed")
+
+    monkeypatch.setattr(benchmark_asr_seedtts, "ResourceMonitor", FakeMonitor)
+    monkeypatch.setattr(
+        benchmark_asr_seedtts,
+        "run_asr_seedtts_once",
+        fail_request,
+    )
+    args = SimpleNamespace(
+        disable_resource_monitor=False,
+        gpu_index=0,
+        monitor_interval_s=0.2,
+        host="127.0.0.1",
+        port=8000,
+        model_path="model",
+        lang="en",
+        stream=False,
+    )
+
+    with pytest.raises(RuntimeError, match="request failed"):
+        await benchmark_asr_seedtts._run_repeat(args, [], 1, 1)
+
+    assert stopped is True

--- a/tests/unit_test/benchmarks/test_runtime_metrics.py
+++ b/tests/unit_test/benchmarks/test_runtime_metrics.py
@@ -22,6 +22,7 @@ def test_summarize_resource_samples_reports_peak_and_steady_values() -> None:
             gpu_memory_used_mib=100.0,
             gpu_memory_free_mib=900.0,
             gpu_process_memory_mib=80.0,
+            gpu_process_rss_mib=256.0,
             gpu_util_percent=10.0,
             power_w=20.0,
             system_cpu_percent=5.0,
@@ -33,6 +34,7 @@ def test_summarize_resource_samples_reports_peak_and_steady_values() -> None:
             gpu_memory_used_mib=200.0,
             gpu_memory_free_mib=800.0,
             gpu_process_memory_mib=180.0,
+            gpu_process_rss_mib=512.0,
             gpu_util_percent=90.0,
             power_w=120.0,
             system_cpu_percent=15.0,
@@ -51,6 +53,7 @@ def test_summarize_resource_samples_reports_peak_and_steady_values() -> None:
         "steady_mean": 150.0,
     }
     assert result["gpu_process_memory_mib"]["max"] == 180.0
+    assert result["gpu_process_rss_mib"]["max"] == 512.0
     assert result["power_w"]["max"] == 120.0
     assert result["gpu_process_cpu_percent"]["max"] == 125.0
     assert result["gpu_process_pids"] == [11, 22]
@@ -116,6 +119,17 @@ def test_nvml_process_snapshot_marks_unsupported_getters_unavailable() -> None:
     assert runtime_metrics._nvml_compute_processes(SimpleNamespace(), object()) is None
 
 
+@pytest.mark.parametrize(
+    "interval_s",
+    [float("nan"), float("inf"), float("-inf"), 0.0],
+)
+def test_resource_monitor_rejects_nonfinite_or_nonpositive_interval(
+    interval_s: float,
+) -> None:
+    with pytest.raises(ValueError, match="interval_s must be finite and > 0"):
+        ResourceMonitor(interval_s=interval_s)
+
+
 def test_resource_monitor_refuses_overlapping_nvml_session(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -132,6 +146,28 @@ def test_resource_monitor_refuses_overlapping_nvml_session(
 
     assert result["available"] is False
     assert result["error"] == "another NVML resource monitor is still active"
+
+
+def test_resource_monitor_aggregates_gpu_process_host_rss() -> None:
+    class FakeProcess:
+        def cpu_percent(self, *, interval=None):
+            assert interval is None
+            return 12.5
+
+        def memory_info(self):
+            return SimpleNamespace(rss=2 * 1024 * 1024)
+
+    monitor = ResourceMonitor()
+    monitor._psutil = SimpleNamespace(
+        Process=lambda _pid: FakeProcess(),
+        NoSuchProcess=RuntimeError,
+        AccessDenied=PermissionError,
+    )
+
+    cpu_percent, rss_mib = monitor._gpu_process_host_metrics({11, 22})
+
+    assert cpu_percent == 25.0
+    assert rss_mib == 4.0
 
 
 def test_resource_monitor_keeps_nvml_calls_on_sampler_thread(


### PR DESCRIPTION
## Summary

- extend the reproducible SeedTTS ASR foundation in #1155 from Qwen3-ASR to the consumer-model matrix: Qwen3-ASR, Fun-ASR-Nano, and Whisper
- add a public-API stability harness covering EN/ZH transcription, Whisper translation, SSE terminal consistency, cancellation/reconnect, malformed-audio fault injection, exact staged concurrency, health, and fail-closed memory retention
- record bounded-memory latency statistics plus device memory, GPU-process allocation, GPU-process host RSS/CPU, utilization, and power evidence
- add focused lifecycle, concurrency, response-bound, bilingual-dataset, provenance, and memory-gate tests plus copyable operating instructions

## Ownership and dependencies

This is the benchmark/stability slice of roadmap #1120. It changes benchmark, documentation, and test code only; model/runtime ownership stays in the model-local PRs.

This PR is intentionally stacked on #1155 (`a691af19`). Review the incremental range from that commit. Merge #1155 first, then rebase or retarget this branch to `main`.

Related runtime slices:

- #1278 — Fun-ASR RTX 4090 serving profile
- #1279 — Whisper RTX 4090 profile and input guards
- #1280 — Whisper `/v1/audio/translations` route
- #1153 — pipeline signal/worker cleanup prerequisite

The older umbrella/result PRs #1152, #1169, #1171, and #1213 contain published consumer-GPU qualification evidence. This PR does not invent or replace measured hardware results; it makes the reusable harness and evidence contract reviewable independently.

## Behavior

- canonical SeedTTS model/dataset revisions are pinned and declared separately from observed repository/dependency state
- the stability soak interleaves distinct EN/ZH splits and rejects one local `meta.lst` masquerading as both languages
- `--concurrencies` is an exact cap across ordinary and chaos HTTP traffic
- when explicitly enabled for a compatible Whisper server, translation uses one shared stage-wide request for every four Chinese requests and rejects untranslated Chinese output
- every stage must complete ordinary traffic and a chaos event; translation stages must complete translation traffic
- JSON, health, and SSE reads have cumulative bounds; oversized responses fail the request
- monitor/sample absence fails the memory gate instead of silently passing
- child workers are cancelled and joined on failure/cancellation; output JSON uses atomic replacement

## Validation

- `python -m pytest tests/unit_test/benchmarks -q` — 105 passed
- changed-file Black, isort, Ruff/F401, and AST hooks — passed
- `python -m benchmarks.eval.benchmark_asr_stability --help` — passed
- local public-HTTP smoke with transcription, translation, streaming, cancel/reconnect, malformed audio, 29.9/30.1-second boundary checks, two load stages, and synthetic resource samples — passed
  - max in flight matched each exact stage cap; both stages completed translation and four chaos events
  - memory gate passed with 0 MiB synthetic retention; final `/health` returned 200

The local workstation is Apple M4 and has no NVIDIA device or configured SSH GPU host. No new RTX 4090 performance claim is made here. A live NVIDIA/NVML run remains required before using a generated JSON artifact as hardware qualification evidence.

## Documentation

`benchmarks/README.md` now documents dataset preparation, server startup, a 30-minute command, model and dataset revisions, exact duration/concurrency semantics, translation cadence, NVML/`psutil` requirements, fail-closed gates, local-dataset limitations, response bounds, and output provenance.

## Source

Migrated and hardened from @wirybeaver's benchmark work in #1155/#1171 and https://github.com/wirybeaver/sglang-omni/pull/4.
