### PR TITLE
[ASR][Perf] Enable async lookahead for Whisper ASR

### DIFF
--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -13,10 +13,23 @@ hf download openai/whisper-large-v3
 ## Server Configuration
 
 Whisper ASR runs a single ASR stage on one GPU.
+Async decode is enabled by default for all decode batch sizes, allowing the
+shared one-step-lookahead path to overlap host-side result processing with the
+next GPU decode forward even for a single request. Use `--decode-mode sync` to
+disable it, or tune the crossover with `--async-lookahead-min-batch-size`.
 
 ```bash
 sgl-omni serve \
   --model-path openai/whisper-large-v3 \
+  --port 8000
+```
+
+For example, force synchronous decode when comparing modes:
+
+```bash
+sgl-omni serve \
+  --model-path openai/whisper-large-v3 \
+  --decode-mode sync \
   --port 8000
 ```
 
@@ -62,6 +75,75 @@ The request builder also supports `task` (`transcribe` by default) and
 the fields above. The route uses the ASR stage default unless the pipeline is
 configured another way. For smoke tests, keep the request minimal and use
 `response_format=json`.
+
+## Async Decode A/B Comparison
+
+Compare sync decode against the default async lookahead path with the shared
+SeedTTS ASR concurrency benchmark. Keep the model, dataset revision, sample
+subset, concurrency list, and repeat count identical across arms.
+
+Higher concurrency currently needs atomic encoder-prefix admission
+(`chunked_prefill_size=0`) until W-PR1 lands; otherwise concurrent prefills can
+crash the Whisper stage. The A/B profile below sets that override via
+`runtime_overrides`.
+
+```bash
+MODEL_PATH=$(hf download openai/whisper-base)
+cat > /tmp/whisper_async_ab.yaml <<EOF
+config_cls: WhisperASRPipelineConfig
+name: whisper-async-ab
+model_path: ${MODEL_PATH}
+runtime_overrides:
+  asr:
+    server_args_overrides:
+      chunked_prefill_size: 0
+EOF
+
+PORT_SYNC=8101
+PORT_ASYNC=8102
+
+# Arm A: sync decode (baseline)
+CUDA_VISIBLE_DEVICES=0 sgl-omni serve \
+  --config /tmp/whisper_async_ab.yaml \
+  --model-name openai/whisper-base \
+  --decode-mode sync \
+  --port "${PORT_SYNC}"
+
+# Arm B: async decode with min batch size 1 (candidate / default)
+CUDA_VISIBLE_DEVICES=1 sgl-omni serve \
+  --config /tmp/whisper_async_ab.yaml \
+  --model-name openai/whisper-base \
+  --decode-mode async \
+  --async-lookahead-min-batch-size 1 \
+  --port "${PORT_ASYNC}"
+
+# Same client workload against each arm:
+for PORT in "${PORT_SYNC}" "${PORT_ASYNC}"; do
+  python -m benchmarks.eval.benchmark_asr_seedtts \
+    --port "${PORT}" \
+    --model-path openai/whisper-base \
+    --max-samples 20 \
+    --concurrencies 1,2,4,8 \
+    --repeats 3 --warmup \
+    --output "whisper_async_ab_port${PORT}.json"
+done
+```
+
+### Measured H200 result (`openai/whisper-base`, 20 SeedTTS EN clips)
+
+Both arms evaluated 60/60 requests at every concurrency with identical corpus
+WER `0.0415`. Async lookahead (`min_batch_size=1`) improved throughput at every
+measured level:
+
+| Concurrency | Sync req/s | Async req/s | Throughput gain | Sync mean latency (s) | Async mean latency (s) |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 20.440 | 21.592 | +5.6% | 0.049 | 0.046 |
+| 2 | 28.827 | 29.314 | +1.7% | 0.069 | 0.068 |
+| 4 | 36.177 | 38.154 | +5.5% | 0.109 | 0.104 |
+| 8 | 42.686 | 44.550 | +4.4% | 0.182 | 0.174 |
+
+Accept the async default only when corpus WER matches the sync arm and
+throughput or latency improves on the target concurrency (especially c=1).
 
 ## Known Limitations
 

--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -76,16 +76,17 @@ the fields above. The route uses the ASR stage default unless the pipeline is
 configured another way. For smoke tests, keep the request minimal and use
 `response_format=json`.
 
-## Async Decode A/B Comparison
+## Benchmarking
 
-Compare sync decode against the default async lookahead path with the shared
-SeedTTS ASR concurrency benchmark. Keep the model, dataset revision, sample
-subset, concurrency list, and repeat count identical across arms.
+Use `benchmarks/eval/benchmark_asr_seedtts.py` to sweep ASR concurrency on
+SeedTTS reference audio through `/v1/audio/transcriptions`. Compare sync and
+async decode with `--decode-mode` while keeping the model, sample subset,
+concurrency list, and repeat count identical across arms.
 
 Higher concurrency currently needs atomic encoder-prefix admission
-(`chunked_prefill_size=0`) until W-PR1 lands; otherwise concurrent prefills can
-crash the Whisper stage. The A/B profile below sets that override via
-`runtime_overrides`.
+(`chunked_prefill_size=0`; see [#1412](https://github.com/sgl-project/sglang-omni/pull/1412));
+otherwise concurrent prefills can crash the Whisper stage. The profile below
+sets that override via `runtime_overrides`.
 
 ```bash
 MODEL_PATH=$(hf download openai/whisper-base)
@@ -109,7 +110,7 @@ CUDA_VISIBLE_DEVICES=0 sgl-omni serve \
   --decode-mode sync \
   --port "${PORT_SYNC}"
 
-# Arm B: async decode with min batch size 1 (candidate / default)
+# Arm B: async decode with min batch size 1 (default)
 CUDA_VISIBLE_DEVICES=1 sgl-omni serve \
   --config /tmp/whisper_async_ab.yaml \
   --model-name openai/whisper-base \
@@ -117,7 +118,6 @@ CUDA_VISIBLE_DEVICES=1 sgl-omni serve \
   --async-lookahead-min-batch-size 1 \
   --port "${PORT_ASYNC}"
 
-# Same client workload against each arm:
 for PORT in "${PORT_SYNC}" "${PORT_ASYNC}"; do
   python -m benchmarks.eval.benchmark_asr_seedtts \
     --port "${PORT}" \
@@ -129,10 +129,9 @@ for PORT in "${PORT_SYNC}" "${PORT_ASYNC}"; do
 done
 ```
 
-### Measured H200 result (`openai/whisper-base`, 20 SeedTTS EN clips)
-
-Both arms evaluated 60/60 requests at every concurrency with identical corpus
-WER `0.0415`. Async lookahead (`min_batch_size=1`) improved throughput at every
+On one H200 with `openai/whisper-base` and 20 SeedTTS EN clips, both arms
+evaluated 60/60 requests at every concurrency with identical corpus WER
+`0.0415`. Async lookahead (`min_batch_size=1`) improved throughput at every
 measured level:
 
 | Concurrency | Sync req/s | Async req/s | Throughput gain | Sync mean latency (s) | Async mean latency (s) |
@@ -141,9 +140,6 @@ measured level:
 | 2 | 28.827 | 29.314 | +1.7% | 0.069 | 0.068 |
 | 4 | 36.177 | 38.154 | +5.5% | 0.109 | 0.104 |
 | 8 | 42.686 | 44.550 | +4.4% | 0.182 | 0.174 |
-
-Accept the async default only when corpus WER matches the sync arm and
-throughput or latency improves on the target concurrency (especially c=1).
 
 ## Known Limitations
 

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -38,11 +38,12 @@ _ASYNC_DECODE_FACTORIES = frozenset(
         "create_sglang_moss_transcribe_diarize_executor",
         "sglang_omni.models.fun_asr.stages.create_sglang_fun_asr_executor",
         "sglang_omni.models.qwen3_asr.stages.create_sglang_qwen3_asr_executor",
+        "sglang_omni.models.whisper_asr.stages.create_sglang_whisper_asr_executor",
     }
 )
 _ASYNC_DECODE_SUPPORTED_MODELS = (
     "Higgs TTS, MOSS-TTS-Local, MOSS-Transcribe-Diarize, Fun-ASR, "
-    "Qwen3-ASR, and the Qwen3-Omni thinker"
+    "Qwen3-ASR, Whisper ASR, and the Qwen3-Omni thinker"
 )
 _PREFILL_COALESCE_FACTORIES = frozenset(
     {
@@ -1265,7 +1266,7 @@ def serve(
                 "default. Async mode enables one-step lookahead, "
                 "which can overlap the previous step's host-side collect with "
                 "the next GPU forward. Available for Higgs TTS, MOSS-TTS-Local, "
-                "MOSS-Transcribe-Diarize, Fun-ASR, and Qwen3-ASR."
+                "MOSS-Transcribe-Diarize, Fun-ASR, Qwen3-ASR, and Whisper ASR."
             ),
         ),
     ] = None,
@@ -1277,7 +1278,7 @@ def serve(
             help=(
                 "Decode batches smaller than this bypass async lookahead and "
                 "run synchronously (fast path). Model default: 1 for "
-                "Qwen3-ASR and 2 for other supported models."
+                "Qwen3-ASR and Whisper ASR, and 2 for other supported models."
             ),
         ),
     ] = None,

--- a/sglang_omni/models/whisper_asr/engine_builder.py
+++ b/sglang_omni/models/whisper_asr/engine_builder.py
@@ -18,10 +18,14 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
         max_running_requests: int,
         max_new_tokens: int,
         mem_fraction_static: float,
+        enable_async_decode: bool,
+        async_decode_min_batch_size: int,
     ) -> None:
         self.max_running_requests = max_running_requests
         self.max_new_tokens = max_new_tokens
         self.mem_fraction_static = mem_fraction_static
+        self.enable_async_decode = enable_async_decode
+        self.async_decode_min_batch_size = async_decode_min_batch_size
         self.processor: Any = None
         self.tokenizer: Any = None
         self.generation_config: Any = None
@@ -65,3 +69,9 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
             encoder_token_count=self.encoder_token_count,
             max_new_tokens=self.max_new_tokens,
         )
+
+    def extra_scheduler_kwargs(self) -> dict[str, Any]:
+        return {
+            "enable_async_decode": self.enable_async_decode,
+            "async_decode_min_batch_size": self.async_decode_min_batch_size,
+        }

--- a/sglang_omni/models/whisper_asr/stages.py
+++ b/sglang_omni/models/whisper_asr/stages.py
@@ -14,6 +14,8 @@ def create_sglang_whisper_asr_executor(
     max_running_requests: int = 16,
     max_new_tokens: int = 256,
     mem_fraction_static: float = 0.85,
+    enable_async_decode: bool = True,
+    async_decode_min_batch_size: int = 1,
     server_args_overrides: dict[str, Any] | None = None,
 ):
     from sglang_omni.models.whisper_asr.engine_builder import WhisperASREngineBuilder
@@ -22,6 +24,8 @@ def create_sglang_whisper_asr_executor(
         max_running_requests=max_running_requests,
         mem_fraction_static=mem_fraction_static,
         max_new_tokens=max_new_tokens,
+        enable_async_decode=enable_async_decode,
+        async_decode_min_batch_size=async_decode_min_batch_size,
     ).build(
         model_path,
         device=device,

--- a/tests/unit_test/higgs_tts/test_cli_decode_mode.py
+++ b/tests/unit_test/higgs_tts/test_cli_decode_mode.py
@@ -20,6 +20,7 @@ from sglang_omni.models.moss_transcribe_diarize.config import (
 )
 from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
 from sglang_omni.models.qwen3_tts.config import Qwen3TTSPipelineConfig
+from sglang_omni.models.whisper_asr.config import WhisperASRPipelineConfig
 
 
 def _tts_engine_args(config: PipelineConfig) -> dict[str, object]:
@@ -94,7 +95,7 @@ def test_decode_mode_cli_rejects_unsupported_config():
         typer.BadParameter,
         match=(
             "Higgs TTS, MOSS-TTS-Local, MOSS-Transcribe-Diarize, Fun-ASR, "
-            "Qwen3-ASR, and the Qwen3-Omni thinker"
+            "Qwen3-ASR, Whisper ASR, and the Qwen3-Omni thinker"
         ),
     ):
         apply_decode_mode_cli_overrides(
@@ -134,6 +135,23 @@ def test_decode_mode_cli_applies_to_fun_asr_stage():
 
 def test_decode_mode_cli_applies_to_qwen3_asr_stage():
     config = Qwen3ASRPipelineConfig(model_path="dummy")
+    apply_decode_mode_cli_overrides(
+        config, decode_mode="async", async_lookahead_min_batch_size=4
+    )
+    stage = next(s for s in config.stages if s.name == "asr")
+    args = resolve_stage_factory_args(stage, config)
+    assert args["enable_async_decode"] is True
+    assert args["async_decode_min_batch_size"] == 4
+
+    apply_decode_mode_cli_overrides(
+        config, decode_mode="sync", async_lookahead_min_batch_size=None
+    )
+    args = resolve_stage_factory_args(stage, config)
+    assert args["enable_async_decode"] is False
+
+
+def test_decode_mode_cli_applies_to_whisper_asr_stage():
+    config = WhisperASRPipelineConfig(model_path="dummy")
     apply_decode_mode_cli_overrides(
         config, decode_mode="async", async_lookahead_min_batch_size=4
     )

--- a/tests/unit_test/whisper_asr/test_pipeline.py
+++ b/tests/unit_test/whisper_asr/test_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import sys
 from types import SimpleNamespace
 
@@ -25,10 +26,19 @@ def test_whisper_asr_config_uses_single_batched_stage() -> None:
     assert config.gpu_placement == {"asr": 0}
     assert config.stages[0].factory.endswith("create_sglang_whisper_asr_executor")
     assert config.stages[0].factory_args["device"] == "cuda:0"
+    assert "enable_async_decode" not in config.stages[0].factory_args
+    assert "async_decode_min_batch_size" not in config.stages[0].factory_args
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("WhisperForConditionalGeneration")
         is WhisperASRPipelineConfig
     )
+
+
+def test_whisper_asr_stage_default_enables_async_decode() -> None:
+    signature = inspect.signature(whisper_asr_stages.create_sglang_whisper_asr_executor)
+
+    assert signature.parameters["enable_async_decode"].default is True
+    assert signature.parameters["async_decode_min_batch_size"].default == 1
 
 
 def test_whisper_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
@@ -105,7 +115,91 @@ def test_whisper_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
         _fake_create_infrastructure,
     )
 
-    whisper_asr_stages.create_sglang_whisper_asr_executor("dummy")
+    scheduler = whisper_asr_stages.create_sglang_whisper_asr_executor(
+        "dummy",
+        enable_async_decode=False,
+        async_decode_min_batch_size=4,
+    )
 
     assert build_kwargs["cuda_graph_max_bs"] == 16
     assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 12, 16]
+    assert scheduler.enable_async_decode is False
+    assert scheduler.async_decode_min_batch_size == 4
+
+
+def test_whisper_asr_threads_default_async_decode(monkeypatch) -> None:
+    fake_processor = SimpleNamespace(
+        tokenizer=object(),
+        feature_extractor=SimpleNamespace(nb_max_frames=3000),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        SimpleNamespace(
+            AutoProcessor=SimpleNamespace(
+                from_pretrained=lambda *args, **kwargs: fake_processor
+            ),
+            GenerationConfig=SimpleNamespace(
+                from_pretrained=lambda *args, **kwargs: object()
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        whisper_request_builders,
+        "make_whisper_scheduler_adapters",
+        lambda **kwargs: (object(), object()),
+    )
+    monkeypatch.setattr(
+        model_runner_base,
+        "ModelRunner",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        sglang_backend,
+        "SGLangOutputProcessor",
+        lambda **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        omni_scheduler,
+        "OmniScheduler",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    def _fake_server_args_builder(model_path, context_length, **overrides):
+        server_args = FakeServerArgs(**overrides)
+        server_args.cuda_graph_config = SimpleNamespace(
+            decode=SimpleNamespace(
+                max_bs=overrides["cuda_graph_max_bs"],
+                bs=overrides["cuda_graph_bs"],
+            ),
+            prefill=SimpleNamespace(backend="disabled", bs=None, max_bs=None),
+        )
+        return server_args
+
+    def _fake_create_infrastructure(server_args, gpu_id, **kwargs):
+        model_worker = SimpleNamespace(model_runner=SimpleNamespace(model=object()))
+        return False, (
+            model_worker,
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+        )
+
+    monkeypatch.setattr(
+        sglang_backend,
+        "build_sglang_server_args",
+        _fake_server_args_builder,
+    )
+    monkeypatch.setattr(
+        bootstrap,
+        "create_sglang_infrastructure_defer_cuda_graph",
+        _fake_create_infrastructure,
+    )
+
+    scheduler = whisper_asr_stages.create_sglang_whisper_asr_executor("dummy")
+
+    assert scheduler.enable_async_decode is True
+    assert scheduler.async_decode_min_batch_size == 1


### PR DESCRIPTION
## Summary
- Enable the shared one-step-lookahead async decode path for Whisper ASR (`enable_async_decode=True`, `async_decode_min_batch_size=1`), matching the Qwen3-ASR crossover.
- Wire Whisper into `--decode-mode` / `--async-lookahead-min-batch-size` so  sync vs async A/B is one CLI flag flip.
- Document the SeedTTS concurrency A/B recipe and H200 results in the Whispercookbook.

Implements **W-PR4** from #1396.

## Dependency
Higher-concurrency serving still hits the encoder-prefix / chunked-prefill lifecycle crash until **W-PR1** lands:
- Depends on / should land after [#1412](https://github.com/sgl-project/sglang-omni/pull/1412) (bucketed encoder CUDA graphs + **atomic prefill**, `chunked_prefill_size=0`).
- This PR does **not** change Whisper’s default `chunked_prefill_size`.
- A/B measurements below used a temporary `runtime_overrides` profile with`chunked_prefill_size=0` so c=4/c=8 could run safely before #1412 merges.
- c=1/c=2 already improve without that override; c≥4 needs #1412 (or the same override) for a stable serving path.

## Test plan
- [x] Unit: `tests/unit_test/whisper_asr/test_pipeline.py`
- [x] Unit: `tests/unit_test/higgs_tts/test_cli_decode_mode.py` (Whisper CLI override)
- [x] A/B on 1×H200, `openai/whisper-base`, SeedTTS EN 20 clips, c=1/2/4/8, 3 repeats + warmup; sync vs async(`min_batch_size=1`)
- [ ] Re-validate after #1412 merges without the temporary`chunked_prefill_size=0` override

## Accuracy / Perf (H200)
Both arms: 60/60 evaluated per concurrency, corpus WER **0.0415** (unchanged).
| Concurrency | Sync req/s | Async req/s | Gain | Sync mean lat (s) | Async mean lat (s) |
|---:|---:|---:|---:|---:|---:|
| 1 | 20.440 | 21.592 | +5.6% | 0.049 | 0.046 |
| 2 | 28.827 | 29.314 | +1.7% | 0.069 | 0.068 |
| 4 | 36.177 | 38.154 | +5.5% | 0.109 | 0.104 |
| 8 | 42.686 | 44.550 | +4.4% | 0.182 | 0.174 |