### PR TITLE
[CI] Confine unit-test and setup work to the runner lane cpuset

### DIFF
--- a/.claude/skills/tune-ci-thresholds/AGENT-PRECHECK.md
+++ b/.claude/skills/tune-ci-thresholds/AGENT-PRECHECK.md
@@ -28,11 +28,13 @@ writing reports.
 
 - Export `TUNE_HOST`, `TUNE_REPO_ROOT`, `TUNE_VENV_PYTHON`, `TUNE_GPU_INCLUDE`,
   and `TUNE_GPU_EXCLUDE` explicitly.
-- Every two-GPU calibration group must be pinned to exactly 32 logical cores
-  (16 physical plus their HT siblings), matching the runner-side bundle for
-  that lane (`0,1` → `0-15,64-79`, `2,3` → `16-31,80-95`, `4,5` →
-  `48-63,112-127`, `6,7` → `32-47,96-111`). `tune.py` resolves this from
-  `hosts/*/gpu_group_cpusets` when `TUNE_GPU_INCLUDE` is set.
+- Every two-GPU calibration group must be pinned to its NUMA-local lane
+  bundle, matching the runner-side .env for that lane (`0,1` → `2-15,66-79`,
+  `2,3` → `16-31,80-95`, `4,5` → `48-63,112-127`, `6,7` → `32-47,96-111`).
+  `tune.py` resolves this from `hosts/*/gpu_group_cpusets` when
+  `TUNE_GPU_INCLUDE` is set. Lane `0,1` deliberately excludes cores
+  `0,1,64,65`: those are the system cores where host daemons (categraf,
+  dockerd) are confined; including them measures daemon noise, not the model.
 - Inside a two-GPU container the picked ids are always `0,1`, so the host
   table cannot resolve the physical lane; export `OMNI_CI_CPUSET` with the
   borrowed lane's cores explicitly.

--- a/.claude/skills/tune-ci-thresholds/AGENT-PRECHECK.md
+++ b/.claude/skills/tune-ci-thresholds/AGENT-PRECHECK.md
@@ -35,6 +35,10 @@ writing reports.
   `TUNE_GPU_INCLUDE` is set. Lane `0,1` deliberately excludes cores
   `0,1,64,65`: those are the system cores where host daemons (categraf,
   dockerd) are confined; including them measures daemon noise, not the model.
+- Calibrations that write thresholds must anchor on the `0,1` lane: its
+  28-core bundle is the conservative baseline for every lane. A threshold
+  calibrated on a 32-core lane can be too aggressive when a CI job lands on
+  `0,1`; use the 32-core lanes for measurement-only runs.
 - Inside a two-GPU container the picked ids are always `0,1`, so the host
   table cannot resolve the physical lane; export `OMNI_CI_CPUSET` with the
   borrowed lane's cores explicitly.

--- a/.claude/skills/tune-ci-thresholds/hosts/sglang-h100-ci.yaml
+++ b/.claude/skills/tune-ci-thresholds/hosts/sglang-h100-ci.yaml
@@ -20,14 +20,12 @@ venv_python: /github/home/calibration/omni/bin/python
 # On 8× H100 shared hosts, GPU 6–7 run CI continuously — never pick or kill them.
 gpu_exclude: [6, 7]
 
-# note (Jiaxin Deng): each CI runner lane owns two GPUs and exactly 32
-# logical cores (16 physical + HT siblings). Keep in sync with the
-# production runner .env partition. Calibration must pin the same bundle:
-# TUNE_GPU_INCLUDE=0,1 → OMNI_CI_CPUSET=0-15,64-79, etc. PR CI does not
-# need to know its lane; calibration does, because it chooses the GPUs.
-# precheck refuses a busy cpuset rather than measuring under intrusion.
+# note (Jiaxin Deng): lane bundles must match the runner-side .env; precheck
+# refuses a busy cpuset rather than measuring under intrusion. Lane 0,1
+# excludes system cores 0,1,64,65 (categraf/dockerd confined there), so its
+# 28-core thresholds are conservative for the 32-core lanes.
 gpu_group_cpusets:
-  "0,1": "0-15,64-79"
+  "0,1": "2-15,66-79"
   "2,3": "16-31,80-95"
   "4,5": "48-63,112-127"
   "6,7": "32-47,96-111"

--- a/.github/actions/omni-setup/action.yaml
+++ b/.github/actions/omni-setup/action.yaml
@@ -40,6 +40,7 @@ runs:
       env:
         VENV_NAME: ${{ inputs.venv-name }}
       run: |
+        source .github/scripts/pin_to_ci_cpuset.sh
         HOST="${OMNI_CI_HOME}/${VENV_NAME}"
         if [ -d "${HOST}" ] && [ -n "$(ls -A "${HOST}/")" ]; then
           rm -rf "./${VENV_NAME}"

--- a/.github/scripts/cleanup_ci_pr_home.sh
+++ b/.github/scripts/cleanup_ci_pr_home.sh
@@ -6,6 +6,8 @@
 # and for ephemeral workflow_dispatch run-* homes—not after every PR CI run.
 set -euo pipefail
 
+source "$(dirname "${BASH_SOURCE[0]}")/pin_to_ci_cpuset.sh"
+
 if [ "$#" -ne 1 ]; then
   echo "usage: $0 <ci-home>" >&2
   exit 1

--- a/.github/scripts/ensure_hf_models.sh
+++ b/.github/scripts/ensure_hf_models.sh
@@ -9,6 +9,8 @@
 #   3. Validate the resulting snapshot; fail setup if weights are incomplete.
 set -euo pipefail
 
+source "$(dirname "${BASH_SOURCE[0]}")/pin_to_ci_cpuset.sh"
+
 if [ "$#" -lt 2 ]; then
   echo "usage: $0 <venv-name> <hf-repo-id> [<hf-repo-id> ...]" >&2
   exit 1

--- a/.github/scripts/pin_to_ci_cpuset.sh
+++ b/.github/scripts/pin_to_ci_cpuset.sh
@@ -1,0 +1,18 @@
+# Pin the sourcing shell (and children) to the runner lane's OMNI_CI_CPUSET;
+# no-op when unset (forks, local runs).
+# note (Jiaxin Deng): docker container options cannot read the runner-local
+# .env value, so the reachable layer is the script shell, not --cpuset-cpus.
+if [ -n "${OMNI_CI_CPUSET:-}" ]; then
+  if ! taskset -pc "${OMNI_CI_CPUSET}" $$ > /dev/null; then
+    echo "::error::failed to pin to OMNI_CI_CPUSET='${OMNI_CI_CPUSET}'"
+    exit 2
+  fi
+  # note (Jiaxin Deng): readback catches the kernel silently narrowing the
+  # mask (e.g. offline CPUs in the lane spec), mirroring the perf fixture.
+  _pin_effective="$(taskset -pc $$ | awk '{print $NF}')"
+  if [ "${_pin_effective}" != "${OMNI_CI_CPUSET}" ]; then
+    echo "::error::pinned mask '${_pin_effective}' != requested OMNI_CI_CPUSET='${OMNI_CI_CPUSET}'"
+    exit 2
+  fi
+  unset _pin_effective
+fi

--- a/.github/scripts/reconcile_omni_ci_env.sh
+++ b/.github/scripts/reconcile_omni_ci_env.sh
@@ -4,6 +4,8 @@
 # Always exits 0 only when validate_omni_env_reusable passes.
 set -euo pipefail
 
+source "$(dirname "${BASH_SOURCE[0]}")/pin_to_ci_cpuset.sh"
+
 if [ "$#" -ne 1 ]; then
   echo "usage: $0 <venv-name>" >&2
   exit 1

--- a/.github/scripts/run_flaky_pytest.sh
+++ b/.github/scripts/run_flaky_pytest.sh
@@ -2,6 +2,8 @@
 
 set -uo pipefail
 
+source "$(dirname "${BASH_SOURCE[0]}")/pin_to_ci_cpuset.sh"
+
 max_attempts="${OMNI_CI_MAX_ATTEMPTS:-3}"
 retry_delay_seconds="${OMNI_CI_RETRY_DELAY_SECONDS:-10}"
 stage_label="${OMNI_CI_STAGE_LABEL:-${GITHUB_JOB:-pytest stage}}"

--- a/.github/scripts/validate_omni_env_reusable.sh
+++ b/.github/scripts/validate_omni_env_reusable.sh
@@ -7,6 +7,8 @@
 # Does not require .omni-env-complete (downstream jobs use this gate; setup writes marker).
 set -euo pipefail
 
+source "$(dirname "${BASH_SOURCE[0]}")/pin_to_ci_cpuset.sh"
+
 if [ "$#" -ne 1 ]; then
   echo "usage: $0 <venv-name>" >&2
   exit 1

--- a/.github/workflows/cleanup-pr-ci-home-on-close.yaml
+++ b/.github/workflows/cleanup-pr-ci-home-on-close.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
     container:
       image: hongccc/sglang-omni@sha256:374d0b1c30b2bff685b1716fc64a02ad3b3d0a90fe2ce73ce9861a6992c28101
-      options: --rm -e NVIDIA_VISIBLE_DEVICES -v /dev/shm:/dev/shm -v /data/omni-ci:/data/omni-ci
+      options: --rm -e NVIDIA_VISIBLE_DEVICES -e OMNI_CI_CPUSET -v /dev/shm:/dev/shm -v /data/omni-ci:/data/omni-ci
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/omni-ci.yaml
+++ b/.github/workflows/omni-ci.yaml
@@ -236,6 +236,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
         -v /data/cache/huggingface:/github/home/.cache/huggingface
@@ -413,6 +414,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
         -v /data/cache/huggingface:/github/home/.cache/huggingface

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,7 @@ jobs:
       options: >-
         --rm
         -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
         -v /data/cache/huggingface:/github/home/.cache/huggingface


### PR DESCRIPTION
## Motivation

OMNI_CI_CPUSET pinning covers only the perf test processes (conftest fixture). The unit-test pytest, dependency install, env validation, model download, and cleanup steps still run with full machine affinity. Measured on the CI host today: the unit-test pytest of a concurrent omni-ci run averaged 7.2 cores and floated onto the lane freed for calibration, which kept tripping the calibration contention gate. The same mechanism pollutes neighboring perf lanes (the foreign peaks seen in #1379).

## Modifications

* New `.github/scripts/pin_to_ci_cpuset.sh`: sourced at the entry of the CPU-heavy CI scripts, pins the script shell to `OMNI_CI_CPUSET` via taskset, children inherit. Validates the effective mask by readback, fails the step on a bad or narrowed value, no-op when unset.
* Self-pin `run_flaky_pytest.sh`, `reconcile_omni_ci_env.sh`, `validate_omni_env_reusable.sh`, `ensure_hf_models.sh`, `cleanup_ci_pr_home.sh`, and the omni-setup restore step. Covers every call site, including the perf workflows' setup phases which already pass the variable.
* Pass `-e OMNI_CI_CPUSET` into the four job containers that were missing it (unit-test, setup, cleanup, close-cleanup), same passthrough as the perf workflows.
* Calibration skill lane table: GPU `0,1` now maps to `2-15,66-79`. Cores `0,1,64,65` become system cores where host daemons (categraf, dockerd) are confined, so neither calibration nor CI measures daemon noise.

## Runner-side changes (deployed on the CI host, disclosed here)

* All four `run-ci.sh` now self-pin the runner tree (listener, worker, docker CLI) to the lane cpuset; live trees pinned in place.
* `actions-runner-h100-4/.env` updated to `OMNI_CI_CPUSET=2-15,66-79`; autoscaler lane table matched.
* systemd drop-ins confine categraf and dockerd to the system cores (containerd deliberately untouched: container processes inherit its mask via shim spawn).

## Scope

TTS stage 5 (`tests/test_ci`, MPS DP2) stays unpinned as before: its thresholds were calibrated without a cpuset, so confining it must land together with a recalibration. Follow-up. `actions/checkout` inside the job container cannot be pinned from the repo side; the runner-tree pin bounds the rest.

## Evidence

* Simulated the pinned step shape in the CI image: worker shell, python child, and grandchild all confined to the requested cpuset; unset means no-op with full affinity; a bad value and a kernel-narrowed mask fail loudly (exit 2).
* Live affinity readout of this PR's own CI on the runner to follow in a comment.