### PR TITLE
[CI] Contention report is advisory, never fatal

### DIFF
--- a/tests/test_model/conftest.py
+++ b/tests/test_model/conftest.py
@@ -64,16 +64,17 @@ def pin_omni_ci_cpuset() -> "Generator[None, None, None]":
     calibrated floors. Child processes inherit the affinity, which keeps the
     managed router, its workers, and the bench client on the reserved cores.
     Pinning restrains only this session, so a contention sampler reports
-    foreign load on the reserved cores at session end. On CI heavy intrusion
-    fails the session after results are written, so the stage retry
-    re-measures on a clean window instead of gating on polluted numbers;
-    calibration handles the same signal itself by rejecting the round.
+    foreign load on the reserved cores at session end. The report is
+    advisory, never fatal: contention can only depress perf numbers, so a
+    gate that passed under intrusion passed for real, and a gate that failed
+    carries the contention line for triage while retrying through the normal
+    failure path. Calibration is stricter and rejects the round itself.
     """
     cpus = _apply_omni_ci_cpuset()
     if cpus is None:
         yield
         return
-    from tests.utils.ci_cpu_contention import FAIL_FOREIGN_CORES, ContentionSampler
+    from tests.utils.ci_cpu_contention import ContentionSampler
 
     sampler = ContentionSampler(cpus)
     sampler.start()
@@ -82,12 +83,6 @@ def pin_omni_ci_cpuset() -> "Generator[None, None, None]":
     finally:
         sampler.stop()
         print(sampler.summary())
-        peak = sampler.peak_foreign_cores()
-        if os.environ.get("GITHUB_ACTIONS") == "true" and peak > FAIL_FOREIGN_CORES:
-            pytest.fail(
-                f"cpuset contention: foreign load peaked at {peak:.2f} cores "
-                f"on the pinned cpuset; failing so the stage retry re-measures"
-            )
 
 
 TTS_ALLOWED_CONCURRENCIES = (1, 2, 4, 8, 16)

--- a/tests/utils/ci_cpu_contention.py
+++ b/tests/utils/ci_cpu_contention.py
@@ -26,8 +26,10 @@ from dataclasses import dataclass
 
 _SAMPLE_INTERVAL_S = 30.0
 _WARN_FOREIGN_CORES = 1.0
-# note (Jiaxin Deng): above this, the session's speed numbers describe the
-# intruder, not the model; CI fails the stage so its retry re-measures.
+# note (Jiaxin Deng): above this a round measured the intruder, not the
+# model. Calibration rejects such rounds (tune.py). CI only reports:
+# contention can only depress perf numbers, so a passing gate is real and
+# failing a passing stage would spend its retries on nothing (PR 1379).
 FAIL_FOREIGN_CORES = 2.0
 
 


### PR DESCRIPTION
Fixes the retry-exhaustion failure mode from PR #1379: the MTD stage passed its gates on all three attempts and was killed each time by the contention guard in fixture teardown (foreign peaks 3.46 / 5.73 / 6.42 cores), spending 53 minutes to report that someone else was using the CPU.

The fail branch was unnecessary on physical grounds: contention can only depress perf numbers, never inflate them, so a gate that passed under intrusion passed for real. A gate that fails already retries through the normal failure path, with the `[cpuset-contention]` line in the log for one-grep triage. This removes the `pytest.fail` and keeps the report.

Calibration is unchanged and stays stricter (it rejects contaminated rounds and re-runs them, since worst-of-N references must not be depressed by intruders).

Complementary work tracked in #1437: wait for a clean cpuset before launching the stage instead of burning retry budget on a window that is known to be contended.