### PR TITLE
[Comm] Add rank-to-rank TP KV cache transfers

### DIFF
--- a/sglang_omni/comm/engine.py
+++ b/sglang_omni/comm/engine.py
@@ -340,7 +340,6 @@ class CommEngine:
         source_page_indices: tuple[int, ...],
         target_pool_id: str,
         to_stage: str,
-        target_endpoint: str,
         metadata: dict[str, Any] | None = None,
         transfer_id: str | None = None,
         lease: KVPageLease | None = None,
@@ -379,7 +378,7 @@ class CommEngine:
             self._outbound_kv_requests[transfer_id] = request_id
             await send_to_endpoint(
                 self._rank_send_sockets,
-                target_endpoint,
+                self.rank_endpoints[to_stage][self.tp_rank],
                 KVTransferPrepareMessage(
                     request_id=request_id,
                     transfer_id=transfer_id,
@@ -426,7 +425,7 @@ class CommEngine:
             try:
                 await send_to_endpoint(
                     self._rank_send_sockets,
-                    target_endpoint,
+                    self.rank_endpoints[to_stage][self.tp_rank],
                     DataReadyMessage(
                         request_id=request_id,
                         from_stage=from_stage,

--- a/sglang_omni/comm/engine.py
+++ b/sglang_omni/comm/engine.py
@@ -27,6 +27,7 @@ from sglang_omni.comm.kv_transfer import (
     KVReceiver,
 )
 from sglang_omni.comm.router import CommRouter
+from sglang_omni.pipeline.control_plane import PullSocket, PushSocket, send_to_endpoint
 from sglang_omni.profiler.comm_trace import elapsed_ms as _comm_elapsed_ms
 from sglang_omni.profiler.comm_trace import emit as _comm_trace
 from sglang_omni.profiler.comm_trace import now_ns as _comm_now_ns
@@ -99,9 +100,15 @@ class CommEngine:
         self,
         router: CommRouter,
         *,
+        tp_rank: int = 0,
+        tp_size: int = 1,
+        rank_endpoints: dict[str, tuple[str, ...]] | None = None,
         task_done_callback: Callable[[asyncio.Task, str], None] | None = None,
     ) -> None:
         self.router = router
+        self.tp_rank = tp_rank
+        self.tp_size = tp_size
+        self.rank_endpoints = rank_endpoints or {}
         cfg = router.comm_config
         queue_size = int(cfg["send_queue_size"]) if "send_queue_size" in cfg else 1024
         self._ack_timeout_s = (
@@ -120,8 +127,32 @@ class CommEngine:
         self._kv_ready: dict[str, asyncio.Future[KVTransferReadyMessage]] = {}
         self._outbound_kv_requests: dict[str, str] = {}
         self._inbound_kv: dict[str, _InboundKVTransfer] = {}
+        self._aborted_kv_requests: set[str] = set()
+        self._rank_recv_socket: PullSocket | None = None
+        self._rank_send_sockets: dict[str, PushSocket] = {}
+        self._rank_control_task: asyncio.Task | None = None
+        self._rank_receive_tasks: set[asyncio.Task[None]] = set()
         self._task_done_callback = task_done_callback
         self._closed = False
+
+    async def start(self) -> None:
+        """Start this process's rank-local communication endpoint."""
+
+        if not self.rank_endpoints or self._rank_recv_socket is not None:
+            return
+        if self._closed:
+            raise RuntimeError("comm engine is closed")
+        recv_socket = PullSocket(
+            self.rank_endpoints[self.router.stage_name][self.tp_rank], bind=True
+        )
+        await recv_socket.start()
+        self._rank_recv_socket = recv_socket
+        task = asyncio.create_task(self._run_rank_control(recv_socket))
+        self._rank_control_task = task
+        self._track_task(
+            task,
+            f"rank endpoint {self.router.stage_name}_rank{self.tp_rank}",
+        )
 
     def outbound(self, target: str) -> TransportKind:
         return self.router.outbound(target)
@@ -304,49 +335,18 @@ class CommEngine:
     async def send_kv_pages(
         self,
         *,
-        control_plane: Any,
         request_id: str,
         source_pool_id: str,
         source_page_indices: tuple[int, ...],
         target_pool_id: str,
-        from_stage: str,
         to_stage: str,
         target_endpoint: str,
         metadata: dict[str, Any] | None = None,
         transfer_id: str | None = None,
         lease: KVPageLease | None = None,
     ) -> DataRef:
-        """Reserve remote pages, transfer directly, and wait for receiver ACK."""
-
-        return await self._send_kv_pages_impl(
-            control_plane=control_plane,
-            request_id=request_id,
-            source_pool_id=source_pool_id,
-            source_page_indices=source_page_indices,
-            target_pool_id=target_pool_id,
-            from_stage=from_stage,
-            to_stage=to_stage,
-            target_endpoint=target_endpoint,
-            metadata=metadata,
-            transfer_id=transfer_id,
-            lease=lease,
-        )
-
-    async def _send_kv_pages_impl(
-        self,
-        *,
-        control_plane: Any,
-        request_id: str,
-        source_pool_id: str,
-        source_page_indices: tuple[int, ...],
-        target_pool_id: str,
-        from_stage: str,
-        to_stage: str,
-        target_endpoint: str,
-        metadata: dict[str, Any] | None,
-        transfer_id: str | None,
-        lease: KVPageLease | None,
-    ) -> DataRef:
+        """Transfer this rank's pages to the same rank of ``to_stage``."""
+        from_stage = self.router.stage_name
         transfer_id = transfer_id or (
             f"{request_id}:kv_pages:{from_stage}:{to_stage}:{uuid4().hex}"
         )
@@ -364,14 +364,21 @@ class CommEngine:
                     "paged KV transfer currently supports only cuda_ipc; topology "
                     f"selected {transport.value}"
                 )
+            target_tp_size = len(self.rank_endpoints[to_stage])
+            if target_tp_size != self.tp_size:
+                raise NotImplementedError(
+                    "paged KV transfer requires matching tensor parallel sizes: "
+                    f"{from_stage} has tp_size={self.tp_size}, "
+                    f"{to_stage} has tp_size={target_tp_size}"
+                )
             relay = self.relay(transport)
             relay.register_kv_pool(pool)
 
             ready_future = asyncio.get_running_loop().create_future()
             self._kv_ready[transfer_id] = ready_future
             self._outbound_kv_requests[transfer_id] = request_id
-            await control_plane.send_to_stage(
-                to_stage,
+            await send_to_endpoint(
+                self._rank_send_sockets,
                 target_endpoint,
                 KVTransferPrepareMessage(
                     request_id=request_id,
@@ -416,14 +423,21 @@ class CommEngine:
             # DataReady may expose the source from this point onward. Pending
             # now owns the lease even if publication or its caller is cancelled.
             lease = None
-            pending_task = await self._publish_registered_data_ready(
-                control_plane=control_plane,
-                request_id=request_id,
-                from_stage=from_stage,
-                to_stage=to_stage,
-                target_endpoint=target_endpoint,
-                data_ref=data_ref,
-            )
+            try:
+                await send_to_endpoint(
+                    self._rank_send_sockets,
+                    target_endpoint,
+                    DataReadyMessage(
+                        request_id=request_id,
+                        from_stage=from_stage,
+                        to_stage=to_stage,
+                        data_ref=data_ref.to_dict(),
+                    ),
+                )
+            except BaseException as exc:
+                self._fail_pending(data_ref.object_id, exc)
+                raise
+            pending_task = self._arm_pending(data_ref.object_id)
             await asyncio.shield(pending_task)
             return data_ref
         finally:
@@ -432,13 +446,84 @@ class CommEngine:
             if lease is not None:
                 lease.release()
 
-    def kv_transfer_ready(self, message: KVTransferReadyMessage) -> None:
-        future = self._kv_ready.get(message.transfer_id)
-        if future is None:
-            logger.debug("Ignoring stale KV transfer ready for %s", message.transfer_id)
-            return
-        if not future.done():
-            future.set_result(message)
+    async def _run_rank_control(self, recv_socket: PullSocket) -> None:
+        try:
+            while not self._closed:
+                message = await recv_socket.recv()
+                if isinstance(message, KVTransferPrepareMessage):
+                    if message.request_id in self._aborted_kv_requests:
+                        ready = self._kv_ready_failure(
+                            message,
+                            f"request {message.request_id!r} was aborted",
+                        )
+                    else:
+                        ready = self.prepare_kv_receive(message)
+                    await send_to_endpoint(
+                        self._rank_send_sockets,
+                        self.rank_endpoints[message.from_stage][self.tp_rank],
+                        ready,
+                    )
+                    continue
+
+                if isinstance(message, KVTransferReadyMessage):
+                    future = self._kv_ready.get(message.transfer_id)
+                    if future is None:
+                        logger.debug(
+                            "Ignoring stale KV transfer ready for %s",
+                            message.transfer_id,
+                        )
+                    elif not future.done():
+                        future.set_result(message)
+                    continue
+
+                if isinstance(message, DataReadyMessage):
+                    task = asyncio.create_task(self._receive_rank_kv(message))
+                    self._rank_receive_tasks.add(task)
+                    task.add_done_callback(self._rank_receive_tasks.discard)
+                    self._track_task(
+                        task,
+                        f"KV receive {message.request_id}:{message.from_stage}",
+                    )
+                    continue
+
+                self.ack_transfer(message)
+        except asyncio.CancelledError:
+            pass
+
+    async def _receive_rank_kv(self, message: DataReadyMessage) -> None:
+        data_ref = DataRef.from_dict(message.data_ref)
+        error: Exception | None = None
+        if message.request_id in self._aborted_kv_requests:
+            error = RuntimeError(f"request {message.request_id!r} was aborted")
+        else:
+            try:
+                await self.read_data(
+                    relay=self.relay(data_ref.transport),
+                    request_id=message.request_id,
+                    data_ref=data_ref,
+                )
+            except Exception as exc:
+                logger.exception(
+                    "KV relay read failed for %s on %s rank %d",
+                    message.request_id,
+                    self.router.stage_name,
+                    self.tp_rank,
+                )
+                error = exc
+                self.cleanup(message.request_id)
+
+        await send_to_endpoint(
+            self._rank_send_sockets,
+            self.rank_endpoints[message.from_stage][self.tp_rank],
+            DataAckMessage(
+                request_id=message.request_id,
+                from_stage=self.router.stage_name,
+                to_stage=message.from_stage,
+                object_id=data_ref.object_id,
+                success=error is None,
+                error=None if error is None else (str(error) or type(error).__name__),
+            ),
+        )
 
     def prepare_kv_receive(
         self,
@@ -553,6 +638,11 @@ class CommEngine:
         )
 
     def cleanup(self, request_id: str) -> None:
+        self._aborted_kv_requests.add(request_id)
+        if len(self._aborted_kv_requests) > 10000:
+            excess = len(self._aborted_kv_requests) - 5000
+            for stale_request_id in list(self._aborted_kv_requests)[:excess]:
+                self._aborted_kv_requests.discard(stale_request_id)
         error = RuntimeError(f"KV transfer request {request_id!r} was cleaned up")
         for transfer_id, state in list(self._inbound_kv.items()):
             if state.request.request_id != request_id:
@@ -574,8 +664,26 @@ class CommEngine:
             self._fail_pending(transfer_id, error)
         self.router.cleanup(request_id)
 
-    def close(self) -> None:
+    async def close(self) -> None:
+        if self._closed:
+            return
         self._closed = True
+        rank_control_task = self._rank_control_task
+        self._rank_control_task = None
+        if rank_control_task is not None:
+            rank_control_task.cancel()
+            await asyncio.gather(rank_control_task, return_exceptions=True)
+        rank_receive_tasks = tuple(self._rank_receive_tasks)
+        for task in rank_receive_tasks:
+            task.cancel()
+        await asyncio.gather(*rank_receive_tasks, return_exceptions=True)
+        self._rank_receive_tasks.clear()
+        if self._rank_recv_socket is not None:
+            self._rank_recv_socket.close()
+            self._rank_recv_socket = None
+        for socket in self._rank_send_sockets.values():
+            socket.close()
+        self._rank_send_sockets.clear()
         for task in self._send_workers.values():
             task.cancel()
         self._send_workers.clear()
@@ -592,6 +700,7 @@ class CommEngine:
                 future.set_exception(close_error)
         self._kv_ready.clear()
         self._outbound_kv_requests.clear()
+        self._aborted_kv_requests.clear()
         self.router.close()
 
     def ack_transfer(self, ack: DataAckMessage) -> None:

--- a/sglang_omni/pipeline/control_plane.py
+++ b/sglang_omni/pipeline/control_plane.py
@@ -282,8 +282,6 @@ class StageControlPlane:
         AdminMessage
         | DataAckMessage
         | DataReadyMessage
-        | KVTransferPrepareMessage
-        | KVTransferReadyMessage
         | SubmitMessage
         | ShutdownMessage
         | ProfilerStartMessage
@@ -298,8 +296,6 @@ class StageControlPlane:
             (
                 DataReadyMessage,
                 DataAckMessage,
-                KVTransferPrepareMessage,
-                KVTransferReadyMessage,
                 SubmitMessage,
                 ShutdownMessage,
                 ProfilerStartMessage,
@@ -314,12 +310,7 @@ class StageControlPlane:
         self,
         next_stage: str,
         next_stage_endpoint: str,
-        msg: (
-            DataReadyMessage
-            | DataAckMessage
-            | KVTransferPrepareMessage
-            | KVTransferReadyMessage
-        ),
+        msg: DataReadyMessage | DataAckMessage,
     ) -> None:
         """Send a stage-to-stage control message."""
         await send_to_endpoint(self._next_stage_sockets, next_stage_endpoint, msg)

--- a/sglang_omni/pipeline/control_plane.py
+++ b/sglang_omni/pipeline/control_plane.py
@@ -105,6 +105,19 @@ class PushSocket:
             self._socket = None
 
 
+async def send_to_endpoint(
+    sockets: dict[str, PushSocket],
+    endpoint: str,
+    msg: ControlMessage,
+) -> None:
+    socket = sockets.get(endpoint)
+    if socket is None:
+        socket = PushSocket(endpoint)
+        await socket.connect()
+        sockets[endpoint] = socket
+    await socket.send(msg)
+
+
 class PullSocket:
     """Async PULL socket for receiving messages."""
 
@@ -309,12 +322,7 @@ class StageControlPlane:
         ),
     ) -> None:
         """Send a stage-to-stage control message."""
-        if next_stage not in self._next_stage_sockets:
-            sock = PushSocket(next_stage_endpoint)
-            await sock.connect()
-            self._next_stage_sockets[next_stage] = sock
-
-        await self._next_stage_sockets[next_stage].send(msg)
+        await send_to_endpoint(self._next_stage_sockets, next_stage_endpoint, msg)
 
     async def send_complete(self, msg: CompleteMessage) -> None:
         """Send completion notification to coordinator."""

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -60,6 +60,13 @@ def _build_stage_groups(
         ctx = multiprocessing.get_context("spawn")
 
     stage_endpoints = {s.name: endpoints[f"stage_{s.name}"] for s in stages_cfg}
+    rank_endpoints = {
+        stage.name: tuple(
+            endpoints[f"comm_{stage.name}_rank{tp_rank}"]
+            for tp_rank in range(stage.tp_size)
+        )
+        for stage in stages_cfg
+    }
     stream_receivers: set[str] = set()
     for scfg in stages_cfg:
         for target in scfg.stream_to:
@@ -120,6 +127,7 @@ def _build_stage_groups(
             coordinator_endpoint=endpoints["completion"],
             abort_endpoint=endpoints["abort"],
             stage_endpoints=stage_endpoints,
+            rank_endpoints=rank_endpoints,
             stream_targets=list(stage_cfg.stream_to),
             stream_done_to_fn=stage_cfg.stream_done_to_fn,
             gpu_stage_names=gpu_stage_names,

--- a/sglang_omni/pipeline/runtime_config.py
+++ b/sglang_omni/pipeline/runtime_config.py
@@ -170,6 +170,9 @@ def allocate_endpoints(
     }
     for stage in stages:
         endpoints[f"stage_{stage.name}"] = f"ipc://{base_dir}/stage_{stage.name}.sock"
+        for tp_rank in range(stage.tp_size):
+            endpoint_name = f"comm_{stage.name}_rank{tp_rank}"
+            endpoints[endpoint_name] = f"ipc://{base_dir}/{endpoint_name}.sock"
     return endpoints
 
 
@@ -223,6 +226,9 @@ def _validate_ipc_endpoint_budget(
 def _longest_endpoint_suffix_len(stages: list[StageConfig]) -> int:
     suffixes = [len("/completion.sock"), len("/abort.sock")]
     suffixes.extend(len(f"/stage_{stage.name}.sock") for stage in stages)
+    suffixes.extend(
+        len(f"/comm_{stage.name}_rank{stage.tp_size - 1}.sock") for stage in stages
+    )
     return max(suffixes)
 
 

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -37,8 +37,6 @@ from sglang_omni.proto import (
     CompleteMessage,
     DataAckMessage,
     DataReadyMessage,
-    KVTransferPrepareMessage,
-    KVTransferReadyMessage,
     ProfilerStartMessage,
     ProfilerStopMessage,
     ShutdownMessage,
@@ -87,6 +85,9 @@ class Stage:
         gpu_id: int | None,
         endpoints: dict[str, str],
         control_plane: Any,
+        rank_endpoints: dict[str, tuple[str, ...]] | None = None,
+        tp_rank: int = 0,
+        tp_size: int = 1,
         placement_gpu_id: int | None = None,
         input_handler: InputHandler | None = None,
         relay: Relay | None = None,
@@ -136,6 +137,9 @@ class Stage:
                 comm_config=comm_config or {},
                 injected_relay=relay,
             ),
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+            rank_endpoints=rank_endpoints,
             task_done_callback=self._on_background_task_done,
         )
 
@@ -158,6 +162,7 @@ class Stage:
         if self._running:
             return
         await self.control_plane.start()
+        await self._comm.start()
         self._loop = asyncio.get_running_loop()
         self._running = True
 
@@ -259,7 +264,7 @@ class Stage:
             except Exception as exc:
                 _record_cleanup_error("TP fanout", exc)
         try:
-            self._comm.close()
+            await self._comm.close()
         except Exception as exc:
             _record_cleanup_error("comm", exc)
         logger.info("Stage %s stopped", self.name)
@@ -326,10 +331,6 @@ class Stage:
             await self._on_submit(msg)
         elif isinstance(msg, DataAckMessage):
             self._comm.ack_transfer(msg)
-        elif isinstance(msg, KVTransferReadyMessage):
-            self._comm.kv_transfer_ready(msg)
-        elif isinstance(msg, KVTransferPrepareMessage):
-            await self._on_kv_transfer_prepare(msg)
         elif isinstance(msg, DataReadyMessage):
             self._schedule_receive_task(msg)
         elif isinstance(msg, ProfilerStartMessage):
@@ -462,29 +463,6 @@ class Stage:
         await self._wait_for_receive_predecessor(predecessor)
         if payload is not None:
             await self._receive_payload_from_stage(request_id, msg.from_stage, payload)
-
-    async def _on_kv_transfer_prepare(
-        self,
-        msg: KVTransferPrepareMessage,
-    ) -> None:
-        endpoint = self.endpoints.get(msg.from_stage)
-        if endpoint is None:
-            raise RuntimeError(
-                f"Stage {self.name}: no endpoint configured for KV ready target "
-                f"{msg.from_stage!r}"
-            )
-        if msg.request_id in self._aborted:
-            ready = KVTransferReadyMessage(
-                request_id=msg.request_id,
-                transfer_id=msg.transfer_id,
-                from_stage=self.name,
-                to_stage=msg.from_stage,
-                success=False,
-                error=f"request {msg.request_id!r} was aborted",
-            )
-        else:
-            ready = self._comm.prepare_kv_receive(msg)
-        await self.control_plane.send_to_stage(msg.from_stage, endpoint, ready)
 
     async def receive_local_payload(
         self,

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -79,6 +79,7 @@ class StageLaunchConfig:
     coordinator_endpoint: str = ""
     abort_endpoint: str = ""
     stage_endpoints: dict[str, str] = field(default_factory=dict)
+    rank_endpoints: dict[str, tuple[str, ...]] = field(default_factory=dict)
 
     # Stream wiring
     stream_targets: list[str] = field(default_factory=list)
@@ -741,6 +742,9 @@ def _construct_stage(
         gpu_id=spec.gpu_id,
         placement_gpu_id=spec.placement_gpu_id,
         endpoints=spec.stage_endpoints,
+        rank_endpoints=spec.rank_endpoints,
+        tp_rank=spec.tp_rank,
+        tp_size=spec.tp_size,
         control_plane=control_plane,
         input_handler=input_handler,
         comm_config=spec.comm_config,

--- a/tests/unit_test/pipeline/test_compile.py
+++ b/tests/unit_test/pipeline/test_compile.py
@@ -484,6 +484,13 @@ def test_mp_runner_preserves_tp_rank_and_visible_device_contracts(tmp_path) -> N
     assert leader.factory_args["tp_rank"] == 0
     assert follower.factory_args["tp_rank"] == 1
     assert leader.factory_args["nccl_port"] == follower.factory_args["nccl_port"]
+    assert leader.recv_endpoint == prep.endpoints["stage_thinker"]
+    assert follower.recv_endpoint == ""
+    for spec in (leader, follower):
+        assert (
+            spec.rank_endpoints["thinker"][spec.tp_rank]
+            == prep.endpoints[f"comm_thinker_rank{spec.tp_rank}"]
+        )
     assert leader.env_defaults == {"SGLANG_TEST_STAGE_ENV": "1"}
     assert follower.env_defaults == {"SGLANG_TEST_STAGE_ENV": "1"}
     assert env["CUDA_VISIBLE_DEVICES"] == "7"

--- a/tests/unit_test/pipeline/test_kv_transfer.py
+++ b/tests/unit_test/pipeline/test_kv_transfer.py
@@ -29,10 +29,12 @@ from tests.unit_test.fixtures.pipeline_fakes import FakeOp, FakeRelay
 
 
 class _PagedRelay(FakeRelay):
-    def __init__(self) -> None:
+    def __init__(self, *, tp_rank: int = 0) -> None:
         super().__init__()
+        self.tp_rank = tp_rank
         self.put_ops: list[FakeOp] = []
         self.get_calls: list[tuple[str, tuple[int, ...], tuple[int, ...]]] = []
+        self.received_source_tp_ranks: list[int] = []
 
     def register_kv_pool(self, pool: KVPool) -> None:
         del pool
@@ -53,6 +55,7 @@ class _PagedRelay(FakeRelay):
                 "transfer_info": {"size": len(source_page_indices)},
                 "fake_kv": True,
                 "key": "kv-put",
+                "source_tp_rank": self.tp_rank,
             },
             self.log,
         )
@@ -69,6 +72,7 @@ class _PagedRelay(FakeRelay):
         request_id: str,
     ) -> FakeOp:
         assert metadata["fake_kv"] is True
+        self.received_source_tp_ranks.append(metadata["source_tp_rank"])
         self.get_calls.append(
             (destination_pool_id, source_page_indices, destination_page_indices)
         )
@@ -199,7 +203,7 @@ async def _start_pair(
     relay: _PagedRelay | None = None,
     endpoints: dict[str, tuple[str, ...]] | None = None,
 ) -> tuple[_PagedRelay, CommEngine, CommEngine]:
-    relay = relay or _PagedRelay()
+    relay = relay or _PagedRelay(tp_rank=tp_rank)
     endpoints = endpoints or _kv_endpoints(tp_size)
     source = _engine(
         "source",
@@ -283,7 +287,6 @@ def test_kv_transfer_requires_cuda_ipc_topology() -> None:
                 source_page_indices=(0,),
                 target_pool_id="destination_pool",
                 to_stage="destination",
-                target_endpoint="unused",
                 lease=lease,
             )
         lease.release.assert_called_once_with()
@@ -316,7 +319,6 @@ def test_kv_transfer_requires_matching_tp_endpoint_counts() -> None:
                 source_page_indices=(0,),
                 target_pool_id="destination_pool",
                 to_stage="destination",
-                target_endpoint=endpoints["destination"][0],
             )
 
     asyncio.run(_run())
@@ -339,7 +341,6 @@ def test_kv_transfer_uses_rank_endpoint_for_full_lifecycle() -> None:
                 source_page_indices=(1, 4),
                 target_pool_id="destination_pool",
                 to_stage="destination",
-                target_endpoint=source.rank_endpoints["destination"][source.tp_rank],
                 lease=lease,
             )
 
@@ -387,9 +388,6 @@ def test_equal_tp_transfer_copies_each_shard_over_its_peer_endpoint() -> None:
                         source_page_indices=(1, 4),
                         target_pool_id="destination_pool",
                         to_stage="destination",
-                        target_endpoint=source.rank_endpoints["destination"][
-                            source.tp_rank
-                        ],
                         lease=lease,
                     )
                     for _, source, _, _, lease in rank_state
@@ -408,6 +406,7 @@ def test_equal_tp_transfer_copies_each_shard_over_its_peer_endpoint() -> None:
                 assert relay.get_calls == [
                     ("destination_pool", (1, 4), (tp_rank, tp_rank + 2))
                 ]
+                assert relay.received_source_tp_ranks == [tp_rank]
                 assert receiver.committed == ["request"]
                 lease.release.assert_called_once_with()
         finally:
@@ -435,9 +434,6 @@ def test_rank_local_prepare_failure_returns_to_same_source_rank() -> None:
                     source_page_indices=(1, 4),
                     target_pool_id="destination_pool",
                     to_stage="destination",
-                    target_endpoint=source.rank_endpoints["destination"][
-                        source.tp_rank
-                    ],
                     lease=lease,
                 )
 
@@ -469,9 +465,6 @@ def test_kv_transfer_rejects_layout_mismatch() -> None:
                     source_page_indices=(1,),
                     target_pool_id="destination_pool",
                     to_stage="destination",
-                    target_endpoint=source.rank_endpoints["destination"][
-                        source.tp_rank
-                    ],
                     lease=lease,
                 )
 
@@ -517,9 +510,6 @@ def test_kv_ack_timeout_retains_pending_sender_resources(
                     source_page_indices=(1,),
                     target_pool_id="destination_pool",
                     to_stage="destination",
-                    target_endpoint=source.rank_endpoints["destination"][
-                        source.tp_rank
-                    ],
                     lease=lease,
                 )
 
@@ -553,9 +543,6 @@ def test_rank_endpoint_dispatches_concurrent_kv_copies_and_aborts_once() -> None
                     source_page_indices=(index,),
                     target_pool_id="destination_pool",
                     to_stage="destination",
-                    target_endpoint=source.rank_endpoints["destination"][
-                        source.tp_rank
-                    ],
                     lease=Mock(),
                 )
             )

--- a/tests/unit_test/pipeline/test_kv_transfer.py
+++ b/tests/unit_test/pipeline/test_kv_transfer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 from unittest.mock import Mock
+from uuid import uuid4
 
 import pytest
 import torch
@@ -12,9 +13,12 @@ import torch
 from sglang_omni.comm.engine import CommEngine
 from sglang_omni.comm.kv_transfer import KVBufferRegion, KVPageDestination, KVPool
 from sglang_omni.comm.router import CommRouter
-from sglang_omni.pipeline.control_plane import deserialize_message, serialize_message
+from sglang_omni.pipeline.control_plane import (
+    deserialize_message,
+    send_to_endpoint,
+    serialize_message,
+)
 from sglang_omni.proto import (
-    DataAckMessage,
     DataReadyMessage,
     KVBufferSpec,
     KVPoolLayout,
@@ -22,7 +26,6 @@ from sglang_omni.proto import (
     KVTransferReadyMessage,
 )
 from tests.unit_test.fixtures.pipeline_fakes import FakeOp, FakeRelay
-from tests.unit_test.pipeline.helpers import make_stage
 
 
 class _PagedRelay(FakeRelay):
@@ -106,79 +109,43 @@ class _Receiver:
         self.aborted.append(request.request_id)
 
 
-class _LinkedControlPlane:
+class _FailingReceiver(_Receiver):
+    def reserve(self, request: KVTransferPrepareMessage) -> KVPageDestination:
+        del request
+        raise RuntimeError("rank-local reserve failed")
+
+
+class _BlockingOp(FakeOp):
+    def __init__(self, request_id: str, started: asyncio.Queue[str]) -> None:
+        super().__init__({"transfer_info": {"size": 0}, "key": "blocking-get"})
+        self.request_id = request_id
+        self.started = started
+
+    async def wait_for_completion(self, timeout: float = 30.0) -> None:
+        del timeout
+        self.started.put_nowait(self.request_id)
+        await asyncio.Future()
+
+
+class _BlockingPagedRelay(_PagedRelay):
     def __init__(self) -> None:
-        self.source: CommEngine | None = None
-        self.destination: Any = None
-        self.messages: list[Any] = []
+        super().__init__()
+        self.copy_started: asyncio.Queue[str] = asyncio.Queue()
 
-    def connect(self, source: CommEngine, destination: Any) -> None:
-        self.source = source
-        self.destination = destination
-
-    async def send_to_stage(
+    async def get_kv_pages(
         self,
-        next_stage: str,
-        next_stage_endpoint: str,
-        message: Any,
-    ) -> None:
-        del next_stage, next_stage_endpoint
-        self.messages.append(message)
-        assert self.source is not None and self.destination is not None
-        if isinstance(message, KVTransferPrepareMessage):
-            await self.destination._on_kv_transfer_prepare(message)
-        elif isinstance(message, KVTransferReadyMessage):
-            self.source.kv_transfer_ready(message)
-        elif isinstance(message, DataReadyMessage):
-            await self.destination._on_data_ready(message)
-        elif isinstance(message, DataAckMessage):
-            self.source.ack_transfer(message)
-        else:
-            raise AssertionError(f"unexpected message {type(message).__name__}")
-
-
-class _DropDataReadyControlPlane(_LinkedControlPlane):
-    async def send_to_stage(
-        self,
-        next_stage: str,
-        next_stage_endpoint: str,
-        message: Any,
-    ) -> None:
-        if isinstance(message, DataReadyMessage):
-            self.messages.append(message)
-            return
-        await super().send_to_stage(next_stage, next_stage_endpoint, message)
-
-
-def _engine(stage_name: str, relay: _PagedRelay) -> CommEngine:
-    return CommEngine(
-        CommRouter(
-            stage_name=stage_name,
-            gpu_id=0,
-            same_process_targets=set(),
-            gpu_stage_names={"source", "destination"},
-            injected_relay=relay,
-            comm_config={"ack_timeout_s": 1.0},
+        metadata: dict[str, Any],
+        *,
+        destination_pool_id: str,
+        source_page_indices: tuple[int, ...],
+        destination_page_indices: tuple[int, ...],
+        request_id: str,
+    ) -> FakeOp:
+        del metadata
+        self.get_calls.append(
+            (destination_pool_id, source_page_indices, destination_page_indices)
         )
-    )
-
-
-def _linked_pair(
-    control_plane: _LinkedControlPlane | None = None,
-) -> tuple[_PagedRelay, CommEngine, Any, _LinkedControlPlane]:
-    relay = _PagedRelay()
-    control_plane = control_plane or _LinkedControlPlane()
-    source = _engine("source", relay)
-    destination = make_stage(
-        name="destination",
-        endpoints={"source": "unused"},
-        gpu_id=0,
-        gpu_stage_names={"source", "destination"},
-        relay=relay,
-        control_plane=control_plane,
-    )
-    control_plane.connect(source, destination)
-    return relay, source, destination, control_plane
+        return _BlockingOp(request_id, self.copy_started)
 
 
 def _pool(pool_id: str, *, buffer_name: str = "layer.0.kv") -> KVPool:
@@ -191,7 +158,69 @@ def _pool(pool_id: str, *, buffer_name: str = "layer.0.kv") -> KVPool:
     )
 
 
-def test_kv_control_messages_round_trip() -> None:
+def _kv_endpoints(tp_size: int) -> dict[str, tuple[str, ...]]:
+    namespace = uuid4().hex
+    return {
+        stage_name: tuple(
+            f"inproc://{namespace}-{stage_name}-rank{tp_rank}"
+            for tp_rank in range(tp_size)
+        )
+        for stage_name in ("source", "destination")
+    }
+
+
+def _engine(
+    stage_name: str,
+    relay: _PagedRelay,
+    *,
+    tp_rank: int = 0,
+    tp_size: int = 1,
+    rank_endpoints: dict[str, tuple[str, ...]] | None = None,
+) -> CommEngine:
+    return CommEngine(
+        CommRouter(
+            stage_name=stage_name,
+            gpu_id=0,
+            same_process_targets=set(),
+            gpu_stage_names={"source", "destination"},
+            injected_relay=relay,
+            comm_config={"ack_timeout_s": 1.0},
+        ),
+        tp_rank=tp_rank,
+        tp_size=tp_size,
+        rank_endpoints=rank_endpoints,
+    )
+
+
+async def _start_pair(
+    *,
+    tp_rank: int = 0,
+    tp_size: int = 1,
+    relay: _PagedRelay | None = None,
+    endpoints: dict[str, tuple[str, ...]] | None = None,
+) -> tuple[_PagedRelay, CommEngine, CommEngine]:
+    relay = relay or _PagedRelay()
+    endpoints = endpoints or _kv_endpoints(tp_size)
+    source = _engine(
+        "source",
+        relay,
+        tp_rank=tp_rank,
+        tp_size=tp_size,
+        rank_endpoints=endpoints,
+    )
+    destination = _engine(
+        "destination",
+        relay,
+        tp_rank=tp_rank,
+        tp_size=tp_size,
+        rank_endpoints=endpoints,
+    )
+    await source.start()
+    await destination.start()
+    return relay, source, destination
+
+
+def test_kv_control_messages_round_trip_without_rank_envelope() -> None:
     layout = KVPoolLayout(
         layout_id="NHD",
         page_size=1,
@@ -226,6 +255,9 @@ def test_kv_control_messages_round_trip() -> None:
     )
 
     for message in messages:
+        encoded = message.to_dict()
+        assert "tp_rank" not in encoded
+        assert "tp_size" not in encoded
         assert deserialize_message(serialize_message(message)) == message
 
 
@@ -246,12 +278,10 @@ def test_kv_transfer_requires_cuda_ipc_topology() -> None:
 
         with pytest.raises(NotImplementedError, match="only cuda_ipc"):
             await source.send_kv_pages(
-                control_plane=_LinkedControlPlane(),
                 request_id="request",
                 source_pool_id="source_pool",
                 source_page_indices=(0,),
                 target_pool_id="destination_pool",
-                from_stage="source",
                 to_stage="destination",
                 target_endpoint="unused",
                 lease=lease,
@@ -261,112 +291,289 @@ def test_kv_transfer_requires_cuda_ipc_topology() -> None:
     asyncio.run(_run())
 
 
-def test_kv_transfer_uses_common_data_ready_lifecycle() -> None:
+def test_kv_transfer_requires_matching_tp_endpoint_counts() -> None:
     async def _run() -> None:
-        relay, source, destination, control_plane = _linked_pair()
-        source.register_kv_pool(_pool("source_pool"))
-        destination._comm.register_kv_pool(_pool("destination_pool"))
-        receiver = _Receiver((0, 3))
-        destination._comm.register_kv_receiver("destination_pool", receiver)
-        lease = Mock()
-
-        data_ref = await source.send_kv_pages(
-            control_plane=control_plane,
-            request_id="request",
-            transfer_id="transfer",
-            source_pool_id="source_pool",
-            source_page_indices=(1, 4),
-            target_pool_id="destination_pool",
-            from_stage="source",
-            to_stage="destination",
-            target_endpoint="unused",
-            lease=lease,
+        relay = _PagedRelay()
+        endpoints = _kv_endpoints(2)
+        endpoints["destination"] = tuple(
+            f"inproc://destination-rank{rank}-{uuid4().hex}" for rank in range(4)
         )
+        source = _engine(
+            "source",
+            relay,
+            tp_size=2,
+            rank_endpoints=endpoints,
+        )
+        source.register_kv_pool(_pool("source_pool"))
 
-        assert data_ref.object_id == "transfer"
-        assert relay.get_calls == [("destination_pool", (1, 4), (0, 3))]
-        assert receiver.committed == ["request"]
-        assert receiver.aborted == []
-        assert destination.scheduler.inbox.empty()
-        lease.release.assert_called_once_with()
-        assert relay.put_ops[0].waited
-        assert ("op_ack", "kv-put") in relay.log.events
-        assert [type(message) for message in control_plane.messages] == [
-            KVTransferPrepareMessage,
-            KVTransferReadyMessage,
-            DataReadyMessage,
-            DataAckMessage,
-        ]
+        with pytest.raises(
+            NotImplementedError,
+            match="source has tp_size=2, destination has tp_size=4",
+        ):
+            await source.send_kv_pages(
+                request_id="request",
+                source_pool_id="source_pool",
+                source_page_indices=(0,),
+                target_pool_id="destination_pool",
+                to_stage="destination",
+                target_endpoint=endpoints["destination"][0],
+            )
+
+    asyncio.run(_run())
+
+
+def test_kv_transfer_uses_rank_endpoint_for_full_lifecycle() -> None:
+    async def _run() -> None:
+        relay, source, destination = await _start_pair()
+        try:
+            source.register_kv_pool(_pool("source_pool"))
+            destination.register_kv_pool(_pool("destination_pool"))
+            receiver = _Receiver((0, 3))
+            destination.register_kv_receiver("destination_pool", receiver)
+            lease = Mock()
+
+            data_ref = await source.send_kv_pages(
+                request_id="request",
+                transfer_id="transfer",
+                source_pool_id="source_pool",
+                source_page_indices=(1, 4),
+                target_pool_id="destination_pool",
+                to_stage="destination",
+                target_endpoint=source.rank_endpoints["destination"][source.tp_rank],
+                lease=lease,
+            )
+
+            assert data_ref.object_id == "transfer"
+            assert relay.get_calls == [("destination_pool", (1, 4), (0, 3))]
+            assert receiver.committed == ["request"]
+            assert receiver.aborted == []
+            lease.release.assert_called_once_with()
+            assert relay.put_ops[0].waited
+            assert ("op_ack", "kv-put") in relay.log.events
+        finally:
+            await source.close()
+            await destination.close()
+
+    asyncio.run(_run())
+
+
+def test_equal_tp_transfer_copies_each_shard_over_its_peer_endpoint() -> None:
+    async def _run() -> None:
+        endpoints = _kv_endpoints(2)
+        rank_state: list[
+            tuple[_PagedRelay, CommEngine, CommEngine, _Receiver, Mock]
+        ] = []
+
+        try:
+            for tp_rank in range(2):
+                relay, source, destination = await _start_pair(
+                    tp_rank=tp_rank,
+                    tp_size=2,
+                    endpoints=endpoints,
+                )
+                source.register_kv_pool(_pool("source_pool"))
+                destination.register_kv_pool(_pool("destination_pool"))
+                receiver = _Receiver((tp_rank, tp_rank + 2))
+                destination.register_kv_receiver("destination_pool", receiver)
+                lease = Mock()
+                rank_state.append((relay, source, destination, receiver, lease))
+
+            await asyncio.gather(
+                *(
+                    source.send_kv_pages(
+                        request_id="request",
+                        transfer_id="transfer",
+                        source_pool_id="source_pool",
+                        source_page_indices=(1, 4),
+                        target_pool_id="destination_pool",
+                        to_stage="destination",
+                        target_endpoint=source.rank_endpoints["destination"][
+                            source.tp_rank
+                        ],
+                        lease=lease,
+                    )
+                    for _, source, _, _, lease in rank_state
+                )
+            )
+
+            for tp_rank, (relay, source, destination, receiver, lease) in enumerate(
+                rank_state
+            ):
+                assert source.rank_endpoints["destination"][source.tp_rank] == (
+                    endpoints["destination"][tp_rank]
+                )
+                assert destination.rank_endpoints["source"][destination.tp_rank] == (
+                    endpoints["source"][tp_rank]
+                )
+                assert relay.get_calls == [
+                    ("destination_pool", (1, 4), (tp_rank, tp_rank + 2))
+                ]
+                assert receiver.committed == ["request"]
+                lease.release.assert_called_once_with()
+        finally:
+            for _, source, destination, _, _ in rank_state:
+                await source.close()
+                await destination.close()
+
+    asyncio.run(_run())
+
+
+def test_rank_local_prepare_failure_returns_to_same_source_rank() -> None:
+    async def _run() -> None:
+        _, source, destination = await _start_pair(tp_rank=1, tp_size=2)
+        try:
+            source.register_kv_pool(_pool("source_pool"))
+            destination.register_kv_pool(_pool("destination_pool"))
+            destination.register_kv_receiver("destination_pool", _FailingReceiver(()))
+            lease = Mock()
+
+            with pytest.raises(RuntimeError, match="rank-local reserve failed"):
+                await source.send_kv_pages(
+                    request_id="request",
+                    transfer_id="transfer",
+                    source_pool_id="source_pool",
+                    source_page_indices=(1, 4),
+                    target_pool_id="destination_pool",
+                    to_stage="destination",
+                    target_endpoint=source.rank_endpoints["destination"][
+                        source.tp_rank
+                    ],
+                    lease=lease,
+                )
+
+            lease.release.assert_called_once_with()
+        finally:
+            await source.close()
+            await destination.close()
 
     asyncio.run(_run())
 
 
 def test_kv_transfer_rejects_layout_mismatch() -> None:
     async def _run() -> None:
-        relay, source, destination, control_plane = _linked_pair()
-        source.register_kv_pool(_pool("source_pool"))
-        destination._comm.register_kv_pool(
-            _pool("destination_pool", buffer_name="different")
-        )
-        receiver = _Receiver((0,))
-        destination._comm.register_kv_receiver("destination_pool", receiver)
-        lease = Mock()
-
-        with pytest.raises(RuntimeError, match="layouts do not match"):
-            await source.send_kv_pages(
-                control_plane=control_plane,
-                request_id="request",
-                transfer_id="transfer",
-                source_pool_id="source_pool",
-                source_page_indices=(1,),
-                target_pool_id="destination_pool",
-                from_stage="source",
-                to_stage="destination",
-                target_endpoint="unused",
-                lease=lease,
+        relay, source, destination = await _start_pair()
+        try:
+            source.register_kv_pool(_pool("source_pool"))
+            destination.register_kv_pool(
+                _pool("destination_pool", buffer_name="different")
             )
+            receiver = _Receiver((0,))
+            destination.register_kv_receiver("destination_pool", receiver)
+            lease = Mock()
 
-        assert receiver.aborted == ["request"]
-        lease.release.assert_called_once_with()
-        assert not relay.put_ops
-        assert [type(message) for message in control_plane.messages] == [
-            KVTransferPrepareMessage,
-            KVTransferReadyMessage,
-        ]
+            with pytest.raises(RuntimeError, match="layouts do not match"):
+                await source.send_kv_pages(
+                    request_id="request",
+                    transfer_id="transfer",
+                    source_pool_id="source_pool",
+                    source_page_indices=(1,),
+                    target_pool_id="destination_pool",
+                    to_stage="destination",
+                    target_endpoint=source.rank_endpoints["destination"][
+                        source.tp_rank
+                    ],
+                    lease=lease,
+                )
+
+            assert receiver.aborted == ["request"]
+            lease.release.assert_called_once_with()
+            assert not relay.put_ops
+        finally:
+            await source.close()
+            await destination.close()
 
     asyncio.run(_run())
 
 
-def test_kv_ack_timeout_retains_pending_sender_resources() -> None:
+def test_kv_ack_timeout_retains_pending_sender_resources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     async def _run() -> None:
-        relay, source, destination, control_plane = _linked_pair(
-            _DropDataReadyControlPlane()
+        relay, source, destination = await _start_pair()
+
+        async def drop_data_ready(
+            sockets: dict[str, Any], target_endpoint: str, message: Any
+        ) -> None:
+            if isinstance(message, DataReadyMessage):
+                return
+            await send_to_endpoint(sockets, target_endpoint, message)
+
+        monkeypatch.setattr(
+            "sglang_omni.comm.engine.send_to_endpoint",
+            drop_data_ready,
         )
-        source._ack_timeout_s = 0.0
+        source._ack_timeout_s = 0.1
         source.register_kv_pool(_pool("source_pool"))
-        destination._comm.register_kv_pool(_pool("destination_pool"))
-        destination._comm.register_kv_receiver("destination_pool", _Receiver((0,)))
+        destination.register_kv_pool(_pool("destination_pool"))
+        destination.register_kv_receiver("destination_pool", _Receiver((0,)))
         lease = Mock()
 
-        with pytest.raises(TimeoutError):
-            await source.send_kv_pages(
-                control_plane=control_plane,
-                request_id="request",
-                transfer_id="transfer",
-                source_pool_id="source_pool",
-                source_page_indices=(1,),
-                target_pool_id="destination_pool",
-                from_stage="source",
-                to_stage="destination",
-                target_endpoint="unused",
-                lease=lease,
+        try:
+            with pytest.raises(TimeoutError):
+                await source.send_kv_pages(
+                    request_id="request",
+                    transfer_id="transfer",
+                    source_pool_id="source_pool",
+                    source_page_indices=(1,),
+                    target_pool_id="destination_pool",
+                    to_stage="destination",
+                    target_endpoint=source.rank_endpoints["destination"][
+                        source.tp_rank
+                    ],
+                    lease=lease,
+                )
+
+            lease.release.assert_not_called()
+            assert not relay.put_ops[0].waited
+            assert relay.put_ops[0].failed is None
+            assert "transfer" not in source._pending
+            assert len(source._retained_pending_kv_transfers) == 1
+        finally:
+            await source.close()
+            await destination.close()
+
+    asyncio.run(_run())
+
+
+def test_rank_endpoint_dispatches_concurrent_kv_copies_and_aborts_once() -> None:
+    async def _run() -> None:
+        relay = _BlockingPagedRelay()
+        _, source, destination = await _start_pair(relay=relay)
+        source.register_kv_pool(_pool("source_pool"))
+        destination.register_kv_pool(_pool("destination_pool"))
+        receiver = _Receiver((0,))
+        destination.register_kv_receiver("destination_pool", receiver)
+
+        def start_transfer(index: int) -> asyncio.Task:
+            return asyncio.create_task(
+                source.send_kv_pages(
+                    request_id=f"request-{index}",
+                    transfer_id=f"transfer-{index}",
+                    source_pool_id="source_pool",
+                    source_page_indices=(index,),
+                    target_pool_id="destination_pool",
+                    to_stage="destination",
+                    target_endpoint=source.rank_endpoints["destination"][
+                        source.tp_rank
+                    ],
+                    lease=Mock(),
+                )
             )
 
-        lease.release.assert_not_called()
-        assert not relay.put_ops[0].waited
-        assert relay.put_ops[0].failed is None
-        assert "transfer" not in source._pending
-        assert len(source._retained_pending_kv_transfers) == 1
+        transfers: list[asyncio.Task] = []
+        try:
+            transfers.append(start_transfer(1))
+            assert await asyncio.wait_for(relay.copy_started.get(), 5.0) == "request-1"
+
+            transfers.append(start_transfer(2))
+            assert await asyncio.wait_for(relay.copy_started.get(), 5.0) == "request-2"
+
+            await destination.close()
+            assert sorted(receiver.aborted) == ["request-1", "request-2"]
+        finally:
+            await destination.close()
+            await source.close()
+            await asyncio.gather(*transfers, return_exceptions=True)
 
     asyncio.run(_run())
 


### PR DESCRIPTION
## Summary

- allocate one rank-local communication endpoint per stage rank (`comm_<stage>_rank<N>`)
- keep ordinary pipeline traffic on the existing leader-owned stage endpoint
- send KV prepare, ready, data-ready, and ACK messages directly between matching rank endpoints
- keep KV pool registration, destination reservation, CUDA IPC copy, leases, and ACK state local to each rank
- reject heterogeneous TP sizes before sending

## Design

For a TP=2 transfer from stage A to stage B:

```text
ordinary stage traffic -> stage_B (leader)

KV shard 0: comm_A_rank0 <-> comm_B_rank0
KV shard 1: comm_A_rank1 <-> comm_B_rank1
```

Messages retain logical `from_stage` and `to_stage` names. The receiving process already knows its local rank and derives the reply endpoint from that rank, so the wire protocol does not need `tp_rank`, `tp_size`, a registration envelope, or leader-side TP proxy queues.

`CommRouter` continues to select the physical data transport by logical stage. Rank endpoints only select the process that handles the KV handshake.

## Scope

This change supports corresponding-rank KV transfer between stages with equal TP sizes over CUDA IPC. Heterogeneous TP re-sharding remains a follow-up.

Stacked on #1315. The base branch is `kv-transfer/infrastructure`.

## Validation

- `uv run pytest -q tests/unit_test/pipeline` — 415 passed
- `uv run pre-commit run --all-files` — passed