### PR TITLE
[Perf] Enable FP8 / CPU offload on TTS pipelines

### DIFF
--- a/benchmarks/benchmarker/utils.py
+++ b/benchmarks/benchmarker/utils.py
@@ -253,6 +253,7 @@ def managed_omni_server(
     max_running_requests: int | None = None,
     cuda_graph_max_bs: int | None = None,
     mem_fraction_static: float | None = None,
+    quantization: str | None = None,
     timeout: int = STARTUP_TIMEOUT,
     wait_for_gpu_release: bool = True,
 ) -> Iterator[None]:
@@ -278,6 +279,8 @@ def managed_omni_server(
         cmd.extend(["--cuda-graph-max-bs", str(cuda_graph_max_bs)])
     if mem_fraction_static is not None:
         cmd.extend(["--mem-fraction-static", str(mem_fraction_static)])
+    if quantization is not None:
+        cmd.extend(["--quantization", quantization])
     logger.info(f"Starting server: {' '.join(cmd)}")
     if log_file is not None:
         log_file.parent.mkdir(parents=True, exist_ok=True)

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -693,6 +693,16 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--quantization",
+        type=str,
+        default=None,
+        help=(
+            "SGLang quantization mode (e.g. fp8) for the TTS generation stage "
+            "of the server started by this benchmark. The ASR server is always "
+            "left unquantized. Defaults to none (bf16)."
+        ),
+    )
+    parser.add_argument(
         "--skip-gpu-cleanup",
         action="store_true",
         help=(
@@ -790,6 +800,7 @@ def main() -> None:
             server_config=config.server_config,
             max_running_requests=config.max_running_requests,
             cuda_graph_max_bs=config.cuda_graph_max_bs,
+            quantization=args.quantization,
             log_file=Path(config.output_dir) / "server_logs" / "tts_server.log",
             timeout=args.server_timeout,
             wait_for_gpu_release=wait_for_gpu_release,

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -258,6 +258,10 @@ class TtsSeedttsBenchmarkConfig:
     # examples/configs/dots_tts.yaml to run the canonical optimized
     # deployment).
     server_config: str | None = None
+    # SGLang quantization mode (e.g. fp8) forwarded to the TTS generation
+    # stage; recorded as run provenance so bf16 vs fp8 archives are
+    # distinguishable. None = bf16.
+    quantization: str | None = None
     # Transcribe phase
     lang: str = "en"
     device: str = "cuda:0"
@@ -313,6 +317,7 @@ def _build_results_config(
         "max_running_requests": config.max_running_requests,
         "cuda_graph_max_bs": config.cuda_graph_max_bs,
         "server_config": config.server_config,
+        "quantization": config.quantization,
     }
 
 
@@ -411,6 +416,7 @@ def run_tts_seedtts_transcribe(
         "initial_codec_chunk_frames": config.initial_codec_chunk_frames,
         "concurrency": config.concurrency,
         "asr_concurrency": config.asr_concurrency,
+        "quantization": config.quantization,
     }
     return run_seedtts_transcribe(
         config,
@@ -456,6 +462,7 @@ def _config_from_args(args: argparse.Namespace) -> TtsSeedttsBenchmarkConfig:
         max_running_requests=args.max_running_requests,
         cuda_graph_max_bs=args.cuda_graph_max_bs,
         server_config=args.server_config,
+        quantization=args.quantization,
         lang=args.lang,
         device=args.device,
         similarity_checkpoint=args.similarity_checkpoint,
@@ -800,7 +807,7 @@ def main() -> None:
             server_config=config.server_config,
             max_running_requests=config.max_running_requests,
             cuda_graph_max_bs=config.cuda_graph_max_bs,
-            quantization=args.quantization,
+            quantization=config.quantization,
             log_file=Path(config.output_dir) / "server_logs" / "tts_server.log",
             timeout=args.server_timeout,
             wait_for_gpu_release=wait_for_gpu_release,

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -593,33 +593,49 @@ def _validate_parallelism_config(pipeline_config: PipelineConfig) -> None:
         raise typer.BadParameter(str(exc)) from exc
 
 
-def apply_thinker_server_args_cli_overrides(
+def _resolve_backbone_stage(pipeline_config: PipelineConfig) -> str:
+    if any(stage.name == "thinker" for stage in pipeline_config.stages):
+        return "thinker"
+    generation_stage = (
+        type(pipeline_config).generation_sglang_role_to_stage().get("generation")
+    )
+    if generation_stage is None:
+        _raise_unsupported_flag(pipeline_config, "--quantization/--cpu-offload-gb")
+    return generation_stage
+
+
+def apply_backbone_server_args_cli_overrides(
     pipeline_config: PipelineConfig,
     *,
     cpu_offload_gb: int | None,
     quantization: str | None,
     thinker_max_running_requests: int | None = None,
 ) -> PipelineConfig:
-    updates: dict[str, object] = {}
+    backbone_updates: dict[str, object] = {}
     if cpu_offload_gb is not None:
         if cpu_offload_gb < 0:
             raise typer.BadParameter("--cpu-offload-gb must be >= 0")
-        updates["cpu_offload_gb"] = int(cpu_offload_gb)
+        backbone_updates["cpu_offload_gb"] = int(cpu_offload_gb)
     if quantization is not None:
         quantization = quantization.strip()
         if not quantization:
             raise typer.BadParameter("--quantization must not be empty")
-        updates["quantization"] = quantization
+        backbone_updates["quantization"] = quantization
+    if backbone_updates:
+        _apply_stage_server_args_override(
+            pipeline_config,
+            stage_name=_resolve_backbone_stage(pipeline_config),
+            updates=backbone_updates,
+            reason="generation SGLang ServerArgs override",
+        )
+
     if thinker_max_running_requests is not None:
         if thinker_max_running_requests < 1:
             raise typer.BadParameter("--thinker-max-running-requests must be >= 1")
-        updates["max_running_requests"] = int(thinker_max_running_requests)
-
-    if updates:
         _apply_stage_server_args_override(
             pipeline_config,
             stage_name="thinker",
-            updates=updates,
+            updates={"max_running_requests": int(thinker_max_running_requests)},
             reason="thinker SGLang ServerArgs override",
         )
     return pipeline_config
@@ -1118,14 +1134,21 @@ def serve(
         typer.Option(
             "--cpu-offload-gb",
             "--cpu_offload_gb",
-            help="Set SGLang cpu_offload_gb for the thinker stage.",
+            help=(
+                "Set SGLang cpu_offload_gb for the backbone generation stage "
+                "(thinker for Omni, tts_engine for Higgs/TTS pipelines)."
+            ),
         ),
     ] = None,
     quantization: Annotated[
         str | None,
         typer.Option(
             "--quantization",
-            help="Set SGLang quantization mode for the thinker stage.",
+            help=(
+                "Set SGLang quantization mode (e.g. fp8) for the backbone "
+                "generation stage (thinker for Omni, tts_engine for Higgs/TTS "
+                "pipelines)."
+            ),
         ),
     ] = None,
     log_level: Annotated[
@@ -1400,7 +1423,7 @@ def serve(
         mem_fraction_static=mem_fraction_static,
         thinker_mem_fraction_static=thinker_mem_fraction_static,
     )
-    merged_config = apply_thinker_server_args_cli_overrides(
+    merged_config = apply_backbone_server_args_cli_overrides(
         merged_config,
         cpu_offload_gb=cpu_offload_gb,
         quantization=quantization,

--- a/tests/unit_test/benchmarks/test_tts_seedtts_benchmark_config.py
+++ b/tests/unit_test/benchmarks/test_tts_seedtts_benchmark_config.py
@@ -44,3 +44,17 @@ def test_seedtts_benchmark_batch_args_are_independent() -> None:
     )
     assert results_config["max_running_requests"] == 32
     assert results_config["cuda_graph_max_bs"] == 128
+
+
+def test_seedtts_benchmark_records_quantization() -> None:
+    config = _config_from_cli("--quantization", "fp8")
+    assert config.quantization == "fp8"
+    results_config = _build_results_config(config, base_url="http://localhost:8000")
+    assert results_config["quantization"] == "fp8"
+
+
+def test_seedtts_benchmark_quantization_defaults_to_none() -> None:
+    config = _config_from_cli()
+    assert config.quantization is None
+    results_config = _build_results_config(config, base_url="http://localhost:8000")
+    assert results_config["quantization"] is None

--- a/tests/unit_test/ming_omni/test_omni_serve.py
+++ b/tests/unit_test/ming_omni/test_omni_serve.py
@@ -8,12 +8,12 @@ import pytest
 import typer
 
 from sglang_omni.cli.serve import (
+    apply_backbone_server_args_cli_overrides,
     apply_cuda_graph_cli_overrides,
     apply_encoder_mem_reserve_cli_override,
     apply_mem_fraction_cli_overrides,
     apply_parallelism_cli_overrides,
     apply_partial_start_cli_overrides,
-    apply_thinker_server_args_cli_overrides,
     apply_torch_compile_cli_overrides,
 )
 from sglang_omni.config import PipelineConfig, StageConfig
@@ -369,7 +369,7 @@ def test_ming_cli_applies_thinker_sglang_server_args() -> None:
         thinker_mem_fraction_static=None,
         talker_mem_fraction_static=None,
     )
-    apply_thinker_server_args_cli_overrides(
+    apply_backbone_server_args_cli_overrides(
         config,
         cpu_offload_gb=0,
         quantization="fp8",

--- a/tests/unit_test/serve/test_generation_server_args.py
+++ b/tests/unit_test/serve/test_generation_server_args.py
@@ -9,7 +9,11 @@ from unittest.mock import patch
 import pytest
 import typer
 
-from sglang_omni.cli.serve import _apply_stage_server_args_override, serve
+from sglang_omni.cli.serve import (
+    _apply_stage_server_args_override,
+    apply_backbone_server_args_cli_overrides,
+    serve,
+)
 from sglang_omni.config import PipelineConfig, StageConfig
 from sglang_omni.models.fishaudio_s2_pro.config import S2ProPipelineConfig
 from sglang_omni.models.fun_asr.config import FunASRPipelineConfig
@@ -310,3 +314,79 @@ def test_generation_server_args_declared_stage_must_exist() -> None:
 
     with pytest.raises(typer.BadParameter, match="missing_generation"):
         _apply_generation_server_args(config)
+
+
+def test_quantization_routes_to_generation_stage_without_thinker() -> None:
+    config = HiggsTtsPipelineConfig(model_path="dummy")
+
+    apply_backbone_server_args_cli_overrides(
+        config,
+        cpu_offload_gb=None,
+        quantization="fp8",
+    )
+
+    overrides = _stage_args(config, "tts_engine")["server_args_overrides"]
+    assert overrides == {"quantization": "fp8"}
+
+
+def test_cpu_offload_routes_to_generation_stage_without_thinker() -> None:
+    config = HiggsTtsPipelineConfig(model_path="dummy")
+
+    apply_backbone_server_args_cli_overrides(
+        config,
+        cpu_offload_gb=20,
+        quantization=None,
+    )
+
+    overrides = _stage_args(config, "tts_engine")["server_args_overrides"]
+    assert overrides == {"cpu_offload_gb": 20}
+
+
+def test_quantization_prefers_thinker_stage_when_present() -> None:
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+
+    apply_backbone_server_args_cli_overrides(
+        config,
+        cpu_offload_gb=None,
+        quantization="fp8",
+    )
+
+    assert _stage_args(config, "thinker")["server_args_overrides"] == {
+        "quantization": "fp8"
+    }
+    assert "server_args_overrides" not in _stage_args(config, "talker_ar")
+
+
+def test_quantization_merges_with_generation_server_args() -> None:
+    config = HiggsTtsPipelineConfig(model_path="dummy")
+
+    apply_backbone_server_args_cli_overrides(
+        config,
+        cpu_offload_gb=None,
+        quantization="fp8",
+    )
+    _apply_generation_server_args(config)
+
+    overrides = _stage_args(config, "tts_engine")["server_args_overrides"]
+    assert overrides == {"quantization": "fp8", **GENERATION_SERVER_ARGS}
+
+
+def test_quantization_rejects_pipeline_without_thinker_or_generation() -> None:
+    config = PipelineConfig(
+        model_path="dummy",
+        stages=[
+            StageConfig(
+                name="stage",
+                process="pipeline",
+                factory="tests.unit_test.fixtures.pipeline_fakes.dummy_factory",
+                terminal=True,
+            )
+        ],
+    )
+
+    with pytest.raises(typer.BadParameter, match="not supported"):
+        apply_backbone_server_args_cli_overrides(
+            config,
+            cpu_offload_gb=None,
+            quantization="fp8",
+        )


### PR DESCRIPTION
## Motivation

`--quantization` and `--cpu-offload-gb` were hardcoded to the thinker stage, which only the Omni pipelines expose. Every TTS pipeline (Higgs, Qwen3-TTS, MOSS, Fish S2, Voxtral, …) has no thinker stage, so passing either flag failed with a stage-not-found error before the server could start. FP8 and CPU offload — the memory-bandwidth lever the 24 GB consumer-GPU roadmap (#1120) depends on — could never reach the backbone generation LM on TTS pipelines.

## Modifications

1. Route `--quantization`/`--cpu-offload-gb` to the thinker stage when a pipeline has one (Omni behavior unchanged), otherwise to the pipeline's generation-role stage, and raise a clear "flag not supported for this pipeline" error when neither exists instead of an internal stage-lookup failure.
2. Apply the flags with merge semantics so they co-exist with other per-stage server args (e.g. max running requests) on the same stage; thinker-specific options stay thinker-scoped.
3. Add a `--quantization` flag to the SeedTTS TTS benchmark (applied to the TTS server only; ASR stays unquantized) and record it in the persisted run config so bf16 and fp8 result archives are distinguishable.

Opt-in, no default-path change: the resolver runs only when a quantization or offload flag is passed, so existing bf16 runs (e.g. H100) are byte-for-byte unchanged and Omni still resolves to the thinker. One ASR pipeline that does not yet declare a generation-role stage still rejects the flag — left as a follow-up.

## Related Issues

Relates to #1120.

## Accuracy Test

SeedTTS-EN, full 1088-sample set, Higgs Audio v3 TTS 4B, bf16 vs fp8, 0 failed requests either side. Corpus WER 0.98% (bf16) → 0.97% (fp8), 0 samples above 50% — no regression.

## Benchmark & Profiling

Higgs Audio v3 TTS 4B on a single RTX 4090 (24 GB, SM89). SeedTTS-EN, 128 samples, same machine and session, identical commands modulo the flag. 0 failed requests in every run.

| metric | bf16 | fp8 | change |
|---|---|---|---|
| c=1 latency (s)          | 1.063 | 0.725  | −31.8% (1.47×) |
| c=1 RTF                  | 0.287 | 0.195  | −32%           |
| c=1 output tok/s         | 95.1  | 140.2  | +47.4%         |
| c=16 latency (s)         | 1.587 | 1.18   | −25.6% (1.35×) |
| c=16 RTF                 | 0.430 | 0.319  | −25.8%         |
| c=16 output tok/s        | 957.6 | 1304.5 | +36.2%         |
| c=16 throughput (req/s)  | 9.54  | 12.91  | +35.4%         |

Full 1088-sample set at c=16 (end-to-end TTS→ASR→WER, 0 failed either side): latency 1.690 s → 1.236 s (−26.9%), throughput 9.39 → 12.86 req/s (+37%), output 1055 → 1444 tok/s (+37%) — in line with the 128-sample c=16 column above.

fp8 cuts the backbone weight footprint 7.6 GB → 4.5 GB (−41%), shrinking the per-step weight read the HBM-bandwidth-bound decode is bottlenecked on (biggest win at c=1, +47% tok/s); c=16 additionally exploits Ada's fp8 tensor cores. Freed weights also grow the static KV pool 85,427 → 107,955 tokens (+26%) at the default static memory fraction.

## Validation

- `tests/unit_test/serve/test_generation_server_args.py`: routing the flags to the generation stage when there is no thinker (Higgs), preferring the thinker when present (Omni), merging with existing generation server args, and the clear rejection when neither stage exists.
- `tests/unit_test/benchmarks/test_tts_seedtts_benchmark_config.py`: the benchmark records the quantization setting in its run config and leaves it unset by default.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.

