### PR TITLE
[CI] Measure cpuset contention from per-CPU counters, not affinity masks

### DIFF
--- a/tests/unit_test/ci/test_cpu_contention.py
+++ b/tests/unit_test/ci/test_cpu_contention.py
@@ -4,6 +4,9 @@
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
+import time
 
 import pytest
 
@@ -15,6 +18,11 @@ from tests.utils.ci_cpu_contention import (
     foreign_ticks,
 )
 
+_HAS_PROC = os.path.isdir("/proc")
+_TWO_CPUS = (
+    _HAS_PROC and hasattr(os, "sched_getaffinity") and len(os.sched_getaffinity(0)) >= 2
+)
+
 
 def test_parse_cpu_list_ranges_and_singles():
     assert _parse_cpu_list("48-51,112") == {48, 49, 50, 51, 112}
@@ -22,38 +30,63 @@ def test_parse_cpu_list_ranges_and_singles():
 
 def test_tree_pids_follows_descendants_only():
     procs = {
-        1: _Proc(ppid=0, ticks=0, overlaps=True),
-        10: _Proc(ppid=1, ticks=0, overlaps=True),
-        20: _Proc(ppid=10, ticks=0, overlaps=True),
-        30: _Proc(ppid=20, ticks=0, overlaps=True),
-        99: _Proc(ppid=1, ticks=0, overlaps=True),
+        1: _Proc(ppid=0, ticks=0),
+        10: _Proc(ppid=1, ticks=0),
+        20: _Proc(ppid=10, ticks=0),
+        30: _Proc(ppid=20, ticks=0),
+        99: _Proc(ppid=1, ticks=0),
     }
     assert _tree_pids(procs, 10) == {10, 20, 30}
 
 
-def test_foreign_ticks_charges_overlapping_outsiders_only():
-    prev = {
-        10: _Proc(ppid=1, ticks=100, overlaps=True),
-        50: _Proc(ppid=1, ticks=100, overlaps=True),
-        60: _Proc(ppid=1, ticks=100, overlaps=False),
-    }
-    cur = {
-        10: _Proc(ppid=1, ticks=500, overlaps=True),
-        50: _Proc(ppid=1, ticks=300, overlaps=True),
-        60: _Proc(ppid=1, ticks=900, overlaps=False),
-        70: _Proc(ppid=1, ticks=999, overlaps=True),
-    }
-    # note (Jiaxin Deng): 10 is in-tree, 60 does not overlap, 70 lacks a
-    # baseline; only pid 50 may be charged.
-    assert foreign_ticks(prev, cur, tree={10}) == 200
+def test_foreign_ticks_deducts_tree_and_clamps():
+    prev = {10: _Proc(ppid=1, ticks=100)}
+    # note (Jiaxin Deng): pid 20 was born inside the window, so its full
+    # tick count is deducted; outsiders never appear here because foreign
+    # time comes from the per-CPU busy delta, not from process scans.
+    cur = {10: _Proc(ppid=1, ticks=300), 20: _Proc(ppid=1, ticks=50)}
+    assert foreign_ticks(500, prev, cur, tree={10, 20}) == 250
+    assert foreign_ticks(100, prev, cur, tree={10, 20}) == 0
 
 
-@pytest.mark.skipif(not os.path.isdir("/proc"), reason="requires Linux procfs")
+@pytest.mark.skipif(not _HAS_PROC, reason="requires Linux procfs")
 def test_sampler_smoke_produces_summary():
     sampler = ContentionSampler({0, 1}, interval_s=0.2)
     sampler.start()
-    import time
-
     time.sleep(0.7)
     sampler.stop()
     assert "[cpuset-contention]" in sampler.summary()
+
+
+def _spin(core: int) -> subprocess.Popen:
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            f"import os\nos.sched_setaffinity(0, {{{core}}})\nwhile True: pass",
+        ]
+    )
+
+
+@pytest.mark.skipif(not _TWO_CPUS, reason="requires Linux procfs and two allowed CPUs")
+def test_controlled_load_inside_cpuset_counts_outside_does_not():
+    """A busy outsider on the pinned core is charged; one on another core is not."""
+    cores = sorted(os.sched_getaffinity(0))
+    core_in, core_out = cores[0], cores[1]
+    session_root = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"]
+    )
+    inside = _spin(core_in)
+    outside = _spin(core_out)
+    sampler = ContentionSampler({core_in}, interval_s=0.4, root_pid=session_root.pid)
+    try:
+        time.sleep(0.2)
+        sampler.start()
+        time.sleep(1.4)
+        sampler.stop()
+        peak = sampler.peak_foreign_cores()
+        assert 0.5 <= peak <= 1.6, sampler.summary()
+    finally:
+        for proc in (inside, outside, session_root):
+            proc.kill()
+            proc.wait(timeout=5)

--- a/tests/unit_test/ci/test_cpu_contention.py
+++ b/tests/unit_test/ci/test_cpu_contention.py
@@ -40,13 +40,29 @@ def test_tree_pids_follows_descendants_only():
 
 
 def test_foreign_ticks_deducts_tree_and_clamps():
-    prev = {10: _Proc(ppid=1, ticks=100)}
+    prev = {10: _Proc(ppid=1, ticks=100, start=5)}
     # note (Jiaxin Deng): pid 20 was born inside the window, so its full
     # tick count is deducted; outsiders never appear here because foreign
     # time comes from the per-CPU busy delta, not from process scans.
-    cur = {10: _Proc(ppid=1, ticks=300), 20: _Proc(ppid=1, ticks=50)}
+    cur = {10: _Proc(ppid=1, ticks=300, start=5), 20: _Proc(ppid=1, ticks=50)}
     assert foreign_ticks(500, prev, cur, tree={10, 20}) == 250
     assert foreign_ticks(100, prev, cur, tree={10, 20}) == 0
+
+
+def test_foreign_ticks_deducts_reaped_child_via_parent_cutime():
+    # A pinned server burned 400 ticks then was killed and reaped; its time
+    # reappears as the parent's child_ticks delta and must not count foreign.
+    prev = {10: _Proc(ppid=1, ticks=100, child_ticks=50, start=5)}
+    cur = {10: _Proc(ppid=1, ticks=110, child_ticks=450, start=5)}
+    assert foreign_ticks(410, prev, cur, tree={10}) == 0
+
+
+def test_foreign_ticks_pid_reuse_is_a_new_process():
+    # Same pid, different starttime: the old incarnation's ticks must not
+    # produce a negative deduction; the new one deducts its full count.
+    prev = {10: _Proc(ppid=1, ticks=100000, start=5)}
+    cur = {10: _Proc(ppid=1, ticks=30, start=999)}
+    assert foreign_ticks(100, prev, cur, tree={10}) == 70
 
 
 @pytest.mark.skipif(not _HAS_PROC, reason="requires Linux procfs")
@@ -68,24 +84,34 @@ def _spin(core: int) -> subprocess.Popen:
     )
 
 
+def _idlest_cores(candidates: list[int], count: int) -> list[int]:
+    from tests.utils.ci_cpu_contention import cpuset_busy_ticks
+
+    before = {c: cpuset_busy_ticks({c}) for c in candidates}
+    time.sleep(0.3)
+    return sorted(candidates, key=lambda c: cpuset_busy_ticks({c}) - before[c])[:count]
+
+
 @pytest.mark.skipif(not _TWO_CPUS, reason="requires Linux procfs and two allowed CPUs")
 def test_controlled_load_inside_cpuset_counts_outside_does_not():
     """A busy outsider on the pinned core is charged; one on another core is not."""
-    cores = sorted(os.sched_getaffinity(0))
-    core_in, core_out = cores[0], cores[1]
+    # note (Jiaxin Deng): /proc/stat is host-global even inside a container,
+    # so pick the two currently idlest allowed cores to keep the bounds tight
+    # on a shared machine.
+    core_in, core_out = _idlest_cores(sorted(os.sched_getaffinity(0)), 2)
     session_root = subprocess.Popen(
         [sys.executable, "-c", "import time; time.sleep(30)"]
     )
     inside = _spin(core_in)
     outside = _spin(core_out)
-    sampler = ContentionSampler({core_in}, interval_s=0.4, root_pid=session_root.pid)
+    sampler = ContentionSampler({core_in}, interval_s=1.0, root_pid=session_root.pid)
     try:
         time.sleep(0.2)
         sampler.start()
-        time.sleep(1.4)
+        time.sleep(3.3)
         sampler.stop()
         peak = sampler.peak_foreign_cores()
-        assert 0.5 <= peak <= 1.6, sampler.summary()
+        assert 0.4 <= peak <= 1.8, sampler.summary()
     finally:
         for proc in (inside, outside, session_root):
             proc.kill()

--- a/tests/utils/ci_cpu_contention.py
+++ b/tests/utils/ci_cpu_contention.py
@@ -8,7 +8,13 @@ kernel's per-CPU counters, not from process affinity masks: the cpuset's
 busy ticks minus the session tree's ticks (the tree is pinned, so its time
 is entirely inside the cpuset). Time spent by outsiders on other cores never
 enters the counters, and short-lived intruders are still charged because the
-per-CPU counters survive process exit.
+per-CPU counters survive process exit. Reaped tree children are deducted
+through their parent's cutime/cstime. Known blind spots, accepted: a tree
+thread that widens its own affinity is over-deducted (nothing in the tree
+does this; the runner-side partition check owns that invariant), and kernel
+work the session induces asynchronously (softirq, kworkers) counts as
+foreign by policy, since the alarm measures cpuset capacity not owned by
+the tree.
 """
 
 from __future__ import annotations
@@ -29,6 +35,8 @@ FAIL_FOREIGN_CORES = 2.0
 class _Proc:
     ppid: int
     ticks: int
+    child_ticks: int = 0
+    start: int = 0
 
 
 def _parse_cpu_list(spec: str) -> set[int]:
@@ -50,7 +58,9 @@ def cpuset_busy_ticks(cpuset: set[int]) -> int:
             if line.startswith("cpu") and line[3:4].isdigit():
                 parts = line.split()
                 if int(parts[0][3:]) in cpuset:
-                    nums = list(map(int, parts[1:]))
+                    # note (Jiaxin Deng): first 8 fields only; guest time is
+                    # already inside user/nice and would be double-counted.
+                    nums = list(map(int, parts[1:9]))
                     busy += sum(nums) - nums[3] - nums[4]
     return busy
 
@@ -65,7 +75,12 @@ def _snapshot() -> dict[int, _Proc]:
             with open(f"/proc/{pid}/stat", "rb") as f:
                 data = f.read().decode("ascii", "replace")
             rest = data[data.rindex(")") + 2 :].split()
-            procs[pid] = _Proc(ppid=int(rest[1]), ticks=int(rest[11]) + int(rest[12]))
+            procs[pid] = _Proc(
+                ppid=int(rest[1]),
+                ticks=int(rest[11]) + int(rest[12]),
+                child_ticks=int(rest[13]) + int(rest[14]),
+                start=int(rest[19]),
+            )
         except (OSError, ValueError):
             continue
     return procs
@@ -92,15 +107,23 @@ def foreign_ticks(
 ) -> int:
     """Cpuset busy ticks not accounted for by the pinned session tree.
 
-    A tree process born inside the window is charged its full tick count; a
-    tree process that exited mid-window cannot be deducted, which biases the
-    result upward, the conservative direction for a contention alarm.
+    Reaped children surface in their parent's cutime/cstime, so a server
+    killed mid-window is still deducted instead of masquerading as multiple
+    foreign cores. A pid is the same process only if starttime matches;
+    otherwise it is treated as born in this window. Per-pid deltas clamp at
+    zero so a reused pid cannot inject a negative deduction.
     """
-    tree_delta = sum(
-        cur[pid].ticks - (prev[pid].ticks if pid in prev else 0)
-        for pid in cur
-        if pid in tree
-    )
+    tree_delta = 0
+    for pid in cur:
+        if pid not in tree:
+            continue
+        proc = cur[pid]
+        before = prev.get(pid)
+        if before is not None and before.start == proc.start:
+            tree_delta += max(0, proc.ticks - before.ticks)
+            tree_delta += max(0, proc.child_ticks - before.child_ticks)
+        else:
+            tree_delta += proc.ticks + proc.child_ticks
     return max(0, busy_delta - tree_delta)
 
 

--- a/tests/utils/ci_cpu_contention.py
+++ b/tests/utils/ci_cpu_contention.py
@@ -3,9 +3,12 @@
 
 Affinity is self-restraint, not a reservation: an unpinned process can still
 be scheduled onto the reserved cores and inflate what a perf gate measures.
-This sampler makes that attributable: each interval it charges CPU time
-consumed on the pinned cores by processes outside the session tree, and the
-fixture prints a summary so a failed speed gate can be triaged from the log.
+This sampler makes that attributable. Foreign load is measured from the
+kernel's per-CPU counters, not from process affinity masks: the cpuset's
+busy ticks minus the session tree's ticks (the tree is pinned, so its time
+is entirely inside the cpuset). Time spent by outsiders on other cores never
+enters the counters, and short-lived intruders are still charged because the
+per-CPU counters survive process exit.
 """
 
 from __future__ import annotations
@@ -26,7 +29,6 @@ FAIL_FOREIGN_CORES = 2.0
 class _Proc:
     ppid: int
     ticks: int
-    overlaps: bool
 
 
 def _parse_cpu_list(spec: str) -> set[int]:
@@ -40,7 +42,20 @@ def _parse_cpu_list(spec: str) -> set[int]:
     return cpus
 
 
-def _snapshot(cpuset: set[int]) -> dict[int, _Proc]:
+def cpuset_busy_ticks(cpuset: set[int]) -> int:
+    """Total non-idle ticks accumulated on the cpuset's cores."""
+    busy = 0
+    with open("/proc/stat", encoding="ascii", errors="replace") as f:
+        for line in f:
+            if line.startswith("cpu") and line[3:4].isdigit():
+                parts = line.split()
+                if int(parts[0][3:]) in cpuset:
+                    nums = list(map(int, parts[1:]))
+                    busy += sum(nums) - nums[3] - nums[4]
+    return busy
+
+
+def _snapshot() -> dict[int, _Proc]:
     procs: dict[int, _Proc] = {}
     for entry in os.listdir("/proc"):
         if not entry.isdigit():
@@ -50,18 +65,7 @@ def _snapshot(cpuset: set[int]) -> dict[int, _Proc]:
             with open(f"/proc/{pid}/stat", "rb") as f:
                 data = f.read().decode("ascii", "replace")
             rest = data[data.rindex(")") + 2 :].split()
-            ppid = int(rest[1])
-            ticks = int(rest[11]) + int(rest[12])
-            allowed = ""
-            with open(f"/proc/{pid}/status", encoding="ascii", errors="replace") as f:
-                for line in f:
-                    if line.startswith("Cpus_allowed_list"):
-                        allowed = line.split(":", 1)[1].strip()
-                        break
-            # note (Jiaxin Deng): an unreadable mask counts as overlapping;
-            # a false positive beats an invisible intruder in this report.
-            overlaps = bool(cpuset & _parse_cpu_list(allowed)) if allowed else True
-            procs[pid] = _Proc(ppid, ticks, overlaps)
+            procs[pid] = _Proc(ppid=int(rest[1]), ticks=int(rest[11]) + int(rest[12]))
         except (OSError, ValueError):
             continue
     return procs
@@ -80,21 +84,38 @@ def _tree_pids(procs: dict[int, _Proc], root: int) -> set[int]:
     return tree
 
 
-def foreign_ticks(prev: dict[int, _Proc], cur: dict[int, _Proc], tree: set[int]) -> int:
-    return sum(
-        cur[pid].ticks - prev[pid].ticks
+def foreign_ticks(
+    busy_delta: int,
+    prev: dict[int, _Proc],
+    cur: dict[int, _Proc],
+    tree: set[int],
+) -> int:
+    """Cpuset busy ticks not accounted for by the pinned session tree.
+
+    A tree process born inside the window is charged its full tick count; a
+    tree process that exited mid-window cannot be deducted, which biases the
+    result upward, the conservative direction for a contention alarm.
+    """
+    tree_delta = sum(
+        cur[pid].ticks - (prev[pid].ticks if pid in prev else 0)
         for pid in cur
-        if pid in prev and cur[pid].overlaps and pid not in tree
+        if pid in tree
     )
+    return max(0, busy_delta - tree_delta)
 
 
 class ContentionSampler:
     """Background sampler; start() before the session, summary() after."""
 
-    def __init__(self, cpuset: set[int], interval_s: float = _SAMPLE_INTERVAL_S):
+    def __init__(
+        self,
+        cpuset: set[int],
+        interval_s: float = _SAMPLE_INTERVAL_S,
+        root_pid: int | None = None,
+    ):
         self._cpuset = set(cpuset)
         self._interval = interval_s
-        self._root = os.getpid()
+        self._root = root_pid or os.getpid()
         self._hz = os.sysconf("SC_CLK_TCK")
         self._samples: list[float] = []
         self._errors = 0
@@ -112,16 +133,18 @@ class ContentionSampler:
         return max(self._samples, default=0.0)
 
     def _loop(self) -> None:
-        prev = _snapshot(self._cpuset)
+        prev_busy = cpuset_busy_ticks(self._cpuset)
+        prev = _snapshot()
         prev_t = time.monotonic()
         while not self._stop.wait(self._interval):
             try:
-                cur = _snapshot(self._cpuset)
+                cur_busy = cpuset_busy_ticks(self._cpuset)
+                cur = _snapshot()
                 now = time.monotonic()
                 tree = _tree_pids(cur, self._root)
-                cores = foreign_ticks(prev, cur, tree) / self._hz / (now - prev_t)
-                self._samples.append(cores)
-                prev, prev_t = cur, now
+                ticks = foreign_ticks(cur_busy - prev_busy, prev, cur, tree)
+                self._samples.append(ticks / self._hz / (now - prev_t))
+                prev_busy, prev, prev_t = cur_busy, cur, now
             except Exception:
                 self._errors += 1
 


### PR DESCRIPTION
Fixes the two review findings on #1415 (thanks @AkazaAkane): affinity-mask overlap charged unpinned processes for work done on other cores, and short-lived intruders escaped the process-scan diff. Measurement now uses the kernel's per-CPU busy counters for the pinned cores minus the session tree's ticks: work elsewhere never enters the counters, and the counters survive process exit.

Hardening from a second adversarial pass on the fix itself:
* Reaped children (server killed at module teardown) are deducted via the parent's cutime/cstime; previously their ticks masqueraded as foreign cores every teardown window.
* Pid identity requires matching starttime; per-pid deltas clamp at zero.
* Busy ticks exclude the duplicated guest fields.
* The controlled test picks the two idlest cores and uses 1s windows.

Verified on the H100 host, 7/7: an inside spinner is charged ~1 core, an outside one is not, and a reaped-child window reports zero foreign. No changes to thresholds, summary format, or fixture wiring.