### PR TITLE
[Model] Add MiMo-V2.5-ASR transcription support

### DIFF
--- a/docs/cookbook/mimo_v25_asr.md
+++ b/docs/cookbook/mimo_v25_asr.md
@@ -1,0 +1,63 @@
+# MiMo-V2.5-ASR
+
+[MiMo-V2.5-ASR](https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR) is Xiaomi MiMo's
+end-to-end speech recognition model. SGLang-Omni serves it through the
+OpenAI-compatible `/v1/audio/transcriptions` endpoint.
+
+Architecture (input path only):
+
+```text
+waveform (24 kHz)
+  -> MiMo-Audio-Tokenizer encoder / 8-layer RVQ
+  -> input-local patch encoder (4 frames -> 1 LM embedding)
+  -> SGLang Qwen2 decode
+  -> text
+```
+
+TTS / spoken-dialogue audio output is out of scope for this integration.
+
+## Prerequisites
+
+Install `sglang-omni`, then download both checkpoints:
+
+```bash
+hf download XiaomiMiMo/MiMo-Audio-Tokenizer
+hf download XiaomiMiMo/MiMo-V2.5-ASR
+```
+
+The tokenizer defaults to `XiaomiMiMo/MiMo-Audio-Tokenizer`. A large GPU is
+required (on the order of an 80 GB card for comfortable serving).
+
+## Server Configuration
+
+```bash
+sgl-omni serve \
+  --model-path XiaomiMiMo/MiMo-V2.5-ASR \
+  --port 8000
+```
+
+## Transcribe Audio
+
+```bash
+curl -X POST http://localhost:8000/v1/audio/transcriptions \
+  -F model=XiaomiMiMo/MiMo-V2.5-ASR \
+  -F file=@tests/data/query_to_cars.wav \
+  -F language=zh \
+  -F response_format=json
+```
+
+`language` maps to the official ASR tags:
+
+| `language` | MiMo tag |
+|---|---|
+| `zh` / `chinese` | `<chinese>` |
+| `en` / `english` | `<english>` |
+| `auto` / omitted | no tag (auto detect) |
+
+## Known Limitations
+
+- First launch downloads the 1.2B audio tokenizer and the 7B ASR weights.
+- Default serving uses `max_running_requests=32` with CUDA graphs disabled.
+- Audio output modalities are rejected.
+- Prompt templates are fixed (first template of each official pool) for
+  deterministic serving; official `asr_sft` randomly samples templates.

--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -419,6 +419,7 @@ class SGLModelRunner(ModelRunner):
             "Qwen3ASRForConditionalGeneration": "sglang_omni.models.qwen3_asr.sglang_model:Qwen3ASRForConditionalGeneration",
             "FunAsrNanoForConditionalGeneration": "sglang_omni.models.fun_asr.sglang_model:FunAsrNanoForConditionalGeneration",
             "ArkasrForConditionalGeneration": "sglang_omni.models.arkasr.sglang_model:ArkasrForConditionalGeneration",
+            "MiMoV2ASRForCausalLM": "sglang_omni.models.mimo_v25_asr.sglang_model:MiMoV2ASRForCausalLM",
         }
         for arch, path in sglang_omni_models.items():
             module_path, _, attr = path.partition(":")

--- a/sglang_omni/models/mimo_v25_asr/__init__.py
+++ b/sglang_omni/models/mimo_v25_asr/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MiMo-V2.5-ASR input-to-text serving package."""

--- a/sglang_omni/models/mimo_v25_asr/audio_tokenizer.py
+++ b/sglang_omni/models/mimo_v25_asr/audio_tokenizer.py
@@ -1,0 +1,385 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Input-only MiMo audio tokenizer encoder.
+
+This module intentionally contains no audio decoder, vocoder, ISTFT, or
+waveform-generation code.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from safetensors import safe_open
+from sgl_kernel.flash_attn import flash_attn_varlen_func
+from torch import nn
+
+
+def _sequence_mask(
+    inputs: torch.Tensor, lengths: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    batch, target_len = inputs.shape[:2]
+    positions = torch.arange(target_len, device=inputs.device)
+    mask = positions < lengths.reshape(batch, 1)
+    mask = mask.unsqueeze(-1)
+    unpacking_index = torch.cumsum(mask.to(torch.int64).reshape(-1), dim=0) - 1
+    return mask, unpacking_index
+
+
+def _unpack_packed(packed: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+    batch = lengths.shape[0]
+    max_len = int(torch.max(lengths).item())
+    mask = (
+        torch.arange(max_len, device=packed.device)[None, :]
+        < lengths[:, None].to(packed.device)
+    ).unsqueeze(-1)
+    unpacking_index = torch.cumsum(mask.to(torch.int64).reshape(-1), dim=0) - 1
+    unpacked = torch.index_select(packed, 0, unpacking_index).view(
+        batch, max_len, packed.shape[-1]
+    )
+    return torch.where(mask, unpacked, 0)
+
+
+def _packed_position_ids(lengths: torch.Tensor) -> torch.Tensor:
+    offsets = torch.cat(
+        [torch.zeros(1, device=lengths.device, dtype=lengths.dtype), lengths[:-1]]
+    ).cumsum(0)
+    return torch.arange(lengths.sum(), device=lengths.device) - torch.repeat_interleave(
+        offsets, lengths
+    )
+
+
+def _rotate_half(value: torch.Tensor) -> torch.Tensor:
+    first, second = value.chunk(2, dim=-1)
+    return torch.cat([-second, first], dim=-1)
+
+
+class _RotaryEmbedding(nn.Module):
+    def __init__(self, theta: float, head_dim: int) -> None:
+        super().__init__()
+        inv_freq = 1.0 / (
+            theta
+            ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / float(head_dim))
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(
+        self, position_ids: torch.Tensor, dtype: torch.dtype
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        frequencies = torch.outer(
+            position_ids.float(), self.inv_freq.float().to(position_ids.device)
+        )
+        embedding = torch.cat([frequencies, frequencies], dim=-1)
+        return embedding.cos().to(dtype), embedding.sin().to(dtype)
+
+
+class _Codebook(nn.Module):
+    """Inference-only codebook with checkpoint-compatible buffer names."""
+
+    def __init__(self, size: int, dimension: int) -> None:
+        super().__init__()
+        self.register_buffer("inited", torch.ones(1))
+        self.register_buffer("cluster_size", torch.zeros(size))
+        self.register_buffer("embed", torch.empty(size, dimension))
+        self.register_buffer("embed_avg", torch.empty(size, dimension))
+
+    def encode(self, values: torch.Tensor) -> torch.Tensor:
+        codebook = self.embed.to(values)
+        distance = -(
+            values.pow(2).sum(1, keepdim=True)
+            - 2 * values @ codebook.T
+            + codebook.pow(2).sum(1, keepdim=False)[None, :]
+        )
+        return distance.argmax(dim=-1)
+
+    def decode(self, indices: torch.Tensor) -> torch.Tensor:
+        return F.embedding(indices, self.embed)
+
+
+class _VectorQuantization(nn.Module):
+    def __init__(self, size: int, dimension: int) -> None:
+        super().__init__()
+        self.project_in = nn.Identity()
+        self.project_out = nn.Identity()
+        self._codebook = _Codebook(size, dimension)
+
+    def encode(self, values: torch.Tensor) -> torch.Tensor:
+        return self._codebook.encode(values)
+
+    def decode(self, indices: torch.Tensor) -> torch.Tensor:
+        return self._codebook.decode(indices)
+
+
+class _ResidualVectorQuantization(nn.Module):
+    def __init__(self, sizes: Sequence[int], dimension: int) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [_VectorQuantization(size, dimension) for size in sizes]
+        )
+
+    def encode(self, values: torch.Tensor, n_q: int | None = None) -> torch.Tensor:
+        residual = values.float()
+        codes: list[torch.Tensor] = []
+        for layer in self.layers[: n_q or len(self.layers)]:
+            indices = layer.encode(residual)
+            residual = residual - layer.decode(indices)
+            codes.append(indices)
+        return torch.stack(codes)
+
+
+class _ResidualVectorQuantizer(nn.Module):
+    def __init__(self, sizes: Sequence[int], dimension: int) -> None:
+        super().__init__()
+        self.vq = _ResidualVectorQuantization(sizes, dimension)
+
+    def encode(self, values: torch.Tensor, n_q: int | None = None) -> torch.Tensor:
+        return self.vq.encode(values, n_q=n_q)
+
+
+class _Attention(nn.Module):
+    def __init__(
+        self,
+        dimension: int,
+        heads: int,
+        *,
+        causal: bool,
+        window_size: tuple[int, int],
+    ) -> None:
+        super().__init__()
+        self.dimension = dimension
+        self.heads = heads
+        self.head_dim = dimension // heads
+        self.window_size = window_size
+        self.causal = causal
+        self.k_proj = nn.Linear(dimension, dimension, bias=False)
+        self.v_proj = nn.Linear(dimension, dimension, bias=True)
+        self.q_proj = nn.Linear(dimension, dimension, bias=True)
+        self.out_proj = nn.Linear(dimension, dimension, bias=True)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        lengths: torch.Tensor,
+        rotary: tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        query = self.q_proj(hidden_states).view(-1, self.heads, self.head_dim)
+        key = self.k_proj(hidden_states).view(-1, self.heads, self.head_dim)
+        value = self.v_proj(hidden_states).view(-1, self.heads, self.head_dim)
+        cos, sin = rotary
+        cos = cos[:, None, :]
+        sin = sin[:, None, :]
+        query = query * cos + _rotate_half(query) * sin
+        key = key * cos + _rotate_half(key) * sin
+        cumulative = F.pad(lengths.cumsum(0), (1, 0)).to(torch.int32)
+        max_length = int(lengths.max().item())
+        output = flash_attn_varlen_func(
+            query,
+            key,
+            value,
+            cumulative,
+            cumulative,
+            max_length,
+            max_length,
+            causal=self.causal,
+            window_size=self.window_size,
+        )
+        return self.out_proj(output.reshape(-1, self.dimension))
+
+
+class _TransformerLayer(nn.Module):
+    def __init__(
+        self,
+        dimension: int,
+        heads: int,
+        feed_forward_dim: int,
+        *,
+        causal: bool,
+        window_size: tuple[int, int],
+    ) -> None:
+        super().__init__()
+        self.self_attn = _Attention(
+            dimension,
+            heads,
+            causal=causal,
+            window_size=window_size,
+        )
+        self.self_attn_layer_norm = nn.LayerNorm(dimension)
+        self.fc1 = nn.Linear(dimension, feed_forward_dim)
+        self.fc2 = nn.Linear(feed_forward_dim, dimension)
+        self.final_layer_norm = nn.LayerNorm(dimension)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        lengths: torch.Tensor,
+        rotary: tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.self_attn(
+            self.self_attn_layer_norm(hidden_states),
+            lengths,
+            rotary,
+        )
+        hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = self.fc2(F.gelu(self.fc1(self.final_layer_norm(hidden_states))))
+        return residual + hidden_states
+
+
+class MiMoAudioTokenizerEncoder(nn.Module):
+    """Native input encoder matching `MiMo-Audio-Tokenizer` weight names."""
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        super().__init__()
+        self.config = config
+        dimension = int(config["d_model"])
+        heads = int(config["encoder_attention_heads"])
+        self.skip_layer_idx = int(config["encoder_skip_layer_id"])
+        self.stride_size = int(config["stride_size"])
+        self.avg_pooler = int(config["avg_pooler"])
+        self.conv1 = nn.Conv1d(
+            int(config["n_mels"]),
+            dimension,
+            int(config["kernel_size"]),
+            padding=1,
+        )
+        self.conv2 = nn.Conv1d(
+            dimension,
+            dimension,
+            int(config["kernel_size"]),
+            stride=self.stride_size,
+            padding=1,
+        )
+        self.position_embedding = _RotaryEmbedding(
+            float(config["rope_theta"]),
+            dimension // heads,
+        )
+        window = tuple(int(value) for value in config["encoder_attn_window_size"])
+        self.layers = nn.ModuleList(
+            [
+                _TransformerLayer(
+                    dimension,
+                    heads,
+                    int(config["encoder_ffn_dim"]),
+                    causal=bool(config["encoder_causal"]),
+                    window_size=window,
+                )
+                for _ in range(int(config["encoder_layers"]))
+            ]
+        )
+        self.layer_norm = nn.LayerNorm(dimension)
+        self.down_sample_layer = nn.Sequential(
+            nn.Conv1d(
+                dimension,
+                dimension,
+                self.avg_pooler,
+                self.avg_pooler,
+                bias=False,
+            ),
+            nn.GELU(),
+        )
+        self.down_sample_norm = nn.LayerNorm(dimension)
+        self.quantizer = _ResidualVectorQuantizer(
+            [int(size) for size in config["codebook_size"]],
+            dimension,
+        )
+
+    def _output_lengths(self, mel_lengths: torch.Tensor) -> torch.Tensor:
+        kernel = int(self.config["kernel_size"])
+        target = mel_lengths + 3 - kernel
+        return (target + 2 - kernel) // self.stride_size + 1
+
+    @torch.no_grad()
+    def encode(
+        self,
+        *,
+        input_features: torch.Tensor,
+        input_lens: torch.Tensor,
+        return_codes_only: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if return_codes_only is not True:
+            raise ValueError("Milestone 1 tokenizer supports codes-only encoding")
+        input_lens = input_lens.to(input_features.device, dtype=torch.int64)
+        hidden = _unpack_packed(input_features, input_lens).transpose(1, 2)
+        hidden = F.gelu(self.conv1(hidden.to(self.conv1.weight)))
+        hidden = F.gelu(self.conv2(hidden)).transpose(1, 2)
+        output_lengths = self._output_lengths(input_lens)
+        mask, unpacking_index = _sequence_mask(hidden, output_lengths)
+        hidden = torch.masked_select(hidden, mask).view(
+            int(output_lengths.sum().item()), int(self.config["d_model"])
+        )
+        positions = _packed_position_ids(output_lengths).long()
+        rotary = self.position_embedding(positions, hidden.dtype)
+
+        skip: torch.Tensor | float = 0.0
+        for index, layer in enumerate(self.layers):
+            hidden = layer(hidden, output_lengths, rotary)
+            if index == self.skip_layer_idx - 1:
+                skip = hidden.clone()
+        hidden = self.layer_norm(hidden + skip)
+
+        batch, target_len = mask.shape[:2]
+        hidden = torch.index_select(hidden, 0, unpacking_index).view(
+            batch, target_len, int(self.config["d_model"])
+        )
+        if target_len % self.avg_pooler:
+            padding = self.avg_pooler - target_len % self.avg_pooler
+            hidden = F.pad(hidden, (0, 0, 0, padding))
+        hidden = self.down_sample_layer(hidden.transpose(1, 2)).transpose(1, 2)
+        output_lengths = output_lengths.div(self.avg_pooler, rounding_mode="floor") + (
+            output_lengths % self.avg_pooler != 0
+        ).to(output_lengths.dtype)
+        mask, _ = _sequence_mask(hidden, output_lengths)
+        hidden = torch.masked_select(hidden, mask).view(
+            int(output_lengths.sum().item()), int(self.config["d_model"])
+        )
+        hidden = self.down_sample_norm(hidden)
+        return self.quantizer.encode(hidden.float()), output_lengths
+
+    @classmethod
+    def from_checkpoint(
+        cls,
+        snapshot_path: str | Path,
+        *,
+        device: str | torch.device = "cuda:0",
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> MiMoAudioTokenizerEncoder:
+        snapshot = Path(snapshot_path)
+        config = json.loads((snapshot / "config.json").read_text())
+        model = cls(config).to(device=device, dtype=dtype).eval()
+        state = model.state_dict()
+        expected = set(state)
+        loaded: set[str] = set()
+        checkpoint = snapshot / "model.safetensors"
+        with safe_open(checkpoint, framework="pt", device="cpu") as tensors:
+            # `safe_open` is not iterable in the pinned safetensors build.
+            for checkpoint_name in tensors.keys():  # noqa: SIM118
+                if not checkpoint_name.startswith("encoder."):
+                    continue
+                name = checkpoint_name.removeprefix("encoder.")
+                if name not in state:
+                    raise ValueError(
+                        f"Unexpected MiMo tokenizer encoder weight {checkpoint_name}"
+                    )
+                destination = state[name]
+                destination.copy_(
+                    tensors.get_tensor(checkpoint_name).to(
+                        device=destination.device,
+                        dtype=destination.dtype,
+                    )
+                )
+                loaded.add(name)
+        missing = expected - loaded
+        if missing:
+            raise ValueError(
+                "Missing MiMo tokenizer encoder weights: "
+                + ", ".join(sorted(missing)[:10])
+            )
+        return model
+
+
+__all__ = ["MiMoAudioTokenizerEncoder"]

--- a/sglang_omni/models/mimo_v25_asr/config.py
+++ b/sglang_omni/models/mimo_v25_asr/config.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pipeline configuration for MiMo-V2.5-ASR transcription."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pydantic import Field
+
+from sglang_omni.config import (
+    PipelineConfig,
+    StageConfig,
+    StageResourceConfig,
+    StageRuntimeConfig,
+)
+
+_PKG = "sglang_omni.models.mimo_v25_asr"
+MIMO_AUDIO_TOKENIZER_PATH = "XiaomiMiMo/MiMo-Audio-Tokenizer"
+
+
+def _mimo_v25_asr_stages() -> list[StageConfig]:
+    return [
+        StageConfig(
+            name="audio_tokenizer",
+            process="audio_tokenizer",
+            factory=f"{_PKG}.stages.create_audio_tokenizer_executor",
+            factory_args={
+                "tokenizer_path": MIMO_AUDIO_TOKENIZER_PATH,
+                "device": "cuda:0",
+            },
+            gpu=0,
+            runtime=StageRuntimeConfig(
+                resources=StageResourceConfig(total_gpu_memory_fraction=0.08)
+            ),
+            next="asr",
+        ),
+        StageConfig(
+            name="asr",
+            process="asr",
+            factory=f"{_PKG}.stages.create_asr_executor",
+            factory_args={
+                "device": "cuda:0",
+                "max_running_requests": 32,
+                "max_new_tokens": 256,
+            },
+            gpu=0,
+            runtime=StageRuntimeConfig(
+                resources=StageResourceConfig(total_gpu_memory_fraction=0.92)
+            ),
+            terminal=True,
+        ),
+    ]
+
+
+class MiMoV25ASRPipelineConfig(PipelineConfig):
+    """Two-stage, single-GPU MiMo-V2.5-ASR transcription pipeline.
+
+    The tokenizer stage converts a normalized waveform into eight-channel RVQ
+    codes. The ASR stage runs SGLang Qwen2 decode and returns text only.
+    """
+
+    architecture: ClassVar[str] = "MiMoV2ASRForCausalLM"
+
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"tokenizer": "audio_tokenizer", "asr": "asr"}
+
+    @classmethod
+    def generation_sglang_role_to_stage(cls) -> dict[str, str]:
+        return {"generation": "asr"}
+
+    model_path: str
+    entry_stage: str = "audio_tokenizer"
+    stages: list[StageConfig] = Field(default_factory=_mimo_v25_asr_stages)
+
+
+EntryClass = MiMoV25ASRPipelineConfig

--- a/sglang_omni/models/mimo_v25_asr/preprocessor.py
+++ b/sglang_omni/models/mimo_v25_asr/preprocessor.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Waveform-to-RVQ preprocessing for MiMo-V2.5-ASR."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+import torchaudio
+
+from sglang_omni.models.mimo_v25_asr.prompt import AUDIO_CHANNELS, pad_audio_codes
+from sglang_omni.utils.audio import load_audio
+
+
+@dataclass(frozen=True)
+class MiMoAudioTokenizerSettings:
+    sampling_rate: int = 24_000
+    n_fft: int = 960
+    hop_length: int = 240
+    window_size: int = 960
+    n_mels: int = 128
+    f_min: float = 0.0
+    f_max: float | None = None
+    chunk_seconds: float = 30.0
+
+    @classmethod
+    def from_config(cls, config: Any) -> MiMoAudioTokenizerSettings:
+        def value(name: str, default: Any) -> Any:
+            if isinstance(config, dict):
+                return config.get(name, default)
+            return getattr(config, name, default)
+
+        return cls(
+            sampling_rate=int(value("sampling_rate", cls.sampling_rate)),
+            n_fft=int(value("nfft", cls.n_fft)),
+            hop_length=int(value("hop_length", cls.hop_length)),
+            window_size=int(value("window_size", cls.window_size)),
+            n_mels=int(value("n_mels", cls.n_mels)),
+            f_min=float(value("fmin", cls.f_min)),
+            f_max=(
+                None
+                if value("fmax", cls.f_max) is None
+                else float(value("fmax", cls.f_max))
+            ),
+        )
+
+
+class MiMoAudioEncoder(Protocol):
+    def encode(
+        self,
+        *,
+        input_features: torch.Tensor,
+        input_lens: torch.Tensor,
+        return_codes_only: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor]: ...
+
+
+class MiMoAudioPreprocessor:
+    """Official V2.5-ASR log-mel preparation with 30s waveform chunking."""
+
+    def __init__(
+        self,
+        settings: MiMoAudioTokenizerSettings | None = None,
+        *,
+        device: str | torch.device = "cpu",
+    ) -> None:
+        self.settings = settings or MiMoAudioTokenizerSettings()
+        self.device = torch.device(device)
+        self.mel_transform = torchaudio.transforms.MelSpectrogram(
+            sample_rate=self.settings.sampling_rate,
+            n_fft=self.settings.n_fft,
+            hop_length=self.settings.hop_length,
+            win_length=self.settings.window_size,
+            f_min=self.settings.f_min,
+            f_max=self.settings.f_max,
+            n_mels=self.settings.n_mels,
+            power=1.0,
+            center=True,
+        ).to(self.device)
+
+    def load_waveform(self, source: Any) -> torch.Tensor:
+        waveform = load_audio(
+            source,
+            source_name="MiMo-V2.5-ASR",
+            target_sample_rate=self.settings.sampling_rate,
+        )
+        if waveform.size == 0:
+            raise ValueError("MiMo-V2.5-ASR input waveform is empty")
+        return torch.from_numpy(np.asarray(waveform, dtype=np.float32)).to(self.device)
+
+    def waveform_to_log_mel(self, waveform: torch.Tensor) -> torch.Tensor:
+        waveform = torch.as_tensor(
+            waveform,
+            dtype=torch.float32,
+            device=self.device,
+        ).reshape(-1)
+        if waveform.numel() == 0:
+            raise ValueError("MiMo-V2.5-ASR input waveform is empty")
+        spectrogram = self.mel_transform(waveform[None, :])
+        return (
+            torch.log(torch.clamp(spectrogram, min=1.0e-7)).squeeze(0).transpose(0, 1)
+        )
+
+    @torch.no_grad()
+    def encode_waveform(
+        self,
+        waveform: torch.Tensor,
+        encoder: MiMoAudioEncoder,
+    ) -> torch.Tensor:
+        """Encode with the official 30-second waveform chunk loop."""
+
+        wav = torch.as_tensor(
+            waveform, dtype=torch.float32, device=self.device
+        ).reshape(-1)
+        if wav.numel() == 0:
+            raise ValueError("MiMo-V2.5-ASR input waveform is empty")
+
+        chunk_samples = int(self.settings.chunk_seconds * self.settings.sampling_rate)
+        n_fft = self.settings.n_fft
+        total_samples = int(wav.shape[-1])
+        code_parts: list[torch.Tensor] = []
+        start = 0
+        while start < total_samples:
+            end = min(start + chunk_samples, total_samples)
+            # Merge a too-short trailing chunk (would break mel reflect padding).
+            if 0 < total_samples - end < n_fft:
+                end = total_samples
+            chunk = wav[start:end]
+            if chunk.shape[-1] < n_fft:
+                chunk = F.pad(chunk, (0, n_fft - chunk.shape[-1]))
+            mel = self.waveform_to_log_mel(chunk)
+            packed_codes, _ = encoder.encode(
+                input_features=mel.to(self.device),
+                input_lens=torch.tensor([mel.size(0)], device=self.device),
+                return_codes_only=True,
+            )
+            if packed_codes.ndim != 2 or packed_codes.shape[0] < AUDIO_CHANNELS:
+                raise ValueError(
+                    "MiMo tokenizer returned invalid codes with shape "
+                    f"{tuple(packed_codes.shape)}"
+                )
+            code_parts.append(packed_codes[:AUDIO_CHANNELS].detach())
+            start = end
+
+        codes = torch.cat(code_parts, dim=-1).transpose(0, 1).cpu().long()
+        return pad_audio_codes(codes)
+
+    def encode_source(
+        self,
+        source: Any,
+        encoder: MiMoAudioEncoder,
+    ) -> tuple[torch.Tensor, float]:
+        waveform = self.load_waveform(source)
+        duration_s = float(waveform.numel() / self.settings.sampling_rate)
+        return self.encode_waveform(waveform, encoder), duration_s
+
+
+def default_tokenizer_config_path(tokenizer_snapshot: str | Path) -> Path:
+    return Path(tokenizer_snapshot) / "config.json"
+
+
+__all__ = [
+    "MiMoAudioEncoder",
+    "MiMoAudioPreprocessor",
+    "MiMoAudioTokenizerSettings",
+    "default_tokenizer_config_path",
+]

--- a/sglang_omni/models/mimo_v25_asr/prompt.py
+++ b/sglang_omni/models/mimo_v25_asr/prompt.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Official-compatible MiMo-V2.5-ASR prompt construction."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+GROUP_SIZE = 4
+AUDIO_CHANNELS = 8
+SPEECH_EMPTY_IDS = (1024, 1024, 128, 128, 128, 128, 128, 128)
+
+SOSP = "<|sosp|>"
+EOSP = "<|eosp|>"
+EMPTY = "<|empty|>"
+
+# Deterministic first templates from XiaomiMiMo/MiMo-V2.5-ASR templates.py.
+ASR_ZH_TEMPLATE = "请将这段语音转换为文字"
+ASR_EN_TEMPLATE = "Please transcribe this audio file"
+
+CHINESE_TAG = "<chinese>"
+ENGLISH_TAG = "<english>"
+
+
+@dataclass(frozen=True)
+class MiMoPrompt:
+    """Official nine-channel representation and SGLang projection."""
+
+    input_ids: list[int]
+    audio_codes: torch.Tensor
+    official_input_ids: torch.Tensor
+    audio_start: int
+    audio_end: int
+    audio_tag: str
+    instruction: str
+
+
+def _token_id(tokenizer: Any, token: str) -> int:
+    if hasattr(tokenizer, "convert_tokens_to_ids"):
+        token_id = tokenizer.convert_tokens_to_ids(token)
+    elif hasattr(tokenizer, "token_to_id"):
+        token_id = tokenizer.token_to_id(token)
+    else:
+        raise TypeError("MiMo tokenizer does not expose token ID lookup")
+    if token_id is None or int(token_id) < 0:
+        raise ValueError(f"MiMo tokenizer is missing required token {token!r}")
+    return int(token_id)
+
+
+def _encode_literal(tokenizer: Any, text: str) -> list[int]:
+    if hasattr(tokenizer, "encode"):
+        encoded = tokenizer.encode(text, add_special_tokens=False)
+        if hasattr(encoded, "ids"):
+            return [int(token_id) for token_id in encoded.ids]
+        return [int(token_id) for token_id in encoded]
+    encoded = tokenizer(text, add_special_tokens=False)
+    input_ids = (
+        encoded.input_ids if hasattr(encoded, "input_ids") else encoded["input_ids"]
+    )
+    if isinstance(input_ids, torch.Tensor):
+        input_ids = input_ids.reshape(-1).tolist()
+    elif input_ids and isinstance(input_ids[0], list):
+        input_ids = input_ids[0]
+    return [int(token_id) for token_id in input_ids]
+
+
+def _expand_text_ids(token_ids: Sequence[int], group_size: int) -> torch.Tensor:
+    expanded = torch.full(
+        (len(token_ids) * group_size,),
+        -100,
+        dtype=torch.int64,
+    )
+    expanded[::group_size] = torch.tensor(token_ids, dtype=torch.int64)
+    return expanded
+
+
+def _speech_empty_rows(length: int, speech_empty_ids: Sequence[int]) -> torch.Tensor:
+    return torch.tensor(speech_empty_ids, dtype=torch.int64)[:, None].expand(-1, length)
+
+
+def resolve_audio_tag(language: str | None) -> str:
+    """Map OpenAI transcription `language` to official MiMo audio tags."""
+
+    if language is None:
+        return ""
+    normalized = str(language).strip().lower()
+    if normalized in {"", "auto", "none"}:
+        return ""
+    if normalized in {"zh", "zh-cn", "zh-hans", "chinese", "cmn"}:
+        return CHINESE_TAG
+    if normalized in {"en", "en-us", "en-gb", "english"}:
+        return ENGLISH_TAG
+    return ""
+
+
+def select_asr_instruction(audio_tag: str) -> str:
+    """Pick a deterministic ASR instruction matching official template pools."""
+
+    if CHINESE_TAG in audio_tag:
+        return ASR_ZH_TEMPLATE
+    if ENGLISH_TAG in audio_tag:
+        return ASR_EN_TEMPLATE
+    # Official auto path samples from zh+en; serving uses the English template.
+    return ASR_EN_TEMPLATE
+
+
+def build_text_segment(
+    tokenizer: Any,
+    text: str,
+    *,
+    group_size: int = GROUP_SIZE,
+    speech_empty_ids: Sequence[int] = SPEECH_EMPTY_IDS,
+) -> torch.Tensor:
+    text_row = _expand_text_ids(_encode_literal(tokenizer, text), group_size)
+    return torch.cat(
+        [text_row[None, :], _speech_empty_rows(text_row.numel(), speech_empty_ids)],
+        dim=0,
+    )
+
+
+def build_audio_segment(
+    tokenizer: Any,
+    audio_codes: torch.Tensor,
+    *,
+    group_size: int = GROUP_SIZE,
+    speech_empty_ids: Sequence[int] = SPEECH_EMPTY_IDS,
+) -> torch.Tensor:
+    codes = torch.as_tensor(audio_codes, dtype=torch.int64)
+    audio_channels = len(speech_empty_ids)
+    if codes.ndim != 2 or codes.shape[1] != audio_channels:
+        raise ValueError(
+            "MiMo audio codes must have shape "
+            f"[frames, {audio_channels}], got {tuple(codes.shape)}"
+        )
+    if codes.shape[0] == 0:
+        raise ValueError("MiMo audio codes must contain at least one frame")
+    if codes.shape[0] % group_size:
+        raise ValueError(
+            f"MiMo audio-code frames must be divisible by group_size={group_size}, "
+            f"got {codes.shape[0]}"
+        )
+
+    audio_frames = codes.T.contiguous()
+    group_count = codes.shape[0] // group_size
+    text_tokens = [
+        _token_id(tokenizer, SOSP),
+        *([_token_id(tokenizer, EMPTY)] * group_count),
+        _token_id(tokenizer, EOSP),
+    ]
+    text_row = _expand_text_ids(text_tokens, group_size)
+    boundary = _speech_empty_rows(group_size, speech_empty_ids)
+    speech_rows = torch.cat([boundary, audio_frames, boundary], dim=1)
+    return torch.cat([text_row[None, :], speech_rows], dim=0)
+
+
+def pad_audio_codes(
+    audio_codes: torch.Tensor, *, group_size: int = GROUP_SIZE
+) -> torch.Tensor:
+    codes = torch.as_tensor(audio_codes, dtype=torch.int64)
+    if codes.ndim != 2 or codes.shape[0] == 0:
+        raise ValueError("MiMo audio codes must be a non-empty rank-2 tensor")
+    remainder = codes.shape[0] % group_size
+    if remainder == 0:
+        return codes
+    return torch.cat(
+        [codes, codes[-1:].expand(group_size - remainder, -1)],
+        dim=0,
+    )
+
+
+def build_asr_sft_prompt(
+    tokenizer: Any,
+    audio_codes: torch.Tensor,
+    *,
+    language: str | None = None,
+    instruction: str | None = None,
+    group_size: int = GROUP_SIZE,
+    speech_empty_ids: Sequence[int] = SPEECH_EMPTY_IDS,
+) -> MiMoPrompt:
+    """Build the official `asr_sft` nine-channel prompt and SGLang projection."""
+
+    audio_tag = resolve_audio_tag(language)
+    resolved_instruction = (
+        instruction.strip()
+        if instruction and instruction.strip()
+        else select_asr_instruction(audio_tag)
+    )
+    codes = pad_audio_codes(audio_codes, group_size=group_size)
+    segments = [
+        build_text_segment(
+            tokenizer,
+            "<|im_start|>user\n",
+            group_size=group_size,
+            speech_empty_ids=speech_empty_ids,
+        ),
+        build_audio_segment(
+            tokenizer,
+            codes,
+            group_size=group_size,
+            speech_empty_ids=speech_empty_ids,
+        ),
+        build_text_segment(
+            tokenizer,
+            resolved_instruction,
+            group_size=group_size,
+            speech_empty_ids=speech_empty_ids,
+        ),
+        build_text_segment(
+            tokenizer,
+            "<|im_end|>\n",
+            group_size=group_size,
+            speech_empty_ids=speech_empty_ids,
+        ),
+        build_text_segment(
+            tokenizer,
+            "<|im_start|>assistant\n",
+            group_size=group_size,
+            speech_empty_ids=speech_empty_ids,
+        ),
+        build_text_segment(
+            tokenizer,
+            f"<think>\n\n</think>\n{audio_tag}",
+            group_size=group_size,
+            speech_empty_ids=speech_empty_ids,
+        ),
+    ]
+    official = torch.cat(segments, dim=1)
+    input_ids = [int(token_id) for token_id in official[0, ::group_size].tolist()]
+    audio_start = input_ids.index(_token_id(tokenizer, SOSP)) + 1
+    audio_end = input_ids.index(_token_id(tokenizer, EOSP), audio_start)
+    if audio_end - audio_start != codes.shape[0] // group_size:
+        raise AssertionError("MiMo prompt audio placeholders do not match code groups")
+    return MiMoPrompt(
+        input_ids=input_ids,
+        audio_codes=codes,
+        official_input_ids=official,
+        audio_start=audio_start,
+        audio_end=audio_end,
+        audio_tag=audio_tag,
+        instruction=resolved_instruction,
+    )
+
+
+def strip_asr_markers(text: str) -> str:
+    cleaned = text
+    for marker in (
+        EMPTY,
+        "<|eot|>",
+        "<|eostm|>",
+        "<|im_end|>",
+        "<|endoftext|>",
+        CHINESE_TAG,
+        ENGLISH_TAG,
+    ):
+        cleaned = cleaned.replace(marker, "")
+    return cleaned.strip()
+
+
+__all__ = [
+    "AUDIO_CHANNELS",
+    "ASR_EN_TEMPLATE",
+    "ASR_ZH_TEMPLATE",
+    "CHINESE_TAG",
+    "EMPTY",
+    "ENGLISH_TAG",
+    "GROUP_SIZE",
+    "SPEECH_EMPTY_IDS",
+    "MiMoPrompt",
+    "build_asr_sft_prompt",
+    "build_audio_segment",
+    "build_text_segment",
+    "pad_audio_codes",
+    "resolve_audio_tag",
+    "select_asr_instruction",
+    "strip_asr_markers",
+]

--- a/sglang_omni/models/mimo_v25_asr/request_builders.py
+++ b/sglang_omni/models/mimo_v25_asr/request_builders.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MiMo-V2.5-ASR StagePayload adapters."""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+    Req,
+)
+from sglang.srt.sampling.sampling_params import SamplingParams
+
+from sglang_omni.models.mimo_v25_asr.prompt import (
+    EMPTY,
+    build_asr_sft_prompt,
+    strip_asr_markers,
+)
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
+
+
+def audio_source_from_payload(payload: StagePayload) -> Any:
+    inputs = payload.request.inputs
+    if isinstance(inputs, dict):
+        for key in ("audio_bytes", "bytes", "file"):
+            if inputs.get(key) is not None:
+                return inputs[key]
+        for key in ("audio_path", "path", "url"):
+            if inputs.get(key) is not None:
+                return inputs[key]
+    if inputs is None:
+        raise ValueError("MiMo-V2.5-ASR request is missing audio input")
+    return inputs
+
+
+def validate_text_only_request(payload: StagePayload) -> None:
+    modalities = payload.request.metadata.get("output_modalities", ["text"])
+    if isinstance(modalities, str):
+        modalities = [modalities]
+    normalized = {str(value).strip().lower() for value in modalities}
+    if "audio" in normalized or normalized - {"text"}:
+        raise ValueError(
+            "MiMo-V2.5-ASR supports text transcription only; audio output is "
+            "not implemented"
+        )
+
+
+@dataclass
+class MiMoV25ASRRequestData(SGLangARRequestData):
+    output_ids: list[int] | None = None
+    prompt_token_ids: list[int] | None = None
+    audio_duration_s: float = 0.0
+    language: str = "auto"
+    engine_start_s: float = 0.0
+
+
+def make_mimo_v25_asr_scheduler_adapters(
+    *,
+    tokenizer: Any,
+    max_new_tokens: int,
+) -> tuple[
+    Callable[[StagePayload], MiMoV25ASRRequestData],
+    Callable[[MiMoV25ASRRequestData], StagePayload],
+]:
+    eos_id = int(tokenizer.eos_token_id)
+    im_end_id = int(tokenizer.convert_tokens_to_ids("<|im_end|>"))
+    empty_id = int(tokenizer.convert_tokens_to_ids(EMPTY))
+    if hasattr(tokenizer, "vocab_size"):
+        vocab_size = int(tokenizer.vocab_size)
+    else:
+        vocab_size = int(len(tokenizer))
+
+    def request_builder(payload: StagePayload) -> MiMoV25ASRRequestData:
+        validate_text_only_request(payload)
+        if not isinstance(payload.data, dict) or "audio_codes" not in payload.data:
+            raise ValueError("MiMo-V2.5-ASR requires preprocessed audio codes")
+        codes = torch.as_tensor(payload.data["audio_codes"], dtype=torch.long)
+        params = payload.request.params or {}
+        language = str(params.get("language") or "auto")
+        prompt_override = params.get("prompt")
+        prompt = build_asr_sft_prompt(
+            tokenizer,
+            codes,
+            language=language,
+            instruction=str(prompt_override) if prompt_override else None,
+        )
+        input_ids = list(prompt.input_ids)
+        fingerprint = str(
+            payload.data.get(
+                "audio_fingerprint",
+                hashlib.sha256(codes.numpy().tobytes()).hexdigest(),
+            )
+        )
+        item = MultimodalDataItem(
+            modality=Modality.AUDIO,
+            hash=int(fingerprint[:16], 16),
+            feature=prompt.audio_codes,
+        )
+        item.set_pad_value()
+        for index in range(prompt.audio_start, prompt.audio_end):
+            input_ids[index] = item.pad_value
+        item.offsets = [(prompt.audio_start, prompt.audio_end - 1)]
+        mm_inputs = MultimodalInputs(
+            mm_items=[item],
+            num_image_tokens=prompt.audio_end - prompt.audio_start,
+        )
+        mm_inputs.audio_token_id = empty_id
+
+        temperature = float(params.get("temperature") or 0.0)
+        request_max_new_tokens = int(params.get("max_new_tokens") or max_new_tokens)
+        sampling = SamplingParams(
+            max_new_tokens=request_max_new_tokens,
+            temperature=temperature,
+            top_p=1.0,
+            stop_token_ids=[eos_id, im_end_id],
+            # `<|empty|>` selects official output-audio generation. Suppress it
+            # so ASR cannot enter a delayed-RVQ path.
+            logit_bias={str(empty_id): -1.0e9},
+        )
+        sampling.normalize(tokenizer=None)
+        req = Req(
+            rid=payload.request_id,
+            origin_input_text="",
+            origin_input_ids=input_ids,
+            sampling_params=sampling,
+            vocab_size=vocab_size,
+            extra_key=fingerprint,
+        )
+        req.multimodal_inputs = mm_inputs
+        req._codec_suppress_tokens = None
+        return MiMoV25ASRRequestData(
+            input_ids=torch.tensor(input_ids, dtype=torch.long),
+            req=req,
+            prompt_token_ids=input_ids,
+            max_new_tokens=request_max_new_tokens,
+            temperature=temperature,
+            audio_duration_s=float(payload.data.get("audio_duration_s", 0.0)),
+            language=language,
+            engine_start_s=time.perf_counter(),
+            stage_payload=payload,
+        )
+
+    def result_adapter(data: MiMoV25ASRRequestData) -> StagePayload:
+        payload = data.stage_payload
+        output_ids = list(data.output_ids or [])
+        text = tokenizer.decode(
+            output_ids,
+            skip_special_tokens=False,
+            clean_up_tokenization_spaces=False,
+        )
+        latency = (
+            time.perf_counter() - data.engine_start_s if data.engine_start_s else 0.0
+        )
+        return StagePayload(
+            request_id=payload.request_id,
+            request=payload.request,
+            data={
+                "text": strip_asr_markers(text),
+                "language": data.language,
+                "duration_s": data.audio_duration_s,
+                "asr_latency_s": latency,
+                "usage": {"engine_time_s": latency},
+                "modality": "text",
+            },
+        )
+
+    return request_builder, result_adapter
+
+
+__all__ = [
+    "MiMoV25ASRRequestData",
+    "audio_source_from_payload",
+    "make_mimo_v25_asr_scheduler_adapters",
+    "validate_text_only_request",
+]

--- a/sglang_omni/models/mimo_v25_asr/sglang_model.py
+++ b/sglang_omni/models/mimo_v25_asr/sglang_model.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SGLang-native MiMo Qwen2 model for audio-input-to-text inference."""
+
+from __future__ import annotations
+
+import copy
+import logging
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+import torch
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.managers.mm_utils import (
+    MultiModalityDataPaddingPatternMultimodalTokens,
+    general_mm_embed_routine,
+)
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.qwen2 import Qwen2ForCausalLM
+from sglang.srt.utils import add_prefix
+from torch import nn
+from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
+from transformers.models.qwen2.modeling_qwen2 import Qwen2Model as HFQwen2Model
+
+from .prompt import AUDIO_CHANNELS, GROUP_SIZE, SPEECH_EMPTY_IDS
+
+logger = logging.getLogger(__name__)
+
+OUTPUT_ONLY_WEIGHT_PREFIXES = (
+    "local_transformer.",
+    "local_transformer_lm_heads.",
+    "hidden_states_downcast.",
+    "speech_embeddings_to_local.",
+)
+
+
+def parse_channel_values(
+    value: str | int | Sequence[int],
+    *,
+    channels: int = AUDIO_CHANNELS,
+) -> tuple[int, ...]:
+    if isinstance(value, str):
+        values = tuple(int(part) for part in value.split("-"))
+    elif isinstance(value, int):
+        values = (value,) * channels
+    else:
+        values = tuple(int(part) for part in value)
+    if len(values) != channels:
+        raise ValueError(f"expected {channels} channel values, got {len(values)}")
+    return values
+
+
+def is_output_only_weight(name: str) -> bool:
+    return name.startswith(OUTPUT_ONLY_WEIGHT_PREFIXES)
+
+
+def make_input_local_config(config: Qwen2Config) -> Qwen2Config:
+    local = copy.deepcopy(config)
+    local.hidden_size = int(getattr(config, "input_local_dim", 1024))
+    local.num_hidden_layers = int(getattr(config, "input_local_layers", 6))
+    local.num_attention_heads = int(getattr(config, "local_attn_heads", 64))
+    local.num_key_value_heads = local.num_attention_heads
+    local.head_dim = local.hidden_size // local.num_attention_heads
+    local.intermediate_size = local.hidden_size * 4
+    local.attention_dropout = float(getattr(config, "local_attn_dropout", 0.1))
+    local.vocab_size = 1
+    local.tie_word_embeddings = False
+    local.use_cache = False
+    local.layer_types = ["full_attention"] * local.num_hidden_layers
+    # Passing an explicit all-visible mask below is only unambiguously
+    # non-causal with eager attention across supported Transformers versions.
+    local._attn_implementation = "eager"
+    return local
+
+
+class MiMoInputPatchEncoder(nn.Module):
+    """Turn `[frames, 8]` RVQ codes into one global embedding per 4 frames."""
+
+    def __init__(self, config: Qwen2Config) -> None:
+        super().__init__()
+        self.group_size = int(getattr(config, "group_size", GROUP_SIZE))
+        self.audio_channels = int(getattr(config, "audio_channels", AUDIO_CHANNELS))
+        if self.group_size != GROUP_SIZE or self.audio_channels != AUDIO_CHANNELS:
+            raise ValueError(
+                "Milestone 1 supports MiMo group_size=4 and audio_channels=8, "
+                f"got {self.group_size} and {self.audio_channels}"
+            )
+
+        self.speech_vocab_sizes = parse_channel_values(
+            getattr(config, "speech_vocab_size", "1025-1025-129-129-129-129-129-129")
+        )
+        self.speech_empty_ids = parse_channel_values(
+            getattr(config, "speech_zeroemb_idx", SPEECH_EMPTY_IDS)
+        )
+        self.input_local_config = make_input_local_config(config)
+        self.input_local_transformer = HFQwen2Model(self.input_local_config)
+        # Official MiMo supplies `inputs_embeds`; this table has no checkpoint
+        # tensor and would waste memory.
+        self.input_local_transformer.embed_tokens = None
+        self.speech_embeddings = nn.ModuleList(
+            [
+                nn.Embedding(vocab_size, self.input_local_config.hidden_size)
+                for vocab_size in self.speech_vocab_sizes
+            ]
+        )
+        self.speech_group_downcast = nn.Linear(
+            self.input_local_config.hidden_size * self.group_size,
+            config.hidden_size,
+            bias=False,
+        )
+
+    def forward(self, audio_codes: torch.Tensor) -> torch.Tensor:
+        codes = torch.as_tensor(audio_codes, dtype=torch.long)
+        if codes.ndim != 2 or codes.shape[1] != self.audio_channels:
+            raise ValueError(
+                "MiMo audio codes must have shape "
+                f"[frames, {self.audio_channels}], got {tuple(codes.shape)}"
+            )
+        if codes.shape[0] == 0 or codes.shape[0] % self.group_size:
+            raise ValueError(
+                "MiMo audio-code frames must be non-empty and divisible by "
+                f"group_size={self.group_size}, got {codes.shape[0]}"
+            )
+        for channel, vocab_size in enumerate(self.speech_vocab_sizes):
+            if torch.any(codes[:, channel] < 0) or torch.any(
+                codes[:, channel] >= vocab_size
+            ):
+                raise ValueError(
+                    f"MiMo channel {channel} code is outside [0, {vocab_size})"
+                )
+
+        device = self.speech_embeddings[0].weight.device
+        codes = codes.to(device)
+        groups = codes.shape[0] // self.group_size
+        grouped = codes.reshape(groups, self.group_size, self.audio_channels)
+        speech_embeds = torch.zeros(
+            (groups, self.group_size, self.input_local_config.hidden_size),
+            device=device,
+            dtype=self.speech_embeddings[0].weight.dtype,
+        )
+        for channel, embedding in enumerate(self.speech_embeddings):
+            speech_embeds.add_(embedding(grouped[:, :, channel]))
+
+        # Each four-frame patch is a separate batch item. An explicit
+        # all-visible eager-attention mask reproduces official
+        # `input_full_attention=True`.
+        output = self.input_local_transformer(
+            inputs_embeds=speech_embeds,
+            attention_mask={"full_attention": None},
+            use_cache=False,
+            return_dict=True,
+        )
+        return self.speech_group_downcast(output.last_hidden_state.reshape(groups, -1))
+
+
+class MiMoV2ASRForCausalLM(nn.Module):
+    """MiMo global Qwen2 plus input-side patch encoder, with text-only output."""
+
+    default_bitsandbytes_target_modules = (
+        Qwen2ForCausalLM.default_bitsandbytes_target_modules
+    )
+    bitsandbytes_stacked_params_mapping = (
+        Qwen2ForCausalLM.bitsandbytes_stacked_params_mapping
+    )
+
+    def __init__(
+        self,
+        config: Qwen2Config,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.language_model = Qwen2ForCausalLM(
+            config,
+            quant_config=quant_config,
+            prefix=add_prefix("language_model", prefix),
+        )
+        self.input_patch_encoder = MiMoInputPatchEncoder(config)
+        self.pattern = MultiModalityDataPaddingPatternMultimodalTokens()
+        self.loaded_weight_names: set[str] = set()
+        self.skipped_output_weight_names: set[str] = set()
+        self.unexpected_weight_names: set[str] = set()
+
+    def pad_input_ids(
+        self, input_ids: list[int], mm_inputs: MultimodalInputs
+    ) -> list[int]:
+        return self.pattern.pad_input_tokens(input_ids, mm_inputs)
+
+    def get_audio_feature(self, items: list[MultimodalDataItem]) -> torch.Tensor:
+        return torch.cat(
+            [self.input_patch_encoder(item.feature) for item in items],
+            dim=0,
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        return general_mm_embed_routine(
+            input_ids=input_ids,
+            forward_batch=forward_batch,
+            language_model=self.language_model,
+            data_embedding_funcs={Modality.AUDIO: self.get_audio_feature},
+            positions=positions,
+        )
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        global_weights: list[tuple[str, torch.Tensor]] = []
+        custom_params = dict(
+            self.input_patch_encoder.named_parameters(remove_duplicate=False)
+        )
+        loaded_custom_params: set[str] = set()
+
+        for name, loaded_weight in weights:
+            if name.startswith(("model.", "lm_head.")):
+                global_weights.append((name, loaded_weight))
+                self.loaded_weight_names.add(name)
+                continue
+            if is_output_only_weight(name):
+                self.skipped_output_weight_names.add(name)
+                continue
+
+            custom_name = name
+            if custom_name.startswith("input_local_transformer."):
+                custom_name = "input_local_transformer." + custom_name.removeprefix(
+                    "input_local_transformer."
+                )
+            if custom_name not in custom_params:
+                self.unexpected_weight_names.add(name)
+                continue
+            param = custom_params[custom_name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded_custom_params.add(custom_name)
+            self.loaded_weight_names.add(name)
+
+        self.language_model.load_weights(global_weights)
+        missing_custom_params = set(custom_params) - loaded_custom_params
+        if missing_custom_params:
+            missing = ", ".join(sorted(missing_custom_params)[:10])
+            raise ValueError(f"Missing required MiMo input weights: {missing}")
+        if self.unexpected_weight_names:
+            unexpected = ", ".join(sorted(self.unexpected_weight_names)[:10])
+            raise ValueError(f"Unexpected MiMo checkpoint weights: {unexpected}")
+        logger.info(
+            "MiMo Milestone 1 loaded %d tensors and intentionally skipped "
+            "%d output-only tensors",
+            len(self.loaded_weight_names),
+            len(self.skipped_output_weight_names),
+        )
+        return self.loaded_weight_names
+
+
+EntryClass = MiMoV2ASRForCausalLM
+
+__all__ = [
+    "OUTPUT_ONLY_WEIGHT_PREFIXES",
+    "EntryClass",
+    "MiMoV2ASRForCausalLM",
+    "MiMoInputPatchEncoder",
+    "is_output_only_weight",
+    "make_input_local_config",
+    "parse_channel_values",
+]

--- a/sglang_omni/models/mimo_v25_asr/stages.py
+++ b/sglang_omni/models/mimo_v25_asr/stages.py
@@ -121,7 +121,9 @@ def create_asr_executor(
         context_length=8192,
         **overrides,
     )
-    validate_generation_batch_policy(model_name="MiMo-V2.5-ASR", server_args=server_args)
+    validate_generation_batch_policy(
+        model_name="MiMo-V2.5-ASR", server_args=server_args
+    )
     (
         _,
         (

--- a/sglang_omni/models/mimo_v25_asr/stages.py
+++ b/sglang_omni/models/mimo_v25_asr/stages.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stage factories for MiMo-V2.5-ASR transcription."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import torch
+from huggingface_hub import snapshot_download
+from sglang.srt.managers.mm_utils import init_mm_embedding_cache
+
+from sglang_omni.models.mimo_v25_asr.audio_tokenizer import MiMoAudioTokenizerEncoder
+from sglang_omni.models.mimo_v25_asr.preprocessor import (
+    MiMoAudioPreprocessor,
+    MiMoAudioTokenizerSettings,
+)
+from sglang_omni.models.mimo_v25_asr.request_builders import (
+    audio_source_from_payload,
+    make_mimo_v25_asr_scheduler_adapters,
+    validate_text_only_request,
+)
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+
+
+def _torch_dtype(value: str) -> torch.dtype:
+    normalized = value.strip().lower()
+    if normalized in {"bf16", "bfloat16"}:
+        return torch.bfloat16
+    if normalized in {"fp16", "float16", "half"}:
+        return torch.float16
+    if normalized in {"fp32", "float32"}:
+        return torch.float32
+    raise ValueError(f"Unsupported MiMo-V2.5-ASR dtype {value!r}")
+
+
+def create_audio_tokenizer_executor(
+    model_path: str,
+    *,
+    tokenizer_path: str,
+    device: str = "cuda:0",
+    dtype: str = "bfloat16",
+) -> SimpleScheduler:
+    del model_path
+    snapshot = snapshot_download(
+        tokenizer_path,
+        allow_patterns=["config.json", "model.safetensors"],
+    )
+    encoder = MiMoAudioTokenizerEncoder.from_checkpoint(
+        snapshot,
+        device=device,
+        dtype=_torch_dtype(dtype),
+    )
+    preprocessor = MiMoAudioPreprocessor(
+        MiMoAudioTokenizerSettings.from_config(encoder.config),
+        device=device,
+    )
+
+    def _encode(payload: StagePayload) -> StagePayload:
+        validate_text_only_request(payload)
+        waveform = preprocessor.load_waveform(audio_source_from_payload(payload))
+        duration_s = float(waveform.numel() / preprocessor.settings.sampling_rate)
+        codes = preprocessor.encode_waveform(waveform, encoder)
+        payload.data = {
+            "audio_codes": codes,
+            "audio_duration_s": duration_s,
+            "audio_fingerprint": hashlib.sha256(
+                waveform.detach().cpu().numpy().tobytes()
+            ).hexdigest(),
+            "code_shape": tuple(codes.shape),
+            "modality": "audio_codes",
+        }
+        return payload
+
+    return SimpleScheduler(_encode)
+
+
+def create_asr_executor(
+    model_path: str,
+    *,
+    device: str = "cuda:0",
+    dtype: str = "bfloat16",
+    max_running_requests: int = 1,
+    max_new_tokens: int = 256,
+    mem_fraction_static: float = 0.80,
+    mm_embedding_cache_size_bytes: int = 0,
+    server_args_overrides: dict[str, Any] | None = None,
+):
+    from transformers import AutoTokenizer
+
+    from sglang_omni.model_runner.base import ModelRunner
+    from sglang_omni.scheduling.bootstrap import (
+        create_sglang_infrastructure_defer_cuda_graph,
+    )
+    from sglang_omni.scheduling.generation_batch_policy import (
+        build_generation_batch_overrides,
+        validate_generation_batch_policy,
+    )
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+    from sglang_omni.scheduling.sglang_backend import (
+        SGLangOutputProcessor,
+        build_sglang_server_args,
+    )
+
+    gpu_id = int(device.split(":")[-1]) if ":" in device else 0
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=False)
+    overrides = build_generation_batch_overrides(
+        max_running_requests=max_running_requests,
+        server_args_overrides=server_args_overrides,
+        disable_cuda_graph=True,
+        disable_overlap_schedule=True,
+        mem_fraction_static=mem_fraction_static,
+        max_prefill_tokens=8192,
+        chunked_prefill_size=8192,
+        sampling_backend="pytorch",
+        dtype=dtype,
+    )
+    server_args = build_sglang_server_args(
+        model_path,
+        context_length=8192,
+        **overrides,
+    )
+    validate_generation_batch_policy(model_name="MiMo-V2.5-ASR", server_args=server_args)
+    (
+        _,
+        (
+            model_worker,
+            tree_cache,
+            req_to_token_pool,
+            token_to_kv_pool_allocator,
+            prefill_mgr,
+            decode_mgr,
+            model_config,
+        ),
+    ) = create_sglang_infrastructure_defer_cuda_graph(
+        server_args,
+        gpu_id,
+        model_arch_override="MiMoV2ASRForCausalLM",
+    )
+    init_mm_embedding_cache(mm_embedding_cache_size_bytes)
+    output_processor = SGLangOutputProcessor(
+        capture_hidden=False,
+        capture_hidden_layers=None,
+        model=model_worker.model_runner.model,
+    )
+    request_builder, result_adapter = make_mimo_v25_asr_scheduler_adapters(
+        tokenizer=tokenizer,
+        max_new_tokens=max_new_tokens,
+    )
+    return OmniScheduler(
+        tp_worker=model_worker,
+        tree_cache=tree_cache,
+        req_to_token_pool=req_to_token_pool,
+        token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+        server_args=server_args,
+        model_config=model_config,
+        prefill_manager=prefill_mgr,
+        decode_manager=decode_mgr,
+        model_runner=ModelRunner(model_worker, output_processor),
+        request_builder=request_builder,
+        result_adapter=result_adapter,
+    )
+
+
+__all__ = ["create_audio_tokenizer_executor", "create_asr_executor"]

--- a/tests/unit_test/mimo_v25_asr/test_config.py
+++ b/tests/unit_test/mimo_v25_asr/test_config.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+from sglang_omni.config.manager import resolve_config_cls_for_model_path
+from sglang_omni.config.placement import StagePlacementPlanner
+from sglang_omni.config.topology import build_process_topology_plan
+from sglang_omni.models.mimo_v25_asr.config import (
+    MIMO_AUDIO_TOKENIZER_PATH,
+    MiMoV25ASRPipelineConfig,
+)
+from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+
+
+def test_mimo_v25_asr_pipeline_is_registered() -> None:
+    assert (
+        PIPELINE_CONFIG_REGISTRY.get_config("MiMoV2ASRForCausalLM")
+        is MiMoV25ASRPipelineConfig
+    )
+
+
+def test_mimo_v25_asr_pipeline_is_text_output_only() -> None:
+    config = MiMoV25ASRPipelineConfig(model_path="XiaomiMiMo/MiMo-V2.5-ASR")
+
+    assert config.entry_stage == "audio_tokenizer"
+    assert [stage.name for stage in config.stages] == ["audio_tokenizer", "asr"]
+    assert config.terminal_stages == ["asr"]
+    assert config.gpu_placement == {"audio_tokenizer": 0, "asr": 0}
+    assert config.stages[0].next == "asr"
+    assert config.stages[0].factory_args["tokenizer_path"] == (
+        MIMO_AUDIO_TOKENIZER_PATH
+    )
+    fractions = {
+        stage.name: stage.runtime.resources.total_gpu_memory_fraction
+        for stage in config.stages
+    }
+    assert fractions == {"audio_tokenizer": 0.08, "asr": 0.92}
+    placement = StagePlacementPlanner(config).build()
+    topology = build_process_topology_plan(config, placement)
+    assert topology.stage_to_process == {
+        "audio_tokenizer": "audio_tokenizer",
+        "asr": "asr",
+    }
+    assert all(
+        forbidden not in stage.name
+        for stage in config.stages
+        for forbidden in ("decoder", "vocoder", "code2wav", "patch_decoder")
+    )
+
+
+def test_checkpoint_architecture_resolves_to_mimo_v25_asr_pipeline(tmp_path) -> None:
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["MiMoV2ASRForCausalLM"],
+                "model_type": "qwen2",
+                "hidden_size": 4096,
+                "num_hidden_layers": 36,
+                "num_attention_heads": 32,
+                "num_key_value_heads": 8,
+                "vocab_size": 151680,
+            }
+        )
+    )
+
+    assert resolve_config_cls_for_model_path(str(tmp_path)) is MiMoV25ASRPipelineConfig

--- a/tests/unit_test/mimo_v25_asr/test_preprocessor.py
+++ b/tests/unit_test/mimo_v25_asr/test_preprocessor.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+
+from sglang_omni.models.mimo_v25_asr.preprocessor import (
+    MiMoAudioPreprocessor,
+    MiMoAudioTokenizerSettings,
+)
+
+
+class _FakeEncoder:
+    def encode(self, *, input_features, input_lens, return_codes_only):
+        assert return_codes_only is True
+        frames = int(input_lens.sum().item()) // 4
+        frames = max(frames, 1)
+        codes = torch.zeros((20, frames), dtype=torch.long)
+        return codes, input_lens
+
+
+def test_encode_waveform_pads_to_group_size() -> None:
+    preprocessor = MiMoAudioPreprocessor(
+        MiMoAudioTokenizerSettings(chunk_seconds=1.0),
+        device="cpu",
+    )
+    # Shorter than n_fft so the pad-to-n_fft branch is exercised.
+    waveform = torch.zeros(100, dtype=torch.float32)
+    codes = preprocessor.encode_waveform(waveform, _FakeEncoder())
+    assert codes.ndim == 2
+    assert codes.shape[1] == 8
+    assert codes.shape[0] % 4 == 0

--- a/tests/unit_test/mimo_v25_asr/test_prompt.py
+++ b/tests/unit_test/mimo_v25_asr/test_prompt.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import pytest
+import torch
+
+from sglang_omni.models.mimo_v25_asr.prompt import (
+    ASR_EN_TEMPLATE,
+    ASR_ZH_TEMPLATE,
+    CHINESE_TAG,
+    ENGLISH_TAG,
+    SPEECH_EMPTY_IDS,
+    build_asr_sft_prompt,
+    pad_audio_codes,
+    resolve_audio_tag,
+    select_asr_instruction,
+    strip_asr_markers,
+)
+
+
+class _Encoding:
+    def __init__(self, ids: list[int]):
+        self.ids = ids
+
+
+class _CharacterTokenizer:
+    special: ClassVar[dict[str, int]] = {
+        "<|im_start|>": 151644,
+        "<|im_end|>": 151645,
+        "<|sosp|>": 151665,
+        "<|eosp|>": 151666,
+        "<|empty|>": 151667,
+        "<think>": 151668,
+        "</think>": 151669,
+    }
+
+    def convert_tokens_to_ids(self, token: str) -> int | None:
+        return self.special.get(token)
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> _Encoding:
+        del add_special_tokens
+        ids: list[int] = []
+        cursor = 0
+        tokens = sorted(self.special, key=len, reverse=True)
+        while cursor < len(text):
+            special = next(
+                (token for token in tokens if text.startswith(token, cursor)), None
+            )
+            if special is not None:
+                ids.append(self.special[special])
+                cursor += len(special)
+            else:
+                ids.append(1000 + ord(text[cursor]))
+                cursor += 1
+        return _Encoding(ids)
+
+
+def test_resolve_audio_tag_maps_openai_language() -> None:
+    assert resolve_audio_tag(None) == ""
+    assert resolve_audio_tag("auto") == ""
+    assert resolve_audio_tag("zh") == CHINESE_TAG
+    assert resolve_audio_tag("chinese") == CHINESE_TAG
+    assert resolve_audio_tag("en") == ENGLISH_TAG
+    assert resolve_audio_tag("english") == ENGLISH_TAG
+
+
+def test_select_asr_instruction_is_deterministic() -> None:
+    assert select_asr_instruction(CHINESE_TAG) == ASR_ZH_TEMPLATE
+    assert select_asr_instruction(ENGLISH_TAG) == ASR_EN_TEMPLATE
+    assert select_asr_instruction("") == ASR_EN_TEMPLATE
+
+
+def test_asr_sft_prompt_has_official_channel_contract() -> None:
+    tokenizer = _CharacterTokenizer()
+    codes = torch.arange(5 * 8, dtype=torch.int64).reshape(5, 8)
+    prompt = build_asr_sft_prompt(tokenizer, codes, language="zh")
+
+    assert prompt.official_input_ids.shape[0] == 9
+    assert prompt.audio_codes.shape == (8, 8)
+    assert torch.equal(prompt.audio_codes[5:], prompt.audio_codes[4:5].expand(3, -1))
+    assert prompt.audio_end - prompt.audio_start == 2
+    assert prompt.input_ids[prompt.audio_start : prompt.audio_end] == [151667, 151667]
+    assert prompt.audio_tag == CHINESE_TAG
+    assert prompt.instruction == ASR_ZH_TEMPLATE
+    assert torch.equal(
+        prompt.official_input_ids[1:, :4],
+        torch.tensor(SPEECH_EMPTY_IDS)[:, None].expand(-1, 4),
+    )
+
+
+def test_asr_sft_prompt_appends_english_tag() -> None:
+    prompt = build_asr_sft_prompt(
+        _CharacterTokenizer(),
+        torch.zeros((4, 8), dtype=torch.int64),
+        language="en",
+    )
+    assert prompt.audio_tag == ENGLISH_TAG
+    assert prompt.instruction == ASR_EN_TEMPLATE
+
+
+def test_strip_asr_markers_removes_language_tags() -> None:
+    assert strip_asr_markers(f"{CHINESE_TAG}北京<|empty|>") == "北京"
+
+
+def test_pad_audio_codes_rejects_empty_input() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        pad_audio_codes(torch.empty((0, 8), dtype=torch.int64))

--- a/tests/unit_test/mimo_v25_asr/test_request_builders.py
+++ b/tests/unit_test/mimo_v25_asr/test_request_builders.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import torch
 import pytest
+import torch
 from sglang.srt.managers.schedule_batch import Modality
 
 from sglang_omni.models.mimo_v25_asr.prompt import CHINESE_TAG, EMPTY

--- a/tests/unit_test/mimo_v25_asr/test_request_builders.py
+++ b/tests/unit_test/mimo_v25_asr/test_request_builders.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+import pytest
+from sglang.srt.managers.schedule_batch import Modality
+
+from sglang_omni.models.mimo_v25_asr.prompt import CHINESE_TAG, EMPTY
+from sglang_omni.models.mimo_v25_asr.request_builders import (
+    make_mimo_v25_asr_scheduler_adapters,
+    validate_text_only_request,
+)
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+class _Encoding:
+    def __init__(self, ids: list[int]):
+        self.ids = ids
+
+
+class _FakeTokenizer:
+    eos_token_id = 151645
+    vocab_size = 151680
+    special = {
+        "<|im_start|>": 151644,
+        "<|im_end|>": 151645,
+        "<|sosp|>": 151665,
+        "<|eosp|>": 151666,
+        EMPTY: 151667,
+        "<think>": 151668,
+        "</think>": 151669,
+        CHINESE_TAG: 151670,
+        "<english>": 151671,
+    }
+
+    def convert_tokens_to_ids(self, token: str) -> int | None:
+        return self.special.get(token)
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> _Encoding:
+        del add_special_tokens
+        ids: list[int] = []
+        cursor = 0
+        tokens = sorted(self.special, key=len, reverse=True)
+        while cursor < len(text):
+            special = next(
+                (token for token in tokens if text.startswith(token, cursor)), None
+            )
+            if special is not None:
+                ids.append(self.special[special])
+                cursor += len(special)
+            else:
+                ids.append(1000 + ord(text[cursor]))
+                cursor += 1
+        return _Encoding(ids)
+
+    def decode(self, token_ids, skip_special_tokens=False, **kwargs):
+        del skip_special_tokens, kwargs
+        return f"{CHINESE_TAG}hello<|empty|>"
+
+
+def _payload(*, language: str = "zh", modalities=None) -> StagePayload:
+    request = OmniRequest(
+        inputs={"audio_path": "dummy.wav"},
+        params={"language": language, "temperature": 0.0, "max_new_tokens": 32},
+        metadata={"output_modalities": modalities or ["text"]},
+    )
+    return StagePayload(
+        request_id="req-1",
+        request=request,
+        data={
+            "audio_codes": torch.zeros((4, 8), dtype=torch.int64),
+            "audio_duration_s": 1.5,
+            "audio_fingerprint": "abcd" * 8,
+        },
+    )
+
+
+def test_validate_text_only_rejects_audio_modality() -> None:
+    with pytest.raises(ValueError, match="text transcription only"):
+        validate_text_only_request(_payload(modalities=["text", "audio"]))
+
+
+def test_request_builder_injects_audio_placeholders() -> None:
+    builder, adapter = make_mimo_v25_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=64,
+    )
+    data = builder(_payload(language="zh"))
+    assert data.req.multimodal_inputs is not None
+    item = data.req.multimodal_inputs.mm_items[0]
+    assert item.modality == Modality.AUDIO
+    assert data.language == "zh"
+    assert data.audio_duration_s == 1.5
+    assert data.req.sampling_params.stop_token_ids
+
+    data.output_ids = [1, 2, 3]
+    data.engine_start_s = 0.0
+    result = adapter(data)
+    assert result.data["text"] == "hello"

--- a/tests/unit_test/mimo_v25_asr/test_sglang_model.py
+++ b/tests/unit_test/mimo_v25_asr/test_sglang_model.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+
+from sglang_omni.models.mimo_v25_asr.sglang_model import (
+    MiMoInputPatchEncoder,
+    MiMoV2ASRForCausalLM,
+    is_output_only_weight,
+    parse_channel_values,
+)
+from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
+
+
+def _tiny_config() -> Qwen2Config:
+    return Qwen2Config(
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=128,
+        group_size=4,
+        audio_channels=8,
+        input_local_dim=32,
+        input_local_layers=1,
+        local_attn_heads=4,
+        speech_vocab_size="8-8-8-8-8-8-8-8",
+        speech_zeroemb_idx="7-7-7-7-7-7-7-7",
+    )
+
+
+def test_parse_channel_values() -> None:
+    assert parse_channel_values("1-2-3-4-5-6-7-8") == (1, 2, 3, 4, 5, 6, 7, 8)
+    assert parse_channel_values(9) == (9,) * 8
+
+
+def test_output_only_weight_prefixes() -> None:
+    assert is_output_only_weight("local_transformer.layers.0.weight")
+    assert not is_output_only_weight("speech_embeddings.0.weight")
+
+
+def test_input_patch_encoder_groups_frames() -> None:
+    encoder = MiMoInputPatchEncoder(_tiny_config())
+    codes = torch.zeros((8, 8), dtype=torch.long)
+    embeds = encoder(codes)
+    assert embeds.shape == (2, 64)
+
+
+def test_model_class_name_matches_hf_architecture() -> None:
+    assert MiMoV2ASRForCausalLM.__name__ == "MiMoV2ASRForCausalLM"

--- a/tests/unit_test/mimo_v25_asr/test_sglang_model.py
+++ b/tests/unit_test/mimo_v25_asr/test_sglang_model.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import torch
+from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
 
 from sglang_omni.models.mimo_v25_asr.sglang_model import (
     MiMoInputPatchEncoder,
@@ -10,7 +11,6 @@ from sglang_omni.models.mimo_v25_asr.sglang_model import (
     is_output_only_weight,
     parse_channel_values,
 )
-from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
 
 
 def _tiny_config() -> Qwen2Config:


### PR DESCRIPTION
## Summary
- Add serving support for [`XiaomiMiMo/MiMo-V2.5-ASR`](https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR) via OpenAI-compatible `/v1/audio/transcriptions`.
- Two-stage pipeline on one GPU: `audio_tokenizer` (MiMo-Audio-Tokenizer encoder / 8-layer RVQ) → `asr` (input-local patch encoder + SGLang Qwen2 decode → text).
- Align with the official `asr_sft` contract: deterministic ZH/EN templates, `language` → `<chinese>` / `<english>` / auto, and 30s waveform chunking.
- Text output only (no TTS / delayed RVQ / vocoder). Distinct from MiMo-Audio Instruct ([#249](https://github.com/sgl-project/sglang-omni/issues/249) / [#1219](https://github.com/sgl-project/sglang-omni/pull/1219)): same family stack, different checkpoint (`MiMoV2ASRForCausalLM`) and ASR prompt path.
## Design
```text
waveform (24 kHz)
  -> MiMo-Audio-Tokenizer (encoder / quantizer only)
  -> 9-channel prompt (1 text + 8 audio codes)
  -> patch encoder (4 frames -> 1 LM embedding)
  -> SGLang Qwen2 decode
  -> text
```

- Registers MiMoV2ASRForCausalLM in the pipeline registry and sglang_model_runner.
- Shared-GPU resource fractions: tokenizer 0.08, ASR 0.92.
- Initial path keeps CUDA graphs / overlap off for correctness; max_running_requests set to 32 for concurrency sweeps.

## Test plan

- [x] Unit tests: pytest tests/unit_test/mimo_v25_asr -q (16 passed)
- [x]  SeedTTS (same dataset family as Fun-ASR / Qwen3-ASR), local managed serve:
      - EN full 1088/1088, corpus WER 0.0107
      - ZH full 2020/2020, corpus WER 0.0070
      - EN concurrency sweep (WER stable at 0.0107):

```
export CUDA_VISIBLE_DEVICES=0
export SGLANG_OMNI_STARTUP_TIMEOUT=900
PYTHONPATH=. python -m sglang_omni.cli serve \
  --model-path XiaomiMiMo/MiMo-V2.5-ASR \
  --model-name mimo-v25-asr \
  --host 127.0.0.1 \
  --port 8010

# SeedTTS EN concurrency sweep (max_running_requests=32)
PYTHONPATH=. python -m benchmarks.eval.benchmark_asr_seedtts \
  --host 127.0.0.1 --port 8010 \
  --model-path XiaomiMiMo/MiMo-V2.5-ASR \
  --lang en --concurrencies 1,16,32 --repeats 1 --warmup \
  --output /tmp/mimo-seedtts-en-c1-16-32.json
```
conc | WER | thrpt | wall | lat mean | lat p95 | lat p99 | RTF mean | RTF p95 | RTFx
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | 0.0107 | 3.42 | 318 | 0.29 | 0.48 | 0.56 | 0.063 | 0.105 | 16.2
16 | 0.0107 | 24.4 | 45 | 0.65 | 0.76 | 0.84 | 0.142 | 0.189 | 115.8
32 | 0.0107 | 24.2 | 45 | 1.31 | 1.42 | 1.49 | 0.286 | 0.383 | 114.5


## Notes
- Tokenizer default: XiaomiMiMo/MiMo-Audio-Tokenizer