### PR TITLE
[Feature][Voxtral TTS] Add bounded RTX 4090 24 GB profile

### DIFF
--- a/docs/cookbook/voxtral_tts.md
+++ b/docs/cookbook/voxtral_tts.md
@@ -32,6 +32,28 @@ sgl-omni serve \
   --port 8000
 ```
 
+### RTX 4090 24 GB Profile
+
+For a single RTX 4090-class 24 GB GPU, use the experimental profile bounded to
+concurrency 1, the only consumer-GPU shape exercised so far:
+
+```bash
+sgl-omni serve \
+  --model-path mistralai/Voxtral-4B-TTS-2603 \
+  --config examples/configs/voxtral_tts_4090_24gb.yaml \
+  --port 8000
+```
+
+The profile keeps BF16 generation, the default `mem_fraction_static=0.85`, CUDA
+Graphs, and `torch.compile`, but caps `max_running_requests` at 1. The generation
+builder derives matching CUDA Graph and compile batch caps, avoiding capture for
+unqualified concurrency shapes.
+
+The audio tokenizer uses `flash_attn` when that package is importable and
+otherwise falls back to PyTorch SDPA. The RTX 4090D run exercised the SDPA
+fallback. That run is functional evidence for SM89 and 24 GB capacity, not
+qualification of a standard RTX 4090 or higher concurrency.
+
 ## Synthesizing Speech
 
 ### Preset Voice
@@ -93,13 +115,15 @@ with open("output.wav", "wb") as f:
     f.write(resp.content)
 ```
 
-### Streaming
+### PCM Output and Stream Compatibility
 
-Set `"stream": true` and `"response_format": "pcm"` to receive raw PCM audio
-chunks in real time:
+Set `"response_format": "pcm"` to receive raw 24 kHz, 16-bit mono PCM bytes.
+`"stream": true` is accepted for API compatibility, but the current Voxtral
+vocoder does not flush incremental chunks: the response arrives when synthesis
+finishes.
 
 ```bash
-curl -N -X POST http://localhost:8000/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
   -H "Content-Type: application/json" \
   -d '{
     "model": "mistralai/Voxtral-4B-TTS-2603",
@@ -111,9 +135,9 @@ curl -N -X POST http://localhost:8000/v1/audio/speech \
   --output output.pcm
 ```
 
-Streaming returns `audio/pcm` 16-bit mono PCM bytes with sample-rate metadata in
-the response headers. See the [Higgs TTS cookbook](../cookbook/higgs_tts.md#streaming)
-for a full Python raw PCM consumer.
+The response uses `audio/pcm` with sample-rate metadata in its headers. Do not
+interpret request latency as time to first audio until incremental vocoder
+delivery is implemented.
 
 ## Request Parameters
 
@@ -124,7 +148,7 @@ for a full Python raw PCM consumer.
 | `voice` | `default` | Preset voice name from the checkpoint's `voice_embedding/` directory |
 | `max_new_tokens` | `4096` | Maximum number of generated acoustic tokens |
 | `response_format` | `wav` | Output container (`wav`, `mp3`, `flac`, `opus`, `aac`, `pcm`) |
-| `stream` | `false` | Stream raw PCM audio chunks |
+| `stream` | `false` | Accepted for compatibility; audio currently arrives after full synthesis |
 
 > Voxtral generation is **deterministic**: the engine fixes `temperature` to `0.0`, so sampling
 > parameters such as `top_p`, `top_k`, and `temperature` are not used. Reference-clip voice
@@ -154,10 +178,32 @@ also quotes ~70 ms first-audio latency at concurrency 1; the table above is a th
 run at concurrency 16, so its RTF reflects batched load rather than the latency-optimized
 single-stream figure. Output is 24 kHz.
 
+### RTX 4090D Functional Run
+
+[Issue #1188](https://github.com/sgl-project/sglang-omni/issues/1188)
+records a single-GPU functional run on an RTX 4090D (SM89, 24,564 MiB), using
+BF16 and the native SDPA audio-tokenizer fallback. Output length was
+nondeterministic, so real-time factor (RTF) is the comparable metric.
+
+| Metric (concurrency 1, 20 requests) | Value |
+|---|---|
+| Completed / failed | 20 / 0 |
+| Latency median / p95 | 1.404 s / 1.729 s |
+| Audio duration median / p95 | 4.800 s / 6.080 s |
+| RTF median / p95 | 0.286 / 0.296 |
+| RTF min / max | 0.283 / 0.310 |
+
+BF16 startup, preset voice synthesis, WAV output, and PCM output completed.
+Reference-voice cloning was unavailable in that run. Incremental streaming,
+steady-state memory, compile-memory deltas, concurrency above 1, and a
+current-`main` quality sweep remain unqualified.
+
 ## Known Limitations
 
 - **Preset voices only.** Voxtral selects from named voices baked into the checkpoint; it does
   not clone an arbitrary speaker from a reference clip in this engine.
+- **Non-incremental streaming.** The API accepts `stream=true`, but Voxtral
+  currently emits audio only after full synthesis.
 - **Deterministic decoding.** `temperature` is fixed at `0.0`; you cannot trade determinism for
   diversity through sampling parameters.
 - **Language coverage.** Quality is tuned for the 9 supported languages (English, French,

--- a/examples/configs/voxtral_tts_4090_24gb.yaml
+++ b/examples/configs/voxtral_tts_4090_24gb.yaml
@@ -1,0 +1,10 @@
+# Experimental single-RTX-4090 (24 GB) profile.
+# Concurrency 1 is the only consumer-GPU shape exercised so far; the generation
+# builder derives matching CUDA Graph and torch.compile batch caps.
+config_cls: VoxtralTTSPipelineConfig
+model_path: mistralai/Voxtral-4B-TTS-2603
+
+runtime_overrides:
+  tts_generation:
+    server_args_overrides:
+      max_running_requests: 1

--- a/tests/README.md
+++ b/tests/README.md
@@ -538,6 +538,8 @@ that happened to contain an older version of the test.
 - `unit_test/voxtral_tts/`: Voxtral-TTS unit tests:
   - pipeline config and registry contracts
   - current `StageConfig` schema wiring
+  - experimental 24 GB RTX 4090 profile resolution and derived batch caps
+  - native SDPA audio-tokenizer causal sliding-window behavior
   - SGLang-backed generation and vocoder GPU placement contracts
   - terminal stage behavior.
 

--- a/tests/unit_test/voxtral_tts/test_pipeline.py
+++ b/tests/unit_test/voxtral_tts/test_pipeline.py
@@ -11,12 +11,20 @@ import pytest
 import torch
 
 from sglang_omni.config import build_process_topology_plan, build_stage_placement_plan
+from sglang_omni.config.manager import ConfigManager
+from sglang_omni.config.runtime import resolve_stage_static_factory_args
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from sglang_omni.models.voxtral_tts.config import VoxtralTTSPipelineConfig
 from sglang_omni.models.voxtral_tts.io import VoxtralTTSState
 from sglang_omni.models.voxtral_tts.pipeline import stages
+from sglang_omni.models.voxtral_tts.pipeline.engine_builder import (
+    VoxtralTtsEngineBuilder,
+)
 from sglang_omni.models.voxtral_tts.request_builders import build_sglang_voxtral_request
 from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.scheduling.generation_batch_policy import (
+    build_generation_batch_overrides,
+)
 from sglang_omni.scheduling.types import RequestOutput
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 from tests.unit_test.fakes import FakeExecutionBridge, FakeServerArgs
@@ -48,6 +56,65 @@ def test_voxtral_tts_config_uses_current_stage_schema() -> None:
         PIPELINE_CONFIG_REGISTRY.get_config("VoxtralTTSForConditionalGeneration")
         is VoxtralTTSPipelineConfig
     )
+
+
+def test_rtx4090_profile_caps_generation_to_exercised_concurrency() -> None:
+    config = ConfigManager.from_file(
+        "examples/configs/voxtral_tts_4090_24gb.yaml"
+    ).config
+
+    assert isinstance(config, VoxtralTTSPipelineConfig)
+    generation = next(
+        stage for stage in config.stages if stage.name == "tts_generation"
+    )
+    factory_args = resolve_stage_static_factory_args(generation, config)
+    defaults = VoxtralTtsEngineBuilder().generation_defaults(dtype="bfloat16")
+    overrides = build_generation_batch_overrides(
+        server_args_overrides=factory_args["server_args_overrides"],
+        **defaults,
+    )
+
+    assert overrides["max_running_requests"] == 1
+    assert overrides["cuda_graph_max_bs"] == 1
+    assert overrides["cuda_graph_bs"] == [1]
+    assert overrides["torch_compile_max_bs"] == 1
+    assert overrides["mem_fraction_static"] == pytest.approx(0.85)
+    build_process_topology_plan(config, build_stage_placement_plan(config))
+
+
+def test_audio_tokenizer_sdpa_fallback_preserves_causal_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.voxtral_tts import audio_tokenizer
+
+    monkeypatch.setattr(audio_tokenizer, "HAS_FLASH_ATTN", False)
+    attention = audio_tokenizer.Attention(
+        audio_tokenizer.AudioTokenizerArgs(
+            dim=2,
+            hidden_dim=4,
+            head_dim=1,
+            n_heads=2,
+            n_kv_heads=1,
+            qk_norm=False,
+            attn_sliding_window_size=2,
+        ),
+        layer_id=0,
+    )
+    with torch.no_grad():
+        attention.alibi_slopes.zero_()
+        attention.wq.weight.zero_()
+        attention.wk.weight.zero_()
+        attention.wv.weight.zero_()
+        attention.wv.weight[0, 0] = 1.0
+        attention.wo.weight.copy_(torch.eye(2))
+
+    values = torch.tensor([1.0, 2.0, 4.0, 8.0])
+    inputs = torch.stack((values, torch.zeros_like(values)), dim=-1)
+    output = attention(inputs)
+
+    expected_values = torch.tensor([1.0, 1.5, 7.0 / 3.0, 14.0 / 3.0])
+    expected = torch.stack((expected_values, expected_values), dim=-1)
+    torch.testing.assert_close(output, expected)
 
 
 def test_voxtral_radix_cache_is_namespaced_by_voice() -> None:


### PR DESCRIPTION
## Summary

- add an experimental single-RTX-4090 24 GB Voxtral TTS profile bounded to concurrency 1, the only consumer-GPU shape exercised so far
- use the existing `runtime_overrides` path so the generation builder derives matching CUDA Graph and `torch.compile` batch caps
- exercise the public native-SDPA audio-tokenizer fallback with causal sliding-window and grouped-query behavior
- publish the RTX 4090D concurrency-1 RTF evidence from #1188 and correct the cookbook's prior incremental-streaming claim

## Validation

- `python -m pytest tests/unit_test/voxtral_tts/test_pipeline.py -q` — 23 passed
- `pre-commit run --files examples/configs/voxtral_tts_4090_24gb.yaml docs/cookbook/voxtral_tts.md tests/README.md tests/unit_test/voxtral_tts/test_pipeline.py` — passed

## Hardware scope

No GPU benchmark was run by this PR. The profile is bounded to the RTX 4090D functional evidence already recorded in #1188: BF16 startup, 20/20 successful concurrency-1 requests, median/p95 RTF 0.286/0.296, and the native SDPA tokenizer path. Standard RTX 4090, concurrency above 1, steady-state memory, compile-memory deltas, incremental streaming, and current-`main` quality remain unqualified.

Related to #1120 and #1188.
