### PR TITLE
[feature] Add Prefill CUDA Graph capability and policy resolution

### DIFF
--- a/sglang_omni/models/higgs_tts/__init__.py
+++ b/sglang_omni/models/higgs_tts/__init__.py
@@ -12,7 +12,10 @@ from __future__ import annotations
 
 from transformers import AutoConfig
 
-from sglang_omni.models.model_capabilities import ModelCapabilities
+from sglang_omni.models.model_capabilities import (
+    ModelCapabilities,
+    PrefillCudaGraphCapability,
+)
 
 from . import config
 from .hf_config import HiggsMultimodalQwen3Config
@@ -25,6 +28,12 @@ CAPABILITIES = ModelCapabilities(
     supports_streaming_vocoder=True,
     supports_cuda_graph=True,
     supports_torch_compile=True,
+    prefill_cuda_graph=PrefillCudaGraphCapability(
+        integration="incompatible",
+        incompatible_reason=(
+            "padded prefill changes Higgs model outputs; keep prefill eager"
+        ),
+    ),
 )
 
 __all__ = ["CAPABILITIES", "config", "HiggsMultimodalQwen3Config"]

--- a/sglang_omni/models/higgs_tts/engine_builder.py
+++ b/sglang_omni/models/higgs_tts/engine_builder.py
@@ -23,6 +23,9 @@ logger = logging.getLogger(__name__)
 class HiggsTtsEngineBuilder(TtsEngineBuilder):
     model_name = "Higgs TTS"
     context_length = 4096
+    prefill_cuda_graph_capability_architecture = (
+        "HiggsMultimodalQwen3ForConditionalGeneration"
+    )
 
     def __init__(
         self,
@@ -99,13 +102,6 @@ class HiggsTtsEngineBuilder(TtsEngineBuilder):
         )
 
     def customize_server_args(self, server_args: Any) -> None:
-        prefill_backend = server_args.cuda_graph_config.prefill.backend
-        if prefill_backend != "disabled":
-            raise RuntimeError(
-                "Higgs prefill CUDA graphs are disabled because padded prefill "
-                "changes model outputs; keep cuda_graph_config.prefill.backend="
-                f"'disabled', got {prefill_backend!r}"
-            )
         override_server_args(
             server_args,
             "sglang_omni.higgs_tts.disable_overlap_schedule",

--- a/sglang_omni/models/model_capabilities.py
+++ b/sglang_omni/models/model_capabilities.py
@@ -6,6 +6,44 @@ from __future__ import annotations
 import importlib
 from dataclasses import dataclass
 from types import ModuleType
+from typing import Literal
+
+PrefillCudaGraphBackend = Literal[
+    "breakable",
+    "full",
+    "tc_piecewise",
+]
+
+PrefillCudaGraphIntegration = Literal[
+    "direct",
+    "adapter",
+    "incompatible",
+]
+
+PrefillCudaGraphStatus = Literal[
+    "validated",
+    "experimental",
+    "performance_unproven",
+    "blocked",
+    "unvalidated",
+]
+
+
+@dataclass(frozen=True)
+class PrefillCudaGraphBackendCapability:
+    backend: PrefillCudaGraphBackend
+    status: PrefillCudaGraphStatus
+    default_buckets: tuple[int, ...] = ()
+    requirements: tuple[str, ...] = ()
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class PrefillCudaGraphCapability:
+    integration: PrefillCudaGraphIntegration
+    backends: tuple[PrefillCudaGraphBackendCapability, ...] = ()
+    preferred_backend: PrefillCudaGraphBackend | None = None
+    incompatible_reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -28,6 +66,8 @@ class ModelCapabilities:
     - supports_torch_compile: the architecture has an owned ``torch.compile``
       path, including codec, codebook, or frame-sampler compiles. This is not
       limited to the generic SGLang ``enable_torch_compile`` server arg.
+    - prefill_cuda_graph: backend-specific Prefill CUDA Graph compatibility and
+      deployment policy metadata.
     """
 
     supports_reference_audio: bool
@@ -35,6 +75,11 @@ class ModelCapabilities:
     supports_streaming_vocoder: bool
     supports_cuda_graph: bool
     supports_torch_compile: bool
+    prefill_cuda_graph: PrefillCudaGraphCapability | None = None
+
+    def __post_init__(self) -> None:
+        if self.prefill_cuda_graph is not None:
+            _validate_prefill_cuda_graph_capability(self.prefill_cuda_graph)
 
 
 def get_model_capabilities(architecture: str) -> ModelCapabilities | None:
@@ -68,7 +113,102 @@ def _ensure_model_capabilities(capabilities: object, source: str) -> ModelCapabi
     return capabilities
 
 
+def _validate_prefill_cuda_graph_capability(
+    capability: PrefillCudaGraphCapability,
+) -> None:
+    if capability.integration not in ("direct", "adapter", "incompatible"):
+        raise ValueError(
+            f"invalid Prefill CUDA Graph integration: {capability.integration!r}"
+        )
+
+    if capability.integration == "incompatible":
+        if not capability.incompatible_reason:
+            raise ValueError(
+                "incompatible Prefill CUDA Graph capability requires "
+                "incompatible_reason"
+            )
+        if capability.backends:
+            raise ValueError(
+                "incompatible Prefill CUDA Graph capability cannot declare backends"
+            )
+
+    declared_backends: set[str] = set()
+    for backend in capability.backends:
+        if not isinstance(backend, PrefillCudaGraphBackendCapability):
+            raise TypeError(
+                "Prefill CUDA Graph backends must be "
+                "PrefillCudaGraphBackendCapability instances"
+            )
+        if backend.backend not in ("breakable", "full", "tc_piecewise"):
+            raise ValueError(f"invalid Prefill CUDA Graph backend: {backend.backend!r}")
+        if backend.backend in declared_backends:
+            raise ValueError(
+                f"duplicate Prefill CUDA Graph backend declaration: {backend.backend}"
+            )
+        declared_backends.add(backend.backend)
+
+        if backend.status not in (
+            "validated",
+            "experimental",
+            "performance_unproven",
+            "blocked",
+            "unvalidated",
+        ):
+            raise ValueError(f"invalid Prefill CUDA Graph status: {backend.status!r}")
+        if backend.status == "blocked" and not backend.reason:
+            raise ValueError(
+                f"blocked Prefill CUDA Graph backend {backend.backend} requires a reason"
+            )
+        _validate_default_buckets(backend.backend, backend.default_buckets)
+
+    if (
+        capability.preferred_backend is not None
+        and capability.preferred_backend not in declared_backends
+    ):
+        raise ValueError(
+            "preferred Prefill CUDA Graph backend must be present in backends: "
+            f"{capability.preferred_backend}"
+        )
+
+
+def _validate_default_buckets(backend: str, buckets: tuple[int, ...]) -> None:
+    if not isinstance(buckets, tuple):
+        raise ValueError(
+            f"default buckets for Prefill CUDA Graph backend {backend} must be a tuple"
+        )
+    if not buckets:
+        raise ValueError(
+            f"default buckets for Prefill CUDA Graph backend {backend} "
+            "must not be empty"
+        )
+    if any(
+        not isinstance(bucket, int) or isinstance(bucket, bool) for bucket in buckets
+    ):
+        raise ValueError(
+            f"default buckets for Prefill CUDA Graph backend {backend} "
+            "must contain integers"
+        )
+    if any(bucket <= 0 for bucket in buckets):
+        raise ValueError(
+            f"default buckets for Prefill CUDA Graph backend {backend} must be positive"
+        )
+    if len(set(buckets)) != len(buckets):
+        raise ValueError(
+            f"default buckets for Prefill CUDA Graph backend {backend} must be unique"
+        )
+    if any(left >= right for left, right in zip(buckets, buckets[1:])):
+        raise ValueError(
+            f"default buckets for Prefill CUDA Graph backend {backend} "
+            "must be strictly increasing"
+        )
+
+
 __all__ = [
     "ModelCapabilities",
+    "PrefillCudaGraphBackend",
+    "PrefillCudaGraphBackendCapability",
+    "PrefillCudaGraphCapability",
+    "PrefillCudaGraphIntegration",
+    "PrefillCudaGraphStatus",
     "get_model_capabilities",
 ]

--- a/sglang_omni/models/model_capabilities.py
+++ b/sglang_omni/models/model_capabilities.py
@@ -33,7 +33,7 @@ PrefillCudaGraphStatus = Literal[
 class PrefillCudaGraphBackendCapability:
     backend: PrefillCudaGraphBackend
     status: PrefillCudaGraphStatus
-    default_buckets: tuple[int, ...] = ()
+    default_token_buckets: tuple[int, ...] = ()
     requirements: tuple[str, ...] = ()
     reason: str | None = None
 
@@ -159,10 +159,10 @@ def _validate_prefill_cuda_graph_capability(
             raise ValueError(
                 f"blocked Prefill CUDA Graph backend {backend.backend} requires a reason"
             )
-        _validate_default_buckets(
+        _validate_default_token_buckets(
             backend.backend,
             backend.status,
-            backend.default_buckets,
+            backend.default_token_buckets,
         )
 
     if (
@@ -175,38 +175,42 @@ def _validate_prefill_cuda_graph_capability(
         )
 
 
-def _validate_default_buckets(
+def _validate_default_token_buckets(
     backend: str,
     status: PrefillCudaGraphStatus,
-    buckets: tuple[int, ...],
+    token_buckets: tuple[int, ...],
 ) -> None:
-    if not isinstance(buckets, tuple):
+    if not isinstance(token_buckets, tuple):
         raise ValueError(
-            f"default buckets for Prefill CUDA Graph backend {backend} must be a tuple"
+            "default token buckets for Prefill CUDA Graph backend "
+            f"{backend} must be a tuple"
         )
-    if not buckets and status not in ("blocked", "unvalidated"):
+    if not token_buckets and status not in ("blocked", "unvalidated"):
         raise ValueError(
-            f"default buckets for Prefill CUDA Graph backend {backend} "
+            f"default token buckets for Prefill CUDA Graph backend {backend} "
             "must not be empty"
         )
     if any(
-        not isinstance(bucket, int) or isinstance(bucket, bool) for bucket in buckets
+        not isinstance(bucket, int) or isinstance(bucket, bool)
+        for bucket in token_buckets
     ):
         raise ValueError(
-            f"default buckets for Prefill CUDA Graph backend {backend} "
+            f"default token buckets for Prefill CUDA Graph backend {backend} "
             "must contain integers"
         )
-    if any(bucket <= 0 for bucket in buckets):
+    if any(bucket <= 0 for bucket in token_buckets):
         raise ValueError(
-            f"default buckets for Prefill CUDA Graph backend {backend} must be positive"
+            "default token buckets for Prefill CUDA Graph backend "
+            f"{backend} must be positive"
         )
-    if len(set(buckets)) != len(buckets):
+    if len(set(token_buckets)) != len(token_buckets):
         raise ValueError(
-            f"default buckets for Prefill CUDA Graph backend {backend} must be unique"
+            "default token buckets for Prefill CUDA Graph backend "
+            f"{backend} must be unique"
         )
-    if any(left >= right for left, right in zip(buckets, buckets[1:])):
+    if any(left >= right for left, right in zip(token_buckets, token_buckets[1:])):
         raise ValueError(
-            f"default buckets for Prefill CUDA Graph backend {backend} "
+            f"default token buckets for Prefill CUDA Graph backend {backend} "
             "must be strictly increasing"
         )
 

--- a/sglang_omni/models/model_capabilities.py
+++ b/sglang_omni/models/model_capabilities.py
@@ -159,7 +159,11 @@ def _validate_prefill_cuda_graph_capability(
             raise ValueError(
                 f"blocked Prefill CUDA Graph backend {backend.backend} requires a reason"
             )
-        _validate_default_buckets(backend.backend, backend.default_buckets)
+        _validate_default_buckets(
+            backend.backend,
+            backend.status,
+            backend.default_buckets,
+        )
 
     if (
         capability.preferred_backend is not None
@@ -171,12 +175,16 @@ def _validate_prefill_cuda_graph_capability(
         )
 
 
-def _validate_default_buckets(backend: str, buckets: tuple[int, ...]) -> None:
+def _validate_default_buckets(
+    backend: str,
+    status: PrefillCudaGraphStatus,
+    buckets: tuple[int, ...],
+) -> None:
     if not isinstance(buckets, tuple):
         raise ValueError(
             f"default buckets for Prefill CUDA Graph backend {backend} must be a tuple"
         )
-    if not buckets:
+    if not buckets and status not in ("blocked", "unvalidated"):
         raise ValueError(
             f"default buckets for Prefill CUDA Graph backend {backend} "
             "must not be empty"

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -25,6 +25,13 @@ from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoi
 logger = logging.getLogger(__name__)
 
 _MISSING = object()
+_CANONICAL_PREFILL_KEYS = {
+    "backend",
+    "max_bs",
+    "bs",
+    "tc_compiler",
+    "full_prefill_max_req",
+}
 
 
 class SGLangGenerationEngineBuilder(ABC):
@@ -41,6 +48,7 @@ class SGLangGenerationEngineBuilder(ABC):
     model_arch_override: str | None = None
     prefill_cuda_graph_backend: str | None = None
     prefill_cuda_graph_buckets: list[int] | tuple[int, ...] | None = None
+    prefill_cuda_graph_compiler: str | None = None
     allow_experimental_prefill_cuda_graph = False
     allow_performance_unproven_prefill_cuda_graph = False
 
@@ -74,10 +82,7 @@ class SGLangGenerationEngineBuilder(ABC):
         self.adjust_overrides(overrides)
         prefill_policy = self._resolve_prefill_cuda_graph_policy(
             overrides=overrides,
-            server_args_overrides=server_args_overrides,
         )
-        overrides.update(prefill_cuda_graph_server_args(prefill_policy))
-        self._log_prefill_cuda_graph_policy(prefill_policy)
 
         server_args = sglang_backend.build_sglang_server_args(
             checkpoint_dir,
@@ -85,6 +90,10 @@ class SGLangGenerationEngineBuilder(ABC):
             **overrides,
         )
         self.customize_server_args(server_args)
+        self._validate_and_log_prefill_cuda_graph_policy(
+            prefill_policy,
+            server_args,
+        )
         self.validate_before_infrastructure(server_args)
 
         infra_kwargs = dict(self.infra_kwargs())
@@ -194,92 +203,82 @@ class SGLangGenerationEngineBuilder(ABC):
         self,
         *,
         overrides: dict[str, Any],
-        server_args_overrides: dict[str, Any] | None,
     ) -> ResolvedPrefillCudaGraphPolicy:
-        incoming = dict(server_args_overrides or {})
+        canonical_config, canonical_prefill = _extract_canonical_prefill_config(
+            overrides
+        )
+        uses_canonical_prefill = bool(canonical_prefill)
         merged_backend = _pop_prefill_value(
             overrides,
             "prefill backend",
             "cuda_graph_backend_prefill",
             "prefill_cuda_graph_backend",
         )
-        override_backend = _get_prefill_value(
-            incoming,
-            "prefill backend",
-            "cuda_graph_backend_prefill",
-            "prefill_cuda_graph_backend",
-        )
-        stage_backend = self.prefill_cuda_graph_backend
-        if override_backend is not _MISSING:
-            if stage_backend is not None and stage_backend != override_backend:
-                raise ValueError(
-                    "Conflicting Prefill CUDA Graph backend settings: "
-                    f"builder={stage_backend!r}, server_args_overrides="
-                    f"{override_backend!r}"
-                )
-            requested_backend = override_backend
-        elif stage_backend is not None:
-            if merged_backend is not _MISSING and merged_backend != stage_backend:
-                raise ValueError(
-                    "Conflicting Prefill CUDA Graph backend settings: "
-                    f"builder={stage_backend!r}, stage={merged_backend!r}"
-                )
-            requested_backend = stage_backend
-        elif merged_backend is not _MISSING:
-            requested_backend = merged_backend
-        else:
-            requested_backend = "disabled"
-
         merged_buckets = _pop_prefill_value(
             overrides,
             "prefill buckets",
             "cuda_graph_bs_prefill",
             "prefill_cuda_graph_buckets",
         )
-        override_buckets = _get_prefill_value(
-            incoming,
-            "prefill buckets",
-            "cuda_graph_bs_prefill",
-            "prefill_cuda_graph_buckets",
+        merged_max_bs = overrides.pop("cuda_graph_max_bs_prefill", _MISSING)
+        merged_compiler = _pop_prefill_value(
+            overrides,
+            "prefill compiler",
+            "cuda_graph_tc_compiler",
+            "prefill_cuda_graph_compiler",
         )
-        stage_buckets = self.prefill_cuda_graph_buckets
-        if override_buckets is not _MISSING:
-            if stage_buckets is not None and tuple(stage_buckets) != tuple(
-                override_buckets
-            ):
-                raise ValueError(
-                    "Conflicting Prefill CUDA Graph bucket settings: "
-                    f"builder={stage_buckets!r}, server_args_overrides="
-                    f"{override_buckets!r}"
-                )
-            requested_buckets = override_buckets
-        elif stage_buckets is not None:
-            if merged_buckets is not _MISSING and tuple(merged_buckets) != tuple(
-                stage_buckets
-            ):
-                raise ValueError(
-                    "Conflicting Prefill CUDA Graph bucket settings: "
-                    f"builder={stage_buckets!r}, stage={merged_buckets!r}"
-                )
-            requested_buckets = stage_buckets
-        elif merged_buckets is not _MISSING:
+        has_convenience_prefill = any(
+            value is not _MISSING
+            for value in (
+                merged_backend,
+                merged_buckets,
+                merged_max_bs,
+                merged_compiler,
+            )
+        ) or bool(overrides.get("disable_prefill_cuda_graph"))
+        if canonical_prefill and has_convenience_prefill:
+            raise ValueError(
+                "cuda_graph_config.prefill cannot be combined with Prefill CUDA "
+                "Graph convenience settings"
+            )
+
+        requested_backend = canonical_prefill.pop("backend", _MISSING)
+        if requested_backend is _MISSING:
+            requested_backend = merged_backend
+        if requested_backend is _MISSING:
+            if overrides.get("disable_prefill_cuda_graph"):
+                requested_backend = "disabled"
+            else:
+                requested_backend = self.prefill_cuda_graph_backend or "disabled"
+
+        requested_buckets = canonical_prefill.pop("bs", _MISSING)
+        if requested_buckets is _MISSING:
             requested_buckets = merged_buckets
-        else:
-            requested_buckets = None
+        if requested_buckets is _MISSING:
+            requested_buckets = self.prefill_cuda_graph_buckets
+
+        requested_max_bs = canonical_prefill.pop("max_bs", _MISSING)
+        if requested_max_bs is _MISSING:
+            requested_max_bs = merged_max_bs
+        if requested_max_bs is None:
+            requested_max_bs = _MISSING
+
+        requested_compiler = canonical_prefill.pop("tc_compiler", _MISSING)
+        if requested_compiler is _MISSING:
+            requested_compiler = merged_compiler
+        if requested_compiler is _MISSING:
+            requested_compiler = self.prefill_cuda_graph_compiler
 
         allow_experimental = _pop_policy_flag(
             overrides,
-            incoming,
             "allow_experimental_prefill_cuda_graph",
             self.allow_experimental_prefill_cuda_graph,
         )
         allow_performance_unproven = _pop_policy_flag(
             overrides,
-            incoming,
             "allow_performance_unproven_prefill_cuda_graph",
             self.allow_performance_unproven_prefill_cuda_graph,
         )
-        requested_max_bs = overrides.pop("cuda_graph_max_bs_prefill", _MISSING)
 
         if requested_backend == "disabled" and requested_buckets is not None:
             raise ValueError(
@@ -289,6 +288,17 @@ class SGLangGenerationEngineBuilder(ABC):
             raise ValueError(
                 "cuda_graph_max_bs_prefill cannot be set when the Prefill CUDA "
                 "Graph backend is disabled"
+            )
+        if requested_backend == "disabled" and requested_compiler is not None:
+            raise ValueError(
+                "Prefill CUDA Graph compiler cannot be set when the backend is disabled"
+            )
+        if (
+            requested_backend != "full"
+            and canonical_prefill.get("full_prefill_max_req") is not None
+        ):
+            raise ValueError(
+                "full_prefill_max_req requires Prefill CUDA Graph backend 'full'"
             )
 
         capability = (
@@ -301,6 +311,7 @@ class SGLangGenerationEngineBuilder(ABC):
             capability=capability,
             requested_backend=requested_backend,
             requested_buckets=requested_buckets,
+            requested_compiler=requested_compiler,
             allow_experimental=allow_experimental,
             allow_performance_unproven=allow_performance_unproven,
             runtime_requirements=(
@@ -315,30 +326,76 @@ class SGLangGenerationEngineBuilder(ABC):
                 f"cuda_graph_max_bs_prefill={requested_max_bs!r}, "
                 f"resolved maximum={max(policy.buckets)!r}"
             )
+
+        if uses_canonical_prefill:
+            resolved_prefill = dict(canonical_prefill)
+            resolved_prefill["backend"] = (
+                policy.resolved_backend if policy.enabled else "disabled"
+            )
+            if policy.enabled:
+                resolved_prefill["bs"] = list(policy.buckets)
+                resolved_prefill["max_bs"] = max(policy.buckets)
+                if policy.compiler is not None:
+                    resolved_prefill["tc_compiler"] = policy.compiler
+            canonical_config["prefill"] = resolved_prefill
+            overrides["cuda_graph_config"] = canonical_config
+        else:
+            overrides.update(prefill_cuda_graph_server_args(policy))
         return policy
 
-    def _log_prefill_cuda_graph_policy(
+    def _validate_and_log_prefill_cuda_graph_policy(
         self,
         policy: ResolvedPrefillCudaGraphPolicy,
+        server_args: Any,
     ) -> None:
-        if not policy.enabled:
-            logger.info(
-                "Prefill CUDA Graph policy: model=%s requested=%s enabled=false",
-                self.model_name,
-                policy.requested_backend,
-            )
-            return
-        buckets = ",".join(str(bucket) for bucket in policy.buckets)
+        actual = server_args.cuda_graph_config.prefill
+        actual_backend = actual.backend
+        actual_buckets = tuple(actual.bs or ())
+        actual_max_bs = actual.max_bs
+        actual_compiler = actual.tc_compiler
+        expected_backend = policy.resolved_backend if policy.enabled else "disabled"
+        changed = actual_backend != expected_backend
+        downgraded = policy.enabled and actual_backend == "disabled"
         logger.info(
-            "Prefill CUDA Graph policy: model=%s requested=%s resolved=%s "
-            "integration=%s status=%s buckets=[%s]",
+            "Prefill CUDA Graph policy: model=%s requested=%s actual=%s "
+            "enabled=%s integration=%s status=%s buckets=%s max_bs=%s "
+            "compiler=%s changed=%s downgraded=%s",
             self.model_name,
             policy.requested_backend,
-            policy.resolved_backend,
+            actual_backend,
+            str(actual_backend != "disabled").lower(),
             policy.integration,
             policy.status,
-            buckets,
+            list(actual_buckets),
+            actual_max_bs,
+            actual_compiler,
+            str(changed).lower(),
+            str(downgraded).lower(),
         )
+        errors: list[str] = []
+        if changed:
+            errors.append(
+                f"backend resolved to {actual_backend!r}, expected {expected_backend!r}"
+            )
+        if policy.enabled and actual_buckets != policy.buckets:
+            errors.append(
+                f"buckets resolved to {actual_buckets!r}, expected {policy.buckets!r}"
+            )
+        if policy.enabled and actual_max_bs != max(policy.buckets):
+            errors.append(
+                f"max_bs resolved to {actual_max_bs!r}, "
+                f"expected {max(policy.buckets)!r}"
+            )
+        if policy.compiler is not None and actual_compiler != policy.compiler:
+            errors.append(
+                f"compiler resolved to {actual_compiler!r}, "
+                f"expected {policy.compiler!r}"
+            )
+        if errors:
+            raise ValueError(
+                f"{self.model_name} Prefill CUDA Graph configuration changed by "
+                "SGLang: " + "; ".join(errors)
+            )
 
     @abstractmethod
     def generation_defaults(
@@ -514,6 +571,32 @@ def _get_prefill_value(
     return first_value
 
 
+def _extract_canonical_prefill_config(
+    overrides: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    raw_config = overrides.pop("cuda_graph_config", None)
+    if raw_config is None:
+        return {}, {}
+    if hasattr(raw_config, "to_dict"):
+        raw_config = raw_config.to_dict()
+    if not isinstance(raw_config, dict):
+        raise ValueError("cuda_graph_config must be a dictionary")
+
+    canonical_config = dict(raw_config)
+    raw_prefill = canonical_config.pop("prefill", {})
+    if not isinstance(raw_prefill, dict):
+        raise ValueError("cuda_graph_config.prefill must be a dictionary")
+    unknown_keys = set(raw_prefill) - _CANONICAL_PREFILL_KEYS
+    if unknown_keys:
+        raise ValueError(
+            "cuda_graph_config.prefill contains unsupported settings: "
+            + ", ".join(sorted(unknown_keys))
+        )
+    if canonical_config:
+        overrides["cuda_graph_config"] = canonical_config
+    return canonical_config, dict(raw_prefill)
+
+
 def _pop_prefill_value(
     values: dict[str, Any],
     label: str,
@@ -533,13 +616,10 @@ def _prefill_values_equal(left: Any, right: Any) -> bool:
 
 def _pop_policy_flag(
     overrides: dict[str, Any],
-    incoming: dict[str, Any],
     key: str,
     default: bool,
 ) -> bool:
     value = overrides.pop(key, _MISSING)
-    if key in incoming:
-        return bool(incoming[key])
     if value is not _MISSING:
         return bool(value)
     return bool(default)

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -3,14 +3,28 @@
 
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from typing import Any
 
+from sglang_omni.models.model_capabilities import (
+    PrefillCudaGraphCapability,
+    get_model_capabilities,
+)
 from sglang_omni.scheduling.generation_batch_policy import (
     build_generation_batch_overrides,
     validate_generation_batch_policy,
 )
+from sglang_omni.scheduling.prefill_cuda_graph_policy import (
+    ResolvedPrefillCudaGraphPolicy,
+    prefill_cuda_graph_server_args,
+    resolve_prefill_cuda_graph_policy,
+)
 from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoint
+
+logger = logging.getLogger(__name__)
+
+_MISSING = object()
 
 
 class SGLangGenerationEngineBuilder(ABC):
@@ -25,6 +39,10 @@ class SGLangGenerationEngineBuilder(ABC):
     model_name: str
     context_length: int
     model_arch_override: str | None = None
+    prefill_cuda_graph_backend: str | None = None
+    prefill_cuda_graph_buckets: list[int] | tuple[int, ...] | None = None
+    allow_experimental_prefill_cuda_graph = False
+    allow_performance_unproven_prefill_cuda_graph = False
 
     def build(
         self,
@@ -54,6 +72,12 @@ class SGLangGenerationEngineBuilder(ABC):
             **self.generation_defaults(dtype=dtype),
         )
         self.adjust_overrides(overrides)
+        prefill_policy = self._resolve_prefill_cuda_graph_policy(
+            overrides=overrides,
+            server_args_overrides=server_args_overrides,
+        )
+        overrides.update(prefill_cuda_graph_server_args(prefill_policy))
+        self._log_prefill_cuda_graph_policy(prefill_policy)
 
         server_args = sglang_backend.build_sglang_server_args(
             checkpoint_dir,
@@ -134,6 +158,187 @@ class SGLangGenerationEngineBuilder(ABC):
         # The shared builder treats checkpoint resolution as a family policy.
         # Subclasses override this when they need a resolved local snapshot.
         return model_path
+
+    def prefill_cuda_graph_capability(self) -> PrefillCudaGraphCapability | None:
+        from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+
+        candidates = (
+            self.model_arch_override,
+            getattr(self, "architecture", None),
+        )
+        for architecture in candidates:
+            if not isinstance(architecture, str) or not architecture:
+                continue
+            capabilities = get_model_capabilities(architecture)
+            if capabilities is not None:
+                return capabilities.prefill_cuda_graph
+
+        model_package = ".".join(self.__class__.__module__.split(".")[:3])
+        package_architectures = {
+            config_cls.architecture
+            for config_cls in set(PIPELINE_CONFIG_REGISTRY.configs.values())
+            if ".".join(config_cls.__module__.split(".")[:3]) == model_package
+        }
+        if len(package_architectures) != 1:
+            return None
+        architecture = package_architectures.pop()
+        capabilities = get_model_capabilities(architecture)
+        if capabilities is None:
+            return None
+        return capabilities.prefill_cuda_graph
+
+    def prefill_cuda_graph_runtime_requirements(self) -> dict[str, bool]:
+        return {}
+
+    def _resolve_prefill_cuda_graph_policy(
+        self,
+        *,
+        overrides: dict[str, Any],
+        server_args_overrides: dict[str, Any] | None,
+    ) -> ResolvedPrefillCudaGraphPolicy:
+        incoming = dict(server_args_overrides or {})
+        merged_backend = _pop_prefill_value(
+            overrides,
+            "prefill backend",
+            "cuda_graph_backend_prefill",
+            "prefill_cuda_graph_backend",
+        )
+        override_backend = _get_prefill_value(
+            incoming,
+            "prefill backend",
+            "cuda_graph_backend_prefill",
+            "prefill_cuda_graph_backend",
+        )
+        stage_backend = self.prefill_cuda_graph_backend
+        if override_backend is not _MISSING:
+            if stage_backend is not None and stage_backend != override_backend:
+                raise ValueError(
+                    "Conflicting Prefill CUDA Graph backend settings: "
+                    f"builder={stage_backend!r}, server_args_overrides="
+                    f"{override_backend!r}"
+                )
+            requested_backend = override_backend
+        elif stage_backend is not None:
+            if merged_backend is not _MISSING and merged_backend != stage_backend:
+                raise ValueError(
+                    "Conflicting Prefill CUDA Graph backend settings: "
+                    f"builder={stage_backend!r}, stage={merged_backend!r}"
+                )
+            requested_backend = stage_backend
+        elif merged_backend is not _MISSING:
+            requested_backend = merged_backend
+        else:
+            requested_backend = "disabled"
+
+        merged_buckets = _pop_prefill_value(
+            overrides,
+            "prefill buckets",
+            "cuda_graph_bs_prefill",
+            "prefill_cuda_graph_buckets",
+        )
+        override_buckets = _get_prefill_value(
+            incoming,
+            "prefill buckets",
+            "cuda_graph_bs_prefill",
+            "prefill_cuda_graph_buckets",
+        )
+        stage_buckets = self.prefill_cuda_graph_buckets
+        if override_buckets is not _MISSING:
+            if stage_buckets is not None and tuple(stage_buckets) != tuple(
+                override_buckets
+            ):
+                raise ValueError(
+                    "Conflicting Prefill CUDA Graph bucket settings: "
+                    f"builder={stage_buckets!r}, server_args_overrides="
+                    f"{override_buckets!r}"
+                )
+            requested_buckets = override_buckets
+        elif stage_buckets is not None:
+            if merged_buckets is not _MISSING and tuple(merged_buckets) != tuple(
+                stage_buckets
+            ):
+                raise ValueError(
+                    "Conflicting Prefill CUDA Graph bucket settings: "
+                    f"builder={stage_buckets!r}, stage={merged_buckets!r}"
+                )
+            requested_buckets = stage_buckets
+        elif merged_buckets is not _MISSING:
+            requested_buckets = merged_buckets
+        else:
+            requested_buckets = None
+
+        allow_experimental = _pop_policy_flag(
+            overrides,
+            incoming,
+            "allow_experimental_prefill_cuda_graph",
+            self.allow_experimental_prefill_cuda_graph,
+        )
+        allow_performance_unproven = _pop_policy_flag(
+            overrides,
+            incoming,
+            "allow_performance_unproven_prefill_cuda_graph",
+            self.allow_performance_unproven_prefill_cuda_graph,
+        )
+        requested_max_bs = overrides.pop("cuda_graph_max_bs_prefill", _MISSING)
+
+        if requested_backend == "disabled" and requested_buckets is not None:
+            raise ValueError(
+                "Prefill CUDA Graph buckets cannot be set when the backend is disabled"
+            )
+        if requested_backend == "disabled" and requested_max_bs is not _MISSING:
+            raise ValueError(
+                "cuda_graph_max_bs_prefill cannot be set when the Prefill CUDA "
+                "Graph backend is disabled"
+            )
+
+        capability = (
+            None
+            if requested_backend == "disabled"
+            else self.prefill_cuda_graph_capability()
+        )
+        policy = resolve_prefill_cuda_graph_policy(
+            model_name=self.model_name,
+            capability=capability,
+            requested_backend=requested_backend,
+            requested_buckets=requested_buckets,
+            allow_experimental=allow_experimental,
+            allow_performance_unproven=allow_performance_unproven,
+            runtime_requirements=(
+                None
+                if requested_backend == "disabled"
+                else self.prefill_cuda_graph_runtime_requirements()
+            ),
+        )
+        if requested_max_bs is not _MISSING and requested_max_bs != max(policy.buckets):
+            raise ValueError(
+                "Conflicting Prefill CUDA Graph maximum bucket: "
+                f"cuda_graph_max_bs_prefill={requested_max_bs!r}, "
+                f"resolved maximum={max(policy.buckets)!r}"
+            )
+        return policy
+
+    def _log_prefill_cuda_graph_policy(
+        self,
+        policy: ResolvedPrefillCudaGraphPolicy,
+    ) -> None:
+        if not policy.enabled:
+            logger.info(
+                "Prefill CUDA Graph policy: model=%s requested=%s enabled=false",
+                self.model_name,
+                policy.requested_backend,
+            )
+            return
+        buckets = ",".join(str(bucket) for bucket in policy.buckets)
+        logger.info(
+            "Prefill CUDA Graph policy: model=%s requested=%s resolved=%s "
+            "integration=%s status=%s buckets=[%s]",
+            self.model_name,
+            policy.requested_backend,
+            policy.resolved_backend,
+            policy.integration,
+            policy.status,
+            buckets,
+        )
 
     @abstractmethod
     def generation_defaults(
@@ -289,6 +494,55 @@ class SGLangGenerationEngineBuilder(ABC):
 
     def post_scheduler_setup(self, scheduler: Any, model_runner: Any) -> None:
         del scheduler, model_runner
+
+
+def _get_prefill_value(
+    values: dict[str, Any],
+    label: str,
+    *keys: str,
+) -> Any:
+    present = [(key, values[key]) for key in keys if key in values]
+    if not present:
+        return _MISSING
+    first_key, first_value = present[0]
+    for key, value in present[1:]:
+        if not _prefill_values_equal(first_value, value):
+            raise ValueError(
+                f"Conflicting {label} settings: "
+                f"{first_key}={first_value!r}, {key}={value!r}"
+            )
+    return first_value
+
+
+def _pop_prefill_value(
+    values: dict[str, Any],
+    label: str,
+    *keys: str,
+) -> Any:
+    value = _get_prefill_value(values, label, *keys)
+    for key in keys:
+        values.pop(key, None)
+    return value
+
+
+def _prefill_values_equal(left: Any, right: Any) -> bool:
+    if isinstance(left, (list, tuple)) and isinstance(right, (list, tuple)):
+        return tuple(left) == tuple(right)
+    return left == right
+
+
+def _pop_policy_flag(
+    overrides: dict[str, Any],
+    incoming: dict[str, Any],
+    key: str,
+    default: bool,
+) -> bool:
+    value = overrides.pop(key, _MISSING)
+    if key in incoming:
+        return bool(incoming[key])
+    if value is not _MISSING:
+        return bool(value)
+    return bool(default)
 
 
 class AsrEngineBuilder(SGLangGenerationEngineBuilder):

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -32,6 +32,23 @@ _CANONICAL_PREFILL_KEYS = {
     "tc_compiler",
     "full_prefill_max_req",
 }
+_PREFILL_BACKEND_KEYS = (
+    "cuda_graph_backend_prefill",
+    "prefill_cuda_graph_backend",
+)
+_PREFILL_TOKEN_BUCKET_KEYS = (
+    "cuda_graph_bs_prefill",
+    "prefill_cuda_graph_token_buckets",
+)
+_PREFILL_COMPILER_KEYS = (
+    "cuda_graph_tc_compiler",
+    "prefill_cuda_graph_compiler",
+)
+_LEGACY_PREFILL_BACKEND_ALIASES = {
+    "enable_breakable_cuda_graph": "breakable",
+    "disable_piecewise_cuda_graph": "disabled",
+    "enforce_piecewise_cuda_graph": "tc_piecewise",
+}
 
 
 class SGLangGenerationEngineBuilder(ABC):
@@ -41,16 +58,21 @@ class SGLangGenerationEngineBuilder(ABC):
     request/result adapters, validation policy, and any stage-owned resources.
     Family-specific builders such as :class:`AsrEngineBuilder` and
     :class:`TtsEngineBuilder` define the lifecycle policy for each modality.
+
+    Prefill controls accept upstream ``cuda_graph_*_prefill`` keys or the
+    stage-facing ``prefill_cuda_graph_*`` aliases. Prefill ``bs`` values are
+    token buckets, not request batch-size buckets.
     """
 
     model_name: str
     context_length: int
     model_arch_override: str | None = None
+    prefill_cuda_graph_capability_architecture: str | None = None
     prefill_cuda_graph_backend: str | None = None
-    prefill_cuda_graph_buckets: list[int] | tuple[int, ...] | None = None
+    prefill_cuda_graph_token_buckets: list[int] | tuple[int, ...] | None = None
     prefill_cuda_graph_compiler: str | None = None
-    allow_experimental_prefill_cuda_graph = False
-    allow_performance_unproven_prefill_cuda_graph = False
+    allow_experimental_prefill_cuda_graph: bool = False
+    allow_performance_unproven_prefill_cuda_graph: bool = False
 
     def build(
         self,
@@ -75,9 +97,15 @@ class SGLangGenerationEngineBuilder(ABC):
 
         self.pre_infra_setup(checkpoint_dir)
 
+        stage_defaults = self.generation_defaults(dtype=dtype)
+        explicit_overrides = dict(server_args_overrides or {})
+        _normalize_prefill_override_precedence(
+            lower_defaults=stage_defaults,
+            explicit_overrides=explicit_overrides,
+        )
         overrides = build_generation_batch_overrides(
-            server_args_overrides=server_args_overrides,
-            **self.generation_defaults(dtype=dtype),
+            server_args_overrides=explicit_overrides,
+            **stage_defaults,
         )
         self.adjust_overrides(overrides)
         prefill_policy = self._resolve_prefill_cuda_graph_policy(
@@ -169,34 +197,16 @@ class SGLangGenerationEngineBuilder(ABC):
         return model_path
 
     def prefill_cuda_graph_capability(self) -> PrefillCudaGraphCapability | None:
-        from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
-
-        candidates = (
-            self.model_arch_override,
-            getattr(self, "architecture", None),
-        )
-        for architecture in candidates:
-            if not isinstance(architecture, str) or not architecture:
-                continue
-            capabilities = get_model_capabilities(architecture)
-            if capabilities is not None:
-                return capabilities.prefill_cuda_graph
-
-        model_package = ".".join(self.__class__.__module__.split(".")[:3])
-        package_architectures = {
-            config_cls.architecture
-            for config_cls in set(PIPELINE_CONFIG_REGISTRY.configs.values())
-            if ".".join(config_cls.__module__.split(".")[:3]) == model_package
-        }
-        if len(package_architectures) != 1:
+        architecture = self.prefill_cuda_graph_capability_architecture
+        if architecture is None:
             return None
-        architecture = package_architectures.pop()
         capabilities = get_model_capabilities(architecture)
         if capabilities is None:
             return None
         return capabilities.prefill_cuda_graph
 
     def prefill_cuda_graph_runtime_requirements(self) -> dict[str, bool]:
+        """Report model-specific prerequisites before explicit enablement."""
         return {}
 
     def _resolve_prefill_cuda_graph_policy(
@@ -204,6 +214,7 @@ class SGLangGenerationEngineBuilder(ABC):
         *,
         overrides: dict[str, Any],
     ) -> ResolvedPrefillCudaGraphPolicy:
+        _normalize_legacy_prefill_aliases(overrides)
         canonical_config, canonical_prefill = _extract_canonical_prefill_config(
             overrides
         )
@@ -211,51 +222,73 @@ class SGLangGenerationEngineBuilder(ABC):
         merged_backend = _pop_prefill_value(
             overrides,
             "prefill backend",
-            "cuda_graph_backend_prefill",
-            "prefill_cuda_graph_backend",
+            *_PREFILL_BACKEND_KEYS,
         )
-        merged_buckets = _pop_prefill_value(
+        merged_token_buckets = _pop_prefill_value(
             overrides,
-            "prefill buckets",
-            "cuda_graph_bs_prefill",
-            "prefill_cuda_graph_buckets",
+            "prefill token buckets",
+            *_PREFILL_TOKEN_BUCKET_KEYS,
         )
         merged_max_bs = overrides.pop("cuda_graph_max_bs_prefill", _MISSING)
         merged_compiler = _pop_prefill_value(
             overrides,
             "prefill compiler",
-            "cuda_graph_tc_compiler",
-            "prefill_cuda_graph_compiler",
+            *_PREFILL_COMPILER_KEYS,
         )
-        has_convenience_prefill = any(
-            value is not _MISSING
-            for value in (
-                merged_backend,
-                merged_buckets,
-                merged_max_bs,
-                merged_compiler,
+        disable_prefill = bool(overrides.pop("disable_prefill_cuda_graph", False))
+        disable_all_graphs = bool(overrides.get("disable_cuda_graph"))
+        has_convenience_prefill = (
+            any(
+                value is not _MISSING
+                for value in (
+                    merged_backend,
+                    merged_token_buckets,
+                    merged_max_bs,
+                    merged_compiler,
+                )
             )
-        ) or bool(overrides.get("disable_prefill_cuda_graph"))
+            or disable_prefill
+        )
         if canonical_prefill and has_convenience_prefill:
             raise ValueError(
                 "cuda_graph_config.prefill cannot be combined with Prefill CUDA "
                 "Graph convenience settings"
             )
 
-        requested_backend = canonical_prefill.pop("backend", _MISSING)
-        if requested_backend is _MISSING:
+        if (
+            disable_prefill
+            and merged_backend is not _MISSING
+            and merged_backend != "disabled"
+        ):
+            raise ValueError(
+                "Conflicting Prefill CUDA Graph settings: a disable flag cannot "
+                "be combined with an enabled prefill backend at the same tier"
+            )
+
+        canonical_backend = canonical_prefill.pop("backend", _MISSING)
+        clear_builder_prefill_settings = False
+        if canonical_backend is not _MISSING:
+            requested_backend = canonical_backend
+            clear_builder_prefill_settings = requested_backend == "disabled"
+        elif merged_backend is not _MISSING:
             requested_backend = merged_backend
-        if requested_backend is _MISSING:
-            if overrides.get("disable_prefill_cuda_graph"):
+            clear_builder_prefill_settings = requested_backend == "disabled"
+        else:
+            if disable_prefill or disable_all_graphs:
                 requested_backend = "disabled"
+                clear_builder_prefill_settings = True
             else:
                 requested_backend = self.prefill_cuda_graph_backend or "disabled"
 
-        requested_buckets = canonical_prefill.pop("bs", _MISSING)
-        if requested_buckets is _MISSING:
-            requested_buckets = merged_buckets
-        if requested_buckets is _MISSING:
-            requested_buckets = self.prefill_cuda_graph_buckets
+        requested_token_buckets = canonical_prefill.pop("bs", _MISSING)
+        if requested_token_buckets is _MISSING:
+            requested_token_buckets = merged_token_buckets
+        if requested_token_buckets is _MISSING:
+            requested_token_buckets = (
+                None
+                if clear_builder_prefill_settings
+                else self.prefill_cuda_graph_token_buckets
+            )
 
         requested_max_bs = canonical_prefill.pop("max_bs", _MISSING)
         if requested_max_bs is _MISSING:
@@ -267,7 +300,11 @@ class SGLangGenerationEngineBuilder(ABC):
         if requested_compiler is _MISSING:
             requested_compiler = merged_compiler
         if requested_compiler is _MISSING:
-            requested_compiler = self.prefill_cuda_graph_compiler
+            requested_compiler = (
+                None
+                if clear_builder_prefill_settings
+                else self.prefill_cuda_graph_compiler
+            )
 
         allow_experimental = _pop_policy_flag(
             overrides,
@@ -280,9 +317,10 @@ class SGLangGenerationEngineBuilder(ABC):
             self.allow_performance_unproven_prefill_cuda_graph,
         )
 
-        if requested_backend == "disabled" and requested_buckets is not None:
+        if requested_backend == "disabled" and requested_token_buckets is not None:
             raise ValueError(
-                "Prefill CUDA Graph buckets cannot be set when the backend is disabled"
+                "Prefill CUDA Graph token buckets cannot be set when the backend "
+                "is disabled"
             )
         if requested_backend == "disabled" and requested_max_bs is not _MISSING:
             raise ValueError(
@@ -310,7 +348,7 @@ class SGLangGenerationEngineBuilder(ABC):
             model_name=self.model_name,
             capability=capability,
             requested_backend=requested_backend,
-            requested_buckets=requested_buckets,
+            requested_token_buckets=requested_token_buckets,
             requested_compiler=requested_compiler,
             allow_experimental=allow_experimental,
             allow_performance_unproven=allow_performance_unproven,
@@ -320,11 +358,13 @@ class SGLangGenerationEngineBuilder(ABC):
                 else self.prefill_cuda_graph_runtime_requirements()
             ),
         )
-        if requested_max_bs is not _MISSING and requested_max_bs != max(policy.buckets):
+        if requested_max_bs is not _MISSING and requested_max_bs != max(
+            policy.token_buckets
+        ):
             raise ValueError(
-                "Conflicting Prefill CUDA Graph maximum bucket: "
+                "Conflicting Prefill CUDA Graph maximum token bucket: "
                 f"cuda_graph_max_bs_prefill={requested_max_bs!r}, "
-                f"resolved maximum={max(policy.buckets)!r}"
+                f"resolved maximum={max(policy.token_buckets)!r}"
             )
 
         if uses_canonical_prefill:
@@ -333,8 +373,8 @@ class SGLangGenerationEngineBuilder(ABC):
                 policy.resolved_backend if policy.enabled else "disabled"
             )
             if policy.enabled:
-                resolved_prefill["bs"] = list(policy.buckets)
-                resolved_prefill["max_bs"] = max(policy.buckets)
+                resolved_prefill["bs"] = list(policy.token_buckets)
+                resolved_prefill["max_bs"] = max(policy.token_buckets)
                 if policy.compiler is not None:
                     resolved_prefill["tc_compiler"] = policy.compiler
             canonical_config["prefill"] = resolved_prefill
@@ -350,7 +390,7 @@ class SGLangGenerationEngineBuilder(ABC):
     ) -> None:
         actual = server_args.cuda_graph_config.prefill
         actual_backend = actual.backend
-        actual_buckets = tuple(actual.bs or ())
+        actual_token_buckets = tuple(actual.bs or ())
         actual_max_bs = actual.max_bs
         actual_compiler = actual.tc_compiler
         expected_backend = policy.resolved_backend if policy.enabled else "disabled"
@@ -358,7 +398,7 @@ class SGLangGenerationEngineBuilder(ABC):
         downgraded = policy.enabled and actual_backend == "disabled"
         logger.info(
             "Prefill CUDA Graph policy: model=%s requested=%s actual=%s "
-            "enabled=%s integration=%s status=%s buckets=%s max_bs=%s "
+            "enabled=%s integration=%s status=%s token_buckets=%s max_bs=%s "
             "compiler=%s changed=%s downgraded=%s",
             self.model_name,
             policy.requested_backend,
@@ -366,7 +406,7 @@ class SGLangGenerationEngineBuilder(ABC):
             str(actual_backend != "disabled").lower(),
             policy.integration,
             policy.status,
-            list(actual_buckets),
+            list(actual_token_buckets),
             actual_max_bs,
             actual_compiler,
             str(changed).lower(),
@@ -377,14 +417,15 @@ class SGLangGenerationEngineBuilder(ABC):
             errors.append(
                 f"backend resolved to {actual_backend!r}, expected {expected_backend!r}"
             )
-        if policy.enabled and actual_buckets != policy.buckets:
+        if policy.enabled and actual_token_buckets != policy.token_buckets:
             errors.append(
-                f"buckets resolved to {actual_buckets!r}, expected {policy.buckets!r}"
+                "token buckets resolved to "
+                f"{actual_token_buckets!r}, expected {policy.token_buckets!r}"
             )
-        if policy.enabled and actual_max_bs != max(policy.buckets):
+        if policy.enabled and actual_max_bs != max(policy.token_buckets):
             errors.append(
                 f"max_bs resolved to {actual_max_bs!r}, "
-                f"expected {max(policy.buckets)!r}"
+                f"expected {max(policy.token_buckets)!r}"
             )
         if policy.compiler is not None and actual_compiler != policy.compiler:
             errors.append(
@@ -558,7 +599,9 @@ def _get_prefill_value(
     label: str,
     *keys: str,
 ) -> Any:
-    present = [(key, values[key]) for key in keys if key in values]
+    present = [
+        (key, values[key]) for key in keys if key in values and values[key] is not None
+    ]
     if not present:
         return _MISSING
     first_key, first_value = present[0]
@@ -569,6 +612,152 @@ def _get_prefill_value(
                 f"{first_key}={first_value!r}, {key}={value!r}"
             )
     return first_value
+
+
+def _normalize_prefill_override_precedence(
+    *,
+    lower_defaults: dict[str, Any],
+    explicit_overrides: dict[str, Any],
+) -> None:
+    _normalize_legacy_prefill_aliases(explicit_overrides)
+    explicit_canonical_prefill = _has_canonical_prefill(explicit_overrides)
+    explicit_setting_keys = _active_prefill_setting_keys(explicit_overrides)
+
+    if explicit_canonical_prefill:
+        if explicit_setting_keys:
+            raise ValueError(
+                "cuda_graph_config.prefill cannot be combined with Prefill CUDA "
+                "Graph convenience settings at the same override tier"
+            )
+        _remove_lower_prefill_settings(lower_defaults)
+        return
+
+    if explicit_setting_keys:
+        _remove_canonical_prefill(lower_defaults)
+        _remove_shadowed_lower_prefill_fields(
+            lower_defaults,
+            explicit_setting_keys,
+        )
+
+    explicit_backend = _get_prefill_value(
+        explicit_overrides,
+        "prefill backend",
+        *_PREFILL_BACKEND_KEYS,
+    )
+    explicit_disable = (
+        explicit_backend == "disabled"
+        or bool(explicit_overrides.get("disable_prefill_cuda_graph"))
+        or bool(explicit_overrides.get("disable_cuda_graph"))
+    )
+    if not explicit_disable:
+        return
+
+    if explicit_backend is not _MISSING and explicit_backend != "disabled":
+        raise ValueError(
+            "Conflicting Prefill CUDA Graph settings: a disable flag cannot be "
+            "combined with an enabled prefill backend at the same override tier"
+        )
+    conflicting_keys = explicit_setting_keys.intersection(
+        {
+            *_PREFILL_TOKEN_BUCKET_KEYS,
+            "cuda_graph_max_bs_prefill",
+            *_PREFILL_COMPILER_KEYS,
+        }
+    )
+    if conflicting_keys:
+        raise ValueError(
+            "Prefill CUDA Graph disable settings cannot be combined with token "
+            "buckets, maximum, or compiler settings at the same override tier: "
+            + ", ".join(sorted(conflicting_keys))
+        )
+    _remove_lower_prefill_settings(lower_defaults)
+
+
+def _normalize_legacy_prefill_aliases(values: dict[str, Any]) -> None:
+    for alias, backend in _LEGACY_PREFILL_BACKEND_ALIASES.items():
+        enabled = values.pop(alias, False)
+        if not enabled:
+            continue
+        current = _get_prefill_value(
+            values,
+            "prefill backend",
+            *_PREFILL_BACKEND_KEYS,
+        )
+        if current is not _MISSING and current != backend:
+            raise ValueError(
+                "Conflicting Prefill CUDA Graph backend settings: "
+                f"{alias}=True selects {backend!r}, existing backend={current!r}"
+            )
+        values["cuda_graph_backend_prefill"] = backend
+
+
+def _active_prefill_setting_keys(values: dict[str, Any]) -> set[str]:
+    keys = {
+        key
+        for key in (
+            *_PREFILL_BACKEND_KEYS,
+            *_PREFILL_TOKEN_BUCKET_KEYS,
+            "cuda_graph_max_bs_prefill",
+            *_PREFILL_COMPILER_KEYS,
+        )
+        if values.get(key) is not None
+    }
+    for key in ("disable_prefill_cuda_graph", "disable_cuda_graph"):
+        if values.get(key):
+            keys.add(key)
+    return keys
+
+
+def _has_canonical_prefill(values: dict[str, Any]) -> bool:
+    config = values.get("cuda_graph_config")
+    if hasattr(config, "to_dict"):
+        config = config.to_dict()
+    return isinstance(config, dict) and bool(config.get("prefill"))
+
+
+def _remove_canonical_prefill(values: dict[str, Any]) -> None:
+    config = values.get("cuda_graph_config")
+    if hasattr(config, "to_dict"):
+        config = config.to_dict()
+    if not isinstance(config, dict) or "prefill" not in config:
+        return
+    remaining = dict(config)
+    remaining.pop("prefill")
+    if remaining:
+        values["cuda_graph_config"] = remaining
+    else:
+        values.pop("cuda_graph_config", None)
+
+
+def _remove_shadowed_lower_prefill_fields(
+    lower_defaults: dict[str, Any],
+    explicit_setting_keys: set[str],
+) -> None:
+    groups = (
+        _PREFILL_BACKEND_KEYS,
+        _PREFILL_TOKEN_BUCKET_KEYS,
+        ("cuda_graph_max_bs_prefill",),
+        _PREFILL_COMPILER_KEYS,
+    )
+    for group in groups:
+        if explicit_setting_keys.intersection(group):
+            for key in group:
+                lower_defaults.pop(key, None)
+    if explicit_setting_keys.intersection(_PREFILL_BACKEND_KEYS):
+        lower_defaults.pop("disable_prefill_cuda_graph", None)
+
+
+def _remove_lower_prefill_settings(values: dict[str, Any]) -> None:
+    _remove_canonical_prefill(values)
+    for key in (
+        *_PREFILL_BACKEND_KEYS,
+        *_PREFILL_TOKEN_BUCKET_KEYS,
+        "cuda_graph_max_bs_prefill",
+        *_PREFILL_COMPILER_KEYS,
+        "disable_prefill_cuda_graph",
+        *_LEGACY_PREFILL_BACKEND_ALIASES,
+    ):
+        values.pop(key, None)
 
 
 def _extract_canonical_prefill_config(

--- a/sglang_omni/scheduling/prefill_cuda_graph_policy.py
+++ b/sglang_omni/scheduling/prefill_cuda_graph_policy.py
@@ -23,6 +23,7 @@ class ResolvedPrefillCudaGraphPolicy:
     buckets: tuple[int, ...]
     requirements: tuple[str, ...]
     reason: str | None
+    compiler: str | None = None
 
 
 def resolve_prefill_cuda_graph_policy(
@@ -31,6 +32,7 @@ def resolve_prefill_cuda_graph_policy(
     capability: PrefillCudaGraphCapability | None,
     requested_backend: str,
     requested_buckets: list[int] | tuple[int, ...] | None,
+    requested_compiler: str | None = None,
     allow_experimental: bool = False,
     allow_performance_unproven: bool = False,
     runtime_requirements: dict[str, bool] | None = None,
@@ -45,6 +47,7 @@ def resolve_prefill_cuda_graph_policy(
             buckets=(),
             requirements=(),
             reason=None,
+            compiler=None,
         )
 
     if capability is None:
@@ -72,6 +75,11 @@ def resolve_prefill_cuda_graph_policy(
         raise ValueError(
             f"{model_name} has not declared Prefill CUDA Graph backend "
             f"{requested_backend!r}; declared backends: {declared}"
+        )
+    if capability.integration == "adapter":
+        raise ValueError(
+            f"{model_name} Prefill CUDA Graph integration requires a concrete "
+            "adapter implementation"
         )
 
     status = backend_capability.status
@@ -120,6 +128,8 @@ def resolve_prefill_cuda_graph_policy(
             "requires at least one bucket"
         )
 
+    compiler = _resolve_compiler(requested_backend, requested_compiler)
+
     return ResolvedPrefillCudaGraphPolicy(
         enabled=True,
         requested_backend=requested_backend,
@@ -129,6 +139,7 @@ def resolve_prefill_cuda_graph_policy(
         buckets=buckets,
         requirements=requirements,
         reason=backend_capability.reason,
+        compiler=compiler,
     )
 
 
@@ -138,11 +149,27 @@ def prefill_cuda_graph_server_args(
     if not policy.enabled:
         return {"cuda_graph_backend_prefill": "disabled"}
 
-    return {
+    server_args: dict[str, object] = {
         "cuda_graph_backend_prefill": policy.resolved_backend,
         "cuda_graph_bs_prefill": list(policy.buckets),
         "cuda_graph_max_bs_prefill": max(policy.buckets),
     }
+    if policy.compiler is not None:
+        server_args["cuda_graph_tc_compiler"] = policy.compiler
+    return server_args
+
+
+def _resolve_compiler(backend: str, requested_compiler: str | None) -> str | None:
+    if backend != "tc_piecewise":
+        if requested_compiler is not None:
+            raise ValueError(
+                "Prefill CUDA Graph compiler can only be set for tc_piecewise"
+            )
+        return None
+    compiler = requested_compiler or "eager"
+    if compiler not in ("eager", "inductor"):
+        raise ValueError("Prefill CUDA Graph compiler must be 'eager' or 'inductor'")
+    return compiler
 
 
 def _validate_buckets(

--- a/sglang_omni/scheduling/prefill_cuda_graph_policy.py
+++ b/sglang_omni/scheduling/prefill_cuda_graph_policy.py
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Shared policy resolution for SGLang Prefill CUDA Graphs."""
+"""Shared policy resolution for SGLang Prefill CUDA Graphs.
+
+Invalid explicit startup configuration fails here. Runtime replay eligibility,
+including eager fallback beyond captured token buckets, remains owned by SGLang.
+Capability metadata never selects a backend automatically; models remain eager
+unless a builder or operator explicitly requests a backend.
+"""
 
 from __future__ import annotations
 
@@ -20,7 +26,7 @@ class ResolvedPrefillCudaGraphPolicy:
     resolved_backend: PrefillCudaGraphBackend | None
     integration: PrefillCudaGraphIntegration | None
     status: PrefillCudaGraphStatus | None
-    buckets: tuple[int, ...]
+    token_buckets: tuple[int, ...]
     requirements: tuple[str, ...]
     reason: str | None
     compiler: str | None = None
@@ -31,7 +37,7 @@ def resolve_prefill_cuda_graph_policy(
     model_name: str,
     capability: PrefillCudaGraphCapability | None,
     requested_backend: str,
-    requested_buckets: list[int] | tuple[int, ...] | None,
+    requested_token_buckets: list[int] | tuple[int, ...] | None,
     requested_compiler: str | None = None,
     allow_experimental: bool = False,
     allow_performance_unproven: bool = False,
@@ -44,7 +50,7 @@ def resolve_prefill_cuda_graph_policy(
             resolved_backend=None,
             integration=None,
             status=None,
-            buckets=(),
+            token_buckets=(),
             requirements=(),
             reason=None,
             compiler=None,
@@ -117,15 +123,15 @@ def resolve_prefill_cuda_graph_policy(
             f"unmet runtime requirements: {', '.join(unmet_requirements)}"
         )
 
-    buckets = _validate_buckets(
-        requested_buckets
-        if requested_buckets is not None
-        else backend_capability.default_buckets
+    token_buckets = _validate_token_buckets(
+        requested_token_buckets
+        if requested_token_buckets is not None
+        else backend_capability.default_token_buckets
     )
-    if not buckets:
+    if not token_buckets:
         raise ValueError(
             f"{model_name} Prefill CUDA Graph backend {requested_backend!r} "
-            "requires at least one bucket"
+            "requires at least one token bucket"
         )
 
     compiler = _resolve_compiler(requested_backend, requested_compiler)
@@ -136,7 +142,7 @@ def resolve_prefill_cuda_graph_policy(
         resolved_backend=backend_capability.backend,
         integration=capability.integration,
         status=status,
-        buckets=buckets,
+        token_buckets=token_buckets,
         requirements=requirements,
         reason=backend_capability.reason,
         compiler=compiler,
@@ -151,8 +157,8 @@ def prefill_cuda_graph_server_args(
 
     server_args: dict[str, object] = {
         "cuda_graph_backend_prefill": policy.resolved_backend,
-        "cuda_graph_bs_prefill": list(policy.buckets),
-        "cuda_graph_max_bs_prefill": max(policy.buckets),
+        "cuda_graph_bs_prefill": list(policy.token_buckets),
+        "cuda_graph_max_bs_prefill": max(policy.token_buckets),
     }
     if policy.compiler is not None:
         server_args["cuda_graph_tc_compiler"] = policy.compiler
@@ -172,23 +178,24 @@ def _resolve_compiler(backend: str, requested_compiler: str | None) -> str | Non
     return compiler
 
 
-def _validate_buckets(
-    buckets: list[int] | tuple[int, ...],
+def _validate_token_buckets(
+    token_buckets: list[int] | tuple[int, ...],
 ) -> tuple[int, ...]:
-    if not isinstance(buckets, (list, tuple)):
-        raise ValueError("Prefill CUDA Graph buckets must be a list or tuple")
+    if not isinstance(token_buckets, (list, tuple)):
+        raise ValueError("Prefill CUDA Graph token buckets must be a list or tuple")
     if any(
-        not isinstance(bucket, int) or isinstance(bucket, bool) for bucket in buckets
+        not isinstance(bucket, int) or isinstance(bucket, bool)
+        for bucket in token_buckets
     ):
-        raise ValueError("Prefill CUDA Graph buckets must contain integers")
+        raise ValueError("Prefill CUDA Graph token buckets must contain integers")
 
-    normalized = tuple(buckets)
+    normalized = tuple(token_buckets)
     if any(bucket <= 0 for bucket in normalized):
-        raise ValueError("Prefill CUDA Graph buckets must be positive")
+        raise ValueError("Prefill CUDA Graph token buckets must be positive")
     if len(set(normalized)) != len(normalized):
-        raise ValueError("Prefill CUDA Graph buckets must be unique")
+        raise ValueError("Prefill CUDA Graph token buckets must be unique")
     if any(left >= right for left, right in zip(normalized, normalized[1:])):
-        raise ValueError("Prefill CUDA Graph buckets must be strictly increasing")
+        raise ValueError("Prefill CUDA Graph token buckets must be strictly increasing")
     return normalized
 
 

--- a/sglang_omni/scheduling/prefill_cuda_graph_policy.py
+++ b/sglang_omni/scheduling/prefill_cuda_graph_policy.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared policy resolution for SGLang Prefill CUDA Graphs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sglang_omni.models.model_capabilities import (
+    PrefillCudaGraphBackend,
+    PrefillCudaGraphCapability,
+    PrefillCudaGraphIntegration,
+    PrefillCudaGraphStatus,
+)
+
+
+@dataclass(frozen=True)
+class ResolvedPrefillCudaGraphPolicy:
+    enabled: bool
+    requested_backend: str
+    resolved_backend: PrefillCudaGraphBackend | None
+    integration: PrefillCudaGraphIntegration | None
+    status: PrefillCudaGraphStatus | None
+    buckets: tuple[int, ...]
+    requirements: tuple[str, ...]
+    reason: str | None
+
+
+def resolve_prefill_cuda_graph_policy(
+    *,
+    model_name: str,
+    capability: PrefillCudaGraphCapability | None,
+    requested_backend: str,
+    requested_buckets: list[int] | tuple[int, ...] | None,
+    allow_experimental: bool = False,
+    allow_performance_unproven: bool = False,
+    runtime_requirements: dict[str, bool] | None = None,
+) -> ResolvedPrefillCudaGraphPolicy:
+    if requested_backend == "disabled":
+        return ResolvedPrefillCudaGraphPolicy(
+            enabled=False,
+            requested_backend=requested_backend,
+            resolved_backend=None,
+            integration=None,
+            status=None,
+            buckets=(),
+            requirements=(),
+            reason=None,
+        )
+
+    if capability is None:
+        raise ValueError(
+            f"{model_name} has not declared Prefill CUDA Graph compatibility"
+        )
+    if capability.integration == "incompatible":
+        raise ValueError(
+            f"{model_name} is incompatible with Prefill CUDA Graph: "
+            f"{capability.incompatible_reason}"
+        )
+
+    backend_capability = next(
+        (
+            backend
+            for backend in capability.backends
+            if backend.backend == requested_backend
+        ),
+        None,
+    )
+    if backend_capability is None:
+        declared = ", ".join(backend.backend for backend in capability.backends)
+        if not declared:
+            declared = "none"
+        raise ValueError(
+            f"{model_name} has not declared Prefill CUDA Graph backend "
+            f"{requested_backend!r}; declared backends: {declared}"
+        )
+
+    status = backend_capability.status
+    if status == "experimental" and not allow_experimental:
+        raise ValueError(
+            f"{model_name} Prefill CUDA Graph backend {requested_backend!r} is "
+            "experimental; set allow_experimental=True to enable it"
+        )
+    if status == "performance_unproven" and not allow_performance_unproven:
+        raise ValueError(
+            f"{model_name} Prefill CUDA Graph backend {requested_backend!r} has "
+            "unproven performance; set allow_performance_unproven=True to enable it"
+        )
+    if status == "blocked":
+        raise ValueError(
+            f"{model_name} Prefill CUDA Graph backend {requested_backend!r} is "
+            f"blocked: {backend_capability.reason}"
+        )
+    if status == "unvalidated":
+        raise ValueError(
+            f"{model_name} Prefill CUDA Graph backend {requested_backend!r} is "
+            "unvalidated"
+        )
+
+    requirements = backend_capability.requirements
+    available_requirements = runtime_requirements or {}
+    unmet_requirements = [
+        requirement
+        for requirement in requirements
+        if available_requirements.get(requirement) is not True
+    ]
+    if unmet_requirements:
+        raise ValueError(
+            f"{model_name} Prefill CUDA Graph backend {requested_backend!r} has "
+            f"unmet runtime requirements: {', '.join(unmet_requirements)}"
+        )
+
+    buckets = _validate_buckets(
+        requested_buckets
+        if requested_buckets is not None
+        else backend_capability.default_buckets
+    )
+    if not buckets:
+        raise ValueError(
+            f"{model_name} Prefill CUDA Graph backend {requested_backend!r} "
+            "requires at least one bucket"
+        )
+
+    return ResolvedPrefillCudaGraphPolicy(
+        enabled=True,
+        requested_backend=requested_backend,
+        resolved_backend=backend_capability.backend,
+        integration=capability.integration,
+        status=status,
+        buckets=buckets,
+        requirements=requirements,
+        reason=backend_capability.reason,
+    )
+
+
+def prefill_cuda_graph_server_args(
+    policy: ResolvedPrefillCudaGraphPolicy,
+) -> dict[str, object]:
+    if not policy.enabled:
+        return {"cuda_graph_backend_prefill": "disabled"}
+
+    return {
+        "cuda_graph_backend_prefill": policy.resolved_backend,
+        "cuda_graph_bs_prefill": list(policy.buckets),
+        "cuda_graph_max_bs_prefill": max(policy.buckets),
+    }
+
+
+def _validate_buckets(
+    buckets: list[int] | tuple[int, ...],
+) -> tuple[int, ...]:
+    if not isinstance(buckets, (list, tuple)):
+        raise ValueError("Prefill CUDA Graph buckets must be a list or tuple")
+    if any(
+        not isinstance(bucket, int) or isinstance(bucket, bool) for bucket in buckets
+    ):
+        raise ValueError("Prefill CUDA Graph buckets must contain integers")
+
+    normalized = tuple(buckets)
+    if any(bucket <= 0 for bucket in normalized):
+        raise ValueError("Prefill CUDA Graph buckets must be positive")
+    if len(set(normalized)) != len(normalized):
+        raise ValueError("Prefill CUDA Graph buckets must be unique")
+    if any(left >= right for left, right in zip(normalized, normalized[1:])):
+        raise ValueError("Prefill CUDA Graph buckets must be strictly increasing")
+    return normalized
+
+
+__all__ = [
+    "ResolvedPrefillCudaGraphPolicy",
+    "prefill_cuda_graph_server_args",
+    "resolve_prefill_cuda_graph_policy",
+]

--- a/tests/unit_test/fakes.py
+++ b/tests/unit_test/fakes.py
@@ -32,6 +32,26 @@ class FakeExecutionBridge:
 class FakeServerArgs(SimpleNamespace):
     """ServerArgs double exposing the 0.5.16 override() mutation entry point."""
 
+    def __init__(self, **fields: object) -> None:
+        cuda_graph_config = fields.get("cuda_graph_config")
+        if cuda_graph_config is None:
+            cuda_graph_config = SimpleNamespace()
+            fields["cuda_graph_config"] = cuda_graph_config
+        prefill = getattr(cuda_graph_config, "prefill", None)
+        if prefill is None:
+            prefill = SimpleNamespace()
+            cuda_graph_config.prefill = prefill
+        defaults = {
+            "backend": fields.get("cuda_graph_backend_prefill", "disabled"),
+            "max_bs": fields.get("cuda_graph_max_bs_prefill", 0),
+            "bs": fields.get("cuda_graph_bs_prefill", []),
+            "tc_compiler": fields.get("cuda_graph_tc_compiler", "eager"),
+        }
+        for name, value in defaults.items():
+            if not hasattr(prefill, name):
+                setattr(prefill, name, value)
+        super().__init__(**fields)
+
     def override(self, source: str, **fields: object) -> None:
         del source
         for name, value in fields.items():

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -438,13 +438,13 @@ def _make_higgs_builder(**kwargs):
 def test_higgs_tts_engine_rejects_prefill_graph_override() -> None:
     builder = _make_higgs_builder()
 
-    with pytest.raises(RuntimeError, match="padded prefill changes model outputs"):
-        builder.customize_server_args(
-            SimpleNamespace(
-                cuda_graph_config=SimpleNamespace(
-                    prefill=SimpleNamespace(backend="full")
-                )
-            )
+    with pytest.raises(ValueError, match="padded prefill changes Higgs model outputs"):
+        builder._resolve_prefill_cuda_graph_policy(
+            overrides={
+                "cuda_graph_config": {
+                    "prefill": {"backend": "full", "bs": [64], "max_bs": 64}
+                }
+            }
         )
 
 

--- a/tests/unit_test/models/test_model_capabilities.py
+++ b/tests/unit_test/models/test_model_capabilities.py
@@ -45,6 +45,12 @@ EXPECTED_TTS_CAPABILITIES = {
         supports_streaming_vocoder=True,
         supports_cuda_graph=True,
         supports_torch_compile=True,
+        prefill_cuda_graph=PrefillCudaGraphCapability(
+            integration="incompatible",
+            incompatible_reason=(
+                "padded prefill changes Higgs model outputs; keep prefill eager"
+            ),
+        ),
     ),
     "MossTTSDelayModel": ModelCapabilities(
         supports_reference_audio=True,
@@ -145,11 +151,15 @@ def _capabilities_with_prefill(
     )
 
 
-def test_existing_declarations_do_not_require_prefill_cuda_graph() -> None:
+def test_only_higgs_declares_prefill_cuda_graph_policy() -> None:
     assert all(
         capabilities.prefill_cuda_graph is None
-        for capabilities in EXPECTED_TTS_CAPABILITIES.values()
+        for architecture, capabilities in EXPECTED_TTS_CAPABILITIES.items()
+        if architecture != "HiggsMultimodalQwen3ForConditionalGeneration"
     )
+    higgs = EXPECTED_TTS_CAPABILITIES["HiggsMultimodalQwen3ForConditionalGeneration"]
+    assert higgs.prefill_cuda_graph is not None
+    assert higgs.prefill_cuda_graph.integration == "incompatible"
 
 
 @pytest.mark.parametrize("integration", ["direct", "adapter"])
@@ -159,7 +169,7 @@ def test_model_capabilities_accept_prefill_cuda_graph_integration(
     backend = PrefillCudaGraphBackendCapability(
         backend="breakable",
         status="validated",
-        default_buckets=(32, 64),
+        default_token_buckets=(32, 64),
     )
 
     capabilities = _capabilities_with_prefill(
@@ -209,7 +219,7 @@ def test_model_capabilities_reject_duplicate_prefill_backends() -> None:
     backend = PrefillCudaGraphBackendCapability(
         backend="breakable",
         status="validated",
-        default_buckets=(32,),
+        default_token_buckets=(32,),
     )
 
     with pytest.raises(ValueError, match="duplicate.*backend"):
@@ -256,7 +266,7 @@ def test_model_capabilities_reject_incompatible_backend_declarations() -> None:
                     PrefillCudaGraphBackendCapability(
                         backend="full",
                         status="validated",
-                        default_buckets=(32,),
+                        default_token_buckets=(32,),
                     ),
                 ),
             )
@@ -273,7 +283,7 @@ def test_model_capabilities_reject_incompatible_backend_declarations() -> None:
         ((32, 64.0), "integers"),
     ],
 )
-def test_model_capabilities_reject_invalid_default_buckets(
+def test_model_capabilities_reject_invalid_default_token_buckets(
     buckets: tuple[int, ...],
     error: str,
 ) -> None:
@@ -285,7 +295,7 @@ def test_model_capabilities_reject_invalid_default_buckets(
                     PrefillCudaGraphBackendCapability(
                         backend="breakable",
                         status="validated",
-                        default_buckets=buckets,
+                        default_token_buckets=buckets,
                     ),
                 ),
             )
@@ -296,7 +306,7 @@ def test_model_capabilities_reject_invalid_default_buckets(
     ("status", "reason"),
     [("blocked", "not supported yet"), ("unvalidated", None)],
 )
-def test_non_enableable_prefill_backend_allows_empty_default_buckets(
+def test_non_enableable_prefill_backend_allows_empty_default_token_buckets(
     status: str,
     reason: str | None,
 ) -> None:
@@ -314,7 +324,7 @@ def test_non_enableable_prefill_backend_allows_empty_default_buckets(
     )
 
     assert capabilities.prefill_cuda_graph is not None
-    assert capabilities.prefill_cuda_graph.backends[0].default_buckets == ()
+    assert capabilities.prefill_cuda_graph.backends[0].default_token_buckets == ()
 
 
 @pytest.mark.parametrize("architecture", EXPECTED_TTS_CAPABILITIES)
@@ -326,7 +336,10 @@ def test_tts_model_package_exports_capabilities(architecture: str) -> None:
     assert isinstance(capabilities, ModelCapabilities)
     for field in fields(ModelCapabilities)[:-1]:
         assert isinstance(getattr(capabilities, field.name), bool)
-    assert capabilities.prefill_cuda_graph is None
+    assert (
+        capabilities.prefill_cuda_graph
+        == EXPECTED_TTS_CAPABILITIES[architecture].prefill_cuda_graph
+    )
 
 
 @pytest.mark.parametrize("architecture", EXPECTED_TTS_CAPABILITIES)

--- a/tests/unit_test/models/test_model_capabilities.py
+++ b/tests/unit_test/models/test_model_capabilities.py
@@ -292,6 +292,31 @@ def test_model_capabilities_reject_invalid_default_buckets(
         )
 
 
+@pytest.mark.parametrize(
+    ("status", "reason"),
+    [("blocked", "not supported yet"), ("unvalidated", None)],
+)
+def test_non_enableable_prefill_backend_allows_empty_default_buckets(
+    status: str,
+    reason: str | None,
+) -> None:
+    capabilities = _capabilities_with_prefill(
+        PrefillCudaGraphCapability(
+            integration="direct",
+            backends=(
+                PrefillCudaGraphBackendCapability(
+                    backend="full",
+                    status=status,
+                    reason=reason,
+                ),
+            ),
+        )
+    )
+
+    assert capabilities.prefill_cuda_graph is not None
+    assert capabilities.prefill_cuda_graph.backends[0].default_buckets == ()
+
+
 @pytest.mark.parametrize("architecture", EXPECTED_TTS_CAPABILITIES)
 def test_tts_model_package_exports_capabilities(architecture: str) -> None:
     module = _package_for_architecture(architecture)

--- a/tests/unit_test/models/test_model_capabilities.py
+++ b/tests/unit_test/models/test_model_capabilities.py
@@ -11,6 +11,8 @@ import pytest
 
 from sglang_omni.models.model_capabilities import (
     ModelCapabilities,
+    PrefillCudaGraphBackendCapability,
+    PrefillCudaGraphCapability,
     get_model_capabilities,
 )
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
@@ -113,10 +115,14 @@ def test_required_model_capability_configs_resolve_capabilities() -> None:
 
 
 def test_model_capabilities_are_frozen_and_explicit() -> None:
-    for field in fields(ModelCapabilities):
+    boolean_fields = fields(ModelCapabilities)[:-1]
+    for field in boolean_fields:
         assert field.type in (bool, "bool")
         assert field.default is MISSING
         assert field.default_factory is MISSING
+    prefill_field = fields(ModelCapabilities)[-1]
+    assert prefill_field.name == "prefill_cuda_graph"
+    assert prefill_field.default is None
 
     with pytest.raises(TypeError):
         ModelCapabilities()
@@ -126,6 +132,166 @@ def test_model_capabilities_are_frozen_and_explicit() -> None:
         capabilities.supports_reference_audio = False
 
 
+def _capabilities_with_prefill(
+    capability: PrefillCudaGraphCapability,
+) -> ModelCapabilities:
+    return ModelCapabilities(
+        supports_reference_audio=False,
+        supports_batch_vocoder=False,
+        supports_streaming_vocoder=False,
+        supports_cuda_graph=False,
+        supports_torch_compile=False,
+        prefill_cuda_graph=capability,
+    )
+
+
+def test_existing_declarations_do_not_require_prefill_cuda_graph() -> None:
+    assert all(
+        capabilities.prefill_cuda_graph is None
+        for capabilities in EXPECTED_TTS_CAPABILITIES.values()
+    )
+
+
+@pytest.mark.parametrize("integration", ["direct", "adapter"])
+def test_model_capabilities_accept_prefill_cuda_graph_integration(
+    integration: str,
+) -> None:
+    backend = PrefillCudaGraphBackendCapability(
+        backend="breakable",
+        status="validated",
+        default_buckets=(32, 64),
+    )
+
+    capabilities = _capabilities_with_prefill(
+        PrefillCudaGraphCapability(
+            integration=integration,
+            backends=(backend,),
+            preferred_backend="breakable",
+        )
+    )
+
+    assert capabilities.prefill_cuda_graph is not None
+    assert capabilities.prefill_cuda_graph.integration == integration
+
+
+@pytest.mark.parametrize("integration", ["direct", "adapter"])
+def test_prefill_cuda_graph_integration_does_not_require_backends(
+    integration: str,
+) -> None:
+    capabilities = _capabilities_with_prefill(
+        PrefillCudaGraphCapability(integration=integration)
+    )
+
+    assert capabilities.prefill_cuda_graph is not None
+    assert capabilities.prefill_cuda_graph.backends == ()
+
+
+def test_model_capabilities_accept_incompatible_prefill_cuda_graph() -> None:
+    capabilities = _capabilities_with_prefill(
+        PrefillCudaGraphCapability(
+            integration="incompatible",
+            incompatible_reason="model forward is not graph compatible",
+        )
+    )
+
+    assert capabilities.prefill_cuda_graph is not None
+    assert capabilities.prefill_cuda_graph.incompatible_reason is not None
+
+
+def test_model_capabilities_reject_incompatible_without_reason() -> None:
+    with pytest.raises(ValueError, match="requires incompatible_reason"):
+        _capabilities_with_prefill(
+            PrefillCudaGraphCapability(integration="incompatible")
+        )
+
+
+def test_model_capabilities_reject_duplicate_prefill_backends() -> None:
+    backend = PrefillCudaGraphBackendCapability(
+        backend="breakable",
+        status="validated",
+        default_buckets=(32,),
+    )
+
+    with pytest.raises(ValueError, match="duplicate.*backend"):
+        _capabilities_with_prefill(
+            PrefillCudaGraphCapability(
+                integration="direct",
+                backends=(backend, backend),
+            )
+        )
+
+
+def test_model_capabilities_reject_invalid_preferred_backend() -> None:
+    with pytest.raises(ValueError, match="preferred.*present"):
+        _capabilities_with_prefill(
+            PrefillCudaGraphCapability(
+                integration="adapter",
+                preferred_backend="breakable",
+            )
+        )
+
+
+def test_model_capabilities_reject_blocked_backend_without_reason() -> None:
+    with pytest.raises(ValueError, match="blocked.*requires a reason"):
+        _capabilities_with_prefill(
+            PrefillCudaGraphCapability(
+                integration="direct",
+                backends=(
+                    PrefillCudaGraphBackendCapability(
+                        backend="full",
+                        status="blocked",
+                    ),
+                ),
+            )
+        )
+
+
+def test_model_capabilities_reject_incompatible_backend_declarations() -> None:
+    with pytest.raises(ValueError, match="incompatible.*cannot declare backends"):
+        _capabilities_with_prefill(
+            PrefillCudaGraphCapability(
+                integration="incompatible",
+                incompatible_reason="unsupported forward",
+                backends=(
+                    PrefillCudaGraphBackendCapability(
+                        backend="full",
+                        status="validated",
+                        default_buckets=(32,),
+                    ),
+                ),
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("buckets", "error"),
+    [
+        ((), "must not be empty"),
+        ((0,), "positive"),
+        ((32, 16), "strictly increasing"),
+        ((32, 32), "unique"),
+        ((32, 64.0), "integers"),
+    ],
+)
+def test_model_capabilities_reject_invalid_default_buckets(
+    buckets: tuple[int, ...],
+    error: str,
+) -> None:
+    with pytest.raises(ValueError, match=error):
+        _capabilities_with_prefill(
+            PrefillCudaGraphCapability(
+                integration="direct",
+                backends=(
+                    PrefillCudaGraphBackendCapability(
+                        backend="breakable",
+                        status="validated",
+                        default_buckets=buckets,
+                    ),
+                ),
+            )
+        )
+
+
 @pytest.mark.parametrize("architecture", EXPECTED_TTS_CAPABILITIES)
 def test_tts_model_package_exports_capabilities(architecture: str) -> None:
     module = _package_for_architecture(architecture)
@@ -133,8 +299,9 @@ def test_tts_model_package_exports_capabilities(architecture: str) -> None:
 
     assert capabilities == EXPECTED_TTS_CAPABILITIES[architecture]
     assert isinstance(capabilities, ModelCapabilities)
-    for field in fields(ModelCapabilities):
+    for field in fields(ModelCapabilities)[:-1]:
         assert isinstance(getattr(capabilities, field.name), bool)
+    assert capabilities.prefill_cuda_graph is None
 
 
 @pytest.mark.parametrize("architecture", EXPECTED_TTS_CAPABILITIES)

--- a/tests/unit_test/scheduling/test_engine_factory.py
+++ b/tests/unit_test/scheduling/test_engine_factory.py
@@ -126,7 +126,13 @@ def test_tts_engine_builder_phase_order_and_override_contract(monkeypatch) -> No
                 decode=SimpleNamespace(
                     max_bs=kwargs["cuda_graph_max_bs"],
                     bs=kwargs["cuda_graph_bs"],
-                )
+                ),
+                prefill=SimpleNamespace(
+                    backend=kwargs["cuda_graph_backend_prefill"],
+                    max_bs=0,
+                    bs=[],
+                    tc_compiler="eager",
+                ),
             ),
             disable_cuda_graph=kwargs["disable_cuda_graph"],
             enable_torch_compile=kwargs["enable_torch_compile"],
@@ -210,9 +216,14 @@ def test_tts_engine_builder_phase_order_and_override_contract(monkeypatch) -> No
             events.append("adjust_overrides")
             assert overrides["mem_fraction_static"] == 0.7
 
-        def _log_prefill_cuda_graph_policy(self, policy: Any) -> None:
+        def _validate_and_log_prefill_cuda_graph_policy(
+            self,
+            policy: Any,
+            server_args: Any,
+        ) -> None:
             events.append("prefill_policy")
             assert policy.enabled is False
+            assert server_args.cuda_graph_config.prefill.backend == "disabled"
 
         def customize_server_args(self, server_args: Any) -> None:
             events.append("customize_server_args")
@@ -313,9 +324,9 @@ def test_tts_engine_builder_phase_order_and_override_contract(monkeypatch) -> No
         "pre_infra_setup",
         "generation_defaults",
         "adjust_overrides",
-        "prefill_policy",
         "build_server_args",
         "customize_server_args",
+        "prefill_policy",
         "infrastructure",
         "setup_model",
         "get_model_buffer_bs",
@@ -361,7 +372,16 @@ def test_asr_engine_builder_phase_order_and_failure_cleanup(monkeypatch) -> None
     def fake_server_args(*args: Any, **kwargs: Any) -> Any:
         del args, kwargs
         events.append("server_args")
-        return SimpleNamespace()
+        return SimpleNamespace(
+            cuda_graph_config=SimpleNamespace(
+                prefill=SimpleNamespace(
+                    backend="disabled",
+                    max_bs=0,
+                    bs=[],
+                    tc_compiler="eager",
+                )
+            )
+        )
 
     def fake_validate(**kwargs: Any) -> None:
         assert kwargs["model_name"] == "Test ASR"
@@ -597,13 +617,13 @@ def test_prefill_cuda_graph_defaults_disabled_without_capability_lookup(
 
     policy = builder._resolve_prefill_cuda_graph_policy(
         overrides=overrides,
-        server_args_overrides=None,
     )
 
     assert policy.enabled is False
     assert overrides == {
         "cuda_graph_bs": [1, 4],
         "cuda_graph_max_bs": 4,
+        "cuda_graph_backend_prefill": "disabled",
     }
 
 
@@ -613,11 +633,10 @@ def test_prefill_cuda_graph_explicit_disabled_override() -> None:
 
     policy = builder._resolve_prefill_cuda_graph_policy(
         overrides=overrides,
-        server_args_overrides={"cuda_graph_backend_prefill": "disabled"},
     )
 
     assert policy.enabled is False
-    assert overrides == {}
+    assert overrides == {"cuda_graph_backend_prefill": "disabled"}
 
 
 def test_prefill_cuda_graph_synthetic_validated_capability_resolves() -> None:
@@ -644,38 +663,72 @@ def test_prefill_cuda_graph_synthetic_validated_capability_resolves() -> None:
 
     policy = builder._resolve_prefill_cuda_graph_policy(
         overrides=overrides,
-        server_args_overrides={
-            "cuda_graph_backend_prefill": "breakable",
-            "cuda_graph_bs_prefill": [16, 32],
-        },
     )
 
     assert policy.enabled is True
     assert policy.buckets == (16, 32)
-    assert overrides == {}
+    assert overrides == {
+        "cuda_graph_backend_prefill": "breakable",
+        "cuda_graph_bs_prefill": [16, 32],
+        "cuda_graph_max_bs_prefill": 32,
+    }
 
 
-def test_prefill_cuda_graph_backend_conflict_is_rejected() -> None:
+def test_prefill_cuda_graph_post_adjust_backend_is_authoritative() -> None:
     builder = _make_prefill_policy_builder()
     builder.prefill_cuda_graph_backend = "breakable"
+    overrides = {"cuda_graph_backend_prefill": "disabled"}
 
-    with pytest.raises(ValueError, match="Conflicting.*backend"):
-        builder._resolve_prefill_cuda_graph_policy(
-            overrides={"cuda_graph_backend_prefill": "disabled"},
-            server_args_overrides={"cuda_graph_backend_prefill": "disabled"},
-        )
+    policy = builder._resolve_prefill_cuda_graph_policy(overrides=overrides)
+
+    assert policy.enabled is False
+    assert overrides == {"cuda_graph_backend_prefill": "disabled"}
 
 
-def test_prefill_cuda_graph_bucket_conflict_is_rejected() -> None:
+def test_adjust_overrides_can_disable_requested_prefill() -> None:
+    builder = _make_prefill_policy_builder()
+    overrides = {
+        "cuda_graph_backend_prefill": "breakable",
+        "cuda_graph_bs_prefill": [32],
+    }
+
+    def disable_prefill(adjusted: dict[str, Any]) -> None:
+        adjusted["cuda_graph_backend_prefill"] = "disabled"
+        adjusted.pop("cuda_graph_bs_prefill")
+
+    builder.adjust_overrides = disable_prefill
+    builder.adjust_overrides(overrides)
+    policy = builder._resolve_prefill_cuda_graph_policy(overrides=overrides)
+
+    assert policy.enabled is False
+    assert overrides == {"cuda_graph_backend_prefill": "disabled"}
+
+
+def test_prefill_cuda_graph_post_adjust_buckets_are_authoritative() -> None:
+    from sglang_omni.models.model_capabilities import (
+        PrefillCudaGraphBackendCapability,
+        PrefillCudaGraphCapability,
+    )
+
     builder = _make_prefill_policy_builder()
     builder.prefill_cuda_graph_backend = "breakable"
     builder.prefill_cuda_graph_buckets = (16, 32)
+    builder.prefill_cuda_graph_capability = lambda: PrefillCudaGraphCapability(
+        integration="direct",
+        backends=(
+            PrefillCudaGraphBackendCapability(
+                backend="breakable",
+                status="validated",
+                default_buckets=(16, 32),
+            ),
+        ),
+    )
+    overrides = {"cuda_graph_bs_prefill": [32, 64]}
 
-    with pytest.raises(ValueError, match="Conflicting.*bucket"):
-        builder._resolve_prefill_cuda_graph_policy(
-            overrides={"cuda_graph_bs_prefill": [32, 64]},
-            server_args_overrides={"cuda_graph_bs_prefill": [32, 64]},
-        )
+    policy = builder._resolve_prefill_cuda_graph_policy(overrides=overrides)
+
+    assert policy.buckets == (32, 64)
+    assert overrides["cuda_graph_bs_prefill"] == [32, 64]
 
 
 def test_prefill_cuda_graph_startup_diagnostic(caplog) -> None:
@@ -698,14 +751,178 @@ def test_prefill_cuda_graph_startup_diagnostic(caplog) -> None:
     )
     policy = builder._resolve_prefill_cuda_graph_policy(
         overrides={},
-        server_args_overrides=None,
+    )
+    server_args = SimpleNamespace(
+        cuda_graph_config=SimpleNamespace(
+            prefill=SimpleNamespace(
+                backend="breakable",
+                max_bs=128,
+                bs=[32, 64, 128],
+                tc_compiler="eager",
+            )
+        )
     )
 
     with caplog.at_level("INFO", logger="sglang_omni.scheduling.engine_factory"):
-        builder._log_prefill_cuda_graph_policy(policy)
+        builder._validate_and_log_prefill_cuda_graph_policy(policy, server_args)
 
     assert (
         "Prefill CUDA Graph policy: model=TestModel requested=breakable "
-        "resolved=breakable integration=direct status=validated "
-        "buckets=[32,64,128]" in caplog.text
+        "actual=breakable enabled=true integration=direct status=validated "
+        "buckets=[32, 64, 128] max_bs=128 compiler=eager changed=false "
+        "downgraded=false" in caplog.text
     )
+
+
+def test_canonical_prefill_config_cannot_bypass_capability_gate() -> None:
+    builder = _make_prefill_policy_builder()
+
+    with pytest.raises(ValueError, match="has not declared.*compatibility"):
+        builder._resolve_prefill_cuda_graph_policy(
+            overrides={
+                "cuda_graph_config": {
+                    "prefill": {
+                        "backend": "full",
+                        "bs": [64],
+                        "max_bs": 64,
+                    }
+                }
+            }
+        )
+
+
+def test_canonical_and_convenience_prefill_settings_are_rejected() -> None:
+    builder = _make_prefill_policy_builder()
+
+    with pytest.raises(ValueError, match="cannot be combined"):
+        builder._resolve_prefill_cuda_graph_policy(
+            overrides={
+                "cuda_graph_config": {"prefill": {"backend": "breakable", "bs": [32]}},
+                "cuda_graph_backend_prefill": "breakable",
+            }
+        )
+
+
+def test_canonical_tc_piecewise_config_is_normalized() -> None:
+    from sglang_omni.models.model_capabilities import (
+        PrefillCudaGraphBackendCapability,
+        PrefillCudaGraphCapability,
+    )
+
+    builder = _make_prefill_policy_builder()
+    builder.prefill_cuda_graph_capability = lambda: PrefillCudaGraphCapability(
+        integration="direct",
+        backends=(
+            PrefillCudaGraphBackendCapability(
+                backend="tc_piecewise",
+                status="validated",
+                default_buckets=(16, 32),
+            ),
+        ),
+    )
+    overrides = {
+        "cuda_graph_config": {
+            "decode": {"backend": "full", "bs": [1, 2], "max_bs": 2},
+            "prefill": {
+                "backend": "tc_piecewise",
+                "bs": [16, 32],
+                "max_bs": 32,
+                "tc_compiler": "inductor",
+            },
+        }
+    }
+
+    policy = builder._resolve_prefill_cuda_graph_policy(overrides=overrides)
+
+    assert policy.compiler == "inductor"
+    assert overrides == {
+        "cuda_graph_config": {
+            "decode": {"backend": "full", "bs": [1, 2], "max_bs": 2},
+            "prefill": {
+                "backend": "tc_piecewise",
+                "bs": [16, 32],
+                "max_bs": 32,
+                "tc_compiler": "inductor",
+            },
+        }
+    }
+
+
+def test_prefill_cuda_graph_upstream_downgrade_is_rejected(caplog) -> None:
+    from sglang_omni.models.model_capabilities import (
+        PrefillCudaGraphBackendCapability,
+        PrefillCudaGraphCapability,
+    )
+
+    builder = _make_prefill_policy_builder()
+    builder.prefill_cuda_graph_backend = "breakable"
+    builder.prefill_cuda_graph_capability = lambda: PrefillCudaGraphCapability(
+        integration="direct",
+        backends=(
+            PrefillCudaGraphBackendCapability(
+                backend="breakable",
+                status="validated",
+                default_buckets=(32,),
+            ),
+        ),
+    )
+    policy = builder._resolve_prefill_cuda_graph_policy(overrides={})
+    server_args = SimpleNamespace(
+        cuda_graph_config=SimpleNamespace(
+            prefill=SimpleNamespace(
+                backend="disabled",
+                max_bs=0,
+                bs=[],
+                tc_compiler="eager",
+            )
+        )
+    )
+
+    with caplog.at_level("INFO", logger="sglang_omni.scheduling.engine_factory"):
+        with pytest.raises(ValueError, match="changed by SGLang"):
+            builder._validate_and_log_prefill_cuda_graph_policy(policy, server_args)
+
+    assert "actual=disabled" in caplog.text
+    assert "changed=true downgraded=true" in caplog.text
+
+
+def test_real_server_args_preserves_validated_canonical_prefill_config() -> None:
+    from sglang_omni.models.model_capabilities import (
+        PrefillCudaGraphBackendCapability,
+        PrefillCudaGraphCapability,
+    )
+    from sglang_omni.scheduling.sglang_backend import build_sglang_server_args
+
+    builder = _make_prefill_policy_builder()
+    builder.prefill_cuda_graph_capability = lambda: PrefillCudaGraphCapability(
+        integration="direct",
+        backends=(
+            PrefillCudaGraphBackendCapability(
+                backend="breakable",
+                status="validated",
+                default_buckets=(16, 32),
+            ),
+        ),
+    )
+    overrides = {
+        "cuda_graph_config": {
+            "prefill": {
+                "backend": "breakable",
+                "bs": [16, 32],
+                "max_bs": 32,
+            }
+        }
+    }
+    policy = builder._resolve_prefill_cuda_graph_policy(overrides=overrides)
+
+    server_args = build_sglang_server_args(
+        "dummy",
+        context_length=128,
+        **overrides,
+    )
+    actual = server_args.cuda_graph_config.prefill
+
+    assert actual.backend == "breakable"
+    assert actual.bs == [16, 32]
+    assert actual.max_bs == 32
+    builder._validate_and_log_prefill_cuda_graph_policy(policy, server_args)

--- a/tests/unit_test/scheduling/test_engine_factory.py
+++ b/tests/unit_test/scheduling/test_engine_factory.py
@@ -639,6 +639,15 @@ def test_prefill_cuda_graph_explicit_disabled_override() -> None:
     assert overrides == {"cuda_graph_backend_prefill": "disabled"}
 
 
+def test_builder_disabled_backend_and_token_buckets_are_rejected() -> None:
+    builder = _make_prefill_policy_builder()
+    builder.prefill_cuda_graph_backend = "disabled"
+    builder.prefill_cuda_graph_token_buckets = (16,)
+
+    with pytest.raises(ValueError, match="token buckets cannot be set"):
+        builder._resolve_prefill_cuda_graph_policy(overrides={})
+
+
 def test_prefill_cuda_graph_synthetic_validated_capability_resolves() -> None:
     from sglang_omni.models.model_capabilities import (
         PrefillCudaGraphBackendCapability,
@@ -652,7 +661,7 @@ def test_prefill_cuda_graph_synthetic_validated_capability_resolves() -> None:
             PrefillCudaGraphBackendCapability(
                 backend="breakable",
                 status="validated",
-                default_buckets=(32, 64, 128),
+                default_token_buckets=(32, 64, 128),
             ),
         ),
     )
@@ -666,7 +675,7 @@ def test_prefill_cuda_graph_synthetic_validated_capability_resolves() -> None:
     )
 
     assert policy.enabled is True
-    assert policy.buckets == (16, 32)
+    assert policy.token_buckets == (16, 32)
     assert overrides == {
         "cuda_graph_backend_prefill": "breakable",
         "cuda_graph_bs_prefill": [16, 32],
@@ -677,12 +686,131 @@ def test_prefill_cuda_graph_synthetic_validated_capability_resolves() -> None:
 def test_prefill_cuda_graph_post_adjust_backend_is_authoritative() -> None:
     builder = _make_prefill_policy_builder()
     builder.prefill_cuda_graph_backend = "breakable"
+    builder.prefill_cuda_graph_token_buckets = (16, 32)
+    builder.prefill_cuda_graph_compiler = "inductor"
     overrides = {"cuda_graph_backend_prefill": "disabled"}
 
     policy = builder._resolve_prefill_cuda_graph_policy(overrides=overrides)
 
     assert policy.enabled is False
     assert overrides == {"cuda_graph_backend_prefill": "disabled"}
+
+
+@pytest.mark.parametrize(
+    "disable_override",
+    [
+        {"cuda_graph_backend_prefill": "disabled"},
+        {"disable_prefill_cuda_graph": True},
+        {"disable_cuda_graph": True},
+        {"disable_piecewise_cuda_graph": True},
+    ],
+)
+def test_higher_tier_disable_clears_lower_prefill_settings(
+    disable_override: dict[str, Any],
+) -> None:
+    from sglang_omni.scheduling import engine_factory
+
+    lower_defaults = {
+        "cuda_graph_backend_prefill": "tc_piecewise",
+        "cuda_graph_bs_prefill": [16, 32],
+        "cuda_graph_max_bs_prefill": 32,
+        "cuda_graph_tc_compiler": "inductor",
+    }
+    explicit_overrides = dict(disable_override)
+
+    engine_factory._normalize_prefill_override_precedence(
+        lower_defaults=lower_defaults,
+        explicit_overrides=explicit_overrides,
+    )
+    overrides = {**lower_defaults, **explicit_overrides}
+    policy = _make_prefill_policy_builder()._resolve_prefill_cuda_graph_policy(
+        overrides=overrides
+    )
+
+    assert policy.enabled is False
+    assert overrides["cuda_graph_backend_prefill"] == "disabled"
+    assert "cuda_graph_bs_prefill" not in overrides
+    assert "cuda_graph_max_bs_prefill" not in overrides
+    assert "cuda_graph_tc_compiler" not in overrides
+    assert "disable_prefill_cuda_graph" not in overrides
+
+
+def test_same_tier_disable_and_token_buckets_are_rejected() -> None:
+    from sglang_omni.scheduling import engine_factory
+
+    with pytest.raises(ValueError, match="same override tier"):
+        engine_factory._normalize_prefill_override_precedence(
+            lower_defaults={},
+            explicit_overrides={
+                "disable_prefill_cuda_graph": True,
+                "cuda_graph_bs_prefill": [16],
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    ("legacy_alias", "backend"),
+    [
+        ("enable_breakable_cuda_graph", "breakable"),
+        ("disable_piecewise_cuda_graph", "disabled"),
+        ("enforce_piecewise_cuda_graph", "tc_piecewise"),
+    ],
+)
+def test_legacy_prefill_backend_aliases_are_normalized(
+    legacy_alias: str,
+    backend: str,
+) -> None:
+    from sglang_omni.scheduling import engine_factory
+
+    explicit_overrides = {legacy_alias: True}
+    engine_factory._normalize_prefill_override_precedence(
+        lower_defaults={},
+        explicit_overrides=explicit_overrides,
+    )
+
+    assert explicit_overrides == {"cuda_graph_backend_prefill": backend}
+
+
+def test_explicit_backend_removes_lower_canonical_prefill_config() -> None:
+    from sglang_omni.scheduling import engine_factory
+
+    lower_defaults = {
+        "cuda_graph_config": {
+            "decode": {"backend": "full"},
+            "prefill": {"backend": "full", "bs": [64], "max_bs": 64},
+        }
+    }
+
+    engine_factory._normalize_prefill_override_precedence(
+        lower_defaults=lower_defaults,
+        explicit_overrides={"cuda_graph_backend_prefill": "disabled"},
+    )
+
+    assert lower_defaults == {"cuda_graph_config": {"decode": {"backend": "full"}}}
+
+
+def test_explicit_canonical_disable_clears_lower_prefill_settings() -> None:
+    from sglang_omni.scheduling import engine_factory
+
+    lower_defaults = {
+        "cuda_graph_backend_prefill": "tc_piecewise",
+        "cuda_graph_bs_prefill": [16, 32],
+        "cuda_graph_max_bs_prefill": 32,
+        "cuda_graph_tc_compiler": "inductor",
+    }
+    explicit_overrides = {"cuda_graph_config": {"prefill": {"backend": "disabled"}}}
+
+    engine_factory._normalize_prefill_override_precedence(
+        lower_defaults=lower_defaults,
+        explicit_overrides=explicit_overrides,
+    )
+    overrides = {**lower_defaults, **explicit_overrides}
+    policy = _make_prefill_policy_builder()._resolve_prefill_cuda_graph_policy(
+        overrides=overrides
+    )
+
+    assert policy.enabled is False
+    assert overrides == explicit_overrides
 
 
 def test_adjust_overrides_can_disable_requested_prefill() -> None:
@@ -704,7 +832,7 @@ def test_adjust_overrides_can_disable_requested_prefill() -> None:
     assert overrides == {"cuda_graph_backend_prefill": "disabled"}
 
 
-def test_prefill_cuda_graph_post_adjust_buckets_are_authoritative() -> None:
+def test_prefill_cuda_graph_post_adjust_token_buckets_are_authoritative() -> None:
     from sglang_omni.models.model_capabilities import (
         PrefillCudaGraphBackendCapability,
         PrefillCudaGraphCapability,
@@ -712,14 +840,14 @@ def test_prefill_cuda_graph_post_adjust_buckets_are_authoritative() -> None:
 
     builder = _make_prefill_policy_builder()
     builder.prefill_cuda_graph_backend = "breakable"
-    builder.prefill_cuda_graph_buckets = (16, 32)
+    builder.prefill_cuda_graph_token_buckets = (16, 32)
     builder.prefill_cuda_graph_capability = lambda: PrefillCudaGraphCapability(
         integration="direct",
         backends=(
             PrefillCudaGraphBackendCapability(
                 backend="breakable",
                 status="validated",
-                default_buckets=(16, 32),
+                default_token_buckets=(16, 32),
             ),
         ),
     )
@@ -727,7 +855,7 @@ def test_prefill_cuda_graph_post_adjust_buckets_are_authoritative() -> None:
 
     policy = builder._resolve_prefill_cuda_graph_policy(overrides=overrides)
 
-    assert policy.buckets == (32, 64)
+    assert policy.token_buckets == (32, 64)
     assert overrides["cuda_graph_bs_prefill"] == [32, 64]
 
 
@@ -745,7 +873,7 @@ def test_prefill_cuda_graph_startup_diagnostic(caplog) -> None:
             PrefillCudaGraphBackendCapability(
                 backend="breakable",
                 status="validated",
-                default_buckets=(32, 64, 128),
+                default_token_buckets=(32, 64, 128),
             ),
         ),
     )
@@ -769,7 +897,7 @@ def test_prefill_cuda_graph_startup_diagnostic(caplog) -> None:
     assert (
         "Prefill CUDA Graph policy: model=TestModel requested=breakable "
         "actual=breakable enabled=true integration=direct status=validated "
-        "buckets=[32, 64, 128] max_bs=128 compiler=eager changed=false "
+        "token_buckets=[32, 64, 128] max_bs=128 compiler=eager changed=false "
         "downgraded=false" in caplog.text
     )
 
@@ -816,7 +944,7 @@ def test_canonical_tc_piecewise_config_is_normalized() -> None:
             PrefillCudaGraphBackendCapability(
                 backend="tc_piecewise",
                 status="validated",
-                default_buckets=(16, 32),
+                default_token_buckets=(16, 32),
             ),
         ),
     )
@@ -862,7 +990,7 @@ def test_prefill_cuda_graph_upstream_downgrade_is_rejected(caplog) -> None:
             PrefillCudaGraphBackendCapability(
                 backend="breakable",
                 status="validated",
-                default_buckets=(32,),
+                default_token_buckets=(32,),
             ),
         ),
     )
@@ -900,7 +1028,7 @@ def test_real_server_args_preserves_validated_canonical_prefill_config() -> None
             PrefillCudaGraphBackendCapability(
                 backend="breakable",
                 status="validated",
-                default_buckets=(16, 32),
+                default_token_buckets=(16, 32),
             ),
         ),
     )

--- a/tests/unit_test/scheduling/test_engine_factory.py
+++ b/tests/unit_test/scheduling/test_engine_factory.py
@@ -210,6 +210,10 @@ def test_tts_engine_builder_phase_order_and_override_contract(monkeypatch) -> No
             events.append("adjust_overrides")
             assert overrides["mem_fraction_static"] == 0.7
 
+        def _log_prefill_cuda_graph_policy(self, policy: Any) -> None:
+            events.append("prefill_policy")
+            assert policy.enabled is False
+
         def customize_server_args(self, server_args: Any) -> None:
             events.append("customize_server_args")
             assert server_args.context_length == 123
@@ -309,6 +313,7 @@ def test_tts_engine_builder_phase_order_and_override_contract(monkeypatch) -> No
         "pre_infra_setup",
         "generation_defaults",
         "adjust_overrides",
+        "prefill_policy",
         "build_server_args",
         "customize_server_args",
         "infrastructure",
@@ -328,6 +333,7 @@ def test_tts_engine_builder_phase_order_and_override_contract(monkeypatch) -> No
     assert build_kwargs["torch_compile_max_bs"] == 8
     assert build_kwargs["mem_fraction_static"] == 0.7
     assert build_kwargs["max_total_tokens"] == TEST_MAX_TOTAL_TOKENS
+    assert build_kwargs["cuda_graph_backend_prefill"] == "disabled"
     assert infrastructure_saw_graph_disabled == [True]
     assert init_graph_calls == [True]
     assert scheduler.kwargs["server_args"].disable_cuda_graph is False
@@ -553,3 +559,153 @@ def test_tts_engine_builder_base_scheduler_preserves_abort_with_extra_kwargs(
     assert captured_kwargs["tp_worker"] == "worker"
     assert captured_kwargs["request_builder"] == "request_builder"
     assert captured_kwargs["result_adapter"] == "result_adapter"
+
+
+def _make_prefill_policy_builder():
+    from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
+
+    class PolicyBuilder(AsrEngineBuilder):
+        model_name = "TestModel"
+        context_length = 128
+        model_arch_override = "TestArch"
+
+        def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
+            del dtype
+            return {"max_running_requests": 4}
+
+        def make_adapters(self, model: Any) -> tuple[Any, Any]:
+            del model
+            return object(), object()
+
+    return PolicyBuilder()
+
+
+def test_prefill_cuda_graph_defaults_disabled_without_capability_lookup(
+    monkeypatch,
+) -> None:
+    from sglang_omni.scheduling import engine_factory
+
+    def fail_lookup(_architecture: str) -> None:
+        raise AssertionError("disabled policy must not load capabilities")
+
+    monkeypatch.setattr(engine_factory, "get_model_capabilities", fail_lookup)
+    builder = _make_prefill_policy_builder()
+    overrides = {
+        "cuda_graph_bs": [1, 4],
+        "cuda_graph_max_bs": 4,
+    }
+
+    policy = builder._resolve_prefill_cuda_graph_policy(
+        overrides=overrides,
+        server_args_overrides=None,
+    )
+
+    assert policy.enabled is False
+    assert overrides == {
+        "cuda_graph_bs": [1, 4],
+        "cuda_graph_max_bs": 4,
+    }
+
+
+def test_prefill_cuda_graph_explicit_disabled_override() -> None:
+    builder = _make_prefill_policy_builder()
+    overrides = {"cuda_graph_backend_prefill": "disabled"}
+
+    policy = builder._resolve_prefill_cuda_graph_policy(
+        overrides=overrides,
+        server_args_overrides={"cuda_graph_backend_prefill": "disabled"},
+    )
+
+    assert policy.enabled is False
+    assert overrides == {}
+
+
+def test_prefill_cuda_graph_synthetic_validated_capability_resolves() -> None:
+    from sglang_omni.models.model_capabilities import (
+        PrefillCudaGraphBackendCapability,
+        PrefillCudaGraphCapability,
+    )
+
+    builder = _make_prefill_policy_builder()
+    builder.prefill_cuda_graph_capability = lambda: PrefillCudaGraphCapability(
+        integration="direct",
+        backends=(
+            PrefillCudaGraphBackendCapability(
+                backend="breakable",
+                status="validated",
+                default_buckets=(32, 64, 128),
+            ),
+        ),
+    )
+    overrides = {
+        "cuda_graph_backend_prefill": "breakable",
+        "cuda_graph_bs_prefill": [16, 32],
+    }
+
+    policy = builder._resolve_prefill_cuda_graph_policy(
+        overrides=overrides,
+        server_args_overrides={
+            "cuda_graph_backend_prefill": "breakable",
+            "cuda_graph_bs_prefill": [16, 32],
+        },
+    )
+
+    assert policy.enabled is True
+    assert policy.buckets == (16, 32)
+    assert overrides == {}
+
+
+def test_prefill_cuda_graph_backend_conflict_is_rejected() -> None:
+    builder = _make_prefill_policy_builder()
+    builder.prefill_cuda_graph_backend = "breakable"
+
+    with pytest.raises(ValueError, match="Conflicting.*backend"):
+        builder._resolve_prefill_cuda_graph_policy(
+            overrides={"cuda_graph_backend_prefill": "disabled"},
+            server_args_overrides={"cuda_graph_backend_prefill": "disabled"},
+        )
+
+
+def test_prefill_cuda_graph_bucket_conflict_is_rejected() -> None:
+    builder = _make_prefill_policy_builder()
+    builder.prefill_cuda_graph_backend = "breakable"
+    builder.prefill_cuda_graph_buckets = (16, 32)
+
+    with pytest.raises(ValueError, match="Conflicting.*bucket"):
+        builder._resolve_prefill_cuda_graph_policy(
+            overrides={"cuda_graph_bs_prefill": [32, 64]},
+            server_args_overrides={"cuda_graph_bs_prefill": [32, 64]},
+        )
+
+
+def test_prefill_cuda_graph_startup_diagnostic(caplog) -> None:
+    from sglang_omni.models.model_capabilities import (
+        PrefillCudaGraphBackendCapability,
+        PrefillCudaGraphCapability,
+    )
+
+    builder = _make_prefill_policy_builder()
+    builder.prefill_cuda_graph_backend = "breakable"
+    builder.prefill_cuda_graph_capability = lambda: PrefillCudaGraphCapability(
+        integration="direct",
+        backends=(
+            PrefillCudaGraphBackendCapability(
+                backend="breakable",
+                status="validated",
+                default_buckets=(32, 64, 128),
+            ),
+        ),
+    )
+    policy = builder._resolve_prefill_cuda_graph_policy(
+        overrides={},
+        server_args_overrides=None,
+    )
+
+    with caplog.at_level("INFO", logger="sglang_omni.scheduling.engine_factory"):
+        builder._log_prefill_cuda_graph_policy(policy)
+
+    assert (
+        "Prefill CUDA Graph policy: model=TestModel requested=breakable "
+        "resolved=breakable integration=direct status=validated "
+        "buckets=[32,64,128]" in caplog.text
+    )

--- a/tests/unit_test/scheduling/test_prefill_cuda_graph_policy.py
+++ b/tests/unit_test/scheduling/test_prefill_cuda_graph_policy.py
@@ -97,6 +97,22 @@ def test_undeclared_backend_lists_declared_backends() -> None:
         _resolve(capability)
 
 
+def test_adapter_integration_requires_concrete_implementation() -> None:
+    capability = PrefillCudaGraphCapability(
+        integration="adapter",
+        backends=(
+            PrefillCudaGraphBackendCapability(
+                backend="breakable",
+                status="validated",
+                default_buckets=(16,),
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="concrete adapter implementation"):
+        _resolve(capability)
+
+
 def test_validated_backend_uses_default_buckets() -> None:
     policy = _resolve(_capability())
 
@@ -212,3 +228,69 @@ def test_server_args_mapping() -> None:
         "cuda_graph_bs_prefill": [32, 64, 128],
         "cuda_graph_max_bs_prefill": 128,
     }
+
+
+@pytest.mark.parametrize("compiler", [None, "eager", "inductor"])
+def test_tc_piecewise_compiler_is_resolved_and_mapped(
+    compiler: str | None,
+) -> None:
+    capability = PrefillCudaGraphCapability(
+        integration="direct",
+        backends=(
+            PrefillCudaGraphBackendCapability(
+                backend="tc_piecewise",
+                status="validated",
+                default_buckets=(16, 32),
+            ),
+        ),
+    )
+
+    policy = resolve_prefill_cuda_graph_policy(
+        model_name="TestModel",
+        capability=capability,
+        requested_backend="tc_piecewise",
+        requested_buckets=None,
+        requested_compiler=compiler,
+    )
+
+    expected_compiler = compiler or "eager"
+    assert policy.compiler == expected_compiler
+    assert prefill_cuda_graph_server_args(policy) == {
+        "cuda_graph_backend_prefill": "tc_piecewise",
+        "cuda_graph_bs_prefill": [16, 32],
+        "cuda_graph_max_bs_prefill": 32,
+        "cuda_graph_tc_compiler": expected_compiler,
+    }
+
+
+def test_compiler_requires_tc_piecewise_backend() -> None:
+    with pytest.raises(ValueError, match="only be set for tc_piecewise"):
+        resolve_prefill_cuda_graph_policy(
+            model_name="TestModel",
+            capability=_capability(),
+            requested_backend="breakable",
+            requested_buckets=None,
+            requested_compiler="inductor",
+        )
+
+
+def test_tc_piecewise_rejects_unknown_compiler() -> None:
+    capability = PrefillCudaGraphCapability(
+        integration="direct",
+        backends=(
+            PrefillCudaGraphBackendCapability(
+                backend="tc_piecewise",
+                status="validated",
+                default_buckets=(16,),
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="must be 'eager' or 'inductor'"):
+        resolve_prefill_cuda_graph_policy(
+            model_name="TestModel",
+            capability=capability,
+            requested_backend="tc_piecewise",
+            requested_buckets=None,
+            requested_compiler="unknown",
+        )

--- a/tests/unit_test/scheduling/test_prefill_cuda_graph_policy.py
+++ b/tests/unit_test/scheduling/test_prefill_cuda_graph_policy.py
@@ -17,7 +17,7 @@ from sglang_omni.scheduling.prefill_cuda_graph_policy import (
 def _capability(
     *,
     status: str = "validated",
-    default_buckets: tuple[int, ...] = (32, 64),
+    default_token_buckets: tuple[int, ...] = (32, 64),
     requirements: tuple[str, ...] = (),
     reason: str | None = None,
 ) -> PrefillCudaGraphCapability:
@@ -27,7 +27,7 @@ def _capability(
             PrefillCudaGraphBackendCapability(
                 backend="breakable",
                 status=status,
-                default_buckets=default_buckets,
+                default_token_buckets=default_token_buckets,
                 requirements=requirements,
                 reason=reason,
             ),
@@ -43,24 +43,24 @@ def _resolve(
         model_name="TestModel",
         capability=capability,
         requested_backend="breakable",
-        requested_buckets=None,
+        requested_token_buckets=None,
         **kwargs,
     )
 
 
-def test_disabled_request_needs_no_declaration_or_valid_buckets() -> None:
+def test_disabled_request_needs_no_declaration_or_valid_token_buckets() -> None:
     policy = resolve_prefill_cuda_graph_policy(
         model_name="TestModel",
         capability=None,
         requested_backend="disabled",
-        requested_buckets=[0, 0],
+        requested_token_buckets=[0, 0],
         runtime_requirements={"missing": False},
     )
 
     assert policy.enabled is False
     assert policy.requested_backend == "disabled"
     assert policy.resolved_backend is None
-    assert policy.buckets == ()
+    assert policy.token_buckets == ()
 
 
 def test_explicit_request_requires_declaration() -> None:
@@ -88,7 +88,7 @@ def test_undeclared_backend_lists_declared_backends() -> None:
             PrefillCudaGraphBackendCapability(
                 backend="full",
                 status="validated",
-                default_buckets=(16,),
+                default_token_buckets=(16,),
             ),
         ),
     )
@@ -104,7 +104,7 @@ def test_adapter_integration_requires_concrete_implementation() -> None:
             PrefillCudaGraphBackendCapability(
                 backend="breakable",
                 status="validated",
-                default_buckets=(16,),
+                default_token_buckets=(16,),
             ),
         ),
     )
@@ -113,14 +113,14 @@ def test_adapter_integration_requires_concrete_implementation() -> None:
         _resolve(capability)
 
 
-def test_validated_backend_uses_default_buckets() -> None:
+def test_validated_backend_uses_default_token_buckets() -> None:
     policy = _resolve(_capability())
 
     assert policy.enabled is True
     assert policy.resolved_backend == "breakable"
     assert policy.integration == "direct"
     assert policy.status == "validated"
-    assert policy.buckets == (32, 64)
+    assert policy.token_buckets == (32, 64)
 
 
 def test_experimental_backend_requires_explicit_allowance() -> None:
@@ -153,20 +153,20 @@ def test_unvalidated_backend_is_rejected() -> None:
         _resolve(_capability(status="unvalidated"))
 
 
-def test_explicit_buckets_override_defaults() -> None:
+def test_explicit_token_buckets_override_defaults() -> None:
     policy = resolve_prefill_cuda_graph_policy(
         model_name="TestModel",
         capability=_capability(),
         requested_backend="breakable",
-        requested_buckets=[8, 16],
+        requested_token_buckets=[8, 16],
     )
 
-    assert policy.buckets == (8, 16)
+    assert policy.token_buckets == (8, 16)
 
 
-def test_enabled_backend_requires_buckets() -> None:
-    with pytest.raises(ValueError, match="at least one bucket"):
-        _resolve(_capability(default_buckets=()))
+def test_enabled_backend_requires_token_buckets() -> None:
+    with pytest.raises(ValueError, match="at least one token bucket"):
+        _resolve(_capability(default_token_buckets=()))
 
 
 @pytest.mark.parametrize(
@@ -178,7 +178,7 @@ def test_enabled_backend_requires_buckets() -> None:
         ([True, 16], "integers"),
     ],
 )
-def test_invalid_explicit_buckets_are_rejected(
+def test_invalid_explicit_token_buckets_are_rejected(
     buckets: list[int],
     error: str,
 ) -> None:
@@ -187,7 +187,7 @@ def test_invalid_explicit_buckets_are_rejected(
             model_name="TestModel",
             capability=_capability(),
             requested_backend="breakable",
-            requested_buckets=buckets,
+            requested_token_buckets=buckets,
         )
 
 
@@ -216,9 +216,9 @@ def test_server_args_mapping() -> None:
         model_name="TestModel",
         capability=None,
         requested_backend="disabled",
-        requested_buckets=None,
+        requested_token_buckets=None,
     )
-    enabled = _resolve(_capability(default_buckets=(32, 64, 128)))
+    enabled = _resolve(_capability(default_token_buckets=(32, 64, 128)))
 
     assert prefill_cuda_graph_server_args(disabled) == {
         "cuda_graph_backend_prefill": "disabled"
@@ -240,7 +240,7 @@ def test_tc_piecewise_compiler_is_resolved_and_mapped(
             PrefillCudaGraphBackendCapability(
                 backend="tc_piecewise",
                 status="validated",
-                default_buckets=(16, 32),
+                default_token_buckets=(16, 32),
             ),
         ),
     )
@@ -249,7 +249,7 @@ def test_tc_piecewise_compiler_is_resolved_and_mapped(
         model_name="TestModel",
         capability=capability,
         requested_backend="tc_piecewise",
-        requested_buckets=None,
+        requested_token_buckets=None,
         requested_compiler=compiler,
     )
 
@@ -269,7 +269,7 @@ def test_compiler_requires_tc_piecewise_backend() -> None:
             model_name="TestModel",
             capability=_capability(),
             requested_backend="breakable",
-            requested_buckets=None,
+            requested_token_buckets=None,
             requested_compiler="inductor",
         )
 
@@ -281,7 +281,7 @@ def test_tc_piecewise_rejects_unknown_compiler() -> None:
             PrefillCudaGraphBackendCapability(
                 backend="tc_piecewise",
                 status="validated",
-                default_buckets=(16,),
+                default_token_buckets=(16,),
             ),
         ),
     )
@@ -291,6 +291,6 @@ def test_tc_piecewise_rejects_unknown_compiler() -> None:
             model_name="TestModel",
             capability=capability,
             requested_backend="tc_piecewise",
-            requested_buckets=None,
+            requested_token_buckets=None,
             requested_compiler="unknown",
         )

--- a/tests/unit_test/scheduling/test_prefill_cuda_graph_policy.py
+++ b/tests/unit_test/scheduling/test_prefill_cuda_graph_policy.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from sglang_omni.models.model_capabilities import (
+    PrefillCudaGraphBackendCapability,
+    PrefillCudaGraphCapability,
+)
+from sglang_omni.scheduling.prefill_cuda_graph_policy import (
+    prefill_cuda_graph_server_args,
+    resolve_prefill_cuda_graph_policy,
+)
+
+
+def _capability(
+    *,
+    status: str = "validated",
+    default_buckets: tuple[int, ...] = (32, 64),
+    requirements: tuple[str, ...] = (),
+    reason: str | None = None,
+) -> PrefillCudaGraphCapability:
+    return PrefillCudaGraphCapability(
+        integration="direct",
+        backends=(
+            PrefillCudaGraphBackendCapability(
+                backend="breakable",
+                status=status,
+                default_buckets=default_buckets,
+                requirements=requirements,
+                reason=reason,
+            ),
+        ),
+    )
+
+
+def _resolve(
+    capability: PrefillCudaGraphCapability | None,
+    **kwargs: object,
+):
+    return resolve_prefill_cuda_graph_policy(
+        model_name="TestModel",
+        capability=capability,
+        requested_backend="breakable",
+        requested_buckets=None,
+        **kwargs,
+    )
+
+
+def test_disabled_request_needs_no_declaration_or_valid_buckets() -> None:
+    policy = resolve_prefill_cuda_graph_policy(
+        model_name="TestModel",
+        capability=None,
+        requested_backend="disabled",
+        requested_buckets=[0, 0],
+        runtime_requirements={"missing": False},
+    )
+
+    assert policy.enabled is False
+    assert policy.requested_backend == "disabled"
+    assert policy.resolved_backend is None
+    assert policy.buckets == ()
+
+
+def test_explicit_request_requires_declaration() -> None:
+    with pytest.raises(
+        ValueError,
+        match="TestModel has not declared Prefill CUDA Graph compatibility",
+    ):
+        _resolve(None)
+
+
+def test_incompatible_model_is_rejected_with_reason() -> None:
+    capability = PrefillCudaGraphCapability(
+        integration="incompatible",
+        incompatible_reason="custom forward cannot be captured",
+    )
+
+    with pytest.raises(ValueError, match="custom forward cannot be captured"):
+        _resolve(capability)
+
+
+def test_undeclared_backend_lists_declared_backends() -> None:
+    capability = PrefillCudaGraphCapability(
+        integration="adapter",
+        backends=(
+            PrefillCudaGraphBackendCapability(
+                backend="full",
+                status="validated",
+                default_buckets=(16,),
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="declared backends: full"):
+        _resolve(capability)
+
+
+def test_validated_backend_uses_default_buckets() -> None:
+    policy = _resolve(_capability())
+
+    assert policy.enabled is True
+    assert policy.resolved_backend == "breakable"
+    assert policy.integration == "direct"
+    assert policy.status == "validated"
+    assert policy.buckets == (32, 64)
+
+
+def test_experimental_backend_requires_explicit_allowance() -> None:
+    capability = _capability(status="experimental")
+
+    with pytest.raises(ValueError, match="experimental"):
+        _resolve(capability)
+
+    assert _resolve(capability, allow_experimental=True).enabled is True
+
+
+def test_performance_unproven_backend_requires_explicit_allowance() -> None:
+    capability = _capability(status="performance_unproven")
+
+    with pytest.raises(ValueError, match="unproven performance"):
+        _resolve(capability)
+
+    assert _resolve(capability, allow_performance_unproven=True).enabled is True
+
+
+def test_blocked_backend_is_rejected_with_reason() -> None:
+    capability = _capability(status="blocked", reason="upstream issue 123")
+
+    with pytest.raises(ValueError, match="upstream issue 123"):
+        _resolve(capability)
+
+
+def test_unvalidated_backend_is_rejected() -> None:
+    with pytest.raises(ValueError, match="unvalidated"):
+        _resolve(_capability(status="unvalidated"))
+
+
+def test_explicit_buckets_override_defaults() -> None:
+    policy = resolve_prefill_cuda_graph_policy(
+        model_name="TestModel",
+        capability=_capability(),
+        requested_backend="breakable",
+        requested_buckets=[8, 16],
+    )
+
+    assert policy.buckets == (8, 16)
+
+
+def test_enabled_backend_requires_buckets() -> None:
+    with pytest.raises(ValueError, match="at least one bucket"):
+        _resolve(_capability(default_buckets=()))
+
+
+@pytest.mark.parametrize(
+    ("buckets", "error"),
+    [
+        ([16, 8], "strictly increasing"),
+        ([16, 16], "unique"),
+        ([0, 16], "positive"),
+        ([True, 16], "integers"),
+    ],
+)
+def test_invalid_explicit_buckets_are_rejected(
+    buckets: list[int],
+    error: str,
+) -> None:
+    with pytest.raises(ValueError, match=error):
+        resolve_prefill_cuda_graph_policy(
+            model_name="TestModel",
+            capability=_capability(),
+            requested_backend="breakable",
+            requested_buckets=buckets,
+        )
+
+
+def test_satisfied_runtime_requirements_are_preserved() -> None:
+    policy = _resolve(
+        _capability(requirements=("static_inputs", "single_rank")),
+        runtime_requirements={"static_inputs": True, "single_rank": True},
+    )
+
+    assert policy.requirements == ("static_inputs", "single_rank")
+
+
+def test_unmet_runtime_requirements_are_listed() -> None:
+    with pytest.raises(
+        ValueError,
+        match="unmet runtime requirements: static_inputs, single_rank",
+    ):
+        _resolve(
+            _capability(requirements=("static_inputs", "single_rank")),
+            runtime_requirements={"static_inputs": False},
+        )
+
+
+def test_server_args_mapping() -> None:
+    disabled = resolve_prefill_cuda_graph_policy(
+        model_name="TestModel",
+        capability=None,
+        requested_backend="disabled",
+        requested_buckets=None,
+    )
+    enabled = _resolve(_capability(default_buckets=(32, 64, 128)))
+
+    assert prefill_cuda_graph_server_args(disabled) == {
+        "cuda_graph_backend_prefill": "disabled"
+    }
+    assert prefill_cuda_graph_server_args(enabled) == {
+        "cuda_graph_backend_prefill": "breakable",
+        "cuda_graph_bs_prefill": [32, 64, 128],
+        "cuda_graph_max_bs_prefill": 128,
+    }


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues

ref #1357

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
