### PR TITLE
[ASR Feature] Auto-chunk long Qwen3-ASR audio

### DIFF
--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -75,7 +75,24 @@ print(resp.json()["text"])
 `verbose_json` is accepted, but currently returns the same minimal JSON shape as `json`:
 `{"text": "..."}`.
 
-`max_new_tokens` is supported inside the model request builder, but the public transcription endpoint does not currently expose it as a form field. The route uses the ASR stage default unless the pipeline is configured another way.
+`max_new_tokens` can be supplied as a multipart form field. The route uses the
+Qwen3-ASR stage default of 4,096 when it is omitted.
+
+## Long Audio
+
+Qwen3-ASR accepts up to 1,200 seconds of audio in one native model request.
+This is a model-owned limit rather than Whisper's 30-second feature-extractor
+window. Audio at or below the limit is therefore processed without serving-layer
+chunking.
+
+Longer uploads are decoded once, split at low-energy boundaries into
+non-overlapping chunks of at most 1,200 seconds, transcribed in order, and
+stitched into one response. This applies to blocking and streaming
+transcriptions. Chunk failures fail the whole upload instead of returning a
+transcript with a silent gap.
+
+Qwen3-ASR does not currently produce timestamped segments, so chunk offsets are
+not exposed in `verbose_json`.
 
 ## Benchmarking
 

--- a/sglang_omni/config/__init__.py
+++ b/sglang_omni/config/__init__.py
@@ -14,6 +14,7 @@ from sglang_omni.config.process_overrides import (
 )
 from sglang_omni.config.runtime import resolve_stage_factory_args
 from sglang_omni.config.schema import (
+    AudioChunkingConfig,
     CommConfig,
     EndpointsConfig,
     ParallelismConfig,
@@ -48,6 +49,7 @@ __all__ = [
     "ProcessGroupPlacement",
     "ProcessTopologyPlan",
     "build_process_topology_plan",
+    "AudioChunkingConfig",
     "PipelineConfig",
     "StageConfig",
     "ParallelismConfig",

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -212,6 +212,21 @@ class StageConfig(BaseModel):
             self.tp_size = self.parallelism.tp
 
 
+class AudioChunkingConfig(BaseModel):
+    """Per-model long-audio policy for the transcription endpoint."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    allow_audio_chunking: bool = False
+    max_audio_clip_s: float | None = Field(default=None, gt=0)
+
+    def model_post_init(self, __context: Any = None) -> None:
+        if self.allow_audio_chunking and self.max_audio_clip_s is None:
+            raise ValueError(
+                "max_audio_clip_s is required when audio chunking is enabled"
+            )
+
+
 class PipelineConfig(BaseModel):
     """Top-level pipeline configuration.
 
@@ -228,6 +243,7 @@ class PipelineConfig(BaseModel):
     required_speech_reference_count: ClassVar[int | None] = None
     speech_reference_text_required: ClassVar[bool] = False
     additional_speech_languages: ClassVar[frozenset[str]] = frozenset()
+    audio_chunking: ClassVar[AudioChunkingConfig] = AudioChunkingConfig()
 
     model_path: str
     stages: list[StageConfig]

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -225,6 +225,10 @@ class AudioChunkingConfig(BaseModel):
             raise ValueError(
                 "max_audio_clip_s is required when audio chunking is enabled"
             )
+        if not self.allow_audio_chunking and self.max_audio_clip_s is not None:
+            raise ValueError(
+                "max_audio_clip_s must be omitted when audio chunking is disabled"
+            )
 
 
 class PipelineConfig(BaseModel):

--- a/sglang_omni/models/qwen3_asr/audio_lengths.py
+++ b/sglang_omni/models/qwen3_asr/audio_lengths.py
@@ -7,6 +7,9 @@ from typing import Any
 
 import torch
 
+QWEN3_ASR_MAX_INPUT_SECONDS = 1200
+QWEN3_ASR_MEL_FRAMES_PER_SECOND = 100
+
 
 def qwen3_asr_audio_token_lengths(input_lengths: Any) -> torch.Tensor:
     """Return Qwen3-ASR encoder output lengths for mel-frame lengths.
@@ -26,7 +29,17 @@ def qwen3_asr_num_audio_tokens(num_mel_frames: int) -> int:
     return int(qwen3_asr_audio_token_lengths(num_mel_frames).item())
 
 
+def qwen3_asr_max_audio_tokens() -> int:
+    """Return the audio-token budget for the model-owned input duration limit."""
+    return qwen3_asr_num_audio_tokens(
+        QWEN3_ASR_MAX_INPUT_SECONDS * QWEN3_ASR_MEL_FRAMES_PER_SECOND
+    )
+
+
 __all__ = [
+    "QWEN3_ASR_MAX_INPUT_SECONDS",
+    "QWEN3_ASR_MEL_FRAMES_PER_SECOND",
     "qwen3_asr_audio_token_lengths",
+    "qwen3_asr_max_audio_tokens",
     "qwen3_asr_num_audio_tokens",
 ]

--- a/sglang_omni/models/qwen3_asr/config.py
+++ b/sglang_omni/models/qwen3_asr/config.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from sglang_omni.config import PipelineConfig, StageConfig
+from sglang_omni.config import AudioChunkingConfig, PipelineConfig, StageConfig
+from sglang_omni.models.qwen3_asr.audio_lengths import QWEN3_ASR_MAX_INPUT_SECONDS
 
 _PKG = "sglang_omni.models.qwen3_asr"
 
@@ -14,6 +15,10 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
     """Single-stage batched ASR pipeline for Qwen3-ASR checkpoints."""
 
     architecture: ClassVar[str] = "Qwen3ASRForConditionalGeneration"
+    audio_chunking: ClassVar[AudioChunkingConfig] = AudioChunkingConfig(
+        allow_audio_chunking=True,
+        max_audio_clip_s=float(QWEN3_ASR_MAX_INPUT_SECONDS),
+    )
 
     @classmethod
     def mem_fraction_role_to_stage(cls) -> dict[str, str]:
@@ -33,7 +38,7 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
             factory_args={
                 "device": "cuda:0",
                 "max_running_requests": 32,
-                "max_new_tokens": 128,
+                "max_new_tokens": 4096,
                 "request_build_max_workers": 8,
                 "request_build_max_pending": 16,
                 "enable_pre_lm_encoder": True,

--- a/sglang_omni/models/qwen3_asr/engine_builder.py
+++ b/sglang_omni/models/qwen3_asr/engine_builder.py
@@ -9,6 +9,7 @@ from sglang.srt.managers.mm_utils import init_mm_embedding_cache
 from transformers import AutoFeatureExtractor, AutoTokenizer
 
 from sglang_omni.models.qwen3_asr import request_builders
+from sglang_omni.models.qwen3_asr.audio_lengths import qwen3_asr_max_audio_tokens
 from sglang_omni.models.qwen3_asr.encoder_service import (
     Qwen3ASRPreLMEncoderService,
     build_cache_namespace,
@@ -77,8 +78,12 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
         self.feature_extractor = AutoFeatureExtractor.from_pretrained(
             checkpoint_dir, trust_remote_code=True
         )
-        encoder_token_count = int(self.feature_extractor.nb_max_frames // 2)
-        self.context_length = encoder_token_count + self.max_new_tokens + 8
+        prompt_token_count = request_builders.qwen3_asr_prompt_token_count(
+            self.tokenizer,
+            qwen3_asr_max_audio_tokens(),
+        )
+        # OmniScheduler admits at most context_length - 1 tokens per request.
+        self.context_length = prompt_token_count + self.max_new_tokens + 1
 
     def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
         defaults: dict[str, Any] = {

--- a/sglang_omni/models/qwen3_asr/engine_builder.py
+++ b/sglang_omni/models/qwen3_asr/engine_builder.py
@@ -78,7 +78,7 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
         self.feature_extractor = AutoFeatureExtractor.from_pretrained(
             checkpoint_dir, trust_remote_code=True
         )
-        prompt_token_count = request_builders.qwen3_asr_prompt_token_count(
+        prompt_token_count = request_builders.qwen3_asr_max_prompt_token_count(
             self.tokenizer,
             qwen3_asr_max_audio_tokens(),
         )

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -87,6 +87,27 @@ def _encode_literal(tokenizer: Any, text: str) -> list[int]:
     return list(input_ids)
 
 
+def qwen3_asr_prompt_token_ids(
+    tokenizer: Any,
+    num_audio_tokens: int,
+    language: str,
+) -> list[int]:
+    """Build the model prompt for one audio-token count and forced language."""
+    prompt = (
+        f"<|im_start|>user\n"
+        f"{_AUDIO_START}{_AUDIO_PAD * num_audio_tokens}{_AUDIO_END}"
+        f"<|im_end|>\n"
+        f"<|im_start|>assistant\n"
+        f"language {language}<asr_text>"
+    )
+    return list(tokenizer(prompt, add_special_tokens=False).input_ids)
+
+
+def qwen3_asr_prompt_token_count(tokenizer: Any, num_audio_tokens: int) -> int:
+    """Return the exact prompt length used to size the serving context."""
+    return len(qwen3_asr_prompt_token_ids(tokenizer, num_audio_tokens, "English"))
+
+
 def make_qwen3_asr_scheduler_adapters(
     *,
     tokenizer: Any,
@@ -103,20 +124,6 @@ def make_qwen3_asr_scheduler_adapters(
     eos_token_id = int(tokenizer.eos_token_id)
     vocab_size = int(tokenizer.vocab_size)
     asr_text_token_ids = _encode_literal(tokenizer, _ASR_TEXT)
-
-    def _build_prompt_ids(num_audio_tokens: int, language: str) -> list[int]:
-        prompt = (
-            f"<|im_start|>user\n"
-            f"{_AUDIO_START}{_AUDIO_PAD * num_audio_tokens}{_AUDIO_END}"
-            f"<|im_end|>\n"
-            f"<|im_start|>assistant\n"
-        )
-        # Qwen3-ASR needs a forced prefix "language <Lang><asr_text>" on the
-        # assistant turn; the model then generates only the transcription after
-        # <asr_text>. Without it the (small) model emits the language tag then
-        # stops. Upstream qwen_asr does the same (_build_text_prompt).
-        prompt = prompt + f"language {language}<asr_text>"
-        return tokenizer(prompt, add_special_tokens=False).input_ids
 
     def request_builder(payload: StagePayload) -> Qwen3ASRRequestData:
         params = payload.request.params or {}
@@ -165,7 +172,11 @@ def make_qwen3_asr_scheduler_adapters(
         forced_language = {"zh": "Chinese", "cn": "Chinese"}.get(
             lang_raw, "Chinese" if lang_raw.startswith("zh") else "English"
         )
-        input_ids = _build_prompt_ids(num_audio_tokens, forced_language)
+        input_ids = qwen3_asr_prompt_token_ids(
+            tokenizer,
+            num_audio_tokens,
+            forced_language,
+        )
 
         audio_item = MultimodalDataItem(
             modality=Modality.AUDIO,
@@ -291,4 +302,6 @@ def make_qwen3_asr_scheduler_adapters(
 __all__ = [
     "Qwen3ASRRequestData",
     "make_qwen3_asr_scheduler_adapters",
+    "qwen3_asr_prompt_token_count",
+    "qwen3_asr_prompt_token_ids",
 ]

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -103,9 +103,12 @@ def qwen3_asr_prompt_token_ids(
     return list(tokenizer(prompt, add_special_tokens=False).input_ids)
 
 
-def qwen3_asr_prompt_token_count(tokenizer: Any, num_audio_tokens: int) -> int:
-    """Return the exact prompt length used to size the serving context."""
-    return len(qwen3_asr_prompt_token_ids(tokenizer, num_audio_tokens, "English"))
+def qwen3_asr_max_prompt_token_count(tokenizer: Any, num_audio_tokens: int) -> int:
+    """Return the largest supported forced-language prompt length."""
+    return max(
+        len(qwen3_asr_prompt_token_ids(tokenizer, num_audio_tokens, language))
+        for language in ("Chinese", "English")
+    )
 
 
 def make_qwen3_asr_scheduler_adapters(
@@ -302,6 +305,6 @@ def make_qwen3_asr_scheduler_adapters(
 __all__ = [
     "Qwen3ASRRequestData",
     "make_qwen3_asr_scheduler_adapters",
-    "qwen3_asr_prompt_token_count",
+    "qwen3_asr_max_prompt_token_count",
     "qwen3_asr_prompt_token_ids",
 ]

--- a/sglang_omni/models/qwen3_asr/stages.py
+++ b/sglang_omni/models/qwen3_asr/stages.py
@@ -12,7 +12,7 @@ def create_sglang_qwen3_asr_executor(
     device: str = "cuda:0",
     dtype: str = "float16",
     max_running_requests: int = 32,
-    max_new_tokens: int = 256,
+    max_new_tokens: int = 4096,
     mem_fraction_static: float | None = None,
     mm_embedding_cache_size_bytes: int = 0,
     enable_torch_compile: bool = False,

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -402,6 +402,7 @@ async def _run_server(
             allowed_media_domains=allowed_media_domains,
             tts_batch_max_items=tts_batch_max_items,
             architectures=[pipeline_config.architecture],
+            audio_chunking=pipeline_config.audio_chunking,
         )
         profiler_dir = os.environ.get("SGLANG_TORCH_PROFILER_DIR")
         profiler_ctl = ProfilerControlClient(mp_runner.stage_control_endpoints)

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -27,6 +27,7 @@ import time
 import uuid
 from collections.abc import Awaitable, Callable
 from contextlib import aclosing, suppress
+from dataclasses import dataclass
 from typing import Any, AsyncIterator
 
 from fastapi import (
@@ -63,6 +64,7 @@ from sglang_omni.client.audio import (
     encode_pcm,
     select_audio_delta,
 )
+from sglang_omni.config import AudioChunkingConfig
 from sglang_omni.http.admin_auth import (
     make_admin_auth_dependency,
     resolve_admin_api_key,
@@ -114,6 +116,11 @@ from sglang_omni.serve.speech_service import SpeechRequestValidator
 from sglang_omni.serve.speech_voices import MAX_VOICE_UPLOAD_BYTES, SpeakerSampleStore
 from sglang_omni.serve.speech_ws import SpeechWebSocketSession
 from sglang_omni.serve.transcription_adapters import resolve_adapter
+from sglang_omni.serve.transcription_chunking import (
+    ChunkPlan,
+    ChunkSpan,
+    plan_audio_chunks,
+)
 
 logger = logging.getLogger(__name__)
 STREAM_DONE_SENTINEL = "[DONE]"
@@ -133,6 +140,38 @@ _BAD_REQUEST_MARKERS = (
     "sequence exceeds max_length",
     "multimodal_train_inputs",
 )
+
+
+@dataclass(frozen=True)
+class _TranscriptionRequestOptions:
+    """Request fields shared by every chunk of one transcription upload."""
+
+    filename: str | None
+    content_type: str | None
+    model: str
+    language: str | None
+    prompt: str | None
+    temperature: float | None
+    max_new_tokens: int | None
+
+    def build(
+        self,
+        audio_bytes: bytes,
+        *,
+        stream: bool = False,
+        content_type: str | None = None,
+    ) -> GenerateRequest:
+        return build_transcription_generate_request(
+            audio_bytes=audio_bytes,
+            filename=self.filename,
+            content_type=content_type or self.content_type,
+            model=self.model,
+            language=self.language,
+            prompt=self.prompt,
+            temperature=self.temperature,
+            max_new_tokens=self.max_new_tokens,
+            stream=stream,
+        )
 
 
 def _is_bad_request_error(exc: Exception) -> bool:
@@ -222,6 +261,7 @@ def create_app(
     admin_api_key: str | None = None,
     tts_batch_max_items: int = DEFAULT_TTS_BATCH_MAX_ITEMS,
     architectures: list[str] | None = None,
+    audio_chunking: AudioChunkingConfig | None = None,
 ) -> FastAPI:
     """Create a FastAPI application with OpenAI-compatible endpoints.
 
@@ -247,6 +287,7 @@ def create_app(
         admin_api_key: Optional API key for admin-control endpoints.
         tts_batch_max_items: Maximum items accepted by
             ``/v1/audio/speech/batch``.
+        audio_chunking: Model-owned long-audio transcription policy.
 
     Returns:
         Configured FastAPI application.
@@ -269,6 +310,7 @@ def create_app(
     app.state.client = client
     app.state.model_name = model_name or "sglang-omni"
     app.state.architectures = [a for a in (architectures or []) if a]
+    app.state.audio_chunking = audio_chunking or AudioChunkingConfig()
     app.state.realtime_enabled = enable_realtime
     app.state.supports_realtime_audio_output = supports_realtime_audio_output
     app.state.speaker_sample_store = SpeakerSampleStore()
@@ -1655,20 +1697,34 @@ def _register_transcriptions(app: FastAPI) -> None:
                         f"'text', got {response_format!r}"
                     ),
                 )
-            gen_req = build_transcription_generate_request(
-                audio_bytes=audio_bytes,
-                filename=file.filename,
-                content_type=file.content_type,
-                model=model or default_model,
-                language=language,
-                prompt=prompt,
-                temperature=temperature,
-                max_new_tokens=max_new_tokens,
-                stream=True,
-            )
+
+        chunking: AudioChunkingConfig = app.state.audio_chunking
+        duration_s, chunk_plan = await _prepare_transcription_audio(
+            audio_bytes,
+            chunking,
+        )
+
+        request_options = _TranscriptionRequestOptions(
+            filename=file.filename,
+            content_type=file.content_type,
+            model=model or default_model,
+            language=language,
+            prompt=prompt,
+            temperature=temperature,
+            max_new_tokens=max_new_tokens,
+        )
+        if stream:
             adapter = resolve_adapter(getattr(app.state, "architectures", None))
-            duration_s = _probe_audio_duration(audio_bytes)
-            chunk_stream = client.generate(gen_req, request_id=request_id)
+            if chunk_plan is None:
+                gen_req = request_options.build(audio_bytes, stream=True)
+                chunk_stream = client.generate(gen_req, request_id=request_id)
+            else:
+                chunk_stream = _stream_transcription_chunks(
+                    client,
+                    chunk_plan,
+                    request_id,
+                    request_options,
+                )
             # note (db-ol): pull the first chunk before sending response
             # headers. Admission rejections such as audio past the context
             # limit arrive as the first stream event, and once headers go out
@@ -1706,19 +1762,18 @@ def _register_transcriptions(app: FastAPI) -> None:
                 headers={"Cache-Control": "no-cache", "X-Request-Id": request_id},
             )
 
-        gen_req = build_transcription_generate_request(
-            audio_bytes=audio_bytes,
-            filename=file.filename,
-            content_type=file.content_type,
-            model=model or default_model,
-            language=language,
-            prompt=prompt,
-            temperature=temperature,
-            max_new_tokens=max_new_tokens,
-        )
-
         try:
-            result = await client.completion(gen_req, request_id=request_id)
+            if chunk_plan is None:
+                gen_req = request_options.build(audio_bytes)
+                result = await client.completion(gen_req, request_id=request_id)
+                text = result.text
+            else:
+                text = await _transcribe_audio_chunks(
+                    client,
+                    chunk_plan,
+                    request_id,
+                    request_options,
+                )
         except ClientError as exc:
             if _is_bad_request_error(exc):
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -1729,7 +1784,6 @@ def _register_transcriptions(app: FastAPI) -> None:
             logger.exception("Error transcribing audio for request %s", request_id)
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-        text = result.text
         if normalized_response_format == "text":
             return PlainTextResponse(text)
         if normalized_response_format not in {"json", "verbose_json"}:
@@ -1743,7 +1797,6 @@ def _register_transcriptions(app: FastAPI) -> None:
 
         adapter = resolve_adapter(getattr(app.state, "architectures", None))
         text = adapter.postprocess_text(text)
-        duration_s = _probe_audio_duration(audio_bytes)
         usage = (
             TranscriptionUsage(seconds=math.ceil(duration_s))
             if duration_s > 0
@@ -1834,6 +1887,135 @@ def _probe_audio_duration(audio_bytes: bytes) -> float:
     except (RuntimeError, ValueError):
         logger.debug("Could not probe audio duration", exc_info=True)
     return 0.0
+
+
+async def _prepare_transcription_audio(
+    audio_bytes: bytes,
+    chunking: AudioChunkingConfig,
+) -> tuple[float, ChunkPlan | None]:
+    """Probe duration and build a chunk plan only when the model policy needs one."""
+    duration_s = _probe_audio_duration(audio_bytes)
+    if (
+        not chunking.allow_audio_chunking
+        or chunking.max_audio_clip_s is None
+        or (0 < duration_s <= chunking.max_audio_clip_s)
+    ):
+        return duration_s, None
+
+    try:
+        chunk_plan = await asyncio.to_thread(
+            plan_audio_chunks,
+            audio_bytes,
+            chunking,
+        )
+    except (RuntimeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Could not decode uploaded audio: {exc}",
+        ) from exc
+    if chunk_plan is None:
+        return duration_s, None
+    return chunk_plan.duration_s, chunk_plan
+
+
+async def _iter_transcription_chunk_requests(
+    plan: ChunkPlan,
+    request_id: str,
+    request_options: _TranscriptionRequestOptions,
+    *,
+    stream: bool,
+) -> AsyncIterator[tuple[ChunkSpan, str, GenerateRequest]]:
+    """Encode ordered spans and build their child engine requests."""
+    for span in plan.spans:
+        audio_bytes = await asyncio.to_thread(plan.encode, span)
+        child_request_id = f"{request_id}-chunk-{span.index}"
+        yield (
+            span,
+            child_request_id,
+            request_options.build(
+                audio_bytes,
+                stream=stream,
+                content_type="audio/wav",
+            ),
+        )
+
+
+def _transcription_chunk_error(span: ChunkSpan, exc: Exception) -> ClientError:
+    return ClientError(
+        f"transcription failed for chunk {span.index} "
+        f"({span.start_s:.1f}s-{span.end_s:.1f}s): {exc}"
+    )
+
+
+async def _stream_transcription_chunks(
+    client: Client,
+    plan: ChunkPlan,
+    request_id: str,
+    request_options: _TranscriptionRequestOptions,
+) -> AsyncIterator[GenerateChunk]:
+    """Stream ordered chunk requests as one coherent transcription."""
+
+    texts: list[str] = []
+    async for span, child_request_id, gen_req in _iter_transcription_chunk_requests(
+        plan,
+        request_id,
+        request_options,
+        stream=True,
+    ):
+        child_stream = client.generate(gen_req, request_id=child_request_id)
+        streamed_text: list[str] = []
+        final_text: str | None = None
+        completed = False
+        try:
+            async with aclosing(child_stream):
+                async for chunk in child_stream:
+                    if chunk.finish_reason is not None:
+                        if isinstance(chunk.text, str) and chunk.text:
+                            final_text = chunk.text
+                        continue
+                    if chunk.modality == "text" and chunk.text:
+                        streamed_text.append(chunk.text)
+                    yield chunk
+            completed = True
+        except Exception as exc:
+            raise _transcription_chunk_error(span, exc) from exc
+        finally:
+            if not completed:
+                with suppress(Exception):
+                    await client.abort(child_request_id)
+        texts.append(final_text if final_text is not None else "".join(streamed_text))
+
+    yield GenerateChunk(
+        request_id=request_id,
+        text="".join(texts),
+        finish_reason="stop",
+    )
+
+
+async def _transcribe_audio_chunks(
+    client: Client,
+    plan: ChunkPlan,
+    request_id: str,
+    request_options: _TranscriptionRequestOptions,
+) -> str:
+    """Transcribe an ordered chunk plan and fail the whole upload on any gap."""
+
+    texts: list[str] = []
+    async for span, child_request_id, gen_req in _iter_transcription_chunk_requests(
+        plan,
+        request_id,
+        request_options,
+        stream=False,
+    ):
+        try:
+            result = await client.completion(
+                gen_req,
+                request_id=child_request_id,
+            )
+        except Exception as exc:
+            raise _transcription_chunk_error(span, exc) from exc
+        texts.append(result.text)
+    return "".join(texts)
 
 
 def build_transcription_generate_request(

--- a/sglang_omni/serve/transcription_chunking.py
+++ b/sglang_omni/serve/transcription_chunking.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model-policy-driven chunking for long transcription uploads."""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from sglang_omni.config import AudioChunkingConfig
+from sglang_omni.utils.audio import load_audio
+
+TARGET_SAMPLE_RATE = 16000
+_BOUNDARY_SEARCH_SECONDS = 5.0
+_ENERGY_WINDOW_SECONDS = 0.1
+_MIN_CHUNK_SECONDS = 0.5
+
+
+@dataclass(frozen=True)
+class ChunkSpan:
+    """Half-open sample range for one transcription chunk."""
+
+    index: int
+    start_sample: int
+    end_sample: int
+    sample_rate: int
+
+    @property
+    def start_s(self) -> float:
+        return self.start_sample / self.sample_rate
+
+    @property
+    def end_s(self) -> float:
+        return self.end_sample / self.sample_rate
+
+
+@dataclass
+class ChunkPlan:
+    """Decoded waveform and the ordered spans submitted to the model."""
+
+    sample_rate: int
+    duration_s: float
+    spans: list[ChunkSpan]
+    waveform: np.ndarray = field(repr=False)
+
+    def encode(self, span: ChunkSpan) -> bytes:
+        """Encode one lossless float WAV chunk for an engine request."""
+        import soundfile as sf
+
+        buffer = io.BytesIO()
+        sf.write(
+            buffer,
+            np.ascontiguousarray(
+                self.waveform[span.start_sample : span.end_sample],
+                dtype=np.float32,
+            ),
+            self.sample_rate,
+            format="WAV",
+            subtype="FLOAT",
+        )
+        return buffer.getvalue()
+
+
+def _quiet_boundary(
+    waveform: np.ndarray,
+    *,
+    start_sample: int,
+    hard_end_sample: int,
+    sample_rate: int,
+) -> int:
+    search_samples = int(_BOUNDARY_SEARCH_SECONDS * sample_rate)
+    search_start = max(start_sample + 1, hard_end_sample - search_samples)
+    region = np.abs(waveform[search_start:hard_end_sample])
+    if region.size == 0:
+        return hard_end_sample
+
+    window_samples = min(
+        max(int(_ENERGY_WINDOW_SECONDS * sample_rate), 1),
+        int(region.size),
+    )
+    cumulative_energy = np.empty(region.size + 1, dtype=np.float64)
+    cumulative_energy[0] = 0.0
+    np.cumsum(region, dtype=np.float64, out=cumulative_energy[1:])
+    window_energy = (
+        cumulative_energy[window_samples:] - cumulative_energy[:-window_samples]
+    )
+    # Prefer the latest equally quiet window so all-silence input stays close
+    # to the hard boundary instead of degenerating into tiny chunks.
+    quietest_window = int(np.flatnonzero(window_energy == window_energy.min())[-1])
+    boundary = search_start + quietest_window + window_samples // 2
+    return min(max(boundary, start_sample + 1), hard_end_sample)
+
+
+def plan_audio_chunks(
+    audio_bytes: bytes,
+    config: AudioChunkingConfig,
+    *,
+    sample_rate: int = TARGET_SAMPLE_RATE,
+) -> ChunkPlan | None:
+    """Decode and split audio that exceeds the configured model clip limit."""
+
+    max_audio_clip_s = config.max_audio_clip_s
+    if not config.allow_audio_chunking or max_audio_clip_s is None:
+        return None
+
+    waveform = load_audio(
+        audio_bytes,
+        source_name="transcription",
+        target_sample_rate=sample_rate,
+    )
+    total_samples = int(waveform.size)
+    max_chunk_samples = max(int(max_audio_clip_s * sample_rate), 1)
+    min_chunk_samples = max(int(_MIN_CHUNK_SECONDS * sample_rate), 1)
+    if total_samples <= max_chunk_samples:
+        return None
+
+    spans: list[ChunkSpan] = []
+    start_sample = 0
+    while total_samples - start_sample > max_chunk_samples:
+        hard_end_sample = start_sample + max_chunk_samples
+        end_sample = _quiet_boundary(
+            waveform,
+            start_sample=start_sample,
+            hard_end_sample=hard_end_sample,
+            sample_rate=sample_rate,
+        )
+        tail_samples = total_samples - end_sample
+        if 0 < tail_samples < min_chunk_samples:
+            end_sample = max(total_samples - min_chunk_samples, start_sample + 1)
+        spans.append(
+            ChunkSpan(
+                index=len(spans),
+                start_sample=start_sample,
+                end_sample=end_sample,
+                sample_rate=sample_rate,
+            )
+        )
+        start_sample = end_sample
+    spans.append(
+        ChunkSpan(
+            index=len(spans),
+            start_sample=start_sample,
+            end_sample=total_samples,
+            sample_rate=sample_rate,
+        )
+    )
+    return ChunkPlan(
+        sample_rate=sample_rate,
+        duration_s=total_samples / sample_rate,
+        spans=spans,
+        waveform=waveform,
+    )
+
+
+__all__ = ["ChunkPlan", "ChunkSpan", "plan_audio_chunks"]

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -29,6 +29,7 @@ def test_qwen3_asr_config_uses_batched_stage_with_32_running_requests() -> None:
     assert config.stages[0].factory.endswith("create_sglang_qwen3_asr_executor")
     assert config.stages[0].factory_args["device"] == "cuda:0"
     assert config.stages[0].factory_args["max_running_requests"] == 32
+    assert config.stages[0].factory_args["max_new_tokens"] == 4096
     assert config.stages[0].factory_args["request_build_max_workers"] == 8
     assert config.stages[0].factory_args["request_build_max_pending"] == 16
     assert "request_build_max_backlog" not in config.stages[0].factory_args
@@ -43,10 +44,18 @@ def test_qwen3_asr_config_uses_batched_stage_with_32_running_requests() -> None:
     )
 
 
+def test_qwen3_asr_config_owns_the_long_audio_chunk_threshold() -> None:
+    config = Qwen3ASRPipelineConfig(model_path="Qwen/Qwen3-ASR-1.7B")
+
+    assert config.audio_chunking.allow_audio_chunking is True
+    assert config.audio_chunking.max_audio_clip_s == 1200.0
+
+
 def test_qwen3_asr_stage_default_allows_32_running_requests() -> None:
     signature = inspect.signature(create_sglang_qwen3_asr_executor)
 
     assert signature.parameters["max_running_requests"].default == 32
+    assert signature.parameters["max_new_tokens"].default == 4096
     assert signature.parameters["request_build_max_workers"].default == 8
     assert signature.parameters["request_build_max_pending"].default == 16
     assert "request_build_max_backlog" not in signature.parameters
@@ -109,6 +118,7 @@ def test_qwen3_asr_stage_default_enables_async_decode() -> None:
 
 def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
     build_kwargs: dict[str, object] = {}
+    built_context_length: int | None = None
 
     monkeypatch.setattr(
         qwen3_asr_builder.AutoTokenizer,
@@ -119,6 +129,11 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
         qwen3_asr_builder.AutoFeatureExtractor,
         "from_pretrained",
         lambda *args, **kwargs: SimpleNamespace(nb_max_frames=3000),
+    )
+    monkeypatch.setattr(
+        request_builders,
+        "qwen3_asr_prompt_token_count",
+        lambda tokenizer, num_audio_tokens: num_audio_tokens + 13,
     )
     monkeypatch.setattr(
         qwen3_asr_builder,
@@ -154,6 +169,8 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
     )
 
     def _fake_server_args_builder(model_path, context_length, **overrides):
+        nonlocal built_context_length
+        built_context_length = context_length
         build_kwargs.update(overrides)
         server_args = FakeServerArgs(**overrides)
         server_args.cuda_graph_config = SimpleNamespace(
@@ -198,6 +215,7 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
 
     assert build_kwargs["cuda_graph_max_bs"] == 32
     assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 12, 16, 24, 32]
+    assert built_context_length == 19_710
     assert scheduler.enable_async_decode is False
     assert scheduler.async_decode_min_batch_size == 4
     assert scheduler.shutdown_callback is fake_encoder_service.close

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -12,6 +12,7 @@ import sglang_omni.models.qwen3_asr.stages as qwen3_asr_stages
 import sglang_omni.scheduling.bootstrap as bootstrap
 import sglang_omni.scheduling.omni_scheduler as omni_scheduler
 import sglang_omni.scheduling.sglang_backend as sglang_backend
+from sglang_omni.config import AudioChunkingConfig
 from sglang_omni.models.qwen3_asr import request_builders
 from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
 from sglang_omni.models.qwen3_asr.stages import create_sglang_qwen3_asr_executor
@@ -49,6 +50,14 @@ def test_qwen3_asr_config_owns_the_long_audio_chunk_threshold() -> None:
 
     assert config.audio_chunking.allow_audio_chunking is True
     assert config.audio_chunking.max_audio_clip_s == 1200.0
+
+
+def test_audio_chunking_policy_rejects_a_threshold_when_disabled() -> None:
+    with pytest.raises(
+        ValueError,
+        match="must be omitted when audio chunking is disabled",
+    ):
+        AudioChunkingConfig(max_audio_clip_s=1200.0)
 
 
 def test_qwen3_asr_stage_default_allows_32_running_requests() -> None:
@@ -132,7 +141,7 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
     )
     monkeypatch.setattr(
         request_builders,
-        "qwen3_asr_prompt_token_count",
+        "qwen3_asr_max_prompt_token_count",
         lambda tokenizer, num_audio_tokens: num_audio_tokens + 13,
     )
     monkeypatch.setattr(

--- a/tests/unit_test/qwen3_asr/test_request_builders.py
+++ b/tests/unit_test/qwen3_asr/test_request_builders.py
@@ -17,6 +17,7 @@ from sglang_omni.models.qwen3_asr.configuration_qwen3_asr import Qwen3ASRProcess
 from sglang_omni.models.qwen3_asr.request_builders import (
     Qwen3ASRRequestData,
     make_qwen3_asr_scheduler_adapters,
+    qwen3_asr_max_prompt_token_count,
 )
 from sglang_omni.proto import OmniRequest, StagePayload
 
@@ -82,6 +83,18 @@ def test_qwen3_asr_audio_token_length_formula_is_shared() -> None:
     assert torch.equal(qwen3_asr_audio_token_lengths(lengths), expected)
     assert torch.equal(processor._get_feat_extract_output_lengths(lengths), expected)
     assert qwen3_asr_num_audio_tokens(3000) == 390
+
+
+def test_qwen3_asr_context_uses_the_largest_supported_language_prompt() -> None:
+    class LanguageAwareTokenizer:
+        def __call__(self, text: str, *, add_special_tokens: bool = False):
+            assert not add_special_tokens
+            extra_tokens = 2 if "Chinese" in text else 1
+            return SimpleNamespace(
+                input_ids=[0] * (text.count("<|audio_pad|>") + extra_tokens)
+            )
+
+    assert qwen3_asr_max_prompt_token_count(LanguageAwareTokenizer(), 3) == 5
 
 
 def test_qwen3_asr_request_builder_records_inclusive_audio_offsets(monkeypatch) -> None:

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -26,12 +26,16 @@ from sglang_omni.serve.openai_api import (
     _chat_stream,
     _ClosableStreamingResponse,
     _first_transcription_chunk,
+    _probe_audio_duration,
     _speech_audio_response,
+    _stream_transcription_chunks,
     _transcription_stream,
+    _TranscriptionRequestOptions,
     build_transcription_generate_request,
 )
 from sglang_omni.serve.protocol import ChatCompletionRequest, CreateSpeechRequest
 from sglang_omni.serve.speech_service import SpeechRequestValidator
+from sglang_omni.serve.transcription_chunking import plan_audio_chunks
 from tests.unit_test.fixtures.pipeline_fakes import RecordingCoordinatorControlPlane
 
 MODEL_FAMILIES = {
@@ -1383,6 +1387,157 @@ def test_transcription_request_passes_explicit_max_new_tokens() -> None:
     assert gen_req.metadata[EXPLICIT_GENERATION_PARAMS_KEY] == ["max_new_tokens"]
     omni_req = Client._build_omni_request(gen_req)
     assert omni_req.params["max_new_tokens"] == 4096
+
+
+def test_create_app_stores_the_audio_chunking_policy() -> None:
+    from sglang_omni.config import AudioChunkingConfig
+
+    app = create_app(SuccessfulTranscriptionClient(), model_name="asr")
+    assert app.state.audio_chunking.allow_audio_chunking is False
+
+    declared = AudioChunkingConfig(
+        allow_audio_chunking=True,
+        max_audio_clip_s=1200.0,
+    )
+    app = create_app(
+        SuccessfulTranscriptionClient(),
+        model_name="asr",
+        audio_chunking=declared,
+    )
+    assert app.state.audio_chunking is declared
+
+
+def test_transcription_endpoint_chunks_audio_past_the_model_limit() -> None:
+    from sglang_omni.config import AudioChunkingConfig
+
+    transcription_client = SuccessfulTranscriptionClient()
+    client = TestClient(
+        create_app(
+            transcription_client,
+            model_name="Qwen/Qwen3-ASR-1.7B",
+            audio_chunking=AudioChunkingConfig(
+                allow_audio_chunking=True,
+                max_audio_clip_s=1.0,
+            ),
+        )
+    )
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={"model": "Qwen/Qwen3-ASR-1.7B"},
+        files={"file": ("sample.wav", _wav_bytes(2.5), "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "text": "hello worldhello worldhello world",
+        "usage": {"type": "duration", "seconds": 3},
+    }
+    assert len(transcription_client.requests) == 3
+    for request in transcription_client.requests:
+        assert _probe_audio_duration(request.prompt["audio_bytes"]) <= 1.0
+
+
+def test_transcription_stream_chunks_audio_past_the_model_limit() -> None:
+    from sglang_omni.config import AudioChunkingConfig
+
+    transcription_client = SuccessfulTranscriptionClient()
+    client = TestClient(
+        create_app(
+            transcription_client,
+            model_name="Qwen/Qwen3-ASR-1.7B",
+            audio_chunking=AudioChunkingConfig(
+                allow_audio_chunking=True,
+                max_audio_clip_s=1.0,
+            ),
+        )
+    )
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={"model": "Qwen/Qwen3-ASR-1.7B", "stream": "true"},
+        files={"file": ("sample.wav", _wav_bytes(2.5), "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert len(transcription_client.requests) == 3
+    assert '"delta":" "' not in response.text
+    assert '"text":"hello worldhello worldhello world"' in response.text
+    assert response.text.endswith("data: [DONE]\n\n")
+
+
+def test_transcription_chunk_planning_maps_decode_errors_to_400() -> None:
+    from sglang_omni.config import AudioChunkingConfig
+
+    client = TestClient(
+        create_app(
+            SuccessfulTranscriptionClient(),
+            model_name="Qwen/Qwen3-ASR-1.7B",
+            audio_chunking=AudioChunkingConfig(
+                allow_audio_chunking=True,
+                max_audio_clip_s=1.0,
+            ),
+        )
+    )
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={"model": "Qwen/Qwen3-ASR-1.7B"},
+        files={"file": ("broken.wav", b"not audio", "audio/wav")},
+    )
+
+    assert response.status_code == 400
+    assert "Could not decode uploaded audio" in response.json()["detail"]
+
+
+def test_closing_a_chunked_transcription_stream_aborts_the_active_chunk() -> None:
+    from sglang_omni.config import AudioChunkingConfig
+
+    class AbortRecordingClient:
+        def __init__(self) -> None:
+            self.request_ids: list[str] = []
+            self.aborted: list[str] = []
+
+        async def generate(self, request, request_id=None):
+            del request
+            self.request_ids.append(request_id)
+            yield GenerateChunk(request_id=request_id, text="partial")
+            await asyncio.Event().wait()
+
+        async def abort(self, request_id: str) -> None:
+            self.aborted.append(request_id)
+
+    async def _drive() -> None:
+        config = AudioChunkingConfig(
+            allow_audio_chunking=True,
+            max_audio_clip_s=1.0,
+        )
+        plan = plan_audio_chunks(_wav_bytes(2.5), config)
+        assert plan is not None
+        transcription_client = AbortRecordingClient()
+        stream = _stream_transcription_chunks(
+            transcription_client,
+            plan,
+            "transcription-1",
+            _TranscriptionRequestOptions(
+                filename="sample.wav",
+                content_type="audio/wav",
+                model="Qwen/Qwen3-ASR-1.7B",
+                language=None,
+                prompt=None,
+                temperature=None,
+                max_new_tokens=None,
+            ),
+        )
+
+        first_chunk = await anext(stream)
+        assert first_chunk.text == "partial"
+        await stream.aclose()
+
+        assert transcription_client.request_ids == ["transcription-1-chunk-0"]
+        assert transcription_client.aborted == ["transcription-1-chunk-0"]
+
+    asyncio.run(_drive())
 
 
 def test_transcription_endpoint_returns_text_json() -> None:

--- a/tests/unit_test/serve/test_transcription_chunking.py
+++ b/tests/unit_test/serve/test_transcription_chunking.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from sglang_omni.config import AudioChunkingConfig
+from sglang_omni.serve.transcription_chunking import plan_audio_chunks
+from sglang_omni.utils.audio import load_audio
+
+_SAMPLE_RATE = 16000
+
+
+def _wav_bytes(waveform: np.ndarray) -> bytes:
+    buffer = io.BytesIO()
+    sf.write(
+        buffer,
+        waveform,
+        _SAMPLE_RATE,
+        format="WAV",
+        subtype="FLOAT",
+    )
+    return buffer.getvalue()
+
+
+@pytest.mark.parametrize(
+    ("config", "duration_s"),
+    [
+        (AudioChunkingConfig(), 2.5),
+        (
+            AudioChunkingConfig(
+                allow_audio_chunking=True,
+                max_audio_clip_s=1.0,
+            ),
+            1.0,
+        ),
+    ],
+)
+def test_audio_within_policy_does_not_create_a_chunk_plan(
+    config: AudioChunkingConfig,
+    duration_s: float,
+) -> None:
+    waveform = np.zeros(int(duration_s * _SAMPLE_RATE), dtype=np.float32)
+
+    assert plan_audio_chunks(_wav_bytes(waveform), config) is None
+
+
+def test_long_audio_is_split_at_quiet_boundaries_without_loss() -> None:
+    rng = np.random.default_rng(7)
+    waveform = rng.uniform(-0.5, 0.5, int(2.5 * _SAMPLE_RATE)).astype(np.float32)
+    waveform[int(0.8 * _SAMPLE_RATE) : int(0.9 * _SAMPLE_RATE)] = 0.0
+    config = AudioChunkingConfig(
+        allow_audio_chunking=True,
+        max_audio_clip_s=1.0,
+    )
+
+    plan = plan_audio_chunks(_wav_bytes(waveform), config)
+
+    assert plan is not None
+    assert plan.sample_rate == _SAMPLE_RATE
+    assert plan.duration_s == 2.5
+    assert (
+        int(0.8 * _SAMPLE_RATE) <= plan.spans[0].end_sample <= int(0.9 * _SAMPLE_RATE)
+    )
+    expected_start = 0
+    for span in plan.spans:
+        assert span.start_sample == expected_start
+        assert 0 < span.end_sample - span.start_sample <= _SAMPLE_RATE
+        expected_start = span.end_sample
+    assert expected_start == waveform.size
+
+
+def test_encoded_chunks_round_trip_sample_for_sample() -> None:
+    waveform = np.linspace(-0.5, 0.5, int(2.5 * _SAMPLE_RATE), dtype=np.float32)
+    config = AudioChunkingConfig(
+        allow_audio_chunking=True,
+        max_audio_clip_s=1.0,
+    )
+    plan = plan_audio_chunks(_wav_bytes(waveform), config)
+
+    assert plan is not None
+    for span in plan.spans:
+        decoded = load_audio(plan.encode(span), target_sample_rate=_SAMPLE_RATE)
+        np.testing.assert_array_equal(
+            decoded,
+            waveform[span.start_sample : span.end_sample],
+        )
+
+
+def test_planner_avoids_a_subminimum_tail_chunk() -> None:
+    waveform = np.zeros(int(1.1 * _SAMPLE_RATE), dtype=np.float32)
+    config = AudioChunkingConfig(
+        allow_audio_chunking=True,
+        max_audio_clip_s=1.0,
+    )
+
+    plan = plan_audio_chunks(_wav_bytes(waveform), config)
+
+    assert plan is not None
+    assert [span.end_sample - span.start_sample for span in plan.spans] == [
+        int(0.6 * _SAMPLE_RATE),
+        int(0.5 * _SAMPLE_RATE),
+    ]


### PR DESCRIPTION
## Summary

- size Qwen3-ASR context for the official 1,200-second native input limit plus the upstream 4,096-token generation default
- keep audio at or below 1,200 seconds as one native model request
- auto-chunk longer uploads at low-energy, non-overlapping boundaries with hard 1,200-second maximums and 0.5-second minimum tails
- stitch blocking and streaming `/v1/audio/transcriptions` results in order, fail the whole upload on a chunk error, and abort active child streams on disconnect
- document the model-owned long-audio behavior

## Why 1,200 seconds, not 30/60 seconds

The original F1 note in #1267 described the old silent 30-second truncation. After #1176, preprocessing no longer truncates at Whisper's 30-second window. The follow-up issue comment identifies the remaining problem as Qwen3-ASR context sizing and points to the official wrapper's `MAX_ASR_INPUT_SECONDS = 1200` behavior.

This therefore deliberately differs from draft #1347's 60-second threshold: Qwen3-ASR processes up to 1,200 seconds natively and chunks only above the model-owned limit.

## Behavior

- no overlap or de-duplication: the official wrapper uses non-overlapping chunks and direct concatenation
- no timestamp remapping: Qwen3-ASR does not currently expose timestamped segments through this serving path
- model policy is default-disabled globally and enabled only by `Qwen3ASRPipelineConfig`

## Validation

- [x] `uv run pytest -q tests/unit_test/qwen3_asr tests/unit_test/preprocessing/test_transcription.py tests/unit_test/serve/test_transcription_chunking.py tests/unit_test/serve/test_openai_api.py` — 131 passed, 1 skipped
- [x] `uvx pre-commit run --from-ref upstream/main --to-ref HEAD`
- [x] Vast.ai GPU VM Docker end-to-end validation (no NCU)
  - public 48GB validation artifacts: https://gist.github.com/wirybeaver/05206d141f06fdf8bdced5739399feba
  - GPU-validated pre-rebase source: `e6fb693fa49a04e7554cf09303cd47e042a1be88`
  - image: `sha256:9e4294c08e6a9a06f6400aacaad161cac8d49dc655d91fb37da7ccf2bc99006a`
  - GPU: NVIDIA RTX 6000 Ada Generation, 49,140 MiB
  - server: concurrency 1, CUDA graph max batch 1, `--mem-fraction-static 0.5`
  - 125-second native request: HTTP 200, non-empty transcript, 101.80 s, usage 125 s
  - 1,201-second request: HTTP 200, non-empty transcript, 50.27 s, usage 1,201 s; server logs show ordered `chunk-0` and `chunk-1`, both successful
  - peak sampled GPU memory: 39,403 MiB for the 1,201-second request

SGLang's automatic KV-cache sizing consumed the additional VRAM and left less than 1 GiB free during the long prefill on 48 GiB GPUs. Pinning `mem_fraction_static=0.5` reserves workspace for the audio encoder; this is required deployment tuning for this maximum-length validation rather than a chunking failure.

## Related

- Tracks F1 in #1267
- Related draft: #1347

