### PR TITLE
feat(qwen3-tts): add true incremental streaming

### DIFF
--- a/docs/cookbook/qwen3_tts.md
+++ b/docs/cookbook/qwen3_tts.md
@@ -156,6 +156,11 @@ Streaming returns `audio/pcm` 16-bit mono PCM bytes with sample-rate metadata in
 the response headers. See the [Higgs TTS cookbook](../cookbook/higgs_tts.md#streaming)
 for a full Python raw PCM consumer.
 
+Base/reference-cloning checkpoints use true incremental codec and vocoder
+streaming for both this HTTP endpoint and `/v1/audio/speech/stream` WebSocket
+sessions with `stream_audio=true`. CustomVoice and VoiceDesign remain
+non-streaming.
+
 ## Generation Parameters
 
 | Parameter | Default | Notes |

--- a/sglang_omni/models/qwen3_tts/__init__.py
+++ b/sglang_omni/models/qwen3_tts/__init__.py
@@ -8,7 +8,7 @@ from . import config
 CAPABILITIES = ModelCapabilities(
     supports_reference_audio=True,
     supports_batch_vocoder=True,
-    supports_streaming_vocoder=False,
+    supports_streaming_vocoder=True,
     supports_cuda_graph=True,
     supports_torch_compile=True,
 )

--- a/sglang_omni/models/qwen3_tts/config.py
+++ b/sglang_omni/models/qwen3_tts/config.py
@@ -66,6 +66,7 @@ class Qwen3TTSPipelineConfig(PipelineConfig):
             factory_args={"dtype": "bfloat16"},
             gpu=0,
             next="vocoder",
+            stream_to=["vocoder"],
         ),
         StageConfig(
             name="vocoder",
@@ -74,6 +75,7 @@ class Qwen3TTSPipelineConfig(PipelineConfig):
             factory_args={"dtype": "bfloat16"},
             gpu=0,
             terminal=True,
+            can_accept_stream_before_payload=True,
         ),
     ]
 

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -20,6 +20,7 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
     def __init__(self, *, attn_implementation: str | None = None) -> None:
         self.attn_implementation = attn_implementation
         self.wrapper: Any | None = None
+        self._stream_output_builder: Any | None = None
 
     def resolve_checkpoint(self, model_path: str) -> str:
         qwen3_stages.apply_qwen_tts_transformers_compatibility_patches()
@@ -107,10 +108,16 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         return model_runner_mod.Qwen3TTSModelRunner(model_worker, output_proc)
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:
-        return request_builders.make_qwen3_tts_scheduler_adapters(
-            model=model,
-            wrapper=self.wrapper,
+        request_builder, result_adapter, self._stream_output_builder = (
+            request_builders.make_qwen3_tts_scheduler_adapters(
+                model=model,
+                wrapper=self.wrapper,
+            )
         )
+        return request_builder, result_adapter
+
+    def extra_scheduler_kwargs(self) -> dict[str, Any]:
+        return {"stream_output_builder": self._stream_output_builder}
 
     def make_abort_callback(self) -> Any | None:
         return request_builders.cleanup_prepared_qwen3_tts_request

--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -154,6 +154,7 @@ class Qwen3TTSModelRunner(ModelRunner):
             code_chunk = self.model._output_codes[row_idx].detach().clone()
             feedback = self.model._output_embeds[row_idx].detach().clone()
             sched_req.data.output_codes.append(code_chunk)
+            sched_req.data.latest_stream_code_chunk = code_chunk
             sched_req.data.pending_feedback_queue.append(feedback)
 
     def _sample_positions(

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -24,6 +24,7 @@ from sglang_omni.sampling.seed import (
     derive_sampling_seed,
     new_random_sampling_seed,
 )
+from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.reference_encoder import (
     KeyedReferenceEncodeHook,
     ReferenceEncodeService,
@@ -33,6 +34,7 @@ from sglang_omni.scheduling.speaker_cache import (
     SpeakerCacheKey,
     get_speaker_artifact_cache,
 )
+from sglang_omni.scheduling.streaming_vocoder import INITIAL_CODEC_CHUNK_FRAMES_PARAM
 from sglang_omni.utils.audio_payload import audio_data_uri_from_reference
 
 QWEN3_TTS_DEFAULT_MAX_NEW_TOKENS = 2048
@@ -101,6 +103,9 @@ class Qwen3TTSSGLangRequestData(SGLangARRequestData):
 
     enforce_request_limits: bool = True
     output_codes: list[torch.Tensor] = field(default_factory=list)
+    latest_stream_code_chunk: torch.Tensor | None = None
+    stream_ref_sent: bool = False
+    stream_codec_output: bool = False
     ref_code: torch.Tensor | None = None
     ref_code_len: int = 0
     prompt_input_embeds: torch.Tensor | None = None
@@ -1028,6 +1033,7 @@ def build_sglang_qwen3_tts_request(
         subtalker_top_p=float(gen_kwargs.get("subtalker_top_p", 1.0)),
         subtalker_top_k=int(gen_kwargs.get("subtalker_top_k", 50)),
         subtalker_sampling_seed=subtalker_sampling_seed,
+        stream_codec_output=not state.non_streaming_mode,
         engine_start_s=time.perf_counter(),
     )
     data.suppress_tokens = list(req._codec_suppress_tokens)
@@ -1086,4 +1092,66 @@ def make_qwen3_tts_scheduler_adapters(*, model: Any, wrapper: Any):
     def result_adapter(data: Qwen3TTSSGLangRequestData) -> StagePayload:
         return apply_sglang_qwen3_tts_result(data.stage_payload, data)
 
-    return request_builder, result_adapter
+    def stream_output_builder(
+        request_id: str,
+        data: Qwen3TTSSGLangRequestData,
+        req_output: Any,
+    ) -> list[OutgoingMessage]:
+        del req_output
+        params = data.stage_payload.request.params
+        if (
+            not data.stream_codec_output
+            or not isinstance(params, dict)
+            or not params.get("stream")
+        ):
+            return []
+
+        codes = data.latest_stream_code_chunk
+        if codes is None:
+            return []
+        data.latest_stream_code_chunk = None
+        if codes.ndim == 1:
+            codes = codes.unsqueeze(0)
+        elif codes.ndim != 2:
+            raise ValueError(
+                f"Qwen3-TTS stream codes must be [Q] or [T, Q], got {tuple(codes.shape)}"
+            )
+
+        metadata: dict[str, Any] = {
+            "modality": "audio_codes",
+            "stream": True,
+            "num_quantizers": int(codes.shape[-1]),
+        }
+        if not data.stream_ref_sent:
+            ref_code = data.ref_code
+            ref_code_len = 0
+            if ref_code is not None and ref_code.numel() > 0:
+                ref_code = ref_code.to(device=codes.device, dtype=torch.long)
+                if ref_code.ndim != 2 or ref_code.shape[-1] != codes.shape[-1]:
+                    raise ValueError(
+                        "Qwen3-TTS reference codes must have shape [T, Q] matching "
+                        f"stream codes, got {tuple(ref_code.shape)} and "
+                        f"{tuple(codes.shape)}"
+                    )
+                ref_code_len = int(ref_code.shape[0])
+                codes = torch.cat((ref_code, codes), dim=0)
+            metadata["ref_code_len"] = ref_code_len
+            if INITIAL_CODEC_CHUNK_FRAMES_PARAM in params:
+                metadata[INITIAL_CODEC_CHUNK_FRAMES_PARAM] = params[
+                    INITIAL_CODEC_CHUNK_FRAMES_PARAM
+                ]
+            data.stream_ref_sent = True
+
+        codes = codes.detach().to(dtype=torch.long)
+
+        return [
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                data=codes,
+                target="vocoder",
+                metadata=metadata,
+            )
+        ]
+
+    return request_builder, result_adapter, stream_output_builder

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -12,18 +12,18 @@ import torch
 from sglang_omni.models.qwen3_tts.compat import (
     apply_qwen_tts_transformers_compatibility_patches,
 )
-from sglang_omni.models.qwen3_tts.payload_types import Qwen3TTSState
 from sglang_omni.models.qwen3_tts.request_builders import (
     cleanup_prepared_qwen3_tts_request,
     preprocess_qwen3_tts_payload,
 )
-from sglang_omni.proto import StagePayload
-from sglang_omni.scheduling.pipeline_state import build_usage
-from sglang_omni.scheduling.pipeline_state import load_state as _load_pipeline_state
-from sglang_omni.scheduling.pipeline_state import store_state as _store_pipeline_state
+from sglang_omni.models.qwen3_tts.streaming_vocoder import (
+    DEFAULT_QWEN3_TTS_INITIAL_CHUNK_FRAMES,
+    DEFAULT_QWEN3_TTS_LEFT_CONTEXT_FRAMES,
+    DEFAULT_QWEN3_TTS_STREAM_FOLLOWUP_STRIDE,
+    DEFAULT_QWEN3_TTS_STREAM_STRIDE,
+    Qwen3TTSStreamingVocoderScheduler,
+)
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
-from sglang_omni.scheduling.vocoder_base import BatchVocoderBase
-from sglang_omni.utils.audio_payload import audio_waveform_payload
 from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoint
 
 logger = logging.getLogger(__name__)
@@ -33,14 +33,6 @@ _QWEN_TTS_INSTALL_HINT = (
     "Install `qwen-tts==0.1.1` and its Transformers 4.57.3 requirement "
     "in the serving environment before launching Qwen3-TTS."
 )
-
-
-def load_state(payload: StagePayload) -> Qwen3TTSState:
-    return _load_pipeline_state(payload, Qwen3TTSState)
-
-
-def store_state(payload: StagePayload, state: Qwen3TTSState) -> StagePayload:
-    return _store_pipeline_state(payload, state)
 
 
 def _load_qwen3_tts_tokenizer(
@@ -156,59 +148,6 @@ def create_sglang_tts_engine_executor(
 create_tts_engine_executor = create_sglang_tts_engine_executor
 
 
-class _Qwen3TTSVocoder(BatchVocoderBase):
-    def __init__(self, tokenizer: Any) -> None:
-        self._tokenizer = tokenizer
-
-    def prepare_item(self, payload: StagePayload) -> tuple[Qwen3TTSState, torch.Tensor]:
-        state = load_state(payload)
-        if state.audio_codes is None:
-            raise RuntimeError("Qwen3-TTS vocoder requires audio_codes from tts_engine")
-
-        codes = torch.as_tensor(state.audio_codes, dtype=torch.long)
-        return state, codes
-
-    async def decode_batch(
-        self, items: list[tuple[Qwen3TTSState, torch.Tensor]]
-    ) -> list[tuple[Any, int]]:
-        wavs, sample_rate = self._tokenizer.decode(
-            [{"audio_codes": codes} for _, codes in items]
-        )
-        if len(wavs) != len(items):
-            raise RuntimeError(
-                f"Qwen3-TTS speech tokenizer returned {len(wavs)} audios for {len(items)} requests"
-            )
-        return [(wav, sample_rate) for wav in wavs]
-
-    def store_result(
-        self,
-        payload: StagePayload,
-        state: Qwen3TTSState,
-        wav: Any,
-        sample_rate: int,
-    ) -> StagePayload:
-        if wav is None:
-            raise RuntimeError("Qwen3-TTS speech tokenizer did not return audio")
-
-        if state.ref_code_len:
-            total_len = len(state.audio_codes)
-            cut = int(state.ref_code_len / max(total_len, 1) * wav.shape[0])
-            wav = wav[cut:]
-        audio_payload = audio_waveform_payload(wav, source_hint="Qwen3-TTS")
-        state.audio_samples = None
-        state.sample_rate = int(sample_rate)
-        state.audio_codes = None
-
-        payload = store_state(payload, state)
-        payload.data.update(audio_payload)
-        payload.data["sample_rate"] = state.sample_rate
-        payload.data["modality"] = "audio"
-        usage = build_usage(state)
-        if usage is not None:
-            payload.data["usage"] = usage
-        return payload
-
-
 def create_vocoder_executor(
     model_path: str,
     *,
@@ -218,6 +157,15 @@ def create_vocoder_executor(
     attn_implementation: str | None = None,
     max_batch_size: int = 8,
     max_batch_wait_ms: int = 2,
+    stream_stride: int = DEFAULT_QWEN3_TTS_STREAM_STRIDE,
+    stream_followup_stride: int = DEFAULT_QWEN3_TTS_STREAM_FOLLOWUP_STRIDE,
+    stream_initial_followup_stride: int | None = None,
+    initial_chunk_frames: int = DEFAULT_QWEN3_TTS_INITIAL_CHUNK_FRAMES,
+    stream_left_context_frames: int = DEFAULT_QWEN3_TTS_LEFT_CONTEXT_FRAMES,
+    initial_max_batch_size: int = 32,
+    initial_batch_wait_ms: int = 2,
+    followup_max_batch_size: int = 8,
+    followup_batch_wait_ms: int = 1,
 ) -> SimpleScheduler:
     if gpu_id is not None:
         device = f"cuda:{gpu_id}"
@@ -228,7 +176,18 @@ def create_vocoder_executor(
         attn_implementation=attn_implementation,
     )
 
-    return _Qwen3TTSVocoder(tokenizer).build_scheduler(
+    return Qwen3TTSStreamingVocoderScheduler(
+        tokenizer,
+        device=device,
+        stream_stride=stream_stride,
+        stream_followup_stride=stream_followup_stride,
+        stream_initial_followup_stride=stream_initial_followup_stride,
+        initial_chunk_frames=initial_chunk_frames,
+        stream_left_context_frames=stream_left_context_frames,
         max_batch_size=max_batch_size,
         max_batch_wait_ms=max_batch_wait_ms,
+        initial_max_batch_size=initial_max_batch_size,
+        initial_batch_wait_ms=initial_batch_wait_ms,
+        followup_max_batch_size=followup_max_batch_size,
+        followup_batch_wait_ms=followup_batch_wait_ms,
     )

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -1,0 +1,895 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Streaming vocoder scheduler for Qwen3-TTS."""
+
+from __future__ import annotations
+
+import queue
+import threading
+import time
+from dataclasses import dataclass, field
+from itertools import count
+from typing import Any, Mapping
+
+import torch
+
+from sglang_omni.models.qwen3_tts.payload_types import Qwen3TTSState
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.messages import OutgoingMessage
+from sglang_omni.scheduling.pipeline_state import build_usage
+from sglang_omni.scheduling.streaming_vocoder import (
+    INITIAL_CODEC_CHUNK_FRAMES_PARAM,
+    StreamingVocoderBase,
+    resolve_initial_codec_chunk_frames,
+)
+from sglang_omni.utils.audio_payload import audio_waveform_payload
+
+DEFAULT_QWEN3_TTS_STREAM_STRIDE = 16
+DEFAULT_QWEN3_TTS_STREAM_FOLLOWUP_STRIDE = 8
+DEFAULT_QWEN3_TTS_STREAM_INITIAL_FOLLOWUP_STRIDE = 8
+DEFAULT_QWEN3_TTS_INITIAL_CHUNK_FRAMES = 1
+DEFAULT_QWEN3_TTS_LEFT_CONTEXT_FRAMES = 16
+_QWEN3_TTS_CODEBOOK_SIZE = 2048
+
+
+@dataclass
+class _Qwen3TTSStreamState:
+    code_chunks: list[torch.Tensor] = field(default_factory=list)
+    total_frames: int = 0
+    ref_frames: int = 0
+    emitted_generated_frames: int = 0
+    next_decode_generated_frames: int = 0
+    decoded_chunks: int = 0
+    num_quantizers: int | None = None
+    pending_ref_frames: int = 0
+    initial_chunk_frames: int = DEFAULT_QWEN3_TTS_INITIAL_CHUNK_FRAMES
+    initial_pending: bool = False
+    followup_pending: bool = False
+    final_pending: bool = False
+    playback_deadline_s: float = 0.0
+
+
+@dataclass(frozen=True)
+class _Qwen3TTSDecodePlan:
+    decoder_input: torch.Tensor
+    absolute_emitted_frames: int
+    generated_frames: int
+    window_start: int
+
+
+_ASYNC_STOP = None
+
+
+class Qwen3TTSStreamingVocoderScheduler(
+    StreamingVocoderBase[_Qwen3TTSStreamState, None]
+):
+    """Decode Qwen3-TTS codec frames on a priority CUDA stream."""
+
+    def __init__(
+        self,
+        tokenizer: Any,
+        *,
+        device: str,
+        stream_stride: int = DEFAULT_QWEN3_TTS_STREAM_STRIDE,
+        stream_followup_stride: int = DEFAULT_QWEN3_TTS_STREAM_FOLLOWUP_STRIDE,
+        stream_initial_followup_stride: int | None = None,
+        initial_chunk_frames: int = DEFAULT_QWEN3_TTS_INITIAL_CHUNK_FRAMES,
+        stream_left_context_frames: int = DEFAULT_QWEN3_TTS_LEFT_CONTEXT_FRAMES,
+        max_batch_size: int = 8,
+        max_batch_wait_ms: int = 2,
+        async_decode: bool | None = None,
+        initial_max_batch_size: int = 32,
+        initial_batch_wait_ms: int = 2,
+        followup_max_batch_size: int = 8,
+        followup_batch_wait_ms: int = 1,
+    ) -> None:
+        if stream_stride <= 0 or stream_followup_stride <= 0:
+            raise ValueError("stream strides must be > 0")
+        if (
+            stream_initial_followup_stride is not None
+            and stream_initial_followup_stride <= 0
+        ):
+            raise ValueError("stream_initial_followup_stride must be > 0")
+        if initial_chunk_frames < 0:
+            raise ValueError("initial_chunk_frames must be >= 0")
+        if stream_left_context_frames < 0:
+            raise ValueError("stream_left_context_frames must be >= 0")
+        if initial_max_batch_size <= 0 or followup_max_batch_size <= 0:
+            raise ValueError("async batch sizes must be > 0")
+        if initial_batch_wait_ms < 0 or followup_batch_wait_ms < 0:
+            raise ValueError("async batch waits must be >= 0")
+        self._tokenizer = tokenizer
+        self._device = torch.device(device)
+        self._decoder = tokenizer.model.decoder
+        self._samples_per_frame = int(self._decoder.total_upsample)
+        self._stream_stride = int(stream_stride)
+        self._stream_followup_stride = int(stream_followup_stride)
+        self._stream_initial_followup_stride = int(
+            min(
+                DEFAULT_QWEN3_TTS_STREAM_INITIAL_FOLLOWUP_STRIDE,
+                self._stream_followup_stride,
+            )
+            if stream_initial_followup_stride is None
+            else stream_initial_followup_stride
+        )
+        self._initial_max_batch_size = int(initial_max_batch_size)
+        self._initial_batch_wait_s = float(initial_batch_wait_ms) / 1000.0
+        self._followup_max_batch_size = int(followup_max_batch_size)
+        self._followup_batch_wait_s = float(followup_batch_wait_ms) / 1000.0
+        self._default_initial_chunk_frames = int(initial_chunk_frames)
+        self._stream_left_context_frames = int(stream_left_context_frames)
+        self._async_decode = (
+            self._device.type == "cuda" if async_decode is None else bool(async_decode)
+        )
+        if self._device.type == "cuda":
+            least_priority, greatest_priority = torch.cuda.Stream.priority_range()
+            followup_priority = min(least_priority, greatest_priority + 1)
+            self._decode_stream = torch.cuda.Stream(
+                device=self._device,
+                priority=greatest_priority,
+            )
+            self._followup_decode_stream = (
+                torch.cuda.Stream(
+                    device=self._device,
+                    priority=followup_priority,
+                )
+                if self._async_decode
+                else None
+            )
+        else:
+            self._decode_stream = None
+            self._followup_decode_stream = None
+        self._initial_queue: queue.Queue[tuple[str, _Qwen3TTSStreamState] | None] = (
+            queue.Queue()
+        )
+        self._followup_queue: queue.PriorityQueue[
+            tuple[float, int, str, _Qwen3TTSStreamState | None]
+        ] = queue.PriorityQueue()
+        self._followup_sequence = count()
+        self._async_stop = threading.Event()
+        self._initial_worker: threading.Thread | None = None
+        self._followup_worker: threading.Thread | None = None
+        sample_rate = int(tokenizer.get_output_sample_rate())
+
+        super().__init__(
+            self._vocode_payload,
+            batch_compute_fn=self._vocode_payloads,
+            sample_rate=sample_rate,
+            stream_source_hint="Qwen3-TTS",
+            max_batch_size=max_batch_size,
+            max_batch_wait_ms=max_batch_wait_ms,
+        )
+
+    def start(self) -> None:
+        try:
+            super().start()
+        finally:
+            self._join_async_workers()
+
+    def stop(self) -> None:
+        self._signal_async_stop()
+        super().stop()
+        self._join_async_workers()
+
+    def on_serving_start(self) -> None:
+        if not self._async_decode:
+            return
+        self._initial_queue = queue.Queue()
+        self._followup_queue = queue.PriorityQueue()
+        self._followup_sequence = count()
+        self._async_stop.clear()
+        self._initial_worker = threading.Thread(
+            target=self._run_initial_worker,
+            name="qwen3-tts-vocoder-initial",
+            daemon=True,
+        )
+        self._followup_worker = threading.Thread(
+            target=self._run_followup_worker,
+            name="qwen3-tts-vocoder-followup",
+            daemon=True,
+        )
+        self._initial_worker.start()
+        self._followup_worker.start()
+
+    def on_serving_stop(self) -> None:
+        self._signal_async_stop()
+
+    def _signal_async_stop(self) -> None:
+        if self._async_stop.is_set():
+            return
+        self._async_stop.set()
+        if self._initial_worker is not None:
+            self._initial_queue.put(_ASYNC_STOP)
+        if self._followup_worker is not None:
+            self._followup_queue.put(
+                (float("inf"), next(self._followup_sequence), "", _ASYNC_STOP)
+            )
+
+    def _join_async_workers(self) -> None:
+        for worker in (self._initial_worker, self._followup_worker):
+            if worker is not None and worker is not threading.current_thread():
+                worker.join()
+        self._initial_worker = None
+        self._followup_worker = None
+
+    def create_stream_state(self, request_id: str) -> _Qwen3TTSStreamState:
+        del request_id
+        return _Qwen3TTSStreamState(
+            initial_chunk_frames=self._default_initial_chunk_frames
+        )
+
+    def latch_stream_contract(
+        self,
+        request_id: str,
+        state: _Qwen3TTSStreamState,
+        source: StagePayload | Mapping[str, Any],
+        *,
+        origin: str,
+    ) -> None:
+        if origin == "payload":
+            params = source.request.params
+            if isinstance(params, Mapping):
+                state.initial_chunk_frames = resolve_initial_codec_chunk_frames(
+                    params,
+                    steady_chunk_frames=self._stream_stride,
+                    default_frames=self._default_initial_chunk_frames,
+                )
+            return
+
+        metadata: Mapping[str, Any] = source
+        if "num_quantizers" not in metadata and state.num_quantizers is None:
+            raise RuntimeError(
+                f"Qwen3-TTS stream chunk for {request_id!r} is missing num_quantizers"
+            )
+        if "num_quantizers" in metadata:
+            num_quantizers = int(metadata["num_quantizers"])
+            if num_quantizers <= 0:
+                raise ValueError("Qwen3-TTS num_quantizers must be > 0")
+            if (
+                state.num_quantizers is not None
+                and state.num_quantizers != num_quantizers
+            ):
+                raise ValueError(
+                    f"Qwen3-TTS num_quantizers changed for {request_id!r}: "
+                    f"{state.num_quantizers} -> {num_quantizers}"
+                )
+            state.num_quantizers = num_quantizers
+        if "ref_code_len" in metadata:
+            ref_frames = int(metadata["ref_code_len"])
+            if ref_frames < 0:
+                raise ValueError("Qwen3-TTS ref_code_len must be >= 0")
+            if state.total_frames or state.ref_frames:
+                raise ValueError(
+                    f"Qwen3-TTS reference codes arrived after stream start for "
+                    f"{request_id!r}"
+                )
+            state.pending_ref_frames = ref_frames
+        if INITIAL_CODEC_CHUNK_FRAMES_PARAM in metadata:
+            state.initial_chunk_frames = resolve_initial_codec_chunk_frames(
+                metadata,
+                steady_chunk_frames=self._stream_stride,
+                default_frames=self._default_initial_chunk_frames,
+            )
+
+    def validate_chunk(
+        self,
+        request_id: str,
+        state: _Qwen3TTSStreamState,
+        codes: torch.Tensor,
+    ) -> torch.Tensor:
+        chunk = codes.detach().to(dtype=torch.long)
+        if chunk.ndim == 1:
+            chunk = chunk.unsqueeze(0)
+        elif chunk.ndim != 2:
+            raise ValueError(
+                f"Qwen3-TTS stream chunk must be [Q] or [T, Q], "
+                f"got {tuple(chunk.shape)}"
+            )
+        if chunk.shape[0] == 0:
+            raise ValueError("Qwen3-TTS stream chunk must not be empty")
+        if state.num_quantizers is None:
+            raise RuntimeError(
+                f"Qwen3-TTS stream contract for {request_id!r} is missing "
+                "num_quantizers"
+            )
+        if int(chunk.shape[1]) != state.num_quantizers:
+            raise ValueError(
+                f"Qwen3-TTS stream chunk has {int(chunk.shape[1])} quantizers, "
+                f"expected {state.num_quantizers}"
+            )
+        if not chunk.is_cuda and (
+            bool((chunk < 0).any()) or bool((chunk >= _QWEN3_TTS_CODEBOOK_SIZE).any())
+        ):
+            raise ValueError(
+                f"Qwen3-TTS stream chunk for {request_id!r} contains codec ids "
+                f"outside [0, {_QWEN3_TTS_CODEBOOK_SIZE})"
+            )
+        return chunk
+
+    def ingest(
+        self,
+        request_id: str,
+        state: _Qwen3TTSStreamState,
+        codes: torch.Tensor,
+    ) -> None:
+        del request_id
+        if state.pending_ref_frames:
+            if state.pending_ref_frames >= int(codes.shape[0]):
+                raise ValueError(
+                    "Qwen3-TTS first stream chunk must include at least one "
+                    "generated codec frame after the reference"
+                )
+            state.ref_frames = state.pending_ref_frames
+            state.pending_ref_frames = 0
+        state.code_chunks.append(codes)
+        state.total_frames += int(codes.shape[0])
+
+    def should_decode(self, state: _Qwen3TTSStreamState, *, is_final: bool) -> bool:
+        if is_final:
+            return True
+        generated_frames = state.total_frames - state.ref_frames
+        next_frames = self._next_decode_threshold(state)
+        return generated_frames >= next_frames
+
+    def _next_decode_threshold(self, state: _Qwen3TTSStreamState) -> int:
+        if state.next_decode_generated_frames:
+            return state.next_decode_generated_frames
+        return state.initial_chunk_frames or self._stream_stride
+
+    def decode_delta(
+        self,
+        request_id: str,
+        state: _Qwen3TTSStreamState,
+        *,
+        is_final: bool,
+    ) -> torch.Tensor | None:
+        del request_id
+        plan = self._build_decode_plan(state, is_final=is_final)
+        if plan is None:
+            return None
+        waveform = self._run_decode_plan(plan, stream=self._decode_stream)
+        return self._commit_decode_plan(state, plan, waveform)
+
+    def _build_decode_plan(
+        self,
+        state: _Qwen3TTSStreamState,
+        *,
+        is_final: bool,
+        max_generated_frames: int | None = None,
+    ) -> _Qwen3TTSDecodePlan | None:
+        available_generated_frames = state.total_frames - state.ref_frames
+        if available_generated_frames <= state.emitted_generated_frames:
+            return None
+        next_frames = self._next_decode_threshold(state)
+        if not is_final and available_generated_frames < next_frames:
+            state.next_decode_generated_frames = next_frames
+            return None
+
+        generated_frames = available_generated_frames
+        if max_generated_frames is not None:
+            generated_frames = min(generated_frames, max_generated_frames)
+
+        absolute_emitted = state.ref_frames + state.emitted_generated_frames
+        window_start = max(0, absolute_emitted - self._stream_left_context_frames)
+        window_end = state.ref_frames + generated_frames
+        codes = torch.cat(state.code_chunks, dim=0)
+        decoder_input = codes[window_start:window_end].transpose(0, 1).unsqueeze(0)
+        return _Qwen3TTSDecodePlan(
+            decoder_input=decoder_input,
+            absolute_emitted_frames=absolute_emitted,
+            generated_frames=generated_frames,
+            window_start=window_start,
+        )
+
+    def _run_decode_plan(
+        self,
+        plan: _Qwen3TTSDecodePlan,
+        *,
+        stream: torch.cuda.Stream | None,
+    ) -> torch.Tensor:
+        return self._run_decode_plans([plan], stream=stream)[0]
+
+    def _run_decode_plans(
+        self,
+        plans: list[_Qwen3TTSDecodePlan],
+        *,
+        stream: torch.cuda.Stream | None,
+    ) -> list[torch.Tensor]:
+        decoder_input = torch.cat([plan.decoder_input for plan in plans], dim=0)
+        with torch.inference_mode():
+            if stream is None:
+                waveform = self._decoder.chunked_decode(decoder_input)
+            else:
+                stream.wait_stream(torch.cuda.current_stream(self._device))
+                with torch.cuda.stream(stream):
+                    waveform = self._decoder.chunked_decode(
+                        decoder_input.to(self._device)
+                    )
+                stream.synchronize()
+        if waveform.ndim == 3:
+            if waveform.shape[0] != len(plans):
+                raise RuntimeError(
+                    "Qwen3-TTS streaming decoder returned the wrong batch size"
+                )
+            return [waveform[index, 0] for index in range(len(plans))]
+        elif waveform.ndim == 2:
+            if len(plans) != 1:
+                raise RuntimeError(
+                    "Qwen3-TTS streaming decoder dropped the batch dimension"
+                )
+            return [waveform[0]]
+        raise ValueError(
+            "Qwen3-TTS decoder returned unexpected waveform shape "
+            f"{tuple(waveform.shape)}"
+        )
+
+    def _commit_decode_plan(
+        self,
+        state: _Qwen3TTSStreamState,
+        plan: _Qwen3TTSDecodePlan,
+        waveform: torch.Tensor,
+    ) -> torch.Tensor:
+        expected_emitted = plan.absolute_emitted_frames - state.ref_frames
+        if state.emitted_generated_frames != expected_emitted:
+            raise RuntimeError("Qwen3-TTS streaming decode plan committed out of order")
+        trim_frames = plan.absolute_emitted_frames - plan.window_start
+        trim_samples = min(
+            trim_frames * self._samples_per_frame,
+            int(waveform.shape[-1]),
+        )
+        new_frames = plan.generated_frames - state.emitted_generated_frames
+        emit_samples = new_frames * self._samples_per_frame
+        delta = waveform[trim_samples : trim_samples + emit_samples]
+        if delta.numel() == 0:
+            raise RuntimeError("Qwen3-TTS streaming decoder returned an empty delta")
+
+        state.emitted_generated_frames = plan.generated_frames
+        state.decoded_chunks += 1
+        followup_stride = (
+            self._stream_initial_followup_stride
+            if state.decoded_chunks == 1
+            else self._stream_followup_stride
+        )
+        state.next_decode_generated_frames = plan.generated_frames + followup_stride
+        delta = delta.detach().to(torch.float32).contiguous()
+        now = time.monotonic()
+        duration_s = float(delta.numel()) / float(self._sample_rate)
+        state.playback_deadline_s = max(state.playback_deadline_s, now) + duration_s
+        return delta
+
+    def _decode_and_emit(
+        self,
+        request_id: str,
+        state: _Qwen3TTSStreamState,
+    ) -> list[OutgoingMessage]:
+        if not self.should_decode(state, is_final=False):
+            return []
+        if self._async_decode:
+            if state.decoded_chunks:
+                self._schedule_followup(request_id, state)
+            else:
+                self._schedule_initial(request_id, state)
+            return []
+        waveform = self.decode_delta(request_id, state, is_final=False)
+        if waveform is None:
+            return []
+
+        self._mark_stream_emitted(request_id)
+        split_samples = state.initial_chunk_frames * self._samples_per_frame
+        if (
+            state.decoded_chunks == 1
+            and split_samples > 0
+            and split_samples < int(waveform.shape[-1])
+        ):
+            return [
+                self._stream_chunk_message(request_id, waveform[:split_samples]),
+                self._stream_chunk_message(request_id, waveform[split_samples:]),
+            ]
+        return [self._stream_chunk_message(request_id, waveform)]
+
+    def _schedule_initial(
+        self,
+        request_id: str,
+        state: _Qwen3TTSStreamState,
+    ) -> None:
+        if state.initial_pending:
+            return
+        if self._initial_worker is None:
+            raise RuntimeError("Qwen3-TTS initial decoder is not running")
+        state.initial_pending = True
+        self._initial_queue.put((request_id, state))
+
+    def _schedule_followup(
+        self,
+        request_id: str,
+        state: _Qwen3TTSStreamState,
+    ) -> None:
+        if state.followup_pending:
+            return
+        if self._followup_worker is None:
+            raise RuntimeError("Qwen3-TTS follow-up decoder is not running")
+        state.followup_pending = True
+        self._enqueue_followup(request_id, state)
+
+    def _enqueue_followup(
+        self,
+        request_id: str,
+        state: _Qwen3TTSStreamState,
+    ) -> None:
+        self._followup_queue.put(
+            (
+                state.playback_deadline_s,
+                next(self._followup_sequence),
+                request_id,
+                state,
+            )
+        )
+
+    def _collect_async_batch(
+        self,
+        work_queue: queue.Queue[tuple[str, _Qwen3TTSStreamState] | None],
+        *,
+        max_batch_size: int,
+        batch_wait_s: float,
+    ) -> list[tuple[str, _Qwen3TTSStreamState]] | None:
+        queued = work_queue.get()
+        if queued is None or self._async_stop.is_set():
+            return None
+        batch = [queued]
+        deadline = time.monotonic() + batch_wait_s
+        while len(batch) < max_batch_size:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                next_queued = work_queue.get(timeout=remaining)
+            except queue.Empty:
+                break
+            if next_queued is None:
+                return None
+            batch.append(next_queued)
+        return batch
+
+    def _run_initial_worker(self) -> None:
+        while True:
+            batch = self._collect_async_batch(
+                self._initial_queue,
+                max_batch_size=self._initial_max_batch_size,
+                batch_wait_s=self._initial_batch_wait_s,
+            )
+            if batch is None:
+                return
+            self._run_initial_batch(batch)
+
+    def _run_initial_batch(
+        self,
+        batch: list[tuple[str, _Qwen3TTSStreamState]],
+    ) -> None:
+        planned: list[tuple[str, _Qwen3TTSStreamState, _Qwen3TTSDecodePlan]] = []
+        with self._state_lock:
+            for request_id, state in batch:
+                if (
+                    self._stream_states.get(request_id) is not state
+                    or state.decoded_chunks
+                ):
+                    continue
+                plan = self._build_decode_plan(
+                    state,
+                    is_final=state.final_pending,
+                    max_generated_frames=(
+                        state.initial_chunk_frames or self._stream_stride
+                    ),
+                )
+                if plan is None:
+                    state.initial_pending = False
+                    continue
+                planned.append((request_id, state, plan))
+
+        for group in self._group_decode_plans(planned):
+            try:
+                waveforms = self._run_decode_plans(
+                    [entry[2] for entry in group],
+                    stream=self._decode_stream,
+                )
+            except Exception as exc:
+                for request_id, state, _ in group:
+                    self._fail_async_stream(request_id, state, exc)
+                continue
+            for entry, waveform in zip(group, waveforms):
+                request_id, state, plan = entry
+                self._commit_initial(request_id, state, plan, waveform)
+
+    @staticmethod
+    def _group_decode_plans(
+        planned: list[tuple[str, _Qwen3TTSStreamState, _Qwen3TTSDecodePlan]],
+    ) -> list[list[tuple[str, _Qwen3TTSStreamState, _Qwen3TTSDecodePlan]]]:
+        groups: dict[
+            tuple[int, ...],
+            list[tuple[str, _Qwen3TTSStreamState, _Qwen3TTSDecodePlan]],
+        ] = {}
+        for entry in planned:
+            groups.setdefault(tuple(entry[2].decoder_input.shape), []).append(entry)
+        return list(groups.values())
+
+    def _commit_initial(
+        self,
+        request_id: str,
+        state: _Qwen3TTSStreamState,
+        plan: _Qwen3TTSDecodePlan,
+        waveform: torch.Tensor,
+    ) -> None:
+        cleanup_abort = False
+        with self._state_lock:
+            if self._stream_states.get(request_id) is not state:
+                return
+            try:
+                delta = self._commit_decode_plan(state, plan, waveform)
+            except Exception as exc:
+                self._emit_error(request_id, exc)
+                self._abort_state(request_id)
+                cleanup_abort = True
+            else:
+                state.initial_pending = False
+                if not self._is_aborted(request_id):
+                    self._mark_stream_emitted(request_id)
+                    self.outbox.put(self._stream_chunk_message(request_id, delta))
+                has_remainder = (
+                    state.total_frames - state.ref_frames
+                    > state.emitted_generated_frames
+                )
+                if state.final_pending and not has_remainder:
+                    self._finish_async_stream(request_id, state)
+                elif state.final_pending or self.should_decode(state, is_final=False):
+                    self._schedule_followup(request_id, state)
+        if cleanup_abort:
+            self._cleanup_aborted_request(request_id)
+
+    def _run_followup_worker(self) -> None:
+        while True:
+            batch = self._collect_followup_batch()
+            if batch is None:
+                return
+            self._run_followup_batch(batch)
+
+    def _collect_followup_batch(
+        self,
+    ) -> list[tuple[str, _Qwen3TTSStreamState]] | None:
+        _, _, request_id, state = self._followup_queue.get()
+        if state is None or self._async_stop.is_set():
+            return None
+        batch = [(request_id, state)]
+        deadline = time.monotonic() + self._followup_batch_wait_s
+        while len(batch) < self._followup_max_batch_size:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                _, _, request_id, state = self._followup_queue.get(timeout=remaining)
+            except queue.Empty:
+                break
+            if state is None:
+                return None
+            batch.append((request_id, state))
+        return batch
+
+    def _run_followup_batch(
+        self,
+        batch: list[tuple[str, _Qwen3TTSStreamState]],
+    ) -> None:
+        planned: list[tuple[str, _Qwen3TTSStreamState, _Qwen3TTSDecodePlan]] = []
+        with self._state_lock:
+            for request_id, state in batch:
+                if self._stream_states.get(request_id) is not state:
+                    continue
+                plan = self._build_decode_plan(
+                    state,
+                    is_final=state.final_pending,
+                    max_generated_frames=self._next_decode_threshold(state),
+                )
+                if plan is None:
+                    state.followup_pending = False
+                    if state.final_pending:
+                        self._finish_async_stream(request_id, state)
+                    continue
+                planned.append((request_id, state, plan))
+
+        for group in self._group_decode_plans(planned):
+            try:
+                waveforms = self._run_decode_plans(
+                    [entry[2] for entry in group],
+                    stream=self._followup_decode_stream,
+                )
+            except Exception as exc:
+                for request_id, state, _ in group:
+                    self._fail_async_stream(request_id, state, exc)
+                continue
+            for entry, waveform in zip(group, waveforms):
+                request_id, state, plan = entry
+                self._commit_followup(request_id, state, plan, waveform)
+
+    def _commit_followup(
+        self,
+        request_id: str,
+        state: _Qwen3TTSStreamState,
+        plan: _Qwen3TTSDecodePlan,
+        waveform: torch.Tensor,
+    ) -> None:
+        cleanup_abort = False
+        with self._state_lock:
+            if self._stream_states.get(request_id) is not state:
+                return
+            try:
+                delta = self._commit_decode_plan(state, plan, waveform)
+            except Exception as exc:
+                self._emit_error(request_id, exc)
+                self._abort_state(request_id)
+                cleanup_abort = True
+            else:
+                if not self._is_aborted(request_id):
+                    self._mark_stream_emitted(request_id)
+                    self.outbox.put(self._stream_chunk_message(request_id, delta))
+                has_remainder = (
+                    state.total_frames - state.ref_frames
+                    > state.emitted_generated_frames
+                )
+                if state.final_pending and not has_remainder:
+                    state.followup_pending = False
+                    self._finish_async_stream(request_id, state)
+                elif state.final_pending or self.should_decode(state, is_final=False):
+                    self._enqueue_followup(request_id, state)
+                else:
+                    state.followup_pending = False
+        if cleanup_abort:
+            self._cleanup_aborted_request(request_id)
+
+    def _fail_async_stream(
+        self,
+        request_id: str,
+        state: _Qwen3TTSStreamState,
+        exc: BaseException,
+    ) -> None:
+        cleanup_abort = False
+        with self._state_lock:
+            if self._stream_states.get(request_id) is state:
+                self._emit_error(request_id, exc)
+                self._abort_state(request_id)
+                cleanup_abort = True
+        if cleanup_abort:
+            self._cleanup_aborted_request(request_id)
+
+    def _handle_stream_done(self, request_id: str) -> None:
+        with self._state_lock:
+            if request_id not in self._stream_payloads:
+                if request_id in self._completed_non_streaming_request_ids:
+                    return
+                self._pending_done.add(request_id)
+                return
+            state = self._get_or_create_stream_state(request_id)
+            if (
+                self._async_decode
+                and state is not None
+                and (state.initial_pending or state.decoded_chunks)
+            ):
+                state.final_pending = True
+                if not state.initial_pending:
+                    self._schedule_followup(request_id, state)
+                return
+        super()._handle_stream_done(request_id)
+
+    def _finish_async_stream(
+        self,
+        request_id: str,
+        state: _Qwen3TTSStreamState,
+    ) -> None:
+        payload = self._stream_payloads.get(request_id)
+        if payload is None or self._is_aborted(request_id):
+            return
+        self.outbox.put(
+            OutgoingMessage(
+                request_id=request_id,
+                type="result",
+                data=StagePayload(
+                    request_id=payload.request_id,
+                    request=payload.request,
+                    data=self.final_result_data(request_id, payload, state),
+                ),
+            )
+        )
+        self._record_completed_stream_request_id(request_id)
+        self._clear_request_state(request_id)
+
+    def fallback_full_decode(
+        self,
+        request_id: str,
+        payload: StagePayload,
+        state: _Qwen3TTSStreamState,
+    ) -> torch.Tensor | None:
+        del request_id, state
+        return self._decode_state_audio(Qwen3TTSState.from_dict(payload.data))
+
+    def final_result_data(
+        self,
+        request_id: str,
+        payload: StagePayload,
+        state: _Qwen3TTSStreamState,
+    ) -> dict[str, Any]:
+        del request_id, state
+        final_state = Qwen3TTSState.from_dict(payload.data)
+        data: dict[str, Any] = {
+            "modality": "audio",
+            "sample_rate": self._sample_rate,
+        }
+        usage = build_usage(final_state)
+        if usage is not None:
+            data["usage"] = usage
+        return data
+
+    async def _vocode_payload(self, payload: StagePayload) -> StagePayload:
+        return (await self._vocode_payloads([payload]))[0]
+
+    async def _vocode_payloads(
+        self, payloads: list[StagePayload]
+    ) -> list[StagePayload]:
+        states = [Qwen3TTSState.from_dict(payload.data) for payload in payloads]
+        codes = []
+        for state in states:
+            if state.audio_codes is None:
+                raise RuntimeError(
+                    "Qwen3-TTS vocoder requires audio_codes from tts_engine"
+                )
+            codes.append(torch.as_tensor(state.audio_codes, dtype=torch.long))
+
+        wavs, sample_rate = self._tokenizer.decode(
+            [{"audio_codes": item} for item in codes]
+        )
+        if len(wavs) != len(payloads):
+            raise RuntimeError(
+                f"Qwen3-TTS speech tokenizer returned {len(wavs)} audios for "
+                f"{len(payloads)} requests"
+            )
+        return [
+            self._store_vocoder_result(payload, state, wav, sample_rate)
+            for payload, state, wav in zip(payloads, states, wavs)
+        ]
+
+    def _store_vocoder_result(
+        self,
+        payload: StagePayload,
+        state: Qwen3TTSState,
+        waveform: Any,
+        sample_rate: int,
+    ) -> StagePayload:
+        if waveform is None:
+            raise RuntimeError("Qwen3-TTS speech tokenizer did not return audio")
+        if state.ref_code_len:
+            total_frames = len(state.audio_codes)
+            cut = int(state.ref_code_len / max(total_frames, 1) * waveform.shape[0])
+            waveform = waveform[cut:]
+
+        data = audio_waveform_payload(
+            waveform,
+            sample_rate=int(sample_rate),
+            modality="audio",
+            source_hint="Qwen3-TTS",
+        )
+        usage = build_usage(state)
+        if usage is not None:
+            data["usage"] = usage
+        payload.data = data
+        return payload
+
+    def _decode_state_audio(self, state: Qwen3TTSState) -> torch.Tensor | None:
+        if state.audio_codes is None:
+            return None
+        codes = torch.as_tensor(state.audio_codes, dtype=torch.long)
+        wavs, _ = self._tokenizer.decode([{"audio_codes": codes}])
+        if not wavs:
+            return None
+        waveform = torch.as_tensor(wavs[0], dtype=torch.float32)
+        if state.ref_code_len:
+            total_frames = len(codes)
+            cut = int(state.ref_code_len / max(total_frames, 1) * waveform.shape[0])
+            waveform = waveform[cut:]
+        return waveform.contiguous()
+
+
+__all__ = ["Qwen3TTSStreamingVocoderScheduler"]

--- a/tests/README.md
+++ b/tests/README.md
@@ -475,6 +475,8 @@ that happened to contain an older version of the test.
   - pipeline config and registry contracts
   - OmniScheduler-backed AR stage factory wiring
   - request mapping for `ref_audio` / `ref_text` and `references`
+  - incremental codec-to-vocoder ordering, priority batching, fallback parity,
+    CUDA stream handoff, and abort/failure cleanup
   - model-owned default preservation for language and sampling parameters
   - Base, CustomVoice, and VoiceDesign request validation
   - voice-clone reference validation

--- a/tests/unit_test/models/test_model_capabilities.py
+++ b/tests/unit_test/models/test_model_capabilities.py
@@ -26,7 +26,7 @@ EXPECTED_TTS_CAPABILITIES = {
     "Qwen3TTSForConditionalGeneration": ModelCapabilities(
         supports_reference_audio=True,
         supports_batch_vocoder=True,
-        supports_streaming_vocoder=False,
+        supports_streaming_vocoder=True,
         supports_cuda_graph=True,
         supports_torch_compile=True,
     ),
@@ -194,7 +194,7 @@ def test_launcher_model_capabilities_log_summary() -> None:
         "architecture": "Qwen3TTSForConditionalGeneration",
         "reference_audio": True,
         "batch_vocoder": True,
-        "streaming_vocoder": False,
+        "streaming_vocoder": True,
         "cuda_graph": True,
         "torch_compile": True,
     }

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -7,7 +7,7 @@ import sys
 import threading
 import types
 from collections import deque
-from queue import Queue
+from queue import Empty, Queue
 from types import SimpleNamespace
 
 import numpy as np
@@ -27,7 +27,11 @@ from sglang_omni.models.qwen3_tts.request_builders import (
     build_sglang_qwen3_tts_request,
     derive_qwen3_tts_sampling_seeds,
 )
+from sglang_omni.models.qwen3_tts.streaming_vocoder import (
+    Qwen3TTSStreamingVocoderScheduler,
+)
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.sampling import seed as sampling_seed
 from sglang_omni.scheduling.messages import IncomingMessage
@@ -229,6 +233,8 @@ def test_qwen3_tts_config_and_registry_contracts() -> None:
     assert "device" not in config.stages[1].factory_args
     assert "device" not in config.stages[2].factory_args
     assert {stage.process for stage in config.stages} == {"pipeline"}
+    assert config.stages[1].stream_to == ["vocoder"]
+    assert config.stages[2].can_accept_stream_before_payload is True
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("Qwen3TTSForConditionalGeneration")
         is Qwen3TTSPipelineConfig
@@ -282,6 +288,7 @@ def test_qwen3_tts_maps_references_and_keeps_upstream_sampling_defaults() -> Non
     assert state.ref_audio == "voice.wav"
     assert state.ref_text == "reference"
     assert state.x_vector_only_mode is False
+    assert state.non_streaming_mode is False
     assert state.generation_kwargs == {"max_new_tokens": 2048}
 
 
@@ -960,6 +967,13 @@ def test_qwen3_tts_vocoder_batches_decode_requests(
     decode_batch_sizes: list[int] = []
 
     class FakeTokenizer:
+        model = SimpleNamespace(
+            decoder=SimpleNamespace(total_upsample=4),
+        )
+
+        def get_output_sample_rate(self):
+            return 24000
+
         def decode(self, encoded):
             decode_batch_sizes.append(len(encoded))
             return [
@@ -975,9 +989,18 @@ def test_qwen3_tts_vocoder_batches_decode_requests(
 
     scheduler = stages.create_vocoder_executor(
         "model",
+        device="cpu",
         max_batch_size=2,
         max_batch_wait_ms=3,
     )
+    assert scheduler.create_stream_state("request").initial_chunk_frames == 1
+    assert scheduler._stream_left_context_frames == 16
+    assert scheduler._stream_followup_stride == 8
+    assert scheduler._stream_initial_followup_stride == 8
+    assert scheduler._initial_max_batch_size == 32
+    assert scheduler._initial_batch_wait_s == pytest.approx(0.002)
+    assert scheduler._followup_max_batch_size == 8
+    assert scheduler._followup_batch_wait_s == pytest.approx(0.001)
     first = make_payload(inputs="first")
     first.data = Qwen3TTSState(
         audio_codes=torch.tensor([[1, 2], [3, 4]]),
@@ -1001,6 +1024,851 @@ def test_qwen3_tts_vocoder_batches_decode_requests(
     assert "audio_codes" not in results[0].data
     second_audio = np.frombuffer(results[1].data["audio_waveform"], dtype=np.float32)
     assert second_audio.tolist() == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+
+
+class _FakeQwen3TTSDecoder:
+    total_upsample = 4
+
+    def __init__(self) -> None:
+        self.decode_inputs: list[torch.Tensor] = []
+
+    def chunked_decode(self, codes: torch.Tensor) -> torch.Tensor:
+        self.decode_inputs.append(codes.detach().clone())
+        return (
+            codes[:, :1]
+            .to(torch.float32)
+            .repeat_interleave(self.total_upsample, dim=-1)
+        )
+
+
+class _FakeQwen3TTSTokenizer:
+    def __init__(self) -> None:
+        self.model = SimpleNamespace(decoder=_FakeQwen3TTSDecoder())
+
+    def get_output_sample_rate(self) -> int:
+        return 24000
+
+    def decode(self, encoded):
+        waveforms = [
+            item["audio_codes"][:, 0]
+            .to(torch.float32)
+            .repeat_interleave(self.model.decoder.total_upsample)
+            .numpy()
+            for item in encoded
+        ]
+        return waveforms, self.get_output_sample_rate()
+
+
+def test_qwen3_tts_streaming_vocoder_buffers_one_initial_frame() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+    )
+
+    assert scheduler.create_stream_state("request").initial_chunk_frames == 1
+
+
+def _qwen3_tts_stream_item(
+    codes: torch.Tensor,
+    *,
+    chunk_id: int,
+    ref_code_len: int | None = None,
+) -> StreamItem:
+    metadata = {
+        "modality": "audio_codes",
+        "stream": True,
+        "num_quantizers": int(codes.shape[-1]),
+    }
+    if ref_code_len is not None:
+        metadata["ref_code_len"] = ref_code_len
+    return StreamItem(
+        chunk_id=chunk_id,
+        data=codes,
+        from_stage="tts_engine",
+        metadata=metadata,
+    )
+
+
+def test_qwen3_tts_initial_chunk_override_is_message_order_independent() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        stream_stride=16,
+    )
+    payload = make_payload(
+        inputs="target",
+        params={"stream": True, "initial_codec_chunk_frames": 32},
+    )
+    payload.request_id = "payload-first"
+    scheduler._on_streaming_new_request(payload.request_id, payload)
+
+    chunk = _qwen3_tts_stream_item(
+        torch.ones((1, 2), dtype=torch.long),
+        chunk_id=0,
+        ref_code_len=0,
+    )
+    assert chunk.metadata is not None
+    chunk.metadata["initial_codec_chunk_frames"] = 32
+    scheduler._on_chunk("chunk-first", chunk)
+
+    assert scheduler._stream_states["payload-first"].initial_chunk_frames == 16
+    assert scheduler._stream_states["chunk-first"].initial_chunk_frames == 16
+
+
+def test_qwen3_tts_streaming_vocoder_keeps_codec_chunks_on_source_device() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+    )
+    state = scheduler.create_stream_state("request")
+    state.num_quantizers = 2
+    transfers: list[dict[str, object]] = []
+
+    class DeviceTrackingCodes:
+        def detach(self):
+            return self
+
+        def to(self, **kwargs):
+            transfers.append(kwargs)
+            return torch.ones((1, 2), dtype=torch.long)
+
+    scheduler.validate_chunk("request", state, DeviceTrackingCodes())
+
+    assert transfers == [{"dtype": torch.long}]
+
+
+def test_qwen3_tts_streaming_vocoder_avoids_cuda_value_sync() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+    )
+    state = scheduler.create_stream_state("request")
+    state.num_quantizers = 2
+
+    class CudaChunk:
+        ndim = 2
+        shape = (1, 2)
+        is_cuda = True
+
+        def __lt__(self, other):
+            raise AssertionError("CUDA codec validation must not reduce on the host")
+
+        def __ge__(self, other):
+            raise AssertionError("CUDA codec validation must not reduce on the host")
+
+    chunk = CudaChunk()
+
+    class Codes:
+        def detach(self):
+            return self
+
+        def to(self, **kwargs):
+            return chunk
+
+    assert scheduler.validate_chunk("request", state, Codes()) is chunk
+
+
+def test_qwen3_tts_decode_stream_waits_for_codec_staging(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+    )
+    state = scheduler.create_stream_state("request")
+    state.code_chunks.append(torch.ones((1, 2), dtype=torch.long))
+    state.total_frames = 1
+    plan = scheduler._build_decode_plan(state, is_final=True)
+    assert plan is not None
+
+    producer_stream = object()
+    events: list[object] = []
+
+    class DecodeStream:
+        def wait_stream(self, stream):
+            events.append(("wait", stream))
+
+        def synchronize(self):
+            events.append("synchronize")
+
+    decode_stream = DecodeStream()
+
+    class StreamContext:
+        def __enter__(self):
+            events.append("enter")
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    monkeypatch.setattr(
+        torch.cuda,
+        "current_stream",
+        lambda device: producer_stream,
+    )
+    monkeypatch.setattr(
+        torch.cuda,
+        "stream",
+        lambda stream: StreamContext(),
+    )
+
+    scheduler._run_decode_plans([plan], stream=decode_stream)
+
+    assert events[0] == ("wait", producer_stream)
+
+
+def test_qwen3_tts_streaming_vocoder_decodes_initial_chunk_early() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        stream_followup_stride=2,
+    )
+    payload = make_payload(inputs="target", params={"stream": True})
+    scheduler._on_streaming_new_request(payload.request_id, payload)
+
+    scheduler._on_chunk(
+        payload.request_id,
+        _qwen3_tts_stream_item(
+            torch.ones((1, 2), dtype=torch.long),
+            chunk_id=0,
+            ref_code_len=0,
+        ),
+    )
+    assert scheduler.outbox.qsize() == 1
+
+    first = scheduler.outbox.get_nowait()
+    assert len(first.data["audio_waveform"]) == 1 * 4 * 4
+
+    scheduler._on_chunk(
+        payload.request_id,
+        _qwen3_tts_stream_item(torch.ones((1, 2), dtype=torch.long), chunk_id=1),
+    )
+    assert scheduler.outbox.qsize() == 0
+    scheduler._on_chunk(
+        payload.request_id,
+        _qwen3_tts_stream_item(torch.ones((1, 2), dtype=torch.long), chunk_id=2),
+    )
+    assert scheduler.outbox.qsize() == 1
+    assert len(scheduler._decoder.decode_inputs) == 2
+
+
+def test_qwen3_tts_streaming_vocoder_uses_steady_followup_stride() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+    )
+    payload = make_payload(inputs="target", params={"stream": True})
+    scheduler._on_streaming_new_request(payload.request_id, payload)
+
+    scheduler._on_chunk(
+        payload.request_id,
+        _qwen3_tts_stream_item(
+            torch.ones((1, 2), dtype=torch.long),
+            chunk_id=0,
+            ref_code_len=0,
+        ),
+    )
+    state = scheduler._stream_states[payload.request_id]
+    assert state.next_decode_generated_frames == 9
+
+    scheduler._on_chunk(
+        payload.request_id,
+        _qwen3_tts_stream_item(torch.ones((8, 2), dtype=torch.long), chunk_id=1),
+    )
+    assert state.next_decode_generated_frames == 17
+    assert len(scheduler._decoder.decode_inputs) == 2
+
+
+def test_qwen3_tts_streaming_vocoder_zero_initial_chunk_uses_steady_stride() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+    )
+    payload = make_payload(
+        inputs="target",
+        params={"stream": True, "initial_codec_chunk_frames": 0},
+    )
+    scheduler._on_streaming_new_request(payload.request_id, payload)
+
+    scheduler._on_chunk(
+        payload.request_id,
+        _qwen3_tts_stream_item(
+            torch.ones((15, 2), dtype=torch.long),
+            chunk_id=0,
+            ref_code_len=0,
+        ),
+    )
+    assert scheduler.outbox.qsize() == 0
+    scheduler._on_chunk(
+        payload.request_id,
+        _qwen3_tts_stream_item(torch.ones((1, 2), dtype=torch.long), chunk_id=1),
+    )
+    assert scheduler.outbox.qsize() == 1
+
+
+def test_qwen3_tts_stream_output_prepends_reference_once() -> None:
+    from sglang_omni.models.qwen3_tts.request_builders import (
+        make_qwen3_tts_scheduler_adapters,
+    )
+
+    payload = make_payload(inputs="target", params={"stream": True})
+    _, _, stream_output_builder = make_qwen3_tts_scheduler_adapters(
+        model=None,
+        wrapper=None,
+    )
+    data = Qwen3TTSSGLangRequestData(
+        ref_code=torch.tensor([[10, 11], [12, 13]]),
+        latest_stream_code_chunk=torch.tensor([1, 2]),
+        stream_codec_output=True,
+        stage_payload=payload,
+    )
+
+    first = stream_output_builder(payload.request_id, data, None)
+    assert len(first) == 1
+    assert first[0].data.tolist() == [[10, 11], [12, 13], [1, 2]]
+    assert first[0].data.device.type == "cpu"
+    assert first[0].metadata["ref_code_len"] == 2
+    assert first[0].metadata["num_quantizers"] == 2
+
+    data.latest_stream_code_chunk = torch.tensor([3, 4])
+    second = stream_output_builder(payload.request_id, data, None)
+    assert second[0].data.tolist() == [[3, 4]]
+    assert "ref_code_len" not in second[0].metadata
+
+
+def test_qwen3_tts_stream_output_skips_non_streaming_generation_modes() -> None:
+    from sglang_omni.models.qwen3_tts.request_builders import (
+        make_qwen3_tts_scheduler_adapters,
+    )
+
+    payload = make_payload(inputs="target", params={"stream": True})
+    _, _, stream_output_builder = make_qwen3_tts_scheduler_adapters(
+        model=None,
+        wrapper=None,
+    )
+    data = Qwen3TTSSGLangRequestData(
+        latest_stream_code_chunk=torch.tensor([1, 2]),
+        stage_payload=payload,
+    )
+    data.stream_codec_output = False
+
+    assert stream_output_builder(payload.request_id, data, None) == []
+
+
+def test_qwen3_tts_streaming_vocoder_matches_full_decode() -> None:
+    tokenizer = _FakeQwen3TTSTokenizer()
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        tokenizer,
+        device="cpu",
+        stream_stride=1,
+        stream_followup_stride=2,
+        initial_chunk_frames=1,
+        stream_left_context_frames=2,
+    )
+    all_codes = torch.tensor(
+        [[10, 11], [12, 13], [1, 2], [3, 4], [5, 6]],
+        dtype=torch.long,
+    )
+    payload = make_payload(inputs="target", params={"stream": True})
+    payload.data = Qwen3TTSState(
+        audio_codes=all_codes,
+        ref_code_len=2,
+        prompt_tokens=2,
+        completion_tokens=3,
+    ).to_dict()
+
+    scheduler._on_streaming_new_request(payload.request_id, payload)
+    scheduler._on_chunk(
+        payload.request_id,
+        _qwen3_tts_stream_item(
+            all_codes[:3],
+            chunk_id=0,
+            ref_code_len=2,
+        ),
+    )
+    first_messages = []
+    while not scheduler.outbox.empty():
+        first_messages.append(scheduler.outbox.get_nowait())
+    assert len(first_messages) == 1
+    first_audio = np.frombuffer(
+        first_messages[0].data["audio_waveform"],
+        dtype=np.float32,
+    )
+    assert first_audio.size == 4
+
+    scheduler._on_chunk(
+        payload.request_id,
+        _qwen3_tts_stream_item(all_codes[3:], chunk_id=1),
+    )
+    scheduler._on_done(payload.request_id)
+    messages = first_messages
+    while not scheduler.outbox.empty():
+        messages.append(scheduler.outbox.get_nowait())
+
+    stream_audio = np.concatenate(
+        [
+            np.frombuffer(message.data["audio_waveform"], dtype=np.float32)
+            for message in messages
+            if message.type == "stream"
+        ]
+    )
+    expected = all_codes[2:, 0].to(torch.float32).repeat_interleave(4).numpy()
+    np.testing.assert_array_equal(stream_audio, expected)
+    result = next(message for message in messages if message.type == "result")
+    assert result.data.data == {
+        "modality": "audio",
+        "sample_rate": 24000,
+        "usage": {
+            "prompt_tokens": 2,
+            "completion_tokens": 3,
+            "total_tokens": 5,
+        },
+    }
+    assert payload.request_id not in scheduler._stream_states
+
+
+def test_qwen3_tts_streaming_fallback_matches_full_decode_reference_trim() -> None:
+    class UnevenTokenizer(_FakeQwen3TTSTokenizer):
+        def decode(self, encoded):
+            return [np.arange(11, dtype=np.float32)], self.get_output_sample_rate()
+
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        UnevenTokenizer(),
+        device="cpu",
+    )
+    state = Qwen3TTSState(
+        audio_codes=torch.ones((5, 2), dtype=torch.long),
+        ref_code_len=2,
+    )
+
+    waveform = scheduler._decode_state_audio(state)
+
+    assert waveform is not None
+    np.testing.assert_array_equal(waveform.numpy(), np.arange(4, 11))
+
+
+def test_qwen3_tts_async_followup_flushes_before_result() -> None:
+    tokenizer = _FakeQwen3TTSTokenizer()
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        tokenizer,
+        device="cpu",
+        stream_stride=1,
+        stream_followup_stride=2,
+        initial_chunk_frames=1,
+        stream_left_context_frames=2,
+        async_decode=True,
+    )
+    all_codes = torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=torch.long)
+    payload = make_payload(inputs="target", params={"stream": True})
+    payload.data = Qwen3TTSState(
+        audio_codes=all_codes,
+        completion_tokens=3,
+    ).to_dict()
+
+    scheduler.on_serving_start()
+    try:
+        scheduler._on_streaming_new_request(payload.request_id, payload)
+        scheduler._on_chunk(
+            payload.request_id,
+            _qwen3_tts_stream_item(
+                all_codes[:1],
+                chunk_id=0,
+                ref_code_len=0,
+            ),
+        )
+        first = scheduler.outbox.get(timeout=1)
+        scheduler._on_chunk(
+            payload.request_id,
+            _qwen3_tts_stream_item(all_codes[1:], chunk_id=1),
+        )
+        scheduler._on_done(payload.request_id)
+
+        followup = scheduler.outbox.get(timeout=1)
+        result = scheduler.outbox.get(timeout=1)
+    finally:
+        scheduler.stop()
+
+    assert first.type == "stream"
+    assert followup.type == "stream"
+    assert result.type == "result"
+    streamed = np.concatenate(
+        [
+            np.frombuffer(message.data["audio_waveform"], dtype=np.float32)
+            for message in (first, followup)
+        ]
+    )
+    expected = all_codes[:, 0].to(torch.float32).repeat_interleave(4).numpy()
+    np.testing.assert_array_equal(streamed, expected)
+    assert payload.request_id not in scheduler._stream_states
+
+
+def test_qwen3_tts_async_initial_batches_ready_requests() -> None:
+    tokenizer = _FakeQwen3TTSTokenizer()
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        tokenizer,
+        device="cpu",
+        stream_stride=1,
+        initial_chunk_frames=1,
+        async_decode=True,
+        initial_batch_wait_ms=20,
+    )
+    payloads = [
+        make_payload(inputs="first", params={"stream": True}),
+        make_payload(inputs="second", params={"stream": True}),
+    ]
+    payloads[0].request_id = "req-first"
+    payloads[1].request_id = "req-second"
+
+    scheduler.on_serving_start()
+    try:
+        for payload in payloads:
+            scheduler._on_streaming_new_request(payload.request_id, payload)
+            scheduler._on_chunk(
+                payload.request_id,
+                _qwen3_tts_stream_item(
+                    torch.ones((1, 2), dtype=torch.long),
+                    chunk_id=0,
+                    ref_code_len=0,
+                ),
+            )
+
+        assert scheduler.outbox.get(timeout=1).type == "stream"
+        assert scheduler.outbox.get(timeout=1).type == "stream"
+    finally:
+        for payload in payloads:
+            scheduler.abort(payload.request_id)
+        scheduler.stop()
+
+    assert [int(codes.shape[0]) for codes in tokenizer.model.decoder.decode_inputs] == [
+        2
+    ]
+
+
+def test_qwen3_tts_async_initial_flushes_before_result() -> None:
+    tokenizer = _FakeQwen3TTSTokenizer()
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        tokenizer,
+        device="cpu",
+        stream_stride=1,
+        initial_chunk_frames=1,
+        async_decode=True,
+    )
+    payload = make_payload(inputs="target", params={"stream": True})
+    payload.data = Qwen3TTSState(
+        audio_codes=torch.ones((1, 2), dtype=torch.long),
+        completion_tokens=1,
+    ).to_dict()
+
+    scheduler.on_serving_start()
+    try:
+        scheduler._on_streaming_new_request(payload.request_id, payload)
+        scheduler._on_chunk(
+            payload.request_id,
+            _qwen3_tts_stream_item(
+                torch.ones((1, 2), dtype=torch.long),
+                chunk_id=0,
+                ref_code_len=0,
+            ),
+        )
+        scheduler._on_done(payload.request_id)
+        stream = scheduler.outbox.get(timeout=1)
+        result = scheduler.outbox.get(timeout=1)
+    finally:
+        scheduler.stop()
+
+    assert stream.type == "stream"
+    assert result.type == "result"
+    assert payload.request_id not in scheduler._stream_states
+
+
+def test_qwen3_tts_async_followup_round_robins_backlog() -> None:
+    tokenizer = _FakeQwen3TTSTokenizer()
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        tokenizer,
+        device="cpu",
+        stream_stride=1,
+        stream_followup_stride=2,
+        initial_chunk_frames=1,
+        stream_left_context_frames=2,
+        async_decode=True,
+    )
+    all_codes = torch.arange(1, 15, dtype=torch.long).reshape(7, 2)
+    payload = make_payload(inputs="target", params={"stream": True})
+    payload.data = Qwen3TTSState(
+        audio_codes=all_codes,
+        completion_tokens=7,
+    ).to_dict()
+
+    scheduler.on_serving_start()
+    try:
+        scheduler._on_streaming_new_request(payload.request_id, payload)
+        scheduler._on_chunk(
+            payload.request_id,
+            _qwen3_tts_stream_item(
+                all_codes[:1],
+                chunk_id=0,
+                ref_code_len=0,
+            ),
+        )
+        messages = [scheduler.outbox.get(timeout=1)]
+        scheduler._on_chunk(
+            payload.request_id,
+            _qwen3_tts_stream_item(all_codes[1:], chunk_id=1),
+        )
+        scheduler._on_done(payload.request_id)
+        messages.extend(scheduler.outbox.get(timeout=1) for _ in range(4))
+    finally:
+        scheduler.stop()
+
+    assert [message.type for message in messages] == [
+        "stream",
+        "stream",
+        "stream",
+        "stream",
+        "result",
+    ]
+    assert [
+        int(codes.shape[-1]) for codes in tokenizer.model.decoder.decode_inputs
+    ] == [1, 3, 4, 4]
+    streamed = np.concatenate(
+        [
+            np.frombuffer(message.data["audio_waveform"], dtype=np.float32)
+            for message in messages[:-1]
+        ]
+    )
+    expected = all_codes[:, 0].to(torch.float32).repeat_interleave(4).numpy()
+    np.testing.assert_array_equal(streamed, expected)
+
+
+def test_qwen3_tts_async_followup_batches_ready_requests() -> None:
+    tokenizer = _FakeQwen3TTSTokenizer()
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        tokenizer,
+        device="cpu",
+        stream_stride=1,
+        stream_followup_stride=2,
+        initial_chunk_frames=1,
+        async_decode=True,
+        followup_batch_wait_ms=20,
+    )
+    payloads = [
+        make_payload(inputs="first", params={"stream": True}),
+        make_payload(inputs="second", params={"stream": True}),
+    ]
+    payloads[0].request_id = "req-first"
+    payloads[1].request_id = "req-second"
+
+    scheduler.on_serving_start()
+    try:
+        for payload in payloads:
+            scheduler._on_streaming_new_request(payload.request_id, payload)
+            scheduler._on_chunk(
+                payload.request_id,
+                _qwen3_tts_stream_item(
+                    torch.ones((1, 2), dtype=torch.long),
+                    chunk_id=0,
+                    ref_code_len=0,
+                ),
+            )
+            assert scheduler.outbox.get(timeout=1).type == "stream"
+
+        for payload in payloads:
+            scheduler._on_chunk(
+                payload.request_id,
+                _qwen3_tts_stream_item(
+                    torch.ones((2, 2), dtype=torch.long),
+                    chunk_id=1,
+                ),
+            )
+
+        assert scheduler.outbox.get(timeout=1).type == "stream"
+        assert scheduler.outbox.get(timeout=1).type == "stream"
+    finally:
+        for payload in payloads:
+            scheduler.abort(payload.request_id)
+        scheduler.stop()
+
+    batch_sizes = [
+        int(codes.shape[0]) for codes in tokenizer.model.decoder.decode_inputs
+    ]
+    assert batch_sizes == [1, 1, 2]
+
+
+def test_qwen3_tts_followup_queue_prioritizes_playback_deadline() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        async_decode=True,
+        followup_batch_wait_ms=0,
+    )
+    later = scheduler.create_stream_state("later")
+    later.playback_deadline_s = 20.0
+    earlier = scheduler.create_stream_state("earlier")
+    earlier.playback_deadline_s = 10.0
+    scheduler._enqueue_followup("later", later)
+    scheduler._enqueue_followup("earlier", earlier)
+
+    assert scheduler._collect_followup_batch() == [("earlier", earlier)]
+
+
+@pytest.mark.parametrize("worker", ["initial", "followup"])
+def test_qwen3_tts_async_worker_propagates_process_exit(
+    monkeypatch: pytest.MonkeyPatch,
+    worker: str,
+) -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        stream_stride=1,
+        stream_followup_stride=1,
+    )
+    state = scheduler.create_stream_state("request")
+    state.num_quantizers = 2
+    state.code_chunks.append(torch.ones((1, 2), dtype=torch.long))
+    state.total_frames = 1
+    if worker == "followup":
+        state.decoded_chunks = 1
+    scheduler._stream_states["request"] = state
+
+    def interrupt(*args, **kwargs):
+        del args, kwargs
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(scheduler, "_run_decode_plans", interrupt)
+
+    with pytest.raises(KeyboardInterrupt):
+        if worker == "initial":
+            scheduler._run_initial_batch([("request", state)])
+        else:
+            scheduler._run_followup_batch([("request", state)])
+
+
+@pytest.mark.parametrize("commit", ["initial", "followup"])
+def test_qwen3_tts_async_commit_propagates_process_exit(
+    monkeypatch: pytest.MonkeyPatch,
+    commit: str,
+) -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        stream_stride=1,
+    )
+    state = scheduler.create_stream_state("request")
+    state.num_quantizers = 2
+    state.code_chunks.append(torch.ones((1, 2), dtype=torch.long))
+    state.total_frames = 1
+    scheduler._stream_states["request"] = state
+    plan = scheduler._build_decode_plan(state, is_final=False)
+    assert plan is not None
+
+    def interrupt(*args, **kwargs):
+        del args, kwargs
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(scheduler, "_commit_decode_plan", interrupt)
+
+    with pytest.raises(KeyboardInterrupt):
+        if commit == "initial":
+            scheduler._commit_initial("request", state, plan, torch.ones(4))
+        else:
+            scheduler._commit_followup("request", state, plan, torch.ones(4))
+
+
+def test_qwen3_tts_async_followup_drops_late_audio_after_abort() -> None:
+    entered = threading.Event()
+    release = threading.Event()
+
+    class BlockingDecoder(_FakeQwen3TTSDecoder):
+        def chunked_decode(self, codes: torch.Tensor) -> torch.Tensor:
+            if self.decode_inputs:
+                entered.set()
+                assert release.wait(timeout=2)
+            return super().chunked_decode(codes)
+
+    tokenizer = _FakeQwen3TTSTokenizer()
+    tokenizer.model.decoder = BlockingDecoder()
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        tokenizer,
+        device="cpu",
+        stream_stride=1,
+        stream_followup_stride=2,
+        initial_chunk_frames=1,
+        async_decode=True,
+    )
+    payload = make_payload(inputs="target", params={"stream": True})
+
+    scheduler.on_serving_start()
+    try:
+        scheduler._on_streaming_new_request(payload.request_id, payload)
+        scheduler._on_chunk(
+            payload.request_id,
+            _qwen3_tts_stream_item(
+                torch.ones((1, 2), dtype=torch.long),
+                chunk_id=0,
+                ref_code_len=0,
+            ),
+        )
+        scheduler.outbox.get(timeout=1)
+        scheduler._on_chunk(
+            payload.request_id,
+            _qwen3_tts_stream_item(
+                torch.ones((2, 2), dtype=torch.long),
+                chunk_id=1,
+            ),
+        )
+        assert entered.wait(timeout=1)
+        scheduler.abort(payload.request_id)
+        release.set()
+        with pytest.raises(Empty):
+            scheduler.outbox.get(timeout=0.1)
+    finally:
+        release.set()
+        scheduler.stop()
+
+    assert payload.request_id not in scheduler._stream_states
+
+
+def test_qwen3_tts_async_initial_drops_late_audio_after_abort() -> None:
+    entered = threading.Event()
+    release = threading.Event()
+
+    class BlockingDecoder(_FakeQwen3TTSDecoder):
+        def chunked_decode(self, codes: torch.Tensor) -> torch.Tensor:
+            entered.set()
+            assert release.wait(timeout=2)
+            return super().chunked_decode(codes)
+
+    tokenizer = _FakeQwen3TTSTokenizer()
+    tokenizer.model.decoder = BlockingDecoder()
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        tokenizer,
+        device="cpu",
+        stream_stride=1,
+        initial_chunk_frames=1,
+        async_decode=True,
+    )
+    payload = make_payload(inputs="target", params={"stream": True})
+
+    scheduler.on_serving_start()
+    try:
+        scheduler._on_streaming_new_request(payload.request_id, payload)
+        scheduler._on_chunk(
+            payload.request_id,
+            _qwen3_tts_stream_item(
+                torch.ones((1, 2), dtype=torch.long),
+                chunk_id=0,
+                ref_code_len=0,
+            ),
+        )
+        assert entered.wait(timeout=1)
+        scheduler.abort(payload.request_id)
+        release.set()
+        with pytest.raises(Empty):
+            scheduler.outbox.get(timeout=0.1)
+    finally:
+        release.set()
+        scheduler.stop()
+
+    assert payload.request_id not in scheduler._stream_states
 
 
 def test_qwen3_tts_result_adapter_keeps_code_handoff_tensor_native() -> None:
@@ -1055,6 +1923,7 @@ def test_qwen3_tts_request_data_keeps_decode_tensors_on_prepared_device(
     assert data.prompt_input_embeds is prepared.prompt_input_embeds
     assert data.ref_code is prepared.ref_code
     assert data.tts_pad_embed is prepared.tts_pad_embed
+    assert data.stream_codec_output is True
     assert isinstance(data.pending_text_queue, PendingTextTensorQueue)
     assert data.pending_text_queue.rows is not None
     assert data.pending_text_queue.rows.device == prepared.trailing_text_hidden.device
@@ -1545,6 +2414,7 @@ def test_qwen3_tts_collect_codes_excludes_semantic_eos(
     )
 
     assert [chunk.tolist() for chunk in requests[0].data.output_codes] == [[1, 2]]
+    assert requests[0].data.latest_stream_code_chunk.tolist() == [1, 2]
     assert len(requests[0].data.pending_feedback_queue) == 1
     assert requests[1].data.output_codes == []
     assert len(requests[1].data.pending_feedback_queue) == 0
@@ -2102,7 +2972,11 @@ def test_qwen3_tts_engine_applies_compat_overrides_and_reenables_cuda_graph(
     monkeypatch.setattr(
         request_builders_mod,
         "make_qwen3_tts_scheduler_adapters",
-        lambda **kwargs: (lambda payload: payload, lambda data: data),
+        lambda **kwargs: (
+            lambda payload: payload,
+            lambda data: data,
+            lambda request_id, data, output: [],
+        ),
     )
     monkeypatch.setattr(
         stages,


### PR DESCRIPTION
## Summary

Narrow replacement for #1240, preserving only the Qwen3-TTS true-streaming path:

- emit generated codec rows from the AR stage as device-resident tensor stream chunks
- prepend reference codes once, then incrementally decode Base/reference-cloning traffic in the model-local vocoder
- use a high-priority initial CUDA stream and lower-priority, deadline-ordered follow-up batches
- preserve stream-before-payload handling, final-stream-before-result ordering, non-streaming batch decode, and abort/failure/stop cleanup
- advertise the streaming-vocoder capability and document the supported Base/reference-cloning scope

CustomVoice, VoiceDesign, and explicit `non_streaming_mode` generation keep the full-utterance fallback rather than publishing incremental codec rows.

## Split from #1240

Deliberately removed unrelated policy/experiments from the original PR:

- 1.7B low-VRAM profile
- preprocessing concurrency changes
- `max_running_requests` increase
- separate reference-encoding CUDA stream
- sampling-loop rename/comment-only churn

The 1.7B consumer-GPU profile will be validated independently under #1120.

## Correctness hardening

- clamp `initial_codec_chunk_frames` identically whether payload or codec chunk arrives first
- keep codec tensors on their source device; avoid a GPU→CPU→GPU round trip and CUDA value-reduction sync on every row
- make the vocoder CUDA stream wait for codec staging before decode
- keep full-decode fallback reference trimming identical to the existing non-streaming vocoder
- gate incremental codec emission on the model's `non_streaming_mode` contract

## Validation

- `87 passed, 11 deselected` for the Qwen3-TTS pipeline suite on macOS; the 11 deselections require unavailable local `sgl_kernel`
- `22 passed` for focused streaming, async lifecycle, vocoder batching, and production request-builder coverage
- `2 passed` for Qwen3-TTS capability export/lookup
- changed-file pre-commit hooks passed
- architecture drift audit: changes are model-local and use the existing `StageConfig.stream_to`, `can_accept_stream_before_payload`, `OmniScheduler.stream_output_builder`, and `StreamingVocoderBase` contracts

## Benchmark provenance

The H100 measurements below are from the original #1240 author and were not rerun in this narrowing pass (Seed-TTS EN, default config, 64 SGLang requests; baseline 1088 requests):

- C8: TTFA p95 0.421s vs 0.330s; QPS 5.825 vs 2.921; C200 90.6% vs 0%
- C16: TTFA p95 0.243s vs 0.497s; QPS 8.868 vs 3.107; C200 39.1% vs 0%
- C32: TTFA p95 0.422s vs 0.895s; QPS 11.348 vs 3.155; C200 21.9% vs 0%

Addresses #1248. Related to #1120.
