### PR TITLE
[CI] Cpuset contention: report it, fail the stage, guard calibration rounds

### DIFF
--- a/.claude/skills/tune-ci-thresholds/OPERATIONS.md
+++ b/.claude/skills/tune-ci-thresholds/OPERATIONS.md
@@ -110,6 +110,20 @@ bash .claude/skills/tune-ci-thresholds/watch_calibration_servers.sh \
   <gpu-group> <group-run-1> [<group-run-2> ...]
 ```
 
+Tab C — cpuset foreign-load supervisor (one per calibration cpuset):
+
+```bash
+bash .claude/skills/tune-ci-thresholds/watch_calibration_cpuset.sh \
+  <cpuset-spec> [interval-s]
+```
+
+Tab C shows the reserved cores' busy fraction so the operator sees an
+intrusion as it happens. Enforcement does not depend on it: `tune.py` waits
+before each launch while the cpuset carries foreign load, and a round whose
+in-session sampler reports a foreign peak above the contention limit is
+discarded and re-run after the cpuset clears, without touching completed
+rounds.
+
 Behavior:
 
 - Resolves the active pytest from its process and `--basetemp`.

--- a/.claude/skills/tune-ci-thresholds/tune.py
+++ b/.claude/skills/tune-ci-thresholds/tune.py
@@ -342,6 +342,19 @@ def resolve_repo_root(host: dict | None) -> Path:
 
 
 _CPUSET_BUSY_WARN = 0.20
+_CPUSET_BUSY_RECHECK_S = 30.0
+_CPUSET_BUSY_WAIT_MAX_S = 900.0
+# note (Jiaxin Deng): keep in sync with FAIL_FOREIGN_CORES in
+# tests/utils/ci_cpu_contention.py; above this the round measured the
+# intruder, not the model.
+_CONTENTION_FAIL_CORES = 2.0
+
+
+def contention_peak_from_log(text: str) -> float | None:
+    peaks = re.findall(r"\[cpuset-contention\] \S+ windows=\d+ "
+                       r"foreign-cores mean=[0-9.]+ max=([0-9.]+)", text)
+    return float(peaks[-1]) if peaks else None
+
 
 
 def cpuset_external_busy(cpuset: str, interval: float = 1.0) -> float | None:
@@ -3274,10 +3287,19 @@ def _run_shared(test_path, stage_keys, all_stages, out, k, py, total, gpus_neede
         if cpuset:
             env["OMNI_CI_CPUSET"] = cpuset
             cpuset_busy = cpuset_external_busy(cpuset)
+            waited = 0.0
+            while (cpuset_busy is not None and cpuset_busy > _CPUSET_BUSY_WARN
+                   and waited < _CPUSET_BUSY_WAIT_MAX_S):
+                print(f"{label} cpuset {cpuset} is {cpuset_busy:.0%} busy with "
+                      f"foreign load — waiting for it to clear "
+                      f"({int(waited)}s/{int(_CPUSET_BUSY_WAIT_MAX_S)}s)")
+                time.sleep(_CPUSET_BUSY_RECHECK_S)
+                waited += _CPUSET_BUSY_RECHECK_S
+                cpuset_busy = cpuset_external_busy(cpuset)
             if cpuset_busy is not None and cpuset_busy > _CPUSET_BUSY_WARN:
-                print(f"{label} WARNING: cpuset {cpuset} is {cpuset_busy:.0%} "
-                      f"busy with foreign load before launch — this round may "
-                      f"be contaminated")
+                print(f"{label} WARNING: cpuset {cpuset} still {cpuset_busy:.0%} "
+                      f"busy after {int(waited)}s — launching anyway; the round "
+                      f"is rejected if contention persists")
         print(f"{label} using GPU(s) {picked} "
               f"(CUDA_VISIBLE_DEVICES={env['CUDA_VISIBLE_DEVICES']}, "
               f"OMNI_CI_CPUSET={cpuset or 'unset'}, "
@@ -3311,6 +3333,26 @@ def _run_shared(test_path, stage_keys, all_stages, out, k, py, total, gpus_neede
             break
         dur = time.monotonic() - t0
         text = log.read_text(errors="replace")
+        contention_peak = contention_peak_from_log(text)
+        if (contention_peak is not None
+                and contention_peak > _CONTENTION_FAIL_CORES):
+            status = "failed"
+            reason = f"cpuset_contention (peak {contention_peak:.2f} cores)"
+            attempt_history.append(dict(
+                attempt=attempts, status=status, reason=reason,
+                duration_s=round(dur, 2), pytest_rc=pytest_rc,
+                gpu_indices=list(picked), cpuset=cpuset,
+                cpuset_busy_prelaunch=cpuset_busy))
+            if attempts < _MAX_RUN_ATTEMPTS:
+                print(f"{label} {reason} — round discarded; waiting for the "
+                      f"cpuset to clear, then re-running this round")
+                if not _ensure_gpus_free(
+                    gpus_needed, host=host, target_gpus=list(picked)
+                ):
+                    status, reason = "failed", "GPU memory not released before retry"
+                    break
+                continue
+            break
         if pytest_rc == 0:
             status, reason = "ok", ""
             attempt_history.append(dict(

--- a/.claude/skills/tune-ci-thresholds/watch_calibration_cpuset.sh
+++ b/.claude/skills/tune-ci-thresholds/watch_calibration_cpuset.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Tab C: foreign-load supervisor for a calibration cpuset.
+# usage: watch_calibration_cpuset.sh <cpuset-spec> [interval-s]
+# One line per interval with the cpuset's total busy fraction. During the
+# idle gap between rounds any busy is foreign; during a round the pytest
+# session's own sampler separates foreign load in its end-of-run summary.
+set -u
+SPEC="${1:?usage: watch_calibration_cpuset.sh <cpuset-spec> [interval-s]}"
+INTERVAL="${2:-10}"
+exec python3 - "$SPEC" "$INTERVAL" <<'PY'
+import sys, time
+
+spec, interval = sys.argv[1], float(sys.argv[2])
+cpus = set()
+for part in spec.split(","):
+    lo, _, hi = part.partition("-")
+    cpus.update(range(int(lo), int(hi or lo) + 1))
+
+
+def snap():
+    vals = {}
+    with open("/proc/stat") as f:
+        for line in f:
+            if line.startswith("cpu") and line[3:4].isdigit():
+                p = line.split()
+                idx = int(p[0][3:])
+                if idx in cpus:
+                    n = list(map(int, p[1:]))
+                    vals[idx] = (sum(n), n[3] + n[4])
+    return vals
+
+
+prev = snap()
+while True:
+    time.sleep(interval)
+    cur = snap()
+    tot = sum(cur[i][0] - prev[i][0] for i in cur if i in prev)
+    idle = sum(cur[i][1] - prev[i][1] for i in cur if i in prev)
+    busy = 1 - idle / tot if tot else 0.0
+    flag = "  <-- BUSY" if busy > 0.2 else ""
+    print(f"[{time.strftime('%H:%M:%S')}] cpuset {spec} busy {busy:5.1%}{flag}",
+          flush=True)
+    prev = cur
+PY

--- a/tests/test_model/conftest.py
+++ b/tests/test_model/conftest.py
@@ -56,15 +56,38 @@ def _apply_omni_ci_cpuset() -> set[int] | None:
 
 
 @pytest.fixture(autouse=True, scope="session")
-def pin_omni_ci_cpuset() -> None:
+def pin_omni_ci_cpuset() -> "Generator[None, None, None]":
     """Pin the test session, and every server it spawns, to OMNI_CI_CPUSET.
 
     The gates in this directory measure host-bound serving stacks, so on a
     shared runner concurrent jobs inflate per-request CPU cost and shift
     calibrated floors. Child processes inherit the affinity, which keeps the
     managed router, its workers, and the bench client on the reserved cores.
+    Pinning restrains only this session, so a contention sampler reports
+    foreign load on the reserved cores at session end. On CI heavy intrusion
+    fails the session after results are written, so the stage retry
+    re-measures on a clean window instead of gating on polluted numbers;
+    calibration handles the same signal itself by rejecting the round.
     """
-    _apply_omni_ci_cpuset()
+    cpus = _apply_omni_ci_cpuset()
+    if cpus is None:
+        yield
+        return
+    from tests.utils.ci_cpu_contention import FAIL_FOREIGN_CORES, ContentionSampler
+
+    sampler = ContentionSampler(cpus)
+    sampler.start()
+    try:
+        yield
+    finally:
+        sampler.stop()
+        print(sampler.summary())
+        peak = sampler.peak_foreign_cores()
+        if os.environ.get("GITHUB_ACTIONS") == "true" and peak > FAIL_FOREIGN_CORES:
+            pytest.fail(
+                f"cpuset contention: foreign load peaked at {peak:.2f} cores "
+                f"on the pinned cpuset; failing so the stage retry re-measures"
+            )
 
 
 TTS_ALLOWED_CONCURRENCIES = (1, 2, 4, 8, 16)

--- a/tests/unit_test/ci/test_cpu_contention.py
+++ b/tests/unit_test/ci/test_cpu_contention.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the cpuset contention sampler."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.utils.ci_cpu_contention import (
+    ContentionSampler,
+    _parse_cpu_list,
+    _Proc,
+    _tree_pids,
+    foreign_ticks,
+)
+
+
+def test_parse_cpu_list_ranges_and_singles():
+    assert _parse_cpu_list("48-51,112") == {48, 49, 50, 51, 112}
+
+
+def test_tree_pids_follows_descendants_only():
+    procs = {
+        1: _Proc(ppid=0, ticks=0, overlaps=True),
+        10: _Proc(ppid=1, ticks=0, overlaps=True),
+        20: _Proc(ppid=10, ticks=0, overlaps=True),
+        30: _Proc(ppid=20, ticks=0, overlaps=True),
+        99: _Proc(ppid=1, ticks=0, overlaps=True),
+    }
+    assert _tree_pids(procs, 10) == {10, 20, 30}
+
+
+def test_foreign_ticks_charges_overlapping_outsiders_only():
+    prev = {
+        10: _Proc(ppid=1, ticks=100, overlaps=True),
+        50: _Proc(ppid=1, ticks=100, overlaps=True),
+        60: _Proc(ppid=1, ticks=100, overlaps=False),
+    }
+    cur = {
+        10: _Proc(ppid=1, ticks=500, overlaps=True),
+        50: _Proc(ppid=1, ticks=300, overlaps=True),
+        60: _Proc(ppid=1, ticks=900, overlaps=False),
+        70: _Proc(ppid=1, ticks=999, overlaps=True),
+    }
+    # note (Jiaxin Deng): 10 is in-tree, 60 does not overlap, 70 lacks a
+    # baseline; only pid 50 may be charged.
+    assert foreign_ticks(prev, cur, tree={10}) == 200
+
+
+@pytest.mark.skipif(not os.path.isdir("/proc"), reason="requires Linux procfs")
+def test_sampler_smoke_produces_summary():
+    sampler = ContentionSampler({0, 1}, interval_s=0.2)
+    sampler.start()
+    import time
+
+    time.sleep(0.7)
+    sampler.stop()
+    assert "[cpuset-contention]" in sampler.summary()

--- a/tests/utils/ci_cpu_contention.py
+++ b/tests/utils/ci_cpu_contention.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Report foreign CPU load on the pinned OMNI_CI_CPUSET during a session.
+
+Affinity is self-restraint, not a reservation: an unpinned process can still
+be scheduled onto the reserved cores and inflate what a perf gate measures.
+This sampler makes that attributable: each interval it charges CPU time
+consumed on the pinned cores by processes outside the session tree, and the
+fixture prints a summary so a failed speed gate can be triaged from the log.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from dataclasses import dataclass
+
+_SAMPLE_INTERVAL_S = 30.0
+_WARN_FOREIGN_CORES = 1.0
+# note (Jiaxin Deng): above this, the session's speed numbers describe the
+# intruder, not the model; CI fails the stage so its retry re-measures.
+FAIL_FOREIGN_CORES = 2.0
+
+
+@dataclass
+class _Proc:
+    ppid: int
+    ticks: int
+    overlaps: bool
+
+
+def _parse_cpu_list(spec: str) -> set[int]:
+    cpus: set[int] = set()
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        lo_text, _, hi_text = part.partition("-")
+        cpus.update(range(int(lo_text), int(hi_text or lo_text) + 1))
+    return cpus
+
+
+def _snapshot(cpuset: set[int]) -> dict[int, _Proc]:
+    procs: dict[int, _Proc] = {}
+    for entry in os.listdir("/proc"):
+        if not entry.isdigit():
+            continue
+        pid = int(entry)
+        try:
+            with open(f"/proc/{pid}/stat", "rb") as f:
+                data = f.read().decode("ascii", "replace")
+            rest = data[data.rindex(")") + 2 :].split()
+            ppid = int(rest[1])
+            ticks = int(rest[11]) + int(rest[12])
+            allowed = ""
+            with open(f"/proc/{pid}/status", encoding="ascii", errors="replace") as f:
+                for line in f:
+                    if line.startswith("Cpus_allowed_list"):
+                        allowed = line.split(":", 1)[1].strip()
+                        break
+            # note (Jiaxin Deng): an unreadable mask counts as overlapping;
+            # a false positive beats an invisible intruder in this report.
+            overlaps = bool(cpuset & _parse_cpu_list(allowed)) if allowed else True
+            procs[pid] = _Proc(ppid, ticks, overlaps)
+        except (OSError, ValueError):
+            continue
+    return procs
+
+
+def _tree_pids(procs: dict[int, _Proc], root: int) -> set[int]:
+    children: dict[int, list[int]] = {}
+    for pid, proc in procs.items():
+        children.setdefault(proc.ppid, []).append(pid)
+    tree, queue = {root}, [root]
+    while queue:
+        for child in children.get(queue.pop(), ()):
+            if child not in tree:
+                tree.add(child)
+                queue.append(child)
+    return tree
+
+
+def foreign_ticks(prev: dict[int, _Proc], cur: dict[int, _Proc], tree: set[int]) -> int:
+    return sum(
+        cur[pid].ticks - prev[pid].ticks
+        for pid in cur
+        if pid in prev and cur[pid].overlaps and pid not in tree
+    )
+
+
+class ContentionSampler:
+    """Background sampler; start() before the session, summary() after."""
+
+    def __init__(self, cpuset: set[int], interval_s: float = _SAMPLE_INTERVAL_S):
+        self._cpuset = set(cpuset)
+        self._interval = interval_s
+        self._root = os.getpid()
+        self._hz = os.sysconf("SC_CLK_TCK")
+        self._samples: list[float] = []
+        self._errors = 0
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=5)
+
+    def peak_foreign_cores(self) -> float:
+        return max(self._samples, default=0.0)
+
+    def _loop(self) -> None:
+        prev = _snapshot(self._cpuset)
+        prev_t = time.monotonic()
+        while not self._stop.wait(self._interval):
+            try:
+                cur = _snapshot(self._cpuset)
+                now = time.monotonic()
+                tree = _tree_pids(cur, self._root)
+                cores = foreign_ticks(prev, cur, tree) / self._hz / (now - prev_t)
+                self._samples.append(cores)
+                prev, prev_t = cur, now
+            except Exception:
+                self._errors += 1
+
+    def summary(self) -> str:
+        spec = ",".join(map(str, sorted(self._cpuset)))
+        if not self._samples:
+            return (
+                f"[cpuset-contention] cpuset={spec} no completed sample "
+                f"windows (errors={self._errors})"
+            )
+        mean = sum(self._samples) / len(self._samples)
+        peak = max(self._samples)
+        lines = [
+            f"[cpuset-contention] cpuset={spec} windows={len(self._samples)} "
+            f"foreign-cores mean={mean:.2f} max={peak:.2f} errors={self._errors}"
+        ]
+        if peak > _WARN_FOREIGN_CORES:
+            lines.append(
+                f"[cpuset-contention] WARNING: foreign load peaked at "
+                f"{peak:.2f} cores on the pinned cpuset; speed metrics in "
+                f"this session may be inflated by contention"
+            )
+        return "\n".join(lines)


### PR DESCRIPTION
Implements the mechanism agreed in the group discussion (report alone is not enough; intrusion should fail CI, and calibration should wait and re-run the affected round). Built on one sampler, applied in three layers:

1. **Report (all pinned sessions)**: a daemon sampler (30s interval) walks /proc and charges CPU time consumed on the pinned cores by processes outside the session tree. Session end prints one greppable line:
```
[cpuset-contention] cpuset=48-63,112-127 windows=42 foreign-cores mean=0.03 max=0.85 errors=0
```
2. **CI fails the stage**: on GitHub Actions, a foreign peak above 2 cores fails the session in fixture teardown, after test results are written. The stage's existing 3-attempt retry then re-measures on a clean window instead of gating on polluted numbers.
3. **Calibration waits and re-runs the round**: tune.py now waits before each launch while the cpuset carries foreign load (30s recheck, 15 min cap), and a round whose in-session peak crossed the limit is discarded and re-run after the cpuset clears, without touching completed rounds. A new Tab C watcher (`watch_calibration_cpuset.sh`) gives the operator a live view of the reserved cores.

No behavior change when `OMNI_CI_CPUSET` is unset. Sampling is read-only /proc traversal every 30s, well under 0.1 percent of one core, from the pytest process (the measured servers live in separate processes).

Unit tests cover cpu-list parsing, the process-tree walk, foreign-tick accounting, and a Linux sampler smoke; the contention-peak log parser is exercised against real summary lines.