### PR TITLE
[Feature][MOSS-TTS Local] Add explicit RTX 4090 24 GB profile

### DIFF
--- a/docs/cookbook/moss_tts_local.md
+++ b/docs/cookbook/moss_tts_local.md
@@ -40,6 +40,24 @@ sgl-omni serve \
 
 A matching config file is available at `examples/configs/moss_tts_local.yaml`.
 
+For a single RTX 4090-class 24 GB GPU, use the experimental profile that keeps
+the reference-audio codec encoder on CPU while leaving AR generation and the
+vocoder on GPU:
+
+```bash
+sgl-omni serve \
+  --model-path OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5 \
+  --config examples/configs/moss_tts_local_4090_24gb.yaml \
+  --port 8000
+```
+
+This trades reference-encoding latency for GPU headroom and retains the
+model's conservative colocated memory budgets. The fallback was exercised on
+an RTX 4090D in [PR #1198](https://github.com/sgl-project/sglang-omni/pull/1198),
+but has not completed quality, long-form, or sustained-load validation; treat
+it as a functional profile rather than a general
+consumer-GPU support claim.
+
 ## Synthesizing Speech
 
 ### Basic Speech

--- a/examples/configs/moss_tts_local_4090_24gb.yaml
+++ b/examples/configs/moss_tts_local_4090_24gb.yaml
@@ -1,0 +1,9 @@
+# Experimental single-RTX-4090 (24 GB) profile.
+# Keep the ~1B-parameter reference codec off GPU; AR and vocoder retain the
+# model's conservative colocated memory budgets.
+config_cls: MossTTSLocalPipelineConfig
+model_path: OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5
+
+runtime_overrides:
+  preprocessing:
+    device: cpu

--- a/tests/README.md
+++ b/tests/README.md
@@ -500,6 +500,7 @@ that happened to contain an older version of the test.
 
 - `unit_test/moss_tts_local/`: MOSS-TTS Local unit tests:
   - pipeline config, request builders, and scheduler adapter contracts
+  - production config resolution for the experimental 24 GB RTX 4090 profile
   - decode-state pool acquisition, launch-state gathers, repetition-penalty history, cleanup, and resume/retraction lifecycle
   - chunked prefill feedback/journal suppression and postprocess alignment checks
   - synchronous frame-decode parity harness and S0 gate coverage

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -12,7 +12,9 @@ import torch
 
 from sglang_omni.client.audio import encode_audio, encode_wav
 from sglang_omni.config import StageConfig
+from sglang_omni.config.manager import ConfigManager
 from sglang_omni.config.placement import build_stage_placement_plan
+from sglang_omni.config.runtime import resolve_stage_static_factory_args
 from sglang_omni.config.topology import build_process_topology_plan
 from sglang_omni.models.moss_tts_local.audio_tokenizer import MossTTSLocalAudioTokenizer
 from sglang_omni.models.moss_tts_local.config import (
@@ -418,6 +420,24 @@ def test_registry_resolves_local_architecture():
     # The Delay family keeps its own architecture.
     delay_cls = PIPELINE_CONFIG_REGISTRY.get_config("MossTTSDelayModel")
     assert delay_cls is not MossTTSLocalPipelineConfig
+
+
+def test_rtx4090_profile_moves_reference_codec_to_cpu() -> None:
+    config = ConfigManager.from_file(
+        "examples/configs/moss_tts_local_4090_24gb.yaml"
+    ).config
+
+    assert isinstance(config, MossTTSLocalPipelineConfig)
+    stages = {stage.name: stage for stage in config.stages}
+    preprocessing = stages["preprocessing"]
+    preprocessing_args = resolve_stage_static_factory_args(preprocessing, config)
+    assert preprocessing_args["device"] == "cpu"
+    assert preprocessing_args["max_concurrency"] == 16
+    assert preprocessing.runtime.resources.total_gpu_memory_fraction == pytest.approx(
+        0.15
+    )
+    assert stages["tts_engine"].factory_args["codec_mem_reserve"] == pytest.approx(0.0)
+    assert stages["vocoder"].factory_args["device"] == "cuda:0"
 
 
 def test_pipeline_stage_wiring():


### PR DESCRIPTION
## Summary

- add an explicit experimental single-RTX-4090 24 GB profile for MOSS-TTS Local
- move only the reference-audio codec encoder to CPU through the existing `runtime_overrides` config path
- preserve the default AR/vocoder placement and conservative GPU memory budgets
- document the latency tradeoff, RTX 4090D provenance, and remaining quality/soak validation gap

## Validation

- `python -m pytest tests/unit_test/moss_tts_local/test_pipeline.py -q -k "rtx4090_profile or pipeline_stage_wiring"` — 2 passed, 72 deselected
- `pre-commit run --files examples/configs/moss_tts_local_4090_24gb.yaml docs/cookbook/moss_tts_local.md tests/README.md tests/unit_test/moss_tts_local/test_pipeline.py` — passed
- broader `tests/unit_test/moss_tts_local/test_pipeline.py` — 70 passed, 3 skipped; one unrelated environment failure because the local macOS verification venv does not contain `torchaudio`

## Scope

This is a config/docs extraction of the MOSS-TTS Local low-memory fallback exercised on RTX 4090D in #1198. It does not claim completed quality, long-form, sustained-load, or exact RTX 4090 qualification.

Related to #1120.
