### PR TITLE
[Perf] dots.tts: default optimize=true for the latent engine and vocoder

### DIFF
--- a/sglang_omni/models/dots_tts/engine_builder.py
+++ b/sglang_omni/models/dots_tts/engine_builder.py
@@ -18,7 +18,7 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
     def __init__(
         self,
         *,
-        optimize: bool = False,
+        optimize: bool = True,
         num_steps: int = 4,
         max_audio_patches: int = 500,
         max_running_requests: int = 16,

--- a/sglang_omni/models/dots_tts/stages.py
+++ b/sglang_omni/models/dots_tts/stages.py
@@ -380,7 +380,7 @@ def create_sglang_latent_engine_executor(
     model_path: str,
     *,
     precision: str = "bfloat16",
-    optimize: bool = False,
+    optimize: bool = True,
     max_generate_length: int = 500,
     num_steps: int = 4,
     device: str | None = "cuda",
@@ -407,7 +407,7 @@ def create_vocoder_executor(
     *,
     device: str | None = "cuda",
     gpu_id: int | None = None,
-    optimize: bool = False,
+    optimize: bool = True,
     vocoder_merge_steps: int = 4,
     **_: Any,
 ) -> DotsTTSStreamingVocoder:


### PR DESCRIPTION
## Motivation

Follow-up to #1372, per maintainer discussion on defaults: a validated optimization should be the default, not an opt-in. On current main the bare `--model-path` deployment and the managed benchmark server still run with `optimize=False`, which means:

- at `max_running_requests=1`, the eager DiT/semantic-encoder single-request path instead of the compiled one that #1349 already ships;
- at **every** concurrency, per-patch eager AudioVAE decode — `DotsTTSStreamingVocoder` collapses `merge_steps` to 1 when the vocoder is not optimized, so the #1349 c=16 baseline paid this tax too.

## Modifications

Default `optimize=True` in `DotsTTSEngineBuilder`, `create_sglang_latent_engine_executor`, and `create_vocoder_executor` (3 lines). `optimize: false` in the pipeline config opts out. `examples/configs/dots_tts.yaml` already sets `optimize: true` explicitly and is unchanged.

Startup cost of the new default: at `max_running_requests=1` the single-request DiT compile warms up lazily on the first requests (~2-4 min on H100); at the default `max_running_requests=16` only the vocoder chunks compile, so startup impact is small.

## Measured effect of the optimized path (from #1372, single H100, Seed-TTS-Eval EN full 1,088 samples, c=1, seed 42)

| Path | RTF mean / p50 / p95 | Corpus WER |
|---|---|---:|
| `optimize=False` (old default) | 0.4508 / 0.4462 / 0.4932 | 1.25% |
| `optimize=True` (new default) | 0.2459 / 0.2420 / 0.2785 | 1.31% |

## Related

- Roadmap #1367; #1372 (measurement + `--server-config` plumbing); #1349.

## Checklist

- [x] Format code with repository hooks.
- [x] Same-card full-set A/B with fixed seed (#1372 thread).
