### PR TITLE
[Perf] dots.tts: bypass redundant vocoder staging

### DIFF
--- a/sglang_omni/models/dots_tts/vocoder.py
+++ b/sglang_omni/models/dots_tts/vocoder.py
@@ -55,9 +55,7 @@ class DotsTTSBatchVocoder(BatchVocoderBase):
 
         with self.codec.lock:
             for bucket_items in buckets.values():
-                frame_counts = [
-                    int(latents.shape[1]) for _, latents in bucket_items
-                ]
+                frame_counts = [int(latents.shape[1]) for _, latents in bucket_items]
                 max_frames = max(frame_counts)
                 if len(bucket_items) == 1:
                     padded = bucket_items[0][1].to(self.codec.device)

--- a/sglang_omni/models/dots_tts/vocoder.py
+++ b/sglang_omni/models/dots_tts/vocoder.py
@@ -55,16 +55,27 @@ class DotsTTSBatchVocoder(BatchVocoderBase):
 
         with self.codec.lock:
             for bucket_items in buckets.values():
-                max_frames = max(int(latents.shape[1]) for _, latents in bucket_items)
-                padded = bucket_items[0][1].new_zeros(
-                    len(bucket_items),
-                    max_frames,
-                    self.codec.latent_dim,
-                    device=self.codec.device,
-                )
-                for row, (_index, latents) in enumerate(bucket_items):
-                    frames = int(latents.shape[1])
-                    padded[row, :frames].copy_(latents[0].to(self.codec.device))
+                frame_counts = [
+                    int(latents.shape[1]) for _, latents in bucket_items
+                ]
+                max_frames = max(frame_counts)
+                if len(bucket_items) == 1:
+                    padded = bucket_items[0][1].to(self.codec.device)
+                elif min(frame_counts) == max_frames:
+                    padded = torch.cat(
+                        [latents for _, latents in bucket_items], dim=0
+                    ).to(self.codec.device)
+                else:
+                    padded = bucket_items[0][1].new_zeros(
+                        len(bucket_items),
+                        max_frames,
+                        self.codec.latent_dim,
+                        device=self.codec.device,
+                    )
+                    for row, ((_index, latents), frames) in enumerate(
+                        zip(bucket_items, frame_counts, strict=True)
+                    ):
+                        padded[row, :frames].copy_(latents[0].to(self.codec.device))
 
                 waveform_batch = self.codec.inference.decode_latents(padded)
                 if waveform_batch.shape[0] != len(bucket_items):
@@ -215,11 +226,14 @@ class DotsTTSStreamingVocoder(StreamingVocoderBase[_DotsStreamState, None]):
                 else (1 if state.received_patches <= 2 else self.merge_steps)
             )
             patches, state.pending = state.pending[:take], state.pending[take:]
+            latent_chunk = (
+                patches[0] if len(patches) == 1 else torch.cat(patches, dim=1)
+            )
             # note (db-ol): compiled stream step cudagraph trees corrupt the
             # backbone decode graph replay in this process, see issue 1392.
             with self.codec.lock:
                 chunk = self.codec.inference.stream_step(
-                    torch.cat(patches, dim=1),
+                    latent_chunk,
                     stream_state=state.codec_state,
                     optimize=self.optimize,
                     use_compiled=False,

--- a/tests/unit_test/dots_tts/test_vocoder.py
+++ b/tests/unit_test/dots_tts/test_vocoder.py
@@ -22,8 +22,10 @@ class _FakeInference:
     def __init__(self, hop_size: int) -> None:
         self.hop_size = hop_size
         self.inputs: list[torch.Tensor] = []
+        self.input_data_ptrs: list[int] = []
 
     def decode_latents(self, latents: torch.Tensor) -> torch.Tensor:
+        self.input_data_ptrs.append(latents.data_ptr())
         self.inputs.append(latents.clone())
         rows = []
         for row in latents:
@@ -109,9 +111,11 @@ def test_multiple_buckets_restore_original_request_order() -> None:
 def test_single_input_preserves_batch_and_waveform_shapes() -> None:
     codec = _codec()
     vocoder = DotsTTSBatchVocoder(codec)
-    [output] = _decode(vocoder, [_latents(12, 5)])
+    latents = _latents(12, 5)
+    [output] = _decode(vocoder, [latents])
 
     assert not vocoder._logged_batch
+    assert codec.inference.input_data_ptrs == [latents.data_ptr()]
     assert codec.inference.inputs[0].shape == (1, 12, 3)
     assert output[0].shape == (1, 1, 24)
     assert output[1] == 48000

--- a/tests/unit_test/dots_tts/test_vocoder_streaming.py
+++ b/tests/unit_test/dots_tts/test_vocoder_streaming.py
@@ -18,6 +18,7 @@ class _RecordingInference:
         self.stream_calls.append(
             {
                 "frames": int(latents.shape[1]),
+                "data_ptr": latents.data_ptr(),
                 "optimize": optimize,
                 "use_compiled": use_compiled,
             }
@@ -53,3 +54,15 @@ def test_streaming_never_uses_the_compiled_stream_step() -> None:
     assert codec.inference.stream_calls, "streaming produced no vocoder steps"
     assert all(not call["use_compiled"] for call in codec.inference.stream_calls)
     assert all(call["optimize"] for call in codec.inference.stream_calls)
+
+
+def test_streaming_single_patch_reuses_input_storage() -> None:
+    codec = _FakeCodec()
+    vocoder = DotsTTSStreamingVocoder(codec, optimize=True, merge_steps=2)
+    state = vocoder.create_stream_state("req")
+    patch = torch.zeros(1, 3, 5)
+
+    vocoder.ingest("req", state, patch)
+    vocoder.decode_delta("req", state, is_final=False)
+
+    assert codec.inference.stream_calls[0]["data_ptr"] == patch.data_ptr()


### PR DESCRIPTION
## Motivation

The dots.tts vocoder always allocated a zero-padded batch and copied every latent input into it, even when a bucket contained one request or every request had the same frame length. Streaming also called `torch.cat` for the first two one-patch chunks, where the input list has exactly one tensor.

Those cases do not need padding.

## Modifications

- Pass a singleton non-streaming latent tensor directly to AudioVAE.
- Assemble equal-length multi-request buckets with one `torch.cat`.
- Keep the existing zero-padding and crop path for genuinely mixed-length buckets.
- Reuse the single pending streaming patch directly; retain `torch.cat` for merged multi-patch chunks.
- Add storage-identity regressions for singleton non-streaming and streaming inputs.

## Impact

This removes redundant zero initialization, per-row copies, and singleton concatenation while preserving request order, mixed-length behavior, waveform cropping, and AudioVAE inputs.

RTX A6000 / PyTorch 2.11.0+cu130 assembly microbenchmark (bf16, 128 frames x 128 dims):

| Equal-length batch | Before (us/batch) | After (us/batch) | Reduction |
| ---: | ---: | ---: | ---: |
| 1 | 39.951 | 1.082 | 97.29% |
| 4 | 85.686 | 14.653 | 82.90% |
| 8 | 187.155 | 17.626 | 90.58% |
| 16 | 357.004 | 18.554 | 94.80% |

The one-patch streaming assembly path drops from 14.424 us/chunk to a direct tensor reuse (0.089 us in the same microbenchmark).

These are isolated input-assembly numbers; AudioVAE forward remains the dominant vocoder cost, so this is not an end-to-end throughput claim.

## Validation

- `python -m pytest -q tests/unit_test/dots_tts/test_vocoder.py tests/unit_test/dots_tts/test_vocoder_streaming.py` — 14 passed
- `ruff check sglang_omni/models/dots_tts/vocoder.py tests/unit_test/dots_tts/test_vocoder.py tests/unit_test/dots_tts/test_vocoder_streaming.py`
- `git diff --check`

Tested locally and in the canonical Aries A6000 container with PyTorch 2.11.0+cu130, SGLang 0.5.16, and `dots.tts==0.2.1`.

Related: #1367