### PR TITLE
[Perf] dots.tts: skip full-batch DiT KV gathers

### DIFF
--- a/sglang_omni/models/dots_tts/tail.py
+++ b/sglang_omni/models/dots_tts/tail.py
@@ -279,6 +279,7 @@ class DotsTtsAcousticTail:
         self._capture_stream: torch.cuda.Stream | None = None
         self._graph_replays: Counter[str] = Counter()
         self._graph_misses: Counter[str] = Counter()
+        self._dit_contiguous_view_steps = 0
         if optimize and device.type == "cuda":
             self._capture_cuda_graphs()
 
@@ -290,7 +291,7 @@ class DotsTtsAcousticTail:
             self._dit_layers,
             spec.num_slots,
             self._dit_heads,
-            spec.dit_cache_tokens,
+            spec.dit_cache_tokens + spec.unit_len,
             self._dit_head_dim,
         )
         self._dit_v = torch.zeros_like(self._dit_k)
@@ -506,26 +507,46 @@ class DotsTtsAcousticTail:
             persistent, device=self.device, dtype=torch.long
         )
         noise = self._sample_noise(slots)
+        direct_kv = len(slots) == spec.num_slots and sorted(slots) == list(
+            range(spec.num_slots)
+        )
+        if direct_kv:
+            order = torch.argsort(slot_index)
+            work_slots = torch.arange(spec.num_slots, device=self.device)
+            work_persistent = persistent_index.index_select(0, order)
+            work_hidden = fm_hidden_rows.index_select(0, order)
+            work_noise = noise.index_select(0, order)
+            self._dit_contiguous_view_steps += spec.nfe
+            if self._dit_contiguous_view_steps == spec.nfe:
+                logger.info("dots.tts contiguous DiT KV view is active")
+        else:
+            work_slots = slot_index
+            work_persistent = persistent_index
+            work_hidden = fm_hidden_rows
+            work_noise = noise
         graph = self._select_graph(self._meanflow_graphs, len(slots), capacity)
         if graph is None:
             self._graph_misses["meanflow"] += 1
             latent = self._sample_patches_core(
-                slot_index,
-                persistent_index,
+                work_slots,
+                work_persistent,
                 capacity,
-                fm_hidden_rows,
-                noise,
+                work_hidden,
+                work_noise,
+                direct_kv=direct_kv,
             )
         else:
-            graph.inputs["slots"].copy_(slot_index)
-            graph.inputs["starts"].copy_(persistent_index)
-            graph.inputs["hidden"].copy_(fm_hidden_rows)
-            graph.inputs["noise"].copy_(noise)
+            graph.inputs["slots"].copy_(work_slots)
+            graph.inputs["starts"].copy_(work_persistent)
+            graph.inputs["hidden"].copy_(work_hidden)
+            graph.inputs["noise"].copy_(work_noise)
             graph.graph.replay()
             latent = graph.output.clone()
             self._graph_replays["meanflow"] += 1
             if self._graph_replays["meanflow"] == 1:
                 logger.info("dots.tts batched MeanFlow CUDA graph replay is active")
+        if direct_kv:
+            latent = latent.index_select(0, slot_index)
         for slot in slots:
             self._fm_seq_len[slot] += spec.latent_patch_size
         return latent
@@ -537,22 +558,33 @@ class DotsTtsAcousticTail:
         capacity: int,
         fm_hidden_rows: torch.Tensor,
         noise: torch.Tensor,
+        *,
+        direct_kv: bool = False,
     ) -> torch.Tensor:
         spec = self.spec
-        self._window[slot_index, spec.unit_len :] = fm_hidden_rows.unsqueeze(1).to(
-            self.dtype
+        window = (
+            self._window[: spec.num_slots] if direct_kv else self._window[slot_index]
         )
+        window[:, spec.unit_len :] = fm_hidden_rows.unsqueeze(1).to(self.dtype)
+        if not direct_kv:
+            self._window[slot_index] = window
         latent = self._run_meanflow(
             slot_index,
             persistent_index,
             capacity,
             noise,
+            direct_kv=direct_kv,
         )
-        carry = self._window[slot_index, spec.unit_len :]
-        self._window[slot_index, : spec.hidden_patch_size] = carry
-        self._window[slot_index, spec.hidden_patch_size : spec.unit_len] = (
-            self._latent_proj(latent).to(self.dtype)
+        window = (
+            self._window[: spec.num_slots] if direct_kv else self._window[slot_index]
         )
+        carry = window[:, spec.unit_len :]
+        window[:, : spec.hidden_patch_size] = carry
+        window[:, spec.hidden_patch_size : spec.unit_len] = self._latent_proj(
+            latent
+        ).to(self.dtype)
+        if not direct_kv:
+            self._window[slot_index] = window
         return latent
 
     def _run_meanflow(
@@ -561,13 +593,21 @@ class DotsTtsAcousticTail:
         persistent_index: torch.Tensor,
         capacity: int,
         latent: torch.Tensor,
+        *,
+        direct_kv: bool = False,
     ) -> torch.Tensor:
         spec = self.spec
         rows = int(slot_index.numel())
         unit = spec.unit_len
         query_len = 2 * unit
-        previous = self._window[slot_index, :unit]
-        hidden = self._window[slot_index, unit:]
+        if direct_kv:
+            previous = self._window[:rows, :unit]
+            hidden = self._window[:rows, unit:]
+            mods = self._all_mods[:, :rows]
+        else:
+            previous = self._window[slot_index, :unit]
+            hidden = self._window[slot_index, unit:]
+            mods = self._all_mods.index_select(1, slot_index)
         latent_slice = slice(
             unit + spec.hidden_patch_size,
             unit + spec.hidden_patch_size + spec.latent_patch_size,
@@ -575,7 +615,6 @@ class DotsTtsAcousticTail:
         mask = self._dit_mask[:rows, :, :, : capacity + query_len]
         self._fill_mask(mask, capacity, persistent_index, unit, unit)
         cos, sin = _rotary_cos_sin(self._dit_rotary, persistent_index, query_len)
-        mods = self._all_mods.index_select(1, slot_index)
         token_index = persistent_index.reshape(1, rows, 1) + torch.arange(
             unit, device=self.device
         ).reshape(1, 1, unit)
@@ -584,20 +623,24 @@ class DotsTtsAcousticTail:
         promote = slice(capacity, capacity + unit)
         with sdpa_kernel(_TAIL_SDPA_BACKENDS):
             for ode_index in range(spec.nfe):
-                keys = self._dit_scratch_k[:, :rows, :, : capacity + query_len]
-                values = self._dit_scratch_v[:, :rows, :, : capacity + query_len]
-                torch.index_select(
-                    self._dit_k[ode_index, :, :, :, :capacity],
-                    1,
-                    slot_index,
-                    out=keys[:, :, :, :capacity],
-                )
-                torch.index_select(
-                    self._dit_v[ode_index, :, :, :, :capacity],
-                    1,
-                    slot_index,
-                    out=values[:, :, :, :capacity],
-                )
+                if direct_kv:
+                    keys = self._dit_k[ode_index, :, :rows, :, : capacity + query_len]
+                    values = self._dit_v[ode_index, :, :rows, :, : capacity + query_len]
+                else:
+                    keys = self._dit_scratch_k[:, :rows, :, : capacity + query_len]
+                    values = self._dit_scratch_v[:, :rows, :, : capacity + query_len]
+                    torch.index_select(
+                        self._dit_k[ode_index, :, :, :, :capacity],
+                        1,
+                        slot_index,
+                        out=keys[:, :, :, :capacity],
+                    )
+                    torch.index_select(
+                        self._dit_v[ode_index, :, :, :, :capacity],
+                        1,
+                        slot_index,
+                        out=values[:, :, :, :capacity],
+                    )
 
                 def cached_attention(
                     layer: int, block: nn.Module, value: torch.Tensor
@@ -858,6 +901,7 @@ class DotsTtsAcousticTail:
                 capacity,
                 inputs["hidden"],
                 inputs["noise"],
+                direct_kv=batch_size == self.spec.num_slots,
             )
         else:
             inputs = {

--- a/tests/unit_test/dots_tts/test_tail.py
+++ b/tests/unit_test/dots_tts/test_tail.py
@@ -155,10 +155,11 @@ def _reference_meanflow(
     return latent
 
 
-def test_kv_cached_tail_matches_full_recompute() -> None:
+@pytest.mark.parametrize("slots", [1, 2])
+def test_kv_cached_tail_matches_full_recompute(slots: int) -> None:
     torch.manual_seed(1234)
     model = _TailModel().eval()
-    acoustic_tail = _build_tail(model, slots=1)
+    acoustic_tail = _build_tail(model, slots=slots)
     unit = acoustic_tail.spec.unit_len
     g_cond = torch.randn(1, FM_HIDDEN)
     grid = torch.linspace(0.0, 1.0, NFE + 1)
@@ -187,6 +188,7 @@ def test_kv_cached_tail_matches_full_recompute() -> None:
     actual = acoustic_tail.sample_patches([slot], fm_hidden_rows=hidden)
 
     torch.testing.assert_close(actual, expected, rtol=2e-4, atol=2e-4)
+    assert acoustic_tail._dit_contiguous_view_steps == (NFE if slots == 1 else 0)
 
 
 def test_tail_slots_are_bounded_and_reusable() -> None:
@@ -201,6 +203,42 @@ def test_tail_slots_are_bounded_and_reusable() -> None:
         raise AssertionError("slot exhaustion must fail")
     acoustic_tail.release_slot(first)
     assert acoustic_tail.acquire_slot() == first
+
+
+def test_permuted_full_pool_matches_fragmented_gather_fallback() -> None:
+    torch.manual_seed(1234)
+    direct = _build_tail(_TailModel().eval(), slots=2)
+    torch.manual_seed(1234)
+    fallback = _build_tail(_TailModel().eval(), slots=3)
+    direct_slots = [direct.acquire_slot(), direct.acquire_slot()][::-1]
+    fallback_slots = [
+        fallback.acquire_slot(),
+        fallback.acquire_slot(),
+        fallback.acquire_slot(),
+    ]
+    fallback.release_slot(fallback_slots.pop(1))
+
+    grid = torch.linspace(0.0, 1.0, NFE + 1)
+    for row, units in enumerate((3, 2)):
+        g_cond = torch.randn(1, FM_HIDDEN)
+        mods = direct.dit.build_mods(
+            grid[:-1], duration=grid[1:] - grid[:-1], g_cond=g_cond
+        )
+        history = torch.randn(units * direct.spec.unit_len, FM_HIDDEN)
+        for acoustic_tail, slot in (
+            (direct, direct_slots[row]),
+            (fallback, fallback_slots[row]),
+        ):
+            acoustic_tail.seed_fm_history(slot, fm_rows=history, all_mods=mods)
+            acoustic_tail.initialize_slot_rng(slot, 100 + row)
+
+    hidden = torch.randn(2, FM_HIDDEN)
+    actual = direct.sample_patches(direct_slots, fm_hidden_rows=hidden)
+    expected = fallback.sample_patches(fallback_slots, fm_hidden_rows=hidden)
+
+    torch.testing.assert_close(actual, expected, rtol=2e-4, atol=2e-4)
+    assert direct._dit_contiguous_view_steps == NFE
+    assert fallback._dit_contiguous_view_steps == 0
 
 
 def test_request_release_forgets_slot_before_it_can_be_reused() -> None:
@@ -284,3 +322,4 @@ def test_batched_tail_cuda_graph_matches_eager_for_dynamic_slot_order() -> None:
     torch.testing.assert_close(graph_feedback, eager_feedback, rtol=2e-2, atol=2e-2)
     assert graph._graph_replays == {"meanflow": 1, "semantic_encoder": 1}
     assert not graph._graph_misses
+    assert graph._dit_contiguous_view_steps == NFE


### PR DESCRIPTION
## Summary

- reorder a full dots.tts acoustic slot pool once into physical slot order
- run every MeanFlow NFE step against contiguous DiT KV cache views instead of copying the persistent prefix with `index_select`
- preserve the existing gather path for partial or fragmented slot batches and restore request order after the fast path

This is a follow-up to the batched acoustic-tail graphs in #1385 and tracks the dots.tts roadmap in #1367.

## Performance

H200, canonical optimized `examples/configs/dots_tts.yaml`, SeedTTS English, 128 requests, concurrency 16, 10 warmups, same GPU and seed, sequential runs:

| Metric | main (`f4a8cd93`) | this PR | Delta |
|---|---:|---:|---:|
| Throughput (req/s) | 3.694 | 3.853 | +4.30% |
| Mean latency (s) | 4.204 | 4.007 | -4.69% |
| P95 latency (s) | 6.379 | 6.334 | -0.71% |
| Mean RTF | 1.1286 | 1.0765 | -4.62% |
| P95 RTF | 1.4015 | 1.3511 | -3.60% |
| Audio throughput (s/s) | 13.968 | 14.549 | +4.16% |

An independent same-GPU repeat measured +4.29% request throughput. The production server log confirms `dots.tts contiguous DiT KV view is active` at concurrency 16.

## Accuracy and validation

- Qwen3-ASR-1.7B WER on the same 128 SeedTTS samples: main 0.95%, PR 0.95%
- H200: `pytest -q tests/unit_test/dots_tts` — 47 passed
- full-pool slot permutations match the fragmented gather fallback with per-slot RNG and unequal persistent lengths
- CUDA graph dynamic slot-order coverage exercises the contiguous path
- `pre-commit` and `git diff --check` pass

The fast path requires the complete slot pool. Partial and fragmented batches retain the current behavior, including retraction-safe slot addressing.
