### PR TITLE
[TTS] Add MOSS-TTS Delay streaming

### DIFF
--- a/sglang_omni/models/moss_tts/__init__.py
+++ b/sglang_omni/models/moss_tts/__init__.py
@@ -6,7 +6,7 @@ from sglang_omni.models.model_capabilities import ModelCapabilities
 CAPABILITIES = ModelCapabilities(
     supports_reference_audio=True,
     supports_batch_vocoder=True,
-    supports_streaming_vocoder=False,
+    supports_streaming_vocoder=True,
     supports_cuda_graph=True,
     supports_torch_compile=False,
 )

--- a/sglang_omni/models/moss_tts/config.py
+++ b/sglang_omni/models/moss_tts/config.py
@@ -71,6 +71,7 @@ class MossTTSPipelineConfig(PipelineConfig):
             factory_args={"dtype": "bfloat16"},
             gpu=0,
             next="vocoder",
+            stream_to=["vocoder"],
         ),
         StageConfig(
             name="vocoder",
@@ -79,6 +80,7 @@ class MossTTSPipelineConfig(PipelineConfig):
             factory_args={"dtype": "float32"},
             gpu=0,
             terminal=True,
+            can_accept_stream_before_payload=True,
         ),
     ]
 

--- a/sglang_omni/models/moss_tts/engine_builder.py
+++ b/sglang_omni/models/moss_tts/engine_builder.py
@@ -50,7 +50,13 @@ class MossTtsEngineBuilder(TtsEngineBuilder):
         return model_runner_mod.MossTTSModelRunner(model_worker, output_proc)
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:
+        self._stream_output_builder = (
+            request_builders.make_moss_tts_stream_output_builder()
+        )
         return request_builders.make_moss_tts_scheduler_adapters(model=model)
+
+    def extra_scheduler_kwargs(self) -> dict[str, Any]:
+        return {"stream_output_builder": self._stream_output_builder}
 
     def make_abort_callback(self) -> Any | None:
         return request_builders.cleanup_prepared_moss_tts_request

--- a/sglang_omni/models/moss_tts/payload_types.py
+++ b/sglang_omni/models/moss_tts/payload_types.py
@@ -26,6 +26,14 @@ def moss_tts_special_token_defaults(
     )
 
 
+def resolve_moss_audio_pad_code(config: Any) -> int:
+    value = getattr(config, "audio_pad_code", None)
+    if value is not None:
+        return int(value)
+    audio_vocab_size = int(getattr(config, "audio_vocab_size", 1024) or 1024)
+    return dict(moss_tts_special_token_defaults(audio_vocab_size))["audio_pad_code"]
+
+
 @dataclass
 class MossTTSState(DeclarativeStateBase):
     """Per-request state for MOSS-TTS Delay generation."""

--- a/sglang_omni/models/moss_tts/request_builders.py
+++ b/sglang_omni/models/moss_tts/request_builders.py
@@ -15,10 +15,17 @@ import torch
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.sampling.sampling_params import SamplingParams
 
-from sglang_omni.models.moss_tts.payload_types import MossTTSState
+from sglang_omni.models.moss_tts.payload_types import (
+    MossTTSState,
+    resolve_moss_audio_pad_code,
+)
 from sglang_omni.proto import StagePayload
 from sglang_omni.sampling.seed import derive_sampling_seed, new_random_sampling_seed
+from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.prepared_request_queue import PreparedRequestQueue
+from sglang_omni.scheduling.streaming_vocoder import (
+    INITIAL_CODEC_CHUNK_FRAMES_PARAM,
+)
 from sglang_omni.scheduling.types import ARRequestData
 from sglang_omni.utils.audio_payload import audio_data_uri_from_reference
 
@@ -79,6 +86,11 @@ class MossTTSSGLangRequestData(ARRequestData):
     prompt_rows: torch.Tensor | None = None
     assistant_prefix_rows: torch.Tensor | None = None
     output_rows: list[torch.Tensor] = field(default_factory=list)
+    stream_audio_active: bool = False
+    stream_audio_ended: bool = False
+    stream_prefix_scanned: bool = False
+    stream_output_row_count: int = 0
+    stream_row_count: int = 0
     pending_feedback_queue: Any = field(default_factory=collections.deque)
     text_temperature: float = 1.5
     text_top_p: float = 1.0
@@ -525,6 +537,127 @@ def _resolve_audio_payload_bounds(
     if end <= start or end <= start + n_vq:
         return None
     return start, end
+
+
+def _moss_stream_metadata(
+    data: MossTTSSGLangRequestData,
+    *,
+    n_vq: int,
+) -> dict[str, Any]:
+    config = data.model_config
+    metadata: dict[str, Any] = {
+        "modality": "audio_codes",
+        "stream": True,
+        "n_vq": int(n_vq),
+        "audio_pad_code": resolve_moss_audio_pad_code(config),
+        "sample_rate": int(
+            data.state.sample_rate or getattr(config, "sampling_rate", 0) or 24000
+        ),
+    }
+    params = getattr(getattr(data.stage_payload, "request", None), "params", None)
+    if (
+        isinstance(params, dict)
+        and params.get(INITIAL_CODEC_CHUNK_FRAMES_PARAM) is not None
+    ):
+        metadata[INITIAL_CODEC_CHUNK_FRAMES_PARAM] = params[
+            INITIAL_CODEC_CHUNK_FRAMES_PARAM
+        ]
+    return metadata
+
+
+def _collect_moss_stream_rows(
+    data: MossTTSSGLangRequestData,
+    req_output: Any,
+) -> list[torch.Tensor]:
+    config = data.model_config
+    rows: list[torch.Tensor] = []
+
+    if not data.stream_prefix_scanned:
+        prefix = data.assistant_prefix_rows
+        if isinstance(prefix, torch.Tensor) and prefix.ndim == 2:
+            for row in prefix.unbind(0):
+                token = int(row[0].item())
+                if token == int(config.audio_start_token_id):
+                    data.stream_audio_active = True
+                    data.stream_audio_ended = False
+                    continue
+                if token == int(config.audio_end_token_id):
+                    data.stream_audio_active = False
+                    data.stream_audio_ended = True
+                    continue
+                if not data.stream_audio_active and token == int(
+                    config.audio_assistant_gen_slot_token_id
+                ):
+                    data.stream_audio_active = True
+                if data.stream_audio_active and not data.stream_audio_ended:
+                    rows.append(row[1:].detach().clone())
+        data.stream_prefix_scanned = True
+
+    output_rows = data.output_rows
+    start = min(int(data.stream_output_row_count), len(output_rows))
+    for index in range(start, len(output_rows)):
+        row = output_rows[index]
+        token = (
+            int(req_output.data)
+            if index == len(output_rows) - 1 and req_output.data is not None
+            else int(row[0].item())
+        )
+        if token == int(config.audio_start_token_id):
+            data.stream_audio_active = True
+            data.stream_audio_ended = False
+            continue
+        if token == int(config.audio_end_token_id):
+            data.stream_audio_active = False
+            data.stream_audio_ended = True
+            continue
+        if not data.stream_audio_active and token == int(
+            config.audio_assistant_gen_slot_token_id
+        ):
+            data.stream_audio_active = True
+        if data.stream_audio_active and not data.stream_audio_ended:
+            rows.append(row[1:].detach().clone())
+    data.stream_output_row_count = len(output_rows)
+    return rows
+
+
+def make_moss_tts_stream_output_builder():
+    """Build incremental delayed-code chunks for streaming requests."""
+
+    def stream_output_builder(
+        request_id: str,
+        data: MossTTSSGLangRequestData,
+        req_output: Any,
+    ) -> list[OutgoingMessage]:
+        params = getattr(getattr(data.stage_payload, "request", None), "params", None)
+        if not isinstance(params, dict) or not bool(params.get("stream", False)):
+            return []
+        req = data.req
+        if req is not None and int(getattr(req, "inflight_middle_chunks", 0) or 0):
+            return []
+
+        rows = _collect_moss_stream_rows(data, req_output)
+        if not rows:
+            return []
+        n_vq = int(rows[0].shape[0])
+        if n_vq <= 0 or any(int(row.shape[0]) != n_vq for row in rows):
+            raise RuntimeError("MOSS-TTS stream rows have inconsistent codebook widths")
+
+        row_index = int(data.stream_row_count)
+        data.stream_row_count += len(rows)
+        chunk = rows[0] if len(rows) == 1 else torch.stack(rows, dim=0)
+        metadata = _moss_stream_metadata(data, n_vq=n_vq)
+        metadata["row_index"] = row_index
+        return [
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                target="vocoder",
+                data=chunk,
+                metadata=metadata,
+            )
+        ]
+
+    return stream_output_builder
 
 
 def _initialize_generation_state(

--- a/sglang_omni/models/moss_tts/request_builders.py
+++ b/sglang_omni/models/moss_tts/request_builders.py
@@ -23,9 +23,7 @@ from sglang_omni.proto import StagePayload
 from sglang_omni.sampling.seed import derive_sampling_seed, new_random_sampling_seed
 from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.prepared_request_queue import PreparedRequestQueue
-from sglang_omni.scheduling.streaming_vocoder import (
-    INITIAL_CODEC_CHUNK_FRAMES_PARAM,
-)
+from sglang_omni.scheduling.streaming_vocoder import INITIAL_CODEC_CHUNK_FRAMES_PARAM
 from sglang_omni.scheduling.types import ARRequestData
 from sglang_omni.utils.audio_payload import audio_data_uri_from_reference
 

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -31,9 +31,7 @@ from sglang_omni.models.moss_tts.request_builders import (
     preprocess_moss_tts_payload,
     set_moss_tts_preprocessing_context,
 )
-from sglang_omni.models.moss_tts.streaming_vocoder import (
-    MossStreamingVocoderScheduler,
-)
+from sglang_omni.models.moss_tts.streaming_vocoder import MossStreamingVocoderScheduler
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.pipeline_state import build_usage
 from sglang_omni.scheduling.pipeline_state import load_state as _load_pipeline_state

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -24,11 +24,15 @@ from sglang_omni.models.moss_tts.hf_loading import (
 from sglang_omni.models.moss_tts.payload_types import (
     MossTTSState,
     moss_tts_special_token_defaults,
+    resolve_moss_audio_pad_code,
 )
 from sglang_omni.models.moss_tts.request_builders import (
     cleanup_prepared_moss_tts_request,
     preprocess_moss_tts_payload,
     set_moss_tts_preprocessing_context,
+)
+from sglang_omni.models.moss_tts.streaming_vocoder import (
+    MossStreamingVocoderScheduler,
 )
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.pipeline_state import build_usage
@@ -233,12 +237,8 @@ class _MossTTSVocoder(BatchVocoderBase):
         delayed_codes: torch.Tensor,
     ) -> tuple[torch.Tensor, int]:
         delayed_codes = delayed_codes.to(device=self._device, dtype=torch.long)
-        audio_pad_code = int(
-            getattr(
-                getattr(self._processor, "model_config", None),
-                "audio_pad_code",
-                1024,
-            )
+        audio_pad_code = resolve_moss_audio_pad_code(
+            getattr(self._processor, "model_config", None)
         )
         segments = split_moss_audio_segments(
             delayed_codes,
@@ -298,7 +298,12 @@ def create_vocoder_executor(
     codec_model_path: str | None = None,
     max_batch_size: int = 8,
     max_batch_wait_ms: int = 2,
-) -> SimpleScheduler:
+    stream_stride: int = 8,
+    stream_followup_stride: int = 8,
+    stream_overlap_tokens: int = 8,
+    stream_holdback_tokens: int = 1,
+    initial_chunk_frames: int = 0,
+) -> MossStreamingVocoderScheduler:
     if gpu_id is not None:
         device = f"cuda:{gpu_id}"
     processor = _load_moss_processor(model_path)
@@ -308,7 +313,14 @@ def create_vocoder_executor(
         dtype=dtype,
     )
 
-    return _MossTTSVocoder(processor, audio_tokenizer, device).build_scheduler(
+    vocoder = _MossTTSVocoder(processor, audio_tokenizer, device)
+    return MossStreamingVocoderScheduler(
+        vocoder,
+        stream_stride=stream_stride,
+        stream_followup_stride=stream_followup_stride,
+        stream_overlap_tokens=stream_overlap_tokens,
+        stream_holdback_tokens=stream_holdback_tokens,
+        initial_chunk_frames=initial_chunk_frames,
         max_batch_size=max_batch_size,
         max_batch_wait_ms=max_batch_wait_ms,
     )

--- a/sglang_omni/models/moss_tts/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts/streaming_vocoder.py
@@ -1,0 +1,439 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Streaming vocoder scheduler for MOSS-TTS Delay."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+import torch
+
+from sglang_omni.models.moss_tts.payload_types import (
+    MossTTSState,
+    resolve_moss_audio_pad_code,
+)
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.pipeline_state import build_usage
+from sglang_omni.scheduling.streaming_vocoder import (
+    INITIAL_CODEC_CHUNK_FRAMES_PARAM,
+    StreamingVocoderBase,
+    resolve_initial_codec_chunk_frames,
+)
+
+
+@dataclass
+class _MossSegmentState:
+    frames: list[torch.Tensor] = field(default_factory=list)
+    emitted_frames: int = 0
+    closed: bool = False
+    tail_emitted: bool = False
+
+
+@dataclass
+class _MossStreamState:
+    delay_window: deque[torch.Tensor] = field(default_factory=deque)
+    pending_raw_frames: deque[torch.Tensor] = field(default_factory=deque)
+    segments: list[_MossSegmentState] = field(default_factory=list)
+    active_segment: int | None = None
+    delayed_count: int = 0
+    next_decode_rows: int = 0
+    n_vq: int | None = None
+    audio_pad_code: int | None = None
+    sample_rate: int = 24000
+    initial_codec_chunk_frames: int = 0
+    samples_per_frame: int | None = None
+
+
+class MossStreamingVocoderScheduler(StreamingVocoderBase[_MossStreamState, None]):
+    """Incrementally reverse MOSS delay rows and decode overlap windows."""
+
+    def __init__(
+        self,
+        vocoder: Any,
+        *,
+        stream_stride: int = 8,
+        stream_followup_stride: int = 8,
+        stream_overlap_tokens: int = 8,
+        stream_holdback_tokens: int = 1,
+        initial_chunk_frames: int = 0,
+        max_batch_size: int = 8,
+        max_batch_wait_ms: int = 2,
+    ) -> None:
+        if stream_stride <= 0 or stream_followup_stride <= 0:
+            raise ValueError("stream strides must be > 0")
+        if stream_overlap_tokens < 0 or stream_holdback_tokens < 0:
+            raise ValueError("stream overlap and holdback must be >= 0")
+
+        self._vocoder = vocoder
+        self._audio_tokenizer = vocoder._audio_tokenizer
+        self._stream_stride = int(stream_stride)
+        self._stream_followup_stride = int(stream_followup_stride)
+        self._stream_overlap_tokens = int(stream_overlap_tokens)
+        self._stream_holdback_tokens = int(stream_holdback_tokens)
+        self._default_initial_chunk_frames = max(0, int(initial_chunk_frames))
+        self._default_n_vq = int(
+            getattr(getattr(vocoder._processor, "model_config", None), "n_vq", 0) or 0
+        )
+        self._default_audio_pad_code = resolve_moss_audio_pad_code(
+            getattr(vocoder._processor, "model_config", None)
+        )
+        sample_rate = int(self._audio_tokenizer.sample_rate)
+        self._default_samples_per_frame = self._resolve_samples_per_frame(
+            self._audio_tokenizer, sample_rate
+        )
+
+        super().__init__(
+            self._vocode_payload,
+            batch_compute_fn=self._vocode_payloads,
+            sample_rate=sample_rate,
+            stream_source_hint="MOSS-TTS",
+            max_batch_size=max_batch_size,
+            max_batch_wait_ms=max_batch_wait_ms,
+        )
+
+    def create_stream_state(self, request_id: str) -> _MossStreamState:
+        del request_id
+        return _MossStreamState(
+            n_vq=self._default_n_vq or None,
+            audio_pad_code=self._default_audio_pad_code,
+            sample_rate=self._sample_rate,
+            samples_per_frame=self._default_samples_per_frame,
+        )
+
+    def latch_stream_contract(
+        self,
+        request_id: str,
+        state: _MossStreamState,
+        source: StagePayload | Mapping[str, Any],
+        *,
+        origin: str,
+    ) -> None:
+        if origin == "payload":
+            payload = source
+            final_state = MossTTSState.from_dict(payload.data)
+            delayed = final_state.delayed_audio_codes
+            n_vq = state.n_vq
+            if delayed is not None:
+                delayed_tensor = torch.as_tensor(delayed)
+                if delayed_tensor.ndim == 2 and int(delayed_tensor.shape[1]) > 0:
+                    n_vq = int(delayed_tensor.shape[1])
+            self._latch_contract_values(
+                request_id,
+                state,
+                n_vq=n_vq,
+                audio_pad_code=state.audio_pad_code,
+                sample_rate=final_state.sample_rate or state.sample_rate,
+                source=origin,
+            )
+            params = (
+                payload.request.params
+                if isinstance(payload.request.params, dict)
+                else None
+            )
+            self._latch_initial_chunk_frames(state, params)
+            return
+
+        metadata: Mapping[str, Any] = source
+        self._latch_contract_values(
+            request_id,
+            state,
+            n_vq=metadata.get("n_vq", state.n_vq),
+            audio_pad_code=metadata.get("audio_pad_code", state.audio_pad_code),
+            sample_rate=metadata.get("sample_rate", state.sample_rate),
+            source=origin,
+        )
+        self._latch_initial_chunk_frames(state, metadata)
+
+    def validate_chunk(
+        self,
+        request_id: str,
+        state: _MossStreamState,
+        codes: torch.Tensor,
+    ) -> torch.Tensor:
+        rows = codes.to(dtype=torch.long)
+        if rows.ndim == 1:
+            rows = rows.unsqueeze(0)
+        elif rows.ndim != 2:
+            raise ValueError(
+                f"MOSS-TTS stream chunk for {request_id!r} must be [N] or "
+                f"[T, N], got {tuple(rows.shape)}"
+            )
+        n_vq, _ = self._require_contract(state, request_id)
+        if int(rows.shape[1]) != n_vq:
+            raise ValueError(
+                f"MOSS-TTS stream chunk has {int(rows.shape[1])} codebooks, "
+                f"expected {n_vq}"
+            )
+        return rows
+
+    def ingest(
+        self,
+        request_id: str,
+        state: _MossStreamState,
+        codes: torch.Tensor,
+    ) -> None:
+        del request_id
+        n_vq, _ = self._require_contract(state, "<stream>")
+        for row in codes.detach().to(device="cpu", dtype=torch.long).unbind(0):
+            state.delay_window.append(row)
+            state.delayed_count += 1
+            if len(state.delay_window) < n_vq:
+                continue
+            raw_frame = torch.stack(
+                [state.delay_window[channel][channel] for channel in range(n_vq)]
+            )
+            state.pending_raw_frames.append(raw_frame)
+            state.delay_window.popleft()
+
+    def decode_delta(
+        self,
+        request_id: str,
+        state: _MossStreamState,
+        *,
+        is_final: bool,
+    ) -> torch.Tensor | None:
+        n_vq, audio_pad_code = self._require_contract(state, request_id)
+        next_decode_rows = state.next_decode_rows or self._first_decode_rows(
+            state, n_vq
+        )
+        if not is_final and state.delayed_count < next_decode_rows:
+            state.next_decode_rows = next_decode_rows
+            return None
+
+        pending_count = len(state.pending_raw_frames)
+        process_count = (
+            pending_count
+            if is_final
+            else max(0, pending_count - self._stream_holdback_tokens)
+        )
+        for _ in range(process_count):
+            self._ingest_raw_frame(
+                state,
+                state.pending_raw_frames.popleft(),
+                audio_pad_code=audio_pad_code,
+            )
+        if is_final:
+            self._close_active_segment(state)
+
+        chunks: list[torch.Tensor] = []
+        for segment in state.segments:
+            chunk = self._decode_segment_delta(
+                state,
+                segment,
+                flush_tail=bool(segment.closed or is_final),
+            )
+            if chunk is not None:
+                chunks.append(chunk)
+
+        if chunks:
+            state.next_decode_rows = state.delayed_count + self._stream_followup_stride
+            return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+        if not is_final:
+            if len(state.pending_raw_frames) <= self._stream_holdback_tokens:
+                state.next_decode_rows = max(
+                    state.delayed_count + 1,
+                    n_vq + self._stream_holdback_tokens,
+                )
+            else:
+                state.next_decode_rows = (
+                    state.delayed_count + self._stream_followup_stride
+                )
+        return None
+
+    def fallback_full_decode(
+        self,
+        request_id: str,
+        payload: StagePayload,
+        state: _MossStreamState,
+    ) -> torch.Tensor | None:
+        del request_id, state
+        final_state, delayed_codes = self._vocoder.prepare_item(payload)
+        waveform, _ = self._vocoder._decode_audio(final_state, delayed_codes)
+        return waveform
+
+    def final_result_data(
+        self,
+        request_id: str,
+        payload: StagePayload,
+        state: _MossStreamState,
+    ) -> dict[str, Any]:
+        del request_id
+        final_state = MossTTSState.from_dict(payload.data)
+        final_state.delayed_audio_codes = None
+        final_state.sample_rate = int(state.sample_rate or self._sample_rate)
+        data = final_state.to_dict()
+        data["modality"] = "audio"
+        data["sample_rate"] = final_state.sample_rate
+        usage = build_usage(final_state)
+        if usage is not None:
+            data["usage"] = usage
+        return data
+
+    async def _vocode_payload(self, payload: StagePayload) -> StagePayload:
+        return (await self._vocode_payloads([payload]))[0]
+
+    async def _vocode_payloads(
+        self, payloads: list[StagePayload]
+    ) -> list[StagePayload]:
+        items = [self._vocoder.prepare_item(payload) for payload in payloads]
+        results = await self._vocoder.decode_batch(items)
+        if len(results) != len(items):
+            raise RuntimeError(
+                f"MOSS-TTS vocoder returned {len(results)} results for "
+                f"{len(items)} requests"
+            )
+        return [
+            self._vocoder.store_result(payload, item[0], waveform, sample_rate)
+            for payload, item, (waveform, sample_rate) in zip(payloads, items, results)
+        ]
+
+    def _decode_segment_delta(
+        self,
+        state: _MossStreamState,
+        segment: _MossSegmentState,
+        *,
+        flush_tail: bool,
+    ) -> torch.Tensor | None:
+        total_frames = len(segment.frames)
+        emitted_frames = int(segment.emitted_frames)
+        if total_frames < emitted_frames:
+            raise RuntimeError("MOSS-TTS streaming segment cursor moved backwards")
+        if total_frames == emitted_frames and (not flush_tail or segment.tail_emitted):
+            return None
+
+        window_start = max(0, emitted_frames - self._stream_overlap_tokens)
+        window = torch.stack(segment.frames[window_start:], dim=0)
+        decoded = self._audio_tokenizer.decode_codes([window])
+        if not decoded:
+            return None
+        audio = torch.as_tensor(decoded[0]).detach().reshape(-1).to(torch.float32)
+        decoded_frames = total_frames - window_start
+        samples_per_frame = state.samples_per_frame or max(
+            int(audio.numel()) // max(decoded_frames, 1), 1
+        )
+        state.samples_per_frame = int(samples_per_frame)
+        trim_frames = emitted_frames - window_start
+        trim_samples = min(trim_frames * samples_per_frame, int(audio.numel()))
+        if flush_tail:
+            delta = audio[trim_samples:].contiguous()
+            segment.tail_emitted = True
+        else:
+            new_frames = total_frames - emitted_frames
+            emit_samples = new_frames * samples_per_frame
+            delta = audio[trim_samples : trim_samples + emit_samples].contiguous()
+        segment.emitted_frames = total_frames
+        return delta if delta.numel() else None
+
+    @staticmethod
+    def _ingest_raw_frame(
+        state: _MossStreamState,
+        frame: torch.Tensor,
+        *,
+        audio_pad_code: int,
+    ) -> None:
+        is_pad = bool(torch.all(frame == int(audio_pad_code)))
+        is_complete = bool(torch.all((frame >= 0) & (frame < int(audio_pad_code))))
+        if is_pad or not is_complete:
+            MossStreamingVocoderScheduler._close_active_segment(state)
+            return
+        if state.active_segment is None:
+            state.segments.append(_MossSegmentState())
+            state.active_segment = len(state.segments) - 1
+        state.segments[state.active_segment].frames.append(frame)
+
+    @staticmethod
+    def _close_active_segment(state: _MossStreamState) -> None:
+        if state.active_segment is None:
+            return
+        state.segments[state.active_segment].closed = True
+        state.active_segment = None
+
+    def _first_decode_rows(self, state: _MossStreamState, n_vq: int) -> int:
+        initial_frames = int(state.initial_codec_chunk_frames)
+        if initial_frames > 0:
+            return n_vq - 1 + initial_frames + self._stream_holdback_tokens
+        return max(n_vq, self._stream_stride)
+
+    def _latch_initial_chunk_frames(
+        self,
+        state: _MossStreamState,
+        values: Mapping[str, Any] | None,
+    ) -> None:
+        self._require_contract(state, "<stream>")
+        steady_frames = self._stream_followup_stride
+        state.initial_codec_chunk_frames = resolve_initial_codec_chunk_frames(
+            values,
+            steady_chunk_frames=steady_frames,
+            default_frames=self._default_initial_chunk_frames,
+        )
+
+    @staticmethod
+    def _latch_contract_values(
+        request_id: str,
+        state: _MossStreamState,
+        *,
+        n_vq: Any,
+        audio_pad_code: Any,
+        sample_rate: Any,
+        source: str,
+    ) -> None:
+        try:
+            n_vq_i = int(n_vq)
+            audio_pad_code_i = int(audio_pad_code)
+            sample_rate_i = int(sample_rate)
+        except (TypeError, ValueError) as exc:
+            raise TypeError(
+                f"MOSS-TTS {source} for {request_id!r} has invalid codec metadata"
+            ) from exc
+        if n_vq_i <= 0 or audio_pad_code_i <= 0 or sample_rate_i <= 0:
+            raise ValueError(
+                f"MOSS-TTS {source} for {request_id!r} has invalid codec metadata"
+            )
+        for name, value in (
+            ("n_vq", n_vq_i),
+            ("audio_pad_code", audio_pad_code_i),
+            ("sample_rate", sample_rate_i),
+        ):
+            previous = getattr(state, name)
+            if previous is not None and int(previous) != value:
+                raise ValueError(
+                    f"MOSS-TTS stream {name} changed for {request_id!r}: "
+                    f"{previous} -> {value}"
+                )
+            setattr(state, name, value)
+
+    @staticmethod
+    def _require_contract(
+        state: _MossStreamState,
+        request_id: str,
+    ) -> tuple[int, int]:
+        if state.n_vq is None or state.audio_pad_code is None:
+            raise RuntimeError(
+                f"MOSS-TTS stream contract for {request_id!r} is incomplete"
+            )
+        return int(state.n_vq), int(state.audio_pad_code)
+
+    @staticmethod
+    def _resolve_samples_per_frame(
+        audio_tokenizer: Any,
+        sample_rate: int,
+    ) -> int | None:
+        config = getattr(getattr(audio_tokenizer, "model", None), "config", None)
+        for attr in (
+            "downsample_rate",
+            "samples_per_frame",
+            "frame_length",
+            "hop_length",
+        ):
+            value = getattr(config, attr, None)
+            if value and int(value) > 0:
+                return int(value)
+        frame_rate = getattr(config, "frame_rate", None)
+        if frame_rate and float(frame_rate) > 0:
+            return max(int(round(sample_rate / float(frame_rate))), 1)
+        return None
+
+
+__all__ = ["MossStreamingVocoderScheduler"]

--- a/sglang_omni/models/moss_tts/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts/streaming_vocoder.py
@@ -61,8 +61,10 @@ class MossStreamingVocoderScheduler(StreamingVocoderBase[_MossStreamState, None]
     ) -> None:
         if stream_stride <= 0 or stream_followup_stride <= 0:
             raise ValueError("stream strides must be > 0")
-        if stream_overlap_tokens < 0 or stream_holdback_tokens < 0:
-            raise ValueError("stream overlap and holdback must be >= 0")
+        if stream_overlap_tokens <= 0:
+            raise ValueError("stream overlap must be > 0")
+        if stream_holdback_tokens < 0:
+            raise ValueError("stream holdback must be >= 0")
 
         self._vocoder = vocoder
         self._audio_tokenizer = vocoder._audio_tokenizer

--- a/sglang_omni/models/moss_tts/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts/streaming_vocoder.py
@@ -16,7 +16,6 @@ from sglang_omni.models.moss_tts.payload_types import (
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.pipeline_state import build_usage
 from sglang_omni.scheduling.streaming_vocoder import (
-    INITIAL_CODEC_CHUNK_FRAMES_PARAM,
     StreamingVocoderBase,
     resolve_initial_codec_chunk_frames,
 )

--- a/tests/README.md
+++ b/tests/README.md
@@ -117,7 +117,8 @@ tests/
     │   ├── test_pipeline.py
     │   └── test_request_builders.py
     ├── moss_tts/
-    │   └── test_pipeline.py
+    │   ├── test_pipeline.py
+    │   └── test_streaming_vocoder.py
     ├── moss_tts_local/
     │   ├── test_pipeline.py
     │   ├── test_radix_hash.py
@@ -499,7 +500,9 @@ that happened to contain an older version of the test.
   - OmniScheduler-backed AR/vocoder stage factory wiring
   - request mapping for `ref_audio`, `references`, and `token_count`
   - preprocessing handoff and abort cleanup behavior
-  - delay-pattern runner, codec splitting, and seeded sampling contracts.
+  - delay-pattern runner, codec splitting, and seeded sampling contracts
+  - incremental delay-row emission, bounded overlap decode parity, early-done
+    final-tail handling, and streaming abort cleanup.
 
 - `unit_test/moss_tts_local/`: MOSS-TTS Local unit tests:
   - pipeline config, request builders, and scheduler adapter contracts

--- a/tests/unit_test/models/test_model_capabilities.py
+++ b/tests/unit_test/models/test_model_capabilities.py
@@ -40,7 +40,7 @@ EXPECTED_TTS_CAPABILITIES = {
     "MossTTSDelayModel": ModelCapabilities(
         supports_reference_audio=True,
         supports_batch_vocoder=True,
-        supports_streaming_vocoder=False,
+        supports_streaming_vocoder=True,
         supports_cuda_graph=True,
         supports_torch_compile=False,
     ),

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -112,6 +112,10 @@ def test_moss_tts_config_and_registry_contracts() -> None:
     }
     assert {stage.process for stage in config.stages} == {"pipeline"}
     assert config.supports_uploaded_voice_references() is True
+    tts_engine = next(stage for stage in config.stages if stage.name == "tts_engine")
+    vocoder = next(stage for stage in config.stages if stage.name == "vocoder")
+    assert tts_engine.stream_to == ["vocoder"]
+    assert vocoder.can_accept_stream_before_payload is True
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("MossTTSDelayModel")
         is MossTTSPipelineConfig

--- a/tests/unit_test/moss_tts/test_streaming_vocoder.py
+++ b/tests/unit_test/moss_tts/test_streaming_vocoder.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import queue
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+from sglang_omni.models.moss_tts.payload_types import MossTTSState
+from sglang_omni.models.moss_tts.request_builders import (
+    MossTTSSGLangRequestData,
+    make_moss_tts_stream_output_builder,
+)
+from sglang_omni.models.moss_tts.stages import _MossTTSVocoder
+from sglang_omni.models.moss_tts.streaming_vocoder import (
+    MossStreamingVocoderScheduler,
+)
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
+from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.scheduling.types import RequestOutput
+
+
+class _FakeAudioTokenizer:
+    sample_rate = 24000
+
+    class _Model:
+        class config:
+            hop_length = 4
+
+    def __init__(self) -> None:
+        self.model = self._Model()
+        self.decode_inputs: list[torch.Tensor] = []
+
+    def decode_codes(self, segments: list[torch.Tensor]) -> list[torch.Tensor]:
+        decoded = []
+        offsets = torch.arange(4, dtype=torch.float32) / 10.0
+        for segment in segments:
+            self.decode_inputs.append(segment.detach().clone())
+            frames = [row.sum().float().repeat(4) + offsets for row in segment]
+            body = torch.cat(frames) if frames else torch.empty(0)
+            tail = torch.tensor([10000.0, 10001.0])
+            decoded.append(torch.cat([body, tail]))
+        return decoded
+
+
+def _make_scheduler(
+    *,
+    stream_stride: int = 3,
+    stream_followup_stride: int = 2,
+    stream_overlap_tokens: int = 1,
+    stream_holdback_tokens: int = 0,
+) -> tuple[MossStreamingVocoderScheduler, _FakeAudioTokenizer, _MossTTSVocoder]:
+    processor = SimpleNamespace(
+        model_config=SimpleNamespace(
+            n_vq=3,
+            audio_pad_code=99,
+            sampling_rate=24000,
+        )
+    )
+    tokenizer = _FakeAudioTokenizer()
+    vocoder = _MossTTSVocoder(processor, tokenizer, "cpu")
+    scheduler = MossStreamingVocoderScheduler(
+        vocoder,
+        stream_stride=stream_stride,
+        stream_followup_stride=stream_followup_stride,
+        stream_overlap_tokens=stream_overlap_tokens,
+        stream_holdback_tokens=stream_holdback_tokens,
+    )
+    return scheduler, tokenizer, vocoder
+
+
+def _apply_delay_pattern(raw_codes: torch.Tensor, pad_code: int = 99) -> torch.Tensor:
+    frames, n_vq = raw_codes.shape
+    delayed = torch.full(
+        (frames + n_vq - 1, n_vq),
+        int(pad_code),
+        dtype=torch.long,
+    )
+    for channel in range(n_vq):
+        delayed[channel : channel + frames, channel] = raw_codes[:, channel]
+    return delayed
+
+
+def _payload(request_id: str, delayed: torch.Tensor) -> StagePayload:
+    state = MossTTSState(
+        delayed_audio_codes=delayed,
+        prompt_tokens=2,
+        completion_tokens=int(delayed.shape[0]),
+    )
+    return StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs="hello", params={"stream": True}),
+        data=state.to_dict(),
+    )
+
+
+def _item(data: torch.Tensor, chunk_id: int = 0) -> StreamItem:
+    return StreamItem(
+        chunk_id=chunk_id,
+        data=data,
+        from_stage="tts_engine",
+        metadata={
+            "modality": "audio_codes",
+            "stream": True,
+            "n_vq": 3,
+            "audio_pad_code": 99,
+            "sample_rate": 24000,
+        },
+    )
+
+
+def _drain(scheduler: MossStreamingVocoderScheduler) -> list:
+    messages = []
+    while True:
+        try:
+            messages.append(scheduler.outbox.get_nowait())
+        except queue.Empty:
+            return messages
+
+
+def test_stream_builder_emits_prefix_and_only_new_audio_rows() -> None:
+    config = SimpleNamespace(
+        audio_start_token_id=10,
+        audio_end_token_id=11,
+        audio_assistant_gen_slot_token_id=12,
+        audio_pad_code=99,
+        audio_vocab_size=99,
+        sampling_rate=24000,
+    )
+    payload = StagePayload(
+        request_id="req",
+        request=OmniRequest(inputs="hello", params={"stream": True}),
+        data={},
+    )
+    data = MossTTSSGLangRequestData(
+        req=SimpleNamespace(inflight_middle_chunks=0),
+        stage_payload=payload,
+        state=MossTTSState(),
+        model_config=config,
+        assistant_prefix_rows=torch.tensor(
+            [[1, 99, 99], [10, 99, 99], [12, 1, 99]], dtype=torch.long
+        ),
+        output_rows=[torch.tensor([12, 2, 3])],
+    )
+    builder = make_moss_tts_stream_output_builder()
+
+    messages = builder("req", data, RequestOutput("req", data=12))
+
+    assert len(messages) == 1
+    assert messages[0].data.tolist() == [[1, 99], [2, 3]]
+    assert messages[0].metadata["row_index"] == 0
+    assert messages[0].metadata["modality"] == "audio_codes"
+
+    assert builder("req", data, RequestOutput("req", data=12)) == []
+    data.output_rows.append(torch.tensor([12, 4, 5]))
+    messages = builder("req", data, RequestOutput("req", data=12))
+    assert messages[0].data.tolist() == [4, 5]
+    assert messages[0].metadata["row_index"] == 2
+
+    data.output_rows.append(torch.tensor([11, 99, 99]))
+    assert builder("req", data, RequestOutput("req", data=11)) == []
+
+
+def test_streaming_matches_full_decode_across_segments() -> None:
+    raw_codes = torch.tensor(
+        [
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+            [10, 11, 12],
+            [99, 99, 99],
+            [13, 14, 15],
+            [16, 17, 18],
+            [19, 20, 21],
+        ],
+        dtype=torch.long,
+    )
+    delayed = _apply_delay_pattern(raw_codes)
+    scheduler, tokenizer, vocoder = _make_scheduler()
+    payload = _payload("req", delayed)
+    full_state, full_delayed = vocoder.prepare_item(payload)
+    full, _ = vocoder._decode_audio(full_state, full_delayed)
+
+    scheduler._on_streaming_new_request("req", payload)
+    scheduler._on_chunk("req", _item(delayed[:5], 0))
+    scheduler._on_chunk("req", _item(delayed[5:], 1))
+    scheduler._on_done("req")
+
+    messages = _drain(scheduler)
+    chunks = [
+        np.frombuffer(message.data["audio_waveform"], dtype=np.float32).copy()
+        for message in messages
+        if message.type == "stream"
+    ]
+    np.testing.assert_array_equal(np.concatenate(chunks), full.numpy())
+    assert max(int(codes.shape[0]) for codes in tokenizer.decode_inputs[2:]) <= 3
+    result = next(message for message in messages if message.type == "result")
+    assert "delayed_audio_codes" not in result.data.data
+    assert result.data.data["usage"]["completion_tokens"] == int(delayed.shape[0])
+
+
+def test_chunks_and_done_before_payload_preserve_final_tail() -> None:
+    raw_codes = torch.tensor(
+        [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]],
+        dtype=torch.long,
+    )
+    delayed = _apply_delay_pattern(raw_codes)
+    scheduler, _, vocoder = _make_scheduler(stream_holdback_tokens=1)
+    payload = _payload("req", delayed)
+    full_state, full_delayed = vocoder.prepare_item(payload)
+    full, _ = vocoder._decode_audio(full_state, full_delayed)
+
+    scheduler._on_chunk("req", _item(delayed))
+    scheduler._on_done("req")
+    assert "req" in scheduler._pending_done
+    scheduler._on_streaming_new_request("req", payload)
+
+    messages = _drain(scheduler)
+    chunks = [
+        np.frombuffer(message.data["audio_waveform"], dtype=np.float32).copy()
+        for message in messages
+        if message.type == "stream"
+    ]
+    np.testing.assert_array_equal(np.concatenate(chunks), full.numpy())
+    assert "req" not in scheduler._pending_done
+    assert "req" not in scheduler._stream_states
+
+
+def test_abort_drops_state_and_late_chunks() -> None:
+    delayed = _apply_delay_pattern(
+        torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.long)
+    )
+    scheduler, _, _ = _make_scheduler()
+    scheduler._on_chunk("req", _item(delayed[:2]))
+    assert "req" in scheduler._stream_states
+
+    scheduler.abort("req")
+    scheduler._on_chunk("req", _item(delayed[2:]))
+
+    assert "req" not in scheduler._stream_states
+    assert _drain(scheduler) == []

--- a/tests/unit_test/moss_tts/test_streaming_vocoder.py
+++ b/tests/unit_test/moss_tts/test_streaming_vocoder.py
@@ -6,6 +6,7 @@ import queue
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 import torch
 
 from sglang_omni.models.moss_tts.payload_types import MossTTSState
@@ -116,6 +117,11 @@ def _drain(scheduler: MossStreamingVocoderScheduler) -> list:
             messages.append(scheduler.outbox.get_nowait())
         except queue.Empty:
             return messages
+
+
+def test_zero_overlap_is_rejected() -> None:
+    with pytest.raises(ValueError, match="stream overlap must be > 0"):
+        _make_scheduler(stream_overlap_tokens=0)
 
 
 def test_stream_builder_emits_prefix_and_only_new_audio_rows() -> None:

--- a/tests/unit_test/moss_tts/test_streaming_vocoder.py
+++ b/tests/unit_test/moss_tts/test_streaming_vocoder.py
@@ -14,9 +14,7 @@ from sglang_omni.models.moss_tts.request_builders import (
     make_moss_tts_stream_output_builder,
 )
 from sglang_omni.models.moss_tts.stages import _MossTTSVocoder
-from sglang_omni.models.moss_tts.streaming_vocoder import (
-    MossStreamingVocoderScheduler,
-)
+from sglang_omni.models.moss_tts.streaming_vocoder import MossStreamingVocoderScheduler
 from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling.types import RequestOutput


### PR DESCRIPTION
## Summary

- stream delayed RVQ rows from the AR engine
- reverse the delay pattern online and decode bounded overlap windows
- preserve non-stream batching, abort handling, and the final codec tail

Supersedes #674 on current main. Credit to @BruceLoveDecimal for the original implementation.

## Full Seed-TTS EN

H100, 1,088 requests, concurrency 8, seed 42, streaming enabled, Triton attention backend, 666 unique references:

| Metric | Result |
|---|---:|
| Completed | 1,088 / 1,088 |
| TTFA mean / p95 / p99 | 2.700 / 3.265 / 3.714 s |
| Latency mean / p95 / p99 | 4.041 / 4.838 / 5.491 s |
| QPS | 1.976 |
| Audio throughput | 8.854 s/s |
| RTF mean / p95 / p99 | 0.943 / 1.286 / 1.475 |
| Chunks mean / p95 | 8.29 / 11 |
| First payload | 3,840 bytes |
| C50 / C100 / C200 | 22.06% / 52.39% / 89.06% |
| Underrun p95 / p99 | 0.246 / 0.368 s |
| EN WER | 2.22% |
| EN WER excluding >50% outliers | 1.64% (7 samples) |

WER used Qwen3-ASR-1.7B. All 1,088 samples were evaluated with no skips. Continuity was reconstructed from captured chunk arrival times and emitted PCM durations; all 1,088 streams were valid.

## H100 smoke

MOSS-TTS v1.5, 64 tokens, warm single request without reference audio:

- streaming: 0.42 s TTFA, 1.22 s total, 9 chunks
- non-streaming: 1.04 s total, 1 chunk
- both returned 249,600 PCM bytes
- a 5.2 s reference-audio request returned 7 chunks with 0.59 s TTFA

## Tests

- 110 related unit tests passed
- black and isort passed
- real H100 streaming smoke passed with and without reference audio
- full Seed-TTS EN completed 1,088 / 1,088