### PR TITLE
[Perf] dots.tts: reuse the CFG null projection bias

### DIFF
--- a/sglang_omni/models/dots_tts/flow_head.py
+++ b/sglang_omni/models/dots_tts/flow_head.py
@@ -498,7 +498,7 @@ class DotsTTSFlowHead(nn.Module):
     def append_hidden(self, state: DotsFlowState, hidden_states: torch.Tensor) -> None:
         hidden = hidden_states[:, -self.hidden_patch_size :]
         projected = self.hidden_proj(hidden)
-        null_projected = self.hidden_proj(torch.zeros_like(hidden))
+        null_projected = self.hidden_proj.bias.view(1, 1, -1).expand_as(projected)
         start, end = self._reserve(state, projected.shape[1])
         state.fm_sequence[:, start:end].copy_(projected)
         state.fm_cfg_sequence[:, start:end].copy_(null_projected)

--- a/tests/unit_test/dots_tts/test_flow_head.py
+++ b/tests/unit_test/dots_tts/test_flow_head.py
@@ -91,6 +91,30 @@ def test_single_stream_decode_batch_accepts_2d_hidden(tmp_path) -> None:
     assert state.decoded_patches == 2
 
 
+def test_append_hidden_uses_bias_for_null_projection(tmp_path) -> None:
+    flow = _flow_head(tmp_path)
+    state, _ = flow.new_request(
+        max_audio_patch_count=2,
+        prompt_latents=None,
+        speaker_embedding=None,
+        speaker_scale=1.0,
+        rng=None,
+    )
+    projection_calls = []
+    hook = flow.hidden_proj.register_forward_hook(
+        lambda _module, inputs, _output: projection_calls.append(inputs[0])
+    )
+    try:
+        flow.append_hidden(state, torch.randn(1, 1, LLM_HIDDEN))
+    finally:
+        hook.remove()
+
+    assert len(projection_calls) == 1
+    torch.testing.assert_close(
+        state.fm_cfg_sequence[0, 0], flow.hidden_proj.bias, rtol=0, atol=0
+    )
+
+
 def test_single_stream_seed_survives_rematerialization(tmp_path) -> None:
     torch.manual_seed(1618)
     flow = _flow_head(tmp_path)


### PR DESCRIPTION
## Motivation

The single-request dots.tts flow-matching path builds the CFG null branch by projecting an all-zero hidden tensor on every generated patch:

`hidden_proj(torch.zeros_like(hidden))`

For a biased linear layer, that result is exactly the layer bias. The weight GEMM is redundant.

## Modifications

- Expand `hidden_proj.bias` to the projected hidden shape for the null CFG row.
- Keep the real hidden projection and both history-buffer copies unchanged.
- Add a forward-hook regression proving `append_hidden` invokes `hidden_proj` once and stores the bias exactly in `fm_cfg_sequence`.

## Impact

SOAR/base single-request decoding removes one `1536 -> 1024` linear projection and one zero-tensor allocation per generated patch. MeanFlow continuous batching is unchanged.

RTX A6000 / PyTorch 2.11.0+cu130 microbenchmark using the checkpoint dimensions (bf16, batch 1, one hidden token; median of 9 x 1,000 calls):

| Path | us / `append_hidden` |
| --- | ---: |
| Two projections | 118.875 |
| Real projection + bias view | 74.577 |

Reduction: 37.26%. The null projection and expanded bias were bitwise equal in the benchmark.

This is an isolated `append_hidden` benchmark, not an end-to-end RTF claim.

## Validation

- `python -m pytest -q tests/unit_test/dots_tts/test_flow_head.py` — 10 passed
- `ruff check sglang_omni/models/dots_tts/flow_head.py tests/unit_test/dots_tts/test_flow_head.py`
- `git diff --check`
- CUDA bf16 exact-parity assertion for `Linear(zeros) == bias`

Tested in the canonical Aries A6000 container with PyTorch 2.11.0+cu130, SGLang 0.5.16, and `dots.tts==0.2.1`.

Related: #1367