### PR TITLE
[Comm] Remove redundant communication validation

### DIFF
--- a/sglang_omni/comm/engine.py
+++ b/sglang_omni/comm/engine.py
@@ -161,10 +161,6 @@ class CommEngine:
         to_stage: str,
         target_endpoint: str,
     ) -> DataRef:
-        if not isinstance(payload, StagePayload):
-            raise TypeError(
-                f"send_payload expects StagePayload, got {type(payload).__name__}"
-            )
         queue = self._send_queue_for(to_stage)
         loop = asyncio.get_running_loop()
         ready: asyncio.Future[DataRef] = loop.create_future()
@@ -596,10 +592,6 @@ class CommEngine:
         self.router.close()
 
     def ack_transfer(self, ack: DataAckMessage) -> None:
-        if ack.to_stage != self.router.stage_name:
-            raise ValueError(
-                f"data_ack for {ack.to_stage!r} delivered to {self.router.stage_name!r}"
-            )
         pending = self._pending.get(ack.object_id)
         if pending is None:
             logger.debug(
@@ -613,11 +605,8 @@ class CommEngine:
             if not pending.ack.done():
                 pending.ack.set_result(None)
             return
-        error = ack.error
-        if error is None:
-            raise ValueError("failed data_ack is missing error")
         if not pending.ack.done():
-            pending.ack.set_exception(RuntimeError(error))
+            pending.ack.set_exception(RuntimeError(ack.error))
 
     def _send_queue_for(
         self, queue_key: str

--- a/sglang_omni/comm/router.py
+++ b/sglang_omni/comm/router.py
@@ -81,11 +81,6 @@ class CommRouter:
         return TransportKind.SHM
 
     def outbound_stream(self, target: str, data: torch.Tensor) -> TransportKind:
-        if not isinstance(data, torch.Tensor):
-            raise TypeError(
-                "relay-backed stream chunks must be torch.Tensor, got "
-                f"{type(data).__name__}"
-            )
         if target in self.remote_stage_names:
             return TransportKind.MOONCAKE
         if not data.is_cuda:
@@ -115,21 +110,10 @@ class CommRouter:
             self._relays[kind] = relay
         return relay
 
-    def relay_for(self, target: str) -> tuple[TransportKind, Relay]:
-        kind = self.outbound(target)
-        if kind is TransportKind.LOCAL_OBJECT:
-            raise ValueError(
-                f"same-process target {target!r} has no relay transport; "
-                "use local-object dispatch"
-            )
-        return kind, self.relay(kind)
-
     def relay_for_payload(
         self, target: str, payload: Any
     ) -> tuple[TransportKind, Relay]:
         kind = self.outbound_payload(target, payload)
-        if kind is TransportKind.LOCAL_OBJECT:
-            raise ValueError("local_object has no relay")
         return kind, self.relay(kind)
 
     def outbound_payload(self, target: str, payload: Any) -> TransportKind:
@@ -148,11 +132,6 @@ class CommRouter:
         self, target: str, data: torch.Tensor
     ) -> tuple[TransportKind, Relay]:
         kind = self.outbound_stream(target, data)
-        if kind is TransportKind.LOCAL_OBJECT:
-            raise ValueError(
-                f"same-process stream target {target!r} has no relay transport; "
-                "use local-object dispatch"
-            )
         return kind, self.relay(kind)
 
     def inbound_relay(self, from_stage: str) -> Relay:

--- a/sglang_omni/comm/stage_io.py
+++ b/sglang_omni/comm/stage_io.py
@@ -44,13 +44,7 @@ _DIRECT_CUDA_IPC_STREAM_INLINE_BYTES_LIMIT = 64 * 1024
 
 
 def relay_device(relay: Relay) -> str:
-    device = relay.device
-    if not isinstance(device, str):
-        raise TypeError(
-            f"{type(relay).__name__}.device must be str, got "
-            f"{type(device).__name__}"
-        )
-    return device
+    return relay.device
 
 
 def extract_tensors(obj: Any, path: str = "") -> tuple[Any, dict[str, torch.Tensor]]:
@@ -136,16 +130,9 @@ def payload_has_cuda_tensor(payload: Any) -> bool:
 
 
 def serialize_direct_cuda_ipc_payload(payload: StagePayload) -> dict[str, Any]:
-    if not isinstance(payload, StagePayload):
-        raise TypeError(
-            f"direct CUDA IPC payload requires StagePayload, got "
-            f"{type(payload).__name__}"
-        )
     if _contains_cuda_tensor(payload.request) or _contains_cpu_tensor(payload.request):
         raise ValueError("direct CUDA IPC payload does not support request tensors")
     data_without_tensors, tensors = extract_cuda_tensors(payload.data)
-    if not tensors:
-        raise ValueError("direct CUDA IPC payload requires at least one CUDA tensor")
     header = StagePayload(
         request_id=payload.request_id,
         request=payload.request,
@@ -170,60 +157,10 @@ def is_direct_cuda_ipc_payload_ref(value: Any) -> bool:
 
 
 def deserialize_direct_cuda_ipc_payload(data_ref: dict[str, Any]) -> StagePayload:
-    if data_ref.get("_type") != _DIRECT_CUDA_IPC_PAYLOAD_TYPE:
-        raise ValueError("data_ref is not a direct CUDA IPC payload")
-    if data_ref.get("version") != 1:
-        raise ValueError(
-            f"unsupported direct CUDA IPC payload version {data_ref.get('version')!r}"
-        )
-    header_bytes = data_ref.get("header")
-    if not isinstance(header_bytes, bytes):
-        raise TypeError(
-            "direct CUDA IPC payload header must be bytes, got "
-            f"{type(header_bytes).__name__}"
-        )
-    header = pickle.loads(header_bytes)
-    if not isinstance(header, StagePayload):
-        raise TypeError(
-            "direct CUDA IPC payload header must decode to StagePayload, got "
-            f"{type(header).__name__}"
-        )
-    raw_tensors = data_ref.get("tensors")
-    if not isinstance(raw_tensors, list):
-        raise TypeError(
-            "direct CUDA IPC payload tensors must be list, got "
-            f"{type(raw_tensors).__name__}"
-        )
-    tensors: dict[str, torch.Tensor] = {}
-    for item in raw_tensors:
-        if not isinstance(item, dict):
-            raise TypeError(
-                "direct CUDA IPC payload tensor entry must be dict, got "
-                f"{type(item).__name__}"
-            )
-        path = item.get("path")
-        if not isinstance(path, str):
-            raise TypeError(
-                "direct CUDA IPC payload tensor path must be str, got "
-                f"{type(path).__name__}"
-            )
-        tensor_bytes = item.get("tensor_bytes")
-        if not isinstance(tensor_bytes, bytes):
-            raise TypeError(
-                "direct CUDA IPC payload tensor_bytes must be bytes, got "
-                f"{type(tensor_bytes).__name__}"
-            )
-        tensor = pickle.loads(tensor_bytes)
-        if not isinstance(tensor, torch.Tensor):
-            raise TypeError(
-                "direct CUDA IPC payload tensor entry must decode to Tensor, got "
-                f"{type(tensor).__name__}"
-            )
-        if not tensor.is_cuda:
-            raise ValueError("direct CUDA IPC payload tensor decoded as non-CUDA")
-        if path in tensors:
-            raise ValueError(f"duplicate direct CUDA IPC tensor path {path!r}")
-        tensors[path] = tensor
+    header = pickle.loads(data_ref["header"])
+    tensors = {
+        item["path"]: pickle.loads(item["tensor_bytes"]) for item in data_ref["tensors"]
+    }
     return StagePayload(
         request_id=header.request_id,
         request=header.request,
@@ -257,34 +194,11 @@ def is_direct_cuda_ipc_stream_chunk_ref(value: Any) -> bool:
 def deserialize_direct_cuda_ipc_stream_chunk(
     data_ref: dict[str, Any],
 ) -> tuple[Any, dict[str, Any] | None]:
-    if data_ref.get("_type") != _DIRECT_CUDA_IPC_STREAM_CHUNK_TYPE:
-        raise ValueError("data_ref is not a direct CUDA IPC stream chunk")
-    if data_ref.get("version") != 1:
-        raise ValueError(
-            f"unsupported direct CUDA IPC version {data_ref.get('version')!r}"
-        )
-    tensor_bytes = data_ref.get("tensor_bytes")
-    if not isinstance(tensor_bytes, bytes):
-        raise TypeError(
-            "direct CUDA IPC data_ref tensor_bytes must be bytes, got "
-            f"{type(tensor_bytes).__name__}"
-        )
-    data = pickle.loads(tensor_bytes)
+    data = pickle.loads(data_ref["tensor_bytes"])
     raw_metadata = data_ref.get("metadata")
     if raw_metadata is None:
         return data, None
-    if not isinstance(raw_metadata, dict):
-        raise TypeError(
-            "direct CUDA IPC metadata must be dict, got "
-            f"{type(raw_metadata).__name__}"
-        )
-    metadata = deserialize_direct_ipc_metadata(raw_metadata)
-    if not isinstance(metadata, dict):
-        raise TypeError(
-            "direct CUDA IPC decoded metadata must be dict, got "
-            f"{type(metadata).__name__}"
-        )
-    return data, metadata
+    return data, deserialize_direct_ipc_metadata(raw_metadata)
 
 
 async def write_payload(
@@ -329,10 +243,6 @@ async def read_payload(
     request_id: str,
     data_ref: DataRef,
 ) -> StagePayload:
-    if data_ref.kind is not DataKind.STAGE_PAYLOAD:
-        raise ValueError(f"expected stage_payload, got {data_ref.kind.value}")
-    if data_ref.header is None:
-        raise ValueError("stage_payload data_ref is missing header")
     header = pickle.loads(base64.b64decode(data_ref.header))
     transfer_buf = await _read_transfer_buffer(relay, request_id, data_ref)
     tensors = {
@@ -363,10 +273,6 @@ async def write_tensor(
     from_stage: str | None = None,
     to_stage: str | None = None,
 ) -> tuple[DataRef, Any]:
-    if not isinstance(tensor, torch.Tensor):
-        raise TypeError(
-            f"write_tensor requires torch.Tensor, got {type(tensor).__name__}"
-        )
     packed = tensor.contiguous().view(torch.uint8).reshape(-1)
     target_device = torch.device(relay_device(relay))
     if packed.device != target_device:
@@ -404,14 +310,6 @@ async def read_tensor(
     relay: Relay,
     data_ref: DataRef,
 ) -> torch.Tensor:
-    if data_ref.layout is not DataLayout.RAW_TENSOR:
-        raise ValueError(f"expected raw_tensor layout, got {data_ref.layout.value}")
-    if data_ref.shape is None:
-        raise ValueError("raw tensor data_ref is missing shape")
-    if data_ref.dtype is None:
-        raise ValueError("raw tensor data_ref is missing dtype")
-    if data_ref.offset is None:
-        raise ValueError("raw tensor data_ref is missing offset")
     transfer_buf = await _read_transfer_buffer(relay, data_ref.object_id, data_ref)
     return (
         transfer_buf[data_ref.offset :]
@@ -704,15 +602,11 @@ def _serialize_direct_ipc_metadata_value(value: Any) -> Any:
 def deserialize_direct_ipc_metadata(value: Any) -> Any:
     if isinstance(value, dict):
         if set(value) == {"_ipc_tensor"}:
-            tensor_bytes = value["_ipc_tensor"]
-            if not isinstance(tensor_bytes, bytes):
-                raise TypeError("_ipc_tensor metadata must be bytes")
-            return pickle.loads(tensor_bytes)
+            return pickle.loads(value["_ipc_tensor"])
         if set(value) == {"_ipc_tuple"}:
-            items = value["_ipc_tuple"]
-            if not isinstance(items, list):
-                raise TypeError("_ipc_tuple metadata must be list")
-            return tuple(deserialize_direct_ipc_metadata(item) for item in items)
+            return tuple(
+                deserialize_direct_ipc_metadata(item) for item in value["_ipc_tuple"]
+            )
         return {
             key: deserialize_direct_ipc_metadata(item) for key, item in value.items()
         }

--- a/sglang_omni/pipeline/control_plane.py
+++ b/sglang_omni/pipeline/control_plane.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import logging
+from typing import cast
 
 import msgpack
 import zmq
@@ -201,9 +202,7 @@ class SubSocket:
         if self._socket is None:
             raise RuntimeError("Socket not connected")
         data = await self._socket.recv()
-        msg = deserialize_message(data)
-        if not isinstance(msg, AbortMessage):
-            raise ValueError(f"Expected AbortMessage, got {type(msg)}")
+        msg = cast(AbortMessage, deserialize_message(data))
         logger.debug("SUB received %s", type(msg).__name__)
         return msg
 
@@ -279,23 +278,18 @@ class StageControlPlane:
         """Receive work from previous stage or coordinator."""
         if self._recv_socket is None:
             raise RuntimeError("Control plane not started")
-        msg = await self._recv_socket.recv()
-        if isinstance(
-            msg,
-            (
-                DataReadyMessage,
-                DataAckMessage,
-                KVTransferPrepareMessage,
-                KVTransferReadyMessage,
-                SubmitMessage,
-                ShutdownMessage,
-                ProfilerStartMessage,
-                ProfilerStopMessage,
-                AdminMessage,
-            ),
-        ):
-            return msg
-        raise ValueError(f"Unexpected message type: {type(msg)}")
+        return cast(
+            AdminMessage
+            | DataAckMessage
+            | DataReadyMessage
+            | KVTransferPrepareMessage
+            | KVTransferReadyMessage
+            | SubmitMessage
+            | ShutdownMessage
+            | ProfilerStartMessage
+            | ProfilerStopMessage,
+            await self._recv_socket.recv(),
+        )
 
     async def send_to_stage(
         self,
@@ -407,12 +401,9 @@ class CoordinatorControlPlane:
         """Receive completion or stream event from a stage."""
         if self._completion_socket is None:
             raise RuntimeError("Control plane not started")
-        msg = await self._completion_socket.recv()
-        if isinstance(msg, (CompleteMessage, StreamMessage, AdminResultMessage)):
-            return msg
-        raise ValueError(
-            "Expected CompleteMessage, StreamMessage, or AdminResultMessage, "
-            f"got {type(msg)}"
+        return cast(
+            CompleteMessage | StreamMessage | AdminResultMessage,
+            await self._completion_socket.recv(),
         )
 
     async def send_admin(

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -694,8 +694,6 @@ class Stage:
         await self._send_failure(request_id, str(error))
 
     def _data_ref_from_message(self, msg: DataReadyMessage) -> DataRef:
-        if msg.data_ref is None:
-            raise ValueError("data_ready message is missing transfer data_ref")
         return DataRef.from_dict(msg.data_ref)
 
     async def _send_data_ack(
@@ -768,8 +766,6 @@ class Stage:
             imported = stage_io.deserialize_direct_cuda_ipc_stream_chunk(msg.data_ref)
             del imported
             return
-        if msg.chunk_id is None:
-            raise ValueError("stream chunk discard requires chunk_id")
         data_ref = self._data_ref_from_message(msg)
         relay = self._comm.relay(data_ref.transport)
         try:

--- a/sglang_omni/proto/messages.py
+++ b/sglang_omni/proto/messages.py
@@ -27,76 +27,11 @@ class DataReadyMessage:
     error: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        _require_str(self.request_id, "request_id")
-        _require_str(self.from_stage, "from_stage")
-        _require_str(self.to_stage, "to_stage")
-        _require_bool(self.is_done, "is_done")
-        if self.is_done and self.error is not None:
-            raise ValueError("stream signal cannot be both done and error")
-        if self.is_done or self.error is not None:
-            if self.data_ref is not None:
-                raise ValueError("stream signal must not carry data_ref")
-            if self.chunk_id is not None:
-                raise ValueError("stream signal must not carry chunk_id")
-        elif not isinstance(self.data_ref, dict):
-            raise TypeError(
-                "DataReadyMessage.data_ref must be dict for data messages, got "
-                f"{type(self.data_ref).__name__}"
-            )
-        d = {
-            "type": "data_ready",
-            "request_id": self.request_id,
-            "from_stage": self.from_stage,
-            "to_stage": self.to_stage,
-        }
-        if self.data_ref is not None:
-            d["data_ref"] = self.data_ref.copy()
-        if self.chunk_id is not None:
-            _require_non_negative_int(self.chunk_id, "chunk_id")
-            d["chunk_id"] = self.chunk_id
-        if self.is_done:
-            d["is_done"] = True
-        if self.error is not None:
-            _require_str(self.error, "error")
-            d["error"] = self.error
-        return d
+        return {"type": "data_ready", **msgspec.to_builtins(self)}
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "DataReadyMessage":
-        request_id = _require_str(d.get("request_id"), "request_id")
-        from_stage = _require_str(d.get("from_stage"), "from_stage")
-        to_stage = _require_str(d.get("to_stage"), "to_stage")
-        data_ref = d.get("data_ref")
-        raw_is_done = d.get("is_done", False)
-        is_done = _require_bool(raw_is_done, "is_done")
-        error = d.get("error")
-        if error is not None:
-            error = _require_str(error, "error")
-        if is_done and error is not None:
-            raise ValueError("stream signal cannot be both done and error")
-        if is_done or error is not None:
-            if data_ref is not None:
-                raise ValueError("stream signal must not carry data_ref")
-            if "chunk_id" in d:
-                raise ValueError("stream signal must not carry chunk_id")
-        elif not isinstance(data_ref, dict):
-            raise TypeError(
-                "data_ready data_ref must be dict for data messages, got "
-                f"{type(data_ref).__name__}"
-            )
-        chunk_id = d.get("chunk_id")
-        if chunk_id is not None:
-            _require_non_negative_int(chunk_id, "chunk_id")
-
-        return cls(
-            request_id=request_id,
-            from_stage=from_stage,
-            to_stage=to_stage,
-            data_ref=data_ref,
-            chunk_id=chunk_id,
-            is_done=is_done,
-            error=error,
-        )
+        return msgspec.convert(d, type=cls, strict=True)
 
 
 class DataAckMessage(msgspec.Struct):
@@ -110,48 +45,11 @@ class DataAckMessage(msgspec.Struct):
     error: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        _require_str(self.request_id, "request_id")
-        _require_str(self.from_stage, "from_stage")
-        _require_str(self.to_stage, "to_stage")
-        _require_str(self.object_id, "object_id")
-        if not isinstance(self.success, bool):
-            raise TypeError("success must be bool")
-        if self.success:
-            if self.error is not None:
-                raise ValueError("successful data ack must not carry error")
-        else:
-            _require_str(self.error, "error")
-        d: dict[str, Any] = {
-            "type": "data_ack",
-            "request_id": self.request_id,
-            "from_stage": self.from_stage,
-            "to_stage": self.to_stage,
-            "object_id": self.object_id,
-            "success": self.success,
-        }
-        if self.error is not None:
-            d["error"] = self.error
-        return d
+        return {"type": "data_ack", **msgspec.to_builtins(self)}
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "DataAckMessage":
-        success = d.get("success")
-        if not isinstance(success, bool):
-            raise TypeError("data_ack success must be bool")
-        error = d.get("error")
-        if success:
-            if error is not None:
-                raise ValueError("successful data_ack must not carry error")
-        else:
-            error = _require_str(error, "error")
-        return cls(
-            request_id=_require_str(d.get("request_id"), "request_id"),
-            from_stage=_require_str(d.get("from_stage"), "from_stage"),
-            to_stage=_require_str(d.get("to_stage"), "to_stage"),
-            object_id=_require_str(d.get("object_id"), "object_id"),
-            success=success,
-            error=error,
-        )
+        return msgspec.convert(d, type=cls, strict=True)
 
 
 @dataclass
@@ -388,21 +286,3 @@ def parse_message(
         return AdminResultMessage.from_dict(d)
     else:
         raise ValueError(f"Unknown message type: {msg_type}")
-
-
-def _require_str(value: Any, name: str) -> str:
-    if not isinstance(value, str) or value == "":
-        raise TypeError(f"{name} must be a non-empty str")
-    return value
-
-
-def _require_bool(value: Any, name: str) -> bool:
-    if type(value) is not bool:
-        raise TypeError(f"{name} must be bool")
-    return value
-
-
-def _require_non_negative_int(value: Any, name: str) -> int:
-    if type(value) is not int or value < 0:
-        raise TypeError(f"{name} must be a non-negative int")
-    return value

--- a/sglang_omni/relay/cuda_ipc.py
+++ b/sglang_omni/relay/cuda_ipc.py
@@ -173,8 +173,6 @@ def _load_cuda_storage_handle(
 
 
 def _slots_for_size(size: int, slot_size: int) -> int:
-    if size < 0:
-        raise ValueError("cuda_ipc transfer size must be non-negative")
     return max(1, (size + slot_size - 1) // slot_size)
 
 
@@ -414,10 +412,6 @@ class CudaIpcGetOperation(RelayOperation):
 
 class _ContiguousSlotAllocator:
     def __init__(self, *, slot_count: int, slot_size: int) -> None:
-        if slot_count <= 0:
-            raise ValueError("slot_count must be positive")
-        if slot_size <= 0:
-            raise ValueError("slot_size must be positive")
         self.slot_count = slot_count
         self.slot_size = slot_size
         self._free = [True] * slot_count
@@ -429,14 +423,6 @@ class _ContiguousSlotAllocator:
     async def acquire_async(
         self, num_slots: int, *, capture_layout: bool = False
     ) -> _SlotAllocation:
-        if num_slots <= 0:
-            raise ValueError("num_slots must be positive")
-        if num_slots > self.slot_count:
-            raise ValueError(
-                f"allocation requires {num_slots} slots, but pool has "
-                f"{self.slot_count}"
-            )
-
         wait_rounds = 0
         last_failed_free_slots = 0
         last_failed_largest_free_run = 0
@@ -471,13 +457,7 @@ class _ContiguousSlotAllocator:
             await self._changed.wait()
 
     def release(self, offset: int, num_slots: int) -> None:
-        if num_slots <= 0:
-            raise ValueError("num_slots must be positive")
-        if offset % self.slot_size != 0:
-            raise ValueError("offset must be slot aligned")
         slot_index = offset // self.slot_size
-        if slot_index < 0 or slot_index + num_slots > self.slot_count:
-            raise ValueError("slot range is outside the pool")
         for index in range(slot_index, slot_index + num_slots):
             if self._free[index]:
                 raise RuntimeError("cuda_ipc slot released twice")

--- a/tests/unit_test/pipeline/test_comm_engine_ack.py
+++ b/tests/unit_test/pipeline/test_comm_engine_ack.py
@@ -11,7 +11,7 @@ import torch
 from sglang_omni.comm.data_ref import DataRef, TransportKind
 from sglang_omni.comm.engine import CommEngine
 from sglang_omni.comm.router import CommRouter
-from sglang_omni.proto import DataAckMessage, DataReadyMessage
+from sglang_omni.proto import DataAckMessage
 from tests.unit_test.fixtures.pipeline_fakes import (
     RecordingStageControlPlane,
     make_stage_payload,
@@ -199,60 +199,6 @@ def test_comm_engine_ignores_duplicate_data_ack() -> None:
         engine.ack_transfer(ack)
 
     asyncio.run(_run())
-
-
-def test_data_messages_reject_missing_data_ref() -> None:
-    with pytest.raises(TypeError, match="data_ref"):
-        DataReadyMessage(
-            request_id="req-1",
-            from_stage="a",
-            to_stage="b",
-            data_ref=None,
-        ).to_dict()
-
-    with pytest.raises(TypeError, match="success"):
-        DataAckMessage.from_dict(
-            {
-                "type": "data_ack",
-                "request_id": "req-1",
-                "from_stage": "b",
-                "to_stage": "a",
-                "object_id": "obj",
-            }
-        )
-
-    with pytest.raises(TypeError, match="is_done"):
-        DataReadyMessage.from_dict(
-            {
-                "type": "data_ready",
-                "request_id": "req-1",
-                "from_stage": "a",
-                "to_stage": "b",
-                "is_done": "false",
-            }
-        )
-
-    with pytest.raises(TypeError, match="chunk_id"):
-        DataReadyMessage.from_dict(
-            {
-                "type": "data_ready",
-                "request_id": "req-1",
-                "from_stage": "a",
-                "to_stage": "b",
-                "data_ref": {"version": 1},
-                "chunk_id": True,
-            }
-        )
-
-    with pytest.raises(ValueError, match="both done and error"):
-        DataReadyMessage(
-            request_id="req-1",
-            from_stage="a",
-            to_stage="b",
-            data_ref=None,
-            is_done=True,
-            error="boom",
-        ).to_dict()
 
 
 def test_data_ref_rejects_bool_int_fields() -> None:

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -1247,13 +1247,6 @@ def test_direct_cuda_ipc_payload_allows_large_ordinary_header(monkeypatch) -> No
     assert ref["tensors"] == [{"path": "gpu", "tensor_bytes": b"cuda-handle"}]
 
 
-def test_direct_cuda_ipc_payload_rejects_cpu_only_payloads() -> None:
-    payload = make_stage_payload(data={"x": torch.ones(1)})
-
-    with pytest.raises(ValueError, match="at least one CUDA tensor"):
-        stage_io.serialize_direct_cuda_ipc_payload(payload)
-
-
 def test_direct_cuda_ipc_payload_rejects_request_tensors() -> None:
     payload = make_stage_payload(data={"x": "ok"}, inputs={"tensor": torch.ones(1)})
 


### PR DESCRIPTION
## Summary

- remove redundant validation from the existing communication lifecycle
- simplify `DataReadyMessage` and `DataAckMessage` wire conversion with `msgspec`
- remove repeated routing, direct CUDA IPC, and slot allocator checks already guaranteed by their callers
- retain protocol dispatch, backend capability, and memory-safety boundaries

## Why

This is a generic communication cleanup split out of #1315 so that the paged KV transfer PR only contains validation changes to code introduced by that PR.

## Validation

- `pre-commit run --all-files`
- `CUDA_VISIBLE_DEVICES=6,7 LD_PRELOAD=/lib/x86_64-linux-gnu/libcuda.so.1 pytest -q tests/unit_test/pipeline tests/unit_test/relay/test_cuda_ipc_relay.py` (`402 passed`)
