### PR TITLE
fix(qwen3-asr): size capacity for the native 1200-second envelope

### DIFF
--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -78,13 +78,11 @@ print(resp.json()["text"])
 
 ## Long Audio
 
-The default stage is sized for Qwen3-ASR's native 1200-second single-forward
-envelope. It preserves the complete mel sequence (`truncation=False`) and does
-not split or stitch transcripts. When `max_new_tokens` is omitted, the output
-budget keeps the upstream Qwen vLLM 4096-token floor and grows to 12000 tokens
-at 1200 seconds so that the upstream default does not become a flat long-audio
-ceiling. The context and prefill limits include the corresponding 15600 audio
-tokens plus the actual tokenized prompt overhead.
+The default stage supports Qwen3-ASR's native 1200-second single-forward
+envelope without truncation or transcript stitching. Its automatic output
+budget keeps the upstream 4096-token floor and grows to 12000 tokens at that
+boundary. Context and prefill capacity include the corresponding 15600 audio
+tokens and tokenized prompt overhead.
 
 Operators can pin `max_new_tokens` or change the guaranteed native envelope
 with the ASR stage's `max_audio_s` factory argument. A request-level

--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -71,11 +71,26 @@ print(resp.json()["text"])
 | `language` | string | `en` | Language hint; `zh`/`cn` select Chinese, other values use English prompting |
 | `response_format` | string | `json` | `json`, `verbose_json`, or `text` |
 | `temperature` | float | `0.01` effective | Sampling temperature; `0` is converted to near-greedy `0.01` |
+| `max_new_tokens` | integer | automatic | Explicit positive transcription-token budget |
 
 `verbose_json` is accepted, but currently returns the same minimal JSON shape as `json`:
 `{"text": "..."}`.
 
-`max_new_tokens` is supported inside the model request builder, but the public transcription endpoint does not currently expose it as a form field. The route uses the ASR stage default unless the pipeline is configured another way.
+## Long Audio
+
+The default stage is sized for Qwen3-ASR's native 1200-second single-forward
+envelope. It preserves the complete mel sequence (`truncation=False`) and does
+not split or stitch transcripts. When `max_new_tokens` is omitted, the output
+budget keeps the upstream Qwen vLLM 4096-token floor and grows to 12000 tokens
+at 1200 seconds so that the upstream default does not become a flat long-audio
+ceiling. The context and prefill limits include the corresponding 15600 audio
+tokens plus the actual tokenized prompt overhead.
+
+Operators can pin `max_new_tokens` or change the guaranteed native envelope
+with the ASR stage's `max_audio_s` factory argument. A request-level
+`max_new_tokens` takes precedence over the operator default. The scheduler
+still clamps an oversized explicit request to the real per-request context and
+KV capacity instead of rejecting a request that otherwise fits.
 
 ## Benchmarking
 
@@ -103,3 +118,6 @@ the transcriber for the TTS and talker WER stages.
 - The endpoint accepts one uploaded file per request.
 - `prompt` is accepted by the HTTP endpoint for OpenAI compatibility, but Qwen3-ASR currently ignores it.
 - Audio is resampled to 16 kHz before transcription.
+- The automatic output budget is a bounded guard, not an EOS guarantee for
+  pathological or highly repetitive audio. Set `max_new_tokens` explicitly
+  when a workload needs a larger budget and the configured context permits it.

--- a/sglang_omni/models/qwen3_asr/config.py
+++ b/sglang_omni/models/qwen3_asr/config.py
@@ -33,7 +33,7 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
             factory_args={
                 "device": "cuda:0",
                 "max_running_requests": 32,
-                "max_new_tokens": 128,
+                "max_audio_s": 1200.0,
                 "request_build_max_workers": 2,
                 "request_build_max_pending": 16,
             },

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -40,9 +40,8 @@ logger = logging.getLogger(__name__)
 
 _SAMPLE_RATE = 16000
 
-# Qwen's native wrapper keeps each clip in one model forward up to 1200 seconds.
-# Longer inputs are split by that wrapper, but SGLang-Omni deliberately does not
-# add a second transcript stitching policy here.
+# note (Junnan Li): 1200 seconds is the largest clip handled by Qwen's native
+# single-forward path; longer inputs require transcript stitching.
 QWEN3_ASR_MAX_AUDIO_SECONDS = 1200.0
 QWEN3_ASR_UPSTREAM_MAX_NEW_TOKENS = 4096
 _OUTPUT_TOKENS_PER_AUDIO_SECOND = 10
@@ -106,7 +105,8 @@ def build_qwen3_asr_prompt_ids(
         f"<|im_end|>\n"
         f"<|im_start|>assistant\n"
     )
-    # Qwen3-ASR needs the same forced assistant prefix as upstream qwen_asr.
+    # note (Junnan Li): Match upstream's forced prefix so decoding starts after
+    # the ASR marker instead of regenerating the language header.
     prompt += f"language {language}{_ASR_TEXT}"
     return list(tokenizer(prompt, add_special_tokens=False).input_ids)
 
@@ -141,7 +141,7 @@ def qwen3_asr_request_output_budget(
     audio_duration_s: float,
     default_max_new_tokens: int | None,
 ) -> int:
-    """Resolve request > operator > duration-aware automatic precedence."""
+    """Honor explicit budgets while keeping long audio safe by default."""
     explicit = params.get("max_new_tokens")
     if explicit is not None:
         return _positive_max_new_tokens(explicit)

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -15,8 +15,10 @@ into those positions. So request_builder must:
 from __future__ import annotations
 
 import logging
+import math
 import time
 from dataclasses import dataclass
+from numbers import Integral
 from typing import Any, Callable
 
 import torch
@@ -38,6 +40,13 @@ logger = logging.getLogger(__name__)
 
 _SAMPLE_RATE = 16000
 
+# Qwen's native wrapper keeps each clip in one model forward up to 1200 seconds.
+# Longer inputs are split by that wrapper, but SGLang-Omni deliberately does not
+# add a second transcript stitching policy here.
+QWEN3_ASR_MAX_AUDIO_SECONDS = 1200.0
+QWEN3_ASR_UPSTREAM_MAX_NEW_TOKENS = 4096
+_OUTPUT_TOKENS_PER_AUDIO_SECOND = 10
+
 _AUDIO_START = "<|audio_start|>"
 _AUDIO_PAD = "<|audio_pad|>"
 _AUDIO_END = "<|audio_end|>"
@@ -46,6 +55,7 @@ _ASR_TEXT = "<asr_text>"
 
 @dataclass
 class Qwen3ASRRequestData(SGLangARRequestData):
+    enforce_request_limits: bool = True
     prompt_token_ids: list[int] | None = None
     output_ids: list[int] | None = None
     audio_duration_s: float = 0.0
@@ -87,10 +97,63 @@ def _encode_literal(tokenizer: Any, text: str) -> list[int]:
     return list(input_ids)
 
 
+def build_qwen3_asr_prompt_ids(
+    tokenizer: Any, num_audio_tokens: int, language: str
+) -> list[int]:
+    prompt = (
+        f"<|im_start|>user\n"
+        f"{_AUDIO_START}{_AUDIO_PAD * num_audio_tokens}{_AUDIO_END}"
+        f"<|im_end|>\n"
+        f"<|im_start|>assistant\n"
+    )
+    # Qwen3-ASR needs the same forced assistant prefix as upstream qwen_asr.
+    prompt += f"language {language}{_ASR_TEXT}"
+    return list(tokenizer(prompt, add_special_tokens=False).input_ids)
+
+
+def qwen3_asr_prompt_overhead_tokens(tokenizer: Any) -> int:
+    """Tokenized non-audio portion of the native ASR prompt."""
+    return len(build_qwen3_asr_prompt_ids(tokenizer, 0, "English"))
+
+
+def qwen3_asr_auto_output_budget(audio_duration_s: float) -> int:
+    """Keep the upstream floor while avoiding a flat long-audio ceiling."""
+    if not math.isfinite(audio_duration_s) or audio_duration_s < 0:
+        raise ValueError("audio duration must be a finite non-negative number")
+    return max(
+        QWEN3_ASR_UPSTREAM_MAX_NEW_TOKENS,
+        math.ceil(audio_duration_s * _OUTPUT_TOKENS_PER_AUDIO_SECOND),
+    )
+
+
+def _positive_max_new_tokens(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError("max_new_tokens must be a positive integer")
+    result = int(value)
+    if result < 1:
+        raise ValueError("max_new_tokens must be a positive integer")
+    return result
+
+
+def qwen3_asr_request_output_budget(
+    params: dict[str, Any],
+    *,
+    audio_duration_s: float,
+    default_max_new_tokens: int | None,
+) -> int:
+    """Resolve request > operator > duration-aware automatic precedence."""
+    explicit = params.get("max_new_tokens")
+    if explicit is not None:
+        return _positive_max_new_tokens(explicit)
+    if default_max_new_tokens is not None:
+        return _positive_max_new_tokens(default_max_new_tokens)
+    return qwen3_asr_auto_output_budget(audio_duration_s)
+
+
 def make_qwen3_asr_scheduler_adapters(
     *,
     tokenizer: Any,
-    max_new_tokens: int,
+    max_new_tokens: int | None,
     feature_extractor: Any = None,
 ) -> tuple[
     Callable[[StagePayload], Qwen3ASRRequestData], Callable[[Any], StagePayload]
@@ -102,20 +165,6 @@ def make_qwen3_asr_scheduler_adapters(
     eos_token_id = int(tokenizer.eos_token_id)
     vocab_size = int(tokenizer.vocab_size)
     asr_text_token_ids = _encode_literal(tokenizer, _ASR_TEXT)
-
-    def _build_prompt_ids(num_audio_tokens: int, language: str) -> list[int]:
-        prompt = (
-            f"<|im_start|>user\n"
-            f"{_AUDIO_START}{_AUDIO_PAD * num_audio_tokens}{_AUDIO_END}"
-            f"<|im_end|>\n"
-            f"<|im_start|>assistant\n"
-        )
-        # Qwen3-ASR needs a forced prefix "language <Lang><asr_text>" on the
-        # assistant turn; the model then generates only the transcription after
-        # <asr_text>. Without it the (small) model emits the language tag then
-        # stops. Upstream qwen_asr does the same (_build_text_prompt).
-        prompt = prompt + f"language {language}<asr_text>"
-        return tokenizer(prompt, add_special_tokens=False).input_ids
 
     def request_builder(payload: StagePayload) -> Qwen3ASRRequestData:
         params = payload.request.params or {}
@@ -164,7 +213,9 @@ def make_qwen3_asr_scheduler_adapters(
         forced_language = {"zh": "Chinese", "cn": "Chinese"}.get(
             lang_raw, "Chinese" if lang_raw.startswith("zh") else "English"
         )
-        input_ids = _build_prompt_ids(num_audio_tokens, forced_language)
+        input_ids = build_qwen3_asr_prompt_ids(
+            tokenizer, num_audio_tokens, forced_language
+        )
 
         audio_item = MultimodalDataItem(
             modality=Modality.AUDIO,
@@ -206,7 +257,11 @@ def make_qwen3_asr_scheduler_adapters(
             # Qwen3-ASR degenerates under pure-greedy (emits only the language
             # tag then EOS); upstream uses 0.01 near-greedy.
             temperature = 0.01
-        request_max_new_tokens = int(params.get("max_new_tokens") or max_new_tokens)
+        request_max_new_tokens = qwen3_asr_request_output_budget(
+            params,
+            audio_duration_s=audio_duration_s,
+            default_max_new_tokens=max_new_tokens,
+        )
         logger.debug(
             f"[qwen3-asr] sampling temp={temperature} "
             f"max_new_tokens={request_max_new_tokens} params={dict(params)}"
@@ -278,6 +333,12 @@ def make_qwen3_asr_scheduler_adapters(
 
 
 __all__ = [
+    "QWEN3_ASR_MAX_AUDIO_SECONDS",
+    "QWEN3_ASR_UPSTREAM_MAX_NEW_TOKENS",
     "Qwen3ASRRequestData",
+    "build_qwen3_asr_prompt_ids",
     "make_qwen3_asr_scheduler_adapters",
+    "qwen3_asr_auto_output_budget",
+    "qwen3_asr_prompt_overhead_tokens",
+    "qwen3_asr_request_output_budget",
 ]

--- a/sglang_omni/models/qwen3_asr/stages.py
+++ b/sglang_omni/models/qwen3_asr/stages.py
@@ -3,14 +3,20 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 from sglang.srt.managers.mm_utils import init_mm_embedding_cache
 from transformers import AutoFeatureExtractor, AutoTokenizer
 
 from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.models.qwen3_asr.audio_lengths import qwen3_asr_num_audio_tokens
 from sglang_omni.models.qwen3_asr.request_builders import (
+    QWEN3_ASR_MAX_AUDIO_SECONDS,
     make_qwen3_asr_scheduler_adapters,
+    qwen3_asr_auto_output_budget,
+    qwen3_asr_prompt_overhead_tokens,
+    qwen3_asr_request_output_budget,
 )
 from sglang_omni.scheduling.bootstrap import (
     create_sglang_infrastructure_defer_cuda_graph,
@@ -33,7 +39,8 @@ def create_sglang_qwen3_asr_executor(
     device: str = "cuda:0",
     dtype: str = "float16",
     max_running_requests: int = 32,
-    max_new_tokens: int = 256,
+    max_audio_s: float = QWEN3_ASR_MAX_AUDIO_SECONDS,
+    max_new_tokens: int | None = None,
     mem_fraction_static: float | None = None,
     mm_embedding_cache_size_bytes: int = 0,
     enable_torch_compile: bool = False,
@@ -45,6 +52,10 @@ def create_sglang_qwen3_asr_executor(
     server_args_overrides: dict[str, Any] | None = None,
 ):
 
+    max_audio_s = float(max_audio_s)
+    if not math.isfinite(max_audio_s) or max_audio_s <= 0:
+        raise ValueError("max_audio_s must be a finite positive number")
+
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0
 
     tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
@@ -52,15 +63,31 @@ def create_sglang_qwen3_asr_executor(
         model_path, trust_remote_code=True
     )
 
-    encoder_token_count = int(feature_extractor.nb_max_frames // 2)
+    max_mel_frames = math.ceil(max_audio_s * 100)
+    max_audio_tokens = qwen3_asr_num_audio_tokens(max_mel_frames)
+    prompt_overhead_tokens = qwen3_asr_prompt_overhead_tokens(tokenizer)
+    max_input_tokens = max_audio_tokens + prompt_overhead_tokens
+    max_output_tokens = (
+        qwen3_asr_request_output_budget(
+            {},
+            audio_duration_s=max_audio_s,
+            default_max_new_tokens=max_new_tokens,
+        )
+        if max_new_tokens is not None
+        else qwen3_asr_auto_output_budget(max_audio_s)
+    )
+    # SGLang reserves one token below context_length and one additional token
+    # in init_req_max_new_tokens. Include both so the advertised output budget
+    # survives scheduler admission unchanged at the 1200-second boundary.
+    context_length = max_input_tokens + max_output_tokens + 2
 
     defaults: dict[str, Any] = {
         "disable_cuda_graph": False,
         "disable_overlap_schedule": True,
         "enable_torch_compile": enable_torch_compile,
         "mem_fraction_static": mem_fraction_static,
-        "max_prefill_tokens": 4096,
-        "chunked_prefill_size": 4096,
+        "max_prefill_tokens": max_input_tokens,
+        "chunked_prefill_size": max_input_tokens,
         "sampling_backend": "pytorch",
         "dtype": dtype,
     }
@@ -70,15 +97,17 @@ def create_sglang_qwen3_asr_executor(
         sm_version = get_visible_gpu_sm_version(gpu_id)
         if sm_version is not None and sm_version >= 100:
             defaults["mm_attention_backend"] = "triton_attn"
+    incoming_overrides = dict(server_args_overrides or {})
+    context_length = int(incoming_overrides.pop("context_length", context_length))
     overrides = build_generation_batch_overrides(
         max_running_requests=max_running_requests,
-        server_args_overrides=server_args_overrides,
+        server_args_overrides=incoming_overrides,
         **defaults,
     )
 
     server_args = build_sglang_server_args(
         model_path,
-        context_length=encoder_token_count + int(max_new_tokens) + 8,
+        context_length=context_length,
         **overrides,
     )
     validate_generation_batch_policy(
@@ -86,14 +115,17 @@ def create_sglang_qwen3_asr_executor(
         server_args=server_args,
     )
 
-    want_cuda_graph, (
-        model_worker,
-        tree_cache,
-        req_to_token_pool,
-        token_to_kv_pool_allocator,
-        prefill_mgr,
-        decode_mgr,
-        model_config,
+    (
+        want_cuda_graph,
+        (
+            model_worker,
+            tree_cache,
+            req_to_token_pool,
+            token_to_kv_pool_allocator,
+            prefill_mgr,
+            decode_mgr,
+            model_config,
+        ),
     ) = create_sglang_infrastructure_defer_cuda_graph(
         server_args,
         gpu_id,

--- a/sglang_omni/models/qwen3_asr/stages.py
+++ b/sglang_omni/models/qwen3_asr/stages.py
@@ -14,7 +14,6 @@ from sglang_omni.models.qwen3_asr.audio_lengths import qwen3_asr_num_audio_token
 from sglang_omni.models.qwen3_asr.request_builders import (
     QWEN3_ASR_MAX_AUDIO_SECONDS,
     make_qwen3_asr_scheduler_adapters,
-    qwen3_asr_auto_output_budget,
     qwen3_asr_prompt_overhead_tokens,
     qwen3_asr_request_output_budget,
 )
@@ -67,18 +66,13 @@ def create_sglang_qwen3_asr_executor(
     max_audio_tokens = qwen3_asr_num_audio_tokens(max_mel_frames)
     prompt_overhead_tokens = qwen3_asr_prompt_overhead_tokens(tokenizer)
     max_input_tokens = max_audio_tokens + prompt_overhead_tokens
-    max_output_tokens = (
-        qwen3_asr_request_output_budget(
-            {},
-            audio_duration_s=max_audio_s,
-            default_max_new_tokens=max_new_tokens,
-        )
-        if max_new_tokens is not None
-        else qwen3_asr_auto_output_budget(max_audio_s)
+    max_output_tokens = qwen3_asr_request_output_budget(
+        {},
+        audio_duration_s=max_audio_s,
+        default_max_new_tokens=max_new_tokens,
     )
-    # SGLang reserves one token below context_length and one additional token
-    # in init_req_max_new_tokens. Include both so the advertised output budget
-    # survives scheduler admission unchanged at the 1200-second boundary.
+    # note (Junnan Li): Two scheduler-reserved tokens keep the configured
+    # output budget available at the maximum input length.
     context_length = max_input_tokens + max_output_tokens + 2
 
     defaults: dict[str, Any] = {

--- a/tests/README.md
+++ b/tests/README.md
@@ -385,6 +385,8 @@ that happened to contain an older version of the test.
     and `--decode-mode async|sync` CLI overrides
   - single-source audio token length formula used by both processor and
     request builder paths
+  - native 1,200-second feature preservation, duration-aware output budgets,
+    context/prefill sizing, and explicit token-budget validation
   - token-level result adapter marker handling, avoiding decode/encode
     text round-trips for byte-level BPE output.
 - `unit_test/fun_asr/`: Fun-ASR-Nano unit tests:

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -6,11 +6,9 @@ import inspect
 from types import SimpleNamespace
 
 import sglang_omni.models.qwen3_asr.stages as qwen3_asr_stages
+from sglang_omni.models.qwen3_asr.audio_lengths import qwen3_asr_num_audio_tokens
 from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
-from sglang_omni.models.qwen3_asr.request_builders import (
-    QWEN3_ASR_MAX_AUDIO_SECONDS,
-    qwen3_asr_num_audio_tokens,
-)
+from sglang_omni.models.qwen3_asr.request_builders import QWEN3_ASR_MAX_AUDIO_SECONDS
 from sglang_omni.models.qwen3_asr.stages import create_sglang_qwen3_asr_executor
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from tests.unit_test.fakes import FakeServerArgs

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -7,6 +7,10 @@ from types import SimpleNamespace
 
 import sglang_omni.models.qwen3_asr.stages as qwen3_asr_stages
 from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
+from sglang_omni.models.qwen3_asr.request_builders import (
+    QWEN3_ASR_MAX_AUDIO_SECONDS,
+    qwen3_asr_num_audio_tokens,
+)
 from sglang_omni.models.qwen3_asr.stages import create_sglang_qwen3_asr_executor
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from tests.unit_test.fakes import FakeServerArgs
@@ -22,6 +26,8 @@ def test_qwen3_asr_config_uses_batched_stage_with_32_running_requests() -> None:
     assert config.stages[0].factory.endswith("create_sglang_qwen3_asr_executor")
     assert config.stages[0].factory_args["device"] == "cuda:0"
     assert config.stages[0].factory_args["max_running_requests"] == 32
+    assert config.stages[0].factory_args["max_audio_s"] == 1200.0
+    assert "max_new_tokens" not in config.stages[0].factory_args
     assert config.stages[0].factory_args["request_build_max_workers"] == 2
     assert config.stages[0].factory_args["request_build_max_pending"] == 16
     assert "request_build_max_backlog" not in config.stages[0].factory_args
@@ -37,6 +43,8 @@ def test_qwen3_asr_stage_default_allows_32_running_requests() -> None:
     assert signature.parameters["max_running_requests"].default == 32
     assert signature.parameters["request_build_max_workers"].default == 2
     assert signature.parameters["request_build_max_pending"].default == 16
+    assert signature.parameters["max_audio_s"].default == QWEN3_ASR_MAX_AUDIO_SECONDS
+    assert signature.parameters["max_new_tokens"].default is None
     assert "request_build_max_backlog" not in signature.parameters
 
 
@@ -67,11 +75,20 @@ def test_qwen3_asr_stage_default_enables_async_decode() -> None:
 
 def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
     build_kwargs: dict[str, object] = {}
+    captured: dict[str, object] = {}
+
+    class _StageTokenizer:
+        def __call__(self, text, *, add_special_tokens=False):
+            assert not add_special_tokens
+            audio_pad_count = text.count("<|audio_pad|>")
+            return SimpleNamespace(
+                input_ids=[11] + [42] * audio_pad_count + [12, 13, 14]
+            )
 
     monkeypatch.setattr(
         qwen3_asr_stages.AutoTokenizer,
         "from_pretrained",
-        lambda *args, **kwargs: object(),
+        lambda *args, **kwargs: _StageTokenizer(),
     )
     monkeypatch.setattr(
         qwen3_asr_stages.AutoFeatureExtractor,
@@ -106,6 +123,7 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
     )
 
     def _fake_server_args_builder(model_path, context_length, **overrides):
+        captured["context_length"] = context_length
         build_kwargs.update(overrides)
         server_args = FakeServerArgs(**overrides)
         server_args.cuda_graph_config = SimpleNamespace(
@@ -145,6 +163,11 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
         async_decode_min_batch_size=4,
     )
 
+    max_audio_tokens = qwen3_asr_num_audio_tokens(1200 * 100)
+    assert max_audio_tokens == 15600
+    assert captured["context_length"] == max_audio_tokens + 4 + 12000 + 2
+    assert build_kwargs["max_prefill_tokens"] == max_audio_tokens + 4
+    assert build_kwargs["chunked_prefill_size"] == max_audio_tokens + 4
     assert build_kwargs["cuda_graph_max_bs"] == 32
     assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 12, 16, 24, 32]
     assert scheduler.enable_async_decode is False

--- a/tests/unit_test/qwen3_asr/test_request_builders.py
+++ b/tests/unit_test/qwen3_asr/test_request_builders.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 import torch
 from transformers import WhisperFeatureExtractor
 
@@ -15,8 +16,11 @@ from sglang_omni.models.qwen3_asr.audio_lengths import (
 )
 from sglang_omni.models.qwen3_asr.configuration_qwen3_asr import Qwen3ASRProcessor
 from sglang_omni.models.qwen3_asr.request_builders import (
+    QWEN3_ASR_MAX_AUDIO_SECONDS,
     Qwen3ASRRequestData,
     make_qwen3_asr_scheduler_adapters,
+    qwen3_asr_auto_output_budget,
+    qwen3_asr_request_output_budget,
 )
 from sglang_omni.proto import OmniRequest, StagePayload
 
@@ -84,13 +88,58 @@ def test_qwen3_asr_audio_token_length_formula_is_shared() -> None:
     assert qwen3_asr_num_audio_tokens(3000) == 390
 
 
+def test_qwen3_asr_auto_output_budget_matches_native_long_audio_envelope() -> None:
+    assert QWEN3_ASR_MAX_AUDIO_SECONDS == 1200.0
+    assert qwen3_asr_auto_output_budget(1.0) == 4096
+    assert qwen3_asr_auto_output_budget(409.6) == 4096
+    assert qwen3_asr_auto_output_budget(1200.0) == 12000
+
+
+@pytest.mark.parametrize("invalid", [0, -1, True, 1.5, "12", "not-an-int"])
+def test_qwen3_asr_request_output_budget_rejects_invalid_explicit_values(
+    invalid,
+) -> None:
+    with pytest.raises(ValueError, match="max_new_tokens"):
+        qwen3_asr_request_output_budget(
+            {"max_new_tokens": invalid},
+            audio_duration_s=1.0,
+            default_max_new_tokens=None,
+        )
+
+
+def test_qwen3_asr_request_output_budget_precedence() -> None:
+    assert (
+        qwen3_asr_request_output_budget(
+            {}, audio_duration_s=1200.0, default_max_new_tokens=None
+        )
+        == 12000
+    )
+    assert (
+        qwen3_asr_request_output_budget(
+            {}, audio_duration_s=1200.0, default_max_new_tokens=6000
+        )
+        == 6000
+    )
+    assert (
+        qwen3_asr_request_output_budget(
+            {"max_new_tokens": 7000},
+            audio_duration_s=1200.0,
+            default_max_new_tokens=6000,
+        )
+        == 7000
+    )
+
+
 def test_qwen3_asr_request_builder_records_inclusive_audio_offsets(monkeypatch) -> None:
     num_mel_frames = 101
     num_audio_tokens = qwen3_asr_num_audio_tokens(num_mel_frames)
-    feature_extractor = lambda *args, **kwargs: SimpleNamespace(
-        input_features=torch.zeros((1, 128, 3000)),
-        attention_mask=torch.ones((1, num_mel_frames), dtype=torch.long),
-    )
+
+    def feature_extractor(*args, **kwargs):
+        return SimpleNamespace(
+            input_features=torch.zeros((1, 128, 3000)),
+            attention_mask=torch.ones((1, num_mel_frames), dtype=torch.long),
+        )
+
     monkeypatch.setattr(
         transcription,
         "load_audio",
@@ -155,6 +204,60 @@ def test_qwen3_asr_request_builder_preserves_audio_beyond_30_seconds(
     assert audio_item.feature.shape == (1, 128, 3100)
     assert int(audio_item.feature_attention_mask.sum().item()) == 3100
     assert data.audio_duration_s == audio_duration_s
+
+
+def test_qwen3_asr_request_builder_accepts_native_1200_second_envelope(
+    monkeypatch,
+) -> None:
+    sample_rate = 16000
+    audio_duration_s = 1200
+    num_mel_frames = audio_duration_s * 100
+    extractor_calls: list[dict] = []
+
+    def _feature_extractor(*args, **kwargs):
+        extractor_calls.append(kwargs)
+        return SimpleNamespace(
+            input_features=torch.empty(
+                (1, 128, num_mel_frames), device="meta", dtype=torch.float32
+            ),
+            attention_mask=torch.ones((1, num_mel_frames), dtype=torch.long),
+        )
+
+    # A zero-stride view represents 1200 seconds without reserving a 77 MB
+    # waveform. Fingerprinting is patched because ndarray.tobytes() would
+    # materialize that view, which is unrelated to this length-contract test.
+    audio = np.broadcast_to(
+        np.zeros(1, dtype=np.float32), (sample_rate * audio_duration_s,)
+    )
+    monkeypatch.setattr(transcription, "load_audio", lambda source, **kwargs: audio)
+    monkeypatch.setattr(transcription, "audio_fingerprint", lambda audio: "0f")
+    request_builder, _ = make_qwen3_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=None,
+        feature_extractor=_feature_extractor,
+    )
+    payload = StagePayload(
+        request_id="req-native-max-asr",
+        request=OmniRequest(inputs={"audio_bytes": b"wav"}),
+        data={},
+    )
+
+    data = request_builder(payload)
+
+    assert extractor_calls == [
+        {
+            "sampling_rate": sample_rate,
+            "return_tensors": "pt",
+            "return_attention_mask": True,
+            "padding": "longest",
+            "truncation": False,
+        }
+    ]
+    assert data.audio_duration_s == audio_duration_s
+    assert data.max_new_tokens == 12000
+    assert data.req.sampling_params.max_new_tokens == 12000
+    assert data.enforce_request_limits is True
+    assert len(data.prompt_token_ids) == qwen3_asr_num_audio_tokens(num_mel_frames) + 4
 
 
 def test_qwen3_asr_result_adapter_decodes_without_text_round_trip() -> None:

--- a/tests/unit_test/qwen3_asr/test_request_builders.py
+++ b/tests/unit_test/qwen3_asr/test_request_builders.py
@@ -223,9 +223,8 @@ def test_qwen3_asr_request_builder_accepts_native_1200_second_envelope(
             attention_mask=torch.ones((1, num_mel_frames), dtype=torch.long),
         )
 
-    # A zero-stride view represents 1200 seconds without reserving a 77 MB
-    # waveform. Fingerprinting is patched because ndarray.tobytes() would
-    # materialize that view, which is unrelated to this length-contract test.
+    # note (Junnan Li): Avoid materializing the full waveform so this boundary
+    # test remains memory-light.
     audio = np.broadcast_to(
         np.zeros(1, dtype=np.float32), (sample_rate * audio_duration_s,)
     )


### PR DESCRIPTION
## Motivation

#1176 removed the silent 30-second feature truncation, but the per-request capacity is still sized from Whisper's extraction-window constant: `create_sglang_qwen3_asr_executor` derives `context_length` from `feature_extractor.nb_max_frames // 2`, which is not a Qwen3-ASR model limit. The official Qwen wrapper accepts up to `MAX_ASR_INPUT_SECONDS = 1200` in one forward and uses a 4,096-token generation default. On current main, a long clip that survives preprocessing is rejected (or its output budget silently exhausted at the flat stage default) by context arithmetic unrelated to the model.

This PR makes the capacity contract follow the model:

- one model-local duration contract (`max_audio_s`, default 1,200 s) sizes context, prefill, and the automatic output budget;
- no silent truncation on either side: input that cannot fit is explicitly rejected, and the automatic output budget scales with duration instead of stopping dense long speech at a flat ceiling;
- no chunking/stitching is added here — this is the capacity layer underneath the in-flight F1 chunking drafts (#1347, #1350, #1352).

## Modifications

- `request_builders.py`: automatic output budget `max(4096, ceil(10 × duration_s))` — keeps the upstream 4,096 floor, avoids a flat long-audio ceiling; precedence stays request > operator default > automatic, with explicit validation of `max_new_tokens`. `enforce_request_limits=True` so oversized explicit budgets are clamped to real remaining capacity and an input that cannot fit is rejected explicitly (never truncated).
- `stages.py`: `context_length = max_audio_tokens + tokenized prompt overhead + max output budget + 2` (the two scheduler reserve slots are measured, see below); `max_prefill_tokens = chunked_prefill_size = full max input` so the multimodal encoder is entered once per request while the mm embedding cache is disabled; `context_length` stays operator-overridable.
- `config.py`: stage default switches from the flat `max_new_tokens=128` (a silent output-truncation source) to `max_audio_s=1200.0`.
- Cookbook: documents the long-audio contract and that the automatic budget is a bounded guard, not an EOS guarantee.

## Validation

CPU unit suites on the rebased head: `tests/unit_test/qwen3_asr` + `preprocessing` + `scheduling` — 163 passed, 1 skipped. Tests pin the exact sizing arithmetic (15,600 audio tokens at 1,200 s; context = input + budget + 2) and the budget precedence/validation matrix.

Runtime evidence (RTX A6000 48 GB, `Qwen/Qwen3-ASR-1.7B` rev `7278e1e`, SGLang 0.5.16):

- a generated 1,200 s clip is admitted as **one prefill batch of 15,613 tokens** (15,600 audio + 13 prompt overhead) and completes with HTTP 200 — the "+2" reserve is exact at the boundary;
- `max_new_tokens=100000` on a short clip is clamped by the scheduler and completes instead of erroring;
- with a flat 4,096 budget, a dense repeated-speech 1,200 s stress clip terminates at the ceiling (`finish_reason=length` path), while the duration-scaled budget does not — the reason the automatic budget scales;
- **negative result, relevant to #1350**: with `chunked_prefill_size` left at 4,096/8,192 while context is enlarged, the 1,200 s request re-enters the audio encoder per prefill chunk (mm embedding cache is disabled) and **OOMed on the 48 GB A6000**; full-request prefill sizing is what made the envelope work. Configs retained as labelled negative experiments.

On an RTX 4090D 48 GB (driver 570.133.20, torch 2.11.0+cu128), a 20-fixture 30/60/120/300 s matrix (5 deterministic concatenated fixtures per bucket, sequential, `max_total_tokens=8192` profile) passed 20/20 with `usage.seconds` exact and near-linear latency; a 650 s probe (8,463 input tokens) was explicitly rejected with the capacity message rather than truncated. The rejection currently surfaces as HTTP 500 — converging with #1193 on 400 classification.

Not validated here: 24/32 GB devices, high-concurrency throughput vs the old 128-token default (larger per-request admission reservations), WER parity on natural long-form corpora. Stated as open items, not claims.


**A100-SXM-64GB concurrency validation** (torch 2.11.0+cu130, same venv both arms, heads `51e62f6` (main) vs `31dd4f1` (this branch), fresh server per arm, 3 repeats each): 128 distinct 5 s clips at concurrency 32 — main 48.0–50.2 req/s vs branch 42.1–51.0 req/s; **ranges overlap, no separable throughput regression** from the larger admission reservation. Peak device memory 57.0 GB (main) vs 43.0 GB (branch). Mixed traffic (1×1,200 s + 16×5 s, 3 repeats): short-request p50 latency delta +0.10 / +0.18 / +0.36 s vs a no-long-request control — head-of-line impact present but sub-second on this hardware class.

## Related work / overlap disclosure

- #1173 — behavior thread; #1176 — merged base (this PR is its capacity follow-up).
- #1193 (@wirybeaver) — proactive context validation + HTTP 400 mapping; complementary, and the 650 s probe above is direct evidence for it.
- #1350 (@wirybeaver) — includes its own context resizing (`prompt + 4096 + 1`). Differences here: duration-scaled output budget (vs flat 4,096), full-request prefill sizing (the A6000 OOM negative result above bites otherwise), and the measured `+2` reserve (vs `+1`). Happy to consolidate either direction — the chunking layer in #1350/#1347/#1352 sits on top of whichever capacity contract lands.
- #1267 — F1 depends on this line for a >30 s native window.

