### PR TITLE
[TTS][Qwen3] Reduce first audio latency

### DIFF
--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import contextlib
 import hashlib
 import json
 import queue
@@ -578,17 +579,40 @@ class _Qwen3TTSAdhocReferenceInput:
     x_vector_only_mode: bool
 
 
+def _new_cuda_encode_stream(device: Any) -> torch.cuda.Stream | None:
+    if device is None or not torch.cuda.is_available():
+        return None
+    try:
+        resolved = torch.device(device)
+    except (TypeError, ValueError, RuntimeError):
+        return None
+    if resolved.type != "cuda":
+        return None
+    return torch.cuda.Stream(device=resolved)
+
+
+def _record_ref_code_consumer_stream(ref_code: Any) -> Any:
+    # note (luojiaxuan): reference codes may be allocated on the batcher's
+    # private stream; register the consumer stream with the caching allocator
+    # so a later batch cannot recycle the block while reads are still queued.
+    if isinstance(ref_code, torch.Tensor) and ref_code.is_cuda:
+        ref_code.record_stream(torch.cuda.current_stream(ref_code.device))
+    return ref_code
+
+
 class _Qwen3TTSRefCodeBatcher:
     def __init__(
         self,
         speech_tokenizer: Any,
         *,
+        device: Any | None = None,
         max_batch_size: int = 8,
         max_batch_wait_ms: float = 2.0,
     ) -> None:
         self._speech_tokenizer = speech_tokenizer
         self._max_batch_size = max(int(max_batch_size), 1)
         self._max_batch_wait_s = max(float(max_batch_wait_ms), 0.0) / 1000.0
+        self._encode_stream = _new_cuda_encode_stream(device)
         self._queue: queue.Queue[object] = queue.Queue()
         self._thread = threading.Thread(
             target=self._run,
@@ -602,7 +626,9 @@ class _Qwen3TTSRefCodeBatcher:
         self._thread.join(timeout=5.0)
 
     def encode(self, waveform: Any, sample_rate: int) -> torch.Tensor:
-        return self.submit(waveform, sample_rate).result(timeout=130.0)
+        return _record_ref_code_consumer_stream(
+            self.submit(waveform, sample_rate).result(timeout=130.0)
+        )
 
     def submit(
         self, waveform: Any, sample_rate: int
@@ -634,6 +660,29 @@ class _Qwen3TTSRefCodeBatcher:
             batch.append(queued)
         return batch, shutdown
 
+    def _synchronize_outcomes(
+        self, outcomes: dict[int, torch.Tensor | Exception]
+    ) -> None:
+        # note (luojiaxuan): resolve futures only after the encode kernels
+        # finish so consumer threads may use the codes on any stream. With a
+        # dedicated stream, waiting on its event leaves the default stream —
+        # where speaker-embedding kernels run concurrently — untouched; the
+        # fallback keeps the historical current-stream synchronize for
+        # tokenizers whose device could not be resolved up front.
+        if self._encode_stream is not None:
+            handoff = torch.cuda.Event()
+            handoff.record(self._encode_stream)
+            handoff.synchronize()
+            return
+        cuda_devices = {
+            outcome.device
+            for outcome in outcomes.values()
+            if not isinstance(outcome, Exception)
+            and getattr(outcome, "is_cuda", False)
+        }
+        for device in cuda_devices:
+            torch.cuda.current_stream(device).synchronize()
+
     def _run(self) -> None:
         while True:
             raw_batch, shutdown = self._drain()
@@ -646,7 +695,12 @@ class _Qwen3TTSRefCodeBatcher:
             for index, (waveform, sample_rate, _) in enumerate(batch):
                 groups.setdefault(sample_rate, []).append((index, waveform))
             outcomes: dict[int, torch.Tensor | Exception] = {}
-            with torch.inference_mode():
+            encode_stream_ctx = (
+                torch.cuda.stream(self._encode_stream)
+                if self._encode_stream is not None
+                else contextlib.nullcontext()
+            )
+            with torch.inference_mode(), encode_stream_ctx:
                 for sample_rate, group in groups.items():
                     waveforms = [waveform for _, waveform in group]
                     try:
@@ -671,14 +725,7 @@ class _Qwen3TTSRefCodeBatcher:
                     else:
                         for (index, _), code in zip(group, encoded, strict=True):
                             outcomes[index] = code
-            cuda_devices = {
-                outcome.device
-                for outcome in outcomes.values()
-                if not isinstance(outcome, Exception)
-                and getattr(outcome, "is_cuda", False)
-            }
-            for device in cuda_devices:
-                torch.cuda.current_stream(device).synchronize()
+            self._synchronize_outcomes(outcomes)
             for index, (_, _, future) in enumerate(batch):
                 outcome = outcomes[index]
                 if isinstance(outcome, Exception):
@@ -703,7 +750,13 @@ class _Qwen3TTSAdhocReferenceHook(
     def __init__(self, *, model: Any, wrapper: Any) -> None:
         self._model = model
         self._wrapper = wrapper
-        self._ref_code_batcher = _Qwen3TTSRefCodeBatcher(model.speech_tokenizer)
+        # note (luojiaxuan): the engine builder loads the speech tokenizer on
+        # the same device as the talker model, so model.device selects the
+        # dedicated reference-code encode stream for that device.
+        self._ref_code_batcher = _Qwen3TTSRefCodeBatcher(
+            model.speech_tokenizer,
+            device=getattr(model, "device", None),
+        )
         self.model_revision = _qwen3_tts_model_revision(model, wrapper)
         self.encoder_config_hash = _qwen3_tts_encoder_config_hash(model, wrapper)
 
@@ -761,7 +814,9 @@ class _Qwen3TTSAdhocReferenceHook(
                 audio=speaker_waveform,
                 sr=speaker_sample_rate,
             )
-            ref_code = ref_code_future.result(timeout=130.0)
+            ref_code = _record_ref_code_consumer_stream(
+                ref_code_future.result(timeout=130.0)
+            )
         voice_clone_prompt = {
             "ref_code": [None if item.x_vector_only_mode else ref_code],
             "ref_spk_embedding": [speaker_embedding],

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -677,8 +677,7 @@ class _Qwen3TTSRefCodeBatcher:
         cuda_devices = {
             outcome.device
             for outcome in outcomes.values()
-            if not isinstance(outcome, Exception)
-            and getattr(outcome, "is_cuda", False)
+            if not isinstance(outcome, Exception) and getattr(outcome, "is_cuda", False)
         }
         for device in cuda_devices:
             torch.cuda.current_stream(device).synchronize()

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import hashlib
 import json
+import queue
 import threading
 import time
 from dataclasses import dataclass, field
@@ -43,6 +45,7 @@ QWEN3_TTS_TASK_CUSTOM_VOICE = "CustomVoice"
 QWEN3_TTS_TASK_VOICE_DESIGN = "VoiceDesign"
 QWEN3_TTS_DEFAULT_CUSTOM_VOICE = "Vivian"
 _QWEN3_TTS_PREPARED_MARKER = "_qwen3_tts_prepared_request"
+_QWEN3_TTS_REF_CODE_BATCH_STOP = object()
 
 _GENERATION_FIELDS = (
     "do_sample",
@@ -166,6 +169,8 @@ def clear_qwen3_tts_preprocessing_context() -> None:
     global _ADHOC_REFERENCE_SERVICE_ENTRY
     global _PREPROCESSING_CONTEXT
     with _PREPARED_REQUESTS_LOCK:
+        if _ADHOC_REFERENCE_SERVICE_ENTRY is not None:
+            _ADHOC_REFERENCE_SERVICE_ENTRY[1].close()
         _PREPROCESSING_CONTEXT = None
         _ADHOC_REFERENCE_SERVICE_ENTRY = None
         _PREPARED_REQUESTS.clear()
@@ -573,6 +578,117 @@ class _Qwen3TTSAdhocReferenceInput:
     x_vector_only_mode: bool
 
 
+class _Qwen3TTSRefCodeBatcher:
+    def __init__(
+        self,
+        speech_tokenizer: Any,
+        *,
+        max_batch_size: int = 8,
+        max_batch_wait_ms: float = 2.0,
+    ) -> None:
+        self._speech_tokenizer = speech_tokenizer
+        self._max_batch_size = max(int(max_batch_size), 1)
+        self._max_batch_wait_s = max(float(max_batch_wait_ms), 0.0) / 1000.0
+        self._queue: queue.Queue[object] = queue.Queue()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="qwen3-tts-ref-code",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def close(self) -> None:
+        self._queue.put(_QWEN3_TTS_REF_CODE_BATCH_STOP)
+        self._thread.join(timeout=5.0)
+
+    def encode(self, waveform: Any, sample_rate: int) -> torch.Tensor:
+        return self.submit(waveform, sample_rate).result(timeout=130.0)
+
+    def submit(
+        self, waveform: Any, sample_rate: int
+    ) -> concurrent.futures.Future[torch.Tensor]:
+        future: concurrent.futures.Future[torch.Tensor] = concurrent.futures.Future()
+        self._queue.put((waveform, int(sample_rate), future))
+        return future
+
+    def _drain(self) -> tuple[list[object], bool]:
+        first = self._queue.get()
+        if first is _QWEN3_TTS_REF_CODE_BATCH_STOP:
+            return [], True
+        batch = [first]
+        deadline = time.monotonic() + self._max_batch_wait_s
+        shutdown = False
+        while len(batch) < self._max_batch_size:
+            try:
+                remaining = deadline - time.monotonic()
+                queued = (
+                    self._queue.get(timeout=remaining)
+                    if remaining > 0
+                    else self._queue.get_nowait()
+                )
+            except queue.Empty:
+                break
+            if queued is _QWEN3_TTS_REF_CODE_BATCH_STOP:
+                shutdown = True
+                break
+            batch.append(queued)
+        return batch, shutdown
+
+    def _run(self) -> None:
+        while True:
+            raw_batch, shutdown = self._drain()
+            if not raw_batch:
+                return
+            batch = [
+                item for item in raw_batch if isinstance(item, tuple) and len(item) == 3
+            ]
+            groups: dict[int, list[tuple[int, Any]]] = {}
+            for index, (waveform, sample_rate, _) in enumerate(batch):
+                groups.setdefault(sample_rate, []).append((index, waveform))
+            outcomes: dict[int, torch.Tensor | Exception] = {}
+            with torch.inference_mode():
+                for sample_rate, group in groups.items():
+                    waveforms = [waveform for _, waveform in group]
+                    try:
+                        encoded = self._speech_tokenizer.encode(
+                            waveforms,
+                            sr=sample_rate,
+                        ).audio_codes
+                        if len(encoded) != len(group):
+                            raise ValueError(
+                                "Qwen3-TTS speech tokenizer returned "
+                                f"{len(encoded)} codes for {len(group)} references"
+                            )
+                    except Exception:
+                        for index, waveform in group:
+                            try:
+                                outcomes[index] = self._speech_tokenizer.encode(
+                                    waveform,
+                                    sr=sample_rate,
+                                ).audio_codes[0]
+                            except Exception as exc:
+                                outcomes[index] = exc
+                    else:
+                        for (index, _), code in zip(group, encoded, strict=True):
+                            outcomes[index] = code
+            cuda_devices = {
+                outcome.device
+                for outcome in outcomes.values()
+                if not isinstance(outcome, Exception)
+                and getattr(outcome, "is_cuda", False)
+            }
+            for device in cuda_devices:
+                torch.cuda.current_stream(device).synchronize()
+            for index, (_, _, future) in enumerate(batch):
+                outcome = outcomes[index]
+                if isinstance(outcome, Exception):
+                    future.set_exception(outcome)
+                else:
+                    future.set_result(outcome)
+            if shutdown:
+                return
+
+
 class _Qwen3TTSAdhocReferenceHook(
     KeyedReferenceEncodeHook[
         _Qwen3TTSAdhocReferenceInput,
@@ -587,6 +703,7 @@ class _Qwen3TTSAdhocReferenceHook(
     def __init__(self, *, model: Any, wrapper: Any) -> None:
         self._model = model
         self._wrapper = wrapper
+        self._ref_code_batcher = _Qwen3TTSRefCodeBatcher(model.speech_tokenizer)
         self.model_revision = _qwen3_tts_model_revision(model, wrapper)
         self.encoder_config_hash = _qwen3_tts_encoder_config_hash(model, wrapper)
 
@@ -600,6 +717,9 @@ class _Qwen3TTSAdhocReferenceHook(
             ref_text=raw_input.ref_text,
             x_vector_only_mode=raw_input.x_vector_only_mode,
         )
+
+    def close(self) -> None:
+        self._ref_code_batcher.close()
 
     def input_key(self, item: _Qwen3TTSAdhocReferenceInput) -> str | None:
         return _qwen3_tts_ref_audio_input_key(item.ref_audio)
@@ -617,18 +737,38 @@ class _Qwen3TTSAdhocReferenceHook(
     def encode_one(
         self, item: _Qwen3TTSAdhocReferenceInput
     ) -> tuple[dict[str, Any], str | None]:
-        with torch.no_grad():
-            prompt_items = self._wrapper.create_voice_clone_prompt(
-                ref_audio=item.ref_audio,
-                ref_text=item.ref_text,
-                x_vector_only_mode=item.x_vector_only_mode,
+        if not item.x_vector_only_mode and not item.ref_text:
+            raise ValueError(
+                "ref_text is required when x_vector_only_mode=False (ICL mode)"
             )
-        if len(prompt_items) != 1:
-            raise ValueError("Qwen3-TTS expects exactly one voice-clone prompt")
-        voice_clone_prompt = self._wrapper._prompt_items_to_voice_clone_prompt(
-            prompt_items
-        )
-        return voice_clone_prompt, prompt_items[0].ref_text
+        with torch.no_grad():
+            normalized = self._wrapper._normalize_audio_inputs([item.ref_audio])
+            if len(normalized) != 1:
+                raise ValueError("Qwen3-TTS expects exactly one reference audio")
+            waveform, sample_rate = normalized[0]
+            ref_code_future = self._ref_code_batcher.submit(waveform, sample_rate)
+            speaker_waveform = waveform
+            speaker_sample_rate = self._model.speaker_encoder_sample_rate
+            if sample_rate != speaker_sample_rate:
+                import librosa
+
+                speaker_waveform = librosa.resample(
+                    y=speaker_waveform.astype("float32"),
+                    orig_sr=int(sample_rate),
+                    target_sr=speaker_sample_rate,
+                )
+            speaker_embedding = self._model.extract_speaker_embedding(
+                audio=speaker_waveform,
+                sr=speaker_sample_rate,
+            )
+            ref_code = ref_code_future.result(timeout=130.0)
+        voice_clone_prompt = {
+            "ref_code": [None if item.x_vector_only_mode else ref_code],
+            "ref_spk_embedding": [speaker_embedding],
+            "x_vector_only_mode": [item.x_vector_only_mode],
+            "icl_mode": [not item.x_vector_only_mode],
+        }
+        return voice_clone_prompt, item.ref_text
 
     def store_artifact(self, artifact: tuple[dict[str, Any], str | None]) -> dict:
         voice_clone_prompt, ref_text = artifact
@@ -695,6 +835,8 @@ def _get_qwen3_tts_adhoc_reference_service_locked(
     owner = (id(model), id(wrapper))
     entry = _ADHOC_REFERENCE_SERVICE_ENTRY
     if entry is None or entry[0] != owner:
+        if entry is not None:
+            entry[1].close()
         service = ReferenceEncodeService(
             _Qwen3TTSAdhocReferenceHook(model=model, wrapper=wrapper),
             max_items=256,

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -166,6 +166,7 @@ def create_vocoder_executor(
     initial_batch_wait_ms: int = 2,
     followup_max_batch_size: int = 8,
     followup_batch_wait_ms: int = 1,
+    initial_cuda_graph: bool = True,
 ) -> SimpleScheduler:
     if gpu_id is not None:
         device = f"cuda:{gpu_id}"
@@ -190,4 +191,5 @@ def create_vocoder_executor(
         initial_batch_wait_ms=initial_batch_wait_ms,
         followup_max_batch_size=followup_max_batch_size,
         followup_batch_wait_ms=followup_batch_wait_ms,
+        initial_cuda_graph=initial_cuda_graph,
     )

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -115,10 +115,19 @@ def _compile_qwen3_tts_backbone(model: Any) -> None:
     ]
 
 
-def create_preprocessing_executor(model_path: str) -> SimpleScheduler:
+def create_preprocessing_executor(
+    model_path: str,
+    *,
+    max_concurrency: int = 8,
+) -> SimpleScheduler:
     del model_path
+    # note (luojiaxuan): preprocessing must admit several requests at once. A
+    # serial executor keeps at most one reference-code request in flight, so
+    # the speech-tokenizer batcher would only ever see batches of one; the
+    # default matches the batcher's max_batch_size.
     return SimpleScheduler(
         preprocess_qwen3_tts_payload,
+        max_concurrency=max_concurrency,
         abort_callback=cleanup_prepared_qwen3_tts_request,
     )
 

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 import queue
 import threading
 import time
@@ -22,6 +23,8 @@ from sglang_omni.scheduling.streaming_vocoder import (
     resolve_initial_codec_chunk_frames,
 )
 from sglang_omni.utils.audio_payload import audio_waveform_payload
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_QWEN3_TTS_STREAM_STRIDE = 16
 DEFAULT_QWEN3_TTS_STREAM_FOLLOWUP_STRIDE = 8
@@ -59,6 +62,85 @@ class _Qwen3TTSDecodePlan:
 _ASYNC_STOP = None
 
 
+class _Qwen3TTSInitialDecodeGraphs:
+    """CUDA graphs for the fixed-size first streaming decode."""
+
+    def __init__(
+        self,
+        decoder: Any,
+        *,
+        device: torch.device,
+        num_quantizers: int,
+        input_frames: int,
+        batch_sizes: tuple[int, ...] = (1, 2, 4, 8),
+        enabled: bool = True,
+    ) -> None:
+        self._decoder = decoder
+        self._device = device
+        self._num_quantizers = int(num_quantizers)
+        self._input_frames = int(input_frames)
+        self._batch_sizes = tuple(sorted(set(int(size) for size in batch_sizes)))
+        self._enabled = bool(enabled and device.type == "cuda")
+        self._graphs: dict[int, torch.cuda.CUDAGraph] = {}
+        self._inputs: dict[int, torch.Tensor] = {}
+        self._outputs: dict[int, torch.Tensor] = {}
+
+    def capture(self) -> None:
+        if not self._enabled or self._graphs:
+            return
+        capture_stream = torch.cuda.Stream(device=self._device)
+        graph_pool = torch.cuda.graph_pool_handle()
+        for batch_size in self._batch_sizes:
+            try:
+                static_input = torch.zeros(
+                    (batch_size, self._num_quantizers, self._input_frames),
+                    dtype=torch.long,
+                    device=self._device,
+                )
+                with torch.inference_mode(), torch.cuda.stream(capture_stream):
+                    for _ in range(2):
+                        self._decoder(static_input)
+                capture_stream.synchronize()
+                graph = torch.cuda.CUDAGraph()
+                with (
+                    torch.inference_mode(),
+                    torch.cuda.graph(
+                        graph,
+                        pool=graph_pool,
+                        stream=capture_stream,
+                    ),
+                ):
+                    static_output = self._decoder(static_input)
+            except Exception:
+                logger.warning(
+                    "Qwen3-TTS initial decoder graph capture failed for batch=%d",
+                    batch_size,
+                    exc_info=True,
+                )
+                continue
+            self._graphs[batch_size] = graph
+            self._inputs[batch_size] = static_input
+            self._outputs[batch_size] = static_output
+
+    def decode(self, codes: torch.Tensor) -> torch.Tensor | None:
+        if (
+            not self._graphs
+            or codes.ndim != 3
+            or int(codes.shape[1]) != self._num_quantizers
+            or int(codes.shape[2]) != self._input_frames
+        ):
+            return None
+        batch_size = int(codes.shape[0])
+        bucket = next((size for size in self._batch_sizes if size >= batch_size), None)
+        if bucket is None or bucket not in self._graphs:
+            return None
+        static_input = self._inputs[bucket]
+        static_input.zero_()
+        static_input[:batch_size].copy_(codes)
+        self._graphs[bucket].replay()
+        return self._outputs[bucket][:batch_size].clone()
+
+
 class Qwen3TTSStreamingVocoderScheduler(
     StreamingVocoderBase[_Qwen3TTSStreamState, None]
 ):
@@ -81,6 +163,7 @@ class Qwen3TTSStreamingVocoderScheduler(
         initial_batch_wait_ms: int = 2,
         followup_max_batch_size: int = 8,
         followup_batch_wait_ms: int = 1,
+        initial_cuda_graph: bool = True,
     ) -> None:
         if stream_stride <= 0 or stream_followup_stride <= 0:
             raise ValueError("stream strides must be > 0")
@@ -100,6 +183,16 @@ class Qwen3TTSStreamingVocoderScheduler(
         self._tokenizer = tokenizer
         self._device = torch.device(device)
         self._decoder = tokenizer.model.decoder
+        tokenizer_config = getattr(tokenizer.model, "config", None)
+        decoder_config = getattr(tokenizer_config, "decoder_config", tokenizer_config)
+        num_quantizers = int(getattr(decoder_config, "num_quantizers", 0) or 0)
+        self._initial_decode_graphs = _Qwen3TTSInitialDecodeGraphs(
+            self._decoder,
+            device=self._device,
+            num_quantizers=num_quantizers,
+            input_frames=int(stream_left_context_frames) + int(initial_chunk_frames),
+            enabled=bool(initial_cuda_graph and num_quantizers > 0),
+        )
         self._samples_per_frame = int(self._decoder.total_upsample)
         self._stream_stride = int(stream_stride)
         self._stream_followup_stride = int(stream_followup_stride)
@@ -125,7 +218,7 @@ class Qwen3TTSStreamingVocoderScheduler(
             followup_priority = min(least_priority, greatest_priority + 1)
             self._decode_stream = torch.cuda.Stream(
                 device=self._device,
-                priority=greatest_priority,
+                priority=followup_priority,
             )
             self._followup_decode_stream = (
                 torch.cuda.Stream(
@@ -173,6 +266,7 @@ class Qwen3TTSStreamingVocoderScheduler(
     def on_serving_start(self) -> None:
         if not self._async_decode:
             return
+        self._initial_decode_graphs.capture()
         self._initial_queue = queue.Queue()
         self._followup_queue = queue.PriorityQueue()
         self._followup_sequence = count()
@@ -401,9 +495,14 @@ class Qwen3TTSStreamingVocoderScheduler(
             else:
                 stream.wait_stream(torch.cuda.current_stream(self._device))
                 with torch.cuda.stream(stream):
-                    waveform = self._decoder.chunked_decode(
-                        decoder_input.to(self._device)
+                    decoder_input = decoder_input.to(self._device)
+                    waveform = (
+                        self._initial_decode_graphs.decode(decoder_input)
+                        if stream is self._decode_stream
+                        else None
                     )
+                    if waveform is None:
+                        waveform = self._decoder.chunked_decode(decoder_input)
                 stream.synchronize()
         if waveform.ndim == 3:
             if waveform.shape[0] != len(plans):

--- a/sglang_omni/scheduling/reference_encoder.py
+++ b/sglang_omni/scheduling/reference_encoder.py
@@ -153,6 +153,11 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
         self._uncacheable = 0
         self._last_log_time = 0.0
 
+    def close(self) -> None:
+        close = getattr(self._hook, "close", None)
+        if callable(close):
+            close()
+
     def get_or_encode(self, raw_input: Any, *, desc: str | None = None) -> ArtifactT:
         item = self._hook.normalize_input(raw_input)
         key = self._hook.cache_key(item)

--- a/tests/unit_test/moss_transcribe_diarize/test_request_builders.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_request_builders.py
@@ -10,6 +10,7 @@ import pytest
 import torch
 
 import sglang_omni.preprocessing.transcription as transcription
+from sglang_omni.models.moss_transcribe_diarize import request_builders
 from sglang_omni.models.moss_transcribe_diarize.request_builders import (
     DEFAULT_TEMPERATURE,
     DEFAULT_TOP_K,

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -16,6 +16,7 @@ import torch
 
 from sglang_omni.models.qwen3_omni.pending_text_queue import PendingTextTensorQueue
 from sglang_omni.models.qwen3_tts import request_builders as qwen3_request_builders
+from sglang_omni.models.qwen3_tts import stages as qwen3_stages
 from sglang_omni.models.qwen3_tts.config import Qwen3TTSPipelineConfig
 from sglang_omni.models.qwen3_tts.payload_types import Qwen3TTSState
 from sglang_omni.models.qwen3_tts.request_builders import (
@@ -712,6 +713,139 @@ def test_qwen3_tts_reference_codes_batch_across_requests() -> None:
     ]
 
 
+def test_qwen3_tts_preprocessing_executor_admits_concurrent_requests() -> None:
+    executor = qwen3_stages.create_preprocessing_executor("unused-model-path")
+    assert executor._max_concurrency > 1
+
+
+def test_qwen3_tts_preprocess_payload_batches_reference_codes_across_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = get_speaker_artifact_cache()
+    cache.clear()
+    qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
+    batch_sizes: list[int] = []
+    both_normalizing = threading.Barrier(2)
+
+    class PatientRefCodeBatcher(qwen3_request_builders._Qwen3TTSRefCodeBatcher):
+        def __init__(self, speech_tokenizer, **kwargs):
+            kwargs["max_batch_wait_ms"] = 500.0
+            super().__init__(speech_tokenizer, **kwargs)
+
+    monkeypatch.setattr(
+        qwen3_request_builders,
+        "_Qwen3TTSRefCodeBatcher",
+        PatientRefCodeBatcher,
+    )
+
+    class FakeSpeechTokenizer:
+        def encode(self, waveforms, *, sr):
+            batch_sizes.append(len(waveforms))
+            assert sr == 24000
+            return SimpleNamespace(
+                audio_codes=[
+                    torch.full((1, 2), index, dtype=torch.long)
+                    for index in range(len(waveforms))
+                ]
+            )
+
+    class FakeWrapper:
+        def _normalize_audio_inputs(self, ref_audio):
+            both_normalizing.wait(timeout=5.0)
+            return [(np.zeros(32, dtype=np.float32), 24000)]
+
+        def _tokenize_texts(self, texts):
+            return [torch.arange(len(texts[0]), dtype=torch.long).unsqueeze(0)]
+
+        def _build_assistant_text(self, text):
+            return text
+
+        def _build_ref_text(self, text):
+            return text
+
+        def _merge_generate_kwargs(self, **kwargs):
+            return kwargs
+
+    class FakeModel:
+        device = torch.device("cpu")
+        root_config = SimpleNamespace(tts_pad_token_id=0)
+        model = SimpleNamespace(_feedback_buffer=torch.empty((1, 4)))
+        speech_tokenizer = FakeSpeechTokenizer()
+        speaker_encoder_sample_rate = 24000
+
+        def extract_speaker_embedding(self, *, audio, sr):
+            return torch.ones(4)
+
+        def build_voice_clone_inputs(self, **kwargs):
+            del kwargs
+            return (
+                torch.ones((1, 2, 4)),
+                torch.ones((1, 2), dtype=torch.long),
+                torch.ones((1, 1, 4)),
+                None,
+            )
+
+        def get_text_embeddings(self):
+            return lambda ids: torch.ones((*ids.shape, 4), device=ids.device)
+
+        def text_projection(self, embeds):
+            return embeds
+
+    monkeypatch.setattr(
+        qwen3_request_builders,
+        "_build_qwen3_tts_pad_embed",
+        lambda model: torch.zeros(4),
+    )
+    qwen3_request_builders.set_qwen3_tts_preprocessing_context(
+        model=FakeModel(),
+        wrapper=FakeWrapper(),
+    )
+
+    def make_distinct_payload(index: int) -> StagePayload:
+        return StagePayload(
+            request_id=f"req-qwen3-tts-batch-{index}",
+            request=OmniRequest(
+                inputs=f"target-{index}",
+                params={},
+                metadata={
+                    "tts_params": {
+                        "ref_audio": f"data:audio/wav;base64,AAA{index}",
+                        "ref_text": f"reference-{index}",
+                    }
+                },
+            ),
+            data={},
+        )
+
+    errors: list[BaseException] = []
+
+    def preprocess(index: int) -> None:
+        try:
+            qwen3_request_builders.preprocess_qwen3_tts_payload(
+                make_distinct_payload(index)
+            )
+        except BaseException as exc:  # noqa: BLE001 - surfaced via assertion
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=preprocess, args=(index,)) for index in range(2)
+    ]
+    try:
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10.0)
+        assert not errors
+        assert all(not thread.is_alive() for thread in threads)
+        with qwen3_request_builders._PREPARED_REQUESTS_LOCK:
+            prepared_count = len(qwen3_request_builders._PREPARED_REQUESTS)
+    finally:
+        qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
+
+    assert prepared_count == 2
+    assert batch_sizes == [2]
+
+
 def test_qwen3_tts_reference_code_overlaps_speaker_embedding() -> None:
     tokenizer_started = threading.Event()
     speaker_started = threading.Event()
@@ -786,6 +920,53 @@ def test_qwen3_tts_reference_code_batcher_synchronizes_cuda_results(
 
     assert result is code
     assert events == ["synchronize"]
+
+
+def test_qwen3_tts_reference_code_batcher_has_no_stream_for_cpu_device() -> None:
+    class FakeSpeechTokenizer:
+        def encode(self, waveforms, *, sr):
+            raise AssertionError("encode must not run in this test")
+
+    batcher = qwen3_request_builders._Qwen3TTSRefCodeBatcher(
+        FakeSpeechTokenizer(),
+        device=torch.device("cpu"),
+    )
+    try:
+        assert batcher._encode_stream is None
+    finally:
+        batcher.close()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_qwen3_tts_reference_code_batcher_encodes_on_dedicated_cuda_stream() -> None:
+    device = torch.device("cuda", torch.cuda.current_device())
+    encode_streams: list[object] = []
+
+    class FakeSpeechTokenizer:
+        def encode(self, waveforms, *, sr):
+            assert sr == 24000
+            encode_streams.append(torch.cuda.current_stream(device))
+            return SimpleNamespace(
+                audio_codes=[
+                    torch.full((1, 2), index, dtype=torch.long, device=device)
+                    for index in range(len(waveforms))
+                ]
+            )
+
+    batcher = qwen3_request_builders._Qwen3TTSRefCodeBatcher(
+        FakeSpeechTokenizer(),
+        device=device,
+    )
+    try:
+        assert batcher._encode_stream is not None
+        assert batcher._encode_stream != torch.cuda.default_stream(device)
+        result = batcher.encode(np.zeros(16, dtype=np.float32), 24000)
+    finally:
+        batcher.close()
+
+    assert encode_streams == [batcher._encode_stream]
+    assert result.is_cuda
+    assert torch.equal(result.cpu(), torch.zeros((1, 2), dtype=torch.long))
 
 
 def test_qwen3_tts_uploaded_voice_x_vector_cache_omits_ref_code(

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -29,6 +29,7 @@ from sglang_omni.models.qwen3_tts.request_builders import (
 )
 from sglang_omni.models.qwen3_tts.streaming_vocoder import (
     Qwen3TTSStreamingVocoderScheduler,
+    _Qwen3TTSInitialDecodeGraphs,
 )
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from sglang_omni.pipeline.stage.stream_queue import StreamItem
@@ -393,13 +394,17 @@ def test_qwen3_tts_preprocessing_does_not_mutate_global_rng(
         tts_params={"ref_audio": "voice.wav", "ref_text": "reference"},
     )
 
-    class FakeWrapper:
-        def create_voice_clone_prompt(self, **kwargs):
-            del kwargs
-            return [SimpleNamespace(ref_text="reference")]
+    class FakeSpeechTokenizer:
+        def encode(self, waveforms, *, sr):
+            assert sr == 24000
+            return SimpleNamespace(
+                audio_codes=[torch.ones((1, 2), dtype=torch.long) for _ in waveforms]
+            )
 
-        def _prompt_items_to_voice_clone_prompt(self, prompt_items):
-            return prompt_items[0]
+    class FakeWrapper:
+        def _normalize_audio_inputs(self, ref_audio):
+            assert ref_audio == ["voice.wav"]
+            return [(np.zeros(32, dtype=np.float32), 24000)]
 
         def _tokenize_texts(self, texts):
             return [[idx + 1 for idx, _ in enumerate(texts[0])]]
@@ -417,6 +422,13 @@ def test_qwen3_tts_preprocessing_does_not_mutate_global_rng(
         device = torch.device("cpu")
         root_config = SimpleNamespace(tts_pad_token_id=0)
         model = SimpleNamespace(_feedback_buffer=torch.empty((1, 4)))
+        speech_tokenizer = FakeSpeechTokenizer()
+        speaker_encoder_sample_rate = 24000
+
+        def extract_speaker_embedding(self, *, audio, sr):
+            assert audio.shape == (32,)
+            assert sr == 24000
+            return torch.ones(4)
 
         def build_voice_clone_inputs(self, **kwargs):
             del kwargs
@@ -562,23 +574,19 @@ def test_qwen3_tts_adhoc_voice_clone_prompt_uses_reference_service(
     calls = 0
     data_uri = "data:audio/wav;base64,AAAA"
 
-    class FakePrompt:
-        def __init__(self, ref_text: str | None) -> None:
-            self.ref_text = ref_text
-
-    class FakeWrapper:
-        def create_voice_clone_prompt(self, **kwargs):
+    class FakeSpeechTokenizer:
+        def encode(self, waveforms, *, sr):
             nonlocal calls
             calls += 1
-            assert kwargs["ref_audio"] == data_uri
-            return [FakePrompt(kwargs["ref_text"])]
+            assert sr == 24000
+            return SimpleNamespace(
+                audio_codes=[torch.ones((1, 2), dtype=torch.long) for _ in waveforms]
+            )
 
-        def _prompt_items_to_voice_clone_prompt(self, prompt_items):
-            return {
-                "ref_code": [torch.ones((1, 2), dtype=torch.long)],
-                "ref_spk_embedding": [torch.ones(4)],
-                "icl_mode": [True],
-            }
+    class FakeWrapper:
+        def _normalize_audio_inputs(self, ref_audio):
+            assert ref_audio == [data_uri]
+            return [(np.zeros(32, dtype=np.float32), 24000)]
 
         def _tokenize_texts(self, texts):
             return [torch.arange(len(texts[0]), dtype=torch.long).unsqueeze(0)]
@@ -596,9 +604,16 @@ def test_qwen3_tts_adhoc_voice_clone_prompt_uses_reference_service(
         device = torch.device("cpu")
         root_config = SimpleNamespace(tts_pad_token_id=0)
         model = SimpleNamespace(_feedback_buffer=torch.empty((1, 4)))
+        speech_tokenizer = FakeSpeechTokenizer()
+        speaker_encoder_sample_rate = 24000
+
+        def extract_speaker_embedding(self, *, audio, sr):
+            assert audio.shape == (32,)
+            assert sr == 24000
+            return torch.ones(4)
 
         def build_voice_clone_inputs(self, **kwargs):
-            assert kwargs["voice_clone_prompt"]["icl_mode"] == [True]
+            assert kwargs["voice_clone_prompt"]["icl_mode"] in ([True], [False])
             return (
                 torch.ones((1, 2, 4)),
                 torch.ones((1, 2), dtype=torch.long),
@@ -652,6 +667,125 @@ def test_qwen3_tts_adhoc_voice_clone_prompt_uses_reference_service(
         wrapper=wrapper,
     )
     assert calls == 3
+    qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
+
+
+def test_qwen3_tts_reference_codes_batch_across_requests() -> None:
+    batch_sizes: list[int] = []
+
+    class FakeSpeechTokenizer:
+        def encode(self, waveforms, *, sr):
+            batch_sizes.append(len(waveforms))
+            assert torch.is_inference_mode_enabled()
+            assert sr == 24000
+            return SimpleNamespace(
+                audio_codes=[torch.tensor([index]) for index in range(len(waveforms))]
+            )
+
+    batcher = qwen3_request_builders._Qwen3TTSRefCodeBatcher(
+        FakeSpeechTokenizer(),
+        max_batch_size=2,
+        max_batch_wait_ms=50.0,
+    )
+    barrier = threading.Barrier(3)
+    results: list[torch.Tensor | None] = [None, None]
+
+    def encode(index: int) -> None:
+        barrier.wait()
+        results[index] = batcher.encode(np.zeros(16, dtype=np.float32), 24000)
+
+    threads = [threading.Thread(target=encode, args=(index,)) for index in range(2)]
+    try:
+        for thread in threads:
+            thread.start()
+        barrier.wait()
+        for thread in threads:
+            thread.join(timeout=2.0)
+    finally:
+        batcher.close()
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert batch_sizes == [2]
+    assert sorted(int(result.item()) for result in results if result is not None) == [
+        0,
+        1,
+    ]
+
+
+def test_qwen3_tts_reference_code_overlaps_speaker_embedding() -> None:
+    tokenizer_started = threading.Event()
+    speaker_started = threading.Event()
+
+    class FakeSpeechTokenizer:
+        def encode(self, waveforms, *, sr):
+            tokenizer_started.set()
+            assert speaker_started.wait(timeout=1.0)
+            return SimpleNamespace(audio_codes=[torch.ones((1, 2), dtype=torch.long)])
+
+    class FakeWrapper:
+        def _normalize_audio_inputs(self, ref_audio):
+            return [(np.zeros(32, dtype=np.float32), 24000)]
+
+    class FakeModel:
+        device = torch.device("cpu")
+        speech_tokenizer = FakeSpeechTokenizer()
+        speaker_encoder_sample_rate = 24000
+
+        def extract_speaker_embedding(self, *, audio, sr):
+            assert tokenizer_started.wait(timeout=1.0)
+            speaker_started.set()
+            return torch.ones(4)
+
+    hook = qwen3_request_builders._Qwen3TTSAdhocReferenceHook(
+        model=FakeModel(),
+        wrapper=FakeWrapper(),
+    )
+    item = qwen3_request_builders._Qwen3TTSAdhocReferenceInput(
+        ref_audio="data:audio/wav;base64,AAAA",
+        ref_text="reference",
+        x_vector_only_mode=False,
+    )
+    try:
+        prompt, ref_text = hook.encode_one(item)
+    finally:
+        hook.close()
+
+    assert ref_text == "reference"
+    assert prompt["icl_mode"] == [True]
+
+
+def test_qwen3_tts_reference_code_batcher_synchronizes_cuda_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[object] = []
+    code = SimpleNamespace(is_cuda=True, device=torch.device("cuda"))
+
+    class FakeCurrentStream:
+        def synchronize(self):
+            events.append("synchronize")
+
+    class FakeSpeechTokenizer:
+        def encode(self, waveforms, *, sr):
+            assert len(waveforms) == 1
+            assert sr == 24000
+            return SimpleNamespace(audio_codes=[code])
+
+    monkeypatch.setattr(
+        torch.cuda,
+        "current_stream",
+        lambda device: FakeCurrentStream(),
+    )
+    batcher = qwen3_request_builders._Qwen3TTSRefCodeBatcher(
+        FakeSpeechTokenizer(),
+        max_batch_wait_ms=0,
+    )
+    try:
+        result = batcher.encode(np.zeros(16, dtype=np.float32), 24000)
+    finally:
+        batcher.close()
+
+    assert result is code
+    assert events == ["synchronize"]
 
 
 def test_qwen3_tts_uploaded_voice_x_vector_cache_omits_ref_code(
@@ -1040,6 +1174,9 @@ class _FakeQwen3TTSDecoder:
             .repeat_interleave(self.total_upsample, dim=-1)
         )
 
+    def __call__(self, codes: torch.Tensor) -> torch.Tensor:
+        return self.chunked_decode(codes)
+
 
 class _FakeQwen3TTSTokenizer:
     def __init__(self) -> None:
@@ -1057,6 +1194,21 @@ class _FakeQwen3TTSTokenizer:
             for item in encoded
         ]
         return waveforms, self.get_output_sample_rate()
+
+
+def test_qwen3_tts_initial_decode_graphs_noop_on_cpu() -> None:
+    decoder = _FakeQwen3TTSDecoder()
+    graphs = _Qwen3TTSInitialDecodeGraphs(
+        decoder,
+        device=torch.device("cpu"),
+        num_quantizers=2,
+        input_frames=17,
+    )
+
+    graphs.capture()
+
+    assert graphs.decode(torch.zeros((1, 2, 17), dtype=torch.long)) is None
+    assert decoder.decode_inputs == []
 
 
 def test_qwen3_tts_streaming_vocoder_buffers_one_initial_frame() -> None:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -827,9 +827,7 @@ def test_qwen3_tts_preprocess_payload_batches_reference_codes_across_requests(
         except BaseException as exc:  # noqa: BLE001 - surfaced via assertion
             errors.append(exc)
 
-    threads = [
-        threading.Thread(target=preprocess, args=(index,)) for index in range(2)
-    ]
+    threads = [threading.Thread(target=preprocess, args=(index,)) for index in range(2)]
     try:
         for thread in threads:
             thread.start()

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -817,14 +817,14 @@ def test_qwen3_tts_preprocess_payload_batches_reference_codes_across_requests(
             data={},
         )
 
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
 
     def preprocess(index: int) -> None:
         try:
             qwen3_request_builders.preprocess_qwen3_tts_payload(
                 make_distinct_payload(index)
             )
-        except BaseException as exc:  # noqa: BLE001 - surfaced via assertion
+        except Exception as exc:
             errors.append(exc)
 
     threads = [threading.Thread(target=preprocess, args=(index,)) for index in range(2)]

--- a/tests/unit_test/scheduling/test_reference_encoder.py
+++ b/tests/unit_test/scheduling/test_reference_encoder.py
@@ -67,6 +67,21 @@ class _TensorHook(TensorReferenceEncodeHook[str]):
         return torch.full((2,), value, dtype=torch.long)
 
 
+def test_service_close_delegates_to_hook() -> None:
+    class _ClosableHook(_TensorHook):
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    hook = _ClosableHook()
+    service = ReferenceEncodeService(hook)
+
+    service.close()
+
+    assert hook.closed
+
+
 def test_tensor_hook_builds_key_and_owns_stored_and_loaded_tensors() -> None:
     class _CompressedHook(_TensorHook):
         storage_dtype = torch.int32


### PR DESCRIPTION
Follow-up to #1286. Reduces Qwen3-TTS first-audio latency by:

- batching reference-code extraction and overlapping it with speaker embedding
- using CUDA graphs for fixed-size initial vocoder decode
- prioritizing follow-up decode without delaying first audio

H100 Seed-TTS EN full set, matched config and hardware, 1088 requests per setup.

| Concurrency | Current TTFA p95 | Baseline | Current C200 | Baseline C200 | Current/Baseline QPS | Current/Baseline EN WER |
|---:|---:|---:|---:|---:|---:|---:|
| 8 | 0.266s | 0.330s | 84.74% | 0% | 6.114 / 2.921 | 1.06% / 1.07% |
| 16 | 0.320s | 0.497s | 12.41% | 0% | 7.746 / 3.107 | 1.06% / 1.06% |
| 32 | 0.541s | 0.895s | 3.03% | 0% | 9.612 / 3.155 | 1.05% / 1.06% |

All runs completed 1088/1088. First payload p95 is 3.75 KiB. This change does not modify talker sampling.

Validation:
- repository pre-commit passed
- reference encoder unit tests: 14 passed
- Python compileall passed
- full Qwen3-TTS coverage runs in CI