### PR TITLE
[Perf] Raise Qwen3-ASR concurrency ceiling to 64

### DIFF
--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -164,9 +164,9 @@ Requests/s by client concurrency:
 | 4 / 16 / 32 | 47.6 | 60.3 | 70.4 | 55.4 | 301/3264 |
 | 8 / 16 / 32 | 48.5 | 75.6 | 89.7 | 64.6 | 173/3264 |
 | 8 / 16 / 16 | 57.6 | 75.4 | 42.2 | 46.7 | 250/3264 |
-| **8 / 32 / 32 (default)** | 57.7 | 76.5 | 87.1 | 65.1 | 0 |
+| 8 / 32 / 32 | 57.7 | 76.5 | 87.1 | 65.1 | 0 |
 | 8 / 64 / 32 | 55.2 | 76.6 | 87.9 | 64.7 | 0 |
-| 8 / 32 / 64 | 57.4 | 77.0 | 90.2 | 96.8 | 0 |
+| **8 / 32 / 64 (default)** | 57.4 | 77.0 | 90.2 | 96.8 | 0 |
 | 8 / 64 / 64 | 57.0 | 74.3 | 88.8 | 100.3 | 0 |
 
 Reading, and the resulting defaults:
@@ -178,14 +178,13 @@ Reading, and the resulting defaults:
   concurrency-8 throughput ~19 %; 64 adds nothing further. 32 is the default.
 - **`max_running_requests` 16 collapses concurrency 32** (queue-bound) with no
   light-load latency benefit, so there is no latency-first case for lowering
-  it. 32 (the default) is memory-conservative for 80 GB GPUs; raising it to
-  **64 unlocks the concurrency-64 regime** (+~50 % requests/s, zero shedding)
-  at the price of larger CUDA-graph and KV memory — the throughput-first
-  override:
+  it. The default is 64 because it unlocks the concurrency-64 regime (+~50 %
+  requests/s, zero shedding), at the price of larger CUDA-graph and KV memory.
+  On memory-constrained GPUs, use the memory-conservative override:
 
 ```bash
 sgl-omni serve --model-path Qwen/Qwen3-ASR-1.7B \
-  --max-running-requests 64   # throughput-first; needs the extra GPU memory
+  --max-running-requests 32
 ```
 
 - Corpus WER stayed 0.0122 for every configuration at every level.

--- a/sglang_omni/models/qwen3_asr/config.py
+++ b/sglang_omni/models/qwen3_asr/config.py
@@ -32,7 +32,7 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
             factory=f"{_PKG}.stages.create_sglang_qwen3_asr_executor",
             factory_args={
                 "device": "cuda:0",
-                "max_running_requests": 32,
+                "max_running_requests": 64,
                 "max_new_tokens": 128,
                 "request_build_max_workers": 8,
                 "request_build_max_pending": 32,

--- a/sglang_omni/models/qwen3_asr/stages.py
+++ b/sglang_omni/models/qwen3_asr/stages.py
@@ -11,7 +11,7 @@ def create_sglang_qwen3_asr_executor(
     *,
     device: str = "cuda:0",
     dtype: str = "auto",
-    max_running_requests: int = 32,
+    max_running_requests: int = 64,
     max_new_tokens: int = 256,
     mem_fraction_static: float | None = None,
     mm_embedding_cache_size_bytes: int = 0,

--- a/tests/README.md
+++ b/tests/README.md
@@ -384,7 +384,8 @@ that happened to contain an older version of the test.
     the `remove_if` eviction predicate evaluated outside the lock (re-entrant
     and deadlock-free), and concurrent remove_if/put state integrity.
 - `unit_test/qwen3_asr/`: Qwen3-ASR unit tests:
-  - pipeline config, stage factory concurrency defaults, async-decode default,
+  - pipeline config and stage factory `max_running_requests=64` default,
+    async-decode default,
     and `--decode-mode async|sync` CLI overrides
   - single-source audio token length formula used by both processor and
     request builder paths

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -19,7 +19,7 @@ from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from tests.unit_test.fakes import FakeServerArgs
 
 
-def test_qwen3_asr_config_uses_batched_stage_with_32_running_requests() -> None:
+def test_qwen3_asr_config_uses_batched_stage_with_64_running_requests() -> None:
     config = Qwen3ASRPipelineConfig(model_path="Qwen/Qwen3-ASR-1.7B")
 
     assert config.entry_stage == "asr"
@@ -28,7 +28,7 @@ def test_qwen3_asr_config_uses_batched_stage_with_32_running_requests() -> None:
     assert config.gpu_placement == {"asr": 0}
     assert config.stages[0].factory.endswith("create_sglang_qwen3_asr_executor")
     assert config.stages[0].factory_args["device"] == "cuda:0"
-    assert config.stages[0].factory_args["max_running_requests"] == 32
+    assert config.stages[0].factory_args["max_running_requests"] == 64
     assert config.stages[0].factory_args["request_build_max_workers"] == 8
     assert config.stages[0].factory_args["request_build_max_pending"] == 32
     assert "request_build_max_backlog" not in config.stages[0].factory_args
@@ -43,10 +43,10 @@ def test_qwen3_asr_config_uses_batched_stage_with_32_running_requests() -> None:
     )
 
 
-def test_qwen3_asr_stage_default_allows_32_running_requests() -> None:
+def test_qwen3_asr_stage_default_allows_64_running_requests() -> None:
     signature = inspect.signature(create_sglang_qwen3_asr_executor)
 
-    assert signature.parameters["max_running_requests"].default == 32
+    assert signature.parameters["max_running_requests"].default == 64
     assert signature.parameters["request_build_max_workers"].default == 8
     assert signature.parameters["request_build_max_pending"].default == 32
     assert "request_build_max_backlog" not in signature.parameters
@@ -205,8 +205,21 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
         server_args_overrides={"context_length": 2048},
     )
 
-    assert build_kwargs["cuda_graph_max_bs"] == 32
-    assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 12, 16, 24, 32]
+    assert build_kwargs["cuda_graph_max_bs"] == 64
+    assert build_kwargs["cuda_graph_bs"] == [
+        1,
+        2,
+        4,
+        8,
+        12,
+        16,
+        24,
+        32,
+        40,
+        48,
+        56,
+        64,
+    ]
     assert adapter_kwargs["context_length"] == 2048
     assert scheduler.enable_async_decode is False
     assert scheduler.async_decode_min_batch_size == 4


### PR DESCRIPTION
## Motivation

Qwen3-ASR's default `max_running_requests=32` caps server-side admission below
the useful concurrency-64 regime. Raise the default ceiling to 64 so high-load
ASR deployments can use the model's measured throughput capacity without an
extra serve override.

## Modifications

1. `sglang_omni/models/qwen3_asr/config.py` and `stages.py`
   - Raise the Qwen3-ASR pipeline and stage-factory
     `max_running_requests` default from 32 to 64.
   - Reuse the shared generation batch policy, which automatically expands the
     default decode CUDA Graph cap and buckets through batch size 64.
2. `tests/unit_test/qwen3_asr/test_pipeline.py`
   - Update the pipeline and stage-default assertions for the 64-request cap.
   - Verify the resolved CUDA Graph buckets include 40, 48, 56, and 64 and
     terminate at `cuda_graph_max_bs=64`.
3. `docs/cookbook/qwen3_asr.md` and `tests/README.md`
   - Mark the measured 8-worker / 32-pending / 64-running configuration as the
     default and document 32 as the memory-conservative override.
   - Synchronize the Qwen3-ASR unit-test catalog with the new default.

## Related Issues

#1396 

## Accuracy Test

**Setup:**

- Baseline: `main @ 18e479f2`, `max_running_requests=32`.
- Candidate: `perf/qwen3-asr-max-running-requests-64 @ 55ba37a1`,
  `max_running_requests=64`.
- Model: `Qwen/Qwen3-ASR-1.7B` at
  `7278e1e70fe206f11671096ffdd38061171dd6e5`, bf16, FA3 LM/MM attention,
  CUDA Graph enabled, torch.compile disabled.
- Evaluation: SeedTTS EN at
  `27f4c1adee83b5b29b7c4b375f6b976324bda308`, 1,088 clips per repeat,
  concurrency 32 and 64, three measured repeats, non-streaming.
- Hardware: one NVIDIA H100 80GB HBM3, physical GPU 1; driver 580.126.20,
  CUDA 13.0.

| Metric | Baseline | Candidate |
| --- | ---: | ---: |
| c=32 corpus WER (mean +/- std) | 0.012334 +/- 0.000000 | 0.012182 +/- 0.000000 |
| c=64 corpus WER (mean +/- std) | 0.012182 +/- 0.000000 | 0.012157 +/- 0.000044 |
| Maximum sample WER | 0.1818 | 0.1818 |
| Evaluated / skipped | 6,528 / 0 | 6,528 / 0 |

## Benchmark & Profiling

Same setup as described in the _Accuracy Test_ section.

| Concurrency | Metric | Baseline (mean +/- std) | Candidate (mean +/- std) | Delta |
| ---: | --- | ---: | ---: | ---: |
| 32 | Throughput (requests/s) | 137.24 +/- 2.89 | 151.23 +/- 5.97 | +10.19% |
| 32 | Mean latency (s) | 0.232 +/- 0.005 | 0.210 +/- 0.009 | -9.28% |
| 32 | P95 latency (s) | 0.311 +/- 0.004 | 0.283 +/- 0.017 | -8.95% |
| 32 | Mean RTF | 0.0502 +/- 0.0010 | 0.0456 +/- 0.0019 | -9.28% |
| 64 | Throughput (requests/s) | 117.24 +/- 1.83 | 168.32 +/- 0.63 | +43.57% |
| 64 | Mean latency (s) | 0.538 +/- 0.008 | 0.376 +/- 0.001 | -30.12% |
| 64 | P95 latency (s) | 0.644 +/- 0.013 | 0.524 +/- 0.024 | -18.61% |
| 64 | Mean RTF | 0.1172 +/- 0.0018 | 0.0811 +/- 0.0001 | -30.79% |

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
