### PR TITLE
[Cosmos03] Diffusion scheduling foundation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "datasets>=2.14.0",       # Arrow-based SeedTTS dataset loading
     "fastapi>=0.110.0",       # OpenAI-compatible API adapter
     "uvicorn>=0.23.0",        # ASGI server for FastAPI
-    "sglang==0.5.16",
+    "sglang[diffusion]==0.5.16",
     "flash-attn-4>=4.0.0b18",  # Required by SGLang 0.5.16; pairs with cutlass-dsl 4.6.0
     "kernels>=0.14.1,<0.15",  # Match the SGLang 0.5.16 stack
     "nixl-cu13>=1.1.0",  # CUDA 13 relay wheel; the generic nixl/-cu12 wheel breaks on cu130

--- a/sglang_omni/diffusion/__init__.py
+++ b/sglang_omni/diffusion/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Numerical diffusion helpers shared by Omni model integrations."""
+
+from sglang_omni.diffusion.flow_unipc import FlowUniPCSolver
+
+__all__ = ["FlowUniPCSolver"]

--- a/sglang_omni/diffusion/flow_unipc.py
+++ b/sglang_omni/diffusion/flow_unipc.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Request-local adapter for SGLang's flow-matching UniPC solver."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+
+def _load_scheduler_class() -> type[Any]:
+    # Keep the import lazy: importing SGLang's diffusion package initializes
+    # optional accelerator backends that ordinary Omni stages do not need.
+    from sglang.multimodal_gen.runtime.models.schedulers.scheduling_flow_unipc_multistep import (
+        FlowUniPCMultistepScheduler,
+    )
+
+    return FlowUniPCMultistepScheduler
+
+
+class FlowUniPCSolver:
+    """Own one mutable FlowUniPC chain for one request and one modality.
+
+    FlowUniPC keeps multistep history on the scheduler instance. Callers must
+    therefore create separate ``FlowUniPCSolver`` objects for concurrent
+    requests and for independently shaped modalities of the same request.
+    """
+
+    def __init__(self, scheduler: Any) -> None:
+        self._scheduler = scheduler
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        num_inference_steps: int,
+        device: str | torch.device,
+        shift: float = 1.0,
+        num_train_timesteps: int = 1000,
+        **scheduler_kwargs: Any,
+    ) -> FlowUniPCSolver:
+        """Create and initialize a request-local SGLang FlowUniPC solver."""
+
+        if num_inference_steps <= 0:
+            raise ValueError("num_inference_steps must be positive")
+
+        scheduler_class = _load_scheduler_class()
+        scheduler = scheduler_class(
+            num_train_timesteps=num_train_timesteps,
+            shift=float(shift),
+            **scheduler_kwargs,
+        )
+        scheduler.set_timesteps(
+            num_inference_steps,
+            device=device,
+            shift=float(shift),
+        )
+        return cls(scheduler)
+
+    @property
+    def timesteps(self) -> torch.Tensor:
+        return self._scheduler.timesteps
+
+    @property
+    def sigmas(self) -> torch.Tensor:
+        return self._scheduler.sigmas
+
+    @property
+    def step_index(self) -> int:
+        index = self._scheduler.step_index
+        return 0 if index is None else int(index)
+
+    @property
+    def is_finished(self) -> bool:
+        return self.step_index >= len(self.timesteps)
+
+    @property
+    def timestep(self) -> torch.Tensor:
+        if self.is_finished:
+            raise RuntimeError("FlowUniPC solver has already finished")
+        return self.timesteps[self.step_index]
+
+    def step(
+        self,
+        velocity: torch.Tensor,
+        sample: torch.Tensor,
+        *,
+        generator: torch.Generator | None = None,
+    ) -> torch.Tensor:
+        """Advance one FlowUniPC step using a flow-prediction velocity."""
+
+        timestep = self.timestep
+        return self._scheduler.step(
+            model_output=velocity,
+            timestep=timestep,
+            sample=sample,
+            return_dict=False,
+            generator=generator,
+        )[0]
+
+    def add_noise(
+        self,
+        original_samples: torch.Tensor,
+        noise: torch.Tensor,
+        timesteps: torch.Tensor,
+    ) -> torch.Tensor:
+        """Delegate scheduler-consistent noising for conditioned inputs."""
+
+        return self._scheduler.add_noise(original_samples, noise, timesteps)

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class ModelWorkerConfig:
     model_arch_override: str | None = None
+    model_weights_path: str | None = None
     weight_prefix: str | None = None
     nccl_port: int | None = None
     total_gpu_memory_fraction: float | None = None
@@ -55,6 +56,7 @@ class ModelWorker:
     ):
         self.server_args = server_args
         self.model_arch_override = config.model_arch_override
+        self.model_weights_path = config.model_weights_path
         self.weight_prefix = config.weight_prefix
         self.nccl_port = config.nccl_port
         self.total_gpu_memory_fraction = config.total_gpu_memory_fraction
@@ -108,6 +110,8 @@ class ModelWorker:
 
         if self.model_arch_override is not None:
             self._apply_arch_override(self.model_config, self.model_arch_override)
+        if self.model_weights_path is not None:
+            self.model_config.model_path = self.model_weights_path
 
     @staticmethod
     def _apply_arch_override(model_config: ModelConfig, arch: str) -> None:

--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -444,6 +444,7 @@ class SGLModelRunner(ModelRunner):
             "FunAsrNanoForConditionalGeneration": "sglang_omni.models.fun_asr.sglang_model:FunAsrNanoForConditionalGeneration",
             "ArkasrForConditionalGeneration": "sglang_omni.models.arkasr.sglang_model:ArkasrForConditionalGeneration",
             "DotsTTSForConditionalGeneration": "sglang_omni.models.dots_tts.sglang_model:DotsTTSSGLangModel",
+            "Cosmos3TextForCausalLM": "sglang_omni.models.cosmos3.components.sglang_text:Cosmos3TextForCausalLM",
         }
         for arch, path in sglang_omni_models.items():
             module_path, _, attr = path.partition(":")

--- a/sglang_omni/models/cosmos3/__init__.py
+++ b/sglang_omni/models/cosmos3/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cosmos3 model support."""
+
+from sglang_omni.models.cosmos3.hf_config import Cosmos3OmniConfig
+
+__all__ = ["Cosmos3OmniConfig"]

--- a/sglang_omni/models/cosmos3/bootstrap.py
+++ b/sglang_omni/models/cosmos3/bootstrap.py
@@ -3,7 +3,50 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
+
+from huggingface_hub import snapshot_download
+
+
+def _has_transformer_weights(path: Path | None) -> bool:
+    return path is not None and path.is_dir() and any(path.glob("*.safetensors"))
+
+
+def resolve_transformer_weights_path(model_path: str) -> str:
+    """Resolve the unified checkpoint's nested transformer component."""
+
+    local_path = Path(model_path)
+    if local_path.exists():
+        transformer_path = local_path / "transformer"
+    else:
+        allow_patterns = [
+            "transformer/*.json",
+            "transformer/*.safetensors",
+        ]
+        try:
+            snapshot_path = snapshot_download(
+                model_path,
+                allow_patterns=allow_patterns,
+                local_files_only=True,
+            )
+        except FileNotFoundError:
+            snapshot_path = None
+        transformer_path = (
+            Path(snapshot_path) / "transformer" if snapshot_path is not None else None
+        )
+        if not _has_transformer_weights(transformer_path):
+            snapshot_path = snapshot_download(
+                model_path,
+                allow_patterns=allow_patterns,
+            )
+            transformer_path = Path(snapshot_path) / "transformer"
+
+    if transformer_path is None or not _has_transformer_weights(transformer_path):
+        raise FileNotFoundError(
+            f"Cosmos3 transformer weights not found under {model_path!r}"
+        )
+    return str(transformer_path)
 
 
 def create_thinker_scheduler(
@@ -43,13 +86,14 @@ def create_thinker_scheduler(
         tp_rank=tp_rank,
         nccl_port=nccl_port,
         model_arch_override="Cosmos3TextForCausalLM",
+        model_weights_path=resolve_transformer_weights_path(server_args.model_path),
         total_gpu_memory_fraction=total_gpu_memory_fraction,
     )
 
     output_processor = SGLangOutputProcessor(capture_hidden=False)
     model_runner = ModelRunner(model_worker, output_processor)
     tokenizer = get_tokenizer(
-        model_config.model_path,
+        server_args.model_path,
         trust_remote_code=True,
     )
     request_builder, result_adapter = make_text_scheduler_adapters(
@@ -76,4 +120,4 @@ def create_thinker_scheduler(
     )
 
 
-__all__ = ["create_thinker_scheduler"]
+__all__ = ["create_thinker_scheduler", "resolve_transformer_weights_path"]

--- a/sglang_omni/models/cosmos3/bootstrap.py
+++ b/sglang_omni/models/cosmos3/bootstrap.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import Any
 
 
-def create_text_scheduler(
+def create_thinker_scheduler(
     server_args: Any,
     gpu_id: int = 0,
     *,
@@ -16,7 +16,7 @@ def create_text_scheduler(
     enable_async_decode: bool = False,
     async_decode_min_batch_size: int = 2,
 ):
-    """Create the SGLang-backed Cosmos3 text AR scheduler."""
+    """Create the SGLang-backed Cosmos3 thinker OmniScheduler."""
 
     from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 
@@ -76,4 +76,4 @@ def create_text_scheduler(
     )
 
 
-__all__ = ["create_text_scheduler"]
+__all__ = ["create_thinker_scheduler"]

--- a/sglang_omni/models/cosmos3/bootstrap.py
+++ b/sglang_omni/models/cosmos3/bootstrap.py
@@ -49,6 +49,42 @@ def resolve_transformer_weights_path(model_path: str) -> str:
     return str(transformer_path)
 
 
+def resolve_vision_encoder_path(model_path: str) -> str:
+    """Resolve the standalone Qwen3-VL vision checkpoint."""
+
+    local_path = Path(model_path)
+    if local_path.exists():
+        vision_path = local_path / "vision_encoder"
+    else:
+        allow_patterns = [
+            "config.json",
+            "vision_encoder/*.json",
+            "vision_encoder/*.safetensors",
+        ]
+        try:
+            snapshot_path = snapshot_download(
+                model_path,
+                allow_patterns=allow_patterns,
+                local_files_only=True,
+            )
+        except FileNotFoundError:
+            snapshot_path = None
+        vision_path = (
+            Path(snapshot_path) / "vision_encoder"
+            if snapshot_path is not None
+            else None
+        )
+        if not _has_transformer_weights(vision_path):
+            snapshot_path = snapshot_download(model_path, allow_patterns=allow_patterns)
+            vision_path = Path(snapshot_path) / "vision_encoder"
+
+    if vision_path is None or not _has_transformer_weights(vision_path):
+        raise FileNotFoundError(
+            f"Cosmos3 vision encoder weights not found under {model_path!r}"
+        )
+    return str(vision_path)
+
+
 def create_thinker_scheduler(
     server_args: Any,
     gpu_id: int = 0,
@@ -63,7 +99,7 @@ def create_thinker_scheduler(
 
     from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 
-    from sglang_omni.model_runner.base import ModelRunner
+    from sglang_omni.models.cosmos3.model_runner import Cosmos3ThinkerModelRunner
     from sglang_omni.models.cosmos3.request_builders import (
         make_text_scheduler_adapters,
         make_text_stream_output_builder,
@@ -91,7 +127,7 @@ def create_thinker_scheduler(
     )
 
     output_processor = SGLangOutputProcessor(capture_hidden=False)
-    model_runner = ModelRunner(model_worker, output_processor)
+    model_runner = Cosmos3ThinkerModelRunner(model_worker, output_processor)
     tokenizer = get_tokenizer(
         server_args.model_path,
         trust_remote_code=True,
@@ -100,6 +136,7 @@ def create_thinker_scheduler(
         tokenizer=tokenizer,
         vocab_size=model_config.vocab_size,
         generation_config=model_config.hf_generation_config,
+        thinker_config=model_config.hf_config,
     )
 
     return OmniScheduler(
@@ -120,4 +157,8 @@ def create_thinker_scheduler(
     )
 
 
-__all__ = ["create_thinker_scheduler", "resolve_transformer_weights_path"]
+__all__ = [
+    "create_thinker_scheduler",
+    "resolve_transformer_weights_path",
+    "resolve_vision_encoder_path",
+]

--- a/sglang_omni/models/cosmos3/bootstrap.py
+++ b/sglang_omni/models/cosmos3/bootstrap.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cosmos3 text scheduler construction."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def create_text_scheduler(
+    server_args: Any,
+    gpu_id: int = 0,
+    *,
+    tp_rank: int = 0,
+    nccl_port: int | None = None,
+    total_gpu_memory_fraction: float | None = None,
+    enable_async_decode: bool = False,
+    async_decode_min_batch_size: int = 2,
+):
+    """Create the SGLang-backed Cosmos3 text AR scheduler."""
+
+    from sglang.srt.utils.hf_transformers_utils import get_tokenizer
+
+    from sglang_omni.model_runner.base import ModelRunner
+    from sglang_omni.models.cosmos3.request_builders import (
+        make_text_scheduler_adapters,
+        make_text_stream_output_builder,
+    )
+    from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+    from sglang_omni.scheduling.sglang_backend import SGLangOutputProcessor
+
+    (
+        model_worker,
+        tree_cache,
+        req_to_token_pool,
+        token_to_kv_pool_allocator,
+        prefill_manager,
+        decode_manager,
+        model_config,
+    ) = create_sglang_infrastructure(
+        server_args,
+        gpu_id,
+        tp_rank=tp_rank,
+        nccl_port=nccl_port,
+        model_arch_override="Cosmos3TextForCausalLM",
+        total_gpu_memory_fraction=total_gpu_memory_fraction,
+    )
+
+    output_processor = SGLangOutputProcessor(capture_hidden=False)
+    model_runner = ModelRunner(model_worker, output_processor)
+    tokenizer = get_tokenizer(
+        model_config.model_path,
+        trust_remote_code=True,
+    )
+    request_builder, result_adapter = make_text_scheduler_adapters(
+        tokenizer=tokenizer,
+        vocab_size=model_config.vocab_size,
+        generation_config=model_config.hf_generation_config,
+    )
+
+    return OmniScheduler(
+        tp_worker=model_worker,
+        tree_cache=tree_cache,
+        req_to_token_pool=req_to_token_pool,
+        token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+        server_args=server_args,
+        model_config=model_config,
+        prefill_manager=prefill_manager,
+        decode_manager=decode_manager,
+        model_runner=model_runner,
+        request_builder=request_builder,
+        result_adapter=result_adapter,
+        stream_output_builder=make_text_stream_output_builder(),
+        enable_async_decode=enable_async_decode,
+        async_decode_min_batch_size=async_decode_min_batch_size,
+    )
+
+
+__all__ = ["create_text_scheduler"]

--- a/sglang_omni/models/cosmos3/components/__init__.py
+++ b/sglang_omni/models/cosmos3/components/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cosmos3 pipeline components."""
+
+from sglang_omni.models.cosmos3.components.text_preprocessor import (
+    Cosmos3TextPreprocessor,
+)
+
+__all__ = ["Cosmos3TextPreprocessor"]

--- a/sglang_omni/models/cosmos3/components/sglang_text.py
+++ b/sglang_omni/models/cosmos3/components/sglang_text.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SGLang text-only model wrapper for Cosmos3-Nano."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.models.qwen3 import Qwen3ForCausalLM
+
+_TEXT_ROOTS = ("embed_tokens.", "layers.", "norm.", "lm_head.")
+_GEN_WEIGHT_MARKERS = (
+    "_moe_gen",
+    ".add_k_proj.",
+    ".add_q_proj.",
+    ".add_v_proj.",
+    ".norm_added_k.",
+    ".norm_added_q.",
+    ".to_add_out.",
+)
+_ATTENTION_NAME_MAP = (
+    (".self_attn.to_q.", ".self_attn.q_proj."),
+    (".self_attn.to_k.", ".self_attn.k_proj."),
+    (".self_attn.to_v.", ".self_attn.v_proj."),
+    (".self_attn.to_out.", ".self_attn.o_proj."),
+    (".self_attn.norm_q.", ".self_attn.q_norm."),
+    (".self_attn.norm_k.", ".self_attn.k_norm."),
+)
+
+
+def resolve_cosmos3_text_positions(
+    positions: torch.Tensor,
+    forward_batch: Any,
+) -> torch.Tensor:
+    """Return Cosmos3's explicit three-axis text mRoPE positions.
+
+    Cosmos3 assigns the same monotonically increasing position to the
+    temporal, height, and width axes for every text token. SGLang computes
+    that ``[3, num_tokens]`` tensor on ``ForwardBatch`` for mRoPE models. The
+    fallback keeps direct/eager calls on the same contract instead of relying
+    on the numerically equivalent one-dimensional RoPE path.
+    """
+
+    mrope_positions = getattr(forward_batch, "mrope_positions", None)
+    if mrope_positions is None:
+        if positions.ndim == 1:
+            return positions.unsqueeze(0).expand(3, -1)
+        mrope_positions = positions
+    if mrope_positions.ndim != 2 or mrope_positions.shape[0] != 3:
+        raise ValueError(
+            "Cosmos3 text mRoPE positions must have shape [3, num_tokens], "
+            f"got {tuple(mrope_positions.shape)}"
+        )
+    return mrope_positions
+
+
+def map_cosmos3_text_weight_name(name: str) -> str | None:
+    """Map one flat Cosmos3 text tensor name to the SGLang Qwen3 tree.
+
+    The checkpoint interleaves UND/text and GEN tensors under ``layers.*``.
+    Returning ``None`` is intentional: those GEN tensors belong to a later
+    stage and must not reach Qwen3's packed-weight loader.
+    """
+
+    bare_name = name.removeprefix("model.")
+    if not bare_name.startswith(_TEXT_ROOTS):
+        return None
+    if any(marker in bare_name for marker in _GEN_WEIGHT_MARKERS):
+        return None
+
+    for source, target in _ATTENTION_NAME_MAP:
+        bare_name = bare_name.replace(source, target)
+    return bare_name
+
+
+class Cosmos3TextForCausalLM(Qwen3ForCausalLM):
+    """Cosmos3-Nano text model backed by SGLang's dense Qwen3 kernels."""
+
+    def __init__(
+        self,
+        config: Any,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        text_config = getattr(config, "text_config", config)
+        if hasattr(config, "tie_word_embeddings"):
+            text_config.tie_word_embeddings = bool(config.tie_word_embeddings)
+        super().__init__(
+            text_config,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+        self.root_config = config
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: Any,
+        input_embeds: torch.Tensor | None = None,
+        get_embedding: bool = False,
+        pp_proxy_tensors: Any = None,
+    ) -> torch.Tensor:
+        # Qwen3ForCausalLM normally consumes the scheduler's flat positions.
+        # Cosmos3 follows Qwen3-VL's explicit T/H/W text-position convention,
+        # so route SGLang's computed mRoPE positions into every decoder layer.
+        positions = resolve_cosmos3_text_positions(positions, forward_batch)
+        return super().forward(
+            input_ids=input_ids,
+            positions=positions,
+            forward_batch=forward_batch,
+            input_embeds=input_embeds,
+            get_embedding=get_embedding,
+            pp_proxy_tensors=pp_proxy_tensors,
+        )
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> Any:
+        mapped_weights = (
+            (mapped_name, loaded_weight)
+            for name, loaded_weight in weights
+            if (mapped_name := map_cosmos3_text_weight_name(name)) is not None
+        )
+        return super().load_weights(mapped_weights)
+
+
+EntryClass = Cosmos3TextForCausalLM
+
+__all__ = [
+    "Cosmos3TextForCausalLM",
+    "EntryClass",
+    "map_cosmos3_text_weight_name",
+    "resolve_cosmos3_text_positions",
+]

--- a/sglang_omni/models/cosmos3/components/sglang_text.py
+++ b/sglang_omni/models/cosmos3/components/sglang_text.py
@@ -8,7 +8,10 @@ from typing import Any
 
 import torch
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.models.qwen3 import Qwen3ForCausalLM
+
+from sglang_omni.models.cosmos3.hf_config import Cosmos3OmniConfig
 
 _TEXT_ROOTS = ("embed_tokens.", "layers.", "norm.", "lm_head.")
 _GEN_WEIGHT_MARKERS = (
@@ -31,29 +34,17 @@ _ATTENTION_NAME_MAP = (
 
 
 def resolve_cosmos3_text_positions(
-    positions: torch.Tensor,
-    forward_batch: Any,
+    forward_batch: ForwardBatch,
 ) -> torch.Tensor:
     """Return Cosmos3's explicit three-axis text mRoPE positions.
 
     Cosmos3 assigns the same monotonically increasing position to the
     temporal, height, and width axes for every text token. SGLang computes
     that ``[3, num_tokens]`` tensor on ``ForwardBatch`` for mRoPE models. The
-    fallback keeps direct/eager calls on the same contract instead of relying
-    on the numerically equivalent one-dimensional RoPE path.
+    scheduler populates that tensor before invoking the model.
     """
 
-    mrope_positions = getattr(forward_batch, "mrope_positions", None)
-    if mrope_positions is None:
-        if positions.ndim == 1:
-            return positions.unsqueeze(0).expand(3, -1)
-        mrope_positions = positions
-    if mrope_positions.ndim != 2 or mrope_positions.shape[0] != 3:
-        raise ValueError(
-            "Cosmos3 text mRoPE positions must have shape [3, num_tokens], "
-            f"got {tuple(mrope_positions.shape)}"
-        )
-    return mrope_positions
+    return forward_batch.mrope_positions
 
 
 def map_cosmos3_text_weight_name(name: str) -> str | None:
@@ -80,13 +71,12 @@ class Cosmos3TextForCausalLM(Qwen3ForCausalLM):
 
     def __init__(
         self,
-        config: Any,
+        config: Cosmos3OmniConfig,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ) -> None:
-        text_config = getattr(config, "text_config", config)
-        if hasattr(config, "tie_word_embeddings"):
-            text_config.tie_word_embeddings = bool(config.tie_word_embeddings)
+        text_config = config.text_config
+        text_config.tie_word_embeddings = bool(config.tie_word_embeddings)
         super().__init__(
             text_config,
             quant_config=quant_config,
@@ -107,7 +97,7 @@ class Cosmos3TextForCausalLM(Qwen3ForCausalLM):
         # Qwen3ForCausalLM normally consumes the scheduler's flat positions.
         # Cosmos3 follows Qwen3-VL's explicit T/H/W text-position convention,
         # so route SGLang's computed mRoPE positions into every decoder layer.
-        positions = resolve_cosmos3_text_positions(positions, forward_batch)
+        positions = resolve_cosmos3_text_positions(forward_batch)
         return super().forward(
             input_ids=input_ids,
             positions=positions,

--- a/sglang_omni/models/cosmos3/components/sglang_text.py
+++ b/sglang_omni/models/cosmos3/components/sglang_text.py
@@ -7,9 +7,17 @@ from collections.abc import Iterable
 from typing import Any
 
 import torch
+from sglang.srt.distributed import get_pp_group
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.pooler import Pooler, PoolingType
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.utils import PPMissingLayer
+from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.models.qwen3 import Qwen3ForCausalLM
+from sglang.srt.models.qwen3_vl import Qwen3LLMModel
+from sglang.srt.runtime_context import get_server_args
+from sglang.srt.utils import add_prefix
 
 from sglang_omni.models.cosmos3.hf_config import Cosmos3OmniConfig
 
@@ -75,13 +83,35 @@ class Cosmos3TextForCausalLM(Qwen3ForCausalLM):
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ) -> None:
+        torch.nn.Module.__init__(self)
         text_config = config.text_config
         text_config.tie_word_embeddings = bool(config.tie_word_embeddings)
-        super().__init__(
-            text_config,
+        text_config.vision_config = config.vision_config
+
+        self.pp_group = get_pp_group()
+        self.config = text_config
+        self.quant_config = quant_config
+        self.model = Qwen3LLMModel(
+            config=text_config,
             quant_config=quant_config,
-            prefix=prefix,
+            prefix=add_prefix("model", prefix),
         )
+        if self.pp_group.is_last_rank:
+            if self.pp_group.world_size == 1 and text_config.tie_word_embeddings:
+                self.lm_head = self.model.embed_tokens
+            else:
+                self.lm_head = ParallelLMHead(
+                    text_config.vocab_size,
+                    text_config.hidden_size,
+                    quant_config=quant_config,
+                    use_attn_tp_group=get_server_args().enable_dp_lm_head,
+                    prefix=add_prefix("lm_head", prefix),
+                )
+        else:
+            self.lm_head = PPMissingLayer()
+        self.logits_processor = LogitsProcessor(text_config)
+        self.pooler = Pooler(pooling_type=PoolingType.LAST, normalize=True)
+        self.capture_aux_hidden_states = False
         self.root_config = config
 
     @torch.no_grad()
@@ -89,8 +119,9 @@ class Cosmos3TextForCausalLM(Qwen3ForCausalLM):
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,
-        forward_batch: Any,
+        forward_batch: ForwardBatch,
         input_embeds: torch.Tensor | None = None,
+        input_deepstack_embeds: torch.Tensor | None = None,
         get_embedding: bool = False,
         pp_proxy_tensors: Any = None,
     ) -> torch.Tensor:
@@ -98,13 +129,36 @@ class Cosmos3TextForCausalLM(Qwen3ForCausalLM):
         # Cosmos3 follows Qwen3-VL's explicit T/H/W text-position convention,
         # so route SGLang's computed mRoPE positions into every decoder layer.
         positions = resolve_cosmos3_text_positions(forward_batch)
-        return super().forward(
-            input_ids=input_ids,
-            positions=positions,
-            forward_batch=forward_batch,
-            input_embeds=input_embeds,
-            get_embedding=get_embedding,
+        if input_deepstack_embeds is None:
+            return super().forward(
+                input_ids=input_ids,
+                positions=positions,
+                forward_batch=forward_batch,
+                input_embeds=input_embeds,
+                get_embedding=get_embedding,
+                pp_proxy_tensors=pp_proxy_tensors,
+            )
+        hidden_states = self.model(
+            input_ids,
+            positions,
+            forward_batch,
+            input_embeds,
             pp_proxy_tensors=pp_proxy_tensors,
+            input_deepstack_embeds=input_deepstack_embeds,
+        )
+        aux_hidden_states = None
+        if self.capture_aux_hidden_states:
+            hidden_states, aux_hidden_states = hidden_states
+        if not self.pp_group.is_last_rank:
+            return hidden_states
+        if get_embedding:
+            return self.pooler(hidden_states, forward_batch)
+        return self.logits_processor(
+            input_ids,
+            hidden_states,
+            self.lm_head,
+            forward_batch,
+            aux_hidden_states,
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> Any:

--- a/sglang_omni/models/cosmos3/components/streaming_detokenizer.py
+++ b/sglang_omni/models/cosmos3/components/streaming_detokenizer.py
@@ -9,13 +9,17 @@ import threading
 import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 from sglang_omni.models.cosmos3.components.text_preprocessor import (
     load_cosmos3_tokenizer,
 )
-from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
-from sglang_omni.models.cosmos3.request_builders import THINKER_STAGE
+from sglang_omni.models.cosmos3.payload_types import (
+    Cosmos3PipelineState,
+    PromptInputs,
+    TextOutput,
+)
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
 
@@ -113,12 +117,9 @@ class Cosmos3StreamingDetokenizer:
                 _STATE_MAX,
             )
 
-    def _on_stream_chunk(self, request_id: str, item: Any) -> None:
+    def _on_stream_chunk(self, request_id: str, item: StreamItem) -> None:
         with self._state_lock:
-            raw_token = item.data
-            token_id = (
-                int(raw_token.item()) if hasattr(raw_token, "item") else int(raw_token)
-            )
+            token_id = int(item.data.item())
             state = self._ensure_state(request_id)
             state.pending_tokens.append(token_id)
             candidate = self._tokenizer.decode(
@@ -207,11 +208,9 @@ class Cosmos3StreamingDetokenizer:
         is_streaming: bool,
     ) -> dict[str, Any]:
         state = Cosmos3PipelineState.from_dict(payload.data)
-        text_out = state.text_out or state.engine_outputs.get(THINKER_STAGE)
-        if not isinstance(text_out, dict):
-            text_out = {"output_ids": [], "is_final": True}
+        text_out = cast(TextOutput, state.text_out)
 
-        output_ids = list(text_out.get("output_ids") or [])
+        output_ids = text_out["output_ids"]
         result: dict[str, Any] = {"modality": "text"}
         if not is_streaming:
             result["text"] = self._tokenizer.decode(
@@ -223,14 +222,8 @@ class Cosmos3StreamingDetokenizer:
             if text_out.get(key) is not None:
                 result[key] = text_out[key]
 
-        input_ids = (
-            state.prompt.get("input_ids") if isinstance(state.prompt, dict) else None
-        )
-        prompt_tokens = (
-            int(input_ids.numel())
-            if hasattr(input_ids, "numel")
-            else len(input_ids or [])
-        )
+        prompt = cast(PromptInputs, state.prompt)
+        prompt_tokens = int(prompt["input_ids"].numel())
         result["usage"] = {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": len(output_ids),

--- a/sglang_omni/models/cosmos3/components/streaming_detokenizer.py
+++ b/sglang_omni/models/cosmos3/components/streaming_detokenizer.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Streaming text detokenizer for the Cosmos3 AR pipeline."""
+
+from __future__ import annotations
+
+import logging
+import queue as queue_mod
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Any
+
+from sglang_omni.models.cosmos3.components.text_preprocessor import (
+    load_cosmos3_tokenizer,
+)
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.models.cosmos3.request_builders import THINKER_STAGE
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
+
+logger = logging.getLogger(__name__)
+
+_DONE_SEEN_MAX = 10000
+_DONE_SEEN_EVICT_TO = 5000
+
+
+@dataclass
+class _RequestState:
+    pending_tokens: list[int] = field(default_factory=list)
+    payload: StagePayload | None = None
+    done: bool = False
+
+
+class Cosmos3StreamingDetokenizer:
+    """Decode per-token stream messages and the terminal AR payload."""
+
+    def __init__(self, tokenizer: Any, *, stage_name: str = "decode") -> None:
+        self.inbox: queue_mod.Queue[IncomingMessage] = queue_mod.Queue()
+        self.outbox: queue_mod.Queue[OutgoingMessage] = queue_mod.Queue()
+        self.stage_name = stage_name
+        self._tokenizer = tokenizer
+        self._running = False
+        self._state: dict[str, _RequestState] = {}
+        self._done_seen: OrderedDict[str, None] = OrderedDict()
+
+    def start(self) -> None:
+        self._running = True
+        while self._running:
+            try:
+                message = self.inbox.get(timeout=0.1)
+            except queue_mod.Empty:
+                continue
+            try:
+                if message.type == "new_request":
+                    self._on_new_request(message.request_id, message.data)
+                elif message.type == "stream_chunk":
+                    self._on_stream_chunk(message.request_id, message.data)
+                elif message.type == "stream_done":
+                    self._on_stream_done(message.request_id)
+            except Exception as exc:
+                logger.exception(
+                    "Cosmos3 detokenizer failed request %s", message.request_id
+                )
+                self.abort(message.request_id)
+                self.outbox.put(
+                    OutgoingMessage(
+                        request_id=message.request_id,
+                        type="error",
+                        data=exc,
+                    )
+                )
+
+    def stop(self) -> None:
+        self._running = False
+
+    def abort(self, request_id: str) -> None:
+        self._state.pop(request_id, None)
+        self._done_seen.pop(request_id, None)
+
+    def _ensure_state(self, request_id: str) -> _RequestState:
+        state = self._state.get(request_id)
+        if state is None:
+            state = _RequestState()
+            self._state[request_id] = state
+        return state
+
+    def _on_stream_chunk(self, request_id: str, item: Any) -> None:
+        raw_token = item.data
+        token_id = (
+            int(raw_token.item()) if hasattr(raw_token, "item") else int(raw_token)
+        )
+        state = self._ensure_state(request_id)
+        state.pending_tokens.append(token_id)
+        candidate = self._tokenizer.decode(
+            state.pending_tokens,
+            skip_special_tokens=True,
+        )
+        if "\ufffd" in candidate:
+            return
+        state.pending_tokens.clear()
+        if not candidate:
+            return
+        self._emit_text(request_id, candidate)
+
+    def _emit_text(self, request_id: str, text: str) -> None:
+        self.outbox.put(
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                target=None,
+                data={
+                    "text": text,
+                    "modality": "text",
+                    "stage_name": self.stage_name,
+                },
+                metadata={"modality": "text"},
+            )
+        )
+
+    def _on_stream_done(self, request_id: str) -> None:
+        state = self._state.get(request_id)
+        if state is None:
+            self._done_seen[request_id] = None
+            if len(self._done_seen) > _DONE_SEEN_MAX:
+                for _ in range(len(self._done_seen) - _DONE_SEEN_EVICT_TO):
+                    self._done_seen.popitem(last=False)
+            return
+        state.done = True
+        if state.payload is not None:
+            self._finalize(request_id)
+
+    def _on_new_request(self, request_id: str, payload: StagePayload) -> None:
+        state = self._ensure_state(request_id)
+        state.payload = payload
+        if request_id in self._done_seen:
+            state.done = True
+            self._done_seen.pop(request_id, None)
+        is_streaming = bool((payload.request.params or {}).get("stream", False))
+        if state.done or not is_streaming:
+            self._finalize(request_id)
+
+    def _finalize(self, request_id: str) -> None:
+        state = self._state.pop(request_id, None)
+        self._done_seen.pop(request_id, None)
+        if state is None or state.payload is None:
+            return
+        if state.pending_tokens:
+            trailing_text = self._tokenizer.decode(
+                state.pending_tokens,
+                skip_special_tokens=True,
+            )
+            if trailing_text:
+                self._emit_text(request_id, trailing_text)
+
+        is_streaming = bool((state.payload.request.params or {}).get("stream", False))
+        state.payload.data = self._build_result(
+            state.payload,
+            is_streaming=is_streaming,
+        )
+        self.outbox.put(
+            OutgoingMessage(
+                request_id=request_id,
+                type="result",
+                data=state.payload,
+            )
+        )
+
+    def _build_result(
+        self,
+        payload: StagePayload,
+        *,
+        is_streaming: bool,
+    ) -> dict[str, Any]:
+        state = Cosmos3PipelineState.from_dict(payload.data)
+        text_out = state.text_out or state.engine_outputs.get(THINKER_STAGE)
+        if not isinstance(text_out, dict):
+            text_out = {"output_ids": [], "is_final": True}
+
+        output_ids = list(text_out.get("output_ids") or [])
+        result: dict[str, Any] = {"modality": "text"}
+        if not is_streaming:
+            result["text"] = self._tokenizer.decode(
+                output_ids,
+                skip_special_tokens=True,
+            )
+
+        for key in ("finish_reason", "output_token_logprobs", "weight_version"):
+            if text_out.get(key) is not None:
+                result[key] = text_out[key]
+
+        input_ids = (
+            state.prompt.get("input_ids") if isinstance(state.prompt, dict) else None
+        )
+        prompt_tokens = (
+            int(input_ids.numel())
+            if hasattr(input_ids, "numel")
+            else len(input_ids or [])
+        )
+        result["usage"] = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": len(output_ids),
+            "total_tokens": prompt_tokens + len(output_ids),
+        }
+        return result
+
+
+def create_streaming_detokenize_scheduler(
+    model_path: str,
+    *,
+    stage_name: str = "decode",
+) -> Cosmos3StreamingDetokenizer:
+    return Cosmos3StreamingDetokenizer(
+        tokenizer=load_cosmos3_tokenizer(model_path),
+        stage_name=stage_name,
+    )
+
+
+__all__ = [
+    "Cosmos3StreamingDetokenizer",
+    "create_streaming_detokenize_scheduler",
+]

--- a/sglang_omni/models/cosmos3/components/streaming_detokenizer.py
+++ b/sglang_omni/models/cosmos3/components/streaming_detokenizer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import queue as queue_mod
+import threading
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import Any
@@ -41,6 +42,8 @@ class Cosmos3StreamingDetokenizer:
         self._running = False
         self._state: dict[str, _RequestState] = {}
         self._done_seen: OrderedDict[str, None] = OrderedDict()
+        # Stage aborts run on the event-loop thread while handlers run here.
+        self._state_lock = threading.RLock()
 
     def start(self) -> None:
         self._running = True
@@ -73,33 +76,36 @@ class Cosmos3StreamingDetokenizer:
         self._running = False
 
     def abort(self, request_id: str) -> None:
-        self._state.pop(request_id, None)
-        self._done_seen.pop(request_id, None)
+        with self._state_lock:
+            self._state.pop(request_id, None)
+            self._done_seen.pop(request_id, None)
 
     def _ensure_state(self, request_id: str) -> _RequestState:
-        state = self._state.get(request_id)
-        if state is None:
-            state = _RequestState()
-            self._state[request_id] = state
-        return state
+        with self._state_lock:
+            state = self._state.get(request_id)
+            if state is None:
+                state = _RequestState()
+                self._state[request_id] = state
+            return state
 
     def _on_stream_chunk(self, request_id: str, item: Any) -> None:
-        raw_token = item.data
-        token_id = (
-            int(raw_token.item()) if hasattr(raw_token, "item") else int(raw_token)
-        )
-        state = self._ensure_state(request_id)
-        state.pending_tokens.append(token_id)
-        candidate = self._tokenizer.decode(
-            state.pending_tokens,
-            skip_special_tokens=True,
-        )
-        if candidate.endswith("\ufffd"):
-            return
-        state.pending_tokens.clear()
-        if not candidate:
-            return
-        self._emit_text(request_id, candidate)
+        with self._state_lock:
+            raw_token = item.data
+            token_id = (
+                int(raw_token.item()) if hasattr(raw_token, "item") else int(raw_token)
+            )
+            state = self._ensure_state(request_id)
+            state.pending_tokens.append(token_id)
+            candidate = self._tokenizer.decode(
+                state.pending_tokens,
+                skip_special_tokens=True,
+            )
+            if candidate.endswith("\ufffd"):
+                return
+            state.pending_tokens.clear()
+            if not candidate:
+                return
+            self._emit_text(request_id, candidate)
 
     def _emit_text(self, request_id: str, text: str) -> None:
         self.outbox.put(
@@ -117,52 +123,57 @@ class Cosmos3StreamingDetokenizer:
         )
 
     def _on_stream_done(self, request_id: str) -> None:
-        state = self._state.get(request_id)
-        if state is None:
-            self._done_seen[request_id] = None
-            if len(self._done_seen) > _DONE_SEEN_MAX:
-                for _ in range(len(self._done_seen) - _DONE_SEEN_EVICT_TO):
-                    self._done_seen.popitem(last=False)
-            return
-        state.done = True
-        if state.payload is not None:
-            self._finalize(request_id)
+        with self._state_lock:
+            state = self._state.get(request_id)
+            if state is None:
+                self._done_seen[request_id] = None
+                if len(self._done_seen) > _DONE_SEEN_MAX:
+                    for _ in range(len(self._done_seen) - _DONE_SEEN_EVICT_TO):
+                        self._done_seen.popitem(last=False)
+                return
+            state.done = True
+            if state.payload is not None:
+                self._finalize(request_id)
 
     def _on_new_request(self, request_id: str, payload: StagePayload) -> None:
-        state = self._ensure_state(request_id)
-        state.payload = payload
-        if request_id in self._done_seen:
-            state.done = True
-            self._done_seen.pop(request_id, None)
-        is_streaming = bool((payload.request.params or {}).get("stream", False))
-        if state.done or not is_streaming:
-            self._finalize(request_id)
+        with self._state_lock:
+            state = self._ensure_state(request_id)
+            state.payload = payload
+            if request_id in self._done_seen:
+                state.done = True
+                self._done_seen.pop(request_id, None)
+            is_streaming = bool((payload.request.params or {}).get("stream", False))
+            if state.done or not is_streaming:
+                self._finalize(request_id)
 
     def _finalize(self, request_id: str) -> None:
-        state = self._state.pop(request_id, None)
-        self._done_seen.pop(request_id, None)
-        if state is None or state.payload is None:
-            return
-        if state.pending_tokens:
-            trailing_text = self._tokenizer.decode(
-                state.pending_tokens,
-                skip_special_tokens=True,
-            )
-            if trailing_text:
-                self._emit_text(request_id, trailing_text)
+        with self._state_lock:
+            state = self._state.pop(request_id, None)
+            self._done_seen.pop(request_id, None)
+            if state is None or state.payload is None:
+                return
+            if state.pending_tokens:
+                trailing_text = self._tokenizer.decode(
+                    state.pending_tokens,
+                    skip_special_tokens=True,
+                )
+                if trailing_text:
+                    self._emit_text(request_id, trailing_text)
 
-        is_streaming = bool((state.payload.request.params or {}).get("stream", False))
-        state.payload.data = self._build_result(
-            state.payload,
-            is_streaming=is_streaming,
-        )
-        self.outbox.put(
-            OutgoingMessage(
-                request_id=request_id,
-                type="result",
-                data=state.payload,
+            is_streaming = bool(
+                (state.payload.request.params or {}).get("stream", False)
             )
-        )
+            state.payload.data = self._build_result(
+                state.payload,
+                is_streaming=is_streaming,
+            )
+            self.outbox.put(
+                OutgoingMessage(
+                    request_id=request_id,
+                    type="result",
+                    data=state.payload,
+                )
+            )
 
     def _build_result(
         self,

--- a/sglang_omni/models/cosmos3/components/streaming_detokenizer.py
+++ b/sglang_omni/models/cosmos3/components/streaming_detokenizer.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 import queue as queue_mod
 import threading
+import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import Any
@@ -22,6 +23,8 @@ logger = logging.getLogger(__name__)
 
 _DONE_SEEN_MAX = 10000
 _DONE_SEEN_EVICT_TO = 5000
+_STATE_MAX = 10000
+_STATE_ORPHAN_IDLE_S = 300.0
 
 
 @dataclass
@@ -29,6 +32,7 @@ class _RequestState:
     pending_tokens: list[int] = field(default_factory=list)
     payload: StagePayload | None = None
     done: bool = False
+    last_seen: float = 0.0
 
 
 class Cosmos3StreamingDetokenizer:
@@ -82,11 +86,32 @@ class Cosmos3StreamingDetokenizer:
 
     def _ensure_state(self, request_id: str) -> _RequestState:
         with self._state_lock:
+            now = time.monotonic()
             state = self._state.get(request_id)
             if state is None:
-                state = _RequestState()
+                state = _RequestState(last_seen=now)
                 self._state[request_id] = state
+            state.last_seen = now
+            if len(self._state) > _STATE_MAX:
+                self._evict_idle_orphans(now)
             return state
+
+    def _evict_idle_orphans(self, now: float) -> None:
+        cutoff = now - _STATE_ORPHAN_IDLE_S
+        with self._state_lock:
+            stale = [
+                request_id
+                for request_id, state in self._state.items()
+                if state.payload is None and not state.done and state.last_seen < cutoff
+            ]
+            for request_id in stale:
+                self._state.pop(request_id, None)
+        if stale:
+            logger.warning(
+                "Evicted %d idle orphan stream states (cap %d exceeded)",
+                len(stale),
+                _STATE_MAX,
+            )
 
     def _on_stream_chunk(self, request_id: str, item: Any) -> None:
         with self._state_lock:

--- a/sglang_omni/models/cosmos3/components/streaming_detokenizer.py
+++ b/sglang_omni/models/cosmos3/components/streaming_detokenizer.py
@@ -94,7 +94,7 @@ class Cosmos3StreamingDetokenizer:
             state.pending_tokens,
             skip_special_tokens=True,
         )
-        if "\ufffd" in candidate:
+        if candidate.endswith("\ufffd"):
             return
         state.pending_tokens.clear()
         if not candidate:

--- a/sglang_omni/models/cosmos3/components/text_preprocessor.py
+++ b/sglang_omni/models/cosmos3/components/text_preprocessor.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Text-only preprocessing for Cosmos3-Nano."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import torch
+from transformers import AutoTokenizer
+
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.preprocessing.text import ensure_chat_template
+from sglang_omni.proto import StagePayload
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_NEW_TOKENS = 2048
+_MEDIA_INPUT_KEYS = ("images", "videos", "audios")
+
+
+def load_cosmos3_tokenizer(model_path: str) -> Any:
+    """Load tokenizer assets without hydrating the checkpoint weights."""
+
+    local_only = Path(model_path).exists()
+    if not local_only:
+        try:
+            return AutoTokenizer.from_pretrained(
+                model_path,
+                trust_remote_code=True,
+                local_files_only=True,
+            )
+        except (OSError, ValueError):
+            pass
+    return AutoTokenizer.from_pretrained(
+        model_path,
+        trust_remote_code=True,
+        local_files_only=local_only,
+    )
+
+
+def _normalize_text_messages(inputs: Any) -> list[dict[str, str]]:
+    if isinstance(inputs, dict):
+        populated_media = [key for key in _MEDIA_INPUT_KEYS if inputs.get(key)]
+        if populated_media:
+            raise ValueError(
+                "Cosmos3 text preprocessing does not support media inputs yet: "
+                + ", ".join(populated_media)
+            )
+        if "messages" not in inputs:
+            raise ValueError("Cosmos3 text preprocessing expects a messages field")
+        inputs = inputs["messages"]
+
+    if not isinstance(inputs, list) or not inputs:
+        raise ValueError(
+            "Cosmos3 text preprocessing expects a non-empty list of chat messages"
+        )
+
+    messages: list[dict[str, str]] = []
+    for index, message in enumerate(inputs):
+        if not isinstance(message, dict):
+            raise TypeError(f"Message {index} must be a dict with role/content")
+        role = message.get("role")
+        content = message.get("content")
+        if not isinstance(role, str) or not role:
+            raise ValueError(f"Message {index} must have a non-empty string role")
+        if not isinstance(content, str):
+            raise TypeError(
+                f"Message {index} content must be a string; multimodal content "
+                "will be added in a later Cosmos3 stage"
+            )
+        messages.append({"role": role, "content": content})
+    return messages
+
+
+def _reject_media_inputs(container: Any) -> None:
+    if not isinstance(container, dict):
+        return
+    populated_media = [key for key in _MEDIA_INPUT_KEYS if container.get(key)]
+    if populated_media:
+        raise ValueError(
+            "Cosmos3 text preprocessing does not support media inputs yet: "
+            + ", ".join(populated_media)
+        )
+
+
+def _flatten_single_batch(value: Any, *, name: str) -> torch.Tensor:
+    tensor = value if isinstance(value, torch.Tensor) else torch.as_tensor(value)
+    if tensor.ndim == 2:
+        if tensor.shape[0] != 1:
+            raise ValueError(f"Tokenizer returned batched {name}; expected one prompt")
+        tensor = tensor[0]
+    if tensor.ndim != 1:
+        raise ValueError(
+            f"Tokenizer returned invalid {name} shape {tuple(tensor.shape)}"
+        )
+    return tensor.to(dtype=torch.long)
+
+
+def validate_prompt_seq_len(
+    input_ids: torch.Tensor,
+    *,
+    max_seq_len: int | None,
+    max_new_tokens: int = DEFAULT_MAX_NEW_TOKENS,
+    request_id: str | None = None,
+) -> None:
+    """Apply the same prompt budget contract as the existing AR pipelines."""
+
+    if max_seq_len is None:
+        return
+    prompt_len = int(input_ids.numel())
+    if prompt_len >= max_seq_len:
+        logger.info(
+            "rejecting request %s: prompt %d tokens >= max_seq_len %d",
+            request_id,
+            prompt_len,
+            max_seq_len,
+        )
+        raise ValueError(
+            f"The input ({prompt_len} tokens) is longer than the model's "
+            f"context length ({max_seq_len} tokens)."
+        )
+
+    total_tokens = prompt_len + int(max_new_tokens)
+    if total_tokens >= max_seq_len:
+        logger.info(
+            "rejecting request %s: prompt %d + max_new_tokens %d >= max_seq_len %d",
+            request_id,
+            prompt_len,
+            int(max_new_tokens),
+            max_seq_len,
+        )
+        raise ValueError(
+            "Requested token count exceeds the model's maximum context length "
+            f"of {max_seq_len} tokens. You requested {prompt_len} prompt tokens "
+            f"and {int(max_new_tokens)} completion tokens."
+        )
+
+
+class Cosmos3TextPreprocessor:
+    """Build a tokenizer-only Cosmos3 pipeline state on CPU."""
+
+    def __init__(
+        self,
+        model_path: str,
+        max_seq_len: int | None = None,
+        *,
+        tokenizer: Any | None = None,
+    ) -> None:
+        self.model_path = model_path
+        self.max_seq_len = max_seq_len
+        self.tokenizer = (
+            tokenizer if tokenizer is not None else load_cosmos3_tokenizer(model_path)
+        )
+        ensure_chat_template(self.tokenizer, model_path=model_path)
+        if not getattr(self.tokenizer, "chat_template", None):
+            raise ValueError(
+                f"Tokenizer for {model_path!r} does not define a chat template"
+            )
+
+    def _tokenize_messages(self, inputs: Any) -> tuple[torch.Tensor, torch.Tensor, str]:
+        messages = _normalize_text_messages(inputs)
+        prompt_text = self.tokenizer.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        encoded = self.tokenizer(
+            prompt_text,
+            add_special_tokens=False,
+            return_tensors="pt",
+        )
+        input_ids = _flatten_single_batch(encoded["input_ids"], name="input_ids")
+        raw_attention_mask = encoded.get("attention_mask")
+        attention_mask = (
+            torch.ones_like(input_ids)
+            if raw_attention_mask is None
+            else _flatten_single_batch(raw_attention_mask, name="attention_mask")
+        )
+        if attention_mask.shape != input_ids.shape:
+            raise ValueError("Tokenizer returned mismatched input_ids/attention_mask")
+        return input_ids, attention_mask, prompt_text
+
+    @staticmethod
+    def _use_pretokenized_inputs(inputs: Any) -> bool:
+        return (
+            isinstance(inputs, list)
+            and bool(inputs)
+            and all(isinstance(token_id, int) for token_id in inputs)
+        )
+
+    def __call__(self, payload: StagePayload) -> StagePayload:
+        # The OpenAI adapter places top-level media fields in metadata rather
+        # than request.inputs. Keep the first Cosmos3 slice strictly text-only
+        # regardless of which entry point constructed the OmniRequest.
+        _reject_media_inputs(payload.request.metadata)
+        inputs = payload.request.inputs
+        if self._use_pretokenized_inputs(inputs):
+            input_ids = torch.tensor(inputs, dtype=torch.long)
+            attention_mask = torch.ones_like(input_ids)
+            prompt_text = ""
+        else:
+            input_ids, attention_mask, prompt_text = self._tokenize_messages(inputs)
+
+        max_new_tokens = payload.request.params.get(
+            "max_new_tokens", DEFAULT_MAX_NEW_TOKENS
+        )
+        if max_new_tokens is None:
+            max_new_tokens = DEFAULT_MAX_NEW_TOKENS
+        validate_prompt_seq_len(
+            input_ids,
+            max_seq_len=self.max_seq_len,
+            max_new_tokens=int(max_new_tokens),
+            request_id=payload.request_id,
+        )
+
+        state = Cosmos3PipelineState(
+            prompt={
+                "input_ids": input_ids,
+                "attention_mask": attention_mask,
+                "prompt_text": prompt_text,
+            },
+            stream_state={"token_ids": [], "text": ""},
+        )
+        payload.data = state.to_dict()
+        payload.request.inputs = None
+        return payload
+
+
+__all__ = [
+    "DEFAULT_MAX_NEW_TOKENS",
+    "Cosmos3TextPreprocessor",
+    "load_cosmos3_tokenizer",
+    "validate_prompt_seq_len",
+]

--- a/sglang_omni/models/cosmos3/components/text_preprocessor.py
+++ b/sglang_omni/models/cosmos3/components/text_preprocessor.py
@@ -1,23 +1,30 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Text-only preprocessing for Cosmos3-Nano."""
+"""Text and vision preprocessing for Cosmos3-Nano."""
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import Any
 
 import torch
-from transformers import AutoTokenizer
+from transformers import AutoProcessor, AutoTokenizer
 
 from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.preprocessing import (
+    compute_image_cache_key,
+    compute_video_cache_key,
+    ensure_image_list_async,
+    ensure_video_list_async,
+)
 from sglang_omni.preprocessing.text import ensure_chat_template
 from sglang_omni.proto import StagePayload
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_NEW_TOKENS = 2048
-_MEDIA_INPUT_KEYS = ("images", "videos", "audios")
+VISION_STAGE = "vision_encoder"
 
 
 def load_cosmos3_tokenizer(model_path: str) -> Any:
@@ -40,14 +47,28 @@ def load_cosmos3_tokenizer(model_path: str) -> Any:
     )
 
 
+def load_cosmos3_processor(model_path: str) -> Any:
+    """Load the Qwen3-VL processor shipped with Cosmos3-Nano."""
+
+    local_only = Path(model_path).exists()
+    if not local_only:
+        try:
+            return AutoProcessor.from_pretrained(
+                model_path,
+                trust_remote_code=True,
+                local_files_only=True,
+            )
+        except (OSError, ValueError):
+            pass
+    return AutoProcessor.from_pretrained(
+        model_path,
+        trust_remote_code=True,
+        local_files_only=local_only,
+    )
+
+
 def _normalize_text_messages(inputs: Any) -> list[dict[str, str]]:
     if isinstance(inputs, dict):
-        populated_media = [key for key in _MEDIA_INPUT_KEYS if inputs.get(key)]
-        if populated_media:
-            raise ValueError(
-                "Cosmos3 text preprocessing does not support media inputs yet: "
-                + ", ".join(populated_media)
-            )
         if "messages" not in inputs:
             raise ValueError("Cosmos3 text preprocessing expects a messages field")
         inputs = inputs["messages"]
@@ -68,19 +89,10 @@ def _normalize_text_messages(inputs: Any) -> list[dict[str, str]]:
         if not isinstance(content, str):
             raise TypeError(
                 f"Message {index} content must be a string; multimodal content "
-                "will be added in a later Cosmos3 stage"
+                "must be passed with top-level images/videos"
             )
         messages.append({"role": role, "content": content})
     return messages
-
-
-def _reject_media_inputs(container: dict[str, Any]) -> None:
-    populated_media = [key for key in _MEDIA_INPUT_KEYS if container.get(key)]
-    if populated_media:
-        raise ValueError(
-            "Cosmos3 text preprocessing does not support media inputs yet: "
-            + ", ".join(populated_media)
-        )
 
 
 def _flatten_single_batch(value: torch.Tensor) -> torch.Tensor:
@@ -128,7 +140,7 @@ def validate_prompt_seq_len(
 
 
 class Cosmos3TextPreprocessor:
-    """Build a tokenizer-only Cosmos3 pipeline state on CPU."""
+    """Build the Cosmos3 prompt and standalone vision-encoder inputs on CPU."""
 
     def __init__(
         self,
@@ -136,11 +148,19 @@ class Cosmos3TextPreprocessor:
         max_seq_len: int | None = None,
         *,
         tokenizer: Any | None = None,
+        processor: Any | None = None,
+        enable_vision: bool = True,
     ) -> None:
         self.model_path = model_path
         self.max_seq_len = max_seq_len
-        self.tokenizer = (
-            tokenizer if tokenizer is not None else load_cosmos3_tokenizer(model_path)
+        self.enable_vision = enable_vision
+        self.processor = processor
+        if self.processor is None and tokenizer is None and enable_vision:
+            self.processor = load_cosmos3_processor(model_path)
+        self.tokenizer = tokenizer or (
+            self.processor.tokenizer
+            if self.processor is not None
+            else load_cosmos3_tokenizer(model_path)
         )
         ensure_chat_template(self.tokenizer, model_path=model_path)
         if not self.tokenizer.chat_template:
@@ -170,6 +190,129 @@ class Cosmos3TextPreprocessor:
         return input_ids, attention_mask, prompt_text
 
     @staticmethod
+    def _multimodal_messages(
+        messages: list[dict[str, str]],
+        *,
+        num_images: int,
+        num_videos: int,
+    ) -> list[dict[str, Any]]:
+        if num_images == 0 and num_videos == 0:
+            return messages
+
+        result: list[dict[str, Any]] = []
+        target = max(
+            (
+                index
+                for index, message in enumerate(messages)
+                if message["role"] == "user"
+            ),
+            default=len(messages) - 1,
+        )
+        for index, message in enumerate(messages):
+            if index != target:
+                result.append(message)
+                continue
+            content: list[dict[str, str]] = []
+            content.extend({"type": "image"} for _ in range(num_images))
+            content.extend({"type": "video"} for _ in range(num_videos))
+            content.append({"type": "text", "text": message["content"]})
+            result.append({"role": message["role"], "content": content})
+        return result
+
+    async def _tokenize_multimodal(
+        self,
+        inputs: dict[str, Any],
+    ) -> tuple[dict[str, torch.Tensor], str, str | None]:
+        if self.processor is None:
+            raise ValueError("Cosmos3 media inputs require the checkpoint processor")
+
+        raw_images = inputs.get("images")
+        raw_videos = inputs.get("videos") or inputs.get("video")
+        video_fps = inputs.get("video_fps")
+        video_max_frames = inputs.get("video_max_frames")
+        video_min_pixels = inputs.get("video_min_pixels")
+        video_max_pixels = inputs.get("video_max_pixels")
+        video_total_pixels = inputs.get("video_total_pixels")
+        image_cache_key = compute_image_cache_key(raw_images)
+        video_cache_key = compute_video_cache_key(raw_videos)
+
+        images, video_result = await asyncio.gather(
+            ensure_image_list_async(raw_images),
+            ensure_video_list_async(
+                raw_videos,
+                fps=float(video_fps) if video_fps is not None else None,
+                max_frames=(
+                    int(video_max_frames) if video_max_frames is not None else None
+                ),
+                min_pixels=(
+                    int(video_min_pixels) if video_min_pixels is not None else None
+                ),
+                max_pixels=(
+                    int(video_max_pixels) if video_max_pixels is not None else None
+                ),
+                total_pixels=(
+                    int(video_total_pixels) if video_total_pixels is not None else None
+                ),
+            ),
+        )
+        videos, sampled_fps, _ = video_result
+        messages = _normalize_text_messages(inputs)
+        messages_mm = self._multimodal_messages(
+            messages,
+            num_images=len(images),
+            num_videos=len(videos),
+        )
+        prompt_text = self.processor.apply_chat_template(
+            messages_mm,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        processor_kwargs: dict[str, Any] = {}
+        if videos:
+            videos_kwargs: dict[str, Any] = {"device": "cpu"}
+            if sampled_fps:
+                videos_kwargs["fps"] = (
+                    sampled_fps[0] if len(sampled_fps) == 1 else sampled_fps
+                )
+            elif video_fps is not None:
+                videos_kwargs["fps"] = float(video_fps)
+            if video_max_frames is not None:
+                videos_kwargs["max_frames"] = int(video_max_frames)
+            if video_min_pixels is not None:
+                videos_kwargs["min_pixels"] = int(video_min_pixels)
+            if video_max_pixels is not None:
+                videos_kwargs["max_pixels"] = int(video_max_pixels)
+            if video_total_pixels is not None:
+                videos_kwargs["total_pixels"] = int(video_total_pixels)
+            processor_kwargs["videos_kwargs"] = videos_kwargs
+
+        encoded = self.processor(
+            text=prompt_text,
+            images=images or None,
+            videos=videos or None,
+            add_special_tokens=False,
+            return_tensors="pt",
+            **processor_kwargs,
+        )
+        if video_cache_key is not None:
+            effective_fps = tuple(sampled_fps or ()) or (
+                (float(video_fps),) if video_fps is not None else None
+            )
+            video_cache_key = "|".join(
+                str(part)
+                for part in (
+                    video_cache_key,
+                    f"fps={effective_fps}",
+                    f"max_frames={video_max_frames}",
+                    f"min_pixels={video_min_pixels}",
+                    f"max_pixels={video_max_pixels}",
+                    f"total_pixels={video_total_pixels}",
+                )
+            )
+        cache_parts = [part for part in (image_cache_key, video_cache_key) if part]
+        return dict(encoded), prompt_text, "|".join(cache_parts) or None
+
+    @staticmethod
     def _use_pretokenized_inputs(inputs: Any) -> bool:
         return (
             isinstance(inputs, list)
@@ -177,18 +320,81 @@ class Cosmos3TextPreprocessor:
             and all(isinstance(token_id, int) for token_id in inputs)
         )
 
-    def __call__(self, payload: StagePayload) -> StagePayload:
-        # The OpenAI adapter places top-level media fields in metadata rather
-        # than request.inputs. Keep the first Cosmos3 slice strictly text-only
-        # regardless of which entry point constructed the OmniRequest.
-        _reject_media_inputs(payload.request.metadata)
+    async def __call__(self, payload: StagePayload) -> StagePayload:
         inputs = payload.request.inputs
         if self._use_pretokenized_inputs(inputs):
             input_ids = torch.tensor(inputs, dtype=torch.long)
             attention_mask = torch.ones_like(input_ids)
             prompt_text = ""
+            mm_token_type_ids = torch.zeros_like(input_ids)
+            mm_inputs: dict[str, Any] = {}
+            vision_inputs: dict[str, Any] = {"_skip": True, "_result": {}}
         else:
-            input_ids, attention_mask, prompt_text = self._tokenize_messages(inputs)
+            if not isinstance(inputs, dict):
+                inputs = {"messages": inputs}
+            for key in (
+                "images",
+                "videos",
+                "video_fps",
+                "video_max_frames",
+                "video_min_pixels",
+                "video_max_pixels",
+                "video_total_pixels",
+            ):
+                if (
+                    inputs.get(key) is None
+                    and payload.request.metadata.get(key) is not None
+                ):
+                    inputs[key] = payload.request.metadata[key]
+
+            if inputs.get("audios") or inputs.get("audio"):
+                raise ValueError("Cosmos3 audio preprocessing is not implemented yet")
+            has_media = bool(
+                inputs.get("images") or inputs.get("videos") or inputs.get("video")
+            )
+            if has_media:
+                if not self.enable_vision:
+                    raise ValueError(
+                        "Cosmos3 text-only pipeline does not accept image/video input"
+                    )
+                encoded, prompt_text, cache_key = await self._tokenize_multimodal(
+                    inputs
+                )
+                input_ids = _flatten_single_batch(encoded["input_ids"])
+                raw_attention_mask = encoded.get("attention_mask")
+                attention_mask = (
+                    torch.ones_like(input_ids)
+                    if raw_attention_mask is None
+                    else _flatten_single_batch(raw_attention_mask)
+                )
+                raw_token_types = encoded.get("mm_token_type_ids")
+                if raw_token_types is None:
+                    raise ValueError(
+                        "Cosmos3 processor did not return mm_token_type_ids"
+                    )
+                mm_token_type_ids = _flatten_single_batch(raw_token_types)
+                mm_inputs = {
+                    key: encoded[key]
+                    for key in ("image_grid_thw", "video_grid_thw")
+                    if isinstance(encoded.get(key), torch.Tensor)
+                }
+                vision_inputs = {
+                    key: encoded[key]
+                    for key in (
+                        "pixel_values",
+                        "image_grid_thw",
+                        "pixel_values_videos",
+                        "video_grid_thw",
+                    )
+                    if isinstance(encoded.get(key), torch.Tensor)
+                }
+                if cache_key is not None:
+                    vision_inputs["cache_key"] = cache_key
+            else:
+                input_ids, attention_mask, prompt_text = self._tokenize_messages(inputs)
+                mm_token_type_ids = torch.zeros_like(input_ids)
+                mm_inputs = {}
+                vision_inputs = {"_skip": True, "_result": {}}
 
         max_new_tokens = payload.request.params.get(
             "max_new_tokens", DEFAULT_MAX_NEW_TOKENS
@@ -207,17 +413,23 @@ class Cosmos3TextPreprocessor:
                 "input_ids": input_ids,
                 "attention_mask": attention_mask,
                 "prompt_text": prompt_text,
+                "mm_token_type_ids": mm_token_type_ids,
             },
+            mm_inputs=mm_inputs,
+            encoder_inputs={VISION_STAGE: vision_inputs},
             stream_state={"token_ids": [], "text": ""},
         )
         payload.data = state.to_dict()
         payload.request.inputs = None
+        for key in ("images", "videos"):
+            payload.request.metadata.pop(key, None)
         return payload
 
 
 __all__ = [
     "DEFAULT_MAX_NEW_TOKENS",
     "Cosmos3TextPreprocessor",
+    "load_cosmos3_processor",
     "load_cosmos3_tokenizer",
     "validate_prompt_seq_len",
 ]

--- a/sglang_omni/models/cosmos3/components/text_preprocessor.py
+++ b/sglang_omni/models/cosmos3/components/text_preprocessor.py
@@ -74,9 +74,7 @@ def _normalize_text_messages(inputs: Any) -> list[dict[str, str]]:
     return messages
 
 
-def _reject_media_inputs(container: Any) -> None:
-    if not isinstance(container, dict):
-        return
+def _reject_media_inputs(container: dict[str, Any]) -> None:
     populated_media = [key for key in _MEDIA_INPUT_KEYS if container.get(key)]
     if populated_media:
         raise ValueError(
@@ -85,17 +83,8 @@ def _reject_media_inputs(container: Any) -> None:
         )
 
 
-def _flatten_single_batch(value: Any, *, name: str) -> torch.Tensor:
-    tensor = value if isinstance(value, torch.Tensor) else torch.as_tensor(value)
-    if tensor.ndim == 2:
-        if tensor.shape[0] != 1:
-            raise ValueError(f"Tokenizer returned batched {name}; expected one prompt")
-        tensor = tensor[0]
-    if tensor.ndim != 1:
-        raise ValueError(
-            f"Tokenizer returned invalid {name} shape {tuple(tensor.shape)}"
-        )
-    return tensor.to(dtype=torch.long)
+def _flatten_single_batch(value: torch.Tensor) -> torch.Tensor:
+    return value[0].to(dtype=torch.long)
 
 
 def validate_prompt_seq_len(
@@ -154,7 +143,7 @@ class Cosmos3TextPreprocessor:
             tokenizer if tokenizer is not None else load_cosmos3_tokenizer(model_path)
         )
         ensure_chat_template(self.tokenizer, model_path=model_path)
-        if not getattr(self.tokenizer, "chat_template", None):
+        if not self.tokenizer.chat_template:
             raise ValueError(
                 f"Tokenizer for {model_path!r} does not define a chat template"
             )
@@ -171,15 +160,13 @@ class Cosmos3TextPreprocessor:
             add_special_tokens=False,
             return_tensors="pt",
         )
-        input_ids = _flatten_single_batch(encoded["input_ids"], name="input_ids")
+        input_ids = _flatten_single_batch(encoded["input_ids"])
         raw_attention_mask = encoded.get("attention_mask")
         attention_mask = (
             torch.ones_like(input_ids)
             if raw_attention_mask is None
-            else _flatten_single_batch(raw_attention_mask, name="attention_mask")
+            else _flatten_single_batch(raw_attention_mask)
         )
-        if attention_mask.shape != input_ids.shape:
-            raise ValueError("Tokenizer returned mismatched input_ids/attention_mask")
         return input_ids, attention_mask, prompt_text
 
     @staticmethod

--- a/sglang_omni/models/cosmos3/components/vision_encoder.py
+++ b/sglang_omni/models/cosmos3/components/vision_encoder.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standalone Qwen3-VL vision encoder for Cosmos3-Nano."""
+
+from __future__ import annotations
+
+import logging
+import types
+from typing import Any
+
+import torch
+from torch import nn
+from transformers import Qwen3VLVisionModel
+from transformers.models.qwen3_vl import modeling_qwen3_vl as hf_modeling
+from transformers.processing_utils import Unpack
+from transformers.utils.generic import TransformersKwargs, merge_with_config_defaults
+from transformers.utils.output_capturing import capture_outputs
+
+from sglang_omni.models.cosmos3.bootstrap import resolve_vision_encoder_path
+from sglang_omni.models.weight_loader import load_module, resolve_dtype
+from sglang_omni.utils import instantiate_module, load_hf_config
+
+logger = logging.getLogger(__name__)
+
+
+class Cosmos3Qwen3VLVisionModelCompat(Qwen3VLVisionModel):
+    """Qwen3-VL tower with the interpolation arithmetic used by Nano's export."""
+
+    def _legacy_pos_embed_interpolate(
+        self,
+        grid_thw: torch.Tensor,
+    ) -> torch.Tensor:
+        grid_thw_list = grid_thw.tolist()
+        grid_ts = [row[0] for row in grid_thw_list]
+        grid_hs = [row[1] for row in grid_thw_list]
+        grid_ws = [row[2] for row in grid_thw_list]
+        device = self.pos_embed.weight.device
+
+        index_lists = [[] for _ in range(4)]
+        weight_lists = [[] for _ in range(4)]
+        for _, height, width in grid_thw_list:
+            height_indices = torch.linspace(0, self.num_grid_per_side - 1, height)
+            width_indices = torch.linspace(0, self.num_grid_per_side - 1, width)
+            height_floor = height_indices.int()
+            width_floor = width_indices.int()
+            height_ceil = (height_floor + 1).clip(max=self.num_grid_per_side - 1)
+            width_ceil = (width_floor + 1).clip(max=self.num_grid_per_side - 1)
+            delta_height = height_indices - height_floor
+            delta_width = width_indices - width_floor
+            base_height = height_floor * self.num_grid_per_side
+            base_height_ceil = height_ceil * self.num_grid_per_side
+
+            indices = [
+                (base_height[:, None] + width_floor[None]).flatten(),
+                (base_height[:, None] + width_ceil[None]).flatten(),
+                (base_height_ceil[:, None] + width_floor[None]).flatten(),
+                (base_height_ceil[:, None] + width_ceil[None]).flatten(),
+            ]
+            weights = [
+                ((1 - delta_height)[:, None] * (1 - delta_width)[None]).flatten(),
+                ((1 - delta_height)[:, None] * delta_width[None]).flatten(),
+                (delta_height[:, None] * (1 - delta_width)[None]).flatten(),
+                (delta_height[:, None] * delta_width[None]).flatten(),
+            ]
+            for corner in range(4):
+                index_lists[corner].extend(indices[corner].tolist())
+                weight_lists[corner].extend(weights[corner].tolist())
+
+        index_tensor = torch.tensor(index_lists, dtype=torch.long, device=device)
+        weight_tensor = torch.tensor(
+            weight_lists,
+            dtype=self.pos_embed.weight.dtype,
+            device=device,
+        )
+        corners = self.pos_embed(index_tensor) * weight_tensor[:, :, None]
+        position_embeds = corners.sum(dim=0)
+        split_embeds = position_embeds.split(
+            [height * width for height, width in zip(grid_hs, grid_ws)]
+        )
+
+        reordered = []
+        merge_size = self.config.spatial_merge_size
+        for position_embed, grid_t, grid_h, grid_w in zip(
+            split_embeds,
+            grid_ts,
+            grid_hs,
+            grid_ws,
+        ):
+            position_embed = position_embed.repeat(grid_t, 1)
+            position_embed = (
+                position_embed.view(
+                    grid_t,
+                    grid_h // merge_size,
+                    merge_size,
+                    grid_w // merge_size,
+                    merge_size,
+                    -1,
+                )
+                .permute(0, 1, 3, 2, 4, 5)
+                .flatten(0, 4)
+            )
+            reordered.append(position_embed)
+        return torch.cat(reordered)
+
+    @merge_with_config_defaults
+    @capture_outputs
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        grid_thw: torch.Tensor,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> tuple | hf_modeling.BaseModelOutputWithDeepstackFeatures:
+        kwargs.pop("bilinear_indices", None)
+        kwargs.pop("bilinear_weights", None)
+        position_ids = hf_modeling.get_vision_position_ids(
+            grid_thw,
+            self.spatial_merge_size,
+            kwargs=kwargs,
+        )
+        cu_seqlens = hf_modeling.get_vision_cu_seqlens(grid_thw, kwargs=kwargs)
+
+        hidden_states = self.patch_embed(hidden_states)
+        position_embeds = self._legacy_pos_embed_interpolate(grid_thw)
+        hidden_states = hidden_states + position_embeds.to(hidden_states.dtype)
+        rotary_pos_emb = self.rotary_pos_emb(position_ids)
+        rotary_pos_emb = rotary_pos_emb.reshape(hidden_states.shape[0], -1)
+        rotary_pos_emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
+        position_embeddings = (rotary_pos_emb.cos(), rotary_pos_emb.sin())
+
+        deepstack_features = []
+        for layer_index, block in enumerate(self.blocks):
+            hidden_states = block(
+                hidden_states,
+                cu_seqlens=cu_seqlens,
+                position_embeddings=position_embeddings,
+                **kwargs,
+            )
+            if layer_index in self.deepstack_visual_indexes:
+                merger_index = self.deepstack_visual_indexes.index(layer_index)
+                deepstack_features.append(
+                    self.deepstack_merger_list[merger_index](hidden_states)
+                )
+
+        return hf_modeling.BaseModelOutputWithDeepstackFeatures(
+            last_hidden_state=hidden_states,
+            pooler_output=self.merger(hidden_states),
+            deepstack_features=deepstack_features,
+        )
+
+
+def _linear_patch_embed_forward(
+    self: nn.Module,
+    hidden_states: torch.Tensor,
+) -> torch.Tensor:
+    return self.linear(hidden_states.to(dtype=self.linear.weight.dtype))
+
+
+def _optimize_patch_embed(visual: nn.Module) -> None:
+    """Replace the non-overlapping Conv3d patch projection with a Linear."""
+
+    patch_embed = getattr(visual, "patch_embed", None)
+    conv = getattr(patch_embed, "proj", None)
+    if not isinstance(conv, nn.Conv3d):
+        return
+    if list(conv.kernel_size) != list(conv.stride):
+        return
+    if conv.padding != (0, 0, 0) or conv.dilation != (1, 1, 1) or conv.groups != 1:
+        return
+
+    in_features = (
+        conv.in_channels
+        * conv.kernel_size[0]
+        * conv.kernel_size[1]
+        * conv.kernel_size[2]
+    )
+    linear = nn.Linear(
+        in_features,
+        conv.out_channels,
+        bias=conv.bias is not None,
+        dtype=conv.weight.dtype,
+        device=conv.weight.device,
+    )
+    with torch.no_grad():
+        linear.weight.copy_(conv.weight.view(conv.out_channels, -1))
+        if conv.bias is not None:
+            linear.bias.copy_(conv.bias)
+
+    del patch_embed.proj
+    patch_embed.linear = linear
+    patch_embed.forward = types.MethodType(_linear_patch_embed_forward, patch_embed)
+    logger.info("Cosmos3 vision patch projection replaced with Linear")
+
+
+class Cosmos3VisionEncoder(nn.Module):
+    """Vision tower split from the unified Cosmos3 checkpoint."""
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        device: str = "cuda",
+        dtype: str | torch.dtype | None = None,
+    ) -> None:
+        super().__init__()
+        root_config = load_hf_config(model_path, local_files_only=True)
+        vision_config = root_config.vision_config
+        torch_dtype = resolve_dtype(dtype)
+        visual = instantiate_module(Cosmos3Qwen3VLVisionModelCompat, vision_config)
+        self.visual = load_module(
+            visual,
+            resolve_vision_encoder_path(model_path),
+            prefix="",
+            dtype=torch_dtype,
+            device=device,
+            strict=True,
+        )
+        _optimize_patch_embed(self.visual)
+
+        self._device = torch.device(device)
+        self.spatial_merge_size = int(vision_config.spatial_merge_size)
+        self.out_hidden_size = int(vision_config.out_hidden_size)
+        self.deepstack_layers = len(vision_config.deepstack_visual_indexes)
+        self.visual_dtype_bytes = torch.empty(
+            (), dtype=self.visual.dtype
+        ).element_size()
+
+    def _encode(
+        self,
+        pixel_values: torch.Tensor,
+        grid_thw: torch.Tensor,
+    ) -> tuple[torch.Tensor, list[torch.Tensor]]:
+        grid_thw = grid_thw.to(self._device, dtype=torch.long)
+        pixel_values = pixel_values.to(
+            device=self._device,
+            dtype=self.visual.dtype,
+        )
+        output = self.visual(pixel_values, grid_thw=grid_thw, return_dict=True)
+        return output.pooler_output, list(output.deepstack_features)
+
+    def forward(
+        self,
+        *,
+        pixel_values: torch.Tensor | None = None,
+        image_grid_thw: torch.Tensor | None = None,
+        pixel_values_videos: torch.Tensor | None = None,
+        video_grid_thw: torch.Tensor | None = None,
+        **_: Any,
+    ) -> dict[str, Any]:
+        outputs: dict[str, Any] = {}
+        merge = self.spatial_merge_size**2
+
+        if isinstance(pixel_values, torch.Tensor) and isinstance(
+            image_grid_thw, torch.Tensor
+        ):
+            image_grid_thw = image_grid_thw.to(self._device, dtype=torch.long)
+            image_embeds, image_deepstack = self._encode(
+                pixel_values,
+                image_grid_thw,
+            )
+            outputs.update(
+                image_embeds=image_embeds,
+                image_grid_thw=image_grid_thw,
+                image_token_counts=image_grid_thw.prod(-1) // merge,
+                deepstack_visual_embeds_image=image_deepstack,
+            )
+
+        if isinstance(pixel_values_videos, torch.Tensor) and isinstance(
+            video_grid_thw, torch.Tensor
+        ):
+            video_grid_thw = video_grid_thw.to(self._device, dtype=torch.long)
+            video_embeds, video_deepstack = self._encode(
+                pixel_values_videos,
+                video_grid_thw,
+            )
+            outputs.update(
+                video_embeds=video_embeds,
+                video_grid_thw=video_grid_thw,
+                video_token_counts=video_grid_thw.prod(-1) // merge,
+                deepstack_visual_embeds_video=video_deepstack,
+            )
+
+        return outputs
+
+
+__all__ = ["Cosmos3Qwen3VLVisionModelCompat", "Cosmos3VisionEncoder"]

--- a/sglang_omni/models/cosmos3/config.py
+++ b/sglang_omni/models/cosmos3/config.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Text-only Cosmos3-Nano pipeline configuration."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pydantic import Field
+
+from sglang_omni.config import PipelineConfig, StageConfig
+
+_PKG = "sglang_omni.models.cosmos3"
+
+PREPROCESSING_STAGE = "preprocessing"
+THINKER_STAGE = "thinker"
+DECODE_STAGE = "decode"
+
+
+def _text_stages() -> list[StageConfig]:
+    return [
+        StageConfig(
+            name=PREPROCESSING_STAGE,
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_preprocessing_executor",
+            factory_args={"thinker_max_seq_len": 8192},
+            runtime_arg_map={"max_seq_len": "thinker_max_seq_len"},
+            next=THINKER_STAGE,
+        ),
+        StageConfig(
+            name=THINKER_STAGE,
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_sglang_text_executor_from_config",
+            factory_args={
+                "thinker_max_seq_len": 8192,
+                "enable_async_decode": False,
+            },
+            runtime_arg_map={"max_seq_len": "thinker_max_seq_len"},
+            gpu=0,
+            tp_size=1,
+            next=DECODE_STAGE,
+            stream_to=[DECODE_STAGE],
+        ),
+        StageConfig(
+            name=DECODE_STAGE,
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_decode_executor",
+            terminal=True,
+            can_accept_stream_before_payload=True,
+        ),
+    ]
+
+
+class Cosmos3TextPipelineConfig(PipelineConfig):
+    """Three-stage MVP: preprocessing → text AR → detokenize."""
+
+    architecture: ClassVar[str] = "Cosmos3ForConditionalGeneration"
+
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {THINKER_STAGE: THINKER_STAGE}
+
+    model_path: str
+    stages: list[StageConfig] = Field(default_factory=_text_stages)
+
+
+EntryClass = Cosmos3TextPipelineConfig
+
+Variants = {"text": Cosmos3TextPipelineConfig}
+
+__all__ = ["Cosmos3TextPipelineConfig", "EntryClass", "Variants"]

--- a/sglang_omni/models/cosmos3/config.py
+++ b/sglang_omni/models/cosmos3/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Text-only Cosmos3-Nano pipeline configuration."""
+"""Cosmos3-Nano thinker pipeline configuration."""
 
 from __future__ import annotations
 
@@ -12,8 +12,81 @@ from sglang_omni.config import PipelineConfig, StageConfig
 _PKG = "sglang_omni.models.cosmos3"
 
 PREPROCESSING_STAGE = "preprocessing"
+VISION_STAGE = "vision_encoder"
 THINKER_STAGE = "thinker"
 DECODE_STAGE = "decode"
+
+
+def _thinker_stage(*, aggregate_vision: bool = False) -> StageConfig:
+    stage = StageConfig(
+        name=THINKER_STAGE,
+        process="pipeline",
+        factory=f"{_PKG}.stages.create_sglang_text_executor_from_config",
+        factory_args={
+            "thinker_max_seq_len": 8192,
+            "enable_async_decode": False,
+        },
+        runtime_arg_map={"max_seq_len": "thinker_max_seq_len"},
+        gpu=0,
+        tp_size=1,
+        next=DECODE_STAGE,
+        stream_to=[DECODE_STAGE],
+        project_payload={
+            DECODE_STAGE: f"{_PKG}.request_builders.project_thinker_to_decode"
+        },
+    )
+    if aggregate_vision:
+        stage.wait_for = [PREPROCESSING_STAGE, VISION_STAGE]
+        stage.wait_for_fn = f"{_PKG}.request_builders.resolve_thinker_wait_sources"
+        stage.merge_fn = f"{_PKG}.merge.merge_for_thinker"
+    return stage
+
+
+def _decode_stage() -> StageConfig:
+    return StageConfig(
+        name=DECODE_STAGE,
+        process="pipeline",
+        factory=f"{_PKG}.stages.create_decode_executor",
+        terminal=True,
+        can_accept_stream_before_payload=True,
+    )
+
+
+def _vision_stages() -> list[StageConfig]:
+    return [
+        StageConfig(
+            name=PREPROCESSING_STAGE,
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_preprocessing_executor",
+            factory_args={"thinker_max_seq_len": 8192, "enable_vision": True},
+            runtime_arg_map={"max_seq_len": "thinker_max_seq_len"},
+            next=[VISION_STAGE, THINKER_STAGE],
+            route_fn=f"{_PKG}.request_builders.resolve_preprocessing_next_stages",
+            project_payload={
+                VISION_STAGE: (
+                    f"{_PKG}.request_builders.project_preprocessing_to_vision_encoder"
+                ),
+                THINKER_STAGE: (
+                    f"{_PKG}.request_builders.project_preprocessing_to_thinker"
+                ),
+            },
+        ),
+        StageConfig(
+            name=VISION_STAGE,
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_vision_encoder_executor",
+            factory_args={"device": "cuda", "dtype": None},
+            gpu=0,
+            next=THINKER_STAGE,
+            project_payload={
+                THINKER_STAGE: (
+                    f"{_PKG}.request_builders.project_vision_encoder_to_thinker"
+                )
+            },
+        ),
+        _thinker_stage(aggregate_vision=True),
+        _decode_stage(),
+    ]
 
 
 def _text_stages() -> list[StageConfig]:
@@ -22,49 +95,48 @@ def _text_stages() -> list[StageConfig]:
             name=PREPROCESSING_STAGE,
             process="pipeline",
             factory=f"{_PKG}.stages.create_preprocessing_executor",
-            factory_args={"thinker_max_seq_len": 8192},
+            factory_args={"thinker_max_seq_len": 8192, "enable_vision": False},
             runtime_arg_map={"max_seq_len": "thinker_max_seq_len"},
             next=THINKER_STAGE,
         ),
-        StageConfig(
-            name=THINKER_STAGE,
-            process="pipeline",
-            factory=f"{_PKG}.stages.create_sglang_text_executor_from_config",
-            factory_args={
-                "thinker_max_seq_len": 8192,
-                "enable_async_decode": False,
-            },
-            runtime_arg_map={"max_seq_len": "thinker_max_seq_len"},
-            gpu=0,
-            tp_size=1,
-            next=DECODE_STAGE,
-            stream_to=[DECODE_STAGE],
-        ),
-        StageConfig(
-            name=DECODE_STAGE,
-            process="pipeline",
-            factory=f"{_PKG}.stages.create_decode_executor",
-            terminal=True,
-            can_accept_stream_before_payload=True,
-        ),
+        _thinker_stage(),
+        _decode_stage(),
     ]
 
 
-class Cosmos3TextPipelineConfig(PipelineConfig):
-    """Three-stage MVP: preprocessing → text AR → detokenize."""
-
+class _Cosmos3PipelineConfig(PipelineConfig):
     architecture: ClassVar[str] = "Cosmos3ForConditionalGeneration"
 
     @classmethod
     def mem_fraction_role_to_stage(cls) -> dict[str, str]:
         return {THINKER_STAGE: THINKER_STAGE}
 
+    @classmethod
+    def generation_sglang_role_to_stage(cls) -> dict[str, str]:
+        return {"generation": THINKER_STAGE}
+
     model_path: str
+
+
+class Cosmos3PipelineConfig(_Cosmos3PipelineConfig):
+    """Nano pipeline with a separately scheduled Qwen3-VL vision tower."""
+
+    stages: list[StageConfig] = Field(default_factory=_vision_stages)
+
+
+class Cosmos3TextPipelineConfig(_Cosmos3PipelineConfig):
+    """Tokenizer → thinker → decode variant without loading vision weights."""
+
     stages: list[StageConfig] = Field(default_factory=_text_stages)
 
 
-EntryClass = Cosmos3TextPipelineConfig
+EntryClass = Cosmos3PipelineConfig
 
 Variants = {"text": Cosmos3TextPipelineConfig}
 
-__all__ = ["Cosmos3TextPipelineConfig", "EntryClass", "Variants"]
+__all__ = [
+    "Cosmos3PipelineConfig",
+    "Cosmos3TextPipelineConfig",
+    "EntryClass",
+    "Variants",
+]

--- a/sglang_omni/models/cosmos3/hf_config.py
+++ b/sglang_omni/models/cosmos3/hf_config.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hugging Face configuration import for Cosmos3."""
+
+from __future__ import annotations
+
+from transformers import Cosmos3OmniConfig
+
+__all__ = ["Cosmos3OmniConfig"]

--- a/sglang_omni/models/cosmos3/merge.py
+++ b/sglang_omni/models/cosmos3/merge.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Merge standalone Cosmos3 encoder outputs at the thinker boundary."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.models.cosmos3.request_builders import VISION_STAGE
+from sglang_omni.proto import StagePayload
+
+
+def _non_empty(value: Any) -> bool:
+    return isinstance(value, torch.Tensor) and value.numel() > 0
+
+
+def build_thinker_inputs(
+    state: Cosmos3PipelineState,
+    vision_out: dict[str, Any],
+) -> dict[str, Any]:
+    model_inputs: dict[str, Any] = {}
+    for key in ("image_embeds", "video_embeds"):
+        value = vision_out.get(key)
+        if _non_empty(value):
+            model_inputs[key] = value
+
+    image_deepstack = vision_out.get("deepstack_visual_embeds_image")
+    video_deepstack = vision_out.get("deepstack_visual_embeds_video")
+    if image_deepstack and video_deepstack:
+        model_inputs["image_deepstack_visual_embeds"] = image_deepstack
+        model_inputs["video_deepstack_visual_embeds"] = video_deepstack
+    elif image_deepstack:
+        model_inputs["deepstack_visual_embeds"] = image_deepstack
+    elif video_deepstack:
+        model_inputs["deepstack_visual_embeds"] = video_deepstack
+
+    for key in ("image_grid_thw", "video_grid_thw"):
+        value = vision_out.get(key)
+        if not _non_empty(value):
+            value = state.mm_inputs.get(key)
+        if _non_empty(value):
+            model_inputs[key] = value.to(dtype=torch.long)
+
+    result: dict[str, Any] = {"model_inputs": model_inputs}
+    cache_key = (state.encoder_inputs.get(VISION_STAGE) or {}).get("cache_key")
+    if cache_key is not None:
+        result["media_cache_key"] = str(cache_key)
+    return result
+
+
+def merge_for_thinker(payloads: dict[str, StagePayload]) -> StagePayload:
+    base = payloads.get("preprocessing") or next(iter(payloads.values()))
+    state = Cosmos3PipelineState.from_dict(base.data)
+    vision_out = dict(state.encoder_outs.get(VISION_STAGE, {}))
+
+    vision_payload = payloads.get(VISION_STAGE)
+    if vision_payload is not None:
+        vision_state = Cosmos3PipelineState.from_dict(vision_payload.data)
+        value = vision_state.encoder_outs.get(VISION_STAGE)
+        if isinstance(value, dict):
+            vision_out = value
+
+    state.thinker_inputs = build_thinker_inputs(state, vision_out)
+    state.encoder_inputs = {}
+    state.encoder_outs = {}
+    base.data = state.to_dict()
+    return base
+
+
+__all__ = ["build_thinker_inputs", "merge_for_thinker"]

--- a/sglang_omni/models/cosmos3/model_runner.py
+++ b/sglang_omni/models/cosmos3/model_runner.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cosmos3 thinker runner with precomputed vision embedding injection."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.model_runner.thinker_model_runner import ThinkerModelRunner
+
+
+class Cosmos3ThinkerModelRunner(ThinkerModelRunner):
+    """Use the Qwen3-VL deepstack injection path with Cosmos3's model layout."""
+
+    def __init__(self, tp_worker: Any, output_processor: Any) -> None:
+        # ThinkerModelRunner's execution logic is architecture-agnostic, but its
+        # constructor unwraps Qwen3-Omni's ``model.thinker`` hierarchy. Cosmos3
+        # exposes the language model directly, so bind the same fields here.
+        ModelRunner.__init__(self, tp_worker, output_processor)
+        self._outer_model = self.model
+        self._text_model = self.model.model
+        self._embed_tokens = self._text_model.embed_tokens
+        self._th_host_bufs = None
+        self._th_slot = 0
+        self._should_capture_hidden = None
+
+        config = tp_worker.model_runner.model_config.hf_config
+        self._image_token_id = int(config.image_token_id)
+        self._video_token_id = int(config.video_token_id)
+        self._audio_token_id = -1
+
+    def lookahead_eligible(self, batch: Any) -> bool:
+        return ModelRunner.lookahead_eligible(self, batch)
+
+
+__all__ = ["Cosmos3ThinkerModelRunner"]

--- a/sglang_omni/models/cosmos3/payload_types.py
+++ b/sglang_omni/models/cosmos3/payload_types.py
@@ -4,25 +4,27 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
+
+import torch
 
 
 class PromptInputs(TypedDict):
     """Tokenized text prompt passed to the Cosmos3 AR stage."""
 
-    input_ids: Any
-    attention_mask: Any
+    input_ids: torch.Tensor
+    attention_mask: torch.Tensor
     prompt_text: str
 
 
-class TextOutput(TypedDict, total=False):
+class TextOutput(TypedDict):
     """Normalized text output populated by the later AR stage."""
 
     output_ids: list[int]
-    finish_reason: str | None
     is_final: bool
-    output_token_logprobs: Any
-    weight_version: Any
+    finish_reason: NotRequired[str | None]
+    output_token_logprobs: NotRequired[list[Any]]
+    weight_version: NotRequired[str | None]
 
 
 @dataclass
@@ -35,18 +37,8 @@ class Cosmos3PipelineState:
     stream_state: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, data: Any) -> Cosmos3PipelineState:
-        if not isinstance(data, dict):
-            data = {}
-        text_out = data.get("text_out")
-        engine_outputs = data.get("engine_outputs")
-        stream_state = data.get("stream_state")
-        return cls(
-            prompt=data.get("prompt") if isinstance(data.get("prompt"), dict) else None,
-            text_out=text_out if isinstance(text_out, dict) else None,
-            engine_outputs=(engine_outputs if isinstance(engine_outputs, dict) else {}),
-            stream_state=stream_state if isinstance(stream_state, dict) else {},
-        )
+    def from_dict(cls, data: dict[str, Any]) -> Cosmos3PipelineState:
+        return cls(**data)
 
     def to_dict(self) -> dict[str, Any]:
         data: dict[str, Any] = {}

--- a/sglang_omni/models/cosmos3/payload_types.py
+++ b/sglang_omni/models/cosmos3/payload_types.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cosmos3 payload schemas."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, TypedDict
+
+
+class PromptInputs(TypedDict):
+    """Tokenized text prompt passed to the Cosmos3 AR stage."""
+
+    input_ids: Any
+    attention_mask: Any
+    prompt_text: str
+
+
+class TextOutput(TypedDict, total=False):
+    """Normalized text output populated by the later AR stage."""
+
+    output_ids: list[int]
+    finish_reason: str | None
+    is_final: bool
+    output_token_logprobs: Any
+    weight_version: Any
+
+
+@dataclass
+class Cosmos3PipelineState:
+    """Typed, process-safe state shared by Cosmos3 pipeline stages."""
+
+    prompt: PromptInputs | None = None
+    text_out: TextOutput | None = None
+    engine_outputs: dict[str, Any] = field(default_factory=dict)
+    stream_state: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Any) -> Cosmos3PipelineState:
+        if not isinstance(data, dict):
+            data = {}
+        text_out = data.get("text_out")
+        engine_outputs = data.get("engine_outputs")
+        stream_state = data.get("stream_state")
+        return cls(
+            prompt=data.get("prompt") if isinstance(data.get("prompt"), dict) else None,
+            text_out=text_out if isinstance(text_out, dict) else None,
+            engine_outputs=(engine_outputs if isinstance(engine_outputs, dict) else {}),
+            stream_state=stream_state if isinstance(stream_state, dict) else {},
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {}
+        if self.prompt is not None:
+            data["prompt"] = self.prompt
+        if self.text_out is not None:
+            data["text_out"] = self.text_out
+        if self.engine_outputs:
+            data["engine_outputs"] = self.engine_outputs
+        if self.stream_state:
+            data["stream_state"] = self.stream_state
+        return data
+
+
+__all__ = ["Cosmos3PipelineState", "PromptInputs", "TextOutput"]

--- a/sglang_omni/models/cosmos3/payload_types.py
+++ b/sglang_omni/models/cosmos3/payload_types.py
@@ -10,11 +10,12 @@ import torch
 
 
 class PromptInputs(TypedDict):
-    """Tokenized text prompt passed to the Cosmos3 AR stage."""
+    """Tokenized prompt passed to the Cosmos3 AR stage."""
 
     input_ids: torch.Tensor
     attention_mask: torch.Tensor
     prompt_text: str
+    mm_token_type_ids: torch.Tensor
 
 
 class TextOutput(TypedDict):
@@ -32,6 +33,10 @@ class Cosmos3PipelineState:
     """Typed, process-safe state shared by Cosmos3 pipeline stages."""
 
     prompt: PromptInputs | None = None
+    mm_inputs: dict[str, Any] = field(default_factory=dict)
+    encoder_inputs: dict[str, dict[str, Any]] = field(default_factory=dict)
+    encoder_outs: dict[str, Any] = field(default_factory=dict)
+    thinker_inputs: dict[str, Any] = field(default_factory=dict)
     text_out: TextOutput | None = None
     engine_outputs: dict[str, Any] = field(default_factory=dict)
     stream_state: dict[str, Any] = field(default_factory=dict)
@@ -44,6 +49,14 @@ class Cosmos3PipelineState:
         data: dict[str, Any] = {}
         if self.prompt is not None:
             data["prompt"] = self.prompt
+        if self.mm_inputs:
+            data["mm_inputs"] = self.mm_inputs
+        if self.encoder_inputs:
+            data["encoder_inputs"] = self.encoder_inputs
+        if self.encoder_outs:
+            data["encoder_outs"] = self.encoder_outs
+        if self.thinker_inputs:
+            data["thinker_inputs"] = self.thinker_inputs
         if self.text_out is not None:
             data["text_out"] = self.text_out
         if self.engine_outputs:

--- a/sglang_omni/models/cosmos3/request_builders.py
+++ b/sglang_omni/models/cosmos3/request_builders.py
@@ -3,14 +3,20 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import torch
+from transformers import GenerationConfig, PreTrainedTokenizerBase
 
-from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState, TextOutput
+from sglang_omni.models.cosmos3.payload_types import (
+    Cosmos3PipelineState,
+    PromptInputs,
+    TextOutput,
+)
 from sglang_omni.proto import EXPLICIT_GENERATION_PARAMS_KEY, StagePayload
 from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
+from sglang_omni.scheduling.types import RequestOutput
 
 THINKER_STAGE = "thinker"
 DECODE_STAGE = "decode"
@@ -23,8 +29,7 @@ _TRANSPORT_SAMPLING_DEFAULTS: dict[str, Any] = {
 }
 
 
-def _value_or_default(config: Any, name: str, fallback: Any) -> Any:
-    value = getattr(config, name, None) if config is not None else None
+def _value_or_default(value: Any, fallback: Any) -> Any:
     return fallback if value is None else value
 
 
@@ -36,12 +41,20 @@ def _request_value(params: dict[str, Any], name: str, default: Any) -> Any:
 def build_cosmos3_sampling_kwargs(
     params: dict[str, Any],
     *,
-    generation_config: Any = None,
+    generation_config: GenerationConfig | None = None,
 ) -> dict[str, Any]:
     """Merge request sampling overrides over Cosmos3-Nano defaults."""
 
-    do_sample = bool(_value_or_default(generation_config, "do_sample", True))
-    default_temperature = _value_or_default(generation_config, "temperature", 0.7)
+    do_sample = bool(
+        _value_or_default(
+            generation_config.do_sample if generation_config is not None else None,
+            True,
+        )
+    )
+    default_temperature = _value_or_default(
+        generation_config.temperature if generation_config is not None else None,
+        0.7,
+    )
     if not do_sample:
         default_temperature = 0.0
     sampling_seed = params.get("seed")
@@ -53,18 +66,31 @@ def build_cosmos3_sampling_kwargs(
         "top_p": _request_value(
             params,
             "top_p",
-            _value_or_default(generation_config, "top_p", 0.8),
+            _value_or_default(
+                generation_config.top_p if generation_config is not None else None,
+                0.8,
+            ),
         ),
         "top_k": _request_value(
             params,
             "top_k",
-            _value_or_default(generation_config, "top_k", 20),
+            _value_or_default(
+                generation_config.top_k if generation_config is not None else None,
+                20,
+            ),
         ),
         "min_p": _request_value(params, "min_p", 0.0),
         "repetition_penalty": _request_value(
             params,
             "repetition_penalty",
-            _value_or_default(generation_config, "repetition_penalty", 1.0),
+            _value_or_default(
+                (
+                    generation_config.repetition_penalty
+                    if generation_config is not None
+                    else None
+                ),
+                1.0,
+            ),
         ),
         "stop": params.get("stop") or [],
         "stop_token_ids": params.get("stop_token_ids") or [],
@@ -85,10 +111,8 @@ def _effective_request_params(
 
     effective = dict(params)
     raw_explicit_fields = metadata.get(EXPLICIT_GENERATION_PARAMS_KEY)
-    has_explicit_marker = isinstance(raw_explicit_fields, (list, tuple))
-    explicit_fields = (
-        {str(field) for field in raw_explicit_fields} if has_explicit_marker else set()
-    )
+    has_explicit_marker = raw_explicit_fields is not None
+    explicit_fields = set(raw_explicit_fields or ())
 
     for field, transport_default in _TRANSPORT_SAMPLING_DEFAULTS.items():
         if field in explicit_fields:
@@ -99,16 +123,18 @@ def _effective_request_params(
     return effective
 
 
-def _eos_token_ids(tokenizer: Any, generation_config: Any) -> set[int] | None:
+def _eos_token_ids(
+    tokenizer: PreTrainedTokenizerBase,
+    generation_config: GenerationConfig | None,
+) -> set[int] | None:
     values = _value_or_default(
-        generation_config,
-        "eos_token_id",
-        getattr(tokenizer, "eos_token_id", None),
+        generation_config.eos_token_id if generation_config is not None else None,
+        tokenizer.eos_token_id,
     )
+    if values is None:
+        return None
     if isinstance(values, int):
         values = [values]
-    if not isinstance(values, (list, tuple, set)):
-        return None
     result = {int(value) for value in values if value is not None and int(value) >= 0}
     return result or None
 
@@ -117,9 +143,9 @@ def build_sglang_text_request(
     state: Cosmos3PipelineState,
     *,
     params: dict[str, Any],
-    tokenizer: Any,
+    tokenizer: PreTrainedTokenizerBase,
     vocab_size: int,
-    generation_config: Any = None,
+    generation_config: GenerationConfig | None = None,
     request_id: str | None = None,
 ) -> SGLangARRequestData:
     """Build one SGLang request from the canonical preprocessing state."""
@@ -127,13 +153,8 @@ def build_sglang_text_request(
     from sglang.srt.managers.schedule_batch import Req
     from sglang.srt.sampling.sampling_params import SamplingParams
 
-    prompt = state.prompt
-    if not isinstance(prompt, dict):
-        raise TypeError("Cosmos3 prompt is missing for the thinker request")
-    raw_input_ids = prompt.get("input_ids")
-    if not isinstance(raw_input_ids, torch.Tensor):
-        raise TypeError("Cosmos3 prompt.input_ids must be a torch.Tensor")
-    input_ids = raw_input_ids.to(dtype=torch.long).flatten()
+    prompt = cast(PromptInputs, state.prompt)
+    input_ids = prompt["input_ids"]
 
     sampling_kwargs = build_cosmos3_sampling_kwargs(
         params,
@@ -145,7 +166,7 @@ def build_sglang_text_request(
 
     req = Req(
         rid=request_id or "cosmos3-request",
-        origin_input_text=prompt.get("prompt_text", ""),
+        origin_input_text=prompt["prompt_text"],
         origin_input_ids=input_ids.tolist(),
         sampling_params=sampling_params,
         eos_token_ids=_eos_token_ids(tokenizer, generation_config),
@@ -153,12 +174,9 @@ def build_sglang_text_request(
     )
     req.tokenizer = tokenizer
 
-    attention_mask = prompt.get("attention_mask")
     return SGLangARRequestData(
         input_ids=input_ids,
-        attention_mask=(
-            attention_mask if isinstance(attention_mask, torch.Tensor) else None
-        ),
+        attention_mask=prompt["attention_mask"],
         max_new_tokens=int(sampling_kwargs["max_new_tokens"]),
         temperature=float(sampling_kwargs["temperature"]),
         top_p=float(sampling_kwargs["top_p"]),
@@ -173,19 +191,19 @@ def apply_text_result(
     state: Cosmos3PipelineState,
     *,
     stage_name: str,
-    result: Any,
+    result: SGLangARRequestData,
 ) -> TextOutput:
     text_out: TextOutput = {
         "output_ids": list(result.output_ids),
         "is_final": True,
     }
-    finish_reason = getattr(result, "finish_reason", None)
+    finish_reason = result.finish_reason
     if finish_reason is not None:
         text_out["finish_reason"] = finish_reason
-    output_token_logprobs = getattr(result, "output_token_logprobs", None)
+    output_token_logprobs = result.output_token_logprobs
     if output_token_logprobs:
         text_out["output_token_logprobs"] = output_token_logprobs
-    weight_version = getattr(result, "weight_version", None)
+    weight_version = result.weight_version
     if weight_version is not None:
         text_out["weight_version"] = weight_version
     state.text_out = text_out
@@ -195,9 +213,9 @@ def apply_text_result(
 
 def make_text_scheduler_adapters(
     *,
-    tokenizer: Any,
+    tokenizer: PreTrainedTokenizerBase,
     vocab_size: int,
-    generation_config: Any = None,
+    generation_config: GenerationConfig | None = None,
     stage_name: str = THINKER_STAGE,
 ):
     """Build StagePayload-to-SGLang adapters for the text thinker."""
@@ -205,8 +223,8 @@ def make_text_scheduler_adapters(
     def request_builder(payload: StagePayload) -> SGLangARRequestData:
         state = Cosmos3PipelineState.from_dict(payload.data)
         params = _effective_request_params(
-            payload.request.params or {},
-            payload.request.metadata or {},
+            payload.request.params,
+            payload.request.metadata,
         )
         req_data = build_sglang_text_request(
             state,
@@ -217,13 +235,11 @@ def make_text_scheduler_adapters(
             request_id=payload.request_id,
         )
         req_data.stage_payload = payload
-        req_data.return_logprob = bool(
-            (payload.request.params or {}).get("return_logprob")
-        )
+        req_data.return_logprob = bool(payload.request.params.get("return_logprob"))
         return req_data
 
     def result_adapter(data: SGLangARRequestData) -> StagePayload:
-        payload = data.stage_payload
+        payload = cast(StagePayload, data.stage_payload)
         state = Cosmos3PipelineState.from_dict(payload.data)
         apply_text_result(state, stage_name=stage_name, result=data)
         return StagePayload(
@@ -241,17 +257,15 @@ def make_text_stream_output_builder(*, decode_stage: str = DECODE_STAGE):
     def stream_output_builder(
         request_id: str,
         req_data: SGLangARRequestData,
-        req_output: Any,
+        req_output: RequestOutput,
     ) -> list[OutgoingMessage]:
-        req = getattr(req_data, "req", None)
-        if req is not None and req.inflight_middle_chunks > 0:
+        req = req_data.req
+        if req.inflight_middle_chunks > 0:
             return []
         if req_output.data is None:
             return []
-        payload = req_data.stage_payload
-        if payload is None or not bool(
-            (payload.request.params or {}).get("stream", False)
-        ):
+        payload = cast(StagePayload, req_data.stage_payload)
+        if not bool(payload.request.params.get("stream", False)):
             return []
         token_id = int(req_output.data)
         return [

--- a/sglang_omni/models/cosmos3/request_builders.py
+++ b/sglang_omni/models/cosmos3/request_builders.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SGLang request and result adapters for Cosmos3 text generation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState, TextOutput
+from sglang_omni.proto import EXPLICIT_GENERATION_PARAMS_KEY, StagePayload
+from sglang_omni.scheduling.messages import OutgoingMessage
+from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
+
+THINKER_STAGE = "thinker"
+DECODE_STAGE = "decode"
+
+_TRANSPORT_SAMPLING_DEFAULTS: dict[str, Any] = {
+    "temperature": 1.0,
+    "top_p": 1.0,
+    "top_k": -1,
+    "repetition_penalty": 1.0,
+}
+
+
+def _value_or_default(config: Any, name: str, fallback: Any) -> Any:
+    value = getattr(config, name, None) if config is not None else None
+    return fallback if value is None else value
+
+
+def _request_value(params: dict[str, Any], name: str, default: Any) -> Any:
+    value = params.get(name)
+    return default if value is None else value
+
+
+def build_cosmos3_sampling_kwargs(
+    params: dict[str, Any],
+    *,
+    generation_config: Any = None,
+) -> dict[str, Any]:
+    """Merge request sampling overrides over Cosmos3-Nano defaults."""
+
+    do_sample = bool(_value_or_default(generation_config, "do_sample", True))
+    default_temperature = _value_or_default(generation_config, "temperature", 0.7)
+    if not do_sample:
+        default_temperature = 0.0
+    sampling_seed = params.get("seed")
+    if sampling_seed is None:
+        sampling_seed = params.get("sampling_seed")
+    return {
+        "max_new_tokens": _request_value(params, "max_new_tokens", 2048),
+        "temperature": _request_value(params, "temperature", default_temperature),
+        "top_p": _request_value(
+            params,
+            "top_p",
+            _value_or_default(generation_config, "top_p", 0.8),
+        ),
+        "top_k": _request_value(
+            params,
+            "top_k",
+            _value_or_default(generation_config, "top_k", 20),
+        ),
+        "min_p": _request_value(params, "min_p", 0.0),
+        "repetition_penalty": _request_value(
+            params,
+            "repetition_penalty",
+            _value_or_default(generation_config, "repetition_penalty", 1.0),
+        ),
+        "stop": params.get("stop") or [],
+        "stop_token_ids": params.get("stop_token_ids") or [],
+        "sampling_seed": sampling_seed,
+    }
+
+
+def _effective_request_params(
+    params: dict[str, Any], metadata: dict[str, Any]
+) -> dict[str, Any]:
+    """Remove transport placeholders that must not shadow Nano defaults.
+
+    OpenAI-compatible request parsing materializes generic sampling defaults.
+    The explicit-field marker distinguishes those placeholders from values the
+    caller actually supplied. Sparse internal requests predate that marker, so
+    non-placeholder values remain valid overrides for backward compatibility.
+    """
+
+    effective = dict(params)
+    raw_explicit_fields = metadata.get(EXPLICIT_GENERATION_PARAMS_KEY)
+    has_explicit_marker = isinstance(raw_explicit_fields, (list, tuple))
+    explicit_fields = (
+        {str(field) for field in raw_explicit_fields} if has_explicit_marker else set()
+    )
+
+    for field, transport_default in _TRANSPORT_SAMPLING_DEFAULTS.items():
+        if field in explicit_fields:
+            continue
+        value = effective.get(field)
+        if has_explicit_marker or value is None or value == transport_default:
+            effective.pop(field, None)
+    return effective
+
+
+def _eos_token_ids(tokenizer: Any, generation_config: Any) -> set[int] | None:
+    values = _value_or_default(
+        generation_config,
+        "eos_token_id",
+        getattr(tokenizer, "eos_token_id", None),
+    )
+    if isinstance(values, int):
+        values = [values]
+    if not isinstance(values, (list, tuple, set)):
+        return None
+    result = {int(value) for value in values if value is not None and int(value) >= 0}
+    return result or None
+
+
+def build_sglang_text_request(
+    state: Cosmos3PipelineState,
+    *,
+    params: dict[str, Any],
+    tokenizer: Any,
+    vocab_size: int,
+    generation_config: Any = None,
+    request_id: str | None = None,
+) -> SGLangARRequestData:
+    """Build one SGLang request from the canonical preprocessing state."""
+
+    from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.sampling.sampling_params import SamplingParams
+
+    prompt = state.prompt
+    if not isinstance(prompt, dict):
+        raise TypeError("Cosmos3 prompt is missing for the thinker request")
+    raw_input_ids = prompt.get("input_ids")
+    if not isinstance(raw_input_ids, torch.Tensor):
+        raise TypeError("Cosmos3 prompt.input_ids must be a torch.Tensor")
+    input_ids = raw_input_ids.to(dtype=torch.long).flatten()
+
+    sampling_kwargs = build_cosmos3_sampling_kwargs(
+        params,
+        generation_config=generation_config,
+    )
+    sampling_params = SamplingParams(**sampling_kwargs)
+    sampling_params.normalize(tokenizer)
+    sampling_params.verify(vocab_size)
+
+    req = Req(
+        rid=request_id or "cosmos3-request",
+        origin_input_text=prompt.get("prompt_text", ""),
+        origin_input_ids=input_ids.tolist(),
+        sampling_params=sampling_params,
+        eos_token_ids=_eos_token_ids(tokenizer, generation_config),
+        vocab_size=vocab_size,
+    )
+    req.tokenizer = tokenizer
+
+    attention_mask = prompt.get("attention_mask")
+    return SGLangARRequestData(
+        input_ids=input_ids,
+        attention_mask=(
+            attention_mask if isinstance(attention_mask, torch.Tensor) else None
+        ),
+        max_new_tokens=int(sampling_kwargs["max_new_tokens"]),
+        temperature=float(sampling_kwargs["temperature"]),
+        top_p=float(sampling_kwargs["top_p"]),
+        top_k=int(sampling_kwargs["top_k"]),
+        repetition_penalty=float(sampling_kwargs["repetition_penalty"]),
+        output_ids=req.output_ids,
+        req=req,
+    )
+
+
+def apply_text_result(
+    state: Cosmos3PipelineState,
+    *,
+    stage_name: str,
+    result: Any,
+) -> TextOutput:
+    text_out: TextOutput = {
+        "output_ids": list(result.output_ids),
+        "is_final": True,
+    }
+    finish_reason = getattr(result, "finish_reason", None)
+    if finish_reason is not None:
+        text_out["finish_reason"] = finish_reason
+    output_token_logprobs = getattr(result, "output_token_logprobs", None)
+    if output_token_logprobs:
+        text_out["output_token_logprobs"] = output_token_logprobs
+    weight_version = getattr(result, "weight_version", None)
+    if weight_version is not None:
+        text_out["weight_version"] = weight_version
+    state.text_out = text_out
+    state.engine_outputs[stage_name] = text_out
+    return text_out
+
+
+def make_text_scheduler_adapters(
+    *,
+    tokenizer: Any,
+    vocab_size: int,
+    generation_config: Any = None,
+    stage_name: str = THINKER_STAGE,
+):
+    """Build StagePayload-to-SGLang adapters for the text thinker."""
+
+    def request_builder(payload: StagePayload) -> SGLangARRequestData:
+        state = Cosmos3PipelineState.from_dict(payload.data)
+        params = _effective_request_params(
+            payload.request.params or {},
+            payload.request.metadata or {},
+        )
+        req_data = build_sglang_text_request(
+            state,
+            params=params,
+            tokenizer=tokenizer,
+            vocab_size=vocab_size,
+            generation_config=generation_config,
+            request_id=payload.request_id,
+        )
+        req_data.stage_payload = payload
+        req_data.return_logprob = bool(
+            (payload.request.params or {}).get("return_logprob")
+        )
+        return req_data
+
+    def result_adapter(data: SGLangARRequestData) -> StagePayload:
+        payload = data.stage_payload
+        state = Cosmos3PipelineState.from_dict(payload.data)
+        apply_text_result(state, stage_name=stage_name, result=data)
+        return StagePayload(
+            request_id=payload.request_id,
+            request=payload.request,
+            data=state.to_dict(),
+        )
+
+    return request_builder, result_adapter
+
+
+def make_text_stream_output_builder(*, decode_stage: str = DECODE_STAGE):
+    """Forward generated token ids to the stream-aware detokenizer."""
+
+    def stream_output_builder(
+        request_id: str,
+        req_data: SGLangARRequestData,
+        req_output: Any,
+    ) -> list[OutgoingMessage]:
+        req = getattr(req_data, "req", None)
+        if req is not None and req.inflight_middle_chunks > 0:
+            return []
+        if req_output.data is None:
+            return []
+        payload = req_data.stage_payload
+        if payload is None or not bool(
+            (payload.request.params or {}).get("stream", False)
+        ):
+            return []
+        token_id = int(req_output.data)
+        return [
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                data=torch.tensor([token_id], dtype=torch.long),
+                target=decode_stage,
+                metadata={"token_id": token_id},
+            )
+        ]
+
+    return stream_output_builder
+
+
+__all__ = [
+    "DECODE_STAGE",
+    "THINKER_STAGE",
+    "apply_text_result",
+    "build_cosmos3_sampling_kwargs",
+    "build_sglang_text_request",
+    "make_text_scheduler_adapters",
+    "make_text_stream_output_builder",
+]

--- a/sglang_omni/models/cosmos3/request_builders.py
+++ b/sglang_omni/models/cosmos3/request_builders.py
@@ -3,9 +3,12 @@
 
 from __future__ import annotations
 
+import itertools
+from dataclasses import dataclass
 from typing import Any, cast
 
 import torch
+import xxhash
 from transformers import GenerationConfig, PreTrainedTokenizerBase
 
 from sglang_omni.models.cosmos3.payload_types import (
@@ -20,6 +23,7 @@ from sglang_omni.scheduling.types import RequestOutput
 
 THINKER_STAGE = "thinker"
 DECODE_STAGE = "decode"
+VISION_STAGE = "vision_encoder"
 
 _TRANSPORT_SAMPLING_DEFAULTS: dict[str, Any] = {
     "temperature": 1.0,
@@ -27,6 +31,143 @@ _TRANSPORT_SAMPLING_DEFAULTS: dict[str, Any] = {
     "top_k": -1,
     "repetition_penalty": 1.0,
 }
+
+
+def _payload_with_state(
+    payload: StagePayload,
+    state: Cosmos3PipelineState,
+) -> StagePayload:
+    return StagePayload(
+        request_id=payload.request_id,
+        request=payload.request,
+        data=state.to_dict(),
+    )
+
+
+def _vision_encoder_is_active(state: Cosmos3PipelineState) -> bool:
+    inputs = state.encoder_inputs.get(VISION_STAGE)
+    if not isinstance(inputs, dict) or inputs.get("_skip"):
+        return False
+    if inputs.get("_active") is not None:
+        return inputs["_active"] is True
+    return isinstance(inputs.get("pixel_values"), torch.Tensor) or isinstance(
+        inputs.get("pixel_values_videos"), torch.Tensor
+    )
+
+
+def resolve_preprocessing_next_stages(
+    request_id: str,
+    output: StagePayload,
+) -> list[str]:
+    del request_id
+    state = Cosmos3PipelineState.from_dict(output.data)
+    stages = [THINKER_STAGE]
+    if _vision_encoder_is_active(state):
+        stages.insert(0, VISION_STAGE)
+    return stages
+
+
+def resolve_thinker_wait_sources(
+    request_id: str,
+    from_stage: str,
+    payload: StagePayload,
+) -> list[str] | None:
+    del request_id
+    if from_stage != "preprocessing":
+        return None
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    sources = ["preprocessing"]
+    if _vision_encoder_is_active(state):
+        sources.append(VISION_STAGE)
+    return sources
+
+
+def project_preprocessing_to_vision_encoder(payload: StagePayload) -> StagePayload:
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    vision_inputs = state.encoder_inputs.get(VISION_STAGE)
+    projected = Cosmos3PipelineState(
+        encoder_inputs=(
+            {VISION_STAGE: dict(vision_inputs)}
+            if isinstance(vision_inputs, dict)
+            else {}
+        )
+    )
+    return _payload_with_state(payload, projected)
+
+
+def project_preprocessing_to_thinker(payload: StagePayload) -> StagePayload:
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    metadata: dict[str, Any] = {}
+    vision_inputs = state.encoder_inputs.get(VISION_STAGE)
+    if isinstance(vision_inputs, dict):
+        if vision_inputs.get("cache_key") is not None:
+            metadata["cache_key"] = vision_inputs["cache_key"]
+        if _vision_encoder_is_active(state):
+            metadata["_active"] = True
+    projected = Cosmos3PipelineState(
+        prompt=dict(state.prompt) if isinstance(state.prompt, dict) else None,
+        mm_inputs=dict(state.mm_inputs),
+        encoder_inputs={VISION_STAGE: metadata} if metadata else {},
+        stream_state=dict(state.stream_state),
+    )
+    return _payload_with_state(payload, projected)
+
+
+def project_vision_encoder_to_thinker(payload: StagePayload) -> StagePayload:
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    output = state.encoder_outs.get(VISION_STAGE, {})
+    return _payload_with_state(
+        payload,
+        Cosmos3PipelineState(encoder_outs={VISION_STAGE: output}),
+    )
+
+
+def project_thinker_to_decode(payload: StagePayload) -> StagePayload:
+    """Drop prefill-only visual tensors before the terminal decode hop."""
+
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    state.mm_inputs = {}
+    state.thinker_inputs = {}
+    return _payload_with_state(payload, state)
+
+
+@dataclass(slots=True)
+class VisionEncoderRequestData:
+    model_inputs: dict[str, Any]
+    cache_key: str | None = None
+    skip_result: dict[str, Any] | None = None
+
+
+def build_vision_encoder_request(
+    state: Cosmos3PipelineState,
+) -> VisionEncoderRequestData:
+    inputs = state.encoder_inputs.get(VISION_STAGE)
+    if not isinstance(inputs, dict) or not inputs:
+        return VisionEncoderRequestData(model_inputs={}, skip_result={})
+    if inputs.get("_skip"):
+        result = inputs.get("_result")
+        return VisionEncoderRequestData(
+            model_inputs={},
+            skip_result=result if isinstance(result, dict) else {},
+        )
+    cache_key = inputs.get("cache_key")
+    return VisionEncoderRequestData(
+        model_inputs={
+            key: value
+            for key, value in inputs.items()
+            if key not in ("cache_key", "_active")
+        },
+        cache_key=str(cache_key) if cache_key is not None else None,
+    )
+
+
+def apply_vision_encoder_result(
+    state: Cosmos3PipelineState,
+    result: Any,
+) -> None:
+    encoder_out = result if isinstance(result, dict) else {"result": result}
+    state.encoder_outs[VISION_STAGE] = encoder_out
+    state.engine_outputs[VISION_STAGE] = encoder_out
 
 
 def _value_or_default(value: Any, fallback: Any) -> Any:
@@ -139,6 +280,92 @@ def _eos_token_ids(
     return result or None
 
 
+def _vision_position_ids(
+    start_position: int,
+    grid_thw: torch.Tensor,
+    *,
+    spatial_merge_size: int,
+) -> torch.Tensor:
+    grid_t, grid_h, grid_w = (int(value) for value in grid_thw.tolist())
+    llm_h = grid_h // spatial_merge_size
+    llm_w = grid_w // spatial_merge_size
+    temporal = torch.arange(grid_t, dtype=torch.long).repeat_interleave(llm_h * llm_w)
+    height = torch.arange(llm_h, dtype=torch.long).repeat_interleave(llm_w)
+    height = height.repeat(grid_t)
+    width = torch.arange(llm_w, dtype=torch.long).repeat(llm_h * grid_t)
+    return torch.stack((temporal, height, width), dim=0) + start_position
+
+
+def compute_cosmos3_mrope_positions(
+    input_ids: torch.Tensor,
+    mm_token_type_ids: torch.Tensor,
+    *,
+    image_grid_thw: torch.Tensor | None,
+    video_grid_thw: torch.Tensor | None,
+    spatial_merge_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute Nano's text-filled T/H/W positions for one prompt."""
+
+    input_ids = input_ids.to(dtype=torch.long, device="cpu").flatten()
+    token_types = mm_token_type_ids.to(dtype=torch.long, device="cpu").flatten()
+    if token_types.shape != input_ids.shape:
+        raise ValueError("Cosmos3 mm_token_type_ids must match input_ids")
+
+    image_grids = (
+        image_grid_thw.to(dtype=torch.long, device="cpu")
+        if isinstance(image_grid_thw, torch.Tensor)
+        else torch.empty((0, 3), dtype=torch.long)
+    )
+    if isinstance(video_grid_thw, torch.Tensor):
+        video_grids = video_grid_thw.to(dtype=torch.long, device="cpu")
+        video_grids = torch.repeat_interleave(
+            video_grids,
+            video_grids[:, 0],
+            dim=0,
+        )
+        video_grids[:, 0] = 1
+    else:
+        video_grids = torch.empty((0, 3), dtype=torch.long)
+    grid_iters = {1: iter(image_grids), 2: iter(video_grids)}
+
+    current_position = 0
+    parts: list[torch.Tensor] = []
+    grouped = itertools.groupby(enumerate(token_types.tolist()), lambda item: item[1])
+    for modality, group in grouped:
+        group_len = sum(1 for _ in group)
+        if modality == 0:
+            positions = torch.arange(group_len, dtype=torch.long)
+            parts.append(positions.unsqueeze(0).expand(3, -1) + current_position)
+            current_position += group_len
+            continue
+        if modality not in grid_iters:
+            raise ValueError(f"Unsupported Cosmos3 token type {modality}")
+        try:
+            grid = next(grid_iters[modality])
+        except StopIteration as exc:
+            raise ValueError(
+                f"Cosmos3 token type {modality} has no matching vision grid"
+            ) from exc
+        positions = _vision_position_ids(
+            current_position,
+            grid,
+            spatial_merge_size=spatial_merge_size,
+        )
+        if positions.shape[1] != group_len:
+            raise ValueError(
+                "Cosmos3 vision positions do not match placeholder tokens: "
+                f"positions={positions.shape[1]}, tokens={group_len}"
+            )
+        parts.append(positions)
+        current_position += int(grid[1:].max().item()) // spatial_merge_size
+
+    positions = (
+        torch.cat(parts, dim=1) if parts else torch.empty((3, 0), dtype=torch.long)
+    )
+    delta = positions.max() + 1 - input_ids.numel() if positions.numel() else 0
+    return positions, torch.tensor([[int(delta)]], dtype=torch.long)
+
+
 def build_sglang_text_request(
     state: Cosmos3PipelineState,
     *,
@@ -147,6 +374,7 @@ def build_sglang_text_request(
     vocab_size: int,
     generation_config: GenerationConfig | None = None,
     request_id: str | None = None,
+    thinker_config: Any = None,
 ) -> SGLangARRequestData:
     """Build one SGLang request from the canonical preprocessing state."""
 
@@ -154,7 +382,29 @@ def build_sglang_text_request(
     from sglang.srt.sampling.sampling_params import SamplingParams
 
     prompt = cast(PromptInputs, state.prompt)
-    input_ids = prompt["input_ids"]
+    original_input_ids = prompt["input_ids"]
+    input_ids = original_input_ids
+    thinker_inputs = state.thinker_inputs or {}
+    model_inputs = dict(thinker_inputs.get("model_inputs", {}))
+    media_cache_key = thinker_inputs.get("media_cache_key")
+    if media_cache_key is not None and thinker_config is not None:
+        token_map: dict[int, int] = {}
+        pad_values: dict[str, int] = {}
+        for modality, token_id in (
+            ("image", thinker_config.image_token_id),
+            ("video", thinker_config.video_token_id),
+        ):
+            if model_inputs.get(f"{modality}_embeds") is None:
+                continue
+            digest = xxhash.xxh3_64(f"{modality}:{media_cache_key}".encode())
+            pad_value = vocab_size + digest.intdigest() % (1 << 62)
+            pad_values[modality] = pad_value
+            token_map[int(token_id)] = pad_value
+        if token_map:
+            input_ids = original_input_ids.clone()
+            for token_id, pad_value in token_map.items():
+                input_ids[input_ids == token_id] = pad_value
+            model_inputs["pad_values"] = pad_values
 
     sampling_kwargs = build_cosmos3_sampling_kwargs(
         params,
@@ -174,6 +424,24 @@ def build_sglang_text_request(
     )
     req.tokenizer = tokenizer
 
+    if model_inputs and thinker_config is not None:
+        from sglang.srt.managers.schedule_batch import MultimodalInputs
+
+        mrope_positions, mrope_delta = compute_cosmos3_mrope_positions(
+            original_input_ids,
+            prompt["mm_token_type_ids"],
+            image_grid_thw=model_inputs.get("image_grid_thw"),
+            video_grid_thw=model_inputs.get("video_grid_thw"),
+            spatial_merge_size=int(thinker_config.vision_config.spatial_merge_size),
+        )
+        multimodal_inputs = MultimodalInputs(mm_items=[])
+        multimodal_inputs.mrope_positions = mrope_positions
+        multimodal_inputs.mrope_position_delta = mrope_delta
+        req.multimodal_inputs = multimodal_inputs
+
+    req.omni_model_inputs = model_inputs if model_inputs else None
+    req._omni_consumed = None
+
     return SGLangARRequestData(
         input_ids=input_ids,
         attention_mask=prompt["attention_mask"],
@@ -182,6 +450,7 @@ def build_sglang_text_request(
         top_p=float(sampling_kwargs["top_p"]),
         top_k=int(sampling_kwargs["top_k"]),
         repetition_penalty=float(sampling_kwargs["repetition_penalty"]),
+        model_inputs=model_inputs,
         output_ids=req.output_ids,
         req=req,
     )
@@ -217,6 +486,7 @@ def make_text_scheduler_adapters(
     vocab_size: int,
     generation_config: GenerationConfig | None = None,
     stage_name: str = THINKER_STAGE,
+    thinker_config: Any = None,
 ):
     """Build StagePayload-to-SGLang adapters for the text thinker."""
 
@@ -233,6 +503,7 @@ def make_text_scheduler_adapters(
             vocab_size=vocab_size,
             generation_config=generation_config,
             request_id=payload.request_id,
+            thinker_config=thinker_config,
         )
         req_data.stage_payload = payload
         req_data.return_logprob = bool(payload.request.params.get("return_logprob"))
@@ -284,9 +555,19 @@ def make_text_stream_output_builder(*, decode_stage: str = DECODE_STAGE):
 __all__ = [
     "DECODE_STAGE",
     "THINKER_STAGE",
+    "VISION_STAGE",
     "apply_text_result",
+    "apply_vision_encoder_result",
     "build_cosmos3_sampling_kwargs",
     "build_sglang_text_request",
+    "build_vision_encoder_request",
+    "compute_cosmos3_mrope_positions",
     "make_text_scheduler_adapters",
     "make_text_stream_output_builder",
+    "project_preprocessing_to_thinker",
+    "project_preprocessing_to_vision_encoder",
+    "project_thinker_to_decode",
+    "project_vision_encoder_to_thinker",
+    "resolve_preprocessing_next_stages",
+    "resolve_thinker_wait_sources",
 ]

--- a/sglang_omni/models/cosmos3/stages.py
+++ b/sglang_omni/models/cosmos3/stages.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 from typing import Any
 
+from sglang_omni.models.cosmos3.bootstrap import create_thinker_scheduler
 from sglang_omni.models.cosmos3.components.text_preprocessor import (
     Cosmos3TextPreprocessor,
 )
+from sglang_omni.scheduling.sglang_backend import build_sglang_server_args
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
 
@@ -38,29 +40,14 @@ def create_sglang_text_executor_from_config(
     enable_async_decode: bool = False,
     async_decode_min_batch_size: int = 2,
 ):
-    """Create the naive single-rank Cosmos3 text AR stage."""
+    """Create the Cosmos3 thinker AR stage."""
 
-    if tp_size != 1 or tp_rank != 0:
-        raise ValueError("Cosmos3 text MVP supports only tp_size=1")
-
-    from sglang_omni.models.cosmos3.bootstrap import create_text_scheduler
-    from sglang_omni.scheduling.sglang_backend import build_sglang_server_args
-
-    overrides: dict[str, Any] = {
-        "tp_size": 1,
-        "enable_multimodal": False,
-        "language_only": True,
-        "sampling_backend": "pytorch",
-    }
-    overrides.update(server_args_overrides or {})
-    if overrides.get("tp_size") != 1:
-        raise ValueError("Cosmos3 text MVP does not support tensor parallelism")
     server_args = build_sglang_server_args(
         model_path,
         context_length=thinker_max_seq_len,
-        **overrides,
+        **{**(server_args_overrides or {}), "tp_size": tp_size},
     )
-    return create_text_scheduler(
+    return create_thinker_scheduler(
         server_args,
         gpu_id,
         tp_rank=tp_rank,

--- a/sglang_omni/models/cosmos3/stages.py
+++ b/sglang_omni/models/cosmos3/stages.py
@@ -9,6 +9,10 @@ from sglang_omni.models.cosmos3.bootstrap import create_thinker_scheduler
 from sglang_omni.models.cosmos3.components.text_preprocessor import (
     Cosmos3TextPreprocessor,
 )
+from sglang_omni.scheduling.generation_batch_policy import (
+    build_generation_batch_overrides,
+    validate_generation_batch_policy,
+)
 from sglang_omni.scheduling.sglang_backend import build_sglang_server_args
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
@@ -42,10 +46,21 @@ def create_sglang_text_executor_from_config(
 ):
     """Create the Cosmos3 thinker AR stage."""
 
+    overrides = build_generation_batch_overrides(
+        max_running_requests=16,
+        server_args_overrides=server_args_overrides,
+        disable_cuda_graph=False,
+        sampling_backend="pytorch",
+    )
+    overrides["tp_size"] = tp_size
     server_args = build_sglang_server_args(
         model_path,
         context_length=thinker_max_seq_len,
-        **{**(server_args_overrides or {}), "tp_size": tp_size},
+        **overrides,
+    )
+    validate_generation_batch_policy(
+        model_name="Cosmos3 thinker",
+        server_args=server_args,
     )
     return create_thinker_scheduler(
         server_args,

--- a/sglang_omni/models/cosmos3/stages.py
+++ b/sglang_omni/models/cosmos3/stages.py
@@ -5,31 +5,16 @@ from __future__ import annotations
 
 from typing import Any
 
-import torch
-
 from sglang_omni.models.cosmos3.bootstrap import create_thinker_scheduler
 from sglang_omni.models.cosmos3.components.text_preprocessor import (
     Cosmos3TextPreprocessor,
 )
-from sglang_omni.models.cosmos3.components.vision_encoder import Cosmos3VisionEncoder
-from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
-from sglang_omni.models.cosmos3.request_builders import (
-    apply_vision_encoder_result,
-    build_vision_encoder_request,
-)
-from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.generation_batch_policy import (
     build_generation_batch_overrides,
     validate_generation_batch_policy,
 )
 from sglang_omni.scheduling.sglang_backend import build_sglang_server_args
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
-from sglang_omni.scheduling.stage_cache import StageOutputCache
-
-VISION_ENCODER_CACHE_MAX_BYTES = 4 * 1024**3
-VISION_ENCODER_CACHE_MAX_ENTRIES = 64
-VISION_ENCODER_BATCH_BUDGET_BYTES = 10 * 1024**3
-VISION_ENCODER_ACTIVATION_MULTIPLIER = 5
 
 
 def create_preprocessing_executor(
@@ -48,229 +33,22 @@ def create_preprocessing_executor(
     return SimpleScheduler(preprocessor)
 
 
-def _store_state(
-    payload: StagePayload,
-    state: Cosmos3PipelineState,
-) -> StagePayload:
-    payload.data = state.to_dict()
-    return payload
-
-
-def _run_vision_request(
-    payload: StagePayload,
-    *,
-    model: Cosmos3VisionEncoder,
-    cache: StageOutputCache,
-) -> StagePayload:
-    state = Cosmos3PipelineState.from_dict(payload.data)
-    request = build_vision_encoder_request(state)
-    if request.skip_result is not None:
-        result = request.skip_result
-    else:
-        result = cache.get(request.cache_key)
-        if result is None:
-            with torch.no_grad():
-                result = model(**request.model_inputs)
-            cache.put(request.cache_key, result)
-    apply_vision_encoder_result(state, result)
-    return _store_state(payload, state)
-
-
-def _split_layers(
-    layers: list[torch.Tensor] | None,
-    start: int,
-    end: int,
-) -> list[torch.Tensor] | None:
-    if layers is None:
-        return None
-    return [layer[start:end] for layer in layers]
-
-
-def _batch_vision_requests(
-    payloads: list[StagePayload],
-    *,
-    model: Cosmos3VisionEncoder,
-    cache: StageOutputCache,
-) -> list[StagePayload]:
-    results: list[StagePayload | None] = [None] * len(payloads)
-    active: list[tuple[int, StagePayload, Cosmos3PipelineState, Any]] = []
-    leaders: dict[str, int] = {}
-    waiters: dict[int, list[tuple[int, StagePayload, Cosmos3PipelineState]]] = {}
-
-    for index, payload in enumerate(payloads):
-        state = Cosmos3PipelineState.from_dict(payload.data)
-        request = build_vision_encoder_request(state)
-        if request.skip_result is not None:
-            apply_vision_encoder_result(state, request.skip_result)
-            results[index] = _store_state(payload, state)
-            continue
-        cached = cache.get(request.cache_key)
-        if cached is not None:
-            apply_vision_encoder_result(state, cached)
-            results[index] = _store_state(payload, state)
-            continue
-        if request.cache_key is not None and request.cache_key in leaders:
-            leader = leaders[request.cache_key]
-            waiters.setdefault(leader, []).append((index, payload, state))
-            continue
-        leader = len(active)
-        active.append((index, payload, state, request))
-        if request.cache_key is not None:
-            leaders[request.cache_key] = leader
-
-    if active:
-        image_pixels: list[torch.Tensor] = []
-        image_grids: list[torch.Tensor] = []
-        video_pixels: list[torch.Tensor] = []
-        video_grids: list[torch.Tensor] = []
-        metadata: list[dict[str, int]] = []
-        merge = model.spatial_merge_size**2
-
-        for _, _, _, request in active:
-            values = request.model_inputs
-            image_grid = values.get("image_grid_thw")
-            video_grid = values.get("video_grid_thw")
-            image_rows = (
-                int(image_grid.shape[0]) if isinstance(image_grid, torch.Tensor) else 0
-            )
-            video_rows = (
-                int(video_grid.shape[0]) if isinstance(video_grid, torch.Tensor) else 0
-            )
-            image_tokens = (
-                int((image_grid.prod(-1) // merge).sum().item())
-                if isinstance(image_grid, torch.Tensor)
-                else 0
-            )
-            video_tokens = (
-                int((video_grid.prod(-1) // merge).sum().item())
-                if isinstance(video_grid, torch.Tensor)
-                else 0
-            )
-            if isinstance(values.get("pixel_values"), torch.Tensor):
-                image_pixels.append(values["pixel_values"])
-                image_grids.append(image_grid)
-            if isinstance(values.get("pixel_values_videos"), torch.Tensor):
-                video_pixels.append(values["pixel_values_videos"])
-                video_grids.append(video_grid)
-            metadata.append(
-                {
-                    "image_rows": image_rows,
-                    "video_rows": video_rows,
-                    "image_tokens": image_tokens,
-                    "video_tokens": video_tokens,
-                }
-            )
-
-        batched: dict[str, torch.Tensor] = {}
-        if image_pixels:
-            batched["pixel_values"] = torch.cat(image_pixels, dim=0)
-            batched["image_grid_thw"] = torch.cat(image_grids, dim=0)
-        if video_pixels:
-            batched["pixel_values_videos"] = torch.cat(video_pixels, dim=0)
-            batched["video_grid_thw"] = torch.cat(video_grids, dim=0)
-        with torch.no_grad():
-            combined = model(**batched)
-
-        image_row = image_token = video_row = video_token = 0
-        for leader, ((index, payload, state, request), meta) in enumerate(
-            zip(active, metadata)
-        ):
-            stage_result: dict[str, Any] = {}
-            if meta["image_rows"]:
-                row_end = image_row + meta["image_rows"]
-                token_end = image_token + meta["image_tokens"]
-                stage_result.update(
-                    image_embeds=combined["image_embeds"][image_token:token_end],
-                    image_grid_thw=combined["image_grid_thw"][image_row:row_end],
-                    image_token_counts=combined["image_token_counts"][
-                        image_row:row_end
-                    ],
-                    deepstack_visual_embeds_image=_split_layers(
-                        combined.get("deepstack_visual_embeds_image"),
-                        image_token,
-                        token_end,
-                    ),
-                )
-                image_row, image_token = row_end, token_end
-            if meta["video_rows"]:
-                row_end = video_row + meta["video_rows"]
-                token_end = video_token + meta["video_tokens"]
-                stage_result.update(
-                    video_embeds=combined["video_embeds"][video_token:token_end],
-                    video_grid_thw=combined["video_grid_thw"][video_row:row_end],
-                    video_token_counts=combined["video_token_counts"][
-                        video_row:row_end
-                    ],
-                    deepstack_visual_embeds_video=_split_layers(
-                        combined.get("deepstack_visual_embeds_video"),
-                        video_token,
-                        token_end,
-                    ),
-                )
-                video_row, video_token = row_end, token_end
-
-            cache.put(request.cache_key, stage_result)
-            apply_vision_encoder_result(state, stage_result)
-            results[index] = _store_state(payload, state)
-            for waiter_index, waiter_payload, waiter_state in waiters.get(leader, []):
-                apply_vision_encoder_result(waiter_state, stage_result)
-                results[waiter_index] = _store_state(waiter_payload, waiter_state)
-
-    if any(result is None for result in results):
-        raise RuntimeError("Cosmos3 vision batch did not produce every result")
-    return [result for result in results if result is not None]
-
-
-def _vision_request_cost(model: Cosmos3VisionEncoder):
-    merge = model.spatial_merge_size**2
-    output_width = model.out_hidden_size * (1 + model.deepstack_layers)
-    dtype_bytes = model.visual_dtype_bytes
-
-    def _cost(payload: StagePayload) -> int:
-        state = Cosmos3PipelineState.from_dict(payload.data)
-        request = build_vision_encoder_request(state)
-        if request.skip_result is not None:
-            return 0
-        inputs = request.model_inputs
-        raw_bytes = sum(
-            int(value.numel() * value.element_size())
-            for key in ("pixel_values", "pixel_values_videos")
-            if isinstance((value := inputs.get(key)), torch.Tensor)
-        )
-        visual_tokens = sum(
-            int((value.prod(-1) // merge).sum().item())
-            for key in ("image_grid_thw", "video_grid_thw")
-            if isinstance((value := inputs.get(key)), torch.Tensor)
-        )
-        output_bytes = visual_tokens * output_width * dtype_bytes
-        return (raw_bytes + output_bytes) * VISION_ENCODER_ACTIVATION_MULTIPLIER
-
-    return _cost
-
-
 def create_vision_encoder_executor(
     model_path: str,
     *,
     device: str = "cuda",
     dtype: str | None = None,
 ) -> SimpleScheduler:
-    model = Cosmos3VisionEncoder(model_path, device=device, dtype=dtype)
-    cache = StageOutputCache(
-        max_size=VISION_ENCODER_CACHE_MAX_ENTRIES,
-        max_bytes=VISION_ENCODER_CACHE_MAX_BYTES,
-        cache_device="cpu",
+    """Create the separately scheduled vision encoder stage."""
+
+    from sglang_omni.models.cosmos3.vision_encoder_scheduler import (
+        create_vision_encoder_scheduler,
     )
-    return SimpleScheduler(
-        lambda payload: _run_vision_request(payload, model=model, cache=cache),
-        batch_compute_fn=lambda payloads: _batch_vision_requests(
-            payloads,
-            model=model,
-            cache=cache,
-        ),
-        max_batch_size=32,
-        max_batch_wait_ms=50,
-        request_cost_fn=_vision_request_cost(model),
-        max_batch_cost=VISION_ENCODER_BATCH_BUDGET_BYTES,
+
+    return create_vision_encoder_scheduler(
+        model_path,
+        device=device,
+        dtype=dtype,
     )
 
 

--- a/sglang_omni/models/cosmos3/stages.py
+++ b/sglang_omni/models/cosmos3/stages.py
@@ -5,30 +5,273 @@ from __future__ import annotations
 
 from typing import Any
 
+import torch
+
 from sglang_omni.models.cosmos3.bootstrap import create_thinker_scheduler
 from sglang_omni.models.cosmos3.components.text_preprocessor import (
     Cosmos3TextPreprocessor,
 )
+from sglang_omni.models.cosmos3.components.vision_encoder import Cosmos3VisionEncoder
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.models.cosmos3.request_builders import (
+    apply_vision_encoder_result,
+    build_vision_encoder_request,
+)
+from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.generation_batch_policy import (
     build_generation_batch_overrides,
     validate_generation_batch_policy,
 )
 from sglang_omni.scheduling.sglang_backend import build_sglang_server_args
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni.scheduling.stage_cache import StageOutputCache
+
+VISION_ENCODER_CACHE_MAX_BYTES = 4 * 1024**3
+VISION_ENCODER_CACHE_MAX_ENTRIES = 64
+VISION_ENCODER_BATCH_BUDGET_BYTES = 10 * 1024**3
+VISION_ENCODER_ACTIVATION_MULTIPLIER = 5
 
 
 def create_preprocessing_executor(
     model_path: str,
     *,
     thinker_max_seq_len: int | None = None,
+    enable_vision: bool = True,
 ) -> SimpleScheduler:
     """Create the CPU-only text preprocessing stage."""
 
     preprocessor = Cosmos3TextPreprocessor(
         model_path=model_path,
         max_seq_len=thinker_max_seq_len,
+        enable_vision=enable_vision,
     )
     return SimpleScheduler(preprocessor)
+
+
+def _store_state(
+    payload: StagePayload,
+    state: Cosmos3PipelineState,
+) -> StagePayload:
+    payload.data = state.to_dict()
+    return payload
+
+
+def _run_vision_request(
+    payload: StagePayload,
+    *,
+    model: Cosmos3VisionEncoder,
+    cache: StageOutputCache,
+) -> StagePayload:
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    request = build_vision_encoder_request(state)
+    if request.skip_result is not None:
+        result = request.skip_result
+    else:
+        result = cache.get(request.cache_key)
+        if result is None:
+            with torch.no_grad():
+                result = model(**request.model_inputs)
+            cache.put(request.cache_key, result)
+    apply_vision_encoder_result(state, result)
+    return _store_state(payload, state)
+
+
+def _split_layers(
+    layers: list[torch.Tensor] | None,
+    start: int,
+    end: int,
+) -> list[torch.Tensor] | None:
+    if layers is None:
+        return None
+    return [layer[start:end] for layer in layers]
+
+
+def _batch_vision_requests(
+    payloads: list[StagePayload],
+    *,
+    model: Cosmos3VisionEncoder,
+    cache: StageOutputCache,
+) -> list[StagePayload]:
+    results: list[StagePayload | None] = [None] * len(payloads)
+    active: list[tuple[int, StagePayload, Cosmos3PipelineState, Any]] = []
+    leaders: dict[str, int] = {}
+    waiters: dict[int, list[tuple[int, StagePayload, Cosmos3PipelineState]]] = {}
+
+    for index, payload in enumerate(payloads):
+        state = Cosmos3PipelineState.from_dict(payload.data)
+        request = build_vision_encoder_request(state)
+        if request.skip_result is not None:
+            apply_vision_encoder_result(state, request.skip_result)
+            results[index] = _store_state(payload, state)
+            continue
+        cached = cache.get(request.cache_key)
+        if cached is not None:
+            apply_vision_encoder_result(state, cached)
+            results[index] = _store_state(payload, state)
+            continue
+        if request.cache_key is not None and request.cache_key in leaders:
+            leader = leaders[request.cache_key]
+            waiters.setdefault(leader, []).append((index, payload, state))
+            continue
+        leader = len(active)
+        active.append((index, payload, state, request))
+        if request.cache_key is not None:
+            leaders[request.cache_key] = leader
+
+    if active:
+        image_pixels: list[torch.Tensor] = []
+        image_grids: list[torch.Tensor] = []
+        video_pixels: list[torch.Tensor] = []
+        video_grids: list[torch.Tensor] = []
+        metadata: list[dict[str, int]] = []
+        merge = model.spatial_merge_size**2
+
+        for _, _, _, request in active:
+            values = request.model_inputs
+            image_grid = values.get("image_grid_thw")
+            video_grid = values.get("video_grid_thw")
+            image_rows = (
+                int(image_grid.shape[0]) if isinstance(image_grid, torch.Tensor) else 0
+            )
+            video_rows = (
+                int(video_grid.shape[0]) if isinstance(video_grid, torch.Tensor) else 0
+            )
+            image_tokens = (
+                int((image_grid.prod(-1) // merge).sum().item())
+                if isinstance(image_grid, torch.Tensor)
+                else 0
+            )
+            video_tokens = (
+                int((video_grid.prod(-1) // merge).sum().item())
+                if isinstance(video_grid, torch.Tensor)
+                else 0
+            )
+            if isinstance(values.get("pixel_values"), torch.Tensor):
+                image_pixels.append(values["pixel_values"])
+                image_grids.append(image_grid)
+            if isinstance(values.get("pixel_values_videos"), torch.Tensor):
+                video_pixels.append(values["pixel_values_videos"])
+                video_grids.append(video_grid)
+            metadata.append(
+                {
+                    "image_rows": image_rows,
+                    "video_rows": video_rows,
+                    "image_tokens": image_tokens,
+                    "video_tokens": video_tokens,
+                }
+            )
+
+        batched: dict[str, torch.Tensor] = {}
+        if image_pixels:
+            batched["pixel_values"] = torch.cat(image_pixels, dim=0)
+            batched["image_grid_thw"] = torch.cat(image_grids, dim=0)
+        if video_pixels:
+            batched["pixel_values_videos"] = torch.cat(video_pixels, dim=0)
+            batched["video_grid_thw"] = torch.cat(video_grids, dim=0)
+        with torch.no_grad():
+            combined = model(**batched)
+
+        image_row = image_token = video_row = video_token = 0
+        for leader, ((index, payload, state, request), meta) in enumerate(
+            zip(active, metadata)
+        ):
+            stage_result: dict[str, Any] = {}
+            if meta["image_rows"]:
+                row_end = image_row + meta["image_rows"]
+                token_end = image_token + meta["image_tokens"]
+                stage_result.update(
+                    image_embeds=combined["image_embeds"][image_token:token_end],
+                    image_grid_thw=combined["image_grid_thw"][image_row:row_end],
+                    image_token_counts=combined["image_token_counts"][
+                        image_row:row_end
+                    ],
+                    deepstack_visual_embeds_image=_split_layers(
+                        combined.get("deepstack_visual_embeds_image"),
+                        image_token,
+                        token_end,
+                    ),
+                )
+                image_row, image_token = row_end, token_end
+            if meta["video_rows"]:
+                row_end = video_row + meta["video_rows"]
+                token_end = video_token + meta["video_tokens"]
+                stage_result.update(
+                    video_embeds=combined["video_embeds"][video_token:token_end],
+                    video_grid_thw=combined["video_grid_thw"][video_row:row_end],
+                    video_token_counts=combined["video_token_counts"][
+                        video_row:row_end
+                    ],
+                    deepstack_visual_embeds_video=_split_layers(
+                        combined.get("deepstack_visual_embeds_video"),
+                        video_token,
+                        token_end,
+                    ),
+                )
+                video_row, video_token = row_end, token_end
+
+            cache.put(request.cache_key, stage_result)
+            apply_vision_encoder_result(state, stage_result)
+            results[index] = _store_state(payload, state)
+            for waiter_index, waiter_payload, waiter_state in waiters.get(leader, []):
+                apply_vision_encoder_result(waiter_state, stage_result)
+                results[waiter_index] = _store_state(waiter_payload, waiter_state)
+
+    if any(result is None for result in results):
+        raise RuntimeError("Cosmos3 vision batch did not produce every result")
+    return [result for result in results if result is not None]
+
+
+def _vision_request_cost(model: Cosmos3VisionEncoder):
+    merge = model.spatial_merge_size**2
+    output_width = model.out_hidden_size * (1 + model.deepstack_layers)
+    dtype_bytes = model.visual_dtype_bytes
+
+    def _cost(payload: StagePayload) -> int:
+        state = Cosmos3PipelineState.from_dict(payload.data)
+        request = build_vision_encoder_request(state)
+        if request.skip_result is not None:
+            return 0
+        inputs = request.model_inputs
+        raw_bytes = sum(
+            int(value.numel() * value.element_size())
+            for key in ("pixel_values", "pixel_values_videos")
+            if isinstance((value := inputs.get(key)), torch.Tensor)
+        )
+        visual_tokens = sum(
+            int((value.prod(-1) // merge).sum().item())
+            for key in ("image_grid_thw", "video_grid_thw")
+            if isinstance((value := inputs.get(key)), torch.Tensor)
+        )
+        output_bytes = visual_tokens * output_width * dtype_bytes
+        return (raw_bytes + output_bytes) * VISION_ENCODER_ACTIVATION_MULTIPLIER
+
+    return _cost
+
+
+def create_vision_encoder_executor(
+    model_path: str,
+    *,
+    device: str = "cuda",
+    dtype: str | None = None,
+) -> SimpleScheduler:
+    model = Cosmos3VisionEncoder(model_path, device=device, dtype=dtype)
+    cache = StageOutputCache(
+        max_size=VISION_ENCODER_CACHE_MAX_ENTRIES,
+        max_bytes=VISION_ENCODER_CACHE_MAX_BYTES,
+        cache_device="cpu",
+    )
+    return SimpleScheduler(
+        lambda payload: _run_vision_request(payload, model=model, cache=cache),
+        batch_compute_fn=lambda payloads: _batch_vision_requests(
+            payloads,
+            model=model,
+            cache=cache,
+        ),
+        max_batch_size=32,
+        max_batch_wait_ms=50,
+        request_cost_fn=_vision_request_cost(model),
+        max_batch_cost=VISION_ENCODER_BATCH_BUDGET_BYTES,
+    )
 
 
 def create_sglang_text_executor_from_config(
@@ -85,4 +328,5 @@ __all__ = [
     "create_decode_executor",
     "create_preprocessing_executor",
     "create_sglang_text_executor_from_config",
+    "create_vision_encoder_executor",
 ]

--- a/sglang_omni/models/cosmos3/stages.py
+++ b/sglang_omni/models/cosmos3/stages.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stage factories for Cosmos3 pipelines."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sglang_omni.models.cosmos3.components.text_preprocessor import (
+    Cosmos3TextPreprocessor,
+)
+from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+
+
+def create_preprocessing_executor(
+    model_path: str,
+    *,
+    thinker_max_seq_len: int | None = None,
+) -> SimpleScheduler:
+    """Create the CPU-only text preprocessing stage."""
+
+    preprocessor = Cosmos3TextPreprocessor(
+        model_path=model_path,
+        max_seq_len=thinker_max_seq_len,
+    )
+    return SimpleScheduler(preprocessor)
+
+
+def create_sglang_text_executor_from_config(
+    model_path: str,
+    *,
+    gpu_id: int = 0,
+    tp_rank: int = 0,
+    tp_size: int = 1,
+    nccl_port: int | None = None,
+    thinker_max_seq_len: int = 8192,
+    server_args_overrides: dict[str, Any] | None = None,
+    total_gpu_memory_fraction: float | None = None,
+    enable_async_decode: bool = False,
+    async_decode_min_batch_size: int = 2,
+):
+    """Create the naive single-rank Cosmos3 text AR stage."""
+
+    if tp_size != 1 or tp_rank != 0:
+        raise ValueError("Cosmos3 text MVP supports only tp_size=1")
+
+    from sglang_omni.models.cosmos3.bootstrap import create_text_scheduler
+    from sglang_omni.scheduling.sglang_backend import build_sglang_server_args
+
+    overrides: dict[str, Any] = {
+        "tp_size": 1,
+        "enable_multimodal": False,
+        "language_only": True,
+        "sampling_backend": "pytorch",
+    }
+    overrides.update(server_args_overrides or {})
+    if overrides.get("tp_size") != 1:
+        raise ValueError("Cosmos3 text MVP does not support tensor parallelism")
+    server_args = build_sglang_server_args(
+        model_path,
+        context_length=thinker_max_seq_len,
+        **overrides,
+    )
+    return create_text_scheduler(
+        server_args,
+        gpu_id,
+        tp_rank=tp_rank,
+        nccl_port=nccl_port,
+        total_gpu_memory_fraction=total_gpu_memory_fraction,
+        enable_async_decode=enable_async_decode,
+        async_decode_min_batch_size=async_decode_min_batch_size,
+    )
+
+
+def create_decode_executor(model_path: str):
+    from sglang_omni.models.cosmos3.components.streaming_detokenizer import (
+        create_streaming_detokenize_scheduler,
+    )
+
+    return create_streaming_detokenize_scheduler(model_path)
+
+
+__all__ = [
+    "create_decode_executor",
+    "create_preprocessing_executor",
+    "create_sglang_text_executor_from_config",
+]

--- a/sglang_omni/models/cosmos3/vision_encoder_scheduler.py
+++ b/sglang_omni/models/cosmos3/vision_encoder_scheduler.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Vision encoder scheduling, batching, and caching for Cosmos3."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from sglang_omni.models.cosmos3.components.vision_encoder import Cosmos3VisionEncoder
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.models.cosmos3.request_builders import (
+    apply_vision_encoder_result,
+    build_vision_encoder_request,
+)
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni.scheduling.stage_cache import StageOutputCache
+
+VISION_ENCODER_CACHE_MAX_BYTES = 4 * 1024**3
+VISION_ENCODER_CACHE_MAX_ENTRIES = 64
+VISION_ENCODER_BATCH_BUDGET_BYTES = 10 * 1024**3
+VISION_ENCODER_ACTIVATION_MULTIPLIER = 5
+
+
+def _store_state(
+    payload: StagePayload,
+    state: Cosmos3PipelineState,
+) -> StagePayload:
+    payload.data = state.to_dict()
+    return payload
+
+
+def _run_vision_request(
+    payload: StagePayload,
+    *,
+    model: Cosmos3VisionEncoder,
+    cache: StageOutputCache,
+) -> StagePayload:
+    state = Cosmos3PipelineState.from_dict(payload.data)
+    request = build_vision_encoder_request(state)
+    if request.skip_result is not None:
+        result = request.skip_result
+    else:
+        result = cache.get(request.cache_key)
+        if result is None:
+            with torch.no_grad():
+                result = model(**request.model_inputs)
+            cache.put(request.cache_key, result)
+    apply_vision_encoder_result(state, result)
+    return _store_state(payload, state)
+
+
+def _split_layers(
+    layers: list[torch.Tensor] | None,
+    start: int,
+    end: int,
+) -> list[torch.Tensor] | None:
+    if layers is None:
+        return None
+    return [layer[start:end] for layer in layers]
+
+
+def _batch_vision_requests(
+    payloads: list[StagePayload],
+    *,
+    model: Cosmos3VisionEncoder,
+    cache: StageOutputCache,
+) -> list[StagePayload]:
+    results: list[StagePayload | None] = [None] * len(payloads)
+    active: list[tuple[int, StagePayload, Cosmos3PipelineState, Any]] = []
+    leaders: dict[str, int] = {}
+    waiters: dict[int, list[tuple[int, StagePayload, Cosmos3PipelineState]]] = {}
+
+    for index, payload in enumerate(payloads):
+        state = Cosmos3PipelineState.from_dict(payload.data)
+        request = build_vision_encoder_request(state)
+        if request.skip_result is not None:
+            apply_vision_encoder_result(state, request.skip_result)
+            results[index] = _store_state(payload, state)
+            continue
+        cached = cache.get(request.cache_key)
+        if cached is not None:
+            apply_vision_encoder_result(state, cached)
+            results[index] = _store_state(payload, state)
+            continue
+        if request.cache_key is not None and request.cache_key in leaders:
+            leader = leaders[request.cache_key]
+            waiters.setdefault(leader, []).append((index, payload, state))
+            continue
+        leader = len(active)
+        active.append((index, payload, state, request))
+        if request.cache_key is not None:
+            leaders[request.cache_key] = leader
+
+    if active:
+        image_pixels: list[torch.Tensor] = []
+        image_grids: list[torch.Tensor] = []
+        video_pixels: list[torch.Tensor] = []
+        video_grids: list[torch.Tensor] = []
+        metadata: list[dict[str, int]] = []
+        merge = model.spatial_merge_size**2
+
+        for _, _, _, request in active:
+            values = request.model_inputs
+            image_grid = values.get("image_grid_thw")
+            video_grid = values.get("video_grid_thw")
+            image_rows = (
+                int(image_grid.shape[0]) if isinstance(image_grid, torch.Tensor) else 0
+            )
+            video_rows = (
+                int(video_grid.shape[0]) if isinstance(video_grid, torch.Tensor) else 0
+            )
+            image_tokens = (
+                int((image_grid.prod(-1) // merge).sum().item())
+                if isinstance(image_grid, torch.Tensor)
+                else 0
+            )
+            video_tokens = (
+                int((video_grid.prod(-1) // merge).sum().item())
+                if isinstance(video_grid, torch.Tensor)
+                else 0
+            )
+            if isinstance(values.get("pixel_values"), torch.Tensor):
+                image_pixels.append(values["pixel_values"])
+                image_grids.append(image_grid)
+            if isinstance(values.get("pixel_values_videos"), torch.Tensor):
+                video_pixels.append(values["pixel_values_videos"])
+                video_grids.append(video_grid)
+            metadata.append(
+                {
+                    "image_rows": image_rows,
+                    "video_rows": video_rows,
+                    "image_tokens": image_tokens,
+                    "video_tokens": video_tokens,
+                }
+            )
+
+        batched: dict[str, torch.Tensor] = {}
+        if image_pixels:
+            batched["pixel_values"] = torch.cat(image_pixels, dim=0)
+            batched["image_grid_thw"] = torch.cat(image_grids, dim=0)
+        if video_pixels:
+            batched["pixel_values_videos"] = torch.cat(video_pixels, dim=0)
+            batched["video_grid_thw"] = torch.cat(video_grids, dim=0)
+        with torch.no_grad():
+            combined = model(**batched)
+
+        image_row = image_token = video_row = video_token = 0
+        for leader, ((index, payload, state, request), meta) in enumerate(
+            zip(active, metadata)
+        ):
+            stage_result: dict[str, Any] = {}
+            if meta["image_rows"]:
+                row_end = image_row + meta["image_rows"]
+                token_end = image_token + meta["image_tokens"]
+                stage_result.update(
+                    image_embeds=combined["image_embeds"][image_token:token_end],
+                    image_grid_thw=combined["image_grid_thw"][image_row:row_end],
+                    image_token_counts=combined["image_token_counts"][
+                        image_row:row_end
+                    ],
+                    deepstack_visual_embeds_image=_split_layers(
+                        combined.get("deepstack_visual_embeds_image"),
+                        image_token,
+                        token_end,
+                    ),
+                )
+                image_row, image_token = row_end, token_end
+            if meta["video_rows"]:
+                row_end = video_row + meta["video_rows"]
+                token_end = video_token + meta["video_tokens"]
+                stage_result.update(
+                    video_embeds=combined["video_embeds"][video_token:token_end],
+                    video_grid_thw=combined["video_grid_thw"][video_row:row_end],
+                    video_token_counts=combined["video_token_counts"][
+                        video_row:row_end
+                    ],
+                    deepstack_visual_embeds_video=_split_layers(
+                        combined.get("deepstack_visual_embeds_video"),
+                        video_token,
+                        token_end,
+                    ),
+                )
+                video_row, video_token = row_end, token_end
+
+            cache.put(request.cache_key, stage_result)
+            apply_vision_encoder_result(state, stage_result)
+            results[index] = _store_state(payload, state)
+            for waiter_index, waiter_payload, waiter_state in waiters.get(leader, []):
+                apply_vision_encoder_result(waiter_state, stage_result)
+                results[waiter_index] = _store_state(waiter_payload, waiter_state)
+
+    if any(result is None for result in results):
+        raise RuntimeError("Cosmos3 vision batch did not produce every result")
+    return [result for result in results if result is not None]
+
+
+def _vision_request_cost(model: Cosmos3VisionEncoder):
+    merge = model.spatial_merge_size**2
+    output_width = model.out_hidden_size * (1 + model.deepstack_layers)
+    dtype_bytes = model.visual_dtype_bytes
+
+    def _cost(payload: StagePayload) -> int:
+        state = Cosmos3PipelineState.from_dict(payload.data)
+        request = build_vision_encoder_request(state)
+        if request.skip_result is not None:
+            return 0
+        inputs = request.model_inputs
+        raw_bytes = sum(
+            int(value.numel() * value.element_size())
+            for key in ("pixel_values", "pixel_values_videos")
+            if isinstance((value := inputs.get(key)), torch.Tensor)
+        )
+        visual_tokens = sum(
+            int((value.prod(-1) // merge).sum().item())
+            for key in ("image_grid_thw", "video_grid_thw")
+            if isinstance((value := inputs.get(key)), torch.Tensor)
+        )
+        output_bytes = visual_tokens * output_width * dtype_bytes
+        return (raw_bytes + output_bytes) * VISION_ENCODER_ACTIVATION_MULTIPLIER
+
+    return _cost
+
+
+def create_vision_encoder_scheduler(
+    model_path: str,
+    *,
+    device: str = "cuda",
+    dtype: str | None = None,
+) -> SimpleScheduler:
+    """Create the cached, dynamically batched vision encoder scheduler."""
+
+    model = Cosmos3VisionEncoder(model_path, device=device, dtype=dtype)
+    cache = StageOutputCache(
+        max_size=VISION_ENCODER_CACHE_MAX_ENTRIES,
+        max_bytes=VISION_ENCODER_CACHE_MAX_BYTES,
+        cache_device="cpu",
+    )
+    return SimpleScheduler(
+        lambda payload: _run_vision_request(payload, model=model, cache=cache),
+        batch_compute_fn=lambda payloads: _batch_vision_requests(
+            payloads,
+            model=model,
+            cache=cache,
+        ),
+        max_batch_size=32,
+        max_batch_wait_ms=50,
+        request_cost_fn=_vision_request_cost(model),
+        max_batch_cost=VISION_ENCODER_BATCH_BUDGET_BYTES,
+    )
+
+
+__all__ = ["create_vision_encoder_scheduler"]

--- a/sglang_omni/scheduling/bootstrap.py
+++ b/sglang_omni/scheduling/bootstrap.py
@@ -67,6 +67,7 @@ def create_sglang_infrastructure(
     tp_rank: int = 0,
     nccl_port: int | None = None,
     model_arch_override: str | None = None,
+    model_weights_path: str | None = None,
     weight_prefix: str | None = None,
     capture_hidden_layers: list[int] | None = None,
     total_gpu_memory_fraction: float | None = None,
@@ -86,6 +87,7 @@ def create_sglang_infrastructure(
     model_worker = ModelWorker(
         config=ModelWorkerConfig(
             model_arch_override=model_arch_override,
+            model_weights_path=model_weights_path,
             weight_prefix=weight_prefix,
             nccl_port=nccl_port,
             total_gpu_memory_fraction=total_gpu_memory_fraction,

--- a/sglang_omni/scheduling/continuous_diffusion_scheduler.py
+++ b/sglang_omni/scheduling/continuous_diffusion_scheduler.py
@@ -12,6 +12,9 @@ from collections.abc import Callable, Hashable
 from dataclasses import dataclass
 from typing import Any, Generic, Protocol, TypeVar
 
+from sglang.srt.distributed.parallel_state import GroupCoordinator
+from sglang.srt.utils import broadcast_pyobj
+
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
 
 logger = logging.getLogger(__name__)
@@ -66,6 +69,7 @@ class ContinuousDiffusionScheduler(Generic[StateT]):
         self,
         backend: ContinuousDiffusionBackend[StateT],
         *,
+        tp_group: GroupCoordinator,
         max_batch_size: int = 1,
         max_running_requests: int | None = None,
         max_batch_wait_ms: int = 0,
@@ -74,7 +78,12 @@ class ContinuousDiffusionScheduler(Generic[StateT]):
     ) -> None:
         self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
         self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
-        self.requires_tp_work_fanout: bool = True
+        self.requires_tp_work_fanout: bool = False
+
+        self.tp_group = tp_group
+        self.tp_rank = tp_group.rank_in_group
+        self.tp_size = tp_group.world_size
+        self.is_entry_rank = self.tp_rank == 0
 
         self._backend = backend
         self._max_batch_size = max(int(max_batch_size), 1)
@@ -147,18 +156,35 @@ class ContinuousDiffusionScheduler(Generic[StateT]):
             self._aborted.discard(request_id)
 
     def _drain_messages(self, *, block: bool) -> None:
+        messages = self._drain_local_inbox(block=block) if self.is_entry_rank else []
+        for message in self._broadcast_messages(messages):
+            self._handle_message(message)
+
+    def _drain_local_inbox(self, *, block: bool) -> list[IncomingMessage]:
+        messages: list[IncomingMessage] = []
         if block:
             try:
-                self._handle_message(self.inbox.get(timeout=0.05))
+                messages.append(self.inbox.get(timeout=0.05))
             except _queue_mod.Empty:
-                return
+                return messages
 
         while True:
             try:
-                message = self.inbox.get_nowait()
+                messages.append(self.inbox.get_nowait())
             except _queue_mod.Empty:
-                return
-            self._handle_message(message)
+                return messages
+
+    def _broadcast_messages(
+        self, messages: list[IncomingMessage]
+    ) -> list[IncomingMessage]:
+        if self.tp_size == 1:
+            return messages
+        return broadcast_pyobj(
+            messages,
+            self.tp_group.rank,
+            self.tp_group.cpu_group,
+            src=self.tp_group.ranks[0],
+        )
 
     def _handle_message(self, message: IncomingMessage) -> None:
         if message.type != "new_request":
@@ -204,15 +230,21 @@ class ContinuousDiffusionScheduler(Generic[StateT]):
     def _wait_for_initial_batch(self) -> None:
         if self._max_batch_wait_s <= 0:
             return
-        deadline = time.monotonic() + self._max_batch_wait_s
-        while len(self._waiting) < self._max_running_requests:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return
-            try:
-                message = self.inbox.get(timeout=remaining)
-            except _queue_mod.Empty:
-                return
+
+        messages: list[IncomingMessage] = []
+        if self.is_entry_rank:
+            deadline = time.monotonic() + self._max_batch_wait_s
+            available_slots = self._max_running_requests - len(self._waiting)
+            while len(messages) < available_slots:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                try:
+                    messages.append(self.inbox.get(timeout=remaining))
+                except _queue_mod.Empty:
+                    break
+
+        for message in self._broadcast_messages(messages):
             self._handle_message(message)
 
     def _purge_aborted(self) -> None:
@@ -347,13 +379,7 @@ class ContinuousDiffusionScheduler(Generic[StateT]):
 
             self._resident.pop(request.request_id, None)
             if not self._is_aborted(request.request_id):
-                self.outbox.put(
-                    OutgoingMessage(
-                        request_id=request.request_id,
-                        type="result",
-                        data=result,
-                    )
-                )
+                self._emit_result(request.request_id, result)
             self._release(request)
             self._clear_aborted(request.request_id)
 
@@ -366,7 +392,16 @@ class ContinuousDiffusionScheduler(Generic[StateT]):
         self._release(request)
         self._clear_aborted(request.request_id)
 
+    def _emit_result(self, request_id: str, result: Any) -> None:
+        if not self.is_entry_rank:
+            return
+        self.outbox.put(
+            OutgoingMessage(request_id=request_id, type="result", data=result)
+        )
+
     def _emit_error(self, request_id: str, error: BaseException) -> None:
+        if not self.is_entry_rank:
+            return
         self.outbox.put(
             OutgoingMessage(
                 request_id=request_id,

--- a/sglang_omni/scheduling/continuous_diffusion_scheduler.py
+++ b/sglang_omni/scheduling/continuous_diffusion_scheduler.py
@@ -1,0 +1,400 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stage-facing scheduler for continuous diffusion requests."""
+
+from __future__ import annotations
+
+import collections
+import logging
+import queue as _queue_mod
+import threading
+import time
+from collections.abc import Callable, Hashable
+from dataclasses import dataclass
+from typing import Any, Generic, Protocol, TypeVar
+
+from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
+
+logger = logging.getLogger(__name__)
+
+StateT = TypeVar("StateT")
+
+_ABORTED_REQUEST_ID_LIMIT = 10000
+_ABORTED_REQUEST_ID_RETAINED = 5000
+
+
+class ContinuousDiffusionBackend(Protocol[StateT]):
+    """Model-owned operations required by the generic diffusion scheduler."""
+
+    def prepare(self, payload: Any) -> StateT: ...
+
+    def batch_key(self, state: StateT) -> Hashable: ...
+
+    def step(self, states: list[StateT]) -> None: ...
+
+    def is_finished(self, state: StateT) -> bool: ...
+
+    def finalize(self, state: StateT) -> Any: ...
+
+    def release(self, state: StateT) -> None: ...
+
+
+@dataclass
+class _PendingRequest:
+    request_id: str
+    payload: Any
+    cost: int
+
+
+@dataclass
+class _ResidentRequest(Generic[StateT]):
+    request_id: str
+    state: StateT
+    batch_key: Hashable
+    cost: int
+
+
+class ContinuousDiffusionScheduler(Generic[StateT]):
+    """Interleave request-local denoising chains one model step at a time.
+
+    The backend owns all model and algorithm state. This scheduler only owns
+    request admission, compatible batching, lifecycle, and cleanup, while
+    exposing the standard Omni stage contract: ``inbox``, ``outbox``,
+    ``start()``, ``stop()``, and ``abort(request_id)``.
+    """
+
+    def __init__(
+        self,
+        backend: ContinuousDiffusionBackend[StateT],
+        *,
+        max_batch_size: int = 1,
+        max_running_requests: int | None = None,
+        max_batch_wait_ms: int = 0,
+        request_cost_fn: Callable[[Any], int] | None = None,
+        max_batch_cost: int | None = None,
+    ) -> None:
+        self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
+        self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
+        self.requires_tp_work_fanout: bool = True
+
+        self._backend = backend
+        self._max_batch_size = max(int(max_batch_size), 1)
+        self._max_running_requests = max(
+            int(
+                self._max_batch_size
+                if max_running_requests is None
+                else max_running_requests
+            ),
+            1,
+        )
+        self._max_batch_wait_s = max(float(max_batch_wait_ms), 0.0) / 1000.0
+        self._request_cost_fn = request_cost_fn
+        self._max_batch_cost = (
+            max(int(max_batch_cost), 0) if max_batch_cost is not None else None
+        )
+
+        self._waiting: collections.deque[_PendingRequest] = collections.deque()
+        self._waiting_ids: set[str] = set()
+        self._resident: dict[str, _ResidentRequest[StateT]] = {}
+        self._ready: collections.deque[str] = collections.deque()
+
+        self._running = False
+        self._aborted: set[str] = set()
+        self._abort_lock = threading.Lock()
+
+    def start(self) -> None:
+        self._running = True
+        try:
+            while self._running:
+                idle = not self._waiting and not self._resident
+                self._drain_messages(block=idle)
+                self._purge_aborted()
+                if not self._running:
+                    break
+
+                if not self._resident and len(self._waiting) == 1:
+                    self._wait_for_initial_batch()
+                    self._purge_aborted()
+
+                self._admit_waiting_requests()
+                batch = self._select_batch()
+                if not batch:
+                    continue
+                self._run_step(batch)
+        finally:
+            self._release_all()
+
+    def event_loop(self) -> None:
+        self.start()
+
+    def stop(self) -> None:
+        self._running = False
+
+    def abort(self, request_id: str) -> None:
+        with self._abort_lock:
+            self._aborted.add(request_id)
+            if len(self._aborted) <= _ABORTED_REQUEST_ID_LIMIT:
+                return
+            excess = len(self._aborted) - _ABORTED_REQUEST_ID_RETAINED
+            for stale_request_id in list(self._aborted)[:excess]:
+                self._aborted.discard(stale_request_id)
+
+    def _is_aborted(self, request_id: str) -> bool:
+        with self._abort_lock:
+            return request_id in self._aborted
+
+    def _clear_aborted(self, request_id: str) -> None:
+        with self._abort_lock:
+            self._aborted.discard(request_id)
+
+    def _drain_messages(self, *, block: bool) -> None:
+        if block:
+            try:
+                self._handle_message(self.inbox.get(timeout=0.05))
+            except _queue_mod.Empty:
+                return
+
+        while True:
+            try:
+                message = self.inbox.get_nowait()
+            except _queue_mod.Empty:
+                return
+            self._handle_message(message)
+
+    def _handle_message(self, message: IncomingMessage) -> None:
+        if message.type != "new_request":
+            logger.warning(
+                "%s: unhandled message type %r for request %s",
+                self.__class__.__name__,
+                message.type,
+                message.request_id,
+            )
+            return
+        if self._is_aborted(message.request_id):
+            self._clear_aborted(message.request_id)
+            return
+        if (
+            message.request_id in self._waiting_ids
+            or message.request_id in self._resident
+        ):
+            self._emit_error(
+                message.request_id,
+                ValueError(f"duplicate request id: {message.request_id}"),
+            )
+            return
+
+        try:
+            cost = (
+                max(int(self._request_cost_fn(message.data)), 0)
+                if self._request_cost_fn is not None
+                else 0
+            )
+        except Exception as exc:
+            self._emit_error(message.request_id, exc)
+            return
+
+        self._waiting.append(
+            _PendingRequest(
+                request_id=message.request_id,
+                payload=message.data,
+                cost=cost,
+            )
+        )
+        self._waiting_ids.add(message.request_id)
+
+    def _wait_for_initial_batch(self) -> None:
+        if self._max_batch_wait_s <= 0:
+            return
+        deadline = time.monotonic() + self._max_batch_wait_s
+        while len(self._waiting) < self._max_running_requests:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            try:
+                message = self.inbox.get(timeout=remaining)
+            except _queue_mod.Empty:
+                return
+            self._handle_message(message)
+
+    def _purge_aborted(self) -> None:
+        if self._waiting:
+            kept: collections.deque[_PendingRequest] = collections.deque()
+            for request in self._waiting:
+                if self._is_aborted(request.request_id):
+                    self._waiting_ids.discard(request.request_id)
+                    self._clear_aborted(request.request_id)
+                else:
+                    kept.append(request)
+            self._waiting = kept
+
+        for request_id, request in list(self._resident.items()):
+            if not self._is_aborted(request_id):
+                continue
+            self._resident.pop(request_id, None)
+            self._release(request)
+            self._clear_aborted(request_id)
+
+        if self._ready:
+            self._ready = collections.deque(
+                request_id for request_id in self._ready if request_id in self._resident
+            )
+
+    def _admit_waiting_requests(self) -> None:
+        while (
+            self._waiting
+            and len(self._resident) < self._max_running_requests
+            and self._running
+        ):
+            pending = self._waiting.popleft()
+            self._waiting_ids.discard(pending.request_id)
+            if self._is_aborted(pending.request_id):
+                self._clear_aborted(pending.request_id)
+                continue
+
+            state_created = False
+            try:
+                state = self._backend.prepare(pending.payload)
+                state_created = True
+                batch_key = self._backend.batch_key(state)
+                hash(batch_key)
+            except Exception as exc:
+                if state_created:
+                    self._release_state(pending.request_id, state)
+                if self._is_aborted(pending.request_id):
+                    self._clear_aborted(pending.request_id)
+                else:
+                    self._emit_error(pending.request_id, exc)
+                continue
+
+            request = _ResidentRequest(
+                request_id=pending.request_id,
+                state=state,
+                batch_key=batch_key,
+                cost=pending.cost,
+            )
+            if self._is_aborted(pending.request_id):
+                self._release(request)
+                self._clear_aborted(pending.request_id)
+                continue
+            self._resident[pending.request_id] = request
+            self._ready.append(pending.request_id)
+
+    def _select_batch(self) -> list[_ResidentRequest[StateT]]:
+        while self._ready and self._ready[0] not in self._resident:
+            self._ready.popleft()
+        if not self._ready:
+            return []
+
+        first = self._resident[self._ready.popleft()]
+        selected = [first]
+        batch_cost = first.cost
+        candidates = len(self._ready)
+
+        for _ in range(candidates):
+            if len(selected) >= self._max_batch_size:
+                break
+            request_id = self._ready.popleft()
+            request = self._resident.get(request_id)
+            if request is None:
+                continue
+            compatible = request.batch_key == first.batch_key
+            within_budget = (
+                self._max_batch_cost is None
+                or batch_cost + request.cost <= self._max_batch_cost
+            )
+            if compatible and within_budget:
+                selected.append(request)
+                batch_cost += request.cost
+            else:
+                self._ready.append(request_id)
+
+        return selected
+
+    def _run_step(self, batch: list[_ResidentRequest[StateT]]) -> None:
+        try:
+            self._backend.step([request.state for request in batch])
+        except Exception as exc:
+            logger.exception("Continuous diffusion backend step failed")
+            for request in batch:
+                if self._resident.pop(request.request_id, None) is None:
+                    continue
+                if not self._is_aborted(request.request_id):
+                    self._emit_error(request.request_id, exc)
+                self._release(request)
+                self._clear_aborted(request.request_id)
+            return
+
+        # abort() can run from the stage event-loop thread while the model step
+        # is executing in this scheduler thread.
+        self._purge_aborted()
+        for request in batch:
+            if self._resident.get(request.request_id) is not request:
+                continue
+            try:
+                finished = self._backend.is_finished(request.state)
+            except Exception as exc:
+                self._fail_request(request, exc)
+                continue
+
+            if not finished:
+                self._ready.append(request.request_id)
+                continue
+
+            try:
+                result = self._backend.finalize(request.state)
+            except Exception as exc:
+                self._fail_request(request, exc)
+                continue
+
+            self._resident.pop(request.request_id, None)
+            if not self._is_aborted(request.request_id):
+                self.outbox.put(
+                    OutgoingMessage(
+                        request_id=request.request_id,
+                        type="result",
+                        data=result,
+                    )
+                )
+            self._release(request)
+            self._clear_aborted(request.request_id)
+
+    def _fail_request(
+        self, request: _ResidentRequest[StateT], error: BaseException
+    ) -> None:
+        self._resident.pop(request.request_id, None)
+        if not self._is_aborted(request.request_id):
+            self._emit_error(request.request_id, error)
+        self._release(request)
+        self._clear_aborted(request.request_id)
+
+    def _emit_error(self, request_id: str, error: BaseException) -> None:
+        self.outbox.put(
+            OutgoingMessage(
+                request_id=request_id,
+                type="error",
+                data=error,
+            )
+        )
+
+    def _release(self, request: _ResidentRequest[StateT]) -> None:
+        self._release_state(request.request_id, request.state)
+
+    def _release_state(self, request_id: str, state: StateT) -> None:
+        try:
+            self._backend.release(state)
+        except Exception:
+            logger.exception(
+                "%s: cleanup failed for request %s",
+                self.__class__.__name__,
+                request_id,
+            )
+
+    def _release_all(self) -> None:
+        for request in list(self._resident.values()):
+            self._release(request)
+        self._resident.clear()
+        self._ready.clear()
+        self._waiting.clear()
+        self._waiting_ids.clear()
+
+
+__all__ = ["ContinuousDiffusionBackend", "ContinuousDiffusionScheduler"]

--- a/tests/unit_test/cosmos3/__init__.py
+++ b/tests/unit_test/cosmos3/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/unit_test/cosmos3/test_bootstrap.py
+++ b/tests/unit_test/cosmos3/test_bootstrap.py
@@ -9,13 +9,8 @@ from sglang.srt.utils import hf_transformers_utils
 from sglang_omni.model_runner import base as model_runner_base
 from sglang_omni.models.cosmos3 import bootstrap, request_builders
 from sglang_omni.models.cosmos3.bootstrap import resolve_transformer_weights_path
-from sglang_omni.scheduling import (
-    bootstrap as scheduling_bootstrap,
-)
-from sglang_omni.scheduling import (
-    omni_scheduler,
-    sglang_backend,
-)
+from sglang_omni.scheduling import bootstrap as scheduling_bootstrap
+from sglang_omni.scheduling import omni_scheduler, sglang_backend
 
 
 def test_resolves_nested_transformer_weights_directory(tmp_path) -> None:

--- a/tests/unit_test/cosmos3/test_bootstrap.py
+++ b/tests/unit_test/cosmos3/test_bootstrap.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from sglang.srt.utils import hf_transformers_utils
+
+from sglang_omni.model_runner import base as model_runner_base
+from sglang_omni.models.cosmos3 import bootstrap, request_builders
+from sglang_omni.models.cosmos3.bootstrap import resolve_transformer_weights_path
+from sglang_omni.scheduling import (
+    bootstrap as scheduling_bootstrap,
+)
+from sglang_omni.scheduling import (
+    omni_scheduler,
+    sglang_backend,
+)
+
+
+def test_resolves_nested_transformer_weights_directory(tmp_path) -> None:
+    transformer_path = tmp_path / "transformer"
+    transformer_path.mkdir()
+    (transformer_path / "model.safetensors").touch()
+
+    assert resolve_transformer_weights_path(str(tmp_path)) == str(transformer_path)
+
+
+def test_remote_resolution_refetches_incomplete_local_snapshot(
+    monkeypatch, tmp_path
+) -> None:
+    partial_snapshot = tmp_path / "partial"
+    partial_snapshot.mkdir()
+    complete_snapshot = tmp_path / "complete"
+    transformer_path = complete_snapshot / "transformer"
+    transformer_path.mkdir(parents=True)
+    (transformer_path / "model.safetensors").touch()
+    local_only_calls: list[bool] = []
+
+    def fake_snapshot_download(model_path, **kwargs):
+        del model_path
+        local_only = bool(kwargs.get("local_files_only"))
+        local_only_calls.append(local_only)
+        return str(partial_snapshot if local_only else complete_snapshot)
+
+    monkeypatch.setattr(bootstrap, "snapshot_download", fake_snapshot_download)
+
+    assert resolve_transformer_weights_path("nvidia/Cosmos3-Nano") == str(
+        transformer_path
+    )
+    assert local_only_calls == [True, False]
+
+
+def test_thinker_loads_tokenizer_from_checkpoint_root(monkeypatch, tmp_path) -> None:
+    transformer_path = tmp_path / "transformer"
+    transformer_path.mkdir()
+    (transformer_path / "model.safetensors").touch()
+    server_args = SimpleNamespace(model_path=str(tmp_path))
+    model_config = SimpleNamespace(
+        model_path=str(transformer_path),
+        vocab_size=10,
+        hf_generation_config=SimpleNamespace(),
+    )
+    tokenizer_paths: list[str] = []
+
+    monkeypatch.setattr(
+        scheduling_bootstrap,
+        "create_sglang_infrastructure",
+        lambda *args, **kwargs: (
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            model_config,
+        ),
+    )
+    monkeypatch.setattr(
+        hf_transformers_utils,
+        "get_tokenizer",
+        lambda path, **kwargs: tokenizer_paths.append(path) or object(),
+    )
+    monkeypatch.setattr(model_runner_base, "ModelRunner", lambda *args: object())
+    monkeypatch.setattr(
+        request_builders,
+        "make_text_scheduler_adapters",
+        lambda **kwargs: (object(), object()),
+    )
+    monkeypatch.setattr(
+        request_builders,
+        "make_text_stream_output_builder",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        sglang_backend,
+        "SGLangOutputProcessor",
+        lambda **kwargs: object(),
+    )
+    monkeypatch.setattr(omni_scheduler, "OmniScheduler", SimpleNamespace)
+
+    bootstrap.create_thinker_scheduler(server_args)
+
+    assert tokenizer_paths == [str(tmp_path)]

--- a/tests/unit_test/cosmos3/test_bootstrap.py
+++ b/tests/unit_test/cosmos3/test_bootstrap.py
@@ -6,8 +6,8 @@ from types import SimpleNamespace
 
 from sglang.srt.utils import hf_transformers_utils
 
-from sglang_omni.model_runner import base as model_runner_base
 from sglang_omni.models.cosmos3 import bootstrap, request_builders
+from sglang_omni.models.cosmos3 import model_runner as cosmos_model_runner
 from sglang_omni.models.cosmos3.bootstrap import resolve_transformer_weights_path
 from sglang_omni.scheduling import bootstrap as scheduling_bootstrap
 from sglang_omni.scheduling import omni_scheduler, sglang_backend
@@ -55,6 +55,7 @@ def test_thinker_loads_tokenizer_from_checkpoint_root(monkeypatch, tmp_path) -> 
         model_path=str(transformer_path),
         vocab_size=10,
         hf_generation_config=SimpleNamespace(),
+        hf_config=SimpleNamespace(),
     )
     tokenizer_paths: list[str] = []
 
@@ -76,7 +77,11 @@ def test_thinker_loads_tokenizer_from_checkpoint_root(monkeypatch, tmp_path) -> 
         "get_tokenizer",
         lambda path, **kwargs: tokenizer_paths.append(path) or object(),
     )
-    monkeypatch.setattr(model_runner_base, "ModelRunner", lambda *args: object())
+    monkeypatch.setattr(
+        cosmos_model_runner,
+        "Cosmos3ThinkerModelRunner",
+        lambda *args: object(),
+    )
     monkeypatch.setattr(
         request_builders,
         "make_text_scheduler_adapters",

--- a/tests/unit_test/cosmos3/test_config.py
+++ b/tests/unit_test/cosmos3/test_config.py
@@ -2,11 +2,42 @@
 
 from __future__ import annotations
 
-from sglang_omni.models.cosmos3.config import Cosmos3TextPipelineConfig
+from sglang_omni.models.cosmos3.config import (
+    Cosmos3PipelineConfig,
+    Cosmos3TextPipelineConfig,
+)
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 
 
-def test_text_pipeline_has_preprocess_ar_decode_topology() -> None:
+def test_pipeline_has_separate_vision_encoder_topology() -> None:
+    config = Cosmos3PipelineConfig(model_path="nvidia/Cosmos3-Nano")
+
+    assert [stage.name for stage in config.stages] == [
+        "preprocessing",
+        "vision_encoder",
+        "thinker",
+        "decode",
+    ]
+    assert config.stages[0].next == ["vision_encoder", "thinker"]
+    assert config.stages[1].next == "thinker"
+    assert config.stages[2].wait_for == ["preprocessing", "vision_encoder"]
+    assert config.stages[2].wait_for_fn.endswith(".resolve_thinker_wait_sources")
+    assert config.stages[2].merge_fn.endswith(".merge_for_thinker")
+    assert config.stages[2].tp_size == 1
+    assert config.stages[2].next == "decode"
+    assert config.stages[2].stream_to == ["decode"]
+    assert config.stages[3].terminal is True
+    assert config.stages[3].can_accept_stream_before_payload is True
+
+
+def test_cosmos_architecture_is_discoverable() -> None:
+    assert (
+        PIPELINE_CONFIG_REGISTRY.get_config("Cosmos3ForConditionalGeneration")
+        is Cosmos3PipelineConfig
+    )
+
+
+def test_text_variant_does_not_load_vision_stage() -> None:
     config = Cosmos3TextPipelineConfig(model_path="nvidia/Cosmos3-Nano")
 
     assert [stage.name for stage in config.stages] == [
@@ -14,16 +45,6 @@ def test_text_pipeline_has_preprocess_ar_decode_topology() -> None:
         "thinker",
         "decode",
     ]
-    assert config.stages[0].next == "thinker"
-    assert config.stages[1].tp_size == 1
-    assert config.stages[1].next == "decode"
-    assert config.stages[1].stream_to == ["decode"]
-    assert config.stages[2].terminal is True
-    assert config.stages[2].can_accept_stream_before_payload is True
-
-
-def test_cosmos_architecture_is_discoverable() -> None:
-    assert (
-        PIPELINE_CONFIG_REGISTRY.get_config("Cosmos3ForConditionalGeneration")
-        is Cosmos3TextPipelineConfig
-    )
+    assert config.stages[1].wait_for is None
+    assert config.stages[1].merge_fn is None
+    assert config.generation_sglang_role_to_stage() == {"generation": "thinker"}

--- a/tests/unit_test/cosmos3/test_config.py
+++ b/tests/unit_test/cosmos3/test_config.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from sglang_omni.models.cosmos3.config import Cosmos3TextPipelineConfig
+from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+
+
+def test_text_pipeline_has_preprocess_ar_decode_topology() -> None:
+    config = Cosmos3TextPipelineConfig(model_path="nvidia/Cosmos3-Nano")
+
+    assert [stage.name for stage in config.stages] == [
+        "preprocessing",
+        "thinker",
+        "decode",
+    ]
+    assert config.stages[0].next == "thinker"
+    assert config.stages[1].tp_size == 1
+    assert config.stages[1].next == "decode"
+    assert config.stages[1].stream_to == ["decode"]
+    assert config.stages[2].terminal is True
+    assert config.stages[2].can_accept_stream_before_payload is True
+
+
+def test_cosmos_architecture_is_discoverable() -> None:
+    assert (
+        PIPELINE_CONFIG_REGISTRY.get_config("Cosmos3ForConditionalGeneration")
+        is Cosmos3TextPipelineConfig
+    )

--- a/tests/unit_test/cosmos3/test_hf_config.py
+++ b/tests/unit_test/cosmos3/test_hf_config.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+from transformers import AutoConfig
+from transformers.models.qwen3_vl.configuration_qwen3_vl import (
+    Qwen3VLTextConfig,
+    Qwen3VLVisionConfig,
+)
+
+from sglang_omni.models.cosmos3.hf_config import Cosmos3OmniConfig
+
+
+def _nano_config() -> dict:
+    return {
+        "model_type": "cosmos3_omni",
+        "architectures": ["Cosmos3ForConditionalGeneration"],
+        "image_token_id": 151655,
+        "video_token_id": 151656,
+        "vision_start_token_id": 151652,
+        "vision_end_token_id": 151653,
+        "tie_word_embeddings": False,
+        "text_config": {
+            "model_type": "qwen3_vl_text",
+            "vocab_size": 151936,
+            "hidden_size": 4096,
+            "intermediate_size": 12288,
+            "num_hidden_layers": 36,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 8,
+            "head_dim": 128,
+            "max_position_embeddings": 262144,
+            "bos_token_id": 151643,
+            "eos_token_id": 151645,
+            "rope_theta": 5000000,
+            "rope_scaling": {
+                "mrope_interleaved": True,
+                "mrope_section": [24, 20, 20],
+                "rope_type": "default",
+            },
+        },
+        "vision_config": {
+            "model_type": "qwen3_vl",
+            "depth": 27,
+            "hidden_size": 1152,
+            "intermediate_size": 4304,
+            "num_heads": 16,
+            "out_hidden_size": 4096,
+        },
+        "model": {
+            "_target": "cosmos_predict2._src.predict2.cosmos3.models.Cosmos3Model",
+            "config": {"vlm_config": {"model_name": "Cosmos3-Nano-Reasoner"}},
+        },
+    }
+
+
+def test_auto_config_loads_cosmos3_nano_shape(tmp_path) -> None:
+    (tmp_path / "config.json").write_text(json.dumps(_nano_config()))
+
+    config = AutoConfig.from_pretrained(tmp_path)
+
+    assert isinstance(config, Cosmos3OmniConfig)
+    assert isinstance(config.text_config, Qwen3VLTextConfig)
+    assert isinstance(config.vision_config, Qwen3VLVisionConfig)
+    assert config.architectures == ["Cosmos3ForConditionalGeneration"]
+    assert config.text_config.hidden_size == 4096
+    assert config.text_config.intermediate_size == 12288
+    assert config.text_config.num_hidden_layers == 36
+    assert config.text_config.num_key_value_heads == 8
+    assert config.text_config.bos_token_id == 151643
+    assert config.text_config.eos_token_id == 151645
+    assert config.text_config.rope_scaling["mrope_section"] == [24, 20, 20]
+    assert config.model["config"]["vlm_config"]["model_name"] == (
+        "Cosmos3-Nano-Reasoner"
+    )
+
+
+def test_cosmos3_config_preserves_top_level_model_type() -> None:
+    config = Cosmos3OmniConfig(**_nano_config())
+
+    assert config.model_type == "cosmos3_omni"
+    assert config.to_dict()["model_type"] == "cosmos3_omni"

--- a/tests/unit_test/cosmos3/test_merge.py
+++ b/tests/unit_test/cosmos3/test_merge.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+
+from sglang_omni.models.cosmos3.merge import merge_for_thinker
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+def _payload(stage: str, state: Cosmos3PipelineState) -> StagePayload:
+    return StagePayload(
+        request_id="merge",
+        request=OmniRequest(inputs=None),
+        data=state.to_dict(),
+    )
+
+
+def test_merge_builds_thinker_inputs_without_duplicate_encoder_payload() -> None:
+    prompt = {
+        "input_ids": torch.tensor([10, 151655, 11]),
+        "attention_mask": torch.ones(3, dtype=torch.long),
+        "prompt_text": "prompt",
+        "mm_token_type_ids": torch.tensor([0, 1, 0]),
+    }
+    preprocessing = Cosmos3PipelineState(
+        prompt=prompt,
+        mm_inputs={"image_grid_thw": torch.tensor([[1, 2, 2]])},
+        encoder_inputs={"vision_encoder": {"cache_key": "key", "_active": True}},
+    )
+    embeddings = torch.ones((1, 4))
+    deepstack = [torch.full((1, 4), index) for index in range(3)]
+    vision = Cosmos3PipelineState(
+        encoder_outs={
+            "vision_encoder": {
+                "image_embeds": embeddings,
+                "image_grid_thw": torch.tensor([[1, 2, 2]]),
+                "deepstack_visual_embeds_image": deepstack,
+            }
+        }
+    )
+
+    result = merge_for_thinker(
+        {
+            "preprocessing": _payload("preprocessing", preprocessing),
+            "vision_encoder": _payload("vision_encoder", vision),
+        }
+    )
+    state = Cosmos3PipelineState.from_dict(result.data)
+    model_inputs = state.thinker_inputs["model_inputs"]
+
+    assert model_inputs["image_embeds"] is embeddings
+    assert model_inputs["deepstack_visual_embeds"] is deepstack
+    assert state.thinker_inputs["media_cache_key"] == "key"
+    assert state.encoder_inputs == {}
+    assert state.encoder_outs == {}

--- a/tests/unit_test/cosmos3/test_request_builders.py
+++ b/tests/unit_test/cosmos3/test_request_builders.py
@@ -13,8 +13,14 @@ from sglang_omni.models.cosmos3.request_builders import (
     apply_text_result,
     build_cosmos3_sampling_kwargs,
     build_sglang_text_request,
+    compute_cosmos3_mrope_positions,
     make_text_scheduler_adapters,
     make_text_stream_output_builder,
+    project_preprocessing_to_thinker,
+    project_preprocessing_to_vision_encoder,
+    project_thinker_to_decode,
+    resolve_preprocessing_next_stages,
+    resolve_thinker_wait_sources,
 )
 from sglang_omni.proto import EXPLICIT_GENERATION_PARAMS_KEY, OmniRequest, StagePayload
 
@@ -271,3 +277,124 @@ def test_apply_text_result_preserves_optional_metadata() -> None:
     assert output["finish_reason"] == "length"
     assert output["output_token_logprobs"] == [-0.5]
     assert output["weight_version"] == "v1"
+
+
+def test_cosmos3_image_mrope_fills_text_axes_and_uses_visual_grid() -> None:
+    token_types = torch.tensor([0, 0, *([1] * 4), 0], dtype=torch.long)
+    positions, delta = compute_cosmos3_mrope_positions(
+        torch.arange(7),
+        token_types,
+        image_grid_thw=torch.tensor([[1, 4, 4]]),
+        video_grid_thw=None,
+        spatial_merge_size=2,
+    )
+
+    assert positions.tolist() == [
+        [0, 1, 2, 2, 2, 2, 4],
+        [0, 1, 2, 2, 3, 3, 4],
+        [0, 1, 2, 3, 2, 3, 4],
+    ]
+    assert delta.tolist() == [[-2]]
+
+
+def test_preprocessing_routes_vision_only_when_media_is_active() -> None:
+    payload = StagePayload(
+        request_id="route",
+        request=OmniRequest(inputs=None),
+        data=_state().to_dict(),
+    )
+    assert resolve_preprocessing_next_stages("route", payload) == ["thinker"]
+    assert resolve_thinker_wait_sources("route", "preprocessing", payload) == [
+        "preprocessing"
+    ]
+
+    state = _state()
+    state.encoder_inputs = {
+        "vision_encoder": {
+            "pixel_values": torch.ones((4, 6)),
+            "image_grid_thw": torch.tensor([[1, 2, 2]]),
+            "cache_key": "image-key",
+        }
+    }
+    payload.data = state.to_dict()
+
+    assert resolve_preprocessing_next_stages("route", payload) == [
+        "vision_encoder",
+        "thinker",
+    ]
+    assert resolve_thinker_wait_sources("route", "vision_encoder", payload) is None
+    assert resolve_thinker_wait_sources("route", "preprocessing", payload) == [
+        "preprocessing",
+        "vision_encoder",
+    ]
+    encoder_payload = project_preprocessing_to_vision_encoder(payload)
+    thinker_payload = project_preprocessing_to_thinker(payload)
+    encoder_state = Cosmos3PipelineState.from_dict(encoder_payload.data)
+    thinker_state = Cosmos3PipelineState.from_dict(thinker_payload.data)
+    assert "pixel_values" in encoder_state.encoder_inputs["vision_encoder"]
+    assert thinker_state.encoder_inputs == {
+        "vision_encoder": {"cache_key": "image-key", "_active": True}
+    }
+
+
+def test_builds_multimodal_request_with_precomputed_vision_inputs() -> None:
+    state = Cosmos3PipelineState(
+        prompt={
+            "input_ids": torch.tensor([10, 151655, 11]),
+            "attention_mask": torch.ones(3, dtype=torch.long),
+            "prompt_text": "image prompt",
+            "mm_token_type_ids": torch.tensor([0, 1, 0]),
+        },
+        thinker_inputs={
+            "model_inputs": {
+                "image_embeds": torch.ones((1, 4)),
+                "deepstack_visual_embeds": [torch.ones((1, 4)) for _ in range(3)],
+                "image_grid_thw": torch.tensor([[1, 2, 2]]),
+            },
+            "media_cache_key": "image-key",
+        },
+    )
+    config = SimpleNamespace(
+        image_token_id=151655,
+        video_token_id=151656,
+        vision_config=SimpleNamespace(spatial_merge_size=2),
+    )
+
+    data = build_sglang_text_request(
+        state,
+        params={"max_new_tokens": 2},
+        tokenizer=_FakeTokenizer(),
+        vocab_size=151936,
+        thinker_config=config,
+    )
+
+    assert data.req.multimodal_inputs.mrope_positions.tolist() == [
+        [0, 1, 2],
+        [0, 1, 2],
+        [0, 1, 2],
+    ]
+    assert data.req.omni_model_inputs["image_embeds"].shape == (1, 4)
+    assert data.req.origin_input_ids[1] > 151936
+    assert (
+        data.req.omni_model_inputs["pad_values"]["image"]
+        == (data.req.origin_input_ids[1])
+    )
+
+
+def test_decode_projection_drops_prefill_only_vision_tensors() -> None:
+    state = _state()
+    state.mm_inputs = {"image_grid_thw": torch.tensor([[1, 2, 2]])}
+    state.thinker_inputs = {"model_inputs": {"image_embeds": torch.ones((1, 4))}}
+    state.text_out = {"output_ids": [42], "is_final": True}
+    payload = StagePayload(
+        request_id="decode-projection",
+        request=OmniRequest(inputs=None),
+        data=state.to_dict(),
+    )
+
+    projected = Cosmos3PipelineState.from_dict(project_thinker_to_decode(payload).data)
+
+    assert projected.thinker_inputs == {}
+    assert projected.mm_inputs == {}
+    assert projected.text_out == {"output_ids": [42], "is_final": True}
+    assert projected.prompt is not None

--- a/tests/unit_test/cosmos3/test_request_builders.py
+++ b/tests/unit_test/cosmos3/test_request_builders.py
@@ -15,11 +15,7 @@ from sglang_omni.models.cosmos3.request_builders import (
     make_text_scheduler_adapters,
     make_text_stream_output_builder,
 )
-from sglang_omni.proto import (
-    EXPLICIT_GENERATION_PARAMS_KEY,
-    OmniRequest,
-    StagePayload,
-)
+from sglang_omni.proto import EXPLICIT_GENERATION_PARAMS_KEY, OmniRequest, StagePayload
 
 
 class _FakeTokenizer:

--- a/tests/unit_test/cosmos3/test_request_builders.py
+++ b/tests/unit_test/cosmos3/test_request_builders.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import torch
+from transformers import GenerationConfig
 
 from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
 from sglang_omni.models.cosmos3.request_builders import (
@@ -37,7 +38,7 @@ def _state() -> Cosmos3PipelineState:
 
 
 def test_sampling_defaults_follow_nano_generation_config() -> None:
-    generation_config = SimpleNamespace(
+    generation_config = GenerationConfig(
         do_sample=True,
         temperature=0.7,
         top_p=0.8,
@@ -58,7 +59,7 @@ def test_sampling_defaults_follow_nano_generation_config() -> None:
 
 
 def test_none_sampling_values_fall_back_to_nano_defaults() -> None:
-    generation_config = SimpleNamespace(
+    generation_config = GenerationConfig(
         do_sample=True,
         temperature=0.7,
         top_p=0.8,
@@ -94,7 +95,7 @@ def test_none_sampling_values_fall_back_to_nano_defaults() -> None:
 
 
 def test_builds_plain_sglang_ar_request() -> None:
-    generation_config = SimpleNamespace(
+    generation_config = GenerationConfig(
         do_sample=True,
         temperature=0.7,
         top_p=0.8,
@@ -167,7 +168,7 @@ def test_scheduler_ignores_unset_openai_sampling_placeholders(monkeypatch) -> No
         ),
         data=_state().to_dict(),
     )
-    generation_config = SimpleNamespace(
+    generation_config = GenerationConfig(
         do_sample=True,
         temperature=0.7,
         top_p=0.8,
@@ -206,7 +207,7 @@ def test_scheduler_honors_explicit_openai_sampling_values(monkeypatch) -> None:
         ),
         data=_state().to_dict(),
     )
-    generation_config = SimpleNamespace(
+    generation_config = GenerationConfig(
         do_sample=True,
         temperature=0.7,
         top_p=0.8,

--- a/tests/unit_test/cosmos3/test_request_builders.py
+++ b/tests/unit_test/cosmos3/test_request_builders.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.models.cosmos3.request_builders import (
+    apply_text_result,
+    build_cosmos3_sampling_kwargs,
+    build_sglang_text_request,
+    make_text_scheduler_adapters,
+    make_text_stream_output_builder,
+)
+from sglang_omni.proto import (
+    EXPLICIT_GENERATION_PARAMS_KEY,
+    OmniRequest,
+    StagePayload,
+)
+
+
+class _FakeTokenizer:
+    eos_token_id = 151645
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        del text, add_special_tokens
+        return [1]
+
+
+def _state() -> Cosmos3PipelineState:
+    return Cosmos3PipelineState(
+        prompt={
+            "input_ids": torch.tensor([11, 12, 13], dtype=torch.long),
+            "attention_mask": torch.ones(3, dtype=torch.long),
+            "prompt_text": "rendered prompt",
+        }
+    )
+
+
+def test_sampling_defaults_follow_nano_generation_config() -> None:
+    generation_config = SimpleNamespace(
+        do_sample=True,
+        temperature=0.7,
+        top_p=0.8,
+        top_k=20,
+        repetition_penalty=1.0,
+    )
+
+    kwargs = build_cosmos3_sampling_kwargs(
+        {"max_new_tokens": 7, "seed": 123},
+        generation_config=generation_config,
+    )
+
+    assert kwargs["max_new_tokens"] == 7
+    assert kwargs["temperature"] == 0.7
+    assert kwargs["top_p"] == 0.8
+    assert kwargs["top_k"] == 20
+    assert kwargs["sampling_seed"] == 123
+
+
+def test_none_sampling_values_fall_back_to_nano_defaults() -> None:
+    generation_config = SimpleNamespace(
+        do_sample=True,
+        temperature=0.7,
+        top_p=0.8,
+        top_k=20,
+        repetition_penalty=1.0,
+    )
+
+    kwargs = build_cosmos3_sampling_kwargs(
+        {
+            "max_new_tokens": None,
+            "temperature": None,
+            "top_p": None,
+            "top_k": None,
+            "min_p": None,
+            "repetition_penalty": None,
+            "seed": None,
+            "sampling_seed": 321,
+        },
+        generation_config=generation_config,
+    )
+
+    assert kwargs == {
+        "max_new_tokens": 2048,
+        "temperature": 0.7,
+        "top_p": 0.8,
+        "top_k": 20,
+        "min_p": 0.0,
+        "repetition_penalty": 1.0,
+        "stop": [],
+        "stop_token_ids": [],
+        "sampling_seed": 321,
+    }
+
+
+def test_builds_plain_sglang_ar_request() -> None:
+    generation_config = SimpleNamespace(
+        do_sample=True,
+        temperature=0.7,
+        top_p=0.8,
+        top_k=20,
+        repetition_penalty=1.0,
+        eos_token_id=[151645, 151643],
+    )
+
+    data = build_sglang_text_request(
+        _state(),
+        params={"max_new_tokens": 4, "temperature": 0.2},
+        tokenizer=_FakeTokenizer(),
+        vocab_size=151936,
+        generation_config=generation_config,
+        request_id="nano-request",
+    )
+
+    assert data.input_ids.tolist() == [11, 12, 13]
+    assert data.max_new_tokens == 4
+    assert data.temperature == 0.2
+    assert data.req.rid == "nano-request"
+    assert data.req.origin_input_ids == [11, 12, 13]
+    assert data.req.eos_token_ids == {151643, 151645}
+    assert data.output_ids is data.req.output_ids
+
+
+def test_scheduler_adapters_store_normalized_text_result(monkeypatch) -> None:
+    payload = StagePayload(
+        request_id="adapter-request",
+        request=OmniRequest(inputs=None, params={"max_new_tokens": 2}),
+        data=_state().to_dict(),
+    )
+    request_builder, result_adapter = make_text_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        vocab_size=151936,
+    )
+    monkeypatch.setattr(
+        "sglang.srt.sampling.sampling_params.SamplingParams.verify",
+        lambda self, vocab_size: None,
+    )
+
+    data = request_builder(payload)
+    data.output_ids.extend([21, 22])
+    data.finish_reason = "stop"
+    result = result_adapter(data)
+    state = Cosmos3PipelineState.from_dict(result.data)
+
+    assert data.stage_payload is payload
+    assert state.text_out == {
+        "output_ids": [21, 22],
+        "is_final": True,
+        "finish_reason": "stop",
+    }
+    assert state.engine_outputs["thinker"] == state.text_out
+
+
+def test_scheduler_ignores_unset_openai_sampling_placeholders(monkeypatch) -> None:
+    payload = StagePayload(
+        request_id="default-sampling-request",
+        request=OmniRequest(
+            inputs=None,
+            params={
+                "max_new_tokens": 2,
+                "temperature": 1.0,
+                "top_p": 1.0,
+                "top_k": -1,
+                "min_p": 0.0,
+                "repetition_penalty": 1.0,
+            },
+        ),
+        data=_state().to_dict(),
+    )
+    generation_config = SimpleNamespace(
+        do_sample=True,
+        temperature=0.7,
+        top_p=0.8,
+        top_k=20,
+        repetition_penalty=1.0,
+    )
+    request_builder, _ = make_text_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        vocab_size=151936,
+        generation_config=generation_config,
+    )
+    monkeypatch.setattr(
+        "sglang.srt.sampling.sampling_params.SamplingParams.verify",
+        lambda self, vocab_size: None,
+    )
+
+    data = request_builder(payload)
+
+    assert data.temperature == 0.7
+    assert data.top_p == 0.8
+    assert data.top_k == 20
+
+
+def test_scheduler_honors_explicit_openai_sampling_values(monkeypatch) -> None:
+    payload = StagePayload(
+        request_id="explicit-sampling-request",
+        request=OmniRequest(
+            inputs=None,
+            params={
+                "temperature": 1.0,
+                "top_p": 1.0,
+                "top_k": -1,
+                "repetition_penalty": 1.0,
+            },
+            metadata={EXPLICIT_GENERATION_PARAMS_KEY: ["temperature"]},
+        ),
+        data=_state().to_dict(),
+    )
+    generation_config = SimpleNamespace(
+        do_sample=True,
+        temperature=0.7,
+        top_p=0.8,
+        top_k=20,
+        repetition_penalty=1.0,
+    )
+    request_builder, _ = make_text_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        vocab_size=151936,
+        generation_config=generation_config,
+    )
+    monkeypatch.setattr(
+        "sglang.srt.sampling.sampling_params.SamplingParams.verify",
+        lambda self, vocab_size: None,
+    )
+
+    data = request_builder(payload)
+
+    assert data.temperature == 1.0
+    assert data.top_p == 0.8
+    assert data.top_k == 20
+
+
+def test_stream_builder_emits_only_for_streaming_requests() -> None:
+    builder = make_text_stream_output_builder()
+    payload = StagePayload(
+        request_id="stream-request",
+        request=OmniRequest(inputs=None, params={"stream": True}),
+        data={},
+    )
+    req_data = SimpleNamespace(
+        req=SimpleNamespace(inflight_middle_chunks=0),
+        stage_payload=payload,
+    )
+
+    messages = builder(
+        "stream-request",
+        req_data,
+        SimpleNamespace(data=42),
+    )
+
+    assert len(messages) == 1
+    assert messages[0].target == "decode"
+    assert messages[0].data.tolist() == [42]
+
+    payload.request.params["stream"] = False
+    assert builder("stream-request", req_data, SimpleNamespace(data=43)) == []
+
+
+def test_apply_text_result_preserves_optional_metadata() -> None:
+    state = Cosmos3PipelineState()
+    result: Any = SimpleNamespace(
+        output_ids=[4],
+        finish_reason="length",
+        output_token_logprobs=[-0.5],
+        weight_version="v1",
+    )
+
+    output = apply_text_result(state, stage_name="thinker", result=result)
+
+    assert output["finish_reason"] == "length"
+    assert output["output_token_logprobs"] == [-0.5]
+    assert output["weight_version"] == "v1"

--- a/tests/unit_test/cosmos3/test_sglang_text.py
+++ b/tests/unit_test/cosmos3/test_sglang_text.py
@@ -10,7 +10,6 @@ from sglang.srt.models.qwen3 import Qwen3ForCausalLM
 from sglang_omni.models.cosmos3.components.sglang_text import (
     Cosmos3TextForCausalLM,
     map_cosmos3_text_weight_name,
-    resolve_cosmos3_text_positions,
 )
 
 
@@ -99,22 +98,6 @@ def test_text_wrapper_uses_nested_text_config(monkeypatch) -> None:
     }
     assert text_config.tie_word_embeddings is False
     assert model.root_config is root_config
-
-
-def test_cosmos_text_positions_fill_all_three_mrope_axes() -> None:
-    positions = torch.arange(4, dtype=torch.long)
-
-    resolved = resolve_cosmos3_text_positions(
-        positions,
-        SimpleNamespace(mrope_positions=None),
-    )
-
-    assert resolved.shape == (3, 4)
-    assert resolved.tolist() == [
-        [0, 1, 2, 3],
-        [0, 1, 2, 3],
-        [0, 1, 2, 3],
-    ]
 
 
 def test_text_forward_prefers_scheduler_mrope_positions(monkeypatch) -> None:

--- a/tests/unit_test/cosmos3/test_sglang_text.py
+++ b/tests/unit_test/cosmos3/test_sglang_text.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+from sglang.srt.models.qwen3 import Qwen3ForCausalLM
+
+from sglang_omni.models.cosmos3.components.sglang_text import (
+    Cosmos3TextForCausalLM,
+    map_cosmos3_text_weight_name,
+    resolve_cosmos3_text_positions,
+)
+
+
+def test_maps_cosmos_attention_names_to_sglang_qwen3() -> None:
+    assert (
+        map_cosmos3_text_weight_name("layers.0.self_attn.to_q.weight")
+        == "layers.0.self_attn.q_proj.weight"
+    )
+    assert (
+        map_cosmos3_text_weight_name("layers.0.self_attn.to_out.weight")
+        == "layers.0.self_attn.o_proj.weight"
+    )
+    assert (
+        map_cosmos3_text_weight_name("layers.0.self_attn.norm_k.weight")
+        == "layers.0.self_attn.k_norm.weight"
+    )
+    assert map_cosmos3_text_weight_name("embed_tokens.weight") == (
+        "embed_tokens.weight"
+    )
+    assert map_cosmos3_text_weight_name("model.norm.weight") == "norm.weight"
+
+
+def test_filters_gen_and_vision_weights_from_text_model() -> None:
+    assert map_cosmos3_text_weight_name("layers.0.mlp_moe_gen.gate_proj.weight") is None
+    assert map_cosmos3_text_weight_name("layers.0.self_attn.add_q_proj.weight") is None
+    assert map_cosmos3_text_weight_name("layers.0.self_attn.to_add_out.weight") is None
+    assert map_cosmos3_text_weight_name("norm_moe_gen.weight") is None
+    assert map_cosmos3_text_weight_name("blocks.0.attn.qkv.weight") is None
+
+
+def test_load_weights_forwards_only_mapped_text_tensors(monkeypatch) -> None:
+    captured: list[tuple[str, torch.Tensor]] = []
+
+    def fake_load_weights(self, weights):
+        del self
+        captured.extend(weights)
+        return {name for name, _ in captured}
+
+    monkeypatch.setattr(Qwen3ForCausalLM, "load_weights", fake_load_weights)
+    model = object.__new__(Cosmos3TextForCausalLM)
+    tensor = torch.ones(1)
+
+    result = Cosmos3TextForCausalLM.load_weights(
+        model,
+        [
+            ("layers.0.self_attn.to_q.weight", tensor),
+            ("layers.0.self_attn.add_q_proj.weight", tensor),
+            ("blocks.0.attn.qkv.weight", tensor),
+            ("lm_head.weight", tensor),
+        ],
+    )
+
+    assert [name for name, _ in captured] == [
+        "layers.0.self_attn.q_proj.weight",
+        "lm_head.weight",
+    ]
+    assert result == {
+        "layers.0.self_attn.q_proj.weight",
+        "lm_head.weight",
+    }
+
+
+def test_text_wrapper_uses_nested_text_config(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_init(self, config, quant_config=None, prefix=""):
+        captured.update(
+            config=config,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+
+    monkeypatch.setattr(Qwen3ForCausalLM, "__init__", fake_init)
+    text_config = SimpleNamespace(tie_word_embeddings=True)
+    root_config = SimpleNamespace(
+        text_config=text_config,
+        tie_word_embeddings=False,
+    )
+
+    model = Cosmos3TextForCausalLM(root_config, quant_config="quant", prefix="p")
+
+    assert captured == {
+        "config": text_config,
+        "quant_config": "quant",
+        "prefix": "p",
+    }
+    assert text_config.tie_word_embeddings is False
+    assert model.root_config is root_config
+
+
+def test_cosmos_text_positions_fill_all_three_mrope_axes() -> None:
+    positions = torch.arange(4, dtype=torch.long)
+
+    resolved = resolve_cosmos3_text_positions(
+        positions,
+        SimpleNamespace(mrope_positions=None),
+    )
+
+    assert resolved.shape == (3, 4)
+    assert resolved.tolist() == [
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+    ]
+
+
+def test_text_forward_prefers_scheduler_mrope_positions(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_forward(self, **kwargs):
+        del self
+        captured.update(kwargs)
+        return "output"
+
+    monkeypatch.setattr(Qwen3ForCausalLM, "forward", fake_forward)
+    model = object.__new__(Cosmos3TextForCausalLM)
+    mrope_positions = torch.tensor(
+        [
+            [4, 5],
+            [4, 5],
+            [4, 5],
+        ],
+        dtype=torch.long,
+    )
+    forward_batch = SimpleNamespace(mrope_positions=mrope_positions)
+
+    result = Cosmos3TextForCausalLM.forward(
+        model,
+        input_ids=torch.tensor([1, 2]),
+        positions=torch.tensor([4, 5]),
+        forward_batch=forward_batch,
+    )
+
+    assert result == "output"
+    assert captured["positions"] is mrope_positions
+    assert captured["forward_batch"] is forward_batch

--- a/tests/unit_test/cosmos3/test_sglang_text.py
+++ b/tests/unit_test/cosmos3/test_sglang_text.py
@@ -6,7 +6,9 @@ from types import SimpleNamespace
 
 import torch
 from sglang.srt.models.qwen3 import Qwen3ForCausalLM
+from torch import nn
 
+from sglang_omni.models.cosmos3.components import sglang_text
 from sglang_omni.models.cosmos3.components.sglang_text import (
     Cosmos3TextForCausalLM,
     map_cosmos3_text_weight_name,
@@ -75,27 +77,51 @@ def test_load_weights_forwards_only_mapped_text_tensors(monkeypatch) -> None:
 def test_text_wrapper_uses_nested_text_config(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
-    def fake_init(self, config, quant_config=None, prefix=""):
+    class _FakeTextModel(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.embed_tokens = nn.Embedding(2, 2)
+
+    def fake_init(*, config, quant_config=None, prefix=""):
         captured.update(
             config=config,
             quant_config=quant_config,
             prefix=prefix,
         )
+        return _FakeTextModel()
 
-    monkeypatch.setattr(Qwen3ForCausalLM, "__init__", fake_init)
-    text_config = SimpleNamespace(tie_word_embeddings=True)
+    monkeypatch.setattr(sglang_text, "Qwen3LLMModel", fake_init)
+    monkeypatch.setattr(
+        sglang_text,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_last_rank=True, world_size=1),
+    )
+    monkeypatch.setattr(
+        sglang_text, "ParallelLMHead", lambda *args, **kwargs: nn.Identity()
+    )
+    monkeypatch.setattr(sglang_text, "LogitsProcessor", lambda config: object())
+    monkeypatch.setattr(sglang_text, "Pooler", lambda **kwargs: object())
+    monkeypatch.setattr(
+        sglang_text,
+        "get_server_args",
+        lambda: SimpleNamespace(enable_dp_lm_head=False),
+    )
+    text_config = SimpleNamespace(
+        tie_word_embeddings=True,
+        vocab_size=10,
+        hidden_size=4,
+    )
     root_config = SimpleNamespace(
         text_config=text_config,
+        vision_config=SimpleNamespace(deepstack_visual_indexes=[1, 2, 3]),
         tie_word_embeddings=False,
     )
 
     model = Cosmos3TextForCausalLM(root_config, quant_config="quant", prefix="p")
 
-    assert captured == {
-        "config": text_config,
-        "quant_config": "quant",
-        "prefix": "p",
-    }
+    assert captured["config"] is text_config
+    assert captured["quant_config"] == "quant"
+    assert captured["prefix"] == "p.model"
     assert text_config.tie_word_embeddings is False
     assert model.root_config is root_config
 
@@ -130,3 +156,36 @@ def test_text_forward_prefers_scheduler_mrope_positions(monkeypatch) -> None:
     assert result == "output"
     assert captured["positions"] is mrope_positions
     assert captured["forward_batch"] is forward_batch
+
+
+def test_multimodal_forward_passes_deepstack_to_qwen3_vl_text_model() -> None:
+    captured: dict[str, object] = {}
+
+    class _TextModel(nn.Module):
+        def forward(self, *args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return torch.ones((2, 4))
+
+    model = object.__new__(Cosmos3TextForCausalLM)
+    nn.Module.__init__(model)
+    model.model = _TextModel()
+    model.pp_group = SimpleNamespace(is_last_rank=True)
+    model.capture_aux_hidden_states = False
+    model.lm_head = nn.Identity()
+    model.logits_processor = lambda *args: "logits"
+    deepstack = torch.ones((2, 12))
+    positions = torch.arange(2).unsqueeze(0).expand(3, -1)
+    forward_batch = SimpleNamespace(mrope_positions=positions)
+
+    result = model.forward(
+        input_ids=torch.tensor([1, 2]),
+        positions=torch.tensor([0, 1]),
+        forward_batch=forward_batch,
+        input_embeds=torch.ones((2, 4)),
+        input_deepstack_embeds=deepstack,
+    )
+
+    assert result == "logits"
+    assert captured["kwargs"]["input_deepstack_embeds"] is deepstack
+    assert captured["args"][1] is positions

--- a/tests/unit_test/cosmos3/test_stages.py
+++ b/tests/unit_test/cosmos3/test_stages.py
@@ -51,8 +51,12 @@ def test_text_factory_passes_through_tensor_parallelism(
         )
         return scheduler
 
+    def fake_validate(**kwargs):
+        captured["validation_kwargs"] = kwargs
+
     monkeypatch.setattr(stages, "build_sglang_server_args", fake_build)
     monkeypatch.setattr(stages, "create_thinker_scheduler", fake_create)
+    monkeypatch.setattr(stages, "validate_generation_batch_policy", fake_validate)
 
     result = stages.create_sglang_text_executor_from_config(
         "nvidia/Cosmos3-Nano",
@@ -60,15 +64,24 @@ def test_text_factory_passes_through_tensor_parallelism(
         gpu_id=2,
         tp_rank=1,
         tp_size=2,
-        server_args_overrides={"disable_cuda_graph": True},
+        server_args_overrides={"max_running_requests": 8},
     )
 
     assert result is scheduler
     assert captured["model_path"] == "nvidia/Cosmos3-Nano"
     assert captured["context_length"] == 4096
     assert captured["kwargs"] == {
-        "disable_cuda_graph": True,
+        "max_running_requests": 8,
+        "cuda_graph_max_bs": 8,
+        "torch_compile_max_bs": 8,
+        "cuda_graph_bs": [1, 2, 4, 8],
+        "disable_cuda_graph": False,
+        "sampling_backend": "pytorch",
         "tp_size": 2,
+    }
+    assert captured["validation_kwargs"] == {
+        "model_name": "Cosmos3 thinker",
+        "server_args": server_args,
     }
     assert captured["server_args"] is server_args
     assert captured["gpu_id"] == 2

--- a/tests/unit_test/cosmos3/test_stages.py
+++ b/tests/unit_test/cosmos3/test_stages.py
@@ -4,13 +4,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-import torch
-
-from sglang_omni.models.cosmos3 import stages
-from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
-from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.models.cosmos3 import stages, vision_encoder_scheduler
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
-from sglang_omni.scheduling.stage_cache import StageOutputCache
 
 
 def test_preprocessing_factory_returns_simple_scheduler(monkeypatch) -> None:
@@ -35,6 +30,30 @@ def test_preprocessing_factory_returns_simple_scheduler(monkeypatch) -> None:
     assert isinstance(scheduler, SimpleScheduler)
     assert scheduler._fn is sentinel
     assert calls == [("nvidia/Cosmos3-Nano", 8192, True)]
+
+
+def test_vision_encoder_factory_delegates_to_scheduler(monkeypatch) -> None:
+    sentinel = object()
+    calls: list[tuple[str, str, str | None]] = []
+
+    def fake_create(model_path: str, *, device: str, dtype: str | None):
+        calls.append((model_path, device, dtype))
+        return sentinel
+
+    monkeypatch.setattr(
+        vision_encoder_scheduler,
+        "create_vision_encoder_scheduler",
+        fake_create,
+    )
+
+    result = stages.create_vision_encoder_executor(
+        "nvidia/Cosmos3-Nano",
+        device="cuda:1",
+        dtype="bfloat16",
+    )
+
+    assert result is sentinel
+    assert calls == [("nvidia/Cosmos3-Nano", "cuda:1", "bfloat16")]
 
 
 def test_text_factory_passes_through_tensor_parallelism(
@@ -95,65 +114,3 @@ def test_text_factory_passes_through_tensor_parallelism(
     assert captured["server_args"] is server_args
     assert captured["gpu_id"] == 2
     assert captured["scheduler_kwargs"]["tp_rank"] == 1
-
-
-class _FakeVisionModel:
-    spatial_merge_size = 2
-    out_hidden_size = 4
-    deepstack_layers = 1
-    visual_dtype_bytes = 4
-
-    def __init__(self) -> None:
-        self.calls = 0
-
-    def __call__(self, **inputs):
-        self.calls += 1
-        grid = inputs["image_grid_thw"]
-        token_count = grid.prod(-1) // 4
-        total = int(token_count.sum().item())
-        embeds = torch.arange(total * 4, dtype=torch.float32).reshape(total, 4)
-        return {
-            "image_embeds": embeds,
-            "image_grid_thw": grid,
-            "image_token_counts": token_count,
-            "deepstack_visual_embeds_image": [embeds + 1],
-        }
-
-
-def _vision_payload(request_id: str, cache_key: str) -> StagePayload:
-    state = Cosmos3PipelineState(
-        encoder_inputs={
-            "vision_encoder": {
-                "pixel_values": torch.ones((4, 6)),
-                "image_grid_thw": torch.tensor([[1, 2, 2]]),
-                "cache_key": cache_key,
-            }
-        }
-    )
-    return StagePayload(
-        request_id=request_id,
-        request=OmniRequest(inputs=None),
-        data=state.to_dict(),
-    )
-
-
-def test_vision_encoder_batches_and_deduplicates_same_cache_key() -> None:
-    model = _FakeVisionModel()
-    cache = StageOutputCache(max_size=4, cache_device="cpu")
-    outputs = stages._batch_vision_requests(
-        [
-            _vision_payload("first", "same-image"),
-            _vision_payload("second", "same-image"),
-        ],
-        model=model,
-        cache=cache,
-    )
-
-    assert model.calls == 1
-    assert len(cache) == 1
-    first = Cosmos3PipelineState.from_dict(outputs[0].data)
-    second = Cosmos3PipelineState.from_dict(outputs[1].data)
-    assert torch.equal(
-        first.encoder_outs["vision_encoder"]["image_embeds"],
-        second.encoder_outs["vision_encoder"]["image_embeds"],
-    )

--- a/tests/unit_test/cosmos3/test_stages.py
+++ b/tests/unit_test/cosmos3/test_stages.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-import pytest
-
 from sglang_omni.models.cosmos3 import stages
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
@@ -30,7 +28,7 @@ def test_preprocessing_factory_returns_simple_scheduler(monkeypatch) -> None:
     assert calls == [("nvidia/Cosmos3-Nano", 8192)]
 
 
-def test_text_factory_builds_single_rank_language_only_server_args(
+def test_text_factory_passes_through_tensor_parallelism(
     monkeypatch,
 ) -> None:
     captured: dict[str, object] = {}
@@ -53,37 +51,25 @@ def test_text_factory_builds_single_rank_language_only_server_args(
         )
         return scheduler
 
-    monkeypatch.setattr(
-        "sglang_omni.scheduling.sglang_backend.build_sglang_server_args",
-        fake_build,
-    )
-    monkeypatch.setattr(
-        "sglang_omni.models.cosmos3.bootstrap.create_text_scheduler",
-        fake_create,
-    )
+    monkeypatch.setattr(stages, "build_sglang_server_args", fake_build)
+    monkeypatch.setattr(stages, "create_thinker_scheduler", fake_create)
 
     result = stages.create_sglang_text_executor_from_config(
         "nvidia/Cosmos3-Nano",
         thinker_max_seq_len=4096,
         gpu_id=2,
+        tp_rank=1,
+        tp_size=2,
+        server_args_overrides={"disable_cuda_graph": True},
     )
 
     assert result is scheduler
     assert captured["model_path"] == "nvidia/Cosmos3-Nano"
     assert captured["context_length"] == 4096
     assert captured["kwargs"] == {
-        "tp_size": 1,
-        "enable_multimodal": False,
-        "language_only": True,
-        "sampling_backend": "pytorch",
+        "disable_cuda_graph": True,
+        "tp_size": 2,
     }
     assert captured["server_args"] is server_args
     assert captured["gpu_id"] == 2
-
-
-def test_text_factory_rejects_parallelism() -> None:
-    with pytest.raises(ValueError, match="tp_size=1"):
-        stages.create_sglang_text_executor_from_config(
-            "nvidia/Cosmos3-Nano",
-            tp_size=2,
-        )
+    assert captured["scheduler_kwargs"]["tp_rank"] == 1

--- a/tests/unit_test/cosmos3/test_stages.py
+++ b/tests/unit_test/cosmos3/test_stages.py
@@ -4,16 +4,25 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import torch
+
 from sglang_omni.models.cosmos3 import stages
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni.scheduling.stage_cache import StageOutputCache
 
 
 def test_preprocessing_factory_returns_simple_scheduler(monkeypatch) -> None:
     sentinel = object()
-    calls: list[tuple[str, int | None]] = []
+    calls: list[tuple[str, int | None, bool]] = []
 
-    def fake_preprocessor(model_path: str, max_seq_len: int | None):
-        calls.append((model_path, max_seq_len))
+    def fake_preprocessor(
+        model_path: str,
+        max_seq_len: int | None,
+        enable_vision: bool,
+    ):
+        calls.append((model_path, max_seq_len, enable_vision))
         return sentinel
 
     monkeypatch.setattr(stages, "Cosmos3TextPreprocessor", fake_preprocessor)
@@ -25,7 +34,7 @@ def test_preprocessing_factory_returns_simple_scheduler(monkeypatch) -> None:
 
     assert isinstance(scheduler, SimpleScheduler)
     assert scheduler._fn is sentinel
-    assert calls == [("nvidia/Cosmos3-Nano", 8192)]
+    assert calls == [("nvidia/Cosmos3-Nano", 8192, True)]
 
 
 def test_text_factory_passes_through_tensor_parallelism(
@@ -86,3 +95,65 @@ def test_text_factory_passes_through_tensor_parallelism(
     assert captured["server_args"] is server_args
     assert captured["gpu_id"] == 2
     assert captured["scheduler_kwargs"]["tp_rank"] == 1
+
+
+class _FakeVisionModel:
+    spatial_merge_size = 2
+    out_hidden_size = 4
+    deepstack_layers = 1
+    visual_dtype_bytes = 4
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, **inputs):
+        self.calls += 1
+        grid = inputs["image_grid_thw"]
+        token_count = grid.prod(-1) // 4
+        total = int(token_count.sum().item())
+        embeds = torch.arange(total * 4, dtype=torch.float32).reshape(total, 4)
+        return {
+            "image_embeds": embeds,
+            "image_grid_thw": grid,
+            "image_token_counts": token_count,
+            "deepstack_visual_embeds_image": [embeds + 1],
+        }
+
+
+def _vision_payload(request_id: str, cache_key: str) -> StagePayload:
+    state = Cosmos3PipelineState(
+        encoder_inputs={
+            "vision_encoder": {
+                "pixel_values": torch.ones((4, 6)),
+                "image_grid_thw": torch.tensor([[1, 2, 2]]),
+                "cache_key": cache_key,
+            }
+        }
+    )
+    return StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs=None),
+        data=state.to_dict(),
+    )
+
+
+def test_vision_encoder_batches_and_deduplicates_same_cache_key() -> None:
+    model = _FakeVisionModel()
+    cache = StageOutputCache(max_size=4, cache_device="cpu")
+    outputs = stages._batch_vision_requests(
+        [
+            _vision_payload("first", "same-image"),
+            _vision_payload("second", "same-image"),
+        ],
+        model=model,
+        cache=cache,
+    )
+
+    assert model.calls == 1
+    assert len(cache) == 1
+    first = Cosmos3PipelineState.from_dict(outputs[0].data)
+    second = Cosmos3PipelineState.from_dict(outputs[1].data)
+    assert torch.equal(
+        first.encoder_outs["vision_encoder"]["image_embeds"],
+        second.encoder_outs["vision_encoder"]["image_embeds"],
+    )

--- a/tests/unit_test/cosmos3/test_stages.py
+++ b/tests/unit_test/cosmos3/test_stages.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from sglang_omni.models.cosmos3 import stages
+from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+
+
+def test_preprocessing_factory_returns_simple_scheduler(monkeypatch) -> None:
+    sentinel = object()
+    calls: list[tuple[str, int | None]] = []
+
+    def fake_preprocessor(model_path: str, max_seq_len: int | None):
+        calls.append((model_path, max_seq_len))
+        return sentinel
+
+    monkeypatch.setattr(stages, "Cosmos3TextPreprocessor", fake_preprocessor)
+
+    scheduler = stages.create_preprocessing_executor(
+        "nvidia/Cosmos3-Nano",
+        thinker_max_seq_len=8192,
+    )
+
+    assert isinstance(scheduler, SimpleScheduler)
+    assert scheduler._fn is sentinel
+    assert calls == [("nvidia/Cosmos3-Nano", 8192)]
+
+
+def test_text_factory_builds_single_rank_language_only_server_args(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+    server_args = SimpleNamespace()
+    scheduler = object()
+
+    def fake_build(model_path: str, context_length: int, **kwargs):
+        captured.update(
+            model_path=model_path,
+            context_length=context_length,
+            kwargs=kwargs,
+        )
+        return server_args
+
+    def fake_create(received_server_args, gpu_id: int, **kwargs):
+        captured.update(
+            server_args=received_server_args,
+            gpu_id=gpu_id,
+            scheduler_kwargs=kwargs,
+        )
+        return scheduler
+
+    monkeypatch.setattr(
+        "sglang_omni.scheduling.sglang_backend.build_sglang_server_args",
+        fake_build,
+    )
+    monkeypatch.setattr(
+        "sglang_omni.models.cosmos3.bootstrap.create_text_scheduler",
+        fake_create,
+    )
+
+    result = stages.create_sglang_text_executor_from_config(
+        "nvidia/Cosmos3-Nano",
+        thinker_max_seq_len=4096,
+        gpu_id=2,
+    )
+
+    assert result is scheduler
+    assert captured["model_path"] == "nvidia/Cosmos3-Nano"
+    assert captured["context_length"] == 4096
+    assert captured["kwargs"] == {
+        "tp_size": 1,
+        "enable_multimodal": False,
+        "language_only": True,
+        "sampling_backend": "pytorch",
+    }
+    assert captured["server_args"] is server_args
+    assert captured["gpu_id"] == 2
+
+
+def test_text_factory_rejects_parallelism() -> None:
+    with pytest.raises(ValueError, match="tp_size=1"):
+        stages.create_sglang_text_executor_from_config(
+            "nvidia/Cosmos3-Nano",
+            tp_size=2,
+        )

--- a/tests/unit_test/cosmos3/test_streaming_detokenizer.py
+++ b/tests/unit_test/cosmos3/test_streaming_detokenizer.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import ClassVar
+
+import torch
+
+from sglang_omni.models.cosmos3.components.streaming_detokenizer import (
+    Cosmos3StreamingDetokenizer,
+)
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+class _FakeTokenizer:
+    pieces: ClassVar[dict[int, str]] = {1: "hello", 2: " ", 3: "world"}
+
+    def decode(self, token_ids, skip_special_tokens: bool = True) -> str:
+        del skip_special_tokens
+        return "".join(self.pieces.get(int(token_id), "") for token_id in token_ids)
+
+
+def _payload(*, stream: bool) -> StagePayload:
+    state = Cosmos3PipelineState(
+        prompt={
+            "input_ids": torch.tensor([8, 9]),
+            "attention_mask": torch.ones(2, dtype=torch.long),
+            "prompt_text": "prompt",
+        },
+        text_out={
+            "output_ids": [1, 2, 3],
+            "finish_reason": "stop",
+            "is_final": True,
+        },
+    )
+    return StagePayload(
+        request_id="decode-request",
+        request=OmniRequest(inputs=None, params={"stream": stream}),
+        data=state.to_dict(),
+    )
+
+
+def test_non_streaming_payload_decodes_complete_text() -> None:
+    scheduler = Cosmos3StreamingDetokenizer(_FakeTokenizer())
+
+    scheduler._on_new_request("decode-request", _payload(stream=False))
+    message = scheduler.outbox.get_nowait()
+
+    assert message.type == "result"
+    assert message.data.data == {
+        "modality": "text",
+        "text": "hello world",
+        "finish_reason": "stop",
+        "usage": {
+            "prompt_tokens": 2,
+            "completion_tokens": 3,
+            "total_tokens": 5,
+        },
+    }
+
+
+def test_streaming_tokens_emit_deltas_and_slim_terminal_result() -> None:
+    scheduler = Cosmos3StreamingDetokenizer(_FakeTokenizer())
+    payload = _payload(stream=True)
+
+    scheduler._on_stream_chunk(
+        "decode-request", SimpleNamespace(data=torch.tensor([1]))
+    )
+    stream_message = scheduler.outbox.get_nowait()
+    assert stream_message.type == "stream"
+    assert stream_message.data["text"] == "hello"
+
+    scheduler._on_new_request("decode-request", payload)
+    assert scheduler.outbox.empty()
+    scheduler._on_stream_done("decode-request")
+    result_message = scheduler.outbox.get_nowait()
+
+    assert result_message.type == "result"
+    assert "text" not in result_message.data.data
+    assert result_message.data.data["usage"]["completion_tokens"] == 3
+
+
+def test_stream_done_before_terminal_payload_does_not_deadlock() -> None:
+    scheduler = Cosmos3StreamingDetokenizer(_FakeTokenizer())
+
+    scheduler._on_stream_done("decode-request")
+    scheduler._on_new_request("decode-request", _payload(stream=True))
+
+    assert scheduler.outbox.get_nowait().type == "result"

--- a/tests/unit_test/cosmos3/test_text_preprocessor.py
+++ b/tests/unit_test/cosmos3/test_text_preprocessor.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import torch
+
+from sglang_omni.models.cosmos3.components.text_preprocessor import (
+    Cosmos3TextPreprocessor,
+)
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+class _FakeTokenizer:
+    chat_template = "fake-template"
+
+    def __init__(self) -> None:
+        self.messages: list[dict[str, str]] | None = None
+        self.tokenize_calls = 0
+
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        tokenize: bool,
+        add_generation_prompt: bool,
+    ) -> str:
+        assert tokenize is False
+        assert add_generation_prompt is True
+        self.messages = messages
+        return "<|im_start|>user\nhello<|im_end|>\n<|im_start|>assistant\n"
+
+    def __call__(
+        self,
+        text: str,
+        *,
+        add_special_tokens: bool,
+        return_tensors: str,
+    ) -> dict[str, torch.Tensor]:
+        assert text.startswith("<|im_start|>user")
+        assert add_special_tokens is False
+        assert return_tensors == "pt"
+        self.tokenize_calls += 1
+        return {
+            "input_ids": torch.tensor([[101, 102, 103]], dtype=torch.long),
+            "attention_mask": torch.tensor([[1, 1, 1]], dtype=torch.long),
+        }
+
+
+def _payload(inputs: Any, **params: Any) -> StagePayload:
+    return StagePayload(
+        request_id="cosmos-request",
+        request=OmniRequest(inputs=inputs, params=params),
+        data={},
+    )
+
+
+def test_preprocesses_text_messages_into_canonical_state() -> None:
+    tokenizer = _FakeTokenizer()
+    preprocessor = Cosmos3TextPreprocessor(
+        "unused-model",
+        max_seq_len=32,
+        tokenizer=tokenizer,
+    )
+    payload = _payload(
+        {"messages": [{"role": "user", "content": "hello"}]},
+        max_new_tokens=8,
+    )
+
+    result = preprocessor(payload)
+    state = Cosmos3PipelineState.from_dict(result.data)
+
+    assert result is payload
+    assert result.request.inputs is None
+    assert tokenizer.messages == [{"role": "user", "content": "hello"}]
+    assert state.prompt is not None
+    assert state.prompt["input_ids"].tolist() == [101, 102, 103]
+    assert state.prompt["input_ids"].dtype == torch.long
+    assert state.prompt["attention_mask"].tolist() == [1, 1, 1]
+    assert state.prompt["prompt_text"].endswith("<|im_start|>assistant\n")
+    assert state.stream_state == {"token_ids": [], "text": ""}
+
+
+def test_pretokenized_prompt_bypasses_chat_template() -> None:
+    tokenizer = _FakeTokenizer()
+    preprocessor = Cosmos3TextPreprocessor(
+        "unused-model",
+        max_seq_len=16,
+        tokenizer=tokenizer,
+    )
+
+    result = preprocessor(_payload([7, 8, 9], max_new_tokens=2))
+    state = Cosmos3PipelineState.from_dict(result.data)
+
+    assert tokenizer.tokenize_calls == 0
+    assert state.prompt is not None
+    assert state.prompt["input_ids"].tolist() == [7, 8, 9]
+    assert state.prompt["attention_mask"].tolist() == [1, 1, 1]
+    assert state.prompt["prompt_text"] == ""
+
+
+@pytest.mark.parametrize(
+    "inputs, expected",
+    [
+        (
+            {"messages": [{"role": "user", "content": "hello"}], "images": [1]},
+            "does not support media inputs yet",
+        ),
+        (
+            [{"role": "user", "content": [{"type": "image"}]}],
+            "content must be a string",
+        ),
+        ({"prompt": "hello"}, "expects a messages field"),
+    ],
+)
+def test_rejects_inputs_outside_pr1_text_scope(inputs: Any, expected: str) -> None:
+    preprocessor = Cosmos3TextPreprocessor(
+        "unused-model",
+        tokenizer=_FakeTokenizer(),
+    )
+
+    with pytest.raises((TypeError, ValueError), match=expected):
+        preprocessor(_payload(inputs, max_new_tokens=2))
+
+
+def test_rejects_media_from_openai_request_metadata() -> None:
+    preprocessor = Cosmos3TextPreprocessor(
+        "unused-model",
+        tokenizer=_FakeTokenizer(),
+    )
+    payload = _payload(
+        [{"role": "user", "content": "describe this"}],
+        max_new_tokens=2,
+    )
+    payload.request.metadata["images"] = ["data:image/png;base64,abc"]
+
+    with pytest.raises(ValueError, match="does not support media inputs yet: images"):
+        preprocessor(payload)
+
+
+def test_rejects_prompt_and_completion_over_context_limit() -> None:
+    preprocessor = Cosmos3TextPreprocessor(
+        "unused-model",
+        max_seq_len=8,
+        tokenizer=_FakeTokenizer(),
+    )
+
+    with pytest.raises(ValueError, match="maximum context length"):
+        preprocessor(_payload([1, 2, 3], max_new_tokens=5))
+
+
+def test_pipeline_state_survives_stage_payload_round_trip() -> None:
+    state = Cosmos3PipelineState(
+        prompt={
+            "input_ids": torch.tensor([1, 2], dtype=torch.long),
+            "attention_mask": torch.tensor([1, 1], dtype=torch.long),
+            "prompt_text": "prompt",
+        },
+        engine_outputs={"text": {"output_ids": [3]}},
+        stream_state={"token_ids": [3], "text": "answer"},
+    )
+    payload = StagePayload(
+        request_id="round-trip",
+        request=OmniRequest(inputs=None),
+        data=state.to_dict(),
+    )
+
+    restored_payload = StagePayload.from_dict(payload.to_dict())
+    restored_state = Cosmos3PipelineState.from_dict(restored_payload.data)
+
+    assert restored_payload.request_id == "round-trip"
+    assert restored_state.prompt is not None
+    assert restored_state.prompt["input_ids"].tolist() == [1, 2]
+    assert restored_state.engine_outputs == {"text": {"output_ids": [3]}}
+    assert restored_state.stream_state == {"token_ids": [3], "text": "answer"}

--- a/tests/unit_test/cosmos3/test_text_preprocessor.py
+++ b/tests/unit_test/cosmos3/test_text_preprocessor.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 import torch
 
+from sglang_omni.models.cosmos3.components import text_preprocessor
 from sglang_omni.models.cosmos3.components.text_preprocessor import (
     Cosmos3TextPreprocessor,
 )
@@ -50,6 +51,27 @@ class _FakeTokenizer:
         }
 
 
+class _FakeProcessor:
+    def __init__(self, tokenizer: _FakeTokenizer) -> None:
+        self.tokenizer = tokenizer
+        self.messages = None
+
+    def apply_chat_template(self, messages, **kwargs) -> str:
+        assert kwargs == {"tokenize": False, "add_generation_prompt": True}
+        self.messages = messages
+        return "multimodal prompt"
+
+    def __call__(self, **kwargs):
+        assert kwargs["images"] == ["loaded-image"]
+        return {
+            "input_ids": torch.tensor([[10, 151655, 11]]),
+            "attention_mask": torch.ones((1, 3), dtype=torch.long),
+            "mm_token_type_ids": torch.tensor([[0, 1, 0]]),
+            "pixel_values": torch.ones((4, 6)),
+            "image_grid_thw": torch.tensor([[1, 2, 2]]),
+        }
+
+
 def _payload(inputs: Any, **params: Any) -> StagePayload:
     return StagePayload(
         request_id="cosmos-request",
@@ -58,7 +80,8 @@ def _payload(inputs: Any, **params: Any) -> StagePayload:
     )
 
 
-def test_preprocesses_text_messages_into_canonical_state() -> None:
+@pytest.mark.asyncio
+async def test_preprocesses_text_messages_into_canonical_state() -> None:
     tokenizer = _FakeTokenizer()
     preprocessor = Cosmos3TextPreprocessor(
         "unused-model",
@@ -70,7 +93,7 @@ def test_preprocesses_text_messages_into_canonical_state() -> None:
         max_new_tokens=8,
     )
 
-    result = preprocessor(payload)
+    result = await preprocessor(payload)
     state = Cosmos3PipelineState.from_dict(result.data)
 
     assert result is payload
@@ -80,11 +103,13 @@ def test_preprocesses_text_messages_into_canonical_state() -> None:
     assert state.prompt["input_ids"].tolist() == [101, 102, 103]
     assert state.prompt["input_ids"].dtype == torch.long
     assert state.prompt["attention_mask"].tolist() == [1, 1, 1]
+    assert state.prompt["mm_token_type_ids"].tolist() == [0, 0, 0]
     assert state.prompt["prompt_text"].endswith("<|im_start|>assistant\n")
     assert state.stream_state == {"token_ids": [], "text": ""}
 
 
-def test_pretokenized_prompt_bypasses_chat_template() -> None:
+@pytest.mark.asyncio
+async def test_pretokenized_prompt_bypasses_chat_template() -> None:
     tokenizer = _FakeTokenizer()
     preprocessor = Cosmos3TextPreprocessor(
         "unused-model",
@@ -92,7 +117,7 @@ def test_pretokenized_prompt_bypasses_chat_template() -> None:
         tokenizer=tokenizer,
     )
 
-    result = preprocessor(_payload([7, 8, 9], max_new_tokens=2))
+    result = await preprocessor(_payload([7, 8, 9], max_new_tokens=2))
     state = Cosmos3PipelineState.from_dict(result.data)
 
     assert tokenizer.tokenize_calls == 0
@@ -102,13 +127,51 @@ def test_pretokenized_prompt_bypasses_chat_template() -> None:
     assert state.prompt["prompt_text"] == ""
 
 
+@pytest.mark.asyncio
+async def test_preprocesses_image_for_standalone_encoder(monkeypatch) -> None:
+    async def fake_images(value):
+        assert value == ["image.png"]
+        return ["loaded-image"]
+
+    async def fake_videos(value, **kwargs):
+        assert value is None
+        return [], None, None
+
+    monkeypatch.setattr(text_preprocessor, "ensure_image_list_async", fake_images)
+    monkeypatch.setattr(text_preprocessor, "ensure_video_list_async", fake_videos)
+    monkeypatch.setattr(
+        text_preprocessor,
+        "compute_image_cache_key",
+        lambda value: "image-cache",
+    )
+    tokenizer = _FakeTokenizer()
+    processor = _FakeProcessor(tokenizer)
+    preprocessor = Cosmos3TextPreprocessor(
+        "unused-model",
+        tokenizer=tokenizer,
+        processor=processor,
+    )
+
+    result = await preprocessor(
+        _payload(
+            {
+                "messages": [{"role": "user", "content": "describe"}],
+                "images": ["image.png"],
+            },
+            max_new_tokens=2,
+        )
+    )
+    state = Cosmos3PipelineState.from_dict(result.data)
+
+    assert state.prompt["mm_token_type_ids"].tolist() == [0, 1, 0]
+    assert state.encoder_inputs["vision_encoder"]["cache_key"] == "image-cache"
+    assert state.encoder_inputs["vision_encoder"]["pixel_values"].shape == (4, 6)
+    assert processor.messages[0]["content"][0] == {"type": "image"}
+
+
 @pytest.mark.parametrize(
     "inputs, expected",
     [
-        (
-            {"messages": [{"role": "user", "content": "hello"}], "images": [1]},
-            "does not support media inputs yet",
-        ),
         (
             [{"role": "user", "content": [{"type": "image"}]}],
             "content must be a string",
@@ -116,17 +179,19 @@ def test_pretokenized_prompt_bypasses_chat_template() -> None:
         ({"prompt": "hello"}, "expects a messages field"),
     ],
 )
-def test_rejects_inputs_outside_pr1_text_scope(inputs: Any, expected: str) -> None:
+@pytest.mark.asyncio
+async def test_rejects_invalid_message_inputs(inputs: Any, expected: str) -> None:
     preprocessor = Cosmos3TextPreprocessor(
         "unused-model",
         tokenizer=_FakeTokenizer(),
     )
 
     with pytest.raises((TypeError, ValueError), match=expected):
-        preprocessor(_payload(inputs, max_new_tokens=2))
+        await preprocessor(_payload(inputs, max_new_tokens=2))
 
 
-def test_rejects_media_from_openai_request_metadata() -> None:
+@pytest.mark.asyncio
+async def test_media_from_openai_metadata_uses_multimodal_path() -> None:
     preprocessor = Cosmos3TextPreprocessor(
         "unused-model",
         tokenizer=_FakeTokenizer(),
@@ -137,11 +202,31 @@ def test_rejects_media_from_openai_request_metadata() -> None:
     )
     payload.request.metadata["images"] = ["data:image/png;base64,abc"]
 
-    with pytest.raises(ValueError, match="does not support media inputs yet: images"):
-        preprocessor(payload)
+    with pytest.raises(ValueError, match="require the checkpoint processor"):
+        await preprocessor(payload)
 
 
-def test_rejects_prompt_and_completion_over_context_limit() -> None:
+@pytest.mark.asyncio
+async def test_text_only_preprocessor_rejects_media_before_loading_it() -> None:
+    preprocessor = Cosmos3TextPreprocessor(
+        "unused-model",
+        tokenizer=_FakeTokenizer(),
+        enable_vision=False,
+    )
+
+    with pytest.raises(ValueError, match="text-only pipeline"):
+        await preprocessor(
+            _payload(
+                {
+                    "messages": [{"role": "user", "content": "describe"}],
+                    "images": ["image.png"],
+                }
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_rejects_prompt_and_completion_over_context_limit() -> None:
     preprocessor = Cosmos3TextPreprocessor(
         "unused-model",
         max_seq_len=8,
@@ -149,7 +234,7 @@ def test_rejects_prompt_and_completion_over_context_limit() -> None:
     )
 
     with pytest.raises(ValueError, match="maximum context length"):
-        preprocessor(_payload([1, 2, 3], max_new_tokens=5))
+        await preprocessor(_payload([1, 2, 3], max_new_tokens=5))
 
 
 def test_pipeline_state_survives_stage_payload_round_trip() -> None:

--- a/tests/unit_test/cosmos3/test_vision_encoder.py
+++ b/tests/unit_test/cosmos3/test_vision_encoder.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+from safetensors.torch import save_file
+from transformers import Qwen3VLVisionConfig, Qwen3VLVisionModel
+
+from sglang_omni.models.cosmos3.components import vision_encoder
+from sglang_omni.models.cosmos3.components.vision_encoder import Cosmos3VisionEncoder
+
+
+def _tiny_vision_config() -> Qwen3VLVisionConfig:
+    return Qwen3VLVisionConfig(
+        depth=1,
+        hidden_size=16,
+        intermediate_size=32,
+        num_heads=4,
+        in_channels=3,
+        patch_size=2,
+        temporal_patch_size=2,
+        spatial_merge_size=2,
+        out_hidden_size=8,
+        num_position_embeddings=16,
+        deepstack_visual_indexes=[0],
+    )
+
+
+def test_vision_encoder_loads_standalone_hf_tower_and_returns_deepstack(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    config = _tiny_vision_config()
+    checkpoint = tmp_path / "vision_encoder"
+    checkpoint.mkdir()
+    reference = Qwen3VLVisionModel(config)
+    save_file(reference.state_dict(), checkpoint / "model.safetensors")
+
+    monkeypatch.setattr(
+        vision_encoder,
+        "load_hf_config",
+        lambda *args, **kwargs: SimpleNamespace(vision_config=config),
+    )
+    monkeypatch.setattr(
+        vision_encoder,
+        "resolve_vision_encoder_path",
+        lambda model_path: str(checkpoint),
+    )
+    encoder = Cosmos3VisionEncoder(
+        "unused-model",
+        device="cpu",
+        dtype="float32",
+    )
+    output = encoder(
+        pixel_values=torch.randn(4, 24),
+        image_grid_thw=torch.tensor([[1, 2, 2]]),
+    )
+
+    assert output["image_embeds"].shape == (1, 8)
+    assert output["image_token_counts"].tolist() == [1]
+    assert len(output["deepstack_visual_embeds_image"]) == 1
+    assert output["deepstack_visual_embeds_image"][0].shape == (1, 8)
+    assert hasattr(encoder.visual.patch_embed, "linear")

--- a/tests/unit_test/cosmos3/test_vision_encoder_scheduler.py
+++ b/tests/unit_test/cosmos3/test_vision_encoder_scheduler.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+
+from sglang_omni.models.cosmos3 import vision_encoder_scheduler
+from sglang_omni.models.cosmos3.payload_types import Cosmos3PipelineState
+from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.scheduling.stage_cache import StageOutputCache
+
+
+class _FakeVisionModel:
+    spatial_merge_size = 2
+    out_hidden_size = 4
+    deepstack_layers = 1
+    visual_dtype_bytes = 4
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, **inputs):
+        self.calls += 1
+        grid = inputs["image_grid_thw"]
+        token_count = grid.prod(-1) // 4
+        total = int(token_count.sum().item())
+        embeds = torch.arange(total * 4, dtype=torch.float32).reshape(total, 4)
+        return {
+            "image_embeds": embeds,
+            "image_grid_thw": grid,
+            "image_token_counts": token_count,
+            "deepstack_visual_embeds_image": [embeds + 1],
+        }
+
+
+def _vision_payload(request_id: str, cache_key: str) -> StagePayload:
+    state = Cosmos3PipelineState(
+        encoder_inputs={
+            "vision_encoder": {
+                "pixel_values": torch.ones((4, 6)),
+                "image_grid_thw": torch.tensor([[1, 2, 2]]),
+                "cache_key": cache_key,
+            }
+        }
+    )
+    return StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs=None),
+        data=state.to_dict(),
+    )
+
+
+def test_vision_encoder_batches_and_deduplicates_same_cache_key() -> None:
+    model = _FakeVisionModel()
+    cache = StageOutputCache(max_size=4, cache_device="cpu")
+    outputs = vision_encoder_scheduler._batch_vision_requests(
+        [
+            _vision_payload("first", "same-image"),
+            _vision_payload("second", "same-image"),
+        ],
+        model=model,
+        cache=cache,
+    )
+
+    assert model.calls == 1
+    assert len(cache) == 1
+    first = Cosmos3PipelineState.from_dict(outputs[0].data)
+    second = Cosmos3PipelineState.from_dict(outputs[1].data)
+    assert torch.equal(
+        first.encoder_outs["vision_encoder"]["image_embeds"],
+        second.encoder_outs["vision_encoder"]["image_embeds"],
+    )

--- a/tests/unit_test/scheduling/test_continuous_diffusion_scheduler.py
+++ b/tests/unit_test/scheduling/test_continuous_diffusion_scheduler.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import queue
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+from sglang_omni.scheduling.continuous_diffusion_scheduler import (
+    ContinuousDiffusionScheduler,
+)
+from sglang_omni.scheduling.messages import IncomingMessage
+from tests.unit_test.pipeline.helpers import run_scheduler
+
+
+@dataclass
+class _State:
+    name: str
+    batch_key: str
+    total_steps: int
+    steps: int = 0
+
+
+class _Backend:
+    def __init__(self) -> None:
+        self.step_batches: list[tuple[str, ...]] = []
+        self.released: list[str] = []
+
+    def prepare(self, payload: dict[str, Any]) -> _State:
+        if payload.get("prepare_error"):
+            raise RuntimeError(f"prepare {payload['name']}")
+        return _State(
+            name=payload["name"],
+            batch_key=payload.get("batch_key", "default"),
+            total_steps=payload.get("total_steps", 1),
+        )
+
+    def batch_key(self, state: _State) -> str:
+        return state.batch_key
+
+    def step(self, states: list[_State]) -> None:
+        self.step_batches.append(tuple(state.name for state in states))
+        for state in states:
+            state.steps += 1
+
+    def is_finished(self, state: _State) -> bool:
+        return state.steps >= state.total_steps
+
+    def finalize(self, state: _State) -> dict[str, Any]:
+        return {"name": state.name, "steps": state.steps}
+
+    def release(self, state: _State) -> None:
+        self.released.append(state.name)
+
+
+def _message(request_id: str, **payload: Any) -> IncomingMessage:
+    return IncomingMessage(
+        request_id=request_id,
+        type="new_request",
+        data={"name": request_id, **payload},
+    )
+
+
+def test_scheduler_batches_compatible_states_and_round_robins_batch_keys() -> None:
+    backend = _Backend()
+    scheduler = ContinuousDiffusionScheduler(
+        backend,
+        max_batch_size=2,
+        max_running_requests=3,
+        max_batch_wait_ms=20,
+    )
+
+    outputs = run_scheduler(
+        scheduler,
+        [
+            _message("image-a", batch_key="image", total_steps=2),
+            _message("image-b", batch_key="image", total_steps=2),
+            _message("video", batch_key="video", total_steps=1),
+        ],
+        output_count=3,
+    )
+
+    assert backend.step_batches == [
+        ("image-a", "image-b"),
+        ("video",),
+        ("image-a", "image-b"),
+    ]
+    assert {output.request_id for output in outputs} == {
+        "image-a",
+        "image-b",
+        "video",
+    }
+    assert all(output.type == "result" for output in outputs)
+    assert sorted(backend.released) == ["image-a", "image-b", "video"]
+
+
+def test_scheduler_applies_batch_cost_without_starving_large_requests() -> None:
+    backend = _Backend()
+    scheduler = ContinuousDiffusionScheduler(
+        backend,
+        max_batch_size=3,
+        max_running_requests=3,
+        max_batch_wait_ms=20,
+        request_cost_fn=lambda payload: payload["cost"],
+        max_batch_cost=3,
+    )
+
+    outputs = run_scheduler(
+        scheduler,
+        [
+            _message("a", cost=2),
+            _message("b", cost=2),
+            _message("large", cost=5),
+        ],
+        output_count=3,
+    )
+
+    assert backend.step_batches == [("a",), ("b",), ("large",)]
+    assert all(output.type == "result" for output in outputs)
+
+
+def test_prepare_error_is_isolated_from_other_requests() -> None:
+    backend = _Backend()
+    scheduler = ContinuousDiffusionScheduler(
+        backend,
+        max_batch_size=2,
+        max_running_requests=2,
+        max_batch_wait_ms=20,
+    )
+
+    outputs = run_scheduler(
+        scheduler,
+        [_message("bad", prepare_error=True), _message("good")],
+        output_count=2,
+    )
+    by_id = {output.request_id: output for output in outputs}
+
+    assert by_id["bad"].type == "error"
+    assert isinstance(by_id["bad"].data, RuntimeError)
+    assert by_id["good"].type == "result"
+    assert backend.released == ["good"]
+
+
+class _FailFirstStepBackend(_Backend):
+    def step(self, states: list[_State]) -> None:
+        self.step_batches.append(tuple(state.name for state in states))
+        if len(self.step_batches) == 1:
+            raise RuntimeError("model step failed")
+        for state in states:
+            state.steps += 1
+
+
+def test_batch_step_error_releases_batch_and_scheduler_keeps_serving() -> None:
+    backend = _FailFirstStepBackend()
+    scheduler = ContinuousDiffusionScheduler(
+        backend,
+        max_batch_size=2,
+        max_running_requests=2,
+        max_batch_wait_ms=20,
+    )
+
+    outputs = run_scheduler(
+        scheduler,
+        [_message("bad-a"), _message("bad-b"), _message("next")],
+        output_count=3,
+    )
+    by_id = {output.request_id: output for output in outputs}
+
+    assert backend.step_batches == [("bad-a", "bad-b"), ("next",)]
+    assert by_id["bad-a"].type == "error"
+    assert by_id["bad-b"].type == "error"
+    assert by_id["next"].type == "result"
+    assert sorted(backend.released) == ["bad-a", "bad-b", "next"]
+
+
+class _BlockingBackend(_Backend):
+    def __init__(self) -> None:
+        super().__init__()
+        self.step_started = threading.Event()
+        self.allow_step = threading.Event()
+        self.state_released = threading.Event()
+
+    def step(self, states: list[_State]) -> None:
+        self.step_started.set()
+        if not self.allow_step.wait(timeout=2.0):
+            raise TimeoutError("test did not release diffusion step")
+        super().step(states)
+
+    def release(self, state: _State) -> None:
+        super().release(state)
+        self.state_released.set()
+
+
+def test_abort_during_model_step_suppresses_result_and_releases_state() -> None:
+    backend = _BlockingBackend()
+    scheduler = ContinuousDiffusionScheduler(backend)
+    thread = threading.Thread(target=scheduler.start, daemon=True)
+    thread.start()
+    try:
+        scheduler.inbox.put(_message("abort-me"))
+        assert backend.step_started.wait(timeout=2.0)
+        scheduler.abort("abort-me")
+        backend.allow_step.set()
+        assert backend.state_released.wait(timeout=2.0)
+        try:
+            output = scheduler.outbox.get(timeout=0.05)
+        except queue.Empty:
+            output = None
+        assert output is None
+        assert backend.released == ["abort-me"]
+    finally:
+        backend.allow_step.set()
+        scheduler.stop()
+        thread.join(timeout=2.0)

--- a/tests/unit_test/scheduling/test_continuous_diffusion_scheduler.py
+++ b/tests/unit_test/scheduling/test_continuous_diffusion_scheduler.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import queue
 import threading
+from copy import deepcopy
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any
 
+from sglang_omni.scheduling import continuous_diffusion_scheduler as scheduler_module
 from sglang_omni.scheduling.continuous_diffusion_scheduler import (
     ContinuousDiffusionScheduler,
 )
@@ -54,6 +57,30 @@ class _Backend:
         self.released.append(state.name)
 
 
+def _tp_group(rank: int = 0, world_size: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(
+        rank=rank,
+        rank_in_group=rank,
+        world_size=world_size,
+        ranks=list(range(world_size)),
+        cpu_group=object(),
+    )
+
+
+def _scheduler(
+    backend: _Backend,
+    *,
+    tp_rank: int = 0,
+    tp_size: int = 1,
+    **kwargs: Any,
+) -> ContinuousDiffusionScheduler:
+    return ContinuousDiffusionScheduler(
+        backend,
+        tp_group=_tp_group(rank=tp_rank, world_size=tp_size),
+        **kwargs,
+    )
+
+
 def _message(request_id: str, **payload: Any) -> IncomingMessage:
     return IncomingMessage(
         request_id=request_id,
@@ -64,7 +91,7 @@ def _message(request_id: str, **payload: Any) -> IncomingMessage:
 
 def test_scheduler_batches_compatible_states_and_round_robins_batch_keys() -> None:
     backend = _Backend()
-    scheduler = ContinuousDiffusionScheduler(
+    scheduler = _scheduler(
         backend,
         max_batch_size=2,
         max_running_requests=3,
@@ -95,9 +122,63 @@ def test_scheduler_batches_compatible_states_and_round_robins_batch_keys() -> No
     assert sorted(backend.released) == ["image-a", "image-b", "video"]
 
 
+def test_tp_leader_owns_ingress_batch_wait_and_output(monkeypatch) -> None:
+    broadcast_payload: list[Any] | None = None
+
+    def replay_broadcast(data, rank, _group, *, src):
+        nonlocal broadcast_payload
+        if rank == src:
+            broadcast_payload = deepcopy(data)
+        assert broadcast_payload is not None
+        return deepcopy(broadcast_payload)
+
+    monkeypatch.setattr(scheduler_module, "broadcast_pyobj", replay_broadcast)
+
+    leader = _scheduler(
+        _Backend(),
+        tp_rank=0,
+        tp_size=2,
+        max_running_requests=2,
+        max_batch_wait_ms=20,
+    )
+    follower = _scheduler(
+        _Backend(),
+        tp_rank=1,
+        tp_size=2,
+        max_running_requests=2,
+        max_batch_wait_ms=20,
+    )
+    assert not leader.requires_tp_work_fanout
+
+    leader.inbox.put(_message("first"))
+    leader._drain_messages(block=False)
+    follower._drain_messages(block=False)
+    assert (
+        [request.request_id for request in leader._waiting]
+        == [request.request_id for request in follower._waiting]
+        == ["first"]
+    )
+
+    leader.inbox.put(_message("late"))
+    leader._wait_for_initial_batch()
+    follower._wait_for_initial_batch()
+    assert (
+        [request.request_id for request in leader._waiting]
+        == [request.request_id for request in follower._waiting]
+        == ["first", "late"]
+    )
+
+    leader._emit_result("first", "leader-result")
+    leader._emit_error("late", RuntimeError("leader-error"))
+    follower._emit_result("first", "follower-result")
+    follower._emit_error("late", RuntimeError("follower-error"))
+    assert [leader.outbox.get_nowait().type for _ in range(2)] == ["result", "error"]
+    assert follower.outbox.empty()
+
+
 def test_scheduler_applies_batch_cost_without_starving_large_requests() -> None:
     backend = _Backend()
-    scheduler = ContinuousDiffusionScheduler(
+    scheduler = _scheduler(
         backend,
         max_batch_size=3,
         max_running_requests=3,
@@ -122,7 +203,7 @@ def test_scheduler_applies_batch_cost_without_starving_large_requests() -> None:
 
 def test_prepare_error_is_isolated_from_other_requests() -> None:
     backend = _Backend()
-    scheduler = ContinuousDiffusionScheduler(
+    scheduler = _scheduler(
         backend,
         max_batch_size=2,
         max_running_requests=2,
@@ -153,7 +234,7 @@ class _FailFirstStepBackend(_Backend):
 
 def test_batch_step_error_releases_batch_and_scheduler_keeps_serving() -> None:
     backend = _FailFirstStepBackend()
-    scheduler = ContinuousDiffusionScheduler(
+    scheduler = _scheduler(
         backend,
         max_batch_size=2,
         max_running_requests=2,
@@ -194,7 +275,7 @@ class _BlockingBackend(_Backend):
 
 def test_abort_during_model_step_suppresses_result_and_releases_state() -> None:
     backend = _BlockingBackend()
-    scheduler = ContinuousDiffusionScheduler(backend)
+    scheduler = _scheduler(backend)
     thread = threading.Thread(target=scheduler.start, daemon=True)
     thread.start()
     try:

--- a/tests/unit_test/serve/test_sglang_bootstrap.py
+++ b/tests/unit_test/serve/test_sglang_bootstrap.py
@@ -74,6 +74,7 @@ def test_create_sglang_infrastructure_runs_0515_initialization_phases(
     monkeypatch,
 ) -> None:
     events: list[str] = []
+    worker_kwargs: dict[str, object] = {}
     monkeypatch.setattr(
         bootstrap,
         "_describe_sglang_runtime_configuration",
@@ -98,7 +99,7 @@ def test_create_sglang_infrastructure_runs_0515_initialization_phases(
         enable_prefill_input_embeds = False
 
         def __init__(self, **kwargs) -> None:
-            del kwargs
+            worker_kwargs.update(kwargs)
             events.append("model_worker")
             self.model_runner = FakeRunner()
 
@@ -136,7 +137,11 @@ def test_create_sglang_infrastructure_runs_0515_initialization_phases(
         chunked_prefill_size=8,
         max_prefill_tokens=16,
     )
-    infrastructure = bootstrap.create_sglang_infrastructure(server_args, 0)
+    infrastructure = bootstrap.create_sglang_infrastructure(
+        server_args,
+        0,
+        model_weights_path="/models/component",
+    )
 
     assert events == [
         "runtime_configuration",
@@ -147,6 +152,7 @@ def test_create_sglang_infrastructure_runs_0515_initialization_phases(
         "get_memory_pool",
     ]
     assert infrastructure[0].model_runner.model is FakeRunner.model
+    assert worker_kwargs["config"].model_weights_path == "/models/component"
 
 
 def test_cuda_graph_init_scopes_prefill_embedding_capture_flag() -> None:

--- a/tests/unit_test/test_flow_unipc.py
+++ b/tests/unit_test/test_flow_unipc.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+import torch
+from sglang.multimodal_gen.runtime.models.schedulers.scheduling_flow_unipc_multistep import (
+    FlowUniPCMultistepScheduler,
+)
+
+from sglang_omni.diffusion.flow_unipc import FlowUniPCSolver
+
+
+def test_flow_unipc_solver_matches_sglang_scheduler_step_for_step() -> None:
+    num_steps = 3
+    shift = 5.0
+    solver = FlowUniPCSolver.create(
+        num_inference_steps=num_steps,
+        device="cpu",
+        shift=shift,
+    )
+    reference = FlowUniPCMultistepScheduler(
+        num_train_timesteps=1000,
+        shift=shift,
+    )
+    reference.set_timesteps(num_steps, device="cpu", shift=shift)
+
+    actual = torch.linspace(-1.0, 1.0, 16).reshape(1, 2, 2, 2, 2)
+    expected = actual.clone()
+    assert torch.equal(solver.timesteps, reference.timesteps)
+    assert torch.equal(solver.sigmas, reference.sigmas)
+
+    for timestep in reference.timesteps:
+        actual_velocity = actual * 0.125 + 0.01
+        expected_velocity = expected * 0.125 + 0.01
+        assert torch.equal(solver.timestep, timestep)
+        actual = solver.step(actual_velocity, actual)
+        expected = reference.step(
+            model_output=expected_velocity,
+            timestep=timestep,
+            sample=expected,
+            return_dict=False,
+        )[0]
+        torch.testing.assert_close(actual, expected)
+
+    assert solver.step_index == num_steps
+    assert solver.is_finished
+    with pytest.raises(RuntimeError, match="already finished"):
+        solver.step(torch.zeros_like(actual), actual)
+
+
+def test_flow_unipc_solver_instances_do_not_share_history() -> None:
+    first = FlowUniPCSolver.create(num_inference_steps=2, device="cpu", shift=1.0)
+    second = FlowUniPCSolver.create(num_inference_steps=2, device="cpu", shift=1.0)
+    sample = torch.zeros(1, 1, 2, 2)
+
+    first.step(torch.ones_like(sample), sample)
+
+    assert first.step_index == 1
+    assert second.step_index == 0
+
+
+def test_flow_unipc_solver_rejects_empty_schedule() -> None:
+    with pytest.raises(ValueError, match="must be positive"):
+        FlowUniPCSolver.create(num_inference_steps=0, device="cpu")


### PR DESCRIPTION
## Summary

This is Stack 3 on top of #1265. It adds the minimal serving foundation needed
before introducing the Cosmos3 GEN stage:

- add a stage-facing continuous-diffusion scheduler with request admission,
  compatible batching, round-robin progress, abort/error cleanup, and an
  opaque backend-state contract;
- add a request-local adapter around SGLang's
  `FlowUniPCMultistepScheduler` instead of copying its numerical
  implementation;
- keep Cosmos3 GEN execution, latent preparation, CFG, UND K/V payloads,
  codecs, and pipeline topology for later stacked PRs;
- leave the existing LLaDA, Ming, Voxtral, and Higgs paths unchanged.

FlowUniPC state is intentionally independent per request and generated
modality because the upstream solver retains model-output and timestep history
on each scheduler instance.

## Request lifecycle

```mermaid
flowchart LR
    A["Stage inbox"] --> B["Waiting queue"]
    B --> C["backend.prepare(payload)"]
    C --> D["Resident request state"]
    D --> E["Group by batch_key and cost"]
    E --> F["backend.step(states)"]
    F --> G{"backend.is_finished(state)?"}
    G -- "No: requeue" --> D
    G -- "Yes" --> H["backend.finalize(state)"]
    H --> I["Stage outbox result"]
    I --> J["backend.release(state)"]
    C -. "Prepare error" .-> K["Error result"]
    F -. "Step error" .-> K
    D -. "Abort" .-> J
    K --> J
```

The scheduler treats request state as opaque. In the following GEN stack, one
`backend.step()` will contain the batched GEN forward, CFG/mask application,
and one request-local FlowUniPC update; unfinished state remains resident for
the next denoising turn.
