### PR TITLE
[CI] Pass OMNI_CI_CPUSET through to perf stage containers

### DIFF
--- a/.github/workflows/test-asr-ci.yaml
+++ b/.github/workflows/test-asr-ci.yaml
@@ -41,6 +41,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
         -v /data/cache/huggingface:/github/home/.cache/huggingface
@@ -95,6 +96,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
         -v /data/cache/huggingface:/github/home/.cache/huggingface

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -38,6 +38,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
@@ -79,6 +80,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
@@ -137,6 +139,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
@@ -182,6 +185,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
@@ -227,6 +231,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
@@ -273,6 +278,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
@@ -318,6 +324,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
@@ -363,6 +370,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
@@ -408,6 +416,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
@@ -455,6 +464,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci

--- a/.github/workflows/test-tts-ci.yaml
+++ b/.github/workflows/test-tts-ci.yaml
@@ -42,6 +42,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
         -v /data/cache/huggingface:/github/home/.cache/huggingface
@@ -109,6 +110,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
         -v /data/cache/huggingface:/github/home/.cache/huggingface
@@ -165,6 +167,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
         -v /data/cache/huggingface:/github/home/.cache/huggingface
@@ -219,6 +222,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
         -v /data/cache/huggingface:/github/home/.cache/huggingface


### PR DESCRIPTION
Follow-up to #1321. The pinning fixture reads OMNI_CI_CPUSET inside the stage container, but runner .env variables do not reach container jobs unless docker run forwards them. This adds a bare `-e OMNI_CI_CPUSET` (same mechanism as the existing `-e NVIDIA_VISIBLE_DEVICES`) to every job that runs tests/test_model: all 10 Qwen3-Omni stages, TTS stages 1 to 4, and both ASR stages.

TTS stage 5 runs tests/test_ci and does not import that conftest, so it is left unchanged.

Behavior: on runners without the variable, docker leaves it unset and the fixture stays a no-op, so this is inert until a runner opts in via its .env. Rollout plan is one runner first (h100-3), then the rest after a clean round. Suggested per runner cpusets: https://github.com/sgl-project/sglang-omni/pull/1321#issuecomment-5213643103