### PR TITLE
patch create_causal_mask signature of transformers 5.12 used by qwen3 tts 0.1.1 

### DIFF
--- a/sglang_omni/models/qwen3_tts/compat.py
+++ b/sglang_omni/models/qwen3_tts/compat.py
@@ -1,18 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 """Compatibility shims for upstream qwen-tts."""
-
+ 
 from __future__ import annotations
-
+ 
 import inspect
 import threading
 from typing import Any, Callable
-
+ 
 import torch
-
+ 
 _APPLY_LOCK = threading.Lock()
 _PATCHED_FLAG = "_sglang_omni_qwen_tts_compat_patched"
-
-
+ 
+ 
 def _compute_default_rope_parameters(
     config: Any,
     device: torch.device | None = None,
@@ -36,25 +36,84 @@ def _compute_default_rope_parameters(
         )
     )
     return inv_freq, 1.0
-
-
+ 
+ 
+def _patch_create_causal_mask() -> None:
+    """Shim `create_causal_mask` to accept qwen-tts's `input_embeds=` /
+    `cache_position=` call signature.
+ 
+    qwen-tts 0.1.1 calls `create_causal_mask(..., input_embeds=..., cache_position=...)`.
+    Under transformers==5.12.1 the parameter is spelled `inputs_embeds` and
+    `cache_position` has been dropped from the signature entirely, so every
+    request 500s. This normalises the call: `input_embeds` is renamed to
+    `inputs_embeds`, and `cache_position` is absorbed (dropped) unless the
+    installed transformers version still accepts it.
+    """
+    from transformers import masking_utils
+ 
+    original = masking_utils.create_causal_mask
+    if getattr(original, _PATCHED_FLAG, False):
+        return
+ 
+    try:
+        signature = inspect.signature(original)
+    except (TypeError, ValueError):
+        return
+ 
+    accepted_params = set(signature.parameters)
+ 
+    def create_causal_mask_compat(*args: Any, **kwargs: Any) -> Any:
+        if "input_embeds" in kwargs:
+            value = kwargs.pop("input_embeds")
+            if "inputs_embeds" not in kwargs:
+                kwargs["inputs_embeds"] = value
+ 
+        if "cache_position" in kwargs and "cache_position" not in accepted_params:
+            kwargs.pop("cache_position")
+ 
+        return original(*args, **kwargs)
+ 
+    create_causal_mask_compat.__name__ = getattr(
+        original, "__name__", "create_causal_mask"
+    )
+    create_causal_mask_compat.__doc__ = getattr(original, "__doc__", None)
+    setattr(create_causal_mask_compat, _PATCHED_FLAG, True)
+ 
+    masking_utils.create_causal_mask = create_causal_mask_compat
+ 
+    # `create_causal_mask` is commonly re-imported by name into modeling
+    # modules (e.g. `from transformers.masking_utils import
+    # create_causal_mask`), so patching the source module alone won't reach
+    # call sites that already bound the original reference. Patch the other
+    # common rebinding point too, best-effort.
+    try:
+        import transformers.modeling_utils as modeling_utils
+    except ImportError:
+        pass
+    else:
+        if getattr(modeling_utils, "create_causal_mask", None) is original:
+            modeling_utils.create_causal_mask = create_causal_mask_compat
+ 
+ 
 def apply_qwen_tts_transformers_compatibility_patches() -> None:
     """Patch Transformers APIs expected by qwen-tts."""
     from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
     from transformers.utils import generic
-
+ 
     with _APPLY_LOCK:
         ROPE_INIT_FUNCTIONS.setdefault("default", _compute_default_rope_parameters)
-
+ 
+        _patch_create_causal_mask()
+ 
         current = generic.check_model_inputs
         if getattr(current, _PATCHED_FLAG, False):
             return
-
+ 
         try:
             signature = inspect.signature(current)
         except (TypeError, ValueError):
             return
-
+ 
         params = list(signature.parameters.values())
         needs_func_arg = (
             len(params) == 1
@@ -67,20 +126,20 @@ def apply_qwen_tts_transformers_compatibility_patches() -> None:
         )
         if not needs_func_arg:
             return
-
+ 
         original = current
-
+ 
         def check_model_inputs_compat(
             func: Callable[..., Any] | None = None,
         ) -> Callable[..., Any]:
             if func is None:
-
+ 
                 def decorator(inner: Callable[..., Any]) -> Callable[..., Any]:
                     return original(inner)
-
+ 
                 return decorator
             return original(func)
-
+ 
         check_model_inputs_compat.__name__ = getattr(
             original, "__name__", "check_model_inputs"
         )

--- a/tests/smoke/test_qwen3_tts_clean_install.py
+++ b/tests/smoke/test_qwen3_tts_clean_install.py
@@ -1,0 +1,327 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Clean-environment smoke test for Qwen3-TTS.
+
+Regression coverage for: "qwen-tts 0.1.1 breaks against transformers 5.12 --
+every request 500s".
+
+The test does following things:
+
+    1. Build a venv from *only* `pyproject.toml` (i.e. whatever transformers
+       version is pinned there today -- currently `transformers==5.12.1` per
+       `pyproject.toml:24`). No dev/test extras, no local overrides.
+    2. Run the exact install line documented at `docs/basic_usage/tts.md:18`
+       (and mirrored at `docs/cookbook/qwen3_tts.md:22`):
+           uv pip install --upgrade sox einops
+           uv pip install --no-deps qwen-tts==0.1.1
+    3. Launch `sgl-omni serve` for a Qwen3-TTS Base checkpoint, exactly as
+       documented.
+    4. Send one real `/v1/audio/speech` request (the same reference-audio
+       example from the docs, since Qwen3-TTS Base requires `ref_audio`) and
+       assert it comes back as audio, not a 500.
+
+Run explicitly with:
+
+    SGLANG_OMNI_RUN_CLEAN_INSTALL_SMOKE=1 pytest -m clean_install_smoke \
+        tests/smoke/test_qwen3_tts_clean_install.py -v -s
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+import wave
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Constants mirrored from the documented, user-facing install / serve flow.
+# If these ever need to change, they should change in lockstep with the docs
+# they're copied from -- that's the whole point of this test.
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# docs/basic_usage/tts.md:18 and docs/cookbook/qwen3_tts.md:22
+QWEN_TTS_EXTRA_DEPS = ["sox", "einops"]
+QWEN_TTS_PACKAGE_SPEC = "qwen-tts==0.1.1"
+
+# docs/basic_usage/tts.md "For Qwen3-TTS Base"
+MODEL_PATH = "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
+MODEL_CONFIG = "examples/configs/qwen3_tts_0_6b.yaml"
+
+# docs/basic_usage/tts.md "Qwen3-TTS Base requires reference audio"
+REFERENCE_AUDIO = (
+    "https://huggingface.co/datasets/zhaochenyang20/seed-tts-eval-mini/"
+    "resolve/main/en/prompt-wavs/common_voice_en_10119832.wav"
+)
+REFERENCE_TEXT = "We asked over twenty different people, and they all said it was his."
+SPEECH_INPUT = "Get the trust fund to the bank early."
+
+SERVER_PORT = int(os.environ.get("SGLANG_OMNI_SMOKE_TEST_PORT", "8931"))
+SERVER_HOST = "127.0.0.1"
+SERVER_BASE_URL = f"http://{SERVER_HOST}:{SERVER_PORT}"
+
+SERVER_BOOT_TIMEOUT_S = float(os.environ.get("SGLANG_OMNI_SMOKE_BOOT_TIMEOUT_S", "900"))
+REQUEST_TIMEOUT_S = float(os.environ.get("SGLANG_OMNI_SMOKE_REQUEST_TIMEOUT_S", "300"))
+
+RUN_ENV_VAR = "SGLANG_OMNI_RUN_CLEAN_INSTALL_SMOKE"
+
+pytestmark = pytest.mark.clean_install_smoke
+
+
+def _skip_reason() -> str | None:
+    """Return why this test should be skipped, or None to run it."""
+    if os.environ.get(RUN_ENV_VAR) != "1":
+        return (
+            f"Set {RUN_ENV_VAR}=1 to run the Qwen3-TTS clean-install smoke "
+            "test (builds a fresh venv, downloads model weights, needs a "
+            "GPU and network access)."
+        )
+    if shutil.which("uv") is None:
+        return "uv is not on PATH; required to build the clean install venv."
+    if not (REPO_ROOT / "pyproject.toml").exists():
+        return f"Could not find pyproject.toml at {REPO_ROOT}; wrong repo root?"
+    try:
+        gpu_check = subprocess.run(
+            ["nvidia-smi", "-L"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return "No GPU detected (nvidia-smi unavailable); required to serve Qwen3-TTS."
+    if gpu_check.returncode != 0 or not gpu_check.stdout.strip():
+        return "No GPU detected (nvidia-smi reported none); required to serve Qwen3-TTS."
+    return None
+
+
+@pytest.fixture(scope="module")
+def clean_env_python(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    """Build a venv from *only* pyproject.toml + the documented install line.
+
+    This deliberately does not reuse the interpreter running pytest: that
+    interpreter may have local patches, editable installs with extra pins,
+    or a transformers version chosen for the rest of the test suite rather
+    than the one actually pinned for release. The whole point of this test
+    is to reproduce what a user gets from a clean install of `main`.
+    """
+    venv_dir = tmp_path_factory.mktemp("qwen3_tts_clean_install") / "venv"
+
+    _run(["uv", "venv", str(venv_dir), "--python", "3.11"], cwd=REPO_ROOT)
+    venv_python = venv_dir / "bin" / "python"
+    if not venv_python.exists():  # pragma: no cover - Windows runners, if any
+        venv_python = venv_dir / "Scripts" / "python.exe"
+
+    # Step 1: install sglang-omni itself exactly as pyproject.toml pins it
+    # (in particular transformers==5.12.1, pyproject.toml:24). No extras.
+    _run(
+        ["uv", "pip", "install", "--python", str(venv_python), str(REPO_ROOT)],
+        cwd=REPO_ROOT,
+    )
+
+    # Step 2: the documented Qwen3-TTS install lines, verbatim
+    # (docs/basic_usage/tts.md:18, docs/cookbook/qwen3_tts.md:22).
+    _run(
+        [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(venv_python),
+            "--upgrade",
+            *QWEN_TTS_EXTRA_DEPS,
+        ],
+        cwd=REPO_ROOT,
+    )
+    _run(
+        [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(venv_python),
+            "--no-deps",
+            QWEN_TTS_PACKAGE_SPEC,
+        ],
+        cwd=REPO_ROOT,
+    )
+
+    # Sanity check: fail fast and legibly if the pin in pyproject.toml has
+    # silently drifted away from what this test assumes.
+    installed_transformers = _run(
+        [
+            str(venv_python),
+            "-c",
+            "import transformers; print(transformers.__version__)",
+        ],
+        cwd=REPO_ROOT,
+    ).stdout.strip()
+    print(f"[clean-install smoke] transformers=={installed_transformers}")
+
+    yield venv_python
+
+
+@pytest.fixture(scope="module")
+def qwen3_tts_server(clean_env_python: Path) -> Iterator[str]:
+    """Boot `sgl-omni serve` for Qwen3-TTS Base inside the clean venv."""
+    log_path = Path(tempfile.mkstemp(suffix=".log", prefix="sgl_omni_serve_")[1])
+    log_file = open(log_path, "w", encoding="utf-8")  # noqa: SIM115
+
+    proc = subprocess.Popen(
+        [
+            str(clean_env_python),
+            "-m",
+            "sglang_omni.cli",
+            "serve",
+            "--model-path",
+            MODEL_PATH,
+            "--config",
+            MODEL_CONFIG,
+            "--port",
+            str(SERVER_PORT),
+            "--host",
+            SERVER_HOST,
+        ],
+        cwd=REPO_ROOT,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+    )
+
+    try:
+        _wait_for_health(SERVER_BASE_URL, proc, log_path, SERVER_BOOT_TIMEOUT_S)
+        yield SERVER_BASE_URL
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=30)
+        log_file.close()
+        if proc.returncode not in (0, None, -15):  # not a clean exit/terminate
+            print(f"[clean-install smoke] server log ({log_path}):")
+            print(log_path.read_text(encoding="utf-8", errors="replace"))
+
+
+def _wait_for_health(
+    base_url: str, proc: subprocess.Popen, log_path: Path, timeout_s: float
+) -> None:
+    deadline = time.monotonic() + timeout_s
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            log_contents = log_path.read_text(encoding="utf-8", errors="replace")
+            raise RuntimeError(
+                f"sgl-omni serve exited early with code {proc.returncode} "
+                f"before becoming healthy.\n--- server log ---\n{log_contents}"
+            )
+        try:
+            with urllib.request.urlopen(f"{base_url}/health", timeout=5) as resp:
+                if resp.status == 200:
+                    return
+        except (urllib.error.URLError, ConnectionError, TimeoutError) as exc:
+            last_error = exc
+        time.sleep(2)
+
+    log_contents = log_path.read_text(encoding="utf-8", errors="replace")
+    raise TimeoutError(
+        f"Server did not become healthy within {timeout_s}s "
+        f"(last error: {last_error}).\n--- server log ---\n{log_contents}"
+    )
+
+
+def _run(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=1800,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Command failed ({result.returncode}): {' '.join(cmd)}\n"
+            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+        )
+    return result
+
+
+@pytest.mark.skipif(_skip_reason() is not None, reason=_skip_reason() or "")
+def test_qwen3_tts_base_serves_one_request_end_to_end(
+    qwen3_tts_server: str,
+) -> None:
+    """Boot Qwen3-TTS Base from a clean install and synthesize once.
+
+    This is the documented "Qwen3-TTS Base requires reference audio" curl
+    example from docs/basic_usage/tts.md, sent as a real HTTP request against
+    a server built from nothing but pyproject.toml + the documented qwen-tts
+    install line.
+
+    Before the create_causal_mask shim, this failed on every request with a
+    500 originating from qwen-tts calling
+    `create_causal_mask(..., input_embeds=..., cache_position=...)` against a
+    transformers version that spells the parameter `inputs_embeds` and no
+    longer accepts `cache_position` at all.
+    """
+    payload = {
+        "input": SPEECH_INPUT,
+        "ref_audio": REFERENCE_AUDIO,
+        "ref_text": REFERENCE_TEXT,
+        "response_format": "wav",
+    }
+    request = urllib.request.Request(
+        f"{qwen3_tts_server}/v1/audio/speech",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_S) as resp:
+            status = resp.status
+            audio_bytes = resp.read()
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        pytest.fail(
+            f"/v1/audio/speech returned HTTP {exc.code} instead of 200.\n"
+            f"Response body: {body}"
+        )
+
+    assert status == 200, f"Expected HTTP 200, got {status}"
+
+    # The failure mode this test guards against returns an OpenAI-style JSON
+    # error envelope (see docs/basic_usage/tts.md "Invalid speech requests")
+    # rather than audio bytes. Confirm we actually got audio, not that.
+    assert not audio_bytes.lstrip().startswith(b"{"), (
+        "Response looks like a JSON error envelope, not audio bytes: "
+        f"{audio_bytes[:200]!r}"
+    )
+
+    with contextlib.closing(wave.open(io.BytesIO(audio_bytes), "rb")) as wav_file:
+        frame_count = wav_file.getnframes()
+        channels = wav_file.getnchannels()
+        sample_rate = wav_file.getframerate()
+
+    assert frame_count > 0, "Synthesized WAV has zero audio frames"
+    assert channels >= 1
+    assert sample_rate > 0
+
+    duration_s = frame_count / sample_rate
+    print(
+        f"[clean-install smoke] synthesized {duration_s:.2f}s of audio "
+        f"({len(audio_bytes)} bytes, {sample_rate}Hz, {channels}ch)"
+    )
+    # A few words of speech should not collapse to near-silence-length audio;
+    # this loosely guards against "200 OK with garbage/empty audio".
+    assert duration_s > 0.2

--- a/tests/smoke/test_qwen3_tts_clean_install.py
+++ b/tests/smoke/test_qwen3_tts_clean_install.py
@@ -6,18 +6,15 @@ every request 500s".
 
 The test does following things:
 
-    1. Build a venv from *only* `pyproject.toml` (i.e. whatever transformers
-       version is pinned there today -- currently `transformers==5.12.1` per
-       `pyproject.toml:24`). No dev/test extras, no local overrides.
-    2. Run the exact install line documented at `docs/basic_usage/tts.md:18`
+    1. Build a venv from only `pyproject.toml` (currently having 
+       `transformers==5.12.1`). No dev/test extras, no local overrides.
+    2. Run the install line as documented at `docs/basic_usage/tts.md:18`
        (and mirrored at `docs/cookbook/qwen3_tts.md:22`):
            uv pip install --upgrade sox einops
            uv pip install --no-deps qwen-tts==0.1.1
-    3. Launch `sgl-omni serve` for a Qwen3-TTS Base checkpoint, exactly as
-       documented.
+    3. Launch `sgl-omni serve` for a Qwen3-TTS Base checkpoint
     4. Send one real `/v1/audio/speech` request (the same reference-audio
-       example from the docs, since Qwen3-TTS Base requires `ref_audio`) and
-       assert it comes back as audio, not a 500.
+       example from the docs) and assert it comes back as audio, not a 500.
 
 Run explicitly with:
 
@@ -44,23 +41,15 @@ from typing import Iterator
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Constants mirrored from the documented, user-facing install / serve flow.
-# If these ever need to change, they should change in lockstep with the docs
-# they're copied from -- that's the whole point of this test.
-# ---------------------------------------------------------------------------
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-# docs/basic_usage/tts.md:18 and docs/cookbook/qwen3_tts.md:22
 QWEN_TTS_EXTRA_DEPS = ["sox", "einops"]
 QWEN_TTS_PACKAGE_SPEC = "qwen-tts==0.1.1"
 
-# docs/basic_usage/tts.md "For Qwen3-TTS Base"
 MODEL_PATH = "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
 MODEL_CONFIG = "examples/configs/qwen3_tts_0_6b.yaml"
 
-# docs/basic_usage/tts.md "Qwen3-TTS Base requires reference audio"
 REFERENCE_AUDIO = (
     "https://huggingface.co/datasets/zhaochenyang20/seed-tts-eval-mini/"
     "resolve/main/en/prompt-wavs/common_voice_en_10119832.wav"
@@ -91,7 +80,7 @@ def _skip_reason() -> str | None:
     if shutil.which("uv") is None:
         return "uv is not on PATH; required to build the clean install venv."
     if not (REPO_ROOT / "pyproject.toml").exists():
-        return f"Could not find pyproject.toml at {REPO_ROOT}; wrong repo root?"
+        return f"Could not find pyproject.toml at {REPO_ROOT};"
     try:
         gpu_check = subprocess.run(
             ["nvidia-smi", "-L"],
@@ -108,7 +97,7 @@ def _skip_reason() -> str | None:
 
 @pytest.fixture(scope="module")
 def clean_env_python(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
-    """Build a venv from *only* pyproject.toml + the documented install line.
+    """Build a venv from *only* pyproject.toml + the documented install line in docs.
 
     This deliberately does not reuse the interpreter running pytest: that
     interpreter may have local patches, editable installs with extra pins,
@@ -120,18 +109,16 @@ def clean_env_python(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]
 
     _run(["uv", "venv", str(venv_dir), "--python", "3.11"], cwd=REPO_ROOT)
     venv_python = venv_dir / "bin" / "python"
-    if not venv_python.exists():  # pragma: no cover - Windows runners, if any
+    if not venv_python.exists():  
         venv_python = venv_dir / "Scripts" / "python.exe"
 
-    # Step 1: install sglang-omni itself exactly as pyproject.toml pins it
-    # (in particular transformers==5.12.1, pyproject.toml:24). No extras.
+    # install sglang-omni itself exactly as pyproject.toml pins it
+    # (in particular transformers==5.12.1).
     _run(
         ["uv", "pip", "install", "--python", str(venv_python), str(REPO_ROOT)],
         cwd=REPO_ROOT,
     )
 
-    # Step 2: the documented Qwen3-TTS install lines, verbatim
-    # (docs/basic_usage/tts.md:18, docs/cookbook/qwen3_tts.md:22).
     _run(
         [
             "uv",
@@ -209,7 +196,7 @@ def qwen3_tts_server(clean_env_python: Path) -> Iterator[str]:
             proc.kill()
             proc.wait(timeout=30)
         log_file.close()
-        if proc.returncode not in (0, None, -15):  # not a clean exit/terminate
+        if proc.returncode not in (0, None, -15):  
             print(f"[clean-install smoke] server log ({log_path}):")
             print(log_path.read_text(encoding="utf-8", errors="replace"))
 
@@ -261,17 +248,12 @@ def _run(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess:
 def test_qwen3_tts_base_serves_one_request_end_to_end(
     qwen3_tts_server: str,
 ) -> None:
-    """Boot Qwen3-TTS Base from a clean install and synthesize once.
-
-    This is the documented "Qwen3-TTS Base requires reference audio" curl
-    example from docs/basic_usage/tts.md, sent as a real HTTP request against
-    a server built from nothing but pyproject.toml + the documented qwen-tts
-    install line.
+    """Boot Qwen3-TTS Base from a clean install.
 
     Before the create_causal_mask shim, this failed on every request with a
     500 originating from qwen-tts calling
-    `create_causal_mask(..., input_embeds=..., cache_position=...)` against a
-    transformers version that spells the parameter `inputs_embeds` and no
+    `create_causal_mask(..., input_embeds=..., cache_position=...)` against
+    transformers 5.12 that spells the parameter `inputs_embeds` and no
     longer accepts `cache_position` at all.
     """
     payload = {


### PR DESCRIPTION
Qwen-tts 0.1.1 calls `create_causal_mask(..., input_embeds=..., cache_position=...)`. Under transformers==5.12.1 the parameter is spelled `inputs_embeds` and `cache_position` has been dropped from the signature entirely, so every request 500s. This normalises the call: `input_embeds` is renamed to `inputs_embeds`, and `cache_position` is absorbed (dropped) unless the installed transformers version still accepts it.

This PR also adds a smoke test to test the above change. Specifically, the test serves one audio request in a clean uv environment.

Reference Issue: #1399 

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
