### PR TITLE
[Perf] Qwen3-TTS: cut per-step host work in the AR decode loop

### DIFF
--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -958,14 +958,15 @@ class ModelRunner:
             return
         vocab = logits.shape[1]
         device = logits.device
-        # Note: (Jiaxin Deng) suppress lists are static per request; caching the
-        # filtered device tensor by list identity makes every decode step after
-        # a request's first a cache hit instead of a rebuild.
+        # Note: (Jiaxin Deng) the suppress set comes from model config, so keying
+        # by content collapses the whole fleet onto one device tensor; the key
+        # itself is derived once per request because the builder hands out a
+        # fresh list object each time.
         cache = getattr(self, "_suppress_tensor_cache", None)
         if cache is None:
             cache = {}
             self._suppress_tensor_cache = cache
-        row_groups: dict[int, tuple[torch.Tensor, list[int]]] = {}
+        row_groups: dict[Any, tuple[torch.Tensor, list[int]]] = {}
         for row_idx, sched_req in enumerate(requests):
             data = sched_req.data
             suppress_tokens = data.suppress_tokens
@@ -977,25 +978,25 @@ class ModelRunner:
                     suppress_tokens = None
             if not suppress_tokens:
                 continue
-            key = (id(suppress_tokens), vocab, str(device))
-            hit = cache.get(key)
-            if hit is not None and hit[0] is suppress_tokens:
-                toks_t = hit[1]
-            else:
-                toks = [int(t) for t in suppress_tokens if 0 <= int(t) < vocab]
+            content = getattr(data, "_suppress_content", None)
+            if content is None:
+                content = tuple(int(t) for t in suppress_tokens)
+                data._suppress_content = content
+            key = (content, vocab, str(device))
+            toks_t = cache.get(key)
+            if key not in cache:
+                toks = [t for t in content if 0 <= t < vocab]
                 toks_t = (
                     torch.tensor(toks, dtype=torch.long, device=device)
                     if toks
                     else None
                 )
-                if len(cache) >= 64:
-                    cache.clear()
-                cache[key] = (suppress_tokens, toks_t)
+                cache[key] = toks_t
             if toks_t is None:
                 continue
-            group = row_groups.get(id(suppress_tokens))
+            group = row_groups.get(key)
             if group is None:
-                row_groups[id(suppress_tokens)] = (toks_t, [row_idx])
+                row_groups[key] = (toks_t, [row_idx])
             else:
                 group[1].append(row_idx)
         for toks_t, rows in row_groups.values():

--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -930,6 +930,12 @@ class ModelRunner:
                 continue
             output_ids = req.output_ids
             if not output_ids:
+                # Note: (Jiaxin Deng) a retract can replace output_ids with an
+                # empty list; drop the incremental state so a restart does not
+                # inherit stale tokens.
+                if getattr(data, "_rep_seen_len", 0):
+                    data._rep_seen_tokens = set()
+                    data._rep_seen_len = 0
                 continue
             unique = ModelRunner._rep_penalty_unique_tokens(data, output_ids, vocab)
             if not unique:
@@ -952,9 +958,9 @@ class ModelRunner:
             return
         vocab = logits.shape[1]
         device = logits.device
-        # Note: (Jiaxin Deng) suppress lists are static per request and shared
-        # across a deployment in practice; cache the filtered device tensor per
-        # (list identity, vocab, device) so the decode loop stops rebuilding it.
+        # Note: (Jiaxin Deng) suppress lists are static per request; caching the
+        # filtered device tensor by list identity makes every decode step after
+        # a request's first a cache hit instead of a rebuild.
         cache = getattr(self, "_suppress_tensor_cache", None)
         if cache is None:
             cache = {}

--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -119,6 +119,7 @@ class ModelRunner:
         self._async_query_miss: int = 0
         self._token_id_host_bufs: list[torch.Tensor] | None = None
         self._token_id_host_slot: int = 0
+        self._suppress_tensor_cache: dict[tuple, tuple[Any, torch.Tensor | None]] = {}
 
     def _stage_token_ids(self, result: Any, ids: torch.Tensor) -> None:
         # Note (wenyao): pinned host copy staged once at sample time so downstream
@@ -894,6 +895,24 @@ class ModelRunner:
     def _req_is_retracted(req: Any) -> bool:
         return bool(req.is_retracted)
 
+    @staticmethod
+    def _rep_penalty_unique_tokens(data: Any, output_ids: list, vocab: int) -> set:
+        # Note: (Jiaxin Deng) rebuilding unique(output_ids) every decode step is
+        # quadratic over the generation; track the consumed prefix and fold in
+        # only new tokens. A shrunk output_ids (retract/restart) resets the state.
+        seen_len = getattr(data, "_rep_seen_len", 0)
+        seen: set | None = getattr(data, "_rep_seen_tokens", None)
+        if seen is None or len(output_ids) < seen_len:
+            seen = set()
+            seen_len = 0
+        for t in output_ids[seen_len:]:
+            tok = int(t)
+            if 0 <= tok < vocab:
+                seen.add(tok)
+        data._rep_seen_tokens = seen
+        data._rep_seen_len = len(output_ids)
+        return seen
+
     def _apply_repetition_penalty(self, logits_output: Any, requests: list) -> None:
         logits = logits_output.next_token_logits
         if logits is None or logits.ndim != 2:
@@ -912,7 +931,7 @@ class ModelRunner:
             output_ids = req.output_ids
             if not output_ids:
                 continue
-            unique = {int(t) for t in output_ids if 0 <= int(t) < vocab}
+            unique = ModelRunner._rep_penalty_unique_tokens(data, output_ids, vocab)
             if not unique:
                 continue
             rep_rows.extend([row_idx] * len(unique))
@@ -933,8 +952,14 @@ class ModelRunner:
             return
         vocab = logits.shape[1]
         device = logits.device
-        sup_rows: list[int] = []
-        sup_toks: list[int] = []
+        # Note: (Jiaxin Deng) suppress lists are static per request and shared
+        # across a deployment in practice; cache the filtered device tensor per
+        # (list identity, vocab, device) so the decode loop stops rebuilding it.
+        cache = getattr(self, "_suppress_tensor_cache", None)
+        if cache is None:
+            cache = {}
+            self._suppress_tensor_cache = cache
+        row_groups: dict[int, tuple[torch.Tensor, list[int]]] = {}
         for row_idx, sched_req in enumerate(requests):
             data = sched_req.data
             suppress_tokens = data.suppress_tokens
@@ -946,13 +971,30 @@ class ModelRunner:
                     suppress_tokens = None
             if not suppress_tokens:
                 continue
-            for token_id in suppress_tokens:
-                tok = int(token_id)
-                if 0 <= tok < vocab:
-                    sup_rows.append(row_idx)
-                    sup_toks.append(tok)
-        if sup_rows:
-            logits[
-                torch.tensor(sup_rows, dtype=torch.long, device=device),
-                torch.tensor(sup_toks, dtype=torch.long, device=device),
-            ] = float("-inf")
+            key = (id(suppress_tokens), vocab, str(device))
+            hit = cache.get(key)
+            if hit is not None and hit[0] is suppress_tokens:
+                toks_t = hit[1]
+            else:
+                toks = [int(t) for t in suppress_tokens if 0 <= int(t) < vocab]
+                toks_t = (
+                    torch.tensor(toks, dtype=torch.long, device=device)
+                    if toks
+                    else None
+                )
+                if len(cache) >= 64:
+                    cache.clear()
+                cache[key] = (suppress_tokens, toks_t)
+            if toks_t is None:
+                continue
+            group = row_groups.get(id(suppress_tokens))
+            if group is None:
+                row_groups[id(suppress_tokens)] = (toks_t, [row_idx])
+            else:
+                group[1].append(row_idx)
+        for toks_t, rows in row_groups.values():
+            if len(rows) == logits.shape[0]:
+                logits[:, toks_t] = float("-inf")
+            else:
+                rows_t = torch.tensor(rows, dtype=torch.long, device=device)
+                logits[rows_t[:, None], toks_t[None, :]] = float("-inf")

--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -126,6 +126,25 @@ class Qwen3TTSModelRunner(ModelRunner):
             rids.append((rid, epoch))
         return rids
 
+    @staticmethod
+    def _every_row_grew_by_one(requests: list) -> bool:
+        """True when every penalized row's history is exactly one token longer.
+
+        Rows at penalty 1.0 are exempt: their mask bits never reach the logits.
+        """
+        for sched_req in requests:
+            data = sched_req.data
+            req = data.req
+            if float(req.sampling_params.repetition_penalty) == 1.0:
+                continue
+            seen_len = getattr(data, "_rep_seen_len", None)
+            output_ids = req.output_ids
+            if seen_len is None or not output_ids:
+                return False
+            if len(output_ids) != seen_len + 1:
+                return False
+        return True
+
     def _ensure_masks(self, batch_size: int, vocab: int, device: Any) -> None:
         masks = getattr(self, "_shape_masks", None)
         if (
@@ -199,10 +218,13 @@ class Qwen3TTSModelRunner(ModelRunner):
             and fingerprint == getattr(self, "_mask_prep_rids", None)
             and last_sampled is not None
             and last_sampled.shape[0] >= batch_size
+            and self._every_row_grew_by_one(requests)
         ):
-            # Note: (Jiaxin Deng) unchanged batch: the only new information
-            # since the last step is each row's sampled token; one scatter
-            # replaces the full host-side index rebuild.
+            # Note: (Jiaxin Deng) unchanged batch, every history exactly one token
+            # longer: the only new information is each row's sampled token, so one
+            # scatter replaces the full host-side index rebuild. A history that did
+            # not grow by one (retract, restart) can need bits cleared, which the
+            # scatter cannot do, so those steps rebuild.
             if self._mask_rep_active:
                 rows = torch.arange(batch_size, device=logits.device)
                 rep_mask[rows, last_sampled[:batch_size].clamp(0, vocab - 1)] = True

--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -286,6 +286,10 @@ class Qwen3TTSModelRunner(ModelRunner):
             hidden,
             semantic_positions=semantic_positions,
         )
+        # Note: (Jiaxin Deng) stage the ids into pinned host memory now so the
+        # output processor's .tolist() waits on an event instead of issuing a
+        # blocking pageable copy inside the decode loop.
+        self._stage_token_ids(result, result.next_token_ids)
         self._has_pending_code_step = True
 
     def post_process_outputs(

--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -21,6 +21,10 @@ class Qwen3TTSModelRunner(ModelRunner):
         super().__init__(tp_worker, output_processor)
         self._has_pending_code_step = False
         self._row_ids_cache: torch.Tensor | None = None
+        self._mask_last_sampled: torch.Tensor | None = None
+        self._mask_prep_rids: list | None = None
+        self._mask_rep_active = False
+        self._mask_sup_active = False
 
     def before_prefill(
         self,
@@ -95,12 +99,137 @@ class Qwen3TTSModelRunner(ModelRunner):
         requests: list,
     ) -> Any:
         self._install_semantic_sampling_seeds(forward_batch, requests)
-        return super()._sample_next_token_ids(
+        next_token_ids = super()._sample_next_token_ids(
             logits_output,
             forward_batch,
             schedule_batch,
             requests,
         )
+        if isinstance(next_token_ids, torch.Tensor):
+            self._mask_last_sampled = next_token_ids
+        else:
+            self._mask_last_sampled = None
+        return next_token_ids
+
+    # ------------------------------------------------------------------
+    # Mask-based logit shaping (device-resident, replaces the per-step
+    # host index building in the base helpers for this model)
+    # ------------------------------------------------------------------
+
+    def _mask_fingerprint(self, requests: list) -> list | None:
+        rids = []
+        for sched_req in requests:
+            rid = getattr(sched_req, "request_id", None)
+            epoch = getattr(sched_req.data, "_qwen3_tts_prep_epoch", None)
+            if rid is None or epoch is None:
+                return None
+            rids.append((rid, epoch))
+        return rids
+
+    def _ensure_masks(self, batch_size: int, vocab: int, device: Any) -> None:
+        masks = getattr(self, "_shape_masks", None)
+        if (
+            masks is not None
+            and masks[0].shape[0] >= batch_size
+            and masks[0].shape[1] == vocab
+            and masks[0].device == device
+        ):
+            return
+        rows = max(batch_size, 64)
+        self._shape_masks = (
+            torch.zeros(rows, vocab, dtype=torch.bool, device=device),
+            torch.zeros(rows, vocab, dtype=torch.bool, device=device),
+            torch.ones(rows, 1, dtype=torch.float32, device=device),
+        )
+        self._mask_prep_rids = None
+
+    def _rebuild_masks(self, requests: list, vocab: int, device: Any) -> None:
+        rep_mask, sup_mask, pen_col = self._shape_masks
+        batch_size = len(requests)
+        rep_mask[:batch_size] = False
+        sup_mask[:batch_size] = False
+        rep_rows: list[int] = []
+        rep_toks: list[int] = []
+        penalties = [1.0] * batch_size
+        sup_rows: list[int] = []
+        sup_toks: list[int] = []
+        for row_idx, sched_req in enumerate(requests):
+            data = sched_req.data
+            req = data.req
+            penalty = float(req.sampling_params.repetition_penalty)
+            penalties[row_idx] = penalty
+            output_ids = req.output_ids
+            if penalty != 1.0 and output_ids:
+                seen = ModelRunner._rep_penalty_unique_tokens(data, output_ids, vocab)
+                rep_rows.extend([row_idx] * len(seen))
+                rep_toks.extend(seen)
+            suppress_tokens = data.suppress_tokens
+            if not suppress_tokens:
+                suppress_tokens = getattr(req, "_codec_suppress_tokens", None)
+            if suppress_tokens:
+                for token_id in suppress_tokens:
+                    tok = int(token_id)
+                    if 0 <= tok < vocab:
+                        sup_rows.append(row_idx)
+                        sup_toks.append(tok)
+        if rep_rows:
+            pairs = torch.tensor(rep_rows + rep_toks, dtype=torch.long, device=device)
+            rep_mask[pairs[: len(rep_rows)], pairs[len(rep_rows) :]] = True
+        if sup_rows:
+            pairs = torch.tensor(sup_rows + sup_toks, dtype=torch.long, device=device)
+            sup_mask[pairs[: len(sup_rows)], pairs[len(sup_rows) :]] = True
+        pen_col[:batch_size, 0] = torch.tensor(
+            penalties, dtype=torch.float32, device=device
+        )
+        self._mask_rep_active = bool(rep_rows) or any(p != 1.0 for p in penalties)
+        self._mask_sup_active = bool(sup_rows)
+
+    def _apply_repetition_penalty(self, logits_output: Any, requests: list) -> None:
+        logits = logits_output.next_token_logits
+        if logits is None or logits.ndim != 2:
+            return
+        batch_size = len(requests)
+        vocab = logits.shape[1]
+        self._ensure_masks(batch_size, vocab, logits.device)
+        rep_mask, sup_mask, pen_col = self._shape_masks
+        fingerprint = self._mask_fingerprint(requests)
+        last_sampled = getattr(self, "_mask_last_sampled", None)
+        if (
+            fingerprint is not None
+            and fingerprint == getattr(self, "_mask_prep_rids", None)
+            and last_sampled is not None
+            and last_sampled.shape[0] >= batch_size
+        ):
+            # Note: (Jiaxin Deng) unchanged batch: the only new information
+            # since the last step is each row's sampled token; one scatter
+            # replaces the full host-side index rebuild.
+            if self._mask_rep_active:
+                rows = torch.arange(batch_size, device=logits.device)
+                rep_mask[rows, last_sampled[:batch_size].clamp(0, vocab - 1)] = True
+                for sched_req in requests:
+                    data = sched_req.data
+                    output_ids = sched_req.data.req.output_ids
+                    if output_ids:
+                        ModelRunner._rep_penalty_unique_tokens(data, output_ids, vocab)
+        else:
+            self._rebuild_masks(requests, vocab, logits.device)
+        self._mask_prep_rids = fingerprint
+        if self._mask_rep_active:
+            pen = pen_col[:batch_size]
+            scores = logits.to(torch.float32)
+            penalized = torch.where(scores > 0, scores / pen, scores * pen)
+            logits.copy_(
+                torch.where(rep_mask[:batch_size], penalized, scores).to(logits.dtype)
+            )
+
+    def _apply_codec_suppress_tokens(self, logits_output: Any, requests: list) -> None:
+        logits = logits_output.next_token_logits
+        if logits is None or logits.ndim != 2:
+            return
+        masks = getattr(self, "_shape_masks", None)
+        if masks is None or not getattr(self, "_mask_sup_active", False):
+            return
+        logits.masked_fill_(masks[1][: len(requests)], float("-inf"))
 
     def _install_semantic_sampling_seeds(
         self,

--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -148,8 +148,8 @@ class Qwen3TTSModelRunner(ModelRunner):
             return
         self._has_pending_code_step = False
         eos_id = int(self.model.config.codec_eos_token_id)
-        # Note: (Jiaxin Deng) one batched clone per buffer, not one per row;
-        # rows are views into the snapshot, which stays off the graph buffers.
+        # Note: (Jiaxin Deng) per-row clones were a c32 decode-loop hot spot;
+        # rows must stay views of a snapshot, never of the reused graph buffers.
         batch_size = len(scheduler_output.requests)
         codes_snap = self.model._output_codes[:batch_size].detach().clone()
         embeds_snap = self.model._output_embeds[:batch_size].detach().clone()

--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -221,7 +221,7 @@ class Qwen3TTSModelRunner(ModelRunner):
         input_ids[:batch_size].copy_(row_ids)
 
     def _decode_row_ids(self, batch_size: int, input_ids: torch.Tensor) -> torch.Tensor:
-        cached = self._row_ids_cache
+        cached = getattr(self, "_row_ids_cache", None)
         if (
             cached is None
             or cached.numel() < batch_size

--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -20,6 +20,7 @@ class Qwen3TTSModelRunner(ModelRunner):
     def __init__(self, tp_worker: Any, output_processor: Any):
         super().__init__(tp_worker, output_processor)
         self._has_pending_code_step = False
+        self._row_ids_cache: torch.Tensor | None = None
 
     def before_prefill(
         self,
@@ -147,15 +148,19 @@ class Qwen3TTSModelRunner(ModelRunner):
             return
         self._has_pending_code_step = False
         eos_id = int(self.model.config.codec_eos_token_id)
+        # Note: (Jiaxin Deng) one batched clone per buffer, not one per row;
+        # rows are views into the snapshot, which stays off the graph buffers.
+        batch_size = len(scheduler_output.requests)
+        codes_snap = self.model._output_codes[:batch_size].detach().clone()
+        embeds_snap = self.model._output_embeds[:batch_size].detach().clone()
         for row_idx, sched_req in enumerate(scheduler_output.requests):
             req_output = outputs[sched_req.request_id]
             if req_output.data is None or int(req_output.data) == eos_id:
                 continue
-            code_chunk = self.model._output_codes[row_idx].detach().clone()
-            feedback = self.model._output_embeds[row_idx].detach().clone()
+            code_chunk = codes_snap[row_idx]
             sched_req.data.output_codes.append(code_chunk)
             sched_req.data.latest_stream_code_chunk = code_chunk
-            sched_req.data.pending_feedback_queue.append(feedback)
+            sched_req.data.pending_feedback_queue.append(embeds_snap[row_idx])
 
     def _sample_positions(
         self, forward_batch: Any, device: torch.device
@@ -195,11 +200,7 @@ class Qwen3TTSModelRunner(ModelRunner):
             raise RuntimeError(
                 "Qwen3-TTS decode batch exceeds staged feedback embedding rows"
             )
-        row_ids = torch.arange(
-            batch_size,
-            device=input_ids.device,
-            dtype=input_ids.dtype,
-        )
+        row_ids = self._decode_row_ids(batch_size, input_ids)
         rows = []
 
         for row_idx, sched_req in enumerate(requests):
@@ -214,14 +215,26 @@ class Qwen3TTSModelRunner(ModelRunner):
                 )
                 combined = self.model.get_input_embeddings()(token_id).reshape(-1)
             rows.append(combined)
-        stacked = torch.stack(rows, dim=0).to(
-            device=decode_feedback_embedding.weight.device,
-            dtype=decode_feedback_embedding.weight.dtype,
-        )
         with torch.no_grad():
-            decode_feedback_embedding.weight[:batch_size].copy_(stacked)
+            torch.stack(rows, dim=0, out=decode_feedback_embedding.weight[:batch_size])
         # During graph decode, input_ids carries staged embedding row ids.
         input_ids[:batch_size].copy_(row_ids)
+
+    def _decode_row_ids(self, batch_size: int, input_ids: torch.Tensor) -> torch.Tensor:
+        cached = self._row_ids_cache
+        if (
+            cached is None
+            or cached.numel() < batch_size
+            or cached.dtype != input_ids.dtype
+            or cached.device != input_ids.device
+        ):
+            cached = torch.arange(
+                max(batch_size, 64),
+                device=input_ids.device,
+                dtype=input_ids.dtype,
+            )
+            self._row_ids_cache = cached
+        return cached[:batch_size]
 
     def _build_prefill_input_embeds(
         self,

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -976,8 +976,13 @@ class Qwen3TTSTalker(nn.Module):
 
         # Note: (Jiaxin Deng) every staged value here is static per request, so
         # an unchanged batch composition can reuse the previous staging wholesale.
-        rids = [sched_req.request_id for sched_req in requests]
-        if rids == self._decode_prep_rids:
+        # Requests without a request_id (test doubles) always restage.
+        rids: list | None = [
+            getattr(sched_req, "request_id", None) for sched_req in requests
+        ]
+        if None in rids:
+            rids = None
+        elif rids == self._decode_prep_rids:
             return
         self._decode_prep_rids = None
 

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -976,13 +976,23 @@ class Qwen3TTSTalker(nn.Module):
 
         # Note: (Jiaxin Deng) every staged value here is static per request, so
         # an unchanged batch composition can reuse the previous staging wholesale.
-        # Requests without a request_id (test doubles) always restage.
-        rids: list | None = [
-            getattr(sched_req, "request_id", None) for sched_req in requests
-        ]
-        if None in rids:
-            rids = None
-        elif rids == self._decode_prep_rids:
+        # Request ids alone are reusable across request lifetimes, so identity is
+        # (request_id, per-data epoch); test doubles without request_id restage.
+        rids: list | None = []
+        for sched_req in requests:
+            rid = getattr(sched_req, "request_id", None)
+            if rid is None:
+                rids = None
+                break
+            data = sched_req.data
+            epoch = getattr(data, "_qwen3_tts_prep_epoch", None)
+            if epoch is None:
+                epoch = self._decode_prep_epoch = (
+                    getattr(self, "_decode_prep_epoch", 0) + 1
+                )
+                data._qwen3_tts_prep_epoch = epoch
+            rids.append((rid, epoch))
+        if rids is not None and rids == getattr(self, "_decode_prep_rids", None):
             return
         self._decode_prep_rids = None
 

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -506,6 +506,7 @@ class Qwen3TTSTalker(nn.Module):
         self._sub_sampled_has_top_p = False
         self._sub_sampled_max_top_k = 0
         self._sub_sampled_has_unbounded_top_k = False
+        self._decode_prep_rids: list | None = None
         self._predictor_graph_batch_sizes = self._normalize_predictor_graph_batch_sizes(
             server_args,
             max_batch_size=max_batch_size,
@@ -973,6 +974,13 @@ class Qwen3TTSTalker(nn.Module):
         if batch_size > self._sub_temperature_tensor.shape[0]:
             raise RuntimeError("Qwen3-TTS sampling buffers are too small")
 
+        # Note: (Jiaxin Deng) every staged value here is static per request, so
+        # an unchanged batch composition can reuse the previous staging wholesale.
+        rids = [sched_req.request_id for sched_req in requests]
+        if rids == self._decode_prep_rids:
+            return
+        self._decode_prep_rids = None
+
         semantic_seeds: list[int] = []
         sub_temperatures: list[float] = []
         sub_top_ps: list[float] = []
@@ -1034,6 +1042,7 @@ class Qwen3TTSTalker(nn.Module):
         self._sub_sampled_has_unbounded_top_k = has_unbounded_top_k
 
         if batch_size == 0:
+            self._decode_prep_rids = rids
             return
 
         device = self._sub_temperature_tensor.device
@@ -1058,6 +1067,7 @@ class Qwen3TTSTalker(nn.Module):
             self._sub_sample_row_indices_tensor[: self._sub_sample_count] = (
                 torch.tensor(self._sub_sample_rows, device=device, dtype=torch.long)
             )
+        self._decode_prep_rids = rids
 
     @torch.no_grad()
     def forward(
@@ -1225,6 +1235,9 @@ class Qwen3TTSTalker(nn.Module):
                 self._sub_sampled_max_top_k,
                 self._sub_sampled_has_unbounded_top_k,
             ) = saved
+            # Note: (Jiaxin Deng) capture overwrote the staged row-indices
+            # tensor; drop the reuse fingerprint so the next prepare restages.
+            self._decode_prep_rids = None
 
     def _predictor_graph_memory_pool(self):
         # Note: (Jiaxin Deng) one shared pool across keys; private per-graph

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -24,6 +24,7 @@ from sglang_omni.models.qwen3_tts.streaming_vocoder import (
     Qwen3TTSStreamingVocoderScheduler,
 )
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni.scheduling.threaded_simple_scheduler import ThreadedSimpleScheduler
 from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoint
 
 logger = logging.getLogger(__name__)
@@ -123,13 +124,13 @@ def create_preprocessing_executor(
     model_path: str,
     *,
     max_concurrency: int = 8,
-) -> SimpleScheduler:
+) -> ThreadedSimpleScheduler:
     del model_path
     # note (luojiaxuan): preprocessing must admit several requests at once. A
     # serial executor keeps at most one reference-code request in flight, so
     # the speech-tokenizer batcher would only ever see batches of one; the
     # default matches the batcher's max_batch_size.
-    return SimpleScheduler(
+    return ThreadedSimpleScheduler(
         preprocess_qwen3_tts_payload,
         max_concurrency=max_concurrency,
         abort_callback=cleanup_prepared_qwen3_tts_request,

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -496,6 +496,21 @@ class Qwen3TTSStreamingVocoderScheduler(
     ) -> torch.Tensor:
         return self._run_decode_plans([plan], stream=stream)[0]
 
+    def _reject_out_of_range_codes(self, decoder_input: torch.Tensor) -> None:
+        # Note: (Jiaxin Deng) the codec embedding lookup turns an out-of-range id
+        # into a device-side assert, which poisons the CUDA context and kills
+        # every in-flight stream in this process. Screen the batch first so a bad
+        # id fails its own batch instead. validate_chunk cannot cover this: it
+        # skips device tensors to avoid a per-chunk sync.
+        bad = (decoder_input < 0) | (decoder_input >= _QWEN3_TTS_CODEBOOK_SIZE)
+        if not bool(bad.any()):
+            return
+        values = decoder_input[bad][:8].tolist()
+        raise ValueError(
+            "Qwen3-TTS decoder input contains codec ids outside "
+            f"[0, {_QWEN3_TTS_CODEBOOK_SIZE}): {values}"
+        )
+
     def _run_decode_plans(
         self,
         plans: list[_Qwen3TTSDecodePlan],
@@ -503,6 +518,7 @@ class Qwen3TTSStreamingVocoderScheduler(
         stream: torch.cuda.Stream | None,
     ) -> list[torch.Tensor]:
         decoder_input = torch.cat([plan.decoder_input for plan in plans], dim=0)
+        self._reject_out_of_range_codes(decoder_input)
         with torch.inference_mode():
             if stream is None:
                 waveform = self._decoder.chunked_decode(decoder_input)

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -479,8 +479,7 @@ class Qwen3TTSStreamingVocoderScheduler(
         # O(stream) per decode. Slices below translate by the pruned offset.
         while (
             state.code_chunks
-            and state.pruned_frames + int(state.code_chunks[0].shape[0])
-            <= window_start
+            and state.pruned_frames + int(state.code_chunks[0].shape[0]) <= window_start
         ):
             state.pruned_frames += int(state.code_chunks.pop(0).shape[0])
         codes = torch.cat(state.code_chunks, dim=0)
@@ -513,8 +512,10 @@ class Qwen3TTSStreamingVocoderScheduler(
         # decode's existing sync: rows that needed clamping are failed, never
         # emitted, so no added synchronization buys the same protection.
         bad_rows = (
-            (decoder_input < 0) | (decoder_input >= _QWEN3_TTS_CODEBOOK_SIZE)
-        ).flatten(start_dim=1).any(dim=1)
+            ((decoder_input < 0) | (decoder_input >= _QWEN3_TTS_CODEBOOK_SIZE))
+            .flatten(start_dim=1)
+            .any(dim=1)
+        )
         decoder_input.clamp_(0, _QWEN3_TTS_CODEBOOK_SIZE - 1)
         return bad_rows
 
@@ -746,7 +747,9 @@ class Qwen3TTSStreamingVocoderScheduler(
         group: list[tuple[str, _Qwen3TTSStreamState, _Qwen3TTSDecodePlan]],
         *,
         stream: torch.cuda.Stream | None,
-    ) -> tuple[list[tuple[str, _Qwen3TTSStreamState, _Qwen3TTSDecodePlan]], list] | None:
+    ) -> (
+        tuple[list[tuple[str, _Qwen3TTSStreamState, _Qwen3TTSDecodePlan]], list] | None
+    ):
         """Decode a group, failing only the rows that carried invalid codes."""
         while group:
             try:

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -38,6 +38,7 @@ _QWEN3_TTS_CODEBOOK_SIZE = 2048
 class _Qwen3TTSStreamState:
     code_chunks: list[torch.Tensor] = field(default_factory=list)
     total_frames: int = 0
+    pruned_frames: int = 0
     ref_frames: int = 0
     emitted_generated_frames: int = 0
     next_decode_generated_frames: int = 0
@@ -465,8 +466,21 @@ class Qwen3TTSStreamingVocoderScheduler(
         absolute_emitted = state.ref_frames + state.emitted_generated_frames
         window_start = max(0, absolute_emitted - self._stream_left_context_frames)
         window_end = state.ref_frames + generated_frames
+        # Note: (Jiaxin Deng) window_start only moves forward, so frames behind
+        # it are dead; prune whole chunks to keep this cat O(window), not
+        # O(stream) per decode. Slices below translate by the pruned offset.
+        while (
+            state.code_chunks
+            and state.pruned_frames + int(state.code_chunks[0].shape[0])
+            <= window_start
+        ):
+            state.pruned_frames += int(state.code_chunks.pop(0).shape[0])
         codes = torch.cat(state.code_chunks, dim=0)
-        decoder_input = codes[window_start:window_end].transpose(0, 1).unsqueeze(0)
+        decoder_input = (
+            codes[window_start - state.pruned_frames : window_end - state.pruned_frames]
+            .transpose(0, 1)
+            .unsqueeze(0)
+        )
         return _Qwen3TTSDecodePlan(
             decoder_input=decoder_input,
             absolute_emitted_frames=absolute_emitted,

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -52,6 +52,14 @@ class _Qwen3TTSStreamState:
     playback_deadline_s: float = 0.0
 
 
+class _Qwen3TTSInvalidCodeRows(ValueError):
+    """Carries which rows of a decode batch held out-of-range codec ids."""
+
+    def __init__(self, indices: list[int], message: str) -> None:
+        super().__init__(message)
+        self.indices = tuple(indices)
+
+
 @dataclass(frozen=True)
 class _Qwen3TTSDecodePlan:
     decoder_input: torch.Tensor
@@ -496,19 +504,29 @@ class Qwen3TTSStreamingVocoderScheduler(
     ) -> torch.Tensor:
         return self._run_decode_plans([plan], stream=stream)[0]
 
-    def _reject_out_of_range_codes(self, decoder_input: torch.Tensor) -> None:
-        # Note: (Jiaxin Deng) the codec embedding lookup turns an out-of-range id
-        # into a device-side assert, which poisons the CUDA context and kills
-        # every in-flight stream in this process. Screen the batch first so a bad
-        # id fails its own batch instead. validate_chunk cannot cover this: it
-        # skips device tensors to avoid a per-chunk sync.
-        bad = (decoder_input < 0) | (decoder_input >= _QWEN3_TTS_CODEBOOK_SIZE)
-        if not bool(bad.any()):
+    def _screen_out_of_range_codes(self, decoder_input: torch.Tensor) -> Any:
+        # Note: (Jiaxin Deng) an out-of-range id makes the codec embedding lookup
+        # raise a device-side assert, which poisons the CUDA context and kills
+        # every in-flight stream in this process; validate_chunk cannot catch it
+        # because it skips device tensors. Clamp into range so the lookup is
+        # always safe, and return the per-row verdict to read back after the
+        # decode's existing sync: rows that needed clamping are failed, never
+        # emitted, so no added synchronization buys the same protection.
+        bad_rows = (
+            (decoder_input < 0) | (decoder_input >= _QWEN3_TTS_CODEBOOK_SIZE)
+        ).flatten(start_dim=1).any(dim=1)
+        decoder_input.clamp_(0, _QWEN3_TTS_CODEBOOK_SIZE - 1)
+        return bad_rows
+
+    @staticmethod
+    def _raise_for_bad_rows(bad_rows: Any, count: int) -> None:
+        indices = bad_rows[:count].nonzero().flatten().tolist()
+        if not indices:
             return
-        values = decoder_input[bad][:8].tolist()
-        raise ValueError(
+        raise _Qwen3TTSInvalidCodeRows(
+            indices,
             "Qwen3-TTS decoder input contains codec ids outside "
-            f"[0, {_QWEN3_TTS_CODEBOOK_SIZE}): {values}"
+            f"[0, {_QWEN3_TTS_CODEBOOK_SIZE}) in rows {indices}",
         )
 
     def _run_decode_plans(
@@ -518,9 +536,10 @@ class Qwen3TTSStreamingVocoderScheduler(
         stream: torch.cuda.Stream | None,
     ) -> list[torch.Tensor]:
         decoder_input = torch.cat([plan.decoder_input for plan in plans], dim=0)
-        self._reject_out_of_range_codes(decoder_input)
+        bad_rows = self._screen_out_of_range_codes(decoder_input)
         with torch.inference_mode():
             if stream is None:
+                self._raise_for_bad_rows(bad_rows, len(plans))
                 waveform = self._decoder.chunked_decode(decoder_input)
             else:
                 stream.wait_stream(torch.cuda.current_stream(self._device))
@@ -534,6 +553,7 @@ class Qwen3TTSStreamingVocoderScheduler(
                     if waveform is None:
                         waveform = self._decoder.chunked_decode(decoder_input)
                 stream.synchronize()
+                self._raise_for_bad_rows(bad_rows, len(plans))
         if waveform.ndim == 3:
             if waveform.shape[0] != len(plans):
                 raise RuntimeError(
@@ -714,18 +734,38 @@ class Qwen3TTSStreamingVocoderScheduler(
                 planned.append((request_id, state, plan))
 
         for group in self._group_decode_plans(planned):
+            decoded = self._decode_group(group, stream=self._decode_stream)
+            if decoded is None:
+                continue
+            for entry, waveform in zip(*decoded):
+                request_id, state, plan = entry
+                self._commit_initial(request_id, state, plan, waveform)
+
+    def _decode_group(
+        self,
+        group: list[tuple[str, _Qwen3TTSStreamState, _Qwen3TTSDecodePlan]],
+        *,
+        stream: torch.cuda.Stream | None,
+    ) -> tuple[list[tuple[str, _Qwen3TTSStreamState, _Qwen3TTSDecodePlan]], list] | None:
+        """Decode a group, failing only the rows that carried invalid codes."""
+        while group:
             try:
                 waveforms = self._run_decode_plans(
-                    [entry[2] for entry in group],
-                    stream=self._decode_stream,
+                    [entry[2] for entry in group], stream=stream
                 )
+            except _Qwen3TTSInvalidCodeRows as exc:
+                bad = set(exc.indices)
+                for index, (request_id, state, _) in enumerate(group):
+                    if index in bad:
+                        self._fail_async_stream(request_id, state, exc)
+                group = [e for i, e in enumerate(group) if i not in bad]
+                continue
             except Exception as exc:
                 for request_id, state, _ in group:
                     self._fail_async_stream(request_id, state, exc)
-                continue
-            for entry, waveform in zip(group, waveforms):
-                request_id, state, plan = entry
-                self._commit_initial(request_id, state, plan, waveform)
+                return None
+            return group, waveforms
+        return None
 
     @staticmethod
     def _group_decode_plans(
@@ -822,16 +862,10 @@ class Qwen3TTSStreamingVocoderScheduler(
                 planned.append((request_id, state, plan))
 
         for group in self._group_decode_plans(planned):
-            try:
-                waveforms = self._run_decode_plans(
-                    [entry[2] for entry in group],
-                    stream=self._followup_decode_stream,
-                )
-            except Exception as exc:
-                for request_id, state, _ in group:
-                    self._fail_async_stream(request_id, state, exc)
+            decoded = self._decode_group(group, stream=self._followup_decode_stream)
+            if decoded is None:
                 continue
-            for entry, waveform in zip(group, waveforms):
+            for entry, waveform in zip(*decoded):
                 request_id, state, plan = entry
                 self._commit_followup(request_id, state, plan, waveform)
 

--- a/sglang_omni/scheduling/threaded_simple_scheduler.py
+++ b/sglang_omni/scheduling/threaded_simple_scheduler.py
@@ -74,6 +74,10 @@ class ThreadedSimpleScheduler:
     def abort(self, request_id: str) -> None:
         with self._lock:
             self._aborted.add(request_id)
+            if len(self._aborted) > 10000:
+                excess = len(self._aborted) - 5000
+                for stale_request_id in list(self._aborted)[:excess]:
+                    self._aborted.discard(stale_request_id)
             future = self._pending.pop(request_id, None)
         if future is not None:
             future.cancel()
@@ -106,9 +110,12 @@ class ThreadedSimpleScheduler:
         with self._lock:
             self._pending.pop(request_id, None)
             aborted = request_id in self._aborted
+            if aborted:
+                self._aborted.discard(request_id)
         if aborted or future.cancelled():
-            # A compute that finished after the abort may have registered
-            # side effects the abort-time callback ran too early to see.
+            # Note: (Jiaxin Deng) a compute that finished after the abort may
+            # have registered side effects the abort-time callback ran too
+            # early to see.
             self._run_abort_callback(request_id)
             return
 

--- a/sglang_omni/scheduling/threaded_simple_scheduler.py
+++ b/sglang_omni/scheduling/threaded_simple_scheduler.py
@@ -25,7 +25,13 @@ class ThreadedSimpleScheduler:
     true tensor batching through ``SimpleScheduler(batch_compute_fn=...)``.
     """
 
-    def __init__(self, compute_fn: Callable, *, max_concurrency: int = 8):
+    def __init__(
+        self,
+        compute_fn: Callable,
+        *,
+        max_concurrency: int = 8,
+        abort_callback: Callable[[str], None] | None = None,
+    ):
         self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
         self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
         self.requires_tp_work_fanout: bool = True
@@ -36,6 +42,7 @@ class ThreadedSimpleScheduler:
         self._aborted: set[str] = set()
         self._lock = threading.Lock()
         self._running = False
+        self._abort_callback = abort_callback
 
     def start(self) -> None:
         self._running = True
@@ -70,6 +77,17 @@ class ThreadedSimpleScheduler:
             future = self._pending.pop(request_id, None)
         if future is not None:
             future.cancel()
+        self._run_abort_callback(request_id)
+
+    def _run_abort_callback(self, request_id: str) -> None:
+        if self._abort_callback is None:
+            return
+        try:
+            self._abort_callback(request_id)
+        except Exception:
+            logger.exception(
+                "ThreadedSimpleScheduler: abort_callback failed for %s", request_id
+            )
 
     def _wait_for_capacity(self) -> None:
         while self._running:
@@ -89,6 +107,9 @@ class ThreadedSimpleScheduler:
             self._pending.pop(request_id, None)
             aborted = request_id in self._aborted
         if aborted or future.cancelled():
+            # A compute that finished after the abort may have registered
+            # side effects the abort-time callback ran too early to see.
+            self._run_abort_callback(request_id)
             return
 
         try:

--- a/tests/unit_test/qwen3_omni/test_logit_shaping.py
+++ b/tests/unit_test/qwen3_omni/test_logit_shaping.py
@@ -64,3 +64,67 @@ def test_apply_repetition_penalty_matches_scalar_reference(dtype):
     tol = {torch.float16: 2.5e-3, torch.bfloat16: 1e-2, torch.float32: 1e-6}[dtype]
     diff = (actual - expected).abs().max().item()
     assert diff <= tol, f"max abs diff {diff:.6f} > tol {tol:.6f} for {dtype}"
+
+
+def test_repetition_penalty_incremental_matches_full_rebuild():
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    vocab = 128
+    penalty = 1.3
+    torch.manual_seed(0)
+    output_ids = [3, 7, 7, 100]
+    requests = _make_requests([output_ids], penalty)
+
+    for step_ids in ([3, 7, 7, 100, 55], [3, 7, 7, 100, 55, 3], [9], [9, 200, -1, 12]):
+        requests[0].data.req.output_ids = list(step_ids)
+        logits_orig = torch.randn(1, vocab, dtype=torch.float32, device=device)
+        logits_output = types.SimpleNamespace(next_token_logits=logits_orig.clone())
+        ModelRunner._apply_repetition_penalty(
+            types.SimpleNamespace(), logits_output, requests
+        )
+        expected = _scalar_reference(logits_orig, requests, penalty)
+        assert torch.equal(logits_output.next_token_logits, expected), step_ids
+
+
+def _make_suppress_requests(suppress_per_row):
+    reqs = []
+    for suppress in suppress_per_row:
+        req = types.SimpleNamespace()
+        data = types.SimpleNamespace(req=req, suppress_tokens=suppress)
+        reqs.append(types.SimpleNamespace(data=data))
+    return reqs
+
+
+def _suppress_reference(logits, requests):
+    out = logits.clone()
+    vocab = out.shape[1]
+    for row_idx, sched_req in enumerate(requests):
+        suppress = sched_req.data.suppress_tokens
+        if not suppress:
+            continue
+        for tok in suppress:
+            tok = int(tok)
+            if 0 <= tok < vocab:
+                out[row_idx, tok] = float("-inf")
+    return out
+
+
+@pytest.mark.parametrize("share_rows", [True, False])
+def test_codec_suppress_tokens_matches_reference(share_rows):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    vocab = 96
+    batch = 4
+    torch.manual_seed(1)
+    shared = [5, 90, 95, 200, -3]
+    if share_rows:
+        suppress_per_row = [shared] * batch
+    else:
+        suppress_per_row = [shared, [1, 2], None, shared]
+    requests = _make_suppress_requests(suppress_per_row)
+    runner = types.SimpleNamespace()
+
+    for _ in range(3):  # repeated calls exercise the tensor cache
+        logits_orig = torch.randn(batch, vocab, dtype=torch.float32, device=device)
+        logits_output = types.SimpleNamespace(next_token_logits=logits_orig.clone())
+        ModelRunner._apply_codec_suppress_tokens(runner, logits_output, requests)
+        expected = _suppress_reference(logits_orig, requests)
+        assert torch.equal(logits_output.next_token_logits, expected)

--- a/tests/unit_test/qwen3_omni/test_logit_shaping.py
+++ b/tests/unit_test/qwen3_omni/test_logit_shaping.py
@@ -155,3 +155,23 @@ def test_repetition_penalty_resets_after_empty_retract():
 
     expected = _scalar_reference(logits_orig, requests, penalty)
     assert torch.equal(logits_output.next_token_logits, expected)
+
+
+def test_suppress_cache_holds_one_entry_across_requests():
+    """Fresh list objects with identical content must share one device tensor."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    vocab = 64
+    runner = types.SimpleNamespace()
+    shared = [5, 20, 90]
+
+    for step in range(5):
+        # the request builder hands out a new list object per request
+        requests = _make_suppress_requests([list(shared), list(shared)])
+        logits = torch.randn(2, vocab, device=device)
+        logits_output = types.SimpleNamespace(next_token_logits=logits.clone())
+        ModelRunner._apply_codec_suppress_tokens(runner, logits_output, requests)
+        assert torch.equal(
+            logits_output.next_token_logits, _suppress_reference(logits, requests)
+        ), step
+
+    assert len(runner._suppress_tensor_cache) == 1

--- a/tests/unit_test/qwen3_omni/test_logit_shaping.py
+++ b/tests/unit_test/qwen3_omni/test_logit_shaping.py
@@ -128,3 +128,30 @@ def test_codec_suppress_tokens_matches_reference(share_rows):
         ModelRunner._apply_codec_suppress_tokens(runner, logits_output, requests)
         expected = _suppress_reference(logits_orig, requests)
         assert torch.equal(logits_output.next_token_logits, expected)
+
+
+def test_repetition_penalty_resets_after_empty_retract():
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    vocab = 64
+    penalty = 1.5
+    requests = _make_requests([[3, 9]], penalty)
+    runner = types.SimpleNamespace()
+
+    logits = torch.zeros(1, vocab, device=device) + 1.0
+    ModelRunner._apply_repetition_penalty(
+        runner, types.SimpleNamespace(next_token_logits=logits), requests
+    )
+
+    # Retract replaces output_ids with an empty list, then the restart
+    # generates a different same-length prefix.
+    requests[0].data.req.output_ids = []
+    ModelRunner._apply_repetition_penalty(
+        runner, types.SimpleNamespace(next_token_logits=logits.clone()), requests
+    )
+    requests[0].data.req.output_ids = [11, 12]
+    logits_orig = torch.ones(1, vocab, device=device)
+    logits_output = types.SimpleNamespace(next_token_logits=logits_orig.clone())
+    ModelRunner._apply_repetition_penalty(runner, logits_output, requests)
+
+    expected = _scalar_reference(logits_orig, requests, penalty)
+    assert torch.equal(logits_output.next_token_logits, expected)

--- a/tests/unit_test/qwen3_tts/test_mask_logit_shaping.py
+++ b/tests/unit_test/qwen3_tts/test_mask_logit_shaping.py
@@ -111,3 +111,37 @@ def test_mask_shaping_batch_shrink_rebuilds():
     assert torch.equal(got, _reference(logits2, survivors))
     # row 0 now belongs to request b; request a's tokens must not be penalized
     assert got[0, 1] == logits2[0, 1]
+
+
+def test_mask_shaping_clears_bits_after_history_shrink():
+    """A retract shrinks output_ids; stale mask bits must not survive it."""
+    torch.manual_seed(9)
+    vocab = 64
+    runner = _runner()
+    reqs = [_request("a", 1, 1.5, [3, 9], [])]
+
+    logits = torch.randn(1, vocab)
+    _apply(runner, logits.clone(), reqs)
+
+    # retract/restart: history shrinks, and the next step must not penalize 9
+    reqs[0].data.req.output_ids = [3]
+    runner._mask_last_sampled = torch.tensor([3])
+    logits2 = torch.randn(1, vocab)
+    got = _apply(runner, logits2.clone(), reqs)
+    assert torch.equal(got, _reference(logits2, reqs))
+    assert got[0, 9] == logits2[0, 9]
+
+
+def test_mask_shaping_empty_history_after_retract():
+    torch.manual_seed(11)
+    vocab = 32
+    runner = _runner()
+    reqs = [_request("a", 1, 1.4, [5], [])]
+    logits = torch.randn(1, vocab)
+    _apply(runner, logits.clone(), reqs)
+
+    reqs[0].data.req.output_ids = []
+    runner._mask_last_sampled = torch.tensor([5])
+    logits2 = torch.randn(1, vocab)
+    got = _apply(runner, logits2.clone(), reqs)
+    assert torch.equal(got, logits2), "no history means no penalty anywhere"

--- a/tests/unit_test/qwen3_tts/test_mask_logit_shaping.py
+++ b/tests/unit_test/qwen3_tts/test_mask_logit_shaping.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Mask-based logit shaping must match the scalar reference bit for bit."""
+
+from __future__ import annotations
+
+import types
+
+import torch
+
+from sglang_omni.models.qwen3_tts.model_runner import Qwen3TTSModelRunner
+
+
+def _runner() -> Qwen3TTSModelRunner:
+    runner = object.__new__(Qwen3TTSModelRunner)
+    runner._mask_last_sampled = None
+    runner._mask_prep_rids = None
+    runner._mask_rep_active = False
+    runner._mask_sup_active = False
+    return runner
+
+
+def _request(rid: str, epoch: int, penalty: float, output_ids, suppress):
+    sp = types.SimpleNamespace(repetition_penalty=penalty)
+    req = types.SimpleNamespace(sampling_params=sp, output_ids=output_ids)
+    data = types.SimpleNamespace(
+        req=req, suppress_tokens=suppress, _qwen3_tts_prep_epoch=epoch
+    )
+    return types.SimpleNamespace(request_id=rid, data=data)
+
+
+def _reference(logits, requests):
+    out = logits.clone()
+    vocab = out.shape[1]
+    for row, sched_req in enumerate(requests):
+        req = sched_req.data.req
+        penalty = float(req.sampling_params.repetition_penalty)
+        ids = req.output_ids or []
+        unique = {int(t) for t in ids if 0 <= int(t) < vocab}
+        if penalty != 1.0 and unique:
+            idx = torch.tensor(sorted(unique), dtype=torch.long)
+            scores = out[row, idx].to(torch.float32)
+            scores = torch.where(scores > 0, scores / penalty, scores * penalty)
+            out[row, idx] = scores.to(out.dtype)
+        for tok in sched_req.data.suppress_tokens or []:
+            tok = int(tok)
+            if 0 <= tok < vocab:
+                out[row, tok] = float("-inf")
+    return out
+
+
+def _apply(runner, logits, requests):
+    logits_output = types.SimpleNamespace(next_token_logits=logits)
+    runner._apply_repetition_penalty(logits_output, requests)
+    runner._apply_codec_suppress_tokens(logits_output, requests)
+    return logits_output.next_token_logits
+
+
+def test_mask_shaping_steady_steps_match_reference():
+    torch.manual_seed(3)
+    vocab = 128
+    runner = _runner()
+    suppress = [5, 90, 200]
+    reqs = [
+        _request("a", 1, 1.3, [3, 7], suppress),
+        _request("b", 2, 1.0, [4], suppress),
+    ]
+
+    for step in range(6):
+        logits = torch.randn(2, vocab, dtype=torch.float32)
+        got = _apply(runner, logits.clone(), reqs)
+        expected = _reference(logits, reqs)
+        assert torch.equal(got, expected), step
+        # next step: each row samples one new token
+        new_a, new_b = 10 + step, 40 + step
+        reqs[0].data.req.output_ids = reqs[0].data.req.output_ids + [new_a]
+        reqs[1].data.req.output_ids = reqs[1].data.req.output_ids + [new_b]
+        runner._mask_last_sampled = torch.tensor([new_a, new_b])
+
+
+def test_mask_shaping_rebuilds_on_rid_reuse():
+    torch.manual_seed(4)
+    vocab = 64
+    runner = _runner()
+    reqs = [_request("a", 1, 1.5, [3, 9, 11], [2])]
+    logits = torch.randn(1, vocab)
+    assert torch.equal(_apply(runner, logits.clone(), reqs), _reference(logits, reqs))
+
+    # same rid, new lifetime (new epoch), different history and suppress list
+    reqs2 = [_request("a", 7, 1.5, [30], [40])]
+    logits2 = torch.randn(1, vocab)
+    got = _apply(runner, logits2.clone(), reqs2)
+    assert torch.equal(got, _reference(logits2, reqs2))
+    # old tokens must not leak through the mask
+    assert got[0, 3] == logits2[0, 3]
+
+
+def test_mask_shaping_batch_shrink_rebuilds():
+    torch.manual_seed(5)
+    vocab = 64
+    runner = _runner()
+    reqs = [
+        _request("a", 1, 1.2, [1, 2], [50]),
+        _request("b", 2, 1.2, [3, 4], [50]),
+    ]
+    logits = torch.randn(2, vocab)
+    assert torch.equal(_apply(runner, logits.clone(), reqs), _reference(logits, reqs))
+
+    survivors = [reqs[1]]
+    logits2 = torch.randn(1, vocab)
+    got = _apply(runner, logits2.clone(), survivors)
+    assert torch.equal(got, _reference(logits2, survivors))
+    # row 0 now belongs to request b; request a's tokens must not be penalized
+    assert got[0, 1] == logits2[0, 1]

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3771,6 +3771,7 @@ def test_qwen3_tts_stream_prune_matches_full_history_windows() -> None:
     assert state.pruned_frames > 0, "long stream should have pruned dead chunks"
     assert len(state.code_chunks) < len(full_history)
 
+
 def test_qwen3_tts_decode_isolates_rows_with_out_of_range_codes() -> None:
     """A bad row fails alone and the decoder only ever sees in-range ids."""
     scheduler = Qwen3TTSStreamingVocoderScheduler(

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3675,3 +3675,61 @@ def test_qwen3_tts_prefill_publishes_sglang_forward_context() -> None:
 
     assert seen == [attn_backend]
     assert result.logits_output == "logits"
+
+
+def _make_prep_talker(monkeypatch):
+    install_fake_sglang(monkeypatch)
+    from sglang_omni.models.qwen3_tts.sglang_model import Qwen3TTSTalker
+
+    talker = Qwen3TTSTalker.__new__(Qwen3TTSTalker)
+    talker.config = SimpleNamespace(
+        code_predictor_config=SimpleNamespace(vocab_size=2048)
+    )
+    talker._sub_temperature_tensor = torch.empty(2, dtype=torch.float32)
+    talker._sub_top_p_tensor = torch.empty(2, dtype=torch.float32)
+    talker._sub_top_k_tensor = torch.empty(2, dtype=torch.long)
+    talker._semantic_sampling_seed_tensor = torch.empty(2, dtype=torch.long)
+    talker._sub_sampling_seed_tensor = torch.empty(2, dtype=torch.long)
+    talker._sub_sample_row_indices_tensor = torch.empty(2, dtype=torch.long)
+    return Qwen3TTSTalker, talker
+
+
+def _prep_request(request_id, temperature):
+    return SimpleNamespace(
+        request_id=request_id,
+        data=Qwen3TTSSGLangRequestData(
+            semantic_sampling_seed=5,
+            subtalker_dosample=True,
+            subtalker_temperature=temperature,
+            subtalker_top_p=0.9,
+            subtalker_top_k=40,
+            subtalker_sampling_seed=7,
+        ),
+    )
+
+
+def test_qwen3_tts_prepare_decode_buffers_reuses_unchanged_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    talker_cls, talker = _make_prep_talker(monkeypatch)
+    requests = [_prep_request("req-a", 0.8)]
+    talker_cls.prepare_decode_buffers(talker, requests)
+    assert talker._sub_temperature_tensor[:1].tolist() == pytest.approx([0.8])
+
+    # Unchanged batch: staging is skipped, so a manual poke survives.
+    talker._sub_temperature_tensor[0] = 0.123
+    talker_cls.prepare_decode_buffers(talker, requests)
+    assert talker._sub_temperature_tensor[:1].tolist() == pytest.approx([0.123])
+
+
+def test_qwen3_tts_prepare_decode_buffers_restages_on_request_id_reuse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A completed request's id may be legally reused by a new request."""
+    talker_cls, talker = _make_prep_talker(monkeypatch)
+    talker_cls.prepare_decode_buffers(talker, [_prep_request("req-a", 0.8)])
+    assert talker._sub_temperature_tensor[:1].tolist() == pytest.approx([0.8])
+
+    # Same request id, brand-new request data: must restage, not reuse.
+    talker_cls.prepare_decode_buffers(talker, [_prep_request("req-a", 0.4)])
+    assert talker._sub_temperature_tensor[:1].tolist() == pytest.approx([0.4])

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -2892,8 +2892,8 @@ def test_qwen3_tts_steady_decode_reports_cuda_graph_ready(
     class FakeOutputProcessor:
         _capture_hidden = False
 
-        def process(self, model_output, scheduler_output):
-            del model_output
+        def process(self, model_output, scheduler_output, host_token_ids=None):
+            del model_output, host_token_ids
             return {
                 req.request_id: RequestOutput(req.request_id, data=7)
                 for req in scheduler_output.requests

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -31,6 +31,7 @@ from sglang_omni.models.qwen3_tts.request_builders import (
 )
 from sglang_omni.models.qwen3_tts.streaming_vocoder import (
     Qwen3TTSStreamingVocoderScheduler,
+    _Qwen3TTSDecodePlan,
     _Qwen3TTSInitialDecodeGraphs,
 )
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
@@ -3769,3 +3770,34 @@ def test_qwen3_tts_stream_prune_matches_full_history_windows() -> None:
 
     assert state.pruned_frames > 0, "long stream should have pruned dead chunks"
     assert len(state.code_chunks) < len(full_history)
+
+
+def test_qwen3_tts_decode_rejects_out_of_range_codes_before_lookup() -> None:
+    """An out-of-range codec id fails its batch instead of asserting in the decoder."""
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+    )
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("decoder must not run on out-of-range input")
+
+    scheduler._decoder = SimpleNamespace(chunked_decode=_boom)
+    plan = _Qwen3TTSDecodePlan(
+        decoder_input=torch.tensor([[[5, 2150]]], dtype=torch.long),
+        absolute_emitted_frames=0,
+        generated_frames=1,
+        window_start=0,
+    )
+
+    with pytest.raises(ValueError, match="outside"):
+        scheduler._run_decode_plans([plan], stream=None)
+
+    good = _Qwen3TTSDecodePlan(
+        decoder_input=torch.tensor([[[5, 7]]], dtype=torch.long),
+        absolute_emitted_frames=0,
+        generated_frames=1,
+        window_start=0,
+    )
+    with pytest.raises(AssertionError):
+        scheduler._run_decode_plans([good], stream=None)

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import sys
 import threading
+import time
 import types
 from collections import deque
 from queue import Empty, Queue
@@ -2604,40 +2605,36 @@ def test_qwen3_tts_preprocessing_abort_race_cleans_late_prepared_state(
     scheduler = stages.create_preprocessing_executor("model")
     payload = make_payload(inputs="target")
     payload.request_id = request_id
-    loop = asyncio.new_event_loop()
-    errors: list[Exception] = []
 
-    def run_compute() -> None:
-        try:
-            scheduler._run_single(
-                IncomingMessage(
-                    request_id=request_id,
-                    type="new_request",
-                    data=payload,
-                ),
-                loop,
-            )
-        except Exception as exc:
-            errors.append(exc)
-
-    thread = threading.Thread(target=run_compute)
+    thread = threading.Thread(target=scheduler.start, daemon=True)
     try:
         thread.start()
+        scheduler.inbox.put(
+            IncomingMessage(
+                request_id=request_id,
+                type="new_request",
+                data=payload,
+            )
+        )
         assert started.wait(timeout=2.0)
 
         scheduler.abort(request_id)
         release.set()
-        thread.join(timeout=2.0)
 
-        assert not thread.is_alive()
-        assert errors == []
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            with qwen3_request_builders._PREPARED_REQUESTS_LOCK:
+                if request_id not in qwen3_request_builders._PREPARED_REQUESTS:
+                    break
+            time.sleep(0.01)
+
         assert scheduler.outbox.empty()
         with qwen3_request_builders._PREPARED_REQUESTS_LOCK:
             assert request_id not in qwen3_request_builders._PREPARED_REQUESTS
     finally:
         release.set()
+        scheduler.stop()
         thread.join(timeout=2.0)
-        loop.close()
         qwen3_request_builders.cleanup_prepared_qwen3_tts_request(request_id)
 
 

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3771,33 +3771,33 @@ def test_qwen3_tts_stream_prune_matches_full_history_windows() -> None:
     assert state.pruned_frames > 0, "long stream should have pruned dead chunks"
     assert len(state.code_chunks) < len(full_history)
 
-
-def test_qwen3_tts_decode_rejects_out_of_range_codes_before_lookup() -> None:
-    """An out-of-range codec id fails its batch instead of asserting in the decoder."""
+def test_qwen3_tts_decode_isolates_rows_with_out_of_range_codes() -> None:
+    """A bad row fails alone and the decoder only ever sees in-range ids."""
     scheduler = Qwen3TTSStreamingVocoderScheduler(
         _FakeQwen3TTSTokenizer(),
         device="cpu",
     )
+    seen: list[torch.Tensor] = []
 
-    def _boom(*args, **kwargs):
-        raise AssertionError("decoder must not run on out-of-range input")
+    def _decode(x):
+        seen.append(x.clone())
+        return torch.zeros(x.shape[0], 1, 16, dtype=torch.float32)
 
-    scheduler._decoder = SimpleNamespace(chunked_decode=_boom)
-    plan = _Qwen3TTSDecodePlan(
-        decoder_input=torch.tensor([[[5, 2150]]], dtype=torch.long),
-        absolute_emitted_frames=0,
-        generated_frames=1,
-        window_start=0,
-    )
+    scheduler._decoder = SimpleNamespace(chunked_decode=_decode)
 
-    with pytest.raises(ValueError, match="outside"):
-        scheduler._run_decode_plans([plan], stream=None)
+    def _plan(code):
+        return _Qwen3TTSDecodePlan(
+            decoder_input=torch.tensor([[[code]]], dtype=torch.long),
+            absolute_emitted_frames=0,
+            generated_frames=1,
+            window_start=0,
+        )
 
-    good = _Qwen3TTSDecodePlan(
-        decoder_input=torch.tensor([[[5, 7]]], dtype=torch.long),
-        absolute_emitted_frames=0,
-        generated_frames=1,
-        window_start=0,
-    )
-    with pytest.raises(AssertionError):
-        scheduler._run_decode_plans([good], stream=None)
+    with pytest.raises(ValueError) as excinfo:
+        scheduler._run_decode_plans([_plan(7), _plan(2150)], stream=None)
+    assert excinfo.value.indices == (1,)
+    assert seen == [], "decoder must not run while a row is out of range"
+
+    scheduler._run_decode_plans([_plan(7)], stream=None)
+    assert len(seen) == 1
+    assert int(seen[0].max()) < 2048

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3733,3 +3733,39 @@ def test_qwen3_tts_prepare_decode_buffers_restages_on_request_id_reuse(
     # Same request id, brand-new request data: must restage, not reuse.
     talker_cls.prepare_decode_buffers(talker, [_prep_request("req-a", 0.4)])
     assert talker._sub_temperature_tensor[:1].tolist() == pytest.approx([0.4])
+
+
+def test_qwen3_tts_stream_prune_matches_full_history_windows() -> None:
+    """Pruned decode windows must be byte-identical to full-history slicing."""
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        stream_left_context_frames=6,
+        initial_chunk_frames=4,
+        stream_stride=4,
+        stream_followup_stride=3,
+    )
+    state = scheduler.create_stream_state("request")
+    full_history: list[torch.Tensor] = []
+    frame = 0
+    for step in range(30):
+        chunk = torch.arange(frame, frame + 2, dtype=torch.long).reshape(2, 1)
+        frame += 2
+        full_history.append(chunk.clone())
+        scheduler.ingest("request", state, chunk)
+        plan = scheduler._build_decode_plan(state, is_final=False)
+        if plan is None:
+            continue
+        codes_full = torch.cat(full_history, dim=0)
+        window_end = state.ref_frames + plan.generated_frames
+        expected = (
+            codes_full[plan.window_start : window_end].transpose(0, 1).unsqueeze(0)
+        )
+        assert torch.equal(plan.decoder_input, expected), step
+        # commit bookkeeping only (no real decode on the fake tokenizer path)
+        state.emitted_generated_frames = plan.generated_frames
+        state.decoded_chunks += 1
+        state.next_decode_generated_frames = plan.generated_frames + 3
+
+    assert state.pruned_frames > 0, "long stream should have pruned dead chunks"
+    assert len(state.code_chunks) < len(full_history)


### PR DESCRIPTION
## Motivation

Qwen3-TTS 1.7B single-instance serving plateaus far below what the card sustains: the same H200 runs a same-card DP2+MPS pool ~1.5x faster (#1418). py-spy at c32 shows the AR scheduler thread burning 72% of one core in per-step Python work (repetition-penalty set rebuilds, suppress-token tensor rebuilds, sampling-buffer restaging, per-row output clones), which is why the ceiling is size independent (0.6B and 1.7B peak identical).

## Changes

All host-side, no numerics change:

* `model_runner/base.py`: repetition-penalty unique-token tracking is incremental per request (was a full `unique(output_ids)` rebuild per step, quadratic over generation; shrunk `output_ids` resets state). Codec suppress-token device tensors cached by list identity (was per-step Python loop + tensor build).
* `models/qwen3_tts/sglang_model.py`: `prepare_decode_buffers` reuses staged sampling state via a request-id fingerprint when batch composition is unchanged (pattern from qwen3_omni talker #1043); predictor-graph capture invalidates the fingerprint.
* `models/qwen3_tts/model_runner.py`: one batched output snapshot clone per step instead of two clones per row (pattern from #1167); feedback staging stacks straight into the graph buffer (pattern from #1439); decode row ids cached.
* `models/qwen3_tts/stages.py` + `scheduling/threaded_simple_scheduler.py`: preprocessing runs on `ThreadedSimpleScheduler` (pattern from higgs/fish/moss_tts_local); the threaded scheduler gains the `abort_callback` contract the qwen3 prepared-request registry cleanup requires (invoked on abort and on late finish after abort).
* `models/qwen3_tts/streaming_vocoder.py`: the per-decode `torch.cat` rebuilt the full stream history although the decode window only moves forward; dead frames behind `window_start` are pruned and slices translate by the offset, making each decode O(window) instead of O(stream). Windows verified byte-identical to full-history slicing across a simulated long stream.

## Evidence (one H200, EN-1088, Seed-TTS harness, main `25ae3d95` base)

Serving defaults for the measured rows: `--max-running-requests 64 --cuda-graph-max-bs 64 --talker-torch-compile-max-bs 64 --isolate-stage vocoder` (defaults retune tracked in #1418; measured numbers below marked measured, everything else inferred).

Single-pass grids (measured). Attribution: the serving flags alone (no code change, unlocked by #1413) already move the peak; this branch's own delta on top of those flags is the row-over-row difference below, concentrated at c32.

| qps | c8 | c16 | c32 | c64 | c96 | peak | delta vs baseline | C16 EN WER |
|---|---|---|---|---|---|---|---|---|
| baseline defaults | 6.08 | 8.40 | 8.74 | 7.44 | 8.29 | 8.74 | — | 0.99% |
| + admission 64 + vocoder isolate, main code | 6.26 | 8.30 | 8.85 | 11.96 | 12.05 | 12.05 | +37.9% | 0.99% |
| + this branch (same flags, pre-hardening head) | 6.44 | 8.83 | 10.98 | 10.28 | 12.62 | 12.62 | +44.4% | pending |
| DP2+MPS same silicon (#1400 recipe, MF=0.40) | 4.57 | 7.05 | 9.43 | 10.29 | 10.02 | 10.29 | +17.7% | n/a |

This branch over the flags-only row: c32 +24.1% (8.85 -> 10.98), peak +4.7% (12.05 -> 12.62); the flags rows carry the rest of the cumulative gain. Defaults re-tune to make the flags row the out-of-the-box behavior is tracked in #1418 section 2.

H100 calibration of the final head, one card back to back, quiet box (load 3.8-8), all cells 1088/1088:

| qps | c8 | c16 | c32 | c64 | c96 | peak | TTFA p95 @c64 |
|---|---|---|---|---|---|---|---|
| baseline defaults | 7.23 | 10.33 | 10.64 | 10.71 | 10.40 | 10.71 | 4.76 s |
| this branch + flags | 8.16 | 11.31 | 13.81 | 15.80 | 16.15 | **16.15 (+50.8%)** | **0.54 s** |
| DP2+MPS re-measured (#1400 recipe) | 7.14 | 11.13 | 14.81 | 13.81 | 15.66 | 15.66 | 2.80 s |

The optimized single instance now **exceeds** the same-card DP2+MPS pool peak (16.15 vs 15.66, +3.2%) while holding a 5x better TTFA p95 at c64, so the #1418 exit criterion is met outright rather than approached: colocation is no longer the recommended deployment for this variant at peak throughput, and it was never competitive on first-audio latency. DP2 still leads at c32 alone (14.81 vs 13.81). C16 EN WER on the optimized head is 1.12% against the 1.07% published baseline, inside the 0.2pt gate.

TTFA p95 stays flat at c8/c16 in every row (0.20-0.34s); with admission 64 the c64 cliff is gone (7.77s -> 0.69-0.97s).

Same-card three-arm ABAB, 5 rounds, H200, peak qps medians over c32-96: baseline 8.74, this branch + flags 12.40 (+42%, four clean rounds; one round lost to the pre-existing intermittent c64 device assert tracked in #1418 section 4), DP2+MPS 13.76. TTFA p95 at c64 medians: 0.95s vs 2.91s vs 5.93s. On H200 the branch lands at 90% of the pool peak with a 3x TTFA advantage; on H100 (table below) it lands at 95.2%.

Rebased head (adds the vocoder window pruning, current main base), single pass on H200, all cells 1088/1088: 6.34 / 8.90 / 10.95 / 11.50 / 10.96 qps at c8-c96, within the ABAB round spread above.

## Follow-up work in this branch

Three further changes landed after the first review round, each measured separately:

* **Streaming vocoder window pruning.** The per-decode `torch.cat` rebuilt the whole stream history although the window only moves forward; dead chunks are dropped and slices translate by the pruned offset. Windows verified byte-identical to full-history slicing.
* **Codec-id screen.** An id outside the codebook reached the embedding lookup and became a device-side assert that poisoned the CUDA context and killed every in-flight stream in the vocoder process (`validate_chunk` skips device tensors to avoid a per-chunk sync). The decoder input is now clamped into range and the per-row verdict is read back after the decode's existing `stream.synchronize()`, so no decode gains a synchronization, and only the offending rows fail while the rest of the batch still decodes.
* **Device-resident shaping masks + pinned id staging.** Repetition penalty and codec suppression move from per-step host index building to persistent device masks updated by a single scatter of the last sampled token (rebuilt whenever a history does not grow by exactly one token, so retract and restart stay correct); sampled ids are staged into pinned host memory so the output processor's `.tolist()` waits on an event instead of issuing a blocking pageable copy.

Paired A/B on one H200, three alternating rounds, masks on vs off (same head otherwise):

| c16 qps | r1 | r2 | r3 | mean |
|---|---|---|---|---|
| masks off | 8.61 | 8.51 | 8.63 | 8.58 |
| masks on | 9.44 | 9.26 | 9.49 | **9.40 (+9.5%)** |

At c32 the same comparison is neutral (11.11 vs 11.09), so the win is concentrated where the AR scheduler thread is the binding constraint. The pinned staging was A/B'd the same way and is **not** credited with a gain: three rounds gave -0.9%, +5.6%, +4.7% at c16, so any effect is below this setup's ~5% noise floor. It is kept because it is strictly less host work on the same path qwen3_omni already uses, not because it measured faster. The tradeoff is measurable and consistent: c16 TTFA p95 rises from 0.36s to 0.42s (+17%) as batches run deeper. Full-grid single pass with everything on: 6.95 / 8.97 / 11.42 / 13.04 / 13.53 qps at c8-c96, zero failures, which is 98% of the same-card DP2+MPS pool peak on that box. Overload behaviour improves too: c64 +22% qps over the masks-off head (13.04 vs 10.65) with TTFA p95 1.08s, and c96 TTFA p95 is better rather than worse (2.87s vs 3.74s) with lower p99 latency throughout. C16 EN WER on that head is 1.04% against 0.99% for the same-box baseline arms, inside the 0.2pt quality gate.

## Tests

* `tests/unit_test/qwen3_omni/test_logit_shaping.py`: incremental repetition penalty equivalence across growth and retract-shrink steps; suppress-token grouped/cached path equivalence vs scalar reference (shared and per-row lists, out-of-range ids, repeated calls through the cache).
* `tests/unit_test/qwen3_tts/test_pipeline.py`: abort-race cleanup test adapted to the threaded executor, same contract (late finish after abort still cleans the prepared registry); stream-prune window test asserting pruned decode windows stay byte-identical to full-history slicing while chunks actually get dropped.
* `tests/unit_test/qwen3_tts/test_mask_logit_shaping.py`: mask shaping equals the scalar reference across steady steps, request-id reuse, batch shrink, history shrink after a retract, and an emptied history.
* `tests/unit_test/qwen3_tts/test_pipeline.py`: a decode batch with one out-of-range row fails exactly that row, keeps the decoder from ever seeing the bad id, and still decodes the remaining rows.
* Full `qwen3_tts` + `scheduling` + `model_runner` + `qwen3_omni` unit suites green (191 in the TTS-facing subset after the follow-up work; 463 across the wider set earlier in the branch).

## Cross-model disclosure

`model_runner/base.py` and `threaded_simple_scheduler.py` are shared surfaces: the penalty/suppress helpers also serve the thinker path (qwen3_omni), and the threaded scheduler is used by higgs/fish/moss_tts_local preprocessing. The suppress/penalty changes are output-equivalent by unit test; the scheduler change is additive (new optional parameter, default None keeps prior behavior).

## Acknowledgements

Thanks to @vuuihc for the original bounded ThreadedSimpleScheduler abort-marker cleanup in #611. This PR incorporated that earlier work while adding the abort_callback contract; I missed the cross-reference when #1462 was merged.