### PR TITLE
[Perf] Streamline Qwen3-ASR request construction

### DIFF
--- a/sglang_omni/models/qwen3_asr/audio_lengths.py
+++ b/sglang_omni/models/qwen3_asr/audio_lengths.py
@@ -23,7 +23,9 @@ def qwen3_asr_audio_token_lengths(input_lengths: Any) -> torch.Tensor:
 
 def qwen3_asr_num_audio_tokens(num_mel_frames: int) -> int:
     """Scalar wrapper for scheduler request construction."""
-    return int(qwen3_asr_audio_token_lengths(num_mel_frames).item())
+    input_lengths_leave = num_mel_frames % 100
+    feat_lengths = (input_lengths_leave - 1) // 2 + 1
+    return ((feat_lengths - 1) // 2 + 1 - 1) // 2 + 1 + (num_mel_frames // 100) * 13
 
 
 __all__ = [

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any, Callable
 
 import torch
@@ -109,16 +110,35 @@ def make_qwen3_asr_scheduler_adapters(
     vocab_size = len(tokenizer)
     asr_text_token_ids = _encode_literal(tokenizer, _ASR_TEXT)
 
-    def _build_prompt_ids(num_audio_tokens: int, language: str | None) -> list[int]:
+    @lru_cache(maxsize=None)
+    def _prompt_parts(language: str | None) -> tuple[tuple[int, ...], tuple[int, ...]]:
         prompt = (
             f"<|im_start|>user\n"
-            f"{_AUDIO_START}{_AUDIO_PAD * num_audio_tokens}{_AUDIO_END}"
+            f"{_AUDIO_START}{_AUDIO_PAD}{_AUDIO_END}"
             f"<|im_end|>\n"
             f"<|im_start|>assistant\n"
         )
         if language is not None:
             prompt += f"language {language}<asr_text>"
-        return tokenizer(prompt, add_special_tokens=False).input_ids
+        template_ids = tokenizer(prompt, add_special_tokens=False).input_ids
+        pad_positions = [
+            index
+            for index, token_id in enumerate(template_ids)
+            if token_id == audio_pad_token_id
+        ]
+        if len(pad_positions) != 1:
+            raise ValueError(
+                "Qwen3-ASR prompt template must contain exactly one audio pad token"
+            )
+        audio_pad_index = pad_positions[0]
+        return (
+            tuple(template_ids[:audio_pad_index]),
+            tuple(template_ids[audio_pad_index + 1 :]),
+        )
+
+    def _build_prompt_ids(num_audio_tokens: int, language: str | None) -> list[int]:
+        prefix_ids, suffix_ids = _prompt_parts(language)
+        return [*prefix_ids, *([audio_pad_token_id] * num_audio_tokens), *suffix_ids]
 
     def _validate_context_budget(
         input_ids: list[int], request_max_new_tokens: int

--- a/tests/unit_test/qwen3_asr/test_request_builders.py
+++ b/tests/unit_test/qwen3_asr/test_request_builders.py
@@ -94,6 +94,15 @@ def test_qwen3_asr_audio_token_length_formula_is_shared() -> None:
     assert qwen3_asr_num_audio_tokens(3000) == 390
 
 
+@pytest.mark.parametrize("num_mel_frames", range(0, 401))
+def test_qwen3_asr_scalar_audio_token_length_matches_tensor_formula(
+    num_mel_frames: int,
+) -> None:
+    expected = int(qwen3_asr_audio_token_lengths(num_mel_frames).item())
+
+    assert qwen3_asr_num_audio_tokens(num_mel_frames) == expected
+
+
 @pytest.mark.parametrize(
     ("language_code", "expected_name"), sorted(LANGUAGE_CODE_TO_NAME.items())
 )
@@ -193,6 +202,41 @@ def test_qwen3_asr_request_builder_omits_language_prompt_for_auto_detection(
     assert data.language is None
     assert data.req.vocab_size == len(tokenizer)
     assert set(data.req.sampling_params.stop_token_ids) == {2}
+
+
+def test_qwen3_asr_request_builder_caches_prompt_template_per_language(
+    monkeypatch,
+) -> None:
+    tokenizer = _FakeTokenizer()
+    feature_extractor = lambda *args, **kwargs: SimpleNamespace(
+        input_features=torch.zeros((1, 128, 100)),
+        attention_mask=torch.ones((1, 100), dtype=torch.long),
+    )
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(1600, dtype=np.float32),
+    )
+    request_builder, _ = make_qwen3_asr_scheduler_adapters(
+        tokenizer=tokenizer,
+        max_new_tokens=32,
+        feature_extractor=feature_extractor,
+    )
+
+    for request_id in ("req-first", "req-second"):
+        request_builder(
+            StagePayload(
+                request_id=request_id,
+                request=OmniRequest(
+                    inputs={"audio_bytes": b"wav"},
+                    params={"language": "en"},
+                ),
+                data={},
+            )
+        )
+
+    assert len(tokenizer.call_texts) == 1
+    assert tokenizer.call_texts[0].count("<|audio_pad|>") == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Motivation

Qwen3-ASR rebuilds and tokenizes the same chat prompt for every request, including one audio placeholder string per emitted audio token. The scalar mel-frame length path also creates a one-element Torch tensor. At high concurrency these small per-request costs accumulate across the request-build workers.

## Modifications

1. Tokenize the invariant Qwen3-ASR prompt template once per canonical language and expand the audio placeholder token ids directly for each request.
2. Compute scalar audio token lengths with integer arithmetic while preserving the tensor helper used by the model configuration.
3. Cover scalar/tensor length equivalence and prompt-template cache behavior.

This PR applies cleanly to current main and does not depend on the measurement stack.

## Related Issues

Related to #1396.

## Accuracy Test

- Real Qwen3-ASR tokenizer: the previous and candidate prompt ids matched exactly for 24 combinations of language and audio-token length, including 1 through 4096 audio tokens.
- Full SeedTTS EN measurements completed 3,264 of 3,264 requests per configuration with zero skips.
- Corpus WER was identical at 0.012333535 for baseline and candidate.

## Benchmark & Profiling

Setup:

- Model: Qwen/Qwen3-ASR-1.7B revision 7278e1e70fe206f11671096ffdd38061171dd6e5.
- Dataset: full SeedTTS EN, 1,088 clips, revision 27f4c1adee83b5b29b7c4b375f6b976324bda308.
- Hardware: one NVIDIA H200 on hyper00, physical GPU 2, BF16, FA3 attention, decode CUDA graphs enabled, torch.compile disabled.
- Software: SGLang 0.5.16, PyTorch 2.11.0+cu130, Transformers 5.12.1.
- Measurement stack: the effective code from #1404, #1421, and #1422. Baseline commit 5cd2019c80a0b7d3ca2dc6e12ee5459188089c79; candidate commit 55981c2390af98394c22d1911cc016e289772c2a contains the same three-file patch as this PR.
- Protocol: same physical GPU, concurrency 64, one discarded full-corpus warmup pass followed by three measured full-corpus repeats per configuration.

H200 full-corpus results:

| Metric | Baseline | Candidate | Delta |
| --- | ---: | ---: | ---: |
| Throughput | 193.625 req/s | 210.497 req/s | +8.71% |
| Mean latency | 0.326979 s | 0.300483 s | -8.10% |
| P95 latency | 0.472651 s | 0.447586 s | -5.30% |
| Corpus WER | 0.012333535 | 0.012333535 | unchanged |

Per-repeat throughput:

| Repeat | Baseline req/s | Candidate req/s |
| ---: | ---: | ---: |
| 1 | 194.606 | 219.293 |
| 2 | 193.189 | 203.703 |
| 3 | 193.080 | 208.496 |

## Validation

- 518 Qwen3-ASR unit tests passed on current main plus this commit.
- 521 Qwen3-ASR unit tests passed on the measurement stack.
- Pre-commit passed for all changed files.
- Git diff check passed.

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests.
- [x] Provide throughput, latency, and accuracy measurements.
