### PR TITLE
[WIP][Perf] Fun-ASR: raise pre-LM encoder batch wait window 4ms -> 24ms

### DIFF
--- a/sglang_omni/models/fun_asr/config.py
+++ b/sglang_omni/models/fun_asr/config.py
@@ -41,7 +41,7 @@ class FunASRPipelineConfig(PipelineConfig):
                 "pre_lm_cache_max_entries": 4096,
                 "pre_lm_cache_size_bytes": 2 * 1024**3,
                 "pre_lm_max_batch_size": 8,
-                "pre_lm_max_batch_wait_ms": 4,
+                "pre_lm_max_batch_wait_ms": 24,
                 "request_build_max_workers": 8,
                 "request_build_max_pending": 16,
             },

--- a/sglang_omni/models/fun_asr/encoder_service.py
+++ b/sglang_omni/models/fun_asr/encoder_service.py
@@ -118,6 +118,20 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
         self._queue_wait_total_s = 0.0
         self._queue_wait_max_s = 0.0
         self._encoder_time_s = 0.0
+        # Queue depth includes only items ready to join a batch, not request
+        # builds still preparing one. Count those builds so the drain loop knows
+        # whether to keep waiting.
+        self._outstanding = 0
+        self._outstanding_lock = threading.Lock()
+        self._build_local = threading.local()
+        self._submit_side_counting = False
+
+        # Record batch sizes and counter-based early flushes.
+        self._batch_size_hist: dict[int, int] = {}
+        self._guard_flushes = 0
+        self._early_flushes = 0
+
+        # The base class starts the worker, so all worker state must exist first.
         super().__init__(worker_name="fun-asr-audio-encode")
 
     def close(self) -> None:
@@ -128,6 +142,51 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
             self._closed = True
             self._queue.put(_SHUTDOWN)
         self._thread.join(timeout=5)
+        logger.info(f"Fun-ASR pre-LM encoder final stats: {self.stats()}")
+
+    def enable_submit_side_counting(self) -> None:
+        """Count executor builds at scheduler submission.
+
+        A build can wait in the executor queue before its builder starts.
+        Counting at submit keeps the batch window open for that build.
+        """
+        self._submit_side_counting = True
+
+    def note_build_submitted(self) -> None:
+        """Increment the counter before a build enters the executor queue."""
+        with self._outstanding_lock:
+            self._outstanding += 1
+
+    def note_build_cancelled(self) -> None:
+        """Decrement the count for a build cancelled before it starts."""
+        with self._outstanding_lock:
+            self._outstanding -= 1
+
+    def note_build_started(self) -> None:
+        """Record that this thread must decrement one outstanding-build count.
+
+        A build without an executor increments the counter here; a submitted
+        build incremented it earlier. Every exit must decrement it once.
+        """
+        self._build_local.unsettled = True
+        if self._submit_side_counting:
+            return
+        with self._outstanding_lock:
+            self._outstanding += 1
+
+    def note_build_finished(self) -> None:
+        """Decrement this build's count unless an earlier path already did."""
+        self._settle_build()
+
+    def _settle_build(self) -> None:
+        if getattr(self._build_local, "unsettled", False):
+            self._build_local.unsettled = False
+            with self._outstanding_lock:
+                self._outstanding -= 1
+
+    def _outstanding_builds(self) -> int:
+        with self._outstanding_lock:
+            return self._outstanding
 
     def _enqueue(
         self,
@@ -144,6 +203,9 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
                     enqueued_at=time.perf_counter(),
                 )
             )
+        # Enqueue before decrementing the outstanding-build count so the drain
+        # loop cannot observe both zero outstanding builds and an empty queue.
+        self._settle_build()
 
     def encode_item(self, item: Any) -> None:
         """Block until ``item.precomputed_embeddings`` holds the LM embedding.
@@ -169,6 +231,7 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
             if self._is_valid(cached, expected_tokens):
                 with self._lock:
                     self._hits += 1
+                self._settle_build()
                 self.attach_embedding(item, cached)
                 return
             logger.warning(
@@ -201,6 +264,10 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
                         raise
             else:
                 self._merged += 1
+        # A merged request cannot add an item to the batch. Decrement its count
+        # before it waits so it does not keep the batch window open. The leader
+        # decrements its count in _enqueue().
+        self._settle_build()
         if cached is not None:
             self.attach_embedding(item, cached)
             return
@@ -226,7 +293,7 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
             )
         self.attach_embedding(item, embedding)
 
-    def stats(self) -> dict[str, int | float]:
+    def stats(self) -> dict[str, Any]:
         with self._lock:
             cache_lookups = self._hits + self._misses
             return {
@@ -239,6 +306,10 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
                 ),
                 "batches": self._batch_count,
                 "items": self._item_count,
+                "batch_size_hist": dict(sorted(self._batch_size_hist.items())),
+                "guard_flushes": self._guard_flushes,
+                "early_flushes": self._early_flushes,
+                "outstanding_builds": self._outstanding_builds(),
                 "queue_depth": self._queue.qsize(),
                 "queue_wait_avg_s": (
                     self._queue_wait_total_s / self._queue_wait_count
@@ -279,6 +350,14 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
         if first is _SHUTDOWN:
             return [], True
         batch = [cast(QueueEntry[Any], first)]
+        # Skip the window when no counted build can add another item and the
+        # queue is empty. Read the counter first: a build that decrements its
+        # count between these probes has already enqueued its item, so the queue
+        # probe sees it.
+        if self._outstanding_builds() == 0 and self._queue.qsize() == 0:
+            with self._lock:
+                self._guard_flushes += 1
+            return batch, False
         deadline = time.monotonic() + self._max_batch_wait_s
         shutdown = False
         while len(batch) < self._max_batch_size:
@@ -295,6 +374,11 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
                 shutdown = True
                 break
             batch.append(cast(QueueEntry[Any], queued))
+            # Stop when no counted build can add another item and the queue is empty.
+            if self._outstanding_builds() == 0 and self._queue.qsize() == 0:
+                with self._lock:
+                    self._early_flushes += 1
+                break
         return batch, shutdown
 
     def _next_batch(self) -> tuple[list[QueueEntry[Any]], bool]:
@@ -386,9 +470,16 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
                     # Note (Akazaakane): Retried items are single-item batches.
                     self._batch_count += retry_recovered
                     self._item_count += retry_recovered
+                    if retry_recovered:
+                        self._batch_size_hist[1] = (
+                            self._batch_size_hist.get(1, 0) + retry_recovered
+                        )
                 return
             self._batch_count += 1
             self._item_count += len(batch)
+            self._batch_size_hist[len(batch)] = (
+                self._batch_size_hist.get(len(batch), 0) + 1
+            )
             batch_count = self._batch_count
             item_count = self._item_count
         if batch_count % 50 == 1:

--- a/sglang_omni/models/fun_asr/encoder_service.py
+++ b/sglang_omni/models/fun_asr/encoder_service.py
@@ -17,6 +17,7 @@ from typing import Any, cast
 import torch
 from sglang.srt.managers.schedule_batch import MultimodalInputFormat
 
+from sglang_omni.scheduling.build_tracker import OutstandingBuildTracker
 from sglang_omni.scheduling.pre_lm_encoder import PreLMEncoderService, QueueEntry
 from sglang_omni.scheduling.stage_cache import StageOutputCache
 
@@ -119,17 +120,18 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
         self._queue_wait_max_s = 0.0
         self._encoder_time_s = 0.0
         # Queue depth includes only items ready to join a batch, not request
-        # builds still preparing one. Count those builds so the drain loop knows
-        # whether to keep waiting.
-        self._outstanding = 0
-        self._outstanding_lock = threading.Lock()
-        self._build_local = threading.local()
-        self._submit_side_counting = False
+        # builds still preparing one. Track those builds so the drain loop
+        # knows whether to keep waiting. Enqueues and the tracker's idle
+        # transition both notify _batch_wakeup so the drain loop never sleeps
+        # past the moment its flush condition becomes true.
+        self._batch_wakeup = threading.Condition()
+        self.build_tracker = OutstandingBuildTracker(on_idle=self._notify_batch_waiter)
 
-        # Record batch sizes and counter-based early flushes.
+        # Record batch sizes and tracker-based early flushes.
         self._batch_size_hist: dict[int, int] = {}
         self._guard_flushes = 0
         self._early_flushes = 0
+        self._wakeup_flushes = 0
 
         # The base class starts the worker, so all worker state must exist first.
         super().__init__(worker_name="fun-asr-audio-encode")
@@ -141,52 +143,13 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
                 return
             self._closed = True
             self._queue.put(_SHUTDOWN)
+        self._notify_batch_waiter()
         self._thread.join(timeout=5)
         logger.info(f"Fun-ASR pre-LM encoder final stats: {self.stats()}")
 
-    def enable_submit_side_counting(self) -> None:
-        """Count executor builds at scheduler submission.
-
-        A build can wait in the executor queue before its builder starts.
-        Counting at submit keeps the batch window open for that build.
-        """
-        self._submit_side_counting = True
-
-    def note_build_submitted(self) -> None:
-        """Increment the counter before a build enters the executor queue."""
-        with self._outstanding_lock:
-            self._outstanding += 1
-
-    def note_build_cancelled(self) -> None:
-        """Decrement the count for a build cancelled before it starts."""
-        with self._outstanding_lock:
-            self._outstanding -= 1
-
-    def note_build_started(self) -> None:
-        """Record that this thread must decrement one outstanding-build count.
-
-        A build without an executor increments the counter here; a submitted
-        build incremented it earlier. Every exit must decrement it once.
-        """
-        self._build_local.unsettled = True
-        if self._submit_side_counting:
-            return
-        with self._outstanding_lock:
-            self._outstanding += 1
-
-    def note_build_finished(self) -> None:
-        """Decrement this build's count unless an earlier path already did."""
-        self._settle_build()
-
-    def _settle_build(self) -> None:
-        if getattr(self._build_local, "unsettled", False):
-            self._build_local.unsettled = False
-            with self._outstanding_lock:
-                self._outstanding -= 1
-
-    def _outstanding_builds(self) -> int:
-        with self._outstanding_lock:
-            return self._outstanding
+    def _notify_batch_waiter(self) -> None:
+        with self._batch_wakeup:
+            self._batch_wakeup.notify_all()
 
     def _enqueue(
         self,
@@ -203,9 +166,10 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
                     enqueued_at=time.perf_counter(),
                 )
             )
-        # Enqueue before decrementing the outstanding-build count so the drain
-        # loop cannot observe both zero outstanding builds and an empty queue.
-        self._settle_build()
+        self._notify_batch_waiter()
+        # Enqueue before settling this build so the drain loop cannot observe
+        # both zero outstanding builds and an empty queue.
+        self.build_tracker.settle()
 
     def encode_item(self, item: Any) -> None:
         """Block until ``item.precomputed_embeddings`` holds the LM embedding.
@@ -231,7 +195,7 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
             if self._is_valid(cached, expected_tokens):
                 with self._lock:
                     self._hits += 1
-                self._settle_build()
+                self.build_tracker.settle()
                 self.attach_embedding(item, cached)
                 return
             logger.warning(
@@ -264,10 +228,10 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
                         raise
             else:
                 self._merged += 1
-        # A merged request cannot add an item to the batch. Decrement its count
+        # A merged request cannot add an item to the batch. Settle its build
         # before it waits so it does not keep the batch window open. The leader
-        # decrements its count in _enqueue().
-        self._settle_build()
+        # settles in _enqueue().
+        self.build_tracker.settle()
         if cached is not None:
             self.attach_embedding(item, cached)
             return
@@ -309,7 +273,8 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
                 "batch_size_hist": dict(sorted(self._batch_size_hist.items())),
                 "guard_flushes": self._guard_flushes,
                 "early_flushes": self._early_flushes,
-                "outstanding_builds": self._outstanding_builds(),
+                "wakeup_flushes": self._wakeup_flushes,
+                "outstanding_builds": self.build_tracker.count,
                 "queue_depth": self._queue.qsize(),
                 "queue_wait_avg_s": (
                     self._queue_wait_total_s / self._queue_wait_count
@@ -350,32 +315,47 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
         if first is _SHUTDOWN:
             return [], True
         batch = [cast(QueueEntry[Any], first)]
-        # Skip the window when no counted build can add another item and the
-        # queue is empty. Read the counter first: a build that decrements its
-        # count between these probes has already enqueued its item, so the queue
-        # probe sees it.
-        if self._outstanding_builds() == 0 and self._queue.qsize() == 0:
+        # Skip the window when no tracked build can add another item and the
+        # queue is empty. Read the tracker first: a build that settles between
+        # these probes has already enqueued its item, so the queue probe sees
+        # it.
+        if self.build_tracker.count == 0 and self._queue.qsize() == 0:
             with self._lock:
                 self._guard_flushes += 1
             return batch, False
         deadline = time.monotonic() + self._max_batch_wait_s
         shutdown = False
         while len(batch) < self._max_batch_size:
+            remaining = deadline - time.monotonic()
             try:
-                remaining = deadline - time.monotonic()
-                queued = (
-                    self._queue.get(timeout=remaining)
-                    if remaining > 0
-                    else self._queue.get_nowait()
-                )
+                queued = self._queue.get_nowait()
             except queue.Empty:
-                break
+                if self.build_tracker.count == 0:
+                    # The last tracked build settled without enqueueing (cache
+                    # hit, merge, failure, or cancel): flush now instead of
+                    # sleeping until the deadline.
+                    with self._lock:
+                        self._wakeup_flushes += 1
+                    break
+                if remaining <= 0:
+                    break
+                # Sleep until an item arrives, the last tracked build settles,
+                # or the window deadline passes. Only this worker consumes the
+                # queue, so a true predicate stays true until the next probe.
+                with self._batch_wakeup:
+                    self._batch_wakeup.wait_for(
+                        lambda: self._queue.qsize() > 0
+                        or self.build_tracker.count == 0,
+                        timeout=remaining,
+                    )
+                continue
             if queued is _SHUTDOWN:
                 shutdown = True
                 break
             batch.append(cast(QueueEntry[Any], queued))
-            # Stop when no counted build can add another item and the queue is empty.
-            if self._outstanding_builds() == 0 and self._queue.qsize() == 0:
+            # Stop when no tracked build can add another item and the queue is
+            # empty.
+            if self.build_tracker.count == 0 and self._queue.qsize() == 0:
                 with self._lock:
                     self._early_flushes += 1
                 break

--- a/sglang_omni/models/fun_asr/request_builders.py
+++ b/sglang_omni/models/fun_asr/request_builders.py
@@ -316,13 +316,10 @@ def make_fun_asr_scheduler_adapters(
     def request_builder(payload: StagePayload) -> FunASRRequestData:
         if audio_encoder_service is None:
             return _build_request(payload)
-        # Count audio preparation because the request build may still add an
+        # Track audio preparation because the request build may still add an
         # item to the batch; otherwise the drain loop can flush too early.
-        audio_encoder_service.note_build_started()
-        try:
+        with audio_encoder_service.build_tracker.tracked_build():
             return _build_request(payload)
-        finally:
-            audio_encoder_service.note_build_finished()
 
     def result_adapter(data: FunASRRequestData) -> StagePayload:
         payload = data.stage_payload

--- a/sglang_omni/models/fun_asr/request_builders.py
+++ b/sglang_omni/models/fun_asr/request_builders.py
@@ -179,7 +179,7 @@ def make_fun_asr_scheduler_adapters(
             add_special_tokens=False,
         ).input_ids
 
-    def request_builder(payload: StagePayload) -> FunASRRequestData:
+    def _build_request(payload: StagePayload) -> FunASRRequestData:
         params = payload.request.params or {}
         prepared = prepare_audio(
             payload,
@@ -312,6 +312,17 @@ def make_fun_asr_scheduler_adapters(
             engine_start_s=time.perf_counter(),
             stage_payload=payload,
         )
+
+    def request_builder(payload: StagePayload) -> FunASRRequestData:
+        if audio_encoder_service is None:
+            return _build_request(payload)
+        # Count audio preparation because the request build may still add an
+        # item to the batch; otherwise the drain loop can flush too early.
+        audio_encoder_service.note_build_started()
+        try:
+            return _build_request(payload)
+        finally:
+            audio_encoder_service.note_build_finished()
 
     def result_adapter(data: FunASRRequestData) -> StagePayload:
         payload = data.stage_payload

--- a/sglang_omni/models/fun_asr/stages.py
+++ b/sglang_omni/models/fun_asr/stages.py
@@ -279,6 +279,7 @@ def create_sglang_fun_asr_executor(
             async_decode_min_batch_size=async_decode_min_batch_size,
             request_build_max_workers=request_build_max_workers,
             request_build_max_pending=request_build_max_pending,
+            request_build_counter=audio_encoder_service,
             shutdown_callback=(
                 audio_encoder_service.close
                 if audio_encoder_service is not None

--- a/sglang_omni/models/fun_asr/stages.py
+++ b/sglang_omni/models/fun_asr/stages.py
@@ -279,7 +279,11 @@ def create_sglang_fun_asr_executor(
             async_decode_min_batch_size=async_decode_min_batch_size,
             request_build_max_workers=request_build_max_workers,
             request_build_max_pending=request_build_max_pending,
-            request_build_counter=audio_encoder_service,
+            request_build_tracker=(
+                audio_encoder_service.build_tracker
+                if audio_encoder_service is not None
+                else None
+            ),
             shutdown_callback=(
                 audio_encoder_service.close
                 if audio_encoder_service is not None

--- a/sglang_omni/scheduling/build_tracker.py
+++ b/sglang_omni/scheduling/build_tracker.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Track request builds that may still enqueue a pre-LM batch item."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import threading
+from collections.abc import Callable, Iterator
+
+logger = logging.getLogger(__name__)
+
+
+class OutstandingBuildTracker:
+    """Counts request builds that may still enqueue a pre-LM batch item.
+
+    The batch drain loop keeps its wait window open while the count is
+    positive. ``on_idle`` fires on every transition to zero (outside the
+    tracker lock, so the callback may take other locks) so the drain loop
+    can re-check its flush condition immediately instead of sleeping until
+    the window deadline.
+
+    Counting sides: submit-side counting is enabled iff builds run on an
+    executor. The scheduler then increments at submit — a build can wait in
+    the executor queue before its builder starts — and refunds builds
+    cancelled before they start via ``note_cancelled``. Without an executor
+    each build increments itself in ``note_started``. Either way the build
+    settles exactly once: ``note_started`` arms a thread-local flag and
+    ``settle`` only decrements while it is armed, so repeated settles are
+    no-ops.
+
+    Failure modes: a leaked positive count only degrades batching back to
+    the full wait window and is visible as ``count`` in service stats. An
+    underflow would flush batches early, so ``note_cancelled``/``settle``
+    raise instead of going negative.
+
+    Boundary: submit-side counting also counts builds queued behind busy
+    executor workers. When every worker blocks on the current encode (for
+    example merged single-flight followers), those queued builds cannot
+    join the current batch but still hold its window open until the
+    deadline. That is a bounded latency cost, not a deadlock.
+    """
+
+    def __init__(self, *, on_idle: Callable[[], None] | None = None) -> None:
+        self._count = 0
+        self._lock = threading.Lock()
+        self._local = threading.local()
+        self._submit_side = False
+        self._on_idle = on_idle
+
+    def enable_submit_side_counting(self) -> None:
+        """Count builds at scheduler submission instead of at build start."""
+        self._submit_side = True
+
+    def note_submitted(self) -> None:
+        """Increment before a build enters the executor queue."""
+        with self._lock:
+            self._count += 1
+
+    def note_cancelled(self) -> None:
+        """Refund a submitted build cancelled before it starts."""
+        self._decrement()
+
+    def note_started(self) -> None:
+        """Arm this thread's build so it settles exactly once."""
+        self._local.unsettled = True
+        if self._submit_side:
+            return
+        with self._lock:
+            self._count += 1
+
+    def settle(self) -> None:
+        """Decrement this build's count unless an earlier path already did."""
+        if getattr(self._local, "unsettled", False):
+            self._local.unsettled = False
+            self._decrement()
+
+    @contextlib.contextmanager
+    def tracked_build(self) -> Iterator[None]:
+        """Count one build for the duration of the block."""
+        self.note_started()
+        try:
+            yield
+        finally:
+            self.settle()
+
+    @property
+    def count(self) -> int:
+        with self._lock:
+            return self._count
+
+    def _decrement(self) -> None:
+        with self._lock:
+            if self._count <= 0:
+                raise RuntimeError(
+                    "outstanding-build count would go negative; an "
+                    "increment/decrement pair is mismatched"
+                )
+            self._count -= 1
+            reached_zero = self._count == 0
+        if reached_zero and self._on_idle is not None:
+            try:
+                self._on_idle()
+            except Exception:
+                logger.exception("outstanding-build idle callback failed")
+
+
+__all__ = ["OutstandingBuildTracker"]

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -193,6 +193,7 @@ class OmniScheduler:
         prefill_coalesce_when_idle: bool = False,
         request_build_max_workers: int = 1,
         request_build_max_pending: int | None = None,
+        request_build_counter: Any | None = None,
         shutdown_callback: Callable[[], None] | None = None,
     ):
         self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
@@ -201,6 +202,11 @@ class OmniScheduler:
 
         # --- Request builder: StagePayload → SGLangARRequestData ----------
         self._request_builder = request_builder
+        # Optional outstanding-build counter for request builds that may still
+        # add an item to a batch. With an executor, the scheduler increments on
+        # submit and decrements on cancel. The builder decrements after enqueue
+        # or when it can no longer add an item to the batch.
+        self._request_build_counter = request_build_counter
         self._result_adapter = result_adapter
         self._model_runner = None
         self._stream_output_builder = stream_output_builder
@@ -243,6 +249,14 @@ class OmniScheduler:
         self._pending_request_builds: dict[str, tuple[Any, bool, Future]] = {}
         self._backlogged_request_build_payloads: deque[Any] = deque()
         self._request_build_max_pending_observed = 0
+        if (
+            self._request_build_executor is not None
+            and self._request_build_counter is not None
+        ):
+            # Increment the counter at submit to keep the batch window open for
+            # builds waiting in the executor queue. A build without an executor
+            # increments the counter when it starts.
+            self._request_build_counter.enable_submit_side_counting()
 
         # --- Core scheduling state (read/written by upstream methods) -----
         self.server_args = server_args
@@ -855,9 +869,19 @@ class OmniScheduler:
                         or req_id in self._pending_request_builds
                     ):
                         continue
-                    future = request_build_executor.submit(
-                        self._run_request_builder, payload, active_stage
-                    )
+                    counter = self._request_build_counter
+                    if counter is not None:
+                        # Increment before submit so the worker cannot decrement
+                        # the count before the scheduler increments it.
+                        counter.note_build_submitted()
+                    try:
+                        future = request_build_executor.submit(
+                            self._run_request_builder, payload, active_stage
+                        )
+                    except BaseException:
+                        if counter is not None:
+                            counter.note_build_cancelled()
+                        raise
                     self._pending_request_builds[req_id] = (
                         payload,
                         pending_stream_done,
@@ -1523,6 +1547,22 @@ class OmniScheduler:
             return
         executor.shutdown(wait=False, cancel_futures=True)
         self._request_build_executor = None
+        counter = self._request_build_counter
+        if counter is None:
+            return
+        # Builds cancelled by executor shutdown never run the builder code that
+        # decrements the outstanding-build count. Remove each cancelled build
+        # under the admission lock before decrementing, so abort() racing with
+        # shutdown cannot decrement the same count.
+        #
+        # For example, if shutdown cancels the last queued build, its count
+        # would stay at 1 even though it can no longer add an item to a batch.
+        with self._request_admission_lock:
+            for req_id in list(self._pending_request_builds):
+                future = self._pending_request_builds[req_id][2]
+                if future.cancelled():
+                    del self._pending_request_builds[req_id]
+                    counter.note_build_cancelled()
 
     def abort(self, request_id: str, *, defer_running_cleanup: bool = True) -> None:
         with self._request_admission_lock:
@@ -1545,7 +1585,11 @@ class OmniScheduler:
             )
             pending = self._pending_request_builds.pop(request_id, None)
             if pending is not None:
-                pending[2].cancel()
+                cancelled = pending[2].cancel()
+                if cancelled and self._request_build_counter is not None:
+                    # A build cancelled before it starts never reaches the code
+                    # that decrements its outstanding-build count.
+                    self._request_build_counter.note_build_cancelled()
             if self._backlogged_request_build_payloads:
                 retained = [
                     payload

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -58,6 +58,7 @@ from sglang_omni.proto.admin import (
     ADMIN_UPDATE_WEIGHTS_FROM_TENSOR,
     ADMIN_WEIGHTS_CHECKER,
 )
+from sglang_omni.scheduling.build_tracker import OutstandingBuildTracker
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
 from sglang_omni.vendor.sglang.server_args import override_server_args
 
@@ -193,7 +194,7 @@ class OmniScheduler:
         prefill_coalesce_when_idle: bool = False,
         request_build_max_workers: int = 1,
         request_build_max_pending: int | None = None,
-        request_build_counter: Any | None = None,
+        request_build_tracker: OutstandingBuildTracker | None = None,
         shutdown_callback: Callable[[], None] | None = None,
     ):
         self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
@@ -202,11 +203,11 @@ class OmniScheduler:
 
         # --- Request builder: StagePayload → SGLangARRequestData ----------
         self._request_builder = request_builder
-        # Optional outstanding-build counter for request builds that may still
-        # add an item to a batch. With an executor, the scheduler increments on
-        # submit and decrements on cancel. The builder decrements after enqueue
-        # or when it can no longer add an item to the batch.
-        self._request_build_counter = request_build_counter
+        # Optional tracker for request builds that may still add an item to a
+        # batch. With an executor, the scheduler increments on submit and
+        # refunds cancels. The builder settles after enqueue or when it can no
+        # longer add an item to the batch.
+        self._request_build_tracker = request_build_tracker
         self._result_adapter = result_adapter
         self._model_runner = None
         self._stream_output_builder = stream_output_builder
@@ -251,12 +252,12 @@ class OmniScheduler:
         self._request_build_max_pending_observed = 0
         if (
             self._request_build_executor is not None
-            and self._request_build_counter is not None
+            and self._request_build_tracker is not None
         ):
-            # Increment the counter at submit to keep the batch window open for
+            # Increment the tracker at submit to keep the batch window open for
             # builds waiting in the executor queue. A build without an executor
-            # increments the counter when it starts.
-            self._request_build_counter.enable_submit_side_counting()
+            # increments the tracker when it starts.
+            self._request_build_tracker.enable_submit_side_counting()
 
         # --- Core scheduling state (read/written by upstream methods) -----
         self.server_args = server_args
@@ -869,18 +870,18 @@ class OmniScheduler:
                         or req_id in self._pending_request_builds
                     ):
                         continue
-                    counter = self._request_build_counter
-                    if counter is not None:
-                        # Increment before submit so the worker cannot decrement
-                        # the count before the scheduler increments it.
-                        counter.note_build_submitted()
+                    tracker = self._request_build_tracker
+                    if tracker is not None:
+                        # Increment before submit so the worker cannot settle
+                        # the build before the scheduler counts it.
+                        tracker.note_submitted()
                     try:
                         future = request_build_executor.submit(
                             self._run_request_builder, payload, active_stage
                         )
                     except BaseException:
-                        if counter is not None:
-                            counter.note_build_cancelled()
+                        if tracker is not None:
+                            tracker.note_cancelled()
                         raise
                     self._pending_request_builds[req_id] = (
                         payload,
@@ -1547,13 +1548,13 @@ class OmniScheduler:
             return
         executor.shutdown(wait=False, cancel_futures=True)
         self._request_build_executor = None
-        counter = self._request_build_counter
-        if counter is None:
+        tracker = self._request_build_tracker
+        if tracker is None:
             return
         # Builds cancelled by executor shutdown never run the builder code that
-        # decrements the outstanding-build count. Remove each cancelled build
-        # under the admission lock before decrementing, so abort() racing with
-        # shutdown cannot decrement the same count.
+        # settles the outstanding-build count. Remove each cancelled build
+        # under the admission lock before refunding, so abort() racing with
+        # shutdown cannot refund the same build twice.
         #
         # For example, if shutdown cancels the last queued build, its count
         # would stay at 1 even though it can no longer add an item to a batch.
@@ -1562,7 +1563,7 @@ class OmniScheduler:
                 future = self._pending_request_builds[req_id][2]
                 if future.cancelled():
                     del self._pending_request_builds[req_id]
-                    counter.note_build_cancelled()
+                    tracker.note_cancelled()
 
     def abort(self, request_id: str, *, defer_running_cleanup: bool = True) -> None:
         with self._request_admission_lock:
@@ -1586,10 +1587,10 @@ class OmniScheduler:
             pending = self._pending_request_builds.pop(request_id, None)
             if pending is not None:
                 cancelled = pending[2].cancel()
-                if cancelled and self._request_build_counter is not None:
+                if cancelled and self._request_build_tracker is not None:
                     # A build cancelled before it starts never reaches the code
-                    # that decrements its outstanding-build count.
-                    self._request_build_counter.note_build_cancelled()
+                    # that settles its outstanding-build count.
+                    self._request_build_tracker.note_cancelled()
             if self._backlogged_request_build_payloads:
                 retained = [
                     payload

--- a/tests/unit_test/fun_asr/test_encoder_service.py
+++ b/tests/unit_test/fun_asr/test_encoder_service.py
@@ -92,14 +92,11 @@ def _run_build(
     item: SimpleNamespace,
     after_start: Callable[[], object] | None = None,
 ) -> None:
-    """Run an encode and always decrement its outstanding-build count."""
-    service.note_build_started()
-    try:
+    """Run an encode inside a tracked build, as the request builder does."""
+    with service.build_tracker.tracked_build():
         if after_start is not None:
             after_start()
         service.encode_item(item)
-    finally:
-        service.note_build_finished()
 
 
 def _await(predicate: Callable[[], bool], timeout_s: float = 5.0) -> bool:
@@ -624,12 +621,12 @@ def test_inflight_build_holds_window_open_and_batches_pair() -> None:
     thread_b.start()
     assert _await(lambda: service._queue.qsize() == 1), "B never queued"
 
-    service.note_build_started()  # C may still add an item to the batch.
+    service.build_tracker.note_started()  # C may still add an item to the batch.
     gate.set()  # Let the drain pick up B while C remains counted.
     try:
         service.encode_item(_item(9103, 4))
     finally:
-        service.note_build_finished()
+        service.build_tracker.settle()
     thread_a.join(timeout=10)
     thread_b.join(timeout=10)
 
@@ -773,11 +770,11 @@ def test_failed_and_finished_builds_settle_the_counter() -> None:
     """A failed build decrements its count so later batches can flush."""
     service = _make_service(max_batch_wait_ms=500)
 
-    service.note_build_started()
+    service.build_tracker.note_started()
     assert service.stats()["outstanding_builds"] == 1
-    service.note_build_finished()
+    service.build_tracker.settle()
     assert service.stats()["outstanding_builds"] == 0
-    service.note_build_finished()
+    service.build_tracker.settle()
     assert service.stats()["outstanding_builds"] == 0
 
     bad_item = SimpleNamespace(hash=1, feature=None, precomputed_embeddings=None)
@@ -800,7 +797,7 @@ def test_dangling_build_does_not_deadlock_close(
     caplog.set_level(logging.INFO, logger="sglang_omni.models.fun_asr.encoder_service")
     service = _make_service(max_batch_wait_ms=200)
 
-    service.note_build_started()
+    service.build_tracker.note_started()
     item = _item(8_100, 4)
     thread = threading.Thread(target=service.encode_item, args=(item,))
     thread.start()
@@ -815,7 +812,7 @@ def test_dangling_build_does_not_deadlock_close(
     assert not service._thread.is_alive()
     assert item.precomputed_embeddings is not None
     assert "final stats" in caplog.text
-    service.note_build_finished()
+    service.build_tracker.settle()
 
 
 def test_wait_zero_and_batch_size_one_edges() -> None:
@@ -873,9 +870,9 @@ def test_merged_follower_settles_before_leader_finishes() -> None:
     follower_thread.start()
     assert _await(lambda: service.stats()["merged"] == 1), "follower never merged"
 
-    assert _await(lambda: service.stats()["outstanding_builds"] == 0), (
-        "merged follower left its build outstanding"
-    )
+    assert _await(
+        lambda: service.stats()["outstanding_builds"] == 0
+    ), "merged follower left its build outstanding"
     assert follower_thread.is_alive(), "follower should still be blocked on the leader"
 
     gate.set()
@@ -887,22 +884,22 @@ def test_merged_follower_settles_before_leader_finishes() -> None:
 def test_submit_side_counting_pairs_scheduler_count_with_builder_settle() -> None:
     """The counter increments and decrements once for a submitted build."""
     service = _make_service(max_batch_wait_ms=500)
-    service.enable_submit_side_counting()
+    service.build_tracker.enable_submit_side_counting()
 
-    service.note_build_submitted()
+    service.build_tracker.note_submitted()
     assert service.stats()["outstanding_builds"] == 1
-    service.note_build_started()
+    service.build_tracker.note_started()
     assert service.stats()["outstanding_builds"] == 1
     item = _item(9_600, 4)
     try:
         service.encode_item(item)
     finally:
-        service.note_build_finished()
+        service.build_tracker.settle()
     assert item.precomputed_embeddings is not None
     assert service.stats()["outstanding_builds"] == 0
 
-    service.note_build_submitted()
-    service.note_build_cancelled()
+    service.build_tracker.note_submitted()
+    service.build_tracker.note_cancelled()
     assert service.stats()["outstanding_builds"] == 0
 
 
@@ -910,21 +907,21 @@ def test_submitted_but_unstarted_build_holds_window_open() -> None:
     """A build waiting in the executor keeps the batch window open."""
     model = _StubModel()
     service = _make_service(model, max_batch_wait_ms=500)
-    service.enable_submit_side_counting()
+    service.build_tracker.enable_submit_side_counting()
     gate = threading.Event()
     model.encode_gate = gate
 
-    service.note_build_submitted()
+    service.build_tracker.note_submitted()
     thread_a = threading.Thread(target=_run_build, args=(service, _item(9_700, 4)))
     thread_a.start()
     assert _await(lambda: model.encode_calls == 1), "A never reached the encoder"
 
-    service.note_build_submitted()
+    service.build_tracker.note_submitted()
     thread_b = threading.Thread(target=_run_build, args=(service, _item(9_701, 4)))
     thread_b.start()
     assert _await(lambda: service._queue.qsize() == 1), "B never queued"
 
-    service.note_build_submitted()
+    service.build_tracker.note_submitted()
     gate.set()  # The drain picks up B while C waits in the executor queue.
     thread_c = threading.Thread(target=_run_build, args=(service, _item(9_702, 4)))
     thread_c.start()
@@ -934,3 +931,125 @@ def test_submitted_but_unstarted_build_holds_window_open() -> None:
     stats = service.stats()
     assert stats["batch_size_hist"] == {1: 1, 2: 1}, stats
     assert stats["outstanding_builds"] == 0, stats
+
+
+def test_settle_without_enqueue_wakes_waiting_drainer() -> None:
+    """A build that settles idle mid-window flushes the batch immediately.
+
+    The drain loop holds one item inside a 5s window while another tracked
+    build is outstanding. When that build settles without enqueueing (as a
+    cache hit, merge, failure, or cancel would), the idle notification must
+    wake the drain loop instead of letting it sleep until the deadline.
+    """
+    model = _StubModel()
+    service = _make_service(model, max_batch_wait_ms=5_000)
+    gate = threading.Event()
+    model.encode_gate = gate
+
+    thread_a = threading.Thread(target=_run_build, args=(service, _item(13_000, 4)))
+    thread_a.start()
+    assert _await(lambda: model.encode_calls == 1), "A never reached the encoder"
+
+    service.build_tracker.note_started()  # C: outstanding, never enqueues.
+    thread_b = threading.Thread(target=_run_build, args=(service, _item(13_001, 4)))
+    thread_b.start()
+    assert _await(lambda: service._queue.qsize() == 1), "B never queued"
+
+    gate.set()
+    thread_a.join(timeout=10)
+    # B's item was enqueued while the encoder was gated, so qsize dropping to
+    # zero proves the drainer picked it up; with C still counted the guard
+    # fails and the drainer is inside the window.
+    assert _await(lambda: service._queue.qsize() == 0), "drainer never took B"
+
+    service.build_tracker.settle()  # C settles idle: 1 -> 0 wakes the drainer.
+    thread_b.join(timeout=2)
+
+    assert not thread_b.is_alive(), "drainer slept until the window deadline"
+    stats = service.stats()
+    assert stats["batch_size_hist"] == {1: 2}, stats
+    assert stats["wakeup_flushes"] == 1, stats
+    assert stats["outstanding_builds"] == 0, stats
+
+
+def test_enqueue_then_delayed_settle_does_not_wait_full_window() -> None:
+    """The put -> drain -> settle interleaving must not cost a full window.
+
+    The drainer can consume an enqueued item and probe the tracker before the
+    producer reaches its settle. The count it sees is still positive, so it
+    enters the window; the settle landing afterwards must wake it.
+    """
+    service = _make_service(max_batch_wait_ms=5_000)
+    tracker = service.build_tracker
+    settle_reached = threading.Event()
+    release_settle = threading.Event()
+    original_settle = tracker.settle
+
+    def delayed_settle() -> None:
+        settle_reached.set()
+        assert release_settle.wait(timeout=10)
+        original_settle()
+
+    tracker.settle = delayed_settle  # type: ignore[method-assign]
+    try:
+        item = _item(13_100, 4)
+
+        def producer() -> None:
+            tracker.note_started()
+            try:
+                service.encode_item(item)
+            finally:
+                original_settle()
+
+        thread = threading.Thread(target=producer)
+        thread.start()
+        # _enqueue puts the item before it calls settle, so once the delayed
+        # settle is reached the item is in the queue while the count is still
+        # positive; qsize dropping to zero then proves the drainer consumed it
+        # and entered the window.
+        assert settle_reached.wait(timeout=5), "producer never reached settle"
+        assert _await(lambda: service._queue.qsize() == 0), "item never drained"
+
+        release_settle.set()
+        thread.join(timeout=2)
+
+        assert not thread.is_alive(), "drainer slept until the window deadline"
+        stats = service.stats()
+        assert stats["batch_size_hist"] == {1: 1}, stats
+        assert stats["wakeup_flushes"] == 1, stats
+        assert stats["outstanding_builds"] == 0, stats
+    finally:
+        tracker.settle = original_settle  # type: ignore[method-assign]
+
+
+def test_stuck_submitted_builds_hold_window_until_deadline() -> None:
+    """Submit-side counts for builds that cannot start bound latency, not liveness.
+
+    With submit-side counting, builds queued behind busy executor workers are
+    counted but cannot join the current batch. The window then waits out its
+    full deadline — the documented latency bound — and the batch still
+    flushes.
+    """
+    service = _make_service(max_batch_wait_ms=50)
+    tracker = service.build_tracker
+    tracker.enable_submit_side_counting()
+
+    tracker.note_submitted()  # A queued build that never starts.
+    tracker.note_submitted()  # Submit-side count for the real build below.
+    item = _item(13_200, 4)
+    start = time.monotonic()
+    with tracker.tracked_build():
+        service.encode_item(item)
+    elapsed = time.monotonic() - start
+
+    assert item.precomputed_embeddings is not None
+    assert elapsed >= 0.04, f"window should have waited ~50ms, took {elapsed:.3f}s"
+    stats = service.stats()
+    assert stats["batch_size_hist"] == {1: 1}, stats
+    assert stats["guard_flushes"] == 0, stats
+    assert stats["early_flushes"] == 0, stats
+    assert stats["wakeup_flushes"] == 0, stats
+    assert stats["outstanding_builds"] == 1, stats
+
+    tracker.note_cancelled()  # The stuck build is eventually refunded.
+    assert service.stats()["outstanding_builds"] == 0

--- a/tests/unit_test/fun_asr/test_encoder_service.py
+++ b/tests/unit_test/fun_asr/test_encoder_service.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 import threading
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from types import SimpleNamespace
 
 import pytest
@@ -71,15 +72,43 @@ def _make_service(
     *,
     cache_max_entries: int = 16,
     cache_max_bytes: int = 1 << 20,
+    max_batch_size: int = 8,
+    max_batch_wait_ms: int = 4,
 ) -> FunASRPreLMEncoderService:
     service = FunASRPreLMEncoderService(
         model or _StubModel(),
         cache_namespace=_NAMESPACE,
         cache_max_entries=cache_max_entries,
         cache_max_bytes=cache_max_bytes,
+        max_batch_size=max_batch_size,
+        max_batch_wait_ms=max_batch_wait_ms,
     )
     _SERVICES.append(service)
     return service
+
+
+def _run_build(
+    service: FunASRPreLMEncoderService,
+    item: SimpleNamespace,
+    after_start: Callable[[], object] | None = None,
+) -> None:
+    """Run an encode and always decrement its outstanding-build count."""
+    service.note_build_started()
+    try:
+        if after_start is not None:
+            after_start()
+        service.encode_item(item)
+    finally:
+        service.note_build_finished()
+
+
+def _await(predicate: Callable[[], bool], timeout_s: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.002)
+    return predicate()
 
 
 def _item(
@@ -560,3 +589,348 @@ def test_build_cache_namespace_is_stable_and_scoped() -> None:
         text_config=SimpleNamespace(hidden_size=_HIDDEN_SIZE), marker="other"
     )
     assert namespace != build_cache_namespace(changed_config, **base)
+
+
+# --- Outstanding-build counting and batching -------------------------------
+# Use generous windows and assert batch composition instead of wall-clock time.
+
+
+def test_cold_single_request_flushes_immediately() -> None:
+    """A lone request flushes when no counted build can add a batch item."""
+    service = _make_service(max_batch_wait_ms=500)
+
+    item = _item(9001, 4)
+    _run_build(service, item)
+
+    assert item.precomputed_embeddings is not None
+    stats = service.stats()
+    assert stats["guard_flushes"] == 1, stats
+    assert stats["batch_size_hist"] == {1: 1}, stats
+    assert stats["outstanding_builds"] == 0, stats
+
+
+def test_inflight_build_holds_window_open_and_batches_pair() -> None:
+    """B's batch window stays open while C may still add an item."""
+    model = _StubModel()
+    service = _make_service(model, max_batch_wait_ms=500)
+    gate = threading.Event()
+    model.encode_gate = gate
+
+    thread_a = threading.Thread(target=_run_build, args=(service, _item(9101, 4)))
+    thread_a.start()
+    assert _await(lambda: model.encode_calls == 1), "A never reached the encoder"
+
+    thread_b = threading.Thread(target=_run_build, args=(service, _item(9102, 4)))
+    thread_b.start()
+    assert _await(lambda: service._queue.qsize() == 1), "B never queued"
+
+    service.note_build_started()  # C may still add an item to the batch.
+    gate.set()  # Let the drain pick up B while C remains counted.
+    try:
+        service.encode_item(_item(9103, 4))
+    finally:
+        service.note_build_finished()
+    thread_a.join(timeout=10)
+    thread_b.join(timeout=10)
+
+    stats = service.stats()
+    assert stats["batch_size_hist"] == {1: 1, 2: 1}, stats
+    assert stats["guard_flushes"] == 1, stats
+    assert stats["early_flushes"] == 1, stats
+    assert stats["outstanding_builds"] == 0, stats
+
+
+def test_closed_loop_c2_pairs_every_round() -> None:
+    """Each c=2 round forms a two-item batch while one build is outstanding."""
+    service = _make_service(max_batch_wait_ms=500)
+    rounds = 30
+    barrier = threading.Barrier(2)
+    errors: list[BaseException] = []
+
+    def producer(base: int) -> None:
+        try:
+            for round_no in range(rounds):
+                _run_build(
+                    service,
+                    _item(base + round_no, 4),
+                    after_start=lambda: barrier.wait(timeout=10),
+                )
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=producer, args=(base,)) for base in (10_000, 20_000)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=60)
+
+    assert not errors, errors
+    stats = service.stats()
+    assert stats["batch_size_hist"] == {2: rounds}, stats
+    assert stats["guard_flushes"] == 0, stats
+    assert stats["early_flushes"] == rounds, stats
+    assert stats["outstanding_builds"] == 0, stats
+
+
+def test_concurrency_migration_keeps_batching_correct_per_phase() -> None:
+    """Changing concurrency does not affect batch sizes in later phases."""
+    service = _make_service(max_batch_wait_ms=500)
+
+    for round_no in range(3):
+        _run_build(service, _item(1_000 + round_no, 4))
+
+    def paired_rounds(bases: tuple[int, int], rounds: int) -> None:
+        barrier = threading.Barrier(2)
+        errors: list[BaseException] = []
+
+        def producer(base: int) -> None:
+            try:
+                for round_no in range(rounds):
+                    _run_build(
+                        service,
+                        _item(base + round_no, 4),
+                        after_start=lambda: barrier.wait(timeout=10),
+                    )
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=producer, args=(base,)) for base in bases]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=60)
+        assert not errors, errors
+
+    paired_rounds((2_000, 3_000), 3)
+
+    burst_barrier = threading.Barrier(32)
+    burst_errors: list[BaseException] = []
+
+    def burst_producer(base: int) -> None:
+        try:
+            _run_build(
+                service,
+                _item(base, 4),
+                after_start=lambda: burst_barrier.wait(timeout=10),
+            )
+        except BaseException as exc:  # noqa: BLE001
+            burst_errors.append(exc)
+
+    burst_threads = [
+        threading.Thread(target=burst_producer, args=(4_000 + idx,))
+        for idx in range(32)
+    ]
+    for thread in burst_threads:
+        thread.start()
+    for thread in burst_threads:
+        thread.join(timeout=60)
+    assert not burst_errors, burst_errors
+
+    paired_rounds((5_000, 6_000), 3)
+
+    stats = service.stats()
+    assert stats["batch_size_hist"] == {1: 3, 2: 6, 8: 4}, stats
+    assert stats["guard_flushes"] == 3, stats
+    assert stats["outstanding_builds"] == 0, stats
+
+
+def test_long_idle_then_burst_batches_together() -> None:
+    """A new burst batches normally after the worker has been idle."""
+    service = _make_service(max_batch_wait_ms=500)
+    _run_build(service, _item(7_000, 4))
+
+    barrier = threading.Barrier(4)
+    errors: list[BaseException] = []
+
+    def producer(base: int) -> None:
+        try:
+            _run_build(
+                service,
+                _item(base, 4),
+                after_start=lambda: barrier.wait(timeout=10),
+            )
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=producer, args=(7_100 + idx,)) for idx in range(4)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert not errors, errors
+    stats = service.stats()
+    assert stats["batch_size_hist"] == {1: 1, 4: 1}, stats
+    assert stats["early_flushes"] == 1, stats
+    assert stats["outstanding_builds"] == 0, stats
+
+
+def test_failed_and_finished_builds_settle_the_counter() -> None:
+    """A failed build decrements its count so later batches can flush."""
+    service = _make_service(max_batch_wait_ms=500)
+
+    service.note_build_started()
+    assert service.stats()["outstanding_builds"] == 1
+    service.note_build_finished()
+    assert service.stats()["outstanding_builds"] == 0
+    service.note_build_finished()
+    assert service.stats()["outstanding_builds"] == 0
+
+    bad_item = SimpleNamespace(hash=1, feature=None, precomputed_embeddings=None)
+    with pytest.raises(RuntimeError, match="num_audio_tokens"):
+        _run_build(service, bad_item)
+    assert service.stats()["outstanding_builds"] == 0
+
+    item = _item(8_000, 4)
+    _run_build(service, item)
+    assert item.precomputed_embeddings is not None
+    stats = service.stats()
+    assert stats["guard_flushes"] == 1, stats
+    assert stats["batch_size_hist"] == {1: 1}, stats
+
+
+def test_dangling_build_does_not_deadlock_close(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Shutdown terminates the worker despite an outstanding-build count."""
+    caplog.set_level(logging.INFO, logger="sglang_omni.models.fun_asr.encoder_service")
+    service = _make_service(max_batch_wait_ms=200)
+
+    service.note_build_started()
+    item = _item(8_100, 4)
+    thread = threading.Thread(target=service.encode_item, args=(item,))
+    thread.start()
+    assert _await(
+        lambda: service._queue.qsize() == 1 or item.precomputed_embeddings is not None
+    )
+
+    service.close()
+    thread.join(timeout=10)
+
+    assert not thread.is_alive()
+    assert not service._thread.is_alive()
+    assert item.precomputed_embeddings is not None
+    assert "final stats" in caplog.text
+    service.note_build_finished()
+
+
+def test_wait_zero_and_batch_size_one_edges() -> None:
+    """Zero wait and batch size one still produce immediate single-item batches."""
+    instant = _make_service(max_batch_wait_ms=0)
+    for idx in range(2):
+        _run_build(instant, _item(8_200 + idx, 4))
+    stats = instant.stats()
+    assert stats["batch_size_hist"] == {1: 2}, stats
+
+    singles = _make_service(max_batch_size=1, max_batch_wait_ms=500)
+    barrier = threading.Barrier(3)
+    errors: list[BaseException] = []
+
+    def producer(base: int) -> None:
+        try:
+            _run_build(
+                singles,
+                _item(base, 4),
+                after_start=lambda: barrier.wait(timeout=10),
+            )
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=producer, args=(8_300 + idx,)) for idx in range(3)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert not errors, errors
+    stats = singles.stats()
+    assert stats["batch_size_hist"] == {1: 3}, stats
+    assert stats["outstanding_builds"] == 0, stats
+
+
+def test_merged_follower_settles_before_leader_finishes() -> None:
+    """A merged request decrements its count because it adds no batch item."""
+    model = _StubModel()
+    service = _make_service(model, max_batch_wait_ms=500)
+    gate = threading.Event()
+    model.encode_gate = gate
+
+    leader_thread = threading.Thread(
+        target=service.encode_item, args=(_item(9_500, 4),)
+    )
+    leader_thread.start()
+    assert _await(lambda: model.encode_calls == 1), "leader never reached the encoder"
+
+    follower_thread = threading.Thread(
+        target=_run_build, args=(service, _item(9_500, 4))
+    )
+    follower_thread.start()
+    assert _await(lambda: service.stats()["merged"] == 1), "follower never merged"
+
+    assert _await(lambda: service.stats()["outstanding_builds"] == 0), (
+        "merged follower left its build outstanding"
+    )
+    assert follower_thread.is_alive(), "follower should still be blocked on the leader"
+
+    gate.set()
+    leader_thread.join(timeout=10)
+    follower_thread.join(timeout=10)
+    assert service.stats()["outstanding_builds"] == 0
+
+
+def test_submit_side_counting_pairs_scheduler_count_with_builder_settle() -> None:
+    """The counter increments and decrements once for a submitted build."""
+    service = _make_service(max_batch_wait_ms=500)
+    service.enable_submit_side_counting()
+
+    service.note_build_submitted()
+    assert service.stats()["outstanding_builds"] == 1
+    service.note_build_started()
+    assert service.stats()["outstanding_builds"] == 1
+    item = _item(9_600, 4)
+    try:
+        service.encode_item(item)
+    finally:
+        service.note_build_finished()
+    assert item.precomputed_embeddings is not None
+    assert service.stats()["outstanding_builds"] == 0
+
+    service.note_build_submitted()
+    service.note_build_cancelled()
+    assert service.stats()["outstanding_builds"] == 0
+
+
+def test_submitted_but_unstarted_build_holds_window_open() -> None:
+    """A build waiting in the executor keeps the batch window open."""
+    model = _StubModel()
+    service = _make_service(model, max_batch_wait_ms=500)
+    service.enable_submit_side_counting()
+    gate = threading.Event()
+    model.encode_gate = gate
+
+    service.note_build_submitted()
+    thread_a = threading.Thread(target=_run_build, args=(service, _item(9_700, 4)))
+    thread_a.start()
+    assert _await(lambda: model.encode_calls == 1), "A never reached the encoder"
+
+    service.note_build_submitted()
+    thread_b = threading.Thread(target=_run_build, args=(service, _item(9_701, 4)))
+    thread_b.start()
+    assert _await(lambda: service._queue.qsize() == 1), "B never queued"
+
+    service.note_build_submitted()
+    gate.set()  # The drain picks up B while C waits in the executor queue.
+    thread_c = threading.Thread(target=_run_build, args=(service, _item(9_702, 4)))
+    thread_c.start()
+    for thread in (thread_a, thread_b, thread_c):
+        thread.join(timeout=10)
+
+    stats = service.stats()
+    assert stats["batch_size_hist"] == {1: 1, 2: 1}, stats
+    assert stats["outstanding_builds"] == 0, stats

--- a/tests/unit_test/fun_asr/test_pipeline.py
+++ b/tests/unit_test/fun_asr/test_pipeline.py
@@ -150,6 +150,7 @@ def test_fun_asr_threads_generation_batch_and_request_build_policy(monkeypatch) 
     class _EncoderService:
         def __init__(self) -> None:
             self.close_calls = 0
+            self.build_tracker = object()
 
         def close(self) -> None:
             self.close_calls += 1
@@ -289,7 +290,7 @@ def test_fun_asr_pipeline_batch_wait_reaches_encoder_service(monkeypatch) -> Non
 
     def _capture_encoder_service(*args, **kwargs):
         captured.update(kwargs)
-        service = SimpleNamespace(close=lambda: None)
+        service = SimpleNamespace(close=lambda: None, build_tracker=object())
         created_services.append(service)
         return service
 
@@ -337,4 +338,4 @@ def test_fun_asr_pipeline_batch_wait_reaches_encoder_service(monkeypatch) -> Non
     assert captured["max_batch_size"] == 8
     assert captured["cache_max_entries"] == 4096
     assert captured["cache_max_bytes"] == 2 * 1024**3
-    assert scheduler.request_build_counter is created_services[0]
+    assert scheduler.request_build_tracker is created_services[0].build_tracker

--- a/tests/unit_test/fun_asr/test_pipeline.py
+++ b/tests/unit_test/fun_asr/test_pipeline.py
@@ -28,7 +28,7 @@ def test_fun_asr_config_uses_batched_stage_with_32_running_requests() -> None:
     assert config.stages[0].factory_args["pre_lm_cache_max_entries"] == 4096
     assert config.stages[0].factory_args["pre_lm_cache_size_bytes"] == 2 * 1024**3
     assert config.stages[0].factory_args["pre_lm_max_batch_size"] == 8
-    assert config.stages[0].factory_args["pre_lm_max_batch_wait_ms"] == 4
+    assert config.stages[0].factory_args["pre_lm_max_batch_wait_ms"] == 24
     assert config.stages[0].factory_args["request_build_max_workers"] == 8
     assert config.stages[0].factory_args["request_build_max_pending"] == 16
     assert (
@@ -243,3 +243,98 @@ def test_fun_asr_threads_generation_batch_and_request_build_policy(monkeypatch) 
         fun_asr_stages.create_sglang_fun_asr_executor("dummy")
 
     assert encoder_services[1].close_calls == 1
+
+
+def test_fun_asr_pipeline_batch_wait_reaches_encoder_service(monkeypatch) -> None:
+    """The pipeline preset wires its batch policy and outstanding-build counter."""
+    captured: dict[str, object] = {}
+
+    def tokenizer(text, add_special_tokens=False):
+        return SimpleNamespace(input_ids=[0] * len(text))
+
+    monkeypatch.setattr(
+        fun_asr_stages.AutoTokenizer,
+        "from_pretrained",
+        lambda *args, **kwargs: tokenizer,
+    )
+    monkeypatch.setattr(
+        fun_asr_stages.AutoFeatureExtractor,
+        "from_pretrained",
+        lambda *args, **kwargs: SimpleNamespace(nb_max_frames=500),
+    )
+    monkeypatch.setattr(
+        fun_asr_stages, "get_visible_gpu_sm_version", lambda gpu_id: None
+    )
+    monkeypatch.setattr(fun_asr_stages, "init_mm_embedding_cache", lambda size: None)
+    monkeypatch.setattr(
+        fun_asr_stages,
+        "make_fun_asr_scheduler_adapters",
+        lambda **kwargs: (object(), object()),
+    )
+    monkeypatch.setattr(
+        fun_asr_stages,
+        "make_fun_asr_stream_output_builder",
+        lambda **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        fun_asr_stages, "SGLangOutputProcessor", lambda **kwargs: object()
+    )
+    monkeypatch.setattr(fun_asr_stages, "ModelRunner", lambda *args, **kwargs: object())
+    monkeypatch.setattr(fun_asr_stages, "OmniScheduler", SimpleNamespace)
+    monkeypatch.setattr(
+        fun_asr_stages, "build_cache_namespace", lambda *args, **kwargs: "ns"
+    )
+
+    created_services: list[SimpleNamespace] = []
+
+    def _capture_encoder_service(*args, **kwargs):
+        captured.update(kwargs)
+        service = SimpleNamespace(close=lambda: None)
+        created_services.append(service)
+        return service
+
+    monkeypatch.setattr(
+        fun_asr_stages, "FunASRPreLMEncoderService", _capture_encoder_service
+    )
+
+    def _fake_server_args_builder(model_path, context_length, **overrides):
+        server_args = FakeServerArgs(**overrides)
+        server_args.mm_attention_backend = None
+        return server_args
+
+    monkeypatch.setattr(
+        fun_asr_stages, "build_sglang_server_args", _fake_server_args_builder
+    )
+    model_worker = SimpleNamespace(model_runner=SimpleNamespace(model=object()))
+    infrastructure = (
+        model_worker,
+        object(),
+        object(),
+        object(),
+        object(),
+        object(),
+        object(),
+    )
+    monkeypatch.setattr(
+        fun_asr_stages,
+        "create_sglang_infrastructure_defer_cuda_graph",
+        lambda *args, **kwargs: (False, infrastructure),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        fun_asr_stages,
+        "validate_generation_batch_policy",
+        lambda **kwargs: None,
+        raising=False,
+    )
+
+    config = FunASRPipelineConfig(model_path="FunAudioLLM/Fun-ASR-Nano-2512-hf")
+    scheduler = fun_asr_stages.create_sglang_fun_asr_executor(
+        config.model_path, **config.stages[0].factory_args
+    )
+
+    assert captured["max_batch_wait_ms"] == 24
+    assert captured["max_batch_size"] == 8
+    assert captured["cache_max_entries"] == 4096
+    assert captured["cache_max_bytes"] == 2 * 1024**3
+    assert scheduler.request_build_counter is created_services[0]

--- a/tests/unit_test/fun_asr/test_request_builders.py
+++ b/tests/unit_test/fun_asr/test_request_builders.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import contextlib
+from collections.abc import Iterator
 from types import SimpleNamespace
 
 import numpy as np
@@ -20,14 +22,27 @@ _AUDIO_PAD = "<|object_ref_start|>"
 _AUDIO_PAD_ID = 42  # arbitrary sentinel distinct from vocabulary ids below
 
 
+class _RecordingTracker:
+    """Build-tracker stub that records tracked_build enters and exits."""
+
+    def __init__(self) -> None:
+        self.entered = 0
+        self.exited = 0
+
+    @contextlib.contextmanager
+    def tracked_build(self) -> Iterator[None]:
+        self.entered += 1
+        try:
+            yield
+        finally:
+            self.exited += 1
+
+
 class _UnexpectedEncoderService:
     """Encoder stub whose encode path must remain unused."""
 
-    def note_build_started(self) -> None:
-        pass
-
-    def note_build_finished(self) -> None:
-        pass
+    def __init__(self) -> None:
+        self.build_tracker = _RecordingTracker()
 
     def encode_item(self, _item: object) -> None:
         pytest.fail("invalid requests must not be encoded")
@@ -152,25 +167,23 @@ def test_fun_asr_request_builder_encodes_after_offsets_are_final(monkeypatch) ->
     observed: dict[str, object] = {}
 
     class _EncoderService:
-        def note_build_started(self) -> None:
-            observed["builds_started"] = observed.get("builds_started", 0) + 1
-
-        def note_build_finished(self) -> None:
-            observed["builds_finished"] = observed.get("builds_finished", 0) + 1
+        def __init__(self) -> None:
+            self.build_tracker = _RecordingTracker()
 
         def encode_item(self, item) -> None:
-            observed["started_before_encode"] = observed.get("builds_started") == 1
+            observed["tracked_during_encode"] = self.build_tracker.entered == 1
             observed["offsets"] = item.offsets
             observed["num_audio_tokens"] = item.num_audio_tokens
             observed["audio_fingerprint"] = item.audio_fingerprint
             item.precomputed_embeddings = torch.zeros(item.num_audio_tokens, 4)
             item.feature = None
 
+    encoder_service = _EncoderService()
     request_builder, _ = request_builders.make_fun_asr_scheduler_adapters(
         tokenizer=_FakeTokenizer(),
         max_new_tokens=16,
         feature_extractor=_feature_extractor(17),
-        audio_encoder_service=_EncoderService(),
+        audio_encoder_service=encoder_service,
     )
     payload = StagePayload(
         request_id="req-fun-asr-pre-lm",
@@ -186,9 +199,9 @@ def test_fun_asr_request_builder_encodes_after_offsets_are_final(monkeypatch) ->
     assert observed["audio_fingerprint"] == audio_fingerprint(audio)
     assert item.feature is None
     assert item.precomputed_embeddings.shape[0] == 3
-    assert observed["started_before_encode"] is True
-    assert observed["builds_started"] == 1
-    assert observed["builds_finished"] == 1
+    assert observed["tracked_during_encode"] is True
+    assert encoder_service.build_tracker.entered == 1
+    assert encoder_service.build_tracker.exited == 1
 
 
 def test_fun_asr_request_builder_language_prompt(monkeypatch) -> None:

--- a/tests/unit_test/fun_asr/test_request_builders.py
+++ b/tests/unit_test/fun_asr/test_request_builders.py
@@ -21,6 +21,14 @@ _AUDIO_PAD_ID = 42  # arbitrary sentinel distinct from vocabulary ids below
 
 
 class _UnexpectedEncoderService:
+    """Encoder stub whose encode path must remain unused."""
+
+    def note_build_started(self) -> None:
+        pass
+
+    def note_build_finished(self) -> None:
+        pass
+
     def encode_item(self, _item: object) -> None:
         pytest.fail("invalid requests must not be encoded")
 
@@ -144,7 +152,14 @@ def test_fun_asr_request_builder_encodes_after_offsets_are_final(monkeypatch) ->
     observed: dict[str, object] = {}
 
     class _EncoderService:
+        def note_build_started(self) -> None:
+            observed["builds_started"] = observed.get("builds_started", 0) + 1
+
+        def note_build_finished(self) -> None:
+            observed["builds_finished"] = observed.get("builds_finished", 0) + 1
+
         def encode_item(self, item) -> None:
+            observed["started_before_encode"] = observed.get("builds_started") == 1
             observed["offsets"] = item.offsets
             observed["num_audio_tokens"] = item.num_audio_tokens
             observed["audio_fingerprint"] = item.audio_fingerprint
@@ -171,6 +186,9 @@ def test_fun_asr_request_builder_encodes_after_offsets_are_final(monkeypatch) ->
     assert observed["audio_fingerprint"] == audio_fingerprint(audio)
     assert item.feature is None
     assert item.precomputed_embeddings.shape[0] == 3
+    assert observed["started_before_encode"] is True
+    assert observed["builds_started"] == 1
+    assert observed["builds_finished"] == 1
 
 
 def test_fun_asr_request_builder_language_prompt(monkeypatch) -> None:

--- a/tests/unit_test/scheduling/test_build_tracker.py
+++ b/tests/unit_test/scheduling/test_build_tracker.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from sglang_omni.scheduling.build_tracker import OutstandingBuildTracker
+
+
+def test_idle_fires_on_every_transition_to_zero() -> None:
+    idle_calls: list[int] = []
+    tracker = OutstandingBuildTracker(on_idle=lambda: idle_calls.append(1))
+
+    tracker.note_started()
+    tracker.settle()
+    assert tracker.count == 0
+    assert len(idle_calls) == 1
+
+    tracker.note_submitted()
+    tracker.note_submitted()
+    tracker.note_cancelled()
+    assert len(idle_calls) == 1, "2 -> 1 must not fire on_idle"
+    tracker.note_cancelled()
+    assert len(idle_calls) == 2, "1 -> 0 via cancel must fire on_idle"
+
+
+def test_settle_is_idempotent_per_build() -> None:
+    idle_calls: list[int] = []
+    tracker = OutstandingBuildTracker(on_idle=lambda: idle_calls.append(1))
+
+    tracker.note_started()
+    tracker.settle()
+    tracker.settle()
+    tracker.settle()
+
+    assert tracker.count == 0
+    assert len(idle_calls) == 1
+
+
+def test_cancel_underflow_raises() -> None:
+    tracker = OutstandingBuildTracker()
+    with pytest.raises(RuntimeError, match="negative"):
+        tracker.note_cancelled()
+    assert tracker.count == 0
+
+
+def test_submit_side_counting_pairs_submit_with_settle() -> None:
+    idle_calls: list[int] = []
+    tracker = OutstandingBuildTracker(on_idle=lambda: idle_calls.append(1))
+    tracker.enable_submit_side_counting()
+
+    tracker.note_submitted()
+    tracker.note_started()  # must not double-count in submit-side mode
+    assert tracker.count == 1
+    tracker.settle()
+    assert tracker.count == 0
+    assert len(idle_calls) == 1
+
+
+def test_tracked_build_settles_on_exception() -> None:
+    tracker = OutstandingBuildTracker()
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with tracker.tracked_build():
+            assert tracker.count == 1
+            raise RuntimeError("boom")
+
+    assert tracker.count == 0
+
+
+def test_settle_on_thread_without_started_build_is_noop() -> None:
+    tracker = OutstandingBuildTracker()
+    tracker.note_started()  # main thread's build stays outstanding
+
+    def foreign_settle() -> None:
+        tracker.settle()
+
+    thread = threading.Thread(target=foreign_settle)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert tracker.count == 1, "another thread must not settle this build"
+    tracker.settle()
+    assert tracker.count == 0
+
+
+def test_idle_callback_errors_are_swallowed() -> None:
+    def bad_callback() -> None:
+        raise RuntimeError("callback boom")
+
+    tracker = OutstandingBuildTracker(on_idle=bad_callback)
+    tracker.note_started()
+    tracker.settle()  # must not raise
+
+    assert tracker.count == 0

--- a/tests/unit_test/scheduling/test_omni_scheduler.py
+++ b/tests/unit_test/scheduling/test_omni_scheduler.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import concurrent.futures
+import threading
+
+from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+
+class _Counter:
+    def __init__(self) -> None:
+        self.cancelled = 0
+
+    def note_build_cancelled(self) -> None:
+        self.cancelled += 1
+
+
+class _FakeExecutor:
+    def __init__(self) -> None:
+        self.shutdown_calls: list[dict] = []
+
+    def shutdown(self, wait=True, cancel_futures=False):  # noqa: ANN001
+        self.shutdown_calls.append({"wait": wait, "cancel_futures": cancel_futures})
+
+
+def _bare_scheduler(counter, executor, pending):
+    """Construct only the scheduler state exercised by shutdown tests."""
+    scheduler = object.__new__(OmniScheduler)
+    scheduler._request_build_executor = executor
+    scheduler._request_build_counter = counter
+    scheduler._pending_request_builds = pending
+    scheduler._request_admission_lock = threading.RLock()
+    return scheduler
+
+
+def test_executor_shutdown_refunds_cancelled_pending_builds() -> None:
+    """Shutdown decrements counts only for builds cancelled before they start."""
+    cancelled_future: concurrent.futures.Future = concurrent.futures.Future()
+    assert cancelled_future.cancel()
+    running_future: concurrent.futures.Future = concurrent.futures.Future()
+    assert running_future.set_running_or_notify_cancel()
+    done_future: concurrent.futures.Future = concurrent.futures.Future()
+    done_future.set_running_or_notify_cancel()
+    done_future.set_result(object())
+
+    counter = _Counter()
+    executor = _FakeExecutor()
+    pending = {
+        "req-cancelled": (object(), False, cancelled_future),
+        "req-running": (object(), False, running_future),
+        "req-done": (object(), False, done_future),
+    }
+    scheduler = _bare_scheduler(counter, executor, pending)
+
+    scheduler._shutdown_request_build_executor()
+
+    assert executor.shutdown_calls == [{"wait": False, "cancel_futures": True}]
+    assert scheduler._request_build_executor is None
+    assert counter.cancelled == 1
+    # Removing the cancelled build prevents abort from decrementing it again.
+    assert set(pending) == {"req-running", "req-done"}
+
+    # A second shutdown must not decrement the count again.
+    scheduler._shutdown_request_build_executor()
+    assert counter.cancelled == 1
+
+
+def test_executor_shutdown_without_counter_is_safe() -> None:
+    """Shutdown works without an outstanding-build counter."""
+    future: concurrent.futures.Future = concurrent.futures.Future()
+    assert future.cancel()
+    scheduler = _bare_scheduler(
+        None, _FakeExecutor(), {"req-1": (object(), False, future)}
+    )
+
+    scheduler._shutdown_request_build_executor()
+
+    assert scheduler._request_build_executor is None

--- a/tests/unit_test/scheduling/test_omni_scheduler.py
+++ b/tests/unit_test/scheduling/test_omni_scheduler.py
@@ -12,7 +12,7 @@ class _Counter:
     def __init__(self) -> None:
         self.cancelled = 0
 
-    def note_build_cancelled(self) -> None:
+    def note_cancelled(self) -> None:
         self.cancelled += 1
 
 
@@ -28,7 +28,7 @@ def _bare_scheduler(counter, executor, pending):
     """Construct only the scheduler state exercised by shutdown tests."""
     scheduler = object.__new__(OmniScheduler)
     scheduler._request_build_executor = executor
-    scheduler._request_build_counter = counter
+    scheduler._request_build_tracker = counter
     scheduler._pending_request_builds = pending
     scheduler._request_admission_lock = threading.RLock()
     return scheduler


### PR DESCRIPTION
## Motivation

Fun-ASR's pre-LM encoder is launch-bound at small batch sizes:

- The configured maximum batch size is 8, but serving traffic previously produced only 2.40 items/batch on average.
- The 70-layer SANM/FSMN encoder launches roughly 1,300 CUDA kernels per forward, so small batches amplify CPU launch overhead.
- In the original measurement environment, increasing the batch wait window from 4 ms to 24 ms raised average batch size to 4.09 and improved throughput by approximately 39%.

A fixed 24 ms window alone, however, adds unnecessary latency when no other request can add an item to the batch (for example, at low concurrency). This PR therefore combines the wider serving preset (4 ms to 24 ms) with an outstanding-build tracker that tells the drain loop whether a request build may still add an item, and wakes the drain loop the moment that stops being true.

#### Examples

These timelines are examples. `t=0` is when the first item enters the encoder queue; exact timing depends on thread scheduling. A **non-enqueue path** is a tracked build that adds no encoder item. This happens when it uses a cached embedding, shares another request's in-flight result, fails before enqueue, or is cancelled before it starts.

- **Concurrency 1:** One item enters at `t=0` and no build remains. Flush it immediately instead of waiting until `t=24 ms`.
- **Concurrency 2, two items:** A enters at `t=0`. B is still being prepared, so the drain loop waits. B enters at `t=6 ms`; the outstanding-build count reaches zero, and the two-item batch can flush around `t=6 ms`.
- **Concurrency 2, one non-enqueue path:** A enters at `t=0`. B is still being prepared, so the drain loop waits. B turns out to be a cache hit at `t=6 ms` and enqueues nothing. The count still reaches zero, so A's batch flushes around `t=6 ms` rather than at `t=24 ms`.
- **Concurrency 32:** If eight items enter by `t=4 ms`, the batch reaches its maximum size of 8 and flushes around `t=4 ms`. Remaining builds feed later batches.

### Code change: Serving preset

- Change the Fun-ASR pipeline preset:
  `pre_lm_max_batch_wait_ms: 4 -> 24`.
- Keep the encoder service/factory default at 4 ms. The 24 ms value remains a
  Fun-ASR serving policy rather than a global service default.

### Code change: Outstanding-build tracker

**Why:** The 24 ms window improves batching at high concurrency, but at low concurrency a request can wait the full window even when no item can be added to its batch. The encoder queue shows only items that are ready; it cannot show a request build that is still preparing one.

**How:** Increment the outstanding-build count before a build can run or wait in the executor queue. Settle the build after it enqueues an item or once it can no longer add an item to the batch, such as after a cache hit, merged request, failure, or cancellation. Keep the batch window open while the count is positive. When the count is zero and the queue is empty, flush the batch.

```mermaid
flowchart LR
    build["Request build starts"] --> increment["Increment outstanding-build count"]
    increment --> finish["Enqueue a batch item<br/>or determine that none will be added"]
    finish --> settle["Settle the build"]
    settle --> decision{"Count is zero<br/>and queue is empty?"}
    decision -->|"Yes"| flush["Flush batch"]
    decision -->|"No"| wait["Keep batch window open"]
```

Enqueue the item before settling the build. Otherwise, the drain loop could see both a zero count and an empty queue before the item becomes visible.

The counting lives in `OutstandingBuildTracker` (`sglang_omni/scheduling/build_tracker.py`) rather than in the encoder service. The encoder service owns the tracker, the scheduler takes it as `request_build_tracker`, and request builds run inside its `tracked_build()` context manager so a raising builder still settles. Each build settles exactly once: `note_started` arms a thread-local flag and `settle` only decrements while it is armed, so repeated settles are no-ops. An underflow raises instead of going negative — a leaked positive count only degrades batching back to the full wait window and is visible as `outstanding_builds` in service stats, whereas a negative count would flush batches early.

### Code change: Wake the drain loop when the last build settles

**Why:** Tracking alone is not enough, because the drain loop has to observe the change. It waited on `queue.get(timeout=remaining)`, which only wakes when an item arrives. A build that settled without enqueueing left the flush condition true while the loop kept sleeping to the full 24 ms deadline — exactly the low-concurrency latency the tracker was meant to avoid.

**How:** The drain loop now waits on a condition variable that is notified from both sides: on enqueue, and on the tracker's transition to a zero count. The loop re-checks its flush condition whenever either changes, so it never sleeps past the moment that condition becomes true. Only the worker consumes the queue, so a true predicate stays true until the next probe. These flushes are counted separately as `wakeup_flushes` in service stats, alongside the existing `guard_flushes` (window skipped outright) and `early_flushes` (window exited after an item was appended).

This also covers the put-then-settle interleaving: the drain loop can consume an enqueued item and probe the tracker before the producer reaches its settle, see a still-positive count, and enter the window. The settle landing afterwards wakes it.

**Known bound:** submit-side counting also counts builds queued behind busy executor workers. When every worker blocks on the current encode (for example, merged single-flight followers), those queued builds cannot join the current batch but still hold its window open until the deadline. That is a bounded latency cost, not a deadlock, and it is covered by a test.

### Original wait-window measurement after 4 ms -> 24 ms

Environment: 1× H100 SXM, 16-vCPU container, one worker, SeedTTS EN, concurrency 32.

| Metric | wait=4 | wait=24 stock |
|---|---:|---:|
| Average items/batch | 2.40 | 4.09 |
| Encoder queue wait | 84 ms/item | 21 ms/item |
| Throughput | 38.5 req/s | 53.5 req/s |
| Mean latency | 827 ms | 581 ms |

Additional observations:

- SeedTTS ZH throughput: 42.0 -> 59.2 req/s (+41%).
- Under CPU contention: +43% to +45%.
- Window dose curve: 12 ms = 51.6, 24 ms = 53.5, 48 ms = 50.8 req/s.
- Increasing the batch-size cap to 16 did not improve throughput.

### Final validation in progress

## Related Issues

- #1109 — Fun-ASR batched pre-LM encoder and original batching knobs.
- #1296 — Fun-ASR performance-gate margin and CPU sensitivity.

## Checklist

- [ ] Run formatting/pre-commit checks on the target environment.
- [x] Add unit tests.
- [x] Update outstanding-build tracker comments and docstrings.
- [ ] Run the new unit tests on the target box.
- [ ] Add the final gv3 throughput and latency table.
