### PR TITLE
[ASR Refactor] Extract shared speech-to-text serving helpers

### DIFF
--- a/sglang_omni/serve/speech_to_text.py
+++ b/sglang_omni/serve/speech_to_text.py
@@ -49,7 +49,7 @@ DEFAULT_STREAMING_RESPONSE_FORMATS = frozenset({"json", "text"})
 
 @dataclass(frozen=True, slots=True)
 class SpeechToTextForm:
-    """Parsed multipart fields shared by speech-to-text endpoints."""
+    """Separate shared form parsing from endpoint-specific policy."""
 
     file: UploadFile
     model: str | None
@@ -71,7 +71,6 @@ async def parse_speech_to_text_form(
     max_new_tokens: int | None = Form(default=None, ge=1),
     stream: bool = Form(default=False),
 ) -> SpeechToTextForm:
-    """Let FastAPI parse the common multipart speech-to-text form."""
     return SpeechToTextForm(
         file=file,
         model=model,
@@ -85,7 +84,7 @@ async def parse_speech_to_text_form(
 
 
 async def read_and_validate_speech_to_text_audio(file: UploadFile) -> bytes:
-    """Read an upload and preserve the endpoint's empty-file error."""
+    """Reject empty uploads before dispatch can consume backend resources."""
     audio_bytes = await file.read()
     if not audio_bytes:
         raise HTTPException(status_code=400, detail="Uploaded audio file is empty")
@@ -100,7 +99,7 @@ def validate_speech_to_text_response_format(
     response_formats: Collection[str] = DEFAULT_RESPONSE_FORMATS,
     streaming_response_formats: Collection[str] = DEFAULT_STREAMING_RESPONSE_FORMATS,
 ) -> str:
-    """Normalize and validate a response format for a speech-to-text route."""
+    """Keep format errors endpoint-specific without duplicating validation."""
     normalized_response_format = response_format.strip().lower()
     if stream and normalized_response_format not in streaming_response_formats:
         raise HTTPException(
@@ -120,7 +119,7 @@ def validate_speech_to_text_response_format(
     return normalized_response_format
 
 
-def build_transcription_generate_request(
+def build_speech_to_text_generate_request(
     *,
     audio_bytes: bytes,
     filename: str | None,
@@ -133,7 +132,7 @@ def build_transcription_generate_request(
     stream: bool = False,
     task: str = "transcribe",
 ) -> GenerateRequest:
-    """Build the model-neutral generation request for a speech-to-text job."""
+    """Keep endpoint policy out of model-neutral request construction."""
     params: dict[str, Any] = {"task": task}
     metadata: dict[str, Any] = {"task": "asr"}
     explicit_fields: list[str] = []
@@ -166,6 +165,11 @@ def build_transcription_generate_request(
     )
 
 
+# note (Junnan Li): Keep the old name while stacked callers migrate to the
+# endpoint-neutral shared API.
+build_transcription_generate_request = build_speech_to_text_generate_request
+
+
 async def complete_speech_to_text_request(
     client: Client,
     gen_req: GenerateRequest,
@@ -173,7 +177,7 @@ async def complete_speech_to_text_request(
     request_id: str,
     error_log_message: str,
 ) -> CompletionResult:
-    """Dispatch one speech-to-text request and preserve HTTP error mapping."""
+    """Keep sibling endpoints on the same backend-to-HTTP error mapping."""
     try:
         return await client.completion(gen_req, request_id=request_id)
     except ClientError as exc:
@@ -190,12 +194,11 @@ async def complete_speech_to_text_request(
 def resolve_speech_to_text_adapter(
     architectures: list[str] | None,
 ) -> TranscriptionAdapter:
-    """Resolve model output semantics at the shared serving boundary."""
     return resolve_adapter(architectures)
 
 
 def probe_audio_duration(audio_bytes: bytes) -> float:
-    """Best-effort duration in seconds using metadata without a full decode."""
+    """Avoid a full decode; unknown duration is valid for response formatting."""
     try:
         import soundfile as sf
 
@@ -217,7 +220,7 @@ def assemble_speech_to_text_response(
     audio_bytes: bytes,
     architectures: list[str] | None,
 ) -> Response:
-    """Serialize text/json/verbose_json without owning endpoint semantics."""
+    """Keep response schemas consistent across sibling endpoints."""
     normalized_response_format = validate_speech_to_text_response_format(
         response_format,
         stream=False,
@@ -288,7 +291,8 @@ async def _first_speech_to_text_chunk(
     chunk_stream: AsyncIterator[GenerateChunk],
     request_id: str,
 ) -> GenerateChunk | None:
-    """Wait for the first stream chunk while watching for disconnect."""
+    # note (Junnan Li): Admit before headers so model validation remains an
+    # HTTP error instead of becoming an SSE error event.
     disconnect_task = asyncio.create_task(_wait_for_request_disconnect(request))
     first_chunk_task = asyncio.create_task(anext(chunk_stream))
     try:
@@ -320,7 +324,7 @@ async def speech_to_text_stream(
     duration_s: float,
     operation_name: str = "transcription",
 ) -> AsyncIterator[str]:
-    """Emit speech-to-text deltas, one done event, then the SSE sentinel."""
+    """Keep terminal event ordering stable for OpenAI-compatible clients."""
     final_text: str | None = None
 
     def _event_for(chunk: GenerateChunk) -> str | None:
@@ -371,7 +375,7 @@ async def create_speech_to_text_streaming_response(
     architectures: list[str] | None,
     operation_name: str = "transcription",
 ) -> Response:
-    """Own first-chunk admission and the complete SSE response lifecycle."""
+    """Delay headers until backend admission can still return an HTTP error."""
     adapter = resolve_speech_to_text_adapter(architectures)
     duration_s = probe_audio_duration(audio_bytes)
     chunk_stream = client.generate(gen_req, request_id=request_id)

--- a/sglang_omni/serve/speech_to_text.py
+++ b/sglang_omni/serve/speech_to_text.py
@@ -1,0 +1,408 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared mechanics for OpenAI-compatible speech-to-text endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import logging
+import math
+from collections.abc import AsyncIterator, Collection
+from contextlib import aclosing
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import File, Form, HTTPException, Request, UploadFile
+from fastapi.responses import JSONResponse, PlainTextResponse, Response
+
+from sglang_omni.client import (
+    Client,
+    ClientError,
+    CompletionResult,
+    GenerateChunk,
+    GenerateRequest,
+    SamplingParams,
+)
+from sglang_omni.serve.generation_params import record_explicit_generation_params
+from sglang_omni.serve.openai_errors import is_bad_request_error
+from sglang_omni.serve.protocol import (
+    TranscriptionResponse,
+    TranscriptionTextDeltaEvent,
+    TranscriptionTextDoneEvent,
+    TranscriptionUsage,
+)
+from sglang_omni.serve.streaming import (
+    STREAM_DONE_SENTINEL,
+    ClosableStreamingResponse,
+    close_async_iterator_if_supported,
+)
+from sglang_omni.serve.transcription_adapters import resolve_adapter
+from sglang_omni.serve.transcription_adapters.base import TranscriptionAdapter
+
+logger = logging.getLogger(__name__)
+HTTP_DISCONNECT_POLL_INTERVAL_S = 0.05
+HTTP_DISCONNECT_CANCEL_TIMEOUT_S = 0.1
+DEFAULT_RESPONSE_FORMATS = frozenset({"json", "text", "verbose_json"})
+DEFAULT_STREAMING_RESPONSE_FORMATS = frozenset({"json", "text"})
+
+
+@dataclass(frozen=True, slots=True)
+class SpeechToTextForm:
+    """Parsed multipart fields shared by speech-to-text endpoints."""
+
+    file: UploadFile
+    model: str | None
+    language: str | None
+    prompt: str | None
+    response_format: str
+    temperature: float | None
+    max_new_tokens: int | None
+    stream: bool
+
+
+async def parse_speech_to_text_form(
+    file: UploadFile = File(...),
+    model: str | None = Form(default=None),
+    language: str | None = Form(default=None),
+    prompt: str | None = Form(default=None),
+    response_format: str = Form(default="json"),
+    temperature: float | None = Form(default=None),
+    max_new_tokens: int | None = Form(default=None, ge=1),
+    stream: bool = Form(default=False),
+) -> SpeechToTextForm:
+    """Let FastAPI parse the common multipart speech-to-text form."""
+    return SpeechToTextForm(
+        file=file,
+        model=model,
+        language=language,
+        prompt=prompt,
+        response_format=response_format,
+        temperature=temperature,
+        max_new_tokens=max_new_tokens,
+        stream=stream,
+    )
+
+
+async def read_and_validate_speech_to_text_audio(file: UploadFile) -> bytes:
+    """Read an upload and preserve the endpoint's empty-file error."""
+    audio_bytes = await file.read()
+    if not audio_bytes:
+        raise HTTPException(status_code=400, detail="Uploaded audio file is empty")
+    return audio_bytes
+
+
+def validate_speech_to_text_response_format(
+    response_format: str,
+    *,
+    stream: bool,
+    endpoint_path: str,
+    response_formats: Collection[str] = DEFAULT_RESPONSE_FORMATS,
+    streaming_response_formats: Collection[str] = DEFAULT_STREAMING_RESPONSE_FORMATS,
+) -> str:
+    """Normalize and validate a response format for a speech-to-text route."""
+    normalized_response_format = response_format.strip().lower()
+    if stream and normalized_response_format not in streaming_response_formats:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "stream=true supports only response_format 'json' or "
+                f"'text', got {response_format!r}"
+            ),
+        )
+    if not stream and normalized_response_format not in response_formats:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unsupported response_format for {endpoint_path}: {response_format!r}"
+            ),
+        )
+    return normalized_response_format
+
+
+def build_transcription_generate_request(
+    *,
+    audio_bytes: bytes,
+    filename: str | None,
+    content_type: str | None,
+    model: str,
+    language: str | None,
+    prompt: str | None,
+    temperature: float | None,
+    max_new_tokens: int | None = None,
+    stream: bool = False,
+    task: str = "transcribe",
+) -> GenerateRequest:
+    """Build the model-neutral generation request for a speech-to-text job."""
+    params: dict[str, Any] = {"task": task}
+    metadata: dict[str, Any] = {"task": "asr"}
+    explicit_fields: list[str] = []
+    if language is not None:
+        params["language"] = language
+    if prompt is not None:
+        params["prompt"] = prompt
+    if temperature is not None:
+        explicit_fields.append("temperature")
+    if max_new_tokens is not None:
+        explicit_fields.append("max_new_tokens")
+    record_explicit_generation_params(metadata, sorted(explicit_fields))
+    sampling = SamplingParams(
+        temperature=temperature if temperature is not None else 0.0,
+        max_new_tokens=max_new_tokens,
+    )
+
+    return GenerateRequest(
+        model=model,
+        prompt={
+            "audio_bytes": audio_bytes,
+            "filename": filename,
+            "content_type": content_type,
+        },
+        sampling=sampling,
+        extra_params=params,
+        stream=stream,
+        output_modalities=["text"],
+        metadata=metadata,
+    )
+
+
+async def complete_speech_to_text_request(
+    client: Client,
+    gen_req: GenerateRequest,
+    *,
+    request_id: str,
+    error_log_message: str,
+) -> CompletionResult:
+    """Dispatch one speech-to-text request and preserve HTTP error mapping."""
+    try:
+        return await client.completion(gen_req, request_id=request_id)
+    except ClientError as exc:
+        if is_bad_request_error(exc):
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except Exception as exc:
+        if is_bad_request_error(exc):
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        logger.exception(error_log_message, request_id)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+def resolve_speech_to_text_adapter(
+    architectures: list[str] | None,
+) -> TranscriptionAdapter:
+    """Resolve model output semantics at the shared serving boundary."""
+    return resolve_adapter(architectures)
+
+
+def probe_audio_duration(audio_bytes: bytes) -> float:
+    """Best-effort duration in seconds using metadata without a full decode."""
+    try:
+        import soundfile as sf
+
+        info = sf.info(io.BytesIO(audio_bytes))
+        if info.samplerate:
+            return max(info.frames / float(info.samplerate), 0.0)
+    except (RuntimeError, ValueError):
+        logger.debug("Could not probe audio duration", exc_info=True)
+    return 0.0
+
+
+def assemble_speech_to_text_response(
+    *,
+    text: str,
+    response_format: str,
+    endpoint_path: str,
+    task: str,
+    language: str | None,
+    audio_bytes: bytes,
+    architectures: list[str] | None,
+) -> Response:
+    """Serialize text/json/verbose_json without owning endpoint semantics."""
+    normalized_response_format = validate_speech_to_text_response_format(
+        response_format,
+        stream=False,
+        endpoint_path=endpoint_path,
+    )
+    if normalized_response_format == "text":
+        return PlainTextResponse(text)
+
+    adapter = resolve_speech_to_text_adapter(architectures)
+    text = adapter.postprocess_text(text)
+    duration_s = probe_audio_duration(audio_bytes)
+    usage = (
+        TranscriptionUsage(seconds=math.ceil(duration_s)) if duration_s > 0 else None
+    )
+    if normalized_response_format == "verbose_json":
+        response = adapter.build_verbose_response(
+            text=text,
+            language=language,
+            audio_duration_s=duration_s,
+        )
+        response.task = task
+        response.usage = usage
+        return JSONResponse(content=response.model_dump(exclude_none=True))
+    return JSONResponse(
+        content=TranscriptionResponse(text=text, usage=usage).model_dump(
+            exclude_none=True
+        )
+    )
+
+
+async def _cancel_task_bounded(task: asyncio.Task[Any]) -> None:
+    task.cancel()
+    done, _ = await asyncio.wait({task}, timeout=HTTP_DISCONNECT_CANCEL_TIMEOUT_S)
+    if done:
+        await asyncio.gather(*done, return_exceptions=True)
+    else:
+        task.add_done_callback(_discard_cancelled_task_result)
+
+
+def _discard_cancelled_task_result(task: asyncio.Task[Any]) -> None:
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        logger.debug("Cancelled request task finished with an error", exc_info=True)
+
+
+async def _wait_for_request_disconnect(request: Request) -> None:
+    while not await request.is_disconnected():
+        await asyncio.sleep(HTTP_DISCONNECT_POLL_INTERVAL_S)
+
+
+async def _abort_and_close_speech_to_text_stream(
+    client: Client,
+    request_id: str,
+    stream: AsyncIterator[Any],
+) -> None:
+    try:
+        await client.abort(request_id)
+    finally:
+        await close_async_iterator_if_supported(stream)
+
+
+async def _first_speech_to_text_chunk(
+    request: Request,
+    client: Client,
+    chunk_stream: AsyncIterator[GenerateChunk],
+    request_id: str,
+) -> GenerateChunk | None:
+    """Wait for the first stream chunk while watching for disconnect."""
+    disconnect_task = asyncio.create_task(_wait_for_request_disconnect(request))
+    first_chunk_task = asyncio.create_task(anext(chunk_stream))
+    try:
+        done, _ = await asyncio.wait(
+            {first_chunk_task, disconnect_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if disconnect_task in done:
+            await _cancel_task_bounded(first_chunk_task)
+            await _abort_and_close_speech_to_text_stream(
+                client, request_id, chunk_stream
+            )
+            raise asyncio.CancelledError
+        try:
+            return first_chunk_task.result()
+        except StopAsyncIteration:
+            return None
+    finally:
+        if not disconnect_task.done():
+            await _cancel_task_bounded(disconnect_task)
+
+
+async def speech_to_text_stream(
+    chunk_stream: AsyncIterator[GenerateChunk],
+    *,
+    first_chunk: GenerateChunk | None,
+    request_id: str,
+    adapter: TranscriptionAdapter,
+    duration_s: float,
+    operation_name: str = "transcription",
+) -> AsyncIterator[str]:
+    """Emit speech-to-text deltas, one done event, then the SSE sentinel."""
+    final_text: str | None = None
+
+    def _event_for(chunk: GenerateChunk) -> str | None:
+        nonlocal final_text
+        if chunk.finish_reason is not None:
+            if isinstance(chunk.text, str) and chunk.text:
+                final_text = chunk.text
+            return None
+        if chunk.modality == "text" and chunk.text:
+            event = TranscriptionTextDeltaEvent(delta=chunk.text)
+            return f"data: {event.model_dump_json(exclude_none=True)}\n\n"
+        return None
+
+    try:
+        async with aclosing(chunk_stream):
+            if first_chunk is not None:
+                line = _event_for(first_chunk)
+                if line is not None:
+                    yield line
+            async for chunk in chunk_stream:
+                line = _event_for(chunk)
+                if line is not None:
+                    yield line
+    except Exception as exc:
+        logger.exception(
+            "Error streaming %s for request %s", operation_name, request_id
+        )
+        payload = {"type": "error", "error": {"message": str(exc)}}
+        yield f"data: {json.dumps(payload)}\n\n"
+        return
+
+    text = adapter.postprocess_text(final_text or "")
+    usage = (
+        TranscriptionUsage(seconds=math.ceil(duration_s)) if duration_s > 0 else None
+    )
+    done_event = TranscriptionTextDoneEvent(text=text, usage=usage)
+    yield f"data: {done_event.model_dump_json(exclude_none=True)}\n\n"
+    yield f"data: {STREAM_DONE_SENTINEL}\n\n"
+
+
+async def create_speech_to_text_streaming_response(
+    *,
+    request: Request,
+    client: Client,
+    gen_req: GenerateRequest,
+    request_id: str,
+    audio_bytes: bytes,
+    architectures: list[str] | None,
+    operation_name: str = "transcription",
+) -> Response:
+    """Own first-chunk admission and the complete SSE response lifecycle."""
+    adapter = resolve_speech_to_text_adapter(architectures)
+    duration_s = probe_audio_duration(audio_bytes)
+    chunk_stream = client.generate(gen_req, request_id=request_id)
+    try:
+        first_chunk = await _first_speech_to_text_chunk(
+            request, client, chunk_stream, request_id
+        )
+    except ClientError as exc:
+        await close_async_iterator_if_supported(chunk_stream)
+        if is_bad_request_error(exc):
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except Exception as exc:
+        await close_async_iterator_if_supported(chunk_stream)
+        if is_bad_request_error(exc):
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        logger.exception(
+            "Error starting %s stream for request %s",
+            operation_name,
+            request_id,
+        )
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return ClosableStreamingResponse(
+        speech_to_text_stream(
+            chunk_stream,
+            first_chunk=first_chunk,
+            request_id=request_id,
+            adapter=adapter,
+            duration_s=duration_s,
+            operation_name=operation_name,
+        ),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Request-Id": request_id},
+    )

--- a/sglang_omni/serve/transcriptions.py
+++ b/sglang_omni/serve/transcriptions.py
@@ -16,7 +16,7 @@ TRANSCRIPTIONS_ENDPOINT = "/v1/audio/transcriptions"
 _first_transcription_chunk = speech_to_text._first_speech_to_text_chunk
 _transcription_stream = speech_to_text.speech_to_text_stream
 build_transcription_generate_request = (
-    speech_to_text.build_transcription_generate_request
+    speech_to_text.build_speech_to_text_generate_request
 )
 
 __all__ = [
@@ -51,7 +51,7 @@ def register_transcriptions(app: FastAPI) -> None:
                 stream=True,
                 endpoint_path=TRANSCRIPTIONS_ENDPOINT,
             )
-            gen_req = build_transcription_generate_request(
+            gen_req = speech_to_text.build_speech_to_text_generate_request(
                 audio_bytes=audio_bytes,
                 filename=form.file.filename,
                 content_type=form.file.content_type,
@@ -71,7 +71,7 @@ def register_transcriptions(app: FastAPI) -> None:
                 architectures=getattr(app.state, "architectures", None),
             )
 
-        gen_req = build_transcription_generate_request(
+        gen_req = speech_to_text.build_speech_to_text_generate_request(
             audio_bytes=audio_bytes,
             filename=form.file.filename,
             content_type=form.file.content_type,

--- a/sglang_omni/serve/transcriptions.py
+++ b/sglang_omni/serve/transcriptions.py
@@ -1,123 +1,39 @@
 # SPDX-License-Identifier: Apache-2.0
-"""OpenAI-compatible audio transcription route and request helpers."""
+"""OpenAI-compatible audio transcription endpoint."""
 
 from __future__ import annotations
 
-import asyncio
-import io
-import json
-import logging
-import math
 import uuid
-from collections.abc import AsyncIterator
-from contextlib import aclosing
-from typing import Any
 
-from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
-from fastapi.responses import JSONResponse, PlainTextResponse, Response
+from fastapi import Depends, FastAPI, Request
+from fastapi.responses import Response
 
-from sglang_omni.client import (
-    Client,
-    ClientError,
-    GenerateChunk,
-    GenerateRequest,
-    SamplingParams,
+from sglang_omni.client import Client
+from sglang_omni.serve import speech_to_text
+
+TRANSCRIPTIONS_ENDPOINT = "/v1/audio/transcriptions"
+
+_first_transcription_chunk = speech_to_text._first_speech_to_text_chunk
+_transcription_stream = speech_to_text.speech_to_text_stream
+build_transcription_generate_request = (
+    speech_to_text.build_transcription_generate_request
 )
-from sglang_omni.serve.generation_params import record_explicit_generation_params
-from sglang_omni.serve.openai_errors import is_bad_request_error
-from sglang_omni.serve.protocol import (
-    TranscriptionResponse,
-    TranscriptionTextDeltaEvent,
-    TranscriptionTextDoneEvent,
-    TranscriptionUsage,
-)
-from sglang_omni.serve.streaming import (
-    STREAM_DONE_SENTINEL,
-    ClosableStreamingResponse,
-    close_async_iterator_if_supported,
-)
-from sglang_omni.serve.transcription_adapters import resolve_adapter
 
-logger = logging.getLogger(__name__)
-HTTP_DISCONNECT_POLL_INTERVAL_S = 0.05
-HTTP_DISCONNECT_CANCEL_TIMEOUT_S = 0.1
-
-
-async def _cancel_task_bounded(task: asyncio.Task[Any]) -> None:
-    task.cancel()
-    done, _ = await asyncio.wait({task}, timeout=HTTP_DISCONNECT_CANCEL_TIMEOUT_S)
-    if done:
-        await asyncio.gather(*done, return_exceptions=True)
-    else:
-        task.add_done_callback(_discard_cancelled_task_result)
-
-
-def _discard_cancelled_task_result(task: asyncio.Task[Any]) -> None:
-    try:
-        task.result()
-    except asyncio.CancelledError:
-        pass
-    except Exception:
-        logger.debug("Cancelled request task finished with an error", exc_info=True)
-
-
-async def _wait_for_request_disconnect(request: Request) -> None:
-    while not await request.is_disconnected():
-        await asyncio.sleep(HTTP_DISCONNECT_POLL_INTERVAL_S)
-
-
-async def _abort_and_close_transcription_stream(
-    client: Client,
-    request_id: str,
-    stream: AsyncIterator[Any],
-) -> None:
-    try:
-        await client.abort(request_id)
-    finally:
-        await close_async_iterator_if_supported(stream)
-
-
-async def _first_transcription_chunk(
-    request: Request,
-    client: Client,
-    chunk_stream: AsyncIterator[GenerateChunk],
-    request_id: str,
-) -> GenerateChunk | None:
-    """Wait for the first stream chunk while watching for client disconnect."""
-    disconnect_task = asyncio.create_task(_wait_for_request_disconnect(request))
-    first_chunk_task = asyncio.create_task(anext(chunk_stream))
-    try:
-        done, _ = await asyncio.wait(
-            {first_chunk_task, disconnect_task},
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-        if disconnect_task in done:
-            await _cancel_task_bounded(first_chunk_task)
-            await _abort_and_close_transcription_stream(
-                client, request_id, chunk_stream
-            )
-            raise asyncio.CancelledError
-        try:
-            return first_chunk_task.result()
-        except StopAsyncIteration:
-            return None
-    finally:
-        if not disconnect_task.done():
-            await _cancel_task_bounded(disconnect_task)
+__all__ = [
+    "_first_transcription_chunk",
+    "_transcription_stream",
+    "build_transcription_generate_request",
+    "register_transcriptions",
+]
 
 
 def register_transcriptions(app: FastAPI) -> None:
-    @app.post("/v1/audio/transcriptions")
+    @app.post(TRANSCRIPTIONS_ENDPOINT)
     async def create_transcription(
         request: Request,
-        file: UploadFile = File(...),
-        model: str | None = Form(default=None),
-        language: str | None = Form(default=None),
-        prompt: str | None = Form(default=None),
-        response_format: str = Form(default="json"),
-        temperature: float | None = Form(default=None),
-        max_new_tokens: int | None = Form(default=None, ge=1),
-        stream: bool = Form(default=False),
+        form: speech_to_text.SpeechToTextForm = Depends(
+            speech_to_text.parse_speech_to_text_form
+        ),
     ) -> Response:
         client: Client = app.state.client
         default_model: str = app.state.model_name
@@ -125,235 +41,58 @@ def register_transcriptions(app: FastAPI) -> None:
 
         # TODO(Ratish): add the same pre-parser body limit used by voice uploads
         # once transcription upload limits are defined.
-        audio_bytes = await file.read()
-        if not audio_bytes:
-            raise HTTPException(status_code=400, detail="Uploaded audio file is empty")
+        audio_bytes = await speech_to_text.read_and_validate_speech_to_text_audio(
+            form.file
+        )
 
-        normalized_response_format = response_format.strip().lower()
-        if stream:
-            if normalized_response_format not in {"json", "text"}:
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        "stream=true supports only response_format 'json' or "
-                        f"'text', got {response_format!r}"
-                    ),
-                )
+        if form.stream:
+            speech_to_text.validate_speech_to_text_response_format(
+                form.response_format,
+                stream=True,
+                endpoint_path=TRANSCRIPTIONS_ENDPOINT,
+            )
             gen_req = build_transcription_generate_request(
                 audio_bytes=audio_bytes,
-                filename=file.filename,
-                content_type=file.content_type,
-                model=model or default_model,
-                language=language,
-                prompt=prompt,
-                temperature=temperature,
-                max_new_tokens=max_new_tokens,
+                filename=form.file.filename,
+                content_type=form.file.content_type,
+                model=form.model or default_model,
+                language=form.language,
+                prompt=form.prompt,
+                temperature=form.temperature,
+                max_new_tokens=form.max_new_tokens,
                 stream=True,
             )
-            adapter = resolve_adapter(getattr(app.state, "architectures", None))
-            duration_s = _probe_audio_duration(audio_bytes)
-            chunk_stream = client.generate(gen_req, request_id=request_id)
-            # Pull the first chunk before sending response headers so admission
-            # failures map to HTTP statuses rather than SSE error payloads.
-            try:
-                first_chunk = await _first_transcription_chunk(
-                    request, client, chunk_stream, request_id
-                )
-            except ClientError as exc:
-                await close_async_iterator_if_supported(chunk_stream)
-                if is_bad_request_error(exc):
-                    raise HTTPException(status_code=400, detail=str(exc)) from exc
-                raise HTTPException(status_code=500, detail=str(exc)) from exc
-            except Exception as exc:
-                await close_async_iterator_if_supported(chunk_stream)
-                if is_bad_request_error(exc):
-                    raise HTTPException(status_code=400, detail=str(exc)) from exc
-                logger.exception(
-                    "Error starting transcription stream for request %s",
-                    request_id,
-                )
-                raise HTTPException(status_code=500, detail=str(exc)) from exc
-            return ClosableStreamingResponse(
-                _transcription_stream(
-                    chunk_stream,
-                    first_chunk=first_chunk,
-                    request_id=request_id,
-                    adapter=adapter,
-                    duration_s=duration_s,
-                ),
-                media_type="text/event-stream",
-                headers={"Cache-Control": "no-cache", "X-Request-Id": request_id},
+            return await speech_to_text.create_speech_to_text_streaming_response(
+                request=request,
+                client=client,
+                gen_req=gen_req,
+                request_id=request_id,
+                audio_bytes=audio_bytes,
+                architectures=getattr(app.state, "architectures", None),
             )
 
         gen_req = build_transcription_generate_request(
             audio_bytes=audio_bytes,
-            filename=file.filename,
-            content_type=file.content_type,
-            model=model or default_model,
-            language=language,
-            prompt=prompt,
-            temperature=temperature,
-            max_new_tokens=max_new_tokens,
+            filename=form.file.filename,
+            content_type=form.file.content_type,
+            model=form.model or default_model,
+            language=form.language,
+            prompt=form.prompt,
+            temperature=form.temperature,
+            max_new_tokens=form.max_new_tokens,
         )
-
-        try:
-            result = await client.completion(gen_req, request_id=request_id)
-        except ClientError as exc:
-            if is_bad_request_error(exc):
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-        except Exception as exc:
-            if is_bad_request_error(exc):
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
-            logger.exception("Error transcribing audio for request %s", request_id)
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-        text = result.text
-        if normalized_response_format == "text":
-            return PlainTextResponse(text)
-        if normalized_response_format not in {"json", "verbose_json"}:
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    "Unsupported response_format for /v1/audio/transcriptions: "
-                    f"{response_format!r}"
-                ),
-            )
-
-        adapter = resolve_adapter(getattr(app.state, "architectures", None))
-        text = adapter.postprocess_text(text)
-        duration_s = _probe_audio_duration(audio_bytes)
-        usage = (
-            TranscriptionUsage(seconds=math.ceil(duration_s))
-            if duration_s > 0
-            else None
+        result = await speech_to_text.complete_speech_to_text_request(
+            client,
+            gen_req,
+            request_id=request_id,
+            error_log_message="Error transcribing audio for request %s",
         )
-        if normalized_response_format == "verbose_json":
-            response = adapter.build_verbose_response(
-                text=text,
-                language=language,
-                audio_duration_s=duration_s,
-            )
-            response.usage = usage
-            return JSONResponse(content=response.model_dump(exclude_none=True))
-        return JSONResponse(
-            content=TranscriptionResponse(text=text, usage=usage).model_dump(
-                exclude_none=True
-            )
+        return speech_to_text.assemble_speech_to_text_response(
+            text=result.text,
+            response_format=form.response_format,
+            endpoint_path=TRANSCRIPTIONS_ENDPOINT,
+            task="transcribe",
+            language=form.language,
+            audio_bytes=audio_bytes,
+            architectures=getattr(app.state, "architectures", None),
         )
-
-
-async def _transcription_stream(
-    chunk_stream: AsyncIterator[GenerateChunk],
-    *,
-    first_chunk: GenerateChunk | None,
-    request_id: str,
-    adapter: Any,
-    duration_s: float,
-) -> AsyncIterator[str]:
-    """SSE generator for streaming transcriptions.
-
-    Emits OpenAI-style transcript.text.delta events for each partial text
-    chunk, then a terminal transcript.text.done event carrying the full
-    post-processed transcript. The caller already pulled first_chunk from
-    chunk_stream so admission failures map to HTTP statuses before response
-    headers go out.
-    """
-    final_text: str | None = None
-
-    def _event_for(chunk: GenerateChunk) -> str | None:
-        nonlocal final_text
-        if chunk.finish_reason is not None:
-            if isinstance(chunk.text, str) and chunk.text:
-                final_text = chunk.text
-            return None
-        if chunk.modality == "text" and chunk.text:
-            event = TranscriptionTextDeltaEvent(delta=chunk.text)
-            return f"data: {event.model_dump_json(exclude_none=True)}\n\n"
-        return None
-
-    try:
-        async with aclosing(chunk_stream):
-            if first_chunk is not None:
-                line = _event_for(first_chunk)
-                if line is not None:
-                    yield line
-            async for chunk in chunk_stream:
-                line = _event_for(chunk)
-                if line is not None:
-                    yield line
-    except Exception as exc:
-        logger.exception("Error streaming transcription for request %s", request_id)
-        payload = {"type": "error", "error": {"message": str(exc)}}
-        yield f"data: {json.dumps(payload)}\n\n"
-        return
-
-    text = adapter.postprocess_text(final_text or "")
-    usage = (
-        TranscriptionUsage(seconds=math.ceil(duration_s)) if duration_s > 0 else None
-    )
-    done_event = TranscriptionTextDoneEvent(text=text, usage=usage)
-    yield f"data: {done_event.model_dump_json(exclude_none=True)}\n\n"
-    yield f"data: {STREAM_DONE_SENTINEL}\n\n"
-
-
-def _probe_audio_duration(audio_bytes: bytes) -> float:
-    """Best-effort audio duration (seconds) from raw upload bytes.
-
-    Uses ``soundfile.info`` (metadata only, no full decode; torchaudio removed
-    its ``info`` API in 2.x). Returns 0.0 if the duration cannot be
-    determined; callers treat 0.0 as "unknown".
-    """
-    try:
-        import soundfile as sf
-
-        info = sf.info(io.BytesIO(audio_bytes))
-        if info.samplerate:
-            return max(info.frames / float(info.samplerate), 0.0)
-    except (RuntimeError, ValueError):
-        logger.debug("Could not probe audio duration", exc_info=True)
-    return 0.0
-
-
-def build_transcription_generate_request(
-    *,
-    audio_bytes: bytes,
-    filename: str | None,
-    content_type: str | None,
-    model: str,
-    language: str | None,
-    prompt: str | None,
-    temperature: float | None,
-    max_new_tokens: int | None = None,
-    stream: bool = False,
-) -> GenerateRequest:
-    params: dict[str, Any] = {"task": "transcribe"}
-    metadata: dict[str, Any] = {"task": "asr"}
-    explicit_fields: list[str] = []
-    if language is not None:
-        params["language"] = language
-    if prompt is not None:
-        params["prompt"] = prompt
-    if temperature is not None:
-        explicit_fields.append("temperature")
-    if max_new_tokens is not None:
-        explicit_fields.append("max_new_tokens")
-    record_explicit_generation_params(metadata, sorted(explicit_fields))
-    sampling = SamplingParams(
-        temperature=temperature if temperature is not None else 0.0,
-        max_new_tokens=max_new_tokens,
-    )
-
-    return GenerateRequest(
-        model=model,
-        prompt={
-            "audio_bytes": audio_bytes,
-            "filename": filename,
-            "content_type": content_type,
-        },
-        sampling=sampling,
-        extra_params=params,
-        stream=stream,
-        output_modalities=["text"],
-        metadata=metadata,
-    )

--- a/tests/README.md
+++ b/tests/README.md
@@ -138,7 +138,8 @@ tests/
     ├── serve/
     │   ├── test_generation_batch_policy.py
     │   ├── test_generation_server_args.py
-    │   └── test_openai_api.py
+    │   ├── test_openai_api.py
+    │   └── test_speech_to_text.py
     ├── scheduling/
     │   ├── test_engine_factory.py
     │   ├── test_pipeline_state.py
@@ -551,6 +552,7 @@ that happened to contain an older version of the test.
 - `unit_test/serve/`: In-process serving API unit tests:
   - generation-stage SGLang server-args role mapping and CLI override capability boundaries
   - OpenAI-compatible request/response behavior
+  - shared speech-to-text form, request, response-format, and serialization mechanics
   - streaming response framing and failure semantics.
 
 - `unit_test/fishaudio_s2_pro/`: FishAudio S2-Pro unit tests:

--- a/tests/unit_test/serve/test_speech_to_text.py
+++ b/tests/unit_test/serve/test_speech_to_text.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import HTTPException
+
+from sglang_omni.serve.speech_to_text import (
+    assemble_speech_to_text_response,
+    build_transcription_generate_request,
+    validate_speech_to_text_response_format,
+)
+
+
+def _build_request(*, task: str = "transcribe"):
+    return build_transcription_generate_request(
+        audio_bytes=b"RIFF",
+        filename="sample.wav",
+        content_type="audio/wav",
+        model="openai/whisper-large-v3",
+        language="en",
+        prompt=None,
+        temperature=None,
+        task=task,
+    )
+
+
+def test_build_request_defaults_to_transcribe_task() -> None:
+    assert _build_request().extra_params["task"] == "transcribe"
+
+
+def test_build_request_accepts_sibling_endpoint_task() -> None:
+    assert _build_request(task="translate").extra_params["task"] == "translate"
+
+
+def test_response_format_validation_preserves_endpoint_error_contract() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        validate_speech_to_text_response_format(
+            " SRT ",
+            stream=False,
+            endpoint_path="/v1/audio/transcriptions",
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == (
+        "Unsupported response_format for /v1/audio/transcriptions: ' SRT '"
+    )
+
+
+def test_verbose_response_uses_requested_task() -> None:
+    response = assemble_speech_to_text_response(
+        text="hello world",
+        response_format="verbose_json",
+        endpoint_path="/v1/audio/transcriptions",
+        task="translate",
+        language="en",
+        audio_bytes=b"not-a-real-audio-file",
+        architectures=None,
+    )
+
+    assert json.loads(response.body)["task"] == "translate"

--- a/tests/unit_test/serve/test_speech_to_text.py
+++ b/tests/unit_test/serve/test_speech_to_text.py
@@ -7,15 +7,14 @@ import json
 import pytest
 from fastapi import HTTPException
 
-from sglang_omni.serve.speech_to_text import (
-    assemble_speech_to_text_response,
-    build_transcription_generate_request,
-    validate_speech_to_text_response_format,
+from sglang_omni.serve import speech_to_text
+from sglang_omni.serve.transcriptions import (
+    build_transcription_generate_request as legacy_transcription_request_builder,
 )
 
 
 def _build_request(*, task: str = "transcribe"):
-    return build_transcription_generate_request(
+    return speech_to_text.build_speech_to_text_generate_request(
         audio_bytes=b"RIFF",
         filename="sample.wav",
         content_type="audio/wav",
@@ -24,6 +23,14 @@ def _build_request(*, task: str = "transcribe"):
         prompt=None,
         temperature=None,
         task=task,
+    )
+
+
+def test_transcription_builder_import_keeps_shared_callable() -> None:
+    """Keep the pre-extraction import stable while stacked consumers migrate."""
+    assert (
+        legacy_transcription_request_builder
+        is speech_to_text.build_speech_to_text_generate_request
     )
 
 
@@ -37,7 +44,7 @@ def test_build_request_accepts_sibling_endpoint_task() -> None:
 
 def test_response_format_validation_preserves_endpoint_error_contract() -> None:
     with pytest.raises(HTTPException) as exc_info:
-        validate_speech_to_text_response_format(
+        speech_to_text.validate_speech_to_text_response_format(
             " SRT ",
             stream=False,
             endpoint_path="/v1/audio/transcriptions",
@@ -50,7 +57,7 @@ def test_response_format_validation_preserves_endpoint_error_contract() -> None:
 
 
 def test_verbose_response_uses_requested_task() -> None:
-    response = assemble_speech_to_text_response(
+    response = speech_to_text.assemble_speech_to_text_response(
         text="hello world",
         response_format="verbose_json",
         endpoint_path="/v1/audio/transcriptions",


### PR DESCRIPTION
## Motivation

M5 (#1285) consolidated transcription serving into `serve/transcriptions.py`, but the reusable mechanics are still fused with the endpoint's identity, down to a hard-coded `task="transcribe"` in request construction. `/v1/audio/translations` (#1267 F2) needs the same flow with a different task, so this behavior-preserving refactor extracts the mechanics first; the translations endpoint follows as a separate PR built on top.

## Modifications

- `serve/speech_to_text.py` (new): endpoint-neutral form parsing/validation, `build_speech_to_text_generate_request(..., task="transcribe")`, dispatch + error mapping, json/verbose_json/text serializers, SSE lifecycle, adapter resolution, duration probe. Old builder name kept as a compatibility alias.
- `serve/transcriptions.py`: thin endpoint layer; existing import paths re-exported.
- New characterization tests; `tests/README.md` registered.

## Validation

- Existing transcription tests (incl. all TestClient HTTP/SSE paths) pass with zero assertion changes.
- Full unit tree (2,200 tests): failure surface identical to clean main.
- Five-model A6000 acceptance (frozen `b7e77625f` vs `520486a2d`): 35 sequential response bodies byte-identical; warm-latency deltas <10%; concurrency-4 green on 4/5 models. Whisper concurrency-4 fails identically on base and head — pre-existing scheduler defect, tracked separately, deliberately not fixed here.
- ruff / format / isort / `git diff --check` clean.

## Related

#1267 (F2). The `/v1/audio/translations` endpoint follows as a separate PR on top of this seam.
