### PR TITLE
[Perf] dots.tts: separate reference and vocoder codec locks

### DIFF
--- a/sglang_omni/models/dots_tts/codec.py
+++ b/sglang_omni/models/dots_tts/codec.py
@@ -69,7 +69,10 @@ class DotsAudioCodec:
         self.sample_rate = int(vocoder.sample_rate)
         self.hop_size = int(vocoder.hop_size)
         self.device = torch.device(device)
-        self.lock = threading.RLock()
+        # Encoder and decoder modules are disjoint; vocoder calls still share one
+        # lock because VocoderInference owns mutable streaming state caches.
+        self.reference_lock = threading.RLock()
+        self.vocoder_lock = threading.RLock()
 
     @staticmethod
     def _reference_load_workers(count: int) -> int:
@@ -113,7 +116,7 @@ class DotsAudioCodec:
         )
         speaker_batch, speaker_lengths = self._speaker_input(batch, audio_lengths)
 
-        with self.lock:
+        with self.reference_lock:
             speaker = self.speaker(speaker_batch, audio_lengths=speaker_lengths)
             latent_distribution = self.inference.extract_latents(batch)
 

--- a/sglang_omni/models/dots_tts/vocoder.py
+++ b/sglang_omni/models/dots_tts/vocoder.py
@@ -53,7 +53,7 @@ class DotsTTSBatchVocoder(BatchVocoderBase):
             )
             self._logged_batch = True
 
-        with self.codec.lock:
+        with self.codec.vocoder_lock:
             for bucket_items in buckets.values():
                 max_frames = max(int(latents.shape[1]) for _, latents in bucket_items)
                 padded = bucket_items[0][1].new_zeros(
@@ -164,7 +164,7 @@ class DotsTTSStreamingVocoder(StreamingVocoderBase[_DotsStreamState, None]):
 
     def create_stream_state(self, request_id: str) -> _DotsStreamState:
         del request_id
-        with self.codec.lock:
+        with self.codec.vocoder_lock:
             codec_state = self.codec.inference.init_stream_state(
                 batch_size=1,
                 chunk_size=self.codec.patch_size * self.merge_steps,
@@ -217,7 +217,7 @@ class DotsTTSStreamingVocoder(StreamingVocoderBase[_DotsStreamState, None]):
             patches, state.pending = state.pending[:take], state.pending[take:]
             # note (db-ol): compiled stream step cudagraph trees corrupt the
             # backbone decode graph replay in this process, see issue 1392.
-            with self.codec.lock:
+            with self.codec.vocoder_lock:
                 chunk = self.codec.inference.stream_step(
                     torch.cat(patches, dim=1),
                     stream_state=state.codec_state,
@@ -227,7 +227,7 @@ class DotsTTSStreamingVocoder(StreamingVocoderBase[_DotsStreamState, None]):
             if chunk.numel():
                 chunks.append(chunk)
         if is_final:
-            with self.codec.lock:
+            with self.codec.vocoder_lock:
                 tail = self.codec.inference.flush(state.codec_state)
             if tail.numel():
                 chunks.append(tail)
@@ -256,7 +256,7 @@ class DotsTTSStreamingVocoder(StreamingVocoderBase[_DotsStreamState, None]):
         tts_state = load_dots_tts_state(payload)
         if tts_state.generated_latents is None:
             return None
-        with self.codec.lock:
+        with self.codec.vocoder_lock:
             return self.codec.inference.decode_latents(
                 tts_state.generated_latents.to(self.codec.device)
             )

--- a/tests/unit_test/dots_tts/test_reference_encode_batching.py
+++ b/tests/unit_test/dots_tts/test_reference_encode_batching.py
@@ -78,7 +78,8 @@ def _make_codec() -> DotsAudioCodec:
     codec.sample_rate = 48000
     codec.hop_size = HOP_SIZE
     codec.device = torch.device("cpu")
-    codec.lock = threading.RLock()
+    codec.reference_lock = threading.RLock()
+    codec.vocoder_lock = threading.RLock()
     return codec
 
 
@@ -115,6 +116,14 @@ def test_batch_of_one_is_identical_to_the_unbatched_path(
 
     assert torch.equal(single["speaker_embedding"], batched["speaker_embedding"])
     assert torch.equal(single["latent_distribution"], batched["latent_distribution"])
+
+
+def test_reference_encode_does_not_acquire_the_vocoder_lock() -> None:
+    codec = _make_codec()
+    codec.vocoder_lock = None
+    [result] = codec._encode_waveforms([_waveform(2, seed=9)])
+
+    assert result["speaker_embedding"].shape == (1, LATENT_DIM)
 
 
 def test_equal_length_batch_is_bit_identical_to_encoding_each_alone(

--- a/tests/unit_test/dots_tts/test_vocoder.py
+++ b/tests/unit_test/dots_tts/test_vocoder.py
@@ -39,7 +39,7 @@ def _codec(*, latent_dim: int = 3, hop_size: int = 2) -> SimpleNamespace:
         hop_size=hop_size,
         sample_rate=48000,
         patch_size=4,
-        lock=threading.RLock(),
+        vocoder_lock=threading.RLock(),
         inference=_FakeInference(hop_size),
     )
 

--- a/tests/unit_test/dots_tts/test_vocoder_streaming.py
+++ b/tests/unit_test/dots_tts/test_vocoder_streaming.py
@@ -32,7 +32,7 @@ class _RecordingInference:
 class _FakeCodec:
     def __init__(self) -> None:
         self.inference = _RecordingInference()
-        self.lock = threading.Lock()
+        self.vocoder_lock = threading.Lock()
         self.sample_rate = 48000
         self.patch_size = 3
         self.latent_dim = 5


### PR DESCRIPTION
## Motivation

The dots.tts reference encoder and vocoder use disjoint AudioVAE submodules but currently share one process-wide lock. #1434 measured material cross-stage contention: 14/80 `stream_step` calls contended for 419 ms in total, while all 5 reference encodes also contended.

## Changes

- use an independent lock for speaker/AudioVAE reference encoding
- keep all batch and streaming vocoder calls serialized behind one vocoder lock because `VocoderInference` owns mutable streaming caches/state
- add a focused test that reference encoding never acquires the vocoder lock

No model weights, math, request scheduling, or output layout change.

## Performance

1x H200, SeedTTS EN, concurrency 8, 10 warmups, seed 42.

### Streaming, 128 samples (mean of 2 fresh-server runs)

| Metric | main (`2e607bc`) | This PR | Delta |
|---|---:|---:|---:|
| Request throughput | 1.427 req/s | 1.616 req/s | **+13.25%** |
| Mean latency | 5.544 s | 4.902 s | **-11.58%** |
| Mean RTF | 1.561 | 1.363 | **-12.66%** |
| Audio throughput | 5.377 s/s | 6.086 s/s | **+13.20%** |
| TTFC | 2.972 s | 1.817 s | **-38.87%** |
| ITL | 0.3669 s | 0.4394 s | **+19.78%** |

The ITL regression is disclosed: removing head-of-line blocking lets cold reference work progress sooner, which improves TTFC, total latency, and throughput but increases GPU competition between later audio chunks. Both paths remain faster than real time on this workload, and all runs completed 128/128 requests without failures.

### Non-streaming, 512 samples

| Metric | main (`2e607bc`) | This PR | Delta |
|---|---:|---:|---:|
| Request throughput | 3.072 req/s | 3.192 req/s | **+3.91%** |
| Mean latency | 2.587 s | 2.493 s | **-3.63%** |
| Mean RTF | 0.6372 | 0.6138 | **-3.67%** |
| Audio throughput | 12.742 s/s | 13.210 s/s | **+3.67%** |

Both runs completed 512/512 requests without failures.

## Correctness

With the real dots codec, three concurrent reference-encode + AudioVAE-decode trials were compared with serialized execution using fixed inputs. Speaker embeddings, latent distributions, and PCM were exactly equal (max absolute difference 0).

## Validation

- `pytest -q tests/unit_test/dots_tts/test_reference_encode_batching.py tests/unit_test/dots_tts/test_vocoder.py tests/unit_test/dots_tts/test_vocoder_streaming.py tests/unit_test/dots_tts/test_result_contracts.py` (42 passed)
- pre-commit hooks passed

Related: #1367
Follow-up to the contention evidence in #1434.
