### PR TITLE
[Fix] Restore MOSS-TD request-builder test import

### DIFF
--- a/tests/unit_test/moss_transcribe_diarize/test_request_builders.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_request_builders.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 import torch
 
+import sglang_omni.models.moss_transcribe_diarize.request_builders as request_builders
 import sglang_omni.preprocessing.transcription as transcription
 from sglang_omni.models.moss_transcribe_diarize.request_builders import (
     DEFAULT_TEMPERATURE,


### PR DESCRIPTION
## Motivation

The current `main` unit-test suite has a deterministic test-only import regression. The MOSS-Transcribe-Diarize duration-budget test still references the model request-builders module after a later refactor replaced that import with the shared transcription module, causing a `NameError`.

## Modifications

1. `tests/unit_test/moss_transcribe_diarize/test_request_builders.py`
   - Restore the request-builders module import used by the duration-scaled output-budget assertion.
   - Keep the shared transcription import used by the audio-loading monkeypatch.

No production behavior changes.

## Related Issues

N/A.

## Accuracy Test

Not applicable. This PR only restores a unit-test import.

## Benchmark & Profiling

Not applicable. This PR does not change runtime or model behavior.

## Validation

- `pytest -q tests/unit_test/moss_transcribe_diarize/test_request_builders.py` — 20 passed.
- `pre-commit run --files tests/unit_test/moss_transcribe_diarize/test_request_builders.py` — passed.

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
