### PR TITLE
Prepare SGLang-Omni 0.1.1 for PyPI

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,15 +1,12 @@
-import os
 import sys
 from datetime import datetime
 from pathlib import Path
 
-sys.path.insert(0, os.path.abspath("../.."))
-
 DOCS_PATH = Path(__file__).parent
 ROOT_PATH = DOCS_PATH.parent
+sys.path.insert(0, str(ROOT_PATH))
 
-
-__version__ = "0.1.0"
+from sglang_omni import __version__  # noqa: E402
 
 project = "SGLang"
 copyright = f"2025-{datetime.now().year}, SGLang-Omni"

--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -32,8 +32,10 @@ cd sglang-omni
 uv venv .venv -p 3.12
 source .venv/bin/activate
 
-uv pip install -v -e .   # drop `-e` for a non-editable install
+uv pip install sglang-omni
 ```
+
+The `dev` image is mutable. Pin the image by digest when you need a reproducible environment.
 
 ## 🛠️ Option B: Manual install
 
@@ -45,11 +47,24 @@ Build the prerequisites first:
 Then install:
 
 ```bash
+uv venv .venv -p 3.12
+source .venv/bin/activate
+
+uv pip install sglang-omni
+```
+
+To pin an exact package version, use `uv pip install "sglang-omni==X.Y.Z"`.
+
+### Install from source
+
+For development or testing an unreleased change, install from source:
+
+```bash
 git clone git@github.com:sgl-project/sglang-omni.git
 cd sglang-omni
 
 uv venv .venv -p 3.12
 source .venv/bin/activate
 
-uv pip install -v -e .   # drop `-e` for a non-editable install
+uv pip install -v -e .   # drop -e for a non-editable install
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,14 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "sglang-omni"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Multi-stage pipeline framework for omni models"
 readme = "README.md"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.10,<3.13"
 dependencies = [
     # Core dependencies
@@ -91,6 +92,11 @@ audar-tts = [
 sgl-omni = "sglang_omni.cli:app"
 sgl-omni-router = "sglang_omni_router.serve:main"
 
+[project.urls]
+Documentation = "https://sgl-project.github.io/sglang-omni/"
+Issues = "https://github.com/sgl-project/sglang-omni/issues"
+Repository = "https://github.com/sgl-project/sglang-omni"
+
 [tool.uv]
 override-dependencies = [
     "protobuf>=6.31.1,<7.0.0",
@@ -108,7 +114,11 @@ markers = [
 where = ["."]
 include = ["sglang_omni*"]
 
+[tool.setuptools.dynamic]
+version = {attr = "sglang_omni.__version__"}
+
 # Non-Python data files that must ship with the wheel.
 [tool.setuptools.package-data]
 "sglang_omni.models.fishaudio_s2_pro" = ["fish_speech/configs/*.yaml"]
 "sglang_omni.models.higgs_tts" = ["configs/*.json"]
+"sglang_omni.models.zonos2" = ["moe_configs/*/*.json"]

--- a/sglang_omni/__init__.py
+++ b/sglang_omni/__init__.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 from importlib import import_module
 
-__version__ = "0.1.0"
+# This is the single source for both runtime and distribution metadata. Keep
+# release bumps here; setuptools reads it through tool.setuptools.dynamic.
+__version__ = "0.1.1"
 
 _EXPORTS: dict[str, tuple[str, str]] = {
     # client

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -40,6 +40,7 @@ from fastapi import (
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
+from sglang_omni import __version__
 from sglang_omni.client import (
     Client,
     ClientError,
@@ -211,7 +212,7 @@ def create_app(
     Returns:
         Configured FastAPI application.
     """
-    app = FastAPI(title="sglang-omni", version="0.1.0")
+    app = FastAPI(title="sglang-omni", version=__version__)
 
     app.add_middleware(
         CORSMiddleware,

--- a/sglang_omni_router/app.py
+++ b/sglang_omni_router/app.py
@@ -16,6 +16,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response
 from pydantic import ValidationError
 
+from sglang_omni import __version__
 from sglang_omni.http.admin_auth import (
     make_admin_auth_dependency,
     resolve_admin_api_key,
@@ -172,7 +173,7 @@ def create_app(
 
     resolved_key = resolve_admin_api_key(admin_api_key)
 
-    app = FastAPI(title="sglang-omni-router", version="0.1.0", lifespan=lifespan)
+    app = FastAPI(title="sglang-omni-router", version=__version__, lifespan=lifespan)
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],

--- a/sglang_omni_router/control_plane.py
+++ b/sglang_omni_router/control_plane.py
@@ -27,6 +27,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from pydantic import Field as PydanticField
 
+from sglang_omni import __version__
 from sglang_omni.http.admin_auth import resolve_admin_api_key
 from sglang_omni_router.admission_shm import (
     AdmissionAggregateView,
@@ -276,7 +277,7 @@ def create_control_plane_app(
             if owns_client:
                 await client.aclose()
 
-    app = FastAPI(title="sglang-omni-router-cp", version="0.1.0", lifespan=lifespan)
+    app = FastAPI(title="sglang-omni-router-cp", version=__version__, lifespan=lifespan)
     resolved_key = resolve_admin_api_key(admin_api_key)
 
     @app.get("/live")

--- a/sglang_omni_router/data_plane.py
+++ b/sglang_omni_router/data_plane.py
@@ -26,6 +26,7 @@ from fastapi import Depends, FastAPI, Header, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response
 
+from sglang_omni import __version__
 from sglang_omni.http.admin_auth import resolve_admin_api_key
 from sglang_omni_router.app import (
     _merge_models,
@@ -451,7 +452,7 @@ def create_data_plane_app(
             if forward_client is not None and forward_client is not internal_client:
                 await forward_client.aclose()
 
-    app = FastAPI(title="sglang-omni-router-dp", version="0.1.0", lifespan=lifespan)
+    app = FastAPI(title="sglang-omni-router-dp", version=__version__, lifespan=lifespan)
     # Note (Jiaxin Deng): same external CORS policy as the single-process app;
     # the DP is the public surface.
     app.add_middleware(


### PR DESCRIPTION
## Motivation

SGLang-Omni currently has no PyPI distribution, so downstream deployments cannot install or pin a published package. This prepares `0.1.1` as the first PyPI package while keeping the router in the same distribution.

## Modifications

- Make `sglang_omni.__version__` the single version source for setuptools metadata, Sphinx, the OpenAI-compatible API, and all router process APIs, and bump it to `0.1.1`.
- Include the ZONOS2 tuned H100 MoE JSON in wheel and source distributions alongside the existing Fish Audio and Higgs runtime data.
- Publish current SPDX license metadata and Documentation, Issues, and Repository URLs in the package metadata.
- Update installation instructions to install `sglang-omni` from PyPI by default, retain the existing Docker/manual/source structure, document optional exact-version pinning, and identify the mutable `dev` image.
- Keep `sglang_omni_router` and the `sgl-omni-router` console entry point in the `sglang-omni` wheel; this PR does not create a separate router package or publishing workflow.

## Related Issues

Addresses the PyPI package portion of #1399, Section 1.2.

## Accuracy Test

Not applicable. This PR does not change model execution or output semantics.

## Benchmark & Profiling

Not applicable. This PR does not change inference execution paths.

## Packaging Validation

- `uv run --no-project --isolated --python 3.12 --with build python -m build --outdir /tmp/sglang-omni-pr-0.1.1.9STwfO` built the `0.1.1` wheel and source distribution from the rebased branch.
- `uv run --no-project --isolated --python 3.12 --with twine python -m twine check --strict /tmp/sglang-omni-pr-0.1.1.9STwfO/*` passed for both artifacts.
- Installed the wheel with `uv pip install --no-deps` into a fresh Python 3.12 environment outside the checkout and verified installed version metadata, all three runtime data files, both console entry points, and the bundled router package.
- `uv pip compile pyproject.toml` resolved the dependency set for Python 3.10, 3.11, and 3.12 on both `x86_64-manylinux_2_34` and `aarch64-manylinux_2_34`.

## Checklist

- [x] Format code and documentation with pre-commit.
- [x] Validate the built wheel and source distribution.
- [x] Update installation documentation.
- [x] Accuracy and performance evaluation are not applicable to this packaging-only change.
