### PR TITLE
[dots.tts] Fix streaming crash under backbone decode CUDA graphs

### DIFF
--- a/sglang_omni/models/dots_tts/vocoder.py
+++ b/sglang_omni/models/dots_tts/vocoder.py
@@ -144,12 +144,14 @@ class DotsTTSStreamingVocoder(StreamingVocoderBase[_DotsStreamState, None]):
                 else (1 if state.received_patches <= 2 else self.merge_steps)
             )
             patches, state.pending = state.pending[:take], state.pending[take:]
+            # note (db-ol): compiled stream step cudagraph trees corrupt the
+            # backbone decode graph replay in this process, see issue 1392.
             with self.codec.lock:
                 chunk = self.codec.inference.stream_step(
                     torch.cat(patches, dim=1),
                     stream_state=state.codec_state,
                     optimize=self.optimize,
-                    use_compiled=not is_final,
+                    use_compiled=False,
                 )
             if chunk.numel():
                 chunks.append(chunk)

--- a/tests/unit_test/dots_tts/test_vocoder_streaming.py
+++ b/tests/unit_test/dots_tts/test_vocoder_streaming.py
@@ -1,0 +1,55 @@
+import threading
+
+import torch
+
+from sglang_omni.models.dots_tts.vocoder import DotsTTSStreamingVocoder
+
+
+class _RecordingInference:
+    def __init__(self) -> None:
+        self.stream_calls: list[dict] = []
+
+    def init_stream_state(self, *, batch_size: int, chunk_size: int):
+        del batch_size, chunk_size
+        return object()
+
+    def stream_step(self, latents, *, stream_state, optimize, use_compiled, **_):
+        del stream_state
+        self.stream_calls.append(
+            {
+                "frames": int(latents.shape[1]),
+                "optimize": optimize,
+                "use_compiled": use_compiled,
+            }
+        )
+        return torch.zeros(1, 8)
+
+    def flush(self, stream_state):
+        del stream_state
+        return torch.zeros(1, 4)
+
+
+class _FakeCodec:
+    def __init__(self) -> None:
+        self.inference = _RecordingInference()
+        self.lock = threading.Lock()
+        self.sample_rate = 48000
+        self.patch_size = 3
+        self.latent_dim = 5
+        self.device = "cpu"
+
+
+def test_streaming_never_uses_the_compiled_stream_step() -> None:
+    codec = _FakeCodec()
+    vocoder = DotsTTSStreamingVocoder(codec, optimize=True, merge_steps=2)
+    state = vocoder.create_stream_state("req")
+
+    for _ in range(4):
+        vocoder.ingest("req", state, torch.zeros(1, 3, 5))
+        if vocoder.should_decode(state, is_final=False):
+            vocoder.decode_delta("req", state, is_final=False)
+    vocoder.decode_delta("req", state, is_final=True)
+
+    assert codec.inference.stream_calls, "streaming produced no vocoder steps"
+    assert all(not call["use_compiled"] for call in codec.inference.stream_calls)
+    assert all(call["optimize"] for call in codec.inference.stream_calls)


### PR DESCRIPTION
## Motivation

Fixes #1392. The first streaming request killed the pipeline stage process on the canonical config. The upstream compiled vocoder stream step is built with reduce overhead mode, and its Inductor cudagraph trees manipulate the caching allocator between chunks while the backbone decode CUDA graph replays in the same process, corrupting replay memory. Isolation matrix in the issue thread: the crash needs both sides together, either side alone is stable, and non streaming never overlaps them.

## Modifications

Streaming always calls stream_step with use_compiled false, keeping merge step batching. A regression test pins the contract. A safe compiled streaming path is left to a follow up since the compile mode is owned upstream.

## Related Issues

Fixes #1392.

## Accuracy Test

Streamed output is deterministic across requests per config (identical md5, seed 42). tests/unit_test/dots_tts passes locally.

## Benchmark & Profiling

With the fix, 3 streaming requests complete on each of the canonical and max_running_requests 1 configs on one H100. Both previously failed on request 1.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
