### PR TITLE
[Perf] dots.tts: SGLang backbone decode CUDA graph via a model-owned feedback buffer

### DIFF
--- a/examples/configs/dots_tts.yaml
+++ b/examples/configs/dots_tts.yaml
@@ -8,5 +8,10 @@ runtime_overrides:
     server_args_overrides:
       mem_fraction_static: 0.20
       max_running_requests: 16
+      # note (luojiaxuan): backbone decode runs through the SGLang CUDA graph
+      # with the model-owned feedback buffer; delete these two lines (or set
+      # disable_cuda_graph: true) to fall back to eager backbone decode.
+      disable_cuda_graph: false
+      cuda_graph_max_bs: 16
   vocoder:
     optimize: true

--- a/sglang_omni/models/dots_tts/engine_builder.py
+++ b/sglang_omni/models/dots_tts/engine_builder.py
@@ -78,6 +78,11 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
             raise ValueError(
                 "dots.tts uses its DiT compile path; SGLang backbone compile is disabled"
             )
+        if not bool(overrides.get("disable_cuda_graph", True)):
+            # note (luojiaxuan): the decode graph must be captured with hidden states (FULL);
+            # its can_run gate requires an exact hidden-mode match with the
+            # acoustic tail's per-step request.
+            overrides["enable_return_hidden_states"] = True
 
     def setup_model(
         self,
@@ -91,6 +96,22 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
         del checkpoint_dir, device, gpu_id
         model = model_worker.model_runner.model
         max_running_requests = int(server_args.max_running_requests)
+        if not bool(server_args.disable_cuda_graph):
+            from sglang_omni.scheduling.generation_batch_policy import (
+                get_decode_cuda_graph_max_bs,
+            )
+
+            # note (luojiaxuan): installed before init_cuda_graphs so capture bakes the buffer
+            # address into the decode graph. Generously sized: rows are tiny
+            # (hidden_size elements) and capture may pad above
+            # max_running_requests.
+            model.enable_graph_feedback(
+                max(
+                    max_running_requests,
+                    int(get_decode_cuda_graph_max_bs(server_args) or 0),
+                    256,
+                )
+            )
         model.flow.optimize = self.optimize and max_running_requests == 1
         if self.optimize and max_running_requests > 1:
             logger.info(
@@ -114,6 +135,14 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
             self.optimize,
             max_running_requests,
             self.num_steps,
+        )
+        logger.info(
+            "dots.tts backbone decode: %s",
+            (
+                "SGLang CUDA graph with model-owned feedback buffer"
+                if not bool(server_args.disable_cuda_graph)
+                else "eager"
+            ),
         )
         if max_running_requests > 1:
             model.flow.init_batched_tail(

--- a/sglang_omni/models/dots_tts/model_runner.py
+++ b/sglang_omni/models/dots_tts/model_runner.py
@@ -114,10 +114,18 @@ class DotsTTSModelRunner(ModelRunner):
             if feedback.ndim > 1:
                 feedback = feedback.reshape(-1, feedback.shape[-1])[-1]
             rows.append(feedback)
-        forward_batch.input_embeds = torch.stack(rows).to(
+        stacked = torch.stack(rows).to(
             device=forward_batch.input_ids.device,
             dtype=next(self.model.parameters()).dtype,
         )
+        buffer = self.model.graph_feedback_buffer
+        if buffer is not None:
+            # note (luojiaxuan): row order matches the forward batch; the copy runs on the same
+            # stream as the (graph or eager) forward, so it is ordered ahead
+            # of the launch. forward() reads the buffer for decode directly.
+            buffer[: stacked.shape[0]].copy_(stacked)
+        else:
+            forward_batch.input_embeds = stacked
 
     def requested_capture_hidden_mode_prefill(
         self, schedule_batch: Any, requests: list
@@ -133,6 +141,12 @@ class DotsTTSModelRunner(ModelRunner):
         del schedule_batch, requests
         from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
 
+        # note (luojiaxuan): decode runs one token per request, so FULL and LAST return the same
+        # rows. The decode CUDA graph is captured with FULL (via
+        # enable_return_hidden_states) and its can_run gate requires an exact
+        # hidden-mode match, so request FULL whenever the graph path is on.
+        if self.model.graph_feedback_buffer is not None:
+            return CaptureHiddenMode.FULL
         return CaptureHiddenMode.LAST
 
     def post_prefill(

--- a/sglang_omni/models/dots_tts/sglang_model.py
+++ b/sglang_omni/models/dots_tts/sglang_model.py
@@ -19,6 +19,10 @@ from sglang_omni.models.weight_loader import default_weight_loader
 class DotsTTSSGLangModel(nn.Module):
     """Keep AR execution in SGLang; add only dots-specific model operators."""
 
+    # note (luojiaxuan): class-level default so partially-constructed instances (tests build via
+    # __new__) resolve the graph-feedback probe to "disabled".
+    _graph_feedback_buffer: torch.Tensor | None = None
+
     def __init__(self, config: Any, quant_config: Any = None, prefix: str = "") -> None:
         super().__init__()
         self.config = config
@@ -40,9 +44,34 @@ class DotsTTSSGLangModel(nn.Module):
             latent_stats_path=str(Path(checkpoint) / "latent_stats.pt"),
             optimize=False,
         )
+        self._graph_feedback_buffer: torch.Tensor | None = None
 
     def get_input_embeddings(self):
         return self.qwen2.get_input_embeddings()
+
+    @property
+    def graph_feedback_buffer(self) -> torch.Tensor | None:
+        return self._graph_feedback_buffer
+
+    def enable_graph_feedback(self, max_batch_size: int) -> None:
+        """Route decode feedback embeddings through a persistent buffer.
+
+        SGLang 0.5.16's decode CUDA graph only stages ``forward_batch
+        .input_embeds`` into a static buffer for dFlash draft workers, so a
+        graph replay would silently ignore the per-step latent feedback and
+        decode from the control-token embeddings instead. Owning the static
+        buffer model-side makes capture bake this address into the graph;
+        ``before_decode`` copies each step's feedback into it, and the same
+        read path serves eager decode, so graph and eager stay equivalent.
+        """
+        if max_batch_size <= 0:
+            raise ValueError("dots.tts graph feedback buffer needs a positive size")
+        parameter = next(self.qwen2.parameters())
+        self._graph_feedback_buffer = torch.zeros(
+            (int(max_batch_size), int(self.qwen2.config.hidden_size)),
+            device=parameter.device,
+            dtype=parameter.dtype,
+        )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         qwen_weights: list[tuple[str, torch.Tensor]] = []
@@ -85,7 +114,14 @@ class DotsTTSSGLangModel(nn.Module):
         **kwargs: Any,
     ) -> LogitsProcessorOutput:
         del kwargs
-        if input_embeds is None:
+        if (
+            self._graph_feedback_buffer is not None
+            and forward_batch.forward_mode.is_decode()
+        ):
+            # note (luojiaxuan): same source for capture, replay, and eager decode; rows beyond
+            # the live batch are padding and their outputs are discarded.
+            input_embeds = self._graph_feedback_buffer[: input_ids.shape[0]]
+        elif input_embeds is None:
             input_embeds = forward_batch.input_embeds
         hidden_states = self.qwen2.model(
             input_ids=input_ids,

--- a/tests/unit_test/dots_tts/test_model_runner.py
+++ b/tests/unit_test/dots_tts/test_model_runner.py
@@ -191,3 +191,43 @@ def test_dots_prefill_failure_releases_materialized_slots() -> None:
     assert released == [flow_state]
     assert runner._request_data == {}
     assert requests[0].data.flow_state is None
+
+
+def _decode_request(request_id: str, fill: float):
+    feedback = torch.full((1, 4), fill)
+    return SimpleNamespace(
+        request_id=request_id,
+        data=SimpleNamespace(pending_feedback_queue=deque([feedback])),
+    )
+
+
+def test_dots_before_decode_writes_graph_feedback_buffer_in_batch_order() -> None:
+    buffer = torch.zeros(4, 4)
+    runner = object.__new__(DotsTTSModelRunner)
+    runner.model = SimpleNamespace(
+        graph_feedback_buffer=buffer,
+        parameters=lambda: iter([torch.zeros(1, dtype=torch.float32)]),
+    )
+    forward_batch = SimpleNamespace(input_ids=torch.tensor([0, 0]), input_embeds=None)
+
+    runner.before_decode(
+        forward_batch, object(), [_decode_request("a", 5.0), _decode_request("b", 6.0)]
+    )
+
+    torch.testing.assert_close(buffer[0], torch.full((4,), 5.0))
+    torch.testing.assert_close(buffer[1], torch.full((4,), 6.0))
+    torch.testing.assert_close(buffer[2], torch.zeros(4))
+    assert forward_batch.input_embeds is None
+
+
+def test_dots_before_decode_without_buffer_sets_forward_batch_embeds() -> None:
+    runner = object.__new__(DotsTTSModelRunner)
+    runner.model = SimpleNamespace(
+        graph_feedback_buffer=None,
+        parameters=lambda: iter([torch.zeros(1, dtype=torch.float32)]),
+    )
+    forward_batch = SimpleNamespace(input_ids=torch.tensor([0]), input_embeds=None)
+
+    runner.before_decode(forward_batch, object(), [_decode_request("a", 9.0)])
+
+    torch.testing.assert_close(forward_batch.input_embeds, torch.full((1, 4), 9.0))

--- a/tests/unit_test/dots_tts/test_sglang_model.py
+++ b/tests/unit_test/dots_tts/test_sglang_model.py
@@ -145,3 +145,47 @@ def test_forward_decode_skips_lm_head_and_returns_per_request_rows() -> None:
     assert isinstance(output, LogitsProcessorOutput)
     torch.testing.assert_close(output.hidden_states, hidden)
     assert output.next_token_logits.shape == (3, 1)
+
+
+def test_graph_feedback_buffer_routes_decode_input_embeds() -> None:
+    class _BufferBackbone(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.config = SimpleNamespace(hidden_size=4)
+            self.weight = nn.Parameter(torch.zeros(1))
+            self.model_kwargs: dict | None = None
+
+        def model(self, **kwargs) -> torch.Tensor:
+            self.model_kwargs = kwargs
+            return kwargs["input_embeds"]
+
+        def forward(self, *args, **kwargs):
+            raise AssertionError("dots.tts must not enter the lm_head logits path")
+
+    model = DotsTTSSGLangModel.__new__(DotsTTSSGLangModel)
+    nn.Module.__init__(model)
+    model.qwen2 = _BufferBackbone()
+
+    assert model.graph_feedback_buffer is None
+    model.enable_graph_feedback(3)
+    buffer = model.graph_feedback_buffer
+    assert buffer is not None and buffer.shape == (3, 4)
+
+    buffer[:2].copy_(torch.full((2, 4), 8.0))
+    decode_batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_decode=lambda: True, is_extend=lambda: False),
+        input_embeds=None,
+    )
+    output = model.forward(torch.tensor([1, 2]), torch.tensor([0, 0]), decode_batch)
+    torch.testing.assert_close(output.hidden_states, torch.full((2, 4), 8.0))
+    assert model.qwen2.model_kwargs["input_embeds"].data_ptr() == buffer.data_ptr()
+
+    prefill_embeds = torch.full((1, 4), 2.0)
+    prefill_batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_decode=lambda: False, is_extend=lambda: True),
+        input_embeds=prefill_embeds,
+        extend_seq_lens=torch.tensor([1]),
+    )
+    output = model.forward(torch.tensor([3]), torch.tensor([0]), prefill_batch)
+    torch.testing.assert_close(output.hidden_states, prefill_embeds)
+    assert model.qwen2.model_kwargs["input_embeds"] is prefill_embeds


### PR DESCRIPTION
## Motivation

Roadmap #1367 item "Enable SGLang backbone decode CUDA Graph". After #1370 and #1372, the c=1 profile is ≈0.44 s fixed per request plus ≈25 ms per latent patch, and the per-patch marginal cost is dominated by the eager backbone decode step (launch-bound; ~28% GPU utilization at c=1).

The blocker: SGLang 0.5.16's decode CUDA graph only stages `forward_batch.input_embeds` into a static buffer for dFlash draft workers (`spec_algorithm.is_dflash_family() and is_draft_worker`), so a dots decode replay would silently ignore the per-step latent feedback and decode from control-token embeddings.

## Modifications

- `DotsTTSSGLangModel.enable_graph_feedback(max_batch_size)`: a model-owned persistent `[max_bs, hidden]` buffer. Decode forwards always read input embeddings from this buffer, so capture bakes the buffer address into the graph and eager decode uses the identical read path. Rows beyond the live batch are padding whose outputs are discarded.
- `DotsTTSModelRunner.before_decode`: with the buffer installed, copy the per-step feedback rows into it (batch order, same stream) instead of setting `forward_batch.input_embeds`.
- Hidden-state capture: the decode graph's `can_run` gate requires an exact hidden-mode match, so the builder sets `enable_return_hidden_states` when graphs are enabled (captures FULL) and the decode hook requests FULL (decode is one token per request, so FULL ≡ LAST rows).
- `DotsTTSEngineBuilder.setup_model` installs the buffer before `init_cuda_graphs` and logs the effective backbone backend. Bare `--model-path` keeps `disable_cuda_graph: true`; the graph path is enabled from the pipeline config (`disable_cuda_graph: false` under `latent_engine.server_args_overrides`).
- Eager fallback preserved: any decode batch the graph cannot serve runs the same eager path as today.

## Benchmark

Single H100 (hyper01), Seed-TTS-Eval EN, full 1,088 samples, `--ref-format references`, seed 42, non-streaming, post-#1370 + post-#1372 main, `optimize: true`, same container and host conditions for both rows, Qwen3-ASR-1.7B WER:

| Full-set c=1 (`max_running_requests=1`) | Latency mean / p50 / p95 / p99 (s) | RTF mean / p50 / p95 / p99 | Corpus WER |
|---|---|---|---:|
| compiled, eager backbone | 1.072 / 1.041 / 1.540 / 1.839 | 0.2611 / 0.2553 / 0.3086 / 0.3590 | 1.29% |
| compiled + backbone CUDA graph (this PR) | **0.769 / 0.749 / 1.093 / 1.283** | **0.1881 / 0.1842 / 0.2232 / 0.2539** | **1.24%** |

**RTF mean −28%** at c=1 with no WER regression (1088/1088 completed, 0 failed, 0 samples above 50% WER in both rows).

Concurrency-16 (128-sample smoke, `max_running_requests=16`, `cuda_graph_max_bs=16`, seed 42): graph **3.87 req/s, RTF mean 1.0765** vs eager backbone 3.668 req/s, 1.1295 on the paired same-subset smoke (~+5% throughput), corpus WER 0.95%, 0 failed in both. (Small-n c=16 numbers are queueing-dominated; they are only comparable within the pair.) The canonical `examples/configs/dots_tts.yaml` now enables the graph; `disable_cuda_graph: true` opts back into eager backbone decode.

For context, the same benchmark on the pre-#1370 eager default measured 0.4508 mean RTF (#1372 thread), so main-to-now c=1 is 0.4508 → 0.1881 (−58%) across #1370, #1372, and this PR.

## Numerics

Graph-captured attention kernels reduce in a different order than eager launches, so outputs are not bitwise identical: on an identical 64-sample slice, 50/64 requests decode the exact same patch count and the rest shift EOS by ≤3 patches (≤0.48 s). Full-set WER above is the quality gate (graph row is 0.05 pp better).

## Validation

- `python -m pytest -q tests/unit_test/dots_tts` — 44 passed (includes new buffer-routing and before_decode tests)
- `black --check` on changed files — clean
- c=16 smoke with graphs on: 128/128 completed, 0 failed, corpus WER 0.95%

## Related

- Roadmap #1367 (backbone CUDA graph item); builds on #1349, #1370, #1372; composes with #1376 (default optimize).

## Checklist

- [x] Format code with repository hooks.
- [x] Add unit tests.
- [x] Full-set same-card A/B with fixed seed.
