### PR TITLE
[Perf] dots.tts: stack feedback into the graph buffer

### DIFF
--- a/sglang_omni/models/dots_tts/model_runner.py
+++ b/sglang_omni/models/dots_tts/model_runner.py
@@ -125,18 +125,17 @@ class DotsTTSModelRunner(ModelRunner):
             if feedback.ndim > 1:
                 feedback = feedback.reshape(-1, feedback.shape[-1])[-1]
             rows.append(feedback)
-        stacked = torch.stack(rows).to(
-            device=forward_batch.input_ids.device,
-            dtype=next(self.model.parameters()).dtype,
-        )
         buffer = self.model.graph_feedback_buffer
         if buffer is not None:
-            # note (luojiaxuan): row order matches the forward batch; the copy runs on the same
-            # stream as the (graph or eager) forward, so it is ordered ahead
-            # of the launch. forward() reads the buffer for decode directly.
-            buffer[: stacked.shape[0]].copy_(stacked)
+            # note (luojiaxuan): stack writes in forward-batch row order on the
+            # same stream as the graph or eager forward. forward() reads this
+            # persistent buffer directly.
+            torch.stack(rows, out=buffer[: len(rows)])
         else:
-            forward_batch.input_embeds = stacked
+            forward_batch.input_embeds = torch.stack(rows).to(
+                device=forward_batch.input_ids.device,
+                dtype=next(self.model.parameters()).dtype,
+            )
 
     def requested_capture_hidden_mode_prefill(
         self, schedule_batch: Any, requests: list

--- a/tests/unit_test/dots_tts/test_model_runner.py
+++ b/tests/unit_test/dots_tts/test_model_runner.py
@@ -201,8 +201,18 @@ def _decode_request(request_id: str, fill: float):
     )
 
 
-def test_dots_before_decode_writes_graph_feedback_buffer_in_batch_order() -> None:
+def test_dots_before_decode_writes_graph_feedback_buffer_in_batch_order(
+    monkeypatch,
+) -> None:
     buffer = torch.zeros(4, 4)
+    stack_outputs = []
+    stack = torch.stack
+
+    def record_stack(values, *args, **kwargs):
+        stack_outputs.append(kwargs.get("out"))
+        return stack(values, *args, **kwargs)
+
+    monkeypatch.setattr(torch, "stack", record_stack)
     runner = object.__new__(DotsTTSModelRunner)
     runner.model = SimpleNamespace(
         graph_feedback_buffer=buffer,
@@ -217,6 +227,8 @@ def test_dots_before_decode_writes_graph_feedback_buffer_in_batch_order() -> Non
     torch.testing.assert_close(buffer[0], torch.full((4,), 5.0))
     torch.testing.assert_close(buffer[1], torch.full((4,), 6.0))
     torch.testing.assert_close(buffer[2], torch.zeros(4))
+    assert len(stack_outputs) == 1
+    assert stack_outputs[0].data_ptr() == buffer.data_ptr()
     assert forward_batch.input_embeds is None
 
 


### PR DESCRIPTION
## Motivation

The dots.tts decode hook staged feedback for the next CUDA Graph replay in two steps:

1. allocate and fill a temporary `torch.stack(rows)` tensor
2. copy that tensor into the model-owned persistent graph feedback buffer

The persistent destination already has the exact batch shape, dtype, and device needed by the next forward.

## Modifications

- Use `torch.stack(..., out=buffer[:batch_size])` on the CUDA Graph path.
- Keep the existing allocating path unchanged when the graph feedback buffer is unavailable.
- Add a regression test that verifies `torch.stack` receives the persistent buffer slice as its `out` tensor and preserves request row order.

## Impact

The graph path removes one temporary device allocation and one full feedback-buffer copy per decode token. Model output, request ordering, dtype conversion, and eager fallback behavior remain unchanged.

RTX A6000 / PyTorch 2.11.0+cu130 microbenchmark (bf16, hidden size 3584; median of 7 x 1,000 steps):

| Batch | Before (us/step) | After (us/step) | Reduction |
| ---: | ---: | ---: | ---: |
| 1 | 42.512 | 21.472 | 49.49% |
| 4 | 41.617 | 18.375 | 55.85% |
| 8 | 43.385 | 18.163 | 58.14% |
| 16 | 45.352 | 22.232 | 50.98% |

This is an isolated feedback-staging benchmark, not an end-to-end throughput claim.

## Validation

- `python -m pytest -q tests/unit_test/dots_tts/test_model_runner.py` — 9 passed
- `ruff check --ignore TRY004 sglang_omni/models/dots_tts/model_runner.py tests/unit_test/dots_tts/test_model_runner.py`
  - `TRY004` is a pre-existing finding at `model_runner.py:301`, outside this diff.
- `git diff --check`
- Direct `torch.stack(out=...)` storage/dtype checks on CPU and CUDA

Tested in the canonical Aries A6000 container with PyTorch 2.11.0+cu130 and SGLang 0.5.16.

Related: #1367