### PR TITLE
[CI] Pin perf-gate test sessions to OMNI_CI_CPUSET when set

### DIFF
--- a/tests/test_model/conftest.py
+++ b/tests/test_model/conftest.py
@@ -16,6 +16,48 @@ if TYPE_CHECKING:
 
     from tests.utils import ServerHandle
 
+
+def _parse_cpuset(spec: str) -> set[int]:
+    """Parse a Linux cpulist such as "0-23,64-87" into a CPU id set."""
+    cpus: set[int] = set()
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            lo_text, hi_text = part.split("-", 1)
+            lo, hi = int(lo_text), int(hi_text)
+            if lo > hi:
+                raise ValueError(f"Invalid OMNI_CI_CPUSET range {part!r}")
+            cpus.update(range(lo, hi + 1))
+        else:
+            cpus.add(int(part))
+    if not cpus:
+        raise ValueError(f"OMNI_CI_CPUSET {spec!r} selects no CPUs")
+    return cpus
+
+
+def _apply_omni_ci_cpuset() -> set[int] | None:
+    spec = os.environ.get("OMNI_CI_CPUSET", "").strip()
+    if not spec or not hasattr(os, "sched_setaffinity"):
+        return None
+    cpus = _parse_cpuset(spec)
+    os.sched_setaffinity(0, cpus)
+    return cpus
+
+
+@pytest.fixture(autouse=True, scope="session")
+def pin_omni_ci_cpuset() -> None:
+    """Pin the test session, and every server it spawns, to OMNI_CI_CPUSET.
+
+    The gates in this directory measure host-bound serving stacks, so on a
+    shared runner concurrent jobs inflate per-request CPU cost and shift
+    calibrated floors. Child processes inherit the affinity, which keeps the
+    managed router, its workers, and the bench client on the reserved cores.
+    """
+    _apply_omni_ci_cpuset()
+
+
 TTS_ALLOWED_CONCURRENCIES = (1, 2, 4, 8, 16)
 TTS_STAGE_NONSTREAM = "tts-stage-1-nonstream"
 TTS_STAGE_STREAM = "tts-stage-2-stream"

--- a/tests/test_model/conftest.py
+++ b/tests/test_model/conftest.py
@@ -23,7 +23,7 @@ def _parse_cpuset(spec: str) -> set[int]:
     for part in spec.split(","):
         part = part.strip()
         if not part:
-            continue
+            raise ValueError(f"Empty component in OMNI_CI_CPUSET {spec!r}")
         if "-" in part:
             lo_text, hi_text = part.split("-", 1)
             lo, hi = int(lo_text), int(hi_text)
@@ -41,9 +41,18 @@ def _apply_omni_ci_cpuset() -> set[int] | None:
     spec = os.environ.get("OMNI_CI_CPUSET", "").strip()
     if not spec or not hasattr(os, "sched_setaffinity"):
         return None
-    cpus = _parse_cpuset(spec)
-    os.sched_setaffinity(0, cpus)
-    return cpus
+    requested = _parse_cpuset(spec)
+    previous = os.sched_getaffinity(0)
+    os.sched_setaffinity(0, requested)
+    # Note: (Jiaxin Deng) Linux may silently intersect the request with the
+    # cgroup/cpuset-allowed CPUs; a partial pin would invalidate calibration.
+    effective = os.sched_getaffinity(0)
+    if effective != requested:
+        raise RuntimeError(
+            f"OMNI_CI_CPUSET pinning ineffective: requested {sorted(requested)}, "
+            f"previously allowed {sorted(previous)}, effective {sorted(effective)}"
+        )
+    return requested
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/unit_test/ci/test_cpuset_pinning.py
+++ b/tests/unit_test/ci/test_cpuset_pinning.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the OMNI_CI_CPUSET pinning hook in test_model/conftest."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.test_model.conftest import _apply_omni_ci_cpuset, _parse_cpuset
+
+
+def test_parse_cpuset_ranges_and_singles():
+    assert _parse_cpuset("0-3,8,64-65") == {0, 1, 2, 3, 8, 64, 65}
+
+
+def test_parse_cpuset_single_cpu():
+    assert _parse_cpuset("7") == {7}
+
+
+def test_parse_cpuset_rejects_empty():
+    with pytest.raises(ValueError):
+        _parse_cpuset(" , ")
+
+
+def test_parse_cpuset_rejects_inverted_range():
+    with pytest.raises(ValueError):
+        _parse_cpuset("5-2")
+
+
+def test_parse_cpuset_rejects_garbage():
+    with pytest.raises(ValueError):
+        _parse_cpuset("0-a")
+
+
+def test_apply_noop_without_env(monkeypatch):
+    monkeypatch.delenv("OMNI_CI_CPUSET", raising=False)
+    assert _apply_omni_ci_cpuset() is None
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "sched_setaffinity"), reason="requires sched_setaffinity"
+)
+def test_apply_pins_and_children_would_inherit(monkeypatch):
+    original = os.sched_getaffinity(0)
+    target = set(sorted(original)[:2])
+    spec = ",".join(str(c) for c in sorted(target))
+    monkeypatch.setenv("OMNI_CI_CPUSET", spec)
+    try:
+        assert _apply_omni_ci_cpuset() == target
+        assert os.sched_getaffinity(0) == target
+    finally:
+        os.sched_setaffinity(0, original)

--- a/tests/unit_test/ci/test_cpuset_pinning.py
+++ b/tests/unit_test/ci/test_cpuset_pinning.py
@@ -18,9 +18,10 @@ def test_parse_cpuset_single_cpu():
     assert _parse_cpuset("7") == {7}
 
 
-def test_parse_cpuset_rejects_empty():
+@pytest.mark.parametrize("spec", ["", " , ", "0,,1", ",0-3", "0-3,", ","])
+def test_parse_cpuset_rejects_empty_components(spec):
     with pytest.raises(ValueError):
-        _parse_cpuset(" , ")
+        _parse_cpuset(spec)
 
 
 def test_parse_cpuset_rejects_inverted_range():
@@ -36,6 +37,14 @@ def test_parse_cpuset_rejects_garbage():
 def test_apply_noop_without_env(monkeypatch):
     monkeypatch.delenv("OMNI_CI_CPUSET", raising=False)
     assert _apply_omni_ci_cpuset() is None
+
+
+def test_apply_fails_when_kernel_narrows_affinity(monkeypatch):
+    monkeypatch.setenv("OMNI_CI_CPUSET", "0-1")
+    monkeypatch.setattr(os, "sched_setaffinity", lambda pid, cpus: None, raising=False)
+    monkeypatch.setattr(os, "sched_getaffinity", lambda pid: {0}, raising=False)
+    with pytest.raises(RuntimeError, match=r"requested \[0, 1\].*effective \[0\]"):
+        _apply_omni_ci_cpuset()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION

## Motivation

Perf gates on the shared runner measure host-bound serving stacks, and their throughput tracks host load (#1296). Measured on the CI host with the Fun-ASR SeedTTS EN speed stage (fresh server per round, CI semantics): with 64 synthetic busy loops as background load, an unpinned run keeps 55 to 62 percent of its quiet-host throughput, while a run pinned to 24 reserved cores with the load placed off those cores keeps about 92 percent. Per-request server CPU time itself inflates 1.5x when load spreads across the machine (SMT sibling occupancy plus all-core frequency drop), which is why gate floors calibrated in quiet windows fail under storms.

## Change

An opt-in autouse session fixture in `tests/test_model/conftest.py`: when `OMNI_CI_CPUSET` is set (Linux cpulist, e.g. `0-23,64-87`), the pytest process pins itself with `sched_setaffinity`, and every child it spawns, the managed router, its workers, and the bench client, inherits the affinity. Unset means no behavior change anywhere. Invalid specs fail fast with `ValueError`.

Assigning the per-lane cpulists stays runner-side configuration (each GPU lane exports its own `OMNI_CI_CPUSET`); this PR ships only the mechanism. Calibration runs should export the same variable so floors are measured under the same policy.

## Verification

* `tests/unit_test/ci/test_cpuset_pinning.py`: cpulist parsing (ranges, singles, rejects empty/inverted/garbage), no-op without the env, and a real `sched_setaffinity` round-trip (skipped off-Linux).
* Throughput retention numbers above from the pinning 2x2 on the CI host, replicated twice per cell (A/B rounds), loadavg and PSI recorded per round.

## Evidence (from the pinning experiment, Fun-ASR seedtts en, c32, fresh server per round)

| condition | qps (A / B) | server CPU ms/req |
|---|---|---|
| quiet baseline | 93.6 / 90.9 | 46 to 47 |
| 64 busy loops, unpinned | 48.2 / 57.5 | 72 to 83 |
| 64 busy loops, pinned 0-23, load on other socket | 83.5 / 81.9 | 51 to 52 |
