### PR TITLE
[dots.tts Perf] Skip the full vocabulary LM head on AR steps

### DIFF
--- a/sglang_omni/models/dots_tts/sglang_model.py
+++ b/sglang_omni/models/dots_tts/sglang_model.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import torch
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.models.qwen2 import Qwen2ForCausalLM
 from torch import nn
 
@@ -82,15 +83,28 @@ class DotsTTSSGLangModel(nn.Module):
         forward_batch: Any,
         input_embeds: torch.Tensor | None = None,
         **kwargs: Any,
-    ):
+    ) -> LogitsProcessorOutput:
+        del kwargs
         if input_embeds is None:
             input_embeds = forward_batch.input_embeds
-        return self.qwen2(
+        hidden_states = self.qwen2.model(
             input_ids=input_ids,
             positions=positions,
             forward_batch=forward_batch,
             input_embeds=input_embeds,
-            **kwargs,
+        )
+        # note (db-ol): dots consumes hidden states only and the runner
+        # overwrites next_token_ids, dummy logits just satisfy the contract.
+        if forward_batch.forward_mode.is_extend():
+            extend_seq_lens = getattr(forward_batch, "extend_seq_lens", None)
+            request_count = (
+                int(extend_seq_lens.numel()) if extend_seq_lens is not None else 1
+            )
+        else:
+            request_count = int(hidden_states.shape[0])
+        return LogitsProcessorOutput(
+            next_token_logits=hidden_states.new_empty((request_count, 1)),
+            hidden_states=hidden_states,
         )
 
 

--- a/tests/unit_test/dots_tts/test_sglang_model.py
+++ b/tests/unit_test/dots_tts/test_sglang_model.py
@@ -1,5 +1,8 @@
+from types import SimpleNamespace
+
 import pytest
 import torch
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from torch import nn
 
 from sglang_omni.models.dots_tts.sglang_model import DotsTTSSGLangModel
@@ -77,3 +80,68 @@ def test_weight_loader_routes_every_checkpoint_namespace() -> None:
 
     with pytest.raises(AssertionError, match="Unexpected dots.tts checkpoint weight"):
         model.load_weights([("new_acoustic_block.weight", torch.ones(1, 1))])
+
+
+class _TransformerOnlyBackbone(nn.Module):
+    def __init__(self, hidden: torch.Tensor) -> None:
+        super().__init__()
+        self.hidden = hidden
+        self.model_kwargs: dict | None = None
+
+    def model(self, **kwargs) -> torch.Tensor:
+        self.model_kwargs = kwargs
+        return self.hidden
+
+    def forward(self, *args, **kwargs):
+        raise AssertionError("dots.tts must not enter the lm_head logits path")
+
+
+def _forward_model(hidden: torch.Tensor) -> DotsTTSSGLangModel:
+    model = DotsTTSSGLangModel.__new__(DotsTTSSGLangModel)
+    nn.Module.__init__(model)
+    model.qwen2 = _TransformerOnlyBackbone(hidden)
+    return model
+
+
+def test_forward_prefill_skips_lm_head_and_keeps_full_hidden_rows() -> None:
+    hidden = torch.arange(12.0).reshape(6, 2)
+    model = _forward_model(hidden)
+    embeds = torch.zeros(6, 2)
+    batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_extend=lambda: True),
+        input_embeds=embeds,
+        extend_seq_lens=torch.tensor([4, 2]),
+    )
+
+    output = model.forward(
+        input_ids=torch.zeros(6, dtype=torch.long),
+        positions=torch.arange(6),
+        forward_batch=batch,
+    )
+
+    assert isinstance(output, LogitsProcessorOutput)
+    torch.testing.assert_close(output.hidden_states, hidden)
+    assert output.next_token_logits.shape == (2, 1)
+    assert model.qwen2.model_kwargs is not None
+    assert model.qwen2.model_kwargs["input_embeds"] is embeds
+
+
+def test_forward_decode_skips_lm_head_and_returns_per_request_rows() -> None:
+    hidden = torch.arange(6.0).reshape(3, 2)
+    model = _forward_model(hidden)
+    embeds = torch.zeros(3, 2)
+    batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_extend=lambda: False),
+        input_embeds=embeds,
+    )
+
+    output = model.forward(
+        input_ids=torch.zeros(3, dtype=torch.long),
+        positions=torch.arange(3),
+        forward_batch=batch,
+        input_embeds=embeds,
+    )
+
+    assert isinstance(output, LogitsProcessorOutput)
+    torch.testing.assert_close(output.hidden_states, hidden)
+    assert output.next_token_logits.shape == (3, 1)


### PR DESCRIPTION
## Motivation

First item of the #1367 roadmap. dots.tts consumes Qwen2 hidden states only. The next step input comes from the MeanFlow latent patch and semantic encoder, EOS is decided by the flow head eos projection, and DotsTTSModelRunner overwrites next_token_ids with the control token before the sampler fallback can fire. The wrapper still delegates to Qwen2ForCausalLM.forward, so every prefill and every AR decode step runs the full vocabulary logits projection (151672 x hidden per the shipped llm_config) plus the logits processor, and the result is discarded.

## Modifications

- DotsTTSSGLangModel.forward now calls the bare Qwen2 transformer (self.qwen2.model) and returns a LogitsProcessorOutput carrying the hidden states directly, skipping lm_head and the logits processor. Prefill returns all extend rows and decode returns one row per request, matching what CaptureHiddenMode FULL and LAST delivered before, so post_prefill row accounting and initialize_history see identical tensors. A dummy next_token_logits of shape (requests, 1) satisfies the result contract, following the same pattern already used by MingTTS and MOSS TTS, and HiggsTTS bypasses its backbone head the same way.
- Weight loading is unchanged. The lm_head weights still load but are never executed. The released checkpoint ships tie_word_embeddings true, so the head shares storage with the embedding and there is no separate weight memory to reclaim, the win is per step compute and kernel count.
- Two new unit tests: the fake backbone raises if anything enters the LM head path, and the tests pin full extend rows at prefill, per request rows at decode, and the dummy logits shape.

## Related Issues

First optimization item of #1367.

## Accuracy Test

Bit exact parity: all 1088 Seed-TTS-Eval EN wav files generated at seed 42 are byte identical between main and this PR (md5 per file), so WER and speaker similarity are unchanged by construction. tests/unit_test/dots_tts passes (60 tests) in a local container, the 5 failures present there fail identically on unmodified main in the same container (stale local sglang install), CPU CI carries the authoritative run.

## Benchmark & Profiling

Same card A/B per the #1367 contract posted in the comment below: speed neutral within host noise, confirmed by an A-B-A drift control where a main replay measures behind this PR, plus the bit exact audio parity above.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
