### PR TITLE
[Benchmark] Add deterministic mixed-arrival TTS serving workloads

### DIFF
--- a/benchmarks/eval/benchmark_tts_serving.py
+++ b/benchmarks/eval/benchmark_tts_serving.py
@@ -758,14 +758,17 @@ def main() -> int:
         print(f"benchmark harness failed: {exc}")
         return 2
 
-    scenarios = build_scenarios(spec)
-    stage_request_total = sum(stage.request_count for stage in spec.params.load_stages)
-    harness_log.append(
-        f"loaded spec={Path(args.spec)} profile={spec.params.profile} "
-        f"stage_requests={stage_request_total} scenarios={len(scenarios)} "
-        f"load_stages={[stage.id for stage in spec.params.load_stages]}"
-    )
+    scenarios: list[Scenario] = []
     try:
+        scenarios = build_scenarios(spec)
+        stage_request_total = sum(
+            stage.request_count for stage in spec.params.load_stages
+        )
+        harness_log.append(
+            f"loaded spec={Path(args.spec)} profile={spec.params.profile} "
+            f"stage_requests={stage_request_total} scenarios={len(scenarios)} "
+            f"load_stages={[stage.id for stage in spec.params.load_stages]}"
+        )
         results = asyncio.run(_run_benchmark(spec, scenarios, harness_log))
         report = build_results_report(spec, results, scenarios=scenarios)
         write_artifacts(out_dir, spec, scenarios, results, report)

--- a/benchmarks/eval/benchmark_tts_serving.py
+++ b/benchmarks/eval/benchmark_tts_serving.py
@@ -26,6 +26,7 @@ import os
 import random
 import time
 from collections.abc import Iterable
+from itertools import groupby
 from pathlib import Path
 
 import aiohttp
@@ -95,7 +96,7 @@ async def _run_stage(
     scenarios: list[Scenario],
     harness_log: list[str],
 ) -> list[ScenarioResult]:
-    if len(scenarios) > stage.request_count:
+    if stage.mode != "scheduled" and len(scenarios) > stage.request_count:
         harness_log.append(
             f"stage={stage.id} scheduled {len(scenarios)} scenarios although "
             f"request_count={stage.request_count}; required benchmark contracts "
@@ -160,7 +161,11 @@ async def _run_scheduled_stage(
     harness_log: list[str],
 ) -> list[ScenarioResult]:
     stage_start = time.perf_counter()
-    offsets = _planned_offsets(stage, len(scenarios), seed=spec.seed)
+    offsets = (
+        [_scheduled_offset(scenario) for scenario in scenarios]
+        if stage.mode == "scheduled"
+        else _planned_offsets(stage, len(scenarios), seed=spec.seed)
+    )
     active_requests = 0
     peak_inflight = 0
 
@@ -178,6 +183,8 @@ async def _run_scheduled_stage(
             planned_start=planned_start,
             actual_start=actual_start,
             generator_lag=max(0.0, actual_start - planned_start),
+            configured_offset=offset,
+            collision_epoch=scenario.collision_epoch_s,
         )
         return result
 
@@ -186,7 +193,18 @@ async def _run_scheduled_stage(
     results: list[ScenarioResult] = []
     peak_pending_tasks = 0
     scheduled_task_count = 0
-    for scenario, offset in zip(scenarios, offsets, strict=True):
+    arrivals = list(zip(scenarios, offsets, strict=True))
+    if stage.mode == "scheduled":
+        arrival_groups: Iterable[tuple[float, list[Scenario]]] = (
+            (offset, [scenario for scenario, _ in grouped_arrivals])
+            for offset, grouped_arrivals in groupby(
+                arrivals,
+                key=lambda item: item[1],
+            )
+        )
+    else:
+        arrival_groups = ((offset, [scenario]) for scenario, offset in arrivals)
+    for offset, group in arrival_groups:
         planned_start = stage_start + offset
         delay_s = planned_start - time.perf_counter()
         if delay_s > 0:
@@ -195,10 +213,10 @@ async def _run_scheduled_stage(
         if done:
             pending.difference_update(done)
             results.extend(_harvest_completed_tasks(done))
-        scheduled_task_count += 1
-        if active_requests >= stage.max_concurrency:
+        scheduled_task_count += len(group)
+        if active_requests + len(group) > stage.max_concurrency:
             actual_start = time.perf_counter()
-            results.append(
+            results.extend(
                 _load_generator_saturated_result(
                     scenario,
                     stage=stage,
@@ -206,12 +224,16 @@ async def _run_scheduled_stage(
                     actual_start=actual_start,
                     active_requests=active_requests,
                     generator_lag=max(0.0, actual_start - planned_start),
+                    configured_offset=offset,
                 )
+                for scenario in group
             )
             continue
-        active_requests += 1
+        active_requests += len(group)
         peak_inflight = max(peak_inflight, active_requests)
-        pending.add(asyncio.create_task(run_planned(scenario, offset)))
+        pending.update(
+            asyncio.create_task(run_planned(scenario, offset)) for scenario in group
+        )
         peak_pending_tasks = max(peak_pending_tasks, len(pending))
     if pending:
         results.extend(await _gather_pending_tasks(pending))
@@ -248,6 +270,7 @@ def _load_generator_saturated_result(
     actual_start: float,
     active_requests: int,
     generator_lag: float,
+    configured_offset: float,
 ) -> ScenarioResult:
     result = ScenarioResult(
         scenario_id=scenario.id,
@@ -276,6 +299,8 @@ def _load_generator_saturated_result(
         actual_start=actual_start,
         peak_inflight=active_requests,
         generator_lag=generator_lag,
+        configured_offset=configured_offset,
+        collision_epoch=scenario.collision_epoch_s,
     )
     return result
 
@@ -362,16 +387,26 @@ def _attach_schedule_metadata(
     actual_start: float,
     peak_inflight: int | None = None,
     generator_lag: float | None = None,
+    configured_offset: float | None = None,
+    collision_epoch: float | None = None,
 ) -> None:
     result.stage_id = stage.id
     result.load_mode = stage.mode
     result.load_concurrency = stage.max_concurrency
     result.configured_max_concurrency = stage.max_concurrency
     result.peak_inflight = peak_inflight
+    result.configured_offset_s = configured_offset
+    result.collision_epoch_s = collision_epoch
     result.planned_start_s = planned_start
     result.actual_start_s = actual_start
     result.queue_wait_s = max(0.0, actual_start - planned_start)
     result.generator_lag_s = generator_lag
+
+
+def _scheduled_offset(scenario: Scenario) -> float:
+    if scenario.t_offset_s is None:
+        raise ValueError(f"scheduled scenario {scenario.id!r} is missing t_offset_s")
+    return scenario.t_offset_s
 
 
 def _planned_offsets(stage: LoadStage, request_count: int, *, seed: int) -> list[float]:

--- a/benchmarks/tts_serving/Dockerfile
+++ b/benchmarks/tts_serving/Dockerfile
@@ -2,6 +2,7 @@
 
 FROM python:3.11-slim
 
+ENV HF_HOME=/tmp/huggingface
 ENV PYTHONUNBUFFERED=1
 
 WORKDIR /workspace
@@ -9,7 +10,10 @@ WORKDIR /workspace
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ffmpeg \
     && rm -rf /var/lib/apt/lists/*
-RUN python -m pip install --no-cache-dir aiohttp==3.13.5 openai==2.6.1
+RUN python -m pip install --no-cache-dir \
+    aiohttp==3.13.5 \
+    huggingface-hub==0.36.0 \
+    openai==2.6.1
 RUN mkdir -p /workspace/benchmarks/eval /workspace/benchmarks/tts_serving /var/benchmark/out
 
 COPY benchmarks/eval/benchmark_tts_serving.py /workspace/benchmarks/eval/benchmark_tts_serving.py

--- a/benchmarks/tts_serving/README.md
+++ b/benchmarks/tts_serving/README.md
@@ -118,10 +118,16 @@ Load-stage fields:
 | `request_rate` | Requests per second for `open_loop` and `ramp`. Do not set this for `soak` because it is derived from `request_count / duration_s`. |
 | `start_request_rate` | Initial requests per second for `ramp`. |
 | `duration_s` | Wall-clock duration for `soak`. |
+| `text_corpus` | Target-text corpus for supported workloads in a `scheduled` stage. `seedtts-en` allocates deterministic, non-overlapping texts from pinned SeedTTS English metadata. |
 | `arrival_distribution` | `deterministic` or `poisson`. |
 | `enabled_endpoints` | Optional per-stage endpoint override. |
 | `coverage_schedule` | Start and end offsets used to spread required contract scenarios across a `scheduled` stage. |
 | `workload_schedules` | Per-workload background and collision offsets for a `scheduled` stage. These offsets are the arrival authority, so rate, duration, distribution, and request-count fields are not accepted with this mode. |
+
+Scheduled offsets must be strictly increasing. Every collision offset must
+contain exactly one request from every configured workload, and background or
+coverage requests cannot use the same offset. The report validates both this
+membership and a common client-observed in-flight interval for each cohort.
 
 ## Endpoint Contracts
 
@@ -247,15 +253,18 @@ headers or placeholder bytes cannot pass as generated audio.
 
 | Stage | Purpose |
 |-------|---------|
-| `mixed-production` | Fixed 300-second mix with per-workload background arrivals and 20 six-workload collision epochs. |
+| `closed-1` | Serial baseline that isolates contract failures from concurrency effects. |
+| `closed-16` | Moderate closed-loop concurrency. |
+| `ramp-128` | Poisson ramp from low request rate to high request rate. |
+| `soak-300s` | Sustained load over a fixed duration. |
+| `ws-burst-512` | WebSocket-only burst pressure. |
 | `voice-cache-pressure` | Uploaded-voice cache pressure below the speaker cap. |
 | `voice-speaker-cap` | State-aware speaker-cap validation. |
+| `mixed-burst-512` | Full-endpoint burst with `request_count=512` and `max_concurrency=512`. |
 
-Equal-offset collision members are launched as one all-or-nothing group. The
-report keeps each workload's metrics separate and records whether the measured
-request intervals had a common overlap across the complete six-workload cohort;
-sharing a stage or overlapping only one peer does not count as mixed-load
-evidence.
+The mixed burst intentionally matches request count and concurrency so the
+client can emit the full burst without creating artificial
+`load_generator_saturated` records.
 
 Speaker-cap stages list existing uploaded voices first, upload only the names
 needed to reach `speaker_max_uploaded`, and require the first overflow upload
@@ -285,7 +294,11 @@ logs/harness.log      # load-stage execution notes
 | `harness_status` | Whether the harness ran successfully. |
 | `overall.coverage_contract_valid` | Whether required scenario coverage was achieved. |
 | `overall.load_generation_valid` | Whether the client emitted the intended load without saturation or excessive lag. |
+| `overall.mixed_arrival_valid` | Whether scheduled workload counts and collision evidence passed. |
 | `metrics.status_counts` | Count of `ok`, protocol failures, unsupported contracts, and load-generator failures. |
 | `metrics.endpoint_mix` | Executed scenario count by endpoint family. |
+| `metrics.by_stage` | Operational metrics across all successful traffic in each stage, including coverage traffic. |
+| `metrics.by_stage_and_workload` | Performance metrics for each workload within a load stage. |
+| `metrics.mixed_arrival` | Workload counts, coverage counts, and per-collision overlap evidence. |
 | `unsupported_contracts` | Enabled API contracts that were missing or unsupported. |
 | `coverage_failures` | Coverage requirements that traffic alone could not prove. |

--- a/benchmarks/tts_serving/README.md
+++ b/benchmarks/tts_serving/README.md
@@ -65,6 +65,7 @@ The Docker image installs `ffmpeg`.
 benchmark_tts_serving.py       # entry point under benchmarks/eval/
 spec.py                        # spec schema and load-stage defaults
 scenarios.py                   # deterministic scenario matrix
+text_corpus.py                 # pinned target-text corpus loading
 http_client.py                 # HTTP request dispatch
 sdk_client.py                  # OpenAI SDK compatibility path
 ws_client.py                   # WebSocket speech-stream path
@@ -208,6 +209,9 @@ docker build -f benchmarks/tts_serving/Dockerfile \
 ```
 
 Run the image with a spec mounted at the contract path:
+
+Specs using `text_corpus: seedtts-en` download the pinned SeedTTS metadata to
+the container's temporary Hugging Face cache on first use.
 
 ```bash
 docker run --rm \

--- a/benchmarks/tts_serving/README.md
+++ b/benchmarks/tts_serving/README.md
@@ -112,14 +112,16 @@ Load-stage fields:
 | Field | Description |
 |-------|-------------|
 | `id` | Stable stage id used in scenario ids and artifacts. |
-| `mode` | `closed_loop`, `open_loop`, `ramp`, `burst`, or `soak`. |
-| `request_count` | Number of scheduled scenarios for the stage. |
+| `mode` | `closed_loop`, `open_loop`, `ramp`, `burst`, `soak`, or `scheduled`. |
+| `request_count` | Number of scenarios for non-`scheduled` stages. |
 | `max_concurrency` | Maximum in-flight requests for the stage. |
 | `request_rate` | Requests per second for `open_loop` and `ramp`. Do not set this for `soak` because it is derived from `request_count / duration_s`. |
 | `start_request_rate` | Initial requests per second for `ramp`. |
 | `duration_s` | Wall-clock duration for `soak`. |
 | `arrival_distribution` | `deterministic` or `poisson`. |
 | `enabled_endpoints` | Optional per-stage endpoint override. |
+| `coverage_schedule` | Start and end offsets used to spread required contract scenarios across a `scheduled` stage. |
+| `workload_schedules` | Per-workload background and collision offsets for a `scheduled` stage. These offsets are the arrival authority, so rate, duration, distribution, and request-count fields are not accepted with this mode. |
 
 ## Endpoint Contracts
 
@@ -245,18 +247,15 @@ headers or placeholder bytes cannot pass as generated audio.
 
 | Stage | Purpose |
 |-------|---------|
-| `closed-1` | Serial baseline that isolates contract failures from concurrency effects. |
-| `closed-16` | Moderate closed-loop concurrency. |
-| `ramp-128` | Poisson ramp from low request rate to high request rate. |
-| `soak-300s` | Sustained load over a fixed duration. |
-| `ws-burst-512` | WebSocket-only burst pressure. |
+| `mixed-production` | Fixed 300-second mix with per-workload background arrivals and 20 six-workload collision epochs. |
 | `voice-cache-pressure` | Uploaded-voice cache pressure below the speaker cap. |
 | `voice-speaker-cap` | State-aware speaker-cap validation. |
-| `mixed-burst-512` | Full-endpoint burst with `request_count=512` and `max_concurrency=512`. |
 
-The mixed burst intentionally matches request count and concurrency so the
-client can emit the full burst without creating artificial
-`load_generator_saturated` records.
+Equal-offset collision members are launched as one all-or-nothing group. The
+report keeps each workload's metrics separate and records whether the measured
+request intervals had a common overlap across the complete six-workload cohort;
+sharing a stage or overlapping only one peer does not count as mixed-load
+evidence.
 
 Speaker-cap stages list existing uploaded voices first, upload only the names
 needed to reach `speaker_max_uploaded`, and require the first overflow upload

--- a/benchmarks/tts_serving/batch_client.py
+++ b/benchmarks/tts_serving/batch_client.py
@@ -13,9 +13,9 @@ from benchmarks.tts_serving.audio_validation import (
     validate_audio_response,
 )
 from benchmarks.tts_serving.http_contracts import (
-    _json_from_bytes,
-    _mark_protocol_error,
-    _mark_success,
+    json_from_bytes,
+    mark_protocol_error,
+    mark_success,
 )
 from benchmarks.tts_serving.metrics import ScenarioResult
 from benchmarks.tts_serving.scenarios import Scenario
@@ -39,7 +39,7 @@ class BatchItemValidation:
 def handle_batch_success(
     body: bytes, result: ScenarioResult, scenario: Scenario
 ) -> None:
-    payload = _json_from_bytes(
+    payload = json_from_bytes(
         body,
         result,
         status="invalid_batch_response",
@@ -50,7 +50,7 @@ def handle_batch_success(
         return
     required_keys = {"id", "results", "total", "succeeded", "failed"}
     if not isinstance(payload, dict) or not required_keys <= set(payload):
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_batch_response",
             error="batch endpoint returned JSON without id/results/total/succeeded/failed",
@@ -62,7 +62,7 @@ def handle_batch_success(
     succeeded = payload.get("succeeded")
     failed = payload.get("failed")
     if not isinstance(payload.get("id"), str) or not payload["id"]:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_batch_response",
             error="batch endpoint id must be a non-empty string",
@@ -74,14 +74,14 @@ def handle_batch_success(
         or not isinstance(succeeded, int)
         or not isinstance(failed, int)
     ):
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_batch_response",
             error="batch endpoint returned non-integer counts or non-list results",
         )
         return
     if total != batch_size or len(results) != batch_size:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_batch_response",
             error=(
@@ -91,7 +91,7 @@ def handle_batch_success(
         )
         return
     if succeeded + failed != total:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_batch_response",
             error="batch endpoint succeeded + failed does not equal total",
@@ -102,7 +102,7 @@ def handle_batch_success(
         batch_size=batch_size,
     )
     if expected_item_failures is None:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_benchmark_scenario",
             error="batch scenario expected_item_failures must contain valid item indexes",
@@ -110,7 +110,7 @@ def handle_batch_success(
         return
     expected_failed = len(expected_item_failures)
     if failed != expected_failed or succeeded != total - expected_failed:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_batch_response",
             error=(
@@ -135,7 +135,7 @@ def handle_batch_success(
             expect_failure=expect_item_failure,
         )
         if validation_error.error is not None:
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="invalid_batch_response",
                 error=f"batch endpoint result item {index}: {validation_error.error}",
@@ -148,7 +148,7 @@ def handle_batch_success(
             successful_audio_bytes += validation_error.audio_bytes
             successful_audio_duration_s += validation_error.audio_duration_s
     if observed_success != succeeded or observed_failed != failed:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_batch_response",
             error=(
@@ -160,7 +160,7 @@ def handle_batch_success(
         return
     result.audio_bytes += successful_audio_bytes
     result.audio_duration_s += successful_audio_duration_s
-    _mark_success(result, capability="pass")
+    mark_success(result, capability="pass")
 
 
 def _expected_batch_item_failures(

--- a/benchmarks/tts_serving/examples/stress.json
+++ b/benchmarks/tts_serving/examples/stress.json
@@ -17,44 +17,41 @@
     "file_ref_text": "Hey, Adam here. Let's create something that feels real, sounds human, and connects every time.",
     "load_stages": [
       {
-        "id": "mixed-production",
-        "mode": "scheduled",
+        "id": "closed-1",
+        "mode": "closed_loop",
+        "request_count": 32,
+        "max_concurrency": 1
+      },
+      {
+        "id": "closed-16",
+        "mode": "closed_loop",
+        "request_count": 128,
+        "max_concurrency": 16
+      },
+      {
+        "id": "ramp-128",
+        "mode": "ramp",
+        "request_count": 256,
         "max_concurrency": 128,
-        "coverage_schedule": {
-          "start_s": 0.625,
-          "end_s": 299.375
-        },
-        "workload_schedules": [
-          {
-            "workload": "speech_normal",
-            "background_offsets_s": [3.75, 18.75, 33.75, 48.75, 63.75, 78.75, 93.75, 108.75, 123.75, 138.75, 153.75, 168.75, 183.75, 198.75, 213.75, 228.75, 243.75, 258.75, 273.75, 288.75],
-            "collision_offsets_s": [7.5, 22.5, 37.5, 52.5, 67.5, 82.5, 97.5, 112.5, 127.5, 142.5, 157.5, 172.5, 187.5, 202.5, 217.5, 232.5, 247.5, 262.5, 277.5, 292.5]
-          },
-          {
-            "workload": "rest_stream",
-            "background_offsets_s": [1.25, 16.25, 31.25, 46.25, 61.25, 76.25, 91.25, 106.25, 121.25, 136.25, 151.25, 166.25, 181.25, 196.25, 211.25, 226.25, 241.25, 256.25, 271.25, 286.25],
-            "collision_offsets_s": [7.5, 22.5, 37.5, 52.5, 67.5, 82.5, 97.5, 112.5, 127.5, 142.5, 157.5, 172.5, 187.5, 202.5, 217.5, 232.5, 247.5, 262.5, 277.5, 292.5]
-          },
-          {
-            "workload": "ws_normal",
-            "background_offsets_s": [1.875, 16.875, 31.875, 46.875, 61.875, 76.875, 91.875, 106.875, 121.875, 136.875, 151.875, 166.875, 181.875, 196.875, 211.875, 226.875, 241.875, 256.875, 271.875, 286.875],
-            "collision_offsets_s": [7.5, 22.5, 37.5, 52.5, 67.5, 82.5, 97.5, 112.5, 127.5, 142.5, 157.5, 172.5, 187.5, 202.5, 217.5, 232.5, 247.5, 262.5, 277.5, 292.5]
-          },
-          {
-            "workload": "ws_stream_audio",
-            "background_offsets_s": [6.25, 21.25, 36.25, 51.25, 66.25, 81.25, 96.25, 111.25, 126.25, 141.25, 156.25, 171.25, 186.25, 201.25, 216.25, 231.25, 246.25, 261.25, 276.25, 291.25],
-            "collision_offsets_s": [7.5, 22.5, 37.5, 52.5, 67.5, 82.5, 97.5, 112.5, 127.5, 142.5, 157.5, 172.5, 187.5, 202.5, 217.5, 232.5, 247.5, 262.5, 277.5, 292.5]
-          },
-          {
-            "workload": "batch_32_all_valid",
-            "background_offsets_s": [],
-            "collision_offsets_s": [7.5, 22.5, 37.5, 52.5, 67.5, 82.5, 97.5, 112.5, 127.5, 142.5, 157.5, 172.5, 187.5, 202.5, 217.5, 232.5, 247.5, 262.5, 277.5, 292.5]
-          },
-          {
-            "workload": "long_prefill_decode",
-            "background_offsets_s": [],
-            "collision_offsets_s": [7.5, 22.5, 37.5, 52.5, 67.5, 82.5, 97.5, 112.5, 127.5, 142.5, 157.5, 172.5, 187.5, 202.5, 217.5, 232.5, 247.5, 262.5, 277.5, 292.5]
-          }
+        "start_request_rate": 2,
+        "request_rate": 64,
+        "arrival_distribution": "poisson"
+      },
+      {
+        "id": "soak-300s",
+        "mode": "soak",
+        "request_count": 512,
+        "duration_s": 300,
+        "max_concurrency": 128,
+        "arrival_distribution": "poisson"
+      },
+      {
+        "id": "ws-burst-512",
+        "mode": "burst",
+        "request_count": 512,
+        "max_concurrency": 512,
+        "enabled_endpoints": [
+          "websocket"
         ]
       },
       {
@@ -79,6 +76,12 @@
         "voice_cache_pressure_voice_count": 0,
         "voice_speaker_cap_count": 1001,
         "speaker_max_uploaded": 1000
+      },
+      {
+        "id": "mixed-burst-512",
+        "mode": "burst",
+        "request_count": 512,
+        "max_concurrency": 512
       }
     ]
   }

--- a/benchmarks/tts_serving/examples/stress.json
+++ b/benchmarks/tts_serving/examples/stress.json
@@ -17,41 +17,44 @@
     "file_ref_text": "Hey, Adam here. Let's create something that feels real, sounds human, and connects every time.",
     "load_stages": [
       {
-        "id": "closed-1",
-        "mode": "closed_loop",
-        "request_count": 32,
-        "max_concurrency": 1
-      },
-      {
-        "id": "closed-16",
-        "mode": "closed_loop",
-        "request_count": 128,
-        "max_concurrency": 16
-      },
-      {
-        "id": "ramp-128",
-        "mode": "ramp",
-        "request_count": 256,
+        "id": "mixed-production",
+        "mode": "scheduled",
         "max_concurrency": 128,
-        "start_request_rate": 2,
-        "request_rate": 64,
-        "arrival_distribution": "poisson"
-      },
-      {
-        "id": "soak-300s",
-        "mode": "soak",
-        "request_count": 512,
-        "duration_s": 300,
-        "max_concurrency": 128,
-        "arrival_distribution": "poisson"
-      },
-      {
-        "id": "ws-burst-512",
-        "mode": "burst",
-        "request_count": 512,
-        "max_concurrency": 512,
-        "enabled_endpoints": [
-          "websocket"
+        "coverage_schedule": {
+          "start_s": 0.625,
+          "end_s": 299.375
+        },
+        "workload_schedules": [
+          {
+            "workload": "speech_normal",
+            "background_offsets_s": [3.75, 18.75, 33.75, 48.75, 63.75, 78.75, 93.75, 108.75, 123.75, 138.75, 153.75, 168.75, 183.75, 198.75, 213.75, 228.75, 243.75, 258.75, 273.75, 288.75],
+            "collision_offsets_s": [7.5, 22.5, 37.5, 52.5, 67.5, 82.5, 97.5, 112.5, 127.5, 142.5, 157.5, 172.5, 187.5, 202.5, 217.5, 232.5, 247.5, 262.5, 277.5, 292.5]
+          },
+          {
+            "workload": "rest_stream",
+            "background_offsets_s": [1.25, 16.25, 31.25, 46.25, 61.25, 76.25, 91.25, 106.25, 121.25, 136.25, 151.25, 166.25, 181.25, 196.25, 211.25, 226.25, 241.25, 256.25, 271.25, 286.25],
+            "collision_offsets_s": [7.5, 22.5, 37.5, 52.5, 67.5, 82.5, 97.5, 112.5, 127.5, 142.5, 157.5, 172.5, 187.5, 202.5, 217.5, 232.5, 247.5, 262.5, 277.5, 292.5]
+          },
+          {
+            "workload": "ws_normal",
+            "background_offsets_s": [1.875, 16.875, 31.875, 46.875, 61.875, 76.875, 91.875, 106.875, 121.875, 136.875, 151.875, 166.875, 181.875, 196.875, 211.875, 226.875, 241.875, 256.875, 271.875, 286.875],
+            "collision_offsets_s": [7.5, 22.5, 37.5, 52.5, 67.5, 82.5, 97.5, 112.5, 127.5, 142.5, 157.5, 172.5, 187.5, 202.5, 217.5, 232.5, 247.5, 262.5, 277.5, 292.5]
+          },
+          {
+            "workload": "ws_stream_audio",
+            "background_offsets_s": [6.25, 21.25, 36.25, 51.25, 66.25, 81.25, 96.25, 111.25, 126.25, 141.25, 156.25, 171.25, 186.25, 201.25, 216.25, 231.25, 246.25, 261.25, 276.25, 291.25],
+            "collision_offsets_s": [7.5, 22.5, 37.5, 52.5, 67.5, 82.5, 97.5, 112.5, 127.5, 142.5, 157.5, 172.5, 187.5, 202.5, 217.5, 232.5, 247.5, 262.5, 277.5, 292.5]
+          },
+          {
+            "workload": "batch_32_all_valid",
+            "background_offsets_s": [],
+            "collision_offsets_s": [7.5, 22.5, 37.5, 52.5, 67.5, 82.5, 97.5, 112.5, 127.5, 142.5, 157.5, 172.5, 187.5, 202.5, 217.5, 232.5, 247.5, 262.5, 277.5, 292.5]
+          },
+          {
+            "workload": "long_prefill_decode",
+            "background_offsets_s": [],
+            "collision_offsets_s": [7.5, 22.5, 37.5, 52.5, 67.5, 82.5, 97.5, 112.5, 127.5, 142.5, 157.5, 172.5, 187.5, 202.5, 217.5, 232.5, 247.5, 262.5, 277.5, 292.5]
+          }
         ]
       },
       {
@@ -76,12 +79,6 @@
         "voice_cache_pressure_voice_count": 0,
         "voice_speaker_cap_count": 1001,
         "speaker_max_uploaded": 1000
-      },
-      {
-        "id": "mixed-burst-512",
-        "mode": "burst",
-        "request_count": 512,
-        "max_concurrency": 512
       }
     ]
   }

--- a/benchmarks/tts_serving/http_client.py
+++ b/benchmarks/tts_serving/http_client.py
@@ -18,12 +18,12 @@ from benchmarks.tts_serving.batch_client import handle_batch_success
 from benchmarks.tts_serving.http_contracts import (
     MAX_HTTP_RESPONSE_BYTES,
     ResponseBodyTooLarge,
-    _classify_http_failure,
-    _is_unsupported_http_status,
-    _mark_protocol_error,
-    _mark_success,
-    _mark_unexpected_success,
-    _mark_unsupported_contract,
+    classify_http_failure,
+    is_unsupported_http_status,
+    mark_protocol_error,
+    mark_success,
+    mark_unexpected_success,
+    mark_unsupported_contract,
     read_response_body,
 )
 from benchmarks.tts_serving.metrics import (
@@ -201,7 +201,7 @@ async def _disconnect_before_response(
                 return_when=asyncio.FIRST_COMPLETED,
             )
             if not done:
-                _mark_protocol_error(
+                mark_protocol_error(
                     result,
                     status="disconnect_not_reached",
                     error="request body was not sent before the configured request timeout",
@@ -212,7 +212,7 @@ async def _disconnect_before_response(
                 result.http_status = response.status
                 result.http_status_class = classify_http_status(response.status)
                 response.close()
-                _mark_protocol_error(
+                mark_protocol_error(
                     result,
                     status="disconnect_completed_too_early",
                     error="request completed before the benchmark client disconnected",
@@ -247,14 +247,14 @@ async def _disconnect_streaming_response(
         if response.status != 200:
             body, body_text = await _response_body_and_text(response)
             result.response_bytes = len(body)
-            _classify_http_failure(response.status, body_text, result, scenario)
+            classify_http_failure(response.status, body_text, result, scenario)
             return False
 
         chunk_iterator = _iter_response_http_chunks(response)
         try:
             chunk, _ = await anext(chunk_iterator)
         except StopAsyncIteration:
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="disconnect_missing_audio",
                 error="streaming response ended before producing an audio chunk",
@@ -266,14 +266,14 @@ async def _disconnect_streaming_response(
             sample_rate=_response_sample_rate(response),
         )
         if not validation.ok:
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="disconnect_invalid_audio",
                 error=f"first streaming audio chunk is invalid: {validation.error}",
             )
             return False
         if response.content.at_eof():
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="disconnect_completed_too_early",
                 error="streaming response completed before the client disconnected",
@@ -306,14 +306,14 @@ async def _run_speech_liveness_probe(
         try:
             body = await read_response_body(response)
         except ResponseBodyTooLarge as exc:
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="disconnect_liveness_response_too_large",
                 error=str(exc),
             )
             return
         if response.status < 200 or response.status >= 300:
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="disconnect_liveness_failed",
                 error=(
@@ -332,13 +332,13 @@ async def _run_speech_liveness_probe(
             sample_rate=_response_sample_rate(response),
         )
         if not validation.ok:
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="disconnect_liveness_invalid_audio",
                 error=f"post-disconnect speech probe returned invalid audio: {validation.error}",
             )
             return
-        _mark_success(result)
+        mark_success(result)
 
 
 async def _handle_probe_response(
@@ -355,8 +355,8 @@ async def _handle_probe_response(
         _mark_response_body_too_large(result, exc)
         return
     result.response_bytes = len(body)
-    if _is_unsupported_http_status(response.status, scenario):
-        _mark_unsupported_contract(
+    if is_unsupported_http_status(response.status, scenario):
+        mark_unsupported_contract(
             result,
             scenario,
             body=body_text,
@@ -366,9 +366,9 @@ async def _handle_probe_response(
         if scenario.endpoint == "voices":
             handle_voice_success(body, result, scenario)
             return
-        _mark_success(result, capability="pass")
+        mark_success(result, capability="pass")
         return
-    _classify_http_failure(response.status, body_text, result, scenario)
+    classify_http_failure(response.status, body_text, result, scenario)
 
 
 async def _handle_binary_response(
@@ -388,8 +388,8 @@ async def _handle_binary_response(
         return
     finish_timing(result, start)
     result.response_bytes = len(body)
-    if _is_unsupported_http_status(response.status, scenario):
-        _mark_unsupported_contract(
+    if is_unsupported_http_status(response.status, scenario):
+        mark_unsupported_contract(
             result,
             scenario,
             body=body.decode("utf-8", errors="replace"),
@@ -397,7 +397,7 @@ async def _handle_binary_response(
         return
     if 200 <= response.status < 300:
         if not scenario.expect_success:
-            _mark_unexpected_success(result, scenario)
+            mark_unexpected_success(result, scenario)
             return
         if scenario.endpoint == "batch":
             await asyncio.to_thread(handle_batch_success, body, result, scenario)
@@ -414,7 +414,7 @@ async def _handle_binary_response(
             sample_rate=_response_sample_rate(response),
         )
         if not validation.ok:
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="invalid_audio_response",
                 error=(
@@ -429,9 +429,9 @@ async def _handle_binary_response(
         result.audio_duration_s = validation.duration_s
         if not _parse_sglang_usage_headers(response, result):
             return
-        _mark_success(result)
+        mark_success(result)
         return
-    _classify_http_failure(
+    classify_http_failure(
         response.status, body.decode("utf-8", errors="replace"), result, scenario
     )
 
@@ -452,10 +452,10 @@ async def _handle_streaming_audio_response(
             _mark_response_body_too_large(result, exc)
             return
         result.response_bytes = len(body)
-        if _is_unsupported_http_status(response.status, scenario):
-            _mark_unsupported_contract(result, scenario, body=body_text)
+        if is_unsupported_http_status(response.status, scenario):
+            mark_unsupported_contract(result, scenario, body=body_text)
             return
-        _classify_http_failure(response.status, body_text, result, scenario)
+        classify_http_failure(response.status, body_text, result, scenario)
         return
 
     if not scenario.expect_success:
@@ -465,7 +465,7 @@ async def _handle_streaming_audio_response(
             _mark_response_body_too_large(result, exc)
             return
         result.response_bytes = len(body)
-        _mark_unexpected_success(result, scenario)
+        mark_unexpected_success(result, scenario)
         return
 
     body = bytearray()
@@ -502,7 +502,7 @@ async def _handle_streaming_audio_response(
         sample_rate=_response_sample_rate(response),
     )
     if not validation.ok:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_streaming_audio_response",
             error=(
@@ -515,7 +515,7 @@ async def _handle_streaming_audio_response(
         return
     result.audio_bytes = len(body)
     result.audio_duration_s = validation.duration_s
-    _mark_success(result)
+    mark_success(result)
 
 
 async def _response_body_and_text(
@@ -530,7 +530,7 @@ def _mark_response_body_too_large(
     exc: ResponseBodyTooLarge,
 ) -> None:
     result.response_bytes = exc.bytes_read
-    _mark_protocol_error(
+    mark_protocol_error(
         result,
         status="response_too_large",
         error=(
@@ -568,21 +568,21 @@ def _parse_sglang_usage_headers(
         try:
             value = parser(raw_value)
         except (TypeError, ValueError):
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="invalid_usage_headers",
                 error=f"{header_name} must be numeric, observed={raw_value!r}",
             )
             return False
         if isinstance(value, float) and not math.isfinite(value):
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="invalid_usage_headers",
                 error=f"{header_name} must be finite, observed={raw_value!r}",
             )
             return False
         if value < 0:
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="invalid_usage_headers",
                 error=f"{header_name} must be non-negative, observed={raw_value!r}",

--- a/benchmarks/tts_serving/http_contracts.py
+++ b/benchmarks/tts_serving/http_contracts.py
@@ -40,7 +40,7 @@ async def read_response_body(response: aiohttp.ClientResponse) -> bytes:
     return bytes(body)
 
 
-def _mark_unexpected_success(result: ScenarioResult, scenario: Scenario) -> None:
+def mark_unexpected_success(result: ScenarioResult, scenario: Scenario) -> None:
     result.success = False
     result.status = "unexpected_success"
     result.capability = "fail"
@@ -51,20 +51,14 @@ def _mark_unexpected_success(result: ScenarioResult, scenario: Scenario) -> None
     )
 
 
-def _result_has_terminal_error(result: ScenarioResult) -> bool:
-    return result.error_class is not None or (
-        result.status not in {"error", "ok"} and not result.success
-    )
-
-
-def _mark_success(result: ScenarioResult, *, capability: str | None = "pass") -> None:
+def mark_success(result: ScenarioResult, *, capability: str | None = "pass") -> None:
     result.success = True
     result.status = "ok"
     if capability is not None:
         result.capability = capability
 
 
-def _mark_unsupported_contract(
+def mark_unsupported_contract(
     result: ScenarioResult,
     scenario: Scenario,
     *,
@@ -82,7 +76,7 @@ def _mark_unsupported_contract(
     )
 
 
-def _classify_http_failure(
+def classify_http_failure(
     status: int,
     body: str,
     result: ScenarioResult,
@@ -96,8 +90,8 @@ def _classify_http_failure(
             result.error_class = "expected_client_error"
             result.capability = "pass"
             return
-        if _is_unsupported_http_status(status, scenario):
-            _mark_unsupported_contract(result, scenario, body=body)
+        if is_unsupported_http_status(status, scenario):
+            mark_unsupported_contract(result, scenario, body=body)
             return
         result.status = "invalid_voice_response"
         result.error_class = "protocol_error"
@@ -110,7 +104,7 @@ def _classify_http_failure(
     if 400 <= status < 500 and _is_expected_client_error_scenario(scenario):
         expected_status = _expected_client_error_status(scenario)
         if status != expected_status:
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="invalid_error_response",
                 error=(
@@ -119,12 +113,12 @@ def _classify_http_failure(
                 ),
             )
             return
-        if not _is_valid_error_response(
+        if not is_valid_error_response(
             status,
             body,
             expected_status=expected_status,
         ):
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="invalid_error_response",
                 error=(
@@ -137,8 +131,8 @@ def _classify_http_failure(
         result.error_class = "expected_client_error"
         result.capability = "pass"
         return
-    if _is_unsupported_http_status(status, scenario):
-        _mark_unsupported_contract(result, scenario, body=body)
+    if is_unsupported_http_status(status, scenario):
+        mark_unsupported_contract(result, scenario, body=body)
         return
     if 500 <= status:
         result.status = "failed"
@@ -151,7 +145,7 @@ def _classify_http_failure(
         result.capability = "fail"
 
 
-def _is_unsupported_http_status(status: int, scenario: Scenario) -> bool:
+def is_unsupported_http_status(status: int, scenario: Scenario) -> bool:
     if status not in UNSUPPORTED_HTTP_STATUSES:
         return False
     if scenario.capability_key == "voices.delete" and not scenario.expect_success:
@@ -171,14 +165,14 @@ def _expected_client_error_status(scenario: Scenario) -> int:
     return scenario.expected_http_status or 400
 
 
-def _json_object_from_bytes(
+def json_object_from_bytes(
     body: bytes,
     result: ScenarioResult,
     *,
     status: str,
     error_prefix: str,
 ) -> dict[str, Any] | None:
-    payload = _json_from_bytes(
+    payload = json_from_bytes(
         body,
         result,
         status=status,
@@ -188,7 +182,7 @@ def _json_object_from_bytes(
     if payload is None:
         return None
     if not isinstance(payload, dict):
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status=status,
             error=f"{error_prefix}: response must be a JSON object",
@@ -197,7 +191,7 @@ def _json_object_from_bytes(
     return payload
 
 
-def _json_from_bytes(
+def json_from_bytes(
     body: bytes,
     result: ScenarioResult,
     *,
@@ -212,7 +206,7 @@ def _json_from_bytes(
             else default_empty
         )
     except json.JSONDecodeError as exc:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status=status,
             error=f"{error_prefix}: {exc}",
@@ -234,7 +228,7 @@ def _is_valid_missing_voice_delete_response(status: int, body: str) -> bool:
     return isinstance(error, (dict, str)) and bool(error)
 
 
-def _is_valid_error_response(
+def is_valid_error_response(
     status: int,
     body: str,
     *,
@@ -246,7 +240,7 @@ def _is_valid_error_response(
     )
 
 
-def _mark_protocol_error(result: ScenarioResult, *, status: str, error: str) -> None:
+def mark_protocol_error(result: ScenarioResult, *, status: str, error: str) -> None:
     result.status = status
     result.success = False
     result.capability = "fail"

--- a/benchmarks/tts_serving/metrics.py
+++ b/benchmarks/tts_serving/metrics.py
@@ -42,6 +42,8 @@ class ScenarioResult:
     http_status: int | None = None
     http_status_class: str | None = None
     latency_s: float = 0.0
+    configured_offset_s: float | None = None
+    collision_epoch_s: float | None = None
     planned_start_s: float | None = None
     actual_start_s: float | None = None
     completed_s: float | None = None

--- a/benchmarks/tts_serving/report.py
+++ b/benchmarks/tts_serving/report.py
@@ -86,11 +86,14 @@ def build_results_report(
         coverage_matrix,
     )
     coverage_contract_valid = not coverage_failures
+    mixed_arrival, mixed_arrival_failures = _mixed_arrival_evidence(spec, results)
+    mixed_arrival_valid = not mixed_arrival_failures
     passed = (
         harness_status == "ok"
         and total > 0
         and load_generation_valid
         and coverage_contract_valid
+        and mixed_arrival_valid
         and _is_benchmark_passed(spec, results, capabilities)
     )
     return {
@@ -109,6 +112,7 @@ def build_results_report(
             "failed": failed,
             "load_generation_valid": load_generation_valid,
             "coverage_contract_valid": coverage_contract_valid,
+            "mixed_arrival_valid": mixed_arrival_valid,
         },
         "config": {
             "test_type": spec.test_type,
@@ -200,6 +204,7 @@ def build_results_report(
             "by_operation": _by_operation(spec, results),
             "by_configured_concurrency": _by_configured_concurrency(spec, results),
             "by_peak_inflight": _by_peak_inflight(spec, results),
+            "mixed_arrival": mixed_arrival,
         },
         "failures": [
             result.to_json() for result in results if not _result_passed(spec, result)
@@ -209,6 +214,7 @@ def build_results_report(
             scenarios or [],
         ),
         "coverage_failures": coverage_failures,
+        "mixed_arrival_failures": mixed_arrival_failures,
         "coverage_matrix": coverage_matrix,
         "planned_coverage_matrix": planned_coverage_matrix,
     }
@@ -1839,6 +1845,165 @@ def _admission_status_counts(results: list[ScenarioResult]) -> dict[str, int]:
         if result.error_type and "Timeout" in result.error_type:
             counts["timeout"] += 1
     return dict(counts)
+
+
+def _mixed_arrival_evidence(
+    spec: BenchmarkSpec,
+    results: list[ScenarioResult],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    evidence: dict[str, Any] = {}
+    failures: list[dict[str, Any]] = []
+    for stage in spec.params.load_stages:
+        if stage.mode != "scheduled":
+            continue
+        stage_results = [result for result in results if result.stage_id == stage.id]
+        performance = _performance_results(stage_results)
+        schedule_by_workload = {
+            schedule.workload: schedule for schedule in stage.workload_schedules
+        }
+        by_workload: dict[str, Any] = {}
+        for workload, schedule in schedule_by_workload.items():
+            workload_results = [
+                result for result in performance if result.workload == workload
+            ]
+            peers = Counter()
+            overlapping = 0
+            for result in workload_results:
+                result_peers = {
+                    peer.workload
+                    for peer in performance
+                    if peer.workload != workload and _results_overlap(result, peer)
+                }
+                if result_peers:
+                    overlapping += 1
+                peers.update(peer for peer in result_peers if peer is not None)
+            target = schedule.request_count
+            if len(workload_results) != target:
+                failures.append(
+                    {
+                        "stage": stage.id,
+                        "workload": workload,
+                        "contract": "successful_sample_count",
+                        "expected": target,
+                        "observed": len(workload_results),
+                    }
+                )
+            by_workload[workload] = {
+                "configured_request_count": target,
+                "successful_request_count": len(workload_results),
+                "overlapping_request_count": overlapping,
+                "overlapping_request_fraction": (
+                    overlapping / len(workload_results) if workload_results else 0.0
+                ),
+                "overlapping_peer_counts": dict(sorted(peers.items())),
+                "configured_collision_count": len(schedule.collision_offsets_s),
+            }
+
+        collision_epochs = sorted(
+            {
+                offset
+                for schedule in stage.workload_schedules
+                for offset in schedule.collision_offsets_s
+            }
+        )
+        epoch_evidence: list[dict[str, Any]] = []
+        for epoch in collision_epochs:
+            expected_workloads = {
+                schedule.workload
+                for schedule in stage.workload_schedules
+                if epoch in schedule.collision_offsets_s
+            }
+            members = [
+                result
+                for result in performance
+                if result.collision_epoch_s == epoch
+                and result.workload in expected_workloads
+            ]
+            member_counts = Counter(result.workload for result in members)
+            observed_workloads = set(member_counts)
+            invalid_membership = {
+                workload: member_counts.get(workload, 0)
+                for workload in sorted(expected_workloads)
+                if member_counts.get(workload, 0) != 1
+            }
+            if invalid_membership:
+                failures.append(
+                    {
+                        "stage": stage.id,
+                        "collision_epoch_s": epoch,
+                        "contract": "collision_membership",
+                        "expected_count_per_workload": 1,
+                        "observed_counts": invalid_membership,
+                    }
+                )
+            common_overlap_s = (
+                _common_overlap_s(members) if not invalid_membership else None
+            )
+            if not invalid_membership and (
+                common_overlap_s is None or common_overlap_s <= 0
+            ):
+                failures.append(
+                    {
+                        "stage": stage.id,
+                        "collision_epoch_s": epoch,
+                        "contract": "collision_cohort_overlap",
+                        "observed_common_overlap_s": common_overlap_s,
+                    }
+                )
+            epoch_valid = (
+                not invalid_membership
+                and common_overlap_s is not None
+                and common_overlap_s > 0
+            )
+            epoch_evidence.append(
+                {
+                    "offset_s": epoch,
+                    "expected_workloads": sorted(expected_workloads),
+                    "observed_workloads": sorted(
+                        workload
+                        for workload in observed_workloads
+                        if workload is not None
+                    ),
+                    "common_overlap_s": common_overlap_s,
+                    "valid": epoch_valid,
+                }
+            )
+        evidence[stage.id] = {
+            "workloads": by_workload,
+            "configured_collision_epoch_count": len(collision_epochs),
+            "observed_collision_epoch_count": sum(
+                epoch["valid"] for epoch in epoch_evidence
+            ),
+            "collision_epochs": epoch_evidence,
+        }
+    return evidence, failures
+
+
+def _results_overlap(left: ScenarioResult, right: ScenarioResult) -> bool:
+    if (
+        left.actual_start_s is None
+        or left.completed_s is None
+        or right.actual_start_s is None
+        or right.completed_s is None
+    ):
+        return False
+    return (
+        left.actual_start_s < right.completed_s
+        and right.actual_start_s < left.completed_s
+    )
+
+
+def _common_overlap_s(results: list[ScenarioResult]) -> float | None:
+    if not results:
+        return None
+    starts: list[float] = []
+    completions: list[float] = []
+    for result in results:
+        if result.actual_start_s is None or result.completed_s is None:
+            return None
+        starts.append(result.actual_start_s)
+        completions.append(result.completed_s)
+    return min(completions) - max(starts)
 
 
 def _performance_results(results: list[ScenarioResult]) -> list[ScenarioResult]:

--- a/benchmarks/tts_serving/report.py
+++ b/benchmarks/tts_serving/report.py
@@ -97,7 +97,7 @@ def build_results_report(
         and _is_benchmark_passed(spec, results, capabilities)
     )
     return {
-        "schema_version": 3,
+        "schema_version": 4,
         "scenario_schema_version": SCENARIO_SCHEMA_VERSION,
         "scenario_set_hash": scenario_set_hash(scenarios) if scenarios else None,
         "workload_spec_hash": workload_spec_hash(spec),
@@ -1858,6 +1858,9 @@ def _mixed_arrival_evidence(
             continue
         stage_results = [result for result in results if result.stage_id == stage.id]
         performance = _performance_results(stage_results)
+        coverage_results = [
+            result for result in stage_results if result.workload is None
+        ]
         schedule_by_workload = {
             schedule.workload: schedule for schedule in stage.workload_schedules
         }
@@ -1913,6 +1916,11 @@ def _mixed_arrival_evidence(
                 for schedule in stage.workload_schedules
                 if epoch in schedule.collision_offsets_s
             }
+            offset_members = [
+                result
+                for result in stage_results
+                if result.configured_offset_s == epoch
+            ]
             members = [
                 result
                 for result in performance
@@ -1926,7 +1934,8 @@ def _mixed_arrival_evidence(
                 for workload in sorted(expected_workloads)
                 if member_counts.get(workload, 0) != 1
             }
-            if invalid_membership:
+            unexpected_member_count = len(offset_members) != len(expected_workloads)
+            if invalid_membership or unexpected_member_count:
                 failures.append(
                     {
                         "stage": stage.id,
@@ -1934,13 +1943,19 @@ def _mixed_arrival_evidence(
                         "contract": "collision_membership",
                         "expected_count_per_workload": 1,
                         "observed_counts": invalid_membership,
+                        "expected_request_count_at_offset": len(expected_workloads),
+                        "observed_request_count_at_offset": len(offset_members),
                     }
                 )
             common_overlap_s = (
-                _common_overlap_s(members) if not invalid_membership else None
+                _common_overlap_s(members)
+                if not invalid_membership and not unexpected_member_count
+                else None
             )
-            if not invalid_membership and (
-                common_overlap_s is None or common_overlap_s <= 0
+            if (
+                not invalid_membership
+                and not unexpected_member_count
+                and (common_overlap_s is None or common_overlap_s <= 0)
             ):
                 failures.append(
                     {
@@ -1952,6 +1967,7 @@ def _mixed_arrival_evidence(
                 )
             epoch_valid = (
                 not invalid_membership
+                and not unexpected_member_count
                 and common_overlap_s is not None
                 and common_overlap_s > 0
             )
@@ -1964,12 +1980,20 @@ def _mixed_arrival_evidence(
                         for workload in observed_workloads
                         if workload is not None
                     ),
+                    "request_count_at_offset": len(offset_members),
                     "common_overlap_s": common_overlap_s,
                     "valid": epoch_valid,
                 }
             )
         evidence[stage.id] = {
             "workloads": by_workload,
+            "coverage_request_count": len(coverage_results),
+            "coverage_passed_count": sum(
+                _result_passed(spec, result) for result in coverage_results
+            ),
+            "expected_error_request_count": sum(
+                not result.expected_success for result in coverage_results
+            ),
             "configured_collision_epoch_count": len(collision_epochs),
             "observed_collision_epoch_count": sum(
                 epoch["valid"] for epoch in epoch_evidence

--- a/benchmarks/tts_serving/scenarios.py
+++ b/benchmarks/tts_serving/scenarios.py
@@ -11,6 +11,10 @@ from dataclasses import asdict, dataclass, field, replace
 from typing import Any
 
 from benchmarks.tts_serving.spec import BenchmarkSpec, LoadStage, SpecError
+from benchmarks.tts_serving.text_corpus import (
+    SEEDTTS_TEXT_CORPUS_REVISION,
+    load_seedtts_target_texts,
+)
 from benchmarks.tts_serving.voice_upload_fixtures import (
     VOICE_UPLOAD_FIXTURE_SIZES,
     VOICE_UPLOAD_WAV_FIXTURE_SIZE,
@@ -77,6 +81,9 @@ VOICE_DESIGN_INSTRUCTIONS = (
     "A warm, steady adult voice with precise articulation and no dramatic affect."
 )
 INITIAL_CODEC_CHUNK_FRAMES = 4
+TEXT_CORPUS_SINGLE_REQUEST_WORKLOADS = frozenset(
+    {"speech_normal", "rest_stream", "ws_normal"}
+)
 
 PROFILE_MIXES = {
     "stress": (
@@ -381,7 +388,6 @@ def _build_scheduled_stage_scenarios(
         for scenario in required_scenarios
         if scenario.workload not in scheduled_workloads
     ]
-
     resolved: list[tuple[float, int, int, Scenario]] = []
     next_index = len(required_scenarios)
     for source_rank, schedule in enumerate(stage.workload_schedules):
@@ -433,6 +439,17 @@ def _build_scheduled_stage_scenarios(
         stage.coverage_schedule.end_s,
         len(coverage_scenarios),
     )
+    collision_offsets = {
+        offset
+        for schedule in stage.workload_schedules
+        for offset in schedule.collision_offsets_s
+    }
+    coverage_at_collision = sorted(collision_offsets.intersection(coverage_offsets))
+    if coverage_at_collision:
+        raise SpecError(
+            "scheduled coverage offsets must not equal collision offsets: "
+            f"{coverage_at_collision}"
+        )
     coverage_rank = len(stage.workload_schedules)
     for source_index, (scenario, offset) in enumerate(
         zip(coverage_scenarios, coverage_offsets, strict=True)
@@ -447,6 +464,23 @@ def _build_scheduled_stage_scenarios(
         )
 
     resolved.sort(key=lambda item: item[:3])
+    for collision_offset in sorted(collision_offsets):
+        cohort = [
+            scenario
+            for offset, _, _, scenario in resolved
+            if offset == collision_offset
+        ]
+        observed_workloads = [scenario.workload for scenario in cohort]
+        if (
+            len(cohort) != len(scheduled_workloads)
+            or set(observed_workloads) != scheduled_workloads
+        ):
+            raise SpecError(
+                f"collision offset {collision_offset} must resolve to exactly one "
+                f"request per scheduled workload; observed={observed_workloads}"
+            )
+    if stage.text_corpus is not None:
+        resolved = _assign_text_corpus(spec, stage, resolved)
     return [scenario for _, _, _, scenario in resolved]
 
 
@@ -483,6 +517,119 @@ def _scheduled_workload_scenario(
     if workload == "ws_stream_audio":
         return _websocket_stream_audio(index, spec, stage)
     raise ValueError(f"unsupported scheduled workload: {workload}")
+
+
+def _assign_text_corpus(
+    spec: BenchmarkSpec,
+    stage: LoadStage,
+    resolved: list[tuple[float, int, int, Scenario]],
+) -> list[tuple[float, int, int, Scenario]]:
+    assert stage.text_corpus is not None
+    texts = list(_load_text_corpus(stage.text_corpus))
+    random.Random(f"{spec.seed}:{stage.id}:{stage.text_corpus}").shuffle(texts)
+    required_text_count = 0
+    for _, _, _, scenario in resolved:
+        if scenario.workload in TEXT_CORPUS_SINGLE_REQUEST_WORKLOADS:
+            required_text_count += 1
+        elif scenario.workload == "batch_32_all_valid":
+            batch_size = scenario.planned_metadata["batch_size"]
+            assert isinstance(batch_size, int)
+            required_text_count += batch_size
+    if required_text_count > len(texts):
+        raise SpecError(
+            f"text corpus {stage.text_corpus!r} has {len(texts)} unique texts but "
+            f"the scheduled stage requires {required_text_count}"
+        )
+
+    text_index = 0
+    assigned: list[tuple[float, int, int, Scenario]] = []
+    for offset, source_rank, source_index, scenario in resolved:
+        if scenario.workload in TEXT_CORPUS_SINGLE_REQUEST_WORKLOADS:
+            scenario = _with_target_text(
+                scenario,
+                stage.text_corpus,
+                texts[text_index],
+            )
+            text_index += 1
+        elif scenario.workload == "batch_32_all_valid":
+            batch_size = scenario.planned_metadata["batch_size"]
+            assert isinstance(batch_size, int)
+            scenario = _with_batch_target_texts(
+                scenario,
+                stage.text_corpus,
+                texts[text_index : text_index + batch_size],
+            )
+            text_index += batch_size
+        assigned.append((offset, source_rank, source_index, scenario))
+    assert text_index == required_text_count
+    return assigned
+
+
+def _with_target_text(
+    scenario: Scenario,
+    corpus_name: str,
+    target_text: str,
+) -> Scenario:
+    if scenario.workload in {"speech_normal", "rest_stream"}:
+        payload = {**scenario.payload, "input": target_text}
+        script = scenario.script
+    elif scenario.workload == "ws_normal":
+        input_step = scenario.script[1]
+        script = [
+            scenario.script[0],
+            {
+                **input_step,
+                "payload": {
+                    **input_step["payload"],
+                    "text": target_text,
+                },
+            },
+            *scenario.script[2:],
+        ]
+        payload = scenario.payload
+    else:
+        raise ValueError(f"unsupported corpus-backed workload: {scenario.workload}")
+    return replace(
+        scenario,
+        payload=payload,
+        script=script,
+        planned_metadata={
+            **scenario.planned_metadata,
+            "text_corpus": corpus_name,
+            "text_corpus_revision": SEEDTTS_TEXT_CORPUS_REVISION,
+        },
+    )
+
+
+def _with_batch_target_texts(
+    scenario: Scenario,
+    corpus_name: str,
+    target_texts: list[str],
+) -> Scenario:
+    items = scenario.payload["items"]
+    assert isinstance(items, list)
+    assert len(items) == len(target_texts)
+    return replace(
+        scenario,
+        payload={
+            **scenario.payload,
+            "items": [
+                {**item, "input": target_text}
+                for item, target_text in zip(items, target_texts, strict=True)
+            ],
+        },
+        planned_metadata={
+            **scenario.planned_metadata,
+            "text_corpus": corpus_name,
+            "text_corpus_revision": SEEDTTS_TEXT_CORPUS_REVISION,
+        },
+    )
+
+
+def _load_text_corpus(name: str) -> tuple[str, ...]:
+    if name != "seedtts-en":
+        raise SpecError(f"unsupported text corpus: {name}")
+    return load_seedtts_target_texts()
 
 
 def _required_stage_scenarios(

--- a/benchmarks/tts_serving/scenarios.py
+++ b/benchmarks/tts_serving/scenarios.py
@@ -7,17 +7,17 @@ import base64
 import hashlib
 import json
 import random
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from typing import Any
 
-from benchmarks.tts_serving.spec import BenchmarkSpec, LoadStage
+from benchmarks.tts_serving.spec import BenchmarkSpec, LoadStage, SpecError
 from benchmarks.tts_serving.voice_upload_fixtures import (
     VOICE_UPLOAD_FIXTURE_SIZES,
     VOICE_UPLOAD_WAV_FIXTURE_SIZE,
     get_wav_upload_fixture,
 )
 
-SCENARIO_SCHEMA_VERSION = 3
+SCENARIO_SCHEMA_VERSION = 4
 
 MULTILINGUAL_TEXTS = (
     ("Auto", "This sentence lets the model auto-detect the target language."),
@@ -237,6 +237,8 @@ class Scenario:
     upload_size_bytes: int = 0
     script: list[dict[str, Any]] = field(default_factory=list)
     planned_metadata: dict[str, Any] = field(default_factory=dict)
+    t_offset_s: float | None = None
+    collision_epoch_s: float | None = None
 
     def to_json(self) -> dict[str, Any]:
         return asdict(self)
@@ -339,6 +341,12 @@ def _build_stage_scenarios(spec: BenchmarkSpec, stage: LoadStage) -> list[Scenar
     rng = random.Random(f"{spec.seed}:{stage.id}")
     endpoint_set = set(stage.enabled_endpoints or spec.params.enabled_endpoints)
     required_scenarios = _required_stage_scenarios(spec, stage, endpoint_set)
+    if stage.mode == "scheduled":
+        return _build_scheduled_stage_scenarios(
+            spec,
+            stage,
+            required_scenarios,
+        )
     if _stage_voice_speaker_cap_count(spec, stage):
         return required_scenarios
     scenarios = list(required_scenarios)
@@ -353,6 +361,128 @@ def _build_stage_scenarios(spec: BenchmarkSpec, stage: LoadStage) -> list[Scenar
             )
         )
     return scenarios
+
+
+def _build_scheduled_stage_scenarios(
+    spec: BenchmarkSpec,
+    stage: LoadStage,
+    required_scenarios: list[Scenario],
+) -> list[Scenario]:
+    assert stage.coverage_schedule is not None
+    scheduled_workloads = {schedule.workload for schedule in stage.workload_schedules}
+    required_by_workload = {
+        workload: [
+            scenario for scenario in required_scenarios if scenario.workload == workload
+        ]
+        for workload in scheduled_workloads
+    }
+    coverage_scenarios = [
+        scenario
+        for scenario in required_scenarios
+        if scenario.workload not in scheduled_workloads
+    ]
+
+    resolved: list[tuple[float, int, int, Scenario]] = []
+    next_index = len(required_scenarios)
+    for source_rank, schedule in enumerate(stage.workload_schedules):
+        events = sorted(
+            (
+                *(
+                    (offset, True, index)
+                    for index, offset in enumerate(schedule.collision_offsets_s)
+                ),
+                *(
+                    (offset, False, index)
+                    for index, offset in enumerate(schedule.background_offsets_s)
+                ),
+            ),
+            key=lambda item: (item[0], not item[1], item[2]),
+        )
+        required = required_by_workload[schedule.workload]
+        if len(required) > len(events):
+            raise SpecError(
+                f"scheduled workload {schedule.workload!r} has "
+                f"{len(required)} required scenarios but only {len(events)} offsets"
+            )
+        for source_index, (offset, collision, _) in enumerate(events):
+            if source_index < len(required):
+                scenario = required[source_index]
+            else:
+                scenario = _scheduled_workload_scenario(
+                    schedule.workload,
+                    next_index,
+                    spec,
+                    stage,
+                )
+                next_index += 1
+            resolved.append(
+                (
+                    offset,
+                    source_rank,
+                    source_index,
+                    replace(
+                        scenario,
+                        t_offset_s=offset,
+                        collision_epoch_s=offset if collision else None,
+                    ),
+                )
+            )
+
+    coverage_offsets = _coverage_offsets(
+        stage.coverage_schedule.start_s,
+        stage.coverage_schedule.end_s,
+        len(coverage_scenarios),
+    )
+    coverage_rank = len(stage.workload_schedules)
+    for source_index, (scenario, offset) in enumerate(
+        zip(coverage_scenarios, coverage_offsets, strict=True)
+    ):
+        resolved.append(
+            (
+                offset,
+                coverage_rank,
+                source_index,
+                replace(scenario, t_offset_s=offset),
+            )
+        )
+
+    resolved.sort(key=lambda item: item[:3])
+    return [scenario for _, _, _, scenario in resolved]
+
+
+def _coverage_offsets(start_s: float, end_s: float, count: int) -> list[float]:
+    if count == 0:
+        return []
+    if count == 1:
+        return [(start_s + end_s) / 2.0]
+    step = (end_s - start_s) / (count - 1)
+    return [start_s + index * step for index in range(count)]
+
+
+def _scheduled_workload_scenario(
+    workload: str,
+    index: int,
+    spec: BenchmarkSpec,
+    stage: LoadStage,
+) -> Scenario:
+    if workload == "speech_normal":
+        return _speech_baseline(
+            index,
+            spec,
+            stage,
+            random.Random(f"{spec.seed}:{stage.id}:{index}:scheduled"),
+        )
+    if workload == "rest_stream":
+        return _speech_raw_pcm_stream(index, spec, stage)
+    if workload == "batch_32_all_valid":
+        return _batch_request(index, spec, stage, batch_size=32)
+    if workload == "long_prefill_decode":
+        return _speech_long_prefill_decode(index, spec, stage)
+    if workload == "ws_normal":
+        return _websocket_normal(index, spec, stage)
+    if workload == "ws_stream_audio":
+        return _websocket_stream_audio(index, spec, stage)
+    raise ValueError(f"unsupported scheduled workload: {workload}")
 
 
 def _required_stage_scenarios(

--- a/benchmarks/tts_serving/scenarios.py
+++ b/benchmarks/tts_serving/scenarios.py
@@ -2293,9 +2293,7 @@ def _websocket_normal(index: int, spec: BenchmarkSpec, stage: LoadStage) -> Scen
                 "payload": {"type": "input.text", "text": "Hello."},
             },
             {"action": "send_json", "payload": {"type": "input.done"}},
-            {"action": "expect", "event": "audio.start"},
-            {"action": "expect_audio_until_done"},
-            {"action": "expect", "event": "session.done"},
+            {"action": "expect_audio_until_session_done", "min_binary_frames": 1},
         ],
         description="stateful WebSocket speech stream",
     )

--- a/benchmarks/tts_serving/sdk_client.py
+++ b/benchmarks/tts_serving/sdk_client.py
@@ -17,6 +17,7 @@ from benchmarks.tts_serving.error_contract import is_openai_error_response
 from benchmarks.tts_serving.http_contracts import (
     MAX_HTTP_RESPONSE_BYTES,
     UNSUPPORTED_HTTP_STATUSES,
+    mark_unexpected_success,
 )
 from benchmarks.tts_serving.metrics import ScenarioResult, finish_timing
 from benchmarks.tts_serving.scenarios import Scenario
@@ -128,6 +129,11 @@ def _run_openai_speech_create(
         return
     result.audio_bytes = len(body)
     result.audio_duration_s = validation.duration_s
+    if not scenario.expect_success:
+        result.http_status = 200
+        result.http_status_class = "2xx"
+        mark_unexpected_success(result, scenario)
+        return
     result.status = "ok"
     result.success = True
     result.capability = "pass"

--- a/benchmarks/tts_serving/spec.py
+++ b/benchmarks/tts_serving/spec.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import math
 import re
+from collections import defaultdict
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
@@ -15,9 +16,17 @@ from urllib.parse import urlparse
 VALID_TEST_TYPES = {"engine", "e2e", "external"}
 DEFAULT_PROFILE = "stress"
 VALID_PROFILES = {DEFAULT_PROFILE}
-VALID_LOAD_MODES = {"closed_loop", "open_loop", "ramp", "burst", "soak"}
+VALID_LOAD_MODES = {"closed_loop", "open_loop", "ramp", "burst", "soak", "scheduled"}
 VALID_ARRIVAL_DISTRIBUTIONS = {"deterministic", "poisson"}
 DEFAULT_ENDPOINTS = ("speech", "speech_stream", "voices", "batch", "websocket")
+SCHEDULED_WORKLOAD_ENDPOINTS = {
+    "speech_normal": "speech",
+    "rest_stream": "speech_stream",
+    "batch_32_all_valid": "batch",
+    "long_prefill_decode": "speech",
+    "ws_normal": "websocket",
+    "ws_stream_audio": "websocket",
+}
 DEFAULT_SPEAKER_MAX_UPLOADED = 1000
 DEFAULT_SEED = 0
 SAFE_STAGE_ID_RE = re.compile(r"^[A-Za-z0-9_.-]{1,64}$")
@@ -77,6 +86,14 @@ LOAD_STAGE_KEYS = {
     "voice_cache_pressure_voice_count",
     "voice_speaker_cap_count",
     "speaker_max_uploaded",
+    "coverage_schedule",
+    "workload_schedules",
+}
+SCHEDULE_KEYS = {"start_s", "end_s"}
+WORKLOAD_SCHEDULE_KEYS = {
+    "workload",
+    "background_offsets_s",
+    "collision_offsets_s",
 }
 
 
@@ -104,6 +121,86 @@ class AuthSpec:
 
 
 @dataclass(frozen=True)
+class CoverageSchedule:
+    start_s: float
+    end_s: float
+
+    @classmethod
+    def from_obj(cls, obj: Any) -> CoverageSchedule:
+        if not isinstance(obj, dict):
+            raise SpecError("params.load_stages[].coverage_schedule must be an object")
+        _reject_unknown_keys(
+            obj,
+            SCHEDULE_KEYS,
+            "params.load_stages[].coverage_schedule",
+        )
+        start_s = _finite_nonnegative_float(
+            obj.get("start_s"),
+            "params.load_stages[].coverage_schedule.start_s",
+        )
+        end_s = _finite_nonnegative_float(
+            obj.get("end_s"),
+            "params.load_stages[].coverage_schedule.end_s",
+        )
+        if end_s < start_s:
+            raise SpecError(
+                "params.load_stages[].coverage_schedule.end_s must be >= start_s"
+            )
+        return cls(start_s=start_s, end_s=end_s)
+
+
+@dataclass(frozen=True)
+class WorkloadSchedule:
+    workload: str
+    background_offsets_s: tuple[float, ...]
+    collision_offsets_s: tuple[float, ...]
+
+    @classmethod
+    def from_obj(cls, obj: Any) -> WorkloadSchedule:
+        if not isinstance(obj, dict):
+            raise SpecError(
+                "params.load_stages[].workload_schedules entries must be objects"
+            )
+        _reject_unknown_keys(
+            obj,
+            WORKLOAD_SCHEDULE_KEYS,
+            "params.load_stages[].workload_schedules[]",
+        )
+        workload = _required_str_at(
+            obj,
+            "workload",
+            "params.load_stages[].workload_schedules[].workload",
+        )
+        if workload not in SCHEDULED_WORKLOAD_ENDPOINTS:
+            raise SpecError(
+                "unknown params.load_stages[].workload_schedules[].workload: "
+                f"{workload}"
+            )
+        background = _offsets(
+            obj.get("background_offsets_s"),
+            "params.load_stages[].workload_schedules[].background_offsets_s",
+        )
+        collisions = _offsets(
+            obj.get("collision_offsets_s"),
+            "params.load_stages[].workload_schedules[].collision_offsets_s",
+        )
+        if not background and not collisions:
+            raise SpecError(
+                "params.load_stages[].workload_schedules[] must contain at "
+                "least one offset"
+            )
+        return cls(
+            workload=workload,
+            background_offsets_s=background,
+            collision_offsets_s=collisions,
+        )
+
+    @property
+    def request_count(self) -> int:
+        return len(self.background_offsets_s) + len(self.collision_offsets_s)
+
+
+@dataclass(frozen=True)
 class LoadStage:
     id: str
     mode: str
@@ -117,6 +214,8 @@ class LoadStage:
     voice_cache_pressure_voice_count: int = 0
     voice_speaker_cap_count: int = 0
     speaker_max_uploaded: int | None = None
+    coverage_schedule: CoverageSchedule | None = None
+    workload_schedules: tuple[WorkloadSchedule, ...] = field(default_factory=tuple)
 
     @classmethod
     def from_obj(cls, obj: Any, *, index: int) -> LoadStage:
@@ -135,12 +234,56 @@ class LoadStage:
                 "and duration_s for soak stages"
             )
 
-        request_count = _positive_int(
-            obj,
-            "request_count",
-            _positive_int(obj, "total_requests", 100, path="params.load_stages[]"),
-            path="params.load_stages[]",
-        )
+        if mode == "scheduled":
+            if "max_concurrency" not in obj:
+                raise SpecError("scheduled stages require an explicit max_concurrency")
+            conflicting = sorted(
+                set(obj)
+                & {
+                    "request_count",
+                    "total_requests",
+                    "request_rate",
+                    "start_request_rate",
+                    "duration_s",
+                    "arrival_distribution",
+                    "concurrency",
+                }
+            )
+            if conflicting:
+                raise SpecError(
+                    "scheduled stages derive arrivals from workload_schedules; "
+                    f"remove fields: {conflicting}"
+                )
+            coverage_schedule = CoverageSchedule.from_obj(obj.get("coverage_schedule"))
+            workload_schedules = _workload_schedules(obj.get("workload_schedules"))
+            latest_workload_offset = max(
+                offset
+                for schedule in workload_schedules
+                for offset in (
+                    *schedule.background_offsets_s,
+                    *schedule.collision_offsets_s,
+                )
+            )
+            if latest_workload_offset > coverage_schedule.end_s:
+                raise SpecError(
+                    "scheduled workload offsets must not exceed "
+                    "coverage_schedule.end_s"
+                )
+            request_count = sum(item.request_count for item in workload_schedules)
+        else:
+            coverage_schedule = None
+            workload_schedules = ()
+            request_count = _positive_int(
+                obj,
+                "request_count",
+                _positive_int(
+                    obj,
+                    "total_requests",
+                    100,
+                    path="params.load_stages[]",
+                ),
+                path="params.load_stages[]",
+            )
         max_concurrency = _positive_int(
             obj,
             "max_concurrency",
@@ -206,6 +349,8 @@ class LoadStage:
             voice_cache_pressure_voice_count=voice_cache_pressure_voice_count,
             voice_speaker_cap_count=voice_speaker_cap_count,
             speaker_max_uploaded=speaker_max_uploaded,
+            coverage_schedule=coverage_schedule,
+            workload_schedules=workload_schedules,
         )
 
     def to_json(self) -> dict[str, Any]:
@@ -228,6 +373,19 @@ class LoadStage:
             "voice_cache_pressure_voice_count": self.voice_cache_pressure_voice_count,
             "voice_speaker_cap_count": self.voice_speaker_cap_count,
             "speaker_max_uploaded": self.speaker_max_uploaded,
+            "coverage_schedule": (
+                asdict(self.coverage_schedule)
+                if self.coverage_schedule is not None
+                else None
+            ),
+            "workload_schedules": [
+                {
+                    "workload": schedule.workload,
+                    "background_offsets_s": list(schedule.background_offsets_s),
+                    "collision_offsets_s": list(schedule.collision_offsets_s),
+                }
+                for schedule in self.workload_schedules
+            ],
         }
 
 
@@ -298,6 +456,10 @@ class BenchmarkParams:
             load_stages,
             default_enabled_endpoints=enabled,
             default_voice_speaker_cap_count=voice_speaker_cap_count,
+        )
+        _validate_scheduled_stage_endpoints(
+            load_stages,
+            default_enabled_endpoints=enabled,
         )
 
         return cls(
@@ -428,6 +590,13 @@ def _required_str(obj: dict[str, Any], key: str) -> str:
     return value
 
 
+def _required_str_at(obj: dict[str, Any], key: str, path: str) -> str:
+    value = obj.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise SpecError(f"{path} must be a non-empty string")
+    return value.strip()
+
+
 def _reject_unknown_keys(obj: dict[str, Any], allowed: set[str], path: str) -> None:
     unknown = sorted(set(obj) - allowed)
     if unknown:
@@ -537,6 +706,60 @@ def _optional_positive_float(value: Any, key: str) -> float | None:
     return float(value)
 
 
+def _finite_nonnegative_float(value: Any, path: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value < 0
+    ):
+        raise SpecError(f"{path} must be a finite non-negative number")
+    return float(value)
+
+
+def _offsets(value: Any, path: str) -> tuple[float, ...]:
+    if not isinstance(value, list):
+        raise SpecError(f"{path} must be a list")
+    offsets = tuple(_finite_nonnegative_float(item, f"{path}[]") for item in value)
+    if any(current < previous for previous, current in zip(offsets, offsets[1:])):
+        raise SpecError(f"{path} must be nondecreasing")
+    return offsets
+
+
+def _workload_schedules(value: Any) -> tuple[WorkloadSchedule, ...]:
+    if not isinstance(value, list) or not value:
+        raise SpecError("scheduled stages require a non-empty workload_schedules list")
+    schedules = tuple(WorkloadSchedule.from_obj(item) for item in value)
+    workloads = [schedule.workload for schedule in schedules]
+    duplicates = sorted(
+        workload for workload in set(workloads) if workloads.count(workload) > 1
+    )
+    if duplicates:
+        raise SpecError(f"duplicate scheduled workloads: {duplicates}")
+    missing = sorted(set(SCHEDULED_WORKLOAD_ENDPOINTS) - set(workloads))
+    if missing:
+        raise SpecError(f"scheduled stage is missing workloads: {missing}")
+
+    collision_workloads: dict[float, set[str]] = defaultdict(set)
+    for schedule in schedules:
+        for offset in schedule.collision_offsets_s:
+            collision_workloads[offset].add(schedule.workload)
+    if not collision_workloads:
+        raise SpecError("scheduled stages require at least one collision offset")
+    scheduled_workloads = set(workloads)
+    invalid = {
+        offset: sorted(scheduled_workloads - workloads_at_offset)
+        for offset, workloads_at_offset in collision_workloads.items()
+        if workloads_at_offset != scheduled_workloads
+    }
+    if invalid:
+        raise SpecError(
+            "collision offsets must be shared by every scheduled workload; "
+            f"missing workloads by offset: {invalid}"
+        )
+    return schedules
+
+
 def _concurrency_levels(value: Any) -> tuple[int, ...] | None:
     if value is None:
         return None
@@ -642,6 +865,27 @@ def _validate_voice_speaker_cap_stages(
             "stage with enabled_endpoints ['voices']; prefer stage-level "
             "voice_speaker_cap_count when multiple voices stages exist"
         )
+
+
+def _validate_scheduled_stage_endpoints(
+    stages: tuple[LoadStage, ...],
+    *,
+    default_enabled_endpoints: tuple[str, ...],
+) -> None:
+    for stage in stages:
+        if stage.mode != "scheduled":
+            continue
+        enabled = set(stage.enabled_endpoints or default_enabled_endpoints)
+        unavailable = sorted(
+            schedule.workload
+            for schedule in stage.workload_schedules
+            if SCHEDULED_WORKLOAD_ENDPOINTS[schedule.workload] not in enabled
+        )
+        if unavailable:
+            raise SpecError(
+                f"scheduled stage {stage.id!r} enables no endpoint for workloads: "
+                f"{unavailable}"
+            )
 
 
 def _effective_voice_speaker_cap_count(

--- a/benchmarks/tts_serving/spec.py
+++ b/benchmarks/tts_serving/spec.py
@@ -18,6 +18,7 @@ DEFAULT_PROFILE = "stress"
 VALID_PROFILES = {DEFAULT_PROFILE}
 VALID_LOAD_MODES = {"closed_loop", "open_loop", "ramp", "burst", "soak", "scheduled"}
 VALID_ARRIVAL_DISTRIBUTIONS = {"deterministic", "poisson"}
+VALID_TEXT_CORPORA = {"seedtts-en"}
 DEFAULT_ENDPOINTS = ("speech", "speech_stream", "voices", "batch", "websocket")
 SCHEDULED_WORKLOAD_ENDPOINTS = {
     "speech_normal": "speech",
@@ -86,6 +87,7 @@ LOAD_STAGE_KEYS = {
     "voice_cache_pressure_voice_count",
     "voice_speaker_cap_count",
     "speaker_max_uploaded",
+    "text_corpus",
     "coverage_schedule",
     "workload_schedules",
 }
@@ -214,6 +216,7 @@ class LoadStage:
     voice_cache_pressure_voice_count: int = 0
     voice_speaker_cap_count: int = 0
     speaker_max_uploaded: int | None = None
+    text_corpus: str | None = None
     coverage_schedule: CoverageSchedule | None = None
     workload_schedules: tuple[WorkloadSchedule, ...] = field(default_factory=tuple)
 
@@ -271,6 +274,8 @@ class LoadStage:
                 )
             request_count = sum(item.request_count for item in workload_schedules)
         else:
+            if "text_corpus" in obj:
+                raise SpecError("text_corpus is only valid for scheduled stages")
             coverage_schedule = None
             workload_schedules = ()
             request_count = _positive_int(
@@ -336,6 +341,12 @@ class LoadStage:
             obj.get("speaker_max_uploaded"),
             "params.load_stages[].speaker_max_uploaded",
         )
+        text_corpus = _optional_str(obj, "text_corpus")
+        if text_corpus is not None and text_corpus not in VALID_TEXT_CORPORA:
+            raise SpecError(
+                "params.load_stages[].text_corpus must be one of "
+                f"{sorted(VALID_TEXT_CORPORA)}"
+            )
         return cls(
             id=stage_id,
             mode=mode,
@@ -349,6 +360,7 @@ class LoadStage:
             voice_cache_pressure_voice_count=voice_cache_pressure_voice_count,
             voice_speaker_cap_count=voice_speaker_cap_count,
             speaker_max_uploaded=speaker_max_uploaded,
+            text_corpus=text_corpus,
             coverage_schedule=coverage_schedule,
             workload_schedules=workload_schedules,
         )
@@ -373,6 +385,7 @@ class LoadStage:
             "voice_cache_pressure_voice_count": self.voice_cache_pressure_voice_count,
             "voice_speaker_cap_count": self.voice_speaker_cap_count,
             "speaker_max_uploaded": self.speaker_max_uploaded,
+            "text_corpus": self.text_corpus,
             "coverage_schedule": (
                 asdict(self.coverage_schedule)
                 if self.coverage_schedule is not None
@@ -721,8 +734,8 @@ def _offsets(value: Any, path: str) -> tuple[float, ...]:
     if not isinstance(value, list):
         raise SpecError(f"{path} must be a list")
     offsets = tuple(_finite_nonnegative_float(item, f"{path}[]") for item in value)
-    if any(current < previous for previous, current in zip(offsets, offsets[1:])):
-        raise SpecError(f"{path} must be nondecreasing")
+    if any(current <= previous for previous, current in zip(offsets, offsets[1:])):
+        raise SpecError(f"{path} must be strictly increasing")
     return offsets
 
 
@@ -746,6 +759,19 @@ def _workload_schedules(value: Any) -> tuple[WorkloadSchedule, ...]:
             collision_workloads[offset].add(schedule.workload)
     if not collision_workloads:
         raise SpecError("scheduled stages require at least one collision offset")
+    collision_offsets = set(collision_workloads)
+    background_at_collision = {
+        schedule.workload: sorted(
+            collision_offsets.intersection(schedule.background_offsets_s)
+        )
+        for schedule in schedules
+        if collision_offsets.intersection(schedule.background_offsets_s)
+    }
+    if background_at_collision:
+        raise SpecError(
+            "scheduled background offsets must not equal collision offsets; "
+            f"overlaps by workload: {background_at_collision}"
+        )
     scheduled_workloads = set(workloads)
     invalid = {
         offset: sorted(scheduled_workloads - workloads_at_offset)

--- a/benchmarks/tts_serving/text_corpus.py
+++ b/benchmarks/tts_serving/text_corpus.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Target-text corpora for TTS serving workloads."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SEEDTTS_TEXT_CORPUS_REPO = "zhaochenyang20/seed-tts-eval"
+SEEDTTS_TEXT_CORPUS_REVISION = "8f5e1aa2a35d42f42e940074c1983358b9491f89"
+SEEDTTS_TEXT_CORPUS_FILE = "en/meta.lst"
+
+
+def load_seedtts_target_texts() -> tuple[str, ...]:
+    """Load unique English target texts from pinned SeedTTS metadata."""
+    from huggingface_hub import hf_hub_download
+
+    metadata_path = hf_hub_download(
+        SEEDTTS_TEXT_CORPUS_REPO,
+        SEEDTTS_TEXT_CORPUS_FILE,
+        repo_type="dataset",
+        revision=SEEDTTS_TEXT_CORPUS_REVISION,
+    )
+    texts: list[str] = []
+    seen: set[str] = set()
+    for line_number, line in enumerate(
+        Path(metadata_path).read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        if not line:
+            continue
+        parts = line.split("|", 3)
+        if len(parts) != 4 or not parts[3]:
+            raise ValueError(
+                f"Invalid SeedTTS metadata at line {line_number}: {line!r}"
+            )
+        target_text = parts[3]
+        if target_text not in seen:
+            seen.add(target_text)
+            texts.append(target_text)
+    return tuple(texts)

--- a/benchmarks/tts_serving/voice_client.py
+++ b/benchmarks/tts_serving/voice_client.py
@@ -16,13 +16,13 @@ from benchmarks.tts_serving.batch_client import handle_batch_success
 from benchmarks.tts_serving.http_contracts import (
     UNSUPPORTED_HTTP_STATUSES,
     ResponseBodyTooLarge,
-    _classify_http_failure,
-    _is_valid_error_response,
-    _json_from_bytes,
-    _json_object_from_bytes,
-    _mark_protocol_error,
-    _mark_success,
-    _mark_unsupported_contract,
+    classify_http_failure,
+    is_valid_error_response,
+    json_from_bytes,
+    json_object_from_bytes,
+    mark_protocol_error,
+    mark_success,
+    mark_unsupported_contract,
     read_response_body,
 )
 from benchmarks.tts_serving.metrics import ScenarioResult, classify_http_status
@@ -259,7 +259,7 @@ async def run_voice_lifecycle(
             result,
         ):
             return
-        _mark_success(result, capability="pass")
+        mark_success(result, capability="pass")
     finally:
         cleanup_error = await _cleanup_voice_names(session, spec, created_voice_names)
         if cleanup_error is not None:
@@ -307,7 +307,7 @@ async def run_voice_upload(
             return
         if not await _delete_voice_by_name(session, spec, scenario, result, voice_name):
             return
-        _mark_success(result, capability="pass")
+        mark_success(result, capability="pass")
     finally:
         cleanup_error = await _cleanup_voice_names(session, spec, created_voice_names)
         if cleanup_error is not None:
@@ -366,7 +366,7 @@ async def run_voice_overwrite(
         ):
             return
         if not voice_contracts.is_voice_overwrite_ack(second_payload):
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="invalid_voice_response",
                 error=(
@@ -390,7 +390,7 @@ async def run_voice_overwrite(
         if not await _delete_voice_by_name(session, spec, scenario, result, voice_name):
             return
         created_voice_names.clear()
-        _mark_success(result, capability="pass")
+        mark_success(result, capability="pass")
     finally:
         cleanup_error = await _cleanup_voice_names(session, spec, created_voice_names)
         if cleanup_error is not None:
@@ -460,7 +460,7 @@ async def run_voice_upload_delete_race(
             return
         entries = voice_contracts.uploaded_voice_entries(voice_list, voice_name)
         if len(entries) > 1:
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="invalid_voice_response",
                 error=(
@@ -474,7 +474,7 @@ async def run_voice_upload_delete_race(
         ):
             return
         created_voice_names.clear()
-        _mark_success(result, capability="pass")
+        mark_success(result, capability="pass")
     except ResponseBodyTooLarge as exc:
         _mark_voice_response_too_large(result, exc)
         return
@@ -539,7 +539,7 @@ async def run_voice_speaker_cap_sequence(
             speaker_max_uploaded=speaker_max_uploaded,
         ):
             return
-        _mark_success(result, capability="pass")
+        mark_success(result, capability="pass")
     finally:
         cleanup_error = await _cleanup_voice_names(
             session,
@@ -558,7 +558,7 @@ async def run_voice_upload_metadata_sequence(
 ) -> None:
     voice_name_prefix = str(scenario.planned_metadata.get("voice_name_prefix", ""))
     if not voice_name_prefix:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_benchmark_scenario",
             error="voice metadata sequence requires voice_name_prefix",
@@ -607,7 +607,7 @@ async def run_voice_upload_metadata_sequence(
             result,
         ):
             return
-        _mark_success(result, capability="pass")
+        mark_success(result, capability="pass")
     finally:
         cleanup_error = await _cleanup_voice_names(session, spec, created_voice_names)
         if cleanup_error is not None:
@@ -707,7 +707,7 @@ async def _run_voice_upload_synthesis_sequence(
         if not await _delete_voice_by_name(session, spec, scenario, result, voice_name):
             return
         created_voice_names.clear()
-        _mark_success(result, capability="pass")
+        mark_success(result, capability="pass")
     finally:
         cleanup_error = await _cleanup_voice_names(session, spec, created_voice_names)
         if cleanup_error is not None:
@@ -723,7 +723,7 @@ async def run_voice_cache_pressure_sequence(
     voice_count = _metadata_positive_int(scenario, "voice_count")
     voice_name_prefix = str(scenario.planned_metadata.get("voice_name_prefix", ""))
     if voice_count is None or not voice_name_prefix:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_benchmark_scenario",
             error="voice cache pressure sequence requires voice_count and voice_name_prefix",
@@ -742,7 +742,7 @@ async def run_voice_cache_pressure_sequence(
             created_voice_names=created_voice_names,
         ):
             return
-        _mark_success(result, capability="pass")
+        mark_success(result, capability="pass")
     finally:
         cleanup_error = await _cleanup_voice_names(session, spec, created_voice_names)
         if cleanup_error is not None:
@@ -1001,7 +1001,7 @@ async def _cleanup_cache_pressure_voices(
     cleanup_count = len(created_voice_names)
     cleanup_error = await _cleanup_voice_names(session, spec, created_voice_names)
     if cleanup_error is not None:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=cleanup_error,
@@ -1026,7 +1026,7 @@ def _speaker_cap_sequence_config(
 ) -> tuple[int, str, int] | None:
     attempt_count = _metadata_positive_int(scenario, "attempt_count")
     if attempt_count is None:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_benchmark_scenario",
             error="speaker cap sequence requires positive integer attempt_count",
@@ -1034,7 +1034,7 @@ def _speaker_cap_sequence_config(
         return None
     voice_name_prefix = str(scenario.planned_metadata.get("voice_name_prefix", ""))
     if not voice_name_prefix:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_benchmark_scenario",
             error="speaker cap sequence requires voice_name_prefix",
@@ -1042,7 +1042,7 @@ def _speaker_cap_sequence_config(
         return None
     speaker_max_uploaded = _metadata_positive_int(scenario, "speaker_max_uploaded")
     if speaker_max_uploaded is None:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_benchmark_scenario",
             error="speaker cap sequence requires positive integer speaker_max_uploaded",
@@ -1069,7 +1069,7 @@ async def _speaker_cap_uploaded_voices_after_stale_cleanup(
     )
     cleanup_error = await _cleanup_voice_names(session, spec, stale_voice_names)
     if cleanup_error is not None:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=cleanup_error,
@@ -1085,7 +1085,7 @@ def _mark_cleanup_error_if_primary_path_passed(
     cleanup_error: str,
 ) -> None:
     if result.error_class is None:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=cleanup_error,
@@ -1102,7 +1102,7 @@ def _speaker_cap_attempts_cross_cap(
 ) -> bool:
     if attempt_count > remaining_before_cap:
         return True
-    _mark_protocol_error(
+    mark_protocol_error(
         result,
         status="invalid_benchmark_scenario",
         error=(
@@ -1188,10 +1188,10 @@ async def _expect_speaker_cap_rejection(
     body_text = response_body.decode("utf-8", errors="replace")
 
     if status in UNSUPPORTED_HTTP_STATUSES:
-        _mark_unsupported_contract(result, scenario, body=body_text)
+        mark_unsupported_contract(result, scenario, body=body_text)
         return False
     if 200 <= status < 300:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="unexpected_success",
             error=(
@@ -1202,8 +1202,8 @@ async def _expect_speaker_cap_rejection(
         result.error_class = "unexpected_success"
         return False
     if status == 400:
-        if not _is_valid_error_response(status, body_text, expected_status=400):
-            _mark_protocol_error(
+        if not is_valid_error_response(status, body_text, expected_status=400):
+            mark_protocol_error(
                 result,
                 status="invalid_error_response",
                 error=(
@@ -1214,7 +1214,7 @@ async def _expect_speaker_cap_rejection(
             return False
         return True
     if 400 <= status < 500:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_error_response",
             error=(
@@ -1322,21 +1322,21 @@ async def _post_voice_upload_audio(
         if response_body is None:
             return None
         if response.status in UNSUPPORTED_HTTP_STATUSES:
-            _mark_unsupported_contract(
+            mark_unsupported_contract(
                 result,
                 scenario,
                 body=response_body.decode("utf-8", errors="replace"),
             )
             return None
         if not 200 <= response.status < 300:
-            _classify_http_failure(
+            classify_http_failure(
                 response.status,
                 response_body.decode("utf-8", errors="replace"),
                 result,
                 scenario,
             )
             return None
-    return _json_object_from_bytes(
+    return json_object_from_bytes(
         response_body,
         result,
         status="invalid_voice_response",
@@ -1371,7 +1371,7 @@ async def _post_speech_with_uploaded_voice(
             return False
         body_text = body.decode("utf-8", errors="replace")
         if response.status in UNSUPPORTED_HTTP_STATUSES:
-            _mark_unsupported_contract(
+            mark_unsupported_contract(
                 result,
                 scenario,
                 body=body_text,
@@ -1379,7 +1379,7 @@ async def _post_speech_with_uploaded_voice(
             )
             return False
         if not 200 <= response.status < 300:
-            _classify_http_failure(response.status, body_text, result, scenario)
+            classify_http_failure(response.status, body_text, result, scenario)
             return False
         validation = validate_audio_response(
             body,
@@ -1387,7 +1387,7 @@ async def _post_speech_with_uploaded_voice(
             content_type=response.headers.get("Content-Type"),
         )
         if not validation.ok:
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="invalid_audio_response",
                 error=(
@@ -1421,7 +1421,7 @@ async def _post_batch_with_uploaded_voice(
             return False
         body_text = body.decode("utf-8", errors="replace")
         if response.status in UNSUPPORTED_HTTP_STATUSES:
-            _mark_unsupported_contract(
+            mark_unsupported_contract(
                 result,
                 scenario,
                 body=body_text,
@@ -1429,7 +1429,7 @@ async def _post_batch_with_uploaded_voice(
             )
             return False
         if not 200 <= response.status < 300:
-            _classify_http_failure(response.status, body_text, result, scenario)
+            classify_http_failure(response.status, body_text, result, scenario)
             return False
         handle_batch_success(body, result, scenario)
         result.audio_duration_s = audio_duration_before
@@ -1462,7 +1462,7 @@ async def _expect_deleted_voice_speech_bad_request(
         status = response.status
     body_text = body.decode("utf-8", errors="replace")
     if status != 400:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=(
@@ -1471,8 +1471,8 @@ async def _expect_deleted_voice_speech_bad_request(
             ),
         )
         return False
-    if not _is_valid_error_response(status, body_text, expected_status=400):
-        _mark_protocol_error(
+    if not is_valid_error_response(status, body_text, expected_status=400):
+        mark_protocol_error(
             result,
             status="invalid_error_response",
             error=(
@@ -1530,7 +1530,7 @@ def _mark_voice_response_too_large(
     exc: ResponseBodyTooLarge,
 ) -> None:
     result.response_bytes += exc.bytes_read
-    _mark_protocol_error(
+    mark_protocol_error(
         result,
         status="response_too_large",
         error=(
@@ -1563,15 +1563,15 @@ def _classify_voice_race_response(
     status, body, _ = response
     body_text = body.decode("utf-8", errors="replace")
     if status in UNSUPPORTED_HTTP_STATUSES:
-        _mark_unsupported_contract(result, scenario, body=body_text)
+        mark_unsupported_contract(result, scenario, body=body_text)
         return False
     if not 200 <= status < 300:
-        _classify_http_failure(status, body_text, result, scenario)
+        classify_http_failure(status, body_text, result, scenario)
         if result.error_class == "http_error":
             result.error = f"{operation} failed: {body_text}"
         return False
     if requires_voice_identifier:
-        payload = _json_object_from_bytes(
+        payload = json_object_from_bytes(
             body,
             result,
             status="invalid_voice_response",
@@ -1580,7 +1580,7 @@ def _classify_voice_race_response(
         if payload is None:
             return False
         if not voice_contracts.voice_upload_response_identifier(payload):
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="invalid_voice_response",
                 error=f"{operation} response must include an identifier",
@@ -1589,7 +1589,7 @@ def _classify_voice_race_response(
     if requires_delete_success and not voice_contracts.is_valid_voice_delete_success(
         body
     ):
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=f"{operation} response must be success JSON",
@@ -1606,7 +1606,7 @@ def _require_voice_upload_identifier(
 ) -> bool:
     if voice_contracts.voice_upload_response_identifier(payload):
         return True
-    _mark_protocol_error(
+    mark_protocol_error(
         result,
         status="invalid_voice_response",
         error=error,
@@ -1622,7 +1622,7 @@ def _validate_overwritten_voice_entry(
     expected_speaker_description: str,
 ) -> bool:
     if len(entries) != 1:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=(
@@ -1632,7 +1632,7 @@ def _validate_overwritten_voice_entry(
         )
         return False
     if entries[0].get("speaker_description") != expected_speaker_description:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=(
@@ -1650,7 +1650,7 @@ def _validate_uploaded_voice_metadata_sequence(
     result: ScenarioResult,
 ) -> bool:
     if not voice_contracts.is_valid_voice_list_response(payload):
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=(
@@ -1662,7 +1662,7 @@ def _validate_uploaded_voice_metadata_sequence(
     for voice_name, expected_fields in expected_entries.items():
         entries = voice_contracts.uploaded_voice_entries(payload, voice_name)
         if len(entries) != 1:
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="invalid_voice_response",
                 error=(
@@ -1674,7 +1674,7 @@ def _validate_uploaded_voice_metadata_sequence(
         entry = entries[0]
         for key, expected_value in expected_fields.items():
             if entry.get(key) != expected_value:
-                _mark_protocol_error(
+                mark_protocol_error(
                     result,
                     status="invalid_voice_response",
                     error=(
@@ -1701,7 +1701,7 @@ def _validate_delete_invalidation_counter(
         return True
     if after_counter > before_counter:
         return True
-    _mark_protocol_error(
+    mark_protocol_error(
         result,
         status="invalid_voice_response",
         error=(
@@ -1744,21 +1744,21 @@ async def _get_voice_list(
         if list_body is None:
             return None
         if list_response.status in UNSUPPORTED_HTTP_STATUSES:
-            _mark_unsupported_contract(
+            mark_unsupported_contract(
                 result,
                 scenario,
                 body=list_body.decode("utf-8", errors="replace"),
             )
             return None
         if not 200 <= list_response.status < 300:
-            _classify_http_failure(
+            classify_http_failure(
                 list_response.status,
                 list_body.decode("utf-8", errors="replace"),
                 result,
                 scenario,
             )
             return None
-    return _json_object_from_bytes(
+    return json_object_from_bytes(
         list_body,
         result,
         status="invalid_voice_response",
@@ -1776,7 +1776,7 @@ async def _get_uploaded_voices(
     if voice_list is None:
         return None
     if not voice_contracts.is_valid_voice_list_response(voice_list):
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=(
@@ -1802,7 +1802,7 @@ async def _require_uploaded_voice_present(
     if voice_list is None:
         return None
     if not voice_contracts.is_valid_voice_list_response(voice_list):
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=(
@@ -1813,7 +1813,7 @@ async def _require_uploaded_voice_present(
         return None
     entries = voice_contracts.uploaded_voice_entries(voice_list, voice_name)
     if len(entries) != 1:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=(
@@ -1831,7 +1831,7 @@ def _require_voice_absent_in_list(
     voice_name: str,
 ) -> bool:
     if not voice_contracts.is_valid_voice_list_response(voice_list):
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=(
@@ -1842,7 +1842,7 @@ def _require_voice_absent_in_list(
         return False
     entries = voice_contracts.uploaded_voice_entries(voice_list, voice_name)
     if entries:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=(
@@ -1870,14 +1870,14 @@ async def _delete_voice_by_name(
         if delete_body is None:
             return False
         if delete_response.status in UNSUPPORTED_HTTP_STATUSES:
-            _mark_unsupported_contract(
+            mark_unsupported_contract(
                 result,
                 scenario,
                 body=delete_body.decode("utf-8", errors="replace"),
             )
             return False
         if not 200 <= delete_response.status < 300:
-            _classify_http_failure(
+            classify_http_failure(
                 delete_response.status,
                 delete_body.decode("utf-8", errors="replace"),
                 result,
@@ -1885,7 +1885,7 @@ async def _delete_voice_by_name(
             )
             return False
         if not voice_contracts.is_valid_voice_delete_success(delete_body):
-            _mark_protocol_error(
+            mark_protocol_error(
                 result,
                 status="invalid_voice_response",
                 error="voice cleanup delete response must be success JSON",
@@ -1991,7 +1991,7 @@ async def _cleanup_voice_absence_error(
 def handle_voice_success(
     body: bytes, result: ScenarioResult, scenario: Scenario
 ) -> None:
-    payload = _json_from_bytes(
+    payload = json_from_bytes(
         body,
         result,
         status="invalid_voice_response",
@@ -2002,9 +2002,9 @@ def handle_voice_success(
         return
     if scenario.capability_key == "voices.list":
         if voice_contracts.is_valid_voice_list_response(payload):
-            _mark_success(result, capability="pass")
+            mark_success(result, capability="pass")
             return
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=(
@@ -2016,12 +2016,12 @@ def handle_voice_success(
         return
     if scenario.capability_key in {"voices.upload", "voices.lifecycle"}:
         if voice_contracts.voice_upload_response_identifier(payload):
-            _mark_success(result, capability="pass")
+            mark_success(result, capability="pass")
             return
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error="voice upload response must include id, voice_id, or name",
         )
         return
-    _mark_success(result, capability="pass")
+    mark_success(result, capability="pass")

--- a/benchmarks/tts_serving/voice_contracts.py
+++ b/benchmarks/tts_serving/voice_contracts.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from benchmarks.tts_serving.http_contracts import _mark_protocol_error
+from benchmarks.tts_serving.http_contracts import mark_protocol_error
 from benchmarks.tts_serving.metrics import ScenarioResult
 
 VOICE_CACHE_STATS_KEY = "cache_stats"
@@ -110,7 +110,7 @@ def require_voice_cache_stats(
     operation: str,
 ) -> dict[str, int] | None:
     if not is_valid_voice_list_response(payload):
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=(
@@ -121,7 +121,7 @@ def require_voice_cache_stats(
         return None
     cache_stats = payload.get(VOICE_CACHE_STATS_KEY)
     if not isinstance(cache_stats, dict):
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=f"{operation} requires voice list response with cache_stats object",
@@ -146,21 +146,21 @@ def require_voice_cache_stats(
             details.append(f"missing={missing}")
         if invalid:
             details.append(f"invalid={invalid}")
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=f"{operation} returned invalid cache_stats: {', '.join(details)}",
         )
         return None
     if parsed["max_bytes"] <= 0:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=f"{operation} cache_stats.max_bytes must be greater than 0",
         )
         return None
     if parsed["memory_bytes"] > parsed["max_bytes"]:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=(
@@ -182,7 +182,7 @@ def validate_cache_pressure_unique_stats(
 ) -> bool:
     miss_delta = after["miss_count"] - before["miss_count"]
     if miss_delta < voice_count:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=(
@@ -193,7 +193,7 @@ def validate_cache_pressure_unique_stats(
         return False
     eviction_delta = after["eviction_count"] - before["eviction_count"]
     if eviction_delta <= 0 and _voice_cache_at_capacity(after):
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=(
@@ -207,7 +207,7 @@ def validate_cache_pressure_unique_stats(
         )
         return False
     if after["memory_bytes"] <= 0 or after["entries"] <= 0:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=(
@@ -229,7 +229,7 @@ def validate_cache_pressure_revisit_stats(
 ) -> bool:
     lookup_delta = _cache_lookup_count(after) - _cache_lookup_count(before)
     if lookup_delta < revisit_count:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=(
@@ -239,7 +239,7 @@ def validate_cache_pressure_revisit_stats(
         )
         return False
     if after["hit_count"] <= before["hit_count"]:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=(
@@ -262,7 +262,7 @@ def validate_cache_pressure_cleanup_stats(
         after["delete_invalidation_counter"] - before["delete_invalidation_counter"]
     )
     if invalidation_delta <= 0:
-        _mark_protocol_error(
+        mark_protocol_error(
             result,
             status="invalid_voice_response",
             error=(

--- a/benchmarks/tts_serving/ws_client.py
+++ b/benchmarks/tts_serving/ws_client.py
@@ -31,6 +31,7 @@ WS_CONTROL_EVENT_TYPES = {
     "response.created",
     "input.ack",
 }
+REQUEST_ID_HEADER = "X-SGLang-Omni-Request-ID"
 UNSUPPORTED_WS_STATUSES = UNSUPPORTED_HTTP_STATUSES
 SUPPORTED_WS_RESPONSE_FORMATS = {"wav", "pcm", "mp3", "flac", "aac", "opus"}
 SUPPORTED_WS_SPLIT_GRANULARITIES = {"sentence", "clause"}
@@ -62,7 +63,11 @@ async def run_ws_scenario(
     url = websocket_url(spec.base_url, scenario.path)
     start = time.perf_counter()
     try:
-        async with session.ws_connect(url, max_msg_size=MAX_HTTP_RESPONSE_BYTES) as ws:
+        async with session.ws_connect(
+            url,
+            headers={REQUEST_ID_HEADER: scenario.id},
+            max_msg_size=MAX_HTTP_RESPONSE_BYTES,
+        ) as ws:
             await _run_ws_script(
                 ws,
                 result,
@@ -656,7 +661,11 @@ async def _probe_websocket_after_disconnect(
         response_format="pcm",
     )
     try:
-        async with session.ws_connect(url, max_msg_size=MAX_HTTP_RESPONSE_BYTES) as ws:
+        async with session.ws_connect(
+            url,
+            headers={REQUEST_ID_HEADER: probe_result.scenario_id},
+            max_msg_size=MAX_HTTP_RESPONSE_BYTES,
+        ) as ws:
             await _run_ws_script(
                 ws,
                 probe_result,


### PR DESCRIPTION
## Motivation

The existing TTS stress profile measures serving workloads in serial stages. That proves each path independently, but it does not exercise the production failure surface where short speech, REST streaming, WebSocket sessions, batch requests, and long generations compete for the same scheduler and worker capacity.

This PR converts the performance portion of the profile into one deterministic mixed-arrival stage. It preserves a separate metric population for every workload while measuring those requests under concurrent cross-workload pressure.

## Design

The new `scheduled` mode treats explicit offsets as the only arrival authority. Requests with the same offset are launched as one atomic cohort; if the client cannot admit the complete cohort, the cohort is rejected rather than silently measuring only part of the intended collision.

The `mixed-production` stage runs for 300 seconds with these exact successful populations:

| Workload | Requests | Traffic shape |
|---|---:|---|
| `speech_normal` | 50 | REST, non-streaming speech |
| `rest_stream` | 50 | REST, streaming PCM |
| `ws_normal` | 50 | WebSocket, non-streaming audio |
| `ws_stream_audio` | 40 | Long WebSocket audio streaming |
| `batch_32_all_valid` | 20 | Batch requests containing 32 valid items |
| `long_prefill_decode` | 20 | Long input and long generation |

Twenty collision epochs occur every 15 seconds. Each epoch launches exactly one request from all six workloads at the same scheduled offset. The report counts an epoch only when the measured request intervals share one common interval:

`max(actual_start_s) < min(completed_s)`

This proves that all six request types were simultaneously in flight; a chain of pairwise overlaps does not pass. Additional staggered background requests keep the three short request classes and long WebSocket streams active between collision epochs.

For example, in the first interval:

- `t=1.25s`: a REST streaming request starts.
- `t=1.875s`: a normal WebSocket request starts.
- `t=3.75s`: a normal speech request starts.
- `t=6.25s`: a long WebSocket streaming request starts.
- `t=7.5s`: one request from every workload is launched as an atomic six-request cohort.
- The epoch is valid only if the actual timestamps prove a moment when all six cohort members were concurrently in flight.

## SeedTTS request data

The three normal text workloads use the published `zhaochenyang20/seed-tts-eval-50-arrow` English corpus at a pinned Hugging Face revision. This reuses the benchmark package's existing dataset registry, downloader, `SampleInput` model, and SeedTTS loader rather than adding a CI-specific data format.

Each of those workloads exercises all 50 target texts exactly once. A workload-specific permutation derived from the benchmark seed controls which text is assigned to each scheduled request, so the input set and ordering are reproducible across runs while the three protocols do not receive texts in the same sequence. These requests intentionally use the target text only; reference audio remains covered by the dedicated reference and voice scenarios.

## Reporting contract

The report retains per-workload latency, streaming, real-time-factor, and generation metrics within the mixed stage. It also records exact successful sample counts, actual request intervals, collision membership, and common-overlap evidence. Expected-error and stateful voice scenarios are excluded from these performance populations.

The existing voice-cache-pressure and speaker-cap stages remain separate because thousands of owner-affine voice-control operations would distort the mixed-serving percentiles and router distribution evidence.

Related to #601.
