### PR TITLE
[ASR] Align long-audio chunking with Qwen3-ASR native limits

### DIFF
--- a/sglang_omni/models/qwen3_asr/audio_lengths.py
+++ b/sglang_omni/models/qwen3_asr/audio_lengths.py
@@ -48,16 +48,10 @@ def qwen3_asr_max_audio_tokens() -> int:
 QWEN3_ASR_OUTPUT_TOKENS_PER_SECOND = 10
 
 
-def qwen3_asr_max_output_tokens() -> int:
-    """Output-token budget of the longest natively supported clip (12,000)."""
-    return QWEN3_ASR_MAX_INPUT_SECONDS * QWEN3_ASR_OUTPUT_TOKENS_PER_SECOND
-
-
 __all__ = [
     "QWEN3_ASR_MAX_INPUT_SECONDS",
     "QWEN3_ASR_OUTPUT_TOKENS_PER_SECOND",
     "qwen3_asr_audio_token_lengths",
     "qwen3_asr_max_audio_tokens",
-    "qwen3_asr_max_output_tokens",
     "qwen3_asr_num_audio_tokens",
 ]

--- a/sglang_omni/models/qwen3_asr/config.py
+++ b/sglang_omni/models/qwen3_asr/config.py
@@ -17,7 +17,7 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
     architecture: ClassVar[str] = "Qwen3ASRForConditionalGeneration"
     audio_chunking: ClassVar[AudioChunkingConfig] = AudioChunkingConfig(
         allow_audio_chunking=True,
-        max_audio_clip_s=60.0,
+        max_audio_clip_s=float(QWEN3_ASR_MAX_INPUT_SECONDS),
         max_native_clip_s=float(QWEN3_ASR_MAX_INPUT_SECONDS),
     )
 
@@ -39,9 +39,7 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
             factory_args={
                 "device": "cuda:0",
                 "max_running_requests": 64,
-                # Note (Jeffro): This is the floor for the per-request output budget.
-                # The request builder will scale the actual budget with audio duration.
-                "max_new_tokens": 128,
+                "max_new_tokens": 4096,
                 "enable_torch_compile": True,
                 "torch_compile_max_bs": 2,
                 "request_build_max_workers": 8,

--- a/sglang_omni/models/qwen3_asr/config.py
+++ b/sglang_omni/models/qwen3_asr/config.py
@@ -17,7 +17,7 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
     architecture: ClassVar[str] = "Qwen3ASRForConditionalGeneration"
     audio_chunking: ClassVar[AudioChunkingConfig] = AudioChunkingConfig(
         allow_audio_chunking=True,
-        max_audio_clip_s=float(QWEN3_ASR_MAX_INPUT_SECONDS),
+        max_audio_clip_s=60.0,
         max_native_clip_s=float(QWEN3_ASR_MAX_INPUT_SECONDS),
     )
 

--- a/sglang_omni/models/qwen3_asr/engine_builder.py
+++ b/sglang_omni/models/qwen3_asr/engine_builder.py
@@ -10,10 +10,7 @@ from sglang.srt.managers.mm_utils import init_mm_embedding_cache
 from transformers import AutoFeatureExtractor, AutoTokenizer
 
 from sglang_omni.models.qwen3_asr import request_builders
-from sglang_omni.models.qwen3_asr.audio_lengths import (
-    qwen3_asr_max_audio_tokens,
-    qwen3_asr_max_output_tokens,
-)
+from sglang_omni.models.qwen3_asr.audio_lengths import qwen3_asr_max_audio_tokens
 from sglang_omni.models.qwen3_asr.encoder_service import (
     Qwen3ASRPreLMEncoderService,
     build_cache_namespace,
@@ -102,14 +99,11 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
         self.feature_extractor = AutoFeatureExtractor.from_pretrained(
             checkpoint_dir, trust_remote_code=True
         )
-        # Note(Jeffro): Size context_length for the model's native max input + output budget.
-        # model natively accepts: 1,200s (MAX_ASR_INPUT_SECONDS, see
+        # Size context_length for the model's native 1,200s maximum input (see
         # https://github.com/QwenLM/Qwen3-ASR/blob/956766769/qwen_asr/inference/utils.py#L34)
-        # = 15,600 audio tokens, plus 64 slack for the ~15-token chat prompt,
-        # +  the max output budget for that input (12,000).
+        # plus the configured output capacity and prompt slack.
         max_prompt_tokens = qwen3_asr_max_audio_tokens() + 64
-        max_output_budget = max(self.max_new_tokens, qwen3_asr_max_output_tokens())
-        self.context_length = max_prompt_tokens + max_output_budget + 8
+        self.context_length = max_prompt_tokens + self.max_new_tokens + 8
 
     def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
         defaults: dict[str, Any] = {

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -51,6 +51,8 @@ _AUDIO_PAD = "<|audio_pad|>"
 _AUDIO_END = "<|audio_end|>"
 _ASR_TEXT = "<asr_text>"
 
+_MIN_GENERATION_TOKENS = 128
+
 
 @dataclass
 class Qwen3ASRRequestData(SGLangARRequestData):
@@ -93,6 +95,29 @@ def _encode_literal(tokenizer: Any, text: str) -> list[int]:
     else:
         input_ids = encoded["input_ids"]
     return list(input_ids)
+
+
+def _request_output_token_budget(
+    params: dict[str, Any],
+    audio_duration_s: float,
+    max_new_tokens: int,
+) -> int:
+    explicit = params.get("max_new_tokens")
+    if explicit is not None:
+        try:
+            requested = int(explicit)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("max_new_tokens must be an integer") from exc
+        if requested < 1 or requested > max_new_tokens:
+            raise ValueError(
+                f"max_new_tokens must be between 1 and {max_new_tokens}, "
+                f"got {requested}"
+            )
+        return requested
+    duration_budget = math.ceil(
+        max(audio_duration_s, 0.0) * QWEN3_ASR_OUTPUT_TOKENS_PER_SECOND
+    )
+    return min(max_new_tokens, max(_MIN_GENERATION_TOKENS, duration_budget))
 
 
 def make_qwen3_asr_scheduler_adapters(
@@ -182,13 +207,11 @@ def make_qwen3_asr_scheduler_adapters(
         fingerprint = prepared.fingerprint
 
         explicit_max_new_tokens = params.get("max_new_tokens")
-        if explicit_max_new_tokens is not None:
-            request_max_new_tokens = int(explicit_max_new_tokens)
-        else:
-            request_max_new_tokens = max(
-                int(max_new_tokens),
-                math.ceil(audio_duration_s * QWEN3_ASR_OUTPUT_TOKENS_PER_SECOND),
-            )
+        request_max_new_tokens = _request_output_token_budget(
+            params,
+            audio_duration_s,
+            max_new_tokens,
+        )
 
         estimated_audio_tokens = None
         if context_length is not None or audio_encoder_service is not None:
@@ -225,7 +248,7 @@ def make_qwen3_asr_scheduler_adapters(
 
             if explicit_max_new_tokens is None:
                 remaining = context_length - 1 - len(estimated_input_ids)
-                if remaining >= int(max_new_tokens):
+                if remaining >= _MIN_GENERATION_TOKENS:
                     request_max_new_tokens = min(request_max_new_tokens, remaining)
 
             _validate_context_budget(estimated_input_ids, request_max_new_tokens)

--- a/sglang_omni/models/qwen3_asr/stages.py
+++ b/sglang_omni/models/qwen3_asr/stages.py
@@ -12,7 +12,7 @@ def create_sglang_qwen3_asr_executor(
     device: str = "cuda:0",
     dtype: str = "auto",
     max_running_requests: int = 64,
-    max_new_tokens: int = 256,
+    max_new_tokens: int = 4096,
     mem_fraction_static: float | None = None,
     mm_embedding_cache_size_bytes: int = 0,
     enable_torch_compile: bool = False,

--- a/sglang_omni/serve/transcription_adapters/base.py
+++ b/sglang_omni/serve/transcription_adapters/base.py
@@ -43,35 +43,6 @@ class TranscriptionAdapter(ABC):
     ) -> TranscriptionVerboseResponse:
         """Build a verbose_json response with segments / timestamps."""
 
-    def build_verbose_response_from_chunks(
-        self,
-        *,
-        text: str,
-        chunks: list[tuple[float, float, str]],
-        language: str | None,
-        audio_duration_s: float,
-    ) -> TranscriptionVerboseResponse:
-        """verbose_json for chunked long audio: one segment per chunk."""
-        segments: list[TranscriptionSegment] = []
-        for start_s, end_s, chunk_text in chunks:
-            stripped = self.postprocess_text(chunk_text).strip()
-            if not stripped:
-                continue
-            segments.append(
-                TranscriptionSegment(
-                    id=len(segments),
-                    start=round(start_s, 2),
-                    end=round(end_s, 2),
-                    text=stripped,
-                )
-            )
-        return TranscriptionVerboseResponse(
-            language=language,
-            duration=round(max(float(audio_duration_s), 0.0), 2),
-            text=text,
-            segments=segments,
-        )
-
 
 class DefaultTranscriptionAdapter(TranscriptionAdapter):
     """Fallback: emit the whole transcript as a single segment."""

--- a/sglang_omni/serve/transcription_chunking.py
+++ b/sglang_omni/serve/transcription_chunking.py
@@ -129,7 +129,9 @@ class RMSSplitter:
         frames = region[: window_count * window].reshape(window_count, window)
         # Mean square orders identically to RMS, so the square root is skipped.
         energies = np.mean(np.square(frames.astype(np.float64)), axis=1)
-        quietest = int(np.argmin(energies))
+        # Prefer the latest equally quiet window so silence stays close to the
+        # hard limit rather than introducing avoidable extra chunks.
+        quietest = int(np.flatnonzero(energies == energies.min())[-1])
         return search_start + quietest * window + window // 2
 
 
@@ -204,24 +206,42 @@ def plan_audio_chunks(
     Blocking: decodes the whole file, so callers on the event loop must run it
     in a thread.
     """
+    _, plan = decode_audio_chunks(
+        audio_bytes,
+        config,
+        splitter=splitter,
+        sample_rate=sample_rate,
+    )
+    return plan
+
+
+def decode_audio_chunks(
+    audio_bytes: bytes,
+    config: AudioChunkingConfig,
+    *,
+    splitter: RMSSplitter | None = None,
+    sample_rate: int = TARGET_SAMPLE_RATE,
+) -> tuple[float, ChunkPlan | None]:
+    """Decode an upload and return its duration plus any required chunk plan."""
     waveform = load_audio(
         audio_bytes, source_name="transcription", target_sample_rate=sample_rate
     )
     total_samples = int(waveform.shape[-1])
+    duration_s = total_samples / sample_rate
     max_chunk_samples = config.chunk_samples(sample_rate)
     if total_samples <= max_chunk_samples:
         logger.debug(
             "[transcription] decoded audio is %d samples, within one chunk",
             total_samples,
         )
-        return None
+        return duration_s, None
 
     spans = (splitter or RMSSplitter()).split(
         waveform, sample_rate, max_chunk_samples, min_tail_s=config.min_tail_s
     )
-    return ChunkPlan(
+    return duration_s, ChunkPlan(
         sample_rate=sample_rate,
-        duration_s=total_samples / sample_rate,
+        duration_s=duration_s,
         spans=[
             ChunkSpan(
                 index=index,
@@ -236,52 +256,6 @@ def plan_audio_chunks(
     )
 
 
-# Scripts that write without spaces between words. Everything not listed --
-# Latin, Cyrillic, Hangul (Korean does use word spaces), Arabic, ... -- takes
-# a space at a chunk seam. An explicit table because Unicode has no
-# word-spacing property: east_asian_width is a display-width proxy that
-# misclassifies Korean (wide but spaced) and Thai (narrow but unspaced).
-_UNSPACED_SCRIPT_RANGES = (
-    (0x0E00, 0x0EFF),  # Thai, Lao
-    (0x1000, 0x109F),  # Myanmar
-    (0x1780, 0x17FF),  # Khmer
-    (0x2E80, 0x303F),  # CJK radicals, Kangxi, CJK symbols and punctuation
-    (0x3040, 0x30FF),  # Hiragana, Katakana
-    (0x3400, 0x9FFF),  # CJK unified ideographs (+ extension A)
-    (0xF900, 0xFAFF),  # CJK compatibility ideographs
-    (0xFF00, 0xFFEF),  # fullwidth and halfwidth forms
-    (0x20000, 0x2FA1F),  # CJK unified ideographs extensions B..F
-)
-
-
-def _is_spaced_script(char: str) -> bool:
-    """Whether this character's writing system separates words with spaces."""
-    if char.isspace():
-        return False
-    code_point = ord(char)
-    return not any(low <= code_point <= high for low, high in _UNSPACED_SCRIPT_RANGES)
-
-
 def join_transcript_parts(parts: Iterable[str]) -> str:
-    """Join per-chunk transcripts into one, adding spaces only where the
-    script needs them.
-
-    A space goes in only when the characters on BOTH sides of the seam belong
-    to spaced scripts: "hello" + "world" -> "hello world", but Chinese chunks
-    join directly -- a space the reference transcript does not have counts as
-    an insertion error in CER, once per seam.
-
-    Each part is stripped first so the seam is fully controlled by this rule
-    rather than by whatever whitespace the model decoded; empty parts (an
-    all-silence chunk) are skipped.
-    """
-    joined = ""
-
-    for part in parts:
-        stripped = part.strip()
-        if not stripped:
-            continue
-        if joined and _is_spaced_script(joined[-1]) and _is_spaced_script(stripped[0]):
-            joined += " "
-        joined += stripped
-    return joined
+    """Join non-overlapping chunk transcripts exactly as the model returned them."""
+    return "".join(parts)

--- a/sglang_omni/serve/transcriptions.py
+++ b/sglang_omni/serve/transcriptions.py
@@ -5,25 +5,22 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import math
 import uuid
 from collections.abc import Awaitable
 
 from fastapi import Depends, FastAPI, HTTPException, Request
-from fastapi.responses import JSONResponse, PlainTextResponse, Response
+from fastapi.responses import Response
 
 from sglang_omni.client import Client, ClientError, GenerateRequest
 from sglang_omni.config import AudioChunkingConfig
 from sglang_omni.serve import speech_to_text
 from sglang_omni.serve.openai_errors import is_bad_request_error
-from sglang_omni.serve.protocol import TranscriptionResponse, TranscriptionUsage
 from sglang_omni.serve.transcription_chunking import (
     ChunkPlan,
     ChunkSpan,
     check_total_duration,
+    decode_audio_chunks,
     join_transcript_parts,
-    needs_chunking,
-    plan_audio_chunks,
 )
 
 logger = logging.getLogger(__name__)
@@ -109,17 +106,11 @@ def register_transcriptions(app: FastAPI) -> None:
             )
 
         duration_s = await asyncio.to_thread(_probe_audio_duration, audio_bytes)
-        plan: ChunkPlan | None = None
-        if needs_chunking(duration_s, chunking):
-            try:
-                # Check duration before decoding: a small compressed file can
-                # hold hours of audio, and decoding that eats gigabytes.
-                check_total_duration(duration_s, chunking)
-            except ValueError as exc:
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
-            # Decode + split in a worker thread: decoding a long file is pure
-            # CPU and would stall the event loop.
-            plan = await asyncio.to_thread(plan_audio_chunks, audio_bytes, chunking)
+        duration_s, plan = await _prepare_transcription_audio(
+            audio_bytes,
+            chunking,
+            duration_s=duration_s,
+        )
 
         if plan is None:
             gen_req = speech_to_text.build_speech_to_text_generate_request(
@@ -138,103 +129,47 @@ def register_transcriptions(app: FastAPI) -> None:
                 request_id=request_id,
                 error_log_message="Error transcribing audio for request %s",
             )
-            return speech_to_text.assemble_speech_to_text_response(
-                text=result.text,
-                response_format=form.response_format,
-                endpoint_path=TRANSCRIPTIONS_ENDPOINT,
-                task="transcribe",
-                language=form.language,
-                audio_bytes=audio_bytes,
-                architectures=getattr(app.state, "architectures", None),
-                duration_s=duration_s,
-            )
+            text = result.text
+        else:
+            try:
+                chunk_texts = await _await_transcription_with_disconnect_abort(
+                    request,
+                    _transcribe_audio_chunks(
+                        client,
+                        plan,
+                        request_id=request_id,
+                        model=form.model or default_model,
+                        filename=form.file.filename,
+                        language=form.language,
+                        prompt=form.prompt,
+                        temperature=form.temperature,
+                        max_new_tokens=form.max_new_tokens,
+                        max_concurrent=chunking.max_concurrent_chunks,
+                    ),
+                )
+            except ClientError as exc:
+                if is_bad_request_error(exc):
+                    raise HTTPException(status_code=400, detail=str(exc)) from exc
+                raise HTTPException(status_code=500, detail=str(exc)) from exc
+            except (HTTPException, asyncio.CancelledError):
+                raise
+            except Exception as exc:
+                if is_bad_request_error(exc):
+                    raise HTTPException(status_code=400, detail=str(exc)) from exc
+                logger.exception("Error transcribing audio for request %s", request_id)
+                raise HTTPException(status_code=500, detail=str(exc)) from exc
+            text = join_transcript_parts(chunk_texts)
 
-        try:
-            chunk_texts = await _await_transcription_with_disconnect_abort(
-                request,
-                _transcribe_audio_chunks(
-                    client,
-                    plan,
-                    request_id=request_id,
-                    model=form.model or default_model,
-                    filename=form.file.filename,
-                    language=form.language,
-                    prompt=form.prompt,
-                    temperature=form.temperature,
-                    max_new_tokens=form.max_new_tokens,
-                    max_concurrent=chunking.max_concurrent_chunks,
-                ),
-            )
-        except ClientError as exc:
-            if is_bad_request_error(exc):
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-        except (HTTPException, asyncio.CancelledError):
-            raise
-        except Exception as exc:
-            if is_bad_request_error(exc):
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
-            logger.exception("Error transcribing audio for request %s", request_id)
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-        text = join_transcript_parts(chunk_texts)
-        return _assemble_chunked_response(
+        return speech_to_text.assemble_speech_to_text_response(
             text=text,
             response_format=form.response_format,
+            endpoint_path=TRANSCRIPTIONS_ENDPOINT,
+            task="transcribe",
             language=form.language,
-            plan=plan,
-            chunk_texts=chunk_texts,
+            audio_bytes=audio_bytes,
             architectures=getattr(app.state, "architectures", None),
+            duration_s=duration_s,
         )
-
-
-def _assemble_chunked_response(
-    *,
-    text: str,
-    response_format: str,
-    language: str | None,
-    plan: ChunkPlan,
-    chunk_texts: list[str],
-    architectures: list[str] | None,
-) -> Response:
-    """Chunk-aware sibling of speech_to_text.assemble_speech_to_text_response.
-
-    The shared assembler probes the upload for a duration and builds one
-    verbose segment for the whole file; here the plan already knows the exact
-    duration and where each chunk sits, so verbose_json gets one segment per
-    chunk with real timestamps.
-    """
-    normalized_response_format = speech_to_text.validate_speech_to_text_response_format(
-        response_format,
-        stream=False,
-        endpoint_path=TRANSCRIPTIONS_ENDPOINT,
-    )
-    if normalized_response_format == "text":
-        return PlainTextResponse(text)
-
-    adapter = speech_to_text.resolve_speech_to_text_adapter(architectures)
-    text = adapter.postprocess_text(text)
-    duration_s = plan.duration_s
-    usage = (
-        TranscriptionUsage(seconds=math.ceil(duration_s)) if duration_s > 0 else None
-    )
-    if normalized_response_format == "verbose_json":
-        response = adapter.build_verbose_response_from_chunks(
-            text=text,
-            chunks=[
-                (span.start_s, span.end_s, chunk_text)
-                for span, chunk_text in zip(plan.spans, chunk_texts)
-            ],
-            language=language,
-            audio_duration_s=duration_s,
-        )
-        response.task = "transcribe"
-        response.usage = usage
-        return JSONResponse(content=response.model_dump(exclude_none=True))
-    return JSONResponse(
-        content=TranscriptionResponse(text=text, usage=usage).model_dump(
-            exclude_none=True
-        )
-    )
 
 
 def _build_chunk_generate_request(
@@ -373,3 +308,42 @@ async def _await_transcription_with_disconnect_abort(
             await _cancel_task_bounded(work_task)
         if not disconnect_task.done():
             await _cancel_task_bounded(disconnect_task)
+
+
+async def _prepare_transcription_audio(
+    audio_bytes: bytes,
+    chunking: AudioChunkingConfig,
+    *,
+    duration_s: float,
+) -> tuple[float, ChunkPlan | None]:
+    """Decode only when the probed duration cannot decide chunking."""
+    if not chunking.allow_audio_chunking:
+        return duration_s, None
+    if 0 < duration_s <= chunking.max_audio_clip_s:
+        return duration_s, None
+
+    if duration_s > 0:
+        try:
+            # Reject known oversized uploads before a compressed file expands
+            # into a large decoded waveform.
+            check_total_duration(duration_s, chunking)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        decoded_duration_s, plan = await asyncio.to_thread(
+            decode_audio_chunks,
+            audio_bytes,
+            chunking,
+        )
+    except (RuntimeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Could not decode uploaded audio: {exc}",
+        ) from exc
+
+    try:
+        check_total_duration(decoded_duration_s, chunking)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return decoded_duration_s, plan

--- a/sglang_omni/serve/transcriptions.py
+++ b/sglang_omni/serve/transcriptions.py
@@ -22,6 +22,7 @@ from sglang_omni.serve.transcription_chunking import (
     decode_audio_chunks,
     join_transcript_parts,
 )
+from sglang_omni.utils.audio import AudioDecodeError
 
 logger = logging.getLogger(__name__)
 
@@ -105,12 +106,20 @@ def register_transcriptions(app: FastAPI) -> None:
                 duration_s=duration_s,
             )
 
-        duration_s = await asyncio.to_thread(_probe_audio_duration, audio_bytes)
-        duration_s, plan = await _prepare_transcription_audio(
-            audio_bytes,
-            chunking,
-            duration_s=duration_s,
-        )
+        try:
+            duration_s = await asyncio.to_thread(_probe_audio_duration, audio_bytes)
+            duration_s, plan = await _prepare_transcription_audio(
+                audio_bytes,
+                chunking,
+                duration_s=duration_s,
+            )
+        except HTTPException:
+            raise
+        except Exception as exc:
+            if is_bad_request_error(exc):
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            logger.exception("Error transcribing audio for request %s", request_id)
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
 
         if plan is None:
             gen_req = speech_to_text.build_speech_to_text_generate_request(
@@ -336,7 +345,7 @@ async def _prepare_transcription_audio(
             audio_bytes,
             chunking,
         )
-    except (RuntimeError, ValueError) as exc:
+    except AudioDecodeError as exc:
         raise HTTPException(
             status_code=400,
             detail=f"Could not decode uploaded audio: {exc}",

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -17,6 +17,7 @@ import sglang_omni.scheduling.sglang_backend as sglang_backend
 from sglang_omni.config.manager import ConfigManager
 from sglang_omni.config.runtime import resolve_stage_static_factory_args
 from sglang_omni.models.qwen3_asr import request_builders
+from sglang_omni.models.qwen3_asr.audio_lengths import qwen3_asr_max_audio_tokens
 from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
 from sglang_omni.models.qwen3_asr.stages import create_sglang_qwen3_asr_executor
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
@@ -101,6 +102,7 @@ def test_qwen3_asr_config_uses_batched_stage_with_64_running_requests() -> None:
     assert config.stages[0].factory.endswith("create_sglang_qwen3_asr_executor")
     assert config.stages[0].factory_args["device"] == "cuda:0"
     assert config.stages[0].factory_args["max_running_requests"] == 64
+    assert config.stages[0].factory_args["max_new_tokens"] == 4096
     assert config.stages[0].factory_args["enable_torch_compile"] is True
     assert config.stages[0].factory_args["torch_compile_max_bs"] == 2
     assert config.stages[0].factory_args["request_build_max_workers"] == 8
@@ -136,6 +138,7 @@ def test_qwen3_asr_stage_default_allows_64_running_requests() -> None:
     signature = inspect.signature(create_sglang_qwen3_asr_executor)
 
     assert signature.parameters["max_running_requests"].default == 64
+    assert signature.parameters["max_new_tokens"].default == 4096
     assert signature.parameters["request_build_max_workers"].default == 8
     assert signature.parameters["request_build_max_pending"].default == 32
     assert signature.parameters["prefill_coalesce_requests"].default == 16
@@ -213,6 +216,43 @@ def test_qwen3_asr_stage_default_enables_async_decode() -> None:
     assert signature.parameters["async_decode_min_batch_size"].default == 1
 
 
+def test_qwen3_asr_default_context_covers_native_audio_and_output_capacity(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        qwen3_asr_builder.AutoTokenizer,
+        "from_pretrained",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        qwen3_asr_builder.AutoFeatureExtractor,
+        "from_pretrained",
+        lambda *args, **kwargs: object(),
+    )
+    builder = qwen3_asr_builder.Qwen3ASREngineBuilder(
+        max_running_requests=64,
+        max_new_tokens=4096,
+        enable_async_decode=True,
+        async_decode_min_batch_size=2,
+        mem_fraction_static=None,
+        mm_embedding_cache_size_bytes=0,
+        enable_torch_compile=False,
+        torch_compile_max_bs=1,
+        mm_attention_backend=None,
+        request_build_max_workers=8,
+        request_build_max_pending=32,
+        prefill_coalesce_requests=16,
+        prefill_coalesce_wait_ms=24.0,
+        prefill_coalesce_when_idle=True,
+        prefill_coalesce_requires_pending_builds=True,
+        prefill_coalesce_after_builds_during_decode=True,
+    )
+
+    builder.pre_infra_setup("dummy")
+
+    assert builder.context_length == qwen3_asr_max_audio_tokens() + 4096 + 72
+
+
 def test_qwen3_asr_rtx4090_profile_is_bf16_and_bounded() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     config = ConfigManager.from_file(
@@ -286,6 +326,7 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch, caplog) -> None:
     )
 
     def _fake_server_args_builder(model_path, context_length, **overrides):
+        build_kwargs["context_length"] = context_length
         build_kwargs.update(overrides)
         normalized_overrides = {
             key: value
@@ -356,6 +397,7 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch, caplog) -> None:
     assert "cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64]" in caplog.text
     assert "mm_attention_backend" not in build_kwargs
     assert memory_queries == [0, 0, 0]
+    assert build_kwargs["context_length"] == 2048
     assert adapter_kwargs["context_length"] == 2048
     assert scheduler.enable_async_decode is False
     assert scheduler.async_decode_min_batch_size == 4

--- a/tests/unit_test/qwen3_asr/test_request_builders.py
+++ b/tests/unit_test/qwen3_asr/test_request_builders.py
@@ -10,6 +10,7 @@ import torch
 from transformers import WhisperFeatureExtractor
 
 import sglang_omni.preprocessing.transcription as transcription
+from sglang_omni.models.qwen3_asr import request_builders
 from sglang_omni.models.qwen3_asr.audio_lengths import (
     qwen3_asr_audio_token_lengths,
     qwen3_asr_num_audio_tokens,
@@ -100,15 +101,12 @@ def test_qwen3_asr_max_audio_tokens_covers_the_native_limit() -> None:
     from sglang_omni.models.qwen3_asr.audio_lengths import (
         QWEN3_ASR_MAX_INPUT_SECONDS,
         qwen3_asr_max_audio_tokens,
-        qwen3_asr_max_output_tokens,
     )
 
     # The official wrapper accepts up to 1,200s natively; the engine context
-    # is sized from this figure (13 audio tokens per second) plus the
-    # duration-scaled output budget that clip would get.
+    # is sized from this figure (13 audio tokens per second).
     assert QWEN3_ASR_MAX_INPUT_SECONDS == 1200
     assert qwen3_asr_max_audio_tokens() == 15_600
-    assert qwen3_asr_max_output_tokens() == 12_000
 
 
 def _budget_test_builder(monkeypatch, num_samples: int):
@@ -123,7 +121,7 @@ def _budget_test_builder(monkeypatch, num_samples: int):
     )
     request_builder, _ = make_qwen3_asr_scheduler_adapters(
         tokenizer=_FakeTokenizer(),
-        max_new_tokens=128,
+        max_new_tokens=4096,
         feature_extractor=feature_extractor,
     )
     return request_builder
@@ -436,6 +434,37 @@ def test_qwen3_asr_request_builder_preserves_sampling_mode(
     assert data.temperature == expected_temperature
     assert data.req.sampling_params.temperature == expected_sampling_temperature
     assert data.req.sampling_params.top_k == expected_top_k
+
+
+@pytest.mark.parametrize(
+    ("duration_s", "expected"),
+    [
+        (0.0, 128),
+        (1.5, 128),
+        (60.0, 600),
+        (1200.0, 4096),
+    ],
+)
+def test_qwen3_asr_default_output_budget_scales_with_duration(
+    duration_s: float,
+    expected: int,
+) -> None:
+    assert (
+        request_builders._request_output_token_budget({}, duration_s, 4096) == expected
+    )
+
+
+@pytest.mark.parametrize("explicit", [0, 4097])
+def test_qwen3_asr_explicit_output_budget_must_fit_capacity(explicit: int) -> None:
+    with pytest.raises(
+        ValueError,
+        match=rf"max_new_tokens must be between 1 and 4096, got {explicit}",
+    ):
+        request_builders._request_output_token_budget(
+            {"max_new_tokens": explicit},
+            60.0,
+            4096,
+        )
 
 
 def test_qwen3_asr_request_builder_preserves_audio_beyond_30_seconds(

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -1512,7 +1512,7 @@ def test_long_audio_is_transcribed_chunk_by_chunk() -> None:
         assert request.prompt["audio_bytes"][:4] == b"RIFF"
         assert request.prompt["content_type"] == "audio/wav"
     # Chunk texts are assembled in span order regardless of completion order.
-    expected_text = " ".join(f"part{index}" for index in range(count))
+    expected_text = "".join(f"part{index}" for index in range(count))
     assert response.json()["text"] == expected_text
     # usage reports the whole upload, not one chunk.
     assert response.json()["usage"] == {"seconds": 3, "type": "duration"}
@@ -1631,7 +1631,7 @@ def test_streamed_short_audio_streams_as_before() -> None:
     assert "transcript.text.done" in response.text
 
 
-def test_verbose_json_reports_per_chunk_segments() -> None:
+def test_verbose_json_does_not_present_chunk_boundaries_as_timestamps() -> None:
     transcription_client = ChunkRecordingTranscriptionClient()
     client = _chunking_test_client(transcription_client)
 
@@ -1644,35 +1644,15 @@ def test_verbose_json_reports_per_chunk_segments() -> None:
     assert response.status_code == 200
     body = response.json()
     segments = body["segments"]
-    # One segment per chunk, with the chunk's own timestamps -- not a single
-    # segment spanning the whole upload.
-    assert len(segments) == len(transcription_client.requests) > 1
-    previous_end = 0.0
-    for index, segment in enumerate(segments):
-        assert segment["id"] == index
-        assert segment["text"] == f"part{index}"
-        assert segment["start"] == pytest.approx(previous_end)
-        assert segment["end"] > segment["start"]
-        previous_end = segment["end"]
-    assert previous_end == pytest.approx(2.5, abs=0.01)
+    expected_text = "".join(
+        f"part{index}" for index in range(len(transcription_client.requests))
+    )
+    assert len(segments) == 1
+    assert segments[0]["id"] == 0
+    assert segments[0]["start"] == 0.0
+    assert segments[0]["end"] == pytest.approx(2.5, abs=0.01)
+    assert segments[0]["text"] == expected_text
     assert body["duration"] == pytest.approx(2.5, abs=0.01)
-
-
-def test_chunk_segments_skip_silent_chunks() -> None:
-    from sglang_omni.serve.transcription_adapters.base import (
-        DefaultTranscriptionAdapter,
-    )
-
-    response = DefaultTranscriptionAdapter().build_verbose_response_from_chunks(
-        text="hello world",
-        chunks=[(0.0, 1.0, "hello"), (1.0, 2.0, "   "), (2.0, 2.5, "world")],
-        language="en",
-        audio_duration_s=2.5,
-    )
-
-    # The silent chunk emits no segment and ids stay consecutive.
-    assert [(s.id, s.text) for s in response.segments] == [(0, "hello"), (1, "world")]
-    assert response.segments[1].start == 2.0
 
 
 def test_chunk_failure_fails_the_whole_request() -> None:
@@ -2080,24 +2060,86 @@ def test_long_m4a_is_probed_and_chunked() -> None:
     )
 
 
-def test_unprobeable_audio_with_chunking_enabled_stays_one_request() -> None:
-    # soundfile cannot read these bytes, so the duration probe returns 0.0 and
-    # the upload keeps today's behaviour instead of paying a decode.
+def test_unknown_probed_duration_uses_decoded_length(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.serve import transcriptions
+
+    monkeypatch.setattr(transcriptions, "_probe_audio_duration", lambda _: 0.0)
+    transcription_client = ChunkRecordingTranscriptionClient()
+    client = _chunking_test_client(transcription_client)
+    upload = _wav_upload(2.5)
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={"model": "asr"},
+        files={"file": ("mystery.m4a", upload, "audio/mp4")},
+    )
+
+    assert response.status_code == 200
+    assert len(transcription_client.requests) > 1
+
+
+def test_unknown_probed_short_audio_preserves_original_upload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.serve import transcriptions
+
+    monkeypatch.setattr(transcriptions, "_probe_audio_duration", lambda _: 0.0)
+    transcription_client = ChunkRecordingTranscriptionClient()
+    client = _chunking_test_client(transcription_client)
+    upload = _wav_upload(0.5)
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={"model": "asr"},
+        files={"file": ("mystery.m4a", upload, "audio/mp4")},
+    )
+
+    assert response.status_code == 200
+    assert len(transcription_client.requests) == 1
+    assert transcription_client.requests[0][1].prompt["audio_bytes"] == upload
+    assert response.json()["usage"] == {"seconds": 1, "type": "duration"}
+
+
+def test_unknown_probed_invalid_audio_returns_400(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.serve import transcriptions
+
+    monkeypatch.setattr(transcriptions, "_probe_audio_duration", lambda _: 0.0)
     transcription_client = ChunkRecordingTranscriptionClient()
     client = _chunking_test_client(transcription_client)
 
     response = client.post(
         "/v1/audio/transcriptions",
         data={"model": "asr"},
-        files={"file": ("mystery.bin", b"RIFF not really audio", "audio/wav")},
+        files={"file": ("broken.m4a", b"not audio", "audio/mp4")},
     )
 
-    assert response.status_code == 200
-    assert len(transcription_client.requests) == 1
-    assert (
-        transcription_client.requests[0][1].prompt["audio_bytes"]
-        == b"RIFF not really audio"
+    assert response.status_code == 400
+    assert "Could not decode uploaded audio" in response.json()["detail"]
+    assert transcription_client.requests == []
+
+
+def test_unknown_probed_duration_enforces_decoded_total_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.serve import transcriptions
+
+    monkeypatch.setattr(transcriptions, "_probe_audio_duration", lambda _: 0.0)
+    transcription_client = ChunkRecordingTranscriptionClient()
+    client = _chunking_test_client(transcription_client, max_total_audio_s=2.0)
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={"model": "asr"},
+        files={"file": ("mystery.m4a", _wav_upload(2.5), "audio/mp4")},
     )
+
+    assert response.status_code == 400
+    assert "accepts audio up to" in response.json()["detail"]
+    assert transcription_client.requests == []
 
 
 def test_transcription_endpoint_returns_text_json() -> None:

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -7,6 +7,7 @@ import base64
 from typing import Any
 
 import pytest
+import torch
 from fastapi.testclient import TestClient
 
 from sglang_omni.client import Client, GenerateChunk
@@ -2119,6 +2120,55 @@ def test_unknown_probed_invalid_audio_returns_400(
 
     assert response.status_code == 400
     assert "Could not decode uploaded audio" in response.json()["detail"]
+    assert transcription_client.requests == []
+
+
+@pytest.mark.parametrize(
+    "decode_error",
+    [
+        RuntimeError("audio decoder backend unavailable"),
+        torch.OutOfMemoryError("audio decoder out of memory"),
+    ],
+    ids=["runtime-error", "out-of-memory"],
+)
+def test_unknown_probed_operational_decode_error_returns_500(
+    monkeypatch: pytest.MonkeyPatch,
+    decode_error: RuntimeError,
+) -> None:
+    from sglang_omni.config import AudioChunkingConfig
+    from sglang_omni.serve import transcriptions
+
+    monkeypatch.setattr(transcriptions, "_probe_audio_duration", lambda _: 0.0)
+
+    def raise_decode_error(*args: Any, **kwargs: Any) -> None:
+        raise decode_error
+
+    monkeypatch.setattr(
+        transcriptions,
+        "decode_audio_chunks",
+        raise_decode_error,
+    )
+    transcription_client = ChunkRecordingTranscriptionClient()
+    client = TestClient(
+        create_app(
+            transcription_client,
+            model_name="asr",
+            audio_chunking=AudioChunkingConfig(
+                allow_audio_chunking=True,
+                max_audio_clip_s=1.0,
+            ),
+        ),
+        raise_server_exceptions=False,
+    )
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={"model": "asr"},
+        files={"file": ("audio.wav", _wav_upload(0.5), "audio/wav")},
+    )
+
+    assert response.status_code == 500
+    assert str(decode_error) in response.json()["detail"]
     assert transcription_client.requests == []
 
 

--- a/tests/unit_test/serve/test_transcription_chunking.py
+++ b/tests/unit_test/serve/test_transcription_chunking.py
@@ -79,10 +79,10 @@ def test_qwen3_asr_pipeline_declares_chunking() -> None:
 
     declared = Qwen3ASRPipelineConfig.audio_chunking
     assert declared.allow_audio_chunking is True
-    assert declared.max_audio_clip_s == 1200.0
+    assert declared.max_audio_clip_s == 60.0
     assert declared.max_native_clip_s == 1200.0
-    assert needs_chunking(1200.0, declared) is False
-    assert needs_chunking(1200.001, declared) is True
+    assert needs_chunking(60.0, declared) is False
+    assert needs_chunking(60.001, declared) is True
     config = Qwen3ASRPipelineConfig(model_path="test")
     assert config.stages[0].factory_args["max_new_tokens"] == 4096
 

--- a/tests/unit_test/serve/test_transcription_chunking.py
+++ b/tests/unit_test/serve/test_transcription_chunking.py
@@ -79,13 +79,12 @@ def test_qwen3_asr_pipeline_declares_chunking() -> None:
 
     declared = Qwen3ASRPipelineConfig.audio_chunking
     assert declared.allow_audio_chunking is True
-    # 60s is a scheduling choice, not a context limit (the context is sized
-    # for the model's native 1,200s): short chunks batch well and keep one
-    # long upload from monopolizing the engine.
-    assert declared.max_audio_clip_s == 60.0
-    # The native limit feeds the streaming path, which cannot chunk and so
-    # accepts single requests up to what the engine context fits.
+    assert declared.max_audio_clip_s == 1200.0
     assert declared.max_native_clip_s == 1200.0
+    assert needs_chunking(1200.0, declared) is False
+    assert needs_chunking(1200.001, declared) is True
+    config = Qwen3ASRPipelineConfig(model_path="test")
+    assert config.stages[0].factory_args["max_new_tokens"] == 4096
 
 
 def test_disabled_config_never_chunks() -> None:
@@ -228,6 +227,15 @@ def test_split_is_deterministic() -> None:
     second = splitter.split(waveform, _SAMPLE_RATE, _SAMPLE_RATE)
 
     assert first == second
+
+
+def test_equal_energy_prefers_the_latest_window() -> None:
+    waveform = _silence(2 * _SAMPLE_RATE)
+    splitter = RMSSplitter(search_window_s=0.25)
+
+    spans = splitter.split(waveform, _SAMPLE_RATE, _SAMPLE_RATE)
+
+    assert spans[0][1] == 14_400
 
 
 def test_search_window_wider_than_the_clip_still_advances() -> None:
@@ -435,34 +443,25 @@ def test_plan_resamples_to_the_target_rate() -> None:
 @pytest.mark.parametrize(
     "parts, expected",
     [
-        # Spaced scripts get one space at the seam.
-        (["hello", "world"], "hello world"),
-        # CJK joins directly; a space here would be a CER insertion error.
+        (["hello", "world"], "helloworld"),
+        (["hello ", "world"], "hello world"),
         (["我们今天讨论的是", "长音频的切分"], "我们今天讨论的是长音频的切分"),
-        # Mixed seam: CJK on either side means no space.
         (["...的是", "OpenAI 的方案"], "...的是OpenAI 的方案"),
         (["the next is", "中文内容"], "the next is中文内容"),
-        # Full-width punctuation counts as CJK; half-width does not.
         (["转写结束。", "下面继续"], "转写结束。下面继续"),
-        (["that is done.", "The next part"], "that is done. The next part"),
-        # Digits behave like spaced script.
-        (["chapter 1", "2 comes after"], "chapter 1 2 comes after"),
-        # Korean is wide in east_asian_width terms but its orthography DOES
-        # separate words with spaces -- a seam must not glue two words.
-        (["안녕하세요", "만나서 반갑습니다"], "안녕하세요 만나서 반갑습니다"),
-        # Thai is narrow but writes without word spaces -- a seam must not
-        # invent one.
+        (["that is done.", "The next part"], "that is done.The next part"),
+        (["chapter 1", "2 comes after"], "chapter 12 comes after"),
+        (["안녕하세요", "만나서 반갑습니다"], "안녕하세요만나서 반갑습니다"),
         (["สวัสดีครับ", "ผมชื่อมาก"], "สวัสดีครับผมชื่อมาก"),
-        # Whitespace inside parts is stripped so the rule owns the seam.
-        (["  hello  ", "  world  "], "hello world"),
-        # Empty / all-whitespace parts (an all-silence chunk) are skipped.
-        (["hello", "   ", "world"], "hello world"),
-        (["hello", "", "world"], "hello world"),
-        (["  only one  "], "only one"),
+        (["  hello  ", "  world  "], "  hello    world  "),
+        (["hello", "   ", "world"], "hello   world"),
+        (["hello", "", "world"], "helloworld"),
+        (["  only one  "], "  only one  "),
         ([], ""),
     ],
     ids=[
-        "english",
+        "english-no-model-space",
+        "english-model-space",
         "chinese",
         "cjk-then-latin",
         "latin-then-cjk",


### PR DESCRIPTION
## Motivation
> [!NOTE]
> This PR is stacked on #1347 and aligns its implementation with the clarified F1 behavior in the [August 5, 2026 issue note](https://github.com/sgl-project/sglang-omni/issues/1267#issuecomment-5186019514). We should merge this PR onto #1347 before landing #1347 onto main.

Qwen3-ASR serving distinguishes the operational chunk size from the model's native single-request limit and the endpoint's total-upload limit:

```text
max_audio_clip_s = 60.0
max_native_clip_s = 1200.0
max_total_audio_s = 3600.0  # inherited default
```

- `stream=false`: audio longer than 60 seconds is automatically chunked; the complete upload may be up to 3,600 seconds by default.
- `stream=true`: uses `max_native_clip_s`, accepts one native request up to 1,200 seconds, and does not chunk; longer input is rejected.
- If `max_native_clip_s` is unset for another model, the streaming limit falls back to `max_audio_clip_s`.

Therefore, 1,200–3,600-second uploads are allowed only for `stream=false`, where they are split into operational chunks. They are not accepted as one native request.

#1350 was my original implementation and validated a 1,201-second upload on a Vast.ai RTX 6000 Ada 48GB. That run used the earlier 1,200-second chunk policy. After reconciling the review feedback on #1347 and #1350, this stacked PR retains #1347's conservative 60-second non-streaming operational chunk size while preserving the separate 1,200-second native limit.

## Modifications

- retain the 60-second operational chunk size for non-streaming requests while preserving the model-owned 1,200-second native limit
- retain the 4,096-token engine capacity from Qwen3-ASR's [official vLLM wrapper](https://github.com/QwenLM/Qwen3-ASR/blob/main/README.md), while deriving each unspecified request's admission budget from decoded audio duration:
  ```text
  Engine capacity:
  C = 4096

  Per-request default:
  B = min(C, max(128, ceil(audio_duration_s × 10)))
  ```
- decode uploads when metadata duration is unavailable, while preserving the original bytes for short audio and enforcing the decoded total-duration limit
- concatenate chunk transcripts exactly as returned by the model
- avoid presenting service chunk boundaries as model-derived timestamps in `verbose_json`

The existing blocking concurrency and total-duration policies from #1347 are intentionally left unchanged so this remains a focused F1 correctness patch. Chunk-aware transcription streaming and GPU-capacity-aware scheduling policies are deferred to follow-ups based on #1347.

## Test Plan

- `685 passed` across the Qwen3-ASR unit suite and affected transcription serving tests
- all pre-commit hooks passed on the changed files

