### PR TITLE
[Qwen3-ASR] Default to BF16 greedy decoding

### DIFF
--- a/benchmarks/tasks/asr.py
+++ b/benchmarks/tasks/asr.py
@@ -220,9 +220,9 @@ def load_router_asr(
 def _transcribe_qwen3_asr(asr: dict, wav_path: str, lang: str) -> str:
     """Transcribe one wav via the Qwen3-ASR server's /v1/audio/transcriptions.
 
-    Note: do not send temperature=0 because Qwen3-ASR degenerates under pure
-    greedy (the server bumps it to 0.01). The language field selects the
-    forced prefix. max_new_tokens comes from the Qwen3 ASR pipeline config.
+    Qwen3-ASR uses its greedy server default unless the caller sends an explicit
+    sampling temperature. The language field selects the forced prefix.
+    max_new_tokens comes from the Qwen3 ASR pipeline config.
     """
     with open(wav_path, "rb") as audio_file:
         response = requests.post(
@@ -325,9 +325,9 @@ def make_asr_send_fn(
     """Return a send_fn(session, sample) -> RequestResult that transcribes one
     SeedTTS reference clip via the Omni /v1/audio/transcriptions endpoint.
 
-    Note: do not send temperature=0 because Qwen3-ASR degenerates under pure
-    greedy (the server bumps it to 0.01). The language field selects the
-    forced prefix. max_new_tokens comes from the Qwen3 ASR pipeline config.
+    Qwen3-ASR uses its greedy server default unless the caller sends an explicit
+    sampling temperature. The language field selects the forced prefix.
+    max_new_tokens comes from the Qwen3 ASR pipeline config.
     """
 
     async def send_fn(

--- a/benchmarks/tasks/asr.py
+++ b/benchmarks/tasks/asr.py
@@ -220,9 +220,9 @@ def load_router_asr(
 def _transcribe_qwen3_asr(asr: dict, wav_path: str, lang: str) -> str:
     """Transcribe one wav via the Qwen3-ASR server's /v1/audio/transcriptions.
 
-    Qwen3-ASR uses its greedy server default unless the caller sends an explicit
-    sampling temperature. The language field selects the forced prefix.
-    max_new_tokens comes from the Qwen3 ASR pipeline config.
+    note (Xinyu): Qwen3-ASR uses its greedy server default unless the caller
+    sends an explicit sampling temperature. The language field selects the
+    forced prefix. max_new_tokens comes from the Qwen3 ASR pipeline config.
     """
     with open(wav_path, "rb") as audio_file:
         response = requests.post(
@@ -325,9 +325,9 @@ def make_asr_send_fn(
     """Return a send_fn(session, sample) -> RequestResult that transcribes one
     SeedTTS reference clip via the Omni /v1/audio/transcriptions endpoint.
 
-    Qwen3-ASR uses its greedy server default unless the caller sends an explicit
-    sampling temperature. The language field selects the forced prefix.
-    max_new_tokens comes from the Qwen3 ASR pipeline config.
+    note (Xinyu): Qwen3-ASR uses its greedy server default unless the caller
+    sends an explicit sampling temperature. The language field selects the
+    forced prefix. max_new_tokens comes from the Qwen3 ASR pipeline config.
     """
 
     async def send_fn(

--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -13,7 +13,9 @@ MODEL_PATH=$(hf download Qwen/Qwen3-ASR-1.7B --revision "${MODEL_REVISION}")
 
 ## Server Configuration
 
-Qwen3-ASR runs a single ASR stage on one GPU.
+Qwen3-ASR runs a single ASR stage on one GPU. Its default `auto` dtype follows
+the checkpoint configuration (BF16 for Qwen3-ASR-1.7B); pass `--dtype float16`
+to force FP16.
 Async decode is enabled by default for decode batches of at least two requests,
 allowing the shared one-step-lookahead path to overlap host-side result
 processing with the next GPU decode forward. Use `--decode-mode sync` to disable
@@ -73,7 +75,7 @@ print(resp.json()["text"])
 | `language` | string | `en` | Language hint as a supported code or canonical name (case-insensitive) |
 | `prompt` | string | none | Accepted for OpenAI compatibility; Qwen3-ASR currently ignores it |
 | `response_format` | string | `json` | `json`, `verbose_json`, or `text` |
-| `temperature` | float | `0.01` effective | Sampling temperature; `0` is converted to near-greedy `0.01` |
+| `temperature` | float | `0` | Sampling temperature; `0` uses greedy decoding |
 | `max_new_tokens` | integer | server stage limit | Per-request generation-token limit |
 | `stream` | boolean | `false` | Return transcript events over SSE |
 

--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -14,8 +14,8 @@ MODEL_PATH=$(hf download Qwen/Qwen3-ASR-1.7B --revision "${MODEL_REVISION}")
 ## Server Configuration
 
 Qwen3-ASR runs a single ASR stage on one GPU. Its default `auto` dtype follows
-the checkpoint configuration (BF16 for Qwen3-ASR-1.7B); pass `--dtype float16`
-to force FP16.
+the checkpoint configuration (BF16 for Qwen3-ASR-1.7B); pass
+`--stages.asr.factory-args.dtype float16` to force FP16.
 Async decode is enabled by default for decode batches of at least two requests,
 allowing the shared one-step-lookahead path to overlap host-side result
 processing with the next GPU decode forward. Use `--decode-mode sync` to disable

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -246,10 +246,6 @@ def make_qwen3_asr_scheduler_adapters(
         mm_inputs.mrope_position_delta = torch.tensor([0], dtype=torch.long)
 
         temperature = float(params.get("temperature") or 0.0)
-        if temperature == 0.0:
-            # Qwen3-ASR degenerates under pure-greedy (emits only the language
-            # tag then EOS); upstream uses 0.01 near-greedy.
-            temperature = 0.01
         logger.debug(
             f"[qwen3-asr] sampling temp={temperature} "
             f"max_new_tokens={request_max_new_tokens} params={dict(params)}"

--- a/sglang_omni/models/qwen3_asr/stages.py
+++ b/sglang_omni/models/qwen3_asr/stages.py
@@ -10,7 +10,7 @@ def create_sglang_qwen3_asr_executor(
     model_path: str,
     *,
     device: str = "cuda:0",
-    dtype: str = "float16",
+    dtype: str = "auto",
     max_running_requests: int = 32,
     max_new_tokens: int = 256,
     mem_fraction_static: float | None = None,

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -52,6 +52,12 @@ def test_qwen3_asr_stage_default_allows_32_running_requests() -> None:
     assert "request_build_max_backlog" not in signature.parameters
 
 
+def test_qwen3_asr_stage_default_uses_auto_dtype() -> None:
+    signature = inspect.signature(create_sglang_qwen3_asr_executor)
+
+    assert signature.parameters["dtype"].default == "auto"
+
+
 def test_qwen3_asr_stage_default_enables_pre_lm_encoder() -> None:
     signature = inspect.signature(create_sglang_qwen3_asr_executor)
 

--- a/tests/unit_test/qwen3_asr/test_request_builders.py
+++ b/tests/unit_test/qwen3_asr/test_request_builders.py
@@ -231,6 +231,52 @@ def test_qwen3_asr_request_builder_records_inclusive_audio_offsets(monkeypatch) 
     )
 
 
+@pytest.mark.parametrize(
+    (
+        "params",
+        "expected_temperature",
+        "expected_sampling_temperature",
+        "expected_top_k",
+    ),
+    [
+        ({}, 0.0, 1.0, 1),
+        ({"temperature": 0.1}, 0.1, 0.1, 1 << 30),
+    ],
+)
+def test_qwen3_asr_request_builder_preserves_sampling_mode(
+    monkeypatch,
+    params: dict[str, float],
+    expected_temperature: float,
+    expected_sampling_temperature: float,
+    expected_top_k: int,
+) -> None:
+    feature_extractor = lambda *args, **kwargs: SimpleNamespace(
+        input_features=torch.zeros((1, 128, 3000)),
+        attention_mask=torch.ones((1, 101), dtype=torch.long),
+    )
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(1600, dtype=np.float32),
+    )
+    request_builder, _ = make_qwen3_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=32,
+        feature_extractor=feature_extractor,
+    )
+    payload = StagePayload(
+        request_id="req-asr-sampling",
+        request=OmniRequest(inputs={"audio_bytes": b"wav"}, params=params),
+        data={},
+    )
+
+    data = request_builder(payload)
+
+    assert data.temperature == expected_temperature
+    assert data.req.sampling_params.temperature == expected_sampling_temperature
+    assert data.req.sampling_params.top_k == expected_top_k
+
+
 def test_qwen3_asr_request_builder_preserves_audio_beyond_30_seconds(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Motivation

Qwen3-ASR-1.7B is configured for BF16, but its stage factory forced FP16 and
its request adapter converted an absent or zero temperature into near-greedy
`0.01` sampling. Use the checkpoint-native dtype and true greedy
decoding by default while preserving explicit dtype and temperature overrides.

## Modifications

1. `sglang_omni/models/qwen3_asr/stages.py`
   - Change the Qwen3-ASR stage factory dtype default from `float16` to
     `auto`, which resolves to BF16 for Qwen3-ASR-1.7B.

2. `sglang_omni/models/qwen3_asr/request_builders.py`
   - Preserve an absent or explicit zero temperature as `0.0`, allowing
     SGLang to normalize the request to greedy decoding.
   - Continue honoring explicit nonzero temperatures such as `0.1`.

3. `tests/unit_test/qwen3_asr/`
   - Assert the stage factory's `auto` dtype default.
   - Exercise the production request adapter for default greedy normalization
     and explicit nonzero sampling.

4. `docs/cookbook/qwen3_asr.md` and `benchmarks/tasks/asr.py`
   - Document the checkpoint-native BF16 and greedy defaults and update the ASR
     benchmark helper comments to match runtime behavior.

## Related Issues

N/A

## Accuracy Test

**Setup:**

- Model: `Qwen/Qwen3-ASR-1.7B` @
  `7278e1e70fe206f11671096ffdd38061171dd6e5`
- SeedTTS EN full set @
  `27f4c1adee83b5b29b7c4b375f6b976324bda308` (1,088 clips)
- Concurrency 1 and 32, 3 measured repeats each, no warmup, non-streaming
- GPU 0: NVIDIA H100 80GB HBM3
- Baseline: `main @ 8c1974bf`, FP16, explicit temperature `0.1`
- Candidate: FP16 + greedy and BF16 (`dtype=auto`) + greedy
- c=32 candidate: runtime commit `d49cf1e2`; c=1/current PR head:
  `b56768c7`, whose only additional change is documentation syntax

The historical regression signature was defined as an empty normalized
transcript, a language-tag-only/`<asr_text>` result, a failed request, or a
per-sample WER of at least 1.

| Load / variant | Corpus WER (mean +/- std) | Evaluated | Empty | Tag-only / marker | Failed | WER >= 1 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| c=1 FP16 + greedy | 0.012182 +/- 0.000000 | 3,264 / 3,264 | 0 | 0 | 0 | 0 |
| c=1 BF16(auto) + greedy | 0.012182 +/- 0.000000 | 3,264 / 3,264 | 0 | 0 | 0 | 0 |
| c=32 FP16 + greedy | 0.012182 +/- 0.000000 | 3,264 / 3,264 | 0 | 0 | 0 | 0 |
| c=32 BF16(auto) + greedy | 0.012334 +/- 0.000000 | 3,264 / 3,264 | 0 | 0 | 0 | 0 |

The PR #643 failure mode did not reproduce in either dtype. At c=1, both
greedy variants were identical across repeats and FP16/BF16 had identical
normalized transcripts for every sample. At c=32, FP16 remained identical
across repeats; BF16 had two samples with minor normalized word/spelling
variation across repeats, not tag-plus-EOS collapse. The BF16 WER difference
between c=1 and c=32 also means greedy should not be described as bitwise
invariant across execution shapes.

### c=1 accuracy

| Metric | Main FP16 + temp 0.1 | Candidate FP16 + greedy | Candidate BF16(auto) + greedy |
| --- | ---: | ---: | ---: |
| Corpus WER (mean +/- std) | 0.012056 +/- 0.000158 | 0.012182 +/- 0.000000 | 0.012182 +/- 0.000000 |
| Absolute WER delta vs main | N/A | +0.000126 | +0.000126 |
| Maximum sample WER | 0.181818 | 0.181818 | 0.181818 |
| Evaluated / skipped | 3,264 / 0 | 3,264 / 0 | 3,264 / 0 |

### c=32 accuracy

| Metric | Main FP16 + temp 0.1 | Candidate FP16 + greedy | Candidate BF16(auto) + greedy |
| --- | ---: | ---: | ---: |
| Corpus WER (mean +/- std) | 0.012157 +/- 0.000158 | 0.012182 +/- 0.000000 | 0.012334 +/- 0.000000 |
| Absolute WER delta vs main | N/A | +0.000025 | +0.000177 |
| Maximum sample WER | 0.181818 | 0.181818 | 0.181818 |
| Evaluated / skipped | 3,264 / 0 | 3,264 / 0 | 3,264 / 0 |

## Benchmark & Profiling

Mean +/- std is across three repeats. Both suites used the benchmark's default
no-warmup behavior, so cold pre-LM cache effects contribute to variance.

### c=1

| Metric | Main FP16 + temp 0.1 | Candidate FP16 + greedy | Delta vs main | Candidate BF16(auto) + greedy | Delta vs main |
| --- | ---: | ---: | ---: | ---: | ---: |
| Throughput (samples/s) | 16.029 +/- 1.029 | 16.628 +/- 1.027 | +3.74% | 17.862 +/- 1.211 | +11.44% |
| Best throughput (samples/s) | 16.901 | 17.503 | +3.56% | 18.590 | +9.99% |
| Mean latency (s) | 0.0624 +/- 0.0041 | 0.0602 +/- 0.0038 | -3.59% | 0.0560 +/- 0.0040 | -10.21% |
| P95 latency (s) | 0.0761 +/- 0.0062 | 0.0742 +/- 0.0050 | -2.54% | 0.0690 +/- 0.0058 | -9.37% |
| Mean RTF | 0.01352 +/- 0.00090 | 0.01302 +/- 0.00085 | -3.73% | 0.01214 +/- 0.00087 | -10.27% |
| RTFx | 75.914 +/- 4.873 | 78.750 +/- 4.866 | +3.74% | 84.595 +/- 5.736 | +11.44% |

The accepted c=1 BF16 result is `candidate/bf16_greedy_rerun`. The first BF16
attempt is preserved locally but excluded: host CPU utilization averaged about
72%/99%/46% across its repeats, versus about 5%/5%/4% in the accepted rerun,
and throughput fell to 11.189 samples/s.

### c=32

| Metric | Main FP16 + temp 0.1 | Candidate FP16 + greedy | Delta vs main | Candidate BF16(auto) + greedy | Delta vs main |
| --- | ---: | ---: | ---: | ---: | ---: |
| Throughput (samples/s) | 123.181 +/- 22.276 | 119.540 +/- 33.814 | -2.96% | 126.659 +/- 23.245 | +2.82% |
| Best throughput (samples/s) | 137.021 | 141.025 | +2.92% | 140.305 | +2.40% |
| Mean latency (s) | 0.2648 +/- 0.0535 | 0.2841 +/- 0.0957 | +7.28% | 0.2573 +/- 0.0521 | -2.84% |
| P95 latency (s) | 0.3869 +/- 0.1223 | 0.4886 +/- 0.3194 | +26.29% | 0.3479 +/- 0.0847 | -10.08% |
| Mean RTF | 0.05737 +/- 0.01172 | 0.06141 +/- 0.02055 | +7.05% | 0.05581 +/- 0.01145 | -2.73% |
| RTFx | 583.396 +/- 105.502 | 566.154 +/- 160.148 | -2.96% | 599.870 +/- 110.090 | +2.82% |

Server logs confirm `torch.bfloat16` for BF16 and `torch.float16` for both
FP16 variants. Each accepted suite completed 9,792 requests without skips
(19,584 total across c=1 and c=32). Evidence is limited to one H100, the two
tested concurrency levels, and the pinned model/dataset revisions. Worker
routing balance is N/A for these single-worker direct-server runs.

## Validation

- Focused Qwen3-ASR unit tests: 19 passed.
- `pre-commit run --all-files`: passed.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.