### PR TITLE
Fix missing CPU operator events in scheduler-thread profiling      

### DIFF
--- a/docs/developer_reference/profiler.md
+++ b/docs/developer_reference/profiler.md
@@ -201,6 +201,44 @@ With all four off (the default), a typical 10-sample MMMU run produces a
 trace in the tens of MB. With all four on, the same workload can produce a
 multi-GB trace — only opt in when you need that specific information.
 
+### Capturing CPU operators from the scheduler thread
+
+Kineto's CPU operator callbacks are thread-local. The profiler is started from
+the stage control thread, while AR model execution runs on a separate scheduler
+thread — so by default a trace carries CUDA activity but no CPU-side Aten
+operators from that execution path.
+
+| Env var | Effect |
+|---|---|
+| `SGLANG_TORCH_PROFILER_SCHEDULER_THREAD=1` | Start/stop the profiler on the scheduler thread, so CPU operators from model execution are recorded |
+
+This flag needs a stage to own the process-wide profiler singleton, declared in
+pipeline config:
+
+```yaml
+stages:
+  - name: tts_engine
+    runtime:
+      torch_profiler_owner: true
+```
+
+Ownership is per OS process, because one process can host several stages on a
+single event loop:
+
+| Process | Behavior |
+|---|---|
+| has an owner | the owner drives the profiler from its scheduler thread; colocated stages leave the singleton alone |
+| has no owner | every stage keeps the default direct start/stop, so it still exports a trace |
+
+Startup fails if one process declares more than one owner, or if the flag is set
+with no owner declared anywhere (it would silently do nothing). The flag is read
+from both the launcher environment and pipeline/stage `env` config.
+
+Full CPU profiling is expensive and is not meant to be left on during normal
+serving. A failed start or stop is reported in the owning stage's logs rather
+than in the HTTP response — the profiler control plane broadcasts without a
+reply channel.
+
 ## HTTP surface
 
 | Method | Path | Body | Notes |

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -98,6 +98,7 @@ class StageRuntimeConfig(BaseModel):
     resources: StageResourceConfig = Field(default_factory=StageResourceConfig)
     max_seq_len: int | None = None
     video_fps: float | None = None
+    torch_profiler_owner: bool = False
     sglang_server_args: SGLangServerArgsConfig = Field(
         default_factory=SGLangServerArgsConfig
     )

--- a/sglang_omni/models/moss_tts/config.py
+++ b/sglang_omni/models/moss_tts/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from sglang_omni.config import PipelineConfig, StageConfig
+from sglang_omni.config import PipelineConfig, StageConfig, StageRuntimeConfig
 
 _PKG = "sglang_omni.models.moss_tts"
 
@@ -70,6 +70,7 @@ class MossTTSPipelineConfig(PipelineConfig):
             factory=f"{_PKG}.stages.create_sglang_tts_engine_executor",
             factory_args={"dtype": "bfloat16"},
             gpu=0,
+            runtime=StageRuntimeConfig(torch_profiler_owner=True),
             next="vocoder",
         ),
         StageConfig(

--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -48,6 +48,7 @@ def _stages(*, codec_device: str, colocated: bool) -> list[StageConfig]:
         sglang_server_args=SGLangServerArgsConfig(
             mem_fraction_static=None if colocated else _AR_MEM_FRACTION_STATIC
         ),
+        torch_profiler_owner=True,
     )
     tts_engine_args: dict[str, Any] = {"dtype": "bfloat16"}
     if colocated:

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -32,6 +32,7 @@ from sglang_omni.pipeline.runtime_config import (
     build_comm_config,
     prepare_pipeline_runtime,
 )
+from sglang_omni.pipeline.stage.runtime import SCHEDULER_THREAD_PROFILER_ENV
 from sglang_omni.pipeline.stage_workers import (
     StageGroup,
     StageLaunchConfig,
@@ -200,9 +201,8 @@ def _resolve_torch_profiler_ownership(groups: list[StageGroup]) -> None:
     - a process without an owner: every stage keeps the pre-existing direct
       path, so a partial rollout never silently drops that process's trace.
 
-    A globally ownerless pipeline under
-    ``SGLANG_TORCH_PROFILER_SCHEDULER_THREAD=1`` is rejected, since the flag
-    would then be a no-op.
+    A globally ownerless pipeline with scheduler-thread profiling requested is
+    rejected, since the flag would then be a no-op.
     """
 
     owners: list[str] = []
@@ -222,11 +222,34 @@ def _resolve_torch_profiler_ownership(groups: list[StageGroup]) -> None:
                 stage_spec.torch_profiler_process_has_owner = bool(process_owners)
             owners.extend(process_owners)
 
-    if os.environ.get("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD") == "1" and not owners:
+    if _scheduler_thread_profiling_requested(groups) and not owners:
         raise ValueError(
-            "SGLANG_TORCH_PROFILER_SCHEDULER_THREAD=1 requires at least one "
+            f"{SCHEDULER_THREAD_PROFILER_ENV}=1 requires at least one "
             "stage with runtime.torch_profiler_owner=true"
         )
+
+
+def _scheduler_thread_profiling_requested(groups: list[StageGroup]) -> bool:
+    """Whether any worker will see the scheduler-thread flag set.
+
+    Checking ``os.environ`` alone only covers the launcher's own environment.
+    The flag can also be declared in pipeline or stage ``env`` config, which
+    ``_patched_spawn_env`` injects at spawn time -- after this validation runs.
+    Reading only the launcher env would let an ownerless pipeline start with the
+    flag on, where it silently degrades to the pre-existing direct path.
+    """
+
+    launcher_value = os.environ.get(SCHEDULER_THREAD_PROFILER_ENV)
+    if launcher_value is not None:
+        # Spawn defaults only apply to keys absent from the launcher env, so
+        # this value is what every worker ends up seeing.
+        return launcher_value == "1"
+    return any(
+        stage_spec.env_defaults.get(SCHEDULER_THREAD_PROFILER_ENV) == "1"
+        for group in groups
+        for process_spec in group.process_specs
+        for stage_spec in process_spec.stage_specs
+    )
 
 
 def _attach_process_memory_fraction_defaults(groups: list[StageGroup]) -> None:

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -204,10 +204,7 @@ def _validate_torch_profiler_owners(groups: list[StageGroup]) -> None:
                 )
             owners.extend(process_owners)
 
-    if (
-        os.environ.get("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD") == "1"
-        and not owners
-    ):
+    if os.environ.get("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD") == "1" and not owners:
         raise ValueError(
             "SGLANG_TORCH_PROFILER_SCHEDULER_THREAD=1 requires at least one "
             "stage with runtime.torch_profiler_owner=true"

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -180,14 +180,30 @@ def _build_stage_groups(
             )
         )
     groups.extend(tp_groups)
-    _validate_torch_profiler_owners(groups)
+    _resolve_torch_profiler_ownership(groups)
     _attach_process_memory_fraction_defaults(groups)
 
     return groups
 
 
-def _validate_torch_profiler_owners(groups: list[StageGroup]) -> None:
-    """Require one process-local owner at most for the profiler singleton."""
+def _resolve_torch_profiler_ownership(groups: list[StageGroup]) -> None:
+    """Resolve profiler ownership per OS process and stamp it on each stage.
+
+    ``TorchProfiler`` is a process-wide singleton, but one OS process can host
+    several stages sharing a single asyncio loop (see ``_run_process``). So
+    ownership is a property of the process, not of a stage:
+
+    - a process with an owner: only that owner drives the singleton, through
+      its scheduler thread. Its colocated siblings must keep their hands off,
+      otherwise whoever handles the broadcast first wins the race and the
+      profiler ends up started (or stopped) on the wrong thread.
+    - a process without an owner: every stage keeps the pre-existing direct
+      path, so a partial rollout never silently drops that process's trace.
+
+    A globally ownerless pipeline under
+    ``SGLANG_TORCH_PROFILER_SCHEDULER_THREAD=1`` is rejected, since the flag
+    would then be a no-op.
+    """
 
     owners: list[str] = []
     for group in groups:
@@ -202,6 +218,8 @@ def _validate_torch_profiler_owners(groups: list[StageGroup]) -> None:
                     f"Process {process_spec.process_name!r} has multiple Torch "
                     f"profiler owners: {process_owners}"
                 )
+            for stage_spec in process_spec.stage_specs:
+                stage_spec.torch_profiler_process_has_owner = bool(process_owners)
             owners.extend(process_owners)
 
     if os.environ.get("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD") == "1" and not owners:

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import multiprocessing
+import os
 import socket
 from typing import Any
 
@@ -128,6 +129,7 @@ def _build_stage_groups(
             is_stream_receiver=stage_cfg.name in stream_receivers,
             can_accept_stream_before_payload=stage_cfg.can_accept_stream_before_payload,
             disable_direct_cuda_ipc_payload=stage_cfg.disable_direct_cuda_ipc_payload,
+            torch_profiler_owner=stage_cfg.runtime.torch_profiler_owner,
             name_map=name_map,
         )
         if tp_size == 1:
@@ -178,9 +180,38 @@ def _build_stage_groups(
             )
         )
     groups.extend(tp_groups)
+    _validate_torch_profiler_owners(groups)
     _attach_process_memory_fraction_defaults(groups)
 
     return groups
+
+
+def _validate_torch_profiler_owners(groups: list[StageGroup]) -> None:
+    """Require one process-local owner at most for the profiler singleton."""
+
+    owners: list[str] = []
+    for group in groups:
+        for process_spec in group.process_specs:
+            process_owners = [
+                stage.stage_name
+                for stage in process_spec.stage_specs
+                if stage.torch_profiler_owner
+            ]
+            if len(process_owners) > 1:
+                raise ValueError(
+                    f"Process {process_spec.process_name!r} has multiple Torch "
+                    f"profiler owners: {process_owners}"
+                )
+            owners.extend(process_owners)
+
+    if (
+        os.environ.get("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD") == "1"
+        and not owners
+    ):
+        raise ValueError(
+            "SGLANG_TORCH_PROFILER_SCHEDULER_THREAD=1 requires at least one "
+            "stage with runtime.torch_profiler_owner=true"
+        )
 
 
 def _attach_process_memory_fraction_defaults(groups: list[StageGroup]) -> None:

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -15,7 +15,7 @@ import os
 import queue as _queue_mod
 import threading
 from contextlib import suppress
-from typing import Any, Awaitable, Callable, Literal
+from typing import Any, Awaitable, Callable, Literal, Protocol, runtime_checkable
 
 import torch
 
@@ -52,6 +52,18 @@ logger = logging.getLogger(__name__)
 
 GetNextFn = Callable[[str, Any], str | list[str] | None]
 GetStreamDoneTargetsFn = Callable[[str, Any], str | list[str] | None]
+_SCHEDULER_THREAD_PROFILER_ENV = "SGLANG_TORCH_PROFILER_SCHEDULER_THREAD"
+
+
+@runtime_checkable
+class SchedulerThreadProfilerControl(Protocol):
+    """Scheduler capability for thread-local profiler lifecycle control."""
+
+    def start_torch_profiler(
+        self, trace_path_template: str, run_id: str | None
+    ) -> dict[str, Any]: ...
+
+    def stop_torch_profiler(self, run_id: str | None) -> dict[str, Any]: ...
 
 
 def _error_text(exc: BaseException) -> str:
@@ -100,6 +112,7 @@ class Stage:
         disable_direct_cuda_ipc_payload: bool = False,
         tp_fanout: TPLeaderFanout | None = None,
         is_terminal: bool = False,
+        torch_profiler_owner: bool = False,
     ):
         self.name = name
         self.role = role
@@ -118,7 +131,17 @@ class Stage:
         self._disable_direct_cuda_ipc_payload = disable_direct_cuda_ipc_payload
         self._tp_fanout = tp_fanout
         self._is_terminal = is_terminal
+        self._torch_profiler_owner = torch_profiler_owner
         self._owns_external_io = role in {"single", "leader"}
+
+        if self._torch_profiler_owner and not isinstance(
+            scheduler, SchedulerThreadProfilerControl
+        ):
+            raise TypeError(
+                f"Stage {name!r} is configured as the Torch profiler owner, "
+                "but its scheduler does not implement scheduler-thread "
+                "profiler control"
+            )
 
         self._comm = CommEngine(
             CommRouter(
@@ -1559,9 +1582,7 @@ class Stage:
 
     def _on_profiler_start(self, msg: ProfilerStartMessage) -> None:
         run_id = msg.run_id
-        scheduler_thread_torch = (
-            os.environ.get("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD") == "1"
-        )
+        scheduler_thread_torch = os.environ.get(_SCHEDULER_THREAD_PROFILER_ENV) == "1"
         if msg.enable_torch and scheduler_thread_torch:
             base_tpl = msg.trace_path_template.format(run_id=run_id, stage=self.name)
             template = f"{base_tpl}_pid{os.getpid()}"
@@ -1573,14 +1594,11 @@ class Stage:
             # starting here on the asyncio thread records CUDA activities but
             # no CPU-side Aten operators. Route the opt-in profiler lifecycle
             # through OmniScheduler's admin queue so start/stop execute on the
-            # actual compute thread. Only that scheduler owns the process-wide
-            # TorchProfiler singleton; sibling stages still participate in the
-            # event recorder below.
-            if self.name == "tts_engine" and hasattr(self.scheduler, "admin"):
-                response = self.scheduler.admin(
-                    "torch_profiler_start",
-                    {"trace_path_template": template, "run_id": run_id},
-                )
+            # actual compute thread. Ownership is explicit runtime intent,
+            # independent of a model-specific stage name. Sibling stages still
+            # participate in the event recorder below.
+            if self._torch_profiler_owner:
+                response = self.scheduler.start_torch_profiler(template, run_id)
                 if not response.get("success", False):
                     raise RuntimeError(response.get("error", response.get("message")))
         elif msg.enable_torch and not TorchProfiler.is_active():
@@ -1604,14 +1622,10 @@ class Stage:
 
     def _on_profiler_stop(self, msg: ProfilerStopMessage) -> None:
         # run_id=None is a wildcard (stop whatever's active).
-        scheduler_thread_torch = (
-            os.environ.get("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD") == "1"
-        )
+        scheduler_thread_torch = os.environ.get(_SCHEDULER_THREAD_PROFILER_ENV) == "1"
         if scheduler_thread_torch:
-            if self.name == "tts_engine" and hasattr(self.scheduler, "admin"):
-                response = self.scheduler.admin(
-                    "torch_profiler_stop", {"run_id": msg.run_id}
-                )
+            if self._torch_profiler_owner:
+                response = self.scheduler.stop_torch_profiler(msg.run_id)
                 if not response.get("success", False):
                     raise RuntimeError(
                         response.get("error", response.get("message"))

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -1627,9 +1627,7 @@ class Stage:
             if self._torch_profiler_owner:
                 response = self.scheduler.stop_torch_profiler(msg.run_id)
                 if not response.get("success", False):
-                    raise RuntimeError(
-                        response.get("error", response.get("message"))
-                    )
+                    raise RuntimeError(response.get("error", response.get("message")))
         elif TorchProfiler.is_active() and (
             msg.run_id is None or TorchProfiler.get_active_run_id() == msg.run_id
         ):

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -1640,11 +1640,7 @@ class Stage:
         mode = self._torch_profiler_mode()
         route_to_scheduler = mode == _TORCH_PROFILER_SCHEDULER_OWNER
         skip_torch = mode == _TORCH_PROFILER_SCHEDULER_SIBLING
-        if (
-            msg.enable_torch
-            and not skip_torch
-            and (route_to_scheduler or not TorchProfiler.is_active())
-        ):
+        if msg.enable_torch and not skip_torch:
             base_tpl = msg.trace_path_template.format(run_id=run_id, stage=self.name)
             template = f"{base_tpl}_pid{os.getpid()}"
             prof_dir = os.environ.get("SGLANG_TORCH_PROFILER_DIR")

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -182,6 +182,8 @@ class Stage:
         self._nonlocal_stream_targets: dict[str, set[str]] = {}
         self._receive_tasks: set[asyncio.Task] = set()
         self._receive_lane_tails: dict[tuple[str, str], asyncio.Future[None]] = {}
+        self._profiler_op_queue: asyncio.Queue[Callable[[], None]] | None = None
+        self._profiler_op_worker: asyncio.Task | None = None
         self._scheduler_thread: threading.Thread | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._scheduler_crash_error: BaseException | None = None
@@ -253,6 +255,12 @@ class Stage:
         await asyncio.gather(*receive_tasks, return_exceptions=True)
         self._receive_tasks.clear()
         self._receive_lane_tails.clear()
+        profiler_worker = self._profiler_op_worker
+        if profiler_worker is not None:
+            profiler_worker.cancel()
+            with suppress(asyncio.CancelledError):
+                await profiler_worker
+            self._profiler_op_worker = None
         if self.scheduler is not None:
             try:
                 self.scheduler.stop()
@@ -338,9 +346,9 @@ class Stage:
         elif isinstance(msg, DataReadyMessage):
             self._schedule_receive_task(msg)
         elif isinstance(msg, ProfilerStartMessage):
-            await self._on_profiler_start(msg)
+            self._on_profiler_start(msg)
         elif isinstance(msg, ProfilerStopMessage):
-            await self._on_profiler_stop(msg)
+            self._on_profiler_stop(msg)
         elif isinstance(msg, AdminMessage):
             await self._on_admin(msg)
 
@@ -1635,19 +1643,55 @@ class Stage:
             "Stage %s Torch profiler %s failed: %s", self.name, operation, detail
         )
 
-    async def _delegate_profiler_to_scheduler(self, call: Callable[[], None]) -> None:
-        """Run a blocking scheduler handoff off the stage control loop.
+    def _submit_profiler_op(self, call: Callable[[], None]) -> None:
+        """Hand a blocking profiler operation to the serialized worker.
 
-        Both the readiness wait and the admin queue handoff block for up to
-        ``_SCHEDULER_THREAD_READY_TIMEOUT_S`` each. This coroutine runs on the
-        loop that also serves submits and acks, so the wait goes to an executor
-        for the same reason :meth:`_run_admin_operation` does.
+        The readiness wait and the admin handoff each block for up to
+        ``_SCHEDULER_THREAD_READY_TIMEOUT_S``. Awaiting them from a message
+        handler would keep :meth:`run` from reaching its next
+        ``control_plane.recv()``, parking this stage's submits and acks behind a
+        profiler request. Handlers therefore return immediately and the work
+        runs here. One queue with one worker preserves arrival order, so a stop
+        can never overtake the start it belongs to.
         """
 
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, call)
+        if self._profiler_op_queue is None:
+            self._profiler_op_queue = asyncio.Queue()
+        if self._profiler_op_worker is None or self._profiler_op_worker.done():
+            self._profiler_op_worker = asyncio.create_task(
+                self._run_profiler_ops(), name=f"profiler-ops-{self.name}"
+            )
+            self._profiler_op_worker.add_done_callback(
+                lambda task: self._on_background_task_done(task, "profiler ops")
+            )
+        self._profiler_op_queue.put_nowait(call)
 
-    async def _on_profiler_start(self, msg: ProfilerStartMessage) -> None:
+    async def _run_profiler_ops(self) -> None:
+        """Run queued profiler operations one at a time, off the event loop."""
+
+        queue = self._profiler_op_queue
+        assert queue is not None
+        loop = asyncio.get_running_loop()
+        while True:
+            call = await queue.get()
+            try:
+                await loop.run_in_executor(None, call)
+            except Exception:
+                logger.warning(
+                    "Stage %s profiler control operation failed",
+                    self.name,
+                    exc_info=True,
+                )
+            finally:
+                queue.task_done()
+
+    async def _wait_for_profiler_ops(self) -> None:
+        """Block until every queued profiler operation has run."""
+
+        if self._profiler_op_queue is not None:
+            await self._profiler_op_queue.join()
+
+    def _on_profiler_start(self, msg: ProfilerStartMessage) -> None:
         run_id = msg.run_id
         mode = self._torch_profiler_mode()
         route_to_scheduler = mode == _TORCH_PROFILER_SCHEDULER_OWNER
@@ -1659,7 +1703,7 @@ class Stage:
             if prof_dir and not os.path.isabs(template):
                 template = os.path.join(prof_dir, template)
             if route_to_scheduler:
-                await self._delegate_profiler_to_scheduler(
+                self._submit_profiler_op(
                     lambda: self._start_torch_profiler_on_scheduler(template, run_id)
                 )
             else:
@@ -1729,7 +1773,7 @@ class Stage:
                 "stop", response.get("error", response.get("message"))
             )
 
-    async def _on_profiler_stop(self, msg: ProfilerStopMessage) -> None:
+    def _on_profiler_stop(self, msg: ProfilerStopMessage) -> None:
         # run_id=None is a wildcard (stop whatever's active).
         # Mirrors _on_profiler_start: only the process-local owner drives the
         # singleton, siblings stay out, ownerless processes stop their own.
@@ -1737,7 +1781,7 @@ class Stage:
         if mode == _TORCH_PROFILER_SCHEDULER_SIBLING:
             pass
         elif mode == _TORCH_PROFILER_SCHEDULER_OWNER:
-            await self._delegate_profiler_to_scheduler(
+            self._submit_profiler_op(
                 lambda: self._stop_torch_profiler_on_scheduler(msg.run_id)
             )
         elif TorchProfiler.is_active() and (

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 
 GetNextFn = Callable[[str, Any], str | list[str] | None]
 GetStreamDoneTargetsFn = Callable[[str, Any], str | list[str] | None]
-_SCHEDULER_THREAD_PROFILER_ENV = "SGLANG_TORCH_PROFILER_SCHEDULER_THREAD"
+SCHEDULER_THREAD_PROFILER_ENV = "SGLANG_TORCH_PROFILER_SCHEDULER_THREAD"
 # The scheduler thread publishes its identity as its first act, so readiness is
 # a startup-order guard, not a wait for the model to load.
 _SCHEDULER_THREAD_READY_TIMEOUT_S = 30.0
@@ -338,9 +338,9 @@ class Stage:
         elif isinstance(msg, DataReadyMessage):
             self._schedule_receive_task(msg)
         elif isinstance(msg, ProfilerStartMessage):
-            self._on_profiler_start(msg)
+            await self._on_profiler_start(msg)
         elif isinstance(msg, ProfilerStopMessage):
-            self._on_profiler_stop(msg)
+            await self._on_profiler_stop(msg)
         elif isinstance(msg, AdminMessage):
             await self._on_admin(msg)
 
@@ -1614,7 +1614,7 @@ class Stage:
           pre-existing behavior so an ownerless process never loses its trace.
         """
 
-        if os.environ.get(_SCHEDULER_THREAD_PROFILER_ENV) != "1":
+        if os.environ.get(SCHEDULER_THREAD_PROFILER_ENV) != "1":
             return _TORCH_PROFILER_DIRECT
         if self._torch_profiler_owner:
             return _TORCH_PROFILER_SCHEDULER_OWNER
@@ -1635,7 +1635,19 @@ class Stage:
             "Stage %s Torch profiler %s failed: %s", self.name, operation, detail
         )
 
-    def _on_profiler_start(self, msg: ProfilerStartMessage) -> None:
+    async def _delegate_profiler_to_scheduler(self, call: Callable[[], None]) -> None:
+        """Run a blocking scheduler handoff off the stage control loop.
+
+        Both the readiness wait and the admin queue handoff block for up to
+        ``_SCHEDULER_THREAD_READY_TIMEOUT_S`` each. This coroutine runs on the
+        loop that also serves submits and acks, so the wait goes to an executor
+        for the same reason :meth:`_run_admin_operation` does.
+        """
+
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, call)
+
+    async def _on_profiler_start(self, msg: ProfilerStartMessage) -> None:
         run_id = msg.run_id
         mode = self._torch_profiler_mode()
         route_to_scheduler = mode == _TORCH_PROFILER_SCHEDULER_OWNER
@@ -1647,7 +1659,9 @@ class Stage:
             if prof_dir and not os.path.isabs(template):
                 template = os.path.join(prof_dir, template)
             if route_to_scheduler:
-                self._start_torch_profiler_on_scheduler(template, run_id)
+                await self._delegate_profiler_to_scheduler(
+                    lambda: self._start_torch_profiler_on_scheduler(template, run_id)
+                )
             else:
                 TorchProfiler.start(template, run_id=run_id)
         if msg.event_dir is not None:
@@ -1715,7 +1729,7 @@ class Stage:
                 "stop", response.get("error", response.get("message"))
             )
 
-    def _on_profiler_stop(self, msg: ProfilerStopMessage) -> None:
+    async def _on_profiler_stop(self, msg: ProfilerStopMessage) -> None:
         # run_id=None is a wildcard (stop whatever's active).
         # Mirrors _on_profiler_start: only the process-local owner drives the
         # singleton, siblings stay out, ownerless processes stop their own.
@@ -1723,7 +1737,9 @@ class Stage:
         if mode == _TORCH_PROFILER_SCHEDULER_SIBLING:
             pass
         elif mode == _TORCH_PROFILER_SCHEDULER_OWNER:
-            self._stop_torch_profiler_on_scheduler(msg.run_id)
+            await self._delegate_profiler_to_scheduler(
+                lambda: self._stop_torch_profiler_on_scheduler(msg.run_id)
+            )
         elif TorchProfiler.is_active() and (
             msg.run_id is None or TorchProfiler.get_active_run_id() == msg.run_id
         ):

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -1559,7 +1559,31 @@ class Stage:
 
     def _on_profiler_start(self, msg: ProfilerStartMessage) -> None:
         run_id = msg.run_id
-        if msg.enable_torch and not TorchProfiler.is_active():
+        scheduler_thread_torch = (
+            os.environ.get("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD") == "1"
+        )
+        if msg.enable_torch and scheduler_thread_torch:
+            base_tpl = msg.trace_path_template.format(run_id=run_id, stage=self.name)
+            template = f"{base_tpl}_pid{os.getpid()}"
+            prof_dir = os.environ.get("SGLANG_TORCH_PROFILER_DIR")
+            if prof_dir and not os.path.isabs(template):
+                template = os.path.join(prof_dir, template)
+            # Kineto CPU operator callbacks are thread-local. The AR scheduler
+            # runs in a dedicated thread that predates this control message, so
+            # starting here on the asyncio thread records CUDA activities but
+            # no CPU-side Aten operators. Route the opt-in profiler lifecycle
+            # through OmniScheduler's admin queue so start/stop execute on the
+            # actual compute thread. Only that scheduler owns the process-wide
+            # TorchProfiler singleton; sibling stages still participate in the
+            # event recorder below.
+            if self.name == "tts_engine" and hasattr(self.scheduler, "admin"):
+                response = self.scheduler.admin(
+                    "torch_profiler_start",
+                    {"trace_path_template": template, "run_id": run_id},
+                )
+                if not response.get("success", False):
+                    raise RuntimeError(response.get("error", response.get("message")))
+        elif msg.enable_torch and not TorchProfiler.is_active():
             base_tpl = msg.trace_path_template.format(run_id=run_id, stage=self.name)
             template = f"{base_tpl}_pid{os.getpid()}"
             prof_dir = os.environ.get("SGLANG_TORCH_PROFILER_DIR")
@@ -1580,7 +1604,19 @@ class Stage:
 
     def _on_profiler_stop(self, msg: ProfilerStopMessage) -> None:
         # run_id=None is a wildcard (stop whatever's active).
-        if TorchProfiler.is_active() and (
+        scheduler_thread_torch = (
+            os.environ.get("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD") == "1"
+        )
+        if scheduler_thread_torch:
+            if self.name == "tts_engine" and hasattr(self.scheduler, "admin"):
+                response = self.scheduler.admin(
+                    "torch_profiler_stop", {"run_id": msg.run_id}
+                )
+                if not response.get("success", False):
+                    raise RuntimeError(
+                        response.get("error", response.get("message"))
+                    )
+        elif TorchProfiler.is_active() and (
             msg.run_id is None or TorchProfiler.get_active_run_id() == msg.run_id
         ):
             TorchProfiler.stop(run_id=msg.run_id)

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -56,6 +56,9 @@ SCHEDULER_THREAD_PROFILER_ENV = "SGLANG_TORCH_PROFILER_SCHEDULER_THREAD"
 # The scheduler thread publishes its identity as its first act, so readiness is
 # a startup-order guard, not a wait for the model to load.
 _SCHEDULER_THREAD_READY_TIMEOUT_S = 30.0
+# Matches the profiler admin timeout: a stop already handed to the scheduler
+# either exports its trace or fails on its own deadline within this window.
+_PROFILER_SHUTDOWN_DRAIN_TIMEOUT_S = 30.0
 
 # How a stage may touch the process-wide TorchProfiler singleton.
 _TORCH_PROFILER_DIRECT = "direct"
@@ -184,6 +187,11 @@ class Stage:
         self._receive_lane_tails: dict[tuple[str, str], asyncio.Future[None]] = {}
         self._profiler_op_queue: asyncio.Queue[Callable[[], None]] | None = None
         self._profiler_op_worker: asyncio.Task | None = None
+        # Two signals, because they fire at different points: the first stops
+        # new work being queued, the second tells work already running in the
+        # executor to bail before it touches a scheduler that is going away.
+        self._profiler_shutdown = threading.Event()
+        self._profiler_lane_abandoned = threading.Event()
         self._scheduler_thread: threading.Thread | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._scheduler_crash_error: BaseException | None = None
@@ -255,12 +263,7 @@ class Stage:
         await asyncio.gather(*receive_tasks, return_exceptions=True)
         self._receive_tasks.clear()
         self._receive_lane_tails.clear()
-        profiler_worker = self._profiler_op_worker
-        if profiler_worker is not None:
-            profiler_worker.cancel()
-            with suppress(asyncio.CancelledError):
-                await profiler_worker
-            self._profiler_op_worker = None
+        await self._shutdown_profiler_ops()
         if self.scheduler is not None:
             try:
                 self.scheduler.stop()
@@ -1643,6 +1646,38 @@ class Stage:
             "Stage %s Torch profiler %s failed: %s", self.name, operation, detail
         )
 
+    async def _shutdown_profiler_ops(self) -> None:
+        """Let queued profiler work finish, within a bound, then stop the lane.
+
+        A ``/stop_profile`` immediately followed by shutdown is an ordinary
+        operator sequence, and the queued stop is what exports the trace, so
+        cancelling outright would throw it away. The drain is bounded because
+        shutdown must not hang on a scheduler that is already gone.
+
+        Cancelling the worker cannot interrupt a call already running in the
+        executor -- ``Task.cancel`` does not reach into the thread. So the
+        deadline also marks the lane abandoned, and a call that was blocked in
+        its readiness wait checks that before going near the scheduler.
+        """
+
+        self._profiler_shutdown.set()
+        worker = self._profiler_op_worker
+        if worker is None:
+            return
+        try:
+            await asyncio.wait_for(
+                self._wait_for_profiler_ops(), _PROFILER_SHUTDOWN_DRAIN_TIMEOUT_S
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Stage %s stopped with profiler operations still pending", self.name
+            )
+        self._profiler_lane_abandoned.set()
+        worker.cancel()
+        with suppress(asyncio.CancelledError):
+            await worker
+        self._profiler_op_worker = None
+
     def _submit_profiler_op(self, call: Callable[[], None]) -> None:
         """Hand a blocking profiler operation to the serialized worker.
 
@@ -1655,6 +1690,11 @@ class Stage:
         can never overtake the start it belongs to.
         """
 
+        if self._profiler_shutdown.is_set():
+            logger.warning(
+                "Stage %s is shutting down, dropping profiler operation", self.name
+            )
+            return
         if self._profiler_op_queue is None:
             self._profiler_op_queue = asyncio.Queue()
         if self._profiler_op_worker is None or self._profiler_op_worker.done():
@@ -1732,7 +1772,15 @@ class Stage:
         but has no CPU operators, which is the defect this mode exists to fix.
         """
 
-        if self.scheduler.wait_until_scheduler_thread_ready(timeout_s):
+        ready = self.scheduler.wait_until_scheduler_thread_ready(timeout_s)
+        if self._profiler_lane_abandoned.is_set():
+            # The stage stopped waiting for this call and is tearing the
+            # scheduler down. Anything issued now races that teardown.
+            self._profiler_control_failed(
+                operation, "stage shut down before the scheduler thread answered"
+            )
+            return False
+        if ready:
             return True
         self._profiler_control_failed(
             operation,

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -53,6 +53,14 @@ logger = logging.getLogger(__name__)
 GetNextFn = Callable[[str, Any], str | list[str] | None]
 GetStreamDoneTargetsFn = Callable[[str, Any], str | list[str] | None]
 _SCHEDULER_THREAD_PROFILER_ENV = "SGLANG_TORCH_PROFILER_SCHEDULER_THREAD"
+# The scheduler thread publishes its identity as its first act, so readiness is
+# a startup-order guard, not a wait for the model to load.
+_SCHEDULER_THREAD_READY_TIMEOUT_S = 30.0
+
+# How a stage may touch the process-wide TorchProfiler singleton.
+_TORCH_PROFILER_DIRECT = "direct"
+_TORCH_PROFILER_SCHEDULER_OWNER = "scheduler_owner"
+_TORCH_PROFILER_SCHEDULER_SIBLING = "scheduler_sibling"
 
 
 @runtime_checkable
@@ -64,6 +72,8 @@ class SchedulerThreadProfilerControl(Protocol):
     ) -> dict[str, Any]: ...
 
     def stop_torch_profiler(self, run_id: str | None) -> dict[str, Any]: ...
+
+    def wait_until_scheduler_thread_ready(self, timeout_s: float) -> bool: ...
 
 
 def _error_text(exc: BaseException) -> str:
@@ -113,6 +123,7 @@ class Stage:
         tp_fanout: TPLeaderFanout | None = None,
         is_terminal: bool = False,
         torch_profiler_owner: bool = False,
+        torch_profiler_process_has_owner: bool = False,
     ):
         self.name = name
         self.role = role
@@ -132,6 +143,9 @@ class Stage:
         self._tp_fanout = tp_fanout
         self._is_terminal = is_terminal
         self._torch_profiler_owner = torch_profiler_owner
+        self._torch_profiler_process_has_owner = (
+            torch_profiler_process_has_owner or torch_profiler_owner
+        )
         self._owns_external_io = role in {"single", "leader"}
 
         if self._torch_profiler_owner and not isinstance(
@@ -1580,34 +1594,66 @@ class Stage:
         self._clear_request_state(request_id)
         self.scheduler.abort(request_id)
 
+    def _torch_profiler_mode(self) -> str:
+        """How this stage may touch the process-wide TorchProfiler singleton.
+
+        Kineto CPU operator callbacks are thread-local. The AR scheduler runs in
+        a dedicated thread that predates any control message, so starting the
+        profiler on the asyncio thread records CUDA activities but no CPU-side
+        Aten operators. The opt-in mode routes the lifecycle through the
+        scheduler admin queue instead.
+
+        The singleton is per process and a process can host several stages on
+        one asyncio loop, so the decision is per process, not per stage:
+
+        - ``scheduler_owner``: drives the singleton from its scheduler thread.
+        - ``scheduler_sibling``: colocated with an owner, so it must not touch
+          the singleton at all -- otherwise whichever stage handles the
+          broadcast first wins and the profiler runs on the wrong thread.
+        - ``direct``: mode off, or no owner in this process. Keeps the
+          pre-existing behavior so an ownerless process never loses its trace.
+        """
+
+        if os.environ.get(_SCHEDULER_THREAD_PROFILER_ENV) != "1":
+            return _TORCH_PROFILER_DIRECT
+        if self._torch_profiler_owner:
+            return _TORCH_PROFILER_SCHEDULER_OWNER
+        if self._torch_profiler_process_has_owner:
+            return _TORCH_PROFILER_SCHEDULER_SIBLING
+        return _TORCH_PROFILER_DIRECT
+
+    def _profiler_control_failed(self, operation: str, detail: object) -> None:
+        """Report a profiler control failure without killing the stage.
+
+        ``ProfilerControlClient`` broadcasts start/stop as fire-and-forget PUSH
+        messages with no response channel, and an exception escaping a message
+        handler tears down every stage in this process. A missing trace must not
+        cost the serving process, so failures are logged instead of raised.
+        """
+
+        logger.error(
+            "Stage %s Torch profiler %s failed: %s", self.name, operation, detail
+        )
+
     def _on_profiler_start(self, msg: ProfilerStartMessage) -> None:
         run_id = msg.run_id
-        scheduler_thread_torch = os.environ.get(_SCHEDULER_THREAD_PROFILER_ENV) == "1"
-        if msg.enable_torch and scheduler_thread_torch:
+        mode = self._torch_profiler_mode()
+        route_to_scheduler = mode == _TORCH_PROFILER_SCHEDULER_OWNER
+        skip_torch = mode == _TORCH_PROFILER_SCHEDULER_SIBLING
+        if (
+            msg.enable_torch
+            and not skip_torch
+            and (route_to_scheduler or not TorchProfiler.is_active())
+        ):
             base_tpl = msg.trace_path_template.format(run_id=run_id, stage=self.name)
             template = f"{base_tpl}_pid{os.getpid()}"
             prof_dir = os.environ.get("SGLANG_TORCH_PROFILER_DIR")
             if prof_dir and not os.path.isabs(template):
                 template = os.path.join(prof_dir, template)
-            # Kineto CPU operator callbacks are thread-local. The AR scheduler
-            # runs in a dedicated thread that predates this control message, so
-            # starting here on the asyncio thread records CUDA activities but
-            # no CPU-side Aten operators. Route the opt-in profiler lifecycle
-            # through OmniScheduler's admin queue so start/stop execute on the
-            # actual compute thread. Ownership is explicit runtime intent,
-            # independent of a model-specific stage name. Sibling stages still
-            # participate in the event recorder below.
-            if self._torch_profiler_owner:
-                response = self.scheduler.start_torch_profiler(template, run_id)
-                if not response.get("success", False):
-                    raise RuntimeError(response.get("error", response.get("message")))
-        elif msg.enable_torch and not TorchProfiler.is_active():
-            base_tpl = msg.trace_path_template.format(run_id=run_id, stage=self.name)
-            template = f"{base_tpl}_pid{os.getpid()}"
-            prof_dir = os.environ.get("SGLANG_TORCH_PROFILER_DIR")
-            if prof_dir and not os.path.isabs(template):
-                template = os.path.join(prof_dir, template)
-            TorchProfiler.start(template, run_id=run_id)
+            if route_to_scheduler:
+                self._start_torch_profiler_on_scheduler(template, run_id)
+            else:
+                TorchProfiler.start(template, run_id=run_id)
         if msg.event_dir is not None:
             try:
                 _get_recorder().start(
@@ -1620,14 +1666,68 @@ class Stage:
                     exc_info=True,
                 )
 
+    def _scheduler_thread_ready_for_profiler(
+        self, operation: str, timeout_s: float
+    ) -> bool:
+        """Whether delegation would actually land on the scheduler thread.
+
+        ``_should_enqueue_admin`` runs an action inline whenever the scheduler
+        thread has not published its id yet, or has already exited. That is fine
+        for ordinary admin work and wrong here, so the caller must skip rather
+        than fall back: a direct call would produce a trace that looks complete
+        but has no CPU operators, which is the defect this mode exists to fix.
+        """
+
+        if self.scheduler.wait_until_scheduler_thread_ready(timeout_s):
+            return True
+        self._profiler_control_failed(
+            operation,
+            "scheduler thread is not ready, refusing to run on the control thread",
+        )
+        return False
+
+    def _start_torch_profiler_on_scheduler(
+        self, template: str, run_id: str | None
+    ) -> None:
+        """Delegate the start to the scheduler thread, or give up loudly."""
+
+        # Stage.start does not wait for the scheduler thread, so an early start
+        # is a legitimate startup race worth waiting out.
+        if not self._scheduler_thread_ready_for_profiler(
+            "start", _SCHEDULER_THREAD_READY_TIMEOUT_S
+        ):
+            return
+        # TorchProfiler.start is idempotent per run_id, so re-issuing a start
+        # for the active run is a no-op rather than an error.
+        response = self.scheduler.start_torch_profiler(template, run_id)
+        if not response.get("success", False):
+            self._profiler_control_failed(
+                "start", response.get("error", response.get("message"))
+            )
+
+    def _stop_torch_profiler_on_scheduler(self, run_id: str | None) -> None:
+        """Delegate the stop to the same thread that started the profiler."""
+
+        # No wait here: by stop time the thread has long been up, so "not ready"
+        # means it is shutting down. Blocking the control thread on a scheduler
+        # that is going away would stall the stage for no benefit.
+        if not self._scheduler_thread_ready_for_profiler("stop", 0.0):
+            return
+        response = self.scheduler.stop_torch_profiler(run_id)
+        if not response.get("success", False):
+            self._profiler_control_failed(
+                "stop", response.get("error", response.get("message"))
+            )
+
     def _on_profiler_stop(self, msg: ProfilerStopMessage) -> None:
         # run_id=None is a wildcard (stop whatever's active).
-        scheduler_thread_torch = os.environ.get(_SCHEDULER_THREAD_PROFILER_ENV) == "1"
-        if scheduler_thread_torch:
-            if self._torch_profiler_owner:
-                response = self.scheduler.stop_torch_profiler(msg.run_id)
-                if not response.get("success", False):
-                    raise RuntimeError(response.get("error", response.get("message")))
+        # Mirrors _on_profiler_start: only the process-local owner drives the
+        # singleton, siblings stay out, ownerless processes stop their own.
+        mode = self._torch_profiler_mode()
+        if mode == _TORCH_PROFILER_SCHEDULER_SIBLING:
+            pass
+        elif mode == _TORCH_PROFILER_SCHEDULER_OWNER:
+            self._stop_torch_profiler_on_scheduler(msg.run_id)
         elif TorchProfiler.is_active() and (
             msg.run_id is None or TorchProfiler.get_active_run_id() == msg.run_id
         ):

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -91,6 +91,7 @@ class StageLaunchConfig:
     can_accept_stream_before_payload: bool = False
     disable_direct_cuda_ipc_payload: bool = False
     torch_profiler_owner: bool = False
+    torch_profiler_process_has_owner: bool = False
 
     # Same-process full payload wiring
     same_process_targets: set[str] = field(default_factory=set)
@@ -761,6 +762,7 @@ def _construct_stage(
         can_accept_stream_before_payload=spec.can_accept_stream_before_payload,
         disable_direct_cuda_ipc_payload=spec.disable_direct_cuda_ipc_payload,
         torch_profiler_owner=spec.torch_profiler_owner,
+        torch_profiler_process_has_owner=spec.torch_profiler_process_has_owner,
         tp_fanout=tp_fanout,
         is_terminal=spec.is_terminal,
     )

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -90,6 +90,7 @@ class StageLaunchConfig:
     is_stream_receiver: bool = False
     can_accept_stream_before_payload: bool = False
     disable_direct_cuda_ipc_payload: bool = False
+    torch_profiler_owner: bool = False
 
     # Same-process full payload wiring
     same_process_targets: set[str] = field(default_factory=set)
@@ -759,6 +760,7 @@ def _construct_stage(
         local_dispatcher=local_dispatcher,
         can_accept_stream_before_payload=spec.can_accept_stream_before_payload,
         disable_direct_cuda_ipc_payload=spec.disable_direct_cuda_ipc_payload,
+        torch_profiler_owner=spec.torch_profiler_owner,
         tp_fanout=tp_fanout,
         is_terminal=spec.is_terminal,
     )

--- a/sglang_omni/profiler/torch_profiler.py
+++ b/sglang_omni/profiler/torch_profiler.py
@@ -44,9 +44,14 @@ class TorchProfiler(ProfilerBase):
         """
         with cls._lock:
 
+            # Resolve rank before the cleanup branch below: both the idempotent
+            # early return and the restart warning reference it.
+            rank = cls._get_rank()
+
             # 1. Cleanup any existing profiler
             if cls._profiler is not None:
                 if run_id is not None and cls._active_run_id == run_id:
+                    # Idempotent start: the same run is already recording.
                     return f"{cls._trace_template}_rank{rank}.trace.json.gz"
 
                 logger.warning(
@@ -64,8 +69,6 @@ class TorchProfiler(ProfilerBase):
                 cls._profiler = None
                 cls._active_run_id = None
                 cls._trace_template = ""
-
-            rank = cls._get_rank()
 
             # 2. Make path absolute
             trace_path_template = os.path.abspath(trace_path_template)

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -66,6 +66,10 @@ _PENDING_STREAM_REQUEST_LIMIT = 10000
 _PENDING_STREAM_REQUEST_RETAINED = 5000
 _ADMIN_TORCH_PROFILER_START = "torch_profiler_start"
 _ADMIN_TORCH_PROFILER_STOP = "torch_profiler_stop"
+# The scheduler drains its admin queue every loop iteration, so a profiler
+# handoff costs about one step. Far below the 300s generic admin default, which
+# would pin a stage's control thread if the scheduler loop went away.
+_PROFILER_ADMIN_TIMEOUT_S = 30.0
 
 
 class _PendingStreamIngress:
@@ -1554,12 +1558,92 @@ class OmniScheduler:
             return self._enqueue_admin(action, payload)
         return self._run_admin_action(action, payload)
 
+    def wait_until_scheduler_thread_ready(self, timeout_s: float) -> bool:
+        """Block until admin actions would actually reach the scheduler thread.
+
+        ``Stage.start`` spawns the scheduler thread and returns without waiting,
+        so a control message can arrive before :meth:`start` has published the
+        thread id. ``_should_enqueue_admin`` would then run the action inline on
+        the caller's thread -- fine for ordinary admin work, wrong for the
+        thread-local profiler.
+        """
+
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            if self._running and self._scheduler_thread_id is not None:
+                return True
+            time.sleep(0.01)
+        return self._running and self._scheduler_thread_id is not None
+
+    def _expired_profiler_admin(
+        self, action: str, payload: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        """Drop a profiler action the caller has already given up on.
+
+        ``_enqueue_admin`` reports a timeout but leaves the request queued, so a
+        scheduler that was busy past the deadline would still run it afterwards.
+        For a profiler start that means an orphan: the caller was told it failed
+        and will never stop it, while full CPU profiling keeps costing the
+        serving path until someone notices.
+        """
+
+        deadline = payload.get("_deadline")
+        if deadline is None or time.monotonic() <= float(deadline):
+            return None
+        logger.warning(
+            "Skipping expired profiler admin action %s (run_id=%s): the caller "
+            "timed out before the scheduler thread reached it",
+            action,
+            payload.get("run_id"),
+        )
+        message = "profiler request expired before the scheduler thread ran it"
+        return {"success": False, "error": message, "message": message}
+
+    def _run_profiler_admin(
+        self, action: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Run a profiler action on the scheduler thread, or not at all.
+
+        :meth:`admin` falls back to running inline whenever the scheduler thread
+        is unavailable. That is right for ordinary admin work and wrong here:
+        Kineto CPU callbacks are thread-local, so an inline run silently
+        produces the very trace this mode exists to prevent.
+
+        The caller's readiness check cannot close this on its own. ``start``
+        clears ``_scheduler_thread_id`` in its ``finally`` but leaves
+        ``_running`` set until :meth:`stop` runs, so a scheduler loop that has
+        exited leaves a window where ``_should_enqueue_admin`` reports inline.
+        Re-checking here, on the values ``admin`` would itself use, turns that
+        window into a failed request instead of a wrong-thread run.
+        """
+
+        scheduler_thread_id = self._scheduler_thread_id
+        if not self._running or scheduler_thread_id is None:
+            return {
+                "success": False,
+                "error": "scheduler thread is not running",
+                "message": "scheduler thread is not running",
+            }
+        if threading.get_ident() == scheduler_thread_id:
+            return self._run_admin_action(action, payload)
+        # Bounded: if the loop dies between the check above and the handoff, the
+        # response never arrives and this would otherwise block the caller's
+        # control thread for the 300s default. The deadline travels with the
+        # request so a scheduler that drains it late drops it instead of acting
+        # on a result the caller has already written off.
+        payload = {
+            **payload,
+            "_admin_timeout_s": _PROFILER_ADMIN_TIMEOUT_S,
+            "_deadline": time.monotonic() + _PROFILER_ADMIN_TIMEOUT_S,
+        }
+        return self._enqueue_admin(action, payload)
+
     def start_torch_profiler(
         self, trace_path_template: str, run_id: str | None
     ) -> dict[str, Any]:
         """Start TorchProfiler on the scheduler's model-execution thread."""
 
-        return self.admin(
+        return self._run_profiler_admin(
             _ADMIN_TORCH_PROFILER_START,
             {"trace_path_template": trace_path_template, "run_id": run_id},
         )
@@ -1567,7 +1651,7 @@ class OmniScheduler:
     def stop_torch_profiler(self, run_id: str | None) -> dict[str, Any]:
         """Stop TorchProfiler on the same model-execution thread."""
 
-        return self.admin(_ADMIN_TORCH_PROFILER_STOP, {"run_id": run_id})
+        return self._run_profiler_admin(_ADMIN_TORCH_PROFILER_STOP, {"run_id": run_id})
 
     def _should_enqueue_admin(self) -> bool:
         scheduler_thread_id = self._scheduler_thread_id
@@ -1616,6 +1700,10 @@ class OmniScheduler:
         self, action: str, payload: dict[str, Any] | None = None
     ) -> dict[str, Any]:
         payload = dict(payload or {})
+        if action in (_ADMIN_TORCH_PROFILER_START, _ADMIN_TORCH_PROFILER_STOP):
+            expired = self._expired_profiler_admin(action, payload)
+            if expired is not None:
+                return expired
         if action == _ADMIN_TORCH_PROFILER_START:
             from sglang_omni.profiler.torch_profiler import TorchProfiler
 

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -64,6 +64,8 @@ _ABORTED_REQUEST_ID_RETAINED = 5000
 _COMPLETED_REQUEST_ID_LIMIT = 10000
 _PENDING_STREAM_REQUEST_LIMIT = 10000
 _PENDING_STREAM_REQUEST_RETAINED = 5000
+_ADMIN_TORCH_PROFILER_START = "torch_profiler_start"
+_ADMIN_TORCH_PROFILER_STOP = "torch_profiler_stop"
 
 
 class _PendingStreamIngress:
@@ -1552,6 +1554,21 @@ class OmniScheduler:
             return self._enqueue_admin(action, payload)
         return self._run_admin_action(action, payload)
 
+    def start_torch_profiler(
+        self, trace_path_template: str, run_id: str | None
+    ) -> dict[str, Any]:
+        """Start TorchProfiler on the scheduler's model-execution thread."""
+
+        return self.admin(
+            _ADMIN_TORCH_PROFILER_START,
+            {"trace_path_template": trace_path_template, "run_id": run_id},
+        )
+
+    def stop_torch_profiler(self, run_id: str | None) -> dict[str, Any]:
+        """Stop TorchProfiler on the same model-execution thread."""
+
+        return self.admin(_ADMIN_TORCH_PROFILER_STOP, {"run_id": run_id})
+
     def _should_enqueue_admin(self) -> bool:
         scheduler_thread_id = self._scheduler_thread_id
         return (
@@ -1599,14 +1616,14 @@ class OmniScheduler:
         self, action: str, payload: dict[str, Any] | None = None
     ) -> dict[str, Any]:
         payload = dict(payload or {})
-        if action == "torch_profiler_start":
+        if action == _ADMIN_TORCH_PROFILER_START:
             from sglang_omni.profiler.torch_profiler import TorchProfiler
 
             trace = TorchProfiler.start(
                 str(payload["trace_path_template"]), run_id=payload.get("run_id")
             )
             return {"success": True, "trace": trace}
-        if action == "torch_profiler_stop":
+        if action == _ADMIN_TORCH_PROFILER_STOP:
             from sglang_omni.profiler.torch_profiler import TorchProfiler
 
             result = TorchProfiler.stop(run_id=payload.get("run_id"))

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -1599,6 +1599,18 @@ class OmniScheduler:
         self, action: str, payload: dict[str, Any] | None = None
     ) -> dict[str, Any]:
         payload = dict(payload or {})
+        if action == "torch_profiler_start":
+            from sglang_omni.profiler.torch_profiler import TorchProfiler
+
+            trace = TorchProfiler.start(
+                str(payload["trace_path_template"]), run_id=payload.get("run_id")
+            )
+            return {"success": True, "trace": trace}
+        if action == "torch_profiler_stop":
+            from sglang_omni.profiler.torch_profiler import TorchProfiler
+
+            result = TorchProfiler.stop(run_id=payload.get("run_id"))
+            return {"success": True, "result": result}
         if action == ADMIN_MODEL_INFO:
             return self._admin_model_info()
         if action == ADMIN_PAUSE_GENERATION:

--- a/tests/unit_test/pipeline/test_admin_control.py
+++ b/tests/unit_test/pipeline/test_admin_control.py
@@ -8,6 +8,7 @@ import queue
 import sys
 import threading
 import time
+from contextlib import suppress
 from types import SimpleNamespace
 from unittest import mock
 
@@ -22,6 +23,7 @@ from sglang_omni.proto import (
     AdminOperation,
     AdminResult,
     AdminResultMessage,
+    DataAckMessage,
     ProfilerStartMessage,
     ProfilerStopMessage,
     parse_message,
@@ -93,14 +95,41 @@ def _patch_direct_torch_profiler(
     )
 
 
+async def _release_profiler_lane(stage: Stage) -> None:
+    """Drain and tear down the profiler lane, as ``Stage.stop`` does.
+
+    Each helper below gets its own ``asyncio.run`` loop, and the queue and
+    worker are bound to the loop that created them. Production keeps one loop
+    for the stage's whole life; tests have to reset between calls.
+    """
+    await stage._wait_for_profiler_ops()
+    worker = stage._profiler_op_worker
+    if worker is not None:
+        worker.cancel()
+        with suppress(asyncio.CancelledError):
+            await worker
+    stage._profiler_op_worker = None
+    stage._profiler_op_queue = None
+
+
 def _profile_start(stage: Stage, msg: ProfilerStartMessage) -> None:
-    """Drive the async profiler-start handler from a sync test."""
-    asyncio.run(stage._on_profiler_start(msg))
+    """Handle a start, then wait for the deferred profiler operation."""
+
+    async def _run() -> None:
+        stage._on_profiler_start(msg)
+        await _release_profiler_lane(stage)
+
+    asyncio.run(_run())
 
 
 def _profile_stop(stage: Stage, msg: ProfilerStopMessage) -> None:
-    """Drive the async profiler-stop handler from a sync test."""
-    asyncio.run(stage._on_profiler_stop(msg))
+    """Handle a stop, then wait for the deferred profiler operation."""
+
+    async def _run() -> None:
+        stage._on_profiler_stop(msg)
+        await _release_profiler_lane(stage)
+
+    asyncio.run(_run())
 
 
 def _profiler_stage(scheduler, *, name: str, owner: bool, process_has_owner: bool):
@@ -1124,12 +1153,12 @@ def test_live_profiler_request_carries_a_deadline_but_still_runs() -> None:
     assert started == ["/tmp/trace"]
 
 
-def test_profiler_delegation_does_not_block_the_stage_control_loop(
+def test_profiler_delegation_does_not_stall_submits_and_acks(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The readiness wait and the admin handoff each block for up to 30s. They
-    run on the loop that also serves submits and acks, so they must go to an
-    executor rather than stalling message handling."""
+    """The readiness wait and the admin handoff each block for up to 30s. If a
+    handler awaited them, `run` would not reach its next `control_plane.recv()`
+    and this stage's submits and acks would queue behind a profiler request."""
     monkeypatch.setenv("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD", "1")
     direct_calls: list[tuple] = []
     _patch_direct_torch_profiler(monkeypatch, direct_calls)
@@ -1144,27 +1173,69 @@ def test_profiler_delegation_does_not_block_the_stage_control_loop(
     owner = _profiler_stage(
         _BlockingScheduler(), name="tts_engine", owner=True, process_has_owner=True
     )
+    handled: list[str] = []
 
     async def _run() -> None:
-        profiler = asyncio.ensure_future(
-            owner._on_profiler_start(
-                ProfilerStartMessage(
-                    run_id="run-1", trace_path_template="/tmp/{stage}/trace"
-                )
+        # Exactly what Stage.run does: dispatch, then take the next message.
+        await owner._handle_message(
+            ProfilerStartMessage(
+                run_id="run-1", trace_path_template="/tmp/{stage}/trace"
             )
         )
-        # The loop must keep turning while the delegation blocks in its thread.
-        served = 0
-        for _ in range(5):
-            await asyncio.sleep(0)
-            served += 1
-        assert not profiler.done()
-        assert served == 5
+        handled.append("profiler_start")
 
+        for index in range(3):
+            await owner._handle_message(
+                DataAckMessage(
+                    request_id=f"req-{index}",
+                    from_stage="upstream",
+                    to_stage="tts_engine",
+                    object_id=f"obj-{index}",
+                )
+            )
+            handled.append(f"ack-{index}")
+
+        # Submits and acks got through while the delegation was still blocked.
+        assert owner.scheduler.profiler_calls == []
         release.set()
-        await asyncio.wait_for(profiler, timeout=5.0)
+        await asyncio.wait_for(owner._wait_for_profiler_ops(), timeout=5.0)
+        await owner.stop()
 
     asyncio.run(_run())
+
+    assert handled == ["profiler_start", "ack-0", "ack-1", "ack-2"]
     assert owner.scheduler.profiler_calls == [
         ("start", f"/tmp/tts_engine/trace_pid{os.getpid()}", "run-1")
     ]
+
+
+def test_profiler_operations_run_in_arrival_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deferring the work must not let a stop overtake its own start."""
+    monkeypatch.setenv("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD", "1")
+    direct_calls: list[tuple] = []
+    _patch_direct_torch_profiler(monkeypatch, direct_calls)
+
+    class _SlowStartScheduler(ProfilerControlScheduler):
+        def start_torch_profiler(self, trace_path_template: str, run_id: str | None):
+            time.sleep(0.05)
+            return super().start_torch_profiler(trace_path_template, run_id)
+
+    owner = _profiler_stage(
+        _SlowStartScheduler(), name="tts_engine", owner=True, process_has_owner=True
+    )
+
+    async def _run() -> None:
+        owner._on_profiler_start(
+            ProfilerStartMessage(
+                run_id="run-1", trace_path_template="/tmp/{stage}/trace"
+            )
+        )
+        owner._on_profiler_stop(ProfilerStopMessage(run_id="run-1"))
+        await asyncio.wait_for(owner._wait_for_profiler_ops(), timeout=5.0)
+        await owner.stop()
+
+    asyncio.run(_run())
+
+    assert [name for name, *_ in owner.scheduler.profiler_calls] == ["start", "stop"]

--- a/tests/unit_test/pipeline/test_admin_control.py
+++ b/tests/unit_test/pipeline/test_admin_control.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import queue
 import threading
 import time
 from types import SimpleNamespace
+
+import pytest
 
 from sglang_omni.pipeline.control_plane import deserialize_message, serialize_message
 from sglang_omni.pipeline.coordinator import Coordinator
@@ -16,6 +19,8 @@ from sglang_omni.proto import (
     AdminOperation,
     AdminResult,
     AdminResultMessage,
+    ProfilerStartMessage,
+    ProfilerStopMessage,
     parse_message,
 )
 from tests.unit_test.fixtures.pipeline_fakes import (
@@ -35,6 +40,20 @@ class AdminScheduler(FakeScheduler):
     def admin(self, action: str, payload: dict):
         self.calls.append((action, payload))
         return {"success": True, "message": "ok", "data": {"action": action}}
+
+
+class ProfilerControlScheduler(FakeScheduler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.profiler_calls: list[tuple] = []
+
+    def start_torch_profiler(self, trace_path_template: str, run_id: str | None):
+        self.profiler_calls.append(("start", trace_path_template, run_id))
+        return {"success": True}
+
+    def stop_torch_profiler(self, run_id: str | None):
+        self.profiler_calls.append(("stop", run_id))
+        return {"success": True}
 
 
 def test_admin_messages_round_trip() -> None:
@@ -474,3 +493,53 @@ def test_stage_admin_dispatches_to_scheduler() -> None:
         assert result_msg.result.data["action"] == "pause_generation"
 
     asyncio.run(_run())
+
+
+def test_stage_routes_torch_profiler_to_explicit_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD", "1")
+    scheduler = ProfilerControlScheduler()
+    stage = Stage(
+        name="ar-with-an-arbitrary-name",
+        role="single",
+        get_next=lambda request_id, output: None,
+        gpu_id=None,
+        endpoints={},
+        control_plane=RecordingStageControlPlane(),
+        relay=FakeRelay(),
+        scheduler=scheduler,
+        torch_profiler_owner=True,
+    )
+
+    stage._on_profiler_start(
+        ProfilerStartMessage(
+            run_id="run-1",
+            trace_path_template="/tmp/{run_id}/{stage}/trace",
+        )
+    )
+    stage._on_profiler_stop(ProfilerStopMessage(run_id="run-1"))
+
+    assert scheduler.profiler_calls == [
+        (
+            "start",
+            f"/tmp/run-1/ar-with-an-arbitrary-name/trace_pid{os.getpid()}",
+            "run-1",
+        ),
+        ("stop", "run-1"),
+    ]
+
+
+def test_stage_rejects_profiler_owner_without_control_capability() -> None:
+    with pytest.raises(TypeError, match="does not implement"):
+        Stage(
+            name="decode",
+            role="single",
+            get_next=lambda request_id, output: None,
+            gpu_id=None,
+            endpoints={},
+            control_plane=RecordingStageControlPlane(),
+            relay=FakeRelay(),
+            scheduler=FakeScheduler(),
+            torch_profiler_owner=True,
+        )

--- a/tests/unit_test/pipeline/test_admin_control.py
+++ b/tests/unit_test/pipeline/test_admin_control.py
@@ -93,6 +93,16 @@ def _patch_direct_torch_profiler(
     )
 
 
+def _profile_start(stage: Stage, msg: ProfilerStartMessage) -> None:
+    """Drive the async profiler-start handler from a sync test."""
+    asyncio.run(stage._on_profiler_start(msg))
+
+
+def _profile_stop(stage: Stage, msg: ProfilerStopMessage) -> None:
+    """Drive the async profiler-stop handler from a sync test."""
+    asyncio.run(stage._on_profiler_stop(msg))
+
+
 def _profiler_stage(scheduler, *, name: str, owner: bool, process_has_owner: bool):
     return Stage(
         name=name,
@@ -564,13 +574,14 @@ def test_stage_routes_torch_profiler_to_explicit_owner(
         torch_profiler_owner=True,
     )
 
-    stage._on_profiler_start(
+    _profile_start(
+        stage,
         ProfilerStartMessage(
             run_id="run-1",
             trace_path_template="/tmp/{run_id}/{stage}/trace",
-        )
+        ),
     )
-    stage._on_profiler_stop(ProfilerStopMessage(run_id="run-1"))
+    _profile_stop(stage, ProfilerStopMessage(run_id="run-1"))
 
     assert scheduler.profiler_calls == [
         (
@@ -611,10 +622,11 @@ def test_ownerless_process_still_profiles_directly(
         scheduler, name="vocoder", owner=False, process_has_owner=False
     )
 
-    stage._on_profiler_start(
-        ProfilerStartMessage(run_id="run-1", trace_path_template="/tmp/{stage}/trace")
+    _profile_start(
+        stage,
+        ProfilerStartMessage(run_id="run-1", trace_path_template="/tmp/{stage}/trace"),
     )
-    stage._on_profiler_stop(ProfilerStopMessage(run_id="run-1"))
+    _profile_stop(stage, ProfilerStopMessage(run_id="run-1"))
 
     assert direct_calls == [
         ("start", f"/tmp/vocoder/trace_pid{os.getpid()}", "run-1"),
@@ -637,11 +649,13 @@ def test_ownerless_process_forwards_a_new_run_to_the_profiler(
         scheduler, name="vocoder", owner=False, process_has_owner=False
     )
 
-    stage._on_profiler_start(
-        ProfilerStartMessage(run_id="run-1", trace_path_template="/tmp/{stage}/trace")
+    _profile_start(
+        stage,
+        ProfilerStartMessage(run_id="run-1", trace_path_template="/tmp/{stage}/trace"),
     )
-    stage._on_profiler_start(
-        ProfilerStartMessage(run_id="run-2", trace_path_template="/tmp/{stage}/trace")
+    _profile_start(
+        stage,
+        ProfilerStartMessage(run_id="run-2", trace_path_template="/tmp/{stage}/trace"),
     )
 
     assert direct_calls == [
@@ -673,10 +687,10 @@ def test_colocated_sibling_never_touches_the_profiler_singleton(
 
     # The sibling is handed the broadcast first: worst-case ordering.
     msg = ProfilerStartMessage(run_id="run-1", trace_path_template="/tmp/{stage}/trace")
-    sibling._on_profiler_start(msg)
-    owner._on_profiler_start(msg)
-    sibling._on_profiler_stop(ProfilerStopMessage(run_id="run-1"))
-    owner._on_profiler_stop(ProfilerStopMessage(run_id="run-1"))
+    _profile_start(sibling, msg)
+    _profile_start(owner, msg)
+    _profile_stop(sibling, ProfilerStopMessage(run_id="run-1"))
+    _profile_stop(owner, ProfilerStopMessage(run_id="run-1"))
 
     assert direct_calls == []
     assert scheduler.profiler_calls == [
@@ -700,8 +714,9 @@ def test_owner_refuses_to_profile_before_the_scheduler_thread_is_ready(
         scheduler, name="tts_engine", owner=True, process_has_owner=True
     )
 
-    owner._on_profiler_start(
-        ProfilerStartMessage(run_id="run-1", trace_path_template="/tmp/{stage}/trace")
+    _profile_start(
+        owner,
+        ProfilerStartMessage(run_id="run-1", trace_path_template="/tmp/{stage}/trace"),
     )
 
     assert direct_calls == []
@@ -723,10 +738,11 @@ def test_profiler_control_failure_does_not_kill_the_stage(
         scheduler, name="tts_engine", owner=True, process_has_owner=True
     )
 
-    owner._on_profiler_start(
-        ProfilerStartMessage(run_id="run-1", trace_path_template="/tmp/{stage}/trace")
+    _profile_start(
+        owner,
+        ProfilerStartMessage(run_id="run-1", trace_path_template="/tmp/{stage}/trace"),
     )
-    owner._on_profiler_stop(ProfilerStopMessage(run_id="run-1"))
+    _profile_stop(owner, ProfilerStopMessage(run_id="run-1"))
 
     assert [name for name, *_ in scheduler.profiler_calls] == ["start", "stop"]
     assert direct_calls == []
@@ -745,10 +761,11 @@ def test_scheduler_thread_mode_off_keeps_legacy_behavior(
         scheduler, name="tts_engine", owner=True, process_has_owner=True
     )
 
-    owner._on_profiler_start(
-        ProfilerStartMessage(run_id="run-1", trace_path_template="/tmp/{stage}/trace")
+    _profile_start(
+        owner,
+        ProfilerStartMessage(run_id="run-1", trace_path_template="/tmp/{stage}/trace"),
     )
-    owner._on_profiler_stop(ProfilerStopMessage(run_id="run-1"))
+    _profile_stop(owner, ProfilerStopMessage(run_id="run-1"))
 
     assert direct_calls == [
         ("start", f"/tmp/tts_engine/trace_pid{os.getpid()}", "run-1"),
@@ -770,12 +787,13 @@ def test_enable_torch_false_never_starts_the_profiler(
         scheduler, name="tts_engine", owner=True, process_has_owner=True
     )
 
-    owner._on_profiler_start(
+    _profile_start(
+        owner,
         ProfilerStartMessage(
             run_id="run-1",
             trace_path_template="/tmp/{stage}/trace",
             enable_torch=False,
-        )
+        ),
     )
 
     assert direct_calls == []
@@ -933,7 +951,7 @@ def test_owner_refuses_to_stop_after_the_scheduler_thread_is_gone(
         scheduler, name="tts_engine", owner=True, process_has_owner=True
     )
 
-    owner._on_profiler_stop(ProfilerStopMessage(run_id="run-1"))
+    _profile_stop(owner, ProfilerStopMessage(run_id="run-1"))
 
     assert direct_calls == []
     assert scheduler.profiler_calls == []
@@ -1104,3 +1122,49 @@ def test_live_profiler_request_carries_a_deadline_but_still_runs() -> None:
 
     assert response["success"] is True
     assert started == ["/tmp/trace"]
+
+
+def test_profiler_delegation_does_not_block_the_stage_control_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The readiness wait and the admin handoff each block for up to 30s. They
+    run on the loop that also serves submits and acks, so they must go to an
+    executor rather than stalling message handling."""
+    monkeypatch.setenv("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD", "1")
+    direct_calls: list[tuple] = []
+    _patch_direct_torch_profiler(monkeypatch, direct_calls)
+
+    release = threading.Event()
+
+    class _BlockingScheduler(ProfilerControlScheduler):
+        def wait_until_scheduler_thread_ready(self, timeout_s: float) -> bool:
+            release.wait(timeout=5.0)
+            return True
+
+    owner = _profiler_stage(
+        _BlockingScheduler(), name="tts_engine", owner=True, process_has_owner=True
+    )
+
+    async def _run() -> None:
+        profiler = asyncio.ensure_future(
+            owner._on_profiler_start(
+                ProfilerStartMessage(
+                    run_id="run-1", trace_path_template="/tmp/{stage}/trace"
+                )
+            )
+        )
+        # The loop must keep turning while the delegation blocks in its thread.
+        served = 0
+        for _ in range(5):
+            await asyncio.sleep(0)
+            served += 1
+        assert not profiler.done()
+        assert served == 5
+
+        release.set()
+        await asyncio.wait_for(profiler, timeout=5.0)
+
+    asyncio.run(_run())
+    assert owner.scheduler.profiler_calls == [
+        ("start", f"/tmp/tts_engine/trace_pid{os.getpid()}", "run-1")
+    ]

--- a/tests/unit_test/pipeline/test_admin_control.py
+++ b/tests/unit_test/pipeline/test_admin_control.py
@@ -5,14 +5,17 @@ from __future__ import annotations
 import asyncio
 import os
 import queue
+import sys
 import threading
 import time
 from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 
 from sglang_omni.pipeline.control_plane import deserialize_message, serialize_message
 from sglang_omni.pipeline.coordinator import Coordinator
+from sglang_omni.pipeline.stage import runtime as runtime_mod
 from sglang_omni.pipeline.stage.runtime import Stage
 from sglang_omni.proto import (
     AdminMessage,
@@ -43,17 +46,66 @@ class AdminScheduler(FakeScheduler):
 
 
 class ProfilerControlScheduler(FakeScheduler):
-    def __init__(self) -> None:
+    def __init__(self, *, thread_ready: bool = True, succeed: bool = True) -> None:
         super().__init__()
         self.profiler_calls: list[tuple] = []
+        self._thread_ready = thread_ready
+        self._succeed = succeed
+
+    def _response(self) -> dict:
+        if self._succeed:
+            return {"success": True}
+        return {"success": False, "error": "kineto unavailable"}
+
+    def wait_until_scheduler_thread_ready(self, timeout_s: float) -> bool:
+        return self._thread_ready
 
     def start_torch_profiler(self, trace_path_template: str, run_id: str | None):
         self.profiler_calls.append(("start", trace_path_template, run_id))
-        return {"success": True}
+        return self._response()
 
     def stop_torch_profiler(self, run_id: str | None):
         self.profiler_calls.append(("stop", run_id))
-        return {"success": True}
+        return self._response()
+
+
+def _patch_direct_torch_profiler(
+    monkeypatch: pytest.MonkeyPatch, calls: list[tuple]
+) -> None:
+    """Record direct (non-delegated) TorchProfiler singleton access."""
+    monkeypatch.setattr(
+        runtime_mod.TorchProfiler,
+        "start",
+        classmethod(
+            lambda cls, template, run_id=None: calls.append(("start", template, run_id))
+        ),
+    )
+    monkeypatch.setattr(
+        runtime_mod.TorchProfiler,
+        "stop",
+        classmethod(lambda cls, *, run_id=None: calls.append(("stop", run_id))),
+    )
+    monkeypatch.setattr(
+        runtime_mod.TorchProfiler, "is_active", classmethod(lambda cls: bool(calls))
+    )
+    monkeypatch.setattr(
+        runtime_mod.TorchProfiler, "get_active_run_id", classmethod(lambda cls: "run-1")
+    )
+
+
+def _profiler_stage(scheduler, *, name: str, owner: bool, process_has_owner: bool):
+    return Stage(
+        name=name,
+        role="single",
+        get_next=lambda request_id, output: None,
+        gpu_id=None,
+        endpoints={},
+        control_plane=RecordingStageControlPlane(),
+        relay=FakeRelay(),
+        scheduler=scheduler,
+        torch_profiler_owner=owner,
+        torch_profiler_process_has_owner=process_has_owner,
+    )
 
 
 def test_admin_messages_round_trip() -> None:
@@ -543,3 +595,484 @@ def test_stage_rejects_profiler_owner_without_control_capability() -> None:
             scheduler=FakeScheduler(),
             torch_profiler_owner=True,
         )
+
+
+def test_ownerless_process_still_profiles_directly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A process with no owner keeps the pre-existing direct path, so a partial
+    rollout never silently drops that process's Torch trace."""
+    monkeypatch.setenv("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD", "1")
+    direct_calls: list[tuple] = []
+    _patch_direct_torch_profiler(monkeypatch, direct_calls)
+
+    scheduler = ProfilerControlScheduler()
+    stage = _profiler_stage(
+        scheduler, name="vocoder", owner=False, process_has_owner=False
+    )
+
+    stage._on_profiler_start(
+        ProfilerStartMessage(run_id="run-1", trace_path_template="/tmp/{stage}/trace")
+    )
+    stage._on_profiler_stop(ProfilerStopMessage(run_id="run-1"))
+
+    assert direct_calls == [
+        ("start", f"/tmp/vocoder/trace_pid{os.getpid()}", "run-1"),
+        ("stop", "run-1"),
+    ]
+    assert scheduler.profiler_calls == []
+
+
+def test_colocated_sibling_never_touches_the_profiler_singleton(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MOSS-TTS-Local runs ``preprocessing`` and the owning ``tts_engine`` in
+    one process. If the sibling handled the broadcast directly it would create
+    the singleton on the control thread and the owner's start would then no-op
+    on it -- a trace with CUDA activity but no CPU operators, the exact defect
+    this mode exists to fix."""
+    monkeypatch.setenv("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD", "1")
+    direct_calls: list[tuple] = []
+    _patch_direct_torch_profiler(monkeypatch, direct_calls)
+
+    scheduler = ProfilerControlScheduler()
+    sibling = _profiler_stage(
+        scheduler, name="preprocessing", owner=False, process_has_owner=True
+    )
+    owner = _profiler_stage(
+        scheduler, name="tts_engine", owner=True, process_has_owner=True
+    )
+
+    # The sibling is handed the broadcast first: worst-case ordering.
+    msg = ProfilerStartMessage(run_id="run-1", trace_path_template="/tmp/{stage}/trace")
+    sibling._on_profiler_start(msg)
+    owner._on_profiler_start(msg)
+    sibling._on_profiler_stop(ProfilerStopMessage(run_id="run-1"))
+    owner._on_profiler_stop(ProfilerStopMessage(run_id="run-1"))
+
+    assert direct_calls == []
+    assert scheduler.profiler_calls == [
+        ("start", f"/tmp/tts_engine/trace_pid{os.getpid()}", "run-1"),
+        ("stop", "run-1"),
+    ]
+
+
+def test_owner_refuses_to_profile_before_the_scheduler_thread_is_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``Stage.start`` does not wait for the scheduler thread to publish its id,
+    so a start can arrive early. Falling back to a direct start would silently
+    profile on the wrong thread; refusing is the honest outcome."""
+    monkeypatch.setenv("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD", "1")
+    direct_calls: list[tuple] = []
+    _patch_direct_torch_profiler(monkeypatch, direct_calls)
+
+    scheduler = ProfilerControlScheduler(thread_ready=False)
+    owner = _profiler_stage(
+        scheduler, name="tts_engine", owner=True, process_has_owner=True
+    )
+
+    owner._on_profiler_start(
+        ProfilerStartMessage(run_id="run-1", trace_path_template="/tmp/{stage}/trace")
+    )
+
+    assert direct_calls == []
+    assert scheduler.profiler_calls == []
+
+
+def test_profiler_control_failure_does_not_kill_the_stage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Profiler broadcasts are fire-and-forget PUSH with no response channel,
+    and an exception escaping a message handler tears down every stage in the
+    process. A failed profiler start must not cost the serving process."""
+    monkeypatch.setenv("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD", "1")
+    direct_calls: list[tuple] = []
+    _patch_direct_torch_profiler(monkeypatch, direct_calls)
+
+    scheduler = ProfilerControlScheduler(succeed=False)
+    owner = _profiler_stage(
+        scheduler, name="tts_engine", owner=True, process_has_owner=True
+    )
+
+    owner._on_profiler_start(
+        ProfilerStartMessage(run_id="run-1", trace_path_template="/tmp/{stage}/trace")
+    )
+    owner._on_profiler_stop(ProfilerStopMessage(run_id="run-1"))
+
+    assert [name for name, *_ in scheduler.profiler_calls] == ["start", "stop"]
+    assert direct_calls == []
+
+
+def test_scheduler_thread_mode_off_keeps_legacy_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the env flag an owner stage behaves exactly as before the PR."""
+    monkeypatch.delenv("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD", raising=False)
+    direct_calls: list[tuple] = []
+    _patch_direct_torch_profiler(monkeypatch, direct_calls)
+
+    scheduler = ProfilerControlScheduler()
+    owner = _profiler_stage(
+        scheduler, name="tts_engine", owner=True, process_has_owner=True
+    )
+
+    owner._on_profiler_start(
+        ProfilerStartMessage(run_id="run-1", trace_path_template="/tmp/{stage}/trace")
+    )
+    owner._on_profiler_stop(ProfilerStopMessage(run_id="run-1"))
+
+    assert direct_calls == [
+        ("start", f"/tmp/tts_engine/trace_pid{os.getpid()}", "run-1"),
+        ("stop", "run-1"),
+    ]
+    assert scheduler.profiler_calls == []
+
+
+def test_enable_torch_false_never_starts_the_profiler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The event recorder still runs, but no Torch profiler is touched."""
+    monkeypatch.setenv("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD", "1")
+    direct_calls: list[tuple] = []
+    _patch_direct_torch_profiler(monkeypatch, direct_calls)
+
+    scheduler = ProfilerControlScheduler()
+    owner = _profiler_stage(
+        scheduler, name="tts_engine", owner=True, process_has_owner=True
+    )
+
+    owner._on_profiler_start(
+        ProfilerStartMessage(
+            run_id="run-1",
+            trace_path_template="/tmp/{stage}/trace",
+            enable_torch=False,
+        )
+    )
+
+    assert direct_calls == []
+    assert scheduler.profiler_calls == []
+
+
+def test_scheduler_admin_runs_torch_profiler_on_the_scheduler_thread() -> None:
+    """The point of the fix: Kineto CPU callbacks are thread-local, so
+    TorchProfiler.start/stop must execute on the model-execution thread, not
+    on the caller's control-plane thread."""
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+    scheduler = OmniScheduler.__new__(OmniScheduler)
+    scheduler._admin_queue = queue.Queue()
+    scheduler._scheduler_thread_id = None
+    scheduler._running = True
+
+    executed_on: list[tuple[str, int]] = []
+
+    class _RecordingTorchProfiler:
+        @staticmethod
+        def start(template: str, run_id: str | None = None) -> str:
+            executed_on.append(("start", threading.get_ident()))
+            return f"{template}_rank0.trace.json.gz"
+
+        @staticmethod
+        def stop(*, run_id: str | None = None) -> dict:
+            executed_on.append(("stop", threading.get_ident()))
+            return {"trace": "t", "table": None}
+
+    stop_event = threading.Event()
+    ready = threading.Event()
+
+    def _scheduler_loop() -> None:
+        scheduler._scheduler_thread_id = threading.get_ident()
+        ready.set()
+        while not stop_event.is_set():
+            scheduler._process_admin_requests()
+            time.sleep(0.001)
+
+    thread = threading.Thread(target=_scheduler_loop, daemon=True)
+    thread.start()
+    ready.wait(timeout=5.0)
+
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "sglang_omni.profiler.torch_profiler": SimpleNamespace(
+                TorchProfiler=_RecordingTorchProfiler
+            )
+        },
+    ):
+        try:
+            start_response = scheduler.start_torch_profiler("/tmp/trace", "run-1")
+            stop_response = scheduler.stop_torch_profiler("run-1")
+        finally:
+            stop_event.set()
+            thread.join(timeout=5.0)
+
+    assert start_response["success"] is True
+    assert stop_response["success"] is True
+
+    caller_thread_id = threading.get_ident()
+    assert [name for name, _ in executed_on] == ["start", "stop"]
+    for name, thread_id in executed_on:
+        assert thread_id == scheduler._scheduler_thread_id, name
+        assert thread_id != caller_thread_id, name
+
+
+def test_scheduler_admin_profiler_failure_surfaces_to_the_caller() -> None:
+    """Exceptions raised on the scheduler thread come back as admin errors so
+    Stage can turn them into a RuntimeError instead of hanging."""
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+    scheduler = OmniScheduler.__new__(OmniScheduler)
+    scheduler._admin_queue = queue.Queue()
+    scheduler._scheduler_thread_id = None
+    scheduler._running = True
+
+    class _ExplodingTorchProfiler:
+        @staticmethod
+        def start(template: str, run_id: str | None = None) -> str:
+            raise RuntimeError("kineto unavailable")
+
+    stop_event = threading.Event()
+    ready = threading.Event()
+
+    def _scheduler_loop() -> None:
+        scheduler._scheduler_thread_id = threading.get_ident()
+        ready.set()
+        while not stop_event.is_set():
+            scheduler._process_admin_requests()
+            time.sleep(0.001)
+
+    thread = threading.Thread(target=_scheduler_loop, daemon=True)
+    thread.start()
+    ready.wait(timeout=5.0)
+
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "sglang_omni.profiler.torch_profiler": SimpleNamespace(
+                TorchProfiler=_ExplodingTorchProfiler
+            )
+        },
+    ):
+        try:
+            response = scheduler.start_torch_profiler("/tmp/trace", "run-1")
+        finally:
+            stop_event.set()
+            thread.join(timeout=5.0)
+
+    assert response["success"] is False
+    assert "kineto unavailable" in response["error"]
+
+
+def test_scheduler_thread_readiness_reports_when_admin_would_run_inline() -> None:
+    """``_should_enqueue_admin`` silently runs inline until the scheduler thread
+    publishes its id. The profiler owner needs to distinguish those states."""
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+    scheduler = OmniScheduler.__new__(OmniScheduler)
+    scheduler._admin_queue = queue.Queue()
+    scheduler._scheduler_thread_id = None
+    scheduler._running = False
+
+    assert scheduler.wait_until_scheduler_thread_ready(0.05) is False
+
+    scheduler._running = True
+    assert scheduler.wait_until_scheduler_thread_ready(0.05) is False
+
+    def _publish() -> None:
+        time.sleep(0.02)
+        scheduler._scheduler_thread_id = threading.get_ident()
+
+    thread = threading.Thread(target=_publish, daemon=True)
+    thread.start()
+    try:
+        assert scheduler.wait_until_scheduler_thread_ready(5.0) is True
+    finally:
+        thread.join(timeout=5.0)
+
+
+def test_owner_refuses_to_stop_after_the_scheduler_thread_is_gone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stopping inline on the control thread is the same wrong-thread defect as
+    starting there, so a shutting-down scheduler must not be worked around."""
+    monkeypatch.setenv("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD", "1")
+    direct_calls: list[tuple] = []
+    _patch_direct_torch_profiler(monkeypatch, direct_calls)
+
+    scheduler = ProfilerControlScheduler(thread_ready=False)
+    owner = _profiler_stage(
+        scheduler, name="tts_engine", owner=True, process_has_owner=True
+    )
+
+    owner._on_profiler_stop(ProfilerStopMessage(run_id="run-1"))
+
+    assert direct_calls == []
+    assert scheduler.profiler_calls == []
+
+
+def test_profiler_admin_never_runs_inline_after_the_loop_exits() -> None:
+    """``OmniScheduler.start`` clears ``_scheduler_thread_id`` in its ``finally``
+    but leaves ``_running`` set until ``stop`` runs, so an exited scheduler loop
+    leaves a durable window where ``_should_enqueue_admin`` reports inline. A
+    readiness check on the Stage side cannot close it -- the loop can exit
+    between that check and the handoff -- so the profiler path must re-check and
+    fail rather than run TorchProfiler on the caller's thread."""
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+    scheduler = OmniScheduler.__new__(OmniScheduler)
+    scheduler._admin_queue = queue.Queue()
+    # Exactly the post-loop state: id cleared, _running not yet cleared.
+    scheduler._running = True
+    scheduler._scheduler_thread_id = None
+
+    executed_on: list[int] = []
+
+    class _RecordingTorchProfiler:
+        @staticmethod
+        def start(template: str, run_id: str | None = None) -> str:
+            executed_on.append(threading.get_ident())
+            return "trace"
+
+        @staticmethod
+        def stop(*, run_id: str | None = None) -> dict:
+            executed_on.append(threading.get_ident())
+            return {}
+
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "sglang_omni.profiler.torch_profiler": SimpleNamespace(
+                TorchProfiler=_RecordingTorchProfiler
+            )
+        },
+    ):
+        start_response = scheduler.start_torch_profiler("/tmp/trace", "run-1")
+        stop_response = scheduler.stop_torch_profiler("run-1")
+
+    assert start_response["success"] is False
+    assert stop_response["success"] is False
+    # The whole point: nothing ran on this thread.
+    assert executed_on == []
+    assert scheduler._admin_queue.empty()
+
+
+def test_profiler_admin_runs_inline_when_already_on_the_scheduler_thread() -> None:
+    """Being the scheduler thread is the goal state, not a fallback."""
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+    scheduler = OmniScheduler.__new__(OmniScheduler)
+    scheduler._admin_queue = queue.Queue()
+    scheduler._running = True
+    scheduler._scheduler_thread_id = threading.get_ident()
+
+    executed_on: list[int] = []
+
+    class _RecordingTorchProfiler:
+        @staticmethod
+        def start(template: str, run_id: str | None = None) -> str:
+            executed_on.append(threading.get_ident())
+            return "trace"
+
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "sglang_omni.profiler.torch_profiler": SimpleNamespace(
+                TorchProfiler=_RecordingTorchProfiler
+            )
+        },
+    ):
+        response = scheduler.start_torch_profiler("/tmp/trace", "run-1")
+
+    assert response["success"] is True
+    assert executed_on == [threading.get_ident()]
+
+
+def test_expired_profiler_start_is_dropped_when_drained_late() -> None:
+    """``_enqueue_admin`` reports a timeout but leaves the request queued. A
+    scheduler that was busy past the deadline must drop it: the caller was told
+    the start failed and will never issue a stop, so running it late leaves an
+    orphan profiler taxing the serving path."""
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+    scheduler = OmniScheduler.__new__(OmniScheduler)
+    scheduler._admin_queue = queue.Queue()
+    scheduler._running = True
+    # A live scheduler thread that is too busy to drain: forces the enqueue path.
+    scheduler._scheduler_thread_id = threading.get_ident() + 1
+
+    started: list[str] = []
+
+    class _RecordingTorchProfiler:
+        @staticmethod
+        def start(template: str, run_id: str | None = None) -> str:
+            started.append(template)
+            return "trace"
+
+    with mock.patch.object(
+        OmniScheduler, "_enqueue_admin", autospec=True
+    ) as enqueue_admin:
+
+        def _queue_and_time_out(self, action, payload):
+            # Mirror the real body, minus the blocking wait the caller gave up on.
+            queued = dict(payload)
+            queued.pop("_admin_timeout_s", None)
+            self._admin_queue.put((action, queued, queue.Queue(maxsize=1)))
+            return {"success": False, "error": "admin operation timed out"}
+
+        enqueue_admin.side_effect = _queue_and_time_out
+        response = scheduler.start_torch_profiler("/tmp/trace", "run-1")
+
+    assert response["success"] is False
+    assert scheduler._admin_queue.qsize() == 1
+
+    # The scheduler frees up after the deadline and drains what it missed.
+    action, payload, _ = scheduler._admin_queue.get_nowait()
+    payload["_deadline"] = time.monotonic() - 1.0
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "sglang_omni.profiler.torch_profiler": SimpleNamespace(
+                TorchProfiler=_RecordingTorchProfiler
+            )
+        },
+    ):
+        late = scheduler._run_admin_action(action, payload)
+
+    assert late["success"] is False
+    assert "expired" in late["error"]
+    assert started == []
+
+
+def test_live_profiler_request_carries_a_deadline_but_still_runs() -> None:
+    """The deadline must not reject requests that arrive in time."""
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+    scheduler = OmniScheduler.__new__(OmniScheduler)
+    started: list[str] = []
+
+    class _RecordingTorchProfiler:
+        @staticmethod
+        def start(template: str, run_id: str | None = None) -> str:
+            started.append(template)
+            return "trace"
+
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "sglang_omni.profiler.torch_profiler": SimpleNamespace(
+                TorchProfiler=_RecordingTorchProfiler
+            )
+        },
+    ):
+        response = scheduler._run_admin_action(
+            "torch_profiler_start",
+            {
+                "trace_path_template": "/tmp/trace",
+                "run_id": "run-1",
+                "_deadline": time.monotonic() + 30.0,
+            },
+        )
+
+    assert response["success"] is True
+    assert started == ["/tmp/trace"]

--- a/tests/unit_test/pipeline/test_admin_control.py
+++ b/tests/unit_test/pipeline/test_admin_control.py
@@ -623,6 +623,34 @@ def test_ownerless_process_still_profiles_directly(
     assert scheduler.profiler_calls == []
 
 
+def test_ownerless_process_forwards_a_new_run_to_the_profiler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The process-wide singleton decides whether a start is idempotent or
+    replaces an active run. The stage must not hide a different run from it."""
+    monkeypatch.setenv("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD", "1")
+    direct_calls: list[tuple] = []
+    _patch_direct_torch_profiler(monkeypatch, direct_calls)
+
+    scheduler = ProfilerControlScheduler()
+    stage = _profiler_stage(
+        scheduler, name="vocoder", owner=False, process_has_owner=False
+    )
+
+    stage._on_profiler_start(
+        ProfilerStartMessage(run_id="run-1", trace_path_template="/tmp/{stage}/trace")
+    )
+    stage._on_profiler_start(
+        ProfilerStartMessage(run_id="run-2", trace_path_template="/tmp/{stage}/trace")
+    )
+
+    assert direct_calls == [
+        ("start", f"/tmp/vocoder/trace_pid{os.getpid()}", "run-1"),
+        ("start", f"/tmp/vocoder/trace_pid{os.getpid()}", "run-2"),
+    ]
+    assert scheduler.profiler_calls == []
+
+
 def test_colocated_sibling_never_touches_the_profiler_singleton(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_test/pipeline/test_admin_control.py
+++ b/tests/unit_test/pipeline/test_admin_control.py
@@ -8,7 +8,6 @@ import queue
 import sys
 import threading
 import time
-from contextlib import suppress
 from types import SimpleNamespace
 from unittest import mock
 
@@ -102,14 +101,10 @@ async def _release_profiler_lane(stage: Stage) -> None:
     worker are bound to the loop that created them. Production keeps one loop
     for the stage's whole life; tests have to reset between calls.
     """
-    await stage._wait_for_profiler_ops()
-    worker = stage._profiler_op_worker
-    if worker is not None:
-        worker.cancel()
-        with suppress(asyncio.CancelledError):
-            await worker
-    stage._profiler_op_worker = None
+    await stage._shutdown_profiler_ops()
     stage._profiler_op_queue = None
+    stage._profiler_shutdown.clear()
+    stage._profiler_lane_abandoned.clear()
 
 
 def _profile_start(stage: Stage, msg: ProfilerStartMessage) -> None:
@@ -1153,7 +1148,7 @@ def test_live_profiler_request_carries_a_deadline_but_still_runs() -> None:
     assert started == ["/tmp/trace"]
 
 
-def test_profiler_delegation_does_not_stall_submits_and_acks(
+def test_profiler_delegation_does_not_stall_control_message_dispatch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The readiness wait and the admin handoff each block for up to 30s. If a
@@ -1195,7 +1190,7 @@ def test_profiler_delegation_does_not_stall_submits_and_acks(
             )
             handled.append(f"ack-{index}")
 
-        # Submits and acks got through while the delegation was still blocked.
+        # Dispatch kept flowing while the delegation was still blocked.
         assert owner.scheduler.profiler_calls == []
         release.set()
         await asyncio.wait_for(owner._wait_for_profiler_ops(), timeout=5.0)
@@ -1239,3 +1234,79 @@ def test_profiler_operations_run_in_arrival_order(
     asyncio.run(_run())
 
     assert [name for name, *_ in owner.scheduler.profiler_calls] == ["start", "stop"]
+
+
+def test_shutdown_drains_a_queued_profiler_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`/stop_profile` immediately followed by shutdown is an ordinary operator
+    sequence. The queued stop is what exports the trace, so shutdown has to let
+    it run instead of cancelling it away."""
+    monkeypatch.setenv("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD", "1")
+    direct_calls: list[tuple] = []
+    _patch_direct_torch_profiler(monkeypatch, direct_calls)
+
+    scheduler = ProfilerControlScheduler()
+    owner = _profiler_stage(
+        scheduler, name="tts_engine", owner=True, process_has_owner=True
+    )
+
+    async def _run() -> None:
+        owner._on_profiler_stop(ProfilerStopMessage(run_id="run-1"))
+        # No drain here: shutdown lands while the stop is still queued.
+        await owner.stop()
+
+    asyncio.run(_run())
+
+    assert scheduler.profiler_calls == [("stop", "run-1")]
+
+
+def test_shutdown_is_bounded_when_a_profiler_operation_is_stuck(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shutdown must not hang on a scheduler that is already gone, and must not
+    accept new profiler work once it has begun."""
+    monkeypatch.setenv("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD", "1")
+    monkeypatch.setattr(runtime_mod, "_PROFILER_SHUTDOWN_DRAIN_TIMEOUT_S", 0.05)
+    direct_calls: list[tuple] = []
+    _patch_direct_torch_profiler(monkeypatch, direct_calls)
+
+    release = threading.Event()
+
+    class _StuckScheduler(ProfilerControlScheduler):
+        def wait_until_scheduler_thread_ready(self, timeout_s: float) -> bool:
+            release.wait(timeout=5.0)
+            return True
+
+    scheduler = _StuckScheduler()
+    owner = _profiler_stage(
+        scheduler, name="tts_engine", owner=True, process_has_owner=True
+    )
+
+    async def _run() -> float:
+        owner._on_profiler_start(
+            ProfilerStartMessage(
+                run_id="run-1", trace_path_template="/tmp/{stage}/trace"
+            )
+        )
+        await asyncio.sleep(0)  # let the worker reach the stuck call
+        started = time.monotonic()
+        await owner.stop()
+        elapsed = time.monotonic() - started
+
+        # Shutdown has begun: further profiler work is refused outright.
+        owner._on_profiler_stop(ProfilerStopMessage(run_id="run-1"))
+        assert owner._profiler_op_queue is not None
+        assert owner._profiler_op_queue.empty()
+        return elapsed
+
+    try:
+        elapsed = asyncio.run(_run())
+    finally:
+        release.set()
+
+    assert elapsed < 2.0
+    assert direct_calls == []
+    # The executor call outlived shutdown -- Task.cancel cannot reach it -- but
+    # it found the lane abandoned and never reached the scheduler.
+    assert [name for name, *_ in scheduler.profiler_calls] == []

--- a/tests/unit_test/pipeline/test_compile.py
+++ b/tests/unit_test/pipeline/test_compile.py
@@ -13,7 +13,7 @@ from sglang_omni.config.schema import (
 from sglang_omni.pipeline.mp_runner import (
     _build_stage_groups,
     _resolve_same_process_targets,
-    _validate_torch_profiler_owners,
+    _resolve_torch_profiler_ownership,
 )
 from sglang_omni.pipeline.runtime_config import prepare_pipeline_runtime
 from sglang_omni.pipeline.stage_workers import (
@@ -44,9 +44,19 @@ def _profiler_owner_group(*owners: str) -> StageGroup:
     )
 
 
+def _process(name: str, stages: dict[str, bool]) -> StageWorkerProcessSpec:
+    return StageWorkerProcessSpec(
+        process_name=name,
+        stage_specs=[
+            StageLaunchConfig(stage_name=stage_name, torch_profiler_owner=is_owner)
+            for stage_name, is_owner in stages.items()
+        ],
+    )
+
+
 def test_torch_profiler_owner_is_unique_per_process() -> None:
     with pytest.raises(ValueError, match="multiple Torch profiler owners"):
-        _validate_torch_profiler_owners([_profiler_owner_group("a", "b")])
+        _resolve_torch_profiler_ownership([_profiler_owner_group("a", "b")])
 
 
 def test_scheduler_thread_profiling_requires_an_owner(
@@ -55,7 +65,32 @@ def test_scheduler_thread_profiling_requires_an_owner(
     monkeypatch.setenv("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD", "1")
 
     with pytest.raises(ValueError, match="requires at least one stage"):
-        _validate_torch_profiler_owners([_profiler_owner_group()])
+        _resolve_torch_profiler_ownership([_profiler_owner_group()])
+
+
+def test_torch_profiler_ownership_is_stamped_per_process() -> None:
+    """Colocated siblings must learn that their process has an owner, while an
+    ownerless process keeps the direct path. TorchProfiler is a per-process
+    singleton, so this is the flag the Stage decision hangs on."""
+    pipeline = _process("pipeline", {"preprocessing": False, "tts_engine": True})
+    vocoder = _process("vocoder", {"vocoder": False})
+
+    _resolve_torch_profiler_ownership(
+        [StageGroup("pipeline", [pipeline]), StageGroup("vocoder", [vocoder])]
+    )
+
+    stamped = {
+        spec.stage_name: (
+            spec.torch_profiler_owner,
+            spec.torch_profiler_process_has_owner,
+        )
+        for spec in (*pipeline.stage_specs, *vocoder.stage_specs)
+    }
+    assert stamped == {
+        "preprocessing": (False, True),
+        "tts_engine": (True, True),
+        "vocoder": (False, False),
+    }
 
 
 def test_pipeline_schema_keeps_topology_and_validation_contracts() -> None:

--- a/tests/unit_test/pipeline/test_compile.py
+++ b/tests/unit_test/pipeline/test_compile.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+from unittest import mock
+
 import pytest
 
 from sglang_omni.config.schema import (
@@ -584,3 +587,53 @@ def test_mp_runner_keeps_cpu_stage_without_gpu_identity(tmp_path) -> None:
 
     assert group.specs[0].gpu_id is None
     assert "gpu_id" not in group.specs[0].comm_config
+
+
+def test_scheduler_thread_flag_from_stage_env_defaults_requires_an_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The flag can be declared in pipeline/stage env config, which is injected
+    at spawn -- after this validation runs. Reading only the launcher env would
+    let an ownerless pipeline start with the flag silently doing nothing."""
+    monkeypatch.delenv("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD", raising=False)
+    group = StageGroup(
+        "test",
+        [
+            StageWorkerProcessSpec(
+                process_name="pipeline",
+                stage_specs=[
+                    StageLaunchConfig(
+                        stage_name="decode",
+                        env_defaults={"SGLANG_TORCH_PROFILER_SCHEDULER_THREAD": "1"},
+                    )
+                ],
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="requires at least one stage"):
+        _resolve_torch_profiler_ownership([group])
+
+
+def test_launcher_env_off_beats_stage_env_defaults() -> None:
+    """Spawn defaults only apply to keys absent from the launcher env, so an
+    explicit off must not be overridden by config."""
+    group = StageGroup(
+        "test",
+        [
+            StageWorkerProcessSpec(
+                process_name="pipeline",
+                stage_specs=[
+                    StageLaunchConfig(
+                        stage_name="decode",
+                        env_defaults={"SGLANG_TORCH_PROFILER_SCHEDULER_THREAD": "1"},
+                    )
+                ],
+            )
+        ],
+    )
+
+    with mock.patch.dict(
+        os.environ, {"SGLANG_TORCH_PROFILER_SCHEDULER_THREAD": "0"}, clear=False
+    ):
+        _resolve_torch_profiler_ownership([group])

--- a/tests/unit_test/pipeline/test_compile.py
+++ b/tests/unit_test/pipeline/test_compile.py
@@ -13,11 +13,49 @@ from sglang_omni.config.schema import (
 from sglang_omni.pipeline.mp_runner import (
     _build_stage_groups,
     _resolve_same_process_targets,
+    _validate_torch_profiler_owners,
 )
 from sglang_omni.pipeline.runtime_config import prepare_pipeline_runtime
-from sglang_omni.pipeline.stage_workers import get_stage_process_env
+from sglang_omni.pipeline.stage_workers import (
+    StageGroup,
+    StageLaunchConfig,
+    StageWorkerProcessSpec,
+    get_stage_process_env,
+)
 from tests.unit_test.fixtures.pipeline_fakes import FakeMpContext, fake_factory_path
 from tests.unit_test.pipeline.helpers import stage
+
+
+def _profiler_owner_group(*owners: str) -> StageGroup:
+    return StageGroup(
+        "test",
+        [
+            StageWorkerProcessSpec(
+                process_name="shared",
+                stage_specs=[
+                    StageLaunchConfig(
+                        stage_name=name,
+                        torch_profiler_owner=True,
+                    )
+                    for name in owners
+                ],
+            )
+        ],
+    )
+
+
+def test_torch_profiler_owner_is_unique_per_process() -> None:
+    with pytest.raises(ValueError, match="multiple Torch profiler owners"):
+        _validate_torch_profiler_owners([_profiler_owner_group("a", "b")])
+
+
+def test_scheduler_thread_profiling_requires_an_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SGLANG_TORCH_PROFILER_SCHEDULER_THREAD", "1")
+
+    with pytest.raises(ValueError, match="requires at least one stage"):
+        _validate_torch_profiler_owners([_profiler_owner_group()])
 
 
 def test_pipeline_schema_keeps_topology_and_validation_contracts() -> None:

--- a/tests/unit_test/profiler/test_torch_profiler_restart.py
+++ b/tests/unit_test/profiler/test_torch_profiler_restart.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: ``TorchProfiler.start`` used ``rank`` before assigning it.
+
+Before scheduler-thread routing, ``Stage._on_profiler_start`` guarded the
+call with ``not TorchProfiler.is_active()``, so the "profiler already
+active" branch inside ``start`` was unreachable. Routing the lifecycle
+through the scheduler admin queue drops that guard, which made the branch
+live -- and it referenced ``rank`` above ``rank = cls._get_rank()``, raising
+``UnboundLocalError`` for *any* second start while a profiler was running.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sglang_omni.profiler import torch_profiler as torch_profiler_mod
+from sglang_omni.profiler.torch_profiler import TorchProfiler
+
+
+class _FakeProfile:
+    """Stand-in for ``torch.profiler.profile``: records lifecycle calls."""
+
+    instances: list["_FakeProfile"] = []
+
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.started = False
+        self.stopped = False
+        _FakeProfile.instances.append(self)
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def export_chrome_trace(self, path: str) -> None:  # pragma: no cover - unused
+        Path(path).write_text("{}")
+
+
+@pytest.fixture(autouse=True)
+def _fake_torch_profile(monkeypatch: pytest.MonkeyPatch):
+    """Avoid touching the real Kineto profiler and reset singleton state."""
+    _FakeProfile.instances = []
+    monkeypatch.setattr(torch_profiler_mod, "profile", _FakeProfile)
+    yield
+    TorchProfiler._profiler = None
+    TorchProfiler._active_run_id = None
+    TorchProfiler._trace_template = ""
+
+
+def test_start_is_idempotent_for_the_active_run(tmp_path: Path) -> None:
+    """Re-issuing a start for the running run returns the same trace path."""
+    template = str(tmp_path / "trace")
+
+    first = TorchProfiler.start(template, run_id="run-1")
+    second = TorchProfiler.start(template, run_id="run-1")
+
+    assert second == first
+    assert first.endswith("_rank0.trace.json.gz")
+    # The active profiler is reused, not torn down and rebuilt.
+    assert len(_FakeProfile.instances) == 1
+    assert _FakeProfile.instances[0].stopped is False
+    assert TorchProfiler.get_active_run_id() == "run-1"
+
+
+def test_start_restarts_for_a_different_run(tmp_path: Path) -> None:
+    """A start for another run stops the previous profiler and rebuilds."""
+    TorchProfiler.start(str(tmp_path / "trace"), run_id="run-1")
+    TorchProfiler.start(str(tmp_path / "trace"), run_id="run-2")
+
+    assert len(_FakeProfile.instances) == 2
+    assert _FakeProfile.instances[0].stopped is True
+    assert _FakeProfile.instances[1].started is True
+    assert TorchProfiler.get_active_run_id() == "run-2"
+
+
+def test_start_restarts_when_run_id_is_omitted(tmp_path: Path) -> None:
+    """The wildcard start path also resolves rank before using it."""
+    TorchProfiler.start(str(tmp_path / "trace"), run_id="run-1")
+    TorchProfiler.start(str(tmp_path / "trace"))
+
+    assert len(_FakeProfile.instances) == 2
+    assert _FakeProfile.instances[0].stopped is True
+    assert TorchProfiler.get_active_run_id() is None


### PR DESCRIPTION
## Summary

Route the opt-in Torch profiler lifecycle through the model scheduler thread.

Kineto CPU operator callbacks are thread-local. The profiler was started from
the stage asyncio/control-plane thread, while AR model execution runs on a
pre-existing scheduler thread. CUDA activities were recorded, but CPU-side Aten
operators from the AR execution path were absent.

Behavior is unchanged unless `SGLANG_TORCH_PROFILER_SCHEDULER_THREAD=1` is set.

A validation trace captured after routing the lifecycle through the scheduler
thread recorded roughly 494k Aten operator events, against none before.

## Design

`TorchProfiler` is a process-wide singleton, but one OS process hosts several
stages on a single asyncio loop (see `_run_process`). Ownership is therefore a
property of the **process**, not of a stage. `_resolve_torch_profiler_ownership`
computes it per `StageWorkerProcessSpec` and stamps each stage with one of three
modes:

| Mode | When | Behavior |
| --- | --- | --- |
| `scheduler_owner` | stage has `runtime.torch_profiler_owner=true` | drives the singleton via the scheduler admin queue |
| `scheduler_sibling` | colocated with an owner | does not touch the singleton at all |
| `direct` | flag off, or no owner in this process | pre-existing direct start/stop |

The sibling rule matters in practice: MOSS-TTS-Local colocates `preprocessing`
with the owning `tts_engine` in `process="pipeline"`. If a sibling handled the
broadcast first it would create the singleton on the control thread, and the
owner's start would then no-op on it — producing exactly the CPU-operator-less
trace this change exists to fix.

The `direct` fallback keeps a partial rollout safe: a process with no configured
owner still emits its own trace rather than silently emitting none.

## Guarantees

**Never runs on the wrong thread.** Two layers, because one is not enough:

- `Stage.start` spawns the scheduler thread and returns without waiting, so a
  control message can arrive before the thread publishes its id.
  `wait_until_scheduler_thread_ready` absorbs that startup race.
- `OmniScheduler.start` clears `_scheduler_thread_id` in its `finally` but leaves
  `_running` set until `stop` runs, so an exited scheduler loop leaves a durable
  window in which `_should_enqueue_admin` reports "run inline". A readiness check
  on the caller side cannot close this — the loop can exit right after it. The
  profiler therefore bypasses the generic `admin()` inline fallback and uses a
  strict path that **fails** rather than running on the caller's thread.

**Off the message path.** The readiness wait and the admin handoff each block
for up to 30s. Awaiting them from a message handler would keep `Stage.run` from
reaching its next `control_plane.recv()`, parking this stage's submits and acks
behind a profiler request. Handlers return immediately and the work runs on a
serialized worker, so a stop can never overtake the start it belongs to.

**Bounded, and no late execution.** Profiler admin requests use a 30s timeout
instead of the 300s generic default, so a dead scheduler cannot pin a stage's
control thread. The request also carries an absolute deadline: `_enqueue_admin`
reports a timeout but leaves the item queued, so a scheduler that drains it late
drops it instead of leaving an orphan profiler the caller was already told had
failed. Full CPU profiling is expensive enough that an orphan degrades serving.

**Failures do not kill the serving process.** `ProfilerControlClient` broadcasts
start/stop as fire-and-forget PUSH messages with no response channel, and an
exception escaping a stage message handler tears down every stage in that
process. Control failures are logged, not raised — a missing trace must not cost
the serving process. Note that this means a failed start is visible in stage
logs rather than at the HTTP call site; the broadcast API has no way to return
it.

## Changes

- Add `runtime.torch_profiler_owner` to identify the stage owning the
  process-wide `TorchProfiler` singleton; set it on the `tts_engine` stage of
  MOSS-TTS and MOSS-TTS-Local.
- Resolve ownership per process and propagate `torch_profiler_process_has_owner`
  through `StageLaunchConfig` to `Stage`.
- Add scheduler-thread profiler control to `OmniScheduler`, routed through the
  existing admin queue, behind a `SchedulerThreadProfilerControl` capability
  rather than a generic `admin` attribute check.
- Reject multiple profiler owners in one process; reject
  `SGLANG_TORCH_PROFILER_SCHEDULER_THREAD=1` with no owner configured anywhere
  (the flag would be a no-op).
- Fix `TorchProfiler.start` referencing `rank` before `rank = cls._get_rank()`.
  The old `not TorchProfiler.is_active()` guard made that branch unreachable;
  routing through the admin queue made it live, so any second start while a
  profiler was running raised `UnboundLocalError` — both the idempotent return
  and the restart warning. Same-`run_id` start is now genuinely idempotent.

The profiler admin action names remain internal to `OmniScheduler`; they are not
exposed as public administrative protocol operations.

## Testing

Added unit tests covering:

- same-`run_id` start is idempotent; different `run_id` restarts; `run_id=None`
  restarts (all three previously raised `UnboundLocalError`)
- owner delegates; colocated sibling never touches the singleton, including the
  worst-case ordering where the sibling handles the broadcast first
- ownerless process keeps the direct path
- ownership stamping is per process
- `TorchProfiler.start`/`stop` execute on the scheduler thread and not on the
  caller's, asserted on real thread ids through the real admin queue
- scheduler not yet ready, and scheduler exited after the readiness check —
  neither falls back to an inline run
- expired request is dropped when drained late; in-time request still runs
- admin failure surfaces to the caller and does not tear down the stage
- flag off keeps pre-existing behavior; `enable_torch=False` starts nothing
- the flag declared in pipeline/stage `env` config still requires an owner, and
  an explicit off in the launcher env is not overridden by config
- profiler delegation does not stall this stage's submits and acks, and queued
  operations run in arrival order

Also validated on a real MOSS-TTS-Local deployment using an NVIDIA H200.

  - Verified `TorchProfiler.start/stop` ran on the AR scheduler thread, not the stage control thread.
  - Three concurrent real TTS requests completed successfully with non-empty audio.
  - Same-run duplicate start was idempotent.
  - Both the owner process and ownerless vocoder switched from run-1 to run-2 and exported traces under run-2.
  - Owner AR traces contained 194k–333k CPU Aten events from real model execution.
  - Profiler control requests returned in milliseconds without blocking request processing.
  - Immediate stop followed by shutdown exported valid traces from both processes; the worker exited in about 7 seconds.
  - Flag-off direct profiling and `enable_torch: false` event-only recording remain compatible.


## Notes

This is an observability fix only. Full CPU profiling can introduce substantial
overhead and is not intended to be enabled during normal serving.

`_enqueue_admin` has no cancellation for non-profiler admin actions either — the
same late-execution shape applies to `update_weights_from_disk` and friends at
the 300s default. That is pre-existing and out of scope here; the deadline added
in this PR is scoped to the profiler path.
