### PR TITLE
[Perf] Keep Qwen3-ASR prefill coalescing during active decode

### DIFF
--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -20,9 +20,11 @@ Async decode is enabled by default for decode batches of at least two requests,
 allowing the shared one-step-lookahead path to overlap host-side result
 processing with the next GPU decode forward. Use `--decode-mode sync` to disable
 it, or tune the crossover with `--async-lookahead-min-batch-size`.
-The request builders also use the shared LM prefill-admission gate while more
-request builds are pending: prefill starts when 16 built requests are ready,
-after the oldest ready request waits 24 ms, or immediately when build work drains.
+The request builders also use the shared LM prefill-admission gate: prefill
+starts when 16 built requests are ready or after the oldest ready request waits
+24 ms. Once request-build work drains, a ready prefill is released immediately
+if decode is idle; while decode is active, it continues coalescing until the
+same request target or deadline.
 
 ```bash
 sgl-omni serve \

--- a/sglang_omni/models/qwen3_asr/config.py
+++ b/sglang_omni/models/qwen3_asr/config.py
@@ -40,6 +40,7 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
                 "prefill_coalesce_wait_ms": 24,
                 "prefill_coalesce_when_idle": True,
                 "prefill_coalesce_requires_pending_builds": True,
+                "prefill_coalesce_after_builds_during_decode": True,
                 "enable_pre_lm_encoder": True,
                 "pre_lm_cache_max_entries": 4096,
                 "pre_lm_cache_size_bytes": 2 * 1024**3,

--- a/sglang_omni/models/qwen3_asr/engine_builder.py
+++ b/sglang_omni/models/qwen3_asr/engine_builder.py
@@ -43,6 +43,7 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
         prefill_coalesce_wait_ms: float,
         prefill_coalesce_when_idle: bool,
         prefill_coalesce_requires_pending_builds: bool,
+        prefill_coalesce_after_builds_during_decode: bool,
         enable_pre_lm_encoder: bool = True,
         pre_lm_cache_max_entries: int = 4096,
         pre_lm_cache_size_bytes: int = 2 * 1024**3,
@@ -72,6 +73,9 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
         self.prefill_coalesce_when_idle = prefill_coalesce_when_idle
         self.prefill_coalesce_requires_pending_builds = (
             prefill_coalesce_requires_pending_builds
+        )
+        self.prefill_coalesce_after_builds_during_decode = (
+            prefill_coalesce_after_builds_during_decode
         )
         self.enable_pre_lm_encoder = enable_pre_lm_encoder
         self.pre_lm_cache_max_entries = pre_lm_cache_max_entries
@@ -212,5 +216,8 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
             "prefill_coalesce_when_idle": self.prefill_coalesce_when_idle,
             "prefill_coalesce_requires_pending_builds": (
                 self.prefill_coalesce_requires_pending_builds
+            ),
+            "prefill_coalesce_after_builds_during_decode": (
+                self.prefill_coalesce_after_builds_during_decode
             ),
         }

--- a/sglang_omni/models/qwen3_asr/stages.py
+++ b/sglang_omni/models/qwen3_asr/stages.py
@@ -25,6 +25,7 @@ def create_sglang_qwen3_asr_executor(
     prefill_coalesce_wait_ms: float = 24.0,
     prefill_coalesce_when_idle: bool = True,
     prefill_coalesce_requires_pending_builds: bool = True,
+    prefill_coalesce_after_builds_during_decode: bool = True,
     enable_pre_lm_encoder: bool = True,
     pre_lm_cache_max_entries: int = 4096,
     pre_lm_cache_size_bytes: int = 2 * 1024**3,
@@ -50,6 +51,9 @@ def create_sglang_qwen3_asr_executor(
         prefill_coalesce_when_idle=prefill_coalesce_when_idle,
         prefill_coalesce_requires_pending_builds=(
             prefill_coalesce_requires_pending_builds
+        ),
+        prefill_coalesce_after_builds_during_decode=(
+            prefill_coalesce_after_builds_during_decode
         ),
         enable_pre_lm_encoder=enable_pre_lm_encoder,
         pre_lm_cache_max_entries=pre_lm_cache_max_entries,

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -196,6 +196,7 @@ class OmniScheduler:
         prefill_coalesce_wait_ms: float = 60.0,
         prefill_coalesce_when_idle: bool = False,
         prefill_coalesce_requires_pending_builds: bool = False,
+        prefill_coalesce_after_builds_during_decode: bool = False,
         request_build_max_workers: int = 1,
         request_build_max_pending: int | None = None,
         shutdown_callback: Callable[[], None] | None = None,
@@ -301,6 +302,9 @@ class OmniScheduler:
         self.prefill_coalesce_when_idle = bool(prefill_coalesce_when_idle)
         self.prefill_coalesce_requires_pending_builds = bool(
             prefill_coalesce_requires_pending_builds
+        )
+        self.prefill_coalesce_after_builds_during_decode = bool(
+            prefill_coalesce_after_builds_during_decode
         )
 
         # Token / memory info (upstream reads from tp_worker.get_worker_info)
@@ -1162,9 +1166,8 @@ class OmniScheduler:
         # so the coalesce hold-off returns an empty plan rather than None.
         if self.prefill_coalesce_requests <= 1 or self.chunked_req is not None:
             return _Upstream.get_new_batch_prefill(self, running_batch)
-        if not self.prefill_coalesce_when_idle and (
-            running_batch is None or running_batch.is_empty()
-        ):
+        decode_is_idle = running_batch is None or running_batch.is_empty()
+        if not self.prefill_coalesce_when_idle and decode_is_idle:
             return _Upstream.get_new_batch_prefill(self, running_batch)
         if self.prefill_coalesce_requires_pending_builds:
             with self._request_admission_lock:
@@ -1172,7 +1175,9 @@ class OmniScheduler:
                     self._pending_request_builds
                     or self._backlogged_request_build_payloads
                 )
-            if not build_work_pending:
+            if not build_work_pending and not (
+                self.prefill_coalesce_after_builds_during_decode and not decode_is_idle
+            ):
                 return _Upstream.get_new_batch_prefill(self, running_batch)
         waiting = self.waiting_queue
         if not waiting or len(waiting) >= self.prefill_coalesce_requests:

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -41,6 +41,7 @@ def _make_engine_builder(
         prefill_coalesce_wait_ms=24.0,
         prefill_coalesce_when_idle=True,
         prefill_coalesce_requires_pending_builds=True,
+        prefill_coalesce_after_builds_during_decode=True,
     )
 
 
@@ -108,6 +109,10 @@ def test_qwen3_asr_config_uses_batched_stage_with_64_running_requests() -> None:
         config.stages[0].factory_args["prefill_coalesce_requires_pending_builds"]
         is True
     )
+    assert (
+        config.stages[0].factory_args["prefill_coalesce_after_builds_during_decode"]
+        is True
+    )
     assert "request_build_max_backlog" not in config.stages[0].factory_args
     assert config.stages[0].factory_args["enable_pre_lm_encoder"] is True
     assert config.stages[0].factory_args["pre_lm_cache_max_entries"] == 4096
@@ -135,6 +140,10 @@ def test_qwen3_asr_stage_default_allows_64_running_requests() -> None:
     assert signature.parameters["prefill_coalesce_when_idle"].default is True
     assert (
         signature.parameters["prefill_coalesce_requires_pending_builds"].default is True
+    )
+    assert (
+        signature.parameters["prefill_coalesce_after_builds_during_decode"].default
+        is True
     )
     assert "request_build_max_backlog" not in signature.parameters
 
@@ -350,4 +359,5 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch, caplog) -> None:
     assert scheduler.prefill_coalesce_wait_ms == 24.0
     assert scheduler.prefill_coalesce_when_idle is True
     assert scheduler.prefill_coalesce_requires_pending_builds is True
+    assert scheduler.prefill_coalesce_after_builds_during_decode is True
     assert scheduler.shutdown_callback is fake_encoder_service.close

--- a/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
+++ b/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
@@ -44,11 +44,15 @@ class _StubScheduler:
         wait_ms: float = 60.0,
         coalesce_when_idle: bool = False,
         requires_pending_builds: bool = False,
+        coalesce_after_builds_during_decode: bool = False,
     ) -> None:
         self.prefill_coalesce_requests = coalesce_requests
         self.prefill_coalesce_wait_s = wait_ms / 1e3
         self.prefill_coalesce_when_idle = coalesce_when_idle
         self.prefill_coalesce_requires_pending_builds = requires_pending_builds
+        self.prefill_coalesce_after_builds_during_decode = (
+            coalesce_after_builds_during_decode
+        )
         self.chunked_req = None
         self.waiting_queue: list = []
         self.running_batch = SimpleNamespace(is_empty=lambda: False)
@@ -244,6 +248,35 @@ def test_pending_build_gate_does_not_wait_without_build_work(upstream, clock):
         wait_ms=6.0,
         coalesce_when_idle=True,
         requires_pending_builds=True,
+    )
+    sched.running_batch = None
+    sched.waiting_queue = [_req(100.0)]
+
+    clock.return_value = 100.001
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+
+
+def test_decode_can_coalesce_after_build_work_drains(upstream, clock):
+    sched = _StubScheduler(
+        coalesce_requests=8,
+        wait_ms=6.0,
+        coalesce_when_idle=True,
+        requires_pending_builds=True,
+        coalesce_after_builds_during_decode=True,
+    )
+    sched.waiting_queue = [_req(100.0)]
+
+    clock.return_value = 100.001
+    assert sched.get_new_batch_prefill() is None
+
+
+def test_idle_decode_still_releases_after_build_work_drains(upstream, clock):
+    sched = _StubScheduler(
+        coalesce_requests=8,
+        wait_ms=6.0,
+        coalesce_when_idle=True,
+        requires_pending_builds=True,
+        coalesce_after_builds_during_decode=True,
     )
     sched.running_batch = None
     sched.waiting_queue = [_req(100.0)]


### PR DESCRIPTION
## Motivation

Qwen3-ASR uses pending request-build work to decide whether a small prefill should wait for the existing 16-request / 24 ms coalescing window. Once request construction drains, small prefills are released immediately even while a decode batch is active. H200 profiling showed that these scattered admissions repeatedly interrupt decode and leave large gaps between CUDA graph launches at high concurrency.

## Modifications

1. Add an opt-in scheduler policy that keeps coalescing after request-build work drains only while decode is active.
2. Keep the existing pending-build-aware early release while decode is idle, preserving light-load behavior.
3. Enable the policy only for Qwen3-ASR and thread it through the pipeline config, stage factory, and engine builder.
4. Add behavior tests for both active-decode coalescing and idle release.

Other model defaults are unchanged.

## Related Issues

Related to #1324 and #1396.

## Accuracy Test

- Model: `Qwen/Qwen3-ASR-1.7B`, revision `7278e1e70fe206f11671096ffdd38061171dd6e5`.
- Dataset: full SeedTTS EN, 1,088 clips, revision `27f4c1adee83b5b29b7c4b375f6b976324bda308`.
- Every measured configuration completed 3,264 of 3,264 requests with zero skips.
- Corpus WER was identical at `0.0121822034` for main and candidate.

## Benchmark & Profiling

Setup:

- Hardware: one NVIDIA H200 on hyper00, physical GPU 0.
- Runtime: BF16, FA3 attention, decode CUDA graphs enabled, torch.compile disabled.
- Baseline: current main at `efef31d612c4d9c101bbd62e4dadae960df1b05e`.
- Candidate: `6a4df39a245576f4a29aa00828511003d0db589c`.
- Protocol: same physical GPU, sequential fresh servers, one discarded full-corpus warmup followed by three measured full-corpus repeats per concurrency.

| Concurrency | Metric | Main | Candidate | Delta |
| ---: | --- | ---: | ---: | ---: |
| 8 | Throughput | 96.994 req/s | 100.503 req/s | +3.62% |
| 8 | Mean latency | 82.128 ms | 79.194 ms | -3.57% |
| 8 | P95 latency | 121.166 ms | 117.236 ms | -3.24% |
| 64 | Throughput | 211.353 req/s | 254.768 req/s | +20.54% |
| 64 | Mean latency | 297.918 ms | 247.116 ms | -17.05% |
| 64 | P95 latency | 443.610 ms | 350.229 ms | -21.05% |

The candidate reaches 254.768 req/s at c64, 7.66% above the fixed 236.639 req/s serving baseline. A separate c2 validation completed all 3,264 requests at 21.636 req/s with the same WER.

## Validation

- `pytest -q tests/unit_test/qwen3_asr tests/unit_test/scheduling/test_prefill_coalesce_gate.py`: 550 passed.
- Pre-commit passed for all six changed files.
- Git diff check passed.

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests.
- [x] Provide reproducible throughput, latency, and accuracy measurements.
