### PR TITLE
[ASR][Perf] Enable async lookahead for single-request Qwen3-ASR

### DIFF
--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -16,10 +16,10 @@ MODEL_PATH=$(hf download Qwen/Qwen3-ASR-1.7B --revision "${MODEL_REVISION}")
 Qwen3-ASR runs a single ASR stage on one GPU. Its default `auto` dtype follows
 the checkpoint configuration (BF16 for Qwen3-ASR-1.7B); pass
 `--stages.asr.factory-args.dtype float16` to force FP16.
-Async decode is enabled by default for decode batches of at least two requests,
-allowing the shared one-step-lookahead path to overlap host-side result
-processing with the next GPU decode forward. Use `--decode-mode sync` to disable
-it, or tune the crossover with `--async-lookahead-min-batch-size`.
+Async decode is enabled by default for all decode batch sizes, allowing the
+shared one-step-lookahead path to overlap host-side result processing with the
+next GPU decode forward even for a single request. Use `--decode-mode sync` to
+disable it, or tune the crossover with `--async-lookahead-min-batch-size`.
 The request builders also use the shared LM prefill-admission gate while more
 request builds are pending: prefill starts when 16 built requests are ready,
 after the oldest ready request waits 24 ms, or immediately when build work drains.

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -1276,7 +1276,8 @@ def serve(
             "--async_lookahead_min_batch_size",
             help=(
                 "Decode batches smaller than this bypass async lookahead and "
-                "run synchronously (fast path). Default 2."
+                "run synchronously (fast path). Model default: 1 for "
+                "Qwen3-ASR and 2 for other supported models."
             ),
         ),
     ] = None,

--- a/sglang_omni/models/qwen3_asr/stages.py
+++ b/sglang_omni/models/qwen3_asr/stages.py
@@ -17,7 +17,7 @@ def create_sglang_qwen3_asr_executor(
     mm_embedding_cache_size_bytes: int = 0,
     enable_torch_compile: bool = False,
     enable_async_decode: bool = True,
-    async_decode_min_batch_size: int = 2,
+    async_decode_min_batch_size: int = 1,
     mm_attention_backend: str | None = None,
     request_build_max_workers: int = 8,
     request_build_max_pending: int | None = 32,

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -197,7 +197,7 @@ def test_qwen3_asr_stage_default_enables_async_decode() -> None:
     signature = inspect.signature(create_sglang_qwen3_asr_executor)
 
     assert signature.parameters["enable_async_decode"].default is True
-    assert signature.parameters["async_decode_min_batch_size"].default == 2
+    assert signature.parameters["async_decode_min_batch_size"].default == 1
 
 
 def test_qwen3_asr_rtx4090_profile_is_bf16_and_bounded() -> None:


### PR DESCRIPTION
## Motivation

Qwen3-ASR enables shared one-step-lookahead async decode by default, but its
minimum async batch size is currently two. Batch size one therefore falls back
to synchronous decode even though the measured async path improves the
single-request workload without changing WER or completion coverage.

This implements Q-PR2 from the ASR optimization roadmap by selecting the
measured Qwen3-ASR crossover while keeping the shared scheduler and other model
defaults unchanged.

## Modifications

1. `sglang_omni/models/qwen3_asr/stages.py`
   - Changes the Qwen3-ASR stage default `async_decode_min_batch_size` from `2`
     to `1`, enabling lookahead for every non-empty decode batch.
   - Leaves the shared `OmniScheduler` default and all other model policies
     unchanged.
2. `sglang_omni/cli/serve.py`
   - Updates `--async-lookahead-min-batch-size` help to describe the
     Qwen3-ASR-specific default and the default used by other supported models.
3. `tests/unit_test/qwen3_asr/test_pipeline.py`
   - Updates the production stage-factory default assertion to lock in the new
     threshold.
4. `docs/cookbook/qwen3_asr.md`
   - Documents that Qwen3-ASR now uses async lookahead at every decode batch
     size, including batch size one.

## Related Issues

Related to #1396 (Q-PR2).

## Accuracy Test

**Setup:**

- **Refs:** baseline `main` @ `efef31d6`; candidate
  `bench/async-lookahead-min-batch-1-20260807` @ `efef31d6` with
  `--async-lookahead-min-batch-size 1` (the behavior made default by this PR).
- **Model:** `Qwen/Qwen3-ASR-1.7B`, revision
  `7278e1e70fe206f11671096ffdd38061171dd6e5`.
- **Dataset:** full SeedTTS EN, revision
  `27f4c1adee83b5b29b7c4b375f6b976324bda308`, 1,088 clips.
- **Workload:** non-streaming transcription at concurrency `1,8,32`, three
  measured repeats per level, no discarded warmup.
- **Hardware / runtime:** physical GPU 1, NVIDIA H100 80GB HBM3.


| Metric | Main | Min batch size 1 | Delta |
| --- | ---: | ---: | ---: |
| Corpus WER, c=1 | 0.0122 | 0.0122 | 0.0000 |
| Corpus WER, c=8 | 0.0122 | 0.0122 | 0.0000 |
| Corpus WER, c=32 | 0.0123 | 0.0123 | 0.0000 |
| Max sample WER | 0.1818 | 0.1818 | 0.0000 |
| Evaluated / attempted per concurrency | 3,264 / 3,264 | 3,264 / 3,264 | same |
| Skipped per concurrency | 0 | 0 | same |

Raw transcripts were pairwise identical at c=1 and c=8. At c=32, 8/3,264
paired raw strings differed; six were formatting-only and two normalized
differences were the same proper-name sample, with unchanged per-sample WER.
Main also varied across high-concurrency repeats, so this is not a measurable
candidate accuracy regression.

## Benchmark & Profiling

Same setup as described in the _Accuracy Test_ section. Values are mean +/-
sample standard deviation across three repeats.

| Concurrency | Metric | Main | Min batch size 1 | Delta |
| ---: | --- | ---: | ---: | ---: |
| 1 | Throughput (samples/s) | 17.5644 +/- 1.6015 | 20.2377 +/- 1.7767 | **+15.22%** |
| 1 | Mean latency (s) | 0.0571 +/- 0.0055 | 0.0495 +/- 0.0046 | **-13.36%** |
| 1 | P95 latency (s) | 0.0713 +/- 0.0083 | 0.0616 +/- 0.0074 | **-13.58%** |
| 8 | Throughput (samples/s) | 105.4838 +/- 1.6723 | 108.1147 +/- 1.8260 | +2.49% |
| 8 | Mean latency (s) | 0.0755 +/- 0.0012 | 0.0737 +/- 0.0013 | -2.42% |
| 8 | P95 latency (s) | 0.1069 +/- 0.0018 | 0.1071 +/- 0.0019 | +0.20% |
| 32 | Throughput (samples/s) | 222.9836 +/- 8.5811 | 228.1131 +/- 3.0977 | +2.30% |
| 32 | Mean latency (s) | 0.1423 +/- 0.0058 | 0.1374 +/- 0.0001 | -3.44% |
| 32 | P95 latency (s) | 0.2102 +/- 0.0126 | 0.1937 +/- 0.0040 | -7.88% |

### Summary:

The target c=1 workload shows a consistent throughput gain across all three
paired repeats (+15.72%, +14.98%, +15.03%). The c=8 improvement is smaller.
The c=32 aggregate is positive but noisy: paired throughput deltas were +1.09%,
+8.05%, and -1.86%, so this PR does not claim a stable high-concurrency win.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
