### PR TITLE
[Qwen3-Omni] Fix 555-sample audio gap at every streamed code2wav chunk boundary

### DIFF
--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -213,9 +213,7 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
             codes,
             graph_eligible=not is_final,
         )
-        trim = context * self._total_upsample
-        if trim:
-            wav = wav[..., trim:]
+        wav = wav[..., -(end - start) * self._total_upsample :]
         audio = wav.reshape(-1).detach().cpu().float().numpy().copy()
         if profile_metadata is not None:
             _emit_event(
@@ -475,9 +473,7 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
                     f"{len(group)} requests"
                 )
             context = min(self._left_context_size, group[0][1].emitted)
-            trim = context * self._total_upsample
-            if trim:
-                wav = wav[..., trim:]
+            wav = wav[..., -(window_frames - context) * self._total_upsample :]
             host = wav.detach().cpu().float()
             for i, (rid, state) in enumerate(group):
                 audio = host[i].reshape(-1).numpy().copy()

--- a/tests/unit_test/fixtures/qwen_fakes.py
+++ b/tests/unit_test/fixtures/qwen_fakes.py
@@ -154,12 +154,13 @@ class FakeAudioEncoderModel:
 
 
 class FakeCode2WavModel:
-    def __init__(self, *, total_upsample: int = 2) -> None:
+    def __init__(self, *, total_upsample: int = 2, output_deficit: int = 0) -> None:
         self.total_upsample = total_upsample
+        self.output_deficit = output_deficit
         self.calls: list[tuple[int, ...]] = []
 
     def __call__(self, codes: torch.Tensor) -> torch.Tensor:
         self.calls.append(tuple(codes.shape))
-        samples = int(codes.shape[-1]) * self.total_upsample
+        samples = int(codes.shape[-1]) * self.total_upsample - self.output_deficit
         base = codes.to(dtype=torch.float32).flatten(1).sum(dim=1).view(-1, 1, 1)
         return torch.arange(samples, dtype=torch.float32).view(1, 1, samples) + base

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -759,3 +759,21 @@ def test_eos_chunk_is_skipped_and_never_decoded() -> None:
     audio = np.frombuffer(message.data.data["audio_waveform"], dtype=np.float32)
     assert model.calls == [(1, 2, 2)]
     assert audio.shape == (4,)
+
+
+def test_qwen_code2wav_emits_full_chunk_despite_model_output_deficit() -> None:
+    model = FakeCode2WavModel(total_upsample=2, output_deficit=1)
+    scheduler = _make_scheduler(model)
+    scheduler._stream_payloads["req-1"] = make_qwen_payload(request_id="req-1")
+    _feed(scheduler, "req-1", (1, 2, 3, 4), stream=True)
+    scheduler._on_done("req-1")
+
+    first = scheduler.outbox.get_nowait()
+    first_audio = np.frombuffer(first.data["audio_waveform"], dtype=np.float32)
+    assert first_audio.shape == (3,)
+
+    second = scheduler.outbox.get_nowait()
+    second_audio = np.frombuffer(second.data["audio_waveform"], dtype=np.float32)
+    assert second_audio.shape == (4,)
+
+    assert first_audio.shape[0] + second_audio.shape[0] == 4 * 2 - 1

--- a/tests/unit_test/qwen3_omni/test_code2wav_batching.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_batching.py
@@ -442,3 +442,23 @@ def test_batch_events_emitted(monkeypatch) -> None:
     assert start_meta["due_bucket_count"] == 1
     assert end_meta["audio_samples"] > 0
     assert end_meta["execution_mode"] == "eager"
+
+
+def test_qwen_code2wav_run_step_emits_full_chunk_despite_output_deficit() -> None:
+    scheduler = Code2WavScheduler(
+        FakeCode2WavModel(total_upsample=2, output_deficit=1),
+        device="cpu",
+        stream_chunk_size=2,
+        left_context_size=1,
+        sample_rate=24000,
+        enable_batching=True,
+    )
+    state = Code2WavStreamState(stream_enabled=True)
+    state.chunks = [torch.tensor([c, c * 10]) for c in (1, 2, 3)]
+    state.emitted = 1
+    state.audio_parts = [np.zeros(1, dtype=np.float32)]
+    scheduler._stream_states["req-1"] = state
+
+    decoded = scheduler.run_step([("req-1", state)], [1])
+    assert decoded["req-1"].shape == (4,)
+    assert state.emitted == 3


### PR DESCRIPTION
## Motivation

Fixes #1354.

Streamed Qwen3-Omni audio clicks at every chunk boundary. The vocoder's output is always 555 samples shorter than `window_frames * total_upsample` (the `CausalTransConvNet` right-trims compound to 8 → 45 → 184 → 555 across the decoder blocks). The scheduler trims a fixed `context * total_upsample` from the left, so every streamed chunk silently loses its last 555 samples (~23 ms at 24 kHz). The next chunk resumes 555 samples later in time, leaving a hole at each boundary — an audible click every 0.8 s with `stream_chunk_size=10`.

## Modifications

Keep the last `new_frames * total_upsample` samples of each decode window instead of trimming a fixed left offset, in both the serial path (`decode_delta`) and the batched path (`run_step`). The samples previously dropped from chunk N sit inside chunk N+1's decode window at offset `context * total_upsample - 555`, so the keep-last form recovers them exactly.

- `sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py`: trim fix in `decode_delta` and `run_step`.
- `tests/unit_test/fixtures/qwen_fakes.py`: `FakeCode2WavModel` gains an `output_deficit` knob to model the real vocoder's short output.
- Regression tests in `test_code2wav.py` and `test_code2wav_batching.py`: with a deficit model, each emitted chunk now has exactly `new_frames * total_upsample` samples.

## Validation

before & after fix audio output:
[after_fix.wav](https://github.com/user-attachments/files/30766283/after_fix.wav)
[before_fix.wav](https://github.com/user-attachments/files/30766286/before_fix.wav)


Small random-init model, 60 frames, chunk 10, context 25 (`total_upsample=1920`):

- Before: streamed concat 111870 samples vs 114645 for full decode (6 chunks × 555 missing).
- After: streamed concat 114645 samples, sample-exact length; max error near every boundary ~1e-8 (float noise).

Real checkpoint (Qwen3-Omni-30B-A3B-Instruct, H200): generated one sentence, decoded the same talker codes with the old and new trim. The old stream drops 555 samples per boundary; the new stream is sample-aligned with the full decode.

Unit tests: `test_code2wav.py`, `test_code2wav_batching.py`, `test_code2wav_cuda_graph.py` all pass.
