### PR TITLE
[ASR Refactor][A-PR2] ARK-ASR: pre-lm encoder

### DIFF
--- a/docs/cookbook/arkasr.md
+++ b/docs/cookbook/arkasr.md
@@ -174,6 +174,12 @@ backend). Changing any of those re-keys the cache rather than serving a stale
 embedding. Concurrent requests for identical audio are deduplicated
 single-flight, so the clip is encoded once.
 
+Request building submits encoder work without waiting for the GPU. The
+scheduler holds the built LM request outside its waiting queue until that
+request's encoder future completes, then performs normal admission on the
+scheduler thread. A bounded encoder queue applies backpressure before mel
+tensors can accumulate without limit.
+
 | knob | default | meaning |
 |---|---|---|
 | `enable_pre_lm_encoder` | `true` | Off falls back to encoding inside the LM forward. |
@@ -181,6 +187,7 @@ single-flight, so the clip is encoded once.
 | `pre_lm_cache_size_bytes` | `2 GiB` | Byte budget; LRU evicts past it. |
 | `pre_lm_max_batch_size` | `8` | Max queued requests drained into one `get_audio_feature` call. |
 | `pre_lm_max_batch_wait_ms` | `0` | Batch-formation window. `0` is a greedy drain: items queued while the previous group encoded are taken instantly, so an idle-arrival request pays no batching latency. |
+| `pre_lm_max_pending` | `32` | Max encoder items waiting behind the active batch. |
 
 ### How this relates to `encoder_max_batch_size`
 
@@ -197,11 +204,10 @@ Raising `pre_lm_max_batch_size` above `encoder_max_batch_size` turns a group
 into several bounded forwards; it never widens a single forward, so it does
 not change peak encoder activation memory.
 
-`request_build_max_workers` defaults to **8** because `encode_item` blocks its
-build worker until the embedding is attached — the encoder only ever sees as
-many concurrent items as there are build workers. These concurrency defaults
-are inherited from the Qwen3-ASR sweep (issue #1324 Q-PR5) and have not yet
-been re-measured on ARK.
+`request_build_max_workers` defaults to **2** and
+`request_build_max_pending` to **16**. These workers only perform CPU request
+construction; encoder concurrency and backpressure are owned by the separate
+pre-LM queue.
 
 ## Benchmarking
 

--- a/docs/cookbook/arkasr.md
+++ b/docs/cookbook/arkasr.md
@@ -158,6 +158,51 @@ adversarial / OOD audio. The request builder defensively suppresses every reserv
 marker (all special + `<...>`-added ids except EOS) at sampling via `logit_bias`
 and strips them on decode. This is a verified no-op on clean speech.
 
+## Pre-LM Audio Encoder
+
+Audio encoding runs **before LM admission**, not inside the LM forward. The
+audio encoder executes at request-build time on a dedicated worker thread and
+CUDA stream, and a request is admitted only once its complete LM-ready
+embedding is attached (`MultimodalDataItem.precomputed_embeddings`). Without
+this, every admission stalls the running decode batch for the whole encoder
+forward on the scheduler thread and the default stream.
+
+Encoded embeddings are cached in a bounded CPU LRU keyed on the audio
+fingerprint plus a namespace digest of the encoder pipeline (checkpoint path,
+model config including `merge_factor`, mel front-end fields, dtype, attention
+backend). Changing any of those re-keys the cache rather than serving a stale
+embedding. Concurrent requests for identical audio are deduplicated
+single-flight, so the clip is encoded once.
+
+| knob | default | meaning |
+|---|---|---|
+| `enable_pre_lm_encoder` | `true` | Off falls back to encoding inside the LM forward. |
+| `pre_lm_cache_max_entries` | `4096` | Max cached embeddings. |
+| `pre_lm_cache_size_bytes` | `2 GiB` | Byte budget; LRU evicts past it. |
+| `pre_lm_max_batch_size` | `8` | Max queued requests drained into one `get_audio_feature` call. |
+| `pre_lm_max_batch_wait_ms` | `0` | Batch-formation window. `0` is a greedy drain: items queued while the previous group encoded are taken instantly, so an idle-arrival request pays no batching latency. |
+
+### How this relates to `encoder_max_batch_size`
+
+The two batch knobs act at different levels and both stay in force:
+
+- `pre_lm_max_batch_size` decides **how many queued requests are handed to one
+  `get_audio_feature` call**.
+- `encoder_max_batch_size` decides **how that call is executed** — it pads and
+  masks the group, then splits it into sequential microbatches to bound
+  encoder activation memory.
+
+Both default to `8`, so one drained group is exactly one encoder microbatch.
+Raising `pre_lm_max_batch_size` above `encoder_max_batch_size` turns a group
+into several bounded forwards; it never widens a single forward, so it does
+not change peak encoder activation memory.
+
+`request_build_max_workers` defaults to **8** because `encode_item` blocks its
+build worker until the embedding is attached — the encoder only ever sees as
+many concurrent items as there are build workers. These concurrency defaults
+are inherited from the Qwen3-ASR sweep (issue #1324 Q-PR5) and have not yet
+been re-measured on ARK.
+
 ## Benchmarking
 
 Use `benchmarks/eval/benchmark_asr_seedtts.py` to sweep ASR concurrency on

--- a/sglang_omni/models/arkasr/config.py
+++ b/sglang_omni/models/arkasr/config.py
@@ -27,8 +27,19 @@ class ArkasrPipelineConfig(PipelineConfig):
                 "max_running_requests": 32,
                 "encoder_max_batch_size": 8,
                 "max_new_tokens": 256,
-                "request_build_max_workers": 2,
-                "request_build_max_pending": 16,
+                # encode_item blocks its request-build worker until the
+                # embedding is attached, so the encoder only ever sees as many
+                # concurrent items as there are build workers; two workers
+                # would cap pre-LM encode groups at two (Qwen3-ASR #1341).
+                "request_build_max_workers": 8,
+                "request_build_max_pending": 32,
+                "enable_pre_lm_encoder": True,
+                "pre_lm_cache_max_entries": 4096,
+                "pre_lm_cache_size_bytes": 2 * 1024**3,
+                # one drained group maps to exactly one encoder microbatch at
+                # the matching encoder_max_batch_size default.
+                "pre_lm_max_batch_size": 8,
+                "pre_lm_max_batch_wait_ms": 0,
             },
             gpu=0,
             terminal=True,

--- a/sglang_omni/models/arkasr/config.py
+++ b/sglang_omni/models/arkasr/config.py
@@ -27,12 +27,8 @@ class ArkasrPipelineConfig(PipelineConfig):
                 "max_running_requests": 32,
                 "encoder_max_batch_size": 8,
                 "max_new_tokens": 256,
-                # encode_item blocks its request-build worker until the
-                # embedding is attached, so the encoder only ever sees as many
-                # concurrent items as there are build workers; two workers
-                # would cap pre-LM encode groups at two (Qwen3-ASR #1341).
-                "request_build_max_workers": 8,
-                "request_build_max_pending": 32,
+                "request_build_max_workers": 2,
+                "request_build_max_pending": 16,
                 "enable_pre_lm_encoder": True,
                 "pre_lm_cache_max_entries": 4096,
                 "pre_lm_cache_size_bytes": 2 * 1024**3,
@@ -40,6 +36,7 @@ class ArkasrPipelineConfig(PipelineConfig):
                 # the matching encoder_max_batch_size default.
                 "pre_lm_max_batch_size": 8,
                 "pre_lm_max_batch_wait_ms": 0,
+                "pre_lm_max_pending": 32,
             },
             gpu=0,
             terminal=True,

--- a/sglang_omni/models/arkasr/config.py
+++ b/sglang_omni/models/arkasr/config.py
@@ -32,8 +32,8 @@ class ArkasrPipelineConfig(PipelineConfig):
                 "enable_pre_lm_encoder": True,
                 "pre_lm_cache_max_entries": 4096,
                 "pre_lm_cache_size_bytes": 2 * 1024**3,
-                # one drained group maps to exactly one encoder microbatch at
-                # the matching encoder_max_batch_size default.
+                # Note (Akazaakane): One drained group maps to exactly one
+                # encoder microbatch at the matching encoder_max_batch_size.
                 "pre_lm_max_batch_size": 8,
                 "pre_lm_max_batch_wait_ms": 0,
                 "pre_lm_max_pending": 32,

--- a/sglang_omni/models/arkasr/encoder_service.py
+++ b/sglang_omni/models/arkasr/encoder_service.py
@@ -1,0 +1,535 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Precompute and cache complete LM-ready ARK-ASR audio embeddings.
+
+A-PR2. Today ``ArkasrForConditionalGeneration.get_audio_feature`` runs inside
+multimodal embedding construction on the LM forward path, so every admission
+stalls the running decode batch for the whole audio-encoder forward on the
+scheduler thread and the default stream. This service mirrors the shared
+pre-LM encoder pattern (Qwen3-ASR / Fun-ASR): complete audio-encoder execution
+happens at request-build time on a dedicated worker thread and CUDA stream, and
+the request is admitted with ``MultimodalDataItem.precomputed_embeddings``
+already attached.
+
+Batching composes with A-PR4 (#1411) rather than duplicating it. This service
+decides *how many queued requests are handed to one* ``get_audio_feature``
+call (``max_batch_size``, drained from the request-build queue);
+``get_audio_feature`` then pads-and-masks that group and splits it into
+sequential microbatches of ``encoder_max_batch_size`` to bound activation
+memory. Both default to 8, so one drained group is exactly one encoder
+microbatch. Raising ``max_batch_size`` above ``encoder_max_batch_size`` is
+what turns the group into several bounded forwards; it does not widen any
+single forward.
+
+The ``pre_lm_max_batch_size`` / ``pre_lm_max_batch_wait_ms`` knob names follow
+Fun-ASR and Qwen3-ASR. Note the difference from those models: Fun-ASR's
+pad+mask encoder has no internal bound, so there its one knob sets the actual
+encoder width, whereas for ARK it only sets how many requests reach the call.
+(MOSS-TD spells its drain size ``encoder_max_batch_size``; that name is
+already ARK's model-internal bound, so it is deliberately not reused here.)
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import contextlib
+import hashlib
+import json
+import logging
+import queue
+import threading
+import time
+import traceback
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any, cast
+
+import torch
+from sglang.srt.managers.schedule_batch import MultimodalInputFormat
+
+from sglang_omni.scheduling.pre_lm_encoder import PreLMEncoderService, QueueEntry
+from sglang_omni.scheduling.stage_cache import StageOutputCache
+
+logger = logging.getLogger(__name__)
+
+_CACHE_MAX_ENTRIES = 4096
+_CACHE_MAX_BYTES = 2 * 1024**3
+_SHUTDOWN = object()
+
+# WhisperFeatureExtractor identity fields; a change to any of these changes the
+# mel features and therefore the embedding.
+_FRONTEND_CONFIG_FIELDS = (
+    "feature_size",
+    "sampling_rate",
+    "hop_length",
+    "chunk_length",
+    "n_fft",
+    "nb_max_frames",
+    "padding_value",
+)
+
+
+@dataclass(frozen=True)
+class _DetachedFailure:
+    exception: Exception
+    formatted_traceback: str
+
+
+def build_cache_namespace(
+    model: Any,
+    *,
+    model_path: str,
+    feature_extractor: Any,
+    mm_attention_backend: str | None,
+) -> str:
+    """Digest identifying this process's encoder pipeline for cache keying."""
+    config = getattr(model, "config", None)
+    if hasattr(config, "to_dict"):
+        model_config: Any = config.to_dict()
+    else:
+        model_config = repr(config)
+    reference = next(model.audio_encoder.parameters())
+    payload = {
+        "model_path": model_path,
+        # ArkasrConfig.to_dict carries merge_factor and the nested
+        # whisper_config, so an adapter or tower change re-keys the cache.
+        "model_config": model_config,
+        "frontend": {
+            field: getattr(feature_extractor, field, None)
+            for field in _FRONTEND_CONFIG_FIELDS
+        },
+        "dtype": str(reference.dtype),
+        "mm_attention_backend": mm_attention_backend or "default",
+        "device_type": reference.device.type,
+    }
+    blob = json.dumps(payload, sort_keys=True, default=str).encode()
+    return hashlib.blake2b(blob, digest_size=8).hexdigest()
+
+
+def _expected_audio_tokens(item: Any) -> int | None:
+    """Audio placeholder token count for an item (rows the LM expects)."""
+    num_tokens = getattr(item, "num_audio_tokens", None)
+    return int(num_tokens) if num_tokens is not None else None
+
+
+def _text_hidden_size(model: Any) -> int:
+    # ArkasrConfig subclasses Qwen2Config, so the LM hidden size is top level;
+    # it is also the adapter's output dim (ArkAudioMLPAdapter.adapting).
+    hidden_size = getattr(model.config, "hidden_size", None)
+    if hidden_size is None:
+        raise RuntimeError("ARK-ASR config does not expose hidden_size")
+    return int(hidden_size)
+
+
+class ArkasrPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Tensor]):
+    """Encode before admission with single-flight deduplication and a CPU LRU."""
+
+    ENCODE_TIMEOUT_S = 300.0
+
+    def __init__(
+        self,
+        model: Any,
+        *,
+        cache_namespace: str,
+        cache_max_entries: int = _CACHE_MAX_ENTRIES,
+        cache_max_bytes: int = _CACHE_MAX_BYTES,
+        max_batch_size: int = 8,
+        max_batch_wait_ms: int = 0,
+    ) -> None:
+        self._model = model
+        reference = next(model.audio_encoder.parameters())
+        self._device = reference.device
+        self._dtype = reference.dtype
+        self._hidden_size = _text_hidden_size(model)
+        self._stream = (
+            torch.cuda.Stream(device=self._device)
+            if self._device.type == "cuda"
+            else None
+        )
+        self._cache = StageOutputCache(
+            max_size=cache_max_entries,
+            max_bytes=cache_max_bytes,
+            cache_device="cpu",
+        )
+        self._namespace = cache_namespace
+        self._max_batch_size = max(int(max_batch_size), 1)
+        self._max_batch_wait_s = max(float(max_batch_wait_ms), 0.0) / 1000.0
+        self._lock = threading.Lock()
+        self._lifecycle_lock = threading.Lock()
+        self._closed = False
+        self._inflight: dict[str, concurrent.futures.Future[torch.Tensor]] = {}
+        self._hits = 0
+        self._misses = 0
+        self._merged = 0
+        self._failed = 0
+        self._batch_count = 0
+        self._item_count = 0
+        self._queue_wait_count = 0
+        self._queue_wait_total_s = 0.0
+        self._queue_wait_max_s = 0.0
+        self._encoder_time_s = 0.0
+        super().__init__(worker_name="arkasr-audio-encode")
+
+    def close(self) -> None:
+        """Stop the encoder worker after all queued requests finish."""
+        with self._lifecycle_lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._queue.put(_SHUTDOWN)
+        self._thread.join(timeout=5)
+
+    def _enqueue(
+        self,
+        item: Any,
+        future: concurrent.futures.Future[torch.Tensor],
+    ) -> None:
+        with self._lifecycle_lock:
+            if self._closed:
+                raise RuntimeError("ARK-ASR pre-LM encoder service is closed")
+            self._queue.put(
+                QueueEntry(
+                    item=item,
+                    future=future,
+                    enqueued_at=time.perf_counter(),
+                )
+            )
+
+    def encode_item(self, item: Any) -> None:
+        """Block until ``item.precomputed_embeddings`` holds the LM embedding.
+
+        On success ``item.feature`` is cleared to release the CPU mel tensor.
+        Raises on encode failure; the request must not be admitted without the
+        complete embedding.
+        """
+        expected_tokens = _expected_audio_tokens(item)
+        if expected_tokens is None:
+            raise RuntimeError(
+                "ARK-ASR pre-LM encode requires the item's num_audio_tokens"
+            )
+        key = self._cache_key(item)
+
+        if key is None:
+            future = self._submit(item)
+            future.result(timeout=self.ENCODE_TIMEOUT_S)
+            return
+
+        cached = self._cache.get(key)
+        if cached is not None:
+            if self._is_valid(cached, expected_tokens):
+                with self._lock:
+                    self._hits += 1
+                self.attach_embedding(item, cached)
+                return
+            logger.warning(
+                f"ARK-ASR pre-LM cache entry {key} failed validation "
+                f"(shape={tuple(cached.shape)}, dtype={cached.dtype}); "
+                f"discarding it if unchanged before re-encoding"
+            )
+            self._cache.remove_if_same(key, cached)
+            cached = None
+
+        leader = False
+        with self._lock:
+            future = self._inflight.get(key)
+            if future is None:
+                # re-check under the single-flight lock so a stale miss cannot
+                # start work after the prior leader cached.
+                cached = self._cache.get(key)
+                if cached is not None and self._is_valid(cached, expected_tokens):
+                    self._hits += 1
+                else:
+                    cached = None
+                    future = concurrent.futures.Future()
+                    self._inflight[key] = future
+                    leader = True
+                    self._misses += 1
+                    try:
+                        self._submit(item, future)
+                    except Exception:
+                        del self._inflight[key]
+                        raise
+            else:
+                self._merged += 1
+        if cached is not None:
+            self.attach_embedding(item, cached)
+            return
+        try:
+            embedding = future.result(timeout=self.ENCODE_TIMEOUT_S)
+        except Exception:
+            with self._lock:
+                self._failed += 1
+            raise
+        finally:
+            if leader:
+                with self._lock:
+                    if self._inflight.get(key) is future:
+                        del self._inflight[key]
+        if leader:
+            return
+        if not self._is_valid(embedding, expected_tokens):
+            with self._lock:
+                self._failed += 1
+            raise RuntimeError(
+                f"ARK-ASR pre-LM encode leader for {key} returned an invalid "
+                f"embedding"
+            )
+        self.attach_embedding(item, embedding)
+
+    def stats(self) -> dict[str, int | float]:
+        with self._lock:
+            cache_lookups = self._hits + self._misses
+            return {
+                "hits": self._hits,
+                "misses": self._misses,
+                "merged": self._merged,
+                "failed": self._failed,
+                "cache_hit_rate": (
+                    self._hits / cache_lookups if cache_lookups else 0.0
+                ),
+                "batches": self._batch_count,
+                "items": self._item_count,
+                "queue_depth": self._queue.qsize(),
+                "queue_wait_avg_s": (
+                    self._queue_wait_total_s / self._queue_wait_count
+                    if self._queue_wait_count
+                    else 0.0
+                ),
+                "queue_wait_max_s": self._queue_wait_max_s,
+                "encoder_time_s": self._encoder_time_s,
+                "cache_entries": len(self._cache),
+                "cache_bytes": self._cache.current_bytes,
+                "cache_evictions": self._cache.eviction_count,
+            }
+
+    def _cache_key(self, item: Any) -> str | None:
+        item_hash = getattr(item, "audio_fingerprint", None)
+        if item_hash is None:
+            return None
+        return f"{self._namespace}:{item_hash}"
+
+    def _is_valid(self, embedding: Any, expected_tokens: int) -> bool:
+        return (
+            isinstance(embedding, torch.Tensor)
+            and embedding.dim() == 2
+            and embedding.shape[0] == expected_tokens
+            and embedding.shape[1] == self._hidden_size
+            and embedding.dtype == self._dtype
+        )
+
+    def attach_embedding(self, item: Any, embedding: torch.Tensor) -> None:
+        embedding = embedding.to(self._device, non_blocking=True)
+        if self._stream is not None and embedding.is_cuda:
+            # the batch path allocates on the private stream while the LM
+            # consumes on the default stream; register the consumer so the
+            # allocator cannot recycle the block for a later batch while LM
+            # reads are still queued.
+            embedding.record_stream(torch.cuda.default_stream(self._device))
+        item.precomputed_embeddings = embedding
+        item.feature = None
+        item.format = MultimodalInputFormat.PRECOMPUTED_EMBEDDING
+
+    def _drain_batch(
+        self,
+    ) -> tuple[list[QueueEntry[Any]], bool]:
+        # the default window is 0 (greedy drain): items that queued while the
+        # previous batch encoded are taken instantly, so groups still form
+        # under load, and an idle-arrival request never pays a batching wait --
+        # at concurrency 1 a window is pure latency.
+        first = self._queue.get()
+        if first is _SHUTDOWN:
+            return [], True
+        batch = [cast(QueueEntry[Any], first)]
+        deadline = time.monotonic() + self._max_batch_wait_s
+        shutdown = False
+        while len(batch) < self._max_batch_size:
+            try:
+                remaining = deadline - time.monotonic()
+                queued = (
+                    self._queue.get(timeout=remaining)
+                    if remaining > 0
+                    else self._queue.get_nowait()
+                )
+            except queue.Empty:
+                break
+            if queued is _SHUTDOWN:
+                shutdown = True
+                break
+            batch.append(cast(QueueEntry[Any], queued))
+        return batch, shutdown
+
+    def _next_batch(self) -> tuple[list[QueueEntry[Any]], bool]:
+        return self._drain_batch()
+
+    @contextlib.contextmanager
+    def _batch_context(self) -> Iterator[None]:
+        with torch.inference_mode():
+            if self._stream is None:
+                yield
+            else:
+                with torch.cuda.stream(self._stream):
+                    yield
+
+    def encode_batch(self, items: list[Any]) -> torch.Tensor:
+        return self._model.get_audio_feature(items)
+
+    def split_embeddings(
+        self,
+        items: list[Any],
+        embedding: torch.Tensor,
+    ) -> list[torch.Tensor]:
+        token_counts = []
+        for item in items:
+            expected = _expected_audio_tokens(item)
+            if expected is None:
+                raise RuntimeError(
+                    "ARK-ASR pre-LM encode item is missing its audio token count"
+                )
+            token_counts.append(expected)
+        # get_audio_feature concatenates each item's [tokens_i, hidden] block
+        # along the token axis, so the result is already flat.
+        if (
+            embedding.dim() != 2
+            or embedding.shape[0] != sum(token_counts)
+            or embedding.shape[1] != self._hidden_size
+            or embedding.dtype != self._dtype
+        ):
+            raise RuntimeError(
+                f"ARK-ASR encoder output {tuple(embedding.shape)} "
+                f"({embedding.dtype}) != expected rows "
+                f"{sum(token_counts)}x{self._hidden_size} ({self._dtype})"
+            )
+        parts = torch.split(embedding, token_counts, dim=0)
+        return [part.clone() for part in parts]
+
+    def synchronize_batch(self) -> None:
+        if self._stream is not None:
+            self._stream.synchronize()
+
+    def cache_embedding(self, item: Any, embedding: torch.Tensor) -> None:
+        key = self._cache_key(item)
+        if key is not None:
+            self._cache.put(key, embedding)
+
+    def _retry_batch(self, batch: list[QueueEntry[Any]], _exc: Exception) -> bool:
+        return len(batch) > 1
+
+    def _handle_batch_failure(
+        self,
+        batch: list[QueueEntry[Any]],
+        exc: Exception,
+    ) -> Exception:
+        failure = self._detach_failure(exc)
+        if len(batch) == 1:
+            logger.error(
+                "ARK-ASR audio encode failed:\n%s",
+                failure.formatted_traceback,
+            )
+        else:
+            logger.error(
+                "ARK-ASR batched audio encode failed for %d items; "
+                "retrying per item:\n%s",
+                len(batch),
+                failure.formatted_traceback,
+            )
+        self._recover_after_failure(failure.exception)
+        return failure.exception
+
+    def _handle_item_failure(
+        self,
+        _entry: QueueEntry[Any],
+        exc: Exception,
+    ) -> Exception:
+        failure = self._detach_failure(exc)
+        logger.error(
+            "ARK-ASR per-item audio encode retry failed:\n%s",
+            failure.formatted_traceback,
+        )
+        self._recover_after_failure(failure.exception)
+        return failure.exception
+
+    @staticmethod
+    def _detach_failure(exc: Exception) -> _DetachedFailure:
+        # keep the formatted traceback for logs but drop frame references from
+        # the propagated exception; a future holding a traceback would pin
+        # encoder tensors after an OOM.
+        formatted_traceback = "".join(traceback.format_exception(exc)).rstrip()
+        message = str(exc)
+        traceback.clear_frames(exc.__traceback__)
+        exc.__traceback__ = None
+        exc.__cause__ = None
+        exc.__context__ = None
+        if isinstance(exc, torch.OutOfMemoryError):
+            detached: Exception = torch.OutOfMemoryError(message)
+        elif isinstance(exc, ValueError):
+            detached = ValueError(message)
+        else:
+            detached = RuntimeError(f"{type(exc).__name__}: {message}")
+        return _DetachedFailure(
+            exception=detached,
+            formatted_traceback=formatted_traceback,
+        )
+
+    def _recover_after_failure(self, exc: Exception) -> None:
+        if not isinstance(exc, torch.OutOfMemoryError):
+            return
+        if self._stream is not None:
+            try:
+                self._stream.synchronize()
+            except Exception:
+                logger.warning(
+                    "ARK-ASR encoder stream cleanup failed after OOM",
+                    exc_info=True,
+                )
+        try:
+            with torch.cuda.device(self._device):
+                torch.cuda.empty_cache()
+        except Exception:
+            logger.warning("ARK-ASR CUDA cache cleanup failed after OOM", exc_info=True)
+
+    def _on_batch_start(self, batch: list[QueueEntry[Any]]) -> None:
+        dequeue_time = time.perf_counter()
+        queue_waits = [
+            dequeue_time - entry.enqueued_at
+            for entry in batch
+            if entry.enqueued_at is not None
+        ]
+        with self._lock:
+            self._queue_wait_count += len(queue_waits)
+            self._queue_wait_total_s += sum(queue_waits)
+            self._queue_wait_max_s = max(
+                self._queue_wait_max_s,
+                max(queue_waits, default=0.0),
+            )
+
+    def _on_batch_finished(
+        self,
+        batch: list[QueueEntry[Any]],
+        batch_exc: Exception | None,
+        retry_recovered: int | None,
+        elapsed_s: float,
+    ) -> None:
+        with self._lock:
+            self._encoder_time_s += elapsed_s
+            if batch_exc is not None:
+                if retry_recovered is not None:
+                    # retried items are single-item batches.
+                    self._batch_count += retry_recovered
+                    self._item_count += retry_recovered
+                return
+            self._batch_count += 1
+            self._item_count += len(batch)
+            batch_count = self._batch_count
+            item_count = self._item_count
+        if batch_count % 50 == 1:
+            logger.info(
+                f"ARK-ASR pre-LM encoder stage: {batch_count} batches, "
+                f"{item_count} items (avg "
+                f"{item_count / batch_count:.2f} items/batch, "
+                f"last batch: {len(batch)}), cache: {self.stats()}"
+            )
+
+
+__all__ = [
+    "ArkasrPreLMEncoderService",
+    "build_cache_namespace",
+]

--- a/sglang_omni/models/arkasr/encoder_service.py
+++ b/sglang_omni/models/arkasr/encoder_service.py
@@ -134,6 +134,7 @@ class ArkasrPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
         cache_max_bytes: int = _CACHE_MAX_BYTES,
         max_batch_size: int = 8,
         max_batch_wait_ms: int = 0,
+        max_queue_size: int = 0,
     ) -> None:
         self._model = model
         reference = next(model.audio_encoder.parameters())
@@ -163,11 +164,18 @@ class ArkasrPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
         self._failed = 0
         self._batch_count = 0
         self._item_count = 0
+        self._submitted = 0
+        self._pending = 0
+        self._queue_full_waits = 0
+        self._queue_depth_max = 0
         self._queue_wait_count = 0
         self._queue_wait_total_s = 0.0
         self._queue_wait_max_s = 0.0
         self._encoder_time_s = 0.0
-        super().__init__(worker_name="arkasr-audio-encode")
+        super().__init__(
+            worker_name="arkasr-audio-encode",
+            max_queue_size=max_queue_size,
+        )
 
     def close(self) -> None:
         """Stop the encoder worker after all queued requests finish."""
@@ -183,24 +191,35 @@ class ArkasrPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
         item: Any,
         future: concurrent.futures.Future[torch.Tensor],
     ) -> None:
-        with self._lifecycle_lock:
-            if self._closed:
-                raise RuntimeError("ARK-ASR pre-LM encoder service is closed")
-            self._queue.put(
-                QueueEntry(
-                    item=item,
-                    future=future,
-                    enqueued_at=time.perf_counter(),
-                )
-            )
+        queue_was_full = False
+        entry = QueueEntry(
+            item=item,
+            future=future,
+            enqueued_at=time.perf_counter(),
+        )
+        while True:
+            with self._lifecycle_lock:
+                if self._closed:
+                    raise RuntimeError("ARK-ASR pre-LM encoder service is closed")
+                try:
+                    self._queue.put_nowait(entry)
+                    break
+                except queue.Full:
+                    queue_was_full = True
+            with self._worker_state_lock:
+                if self._worker_error is not None:
+                    raise RuntimeError(
+                        "pre-LM encoder worker has failed"
+                    ) from self._worker_error
+            time.sleep(0.01)
+        queue_depth = self._queue.qsize()
+        with self._lock:
+            if queue_was_full:
+                self._queue_full_waits += 1
+            self._queue_depth_max = max(self._queue_depth_max, queue_depth)
 
-    def encode_item(self, item: Any) -> None:
-        """Block until ``item.precomputed_embeddings`` holds the LM embedding.
-
-        On success ``item.feature`` is cleared to release the CPU mel tensor.
-        Raises on encode failure; the request must not be admitted without the
-        complete embedding.
-        """
+    def submit_item(self, item: Any) -> concurrent.futures.Future[torch.Tensor]:
+        """Return when the item has been queued for LM-ready encoding."""
         expected_tokens = _expected_audio_tokens(item)
         if expected_tokens is None:
             raise RuntimeError(
@@ -209,9 +228,7 @@ class ArkasrPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
         key = self._cache_key(item)
 
         if key is None:
-            future = self._submit(item)
-            future.result(timeout=self.ENCODE_TIMEOUT_S)
-            return
+            return self._track_submission(self._submit(item))
 
         cached = self._cache.get(key)
         if cached is not None:
@@ -219,7 +236,11 @@ class ArkasrPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
                 with self._lock:
                     self._hits += 1
                 self.attach_embedding(item, cached)
-                return
+                future: concurrent.futures.Future[torch.Tensor] = (
+                    concurrent.futures.Future()
+                )
+                future.set_result(cached)
+                return self._track_submission(future)
             logger.warning(
                 f"ARK-ASR pre-LM cache entry {key} failed validation "
                 f"(shape={tuple(cached.shape)}, dtype={cached.dtype}); "
@@ -228,12 +249,11 @@ class ArkasrPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
             self._cache.remove_if_same(key, cached)
             cached = None
 
+        follower_of: concurrent.futures.Future[torch.Tensor] | None = None
         leader = False
         with self._lock:
             future = self._inflight.get(key)
             if future is None:
-                # re-check under the single-flight lock so a stale miss cannot
-                # start work after the prior leader cached.
                 cached = self._cache.get(key)
                 if cached is not None and self._is_valid(cached, expected_tokens):
                     self._hits += 1
@@ -250,30 +270,79 @@ class ArkasrPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
                         raise
             else:
                 self._merged += 1
+                follower_of = future
         if cached is not None:
             self.attach_embedding(item, cached)
-            return
-        try:
-            embedding = future.result(timeout=self.ENCODE_TIMEOUT_S)
-        except Exception:
-            with self._lock:
-                self._failed += 1
-            raise
-        finally:
-            if leader:
-                with self._lock:
-                    if self._inflight.get(key) is future:
-                        del self._inflight[key]
-        if leader:
-            return
-        if not self._is_valid(embedding, expected_tokens):
-            with self._lock:
-                self._failed += 1
-            raise RuntimeError(
-                f"ARK-ASR pre-LM encode leader for {key} returned an invalid "
-                f"embedding"
+            completed: concurrent.futures.Future[torch.Tensor] = (
+                concurrent.futures.Future()
             )
-        self.attach_embedding(item, embedding)
+            completed.set_result(cached)
+            return self._track_submission(completed)
+        if leader:
+            future.add_done_callback(
+                lambda done, cache_key=key: self._clear_inflight(cache_key, done)
+            )
+        if follower_of is None:
+            return self._track_submission(future)
+
+        item.feature = None
+        completion: concurrent.futures.Future[torch.Tensor] = (
+            concurrent.futures.Future()
+        )
+
+        def attach_follower(done: concurrent.futures.Future[torch.Tensor]) -> None:
+            try:
+                embedding = done.result()
+                if not self._is_valid(embedding, expected_tokens):
+                    raise RuntimeError(
+                        f"ARK-ASR pre-LM encode leader for {key} returned an "
+                        "invalid embedding"
+                    )
+                self.attach_embedding(item, embedding)
+                completion.set_result(embedding)
+            except Exception as exc:
+                completion.set_exception(exc)
+
+        follower_of.add_done_callback(attach_follower)
+        return self._track_submission(completion)
+
+    def encode_item(self, item: Any) -> None:
+        """Block until ``item.precomputed_embeddings`` holds the LM embedding.
+
+        On success ``item.feature`` is cleared to release the CPU mel tensor.
+        Raises on encode failure; the request must not be admitted without the
+        complete embedding.
+        """
+        self.submit_item(item).result(timeout=self.ENCODE_TIMEOUT_S)
+
+    def _track_submission(
+        self, future: concurrent.futures.Future[torch.Tensor]
+    ) -> concurrent.futures.Future[torch.Tensor]:
+        with self._lock:
+            self._submitted += 1
+            self._pending += 1
+
+        def finish(done: concurrent.futures.Future[torch.Tensor]) -> None:
+            try:
+                failed = done.exception() is not None
+            except concurrent.futures.CancelledError:
+                failed = True
+            with self._lock:
+                self._pending -= 1
+                if failed:
+                    self._failed += 1
+
+        future.add_done_callback(finish)
+        return future
+
+    def _clear_inflight(
+        self,
+        key: str,
+        future: concurrent.futures.Future[torch.Tensor],
+    ) -> None:
+        with self._lock:
+            if self._inflight.get(key) is future:
+                del self._inflight[key]
 
     def stats(self) -> dict[str, int | float]:
         with self._lock:
@@ -283,6 +352,10 @@ class ArkasrPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
                 "misses": self._misses,
                 "merged": self._merged,
                 "failed": self._failed,
+                "submitted": self._submitted,
+                "pending": self._pending,
+                "queue_full_waits": self._queue_full_waits,
+                "queue_depth_max": self._queue_depth_max,
                 "cache_hit_rate": (
                     self._hits / cache_lookups if cache_lookups else 0.0
                 ),

--- a/sglang_omni/models/arkasr/encoder_service.py
+++ b/sglang_omni/models/arkasr/encoder_service.py
@@ -263,11 +263,6 @@ class ArkasrPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
                     self._inflight[key] = future
                     leader = True
                     self._misses += 1
-                    try:
-                        self._submit(item, future)
-                    except Exception:
-                        del self._inflight[key]
-                        raise
             else:
                 self._merged += 1
                 follower_of = future
@@ -282,6 +277,12 @@ class ArkasrPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
             future.add_done_callback(
                 lambda done, cache_key=key: self._clear_inflight(cache_key, done)
             )
+            try:
+                self._submit(item, future)
+            except Exception as exc:
+                if not future.done():
+                    future.set_exception(exc)
+                raise
         if follower_of is None:
             return self._track_submission(future)
 

--- a/sglang_omni/models/arkasr/engine_builder.py
+++ b/sglang_omni/models/arkasr/engine_builder.py
@@ -9,6 +9,10 @@ from sglang.srt.managers.mm_utils import init_mm_embedding_cache
 from transformers import AutoConfig, AutoTokenizer, WhisperFeatureExtractor
 
 from sglang_omni.models.arkasr import request_builders
+from sglang_omni.models.arkasr.encoder_service import (
+    ArkasrPreLMEncoderService,
+    build_cache_namespace,
+)
 from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
 from sglang_omni.utils.gpu_compat import get_visible_gpu_sm_version
 
@@ -31,7 +35,20 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
         mm_attention_backend: str | None,
         request_build_max_workers: int,
         request_build_max_pending: int | None,
+        enable_pre_lm_encoder: bool = True,
+        pre_lm_cache_max_entries: int = 4096,
+        pre_lm_cache_size_bytes: int = 2 * 1024**3,
+        pre_lm_max_batch_size: int = 8,
+        pre_lm_max_batch_wait_ms: int = 0,
     ) -> None:
+        if pre_lm_max_batch_size < 1:
+            raise ValueError(
+                f"pre_lm_max_batch_size must be >= 1, got {pre_lm_max_batch_size}"
+            )
+        if pre_lm_max_batch_wait_ms < 0:
+            raise ValueError(
+                f"pre_lm_max_batch_wait_ms must be >= 0, got {pre_lm_max_batch_wait_ms}"
+            )
         self.max_running_requests = max_running_requests
         self.encoder_max_batch_size = encoder_max_batch_size
         self.max_new_tokens = int(max_new_tokens)
@@ -43,13 +60,21 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
         self.mm_attention_backend = mm_attention_backend
         self.request_build_max_workers = request_build_max_workers
         self.request_build_max_pending = request_build_max_pending
+        self.enable_pre_lm_encoder = enable_pre_lm_encoder
+        self.pre_lm_cache_max_entries = pre_lm_cache_max_entries
+        self.pre_lm_cache_size_bytes = pre_lm_cache_size_bytes
+        self.pre_lm_max_batch_size = pre_lm_max_batch_size
+        self.pre_lm_max_batch_wait_ms = pre_lm_max_batch_wait_ms
         self.tokenizer: Any = None
         self.feature_extractor: Any = None
         self.merge_factor = 4
         self.audio_token_id = 151663
         self.context_length = 0
+        self.model_path: str | None = None
+        self.audio_encoder_service: Any = None
 
     def pre_infra_setup(self, checkpoint_dir: str) -> None:
+        self.model_path = checkpoint_dir
         self.tokenizer = AutoTokenizer.from_pretrained(
             checkpoint_dir, trust_remote_code=True
         )
@@ -89,9 +114,27 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
         *,
         generation_cuda_graph_enabled: bool,
     ) -> None:
-        del server_args, generation_cuda_graph_enabled
+        del generation_cuda_graph_enabled
         model.set_encoder_max_batch_size(self.encoder_max_batch_size)
         init_mm_embedding_cache(self.mm_embedding_cache_size_bytes)
+        if self.enable_pre_lm_encoder:
+            # constructed after SGLang's generation CUDA graphs so the
+            # encoder's dedicated stream never interleaves with graph capture.
+            self.audio_encoder_service = ArkasrPreLMEncoderService(
+                model,
+                cache_namespace=build_cache_namespace(
+                    model,
+                    model_path=self.model_path or "",
+                    feature_extractor=self.feature_extractor,
+                    mm_attention_backend=getattr(
+                        server_args, "mm_attention_backend", None
+                    ),
+                ),
+                cache_max_entries=self.pre_lm_cache_max_entries,
+                cache_max_bytes=self.pre_lm_cache_size_bytes,
+                max_batch_size=self.pre_lm_max_batch_size,
+                max_batch_wait_ms=self.pre_lm_max_batch_wait_ms,
+            )
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:
         del model
@@ -101,7 +144,18 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
             max_new_tokens=self.max_new_tokens,
             merge_factor=self.merge_factor,
             audio_token_id=self.audio_token_id,
+            audio_encoder_service=self.audio_encoder_service,
         )
+
+    def extra_scheduler_callbacks(self) -> dict[str, Any]:
+        if self.audio_encoder_service is None:
+            return {}
+        return {"shutdown_callback": self.audio_encoder_service.close}
+
+    def cleanup_build_failure(self) -> None:
+        if self.audio_encoder_service is not None:
+            self.audio_encoder_service.close()
+            self.audio_encoder_service = None
 
     def extra_scheduler_kwargs(self) -> dict[str, Any]:
         return {

--- a/sglang_omni/models/arkasr/engine_builder.py
+++ b/sglang_omni/models/arkasr/engine_builder.py
@@ -40,6 +40,7 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
         pre_lm_cache_size_bytes: int = 2 * 1024**3,
         pre_lm_max_batch_size: int = 8,
         pre_lm_max_batch_wait_ms: int = 0,
+        pre_lm_max_pending: int = 32,
     ) -> None:
         if pre_lm_max_batch_size < 1:
             raise ValueError(
@@ -48,6 +49,10 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
         if pre_lm_max_batch_wait_ms < 0:
             raise ValueError(
                 f"pre_lm_max_batch_wait_ms must be >= 0, got {pre_lm_max_batch_wait_ms}"
+            )
+        if pre_lm_max_pending < 1:
+            raise ValueError(
+                f"pre_lm_max_pending must be >= 1, got {pre_lm_max_pending}"
             )
         self.max_running_requests = max_running_requests
         self.encoder_max_batch_size = encoder_max_batch_size
@@ -65,6 +70,7 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
         self.pre_lm_cache_size_bytes = pre_lm_cache_size_bytes
         self.pre_lm_max_batch_size = pre_lm_max_batch_size
         self.pre_lm_max_batch_wait_ms = pre_lm_max_batch_wait_ms
+        self.pre_lm_max_pending = pre_lm_max_pending
         self.tokenizer: Any = None
         self.feature_extractor: Any = None
         self.merge_factor = 4
@@ -134,6 +140,7 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
                 cache_max_bytes=self.pre_lm_cache_size_bytes,
                 max_batch_size=self.pre_lm_max_batch_size,
                 max_batch_wait_ms=self.pre_lm_max_batch_wait_ms,
+                max_queue_size=self.pre_lm_max_pending,
             )
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:

--- a/sglang_omni/models/arkasr/engine_builder.py
+++ b/sglang_omni/models/arkasr/engine_builder.py
@@ -124,7 +124,7 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
         model.set_encoder_max_batch_size(self.encoder_max_batch_size)
         init_mm_embedding_cache(self.mm_embedding_cache_size_bytes)
         if self.enable_pre_lm_encoder:
-            # constructed after SGLang's generation CUDA graphs so the
+            # Note (Akazaakane): Constructed after generation CUDA graphs so the
             # encoder's dedicated stream never interleaves with graph capture.
             self.audio_encoder_service = ArkasrPreLMEncoderService(
                 model,

--- a/sglang_omni/models/arkasr/request_builders.py
+++ b/sglang_omni/models/arkasr/request_builders.py
@@ -94,6 +94,7 @@ def make_arkasr_scheduler_adapters(
     feature_extractor: Any = None,
     merge_factor: int = 4,
     audio_token_id: int = 151663,
+    audio_encoder_service: Any = None,
 ) -> tuple[Callable[[StagePayload], ArkASRRequestData], Callable[[Any], StagePayload]]:
     if feature_extractor is None:
         raise ValueError("ARK-ASR processor is missing a feature_extractor")
@@ -153,7 +154,13 @@ def make_arkasr_scheduler_adapters(
             modality=Modality.AUDIO,
             hash=prepared.fingerprint_int,
             feature=features,
-            model_specific_data={"feature_attention_mask": feature_attention_mask},
+            model_specific_data={
+                "feature_attention_mask": feature_attention_mask,
+                # the pre-LM encoder service reads these to split batched
+                # encoder output and key its embedding cache.
+                "num_audio_tokens": num_audio_tokens,
+                "audio_fingerprint": fingerprint,
+            },
         )
         # scatter contract (same as qwen3_asr): replace <|audio|> placeholders
         # with the item's pad_value and record the span as inclusive offsets.
@@ -183,6 +190,12 @@ def make_arkasr_scheduler_adapters(
             ),
         )
         sampling_params.normalize(tokenizer=None)
+
+        # encode before Req creation -- a request is only admitted with its
+        # complete LM-ready embedding, and a failed encode raises here instead
+        # of poisoning the waiting queue.
+        if audio_encoder_service is not None:
+            audio_encoder_service.encode_item(audio_item)
 
         req = Req(
             rid=payload.request_id,

--- a/sglang_omni/models/arkasr/request_builders.py
+++ b/sglang_omni/models/arkasr/request_builders.py
@@ -162,7 +162,7 @@ def make_arkasr_scheduler_adapters(
             feature=features,
             model_specific_data={
                 "feature_attention_mask": feature_attention_mask,
-                # the pre-LM encoder service reads these to split batched
+                # Note (Akazaakane): The service reads these to split batched
                 # encoder output and key its embedding cache.
                 "num_audio_tokens": num_audio_tokens,
                 "audio_fingerprint": fingerprint,

--- a/sglang_omni/models/arkasr/request_builders.py
+++ b/sglang_omni/models/arkasr/request_builders.py
@@ -27,6 +27,7 @@ from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang_omni.preprocessing.transcription import prepare_audio
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
+from sglang_omni.scheduling.types import DeferredAdmission
 
 from .audio_lengths import arkasr_num_audio_tokens
 
@@ -95,7 +96,10 @@ def make_arkasr_scheduler_adapters(
     merge_factor: int = 4,
     audio_token_id: int = 151663,
     audio_encoder_service: Any = None,
-) -> tuple[Callable[[StagePayload], ArkASRRequestData], Callable[[Any], StagePayload]]:
+) -> tuple[
+    Callable[[StagePayload], ArkASRRequestData | DeferredAdmission],
+    Callable[[Any], StagePayload],
+]:
     if feature_extractor is None:
         raise ValueError("ARK-ASR processor is missing a feature_extractor")
 
@@ -119,7 +123,9 @@ def make_arkasr_scheduler_adapters(
         )
         return list(tokenizer(prompt, add_special_tokens=False).input_ids)
 
-    def request_builder(payload: StagePayload) -> ArkASRRequestData:
+    def request_builder(
+        payload: StagePayload,
+    ) -> ArkASRRequestData | DeferredAdmission:
         params = payload.request.params or {}
         prepared = prepare_audio(
             payload, source_name="ARK-ASR", target_sample_rate=_SAMPLE_RATE
@@ -191,12 +197,6 @@ def make_arkasr_scheduler_adapters(
         )
         sampling_params.normalize(tokenizer=None)
 
-        # encode before Req creation -- a request is only admitted with its
-        # complete LM-ready embedding, and a failed encode raises here instead
-        # of poisoning the waiting queue.
-        if audio_encoder_service is not None:
-            audio_encoder_service.encode_item(audio_item)
-
         req = Req(
             rid=payload.request_id,
             origin_input_text="",
@@ -208,7 +208,7 @@ def make_arkasr_scheduler_adapters(
         req.multimodal_inputs = mm_inputs
         req._codec_suppress_tokens = None
 
-        return ArkASRRequestData(
+        req_data = ArkASRRequestData(
             input_ids=torch.tensor(input_ids, dtype=torch.long),
             req=req,
             prompt_token_ids=input_ids,
@@ -218,6 +218,12 @@ def make_arkasr_scheduler_adapters(
             language=str(params.get("language") or "en"),
             engine_start_s=time.perf_counter(),
             stage_payload=payload,
+        )
+        if audio_encoder_service is None:
+            return req_data
+        return DeferredAdmission(
+            value=req_data,
+            ready=audio_encoder_service.submit_item(audio_item),
         )
 
     def result_adapter(data: ArkASRRequestData) -> StagePayload:

--- a/sglang_omni/models/arkasr/stages.py
+++ b/sglang_omni/models/arkasr/stages.py
@@ -20,8 +20,13 @@ def create_sglang_arkasr_executor(
     enable_async_decode: bool = True,
     async_decode_min_batch_size: int = 2,
     mm_attention_backend: str | None = None,
-    request_build_max_workers: int = 2,
-    request_build_max_pending: int | None = 16,
+    request_build_max_workers: int = 8,
+    request_build_max_pending: int | None = 32,
+    enable_pre_lm_encoder: bool = True,
+    pre_lm_cache_max_entries: int = 4096,
+    pre_lm_cache_size_bytes: int = 2 * 1024**3,
+    pre_lm_max_batch_size: int = 8,
+    pre_lm_max_batch_wait_ms: int = 0,
     server_args_overrides: dict[str, Any] | None = None,
 ):
     from sglang_omni.models.arkasr.engine_builder import ArkasrEngineBuilder
@@ -38,6 +43,11 @@ def create_sglang_arkasr_executor(
         mm_attention_backend=mm_attention_backend,
         request_build_max_workers=request_build_max_workers,
         request_build_max_pending=request_build_max_pending,
+        enable_pre_lm_encoder=enable_pre_lm_encoder,
+        pre_lm_cache_max_entries=pre_lm_cache_max_entries,
+        pre_lm_cache_size_bytes=pre_lm_cache_size_bytes,
+        pre_lm_max_batch_size=pre_lm_max_batch_size,
+        pre_lm_max_batch_wait_ms=pre_lm_max_batch_wait_ms,
     ).build(
         model_path,
         device=device,

--- a/sglang_omni/models/arkasr/stages.py
+++ b/sglang_omni/models/arkasr/stages.py
@@ -20,13 +20,14 @@ def create_sglang_arkasr_executor(
     enable_async_decode: bool = True,
     async_decode_min_batch_size: int = 2,
     mm_attention_backend: str | None = None,
-    request_build_max_workers: int = 8,
-    request_build_max_pending: int | None = 32,
+    request_build_max_workers: int = 2,
+    request_build_max_pending: int | None = 16,
     enable_pre_lm_encoder: bool = True,
     pre_lm_cache_max_entries: int = 4096,
     pre_lm_cache_size_bytes: int = 2 * 1024**3,
     pre_lm_max_batch_size: int = 8,
     pre_lm_max_batch_wait_ms: int = 0,
+    pre_lm_max_pending: int = 32,
     server_args_overrides: dict[str, Any] | None = None,
 ):
     from sglang_omni.models.arkasr.engine_builder import ArkasrEngineBuilder
@@ -48,6 +49,7 @@ def create_sglang_arkasr_executor(
         pre_lm_cache_size_bytes=pre_lm_cache_size_bytes,
         pre_lm_max_batch_size=pre_lm_max_batch_size,
         pre_lm_max_batch_wait_ms=pre_lm_max_batch_wait_ms,
+        pre_lm_max_pending=pre_lm_max_pending,
     ).build(
         model_path,
         device=device,

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -63,6 +63,7 @@ from sglang_omni.scheduling.prefill_coalesce import (
     validate_prefill_coalesce_requests,
     validate_prefill_coalesce_wait_ms,
 )
+from sglang_omni.scheduling.types import DeferredAdmission
 from sglang_omni.vendor.sglang.parallel_state import create_parallel_state
 from sglang_omni.vendor.sglang.server_args import override_server_args
 from sglang_omni.vendor.sglang.signature import supported_kwargs
@@ -251,6 +252,9 @@ class OmniScheduler:
             self._request_build_backlog_limit = 0
             self._request_build_executor = None
         self._pending_request_builds: dict[str, tuple[Any, bool, Future]] = {}
+        self._pending_request_admissions: dict[
+            str, tuple[Any, bool, DeferredAdmission]
+        ] = {}
         self._backlogged_request_build_payloads: deque[Any] = deque()
         self._request_build_max_pending_observed = 0
 
@@ -857,6 +861,7 @@ class OmniScheduler:
 
     def process_input_requests(self, recv_reqs):
         """Convert incoming payloads to SGLang Reqs and enqueue."""
+        self._drain_request_admission_results()
         self._drain_request_build_results()
         recv_reqs, rejected_reqs = self._stage_request_build_payloads(recv_reqs)
         for payload in rejected_reqs:
@@ -867,6 +872,7 @@ class OmniScheduler:
                 if (
                     req_id in self._aborted_request_ids
                     or req_id in self._pending_request_builds
+                    or req_id in self._pending_request_admissions
                 ):
                     continue
             ingress = self._pending_stream_ingress.get(req_id)
@@ -898,6 +904,7 @@ class OmniScheduler:
                     if (
                         req_id in self._aborted_request_ids
                         or req_id in self._pending_request_builds
+                        or req_id in self._pending_request_admissions
                     ):
                         continue
                     future = request_build_executor.submit(
@@ -920,8 +927,9 @@ class OmniScheduler:
                 self._emit_request_error(req_id, exc)
                 self.abort(req_id)
                 continue
-            self._enqueue_built_request(payload, pending_stream_done, req_data)
+            self._admit_or_defer_built_request(payload, pending_stream_done, req_data)
         self._drain_request_build_results()
+        self._drain_request_admission_results()
 
     def _run_request_builder(self, payload: Any, active_stage: str | None) -> Any:
         req_id = payload.request_id
@@ -940,8 +948,10 @@ class OmniScheduler:
 
     def _sleep_during_idle(self) -> None:
         with self._request_admission_lock:
-            request_build_pending = bool(self._pending_request_builds)
-        time.sleep(0.0001 if request_build_pending else 0.001)
+            request_admission_pending = bool(
+                self._pending_request_builds or self._pending_request_admissions
+            )
+        time.sleep(0.0001 if request_admission_pending else 0.001)
 
     def _stage_request_build_payloads(
         self, recv_reqs: list[Any]
@@ -952,6 +962,7 @@ class OmniScheduler:
         with self._request_admission_lock:
             backlog = self._backlogged_request_build_payloads
             pending_builds = self._pending_request_builds
+            pending_admissions = self._pending_request_admissions
             rejected: list[Any] = []
             backlog_ids = {payload.request_id for payload in backlog}
             capacity = max(
@@ -964,7 +975,11 @@ class OmniScheduler:
                 payload = backlog.popleft()
                 req_id = payload.request_id
                 backlog_ids.discard(req_id)
-                if req_id in self._aborted_request_ids or req_id in pending_builds:
+                if (
+                    req_id in self._aborted_request_ids
+                    or req_id in pending_builds
+                    or req_id in pending_admissions
+                ):
                     continue
                 selected.append(payload)
                 selected_ids.add(req_id)
@@ -975,6 +990,7 @@ class OmniScheduler:
                 if (
                     req_id in self._aborted_request_ids
                     or req_id in pending_builds
+                    or req_id in pending_admissions
                     or req_id in backlog_ids
                     or req_id in selected_ids
                 ):
@@ -1030,10 +1046,81 @@ class OmniScheduler:
             with self._request_admission_lock:
                 if req_id in self._aborted_request_ids:
                     continue
-                self._enqueue_built_request(
+                self._admit_or_defer_built_request(
                     payload,
                     pending_stream_done,
                     req_data,
+                    request_admission_lock_held=True,
+                )
+
+    def _admit_or_defer_built_request(
+        self,
+        payload: Any,
+        pending_stream_done: bool,
+        result: Any,
+        *,
+        request_admission_lock_held: bool = False,
+    ) -> None:
+        if not isinstance(result, DeferredAdmission):
+            self._enqueue_built_request(
+                payload,
+                pending_stream_done,
+                result,
+                request_admission_lock_held=request_admission_lock_held,
+            )
+            return
+
+        req_id = payload.request_id
+
+        def admit_or_hold() -> None:
+            if req_id in self._aborted_request_ids:
+                return
+            if not result.ready.done():
+                self._pending_request_admissions[req_id] = (
+                    payload,
+                    pending_stream_done,
+                    result,
+                )
+                return
+            try:
+                result.ready.result()
+            except Exception as exc:
+                logger.exception(
+                    "OmniScheduler: deferred request admission failed for %s",
+                    req_id,
+                )
+                self._emit_request_error(req_id, exc)
+                self.abort(req_id)
+                return
+            self._enqueue_built_request(
+                payload,
+                pending_stream_done,
+                result.value,
+                request_admission_lock_held=True,
+            )
+
+        if request_admission_lock_held:
+            admit_or_hold()
+        else:
+            with self._request_admission_lock:
+                admit_or_hold()
+
+    def _drain_request_admission_results(self) -> None:
+        with self._request_admission_lock:
+            ready_request_ids = [
+                req_id
+                for req_id, (_, _, deferred) in self._pending_request_admissions.items()
+                if deferred.ready.done()
+            ]
+            for req_id in ready_request_ids:
+                pending = self._pending_request_admissions.pop(req_id, None)
+                if pending is None or req_id in self._aborted_request_ids:
+                    continue
+                payload, pending_stream_done, deferred = pending
+                self._admit_or_defer_built_request(
+                    payload,
+                    pending_stream_done,
+                    deferred,
                     request_admission_lock_held=True,
                 )
 
@@ -1211,6 +1298,7 @@ class OmniScheduler:
             with self._request_admission_lock:
                 build_work_pending = bool(
                     self._pending_request_builds
+                    or self._pending_request_admissions
                     or self._backlogged_request_build_payloads
                 )
             if not build_work_pending and not (
@@ -1596,6 +1684,7 @@ class OmniScheduler:
             try:
                 self._shutdown_request_build_executor()
             finally:
+                self._discard_pending_request_admissions()
                 self._shutdown_resources()
 
     def event_loop(self) -> None:
@@ -1603,7 +1692,12 @@ class OmniScheduler:
 
     def stop(self) -> None:
         self._running = False
+        self._discard_pending_request_admissions()
         self._shutdown_resources()
+
+    def _discard_pending_request_admissions(self) -> None:
+        with self._request_admission_lock:
+            self._pending_request_admissions.clear()
 
     def _shutdown_resources(self) -> None:
         with self._shutdown_lock:
@@ -1641,6 +1735,7 @@ class OmniScheduler:
             pending = self._pending_request_builds.pop(request_id, None)
             if pending is not None:
                 pending[2].cancel()
+            self._pending_request_admissions.pop(request_id, None)
             if self._backlogged_request_build_payloads:
                 retained = [
                     payload
@@ -1763,6 +1858,7 @@ class OmniScheduler:
             info.update(self.model_worker.model_info())
         with self._request_admission_lock:
             request_build_pending = len(self._pending_request_builds)
+            request_admission_pending = len(self._pending_request_admissions)
             request_build_backlog = len(self._backlogged_request_build_payloads)
             waiting_queue_size = len(self.waiting_queue)
         info.update(
@@ -1773,6 +1869,7 @@ class OmniScheduler:
                 "waiting_queue_size": waiting_queue_size,
                 "request_build_workers": self.request_build_max_workers,
                 "request_build_pending": request_build_pending,
+                "request_admission_pending": request_admission_pending,
                 "request_build_max_pending": self.request_build_max_pending,
                 "request_build_backlog": request_build_backlog,
                 "request_build_max_pending_observed": (
@@ -2035,6 +2132,8 @@ class OmniScheduler:
         with self._request_admission_lock:
             if self._pending_request_builds:
                 request_ids.update(self._pending_request_builds.keys())
+            if self._pending_request_admissions:
+                request_ids.update(self._pending_request_admissions.keys())
             if self._backlogged_request_build_payloads:
                 request_ids.update(
                     payload.request_id

--- a/sglang_omni/scheduling/pre_lm_encoder.py
+++ b/sglang_omni/scheduling/pre_lm_encoder.py
@@ -31,8 +31,10 @@ class QueueEntry(Generic[ItemT]):
 class PreLMEncoderService(ABC, Generic[ItemT, EncodedT, EmbeddingT]):
     """Run model-owned encoder hooks on a queue-backed worker thread."""
 
-    def __init__(self, *, worker_name: str) -> None:
-        self._queue: queue.Queue[Any] = queue.Queue()
+    def __init__(self, *, worker_name: str, max_queue_size: int = 0) -> None:
+        if max_queue_size < 0:
+            raise ValueError(f"max_queue_size must be >= 0, got {max_queue_size}")
+        self._queue: queue.Queue[Any] = queue.Queue(maxsize=max_queue_size)
         self._worker_state_lock = threading.Lock()
         self._worker_error: Exception | None = None
         self._thread = threading.Thread(
@@ -47,7 +49,17 @@ class PreLMEncoderService(ABC, Generic[ItemT, EncodedT, EmbeddingT]):
         item: ItemT,
         future: concurrent.futures.Future[Any],
     ) -> None:
-        self._queue.put(QueueEntry(item=item, future=future))
+        entry = QueueEntry(item=item, future=future)
+        while True:
+            try:
+                self._queue.put(entry, timeout=0.1)
+                return
+            except queue.Full:
+                with self._worker_state_lock:
+                    if self._worker_error is not None:
+                        raise RuntimeError(
+                            "pre-LM encoder worker has failed"
+                        ) from self._worker_error
 
     def _submit(
         self,
@@ -61,7 +73,11 @@ class PreLMEncoderService(ABC, Generic[ItemT, EncodedT, EmbeddingT]):
                 raise RuntimeError(
                     "pre-LM encoder worker has failed"
                 ) from self._worker_error
-            self._enqueue(item, future)
+        self._enqueue(item, future)
+        with self._worker_state_lock:
+            worker_error = self._worker_error
+        if worker_error is not None and not future.done():
+            future.set_exception(worker_error)
         return future
 
     @abstractmethod

--- a/sglang_omni/scheduling/types.py
+++ b/sglang_omni/scheduling/types.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from concurrent.futures import Future
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Any
@@ -26,6 +27,12 @@ class SchedulerRequest:
     error: Exception | None = None
     arrival_time: float = 0.0
     finish_time: float | None = None
+
+
+@dataclass(slots=True)
+class DeferredAdmission:
+    value: Any
+    ready: Future[Any]
 
 
 @dataclass

--- a/tests/README.md
+++ b/tests/README.md
@@ -146,6 +146,7 @@ tests/
     │   ├── test_translation_capability.py
     │   └── test_translations.py
     ├── scheduling/
+    │   ├── test_deferred_admission.py
     │   ├── test_engine_factory.py
     │   ├── test_pipeline_state.py
     │   ├── test_reference_encoder.py
@@ -388,6 +389,8 @@ that happened to contain an older version of the test.
   - static TTS `ModelCapabilities` declarations, registry lookup, aliases, and
     launcher startup logging.
 - `unit_test/scheduling/`: Shared scheduling-service unit tests:
+  - deferred request admission completion, abort, and dependency-failure
+    semantics.
   - `ReferenceEncodeService` cache, same-key single-flight, timeout, failure,
     and revalidation semantics.
   - `StageOutputCache` thread safety: concurrent get/put byte-accounting,

--- a/tests/README.md
+++ b/tests/README.md
@@ -99,12 +99,12 @@ tests/
     │   ├── test_encoder_service.py
     │   ├── test_model.py
     │   ├── test_pipeline.py
-    │   └── test_request_builders.py
-    ├── arkasr/
-    │   └── test_pipeline.py
     │   ├── test_request_builders.py
     │   ├── test_stream_output_builder.py
     │   └── test_streaming_client.py
+    ├── arkasr/
+    │   ├── test_encoder_service.py
+    │   └── test_pipeline.py
     ├── moss_transcribe_diarize/
     │   ├── test_encoder_cache.py
     │   ├── test_encoder_service.py
@@ -411,6 +411,8 @@ that happened to contain an older version of the test.
   - invalid encoded-audio classification versus operational loader failures,
     including transcription-route HTTP 400/500 mapping.
 - `unit_test/arkasr/`: ARK-ASR-3B unit tests:
+  - asynchronous pre-LM encoder submission, bounded queue backpressure,
+    single-flight deduplication, CPU cache validation, and failure recovery
   - pipeline config, stage factory concurrency defaults, deferred CUDA-graph
     capture, async-decode default, and `--decode-mode async|sync` CLI overrides
   - audio-token count formula, audio-tower forward shape, marker-token

--- a/tests/unit_test/arkasr/test_encoder_service.py
+++ b/tests/unit_test/arkasr/test_encoder_service.py
@@ -1,0 +1,601 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.arkasr.encoder_service import (
+    ArkasrPreLMEncoderService,
+    _expected_audio_tokens,
+    build_cache_namespace,
+)
+
+_HIDDEN_SIZE = 4
+_NAMESPACE = "testns"
+_SERVICES: list[ArkasrPreLMEncoderService] = []
+
+
+@pytest.fixture(autouse=True)
+def _close_services() -> Iterator[None]:
+    yield
+    for service in _SERVICES:
+        service.close()
+    _SERVICES.clear()
+
+
+class _StubModel(torch.nn.Module):
+    def __init__(self, dtype: torch.dtype = torch.float32) -> None:
+        super().__init__()
+        # ARK's model exposes the tower + adapter as ``audio_encoder``.
+        self.audio_encoder = torch.nn.Linear(2, 2).to(dtype)
+        # ArkasrConfig subclasses Qwen2Config: hidden_size is top level.
+        self.config = SimpleNamespace(hidden_size=_HIDDEN_SIZE)
+        self.dtype = dtype
+        self.encode_calls = 0
+        self.fail = False
+        self.fail_oom = False
+        self.fail_multi_item = False
+        self.packed_3d_output = False
+        self.encode_gate: threading.Event | None = None
+        self.row_offset = 0
+        self.encode_delay_s = 0.0
+        self.grad_enabled_during_encode: bool | None = None
+
+    def get_audio_feature(self, items):  # noqa: ANN001
+        self.grad_enabled_during_encode = torch.is_grad_enabled()
+        self.encode_calls += 1
+        gate = self.encode_gate
+        if gate is not None:
+            self.encode_gate = None
+            gate.wait(timeout=10)
+        if self.encode_delay_s:
+            time.sleep(self.encode_delay_s)
+        if self.fail_oom:
+            raise torch.OutOfMemoryError("encoder OOM")
+        if self.fail:
+            raise RuntimeError("boom")
+        if self.fail_multi_item and len(items) > 1:
+            raise RuntimeError("multi-item boom")
+        parts = []
+        for item in items:
+            rows = _expected_audio_tokens(item) + self.row_offset
+            fill = float((getattr(item, "hash", None) or 0) % 97 + 1)
+            parts.append(torch.full((rows, _HIDDEN_SIZE), fill, dtype=self.dtype))
+        # ARK's get_audio_feature concatenates each item's [tokens_i, hidden]
+        # block in item order across its encoder microbatches, so the result is
+        # already flat (A-PR4 #1411).
+        packed = torch.cat(parts, dim=0)
+        if self.packed_3d_output:
+            return packed.unsqueeze(0)
+        return packed
+
+
+def _make_service(
+    model: _StubModel | None = None,
+    *,
+    cache_max_entries: int = 16,
+    cache_max_bytes: int = 1 << 20,
+) -> ArkasrPreLMEncoderService:
+    service = ArkasrPreLMEncoderService(
+        model or _StubModel(),
+        cache_namespace=_NAMESPACE,
+        cache_max_entries=cache_max_entries,
+        cache_max_bytes=cache_max_bytes,
+    )
+    _SERVICES.append(service)
+    return service
+
+
+def _item(
+    audio_hash: int | None,
+    num_audio_tokens: int,
+    *,
+    with_feature: bool = True,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        hash=audio_hash,
+        audio_fingerprint=str(audio_hash) if audio_hash is not None else None,
+        num_audio_tokens=num_audio_tokens,
+        feature=torch.zeros(1, 128, 300) if with_feature else None,
+        precomputed_embeddings=None,
+    )
+
+
+def test_encode_attaches_lm_ready_embedding_and_clears_feature() -> None:
+    model = _StubModel()
+    service = _make_service(model)
+    item = _item(7, 3)
+
+    service.encode_item(item)
+
+    assert item.precomputed_embeddings.shape == (3, _HIDDEN_SIZE)
+    assert item.precomputed_embeddings.dtype == model.dtype
+    assert (
+        item.precomputed_embeddings.device
+        == next(model.audio_encoder.parameters()).device
+    )
+    assert item.feature is None
+    assert item.format.name == "PRECOMPUTED_EMBEDDING"
+    assert model.encode_calls == 1
+    assert model.grad_enabled_during_encode is False
+    assert service.stats()["misses"] == 1
+
+
+def test_close_stops_worker() -> None:
+    service = _make_service()
+
+    service.close()
+
+    assert not service._thread.is_alive()
+
+
+def test_batch_context_unwinds_inference_mode_when_stream_context_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = object.__new__(ArkasrPreLMEncoderService)
+    service._stream = object()
+
+    def fail_stream(_stream):  # noqa: ANN001, ANN202
+        raise RuntimeError("stream context failed")
+
+    monkeypatch.setattr(torch.cuda, "stream", fail_stream)
+
+    assert not torch.is_inference_mode_enabled()
+    with pytest.raises(RuntimeError, match="stream context failed"):
+        with service._batch_context():
+            pass
+    assert not torch.is_inference_mode_enabled()
+
+
+def test_cache_hit_skips_reencode() -> None:
+    model = _StubModel()
+    service = _make_service(model)
+
+    first = _item(11, 3)
+    second = _item(11, 3)
+    service.encode_item(first)
+    service.encode_item(second)
+
+    assert model.encode_calls == 1
+    assert torch.equal(first.precomputed_embeddings, second.precomputed_embeddings)
+    assert second.feature is None
+    assert service.stats()["hits"] == 1
+
+
+def test_extended_audio_never_reuses_prefix_embedding() -> None:
+    model = _StubModel()
+    service = _make_service(model)
+
+    short = _item(111, 3)
+    extended = _item(222, 5)
+    service.encode_item(short)
+    service.encode_item(extended)
+
+    assert model.encode_calls == 2
+    assert extended.precomputed_embeddings.shape == (5, _HIDDEN_SIZE)
+    assert len(service._cache) == 2
+    assert not torch.equal(
+        short.precomputed_embeddings[0], extended.precomputed_embeddings[0]
+    )
+
+
+def test_cache_key_prefers_full_waveform_fingerprint() -> None:
+    model = _StubModel()
+    service = _make_service(model)
+    first = _item(7, 3)
+    second = _item(7, 3)
+    first.audio_fingerprint = "full-hash-a"
+    second.audio_fingerprint = "full-hash-b"
+
+    service.encode_item(first)
+    service.encode_item(second)
+
+    assert model.encode_calls == 2
+    assert len(service._cache) == 2
+
+
+def test_concurrent_identical_requests_encode_once() -> None:
+    model = _StubModel()
+    model.encode_delay_s = 0.05
+    service = _make_service(model)
+    n_threads = 8
+    barrier = threading.Barrier(n_threads)
+    items = [_item(123, 3) for _ in range(n_threads)]
+    errors: list[Exception] = []
+
+    def worker(item: SimpleNamespace) -> None:
+        try:
+            barrier.wait(timeout=10)
+            service.encode_item(item)
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(item,)) for item in items]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert not errors, errors
+    assert model.encode_calls == 1
+    for item in items:
+        assert item.precomputed_embeddings.shape == (3, _HIDDEN_SIZE)
+        assert torch.equal(item.precomputed_embeddings, items[0].precomputed_embeddings)
+    stats = service.stats()
+    assert stats["merged"] + stats["hits"] == n_threads - 1
+
+
+def test_stale_cache_miss_rechecks_before_starting_duplicate_encode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = _StubModel()
+    service = _make_service(model)
+    stale_miss = threading.Event()
+    release_stale_reader = threading.Event()
+    original_get = service._cache.get
+
+    def controlled_get(key: str | None):  # noqa: ANN202
+        cached = original_get(key)
+        if (
+            threading.current_thread().name == "stale-cache-reader"
+            and not stale_miss.is_set()
+        ):
+            assert cached is None
+            stale_miss.set()
+            assert release_stale_reader.wait(timeout=10)
+        return cached
+
+    monkeypatch.setattr(service._cache, "get", controlled_get)
+    follower_item = _item(123, 3)
+    errors: list[Exception] = []
+
+    def follower() -> None:
+        try:
+            service.encode_item(follower_item)
+        except Exception as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=follower, name="stale-cache-reader")
+    thread.start()
+    assert stale_miss.wait(timeout=10)
+
+    leader_item = _item(123, 3)
+    service.encode_item(leader_item)
+    release_stale_reader.set()
+    thread.join(timeout=30)
+
+    assert not thread.is_alive()
+    assert not errors, errors
+    assert model.encode_calls == 1
+    assert torch.equal(
+        leader_item.precomputed_embeddings,
+        follower_item.precomputed_embeddings,
+    )
+    assert service.stats()["hits"] == 1
+
+
+def test_concurrent_identical_requests_deduplicate_without_cache() -> None:
+    model = _StubModel()
+    model.encode_delay_s = 0.05
+    service = _make_service(model, cache_max_entries=0)
+    barrier = threading.Barrier(2)
+    items = [_item(123, 3) for _ in range(2)]
+    errors: list[Exception] = []
+
+    def worker(item: SimpleNamespace) -> None:
+        try:
+            barrier.wait(timeout=10)
+            service.encode_item(item)
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(item,)) for item in items]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert not errors, errors
+    assert model.encode_calls == 1
+    assert len(service._cache) == 0
+    assert torch.equal(items[0].precomputed_embeddings, items[1].precomputed_embeddings)
+
+
+def test_encode_failure_propagates_without_poisoning_cache() -> None:
+    model = _StubModel()
+    model.fail = True
+    model.encode_delay_s = 0.05
+    service = _make_service(model)
+    barrier = threading.Barrier(2)
+    errors: list[Exception] = []
+
+    def worker() -> None:
+        try:
+            barrier.wait(timeout=10)
+            service.encode_item(_item(55, 3))
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert len(errors) == 2
+    assert all(isinstance(exc, RuntimeError) and "boom" in str(exc) for exc in errors)
+    assert len(service._cache) == 0
+    assert service.stats()["failed"] == 2
+
+    model.fail = False
+    item = _item(55, 3)
+    service.encode_item(item)
+    assert item.precomputed_embeddings.shape == (3, _HIDDEN_SIZE)
+
+
+def test_oom_failure_detaches_traceback_and_recovers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = _StubModel()
+    model.fail_oom = True
+    service = _make_service(model)
+    empty_cache_calls: list[bool] = []
+    monkeypatch.setattr(
+        torch.cuda, "empty_cache", lambda: empty_cache_calls.append(True)
+    )
+
+    with pytest.raises(torch.OutOfMemoryError, match="encoder OOM") as excinfo:
+        service.encode_item(_item(77, 3))
+
+    # the propagated exception must not pin encoder frames.
+    assert excinfo.value.__traceback__ is not None  # pytest's own raise site
+    assert excinfo.value.__cause__ is None
+    assert excinfo.value.__context__ is None
+    assert service.stats()["failed"] == 1
+
+    model.fail_oom = False
+    item = _item(77, 3)
+    service.encode_item(item)
+    assert item.precomputed_embeddings.shape == (3, _HIDDEN_SIZE)
+
+
+def test_merged_follower_token_mismatch_raises_and_counts_failed() -> None:
+    model = _StubModel()
+    model.encode_delay_s = 0.2
+    service = _make_service(model)
+    leader_item = _item(321, 3)
+    follower_item = _item(321, 5)
+    errors: list[Exception] = []
+
+    def leader() -> None:
+        try:
+            service.encode_item(leader_item)
+        except Exception as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=leader)
+    thread.start()
+    deadline = time.monotonic() + 5
+    while not service._inflight and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert service._inflight, "leader never registered in-flight"
+
+    with pytest.raises(RuntimeError, match="returned an invalid"):
+        service.encode_item(follower_item)
+    thread.join(timeout=30)
+
+    assert not errors, errors
+    assert leader_item.precomputed_embeddings.shape == (3, _HIDDEN_SIZE)
+    assert follower_item.precomputed_embeddings is None
+    stats = service.stats()
+    assert stats["merged"] == 1
+    assert stats["failed"] == 1
+
+
+def test_multi_item_batch_failure_retries_per_item_and_counts_stats() -> None:
+    model = _StubModel()
+    model.fail_multi_item = True
+    gate = threading.Event()
+    model.encode_gate = gate
+    service = _make_service(model)
+    items = [_item(31, 3), _item(32, 3), _item(33, 4)]
+    errors: list[Exception] = []
+
+    def worker(item: SimpleNamespace) -> None:
+        try:
+            service.encode_item(item)
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(item,)) for item in items]
+    for thread in threads:
+        thread.start()
+    # queue every leader before releasing the gate so the next drain exercises
+    # the multi-item retry path.
+    deadline = time.monotonic() + 5
+    while len(service._inflight) < 3 and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert len(service._inflight) == 3, "items never queued"
+    gate.set()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert not errors, errors
+    for item in items:
+        assert item.precomputed_embeddings.shape == (
+            item.num_audio_tokens,
+            _HIDDEN_SIZE,
+        )
+    stats = service.stats()
+    assert stats["failed"] == 0
+    assert stats["items"] == 3
+    assert stats["batches"] == 3
+    assert model.encode_calls == 4
+    assert len(service._cache) == 3
+
+
+def test_eviction_under_byte_budget_triggers_reencode() -> None:
+    model = _StubModel()
+    service = _make_service(model, cache_max_bytes=100)
+
+    for audio_hash in (1, 2, 3):
+        service.encode_item(_item(audio_hash, 3))
+    assert model.encode_calls == 3
+    assert service._cache.eviction_count >= 1
+    assert len(service._cache) == 2
+
+    service.encode_item(_item(1, 3))
+    assert model.encode_calls == 4
+
+
+def test_invalid_cache_entry_is_evicted_and_reencoded() -> None:
+    model = _StubModel()
+    service = _make_service(model)
+    probe = _item(42, 3)
+    service.encode_item(probe)
+    assert model.encode_calls == 1
+    key = service._cache_key(probe)
+
+    for poison in (
+        torch.zeros(5, _HIDDEN_SIZE),
+        torch.zeros(3, _HIDDEN_SIZE + 1),
+        torch.zeros(3, _HIDDEN_SIZE, dtype=torch.float64),
+    ):
+        service._cache.put(key, poison)
+        item = _item(42, 3)
+        service.encode_item(item)
+        assert model.encode_calls == 2
+        assert item.precomputed_embeddings.shape == (3, _HIDDEN_SIZE)
+        assert torch.equal(item.precomputed_embeddings, probe.precomputed_embeddings)
+        model.encode_calls = 1
+
+
+def test_token_count_mismatch_fails_loudly() -> None:
+    model = _StubModel()
+    model.row_offset = 1
+    service = _make_service(model)
+    item = _item(9, 3)
+
+    with pytest.raises(RuntimeError, match="!= expected rows"):
+        service.encode_item(item)
+
+    assert item.precomputed_embeddings is None
+    assert len(service._cache) == 0
+
+
+def test_packed_3d_encoder_output_is_rejected() -> None:
+    """ARK's get_audio_feature returns a flat [total_tokens, hidden] tensor.
+
+    Unlike Qwen3-ASR (whose tower emits a packed [1, total, hidden]
+    last_hidden_state), there is no unit batch dim to squeeze here -- A-PR4's
+    batched encoder still flattens its microbatch outputs back to 2-D in item
+    order. A 3-D result means the encoder contract changed and the split would
+    be wrong, so fail loudly rather than mis-scatter rows into the LM.
+    """
+    model = _StubModel()
+    model.packed_3d_output = True
+    service = _make_service(model)
+    item = _item(8, 3)
+
+    with pytest.raises(RuntimeError, match="!= expected rows"):
+        service.encode_item(item)
+
+    assert item.precomputed_embeddings is None
+    assert len(service._cache) == 0
+
+
+def test_missing_token_count_raises() -> None:
+    service = _make_service()
+    item = SimpleNamespace(hash=1, feature=None, precomputed_embeddings=None)
+
+    with pytest.raises(RuntimeError, match="num_audio_tokens"):
+        service.encode_item(item)
+
+
+def test_item_without_fingerprint_encodes_without_caching() -> None:
+    model = _StubModel()
+    service = _make_service(model)
+
+    first = _item(1, 2)
+    second = _item(1, 2)
+    first.audio_fingerprint = None
+    second.audio_fingerprint = None
+    service.encode_item(first)
+    service.encode_item(second)
+
+    assert model.encode_calls == 2
+    assert first.feature is None
+    assert first.precomputed_embeddings.shape == (2, _HIDDEN_SIZE)
+    assert len(service._cache) == 0
+
+
+def test_expected_audio_tokens_uses_request_metadata() -> None:
+    explicit = SimpleNamespace(num_audio_tokens=5, feature=torch.zeros(1, 128, 300))
+    assert _expected_audio_tokens(explicit) == 5
+    assert _expected_audio_tokens(SimpleNamespace()) is None
+
+
+def test_build_cache_namespace_is_stable_and_scoped() -> None:
+    model = _StubModel()
+    frontend = SimpleNamespace(
+        feature_size=128,
+        sampling_rate=16000,
+        hop_length=160,
+        chunk_length=30,
+        n_fft=400,
+        nb_max_frames=3000,
+        padding_value=0.0,
+    )
+    base = dict(
+        model_path="AutoArk-AI/ARK-ASR-3B",
+        feature_extractor=frontend,
+        mm_attention_backend=None,
+    )
+
+    namespace = build_cache_namespace(model, **base)
+    assert namespace == build_cache_namespace(model, **base)
+    assert namespace != build_cache_namespace(
+        model, **{**base, "model_path": "other/revision"}
+    )
+    assert namespace != build_cache_namespace(
+        model, **{**base, "mm_attention_backend": "triton_attn"}
+    )
+    assert namespace != build_cache_namespace(_StubModel(dtype=torch.bfloat16), **base)
+    changed_frontend = SimpleNamespace(**{**vars(frontend), "hop_length": 320})
+    assert namespace != build_cache_namespace(
+        model, **{**base, "feature_extractor": changed_frontend}
+    )
+    changed_config = _StubModel()
+    changed_config.config = SimpleNamespace(hidden_size=_HIDDEN_SIZE, marker="other")
+    assert namespace != build_cache_namespace(changed_config, **base)
+
+
+def test_build_cache_namespace_tracks_merge_factor() -> None:
+    """merge_factor changes the adapter's frame merge and therefore the
+    embedding, so it must re-key the cache. ArkasrConfig carries it in
+    to_dict()."""
+    base = dict(
+        model_path="AutoArk-AI/ARK-ASR-3B",
+        feature_extractor=SimpleNamespace(sampling_rate=16000),
+        mm_attention_backend=None,
+    )
+
+    def _model(merge_factor: int) -> _StubModel:
+        model = _StubModel()
+        model.config = SimpleNamespace(
+            to_dict=lambda mf=merge_factor: {
+                "hidden_size": _HIDDEN_SIZE,
+                "merge_factor": mf,
+            }
+        )
+        return model
+
+    assert build_cache_namespace(_model(4), **base) != build_cache_namespace(
+        _model(2), **base
+    )

--- a/tests/unit_test/arkasr/test_encoder_service.py
+++ b/tests/unit_test/arkasr/test_encoder_service.py
@@ -45,6 +45,7 @@ class _StubModel(torch.nn.Module):
         self.fail_multi_item = False
         self.packed_3d_output = False
         self.encode_gate: threading.Event | None = None
+        self.encode_started: threading.Event | None = None
         self.row_offset = 0
         self.encode_delay_s = 0.0
         self.grad_enabled_during_encode: bool | None = None
@@ -53,6 +54,8 @@ class _StubModel(torch.nn.Module):
         self.grad_enabled_during_encode = torch.is_grad_enabled()
         self.encode_calls += 1
         self.encode_batch_sizes.append(len(items))
+        if self.encode_started is not None:
+            self.encode_started.set()
         gate = self.encode_gate
         if gate is not None:
             self.encode_gate = None
@@ -154,15 +157,16 @@ def test_submit_returns_before_encoding_completes() -> None:
 def test_async_submissions_form_full_batch_without_blocked_callers() -> None:
     model = _StubModel()
     gate = threading.Event()
+    encode_started = threading.Event()
     model.encode_gate = gate
+    model.encode_started = encode_started
     service = _make_service(model, max_batch_size=8)
     items = [_item(audio_hash, 3) for audio_hash in range(9)]
 
-    futures = [service.submit_item(item) for item in items]
-    deadline = time.monotonic() + 2
-    while model.encode_calls == 0 and time.monotonic() < deadline:
-        time.sleep(0.005)
+    futures = [service.submit_item(items[0])]
+    assert encode_started.wait(timeout=2)
     assert model.encode_calls == 1
+    futures.extend(service.submit_item(item) for item in items[1:])
     gate.set()
     for future in futures:
         future.result(timeout=2)

--- a/tests/unit_test/arkasr/test_encoder_service.py
+++ b/tests/unit_test/arkasr/test_encoder_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import threading
 import time
 from collections.abc import Iterator
@@ -38,6 +39,7 @@ class _StubModel(torch.nn.Module):
         self.config = SimpleNamespace(hidden_size=_HIDDEN_SIZE)
         self.dtype = dtype
         self.encode_calls = 0
+        self.encode_batch_sizes: list[int] = []
         self.fail = False
         self.fail_oom = False
         self.fail_multi_item = False
@@ -50,6 +52,7 @@ class _StubModel(torch.nn.Module):
     def get_audio_feature(self, items):  # noqa: ANN001
         self.grad_enabled_during_encode = torch.is_grad_enabled()
         self.encode_calls += 1
+        self.encode_batch_sizes.append(len(items))
         gate = self.encode_gate
         if gate is not None:
             self.encode_gate = None
@@ -81,12 +84,16 @@ def _make_service(
     *,
     cache_max_entries: int = 16,
     cache_max_bytes: int = 1 << 20,
+    max_batch_size: int = 8,
+    max_queue_size: int = 0,
 ) -> ArkasrPreLMEncoderService:
     service = ArkasrPreLMEncoderService(
         model or _StubModel(),
         cache_namespace=_NAMESPACE,
         cache_max_entries=cache_max_entries,
         cache_max_bytes=cache_max_bytes,
+        max_batch_size=max_batch_size,
+        max_queue_size=max_queue_size,
     )
     _SERVICES.append(service)
     return service
@@ -125,6 +132,90 @@ def test_encode_attaches_lm_ready_embedding_and_clears_feature() -> None:
     assert model.encode_calls == 1
     assert model.grad_enabled_during_encode is False
     assert service.stats()["misses"] == 1
+
+
+def test_submit_returns_before_encoding_completes() -> None:
+    model = _StubModel()
+    gate = threading.Event()
+    model.encode_gate = gate
+    service = _make_service(model)
+    item = _item(7, 3)
+
+    future = service.submit_item(item)
+
+    assert not future.done()
+    assert item.precomputed_embeddings is None
+    gate.set()
+    future.result(timeout=2)
+    assert item.precomputed_embeddings.shape == (3, _HIDDEN_SIZE)
+    assert service.stats()["pending"] == 0
+
+
+def test_async_submissions_form_full_batch_without_blocked_callers() -> None:
+    model = _StubModel()
+    gate = threading.Event()
+    model.encode_gate = gate
+    service = _make_service(model, max_batch_size=8)
+    items = [_item(audio_hash, 3) for audio_hash in range(9)]
+
+    futures = [service.submit_item(item) for item in items]
+    deadline = time.monotonic() + 2
+    while model.encode_calls == 0 and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert model.encode_calls == 1
+    gate.set()
+    for future in futures:
+        future.result(timeout=2)
+
+    assert model.encode_batch_sizes == [1, 8]
+
+
+def test_async_single_flight_completes_each_item_future() -> None:
+    model = _StubModel()
+    gate = threading.Event()
+    model.encode_gate = gate
+    service = _make_service(model)
+    items = [_item(123, 3) for _ in range(3)]
+
+    futures = [service.submit_item(item) for item in items]
+    assert all(not future.done() for future in futures)
+    gate.set()
+    for future in futures:
+        future.result(timeout=2)
+
+    assert model.encode_calls == 1
+    assert service.stats()["merged"] == 2
+    assert all(item.precomputed_embeddings is not None for item in items)
+
+
+def test_bounded_queue_applies_backpressure_and_records_saturation() -> None:
+    model = _StubModel()
+    gate = threading.Event()
+    model.encode_gate = gate
+    service = _make_service(model, max_queue_size=1)
+    futures = [service.submit_item(_item(1, 3))]
+    deadline = time.monotonic() + 2
+    while model.encode_calls == 0 and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert model.encode_calls == 1
+    futures.append(service.submit_item(_item(2, 3)))
+    submitted: list[concurrent.futures.Future[torch.Tensor]] = []
+
+    thread = threading.Thread(
+        target=lambda: submitted.append(service.submit_item(_item(3, 3)))
+    )
+    thread.start()
+    time.sleep(0.02)
+    assert thread.is_alive()
+
+    gate.set()
+    thread.join(timeout=2)
+    assert not thread.is_alive()
+    for future in [*futures, *submitted]:
+        future.result(timeout=2)
+    stats = service.stats()
+    assert stats["queue_full_waits"] == 1
+    assert stats["queue_depth_max"] == 1
 
 
 def test_close_stops_worker() -> None:

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -225,9 +225,7 @@ def _stub_arkasr_engine_build(
         lambda worker: graph_init_workers.append(worker),
     )
     monkeypatch.setattr(sglang_backend, "SGLangOutputProcessor", lambda **k: object())
-    monkeypatch.setattr(
-        omni_scheduler, "OmniScheduler", lambda **k: SimpleNamespace(**k)
-    )
+    monkeypatch.setattr(omni_scheduler, "OmniScheduler", SimpleNamespace)
     return SimpleNamespace(
         graph_init_workers=graph_init_workers,
         adapter_kwargs=adapter_kwargs,

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -68,8 +68,59 @@ def test_arkasr_stage_defaults():
     signature = inspect.signature(create_sglang_arkasr_executor)
     assert signature.parameters["max_running_requests"].default == 32
     assert signature.parameters["encoder_max_batch_size"].default == 8
-    assert signature.parameters["request_build_max_workers"].default == 2
-    assert signature.parameters["request_build_max_pending"].default == 16
+    # encode_item blocks its request-build worker until the embedding is
+    # attached, so the encoder only ever sees as many concurrent items as there
+    # are build workers; two workers would cap pre-LM encode groups at two.
+    assert signature.parameters["request_build_max_workers"].default == 8
+    assert signature.parameters["request_build_max_pending"].default == 32
+    assert signature.parameters["enable_pre_lm_encoder"].default is True
+    assert signature.parameters["pre_lm_max_batch_size"].default == 8
+    assert signature.parameters["pre_lm_max_batch_wait_ms"].default == 0
+
+
+def test_arkasr_pre_lm_group_matches_one_encoder_microbatch_by_default():
+    """pre_lm_max_batch_size decides how many requests reach one
+    get_audio_feature call; encoder_max_batch_size bounds how that call is
+    executed. Equal defaults mean one drained group is one encoder microbatch,
+    so the pre-LM service cannot silently widen a single encoder forward."""
+    signature = inspect.signature(create_sglang_arkasr_executor)
+
+    assert (
+        signature.parameters["pre_lm_max_batch_size"].default
+        == signature.parameters["encoder_max_batch_size"].default
+    )
+
+
+def test_arkasr_pre_lm_encoder_knobs_are_stage_configurable():
+    factory_args = (
+        ArkasrPipelineConfig(model_path="AutoArk-AI/ARK-ASR-3B").stages[0].factory_args
+    )
+
+    assert factory_args["request_build_max_workers"] == 8
+    assert factory_args["request_build_max_pending"] == 32
+    assert factory_args["enable_pre_lm_encoder"] is True
+    assert factory_args["pre_lm_cache_max_entries"] == 4096
+    assert factory_args["pre_lm_cache_size_bytes"] == 2 * 1024**3
+    assert factory_args["pre_lm_max_batch_size"] == 8
+    assert factory_args["pre_lm_max_batch_wait_ms"] == 0
+
+
+def test_arkasr_rejects_invalid_pre_lm_batch_size():
+    with pytest.raises(ValueError, match="pre_lm_max_batch_size"):
+        arkasr_builder.ArkasrEngineBuilder(
+            max_running_requests=32,
+            encoder_max_batch_size=8,
+            max_new_tokens=256,
+            enable_async_decode=True,
+            async_decode_min_batch_size=2,
+            mem_fraction_static=None,
+            mm_embedding_cache_size_bytes=0,
+            enable_torch_compile=False,
+            mm_attention_backend=None,
+            request_build_max_workers=8,
+            request_build_max_pending=32,
+            pre_lm_max_batch_size=0,
+        )
 
 
 def test_arkasr_stage_default_enables_async_decode():
@@ -79,14 +130,18 @@ def test_arkasr_stage_default_enables_async_decode():
     assert signature.parameters["async_decode_min_batch_size"].default == 2
 
 
-@pytest.mark.parametrize("want_cuda_graph", [True, False])
-def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
-    monkeypatch: pytest.MonkeyPatch, want_cuda_graph: bool
-) -> None:
-    """The factory defers capture, then calls bootstrap.init_sglang_cuda_graphs
-    exactly when the deferred-capture probe asked for graphs. The worker stub
-    stays minimal: helper internals are already covered in
-    tests/unit_test/serve/test_sglang_bootstrap.py."""
+def _stub_arkasr_engine_build(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    want_cuda_graph: bool,
+    encoder_service: object,
+) -> SimpleNamespace:
+    """Stub every out-of-process dependency of ArkasrEngineBuilder.build().
+
+    Returns the recorders the tests assert on. The worker stub stays minimal:
+    helper internals are already covered in
+    tests/unit_test/serve/test_sglang_bootstrap.py.
+    """
     graph_init_workers: list[object] = []
     adapter_kwargs: dict[str, object] = {}
 
@@ -128,6 +183,12 @@ def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
     )
     monkeypatch.setattr(arkasr_builder, "init_mm_embedding_cache", lambda n: None)
     monkeypatch.setattr(
+        arkasr_builder, "build_cache_namespace", lambda *a, **k: "testns"
+    )
+    monkeypatch.setattr(
+        arkasr_builder, "ArkasrPreLMEncoderService", lambda *a, **k: encoder_service
+    )
+    monkeypatch.setattr(
         request_builders,
         "make_arkasr_scheduler_adapters",
         lambda **k: (adapter_kwargs.update(k) or object(), object()),
@@ -167,6 +228,26 @@ def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
     monkeypatch.setattr(
         omni_scheduler, "OmniScheduler", lambda **k: SimpleNamespace(**k)
     )
+    return SimpleNamespace(
+        graph_init_workers=graph_init_workers,
+        adapter_kwargs=adapter_kwargs,
+        infra_kwargs_seen=infra_kwargs_seen,
+        encoder_batch_sizes=encoder_batch_sizes,
+        model_worker=model_worker,
+    )
+
+
+@pytest.mark.parametrize("want_cuda_graph", [True, False])
+def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
+    monkeypatch: pytest.MonkeyPatch, want_cuda_graph: bool
+) -> None:
+    """The factory defers capture, then calls bootstrap.init_sglang_cuda_graphs
+    exactly when the deferred-capture probe asked for graphs."""
+    stub = _stub_arkasr_engine_build(
+        monkeypatch,
+        want_cuda_graph=want_cuda_graph,
+        encoder_service=SimpleNamespace(close=lambda: None),
+    )
 
     scheduler = create_sglang_arkasr_executor(
         "AutoArk-AI/ARK-ASR-3B",
@@ -175,22 +256,65 @@ def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
         async_decode_min_batch_size=4,
     )
 
-    assert graph_init_workers == ([model_worker] if want_cuda_graph else [])
+    assert stub.graph_init_workers == ([stub.model_worker] if want_cuda_graph else [])
     # note (jiannan-17): the scheduler fake records its kwargs, proving the
     # builder forwards the stage knobs instead of dropping them.
-    assert scheduler.request_build_max_workers == 2
-    assert scheduler.request_build_max_pending == 16
+    assert scheduler.request_build_max_workers == 8
+    assert scheduler.request_build_max_pending == 32
     assert scheduler.enable_async_decode is False
     assert scheduler.async_decode_min_batch_size == 4
-    assert adapter_kwargs["merge_factor"] == 7
-    assert adapter_kwargs["audio_token_id"] == 4242
-    assert adapter_kwargs["max_new_tokens"] == 256
+    assert stub.adapter_kwargs["merge_factor"] == 7
+    assert stub.adapter_kwargs["audio_token_id"] == 4242
+    assert stub.adapter_kwargs["max_new_tokens"] == 256
     # note (jiannan-17): context_length and model_arch_override moved from
     # stages.py into the builder. Keep both pinned so a missing value fails
     # here instead of at serve time.
     assert scheduler.server_args.context_length == 2000 // 2 + 256 + 8
-    assert infra_kwargs_seen["model_arch_override"] == "ArkasrForConditionalGeneration"
-    assert encoder_batch_sizes == [8]
+    assert (
+        stub.infra_kwargs_seen["model_arch_override"]
+        == "ArkasrForConditionalGeneration"
+    )
+    assert stub.encoder_batch_sizes == [8]
+
+
+def test_arkasr_pre_lm_encoder_reaches_request_builder_and_shutdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The encoder service is handed to the request builder (so encoding runs
+    before LM admission) and its close() is registered as the scheduler's
+    shutdown callback (so the worker thread cannot outlive the stage)."""
+    encoder_service = SimpleNamespace(close=lambda: None)
+    stub = _stub_arkasr_engine_build(
+        monkeypatch, want_cuda_graph=False, encoder_service=encoder_service
+    )
+
+    scheduler = create_sglang_arkasr_executor("AutoArk-AI/ARK-ASR-3B")
+
+    assert stub.adapter_kwargs["audio_encoder_service"] is encoder_service
+    assert scheduler.shutdown_callback == encoder_service.close
+    # A-PR4's model-internal bound is still applied when the pre-LM service is
+    # in front of it; the two batch limits are independent.
+    assert stub.encoder_batch_sizes == [8]
+
+
+def test_arkasr_pre_lm_encoder_can_be_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the service off, the request builder falls back to encoding inside
+    the LM forward and no shutdown callback is registered."""
+    stub = _stub_arkasr_engine_build(
+        monkeypatch,
+        want_cuda_graph=False,
+        encoder_service=SimpleNamespace(close=lambda: None),
+    )
+
+    scheduler = create_sglang_arkasr_executor(
+        "AutoArk-AI/ARK-ASR-3B", enable_pre_lm_encoder=False
+    )
+
+    assert stub.adapter_kwargs["audio_encoder_service"] is None
+    assert not hasattr(scheduler, "shutdown_callback")
+    assert stub.encoder_batch_sizes == [8]
 
 
 def test_arkasr_audio_token_count():

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -68,14 +68,12 @@ def test_arkasr_stage_defaults():
     signature = inspect.signature(create_sglang_arkasr_executor)
     assert signature.parameters["max_running_requests"].default == 32
     assert signature.parameters["encoder_max_batch_size"].default == 8
-    # encode_item blocks its request-build worker until the embedding is
-    # attached, so the encoder only ever sees as many concurrent items as there
-    # are build workers; two workers would cap pre-LM encode groups at two.
-    assert signature.parameters["request_build_max_workers"].default == 8
-    assert signature.parameters["request_build_max_pending"].default == 32
+    assert signature.parameters["request_build_max_workers"].default == 2
+    assert signature.parameters["request_build_max_pending"].default == 16
     assert signature.parameters["enable_pre_lm_encoder"].default is True
     assert signature.parameters["pre_lm_max_batch_size"].default == 8
     assert signature.parameters["pre_lm_max_batch_wait_ms"].default == 0
+    assert signature.parameters["pre_lm_max_pending"].default == 32
 
 
 def test_arkasr_pre_lm_group_matches_one_encoder_microbatch_by_default():
@@ -96,13 +94,14 @@ def test_arkasr_pre_lm_encoder_knobs_are_stage_configurable():
         ArkasrPipelineConfig(model_path="AutoArk-AI/ARK-ASR-3B").stages[0].factory_args
     )
 
-    assert factory_args["request_build_max_workers"] == 8
-    assert factory_args["request_build_max_pending"] == 32
+    assert factory_args["request_build_max_workers"] == 2
+    assert factory_args["request_build_max_pending"] == 16
     assert factory_args["enable_pre_lm_encoder"] is True
     assert factory_args["pre_lm_cache_max_entries"] == 4096
     assert factory_args["pre_lm_cache_size_bytes"] == 2 * 1024**3
     assert factory_args["pre_lm_max_batch_size"] == 8
     assert factory_args["pre_lm_max_batch_wait_ms"] == 0
+    assert factory_args["pre_lm_max_pending"] == 32
 
 
 def test_arkasr_rejects_invalid_pre_lm_batch_size():
@@ -120,6 +119,24 @@ def test_arkasr_rejects_invalid_pre_lm_batch_size():
             request_build_max_workers=8,
             request_build_max_pending=32,
             pre_lm_max_batch_size=0,
+        )
+
+
+def test_arkasr_rejects_invalid_pre_lm_pending_limit():
+    with pytest.raises(ValueError, match="pre_lm_max_pending"):
+        arkasr_builder.ArkasrEngineBuilder(
+            max_running_requests=32,
+            encoder_max_batch_size=8,
+            max_new_tokens=256,
+            enable_async_decode=True,
+            async_decode_min_batch_size=2,
+            mem_fraction_static=None,
+            mm_embedding_cache_size_bytes=0,
+            enable_torch_compile=False,
+            mm_attention_backend=None,
+            request_build_max_workers=2,
+            request_build_max_pending=16,
+            pre_lm_max_pending=0,
         )
 
 
@@ -144,6 +161,7 @@ def _stub_arkasr_engine_build(
     """
     graph_init_workers: list[object] = []
     adapter_kwargs: dict[str, object] = {}
+    encoder_service_kwargs: dict[str, object] = {}
 
     encoder_batch_sizes: list[int] = []
     model_worker = SimpleNamespace(
@@ -186,7 +204,9 @@ def _stub_arkasr_engine_build(
         arkasr_builder, "build_cache_namespace", lambda *a, **k: "testns"
     )
     monkeypatch.setattr(
-        arkasr_builder, "ArkasrPreLMEncoderService", lambda *a, **k: encoder_service
+        arkasr_builder,
+        "ArkasrPreLMEncoderService",
+        lambda *a, **k: (encoder_service_kwargs.update(k) or encoder_service),
     )
     monkeypatch.setattr(
         request_builders,
@@ -229,6 +249,7 @@ def _stub_arkasr_engine_build(
     return SimpleNamespace(
         graph_init_workers=graph_init_workers,
         adapter_kwargs=adapter_kwargs,
+        encoder_service_kwargs=encoder_service_kwargs,
         infra_kwargs_seen=infra_kwargs_seen,
         encoder_batch_sizes=encoder_batch_sizes,
         model_worker=model_worker,
@@ -257,8 +278,8 @@ def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
     assert stub.graph_init_workers == ([stub.model_worker] if want_cuda_graph else [])
     # note (jiannan-17): the scheduler fake records its kwargs, proving the
     # builder forwards the stage knobs instead of dropping them.
-    assert scheduler.request_build_max_workers == 8
-    assert scheduler.request_build_max_pending == 32
+    assert scheduler.request_build_max_workers == 2
+    assert scheduler.request_build_max_pending == 16
     assert scheduler.enable_async_decode is False
     assert scheduler.async_decode_min_batch_size == 4
     assert stub.adapter_kwargs["merge_factor"] == 7
@@ -273,6 +294,7 @@ def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
         == "ArkasrForConditionalGeneration"
     )
     assert stub.encoder_batch_sizes == [8]
+    assert stub.encoder_service_kwargs["max_queue_size"] == 32
 
 
 def test_arkasr_pre_lm_encoder_reaches_request_builder_and_shutdown(

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -312,8 +312,8 @@ def test_arkasr_pre_lm_encoder_reaches_request_builder_and_shutdown(
 
     assert stub.adapter_kwargs["audio_encoder_service"] is encoder_service
     assert scheduler.shutdown_callback == encoder_service.close
-    # A-PR4's model-internal bound is still applied when the pre-LM service is
-    # in front of it; the two batch limits are independent.
+    # Note (Akazaakane): The model-internal bound still applies behind the
+    # pre-LM service because the two batch limits are independent.
     assert stub.encoder_batch_sizes == [8]
 
 

--- a/tests/unit_test/pipeline/test_async_decode.py
+++ b/tests/unit_test/pipeline/test_async_decode.py
@@ -569,6 +569,7 @@ def _new_scheduler_for_async_loop():
     s._admin_queue = queue.Queue()
     s._request_admission_lock = threading.RLock()
     s._pending_request_builds = {}
+    s._pending_request_admissions = {}
     s._model_runner = None
     s.chunked_req = None
     s.is_mixed_chunk = False

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -2081,6 +2081,8 @@ def test_omni_scheduler_stop_runs_shutdown_callback_once() -> None:
     scheduler = object.__new__(OmniScheduler)
     shutdowns: list[None] = []
     scheduler._running = True
+    scheduler._request_admission_lock = threading.RLock()
+    scheduler._pending_request_admissions = {}
     scheduler._shutdown_lock = threading.Lock()
     scheduler._shutdown_callback = lambda: shutdowns.append(None)
 
@@ -2115,6 +2117,8 @@ def test_omni_scheduler_start_closes_active_model_paths(
     scheduler._prefill_start_done = {"req-1", "req-2"}
     scheduler._prefill_end_done = set()
     scheduler._request_build_executor = None
+    scheduler._request_admission_lock = threading.RLock()
+    scheduler._pending_request_admissions = {}
     scheduler._shutdown_lock = threading.Lock()
     scheduler._shutdown_callback = None
 

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -40,6 +40,7 @@ def _init_sync_request_build_state(scheduler: OmniScheduler) -> None:
     scheduler._request_build_executor = None
     scheduler.request_build_max_pending = 0
     scheduler._pending_request_builds = {}
+    scheduler._pending_request_admissions = {}
     scheduler._backlogged_request_build_payloads = []
     scheduler._request_build_max_pending_observed = 0
     scheduler._async_pending = None
@@ -67,6 +68,7 @@ def test_scheduler_idle_sleep_yields_to_pending_request_builds(monkeypatch) -> N
     scheduler = object.__new__(OmniScheduler)
     scheduler._request_admission_lock = threading.RLock()
     scheduler._pending_request_builds = {}
+    scheduler._pending_request_admissions = {}
     sleep_calls: list[float] = []
     monkeypatch.setattr(omni_scheduler_module.time, "sleep", sleep_calls.append)
 
@@ -83,6 +85,7 @@ def test_normal_event_loop_uses_request_build_aware_idle_sleep(monkeypatch) -> N
     scheduler._engine_paused = False
     scheduler._request_admission_lock = threading.RLock()
     scheduler._pending_request_builds = {"req": object()}
+    scheduler._pending_request_admissions = {}
     scheduler._process_admin_requests = lambda: None
     scheduler.recv_requests = lambda: []
     scheduler._take_deferred_request_payloads = lambda: []
@@ -2475,6 +2478,7 @@ def test_omni_scheduler_running_abort_does_not_leak_prefill_dedup_state(
     scheduler._aborted_request_ids = set()
     scheduler._aborted_request_id_order = collections.deque()
     scheduler._pending_request_builds = {}
+    scheduler._pending_request_admissions = {}
     scheduler._backlogged_request_build_payloads = []
     scheduler.waiting_queue = []
     scheduler._abort_callback = None

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -281,6 +281,8 @@ def test_stage_stop_waits_for_scheduler_model_path_terminalization(
         scheduler._prefill_start_done = {"req-active"}
         scheduler._prefill_end_done = set()
         scheduler._request_build_executor = None
+        scheduler._request_admission_lock = threading.RLock()
+        scheduler._pending_request_admissions = {}
         scheduler._shutdown_lock = threading.Lock()
         scheduler._shutdown_callback = None
 
@@ -328,6 +330,8 @@ def test_stage_stop_warns_but_succeeds_on_a_stuck_scheduler_thread(
         scheduler._prefill_start_done = set()
         scheduler._prefill_end_done = set()
         scheduler._request_build_executor = None
+        scheduler._request_admission_lock = threading.RLock()
+        scheduler._pending_request_admissions = {}
         scheduler._shutdown_lock = threading.Lock()
         scheduler._shutdown_callback = None
 

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -1140,6 +1140,7 @@ def _build_state_machine_scheduler(
     scheduler._request_build_executor = None
     scheduler.request_build_max_pending = 0
     scheduler._pending_request_builds = {}
+    scheduler._pending_request_admissions = {}
     scheduler._backlogged_request_build_payloads = deque()
     scheduler._request_build_max_pending_observed = 0
     scheduler.max_req_len = 8192

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -2733,6 +2733,7 @@ def test_qwen3_tts_ar_scheduler_abort_cleans_prepared_state() -> None:
         scheduler._request_build_executor = None
         scheduler.request_build_max_pending = 0
         scheduler._pending_request_builds = {}
+        scheduler._pending_request_admissions = {}
         scheduler._backlogged_request_build_payloads = []
         scheduler._request_build_max_pending_observed = 0
         scheduler.running_batch = SimpleNamespace(reqs=[], batch_is_full=False)

--- a/tests/unit_test/scheduling/test_deferred_admission.py
+++ b/tests/unit_test/scheduling/test_deferred_admission.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import concurrent.futures
+import threading
+from types import SimpleNamespace
+
+from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+from sglang_omni.scheduling.types import DeferredAdmission
+
+
+class _StubScheduler:
+    _admit_or_defer_built_request = OmniScheduler._admit_or_defer_built_request
+    _drain_request_admission_results = OmniScheduler._drain_request_admission_results
+
+    def __init__(self) -> None:
+        self._request_admission_lock = threading.RLock()
+        self._pending_request_admissions: dict = {}
+        self._aborted_request_ids: set[str] = set()
+        self.admitted: list[str] = []
+        self.errors: list[tuple[str, Exception]] = []
+
+    def _enqueue_built_request(
+        self,
+        payload,
+        pending_stream_done,
+        req_data,
+        *,
+        request_admission_lock_held=False,
+    ) -> None:
+        del pending_stream_done, request_admission_lock_held
+        self.admitted.append(req_data.req.rid)
+
+    def _emit_request_error(self, request_id: str, exc: Exception) -> None:
+        self.errors.append((request_id, exc))
+
+    def abort(self, request_id: str) -> None:
+        self._aborted_request_ids.add(request_id)
+        self._pending_request_admissions.pop(request_id, None)
+
+
+def _deferred(request_id: str):  # noqa: ANN202
+    future: concurrent.futures.Future[None] = concurrent.futures.Future()
+    payload = SimpleNamespace(request_id=request_id)
+    value = SimpleNamespace(req=SimpleNamespace(rid=request_id))
+    return payload, value, future, DeferredAdmission(value=value, ready=future)
+
+
+def test_request_waits_outside_lm_queue_until_dependency_completes() -> None:
+    scheduler = _StubScheduler()
+    payload, _, future, deferred = _deferred("r1")
+
+    scheduler._admit_or_defer_built_request(payload, False, deferred)
+    assert scheduler.admitted == []
+    assert list(scheduler._pending_request_admissions) == ["r1"]
+
+    future.set_result(None)
+    scheduler._drain_request_admission_results()
+    assert scheduler.admitted == ["r1"]
+    assert scheduler._pending_request_admissions == {}
+
+
+def test_aborted_deferred_request_is_never_admitted() -> None:
+    scheduler = _StubScheduler()
+    payload, _, future, deferred = _deferred("r1")
+    scheduler._admit_or_defer_built_request(payload, False, deferred)
+
+    scheduler.abort("r1")
+    future.set_result(None)
+    scheduler._drain_request_admission_results()
+
+    assert scheduler.admitted == []
+    assert not future.cancelled()
+
+
+def test_failed_dependency_emits_error_without_admission() -> None:
+    scheduler = _StubScheduler()
+    payload, _, future, deferred = _deferred("r1")
+    scheduler._admit_or_defer_built_request(payload, False, deferred)
+
+    future.set_exception(RuntimeError("encode failed"))
+    scheduler._drain_request_admission_results()
+
+    assert scheduler.admitted == []
+    assert len(scheduler.errors) == 1
+    assert scheduler.errors[0][0] == "r1"
+    assert "encode failed" in str(scheduler.errors[0][1])
+    assert "r1" in scheduler._aborted_request_ids

--- a/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
+++ b/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
@@ -58,6 +58,7 @@ class _StubScheduler:
         self.running_batch = SimpleNamespace(is_empty=lambda: False)
         self._request_admission_lock = threading.RLock()
         self._pending_request_builds: dict = {}
+        self._pending_request_admissions: dict = {}
         self._backlogged_request_build_payloads: list = []
 
     def get_new_batch_prefill(self):


### PR DESCRIPTION
## Motivation

ARK-ASR currently computes audio features during multimodal embedding construction on the LM path. Moving that work into a pre-LM encoder prevents audio encoding from stalling the running decode batch.

The first version of this PR performed the encode from `request_builder()`, but the builder blocked until GPU completion. That coupled encoder batching to the number of request-build workers and required raising the worker count from 2 to 8. This rewrite separates request construction from encoder completion:

```text
request builder -> submit encoder work -> pending admission
                                           |
                                           v
                              encoder future completes
                                           |
                                           v
                                    waiting_queue -> LM
```

Only the scheduler thread admits completed requests to `waiting_queue`.

## Modifications

- Add a generic `DeferredAdmission` result for request builders whose output has an asynchronous dependency.
- Add a scheduler-owned pending-admission stage with lifecycle handling for:
  - completed and failed dependencies;
  - request aborts without cancelling shared futures;
  - active-request accounting, idle polling, admin model info, and shutdown.
- Add a bounded pre-LM encoder queue. Existing users retain the unbounded default; ARK-ASR uses a pending limit of 32.
- Add nonblocking `ArkasrPreLMEncoderService.submit_item()` while retaining `encode_item()` as a synchronous compatibility helper.
- Preserve ARK-ASR's existing behavior:
  - CPU-backed embedding cache;
  - single-flight deduplication, now with a completion future per request;
  - private CUDA stream and batch synchronization;
  - greedy batches of up to 8 and model-internal encoder microbatches of up to 8;
  - existing validation, failure recovery, and OOM cleanup.
- Restore request construction defaults to 2 workers and 16 pending builds. Encoder backpressure is now controlled independently through `pre_lm_max_pending=32`.
- Add telemetry for submitted/pending requests, queue saturation, maximum queue depth, batching, queue wait, cache behavior, and encoder time.
- Add focused coverage for deferred admission, abort/error handling, asynchronous submission, asynchronous single-flight, full batch formation, bounded queue backpressure, configuration, and lifecycle wiring.
- Update the ARK-ASR cookbook documentation.

## Related Issues

- Builds on the batched ARK-ASR encoder work in #1411.

## Accuracy Test

Not run in this environment. The model computation, cache format, CUDA stream, synchronization point, and encoder batch-size bound are unchanged by this rewrite. WER parity still needs GPU validation before merge.

## Benchmark & Profiling

| Cache | Concurrency | Main req/s | PR req/s | Throughput Δ | Main mean latency | PR mean latency | Latency Δ |
|---|---|---|---|---|---|---|---|
| Cold | c16 | 32.938 | 55.258 | +67.8% | 0.485 s | 0.287 s | −40.8% |
| Warm | c16 | 98.963 | 98.318 | −0.7% | 0.161 s | 0.162 s | +0.6% |
| Cold | c32 | 48.839 | 100.055 | +104.9% | 0.652 s | 0.317 s | −51.4% |
| Warm | c32 | 136.021 ± 1.377 | 134.717 ± 4.656 | −1.0% | 0.233 ± 0.003 s | 0.236 ± 0.008 s | +1.1% |


## Validation

- Focused pre-commit checks passed across all 17 changed files.
- `git diff --check origin/main...HEAD` passed.
- Rebase `range-diff` confirmed the original two PR patches remained equivalent before the four rewrite commits.
- Unit tests and GPU benchmarks were not executed, per repository task instructions.

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the `run-ci` label. Once labeled, every subsequent push re-triggers CI as long as the label remains. Use `/tag-and-rerun-ci higgs` or `/tag-and-rerun-ci moss` to select a TTS CI model, and `/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR CI model. One selector from each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
