### PR TITLE
[qwen3-asr] add breakable prefill CUDA graph (BCG) support

### DIFF
--- a/sglang_omni/models/qwen3_asr/engine_builder.py
+++ b/sglang_omni/models/qwen3_asr/engine_builder.py
@@ -174,15 +174,15 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
             return
         if "cuda_graph_bs_prefill" in overrides:
             return
-        # Derived from the merged caps: a ladder past any of them fails
-        # startup or captures buckets that can never replay.
+        # note(ratish): derived from the merged caps: a ladder past any of
+        # them fails startup or captures buckets that can never replay.
         caps = [
             overrides["max_prefill_tokens"],
             overrides.get("cuda_graph_max_bs_prefill"),
             overrides.get("max_total_tokens"),
             self.context_length,
         ]
-        if overrides["chunked_prefill_size"] != -1:
+        if overrides["chunked_prefill_size"] > 0:
             caps.append(overrides["chunked_prefill_size"])
         ladder = build_default_prefill_cuda_graph_bs(
             min(int(cap) for cap in caps if cap is not None)

--- a/sglang_omni/models/qwen3_asr/engine_builder.py
+++ b/sglang_omni/models/qwen3_asr/engine_builder.py
@@ -19,7 +19,11 @@ from sglang_omni.models.qwen3_asr.encoder_service import (
     build_cache_namespace,
 )
 from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
-from sglang_omni.scheduling.generation_batch_policy import get_decode_cuda_graph_bs
+from sglang_omni.scheduling.generation_batch_policy import (
+    CudaGraphBackend,
+    build_default_prefill_cuda_graph_bs,
+    get_decode_cuda_graph_bs,
+)
 from sglang_omni.utils.gpu_compat import get_visible_gpu_sm_version
 from sglang_omni.utils.gpu_memory import format_bytes_gib, get_process_gpu_memory_bytes
 
@@ -29,6 +33,7 @@ logger = logging.getLogger(__name__)
 class Qwen3ASREngineBuilder(AsrEngineBuilder):
     model_name = "Qwen3-ASR"
     model_arch_override = "Qwen3ASRForConditionalGeneration"
+    supports_breakable_prefill_cuda_graph = True
 
     def __init__(
         self,
@@ -123,6 +128,7 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
             "chunked_prefill_size": 4096,
             "sampling_backend": "pytorch",
             "dtype": dtype,
+            "cuda_graph_backend_prefill": CudaGraphBackend.BREAKABLE,
         }
         if self.mm_attention_backend is not None:
             defaults["mm_attention_backend"] = self.mm_attention_backend
@@ -164,6 +170,25 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
     def adjust_overrides(self, overrides: dict[str, Any]) -> None:
         if "context_length" in overrides:
             self.context_length = int(overrides.pop("context_length"))
+        if overrides.get("cuda_graph_backend_prefill") == CudaGraphBackend.DISABLED:
+            return
+        if "cuda_graph_bs_prefill" in overrides:
+            return
+        # Derived from the merged caps: a ladder past any of them fails
+        # startup or captures buckets that can never replay.
+        caps = [
+            overrides["max_prefill_tokens"],
+            overrides.get("cuda_graph_max_bs_prefill"),
+            overrides.get("max_total_tokens"),
+            self.context_length,
+        ]
+        if overrides["chunked_prefill_size"] != -1:
+            caps.append(overrides["chunked_prefill_size"])
+        ladder = build_default_prefill_cuda_graph_bs(
+            min(int(cap) for cap in caps if cap is not None)
+        )
+        overrides["cuda_graph_bs_prefill"] = ladder
+        overrides["cuda_graph_max_bs_prefill"] = max(ladder)
 
     def customize_server_args(self, server_args: Any) -> None:
         self.context_length = int(server_args.context_length)

--- a/sglang_omni/models/qwen3_asr/sglang_model.py
+++ b/sglang_omni/models/qwen3_asr/sglang_model.py
@@ -61,8 +61,8 @@ def _fused_asr_forward_prepare_native(
             hidden_states,
         )
     if positions.dtype != torch.int32:
-        # The prefill CUDA graph bypasses forward()'s int32 cast; the kernel
-        # rejects int64 positions.
+        # note(ratish): the prefill CUDA graph bypasses forward()'s int32
+        # cast; the kernel rejects int64 positions.
         positions = positions.to(torch.int32)
     qkv, _ = attention.qkv_proj(hidden_states)
     fused_qk_norm_rope(

--- a/sglang_omni/models/qwen3_asr/sglang_model.py
+++ b/sglang_omni/models/qwen3_asr/sglang_model.py
@@ -60,6 +60,10 @@ def _fused_asr_forward_prepare_native(
             positions,
             hidden_states,
         )
+    if positions.dtype != torch.int32:
+        # The prefill CUDA graph bypasses forward()'s int32 cast; the kernel
+        # rejects int64 positions.
+        positions = positions.to(torch.int32)
     qkv, _ = attention.qkv_proj(hidden_states)
     fused_qk_norm_rope(
         qkv,

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -7,12 +7,11 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from typing import Any
 
-from sglang.srt.model_executor.cuda_graph_config import CudaGraphConfig
-
 from sglang_omni.scheduling.generation_batch_policy import (
     CudaGraphBackend,
     build_generation_batch_overrides,
     get_prefill_cuda_graph_backend,
+    nested_prefill_overrides,
     validate_generation_batch_policy,
 )
 from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoint
@@ -25,14 +24,7 @@ def _operator_selected_prefill_graph_backend(
         return False
     if "cuda_graph_backend_prefill" in server_args_overrides:
         return True
-
-    config = server_args_overrides.get("cuda_graph_config")
-    if isinstance(config, CudaGraphConfig):
-        config = config.to_dict()
-    if not isinstance(config, Mapping):
-        return False
-    prefill_config = config.get("prefill")
-    return isinstance(prefill_config, Mapping) and "backend" in prefill_config
+    return "backend" in nested_prefill_overrides(server_args_overrides)
 
 
 class SGLangGenerationEngineBuilder(ABC):

--- a/sglang_omni/scheduling/generation_batch_policy.py
+++ b/sglang_omni/scheduling/generation_batch_policy.py
@@ -90,7 +90,8 @@ def build_generation_batch_overrides(
     **stage_defaults: Any,
 ) -> dict[str, Any]:
     incoming = dict(server_args_overrides or {})
-    # The nested form wins in sglang; mirror its prefill fields into the flat keys.
+    # note(ratish): the nested form wins in sglang; mirror its prefill
+    # fields into the flat keys.
     nested_prefill = nested_prefill_overrides(incoming)
     for nested_key, flat_key in (
         ("backend", "cuda_graph_backend_prefill"),
@@ -149,11 +150,23 @@ def build_generation_batch_overrides(
         overrides.pop("cuda_graph_bs_prefill", None)
         overrides.pop("cuda_graph_max_bs_prefill", None)
 
-    # Derive the prefill cap when only the bucket list is given so the
-    # resolved config stays coherent (max(bs) == max_bs).
+    # Reconcile the merged buckets with the cap: derive a missing cap from
+    # the buckets, and trim stage-default buckets to an operator cap. An
+    # operator-stated list is never trimmed; contradictions fail validation.
     prefill_bs = overrides.get("cuda_graph_bs_prefill")
-    if prefill_bs and "cuda_graph_max_bs_prefill" not in overrides:
+    prefill_max_bs = overrides.get("cuda_graph_max_bs_prefill")
+    if prefill_bs and prefill_max_bs is None:
         overrides["cuda_graph_max_bs_prefill"] = max(int(b) for b in prefill_bs)
+    elif (
+        prefill_bs
+        and "cuda_graph_bs_prefill" not in incoming
+        and int(prefill_max_bs) < max(int(b) for b in prefill_bs)
+    ):
+        cap = int(prefill_max_bs)
+        trimmed = [int(b) for b in prefill_bs if int(b) <= cap]
+        if not trimmed or trimmed[-1] != cap:
+            trimmed.append(cap)
+        overrides["cuda_graph_bs_prefill"] = trimmed
 
     return overrides
 

--- a/sglang_omni/scheduling/generation_batch_policy.py
+++ b/sglang_omni/scheduling/generation_batch_policy.py
@@ -9,6 +9,7 @@ from numbers import Integral
 from typing import Any
 
 from sglang.srt.model_executor.cuda_graph_config import Backend as CudaGraphBackend
+from sglang.srt.model_executor.cuda_graph_config import CudaGraphConfig
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +70,17 @@ def build_default_prefill_cuda_graph_bs(max_num_tokens: int) -> list[int]:
     return values
 
 
+def nested_prefill_overrides(overrides: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Extract the prefill section of a nested cuda_graph_config override."""
+    config = overrides.get("cuda_graph_config")
+    if isinstance(config, CudaGraphConfig):
+        config = config.to_dict()
+    if not isinstance(config, Mapping):
+        return {}
+    prefill_config = config.get("prefill")
+    return prefill_config if isinstance(prefill_config, Mapping) else {}
+
+
 def build_generation_batch_overrides(
     *,
     max_running_requests: int,
@@ -78,6 +90,23 @@ def build_generation_batch_overrides(
     **stage_defaults: Any,
 ) -> dict[str, Any]:
     incoming = dict(server_args_overrides or {})
+    # The nested form wins in sglang; mirror its prefill fields into the flat keys.
+    nested_prefill = nested_prefill_overrides(incoming)
+    for nested_key, flat_key in (
+        ("backend", "cuda_graph_backend_prefill"),
+        ("bs", "cuda_graph_bs_prefill"),
+        ("max_bs", "cuda_graph_max_bs_prefill"),
+    ):
+        if nested_key not in nested_prefill:
+            continue
+        nested_value = nested_prefill[nested_key]
+        if flat_key in incoming and incoming[flat_key] != nested_value:
+            raise ValueError(
+                f"Conflicting {flat_key} and cuda_graph_config prefill "
+                f"{nested_key} values: "
+                f"{incoming[flat_key]!r} != {nested_value!r}"
+            )
+        incoming[flat_key] = nested_value
     max_running_requests = _normalize_positive_int(
         "max_running_requests",
         incoming.pop("max_running_requests", max_running_requests),
@@ -230,6 +259,19 @@ def _validate_prefill_graph_policy(
             f"got {backend!r}"
         )
         return
+
+    incompatibilities = (
+        ("context parallel (attn_cp_size > 1)", server_args.attn_cp_size > 1),
+        ("decode context parallel (dcp_size > 1)", server_args.dcp_size > 1),
+        ("LoRA", bool(server_args.lora_paths) or bool(server_args.enable_lora)),
+        ("MoE A2A", server_args.moe_a2a_backend != "none"),
+    )
+    for feature, is_active in incompatibilities:
+        if is_active:
+            errors.append(
+                f"breakable prefill CUDA graphs are incompatible with {feature}; "
+                "set cuda_graph_backend_prefill='disabled'"
+            )
 
     if ("prefill", "bs") not in server_args._cuda_graph_config_locked:
         errors.append(

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -268,6 +268,11 @@ def _install_higgs_engine_build_fakes(monkeypatch) -> dict[str, object]:
             chunked_prefill_size=overrides.get("chunked_prefill_size"),
             max_prefill_tokens=overrides.get("max_prefill_tokens", 16384),
             tp_size=1,
+            attn_cp_size=1,
+            dcp_size=1,
+            lora_paths=None,
+            enable_lora=None,
+            moe_a2a_backend="none",
             cuda_graph_config=SimpleNamespace(
                 decode=SimpleNamespace(
                     max_bs=overrides["cuda_graph_max_bs"],

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -299,7 +299,7 @@ def _patch_engine_dependencies(
     monkeypatch.setattr(
         qwen3_asr_builder.AutoFeatureExtractor,
         "from_pretrained",
-        lambda *args, **kwargs: SimpleNamespace(nb_max_frames=3000),
+        lambda *args, **kwargs: SimpleNamespace(nb_max_frames=55072),
     )
     monkeypatch.setattr(
         qwen3_asr_builder,
@@ -480,7 +480,7 @@ def test_qwen3_asr_build_initializes_and_attests_prefill_graphs(monkeypatch) -> 
     [
         ({"context_length": 1000}, 1000),
         ({"chunked_prefill_size": 512}, 512),
-        ({"chunked_prefill_size": 0}, 1636),
+        ({"chunked_prefill_size": 0}, 4096),
         ({"max_prefill_tokens": 768}, 768),
         ({"cuda_graph_max_bs_prefill": 512}, 512),
         ({"max_total_tokens": 640}, 640),

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -480,6 +480,7 @@ def test_qwen3_asr_build_initializes_and_attests_prefill_graphs(monkeypatch) -> 
     [
         ({"context_length": 1000}, 1000),
         ({"chunked_prefill_size": 512}, 512),
+        ({"chunked_prefill_size": 0}, 1636),
         ({"max_prefill_tokens": 768}, 768),
         ({"cuda_graph_max_bs_prefill": 512}, 512),
         ({"max_total_tokens": 640}, 640),

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -14,19 +15,65 @@ import sglang_omni.models.qwen3_asr.stages as qwen3_asr_stages
 import sglang_omni.scheduling.bootstrap as bootstrap
 import sglang_omni.scheduling.omni_scheduler as omni_scheduler
 import sglang_omni.scheduling.sglang_backend as sglang_backend
+import sglang_omni.utils.cuda_graph_batch_validator as cuda_graph_batch_validator
 from sglang_omni.config.manager import ConfigManager
 from sglang_omni.config.runtime import resolve_stage_static_factory_args
 from sglang_omni.models.qwen3_asr import request_builders
 from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
 from sglang_omni.models.qwen3_asr.stages import create_sglang_qwen3_asr_executor
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+from sglang_omni.scheduling.generation_batch_policy import (
+    build_generation_batch_overrides,
+    validate_generation_batch_policy,
+)
 from tests.unit_test.fakes import FakeServerArgs
 
 
+def _fake_server_args_builder(build_kwargs: dict[str, object]):
+    def _build(model_path, context_length, **overrides):
+        del model_path
+        build_kwargs.update(overrides)
+        flat = {
+            key: value
+            for key, value in overrides.items()
+            if not key.startswith("cuda_graph_")
+        }
+        for name, default in (
+            ("attn_cp_size", 1),
+            ("dcp_size", 1),
+            ("lora_paths", None),
+            ("enable_lora", None),
+            ("moe_a2a_backend", "none"),
+        ):
+            flat.setdefault(name, default)
+        server_args = FakeServerArgs(context_length=context_length, **flat)
+        prefill_bs = overrides.get("cuda_graph_bs_prefill")
+        server_args.cuda_graph_config = SimpleNamespace(
+            decode=SimpleNamespace(
+                max_bs=overrides["cuda_graph_max_bs"],
+                bs=overrides["cuda_graph_bs"],
+            ),
+            prefill=SimpleNamespace(
+                backend=overrides.get("cuda_graph_backend_prefill", "disabled"),
+                bs=prefill_bs,
+                max_bs=overrides.get("cuda_graph_max_bs_prefill"),
+            ),
+        )
+        locked = set()
+        if "cuda_graph_backend_prefill" in overrides:
+            locked.add(("prefill", "backend"))
+        if prefill_bs is not None:
+            locked.add(("prefill", "bs"))
+        server_args._cuda_graph_config_locked = locked
+        return server_args
+
+    return _build
+
+
 def _make_engine_builder(
-    *, mm_attention_backend: str | None = None
+    *, mm_attention_backend: str | None = None, context_length: int = 1636
 ) -> qwen3_asr_builder.Qwen3ASREngineBuilder:
-    return qwen3_asr_builder.Qwen3ASREngineBuilder(
+    builder = qwen3_asr_builder.Qwen3ASREngineBuilder(
         max_running_requests=64,
         max_new_tokens=128,
         enable_async_decode=True,
@@ -44,6 +91,8 @@ def _make_engine_builder(
         prefill_coalesce_requires_pending_builds=True,
         prefill_coalesce_after_builds_during_decode=True,
     )
+    builder.context_length = context_length
+    return builder
 
 
 @pytest.mark.parametrize(
@@ -227,10 +276,20 @@ def test_qwen3_asr_rtx4090_profile_is_bf16_and_bounded() -> None:
     assert factory_args["server_args_overrides"]["mem_fraction_static"] == 0.65
 
 
-def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch, caplog) -> None:
-    build_kwargs: dict[str, object] = {}
-    adapter_kwargs: dict[str, object] = {}
-    memory_queries: list[int] = []
+def _patch_engine_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    want_cuda_graph: bool = False,
+) -> SimpleNamespace:
+    recorded = SimpleNamespace(
+        build_kwargs={},
+        adapter_kwargs={},
+        memory_queries=[],
+        infra_kwargs=[],
+        attest_calls=[],
+        graph_init_calls=[],
+        encoder_service=SimpleNamespace(close=lambda: None),
+    )
 
     monkeypatch.setattr(
         qwen3_asr_builder.AutoTokenizer,
@@ -250,14 +309,13 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch, caplog) -> None:
     monkeypatch.setattr(
         qwen3_asr_builder,
         "get_process_gpu_memory_bytes",
-        lambda gpu_id: memory_queries.append(gpu_id) or 0,
+        lambda gpu_id: recorded.memory_queries.append(gpu_id) or 0,
     )
     monkeypatch.setattr(qwen3_asr_builder, "init_mm_embedding_cache", lambda size: None)
-    fake_encoder_service = SimpleNamespace(close=lambda: None)
     monkeypatch.setattr(
         qwen3_asr_builder,
         "Qwen3ASRPreLMEncoderService",
-        lambda *args, **kwargs: fake_encoder_service,
+        lambda *args, **kwargs: recorded.encoder_service,
     )
     monkeypatch.setattr(
         qwen3_asr_builder,
@@ -267,7 +325,7 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch, caplog) -> None:
     monkeypatch.setattr(
         request_builders,
         "make_qwen3_asr_scheduler_adapters",
-        lambda **kwargs: (adapter_kwargs.update(kwargs) or object(), object()),
+        lambda **kwargs: (recorded.adapter_kwargs.update(kwargs) or object(), object()),
     )
     monkeypatch.setattr(
         sglang_backend,
@@ -284,32 +342,20 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch, caplog) -> None:
         "OmniScheduler",
         lambda **kwargs: SimpleNamespace(**kwargs),
     )
-
-    def _fake_server_args_builder(model_path, context_length, **overrides):
-        build_kwargs.update(overrides)
-        normalized_overrides = {
-            key: value
-            for key, value in overrides.items()
-            if key not in {"cuda_graph_bs", "cuda_graph_max_bs"}
-        }
-        server_args = FakeServerArgs(
-            context_length=context_length, **normalized_overrides
-        )
-        server_args.cuda_graph_config = SimpleNamespace(
-            decode=SimpleNamespace(
-                max_bs=overrides["cuda_graph_max_bs"],
-                bs=overrides["cuda_graph_bs"],
-            ),
-            prefill=SimpleNamespace(backend="disabled", bs=None, max_bs=None),
-        )
-        return server_args
+    monkeypatch.setattr(
+        sglang_backend,
+        "build_sglang_server_args",
+        _fake_server_args_builder(recorded.build_kwargs),
+    )
 
     def _fake_create_infrastructure(server_args, gpu_id, **kwargs):
+        del server_args
+        recorded.infra_kwargs.append(dict(kwargs))
         model_worker = SimpleNamespace(
             gpu_id=gpu_id,
             model_runner=SimpleNamespace(model=object()),
         )
-        return False, (
+        return want_cuda_graph, (
             model_worker,
             object(),
             object(),
@@ -320,15 +366,28 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch, caplog) -> None:
         )
 
     monkeypatch.setattr(
-        sglang_backend,
-        "build_sglang_server_args",
-        _fake_server_args_builder,
-    )
-    monkeypatch.setattr(
         bootstrap,
         "create_sglang_infrastructure_defer_cuda_graph",
         _fake_create_infrastructure,
     )
+    monkeypatch.setattr(
+        bootstrap,
+        "init_sglang_cuda_graphs",
+        lambda model_worker: recorded.graph_init_calls.append(model_worker),
+    )
+    monkeypatch.setattr(
+        cuda_graph_batch_validator,
+        "attest_prefill_cuda_graphs",
+        lambda model_runner, server_args: recorded.attest_calls.append(
+            (model_runner, server_args)
+        ),
+    )
+    return recorded
+
+
+def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch, caplog) -> None:
+    recorded = _patch_engine_dependencies(monkeypatch)
+    build_kwargs = recorded.build_kwargs
 
     with caplog.at_level("INFO", logger=qwen3_asr_builder.__name__):
         scheduler = qwen3_asr_stages.create_sglang_qwen3_asr_executor(
@@ -355,8 +414,8 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch, caplog) -> None:
     ]
     assert "cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64]" in caplog.text
     assert "mm_attention_backend" not in build_kwargs
-    assert memory_queries == [0, 0, 0]
-    assert adapter_kwargs["context_length"] == 2048
+    assert recorded.memory_queries == [0, 0, 0]
+    assert recorded.adapter_kwargs["context_length"] == 2048
     assert scheduler.enable_async_decode is False
     assert scheduler.async_decode_min_batch_size == 4
     assert scheduler.prefill_coalesce_requests == 16
@@ -364,4 +423,120 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch, caplog) -> None:
     assert scheduler.prefill_coalesce_when_idle is True
     assert scheduler.prefill_coalesce_requires_pending_builds is True
     assert scheduler.prefill_coalesce_after_builds_during_decode is True
-    assert scheduler.shutdown_callback is fake_encoder_service.close
+    assert scheduler.shutdown_callback is recorded.encoder_service.close
+
+
+@pytest.mark.parametrize(
+    ("context_length", "expected_cap"),
+    [
+        (1636, 1636),
+        (512, 512),
+        (8192, 4096),
+    ],
+)
+def test_prefill_ladder_never_exceeds_the_context_length(
+    context_length: int, expected_cap: int
+) -> None:
+    builder = _make_engine_builder(
+        mm_attention_backend="fa3", context_length=context_length
+    )
+    overrides = build_generation_batch_overrides(
+        **builder.generation_defaults(dtype="bfloat16")
+    )
+
+    builder.adjust_overrides(overrides)
+
+    assert max(overrides["cuda_graph_bs_prefill"]) == expected_cap
+
+
+def test_qwen3_asr_prefill_ladder_is_accepted_by_the_shared_policy(caplog) -> None:
+    builder = _make_engine_builder(mm_attention_backend="fa3")
+    overrides = build_generation_batch_overrides(
+        **builder.generation_defaults(dtype="bfloat16")
+    )
+    builder.adjust_overrides(overrides)
+    server_args = _fake_server_args_builder({})("dummy", 1636, **overrides)
+
+    with caplog.at_level(logging.WARNING):
+        validate_generation_batch_policy(
+            model_name="Qwen3-ASR", server_args=server_args
+        )
+
+    assert not any("padding factor" in record.message for record in caplog.records)
+
+
+def test_qwen3_asr_build_initializes_and_attests_prefill_graphs(monkeypatch) -> None:
+    recorded = _patch_engine_dependencies(monkeypatch, want_cuda_graph=True)
+
+    qwen3_asr_stages.create_sglang_qwen3_asr_executor("dummy")
+
+    assert recorded.infra_kwargs[-1]["enable_prefill_input_embeds"] is True
+    assert len(recorded.graph_init_calls) == 1
+    assert len(recorded.attest_calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("cap_override", "expected_cap"),
+    [
+        ({"context_length": 1000}, 1000),
+        ({"chunked_prefill_size": 512}, 512),
+        ({"max_prefill_tokens": 768}, 768),
+        ({"cuda_graph_max_bs_prefill": 512}, 512),
+        ({"max_total_tokens": 640}, 640),
+    ],
+)
+def test_qwen3_asr_ladder_respects_deployment_cap_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    cap_override: dict[str, int],
+    expected_cap: int,
+) -> None:
+    recorded = _patch_engine_dependencies(monkeypatch, want_cuda_graph=True)
+
+    qwen3_asr_stages.create_sglang_qwen3_asr_executor(
+        "dummy", server_args_overrides=dict(cap_override)
+    )
+
+    _, attested = recorded.attest_calls[-1]
+    assert max(attested.cuda_graph_config.prefill.bs) == expected_cap
+    assert attested.cuda_graph_config.prefill.max_bs == expected_cap
+
+
+@pytest.mark.parametrize(
+    ("disable_override", "want_cuda_graph", "expected_graph_inits"),
+    [
+        ({"disable_cuda_graph": True}, False, 0),
+        ({"cuda_graph_backend_prefill": "disabled"}, True, 1),
+    ],
+)
+def test_qwen3_asr_disable_override_yields_no_prefill_ladder(
+    monkeypatch: pytest.MonkeyPatch,
+    disable_override: dict[str, object],
+    want_cuda_graph: bool,
+    expected_graph_inits: int,
+) -> None:
+    recorded = _patch_engine_dependencies(monkeypatch, want_cuda_graph=want_cuda_graph)
+
+    qwen3_asr_stages.create_sglang_qwen3_asr_executor(
+        "dummy", server_args_overrides=dict(disable_override)
+    )
+
+    assert "cuda_graph_bs_prefill" not in recorded.build_kwargs
+    assert len(recorded.graph_init_calls) == expected_graph_inits
+    assert recorded.attest_calls == []
+
+
+def test_qwen3_asr_nested_prefill_override_supersedes_the_derived_ladder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded = _patch_engine_dependencies(monkeypatch, want_cuda_graph=True)
+
+    qwen3_asr_stages.create_sglang_qwen3_asr_executor(
+        "dummy",
+        server_args_overrides={
+            "cuda_graph_config": {"prefill": {"backend": "breakable", "bs": [128, 256]}}
+        },
+    )
+
+    _, attested = recorded.attest_calls[-1]
+    assert list(attested.cuda_graph_config.prefill.bs) == [128, 256]
+    assert attested.cuda_graph_config.prefill.max_bs == 256

--- a/tests/unit_test/qwen3_asr/test_prefill_graph_positions.py
+++ b/tests/unit_test/qwen3_asr/test_prefill_graph_positions.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
+    PrefillCudaGraphRunner,
+)
+
+from sglang_omni.models.qwen3_asr import sglang_model
+from sglang_omni.models.qwen3_asr.sglang_model import Qwen3ASRForConditionalGeneration
+
+
+def _forward_batch(*, carries_mrope: bool) -> SimpleNamespace:
+    positions = torch.arange(3)
+    return SimpleNamespace(
+        positions=positions,
+        mrope_positions=(
+            positions.unsqueeze(0).expand(3, -1).clone() if carries_mrope else None
+        ),
+    )
+
+
+def _eager_positions(
+    monkeypatch: pytest.MonkeyPatch, forward_batch: SimpleNamespace
+) -> torch.Tensor:
+    model = SimpleNamespace(language_model=object(), get_audio_feature=object())
+    captured: dict[str, torch.Tensor] = {}
+
+    def fake_routine(**kwargs):
+        captured["positions"] = kwargs["positions"]
+        return torch.zeros(3)
+
+    monkeypatch.setattr(sglang_model, "general_mm_embed_routine", fake_routine)
+    Qwen3ASRForConditionalGeneration.forward(
+        model,
+        input_ids=torch.tensor([1, 2, 3]),
+        positions=forward_batch.positions,
+        forward_batch=forward_batch,
+    )
+    return captured["positions"]
+
+
+def _captured_positions(forward_batch: SimpleNamespace) -> torch.Tensor:
+    runner = SimpleNamespace(
+        model_runner=SimpleNamespace(model=Qwen3ASRForConditionalGeneration)
+    )
+    return PrefillCudaGraphRunner._get_layer_model_positions(runner, forward_batch)
+
+
+@pytest.mark.parametrize("carries_mrope", [True, False])
+def test_capture_selects_value_equal_positions_to_eager(
+    monkeypatch: pytest.MonkeyPatch,
+    carries_mrope: bool,
+) -> None:
+    forward_batch = _forward_batch(carries_mrope=carries_mrope)
+
+    eager = _eager_positions(monkeypatch, forward_batch)
+    captured = _captured_positions(forward_batch)
+
+    assert captured is forward_batch.positions
+    assert torch.equal(captured.to(eager.dtype), eager)
+
+
+@pytest.mark.parametrize(
+    ("positions_dtype", "expect_same_object"),
+    [(torch.int64, False), (torch.int32, True)],
+)
+def test_fused_rope_hook_feeds_the_kernel_int32_positions(
+    monkeypatch: pytest.MonkeyPatch,
+    positions_dtype: torch.dtype,
+    expect_same_object: bool,
+) -> None:
+    seen: dict[str, torch.Tensor] = {}
+
+    def fake_kernel(
+        qkv,
+        num_heads_q,
+        num_heads_k,
+        num_heads_v,
+        head_dim,
+        eps,
+        q_weight,
+        k_weight,
+        base,
+        is_neox,
+        position_ids,
+        *rest,
+    ):
+        seen["position_ids"] = position_ids
+
+    monkeypatch.setattr(sglang_model, "fused_qk_norm_rope", fake_kernel)
+    attention = SimpleNamespace(
+        qkv_proj=lambda hidden_states: (
+            torch.zeros(hidden_states.shape[0], 16, dtype=hidden_states.dtype),
+            None,
+        ),
+        num_heads=2,
+        num_kv_heads=1,
+        head_dim=4,
+        q_norm=SimpleNamespace(variance_epsilon=1e-6, weight=torch.ones(4)),
+        k_norm=SimpleNamespace(weight=torch.ones(4)),
+        rope_theta=10000.0,
+        rotary_emb=SimpleNamespace(is_neox_style=True),
+        q_size=8,
+        kv_size=4,
+    )
+    positions = torch.arange(3, dtype=positions_dtype)
+    hidden_states = torch.zeros((3, 8), dtype=torch.bfloat16)
+
+    query, key, value = sglang_model._fused_asr_forward_prepare_native(
+        attention, positions, hidden_states
+    )
+
+    assert seen["position_ids"].dtype == torch.int32
+    assert torch.equal(seen["position_ids"].to(positions_dtype), positions)
+    assert (seen["position_ids"] is positions) == expect_same_object
+    assert query.shape == (3, 8)
+    assert key.shape == (3, 4)
+    assert value.shape == (3, 4)

--- a/tests/unit_test/scheduling/test_prefill_graph_policy.py
+++ b/tests/unit_test/scheduling/test_prefill_graph_policy.py
@@ -220,6 +220,30 @@ def test_nested_prefill_max_bs_composes_as_a_flat_cap() -> None:
     assert "cuda_graph_bs_prefill" not in overrides
 
 
+def test_nested_prefill_max_bs_trims_a_stage_default_ladder() -> None:
+    overrides = build_generation_batch_overrides(
+        max_running_requests=4,
+        cuda_graph_bs_prefill=build_default_prefill_cuda_graph_bs(512),
+        server_args_overrides={"cuda_graph_config": {"prefill": {"max_bs": 128}}},
+    )
+
+    assert overrides["cuda_graph_max_bs_prefill"] == 128
+    assert max(overrides["cuda_graph_bs_prefill"]) == 128
+
+
+def test_operator_prefill_buckets_are_never_trimmed_by_a_nested_cap() -> None:
+    overrides = build_generation_batch_overrides(
+        max_running_requests=4,
+        server_args_overrides={
+            "cuda_graph_bs_prefill": [128, 256],
+            "cuda_graph_config": {"prefill": {"max_bs": 128}},
+        },
+    )
+
+    assert overrides["cuda_graph_bs_prefill"] == [128, 256]
+    assert overrides["cuda_graph_max_bs_prefill"] == 128
+
+
 def test_nested_disabled_backend_overrides_a_stage_default() -> None:
     overrides = build_generation_batch_overrides(
         max_running_requests=4,

--- a/tests/unit_test/scheduling/test_prefill_graph_policy.py
+++ b/tests/unit_test/scheduling/test_prefill_graph_policy.py
@@ -35,6 +35,11 @@ def _server_args(
         chunked_prefill_size=chunked_prefill_size,
         max_prefill_tokens=max_prefill_tokens,
         tp_size=1,
+        attn_cp_size=1,
+        dcp_size=1,
+        lora_paths=None,
+        enable_lora=None,
+        moe_a2a_backend="none",
         cuda_graph_config=SimpleNamespace(
             decode=SimpleNamespace(max_bs=4, bs=(1, 2, 4)),
             prefill=SimpleNamespace(
@@ -164,6 +169,77 @@ def test_breakable_rejects_buckets_above_max_prefill_tokens() -> None:
                 chunked_prefill_size=-1,
                 max_prefill_tokens=16384,
             )
+        )
+
+
+@pytest.mark.parametrize(
+    ("incompatibility", "match"),
+    [
+        ({"attn_cp_size": 2}, "attn_cp_size"),
+        ({"dcp_size": 2}, "dcp_size"),
+        ({"lora_paths": ["adapter"]}, "LoRA"),
+        ({"enable_lora": True}, "LoRA"),
+        ({"moe_a2a_backend": "deepep"}, "MoE A2A"),
+    ],
+)
+def test_breakable_rejects_sglang_incompatible_features(
+    incompatibility: dict[str, Any], match: str
+) -> None:
+    server_args = _server_args(
+        prefill_backend="breakable",
+        prefill_bs=(128, 256, 512),
+        prefill_max_bs=512,
+        locked=_PREFILL_BS_LOCKED,
+    )
+    server_args.override("test", **incompatibility)
+
+    with pytest.raises(ValueError, match=match):
+        _validate(server_args)
+
+
+def test_nested_prefill_bs_composes_as_operator_buckets() -> None:
+    overrides = build_generation_batch_overrides(
+        max_running_requests=4,
+        server_args_overrides={
+            "cuda_graph_config": {"prefill": {"backend": "breakable", "bs": [128, 256]}}
+        },
+    )
+
+    assert overrides["cuda_graph_backend_prefill"] == "breakable"
+    assert overrides["cuda_graph_bs_prefill"] == [128, 256]
+    assert overrides["cuda_graph_max_bs_prefill"] == 256
+
+
+def test_nested_prefill_max_bs_composes_as_a_flat_cap() -> None:
+    overrides = build_generation_batch_overrides(
+        max_running_requests=4,
+        server_args_overrides={"cuda_graph_config": {"prefill": {"max_bs": 512}}},
+    )
+
+    assert overrides["cuda_graph_max_bs_prefill"] == 512
+    assert "cuda_graph_bs_prefill" not in overrides
+
+
+def test_nested_disabled_backend_overrides_a_stage_default() -> None:
+    overrides = build_generation_batch_overrides(
+        max_running_requests=4,
+        cuda_graph_backend_prefill="breakable",
+        server_args_overrides={
+            "cuda_graph_config": {"prefill": {"backend": "disabled"}}
+        },
+    )
+
+    assert overrides["cuda_graph_backend_prefill"] == "disabled"
+
+
+def test_conflicting_flat_and_nested_prefill_overrides_are_rejected() -> None:
+    with pytest.raises(ValueError, match="Conflicting"):
+        build_generation_batch_overrides(
+            max_running_requests=4,
+            server_args_overrides={
+                "cuda_graph_bs_prefill": [128],
+                "cuda_graph_config": {"prefill": {"bs": [128, 256]}},
+            },
         )
 
 


### PR DESCRIPTION
Enables SGLang's breakable prefill CUDA graph for Qwen3-ASR, following the Higgs TTS
enablement (#1364). The captured region is the LM transformer body; the audio tower,
multimodal embedding composition, and logits processing stay eager, and composed
embeddings reach the captured body through SGLang's static `input_embeds` slot, so no
omni-side transport layer is needed.

Two seams had to be closed for this model. First, SGLang auto-disables the breakable
backend for multimodal models unless the backend is named explicitly, and an explicitly
named backend also skips SGLang's remaining breakable incompatibility rules, so the
policy layer has to enforce those itself. Second, the prefill graph bypasses
`forward()`, which is where positions get cast to the int32 the per-layer fused
qk-norm-rope kernel (#1447) requires, so the fused hook normalizes the dtype itself.
The position values agree between eager and capture by construction: Qwen3-ASR's mrope
rows are degenerate, so the runner's plain positions equal `forward()`'s row-0
substitution.

## Changes

- The fused qk-norm-rope hook normalizes positions to int32 before the kernel; the
  captured body skips `forward()`'s cast. Tests assert eager/capture position
  agreement and the kernel's dtype in both shapes.
- The engine builder names `cuda_graph_backend_prefill=breakable` and declares
  `supports_breakable_prefill_cuda_graph = True` (the factory refuses the breakable
  backend for models without the flag).
- The token-bucket ladder is derived after deployment overrides merge, from the
  effective caps: `chunked_prefill_size` (`-1` disables chunking and does not bound),
  `max_prefill_tokens`, `cuda_graph_max_bs_prefill`, `max_total_tokens`, and the
  resolved `context_length`. Lowering any cap shortens the ladder with it; an explicit
  bucket list is left untouched.
- The shared validator enforces the breakable incompatibility rules the explicit
  backend naming makes SGLang skip: attention CP, decode CP, LoRA, and MoE A2A.
- Partial nested `cuda_graph_config` prefill overrides (SGLang's highest-precedence
  form) are mirrored into the flat fields the composition reads, so nested `bs`
  without `max_bs` or the inverse can no longer resolve into a mismatch; conflicting
  flat and nested values are rejected.
- Disable per deployment with
  `server_args_overrides.cuda_graph_backend_prefill: disabled`.

## Benchmark

H100, full pinned SeedTTS EN (1088 clips), measured repeats after a discarded warmup,
arms back-to-back on the same GPU, baseline is main at `c6980be8c`. torch.compile is
enabled in both arms; main auto-resolves prefill graphs to disabled, the candidate
attests breakable graphs.

| Concurrency | Main req/s | BCG req/s | Throughput |
|---:|---:|---:|---:|
| 8 | 83.034 | 93.503 | +12.61% |
| 16 | 144.221 | 163.904 | +13.65% |
| 32 | 239.07 | 279.47 | +16.90% |
| 64 | 313.95 | 358.31 | +14.13% |

- At c8/c16: p95 latency 116.5 ms -> 106.2 ms and 133.4 ms -> 117.2 ms, mean RTF
  0.02086 -> 0.01852 and 0.02403 -> 0.02114, RTFx 393.26x -> 442.84x and
  683.04x -> 776.27x, per-request prefill profile 9.795 ms -> 5.051 ms and
  11.109 ms -> 5.989 ms.
- Corpus WER 0.0123335 and normalized-EN CER 0.0036427 in both arms, equal in every
  repeat; 6,528/6,528 requests succeeded per arm.
- Exact returned-transcript comparison at c1: 200/200 identical between eager and BCG.
- All 50 buckets from 4 through 4096 tokens capture and attest; prefill capture costs
  3.31 s and 0.59 GB. MPS DP2 attests all 50 buckets on both replicas.
