### PR TITLE
[Perf][MOSS-TTS] Refactor and optimize vocoder decoding

### DIFF
--- a/sglang_omni/models/moss_tts/config.py
+++ b/sglang_omni/models/moss_tts/config.py
@@ -88,7 +88,10 @@ class MossTTSPipelineConfig(PipelineConfig):
             name="vocoder",
             process="pipeline",
             factory=f"{_PKG}.stages.create_vocoder_executor",
-            factory_args={"dtype": "bfloat16"},
+            factory_args={
+                "dtype": "bfloat16",
+                "compute_dtype": "bfloat16",
+            },
             gpu=0,
             terminal=True,
             can_accept_stream_before_payload=True,

--- a/sglang_omni/models/moss_tts/config.py
+++ b/sglang_omni/models/moss_tts/config.py
@@ -62,11 +62,7 @@ class MossTTSPipelineConfig(PipelineConfig):
             name="preprocessing",
             process="pipeline",
             factory=f"{_PKG}.stages.create_preprocessing_executor",
-            # Keep the standalone reference encoder off GPU. MOSS-TTS loads a
-            # second audio-tokenizer instance for vocoding, so colocating both
-            # FP32 codec copies leaves no credible runtime margin on 32 GB.
             factory_args={
-                "device": "cpu",
                 "dtype": "float32",
                 "ref_audio_cache": True,
                 "ref_audio_cache_max_items": _REF_AUDIO_CACHE_MAX_ITEMS,
@@ -89,7 +85,7 @@ class MossTTSPipelineConfig(PipelineConfig):
             process="pipeline",
             factory=f"{_PKG}.stages.create_vocoder_executor",
             factory_args={
-                "dtype": "bfloat16",
+                "dtype": "float32",
                 "compute_dtype": "bfloat16",
             },
             gpu=0,

--- a/sglang_omni/models/moss_tts/delay_pattern.py
+++ b/sglang_omni/models/moss_tts/delay_pattern.py
@@ -7,8 +7,6 @@ from typing import Any
 
 import torch
 
-from sglang_omni.utils.codec_delay import reverse_delay_pattern
-
 
 def split_moss_audio_segments(
     delayed_audio_codes: Any,
@@ -23,10 +21,25 @@ def split_moss_audio_segments(
     if not isinstance(delayed_audio_codes, torch.Tensor):
         delayed_audio_codes = torch.as_tensor(delayed_audio_codes, dtype=torch.long)
     delayed_audio_codes = delayed_audio_codes.to(dtype=torch.long)
+    if delayed_audio_codes.ndim != 2:
+        raise ValueError(
+            "delayed codes must be 2-D [L, N], got shape "
+            f"{tuple(delayed_audio_codes.shape)}"
+        )
     if delayed_audio_codes.numel() == 0:
         return []
+    length, num_codebooks = delayed_audio_codes.shape
+    rows = length - (num_codebooks - 1)
+    if rows <= 0 or num_codebooks == 0:
+        return []
 
-    audio_codes = reverse_delay_pattern(delayed_audio_codes, allow_short=True)
+    # out[t, c] = delayed[t + c, c]. A strided view performs the inverse
+    # delay without 32 per-codebook slice copies on the normal MOSS checkpoint.
+    delayed_audio_codes = delayed_audio_codes.contiguous()
+    audio_codes = delayed_audio_codes.as_strided(
+        size=(rows, num_codebooks),
+        stride=(num_codebooks, num_codebooks + 1),
+    )
     if audio_codes.numel() == 0:
         return []
 

--- a/sglang_omni/models/moss_tts/payload_types.py
+++ b/sglang_omni/models/moss_tts/payload_types.py
@@ -6,7 +6,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from sglang_omni.scheduling.pipeline_state import DeclarativeStateBase, wire
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.pipeline_state import DeclarativeStateBase
+from sglang_omni.scheduling.pipeline_state import load_state as _load_pipeline_state
+from sglang_omni.scheduling.pipeline_state import store_state as _store_pipeline_state
+from sglang_omni.scheduling.pipeline_state import wire
 
 
 @dataclass(frozen=True)
@@ -62,3 +66,11 @@ class MossTTSState(DeclarativeStateBase):
     generation_kwargs: dict[str, Any] = wire(default_factory=dict, codec="dict")
     delayed_audio_codes: Any | None = wire(None, codec="tensor_cpu")
     assistant_start_length: int = wire(0, emit="truthy", codec="int")
+
+
+def load_moss_tts_state(payload: StagePayload) -> MossTTSState:
+    return _load_pipeline_state(payload, MossTTSState)
+
+
+def store_moss_tts_state(payload: StagePayload, state: MossTTSState) -> StagePayload:
+    return _store_pipeline_state(payload, state)

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -20,36 +20,26 @@ from sglang_omni.models.moss_tts.audio_tokenizer import (
     MossTTSAudioTokenizer,
     load_moss_tts_audio_tokenizer,
 )
-from sglang_omni.models.moss_tts.delay_pattern import split_moss_audio_segments
 from sglang_omni.models.moss_tts.engine_builder import MossTtsEngineBuilder
 from sglang_omni.models.moss_tts.hf_loading import (
     load_moss_processor_class,
     moss_transformers_processor_compat,
 )
-from sglang_omni.models.moss_tts.payload_types import (
-    MossTTSState,
-    moss_tts_special_token_defaults,
-    resolve_moss_audio_pad_code,
-)
+from sglang_omni.models.moss_tts.payload_types import moss_tts_special_token_defaults
 from sglang_omni.models.moss_tts.request_builders import (
     cleanup_prepared_moss_tts_request,
     preprocess_moss_tts_payload,
     set_moss_tts_preprocessing_context,
 )
 from sglang_omni.models.moss_tts.streaming_vocoder import MossStreamingVocoderScheduler
+from sglang_omni.models.moss_tts.vocoder import MossTTSVocoder
 from sglang_omni.preprocessing.cache_key import hash_bytes
-from sglang_omni.proto import StagePayload
-from sglang_omni.scheduling.pipeline_state import build_usage
-from sglang_omni.scheduling.pipeline_state import load_state as _load_pipeline_state
-from sglang_omni.scheduling.pipeline_state import store_state as _store_pipeline_state
 from sglang_omni.scheduling.reference_encoder import (
     ReferenceEncodeService,
     TensorReferenceEncodeHook,
 )
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
-from sglang_omni.scheduling.vocoder_base import BatchVocoderBase
 from sglang_omni.utils.audio import audio_fingerprint, load_audio
-from sglang_omni.utils.audio_payload import audio_waveform_payload
 
 logger = logging.getLogger(__name__)
 
@@ -75,12 +65,25 @@ _ReferenceEncodeQueueEntry: TypeAlias = tuple[
 ]
 
 
-def load_state(payload: StagePayload) -> MossTTSState:
-    return _load_pipeline_state(payload, MossTTSState)
+_COMPUTE_DTYPES: dict[str, torch.dtype] = {
+    "float32": torch.float32,
+    "bfloat16": torch.bfloat16,
+}
 
 
-def store_state(payload: StagePayload, state: MossTTSState) -> StagePayload:
-    return _store_pipeline_state(payload, state)
+def _resolve_compute_dtype(
+    dtype: str | torch.dtype | None,
+) -> torch.dtype | None:
+    if dtype is None:
+        return None
+    if isinstance(dtype, str):
+        try:
+            return _COMPUTE_DTYPES[dtype.lower()]
+        except KeyError:
+            pass
+    elif isinstance(dtype, torch.dtype) and dtype in (torch.float32, torch.bfloat16):
+        return dtype
+    raise ValueError(f"compute_dtype must be float32, bfloat16, or null; got {dtype!r}")
 
 
 def _normalize_moss_processor_config(processor: Any) -> None:
@@ -513,84 +516,6 @@ def create_sglang_tts_engine_executor(
 create_tts_engine_executor = create_sglang_tts_engine_executor
 
 
-class _MossTTSVocoder(BatchVocoderBase):
-    def __init__(
-        self,
-        processor: Any,
-        audio_tokenizer: MossTTSAudioTokenizer,
-        device: str,
-    ) -> None:
-        self._processor = processor
-        self._audio_tokenizer = audio_tokenizer
-        self._device = device
-
-    def prepare_item(self, payload: StagePayload) -> tuple[MossTTSState, torch.Tensor]:
-        state = load_state(payload)
-        if state.delayed_audio_codes is None:
-            raise RuntimeError("MOSS-TTS vocoder requires delayed_audio_codes")
-        delayed_codes = torch.as_tensor(state.delayed_audio_codes, dtype=torch.long)
-        if delayed_codes.numel() == 0:
-            raise RuntimeError("MOSS-TTS generated no delayed audio codes")
-        return state, delayed_codes
-
-    def _decode_audio(
-        self,
-        state: MossTTSState,
-        delayed_codes: torch.Tensor,
-    ) -> tuple[torch.Tensor, int]:
-        delayed_codes = delayed_codes.to(device=self._device, dtype=torch.long)
-        audio_pad_code = resolve_moss_audio_pad_code(
-            getattr(self._processor, "model_config", None)
-        )
-        segments = split_moss_audio_segments(
-            delayed_codes,
-            audio_pad_code=audio_pad_code,
-            assistant_start_length=int(state.assistant_start_length),
-        )
-        decoded = []
-        for segment in segments:
-            decoded.extend(self._audio_tokenizer.decode_codes([segment]))
-        if not decoded:
-            raise RuntimeError("MOSS-TTS vocoder decoded no audio segments")
-        waveforms = [
-            torch.as_tensor(wav).detach().reshape(-1).to("cpu") for wav in decoded
-        ]
-        waveform = torch.cat(waveforms, dim=0)
-        sample_rate = int(
-            getattr(self._audio_tokenizer, "sample_rate", 0)
-            or getattr(
-                getattr(self._processor, "model_config", None), "sampling_rate", 0
-            )
-            or state.sample_rate
-            or 24000
-        )
-        return waveform, sample_rate
-
-    async def decode_batch(
-        self, items: list[tuple[MossTTSState, torch.Tensor]]
-    ) -> list[tuple[torch.Tensor, int]]:
-        return [self._decode_audio(state, codes) for state, codes in items]
-
-    def store_result(
-        self,
-        payload: StagePayload,
-        state: MossTTSState,
-        wav: torch.Tensor,
-        sample_rate: int,
-    ) -> StagePayload:
-        audio_payload = audio_waveform_payload(wav, source_hint="MOSS-TTS")
-        state.delayed_audio_codes = None
-        state.sample_rate = int(sample_rate)
-        payload = store_state(payload, state)
-        payload.data.update(audio_payload)
-        payload.data["sample_rate"] = state.sample_rate
-        payload.data["modality"] = "audio"
-        usage = build_usage(state)
-        if usage is not None:
-            payload.data["usage"] = usage
-        return payload
-
-
 def create_vocoder_executor(
     model_path: str,
     *,
@@ -605,11 +530,13 @@ def create_vocoder_executor(
     stream_overlap_tokens: int = 8,
     stream_holdback_tokens: int = 1,
     initial_chunk_frames: int = 0,
+    compute_dtype: str | torch.dtype | None = "bfloat16",
 ) -> MossStreamingVocoderScheduler:
     # An explicit device is a model policy/user override; gpu_id is only the
     # placement-derived fallback. This matches preprocessing resolution and
     # permits a CPU-vocoder escape hatch on especially constrained hardware.
     device = _resolve_codec_device(device, gpu_id)
+    resolved_compute_dtype = _resolve_compute_dtype(compute_dtype)
     processor = _load_moss_processor(model_path)
     audio_tokenizer = load_moss_tts_audio_tokenizer(
         _resolve_audio_tokenizer_model_path(processor, codec_model_path),
@@ -617,7 +544,13 @@ def create_vocoder_executor(
         dtype=dtype,
     )
 
-    vocoder = _MossTTSVocoder(processor, audio_tokenizer, device)
+    vocoder = MossTTSVocoder(
+        processor,
+        audio_tokenizer,
+        device,
+        compute_dtype=resolved_compute_dtype,
+        max_segment_batch_size=max_batch_size,
+    )
     return MossStreamingVocoderScheduler(
         vocoder,
         stream_stride=stream_stride,

--- a/sglang_omni/models/moss_tts/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts/streaming_vocoder.py
@@ -10,7 +10,7 @@ from typing import Any, Mapping
 import torch
 
 from sglang_omni.models.moss_tts.payload_types import (
-    MossTTSState,
+    load_moss_tts_state,
     resolve_moss_audio_pad_code,
 )
 from sglang_omni.proto import StagePayload
@@ -112,7 +112,7 @@ class MossStreamingVocoderScheduler(StreamingVocoderBase[_MossStreamState, None]
     ) -> None:
         if origin == "payload":
             payload = source
-            final_state = MossTTSState.from_dict(payload.data)
+            final_state = load_moss_tts_state(payload)
             delayed = final_state.delayed_audio_codes
             n_vq = state.n_vq
             if delayed is not None:
@@ -261,7 +261,7 @@ class MossStreamingVocoderScheduler(StreamingVocoderBase[_MossStreamState, None]
         state: _MossStreamState,
     ) -> dict[str, Any]:
         del request_id
-        final_state = MossTTSState.from_dict(payload.data)
+        final_state = load_moss_tts_state(payload)
         final_state.delayed_audio_codes = None
         final_state.sample_rate = int(state.sample_rate or self._sample_rate)
         data = final_state.to_dict()

--- a/sglang_omni/models/moss_tts/vocoder.py
+++ b/sglang_omni/models/moss_tts/vocoder.py
@@ -1,0 +1,390 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Non-streaming vocoder implementation for MOSS-TTS Delay."""
+
+from __future__ import annotations
+
+import logging
+import traceback
+from collections.abc import Iterator
+from contextlib import contextmanager
+from itertools import accumulate
+from typing import Any, cast
+
+import torch
+from torch.nn.utils.rnn import pad_sequence
+
+from sglang_omni.models.moss_tts.audio_tokenizer import MossTTSAudioTokenizer
+from sglang_omni.models.moss_tts.delay_pattern import split_moss_audio_segments
+from sglang_omni.models.moss_tts.payload_types import (
+    MossTTSState,
+    load_moss_tts_state,
+    resolve_moss_audio_pad_code,
+    store_moss_tts_state,
+)
+from sglang_omni.models.moss_tts.vocoder_decoder import MossAudioTokenizerVocoderDecoder
+from sglang_omni.models.moss_tts.vocoder_quantizer import (
+    MossAudioTokenizerQuantizerDecoder,
+)
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.pipeline_state import build_usage
+from sglang_omni.scheduling.vocoder_base import BatchVocoderBase
+from sglang_omni.utils.audio_payload import audio_waveform_payload
+
+logger = logging.getLogger(__name__)
+
+
+def _codec_device(codec: Any, fallback: str) -> torch.device:
+    try:
+        return next(codec.parameters()).device
+    except (AttributeError, StopIteration):
+        return torch.device(fallback)
+
+
+def _module_dtype(module: Any) -> torch.dtype | None:
+    try:
+        return next(
+            parameter.dtype
+            for parameter in module.parameters()
+            if parameter.is_floating_point()
+        )
+    except (AttributeError, StopIteration):
+        return None
+
+
+@contextmanager
+def _autocast_if_supported(
+    device: torch.device,
+    dtype: torch.dtype | None,
+) -> Iterator[None]:
+    enabled = (device.type == "cuda" and dtype in (torch.float16, torch.bfloat16)) or (
+        device.type == "cpu" and dtype is torch.bfloat16
+    )
+    if enabled:
+        with torch.autocast(
+            device_type=device.type,
+            dtype=cast(torch.dtype, dtype),
+        ):
+            yield
+    else:
+        yield
+
+
+def _join_waveforms(waveforms: list[torch.Tensor]) -> torch.Tensor:
+    if not waveforms:
+        raise ValueError("waveforms must not be empty")
+    return waveforms[0] if len(waveforms) == 1 else torch.cat(waveforms, dim=0)
+
+
+def _copy_valid_waveforms_to_cpu(
+    audio: torch.Tensor,
+    output_lengths: list[int],
+) -> list[torch.Tensor]:
+    if audio.ndim != 3 or int(audio.shape[1]) != 1:
+        raise ValueError(
+            "MOSS-TTS Delay decoder audio must have shape [B, 1, T], got "
+            f"{tuple(audio.shape)}"
+        )
+    if len(output_lengths) != int(audio.shape[0]):
+        raise ValueError("output_lengths must match the decoder batch size")
+    max_length = int(audio.shape[2])
+    if any(length < 0 or length > max_length for length in output_lengths):
+        raise ValueError("output_lengths must be within the decoded waveform")
+
+    valid_waveforms = [
+        audio[index, 0, :length] for index, length in enumerate(output_lengths)
+    ]
+    flat_audio = _join_waveforms(valid_waveforms)
+    if flat_audio.device.type == "cuda":
+        try:
+            flat_cpu = torch.empty(
+                flat_audio.shape,
+                device="cpu",
+                dtype=torch.float32,
+                pin_memory=True,
+            )
+        except RuntimeError:
+            flat_cpu = flat_audio.detach().to(device="cpu", dtype=torch.float32)
+        else:
+            flat_cpu.copy_(flat_audio.detach(), non_blocking=True)
+            torch.cuda.current_stream(flat_audio.device).synchronize()
+    else:
+        flat_cpu = flat_audio.detach().to(device="cpu", dtype=torch.float32)
+    offsets = [0, *accumulate(output_lengths)]
+    return [
+        flat_cpu[start:end].contiguous()
+        for start, end in zip(offsets[:-1], offsets[1:], strict=True)
+    ]
+
+
+class MossTTSVocoder(BatchVocoderBase):
+    def __init__(
+        self,
+        processor: Any,
+        audio_tokenizer: MossTTSAudioTokenizer,
+        device: str,
+        *,
+        compute_dtype: torch.dtype | None = None,
+        max_segment_batch_size: int = 8,
+    ) -> None:
+        self._processor = processor
+        self._audio_tokenizer = audio_tokenizer
+        self._device = device
+        self._compute_dtype = compute_dtype
+        self._max_segment_batch_size = max(int(max_segment_batch_size), 1)
+        self._codec = getattr(audio_tokenizer, "model", None)
+        self._quantizer = getattr(self._codec, "quantizer", None)
+        self._quantizer_decoder = None
+        self._nonstream_decoder = None
+        if (
+            self._compute_dtype is not None
+            and self._codec is not None
+            and callable(getattr(self._quantizer, "decode_codes", None))
+            and hasattr(self._codec, "decoder")
+        ):
+            codec_device = _codec_device(self._codec, self._device)
+            try:
+                nonstream_decoder = MossAudioTokenizerVocoderDecoder(
+                    self._codec.decoder
+                )
+                supports_packed_flash = nonstream_decoder.supports_packed_flash(
+                    codec_device,
+                    self._compute_dtype,
+                )
+            except (AttributeError, AssertionError, TypeError, ValueError):
+                logger.exception(
+                    "MOSS-TTS Delay codec is incompatible with the batched "
+                    "packed decoder; falling back to standalone codec decode"
+                )
+            else:
+                if supports_packed_flash:
+                    self._quantizer.to(dtype=torch.float32)
+                    try:
+                        self._quantizer_decoder = MossAudioTokenizerQuantizerDecoder(
+                            self._quantizer
+                        )
+                    except (AttributeError, RuntimeError, TypeError, ValueError):
+                        logger.exception(
+                            "MOSS-TTS Delay quantizer is incompatible with the "
+                            "cached decoder; using source quantizer decode"
+                        )
+                    self._nonstream_decoder = nonstream_decoder
+                    logger.info(
+                        "MOSS-TTS Delay vocoder enabled batched packed decoder "
+                        "stages=%d compute_dtype=%s",
+                        len(self._nonstream_decoder),
+                        self._compute_dtype,
+                    )
+                else:
+                    logger.info(
+                        "MOSS-TTS Delay packed decoder is unavailable for "
+                        "device=%s compute_dtype=%s; using standalone codec decode",
+                        codec_device,
+                        self._compute_dtype,
+                    )
+
+    def prepare_item(self, payload: StagePayload) -> tuple[MossTTSState, torch.Tensor]:
+        state = load_moss_tts_state(payload)
+        if state.delayed_audio_codes is None:
+            raise RuntimeError("MOSS-TTS vocoder requires delayed_audio_codes")
+        delayed_codes = torch.as_tensor(state.delayed_audio_codes, dtype=torch.long)
+        if delayed_codes.numel() == 0:
+            raise RuntimeError("MOSS-TTS generated no delayed audio codes")
+        return state, delayed_codes
+
+    def _decode_audio(
+        self,
+        state: MossTTSState,
+        delayed_codes: torch.Tensor,
+    ) -> tuple[torch.Tensor, int]:
+        delayed_codes = delayed_codes.to(device=self._device, dtype=torch.long)
+        audio_pad_code = resolve_moss_audio_pad_code(
+            getattr(self._processor, "model_config", None)
+        )
+        segments = split_moss_audio_segments(
+            delayed_codes,
+            audio_pad_code=audio_pad_code,
+            assistant_start_length=int(state.assistant_start_length),
+        )
+        codec_decoder = getattr(self._codec, "decoder", self._codec)
+        codec_dtype = _module_dtype(codec_decoder) or _module_dtype(self._codec)
+        codec_device = _codec_device(self._codec, self._device)
+        decoded = []
+        with _autocast_if_supported(codec_device, codec_dtype):
+            for segment in segments:
+                decoded.extend(self._audio_tokenizer.decode_codes([segment]))
+        if not decoded:
+            raise RuntimeError("MOSS-TTS vocoder decoded no audio segments")
+        waveforms = [
+            torch.as_tensor(wav).detach().reshape(-1).to("cpu") for wav in decoded
+        ]
+        waveform = _join_waveforms(waveforms)
+        return waveform, self._resolve_sample_rate(state)
+
+    def _resolve_sample_rate(self, state: MossTTSState) -> int:
+        return int(
+            getattr(self._audio_tokenizer, "sample_rate", 0)
+            or getattr(getattr(self._codec, "config", None), "sampling_rate", 0)
+            or getattr(
+                getattr(self._processor, "model_config", None), "sampling_rate", 0
+            )
+            or state.sample_rate
+            or 24000
+        )
+
+    def _decode_segments_batch(
+        self,
+        segments: list[torch.Tensor],
+    ) -> list[torch.Tensor]:
+        codec = self._codec
+        if codec is None:
+            raise RuntimeError("batched MOSS-TTS Delay codec path is unavailable")
+        packed_decoder = self._nonstream_decoder
+        if packed_decoder is None:
+            raise RuntimeError("packed MOSS-TTS Delay codec path is unavailable")
+        if not segments:
+            return []
+
+        if any(segment.ndim != 2 for segment in segments):
+            raise ValueError("MOSS-TTS Delay codec segments must be 2D")
+        device = _codec_device(codec, self._device)
+        n_vq = int(segments[0].shape[1])
+        if n_vq <= 0 or any(int(segment.shape[1]) != n_vq for segment in segments):
+            raise ValueError("MOSS-TTS Delay codec segments must share one n_vq")
+
+        host_segments = [
+            segment.to(device="cpu", dtype=torch.long) for segment in segments
+        ]
+        input_lengths_cpu = [int(segment.shape[0]) for segment in host_segments]
+        padded_codes = pad_sequence(
+            host_segments,
+            batch_first=True,
+            padding_value=0,
+        )
+        audio_codes = (
+            padded_codes.permute(2, 0, 1)
+            .contiguous()
+            .to(device=device, non_blocking=True)
+        )
+        input_lengths = torch.tensor(
+            input_lengths_cpu,
+            device=device,
+            dtype=torch.int32,
+        )
+        output_lengths_cpu = packed_decoder.output_lengths(input_lengths_cpu)
+
+        quantizer = self._quantizer
+        if quantizer is None or not callable(getattr(quantizer, "decode_codes", None)):
+            raise RuntimeError(
+                "MOSS-TTS Delay audio tokenizer has no supported "
+                "quantizer.decode_codes"
+            )
+        with torch.inference_mode():
+            # Keep codebook math in FP32. Only decoder stages run under the
+            # configured compute autocast, independent of the attention backend.
+            with torch.autocast(device_type=device.type, enabled=False):
+                quantizer_decoder = self._quantizer_decoder
+                decoder_hidden_states = (
+                    quantizer.decode_codes(audio_codes)
+                    if quantizer_decoder is None
+                    else quantizer_decoder.decode_codes(audio_codes)
+                ).float()
+            with _autocast_if_supported(device, self._compute_dtype):
+                audio, audio_lengths = packed_decoder(
+                    decoder_hidden_states,
+                    input_lengths,
+                    input_lengths_cpu=input_lengths_cpu,
+                )
+        if audio is None or audio_lengths is None:
+            raise RuntimeError(
+                "MOSS-TTS Delay audio tokenizer returned empty audio/audio_lengths"
+            )
+        if len(output_lengths_cpu) != int(audio.shape[0]):
+            raise RuntimeError(
+                "MOSS-TTS Delay decoder returned an unexpected output batch size"
+            )
+        return _copy_valid_waveforms_to_cpu(audio, output_lengths_cpu)
+
+    def _decode_segment_batches(
+        self,
+        segments: list[torch.Tensor],
+    ) -> list[torch.Tensor]:
+        decoded: list[torch.Tensor] = []
+        for start in range(0, len(segments), self._max_segment_batch_size):
+            decoded.extend(
+                self._decode_segments_batch(
+                    segments[start : start + self._max_segment_batch_size],
+                )
+            )
+        return decoded
+
+    async def decode_batch(
+        self, items: list[tuple[MossTTSState, torch.Tensor]]
+    ) -> list[tuple[torch.Tensor, int]]:
+        if self._nonstream_decoder is None:
+            return [self._decode_audio(state, codes) for state, codes in items]
+
+        audio_pad_code = resolve_moss_audio_pad_code(
+            getattr(self._processor, "model_config", None)
+        )
+        request_segments: list[list[int]] = [[] for _ in items]
+        flat_segments: list[torch.Tensor] = []
+        for request_index, (state, delayed_codes) in enumerate(items):
+            segments = split_moss_audio_segments(
+                delayed_codes.to(dtype=torch.long),
+                audio_pad_code=audio_pad_code,
+                assistant_start_length=int(state.assistant_start_length),
+            )
+            for segment in segments:
+                request_segments[request_index].append(len(flat_segments))
+                flat_segments.append(segment)
+
+        if any(not indices for indices in request_segments):
+            raise RuntimeError("MOSS-TTS vocoder decoded no audio segments")
+
+        failure_traceback = None
+        try:
+            decoded_segments = self._decode_segment_batches(flat_segments)
+        except Exception:
+            # Materialize the traceback as text, then leave the exception scope
+            # before retrying. The exception traceback can otherwise retain the
+            # failed batch's CUDA tensors throughout the fallback.
+            failure_traceback = traceback.format_exc()
+        if failure_traceback is not None:
+            self._nonstream_decoder = None
+            self._quantizer_decoder = None
+            logger.error(
+                "MOSS-TTS Delay packed codec decode failed; disabling the "
+                "packed path and falling back to standalone codec decode:\n%s",
+                failure_traceback.rstrip(),
+            )
+            return [self._decode_audio(state, codes) for state, codes in items]
+
+        return [
+            (
+                _join_waveforms([decoded_segments[index] for index in indices]),
+                self._resolve_sample_rate(items[request_index][0]),
+            )
+            for request_index, indices in enumerate(request_segments)
+        ]
+
+    def store_result(
+        self,
+        payload: StagePayload,
+        state: MossTTSState,
+        wav: torch.Tensor,
+        sample_rate: int,
+    ) -> StagePayload:
+        audio_payload = audio_waveform_payload(wav, source_hint="MOSS-TTS")
+        state.delayed_audio_codes = None
+        state.sample_rate = int(sample_rate)
+        payload = store_moss_tts_state(payload, state)
+        payload.data.update(audio_payload)
+        payload.data["sample_rate"] = state.sample_rate
+        payload.data["modality"] = "audio"
+        usage = build_usage(state)
+        if usage is not None:
+            payload.data["usage"] = usage
+        return payload
+
+
+__all__ = ["MossTTSVocoder"]

--- a/sglang_omni/models/moss_tts/vocoder_decoder.py
+++ b/sglang_omni/models/moss_tts/vocoder_decoder.py
@@ -1,18 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
-"""MOSS-TTS Local non-streaming vocoder decoder with packed attention.
+"""Shared MOSS audio-tokenizer non-streaming decoder with packed attention.
 
 The wrapper keeps the upstream codec embeddings, pretransform stages, and
 waveform projection. It replaces only the non-streaming projected transformer
 attention path so decoder frames can run through SGLang's packed varlen
-FlashAttention.
+FlashAttention. Both MOSS-Audio-Tokenizer-v2 (MOSS-TTS Local) and the legacy
+MOSS-Audio-Tokenizer used by MOSS-TTS Delay are supported; the latter exposes
+equivalent primitives under older field names.
 """
 
 from __future__ import annotations
 
 import importlib
 import math
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
+from itertools import accumulate
 from typing import Any
 
 import torch
@@ -23,11 +26,53 @@ try:
 except ImportError:
     flash_attn_varlen_func = None
 
+from sglang_omni.models.moss_tts.vocoder_kernels import (
+    apply_exact_interleaved_rope_inplace,
+)
 
 # note (Zhang Yiyang): FA3 local-window attention diverges from SDPA when one
 # varlen sequence spans multiple 128-token query tiles. Pack each tile as an
 # independent sequence in one kernel launch.
 _FA3_LOCAL_WINDOW_QUERY_TILE_SIZE = 128
+_FLASH_ATTENTION_BACKEND = "flash_attention_2"
+
+
+def _single_module(source: nn.Module, singular: str, plural: str) -> nn.Module:
+    module = getattr(source, singular, None)
+    if module is not None:
+        return module
+    modules = getattr(source, plural, None)
+    if modules is None or len(modules) != 1:
+        raise ValueError(
+            f"MOSS vocoder expects one {singular!r} module; "
+            f"got {plural}={modules!r}"
+        )
+    return modules[0]
+
+
+class _LegacyFeedForward(nn.Module):
+    """Expose the legacy Linear-GELU-Linear fields as one callable module."""
+
+    def __init__(self, source: nn.Module) -> None:
+        super().__init__()
+        self.linear1 = source.linear1
+        self.linear2 = source.linear2
+        self.activation = source.activation
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear2(self.activation(self.linear1(x)))
+
+
+def _feed_forward(source: nn.Module) -> nn.Module:
+    ffn = getattr(source, "ffn", None)
+    if ffn is not None:
+        return ffn
+    if (
+        getattr(source, "linear1", None) is None
+        or getattr(source, "linear2", None) is None
+    ):
+        raise ValueError("MOSS vocoder transformer layer has no supported FFN")
+    return _LegacyFeedForward(source)
 
 
 @dataclass(frozen=True)
@@ -45,13 +90,21 @@ def _build_local_causal_flash_plan(
     *,
     context: int,
     query_chunk_size: int = _FA3_LOCAL_WINDOW_QUERY_TILE_SIZE,
+    sequence_lengths: Sequence[int] | None = None,
 ) -> _LocalCausalFlashPlan:
     if context <= 0:
         raise ValueError(f"local causal context must be positive, got {context}")
     if query_chunk_size <= 0:
         raise ValueError(f"query_chunk_size must be positive, got {query_chunk_size}")
 
-    sequence_lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).to("cpu").tolist()
+    if sequence_lengths is None:
+        sequence_lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).to("cpu").tolist()
+    else:
+        sequence_lengths = [int(length) for length in sequence_lengths]
+        if len(sequence_lengths) != int(cu_seqlens.shape[0]) - 1:
+            raise ValueError(
+                "sequence_lengths must match the number of packed sequences"
+            )
     q_lengths: list[int] = []
     k_lengths: list[int] = []
     key_starts: list[int] = []
@@ -157,6 +210,46 @@ def _pack_padded_sequence(
     return packed_x, valid_mask, cu_seqlens, position_ids
 
 
+def _pack_padded_sequence_from_host_lengths(
+    x: torch.Tensor,
+    input_lengths: torch.Tensor,
+    input_lengths_cpu: Sequence[int],
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pack with matching device/host lengths without synchronizing the device."""
+
+    batch_size, max_seqlen, hidden_size = x.shape
+    lengths = list(map(int, input_lengths_cpu))
+    if len(lengths) != batch_size:
+        raise ValueError("input_lengths_cpu must match the decoder batch size")
+    if input_lengths.ndim != 1 or int(input_lengths.numel()) != batch_size:
+        raise ValueError("input_lengths must match the decoder batch size")
+    if input_lengths.device != x.device:
+        raise ValueError("input_lengths and decoder inputs must share one device")
+    if any(length < 0 or length > max_seqlen for length in lengths):
+        raise ValueError("input_lengths_cpu must be within the padded sequence")
+
+    total_tokens = sum(lengths)
+    cu_seqlens = torch.tensor(
+        [0, *accumulate(lengths)],
+        device=x.device,
+        dtype=torch.int32,
+    )
+    batch_ids = torch.repeat_interleave(
+        torch.arange(batch_size, device=x.device, dtype=torch.long),
+        input_lengths,
+        output_size=total_tokens,
+    )
+    position_ids = torch.arange(total_tokens, device=x.device, dtype=torch.long)
+    position_ids = position_ids - cu_seqlens[:-1].to(torch.long).index_select(
+        0, batch_ids
+    )
+    flat_indices = batch_ids * max_seqlen + position_ids
+    packed_x = x.reshape(batch_size * max_seqlen, hidden_size).index_select(
+        0, flat_indices
+    )
+    return packed_x, flat_indices, cu_seqlens, position_ids
+
+
 def _pack_unpadded_sequence(
     x: torch.Tensor,
     position_ids_cache: "_PositionIdsCache",
@@ -182,6 +275,17 @@ def _unpack_packed_sequence(
     return x
 
 
+def _unpack_packed_sequence_from_indices(
+    packed_x: torch.Tensor,
+    flat_indices: torch.Tensor,
+    batch_size: int,
+    max_seqlen: int,
+) -> torch.Tensor:
+    x = packed_x.new_zeros(batch_size * max_seqlen, packed_x.shape[-1])
+    x.index_copy_(0, flat_indices, packed_x)
+    return x.view(batch_size, max_seqlen, packed_x.shape[-1])
+
+
 def _unpack_unpadded_sequence(
     packed_x: torch.Tensor,
 ) -> torch.Tensor:
@@ -195,6 +299,7 @@ class _MossPackedRopeCache:
         self._head_dim = 0
         self._cos: torch.Tensor | None = None
         self._sin: torch.Tensor | None = None
+        self._cos_sin: torch.Tensor | None = None
 
     def get(
         self,
@@ -210,6 +315,7 @@ class _MossPackedRopeCache:
         if (
             self._cos is not None
             and self._sin is not None
+            and self._cos_sin is not None
             and self._device == device
             and self._head_dim == head_dim
             and self._cos.shape[0] >= max_positions
@@ -227,7 +333,23 @@ class _MossPackedRopeCache:
         self._head_dim = head_dim
         self._cos = torch.cos(phase)
         self._sin = torch.sin(phase)
+        self._cos_sin = torch.cat((self._cos, self._sin), dim=-1)
         return self._cos, self._sin
+
+    def get_cos_sin_cache(
+        self,
+        *,
+        device: torch.device,
+        head_dim: int,
+        max_positions: int,
+    ) -> torch.Tensor:
+        self.get(
+            device=device,
+            head_dim=head_dim,
+            max_positions=max_positions,
+        )
+        assert self._cos_sin is not None
+        return self._cos_sin[:max_positions]
 
 
 def _apply_cached_packed_rope(
@@ -249,6 +371,20 @@ def _apply_cached_packed_rope(
     _, _, head_dim = q.shape
     if head_dim <= 0 or head_dim % 2 != 0:
         raise ValueError(f"RoPE requires an even head_dim, got {head_dim}")
+    if q.device.type == "cuda":
+        cos_sin_cache = cache.get_cos_sin_cache(
+            device=q.device,
+            head_dim=head_dim,
+            max_positions=max_positions,
+        )
+        if apply_exact_interleaved_rope_inplace(
+            q,
+            k,
+            cos_sin_cache,
+            position_ids,
+        ):
+            return q, k
+
     cos_cache, sin_cache = cache.get(
         device=q.device,
         head_dim=head_dim,
@@ -285,7 +421,7 @@ def _apply_cached_packed_rope(
     return q_out, k_out
 
 
-class MossTTSLocalAttention(nn.Module):
+class MossAudioTokenizerAttention(nn.Module):
     """MOSS local-causal self attention over dense or packed decoder frames."""
 
     def __init__(
@@ -296,8 +432,8 @@ class MossTTSLocalAttention(nn.Module):
     ) -> None:
         super().__init__()
         object.__setattr__(self, "source", source)
-        self.in_proj = source.in_proj
-        self.out_proj = source.out_proj
+        self.in_proj = _single_module(source, "in_proj", "in_projs")
+        self.out_proj = _single_module(source, "out_proj", "out_projs")
         self.embed_dim = int(source.embed_dim)
         self.num_heads = int(source.num_heads)
         self.head_dim = int(
@@ -311,6 +447,7 @@ class MossTTSLocalAttention(nn.Module):
         self.causal = bool(source.causal)
         self.context = source.context
         self.rope = source.rope
+        self._legacy_api = not hasattr(source, "resolve_attention_implementation")
         self._flash_attn_varlen = flash_attn_varlen_func
         max_period = self.rope.max_period if self.rope is not None else 10000.0
         self._packed_rope_cache = packed_rope_cache or _MossPackedRopeCache(
@@ -318,19 +455,50 @@ class MossTTSLocalAttention(nn.Module):
         )
 
     def resolve_attention_implementation(self, x: torch.Tensor) -> str:
-        if (
-            self.source.attention_implementation == "flash_attention_2"
-            and self._can_run_packed_flash(x)
-        ):
-            return "flash_attention_2"
-        return self.source.resolve_attention_implementation(x, is_streaming=False)
+        preferred = getattr(self.source, "attention_implementation", None)
+        if preferred is None:
+            # The legacy tokenizer has no backend selector, but exposes the same
+            # local-causal operation. Prefer the packed path when its dtype and
+            # device requirements are satisfied.
+            preferred = _FLASH_ATTENTION_BACKEND
+        if preferred == _FLASH_ATTENTION_BACKEND and self._can_run_packed_flash(x):
+            return _FLASH_ATTENTION_BACKEND
+        resolver = getattr(self.source, "resolve_attention_implementation", None)
+        if resolver is None:
+            return "sdpa"
+        return resolver(x, is_streaming=False)
+
+    def supports_packed_flash(
+        self,
+        device: torch.device,
+        dtype: torch.dtype | None,
+    ) -> bool:
+        if dtype is None or self._flash_attn_varlen is None or device.type != "cuda":
+            return False
+        preferred = getattr(self.source, "attention_implementation", None)
+        if preferred not in (None, _FLASH_ATTENTION_BACKEND):
+            return False
+        if getattr(self.source, "_get_backend_check_dtype", None) is not None:
+            # Preserve the v2/Local contract, whose packed path is BF16-only.
+            return dtype == torch.bfloat16
+        return dtype in (torch.float16, torch.bfloat16)
 
     def _can_run_packed_flash(self, x: torch.Tensor) -> bool:
-        if self._flash_attn_varlen is None:
-            return False
-        if x.device.type != "cuda":
-            return False
-        return self.source._get_backend_check_dtype(x) == torch.bfloat16
+        dtype_resolver = getattr(self.source, "_get_backend_check_dtype", None)
+        if dtype_resolver is not None:
+            backend_dtype = dtype_resolver(x)
+        else:
+            backend_dtype = x.dtype
+            try:
+                autocast_enabled = torch.is_autocast_enabled("cuda")
+            except TypeError:
+                autocast_enabled = torch.is_autocast_enabled()
+            if autocast_enabled:
+                try:
+                    backend_dtype = torch.get_autocast_dtype("cuda")
+                except TypeError:
+                    backend_dtype = torch.get_autocast_gpu_dtype()
+        return self.supports_packed_flash(x.device, backend_dtype)
 
     def forward(
         self,
@@ -367,10 +535,9 @@ class MossTTSLocalAttention(nn.Module):
             )
         if input_lengths is None:
             raise ValueError("dense attention requires input_lengths")
-        return self.source(
-            query,
-            input_lengths=input_lengths,
-        )
+        if self._legacy_api:
+            return self.source(query, query, query)
+        return self.source(query, input_lengths=input_lengths)
 
     def _project_qkv(
         self, x: torch.Tensor
@@ -421,7 +588,11 @@ class MossTTSLocalAttention(nn.Module):
             max_positions=max_seqlen,
         )
         assert self._flash_attn_varlen is not None
-        if self.causal and self.context is not None:
+        if (
+            self.causal
+            and self.context is not None
+            and max_seqlen > _FA3_LOCAL_WINDOW_QUERY_TILE_SIZE
+        ):
             context = int(self.context)
             plan = local_flash_plan or _build_local_causal_flash_plan(
                 cu_seqlens,
@@ -468,7 +639,7 @@ class MossTTSLocalAttention(nn.Module):
         return (max(int(self.context) - 1, 0), 0)
 
 
-class MossTTSLocalTransformerLayer(nn.Module):
+class MossAudioTokenizerTransformerLayer(nn.Module):
     """One MOSS vocoder transformer layer."""
 
     def __init__(
@@ -483,14 +654,12 @@ class MossTTSLocalTransformerLayer(nn.Module):
         self.norm2 = source.norm2
         self.layer_scale_1 = source.layer_scale_1
         self.layer_scale_2 = source.layer_scale_2
-        self.ffn = source.ffn
-        self.self_attn = MossTTSLocalAttention(
+        self.ffn = _feed_forward(source)
+        self.self_attn = MossAudioTokenizerAttention(
             source.self_attn,
             packed_rope_cache=packed_rope_cache,
         )
-        assert (
-            isinstance(self.ffn, nn.Sequential) and len(self.ffn) >= 3
-        ), "MOSS vocoder transformer layer requires Linear-GELU-Linear FFN"
+        assert callable(self.ffn), "MOSS vocoder transformer layer requires an FFN"
 
     def forward(self, x: torch.Tensor, **kwargs: Any) -> torch.Tensor:
         residual = x
@@ -502,7 +671,7 @@ class MossTTSLocalTransformerLayer(nn.Module):
         return x
 
 
-class MossTTSLocalTransformer(nn.Module):
+class MossAudioTokenizerTransformer(nn.Module):
     """MOSS vocoder transformer body."""
 
     def __init__(self, source: nn.Module) -> None:
@@ -511,7 +680,7 @@ class MossTTSLocalTransformer(nn.Module):
         packed_rope_cache = _MossPackedRopeCache(max_period=source.max_period)
         self.layers = nn.ModuleList(
             [
-                MossTTSLocalTransformerLayer(
+                MossAudioTokenizerTransformerLayer(
                     layer,
                     packed_rope_cache=packed_rope_cache,
                 )
@@ -527,6 +696,16 @@ class MossTTSLocalTransformer(nn.Module):
     def resolve_attention_implementation(self, x: torch.Tensor) -> str:
         assert len(self.layers) > 0, "MOSS vocoder transformer must have layers"
         return self.layers[0].self_attn.resolve_attention_implementation(x)
+
+    def supports_packed_flash(
+        self,
+        device: torch.device,
+        dtype: torch.dtype | None,
+    ) -> bool:
+        return bool(self.layers) and all(
+            layer.self_attn.supports_packed_flash(device, dtype)
+            for layer in self.layers
+        )
 
     def forward(self, x: torch.Tensor, **kwargs: Any) -> torch.Tensor:
         if self.positional_embedding in {"sin", "sin_rope"}:
@@ -551,7 +730,7 @@ class MossTTSLocalTransformer(nn.Module):
         return x
 
 
-class MossTTSLocalProjectedTransformer(nn.Module):
+class MossAudioTokenizerProjectedTransformer(nn.Module):
     """Projected transformer decoder stage with the MOSS input/output layout."""
 
     def __init__(self, source: nn.Module) -> None:
@@ -559,20 +738,29 @@ class MossTTSLocalProjectedTransformer(nn.Module):
         object.__setattr__(self, "source", source)
         self.input_proj = source.input_proj
         self.output_proj = source.output_proj
-        self.transformer = MossTTSLocalTransformer(source.transformer)
+        self.transformer = MossAudioTokenizerTransformer(source.transformer)
         self._position_ids_cache = _PositionIdsCache()
 
     def forward(
         self,
         x: torch.Tensor,
         input_lengths: torch.Tensor,
+        *,
+        input_lengths_cpu: Sequence[int] | None = None,
         **kwargs: Any,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         x = self.input_proj(x.transpose(1, 2))
         backend = self.transformer.resolve_attention_implementation(x)
         if backend == "flash_attention_2":
             batch_size, max_seqlen, _ = x.shape
-            max_valid_seqlen = int(input_lengths.max().item()) if max_seqlen else 0
+            if input_lengths_cpu is not None:
+                if len(input_lengths_cpu) != batch_size:
+                    raise ValueError(
+                        "input_lengths_cpu must match the decoder batch size"
+                    )
+                max_valid_seqlen = max(map(int, input_lengths_cpu), default=0)
+            else:
+                max_valid_seqlen = int(input_lengths.max().item()) if max_seqlen else 0
             if max_valid_seqlen == 0:
                 x = x.new_zeros(x.shape)
             else:
@@ -583,16 +771,32 @@ class MossTTSLocalProjectedTransformer(nn.Module):
                         self._position_ids_cache,
                     )
                     valid_mask = None
+                    flat_indices = None
+                elif input_lengths_cpu is not None:
+                    packed_x, flat_indices, cu_seqlens, position_ids = (
+                        _pack_padded_sequence_from_host_lengths(
+                            x,
+                            input_lengths,
+                            input_lengths_cpu,
+                        )
+                    )
+                    valid_mask = None
                 else:
                     packed_x, valid_mask, cu_seqlens, position_ids = (
                         _pack_padded_sequence(x, input_lengths)
                     )
+                    flat_indices = None
                 first_attention = self.transformer.layers[0].self_attn
                 local_flash_plan = None
-                if first_attention.causal and first_attention.context is not None:
+                if (
+                    first_attention.causal
+                    and first_attention.context is not None
+                    and max_valid_seqlen > _FA3_LOCAL_WINDOW_QUERY_TILE_SIZE
+                ):
                     local_flash_plan = _build_local_causal_flash_plan(
                         cu_seqlens,
                         context=int(first_attention.context),
+                        sequence_lengths=input_lengths_cpu,
                     )
                 packed_x = self.transformer(
                     packed_x,
@@ -603,22 +807,36 @@ class MossTTSLocalProjectedTransformer(nn.Module):
                     local_flash_plan=local_flash_plan,
                     **kwargs,
                 )
-                x = (
-                    _unpack_unpadded_sequence(packed_x)
-                    if valid_mask is None
-                    else _unpack_packed_sequence(
+                if is_unpadded_single:
+                    x = _unpack_unpadded_sequence(packed_x)
+                elif flat_indices is not None:
+                    x = _unpack_packed_sequence_from_indices(
+                        packed_x,
+                        flat_indices,
+                        batch_size,
+                        max_seqlen,
+                    )
+                else:
+                    assert valid_mask is not None
+                    x = _unpack_packed_sequence(
                         packed_x,
                         valid_mask,
                         batch_size,
                         max_seqlen,
                     )
-                )
         else:
             x = self.transformer(x, input_lengths=input_lengths, **kwargs)
         return self.output_proj(x).transpose(1, 2), input_lengths
 
+    def supports_packed_flash(
+        self,
+        device: torch.device,
+        dtype: torch.dtype | None,
+    ) -> bool:
+        return self.transformer.supports_packed_flash(device, dtype)
 
-class MossTTSLocalVocoderDecoder(nn.Module):
+
+class MossAudioTokenizerVocoderDecoder(nn.Module):
     """Iterable MOSS vocoder decoder with patched projected transformers."""
 
     def __init__(self, source: nn.Module) -> None:
@@ -633,7 +851,7 @@ class MossTTSLocalVocoderDecoder(nn.Module):
     def _wrap_stage(stage: nn.Module) -> nn.Module:
         module_type = stage.module_type
         if module_type == "Transformer":
-            return MossTTSLocalProjectedTransformer(stage)
+            return MossAudioTokenizerProjectedTransformer(stage)
         if module_type == "PatchedPretransform":
             return stage
         raise ValueError(
@@ -650,11 +868,69 @@ class MossTTSLocalVocoderDecoder(nn.Module):
     def __getitem__(self, index: int) -> nn.Module:
         return self.stages[index]
 
+    def supports_packed_flash(
+        self,
+        device: str | torch.device,
+        dtype: torch.dtype | None,
+    ) -> bool:
+        device = torch.device(device)
+        transformer_stages = [
+            stage
+            for stage in self.stages
+            if isinstance(stage, MossAudioTokenizerProjectedTransformer)
+        ]
+        return bool(transformer_stages) and all(
+            stage.supports_packed_flash(device, dtype) for stage in transformer_stages
+        )
+
+    @staticmethod
+    def _update_cpu_lengths(
+        stage: nn.Module,
+        input_lengths: Sequence[int],
+    ) -> list[int]:
+        if isinstance(stage, MossAudioTokenizerProjectedTransformer):
+            return list(map(int, input_lengths))
+        patch_size = int(getattr(stage, "patch_size", 0))
+        if patch_size <= 0:
+            raise ValueError("MOSS patched pretransform requires patch_size > 0")
+        if bool(getattr(stage, "is_downsample", False)):
+            return [int(length) // patch_size for length in input_lengths]
+        return [int(length) * patch_size for length in input_lengths]
+
+    def output_lengths(self, input_lengths: Sequence[int]) -> list[int]:
+        output_lengths = list(map(int, input_lengths))
+        for stage in self.stages:
+            output_lengths = self._update_cpu_lengths(stage, output_lengths)
+        return output_lengths
+
     def forward(
         self,
         x: torch.Tensor,
         input_lengths: torch.Tensor,
+        *,
+        input_lengths_cpu: Sequence[int] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        cpu_lengths = (
+            None if input_lengths_cpu is None else list(map(int, input_lengths_cpu))
+        )
         for stage in self.stages:
-            x, input_lengths = stage(x, input_lengths)
+            if isinstance(stage, MossAudioTokenizerProjectedTransformer):
+                x, input_lengths = stage(
+                    x,
+                    input_lengths,
+                    input_lengths_cpu=cpu_lengths,
+                )
+            else:
+                x, input_lengths = stage(x, input_lengths)
+            if cpu_lengths is not None:
+                cpu_lengths = self._update_cpu_lengths(stage, cpu_lengths)
         return x, input_lengths
+
+
+__all__ = [
+    "MossAudioTokenizerAttention",
+    "MossAudioTokenizerProjectedTransformer",
+    "MossAudioTokenizerTransformer",
+    "MossAudioTokenizerTransformerLayer",
+    "MossAudioTokenizerVocoderDecoder",
+]

--- a/sglang_omni/models/moss_tts/vocoder_decoder.py
+++ b/sglang_omni/models/moss_tts/vocoder_decoder.py
@@ -457,9 +457,10 @@ class MossAudioTokenizerAttention(nn.Module):
     def resolve_attention_implementation(self, x: torch.Tensor) -> str:
         preferred = getattr(self.source, "attention_implementation", None)
         if preferred is None:
-            # The legacy tokenizer has no backend selector, but exposes the same
-            # local-causal operation. Prefer the packed path when its dtype and
-            # device requirements are satisfied.
+            # Note (Zhang Yiyang): The legacy MOSS-Audio-Tokenizer attention has
+            # no backend selector, but implements the same local-causal operation.
+            # Prefer packed FlashAttention when its device and dtype requirements
+            # are satisfied.
             preferred = _FLASH_ATTENTION_BACKEND
         if preferred == _FLASH_ATTENTION_BACKEND and self._can_run_packed_flash(x):
             return _FLASH_ATTENTION_BACKEND

--- a/sglang_omni/models/moss_tts/vocoder_kernels.py
+++ b/sglang_omni/models/moss_tts/vocoder_kernels.py
@@ -57,9 +57,10 @@ if triton is not None and hasattr(tl, "inline_asm_elementwise"):
         kr = tl.load(k_base, mask=mask).to(tl.float32)
         ki = tl.load(k_base + 1, mask=mask).to(tl.float32)
 
-        # The source implementation materializes each FP32 multiply before the
-        # add/subtract. Explicit rounding prevents contraction into FMAs and
-        # keeps the fused kernel bitwise-equivalent after the low-precision store.
+        # Note (Zhang Yiyang): The source implementation materializes each FP32
+        # multiply before the add/subtract. Explicit rounding prevents contraction
+        # into FMAs and keeps the fused kernel bitwise-equivalent after the
+        # low-precision store.
         qor, qoi, kor, koi = tl.inline_asm_elementwise(
             asm="""
             {

--- a/sglang_omni/models/moss_tts/vocoder_kernels.py
+++ b/sglang_omni/models/moss_tts/vocoder_kernels.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared inference kernels for the MOSS audio-tokenizer vocoder."""
+
+from __future__ import annotations
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:  # pragma: no cover - depends on runtime image
+    triton = None
+    tl = None
+
+
+_EXACT_ROPE_BLOCK_SIZE = 256
+_EXACT_ROPE_NUM_WARPS = 4
+
+
+if triton is not None and hasattr(tl, "inline_asm_elementwise"):
+
+    @triton.jit
+    def _exact_interleaved_rope_kernel(
+        q,
+        k,
+        cos_sin,
+        positions,
+        total_pairs,
+        stride_qt,
+        stride_qh,
+        stride_kt,
+        stride_kh,
+        num_heads: tl.constexpr,
+        head_dim: tl.constexpr,
+        block_size: tl.constexpr,
+    ):
+        half_dim: tl.constexpr = head_dim // 2
+        offsets = tl.program_id(0) * block_size + tl.arange(0, block_size)
+        mask = offsets < total_pairs
+        token = offsets // (num_heads * half_dim)
+        pair_in_token = offsets % (num_heads * half_dim)
+        head = pair_in_token // half_dim
+        pair = pair_in_token % half_dim
+        q_base = q + token * stride_qt + head * stride_qh + pair * 2
+        k_base = k + token * stride_kt + head * stride_kh + pair * 2
+        position = tl.load(positions + token, mask=mask, other=0)
+        cos = tl.load(
+            cos_sin + position * head_dim + pair,
+            mask=mask,
+        ).to(tl.float32)
+        sin = tl.load(
+            cos_sin + position * head_dim + half_dim + pair,
+            mask=mask,
+        ).to(tl.float32)
+        qr = tl.load(q_base, mask=mask).to(tl.float32)
+        qi = tl.load(q_base + 1, mask=mask).to(tl.float32)
+        kr = tl.load(k_base, mask=mask).to(tl.float32)
+        ki = tl.load(k_base + 1, mask=mask).to(tl.float32)
+
+        # The source implementation materializes each FP32 multiply before the
+        # add/subtract. Explicit rounding prevents contraction into FMAs and
+        # keeps the fused kernel bitwise-equivalent after the low-precision store.
+        qor, qoi, kor, koi = tl.inline_asm_elementwise(
+            asm="""
+            {
+                .reg .f32 a;
+                .reg .f32 b;
+                mul.rn.f32 a, $4, $8;
+                mul.rn.f32 b, $5, $9;
+                sub.rn.f32 $0, a, b;
+                mul.rn.f32 a, $4, $9;
+                mul.rn.f32 b, $5, $8;
+                add.rn.f32 $1, a, b;
+                mul.rn.f32 a, $6, $8;
+                mul.rn.f32 b, $7, $9;
+                sub.rn.f32 $2, a, b;
+                mul.rn.f32 a, $6, $9;
+                mul.rn.f32 b, $7, $8;
+                add.rn.f32 $3, a, b;
+            }
+            """,
+            constraints="=f,=f,=f,=f,f,f,f,f,f,f",
+            args=[qr, qi, kr, ki, cos, sin],
+            dtype=(tl.float32, tl.float32, tl.float32, tl.float32),
+            is_pure=True,
+            pack=1,
+        )
+        tl.store(q_base, qor, mask=mask)
+        tl.store(q_base + 1, qoi, mask=mask)
+        tl.store(k_base, kor, mask=mask)
+        tl.store(k_base + 1, koi, mask=mask)
+
+else:
+    _exact_interleaved_rope_kernel = None
+
+
+def apply_exact_interleaved_rope_inplace(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    position_ids: torch.Tensor,
+) -> bool:
+    """Apply source-equivalent interleaved RoPE in one CUDA kernel if supported."""
+
+    if (
+        _exact_interleaved_rope_kernel is None
+        or torch.version.hip is not None
+        or q.device.type != "cuda"
+        or k.device != q.device
+        or cos_sin_cache.device != q.device
+        or position_ids.device != q.device
+        or q.dtype not in (torch.bfloat16, torch.float16)
+        or k.dtype != q.dtype
+        or cos_sin_cache.dtype != torch.float32
+        or position_ids.dtype not in (torch.int32, torch.int64)
+        or q.ndim != 3
+        or k.shape != q.shape
+        or cos_sin_cache.ndim != 2
+        or int(cos_sin_cache.shape[0]) == 0
+        or int(cos_sin_cache.shape[1]) != int(q.shape[2])
+        or position_ids.ndim != 1
+        or int(position_ids.numel()) != int(q.shape[0])
+        or q.stride(2) != 1
+        or k.stride(2) != 1
+        or position_ids.stride(0) != 1
+        or not cos_sin_cache.is_contiguous()
+    ):
+        return False
+
+    tokens, num_heads, head_dim = map(int, q.shape)
+    if tokens == 0 or num_heads <= 0 or head_dim <= 0 or head_dim % 2 != 0:
+        return False
+    total_pairs = tokens * num_heads * (head_dim // 2)
+    block_size = _EXACT_ROPE_BLOCK_SIZE
+    _exact_interleaved_rope_kernel[(triton.cdiv(total_pairs, block_size),)](
+        q,
+        k,
+        cos_sin_cache,
+        position_ids,
+        total_pairs,
+        q.stride(0),
+        q.stride(1),
+        k.stride(0),
+        k.stride(1),
+        num_heads=num_heads,
+        head_dim=head_dim,
+        block_size=block_size,
+        num_warps=_EXACT_ROPE_NUM_WARPS,
+    )
+    return True
+
+
+__all__ = ["apply_exact_interleaved_rope_inplace"]

--- a/sglang_omni/models/moss_tts/vocoder_quantizer.py
+++ b/sglang_omni/models/moss_tts/vocoder_quantizer.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Inference-only quantizer decode helpers for MOSS-TTS Delay."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+
+def _pointwise_conv1d_parameters(
+    module: nn.Module,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    if not isinstance(module, nn.Conv1d):
+        raise TypeError(f"expected Conv1d, got {module.__class__.__name__}")
+    if (
+        module.kernel_size != (1,)
+        or module.stride != (1,)
+        or module.padding != (0,)
+        or module.dilation != (1,)
+        or module.groups != 1
+    ):
+        raise ValueError("cached quantizer decode requires pointwise Conv1d")
+    weight = module.weight.detach().squeeze(-1).to(dtype=torch.float32)
+    bias = None if module.bias is None else module.bias.detach().to(dtype=torch.float32)
+    return weight, bias
+
+
+class MossAudioTokenizerQuantizerDecoder:
+    """Cache FP32 codebooks and projections used by residual codec decode."""
+
+    def __init__(self, source: nn.Module) -> None:
+        quantizers = list(getattr(source, "quantizers", ()))
+        if not quantizers:
+            raise ValueError("MOSS quantizer has no residual codebooks")
+
+        codebooks: list[torch.Tensor] = []
+        weights: list[torch.Tensor] = []
+        biases: list[torch.Tensor | None] = []
+        codebook_size = 0
+        output_dim = 0
+        for quantizer in quantizers:
+            codebook = getattr(getattr(quantizer, "codebook", None), "weight", None)
+            if not isinstance(codebook, torch.Tensor) or codebook.ndim != 2:
+                raise TypeError("MOSS quantizer codebook must be a 2D tensor")
+            weight, bias = _pointwise_conv1d_parameters(quantizer.out_proj)
+            if int(codebook.shape[1]) != int(weight.shape[1]):
+                raise ValueError("MOSS codebook and projection dimensions do not match")
+            if not codebooks:
+                codebook_size = int(codebook.shape[0])
+                output_dim = int(weight.shape[0])
+            elif (
+                tuple(codebook.shape) != tuple(codebooks[0].shape)
+                or int(weight.shape[0]) != output_dim
+            ):
+                raise ValueError(
+                    "MOSS residual codebooks must share input and output sizes"
+                )
+            codebooks.append(codebook.detach().to(dtype=torch.float32))
+            weights.append(weight)
+            biases.append(bias)
+
+        output_proj = getattr(source, "output_proj", None)
+        if isinstance(output_proj, nn.Identity):
+            output_weight = None
+            output_bias = None
+        else:
+            output_weight, output_bias = _pointwise_conv1d_parameters(output_proj)
+            if int(output_weight.shape[1]) != output_dim:
+                raise ValueError(
+                    "MOSS quantizer output projection has an unexpected input size"
+                )
+
+        self._num_quantizers = len(quantizers)
+        self._output_dim = output_dim
+        self._flat_codebooks = torch.stack(codebooks).flatten(0, 1)
+        self._weights = tuple(weights)
+        self._biases = tuple(biases)
+        self._offsets = (
+            torch.arange(
+                self._num_quantizers,
+                device=self._flat_codebooks.device,
+                dtype=torch.long,
+            )
+            * codebook_size
+        ).view(-1, 1, 1)
+        self._output_weight = output_weight
+        self._output_bias = output_bias
+
+    def decode_codes(self, codes: torch.Tensor) -> torch.Tensor:
+        if codes.ndim != 3:
+            raise ValueError(
+                f"MOSS quantizer codes must be [N, B, T], got {tuple(codes.shape)}"
+            )
+        num_quantizers = int(codes.shape[0])
+        if num_quantizers <= 0 or num_quantizers > self._num_quantizers:
+            raise ValueError(
+                "MOSS quantizer codebook count must be within "
+                f"[1, {self._num_quantizers}], got {num_quantizers}"
+            )
+        if codes.device != self._flat_codebooks.device:
+            raise ValueError(
+                "MOSS quantizer codes and cached weights must share one device"
+            )
+
+        _, batch_size, frames = codes.shape
+        decoded = torch.zeros(
+            batch_size,
+            self._output_dim,
+            frames,
+            device=codes.device,
+            dtype=torch.float32,
+        )
+        embedded = F.embedding(
+            codes + self._offsets[:num_quantizers],
+            self._flat_codebooks,
+        )
+        for index in range(num_quantizers):
+            decoded.add_(
+                F.conv1d(
+                    embedded[index].transpose(1, 2),
+                    self._weights[index].unsqueeze(-1),
+                    self._biases[index],
+                )
+            )
+        if self._output_weight is not None:
+            decoded = F.conv1d(
+                decoded,
+                self._output_weight.unsqueeze(-1),
+                self._output_bias,
+            )
+        return decoded
+
+
+__all__ = ["MossAudioTokenizerQuantizerDecoder"]

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -16,8 +16,8 @@ from typing import Any, Mapping
 
 import torch
 
+from sglang_omni.models.moss_tts.vocoder_decoder import MossAudioTokenizerVocoderDecoder
 from sglang_omni.models.moss_tts_local.payload_types import MossTTSLocalState
-from sglang_omni.models.moss_tts_local.vocoder_decoder import MossTTSLocalVocoderDecoder
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.pipeline_state import build_usage
 from sglang_omni.scheduling.streaming_vocoder import (
@@ -374,7 +374,7 @@ class MossTTSLocalStreamingVocoderScheduler(
                 f"MOSS-TTS Local streaming vocoder: codec is missing {missing}; "
                 "the installed MOSS-Audio-Tokenizer-v2 version is incompatible"
             )
-        nonstream_decoder = MossTTSLocalVocoderDecoder(codec.decoder)
+        nonstream_decoder = MossAudioTokenizerVocoderDecoder(codec.decoder)
         logger.info(
             f"MOSS-TTS Local non-streaming vocoder uses packed SGLang attention "
             f"stages={len(nonstream_decoder)}"

--- a/tests/unit_test/moss_tts/test_delay_pattern.py
+++ b/tests/unit_test/moss_tts/test_delay_pattern.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sglang_omni.models.moss_tts.delay_pattern import split_moss_audio_segments
+
+
+def _delay(raw_codes: torch.Tensor, *, fill: int = 1024) -> torch.Tensor:
+    frames, num_codebooks = raw_codes.shape
+    delayed = torch.full(
+        (frames + num_codebooks - 1, num_codebooks),
+        fill,
+        dtype=raw_codes.dtype,
+    )
+    for codebook in range(num_codebooks):
+        delayed[codebook : codebook + frames, codebook] = raw_codes[:, codebook]
+    return delayed
+
+
+def test_split_moss_audio_segments_reverses_delay_pattern() -> None:
+    raw_codes = torch.tensor(
+        [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+        dtype=torch.long,
+    )
+
+    segments = split_moss_audio_segments(_delay(raw_codes), audio_pad_code=1024)
+
+    assert len(segments) == 1
+    assert torch.equal(segments[0], raw_codes)
+
+
+def test_split_moss_audio_segments_preserves_contiguous_runs() -> None:
+    raw_codes = torch.tensor(
+        [
+            [1, 2, 3],
+            [4, 5, 6],
+            [1024, 1024, 1024],
+            [7, 8, 9],
+            [10, 11, 12],
+        ],
+        dtype=torch.long,
+    )
+
+    segments = split_moss_audio_segments(_delay(raw_codes), audio_pad_code=1024)
+
+    assert [segment.tolist() for segment in segments] == [
+        [[1, 2, 3], [4, 5, 6]],
+        [[7, 8, 9], [10, 11, 12]],
+    ]
+
+
+def test_split_moss_audio_segments_trims_assistant_prefix() -> None:
+    raw_codes = torch.tensor(
+        [[1, 2], [3, 4], [5, 6], [7, 8]],
+        dtype=torch.long,
+    )
+
+    segments = split_moss_audio_segments(
+        _delay(raw_codes),
+        audio_pad_code=1024,
+        assistant_start_length=2,
+    )
+
+    assert len(segments) == 1
+    assert torch.equal(segments[0], raw_codes[2:])
+
+
+def test_split_moss_audio_segments_accepts_noncontiguous_input() -> None:
+    raw_codes = torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=torch.long)
+    delayed = _delay(raw_codes)
+    storage = torch.full(
+        (delayed.shape[0], delayed.shape[1] * 2),
+        -1,
+        dtype=delayed.dtype,
+    )
+    storage[:, ::2] = delayed
+    noncontiguous = storage[:, ::2]
+    assert not noncontiguous.is_contiguous()
+
+    segments = split_moss_audio_segments(noncontiguous, audio_pad_code=1024)
+
+    assert len(segments) == 1
+    assert torch.equal(segments[0], raw_codes)
+
+
+def test_split_moss_audio_segments_allows_short_delay_window() -> None:
+    delayed = torch.zeros((2, 3), dtype=torch.long)
+
+    assert split_moss_audio_segments(delayed, audio_pad_code=1024) == []
+
+
+@pytest.mark.parametrize("shape", [(3,), (1, 2, 3)])
+def test_split_moss_audio_segments_rejects_non_matrix(shape: tuple[int, ...]) -> None:
+    with pytest.raises(ValueError, match="must be 2-D"):
+        split_moss_audio_segments(torch.zeros(shape), audio_pad_code=1024)

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -24,7 +24,6 @@ from benchmarks.tasks.tts import (
 from sglang_omni.config.manager import ConfigManager
 from sglang_omni.config.runtime import resolve_stage_factory_args
 from sglang_omni.models.moss_tts.config import MossTTSPipelineConfig
-from sglang_omni.models.moss_tts.delay_pattern import split_moss_audio_segments
 from sglang_omni.models.moss_tts.payload_types import MossTTSState
 from sglang_omni.models.moss_tts.request_builders import (
     _INF_DELAY,
@@ -139,7 +138,10 @@ def test_moss_tts_config_and_registry_contracts() -> None:
         "ref_audio_cache_max_items": 8192,
         "ref_audio_cache_max_bytes": 64 * 1024 * 1024,
     }
-    assert vocoder.factory_args == {"dtype": "bfloat16"}
+    assert vocoder.factory_args == {
+        "dtype": "bfloat16",
+        "compute_dtype": "bfloat16",
+    }
 
 
 def test_moss_tts_production_config_resolves_codec_memory_policy() -> None:
@@ -163,6 +165,7 @@ def test_moss_tts_production_config_resolves_codec_memory_policy() -> None:
     }
     assert vocoder_args == {
         "dtype": "bfloat16",
+        "compute_dtype": "bfloat16",
         "model_path": "OpenMOSS-Team/MOSS-TTS-v1.5",
         "gpu_id": 0,
     }
@@ -189,6 +192,7 @@ def test_moss_tts_32gb_config_bounds_runtime_memory() -> None:
         "cuda_graph_max_bs": 1,
     }
     assert vocoder_args["dtype"] == "bfloat16"
+    assert vocoder_args["compute_dtype"] == "bfloat16"
     assert vocoder_args["max_batch_size"] == 1
     assert vocoder_args["max_batch_wait_ms"] == 2
 
@@ -215,6 +219,7 @@ def test_moss_tts_24gb_config_bounds_runtime_memory() -> None:
         "cuda_graph_max_bs": 1,
     }
     assert vocoder_args["dtype"] == "bfloat16"
+    assert vocoder_args["compute_dtype"] == "bfloat16"
     assert vocoder_args["max_batch_size"] == 1
     assert vocoder_args["max_batch_wait_ms"] == 2
 
@@ -239,6 +244,7 @@ def test_moss_tts_codec_runtime_overrides_take_precedence() -> None:
     assert preprocessing_args["gpu_id"] == 2
     assert vocoder_args["device"] == "cpu"
     assert vocoder_args["dtype"] == "float32"
+    assert vocoder_args["compute_dtype"] == "bfloat16"
     assert vocoder_args["gpu_id"] == 2
 
 
@@ -260,6 +266,53 @@ def test_moss_tts_config_merge_updates_reference_cache_factory_args() -> None:
     assert preprocessing.factory_args["ref_audio_cache"] is False
     assert preprocessing.factory_args["ref_audio_cache_max_items"] == 17
     assert preprocessing.factory_args["ref_audio_cache_max_bytes"] == 4096
+
+
+def test_moss_tts_config_merge_updates_vocoder_factory_args() -> None:
+    from sglang_omni.config.manager import ConfigManager
+
+    config = MossTTSPipelineConfig(model_path="model")
+    merged = ConfigManager(config).merge_config(
+        {
+            "stages.vocoder.factory_args.compute_dtype": "float32",
+        }
+    )
+    vocoder = next(stage for stage in merged.stages if stage.name == "vocoder")
+
+    assert vocoder.factory_args["compute_dtype"] == "float32"
+
+    disabled = ConfigManager(config).merge_config(
+        {"stages.vocoder.factory_args.compute_dtype": None}
+    )
+    vocoder = next(stage for stage in disabled.stages if stage.name == "vocoder")
+
+    assert vocoder.factory_args["compute_dtype"] is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        ("float32", torch.float32),
+        ("bfloat16", torch.bfloat16),
+        (torch.float32, torch.float32),
+        (torch.bfloat16, torch.bfloat16),
+    ],
+)
+def test_moss_tts_resolves_compute_dtype(value, expected) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    assert stages._resolve_compute_dtype(value) is expected
+
+
+@pytest.mark.parametrize(
+    "value", ["fp16", "float16", "fp32", "bf16", "invalid", torch.float16]
+)
+def test_moss_tts_rejects_invalid_compute_dtype(value) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    with pytest.raises(ValueError, match="compute_dtype"):
+        stages._resolve_compute_dtype(value)
 
 
 def test_moss_tts_preprocessing_factory_receives_placement_gpu_id() -> None:
@@ -1850,22 +1903,6 @@ def test_moss_audio_end_in_batch_uses_full_text_path_on_next_step() -> None:
     )
 
     assert seen == {"head": False, "sampler": False}
-
-
-def test_moss_delay_codec_splits_non_pad_segments() -> None:
-    delayed = torch.tensor(
-        [
-            [1, 1024],
-            [2, 3],
-            [1024, 4],
-            [1024, 1024],
-        ],
-        dtype=torch.long,
-    )
-
-    segments = split_moss_audio_segments(delayed, audio_pad_code=1024)
-
-    assert [segment.tolist() for segment in segments] == [[[1, 3], [2, 4]]]
 
 
 def test_moss_sample_tokens_uses_per_row_top_k() -> None:

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -132,14 +132,13 @@ def test_moss_tts_config_and_registry_contracts() -> None:
     )
     vocoder = next(stage for stage in config.stages if stage.name == "vocoder")
     assert preprocessing.factory_args == {
-        "device": "cpu",
         "dtype": "float32",
         "ref_audio_cache": True,
         "ref_audio_cache_max_items": 8192,
         "ref_audio_cache_max_bytes": 64 * 1024 * 1024,
     }
     assert vocoder.factory_args == {
-        "dtype": "bfloat16",
+        "dtype": "float32",
         "compute_dtype": "bfloat16",
     }
 
@@ -155,7 +154,6 @@ def test_moss_tts_production_config_resolves_codec_memory_policy() -> None:
     vocoder_args = resolve_stage_factory_args(stages["vocoder"], config, gpu_id=0)
 
     assert preprocessing_args == {
-        "device": "cpu",
         "dtype": "float32",
         "ref_audio_cache": True,
         "ref_audio_cache_max_items": 8192,
@@ -164,7 +162,7 @@ def test_moss_tts_production_config_resolves_codec_memory_policy() -> None:
         "gpu_id": 0,
     }
     assert vocoder_args == {
-        "dtype": "bfloat16",
+        "dtype": "float32",
         "compute_dtype": "bfloat16",
         "model_path": "OpenMOSS-Team/MOSS-TTS-v1.5",
         "gpu_id": 0,
@@ -333,7 +331,7 @@ def test_moss_tts_preprocessing_factory_receives_placement_gpu_id() -> None:
 
     assert preprocessing.gpu == 2
     assert factory_args["gpu_id"] == 2
-    assert factory_args["device"] == "cpu"
+    assert "device" not in factory_args
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_test/moss_tts/test_streaming_vocoder.py
+++ b/tests/unit_test/moss_tts/test_streaming_vocoder.py
@@ -14,8 +14,8 @@ from sglang_omni.models.moss_tts.request_builders import (
     MossTTSSGLangRequestData,
     make_moss_tts_stream_output_builder,
 )
-from sglang_omni.models.moss_tts.stages import _MossTTSVocoder
 from sglang_omni.models.moss_tts.streaming_vocoder import MossStreamingVocoderScheduler
+from sglang_omni.models.moss_tts.vocoder import MossTTSVocoder
 from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling.types import RequestOutput
@@ -50,7 +50,7 @@ def _make_scheduler(
     stream_followup_stride: int = 2,
     stream_overlap_tokens: int = 1,
     stream_holdback_tokens: int = 0,
-) -> tuple[MossStreamingVocoderScheduler, _FakeAudioTokenizer, _MossTTSVocoder]:
+) -> tuple[MossStreamingVocoderScheduler, _FakeAudioTokenizer, MossTTSVocoder]:
     processor = SimpleNamespace(
         model_config=SimpleNamespace(
             n_vq=3,
@@ -59,7 +59,7 @@ def _make_scheduler(
         )
     )
     tokenizer = _FakeAudioTokenizer()
-    vocoder = _MossTTSVocoder(processor, tokenizer, "cpu")
+    vocoder = MossTTSVocoder(processor, tokenizer, "cpu")
     scheduler = MossStreamingVocoderScheduler(
         vocoder,
         stream_stride=stream_stride,
@@ -203,6 +203,29 @@ def test_streaming_matches_full_decode_across_segments() -> None:
     result = next(message for message in messages if message.type == "result")
     assert "delayed_audio_codes" not in result.data.data
     assert result.data.data["usage"]["completion_tokens"] == int(delayed.shape[0])
+
+
+def test_streaming_path_does_not_call_nonstream_batch_decoder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    delayed = _apply_delay_pattern(
+        torch.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=torch.long)
+    )
+    scheduler, tokenizer, vocoder = _make_scheduler()
+
+    async def fail_decode_batch(*_args, **_kwargs):
+        pytest.fail("streaming requests must not use the non-streaming batch decoder")
+
+    monkeypatch.setattr(vocoder, "decode_batch", fail_decode_batch)
+    scheduler._on_streaming_new_request("req", _payload("req", delayed))
+    scheduler._on_chunk("req", _item(delayed))
+    scheduler._on_done("req")
+
+    messages = _drain(scheduler)
+
+    assert tokenizer.decode_inputs
+    assert any(message.type == "stream" for message in messages)
+    assert any(message.type == "result" for message in messages)
 
 
 def test_chunks_and_done_before_payload_preserve_final_tail() -> None:

--- a/tests/unit_test/moss_tts/test_vocoder.py
+++ b/tests/unit_test/moss_tts/test_vocoder.py
@@ -1,0 +1,571 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+import sglang_omni.models.moss_tts.vocoder as vocoder_module
+from sglang_omni.models.moss_tts.payload_types import MossTTSState
+from sglang_omni.models.moss_tts.vocoder import (
+    MossTTSVocoder,
+    _copy_valid_waveforms_to_cpu,
+)
+from sglang_omni.models.moss_tts.vocoder_quantizer import (
+    MossAudioTokenizerQuantizerDecoder,
+)
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+def _make_payload(request_id: str) -> StagePayload:
+    return StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs=request_id, params={}),
+        data={},
+    )
+
+
+class _AlwaysPackedVocoderDecoder(nn.Module):
+    def __init__(self, source: nn.Module) -> None:
+        super().__init__()
+        self.stages = source
+
+    def __len__(self) -> int:
+        return len(self.stages)
+
+    def supports_packed_flash(self, device, dtype) -> bool:
+        del device, dtype
+        return True
+
+    def output_lengths(self, input_lengths):
+        output_lengths = list(input_lengths)
+        for stage in self.stages:
+            patch_size = int(getattr(stage, "patch_size", 1))
+            if bool(getattr(stage, "is_downsample", False)):
+                output_lengths = [length // patch_size for length in output_lengths]
+            else:
+                output_lengths = [length * patch_size for length in output_lengths]
+        return output_lengths
+
+    def forward(self, x, input_lengths, *, input_lengths_cpu=None):
+        del input_lengths_cpu
+        for stage in self.stages:
+            x, input_lengths = stage(x, input_lengths)
+        return x, input_lengths
+
+
+class _NeverPackedVocoderDecoder(_AlwaysPackedVocoderDecoder):
+    def supports_packed_flash(self, device, dtype) -> bool:
+        del device, dtype
+        return False
+
+
+class _FakeCodebookQuantizer(nn.Module):
+    def __init__(
+        self,
+        *,
+        codebook_size: int,
+        codebook_dim: int,
+        output_dim: int,
+    ) -> None:
+        super().__init__()
+        self.codebook = nn.Embedding(codebook_size, codebook_dim)
+        self.out_proj = nn.Conv1d(codebook_dim, output_dim, kernel_size=1)
+
+    def decode_code(self, codes: torch.Tensor) -> torch.Tensor:
+        embedded = self.codebook(codes).transpose(1, 2).float()
+        return self.out_proj(embedded).float()
+
+
+class _FakeResidualQuantizer(nn.Module):
+    def __init__(self, *, num_quantizers: int = 4) -> None:
+        super().__init__()
+        self.quantizers = nn.ModuleList(
+            [
+                _FakeCodebookQuantizer(
+                    codebook_size=16,
+                    codebook_dim=3,
+                    output_dim=8,
+                )
+                for _ in range(num_quantizers)
+            ]
+        )
+        self.output_proj = nn.Conv1d(8, 6, kernel_size=1)
+
+    def decode_codes(self, codes: torch.Tensor) -> torch.Tensor:
+        _, batch_size, frames = codes.shape
+        decoded = torch.zeros(batch_size, 8, frames, dtype=torch.float32)
+        for index, quantizer in enumerate(self.quantizers[: codes.shape[0]]):
+            decoded += quantizer.decode_code(codes[index])
+        return self.output_proj(decoded)
+
+
+@pytest.mark.parametrize("num_quantizers", [1, 3, 4])
+def test_cached_quantizer_matches_source_decode(num_quantizers: int) -> None:
+    torch.manual_seed(0)
+    source = _FakeResidualQuantizer()
+    decoder = MossAudioTokenizerQuantizerDecoder(source)
+    codes = torch.randint(0, 16, (num_quantizers, 2, 7))
+
+    expected = source.decode_codes(codes)
+    actual = decoder.decode_codes(codes)
+
+    assert torch.equal(actual, expected)
+
+
+def test_cached_quantizer_rejects_invalid_codebook_count() -> None:
+    decoder = MossAudioTokenizerQuantizerDecoder(_FakeResidualQuantizer())
+
+    with pytest.raises(ValueError, match="codebook count"):
+        decoder.decode_codes(torch.empty((0, 2, 3), dtype=torch.long))
+    with pytest.raises(ValueError, match="codebook count"):
+        decoder.decode_codes(torch.zeros((5, 2, 3), dtype=torch.long))
+
+
+def test_moss_tts_vocoder_copies_only_valid_waveforms() -> None:
+    audio = torch.tensor(
+        [
+            [[1.0, 2.0, 99.0]],
+            [[3.0, 4.0, 5.0]],
+        ],
+        dtype=torch.bfloat16,
+    )
+
+    waveforms = _copy_valid_waveforms_to_cpu(audio, [2, 3])
+
+    assert [waveform.dtype for waveform in waveforms] == [
+        torch.float32,
+        torch.float32,
+    ]
+    assert [waveform.tolist() for waveform in waveforms] == [
+        [1.0, 2.0],
+        [3.0, 4.0, 5.0],
+    ]
+
+
+def test_moss_tts_vocoder_batches_mixed_length_segments_across_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    class FakePatchStage(nn.Module):
+        module_type = "PatchedPretransform"
+        patch_size = 2
+        is_downsample = False
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.weight = nn.Parameter(torch.ones((), dtype=torch.float32))
+            self.autocast_enabled: list[bool] = []
+
+        def forward(self, x, input_lengths):
+            self.autocast_enabled.append(torch.is_autocast_enabled("cpu"))
+            return x.repeat_interleave(2, dim=-1), input_lengths * 2
+
+    class FakeQuantizer(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.codebook = nn.Parameter(torch.zeros((), dtype=torch.bfloat16))
+            self.decode_shapes: list[tuple[int, ...]] = []
+            self.autocast_enabled: list[bool] = []
+
+        def decode_codes(self, audio_codes):
+            self.decode_shapes.append(tuple(audio_codes.shape))
+            self.autocast_enabled.append(torch.is_autocast_enabled("cpu"))
+            _, batch_size, frames = audio_codes.shape
+            decoded = torch.zeros(batch_size, 1, frames, dtype=torch.float32)
+            for index in range(batch_size):
+                decoded[index].fill_(float(index + 1))
+            return decoded
+
+    class FakeCodec(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.dummy = nn.Parameter(torch.zeros(()))
+            self.quantizer = FakeQuantizer()
+            self.decoder = nn.ModuleList([FakePatchStage()])
+            self.config = SimpleNamespace(sampling_rate=24000)
+
+    class FakeAudioTokenizer:
+        def __init__(self, model) -> None:
+            self.model = model
+            self.sample_rate = 24000
+            self.decode_calls = 0
+
+        def decode_codes(self, segments):
+            self.decode_calls += 1
+            return [torch.zeros(1) for _ in segments]
+
+    codec = FakeCodec()
+    audio_tokenizer = FakeAudioTokenizer(codec)
+    processor = SimpleNamespace(
+        audio_tokenizer=None,
+        model_config=SimpleNamespace(audio_pad_code=1024, sampling_rate=24000),
+    )
+    monkeypatch.setattr(stages, "_load_moss_processor", lambda *args: processor)
+    monkeypatch.setattr(
+        stages,
+        "load_moss_tts_audio_tokenizer",
+        lambda *args, **kwargs: audio_tokenizer,
+    )
+    monkeypatch.setattr(
+        vocoder_module,
+        "MossAudioTokenizerVocoderDecoder",
+        _AlwaysPackedVocoderDecoder,
+    )
+
+    scheduler = stages.create_vocoder_executor(
+        "model",
+        device="cpu",
+        max_batch_size=4,
+        compute_dtype="bfloat16",
+    )
+    first = _make_payload("first")
+    first.data = MossTTSState(
+        delayed_audio_codes=torch.tensor(
+            [[1, 1024], [2, 3], [1024, 4], [1024, 1024]],
+            dtype=torch.long,
+        )
+    ).to_dict()
+    second = _make_payload("second")
+    second.data = MossTTSState(
+        delayed_audio_codes=torch.tensor(
+            [[5, 1024], [6, 7], [9, 8], [1024, 10], [1024, 1024]],
+            dtype=torch.long,
+        )
+    ).to_dict()
+
+    results = asyncio.run(scheduler._batch_fn([first, second]))
+
+    assert codec.quantizer.decode_shapes == [(2, 2, 3)]
+    assert codec.quantizer.autocast_enabled == [False]
+    assert codec.quantizer.codebook.dtype is torch.float32
+    assert codec.decoder[0].weight.dtype is torch.float32
+    assert codec.decoder[0].autocast_enabled == [True]
+    assert audio_tokenizer.decode_calls == 0
+    assert np.frombuffer(
+        results[0].data["audio_waveform"], dtype=np.float32
+    ).tolist() == [1.0, 1.0, 1.0, 1.0]
+    assert np.frombuffer(
+        results[1].data["audio_waveform"], dtype=np.float32
+    ).tolist() == [2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
+    assert results[0].data["sample_rate"] == 24000
+
+
+def test_moss_tts_vocoder_uses_standalone_codec_without_packed_flash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    class FakeQuantizer(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.codebook = nn.Parameter(torch.zeros((), dtype=torch.bfloat16))
+
+        def decode_codes(self, _audio_codes):
+            pytest.fail("standalone fallback must not call quantizer directly")
+
+    class FakeCodec(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.dummy = nn.Parameter(torch.zeros(()))
+            self.quantizer = FakeQuantizer()
+            self.decoder = nn.ModuleList([nn.Identity()])
+
+    class FakeAudioTokenizer:
+        sample_rate = 16000
+
+        def __init__(self) -> None:
+            self.model = FakeCodec()
+            self.decode_calls = 0
+            self.decode_shapes: list[list[tuple[int, ...]]] = []
+
+        def decode_codes(self, segments):
+            self.decode_calls += 1
+            self.decode_shapes.append([tuple(segment.shape) for segment in segments])
+            return [
+                torch.full((2,), float(self.decode_calls), dtype=torch.float32)
+                for _ in segments
+            ]
+
+    audio_tokenizer = FakeAudioTokenizer()
+    processor = SimpleNamespace(
+        model_config=SimpleNamespace(audio_pad_code=1024, sampling_rate=16000)
+    )
+    monkeypatch.setattr(stages, "_load_moss_processor", lambda *args: processor)
+    monkeypatch.setattr(
+        stages,
+        "load_moss_tts_audio_tokenizer",
+        lambda *args, **kwargs: audio_tokenizer,
+    )
+    monkeypatch.setattr(
+        vocoder_module,
+        "MossAudioTokenizerVocoderDecoder",
+        _NeverPackedVocoderDecoder,
+    )
+
+    scheduler = stages.create_vocoder_executor(
+        "model",
+        device="cpu",
+        max_batch_size=2,
+        compute_dtype="bfloat16",
+    )
+    payloads = []
+    for request_id, offset in (("first", 0), ("second", 4)):
+        payload = _make_payload(request_id)
+        payload.data = MossTTSState(
+            delayed_audio_codes=torch.tensor(
+                [
+                    [1 + offset, 1024],
+                    [2 + offset, 3 + offset],
+                    [1024, 4 + offset],
+                    [1024, 1024],
+                ],
+                dtype=torch.long,
+            )
+        ).to_dict()
+        payloads.append(payload)
+
+    results = asyncio.run(scheduler._batch_fn(payloads))
+
+    assert scheduler._vocoder._nonstream_decoder is None
+    assert audio_tokenizer.model.quantizer.codebook.dtype is torch.bfloat16
+    assert audio_tokenizer.decode_calls == 2
+    assert audio_tokenizer.decode_shapes == [[(2, 2)], [(2, 2)]]
+    assert np.frombuffer(
+        results[0].data["audio_waveform"], dtype=np.float32
+    ).tolist() == [1.0, 1.0]
+    assert np.frombuffer(
+        results[1].data["audio_waveform"], dtype=np.float32
+    ).tolist() == [2.0, 2.0]
+
+
+def test_moss_tts_vocoder_autocasts_low_precision_standalone_codec() -> None:
+    class FakeCodec(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.decoder = nn.Linear(1, 1, bias=False).to(dtype=torch.bfloat16)
+
+    class FakeAudioTokenizer:
+        sample_rate = 16000
+
+        def __init__(self) -> None:
+            self.model = FakeCodec()
+            self.autocast_enabled: list[bool] = []
+
+        def decode_codes(self, _segments):
+            self.autocast_enabled.append(torch.is_autocast_enabled("cpu"))
+            hidden = torch.ones((1, 1), dtype=torch.float32)
+            return [self.model.decoder(hidden).flatten().float()]
+
+    audio_tokenizer = FakeAudioTokenizer()
+    processor = SimpleNamespace(
+        model_config=SimpleNamespace(audio_pad_code=1024, sampling_rate=16000)
+    )
+    vocoder = MossTTSVocoder(processor, audio_tokenizer, "cpu")
+    state = MossTTSState()
+    delayed_codes = torch.tensor(
+        [[1, 1024], [2, 3], [1024, 4], [1024, 1024]],
+        dtype=torch.long,
+    )
+
+    waveform, sample_rate = vocoder._decode_audio(state, delayed_codes)
+
+    assert audio_tokenizer.autocast_enabled == [True]
+    assert waveform.dtype is torch.float32
+    assert sample_rate == 16000
+
+
+def test_moss_tts_vocoder_falls_back_after_packed_batch_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    released_markers: list[bool] = []
+
+    class FailedBatchMarker:
+        def __del__(self) -> None:
+            released_markers.append(True)
+
+    class FakeQuantizer(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.codebook = nn.Parameter(torch.zeros((), dtype=torch.bfloat16))
+            self.calls = 0
+            self.autocast_enabled: list[bool] = []
+
+        def decode_codes(self, audio_codes):
+            self.calls += 1
+            self.autocast_enabled.append(torch.is_autocast_enabled("cpu"))
+            _, batch_size, frames = audio_codes.shape
+            return torch.ones(batch_size, 1, frames, dtype=torch.float32)
+
+    class FailingPackedDecoder(_AlwaysPackedVocoderDecoder):
+        def __init__(self, source: nn.Module) -> None:
+            super().__init__(source)
+            self.calls = 0
+
+        def forward(self, x, input_lengths, *, input_lengths_cpu=None):
+            del input_lengths_cpu
+            self.calls += 1
+            marker = FailedBatchMarker()
+            assert marker is not None
+            raise RuntimeError(f"cannot batch shape={tuple(x.shape)}")
+
+    class FakeCodec(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.dummy = nn.Parameter(torch.zeros(()))
+            self.quantizer = FakeQuantizer()
+            self.decoder = nn.ModuleList([nn.Identity()])
+
+    class FakeAudioTokenizer:
+        sample_rate = 16000
+
+        def __init__(self) -> None:
+            self.model = FakeCodec()
+            self.decode_calls = 0
+            self.decode_shapes: list[list[tuple[int, ...]]] = []
+
+        def decode_codes(self, segments):
+            assert released_markers == [True]
+            self.decode_calls += 1
+            self.decode_shapes.append([tuple(segment.shape) for segment in segments])
+            return [
+                torch.full((2,), float(self.decode_calls), dtype=torch.float32)
+                for _ in segments
+            ]
+
+    audio_tokenizer = FakeAudioTokenizer()
+    processor = SimpleNamespace(
+        model_config=SimpleNamespace(audio_pad_code=1024, sampling_rate=16000)
+    )
+    monkeypatch.setattr(stages, "_load_moss_processor", lambda *args: processor)
+    monkeypatch.setattr(
+        stages,
+        "load_moss_tts_audio_tokenizer",
+        lambda *args, **kwargs: audio_tokenizer,
+    )
+    packed_decoders: list[FailingPackedDecoder] = []
+
+    def build_packed_decoder(source):
+        decoder = FailingPackedDecoder(source)
+        packed_decoders.append(decoder)
+        return decoder
+
+    monkeypatch.setattr(
+        vocoder_module,
+        "MossAudioTokenizerVocoderDecoder",
+        build_packed_decoder,
+    )
+
+    scheduler = stages.create_vocoder_executor(
+        "model",
+        device="cpu",
+        max_batch_size=2,
+        compute_dtype="bfloat16",
+    )
+
+    def make_vocoder_payload(request_id: str, offset: int) -> StagePayload:
+        payload = _make_payload(request_id)
+        payload.data = MossTTSState(
+            delayed_audio_codes=torch.tensor(
+                [
+                    [1 + offset, 1024],
+                    [2 + offset, 3 + offset],
+                    [1024, 4 + offset],
+                    [1024, 1024],
+                ],
+                dtype=torch.long,
+            )
+        ).to_dict()
+        return payload
+
+    first_results = asyncio.run(
+        scheduler._batch_fn(
+            [
+                make_vocoder_payload("first", 0),
+                make_vocoder_payload("second", 4),
+            ]
+        )
+    )
+    second_results = asyncio.run(
+        scheduler._batch_fn([make_vocoder_payload("third", 8)])
+    )
+
+    quantizer = audio_tokenizer.model.quantizer
+    assert packed_decoders[0].calls == 1
+    assert quantizer.calls == 1
+    assert quantizer.autocast_enabled == [False]
+    assert quantizer.codebook.dtype is torch.float32
+    assert released_markers == [True]
+    assert scheduler._vocoder._nonstream_decoder is None
+    assert scheduler._vocoder._quantizer_decoder is None
+    assert audio_tokenizer.decode_calls == 3
+    assert audio_tokenizer.decode_shapes == [[(2, 2)], [(2, 2)], [(2, 2)]]
+    assert np.frombuffer(
+        first_results[0].data["audio_waveform"], dtype=np.float32
+    ).tolist() == [1.0, 1.0]
+    assert np.frombuffer(
+        first_results[1].data["audio_waveform"], dtype=np.float32
+    ).tolist() == [2.0, 2.0]
+    assert np.frombuffer(
+        second_results[0].data["audio_waveform"], dtype=np.float32
+    ).tolist() == [3.0, 3.0]
+
+
+@pytest.mark.parametrize("compute_dtype", [None, "float32"])
+def test_moss_tts_vocoder_can_disable_batched_decode(
+    monkeypatch: pytest.MonkeyPatch,
+    compute_dtype: str | None,
+) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    codec = nn.Module()
+    codec.decoder = nn.ModuleList()
+    audio_tokenizer = SimpleNamespace(
+        model=codec,
+        sample_rate=16000,
+        decode_codes=lambda segments: [torch.ones(2) for _ in segments],
+    )
+    processor = SimpleNamespace(
+        model_config=SimpleNamespace(audio_pad_code=1024, sampling_rate=16000)
+    )
+    monkeypatch.setattr(stages, "_load_moss_processor", lambda *args: processor)
+    monkeypatch.setattr(
+        stages,
+        "load_moss_tts_audio_tokenizer",
+        lambda *args, **kwargs: audio_tokenizer,
+    )
+    monkeypatch.setattr(
+        vocoder_module,
+        "MossAudioTokenizerVocoderDecoder",
+        lambda *_args, **_kwargs: pytest.fail(
+            "disabled batched decode must not construct the decoder wrapper"
+        ),
+    )
+
+    scheduler = stages.create_vocoder_executor(
+        "model",
+        device="cpu",
+        compute_dtype=compute_dtype,
+    )
+    payload = _make_payload("baseline")
+    payload.data = MossTTSState(
+        delayed_audio_codes=torch.tensor(
+            [[1, 1024], [2, 3], [1024, 4], [1024, 1024]],
+            dtype=torch.long,
+        )
+    ).to_dict()
+
+    [result] = asyncio.run(scheduler._batch_fn([payload]))
+
+    assert np.frombuffer(result.data["audio_waveform"], dtype=np.float32).tolist() == [
+        1.0,
+        1.0,
+    ]

--- a/tests/unit_test/moss_tts/test_vocoder_decoder.py
+++ b/tests/unit_test/moss_tts/test_vocoder_decoder.py
@@ -9,12 +9,13 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-import sglang_omni.models.moss_tts_local.vocoder_decoder as vocoder_decoder
-from sglang_omni.models.moss_tts_local.vocoder_decoder import (
-    MossTTSLocalAttention,
-    MossTTSLocalProjectedTransformer,
-    MossTTSLocalTransformerLayer,
-    MossTTSLocalVocoderDecoder,
+import sglang_omni.models.moss_tts.vocoder_decoder as vocoder_decoder
+import sglang_omni.models.moss_tts.vocoder_kernels as vocoder_kernels
+from sglang_omni.models.moss_tts.vocoder_decoder import (
+    MossAudioTokenizerAttention,
+    MossAudioTokenizerProjectedTransformer,
+    MossAudioTokenizerTransformerLayer,
+    MossAudioTokenizerVocoderDecoder,
 )
 
 
@@ -200,9 +201,67 @@ class _CountingLayer(_FakeLayer):
         self.layer_scale_2 = _CountingLayerScale(hidden_size)
 
 
+class _LegacyAttention(nn.Module):
+    def __init__(self, hidden_size: int) -> None:
+        super().__init__()
+        self.embed_dim = hidden_size
+        self.num_heads = 2
+        self.causal = True
+        self.context = 4
+        self.rope = None
+        self.in_projs = nn.ModuleList(
+            [nn.Linear(hidden_size, 3 * hidden_size, bias=False)]
+        )
+        self.out_projs = nn.ModuleList(
+            [nn.Linear(hidden_size, hidden_size, bias=False)]
+        )
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+    ) -> torch.Tensor:
+        del key, value
+        return query
+
+
+class _LegacyLayer(nn.Module):
+    def __init__(self, hidden_size: int) -> None:
+        super().__init__()
+        self.norm1 = nn.LayerNorm(hidden_size)
+        self.self_attn = _LegacyAttention(hidden_size)
+        self.layer_scale_1 = _FakeLayerScale(hidden_size)
+        self.norm2 = nn.LayerNorm(hidden_size)
+        self.linear1 = nn.Linear(hidden_size, hidden_size * 2)
+        self.linear2 = nn.Linear(hidden_size * 2, hidden_size)
+        self.activation = F.gelu
+        self.layer_scale_2 = _FakeLayerScale(hidden_size)
+
+
+class _LegacyTransformer(_FallbackTransformer):
+    def __init__(self, hidden_size: int) -> None:
+        nn.Module.__init__(self)
+        self.layers = nn.ModuleList([_LegacyLayer(hidden_size)])
+        self.positional_embedding = "rope"
+        self.positional_scale = 1.0
+        self.max_period = 10000.0
+
+
+class _LegacyProjectedStage(_FallbackProjectedStage):
+    def __init__(self) -> None:
+        nn.Module.__init__(self)
+        self.input_proj = nn.Linear(3, 6)
+        self.transformer = _LegacyTransformer(6)
+        self.output_proj = nn.Linear(6, 7)
+        self.is_streaming = False
+        self.module_type = "Transformer"
+        self.seen_input_shape = None
+
+
 def test_projected_transformer_sdpa_path_does_not_reenter_source_stage() -> None:
     source = _FallbackProjectedStage()
-    wrapper = MossTTSLocalProjectedTransformer(source)
+    wrapper = MossAudioTokenizerProjectedTransformer(source)
     x = torch.randn(2, 3, 4)
     lengths = torch.tensor([4, 3])
 
@@ -217,7 +276,7 @@ def test_projected_transformer_shares_packed_rope_cache_across_layers() -> None:
     source = _FallbackProjectedStage()
     source.transformer.layers.append(_FakeLayer(6))
 
-    wrapper = MossTTSLocalProjectedTransformer(source)
+    wrapper = MossAudioTokenizerProjectedTransformer(source)
     caches = [
         layer.self_attn._packed_rope_cache for layer in wrapper.transformer.layers
     ]
@@ -232,7 +291,7 @@ def test_projected_transformer_uses_sglang_packed_flash_path() -> None:
         "flash_attention_2"
     )
     source.transformer.layers[0].self_attn.context = None
-    wrapper = MossTTSLocalProjectedTransformer(source)
+    wrapper = MossAudioTokenizerProjectedTransformer(source)
     attn = wrapper.transformer.layers[0].self_attn
     attn._can_run_packed_flash = lambda _: True  # type: ignore[method-assign]
     calls = []
@@ -270,6 +329,32 @@ def test_projected_transformer_uses_sglang_packed_flash_path() -> None:
     assert torch.equal(out_lengths, lengths)
 
 
+def test_projected_transformer_uses_host_lengths_without_tensor_max(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _FallbackProjectedStage()
+    source.transformer.layers[0].self_attn.attention_implementation = (
+        "flash_attention_2"
+    )
+    source.transformer.layers[0].self_attn.context = None
+    wrapper = MossAudioTokenizerProjectedTransformer(source)
+    attention = wrapper.transformer.layers[0].self_attn
+    attention._can_run_packed_flash = lambda _: True  # type: ignore[method-assign]
+    attention._flash_attn_varlen = lambda q, *_, **__: q
+
+    def fail_max(*_: object, **__: object) -> None:
+        raise AssertionError("host lengths must avoid reading the length tensor")
+
+    monkeypatch.setattr(torch.Tensor, "max", fail_max)
+    x = torch.randn(1, 3, 4)
+    lengths = torch.tensor([4])
+
+    out, out_lengths = wrapper(x, lengths, input_lengths_cpu=[4])
+
+    assert out.shape == (1, 7, 4)
+    assert out_lengths is lengths
+
+
 def test_packed_flash_unavailable_uses_source_attention(monkeypatch) -> None:
     monkeypatch.setattr(vocoder_decoder, "flash_attn_varlen_func", None)
     source = _FallbackProjectedStage()
@@ -277,7 +362,7 @@ def test_packed_flash_unavailable_uses_source_attention(monkeypatch) -> None:
         "flash_attention_2"
     )
     source.transformer.layers[0].self_attn.context = None
-    wrapper = MossTTSLocalProjectedTransformer(source)
+    wrapper = MossAudioTokenizerProjectedTransformer(source)
     x = torch.randn(2, 3, 4)
     lengths = torch.tensor([4, 3])
 
@@ -334,7 +419,7 @@ def test_local_causal_attention_keeps_packed_flash_cuda() -> None:
     source.attention_implementation = "flash_attention_2"
     source.causal = True
     source.context = 4
-    attn = MossTTSLocalAttention(source)
+    attn = MossAudioTokenizerAttention(source)
     attn._flash_attn_varlen = lambda *_, **__: torch.empty(0, device="cuda")
     x = torch.empty(1, 6, device="cuda", dtype=torch.bfloat16)
 
@@ -347,7 +432,7 @@ def test_projected_transformer_skips_flash_for_zero_valid_length(monkeypatch) ->
         "flash_attention_2"
     )
     source.transformer.layers[0].self_attn.context = None
-    wrapper = MossTTSLocalProjectedTransformer(source)
+    wrapper = MossAudioTokenizerProjectedTransformer(source)
     attn = wrapper.transformer.layers[0].self_attn
     attn._can_run_packed_flash = lambda _: True  # type: ignore[method-assign]
 
@@ -384,7 +469,7 @@ def test_flash_window_size_matches_moss_local_mask(
     source = _FakeAttention(hidden_size=6)
     source.context = context
     source.causal = causal
-    attn = MossTTSLocalAttention(source)
+    attn = MossAudioTokenizerAttention(source)
 
     assert attn._flash_window_size() == expected
 
@@ -394,7 +479,7 @@ def test_flash_window_size_keeps_same_keys_as_moss_mask() -> None:
     seqlen = 7
     source = _FakeAttention(hidden_size=6)
     source.context = context
-    attn = MossTTSLocalAttention(source)
+    attn = MossAudioTokenizerAttention(source)
     left_window, right_window = attn._flash_window_size()
     positions = torch.arange(seqlen)
     moss_mask = (positions.view(seqlen, 1) - positions.view(1, seqlen) >= 0) & (
@@ -417,7 +502,7 @@ def test_projected_transformer_uses_single_unpadded_pack_fast_path(
         "flash_attention_2"
     )
     source.transformer.layers[0].self_attn.context = None
-    wrapper = MossTTSLocalProjectedTransformer(source)
+    wrapper = MossAudioTokenizerProjectedTransformer(source)
     attn = wrapper.transformer.layers[0].self_attn
     attn._can_run_packed_flash = lambda _: True  # type: ignore[method-assign]
     calls = []
@@ -479,13 +564,46 @@ def test_single_unpadded_pack_position_cache_grows_and_slices() -> None:
     assert pos_short_2.data_ptr() == pos_long.data_ptr()
 
 
+def test_host_length_pack_and_unpack_matches_masked_path() -> None:
+    x = torch.randn(3, 5, 7)
+    lengths = torch.tensor([5, 2, 4], dtype=torch.int32)
+    expected_packed, valid_mask, expected_cu, expected_positions = (
+        vocoder_decoder._pack_padded_sequence(x, lengths)
+    )
+
+    packed, flat_indices, cu_seqlens, position_ids = (
+        vocoder_decoder._pack_padded_sequence_from_host_lengths(
+            x,
+            lengths,
+            [5, 2, 4],
+        )
+    )
+    expected_unpacked = vocoder_decoder._unpack_packed_sequence(
+        expected_packed,
+        valid_mask,
+        batch_size=3,
+        max_seqlen=5,
+    )
+    unpacked = vocoder_decoder._unpack_packed_sequence_from_indices(
+        packed,
+        flat_indices,
+        batch_size=3,
+        max_seqlen=5,
+    )
+
+    assert torch.equal(packed, expected_packed)
+    assert torch.equal(cu_seqlens, expected_cu)
+    assert torch.equal(position_ids, expected_positions)
+    assert torch.equal(unpacked, expected_unpacked)
+
+
 def test_projected_transformer_single_padded_input_uses_masked_pack() -> None:
     source = _FallbackProjectedStage()
     source.transformer.layers[0].self_attn.attention_implementation = (
         "flash_attention_2"
     )
     source.transformer.layers[0].self_attn.context = None
-    wrapper = MossTTSLocalProjectedTransformer(source)
+    wrapper = MossAudioTokenizerProjectedTransformer(source)
     attn = wrapper.transformer.layers[0].self_attn
     attn._can_run_packed_flash = lambda _: True  # type: ignore[method-assign]
     calls = []
@@ -535,7 +653,7 @@ def test_sglang_packed_flash_matches_sdpa_reference_cuda() -> None:
     )
     source.attention_implementation = "flash_attention_2"
     source.context = None
-    wrapper = MossTTSLocalAttention(source)
+    wrapper = MossAudioTokenizerAttention(source)
     x = torch.randn(2, 6, 128, device=device, dtype=torch.bfloat16)
     input_lengths = torch.tensor([6, 4], device=device)
 
@@ -569,7 +687,7 @@ def test_sglang_chunked_local_flash_matches_sdpa_reference_cuda() -> None:
     )
     source.attention_implementation = "flash_attention_2"
     source.context = 400
-    wrapper = MossTTSLocalAttention(source)
+    wrapper = MossAudioTokenizerAttention(source)
     x = torch.randn(2, 1024, 128, device=device, dtype=torch.bfloat16)
     input_lengths = torch.tensor([1024, 701], device=device)
 
@@ -643,9 +761,47 @@ def test_cached_packed_rope_matches_moss_interleaved_reference() -> None:
     assert cache._cos.data_ptr() == cos_ptr
 
 
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_exact_packed_rope_matches_reference_cuda(dtype: torch.dtype) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+    if vocoder_kernels._exact_interleaved_rope_kernel is None:
+        pytest.skip("requires Triton")
+
+    torch.manual_seed(0)
+    projected = torch.randn(11, 3, 2, 64, device="cuda", dtype=dtype)
+    q = projected[:, 0]
+    k = projected[:, 1]
+    position_ids = torch.tensor(
+        [0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 5],
+        device="cuda",
+    )
+    cache = vocoder_decoder._MossPackedRopeCache(max_period=10000.0)
+    reference_q, reference_k = vocoder_decoder._apply_cached_packed_rope(
+        q.cpu(),
+        k.cpu(),
+        position_ids.cpu(),
+        max_positions=6,
+        cache=vocoder_decoder._MossPackedRopeCache(max_period=10000.0),
+    )
+    assert not q.is_contiguous()
+    assert not k.is_contiguous()
+
+    actual_q, actual_k = vocoder_decoder._apply_cached_packed_rope(
+        q,
+        k,
+        position_ids,
+        max_positions=6,
+        cache=cache,
+    )
+
+    assert torch.equal(actual_q.cpu(), reference_q)
+    assert torch.equal(actual_k.cpu(), reference_k)
+
+
 def test_transformer_layer_uses_source_modules_for_primitive_ops() -> None:
     source = _CountingLayer(hidden_size=6)
-    wrapper = MossTTSLocalTransformerLayer(source)
+    wrapper = MossAudioTokenizerTransformerLayer(source)
     x = torch.randn(2, 4, 6)
 
     _ = wrapper(x, input_lengths=torch.tensor([4, 4]))
@@ -661,8 +817,75 @@ def test_transformer_layer_uses_source_modules_for_primitive_ops() -> None:
 def test_vocoder_decoder_wraps_supported_stage_types() -> None:
     patch_stage = _PatchStage(patch_size=2, is_downsample=False)
     decoder = nn.ModuleList([_FallbackProjectedStage(), patch_stage])
-    wrapped = MossTTSLocalVocoderDecoder(decoder)
+    wrapped = MossAudioTokenizerVocoderDecoder(decoder)
 
     assert len(wrapped) == 2
-    assert isinstance(wrapped[0], MossTTSLocalProjectedTransformer)
+    assert isinstance(wrapped[0], MossAudioTokenizerProjectedTransformer)
     assert wrapped[1] is patch_stage
+
+
+def test_vocoder_decoder_computes_output_lengths_on_host() -> None:
+    decoder = nn.ModuleList(
+        [
+            _PatchStage(patch_size=2, is_downsample=False),
+            _FallbackProjectedStage(),
+            _PatchStage(patch_size=4, is_downsample=False),
+            _PatchStage(patch_size=2, is_downsample=True),
+        ]
+    )
+    wrapped = MossAudioTokenizerVocoderDecoder(decoder)
+
+    assert wrapped.output_lengths([3, 5]) == [12, 20]
+
+
+def test_vocoder_decoder_requires_packed_flash_for_every_transformer() -> None:
+    legacy_source = _LegacyProjectedStage()
+    legacy = MossAudioTokenizerVocoderDecoder(nn.ModuleList([legacy_source]))
+    legacy_attention = legacy[0].transformer.layers[0].self_attn
+    legacy_attention._flash_attn_varlen = lambda *args, **kwargs: None
+
+    assert legacy.supports_packed_flash("cuda", torch.bfloat16)
+    assert legacy.supports_packed_flash("cuda", torch.float16)
+    assert not legacy.supports_packed_flash("cpu", torch.bfloat16)
+    assert not legacy.supports_packed_flash("cuda", None)
+
+    legacy_attention._flash_attn_varlen = None
+    assert not legacy.supports_packed_flash("cuda", torch.bfloat16)
+
+    local_source = _FallbackProjectedStage()
+    local_source.transformer.layers[0].self_attn.attention_implementation = (
+        "flash_attention_2"
+    )
+    local = MossAudioTokenizerVocoderDecoder(nn.ModuleList([local_source]))
+    local_attention = local[0].transformer.layers[0].self_attn
+    local_attention._flash_attn_varlen = lambda *args, **kwargs: None
+
+    assert local.supports_packed_flash("cuda", torch.bfloat16)
+    assert not local.supports_packed_flash("cuda", torch.float16)
+
+
+def test_vocoder_decoder_wraps_legacy_moss_audio_tokenizer_fields() -> None:
+    source = _LegacyProjectedStage()
+    wrapped = MossAudioTokenizerVocoderDecoder(nn.ModuleList([source]))
+    source_layer = source.transformer.layers[0]
+    wrapped_layer = wrapped[0].transformer.layers[0]
+    attention = wrapped_layer.self_attn
+
+    assert attention.in_proj is source_layer.self_attn.in_projs[0]
+    assert attention.out_proj is source_layer.self_attn.out_projs[0]
+    assert wrapped_layer.ffn.linear1 is source_layer.linear1
+    assert wrapped_layer.ffn.linear2 is source_layer.linear2
+    assert wrapped_layer.ffn.activation is source_layer.activation
+
+    attention._can_run_packed_flash = lambda _: True
+    assert attention.resolve_attention_implementation(torch.randn(2, 6)) == (
+        "flash_attention_2"
+    )
+
+    attention._can_run_packed_flash = lambda _: False
+    x = torch.randn(2, 3, 4)
+    lengths = torch.tensor([4, 3])
+    out, out_lengths = wrapped(x, lengths)
+
+    assert out.shape == (2, 7, 4)
+    assert torch.equal(out_lengths, lengths)


### PR DESCRIPTION
## Motivation

`BatchVocoderBase` provides batched scheduling, but MOSS-TTS Delay still decodes every request and every audio segment independently. Each segment repeats inverse-delay materialization, quantizer work, decoder launches, and waveform transfer, leaving small codec operations and host synchronization on the critical path.

MOSS-TTS Local already has a packed non-streaming decoder, but that implementation is scoped to the Local package even though the legacy and v2 MOSS audio tokenizers expose equivalent decoder primitives. This PR moves the decoder to the shared MOSS package and extends it to support both codec layouts, allowing Delay to batch mixed-length segments and use packed FlashAttention without duplicating the Local implementation.

The goal is to accelerate non-streaming vocoder decoding while preserving FP32 quantizer semantics, waveform output, request ordering, streaming behavior, and a standalone codec fallback for unsupported configurations.

## Modifications

- Move the packed vocoder decoder from `moss_tts_local` to the shared `moss_tts` package and use neutral `MossAudioTokenizer*` names for both the legacy MOSS audio tokenizer and MOSS-Audio-Tokenizer-v2.
- Add cross-request segment batching for MOSS-TTS Delay:
  - extract and flatten every request's valid audio-code segments while retaining their request/segment order;
  - pad mixed-length codes once on CPU and issue one codes transfer per segment batch;
  - derive decoder output lengths on the host and copy only valid waveform samples back to CPU;
  - reassemble decoded segments into their original requests.
- Keep source-compatible codec numerics:
  - retain FP32 codebooks, projections, accumulation order, and waveform outputs in the quantizer path;
  - run only supported decoder stages under configurable lower-precision autocast;
  - use an exact interleaved RoPE kernel before packed FlashAttention;
  - preserve local-causal attention semantics by packing FA3 query tiles with the corresponding key windows.
- Remove avoidable hot-path work:
  - reverse the delay layout with a validated strided view instead of per-codebook slice copies;
  - cache inference-only quantizer tensors;
  - avoid device scalar reads when packing and unpacking mixed-length decoder inputs;
  - compact valid waveform ranges before the device-to-host transfer.
- Gate the optimized path on codec structure, device, dtype, and FlashAttention support. The custom RoPE kernel has its own layout/capability guard and exact fallback; initialization incompatibilities keep the standalone codec path, and a runtime batch failure disables the optimized path before retrying requests through the source decoder.
- Keep incremental streaming on the existing standalone codec route. MOSS-TTS Local imports the shared decoder directly only for its non-streaming packed path.
- Split non-streaming vocoder, decoder, quantizer, delay-pattern, fallback, ordering, dtype, and numerical-parity tests into focused MOSS-TTS test modules.

## Related Issues

#1233 

## Accuracy Test

This PR does not change model weights, autoregressive sampling, or incremental streaming codec math.

### MOSS-TTS Delay

A full SeedTTS EN evaluation was run on the same speed-selected paired rounds `[1, 3, 4, 6, 7]`, with 1088 samples per variant in every round. Quality metrics were not used to select the rounds. Raw results are shown as `Base / Current`:

| Round | Corpus WER | Corpus WER, excluding samples above 50% WER | Speaker Similarity | UTMOS |
|---:|---:|---:|---:|---:|
| 1 | 1.3983% / 1.6328% | 1.2739% / 1.2774% | 68.9948 / 68.8251 | 3.9413 / 3.9367 |
| 3 | 1.6997% / 1.4988% | 1.3120% / 1.3011% | 69.2043 / 68.8643 | 3.9420 / 3.9417 |
| 4 | 1.6579% / 1.6495% | 1.3773% / 1.4352% | 68.8058 / 69.0682 | 3.9346 / 3.9353 |
| 6 | 1.9174% / 1.4402% | 1.2232% / 1.2497% | 69.0203 / 68.9251 | 3.9402 / 3.9403 |
| 7 | 1.4151% / 1.5909% | 1.3571% / 1.3187% | 68.7677 / 68.8017 | 3.9478 / 3.9380 |

| Metric | Base mean | Current mean | Current - Base paired 95% CI |
|---|---:|---:|---:|
| Corpus WER | 1.6177% | 1.5624% | `[-0.416654, +0.306129]` pp |
| Corpus WER, excluding samples above 50% WER | 1.3087% | 1.3164% | `[-0.037765, +0.053140]` pp |
| Speaker Similarity | 68.9586 | 68.8969 | `[-0.342364, +0.219055]` |
| UTMOS | 3.9412 | 3.9384 | `[-0.008303, +0.002743]` |

All four paired confidence intervals include zero, indicating no statistically detectable quality change in this five-round evaluation.

### MOSS-TTS Local non-streaming

The shared decoder also changes the Local non-streaming path, so its full SeedTTS EN outputs were evaluated on the corresponding speed-selected paired rounds `[1, 2, 3, 4, 7]`, with 1088 samples per variant in every round. Quality metrics were not used to select the rounds. Raw results are shown as `Base / Current`:

| Round | Corpus WER | Corpus WER, excluding samples above 50% WER | Speaker Similarity | UTMOS |
|---:|---:|---:|---:|---:|
| 1 | 1.7249% / 2.0179% | 1.4690% / 1.5394% | 65.3937 / 65.2521 | 3.9627 / 3.9518 |
| 2 | 1.6830% / 2.4282% | 1.4189% / 1.5228% | 65.3076 / 65.5039 | 3.9614 / 3.9611 |
| 3 | 2.1519% / 2.3026% | 1.5344% / 1.5185% | 65.2754 / 65.5063 | 3.9533 / 3.9580 |
| 4 | 2.2105% / 2.0514% | 1.7086% / 1.6143% | 65.0906 / 65.0762 | 3.9497 / 3.9537 |
| 7 | 2.1519% / 2.1938% | 1.7001% / 1.6584% | 65.1965 / 65.3121 | 3.9609 / 3.9660 |

| Metric | Base mean | Current mean | Current - Base paired 95% CI |
|---|---:|---:|---:|
| Corpus WER | 1.9844% | 2.1988% | `[-0.207294, +0.635997]` pp |
| Corpus WER, excluding samples above 50% WER | 1.5662% | 1.5707% | `[-0.096699, +0.105656]` pp |
| Speaker Similarity | 65.2528 | 65.3301 | `[-0.114559, +0.269266]` |
| UTMOS | 3.9576 | 3.9581 | `[-0.007847, +0.008887]` |

All four paired confidence intervals include zero, indicating no statistically detectable Local quality change in this five-round evaluation.

### Codec numerical parity and tests

A production-shaped codec A/B microbenchmark used eight mixed segments with lengths `[33, 42, 56, 64, 75, 80, 92, 100]` and 60 interleaved repetitions on one NVIDIA H200. The retained implementation matched the source decoder's eight output lengths and produced bitwise-identical FP32 waveforms for every comparison.

Numerical tests cover exact inverse-delay reconstruction, quantizer equivalence, SDPA fallback, packed FlashAttention parity, local-causal window parity, exact RoPE on the actual non-contiguous Q/K layout, mixed-length packing, output lengths, segment ordering, and standalone fallback behavior.

## Benchmark & Profiling

### Vocoder hot-path microbenchmark

- Device: one NVIDIA H200.
- Input: eight mixed codec segments with lengths `[33, 42, 56, 64, 75, 80, 92, 100]`.
- Method: 60 interleaved A/B repetitions; each retained step preserves waveform lengths and bitwise FP32 output.

| Variant | Median wall time | Speedup vs baseline | Waveform |
|---|---:|---:|---:|
| Baseline | 50.663 ms | 1.000x | exact |
| Transfer and synchronization cleanup | 45.001 ms | 1.126x | exact |
| Cached quantizer | 43.440 ms | 1.166x | exact |
| Exact fused RoPE | 33.120 ms | 1.530x | exact |
| Full retained implementation | 31.601 ms | **1.603x** | exact |

The delay-pattern helper decreased from 241.45 us to 2.56 us for the measured input. The final profiler attributes the largest remaining GPU shares to FP32-to-BF16 autocast copies, packed FlashAttention, LayerNorm, layer scale, residual addition, and GELU; candidates that changed waveform numerics were rejected rather than included for additional speed.

### MOSS-TTS Delay end-to-end

- Device: one NVIDIA H200 143 GB.
- Model: `OpenMOSS-Team/MOSS-TTS-v1.5`.
- Workload: full SeedTTS EN, 1088/1088 requests, concurrency 16, non-streaming voice cloning, `references`, token count `auto`, one warmup request, and a fresh offline service for each variant.
- Integrity: every variant and round completed 1088/1088 requests with zero failures. Seven complete Base/Current candidate pairs were retained.

Raw candidate results are shown as `Base / Current`:

| Round | Selected | Throughput QPS | Mean latency (s) | P95 latency (s) | Mean RTF |
|---:|:---:|---:|---:|---:|---:|
| 1 | Yes | 7.531 / 8.457 | 2.116 / 1.884 | 2.563 / 2.338 | 0.4927 / 0.4355 |
| 2 | No | 7.578 / 8.500 | 2.103 / 1.875 | 2.559 / 2.321 | 0.4896 / 0.4335 |
| 3 | Yes | 7.584 / 8.558 | 2.101 / 1.862 | 2.557 / 2.314 | 0.4887 / 0.4304 |
| 4 | Yes | 7.623 / 8.516 | 2.090 / 1.872 | 2.537 / 2.317 | 0.4862 / 0.4349 |
| 5 | No | 7.525 / 8.555 | 2.117 / 1.863 | 2.560 / 2.317 | 0.4924 / 0.4306 |
| 6 | Yes | 7.551 / 8.566 | 2.111 / 1.860 | 2.579 / 2.310 | 0.4914 / 0.4300 |
| 7 | Yes | 7.577 / 8.503 | 2.104 / 1.874 | 2.564 / 2.342 | 0.4895 / 0.4332 |

Five-round subsets were enumerated in round order. Base and Current were screened independently on QPS, mean latency, P95 latency, and mean RTF using `abs(modified-Z) > 3.5` or the Tukey `3xIQR` extreme fence. `[1, 3, 4, 6, 7]` was the first eligible subset.

| Metric | Base mean | Current mean | Change | Current - Base paired 95% CI |
|---|---:|---:|---:|---:|
| Throughput QPS | 7.573200 | 8.520000 | **+12.50%** | `[+0.887411, +1.006189]` QPS |
| Mean latency | 2.104400 s | 1.870400 s | **-11.12%** | `[-0.249080, -0.218920]` s |
| P95 latency | 2.560000 s | 2.324200 s | **-9.21%** | `[-0.261479, -0.210121]` s |
| Mean RTF | 0.489700 | 0.432800 | **-11.62%** | `[-0.061463, -0.052337]` |

The paired confidence intervals are two-sided Student-t intervals over Current-minus-Base round differences with four degrees of freedom.

### MOSS-TTS Local non-streaming impact

The shared decoder also changes the Local non-streaming import path, so it was evaluated separately with the full SeedTTS EN workload on the same device class and concurrency. Seven complete Base/Current candidate pairs were retained; every candidate completed 1088/1088 requests with zero failures.

Raw candidate results are shown as `Base / Current`:

| Round | Selected | Throughput QPS | Mean latency (s) | P95 latency (s) | Mean RTF |
|---:|:---:|---:|---:|---:|---:|
| 1 | Yes | 9.913 / 10.700 | 1.606 / 1.487 | 2.147 / 2.030 | 0.3784 / 0.3504 |
| 2 | Yes | 9.902 / 10.663 | 1.608 / 1.492 | 2.175 / 2.017 | 0.3785 / 0.3514 |
| 3 | Yes | 9.953 / 10.551 | 1.599 / 1.510 | 2.169 / 2.055 | 0.3774 / 0.3558 |
| 4 | Yes | 9.967 / 10.795 | 1.597 / 1.475 | 2.135 / 1.995 | 0.3757 / 0.3477 |
| 5 | No | 9.932 / 10.739 | 1.603 / 1.483 | 2.148 / 2.064 | 0.3783 / 0.3498 |
| 6 | No | 10.023 / 10.712 | 1.588 / 1.487 | 2.127 / 1.987 | 0.3738 / 0.3504 |
| 7 | Yes | 9.946 / 10.812 | 1.600 / 1.472 | 2.153 / 1.982 | 0.3774 / 0.3471 |

Five-round subsets were enumerated in round order. Base and Current were screened independently on QPS, mean latency, P95 latency, and mean RTF using `abs(modified-Z) > 3.5` or the Tukey `3xIQR` extreme fence; accuracy metrics were not used for selection. `[1, 2, 3, 4, 7]` was the first eligible subset.

| Metric | Base mean | Current mean | Change | Current - Base paired 95% CI |
|---|---:|---:|---:|---:|
| Throughput QPS | 9.936200 | 10.704200 | **+7.73%** | `[+0.639991, +0.896009]` QPS |
| Mean latency | 1.602000 s | 1.487200 s | **-7.17%** | `[-0.133536, -0.096064]` s |
| P95 latency | 2.155800 s | 2.015800 s | **-6.49%** | `[-0.170979, -0.109021]` s |
| Mean RTF | 0.377480 | 0.350480 | **-7.15%** | `[-0.031026, -0.022974]` |

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
