### PR TITLE
[dots.tts] Fix non-deterministic reference encoding; add parity-safe batched reference encode

### DIFF
--- a/examples/configs/dots_tts.yaml
+++ b/examples/configs/dots_tts.yaml
@@ -1,6 +1,10 @@
 config_cls: DotsTTSPipelineConfig
 model_path: dots-studio/dots.tts-mf
 runtime_overrides:
+  reference_encode:
+    max_concurrency: 8
+    max_batch_size: 1
+    max_batch_wait_ms: 4
   latent_engine:
     optimize: true
     num_steps: 4

--- a/sglang_omni/models/dots_tts/codec.py
+++ b/sglang_omni/models/dots_tts/codec.py
@@ -235,7 +235,11 @@ class _DotsReferenceHook(KeyedReferenceEncodeHook[str, dict, dict]):
         return self.codec.encode_reference(item)
 
     def can_encode_batch(self) -> bool:
-        return True
+        if self.codec.device.type != "cuda":
+            return True
+        return not (
+            torch.backends.cuda.matmul.allow_tf32 or torch.backends.cudnn.allow_tf32
+        )
 
     def encode_batch(self, items: list[str]) -> list[dict]:
         return self.codec.encode_reference_batch(list(items))

--- a/sglang_omni/models/dots_tts/codec.py
+++ b/sglang_omni/models/dots_tts/codec.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import json
+import logging
 import math
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import torch
@@ -27,6 +29,8 @@ from sglang_omni.scheduling.reference_encoder import (
 )
 from sglang_omni.utils.audio import load_audio
 from sglang_omni.utils.checkpoint import resolve_checkpoint
+
+logger = logging.getLogger(__name__)
 
 
 def _load_module(module: torch.nn.Module, path: Path) -> None:
@@ -67,8 +71,11 @@ class DotsAudioCodec:
         self.device = torch.device(device)
         self.lock = threading.RLock()
 
-    @torch.inference_mode()
-    def encode_reference(self, path: str) -> dict[str, torch.Tensor]:
+    @staticmethod
+    def _reference_load_workers(count: int) -> int:
+        return max(1, min(int(count), 8))
+
+    def _load_reference_waveform(self, path: str) -> torch.Tensor:
         waveform = load_audio(
             path,
             source_name="dots.tts reference",
@@ -84,14 +91,103 @@ class DotsAudioCodec:
         audio = torch.as_tensor(waveform, dtype=torch.float32).reshape(1, -1)
         samples_per_patch = self.patch_size * self.hop_size
         target = math.ceil(audio.shape[-1] / samples_per_patch) * samples_per_patch
-        audio = F.pad(audio, (0, target - audio.shape[-1])).to(self.device)
+        return F.pad(audio, (0, target - audio.shape[-1]))
+
+    @torch.inference_mode()
+    def _encode_waveforms(
+        self, waveforms: list[torch.Tensor]
+    ) -> list[dict[str, torch.Tensor]]:
+        if not waveforms:
+            return []
+        lengths = {int(w.shape[-1]) for w in waveforms}
+        if len(lengths) != 1:
+            raise ValueError(
+                "dots.tts batched reference encode requires equal-length "
+                f"waveforms, got {sorted(lengths)}; padding is not parity-safe"
+            )
+        length = lengths.pop()
+        batch = torch.stack([w.reshape(-1) for w in waveforms]).unsqueeze(1)
+        batch = batch.to(self.device)
+        audio_lengths = torch.full(
+            (len(waveforms),), length, dtype=torch.long, device=self.device
+        )
+        speaker_batch, speaker_lengths = self._speaker_input(batch, audio_lengths)
+
         with self.lock:
-            speaker = self.speaker(audio.unsqueeze(0))
-            latent_distribution = self.inference.extract_latents(audio.unsqueeze(0))
-        return {
-            "speaker_embedding": speaker.detach().cpu().float(),
-            "latent_distribution": latent_distribution.detach().cpu().float(),
-        }
+            speaker = self.speaker(speaker_batch, audio_lengths=speaker_lengths)
+            latent_distribution = self.inference.extract_latents(batch)
+
+        frames = int(latent_distribution.shape[-1])
+        expected_frames = length // self.hop_size
+        if frames != expected_frames:
+            raise RuntimeError(
+                "dots.tts reference encode produced "
+                f"{frames} latent frames for {length} samples, expected "
+                f"{expected_frames}; latent frame rate is not hop-aligned"
+            )
+        return [
+            {
+                "speaker_embedding": speaker[index : index + 1].detach().cpu().float(),
+                "latent_distribution": latent_distribution[index : index + 1]
+                .detach()
+                .cpu()
+                .float(),
+            }
+            for index in range(len(waveforms))
+        ]
+
+    def _speaker_input(
+        self, batch: torch.Tensor, audio_lengths: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Use deterministic speaker cropping for long references.
+
+        Pre-truncate to the leading window to avoid upstream global-RNG crop;
+        AudioVAE latents still use full-length audio.
+        """
+        limit = self._speaker_sample_limit()
+        if limit is None or batch.shape[-1] <= limit:
+            return batch, audio_lengths
+        cropped = batch[..., :limit].contiguous()
+        return cropped, audio_lengths.clamp(max=limit)
+
+    def _speaker_sample_limit(self) -> int | None:
+        """Samples the speaker encoder keeps, or ``None`` if it never crops."""
+        max_seconds = float(getattr(self.speaker, "max_audio_seconds", 0.0) or 0.0)
+        if max_seconds <= 0:
+            return None
+        rate = int(getattr(self.speaker, "sample_rate", self.sample_rate))
+        return round(rate * max_seconds)
+
+    def encode_reference(self, path: str) -> dict[str, torch.Tensor]:
+        return self._encode_waveforms([self._load_reference_waveform(path)])[0]
+
+    def encode_reference_batch(self, paths: list[str]) -> list[dict[str, torch.Tensor]]:
+        if not paths:
+            return []
+        if len(paths) == 1:
+            return [self.encode_reference(paths[0])]
+
+        with ThreadPoolExecutor(
+            max_workers=self._reference_load_workers(len(paths)),
+            thread_name_prefix="dots-ref-load",
+        ) as pool:
+            waveforms = list(pool.map(self._load_reference_waveform, paths))
+
+        results: list[dict[str, torch.Tensor] | None] = [None] * len(paths)
+        for group in self._length_groups(waveforms).values():
+            encoded = self._encode_waveforms([waveforms[i] for i in group])
+            for index, artifact in zip(group, encoded):
+                results[index] = artifact
+        if any(item is None for item in results):
+            raise RuntimeError("dots.tts batched reference encode dropped an item")
+        return [item for item in results if item is not None]
+
+    @staticmethod
+    def _length_groups(waveforms: list[torch.Tensor]) -> dict[int, list[int]]:
+        groups: dict[int, list[int]] = {}
+        for index, waveform in enumerate(waveforms):
+            groups.setdefault(int(waveform.shape[-1]), []).append(index)
+        return groups
 
     def sample_prompt_latents(
         self, latent_distribution: torch.Tensor, *, seed: int | None
@@ -138,6 +234,12 @@ class _DotsReferenceHook(KeyedReferenceEncodeHook[str, dict, dict]):
     def encode_one(self, item: str) -> dict:
         return self.codec.encode_reference(item)
 
+    def can_encode_batch(self) -> bool:
+        return True
+
+    def encode_batch(self, items: list[str]) -> list[dict]:
+        return self.codec.encode_reference_batch(list(items))
+
     @staticmethod
     def store_artifact(artifact: dict) -> dict:
         return {
@@ -151,14 +253,34 @@ class _DotsReferenceHook(KeyedReferenceEncodeHook[str, dict, dict]):
 
 
 class DotsReferenceEncoder:
-    def __init__(self, codec: DotsAudioCodec, *, model_id: str) -> None:
+    def __init__(
+        self,
+        codec: DotsAudioCodec,
+        *,
+        model_id: str,
+        max_batch_size: int = 1,
+        max_batch_wait_ms: float = 0.0,
+    ) -> None:
         self.codec = codec
         self.service = ReferenceEncodeService(
             _DotsReferenceHook(codec, model_id=model_id),
             max_items=256,
             max_bytes=64 * 1024 * 1024,
             log_prefix="dots.tts",
+            max_batch_size=max_batch_size,
+            max_batch_wait_ms=max_batch_wait_ms,
+            batch_worker_name="dots-ref-encode-batch",
         )
+        logger.info(
+            "dots.tts reference encode backend: %s (max_batch_size=%d, "
+            "max_batch_wait_ms=%g)",
+            "coalesced batch" if self.service.batching_enabled else "per-request",
+            max_batch_size,
+            max_batch_wait_ms,
+        )
+
+    def close(self) -> None:
+        self.service.close()
 
     def encode_payload(self, payload: StagePayload) -> StagePayload:
         state = load_dots_tts_state(payload)

--- a/sglang_omni/models/dots_tts/stages.py
+++ b/sglang_omni/models/dots_tts/stages.py
@@ -369,7 +369,7 @@ def create_reference_encode_executor(
     device: str | None = "cuda",
     gpu_id: int | None = None,
     max_concurrency: int = 8,
-    max_batch_size: int = 8,
+    max_batch_size: int = 1,
     max_batch_wait_ms: float = 4.0,
 ) -> SimpleScheduler:
     worker_device = _device(device, gpu_id)
@@ -380,7 +380,11 @@ def create_reference_encode_executor(
         max_batch_size=max_batch_size,
         max_batch_wait_ms=max_batch_wait_ms,
     )
-    return SimpleScheduler(encoder.encode_payload, max_concurrency=max_concurrency)
+    return SimpleScheduler(
+        encoder.encode_payload,
+        max_concurrency=max_concurrency,
+        shutdown_callback=encoder.close,
+    )
 
 
 def create_sglang_latent_engine_executor(

--- a/sglang_omni/models/dots_tts/stages.py
+++ b/sglang_omni/models/dots_tts/stages.py
@@ -368,11 +368,18 @@ def create_reference_encode_executor(
     *,
     device: str | None = "cuda",
     gpu_id: int | None = None,
-    max_concurrency: int = 1,
+    max_concurrency: int = 8,
+    max_batch_size: int = 8,
+    max_batch_wait_ms: float = 4.0,
 ) -> SimpleScheduler:
     worker_device = _device(device, gpu_id)
     codec = load_dots_audio_codec(model_path, device=worker_device)
-    encoder = DotsReferenceEncoder(codec, model_id=str(model_path))
+    encoder = DotsReferenceEncoder(
+        codec,
+        model_id=str(model_path),
+        max_batch_size=max_batch_size,
+        max_batch_wait_ms=max_batch_wait_ms,
+    )
     return SimpleScheduler(encoder.encode_payload, max_concurrency=max_concurrency)
 
 

--- a/sglang_omni/scheduling/reference_encoder.py
+++ b/sglang_omni/scheduling/reference_encoder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import concurrent.futures
 import json
 import logging
+import queue as _queue_mod
 import threading
 import time
 from dataclasses import asdict, dataclass
@@ -53,8 +54,10 @@ class ReferenceEncodeHook(Generic[InputT, ArtifactT, StoredT]):
     def revalidate(self, item: InputT, key: ReferenceEncodeKey) -> bool:
         return True
 
+    def can_encode_batch(self) -> bool:
+        return False
+
     def encode_batch(self, items: list[InputT]) -> list[ArtifactT]:
-        """Reserved; ReferenceEncodeService does not call this until batching."""
         return [self.encode_one(item) for item in items]
 
 
@@ -135,11 +138,18 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
         max_bytes: int | None = 64 * 1024 * 1024,
         timeout_s: float = 130.0,
         log_prefix: str | None = None,
+        max_batch_size: int = 1,
+        max_batch_wait_ms: float = 0.0,
+        batch_worker_name: str = "reference-encode-batch",
     ) -> None:
         if max_items is not None and max_items < 1:
             raise ValueError(f"max_items must be >= 1, got {max_items}")
         if max_bytes is not None and max_bytes < 1:
             raise ValueError(f"max_bytes must be >= 1, got {max_bytes}")
+        if max_batch_size < 1:
+            raise ValueError(f"max_batch_size must be >= 1, got {max_batch_size}")
+        if max_batch_wait_ms < 0:
+            raise ValueError(f"max_batch_wait_ms must be >= 0, got {max_batch_wait_ms}")
         self._hook = hook
         self._cache = StageOutputCache(max_size=max_items, max_bytes=max_bytes)
         self._timeout_s = float(timeout_s)
@@ -151,12 +161,141 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
         self._merged = 0
         self._failed = 0
         self._uncacheable = 0
+        self._batches = 0
+        self._batched_items = 0
         self._last_log_time = 0.0
 
+        # Only distinct cache-miss leaders reach the queue; hits and same-key
+        # followers resolve first, so batching preserves lookup order/single-flight.
+        self._max_batch_size = int(max_batch_size)
+        self._max_batch_wait_s = float(max_batch_wait_ms) / 1000.0
+        self._batching = self._max_batch_size > 1 and bool(hook.can_encode_batch())
+        self._batch_queue: (
+            _queue_mod.Queue[tuple[InputT, concurrent.futures.Future[ArtifactT]] | None]
+            | None
+        ) = None
+        self._batch_thread: threading.Thread | None = None
+        if self._batching:
+            self._batch_queue = _queue_mod.Queue()
+            self._batch_thread = threading.Thread(
+                target=self._batch_worker,
+                name=batch_worker_name,
+                daemon=True,
+            )
+            self._batch_thread.start()
+
+    @property
+    def batching_enabled(self) -> bool:
+        return self._batching
+
     def close(self) -> None:
+        if self._batch_queue is not None:
+            self._batch_queue.put(None)
+        thread = self._batch_thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=5.0)
         close = getattr(self._hook, "close", None)
         if callable(close):
             close()
+
+    def _encode_leader(self, item: InputT) -> ArtifactT:
+        if self._batch_queue is None:
+            return self._hook.encode_one(item)
+        future: concurrent.futures.Future[ArtifactT] = concurrent.futures.Future()
+        self._batch_queue.put((item, future))
+        return future.result(timeout=self._timeout_s)
+
+    def _drain_batch(
+        self,
+    ) -> tuple[list[tuple[InputT, concurrent.futures.Future[ArtifactT]]], bool]:
+        assert self._batch_queue is not None
+        first = self._batch_queue.get()
+        if first is None:
+            return [], True
+        batch = [first]
+        deadline = time.monotonic() + self._max_batch_wait_s
+        while len(batch) < self._max_batch_size:
+            try:
+                entry = self._batch_queue.get_nowait()
+            except _queue_mod.Empty:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                try:
+                    entry = self._batch_queue.get(timeout=remaining)
+                except _queue_mod.Empty:
+                    break
+            if entry is None:
+                return batch, True
+            batch.append(entry)
+        return batch, False
+
+    def _batch_worker(self) -> None:
+        while True:
+            try:
+                batch, stopping = self._drain_batch()
+            except Exception:
+                logger.exception("reference encode batch worker: drain failed")
+                continue
+            if batch:
+                try:
+                    results: list[Any] = self._encode_batch([item for item, _ in batch])
+                except BaseException as exc:  # never let the worker die silently
+                    logger.exception("reference encode batch worker: encode failed")
+                    results = [exc] * len(batch)
+                for (_, future), outcome in zip(batch, results):
+                    if future.cancelled():
+                        continue
+                    if isinstance(outcome, BaseException):
+                        future.set_exception(_fresh_exception(outcome))
+                    else:
+                        future.set_result(cast(ArtifactT, outcome))
+            if stopping:
+                self._drain_pending_on_shutdown()
+                return
+
+    def _drain_pending_on_shutdown(self) -> None:
+        """Fail queued waiters instead of leaving them to time out."""
+        if self._batch_queue is None:
+            return
+        while True:
+            try:
+                entry = self._batch_queue.get_nowait()
+            except _queue_mod.Empty:
+                return
+            if entry is None:
+                continue
+            _, future = entry
+            if not future.cancelled():
+                future.set_exception(
+                    RuntimeError("reference encode service is shutting down")
+                )
+
+    def _encode_batch(self, items: list[InputT]) -> list[Any]:
+        """Encode a drained batch, falling back to per-item encodes on failure."""
+        try:
+            artifacts = self._hook.encode_batch(items)
+            if len(artifacts) != len(items):
+                raise RuntimeError(
+                    f"encode_batch returned {len(artifacts)} artifacts for "
+                    f"{len(items)} items"
+                )
+            with self._lock:
+                self._batches += 1
+                self._batched_items += len(items)
+            return list(artifacts)
+        except Exception:
+            logger.exception(
+                "%s batched reference encode failed; retrying per item",
+                self._log_prefix or "reference encode",
+            )
+        results: list[Any] = []
+        for item in items:
+            try:
+                results.append(self._hook.encode_one(item))
+            except Exception as exc:
+                results.append(exc)
+        return results
 
     def get_or_encode(self, raw_input: Any, *, desc: str | None = None) -> ArtifactT:
         item = self._hook.normalize_input(raw_input)
@@ -165,7 +304,7 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
             with self._lock:
                 self._uncacheable += 1
             try:
-                return self._hook.encode_one(item)
+                return self._encode_leader(item)
             except BaseException as exc:
                 self._add_exception_note(exc, desc)
                 with self._lock:
@@ -211,7 +350,7 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
         # poison + timeout-length hangs). A hook's revalidate() may legitimately
         # raise (e.g. a reference file mutated during the encode window).
         try:
-            artifact = self._hook.encode_one(item)
+            artifact = self._encode_leader(item)
             stored = self._hook.store_artifact(artifact)
             should_cache = self._hook.revalidate(item, key)
             with self._lock:
@@ -240,6 +379,8 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
                 "evictions": self._cache.eviction_count,
                 "failed": self._failed,
                 "uncacheable": self._uncacheable,
+                "batches": self._batches,
+                "batched_items": self._batched_items,
             }
 
     @staticmethod
@@ -269,5 +410,7 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
                 "evictions": self._cache.eviction_count,
                 "failed": self._failed,
                 "uncacheable": self._uncacheable,
+                "batches": self._batches,
+                "batched_items": self._batched_items,
             }
         logger.info("%s reference encode stats: %s", self._log_prefix, stats)

--- a/sglang_omni/scheduling/simple_scheduler.py
+++ b/sglang_omni/scheduling/simple_scheduler.py
@@ -41,6 +41,7 @@ class SimpleScheduler:
         max_batch_cost: int | None = None,
         max_concurrency: int = 1,
         abort_callback: Callable[[str], None] | None = None,
+        shutdown_callback: Callable[[], None] | None = None,
     ):
         self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
         self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
@@ -64,6 +65,8 @@ class SimpleScheduler:
                 "max_concurrency > 1 and batch_compute_fn are mutually exclusive"
             )
         self._abort_callback = abort_callback
+        self._shutdown_callback = shutdown_callback
+        self._shutdown_lock = threading.Lock()
         self._aborted: set[str] = set()
         self._abort_lock = threading.Lock()
         self._running = False
@@ -298,6 +301,11 @@ class SimpleScheduler:
 
     def stop(self) -> None:
         self._running = False
+        with self._shutdown_lock:
+            callback = self._shutdown_callback
+            self._shutdown_callback = None
+        if callback is not None:
+            callback()
 
     def abort(self, request_id: str) -> None:
         with self._abort_lock:

--- a/tests/unit_test/audar_tts/test_pipeline.py
+++ b/tests/unit_test/audar_tts/test_pipeline.py
@@ -686,6 +686,8 @@ def test_reference_encoder_reports_cache_stats() -> None:
         "evictions": 0,
         "failed": 0,
         "uncacheable": 0,
+        "batches": 0,
+        "batched_items": 0,
     }
 
 

--- a/tests/unit_test/dots_tts/test_reference_encode_batching.py
+++ b/tests/unit_test/dots_tts/test_reference_encode_batching.py
@@ -1,0 +1,515 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests exact-length batching parity for dots.tts reference encoding.
+
+Padding perturbs both speaker embeddings and AudioVAE latents, so batching must
+group only identical lengths. These stubs are intentionally padding-sensitive so
+any regression to padded batching fails loudly.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import threading
+
+import pytest
+import torch
+
+from sglang_omni.models.dots_tts.codec import DotsAudioCodec
+
+HOP_SIZE = 8
+PATCH_SIZE = 4
+LATENT_DIM = 3
+SAMPLES_PER_PATCH = HOP_SIZE * PATCH_SIZE
+
+
+class _PaddingSensitiveSpeaker:
+    """Padding-sensitive speaker stub; accepts but ignores ``audio_lengths``."""
+
+    max_audio_seconds = 0.0
+    sample_rate = 48000
+
+    def __call__(
+        self, audio: torch.Tensor, audio_lengths: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        batch = audio[:, 0]
+        return torch.stack(
+            [batch.mean(-1), batch.std(-1), batch.abs().max(-1).values], dim=-1
+        )
+
+
+class _RandomCroppingSpeaker(_PaddingSensitiveSpeaker):
+    """Mirrors upstream random crop beyond the duration cap."""
+
+    def __init__(self, max_audio_seconds: float = 1.0, sample_rate: int = 48000):
+        self.max_audio_seconds = max_audio_seconds
+        self.sample_rate = sample_rate
+
+    def __call__(
+        self, audio: torch.Tensor, audio_lengths: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        limit = round(self.sample_rate * self.max_audio_seconds)
+        total = audio.shape[-1]
+        if total > limit:
+            start = random.randint(0, total - limit)
+            audio = audio[..., start : start + limit]
+        return super().__call__(audio, audio_lengths)
+
+
+class _PaddingSensitiveLatents:
+    """Padding-sensitive latent stub that perturbs all frames."""
+
+    def extract_latents(self, audio: torch.Tensor) -> torch.Tensor:
+        batch_size, _, samples = audio.shape
+        frames = audio.reshape(batch_size, samples // HOP_SIZE, HOP_SIZE).mean(-1)
+        causal = torch.cumsum(frames, dim=1)
+        causal = causal + frames.mean(dim=1, keepdim=True)
+        scales = torch.arange(1, 2 * LATENT_DIM + 1, dtype=torch.float32)
+        return causal.unsqueeze(1) * scales.reshape(1, -1, 1)
+
+
+def _make_codec() -> DotsAudioCodec:
+    codec = object.__new__(DotsAudioCodec)
+    codec.speaker = _PaddingSensitiveSpeaker()
+    codec.inference = _PaddingSensitiveLatents()
+    codec.vocoder = None
+    codec.patch_size = PATCH_SIZE
+    codec.latent_dim = LATENT_DIM
+    codec.sample_rate = 48000
+    codec.hop_size = HOP_SIZE
+    codec.device = torch.device("cpu")
+    codec.lock = threading.RLock()
+    return codec
+
+
+def _waveform(patches: int, seed: int) -> torch.Tensor:
+    generator = torch.Generator().manual_seed(seed)
+    return torch.randn(1, patches * SAMPLES_PER_PATCH, generator=generator)
+
+
+def _install_waveforms(
+    monkeypatch: pytest.MonkeyPatch, waveforms: dict[str, torch.Tensor]
+) -> None:
+    def _fake_load_audio(path: str, **_: object):
+        return waveforms[path].reshape(-1).numpy()
+
+    monkeypatch.setattr(
+        "sglang_omni.models.dots_tts.codec.load_audio", _fake_load_audio
+    )
+
+
+def test_batch_of_one_is_identical_to_the_unbatched_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    codec = _make_codec()
+    waveform = _waveform(6, seed=1)
+    _install_waveforms(monkeypatch, {"a.wav": waveform})
+
+    single = codec.encode_reference("a.wav")
+    batched = codec._encode_waveforms([waveform])[0]
+
+    assert torch.equal(single["speaker_embedding"], batched["speaker_embedding"])
+    assert torch.equal(single["latent_distribution"], batched["latent_distribution"])
+
+
+def test_equal_length_batch_is_bit_identical_to_encoding_each_alone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The whole point: same length in a batch changes nothing at all."""
+    codec = _make_codec()
+    waveforms = {
+        "a.wav": _waveform(5, seed=2),
+        "b.wav": _waveform(5, seed=3),
+        "c.wav": _waveform(5, seed=4),
+    }
+    _install_waveforms(monkeypatch, waveforms)
+
+    singles = [codec.encode_reference(name) for name in waveforms]
+    batched = codec.encode_reference_batch(list(waveforms))
+
+    assert len(batched) == len(singles)
+    for single, batch_item in zip(singles, batched):
+        assert torch.equal(single["speaker_embedding"], batch_item["speaker_embedding"])
+        assert torch.equal(
+            single["latent_distribution"], batch_item["latent_distribution"]
+        )
+
+
+def test_mixed_lengths_still_match_the_unbatched_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parity check: mixed-length batches must never mix lengths in a group."""
+    codec = _make_codec()
+    waveforms = {
+        "a.wav": _waveform(3, seed=5),
+        "b.wav": _waveform(11, seed=6),
+        "c.wav": _waveform(3, seed=7),
+        "d.wav": _waveform(7, seed=8),
+        "e.wav": _waveform(11, seed=9),
+    }
+    _install_waveforms(monkeypatch, waveforms)
+
+    singles = [codec.encode_reference(name) for name in waveforms]
+    batched = codec.encode_reference_batch(list(waveforms))
+
+    for (name, _), single, batch_item in zip(waveforms.items(), singles, batched):
+        assert torch.equal(
+            single["speaker_embedding"], batch_item["speaker_embedding"]
+        ), name
+        assert torch.equal(
+            single["latent_distribution"], batch_item["latent_distribution"]
+        ), name
+
+
+def test_stub_actually_detects_padding_so_parity_tests_are_not_vacuous() -> None:
+    """Guard check: padding must change stub output or parity tests are vacuous."""
+    codec = _make_codec()
+    short = _waveform(3, seed=10)
+    padded = torch.zeros(1, 11 * SAMPLES_PER_PATCH)
+    padded[0, : short.shape[-1]] = short.reshape(-1)
+
+    alone = codec._encode_waveforms([short])[0]
+    in_padded_row = codec._encode_waveforms([padded])[0]
+    frames = short.shape[-1] // HOP_SIZE
+
+    assert not torch.equal(
+        alone["speaker_embedding"], in_padded_row["speaker_embedding"]
+    )
+    assert not torch.equal(
+        alone["latent_distribution"],
+        in_padded_row["latent_distribution"][..., :frames],
+    )
+
+
+def test_unequal_lengths_are_rejected_by_the_batched_forward() -> None:
+    codec = _make_codec()
+    with pytest.raises(ValueError, match="equal-length"):
+        codec._encode_waveforms([_waveform(3, seed=11), _waveform(4, seed=12)])
+
+
+def test_latents_have_each_items_true_frame_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    codec = _make_codec()
+    waveforms = {
+        "a.wav": _waveform(2, seed=13),
+        "b.wav": _waveform(9, seed=14),
+        "c.wav": _waveform(2, seed=15),
+    }
+    _install_waveforms(monkeypatch, waveforms)
+
+    batched = codec.encode_reference_batch(list(waveforms))
+
+    for (name, waveform), artifact in zip(waveforms.items(), batched):
+        expected_frames = waveform.shape[-1] // HOP_SIZE
+        assert artifact["latent_distribution"].shape == (
+            1,
+            2 * LATENT_DIM,
+            expected_frames,
+        ), name
+
+
+def test_consumed_prompt_latents_are_identical(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    codec = _make_codec()
+    waveforms = {
+        "a.wav": _waveform(6, seed=16),
+        "b.wav": _waveform(6, seed=17),
+    }
+    _install_waveforms(monkeypatch, waveforms)
+
+    singles = [codec.encode_reference(name) for name in waveforms]
+    batched = codec.encode_reference_batch(list(waveforms))
+
+    for single, batch_item in zip(singles, batched):
+        expected = codec.sample_prompt_latents(single["latent_distribution"], seed=42)
+        actual = codec.sample_prompt_latents(batch_item["latent_distribution"], seed=42)
+        assert torch.equal(expected, actual)
+
+
+def test_length_groups_are_exact_not_bucketed() -> None:
+    waveforms = [
+        torch.zeros(1, 100),
+        torch.zeros(1, 110),
+        torch.zeros(1, 100),
+        torch.zeros(1, 120),
+    ]
+    groups = DotsAudioCodec._length_groups(waveforms)
+
+    assert groups == {100: [0, 2], 110: [1], 120: [3]}
+    for length, indices in groups.items():
+        assert all(int(waveforms[i].shape[-1]) == length for i in indices)
+
+
+def test_length_groups_preserve_every_index() -> None:
+    waveforms = [torch.zeros(1, n) for n in (30, 10, 30, 20, 10, 10)]
+    groups = DotsAudioCodec._length_groups(waveforms)
+    assert sorted(i for indices in groups.values() for i in indices) == list(range(6))
+
+
+def test_empty_batch_returns_empty() -> None:
+    codec = _make_codec()
+    assert codec.encode_reference_batch([]) == []
+    assert codec._encode_waveforms([]) == []
+
+
+def test_batch_preserves_input_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    codec = _make_codec()
+    waveforms = {
+        "long.wav": _waveform(12, seed=18),
+        "short.wav": _waveform(2, seed=19),
+        "mid.wav": _waveform(12, seed=20),
+    }
+    _install_waveforms(monkeypatch, waveforms)
+
+    names = list(waveforms)
+    batched = codec.encode_reference_batch(names)
+    singles = [codec.encode_reference(name) for name in names]
+
+    for name, single, batch_item in zip(names, singles, batched):
+        assert torch.equal(
+            single["speaker_embedding"], batch_item["speaker_embedding"]
+        ), name
+
+
+def test_hop_misaligned_latents_are_rejected() -> None:
+    codec = _make_codec()
+
+    class _WrongRate:
+        def extract_latents(self, audio: torch.Tensor) -> torch.Tensor:
+            frames = audio.shape[-1] // HOP_SIZE
+            return torch.zeros(audio.shape[0], 2 * LATENT_DIM, frames + 1)
+
+    codec.inference = _WrongRate()
+    with pytest.raises(RuntimeError, match="hop-aligned"):
+        codec._encode_waveforms([_waveform(3, seed=21)])
+
+
+def test_encoder_coalesces_equal_length_references_into_one_forward(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import concurrent.futures
+
+    from sglang_omni.models.dots_tts.codec import DotsReferenceEncoder
+
+    codec = _make_codec()
+    # Same duration, different content: the case batching can actually help.
+    waveforms = {
+        f"ref-{index}.wav": _waveform(4, seed=30 + index) for index in range(4)
+    }
+    _install_waveforms(monkeypatch, waveforms)
+
+    calls: list[int] = []
+    original = codec._encode_waveforms
+
+    def _counting(batch):
+        calls.append(len(batch))
+        return original(batch)
+
+    codec._encode_waveforms = _counting  # type: ignore[method-assign]
+
+    encoder = DotsReferenceEncoder(
+        codec,
+        model_id="stub",
+        max_batch_size=8,
+        max_batch_wait_ms=50.0,
+    )
+    try:
+        assert encoder.service.batching_enabled is True
+        names = list(waveforms)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(names)) as pool:
+            futures = [pool.submit(encoder.service.get_or_encode, n) for n in names]
+            artifacts = [f.result(timeout=10) for f in futures]
+
+        assert len(artifacts) == len(names)
+        assert max(calls) > 1, "equal-length references should share a forward"
+        stats = encoder.service.stats()
+        assert stats["misses"] == len(names)
+        assert stats["batched_items"] == len(names)
+    finally:
+        encoder.close()
+
+
+def test_encoder_handles_all_distinct_lengths_without_padding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Worst case for grouping: every group is size one, results still correct."""
+    import concurrent.futures
+
+    from sglang_omni.models.dots_tts.codec import DotsReferenceEncoder
+
+    codec = _make_codec()
+    waveforms = {
+        f"ref-{index}.wav": _waveform(4 + index, seed=40 + index) for index in range(4)
+    }
+    _install_waveforms(monkeypatch, waveforms)
+
+    expected = {name: codec.encode_reference(name) for name in waveforms}
+
+    encoder = DotsReferenceEncoder(
+        codec, model_id="stub", max_batch_size=8, max_batch_wait_ms=50.0
+    )
+    try:
+        names = list(waveforms)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(names)) as pool:
+            futures = {
+                name: pool.submit(encoder.service.get_or_encode, name) for name in names
+            }
+            for name, future in futures.items():
+                artifact = future.result(timeout=10)
+                assert torch.equal(
+                    expected[name]["speaker_embedding"], artifact["speaker_embedding"]
+                ), name
+                assert torch.equal(
+                    expected[name]["latent_distribution"],
+                    artifact["latent_distribution"],
+                ), name
+    finally:
+        encoder.close()
+
+
+# --------------------------------------------------------------------------
+# Deterministic speaker cropping (upstream _crop_audio non-determinism)
+# --------------------------------------------------------------------------
+def _cropping_codec(max_audio_seconds: float = 1.0) -> DotsAudioCodec:
+    codec = _make_codec()
+    codec.speaker = _RandomCroppingSpeaker(
+        max_audio_seconds=max_audio_seconds, sample_rate=codec.sample_rate
+    )
+    return codec
+
+
+def _seconds_to_patches(codec: DotsAudioCodec, seconds: float) -> int:
+    samples = int(seconds * codec.sample_rate)
+    return max(1, math.ceil(samples / SAMPLES_PER_PATCH))
+
+
+def test_stub_reproduces_upstream_random_crop() -> None:
+    """Guard check: without the fix, this stub must vary or tests become vacuous."""
+    codec = _cropping_codec()
+    long_ref = _waveform(_seconds_to_patches(codec, 3.0), seed=50)
+    batch = long_ref.reshape(1, 1, -1)
+    lengths = torch.tensor([batch.shape[-1]])
+
+    random.seed(1)
+    first = codec.speaker(batch, lengths)
+    spread = max(
+        (first - codec.speaker(batch, lengths)).abs().max().item() for _ in range(20)
+    )
+    assert spread > 0.0, "stub does not reproduce the upstream random crop"
+
+
+def test_long_references_encode_deterministically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fix: repeated encodes of a >max_audio_seconds reference must match."""
+    codec = _cropping_codec()
+    long_ref = _waveform(_seconds_to_patches(codec, 3.0), seed=51)
+    _install_waveforms(monkeypatch, {"long.wav": long_ref})
+
+    baseline = codec.encode_reference("long.wav")
+    for _ in range(20):
+        repeat = codec.encode_reference("long.wav")
+        assert torch.equal(
+            baseline["speaker_embedding"], repeat["speaker_embedding"]
+        ), "speaker embedding varies across encodes of the same reference"
+
+
+def test_long_reference_is_unaffected_by_global_random_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent requests reseeding `random` must not change the embedding."""
+    codec = _cropping_codec()
+    long_ref = _waveform(_seconds_to_patches(codec, 3.0), seed=52)
+    _install_waveforms(monkeypatch, {"long.wav": long_ref})
+
+    random.seed(0)
+    baseline = codec.encode_reference("long.wav")
+    for seed in (1, 7, 99, 12345):
+        random.seed(seed)
+        assert torch.equal(
+            baseline["speaker_embedding"],
+            codec.encode_reference("long.wav")["speaker_embedding"],
+        )
+
+
+def test_speaker_sees_the_leading_window_only() -> None:
+    """Pre-crop must be the leading window, matching upstream's start=0 draw."""
+    codec = _cropping_codec()
+    limit = codec._speaker_sample_limit()
+    assert limit == codec.sample_rate
+
+    long_ref = _waveform(_seconds_to_patches(codec, 3.0), seed=53)
+    batch = long_ref.reshape(1, 1, -1)
+    lengths = torch.tensor([batch.shape[-1]])
+    cropped, cropped_lengths = codec._speaker_input(batch, lengths)
+
+    assert cropped.shape[-1] == limit
+    assert torch.equal(cropped[0, 0], batch[0, 0, :limit])
+    assert int(cropped_lengths[0]) == limit
+
+
+def test_short_references_are_passed_through_untouched() -> None:
+    """Below the cap there is nothing to crop, so the tensor must be identical."""
+    codec = _cropping_codec()
+    short = _waveform(_seconds_to_patches(codec, 0.5), seed=54)
+    batch = short.reshape(1, 1, -1)
+    lengths = torch.tensor([batch.shape[-1]])
+
+    cropped, cropped_lengths = codec._speaker_input(batch, lengths)
+    assert cropped is batch
+    assert cropped_lengths is lengths
+
+
+def test_audiovae_still_receives_the_full_length_audio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the speaker view is truncated; latents must cover the whole file."""
+    codec = _cropping_codec()
+    patches = _seconds_to_patches(codec, 3.0)
+    long_ref = _waveform(patches, seed=55)
+    _install_waveforms(monkeypatch, {"long.wav": long_ref})
+
+    artifact = codec.encode_reference("long.wav")
+    expected_frames = long_ref.shape[-1] // HOP_SIZE
+    assert artifact["latent_distribution"].shape[-1] == expected_frames
+
+
+def test_no_cropping_when_encoder_has_no_duration_cap() -> None:
+    codec = _make_codec()  # max_audio_seconds = 0.0
+    assert codec._speaker_sample_limit() is None
+
+    audio = _waveform(8, seed=56).reshape(1, 1, -1)
+    lengths = torch.tensor([audio.shape[-1]])
+    cropped, cropped_lengths = codec._speaker_input(audio, lengths)
+    assert cropped is audio
+    assert cropped_lengths is lengths
+
+
+def test_cropping_limit_uses_the_encoders_own_sample_rate() -> None:
+    """`_crop_audio` measures against the encoder's rate, not the codec's."""
+    codec = _cropping_codec()
+    codec.speaker.sample_rate = 16000
+    codec.speaker.max_audio_seconds = 10.0
+    assert codec._speaker_sample_limit() == 160000
+    assert codec.sample_rate == 48000
+
+
+def test_batched_long_references_are_also_deterministic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    codec = _cropping_codec()
+    patches = _seconds_to_patches(codec, 3.0)
+    waveforms = {
+        "a.wav": _waveform(patches, seed=57),
+        "b.wav": _waveform(patches, seed=58),
+    }
+    _install_waveforms(monkeypatch, waveforms)
+
+    baseline = codec.encode_reference_batch(list(waveforms))
+    for seed in (3, 17, 2024):
+        random.seed(seed)
+        repeat = codec.encode_reference_batch(list(waveforms))
+        for one, two in zip(baseline, repeat):
+            assert torch.equal(one["speaker_embedding"], two["speaker_embedding"])

--- a/tests/unit_test/dots_tts/test_reference_encode_batching.py
+++ b/tests/unit_test/dots_tts/test_reference_encode_batching.py
@@ -98,6 +98,11 @@ def _install_waveforms(
     )
 
 
+def _set_tf32(monkeypatch: pytest.MonkeyPatch, *, enabled: bool) -> None:
+    monkeypatch.setattr(torch.backends.cuda.matmul, "allow_tf32", enabled)
+    monkeypatch.setattr(torch.backends.cudnn, "allow_tf32", enabled)
+
+
 def test_batch_of_one_is_identical_to_the_unbatched_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -293,6 +298,7 @@ def test_encoder_coalesces_equal_length_references_into_one_forward(
 
     from sglang_omni.models.dots_tts.codec import DotsReferenceEncoder
 
+    _set_tf32(monkeypatch, enabled=False)
     codec = _make_codec()
     # Same duration, different content: the case batching can actually help.
     waveforms = {
@@ -339,6 +345,7 @@ def test_encoder_handles_all_distinct_lengths_without_padding(
 
     from sglang_omni.models.dots_tts.codec import DotsReferenceEncoder
 
+    _set_tf32(monkeypatch, enabled=False)
     codec = _make_codec()
     waveforms = {
         f"ref-{index}.wav": _waveform(4 + index, seed=40 + index) for index in range(4)
@@ -367,6 +374,63 @@ def test_encoder_handles_all_distinct_lengths_without_padding(
                 ), name
     finally:
         encoder.close()
+
+
+def test_cuda_reference_batching_is_disabled_with_default_cudnn_tf32(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.dots_tts.codec import DotsReferenceEncoder
+
+    _set_tf32(monkeypatch, enabled=False)
+    monkeypatch.setattr(torch.backends.cudnn, "allow_tf32", True)
+    codec = _make_codec()
+    codec.device = torch.device("cuda")
+    encoder = DotsReferenceEncoder(codec, model_id="stub", max_batch_size=8)
+    try:
+        assert encoder.service.batching_enabled is False
+    finally:
+        encoder.close()
+
+
+def test_reference_executor_defaults_to_per_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.dots_tts import stages
+
+    _set_tf32(monkeypatch, enabled=False)
+    codec = _make_codec()
+    monkeypatch.setattr(
+        stages, "load_dots_audio_codec", lambda *_args, **_kwargs: codec
+    )
+
+    scheduler = stages.create_reference_encode_executor("stub", device="cpu")
+    try:
+        encoder = scheduler._fn.__self__
+        assert encoder.service.batching_enabled is False
+    finally:
+        scheduler.stop()
+
+
+def test_reference_executor_stop_closes_batch_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.dots_tts import stages
+
+    _set_tf32(monkeypatch, enabled=False)
+    codec = _make_codec()
+    monkeypatch.setattr(
+        stages, "load_dots_audio_codec", lambda *_args, **_kwargs: codec
+    )
+    scheduler = stages.create_reference_encode_executor(
+        "stub", device="cpu", max_batch_size=2
+    )
+    encoder = scheduler._fn.__self__
+    assert encoder.service._batch_thread is not None
+    assert encoder.service._batch_thread.is_alive()
+
+    scheduler.stop()
+
+    assert not encoder.service._batch_thread.is_alive()
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit_test/pipeline/test_simple_scheduler_concurrent.py
+++ b/tests/unit_test/pipeline/test_simple_scheduler_concurrent.py
@@ -47,6 +47,19 @@ def run_scheduler(
         thread.join(timeout=2.0)
 
 
+def test_stop_runs_shutdown_callback_once() -> None:
+    shutdowns: list[None] = []
+    scheduler = SimpleScheduler(
+        lambda payload: payload,
+        shutdown_callback=lambda: shutdowns.append(None),
+    )
+
+    scheduler.stop()
+    scheduler.stop()
+
+    assert shutdowns == [None]
+
+
 def test_max_concurrency_runs_sync_fn_in_parallel() -> None:
     """Two sync ``compute_fn`` invocations must be in flight simultaneously
     when ``max_concurrency=2``, not serialized."""

--- a/tests/unit_test/scheduling/test_reference_encoder_batching.py
+++ b/tests/unit_test/scheduling/test_reference_encoder_batching.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: Apache-2.0
+"""M4b different-key batch coalescing in ReferenceEncodeService."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import threading
+import time
+from typing import Any
+
+import pytest
+import torch
+
+from sglang_omni.scheduling.reference_encoder import (
+    ReferenceEncodeService,
+    TensorReferenceEncodeHook,
+)
+
+
+class _BatchHook(TensorReferenceEncodeHook[str]):
+    model_id = "test"
+    model_revision = "rev"
+    encoder_id = "encoder"
+    encoder_config_hash = "cfg"
+    artifact_kind = "codes"
+    storage_dtype = torch.long
+    output_dtype = torch.long
+
+    def __init__(self, *, batch_enabled: bool = True) -> None:
+        self.batch_enabled = batch_enabled
+        self.batch_sizes: list[int] = []
+        self.single_calls: list[str] = []
+        self.lock = threading.Lock()
+        self.fail_batch = False
+        self.fail_items: set[str] = set()
+        self.gate: threading.Event | None = None
+
+    def input_key(self, item: str) -> str | None:
+        if item.startswith("uncacheable"):
+            return None
+        return item
+
+    def can_encode_batch(self) -> bool:
+        return self.batch_enabled
+
+    @staticmethod
+    def _encode(item: str) -> torch.Tensor:
+        return torch.tensor([len(item), ord(item[-1])], dtype=torch.long)
+
+    def encode_one(self, item: str) -> torch.Tensor:
+        with self.lock:
+            self.single_calls.append(item)
+        if item in self.fail_items:
+            raise ValueError(f"bad reference: {item}")
+        return self._encode(item)
+
+    def encode_batch(self, items: list[str]) -> list[torch.Tensor]:
+        if self.gate is not None:
+            self.gate.wait(timeout=5)
+        with self.lock:
+            self.batch_sizes.append(len(items))
+        if self.fail_batch:
+            raise RuntimeError("batch encode exploded")
+        return [self._encode(item) for item in items]
+
+
+def _service(hook: _BatchHook, **kwargs: Any) -> ReferenceEncodeService[Any, Any, Any]:
+    params: dict[str, Any] = {"max_batch_size": 8, "max_batch_wait_ms": 50.0}
+    params.update(kwargs)
+    return ReferenceEncodeService(hook, **params)
+
+
+def _parallel(
+    service: ReferenceEncodeService[Any, Any, Any], items: list[str]
+) -> list[Any]:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(items)) as pool:
+        futures = [pool.submit(service.get_or_encode, item) for item in items]
+        return [future.result(timeout=10) for future in futures]
+
+
+def test_batching_is_opt_in_per_hook() -> None:
+    hook = _BatchHook(batch_enabled=False)
+    service = _service(hook)
+    try:
+        assert service.batching_enabled is False
+        service.get_or_encode("a")
+        assert hook.batch_sizes == []
+        assert hook.single_calls == ["a"]
+    finally:
+        service.close()
+
+
+def test_batching_requires_max_batch_size_above_one() -> None:
+    hook = _BatchHook()
+    service = _service(hook, max_batch_size=1)
+    try:
+        assert service.batching_enabled is False
+        service.get_or_encode("a")
+        assert hook.batch_sizes == []
+    finally:
+        service.close()
+
+
+def test_distinct_keys_coalesce_into_one_batch() -> None:
+    hook = _BatchHook()
+    hook.gate = threading.Event()
+    service = _service(hook)
+    try:
+        items = ["a", "bb", "ccc", "dddd"]
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(service.get_or_encode, item) for item in items]
+            # Let all four threads reach the queue before the worker proceeds.
+            time.sleep(0.2)
+            hook.gate.set()
+            results = [future.result(timeout=10) for future in futures]
+
+        assert [tuple(r.tolist()) for r in results] == [
+            (1, ord("a")),
+            (2, ord("b")),
+            (3, ord("c")),
+            (4, ord("d")),
+        ]
+        assert sum(hook.batch_sizes) == 4
+        assert max(hook.batch_sizes) > 1, "expected real coalescing"
+        assert hook.single_calls == []
+        stats = service.stats()
+        assert stats["batched_items"] == 4
+        assert stats["misses"] == 4
+    finally:
+        service.close()
+
+
+def test_batch_results_map_to_the_right_items() -> None:
+    hook = _BatchHook()
+    service = _service(hook)
+    try:
+        items = [f"ref-{index}{chr(ord('a') + index)}" for index in range(6)]
+        results = _parallel(service, items)
+        for item, result in zip(items, results):
+            assert tuple(result.tolist()) == (len(item), ord(item[-1]))
+    finally:
+        service.close()
+
+
+def test_cache_hits_never_reach_the_batch_queue() -> None:
+    hook = _BatchHook()
+    service = _service(hook)
+    try:
+        service.get_or_encode("a")
+        before = list(hook.batch_sizes)
+        for _ in range(5):
+            service.get_or_encode("a")
+        assert hook.batch_sizes == before
+        assert service.stats()["hits"] == 5
+    finally:
+        service.close()
+
+
+def test_same_key_followers_merge_before_batching() -> None:
+    hook = _BatchHook()
+    hook.gate = threading.Event()
+    service = _service(hook)
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(service.get_or_encode, "same") for _ in range(4)]
+            time.sleep(0.2)
+            hook.gate.set()
+            results = [future.result(timeout=10) for future in futures]
+
+        assert all(tuple(r.tolist()) == (4, ord("e")) for r in results)
+        # Single-flight collapses the four callers to one encoded item.
+        assert sum(hook.batch_sizes) == 1
+        assert service.stats()["merged"] == 3
+    finally:
+        service.close()
+
+
+def test_batch_failure_retries_per_item() -> None:
+    hook = _BatchHook()
+    hook.fail_batch = True
+    service = _service(hook)
+    try:
+        results = _parallel(service, ["a", "bb", "ccc"])
+        assert [tuple(r.tolist()) for r in results] == [
+            (1, ord("a")),
+            (2, ord("b")),
+            (3, ord("c")),
+        ]
+        assert sorted(hook.single_calls) == ["a", "bb", "ccc"]
+    finally:
+        service.close()
+
+
+def test_one_bad_reference_does_not_fail_its_batch_peers() -> None:
+    hook = _BatchHook()
+    hook.fail_batch = True
+    hook.fail_items = {"bad"}
+    service = _service(hook)
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
+            good = pool.submit(service.get_or_encode, "good")
+            bad = pool.submit(service.get_or_encode, "bad")
+            other = pool.submit(service.get_or_encode, "other")
+            assert tuple(good.result(timeout=10).tolist()) == (4, ord("d"))
+            assert tuple(other.result(timeout=10).tolist()) == (5, ord("r"))
+            with pytest.raises(ValueError, match="bad reference"):
+                bad.result(timeout=10)
+        # A failed reference must not poison the key for later requests.
+        hook.fail_items = set()
+        hook.fail_batch = False
+        assert tuple(service.get_or_encode("bad").tolist()) == (3, ord("d"))
+    finally:
+        service.close()
+
+
+def test_uncacheable_items_still_batch() -> None:
+    hook = _BatchHook()
+    service = _service(hook)
+    try:
+        results = _parallel(service, ["uncacheable-a", "uncacheable-b"])
+        assert len(results) == 2
+        assert sum(hook.batch_sizes) == 2
+        assert service.stats()["uncacheable"] == 2
+    finally:
+        service.close()
+
+
+def test_max_batch_size_caps_the_forward() -> None:
+    hook = _BatchHook()
+    hook.gate = threading.Event()
+    service = _service(hook, max_batch_size=2)
+    try:
+        items = [f"item-{index}" for index in range(6)]
+        with concurrent.futures.ThreadPoolExecutor(max_workers=6) as pool:
+            futures = [pool.submit(service.get_or_encode, item) for item in items]
+            time.sleep(0.2)
+            hook.gate.set()
+            for future in futures:
+                future.result(timeout=10)
+        assert max(hook.batch_sizes) <= 2
+        assert sum(hook.batch_sizes) == 6
+    finally:
+        service.close()
+
+
+def test_close_stops_the_batch_worker() -> None:
+    hook = _BatchHook()
+    service = _service(hook)
+    service.get_or_encode("a")
+    service.close()
+    assert service._batch_thread is not None
+    assert not service._batch_thread.is_alive()
+
+
+def test_shutdown_fails_queued_waiters_instead_of_hanging() -> None:
+    hook = _BatchHook()
+    hook.gate = threading.Event()
+    service = _service(hook, max_batch_size=2, timeout_s=30.0)
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [
+                pool.submit(service.get_or_encode, f"item-{index}")
+                for index in range(4)
+            ]
+            time.sleep(0.2)
+            service.close()
+            hook.gate.set()
+            outcomes = []
+            for future in futures:
+                try:
+                    future.result(timeout=10)
+                    outcomes.append("ok")
+                except Exception:
+                    outcomes.append("failed")
+        # Nothing may block on the 30s encode timeout after close().
+        assert len(outcomes) == 4
+    finally:
+        service.close()
+
+
+def test_invalid_batch_settings_are_rejected() -> None:
+    with pytest.raises(ValueError, match="max_batch_size"):
+        ReferenceEncodeService(_BatchHook(), max_batch_size=0)
+    with pytest.raises(ValueError, match="max_batch_wait_ms"):
+        ReferenceEncodeService(_BatchHook(), max_batch_wait_ms=-1)


### PR DESCRIPTION
## Motivation
`dots.tts` reference encoding is non-deterministic. `SpeakerXVectorFeatures._crop_audio` (upstream `dots_tts` v0.2.1, `modules/speaker/encoder.py:82`) picks its window with the global `random` module and has no `self.training` guard, so it runs at inference:

``` start = random.randint(0, total_length - cropped_length)```

Any reference longer than `max_audio_seconds` (10 s on `dots-studio/dots.tts-mf`) gets a random crop, so voice cloning is not reproducible.

Two things hide this: the reference cache pins whichever crop was drawn first, and the server seeds the global RNG at startup, so a restart redraws the same window. What varies in production is the RNG position, each long reference consumes one `randint`, so the crop you get depends on how many other long references were encoded before yours, i.e. on request ordering and load.

This also blocks batching parity: the crop loops per item from the shared RNG stream, and grouping reorders items, so batched ≠ unbatched for any reference over 10 s.

## Modifications
- codec.py : `_speaker_input()` / `_speaker_sample_limit()` truncate to the leading `max_audio_seconds` before the speaker encoder, exactly what upstream emits when its draw returns 0. AudioVAE still receives full-length audio.
- codec.py : `encode_reference_batch` groups waveforms by exact sample length. Padding was tried and rejected on measurement: CAM++ masks its pooling, but the TDNN stack between fbank and pooling is unmasked and pulls zeros into the valid region, padded batching moved the speaker embedding by 1.386.
- stages.py  /  reference_encoder.py : plumb batch settings.
- dots_tts.yaml : ships disabled (`max_batch_size: 1`)

## Related Issues

Part of #1367 (reference encoder work items).

## Accuracy Test

### Encode-Order Sensitivity
*Identical reference, process, and cache; only the number of other long references encoded first varies.*

| Preceding Long Encodes | Max Abs Diff (Before) | Cosine (Before) | After |
| :--- | :--- | :--- | :--- |
| 1 | 0.570 | 0.9833 | 0.0 |
| 2 | 0.529 | 0.9832 | 0.0 |
| 3 | 0.185 | 0.9976 | 0.0 |

### Repeated Encodes of the Same Input

| Case | Before | After |
| :--- | :--- | :--- |
| reference > 10 s, max abs diff | 0.738 | 0.0 |
| reference > 10 s, min cosine | 0.9739 | 1.0 |
| reference < 10 s (control) | 0.0 | 0.0 |
| global RNG seeded (control) | 0.0 | 0.0 |

* **Impact:** `0.738` represents **19.8%** of the distance between two completely different speakers (`3.72`). 
* **Root Cause:** The two control cases pin the issue directly on unseeded `random.randint` usage rather than standard numerical/floating-point noise.

### Batching Parity (H200)
* Speaker embedding is **bit-exact** with TF32 disabled (latents: `1.7e-5`).
* The `~6e-4` residual observed with TF32 enabled is due to **cuDNN tiling** effects (identical rows within the exact same batch also differ). 
* Therefore, parity is now successfully gated both ways.
## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the `run-ci` label. Once labeled, every subsequent push re-triggers CI as long as the label remains. Use `/tag-and-rerun-ci higgs` or `/tag-and-rerun-ci moss` to select a TTS CI model, and `/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR CI model. One selector from each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
