### PR TITLE
[ASR] Multilingual support for Qwen3-ASR

### DIFF
--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -70,7 +70,7 @@ print(resp.json()["text"])
 |---|---|---|---|
 | `file` | file | required | Audio file uploaded as multipart form data |
 | `model` | string | server default | Model identifier |
-| `language` | string | `en` | Language hint; `zh`/`cn` select Chinese, other values use English prompting |
+| `language` | string | `en` | Language hint as a supported code or canonical name (case-insensitive) |
 | `prompt` | string | none | Accepted for OpenAI compatibility; Qwen3-ASR currently ignores it |
 | `response_format` | string | `json` | `json`, `verbose_json`, or `text` |
 | `temperature` | float | `0.01` effective | Sampling temperature; `0` is converted to near-greedy `0.01` |
@@ -79,6 +79,24 @@ print(resp.json()["text"])
 
 `verbose_json` uses the model adapter's verbose response schema and includes
 duration-based usage (rounded-up audio seconds) when duration probing succeeds.
+
+### Language Hints
+
+Qwen3-ASR accepts the following 30 language codes and their canonical names:
+
+| Codes | Canonical names |
+|---|---|
+| `ar`, `yue`, `zh`, `cs`, `da`, `nl`, `en`, `fil`, `fi`, `fr` | Arabic, Cantonese, Chinese, Czech, Danish, Dutch, English, Filipino, Finnish, French |
+| `de`, `el`, `hi`, `hu`, `id`, `it`, `ja`, `ko`, `mk`, `ms` | German, Greek, Hindi, Hungarian, Indonesian, Italian, Japanese, Korean, Macedonian, Malay |
+| `fa`, `pl`, `pt`, `ro`, `ru`, `es`, `sv`, `th`, `tr`, `vi` | Persian, Polish, Portuguese, Romanian, Russian, Spanish, Swedish, Thai, Turkish, Vietnamese |
+
+For example, `language=es` and `language=Spanish` both force the prompt suffix
+`language Spanish<asr_text>`. The legacy `cn` and regional `zh-*` spellings are
+also accepted as Chinese. Unsupported language hints return HTTP 400 instead of
+silently falling back to English.
+
+The model also has ASR coverage for 22 Chinese dialects, but those dialect names
+are not supported as forced `language` hints; use `Chinese`/`zh` for them.
 
 ## Benchmarking
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,7 +45,7 @@ Supported Models
      - Text-to-speech and zero-shot voice cloning
    * - `Qwen/Qwen3-ASR-1.7B <https://huggingface.co/Qwen/Qwen3-ASR-1.7B>`_
      - ASR
-     - Audio transcription through ``/v1/audio/transcriptions``
+     - Multilingual audio transcription with 30 language hints
    * - `openai/whisper-large-v3 <https://huggingface.co/openai/whisper-large-v3>`_
      - ASR
      - Experimental Whisper transcription route; response schema is served, correctness is not yet validated

--- a/sglang_omni/models/qwen3_asr/languages.py
+++ b/sglang_omni/models/qwen3_asr/languages.py
@@ -49,11 +49,13 @@ def resolve_language(language: str) -> str:
 
     value = str(language).strip()
     if not value:
-        raise ValueError("Unsupported language: the language hint is empty")
+        raise ValueError(
+            "Unsupported language: the language hint is empty. Use a supported "
+            f"language code ({', '.join(sorted(LANGUAGE_CODE_TO_NAME))}) or "
+            "canonical name."
+        )
 
     normalized = value.casefold()
-    # Preserve the historical ``cn`` and regional ``zh-*`` inputs while using
-    # the upstream ``zh`` canonical code for new requests.
     if normalized == "cn" or normalized.startswith(("zh-", "zh_")):
         return "Chinese"
 

--- a/sglang_omni/models/qwen3_asr/languages.py
+++ b/sglang_omni/models/qwen3_asr/languages.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Language-hint normalization for Qwen3-ASR."""
+
+from __future__ import annotations
+
+# Qwen3-ASR was trained with canonical full names in the forced-language
+# suffix: ``language <NAME><asr_text>``.
+LANGUAGE_CODE_TO_NAME: dict[str, str] = {
+    "ar": "Arabic",
+    "yue": "Cantonese",
+    "zh": "Chinese",
+    "cs": "Czech",
+    "da": "Danish",
+    "nl": "Dutch",
+    "en": "English",
+    "fil": "Filipino",
+    "fi": "Finnish",
+    "fr": "French",
+    "de": "German",
+    "el": "Greek",
+    "hi": "Hindi",
+    "hu": "Hungarian",
+    "id": "Indonesian",
+    "it": "Italian",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "mk": "Macedonian",
+    "ms": "Malay",
+    "fa": "Persian",
+    "pl": "Polish",
+    "pt": "Portuguese",
+    "ro": "Romanian",
+    "ru": "Russian",
+    "es": "Spanish",
+    "sv": "Swedish",
+    "th": "Thai",
+    "tr": "Turkish",
+    "vi": "Vietnamese",
+}
+
+SUPPORTED_LANGUAGE_NAMES = frozenset(LANGUAGE_CODE_TO_NAME.values())
+_LANGUAGE_NAME_BY_CASEFOLD = {
+    name.casefold(): name for name in SUPPORTED_LANGUAGE_NAMES
+}
+
+
+def resolve_language(language: str) -> str:
+    """Resolve a Qwen3-ASR language code or name to its canonical prompt name."""
+
+    value = str(language).strip()
+    if not value:
+        raise ValueError("Unsupported language: the language hint is empty")
+
+    normalized = value.casefold()
+    # Preserve the historical ``cn`` and regional ``zh-*`` inputs while using
+    # the upstream ``zh`` canonical code for new requests.
+    if normalized == "cn" or normalized.startswith(("zh-", "zh_")):
+        return "Chinese"
+
+    resolved = LANGUAGE_CODE_TO_NAME.get(normalized)
+    if resolved is None:
+        resolved = _LANGUAGE_NAME_BY_CASEFOLD.get(normalized)
+    if resolved is not None:
+        return resolved
+
+    raise ValueError(
+        f"Unsupported language: {language!r}. Use a supported language code "
+        f"({', '.join(sorted(LANGUAGE_CODE_TO_NAME))}) or canonical name."
+    )
+
+
+__all__ = [
+    "LANGUAGE_CODE_TO_NAME",
+    "SUPPORTED_LANGUAGE_NAMES",
+    "resolve_language",
+]

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -33,6 +33,7 @@ from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 
 from .audio_lengths import qwen3_asr_num_audio_tokens
+from .languages import resolve_language
 
 logger = logging.getLogger(__name__)
 
@@ -120,6 +121,8 @@ def make_qwen3_asr_scheduler_adapters(
 
     def request_builder(payload: StagePayload) -> Qwen3ASRRequestData:
         params = payload.request.params or {}
+        requested_language = str(params.get("language") or "en")
+        forced_language = resolve_language(requested_language)
         prepared = prepare_audio(
             payload, source_name="Qwen3-ASR", target_sample_rate=_SAMPLE_RATE
         )
@@ -161,10 +164,6 @@ def make_qwen3_asr_scheduler_adapters(
             f"num_audio_tokens={num_audio_tokens} feat_shape={tuple(features.shape)}"
         )
 
-        lang_raw = str(params.get("language") or "en").strip().lower()
-        forced_language = {"zh": "Chinese", "cn": "Chinese"}.get(
-            lang_raw, "Chinese" if lang_raw.startswith("zh") else "English"
-        )
         input_ids = _build_prompt_ids(num_audio_tokens, forced_language)
 
         audio_item = MultimodalDataItem(
@@ -248,7 +247,7 @@ def make_qwen3_asr_scheduler_adapters(
             max_new_tokens=request_max_new_tokens,
             temperature=temperature,
             audio_duration_s=audio_duration_s,
-            language=str(params.get("language") or "en"),
+            language=requested_language,
             engine_start_s=time.perf_counter(),
             stage_payload=payload,
         )

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -121,7 +121,8 @@ def make_qwen3_asr_scheduler_adapters(
 
     def request_builder(payload: StagePayload) -> Qwen3ASRRequestData:
         params = payload.request.params or {}
-        requested_language = str(params.get("language") or "en")
+        language = params.get("language")
+        requested_language = "en" if language is None else str(language)
         forced_language = resolve_language(requested_language)
         prepared = prepare_audio(
             payload, source_name="Qwen3-ASR", target_sample_rate=_SAMPLE_RATE

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -125,6 +125,7 @@ MAX_VOICE_UPLOAD_BODY_BYTES = (
 )
 
 _BAD_REQUEST_MARKERS = (
+    "Unsupported language:",
     "longer than the model's context length",
     "Requested token count exceeds the model's maximum context length",
     "accepts audio up to",

--- a/tests/README.md
+++ b/tests/README.md
@@ -387,6 +387,8 @@ that happened to contain an older version of the test.
     and `--decode-mode async|sync` CLI overrides
   - single-source audio token length formula used by both processor and
     request builder paths
+  - all 30 language-code/name mappings, Chinese compatibility aliases,
+    canonical forced-language prompts, and early unsupported-language rejection
   - token-level result adapter marker handling, avoiding decode/encode
     text round-trips for byte-level BPE output.
 - `unit_test/fun_asr/`: Fun-ASR-Nano unit tests:

--- a/tests/unit_test/qwen3_asr/test_request_builders.py
+++ b/tests/unit_test/qwen3_asr/test_request_builders.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 import torch
 from transformers import WhisperFeatureExtractor
 
@@ -14,6 +15,10 @@ from sglang_omni.models.qwen3_asr.audio_lengths import (
     qwen3_asr_num_audio_tokens,
 )
 from sglang_omni.models.qwen3_asr.configuration_qwen3_asr import Qwen3ASRProcessor
+from sglang_omni.models.qwen3_asr.languages import (
+    LANGUAGE_CODE_TO_NAME,
+    resolve_language,
+)
 from sglang_omni.models.qwen3_asr.request_builders import (
     Qwen3ASRRequestData,
     make_qwen3_asr_scheduler_adapters,
@@ -26,6 +31,7 @@ class _FakeTokenizer:
     vocab_size = 1000
 
     def __init__(self) -> None:
+        self.call_texts: list[str] = []
         self.encode_calls: list[str] = []
         self.decode_calls: list[dict] = []
 
@@ -41,6 +47,7 @@ class _FakeTokenizer:
 
     def __call__(self, text: str, *, add_special_tokens: bool = False):
         assert not add_special_tokens
+        self.call_texts.append(text)
         audio_pad_count = text.count("<|audio_pad|>")
         return SimpleNamespace(input_ids=[11] + [42] * audio_pad_count + [12, 13, 14])
 
@@ -82,6 +89,96 @@ def test_qwen3_asr_audio_token_length_formula_is_shared() -> None:
     assert torch.equal(qwen3_asr_audio_token_lengths(lengths), expected)
     assert torch.equal(processor._get_feat_extract_output_lengths(lengths), expected)
     assert qwen3_asr_num_audio_tokens(3000) == 390
+
+
+@pytest.mark.parametrize(
+    ("language_code", "expected_name"), sorted(LANGUAGE_CODE_TO_NAME.items())
+)
+def test_qwen3_asr_resolves_every_supported_language_code(
+    language_code: str,
+    expected_name: str,
+) -> None:
+    assert resolve_language(language_code) == expected_name
+    assert resolve_language(language_code.upper()) == expected_name
+
+
+@pytest.mark.parametrize("language_name", sorted(LANGUAGE_CODE_TO_NAME.values()))
+def test_qwen3_asr_resolves_canonical_names_case_insensitively(
+    language_name: str,
+) -> None:
+    assert resolve_language(f"  {language_name.swapcase()}  ") == language_name
+
+
+@pytest.mark.parametrize("language", ["cn", "zh-CN", "zh_Hant"])
+def test_qwen3_asr_preserves_chinese_compatibility_aliases(language: str) -> None:
+    assert resolve_language(language) == "Chinese"
+
+
+@pytest.mark.parametrize(
+    ("language", "expected_name"),
+    [("en", "English"), ("es", "Spanish"), ("fReNcH", "French")],
+)
+def test_qwen3_asr_request_builder_uses_canonical_language_prompt(
+    monkeypatch,
+    language: str,
+    expected_name: str,
+) -> None:
+    tokenizer = _FakeTokenizer()
+    feature_extractor = lambda *args, **kwargs: SimpleNamespace(
+        input_features=torch.zeros((1, 128, 100)),
+        attention_mask=torch.ones((1, 100), dtype=torch.long),
+    )
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(1600, dtype=np.float32),
+    )
+    request_builder, _ = make_qwen3_asr_scheduler_adapters(
+        tokenizer=tokenizer,
+        max_new_tokens=32,
+        feature_extractor=feature_extractor,
+    )
+    payload = StagePayload(
+        request_id="req-language",
+        request=OmniRequest(
+            inputs={"audio_bytes": b"wav"},
+            params={"language": language},
+        ),
+        data={},
+    )
+
+    data = request_builder(payload)
+
+    assert tokenizer.call_texts[-1].endswith(f"language {expected_name}<asr_text>")
+    assert data.language == language
+
+
+def test_qwen3_asr_rejects_unsupported_language_before_loading_audio(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: pytest.fail(
+            "invalid language must fail before audio loading"
+        ),
+    )
+    request_builder, _ = make_qwen3_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=32,
+        feature_extractor=object(),
+    )
+    payload = StagePayload(
+        request_id="req-unsupported-language",
+        request=OmniRequest(
+            inputs={"audio_bytes": b"wav"},
+            params={"language": "Klingon"},
+        ),
+        data={},
+    )
+
+    with pytest.raises(ValueError, match="Unsupported language: 'Klingon'"):
+        request_builder(payload)
 
 
 def test_qwen3_asr_request_builder_records_inclusive_audio_offsets(monkeypatch) -> None:

--- a/tests/unit_test/qwen3_asr/test_request_builders.py
+++ b/tests/unit_test/qwen3_asr/test_request_builders.py
@@ -115,13 +115,19 @@ def test_qwen3_asr_preserves_chinese_compatibility_aliases(language: str) -> Non
 
 
 @pytest.mark.parametrize(
-    ("language", "expected_name"),
-    [("en", "English"), ("es", "Spanish"), ("fReNcH", "French")],
+    ("language", "expected_name", "expected_language"),
+    [
+        (None, "English", "en"),
+        ("en", "English", "en"),
+        ("es", "Spanish", "es"),
+        ("fReNcH", "French", "fReNcH"),
+    ],
 )
 def test_qwen3_asr_request_builder_uses_canonical_language_prompt(
     monkeypatch,
-    language: str,
+    language: str | None,
     expected_name: str,
+    expected_language: str,
 ) -> None:
     tokenizer = _FakeTokenizer()
     feature_extractor = lambda *args, **kwargs: SimpleNamespace(
@@ -142,7 +148,7 @@ def test_qwen3_asr_request_builder_uses_canonical_language_prompt(
         request_id="req-language",
         request=OmniRequest(
             inputs={"audio_bytes": b"wav"},
-            params={"language": language},
+            params={} if language is None else {"language": language},
         ),
         data={},
     )
@@ -150,11 +156,21 @@ def test_qwen3_asr_request_builder_uses_canonical_language_prompt(
     data = request_builder(payload)
 
     assert tokenizer.call_texts[-1].endswith(f"language {expected_name}<asr_text>")
-    assert data.language == language
+    assert data.language == expected_language
 
 
-def test_qwen3_asr_rejects_unsupported_language_before_loading_audio(
+@pytest.mark.parametrize(
+    ("language", "error_match"),
+    [
+        ("", "language hint is empty.*supported language code"),
+        ("   ", "language hint is empty.*supported language code"),
+        ("Klingon", "Unsupported language: 'Klingon'.*supported language code"),
+    ],
+)
+def test_qwen3_asr_rejects_explicit_unsupported_language_before_loading_audio(
     monkeypatch,
+    language: str,
+    error_match: str,
 ) -> None:
     monkeypatch.setattr(
         transcription,
@@ -172,12 +188,12 @@ def test_qwen3_asr_rejects_unsupported_language_before_loading_audio(
         request_id="req-unsupported-language",
         request=OmniRequest(
             inputs={"audio_bytes": b"wav"},
-            params={"language": "Klingon"},
+            params={"language": language},
         ),
         data={},
     )
 
-    with pytest.raises(ValueError, match="Unsupported language: 'Klingon'"):
+    with pytest.raises(ValueError, match=error_match):
         request_builder(payload)
 
 

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -1354,6 +1354,22 @@ def test_transcription_request_builds_asr_generate_request() -> None:
     assert gen_req.stream is False
 
 
+def test_transcription_request_preserves_explicit_empty_language() -> None:
+    gen_req = build_transcription_generate_request(
+        audio_bytes=b"RIFF",
+        filename="sample.wav",
+        content_type="audio/wav",
+        model="Qwen/Qwen3-ASR-1.7B",
+        language="",
+        prompt=None,
+        temperature=None,
+    )
+
+    assert gen_req.extra_params["language"] == ""
+    omni_req = Client._build_omni_request(gen_req)
+    assert omni_req.params["language"] == ""
+
+
 def test_transcription_request_passes_explicit_temperature() -> None:
     gen_req = build_transcription_generate_request(
         audio_bytes=b"RIFF",
@@ -1454,7 +1470,10 @@ def test_transcription_endpoint_maps_max_new_tokens_error_to_400() -> None:
 
 
 def test_transcription_endpoint_maps_unsupported_language_error_to_400() -> None:
-    bad_request_error = "Unsupported language: 'Klingon'"
+    bad_request_error = (
+        "Unsupported language: 'Klingon'. Use a supported language code "
+        "(ar, en, zh) or canonical name."
+    )
     client = TestClient(
         create_app(
             _fault_client("qwen3-omni", error=bad_request_error),
@@ -1470,6 +1489,7 @@ def test_transcription_endpoint_maps_unsupported_language_error_to_400() -> None
 
     assert response.status_code == 400
     assert "Unsupported language:" in response.json()["detail"]
+    assert "Use a supported language code" in response.json()["detail"]
 
 
 def test_transcription_endpoint_passes_explicit_max_new_tokens() -> None:

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -1453,6 +1453,25 @@ def test_transcription_endpoint_maps_max_new_tokens_error_to_400() -> None:
     assert "max_new_tokens must be" in response.json()["detail"]
 
 
+def test_transcription_endpoint_maps_unsupported_language_error_to_400() -> None:
+    bad_request_error = "Unsupported language: 'Klingon'"
+    client = TestClient(
+        create_app(
+            _fault_client("qwen3-omni", error=bad_request_error),
+            model_name="qwen3-omni",
+        )
+    )
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={"model": "qwen3-omni", "language": "Klingon"},
+        files={"file": ("sample.wav", b"RIFF", "audio/wav")},
+    )
+
+    assert response.status_code == 400
+    assert "Unsupported language:" in response.json()["detail"]
+
+
 def test_transcription_endpoint_passes_explicit_max_new_tokens() -> None:
     transcription_client = SuccessfulTranscriptionClient()
     client = TestClient(


### PR DESCRIPTION

## Motivation

- Qwen3-ASR previously treated only Chinese aliases specially and silently forced every other language hint to English.
- Support the model's complete language-hint set while returning an actionable client error for unsupported values.

## Modifications

1. `sglang_omni/models/qwen3_asr/languages.py` and `request_builders.py`
   - Add the canonical mapping for 30 supported language codes and names.
   - Normalize codes and canonical names case-insensitively while preserving the legacy `cn`, `zh-*`, and `zh_*` Chinese aliases.
   - Resolve the requested language before loading audio, use its canonical name in the forced prompt suffix, and reject empty or unsupported hints instead of silently falling back to English.
2. `sglang_omni/serve/openai_api.py`
   - Map unsupported-language validation failures to HTTP 400 responses on the OpenAI-compatible transcription endpoint.
3. `tests/unit_test/qwen3_asr/test_request_builders.py` and `tests/unit_test/serve/test_openai_api.py`
   - Cover all supported codes and names, case normalization, Chinese compatibility aliases, canonical prompt construction, early rejection before audio loading, and HTTP 400 error mapping.
4. `docs/cookbook/qwen3_asr.md`, `docs/index.rst`, and `tests/README.md`
   - Document the supported language hints, compatibility aliases, invalid-input behavior, and corresponding test coverage.

## Related Issues

#1324 

## Accuracy Test
N/A

## Benchmark & Profiling

N/A

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
