### PR TITLE
[Perf][MOSS-TTS] Add MOSS-TTS sampling CUDA graphs

### DIFF
--- a/sglang_omni/models/moss_tts/engine_builder.py
+++ b/sglang_omni/models/moss_tts/engine_builder.py
@@ -40,7 +40,16 @@ class MossTtsEngineBuilder(TtsEngineBuilder):
         gpu_id: int,
         server_args: Any,
     ) -> None:
-        del model_worker, checkpoint_dir, device, gpu_id, server_args
+        del checkpoint_dir, device, gpu_id, server_args
+        self._model_runner = model_worker.model_runner
+
+    def post_cuda_graph_setup(self, model: Any, server_args: Any) -> None:
+        del server_args
+        graph_runner = self._model_runner.graph_runner
+        model.init_sampling_graphs(
+            list(graph_runner.capture_bs),
+            disable_padding=graph_runner.disable_padding,
+        )
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
         model_runner_mod = importlib.import_module(

--- a/sglang_omni/models/moss_tts/engine_builder.py
+++ b/sglang_omni/models/moss_tts/engine_builder.py
@@ -45,7 +45,7 @@ class MossTtsEngineBuilder(TtsEngineBuilder):
 
     def post_cuda_graph_setup(self, model: Any, server_args: Any) -> None:
         del server_args
-        graph_runner = self._model_runner.graph_runner
+        graph_runner = self._model_runner.decode_cuda_graph_runner
         model.init_sampling_graphs(
             list(graph_runner.capture_bs),
             disable_padding=graph_runner.disable_padding,

--- a/sglang_omni/models/moss_tts/model_runner.py
+++ b/sglang_omni/models/moss_tts/model_runner.py
@@ -6,35 +6,20 @@ from __future__ import annotations
 from typing import Any
 
 import torch
-from sglang.kernels.ops.sampling.murmur_hash import murmur_hash32
 from sglang.srt.layers.sampler import multinomial_with_seed
 
 from sglang_omni.model_runner.base import ModelRunner
 from sglang_omni.models.moss_tts.request_builders import _INF_DELAY
+from sglang_omni.models.moss_tts.sampler import DelayGraphBatch
+from sglang_omni.models.moss_tts.sampling_kernels import (
+    multinomial_with_seed_and_token_ids,
+)
 from sglang_omni.scheduling.types import RequestOutput
 
 _NEG_INF = float("-inf")
 _INT64_MAX = torch.iinfo(torch.int64).max
 _UINT64_MASK = (1 << 64) - 1
 _INT64_SEED_MASK = (1 << 63) - 1
-
-
-@torch.compile(dynamic=True)
-def _multinomial_with_seed_and_token_ids(
-    logprobs: torch.Tensor,
-    seed: torch.Tensor,
-    positions: torch.Tensor,
-    token_ids: torch.Tensor,
-) -> torch.Tensor:
-    """Seeded Gumbel-max using original vocabulary ids as RNG columns."""
-
-    seed = seed.to(torch.uint64)
-    hashed = murmur_hash32(seed, positions, token_ids)
-    noise = hashed.to(torch.float64) / torch.iinfo(torch.uint32).max
-    noise.log_().clamp_(min=torch.finfo(noise.dtype).min).neg_()
-    noise.log_().neg_()
-    noise.add_(logprobs.to(torch.float64))
-    return torch.argmax(noise, dim=1)
 
 
 class MossTTSModelRunner(ModelRunner):
@@ -179,12 +164,15 @@ class MossTTSModelRunner(ModelRunner):
         if not requests:
             return
 
-        rows = self._sample_rows(
-            channel_logits,
-            datas,
-            n_vq=n_vq,
-            is_audio=is_audio,
-        )
+        if self._can_use_sampling_cuda_graph(datas, is_audio=is_audio):
+            rows = self._sample_rows_graphed(channel_logits, datas)
+        else:
+            rows = self._sample_rows(
+                channel_logits,
+                datas,
+                n_vq=n_vq,
+                is_audio=is_audio,
+            )
 
         next_token_ids = rows[:, 0].contiguous()
         result.next_token_ids = next_token_ids
@@ -193,6 +181,73 @@ class MossTTSModelRunner(ModelRunner):
         )
         self._pending_rows = rows
         self._pending_embeds = embeds.detach()
+
+    def _can_use_sampling_cuda_graph(
+        self,
+        datas: list,
+        *,
+        is_audio: bool,
+    ) -> bool:
+        if not is_audio or not datas:
+            return False
+        is_compatible = getattr(
+            self.model,
+            "is_sampling_cuda_graph_compatible",
+            None,
+        )
+        if not callable(is_compatible):
+            return False
+        return all(
+            is_compatible(data) for data in datas
+        ) and self._sampling_graph_available(len(datas))
+
+    def _sampling_graph_available(self, batch_size: int) -> bool:
+        available = getattr(self.model, "sampling_graph_available", None)
+        return bool(callable(available) and available(batch_size))
+
+    def _sample_rows_graphed(
+        self,
+        channel_logits: list[torch.Tensor],
+        datas: list,
+    ) -> torch.Tensor:
+        device = channel_logits[0].device
+        batch_size = len(datas)
+        n_vq = len(channel_logits) - 1
+        delay_state = torch.stack(
+            [self._delay_state_tensor(data, device) for data in datas], dim=0
+        )
+        seeds = torch.tensor(
+            [int(data.sampling_seed) for data in datas],
+            dtype=torch.long,
+            device=device,
+        )
+        generation_steps = torch.tensor(
+            [int(data.generation_steps) for data in datas],
+            dtype=torch.long,
+            device=device,
+        )
+        audio_logits = torch.stack(
+            [logits.to(torch.float32) for logits in channel_logits[1:]], dim=1
+        )
+        if tuple(audio_logits.shape[:2]) != (batch_size, n_vq):
+            raise RuntimeError(
+                "MOSS-TTS Delay sampling graph audio-logits shape mismatch: "
+                f"got {tuple(audio_logits.shape)}"
+            )
+        sampled = self.model.sample_delay_graphed(
+            channel_logits[0].to(torch.float32),
+            audio_logits,
+            DelayGraphBatch(
+                delay_state=delay_state,
+                seeds=seeds,
+                generation_steps=generation_steps,
+            ),
+        )
+        rows = sampled.rows[:batch_size].clone()
+        next_state = sampled.next_delay_state[:batch_size].clone()
+        for index, data in enumerate(datas):
+            data.delay_state = next_state[index]
+        return rows
 
     def _channel_logits_from_result(
         self,
@@ -530,7 +585,7 @@ class MossTTSModelRunner(ModelRunner):
                     positions_row,
                 )
             else:
-                candidate_sampled = _multinomial_with_seed_and_token_ids(
+                candidate_sampled = multinomial_with_seed_and_token_ids(
                     scores,
                     seeds_row,
                     positions_row,

--- a/sglang_omni/models/moss_tts/payload_types.py
+++ b/sglang_omni/models/moss_tts/payload_types.py
@@ -9,6 +9,20 @@ from typing import Any
 from sglang_omni.scheduling.pipeline_state import DeclarativeStateBase, wire
 
 
+@dataclass(frozen=True)
+class ChannelSampling:
+    """Sampling defaults for one MOSS-TTS channel group."""
+
+    temperature: float
+    top_p: float
+    top_k: int
+
+
+TEXT_SAMPLING = ChannelSampling(temperature=1.5, top_p=1.0, top_k=50)
+AUDIO_SAMPLING = ChannelSampling(temperature=1.7, top_p=0.8, top_k=25)
+AUDIO_REPETITION_PENALTY = 1.0
+
+
 def moss_tts_special_token_defaults(
     audio_vocab_size: int = 1024,
 ) -> tuple[tuple[str, int], ...]:

--- a/sglang_omni/models/moss_tts/request_builders.py
+++ b/sglang_omni/models/moss_tts/request_builders.py
@@ -16,6 +16,9 @@ from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.sampling.sampling_params import SamplingParams
 
 from sglang_omni.models.moss_tts.payload_types import (
+    AUDIO_REPETITION_PENALTY,
+    AUDIO_SAMPLING,
+    TEXT_SAMPLING,
     MossTTSState,
     resolve_moss_audio_pad_code,
 )
@@ -90,13 +93,13 @@ class MossTTSSGLangRequestData(ARRequestData):
     stream_output_row_count: int = 0
     stream_row_count: int = 0
     pending_feedback_queue: Any = field(default_factory=collections.deque)
-    text_temperature: float = 1.5
-    text_top_p: float = 1.0
-    text_top_k: int = 50
-    audio_temperature: float = 1.7
-    audio_top_p: float = 0.8
-    audio_top_k: int = 25
-    audio_repetition_penalty: float = 1.0
+    text_temperature: float = TEXT_SAMPLING.temperature
+    text_top_p: float = TEXT_SAMPLING.top_p
+    text_top_k: int = TEXT_SAMPLING.top_k
+    audio_temperature: float = AUDIO_SAMPLING.temperature
+    audio_top_p: float = AUDIO_SAMPLING.top_p
+    audio_top_k: int = AUDIO_SAMPLING.top_k
+    audio_repetition_penalty: float = AUDIO_REPETITION_PENALTY
     seed: int | None = None
     sampling_seed: int = field(default_factory=_new_moss_tts_sampling_seed)
     delay_state: torch.Tensor | None = None
@@ -303,13 +306,13 @@ def build_generation_kwargs(
         # note (chenyang): the checkpoint's own generate() defaults; greedy
         # (temperature=0) collapses the codec LM into copying the reference
         # audio. Callers may override any field.
-        "text_temperature": 1.5,
-        "audio_temperature": 1.7,
-        "text_top_p": 1.0,
-        "audio_top_p": 0.8,
-        "text_top_k": 50,
-        "audio_top_k": 25,
-        "audio_repetition_penalty": 1.0,
+        "text_temperature": TEXT_SAMPLING.temperature,
+        "audio_temperature": AUDIO_SAMPLING.temperature,
+        "text_top_p": TEXT_SAMPLING.top_p,
+        "audio_top_p": AUDIO_SAMPLING.top_p,
+        "text_top_k": TEXT_SAMPLING.top_k,
+        "audio_top_k": AUDIO_SAMPLING.top_k,
+        "audio_repetition_penalty": AUDIO_REPETITION_PENALTY,
     }
 
     if "temperature" in explicit_fields and params.get("temperature") is not None:
@@ -728,13 +731,22 @@ def build_sglang_moss_tts_request(
         state=prepared.state,
         model_config=cfg,
         prompt_rows=prepared.prompt_rows,
-        text_temperature=float(gen_kwargs.get("text_temperature", 0.0)),
-        text_top_p=float(gen_kwargs.get("text_top_p", 1.0)),
-        text_top_k=int(gen_kwargs.get("text_top_k", -1)),
-        audio_temperature=float(gen_kwargs.get("audio_temperature", 0.0)),
-        audio_top_p=float(gen_kwargs.get("audio_top_p", 1.0)),
-        audio_top_k=int(gen_kwargs.get("audio_top_k", -1)),
-        audio_repetition_penalty=float(gen_kwargs.get("audio_repetition_penalty", 1.0)),
+        text_temperature=float(
+            gen_kwargs.get("text_temperature", TEXT_SAMPLING.temperature)
+        ),
+        text_top_p=float(gen_kwargs.get("text_top_p", TEXT_SAMPLING.top_p)),
+        text_top_k=int(gen_kwargs.get("text_top_k", TEXT_SAMPLING.top_k)),
+        audio_temperature=float(
+            gen_kwargs.get("audio_temperature", AUDIO_SAMPLING.temperature)
+        ),
+        audio_top_p=float(gen_kwargs.get("audio_top_p", AUDIO_SAMPLING.top_p)),
+        audio_top_k=int(gen_kwargs.get("audio_top_k", AUDIO_SAMPLING.top_k)),
+        audio_repetition_penalty=float(
+            gen_kwargs.get(
+                "audio_repetition_penalty",
+                AUDIO_REPETITION_PENALTY,
+            )
+        ),
         seed=gen_kwargs.get("seed"),
         sampling_seed=(
             derive_moss_tts_sampling_seed(gen_kwargs["seed"])

--- a/sglang_omni/models/moss_tts/sampler.py
+++ b/sglang_omni/models/moss_tts/sampler.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fixed-shape sampling and Delay-FSM transition for MOSS-TTS."""
+
+from __future__ import annotations
+
+from typing import Any, NamedTuple
+
+import torch
+from sglang.srt.layers.sampler import multinomial_with_seed
+from torch import nn
+
+from sglang_omni.models.moss_tts.payload_types import (
+    AUDIO_REPETITION_PENALTY,
+    AUDIO_SAMPLING,
+    TEXT_SAMPLING,
+    ChannelSampling,
+)
+from sglang_omni.models.moss_tts.sampling_kernels import (
+    multinomial_with_seed_and_token_ids,
+    seeded_gumbel_argmax,
+)
+
+_NEG_INF = float("-inf")
+_INT64_MAX = torch.iinfo(torch.int64).max
+
+
+class DelayGraphBatch(NamedTuple):
+    """Request state consumed by one fixed-shape sampling graph replay."""
+
+    delay_state: torch.Tensor
+    seeds: torch.Tensor
+    generation_steps: torch.Tensor
+
+
+class DelaySamplingOutput(NamedTuple):
+    """One fixed-width token row and the state consumed by the next step."""
+
+    rows: torch.Tensor
+    next_delay_state: torch.Tensor
+
+
+def matches_graph_profile(data: Any) -> bool:
+    """Return whether a request matches the profile baked into the graph."""
+
+    text = ChannelSampling(
+        temperature=float(getattr(data, "text_temperature", TEXT_SAMPLING.temperature)),
+        top_p=float(getattr(data, "text_top_p", TEXT_SAMPLING.top_p)),
+        top_k=int(getattr(data, "text_top_k", TEXT_SAMPLING.top_k)),
+    )
+    audio = ChannelSampling(
+        temperature=float(
+            getattr(data, "audio_temperature", AUDIO_SAMPLING.temperature)
+        ),
+        top_p=float(getattr(data, "audio_top_p", AUDIO_SAMPLING.top_p)),
+        top_k=int(getattr(data, "audio_top_k", AUDIO_SAMPLING.top_k)),
+    )
+    penalty = float(
+        getattr(
+            data,
+            "audio_repetition_penalty",
+            AUDIO_REPETITION_PENALTY,
+        )
+    )
+    return (text, audio, penalty) == (
+        TEXT_SAMPLING,
+        AUDIO_SAMPLING,
+        AUDIO_REPETITION_PENALTY,
+    )
+
+
+def _sample_default_audio_tokens(
+    logits: torch.Tensor,
+    *,
+    seeds: torch.Tensor,
+    positions: torch.Tensor,
+    output: torch.Tensor | None,
+) -> torch.Tensor:
+    """Checkpoint-default audio sampling with full-vocabulary tie semantics."""
+
+    scores = logits / AUDIO_SAMPLING.temperature
+    vocab = int(scores.shape[-1])
+    if 0 < AUDIO_SAMPLING.top_k < vocab:
+        topk_scores = torch.topk(scores, k=AUDIO_SAMPLING.top_k, dim=-1).values
+        scores = scores.masked_fill(scores < topk_scores[:, -1:], _NEG_INF)
+
+    sorted_scores, sorted_indices = torch.sort(scores, descending=True, dim=-1)
+    probs_sorted = torch.softmax(sorted_scores, dim=-1)
+    cumulative = torch.cumsum(probs_sorted, dim=-1)
+    remove = cumulative > AUDIO_SAMPLING.top_p
+    remove[..., 1:] = remove[..., :-1].clone()
+    remove[..., 0] = False
+    remove_scattered = torch.zeros_like(scores, dtype=torch.bool).scatter_(
+        -1, sorted_indices, remove
+    )
+    scores = scores.masked_fill(remove_scattered, _NEG_INF)
+
+    if scores.device.type == "cuda" and output is not None:
+        return seeded_gumbel_argmax(scores, seeds, positions, output)
+    return multinomial_with_seed(scores, seeds, positions).view(-1).long()
+
+
+class MossTTSDelayAudioGraphSampler(nn.Module):
+    """Pure-tensor fixed-shape sampler for all-audio Delay batches.
+
+    The graph path is specialized to the checkpoint-default stochastic profile.
+    Arbitrary request parameters continue to use the general eager sampler in
+    :mod:`model_runner`.
+    """
+
+    def __init__(self, config: Any) -> None:
+        super().__init__()
+        self.n_vq = int(config.n_vq)
+        self.num_channels = self.n_vq + 1
+        self.pad_token_id = int(config.pad_token_id)
+        self.gen_slot_token_id = int(config.audio_assistant_gen_slot_token_id)
+        self.delay_slot_token_id = int(config.audio_assistant_delay_slot_token_id)
+        self.audio_start_token_id = int(config.audio_start_token_id)
+        self.audio_end_token_id = int(config.audio_end_token_id)
+        self.im_end_token_id = int(config.im_end_token_id)
+        self.audio_pad_code = int(config.audio_pad_code)
+
+        audio_vocab = int(config.vocab_size_list[1])
+        self.register_buffer(
+            "text_control_token_ids",
+            torch.tensor(
+                [
+                    self.gen_slot_token_id,
+                    self.delay_slot_token_id,
+                ],
+                dtype=torch.long,
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "audio_invalid_mask",
+            torch.arange(audio_vocab) >= self.audio_pad_code,
+            persistent=False,
+        )
+        self.register_buffer(
+            "channel_indices",
+            torch.arange(self.n_vq, dtype=torch.long).view(1, -1),
+            persistent=False,
+        )
+
+    def forward(
+        self,
+        control_logits: torch.Tensor,
+        audio_logits: torch.Tensor,
+        batch: DelayGraphBatch,
+        *,
+        audio_sample_output: torch.Tensor | None = None,
+    ) -> DelaySamplingOutput:
+        """Static checkpoint-default stochastic topology."""
+        batch_size = int(control_logits.shape[0])
+        num_controls = len(self.text_control_token_ids)
+        if tuple(control_logits.shape) != (batch_size, num_controls):
+            raise ValueError(
+                "MOSS-TTS Delay graph control logits must have shape "
+                f"[B, {num_controls}], "
+                f"got {tuple(control_logits.shape)}"
+            )
+        if tuple(audio_logits.shape[:2]) != (batch_size, self.n_vq):
+            raise ValueError(
+                "MOSS-TTS Delay graph audio logits must have shape [B, n_vq, V], "
+                f"got {tuple(audio_logits.shape)}"
+            )
+
+        seeds = batch.seeds
+        generation_steps = batch.generation_steps
+        audio_lengths, delayed, is_audio = batch.delay_state.unbind(dim=1)
+        is_audio = is_audio.bool()
+
+        next_text = torch.full(
+            (batch_size,),
+            self.pad_token_id,
+            dtype=torch.long,
+            device=control_logits.device,
+        )
+        next_text = torch.where(
+            delayed < self.n_vq,
+            torch.full_like(next_text, self.delay_slot_token_id),
+            next_text,
+        )
+        is_audio_eos = delayed == self.n_vq
+        next_text = torch.where(
+            is_audio_eos,
+            torch.full_like(next_text, self.audio_end_token_id),
+            next_text,
+        )
+        is_audio = is_audio & ~is_audio_eos
+        sampling_text_mask = is_audio & (delayed > self.n_vq)
+
+        masked_control_logits = control_logits.float() / TEXT_SAMPLING.temperature
+        delay_logits = masked_control_logits[:, -1]
+        masked_control_logits[:, -1] = torch.where(
+            generation_steps == 0,
+            torch.full_like(delay_logits, _NEG_INF),
+            delay_logits,
+        )
+        sampled_control = multinomial_with_seed_and_token_ids(
+            masked_control_logits,
+            seeds,
+            generation_steps * self.num_channels,
+            self.text_control_token_ids,
+        )
+        sampled_text = self.text_control_token_ids[sampled_control]
+        next_text = torch.where(sampling_text_mask, sampled_text, next_text)
+        is_audio = (is_audio | (next_text == self.audio_start_token_id)) & (
+            next_text != self.im_end_token_id
+        )
+
+        pre_audio = audio_lengths.unsqueeze(1) > self.channel_indices
+        post_audio = self.channel_indices > (delayed.unsqueeze(1) - 1)
+        post_audio = post_audio | (delayed == _INT64_MAX).unsqueeze(1)
+        sampling_audio_mask = pre_audio & post_audio
+
+        masked_audio_logits = audio_logits.float().masked_fill(
+            self.audio_invalid_mask.view(1, 1, -1), _NEG_INF
+        )
+        flat_audio_logits = masked_audio_logits.reshape(batch_size * self.n_vq, -1)
+        audio_positions = generation_steps.unsqueeze(1) * self.num_channels
+        audio_positions = (
+            (audio_positions + self.channel_indices + 1).reshape(-1).contiguous()
+        )
+        audio_seeds = seeds.unsqueeze(1).expand(batch_size, self.n_vq).reshape(-1)
+        sampled_audio = _sample_default_audio_tokens(
+            flat_audio_logits,
+            seeds=audio_seeds,
+            positions=audio_positions,
+            output=audio_sample_output,
+        ).view(batch_size, self.n_vq)
+
+        next_audio = torch.where(
+            sampling_audio_mask,
+            sampled_audio,
+            torch.full_like(sampled_audio, self.audio_pad_code),
+        )
+
+        increment = (
+            (next_text == self.audio_start_token_id)
+            | (next_text == self.gen_slot_token_id)
+            | (next_text == self.delay_slot_token_id)
+        )
+        next_audio_lengths = audio_lengths + increment.long()
+        next_audio_lengths = torch.where(
+            next_text == self.audio_end_token_id,
+            torch.zeros_like(next_audio_lengths),
+            next_audio_lengths,
+        )
+        next_delayed = torch.where(
+            (delayed == _INT64_MAX) & (next_text == self.delay_slot_token_id),
+            torch.zeros_like(delayed),
+            delayed,
+        )
+        next_delayed = torch.where(
+            next_delayed != _INT64_MAX,
+            next_delayed + 1,
+            next_delayed,
+        )
+        next_delayed = torch.where(
+            next_delayed > self.n_vq,
+            torch.full_like(next_delayed, _INT64_MAX),
+            next_delayed,
+        )
+        next_delay_state = torch.stack(
+            (next_audio_lengths, next_delayed, is_audio.long()), dim=1
+        )
+        rows = torch.cat((next_text.unsqueeze(1), next_audio), dim=1)
+        return DelaySamplingOutput(rows=rows, next_delay_state=next_delay_state)

--- a/sglang_omni/models/moss_tts/sampling_cuda_graph.py
+++ b/sglang_omni/models/moss_tts/sampling_cuda_graph.py
@@ -1,0 +1,329 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bucket-aligned CUDA graphs for MOSS-TTS Delay sampling and its FSM."""
+
+from __future__ import annotations
+
+import gc
+import logging
+from bisect import bisect_left
+from typing import Any, NamedTuple
+
+import torch
+
+from sglang_omni.models.moss_tts.sampler import DelayGraphBatch, DelaySamplingOutput
+
+logger = logging.getLogger(__name__)
+
+_MIN_CAPTURE_FREE_BYTES = 512 * 1024**2
+
+
+class _StaticSamplingInputs(NamedTuple):
+    control_logits: torch.Tensor
+    audio_logits: torch.Tensor
+    delay_state: torch.Tensor
+    seeds: torch.Tensor
+    generation_steps: torch.Tensor
+    audio_sample_output: torch.Tensor
+
+
+class _CapturedSamplingGraph(NamedTuple):
+    graph: torch.cuda.CUDAGraph
+    rows: torch.Tensor
+    next_delay_state: torch.Tensor
+
+
+class MossTTSDelaySamplingCudaGraphRunner:
+    """Sampling/FSM graphs aligned to the backbone CUDA-graph buckets.
+
+    LM heads and feedback embedding deliberately remain eager. Every graph uses
+    all 32 codebook rows and applies the Delay mask only to its fixed-shape
+    output, so replay topology does not depend on the number of active channels.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: Any,
+        capture_bs: tuple[int, ...],
+        disable_padding: bool = False,
+    ) -> None:
+        if not capture_bs:
+            raise ValueError("MOSS-TTS Delay sampling CUDA graph bs must be non-empty")
+        if any(batch_size < 1 for batch_size in capture_bs):
+            raise ValueError("MOSS-TTS Delay sampling CUDA graph bs must be >= 1")
+        if tuple(sorted(set(capture_bs))) != tuple(capture_bs):
+            raise ValueError(
+                "MOSS-TTS Delay sampling CUDA graph bs must be strictly increasing"
+            )
+        self.model = model
+        self.capture_bs = tuple(int(batch_size) for batch_size in capture_bs)
+        self.disable_padding = bool(disable_padding)
+        self.graphs: dict[int, _CapturedSamplingGraph] = {}
+        self._inputs: _StaticSamplingInputs | None = None
+        self._graph_pool = None
+        self._warmup_stream: torch.cuda.Stream | None = None
+        self._capture_stream: torch.cuda.Stream | None = None
+
+    @classmethod
+    def capture(
+        cls,
+        *,
+        model: Any,
+        capture_bs: tuple[int, ...],
+        disable_padding: bool = False,
+    ) -> "MossTTSDelaySamplingCudaGraphRunner":
+        runner = cls(
+            model=model,
+            capture_bs=capture_bs,
+            disable_padding=disable_padding,
+        )
+        capture_failed = False
+        try:
+            with torch.cuda.device(model.device):
+                torch.cuda.synchronize()
+                runner._capture_all()
+        except Exception as exc:
+            capture_failed = True
+            failure = "OOM" if runner._is_cuda_oom(exc) else "failure"
+            logger.exception(
+                "MOSS-TTS Delay sampling CUDA graph initialization %s; "
+                "discarding partial graphs and using eager sampling",
+                failure,
+            )
+        # note (Zhang Yiyang): Clear outside the active exception scope so its
+        # traceback cannot retain failed-capture tensors while empty_cache runs.
+        if capture_failed:
+            try:
+                runner.clear()
+            except Exception:
+                logger.exception(
+                    "Failed to release MOSS-TTS Delay sampling CUDA graph "
+                    "resources after capture failure"
+                )
+        return runner
+
+    def _capture_all(self) -> None:
+        buckets = self.capture_buckets
+        if not buckets:
+            return
+        self._inputs = self._make_static_inputs(buckets[-1])
+
+        for bucket in reversed(buckets):
+            free_bytes, _ = torch.cuda.mem_get_info(self.model.device)
+            if free_bytes < _MIN_CAPTURE_FREE_BYTES:
+                logger.warning(
+                    "MOSS-TTS Delay sampling CUDA graph capture stopped: free "
+                    "VRAM %.2f GiB is below %.2f GiB headroom; discarding "
+                    "partial graphs and using eager sampling",
+                    free_bytes / 1024**3,
+                    _MIN_CAPTURE_FREE_BYTES / 1024**3,
+                )
+                self.clear()
+                return
+
+            try:
+                self.graphs[bucket] = self._capture_bucket(bucket)
+                logger.info(
+                    "Captured MOSS-TTS Delay sampling CUDA graph backbone_bucket=%s",
+                    bucket,
+                )
+            except Exception as exc:
+                self.graphs.pop(bucket, None)
+                if self._is_cuda_oom(exc):
+                    logger.exception(
+                        "MOSS-TTS Delay sampling CUDA graph OOM for "
+                        "backbone_bucket=%s; discarding partial graphs",
+                        bucket,
+                    )
+                    self.clear()
+                    return
+                logger.exception(
+                    "Failed to capture MOSS-TTS Delay sampling CUDA graph "
+                    "backbone_bucket=%s; that bucket will use eager",
+                    bucket,
+                )
+
+    @staticmethod
+    def _is_cuda_oom(exc: BaseException) -> bool:
+        return (
+            isinstance(exc, torch.OutOfMemoryError)
+            or "out of memory" in str(exc).lower()
+        )
+
+    def clear(self) -> None:
+        self.graphs.clear()
+        self._inputs = None
+        self._graph_pool = None
+        self._warmup_stream = None
+        self._capture_stream = None
+        gc.collect()
+        if self.model.device.type == "cuda" and torch.cuda.is_available():
+            with torch.cuda.device(self.model.device):
+                torch.cuda.empty_cache()
+
+    def _make_static_inputs(self, max_bs: int) -> _StaticSamplingInputs:
+        device = self.model.device
+        n_vq = int(self.model.config.n_vq)
+        audio_vocab = int(self.model.config.vocab_size_list[1])
+        return _StaticSamplingInputs(
+            control_logits=torch.zeros(
+                max_bs,
+                2,
+                device=device,
+                dtype=torch.float32,
+            ),
+            audio_logits=torch.zeros(
+                max_bs,
+                n_vq,
+                audio_vocab,
+                device=device,
+                dtype=torch.float32,
+            ),
+            delay_state=torch.zeros(
+                max_bs,
+                3,
+                device=device,
+                dtype=torch.long,
+            ),
+            seeds=torch.zeros(max_bs, device=device, dtype=torch.long),
+            generation_steps=torch.zeros(max_bs, device=device, dtype=torch.long),
+            audio_sample_output=torch.empty(
+                max_bs * n_vq,
+                device=device,
+                dtype=torch.long,
+            ),
+        )
+
+    def _require_inputs(self) -> _StaticSamplingInputs:
+        if self._inputs is None:
+            raise RuntimeError("MOSS-TTS Delay sampling CUDA graph is not captured")
+        return self._inputs
+
+    def _run_static(
+        self,
+        bucket: int,
+    ) -> DelaySamplingOutput:
+        inputs = self._require_inputs()
+        batch = DelayGraphBatch(
+            delay_state=inputs.delay_state[:bucket],
+            seeds=inputs.seeds[:bucket],
+            generation_steps=inputs.generation_steps[:bucket],
+        )
+        return self.model.sample_delay_fixed_shape(
+            inputs.control_logits[:bucket],
+            inputs.audio_logits[:bucket],
+            batch,
+            audio_sample_output=inputs.audio_sample_output,
+        )
+
+    def _capture_bucket(
+        self,
+        bucket: int,
+    ) -> _CapturedSamplingGraph:
+        device = self.model.device
+        if self._warmup_stream is None:
+            self._warmup_stream = torch.cuda.Stream(device=device)
+        warmup_stream = self._warmup_stream
+        warmup_stream.wait_stream(torch.cuda.current_stream(device))
+        with torch.cuda.stream(warmup_stream):
+            for _ in range(2):
+                self._run_static(bucket)
+        torch.cuda.current_stream(device).wait_stream(warmup_stream)
+        torch.cuda.synchronize(device)
+
+        if self._graph_pool is None:
+            self._graph_pool = torch.cuda.graph_pool_handle()
+        if self._capture_stream is None:
+            self._capture_stream = torch.cuda.Stream(device=device)
+        capture_stream = self._capture_stream
+        capture_stream.wait_stream(torch.cuda.current_stream(device))
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.stream(capture_stream):
+            with torch.cuda.graph(
+                graph,
+                pool=self._graph_pool,
+                stream=capture_stream,
+                capture_error_mode="thread_local",
+            ):
+                output = self._run_static(bucket)
+        torch.cuda.current_stream(device).wait_stream(capture_stream)
+        return _CapturedSamplingGraph(
+            graph=graph,
+            rows=output.rows,
+            next_delay_state=output.next_delay_state,
+        )
+
+    def canonical_bucket(self, batch_size: int) -> int | None:
+        index = bisect_left(self.capture_bs, int(batch_size))
+        if index == len(self.capture_bs):
+            return None
+        return self.capture_bs[index]
+
+    @property
+    def capture_buckets(self) -> tuple[int, ...]:
+        return self.capture_bs
+
+    def _graph_key(self, batch_size: int) -> int | None:
+        bucket = self.canonical_bucket(batch_size)
+        if bucket is None or (self.disable_padding and bucket != int(batch_size)):
+            return None
+        return bucket
+
+    def can_replay(self, batch_size: int) -> bool:
+        key = self._graph_key(batch_size)
+        return key is not None and key in self.graphs
+
+    @torch.no_grad()
+    def replay(
+        self,
+        control_logits: torch.Tensor,
+        audio_logits: torch.Tensor,
+        batch: DelayGraphBatch,
+    ) -> DelaySamplingOutput:
+        batch_size = int(control_logits.shape[0])
+        bucket = self.canonical_bucket(batch_size)
+        key = self._graph_key(batch_size)
+        if key is None or key not in self.graphs:
+            raise RuntimeError(
+                "MOSS-TTS Delay sampling CUDA graph is unavailable for "
+                f"raw_bs={batch_size} backbone_bucket={bucket}"
+            )
+
+        inputs = self._require_inputs()
+        expected_audio_shape = (
+            batch_size,
+            int(inputs.audio_logits.shape[1]),
+            int(inputs.audio_logits.shape[2]),
+        )
+        if tuple(control_logits.shape) != (batch_size, 2):
+            raise RuntimeError(
+                "MOSS-TTS Delay sampling graph control-logits shape mismatch: "
+                f"got {tuple(control_logits.shape)}, expected {(batch_size, 2)}"
+            )
+        if tuple(audio_logits.shape) != expected_audio_shape:
+            raise RuntimeError(
+                "MOSS-TTS Delay sampling graph audio-logits shape mismatch: "
+                f"got {tuple(audio_logits.shape)}, expected {expected_audio_shape}"
+            )
+        if tuple(batch.delay_state.shape) != (batch_size, 3):
+            raise RuntimeError("MOSS-TTS Delay sampling graph state shape mismatch")
+
+        inputs.control_logits[:batch_size].copy_(control_logits)
+        inputs.audio_logits[:batch_size].copy_(audio_logits)
+        inputs.delay_state[:batch_size].copy_(batch.delay_state)
+        inputs.seeds[:batch_size].copy_(batch.seeds)
+        inputs.generation_steps[:batch_size].copy_(batch.generation_steps)
+        assert bucket is not None
+        if batch_size < bucket:
+            inputs.control_logits[batch_size:bucket].zero_()
+            inputs.audio_logits[batch_size:bucket].zero_()
+            inputs.delay_state[batch_size:bucket].zero_()
+            inputs.seeds[batch_size:bucket].zero_()
+            inputs.generation_steps[batch_size:bucket].zero_()
+
+        captured = self.graphs[key]
+        captured.graph.replay()
+        return DelaySamplingOutput(
+            rows=captured.rows[:batch_size],
+            next_delay_state=captured.next_delay_state[:batch_size],
+        )

--- a/sglang_omni/models/moss_tts/sampling_kernels.py
+++ b/sglang_omni/models/moss_tts/sampling_kernels.py
@@ -10,6 +10,8 @@ from sglang.kernels.ops.sampling.murmur_hash import fmix32, murmur3_mix, murmur_
 from sglang.srt.layers.sampler import multinomial_with_seed
 from triton.language.extra import libdevice
 
+_UINT32_MAX_F64 = tl.constexpr(float(torch.iinfo(torch.uint32).max))
+
 
 @triton.jit
 def _seeded_gumbel_argmax_kernel(
@@ -43,7 +45,8 @@ def _seeded_gumbel_argmax_kernel(
     hash_value ^= 16
     hash_value = fmix32(hash_value)
 
-    uniform = hash_value.to(tl.float64) * 2.3283064370807974e-10
+    # Match multinomial_with_seed exactly, including hash_value == UINT32_MAX.
+    uniform = hash_value.to(tl.float64) / _UINT32_MAX_F64
     log_uniform = libdevice.log(uniform)
     neg_log_uniform = -tl.maximum(log_uniform, -1.7976931348623157e308)
     gumbel = -libdevice.log(neg_log_uniform)

--- a/sglang_omni/models/moss_tts/sampling_kernels.py
+++ b/sglang_omni/models/moss_tts/sampling_kernels.py
@@ -99,6 +99,8 @@ def seeded_gumbel_argmax(
         raise ValueError(
             "seeded Gumbel output must be a sufficiently large int64 vector"
         )
+    if output.stride(0) != 1:
+        raise ValueError("seeded Gumbel output must have stride 1")
 
     block_size = triton.next_power_of_2(vocab_size)
     if block_size > 2048:

--- a/sglang_omni/models/moss_tts/sampling_kernels.py
+++ b/sglang_omni/models/moss_tts/sampling_kernels.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Graph-friendly seeded sampling kernels owned by MOSS-TTS."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from sglang.kernels.ops.sampling.murmur_hash import fmix32, murmur3_mix, murmur_hash32
+from sglang.srt.layers.sampler import multinomial_with_seed
+from triton.language.extra import libdevice
+
+
+@triton.jit
+def _seeded_gumbel_argmax_kernel(
+    scores_ptr,
+    seeds_ptr,
+    positions_ptr,
+    output_ptr,
+    VOCAB_SIZE: tl.constexpr,
+    SCORE_ROW_STRIDE: tl.constexpr,
+    SCORE_COL_STRIDE: tl.constexpr,
+    SEED_STRIDE: tl.constexpr,
+    POSITION_STRIDE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Generate seeded Gumbel noise and reduce one vocabulary row in one pass."""
+
+    row = tl.program_id(0)
+    token_ids = tl.arange(0, BLOCK_SIZE)
+    valid = token_ids < VOCAB_SIZE
+    seed = tl.load(seeds_ptr + row * SEED_STRIDE).to(tl.uint64)
+    position = tl.load(positions_ptr + row * POSITION_STRIDE).to(tl.uint32)
+
+    hash_value: tl.uint32 = 0
+    hash_value = murmur3_mix(hash_value, (seed & 0xFFFFFFFF).to(tl.uint32))
+    hash_value = murmur3_mix(
+        hash_value,
+        ((seed >> 32) & 0xFFFFFFFF).to(tl.uint32),
+    )
+    hash_value = murmur3_mix(hash_value, position)
+    hash_value = murmur3_mix(hash_value, token_ids.to(tl.uint32))
+    hash_value ^= 16
+    hash_value = fmix32(hash_value)
+
+    uniform = hash_value.to(tl.float64) * 2.3283064370807974e-10
+    log_uniform = libdevice.log(uniform)
+    neg_log_uniform = -tl.maximum(log_uniform, -1.7976931348623157e308)
+    gumbel = -libdevice.log(neg_log_uniform)
+    score = tl.load(
+        scores_ptr + row * SCORE_ROW_STRIDE + token_ids * SCORE_COL_STRIDE,
+        mask=valid,
+        other=-float("inf"),
+    ).to(tl.float64)
+    value = score + gumbel
+
+    is_nan = value != value
+    nan_index = tl.min(tl.where(valid & is_nan, token_ids, 2147483647), axis=0)
+    non_nan_value = tl.where(valid & ~is_nan, value, -float("inf"))
+    max_value = tl.max(non_nan_value, axis=0)
+    max_index = tl.min(
+        tl.where(
+            valid & ~is_nan & (non_nan_value == max_value),
+            token_ids,
+            2147483647,
+        ),
+        axis=0,
+    )
+    tl.store(
+        output_ptr + row,
+        tl.where(nan_index != 2147483647, nan_index, max_index),
+    )
+
+
+def seeded_gumbel_argmax(
+    scores: torch.Tensor,
+    seeds: torch.Tensor,
+    positions: torch.Tensor,
+    output: torch.Tensor,
+) -> torch.Tensor:
+    """Sample rows without materializing a full-vocabulary Gumbel tensor."""
+
+    if scores.ndim != 2:
+        raise ValueError(f"seeded Gumbel scores must be rank 2, got {scores.shape}")
+    rows, vocab_size = scores.shape
+    if seeds.shape != (rows,) or positions.shape != (rows,):
+        raise ValueError("seeded Gumbel metadata shape mismatch")
+    if scores.device.type != "cuda" or not (
+        seeds.device == scores.device
+        and positions.device == scores.device
+        and output.device == scores.device
+    ):
+        raise ValueError("seeded_gumbel_argmax requires one CUDA device")
+    if scores.dtype != torch.float32:
+        raise TypeError(f"seeded Gumbel scores must be float32, got {scores.dtype}")
+    if seeds.dtype != torch.int64 or positions.dtype != torch.int64:
+        raise TypeError("seeded Gumbel seeds and positions must be int64")
+    if output.dtype != torch.int64 or output.ndim != 1 or output.numel() < rows:
+        raise ValueError(
+            "seeded Gumbel output must be a sufficiently large int64 vector"
+        )
+
+    block_size = triton.next_power_of_2(vocab_size)
+    if block_size > 2048:
+        raise ValueError(
+            f"seeded Gumbel one-pass vocabulary exceeds 2048: {vocab_size}"
+        )
+    result = output[:rows]
+    _seeded_gumbel_argmax_kernel[(rows,)](
+        scores,
+        seeds,
+        positions,
+        result,
+        VOCAB_SIZE=vocab_size,
+        SCORE_ROW_STRIDE=scores.stride(0),
+        SCORE_COL_STRIDE=scores.stride(1),
+        SEED_STRIDE=seeds.stride(0),
+        POSITION_STRIDE=positions.stride(0),
+        BLOCK_SIZE=block_size,
+        num_warps=4,
+    )
+    return result
+
+
+@torch.compile(dynamic=True)
+def multinomial_with_seed_and_token_ids(
+    logprobs: torch.Tensor,
+    seed: torch.Tensor,
+    positions: torch.Tensor,
+    token_ids: torch.Tensor,
+) -> torch.Tensor:
+    """Seeded Gumbel-max using original vocabulary ids as RNG columns."""
+
+    seed = seed.to(torch.uint64)
+    hashed = murmur_hash32(seed, positions, token_ids)
+    noise = hashed.to(torch.float64) / torch.iinfo(torch.uint32).max
+    noise.log_().clamp_(min=torch.finfo(noise.dtype).min).neg_()
+    noise.log_().neg_()
+    noise.add_(logprobs.to(torch.float64))
+    return torch.argmax(noise, dim=1)
+
+
+def sample_seeded_branchless(
+    logits: torch.Tensor,
+    *,
+    temperature: torch.Tensor,
+    top_p: torch.Tensor,
+    top_k: torch.Tensor,
+    seeds: torch.Tensor,
+    positions: torch.Tensor,
+) -> torch.Tensor:
+    """Seeded temperature/top-k/top-p sampling without host control flow."""
+
+    vocab = logits.shape[-1]
+    do_sample = temperature > 0
+    safe_temp = torch.where(do_sample, temperature, torch.ones_like(temperature))
+    scores = logits / safe_temp.unsqueeze(1)
+
+    k_active = (top_k > 0) & (top_k < vocab)
+    k_clamped = top_k.clamp(min=1, max=vocab)
+    sorted_scores, sorted_indices = torch.sort(scores, descending=True, dim=-1)
+    kth = sorted_scores.gather(1, (k_clamped - 1).unsqueeze(1))
+    threshold = torch.where(
+        k_active.unsqueeze(1), kth, torch.full_like(kth, float("-inf"))
+    )
+    scores = scores.masked_fill(scores < threshold, float("-inf"))
+
+    p_active = (top_p > 0.0) & (top_p < 1.0)
+    sorted_masked = sorted_scores.masked_fill(sorted_scores < threshold, float("-inf"))
+    probs_sorted = torch.softmax(sorted_masked, dim=-1)
+    cumulative = torch.cumsum(probs_sorted, dim=-1)
+    remove = cumulative > top_p.unsqueeze(1)
+    remove[..., 1:] = remove[..., :-1].clone()
+    remove[..., 0] = False
+    remove = remove & p_active.unsqueeze(1)
+    remove_scattered = torch.zeros_like(scores, dtype=torch.bool).scatter_(
+        -1, sorted_indices, remove
+    )
+    scores = scores.masked_fill(remove_scattered, float("-inf"))
+
+    probs = torch.softmax(scores, dim=-1)
+    probs = torch.nan_to_num(probs, nan=0.0, posinf=0.0, neginf=0.0)
+    sampled = multinomial_with_seed(scores, seeds, positions).view(-1)
+    fallback = (~do_sample) | (probs.sum(dim=-1) <= 0)
+    return torch.where(fallback, torch.argmax(logits, dim=-1), sampled)
+
+
+__all__ = [
+    "multinomial_with_seed_and_token_ids",
+    "sample_seeded_branchless",
+    "seeded_gumbel_argmax",
+]

--- a/sglang_omni/models/moss_tts/sglang_model.py
+++ b/sglang_omni/models/moss_tts/sglang_model.py
@@ -30,6 +30,15 @@ from sglang.srt.models.qwen3 import Qwen3Model
 from sglang.srt.utils import add_prefix
 
 from sglang_omni.models.moss_tts.payload_types import moss_tts_special_token_defaults
+from sglang_omni.models.moss_tts.sampler import (
+    DelayGraphBatch,
+    DelaySamplingOutput,
+    MossTTSDelayAudioGraphSampler,
+    matches_graph_profile,
+)
+from sglang_omni.models.moss_tts.sampling_cuda_graph import (
+    MossTTSDelaySamplingCudaGraphRunner,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +83,8 @@ class MossTTSDelaySGLangModel(torch.nn.Module):
         self.config = self._normalize_config(config)
         self.quant_config = quant_config
         self.hidden_size = int(self.config.hidden_size)
+        self.delay_graph_sampler = MossTTSDelayAudioGraphSampler(self.config)
+        self._sampling_graph_runner: MossTTSDelaySamplingCudaGraphRunner | None = None
 
         self.embedding_list = torch.nn.ModuleList()
         if self.pp_group.is_first_rank or (
@@ -369,6 +380,108 @@ class MossTTSDelaySGLangModel(torch.nn.Module):
     @property
     def text_control_token_ids(self) -> torch.Tensor:
         return self._text_control_token_ids
+
+    @staticmethod
+    def is_sampling_cuda_graph_compatible(data: Any) -> bool:
+        """Return whether one request uses the captured sampling profile."""
+
+        return matches_graph_profile(data)
+
+    def _sampling_graph_support_reason(self) -> str | None:
+        if self.device.type != "cuda" or not torch.cuda.is_available():
+            return "CUDA is unavailable"
+        if int(self.config.channels) != int(self.config.n_vq) + 1:
+            return (
+                "sampling CUDA graph requires channels == n_vq + 1 "
+                f"(got n_vq={self.config.n_vq}, channels={self.config.channels})"
+            )
+        audio_vocabs = {int(size) for size in self.config.vocab_size_list[1:]}
+        if len(audio_vocabs) != 1:
+            return "all audio codebooks must use the same vocabulary size"
+        if int(self.config.audio_pad_code) < 0:
+            return "audio_pad_code must be non-negative"
+        if not bool(self.pp_group.is_first_rank and self.pp_group.is_last_rank):
+            return "pipeline parallelism is not supported"
+        return None
+
+    @torch.no_grad()
+    def sample_delay_fixed_shape(
+        self,
+        control_logits: torch.Tensor,
+        audio_logits: torch.Tensor,
+        batch: DelayGraphBatch,
+        *,
+        audio_sample_output: torch.Tensor | None = None,
+    ) -> DelaySamplingOutput:
+        """Run one fixed-shape all-audio sampling/FSM step."""
+
+        return self.delay_graph_sampler(
+            control_logits,
+            audio_logits,
+            batch,
+            audio_sample_output=audio_sample_output,
+        )
+
+    @torch.no_grad()
+    def init_sampling_graphs(
+        self,
+        batch_sizes: list[int],
+        *,
+        disable_padding: bool = False,
+    ) -> None:
+        """Capture sampling/FSM graphs in the backbone batch envelope."""
+
+        buckets = tuple(sorted({int(batch_size) for batch_size in batch_sizes}))
+        if not buckets:
+            return
+        if any(batch_size < 1 for batch_size in buckets):
+            raise ValueError("MOSS-TTS Delay sampling CUDA graph bs must be >= 1")
+        reason = self._sampling_graph_support_reason()
+        if reason is not None:
+            logger.warning(
+                "MOSS-TTS Delay sampling CUDA graph disabled: %s. "
+                "Falling back to eager sampling.",
+                reason,
+            )
+            return
+        runner = MossTTSDelaySamplingCudaGraphRunner.capture(
+            model=self,
+            capture_bs=buckets,
+            disable_padding=disable_padding,
+        )
+        if not runner.graphs:
+            logger.warning(
+                "MOSS-TTS Delay sampling CUDA graph captured no buckets; "
+                "using eager sampling"
+            )
+            self._sampling_graph_runner = None
+            return
+        self._sampling_graph_runner = runner
+
+    def sampling_graph_available(
+        self,
+        batch_size: int,
+    ) -> bool:
+        runner = self._sampling_graph_runner
+        return runner is not None and runner.can_replay(batch_size)
+
+    @torch.no_grad()
+    def sample_delay_graphed(
+        self,
+        control_logits: torch.Tensor,
+        audio_logits: torch.Tensor,
+        batch: DelayGraphBatch,
+    ) -> DelaySamplingOutput:
+        """Replay one fixed-shape sampling/FSM CUDA graph."""
+
+        runner = self._sampling_graph_runner
+        if runner is None:
+            raise RuntimeError("MOSS-TTS Delay sampling CUDA graph is not configured")
+        return runner.replay(
+            control_logits,
+            audio_logits,
+            batch,
+        )
 
     @staticmethod
     def _select_sample_hidden_states(

--- a/sglang_omni/models/moss_tts_local/local_transformer.py
+++ b/sglang_omni/models/moss_tts_local/local_transformer.py
@@ -8,55 +8,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 
-def sample_seeded_branchless(
-    logits: torch.Tensor,
-    *,
-    temperature: torch.Tensor,
-    top_p: torch.Tensor,
-    top_k: torch.Tensor,
-    seeds: torch.Tensor,
-    positions: torch.Tensor,
-) -> torch.Tensor:
-    """Seeded temperature/top-k/top-p sampling without host control flow."""
-    from sglang.srt.layers.sampler import multinomial_with_seed
-
-    vocab = logits.shape[-1]
-    do_sample = temperature > 0
-    safe_temp = torch.where(do_sample, temperature, torch.ones_like(temperature))
-    scores = logits / safe_temp.unsqueeze(1)
-
-    k_active = (top_k > 0) & (top_k < vocab)
-    k_clamped = top_k.clamp(min=1, max=vocab)
-    sorted_scores, sorted_indices = torch.sort(scores, descending=True, dim=-1)
-    kth = sorted_scores.gather(1, (k_clamped - 1).unsqueeze(1))
-    threshold = torch.where(
-        k_active.unsqueeze(1), kth, torch.full_like(kth, float("-inf"))
-    )
-    scores = scores.masked_fill(scores < threshold, float("-inf"))
-
-    p_active = (top_p > 0.0) & (top_p < 1.0)
-    sorted_masked = sorted_scores.masked_fill(sorted_scores < threshold, float("-inf"))
-    probs_sorted = torch.softmax(sorted_masked, dim=-1)
-    cumulative = torch.cumsum(probs_sorted, dim=-1)
-    remove = cumulative > top_p.unsqueeze(1)
-    remove[..., 1:] = remove[..., :-1].clone()
-    remove[..., 0] = False
-    remove = remove & p_active.unsqueeze(1)
-    remove_scattered = torch.zeros_like(scores, dtype=torch.bool).scatter_(
-        -1, sorted_indices, remove
-    )
-    scores = scores.masked_fill(remove_scattered, float("-inf"))
-
-    probs = torch.softmax(scores, dim=-1)
-    probs = torch.nan_to_num(probs, nan=0.0, posinf=0.0, neginf=0.0)
-    # Note:(Chenchen Hong, Xuesong) post1's multinomial_with_seed is Gumbel-max and
-    # wants logits, not probs: softmax maps the top-k/top-p -inf to 0, so gumbel can
-    # pick a masked token. Match eager.
-    sampled = multinomial_with_seed(scores, seeds, positions).view(-1)
-    fallback = (~do_sample) | (probs.sum(dim=-1) <= 0)
-    return torch.where(fallback, torch.argmax(logits, dim=-1), sampled)
-
-
 def _rotate_half_interleaved(x: torch.Tensor) -> torch.Tensor:
     """Interleaved-pair rotation: [x0, x1, x2, x3, ...] -> [-x1, x0, -x3, x2, ...]."""
     even = x[..., ::2]

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -30,10 +30,8 @@ from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen3 import Qwen3Model
 from sglang.srt.utils import add_prefix
 
-from sglang_omni.models.moss_tts_local.local_transformer import (
-    MossTTSLocalTransformer,
-    sample_seeded_branchless,
-)
+from sglang_omni.models.moss_tts.sampling_kernels import sample_seeded_branchless
+from sglang_omni.models.moss_tts_local.local_transformer import MossTTSLocalTransformer
 from sglang_omni.models.moss_tts_local.payload_types import (
     moss_tts_local_special_token_defaults,
 )

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -194,10 +194,25 @@ def test_moss_tts_engine_uses_auto_mem_fraction_by_default(monkeypatch) -> None:
         captured["gpu_id"] = gpu_id
         captured["model_arch_override"] = model_arch_override
         captured["defer_cuda_graph_capture"] = defer_cuda_graph_capture
-        model = object()
+
+        def init_sampling_graphs(batch_sizes, *, disable_padding):
+            captured.setdefault("sampling_graph_inits", []).append(
+                (batch_sizes, disable_padding)
+            )
+            captured.setdefault("graph_init_order", []).append("sampling")
+
+        def init_cuda_graphs():
+            captured["graph_inits"] = int(captured.get("graph_inits", 0)) + 1
+            captured.setdefault("graph_init_order", []).append("backbone")
+
+        model = SimpleNamespace(init_sampling_graphs=init_sampling_graphs)
         model_runner = SimpleNamespace(
             model=model,
-            init_cuda_graphs=lambda: captured.setdefault("graph_inits", 0) or None,
+            graph_runner=SimpleNamespace(
+                capture_bs=tuple(server_args.cuda_graph_bs),
+                disable_padding=False,
+            ),
+            init_cuda_graphs=init_cuda_graphs,
         )
         model_worker = SimpleNamespace(model_runner=model_runner)
         return (
@@ -273,6 +288,18 @@ def test_moss_tts_engine_uses_auto_mem_fraction_by_default(monkeypatch) -> None:
     assert explicit_kwargs["mem_fraction_static"] == 0.61
     assert captured["context_length"] == 8192
     assert captured["model_arch_override"] == "MossTTSDelaySGLangModel"
+    assert captured["defer_cuda_graph_capture"] is True
+    assert captured["graph_inits"] == 2
+    assert captured["sampling_graph_inits"] == [
+        ([1, 2, 4, 8, 12, 16], False),
+        ([1, 2, 4, 8, 12, 16], False),
+    ]
+    assert captured["graph_init_order"] == [
+        "backbone",
+        "sampling",
+        "backbone",
+        "sampling",
+    ]
 
 
 def test_moss_tts_talker_torch_compile_cli_override_targets_tts_engine() -> None:
@@ -699,7 +726,7 @@ def test_moss_tts_audio_tokenizer_preserves_processor_code_layout() -> None:
     assert chunk_duration == 8
 
 
-def test_moss_tts_maps_references_token_count_and_deterministic_defaults() -> None:
+def test_moss_tts_maps_references_token_count_and_checkpoint_defaults() -> None:
     payload = make_payload(
         inputs={
             "text": "${token:120}hello [pause 0.5s] ni3 hao3 /hello/",
@@ -722,9 +749,12 @@ def test_moss_tts_maps_references_token_count_and_deterministic_defaults() -> No
     assert state.generation_kwargs["max_new_tokens"] == 4096
     # Defaults follow the upstream checkpoint's generate() (sampling), not greedy.
     assert state.generation_kwargs["text_temperature"] == 1.5
+    assert state.generation_kwargs["text_top_p"] == 1.0
+    assert state.generation_kwargs["text_top_k"] == 50
     assert state.generation_kwargs["audio_temperature"] == 1.7
     assert state.generation_kwargs["audio_top_p"] == 0.8
     assert state.generation_kwargs["audio_top_k"] == 25
+    assert state.generation_kwargs["audio_repetition_penalty"] == 1.0
 
 
 def test_moss_tts_benchmark_auto_token_count_uses_openmoss_estimate() -> None:

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -208,7 +208,7 @@ def test_moss_tts_engine_uses_auto_mem_fraction_by_default(monkeypatch) -> None:
         model = SimpleNamespace(init_sampling_graphs=init_sampling_graphs)
         model_runner = SimpleNamespace(
             model=model,
-            graph_runner=SimpleNamespace(
+            decode_cuda_graph_runner=SimpleNamespace(
                 capture_bs=tuple(server_args.cuda_graph_bs),
                 disable_padding=False,
             ),

--- a/tests/unit_test/moss_tts/test_sampling_cuda_graph.py
+++ b/tests/unit_test/moss_tts/test_sampling_cuda_graph.py
@@ -1,0 +1,429 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness and routing tests for MOSS-TTS Delay sampling graphs."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.moss_tts.engine_builder import MossTtsEngineBuilder
+from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+from sglang_omni.models.moss_tts.sampler import (
+    DelayGraphBatch,
+    MossTTSDelayAudioGraphSampler,
+)
+from sglang_omni.models.moss_tts.sampling_cuda_graph import (
+    MossTTSDelaySamplingCudaGraphRunner,
+)
+from sglang_omni.models.moss_tts.sglang_model import MossTTSDelaySGLangModel
+
+_INT64_MAX = torch.iinfo(torch.int64).max
+_MOSS_DELAY_N_VQ = 32
+_MOSS_DELAY_AUDIO_VOCAB = 1025
+
+
+def _config(*, n_vq: int = 2, audio_vocab: int = 5) -> SimpleNamespace:
+    return SimpleNamespace(
+        n_vq=n_vq,
+        channels=n_vq + 1,
+        pad_token_id=0,
+        audio_start_token_id=10,
+        audio_end_token_id=11,
+        audio_assistant_gen_slot_token_id=12,
+        audio_assistant_delay_slot_token_id=13,
+        audio_pad_code=audio_vocab - 1,
+        im_end_token_id=14,
+        vocab_size_list=[20] + [audio_vocab] * n_vq,
+    )
+
+
+def _sampling_data(
+    *,
+    profile: str,
+    repetition_penalty: float = 1.0,
+) -> SimpleNamespace:
+    if profile == "default":
+        values = (1.5, 1.0, 50, 1.7, 0.8, 25)
+    elif profile == "greedy":
+        values = (0.0, 0.7, 7, 0.0, 0.6, 5)
+    elif profile == "custom":
+        values = (1.0, 1.0, 50, 1.6, 0.8, 25)
+    else:
+        raise ValueError(profile)
+    return SimpleNamespace(
+        text_temperature=values[0],
+        text_top_p=values[1],
+        text_top_k=values[2],
+        audio_temperature=values[3],
+        audio_top_p=values[4],
+        audio_top_k=values[5],
+        audio_repetition_penalty=repetition_penalty,
+    )
+
+
+def test_sampling_graph_accepts_only_checkpoint_default_profile() -> None:
+    assert MossTTSDelaySGLangModel.is_sampling_cuda_graph_compatible(
+        _sampling_data(profile="default")
+    )
+    assert not MossTTSDelaySGLangModel.is_sampling_cuda_graph_compatible(
+        _sampling_data(profile="greedy")
+    )
+    assert not MossTTSDelaySGLangModel.is_sampling_cuda_graph_compatible(
+        _sampling_data(profile="custom")
+    )
+    assert not MossTTSDelaySGLangModel.is_sampling_cuda_graph_compatible(
+        _sampling_data(profile="default", repetition_penalty=1.1)
+    )
+
+
+def test_model_runner_rejects_greedy_sampling_graph_batch() -> None:
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    runner.model = SimpleNamespace(
+        is_sampling_cuda_graph_compatible=(
+            MossTTSDelaySGLangModel.is_sampling_cuda_graph_compatible
+        ),
+        sampling_graph_available=lambda batch_size: batch_size == 1,
+    )
+
+    assert runner._can_use_sampling_cuda_graph(
+        [_sampling_data(profile="default")], is_audio=True
+    )
+    assert not runner._can_use_sampling_cuda_graph(
+        [_sampling_data(profile="greedy")], is_audio=True
+    )
+    assert not runner._can_use_sampling_cuda_graph(
+        [_sampling_data(profile="default"), _sampling_data(profile="greedy")],
+        is_audio=True,
+    )
+
+
+def test_engine_builder_uses_backbone_capture_buckets() -> None:
+    calls = []
+    builder = MossTtsEngineBuilder()
+    builder.setup_model(
+        model_worker=SimpleNamespace(
+            model_runner=SimpleNamespace(
+                graph_runner=SimpleNamespace(capture_bs=(1, 2, 4), disable_padding=True)
+            )
+        ),
+        checkpoint_dir="checkpoint",
+        device="cuda:0",
+        gpu_id=0,
+        server_args=SimpleNamespace(),
+    )
+    model = SimpleNamespace(
+        init_sampling_graphs=lambda batch_sizes, disable_padding: calls.append(
+            (batch_sizes, disable_padding)
+        )
+    )
+
+    builder.post_cuda_graph_setup(model, SimpleNamespace())
+
+    assert calls == [([1, 2, 4], True)]
+
+
+def test_model_runner_routes_supported_audio_batch_to_sampling_graph() -> None:
+    calls = []
+
+    class FakeModel:
+        device = torch.device("cpu")
+        hidden_size = 3
+        text_control_token_ids = torch.tensor([12, 13], dtype=torch.long)
+
+        @staticmethod
+        def is_sampling_cuda_graph_compatible(data):
+            return MossTTSDelaySGLangModel.is_sampling_cuda_graph_compatible(data)
+
+        @staticmethod
+        def sampling_graph_available(batch_size):
+            return batch_size == 1
+
+        @staticmethod
+        def compute_channel_logits(hidden_states, forward_batch, *, is_audio=False):
+            del hidden_states, forward_batch
+            assert is_audio is True
+            return [
+                torch.tensor([[3.0, 1.0]]),
+                torch.zeros(1, 5),
+                torch.zeros(1, 5),
+            ]
+
+        @staticmethod
+        def sample_delay_graphed(
+            control_logits,
+            audio_logits,
+            batch,
+        ):
+            calls.append((control_logits.clone(), audio_logits.clone(), batch))
+            return SimpleNamespace(
+                rows=torch.tensor([[12, 2, 4]], dtype=torch.long),
+                next_delay_state=torch.tensor([[2, _INT64_MAX, 1]], dtype=torch.long),
+            )
+
+        @staticmethod
+        def _prepare_multi_modal_inputs(rows):
+            return rows.to(torch.float32)
+
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    runner.model = FakeModel()
+    runner._pending_rows = None
+    runner._pending_embeds = None
+    profile = _sampling_data(profile="default")
+    data = SimpleNamespace(
+        is_audio=True,
+        delay_state=torch.tensor([1, _INT64_MAX, 1]),
+        sampling_seed=123,
+        generation_steps=1,
+        text_temperature=profile.text_temperature,
+        text_top_p=profile.text_top_p,
+        text_top_k=profile.text_top_k,
+        audio_temperature=profile.audio_temperature,
+        audio_top_p=profile.audio_top_p,
+        audio_top_k=profile.audio_top_k,
+        audio_repetition_penalty=1.0,
+    )
+    request = SimpleNamespace(data=data)
+    result = SimpleNamespace(
+        logits_output=SimpleNamespace(
+            customized_info=None,
+            hidden_states=torch.zeros(1, 3),
+        )
+    )
+    schedule_batch = SimpleNamespace()
+
+    runner._collect_moss_step(
+        result,
+        SimpleNamespace(),
+        schedule_batch,
+        [request],
+    )
+
+    assert len(calls) == 1
+    assert result.next_token_ids.tolist() == [12]
+    assert runner._pending_rows.tolist() == [[12, 2, 4]]
+    assert data.delay_state.tolist() == [2, _INT64_MAX, 1]
+
+
+def test_sampling_cuda_graph_setup_failure_uses_eager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = SimpleNamespace(device=torch.device("cpu"))
+
+    monkeypatch.setattr(torch.cuda, "device", lambda _device: nullcontext())
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda *args, **kwargs: None)
+
+    def fail_static_input_allocation(self, max_bs):
+        del self, max_bs
+        raise torch.OutOfMemoryError("synthetic static-input OOM")
+
+    monkeypatch.setattr(
+        MossTTSDelaySamplingCudaGraphRunner,
+        "_make_static_inputs",
+        fail_static_input_allocation,
+    )
+
+    runner = MossTTSDelaySamplingCudaGraphRunner.capture(
+        model=model,
+        capture_bs=(1,),
+    )
+
+    assert runner.graphs == {}
+    assert runner._inputs is None
+    assert not runner.can_replay(1)
+
+
+class _CudaGraphModel:
+    def __init__(self, device: torch.device) -> None:
+        self.config = _config(
+            n_vq=_MOSS_DELAY_N_VQ,
+            audio_vocab=_MOSS_DELAY_AUDIO_VOCAB,
+        )
+        self.device = device
+        self.delay_graph_sampler = MossTTSDelayAudioGraphSampler(self.config).to(device)
+
+    def sample_delay_fixed_shape(
+        self,
+        control_logits: torch.Tensor,
+        audio_logits: torch.Tensor,
+        batch: DelayGraphBatch,
+        *,
+        audio_sample_output=None,
+    ):
+        return self.delay_graph_sampler(
+            control_logits,
+            audio_logits,
+            batch,
+            audio_sample_output=audio_sample_output,
+        )
+
+
+def _request_data(
+    delay_state: torch.Tensor,
+    *,
+    seed: int,
+    generation_steps: int,
+) -> SimpleNamespace:
+    profile = _sampling_data(profile="default")
+    return SimpleNamespace(
+        delay_state=delay_state,
+        audio_length=int(delay_state[0]),
+        delayed_length=int(delay_state[1]),
+        is_audio=bool(int(delay_state[2])),
+        sampling_seed=seed,
+        generation_steps=generation_steps,
+        text_temperature=profile.text_temperature,
+        text_top_p=profile.text_top_p,
+        text_top_k=profile.text_top_k,
+        audio_temperature=profile.audio_temperature,
+        audio_top_p=profile.audio_top_p,
+        audio_top_k=profile.audio_top_k,
+        audio_repetition_penalty=1.0,
+        prompt_rows=None,
+        output_rows=[],
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fixed_shape_sampling_matches_current_compacted_eager() -> None:
+    device = torch.device("cuda")
+    config = _config(
+        n_vq=_MOSS_DELAY_N_VQ,
+        audio_vocab=_MOSS_DELAY_AUDIO_VOCAB,
+    )
+    sampler = MossTTSDelayAudioGraphSampler(config).to(device)
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    runner.model = SimpleNamespace(
+        config=config,
+        text_control_token_ids=torch.tensor([12, 13], device=device),
+    )
+    initial_states = torch.tensor(
+        [
+            [1, _INT64_MAX, 1],
+            [17, _INT64_MAX, 1],
+            [_MOSS_DELAY_N_VQ + 1, _INT64_MAX, 1],
+            [_MOSS_DELAY_N_VQ + 1, 0, 1],
+            [_MOSS_DELAY_N_VQ + 1, _MOSS_DELAY_N_VQ - 1, 1],
+            [_MOSS_DELAY_N_VQ + 1, _MOSS_DELAY_N_VQ, 1],
+        ],
+        dtype=torch.long,
+        device=device,
+    )
+    seeds = torch.tensor(
+        [101, 202, 303, 404, 505, 606], dtype=torch.long, device=device
+    )
+    steps = torch.tensor([1, 7, 8, 9, 10, 11], dtype=torch.long, device=device)
+    datas = [
+        _request_data(
+            initial_states[index].clone(),
+            seed=int(seeds[index]),
+            generation_steps=int(steps[index]),
+        )
+        for index in range(int(initial_states.shape[0]))
+    ]
+    generator = torch.Generator(device=device).manual_seed(20260722)
+    batch_size = int(initial_states.shape[0])
+    channel_logits = [
+        torch.randn(batch_size, 2, device=device, generator=generator),
+        *[
+            torch.randn(
+                batch_size,
+                _MOSS_DELAY_AUDIO_VOCAB,
+                device=device,
+                generator=generator,
+            )
+            for _ in range(_MOSS_DELAY_N_VQ)
+        ],
+    ]
+
+    eager_rows = runner._sample_rows(
+        [logits.clone() for logits in channel_logits],
+        datas,
+        n_vq=_MOSS_DELAY_N_VQ,
+        is_audio=True,
+    )
+    eager_state = torch.stack([data.delay_state for data in datas])
+    graph_batch = DelayGraphBatch(
+        delay_state=initial_states,
+        seeds=seeds,
+        generation_steps=steps,
+    )
+    fixed = sampler(
+        channel_logits[0],
+        torch.stack(channel_logits[1:], dim=1),
+        graph_batch,
+    )
+    torch.cuda.synchronize()
+
+    assert torch.equal(eager_rows, fixed.rows)
+    assert torch.equal(eager_state, fixed.next_delay_state)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_sampling_cuda_graph_replay_matches_fixed_shape_eager() -> None:
+    device = torch.device("cuda")
+    model = _CudaGraphModel(device)
+    runner = MossTTSDelaySamplingCudaGraphRunner.capture(
+        model=model,
+        capture_bs=(2,),
+    )
+    assert set(runner.graphs) == {2}
+    assert runner.can_replay(1)
+    assert runner.can_replay(2)
+
+    generator = torch.Generator(device=device).manual_seed(20260722)
+    for replay_index, batch_size in enumerate((2, 1, 2)):
+        control_logits = torch.randn(
+            batch_size,
+            2,
+            device=device,
+            dtype=torch.float32,
+            generator=generator,
+        )
+        audio_logits = torch.randn(
+            batch_size,
+            _MOSS_DELAY_N_VQ,
+            _MOSS_DELAY_AUDIO_VOCAB,
+            device=device,
+            dtype=torch.float32,
+            generator=generator,
+        )
+        batch = DelayGraphBatch(
+            delay_state=torch.tensor(
+                [[_MOSS_DELAY_N_VQ + 1, _INT64_MAX, 1]] * batch_size,
+                device=device,
+            ),
+            seeds=torch.arange(batch_size, device=device, dtype=torch.long)
+            + 1_234_567
+            + replay_index * 100,
+            generation_steps=torch.arange(batch_size, device=device, dtype=torch.long)
+            + 7
+            + replay_index,
+        )
+
+        expected = model.sample_delay_fixed_shape(
+            control_logits,
+            audio_logits,
+            batch,
+        )
+        actual = runner.replay(
+            control_logits,
+            audio_logits,
+            batch,
+        )
+        actual_rows = actual.rows.clone()
+        actual_state = actual.next_delay_state.clone()
+        torch.cuda.synchronize()
+
+        assert torch.equal(expected.rows, actual_rows)
+        assert torch.equal(expected.next_delay_state, actual_state)
+        if batch_size == 1:
+            static_inputs = runner._require_inputs()
+            assert not torch.count_nonzero(static_inputs.control_logits[1:2])
+            assert not torch.count_nonzero(static_inputs.audio_logits[1:2])
+            assert not torch.count_nonzero(static_inputs.delay_state[1:2])
+            assert not torch.count_nonzero(static_inputs.seeds[1:2])
+            assert not torch.count_nonzero(static_inputs.generation_steps[1:2])
+    runner.clear()

--- a/tests/unit_test/moss_tts/test_sampling_cuda_graph.py
+++ b/tests/unit_test/moss_tts/test_sampling_cuda_graph.py
@@ -106,7 +106,9 @@ def test_engine_builder_uses_backbone_capture_buckets() -> None:
     builder.setup_model(
         model_worker=SimpleNamespace(
             model_runner=SimpleNamespace(
-                graph_runner=SimpleNamespace(capture_bs=(1, 2, 4), disable_padding=True)
+                decode_cuda_graph_runner=SimpleNamespace(
+                    capture_bs=(1, 2, 4), disable_padding=True
+                )
             )
         ),
         checkpoint_dir="checkpoint",

--- a/tests/unit_test/moss_tts/test_sampling_kernels.py
+++ b/tests/unit_test/moss_tts/test_sampling_kernels.py
@@ -32,3 +32,17 @@ def test_seeded_gumbel_argmax_matches_production_shape(
 
     assert seeds.stride(0) == 0
     assert torch.equal(expected, actual)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_seeded_gumbel_argmax_rejects_strided_output() -> None:
+    device = torch.device("cuda")
+    rows, vocab = 2, 16
+    scores = torch.randn(rows, vocab, device=device, dtype=torch.float32)
+    seeds = torch.arange(rows, device=device, dtype=torch.long)
+    positions = torch.arange(rows, device=device, dtype=torch.long)
+    output = torch.empty(rows * 2, device=device, dtype=torch.long)[::2]
+
+    assert output.stride(0) == 2
+    with pytest.raises(ValueError, match="output must have stride 1"):
+        seeded_gumbel_argmax(scores, seeds, positions, output)

--- a/tests/unit_test/moss_tts/test_sampling_kernels.py
+++ b/tests/unit_test/moss_tts/test_sampling_kernels.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness tests for MOSS-TTS sampling kernels."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from sglang.srt.layers.sampler import multinomial_with_seed
+
+from sglang_omni.models.moss_tts.sampling_kernels import seeded_gumbel_argmax
+
+
+@pytest.mark.parametrize("equal_scores", [False, True], ids=["random", "tied"])
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_seeded_gumbel_argmax_matches_production_shape(
+    equal_scores: bool,
+) -> None:
+    device = torch.device("cuda")
+    rows, vocab = 32, 1025
+    scores = (
+        torch.zeros(rows, vocab, device=device, dtype=torch.float32)
+        if equal_scores
+        else torch.randn(rows, vocab, device=device, dtype=torch.float32)
+    )
+    seeds = torch.tensor([20260720], device=device, dtype=torch.long).expand(rows)
+    positions = torch.arange(rows, device=device, dtype=torch.long)
+    output = torch.empty(rows, device=device, dtype=torch.long)
+
+    expected = multinomial_with_seed(scores, seeds, positions).view(-1)
+    actual = seeded_gumbel_argmax(scores, seeds, positions, output)
+    torch.cuda.synchronize()
+
+    assert seeds.stride(0) == 0
+    assert torch.equal(expected, actual)

--- a/tests/unit_test/moss_tts/test_sampling_kernels.py
+++ b/tests/unit_test/moss_tts/test_sampling_kernels.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 
 import pytest
 import torch
+from sglang.kernels.ops.sampling.murmur_hash import murmur_hash32
 from sglang.srt.layers.sampler import multinomial_with_seed
 
 from sglang_omni.models.moss_tts.sampling_kernels import seeded_gumbel_argmax
+
+_UINT32_MAX_HASH_POSITION = 1_707_985_137
 
 
 @pytest.mark.parametrize("equal_scores", [False, True], ids=["random", "tied"])
@@ -31,6 +34,31 @@ def test_seeded_gumbel_argmax_matches_production_shape(
     torch.cuda.synchronize()
 
     assert seeds.stride(0) == 0
+    assert torch.equal(expected, actual)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_seeded_gumbel_argmax_matches_uint32_max_hash() -> None:
+    device = torch.device("cuda")
+    scores = torch.tensor([[-100.0, 0.0]], device=device)
+    seeds = torch.tensor([0], device=device, dtype=torch.long)
+    # This position makes MurmurHash(seed=0, position, token_id=0) UINT32_MAX.
+    positions = torch.tensor(
+        [_UINT32_MAX_HASH_POSITION], device=device, dtype=torch.long
+    )
+    output = torch.empty(1, device=device, dtype=torch.long)
+
+    hashes = murmur_hash32(
+        seeds.to(torch.uint64),
+        positions,
+        torch.arange(scores.shape[1], device=device),
+    )
+    expected = multinomial_with_seed(scores, seeds, positions).view(-1)
+    actual = seeded_gumbel_argmax(scores, seeds, positions, output)
+    torch.cuda.synchronize()
+
+    assert hashes[0, 0].item() == torch.iinfo(torch.uint32).max
+    assert expected.item() == 0
     assert torch.equal(expected, actual)
 
 

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -1196,9 +1196,7 @@ def test_build_generation_kwargs_precedence():
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
 def test_decode_frame_graphed_matches_branchless_eager():
     """The captured frame graph must reproduce the branchless eager decode."""
-    from sglang_omni.models.moss_tts_local.local_transformer import (
-        sample_seeded_branchless,
-    )
+    from sglang_omni.models.moss_tts.sampling_kernels import sample_seeded_branchless
 
     torch.manual_seed(11)
     device = torch.device("cuda")
@@ -1736,9 +1734,7 @@ def test_branchless_sampler_matches_eager_sampler():
     """The CUDA-graphable sampler must reproduce the eager path exactly."""
     pytest.importorskip("sglang")
     from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
-    from sglang_omni.models.moss_tts_local.local_transformer import (
-        sample_seeded_branchless,
-    )
+    from sglang_omni.models.moss_tts.sampling_kernels import sample_seeded_branchless
 
     torch.manual_seed(7)
     rows, vocab = 6, 64

--- a/tests/unit_test/moss_tts_local/test_s0_gate.py
+++ b/tests/unit_test/moss_tts_local/test_s0_gate.py
@@ -23,9 +23,9 @@ def test_s0_graph_replay_is_deterministic():
     Exercises the same decode-frame kernel as the production v1.5 pipeline
     (MossTTSLocalTransformer + sample_seeded_branchless loop).
     """
+    from sglang_omni.models.moss_tts.sampling_kernels import sample_seeded_branchless
     from sglang_omni.models.moss_tts_local.local_transformer import (
         MossTTSLocalTransformer,
-        sample_seeded_branchless,
     )
 
     device = torch.device("cuda")


### PR DESCRIPTION
## Motivation

MOSS-TTS Delay samples one control decision and 32 audio codebook heads on every autoregressive decode step. The existing eager path launches the same sampling topology repeatedly, so CUDA launch and host scheduling overhead remain on the critical path even when the request uses the checkpoint's fixed default sampling profile.

This PR adds a model-local CUDA Graph path for that stable sampling workload. The goal is to reduce end-to-end latency and improve throughput while preserving the existing sampling semantics and retaining the eager implementation for unsupported or customized requests.

## Modifications

- Add `MossTTSDelaySamplingCudaGraphRunner` and capture sampling graphs with the same batch-size buckets used by SGLang's backbone decode CUDA Graph runner.
- Add a fixed-shape MOSS-TTS Delay sampler covering:
  - 32 audio codebook heads and Delay-state transitions;
  - valid-channel masking;
  - temperature, top-k, top-p, and audio repetition penalty;
  - deterministic per-request seeded Gumbel sampling.
- Add model-local graph-friendly seeded sampling kernels without materializing a full-vocabulary Gumbel tensor.
- Restrict graph replay to audio batches using the supported checkpoint-default stochastic sampling profile. Greedy, custom-parameter, non-audio, unavailable-bucket, and graph-initialization-failure cases continue through eager sampling.
- Clear padded static buffers before replay so a smaller batch cannot observe stale data from an earlier larger batch.
- Move the reusable MOSS-TTS sampling kernels from `moss_tts_local/local_transformer.py` to `moss_tts/sampling_kernels.py`, with MOSS-TTS Local importing the shared model-local implementation.
- Add tests for kernel equivalence, graph eligibility and routing, eager fallback, fixed-shape eager equivalence, graph replay across changing batch sizes, padding cleanup, engine/pipeline integration, and MOSS-TTS Local regression coverage.

## Related Issues

#1233

<!-- Paste-ready replacement for the current "Accuracy Test" and "Benchmark & Profiling" sections in PR #1303. -->

## Accuracy Test

Accuracy was evaluated from the audio generated by the same five paired Baseline/Current rounds used in the performance comparison below. Accuracy metrics did not participate in outlier rejection or round selection.

### Accuracy configuration

- Baseline: `3d4eb6e49096aa42e7f8f4e72f028823b2d85b73`
- Current: `342acdcd154106746c580cba6ab77ab003632987`
- Model: `OpenMOSS-Team/MOSS-TTS-v1.5@cdd3b911b1585e3f2dbc7775ef10f9926f58850a`
- Dataset: Seed-TTS EN, full `1088` samples per candidate
- WER ASR: `Qwen/Qwen3-ASR-1.7B`, ASR concurrency 32
- Speaker Similarity: Seed-TTS WavLM speaker-verification scorer
- Naturalness: `balacoon/utmos`
- Offline evaluation: `HF_HUB_OFFLINE=1`, `HF_DATASETS_OFFLINE=1`, and `TRANSFORMERS_OFFLINE=1`

WER, Speaker Similarity, and UTMOS each evaluated all `10,880/10,880` generated outputs with `0` skipped. `Filtered WER` is corpus WER after excluding samples whose individual WER is greater than 50%.

### Per-run accuracy results

| Pair | Base corpus WER | Current corpus WER | Base filtered WER | Current filtered WER | Base SIM | Current SIM | Base UTMOS | Current UTMOS |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 1.5490% | 1.6160% | 1.2186% | 1.2774% | 68.9250 | 68.8296 | 3.9316 | 3.9393 |
| 2 | 1.8421% | 1.7500% | 1.2631% | 1.3701% | 68.7150 | 68.9703 | 3.9419 | 3.9445 |
| 3 | 2.0095% | 1.5323% | 1.3572% | 1.3431% | 69.0739 | 68.8866 | 3.9415 | 3.9415 |
| 4 | 1.6830% | 1.2308% | 1.3113% | 1.1728% | 69.1220 | 68.9727 | 3.9437 | 3.9407 |
| 5 | 1.3732% | 1.7667% | 1.1664% | 1.3957% | 68.9909 | 68.9787 | 3.9435 | 3.9452 |

### Five-run accuracy summary

Values are mean ± sample standard deviation. Confidence intervals are two-sided Student-t intervals over the five paired `Current - Baseline` differences (`df=4`).

| Metric | Baseline | Current | Absolute change | Paired difference, Current - Baseline (95% CI) |
| --- | ---: | ---: | ---: | ---: |
| Corpus WER | 1.6914% ± 0.2478% | 1.5792% ± 0.2175% | -0.1122 pp | -0.1122 pp `[-0.5672, +0.3428]` |
| Filtered corpus WER | 1.2633% ± 0.0750% | 1.3118% ± 0.0893% | +0.0485 pp | +0.0485 pp `[-0.1216, +0.2186]` |
| Speaker Similarity | 68.9654 ± 0.1591 | 68.9276 ± 0.0666 | -0.0378 | -0.0378 `[-0.2570, +0.1814]` |
| UTMOS | 3.94044 ± 0.00503 | 3.94224 ± 0.00252 | +0.00180 | +0.00180 `[-0.00308, +0.00668]` |

All four paired accuracy confidence intervals include zero.

## Benchmark & Profiling

The previous A800 table is superseded by this rerun after the sampling-kernel normalization fix. This rerun pins both source revisions, uses a fresh service for every candidate, reports all completed candidates, applies the stated speed-only outlier rule, and reports paired confidence intervals.

### Benchmark configuration

- Baseline: `3d4eb6e49096aa42e7f8f4e72f028823b2d85b73`
- Current: `342acdcd154106746c580cba6ab77ab003632987`
- Model: `OpenMOSS-Team/MOSS-TTS-v1.5@cdd3b911b1585e3f2dbc7775ef10f9926f58850a`
- Dataset: Seed-TTS EN, full `1088` samples per candidate
- Request format: non-streaming voice cloning with `--ref-format references --token-count auto`
- Client concurrency: `16`
- Sampling seed: unset (`None`), preserving the framework default
- Warmup: one request before every measured candidate
- Server limits: `--max-running-requests 64 --cuda-graph-max-bs 64`
- Hardware: one NVIDIA H200
- Software: Python 3.12.3, PyTorch 2.11.0+cu130, SGLang 0.5.16
- Offline mode: `HF_HUB_OFFLINE=1`, `HF_DATASETS_OFFLINE=1`, and `TRANSFORMERS_OFFLINE=1`
- Collection order: Baseline r1, Current r1, Baseline r2, Current r2, and so on
- Service lifecycle: every `(variant, round)` used a newly started service; startup and the warmup request are excluded from the measurements

All ten completed candidates generated `1088/1088` requests with `0` failures. Integrity validation also passed for all 10,880 generated 24 kHz mono PCM16 WAV files.

The measured client command was:

```bash
python -m benchmarks.eval.benchmark_tts_seedtts \
  --generate-only --use-existing-server \
  --meta zhaochenyang20/seed-tts-eval-arrow \
  --model OpenMOSS-Team/MOSS-TTS-v1.5 \
  --host 127.0.0.1 --port 18081 \
  --ref-format references --token-count auto \
  --lang en --max-concurrency 16 --warmup 1 \
  --max-new-tokens 2048 \
  --max-running-requests 64 --cuda-graph-max-bs 64
```

### Candidate-run speed summaries

No completed candidate was removed or replaced. The initial five paired rounds all passed the speed-only screen described below.

| Pair | Base QPS | Current QPS | Base mean latency | Current mean latency | Base P95 | Current P95 | Base mean RTF | Current mean RTF |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 6.617 | 6.926 | 2.408 | 2.302 | 3.093 | 2.851 | 0.5579 | 0.5342 |
| 2 | 6.442 | 7.390 | 2.474 | 2.157 | 3.446 | 2.650 | 0.5739 | 0.5010 |
| 3 | 6.414 | 7.212 | 2.486 | 2.211 | 3.188 | 2.720 | 0.5762 | 0.5136 |
| 4 | 6.748 | 7.240 | 2.362 | 2.203 | 3.044 | 2.750 | 0.5477 | 0.5113 |
| 5 | 6.762 | 7.038 | 2.357 | 2.266 | 3.023 | 2.818 | 0.5462 | 0.5266 |

### Outlier and subset-selection rule

Baseline and Current use the same round numbers. For each candidate five-round subset, the two groups are screened independently on these four speed metrics:

1. Throughput QPS
2. Mean latency
3. P95 latency
4. Mean RTF

Each observation is checked by both extreme-outlier rules:

```text
modified-Z = 0.6745 * (x - median) / MAD
outlier if abs(modified-Z) > 3.5
```

When `MAD == 0`, the modified-Z check is skipped for that metric.

```text
x < Q1 - 3 * IQR  or  x > Q3 + 3 * IQR
```

Quartiles use linear interpolation with position `(n - 1) * q`. Either rule is sufficient to reject a subset. Five-round subsets are enumerated lexicographically by round number, and the first passing subset is selected without ranking its means or improvement. If none passes, another complete Baseline/Current pair is collected without relaxing the thresholds. The accuracy metrics reported above are not used in this selection.

For the initial subset `{1,2,3,4,5}`, the diagnostics were:

| Group | Metric | Median | MAD | Maximum `abs(modified-Z)` | Tukey extreme fence | Flagged rounds |
| --- | --- | ---: | ---: | ---: | --- | --- |
| Base | Throughput QPS | 6.617 | 0.1450 | 0.9443 | `[5.524, 7.666]` | none |
| Base | Mean latency | 2.408 | 0.0510 | 1.0316 | `[2.026, 2.810]` | none |
| Base | P95 latency | 3.093 | 0.0700 | 3.4014 | `[2.612, 3.620]` | none |
| Base | Mean RTF | 0.5579 | 0.0117 | 1.0550 | `[0.4691, 0.6525]` | none |
| Current | Throughput QPS | 7.212 | 0.1740 | 1.1087 | `[6.432, 7.846]` | none |
| Current | Mean latency | 2.211 | 0.0540 | 1.1367 | `[2.014, 2.455]` | none |
| Current | P95 latency | 2.750 | 0.0680 | 1.0018 | `[2.426, 3.112]` | none |
| Current | Mean RTF | 0.5136 | 0.0126 | 1.1028 | `[0.4654, 0.5725]` | none |

The first subset therefore passed all checks and was selected as-is.

### Selected five-run benchmark result

Values are mean ± sample standard deviation. Confidence intervals are two-sided Student-t intervals over the five paired `Current - Baseline` differences (`df=4`).

| Metric | Baseline | Current | Change | Paired difference, Current - Baseline (95% CI) |
| --- | ---: | ---: | ---: | ---: |
| Throughput | 6.5966 ± 0.1643 QPS | 7.1612 ± 0.1814 QPS | **+8.56%** | +0.5646 QPS `[+0.1945, +0.9347]` |
| Mean latency | 2.4174 ± 0.0607 s | 2.2278 ± 0.0567 s | **-7.84%** | -0.1896 s `[-0.3156, -0.0636]` |
| P95 latency | 3.1588 ± 0.1727 s | 2.7578 ± 0.0797 s | **-12.69%** | -0.4010 s `[-0.7024, -0.0996]` |
| Mean RTF | 0.56038 ± 0.01415 | 0.51734 ± 0.01311 | **-7.68%** | -0.04304 `[-0.07243, -0.01365]` |

This rerun does not reproduce the previous P95 regression: in this single-H200, concurrency-16 workload, Current improves throughput, mean latency, P95 latency, and mean RTF, and all four paired confidence intervals exclude zero in the favorable direction. These results supersede the previous table but should not be interpreted as the same hardware experiment as the earlier A800 run.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
