### PR TITLE
[LLaDA2-Uni] Add streaming text output

### DIFF
--- a/sglang_omni/models/llada2_uni/bootstrap.py
+++ b/sglang_omni/models/llada2_uni/bootstrap.py
@@ -25,6 +25,7 @@ def create_dllm_thinker_scheduler(
 
     from sglang_omni.models.llada2_uni.request_builders import (
         make_dllm_thinker_scheduler_adapters,
+        make_dllm_thinker_stream_output_builder,
     )
     from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
     from sglang_omni.scheduling.dllm_scheduler import DllmScheduler
@@ -62,6 +63,7 @@ def create_dllm_thinker_scheduler(
         vocab_size=model_config.vocab_size,
         dllm_config=dllm_config,
     )
+    stream_output_builder = make_dllm_thinker_stream_output_builder()
 
     return DllmScheduler(
         tp_worker=model_worker,
@@ -73,4 +75,5 @@ def create_dllm_thinker_scheduler(
         dllm_config=dllm_config,
         request_builder=request_builder,
         result_adapter=result_adapter,
+        stream_output_builder=stream_output_builder,
     )

--- a/sglang_omni/models/llada2_uni/components/streaming_detokenizer.py
+++ b/sglang_omni/models/llada2_uni/components/streaming_detokenizer.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stream-aware text decoder for LLaDA2-Uni accepted token blocks."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from sglang_omni.models.llada2_uni.config import THINKER_STAGE
+from sglang_omni.models.llada2_uni.merge import decode_events, decode_text_output
+from sglang_omni.models.llada2_uni.payload_types import (
+    LLaDA2UniEvent,
+    LLaDA2UniPipelineState,
+)
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.messages import OutgoingMessage
+from sglang_omni.scheduling.streaming_simple_scheduler import StreamingSimpleScheduler
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _TextStreamState:
+    token_ids: list[int] = field(default_factory=list)
+    emitted_text: str = ""
+
+
+def _event_to_dict(event: LLaDA2UniEvent) -> dict[str, Any]:
+    return {
+        "type": event.type,
+        "modality": event.modality,
+        "payload": dict(event.payload),
+        "is_final": bool(event.is_final),
+    }
+
+
+def _coerce_token_ids(data: Any) -> list[int]:
+    if isinstance(data, dict):
+        data = data.get("token_ids")
+    if data is None:
+        return []
+    if isinstance(data, (list, tuple)):
+        values = data
+    elif hasattr(data, "detach") and hasattr(data, "reshape"):
+        values = data.detach().cpu().reshape(-1).tolist()
+    elif hasattr(data, "tolist"):
+        values = data.tolist()
+    else:
+        values = [data]
+    if not isinstance(values, (list, tuple)):
+        values = [values]
+    return [int(token_id) for token_id in values]
+
+
+class LLaDA2StreamingDetokenizeScheduler(StreamingSimpleScheduler):
+    """Decode accepted dLLM blocks and emit append-only text deltas."""
+
+    def __init__(
+        self,
+        tokenizer: Any,
+        eos_token_id: int | None,
+        *,
+        stage_name: str = "decode",
+    ) -> None:
+        self._tokenizer = tokenizer
+        self._eos_token_id = eos_token_id
+        self._stage_name = stage_name
+        self._text_states: dict[str, _TextStreamState] = {}
+        super().__init__(self._decode_non_streaming)
+
+    def is_streaming_payload(self, payload: Any) -> bool:
+        return isinstance(payload, StagePayload) and bool(
+            (payload.request.params or {}).get("stream", False)
+        )
+
+    def on_streaming_new_request(self, request_id: str, payload: StagePayload) -> None:
+        del payload
+        self._text_states.setdefault(request_id, _TextStreamState())
+
+    def on_stream_chunk(
+        self, request_id: str, item: StreamItem
+    ) -> list[OutgoingMessage]:
+        token_ids = _coerce_token_ids(item.data)
+        if not token_ids:
+            return []
+
+        state = self._text_states.setdefault(request_id, _TextStreamState())
+        state.token_ids.extend(token_ids)
+        text = self._decode_text(state.token_ids)
+        if text.endswith("\ufffd"):
+            return []
+        delta = self._append_only_delta(state, text)
+        return self._stream_messages(request_id, delta)
+
+    def on_stream_done(self, request_id: str) -> list[OutgoingMessage]:
+        payload = self._stream_payloads.get(request_id)
+        if not isinstance(payload, StagePayload):
+            raise TypeError(
+                f"LLaDA2 decode expected StagePayload for {request_id!r}, "
+                f"got {type(payload).__name__}"
+            )
+
+        state = self._text_states.setdefault(request_id, _TextStreamState())
+        pipeline_state, thinker_out = self._load_thinker_output(payload)
+        del pipeline_state
+        final_text = decode_text_output(
+            thinker_out=thinker_out,
+            tokenizer=self._tokenizer,
+        )
+        delta = self._append_only_delta(state, final_text)
+        messages = self._stream_messages(request_id, delta)
+        messages.append(
+            OutgoingMessage(
+                request_id=request_id,
+                type="result",
+                data=self._build_result(payload, is_streaming=True),
+            )
+        )
+        return messages
+
+    def clear_stream_state(self, request_id: str) -> None:
+        self._text_states.pop(request_id, None)
+
+    def _decode_text(self, token_ids: list[int]) -> str:
+        visible_ids = [
+            int(token_id)
+            for token_id in token_ids
+            if self._eos_token_id is None or int(token_id) != int(self._eos_token_id)
+        ]
+        if not visible_ids:
+            return ""
+        return self._tokenizer.decode(visible_ids, skip_special_tokens=True)
+
+    @staticmethod
+    def _append_only_delta(state: _TextStreamState, text: str) -> str:
+        if not text.startswith(state.emitted_text):
+            raise ValueError(
+                "LLaDA2 incremental decode is not prefix-stable: "
+                f"emitted={state.emitted_text!r}, decoded={text!r}"
+            )
+        delta = text[len(state.emitted_text) :]
+        state.emitted_text = text
+        return delta
+
+    def _stream_messages(self, request_id: str, delta: str) -> list[OutgoingMessage]:
+        if not delta:
+            return []
+        return [
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                target=None,
+                data={
+                    "text": delta,
+                    "modality": "text",
+                    "stage_name": self._stage_name,
+                },
+                metadata={"modality": "text"},
+            )
+        ]
+
+    def _decode_non_streaming(self, payload: StagePayload) -> StagePayload:
+        return self._build_result(payload, is_streaming=False)
+
+    def _load_thinker_output(
+        self, payload: StagePayload
+    ) -> tuple[LLaDA2UniPipelineState, dict[str, Any]]:
+        state = LLaDA2UniPipelineState.from_dict(payload.data)
+        thinker_out = state.thinker_out or state.engine_outputs.get(THINKER_STAGE)
+        if not isinstance(thinker_out, dict):
+            logger.warning(
+                "request %s: thinker produced no output (got %s), returning empty text",
+                payload.request_id,
+                type(thinker_out).__name__,
+            )
+            thinker_out = {"output_ids": [], "is_final": True}
+        return state, thinker_out
+
+    def _build_result(
+        self, payload: StagePayload, *, is_streaming: bool
+    ) -> StagePayload:
+        state, thinker_out = self._load_thinker_output(payload)
+        events = decode_events(thinker_out=thinker_out, tokenizer=self._tokenizer)
+        result: dict[str, Any] = {"events": [_event_to_dict(event) for event in events]}
+        if events:
+            result.update(events[-1].payload)
+            result.setdefault("modality", events[-1].modality)
+
+        if is_streaming:
+            result.pop("text", None)
+
+        finish_reason = thinker_out.get("finish_reason")
+        if finish_reason is not None:
+            result["finish_reason"] = finish_reason
+
+        input_ids = (
+            state.prompt.get("input_ids") if isinstance(state.prompt, dict) else None
+        )
+        if input_ids is None:
+            prompt_tokens = 0
+        elif hasattr(input_ids, "numel"):
+            prompt_tokens = int(input_ids.numel())
+        else:
+            prompt_tokens = len(input_ids)
+
+        completion_tokens = len(thinker_out.get("output_ids") or [])
+        result["usage"] = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        }
+        payload.data = result
+        return payload
+
+
+def create_streaming_detokenize_scheduler(
+    model_path: str,
+    *,
+    stage_name: str = "decode",
+) -> LLaDA2StreamingDetokenizeScheduler:
+    from sglang_omni.models.llada2_uni.components.common import load_llada2_tokenizer
+
+    tokenizer = load_llada2_tokenizer(model_path)
+    return LLaDA2StreamingDetokenizeScheduler(
+        tokenizer=tokenizer,
+        eos_token_id=getattr(tokenizer, "eos_token_id", None),
+        stage_name=stage_name,
+    )
+
+
+__all__ = [
+    "LLaDA2StreamingDetokenizeScheduler",
+    "create_streaming_detokenize_scheduler",
+]

--- a/sglang_omni/models/llada2_uni/config.py
+++ b/sglang_omni/models/llada2_uni/config.py
@@ -51,12 +51,14 @@ class LLaDA2UniPipelineConfig(PipelineConfig):
             factory_args={"thinker_max_seq_len": 8192},
             gpu=0,
             next=DECODE_STAGE,
+            stream_to=[DECODE_STAGE],
         ),
         StageConfig(
             name=DECODE_STAGE,
             process="pipeline",
             factory=f"{_PKG}.stages.create_decode_executor",
             terminal=True,
+            can_accept_stream_before_payload=True,
         ),
     ]
 

--- a/sglang_omni/models/llada2_uni/merge.py
+++ b/sglang_omni/models/llada2_uni/merge.py
@@ -8,18 +8,54 @@ from typing import Any
 from sglang_omni.models.llada2_uni.payload_types import LLaDA2UniEvent
 
 
+def decode_text_output(*, thinker_out: dict[str, Any], tokenizer: Any) -> str:
+    """Decode terminal output and apply SGLang's default stop trimming."""
+    output_ids = list(thinker_out.get("output_ids") or [])
+    finish_reason_data = thinker_out.get("finish_reason_data")
+    matched_stop: Any = None
+    if (
+        isinstance(finish_reason_data, dict)
+        and finish_reason_data.get("type") == "stop"
+    ):
+        matched_stop = finish_reason_data.get("matched")
+
+    if isinstance(matched_stop, int):
+        if output_ids and output_ids[-1] == matched_stop:
+            output_ids.pop()
+    elif isinstance(matched_stop, (list, tuple)):
+        matched_token_ids = [int(token_id) for token_id in matched_stop]
+        if (
+            matched_token_ids
+            and output_ids[-len(matched_token_ids) :] == matched_token_ids
+        ):
+            del output_ids[-len(matched_token_ids) :]
+
+    if not output_ids:
+        return ""
+
+    text = tokenizer.decode(output_ids, skip_special_tokens=True)
+    if isinstance(matched_stop, str) and matched_stop:
+        stop_pos = text.find(matched_stop)
+        if stop_pos >= 0:
+            text = text[:stop_pos]
+    return text
+
+
 def decode_events(
     *,
     thinker_out: dict[str, Any],
     tokenizer: Any,
 ) -> list[LLaDA2UniEvent]:
-    """Convert thinker output tokens to a text_final event."""
-    # TODO: add streaming support
+    """Convert the terminal thinker output to a text event.
+
+    Incremental blocks are decoded by the stream-aware decode scheduler; this
+    function remains the canonical terminal reconstruction used by both modes.
+    """
     output_ids = thinker_out.get("output_ids", [])
     if not output_ids:
         return []
 
-    text = tokenizer.decode(output_ids, skip_special_tokens=True)
+    text = decode_text_output(thinker_out=thinker_out, tokenizer=tokenizer)
 
     return [
         LLaDA2UniEvent(

--- a/sglang_omni/models/llada2_uni/payload_types.py
+++ b/sglang_omni/models/llada2_uni/payload_types.py
@@ -13,6 +13,7 @@ class ThinkerOutput(TypedDict, total=False):
     output_ids: list[int]
     is_final: bool
     finish_reason: str | None
+    finish_reason_data: dict[str, Any] | None
 
 
 @dataclass

--- a/sglang_omni/models/llada2_uni/request_builders.py
+++ b/sglang_omni/models/llada2_uni/request_builders.py
@@ -13,6 +13,7 @@ from sglang_omni.models.llada2_uni.components.preprocessor import (
     IMAGE_TOKEN_OFFSET,
 )
 from sglang_omni.models.llada2_uni.config import (
+    DECODE_STAGE,
     DEFAULT_THINKER_MAX_NEW_TOKENS,
     IMAGE_STAGE,
     THINKER_STAGE,
@@ -22,6 +23,7 @@ from sglang_omni.models.llada2_uni.payload_types import (
     ThinkerOutput,
 )
 from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.sglang_backend import SGLangDLLMRequestData
 
 
@@ -168,6 +170,7 @@ def apply_dllm_thinker_result(
     stage_name: str,
     output_ids: list[int],
     finish_reason: str | None = None,
+    finish_reason_data: dict[str, Any] | None = None,
 ) -> ThinkerOutput:
     """Apply DLLM thinker result to pipeline state."""
     thinker_out: ThinkerOutput = {
@@ -176,10 +179,41 @@ def apply_dllm_thinker_result(
     }
     if finish_reason is not None:
         thinker_out["finish_reason"] = finish_reason
+    if finish_reason_data is not None:
+        thinker_out["finish_reason_data"] = dict(finish_reason_data)
 
     state.thinker_out = thinker_out
     state.engine_outputs[stage_name] = thinker_out
     return thinker_out
+
+
+def make_dllm_thinker_stream_output_builder(*, target: str = DECODE_STAGE):
+    """Build accepted dLLM token blocks for the streaming decode stage."""
+
+    def build_stream_output(
+        request_id: str,
+        req_data: SGLangDLLMRequestData,
+        token_ids: list[int],
+    ) -> list[OutgoingMessage]:
+        payload = req_data.stage_payload
+        if not isinstance(payload, StagePayload):
+            return []
+        if not (payload.request.params or {}).get("stream", False):
+            return []
+        if not token_ids:
+            return []
+
+        return [
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                data=torch.tensor(token_ids, dtype=torch.long),
+                target=target,
+                metadata={"modality": "text"},
+            )
+        ]
+
+    return build_stream_output
 
 
 def make_dllm_thinker_scheduler_adapters(
@@ -212,6 +246,7 @@ def make_dllm_thinker_scheduler_adapters(
             stage_name=stage_name,
             output_ids=data.output_ids,
             finish_reason=data.finish_reason,
+            finish_reason_data=data.finish_reason_data,
         )
         return StagePayload(
             request_id=payload.request_id,

--- a/sglang_omni/models/llada2_uni/stages.py
+++ b/sglang_omni/models/llada2_uni/stages.py
@@ -6,18 +6,9 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from sglang_omni.models.llada2_uni.config import IMAGE_STAGE, THINKER_STAGE
+from sglang_omni.models.llada2_uni.config import IMAGE_STAGE
 
 logger = logging.getLogger(__name__)
-
-
-def _event_to_dict(event) -> dict[str, Any]:
-    return {
-        "type": event.type,
-        "modality": event.modality,
-        "payload": dict(event.payload),
-        "is_final": bool(event.is_final),
-    }
 
 
 def create_preprocessing_executor(
@@ -116,65 +107,8 @@ def create_sglang_dllm_thinker_executor_from_config(
 
 
 def create_decode_executor(model_path: str):
-    from sglang_omni.models.llada2_uni.components.common import load_llada2_tokenizer
-    from sglang_omni.models.llada2_uni.merge import decode_events
-    from sglang_omni.models.llada2_uni.payload_types import LLaDA2UniPipelineState
-    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+    from sglang_omni.models.llada2_uni.components.streaming_detokenizer import (
+        create_streaming_detokenize_scheduler,
+    )
 
-    tokenizer = load_llada2_tokenizer(model_path)
-
-    def _decode(payload):
-        state = LLaDA2UniPipelineState.from_dict(payload.data)
-        thinker_out = state.thinker_out or state.engine_outputs.get(THINKER_STAGE)
-        if not isinstance(thinker_out, dict):
-            logger.warning(
-                "request %s: thinker produced no output (got %s), returning empty text",
-                payload.request_id,
-                type(thinker_out).__name__,
-            )
-            thinker_out = {
-                "output_ids": [],
-                "is_final": True,
-            }
-
-        events = decode_events(
-            thinker_out=thinker_out,
-            tokenizer=tokenizer,
-        )
-        event_dicts = [_event_to_dict(event) for event in events]
-
-        result: dict[str, Any] = {"events": event_dicts}
-        if events:
-            result.update(events[0].payload)
-            result.setdefault("modality", events[0].modality)
-
-        finish_reason = thinker_out.get("finish_reason")
-        if finish_reason is not None:
-            result.setdefault("finish_reason", finish_reason)
-
-        input_ids = (
-            state.prompt.get("input_ids") if isinstance(state.prompt, dict) else None
-        )
-        if input_ids is None:
-            prompt_tokens = 0
-        elif hasattr(input_ids, "numel"):
-            prompt_tokens = int(input_ids.numel())
-        else:
-            prompt_tokens = len(input_ids)
-
-        completion_ids = thinker_out.get("output_ids") or []
-        completion_tokens = len(completion_ids)
-
-        result.setdefault(
-            "usage",
-            {
-                "prompt_tokens": prompt_tokens,
-                "completion_tokens": completion_tokens,
-                "total_tokens": prompt_tokens + completion_tokens,
-            },
-        )
-
-        payload.data = result
-        return payload
-
-    return SimpleScheduler(_decode)
+    return create_streaming_detokenize_scheduler(model_path)

--- a/sglang_omni/scheduling/dllm_scheduler.py
+++ b/sglang_omni/scheduling/dllm_scheduler.py
@@ -45,12 +45,14 @@ class DllmScheduler:
         *,
         request_builder: Callable,
         result_adapter: Callable,
+        stream_output_builder: Callable | None = None,
     ):
         self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
         self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
 
         self._request_builder = request_builder
         self._result_adapter = result_adapter
+        self._stream_output_builder = stream_output_builder
 
         self.tp_worker = tp_worker
         self.tree_cache = tree_cache
@@ -315,17 +317,45 @@ class DllmScheduler:
             req.output_ids.extend(req_token_ids)
             req.update_finish_state(new_accepted_len=new_tokens)
 
+            req_data = self._rid_to_req_data.get(req.rid)
+            finished_reason = req.finished_reason
+            finish_reason_data = (
+                finished_reason.to_json() if finished_reason is not None else None
+            )
+            terminal_needs_stop_trim = bool(
+                finish_reason_data
+                and finish_reason_data.get("type") == "stop"
+                and finish_reason_data.get("matched") is not None
+            )
+            should_stream = not terminal_needs_stop_trim and (
+                req.finished() or not req.check_match_stop_str_prefix()
+            )
+            if (
+                req_data is not None
+                and self._stream_output_builder is not None
+                and should_stream
+            ):
+                output_ids_through_stop = req.output_ids_through_stop
+                send_token_offset = req.send_token_offset
+                visible_token_ids = list(output_ids_through_stop[send_token_offset:])
+                req.send_token_offset = len(output_ids_through_stop)
+                messages = self._stream_output_builder(
+                    req.rid,
+                    req_data,
+                    visible_token_ids,
+                )
+                for message in messages:
+                    self.outbox.put(message)
+
             if req.finished():
                 req_data = self._rid_to_req_data.pop(req.rid, None)
                 if req_data is None:
                     continue
                 req_data.output_ids = list(req.output_ids_through_stop)
-                finished_reason = req.finished_reason
                 req_data.finish_reason = (
-                    finished_reason.to_json().get("type")
-                    if finished_reason is not None
-                    else None
+                    finish_reason_data.get("type") if finish_reason_data else None
                 )
+                req_data.finish_reason_data = finish_reason_data
                 self.outbox.put(
                     OutgoingMessage(
                         request_id=req.rid,

--- a/sglang_omni/scheduling/sglang_backend/request_data.py
+++ b/sglang_omni/scheduling/sglang_backend/request_data.py
@@ -41,3 +41,4 @@ class SGLangDLLMRequestData:
     req: Any = None
     stage_payload: Any = None
     finish_reason: str | None = None
+    finish_reason_data: dict[str, Any] | None = None

--- a/tests/unit_test/llada2_uni/test_streaming.py
+++ b/tests/unit_test/llada2_uni/test_streaming.py
@@ -1,0 +1,389 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import torch
+
+from sglang_omni.client.client import Client
+from sglang_omni.client.types import GenerateRequest
+from sglang_omni.models.llada2_uni.components.streaming_detokenizer import (
+    LLaDA2StreamingDetokenizeScheduler,
+)
+from sglang_omni.models.llada2_uni.config import LLaDA2UniPipelineConfig
+from sglang_omni.models.llada2_uni.request_builders import (
+    make_dllm_thinker_stream_output_builder,
+)
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
+from sglang_omni.proto import CompleteMessage, OmniRequest, StagePayload, StreamMessage
+from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
+
+
+class _ByteTokenizer:
+    def __init__(
+        self,
+        vocab: dict[int, bytes],
+        *,
+        special_token_ids: set[int] | None = None,
+        eos_token_id: int | None = None,
+    ) -> None:
+        self._vocab = vocab
+        self._special = special_token_ids or set()
+        self.eos_token_id = eos_token_id
+
+    def decode(self, token_ids, *, skip_special_tokens: bool = False) -> str:
+        chunks = []
+        for token_id in token_ids:
+            token_id = int(token_id)
+            if skip_special_tokens and token_id in self._special:
+                continue
+            chunks.append(self._vocab[token_id])
+        return b"".join(chunks).decode("utf-8", errors="replace")
+
+
+def _payload(
+    *,
+    stream: bool,
+    output_ids: list[int] | None = None,
+    finish_reason: str = "stop",
+    finish_reason_data: dict[str, object] | None = None,
+) -> StagePayload:
+    output_ids = list(output_ids or [])
+    thinker_out = {
+        "output_ids": output_ids,
+        "is_final": True,
+        "finish_reason": finish_reason,
+    }
+    if finish_reason_data is not None:
+        thinker_out["finish_reason_data"] = finish_reason_data
+    return StagePayload(
+        request_id="req",
+        request=OmniRequest(inputs=[], params={"stream": stream}),
+        data={
+            "prompt": {"input_ids": torch.tensor([[101, 102]])},
+            "thinker_out": thinker_out,
+        },
+    )
+
+
+def _stream_item(data: object, chunk_id: int = 0) -> StreamItem:
+    return StreamItem(
+        chunk_id=chunk_id,
+        data=data,
+        from_stage="thinker",
+        metadata={"modality": "text"},
+    )
+
+
+def _drain(scheduler: LLaDA2StreamingDetokenizeScheduler) -> list[OutgoingMessage]:
+    messages = []
+    while not scheduler.outbox.empty():
+        messages.append(scheduler.outbox.get_nowait())
+    return messages
+
+
+class _FakeCoordinator:
+    def __init__(self, messages: list[StreamMessage | CompleteMessage]) -> None:
+        self._messages = messages
+
+    async def stream(self, request_id, omni_request):
+        del request_id, omni_request
+        for message in self._messages:
+            yield message
+
+
+def test_llada2_streaming_topology_routes_thinker_to_decode() -> None:
+    config = LLaDA2UniPipelineConfig(model_path="dummy")
+    thinker = next(stage for stage in config.stages if stage.name == "thinker")
+    decode = next(stage for stage in config.stages if stage.name == "decode")
+
+    assert thinker.stream_to == ["decode"]
+    assert decode.can_accept_stream_before_payload is True
+
+
+def test_dllm_stream_builder_emits_only_for_streaming_requests() -> None:
+    builder = make_dllm_thinker_stream_output_builder()
+    req_data = SimpleNamespace(stage_payload=_payload(stream=False))
+
+    assert builder("req", req_data, [1, 2]) == []
+
+    req_data.stage_payload = _payload(stream=True)
+    messages = builder("req", req_data, [1, 2])
+
+    assert len(messages) == 1
+    assert messages[0].target == "decode"
+    assert messages[0].metadata == {"modality": "text"}
+    assert torch.equal(messages[0].data, torch.tensor([1, 2]))
+
+
+def test_accepted_blocks_emit_append_only_text_and_slim_final() -> None:
+    tokenizer = _ByteTokenizer({1: b"hello", 2: b" ", 3: b"world"})
+    scheduler = LLaDA2StreamingDetokenizeScheduler(tokenizer, eos_token_id=None)
+    payload = _payload(stream=True, output_ids=[1, 2, 3])
+    scheduler._on_streaming_new_request("req", payload)
+
+    scheduler._on_chunk("req", _stream_item(torch.tensor([1, 2])))
+    scheduler._on_chunk("req", _stream_item(torch.tensor([3]), chunk_id=1))
+    scheduler._on_done("req")
+
+    messages = _drain(scheduler)
+    assert [message.type for message in messages] == ["stream", "stream", "result"]
+    assert [message.data["text"] for message in messages[:-1]] == ["hello ", "world"]
+    result = messages[-1].data.data
+    assert "text" not in result
+    assert result["finish_reason"] == "stop"
+    assert result["usage"] == {
+        "prompt_tokens": 2,
+        "completion_tokens": 3,
+        "total_tokens": 5,
+    }
+    assert result["events"][0]["payload"]["text"] == "hello world"
+
+
+def test_utf8_sequence_can_span_accepted_blocks() -> None:
+    tokenizer = _ByteTokenizer({1: b"\xe4", 2: b"\xbd", 3: b"\xa0"})
+    scheduler = LLaDA2StreamingDetokenizeScheduler(tokenizer, eos_token_id=None)
+    scheduler._on_streaming_new_request(
+        "req", _payload(stream=True, output_ids=[1, 2, 3])
+    )
+
+    scheduler._on_chunk("req", _stream_item(torch.tensor([1, 2])))
+    assert _drain(scheduler) == []
+
+    scheduler._on_chunk("req", _stream_item(torch.tensor([3]), chunk_id=1))
+    messages = _drain(scheduler)
+    assert len(messages) == 1
+    assert messages[0].data["text"] == "\u4f60"
+
+
+def test_eos_and_special_tokens_do_not_emit_text() -> None:
+    tokenizer = _ByteTokenizer(
+        {1: b"ok", 2: b"<eos>", 3: b"<special>"},
+        special_token_ids={2, 3},
+        eos_token_id=2,
+    )
+    scheduler = LLaDA2StreamingDetokenizeScheduler(tokenizer, eos_token_id=2)
+    scheduler._on_streaming_new_request("req", _payload(stream=True, output_ids=[1, 2]))
+
+    scheduler._on_chunk("req", _stream_item(torch.tensor([1, 3, 2])))
+
+    messages = _drain(scheduler)
+    assert len(messages) == 1
+    assert messages[0].data["text"] == "ok"
+
+
+def test_done_before_payload_finalizes_when_payload_arrives() -> None:
+    tokenizer = _ByteTokenizer({1: b"ready"})
+    scheduler = LLaDA2StreamingDetokenizeScheduler(tokenizer, eos_token_id=None)
+
+    scheduler._on_chunk("req", _stream_item(torch.tensor([1])))
+    scheduler._on_done("req")
+    assert [message.type for message in _drain(scheduler)] == ["stream"]
+
+    scheduler._on_streaming_new_request("req", _payload(stream=True, output_ids=[1]))
+    messages = _drain(scheduler)
+    assert [message.type for message in messages] == ["result"]
+    assert "req" not in scheduler._text_states
+
+
+def test_terminal_payload_flushes_missing_stream_suffix() -> None:
+    tokenizer = _ByteTokenizer({1: b"first", 2: b" second"})
+    scheduler = LLaDA2StreamingDetokenizeScheduler(tokenizer, eos_token_id=None)
+    scheduler._on_streaming_new_request("req", _payload(stream=True, output_ids=[1, 2]))
+    scheduler._on_chunk("req", _stream_item(torch.tensor([1])))
+    _drain(scheduler)
+
+    scheduler._on_done("req")
+
+    messages = _drain(scheduler)
+    assert [message.type for message in messages] == ["stream", "result"]
+    assert messages[0].data["text"] == " second"
+
+
+def test_non_streaming_request_preserves_full_text_result() -> None:
+    tokenizer = _ByteTokenizer({1: b"full", 2: b" text"})
+    scheduler = LLaDA2StreamingDetokenizeScheduler(tokenizer, eos_token_id=None)
+    message = IncomingMessage(
+        request_id="req",
+        type="new_request",
+        data=_payload(stream=False, output_ids=[1, 2]),
+    )
+
+    scheduler._handle_new_request_batch([message])
+
+    messages = _drain(scheduler)
+    assert len(messages) == 1
+    assert messages[0].type == "result"
+    assert messages[0].data.data["text"] == "full text"
+
+
+def test_non_streaming_request_trims_matched_stop_string() -> None:
+    tokenizer = _ByteTokenizer(
+        {1: b"The ", 2: b"uppercase", 3: b" English", 4: b" ignored"}
+    )
+    scheduler = LLaDA2StreamingDetokenizeScheduler(tokenizer, eos_token_id=None)
+    message = IncomingMessage(
+        request_id="req",
+        type="new_request",
+        data=_payload(
+            stream=False,
+            output_ids=[1, 2, 3, 4],
+            finish_reason_data={"type": "stop", "matched": "uppercase English"},
+        ),
+    )
+
+    scheduler._handle_new_request_batch([message])
+
+    messages = _drain(scheduler)
+    assert len(messages) == 1
+    assert messages[0].data.data["text"] == "The "
+    assert messages[0].data.data["usage"]["completion_tokens"] == 4
+
+
+def test_non_streaming_request_trims_matched_stop_token() -> None:
+    tokenizer = _ByteTokenizer({1: b"visible", 2: b"<stop>"})
+    scheduler = LLaDA2StreamingDetokenizeScheduler(tokenizer, eos_token_id=None)
+    message = IncomingMessage(
+        request_id="req",
+        type="new_request",
+        data=_payload(
+            stream=False,
+            output_ids=[1, 2],
+            finish_reason_data={"type": "stop", "matched": 2},
+        ),
+    )
+
+    scheduler._handle_new_request_batch([message])
+
+    messages = _drain(scheduler)
+    assert messages[0].data.data["text"] == "visible"
+
+
+def test_length_finish_does_not_trim_matching_text() -> None:
+    tokenizer = _ByteTokenizer({1: b"before ", 2: b"stop", 3: b" after"})
+    scheduler = LLaDA2StreamingDetokenizeScheduler(tokenizer, eos_token_id=None)
+    message = IncomingMessage(
+        request_id="req",
+        type="new_request",
+        data=_payload(
+            stream=False,
+            output_ids=[1, 2, 3],
+            finish_reason="length",
+            finish_reason_data={"type": "length", "length": 3},
+        ),
+    )
+
+    scheduler._handle_new_request_batch([message])
+
+    messages = _drain(scheduler)
+    assert messages[0].data.data["text"] == "before stop after"
+
+
+def test_streaming_terminal_stop_only_flushes_text_before_match() -> None:
+    tokenizer = _ByteTokenizer(
+        {1: b"The ", 2: b"uppercase", 3: b" English", 4: b" ignored"}
+    )
+    scheduler = LLaDA2StreamingDetokenizeScheduler(tokenizer, eos_token_id=None)
+    scheduler._on_streaming_new_request(
+        "req",
+        _payload(
+            stream=True,
+            output_ids=[1, 2, 3, 4],
+            finish_reason_data={"type": "stop", "matched": "uppercase English"},
+        ),
+    )
+
+    scheduler._on_done("req")
+
+    messages = _drain(scheduler)
+    assert [message.type for message in messages] == ["stream", "result"]
+    assert messages[0].data["text"] == "The "
+    result = messages[1].data.data
+    assert "text" not in result
+    assert result["events"][0]["payload"]["text"] == "The "
+
+
+def test_streaming_terminal_stop_preserves_emitted_safe_prefix() -> None:
+    tokenizer = _ByteTokenizer({1: b"safe ", 2: b"stop", 3: b" here"})
+    scheduler = LLaDA2StreamingDetokenizeScheduler(tokenizer, eos_token_id=None)
+    scheduler._on_streaming_new_request(
+        "req",
+        _payload(
+            stream=True,
+            output_ids=[1, 2, 3],
+            finish_reason_data={"type": "stop", "matched": "stop here"},
+        ),
+    )
+    scheduler._on_chunk("req", _stream_item(torch.tensor([1])))
+    first_messages = _drain(scheduler)
+    assert [message.data["text"] for message in first_messages] == ["safe "]
+
+    scheduler._on_done("req")
+
+    messages = _drain(scheduler)
+    assert [message.type for message in messages] == ["result"]
+    assert messages[0].data.data["events"][0]["payload"]["text"] == "safe "
+
+
+def test_client_stream_aggregates_llada_deltas_once() -> None:
+    tokenizer = _ByteTokenizer({1: b"hello", 2: b" ", 3: b"world"})
+    scheduler = LLaDA2StreamingDetokenizeScheduler(tokenizer, eos_token_id=None)
+    scheduler._on_streaming_new_request(
+        "req", _payload(stream=True, output_ids=[1, 2, 3])
+    )
+    scheduler._on_chunk("req", _stream_item(torch.tensor([1, 2])))
+    scheduler._on_chunk("req", _stream_item(torch.tensor([3]), chunk_id=1))
+    scheduler._on_done("req")
+
+    coordinator_messages: list[StreamMessage | CompleteMessage] = []
+    for message in _drain(scheduler):
+        if message.type == "stream":
+            coordinator_messages.append(
+                StreamMessage(
+                    request_id=message.request_id,
+                    from_stage="decode",
+                    chunk=message.data,
+                    stage_name="decode",
+                    modality="text",
+                )
+            )
+        else:
+            coordinator_messages.append(
+                CompleteMessage(
+                    request_id=message.request_id,
+                    from_stage="decode",
+                    success=True,
+                    result=message.data.data,
+                )
+            )
+
+    client = Client(coordinator=_FakeCoordinator(coordinator_messages))
+
+    async def collect():
+        return [
+            chunk
+            async for chunk in client.completion_stream(
+                GenerateRequest(prompt="ignored", stream=True),
+                request_id="req",
+            )
+        ]
+
+    chunks = asyncio.run(collect())
+
+    assert "".join(chunk.text or "" for chunk in chunks) == "hello world"
+    assert chunks[-1].text in (None, "")
+    assert chunks[-1].finish_reason == "stop"
+    assert chunks[-1].usage is not None
+    assert chunks[-1].usage.completion_tokens == 3
+
+
+def test_abort_clears_incremental_text_state() -> None:
+    tokenizer = _ByteTokenizer({1: b"partial"})
+    scheduler = LLaDA2StreamingDetokenizeScheduler(tokenizer, eos_token_id=None)
+    scheduler._on_chunk("req", _stream_item(torch.tensor([1])))
+
+    scheduler.abort("req")
+
+    assert "req" not in scheduler._text_states

--- a/tests/unit_test/scheduling/test_dllm_scheduler.py
+++ b/tests/unit_test/scheduling/test_dllm_scheduler.py
@@ -9,6 +9,7 @@ import pytest
 from sglang_omni.model_runner.model_worker import ModelWorker
 from sglang_omni.scheduling import dllm_scheduler as dllm_scheduler_module
 from sglang_omni.scheduling.dllm_scheduler import DllmScheduler
+from sglang_omni.scheduling.messages import OutgoingMessage
 
 
 class _ReqDouble:
@@ -22,17 +23,28 @@ class _ReqDouble:
         )
         self.extend_range = SimpleNamespace(end=len(self.full_untruncated_fill_ids))
         self.output_ids: list[int] = []
-        self.output_ids_through_stop: list[int] = self.output_ids
+        self.finished_len: int | None = None
         self.finished_reason = None
+        self.send_token_offset = 0
         self.req_pool_idx = 3
         self.accepted_lengths: list[int] = []
         self._finished = False
+        self._matches_stop_prefix = False
 
     def update_finish_state(self, *, new_accepted_len: int = 1) -> None:
         self.accepted_lengths.append(new_accepted_len)
 
     def finished(self) -> bool:
         return self._finished
+
+    def check_match_stop_str_prefix(self) -> bool:
+        return self._matches_stop_prefix
+
+    @property
+    def output_ids_through_stop(self) -> list[int]:
+        if self.finished_len is None:
+            return self.output_ids
+        return self.output_ids[: self.finished_len]
 
 
 def _scheduler(*, fdfo: bool, block_size: int = 4) -> DllmScheduler:
@@ -43,6 +55,7 @@ def _scheduler(*, fdfo: bool, block_size: int = 4) -> DllmScheduler:
     )
     scheduler._rid_to_req_data = {}
     scheduler._result_adapter = lambda value: value
+    scheduler._stream_output_builder = None
     scheduler.outbox = SimpleNamespace(put=lambda value: None)
     return scheduler
 
@@ -236,6 +249,24 @@ def test_fdfo_unresolved_block_carries_tokens_state_and_resident_kv() -> None:
     assert req.req_pool_idx == 3
 
 
+def test_fdfo_unresolved_block_does_not_emit_stream_output() -> None:
+    scheduler = _scheduler(fdfo=True)
+    req = _ReqDouble()
+    scheduler._rid_to_req_data[req.rid] = object()
+    emitted = []
+    scheduler._stream_output_builder = lambda *args: emitted.append(args) or []
+    batch = SimpleNamespace(reqs=[req])
+    result = SimpleNamespace(
+        next_token_ids=[[10, 11, 12, 13]],
+        accept_length_per_req_cpu=[0],
+        dllm_algo_state=[{"round": 2}],
+    )
+
+    scheduler._apply_results(batch, result)
+
+    assert emitted == []
+
+
 def test_fdfo_resolved_block_commits_fill_ids_and_output_tokens() -> None:
     scheduler = _scheduler(fdfo=True)
     req = _ReqDouble()
@@ -285,3 +316,180 @@ def test_sync_dllm_result_commits_generated_suffix() -> None:
     assert req.full_untruncated_fill_ids == array("q", [1, 2, -1, -1, 10, 11])
     assert req.output_ids == [10, 11]
     assert req.accepted_lengths == [2]
+
+
+def test_dllm_stream_output_precedes_terminal_result() -> None:
+    scheduler = _scheduler(fdfo=False)
+    req = _ReqDouble()
+    req._finished = True
+    req_data = SimpleNamespace(output_ids=[])
+    scheduler._rid_to_req_data[req.rid] = req_data
+    outbox = []
+    scheduler.outbox = SimpleNamespace(put=outbox.append)
+
+    def build_stream_output(request_id, data, token_ids):
+        assert data is req_data
+        return [
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                data=list(token_ids),
+                target="decode",
+            )
+        ]
+
+    scheduler._stream_output_builder = build_stream_output
+    batch = SimpleNamespace(reqs=[req])
+    result = SimpleNamespace(
+        next_token_ids=[[10, 11]],
+        accept_length_per_req_cpu=None,
+        dllm_algo_state=None,
+    )
+
+    scheduler._apply_results(batch, result)
+
+    assert [message.type for message in outbox] == ["stream", "result"]
+    assert outbox[0].data == [10, 11]
+    assert req_data.output_ids == [10, 11]
+
+
+def test_dllm_stream_output_excludes_tokens_after_stop() -> None:
+    scheduler = _scheduler(fdfo=False)
+    req = _ReqDouble()
+    req._finished = True
+    req.finished_len = 1
+    req_data = SimpleNamespace(output_ids=[])
+    scheduler._rid_to_req_data[req.rid] = req_data
+    streamed = []
+
+    def build_stream_output(_request_id, _data, token_ids):
+        streamed.extend(token_ids)
+        return []
+
+    scheduler._stream_output_builder = build_stream_output
+    batch = SimpleNamespace(reqs=[req])
+    result = SimpleNamespace(
+        next_token_ids=[[10, 11, 12]],
+        accept_length_per_req_cpu=None,
+        dllm_algo_state=None,
+    )
+
+    scheduler._apply_results(batch, result)
+
+    assert streamed == [10]
+    assert req_data.output_ids == [10]
+
+
+def test_dllm_stream_output_holds_stop_prefix_and_releases_from_send_offset() -> None:
+    scheduler = _scheduler(fdfo=False)
+    req = _ReqDouble()
+    req._matches_stop_prefix = True
+    req_data = SimpleNamespace(output_ids=[])
+    scheduler._rid_to_req_data[req.rid] = req_data
+    streamed = []
+
+    def build_stream_output(_request_id, _data, token_ids):
+        streamed.append(list(token_ids))
+        return []
+
+    scheduler._stream_output_builder = build_stream_output
+    batch = SimpleNamespace(reqs=[req])
+
+    scheduler._apply_results(
+        batch,
+        SimpleNamespace(
+            next_token_ids=[[10, 11]],
+            accept_length_per_req_cpu=None,
+            dllm_algo_state=None,
+        ),
+    )
+
+    assert streamed == []
+    assert req.send_token_offset == 0
+
+    req._matches_stop_prefix = False
+    scheduler._apply_results(
+        batch,
+        SimpleNamespace(
+            next_token_ids=[[12, 13]],
+            accept_length_per_req_cpu=None,
+            dllm_algo_state=None,
+        ),
+    )
+
+    assert streamed == [[10, 11, 12, 13]]
+    assert req.send_token_offset == 4
+
+
+def test_dllm_stream_output_withholds_terminal_matched_stop_block() -> None:
+    scheduler = _scheduler(fdfo=False)
+    req = _ReqDouble()
+    req._finished = True
+    req.finished_len = 2
+    req.finished_reason = SimpleNamespace(
+        to_json=lambda: {"type": "stop", "matched": "stop here"}
+    )
+    req_data = SimpleNamespace(output_ids=[])
+    scheduler._rid_to_req_data[req.rid] = req_data
+    streamed = []
+    outbox = []
+    scheduler.outbox = SimpleNamespace(put=outbox.append)
+    scheduler._stream_output_builder = lambda _request_id, _data, token_ids: (
+        streamed.append(list(token_ids)) or []
+    )
+
+    scheduler._apply_results(
+        SimpleNamespace(reqs=[req]),
+        SimpleNamespace(
+            next_token_ids=[[10, 11, 12]],
+            accept_length_per_req_cpu=None,
+            dllm_algo_state=None,
+        ),
+    )
+
+    assert streamed == []
+    assert [message.type for message in outbox] == ["result"]
+    assert req_data.output_ids == [10, 11]
+    assert req_data.finish_reason == "stop"
+    assert req_data.finish_reason_data == {
+        "type": "stop",
+        "matched": "stop here",
+    }
+
+
+def test_dllm_stream_output_flushes_held_prefix_on_length_finish() -> None:
+    scheduler = _scheduler(fdfo=False)
+    req = _ReqDouble()
+    req.output_ids = [10, 11]
+    req._finished = True
+    req.finished_reason = SimpleNamespace(
+        to_json=lambda: {"type": "length", "length": 4}
+    )
+    req_data = SimpleNamespace(output_ids=[])
+    scheduler._rid_to_req_data[req.rid] = req_data
+    outbox = []
+    scheduler.outbox = SimpleNamespace(put=outbox.append)
+
+    def build_stream_output(request_id, _data, token_ids):
+        return [
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                data=list(token_ids),
+                target="decode",
+            )
+        ]
+
+    scheduler._stream_output_builder = build_stream_output
+    scheduler._apply_results(
+        SimpleNamespace(reqs=[req]),
+        SimpleNamespace(
+            next_token_ids=[[12, 13]],
+            accept_length_per_req_cpu=None,
+            dllm_algo_state=None,
+        ),
+    )
+
+    assert [message.type for message in outbox] == ["stream", "result"]
+    assert outbox[0].data == [10, 11, 12, 13]
+    assert req.send_token_offset == 4


### PR DESCRIPTION
## Motivation

LLaDA2.0-Uni currently waits for the terminal thinker result even when an
OpenAI-compatible request sets `stream=true`. Its diffusion scheduler already
accepts stable token blocks during generation, but those blocks are not routed
through an incremental text decoder.

This PR exposes accepted text blocks as append-only SSE deltas while preserving
the existing non-streaming result. It also follows SGLang's stop semantics so a
stop string, including one split across accepted blocks, is never leaked to the
client.

## Modifications

- Route accepted dLLM token blocks from the LLaDA2 thinker to the decode stage.
- Add a stream-aware detokenizer that:
  - emits append-only text deltas;
  - buffers incomplete UTF-8 sequences;
  - filters EOS and special tokens;
  - reconciles the terminal output without duplicating streamed text;
  - preserves terminal `finish_reason` and usage metadata.
- Track the scheduler's sent-token offset and hold output whose suffix may be a
  prefix of a configured stop string.
- Propagate the matched stop metadata to terminal decoding and trim matched stop
  strings or stop tokens consistently for streaming and non-streaming requests.
- Add unit coverage for stage wiring, accepted-block streaming, UTF-8 boundaries,
  terminal ordering, usage, stop trimming, false stop-prefix recovery, and abort
  cleanup.

## Related Issues

Part of #445 (`Streaming support`).

Roadmap: #1081.

## Accuracy Test

This PR does not change model weights, logits, sampling, or the denoising
algorithm. Validation therefore focused on deterministic output parity and
serving-protocol behavior.

### Local test suites

- `pre-commit run --all-files --show-diff-on-failure`: passed.
- LLaDA2 and scheduler unit-test scopes: **213 passed**.
- Full unit-test sweep excluding two platform-incompatible MOSS-TTS CUDA tests:
  **4,110 passed, 32 skipped, 2 deselected**. The two deselected tests were run
  separately and fail because RTX 5090 takes the FA2 fallback path while this
  environment does not export `flash_attn_varlen_func`. No LLaDA2 or shared
  scheduler test failed.

### End-to-end model validation

| Item | Configuration |
| --- | --- |
| Model | `inclusionAI/LLaDA2.0-Uni` BF16 checkpoint |
| GPU | NVIDIA GeForce RTX 5090, 32 GB |
| Runtime | PyTorch 2.11.0 + CUDA 13.0 |
| Memory settings | 8 GB CPU offload, thinker `mem_fraction_static=0.80` |
| Sampling | `temperature=0` with fixed seeds |

The following checks passed against a real local server:

- English, Chinese, and image-plus-text requests produced byte-identical
  streaming and non-streaming text with identical usage and finish reasons.
- A stop string split across accepted blocks was fully trimmed in both modes.
- A suffix that only looked like a stop prefix was held and later released
  without lost or duplicated text.
- A later-block stop match preserved text emitted by an earlier block and only
  flushed the remaining safe suffix.
- Two concurrent streams kept their request IDs, deltas, terminal events, and
  usage isolated.
- Closing a stream after its first delta aborted the request; within 0.5 seconds
  the server reported zero pending completions and no retained request state.

## Benchmark & Profiling

This PR changes when accepted text is delivered, not the model compute path, and
makes no throughput or kernel-performance claim. End-to-end validation confirmed
that normal requests emit incremental content before the terminal usage event.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed. No
      README or cookbook changes are included in this PR.
- [x] Provide throughput / latency benchmark results and accuracy evaluation
      results as needed. This is a protocol-delivery change; deterministic
      parity and lifecycle results are provided above.
- [ ] For reviewers: If you haven't made any contributions to this PR and are
      only assisting with merging the main branch, please remove yourself as a
      co-author when merging the PR.