### PR TITLE
[ASR] Stream chunked long-audio transcriptions in order

### DIFF
--- a/sglang_omni/serve/transcriptions.py
+++ b/sglang_omni/serve/transcriptions.py
@@ -10,7 +10,7 @@ import logging
 import math
 import uuid
 from collections.abc import AsyncIterator, Awaitable
-from contextlib import aclosing
+from contextlib import aclosing, suppress
 from typing import Any
 
 from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
@@ -150,32 +150,47 @@ def register_transcriptions(app: FastAPI) -> None:
                 )
             stream_chunking: AudioChunkingConfig = app.state.audio_chunking
             duration_s = _probe_audio_duration(audio_bytes)
+            plan: ChunkPlan | None = None
             if (
                 stream_chunking.allow_audio_chunking
                 and duration_s > stream_chunking.stream_clip_limit_s
             ):
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        "stream=true does not support audio longer than "
-                        f"{stream_chunking.stream_clip_limit_s:g} seconds; "
-                        "use stream=false, which transcribes long audio in "
-                        "chunks"
-                    ),
+                try:
+                    check_total_duration(duration_s, stream_chunking)
+                    plan = await asyncio.to_thread(
+                        plan_audio_chunks,
+                        audio_bytes,
+                        stream_chunking,
+                    )
+                except (RuntimeError, ValueError) as exc:
+                    raise HTTPException(status_code=400, detail=str(exc)) from exc
+            if plan is not None:
+                duration_s = plan.duration_s
+                chunk_stream = _stream_transcription_chunks(
+                    client,
+                    plan,
+                    request_id=request_id,
+                    model=model or default_model,
+                    filename=file.filename,
+                    language=language,
+                    prompt=prompt,
+                    temperature=temperature,
+                    max_new_tokens=max_new_tokens,
                 )
-            gen_req = build_transcription_generate_request(
-                audio_bytes=audio_bytes,
-                filename=file.filename,
-                content_type=file.content_type,
-                model=model or default_model,
-                language=language,
-                prompt=prompt,
-                temperature=temperature,
-                max_new_tokens=max_new_tokens,
-                stream=True,
-            )
+            else:
+                gen_req = build_transcription_generate_request(
+                    audio_bytes=audio_bytes,
+                    filename=file.filename,
+                    content_type=file.content_type,
+                    model=model or default_model,
+                    language=language,
+                    prompt=prompt,
+                    temperature=temperature,
+                    max_new_tokens=max_new_tokens,
+                    stream=True,
+                )
+                chunk_stream = client.generate(gen_req, request_id=request_id)
             adapter = resolve_adapter(getattr(app.state, "architectures", None))
-            chunk_stream = client.generate(gen_req, request_id=request_id)
             # Pull the first chunk before sending response headers so admission
             # failures map to HTTP statuses rather than SSE error payloads.
             try:
@@ -388,6 +403,75 @@ def _build_chunk_generate_request(
         temperature=temperature,
         max_new_tokens=max_new_tokens,
         stream=stream,
+    )
+
+
+async def _stream_transcription_chunks(
+    client: Client,
+    plan: ChunkPlan,
+    *,
+    request_id: str,
+    model: str,
+    filename: str | None,
+    language: str | None,
+    prompt: str | None,
+    temperature: float | None,
+    max_new_tokens: int | None,
+) -> AsyncIterator[GenerateChunk]:
+    """Stream ordered child requests as one coherent transcription."""
+    texts: list[str] = []
+    emitted_text = ""
+    for span in plan.spans:
+        chunk_bytes = await asyncio.to_thread(plan.encode, span)
+        gen_req = _build_chunk_generate_request(
+            chunk_bytes,
+            model=model,
+            filename=filename,
+            language=language,
+            prompt=prompt,
+            temperature=temperature,
+            max_new_tokens=max_new_tokens,
+            stream=True,
+        )
+        child_request_id = f"{request_id}-chunk-{span.index}"
+        child_stream = client.generate(gen_req, request_id=child_request_id)
+        streamed_text: list[str] = []
+        final_text: str | None = None
+        completed = False
+        try:
+            async with aclosing(child_stream):
+                async for chunk in child_stream:
+                    if chunk.finish_reason is not None:
+                        if isinstance(chunk.text, str) and chunk.text:
+                            final_text = chunk.text
+                        continue
+                    if chunk.modality == "text" and chunk.text:
+                        streamed_text.append(chunk.text)
+            completed = True
+        except Exception as exc:
+            raise ClientError(
+                f"transcription failed for chunk {span.index} "
+                f"({span.start_s:.1f}s-{span.end_s:.1f}s): {exc}"
+            ) from exc
+        finally:
+            if not completed:
+                with suppress(Exception):
+                    await client.abort(child_request_id)
+        child_text = final_text if final_text is not None else "".join(streamed_text)
+        texts.append(child_text)
+        joined_text = join_transcript_parts(texts)
+        delta = joined_text[len(emitted_text) :]
+        if delta:
+            # Qwen3-ASR currently emits one terminal text chunk rather than
+            # token deltas. Emit completed children at chunk granularity and
+            # include the same seam text used by the final joined transcript.
+            yield GenerateChunk(request_id=child_request_id, text=delta)
+        emitted_text = joined_text
+
+    yield GenerateChunk(
+        request_id=request_id,
+        text=emitted_text,
+        finish_reason="stop",
     )
 
 

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 from typing import Any
 
 import pytest
@@ -347,6 +348,23 @@ class ChunkRecordingTranscriptionClient:
         if self.fail_chunk is not None and index == self.fail_chunk:
             raise ClientError(self.fail_message)
         return CompletionResult(request_id=request_id, text=f"part{index}")
+
+    async def generate(
+        self,
+        request: GenerateRequest,
+        request_id: str | None = None,
+    ):
+        from sglang_omni.client import ClientError
+
+        assert request_id is not None
+        self.requests.append((request_id, request))
+        index = self._chunk_index(request_id)
+        if index is None:
+            index = len(self.requests) - 1
+        if self.fail_chunk is not None and index == self.fail_chunk:
+            raise ClientError(self.fail_message)
+        text = f"part{index}"
+        yield GenerateChunk(request_id=request_id, text=text, finish_reason="stop")
 
     async def abort(self, request_id: str) -> None:
         self.aborted.append(request_id)
@@ -1518,11 +1536,7 @@ def test_long_audio_is_transcribed_chunk_by_chunk() -> None:
     assert response.json()["usage"] == {"seconds": 3, "type": "duration"}
 
 
-def test_streamed_long_audio_is_rejected_explicitly() -> None:
-    # Streaming cannot chunk; without this 400 a too-long upload would run
-    # as a single request and truncate (observed live: 243s audio came back
-    # 20% short with HTTP 200). No native limit declared here, so the guard
-    # falls back to the chunk length.
+def test_streamed_long_audio_is_transcribed_chunk_by_chunk() -> None:
     transcription_client = ChunkRecordingTranscriptionClient()
     client = _chunking_test_client(transcription_client)
 
@@ -1532,9 +1546,65 @@ def test_streamed_long_audio_is_rejected_explicitly() -> None:
         files={"file": ("long.wav", _wav_upload(2.5), "audio/wav")},
     )
 
-    assert response.status_code == 400
-    assert "stream=false" in response.json()["detail"]
-    assert transcription_client.requests == []
+    assert response.status_code == 200
+    count = len(transcription_client.requests)
+    assert count > 1
+    seen_ids = [request_id for request_id, _ in transcription_client.requests]
+    assert [
+        int(request_id.rsplit("-chunk-", 1)[-1]) for request_id in seen_ids
+    ] == list(range(count))
+    for _, request in transcription_client.requests:
+        assert request.stream is True
+        assert request.prompt["audio_bytes"][:4] == b"RIFF"
+        assert request.prompt["content_type"] == "audio/wav"
+    expected_text = " ".join(f"part{index}" for index in range(count))
+    assert f'"text":"{expected_text}"' in response.text
+    events = [
+        json.loads(line.removeprefix("data: "))
+        for line in response.text.splitlines()
+        if line.startswith("data: {")
+    ]
+    deltas = [
+        event["delta"] for event in events if event["type"] == "transcript.text.delta"
+    ]
+    streamed_text = "".join(deltas)
+    done_text = next(
+        event["text"] for event in events if event["type"] == "transcript.text.done"
+    )
+    assert len(deltas) == count
+    assert streamed_text == done_text == expected_text
+    assert response.text.rstrip().endswith("data: [DONE]")
+
+
+def test_streamed_long_audio_first_chunk_failure_maps_before_sse() -> None:
+    transcription_client = ChunkRecordingTranscriptionClient(fail_chunk=0)
+    client = _chunking_test_client(transcription_client)
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={"model": "asr", "stream": "true"},
+        files={"file": ("long.wav", _wav_upload(2.5), "audio/wav")},
+    )
+
+    assert response.status_code == 500
+    assert "chunk 0" in response.json()["detail"]
+
+
+def test_streamed_long_audio_later_failure_emits_error_without_done() -> None:
+    transcription_client = ChunkRecordingTranscriptionClient(fail_chunk=1)
+    client = _chunking_test_client(transcription_client)
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={"model": "asr", "stream": "true"},
+        files={"file": ("long.wav", _wav_upload(2.5), "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert '"delta":"part0"' in response.text
+    assert '"type": "error"' in response.text
+    assert "chunk 1" in response.text
+    assert "data: [DONE]" not in response.text
 
 
 def test_streamed_audio_within_the_native_limit_streams_whole() -> None:
@@ -1555,7 +1625,7 @@ def test_streamed_audio_within_the_native_limit_streams_whole() -> None:
     assert "transcript.text.done" in response.text
 
 
-def test_streamed_audio_beyond_the_native_limit_is_rejected() -> None:
+def test_streamed_audio_beyond_the_native_limit_is_chunked() -> None:
     transcription_client = ChunkRecordingTranscriptionClient()
     client = _chunking_test_client(transcription_client, max_native_clip_s=2.0)
 
@@ -1565,9 +1635,9 @@ def test_streamed_audio_beyond_the_native_limit_is_rejected() -> None:
         files={"file": ("long.wav", _wav_upload(2.5), "audio/wav")},
     )
 
-    assert response.status_code == 400
-    assert "2 seconds" in response.json()["detail"]
-    assert transcription_client.requests == []
+    assert response.status_code == 200
+    assert len(transcription_client.requests) > 1
+    assert all(request.stream for _, request in transcription_client.requests)
 
 
 def test_streamed_short_audio_streams_as_before() -> None:
@@ -1755,6 +1825,53 @@ def _run_chunks(client: Any, plan: Any, *, max_concurrent: int):
         ),
         timeout=10.0,
     )
+
+
+def test_closing_chunked_stream_aborts_active_child() -> None:
+    from sglang_omni.serve.transcriptions import _stream_transcription_chunks
+
+    class HangingStreamClient:
+        def __init__(self) -> None:
+            self.aborted: list[str] = []
+            self.closed = asyncio.Event()
+            self.started = asyncio.Event()
+
+        async def generate(self, request, request_id):
+            del request
+            try:
+                self.started.set()
+                await asyncio.Future()
+                yield GenerateChunk(request_id=request_id, text="unreachable")
+            finally:
+                self.closed.set()
+
+        async def abort(self, request_id: str) -> None:
+            self.aborted.append(request_id)
+
+    async def scenario() -> None:
+        client = HangingStreamClient()
+        stream = _stream_transcription_chunks(
+            client,
+            _tiny_plan(2),
+            request_id="req",
+            model="asr",
+            filename=None,
+            language=None,
+            prompt=None,
+            temperature=None,
+            max_new_tokens=None,
+        )
+
+        first_chunk_task = asyncio.create_task(anext(stream))
+        await client.started.wait()
+        first_chunk_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first_chunk_task
+
+        assert client.aborted == ["req-chunk-0"]
+        assert client.closed.is_set()
+
+    asyncio.run(scenario())
 
 
 def test_chunks_run_concurrently() -> None:


### PR DESCRIPTION
## Summary

- allow `stream=true` long-audio requests to reuse #1347's chunk plan once the upload exceeds the model's native clip limit
- transcribe chunks sequentially and emit completed chunk text in source order
- keep streamed deltas and the terminal `transcript.text.done` text identical, including seam joining
- map first-chunk failures to an HTTP error and later failures to an SSE error without a false done event
- abort an active child request when the composite stream is closed or fails

## Scope

This is stacked on #1347 because it depends on that PR's chunk planning and lifecycle infrastructure. Uploads remain fully buffered before transcription; incremental upload/input streaming and additional scheduling policies are intentionally outside this PR.

## Testing

- `158 passed`: `tests/unit_test/serve/test_openai_api.py` and `tests/unit_test/serve/test_transcription_chunking.py`
- pre-commit hooks pass for the changed files
