### PR TITLE
[Perf][MOSS-TTS] Batch and cache reference encoding

### DIFF
--- a/sglang_omni/models/moss_tts/config.py
+++ b/sglang_omni/models/moss_tts/config.py
@@ -8,6 +8,8 @@ from typing import ClassVar
 from sglang_omni.config import PipelineConfig, StageConfig
 
 _PKG = "sglang_omni.models.moss_tts"
+_REF_AUDIO_CACHE_MAX_ITEMS = 8192
+_REF_AUDIO_CACHE_MAX_BYTES = 64 * 1024 * 1024
 
 
 class MossTTSPipelineConfig(PipelineConfig):
@@ -60,7 +62,12 @@ class MossTTSPipelineConfig(PipelineConfig):
             name="preprocessing",
             process="pipeline",
             factory=f"{_PKG}.stages.create_preprocessing_executor",
-            factory_args={"dtype": "float32"},
+            factory_args={
+                "dtype": "float32",
+                "ref_audio_cache": True,
+                "ref_audio_cache_max_items": _REF_AUDIO_CACHE_MAX_ITEMS,
+                "ref_audio_cache_max_bytes": _REF_AUDIO_CACHE_MAX_BYTES,
+            },
             gpu=0,
             next="tts_engine",
         ),

--- a/sglang_omni/models/moss_tts/request_builders.py
+++ b/sglang_omni/models/moss_tts/request_builders.py
@@ -7,6 +7,7 @@ import collections
 import hashlib
 import os
 import re
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import Any
@@ -129,6 +130,17 @@ class MossTTSPreprocessingContext:
 _QUEUE: PreparedRequestQueue[MossTTSPreprocessingContext, MossTTSPreparedRequest] = (
     PreparedRequestQueue()
 )
+_CONTEXT_LIFECYCLE_LOCK = threading.Lock()
+
+
+def _close_moss_tts_preprocessing_context(
+    context: MossTTSPreprocessingContext | None,
+) -> None:
+    if context is None:
+        return
+    close = getattr(context.reference_encoder, "close", None)
+    if callable(close):
+        close()
 
 
 def set_moss_tts_preprocessing_context(
@@ -136,18 +148,26 @@ def set_moss_tts_preprocessing_context(
 ) -> None:
     """Register the upstream MOSS processor used by preprocessing."""
 
-    _QUEUE.set_context(
-        MossTTSPreprocessingContext(
-            processor=processor,
-            reference_encoder=reference_encoder,
+    with _CONTEXT_LIFECYCLE_LOCK:
+        previous = _QUEUE.snapshot().context
+        _QUEUE.set_context(
+            MossTTSPreprocessingContext(
+                processor=processor,
+                reference_encoder=reference_encoder,
+            )
         )
-    )
+        if previous is not None and previous.reference_encoder is reference_encoder:
+            return
+        _close_moss_tts_preprocessing_context(previous)
 
 
 def clear_moss_tts_preprocessing_context() -> None:
     """Clear MOSS-TTS preprocessing globals, mainly for tests and reloads."""
 
-    _QUEUE.clear_context()
+    with _CONTEXT_LIFECYCLE_LOCK:
+        previous = _QUEUE.snapshot().context
+        _QUEUE.clear_context()
+        _close_moss_tts_preprocessing_context(previous)
 
 
 def cleanup_prepared_moss_tts_request(request_id: str) -> None:

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -3,9 +3,14 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import logging
 import os
-from typing import Any
+import queue
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, TypeAlias, cast
 
 import torch
 from transformers import AutoConfig, AutoTokenizer
@@ -32,13 +37,18 @@ from sglang_omni.models.moss_tts.request_builders import (
     set_moss_tts_preprocessing_context,
 )
 from sglang_omni.models.moss_tts.streaming_vocoder import MossStreamingVocoderScheduler
+from sglang_omni.preprocessing.cache_key import hash_bytes
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.pipeline_state import build_usage
 from sglang_omni.scheduling.pipeline_state import load_state as _load_pipeline_state
 from sglang_omni.scheduling.pipeline_state import store_state as _store_pipeline_state
+from sglang_omni.scheduling.reference_encoder import (
+    ReferenceEncodeService,
+    TensorReferenceEncodeHook,
+)
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from sglang_omni.scheduling.vocoder_base import BatchVocoderBase
-from sglang_omni.utils.audio import load_audio
+from sglang_omni.utils.audio import audio_fingerprint, load_audio
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 
 logger = logging.getLogger(__name__)
@@ -48,6 +58,21 @@ _MOSS_TTS_INSTALL_HINT = (
     "Launch with trust_remote_code=True and make sure the checkpoint can load "
     "OpenMOSS-Team/MOSS-Audio-Tokenizer."
 )
+_MAX_REFERENCE_SECONDS = 100.0
+_MOSS_TTS_REFERENCE_ENCODE_STOP = object()
+
+
+@dataclass(frozen=True, eq=False)
+class _LoadedReferenceWaveform:
+    waveform: torch.Tensor
+    sample_rate: int
+    content_key: str
+
+
+_ReferenceEncodeQueueEntry: TypeAlias = tuple[
+    _LoadedReferenceWaveform,
+    concurrent.futures.Future[torch.Tensor],
+]
 
 
 def load_state(payload: StagePayload) -> MossTTSState:
@@ -135,24 +160,269 @@ def _resolve_codec_device(device: str | None, gpu_id: int | None) -> str:
     return "cuda:0"
 
 
-class _MossTTSReferenceEncoder:
-    """Reference-encode boundary backed by a standalone audio tokenizer."""
+class _BatchedReferenceEncoder:
+    """Coalesce concurrent Delay reference encodes into codec batches."""
 
-    def __init__(self, audio_tokenizer: MossTTSAudioTokenizer, *, n_vq: int) -> None:
-        self.audio_tokenizer = audio_tokenizer
-        self.n_vq = int(n_vq)
+    MAX_REFERENCE_SECONDS = _MAX_REFERENCE_SECONDS
+    ENCODE_TIMEOUT_S = 120.0
+
+    def __init__(
+        self,
+        audio_tokenizer: MossTTSAudioTokenizer,
+        *,
+        n_vq: int,
+        max_batch_size: int = 8,
+        max_batch_wait_ms: int = 4,
+    ) -> None:
+        self._audio_tokenizer = audio_tokenizer
+        self._n_vq = int(n_vq)
+        self._max_batch_size = max(int(max_batch_size), 1)
+        self._max_wait_s = max(float(max_batch_wait_ms), 0.0) / 1000.0
+        self._queue: queue.Queue[object] = queue.Queue()
+        self._lifecycle_lock = threading.Lock()
+        self._closed = False
+        self._thread = threading.Thread(
+            target=self._worker,
+            name="moss-tts-ref-encode",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def close(self) -> None:
+        """Stop the codec worker after all already-queued jobs finish."""
+        with self._lifecycle_lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._queue.put(_MOSS_TTS_REFERENCE_ENCODE_STOP)
+        self._thread.join(timeout=5.0)
+
+    def load(self, source: str | os.PathLike[str]) -> _LoadedReferenceWaveform:
+        with self._lifecycle_lock:
+            if self._closed:
+                raise RuntimeError("MOSS-TTS reference encoder is closed")
+        return _load_reference_waveform(self._audio_tokenizer, source)
 
     def encode(self, source: str | os.PathLike[str]) -> torch.Tensor:
-        waveform = load_audio(
-            os.fsdecode(source),
-            source_name="MOSS-TTS reference",
-            target_sample_rate=self.audio_tokenizer.sample_rate,
-            mono=True,
+        return self.encode_input(self.load(source))
+
+    def encode_input(self, item: _LoadedReferenceWaveform) -> torch.Tensor:
+        future: concurrent.futures.Future[torch.Tensor] = concurrent.futures.Future()
+        with self._lifecycle_lock:
+            if self._closed:
+                raise RuntimeError("MOSS-TTS reference encoder is closed")
+            self._queue.put((item, future))
+        return future.result(timeout=self.ENCODE_TIMEOUT_S)
+
+    def _drain_batch(
+        self,
+    ) -> tuple[list[_ReferenceEncodeQueueEntry], bool]:
+        first = self._queue.get()
+        if first is _MOSS_TTS_REFERENCE_ENCODE_STOP:
+            return [], True
+        batch = [cast(_ReferenceEncodeQueueEntry, first)]
+        deadline = time.monotonic() + self._max_wait_s
+        shutdown = False
+        while len(batch) < self._max_batch_size:
+            try:
+                if self._max_wait_s > 0:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        break
+                    queued = self._queue.get(timeout=remaining)
+                else:
+                    queued = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            if queued is _MOSS_TTS_REFERENCE_ENCODE_STOP:
+                shutdown = True
+                break
+            batch.append(cast(_ReferenceEncodeQueueEntry, queued))
+        return batch, shutdown
+
+    def _worker(self) -> None:
+        while True:
+            batch, shutdown = self._drain_batch()
+            if not batch:
+                return
+            try:
+                results = self._encode_batch(batch)
+            except BaseException as exc:
+                logger.exception("MOSS-TTS reference encode worker failed")
+                results = {index: exc for index in range(len(batch))}
+            for index, (_, future) in enumerate(batch):
+                outcome = results.get(index)
+                if isinstance(outcome, BaseException):
+                    future.set_exception(
+                        RuntimeError(f"reference encode failed: {outcome}")
+                    )
+                elif outcome is None:
+                    future.set_exception(
+                        RuntimeError("reference encode produced no codes")
+                    )
+                else:
+                    future.set_result(outcome)
+            if shutdown:
+                return
+
+    def _encode_batch(
+        self,
+        batch: list[_ReferenceEncodeQueueEntry],
+    ) -> dict[int, torch.Tensor | BaseException]:
+        results: dict[int, torch.Tensor | BaseException] = {}
+        group_indices: list[list[int]] = []
+        waveforms: list[tuple[torch.Tensor, int]] = []
+        content_to_group: dict[str, int] = {}
+        for index, (job, _) in enumerate(batch):
+            group = content_to_group.get(job.content_key)
+            if group is None:
+                group = len(waveforms)
+                waveforms.append((job.waveform, job.sample_rate))
+                group_indices.append([])
+                content_to_group[job.content_key] = group
+            group_indices[group].append(index)
+
+        try:
+            encoded = self._audio_tokenizer.encode_waveforms(
+                waveforms,
+                num_quantizers=self._n_vq,
+            )
+            if len(encoded) != len(waveforms):
+                raise RuntimeError(
+                    "MOSS-TTS audio tokenizer returned an unexpected batch size: "
+                    f"{len(encoded)} != {len(waveforms)}"
+                )
+            for indices, codes in zip(group_indices, encoded):
+                for index in indices:
+                    results[index] = codes
+            return results
+        except Exception:
+            logger.exception(
+                "MOSS-TTS batched reference encode failed; retrying per item"
+            )
+
+        for indices, waveform in zip(group_indices, waveforms):
+            try:
+                codes = self._audio_tokenizer.encode_waveforms(
+                    [waveform],
+                    num_quantizers=self._n_vq,
+                )[0]
+            except Exception as exc:
+                codes = exc
+            for index in indices:
+                results[index] = codes
+        return results
+
+
+def _load_reference_waveform(
+    audio_tokenizer: MossTTSAudioTokenizer,
+    source: str | os.PathLike[str],
+) -> _LoadedReferenceWaveform:
+    """Load once through the shared resolver and key the exact codec input."""
+
+    waveform = load_audio(
+        os.fsdecode(source),
+        source_name="MOSS-TTS reference",
+        target_sample_rate=audio_tokenizer.sample_rate,
+        mono=True,
+    )
+    duration = len(waveform) / max(audio_tokenizer.sample_rate, 1)
+    if duration > _MAX_REFERENCE_SECONDS:
+        raise ValueError(
+            f"reference audio is {duration:.1f}s long, limit is "
+            f"{_MAX_REFERENCE_SECONDS:.0f}s"
         )
-        return self.audio_tokenizer.encode_waveforms(
-            [(torch.from_numpy(waveform), self.audio_tokenizer.sample_rate)],
-            num_quantizers=self.n_vq,
-        )[0]
+    return _LoadedReferenceWaveform(
+        torch.from_numpy(waveform),
+        audio_tokenizer.sample_rate,
+        f"waveform:{audio_fingerprint(waveform)}",
+    )
+
+
+class _MossTTSReferenceEncodeHook(TensorReferenceEncodeHook[_LoadedReferenceWaveform]):
+    model_id = "moss_tts_delay"
+    encoder_id = "moss_audio_tokenizer"
+    artifact_kind = "moss_tts_reference_codes"
+    storage_dtype = torch.int32
+    output_dtype = torch.long
+
+    def __init__(
+        self,
+        encoder: _BatchedReferenceEncoder,
+        *,
+        codec_model_path: str,
+        n_vq: int,
+    ) -> None:
+        self._encoder = encoder
+        self.model_revision = str(codec_model_path)
+        model = getattr(encoder._audio_tokenizer, "model", None)
+        try:
+            parameter_dtype = str(next(model.parameters()).dtype)
+        except (AttributeError, StopIteration):
+            parameter_dtype = "unknown"
+        config = (
+            f"n_vq:{int(n_vq)}|sample_rate:"
+            f"{getattr(encoder._audio_tokenizer, 'sample_rate', 'unknown')}|device:"
+            f"{getattr(encoder._audio_tokenizer, 'device', 'unknown')}|dtype:"
+            f"{parameter_dtype}"
+        )
+        self.encoder_config_hash = hash_bytes(config.encode("utf-8"))
+
+    def normalize_input(self, raw_input: Any) -> _LoadedReferenceWaveform:
+        if isinstance(raw_input, _LoadedReferenceWaveform):
+            return raw_input
+        # The service needs content identity before lookup; derive it only after
+        # load_audio has resolved and normalized the source.
+        return self._encoder.load(raw_input)
+
+    def input_key(self, item: _LoadedReferenceWaveform) -> str:
+        return item.content_key
+
+    def encode_one(self, item: _LoadedReferenceWaveform) -> torch.Tensor:
+        return self._encoder.encode_input(item)
+
+    def close(self) -> None:
+        close = getattr(self._encoder, "close", None)
+        if callable(close):
+            close()
+
+
+class _MossTTSReferenceEncoder:
+    """Load each source, then cache/merge codec work by waveform identity."""
+
+    def __init__(
+        self,
+        encoder: _BatchedReferenceEncoder,
+        *,
+        codec_model_path: str,
+        n_vq: int,
+        max_items: int | None = 8192,
+        max_bytes: int | None = 64 * 1024 * 1024,
+    ) -> None:
+        self._service = ReferenceEncodeService(
+            _MossTTSReferenceEncodeHook(
+                encoder,
+                codec_model_path=codec_model_path,
+                n_vq=n_vq,
+            ),
+            max_items=max_items,
+            max_bytes=max_bytes,
+            timeout_s=_BatchedReferenceEncoder.ENCODE_TIMEOUT_S + 10,
+            log_prefix="MOSS-TTS ref cache",
+        )
+
+    def encode(self, source: str | os.PathLike[str]) -> torch.Tensor:
+        source = os.fsdecode(source)
+        return self._service.get_or_encode(
+            source,
+            desc="data-URI" if source.startswith("data:") else repr(source),
+        )
+
+    def stats(self) -> dict[str, int]:
+        return self._service.stats()
+
+    def close(self) -> None:
+        self._service.close()
 
 
 def create_preprocessing_executor(
@@ -162,26 +432,60 @@ def create_preprocessing_executor(
     gpu_id: int | None = None,
     dtype: str = "float32",
     codec_model_path: str | None = None,
-    max_concurrency: int = 8,
+    max_concurrency: int = 16,
+    encode_batch_size: int = 8,
+    encode_batch_wait_ms: int = 4,
+    ref_audio_cache: bool = True,
+    ref_audio_cache_max_items: int = 8192,
+    ref_audio_cache_max_bytes: int = 64 * 1024 * 1024,
 ) -> SimpleScheduler:
+    for name, value in (
+        ("ref_audio_cache_max_items", ref_audio_cache_max_items),
+        ("ref_audio_cache_max_bytes", ref_audio_cache_max_bytes),
+    ):
+        if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+            raise ValueError(f"{name} must be an integer >= 1; got {value!r}")
+
+    env_toggle = os.environ.get("MOSS_REF_AUDIO_CACHE")
+    if env_toggle is not None:
+        ref_audio_cache = env_toggle.strip().lower() not in (
+            "0",
+            "false",
+            "no",
+            "off",
+            "",
+        )
     device = _resolve_codec_device(device, gpu_id)
     processor = _load_moss_processor(model_path)
+    resolved_codec_model_path = _resolve_audio_tokenizer_model_path(
+        processor,
+        codec_model_path,
+    )
     audio_tokenizer = load_moss_tts_audio_tokenizer(
-        _resolve_audio_tokenizer_model_path(processor, codec_model_path),
+        resolved_codec_model_path,
         device=device,
         dtype=dtype,
     )
-    reference_encoder = _MossTTSReferenceEncoder(
+    reference_encoder: Any = _BatchedReferenceEncoder(
         audio_tokenizer,
         n_vq=int(processor.model_config.n_vq),
+        max_batch_size=encode_batch_size,
+        max_batch_wait_ms=encode_batch_wait_ms,
     )
+    if ref_audio_cache:
+        reference_encoder = _MossTTSReferenceEncoder(
+            reference_encoder,
+            codec_model_path=resolved_codec_model_path,
+            n_vq=int(processor.model_config.n_vq),
+            max_items=ref_audio_cache_max_items,
+            max_bytes=ref_audio_cache_max_bytes,
+        )
     set_moss_tts_preprocessing_context(
         processor=processor,
         reference_encoder=reference_encoder,
     )
-    # Reference loading and text tokenization remain CPU-side, while the codec
-    # forward follows the preprocessing stage's GPU placement. Keep multiple
-    # workers so those CPU portions do not starve the AR engine.
+    # note (Zhang Yiyang): Every device uses the same batch queue; there is no
+    # device-specific fallback.
     return SimpleScheduler(
         preprocess_moss_tts_payload,
         abort_callback=cleanup_prepared_moss_tts_request,

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -129,7 +129,31 @@ def test_moss_tts_config_and_registry_contracts() -> None:
     preprocessing = next(
         stage for stage in config.stages if stage.name == "preprocessing"
     )
-    assert preprocessing.factory_args == {"dtype": "float32"}
+    assert "device" not in preprocessing.factory_args
+    assert preprocessing.factory_args["dtype"] == "float32"
+    assert preprocessing.factory_args["ref_audio_cache"] is True
+    assert preprocessing.factory_args["ref_audio_cache_max_items"] == 8192
+    assert preprocessing.factory_args["ref_audio_cache_max_bytes"] == 64 * 1024 * 1024
+
+
+def test_moss_tts_config_merge_updates_reference_cache_factory_args() -> None:
+    from sglang_omni.config.manager import ConfigManager
+
+    config = MossTTSPipelineConfig(model_path="model")
+    merged = ConfigManager(config).merge_config(
+        {
+            "stages.preprocessing.factory_args.ref_audio_cache": False,
+            "stages.preprocessing.factory_args.ref_audio_cache_max_items": 17,
+            "stages.preprocessing.factory_args.ref_audio_cache_max_bytes": 4096,
+        }
+    )
+    preprocessing = next(
+        stage for stage in merged.stages if stage.name == "preprocessing"
+    )
+
+    assert preprocessing.factory_args["ref_audio_cache"] is False
+    assert preprocessing.factory_args["ref_audio_cache_max_items"] == 17
+    assert preprocessing.factory_args["ref_audio_cache_max_bytes"] == 4096
 
 
 def test_moss_tts_preprocessing_factory_receives_placement_gpu_id() -> None:
@@ -151,6 +175,29 @@ def test_moss_tts_preprocessing_factory_receives_placement_gpu_id() -> None:
     assert preprocessing.gpu == 2
     assert factory_args["gpu_id"] == 2
     assert "device" not in factory_args
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"ref_audio_cache_max_items": 0}, "ref_audio_cache_max_items"),
+        ({"ref_audio_cache_max_bytes": 0}, "ref_audio_cache_max_bytes"),
+    ],
+)
+def test_moss_tts_preprocessing_rejects_invalid_reference_cache_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    kwargs,
+    match,
+) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    monkeypatch.setattr(
+        stages,
+        "_load_moss_processor",
+        lambda *_args, **_kwargs: pytest.fail("validation must precede model loading"),
+    )
+    with pytest.raises(ValueError, match=match):
+        stages.create_preprocessing_executor("model", **kwargs)
 
 
 def test_moss_tts_engine_uses_auto_mem_fraction_by_default(monkeypatch) -> None:
@@ -427,13 +474,18 @@ def test_moss_tts_preprocessing_loads_separate_codec(
     monkeypatch.setattr(stages, "load_moss_tts_audio_tokenizer", load_codec)
 
     try:
-        stages.create_preprocessing_executor("model", device="cpu")
+        stages.create_preprocessing_executor(
+            "model",
+            device="cpu",
+            ref_audio_cache=False,
+        )
         context = rb._QUEUE.snapshot().context
         assert context is not None
         assert context.processor is processor
         assert context.processor.audio_tokenizer is None
-        assert context.reference_encoder.audio_tokenizer is codec
-        assert context.reference_encoder.n_vq == 32
+        assert context.reference_encoder._audio_tokenizer is codec
+        assert context.reference_encoder._n_vq == 32
+        assert isinstance(context.reference_encoder, stages._BatchedReferenceEncoder)
     finally:
         rb.clear_moss_tts_preprocessing_context()
 
@@ -464,22 +516,18 @@ def test_moss_tts_preprocessing_uses_placement_gpu_id(
     monkeypatch.setattr(stages, "load_moss_tts_audio_tokenizer", load_codec)
 
     try:
-        stages.create_preprocessing_executor("model", gpu_id=2)
+        stages.create_preprocessing_executor(
+            "model",
+            gpu_id=2,
+            ref_audio_cache=False,
+        )
         context = rb._QUEUE.snapshot().context
         assert context is not None
-        assert context.reference_encoder.audio_tokenizer is codec
-
-        stages.create_preprocessing_executor("model", device="cpu", gpu_id=2)
-        context = rb._QUEUE.snapshot().context
-        assert context is not None
-        assert context.reference_encoder.audio_tokenizer is codec
+        assert isinstance(context.reference_encoder, stages._BatchedReferenceEncoder)
     finally:
         rb.clear_moss_tts_preprocessing_context()
 
-    assert loaded == [
-        ("codec", "cuda:2", "float32"),
-        ("codec", "cpu", "float32"),
-    ]
+    assert loaded == [("codec", "cuda:2", "float32")]
 
 
 def test_moss_tts_pathlike_reference_uses_separate_codec() -> None:
@@ -504,54 +552,48 @@ def test_moss_tts_pathlike_reference_uses_separate_codec() -> None:
     assert encoded_paths == ["voice.wav"]
 
 
-@pytest.mark.parametrize(
-    "source",
-    [
-        "voice.wav",
-        "data:audio/wav;base64,UklGRg==",
-    ],
-)
-def test_moss_tts_reference_encoder_uses_shared_audio_loader(
+def test_moss_tts_preprocessing_reference_cache_toggles(
     monkeypatch: pytest.MonkeyPatch,
-    source: str,
 ) -> None:
+    from sglang_omni.models.moss_tts import request_builders as rb
     from sglang_omni.models.moss_tts import stages
 
-    encoded = torch.tensor([[7, 8]], dtype=torch.long)
-    load_calls: list[tuple[str, str, int, bool]] = []
-    encode_calls: list[tuple[list[tuple[torch.Tensor, int]], int]] = []
+    processor = SimpleNamespace(
+        audio_tokenizer=None,
+        model_config=SimpleNamespace(
+            n_vq=32,
+            audio_tokenizer_name_or_path="codec",
+        ),
+    )
+    codec = SimpleNamespace(sample_rate=24000, device="cpu", model=None)
+    monkeypatch.setattr(stages, "_load_moss_processor", lambda model_path: processor)
+    monkeypatch.setattr(stages, "load_moss_tts_audio_tokenizer", lambda *a, **k: codec)
 
-    class FakeAudioTokenizer:
-        sample_rate = 24000
+    try:
+        stages.create_preprocessing_executor(
+            "model",
+            device="cpu",
+            ref_audio_cache=False,
+        )
+        assert isinstance(
+            rb._QUEUE.snapshot().context.reference_encoder,
+            stages._BatchedReferenceEncoder,
+        )
 
-        def encode_waveforms(self, waveforms, *, num_quantizers):
-            encode_calls.append((waveforms, num_quantizers))
-            return [encoded]
+        monkeypatch.setenv("MOSS_REF_AUDIO_CACHE", "0")
+        stages.create_preprocessing_executor("model", device="cpu")
+        assert isinstance(
+            rb._QUEUE.snapshot().context.reference_encoder,
+            stages._BatchedReferenceEncoder,
+        )
 
-    def fake_load_audio(
-        audio_source,
-        *,
-        source_name,
-        target_sample_rate,
-        mono,
-    ):
-        load_calls.append((audio_source, source_name, target_sample_rate, mono))
-        return np.asarray([0.1, 0.2], dtype=np.float32)
-
-    monkeypatch.setattr(stages, "load_audio", fake_load_audio)
-    encoder = stages._MossTTSReferenceEncoder(FakeAudioTokenizer(), n_vq=2)
-
-    result = encoder.encode(source)
-
-    assert result is encoded
-    assert load_calls == [(source, "MOSS-TTS reference", 24000, True)]
-    assert len(encode_calls) == 1
-    waveforms, num_quantizers = encode_calls[0]
-    assert num_quantizers == 2
-    assert len(waveforms) == 1
-    waveform, sample_rate = waveforms[0]
-    assert waveform.tolist() == pytest.approx([0.1, 0.2])
-    assert sample_rate == 24000
+        monkeypatch.delenv("MOSS_REF_AUDIO_CACHE")
+        stages.create_preprocessing_executor("model", device="cpu")
+        cached = rb._QUEUE.snapshot().context.reference_encoder
+        assert isinstance(cached, stages._MossTTSReferenceEncoder)
+        assert cached._service._cache.max_size == 8192
+    finally:
+        rb.clear_moss_tts_preprocessing_context()
 
 
 def test_moss_tts_processor_load_preserves_codec_metadata(

--- a/tests/unit_test/moss_tts/test_reference_encoding.py
+++ b/tests/unit_test/moss_tts/test_reference_encoding.py
@@ -1,0 +1,632 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reference encoding, caching, and lifecycle tests for MOSS-TTS."""
+
+from __future__ import annotations
+
+import base64
+import concurrent.futures
+import struct
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+
+def test_moss_tts_reference_encoder_uses_shared_audio_loader(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    encoded = torch.tensor([[7, 8]], dtype=torch.long)
+    reference_bytes = b"reference audio"
+    reference_path = tmp_path / "voice.wav"
+    reference_path.write_bytes(reference_bytes)
+    load_calls: list[tuple[str, str, int, bool]] = []
+    encode_calls: list[tuple[list[tuple[torch.Tensor, int]], int]] = []
+    load_threads: list[str] = []
+    encode_threads: list[str] = []
+
+    class FakeAudioTokenizer:
+        sample_rate = 24000
+
+        def encode_waveforms(self, waveforms, *, num_quantizers):
+            encode_threads.append(threading.current_thread().name)
+            encode_calls.append((waveforms, num_quantizers))
+            return [encoded]
+
+    def fake_load_audio(
+        audio_source,
+        *,
+        source_name,
+        target_sample_rate,
+        mono,
+    ):
+        load_threads.append(threading.current_thread().name)
+        load_calls.append((audio_source, source_name, target_sample_rate, mono))
+        return np.asarray([0.1, 0.2], dtype=np.float32)
+
+    monkeypatch.setattr(stages, "load_audio", fake_load_audio)
+    encoder = stages._BatchedReferenceEncoder(
+        FakeAudioTokenizer(),
+        n_vq=2,
+        max_batch_wait_ms=0,
+    )
+    request.addfinalizer(encoder.close)
+
+    result = encoder.encode(reference_path)
+
+    assert result is encoded
+    assert load_calls == [(str(reference_path), "MOSS-TTS reference", 24000, True)]
+    assert len(encode_calls) == 1
+    waveforms, num_quantizers = encode_calls[0]
+    assert num_quantizers == 2
+    assert len(waveforms) == 1
+    waveform, sample_rate = waveforms[0]
+    assert waveform.tolist() == pytest.approx([0.1, 0.2])
+    assert sample_rate == 24000
+    assert load_threads == [threading.current_thread().name]
+    assert encode_threads == ["moss-tts-ref-encode"]
+
+
+def test_moss_tts_slow_reference_load_does_not_block_ready_reference(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    slow_started = threading.Event()
+    release_slow = threading.Event()
+    results: dict[str, torch.Tensor | BaseException] = {}
+    slow_source = "https://slow.test/ref.wav"
+    fast_source = "https://fast.test/ref.wav"
+
+    class FakeAudioTokenizer:
+        sample_rate = 24000
+
+        def encode_waveforms(self, waveforms, *, num_quantizers):
+            assert num_quantizers == 2
+            return [
+                torch.tensor([[int(waveform[0].item())]], dtype=torch.long)
+                for waveform, _ in waveforms
+            ]
+
+    def fake_load_audio(source, **kwargs):
+        del kwargs
+        if source == slow_source:
+            slow_started.set()
+            assert release_slow.wait(timeout=5)
+            return np.asarray([1.0], dtype=np.float32)
+        return np.asarray([2.0], dtype=np.float32)
+
+    monkeypatch.setattr(stages, "load_audio", fake_load_audio)
+    encoder = stages._BatchedReferenceEncoder(
+        FakeAudioTokenizer(),
+        n_vq=2,
+        max_batch_size=1,
+        max_batch_wait_ms=0,
+    )
+    request.addfinalizer(encoder.close)
+
+    def run(path: str) -> None:
+        try:
+            results[path] = encoder.encode(path)
+        except BaseException as exc:
+            results[path] = exc
+
+    slow = threading.Thread(target=run, args=(slow_source,))
+    fast = threading.Thread(target=run, args=(fast_source,))
+    slow.start()
+    assert slow_started.wait(timeout=5)
+    fast.start()
+    try:
+        fast.join(timeout=2)
+        assert not fast.is_alive()
+        assert int(results[fast_source][0, 0]) == 2
+    finally:
+        release_slow.set()
+        slow.join(timeout=5)
+        fast.join(timeout=5)
+
+    assert int(results[slow_source][0, 0]) == 1
+
+
+def test_moss_tts_batch_wait_uses_one_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    entries = [(object(), object()), (object(), object())]
+
+    class FakeQueue:
+        def __init__(self) -> None:
+            self.timeouts: list[float | None] = []
+
+        def get(self, timeout=None):
+            self.timeouts.append(timeout)
+            if entries:
+                return entries.pop(0)
+            raise stages.queue.Empty
+
+    fake_queue = FakeQueue()
+    encoder = object.__new__(stages._BatchedReferenceEncoder)
+    encoder._max_batch_size = 8
+    encoder._max_wait_s = 0.004
+    encoder._queue = fake_queue
+    clock = iter((10.0, 10.001, 10.003))
+    monkeypatch.setattr(stages.time, "monotonic", lambda: next(clock))
+
+    batch, shutdown = encoder._drain_batch()
+
+    assert len(batch) == 2
+    assert shutdown is False
+    assert fake_queue.timeouts[0] is None
+    assert fake_queue.timeouts[1:] == pytest.approx([0.003, 0.001])
+
+
+def test_moss_tts_batched_reference_encoder_close_is_idempotent() -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    codec = SimpleNamespace(sample_rate=24000)
+    encoder = stages._BatchedReferenceEncoder(codec, n_vq=2)
+    worker = encoder._thread
+
+    encoder.close()
+    encoder.close()
+
+    assert not worker.is_alive()
+    with pytest.raises(RuntimeError, match="reference encoder is closed"):
+        encoder.encode("unused.wav")
+
+
+def test_moss_tts_preprocessing_context_closes_replaced_encoder() -> None:
+    from sglang_omni.models.moss_tts import request_builders as rb
+    from sglang_omni.models.moss_tts import stages
+
+    codec = SimpleNamespace(sample_rate=24000, device="cuda:0", model=None)
+    first = stages._BatchedReferenceEncoder(codec, n_vq=2)
+    second_batcher = stages._BatchedReferenceEncoder(codec, n_vq=2)
+    second = stages._MossTTSReferenceEncoder(
+        second_batcher,
+        codec_model_path="codec",
+        n_vq=2,
+    )
+
+    try:
+        rb.set_moss_tts_preprocessing_context(
+            processor=object(), reference_encoder=first
+        )
+        rb.set_moss_tts_preprocessing_context(
+            processor=object(), reference_encoder=second
+        )
+        assert not first._thread.is_alive()
+        assert second_batcher._thread.is_alive()
+    finally:
+        rb.clear_moss_tts_preprocessing_context()
+
+    assert not second_batcher._thread.is_alive()
+
+
+def _make_moss_tts_wav_data_uri(
+    n_samples: int = 100,
+    sample_rate: int = 16000,
+) -> tuple[str, bytes]:
+    samples = b"\x00\x00" * n_samples
+    header = struct.pack(
+        "<4sI4s4sIHHIIHH4sI",
+        b"RIFF",
+        36 + len(samples),
+        b"WAVE",
+        b"fmt ",
+        16,
+        1,
+        1,
+        sample_rate,
+        sample_rate * 2,
+        2,
+        16,
+        b"data",
+        len(samples),
+    )
+    raw = header + samples
+    return f"data:audio/wav;base64,{base64.b64encode(raw).decode()}", raw
+
+
+def test_moss_tts_path_file_uri_and_data_uri_use_shared_audio_loader(
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    data_uri, raw = _make_moss_tts_wav_data_uri()
+    reference_path = tmp_path / "reference.wav"
+    reference_path.write_bytes(raw)
+    encoded_waveforms: list[tuple[torch.Tensor, int]] = []
+
+    class FakeAudioTokenizer:
+        sample_rate = 16000
+
+        def encode_waveforms(self, waveforms, *, num_quantizers):
+            assert num_quantizers == 2
+            encoded_waveforms.extend(waveforms)
+            return [torch.full((2, 2), 7, dtype=torch.long) for _ in waveforms]
+
+    encoder = stages._BatchedReferenceEncoder(
+        FakeAudioTokenizer(),
+        n_vq=2,
+        max_batch_wait_ms=0,
+    )
+    request.addfinalizer(encoder.close)
+
+    path_result = encoder.encode(reference_path)
+    file_uri_result = encoder.encode(reference_path.as_uri())
+    data_uri_result = encoder.encode(data_uri)
+
+    expected = torch.full((2, 2), 7, dtype=torch.long)
+    assert torch.equal(path_result, expected)
+    assert torch.equal(file_uri_result, expected)
+    assert torch.equal(data_uri_result, expected)
+    assert len(encoded_waveforms) == 3
+    for waveform, sample_rate in encoded_waveforms:
+        assert sample_rate == 16000
+        assert waveform.shape == (100,)
+        assert torch.count_nonzero(waveform) == 0
+
+
+def test_moss_tts_batched_reference_encoder_coalesces_and_isolates_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    calls: list[list[int]] = []
+    loaded_sources: list[str] = []
+    paths = {name: tmp_path / f"{name}.wav" for name in ("aa", "bbb", "bad1")}
+    for name, path in paths.items():
+        path.write_bytes(name.encode())
+
+    class FakeAudioTokenizer:
+        sample_rate = 24000
+        device = "cuda:0"
+
+        def encode_waveforms(self, waveforms, *, num_quantizers):
+            assert num_quantizers == 2
+            lengths = [int(wav.shape[-1]) for wav, _ in waveforms]
+            calls.append(lengths)
+            if 4 in lengths:
+                raise RuntimeError("cannot encode bad reference")
+            return [torch.full((length, 2), length) for length in lengths]
+
+    def fake_load_audio(source, **kwargs):
+        del kwargs
+        name = Path(source).read_text()
+        loaded_sources.append(name)
+        length = {"aa": 2, "bbb": 3, "bad1": 4}[name]
+        return np.full(length, length, dtype=np.float32)
+
+    monkeypatch.setattr(stages, "load_audio", fake_load_audio)
+    encoder = stages._BatchedReferenceEncoder(
+        FakeAudioTokenizer(),
+        n_vq=2,
+        max_batch_size=4,
+        max_batch_wait_ms=20,
+    )
+    request.addfinalizer(encoder.close)
+    results: dict[str, torch.Tensor | BaseException] = {}
+
+    def run(path: str) -> None:
+        try:
+            results[path] = encoder.encode(paths[path])
+        except BaseException as exc:
+            results[path] = exc
+
+    threads = [
+        threading.Thread(target=run, args=(path,)) for path in ("aa", "bbb", "bad1")
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert isinstance(results["bad1"], BaseException)
+    assert int(results["aa"][0, 0]) == 2
+    assert int(results["bbb"][0, 0]) == 3
+    assert sorted(loaded_sources) == ["aa", "bad1", "bbb"]
+    assert any(len(call) > 1 for call in calls)
+
+
+def test_moss_tts_batched_reference_encoder_deduplicates_same_batch(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    reference_path = tmp_path / "same.wav"
+    reference_path.write_bytes(b"same reference")
+    loaded_sources: list[str] = []
+    encode_batch_sizes: list[int] = []
+
+    class FakeAudioTokenizer:
+        sample_rate = 24000
+        device = "cuda:0"
+
+        def encode_waveforms(self, waveforms, *, num_quantizers):
+            assert num_quantizers == 2
+            encode_batch_sizes.append(len(waveforms))
+            return [torch.full((3, 2), 7) for _ in waveforms]
+
+    def fake_load_audio(source, **kwargs):
+        del kwargs
+        loaded_sources.append(str(source))
+        return np.zeros(3, dtype=np.float32)
+
+    monkeypatch.setattr(stages, "load_audio", fake_load_audio)
+    encoder = stages._BatchedReferenceEncoder(
+        FakeAudioTokenizer(),
+        n_vq=2,
+        max_batch_size=2,
+        max_batch_wait_ms=100,
+    )
+    request.addfinalizer(encoder.close)
+    barrier = threading.Barrier(2)
+
+    def run() -> torch.Tensor:
+        barrier.wait(timeout=5)
+        return encoder.encode(reference_path)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        results = [
+            future.result(timeout=10) for future in (pool.submit(run), pool.submit(run))
+        ]
+
+    assert all(torch.equal(result, torch.full((3, 2), 7)) for result in results)
+    assert loaded_sources == [str(reference_path), str(reference_path)]
+    assert encode_batch_sizes == [1]
+
+
+def test_moss_tts_path_replacement_keeps_content_versions_isolated(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    reference_path = tmp_path / "reference.wav"
+    reference_path.write_bytes(b"1")
+    old_load_started = threading.Event()
+    release_old_load = threading.Event()
+    load_calls: list[int] = []
+
+    class FakeAudioTokenizer:
+        sample_rate = 1
+        device = "cuda:0"
+        model = None
+
+        def encode_waveforms(self, waveforms, *, num_quantizers):
+            assert num_quantizers == 1
+            return [
+                torch.tensor([[int(waveform[0].item())]], dtype=torch.long)
+                for waveform, _ in waveforms
+            ]
+
+    def fake_load_audio(source, **kwargs):
+        del kwargs
+        value = int(Path(source).read_text())
+        load_calls.append(value)
+        if value == 1:
+            old_load_started.set()
+            assert release_old_load.wait(timeout=5)
+        return np.asarray([value], dtype=np.float32)
+
+    monkeypatch.setattr(stages, "load_audio", fake_load_audio)
+    batcher = stages._BatchedReferenceEncoder(
+        FakeAudioTokenizer(),
+        n_vq=1,
+        max_batch_size=2,
+        max_batch_wait_ms=0,
+    )
+    encoder = stages._MossTTSReferenceEncoder(
+        batcher,
+        codec_model_path="codec",
+        n_vq=1,
+        max_items=8,
+        max_bytes=4096,
+    )
+    request.addfinalizer(encoder.close)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        old_result = pool.submit(encoder.encode, reference_path)
+        assert old_load_started.wait(timeout=5)
+        reference_path.write_bytes(b"2")
+        new_result = pool.submit(encoder.encode, reference_path)
+        try:
+            assert int(new_result.result(timeout=2)[0, 0]) == 2
+        finally:
+            release_old_load.set()
+        assert int(old_result.result(timeout=5)[0, 0]) == 1
+
+    assert int(encoder.encode(reference_path)[0, 0]) == 2
+    assert load_calls == [1, 2, 2]
+    assert encoder.stats()["hits"] == 1
+    assert encoder.stats()["misses"] == 2
+    assert encoder.stats()["entries"] == 2
+
+
+def test_moss_tts_url_cache_tracks_fetched_waveform(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    loaded_values = iter((1.0, 2.0, 2.0))
+    encode_count = 0
+
+    class FakeAudioTokenizer:
+        sample_rate = 1
+        device = "cuda:0"
+        model = None
+
+        def encode_waveforms(self, waveforms, *, num_quantizers):
+            nonlocal encode_count
+            assert num_quantizers == 1
+            encode_count += 1
+            return [
+                torch.tensor([[int(waveform[0].item())]], dtype=torch.long)
+                for waveform, _ in waveforms
+            ]
+
+    def fake_load_audio(source, **kwargs):
+        del kwargs
+        assert source == "https://example.test/reference.wav"
+        return np.asarray([next(loaded_values)], dtype=np.float32)
+
+    monkeypatch.setattr(stages, "load_audio", fake_load_audio)
+    batcher = stages._BatchedReferenceEncoder(
+        FakeAudioTokenizer(),
+        n_vq=1,
+        max_batch_wait_ms=0,
+    )
+    encoder = stages._MossTTSReferenceEncoder(
+        batcher,
+        codec_model_path="codec",
+        n_vq=1,
+        max_items=8,
+        max_bytes=4096,
+    )
+    request.addfinalizer(encoder.close)
+
+    assert int(encoder.encode("https://example.test/reference.wav")[0, 0]) == 1
+    assert int(encoder.encode("https://example.test/reference.wav")[0, 0]) == 2
+    assert int(encoder.encode("https://example.test/reference.wav")[0, 0]) == 2
+    assert encode_count == 2
+    assert encoder.stats()["hits"] == 1
+    assert encoder.stats()["misses"] == 2
+    assert encoder.stats()["entries"] == 2
+
+
+def test_moss_tts_cached_reference_encoder_uses_loaded_waveform_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    data_uri, raw = _make_moss_tts_wav_data_uri()
+    ref = tmp_path / "ref.wav"
+    ref.write_bytes(raw)
+    load_calls: list[str] = []
+    encode_calls: list[list[tuple[torch.Tensor, int]]] = []
+    real_load_audio = stages.load_audio
+
+    class FakeAudioTokenizer:
+        sample_rate = 16000
+        device = "cuda:0"
+        model = None
+
+        def encode_waveforms(self, waveforms, *, num_quantizers):
+            assert num_quantizers == 2
+            encode_calls.append(waveforms)
+            return [torch.full((4, 2), 99, dtype=torch.long)]
+
+    def counting_load_audio(source, **kwargs):
+        load_calls.append(str(source))
+        return real_load_audio(source, **kwargs)
+
+    monkeypatch.setattr(stages, "load_audio", counting_load_audio)
+
+    batcher = stages._BatchedReferenceEncoder(
+        FakeAudioTokenizer(),
+        n_vq=2,
+        max_batch_wait_ms=0,
+    )
+    encoder = stages._MossTTSReferenceEncoder(
+        batcher,
+        codec_model_path="codec",
+        n_vq=2,
+        max_items=8,
+        max_bytes=4096,
+    )
+    request.addfinalizer(encoder.close)
+
+    first_path = encoder.encode(ref)
+    first_path.fill_(-1)
+    second_path = encoder.encode(ref)
+    first_uri = encoder.encode(data_uri)
+    first_uri.fill_(-1)
+    second_uri = encoder.encode(data_uri)
+
+    assert torch.all(second_path == 99)
+    assert torch.all(second_uri == 99)
+    assert load_calls == [str(ref), str(ref), data_uri, data_uri]
+    assert len(encode_calls) == 1
+    for waveforms in encode_calls:
+        assert len(waveforms) == 1
+        waveform, sample_rate = waveforms[0]
+        assert sample_rate == 16000
+        assert waveform.shape == (100,)
+    assert encoder.stats()["hits"] == 3
+    assert encoder.stats()["misses"] == 1
+    assert encoder.stats()["entries"] == 1
+
+
+def test_moss_tts_cached_reference_encoder_merges_inflight(tmp_path: Path) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    ref = tmp_path / "ref.wav"
+    ref.write_bytes(b"reference bytes")
+    entered = threading.Event()
+    release = threading.Event()
+    encode_count = 0
+
+    class FakeBatched:
+        class AudioTokenizer:
+            sample_rate = 24000
+            device = "cuda:0"
+            model = None
+
+        _audio_tokenizer = AudioTokenizer()
+
+        @staticmethod
+        def load(source):
+            del source
+            return stages._LoadedReferenceWaveform(
+                torch.zeros(4, dtype=torch.float32),
+                24000,
+                "waveform:shared",
+            )
+
+        def encode_input(self, item):
+            nonlocal encode_count
+            del item
+            encode_count += 1
+            entered.set()
+            assert release.wait(timeout=5)
+            return torch.ones((4, 2), dtype=torch.long)
+
+    encoder = stages._MossTTSReferenceEncoder(
+        FakeBatched(),
+        codec_model_path="codec",
+        n_vq=2,
+    )
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(encoder.encode, ref)
+        assert entered.wait(timeout=5)
+        second = pool.submit(encoder.encode, ref)
+        deadline = time.monotonic() + 5
+        while encoder.stats()["merged"] < 1 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        try:
+            assert encoder.stats()["merged"] == 1
+        finally:
+            release.set()
+        assert torch.equal(first.result(timeout=5), second.result(timeout=5))
+
+    assert encode_count == 1
+    assert encoder.stats()["merged"] == 1


### PR DESCRIPTION
## Motivation

MOSS-TTS Delay currently loads and encodes reference audio independently for every request. Under concurrent voice-cloning workloads, repeated references duplicate codec work, while different cold references issue one GPU codec forward per preprocessing worker.

Other TTS paths already use the shared `ReferenceEncodeService` pattern introduced by #748 and generalized in #926, #927, #1051, and #1096. This PR brings MOSS-TTS Delay onto the same content-addressed, byte-bounded, single-flight cache contract and adds model-local batching around the MOSS audio tokenizer's native `encode_waveforms` batch API.

## Modifications

- Add a MOSS-TTS `TensorReferenceEncodeHook` backed by `ReferenceEncodeService`:
  - cache-owned CPU `int32` tensors and caller-owned `torch.long` results;
  - model, codec revision, encoder configuration, artifact kind, and reference content in the cache identity;
  - byte-bounded LRU defaults of 8192 entries / 64 MiB;
  - same-key single-flight deduplication and cache statistics.
- Add GPU reference-encode batching:
  - drain up to 8 cold leaders with a single 4 ms deadline;
  - deduplicate identical content inside a batch;
  - retry per item after a batch failure so one bad reference does not fail unrelated requests;
  - keep loading/resampling outside the codec worker so a slow source does not block ready references.
- Preserve input and cache correctness:
  - pass local paths, file URIs, data URIs, and remote URLs through the shared `load_audio` path;
  - key codec artifacts by the mono, resampled waveform actually passed to the audio tokenizer;
  - safely reuse byte-identical normalized waveforms across different source representations;
  - isolate concurrent old/new versions when a local path is replaced;
  - cover source handling, path replacement, and cache-artifact mutation with tests.
- Remove the device-specific direct encoder: every preprocessing device uses the same batched reference-encode path, matching MOSS-TTS Local.
- Raise the preprocessing scheduler default concurrency from 8 to 16.
- Add stage-native cache controls and validate capacities before loading model components:
  - `ref_audio_cache`;
  - `ref_audio_cache_max_items`;
  - `ref_audio_cache_max_bytes`;
  - `MOSS_REF_AUDIO_CACHE` provides an operational kill switch.
- Close the reference worker when the preprocessing context is replaced or cleared; `close()` is idempotent and rejects submissions after shutdown.
- Split reference encoding/cache/lifecycle tests into `tests/unit_test/moss_tts/test_reference_encoding.py`.

## Related Issues

#1233 

## Accuracy Test

Full SeedTTS EN (1088 samples) was evaluated for each of the five selected paired rounds `{2, 3, 4, 5, 6}`. Every quality job evaluated 1088/1088 samples with no skips.

Raw per-round results are shown as `Baseline / Current`:

| Round | Corpus WER | Corpus WER, excluding samples with WER > 50% | Speaker Similarity | UTMOS |
|---:|---:|---:|---:|---:|
| 2 | 1.6495% / 1.4737% | 1.2359% / 1.3258% | 68.8680 / 68.9796 | 3.9326 / 3.9444 |
| 3 | 1.6411% / 1.4402% | 1.3436% / 1.1928% | 68.6905 / 69.0143 | 3.9310 / 3.9425 |
| 4 | 1.5239% / 1.5825% | 1.3006% / 1.2353% | 68.8399 / 69.0752 | 3.9434 / 3.9347 |
| 5 | 1.4485% / 1.9844% | 1.1673% / 1.4644% | 68.8695 / 69.1257 | 3.9432 / 3.9374 |
| 6 | 1.8337% / 1.7751% | 1.3634% / 1.3461% | 68.9248 / 68.9417 | 3.9338 / 3.9372 |

Five-round aggregates:

| Metric | Baseline mean | Current mean | Current - Baseline paired 95% CI |
|---|---:|---:|---:|
| Corpus WER | 1.6194% | 1.6512% | [-0.3408, +0.4045] pp |
| Corpus WER (excluding samples with WER > 50%) | 1.2822% | 1.3129% | [-0.1834, +0.2449] pp |
| Speaker Similarity | 68.8385 | 69.0273 | [+0.0361, +0.3414] |
| UTMOS | 3.9368 | 3.9392 | [-0.0094, +0.0143] |

The WER and UTMOS paired confidence intervals include zero. Speaker Similarity shows a small positive paired shift (+0.1888 absolute on average); the rerun does not show a quality regression.

Unit and contract validation:

- `tests/unit_test/moss_tts/test_reference_encoding.py`: 12 passed.
- `tests/unit_test/moss_tts/test_pipeline.py`: 52 passed.
- MOSS-TTS plus shared reference-service/audio-loader lane: 112 passed.
- Related-file pre-commit hooks and working-tree diff check: passed.

## Benchmark & Profiling

- Device: one NVIDIA H200 143 GB (physical GPU 4).
- Workload: full SeedTTS EN 1088/1088, concurrency 16, non-streaming voice cloning, `references`, token count `auto`, and the default benchmark seed.
- Lifecycle: a fresh offline service for every variant/round; model loading is excluded from measured time.
- Integrity: all six candidate pairs completed 13,056/13,056 generation requests with 13,056 valid 24 kHz mono PCM16 WAV files. The selected five pairs contain 10,880/10,880 successful requests.
- Selection: candidate rounds `[1, 2, 3, 4, 5, 6]` were paired by round number. `{2, 3, 4, 5, 6}` was the first eligible five-round subset in enumeration order; every candidate round and failed-subset audit is retained.
- Screening applies only to QPS, mean latency, P95 latency, and mean RTF, independently within each variant: `abs(modified-Z) > 3.5` or outside the Tukey 3xIQR extreme fences.

Raw candidate results are shown as `Baseline / Current`:

| Round | Selected | Throughput QPS | Mean latency (s) | P95 latency (s) | Mean RTF |
|---:|:---:|---:|---:|---:|---:|
| 1 | No | 6.681 / 8.987 | 2.387 / 1.773 | 2.907 / 2.191 | 0.5553 / 0.4109 |
| 2 | Yes | 6.711 / 8.943 | 2.377 / 1.780 | 2.946 / 2.183 | 0.5528 / 0.4129 |
| 3 | Yes | 6.850 / 8.994 | 2.328 / 1.771 | 2.880 / 2.201 | 0.5419 / 0.4110 |
| 4 | Yes | 7.053 / 9.029 | 2.261 / 1.765 | 2.791 / 2.222 | 0.5257 / 0.4093 |
| 5 | Yes | 6.998 / 8.989 | 2.279 / 1.772 | 2.803 / 2.185 | 0.5298 / 0.4113 |
| 6 | Yes | 6.731 / 9.045 | 2.369 / 1.761 | 3.080 / 2.174 | 0.5517 / 0.4083 |

Selected five-round aggregates:

| Metric | Baseline mean | Current mean | Improvement | Current - Baseline paired 95% CI |
|---|---:|---:|---:|---:|
| Throughput QPS | 6.868600 | 9.000000 | +31.03% | [+1.947773, +2.315027] |
| Mean latency | 2.322800 s | 1.769800 s | 23.81% lower | [-0.616136, -0.489864] s |
| P95 latency | 2.900000 s | 2.193000 s | 24.38% lower | [-0.871826, -0.542174] s |
| Mean RTF | 0.540380 | 0.410560 | 24.02% lower | [-0.144969, -0.114671] |

Paired confidence intervals are two-sided Student-t intervals over Current-minus-Baseline round differences (`df=4`). Selected-round prompt tokens were identical at 178,874 per round; mean total output tokens were 96,831.2 vs 96,829.0 and mean generated duration was 4.4800 s vs 4.4796 s.

For transparency, the selected Baseline QPS values have a 5.096% max/min span and 2.242% sample CV; Current has a 1.141% span and 0.440% sample CV. These are descriptive variability checks, not additional selection gates.

A separate host-side sanity microbenchmark on one 2.64-second 24 kHz WAV measured `load_audio + waveform fingerprint` capacity at 898.7 requests/s with concurrency 16 (1088 calls). This is a preprocessing-cost bound, not a replacement for the end-to-end GPU result above.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
