### PR TITLE
[ASR Feature] Auto-chunk long Qwen3-ASR audio at silence boundaries

### DIFF
--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -5,7 +5,6 @@ from typing import Annotated, Literal, NoReturn
 
 import typer
 from sglang_omni.models.qwen3_asr.chunking import (
-    QWEN3_ASR_CHUNK_OVERLAP_SECONDS,
     QWEN3_ASR_CHUNK_WINDOW_SECONDS,
     validate_qwen3_asr_chunking,
 )
@@ -876,15 +875,12 @@ def apply_asr_chunking_cli_overrides(
     *,
     asr_auto_chunk: bool | None,
     asr_chunk_max_seconds: float | None,
-    asr_chunk_overlap_seconds: float | None,
 ) -> PipelineConfig:
     updates: dict[str, object] = {}
     if asr_auto_chunk is not None:
         updates["asr_auto_chunk"] = bool(asr_auto_chunk)
     if asr_chunk_max_seconds is not None:
         updates["asr_chunk_max_seconds"] = float(asr_chunk_max_seconds)
-    if asr_chunk_overlap_seconds is not None:
-        updates["asr_chunk_overlap_seconds"] = float(asr_chunk_overlap_seconds)
     if not updates:
         return pipeline_config
 
@@ -894,7 +890,7 @@ def apply_asr_chunking_cli_overrides(
     if not matching_stages:
         _raise_unsupported_flag(
             pipeline_config,
-            "--asr-auto-chunk/--asr-chunk-max-seconds/--asr-chunk-overlap-seconds",
+            "--asr-auto-chunk/--asr-chunk-max-seconds",
         )
     for stage in matching_stages:
         effective = dict(stage.factory_args or {})
@@ -907,12 +903,7 @@ def apply_asr_chunking_cli_overrides(
                     effective.get(
                         "asr_chunk_max_seconds", QWEN3_ASR_CHUNK_WINDOW_SECONDS
                     )
-                ),
-                float(
-                    effective.get(
-                        "asr_chunk_overlap_seconds", QWEN3_ASR_CHUNK_OVERLAP_SECONDS
-                    )
-                ),
+                )
             )
         except ValueError as exc:
             raise typer.BadParameter(str(exc)) from exc
@@ -1246,14 +1237,6 @@ def serve(
             help="Override the hard maximum duration of each ASR chunk.",
         ),
     ] = None,
-    asr_chunk_overlap_seconds: Annotated[
-        float | None,
-        typer.Option(
-            "--asr-chunk-overlap-seconds",
-            min=0.0,
-            help="Override the overlap duration between adjacent ASR chunks.",
-        ),
-    ] = None,
     decode_mode: Annotated[
         str | None,
         typer.Option(
@@ -1414,7 +1397,6 @@ def serve(
         merged_config,
         asr_auto_chunk=asr_auto_chunk,
         asr_chunk_max_seconds=asr_chunk_max_seconds,
-        asr_chunk_overlap_seconds=asr_chunk_overlap_seconds,
     )
     generation_server_args_overrides: dict[str, object] = {}
     if max_running_requests is not None:

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -42,6 +42,9 @@ _ASYNC_DECODE_SUPPORTED_MODELS = (
 _QWEN_PARTIAL_START_TALKER_FACTORY = (
     "sglang_omni.models.qwen3_omni.stages.create_talker_ar_executor_from_config"
 )
+_QWEN_ASR_FACTORY = (
+    "sglang_omni.models.qwen3_asr.stages.create_sglang_qwen3_asr_executor"
+)
 
 
 def launch_server(*args: object, **kwargs: object) -> object:
@@ -863,6 +866,53 @@ def apply_decode_mode_cli_overrides(
     return pipeline_config
 
 
+def apply_asr_chunking_cli_overrides(
+    pipeline_config: PipelineConfig,
+    *,
+    asr_auto_chunk: bool | None,
+    asr_chunk_max_seconds: float | None,
+    asr_chunk_overlap_seconds: float | None,
+) -> PipelineConfig:
+    updates: dict[str, object] = {}
+    if asr_auto_chunk is not None:
+        updates["asr_auto_chunk"] = bool(asr_auto_chunk)
+    if asr_chunk_max_seconds is not None:
+        if asr_chunk_max_seconds <= 0:
+            raise typer.BadParameter("--asr-chunk-max-seconds must be positive")
+        updates["asr_chunk_max_seconds"] = float(asr_chunk_max_seconds)
+    if asr_chunk_overlap_seconds is not None:
+        if asr_chunk_overlap_seconds < 0:
+            raise typer.BadParameter("--asr-chunk-overlap-seconds must be non-negative")
+        updates["asr_chunk_overlap_seconds"] = float(asr_chunk_overlap_seconds)
+    if not updates:
+        return pipeline_config
+
+    matching_stages = [
+        stage for stage in pipeline_config.stages if stage.factory == _QWEN_ASR_FACTORY
+    ]
+    if not matching_stages:
+        _raise_unsupported_flag(
+            pipeline_config,
+            "--asr-auto-chunk/--asr-chunk-max-seconds/--asr-chunk-overlap-seconds",
+        )
+    for stage in matching_stages:
+        effective = dict(stage.factory_args or {})
+        effective.update(updates)
+        max_seconds = effective.get("asr_chunk_max_seconds")
+        overlap_seconds = effective.get("asr_chunk_overlap_seconds")
+        if (
+            max_seconds is not None
+            and overlap_seconds is not None
+            and float(overlap_seconds) >= float(max_seconds)
+        ):
+            raise typer.BadParameter(
+                "--asr-chunk-overlap-seconds must be smaller than "
+                "--asr-chunk-max-seconds"
+            )
+    _apply_factory_args_updates(pipeline_config, matching_stages, updates)
+    return pipeline_config
+
+
 def apply_torch_compile_cli_overrides(
     pipeline_config: PipelineConfig,
     *,
@@ -1143,8 +1193,7 @@ def serve(
             "--talker-torch-compile",
             "--talker_torch_compile",
             help=(
-                "torch.compile mode for supported SGLang talker stage: "
-                "default|on|off."
+                "torch.compile mode for supported SGLang talker stage: default|on|off."
             ),
         ),
     ] = "default",
@@ -1172,6 +1221,32 @@ def serve(
             help="Mount the OpenAI Realtime WebSocket endpoint at /v1/realtime.",
         ),
     ] = False,
+    asr_auto_chunk: Annotated[
+        bool | None,
+        typer.Option(
+            "--asr-auto-chunk/--no-asr-auto-chunk",
+            help=(
+                "Enable or disable model-owned long-audio chunking for "
+                "supported ASR pipelines."
+            ),
+        ),
+    ] = None,
+    asr_chunk_max_seconds: Annotated[
+        float | None,
+        typer.Option(
+            "--asr-chunk-max-seconds",
+            min=0.001,
+            help="Override the hard maximum duration of each ASR chunk.",
+        ),
+    ] = None,
+    asr_chunk_overlap_seconds: Annotated[
+        float | None,
+        typer.Option(
+            "--asr-chunk-overlap-seconds",
+            min=0.0,
+            help="Override the overlap duration between adjacent ASR chunks.",
+        ),
+    ] = None,
     decode_mode: Annotated[
         str | None,
         typer.Option(
@@ -1327,6 +1402,12 @@ def serve(
         merged_config,
         decode_mode=decode_mode,
         async_lookahead_min_batch_size=async_lookahead_min_batch_size,
+    )
+    merged_config = apply_asr_chunking_cli_overrides(
+        merged_config,
+        asr_auto_chunk=asr_auto_chunk,
+        asr_chunk_max_seconds=asr_chunk_max_seconds,
+        asr_chunk_overlap_seconds=asr_chunk_overlap_seconds,
     )
     generation_server_args_overrides: dict[str, object] = {}
     if max_running_requests is not None:

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -4,6 +4,11 @@ import logging
 from typing import Annotated, Literal, NoReturn
 
 import typer
+from sglang_omni.models.qwen3_asr.chunking import (
+    QWEN3_ASR_CHUNK_OVERLAP_SECONDS,
+    QWEN3_ASR_CHUNK_WINDOW_SECONDS,
+    validate_qwen3_asr_chunking,
+)
 import yaml
 
 from sglang_omni.config import (
@@ -877,12 +882,8 @@ def apply_asr_chunking_cli_overrides(
     if asr_auto_chunk is not None:
         updates["asr_auto_chunk"] = bool(asr_auto_chunk)
     if asr_chunk_max_seconds is not None:
-        if asr_chunk_max_seconds <= 0:
-            raise typer.BadParameter("--asr-chunk-max-seconds must be positive")
         updates["asr_chunk_max_seconds"] = float(asr_chunk_max_seconds)
     if asr_chunk_overlap_seconds is not None:
-        if asr_chunk_overlap_seconds < 0:
-            raise typer.BadParameter("--asr-chunk-overlap-seconds must be non-negative")
         updates["asr_chunk_overlap_seconds"] = float(asr_chunk_overlap_seconds)
     if not updates:
         return pipeline_config
@@ -898,17 +899,23 @@ def apply_asr_chunking_cli_overrides(
     for stage in matching_stages:
         effective = dict(stage.factory_args or {})
         effective.update(updates)
-        max_seconds = effective.get("asr_chunk_max_seconds")
-        overlap_seconds = effective.get("asr_chunk_overlap_seconds")
-        if (
-            max_seconds is not None
-            and overlap_seconds is not None
-            and float(overlap_seconds) >= float(max_seconds)
-        ):
-            raise typer.BadParameter(
-                "--asr-chunk-overlap-seconds must be smaller than "
-                "--asr-chunk-max-seconds"
+        # Single validation source: the model-owned validator. The CLI layer
+        # only translates its ValueError into a typer.BadParameter.
+        try:
+            validate_qwen3_asr_chunking(
+                float(
+                    effective.get(
+                        "asr_chunk_max_seconds", QWEN3_ASR_CHUNK_WINDOW_SECONDS
+                    )
+                ),
+                float(
+                    effective.get(
+                        "asr_chunk_overlap_seconds", QWEN3_ASR_CHUNK_OVERLAP_SECONDS
+                    )
+                ),
             )
+        except ValueError as exc:
+            raise typer.BadParameter(str(exc)) from exc
     _apply_factory_args_updates(pipeline_config, matching_stages, updates)
     return pipeline_config
 

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -4,10 +4,6 @@ import logging
 from typing import Annotated, Literal, NoReturn
 
 import typer
-from sglang_omni.models.qwen3_asr.chunking import (
-    QWEN3_ASR_CHUNK_WINDOW_SECONDS,
-    validate_qwen3_asr_chunking,
-)
 import yaml
 
 from sglang_omni.config import (
@@ -16,6 +12,10 @@ from sglang_omni.config import (
     apply_stage_process_overrides,
 )
 from sglang_omni.config.manager import ConfigManager
+from sglang_omni.models.qwen3_asr.chunking import (
+    QWEN3_ASR_CHUNK_WINDOW_SECONDS,
+    validate_qwen3_asr_chunking,
+)
 from sglang_omni.preprocessing.resource_connector import (
     resolve_allowed_local_media_path,
 )
@@ -895,8 +895,8 @@ def apply_asr_chunking_cli_overrides(
     for stage in matching_stages:
         effective = dict(stage.factory_args or {})
         effective.update(updates)
-        # Single validation source: the model-owned validator. The CLI layer
-        # only translates its ValueError into a typer.BadParameter.
+        # note (Junnan Li): Keep validation model-owned; the CLI only translates
+        # ValueError into a command-line error.
         try:
             validate_qwen3_asr_chunking(
                 float(

--- a/sglang_omni/models/qwen3_asr/chunking.py
+++ b/sglang_omni/models/qwen3_asr/chunking.py
@@ -3,16 +3,18 @@
 
 from __future__ import annotations
 
+import math
+
 QWEN3_ASR_AUTO_CHUNK_DEFAULT = True
 
-# The serving context currently admits 30-second requests, which is smaller
-# than Qwen3-ASR's native audio envelope.
+# note (Junnan Li): Keep the chunk ceiling aligned with the deployed 30-second
+# serving context; raise it when that context limit changes.
 QWEN3_ASR_CHUNK_WINDOW_SECONDS = 30.0
 
 
 def validate_qwen3_asr_chunking(max_seconds: float) -> None:
-    if max_seconds <= 0:
-        raise ValueError("asr_chunk_max_seconds must be positive")
+    if not math.isfinite(max_seconds) or max_seconds <= 0:
+        raise ValueError("asr_chunk_max_seconds must be a finite positive number")
 
 
 __all__ = [

--- a/sglang_omni/models/qwen3_asr/chunking.py
+++ b/sglang_omni/models/qwen3_asr/chunking.py
@@ -8,23 +8,15 @@ QWEN3_ASR_AUTO_CHUNK_DEFAULT = True
 # The serving context currently admits 30-second requests, which is smaller
 # than Qwen3-ASR's native audio envelope.
 QWEN3_ASR_CHUNK_WINDOW_SECONDS = 30.0
-QWEN3_ASR_CHUNK_OVERLAP_SECONDS = 2.0
 
 
-def validate_qwen3_asr_chunking(max_seconds: float, overlap_seconds: float) -> None:
+def validate_qwen3_asr_chunking(max_seconds: float) -> None:
     if max_seconds <= 0:
         raise ValueError("asr_chunk_max_seconds must be positive")
-    if overlap_seconds < 0:
-        raise ValueError("asr_chunk_overlap_seconds must be non-negative")
-    if overlap_seconds >= max_seconds:
-        raise ValueError(
-            "asr_chunk_overlap_seconds must be smaller than asr_chunk_max_seconds"
-        )
 
 
 __all__ = [
     "QWEN3_ASR_AUTO_CHUNK_DEFAULT",
-    "QWEN3_ASR_CHUNK_OVERLAP_SECONDS",
     "QWEN3_ASR_CHUNK_WINDOW_SECONDS",
     "validate_qwen3_asr_chunking",
 ]

--- a/sglang_omni/models/qwen3_asr/chunking.py
+++ b/sglang_omni/models/qwen3_asr/chunking.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 
 QWEN3_ASR_AUTO_CHUNK_DEFAULT = True
 
-# This is the safe window admitted by the current deployed context sizing in
-# stages.py. It is not the model's native envelope; when that capacity grows,
-# this model-owned constant is the single default that needs to change.
+# The serving context currently admits 30-second requests, which is smaller
+# than Qwen3-ASR's native audio envelope.
 QWEN3_ASR_CHUNK_WINDOW_SECONDS = 30.0
 QWEN3_ASR_CHUNK_OVERLAP_SECONDS = 2.0
 

--- a/sglang_omni/models/qwen3_asr/chunking.py
+++ b/sglang_omni/models/qwen3_asr/chunking.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen3-ASR-owned long-audio chunking policy."""
+
+from __future__ import annotations
+
+QWEN3_ASR_AUTO_CHUNK_DEFAULT = True
+
+# This is the safe window admitted by the current deployed context sizing in
+# stages.py. It is not the model's native envelope; when that capacity grows,
+# this model-owned constant is the single default that needs to change.
+QWEN3_ASR_CHUNK_WINDOW_SECONDS = 30.0
+QWEN3_ASR_CHUNK_OVERLAP_SECONDS = 2.0
+
+
+def validate_qwen3_asr_chunking(max_seconds: float, overlap_seconds: float) -> None:
+    if max_seconds <= 0:
+        raise ValueError("asr_chunk_max_seconds must be positive")
+    if overlap_seconds < 0:
+        raise ValueError("asr_chunk_overlap_seconds must be non-negative")
+    if overlap_seconds >= max_seconds:
+        raise ValueError(
+            "asr_chunk_overlap_seconds must be smaller than asr_chunk_max_seconds"
+        )
+
+
+__all__ = [
+    "QWEN3_ASR_AUTO_CHUNK_DEFAULT",
+    "QWEN3_ASR_CHUNK_OVERLAP_SECONDS",
+    "QWEN3_ASR_CHUNK_WINDOW_SECONDS",
+    "validate_qwen3_asr_chunking",
+]

--- a/sglang_omni/models/qwen3_asr/config.py
+++ b/sglang_omni/models/qwen3_asr/config.py
@@ -7,6 +7,12 @@ from typing import ClassVar
 
 from sglang_omni.config import PipelineConfig, StageConfig
 
+from .chunking import (
+    QWEN3_ASR_AUTO_CHUNK_DEFAULT,
+    QWEN3_ASR_CHUNK_OVERLAP_SECONDS,
+    QWEN3_ASR_CHUNK_WINDOW_SECONDS,
+)
+
 _PKG = "sglang_omni.models.qwen3_asr"
 
 
@@ -36,6 +42,9 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
                 "max_new_tokens": 128,
                 "request_build_max_workers": 2,
                 "request_build_max_pending": 16,
+                "asr_auto_chunk": QWEN3_ASR_AUTO_CHUNK_DEFAULT,
+                "asr_chunk_max_seconds": QWEN3_ASR_CHUNK_WINDOW_SECONDS,
+                "asr_chunk_overlap_seconds": QWEN3_ASR_CHUNK_OVERLAP_SECONDS,
             },
             gpu=0,
             terminal=True,

--- a/sglang_omni/models/qwen3_asr/config.py
+++ b/sglang_omni/models/qwen3_asr/config.py
@@ -7,10 +7,7 @@ from typing import ClassVar
 
 from sglang_omni.config import PipelineConfig, StageConfig
 
-from .chunking import (
-    QWEN3_ASR_AUTO_CHUNK_DEFAULT,
-    QWEN3_ASR_CHUNK_WINDOW_SECONDS,
-)
+from .chunking import QWEN3_ASR_AUTO_CHUNK_DEFAULT, QWEN3_ASR_CHUNK_WINDOW_SECONDS
 
 _PKG = "sglang_omni.models.qwen3_asr"
 

--- a/sglang_omni/models/qwen3_asr/config.py
+++ b/sglang_omni/models/qwen3_asr/config.py
@@ -9,7 +9,6 @@ from sglang_omni.config import PipelineConfig, StageConfig
 
 from .chunking import (
     QWEN3_ASR_AUTO_CHUNK_DEFAULT,
-    QWEN3_ASR_CHUNK_OVERLAP_SECONDS,
     QWEN3_ASR_CHUNK_WINDOW_SECONDS,
 )
 
@@ -44,7 +43,6 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
                 "request_build_max_pending": 16,
                 "asr_auto_chunk": QWEN3_ASR_AUTO_CHUNK_DEFAULT,
                 "asr_chunk_max_seconds": QWEN3_ASR_CHUNK_WINDOW_SECONDS,
-                "asr_chunk_overlap_seconds": QWEN3_ASR_CHUNK_OVERLAP_SECONDS,
             },
             gpu=0,
             terminal=True,

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -35,7 +35,6 @@ from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 from .audio_lengths import qwen3_asr_num_audio_tokens
 from .chunking import (
     QWEN3_ASR_AUTO_CHUNK_DEFAULT,
-    QWEN3_ASR_CHUNK_OVERLAP_SECONDS,
     QWEN3_ASR_CHUNK_WINDOW_SECONDS,
     validate_qwen3_asr_chunking,
 )
@@ -100,14 +99,13 @@ def make_qwen3_asr_scheduler_adapters(
     feature_extractor: Any = None,
     asr_auto_chunk: bool = QWEN3_ASR_AUTO_CHUNK_DEFAULT,
     asr_chunk_max_seconds: float = QWEN3_ASR_CHUNK_WINDOW_SECONDS,
-    asr_chunk_overlap_seconds: float = QWEN3_ASR_CHUNK_OVERLAP_SECONDS,
     sample_rate: int = _SAMPLE_RATE,
 ) -> tuple[
     Callable[[StagePayload], Qwen3ASRRequestData], Callable[[Any], StagePayload]
 ]:
     if feature_extractor is None:
         raise ValueError("Qwen3-ASR processor is missing a feature_extractor")
-    validate_qwen3_asr_chunking(asr_chunk_max_seconds, asr_chunk_overlap_seconds)
+    validate_qwen3_asr_chunking(asr_chunk_max_seconds)
 
     audio_pad_token_id = int(tokenizer.convert_tokens_to_ids(_AUDIO_PAD))
     eos_token_id = int(tokenizer.eos_token_id)

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -157,8 +157,8 @@ def make_qwen3_asr_scheduler_adapters(
             return_tensors="pt",
             return_attention_mask=True,
             padding="longest",
-            # note (Junnan Li): Qwen3-ASR's encoder accepts mel sequences beyond
-            # Whisper's 30-second window, so preprocessing must not truncate them.
+            # note (Junnan Li): Qwen3-ASR accepts variable-length mel inputs, so
+            # Whisper's 30-second preprocessing truncation must stay disabled.
             truncation=False,
         )
         features = extracted.input_features

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -33,6 +33,12 @@ from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 
 from .audio_lengths import qwen3_asr_num_audio_tokens
+from .chunking import (
+    QWEN3_ASR_AUTO_CHUNK_DEFAULT,
+    QWEN3_ASR_CHUNK_OVERLAP_SECONDS,
+    QWEN3_ASR_CHUNK_WINDOW_SECONDS,
+    validate_qwen3_asr_chunking,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -92,11 +98,16 @@ def make_qwen3_asr_scheduler_adapters(
     tokenizer: Any,
     max_new_tokens: int,
     feature_extractor: Any = None,
+    asr_auto_chunk: bool = QWEN3_ASR_AUTO_CHUNK_DEFAULT,
+    asr_chunk_max_seconds: float = QWEN3_ASR_CHUNK_WINDOW_SECONDS,
+    asr_chunk_overlap_seconds: float = QWEN3_ASR_CHUNK_OVERLAP_SECONDS,
+    sample_rate: int = _SAMPLE_RATE,
 ) -> tuple[
     Callable[[StagePayload], Qwen3ASRRequestData], Callable[[Any], StagePayload]
 ]:
     if feature_extractor is None:
         raise ValueError("Qwen3-ASR processor is missing a feature_extractor")
+    validate_qwen3_asr_chunking(asr_chunk_max_seconds, asr_chunk_overlap_seconds)
 
     audio_pad_token_id = int(tokenizer.convert_tokens_to_ids(_AUDIO_PAD))
     eos_token_id = int(tokenizer.eos_token_id)
@@ -120,11 +131,17 @@ def make_qwen3_asr_scheduler_adapters(
     def request_builder(payload: StagePayload) -> Qwen3ASRRequestData:
         params = payload.request.params or {}
         prepared = prepare_audio(
-            payload, source_name="Qwen3-ASR", target_sample_rate=_SAMPLE_RATE
+            payload, source_name="Qwen3-ASR", target_sample_rate=sample_rate
         )
         audio = prepared.waveform
         audio_duration_s = prepared.duration_s
         fingerprint = prepared.fingerprint
+        if not asr_auto_chunk and audio_duration_s > asr_chunk_max_seconds:
+            raise ValueError(
+                "Qwen3-ASR accepts audio up to "
+                f"{asr_chunk_max_seconds:.3f} seconds when auto chunking is "
+                f"disabled; got {audio_duration_s:.3f} seconds"
+            )
 
         # note (Jeffro Qu): unlike Whisper's default 30s window, here we pad the mel to the clip's true length.
         # WhisperFeatureExtractor defaults to padding="max_length", padding every clip to nb_max_frames=3000 (~30s),
@@ -136,7 +153,7 @@ def make_qwen3_asr_scheduler_adapters(
         #  https://github.com/huggingface/transformers/issues/26241
         extracted = feature_extractor(
             audio,
-            sampling_rate=_SAMPLE_RATE,
+            sampling_rate=sample_rate,
             return_tensors="pt",
             return_attention_mask=True,
             padding="longest",

--- a/sglang_omni/models/qwen3_asr/stages.py
+++ b/sglang_omni/models/qwen3_asr/stages.py
@@ -26,6 +26,13 @@ from sglang_omni.scheduling.sglang_backend import (
 )
 from sglang_omni.utils.gpu_compat import get_visible_gpu_sm_version
 
+from .chunking import (
+    QWEN3_ASR_AUTO_CHUNK_DEFAULT,
+    QWEN3_ASR_CHUNK_OVERLAP_SECONDS,
+    QWEN3_ASR_CHUNK_WINDOW_SECONDS,
+    validate_qwen3_asr_chunking,
+)
+
 
 def create_sglang_qwen3_asr_executor(
     model_path: str,
@@ -42,8 +49,13 @@ def create_sglang_qwen3_asr_executor(
     mm_attention_backend: str | None = None,
     request_build_max_workers: int = 2,
     request_build_max_pending: int | None = 16,
+    asr_auto_chunk: bool = QWEN3_ASR_AUTO_CHUNK_DEFAULT,
+    asr_chunk_max_seconds: float = QWEN3_ASR_CHUNK_WINDOW_SECONDS,
+    asr_chunk_overlap_seconds: float = QWEN3_ASR_CHUNK_OVERLAP_SECONDS,
     server_args_overrides: dict[str, Any] | None = None,
 ):
+
+    validate_qwen3_asr_chunking(asr_chunk_max_seconds, asr_chunk_overlap_seconds)
 
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0
 
@@ -86,14 +98,17 @@ def create_sglang_qwen3_asr_executor(
         server_args=server_args,
     )
 
-    want_cuda_graph, (
-        model_worker,
-        tree_cache,
-        req_to_token_pool,
-        token_to_kv_pool_allocator,
-        prefill_mgr,
-        decode_mgr,
-        model_config,
+    (
+        want_cuda_graph,
+        (
+            model_worker,
+            tree_cache,
+            req_to_token_pool,
+            token_to_kv_pool_allocator,
+            prefill_mgr,
+            decode_mgr,
+            model_config,
+        ),
     ) = create_sglang_infrastructure_defer_cuda_graph(
         server_args,
         gpu_id,
@@ -114,6 +129,9 @@ def create_sglang_qwen3_asr_executor(
         tokenizer=tokenizer,
         feature_extractor=feature_extractor,
         max_new_tokens=max_new_tokens,
+        asr_auto_chunk=asr_auto_chunk,
+        asr_chunk_max_seconds=asr_chunk_max_seconds,
+        asr_chunk_overlap_seconds=asr_chunk_overlap_seconds,
     )
 
     return OmniScheduler(

--- a/sglang_omni/models/qwen3_asr/stages.py
+++ b/sglang_omni/models/qwen3_asr/stages.py
@@ -54,7 +54,6 @@ def create_sglang_qwen3_asr_executor(
     asr_chunk_overlap_seconds: float = QWEN3_ASR_CHUNK_OVERLAP_SECONDS,
     server_args_overrides: dict[str, Any] | None = None,
 ):
-
     validate_qwen3_asr_chunking(asr_chunk_max_seconds, asr_chunk_overlap_seconds)
 
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0

--- a/sglang_omni/models/qwen3_asr/stages.py
+++ b/sglang_omni/models/qwen3_asr/stages.py
@@ -28,7 +28,6 @@ from sglang_omni.utils.gpu_compat import get_visible_gpu_sm_version
 
 from .chunking import (
     QWEN3_ASR_AUTO_CHUNK_DEFAULT,
-    QWEN3_ASR_CHUNK_OVERLAP_SECONDS,
     QWEN3_ASR_CHUNK_WINDOW_SECONDS,
     validate_qwen3_asr_chunking,
 )
@@ -51,10 +50,9 @@ def create_sglang_qwen3_asr_executor(
     request_build_max_pending: int | None = 16,
     asr_auto_chunk: bool = QWEN3_ASR_AUTO_CHUNK_DEFAULT,
     asr_chunk_max_seconds: float = QWEN3_ASR_CHUNK_WINDOW_SECONDS,
-    asr_chunk_overlap_seconds: float = QWEN3_ASR_CHUNK_OVERLAP_SECONDS,
     server_args_overrides: dict[str, Any] | None = None,
 ):
-    validate_qwen3_asr_chunking(asr_chunk_max_seconds, asr_chunk_overlap_seconds)
+    validate_qwen3_asr_chunking(asr_chunk_max_seconds)
 
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0
 
@@ -130,7 +128,6 @@ def create_sglang_qwen3_asr_executor(
         max_new_tokens=max_new_tokens,
         asr_auto_chunk=asr_auto_chunk,
         asr_chunk_max_seconds=asr_chunk_max_seconds,
-        asr_chunk_overlap_seconds=asr_chunk_overlap_seconds,
     )
 
     return OmniScheduler(

--- a/sglang_omni/preprocessing/transcription.py
+++ b/sglang_omni/preprocessing/transcription.py
@@ -14,8 +14,10 @@ sources beyond the default payload keys (e.g. MOSS-Transcribe-Diarize).
 
 from __future__ import annotations
 
+import math
+import unicodedata
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 import numpy as np
 
@@ -61,6 +63,241 @@ class PreparedAudio:
         return audio_fingerprint_int(self.fingerprint)
 
 
+@dataclass(frozen=True)
+class Chunk:
+    """Half-open sample range for one transcription window."""
+
+    start_sample: int
+    end_sample: int
+
+    @property
+    def num_samples(self) -> int:
+        return self.end_sample - self.start_sample
+
+
+# Conservative upper bound for either CJK characters or whitespace-delimited
+# words produced by ASR during one second of overlapped audio.
+_MAX_STITCH_UNITS_PER_OVERLAP_SECOND = 20
+
+
+@dataclass(frozen=True)
+class _TranscriptUnit:
+    normalized: str
+    start: int
+    end: int
+
+
+def detect_silence_boundaries(
+    waveform: np.ndarray,
+    sample_rate: int,
+    *,
+    min_silence_s: float = 0.3,
+    frame_duration_s: float = 0.02,
+    relative_threshold: float = 0.1,
+) -> list[int]:
+    """Return sample midpoints of internal low-energy runs.
+
+    This offline detector intentionally avoids the realtime Silero VAD's model
+    lifecycle. It provides deterministic silence candidates; ``plan_chunks``
+    still enforces the hard maximum when no candidate is usable.
+    """
+
+    if sample_rate <= 0:
+        raise ValueError("sample_rate must be positive")
+    frame_samples = round(frame_duration_s * sample_rate)
+    min_silence_samples = round(min_silence_s * sample_rate)
+    if frame_samples <= 0 or min_silence_samples <= 0:
+        raise ValueError("silence durations must produce at least one sample")
+    if not 0.0 <= relative_threshold < 1.0:
+        raise ValueError("relative_threshold must be in [0, 1)")
+    if len(waveform) < frame_samples * 3:
+        return []
+
+    rms: list[float] = []
+    for start in range(0, len(waveform), frame_samples):
+        frame = waveform[start : start + frame_samples]
+        rms.append(float(np.sqrt(np.mean(np.square(frame, dtype=np.float64)))))
+    peak = max(rms, default=0.0)
+    if peak == 0.0:
+        return []
+    silent = [value <= peak * relative_threshold for value in rms]
+
+    boundaries: list[int] = []
+    run_start: int | None = None
+    for index, is_silent in enumerate([*silent, False]):
+        if is_silent and run_start is None:
+            run_start = index
+            continue
+        if is_silent or run_start is None:
+            continue
+        run_end = index
+        start_sample = run_start * frame_samples
+        end_sample = min(run_end * frame_samples, len(waveform))
+        is_internal = run_start > 0 and run_end < len(silent)
+        if is_internal and end_sample - start_sample >= min_silence_samples:
+            boundaries.append((start_sample + end_sample) // 2)
+        run_start = None
+    return boundaries
+
+
+def plan_chunks(
+    num_samples: int,
+    sample_rate: int,
+    max_window_s: float,
+    overlap_s: float,
+    vad_boundaries: Sequence[int],
+) -> list[Chunk]:
+    """Plan exact half-open windows, preferring silence before each hard limit."""
+
+    if num_samples < 0:
+        raise ValueError("num_samples must be non-negative")
+    if sample_rate <= 0:
+        raise ValueError("sample_rate must be positive")
+    max_samples = round(max_window_s * sample_rate)
+    overlap_samples = round(overlap_s * sample_rate)
+    if max_samples <= 0:
+        raise ValueError("max_window_s must produce at least one sample")
+    if overlap_samples < 0:
+        raise ValueError("overlap_s must be non-negative")
+    if overlap_samples >= max_samples:
+        raise ValueError("overlap_s must be smaller than max_window_s")
+    if num_samples == 0:
+        return []
+    if num_samples <= max_samples:
+        return [Chunk(0, num_samples)]
+
+    boundaries = sorted(
+        {int(boundary) for boundary in vad_boundaries if 0 < boundary < num_samples}
+    )
+    chunks: list[Chunk] = []
+    start = 0
+    previous_end = 0
+    while start < num_samples:
+        hard_end = min(start + max_samples, num_samples)
+        if hard_end == num_samples:
+            end = hard_end
+        else:
+            candidates = [
+                boundary
+                for boundary in boundaries
+                if previous_end < boundary <= hard_end
+            ]
+            end = candidates[-1] if candidates else hard_end
+        chunks.append(Chunk(start, end))
+        if end == num_samples:
+            break
+        previous_end = end
+        start = end - overlap_samples
+    return chunks
+
+
+def stitch_transcripts(
+    pieces: Sequence[str], overlap_info: Sequence[int | float | bool]
+) -> str:
+    """Join chunk text with bounded exact suffix-prefix overlap removal.
+
+    CJK text is split into individual characters while whitespace-delimited
+    text is split into words. The overlap duration bounds how many units may be
+    compared, so repeated text outside the audio overlap is never guessed away.
+    """
+
+    if len(overlap_info) != max(len(pieces) - 1, 0):
+        raise ValueError("overlap_info must have one entry per adjacent piece")
+
+    stitched = ""
+    for index, piece in enumerate(pieces):
+        piece = piece.strip()
+        if not piece:
+            continue
+        if stitched and index > 0 and overlap_info[index - 1] > 0:
+            stitched_units = _transcript_units(stitched)
+            piece_units = _transcript_units(piece)
+            unit_budget = math.ceil(
+                float(overlap_info[index - 1]) * _MAX_STITCH_UNITS_PER_OVERLAP_SECOND
+            )
+            max_match = min(len(stitched_units), len(piece_units), unit_budget)
+            duplicate_units = 0
+            for count in range(max_match, 0, -1):
+                if [unit.normalized for unit in stitched_units[-count:]] == [
+                    unit.normalized for unit in piece_units[:count]
+                ]:
+                    duplicate_units = count
+                    break
+            if duplicate_units == len(piece_units):
+                piece = ""
+            elif duplicate_units:
+                piece = piece[piece_units[duplicate_units].start :].lstrip()
+        if piece:
+            stitched += _transcript_separator(stitched, piece) + piece
+    return stitched
+
+
+def _transcript_units(text: str) -> list[_TranscriptUnit]:
+    units: list[_TranscriptUnit] = []
+    word_start: int | None = None
+
+    def append_word(end: int) -> None:
+        nonlocal word_start
+        if word_start is None:
+            return
+        word = text[word_start:end]
+        units.append(_TranscriptUnit(_normalize_word(word), word_start, end))
+        word_start = None
+
+    for index, character in enumerate(text):
+        if character.isspace():
+            append_word(index)
+        elif _is_cjk_character(character):
+            append_word(index)
+            units.append(
+                _TranscriptUnit(character.casefold(), index, index + len(character))
+            )
+        elif word_start is None:
+            word_start = index
+    append_word(len(text))
+    return units
+
+
+def _transcript_separator(previous: str, current: str) -> str:
+    if not previous or not current or previous[-1].isspace() or current[0].isspace():
+        return ""
+    if _is_no_space_boundary(previous[-1]) or _is_no_space_boundary(current[0]):
+        return ""
+    if unicodedata.category(current[0]).startswith("P"):
+        return ""
+    return " "
+
+
+def _is_no_space_boundary(character: str) -> bool:
+    return _is_cjk_character(character) or (
+        unicodedata.category(character).startswith("P")
+        and unicodedata.east_asian_width(character) in {"F", "W"}
+    )
+
+
+def _is_cjk_character(character: str) -> bool:
+    codepoint = ord(character)
+    return (
+        0x3400 <= codepoint <= 0x4DBF
+        or 0x4E00 <= codepoint <= 0x9FFF
+        or 0xF900 <= codepoint <= 0xFAFF
+        or 0x20000 <= codepoint <= 0x2FA1F
+        or 0x3040 <= codepoint <= 0x30FF
+        or 0xAC00 <= codepoint <= 0xD7AF
+    )
+
+
+def _normalize_word(word: str) -> str:
+    start = 0
+    end = len(word)
+    while start < end and unicodedata.category(word[start]).startswith("P"):
+        start += 1
+    while end > start and unicodedata.category(word[end - 1]).startswith("P"):
+        end -= 1
+    normalized = word[start:end]
+    return (normalized or word).casefold()
+
+
 def prepare_audio(
     payload: StagePayload,
     *,
@@ -96,8 +333,12 @@ def prepare_audio(
 
 
 __all__ = [
+    "Chunk",
     "DEFAULT_TARGET_SAMPLE_RATE",
     "PreparedAudio",
+    "detect_silence_boundaries",
+    "plan_chunks",
     "prepare_audio",
     "resolve_audio_source",
+    "stitch_transcripts",
 ]

--- a/sglang_omni/preprocessing/transcription.py
+++ b/sglang_omni/preprocessing/transcription.py
@@ -187,7 +187,9 @@ def plan_chunks(
         if end == num_samples:
             break
         previous_end = end
-        start = end - overlap_samples
+        # An early silence boundary can sit at or before the overlap width;
+        # clamp so every start stays in-range and strictly increases.
+        start = max(end - overlap_samples, start + 1)
     return chunks
 
 

--- a/sglang_omni/preprocessing/transcription.py
+++ b/sglang_omni/preprocessing/transcription.py
@@ -14,7 +14,6 @@ sources beyond the default payload keys (e.g. MOSS-Transcribe-Diarize).
 
 from __future__ import annotations
 
-import math
 import unicodedata
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Sequence
@@ -75,18 +74,6 @@ class Chunk:
         return self.end_sample - self.start_sample
 
 
-# Conservative upper bound for either CJK characters or whitespace-delimited
-# words produced by ASR during one second of overlapped audio.
-_MAX_STITCH_UNITS_PER_OVERLAP_SECOND = 20
-
-
-@dataclass(frozen=True)
-class _TranscriptUnit:
-    normalized: str
-    start: int
-    end: int
-
-
 def detect_silence_boundaries(
     waveform: np.ndarray,
     sample_rate: int,
@@ -144,23 +131,17 @@ def plan_chunks(
     num_samples: int,
     sample_rate: int,
     max_window_s: float,
-    overlap_s: float,
     vad_boundaries: Sequence[int],
 ) -> list[Chunk]:
-    """Plan exact half-open windows, preferring silence before each hard limit."""
+    """Plan non-overlapping windows, preferring silence before each hard limit."""
 
     if num_samples < 0:
         raise ValueError("num_samples must be non-negative")
     if sample_rate <= 0:
         raise ValueError("sample_rate must be positive")
     max_samples = round(max_window_s * sample_rate)
-    overlap_samples = round(overlap_s * sample_rate)
     if max_samples <= 0:
         raise ValueError("max_window_s must produce at least one sample")
-    if overlap_samples < 0:
-        raise ValueError("overlap_s must be non-negative")
-    if overlap_samples >= max_samples:
-        raise ValueError("overlap_s must be smaller than max_window_s")
     if num_samples == 0:
         return []
     if num_samples <= max_samples:
@@ -171,104 +152,31 @@ def plan_chunks(
     )
     chunks: list[Chunk] = []
     start = 0
-    previous_end = 0
     while start < num_samples:
         hard_end = min(start + max_samples, num_samples)
         if hard_end == num_samples:
             end = hard_end
         else:
             candidates = [
-                boundary
-                for boundary in boundaries
-                if previous_end < boundary <= hard_end
+                boundary for boundary in boundaries if start < boundary <= hard_end
             ]
             end = candidates[-1] if candidates else hard_end
         chunks.append(Chunk(start, end))
         if end == num_samples:
             break
-        previous_end = end
-        # An early silence boundary can sit at or before the overlap width;
-        # clamp so every start stays in-range and strictly increases.
-        start = max(end - overlap_samples, start + 1)
+        start = end
     return chunks
 
 
-def stitch_transcripts(
-    pieces: Sequence[str], overlap_info: Sequence[int | float | bool]
-) -> str:
-    """Join chunk text with bounded exact suffix-prefix overlap removal.
-
-    CJK text is split into individual characters while whitespace-delimited
-    text is split into words. The overlap duration bounds how many units may be
-    compared, so repeated text outside the audio overlap is never guessed away.
-    """
-
-    if len(overlap_info) != max(len(pieces) - 1, 0):
-        raise ValueError("overlap_info must have one entry per adjacent piece")
-
+def stitch_transcripts(pieces: Sequence[str]) -> str:
+    """Join chunk text with a language-aware separator and no de-duplication."""
     stitched = ""
-    for index, piece in enumerate(pieces):
+    for piece in pieces:
         piece = piece.strip()
         if not piece:
             continue
-        if stitched and index > 0 and overlap_info[index - 1] > 0:
-            # Match on content units only: ASR often attaches sentence-final
-            # punctuation to the first chunk's tail ("...在此。" vs "在此奉劝"),
-            # and a punctuation unit would block the exact suffix-prefix match.
-            stitched_units = [
-                unit
-                for unit in _transcript_units(stitched)
-                if not _is_punctuation_only(unit.normalized)
-            ]
-            piece_units = [
-                unit
-                for unit in _transcript_units(piece)
-                if not _is_punctuation_only(unit.normalized)
-            ]
-            unit_budget = math.ceil(
-                float(overlap_info[index - 1]) * _MAX_STITCH_UNITS_PER_OVERLAP_SECOND
-            )
-            max_match = min(len(stitched_units), len(piece_units), unit_budget)
-            duplicate_units = 0
-            for count in range(max_match, 0, -1):
-                if [unit.normalized for unit in stitched_units[-count:]] == [
-                    unit.normalized for unit in piece_units[:count]
-                ]:
-                    duplicate_units = count
-                    break
-            if duplicate_units == len(piece_units):
-                piece = ""
-            elif duplicate_units:
-                piece = piece[piece_units[duplicate_units].start :].lstrip()
-        if piece:
-            stitched += _transcript_separator(stitched, piece) + piece
+        stitched += _transcript_separator(stitched, piece) + piece
     return stitched
-
-
-def _transcript_units(text: str) -> list[_TranscriptUnit]:
-    units: list[_TranscriptUnit] = []
-    word_start: int | None = None
-
-    def append_word(end: int) -> None:
-        nonlocal word_start
-        if word_start is None:
-            return
-        word = text[word_start:end]
-        units.append(_TranscriptUnit(_normalize_word(word), word_start, end))
-        word_start = None
-
-    for index, character in enumerate(text):
-        if character.isspace():
-            append_word(index)
-        elif _is_cjk_character(character):
-            append_word(index)
-            units.append(
-                _TranscriptUnit(character.casefold(), index, index + len(character))
-            )
-        elif word_start is None:
-            word_start = index
-    append_word(len(text))
-    return units
 
 
 def _transcript_separator(previous: str, current: str) -> str:
@@ -298,23 +206,6 @@ def _is_cjk_character(character: str) -> bool:
         or 0x3040 <= codepoint <= 0x30FF
         or 0xAC00 <= codepoint <= 0xD7AF
     )
-
-
-def _is_punctuation_only(normalized: str) -> bool:
-    return bool(normalized) and all(
-        unicodedata.category(character).startswith("P") for character in normalized
-    )
-
-
-def _normalize_word(word: str) -> str:
-    start = 0
-    end = len(word)
-    while start < end and unicodedata.category(word[start]).startswith("P"):
-        start += 1
-    while end > start and unicodedata.category(word[end - 1]).startswith("P"):
-        end -= 1
-    normalized = word[start:end]
-    return (normalized or word).casefold()
 
 
 def prepare_audio(

--- a/sglang_omni/preprocessing/transcription.py
+++ b/sglang_omni/preprocessing/transcription.py
@@ -212,8 +212,19 @@ def stitch_transcripts(
         if not piece:
             continue
         if stitched and index > 0 and overlap_info[index - 1] > 0:
-            stitched_units = _transcript_units(stitched)
-            piece_units = _transcript_units(piece)
+            # Match on content units only: ASR often attaches sentence-final
+            # punctuation to the first chunk's tail ("...在此。" vs "在此奉劝"),
+            # and a punctuation unit would block the exact suffix-prefix match.
+            stitched_units = [
+                unit
+                for unit in _transcript_units(stitched)
+                if not _is_punctuation_only(unit.normalized)
+            ]
+            piece_units = [
+                unit
+                for unit in _transcript_units(piece)
+                if not _is_punctuation_only(unit.normalized)
+            ]
             unit_budget = math.ceil(
                 float(overlap_info[index - 1]) * _MAX_STITCH_UNITS_PER_OVERLAP_SECOND
             )
@@ -286,6 +297,12 @@ def _is_cjk_character(character: str) -> bool:
         or 0x20000 <= codepoint <= 0x2FA1F
         or 0x3040 <= codepoint <= 0x30FF
         or 0xAC00 <= codepoint <= 0xD7AF
+    )
+
+
+def _is_punctuation_only(normalized: str) -> bool:
+    return bool(normalized) and all(
+        unicodedata.category(character).startswith("P") for character in normalized
     )
 
 

--- a/sglang_omni/preprocessing/transcription.py
+++ b/sglang_omni/preprocessing/transcription.py
@@ -14,6 +14,7 @@ sources beyond the default payload keys (e.g. MOSS-Transcribe-Diarize).
 
 from __future__ import annotations
 
+import math
 import unicodedata
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Sequence
@@ -132,8 +133,10 @@ def plan_chunks(
     sample_rate: int,
     max_window_s: float,
     vad_boundaries: Sequence[int],
+    *,
+    boundary_search_s: float = 5.0,
 ) -> list[Chunk]:
-    """Plan non-overlapping windows, preferring silence before each hard limit."""
+    """Plan non-overlapping windows, preferring nearby silence before each limit."""
 
     if num_samples < 0:
         raise ValueError("num_samples must be non-negative")
@@ -142,6 +145,14 @@ def plan_chunks(
     max_samples = round(max_window_s * sample_rate)
     if max_samples <= 0:
         raise ValueError("max_window_s must produce at least one sample")
+    if not math.isfinite(boundary_search_s) or boundary_search_s < 0:
+        raise ValueError("boundary_search_s must be a finite non-negative number")
+    # note (Junnan Li): The 5-second default keeps silence cuts near the hard
+    # limit; fall back to the hard limit instead of overlapping when none exists.
+    search_samples = min(
+        round(boundary_search_s * sample_rate),
+        max_samples // 2,
+    )
     if num_samples == 0:
         return []
     if num_samples <= max_samples:
@@ -157,8 +168,11 @@ def plan_chunks(
         if hard_end == num_samples:
             end = hard_end
         else:
+            search_start = hard_end - search_samples
             candidates = [
-                boundary for boundary in boundaries if start < boundary <= hard_end
+                boundary
+                for boundary in boundaries
+                if search_start <= boundary <= hard_end
             ]
             end = candidates[-1] if candidates else hard_end
         chunks.append(Chunk(start, end))

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -203,7 +203,6 @@ def _transcription_chunking_kwargs(
     keys = (
         "asr_auto_chunk",
         "asr_chunk_max_seconds",
-        "asr_chunk_overlap_seconds",
     )
     if "asr_chunk_max_seconds" not in factory_args:
         return {}

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -184,8 +184,6 @@ def _model_capabilities_log_summary(
 def _transcription_chunking_kwargs(
     pipeline_config: PipelineConfig,
 ) -> dict[str, Any]:
-    """Forward an entry stage's optional model-owned chunking policy."""
-
     entry_stage = next(
         (
             stage
@@ -196,9 +194,8 @@ def _transcription_chunking_kwargs(
     )
     if entry_stage is None:
         return {}
-    # Use the standard resolver so runtime_overrides win here exactly as they
-    # do for the worker-side factory; reading factory_args directly can hand
-    # the endpoint a different policy than the stage actually runs with.
+    # note (Junnan Li): Use the standard resolver so the endpoint and worker
+    # apply the same runtime-overridden policy.
     factory_args = resolve_stage_static_factory_args(entry_stage, pipeline_config)
     keys = (
         "asr_auto_chunk",

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -39,6 +39,7 @@ from pydantic import BaseModel
 
 from sglang_omni.client import Client
 from sglang_omni.config import PipelineConfig
+from sglang_omni.config.runtime import resolve_stage_static_factory_args
 from sglang_omni.models.model_capabilities import get_model_capabilities
 from sglang_omni.pipeline.mp_runner import MultiProcessPipelineRunner
 from sglang_omni.profiler.event_recorder import get_recorder as _get_event_recorder
@@ -193,7 +194,12 @@ def _transcription_chunking_kwargs(
         ),
         None,
     )
-    factory_args = dict(entry_stage.factory_args or {}) if entry_stage else {}
+    if entry_stage is None:
+        return {}
+    # Use the standard resolver so runtime_overrides win here exactly as they
+    # do for the worker-side factory; reading factory_args directly can hand
+    # the endpoint a different policy than the stage actually runs with.
+    factory_args = resolve_stage_static_factory_args(entry_stage, pipeline_config)
     keys = (
         "asr_auto_chunk",
         "asr_chunk_max_seconds",

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -180,6 +180,30 @@ def _model_capabilities_log_summary(
     }
 
 
+def _transcription_chunking_kwargs(
+    pipeline_config: PipelineConfig,
+) -> dict[str, Any]:
+    """Forward an entry stage's optional model-owned chunking policy."""
+
+    entry_stage = next(
+        (
+            stage
+            for stage in pipeline_config.stages
+            if stage.name == pipeline_config.entry_stage
+        ),
+        None,
+    )
+    factory_args = dict(entry_stage.factory_args or {}) if entry_stage else {}
+    keys = (
+        "asr_auto_chunk",
+        "asr_chunk_max_seconds",
+        "asr_chunk_overlap_seconds",
+    )
+    if "asr_chunk_max_seconds" not in factory_args:
+        return {}
+    return {key: factory_args[key] for key in keys if key in factory_args}
+
+
 def _log_model_capabilities(pipeline_config: PipelineConfig) -> None:
     try:
         summary = _model_capabilities_log_summary(pipeline_config)
@@ -402,6 +426,7 @@ async def _run_server(
             allowed_media_domains=allowed_media_domains,
             tts_batch_max_items=tts_batch_max_items,
             architectures=[pipeline_config.architecture],
+            **_transcription_chunking_kwargs(pipeline_config),
         )
         profiler_dir = os.environ.get("SGLANG_TORCH_PROFILER_DIR")
         profiler_ctl = ProfilerControlClient(mp_runner.stage_control_endpoints)

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -1842,8 +1842,6 @@ def _register_transcriptions(app: FastAPI) -> None:
 
         adapter = resolve_adapter(getattr(app.state, "architectures", None))
         text = adapter.postprocess_text(text)
-        # Chunked responses aggregate text only because timestamp-bearing
-        # formats require remapping each chunk to the original timeline.
         usage = (
             TranscriptionUsage(seconds=math.ceil(duration_s))
             if duration_s > 0
@@ -1886,6 +1884,8 @@ async def _complete_auto_chunked_transcription(
     waveform: Any,
     chunks: list[Chunk],
 ) -> str:
+    # note (Junnan Li): Do not expose accumulated text until every child finishes;
+    # a partial transcript must never be returned as a successful response.
     pieces: list[str] = []
     for index, chunk in enumerate(chunks):
         chunk_bytes, _ = encode_audio(
@@ -1907,6 +1907,8 @@ async def _complete_auto_chunked_transcription(
             request_id=f"{request_id}-chunk-{index}",
         )
         pieces.append(result.text)
+    # note (Junnan Li): Timestamp-bearing formats need per-chunk timeline
+    # remapping, so auto-chunking currently aggregates text only.
     return stitch_transcripts(pieces)
 
 

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -234,7 +234,6 @@ def create_app(
     architectures: list[str] | None = None,
     asr_auto_chunk: bool | None = None,
     asr_chunk_max_seconds: float | None = None,
-    asr_chunk_overlap_seconds: float = 0.0,
 ) -> FastAPI:
     """Create a FastAPI application with OpenAI-compatible endpoints.
 
@@ -263,7 +262,6 @@ def create_app(
         architectures: Model architectures used by transcription adapters.
         asr_auto_chunk: Optional model-owned long-audio chunking toggle.
         asr_chunk_max_seconds: Hard maximum duration for each ASR chunk.
-        asr_chunk_overlap_seconds: Overlap between adjacent ASR chunks.
 
     Returns:
         Configured FastAPI application.
@@ -288,7 +286,6 @@ def create_app(
     app.state.architectures = [a for a in (architectures or []) if a]
     app.state.asr_auto_chunk = asr_auto_chunk
     app.state.asr_chunk_max_seconds = asr_chunk_max_seconds
-    app.state.asr_chunk_overlap_seconds = asr_chunk_overlap_seconds
     app.state.realtime_enabled = enable_realtime
     app.state.supports_realtime_audio_output = supports_realtime_audio_output
     app.state.speaker_sample_store = SpeakerSampleStore()
@@ -1696,7 +1693,6 @@ def _register_transcriptions(app: FastAPI) -> None:
             chunk_plan = _plan_transcription_chunks(
                 chunk_waveform,
                 chunk_max_s,
-                app.state.asr_chunk_overlap_seconds,
             )
         if chunk_plan is not None and stream:
             base_request = build_transcription_generate_request(
@@ -1871,14 +1867,12 @@ def _register_transcriptions(app: FastAPI) -> None:
 def _plan_transcription_chunks(
     waveform: Any,
     max_window_s: float,
-    overlap_s: float,
 ) -> list[Chunk]:
     vad_boundaries = detect_silence_boundaries(waveform, DEFAULT_TARGET_SAMPLE_RATE)
     return plan_chunks(
         len(waveform),
         DEFAULT_TARGET_SAMPLE_RATE,
         max_window_s,
-        overlap_s,
         vad_boundaries,
     )
 
@@ -1913,11 +1907,7 @@ async def _complete_auto_chunked_transcription(
             request_id=f"{request_id}-chunk-{index}",
         )
         pieces.append(result.text)
-    overlap_seconds = [
-        (previous.end_sample - current.start_sample) / DEFAULT_TARGET_SAMPLE_RATE
-        for previous, current in zip(chunks, chunks[1:])
-    ]
-    return stitch_transcripts(pieces, overlap_seconds)
+    return stitch_transcripts(pieces)
 
 
 async def _completed_transcription_stream(

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -27,6 +27,7 @@ import time
 import uuid
 from collections.abc import Awaitable, Callable
 from contextlib import aclosing, suppress
+from dataclasses import replace
 from typing import Any, AsyncIterator
 
 from fastapi import (
@@ -60,6 +61,7 @@ from sglang_omni.client import (
 from sglang_omni.client.audio import (
     DEFAULT_SAMPLE_RATE,
     apply_speed,
+    encode_audio,
     encode_pcm,
     select_audio_delta,
 )
@@ -69,6 +71,13 @@ from sglang_omni.http.admin_auth import (
 )
 from sglang_omni.http.favicon import register_favicon
 from sglang_omni.proto import EXPLICIT_GENERATION_PARAMS_KEY
+from sglang_omni.preprocessing.transcription import (
+    DEFAULT_TARGET_SAMPLE_RATE,
+    Chunk,
+    detect_silence_boundaries,
+    plan_chunks,
+    stitch_transcripts,
+)
 from sglang_omni.serve.protocol import (
     DEFAULT_TTS_BATCH_MAX_ITEMS,
     AdminRequestBase,
@@ -114,6 +123,7 @@ from sglang_omni.serve.speech_service import SpeechRequestValidator
 from sglang_omni.serve.speech_voices import MAX_VOICE_UPLOAD_BYTES, SpeakerSampleStore
 from sglang_omni.serve.speech_ws import SpeechWebSocketSession
 from sglang_omni.serve.transcription_adapters import resolve_adapter
+from sglang_omni.utils.audio import load_audio
 
 logger = logging.getLogger(__name__)
 STREAM_DONE_SENTINEL = "[DONE]"
@@ -222,6 +232,9 @@ def create_app(
     admin_api_key: str | None = None,
     tts_batch_max_items: int = DEFAULT_TTS_BATCH_MAX_ITEMS,
     architectures: list[str] | None = None,
+    asr_auto_chunk: bool | None = None,
+    asr_chunk_max_seconds: float | None = None,
+    asr_chunk_overlap_seconds: float = 0.0,
 ) -> FastAPI:
     """Create a FastAPI application with OpenAI-compatible endpoints.
 
@@ -247,6 +260,10 @@ def create_app(
         admin_api_key: Optional API key for admin-control endpoints.
         tts_batch_max_items: Maximum items accepted by
             ``/v1/audio/speech/batch``.
+        architectures: Model architectures used by transcription adapters.
+        asr_auto_chunk: Optional model-owned long-audio chunking toggle.
+        asr_chunk_max_seconds: Hard maximum duration for each ASR chunk.
+        asr_chunk_overlap_seconds: Overlap between adjacent ASR chunks.
 
     Returns:
         Configured FastAPI application.
@@ -269,6 +286,9 @@ def create_app(
     app.state.client = client
     app.state.model_name = model_name or "sglang-omni"
     app.state.architectures = [a for a in (architectures or []) if a]
+    app.state.asr_auto_chunk = asr_auto_chunk
+    app.state.asr_chunk_max_seconds = asr_chunk_max_seconds
+    app.state.asr_chunk_overlap_seconds = asr_chunk_overlap_seconds
     app.state.realtime_enabled = enable_realtime
     app.state.supports_realtime_audio_output = supports_realtime_audio_output
     app.state.speaker_sample_store = SpeakerSampleStore()
@@ -1646,15 +1666,80 @@ def _register_transcriptions(app: FastAPI) -> None:
             raise HTTPException(status_code=400, detail="Uploaded audio file is empty")
 
         normalized_response_format = response_format.strip().lower()
-        if stream:
-            if normalized_response_format not in {"json", "text"}:
+        if stream and normalized_response_format not in {"json", "text"}:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "stream=true supports only response_format 'json' or "
+                    f"'text', got {response_format!r}"
+                ),
+            )
+        duration_s = _probe_audio_duration(audio_bytes)
+        chunk_plan = None
+        chunk_waveform = None
+        chunk_max_s = app.state.asr_chunk_max_seconds
+        if chunk_max_s is not None and duration_s > chunk_max_s:
+            if not app.state.asr_auto_chunk:
                 raise HTTPException(
                     status_code=400,
                     detail=(
-                        "stream=true supports only response_format 'json' or "
-                        f"'text', got {response_format!r}"
+                        f"Audio duration {duration_s:.3f} seconds exceeds the "
+                        f"model window of {chunk_max_s:.3f} seconds while auto "
+                        "chunking is disabled"
                     ),
                 )
+            chunk_waveform = load_audio(
+                audio_bytes,
+                source_name="transcription",
+                target_sample_rate=DEFAULT_TARGET_SAMPLE_RATE,
+            )
+            chunk_plan = _plan_transcription_chunks(
+                chunk_waveform,
+                chunk_max_s,
+                app.state.asr_chunk_overlap_seconds,
+            )
+        if chunk_plan is not None and stream:
+            base_request = build_transcription_generate_request(
+                audio_bytes=audio_bytes,
+                filename=file.filename,
+                content_type=file.content_type,
+                model=model or default_model,
+                language=language,
+                prompt=prompt,
+                temperature=temperature,
+                max_new_tokens=max_new_tokens,
+            )
+            try:
+                text = await _complete_auto_chunked_transcription(
+                    client,
+                    base_request,
+                    request_id=request_id,
+                    filename=file.filename,
+                    waveform=chunk_waveform,
+                    chunks=chunk_plan,
+                )
+            except ClientError as exc:
+                if _is_bad_request_error(exc):
+                    raise HTTPException(status_code=400, detail=str(exc)) from exc
+                raise HTTPException(status_code=500, detail=str(exc)) from exc
+            except Exception as exc:
+                if _is_bad_request_error(exc):
+                    raise HTTPException(status_code=400, detail=str(exc)) from exc
+                logger.exception(
+                    "Error transcribing chunked audio for request %s", request_id
+                )
+                raise HTTPException(status_code=500, detail=str(exc)) from exc
+            adapter = resolve_adapter(getattr(app.state, "architectures", None))
+            return _ClosableStreamingResponse(
+                _completed_transcription_stream(
+                    text,
+                    adapter=adapter,
+                    duration_s=duration_s,
+                ),
+                media_type="text/event-stream",
+                headers={"Cache-Control": "no-cache", "X-Request-Id": request_id},
+            )
+        if stream:
             gen_req = build_transcription_generate_request(
                 audio_bytes=audio_bytes,
                 filename=file.filename,
@@ -1667,7 +1752,6 @@ def _register_transcriptions(app: FastAPI) -> None:
                 stream=True,
             )
             adapter = resolve_adapter(getattr(app.state, "architectures", None))
-            duration_s = _probe_audio_duration(audio_bytes)
             chunk_stream = client.generate(gen_req, request_id=request_id)
             # note (db-ol): pull the first chunk before sending response
             # headers. Admission rejections such as audio past the context
@@ -1706,19 +1790,39 @@ def _register_transcriptions(app: FastAPI) -> None:
                 headers={"Cache-Control": "no-cache", "X-Request-Id": request_id},
             )
 
-        gen_req = build_transcription_generate_request(
-            audio_bytes=audio_bytes,
-            filename=file.filename,
-            content_type=file.content_type,
-            model=model or default_model,
-            language=language,
-            prompt=prompt,
-            temperature=temperature,
-            max_new_tokens=max_new_tokens,
-        )
-
         try:
-            result = await client.completion(gen_req, request_id=request_id)
+            if chunk_plan is None:
+                gen_req = build_transcription_generate_request(
+                    audio_bytes=audio_bytes,
+                    filename=file.filename,
+                    content_type=file.content_type,
+                    model=model or default_model,
+                    language=language,
+                    prompt=prompt,
+                    temperature=temperature,
+                    max_new_tokens=max_new_tokens,
+                )
+                result = await client.completion(gen_req, request_id=request_id)
+                text = result.text
+            else:
+                base_request = build_transcription_generate_request(
+                    audio_bytes=audio_bytes,
+                    filename=file.filename,
+                    content_type=file.content_type,
+                    model=model or default_model,
+                    language=language,
+                    prompt=prompt,
+                    temperature=temperature,
+                    max_new_tokens=max_new_tokens,
+                )
+                text = await _complete_auto_chunked_transcription(
+                    client,
+                    base_request,
+                    request_id=request_id,
+                    filename=file.filename,
+                    waveform=chunk_waveform,
+                    chunks=chunk_plan,
+                )
         except ClientError as exc:
             if _is_bad_request_error(exc):
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -1729,7 +1833,6 @@ def _register_transcriptions(app: FastAPI) -> None:
             logger.exception("Error transcribing audio for request %s", request_id)
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-        text = result.text
         if normalized_response_format == "text":
             return PlainTextResponse(text)
         if normalized_response_format not in {"json", "verbose_json"}:
@@ -1743,7 +1846,9 @@ def _register_transcriptions(app: FastAPI) -> None:
 
         adapter = resolve_adapter(getattr(app.state, "architectures", None))
         text = adapter.postprocess_text(text)
-        duration_s = _probe_audio_duration(audio_bytes)
+        # Chunk-local timestamps are intentionally not remapped in F1. The
+        # endpoint's current plain-text/minimal-JSON contract is preserved;
+        # timestamp-bearing chunk aggregation belongs to a follow-up.
         usage = (
             TranscriptionUsage(seconds=math.ceil(duration_s))
             if duration_s > 0
@@ -1762,6 +1867,76 @@ def _register_transcriptions(app: FastAPI) -> None:
                 exclude_none=True
             )
         )
+
+
+def _plan_transcription_chunks(
+    waveform: Any,
+    max_window_s: float,
+    overlap_s: float,
+) -> list[Chunk]:
+    vad_boundaries = detect_silence_boundaries(waveform, DEFAULT_TARGET_SAMPLE_RATE)
+    return plan_chunks(
+        len(waveform),
+        DEFAULT_TARGET_SAMPLE_RATE,
+        max_window_s,
+        overlap_s,
+        vad_boundaries,
+    )
+
+
+async def _complete_auto_chunked_transcription(
+    client: Client,
+    base_request: GenerateRequest,
+    *,
+    request_id: str,
+    filename: str | None,
+    waveform: Any,
+    chunks: list[Chunk],
+) -> str:
+    pieces: list[str] = []
+    for index, chunk in enumerate(chunks):
+        chunk_bytes, _ = encode_audio(
+            waveform[chunk.start_sample : chunk.end_sample],
+            response_format="wav",
+            sample_rate=DEFAULT_TARGET_SAMPLE_RATE,
+        )
+        chunk_request = replace(
+            base_request,
+            prompt={
+                "audio_bytes": chunk_bytes,
+                "filename": f"{filename or 'audio'}.chunk-{index:04d}.wav",
+                "content_type": "audio/wav",
+            },
+            stream=False,
+        )
+        result = await client.completion(
+            chunk_request,
+            request_id=f"{request_id}-chunk-{index}",
+        )
+        pieces.append(result.text)
+    overlap_seconds = [
+        (previous.end_sample - current.start_sample) / DEFAULT_TARGET_SAMPLE_RATE
+        for previous, current in zip(chunks, chunks[1:])
+    ]
+    return stitch_transcripts(pieces, overlap_seconds)
+
+
+async def _completed_transcription_stream(
+    text: str,
+    *,
+    adapter: Any,
+    duration_s: float,
+) -> AsyncIterator[str]:
+    text = adapter.postprocess_text(text)
+    if text:
+        event = TranscriptionTextDeltaEvent(delta=text)
+        yield f"data: {event.model_dump_json(exclude_none=True)}\n\n"
+    usage = (
+        TranscriptionUsage(seconds=math.ceil(duration_s)) if duration_s > 0 else None
+    )
+    done_event = TranscriptionTextDoneEvent(text=text, usage=usage)
+    yield f"data: {done_event.model_dump_json(exclude_none=True)}\n\n"
+    yield f"data: {STREAM_DONE_SENTINEL}\n\n"
 
 
 async def _transcription_stream(

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -70,7 +70,6 @@ from sglang_omni.http.admin_auth import (
     resolve_admin_api_key,
 )
 from sglang_omni.http.favicon import register_favicon
-from sglang_omni.proto import EXPLICIT_GENERATION_PARAMS_KEY
 from sglang_omni.preprocessing.transcription import (
     DEFAULT_TARGET_SAMPLE_RATE,
     Chunk,
@@ -78,6 +77,7 @@ from sglang_omni.preprocessing.transcription import (
     plan_chunks,
     stitch_transcripts,
 )
+from sglang_omni.proto import EXPLICIT_GENERATION_PARAMS_KEY
 from sglang_omni.serve.protocol import (
     DEFAULT_TTS_BATCH_MAX_ITEMS,
     AdminRequestBase,
@@ -1846,9 +1846,8 @@ def _register_transcriptions(app: FastAPI) -> None:
 
         adapter = resolve_adapter(getattr(app.state, "architectures", None))
         text = adapter.postprocess_text(text)
-        # Chunk-local timestamps are intentionally not remapped in F1. The
-        # endpoint's current plain-text/minimal-JSON contract is preserved;
-        # timestamp-bearing chunk aggregation belongs to a follow-up.
+        # Chunked responses aggregate text only because timestamp-bearing
+        # formats require remapping each chunk to the original timeline.
         usage = (
             TranscriptionUsage(seconds=math.ceil(duration_s))
             if duration_s > 0

--- a/tests/README.md
+++ b/tests/README.md
@@ -374,7 +374,7 @@ that happened to contain an older version of the test.
   - ASR audio source compatibility, duration/fingerprint derivation, and
     resampling/downmix behavior
   - exact-sample long-audio chunk planning, silence-boundary preference,
-    hard-window fallback, overlap, and transcript de-duplication.
+    non-overlapping hard-window fallback, and language-aware text joining.
 - `unit_test/models/`: Model registry and cross-model contract tests:
   - static TTS `ModelCapabilities` declarations, registry lookup, aliases, and
     launcher startup logging.
@@ -397,7 +397,7 @@ that happened to contain an older version of the test.
     short-audio path preservation, and explicit over-window rejection when
     chunking is disabled.
 - `unit_test/serve/test_asr_auto_chunk.py`: OpenAI-compatible transcription tests:
-  - long-audio chunk orchestration and overlap-aware multilingual text stitching
+  - non-overlapping long-audio chunk orchestration and multilingual text joining
   - unchanged single-request handling at or below the configured model window
   - explicit HTTP 400 behavior when long-audio auto chunking is disabled
   - whole-request HTTP 500 failure with remaining chunks abandoned after a child

--- a/tests/README.md
+++ b/tests/README.md
@@ -134,6 +134,7 @@ tests/
     │   ├── test_stop_run_id.py
     │   └── test_views.py
     ├── serve/
+    │   ├── test_asr_auto_chunk.py
     │   ├── test_generation_batch_policy.py
     │   ├── test_generation_server_args.py
     │   └── test_openai_api.py
@@ -369,6 +370,11 @@ that happened to contain an older version of the test.
 - `unit_test/utils/`: Shared utility tests:
   - audio loading helpers for data URIs, file URIs, HTTP URLs, timeout fallback,
     and mono/channel preservation.
+- `unit_test/preprocessing/`: Shared request-preparation tests:
+  - ASR audio source compatibility, duration/fingerprint derivation, and
+    resampling/downmix behavior
+  - exact-sample long-audio chunk planning, silence-boundary preference,
+    hard-window fallback, overlap, and transcript de-duplication.
 - `unit_test/models/`: Model registry and cross-model contract tests:
   - static TTS `ModelCapabilities` declarations, registry lookup, aliases, and
     launcher startup logging.
@@ -387,6 +393,15 @@ that happened to contain an older version of the test.
     request builder paths
   - token-level result adapter marker handling, avoiding decode/encode
     text round-trips for byte-level BPE output.
+  - model-owned auto-chunk defaults, CLI/factory override propagation,
+    short-audio path preservation, and explicit over-window rejection when
+    chunking is disabled.
+- `unit_test/serve/test_asr_auto_chunk.py`: OpenAI-compatible transcription tests:
+  - long-audio chunk orchestration and overlap-aware multilingual text stitching
+  - unchanged single-request handling at or below the configured model window
+  - explicit HTTP 400 behavior when long-audio auto chunking is disabled
+  - whole-request HTTP 500 failure with remaining chunks abandoned after a child
+    completion fails.
 - `unit_test/fun_asr/`: Fun-ASR-Nano unit tests:
   - pipeline config and stage factory: single `asr` stage, `max_running_requests=32`,
     auto static KV budget, pre-LM encoder/cache defaults, scheduler-owned

--- a/tests/unit_test/preprocessing/test_transcription.py
+++ b/tests/unit_test/preprocessing/test_transcription.py
@@ -222,14 +222,6 @@ def test_plan_chunks_falls_back_to_non_overlapping_fixed_windows() -> None:
     ]
 
 
-def test_plan_chunks_preserves_a_short_final_window() -> None:
-    assert plan_chunks(95, 10, 4.0, []) == [
-        Chunk(0, 40),
-        Chunk(40, 80),
-        Chunk(80, 95),
-    ]
-
-
 def test_plan_chunks_prefers_latest_vad_boundary_before_hard_limit() -> None:
     assert plan_chunks(100, 10, 4.0, [15, 35, 65]) == [
         Chunk(0, 35),
@@ -258,19 +250,14 @@ def test_stitch_transcripts_ignores_empty_pieces() -> None:
     assert stitch_transcripts(["", "hello world", "", "again"]) == "hello world again"
 
 
-def test_plan_chunks_early_silence_boundary_keeps_non_overlapping_starts_valid() -> (
-    None
-):
-    chunks = transcription.plan_chunks(
+def test_plan_chunks_ignores_silence_far_before_hard_limit() -> None:
+    assert transcription.plan_chunks(
         num_samples=100,
         sample_rate=1,
         max_window_s=35.0,
         vad_boundaries=[5],
-    )
-
-    for index, chunk in enumerate(chunks):
-        assert 0 <= chunk.start_sample < chunk.end_sample <= 100
-        if index:
-            assert chunks[index - 1].end_sample == chunk.start_sample
-    assert chunks[0] == transcription.Chunk(0, 5)
-    assert chunks[-1].end_sample == 100
+    ) == [
+        transcription.Chunk(0, 35),
+        transcription.Chunk(35, 70),
+        transcription.Chunk(70, 100),
+    ]

--- a/tests/unit_test/preprocessing/test_transcription.py
+++ b/tests/unit_test/preprocessing/test_transcription.py
@@ -180,9 +180,7 @@ def test_prepare_audio_resamples_and_downmixes_like_before() -> None:
 
 
 def test_plan_chunks_keeps_short_audio_in_one_exact_window() -> None:
-    assert plan_chunks(319, 160, 2.0, 0.25, []) == [
-        Chunk(start_sample=0, end_sample=319)
-    ]
+    assert plan_chunks(319, 160, 2.0, []) == [Chunk(start_sample=0, end_sample=319)]
 
 
 def test_detect_silence_boundaries_returns_internal_silence_midpoint() -> None:
@@ -216,122 +214,63 @@ def test_detect_silence_boundaries_ignores_audio_without_internal_silence() -> N
     )
 
 
-def test_plan_chunks_falls_back_to_fixed_windows_with_overlap() -> None:
-    assert plan_chunks(100, 10, 4.0, 1.0, []) == [
+def test_plan_chunks_falls_back_to_non_overlapping_fixed_windows() -> None:
+    assert plan_chunks(100, 10, 4.0, []) == [
         Chunk(0, 40),
-        Chunk(30, 70),
-        Chunk(60, 100),
+        Chunk(40, 80),
+        Chunk(80, 100),
     ]
 
 
 def test_plan_chunks_preserves_a_short_final_window() -> None:
-    assert plan_chunks(95, 10, 4.0, 1.0, []) == [
+    assert plan_chunks(95, 10, 4.0, []) == [
         Chunk(0, 40),
-        Chunk(30, 70),
-        Chunk(60, 95),
+        Chunk(40, 80),
+        Chunk(80, 95),
     ]
 
 
 def test_plan_chunks_prefers_latest_vad_boundary_before_hard_limit() -> None:
-    assert plan_chunks(100, 10, 4.0, 1.0, [15, 35, 65]) == [
+    assert plan_chunks(100, 10, 4.0, [15, 35, 65]) == [
         Chunk(0, 35),
-        Chunk(25, 65),
-        Chunk(55, 95),
-        Chunk(85, 100),
+        Chunk(35, 65),
+        Chunk(65, 100),
     ]
 
 
-@pytest.mark.parametrize(
-    ("max_window_s", "overlap_s"),
-    [(0.0, 0.0), (1.0, -0.1), (1.0, 1.0), (1.0, 1.1)],
-)
-def test_plan_chunks_rejects_invalid_windows(
-    max_window_s: float, overlap_s: float
-) -> None:
+@pytest.mark.parametrize("max_window_s", [0.0, -1.0])
+def test_plan_chunks_rejects_invalid_windows(max_window_s: float) -> None:
     with pytest.raises(ValueError):
-        plan_chunks(100, 10, max_window_s, overlap_s, [])
+        plan_chunks(100, 10, max_window_s, [])
 
 
-def test_stitch_transcripts_removes_repeated_overlap_words() -> None:
-    assert (
-        stitch_transcripts(
-            ["the quick brown fox", "brown fox jumps over", "over the dog"],
-            [2, 1],
-        )
-        == "the quick brown fox jumps over the dog"
-    )
-
-
-def test_stitch_transcripts_keeps_non_repeated_boundary_words() -> None:
-    assert stitch_transcripts(["hello boundary", "different world"], [1]) == (
+def test_stitch_transcripts_separates_latin_chunks_with_space() -> None:
+    assert stitch_transcripts(["hello boundary", "different world"]) == (
         "hello boundary different world"
     )
 
 
-def test_stitch_transcripts_matches_overlap_across_case_and_punctuation() -> None:
-    assert stitch_transcripts(["Hello, boundary!", "BOUNDARY world"], [1]) == (
-        "Hello, boundary! world"
-    )
-
-
-def test_stitch_transcripts_removes_repeated_chinese_phrase() -> None:
-    assert stitch_transcripts(["今天天气很好", "天气很好我们去公园"], [1.0]) == (
-        "今天天气很好我们去公园"
-    )
-
-
-def test_stitch_transcripts_handles_mixed_chinese_and_english() -> None:
-    assert (
-        stitch_transcripts(["今天学习 Qwen three", "Qwen three模型很好用"], [1.0])
-        == "今天学习 Qwen three模型很好用"
-    )
-
-
-def test_stitch_transcripts_joins_unmatched_cjk_without_space() -> None:
-    assert stitch_transcripts(["你好世界", "今天天气很好"], [1.0]) == (
-        "你好世界今天天气很好"
-    )
-
-
-def test_stitch_transcripts_limits_matching_to_overlap_derived_budget() -> None:
-    assert stitch_transcripts(["甲乙丙", "甲乙丙丁"], [0.1]) == "甲乙丙甲乙丙丁"
+def test_stitch_transcripts_joins_cjk_chunks_without_space() -> None:
+    assert stitch_transcripts(["你好世界", "今天天气很好"]) == ("你好世界今天天气很好")
 
 
 def test_stitch_transcripts_ignores_empty_pieces() -> None:
-    assert stitch_transcripts(["", "hello world", "", "world again"], [1, 1, 1]) == (
-        "hello world again"
-    )
+    assert stitch_transcripts(["", "hello world", "", "again"]) == "hello world again"
 
 
-def test_plan_chunks_early_silence_boundary_keeps_starts_valid() -> None:
-    """A silence point at or before the overlap width must not slip negative."""
+def test_plan_chunks_early_silence_boundary_keeps_non_overlapping_starts_valid() -> (
+    None
+):
     chunks = transcription.plan_chunks(
         num_samples=100,
         sample_rate=1,
         max_window_s=35.0,
-        overlap_s=10.0,
         vad_boundaries=[5],
     )
 
-    previous_start = -1
-    for chunk in chunks:
+    for index, chunk in enumerate(chunks):
         assert 0 <= chunk.start_sample < chunk.end_sample <= 100
-        assert chunk.start_sample > previous_start
-        previous_start = chunk.start_sample
+        if index:
+            assert chunks[index - 1].end_sample == chunk.start_sample
     assert chunks[0] == transcription.Chunk(0, 5)
     assert chunks[-1].end_sample == 100
-
-
-def test_stitch_dedup_ignores_sentence_final_punctuation_units() -> None:
-    """A100 regression: chunk 1 tail '在此。' must still match chunk 2's '在此…'."""
-    stitched = transcription.stitch_transcripts(
-        ["在此。", "在此奉劝大家，别乱打美白针。"], [2.0]
-    )
-    assert stitched == "在此。奉劝大家，别乱打美白针。"
-
-
-def test_stitch_dedup_ignores_punctuation_in_latin_overlap() -> None:
-    stitched = transcription.stitch_transcripts(
-        ["We learned a lot today.", "today, and there will be a quiz"], [2.0]
-    )
-    assert stitched == "We learned a lot today. and there will be a quiz"

--- a/tests/unit_test/preprocessing/test_transcription.py
+++ b/tests/unit_test/preprocessing/test_transcription.py
@@ -11,9 +11,13 @@ import pytest
 
 import sglang_omni.preprocessing.transcription as transcription
 from sglang_omni.preprocessing.transcription import (
+    Chunk,
     PreparedAudio,
+    detect_silence_boundaries,
+    plan_chunks,
     prepare_audio,
     resolve_audio_source,
+    stitch_transcripts,
 )
 from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.utils.audio import audio_fingerprint, audio_fingerprint_int
@@ -175,3 +179,127 @@ def test_prepare_audio_resamples_and_downmixes_like_before() -> None:
     )
     assert prepared.waveform.ndim == 1
     assert prepared.duration_s == pytest.approx(0.1)
+
+
+def test_plan_chunks_keeps_short_audio_in_one_exact_window() -> None:
+    assert plan_chunks(319, 160, 2.0, 0.25, []) == [
+        Chunk(start_sample=0, end_sample=319)
+    ]
+
+
+def test_detect_silence_boundaries_returns_internal_silence_midpoint() -> None:
+    waveform = np.concatenate(
+        [
+            np.ones(20, dtype=np.float32),
+            np.zeros(20, dtype=np.float32),
+            np.ones(20, dtype=np.float32),
+        ]
+    )
+
+    assert detect_silence_boundaries(
+        waveform,
+        100,
+        min_silence_s=0.2,
+        frame_duration_s=0.1,
+        relative_threshold=0.1,
+    ) == [30]
+
+
+def test_detect_silence_boundaries_ignores_audio_without_internal_silence() -> None:
+    assert (
+        detect_silence_boundaries(
+            np.ones(60, dtype=np.float32),
+            100,
+            min_silence_s=0.2,
+            frame_duration_s=0.1,
+            relative_threshold=0.1,
+        )
+        == []
+    )
+
+
+def test_plan_chunks_falls_back_to_fixed_windows_with_overlap() -> None:
+    assert plan_chunks(100, 10, 4.0, 1.0, []) == [
+        Chunk(0, 40),
+        Chunk(30, 70),
+        Chunk(60, 100),
+    ]
+
+
+def test_plan_chunks_preserves_a_short_final_window() -> None:
+    assert plan_chunks(95, 10, 4.0, 1.0, []) == [
+        Chunk(0, 40),
+        Chunk(30, 70),
+        Chunk(60, 95),
+    ]
+
+
+def test_plan_chunks_prefers_latest_vad_boundary_before_hard_limit() -> None:
+    assert plan_chunks(100, 10, 4.0, 1.0, [15, 35, 65]) == [
+        Chunk(0, 35),
+        Chunk(25, 65),
+        Chunk(55, 95),
+        Chunk(85, 100),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("max_window_s", "overlap_s"),
+    [(0.0, 0.0), (1.0, -0.1), (1.0, 1.0), (1.0, 1.1)],
+)
+def test_plan_chunks_rejects_invalid_windows(
+    max_window_s: float, overlap_s: float
+) -> None:
+    with pytest.raises(ValueError):
+        plan_chunks(100, 10, max_window_s, overlap_s, [])
+
+
+def test_stitch_transcripts_removes_repeated_overlap_words() -> None:
+    assert (
+        stitch_transcripts(
+            ["the quick brown fox", "brown fox jumps over", "over the dog"],
+            [2, 1],
+        )
+        == "the quick brown fox jumps over the dog"
+    )
+
+
+def test_stitch_transcripts_keeps_non_repeated_boundary_words() -> None:
+    assert stitch_transcripts(["hello boundary", "different world"], [1]) == (
+        "hello boundary different world"
+    )
+
+
+def test_stitch_transcripts_matches_overlap_across_case_and_punctuation() -> None:
+    assert stitch_transcripts(["Hello, boundary!", "BOUNDARY world"], [1]) == (
+        "Hello, boundary! world"
+    )
+
+
+def test_stitch_transcripts_removes_repeated_chinese_phrase() -> None:
+    assert stitch_transcripts(["今天天气很好", "天气很好我们去公园"], [1.0]) == (
+        "今天天气很好我们去公园"
+    )
+
+
+def test_stitch_transcripts_handles_mixed_chinese_and_english() -> None:
+    assert (
+        stitch_transcripts(["今天学习 Qwen three", "Qwen three模型很好用"], [1.0])
+        == "今天学习 Qwen three模型很好用"
+    )
+
+
+def test_stitch_transcripts_joins_unmatched_cjk_without_space() -> None:
+    assert stitch_transcripts(["你好世界", "今天天气很好"], [1.0]) == (
+        "你好世界今天天气很好"
+    )
+
+
+def test_stitch_transcripts_limits_matching_to_overlap_derived_budget() -> None:
+    assert stitch_transcripts(["甲乙丙", "甲乙丙丁"], [0.1]) == "甲乙丙甲乙丙丁"
+
+
+def test_stitch_transcripts_ignores_empty_pieces() -> None:
+    assert stitch_transcripts(["", "hello world", "", "world again"], [1, 1, 1]) == (
+        "hello world again"
+    )

--- a/tests/unit_test/preprocessing/test_transcription.py
+++ b/tests/unit_test/preprocessing/test_transcription.py
@@ -320,3 +320,18 @@ def test_plan_chunks_early_silence_boundary_keeps_starts_valid() -> None:
         previous_start = chunk.start_sample
     assert chunks[0] == transcription.Chunk(0, 5)
     assert chunks[-1].end_sample == 100
+
+
+def test_stitch_dedup_ignores_sentence_final_punctuation_units() -> None:
+    """A100 regression: chunk 1 tail '在此。' must still match chunk 2's '在此…'."""
+    stitched = transcription.stitch_transcripts(
+        ["在此。", "在此奉劝大家，别乱打美白针。"], [2.0]
+    )
+    assert stitched == "在此。奉劝大家，别乱打美白针。"
+
+
+def test_stitch_dedup_ignores_punctuation_in_latin_overlap() -> None:
+    stitched = transcription.stitch_transcripts(
+        ["We learned a lot today.", "today, and there will be a quiz"], [2.0]
+    )
+    assert stitched == "We learned a lot today. and there will be a quiz"

--- a/tests/unit_test/preprocessing/test_transcription.py
+++ b/tests/unit_test/preprocessing/test_transcription.py
@@ -166,14 +166,12 @@ def test_prepare_audio_accepts_http_url(monkeypatch) -> None:
 
 
 def test_prepare_audio_resamples_and_downmixes_like_before() -> None:
-    # 8 kHz clip: resampled to the 16 kHz target, so duration is preserved
     prepared = prepare_audio(
         _payload({"audio_bytes": _wav_bytes(num_samples=800, sample_rate=8000)}),
         source_name="Test",
     )
     assert prepared.duration_s == pytest.approx(0.1)
 
-    # stereo clip: downmixed to mono at the same length
     prepared = prepare_audio(
         _payload({"audio_bytes": _wav_bytes(num_channels=2)}), source_name="Test"
     )

--- a/tests/unit_test/preprocessing/test_transcription.py
+++ b/tests/unit_test/preprocessing/test_transcription.py
@@ -301,3 +301,22 @@ def test_stitch_transcripts_ignores_empty_pieces() -> None:
     assert stitch_transcripts(["", "hello world", "", "world again"], [1, 1, 1]) == (
         "hello world again"
     )
+
+
+def test_plan_chunks_early_silence_boundary_keeps_starts_valid() -> None:
+    """A silence point at or before the overlap width must not slip negative."""
+    chunks = transcription.plan_chunks(
+        num_samples=100,
+        sample_rate=1,
+        max_window_s=35.0,
+        overlap_s=10.0,
+        vad_boundaries=[5],
+    )
+
+    previous_start = -1
+    for chunk in chunks:
+        assert 0 <= chunk.start_sample < chunk.end_sample <= 100
+        assert chunk.start_sample > previous_start
+        previous_start = chunk.start_sample
+    assert chunks[0] == transcription.Chunk(0, 5)
+    assert chunks[-1].end_sample == 100

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import inspect
 from types import SimpleNamespace
 
+import pytest
+import typer
+
 import sglang_omni.models.qwen3_asr.stages as qwen3_asr_stages
 from sglang_omni.cli.serve import apply_asr_chunking_cli_overrides
 from sglang_omni.models.qwen3_asr.chunking import (
@@ -205,3 +208,47 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
     assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 12, 16, 24, 32]
     assert scheduler.enable_async_decode is False
     assert scheduler.async_decode_min_batch_size == 4
+
+
+def test_qwen3_asr_launcher_chunking_respects_runtime_overrides() -> None:
+    """The endpoint must see the same resolved policy as the worker factory."""
+    config = Qwen3ASRPipelineConfig(model_path="Qwen/Qwen3-ASR-1.7B")
+    config.stages[0].factory_args.update(
+        {
+            "asr_auto_chunk": False,
+            "asr_chunk_max_seconds": 45.0,
+            "asr_chunk_overlap_seconds": 3.0,
+        }
+    )
+    config.runtime_overrides = {
+        "asr": {
+            "asr_auto_chunk": True,
+            "asr_chunk_max_seconds": 30.0,
+            "asr_chunk_overlap_seconds": 2.0,
+        }
+    }
+
+    assert _transcription_chunking_kwargs(config) == {
+        "asr_auto_chunk": True,
+        "asr_chunk_max_seconds": 30.0,
+        "asr_chunk_overlap_seconds": 2.0,
+    }
+
+
+def test_qwen3_asr_cli_chunking_validation_uses_model_validator() -> None:
+    config = Qwen3ASRPipelineConfig(model_path="Qwen/Qwen3-ASR-1.7B")
+
+    with pytest.raises(typer.BadParameter, match="must be positive"):
+        apply_asr_chunking_cli_overrides(
+            config,
+            asr_auto_chunk=None,
+            asr_chunk_max_seconds=-1.0,
+            asr_chunk_overlap_seconds=None,
+        )
+    with pytest.raises(typer.BadParameter, match="smaller than"):
+        apply_asr_chunking_cli_overrides(
+            config,
+            asr_auto_chunk=None,
+            asr_chunk_max_seconds=10.0,
+            asr_chunk_overlap_seconds=10.0,
+        )

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -6,10 +6,17 @@ import inspect
 from types import SimpleNamespace
 
 import sglang_omni.models.qwen3_asr.stages as qwen3_asr_stages
+from sglang_omni.cli.serve import apply_asr_chunking_cli_overrides
 from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
+from sglang_omni.models.qwen3_asr.chunking import (
+    QWEN3_ASR_AUTO_CHUNK_DEFAULT,
+    QWEN3_ASR_CHUNK_OVERLAP_SECONDS,
+    QWEN3_ASR_CHUNK_WINDOW_SECONDS,
+)
 from sglang_omni.models.qwen3_asr.stages import create_sglang_qwen3_asr_executor
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from tests.unit_test.fakes import FakeServerArgs
+from sglang_omni.serve.launcher import _transcription_chunking_kwargs
 
 
 def test_qwen3_asr_config_uses_batched_stage_with_32_running_requests() -> None:
@@ -24,6 +31,9 @@ def test_qwen3_asr_config_uses_batched_stage_with_32_running_requests() -> None:
     assert config.stages[0].factory_args["max_running_requests"] == 32
     assert config.stages[0].factory_args["request_build_max_workers"] == 2
     assert config.stages[0].factory_args["request_build_max_pending"] == 16
+    assert config.stages[0].factory_args["asr_auto_chunk"] is True
+    assert config.stages[0].factory_args["asr_chunk_max_seconds"] == 30.0
+    assert config.stages[0].factory_args["asr_chunk_overlap_seconds"] == 2.0
     assert "request_build_max_backlog" not in config.stages[0].factory_args
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("Qwen3ASRForConditionalGeneration")
@@ -63,6 +73,52 @@ def test_qwen3_asr_stage_default_enables_async_decode() -> None:
 
     assert signature.parameters["enable_async_decode"].default is True
     assert signature.parameters["async_decode_min_batch_size"].default == 2
+
+
+def test_qwen3_asr_stage_owns_auto_chunk_defaults() -> None:
+    signature = inspect.signature(create_sglang_qwen3_asr_executor)
+
+    assert signature.parameters["asr_auto_chunk"].default is (
+        QWEN3_ASR_AUTO_CHUNK_DEFAULT
+    )
+    assert signature.parameters["asr_chunk_max_seconds"].default == (
+        QWEN3_ASR_CHUNK_WINDOW_SECONDS
+    )
+    assert signature.parameters["asr_chunk_overlap_seconds"].default == (
+        QWEN3_ASR_CHUNK_OVERLAP_SECONDS
+    )
+
+
+def test_qwen3_asr_cli_chunking_overrides_take_priority() -> None:
+    config = Qwen3ASRPipelineConfig(model_path="Qwen/Qwen3-ASR-1.7B")
+
+    result = apply_asr_chunking_cli_overrides(
+        config,
+        asr_auto_chunk=False,
+        asr_chunk_max_seconds=45.0,
+        asr_chunk_overlap_seconds=3.0,
+    )
+
+    assert result is config
+    assert config.stages[0].factory_args["asr_auto_chunk"] is False
+    assert config.stages[0].factory_args["asr_chunk_max_seconds"] == 45.0
+    assert config.stages[0].factory_args["asr_chunk_overlap_seconds"] == 3.0
+
+
+def test_qwen3_asr_launcher_forwards_resolved_chunking_policy() -> None:
+    config = Qwen3ASRPipelineConfig(model_path="Qwen/Qwen3-ASR-1.7B")
+    apply_asr_chunking_cli_overrides(
+        config,
+        asr_auto_chunk=False,
+        asr_chunk_max_seconds=45.0,
+        asr_chunk_overlap_seconds=3.0,
+    )
+
+    assert _transcription_chunking_kwargs(config) == {
+        "asr_auto_chunk": False,
+        "asr_chunk_max_seconds": 45.0,
+        "asr_chunk_overlap_seconds": 3.0,
+    }
 
 
 def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import math
 from types import SimpleNamespace
 
 import pytest
@@ -35,7 +36,6 @@ def test_qwen3_asr_config_uses_batched_stage_with_32_running_requests() -> None:
     assert config.stages[0].factory_args["request_build_max_pending"] == 16
     assert config.stages[0].factory_args["asr_auto_chunk"] is True
     assert config.stages[0].factory_args["asr_chunk_max_seconds"] == 30.0
-    assert "asr_chunk_overlap_seconds" not in config.stages[0].factory_args
     assert "request_build_max_backlog" not in config.stages[0].factory_args
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("Qwen3ASRForConditionalGeneration")
@@ -86,7 +86,6 @@ def test_qwen3_asr_stage_owns_auto_chunk_defaults() -> None:
     assert signature.parameters["asr_chunk_max_seconds"].default == (
         QWEN3_ASR_CHUNK_WINDOW_SECONDS
     )
-    assert "asr_chunk_overlap_seconds" not in signature.parameters
 
 
 def test_qwen3_asr_cli_chunking_overrides_take_priority() -> None:
@@ -101,21 +100,6 @@ def test_qwen3_asr_cli_chunking_overrides_take_priority() -> None:
     assert result is config
     assert config.stages[0].factory_args["asr_auto_chunk"] is False
     assert config.stages[0].factory_args["asr_chunk_max_seconds"] == 45.0
-    assert "asr_chunk_overlap_seconds" not in config.stages[0].factory_args
-
-
-def test_qwen3_asr_launcher_forwards_resolved_chunking_policy() -> None:
-    config = Qwen3ASRPipelineConfig(model_path="Qwen/Qwen3-ASR-1.7B")
-    apply_asr_chunking_cli_overrides(
-        config,
-        asr_auto_chunk=False,
-        asr_chunk_max_seconds=45.0,
-    )
-
-    assert _transcription_chunking_kwargs(config) == {
-        "asr_auto_chunk": False,
-        "asr_chunk_max_seconds": 45.0,
-    }
 
 
 def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
@@ -226,12 +210,15 @@ def test_qwen3_asr_launcher_chunking_respects_runtime_overrides() -> None:
     }
 
 
-def test_qwen3_asr_cli_chunking_validation_uses_model_validator() -> None:
+@pytest.mark.parametrize("invalid_window", [-1.0, math.nan, math.inf])
+def test_qwen3_asr_cli_chunking_validation_uses_model_validator(
+    invalid_window: float,
+) -> None:
     config = Qwen3ASRPipelineConfig(model_path="Qwen/Qwen3-ASR-1.7B")
 
-    with pytest.raises(typer.BadParameter, match="must be positive"):
+    with pytest.raises(typer.BadParameter, match="finite positive"):
         apply_asr_chunking_cli_overrides(
             config,
             asr_auto_chunk=None,
-            asr_chunk_max_seconds=-1.0,
+            asr_chunk_max_seconds=invalid_window,
         )

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -12,7 +12,6 @@ import sglang_omni.models.qwen3_asr.stages as qwen3_asr_stages
 from sglang_omni.cli.serve import apply_asr_chunking_cli_overrides
 from sglang_omni.models.qwen3_asr.chunking import (
     QWEN3_ASR_AUTO_CHUNK_DEFAULT,
-    QWEN3_ASR_CHUNK_OVERLAP_SECONDS,
     QWEN3_ASR_CHUNK_WINDOW_SECONDS,
 )
 from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
@@ -36,7 +35,7 @@ def test_qwen3_asr_config_uses_batched_stage_with_32_running_requests() -> None:
     assert config.stages[0].factory_args["request_build_max_pending"] == 16
     assert config.stages[0].factory_args["asr_auto_chunk"] is True
     assert config.stages[0].factory_args["asr_chunk_max_seconds"] == 30.0
-    assert config.stages[0].factory_args["asr_chunk_overlap_seconds"] == 2.0
+    assert "asr_chunk_overlap_seconds" not in config.stages[0].factory_args
     assert "request_build_max_backlog" not in config.stages[0].factory_args
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("Qwen3ASRForConditionalGeneration")
@@ -87,9 +86,7 @@ def test_qwen3_asr_stage_owns_auto_chunk_defaults() -> None:
     assert signature.parameters["asr_chunk_max_seconds"].default == (
         QWEN3_ASR_CHUNK_WINDOW_SECONDS
     )
-    assert signature.parameters["asr_chunk_overlap_seconds"].default == (
-        QWEN3_ASR_CHUNK_OVERLAP_SECONDS
-    )
+    assert "asr_chunk_overlap_seconds" not in signature.parameters
 
 
 def test_qwen3_asr_cli_chunking_overrides_take_priority() -> None:
@@ -99,13 +96,12 @@ def test_qwen3_asr_cli_chunking_overrides_take_priority() -> None:
         config,
         asr_auto_chunk=False,
         asr_chunk_max_seconds=45.0,
-        asr_chunk_overlap_seconds=3.0,
     )
 
     assert result is config
     assert config.stages[0].factory_args["asr_auto_chunk"] is False
     assert config.stages[0].factory_args["asr_chunk_max_seconds"] == 45.0
-    assert config.stages[0].factory_args["asr_chunk_overlap_seconds"] == 3.0
+    assert "asr_chunk_overlap_seconds" not in config.stages[0].factory_args
 
 
 def test_qwen3_asr_launcher_forwards_resolved_chunking_policy() -> None:
@@ -114,13 +110,11 @@ def test_qwen3_asr_launcher_forwards_resolved_chunking_policy() -> None:
         config,
         asr_auto_chunk=False,
         asr_chunk_max_seconds=45.0,
-        asr_chunk_overlap_seconds=3.0,
     )
 
     assert _transcription_chunking_kwargs(config) == {
         "asr_auto_chunk": False,
         "asr_chunk_max_seconds": 45.0,
-        "asr_chunk_overlap_seconds": 3.0,
     }
 
 
@@ -217,21 +211,18 @@ def test_qwen3_asr_launcher_chunking_respects_runtime_overrides() -> None:
         {
             "asr_auto_chunk": False,
             "asr_chunk_max_seconds": 45.0,
-            "asr_chunk_overlap_seconds": 3.0,
         }
     )
     config.runtime_overrides = {
         "asr": {
             "asr_auto_chunk": True,
             "asr_chunk_max_seconds": 30.0,
-            "asr_chunk_overlap_seconds": 2.0,
         }
     }
 
     assert _transcription_chunking_kwargs(config) == {
         "asr_auto_chunk": True,
         "asr_chunk_max_seconds": 30.0,
-        "asr_chunk_overlap_seconds": 2.0,
     }
 
 
@@ -243,12 +234,4 @@ def test_qwen3_asr_cli_chunking_validation_uses_model_validator() -> None:
             config,
             asr_auto_chunk=None,
             asr_chunk_max_seconds=-1.0,
-            asr_chunk_overlap_seconds=None,
-        )
-    with pytest.raises(typer.BadParameter, match="smaller than"):
-        apply_asr_chunking_cli_overrides(
-            config,
-            asr_auto_chunk=None,
-            asr_chunk_max_seconds=10.0,
-            asr_chunk_overlap_seconds=10.0,
         )

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -7,16 +7,16 @@ from types import SimpleNamespace
 
 import sglang_omni.models.qwen3_asr.stages as qwen3_asr_stages
 from sglang_omni.cli.serve import apply_asr_chunking_cli_overrides
-from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
 from sglang_omni.models.qwen3_asr.chunking import (
     QWEN3_ASR_AUTO_CHUNK_DEFAULT,
     QWEN3_ASR_CHUNK_OVERLAP_SECONDS,
     QWEN3_ASR_CHUNK_WINDOW_SECONDS,
 )
+from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
 from sglang_omni.models.qwen3_asr.stages import create_sglang_qwen3_asr_executor
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
-from tests.unit_test.fakes import FakeServerArgs
 from sglang_omni.serve.launcher import _transcription_chunking_kwargs
+from tests.unit_test.fakes import FakeServerArgs
 
 
 def test_qwen3_asr_config_uses_batched_stage_with_32_running_requests() -> None:

--- a/tests/unit_test/qwen3_asr/test_request_builders.py
+++ b/tests/unit_test/qwen3_asr/test_request_builders.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 import torch
 from transformers import WhisperFeatureExtractor
 
@@ -87,10 +88,13 @@ def test_qwen3_asr_audio_token_length_formula_is_shared() -> None:
 def test_qwen3_asr_request_builder_records_inclusive_audio_offsets(monkeypatch) -> None:
     num_mel_frames = 101
     num_audio_tokens = qwen3_asr_num_audio_tokens(num_mel_frames)
-    feature_extractor = lambda *args, **kwargs: SimpleNamespace(
-        input_features=torch.zeros((1, 128, 3000)),
-        attention_mask=torch.ones((1, num_mel_frames), dtype=torch.long),
-    )
+
+    def feature_extractor(*args, **kwargs):
+        return SimpleNamespace(
+            input_features=torch.zeros((1, 128, 3000)),
+            attention_mask=torch.ones((1, num_mel_frames), dtype=torch.long),
+        )
+
     monkeypatch.setattr(
         transcription,
         "load_audio",
@@ -155,6 +159,63 @@ def test_qwen3_asr_request_builder_preserves_audio_beyond_30_seconds(
     assert audio_item.feature.shape == (1, 128, 3100)
     assert int(audio_item.feature_attention_mask.sum().item()) == 3100
     assert data.audio_duration_s == audio_duration_s
+
+
+def test_qwen3_asr_rejects_over_window_audio_when_auto_chunk_is_disabled(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(310, dtype=np.float32),
+    )
+    request_builder, _ = make_qwen3_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=32,
+        feature_extractor=object(),
+        asr_auto_chunk=False,
+        asr_chunk_max_seconds=30.0,
+        sample_rate=10,
+    )
+    payload = StagePayload(
+        request_id="req-over-window",
+        request=OmniRequest(inputs={"audio_bytes": b"wav"}),
+        data={},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"Qwen3-ASR accepts audio up to 30\.000 seconds when auto chunking "
+            r"is disabled; got 31\.000 seconds"
+        ),
+    ):
+        request_builder(payload)
+
+
+def test_qwen3_asr_custom_window_controls_disabled_chunking_limit(monkeypatch) -> None:
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(160, dtype=np.float32),
+    )
+    request_builder, _ = make_qwen3_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=32,
+        feature_extractor=object(),
+        asr_auto_chunk=False,
+        asr_chunk_max_seconds=15.0,
+        sample_rate=10,
+    )
+
+    with pytest.raises(ValueError, match=r"15\.000.*16\.000"):
+        request_builder(
+            StagePayload(
+                request_id="req-custom-window",
+                request=OmniRequest(inputs={"audio_bytes": b"wav"}),
+                data={},
+            )
+        )
 
 
 def test_qwen3_asr_result_adapter_decodes_without_text_round_trip() -> None:

--- a/tests/unit_test/serve/test_asr_auto_chunk.py
+++ b/tests/unit_test/serve/test_asr_auto_chunk.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import io
+import json
+
+import numpy as np
+import pytest
+import soundfile as sf
+from fastapi import HTTPException
+
+from sglang_omni.client.types import CompletionResult, GenerateRequest
+from sglang_omni.serve import create_app
+from sglang_omni.serve.openai_api import _probe_audio_duration
+
+
+class _TranscriptionClient:
+    def __init__(self, texts: list[str]) -> None:
+        self.requests: list[GenerateRequest] = []
+        self._texts = iter(texts)
+
+    def health(self) -> dict[str, bool]:
+        return {"running": True}
+
+    async def completion(
+        self,
+        request: GenerateRequest,
+        *,
+        request_id: str,
+        audio_format: str = "wav",
+    ) -> CompletionResult:
+        del audio_format
+        self.requests.append(request)
+        return CompletionResult(request_id=request_id, text=next(self._texts))
+
+
+class _FailingTranscriptionClient(_TranscriptionClient):
+    async def completion(
+        self,
+        request: GenerateRequest,
+        *,
+        request_id: str,
+        audio_format: str = "wav",
+    ) -> CompletionResult:
+        if len(self.requests) == 1:
+            self.requests.append(request)
+            raise RuntimeError("child completion failed")
+        return await super().completion(
+            request, request_id=request_id, audio_format=audio_format
+        )
+
+
+class _DirectUpload:
+    filename = "sample.wav"
+    content_type = "audio/wav"
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    async def read(self) -> bytes:
+        return self._data
+
+
+def _wav_bytes(duration_s: float, sample_rate: int = 16000) -> bytes:
+    buffer = io.BytesIO()
+    samples = np.zeros(round(duration_s * sample_rate), dtype=np.float32)
+    sf.write(buffer, samples, sample_rate, format="WAV")
+    return buffer.getvalue()
+
+
+def _endpoint(app):
+    return next(
+        route.endpoint
+        for route in app.routes
+        if getattr(route, "path", None) == "/v1/audio/transcriptions"
+    )
+
+
+def _app(client, *, enabled: bool):
+    return create_app(
+        client,
+        model_name="Qwen/Qwen3-ASR-1.7B",
+        asr_auto_chunk=enabled,
+        asr_chunk_max_seconds=4.0,
+        asr_chunk_overlap_seconds=1.0,
+    )
+
+
+async def _call(app, audio_bytes: bytes, *, stream: bool = False):
+    return await _endpoint(app)(
+        request=object(),
+        file=_DirectUpload(audio_bytes),
+        model="Qwen/Qwen3-ASR-1.7B",
+        language="en",
+        prompt=None,
+        response_format="json",
+        temperature=None,
+        max_new_tokens=None,
+        stream=stream,
+    )
+
+
+@pytest.mark.asyncio
+async def test_endpoint_auto_chunks_and_stitches_long_audio() -> None:
+    client = _TranscriptionClient(["hello boundary", "boundary world", "world done"])
+
+    response = await _call(_app(client, enabled=True), _wav_bytes(8.0))
+
+    assert response.status_code == 200
+    assert json.loads(response.body) == {
+        "text": "hello boundary world done",
+        "usage": {"type": "duration", "seconds": 8},
+    }
+    assert len(client.requests) == 3
+    assert all(
+        _probe_audio_duration(request.prompt["audio_bytes"]) <= 4.0
+        for request in client.requests
+    )
+
+
+@pytest.mark.asyncio
+async def test_endpoint_keeps_short_audio_on_original_single_path() -> None:
+    audio_bytes = _wav_bytes(3.5)
+    client = _TranscriptionClient(["hello world"])
+
+    response = await _call(_app(client, enabled=True), audio_bytes)
+
+    assert response.status_code == 200
+    assert len(client.requests) == 1
+    assert client.requests[0].prompt["audio_bytes"] == audio_bytes
+
+
+@pytest.mark.asyncio
+async def test_endpoint_rejects_long_audio_when_auto_chunk_disabled() -> None:
+    client = _TranscriptionClient([])
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _call(_app(client, enabled=False), _wav_bytes(8.0))
+
+    assert exc_info.value.status_code == 400
+    assert "8.000 seconds" in exc_info.value.detail
+    assert "4.000 seconds" in exc_info.value.detail
+    assert client.requests == []
+
+
+@pytest.mark.asyncio
+async def test_endpoint_streams_stitched_long_audio() -> None:
+    client = _TranscriptionClient(["hello boundary", "boundary world", "world done"])
+
+    response = await _call(_app(client, enabled=True), _wav_bytes(8.0), stream=True)
+    body = "".join([line async for line in response.body_iterator])
+
+    assert response.status_code == 200
+    assert '"delta":"hello boundary world done"' in body
+    assert '"text":"hello boundary world done"' in body
+    assert body.endswith("data: [DONE]\n\n")
+
+
+@pytest.mark.asyncio
+async def test_endpoint_abandons_remaining_chunks_and_returns_500_on_child_failure() -> (
+    None
+):
+    client = _FailingTranscriptionClient(["first chunk"])
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _call(_app(client, enabled=True), _wav_bytes(8.0))
+
+    assert exc_info.value.status_code == 500
+    assert "child completion failed" in exc_info.value.detail
+    assert len(client.requests) == 2

--- a/tests/unit_test/serve/test_asr_auto_chunk.py
+++ b/tests/unit_test/serve/test_asr_auto_chunk.py
@@ -83,7 +83,6 @@ def _app(client, *, enabled: bool):
         model_name="Qwen/Qwen3-ASR-1.7B",
         asr_auto_chunk=enabled,
         asr_chunk_max_seconds=4.0,
-        asr_chunk_overlap_seconds=1.0,
     )
 
 
@@ -102,8 +101,8 @@ async def _call(app, audio_bytes: bytes, *, stream: bool = False):
 
 
 @pytest.mark.asyncio
-async def test_endpoint_auto_chunks_and_stitches_long_audio() -> None:
-    client = _TranscriptionClient(["hello boundary", "boundary world", "world done"])
+async def test_endpoint_auto_chunks_and_joins_long_audio() -> None:
+    client = _TranscriptionClient(["hello boundary", "world done"])
 
     response = await _call(_app(client, enabled=True), _wav_bytes(8.0))
 
@@ -112,7 +111,7 @@ async def test_endpoint_auto_chunks_and_stitches_long_audio() -> None:
         "text": "hello boundary world done",
         "usage": {"type": "duration", "seconds": 8},
     }
-    assert len(client.requests) == 3
+    assert len(client.requests) == 2
     assert all(
         _probe_audio_duration(request.prompt["audio_bytes"]) <= 4.0
         for request in client.requests
@@ -145,8 +144,8 @@ async def test_endpoint_rejects_long_audio_when_auto_chunk_disabled() -> None:
 
 
 @pytest.mark.asyncio
-async def test_endpoint_streams_stitched_long_audio() -> None:
-    client = _TranscriptionClient(["hello boundary", "boundary world", "world done"])
+async def test_endpoint_streams_joined_long_audio() -> None:
+    client = _TranscriptionClient(["hello boundary", "world done"])
 
     response = await _call(_app(client, enabled=True), _wav_bytes(8.0), stream=True)
     body = "".join([line async for line in response.body_iterator])
@@ -164,7 +163,7 @@ async def test_endpoint_abandons_remaining_chunks_and_returns_500_on_child_failu
     client = _FailingTranscriptionClient(["first chunk"])
 
     with pytest.raises(HTTPException) as exc_info:
-        await _call(_app(client, enabled=True), _wav_bytes(8.0))
+        await _call(_app(client, enabled=True), _wav_bytes(12.0))
 
     assert exc_info.value.status_code == 500
     assert "child completion failed" in exc_info.value.detail


### PR DESCRIPTION
## Motivation

F1 in #1267: long Qwen3-ASR uploads should be auto-chunked instead of failing at the deployed per-request context, and disabling chunking must never silently truncate.

This implements the F1 mechanics as **non-overlapping, silence-boundary chunking with direct concatenation** — the same shape as the official Qwen wrapper. An earlier revision of this draft carried a chunk-overlap + de-duplication layer; it was removed after validation showed why it does not belong in the default path:

- at the native 1,200 s window (where this policy is headed once the capacity line lands), a 5 s boundary-search window of real speech essentially always contains a pause, so the "no silence candidate" case the overlap was designed for does not occur in practice;
- the one scenario that defeats energy-based silence detection — noisy audio — is also where exact-match de-duplication is least reliable.

The overlap machinery is archived on a separate branch and can be proposed later as an opt-in feature; it is intentionally not part of this PR.

## Modifications

- `sglang_omni/preprocessing/transcription.py` — shared mechanics only: silence-aware chunk planning (hard cap, exact sample boundaries, boundaries never extend past the hard end, fixed-window fallback, strict non-overlap invariant `next.start == previous.end`) and language-aware transcript joining (no separator inserted between CJK segments, single space between Latin words).
- `sglang_omni/models/qwen3_asr/chunking.py` — model-owned policy: default-on, 30 s window matching what the current deployed context sizing admits; deliberately a single constant so it lifts to the native 1,200 s envelope once capacity lands (#1353). No model-name branching in shared code.
- `sglang_omni/serve/openai_api.py` + `launcher.py` — fan-out coordinator: one upload → N chunk completions → ordered join; JSON/text and SSE; any chunk failure aborts the remaining chunks and fails the whole request (a partial transcript is never returned as success). Policy reaches the endpoint through the standard `runtime_overrides` resolver, so the endpoint and the worker factory always agree.
- `sglang_omni/cli/serve.py` — `--asr-auto-chunk/--no-asr-auto-chunk`, `--asr-chunk-max-seconds`; validation has a single source (the model-owned validator), translated to CLI errors.
- Explicit client error (with actual duration and window seconds) when chunking is off and the input exceeds the window — enforced at the endpoint and again in the request builder.
- Requests at or below the window keep the exact pre-change single-request path, locked by tests.

Scope reduction, stated upfront: timestamp remapping (`verbose_json`/`srt`/`vtt`) is not implemented — the current serving path returns minimal JSON only; left for a follow-up.

## Validation

CPU unit suites: `tests/unit_test/preprocessing` + `qwen3_asr` + `serve` (chunk/endpoint suites) — 122 passed, 1 skipped; `ruff check` / `ruff format --check` clean on changed files.

GPU (this head, RTX A6000 48 GB, `Qwen/Qwen3-ASR-1.7B` rev `7278e1e`): server healthy; a 60 s English clip is chunked and transcribed coherently; a 36 s Chinese clip returns exact `usage.seconds` with no characters lost at the chunk boundary (the boundary shows only a sentence-split seam, the expected direct-concatenation behavior).

Boundary behavior (A100-SXM-64GB, 3 repeats per cell, single-forward no-chunk output as reference): silence-boundary non-overlapping chunking produced **zero boundary word errors in both English and Chinese** — the direct evidence behind removing the overlap layer from the default path.

## Related work / overlap disclosure

Canonical thread: #1267 (F1). Two other drafts are in flight; this is submitted as a comparison/consolidation candidate, not a competing claim:

- #1347 (@0xjeffro) — serving-layer chunking at the deployed clip limit, non-overlapping. Same design family; this draft adds the model-owned policy split, explicit 400, all-or-nothing failure semantics, and resolver-consistent configuration.
- #1350 (@wirybeaver) — resizes context to the native 1,200 s envelope and chunks only above it. Same concatenation semantics; the capacity/context work is deliberately **not** part of this PR — that is the separate long-input line (#1173, #1176 merged, #1193, #1353), which this policy constant is designed to follow.

Happy to fold any of these pieces into whichever PR the maintainers pick as canonical.
