### PR TITLE
[Fix] Keep MOSS-TD encoder OOM request-scoped

### DIFF
--- a/sglang_omni/models/moss_transcribe_diarize/encoder_service.py
+++ b/sglang_omni/models/moss_transcribe_diarize/encoder_service.py
@@ -12,6 +12,7 @@ import logging
 import queue
 import threading
 import traceback
+from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -22,6 +23,12 @@ logger = logging.getLogger(__name__)
 
 _CACHE_MAX_ENTRIES = 4096
 _CACHE_MAX_BYTES = 2 * 1024**3
+
+
+@dataclass(frozen=True)
+class _DetachedFailure:
+    exception: Exception
+    formatted_traceback: str
 
 
 class BatchedAudioEncoderService:
@@ -84,42 +91,33 @@ class BatchedAudioEncoderService:
         except Exception as batch_exc:
             if len(batch) == 1:
                 failure = self._detach_failure(batch_exc)
-                failure_type = type(failure).__name__
-                failure_message = str(failure)
                 logger.error(
-                    "MOSS-TD audio encode failed: %s: %s",
-                    failure_type,
-                    failure_message,
+                    "MOSS-TD audio encode failed:\n%s",
+                    failure.formatted_traceback,
                 )
-                self._recover_after_failure(failure)
-                batch[0][1].set_exception(failure)
+                self._recover_after_failure(failure.exception)
+                batch[0][1].set_exception(failure.exception)
                 return
 
             failure = self._detach_failure(batch_exc)
-            failure_type = type(failure).__name__
-            failure_message = str(failure)
             logger.error(
                 "MOSS-TD batched audio encode failed for %d items; "
-                "retrying per item: %s: %s",
+                "retrying per item:\n%s",
                 len(items),
-                failure_type,
-                failure_message,
+                failure.formatted_traceback,
             )
-            self._recover_after_failure(failure)
+            self._recover_after_failure(failure.exception)
             for item, future in batch:
                 try:
                     self._encode_batch([item])
                 except Exception as item_exc:
                     failure = self._detach_failure(item_exc)
-                    failure_type = type(failure).__name__
-                    failure_message = str(failure)
                     logger.error(
-                        "MOSS-TD per-item audio encode retry failed: %s: %s",
-                        failure_type,
-                        failure_message,
+                        "MOSS-TD per-item audio encode retry failed:\n%s",
+                        failure.formatted_traceback,
                     )
-                    self._recover_after_failure(failure)
-                    future.set_exception(failure)
+                    self._recover_after_failure(failure.exception)
+                    future.set_exception(failure.exception)
                 else:
                     self._record_success(1)
                     future.set_result(None)
@@ -130,17 +128,23 @@ class BatchedAudioEncoderService:
             future.set_result(None)
 
     @staticmethod
-    def _detach_failure(exc: Exception) -> Exception:
+    def _detach_failure(exc: Exception) -> _DetachedFailure:
+        formatted_traceback = "".join(traceback.format_exception(exc)).rstrip()
         message = str(exc)
         traceback.clear_frames(exc.__traceback__)
         exc.__traceback__ = None
         exc.__cause__ = None
         exc.__context__ = None
         if isinstance(exc, torch.OutOfMemoryError):
-            return torch.OutOfMemoryError(message)
-        if isinstance(exc, ValueError):
-            return ValueError(message)
-        return RuntimeError(f"{type(exc).__name__}: {message}")
+            detached = torch.OutOfMemoryError(message)
+        elif isinstance(exc, ValueError):
+            detached = ValueError(message)
+        else:
+            detached = RuntimeError(f"{type(exc).__name__}: {message}")
+        return _DetachedFailure(
+            exception=detached,
+            formatted_traceback=formatted_traceback,
+        )
 
     def _recover_after_failure(self, exc: Exception) -> None:
         if not isinstance(exc, torch.OutOfMemoryError):

--- a/sglang_omni/models/moss_transcribe_diarize/encoder_service.py
+++ b/sglang_omni/models/moss_transcribe_diarize/encoder_service.py
@@ -11,6 +11,7 @@ import concurrent.futures
 import logging
 import queue
 import threading
+import traceback
 from typing import Any
 
 import torch
@@ -72,33 +73,100 @@ class BatchedAudioEncoderService:
 
     def _worker(self) -> None:
         while True:
-            batch = self._drain_batch()
-            items = [item for item, _ in batch]
-            try:
-                self._encode_batch(items)
-            except Exception:
-                logger.exception(
-                    f"MOSS-TD batched audio encode failed for {len(items)} "
-                    f"items; retrying per item"
+            self._process_batch(self._drain_batch())
+
+    def _process_batch(
+        self, batch: list[tuple[Any, concurrent.futures.Future]]
+    ) -> None:
+        items = [item for item, _ in batch]
+        try:
+            self._encode_batch(items)
+        except Exception as batch_exc:
+            if len(batch) == 1:
+                failure = self._detach_failure(batch_exc)
+                failure_type = type(failure).__name__
+                failure_message = str(failure)
+                logger.error(
+                    "MOSS-TD audio encode failed: %s: %s",
+                    failure_type,
+                    failure_message,
                 )
-                for item, future in batch:
-                    try:
-                        self._encode_batch([item])
-                        future.set_result(None)
-                    except Exception as item_exc:
-                        future.set_exception(item_exc)
-                continue
-            for _, future in batch:
-                future.set_result(None)
-            self._batch_count += 1
-            self._item_count += len(items)
-            if self._batch_count % 50 == 1:
-                logger.info(
-                    f"MOSS-TD pre-LM encoder stage: {self._batch_count} batches, "
-                    f"{self._item_count} items (avg "
-                    f"{self._item_count / self._batch_count:.2f} items/batch, "
-                    f"last batch: {len(items)})"
-                )
+                self._recover_after_failure(failure)
+                batch[0][1].set_exception(failure)
+                return
+
+            failure = self._detach_failure(batch_exc)
+            failure_type = type(failure).__name__
+            failure_message = str(failure)
+            logger.error(
+                "MOSS-TD batched audio encode failed for %d items; "
+                "retrying per item: %s: %s",
+                len(items),
+                failure_type,
+                failure_message,
+            )
+            self._recover_after_failure(failure)
+            for item, future in batch:
+                try:
+                    self._encode_batch([item])
+                except Exception as item_exc:
+                    failure = self._detach_failure(item_exc)
+                    failure_type = type(failure).__name__
+                    failure_message = str(failure)
+                    logger.error(
+                        "MOSS-TD per-item audio encode retry failed: %s: %s",
+                        failure_type,
+                        failure_message,
+                    )
+                    self._recover_after_failure(failure)
+                    future.set_exception(failure)
+                else:
+                    self._record_success(1)
+                    future.set_result(None)
+            return
+
+        self._record_success(len(items))
+        for _, future in batch:
+            future.set_result(None)
+
+    @staticmethod
+    def _detach_failure(exc: Exception) -> Exception:
+        message = str(exc)
+        traceback.clear_frames(exc.__traceback__)
+        exc.__traceback__ = None
+        exc.__cause__ = None
+        exc.__context__ = None
+        if isinstance(exc, torch.OutOfMemoryError):
+            return torch.OutOfMemoryError(message)
+        if isinstance(exc, ValueError):
+            return ValueError(message)
+        return RuntimeError(f"{type(exc).__name__}: {message}")
+
+    def _recover_after_failure(self, exc: Exception) -> None:
+        if not isinstance(exc, torch.OutOfMemoryError):
+            return
+        try:
+            self._stream.synchronize()
+        except Exception:
+            logger.warning(
+                "MOSS-TD encoder stream cleanup failed after OOM", exc_info=True
+            )
+        try:
+            with torch.cuda.device(self._device):
+                torch.cuda.empty_cache()
+        except Exception:
+            logger.warning("MOSS-TD CUDA cache cleanup failed after OOM", exc_info=True)
+
+    def _record_success(self, item_count: int) -> None:
+        self._batch_count += 1
+        self._item_count += item_count
+        if self._batch_count % 50 == 1:
+            logger.info(
+                f"MOSS-TD pre-LM encoder stage: {self._batch_count} batches, "
+                f"{self._item_count} items (avg "
+                f"{self._item_count / self._batch_count:.2f} items/batch, "
+                f"last batch: {item_count})"
+            )
 
     def _encode_batch(self, items: list[Any]) -> None:
         with torch.cuda.stream(self._stream):
@@ -111,11 +179,14 @@ class BatchedAudioEncoderService:
                     f"encoder output rows {embedding.shape[0]} != expected "
                     f"{sum(token_counts)}"
                 )
-            parts = torch.split(embedding, token_counts, dim=0)
-            for item, part in zip(items, parts):
-                item.precomputed_embeddings = part.contiguous()
-                item.feature = None
+            parts = tuple(
+                part.contiguous()
+                for part in torch.split(embedding, token_counts, dim=0)
+            )
         self._stream.synchronize()
+        for item, part in zip(items, parts):
+            item.precomputed_embeddings = part
+            item.feature = None
         for item in items:
             if item.hash is not None:
                 self._cache.put(str(item.hash), item.precomputed_embeddings)

--- a/tests/README.md
+++ b/tests/README.md
@@ -102,6 +102,7 @@ tests/
     │   └── test_streaming_client.py
     ├── moss_transcribe_diarize/
     │   ├── test_encoder_cache.py
+    │   ├── test_encoder_service.py
     │   ├── test_pipeline.py
     │   ├── test_request_builders.py
     │   ├── test_stream_output_builder.py
@@ -400,6 +401,8 @@ that happened to contain an older version of the test.
   - pipeline config and stage factory default routing/memory contracts
   - request builder audio-source resolution, single-audio enforcement, audio
     token padding, and default transcribe+diarize prompt injection
+  - pre-LM encoder service bounded batching, request-scoped OOM recovery,
+    transactional embedding publication, and per-item fallback
   - verbose_json transcription adapter: architecture-based resolution, special
     token stripping, and speaker/timestamp segment parsing with fallback.
 - `unit_test/qwen3_omni/` Qwen3-Omni unit tests:

--- a/tests/unit_test/moss_transcribe_diarize/test_encoder_service.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_encoder_service.py
@@ -3,10 +3,17 @@
 from __future__ import annotations
 
 import concurrent.futures
+import contextlib
+import gc
 import queue
+import threading
+import weakref
+from types import SimpleNamespace
 
 import pytest
+import torch
 
+from sglang_omni.models.moss_transcribe_diarize import encoder_service
 from sglang_omni.models.moss_transcribe_diarize.encoder_service import (
     BatchedAudioEncoderService,
 )
@@ -30,3 +37,179 @@ def test_drain_batch_respects_gpu_microbatch_limit() -> None:
 def test_encoder_microbatch_limit_must_be_positive() -> None:
     with pytest.raises(ValueError, match="max_batch_size must be >= 1"):
         BatchedAudioEncoderService(object(), max_batch_size=0)
+
+
+class _FailingStream:
+    def synchronize(self) -> None:
+        raise torch.OutOfMemoryError("test encoder OOM")
+
+
+class _EncoderIntermediate:
+    pass
+
+
+class _StopWorker(BaseException):
+    pass
+
+
+def test_encode_batch_commits_item_state_only_after_stream_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = object.__new__(BatchedAudioEncoderService)
+    service._stream = _FailingStream()
+    service._model = SimpleNamespace(
+        _get_audio_feature_uncached=lambda items, forward_batch: torch.ones(2, 3)
+    )
+    monkeypatch.setattr(
+        encoder_service.torch.cuda,
+        "stream",
+        lambda stream: contextlib.nullcontext(),
+    )
+    features = [torch.ones(1), torch.ones(1)]
+    items = [
+        SimpleNamespace(
+            feature=feature,
+            audio_feature_lengths=torch.tensor([1]),
+            hash=None,
+        )
+        for feature in features
+    ]
+
+    with pytest.raises(torch.OutOfMemoryError, match="test encoder OOM"):
+        service._encode_batch(items)
+
+    for item, feature in zip(items, features):
+        assert item.feature is feature
+        assert not hasattr(item, "precomputed_embeddings")
+
+
+def test_singleton_oom_is_request_scoped_and_worker_processes_next_item(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    service = object.__new__(BatchedAudioEncoderService)
+    service._max_batch_size = 1
+    service._queue = queue.Queue()
+    service._batch_count = 0
+    service._item_count = 0
+    service._device = "cuda:7"
+    cleanup_steps: list[str] = []
+    selected_devices: list[str] = []
+    calls: list[list[object]] = []
+    retained_intermediates: list[weakref.ReferenceType[_EncoderIntermediate]] = []
+    poisoned = False
+    failed_item = SimpleNamespace(hash=None, feature=object())
+    healthy_item = SimpleNamespace(hash=None, feature=object())
+    stop_item = object()
+
+    def _encode_batch(items: list[object]) -> None:
+        nonlocal poisoned
+        if items == [stop_item]:
+            raise _StopWorker
+        calls.append(items)
+        if items == [failed_item]:
+            intermediate = _EncoderIntermediate()
+            retained_intermediates.append(weakref.ref(intermediate))
+            poisoned = True
+            raise torch.OutOfMemoryError("test encoder OOM")
+        if poisoned:
+            raise RuntimeError("allocator remained poisoned after OOM")
+        items[0].precomputed_embeddings = object()
+        items[0].feature = None
+
+    def _cuda_device(device: str) -> contextlib.AbstractContextManager:
+        selected_devices.append(device)
+        return contextlib.nullcontext()
+
+    def _empty_cache() -> None:
+        nonlocal poisoned
+        cleanup_steps.append("empty_cache")
+        poisoned = False
+
+    service._stream = SimpleNamespace(
+        synchronize=lambda: cleanup_steps.append("synchronize")
+    )
+    monkeypatch.setattr(service, "_encode_batch", _encode_batch)
+    monkeypatch.setattr(encoder_service.torch.cuda, "device", _cuda_device)
+    monkeypatch.setattr(encoder_service.torch.cuda, "empty_cache", _empty_cache)
+
+    def _run_worker() -> None:
+        try:
+            service._worker()
+        except _StopWorker:
+            pass
+
+    service._thread = threading.Thread(target=_run_worker, daemon=True)
+    service._thread.start()
+
+    try:
+        with pytest.raises(torch.OutOfMemoryError, match="test encoder OOM"):
+            service.encode_item(failed_item)
+        service.encode_item(healthy_item)
+    finally:
+        service._queue.put((stop_item, concurrent.futures.Future()))
+        service._thread.join(timeout=1)
+
+    gc.collect()
+    assert not service._thread.is_alive()
+    assert calls == [[failed_item], [healthy_item]]
+    assert cleanup_steps == ["synchronize", "empty_cache"]
+    assert selected_devices == ["cuda:7"]
+    assert healthy_item.feature is None
+    assert service._batch_count == 1
+    assert service._item_count == 1
+    assert retained_intermediates[0]() is None
+    assert all(record.exc_info is None for record in caplog.records)
+    assert all(
+        not any(isinstance(arg, BaseException) for arg in record.args)
+        for record in caplog.records
+    )
+
+
+def test_batched_oom_falls_back_to_per_item_encoding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = object.__new__(BatchedAudioEncoderService)
+    service._batch_count = 0
+    service._item_count = 0
+    service._device = "cuda:5"
+    cleanup_steps: list[str] = []
+    selected_devices: list[str] = []
+    service._stream = SimpleNamespace(
+        synchronize=lambda: cleanup_steps.append("synchronize")
+    )
+    poisoned = False
+    calls: list[list[object]] = []
+    items = [object(), object()]
+
+    def _encode_batch(batch: list[object]) -> None:
+        nonlocal poisoned
+        calls.append(batch)
+        if len(batch) > 1:
+            poisoned = True
+            raise torch.OutOfMemoryError("aggregate batch is too large")
+        if poisoned:
+            raise RuntimeError("allocator remained poisoned after OOM")
+
+    def _cuda_device(device: str) -> contextlib.AbstractContextManager:
+        selected_devices.append(device)
+        return contextlib.nullcontext()
+
+    def _empty_cache() -> None:
+        nonlocal poisoned
+        cleanup_steps.append("empty_cache")
+        poisoned = False
+
+    monkeypatch.setattr(service, "_encode_batch", _encode_batch)
+    monkeypatch.setattr(encoder_service.torch.cuda, "device", _cuda_device)
+    monkeypatch.setattr(encoder_service.torch.cuda, "empty_cache", _empty_cache)
+    futures = [concurrent.futures.Future(), concurrent.futures.Future()]
+
+    service._process_batch(list(zip(items, futures)))
+
+    assert [future.result() for future in futures] == [None, None]
+    assert calls == [items, [items[0]], [items[1]]]
+    assert service._batch_count == 2
+    assert cleanup_steps == ["synchronize", "empty_cache"]
+    assert selected_devices == ["cuda:5"]
+    assert service._item_count == 2

--- a/tests/unit_test/moss_transcribe_diarize/test_encoder_service.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_encoder_service.py
@@ -213,3 +213,39 @@ def test_batched_oom_falls_back_to_per_item_encoding(
     assert cleanup_steps == ["synchronize", "empty_cache"]
     assert selected_devices == ["cuda:5"]
     assert service._item_count == 2
+
+
+def test_non_oom_failure_logs_traceback_without_retaining_exception_state(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    service = object.__new__(BatchedAudioEncoderService)
+    retained_intermediates: list[weakref.ReferenceType[_EncoderIntermediate]] = []
+
+    def _raise_non_oom_encoder_failure(_items: list[object]) -> None:
+        intermediate = _EncoderIntermediate()
+        retained_intermediates.append(weakref.ref(intermediate))
+        raise ValueError("unexpected encoder shape")
+
+    monkeypatch.setattr(service, "_encode_batch", _raise_non_oom_encoder_failure)
+    future: concurrent.futures.Future = concurrent.futures.Future()
+
+    service._process_batch([(object(), future)])
+
+    failure = future.exception()
+    assert isinstance(failure, ValueError)
+    assert failure.__traceback__ is None
+    assert failure.__cause__ is None
+    assert failure.__context__ is None
+
+    gc.collect()
+    assert retained_intermediates[0]() is None
+    message = "\n".join(record.getMessage() for record in caplog.records)
+    assert "Traceback (most recent call last):" in message
+    assert "_raise_non_oom_encoder_failure" in message
+    assert "ValueError: unexpected encoder shape" in message
+    assert all(record.exc_info is None for record in caplog.records)
+    assert all(
+        not any(isinstance(arg, BaseException) for arg in record.args)
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary

- keep MOSS-Transcribe-Diarize encoder item state transactional until the dedicated CUDA stream synchronizes successfully
- make a singleton encoder OOM request-scoped without retrying the same impossible allocation; retain per-item fallback for failed aggregate batches
- recover the allocator on the encoder stage's selected CUDA device
- format unexpected failure tracebacks for diagnostics, then detach live traceback/cause/context references before logging or publishing the request error
- cover the real queue/worker/`encode_item` future path, allocator cleanup ordering, buffered-log retention, failed-intermediate release, non-OOM traceback diagnostics, and follow-on request health

Closes #1201.

## Why

An asynchronous encoder OOM could surface at stream synchronization after `precomputed_embeddings` had already been published and `feature` cleared. The fallback then retried poisoned items, while raw exception tracebacks could retain failed encoder tensors. Under pressure this could cascade from one request failure into an unhealthy ASR stage.

Unexpected non-OOM encoder failures still need a complete traceback for diagnosis. The traceback is now formatted to text before live exception state is detached, preserving diagnostics without retaining failed tensor frames in futures or buffered log records.

The equivalent Fun-ASR pre-LM encoder lifecycle issue is tracked separately in #1301 so this PR remains model-local.

## Validation

- `python -m pytest tests/unit_test/moss_transcribe_diarize/test_encoder_service.py -q` — 6 passed
- full `tests/unit_test/moss_transcribe_diarize` suite — 60 passed, 14 skipped in the local CPU environment
- `pre-commit run --files sglang_omni/models/moss_transcribe_diarize/encoder_service.py tests/unit_test/moss_transcribe_diarize/test_encoder_service.py tests/README.md`

Real asynchronous CUDA OOM reclamation still requires the repository GPU lane; the unit tests model the poisoned-allocator, stream-publication, traceback-retention, and follow-on health contracts deterministically.
