### PR TITLE
Add Qwen3-Omni audio streaming to /v1/realtime

### DIFF
--- a/docs/basic_usage/qwen3_omni.md
+++ b/docs/basic_usage/qwen3_omni.md
@@ -157,7 +157,8 @@ print(result["choices"][0]["message"]["content"])
 
 ## Speech Mode
 
-Speech mode runs the full 9-stage pipeline across multiple GPUs. It produces both text (from the thinker) and audio (from the talker) output.
+Speech mode runs the full eight-stage pipeline on one or more GPUs. It produces
+both text (from the thinker) and audio (from the talker) output.
 
 ### Launch the Server
 
@@ -273,6 +274,46 @@ runtime_overrides:
     server_args_overrides:
       max_running_requests: 16
 ```
+
+### Realtime Speech with Server VAD
+
+The speech pipeline can stream spoken responses over `/v1/realtime`. Enable the
+WebSocket endpoint on the standard speech pipeline:
+
+```bash
+sgl-omni serve \
+  --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
+  --port 8008 \
+  --enable-realtime
+```
+
+After connecting to `ws://localhost:8008/v1/realtime`, request text and audio
+output:
+
+```json
+{
+  "type": "session.update",
+  "session": {
+    "modalities": ["text", "audio"],
+    "input_audio_format": "pcm16",
+    "output_audio_format": "pcm16"
+  }
+}
+```
+
+Stream mono 16 kHz PCM16 input with `input_audio_buffer.append`. Server VAD
+automatically commits each utterance and starts generation. Text arrives in
+`response.text.delta` events; spoken output arrives as base64-encoded mono
+24 kHz PCM16 in `response.audio.delta` events, followed by
+`response.audio.done` and `response.done`.
+
+Audio output is opt-in: sessions remain text-only unless both modalities are
+requested. A thinker-only server rejects audio negotiation because it has no
+`code2wav` stage.
+
+The browser example in `playground/qwen-omni/realtime` captures microphone
+input and lets the user select text-only output or text plus streamed PCM16
+audio playback.
 
 ## Single-GPU FP8 on H100/H20
 

--- a/examples/launchers/qwen3_omni.py
+++ b/examples/launchers/qwen3_omni.py
@@ -308,7 +308,13 @@ def _build_qwen_speech_server_parser() -> argparse.ArgumentParser:
             "point to the same device."
         ),
     )
+    target.add_argument(
+        "--enable-realtime",
+        action="store_true",
+        help="Mount the WebSocket /v1/realtime endpoint.",
+    )
     add_server_args(target, model_name="qwen3-omni")
+
     return target
 
 
@@ -457,6 +463,7 @@ def launch_qwen_speech_server(args: argparse.Namespace) -> None:
         host=args.host,
         port=args.port,
         model_name=args.model_name,
+        enable_realtime=args.enable_realtime,
     )
 
 

--- a/playground/qwen-omni/realtime/README.md
+++ b/playground/qwen-omni/realtime/README.md
@@ -78,6 +78,8 @@ build step.
 - Text-only mode requests only the `text` modality.
 - Text + audio mode requests both modalities. Audio deltas are mono 24 kHz
   PCM16 little-endian and are queued with Web Audio for gapless playback.
+- When server VAD detects new speech, the browser immediately flushes queued
+  assistant playback so it does not feed back into the microphone.
 - The page does no error handling beyond updating the status line —
   matching the project's house style. If the WS drops mid-session,
   reconnect.

--- a/playground/qwen-omni/realtime/README.md
+++ b/playground/qwen-omni/realtime/README.md
@@ -3,19 +3,44 @@
 ![preview](preview.png)
 
 Editorial-broadsheet single-page client for `/v1/realtime`. Captures
-the microphone, streams PCM16 chunks to the WebSocket, and renders each
-turn as an editorial card: the assistant's reply (drop caps, vermilion
-in-progress rule) appears first, then the verbatim transcript of what
-you said fills in below. Vanilla HTML/CSS/JS — no build step.
+the microphone and streams PCM16 chunks to the WebSocket. The user can select
+text-only output or text plus streamed PCM16 audio. Vanilla HTML/CSS/JS — no
+build step.
 
 ## Run
 
-1. **Start the server** (with the realtime endpoint enabled):
+1. **Start the server** with one of these configurations:
+
+   Text output only (one GPU; matches the playground default):
 
    ```bash
    sgl-omni serve \
      --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
      --text-only \
+     --port 8765 \
+     --enable-realtime
+   ```
+
+   Text and audio output on one H200:
+
+   ```bash
+   sgl-omni serve \
+     --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
+     --config examples/configs/qwen3_omni_colocated_h200.yaml \
+     --colocate \
+     --port 8765 \
+     --enable-realtime
+   ```
+
+   Text and audio output on two GPUs:
+
+   ```bash
+   python examples/run_omni.py qwen3-speech-server \
+     --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
+     --gpu-thinker 0 \
+     --gpu-talker 1 \
+     --gpu-code-predictor 1 \
+     --gpu-code2wav 1 \
      --port 8765 \
      --enable-realtime
    ```
@@ -28,18 +53,19 @@ you said fills in below. Vanilla HTML/CSS/JS — no build step.
    python -m http.server 8080
    ```
 
-3. **Open** <http://127.0.0.1:8080> in a modern browser. Click
-   **Open Wire**, then **Begin Transmission**, and start speaking.
-   Server VAD detects when you stop; the engine replies, then
-   transcribes your speech to fill conversation history.
+3. **Open** <http://127.0.0.1:8080> in a modern browser. Choose an output mode,
+   click **Open Wire**, then **Begin Transmission**,
+   and start speaking. The output mode is locked for the duration of the
+   connection. **Text + audio** requires one of the speech-server configurations.
 
 ## What you'll see
 
 | UI panel | Meaning |
 |---|---|
 | **Endpoint** | WebSocket endpoint to connect to. |
+| **Output** | Defaults to **Text only**, which requests `["text"]` and displays the assistant reply followed by the user's verbatim transcript. **Text + audio** requests `["text", "audio"]`, plays the streamed spoken response, and displays only the assistant reply. |
 | **Instructions** | System prompt sent in `session.update`. Affects the assistant reply only — transcription always runs verbatim. |
-| **Transcripts** | Each VAD-driven turn appears as a card. The assistant reply streams in first (from `response.text.delta`), then the user transcript fills in below (from `conversation.item.input_audio_transcription.delta`). |
+| **Responses** | Each VAD-driven turn appears as a card. Assistant text is rendered from `response.text.delta`; text-only mode also renders `conversation.item.input_audio_transcription.delta`. |
 
 ## Notes
 
@@ -49,6 +75,9 @@ you said fills in below. Vanilla HTML/CSS/JS — no build step.
   step / package.json required.
 - Audio is captured at 16 kHz, converted to PCM16 little-endian, and
   base64-encoded into `input_audio_buffer.append` frames.
+- Text-only mode requests only the `text` modality.
+- Text + audio mode requests both modalities. Audio deltas are mono 24 kHz
+  PCM16 little-endian and are queued with Web Audio for gapless playback.
 - The page does no error handling beyond updating the status line —
   matching the project's house style. If the WS drops mid-session,
   reconnect.

--- a/playground/qwen-omni/realtime/app.js
+++ b/playground/qwen-omni/realtime/app.js
@@ -443,10 +443,14 @@
         return;
 
       case "input_audio_buffer.speech_started":
-        if (connectionWantsAudio() && respondingTurnItemId) {
-          wsSend({ type: "response.cancel" });
+        if (
+          connectionWantsAudio() &&
+          (respondingTurnItemId || playbackSources.size)
+        ) {
           interruptPlayback();
-          setTurnMeta(respondingTurnItemId, "interrupted");
+          if (respondingTurnItemId) {
+            setTurnMeta(respondingTurnItemId, "playback interrupted");
+          }
         }
         ensureTurn(evt.item_id);
         setTurnMeta(evt.item_id, `started ${ms(evt.audio_start_ms)}`);

--- a/playground/qwen-omni/realtime/app.js
+++ b/playground/qwen-omni/realtime/app.js
@@ -3,10 +3,9 @@
  *
  * Captures mic → 16 kHz mono PCM16 via AudioWorklet → base64-encodes →
  * sends `input_audio_buffer.append`. Server VAD is always on; auto-commit
- * fires on speech_stopped. Each turn renders an editorial card with two
- * paragraphs: the assistant's reply (streamed from response.text.delta)
- * appears first, then the verbatim transcript of what you said (streamed
- * from conversation.item.input_audio_transcription.delta) fills in below.
+ * fires on speech_stopped. Text-only mode renders the assistant reply and
+ * user transcript. Text + audio mode renders the assistant reply and queues
+ * its 24 kHz PCM16 audio for gapless playback.
  *
  * Vanilla — no framework, no build step, no error handling. Per house
  * style: if something fails, the browser console gets the exception.
@@ -19,6 +18,7 @@
 
   // ─────────────────────  DOM refs  ─────────────────────
   const wsUrlEl       = $("ws-url");
+  const outputModeEl  = $("output-mode");
   const instructionsEl = $("instructions");
   const connectBtn    = $("connect");
   const disconnectBtn = $("disconnect");
@@ -35,6 +35,10 @@
   const oscilloCtx    = oscilloCanvas.getContext("2d");
 
   const transcriptsEl = $("transcripts");
+  const mastheadModeEl = $("masthead-mode");
+  const mastheadTaglineEl = $("masthead-tagline");
+  const transcriptsLabelEl = $("transcripts-label");
+  const transcriptsTaglineEl = $("transcripts-tagline");
 
   // ─────────────────────  State  ─────────────────────
   let ws = null;
@@ -43,6 +47,10 @@
   let workletNode = null;
   let analyserNode = null;
   let drawRaf = 0;
+  let playbackCtx = null;
+  let nextPlaybackTime = 0;
+  let activeModalities = null;
+  let sessionReady = false;
   let turnCounter = 0;
   // Each turn card is keyed by the audio item_id minted at speech_started /
   // committed.
@@ -53,6 +61,7 @@
   const pendingAudioForResponse = [];    // queue of item_ids awaiting response
   let respondingTurnItemId = null;       // item_id of the response currently streaming
   const TARGET_SR = 16000;
+  const OUTPUT_SR = 24000;
 
   // ─────────────────────  Status helpers  ─────────────────────
 
@@ -82,31 +91,57 @@
     ws.send(JSON.stringify(payload));
   }
 
-  function sendSessionUpdate() {
+  function wantsAudioOutput() {
+    return outputModeEl.value === "text-audio";
+  }
+
+  function connectionWantsAudio() {
+    return activeModalities
+      ? activeModalities.includes("audio")
+      : wantsAudioOutput();
+  }
+
+  function selectedModalities() {
+    return wantsAudioOutput() ? ["text", "audio"] : ["text"];
+  }
+
+  function sendSessionUpdate(modalities = activeModalities || selectedModalities()) {
     // turn_detection is fixed server-side (always server_vad with defaults);
-    // only instructions and audio format need to be sent.
+    // output modalities follow the mode selected before opening the wire.
+    const wantsAudio = modalities.includes("audio");
+    const session = {
+      modalities,
+      input_audio_format: "pcm16",
+      instructions: instructionsEl.value,
+    };
+    if (wantsAudio) {
+      session.output_audio_format = "pcm16";
+    }
     wsSend({
       type: "session.update",
-      session: {
-        modalities: ["text"],
-        input_audio_format: "pcm16",
-        instructions: instructionsEl.value,
-      },
+      session,
     });
   }
 
   connectBtn.addEventListener("click", () => {
     const url = wsUrlEl.value.trim();
+    activeModalities = selectedModalities();
+    sessionReady = false;
+    stopPlayback();
+    if (connectionWantsAudio()) {
+      ensurePlaybackContext();
+    }
+    outputModeEl.disabled = true;
     ws = new WebSocket(url);
     setStatus("Opening line…");
 
     ws.onopen = () => {
-      setStatus("Wire open", "connected");
+      setStatus("Negotiating output mode…");
       setLive(true);
       connectBtn.disabled = true;
       disconnectBtn.disabled = false;
-      micStartBtn.disabled = false;
-      sendSessionUpdate();
+      micStartBtn.disabled = true;
+      sendSessionUpdate(activeModalities);
     };
 
     ws.onmessage = (ev) => {
@@ -118,10 +153,14 @@
       setLive(false);
       connectBtn.disabled = false;
       disconnectBtn.disabled = true;
+      outputModeEl.disabled = false;
       micStartBtn.disabled = true;
       micStopBtn.disabled = true;
       clearBufferBtn.disabled = true;
       stopMic();
+      stopPlayback();
+      activeModalities = null;
+      sessionReady = false;
       ws = null;
     };
 
@@ -262,6 +301,58 @@
     return btoa(binary);
   }
 
+  function base64ToBytes(encoded) {
+    const binary = atob(encoded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+
+  function ensurePlaybackContext() {
+    if (!playbackCtx || playbackCtx.state === "closed") {
+      playbackCtx = new (window.AudioContext || window.webkitAudioContext)();
+      nextPlaybackTime = 0;
+    }
+    if (playbackCtx.state === "suspended") {
+      playbackCtx.resume();
+    }
+    return playbackCtx;
+  }
+
+  function queueAudioDelta(encoded) {
+    const bytes = base64ToBytes(encoded);
+    if (bytes.byteLength % 2 !== 0) {
+      throw new Error("Received an odd-length PCM16 audio delta");
+    }
+
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    const samples = new Float32Array(bytes.byteLength / 2);
+    for (let i = 0; i < samples.length; i++) {
+      samples[i] = view.getInt16(i * 2, true) / 0x8000;
+    }
+
+    const ctx = ensurePlaybackContext();
+    const buffer = ctx.createBuffer(1, samples.length, OUTPUT_SR);
+    buffer.copyToChannel(samples, 0);
+    const source = ctx.createBufferSource();
+    source.buffer = buffer;
+    source.connect(ctx.destination);
+
+    const startAt = Math.max(ctx.currentTime + 0.02, nextPlaybackTime);
+    source.start(startAt);
+    nextPlaybackTime = startAt + buffer.duration;
+  }
+
+  function stopPlayback() {
+    if (playbackCtx) {
+      playbackCtx.close();
+      playbackCtx = null;
+    }
+    nextPlaybackTime = 0;
+  }
+
   // ─────────────────────  Oscilloscope  ─────────────────────
 
   function clearScope() {
@@ -311,10 +402,25 @@
   function handleServerEvent(evt) {
     switch (evt.type) {
       case "session.created":
+        setStatus("Negotiating output mode…");
+        return;
+
       case "session.updated":
-        if (evt.session && evt.session.id) {
-          setStatus(`session ${evt.session.id.slice(0, 12)}…`, "connected");
+        if (
+          !evt.session ||
+          JSON.stringify(evt.session.modalities) !== JSON.stringify(activeModalities)
+        ) {
+          setStatus("Output mode negotiation failed", "error");
+          if (ws) ws.close();
+          return;
         }
+        sessionReady = true;
+        micStartBtn.disabled = false;
+        setStatus(
+          `${connectionWantsAudio() ? "Text + audio" : "Text only"} · ` +
+            `session ${evt.session.id.slice(0, 12)}…`,
+          "connected",
+        );
         return;
 
       case "input_audio_buffer.speech_started":
@@ -350,22 +456,56 @@
 
       case "response.text.done":
         if (respondingTurnItemId) {
-          setTurnMeta(respondingTurnItemId, "reply done · transcribing");
+          setTurnMeta(
+            respondingTurnItemId,
+            connectionWantsAudio()
+              ? "reply streaming"
+              : "reply done · transcribing",
+          );
+        }
+        return;
+
+      case "response.audio.delta":
+        if (connectionWantsAudio() && evt.delta) {
+          queueAudioDelta(evt.delta);
+        }
+        return;
+
+      case "response.audio.done":
+        if (respondingTurnItemId) {
+          setTurnMeta(respondingTurnItemId, "reply streaming");
         }
         return;
 
       case "response.done":
+        if (respondingTurnItemId) {
+          const responseStatus =
+            (evt.response && evt.response.status) || "completed";
+          const node = turnCards.get(respondingTurnItemId);
+          if (node) node.dataset.state = responseStatus;
+          if (connectionWantsAudio() || responseStatus !== "completed") {
+            setTurnMeta(
+              respondingTurnItemId,
+              responseStatus === "completed" ? "complete" : responseStatus,
+            );
+          }
+        }
         respondingTurnItemId = null;
         return;
 
-      // ── Pass 2: transcription of what the user said (streams after) ──
+      // In text-only mode, render the incremental user transcript.
       case "conversation.item.input_audio_transcription.delta":
-        appendToBody(evt.item_id, "user-body", evt.delta || "");
+        if (!connectionWantsAudio()) {
+          appendToBody(evt.item_id, "user-body", evt.delta || "");
+        }
         return;
 
       case "conversation.item.input_audio_transcription.completed": {
+        if (connectionWantsAudio()) return;
         const node = ensureTurn(evt.item_id);
-        node.dataset.state = "completed";
+        const responseFailed =
+          node.dataset.state === "failed" || node.dataset.state === "cancelled";
+        if (!responseFailed) node.dataset.state = "completed";
         const body = node.querySelector(".user-body");
         const final = evt.transcript || (body && body.textContent) || "";
         if (body) {
@@ -377,7 +517,7 @@
             body.style.color = "var(--ink-faint)";
           }
         }
-        setTurnMeta(evt.item_id, "complete");
+        if (!responseFailed) setTurnMeta(evt.item_id, "complete");
         return;
       }
 
@@ -403,16 +543,39 @@
     node = document.createElement("article");
     node.className = "utterance";
     node.dataset.state = "in-progress";
-    node.innerHTML =
-      `<div class="utterance-meta">` +
-      `<span class="serial">${serial}</span>` +
-      `<span class="ts">${nowTime()}</span>` +
-      `<span class="state">opening</span>` +
-      `</div>` +
-      `<p class="utterance-role">Assistant</p>` +
-      `<p class="utterance-body assistant-body"></p>` +
-      `<p class="utterance-role">You said</p>` +
-      `<p class="utterance-body user-body"></p>`;
+    const meta = document.createElement("div");
+    meta.className = "utterance-meta";
+    for (const [className, text] of [
+      ["serial", serial],
+      ["ts", nowTime()],
+      ["state", "opening"],
+    ]) {
+      const span = document.createElement("span");
+      span.className = className;
+      span.textContent = text;
+      meta.appendChild(span);
+    }
+    node.appendChild(meta);
+
+    const assistantRole = document.createElement("p");
+    assistantRole.className = "utterance-role";
+    assistantRole.textContent = "Assistant";
+    node.appendChild(assistantRole);
+
+    const assistantBody = document.createElement("p");
+    assistantBody.className = "utterance-body assistant-body";
+    node.appendChild(assistantBody);
+
+    if (!connectionWantsAudio()) {
+      const userRole = document.createElement("p");
+      userRole.className = "utterance-role";
+      userRole.textContent = "You said";
+      node.appendChild(userRole);
+
+      const userBody = document.createElement("p");
+      userBody.className = "utterance-body user-body";
+      node.appendChild(userBody);
+    }
     transcriptsEl.appendChild(node);
     transcriptsEl.scrollTop = transcriptsEl.scrollHeight;
     turnCards.set(itemId, node);
@@ -440,5 +603,34 @@
 
   // ─────────────────────  Misc UI  ─────────────────────
 
+  function updatePresentation() {
+    if (wantsAudioOutput()) {
+      mastheadModeEl.textContent = "LIVE AUDIO RESPONSES";
+      mastheadTaglineEl.textContent =
+        "A demonstration of /v1/realtime — voice in, streamed text and voice " +
+        "out. Server VAD detects when you stop; the engine streams its spoken answer.";
+      transcriptsLabelEl.textContent = "Assistant Responses";
+      transcriptsTaglineEl.textContent =
+        "Each response is set in Newsreader Italic, lifted from the wire as " +
+        "the engine emits it.";
+    } else {
+      mastheadModeEl.textContent = "A LIVE TRANSCRIPT";
+      mastheadTaglineEl.textContent =
+        "A demonstration of /v1/realtime — voice in, text out. " +
+        "Server VAD detects when you stop; the engine answers, then " +
+        "transcribes what you said.";
+      transcriptsLabelEl.textContent = "The Transcript";
+      transcriptsTaglineEl.textContent =
+        "Each turn shows the assistant reply followed by the verbatim " +
+        "transcript of what you said.";
+    }
+    clearTurns();
+  }
+
+  outputModeEl.addEventListener("change", () => {
+    stopPlayback();
+    updatePresentation();
+  });
   instructionsEl.addEventListener("change", () => sendSessionUpdate());
+  updatePresentation();
 })();

--- a/playground/qwen-omni/realtime/app.js
+++ b/playground/qwen-omni/realtime/app.js
@@ -49,6 +49,8 @@
   let drawRaf = 0;
   let playbackCtx = null;
   let nextPlaybackTime = 0;
+  let acceptingResponseAudio = false;
+  const playbackSources = new Set();
   let activeModalities = null;
   let sessionReady = false;
   let turnCounter = 0;
@@ -322,6 +324,7 @@
   }
 
   function queueAudioDelta(encoded) {
+    if (!acceptingResponseAudio) return;
     const bytes = base64ToBytes(encoded);
     if (bytes.byteLength % 2 !== 0) {
       throw new Error("Received an odd-length PCM16 audio delta");
@@ -339,13 +342,29 @@
     const source = ctx.createBufferSource();
     source.buffer = buffer;
     source.connect(ctx.destination);
+    playbackSources.add(source);
+    source.onended = () => playbackSources.delete(source);
 
     const startAt = Math.max(ctx.currentTime + 0.02, nextPlaybackTime);
     source.start(startAt);
     nextPlaybackTime = startAt + buffer.duration;
   }
 
+  function interruptPlayback() {
+    acceptingResponseAudio = false;
+    for (const source of playbackSources) {
+      try {
+        source.stop();
+      } catch (_) {
+        // The source may have already ended between iteration and stop().
+      }
+    }
+    playbackSources.clear();
+    nextPlaybackTime = playbackCtx ? playbackCtx.currentTime : 0;
+  }
+
   function stopPlayback() {
+    interruptPlayback();
     if (playbackCtx) {
       playbackCtx.close();
       playbackCtx = null;
@@ -424,6 +443,11 @@
         return;
 
       case "input_audio_buffer.speech_started":
+        if (connectionWantsAudio() && respondingTurnItemId) {
+          wsSend({ type: "response.cancel" });
+          interruptPlayback();
+          setTurnMeta(respondingTurnItemId, "interrupted");
+        }
         ensureTurn(evt.item_id);
         setTurnMeta(evt.item_id, `started ${ms(evt.audio_start_ms)}`);
         return;
@@ -443,6 +467,8 @@
       // ── Pass 1: assistant reply (streams first) ──
       case "response.created":
         respondingTurnItemId = pendingAudioForResponse.shift() || null;
+        acceptingResponseAudio =
+          connectionWantsAudio() && respondingTurnItemId !== null;
         if (respondingTurnItemId) {
           setTurnMeta(respondingTurnItemId, "replying");
         }
@@ -466,7 +492,7 @@
         return;
 
       case "response.audio.delta":
-        if (connectionWantsAudio() && evt.delta) {
+        if (connectionWantsAudio() && acceptingResponseAudio && evt.delta) {
           queueAudioDelta(evt.delta);
         }
         return;
@@ -478,6 +504,7 @@
         return;
 
       case "response.done":
+        acceptingResponseAudio = false;
         if (respondingTurnItemId) {
           const responseStatus =
             (evt.response && evt.response.status) || "completed";

--- a/playground/qwen-omni/realtime/index.html
+++ b/playground/qwen-omni/realtime/index.html
@@ -20,7 +20,7 @@
       <span class="meta-line">FILED FROM sglang-omni</span>
     </div>
     <div class="masthead-meta-right">
-      <span class="meta-line">A LIVE TRANSCRIPT</span>
+      <span class="meta-line" id="masthead-mode">LIVE AUDIO RESPONSES</span>
       <span class="meta-line">EST. 2026</span>
     </div>
 
@@ -33,8 +33,8 @@
 
     <hr class="rule rule-thin" />
 
-    <p class="masthead-tagline">
-      A demonstration of <code>/v1/realtime</code> — voice in, reply out, in the time it takes to hear yourself stop talking. Server VAD detects when you stop; the engine answers, then transcribes what you said.
+    <p class="masthead-tagline" id="masthead-tagline">
+      A demonstration of <code>/v1/realtime</code> — voice in, streamed text and voice out. Server VAD detects when you stop; the engine streams its spoken answer.
     </p>
 
     <hr class="rule rule-thick" />
@@ -54,6 +54,14 @@
         <label class="field">
           <span class="field-label">Endpoint</span>
           <input id="ws-url" type="text" value="ws://127.0.0.1:8765/v1/realtime" />
+        </label>
+
+        <label class="field">
+          <span class="field-label">Output</span>
+          <select id="output-mode">
+            <option value="text">Text only</option>
+            <option value="text-audio">Text + audio</option>
+          </select>
         </label>
 
         <label class="field">
@@ -98,19 +106,19 @@
     </aside>
 
 
-    <!-- ─────────────────────  TRANSCRIPT  (HERO COLUMN) ───────────────────── -->
+    <!-- ─────────────────────  RESPONSES  (HERO COLUMN) ───────────────────── -->
     <article class="transcripts">
 
       <header class="transcripts-head">
         <h2 class="transcripts-title">
-          <span class="transcripts-label">The Transcript</span>
+          <span class="transcripts-label" id="transcripts-label">Assistant Responses</span>
           <span class="live-pill" id="live-pill">
             <span class="live-dot"></span>
             <span class="live-text">OFFLINE</span>
           </span>
         </h2>
-        <p class="transcripts-tagline">
-          Each utterance is set in <em>Newsreader Italic</em>, lifted from the wire as the engine emits it. Drop caps mark the start of every committed turn. Tap an utterance to see the wire payload that produced it.
+        <p class="transcripts-tagline" id="transcripts-tagline">
+          Each response is set in <em>Newsreader Italic</em>, lifted from the wire as the engine emits it.
         </p>
         <hr class="rule rule-thin" />
       </header>
@@ -136,6 +144,6 @@
     </div>
   </footer>
 
-  <script src="app.js"></script>
+  <script src="app.js?v=output-modes-v2"></script>
 </body>
 </html>

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -395,6 +395,9 @@ async def _run_server(
             ),
             additional_speech_languages=pipeline_config.additional_speech_languages,
             enable_realtime=enable_realtime,
+            supports_realtime_audio_output=(
+                type(pipeline_config).code2wav_stage() is not None
+            ),
             allowed_local_media_path=allowed_local_media_path,
             allowed_media_domains=allowed_media_domains,
             tts_batch_max_items=tts_batch_max_items,

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -213,6 +213,7 @@ def create_app(
     speech_reference_text_required: bool = False,
     additional_speech_languages: frozenset[str] = frozenset(),
     enable_realtime: bool = False,
+    supports_realtime_audio_output: bool = False,
     allowed_local_media_path: str | None = None,
     allowed_media_domains: list[str] | None = None,
     admin_api_key: str | None = None,
@@ -235,6 +236,8 @@ def create_app(
         additional_speech_languages: Pipeline-specific accepted languages.
         enable_realtime: If True, mount the WebSocket ``/v1/realtime``
             endpoint (OpenAI Realtime API).
+        supports_realtime_audio_output: Whether the mounted realtime endpoint
+            can request streamed audio from the configured pipeline.
         allowed_local_media_path: Directory allowed for ``file://`` TTS
             reference audio.
         allowed_media_domains: Domains allowed for remote TTS reference audio.
@@ -264,6 +267,7 @@ def create_app(
     app.state.model_name = model_name or "sglang-omni"
     app.state.architectures = [a for a in (architectures or []) if a]
     app.state.realtime_enabled = enable_realtime
+    app.state.supports_realtime_audio_output = supports_realtime_audio_output
     app.state.speaker_sample_store = SpeakerSampleStore()
     app.state.speech_service = SpeechRequestValidator(
         default_model=app.state.model_name,
@@ -1203,7 +1207,11 @@ def _register_realtime(app: FastAPI) -> None:
 
     client: Client = app.state.client
     model_name: str = app.state.model_name
-    manager = RealtimeSessionManager(client=client, model_name=model_name)
+    manager = RealtimeSessionManager(
+        client=client,
+        model_name=model_name,
+        supports_audio_output=app.state.supports_realtime_audio_output,
+    )
     app.state.realtime_manager = manager
 
     @app.websocket("/v1/realtime")

--- a/sglang_omni/serve/realtime/events.py
+++ b/sglang_omni/serve/realtime/events.py
@@ -39,6 +39,7 @@ class SessionConfig(EventBase):
     modalities: list[str] | None = None
     instructions: str | None = None
     input_audio_format: Literal["pcm16", "g711_ulaw", "g711_alaw"] | None = None
+    output_audio_format: Literal["pcm16", "g711_ulaw", "g711_alaw"] | None = None
     turn_detection: TurnDetection | None = None
     temperature: float | None = None
     max_response_output_tokens: int | str | None = None
@@ -51,6 +52,7 @@ class SessionObject(EventBase):
     modalities: list[str] = Field(default_factory=lambda: ["text"])
     instructions: str = ""
     input_audio_format: str = "pcm16"
+    output_audio_format: str = "pcm16"
     turn_detection: TurnDetection | None = None
     temperature: float = 0.8
     max_response_output_tokens: int | str = "inf"

--- a/sglang_omni/serve/realtime/manager.py
+++ b/sglang_omni/serve/realtime/manager.py
@@ -11,9 +11,16 @@ logger = logging.getLogger(__name__)
 
 
 class RealtimeSessionManager:
-    def __init__(self, *, client: Client, model_name: str) -> None:
+    def __init__(
+        self,
+        *,
+        client: Client,
+        model_name: str,
+        supports_audio_output: bool = False,
+    ) -> None:
         self.client = client
         self.model_name = model_name
+        self.supports_audio_output = supports_audio_output
         self.sessions: dict[str, RealtimeSession] = {}
 
     def open(self, websocket: WebSocket) -> RealtimeSession:
@@ -21,6 +28,7 @@ class RealtimeSessionManager:
             websocket,
             client=self.client,
             model_name=self.model_name,
+            supports_audio_output=self.supports_audio_output,
         )
         self.sessions[session.session_id] = session
         logger.info(f"Realtime session opened: {session.session_id}")

--- a/sglang_omni/serve/realtime/session.py
+++ b/sglang_omni/serve/realtime/session.py
@@ -58,7 +58,7 @@ class ConversationItem:
 
 
 class RealtimeSession:
-    """Owns one WebSocket and one OpenAI-Realtime audio-in / text-out session.
+    """Owns one WebSocket and one OpenAI-Realtime audio-in session.
 
     Per turn (VAD ``speech_stopped`` → auto-commit):
       1. ``run_response`` consumes the audio + prior conversation, streams
@@ -77,11 +77,13 @@ class RealtimeSession:
         client: Client,
         model_name: str,
         session_id: str | None = None,
+        supports_audio_output: bool = False,
     ) -> None:
         self.websocket = websocket
         self.client = client
         self.model_name = model_name
         self.session_id = session_id or new_id("sess")
+        self.supports_audio_output = supports_audio_output
 
         self.session_object = SessionObject(
             id=self.session_id,
@@ -98,6 +100,9 @@ class RealtimeSession:
 
         self.active_request_id: str | None = None
         self.active_task: asyncio.Task | None = None
+        self.cancel_cleanup_tasks: dict[asyncio.Task, asyncio.Task] = {}
+        self.response_start_pending = False
+        self.cancel_pending_response = False
         # VAD may emit speech_stopped while engine is still busy on an
         # earlier utterance — serialize via FIFO.
         self.response_queue: asyncio.Queue[tuple[str, str]] = asyncio.Queue()
@@ -146,7 +151,30 @@ class RealtimeSession:
         candidate = SessionObject.model_validate(
             self.session_object.model_dump() | update
         )
+        modalities = set(candidate.modalities)
+        if modalities not in ({"text"}, {"text", "audio"}):
+            await self.send_error(
+                "invalid_request_error",
+                "unsupported_modality",
+                "modalities must be ['text'] or ['text', 'audio'].",
+            )
+            return
+        audio_requested = "audio" in modalities
+        if audio_requested and not self.supports_audio_output:
+            await self.send_error(
+                "invalid_request_error",
+                "unsupported_modality",
+                "Audio output is unavailable for this pipeline.",
+            )
+            return
         assert candidate.input_audio_format == "pcm16", "Only pcm16 is supported"
+        if "output_audio_format" in update and candidate.output_audio_format != "pcm16":
+            await self.send_error(
+                "invalid_request_error",
+                "unsupported_audio_format",
+                "Only PCM16 output audio is supported.",
+            )
+            return
         self.session_object = candidate
         await self.send(
             make_event(
@@ -218,16 +246,34 @@ class RealtimeSession:
     async def handle_response_cancel(self, event: ResponseCancel) -> None:
         if self.active_task is None or self.active_task.done():
             return
-        if self.active_request_id is not None:
-            await self.client.abort(self.active_request_id)
-        self.active_task.cancel()
+        task = self.active_task
+        if self.response_start_pending:
+            self.cancel_pending_response = True
+            return
+        if self.active_request_id is None:
+            return
+        cleanup_task = self.cancel_cleanup_tasks.get(task)
+        if cleanup_task is not None and not cleanup_task.done():
+            return
+        request_id = self.active_request_id
+        task.cancel()
+        cleanup_task = asyncio.create_task(self._abort_and_drain(task, request_id))
+        self.cancel_cleanup_tasks[task] = cleanup_task
+        cleanup_task.add_done_callback(
+            lambda _: self.cancel_cleanup_tasks.pop(task, None)
+        )
 
     async def drain_queue(self) -> None:
         while not self.closed:
             item_id, payload = await self.response_queue.get()
-            self.active_task = asyncio.create_task(self.run_turn(item_id, payload))
-            await asyncio.gather(self.active_task, return_exceptions=True)
-            self.active_task = None
+            self.response_start_pending = True
+            try:
+                self.active_task = asyncio.create_task(self.run_turn(item_id, payload))
+                await asyncio.gather(self.active_task, return_exceptions=True)
+            finally:
+                self.active_task = None
+                self.response_start_pending = False
+                self.cancel_pending_response = False
 
     async def run_turn(self, item_id: str, audio_payload: str) -> None:
         """Pass 1: response (user-facing, streams fast).
@@ -244,10 +290,20 @@ class RealtimeSession:
             )
 
     async def run_response(self, audio_payload: str) -> str:
-        """Emit response.created → response.text.delta × N → text.done → done."""
+        """Stream the assistant response and wait for every active terminal."""
+        response_request = self.build_response_request(audio_payload)
+        wants_audio = "audio" in (response_request.output_modalities or [])
         response_id = new_id("resp")
+        resp_item_id = new_id("item")
         request_id = f"rt-{self.session_id}-{uuid.uuid4().hex}"
         self.active_request_id = request_id
+        text_acc: list[str] = []
+        finish_reason = "stop"
+        usage: dict[str, Any] | None = None
+        saw_audio = False
+        text_done = False
+        audio_done = False
+        response_done = False
 
         try:
             await self.send(
@@ -262,15 +318,37 @@ class RealtimeSession:
                 )
             )
 
-            resp_item_id = new_id("item")
-            text_acc: list[str] = []
-            finish_reason = "stop"
-            usage: dict[str, Any] | None = None
+            self.response_start_pending = False
+            if self.cancel_pending_response:
+                self.cancel_pending_response = False
+                await self.send(
+                    make_event(
+                        "response.text.done",
+                        response_id=response_id,
+                        item_id=resp_item_id,
+                        output_index=0,
+                        content_index=0,
+                        text="",
+                    )
+                )
+                await self._send_response_done(
+                    response_id=response_id,
+                    item_id=resp_item_id,
+                    response_text="",
+                    include_audio=False,
+                    status="cancelled",
+                    reason="client_cancelled",
+                    usage=None,
+                )
+                response_done = True
+                raise asyncio.CancelledError
+
             async for chunk in self.client.completion_stream(
-                self.build_response_request(audio_payload),
+                response_request,
                 request_id=request_id,
+                audio_format="pcm" if wants_audio else "wav",
             ):
-                if chunk.modality == "text" and chunk.text:
+                if chunk.text and (chunk.modality == "text" or not text_acc):
                     text_acc.append(chunk.text)
                     await self.send(
                         make_event(
@@ -282,50 +360,229 @@ class RealtimeSession:
                             delta=chunk.text,
                         )
                     )
+
+                if wants_audio and chunk.modality == "audio" and chunk.audio_b64:
+                    saw_audio = True
+                    await self.send(
+                        make_event(
+                            "response.audio.delta",
+                            response_id=response_id,
+                            item_id=resp_item_id,
+                            output_index=0,
+                            content_index=1,
+                            delta=chunk.audio_b64,
+                        )
+                    )
+
                 if chunk.finish_reason is not None:
                     finish_reason = chunk.finish_reason
-                    usage = (
-                        dataclasses.asdict(chunk.usage)
-                        if chunk.usage is not None
-                        else None
+                    if chunk.usage is not None:
+                        usage = dataclasses.asdict(chunk.usage)
+
+                if (
+                    chunk.modality == "text"
+                    and chunk.finish_reason is not None
+                    and not text_done
+                ):
+                    await self.send(
+                        make_event(
+                            "response.text.done",
+                            response_id=response_id,
+                            item_id=resp_item_id,
+                            output_index=0,
+                            content_index=0,
+                            text="".join(text_acc),
+                        )
                     )
-                    break
+                    text_done = True
+                elif (
+                    wants_audio
+                    and chunk.modality == "audio"
+                    and chunk.finish_reason is not None
+                    and saw_audio
+                    and not audio_done
+                ):
+                    await self.send(
+                        make_event(
+                            "response.audio.done",
+                            response_id=response_id,
+                            item_id=resp_item_id,
+                            output_index=0,
+                            content_index=1,
+                        )
+                    )
+                    audio_done = True
 
             response_text = "".join(text_acc)
-            await self.send(
-                make_event(
-                    "response.text.done",
+            if not text_done:
+                await self.send(
+                    make_event(
+                        "response.text.done",
+                        response_id=response_id,
+                        item_id=resp_item_id,
+                        output_index=0,
+                        content_index=0,
+                        text=response_text,
+                    )
+                )
+                text_done = True
+            if wants_audio and not saw_audio:
+                await self.send_error(
+                    "server_error",
+                    "audio_output_missing",
+                    "The configured pipeline completed without audio output.",
+                )
+                await self._send_response_done(
                     response_id=response_id,
                     item_id=resp_item_id,
-                    output_index=0,
-                    content_index=0,
-                    text=response_text,
+                    response_text=response_text,
+                    include_audio=False,
+                    status="failed",
+                    reason="audio_output_missing",
+                    usage=usage,
                 )
-            )
-            await self.send(
-                make_event(
-                    "response.done",
-                    response={
-                        "id": response_id,
-                        "object": "realtime.response",
-                        "status": "completed",
-                        "status_details": {"reason": finish_reason},
-                        "output": [
-                            {
-                                "id": resp_item_id,
-                                "object": "realtime.item",
-                                "type": "message",
-                                "role": "assistant",
-                                "content": [{"type": "text", "text": response_text}],
-                            }
-                        ],
-                        "usage": usage,
-                    },
+                response_done = True
+                return ""
+
+            if wants_audio and not audio_done:
+                await self.send(
+                    make_event(
+                        "response.audio.done",
+                        response_id=response_id,
+                        item_id=resp_item_id,
+                        output_index=0,
+                        content_index=1,
+                    )
                 )
+                audio_done = True
+
+            await self._send_response_done(
+                response_id=response_id,
+                item_id=resp_item_id,
+                response_text=response_text,
+                include_audio=wants_audio,
+                status="completed",
+                reason=finish_reason,
+                usage=usage,
             )
+            response_done = True
             return response_text
+        except asyncio.CancelledError:
+            if not response_done:
+                if not text_done:
+                    await self.send(
+                        make_event(
+                            "response.text.done",
+                            response_id=response_id,
+                            item_id=resp_item_id,
+                            output_index=0,
+                            content_index=0,
+                            text="".join(text_acc),
+                        )
+                    )
+                if wants_audio and saw_audio and not audio_done:
+                    await self.send(
+                        make_event(
+                            "response.audio.done",
+                            response_id=response_id,
+                            item_id=resp_item_id,
+                            output_index=0,
+                            content_index=1,
+                        )
+                    )
+                await self._send_response_done(
+                    response_id=response_id,
+                    item_id=resp_item_id,
+                    response_text="".join(text_acc),
+                    include_audio=wants_audio and saw_audio,
+                    status="cancelled",
+                    reason="client_cancelled",
+                    usage=usage,
+                )
+            raise
+        except Exception as exc:
+            asyncio.get_running_loop().call_exception_handler(
+                {
+                    "message": "Realtime response generation failed",
+                    "exception": exc,
+                }
+            )
+            response_text = "".join(text_acc)
+            if not response_done:
+                if not text_done:
+                    await self.send(
+                        make_event(
+                            "response.text.done",
+                            response_id=response_id,
+                            item_id=resp_item_id,
+                            output_index=0,
+                            content_index=0,
+                            text=response_text,
+                        )
+                    )
+                if wants_audio and saw_audio and not audio_done:
+                    await self.send(
+                        make_event(
+                            "response.audio.done",
+                            response_id=response_id,
+                            item_id=resp_item_id,
+                            output_index=0,
+                            content_index=1,
+                        )
+                    )
+                await self.send_error(
+                    "server_error",
+                    "response_generation_failed",
+                    "Realtime response generation failed.",
+                )
+                await self._send_response_done(
+                    response_id=response_id,
+                    item_id=resp_item_id,
+                    response_text=response_text,
+                    include_audio=wants_audio and saw_audio,
+                    status="failed",
+                    reason="error",
+                    usage=usage,
+                )
+            return ""
         finally:
             self.active_request_id = None
+
+    async def _send_response_done(
+        self,
+        *,
+        response_id: str,
+        item_id: str,
+        response_text: str,
+        include_audio: bool,
+        status: str,
+        reason: str,
+        usage: dict[str, Any] | None,
+    ) -> None:
+        content: list[dict[str, Any]] = [{"type": "text", "text": response_text}]
+        if include_audio:
+            content.append({"type": "audio", "transcript": response_text})
+        await self.send(
+            make_event(
+                "response.done",
+                response={
+                    "id": response_id,
+                    "object": "realtime.response",
+                    "status": status,
+                    "status_details": {"reason": reason},
+                    "output": [
+                        {
+                            "id": item_id,
+                            "object": "realtime.item",
+                            "type": "message",
+                            "role": "assistant",
+                            "content": content,
+                        }
+                    ],
+                    "usage": usage,
+                },
+            )
+        )
 
     async def run_transcription(self, item_id: str, audio_payload: str) -> str:
         request_id = f"rt-{self.session_id}-{uuid.uuid4().hex}"
@@ -397,7 +654,7 @@ class RealtimeSession:
             messages=messages,
             sampling=self._sampling(),
             stream=True,
-            output_modalities=["text"],
+            output_modalities=list(self.session_object.modalities),
             metadata={"audios": [audio_payload]},
         )
 
@@ -442,13 +699,32 @@ class RealtimeSession:
         """
         if task is None or task.done():
             return
-        if request_id is not None:
-            await self.client.abort(request_id)
         task.cancel()
-        await asyncio.gather(task, return_exceptions=True)
+        await self._abort_and_drain(task, request_id)
+
+    async def _abort_and_drain(
+        self, task: asyncio.Task, request_id: str | None
+    ) -> None:
+        try:
+            if request_id is not None:
+                await self.client.abort(request_id)
+        except Exception as exc:
+            asyncio.get_running_loop().call_exception_handler(
+                {
+                    "message": "Realtime response abort failed",
+                    "exception": exc,
+                    "task": task,
+                }
+            )
+        finally:
+            await asyncio.gather(task, return_exceptions=True)
 
     async def teardown(self) -> None:
         self.closed = True
+        if self.cancel_cleanup_tasks:
+            await asyncio.gather(
+                *list(self.cancel_cleanup_tasks.values()), return_exceptions=True
+            )
         await self._cancel_and_abort(self.active_task, self.active_request_id)
         await self._cancel_and_abort(self.queue_drainer, None)
         if self.websocket.client_state == WebSocketState.CONNECTED:

--- a/tests/README.md
+++ b/tests/README.md
@@ -214,6 +214,9 @@ Relevant model CI ownership:
   router at TTS generation concurrency 16 and verifies both colocated workers
   receive traffic. WER reuses saved audio after the Qwen3-Omni server is
   stopped, then transcribes through Qwen3-ASR at concurrency 32.
+- `test_qwen3_omni_realtime.py` keeps the lower-cost thinker-only VAD/text
+  path covered; `test_qwen3_omni_realtime_audio.py` separately launches the
+  speech topology and verifies VAD-driven raw PCM16 response streaming.
 - `test_asr_ci_multi_speaker.py`: MOSS-Transcribe-Diarize multi-speaker
   ASR/diarization correctness + speed via the managed router at DP=2. It
   runs movies800times (non-stream + stream), aishell4_long, and googletime,

--- a/tests/test_model/test_qwen3_omni_realtime_audio.py
+++ b/tests/test_model/test_qwen3_omni_realtime_audio.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Realtime speech-output integration test for the Qwen3-Omni speech pipeline.
+
+Usage:
+    pytest tests/test_model/test_qwen3_omni_realtime_audio.py -s -x
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import subprocess
+import sys
+import wave
+from pathlib import Path
+
+import pytest
+import websockets
+
+from sglang_omni.utils import find_available_port
+from tests.utils import (
+    disable_proxy,
+    server_log_file,
+    start_server_from_cmd,
+    stop_server,
+)
+
+MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
+MODEL_NAME = "qwen3-omni"
+STARTUP_TIMEOUT = 600
+WS_TIMEOUT = 120
+AUDIO_FIXTURE = Path(__file__).parent.parent / "data" / "query_to_draw.wav"
+
+
+@pytest.fixture(scope="module")
+def speech_server(tmp_path_factory: pytest.TempPathFactory):
+    port = find_available_port()
+    log_file = server_log_file(tmp_path_factory, "realtime_audio_logs")
+    cmd = [
+        sys.executable,
+        "examples/run_qwen3_omni_speech_server.py",
+        "--model-path",
+        MODEL_PATH,
+        "--model-name",
+        MODEL_NAME,
+        "--gpu-thinker",
+        "0",
+        "--gpu-talker",
+        "1",
+        "--gpu-code2wav",
+        "1",
+        "--enable-realtime",
+        "--port",
+        str(port),
+    ]
+    proc = start_server_from_cmd(cmd, log_file, port, timeout=STARTUP_TIMEOUT)
+    proc.port = port  # type: ignore[attr-defined]
+    yield proc
+    stop_server(proc)
+
+
+def _load_pcm16_with_silence(path: Path) -> bytes:
+    with wave.open(str(path)) as wav:
+        assert wav.getnchannels() == 1
+        assert wav.getframerate() == 16000
+        assert wav.getsampwidth() == 2
+        pcm = wav.readframes(wav.getnframes())
+    return pcm + b"\x00\x00" * 16000
+
+
+async def _recv_event(ws) -> dict:
+    return json.loads(await asyncio.wait_for(ws.recv(), timeout=WS_TIMEOUT))
+
+
+async def _recv_until(ws, terminal_type: str, *, limit: int = 500) -> list[dict]:
+    events: list[dict] = []
+    for _ in range(limit):
+        event = await _recv_event(ws)
+        events.append(event)
+        if event.get("type") == terminal_type:
+            return events
+    raise AssertionError(
+        f"did not see {terminal_type}; saw {[event.get('type') for event in events]}"
+    )
+
+
+async def _stream_audio(ws, pcm: bytes, *, chunk_ms: int = 200) -> None:
+    chunk_bytes = 16000 * chunk_ms // 1000 * 2
+    for start in range(0, len(pcm), chunk_bytes):
+        await ws.send(
+            json.dumps(
+                {
+                    "type": "input_audio_buffer.append",
+                    "audio": base64.b64encode(
+                        pcm[start : start + chunk_bytes]
+                    ).decode(),
+                }
+            )
+        )
+
+
+@pytest.mark.benchmark
+@pytest.mark.asyncio
+async def test_vad_turn_streams_raw_pcm_audio(
+    speech_server: subprocess.Popen,
+) -> None:
+    """A VAD-committed turn emits non-empty audio and completes."""
+    port: int = speech_server.port  # type: ignore[attr-defined]
+    with disable_proxy():
+        async with websockets.connect(f"ws://localhost:{port}/v1/realtime") as ws:
+            assert (await _recv_event(ws))["type"] == "session.created"
+            await ws.send(
+                json.dumps(
+                    {
+                        "type": "session.update",
+                        "session": {
+                            "modalities": ["text", "audio"],
+                            "input_audio_format": "pcm16",
+                            "output_audio_format": "pcm16",
+                        },
+                    }
+                )
+            )
+            updated = await _recv_event(ws)
+            assert updated["type"] == "session.updated", updated
+
+            await _stream_audio(ws, _load_pcm16_with_silence(AUDIO_FIXTURE))
+            events = await _recv_until(
+                ws, "conversation.item.input_audio_transcription.completed"
+            )
+
+    types = [event["type"] for event in events]
+    response_done_index = types.index("response.done")
+    assert types.index("response.audio.done") < response_done_index
+
+    encoded_deltas = [
+        event["delta"] for event in events if event["type"] == "response.audio.delta"
+    ]
+    pcm = b"".join(base64.b64decode(delta, validate=True) for delta in encoded_deltas)
+    assert pcm
+
+    response = events[response_done_index]["response"]
+    assert response["status"] == "completed"
+    assert {content["type"] for content in response["output"][0]["content"]} == {
+        "text",
+        "audio",
+    }

--- a/tests/unit_test/qwen3_omni/test_example_launcher.py
+++ b/tests/unit_test/qwen3_omni/test_example_launcher.py
@@ -286,6 +286,7 @@ def _make_args(**overrides) -> argparse.Namespace:
         host="0.0.0.0",
         port=8000,
         model_name="qwen3-omni",
+        enable_realtime=False,
     )
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
@@ -356,6 +357,13 @@ def test_tp1_default_config_contract(mock_launch_server):
     assert thinker.gpu == 0
     assert talker.gpu == 1
     assert code2wav.gpu == 0
+
+
+def test_speech_server_forwards_realtime_flag(mock_launch_server):
+    args = _make_args(enable_realtime=True)
+    _launch_speech_server(args)
+
+    assert mock_launch_server.call_args.kwargs["enable_realtime"] is True
 
 
 def test_mem_fractions_applied(mock_launch_server):


### PR DESCRIPTION
## Motivation

`/v1/realtime` already accepts streaming microphone input, uses server VAD to
commit turns, and streams assistant text. Qwen3-Omni speech pipelines also
produce audio through Talker and Code2Wav, but that audio was not exposed by
the realtime API.

This PR adds opt-in speech output to `/v1/realtime` while preserving the
existing text-only default.

## What this PR adds

- Supports `modalities: ["text", "audio"]` on speech-capable Qwen3-Omni
  pipelines.
- Streams raw mono 24 kHz PCM16 through `response.audio.delta`, followed by
  `response.audio.done`.
- Keeps `response.text.*` and `response.audio.*` independent, and emits
  `response.done` only after all requested output streams terminate.
- Rejects audio negotiation with a protocol error when the configured pipeline
  has no Code2Wav stage, without closing the session.
- Handles completion, cancellation, missing-audio, and generation-failure
  terminal ordering.
- Exposes `--enable-realtime` on the Qwen3-Omni speech launcher.
- Adds a **Text only / Text + audio** selector and gapless PCM16 playback to
  the light Wire Service playground.

The playground flushes already queued browser playback when new speech starts
to avoid microphone feedback. This does not cancel backend generation and is
not server-owned automatic barge-in.

## Compatibility and scope

- `["text"]` remains the default and works on thinker-only pipelines.
- Audio is generated only when the client explicitly requests
  `["text", "audio"]`.
- This PR does not change model architecture, weights, kernels, sampling, or
  audio quality.
- Semantic VAD, automatic server-owned barge-in, and performance optimizations
  are outside this PR.
- Preserving transcription/history after explicit `response.cancel` is split
  into a separate follow-up change.

## Related Issues

Closes #1110.

## Demo

- Recorded demo: **[add recording link here]**

## Accuracy Test

Not applicable. The model execution and generated outputs are unchanged; this
PR exposes the existing speech-pipeline output through the realtime protocol.

## Benchmark & Profiling

No comparative throughput or latency benchmark was run because this PR does
not change the inference hot path.

Single-H200 colocated functional measurement of the same realtime audio path:

| Measurement | Result |
|---|---:|
| Submitted audio | 7.064 s mono 16 kHz PCM16, including trailing VAD silence |
| Assistant text | 333 characters |
| Streamed output audio | 909,210 raw PCM16 bytes |
| Output audio duration | 18.94 s at mono 24 kHz |
| Terminal result | `response.text.done`, `response.audio.done`, and completed `response.done` |

This was one functional run, not a throughput or statistical latency
benchmark.

## Testing

- [x] Local code review completed.
- [x] 55 Qwen3-Omni launcher tests passed on head `3f39d0fd`.
- [x] Black, isort, Ruff F401, Python compilation, and browser JavaScript
  syntax checks passed.
- [x] Live two-H100 validation of the unchanged normal completion path:
  - text-only: 224 response characters and zero audio events;
  - text+audio: 195 response characters, 491,340 PCM16 bytes (10.24 s), and
    completed audio/response terminals.
- [x] Qwen3-Omni speech integration test is included for GPU CI and covers
  non-empty realtime audio plus terminal ordering.

## Checklist

- [x] Format code with pre-commit.
- [x] Add focused tests.
- [x] Update documentation and the browser example.
- [x] Provide relevant validation and benchmark measurements.
- [ ] For reviewers: If you have not contributed to this PR and are only
  assisting with the merge, remove yourself as a co-author when merging.

## CI

GPU CI requires a maintainer to add the `run-ci` label. Draft PRs are skipped
even when labeled.
