### PR TITLE
[Perf] dots.tts single-request path: async EOS readback, effective-backend logging, benchmark --server-config

### DIFF
--- a/benchmarks/benchmarker/utils.py
+++ b/benchmarks/benchmarker/utils.py
@@ -249,6 +249,7 @@ def managed_omni_server(
     port: int,
     host: str,
     log_file: Path | None,
+    server_config: str | None = None,
     max_running_requests: int | None = None,
     cuda_graph_max_bs: int | None = None,
     mem_fraction_static: float | None = None,
@@ -269,6 +270,8 @@ def managed_omni_server(
         "--host",
         host,
     ]
+    if server_config is not None:
+        cmd.extend(["--config", server_config])
     if max_running_requests is not None:
         cmd.extend(["--max-running-requests", str(max_running_requests)])
     if cuda_graph_max_bs is not None:

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -253,6 +253,10 @@ class TtsSeedttsBenchmarkConfig:
     disable_tqdm: bool = False
     max_running_requests: int = 64
     cuda_graph_max_bs: int = 64
+    # Optional sglang-omni pipeline config yaml forwarded to the managed TTS
+    # server as ``--config`` (e.g. examples/configs/dots_tts.yaml to run the
+    # canonical optimized deployment).
+    server_config: str | None = None
     # Transcribe phase
     lang: str = "en"
     device: str = "cuda:0"
@@ -307,6 +311,7 @@ def _build_results_config(
         "initial_codec_chunk_frames": config.initial_codec_chunk_frames,
         "max_running_requests": config.max_running_requests,
         "cuda_graph_max_bs": config.cuda_graph_max_bs,
+        "server_config": config.server_config,
     }
 
 
@@ -449,6 +454,7 @@ def _config_from_args(args: argparse.Namespace) -> TtsSeedttsBenchmarkConfig:
         disable_tqdm=args.disable_tqdm,
         max_running_requests=args.max_running_requests,
         cuda_graph_max_bs=args.cuda_graph_max_bs,
+        server_config=args.server_config,
         lang=args.lang,
         device=args.device,
         similarity_checkpoint=args.similarity_checkpoint,
@@ -675,6 +681,17 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--server-config",
+        type=str,
+        default=None,
+        help=(
+            "Optional sglang-omni pipeline config yaml passed to the managed "
+            "TTS server as --config (e.g. examples/configs/dots_tts.yaml for "
+            "the canonical optimized dots.tts deployment). Ignored with "
+            "--use-existing-server."
+        ),
+    )
+    parser.add_argument(
         "--skip-gpu-cleanup",
         action="store_true",
         help=(
@@ -769,6 +786,7 @@ def main() -> None:
             model_path=config.model,
             port=config.port,
             host=config.host,
+            server_config=config.server_config,
             max_running_requests=config.max_running_requests,
             cuda_graph_max_bs=config.cuda_graph_max_bs,
             log_file=Path(config.output_dir) / "server_logs" / "tts_server.log",

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -253,9 +253,10 @@ class TtsSeedttsBenchmarkConfig:
     disable_tqdm: bool = False
     max_running_requests: int = 64
     cuda_graph_max_bs: int = 64
-    # Optional sglang-omni pipeline config yaml forwarded to the managed TTS
-    # server as ``--config`` (e.g. examples/configs/dots_tts.yaml to run the
-    # canonical optimized deployment).
+    # note (luojiaxuan): optional sglang-omni pipeline config yaml forwarded
+    # to the managed TTS server as ``--config`` (e.g.
+    # examples/configs/dots_tts.yaml to run the canonical optimized
+    # deployment).
     server_config: str | None = None
     # Transcribe phase
     lang: str = "en"

--- a/sglang_omni/models/dots_tts/engine_builder.py
+++ b/sglang_omni/models/dots_tts/engine_builder.py
@@ -99,6 +99,22 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
                 "max_running_requests=1",
                 max_running_requests,
             )
+        if max_running_requests == 1:
+            tail_backend = (
+                "compiled single-request DiT/semantic encoder"
+                if model.flow.optimize
+                else "eager single-request DiT/semantic encoder"
+            )
+        else:
+            tail_backend = "fused eager batched tail"
+        logger.info(
+            "dots.tts latent engine backend: %s (optimize=%s, "
+            "max_running_requests=%d, num_steps=%d)",
+            tail_backend,
+            self.optimize,
+            max_running_requests,
+            self.num_steps,
+        )
         if max_running_requests > 1:
             model.flow.init_batched_tail(
                 num_slots=max_running_requests,

--- a/sglang_omni/models/dots_tts/flow_head.py
+++ b/sglang_omni/models/dots_tts/flow_head.py
@@ -106,6 +106,8 @@ class DotsTTSFlowHead(nn.Module):
         self._dit_solver: Any = None
         self._tail: Any = None
         self._batched_nfe: int | None = None
+        self._eos_pinned: torch.Tensor | None = None
+        self._eos_event: torch.cuda.Event | None = None
 
     def _bucket(self, requested: int) -> int:
         if requested <= 0:
@@ -501,14 +503,27 @@ class DotsTTSFlowHead(nn.Module):
         should_check_eos = not (
             state.suppress_first_eos_check and state.decoded_patches == 0
         )
-        finished = should_check_eos and bool(
-            (
+        # note (luojiaxuan): compute the EOS flag now but keep it on the GPU;
+        # reading it here would stall the host before any tail work is queued.
+        # The readback happens after the DiT/patch-encoder launches below, via
+        # a pinned staging buffer + event so the copy overlaps the tail kernels
+        # (same idea as the batched path's single deferred readback).
+        eos_hit: torch.Tensor | None = None
+        if should_check_eos:
+            eos_hit = (
                 self.eos_proj(hidden_states)
                 .softmax(dim=-1)[:, -1, 1]
                 .gt(float(eos_threshold))
-                .item()
+                .reshape(())
             )
-        )
+            if eos_hit.is_cuda:
+                if self._eos_pinned is None:
+                    self._eos_pinned = torch.zeros(
+                        (), dtype=torch.bool, pin_memory=True
+                    )
+                    self._eos_event = torch.cuda.Event()
+                self._eos_pinned.copy_(eos_hit, non_blocking=True)
+                self._eos_event.record()
         from dots_tts.modules.backbone.dit_inference import DiTSolverState
 
         if state.dit_state is None:
@@ -547,6 +562,13 @@ class DotsTTSFlowHead(nn.Module):
             bucket_resolver=self._bucket,
             dtype=state.fm_sequence.dtype,
         )
+        if eos_hit is None:
+            finished = False
+        elif eos_hit.is_cuda:
+            self._eos_event.synchronize()
+            finished = bool(self._eos_pinned.item())
+        else:
+            finished = bool(eos_hit.item())
         emit = not state.drop_regenerated_prompt_patch
         state.drop_regenerated_prompt_patch = False
         state.decoded_patches += 1

--- a/sglang_omni/models/dots_tts/stages.py
+++ b/sglang_omni/models/dots_tts/stages.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import math
 import os
 from pathlib import Path
@@ -411,11 +412,17 @@ def create_vocoder_executor(
     **_: Any,
 ) -> DotsTTSStreamingVocoder:
     codec = load_dots_audio_codec(model_path, device=_device(device, gpu_id))
-    return DotsTTSStreamingVocoder(
+    vocoder = DotsTTSStreamingVocoder(
         codec,
         optimize=optimize,
         merge_steps=vocoder_merge_steps,
     )
+    logging.getLogger(__name__).info(
+        "dots.tts vocoder backend: %s (merge_steps=%d)",
+        "compiled streaming chunks" if vocoder.optimize else "eager per-patch decode",
+        vocoder.merge_steps,
+    )
+    return vocoder
 
 
 __all__ = [


### PR DESCRIPTION
## Motivation

Low-hanging items from the dots.tts roadmap #1367 focused on the `max_running_requests=1` (single-request) path.

Two gaps made c=1 numbers look much worse than the merged implementation actually is:

1. `benchmarks.eval.benchmark_tts_seedtts` starts its managed server with `--model-path` only, so the canonical optimized deployment (`examples/configs/dots_tts.yaml`, `optimize: true`) is unreachable from the benchmark: c=1 runs measured the eager DiT/semantic-encoder path with per-patch eager AudioVAE decode (`merge_steps` is forced to 1 when the vocoder is not optimized).
2. The single-request `decode_next` reads the EOS flag with a blocking `.item()` **before** any DiT/semantic-encoder work is queued, so every step pays a host-sync bubble between the backbone forward and the acoustic tail. The batched path already avoids this ("Single readback after the tail work is queued so the sync overlaps it").

## Modifications

- `flow_head.decode_next`: keep the EOS flag on the GPU, stage it through a cached pinned buffer + CUDA event, and read it back only after the DiT + patch-encoder launches are queued. The copy overlaps the tail kernels; numerics are unchanged (same tensor, same threshold, later sync). CPU fallback keeps the direct `.item()` for the unit-test path.
- `engine_builder.setup_model` / `stages.create_vocoder_executor`: log the effective latent-engine and vocoder backend (roadmap: "Log the effective backend selected for every component").
- `benchmark_tts_seedtts` + `managed_omni_server`: new `--server-config` flag forwarded to `sglang_omni.cli serve` as `--config`, so benchmark runs can start the canonical optimized deployment directly. The value is recorded in `speed_results.json`.

## Benchmark

Single H100 (hyper01), Seed-TTS-Eval EN, `--ref-format references`, c=1, `max_running_requests=1`, seed 42, warmup 8, first 64 samples, same card class A/B (eager on one idle GPU, compiled on another; no co-tenant processes on the measured GPUs).

| Server | Latency mean (s) | RTF mean | RTF p50 | RTF p95 |
|---|---:|---:|---:|---:|
| eager (current benchmark default, no config) | 1.882 | 0.4811 | 0.4646 | 0.5711 |
| compiled (`--server-config examples/configs/dots_tts.yaml`, unpatched main) | 1.082 | 0.2796 | 0.2623 | 0.3592 |
| compiled + this PR | **1.051** | **0.2717** | **0.2548** | **0.3509** |

A full-set (1,088-sample) c=1 run of the eager default and of the compiled+patched path is in flight on the same card; final full-set speed + WER numbers will follow as a PR comment.

Repro command after this PR:

```bash
python -m benchmarks.eval.benchmark_tts_seedtts \
  --meta zhaochenyang20/seed-tts-eval-arrow \
  --model dots-studio/dots.tts-mf \
  --server-config examples/configs/dots_tts.yaml \
  --ref-format references \
  --host 127.0.0.1 --port 30190 --lang en \
  --max-concurrency 1 --max-running-requests 1 \
  --warmup 8 --seed 42 \
  --output-dir results/dots-seedtts-en-c1-optimized
```

## Accuracy

Same 64-sample slice, same seed, Qwen3-ASR-1.7B (`--transcribe-only`):

| Server | Corpus WER | >50% WER samples |
|---|---:|---:|
| eager | 1.28% | 0 |
| compiled + this PR | 1.14% | 0 |

The EOS change is numerics-preserving (same tensor, same threshold, later readback); the compiled path itself is the already-merged single-request optimization from #1349, previously unreachable from the managed benchmark server.

## Validation

- `python -m pytest -q tests/unit_test/dots_tts` — 39 passed
- `black --check` on changed files — clean

## Related

- Roadmap #1367 (single-request items); model support #1349.

## Checklist

- [x] Format code with repository hooks.
- [x] Benchmark A/B on the same card class with fixed seed and dataset slice.
