### PR TITLE
[Enhancement] dots.tts: document and gate acoustic-tail pool memory

### DIFF
--- a/docs/cookbook/dots_tts.md
+++ b/docs/cookbook/dots_tts.md
@@ -51,7 +51,32 @@ SOAR is a flow-matching checkpoint. It runs the single-request solver with class
 
 `examples/configs/dots_tts.yaml` is the canonical MeanFlow deployment. It is already tuned; compiled acoustic tail and vocoder (`optimize: true`, on by default); continuous batching at `max_running_requests=16`; and the backbone decode CUDA graph. `--model-path` alone keeps the compiled tail and batching but leaves backbone decode eager, which is slower per request (see [Performance](#performance)). Use the config file.
 
+If startup fails with `dots.tts acoustic-tail admission failed at startup`, the GPU cannot hold `max_running_requests × max_generate_length` full-length acoustic pools — lower those knobs yourself. The engine never silently shrinks them.
+
 The examples below read local clips from `docs/_static/audio`. To fetch reference audio over HTTP instead, allow the domains you need, e.g. `--allowed-media-domain huggingface.co`.
+
+## Memory and capacity
+
+Continuous batching eagerly allocates acoustic-tail state for every slot at the full generate length:
+
+```text
+patch_capacity = max_generate_length + 1
+dit_cache_tokens = patch_capacity × (hidden_patch_size + latent_patch_size)   # MF: ×5
+```
+
+Pool bytes scale roughly as `max_running_requests × patch_capacity` and include DiT KV (per NFE), semantic-encoder KV, scratch K/V, masks, window, and AdaLN mods. Startup logs the estimated breakdown and free CUDA memory, then refuses to allocate when free VRAM is below the estimate plus a 15% headroom for graphs and workspace.
+
+`mem_fraction_static` (default `0.20` in `examples/configs/dots_tts.yaml`) only budgets the **SGLang backbone** KV cache. Acoustic-tail pools are separate and are **not** covered by that fraction.
+
+| Knob | Effect on pool size |
+|---|---|
+| `max_running_requests` | Number of full-length slots |
+| `max_generate_length` | `patch_capacity` (and therefore DiT / encoder sequence length) |
+| `num_steps` | DiT KV is replicated per NFE step |
+
+On a full GPU the default `16 × 500` layout is intended. On tighter cards, lower `max_running_requests` and/or `max_generate_length` explicitly rather than hoping for automatic downsizing. A live request that needs a free slot when all are busy fails with `dots.tts acoustic tail admission failed: ran out of slots` — lower client concurrency or raise `max_running_requests` (if memory allows).
+
+Incremental / bucketed tail-KV allocation is not implemented yet; capacity is still the eager full-length pool.
 
 ## Synthesizing Speech
 

--- a/sglang_omni/models/dots_tts/tail.py
+++ b/sglang_omni/models/dots_tts/tail.py
@@ -186,6 +186,158 @@ class DotsTtsTailSpec:
         return self.patch_capacity * self.unit_len
 
 
+def _dtype_nbytes(dtype: torch.dtype) -> int:
+    return torch.empty((), dtype=dtype).element_size()
+
+
+def _gib(num_bytes: int) -> float:
+    return float(num_bytes) / float(1 << 30)
+
+
+@dataclass(frozen=True)
+class AcousticPoolMemoryEstimate:
+    """Eager acoustic-tail pool byte budget matching _allocate_pools shapes."""
+
+    dit_kv_bytes: int
+    encoder_kv_bytes: int
+    scratch_bytes: int
+    aux_bytes: int
+    total_bytes: int
+    num_slots: int
+    patch_capacity: int
+    nfe: int
+    dtype: torch.dtype
+
+    @property
+    def bytes_per_slot(self) -> int:
+        return self.total_bytes // max(int(self.num_slots), 1)
+
+
+def estimate_acoustic_pool_bytes(
+    *,
+    spec: DotsTtsTailSpec,
+    dit_layers: int,
+    dit_heads: int,
+    dit_head_dim: int,
+    encoder_layers: int,
+    encoder_heads: int,
+    encoder_head_dim: int,
+    encoder_block: int,
+    encoder_conv_channels: int,
+    encoder_conv_padding: int,
+    mods_width: int,
+    dtype: torch.dtype,
+) -> AcousticPoolMemoryEstimate:
+    """Sum pool tensor bytes; excludes weights, backbone KV, and graph workspace."""
+    elem = _dtype_nbytes(dtype)
+    bool_elem = _dtype_nbytes(torch.bool)
+    slots = int(spec.num_slots)
+    nfe = int(spec.nfe)
+    dit_tokens = int(spec.dit_cache_tokens) + int(spec.unit_len)
+    dit_query = 2 * int(spec.unit_len)
+    dit_scratch_tokens = int(spec.dit_cache_tokens) + dit_query
+    encoder_tokens = int(spec.patch_capacity) * int(encoder_block)
+
+    dit_kv = (
+        2
+        * nfe
+        * int(dit_layers)
+        * slots
+        * int(dit_heads)
+        * dit_tokens
+        * int(dit_head_dim)
+        * elem
+    )
+    encoder_kv = (
+        2
+        * int(encoder_layers)
+        * slots
+        * int(encoder_heads)
+        * encoder_tokens
+        * int(encoder_head_dim)
+        * elem
+    )
+    dit_scratch = (
+        2
+        * int(dit_layers)
+        * slots
+        * int(dit_heads)
+        * dit_scratch_tokens
+        * int(dit_head_dim)
+        * elem
+    )
+    encoder_scratch = (
+        2
+        * int(encoder_layers)
+        * slots
+        * int(encoder_heads)
+        * (encoder_tokens + int(encoder_block))
+        * int(encoder_head_dim)
+        * elem
+    )
+    dit_mask = slots * 1 * dit_query * dit_scratch_tokens * bool_elem
+    encoder_mask = (
+        slots
+        * 1
+        * int(encoder_block)
+        * (encoder_tokens + int(encoder_block))
+        * bool_elem
+    )
+    window = slots * int(spec.window_len) * int(spec.fm_hidden_size) * elem
+    all_mods = nfe * slots * int(mods_width) * elem
+    conv_tail = slots * int(encoder_conv_channels) * int(encoder_conv_padding) * elem
+
+    scratch = dit_scratch + encoder_scratch
+    aux = dit_mask + encoder_mask + window + all_mods + conv_tail
+    total = dit_kv + encoder_kv + scratch + aux
+    return AcousticPoolMemoryEstimate(
+        dit_kv_bytes=dit_kv,
+        encoder_kv_bytes=encoder_kv,
+        scratch_bytes=scratch,
+        aux_bytes=aux,
+        total_bytes=total,
+        num_slots=slots,
+        patch_capacity=int(spec.patch_capacity),
+        nfe=nfe,
+        dtype=dtype,
+    )
+
+
+def validate_acoustic_pool_memory(
+    estimate: AcousticPoolMemoryEstimate,
+    *,
+    device: torch.device,
+    headroom_ratio: float = 0.15,
+) -> None:
+    """Raise if free CUDA memory cannot hold the pools plus headroom."""
+    # note (guozhihao-224): CPU paths skip this gate so unit tests can allocate
+    # tiny pools; never silently lower max_running_requests or patch capacity.
+    if device.type != "cuda":
+        return
+    if headroom_ratio < 0.0:
+        raise ValueError("dots.tts acoustic pool headroom_ratio must be non-negative")
+    free_bytes, total_bytes = torch.cuda.mem_get_info(device)
+    # note (guozhihao-224): 15% headroom covers CUDA-graph capture and scratch
+    # beyond the eager pool tensors themselves.
+    required = int(estimate.total_bytes * (1.0 + float(headroom_ratio)))
+    if free_bytes >= required:
+        return
+    fit_slots = max(int(free_bytes // max(estimate.bytes_per_slot, 1)), 0)
+    raise ValueError(
+        "dots.tts acoustic-tail admission failed at startup: estimated pools need "
+        f"{_gib(required):.2f} GiB "
+        f"(pools={_gib(estimate.total_bytes):.2f} GiB + "
+        f"{headroom_ratio:.0%} headroom for graphs/workspace) but only "
+        f"{_gib(free_bytes):.2f} GiB is free on {device} "
+        f"(GPU total {_gib(total_bytes):.2f} GiB). "
+        f"Configured slots={estimate.num_slots} patch_capacity={estimate.patch_capacity} "
+        f"nfe={estimate.nfe} dtype={estimate.dtype}. "
+        "Lower max_running_requests and/or max_generate_length "
+        f"(about {fit_slots} full-length slot(s) would fit at this capacity). "
+        "Parameters are not changed automatically."
+    )
+
+
 @dataclass
 class _CapturedTailGraph:
     graph: torch.cuda.CUDAGraph
@@ -265,7 +417,8 @@ class DotsTtsAcousticTail:
         self._encoder_heads = int(encoder_attention.num_heads)
         self._encoder_head_dim = int(encoder_attention.head_dim)
 
-        self._allocate_pools(int(dit.fused_adaln[-1].out_features))
+        self._mods_width = int(dit.fused_adaln[-1].out_features)
+        self._allocate_pools(self._mods_width)
         self._times = torch.linspace(0.0, 1.0, spec.nfe + 1, device=device, dtype=dtype)
         self._dit_layer_index = torch.arange(self._dit_layers, device=device)
         self._encoder_layer_index = torch.arange(self._encoder_layers, device=device)
@@ -283,8 +436,74 @@ class DotsTtsAcousticTail:
         if optimize and device.type == "cuda":
             self._capture_cuda_graphs()
 
+    def _pool_tensors(self) -> tuple[torch.Tensor, ...]:
+        return (
+            self._dit_k,
+            self._dit_v,
+            self._encoder_k,
+            self._encoder_v,
+            self._encoder_conv_tail,
+            self._window,
+            self._all_mods,
+            self._dit_scratch_k,
+            self._dit_scratch_v,
+            self._dit_mask,
+            self._encoder_scratch_k,
+            self._encoder_scratch_v,
+            self._encoder_mask,
+        )
+
+    def _pool_memory_estimate(self, mods_width: int) -> AcousticPoolMemoryEstimate:
+        return estimate_acoustic_pool_bytes(
+            spec=self.spec,
+            dit_layers=self._dit_layers,
+            dit_heads=self._dit_heads,
+            dit_head_dim=self._dit_head_dim,
+            encoder_layers=self._encoder_layers,
+            encoder_heads=self._encoder_heads,
+            encoder_head_dim=self._encoder_head_dim,
+            encoder_block=self._encoder_block,
+            encoder_conv_channels=int(self._encoder.ds_proj.in_channels),
+            encoder_conv_padding=int(self._encoder.ds_proj.left_padding),
+            mods_width=int(mods_width),
+            dtype=self.dtype,
+        )
+
+    def _allocated_pool_bytes(self) -> int:
+        return sum(int(tensor.nbytes) for tensor in self._pool_tensors())
+
     def _allocate_pools(self, mods_width: int) -> None:
+        # note (guozhihao-224): pools are num_slots x full patch_capacity; log the
+        # formula then fail fast if free VRAM cannot cover pools + headroom.
         spec = self.spec
+        estimate = self._pool_memory_estimate(mods_width)
+        free_bytes = total_bytes = None
+        if self.device.type == "cuda":
+            free_bytes, total_bytes = torch.cuda.mem_get_info(self.device)
+        logger.info(
+            "dots.tts acoustic pools (estimate): slots=%d nfe=%d patch_capacity=%d "
+            "dtype=%s total=%.2f GiB "
+            "(dit_kv=%.2f encoder_kv=%.2f scratch=%.2f aux=%.2f)%s",
+            estimate.num_slots,
+            estimate.nfe,
+            estimate.patch_capacity,
+            estimate.dtype,
+            _gib(estimate.total_bytes),
+            _gib(estimate.dit_kv_bytes),
+            _gib(estimate.encoder_kv_bytes),
+            _gib(estimate.scratch_bytes),
+            _gib(estimate.aux_bytes),
+            (
+                ""
+                if free_bytes is None or total_bytes is None
+                else (
+                    f" cuda_free={_gib(free_bytes):.2f} GiB "
+                    f"cuda_total={_gib(total_bytes):.2f} GiB"
+                )
+            ),
+        )
+        validate_acoustic_pool_memory(estimate, device=self.device)
+
         zeros = partial(torch.zeros, device=self.device, dtype=self.dtype)
         self._dit_k = zeros(
             spec.nfe,
@@ -344,17 +563,32 @@ class DotsTtsAcousticTail:
             device=self.device,
             dtype=torch.bool,
         )
+        pool_tensors = self._pool_tensors()
+        allocated = sum(int(tensor.nbytes) for tensor in pool_tensors)
+        if allocated != estimate.total_bytes:
+            logger.warning(
+                "dots.tts acoustic pool nbytes mismatch: estimated=%d allocated=%d",
+                estimate.total_bytes,
+                allocated,
+            )
         logger.info(
-            "dots.tts acoustic pools: slots=%s nfe=%s patch_capacity=%s",
+            "dots.tts acoustic pools allocated: %.2f GiB across %d tensors "
+            "(slots=%d patch_capacity=%d)",
+            _gib(allocated),
+            len(pool_tensors),
             spec.num_slots,
-            spec.nfe,
             spec.patch_capacity,
         )
 
     def acquire_slot(self) -> int:
         if not self._free_slots:
+            # note (guozhihao-224): slot exhaustion is an admission failure, not a
+            # cue to resize the pool under a live request.
+            in_use = int(self.spec.num_slots)
             raise RuntimeError(
-                "dots.tts acoustic tail ran out of slots; lower concurrency"
+                "dots.tts acoustic tail admission failed: ran out of slots "
+                f"({in_use}/{in_use} in use). Lower client concurrency or "
+                "max_running_requests; the engine does not silently shrink capacity."
             )
         slot = self._free_slots.pop()
         self._fm_seq_len[slot] = 0
@@ -958,8 +1192,11 @@ class DotsTtsAcousticTail:
 
 
 __all__ = [
+    "AcousticPoolMemoryEstimate",
     "DotsTtsAcousticTail",
     "DotsTtsTailSpec",
     "batched_causal_update_mask",
+    "estimate_acoustic_pool_bytes",
     "fuse_dit_for_inference",
+    "validate_acoustic_pool_memory",
 ]

--- a/sglang_omni/models/dots_tts/tail.py
+++ b/sglang_omni/models/dots_tts/tail.py
@@ -316,13 +316,16 @@ def validate_acoustic_pool_memory(
         return
     if headroom_ratio < 0.0:
         raise ValueError("dots.tts acoustic pool headroom_ratio must be non-negative")
+    with torch.cuda.device(device):
+        torch.cuda.empty_cache()
     free_bytes, total_bytes = torch.cuda.mem_get_info(device)
     # note (guozhihao-224): 15% headroom covers CUDA-graph capture and scratch
     # beyond the eager pool tensors themselves.
     required = int(estimate.total_bytes * (1.0 + float(headroom_ratio)))
     if free_bytes >= required:
         return
-    fit_slots = max(int(free_bytes // max(estimate.bytes_per_slot, 1)), 0)
+    slot_required = estimate.bytes_per_slot * (1.0 + float(headroom_ratio))
+    fit_slots = max(int(free_bytes // max(slot_required, 1.0)), 0)
     raise ValueError(
         "dots.tts acoustic-tail admission failed at startup: estimated pools need "
         f"{_gib(required):.2f} GiB "
@@ -588,7 +591,7 @@ class DotsTtsAcousticTail:
             raise RuntimeError(
                 "dots.tts acoustic tail admission failed: ran out of slots "
                 f"({in_use}/{in_use} in use). Lower client concurrency or "
-                "max_running_requests; the engine does not silently shrink capacity."
+                "raise max_running_requests; the engine does not silently shrink capacity."
             )
         slot = self._free_slots.pop()
         self._fm_seq_len[slot] = 0

--- a/tests/unit_test/dots_tts/test_tail.py
+++ b/tests/unit_test/dots_tts/test_tail.py
@@ -198,11 +198,85 @@ def test_tail_slots_are_bounded_and_reusable() -> None:
     try:
         acoustic_tail.acquire_slot()
     except RuntimeError as error:
-        assert "ran out of slots" in str(error)
+        message = str(error)
+        assert "ran out of slots" in message
+        assert "admission failed" in message
+        assert "does not silently shrink" in message
     else:
         raise AssertionError("slot exhaustion must fail")
     acoustic_tail.release_slot(first)
     assert acoustic_tail.acquire_slot() == first
+
+
+def test_estimate_acoustic_pool_bytes_matches_allocated_tensors() -> None:
+    acoustic_tail = _build_tail(_TailModel().eval(), slots=2, patch_capacity=8)
+    estimate = acoustic_tail._pool_memory_estimate(acoustic_tail._mods_width)
+    assert estimate.total_bytes == acoustic_tail._allocated_pool_bytes()
+    assert estimate.num_slots == 2
+    assert estimate.patch_capacity == 8
+    assert estimate.bytes_per_slot == estimate.total_bytes // 2
+    # note (guozhihao-224): pool bytes scale linearly with slot count at fixed capacity.
+    double = tail.estimate_acoustic_pool_bytes(
+        spec=tail.DotsTtsTailSpec(
+            nfe=NFE,
+            patch_capacity=8,
+            num_slots=4,
+            hidden_patch_size=1,
+            latent_patch_size=PATCH_SIZE,
+            latent_dim=LATENT_DIM,
+            fm_hidden_size=FM_HIDDEN,
+        ),
+        dit_layers=acoustic_tail._dit_layers,
+        dit_heads=acoustic_tail._dit_heads,
+        dit_head_dim=acoustic_tail._dit_head_dim,
+        encoder_layers=acoustic_tail._encoder_layers,
+        encoder_heads=acoustic_tail._encoder_heads,
+        encoder_head_dim=acoustic_tail._encoder_head_dim,
+        encoder_block=acoustic_tail._encoder_block,
+        encoder_conv_channels=int(acoustic_tail._encoder.ds_proj.in_channels),
+        encoder_conv_padding=int(acoustic_tail._encoder.ds_proj.left_padding),
+        mods_width=acoustic_tail._mods_width,
+        dtype=acoustic_tail.dtype,
+    )
+    assert double.total_bytes == 2 * estimate.total_bytes
+
+
+def test_validate_acoustic_pool_memory_rejects_when_vram_is_tight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    estimate = tail.AcousticPoolMemoryEstimate(
+        dit_kv_bytes=8 << 30,
+        encoder_kv_bytes=2 << 30,
+        scratch_bytes=1 << 30,
+        aux_bytes=1 << 30,
+        total_bytes=12 << 30,
+        num_slots=16,
+        patch_capacity=501,
+        nfe=4,
+        dtype=torch.bfloat16,
+    )
+    device = torch.device("cuda:0")
+    monkeypatch.setattr(
+        torch.cuda,
+        "mem_get_info",
+        lambda _device=None: (4 << 30, 80 << 30),
+    )
+    with pytest.raises(ValueError, match="admission failed at startup") as caught:
+        tail.validate_acoustic_pool_memory(estimate, device=device)
+    message = str(caught.value)
+    assert "Parameters are not changed automatically" in message
+    assert "Lower max_running_requests" in message
+
+    # Enough free memory passes.
+    monkeypatch.setattr(
+        torch.cuda,
+        "mem_get_info",
+        lambda _device=None: (40 << 30, 80 << 30),
+    )
+    tail.validate_acoustic_pool_memory(estimate, device=device)
+
+    # Non-CUDA devices skip the gate.
+    tail.validate_acoustic_pool_memory(estimate, device=torch.device("cpu"))
 
 
 def test_permuted_full_pool_matches_fragmented_gather_fallback() -> None:

--- a/tests/unit_test/dots_tts/test_tail.py
+++ b/tests/unit_test/dots_tts/test_tail.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 import pytest
@@ -202,6 +203,7 @@ def test_tail_slots_are_bounded_and_reusable() -> None:
         assert "ran out of slots" in message
         assert "admission failed" in message
         assert "does not silently shrink" in message
+        assert "raise max_running_requests" in message
     else:
         raise AssertionError("slot exhaustion must fail")
     acoustic_tail.release_slot(first)
@@ -256,6 +258,8 @@ def test_validate_acoustic_pool_memory_rejects_when_vram_is_tight(
         dtype=torch.bfloat16,
     )
     device = torch.device("cuda:0")
+    monkeypatch.setattr(torch.cuda, "device", lambda _device: nullcontext())
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: None)
     monkeypatch.setattr(
         torch.cuda,
         "mem_get_info",
@@ -266,6 +270,7 @@ def test_validate_acoustic_pool_memory_rejects_when_vram_is_tight(
     message = str(caught.value)
     assert "Parameters are not changed automatically" in message
     assert "Lower max_running_requests" in message
+    assert "about 4 full-length slot(s)" in message
 
     # Enough free memory passes.
     monkeypatch.setattr(
@@ -277,6 +282,39 @@ def test_validate_acoustic_pool_memory_rejects_when_vram_is_tight(
 
     # Non-CUDA devices skip the gate.
     tail.validate_acoustic_pool_memory(estimate, device=torch.device("cpu"))
+
+
+def test_validate_acoustic_pool_memory_releases_cached_blocks_before_sampling_free_vram(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    estimate = tail.AcousticPoolMemoryEstimate(
+        dit_kv_bytes=10,
+        encoder_kv_bytes=0,
+        scratch_bytes=0,
+        aux_bytes=0,
+        total_bytes=10,
+        num_slots=1,
+        patch_capacity=1,
+        nfe=1,
+        dtype=torch.uint8,
+    )
+    memory = {"free": 10}
+    monkeypatch.setattr(torch.cuda, "device", lambda _device: nullcontext())
+    monkeypatch.setattr(
+        torch.cuda,
+        "empty_cache",
+        lambda: memory.update(free=12),
+    )
+    monkeypatch.setattr(
+        torch.cuda,
+        "mem_get_info",
+        lambda _device=None: (memory["free"], 20),
+    )
+
+    tail.validate_acoustic_pool_memory(
+        estimate,
+        device=torch.device("cuda:0"),
+    )
 
 
 def test_permuted_full_pool_matches_fragmented_gather_fallback() -> None:


### PR DESCRIPTION
## Motivation
Continuous batching eagerly allocates acoustic-tail state as`max_running_requests × (max_generate_length + 1)` full-length DiT / encoder pools. Startup only logged `slots` / `nfe` / `patch_capacity`, with no byte formula and no check against free CUDA memory. On tighter GPUs this either OOMs late or leaves operators guessing which knobs to lower.
`mem_fraction_static` only budgets the SGLang backbone KV cache and does not cover these pools.

This lands the Memory/admission bookkeeping items from #1367: document and log the pool formula, validate against free VRAM before allocate, and make slot-exhaustion a clear admission failure. Parameters are never silently resized. Incremental / bucketed tail-KV allocation is out of scope.

## Modifications
- Add `estimate_acoustic_pool_bytes()` matching `_allocate_pools` shapes (DiT KV, encoder KV, scratch, aux) and `AcousticPoolMemoryEstimate`
- Log estimated GiB breakdown plus `cuda_free` / `cuda_total` before allocate; verify allocated `nbytes` afterward
-  `validate_acoustic_pool_memory()`: fail fast when free VRAM < pools + 15% headroom for graphs/workspace; suggest how many full-length slots would fit
- Clarify live `acquire_slot` exhaustion as an admission error (no under-request resize)
- Cookbook: Memory and capacity section (formula, `mem_fraction_static` scope, which knobs shrink the pool)
- Unit tests for estimate↔allocated nbytes, linear slot scaling, mocked VRAMreject/pass, and admission error wording

## Benchmark
Not a throughput PR. Same-card speed A/B is not the acceptance bar here. H200 startup smoke (`examples/configs/dots_tts.yaml`, GPU1):
| Config | slots × patch_capacity | Estimated pools | Allocated | cuda_free | Result |
| --- | --- | ---: | ---: | ---: | --- |
| default | 16 × 501 | 16.75 GiB (dit_kv 11.03 / encoder_kv 1.47 / scratch 4.23 / aux 0.01) | 16.75 GiB | 110.07 GiB | gate pass |

Estimate matched allocated nbytes. The fail-fast path is covered by a mocked`mem_get_info` unit test (this H200 has enough free VRAM to reject naturally).

## Validation
- `pytest -q tests/unit_test/dots_tts/test_tail.py -k 'not cuda_graph'` — 9 passed
- `pre-commit run --all-files` — clean (if already run on the branch)
- H200 real startup log above: estimate == allocated, gate passes

## Related
- Roadmap #1367


## Checklist
- [x] Format code with repository hooks.
- [x] Add unit tests.
- [ ] Benchmark A/B on the same card class with fixed seed and dataset slice.
  (N/A for this memory/admission PR; startup smoke + unit tests instead.)