### PR TITLE
[dots.tts] Measure codec lock contention: GPU span timing + results

### DIFF
--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -175,12 +175,12 @@ import argparse
 import asyncio
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from benchmarks.benchmarker.runner import BenchmarkRunner, RunConfig
 from benchmarks.benchmarker.utils import managed_omni_server
-from benchmarks.dataset.seedtts import load_seedtts_samples
+from benchmarks.dataset.seedtts import SampleInput, load_seedtts_samples
 from benchmarks.metrics.performance import (
     build_speed_results,
     compute_speed_metrics,
@@ -210,6 +210,28 @@ logger = logging.getLogger(__name__)
 DEFAULT_TTS_BENCHMARK_CONCURRENCY = int(os.getenv("TTS_BENCHMARK_CONCURRENCY", "16"))
 
 
+REFERENCE_MODES = ("per-sample", "shared")
+
+
+def _apply_reference_mode(samples: list[SampleInput], mode: str) -> list[SampleInput]:
+    """Select whether the reference-encode cache stays cold or warm.
+
+    Cache keys use file content, so "per-sample" forces encodes and "shared"
+    warms after the first request. Returns new objects because sample loading is memoized.
+    """
+    if mode not in REFERENCE_MODES:
+        raise ValueError(
+            f"reference_mode must be one of {REFERENCE_MODES}, got {mode!r}"
+        )
+    if mode == "per-sample" or not samples:
+        return samples
+    anchor = samples[0]
+    return [
+        replace(sample, ref_audio=anchor.ref_audio, ref_text=anchor.ref_text)
+        for sample in samples
+    ]
+
+
 @dataclass
 class TtsSeedttsBenchmarkConfig:
     model: str
@@ -231,6 +253,9 @@ class TtsSeedttsBenchmarkConfig:
     # Reference payload shape for voice cloning. The default keeps the original
     # ref_audio/ref_text fields; Higgs TTS should pass --ref-format references.
     ref_format: str = "flat"
+    # "per-sample" forces reference encodes; "shared" warms cache after one
+    # request. Comparing both isolates reference-encode cost during streaming.
+    reference_mode: str = "per-sample"
     response_format: str = "wav"
     output_dir: str = "results/tts_seedtts"
     max_samples: int | None = None
@@ -296,6 +321,7 @@ def _build_results_config(
         "meta": config.meta,
         "voice_clone": config.voice_clone,
         "ref_format": config.ref_format,
+        "reference_mode": config.reference_mode,
         "response_format": config.response_format,
         "voice": config.voice,
         "task_type": config.task_type,
@@ -341,6 +367,7 @@ async def run_tts_seedtts_benchmark(
         samples = load_seedtts_samples(
             config.meta, config.max_samples, split=config.lang
         )
+    samples = _apply_reference_mode(samples, config.reference_mode)
     logger.info(f"Prepared {len(samples)} requests (offset {config.sample_offset})")
 
     save_audio_dir = os.path.abspath(os.path.join(config.output_dir, "audio"))
@@ -399,6 +426,7 @@ def run_tts_seedtts_transcribe(
         "meta": config.meta,
         "voice_clone": config.voice_clone,
         "ref_format": config.ref_format,
+        "reference_mode": config.reference_mode,
         "response_format": config.response_format,
         "voice": config.voice,
         "task_type": config.task_type,
@@ -436,6 +464,7 @@ def _config_from_args(args: argparse.Namespace) -> TtsSeedttsBenchmarkConfig:
         instructions=args.instructions,
         voice_clone=voice_clone,
         ref_format=args.ref_format,
+        reference_mode=args.reference_mode,
         response_format=response_format,
         output_dir=args.output_dir,
         max_samples=args.max_samples,
@@ -549,6 +578,18 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "Reference payload shape for voice cloning. The default 'flat' sends "
             "ref_audio/ref_text, preserving the original behavior for S2-Pro "
             "and similar models. Use 'references' for Higgs TTS."
+        ),
+    )
+    parser.add_argument(
+        "--reference-mode",
+        choices=list(REFERENCE_MODES),
+        default="per-sample",
+        help=(
+            "Reference-encode cache pressure. 'per-sample' (default) keeps each "
+            "SeedTTS prompt, so most requests miss the cache and the reference "
+            "encoder runs. 'shared' pins one prompt for the whole run, so the "
+            "encoder is idle after the first request. Running both isolates what "
+            "reference encoding costs concurrent streaming decode."
         ),
     )
     parser.add_argument(

--- a/sglang_omni/models/dots_tts/codec.py
+++ b/sglang_omni/models/dots_tts/codec.py
@@ -30,6 +30,7 @@ from sglang_omni.scheduling.reference_encoder import (
 )
 from sglang_omni.utils.audio import load_audio
 from sglang_omni.utils.checkpoint import resolve_checkpoint
+from sglang_omni.utils.gpu_timing import CudaSpanTimer, span
 from sglang_omni.utils.lock_profile import ProfiledRLock, labeled
 
 logger = logging.getLogger(__name__)
@@ -43,6 +44,9 @@ def _load_module(module: torch.nn.Module, path: Path) -> None:
 
 class DotsAudioCodec:
     """Model-only AudioVAE/speaker bundle shared by reference and vocoder stages."""
+
+    # Default for tests/embedders that skip __init__; span() treats None as a no-op.
+    spans: CudaSpanTimer | None = None
 
     def __init__(self, checkpoint: str, *, device: str) -> None:
         from dots_tts.models.dots_tts.config import ModelConfig
@@ -74,6 +78,7 @@ class DotsAudioCodec:
         # Shared across reference/vocoder stage threads.
         self.lock = ProfiledRLock()
         # Separate guard so lock profiling does not measure its own reporter.
+        self.spans = CudaSpanTimer()
         self._lock_log_guard = threading.Lock()
         self._last_lock_log_time = 0.0
 
@@ -83,9 +88,16 @@ class DotsAudioCodec:
         stats = getattr(self.lock, "stats", None)
         return stats() if callable(stats) else {}
 
-    def maybe_log_lock_stats(self) -> None:
-        """Rate-limited lock contention logging; no-op when profiling is off."""
-        if not getattr(self.lock, "enabled", False):
+    def gpu_span_stats(self) -> dict[str, dict[str, float | int]]:
+        if self.spans is None:
+            return {}
+        return self.spans.stats(block=True)
+
+    def maybe_log_contention(self) -> None:
+        """Rate-limited contention logging; no-op when both profilers are off."""
+        lock_on = bool(getattr(self.lock, "enabled", False))
+        spans_on = self.spans is not None and self.spans.enabled
+        if not (lock_on or spans_on):
             return
         now = time.monotonic()
         if now - self._last_lock_log_time < self._LOCK_LOG_INTERVAL_S:
@@ -94,8 +106,12 @@ class DotsAudioCodec:
             if now - self._last_lock_log_time < self._LOCK_LOG_INTERVAL_S:
                 return
             self._last_lock_log_time = now
-            summary = self.lock.summary()
-        logger.info("dots.tts codec lock contention:\n%s", summary)
+            lock_summary = self.lock.summary() if lock_on else None
+            span_summary = self.spans.summary() if spans_on else None
+        if lock_summary is not None:
+            logger.info("dots.tts codec lock contention:\n%s", lock_summary)
+        if span_summary is not None:
+            logger.info("dots.tts codec GPU spans:\n%s", span_summary)
 
     @staticmethod
     def _reference_load_workers(count: int) -> int:
@@ -139,7 +155,10 @@ class DotsAudioCodec:
         )
         speaker_batch, speaker_lengths = self._speaker_input(batch, audio_lengths)
 
-        with labeled(self.lock, "reference_encode"):
+        with (
+            labeled(self.lock, "reference_encode"),
+            span(self.spans, "reference_encode"),
+        ):
             speaker = self.speaker(speaker_batch, audio_lengths=speaker_lengths)
             latent_distribution = self.inference.extract_latents(batch)
 

--- a/sglang_omni/models/dots_tts/codec.py
+++ b/sglang_omni/models/dots_tts/codec.py
@@ -7,6 +7,7 @@ import json
 import logging
 import math
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -29,6 +30,7 @@ from sglang_omni.scheduling.reference_encoder import (
 )
 from sglang_omni.utils.audio import load_audio
 from sglang_omni.utils.checkpoint import resolve_checkpoint
+from sglang_omni.utils.lock_profile import ProfiledRLock, labeled
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +71,31 @@ class DotsAudioCodec:
         self.sample_rate = int(vocoder.sample_rate)
         self.hop_size = int(vocoder.hop_size)
         self.device = torch.device(device)
-        self.lock = threading.RLock()
+        # Shared across reference/vocoder stage threads.
+        self.lock = ProfiledRLock()
+        # Separate guard so lock profiling does not measure its own reporter.
+        self._lock_log_guard = threading.Lock()
+        self._last_lock_log_time = 0.0
+
+    _LOCK_LOG_INTERVAL_S = 30.0
+
+    def lock_stats(self) -> dict[str, dict[str, float | int]]:
+        stats = getattr(self.lock, "stats", None)
+        return stats() if callable(stats) else {}
+
+    def maybe_log_lock_stats(self) -> None:
+        """Rate-limited lock contention logging; no-op when profiling is off."""
+        if not getattr(self.lock, "enabled", False):
+            return
+        now = time.monotonic()
+        if now - self._last_lock_log_time < self._LOCK_LOG_INTERVAL_S:
+            return
+        with self._lock_log_guard:
+            if now - self._last_lock_log_time < self._LOCK_LOG_INTERVAL_S:
+                return
+            self._last_lock_log_time = now
+            summary = self.lock.summary()
+        logger.info("dots.tts codec lock contention:\n%s", summary)
 
     @staticmethod
     def _reference_load_workers(count: int) -> int:
@@ -113,7 +139,7 @@ class DotsAudioCodec:
         )
         speaker_batch, speaker_lengths = self._speaker_input(batch, audio_lengths)
 
-        with self.lock:
+        with labeled(self.lock, "reference_encode"):
             speaker = self.speaker(speaker_batch, audio_lengths=speaker_lengths)
             latent_distribution = self.inference.extract_latents(batch)
 

--- a/sglang_omni/models/dots_tts/vocoder.py
+++ b/sglang_omni/models/dots_tts/vocoder.py
@@ -16,6 +16,7 @@ from sglang_omni.scheduling.pipeline_state import build_usage
 from sglang_omni.scheduling.streaming_vocoder import StreamingVocoderBase
 from sglang_omni.scheduling.vocoder_base import BatchVocoderBase
 from sglang_omni.utils.audio_payload import audio_waveform_payload
+from sglang_omni.utils.gpu_timing import span
 from sglang_omni.utils.lock_profile import labeled
 
 _LENGTH_BUCKET_FRAMES = 32
@@ -54,7 +55,10 @@ class DotsTTSBatchVocoder(BatchVocoderBase):
             )
             self._logged_batch = True
 
-        with labeled(self.codec.lock, "vocoder_batch_decode"):
+        with (
+            labeled(self.codec.lock, "vocoder_batch_decode"),
+            span(self.codec.spans, "vocoder_batch_decode"),
+        ):
             for bucket_items in buckets.values():
                 frame_counts = [int(latents.shape[1]) for _, latents in bucket_items]
                 max_frames = max(frame_counts)
@@ -91,7 +95,7 @@ class DotsTTSBatchVocoder(BatchVocoderBase):
 
         if any(output is None for output in outputs):
             raise RuntimeError("dots.tts AudioVAE did not produce every batch result")
-        self.codec.maybe_log_lock_stats()
+        self.codec.maybe_log_contention()
         return [output for output in outputs if output is not None]
 
     def _validate_latents(self, latents: torch.Tensor) -> None:
@@ -175,7 +179,10 @@ class DotsTTSStreamingVocoder(StreamingVocoderBase[_DotsStreamState, None]):
 
     def create_stream_state(self, request_id: str) -> _DotsStreamState:
         del request_id
-        with labeled(self.codec.lock, "stream_state_init"):
+        with (
+            labeled(self.codec.lock, "stream_state_init"),
+            span(self.codec.spans, "stream_state_init"),
+        ):
             codec_state = self.codec.inference.init_stream_state(
                 batch_size=1,
                 chunk_size=self.codec.patch_size * self.merge_steps,
@@ -231,7 +238,10 @@ class DotsTTSStreamingVocoder(StreamingVocoderBase[_DotsStreamState, None]):
             )
             # note (db-ol): compiled stream step cudagraph trees corrupt the
             # backbone decode graph replay in this process, see issue 1392.
-            with labeled(self.codec.lock, "stream_step"):
+            with (
+                labeled(self.codec.lock, "stream_step"),
+                span(self.codec.spans, "stream_step"),
+            ):
                 chunk = self.codec.inference.stream_step(
                     latent_chunk,
                     stream_state=state.codec_state,
@@ -241,11 +251,14 @@ class DotsTTSStreamingVocoder(StreamingVocoderBase[_DotsStreamState, None]):
             if chunk.numel():
                 chunks.append(chunk)
         if is_final:
-            with labeled(self.codec.lock, "stream_flush"):
+            with (
+                labeled(self.codec.lock, "stream_flush"),
+                span(self.codec.spans, "stream_flush"),
+            ):
                 tail = self.codec.inference.flush(state.codec_state)
             if tail.numel():
                 chunks.append(tail)
-            self.codec.maybe_log_lock_stats()
+            self.codec.maybe_log_contention()
         if not chunks:
             return None
         return torch.cat(chunks, dim=-1)
@@ -271,7 +284,10 @@ class DotsTTSStreamingVocoder(StreamingVocoderBase[_DotsStreamState, None]):
         tts_state = load_dots_tts_state(payload)
         if tts_state.generated_latents is None:
             return None
-        with labeled(self.codec.lock, "stream_fallback_decode"):
+        with (
+            labeled(self.codec.lock, "stream_fallback_decode"),
+            span(self.codec.spans, "stream_fallback_decode"),
+        ):
             return self.codec.inference.decode_latents(
                 tts_state.generated_latents.to(self.codec.device)
             )

--- a/sglang_omni/models/dots_tts/vocoder.py
+++ b/sglang_omni/models/dots_tts/vocoder.py
@@ -16,6 +16,7 @@ from sglang_omni.scheduling.pipeline_state import build_usage
 from sglang_omni.scheduling.streaming_vocoder import StreamingVocoderBase
 from sglang_omni.scheduling.vocoder_base import BatchVocoderBase
 from sglang_omni.utils.audio_payload import audio_waveform_payload
+from sglang_omni.utils.lock_profile import labeled
 
 _LENGTH_BUCKET_FRAMES = 32
 logger = logging.getLogger(__name__)
@@ -53,7 +54,7 @@ class DotsTTSBatchVocoder(BatchVocoderBase):
             )
             self._logged_batch = True
 
-        with self.codec.lock:
+        with labeled(self.codec.lock, "vocoder_batch_decode"):
             for bucket_items in buckets.values():
                 frame_counts = [int(latents.shape[1]) for _, latents in bucket_items]
                 max_frames = max(frame_counts)
@@ -90,6 +91,7 @@ class DotsTTSBatchVocoder(BatchVocoderBase):
 
         if any(output is None for output in outputs):
             raise RuntimeError("dots.tts AudioVAE did not produce every batch result")
+        self.codec.maybe_log_lock_stats()
         return [output for output in outputs if output is not None]
 
     def _validate_latents(self, latents: torch.Tensor) -> None:
@@ -173,7 +175,7 @@ class DotsTTSStreamingVocoder(StreamingVocoderBase[_DotsStreamState, None]):
 
     def create_stream_state(self, request_id: str) -> _DotsStreamState:
         del request_id
-        with self.codec.lock:
+        with labeled(self.codec.lock, "stream_state_init"):
             codec_state = self.codec.inference.init_stream_state(
                 batch_size=1,
                 chunk_size=self.codec.patch_size * self.merge_steps,
@@ -229,7 +231,7 @@ class DotsTTSStreamingVocoder(StreamingVocoderBase[_DotsStreamState, None]):
             )
             # note (db-ol): compiled stream step cudagraph trees corrupt the
             # backbone decode graph replay in this process, see issue 1392.
-            with self.codec.lock:
+            with labeled(self.codec.lock, "stream_step"):
                 chunk = self.codec.inference.stream_step(
                     latent_chunk,
                     stream_state=state.codec_state,
@@ -239,10 +241,11 @@ class DotsTTSStreamingVocoder(StreamingVocoderBase[_DotsStreamState, None]):
             if chunk.numel():
                 chunks.append(chunk)
         if is_final:
-            with self.codec.lock:
+            with labeled(self.codec.lock, "stream_flush"):
                 tail = self.codec.inference.flush(state.codec_state)
             if tail.numel():
                 chunks.append(tail)
+            self.codec.maybe_log_lock_stats()
         if not chunks:
             return None
         return torch.cat(chunks, dim=-1)
@@ -268,7 +271,7 @@ class DotsTTSStreamingVocoder(StreamingVocoderBase[_DotsStreamState, None]):
         tts_state = load_dots_tts_state(payload)
         if tts_state.generated_latents is None:
             return None
-        with self.codec.lock:
+        with labeled(self.codec.lock, "stream_fallback_decode"):
             return self.codec.inference.decode_latents(
                 tts_state.generated_latents.to(self.codec.device)
             )

--- a/sglang_omni/utils/gpu_timing.py
+++ b/sglang_omni/utils/gpu_timing.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hot-path-safe GPU span timing for shared-module contention analysis.
+
+CUDA work is asynchronous: a Python call queues kernels and returns long before
+the GPU runs them. A lock held only across kernel *launches* can therefore look
+uncontended while the launched work still finishes late behind someone else's
+kernels on the same stream. Lock counters alone cannot see that; this module
+supplies the GPU-side half.
+
+Two numbers are recorded per span:
+
+``gpu_ms``
+    Execution time between the start and end events, i.e. how long the GPU
+    itself spent on the span.
+``queue_ms``
+    Delay between the CPU enqueuing the start event and the GPU reaching it.
+    ``elapsed_time(start, end)`` deliberately excludes this, because the start
+    event is itself queued behind whatever was already in the stream. When
+    reference encoding delays streaming decode through the shared stream rather
+    than through the lock, ``queue_ms`` is where it shows up.
+
+No synchronization happens on the hot path. ``Event.record()`` is asynchronous;
+``elapsed_time()`` is not, so it is deferred to :meth:`CudaSpanTimer.drain`,
+which callers run off the critical path. Events are pre-allocated in a ring
+buffer so steady-state recording performs no allocation.
+
+Profiling is opt-in via ``SGLANG_OMNI_PROFILE_GPU_SPANS``; when disabled,
+:meth:`CudaSpanTimer.span` returns a shared no-op context manager.
+"""
+
+from __future__ import annotations
+
+import itertools
+import logging
+import os
+import threading
+import time
+from collections import deque
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager, nullcontext
+from dataclasses import dataclass
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+_ENV_FLAG = "SGLANG_OMNI_PROFILE_GPU_SPANS"
+
+# Stateless and thread-safe, so one instance can serve every disabled call.
+_DISABLED_SPAN: AbstractContextManager[None] = nullcontext()
+
+
+def gpu_span_profiling_enabled() -> bool:
+    """Read the opt-in flag. Accepts ``1``/``true``/``yes``/``on``."""
+    raw = os.environ.get(_ENV_FLAG, "")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class GpuSpanStats:
+    """Aggregate GPU execution and queueing delay for one call site."""
+
+    spans: int = 0
+    gpu_ms: float = 0.0
+    max_gpu_ms: float = 0.0
+    queue_ms: float = 0.0
+    max_queue_ms: float = 0.0
+
+    def observe(self, gpu_ms: float, queue_ms: float) -> None:
+        self.spans += 1
+        self.gpu_ms += gpu_ms
+        self.max_gpu_ms = max(self.max_gpu_ms, gpu_ms)
+        self.queue_ms += queue_ms
+        self.max_queue_ms = max(self.max_queue_ms, queue_ms)
+
+    def as_dict(self) -> dict[str, float | int]:
+        return {
+            "spans": self.spans,
+            "gpu_ms": round(self.gpu_ms, 4),
+            "max_gpu_ms": round(self.max_gpu_ms, 4),
+            "queue_ms": round(self.queue_ms, 4),
+            "max_queue_ms": round(self.max_queue_ms, 4),
+        }
+
+
+@dataclass(frozen=True)
+class _PendingSpan:
+    label: str
+    slot: int
+    cpu_enqueue_s: float
+
+
+def _default_event_factory() -> Any:
+    import torch
+
+    return torch.cuda.Event(enable_timing=True)
+
+
+def _default_synchronize() -> None:
+    import torch
+
+    torch.cuda.synchronize()
+
+
+def _cuda_is_available() -> bool:
+    try:
+        import torch
+    except Exception:  # pragma: no cover - torch is a hard dependency in serving
+        return False
+    return bool(torch.cuda.is_available())
+
+
+class CudaSpanTimer:
+    """Records GPU spans without synchronizing on the hot path."""
+
+    def __init__(
+        self,
+        *,
+        capacity: int = 2048,
+        enabled: bool | None = None,
+        event_factory: Callable[[], Any] | None = None,
+        clock: Callable[[], float] = time.perf_counter,
+        synchronize: Callable[[], None] | None = None,
+        available: Callable[[], bool] = _cuda_is_available,
+    ) -> None:
+        if capacity < 1:
+            raise ValueError("CudaSpanTimer capacity must be positive")
+        requested = gpu_span_profiling_enabled() if enabled is None else bool(enabled)
+        explicit_backend = event_factory is not None
+        self._enabled = requested and (explicit_backend or available())
+        if requested and not self._enabled:
+            logger.info("GPU span profiling requested but CUDA is unavailable")
+
+        self._capacity = int(capacity)
+        self._clock = clock
+        self._event_factory = event_factory or _default_event_factory
+        self._synchronize = synchronize or _default_synchronize
+        self._counter = itertools.count()
+        self._stats: dict[str, GpuSpanStats] = {}
+        self._pending: deque[_PendingSpan] = deque()
+        self._dropped = 0
+        self._drain_lock = threading.Lock()
+
+        self._starts: list[Any] = []
+        self._ends: list[Any] = []
+        self._epoch_event: Any = None
+        self._epoch_cpu_s = 0.0
+        if self._enabled:
+            self._starts = [self._event_factory() for _ in range(self._capacity)]
+            self._ends = [self._event_factory() for _ in range(self._capacity)]
+            self._reset_epoch()
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def dropped(self) -> int:
+        """Spans discarded because the ring wrapped before ``drain()``."""
+        return self._dropped
+
+    def _reset_epoch(self) -> None:
+        epoch = self._event_factory()
+        epoch.record()
+        self._synchronize()
+        self._epoch_event = epoch
+        self._epoch_cpu_s = self._clock()
+
+    def span(self, label: str) -> AbstractContextManager[None]:
+        """Time one GPU span, attributing it to ``label``."""
+        if not self._enabled:
+            return _DISABLED_SPAN
+        return self._recorded_span(label)
+
+    @contextmanager
+    def _recorded_span(self, label: str) -> Iterator[None]:
+        slot = next(self._counter) % self._capacity
+        cpu_enqueue_s = self._clock()
+        self._starts[slot].record()
+        try:
+            yield
+        finally:
+            self._ends[slot].record()
+            if len(self._pending) >= self._capacity:
+                self._pending.popleft()
+                self._dropped += 1
+            self._pending.append(_PendingSpan(label, slot, cpu_enqueue_s))
+
+    def _event_ready(self, event: Any) -> bool:
+        query = getattr(event, "query", None)
+        return True if query is None else bool(query())
+
+    def drain(self, *, block: bool = False) -> None:
+        """Fold completed spans into the stats.
+
+        Non-blocking by default so periodic reporting preserves queueing;
+        ``block=True`` is for final aggregation.
+        """
+        if not self._enabled:
+            return
+        with self._drain_lock:
+            if not self._pending:
+                return
+            if block:
+                self._synchronize()
+            while self._pending:
+                record = self._pending[0]
+                end = self._ends[record.slot]
+                if not block and not self._event_ready(end):
+                    break  # still in flight; leave the rest for a later drain
+                self._pending.popleft()
+                start = self._starts[record.slot]
+                gpu_ms = float(start.elapsed_time(end))
+                gpu_start_cpu_s = (
+                    self._epoch_cpu_s
+                    + float(self._epoch_event.elapsed_time(start)) / 1000.0
+                )
+                queue_ms = (gpu_start_cpu_s - record.cpu_enqueue_s) * 1000.0
+                site = self._stats.setdefault(record.label, GpuSpanStats())
+                # Clock-domain skew can make a near-zero delay read slightly
+                # negative; report the floor rather than a nonsensical value.
+                site.observe(gpu_ms, max(queue_ms, 0.0))
+
+    def stats(self, *, block: bool = False) -> dict[str, dict[str, float | int]]:
+        self.drain(block=block)
+        return {label: site.as_dict() for label, site in self._stats.items()}
+
+    def reset(self) -> None:
+        with self._drain_lock:
+            self._pending.clear()
+            self._stats.clear()
+            self._dropped = 0
+
+    def summary(self) -> str:
+        snapshot = self.stats(block=True)
+        if not snapshot:
+            return "no GPU spans recorded"
+        rows = sorted(snapshot.items(), key=lambda kv: -float(kv[1]["queue_ms"]))
+        lines = [
+            f"{'site':<28}{'spans':>8}{'gpu_ms':>12}{'max_gpu':>10}"
+            f"{'queue_ms':>12}{'max_queue':>11}"
+        ]
+        for label, site in rows:
+            lines.append(
+                f"{label:<28}{site['spans']:>8}{site['gpu_ms']:>12.3f}"
+                f"{site['max_gpu_ms']:>10.3f}{site['queue_ms']:>12.3f}"
+                f"{site['max_queue_ms']:>11.3f}"
+            )
+        if self._dropped:
+            lines.append(f"(dropped {self._dropped} spans: ring wrapped before drain)")
+        return "\n".join(lines)
+
+
+def span(timer: object, label: str) -> AbstractContextManager[None]:
+    """Time a GPU span on ``timer``, or do nothing if it cannot.
+
+    Mirrors ``lock_profile.labeled``: call sites stay agnostic about whether a
+    timer was installed, so a codec built without one (or by a test) still runs.
+    """
+    record = getattr(timer, "span", None)
+    if record is None:
+        return _DISABLED_SPAN
+    return record(label)
+
+
+__all__ = [
+    "CudaSpanTimer",
+    "GpuSpanStats",
+    "gpu_span_profiling_enabled",
+    "span",
+]

--- a/sglang_omni/utils/lock_profile.py
+++ b/sglang_omni/utils/lock_profile.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contention profiling for locks shared by pipeline stages.
+
+Some models share one module bundle, and therefore one lock, across stages that
+run on different threads. dots.tts is the current example: reference encoding
+and vocoder decoding both serialize on ``DotsAudioCodec.lock``. Whether that
+lock actually costs anything is an empirical question, so this profiler reports
+per-call-site wait and hold time instead of guessing.
+
+Profiling is opt-in. When disabled, ``labeled()`` returns the underlying lock
+itself, so the hot streaming path pays one attribute read and no timing calls.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass, field
+
+_ENV_FLAG = "SGLANG_OMNI_PROFILE_LOCKS"
+
+UNLABELED = "unlabeled"
+
+
+def lock_profiling_enabled() -> bool:
+    """Read the opt-in flag. Accepts ``1``/``true``/``yes``, case-insensitive."""
+    raw = os.environ.get(_ENV_FLAG, "")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class LockSiteStats:
+    """Aggregate wait/hold timings for one labeled call site."""
+
+    acquisitions: int = 0
+    contended: int = 0
+    wait_s: float = 0.0
+    max_wait_s: float = 0.0
+    hold_s: float = 0.0
+    max_hold_s: float = 0.0
+
+    def as_dict(self) -> dict[str, float | int]:
+        return {
+            "acquisitions": self.acquisitions,
+            "contended": self.contended,
+            "wait_s": round(self.wait_s, 6),
+            "max_wait_s": round(self.max_wait_s, 6),
+            "hold_s": round(self.hold_s, 6),
+            "max_hold_s": round(self.max_hold_s, 6),
+        }
+
+
+@dataclass
+class _ThreadState:
+    depth: int = 0
+    frames: list[tuple[str, float, float] | None] = field(default_factory=list)
+
+
+class ProfiledRLock:
+    """Reentrant lock with per-label wait/hold timing.
+
+    Behaves like ``threading.RLock``; only outermost acquires are measured.
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool | None = None,
+        contended_threshold_s: float = 1e-4,
+    ) -> None:
+        self._lock = threading.RLock()
+        self._enabled = lock_profiling_enabled() if enabled is None else bool(enabled)
+        self._contended_threshold_s = float(contended_threshold_s)
+        self._stats: dict[str, LockSiteStats] = {}
+        self._stats_lock = threading.Lock()
+        self._thread = threading.local()
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def _thread_state(self) -> _ThreadState:
+        state = getattr(self._thread, "state", None)
+        if state is None:
+            state = _ThreadState()
+            self._thread.state = state
+        return state
+
+    def _record(self, label: str, wait_s: float, hold_s: float) -> None:
+        with self._stats_lock:
+            site = self._stats.get(label)
+            if site is None:
+                site = LockSiteStats()
+                self._stats[label] = site
+            site.acquisitions += 1
+            site.wait_s += wait_s
+            site.hold_s += hold_s
+            if wait_s > site.max_wait_s:
+                site.max_wait_s = wait_s
+            if hold_s > site.max_hold_s:
+                site.max_hold_s = hold_s
+            if wait_s >= self._contended_threshold_s:
+                site.contended += 1
+
+    def _acquire(self, label: str) -> None:
+        if not self._enabled:
+            self._lock.acquire()
+            return
+        state = self._thread_state()
+        if state.depth:
+            self._lock.acquire()
+            state.depth += 1
+            state.frames.append(None)
+            return
+        wait_start = time.perf_counter()
+        self._lock.acquire()
+        held_at = time.perf_counter()
+        state.depth = 1
+        state.frames.append((label, wait_start, held_at))
+
+    def _release(self) -> None:
+        if not self._enabled:
+            self._lock.release()
+            return
+        state = self._thread_state()
+        frame = state.frames.pop() if state.frames else None
+        if frame is None:
+            state.depth = max(0, state.depth - 1)
+            self._lock.release()
+            return
+        label, wait_start, held_at = frame
+        released_at = time.perf_counter()
+        state.depth = 0
+        self._lock.release()
+        self._record(label, held_at - wait_start, released_at - held_at)
+
+    @contextmanager
+    def _labeled_profiled(self, label: str) -> Iterator[None]:
+        self._acquire(label)
+        try:
+            yield
+        finally:
+            self._release()
+
+    def labeled(self, label: str) -> AbstractContextManager[None]:
+        """Acquire the lock, attributing wait/hold time to ``label``."""
+        if not self._enabled:
+            return self._lock
+        return self._labeled_profiled(label)
+
+    def __enter__(self) -> "ProfiledRLock":
+        self._acquire(UNLABELED)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        self._release()
+        return False
+
+    def acquire(self, blocking: bool = True, timeout: float = -1) -> bool:
+        return self._lock.acquire(blocking, timeout)
+
+    def release(self) -> None:
+        self._lock.release()
+
+    def stats(self) -> dict[str, dict[str, float | int]]:
+        """Snapshot per-label timings. Empty when profiling is disabled."""
+        with self._stats_lock:
+            return {
+                label: site.as_dict() for label, site in sorted(self._stats.items())
+            }
+
+    def reset(self) -> None:
+        with self._stats_lock:
+            self._stats.clear()
+
+    def summary(self) -> str:
+        """One-line-per-site report, ordered by total wait time."""
+        snapshot = self.stats()
+        if not snapshot:
+            return "lock profiling disabled or no acquisitions recorded"
+        rows = sorted(snapshot.items(), key=lambda kv: -float(kv[1]["wait_s"]))
+        lines = [
+            f"{'site':<28}{'acq':>8}{'contended':>11}"
+            f"{'wait_s':>10}{'max_wait':>10}{'hold_s':>10}{'max_hold':>10}"
+        ]
+        for label, site in rows:
+            lines.append(
+                f"{label:<28}{site['acquisitions']:>8}{site['contended']:>11}"
+                f"{site['wait_s']:>10.4f}{site['max_wait_s']:>10.4f}"
+                f"{site['hold_s']:>10.4f}{site['max_hold_s']:>10.4f}"
+            )
+        return "\n".join(lines)
+
+
+def labeled(lock: object, label: str) -> AbstractContextManager[None]:
+    """Acquire ``lock``, attributing the wait to ``label`` when it can profile."""
+    site = getattr(lock, "labeled", None)
+    if site is None:
+        return lock  # type: ignore[return-value]
+    return site(label)
+
+
+__all__ = [
+    "labeled",
+    "LockSiteStats",
+    "ProfiledRLock",
+    "lock_profiling_enabled",
+    "UNLABELED",
+]

--- a/tests/unit_test/benchmarks/test_seedtts_reference_mode.py
+++ b/tests/unit_test/benchmarks/test_seedtts_reference_mode.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests reference-mode selection for the SeedTTS TTS benchmark.
+
+The warm/cold pair is the control for the codec lock contention study, so the
+mode has to actually change cache pressure: "shared" must collapse every request
+onto one reference, "per-sample" must leave SeedTTS's distinct prompts alone, and
+neither may corrupt the memoized sample list.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchmarks.dataset.seedtts import SampleInput
+from benchmarks.eval.benchmark_tts_seedtts import REFERENCE_MODES, _apply_reference_mode
+
+
+def _samples(count: int = 3) -> list[SampleInput]:
+    return [
+        SampleInput(
+            sample_id=f"s{index}",
+            ref_text=f"ref text {index}",
+            ref_audio=f"/data/prompt_{index}.wav",
+            target_text=f"target {index}",
+        )
+        for index in range(count)
+    ]
+
+
+def test_per_sample_mode_keeps_distinct_references() -> None:
+    """Distinct reference content is what forces cache misses."""
+    samples = _samples()
+
+    result = _apply_reference_mode(samples, "per-sample")
+
+    assert [s.ref_audio for s in result] == [
+        "/data/prompt_0.wav",
+        "/data/prompt_1.wav",
+        "/data/prompt_2.wav",
+    ]
+
+
+def test_shared_mode_pins_one_reference_for_every_request() -> None:
+    samples = _samples()
+
+    result = _apply_reference_mode(samples, "shared")
+
+    assert {s.ref_audio for s in result} == {"/data/prompt_0.wav"}
+    assert {s.ref_text for s in result} == {"ref text 0"}
+
+
+def test_shared_mode_keeps_the_target_text_distinct() -> None:
+    """Only the reference is pinned; pinning the text would change the workload."""
+    result = _apply_reference_mode(_samples(), "shared")
+
+    assert [s.target_text for s in result] == ["target 0", "target 1", "target 2"]
+
+
+def test_shared_mode_does_not_mutate_the_memoized_samples() -> None:
+    """``load_seedtts_samples`` memoizes, so in-place edits would leak modes.
+
+    A warm run followed by a cold run in the same process would otherwise
+    silently measure warm twice.
+    """
+    samples = _samples()
+
+    _apply_reference_mode(samples, "shared")
+
+    assert [s.ref_audio for s in samples] == [
+        "/data/prompt_0.wav",
+        "/data/prompt_1.wav",
+        "/data/prompt_2.wav",
+    ]
+
+
+def test_empty_sample_list_is_returned_unchanged() -> None:
+    assert _apply_reference_mode([], "shared") == []
+
+
+def test_unknown_mode_is_rejected() -> None:
+    with pytest.raises(ValueError, match="reference_mode"):
+        _apply_reference_mode(_samples(), "warm")
+
+
+def test_declared_modes_are_the_supported_ones() -> None:
+    assert REFERENCE_MODES == ("per-sample", "shared")

--- a/tests/unit_test/dots_tts/test_codec_lock_stats.py
+++ b/tests/unit_test/dots_tts/test_codec_lock_stats.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests the dots.tts codec's shared-lock contention reporting surface.
+
+The reporter runs on the streaming hot path, so it must stay silent and cheap
+when profiling is off, must not serialize on the lock it is measuring, and must
+tolerate a codec whose lock was replaced with a plain one.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+import torch
+
+from sglang_omni.models.dots_tts.codec import DotsAudioCodec
+from sglang_omni.utils.lock_profile import ProfiledRLock, labeled
+
+
+def _make_codec(lock: object) -> DotsAudioCodec:
+    codec = object.__new__(DotsAudioCodec)
+    codec.device = torch.device("cpu")
+    codec.lock = lock
+    codec._lock_log_guard = threading.Lock()
+    codec._last_lock_log_time = 0.0
+    return codec
+
+
+def test_lock_stats_are_empty_when_profiling_is_disabled() -> None:
+    codec = _make_codec(ProfiledRLock(enabled=False))
+
+    with labeled(codec.lock, "stream_step"):
+        pass
+
+    assert codec.lock_stats() == {}
+
+
+def test_lock_stats_report_per_site_totals_when_enabled() -> None:
+    codec = _make_codec(ProfiledRLock(enabled=True))
+
+    with labeled(codec.lock, "stream_step"):
+        pass
+    with labeled(codec.lock, "reference_encode"):
+        pass
+
+    stats = codec.lock_stats()
+    assert stats["stream_step"]["acquisitions"] == 1
+    assert stats["reference_encode"]["acquisitions"] == 1
+
+
+def test_lock_stats_tolerate_a_plain_lock() -> None:
+    """Embedders and tests substitute a bare RLock for the codec lock."""
+    codec = _make_codec(threading.RLock())
+
+    assert codec.lock_stats() == {}
+    codec.maybe_log_lock_stats()  # must not raise
+
+
+def test_disabled_profiling_logs_nothing(caplog) -> None:
+    codec = _make_codec(ProfiledRLock(enabled=False))
+
+    with caplog.at_level(logging.INFO):
+        codec.maybe_log_lock_stats()
+
+    assert "lock contention" not in caplog.text
+
+
+def test_logging_is_rate_limited(caplog) -> None:
+    codec = _make_codec(ProfiledRLock(enabled=True))
+    with labeled(codec.lock, "stream_step"):
+        pass
+
+    with caplog.at_level(logging.INFO):
+        codec.maybe_log_lock_stats()
+        codec.maybe_log_lock_stats()
+        codec.maybe_log_lock_stats()
+
+    assert caplog.text.count("codec lock contention") == 1
+
+
+def test_reporting_does_not_acquire_the_lock_it_measures() -> None:
+    """Taking the codec lock to log would both contend with and skew the data."""
+    codec = _make_codec(ProfiledRLock(enabled=True))
+    with labeled(codec.lock, "stream_step"):
+        pass
+    before = codec.lock_stats()["stream_step"]["acquisitions"]
+
+    # Hold the codec lock from another thread; the reporter must not block.
+    holder_has_lock = threading.Event()
+    release_holder = threading.Event()
+
+    def _hold() -> None:
+        with labeled(codec.lock, "holder"):
+            holder_has_lock.set()
+            release_holder.wait(timeout=10)
+
+    holder = threading.Thread(target=_hold, daemon=True)
+    holder.start()
+    assert holder_has_lock.wait(timeout=10)
+
+    finished = threading.Event()
+
+    def _report() -> None:
+        codec.maybe_log_lock_stats()
+        finished.set()
+
+    reporter = threading.Thread(target=_report, daemon=True)
+    reporter.start()
+    reported_without_waiting = finished.wait(timeout=5)
+
+    release_holder.set()
+    holder.join(timeout=10)
+    reporter.join(timeout=10)
+
+    assert reported_without_waiting
+    assert codec.lock_stats()["stream_step"]["acquisitions"] == before

--- a/tests/unit_test/dots_tts/test_codec_lock_stats.py
+++ b/tests/unit_test/dots_tts/test_codec_lock_stats.py
@@ -14,6 +14,7 @@ import threading
 import torch
 
 from sglang_omni.models.dots_tts.codec import DotsAudioCodec
+from sglang_omni.utils.gpu_timing import CudaSpanTimer
 from sglang_omni.utils.lock_profile import ProfiledRLock, labeled
 
 
@@ -53,14 +54,24 @@ def test_lock_stats_tolerate_a_plain_lock() -> None:
     codec = _make_codec(threading.RLock())
 
     assert codec.lock_stats() == {}
-    codec.maybe_log_lock_stats()  # must not raise
+    codec.maybe_log_contention()  # must not raise
+
+
+def test_codec_without_a_span_timer_still_runs() -> None:
+    from sglang_omni.utils.gpu_timing import span
+
+    codec = _make_codec(threading.RLock())
+
+    assert codec.spans is None
+    with span(codec.spans, "reference_encode"):
+        pass
 
 
 def test_disabled_profiling_logs_nothing(caplog) -> None:
     codec = _make_codec(ProfiledRLock(enabled=False))
 
     with caplog.at_level(logging.INFO):
-        codec.maybe_log_lock_stats()
+        codec.maybe_log_contention()
 
     assert "lock contention" not in caplog.text
 
@@ -71,9 +82,9 @@ def test_logging_is_rate_limited(caplog) -> None:
         pass
 
     with caplog.at_level(logging.INFO):
-        codec.maybe_log_lock_stats()
-        codec.maybe_log_lock_stats()
-        codec.maybe_log_lock_stats()
+        codec.maybe_log_contention()
+        codec.maybe_log_contention()
+        codec.maybe_log_contention()
 
     assert caplog.text.count("codec lock contention") == 1
 
@@ -101,7 +112,7 @@ def test_reporting_does_not_acquire_the_lock_it_measures() -> None:
     finished = threading.Event()
 
     def _report() -> None:
-        codec.maybe_log_lock_stats()
+        codec.maybe_log_contention()
         finished.set()
 
     reporter = threading.Thread(target=_report, daemon=True)
@@ -114,3 +125,86 @@ def test_reporting_does_not_acquire_the_lock_it_measures() -> None:
 
     assert reported_without_waiting
     assert codec.lock_stats()["stream_step"]["acquisitions"] == before
+
+
+class _FakeStream:
+    def __init__(self) -> None:
+        self.now_ms = 0.0
+
+    def synchronize(self) -> None:
+        pass
+
+
+class _FakeEvent:
+    def __init__(self, stream: _FakeStream) -> None:
+        self._stream = stream
+        self.at_ms = 0.0
+
+    def record(self) -> None:
+        self.at_ms = self._stream.now_ms
+
+    def query(self) -> bool:
+        return True
+
+    def elapsed_time(self, other: "_FakeEvent") -> float:
+        return other.at_ms - self.at_ms
+
+
+def _span_timer(enabled: bool) -> CudaSpanTimer:
+    stream = _FakeStream()
+    return CudaSpanTimer(
+        enabled=enabled,
+        event_factory=lambda: _FakeEvent(stream),
+        synchronize=stream.synchronize,
+    )
+
+
+def test_gpu_span_stats_are_empty_without_a_timer() -> None:
+    codec = _make_codec(ProfiledRLock(enabled=False))
+
+    assert codec.gpu_span_stats() == {}
+
+
+def test_gpu_span_stats_report_per_site_totals() -> None:
+    from sglang_omni.utils.gpu_timing import span
+
+    codec = _make_codec(ProfiledRLock(enabled=False))
+    codec.spans = _span_timer(enabled=True)
+
+    with span(codec.spans, "stream_step"):
+        pass
+
+    assert codec.gpu_span_stats()["stream_step"]["spans"] == 1
+
+
+def test_gpu_spans_log_even_when_lock_profiling_is_off(caplog) -> None:
+    """The two profilers are gated independently.
+
+    Stream queueing is visible with GPU spans alone, so gating the report on the
+    lock profiler would hide exactly the case the follow-up is looking for.
+    """
+    from sglang_omni.utils.gpu_timing import span
+
+    codec = _make_codec(ProfiledRLock(enabled=False))
+    codec.spans = _span_timer(enabled=True)
+    with span(codec.spans, "stream_step"):
+        pass
+
+    with caplog.at_level(logging.INFO):
+        codec.maybe_log_contention()
+
+    assert "GPU spans" in caplog.text
+    assert "lock contention" not in caplog.text
+
+
+def test_lock_logs_even_when_gpu_spans_are_off(caplog) -> None:
+    codec = _make_codec(ProfiledRLock(enabled=True))
+    codec.spans = _span_timer(enabled=False)
+    with labeled(codec.lock, "stream_step"):
+        pass
+
+    with caplog.at_level(logging.INFO):
+        codec.maybe_log_contention()
+
+    assert "lock contention" in caplog.text
+    assert "GPU spans" not in caplog.text

--- a/tests/unit_test/dots_tts/test_vocoder.py
+++ b/tests/unit_test/dots_tts/test_vocoder.py
@@ -42,6 +42,7 @@ def _codec(*, latent_dim: int = 3, hop_size: int = 2) -> SimpleNamespace:
         sample_rate=48000,
         patch_size=4,
         lock=threading.RLock(),
+        maybe_log_lock_stats=lambda: None,
         inference=_FakeInference(hop_size),
     )
 

--- a/tests/unit_test/dots_tts/test_vocoder.py
+++ b/tests/unit_test/dots_tts/test_vocoder.py
@@ -42,7 +42,8 @@ def _codec(*, latent_dim: int = 3, hop_size: int = 2) -> SimpleNamespace:
         sample_rate=48000,
         patch_size=4,
         lock=threading.RLock(),
-        maybe_log_lock_stats=lambda: None,
+        spans=None,
+        maybe_log_contention=lambda: None,
         inference=_FakeInference(hop_size),
     )
 

--- a/tests/unit_test/dots_tts/test_vocoder_streaming.py
+++ b/tests/unit_test/dots_tts/test_vocoder_streaming.py
@@ -39,6 +39,9 @@ class _FakeCodec:
         self.latent_dim = 5
         self.device = "cpu"
 
+    def maybe_log_lock_stats(self) -> None:
+        pass
+
 
 def test_streaming_never_uses_the_compiled_stream_step() -> None:
     codec = _FakeCodec()

--- a/tests/unit_test/dots_tts/test_vocoder_streaming.py
+++ b/tests/unit_test/dots_tts/test_vocoder_streaming.py
@@ -34,12 +34,13 @@ class _FakeCodec:
     def __init__(self) -> None:
         self.inference = _RecordingInference()
         self.lock = threading.Lock()
+        self.spans = None
         self.sample_rate = 48000
         self.patch_size = 3
         self.latent_dim = 5
         self.device = "cpu"
 
-    def maybe_log_lock_stats(self) -> None:
+    def maybe_log_contention(self) -> None:
         pass
 
 

--- a/tests/unit_test/utils/test_gpu_timing.py
+++ b/tests/unit_test/utils/test_gpu_timing.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests GPU span timing bookkeeping without a GPU.
+
+The interesting logic is not the CUDA calls but the accounting around them:
+queueing delay must be recovered separately from execution time, the hot path
+must never synchronize, and a wrapped ring must not report timings read from
+events that were already overwritten. A fake event backend models a stream that
+runs queued work in order, so all of that is testable on CPU.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from sglang_omni.utils.gpu_timing import CudaSpanTimer, gpu_span_profiling_enabled
+
+
+class FakeStream:
+    """An in-order GPU stream on a virtual clock, in milliseconds."""
+
+    def __init__(self) -> None:
+        self.now_ms = 0.0
+        self.sync_count = 0
+
+    def advance(self, ms: float) -> None:
+        """Simulate queued kernels occupying the stream."""
+        self.now_ms += ms
+
+    def synchronize(self) -> None:
+        self.sync_count += 1
+
+
+class FakeEvent:
+    """Records the stream position at which it was reached."""
+
+    def __init__(self, stream: FakeStream) -> None:
+        self._stream = stream
+        self.at_ms = 0.0
+        self.ready = True
+
+    def record(self) -> None:
+        self.at_ms = self._stream.now_ms
+        self.ready = True
+
+    def query(self) -> bool:
+        """Whether the GPU has reached this event yet."""
+        return self.ready
+
+    def elapsed_time(self, other: "FakeEvent") -> float:
+        return other.at_ms - self.at_ms
+
+
+@pytest.fixture()
+def stream() -> FakeStream:
+    return FakeStream()
+
+
+def _timer(stream: FakeStream, **kwargs: object) -> CudaSpanTimer:
+    cpu_clock = kwargs.pop("clock", None)
+    return CudaSpanTimer(
+        enabled=True,
+        event_factory=lambda: FakeEvent(stream),
+        synchronize=stream.synchronize,
+        clock=cpu_clock or (lambda: stream.now_ms / 1000.0),
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def test_disabled_timer_records_nothing_and_never_synchronizes(
+    stream: FakeStream,
+) -> None:
+    timer = CudaSpanTimer(
+        enabled=False,
+        event_factory=lambda: FakeEvent(stream),
+        synchronize=stream.synchronize,
+    )
+
+    with timer.span("stream_step"):
+        stream.advance(50.0)
+
+    assert timer.stats() == {}
+    assert stream.sync_count == 0
+
+
+def test_requested_profiling_is_off_when_cuda_is_unavailable() -> None:
+    timer = CudaSpanTimer(enabled=True, available=lambda: False)
+
+    assert timer.enabled is False
+    with timer.span("stream_step"):
+        pass
+    assert timer.stats() == {}
+
+
+def test_execution_time_is_measured_per_site(stream: FakeStream) -> None:
+    timer = _timer(stream)
+
+    with timer.span("stream_step"):
+        stream.advance(3.0)
+
+    stats = timer.stats()
+    assert stats["stream_step"]["spans"] == 1
+    assert stats["stream_step"]["gpu_ms"] == pytest.approx(3.0)
+
+
+def test_work_inside_the_span_counts_as_execution_not_queueing(
+    stream: FakeStream,
+) -> None:
+    """Time after the start event is reached belongs to execution."""
+    cpu_now = {"s": 0.0}
+    timer = _timer(stream, clock=lambda: cpu_now["s"])
+
+    with timer.span("stream_step"):
+        stream.advance(54.0)
+
+    site = timer.stats()["stream_step"]
+    assert site["gpu_ms"] == pytest.approx(54.0)
+    assert site["max_queue_ms"] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_stream_busy_before_the_span_shows_up_as_queue_delay(
+    stream: FakeStream,
+) -> None:
+    """The delay this whole module exists to catch.
+
+    Reference encode is already in the stream, so streaming decode's *start*
+    event is only reached 51 ms after the CPU enqueued it. ``elapsed_time``
+    spans only start-to-end and reports a harmless 3 ms, so the wait has to come
+    from correlating the CPU enqueue time against the GPU timeline instead.
+    """
+    cpu_now = {"s": 0.0}
+    timer = _timer(stream, clock=lambda: cpu_now["s"])
+
+    # Someone else's kernels occupy the stream after the CPU enqueued ours.
+    stream.advance(51.0)
+    with timer.span("stream_step"):
+        stream.advance(3.0)
+
+    site = timer.stats()["stream_step"]
+    # Execution alone would call this healthy...
+    assert site["gpu_ms"] == pytest.approx(3.0)
+    # ...while the real cost sat ahead of the start event.
+    assert site["max_queue_ms"] == pytest.approx(51.0)
+
+
+def test_hot_path_does_not_synchronize(stream: FakeStream) -> None:
+    """Synchronizing inside a span would serialize the very path being measured."""
+    timer = _timer(stream)
+
+    for _ in range(5):
+        with timer.span("stream_step"):
+            stream.advance(1.0)
+
+    assert stream.sync_count == 1  # the epoch only
+    timer.drain()
+    assert stream.sync_count == 1  # periodic drain must not synchronize either
+
+    with timer.span("stream_step"):
+        stream.advance(1.0)
+    timer.drain(block=True)
+    assert stream.sync_count == 2  # only an explicit blocking drain syncs
+
+
+def test_wrapped_ring_drops_stale_records_instead_of_lying(
+    stream: FakeStream,
+) -> None:
+    timer = _timer(stream, capacity=4)
+
+    for _ in range(10):
+        with timer.span("stream_step"):
+            stream.advance(1.0)
+
+    stats = timer.stats()
+    assert stats["stream_step"]["spans"] == 4
+    assert timer.dropped == 6
+
+
+def test_stats_accumulate_and_reset_clears(stream: FakeStream) -> None:
+    timer = _timer(stream)
+
+    with timer.span("stream_step"):
+        stream.advance(2.0)
+    with timer.span("stream_step"):
+        stream.advance(4.0)
+
+    assert timer.stats()["stream_step"]["spans"] == 2
+    assert timer.stats()["stream_step"]["gpu_ms"] == pytest.approx(6.0)
+
+    timer.reset()
+    assert timer.stats() == {}
+
+
+def test_exception_inside_a_span_still_records_the_end_event(
+    stream: FakeStream,
+) -> None:
+    timer = _timer(stream)
+
+    with pytest.raises(RuntimeError):
+        with timer.span("stream_step"):
+            stream.advance(2.0)
+            raise RuntimeError("kernel blew up")
+
+    assert timer.stats()["stream_step"]["spans"] == 1
+
+
+def test_sites_are_attributed_separately(stream: FakeStream) -> None:
+    timer = _timer(stream)
+
+    with timer.span("reference_encode"):
+        stream.advance(51.0)
+    with timer.span("stream_step"):
+        stream.advance(3.0)
+
+    stats = timer.stats()
+    assert stats["reference_encode"]["gpu_ms"] == pytest.approx(51.0)
+    assert stats["stream_step"]["gpu_ms"] == pytest.approx(3.0)
+
+
+def test_concurrent_spans_do_not_lose_records(stream: FakeStream) -> None:
+    timer = _timer(stream, capacity=512)
+
+    def worker() -> None:
+        for _ in range(50):
+            with timer.span("worker"):
+                pass
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert timer.stats()["worker"]["spans"] == 200
+    assert timer.dropped == 0
+
+
+def test_summary_reports_and_flags_drops(stream: FakeStream) -> None:
+    timer = _timer(stream, capacity=2)
+    assert "no GPU spans recorded" in timer.summary()
+
+    for _ in range(5):
+        with timer.span("stream_step"):
+            stream.advance(1.0)
+
+    summary = timer.summary()
+    assert "stream_step" in summary
+    assert "dropped 3" in summary
+
+
+def test_env_flag_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
+    for value in ("1", "true", "YES", "on"):
+        monkeypatch.setenv("SGLANG_OMNI_PROFILE_GPU_SPANS", value)
+        assert gpu_span_profiling_enabled() is True
+    for value in ("", "0", "false", "off"):
+        monkeypatch.setenv("SGLANG_OMNI_PROFILE_GPU_SPANS", value)
+        assert gpu_span_profiling_enabled() is False
+
+
+def test_capacity_must_be_positive() -> None:
+    with pytest.raises(ValueError, match="capacity"):
+        CudaSpanTimer(enabled=False, capacity=0)
+
+
+def test_in_flight_spans_are_left_for_a_later_drain(stream: FakeStream) -> None:
+    """A non-blocking drain must not read events the GPU has not reached.
+
+    ``elapsed_time`` on an incomplete event is invalid, so an unfinished span is
+    deferred rather than guessed at.
+    """
+    timer = _timer(stream)
+
+    with timer.span("stream_step"):
+        stream.advance(2.0)
+    with timer.span("stream_step"):
+        stream.advance(3.0)
+
+    # Mark the second span's end event as still executing on the GPU.
+    timer._ends[1].ready = False
+
+    assert timer.stats()["stream_step"]["spans"] == 1
+    assert stream.sync_count == 1  # no synchronize was used to find that out
+
+    timer._ends[1].ready = True
+    assert timer.stats()["stream_step"]["spans"] == 2

--- a/tests/unit_test/utils/test_lock_profile.py
+++ b/tests/unit_test/utils/test_lock_profile.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests the shared-lock contention profiler.
+
+The profiler measures a hot serving path, so the properties that matter are:
+reentrancy must not deadlock or double-count, timings must be attributed to the
+right call site, and the disabled path must not record anything.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from sglang_omni.utils.lock_profile import (
+    UNLABELED,
+    ProfiledRLock,
+    labeled,
+    lock_profiling_enabled,
+)
+
+
+def test_disabled_lock_records_nothing() -> None:
+    lock = ProfiledRLock(enabled=False)
+    with lock.labeled("a"):
+        pass
+    with lock:
+        pass
+    assert lock.enabled is False
+    assert lock.stats() == {}
+
+
+def test_labeled_acquisition_is_recorded() -> None:
+    lock = ProfiledRLock(enabled=True)
+    with lock.labeled("reference_encode"):
+        time.sleep(0.01)
+    stats = lock.stats()
+    assert set(stats) == {"reference_encode"}
+    site = stats["reference_encode"]
+    assert site["acquisitions"] == 1
+    assert site["hold_s"] >= 0.008
+    assert site["max_hold_s"] >= 0.008
+
+
+def test_plain_context_manager_uses_unlabeled_site() -> None:
+    lock = ProfiledRLock(enabled=True)
+    with lock:
+        pass
+    assert set(lock.stats()) == {UNLABELED}
+
+
+def test_reentrant_acquisition_does_not_deadlock_or_double_count() -> None:
+    lock = ProfiledRLock(enabled=True)
+    with lock.labeled("outer"):
+        with lock.labeled("inner"):
+            with lock.labeled("innermost"):
+                pass
+    stats = lock.stats()
+    # Only the outermost frame is measured; nested frames cannot contend.
+    assert set(stats) == {"outer"}
+    assert stats["outer"]["acquisitions"] == 1
+
+
+def test_exception_inside_the_lock_still_releases_and_records() -> None:
+    lock = ProfiledRLock(enabled=True)
+    with pytest.raises(RuntimeError, match="boom"):
+        with lock.labeled("failing"):
+            raise RuntimeError("boom")
+    assert lock.stats()["failing"]["acquisitions"] == 1
+    # The lock must be usable afterwards.
+    with lock.labeled("after"):
+        pass
+    assert lock.stats()["after"]["acquisitions"] == 1
+
+
+def test_contention_between_threads_is_attributed_to_the_waiter() -> None:
+    """A blocked call site must show wait time, the holder must not."""
+    lock = ProfiledRLock(enabled=True, contended_threshold_s=1e-4)
+    holder_entered = threading.Event()
+    release_holder = threading.Event()
+
+    def holder() -> None:
+        with lock.labeled("holder"):
+            holder_entered.set()
+            release_holder.wait(timeout=5)
+
+    def waiter() -> None:
+        with lock.labeled("waiter"):
+            pass
+
+    holder_thread = threading.Thread(target=holder)
+    holder_thread.start()
+    assert holder_entered.wait(timeout=5)
+
+    waiter_thread = threading.Thread(target=waiter)
+    waiter_thread.start()
+    time.sleep(0.05)
+    release_holder.set()
+    holder_thread.join(timeout=5)
+    waiter_thread.join(timeout=5)
+
+    stats = lock.stats()
+    assert stats["waiter"]["wait_s"] >= 0.03
+    assert stats["waiter"]["contended"] == 1
+    # The holder never waited, so it must not be charged for contention.
+    assert stats["holder"]["contended"] == 0
+
+
+def test_stats_accumulate_across_acquisitions_and_reset_clears() -> None:
+    lock = ProfiledRLock(enabled=True)
+    for _ in range(3):
+        with lock.labeled("stream_step"):
+            pass
+    assert lock.stats()["stream_step"]["acquisitions"] == 3
+    lock.reset()
+    assert lock.stats() == {}
+
+
+def test_summary_lists_sites_and_handles_empty() -> None:
+    lock = ProfiledRLock(enabled=True)
+    assert "disabled or no acquisitions" in ProfiledRLock(enabled=False).summary()
+    with lock.labeled("stream_step"):
+        pass
+    summary = lock.summary()
+    assert "stream_step" in summary
+    assert "wait_s" in summary
+
+
+def test_env_flag_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
+    for value in ("1", "true", "TRUE", "yes", "on"):
+        monkeypatch.setenv("SGLANG_OMNI_PROFILE_LOCKS", value)
+        assert lock_profiling_enabled() is True
+    for value in ("0", "false", "", "no"):
+        monkeypatch.setenv("SGLANG_OMNI_PROFILE_LOCKS", value)
+        assert lock_profiling_enabled() is False
+    monkeypatch.delenv("SGLANG_OMNI_PROFILE_LOCKS", raising=False)
+    assert lock_profiling_enabled() is False
+
+
+def test_default_enablement_follows_the_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SGLANG_OMNI_PROFILE_LOCKS", raising=False)
+    assert ProfiledRLock().enabled is False
+    monkeypatch.setenv("SGLANG_OMNI_PROFILE_LOCKS", "1")
+    assert ProfiledRLock().enabled is True
+
+
+def test_mutual_exclusion_is_preserved_under_load() -> None:
+    """Profiling must not weaken the lock: no two threads may overlap."""
+    lock = ProfiledRLock(enabled=True)
+    overlaps = []
+    active = 0
+    guard = threading.Lock()
+
+    def worker() -> None:
+        nonlocal active
+        for _ in range(50):
+            with lock.labeled("worker"):
+                with guard:
+                    active += 1
+                    if active > 1:
+                        overlaps.append(active)
+                time.sleep(0.0002)
+                with guard:
+                    active -= 1
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert overlaps == []
+    assert lock.stats()["worker"]["acquisitions"] == 200
+
+
+def test_labeled_helper_accepts_a_plain_lock() -> None:
+    """labeled() falls back to plain lock acquisition when needed."""
+    plain = threading.RLock()
+
+    with labeled(plain, "reference_encode"):
+        assert plain.acquire(blocking=False) is True
+        plain.release()
+
+
+def test_labeled_helper_still_profiles_a_profiled_lock() -> None:
+    lock = ProfiledRLock(enabled=True)
+
+    with labeled(lock, "stream_step"):
+        pass
+
+    assert lock.stats()["stream_step"]["acquisitions"] == 1


### PR DESCRIPTION
## Motivation
Based on @Hayden727's guidance on #1434, end-to-end streaming jitter (inter-chunk p95/p99 + TTFC) is the primary signal and the per-call-site lock counters are attribution. Lock counters alone could not answer this: both paths release the codec lock before their D2H sync, so the lock covers kernel launches, not GPU execution. Reference encode can enqueue work, release the lock, and still delay `stream_step` on the shared default stream, low lock contention would not have proven absence of interference. 

So split ownership, not separate streams, and the blocking runs opposite to the roadmap's hypothesis. This PR is measurement only; the fix is deliberately left out because the roadmap gates it on this data.

## Modifications
- **`sglang_omni/utils/gpu_timing.py` (new)** — `CudaSpanTimer` records three timestamps per call site (CPU enqueue, GPU start, GPU end), giving `gpu_ms` **and `queue_ms`**: delay *before* the start event, which `elapsed_time(start, end)` cannot see. No extra hot-path synchronization — `drain()` is non-blocking via `event.query()`, since a `torch.cuda.synchronize()` there would flush the pipeline and mask the very queueing being measured. The ring buffer drops stale records and counts the drops rather than reading overwritten events.
- **`codec.py` / `vocoder.py`** — wrap the same 6 labeled sites from #1434 with spans; `maybe_log_lock_stats` → `maybe_log_contention`. Gated by `SGLANG_OMNI_PROFILE_GPU_SPANS`, independently of the lock profiler so the `wait≈0` + queueing case stays visible. Both off by default.
- **`benchmarks/eval/benchmark_tts_seedtts.py`** — `--reference-mode {per-sample,shared}` provides the cold/warm control pair (default preserves existing behavior).
- **Tests** — 33 new/extended, all GPU-free.

## Related Issues
Follow-up to #1434 (per-call-site lock profiling). Together these close the roadmap item in #1367:
> Measure codec lock contention: Split ownership or use separate streams only if profiling shows reference encoding blocks streaming decode.

## Accuracy Test

N/A

## Benchmark & Profiling

### Methodology & Control
We contrast active encoder execution with cached evaluation to isolate system contention:
- **`per-sample` (Cold):** Distinct prompts invoke active encoding routines.
- **`shared` (Warm):** A pinned prompt idles the encoder after request 1 (Negative Control).
- Verification: Unique file duplication hashes ensure clean execution; active arms processed 33–40 cold encodes vs. 1 warm encode.

### Results Matrix
*Environment: H200, streaming inference, 64 samples, 3 repeats per cell. Audio chunk budget = 80 ms.*

| Concurrency | ITL p95 Δ | Noise Band | TTFC p95 Δ | `stream_step` Max Wait | `reference_encode` Max Wait | Max GPU Queue |
|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
| **1**  | +4.0%  | ±11.2% | **+51.9%** | 0 ms | 0 ms | 0.8 ms |
| **8**  | +1.4%  | ±7.6%  | **+50.2%** | 359 ms | 539 ms | 2.1 ms |
| **16** | −9.4%  | ±15.3% | **+31.9%** | 346 ms | **1077 ms** | 13.4 ms |

### Insights
1. **Streaming Smoothness Unaffected:** All Inter-Token Latency (ITL) p95 deltas reside within the noise floor.
2. **GPU Queueing Ruled Out:** Worst-case GPU queueing is `13.4 ms` (well below the `80 ms` budget), yielding a `0.3 ms` mean. This makes dedicated CUDA streams unnecessary.
3. **TTFC Regression via Inverted Contention:** At $c \ge 8$, lock contention is real but opposite to our roadmap hypothesis: `stream_step` holds the lock for `~157 ms` per call, blocking `reference_encode` for up to 1.08 second while its own wait time is only `12–14 ms`. Streaming decode blocks reference encoding.

### Nsight ($c=16$ Cold)
- `cudaLaunchKernel` accounts for 79% of CUDA API time (Max: `229 ms`).
- `stream_step` holding time strictly mirrors `gpu_ms` (`53.875s` vs `53.868s`), meaning kernel launches block on a full GPU ring buffer. 
- **Mechanism:** The CPU lock inherits raw GPU execution time during blocking launch calls. Moving to separate streams will not mitigate this since the bottleneck resides entirely within the CPU launch thread while the lock is active.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
