### PR TITLE
[Model] dots.tts: serve the SOAR checkpoint on the single-request solver

### DIFF
--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -29,7 +29,7 @@ uv pip install --no-deps qwen-tts==0.1.1
 | [Qwen3-TTS VoiceDesign](../cookbook/qwen3_tts.md) | `examples/configs/qwen3_tts_1_7b_voicedesign.yaml` | Requires `task_type="VoiceDesign"` and non-empty `instructions`. No reference audio is required |
 | [Ming-Omni-TTS](../cookbook/ming_tts.md) | `examples/configs/ming_omni_tts.yaml` | Text-only synthesis or one local reference clip with its transcript; TP1 is supported and the provided config uses TP2 |
 | [MOSS-TTS](../cookbook/moss_tts.md) | `examples/configs/moss_tts.yaml` | Voice cloning via `ref_audio` or `references[0].audio_path` (+ `text`). Duration via `${token:N}` or `token_count`. Benchmark at `--max-concurrency 8` |
-| [dots.tts](https://github.com/studio-dots-ai/dots.tts) | `examples/configs/dots_tts.yaml` | 48 kHz continuous-latent TTS with reference audio and continuous batching (`max_running_requests=16` by default). The MF batch path uses engine-wide `num_steps=4` and Euler, and requires `ref_audio` + `ref_text`. TP1 only |
+| [dots.tts](https://github.com/studio-dots-ai/dots.tts) | `examples/configs/dots_tts.yaml` (MeanFlow), `examples/configs/dots_tts_soar.yaml` (SOAR) | 48 kHz continuous-latent TTS with reference audio. MeanFlow (`dots.tts-mf`) uses continuous batching (`max_running_requests=16` by default) with engine-wide `num_steps=4` and Euler. SOAR (`dots.tts-soar`) is flow matching and runs the single-request solver with CFG at `max_running_requests=1`. Both require `ref_audio` + `ref_text`. TP1 only |
 
 ## Launch the Server
 
@@ -129,6 +129,23 @@ sgl-omni serve \
   --allowed-media-domain us.aws.cdn.hf.co \
   --port 8000
 ```
+
+For dots.tts SOAR:
+
+```bash
+sgl-omni serve \
+  --model-path dots-studio/dots.tts-soar \
+  --config examples/configs/dots_tts_soar.yaml \
+  --allowed-media-domain huggingface.co \
+  --allowed-media-domain cas-bridge.xethub.hf.co \
+  --allowed-media-domain us.aws.cdn.hf.co \
+  --port 8000
+```
+
+SOAR is a flow-matching checkpoint, so it runs the single-request solver
+(`max_running_requests=1`) with classifier-free guidance. Continuous batching is
+MeanFlow-only for now. `rednote-hilab/dots.tts-*` is the old org name and redirects to
+`dots-studio/dots.tts-*`; both work as `--model-path`.
 
 For Ming-Omni-TTS on two 80 GB GPUs:
 

--- a/examples/configs/dots_tts_soar.yaml
+++ b/examples/configs/dots_tts_soar.yaml
@@ -1,0 +1,17 @@
+config_cls: DotsTTSPipelineConfig
+model_path: dots-studio/dots.tts-soar
+runtime_overrides:
+  latent_engine:
+    optimize: true
+    # note (luojiaxuan): SOAR is a flow-matching checkpoint, so it runs the
+    # single-request solver (max_running_requests=1) with CFG. num_steps is the
+    # upstream SOAR default; the MeanFlow checkpoint uses 4.
+    num_steps: 10
+    max_generate_length: 500
+    server_args_overrides:
+      mem_fraction_static: 0.20
+      max_running_requests: 1
+      disable_cuda_graph: false
+      cuda_graph_max_bs: 1
+  vocoder:
+    optimize: true

--- a/sglang_omni/models/dots_tts/flow_head.py
+++ b/sglang_omni/models/dots_tts/flow_head.py
@@ -156,7 +156,14 @@ class DotsTTSFlowHead(nn.Module):
         optimize: bool = False,
     ) -> None:
         if self.mode != "meanflow":
-            raise ValueError("dots.tts continuous batching currently requires MeanFlow")
+            # note (luojiaxuan): flow-matching checkpoints (SOAR, base) need the
+            # CFG double branch, which the batched tail does not implement. They
+            # serve on the single-request solver instead.
+            raise ValueError(
+                "dots.tts continuous batching requires a MeanFlow checkpoint; "
+                f"this checkpoint is {self.mode}. Serve it with "
+                "max_running_requests=1 (see examples/configs/dots_tts_soar.yaml)"
+            )
         from sglang_omni.models.dots_tts.tail import (
             DotsTtsAcousticTail,
             DotsTtsTailSpec,

--- a/tests/unit_test/dots_tts/test_flow_head.py
+++ b/tests/unit_test/dots_tts/test_flow_head.py
@@ -368,7 +368,7 @@ def test_flow_matching_checkpoint_runs_the_single_request_solver(tmp_path) -> No
             "rotary_bias": True,
         },
         "vocoder": {"sample_rate": 48000},
-        # SOAR and base ship without a meanflow block.
+        # note (luojiaxuan): SOAR and base ship without a meanflow block.
         "meanflow": None,
     }
     flow = DotsTTSFlowHead(
@@ -384,7 +384,7 @@ def test_flow_matching_checkpoint_runs_the_single_request_solver(tmp_path) -> No
 
     assert flow.mode == "flow_matching"
     assert not flow.is_batched
-    # Single-request serving keeps per-request num_steps and CFG.
+    # note (luojiaxuan): single-request serving keeps per-request num_steps and CFG.
     flow.validate_request(num_steps=10, ode_method="euler")
 
     with pytest.raises(ValueError, match="max_running_requests=1"):

--- a/tests/unit_test/dots_tts/test_flow_head.py
+++ b/tests/unit_test/dots_tts/test_flow_head.py
@@ -343,8 +343,6 @@ def test_validate_request_batched_gates_prompt_and_span_budget() -> None:
     )
 
 
-
-
 def test_flow_matching_checkpoint_runs_the_single_request_solver(tmp_path) -> None:
     torch.save(
         {"mean": torch.zeros(LATENT_DIM), "var": torch.ones(LATENT_DIM)},

--- a/tests/unit_test/dots_tts/test_flow_head.py
+++ b/tests/unit_test/dots_tts/test_flow_head.py
@@ -341,3 +341,73 @@ def test_validate_request_batched_gates_prompt_and_span_budget() -> None:
         prompt_patch_count=0,
         total_span_count=10**6,
     )
+
+
+
+
+def test_flow_matching_checkpoint_runs_the_single_request_solver(tmp_path) -> None:
+    torch.save(
+        {"mean": torch.zeros(LATENT_DIM), "var": torch.ones(LATENT_DIM)},
+        tmp_path / "latent_stats.pt",
+    )
+    config = {
+        "latent_dim": LATENT_DIM,
+        "patch_size": PATCH_SIZE,
+        "PatchEncoder": {
+            "num_layers": 1,
+            "num_heads": 2,
+            "hidden_size": FM_HIDDEN,
+            "ffn_hidden_size": 64,
+            "causal": True,
+        },
+        "DiT": {
+            "num_layers": 2,
+            "num_heads": 2,
+            "hidden_size": FM_HIDDEN,
+            "ffn_hidden_size": 64,
+            "modulation": True,
+            "qk_norm": True,
+            "rotary_bias": True,
+        },
+        "vocoder": {"sample_rate": 48000},
+        # SOAR and base ship without a meanflow block.
+        "meanflow": None,
+    }
+    flow = DotsTTSFlowHead(
+        config,
+        llm_hidden_size=LLM_HIDDEN,
+        latent_stats_path=str(tmp_path / "latent_stats.pt"),
+        optimize=False,
+    )
+    with torch.no_grad():
+        for parameter in flow.parameters():
+            parameter.normal_(0.0, 0.2)
+    flow = flow.eval()
+
+    assert flow.mode == "flow_matching"
+    assert not flow.is_batched
+    # Single-request serving keeps per-request num_steps and CFG.
+    flow.validate_request(num_steps=10, ode_method="euler")
+
+    with pytest.raises(ValueError, match="max_running_requests=1"):
+        flow.init_batched_tail(num_slots=16, nfe=10, max_audio_patches=8)
+
+    state, _ = flow.new_request(
+        max_audio_patch_count=8,
+        prompt_latents=None,
+        speaker_embedding=torch.randn(1, 512),
+        speaker_scale=1.5,
+        rng=None,
+    )
+    flow.append_hidden(state, torch.randn(1, 1, LLM_HIDDEN))
+    step = flow.decode_next(
+        state,
+        hidden_states=torch.randn(1, 1, LLM_HIDDEN),
+        num_steps=2,
+        ode_method="euler",
+        guidance_scale=1.2,
+        eos_threshold=0.8,
+    )
+    assert step.latent_patch.shape == (1, PATCH_SIZE, LATENT_DIM)
+    assert torch.isfinite(step.latent_patch).all()
+    assert torch.isfinite(step.feedback_embedding).all()


### PR DESCRIPTION
## Motivation

dots.tts ships three checkpoints. Only `dots.tts-mf` is usable today: serving `dots.tts-soar` fails at startup because the pipeline always builds the batched acoustic tail, which raises `dots.tts continuous batching currently requires MeanFlow`. SOAR is the higher-quality checkpoint upstream, so it is worth serving even before the batched tail learns flow matching.

This is the "dots.tts SOAR checkpoint" item in #1367.

## Modifications

The single-request solver already handles flow matching: `DiTSolver(meanflow=False)` runs the CFG double branch, and `DotsTTSFlowHead` already threads `fm_cfg_sequence`, `fm_null_g_cond`, and `guidance_scale` through it. What was missing was a way to reach that path.

- Add `examples/configs/dots_tts_soar.yaml`: `max_running_requests=1` (single-request solver), `num_steps=10` (upstream SOAR default; MeanFlow uses 4), compiled tail and vocoder, backbone decode CUDA graph.
- Make the batched-tail rejection actionable: it now names the checkpoint mode and points at the SOAR config instead of only stating the MeanFlow requirement.
- Add a unit test covering a flow-matching (`meanflow: null`) checkpoint: mode detection, `init_batched_tail` rejection, per-request `num_steps`, and a finite single-request decode step.
- Document both checkpoints in `docs/basic_usage/tts.md`.

Batched (concurrency > 1) SOAR serving still needs the CFG double branch in the batched tail and stays open in #1367.

Note on repo IDs: `rednote-hilab/dots.tts-*` is the old org name and HTTP-redirects to `dots-studio/dots.tts-*`. Both resolve through `huggingface_hub`, so either works as `--model-path`; the configs use the canonical `dots-studio` IDs.

## Accuracy

Seed-TTS-Eval EN, first 100 samples, seed 42, `dots-studio/dots.tts-soar` served with the new config (`num_steps=10`, `max_running_requests=1`, CFG `guidance_scale=1.2`), 1× H200. WER from `Qwen/Qwen3-ASR-1.7B`:

| Metric | SOAR |
|---|---:|
| Completed / failed | 100 / 0 |
| Corpus WER | **1.09%** |
| Per-sample WER mean | 1.12% |
| Samples above 50% WER | 0 |
| Latency mean | 1.451 s |
| RTF mean | 0.3895 |
| Audio duration mean | 3.819 s |

For reference, `dots.tts-mf` on the same host at `max_running_requests=1` measures RTF 0.1881 / corpus WER 1.24% over the full 1,088-sample set. SOAR is roughly 2× the per-request cost, which is expected: `num_steps=10` instead of 4, and flow matching runs the CFG double branch while MeanFlow does not.

## Validation

- `python -m pytest -q tests/unit_test/dots_tts` — 45 passed, 1 skipped
- Live H200 serve + generate on `dots-studio/dots.tts-soar` with the new config, WER measured with `Qwen/Qwen3-ASR-1.7B`.

## Related

- Roadmap #1367; model support #1349.

## Checklist

- [x] Format code with repository hooks.
- [x] Add unit tests.
- [x] Update documentation and example configuration.
