### PR TITLE
[Perf] dots.tts: reuse batched latent denormalization

### DIFF
--- a/sglang_omni/models/dots_tts/flow_head.py
+++ b/sglang_omni/models/dots_tts/flow_head.py
@@ -650,6 +650,7 @@ class DotsTTSFlowHead(nn.Module):
             self._patch_encoder_input(normalized, already_normalized=True),
         )
         self._stage_batched_eos(eos_hits)
+        latent_patches = self.io.denormalize(normalized)
         results = []
         for row, state in enumerate(states):
             emit = not state.drop_regenerated_prompt_patch
@@ -657,7 +658,7 @@ class DotsTTSFlowHead(nn.Module):
             state.decoded_patches += 1
             results.append(
                 DotsFlowStep(
-                    latent_patch=self.io.denormalize(normalized[row : row + 1]),
+                    latent_patch=latent_patches[row : row + 1],
                     feedback_embedding=feedback[row],
                     finished=False,
                     emit=emit,

--- a/sglang_omni/models/dots_tts/flow_head.py
+++ b/sglang_omni/models/dots_tts/flow_head.py
@@ -645,12 +645,17 @@ class DotsTTSFlowHead(nn.Module):
             slots,
             fm_hidden_rows=self.hidden_proj(hidden),
         )
+        latent_patches = self.io.denormalize(normalized)
+        patch_encoder_input = (
+            normalized
+            if self.patch_encoder.expects_normalized_input
+            else latent_patches
+        ).to(dtype=next(self.patch_encoder.parameters()).dtype)
         feedback = self._tail.encode_feedback(
             slots,
-            self._patch_encoder_input(normalized, already_normalized=True),
+            patch_encoder_input,
         )
         self._stage_batched_eos(eos_hits)
-        latent_patches = self.io.denormalize(normalized)
         results = []
         for row, state in enumerate(states):
             emit = not state.drop_regenerated_prompt_patch

--- a/tests/unit_test/dots_tts/test_flow_head.py
+++ b/tests/unit_test/dots_tts/test_flow_head.py
@@ -439,6 +439,14 @@ def test_batched_eos_resolve_reads_staged_flags(tmp_path) -> None:
         )
         states.append(state)
 
+    denormalize_shapes = []
+    denormalize = flow.io.denormalize
+
+    def record_denormalize(value):
+        denormalize_shapes.append(tuple(value.shape))
+        return denormalize(value)
+
+    flow.io.denormalize = record_denormalize
     steps = flow.decode_batch(
         states,
         hidden_states=torch.randn(2, LLM_HIDDEN),
@@ -448,6 +456,7 @@ def test_batched_eos_resolve_reads_staged_flags(tmp_path) -> None:
         eos_thresholds=[2.0, 2.0],
         append_hidden=False,
     )
+    assert denormalize_shapes == [(2, PATCH_SIZE, LATENT_DIM)]
     assert all(not step.finished for step in steps)
     assert flow.has_pending_batched_eos
     assert flow.resolve_batched_eos() == [False, False]


### PR DESCRIPTION
## Motivation

The continuous-batched dots.tts tail denormalized the same sampled latent batch once for the semantic encoder and then once per request when building `DotsFlowStep` results. At batch size 16, that is 17 elementwise denormalization calls per generated patch.

## Modifications

- Denormalize the sampled latent batch once.
- Reuse that result as the semantic-encoder input when the encoder expects raw latents.
- Return per-request views from the batched result instead of launching per-row denormalization.
- Preserve the existing float32 output and patch-encoder dtype conversion semantics.
- Add a regression assertion that the two-request decode performs one batched denormalization.

## Impact

Denormalization calls per decode step become constant: `batch_size + 1 -> 1`. This removes redundant CUDA launches and temporary tensors without changing model math, RNG, scheduling, or output layout.

RTX A6000 / PyTorch 2.11.0+cu130 microbenchmark (bf16 normalized input, float32 stats; median of 7 x 300 steps):

| Batch | Before (us/step) | After (us/step) | Reduction |
| ---: | ---: | ---: | ---: |
| 1 | 101.319 | 63.975 | 36.86% |
| 4 | 232.303 | 79.531 | 65.76% |
| 8 | 408.640 | 65.731 | 83.91% |
| 16 | 558.794 | 77.494 | 86.13% |

This is an isolated operator-path benchmark, not an end-to-end throughput claim.

## Validation

- `python -m pytest -q tests/unit_test/dots_tts/test_flow_head.py` — 9 passed
- `ruff check sglang_omni/models/dots_tts/flow_head.py tests/unit_test/dots_tts/test_flow_head.py`
- `git diff --check`

Tested in the canonical Aries A6000 container with PyTorch 2.11.0+cu130 and `dots.tts==0.2.1`.

Related: #1367