### PR TITLE
[ASR][Perf] Enable async decode for Qwen3-ASR

### DIFF
--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -13,10 +13,23 @@ hf download Qwen/Qwen3-ASR-1.7B
 ## Server Configuration
 
 Qwen3-ASR runs a single ASR stage on one GPU.
+Async decode is enabled by default for decode batches of at least two requests,
+allowing the shared one-step-lookahead path to overlap host-side result
+processing with the next GPU decode forward. Use `--decode-mode sync` to disable
+it, or tune the crossover with `--async-lookahead-min-batch-size`.
 
 ```bash
 sgl-omni serve \
   --model-path Qwen/Qwen3-ASR-1.7B \
+  --port 8000
+```
+
+For example, force synchronous decode when comparing modes:
+
+```bash
+sgl-omni serve \
+  --model-path Qwen/Qwen3-ASR-1.7B \
+  --decode-mode sync \
   --port 8000
 ```
 

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -33,10 +33,11 @@ _ASYNC_DECODE_FACTORIES = frozenset(
         "sglang_omni.models.moss_transcribe_diarize.stages."
         "create_sglang_moss_transcribe_diarize_executor",
         "sglang_omni.models.fun_asr.stages.create_sglang_fun_asr_executor",
+        "sglang_omni.models.qwen3_asr.stages.create_sglang_qwen3_asr_executor",
     }
 )
 _ASYNC_DECODE_SUPPORTED_MODELS = (
-    "Higgs TTS, MOSS-TTS-Local, MOSS-Transcribe-Diarize, and Fun-ASR"
+    "Higgs TTS, MOSS-TTS-Local, MOSS-Transcribe-Diarize, Fun-ASR, and Qwen3-ASR"
 )
 _QWEN_PARTIAL_START_TALKER_FACTORY = (
     "sglang_omni.models.qwen3_omni.stages.create_talker_ar_executor_from_config"
@@ -1182,7 +1183,7 @@ def serve(
                 "default. Async mode enables one-step lookahead, "
                 "which can overlap the previous step's host-side collect with "
                 "the next GPU forward. Available for Higgs TTS, MOSS-TTS-Local, "
-                "MOSS-Transcribe-Diarize, and Fun-ASR."
+                "MOSS-Transcribe-Diarize, Fun-ASR, and Qwen3-ASR."
             ),
         ),
     ] = None,

--- a/sglang_omni/models/qwen3_asr/stages.py
+++ b/sglang_omni/models/qwen3_asr/stages.py
@@ -37,6 +37,8 @@ def create_sglang_qwen3_asr_executor(
     mem_fraction_static: float | None = None,
     mm_embedding_cache_size_bytes: int = 0,
     enable_torch_compile: bool = False,
+    enable_async_decode: bool = True,
+    async_decode_min_batch_size: int = 2,
     mm_attention_backend: str | None = None,
     request_build_max_workers: int = 2,
     request_build_max_pending: int | None = 16,
@@ -126,6 +128,8 @@ def create_sglang_qwen3_asr_executor(
         model_runner=ModelRunner(model_worker, output_proc),
         request_builder=request_builder,
         result_adapter=result_adapter,
+        enable_async_decode=enable_async_decode,
+        async_decode_min_batch_size=async_decode_min_batch_size,
         request_build_max_workers=request_build_max_workers,
         request_build_max_pending=request_build_max_pending,
     )

--- a/tests/README.md
+++ b/tests/README.md
@@ -378,7 +378,8 @@ that happened to contain an older version of the test.
     the `remove_if` eviction predicate evaluated outside the lock (re-entrant
     and deadlock-free), and concurrent remove_if/put state integrity.
 - `unit_test/qwen3_asr/`: Qwen3-ASR unit tests:
-  - pipeline config and stage factory concurrency defaults
+  - pipeline config, stage factory concurrency defaults, async-decode default,
+    and `--decode-mode async|sync` CLI overrides
   - single-source audio token length formula used by both processor and
     request builder paths
   - token-level result adapter marker handling, avoiding decode/encode

--- a/tests/unit_test/higgs_tts/test_cli_decode_mode.py
+++ b/tests/unit_test/higgs_tts/test_cli_decode_mode.py
@@ -18,6 +18,7 @@ from sglang_omni.models.higgs_tts.config import HiggsTtsPipelineConfig
 from sglang_omni.models.moss_transcribe_diarize.config import (
     MossTranscribeDiarizePipelineConfig,
 )
+from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
 from sglang_omni.models.qwen3_tts.config import Qwen3TTSPipelineConfig
 
 
@@ -91,7 +92,10 @@ def test_decode_mode_cli_rejects_unsupported_config():
     config = Qwen3TTSPipelineConfig(model_path="dummy")
     with pytest.raises(
         typer.BadParameter,
-        match="Higgs TTS, MOSS-TTS-Local, MOSS-Transcribe-Diarize, and Fun-ASR",
+        match=(
+            "Higgs TTS, MOSS-TTS-Local, MOSS-Transcribe-Diarize, Fun-ASR, "
+            "and Qwen3-ASR"
+        ),
     ):
         apply_decode_mode_cli_overrides(
             config, decode_mode="sync", async_lookahead_min_batch_size=None
@@ -113,6 +117,23 @@ def test_decode_mode_cli_applies_to_moss_transcribe_diarize_asr_stage():
 
 def test_decode_mode_cli_applies_to_fun_asr_stage():
     config = FunASRPipelineConfig(model_path="dummy")
+    apply_decode_mode_cli_overrides(
+        config, decode_mode="async", async_lookahead_min_batch_size=4
+    )
+    stage = next(s for s in config.stages if s.name == "asr")
+    args = resolve_stage_factory_args(stage, config)
+    assert args["enable_async_decode"] is True
+    assert args["async_decode_min_batch_size"] == 4
+
+    apply_decode_mode_cli_overrides(
+        config, decode_mode="sync", async_lookahead_min_batch_size=None
+    )
+    args = resolve_stage_factory_args(stage, config)
+    assert args["enable_async_decode"] is False
+
+
+def test_decode_mode_cli_applies_to_qwen3_asr_stage():
+    config = Qwen3ASRPipelineConfig(model_path="dummy")
     apply_decode_mode_cli_overrides(
         config, decode_mode="async", async_lookahead_min_batch_size=4
     )

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -58,6 +58,13 @@ def test_qwen3_asr_stage_default_disables_torch_compile() -> None:
     assert signature.parameters["enable_torch_compile"].default is False
 
 
+def test_qwen3_asr_stage_default_enables_async_decode() -> None:
+    signature = inspect.signature(create_sglang_qwen3_asr_executor)
+
+    assert signature.parameters["enable_async_decode"].default is True
+    assert signature.parameters["async_decode_min_batch_size"].default == 2
+
+
 def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
     build_kwargs: dict[str, object] = {}
 
@@ -132,7 +139,13 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
         _fake_create_infrastructure,
     )
 
-    qwen3_asr_stages.create_sglang_qwen3_asr_executor("dummy")
+    scheduler = qwen3_asr_stages.create_sglang_qwen3_asr_executor(
+        "dummy",
+        enable_async_decode=False,
+        async_decode_min_batch_size=4,
+    )
 
     assert build_kwargs["cuda_graph_max_bs"] == 32
     assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 12, 16, 24, 32]
+    assert scheduler.enable_async_decode is False
+    assert scheduler.async_decode_min_batch_size == 4


### PR DESCRIPTION
## Motivation

Qwen3-ASR already uses the shared plain `ModelRunner`, but its stage did not enable the shared one-step-lookahead async decode path and the CLI rejected decode-mode overrides for its factory. As a result, host-side output processing
could not overlap the next decode forward through this mechanism under concurrent serving.

This implements Q-PR3 from the Qwen3-ASR high-concurrency roadmap while keeping the decode loop model-neutral.

## Modifications

1. `sglang_omni/models/qwen3_asr/stages.py`
   - Adds `enable_async_decode=True` and `async_decode_min_batch_size=2` to
     `create_sglang_qwen3_asr_executor`.
   - Passes both settings to `OmniScheduler` while continuing to use the shared
     `ModelRunner`; no Qwen3-ASR-specific decode loop is introduced.
2. `sglang_omni/cli/serve.py`
   - Adds `create_sglang_qwen3_asr_executor` to the async-decode factory
     allowlist.
   - Enables `--decode-mode async|sync` and
     `--async-lookahead-min-batch-size` for Qwen3-ASR and updates CLI help and
     validation text.
3. `tests/unit_test/qwen3_asr/test_pipeline.py` and
   `tests/unit_test/higgs_tts/test_cli_decode_mode.py`
   - Covers the default async mode and minimum batch threshold.
   - Verifies explicit factory propagation and CLI overrides for forced sync,
     async mode, and a custom threshold.
   - Reuses the shared async-decode lifecycle suites for finish, abort,
     stale/retracted rows, exact KV-slot cleanup, failure handling, and stream
     ordering.
4. `docs/cookbook/qwen3_asr.md` and `tests/README.md`
   - Documents the default lookahead behavior, threshold, forced-sync command,
     and corresponding test coverage.

## Related Issues

Related to #1324 (Q-PR3).

## Accuracy Test

**Setup:**
- **Refs:** baseline `main` @ `4ce2a6ca`; candidate `feat/qwen3-asr-async-decode` @ `98ec3e2a`.
- **Model:** `Qwen/Qwen3-ASR-1.7B`, cached snapshot `7278e1e70fe206f11671096ffdd38061171dd6e5`.
- **Dataset:** full `zhaochenyang20/seed-tts-eval-arrow` English split, 1,088 samples per repeat.
- **Workload:** non-streaming transcription, concurrency 16, three repeats per ref
- **Hardware / runtime:** physical GPU 1, NVIDIA H100 80GB;

| Metric | Main (sync) | Feature (async default) | Delta |
| --- | ---: | ---: | ---: |
| Corpus WER | 0.0122 +/- 0.0000 | 0.0122 +/- 0.0000 | 0.0000 |
| Max sample WER | 0.1818 +/- 0.0000 | 0.1818 +/- 0.0000 | 0.0000 |
| Evaluated / attempted | 3,264 / 3,264 | 3,264 / 3,264 | same |
| Skipped | 0 | 0 | same |

## Benchmark & Profiling

Same setup as described in the _Accuracy Test_ section. Values are mean +/- sample standard deviation across three repeats.

| Metric | Main (sync) | Feature (async default) | Delta |
| --- | ---: | ---: | ---: |
| Throughput (samples/s) | 59.001 +/- 10.724 | 73.459 +/- 13.558 | **+24.50%** |
| RTFx | 279.435 +/- 50.792 | 347.908 +/- 64.211 | **+24.50%** |
| Mean latency (s) | 0.2770 +/- 0.0563 | 0.2226 +/- 0.0463 | **-19.64%** |
| P95 latency (s) | 0.3772 +/- 0.0881 | 0.3151 +/- 0.0881 | **-16.48%** |
| P99 latency (s) | 0.4859 +/- 0.1894 | 0.4081 +/- 0.1871 | **-16.01%** |
| Mean RTF | 0.0600 +/- 0.0121 | 0.0483 +/- 0.0101 | **-19.41%** |
| Wall time / repeat (s) | 18.903 +/- 3.819 | 15.197 +/- 3.139 | **-19.60%** |


## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
