### PR TITLE
[ASR][Perf] Current-main concurrency benchmark and bottleneck profile for Qwen3-ASR

### DIFF
--- a/benchmarks/eval/asr_profiling.py
+++ b/benchmarks/eval/asr_profiling.py
@@ -179,6 +179,8 @@ class UtilizationSampler:
             try:
                 sample["load_avg_1m"] = os.getloadavg()[0]
             except OSError:
+                # note (luojiaxuan): load average is optional telemetry and
+                # unavailable on some platforms (e.g. Windows); skip silently.
                 pass
             gpu = _query_gpu_utilization(self.gpu_ids)
             if gpu:
@@ -244,12 +246,38 @@ _FINGERPRINT_ENV_KEYS = (
 )
 
 
+def collect_server_identity(base_url: str) -> dict:
+    """Best-effort identity of the serving process under test.
+
+    The client-side fingerprint describes the benchmark process; the server
+    may run different code. This records what the server itself reports
+    (currently its /v1/models listing) alongside the target URL.
+    """
+    identity: dict[str, Any] = {"url": base_url.rstrip("/")}
+    try:
+        response = requests.get(
+            f"{base_url.rstrip('/')}/v1/models",
+            timeout=10,
+            proxies=_NO_PROXIES,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        identity["models"] = [
+            entry.get("id") for entry in payload.get("data", []) if entry.get("id")
+        ]
+    except (requests.RequestException, ValueError):
+        identity["models"] = None
+    return identity
+
+
 def collect_environment_fingerprint(model_path: str | None = None) -> dict:
-    """Capture code, dependency, and hardware identity for a benchmark run.
+    """Capture code, dependency, and hardware identity of the client process.
 
     Every field is best-effort: a missing tool (git outside a checkout,
     nvidia-smi on CPU hosts) yields None rather than an exception, so the
-    fingerprint never blocks a run.
+    fingerprint never blocks a run. This describes the benchmark client;
+    pair it with :func:`collect_server_identity` for the server side (they
+    coincide only when client and server share one host and checkout).
     """
     pip_freeze = _run_command([sys.executable, "-m", "pip", "freeze"])
     fingerprint: dict[str, Any] = {

--- a/benchmarks/eval/asr_profiling.py
+++ b/benchmarks/eval/asr_profiling.py
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bottleneck-profiling helpers for the ASR concurrency benchmark (issue #1324).
+
+Small, dependency-light building blocks used by ``benchmark_asr_seedtts``:
+
+- request-profile control against the serve HTTP surface
+  (``/start_request_profile`` / ``/stop_request_profile``);
+- stage/hop breakdown assembly from profiler event JSONL via
+  ``sglang_omni.profiler.views``;
+- background host-CPU / GPU utilization sampling around a benchmark pass;
+- environment fingerprinting so results stay attributable to an exact
+  code + dependency + hardware state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import requests
+
+_NO_PROXIES = {"http": None, "https": None}
+_PROFILE_TIMEOUT_S = 30
+
+
+def start_request_profile(base_url: str, run_id: str, event_dir: str) -> dict:
+    """Start request-level (JSONL) event profiling on one serve process."""
+    response = requests.post(
+        f"{base_url.rstrip('/')}/start_request_profile",
+        json={"run_id": run_id, "event_dir": event_dir},
+        timeout=_PROFILE_TIMEOUT_S,
+        proxies=_NO_PROXIES,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def stop_request_profile(base_url: str, run_id: str | None = None) -> dict:
+    """Stop request-level event profiling (run_id=None stops whatever runs)."""
+    response = requests.post(
+        f"{base_url.rstrip('/')}/stop_request_profile",
+        json={"run_id": run_id},
+        timeout=_PROFILE_TIMEOUT_S,
+        proxies=_NO_PROXIES,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def build_stage_breakdown(event_dir: str, *, include_timelines: bool = False) -> dict:
+    """Summarize profiler event JSONL into stage and hop breakdowns.
+
+    Requires the benchmark to run on the same host as the server, because
+    ``event_dir`` is a server-side path. Timelines are dropped by default to
+    keep result JSON small; breakdown rows carry count/total/avg/p50/p95/max.
+    """
+    from sglang_omni.profiler.views import build_report
+
+    report = build_report(event_dir)
+    if not include_timelines:
+        report.pop("timelines", None)
+    return report
+
+
+@dataclass
+class UtilizationSummary:
+    samples: int
+    cpu_percent_mean: float | None
+    cpu_percent_max: float | None
+    load_avg_1m_max: float | None
+    gpu: dict[str, dict[str, float]]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "samples": self.samples,
+            "cpu_percent_mean": self.cpu_percent_mean,
+            "cpu_percent_max": self.cpu_percent_max,
+            "load_avg_1m_max": self.load_avg_1m_max,
+            "gpu": self.gpu,
+        }
+
+
+def _read_proc_stat() -> tuple[int, int] | None:
+    """Return (busy, total) jiffies from /proc/stat, or None off-Linux."""
+    try:
+        with open("/proc/stat", encoding="utf-8") as handle:
+            first = handle.readline().split()
+    except OSError:
+        return None
+    if not first or first[0] != "cpu":
+        return None
+    values = [int(v) for v in first[1:]]
+    idle = values[3] + (values[4] if len(values) > 4 else 0)
+    total = sum(values)
+    return total - idle, total
+
+
+def _query_gpu_utilization(gpu_ids: list[int]) -> dict[str, dict[str, float]]:
+    try:
+        raw = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,utilization.gpu,memory.used",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    out: dict[str, dict[str, float]] = {}
+    wanted = {str(i) for i in gpu_ids} if gpu_ids else None
+    for line in raw.strip().splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) < 3:
+            continue
+        index, util, mem = parts[0], parts[1], parts[2]
+        if wanted is not None and index not in wanted:
+            continue
+        try:
+            out[index] = {"util_percent": float(util), "memory_mib": float(mem)}
+        except ValueError:
+            continue
+    return out
+
+
+@dataclass
+class UtilizationSampler:
+    """Background sampler of host CPU and selected-GPU utilization.
+
+    CPU usage comes from /proc/stat deltas (Linux; None elsewhere) so the
+    benchmark does not grow a psutil dependency. GPU stats come from a
+    best-effort ``nvidia-smi`` query and are empty when unavailable.
+    """
+
+    gpu_ids: list[int] = field(default_factory=list)
+    interval_s: float = 1.0
+    _samples: list[dict[str, Any]] = field(default_factory=list, repr=False)
+    _stop_event: threading.Event = field(default_factory=threading.Event, repr=False)
+    _thread: threading.Thread | None = field(default=None, repr=False)
+
+    def start(self) -> None:
+        if self._thread is not None:
+            raise RuntimeError("UtilizationSampler already started")
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run, name="asr-bench-util-sampler", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self) -> UtilizationSummary:
+        if self._thread is not None:
+            self._stop_event.set()
+            self._thread.join(timeout=max(self.interval_s * 3.0, 10.0))
+            self._thread = None
+        return self.summary()
+
+    def _run(self) -> None:
+        previous = _read_proc_stat()
+        while not self._stop_event.wait(self.interval_s):
+            sample: dict[str, Any] = {"t": time.time()}
+            current = _read_proc_stat()
+            if previous is not None and current is not None:
+                busy = current[0] - previous[0]
+                total = current[1] - previous[1]
+                if total > 0:
+                    sample["cpu_percent"] = 100.0 * busy / total
+            previous = current
+            try:
+                sample["load_avg_1m"] = os.getloadavg()[0]
+            except OSError:
+                pass
+            gpu = _query_gpu_utilization(self.gpu_ids)
+            if gpu:
+                sample["gpu"] = gpu
+            self._samples.append(sample)
+
+    @property
+    def samples(self) -> list[dict[str, Any]]:
+        return list(self._samples)
+
+    def summary(self) -> UtilizationSummary:
+        cpu = [s["cpu_percent"] for s in self._samples if "cpu_percent" in s]
+        loads = [s["load_avg_1m"] for s in self._samples if "load_avg_1m" in s]
+        per_gpu: dict[str, dict[str, list[float]]] = {}
+        for sample in self._samples:
+            for index, stats in sample.get("gpu", {}).items():
+                bucket = per_gpu.setdefault(index, {"util": [], "mem": []})
+                bucket["util"].append(stats["util_percent"])
+                bucket["mem"].append(stats["memory_mib"])
+        gpu_summary = {
+            index: {
+                "util_percent_mean": sum(b["util"]) / len(b["util"]),
+                "util_percent_max": max(b["util"]),
+                "memory_mib_max": max(b["mem"]),
+            }
+            for index, b in per_gpu.items()
+            if b["util"]
+        }
+        return UtilizationSummary(
+            samples=len(self._samples),
+            cpu_percent_mean=(sum(cpu) / len(cpu)) if cpu else None,
+            cpu_percent_max=max(cpu) if cpu else None,
+            load_avg_1m_max=max(loads) if loads else None,
+            gpu=gpu_summary,
+        )
+
+
+def _run_command(command: list[str]) -> str | None:
+    try:
+        return subprocess.run(
+            command, capture_output=True, text=True, timeout=60, check=True
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        from importlib.metadata import version
+
+        return version(name)
+    except Exception:
+        return None
+
+
+_FINGERPRINT_ENV_KEYS = (
+    "CUDA_VISIBLE_DEVICES",
+    "HF_HOME",
+    "HF_ENDPOINT",
+    "TORCHINDUCTOR_CACHE_DIR",
+    "OMP_NUM_THREADS",
+    "SGLANG_TORCH_PROFILER_DIR",
+)
+
+
+def collect_environment_fingerprint(model_path: str | None = None) -> dict:
+    """Capture code, dependency, and hardware identity for a benchmark run.
+
+    Every field is best-effort: a missing tool (git outside a checkout,
+    nvidia-smi on CPU hosts) yields None rather than an exception, so the
+    fingerprint never blocks a run.
+    """
+    pip_freeze = _run_command([sys.executable, "-m", "pip", "freeze"])
+    fingerprint: dict[str, Any] = {
+        "captured_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "hostname": platform.node(),
+        "platform": platform.platform(),
+        "python": sys.version.split()[0],
+        "git": {
+            "sha": _run_command(["git", "rev-parse", "HEAD"]),
+            "branch": _run_command(["git", "rev-parse", "--abbrev-ref", "HEAD"]),
+            "dirty": bool(_run_command(["git", "status", "--porcelain"]) or ""),
+        },
+        "packages": {
+            name: _package_version(name)
+            for name in ("torch", "sglang", "sglang-omni", "transformers")
+        },
+        "dependency_freeze_sha256": (
+            hashlib.sha256(pip_freeze.encode("utf-8")).hexdigest()
+            if pip_freeze
+            else None
+        ),
+        "gpus": _run_command(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,name,driver_version,memory.total",
+                "--format=csv,noheader",
+            ]
+        ),
+        "env": {key: os.environ.get(key) for key in _FINGERPRINT_ENV_KEYS},
+    }
+    if model_path:
+        fingerprint["model_path"] = model_path
+        fingerprint["model_revision"] = _cached_hf_revision(model_path)
+    return fingerprint
+
+
+def _cached_hf_revision(model_path: str) -> str | None:
+    """Resolve the locally cached HF snapshot revision for a repo id."""
+    if os.path.sep in model_path and os.path.isdir(model_path):
+        return None
+    hf_home = os.environ.get("HF_HOME") or os.path.join(
+        os.path.expanduser("~"), ".cache", "huggingface"
+    )
+    repo_dir = os.path.join(
+        hf_home, "hub", "models--" + model_path.replace("/", "--")
+    )
+    ref_main = os.path.join(repo_dir, "refs", "main")
+    try:
+        with open(ref_main, encoding="utf-8") as handle:
+            return handle.read().strip() or None
+    except OSError:
+        return None
+
+
+def write_json(path: str, payload: Any) -> None:
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)

--- a/benchmarks/eval/asr_profiling.py
+++ b/benchmarks/eval/asr_profiling.py
@@ -293,9 +293,7 @@ def _cached_hf_revision(model_path: str) -> str | None:
     hf_home = os.environ.get("HF_HOME") or os.path.join(
         os.path.expanduser("~"), ".cache", "huggingface"
     )
-    repo_dir = os.path.join(
-        hf_home, "hub", "models--" + model_path.replace("/", "--")
-    )
+    repo_dir = os.path.join(hf_home, "hub", "models--" + model_path.replace("/", "--"))
     ref_main = os.path.join(repo_dir, "refs", "main")
     try:
         with open(ref_main, encoding="utf-8") as handle:

--- a/benchmarks/eval/benchmark_asr_seedtts.py
+++ b/benchmarks/eval/benchmark_asr_seedtts.py
@@ -99,6 +99,7 @@ from benchmarks.eval.asr_profiling import (
     UtilizationSampler,
     build_stage_breakdown,
     collect_environment_fingerprint,
+    collect_server_identity,
     start_request_profile,
     stop_request_profile,
 )
@@ -505,7 +506,13 @@ async def _run_profiled_pass(args, samples, concurrency: int) -> dict | None:
             started.append(url)
     except requests.RequestException as exc:
         for url in started:
-            stop_request_profile(url)
+            try:
+                stop_request_profile(url, run_id)
+            except requests.RequestException as stop_exc:
+                print(
+                    f"[conc={concurrency}] failed to stop profiling on "
+                    f"{url}: {stop_exc}"
+                )
         print(f"[conc={concurrency}] profiling unavailable, skipping: {exc}")
         return None
     try:
@@ -513,9 +520,14 @@ async def _run_profiled_pass(args, samples, concurrency: int) -> dict | None:
     finally:
         for url in started:
             try:
-                stop_request_profile(url)
-            except requests.RequestException:
-                pass
+                stop_request_profile(url, run_id)
+            except requests.RequestException as stop_exc:
+                # The pass metrics remain valid; profiling just keeps
+                # recording on that worker until the next explicit stop.
+                print(
+                    f"[conc={concurrency}] failed to stop profiling on "
+                    f"{url}: {stop_exc}"
+                )
     report = build_stage_breakdown(event_dir)
     return {
         "run_id": run_id,
@@ -607,9 +619,12 @@ def main() -> None:
         "results": aggregates,
     }
     if args.fingerprint:
-        payload["environment_fingerprint"] = collect_environment_fingerprint(
-            args.model_path
-        )
+        # The client fingerprint equals the server's only when both share one
+        # host and checkout; the server block records what the server reports.
+        payload["environment_fingerprint"] = {
+            "client": collect_environment_fingerprint(args.model_path),
+            "server": collect_server_identity(f"http://{args.host}:{args.port}"),
+        }
     output_path = os.path.abspath(args.output)
     with open(output_path, "w") as handle:
         json.dump(payload, handle, indent=2)

--- a/benchmarks/eval/benchmark_asr_seedtts.py
+++ b/benchmarks/eval/benchmark_asr_seedtts.py
@@ -89,11 +89,19 @@ import asyncio
 import json
 import os
 import statistics
+import time
 
 import requests
 
 from benchmarks.dataset.prepare import DATASETS
 from benchmarks.dataset.seedtts import SampleInput, load_seedtts_samples
+from benchmarks.eval.asr_profiling import (
+    UtilizationSampler,
+    build_stage_breakdown,
+    collect_environment_fingerprint,
+    start_request_profile,
+    stop_request_profile,
+)
 from benchmarks.tasks.asr import (
     FUN_ASR_MODEL_PATH,
     QWEN3_ASR_MODEL_PATH,
@@ -182,16 +190,34 @@ async def run_asr_seedtts_once(
     return benchmark_result
 
 
+def _save_raw_per_sample(
+    raw_dir: str, concurrency: int, label: str, per_sample: list[dict]
+) -> None:
+    os.makedirs(raw_dir, exist_ok=True)
+    path = os.path.join(raw_dir, f"conc{concurrency}_{label}.jsonl")
+    with open(path, "w", encoding="utf-8") as handle:
+        for record in per_sample:
+            handle.write(json.dumps(record) + "\n")
+
+
 async def _run_repeat(args, samples, concurrency: int, repeat: int) -> dict:
-    benchmark_result = await run_asr_seedtts_once(
-        samples,
-        host=args.host,
-        port=args.port,
-        model_path=args.model_path,
-        lang=args.lang,
-        concurrency=concurrency,
-        stream=args.stream,
-    )
+    sampler = None
+    if args.sample_util:
+        gpu_ids = [int(g) for g in args.util_gpu_ids.split(",") if g.strip()]
+        sampler = UtilizationSampler(gpu_ids=gpu_ids, interval_s=args.util_interval)
+        sampler.start()
+    try:
+        benchmark_result = await run_asr_seedtts_once(
+            samples,
+            host=args.host,
+            port=args.port,
+            model_path=args.model_path,
+            lang=args.lang,
+            concurrency=concurrency,
+            stream=args.stream,
+        )
+    finally:
+        util_summary = sampler.stop().to_dict() if sampler is not None else None
     summary = benchmark_result["summary"]
     speed = benchmark_result["speed"]
     has_evaluated_samples = summary["evaluated"] > 0
@@ -210,12 +236,24 @@ async def _run_repeat(args, samples, concurrency: int, repeat: int) -> dict:
         "throughput_samples_per_s": speed["throughput_samples_per_s"],
         "rtfx": speed["rtfx"],
         "latency_mean_s": (speed["latency_mean_s"] if has_evaluated_samples else None),
+        "latency_median_s": (
+            speed["latency_median_s"] if has_evaluated_samples else None
+        ),
         "latency_p95_s": (speed["latency_p95_s"] if has_evaluated_samples else None),
         "latency_p99_s": (speed["latency_p99_s"] if has_evaluated_samples else None),
         "rtf_mean": speed["rtf_mean"] if has_rtf else None,
         "rtf_p95": speed["rtf_p95"],
         "worker": benchmark_result["worker"],
     }
+    if util_summary is not None:
+        result["utilization"] = util_summary
+    if args.save_raw_dir:
+        _save_raw_per_sample(
+            args.save_raw_dir,
+            concurrency,
+            f"rep{repeat}",
+            benchmark_result["per_sample"],
+        )
     for key in (
         "text_ttft_mean_s",
         "text_ttft_median_s",
@@ -262,6 +300,7 @@ def _aggregate(repeats: list[dict]) -> dict:
         "throughput_samples_per_s": _stat("throughput_samples_per_s"),
         "rtfx": _stat("rtfx"),
         "latency_mean_s": _stat("latency_mean_s"),
+        "latency_median_s": _stat("latency_median_s"),
         "latency_p95_s": _stat("latency_p95_s"),
         "latency_p99_s": _stat("latency_p99_s"),
         "rtf_mean": _stat("rtf_mean"),
@@ -291,12 +330,12 @@ def _print_table(aggregates: list[dict]) -> None:
     header = (
         "| conc | valid reps (lat/RTF/WER) | evaluated/requests | "
         "wall(s) mean | req/s mean | req/s best | RTFx mean | lat mean(s) | "
-        "lat p95(s) | RTF mean | RTF p95 | "
+        "lat p50(s) | lat p95(s) | RTF mean | RTF p95 | "
     )
     if include_ttft:
         header += "TTFT mean(s) | TTFT p95(s) | ITL mean(s) | "
     header += "corpus WER | max WER |"
-    sep = "|---:" * (16 if include_ttft else 13) + "|"
+    sep = "|---:" * (17 if include_ttft else 14) + "|"
     print("\n" + header)
     print(sep)
     for agg in aggregates:
@@ -311,6 +350,7 @@ def _print_table(aggregates: list[dict]) -> None:
             f"| {_format_metric(agg['throughput_samples_per_s']['max'], 3)} "
             f"| {_format_metric(agg['rtfx']['mean'], 3)} "
             f"| {_format_metric(agg['latency_mean_s']['mean'], 3)} "
+            f"| {_format_metric(agg['latency_median_s']['mean'], 3)} "
             f"| {_format_metric(agg['latency_p95_s']['mean'], 3)} "
             f"| {_format_metric(agg['rtf_mean']['mean'], 4)} "
             f"| {_format_metric(agg['rtf_p95']['mean'], 4)} "
@@ -382,7 +422,109 @@ def parse_args() -> argparse.Namespace:
         default="asr_seedtts_results.json",
         help="Where to write the full JSON results.",
     )
-    return parser.parse_args()
+    parser.add_argument(
+        "--save-raw-dir",
+        default="",
+        help=(
+            "Directory for raw per-request JSONL (one file per concurrency "
+            "and repeat). Empty disables raw preservation."
+        ),
+    )
+    parser.add_argument(
+        "--profile-events",
+        action="store_true",
+        help=(
+            "After the measured repeats of each concurrency, run one extra "
+            "profiled pass with request-level event recording and attach the "
+            "stage/hop breakdown. Requires running on the server host."
+        ),
+    )
+    parser.add_argument(
+        "--profile-urls",
+        default="",
+        help=(
+            "Comma-separated serve base URLs exposing /start_request_profile "
+            "(the serve port for DP=1, each worker base URL behind a router). "
+            "Defaults to http://<host>:<port>."
+        ),
+    )
+    parser.add_argument(
+        "--profile-event-dir",
+        default="/tmp/asr_bench_profile",
+        help="Server-side base directory for profiler event JSONL.",
+    )
+    parser.add_argument(
+        "--sample-util",
+        action="store_true",
+        help=(
+            "Sample host CPU and GPU utilization during each measured repeat "
+            "and attach mean/max summaries to the results."
+        ),
+    )
+    parser.add_argument(
+        "--util-gpu-ids",
+        default="",
+        help="Comma-separated GPU indices to sample (empty = all visible).",
+    )
+    parser.add_argument(
+        "--util-interval",
+        type=float,
+        default=1.0,
+        help="Utilization sampling interval in seconds.",
+    )
+    parser.add_argument(
+        "--fingerprint",
+        action="store_true",
+        help=(
+            "Record an environment fingerprint (git state, package versions, "
+            "dependency freeze hash, GPUs, cached model revision) in the "
+            "output JSON."
+        ),
+    )
+    args = parser.parse_args()
+    if not args.profile_urls:
+        args.profile_urls = f"http://{args.host}:{args.port}"
+    return args
+
+
+async def _run_profiled_pass(args, samples, concurrency: int) -> dict | None:
+    """One extra profiled pass, excluded from measured aggregates.
+
+    Request-event profiling adds server-side JSONL writes, so the measured
+    repeats stay clean and one dedicated pass captures the stage breakdown.
+    The event dir is a server-side path; building the report assumes the
+    benchmark runs on the same host as the server.
+    """
+    run_id = f"asrbench-c{concurrency}-{int(time.time())}"
+    event_dir = os.path.join(args.profile_event_dir, run_id)
+    profile_urls = [u.strip() for u in args.profile_urls.split(",") if u.strip()]
+    started: list[str] = []
+    try:
+        for url in profile_urls:
+            start_request_profile(url, run_id, event_dir)
+            started.append(url)
+    except requests.RequestException as exc:
+        for url in started:
+            stop_request_profile(url)
+        print(f"[conc={concurrency}] profiling unavailable, skipping: {exc}")
+        return None
+    try:
+        result = await _run_repeat(args, samples, concurrency, repeat=0)
+    finally:
+        for url in started:
+            try:
+                stop_request_profile(url)
+            except requests.RequestException:
+                pass
+    report = build_stage_breakdown(event_dir)
+    return {
+        "run_id": run_id,
+        "event_dir": event_dir,
+        "pass_metrics": result,
+        "request_count": report.get("request_count"),
+        "stage_breakdown": report.get("stage_breakdown"),
+        "hop_breakdown": report.get("hop_breakdown"),
+    }
 
 
 async def _sweep(args, samples, concurrencies: list[int]) -> list[dict]:
@@ -424,7 +566,11 @@ async def _sweep(args, samples, concurrencies: list[int]) -> list[dict]:
             print(line)
             if result["worker"].get("per_worker_routed"):
                 print(f"    routed per worker: {result['worker']['per_worker_routed']}")
-        aggregates.append(_aggregate(repeats))
+        aggregate = _aggregate(repeats)
+        if args.profile_events:
+            print(f"[conc={concurrency}] profiled pass ...")
+            aggregate["profile"] = await _run_profiled_pass(args, samples, concurrency)
+        aggregates.append(aggregate)
     return aggregates
 
 
@@ -455,9 +601,15 @@ def main() -> None:
             "repeats": args.repeats,
             "warmup": args.warmup,
             "stream": args.stream,
+            "profile_events": args.profile_events,
+            "sample_util": args.sample_util,
         },
         "results": aggregates,
     }
+    if args.fingerprint:
+        payload["environment_fingerprint"] = collect_environment_fingerprint(
+            args.model_path
+        )
     output_path = os.path.abspath(args.output)
     with open(output_path, "w") as handle:
         json.dump(payload, handle, indent=2)

--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -98,6 +98,12 @@ The ASR CI gate runs the selected ASR CI model preset on this same benchmark
 entry point (`tests/test_model/test_asr_ci_seedtts.py`). Qwen3-ASR remains
 the transcriber for the TTS and talker WER stages.
 
+For the current-main concurrency baseline, the fixed-baseline comparison, and
+the per-stage bottleneck decomposition (issue #1324), see
+[Qwen3-ASR concurrency profile](../developer_reference/qwen3_asr_concurrency_profile.md).
+The benchmark's `--profile-events`, `--sample-util`, `--save-raw-dir`, and
+`--fingerprint` flags capture the telemetry that report uses.
+
 ## Known Limitations
 
 - The endpoint accepts one uploaded file per request.

--- a/docs/developer_reference/qwen3_asr_concurrency_profile.md
+++ b/docs/developer_reference/qwen3_asr_concurrency_profile.md
@@ -174,10 +174,13 @@ Dominant costs, in order:
 
 ## Environment
 
-Fingerprints (git SHA, dependency freeze hash, driver, GPU, cached model
-revision) are embedded in each result JSON produced by `--fingerprint`; raw
-per-request records and profiler event JSONL live beside the result files on
-the measurement host.
+Fingerprints are embedded in each result JSON produced by
+`--fingerprint`: a client block (git SHA, dependency freeze hash, driver,
+GPU, cached model revision — describing the benchmark process) and a server
+block (what the target server reports about itself). In the runs above,
+client and server shared one host and checkout, so the client git state also
+identifies the server code. Raw per-request records and profiler event JSONL
+live beside the result files on the measurement host.
 
 Summary for the runs above: NVIDIA H100 80GB HBM3, driver 580.126.20,
 torch 2.11.0+cu130, sglang 0.5.16, transformers 5.12.1, model snapshot

--- a/docs/developer_reference/qwen3_asr_concurrency_profile.md
+++ b/docs/developer_reference/qwen3_asr_concurrency_profile.md
@@ -1,0 +1,187 @@
+# Qwen3-ASR High-Concurrency Benchmark and Bottleneck Profile
+
+This is the issue #1324 Q-PR2 deliverable: a reproducible current-main
+benchmark of Qwen3-ASR serving at concurrency 1–64, compared against a fixed
+serving baseline on identical pre-segmented audio, with enough internal
+telemetry to attribute where request time goes. The numbers below are the
+before-baseline for Q-PR3 (#1326, merged), Q-PR4, and Q-PR5.
+
+## Method
+
+- Model: `Qwen/Qwen3-ASR-1.7B`, bf16, one 80 GB GPU per server (DP=1).
+- Data: full SeedTTS reference sets — EN 1088 clips, ZH 2020 clips — staged by
+  `benchmarks.dataset.seedtts`; both systems receive the same files through
+  the same client (`benchmarks/eval/benchmark_asr_seedtts.py`).
+- Sweep: concurrency `1, 8, 16, 32, 64`, one discarded warmup pass plus three
+  measured repeats per level; closed-loop client.
+- Current is SGLang-Omni at the commit under review, served with the default
+  Qwen3-ASR pipeline (`max_running_requests=32`,
+  `request_build_max_workers=2`, `request_build_max_pending=16`, async decode
+  on). Baseline is a fixed OpenAI-compatible serving stack for the same
+  checkpoint with its stock configuration, on an identical GPU of the same
+  host. Neither side was tuned.
+- Telemetry: per-request profiler events (request build, admission queue,
+  first forward, decode tail), host CPU and per-GPU utilization sampling, raw
+  per-request JSONL, and an environment fingerprint are captured by the
+  benchmark's `--profile-events --sample-util --fingerprint --save-raw-dir`
+  flags added in this PR.
+
+### Reproduce
+
+```bash
+# current
+sgl-omni serve --model-path Qwen/Qwen3-ASR-1.7B --port 8511
+
+python -m benchmarks.eval.benchmark_asr_seedtts \
+  --port 8511 --concurrencies 1,8,16,32,64 --repeats 3 --warmup \
+  --profile-events --profile-event-dir /tmp/asr_profile \
+  --sample-util --util-gpu-ids <gpu> --fingerprint \
+  --save-raw-dir raw-current --output asr_en_current.json
+
+# baseline: point the same client at the baseline server's port
+python -m benchmarks.eval.benchmark_asr_seedtts \
+  --port <baseline-port> --concurrencies 1,8,16,32,64 --repeats 3 --warmup \
+  --sample-util --util-gpu-ids <gpu> --fingerprint \
+  --output asr_en_baseline.json
+```
+
+## Shared-host variance
+
+The measurement host is shared; co-tenant load shifts between runs and shows
+up directly in these host-bound workloads (see #907). Runs on a quiet host
+and a loaded host are both reported: the absolute peaks move, but the
+structural findings — the concurrency knee, its cause, and the stage
+decomposition — are identical in every run. Current-vs-baseline comparisons
+were taken back-to-back so both sides see similar external load.
+
+## Results — current (quiet host)
+
+SeedTTS EN, 1088 clips, mean over three repeats:
+
+| conc | req/s | RTFx | lat mean | lat p95 | corpus WER | completed |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 11.6 | 54.8 | 0.088 s | 0.129 s | 0.0122 | 3264/3264 |
+| 8 | 27.5 | 130.4 | 0.289 s | 0.437 s | 0.0122 | 3264/3264 |
+| 16 | 53.0 | 251.2 | 0.304 s | 0.458 s | 0.0122 | 3264/3264 |
+| 32 | 108.0 | 511.4 | 0.295 s | 0.399 s | 0.0122 | 3264/3264 |
+| 64 | 103.0 | 486.8 | 0.610 s | 0.741 s | 0.0125 | 3165/3264 |
+
+SeedTTS ZH, 2020 clips, mean over three repeats:
+
+| conc | req/s | RTFx | lat mean | lat p95 | corpus CER | completed |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 14.3 | 66.9 | 0.070 s | 0.088 s | 0.0062 | 6060/6060 |
+| 8 | 64.2 | 300.8 | 0.124 s | 0.175 s | 0.0064 | 6060/6060 |
+| 16 | 96.5 | 451.9 | 0.165 s | 0.231 s | 0.0062 | 6060/6060 |
+| 32 | 126.4 | 591.6 | 0.252 s | 0.353 s | 0.0062 | 6060/6060 |
+| 64 | 129.2 | 604.3 | 0.489 s | 0.613 s | 0.0062 | 5993/6060 |
+
+Reading:
+
+- Throughput saturates at concurrency 32 and stops scaling to 64 on both
+  languages while mean latency roughly doubles.
+- At concurrency 64 both languages shed 1–4 % of requests with HTTP 500: a
+  single worker admits at most `request_build_max_pending=16` request builds
+  and `max_running_requests=32` running requests, so the 64-deep closed loop
+  overflows the build backlog.
+- WER/CER stay in band at every level (the concurrency-64 uptick is the
+  shed-request denominator, not transcription regressions).
+- Relative to the pre-#1326 reference (97.9 req/s at concurrency 32 on the
+  same EN set and hardware class), async decode lifted saturation throughput
+  by about 10 %.
+
+## Results — current vs baseline (back-to-back, same host window)
+
+SeedTTS EN, 1088 clips, mean over three repeats; the two sweeps ran
+back-to-back on identical neighboring GPUs so both saw the same co-tenant
+load. One baseline concurrency-1 repeat was hit by a co-tenant burst
+(7.3 req/s against 22.6/21.4); the mean below includes it.
+
+| conc | current req/s | baseline req/s | ratio | current lat mean/p95 | baseline lat mean/p95 | current completed | baseline completed |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 12.0 | 17.1 | 1.42× | 0.083 / 0.102 s | 0.076 / 0.149 s | 3264/3264 | 3264/3264 |
+| 8 | 41.9 | 70.3 | 1.68× | 0.191 / 0.256 s | 0.117 / 0.174 s | 3264/3264 | 3264/3264 |
+| 16 | 62.6 | 120.6 | 1.93× | 0.255 / 0.346 s | 0.132 / 0.171 s | 3264/3264 | 3264/3264 |
+| 32 | 79.5 | 183.8 | 2.31× | 0.401 / 0.549 s | 0.175 / 0.242 s | 3264/3264 | 3264/3264 |
+| 64 | 80.9 | 264.6 | 3.27× | 0.777 / 0.947 s | 0.238 / 0.291 s | 3208/3264 | 3264/3264 |
+
+Corpus WER stayed 0.0122–0.0125 (current) and 0.0123–0.0124 (baseline) at
+every level. Reading:
+
+- The gap is a scaling gap, not a single-request model-forward gap: baseline
+  keeps scaling past current's concurrency-32 saturation and completes every
+  request at 64 while current sheds 1–2 % there.
+- Excluding the contended repeat, baseline is ~1.8× faster even at
+  concurrency 1 (0.044 s vs 0.083 s mean), so part of the gap is fixed
+  per-request serving overhead, and the rest grows with concurrency —
+  consistent with the admission cap and host-dispatch costs quantified
+  below.
+- This reproduces the external report's direction with a wider magnitude on
+  this hardware/window; the concurrency knee the roadmap describes is
+  confirmed on current main.
+
+SeedTTS ZH, 2020 clips, mean over three repeats, same back-to-back pairing
+(current concurrency-1 repeats were partially contended in this window):
+
+| conc | current req/s | baseline req/s | ratio | current lat mean/p95 | baseline lat mean/p95 | current completed | baseline completed |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 9.1 | 25.2 | 2.78× | 0.116 / 0.178 s | 0.039 / 0.053 s | 6060/6060 | 6060/6060 |
+| 8 | 47.8 | 131.0 | 2.74× | 0.167 / 0.238 s | 0.061 / 0.083 s | 6060/6060 | 6060/6060 |
+| 16 | 68.4 | 186.5 | 2.73× | 0.233 / 0.324 s | 0.085 / 0.117 s | 6060/6060 | 6060/6060 |
+| 32 | 86.6 | 245.5 | 2.83× | 0.368 / 0.522 s | 0.129 / 0.164 s | 6060/6060 | 6060/6060 |
+| 64 | 82.1 | 265.7 | 3.24× | 0.772 / 1.017 s | 0.238 / 0.339 s | 5961/6060 | 6060/6060 |
+
+Corpus CER stayed 0.0061–0.0063 (current) and 0.0064–0.0066 (baseline) at
+every level.
+
+## Bottleneck decomposition (profiled passes, EN)
+
+Per-request stage averages from the request-event profiler; encoder work runs
+inside the first LM forward on this path, so "first forward" is encoder +
+prefill:
+
+| conc | build | build→queued | queued→scheduled | first forward | decode tail | total |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 5.6 ms | 0.7 ms | 1.1 ms | 28.0 ms | 55.3 ms | 91 ms |
+| 8 | 6.0 ms | 16.5 ms | 2.0 ms | 29.5 ms | 131.8 ms | 196 ms |
+| 16 | 6.1 ms | 20.0 ms | 1.9 ms | 30.1 ms | 185.6 ms | 259 ms |
+| 32 | 6.5 ms | 23.1 ms | 5.9 ms | 46.2 ms | 357.7 ms | 472 ms |
+| 64 | 6.3 ms | 30.1 ms | 412.8 ms | 33.3 ms | 392.6 ms | 910 ms |
+
+GPU utilization stays between 33 % and 54 % (mean) at every level; the GPU is
+never the constraint.
+
+Dominant costs, in order:
+
+1. **Admission queueing at concurrency 64.** The queued→scheduled wait jumps
+   from ~6 ms to ~413 ms — the entire knee. Requests beyond
+   `max_running_requests=32` wait; requests beyond the build backlog are
+   rejected. This is the Q-PR5 target.
+2. **Decode-step host dispatch.** The decode tail grows from 55 ms to
+   ~360 ms per request as concurrency rises while GPU utilization falls —
+   decode wall-clock is dominated by host-side per-step work shared across
+   the running batch, consistent with the #907 causal profiling
+   (GPU-idle-94 %, CPU-sensitivity-0.69). Q-PR5's knob sweep and any further
+   host-side batching improvements attack this.
+3. **First-forward stalls.** Encoder + prefill costs 28–46 ms per admitted
+   request and executes on the scheduler thread and default stream, so every
+   admission stalls the whole running decode batch for that long (and forces
+   an async-decode drain). This is the Q-PR4 target: move the encoder ahead
+   of LM admission onto its own thread/stream and batch it.
+4. **Build-to-queued gap.** 16–30 ms at concurrency ≥ 8 from the FIFO
+   build-result drain and admission-lock path; small but visible, also in
+   Q-PR5 scope.
+
+## Environment
+
+Fingerprints (git SHA, dependency freeze hash, driver, GPU, cached model
+revision) are embedded in each result JSON produced by `--fingerprint`; raw
+per-request records and profiler event JSONL live beside the result files on
+the measurement host.
+
+Summary for the runs above: NVIDIA H100 80GB HBM3, driver 580.126.20,
+torch 2.11.0+cu130, sglang 0.5.16, transformers 5.12.1, model snapshot
+`7278e1e70fe206f11671096ffdd38061171dd6e5`, dependency freeze
+`49652ce3ea5a7720…`. The current-side numbers were produced at this
+branch's commit; note the fingerprint's `git.dirty` flag also counts
+untracked run-output directories.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -117,4 +117,5 @@ Supported Models
    developer_reference/communication.md
    developer_reference/reference_encode_service.md
    developer_reference/profiler.md
+   developer_reference/qwen3_asr_concurrency_profile.md
    developer_reference/rl_admin_control.md

--- a/sglang_omni/profiler/views.py
+++ b/sglang_omni/profiler/views.py
@@ -138,8 +138,11 @@ _STAGE_INTERVAL_EVENTS = (
     ("encoder_start", "encoder_end"),
     ("preprocess_start", "preprocess_end"),
     ("scheduler_request_build_start", "scheduler_request_build_end"),
+    ("scheduler_request_build_end", "scheduler_queue_enter"),
+    ("scheduler_queue_enter", "scheduler_prefill_start"),
     ("scheduler_prefill_start", "stage_first_stream_chunk_sent"),
     ("scheduler_prefill_start", "scheduler_first_emit"),
+    ("scheduler_first_emit", "stage_complete"),
 )
 
 

--- a/sglang_omni/profiler/views.py
+++ b/sglang_omni/profiler/views.py
@@ -140,6 +140,8 @@ _STAGE_INTERVAL_EVENTS = (
     ("scheduler_request_build_start", "scheduler_request_build_end"),
     ("scheduler_request_build_end", "scheduler_queue_enter"),
     ("scheduler_queue_enter", "scheduler_prefill_start"),
+    ("scheduler_prefill_start", "scheduler_prefill_end"),
+    ("scheduler_prefill_end", "stage_complete"),
     ("scheduler_prefill_start", "stage_first_stream_chunk_sent"),
     ("scheduler_prefill_start", "scheduler_first_emit"),
     ("scheduler_first_emit", "stage_complete"),

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -1341,6 +1341,13 @@ class OmniScheduler:
         prefill — for streaming and non-streaming requests alike. The
         metadata carries the realized batch size (issue #1324 Q-PR2).
         """
+        # note (luojiaxuan): steady-state decode reaches here after every
+        # step. _prefill_end_done only ever holds rids present in
+        # _prefill_start_done and both are discarded together, so equal sizes
+        # mean every started request already emitted -- skip before building
+        # metadata or scanning the batch.
+        if len(self._prefill_end_done) == len(self._prefill_start_done):
+            return
         metadata = {
             "batch_size": len(batch.reqs),
             "is_extend_in_batch": bool(batch.is_extend_in_batch),

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -489,6 +489,7 @@ class OmniScheduler:
         self._dirty_deferred_request_ids: set[str] = set()
         self._first_emit_done: set[str] = set()
         self._prefill_start_done: set[str] = set()
+        self._prefill_end_done: set[str] = set()
 
     def bind_model_runner(self, model_runner: Any) -> None:
         """Attach a custom runner and its SGLang execution-contract bridge.
@@ -1194,6 +1195,7 @@ class OmniScheduler:
         batch.forward_iter = self.forward_ct
         sched_output = self._build_sched_output(batch)
         mr_output = self._model_runner.execute(sched_output)
+        self._emit_prefill_end_for_batch(batch)
         self._emit_stream_output(sched_output, mr_output)
         return self._make_batch_result(mr_output)
 
@@ -1328,6 +1330,30 @@ class OmniScheduler:
                 request_id=rid,
                 stage=None,
                 event_name="scheduler_prefill_start",
+                metadata=metadata,
+            )
+
+    def _emit_prefill_end_for_batch(self, batch: ScheduleBatch) -> None:
+        """Emit once after a request's first executed batch returns.
+
+        Paired with ``scheduler_prefill_start`` this frames the request's
+        first model forward — for multimodal models that is encoder plus
+        prefill — for streaming and non-streaming requests alike. The
+        metadata carries the realized batch size (issue #1324 Q-PR2).
+        """
+        metadata = {
+            "batch_size": len(batch.reqs),
+            "is_extend_in_batch": bool(batch.is_extend_in_batch),
+        }
+        for req in batch.reqs:
+            rid = req.rid
+            if rid in self._prefill_end_done or rid not in self._prefill_start_done:
+                continue
+            self._prefill_end_done.add(rid)
+            _emit_event(
+                request_id=rid,
+                stage=None,
+                event_name="scheduler_prefill_end",
                 metadata=metadata,
             )
 
@@ -1574,6 +1600,7 @@ class OmniScheduler:
         # later prefill_start for the same id.
         self._emit_model_path_end_once(request_id, status="aborted")
         self._prefill_start_done.discard(request_id)
+        self._prefill_end_done.discard(request_id)
         if not running_abort:
             self._release_immediate_request_resources(request_id)
             _remove_from_batch(self.running_batch, request_id)
@@ -2437,6 +2464,7 @@ class OmniScheduler:
             abort_cleanup_needed = request_id in self._aborted_request_ids
         self._first_emit_done.discard(request_id)
         self._prefill_start_done.discard(request_id)
+        self._prefill_end_done.discard(request_id)
         return abort_cleanup_needed
 
     def _find_request_data(self, request_id: str) -> Any | None:

--- a/tests/unit_test/benchmarks/test_asr_profiling.py
+++ b/tests/unit_test/benchmarks/test_asr_profiling.py
@@ -59,6 +59,7 @@ def test_build_stage_breakdown_pairs_queue_and_decode_intervals(tmp_path) -> Non
         ("scheduler_request_build_end", base_ns + 5_000_000),
         ("scheduler_queue_enter", base_ns + 6_000_000),
         ("scheduler_prefill_start", base_ns + 30_000_000),
+        ("scheduler_prefill_end", base_ns + 60_000_000),
         ("scheduler_first_emit", base_ns + 80_000_000),
         ("stage_complete", base_ns + 200_000_000),
     ]
@@ -88,6 +89,10 @@ def test_build_stage_breakdown_pairs_queue_and_decode_intervals(tmp_path) -> Non
     assert build["avg_ms"] == pytest.approx(5.0)
     queue = by_interval["scheduler_queue_enter->scheduler_prefill_start"]
     assert queue["avg_ms"] == pytest.approx(24.0)
+    prefill = by_interval["scheduler_prefill_start->scheduler_prefill_end"]
+    assert prefill["avg_ms"] == pytest.approx(30.0)
+    decode_tail = by_interval["scheduler_prefill_end->stage_complete"]
+    assert decode_tail["avg_ms"] == pytest.approx(140.0)
     decode = by_interval["scheduler_first_emit->stage_complete"]
     assert decode["avg_ms"] == pytest.approx(120.0)
 

--- a/tests/unit_test/benchmarks/test_asr_profiling.py
+++ b/tests/unit_test/benchmarks/test_asr_profiling.py
@@ -234,9 +234,7 @@ def test_prefill_end_emission_skips_when_no_request_is_pending(
     assert emitted == []
 
     scheduler._prefill_start_done = {"r1", "r2"}
-    batch = SimpleNamespace(
-        reqs=[SimpleNamespace(rid="r2")], is_extend_in_batch=True
-    )
+    batch = SimpleNamespace(reqs=[SimpleNamespace(rid="r2")], is_extend_in_batch=True)
     scheduler._emit_prefill_end_for_batch(batch)
     assert emitted == ["r2"]
     assert scheduler._prefill_end_done == {"r1", "r2"}

--- a/tests/unit_test/benchmarks/test_asr_profiling.py
+++ b/tests/unit_test/benchmarks/test_asr_profiling.py
@@ -200,3 +200,43 @@ def test_server_identity_reports_models_best_effort(
     identity = collect_server_identity("http://127.0.0.1:8000")
     assert identity["url"] == "http://127.0.0.1:8000"
     assert identity["models"] is None
+
+
+def test_prefill_end_emission_skips_when_no_request_is_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+
+    from sglang_omni.scheduling import omni_scheduler
+
+    emitted: list[str] = []
+    monkeypatch.setattr(
+        omni_scheduler,
+        "_emit_event",
+        lambda **kwargs: emitted.append(kwargs["request_id"]),
+    )
+    scheduler = object.__new__(omni_scheduler.OmniScheduler)
+    scheduler._prefill_start_done = {"r1"}
+    scheduler._prefill_end_done = {"r1"}
+
+    class _ExplodingBatch:
+        # note (luojiaxuan): the O(1) fast path must return before touching
+        # the batch at all -- steady-state decode pays this on every step.
+        @property
+        def reqs(self):
+            raise AssertionError("fast path must not scan the batch")
+
+        @property
+        def is_extend_in_batch(self):
+            raise AssertionError("fast path must not build metadata")
+
+    scheduler._emit_prefill_end_for_batch(_ExplodingBatch())
+    assert emitted == []
+
+    scheduler._prefill_start_done = {"r1", "r2"}
+    batch = SimpleNamespace(
+        reqs=[SimpleNamespace(rid="r2")], is_extend_in_batch=True
+    )
+    scheduler._emit_prefill_end_for_batch(batch)
+    assert emitted == ["r2"]
+    assert scheduler._prefill_end_done == {"r1", "r2"}

--- a/tests/unit_test/benchmarks/test_asr_profiling.py
+++ b/tests/unit_test/benchmarks/test_asr_profiling.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit coverage for the ASR bottleneck-profiling helpers (issue #1324)."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from benchmarks.eval import asr_profiling
+from benchmarks.eval.asr_profiling import (
+    UtilizationSampler,
+    build_stage_breakdown,
+    collect_environment_fingerprint,
+    start_request_profile,
+    stop_request_profile,
+)
+from benchmarks.eval.benchmark_asr_seedtts import _aggregate, _print_table
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def test_profile_control_posts_run_id_and_event_dir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, dict]] = []
+
+    def fake_post(url, *, json, timeout, proxies):
+        del timeout, proxies
+        calls.append((url, json))
+        return _FakeResponse({"run_id": json.get("run_id"), "event_dir": "/tmp/e"})
+
+    monkeypatch.setattr(asr_profiling.requests, "post", fake_post)
+
+    started = start_request_profile("http://127.0.0.1:8000/", "run-1", "/tmp/e")
+    stopped = stop_request_profile("http://127.0.0.1:8000")
+
+    assert started["run_id"] == "run-1"
+    assert stopped["run_id"] is None
+    assert calls[0][0] == "http://127.0.0.1:8000/start_request_profile"
+    assert calls[0][1] == {"run_id": "run-1", "event_dir": "/tmp/e"}
+    assert calls[1][0] == "http://127.0.0.1:8000/stop_request_profile"
+
+
+def test_build_stage_breakdown_pairs_queue_and_decode_intervals(tmp_path) -> None:
+    base_ns = 1_000_000_000
+    events = [
+        ("scheduler_request_build_start", base_ns),
+        ("scheduler_request_build_end", base_ns + 5_000_000),
+        ("scheduler_queue_enter", base_ns + 6_000_000),
+        ("scheduler_prefill_start", base_ns + 30_000_000),
+        ("scheduler_first_emit", base_ns + 80_000_000),
+        ("stage_complete", base_ns + 200_000_000),
+    ]
+    event_file = tmp_path / "events_run_1.jsonl"
+    with event_file.open("w") as handle:
+        for name, ts in events:
+            handle.write(
+                json.dumps(
+                    {
+                        "request_id": "req-1",
+                        "stage": "asr",
+                        "event_name": name,
+                        "timestamp_ns": ts,
+                        "run_id": "run-1",
+                        "pid": 1,
+                    }
+                )
+                + "\n"
+            )
+
+    report = build_stage_breakdown(str(tmp_path))
+
+    assert "timelines" not in report
+    assert report["request_count"] == 1
+    by_interval = {row["interval_name"]: row for row in report["stage_breakdown"]}
+    build = by_interval["scheduler_request_build_start->scheduler_request_build_end"]
+    assert build["avg_ms"] == pytest.approx(5.0)
+    queue = by_interval["scheduler_queue_enter->scheduler_prefill_start"]
+    assert queue["avg_ms"] == pytest.approx(24.0)
+    decode = by_interval["scheduler_first_emit->stage_complete"]
+    assert decode["avg_ms"] == pytest.approx(120.0)
+
+
+def test_utilization_sampler_summarizes_cpu_and_gpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stat_values = iter([(100, 1000), (200, 1200), (350, 1400), (400, 1600)])
+    monkeypatch.setattr(
+        asr_profiling, "_read_proc_stat", lambda: next(stat_values, (400, 1600))
+    )
+    monkeypatch.setattr(
+        asr_profiling,
+        "_query_gpu_utilization",
+        lambda gpu_ids: {"3": {"util_percent": 40.0, "memory_mib": 1024.0}},
+    )
+
+    sampler = UtilizationSampler(gpu_ids=[3], interval_s=0.01)
+    sampler.start()
+    time.sleep(0.08)
+    summary = sampler.stop()
+
+    assert summary.samples >= 2
+    assert summary.cpu_percent_mean is not None
+    assert 0.0 < summary.cpu_percent_mean <= 100.0
+    assert summary.gpu["3"]["util_percent_max"] == pytest.approx(40.0)
+    assert summary.gpu["3"]["memory_mib_max"] == pytest.approx(1024.0)
+    assert summary.to_dict()["samples"] == summary.samples
+
+
+def test_environment_fingerprint_is_best_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(asr_profiling, "_run_command", lambda command: None)
+
+    fingerprint = collect_environment_fingerprint("Qwen/Qwen3-ASR-1.7B")
+
+    assert fingerprint["git"]["sha"] is None
+    assert fingerprint["dependency_freeze_sha256"] is None
+    assert fingerprint["gpus"] is None
+    assert fingerprint["model_path"] == "Qwen/Qwen3-ASR-1.7B"
+    assert "torch" in fingerprint["packages"]
+    assert "CUDA_VISIBLE_DEVICES" in fingerprint["env"]
+
+
+def _repeat(concurrency: int, repeat: int, median: float) -> dict:
+    return {
+        "concurrency": concurrency,
+        "repeat": repeat,
+        "evaluated": 10,
+        "total": 10,
+        "skipped": 0,
+        "corpus_wer": 0.01,
+        "per_sample_wer_max": 0.05,
+        "wall_clock_s": 2.0,
+        "throughput_samples_per_s": 5.0,
+        "rtfx": 20.0,
+        "latency_mean_s": 0.5,
+        "latency_median_s": median,
+        "latency_p95_s": 0.9,
+        "latency_p99_s": 1.1,
+        "rtf_mean": 0.1,
+        "rtf_p95": 0.2,
+        "worker": {},
+    }
+
+
+def test_aggregate_and_table_surface_latency_median() -> None:
+    aggregate = _aggregate([_repeat(8, 1, 0.4), _repeat(8, 2, 0.6)])
+
+    assert aggregate["latency_median_s"]["mean"] == pytest.approx(0.5)
+    assert aggregate["latency_median_s"]["n"] == 2
+    # note (luojiaxuan): the markdown table must render the p50 column without
+    # raising for both plain and profiled aggregates.
+    aggregate["profile"] = None
+    _print_table([aggregate])

--- a/tests/unit_test/benchmarks/test_asr_profiling.py
+++ b/tests/unit_test/benchmarks/test_asr_profiling.py
@@ -13,6 +13,7 @@ from benchmarks.eval.asr_profiling import (
     UtilizationSampler,
     build_stage_breakdown,
     collect_environment_fingerprint,
+    collect_server_identity,
     start_request_profile,
     stop_request_profile,
 )
@@ -169,3 +170,33 @@ def test_aggregate_and_table_surface_latency_median() -> None:
     # raising for both plain and profiled aggregates.
     aggregate["profile"] = None
     _print_table([aggregate])
+
+
+def test_server_identity_reports_models_best_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _ModelsResponse:
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> dict:
+            return {"data": [{"id": "Qwen/Qwen3-ASR-1.7B"}]}
+
+    monkeypatch.setattr(
+        asr_profiling.requests,
+        "get",
+        lambda url, *, timeout, proxies: _ModelsResponse(),
+    )
+    identity = collect_server_identity("http://127.0.0.1:8000/")
+    assert identity == {
+        "url": "http://127.0.0.1:8000",
+        "models": ["Qwen/Qwen3-ASR-1.7B"],
+    }
+
+    def _down(url, *, timeout, proxies):
+        raise asr_profiling.requests.ConnectionError("down")
+
+    monkeypatch.setattr(asr_profiling.requests, "get", _down)
+    identity = collect_server_identity("http://127.0.0.1:8000")
+    assert identity["url"] == "http://127.0.0.1:8000"
+    assert identity["models"] is None

--- a/tests/unit_test/benchmarks/test_asr_profiling.py
+++ b/tests/unit_test/benchmarks/test_asr_profiling.py
@@ -83,7 +83,7 @@ def test_build_stage_breakdown_pairs_queue_and_decode_intervals(tmp_path) -> Non
 
     assert "timelines" not in report
     assert report["request_count"] == 1
-    by_interval = {row["interval_name"]: row for row in report["stage_breakdown"]}
+    by_interval = {row["interval"]: row for row in report["stage_breakdown"]}
     build = by_interval["scheduler_request_build_start->scheduler_request_build_end"]
     assert build["avg_ms"] == pytest.approx(5.0)
     queue = by_interval["scheduler_queue_enter->scheduler_prefill_start"]

--- a/tests/unit_test/fishaudio_s2_pro/test_tts.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_tts.py
@@ -658,6 +658,7 @@ def test_fish_req_hits_max_new_tokens_and_scheduler_reports_length() -> None:
     scheduler._request_finished_callback = None
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler._result_adapter = result_adapter
     scheduler._model_runner = None
     scheduler._stream_output_builder = None

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -259,6 +259,7 @@ def test_omni_scheduler_run_batch_failure_emits_error_and_aborts(monkeypatch) ->
     scheduler.forward_ct = 0
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
 
     batch = SimpleNamespace(
         reqs=[
@@ -458,6 +459,7 @@ def test_omni_scheduler_custom_runner_advances_forward_ct() -> None:
     scheduler._model_runner = FakeModelRunner()
     scheduler._stream_output_builder = None
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler.forward_ct = 0
 
     def _batch():
@@ -580,6 +582,7 @@ def test_omni_scheduler_abort_propagates_immediate_kv_cleanup_failure(
     scheduler._dirty_deferred_request_ids = set()
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler.inbox = Queue()
     scheduler.waiting_queue = []
     scheduler.tree_cache = object()
@@ -628,6 +631,7 @@ def test_omni_scheduler_abort_marks_running_request_for_finish(monkeypatch) -> N
     scheduler._dirty_deferred_request_ids = {"req-run"}
     scheduler._first_emit_done = {"req-run"}
     scheduler._prefill_start_done = {"req-run"}
+    scheduler._prefill_end_done = set()
     scheduler.inbox = Queue()
     scheduler.waiting_queue = []
 
@@ -686,6 +690,7 @@ def test_omni_scheduler_abort_cleans_queued_request_immediately(monkeypatch) -> 
     scheduler._dirty_deferred_request_ids = set()
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler.inbox = Queue()
 
     req = SimpleNamespace(rid="req-wait")
@@ -716,6 +721,7 @@ def test_omni_scheduler_abort_treats_retracted_alias_as_waiting_owned() -> None:
     scheduler._dirty_deferred_request_ids = set()
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler.inbox = Queue()
     scheduler.tree_cache = None
 
@@ -780,6 +786,7 @@ def test_omni_scheduler_flushes_stream_before_terminal_result(monkeypatch) -> No
     scheduler._aborted_request_ids = set()
     scheduler._first_emit_done = {"req-finished"}
     scheduler._prefill_start_done = {"req-finished"}
+    scheduler._prefill_end_done = set()
     calls: list[str] = []
     model_path_ends: list[tuple[str, str]] = []
     monkeypatch.setattr(
@@ -861,6 +868,7 @@ def test_omni_scheduler_fish_abort_during_step_suppresses_chunk_and_result() -> 
     scheduler._dirty_deferred_request_ids = set()
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler._stream_output_builder = stream_output_builder
 
     def tracking_result_adapter(data):
@@ -931,6 +939,7 @@ def test_stream_output_drains_runner_before_terminal_payload() -> None:
     scheduler._aborted_request_ids = set()
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler._result_adapter = lambda data: {"ok": True}
     scheduler.server_args = SimpleNamespace(weight_version=None)
 
@@ -967,6 +976,7 @@ def test_stream_output_cleans_request_when_runner_finish_hook_fails() -> None:
     scheduler._aborted_request_ids = set()
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler.server_args = SimpleNamespace(weight_version=None)
     cleanup_calls: list[str] = []
     scheduler._request_finished_callback = cleanup_calls.append
@@ -1003,6 +1013,7 @@ def test_stream_output_releases_request_when_terminal_flush_fails() -> None:
     scheduler._aborted_request_ids = set()
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler.server_args = SimpleNamespace(weight_version=None)
     cleanup_calls: list[str] = []
     scheduler._request_finished_callback = cleanup_calls.append
@@ -1108,6 +1119,7 @@ def test_stream_output_atomically_claims_request_data_against_abort() -> None:
     scheduler._dirty_deferred_request_ids = set()
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     abort_cleanup: list[str] = []
     finished_cleanup: list[str] = []
     scheduler._abort_callback = abort_cleanup.append
@@ -1162,6 +1174,7 @@ def test_abort_after_terminal_close_runs_its_own_cleanup() -> None:
     scheduler._dirty_deferred_request_ids = set()
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler.waiting_queue = []
     scheduler.tree_cache = None
     cleaned: list[str] = []
@@ -1224,6 +1237,7 @@ def test_abort_publishes_request_id_before_marking_terminal_finish() -> None:
     scheduler._dirty_deferred_request_ids = set()
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     cleaned: list[str] = []
     scheduler._abort_callback = cleaned.append
     scheduler._request_finished_callback = None
@@ -1307,6 +1321,7 @@ def test_terminal_request_data_is_collectable_without_cyclic_gc() -> None:
     scheduler._aborted_request_ids = set()
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler._result_adapter = lambda _data: None
     scheduler.server_args = SimpleNamespace(weight_version=None)
 
@@ -1347,6 +1362,7 @@ def test_stream_output_skips_runner_hook_for_aborted_requests() -> None:
     scheduler._abort_callback = None
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler._model_runner = SimpleNamespace(
         on_request_finished=lambda rid, _data: calls.append(rid)
     )
@@ -1375,6 +1391,7 @@ def test_stream_output_closes_late_stream_ingress() -> None:
     scheduler._aborted_request_ids = set()
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler._result_adapter = lambda _data: {"ok": True}
     scheduler.server_args = SimpleNamespace(weight_version=None)
 
@@ -1464,6 +1481,7 @@ def test_stream_output_drops_stale_terminal_alias_without_raising() -> None:
     scheduler._aborted_request_ids = set()
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
 
     req = SimpleNamespace(
         rid="req-stale-terminal",
@@ -1493,6 +1511,7 @@ def test_omni_scheduler_abort_caps_aborted_id_set() -> None:
     scheduler._dirty_deferred_request_ids = set()
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler.inbox = Queue()
     scheduler.waiting_queue = []
     scheduler.running_batch = SimpleNamespace(reqs=[], batch_is_full=False)
@@ -1535,6 +1554,7 @@ def test_omni_scheduler_distinguishes_queue_enter_from_prefill_start(
     scheduler._aborted_request_ids = set()
     scheduler._aborted_request_id_order = deque()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler.max_req_len = 16
     scheduler.max_req_input_len = 16
     _init_sync_request_build_state(scheduler)
@@ -1936,6 +1956,7 @@ def test_omni_scheduler_start_closes_active_model_paths(
     scheduler.enable_async_decode = False
     scheduler.enable_overlap = False
     scheduler._prefill_start_done = {"req-1", "req-2"}
+    scheduler._prefill_end_done = set()
     scheduler._request_build_executor = None
     scheduler._shutdown_lock = threading.Lock()
     scheduler._shutdown_callback = None
@@ -1976,6 +1997,7 @@ def test_omni_scheduler_request_builder_errors_do_not_stop_loop() -> None:
     scheduler._abort_callback = None
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler.inbox = Queue()
     scheduler.tree_cache = None
     _init_sync_request_build_state(scheduler)
@@ -2012,6 +2034,7 @@ def test_omni_scheduler_follower_request_builder_errors_do_not_emit() -> None:
     scheduler._abort_callback = None
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler.inbox = Queue()
     scheduler.tree_cache = None
     _init_sync_request_build_state(scheduler)
@@ -2087,6 +2110,7 @@ def test_omni_scheduler_rejects_custom_request_over_context() -> None:
     scheduler._abort_callback = None
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler.inbox = Queue()
     scheduler.tree_cache = None
     _init_sync_request_build_state(scheduler)
@@ -2135,6 +2159,7 @@ def test_omni_scheduler_follower_rejections_do_not_emit_errors() -> None:
     scheduler._abort_callback = None
     scheduler._first_emit_done = set()
     scheduler._prefill_start_done = set()
+    scheduler._prefill_end_done = set()
     scheduler.inbox = Queue()
     scheduler.tree_cache = None
     scheduler.max_req_len = 6
@@ -2234,6 +2259,7 @@ def test_omni_scheduler_result_adapter_failure_emits_error_without_raise(
     scheduler._aborted_request_ids = set()
     scheduler._first_emit_done = {"req-adapter"}
     scheduler._prefill_start_done = {"req-adapter"}
+    scheduler._prefill_end_done = set()
     model_path_ends: list[tuple[str, str]] = []
     monkeypatch.setattr(
         omni_scheduler_module,
@@ -2305,6 +2331,7 @@ def test_omni_scheduler_running_abort_does_not_leak_prefill_dedup_state(
     scheduler._dirty_deferred_request_ids = set()
     scheduler._first_emit_done = {"req-1"}
     scheduler._prefill_start_done = {"req-1"}
+    scheduler._prefill_end_done = set()
     scheduler._drain_inbox_for_request = lambda _rid: None
 
     scheduler.abort("req-1")

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -265,6 +265,7 @@ def test_stage_stop_waits_for_scheduler_model_path_terminalization(
         scheduler.enable_async_decode = False
         scheduler.enable_overlap = False
         scheduler._prefill_start_done = {"req-active"}
+        scheduler._prefill_end_done = set()
         scheduler._request_build_executor = None
         scheduler._shutdown_lock = threading.Lock()
         scheduler._shutdown_callback = None
@@ -311,6 +312,7 @@ def test_stage_stop_warns_but_succeeds_on_a_stuck_scheduler_thread(
         scheduler.enable_async_decode = False
         scheduler.enable_overlap = False
         scheduler._prefill_start_done = set()
+        scheduler._prefill_end_done = set()
         scheduler._request_build_executor = None
         scheduler._shutdown_lock = threading.Lock()
         scheduler._shutdown_callback = None

--- a/tests/unit_test/profiler/test_views.py
+++ b/tests/unit_test/profiler/test_views.py
@@ -375,7 +375,17 @@ def test_stage_breakdown_uses_prefill_start_not_queue_enter(
         ].total_ms
         == 5.0
     )
-    assert all("scheduler_queue_enter->" not in r.interval_name for r in rows)
+    # note (luojiaxuan): queue wait is now its own interval (issue #1324
+    # Q-PR2); TTFT-style intervals must still open at prefill_start only.
+    assert (
+        by_key[("thinker", "scheduler_queue_enter->scheduler_prefill_start")].total_ms
+        == 5.0
+    )
+    assert all(
+        not r.interval_name.startswith("scheduler_queue_enter->")
+        or r.interval_name == "scheduler_queue_enter->scheduler_prefill_start"
+        for r in rows
+    )
 
 
 def test_build_report_returns_all_three_views(tmp_path: Path) -> None:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -2590,6 +2590,7 @@ def test_qwen3_tts_ar_scheduler_abort_cleans_prepared_state() -> None:
         scheduler._dirty_deferred_request_ids = set()
         scheduler._first_emit_done = set()
         scheduler._prefill_start_done = set()
+        scheduler._prefill_end_done = set()
         scheduler.waiting_queue = []
         scheduler._request_admission_lock = threading.RLock()
         scheduler._request_build_executor = None

--- a/tests/unit_test/zonos2/test_state_lifecycle.py
+++ b/tests/unit_test/zonos2/test_state_lifecycle.py
@@ -125,6 +125,7 @@ def test_length_terminal_releases_pool_row_through_scheduler_result_path() -> No
     scheduler._request_finished_callback = None
     scheduler._first_emit_done = {request_id}
     scheduler._prefill_start_done = {request_id}
+    scheduler._prefill_end_done = set()
     scheduler._result_adapter = result_adapter
     scheduler._model_runner = None
     scheduler._stream_output_builder = None


### PR DESCRIPTION
## Motivation

Q-PR2 of #1324. Reproduces the reported high-concurrency serving gap on current main with a pinned environment and enough internal telemetry to attribute request time to request build, admission queueing, encoder+prefill, and decode. These results are the before-baseline for Q-PR4 and Q-PR5 (Q-PR3 landed as #1326).

## Modifications

- `benchmarks/eval/benchmark_asr_seedtts.py`: adds `--save-raw-dir` (raw per-request JSONL), `--profile-events` (one extra profiled pass per concurrency with the stage/hop breakdown attached), `--sample-util` (host CPU + GPU utilization), `--fingerprint` (git/dependency/driver/model-revision identity), and surfaces p50 latency.
- New `benchmarks/eval/asr_profiling.py`: profile-control client, breakdown builder, utilization sampler, environment fingerprint (all dependency-light, unit-tested).
- Profiler: pairs queue-wait, build-to-queued, first-forward, and decode-tail intervals; emits `scheduler_prefill_end` once per request after its first executed batch (realized batch size in metadata) so non-streaming models get a prefill/decode split.
- Docs: `docs/developer_reference/qwen3_asr_concurrency_profile.md` report + cookbook pointer.

## Results

Single H100 80 GB per server, DP=1, full SeedTTS sets, one discarded warmup + three measured repeats, identical pre-segmented audio through the same client. Full tables and methodology in the doc; highlights:

Current, quiet host (EN 1088):

| conc | req/s | lat mean | lat p95 | WER | completed |
|---:|---:|---:|---:|---:|---:|
| 32 | 108.0 | 0.295s | 0.399s | 0.0122 | 3264/3264 |
| 64 | 103.0 | 0.610s | 0.741s | 0.0125 | 3165/3264 |

Current vs baseline, back-to-back same-host windows (EN):

| conc | current req/s | baseline req/s | ratio |
|---:|---:|---:|---:|
| 8 | 41.9 | 70.3 | 1.68x |
| 16 | 62.6 | 120.6 | 1.93x |
| 32 | 79.5 | 183.8 | 2.31x |
| 64 | 80.9 | 264.6 | 3.27x |

ZH tracks the same shape (2.7-3.2x); WER/CER stay in band everywhere; baseline completes 100% at c=64 while current sheds 1-2%.

Bottleneck decomposition (profiled passes): at c=64 admission queue wait explodes from ~6 ms to ~413 ms per request (the knee; `max_running_requests=32` + `request_build_max_pending=16`); the decode tail grows 55→~360 ms per request while GPU utilization stays at 33-54% (host-dispatch-bound, matching #907); encoder+prefill costs 28-46 ms per admission on the scheduler thread/default stream and stalls the running decode batch (Q-PR4 target); the build-to-queued FIFO gap reaches 16-30 ms (Q-PR5 scope).

## Validation

- 169 unit tests pass (profiler, benchmarks, qwen3_asr, scheduling) on the pinned H100 environment; repository pre-commit passes.
- The new telemetry is emit-gated: with no active profile run the added event path is a no-op, and measured repeats never run with profiling enabled.
- Raw per-request records, profiler event JSONL, and environment fingerprints for every table are preserved on the measurement host.