### PR TITLE
[Perf] Query Qwen3-ASR embedding cache before mel extraction

### DIFF
--- a/sglang_omni/models/qwen3_asr/encoder_service.py
+++ b/sglang_omni/models/qwen3_asr/encoder_service.py
@@ -195,20 +195,12 @@ class Qwen3ASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.T
             future.result(timeout=self.ENCODE_TIMEOUT_S)
             return
 
-        cached = self._cache.get(key)
+        cached = self.lookup_cached_embedding(
+            getattr(item, "audio_fingerprint", None), expected_tokens
+        )
         if cached is not None:
-            if self._is_valid(cached, expected_tokens):
-                with self._lock:
-                    self._hits += 1
-                self.attach_embedding(item, cached)
-                return
-            logger.warning(
-                f"Qwen3-ASR pre-LM cache entry {key} failed validation "
-                f"(shape={tuple(cached.shape)}, dtype={cached.dtype}); "
-                f"discarding it if unchanged before re-encoding"
-            )
-            self._cache.remove_if_same(key, cached)
-            cached = None
+            self.attach_embedding(item, cached)
+            return
 
         leader = False
         with self._lock:
@@ -257,6 +249,30 @@ class Qwen3ASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.T
             )
         self.attach_embedding(item, embedding)
 
+    def lookup_cached_embedding(
+        self,
+        audio_fingerprint: str | None,
+        expected_tokens: int,
+    ) -> torch.Tensor | None:
+        """Return a validated cached embedding without starting an encode."""
+        key = self._cache_key_from_fingerprint(audio_fingerprint)
+        cached = self._cache.get(key)
+        if cached is None:
+            return None
+        if self._is_valid(cached, expected_tokens):
+            with self._lock:
+                self._hits += 1
+            return cached
+        logger.warning(
+            "Qwen3-ASR pre-LM cache entry %s failed validation "
+            "(shape=%s, dtype=%s); discarding it if unchanged before re-encoding",
+            key,
+            getattr(cached, "shape", None),
+            getattr(cached, "dtype", None),
+        )
+        self._cache.remove_if_same(key, cached)
+        return None
+
     def stats(self) -> dict[str, int | float]:
         with self._lock:
             cache_lookups = self._hits + self._misses
@@ -284,10 +300,14 @@ class Qwen3ASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.T
             }
 
     def _cache_key(self, item: Any) -> str | None:
-        item_hash = getattr(item, "audio_fingerprint", None)
-        if item_hash is None:
+        return self._cache_key_from_fingerprint(
+            getattr(item, "audio_fingerprint", None)
+        )
+
+    def _cache_key_from_fingerprint(self, audio_fingerprint: str | None) -> str | None:
+        if audio_fingerprint is None:
             return None
-        return f"{self._namespace}:{item_hash}"
+        return f"{self._namespace}:{audio_fingerprint}"
 
     def _is_valid(self, embedding: Any, expected_tokens: int) -> bool:
         return (

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -6,10 +6,11 @@ Qwen3-ASR is a Qwen3 causal LM that ingests audio as multimodal embeddings:
 the prompt contains an ``<|audio_pad|>`` placeholder repeated once per audio
 token, and the model's ``general_mm_embed_routine`` scatters the encoder output
 into those positions. So request_builder must:
-  * extract mel features (WhisperFeatureExtractor) + attention mask,
+  * reuse a cached LM-ready embedding before mel extraction when available,
+  * otherwise extract mel features (WhisperFeatureExtractor) + attention mask,
   * compute how many audio tokens the encoder will emit,
   * build the chat prompt with that many ``<|audio_pad|>`` tokens,
-  * hand the features over as a ``MultimodalDataItem``.
+  * hand features or precomputed embeddings over as a ``MultimodalDataItem``.
 """
 
 from __future__ import annotations
@@ -150,56 +151,78 @@ def make_qwen3_asr_scheduler_adapters(
         fingerprint = prepared.fingerprint
         request_max_new_tokens = int(params.get("max_new_tokens") or max_new_tokens)
 
-        if context_length is not None:
-            hop_length = int(getattr(feature_extractor, "hop_length", 0))
+        estimated_audio_tokens = None
+        if context_length is not None or audio_encoder_service is not None:
+            try:
+                hop_length = int(feature_extractor.hop_length)
+            except AttributeError as exc:
+                raise ValueError(
+                    "Qwen3-ASR feature extractor is missing its hop length"
+                ) from exc
             if hop_length <= 0:
                 raise ValueError(
                     "Qwen3-ASR feature extractor has an invalid hop length"
                 )
+            estimated_mel_frames = len(audio) // hop_length
+            estimated_audio_tokens = qwen3_asr_num_audio_tokens(estimated_mel_frames)
+
+        cached_embedding = None
+        if audio_encoder_service is not None:
+            assert estimated_audio_tokens is not None
+            cached_embedding = audio_encoder_service.lookup_cached_embedding(
+                fingerprint, estimated_audio_tokens
+            )
+
+        if context_length is not None:
+            assert estimated_audio_tokens is not None
             # WhisperFeatureExtractor emits floor(samples / hop_length) frames.
             # Check the resulting prompt before the mel FFT so requests that
             # cannot fit the configured context do not consume preprocessing
             # memory and CPU.
-            estimated_mel_frames = len(audio) // hop_length
-            estimated_audio_tokens = qwen3_asr_num_audio_tokens(estimated_mel_frames)
             estimated_input_ids = _build_prompt_ids(
                 estimated_audio_tokens, forced_language
             )
             _validate_context_budget(estimated_input_ids, request_max_new_tokens)
 
-        # note (Jeffro Qu): unlike Whisper's default 30s window, here we pad the mel to the clip's true length.
-        # WhisperFeatureExtractor defaults to padding="max_length", padding every clip to nb_max_frames=3000 (~30s),
-        # so a short clip pays the full 30s of mel FFT on silence.
-        # This is safe for Qwen3-ASR because its encoder is variable-length and keeps only the
-        # valid frames via feature_attention_mask; vanilla Whisper's fixed-length encoder would instead break on padding="longest" (see ref: transformers#26241).
-        # refs:
-        #  https://github.com/huggingface/transformers/blob/main/src/transformers/models/whisper/feature_extraction_whisper.py
-        #  https://github.com/huggingface/transformers/issues/26241
-        extracted = feature_extractor(
-            audio,
-            sampling_rate=_SAMPLE_RATE,
-            return_tensors="pt",
-            return_attention_mask=True,
-            padding="longest",
-            # note (Junnan Li): Qwen3-ASR's encoder accepts mel sequences beyond
-            # Whisper's 30-second window, so preprocessing must not truncate them.
-            truncation=False,
-        )
-        features = extracted.input_features
-        feature_attention_mask = getattr(extracted, "attention_mask", None)
-        if feature_attention_mask is None:
-            # WhisperFeatureExtractor normally returns one; fall back to all-valid.
-            feature_attention_mask = torch.ones(
-                (features.shape[0], features.shape[-1]), dtype=torch.long
+        if cached_embedding is None:
+            # note (Jeffro Qu): unlike Whisper's default 30s window, here we pad the mel to the clip's true length.
+            # WhisperFeatureExtractor defaults to padding="max_length", padding every clip to nb_max_frames=3000 (~30s),
+            # so a short clip pays the full 30s of mel FFT on silence.
+            # This is safe for Qwen3-ASR because its encoder is variable-length and keeps only the
+            # valid frames via feature_attention_mask; vanilla Whisper's fixed-length encoder would instead break on padding="longest" (see ref: transformers#26241).
+            # refs:
+            #  https://github.com/huggingface/transformers/blob/main/src/transformers/models/whisper/feature_extraction_whisper.py
+            #  https://github.com/huggingface/transformers/issues/26241
+            extracted = feature_extractor(
+                audio,
+                sampling_rate=_SAMPLE_RATE,
+                return_tensors="pt",
+                return_attention_mask=True,
+                padding="longest",
+                # note (Junnan Li): Qwen3-ASR's encoder accepts mel sequences beyond
+                # Whisper's 30-second window, so preprocessing must not truncate them.
+                truncation=False,
             )
-        # note (Jeffro Qu): get_audio_feature uses the mask to select valid
-        # frames; its no-mask branch transposes wrong, so the mask path must be taken.
-        num_mel_frames = int(feature_attention_mask.sum().item())
-        num_audio_tokens = int(qwen3_asr_num_audio_tokens(num_mel_frames))
-        logger.debug(
-            f"[qwen3-asr] mel_frames={num_mel_frames} "
-            f"num_audio_tokens={num_audio_tokens} feat_shape={tuple(features.shape)}"
-        )
+            features = extracted.input_features
+            feature_attention_mask = getattr(extracted, "attention_mask", None)
+            if feature_attention_mask is None:
+                # WhisperFeatureExtractor normally returns one; fall back to all-valid.
+                feature_attention_mask = torch.ones(
+                    (features.shape[0], features.shape[-1]), dtype=torch.long
+                )
+            # note (Jeffro Qu): get_audio_feature uses the mask to select valid
+            # frames; its no-mask branch transposes wrong, so the mask path must be taken.
+            num_mel_frames = int(feature_attention_mask.sum().item())
+            num_audio_tokens = int(qwen3_asr_num_audio_tokens(num_mel_frames))
+            logger.debug(
+                f"[qwen3-asr] mel_frames={num_mel_frames} "
+                f"num_audio_tokens={num_audio_tokens} feat_shape={tuple(features.shape)}"
+            )
+        else:
+            features = None
+            feature_attention_mask = None
+            assert estimated_audio_tokens is not None
+            num_audio_tokens = estimated_audio_tokens
 
         input_ids = _build_prompt_ids(num_audio_tokens, forced_language)
         _validate_context_budget(input_ids, request_max_new_tokens)
@@ -260,7 +283,10 @@ def make_qwen3_asr_scheduler_adapters(
         # a request is only admitted with its complete LM-ready embedding, and
         # a failed encode raises here instead of poisoning the waiting queue.
         if audio_encoder_service is not None:
-            audio_encoder_service.encode_item(audio_item)
+            if cached_embedding is None:
+                audio_encoder_service.encode_item(audio_item)
+            else:
+                audio_encoder_service.attach_embedding(audio_item, cached_embedding)
 
         req = Req(
             rid=payload.request_id,

--- a/tests/unit_test/qwen3_asr/test_encoder_service.py
+++ b/tests/unit_test/qwen3_asr/test_encoder_service.py
@@ -169,6 +169,22 @@ def test_cache_hit_skips_reencode() -> None:
     assert service.stats()["hits"] == 1
 
 
+def test_lookup_cached_embedding_returns_only_valid_entries() -> None:
+    model = _StubModel()
+    service = _make_service(model)
+    item = _item(11, 3)
+    service.encode_item(item)
+
+    cached = service.lookup_cached_embedding(item.audio_fingerprint, 3)
+
+    assert cached is not None
+    assert torch.equal(cached, item.precomputed_embeddings.cpu())
+    assert service.stats()["hits"] == 1
+
+    assert service.lookup_cached_embedding(item.audio_fingerprint, 4) is None
+    assert len(service._cache) == 0
+
+
 def test_extended_audio_never_reuses_prefix_embedding() -> None:
     model = _StubModel()
     service = _make_service(model)

--- a/tests/unit_test/qwen3_asr/test_request_builders.py
+++ b/tests/unit_test/qwen3_asr/test_request_builders.py
@@ -385,6 +385,118 @@ def test_qwen3_asr_rejects_full_context_before_mel_extraction(
         request_builder(payload)
 
 
+def test_qwen3_asr_embedding_cache_hit_skips_mel_extraction(monkeypatch) -> None:
+    class _UnexpectedFeatureExtractor:
+        hop_length = 160
+
+        def __call__(self, *args, **kwargs):
+            raise AssertionError("feature extractor should not be called")
+
+    class _EncoderService:
+        def __init__(self) -> None:
+            self.lookup: tuple[str, int] | None = None
+            self.embedding = torch.zeros((13, 4))
+
+        def lookup_cached_embedding(
+            self, audio_fingerprint: str, expected_tokens: int
+        ) -> torch.Tensor | None:
+            self.lookup = (audio_fingerprint, expected_tokens)
+            return self.embedding
+
+        def attach_embedding(self, item, embedding: torch.Tensor) -> None:
+            item.precomputed_embeddings = embedding
+            item.feature = None
+
+        def encode_item(self, item) -> None:
+            raise AssertionError("encoder should not be called on a cache hit")
+
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(16000, dtype=np.float32),
+    )
+    encoder_service = _EncoderService()
+    request_builder, _ = make_qwen3_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=32,
+        feature_extractor=_UnexpectedFeatureExtractor(),
+        audio_encoder_service=encoder_service,
+    )
+    payload = StagePayload(
+        request_id="req-asr-cache-hit",
+        request=OmniRequest(inputs={"audio_bytes": b"wav"}),
+        data={},
+    )
+
+    data = request_builder(payload)
+
+    item = data.req.multimodal_inputs.mm_items[0]
+    assert encoder_service.lookup == (data.req.extra_key, 13)
+    assert item.feature is None
+    assert item.precomputed_embeddings is encoder_service.embedding
+    assert item.num_audio_tokens == 13
+
+
+def test_qwen3_asr_embedding_cache_miss_extracts_and_encodes(monkeypatch) -> None:
+    class _FeatureExtractor:
+        hop_length = 160
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def __call__(self, *args, **kwargs):
+            self.calls += 1
+            return SimpleNamespace(
+                input_features=torch.zeros((1, 128, 100)),
+                attention_mask=torch.ones((1, 100), dtype=torch.long),
+            )
+
+    class _EncoderService:
+        def __init__(self) -> None:
+            self.lookup: tuple[str, int] | None = None
+            self.encoded_feature: torch.Tensor | None = None
+
+        def lookup_cached_embedding(
+            self, audio_fingerprint: str, expected_tokens: int
+        ) -> None:
+            self.lookup = (audio_fingerprint, expected_tokens)
+            return None
+
+        def attach_embedding(self, item, embedding: torch.Tensor) -> None:
+            raise AssertionError("no cached embedding should be attached")
+
+        def encode_item(self, item) -> None:
+            self.encoded_feature = item.feature
+            item.precomputed_embeddings = torch.zeros((item.num_audio_tokens, 4))
+            item.feature = None
+
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(16000, dtype=np.float32),
+    )
+    feature_extractor = _FeatureExtractor()
+    encoder_service = _EncoderService()
+    request_builder, _ = make_qwen3_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=32,
+        feature_extractor=feature_extractor,
+        audio_encoder_service=encoder_service,
+    )
+    payload = StagePayload(
+        request_id="req-asr-cache-miss",
+        request=OmniRequest(inputs={"audio_bytes": b"wav"}),
+        data={},
+    )
+
+    data = request_builder(payload)
+
+    assert encoder_service.lookup == (data.req.extra_key, 13)
+    assert feature_extractor.calls == 1
+    assert encoder_service.encoded_feature is not None
+    assert data.req.multimodal_inputs.mm_items[0].feature is None
+
+
 def test_qwen3_asr_result_adapter_decodes_without_text_round_trip() -> None:
     tokenizer = _FakeTokenizer()
     _, result_adapter = make_qwen3_asr_scheduler_adapters(
@@ -424,6 +536,7 @@ def test_qwen3_asr_request_builder_encodes_after_offsets_are_final(
         input_features=torch.zeros((1, 128, 3000)),
         attention_mask=torch.ones((1, num_mel_frames), dtype=torch.long),
     )
+    feature_extractor.hop_length = 160
     monkeypatch.setattr(
         transcription,
         "load_audio",
@@ -432,6 +545,11 @@ def test_qwen3_asr_request_builder_encodes_after_offsets_are_final(
     observed: dict[str, object] = {}
 
     class _EncoderService:
+        def lookup_cached_embedding(
+            self, audio_fingerprint: str, expected_tokens: int
+        ) -> None:
+            return None
+
         def encode_item(self, item) -> None:
             observed["offsets"] = item.offsets
             observed["num_audio_tokens"] = item.num_audio_tokens


### PR DESCRIPTION
## Motivation

Qwen3-ASR currently extracts Whisper mel features before the pre-LM encoder
service checks its embedding cache. Repeated audio therefore still pays the
CPU mel-extraction cost even when a complete LM-ready embedding is already
cached.

Move the cache lookup immediately after audio decode/resample/fingerprinting so
a valid hit can build the request directly from the cached embedding. Cache
misses keep the existing feature extraction, encoder, and cache-fill path.

## Modifications

1. `sglang_omni/models/qwen3_asr/request_builders.py`

   - Derive the expected Whisper frame/audio-token count from the resampled
     waveform and feature-extractor hop length before mel extraction.
   - Query the pre-LM embedding cache with the full waveform fingerprint and
     expected token count.
   - On a valid hit, skip `WhisperFeatureExtractor` and the audio encoder,
     construct the multimodal token span, and attach the cached LM-ready
     embedding. On a miss, preserve the existing mel -> encoder -> cache flow.
   - Keep context-budget validation, multimodal offsets, MRoPE positions,
     sampling, and request admission behavior unchanged.

2. `sglang_omni/models/qwen3_asr/encoder_service.py`

   - Add `lookup_cached_embedding()` for a lookup-only fast path that does not
     start encoder work.
   - Reuse the existing namespace + waveform fingerprint key, tensor
     shape/dtype validation, hit accounting, LRU touch, and invalid-entry
     eviction behavior.
   - Route `encode_item()` through the same lookup helper while retaining its
     locked single-flight recheck for concurrent misses.

3. `tests/unit_test/qwen3_asr/`

   - Prove a cache hit skips both mel extraction and encoder execution.
   - Prove a cache miss still extracts features and encodes the item.
   - Cover direct valid lookup and eviction of an entry with the wrong audio
     token count.

## Related Issues

#1396 

## Accuracy Test

**Setup:**
- Qwen/Qwen3-ASR-1.7B revision
`7278e1e70fe206f11671096ffdd38061171dd6e5`
- full SeedTTS English
(1,088 clips) revision `27f4c1adee83b5b29b7c4b375f6b976324bda308`,
- non-streaming, concurrency 1 and 32, three measured repeats without an extra
warmup
- one H100 80GB on physical GPU 0. 
- Baseline: `main @ f21c2c8a`; candidate: `perf/qwen3-asr-early-embedding-cache @ 8b0ba391`. 

| Metric | Baseline | Candidate |
| --- | ---: | ---: |
| Corpus WER, c=1 | 0.0122 | 0.0122 |
| Corpus WER, c=32 | 0.0123 | 0.0123 |
| Maximum sample WER | 0.1818 | 0.1818 |
| Evaluated / total, c=1 | 3,264 / 3,264 | 3,264 / 3,264 |
| Evaluated / total, c=32 | 3,264 / 3,264 | 3,264 / 3,264 |
| Skipped requests | 0 | 0 |

## Benchmark & Profiling

Same setup as described in the _Accuracy Test_ section. 

| Concurrency | Metric | Baseline (mean +/- std) | Candidate (mean +/- std) | Delta |
| ---: | --- | ---: | ---: | ---: |
| 1 | Throughput (req/s) | 16.958 +/- 0.784 | 17.347 +/- 1.162 | +2.29% |
| 1 | Mean latency (s) | 0.0590 +/- 0.0028 | 0.0578 +/- 0.0040 | -1.98% |
| 1 | P95 latency (s) | 0.0730 +/- 0.0034 | 0.0718 +/- 0.0055 | -1.64% |
| 1 | Mean RTF | 0.0128 +/- 0.0006 | 0.0125 +/- 0.0009 | -1.93% |
| 32 | Throughput (req/s) | 139.997 +/- 2.027 | 155.058 +/- 3.259 | +10.76% |
| 32 | Mean latency (s) | 0.2272 +/- 0.0031 | 0.2051 +/- 0.0042 | -9.72% |
| 32 | P95 latency (s) | 0.3023 +/- 0.0060 | 0.2758 +/- 0.0105 | -8.78% |
| 32 | Mean RTF | 0.0491 +/- 0.0006 | 0.0443 +/- 0.0009 | -9.79% |

### Summary:

- At c=32, early cache lookup improves throughput by 10.76% and reduces mean
  latency/RTF by about 9.7% with unchanged WER and coverage.
- For the cache-warm c=1 repeats 2-3, throughput improves 3.62%, mean latency
  drops 3.41%, and mean RTF drops 3.36%.
- Worker-routing balance is not applicable to this single-server DP=1 run;
  the direct ASR server exposes no `/workers` metadata.

## Validation

- `pre-commit run --all-files` — passed.
- `/data/.venv/bin/python -m pytest tests/unit_test/qwen3_asr -q` — 119 passed.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
