### PR TITLE
build: make Descript codecs model-specific

### DIFF
--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -10,6 +10,10 @@ Install `sglang-omni` by following [Installation](../get_started/installation.md
 hf download fishaudio/s2-pro
 ```
 
+Fish Audio also requires its model-specific DAC dependencies. Complete the
+[Fish Audio S2-Pro prerequisites](../cookbook/fishaudio_s2_pro.md#prerequisites)
+before starting the server.
+
 Qwen3-TTS uses the upstream `qwen-tts` package. Install it without dependencies
 so the SGLang-Omni Transformers 5.12 / SGLang 0.5.16 stack remains in place:
 

--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -10,7 +10,7 @@ Install `sglang-omni` by following [Installation](../get_started/installation.md
 hf download fishaudio/s2-pro
 ```
 
-Fish Audio also requires its model-specific DAC dependencies. Complete the
+Fish Audio requires its model-specific DAC dependencies. Complete the
 [Fish Audio S2-Pro prerequisites](../cookbook/fishaudio_s2_pro.md#prerequisites)
 before starting the server.
 

--- a/docs/cookbook/fishaudio_s2_pro.md
+++ b/docs/cookbook/fishaudio_s2_pro.md
@@ -4,7 +4,19 @@
 
 ## Prerequisites
 
-Install `sglang-omni` by following [Installation](../get_started/installation.md), then download the model:
+Install `sglang-omni` by following [Installation](../get_started/installation.md).
+
+Fish Audio uses the Descript DAC codec, which is not included in the base
+`sglang-omni` package. From the SGLang-Omni repository root, install its
+model-specific dependencies:
+
+```bash
+uv pip install \
+  "descript-audiotools==0.7.2" \
+  "descript-audio-codec==1.0.0"
+```
+
+Then download the model:
 
 ```bash
 hf download fishaudio/s2-pro

--- a/docs/cookbook/zonos2.md
+++ b/docs/cookbook/zonos2.md
@@ -11,16 +11,27 @@ vocoder` pipeline and is served through the OpenAI-compatible
 
 ## Prerequisites
 
-Install `sglang-omni` by following [Installation](../get_started/installation.md), then
-download the model:
+Install `sglang-omni` by following [Installation](../get_started/installation.md).
+
+ZONOS2 uses the Descript DAC codec, which is not included in the base
+`sglang-omni` package. From the SGLang-Omni repository root, install its
+model-specific dependencies:
+
+```bash
+uv pip install \
+  "descript-audiotools==0.7.2" \
+  "descript-audio-codec==1.0.0"
+```
+
+Then download the model:
 
 ```bash
 hf download Zyphra/zonos2
 ```
 
-The processor ships with the checkpoint, so no extra TTS package is needed. Voice cloning
-transcodes reference audio (file, URL, or base64 data-URI) with **ffmpeg**, so `ffmpeg` must
-be on the server's `PATH` (e.g. `apt-get install ffmpeg`).
+The processor ships with the checkpoint. Voice cloning transcodes reference audio
+(file, URL, or base64 data-URI) with **ffmpeg**, so `ffmpeg` must be on the
+server's `PATH` (e.g. `apt-get install ffmpeg`).
 
 ## Server Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,6 @@ dependencies = [
     "tiktoken",
     "hydra-core",
     "omegaconf",
-    "descript-audiotools",
-    "descript-audio-codec==1.0.0",
     "torchaudio==2.11.0",
     "torchcodec==0.11.1",     # Matches torch 2.11.x / sglang 0.5.16
     # Gradio playground


### PR DESCRIPTION
## Motivation

A clean installation of the release wheel cannot resolve its declared dependencies: `sglang==0.5.16` requires Protobuf 6, while `descript-audiotools==0.7.2` requires Protobuf below 3.20. The repository's uv override does not become part of the published wheel metadata.

Keep the base `sglang-omni` package installable and make the Descript DAC dependencies explicit only for the Fish Audio and ZONOS2 models that use them.

## Modifications

- Remove `descript-audiotools` and `descript-audio-codec` from the base package dependencies.
- Document the pinned, model-specific DAC installation commands in the Fish Audio and ZONOS2 cookbooks.
- Link the Fish Audio prerequisites from the TTS usage guide and clarify the ZONOS2 prerequisite wording.
- Leave model implementations, CI, Docker configuration, and the lockfile unchanged.

## Related Issues

Part of #1399.

## Validation

- Built the 0.1.1 wheel and source distribution with `uv build`.
- Passed `twine check --strict` for both artifacts.
- Verified the wheel metadata contains version 0.1.1 and no Descript dependency declarations.
- Resolved a clean Python 3.12 Linux installation from the wheel with repository configuration disabled.
- Built the documentation with Sphinx warnings treated as errors.
- Passed the repository pre-commit hooks for this commit.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Unit tests, accuracy evaluation, and performance benchmarks are not applicable because this changes package metadata and documentation only.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the `run-ci` label. This change does not modify model execution paths; existing Fish Audio and ZONOS2 imports remain lazy.
