### PR TITLE
[Docs] Document configuration flow and refactor proposal

### DIFF
--- a/docs/design/configuration_interface_refactor_proposal.md
+++ b/docs/design/configuration_interface_refactor_proposal.md
@@ -95,6 +95,8 @@ sgl-omni serve \
 
 Tracking issue: [#1466](https://github.com/sgl-project/sglang-omni/issues/1466)
 
+English version: [Configuration Interface Refactoring Design Proposal](./configuration_interface_refactor_proposal_en.md)
+
 重构目标是：
 
 1. **统一配置处理代码**：同一个用户语义只有一个 canonical config path；YAML、CLI 和 Router 全部进入同一个解析、类型转换、优先级、校验和冲突处理流程。
@@ -531,7 +533,7 @@ sgl-omni serve \
   --set pipeline.stages.thinker.placement.tp=2
 ```
 
-value 使用 YAML scalar/flow value 解析，因此 bool、None、number、list 和 dict 具有同一类型规则。path 必须存在于 public schema；不能写 runtime-derived 或 deprecated internal path。
+value 使用 YAML scalar/flow value 解析，因此 bool、null、number、list 和 dict 具有同一类型规则。path 必须存在于 public schema；不能写 runtime-derived 或 deprecated internal path。
 
 ## 6.3 专用 CLI 的最终定位
 
@@ -601,14 +603,14 @@ class ConfigPatch(BaseModel):
     layer: int
 ```
 
-V1 操作只包含 `set` 和 `declare_stage`：
+初版 patch protocol 的操作只包含 `set` 和 `declare_stage`：
 
 - `set` 设置一个 typed value；`null` 始终是普通值，用于清空允许为 null 的 optional field；
 - `declare_stage` 只由 `document_mode: full` 的 YAML adapter 产生，用于声明 stage name 和 stage type。
 
-full document 从空 topology 开始，可以声明 stage；partial document 和 CLI `--set` 只能修改已经存在的 stage，不能创建或删除 stage。`stage_order` 中的名称必须与最终声明的 stages 一一对应，不能缺失、重复或引用未知 stage。V1 不提供删除继承 stage/map entry 的 patch；需要改变 stage membership 时使用 full document。
+full document 从空 topology 开始，可以声明 stage；partial document 和 CLI `--set` 只能修改已经存在的 stage，不能创建或删除 stage。`stage_order` 中的名称必须与最终声明的 stages 一一对应，不能缺失、重复或引用未知 stage。初版 patch protocol 不提供删除继承 stage/map entry 的操作；需要改变 stage membership 时使用 full document。
 
-list 在 V1 中始终整体替换，不增加 append/remove item 等顺序敏感操作。复杂 list 应优先写 YAML。
+初版 patch protocol 始终整体替换 list，不增加 append/remove item 等顺序敏感操作。复杂 list 应优先写 YAML。
 
 `ConfigPath` 不是任意字符串遍历器，而是由 public schema 编译的 path：
 
@@ -679,7 +681,7 @@ resolved config 与用户 document 分开：
 
 只能在模型加载或 worker 初始化后确定的值进入独立的 `WorkerRuntimeDerivation`，例如依赖实际 loaded backend 的兼容调整。它通过 worker startup diagnostic 和带 source 的 `ServerArgs.override()` 记录 provenance，不反向补写 `DerivedRuntimePlan` 或 `ResolvedPipelineConfig`。
 
-`config explain` 解释用户配置和输入 provenance；`runtime explain` 或 worker startup diagnostic 联合展示 `DerivedRuntimePlan` 与 `WorkerRuntimeDerivation`，解释最终 effective value。
+`config explain` 解释用户配置和输入 provenance；runtime planner diagnostic 展示 `DerivedRuntimePlan`，worker startup diagnostic 展示 `WorkerRuntimeDerivation`，共同解释最终 effective value。
 
 ## 7.5 canonical runtime namespace
 
@@ -818,7 +820,7 @@ launcher:
 
 ## 9.2 worker 传递方式
 
-V1 可以继续生成 argv，但只生成机器接口：
+初版结构化 Router 实现可以继续生成 argv，但只生成机器接口：
 
 ```text
 sgl-omni serve
@@ -863,7 +865,7 @@ managed worker 的 layer 固定：
 | 同 source 重复 | 两个 `--set` 写同 path | 启动前报错 |
 | alias/canonical 重复 | typed CLI 与 `--set` 写同 path | 启动前报错 |
 | typed/extension 重叠 | extension 试图设置公共 SGLang 字段 | schema 注册失败 |
-| parent/child 重叠 | YAML 设置 `runtime.sglang`，CLI 同层设置其 child | 同层报错；跨层允许并记录 |
+| parent/child 重叠 | 两个同层 patch source 分别设置 `runtime.sglang` 及其 child | 同层报错；跨层允许并记录 |
 | owner 违规 | 用户设置 `gpu_id` 或 endpoint | path 不公开，解析失败 |
 | capability 不支持 | 非 SGLang stage 设置 `runtime.sglang` | model validation 失败 |
 | cross-field 不一致 | TP=2 但只有一个 GPU | resolved model validation 失败 |

--- a/docs/design/configuration_interface_refactor_proposal.md
+++ b/docs/design/configuration_interface_refactor_proposal.md
@@ -1,0 +1,1199 @@
+# 配置接口重构设计方案
+
+# 1. 背景与范围
+
+SGLang-Omni 当前的配置方式有以下几种：模型 Python 默认参数、Pipeline YAML、动态 dotted CLI、专用 typed CLI、环境变量和 Router launcher YAML。多种入口本身不是问题：YAML 适合保存完整部署的静态参数，CLI 适合选择配置和动态的临时覆盖，环境变量适合进程级注入。但是现在的配置逻辑主要存在三个问题：
+
+1. **处理逻辑不统一**：同一个配置项从不同入口传入时，走的不是同一套处理代码。例如 YAML 和 CLI 都能设置同一个参数时，字段寻址、类型转换和参数校验可能需要重复实现。
+2. **开发者扩展路径不明确**：开发者增加一个配置项时，不清楚它应该进入 typed schema、CLI option、`factory_args`、`runtime_overrides` 还是模型专属配置，也不知道需要同步修改哪些模块。
+3. **用户修改路径不明确**：用户不清楚某个配置应该写入 YAML 的哪个层级、使用哪个 CLI flag，以及多个入口同时设置时最终哪个值生效。
+
+综上，重构必须同时解决“实现是否统一”“开发者如何扩展”和“用户如何配置”三个问题，而不只是替换当前的 merge 实现。
+
+## 1.1 一句话方案
+
+**一个参数只定义一次；YAML 用来长期保存，CLI 用来临时覆盖；无论从哪里传入，都交给同一段代码解析和校验。**
+
+重构前，同一个参数可能拥有多条处理路径：
+
+```text
+同一个参数
+├── YAML typed field
+├── stage_overrides
+├── runtime_overrides
+├── factory_args
+├── dotted CLI
+└── typed CLI helper
+```
+
+每条路径都可能包含自己的字段查找、类型转换、优先级和校验代码。
+
+重构后，一个参数只有一个正式地址：
+
+```text
+一个参数
+└── 一个配置路径
+    ├── YAML：长期保存
+    ├── CLI --set：临时覆盖
+    └── Router：结构化传入
+            ↓
+       同一个配置处理器
+            ↓
+       最终只读配置
+```
+
+例如 `max_running_requests` 只定义为：
+
+```text
+pipeline.stages.thinker.runtime.sglang.max_running_requests
+```
+
+YAML 可以持久化设置：
+
+```yaml
+pipeline:
+  stages:
+    thinker:
+      runtime:
+        sglang:
+          max_running_requests: 32
+```
+
+CLI 可以临时覆盖同一个路径：
+
+```bash
+sgl-omni serve \
+  --config config.yaml \
+  --set pipeline.stages.thinker.runtime.sglang.max_running_requests=32
+```
+
+两种写法最终进入同一套类型转换、范围校验、冲突检查和优先级处理代码。
+
+## 1.2 三个目标对应的解决办法
+
+| 当前问题 | 重构后的规则 |
+|---|---|
+| YAML 和 CLI 重复实现参数处理 | 所有入口先转换成统一的配置修改，再交给同一个处理器 |
+| 开发者不知道参数应该加在哪里 | 公共参数只加到公共 schema；模型参数只加到模型 extension；服务参数只加到 server config |
+| 用户不知道应该从哪里修改 | 长期配置写 YAML，临时覆盖用 `--set`，host/port/log 等服务参数使用专用 CLI |
+
+开发者新增一个公共参数时，只需要在 schema 中定义一次类型、默认值和校验，再在 runtime adapter 中消费。CLI 帮助、YAML Schema、文档和等价性测试都从这份定义生成。
+
+用户不需要理解 `factory_args`、`runtime_overrides` 或内部 planner。用户只需要找到参数的正式路径，并决定这次修改是“写入 YAML 长期保存”还是“使用 CLI 临时覆盖”。
+
+## 1.3 文档中的术语
+
+后文使用三个技术名称表示上述简单流程：
+
+- **canonical path**：一个参数唯一、正式的配置地址；
+- **ConfigPatch**：一次“把某个地址设置成某个值”的修改记录，同时保存来源是 YAML、CLI 还是 Router；
+- **ConfigResolver**：统一执行类型转换、优先级、冲突检查和校验的配置处理器。
+
+这三个名称不是三套新接口，而是同一条配置处理管道的三个环节。
+
+本文只讨论启动期配置，不改变请求协议、Stage payload、调度算法或 SGLang 内部 `ServerArgs` 的字段定义。文中“当前实现”核对的代码 revision 为 `42a124cd`；完整现状可参考 `docs/developer_reference/configuration.md`。
+
+Tracking issue: [#1466](https://github.com/sgl-project/sglang-omni/issues/1466)
+
+重构目标是：
+
+1. **统一配置处理代码**：同一个用户语义只有一个 canonical config path；YAML、CLI 和 Router 全部进入同一个解析、类型转换、优先级、校验和冲突处理流程。
+2. **建立唯一的开发者扩展接口**：新增公共配置只修改一次 typed schema；CLI、JSON Schema、文档、patch 类型和等价性测试从 schema 生成。模型专属参数使用明确的 extension schema，不再任意选择多个透传 dict。
+3. **建立可发现、可解释的用户接口**：明确 YAML 与 CLI 的职责，提供 schema、validate、resolve、explain 和 migrate 工具，让用户可以找到合法配置路径并确认最终值来源。
+
+配置在进入 placement/runtime 前应一次性 resolve、完整校验并冻结；旧接口通过分阶段迁移兼容，但不永久保留两套语义。
+
+本文不要求一次性重写全部模型配置。新接口先稳定配置边界，再逐步迁移模型专属参数。
+
+# 2. 当前配置接口与执行链路
+
+## 2.1 配置来源
+
+当前公开配置来源可以分成六类：
+
+| 来源 | 当前入口 | 主要实现 |
+|---|---|---|
+| 模型默认 | `PipelineConfig` 子类、`Variants` | `models/*/config.py`、`config/manager.py` |
+| Pipeline YAML | `sgl-omni serve --config` | `ConfigManager.from_file()` |
+| YAML 紧凑覆盖 | `stage_overrides`、`runtime_overrides` | `config/manager.py`、`config/runtime.py` |
+| 动态 CLI | `--stages.thinker... VALUE` | `ConfigManager.parse_extra_args()` |
+| 专用 CLI | `--mem-fraction-static` 等 | `cli/serve.py` 中的 `apply_*_cli_overrides()` |
+| Router launcher | `--launcher-config`、`worker_extra_args` | `sglang_omni_router/launcher/*` |
+
+`sgl-omni serve` 对未知 option 开启 `ignore_unknown_options`，因此 Typer 先解析 41 个专用参数，剩余 token 再由 `ConfigManager` 解析为 dotted override。两类 CLI 在不同阶段执行。
+
+## 2.2 当前合并顺序
+
+当前主进程按以下顺序构造最终 `PipelineConfig`：
+
+1. 有 `--config` 时用 YAML 中的 `config_cls` 构造配置类；否则通过 `model_path` 识别模型 architecture；
+2. YAML `stage_overrides` 深合并到 typed `StageRuntimeConfig`；
+3. `ctx.args` 中的 dotted CLI 修改 `model_dump()` 后的 dict，再重建 Pydantic model；
+4. 显式 `--model-path` 覆盖 YAML 中的 `model_path`；
+5. `serve.py` 依次执行 memory、TP/GPU、process、CUDA graph、compile、decode、prefill 和 generation batch helper；
+6. `launch_server()` 将 HTTP/API 参数与 `PipelineConfig` 分开传入；
+7. runtime preparation 构造 placement、process topology、endpoint 和 worker spec；
+8. worker 子进程合并 factory args，并在 factory 内构造 `ServerArgs` 和 `ModelConfig`。
+
+| 顺序 | 处理阶段 | 输入与输出 |
+|---|---|---|
+| 1 | 选择基础配置 | 模型 Python 默认或 Pipeline YAML → `ConfigManager` |
+| 2 | 应用 YAML 紧凑覆盖 | `stage_overrides` → typed runtime |
+| 3 | 应用动态 CLI | dotted CLI → 重建 `PipelineConfig` |
+| 4 | 应用专用 CLI | typed CLI helpers → 原地修改 `PipelineConfig` |
+| 5 | 运行时规划 | `PipelineConfig` → placement、process topology、worker spec |
+| 6 | worker 构造 | worker spec → stage factory → `ServerArgs` |
+
+该顺序表面上提供了优先级，但优先级并不是一条统一规则。不同 helper 会选择“覆盖”“拒绝”“同步两个 alias”“同时写 `factory_args` 和 `runtime_overrides`”或“等到 worker 再报冲突”。
+
+## 2.3 当前 factory 参数路径
+
+stage factory kwargs 由以下来源组合：
+
+```text
+factory_args
+< runtime_overrides
+< typed runtime 映射
++ signature-dependent defaults
+```
+
+其中 `server_args_overrides` 在 `factory_args` 和 `runtime_overrides` 之间执行一层 dict merge；typed `runtime.max_seq_len` 和 `runtime.video_fps` 通过 `runtime_arg_map` 改名；typed `mem_fraction_static` 最终又写回 `server_args_overrides`。
+
+`model_path`、`gpu_id` 和 `total_gpu_memory_fraction` 不是普通用户 factory args。它们在 worker import factory 后，根据函数签名按需注入。`gpu_id`、process cumulative budget、NCCL port 和 IPC endpoints 由 planner/runner 派生。
+
+# 3. 当前设计的问题
+
+## 3.1 同一语义存在多个用户入口
+
+`mem_fraction_static` 是最完整的代表：
+
+| 入口 | 写入位置 | 校验位置 |
+|---|---|---|
+| YAML typed runtime | `stage.runtime.sglang_server_args.mem_fraction_static` | Pydantic schema |
+| YAML compatibility override | `runtime_overrides.<stage>.server_args_overrides.mem_fraction_static` | runtime adapter |
+| 完整 stage YAML | `factory_args.server_args_overrides.mem_fraction_static` | runtime adapter |
+| dotted CLI | 可写上面任意路径 | merge 后 Pydantic/runtime adapter |
+| global typed CLI | `--mem-fraction-static` | `apply_mem_fraction_cli_overrides()` |
+| role typed CLI | `--thinker-mem-fraction-static` 等 | 同一 helper 和 role map |
+
+当前代码需要显式检测 typed runtime 与 `server_args_overrides` 的重复来源。这种检测只能覆盖已知冲突；新增来源时容易遗漏。
+
+generation batch 也有同类问题。`max_running_requests` 可以来自：
+
+- 模型 factory 默认；
+- YAML `factory_args`；
+- YAML `runtime_overrides`；
+- dotted CLI；
+- `--thinker-max-running-requests`；
+- `--max-running-requests`；
+- 模型 generation batch policy 的派生或校验。
+
+用户看到的是一个功能，代码维护的是多条路径。
+
+## 3.2 YAML 同时承担“配置实例”和“补丁”
+
+当前 YAML 可以是：
+
+1. 只包含 `config_cls` 和 `model_path` 的模板选择；
+2. 带 `stage_overrides` 的紧凑 patch；
+3. 带 `runtime_overrides` 的 factory patch；
+4. 带完整 `stages` 的 resolved-like 配置。
+
+四种写法进入不同 merge 逻辑。特别是：
+
+- `stage_overrides` 只允许 typed `runtime`；
+- `runtime_overrides` 是自由 dict；
+- 完整 `stages` 整体替换模型默认列表；
+- 同一 YAML 中可以混合这些形式。
+
+因此“这个字段应该写在哪里”不能只从字段语义回答，还取决于用户选择了哪种 YAML 形态。
+
+## 3.3 CLI 既是接口层，也是业务层
+
+`cli/serve.py` 不仅声明 option，还负责：
+
+- public role 到模型 stage 的解析；
+- 修改 nested Pydantic object；
+- 同步 `tp_size` 与 `parallelism.tp`；
+- 把参数写入 `factory_args` 和 `runtime_overrides`；
+- 检查 factory 是否属于支持集合；
+- 执行 GPU topology probe；
+- 重跑部分 Pydantic validation。
+
+这导致新增一个 runtime 参数通常需要同时修改：
+
+1. Typer 签名；
+2. CLI helper；
+3. role map；
+4. runtime adapter 或 factory；
+5. 测试；
+6. 文档。
+
+CLI 不再是输入 adapter，而成为第二个配置编译器。
+
+## 3.4 原地 mutation 绕过 schema validation
+
+当前 Pydantic models 没有启用 `validate_assignment=True`。`ConfigManager.merge_config()` 会 dump、deepcopy、重建，因此能执行完整 validation；大多数 typed CLI helper 则直接修改：
+
+- `stage.gpu`
+- `stage.tp_size`
+- `stage.runtime.*`
+- `stage.factory_args`
+- `pipeline_config.runtime_overrides`
+
+helper 必须自行保证原子性和校验完整性。部分路径会手动重建整个 config，部分路径只做局部范围检查。配置是否合法取决于修改它的具体 helper，而不是 config schema 本身。
+
+## 3.5 动态 dotted CLI 缺少稳定契约
+
+动态 CLI 把 `-` 转 `_`，按 `.` 遍历 dict/list，并只支持 bool、None、int、float 和 string scalar。它存在以下限制：
+
+- 可以写任意内部字段，包括不应公开的兼容字段；
+- stage list 同时支持数字 index 和 name，导出配置变化后 index 不稳定；
+- list/dict 没有统一编码；
+- path 不存在时可能抛出 `KeyError`/`IndexError`，错误格式不统一；
+- 无法从 Typer help 得到可用路径；
+- 内部字段重命名会直接破坏用户命令。
+
+开放 override 本身有价值，但必须针对 public schema，而不是直接暴露 `model_dump()` 的内部结构。
+
+## 3.6 Router 把结构化配置重新变成字符串
+
+这里涉及两份作用不同的 YAML：
+
+1. **Router launcher YAML**：描述启动几个完整 worker、为它们分配哪些 GPU 和端口；
+2. **Pipeline YAML**：描述每个 worker 内部使用哪个 Pipeline、stage topology 和 runtime 参数。
+
+当前 Router launcher YAML 不能结构化描述 worker 的 Pipeline 配置，只能把 worker 参数写成一段字符串：
+
+```yaml
+launcher:
+  model_path: Qwen/Qwen3-Omni
+  num_workers: 2
+  worker_extra_args: "--config examples/configs/qwen.yaml --colocate"
+```
+
+Router 先为一个 worker 生成基础命令：
+
+```bash
+sgl-omni serve \
+  --model-path Qwen/Qwen3-Omni \
+  --host 127.0.0.1 \
+  --port 8011
+```
+
+`worker_extra_args` 此时仍然只是普通字符串。Router 使用 `shlex.split()` 将它拆成：
+
+```python
+["--config", "examples/configs/qwen.yaml", "--colocate"]
+```
+
+再把这些参数追加到基础命令：
+
+```bash
+sgl-omni serve \
+  --model-path Qwen/Qwen3-Omni \
+  --host 127.0.0.1 \
+  --port 8011 \
+  --config examples/configs/qwen.yaml \
+  --colocate
+```
+
+Router 启动该 worker 子进程时，还通过环境变量设置物理 GPU：
+
+```bash
+CUDA_VISIBLE_DEVICES=0
+```
+
+worker 启动之后，`sgl-omni serve` 才会解析 `--config`，再由 `ConfigManager` 加载第二份 Pipeline YAML。因此实际链路是：
+
+```text
+Router launcher YAML
+→ 读取 worker_extra_args 字符串
+→ shlex.split 拆成 worker CLI 参数
+→ 启动 sgl-omni serve 子进程
+→ worker 解析 --config
+→ ConfigManager 加载 Pipeline YAML
+```
+
+问题不是 Router 启动 worker 本身，而是 Router 只知道一段字符串，不理解其中配置了什么。字段类型、重复 option、Pipeline 文件路径和参数兼容性都只能等 worker 启动后验证；Router schema 无法提前说明或检查 worker 的实际配置。
+
+## 3.7 最终配置缺少 provenance
+
+当前 debug merged config 只显示最终 `PipelineConfig`，不能回答：
+
+- 某个值来自模型默认、YAML 还是 CLI；
+- 它覆盖了哪个旧值；
+- 是否通过 deprecated path 设置；
+- 后续是否还会被 factory defaults 或 `ServerArgs.override()` 修改。
+
+当多个入口冲突时，维护者只能反向阅读 `serve()` 的 helper 顺序。
+
+# 4. 设计原则与非目标
+
+## 4.1 三个核心目标如何落地
+
+| 核心目标 | 设计机制 | 验收标准 |
+|---|---|---|
+| 统一配置处理代码 | canonical schema、`ConfigPatch`、唯一 `ConfigResolver` | YAML、`--set` 和迁移期 CLI alias 对同一字段产生相同 resolved value，且不再包含入口专属 mutation helper |
+| 明确开发者扩展接口 | public typed schema、model extension schema、schema metadata 生成 CLI/文档/测试 | 新增公共字段只定义一次；新增模型字段只能进入注册过的 extension schema |
+| 明确用户修改方式 | YAML/CLI 职责边界、name-keyed path、`config schema/validate/resolve/explain/migrate` | 用户可以发现合法 path、在启动前验证配置，并看到最终值及覆盖来源 |
+
+后续所有数据结构、迁移步骤和测试都必须服务于这三个目标。若某项设计只减少内部代码、却没有降低开发者或用户的选择成本，则不视为完成本次重构。
+
+## 4.2 设计原则
+
+1. **一个语义，一个 canonical path**：相同运行时功能不得同时暴露 typed 和 untyped public path。
+2. **输入 adapter 无业务逻辑**：YAML、CLI、Router 只产生 typed assignment/patch。
+3. **一次 resolve，一次完整 validation**：进入 runtime planner 后配置冻结。
+4. **用户配置与派生计划分离**：GPU logical placement 可以配置，`gpu_id`、endpoint、NCCL port 等 runtime 值不可配置。
+5. **显式覆盖，保留来源**：跨层覆盖允许，但必须可解释；同层重复定义直接失败。
+6. **兼容层有删除终点**：旧接口可以适配，但不能永久成为第二套 canonical schema。
+
+## 4.3 非目标
+
+- 不把 SGLang 的全部 `ServerArgs` 原样复制成 Omni 顶层 CLI；
+- 不让 YAML 选择 ZMQ/CUDA IPC 等由 locality/placement 推导的 transport；
+- 不在本次重构中改变 Stage/process/TP 的运行时语义；
+- 不允许 request-time 参数进入启动期 `PipelineConfig`；
+- 不要求 Router 与 worker 共享同一个顶层 schema，它们只共享 patch 表达。
+
+# 5. 新设计总览
+
+新设计增加一个单向配置编译阶段：
+
+```text
+Input documents
+→ adapters
+→ ConfigPatchSet
+→ ConfigResolver
+→ immutable ResolvedPipelineConfig
+→ runtime planners
+→ worker specs
+```
+
+| 顺序 | 处理阶段 | 职责 |
+|---|---|---|
+| 1 | 输入 adapter | Python defaults、YAML、CLI、兼容入口和 Router 都转换成 `ConfigPatch` |
+| 2 | `ConfigPatchSet` | 保存所有修改及其来源，不执行入口专属业务逻辑 |
+| 3 | `ConfigResolver` | 统一处理类型、优先级、重复定义、冲突和完整校验 |
+| 4 | `ResolvedPipelineConfig` | 生成完整、只读并带 provenance 的最终用户配置 |
+| 5 | Runtime planners | 只读最终配置，生成 placement、process 和 derived runtime plans |
+| 6 | Worker specs | 根据最终配置和 plans 构造跨进程启动参数 |
+
+所有 adapter 只依赖 public schema 和 path registry。`ConfigResolver` 是唯一执行 precedence、alias normalization、duplicate detection 和 merge 的组件。runtime planner 不再读取 unresolved compatibility fields。
+
+# 6. 新的用户接口
+
+## 6.1 YAML 是 Pipeline 的持久化声明
+
+当前 YAML 既可以完整列出所有 stages，也可以只写基于模型默认值的修改项，但文件本身没有明确说明自己属于哪一种。V2 使用 `document_mode` 把两种用途区分开。
+
+### `full`：完整 Pipeline
+
+`full` 从空 topology 开始构造，不继承模型配置类的默认 stages。文件必须完整声明 entry stage、所有 stages 和构造顺序，单独拿到该文件就能确定整个 Pipeline。下面的 `example.*` factory 仅用于展示结构。
+
+```yaml
+schema_version: 2
+document_mode: full
+
+model:
+  path: Qwen/Qwen3-Omni-30B-A3B-Instruct
+
+pipeline:
+  name: qwen3-omni-text
+  entry_stage: preprocessing
+
+  stage_order:
+    - preprocessing
+    - thinker
+    - decode
+
+  stages:
+    preprocessing:
+      factory: example.create_preprocessing
+      process: pipeline
+      next: thinker
+
+    thinker:
+      factory: example.create_thinker
+      process: pipeline
+      next: decode
+      placement:
+        gpus: [0]
+      runtime:
+        sglang:
+          max_running_requests: 32
+
+    decode:
+      factory: example.create_decode
+      process: pipeline
+      terminal: true
+```
+
+`stage_order` 必须与 `stages` 中的名称一一对应，不能缺少、重复或引用不存在的 stage。`config export` 默认输出这种完整形式，适合归档和精确复现。
+
+### `partial`：在模型模板上修改少量字段
+
+`partial` 必须通过 `model.config` 或 variant 选择一个模型模板。resolver 先创建模板的默认 Pipeline，再应用 YAML 中写出的修改；没有写出的 stage 和字段保持模型默认值。
+
+```yaml
+schema_version: 2
+document_mode: partial
+
+model:
+  path: Qwen/Qwen3-Omni-30B-A3B-Instruct
+  config: Qwen3OmniSpeechColocatedPipelineConfig
+
+pipeline:
+  stages:
+    thinker:
+      runtime:
+        sglang:
+          max_running_requests: 32
+```
+
+这个例子的含义只有三步：
+
+1. 创建 `Qwen3OmniSpeechColocatedPipelineConfig` 默认 Pipeline；
+2. 找到名为 `thinker` 的 stage；
+3. 把 `max_running_requests` 改成 32。
+
+`partial` 可以省略不修改的内容，但只能修改模板中已经存在的 stage，不能创建或删除 stage。需要改变完整 topology 时，应使用 `full`。
+
+### 为什么 stages 改成按名称保存
+
+当前配置把 stages 保存为 list，动态 CLI 可能需要使用不稳定的数字位置：
+
+```text
+stages.4.runtime...
+```
+
+V2 将 stages 保存为 name-keyed mapping：
+
+```text
+pipeline.stages.thinker.runtime...
+```
+
+stage 名成为稳定身份，YAML 和 CLI 可以使用同一个路径，不再依赖 list index。mapping 本身不负责表达构造顺序，因此 `full` document 额外使用 `stage_order`；`partial` 直接继承模板已有的顺序。
+
+当前 `stage_overrides` 之所以存在，是因为用户需要按 stage 名修改默认 stage list。V2 的 `partial.pipeline.stages.<name>` 本身就是 canonical 修改路径，因此不再需要单独设计一套 `stage_overrides` merge 逻辑。
+
+## 6.2 CLI 只保留启动参数和通用 patch
+
+steady-state `serve` 接口分成三组：
+
+### 配置选择
+
+```text
+--config FILE
+```
+
+或：
+
+```text
+--model-path MODEL [--variant text|speech|...]
+```
+
+两种模式互斥。`--model-path` 是“从模型默认构造配置”的 shorthand；当 `--config` 已包含 `model.path` 时，不能再覆盖它。
+
+### 服务进程参数
+
+以下值不属于 Pipeline，继续作为 CLI option：
+
+```text
+--host
+--port
+--model-name
+--log-level
+--allowed-local-media-path
+--allowed-media-domain
+--tts-batch-max-items
+--enable-realtime
+```
+
+它们由 `ServerLaunchConfig` 单独接收，不写入 `PipelineConfig`。如未来需要保存服务配置，应引入独立 deployment document，而不是塞入 Pipeline YAML。
+
+### Pipeline 临时覆盖
+
+统一使用可重复的：
+
+```text
+--set PATH=VALUE
+```
+
+例如：
+
+```bash
+sgl-omni serve \
+  --config qwen.yaml \
+  --set pipeline.stages.thinker.runtime.sglang.max_running_requests=32 \
+  --set pipeline.stages.thinker.placement.gpus='[0,1]' \
+  --set pipeline.stages.thinker.placement.tp=2
+```
+
+value 使用 YAML scalar/flow value 解析，因此 bool、None、number、list 和 dict 具有同一类型规则。path 必须存在于 public schema；不能写 runtime-derived 或 deprecated internal path。
+
+## 6.3 专用 CLI 的最终定位
+
+现有 runtime 专用 CLI 在迁移期保留，但不再执行 helper。每个 option 只声明一个 canonical path：
+
+```python
+CliAlias(
+    option="--thinker-max-running-requests",
+    path="pipeline.stages.${role:thinker}.runtime.sglang.max_running_requests",
+)
+```
+
+解析后产生普通 `ConfigPatch`。同一启动命令同时使用 alias 和 `--set` 写同一路径时直接报 duplicate assignment。
+
+V2 稳定后，runtime 专用 CLI 分批删除，只保留 `--set` 和服务进程参数。这样最终接口不会长期维护“YAML 字段 + 专用 CLI 字段”两份定义。若项目决定长期保留极少数高频 alias，它们必须由 schema metadata 自动生成 help、类型和 patch，不允许拥有独立业务代码。
+
+## 6.4 配置工具
+
+增加：
+
+```bash
+sgl-omni config schema
+sgl-omni config validate --config FILE
+sgl-omni config resolve --config FILE [--set ...]
+sgl-omni config explain --config FILE PATH [--set ...]
+sgl-omni config migrate --input v1.yaml --output v2.yaml
+```
+
+`resolve` 输出冻结前的完整 canonical Pipeline；`explain` 输出最终值、source chain 和是否使用 deprecated adapter。例如：
+
+```text
+pipeline.stages.thinker.runtime.sglang.max_running_requests = 32
+
+1. model-default:Qwen3OmniSpeechPipelineConfig  64
+2. file:qwen.yaml:41                           48
+3. cli:--set[0]                                32
+```
+
+## 6.5 用户配置决策
+
+用户只需要按以下规则选择入口：
+
+1. 需要保存、review 或复现的 Pipeline 改动，写入 YAML canonical path；
+2. 只在本次启动临时覆盖 Pipeline 字段，使用 `--set` 写同一个 canonical path；
+3. 修改 host、port、日志或 API policy，使用服务进程 CLI；
+4. 不知道字段路径时，先运行 `config schema`；不确定最终值时，运行 `config resolve` 或 `config explain`；
+5. 不直接设置 `factory_args`、`runtime_overrides` 或 runtime-derived fields。
+
+因此文档和错误信息不再回答“这个值在五种入口中应该选哪个”，而只需要回答“这个值属于哪个 canonical path，以及本次改动应持久化还是临时覆盖”。
+
+# 7. 核心内部数据结构
+
+## 7.1 `ConfigPatch`
+
+```python
+class ConfigSource(BaseModel):
+    kind: Literal["model_default", "file", "cli", "router", "compat"]
+    location: str
+    deprecated: bool = False
+
+
+class ConfigPatch(BaseModel):
+    op: Literal["set", "declare_stage"]
+    path: ConfigPath
+    value: object | None = None
+    source: ConfigSource
+    layer: int
+```
+
+V1 操作只包含 `set` 和 `declare_stage`：
+
+- `set` 设置一个 typed value；`null` 始终是普通值，用于清空允许为 null 的 optional field；
+- `declare_stage` 只由 `document_mode: full` 的 YAML adapter 产生，用于声明 stage name 和 stage type。
+
+full document 从空 topology 开始，可以声明 stage；partial document 和 CLI `--set` 只能修改已经存在的 stage，不能创建或删除 stage。`stage_order` 中的名称必须与最终声明的 stages 一一对应，不能缺失、重复或引用未知 stage。V1 不提供删除继承 stage/map entry 的 patch；需要改变 stage membership 时使用 full document。
+
+list 在 V1 中始终整体替换，不增加 append/remove item 等顺序敏感操作。复杂 list 应优先写 YAML。
+
+`ConfigPath` 不是任意字符串遍历器，而是由 public schema 编译的 path：
+
+- 支持 name-keyed stage；
+- 验证字段是否 public/configurable；
+- 返回目标 Pydantic type；
+- 禁止访问 `factory_args`、derived plans 和 private fields；
+- error 中列出相邻合法 path。
+
+## 7.2 `ConfigPatchSet`
+
+adapter 输出有序 patch set。layer 固定为：
+
+| Layer | 来源 |
+|---|---|
+| 0 | framework/schema defaults |
+| 10 | model Python defaults |
+| 20 | selected profile/variant |
+| 30 | user YAML |
+| 40 | Router structured worker patch |
+| 50 | worker CLI `--set` 或迁移期 alias |
+
+layer 只解决跨来源 precedence，不解决同层歧义：
+
+- 同一个 document/CLI 中同 path 重复出现：报错；
+- 同层多个来源写同 path：报错，要求调用者明确顺序或合并 document；
+- 高 layer 覆盖低 layer：允许并记录 provenance；
+- deprecated path 与 canonical path 同时指向同一 leaf：报错；
+- 同 layer 的 parent subtree 与 child leaf assignment 重叠：报错；
+- 跨 layer 时先应用低层：高层 child 可以覆盖低层 parent 的对应 leaf，高层 parent 则整体替换低层 subtree；
+- list 始终视为 leaf，不执行按 index merge。
+
+YAML parser 必须开启 duplicate-key rejection，并保留每个 mapping/scalar 的文件、行、列信息。重复 YAML key、规范化后重复 path 以及 alias/canonical 重复必须在生成 `ConfigPatchSet` 时报告，不能先读成普通 dict 再让后值静默覆盖前值。
+
+## 7.3 `ConfigResolver`
+
+resolver 顺序固定：
+
+1. 收集 adapter patches；
+2. 将 V1 path/alias 归一化为 canonical path；
+3. 结合 layer 执行 duplicate 和 subtree overlap 检查；
+4. 根据 target schema 解析 value；
+5. 按 layer 应用到 immutable base tree；
+6. 构造完整 `ResolvedPipelineConfig`；
+7. 执行 cross-field 和 model capability validation；
+8. 冻结配置并输出 provenance map。
+
+resolver 不执行 GPU topology probe、不 import stage factory、不构造 `ServerArgs`。这些属于后续 planner/worker，但只能读取已经 resolve 的 typed fields。
+
+## 7.4 `ResolvedPipelineConfig`
+
+resolved config 与用户 document 分开：
+
+| 对象 | 内容 | 是否允许用户设置 |
+|---|---|---|
+| `PipelineConfigDocumentV2` | partial/full public document | 是 |
+| `ResolvedPipelineConfig` | 所有 defaults 和 patches 应用后的完整 typed config | 通过 resolver 生成 |
+| `StagePlacementPlan` | 实际 GPU placement 与 memory accounting | 否 |
+| `ProcessTopologyPlan` | OS process membership 和 TP ranks | 否 |
+| `DerivedRuntimePlan` | 主进程 topology/hardware probe 可确定的 effective runtime values | 否 |
+| `StageWorkerProcessSpec` | spawn payload、endpoint、queues、factory defaults | 否 |
+| `WorkerRuntimeDerivation` | 只能在 worker 初始化时确定的 effective values 及 provenance | 否 |
+| `ServerArgs` / `ModelConfig` | worker 内 SGLang runtime object | 否 |
+
+`ResolvedPipelineConfig` 使用 frozen model，runtime planner 不得反向修改。resolver 只冻结用户意图，例如 `custom_all_reduce: auto|on|off`，不得依赖 GPU topology 或 hardware probe。
+
+所有可在主进程确定的 topology-dependent effective value 由 runtime planner 写入完整的 `DerivedRuntimePlan`，并记录 topology/hardware source；worker spec 携带当前 worker 需要的 plan slice，worker builder 只能消费，不能补写或反向修改该 plan。
+
+只能在模型加载或 worker 初始化后确定的值进入独立的 `WorkerRuntimeDerivation`，例如依赖实际 loaded backend 的兼容调整。它通过 worker startup diagnostic 和带 source 的 `ServerArgs.override()` 记录 provenance，不反向补写 `DerivedRuntimePlan` 或 `ResolvedPipelineConfig`。
+
+`config explain` 解释用户配置和输入 provenance；`runtime explain` 或 worker startup diagnostic 联合展示 `DerivedRuntimePlan` 与 `WorkerRuntimeDerivation`，解释最终 effective value。
+
+## 7.5 canonical runtime namespace
+
+公共 runtime 参数进入 typed namespace：
+
+```text
+pipeline.stages.<stage>.runtime.max_seq_len
+pipeline.stages.<stage>.runtime.video_fps
+pipeline.stages.<stage>.runtime.sglang.mem_fraction_static
+pipeline.stages.<stage>.runtime.sglang.max_running_requests
+pipeline.stages.<stage>.runtime.sglang.max_total_tokens
+pipeline.stages.<stage>.runtime.sglang.cuda_graph.*
+pipeline.stages.<stage>.runtime.compile.*
+pipeline.stages.<stage>.runtime.decode.*
+pipeline.stages.<stage>.runtime.prefill_coalesce.*
+```
+
+以下字段不再作为 public user interface：
+
+```text
+factory_args.server_args_overrides
+runtime_overrides
+runtime_arg_map
+gpu_id
+process_total_gpu_memory_fraction
+nccl_port
+endpoints
+```
+
+模型专属、尚未进入公共 schema 的参数放在：
+
+```yaml
+pipeline:
+  stages:
+    talker_ar:
+      extensions:
+        qwen3_omni:
+          partial_start: true
+```
+
+extension model 仍必须由模型包注册 Pydantic schema；不允许裸 `dict[str, Any]` 覆盖公共字段。成熟的跨模型功能再从 extension 提升到公共 runtime namespace。
+
+## 7.6 role 与 stage 的关系
+
+现有 CLI 通过多个 class method 分别维护 thinker、talker、generation 和 memory role map。V2 在 model config 中统一声明：
+
+```yaml
+pipeline:
+  roles:
+    thinker: thinker
+    talker: talker_ar
+    generation: talker_ar
+    code2wav: code2wav
+```
+
+role 只用于：
+
+- 迁移旧 typed CLI alias；
+- 模型能力校验；
+- 生成面向用户的 shortcut/help。
+
+canonical storage 始终是具体 stage path。resolver 在产生 patch 时解析 role，不在 runtime helper 中重复解析。
+
+## 7.7 开发者新增配置的唯一流程
+
+开发者先根据 owner 判断字段归属：
+
+| 新配置类型 | 应增加的位置 | 不应增加的位置 |
+|---|---|---|
+| 多模型共享的 Pipeline/runtime 字段 | public typed schema | 手写 CLI helper、裸 `factory_args` |
+| 单一模型专属字段 | 模型注册的 extension schema | 全局 `serve()` 签名 |
+| HTTP server/process 字段 | `ServerLaunchConfig` | `PipelineConfig` |
+| topology/hardware 派生值 | `DerivedRuntimePlan` | 用户 YAML/CLI |
+| worker 初始化后才能确定的值 | `WorkerRuntimeDerivation` | resolver 或 Pipeline mutation |
+| request-time 字段 | request protocol/schema | 启动期配置 |
+
+新增一个 public typed field 的标准步骤固定为：
+
+1. 在 canonical schema 定义 path、类型、默认值、description 和 capability constraint；
+2. 在 resolved config → runtime consumer adapter 中消费该 typed field；
+3. 从 schema metadata 自动生成 JSON Schema、CLI path help 和 YAML/CLI 等价性测试；
+4. 如需兼容旧入口，只在 `compat.py` 添加限时 old path → canonical path 映射，并声明删除 Phase；
+5. 不在 `serve.py` 新增参数专属 mutation helper。
+
+Code review 可以据此拒绝任何绕过 canonical schema 的新公共配置入口。
+
+# 8. YAML 与 CLI 的职责边界
+
+新接口明确以下规则：
+
+| 配置类别 | YAML | CLI | 原因 |
+|---|---|---|---|
+| 模型、stage topology | canonical source | 只通过 `--config`/`--model-path` 选择 | 结构复杂，需要持久化 |
+| GPU/TP/process placement | canonical source | 可用 `--set` 临时覆盖 | 属于 Pipeline，需统一 validation |
+| SGLang/runtime 参数 | canonical source | 可用 `--set` 临时覆盖 | 同一 path、同一类型、同一校验 |
+| HTTP bind/log/API policy | 不进入 Pipeline YAML | 专用 CLI | 属于服务进程，不属于模型 Pipeline |
+| runtime-derived endpoint/port/gpu id | 不可设置 | 不可设置 | planner/runner owner |
+| Router worker pool | Router YAML | Router CLI 只选择 source/路由参数 | 与 worker Pipeline 分层 |
+
+CLI 和 YAML 因而仍有两种语法，但只有一套 Pipeline 语义：
+
+```text
+YAML leaf
+→ ConfigPatch(path, value, file source)
+
+CLI --set
+→ ConfigPatch(path, value, cli source)
+```
+
+# 9. Router 接口重构
+
+## 9.1 structured worker config
+
+launcher YAML 移除自由字符串 `worker_extra_args`，改为：
+
+```yaml
+schema_version: 2
+
+launcher:
+  backend: local
+  num_workers: 2
+  num_gpus_per_worker: 1
+  worker_host: 127.0.0.1
+  worker_base_port: 8011
+  wait_timeout: 600
+
+  worker:
+    config: examples/configs/qwen3_omni_colocated_h20_v2.yaml
+    service:
+      model_name: qwen3-omni
+    patches:
+      pipeline.stages.thinker.runtime.sglang.max_running_requests: 32
+```
+
+`worker.config` 与 `worker.model` 二选一，对应 worker `--config` 与 `--model-path` 模式。`worker.patches` 由 Router schema 校验 path/value，并作为结构化 patch 传递。
+
+## 9.2 worker 传递方式
+
+V1 可以继续生成 argv，但只生成机器接口：
+
+```text
+sgl-omni serve
+  --config ...
+  --config-patch-file /tmp/.../worker-0-patches.json
+```
+
+patch file 内容是序列化的 `ConfigPatchSet`，不是 shell fragment。worker 验证 source 和 schema version 后交给同一个 resolver。
+
+后续如果 Router 与 worker 改为 Python API 或 supervisor protocol，仍复用 `ConfigPatchSet`，不改变配置语义。GPU visibility 继续由 Router 通过 subprocess env 管理，因为它是进程资源边界，不属于 Pipeline patch。
+
+Router 和 worker 使用同版本的 schema registry 与 `ConfigResolver`。Router 在创建 subprocess 前，对 `worker.config/model + worker.patches` 执行完整 dry-run resolve：
+
+- 相对配置路径以 launcher YAML 所在目录为基准；
+- Router 必须能加载 worker 所需的 model config 和 extension schema；
+- path、type、role 或 extension 无法解析时，在启动任何 worker 前失败；
+- worker 收到 patch file 后再次校验 schema version 和内容，但不得采用不同的 merge 规则。
+
+GPU 使用两个明确坐标系：
+
+- Router 独占物理 GPU 分配权，通过 `CUDA_VISIBLE_DEVICES` 建立每个 worker 的可见设备集合；
+- Pipeline `placement.gpus` 始终使用 worker-local logical GPU ID，即可见设备重新编号后的 `0..N-1`。
+
+Router dry-run 必须验证所有 logical GPU ID 均位于 `[0, num_gpus_per_worker)`，并验证 TP size、GPU list 和 worker allocation 一致。Pipeline 不允许直接引用宿主机 physical GPU ID。
+
+## 9.3 Router 与 worker 的优先级
+
+managed worker 的 layer 固定：
+
+```text
+模型默认 < worker Pipeline YAML < Router worker.patches < worker CLI emergency patch
+```
+
+默认不允许 `worker CLI emergency patch`，只有调试模式显式开启。生产配置由 Router YAML 完整决定，避免 supervisor 生成值和手工 argv 再次竞争。
+
+# 10. 配置冲突与错误模型
+
+## 10.1 冲突分类
+
+| 冲突类型 | 示例 | V2 行为 |
+|---|---|---|
+| 同 source 重复 | 两个 `--set` 写同 path | 启动前报错 |
+| alias/canonical 重复 | typed CLI 与 `--set` 写同 path | 启动前报错 |
+| typed/extension 重叠 | extension 试图设置公共 SGLang 字段 | schema 注册失败 |
+| parent/child 重叠 | YAML 设置 `runtime.sglang`，CLI 同层设置其 child | 同层报错；跨层允许并记录 |
+| owner 违规 | 用户设置 `gpu_id` 或 endpoint | path 不公开，解析失败 |
+| capability 不支持 | 非 SGLang stage 设置 `runtime.sglang` | model validation 失败 |
+| cross-field 不一致 | TP=2 但只有一个 GPU | resolved model validation 失败 |
+| deprecated/canonical 重复 | V1 `runtime_overrides` 与 V2 field | migration error，不猜优先级 |
+
+## 10.2 原子性
+
+resolver 在内存中的 immutable tree 上应用所有 patches。任何 path、type、conflict 或 validation 失败时，不返回 partial config，也不进入 runtime planner。
+
+错误必须包含：
+
+- canonical path；
+- source location；
+- 原值及其 source；
+- 冲突规则；
+- 可执行的修复建议。
+
+例如：
+
+```text
+duplicate configuration for
+pipeline.stages.thinker.runtime.sglang.mem_fraction_static
+
+file:qwen.yaml:42 = 0.70
+cli:--thinker-mem-fraction-static = 0.65
+
+The CLI alias and canonical field target the same setting.
+Remove one source or use `config explain` to inspect precedence.
+```
+
+# 11. 配置编译与运行时边界
+
+V2 编译链为：
+
+```text
+① Parse input documents
+→ ② Normalize patches
+→ ③ Resolve + validate + freeze
+→ ④ Build placement/process plans
+→ ⑤ Build derived runtime plan
+→ ⑥ Build worker specs
+→ ⑦ Construct worker runtime objects
+```
+
+只按 **① → ② → ③ → ④ → ⑤ → ⑥ → ⑦** 阅读：
+
+- ②之后所有输入都使用 canonical path；
+- ③是最后一次修改用户配置的步骤；
+- ④只生成派生 plan，不回写 Pipeline；
+- ⑤保存主进程 topology/hardware probe 可决定的 effective runtime values；
+- ⑥只整理跨进程 DTO；
+- ⑦才 import factory、构造 `ServerArgs` 和 `ModelConfig`；只能在该阶段确定的调整记录到 `WorkerRuntimeDerivation`。
+
+当前 `_apply_tensor_parallel_server_args_overrides()` 会基于 topology probe 修改 stage server args。V2 将其拆为：
+
+1. 用户配置表达 `custom_all_reduce: auto|on|off`；
+2. placement planner 产生 topology capability；
+3. 主进程 runtime planner 根据两者产生 `DerivedRuntimePlan`；
+4. worker builder 只消费 plan 中的 effective `ServerArgs` value；
+5. 不修改 frozen Pipeline，也不在 worker 重新执行同一 topology 决策。
+
+其他 topology-dependent 参数遵循同样模式。
+
+# 12. 改动范围
+
+## 12.1 配置 schema 与 resolver
+
+| 模块 | 改动 |
+|---|---|
+| `sglang_omni/config/schema.py` | 增加 V2 public schema、name-keyed stages、typed runtime namespaces、frozen resolved model |
+| `sglang_omni/config/patch.py`（新增） | `ConfigPath`、`ConfigSource`、`ConfigPatch`、duplicate/overlap 检查 |
+| `sglang_omni/config/resolver.py`（新增） | layer merge、type conversion、provenance、完整 validation |
+| `sglang_omni/config/compat.py`（新增） | V1 YAML/dotted/typed CLI 到 V2 patch 的限时 adapter |
+| `sglang_omni/models/registry.py` | 注册 V2 model defaults、roles 和 extension schemas |
+
+`ConfigManager` 的文件加载职责并入 adapter/resolver。旧类在迁移期保留 facade，最终删除自定义 dotted merge。
+
+## 12.2 CLI
+
+| 模块 | 改动 |
+|---|---|
+| `sglang_omni/cli/serve.py` | 参数解析后只构造 `ServerLaunchConfig` 和 patches；删除业务 mutation helper |
+| `sglang_omni/cli/config.py` | 增加 schema/validate/resolve/explain/migrate |
+| `sglang_omni/cli/__init__.py` | 关闭未知 option；开放覆盖统一走显式 `--set` |
+
+迁移期 typed CLI alias 可以继续在 `serve()` 签名中出现，但实现由 alias registry 自动生成 patch。
+
+## 12.3 runtime
+
+| 模块 | 改动 |
+|---|---|
+| `sglang_omni/config/runtime.py` | 只把 typed resolved runtime 转成 factory kwargs；不再解决用户来源冲突 |
+| `sglang_omni/pipeline/runtime_config.py` | 只读 frozen resolved config，输出 placement/process 和 `DerivedRuntimePlan` |
+| `sglang_omni/pipeline/mp_runner.py` | 从 resolved config/plans 构造 spec，不接收 compatibility fields |
+| `sglang_omni/scheduling/sglang_backend/server_args_builder.py` | 从 typed SGLang config 构造 `ServerArgs`，保留明确的 derived runtime overrides |
+
+模型 factory 可以暂时继续接收 `server_args_overrides`，但该 dict 只能由 typed runtime adapter 内部生成，不再是 public YAML/CLI 入口。
+
+## 12.4 Router
+
+| 模块 | 改动 |
+|---|---|
+| `sglang_omni_router/launcher/config.py` | `worker.config/model/service/patches` schema |
+| `sglang_omni_router/launcher/local.py` | 生成 patch file，不拼接 `worker_extra_args` |
+| `sglang_omni_router/serve.py` | worker source validation 与 structured launcher 接入 |
+
+# 13. 分阶段兼容方案
+
+V2 采用分阶段迁移，不要求一个版本内修改所有配置，但每个 deprecated 入口都有删除阶段。
+
+## 13.1 Phase 0：建立 resolver，不改变默认行为
+
+- 引入 `ConfigPatch`、provenance 和 `config resolve/explain`；
+- 当前模型默认、V1 YAML、dotted CLI 和 typed CLI 全部通过 compatibility adapter 产生 patch；
+- 用 golden tests 锁定最终 resolved value 和成功/失败行为；
+- runtime 仍消费现有 `PipelineConfig` shape；
+- 新 resolver 发现的 V1 重复来源先记录 diagnostic，不改变当前成功/失败结果；
+- 内部测试的 V2 输入从一开始执行严格 duplicate/overlap 规则。
+
+该阶段目标是先得到唯一 merge engine，而不是立即改变用户语法或 validation 行为。Phase 1 起，V2 输入严格报错，V1 输入对新发现的重复来源 warning；Phase 2 起，V1 同义重复也报错。
+
+## 13.2 Phase 1：V2 opt-in
+
+- 支持 `schema_version: 2`；
+- 新文档和 export 默认展示 V2，可通过 flag 保留 V1 export；
+- Router 支持 structured worker 配置，同时兼容 `worker_extra_args`；
+- typed CLI alias 打印 canonical `--set` 替代方式；
+- telemetry/log 统计 deprecated path，不上传具体配置值。
+
+V2 document 不允许出现 V1 `stage_overrides`、`runtime_overrides` 或 public `factory_args.server_args_overrides`。
+V1 输入继续保留当前最终值语义，但新发现的重复来源输出 warning。
+
+## 13.3 Phase 2：V2 默认
+
+- `config export`、官方 examples、cookbook 和 Router examples 全部切换到 V2；
+- 没有 `schema_version` 的 YAML 按 V1 处理并输出 warning；
+- dotted unknown option 关闭，要求显式 `--set`；
+- runtime typed CLI alias 输出 deprecation warning；
+- V1 deprecated/canonical 同义重复改为启动错误；
+- `worker_extra_args` warning，并提供 `config migrate` 自动转换可识别参数。
+
+## 13.4 Phase 3：删除旧入口
+
+在下一个明确公布的 major/minor compatibility boundary：
+
+- 删除 `stage_overrides`；
+- 删除 public `runtime_overrides`；
+- 禁止 YAML 设置 public `factory_args.server_args_overrides`；
+- 删除动态 unknown option dotted CLI；
+- 删除 runtime 专用 typed CLI alias；
+- 删除 Router `worker_extra_args`；
+- 删除 `ConfigManager.merge_config()` 的 V1 path traversal。
+
+读取 V1 YAML 时给出明确错误和离线 migration 命令，不在 server 内继续隐式兼容。
+
+## 13.5 兼容行为表
+
+| 当前接口 | Phase 0 | Phase 1 | Phase 2 | Phase 3 |
+|---|---|---|---|---|
+| V1 Pipeline YAML | 支持 | 支持 + 可迁移 | warning | 拒绝 |
+| `stage_overrides` | 支持 | warning | warning | 拒绝 |
+| `runtime_overrides` | 支持 | warning | warning | 拒绝 |
+| dotted unknown CLI | 支持 | warning | 拒绝并提示 `--set` | 删除 |
+| runtime typed CLI | 支持 | warning | warning | 删除 |
+| V2 YAML | 内部测试 | opt-in | 默认 | 唯一格式 |
+| Router `worker_extra_args` | 支持 | warning | warning | 拒绝 |
+| structured Router worker | 内部测试 | opt-in | 默认 | 唯一格式 |
+
+# 14. 校验与测试
+
+校验分为 resolver 和 runtime planning 两层。前者证明“用户声明唯一且类型正确”，后者证明“解析后的 topology 可以执行”。
+
+## 14.1 Resolver 单元测试
+
+| 测试类别 | 检查内容 |
+|---|---|
+| path | 合法 field、unknown field、private/derived field、stage name |
+| type | scalar、null、list、dict、enum、invalid coercion |
+| document structure | duplicate YAML key、full/partial mode、stage declaration、`stage_order` 完整性 |
+| precedence | defaults、profile、YAML、Router patch、CLI |
+| duplicates | 同 source、同 layer、alias/canonical、parent/child |
+| cross-layer subtree | 高层 child 覆盖低层 parent、高层 parent 替换低层 subtree、list 整体替换 |
+| provenance | 每次覆盖的旧值、source、location、deprecated 标记 |
+| atomicity | 任意 patch 失败时不产生 partial resolved config |
+| frozen config | resolver 返回后禁止 assignment |
+| role | role 到 stage 的唯一解析、unknown/unsupported role |
+| extension | 注册 schema、未知 key、禁止覆盖公共 namespace |
+
+## 14.2 CLI/YAML 等价性
+
+对每个 public typed field建立参数化测试：
+
+```text
+YAML canonical leaf
+==
+CLI --set canonical path
+==
+迁移期 typed CLI alias
+```
+
+三种输入必须产生相同 `ResolvedPipelineConfig`，只有 provenance 不同。参数表由 schema metadata 自动生成，避免手写测试遗漏新字段。
+
+## 14.3 V1 migration golden
+
+选取官方 examples：
+
+- Qwen3-Omni text/speech/colocated；
+- Qwen3-TTS；
+- Higgs、MOSS、FishAudio；
+- ASR 单 stage；
+- Ming 完整 stages YAML；
+- TP 和 process isolation 配置。
+
+分别执行 V1 adapter 和迁移后的 V2 document，比较：
+
+- stage topology 和顺序；
+- placement/TP/process；
+- typed runtime；
+- factory 最终 kwargs；
+- placement/process plans；
+- worker specs；
+- `ServerArgs` 用户可控字段。
+
+runtime-derived endpoint 和临时 port 使用结构比较，不比较随机值。
+
+## 14.4 冲突回归
+
+必须覆盖：
+
+- typed `mem_fraction_static` 与旧 `server_args_overrides`；
+- global 与 per-role CLI；
+- `--encoder-mem-reserve` 与 explicit fraction；
+- `tp_size` 与 GPU list；
+- generation role 与 thinker role 指向同/不同 stage；
+- deprecated path 与 canonical path；
+- Router patch 与 worker CLI；
+- extension 与 public namespace。
+
+每个冲突断言 canonical path 和两个 source 都出现在错误中。
+
+## 14.5 Runtime 边界
+
+验证：
+
+- runtime planner 不修改 frozen config；
+- topology-dependent effective value 只进入 `DerivedRuntimePlan`；
+- worker builder 只消费 `DerivedRuntimePlan`，不能补写或重复决策；
+- worker-only effective value 只进入 `WorkerRuntimeDerivation` 并保留 source；
+- child process 不重新 resolve user config；
+- factory signature injection 只补缺失的 derived defaults；
+- user 不能设置 `gpu_id`、process cumulative budget、NCCL port 和 endpoint；
+- TP env mapping 与当前行为一致；
+- no-config/default model path 的 worker specs 与 golden 一致；
+- `ServerArgs.override()` 仍记录 worker 内 derived mutation source。
+
+## 14.6 Router
+
+验证：
+
+- structured config 生成的 worker command 不包含 shell-like extra args；
+- patch file 每 worker 独立、schema version 正确；
+- model/config 互斥；
+- Router 使用同版本 registry/resolver，在启动 subprocess 前完成 dry-run；
+- launcher-relative config path 和 model extension schema 正确解析；
+- Router YAML path/type/role/extension 在启动 subprocess 前失败；
+- GPU 继续通过 environment 传递；
+- physical GPU assignment 与 worker-local logical GPU ID 转换正确；
+- logical GPU 越界、TP 和 worker allocation 不一致时启动前失败；
+- V1 `worker_extra_args` migration 能识别 `--config`、typed alias 和 `--set`；
+- 无法安全迁移的任意 shell token 明确失败，不静默丢弃。
+
+## 14.7 Phase 准入标准
+
+每个迁移 Phase 都必须有 compatibility matrix 测试，断言每种旧入口的：
+
+- success、warning 或 error；
+- 最终 resolved value；
+- provenance/diagnostic；
+- 推荐的 migration command。
+
+进入下一 Phase 前必须满足：
+
+1. 官方 Pipeline 和 Router examples 全部通过 migration golden；
+2. structured Router 至少完成一条多 worker E2E；
+3. runtime 不再直接读取 public compatibility fields；
+4. 当前 Phase 的 warning/error matrix 在 CI 中固定；
+5. deprecated 入口使用量达到项目预先公布的迁移阈值；
+6. release notes 已给出下一 Phase 的目标版本和删除项。
+
+# 15. 发布与文档
+
+发布 V2 时同步提供：
+
+1. V1 → V2 migration guide；
+2. CLI/YAML 职责表；
+3. canonical path reference 和生成的 JSON Schema；
+4. `config resolve/explain` 调试示例；
+5. deprecated 入口删除版本；
+6. 官方 examples 的 V1/V2 diff；
+7. Router structured worker 示例。
+
+CLI `--help` 不再列出全部模型 runtime 字段，只说明 `--set` 并指向：
+
+```bash
+sgl-omni config schema
+sgl-omni config resolve
+```
+
+模型特定字段由选定 model config/extension schema 动态展示，而不是把所有模型 option 固定到一个全局 `serve()` 签名。
+
+# 16. 预期结果
+
+重构完成后的稳定关系是：
+
+```text
+YAML / CLI / Router
+        ↓
+同一种 ConfigPatch
+        ↓
+唯一 ConfigResolver
+        ↓
+冻结的 ResolvedPipelineConfig
+        ↓
+只读 runtime planners
+```
+
+YAML 与 CLI 保留不同使用场景：
+
+- YAML 保存完整、可 review、可复现的 Pipeline；
+- CLI 选择配置、设置服务进程参数，并用 `--set` 做临时 Pipeline patch；
+- Router YAML 结构化引用 worker config 和 patches。
+
+它们不再分别定义 runtime 参数的类型、默认值、优先级和 mutation 逻辑。新增一个公共配置字段时，只需要在 canonical schema 定义一次；CLI、JSON Schema、文档、patch type 和等价性测试都从该定义生成。

--- a/docs/design/configuration_interface_refactor_proposal.md
+++ b/docs/design/configuration_interface_refactor_proposal.md
@@ -91,7 +91,7 @@ sgl-omni serve \
 
 这三个名称不是三套新接口，而是同一条配置处理管道的三个环节。
 
-本文只讨论启动期配置，不改变请求协议、Stage payload、调度算法或 SGLang 内部 `ServerArgs` 的字段定义。文中“当前实现”核对的代码 revision 为 `42a124cd`；完整现状可参考 `docs/developer_reference/configuration.md`。
+本文只讨论启动期配置，不改变请求协议、Stage payload、调度算法或 SGLang 内部 `ServerArgs` 的字段定义。文中“当前实现”核对的代码 revision 为 `2b45073c`；完整现状可参考 `docs/developer_reference/configuration.md`。
 
 Tracking issue: [#1466](https://github.com/sgl-project/sglang-omni/issues/1466)
 
@@ -111,7 +111,7 @@ English version: [Configuration Interface Refactoring Design Proposal](./configu
 
 ## 2.1 配置来源
 
-当前公开配置来源可以分成六类：
+当前公开配置来源可以分成七类：
 
 | 来源 | 当前入口 | 主要实现 |
 |---|---|---|
@@ -120,9 +120,12 @@ English version: [Configuration Interface Refactoring Design Proposal](./configu
 | YAML 紧凑覆盖 | `stage_overrides`、`runtime_overrides` | `config/manager.py`、`config/runtime.py` |
 | 动态 CLI | `--stages.thinker... VALUE` | `ConfigManager.parse_extra_args()` |
 | 专用 CLI | `--mem-fraction-static` 等 | `cli/serve.py` 中的 `apply_*_cli_overrides()` |
+| 已配置的环境默认值 | Pipeline `env_defaults`、stage 级 `StageConfig.env` | `config/schema.py`、`pipeline/mp_runner.py`、`pipeline/stage_workers.py` |
 | Router launcher | `--launcher-config`、`worker_extra_args` | `sglang_omni_router/launcher/*` |
 
 `sgl-omni serve` 对未知 option 开启 `ignore_unknown_options`，因此 Typer 先解析 41 个专用参数，剩余 token 再由 `ConfigManager` 解析为 dotted override。两类 CLI 在不同阶段执行。
+
+已配置的环境值具有比下文配置 layer 更窄的契约。Pipeline `env_defaults` 是 canonical 已配置默认值，`StageConfig.env` 在对应 stage 上覆盖它们。spawn 时，这些默认值只填充继承进程环境中不存在的变量，因此绝不覆盖 `os.environ`。最终的 `ResolvedProcessEnv` 是派生的进程产物，组合继承环境、已配置默认值以及 runner 拥有的 rank/device 等增量；它不是新的用户 precedence layer。库或 runtime 中直接读取 `os.environ` 的位置仍是外部输入，应在相关环境诊断中展示，而不是全部收进一个通用配置层。
 
 ## 2.2 当前合并顺序
 
@@ -135,7 +138,8 @@ English version: [Configuration Interface Refactoring Design Proposal](./configu
 5. `serve.py` 依次执行 memory、TP/GPU、process、CUDA graph、compile、decode、prefill 和 generation batch helper；
 6. `launch_server()` 将 HTTP/API 参数与 `PipelineConfig` 分开传入；
 7. runtime preparation 构造 placement、process topology、endpoint 和 worker spec；
-8. worker 子进程合并 factory args，并在 factory 内构造 `ServerArgs` 和 `ModelConfig`。
+8. spawn 前，父进程把 `factory_args`、`runtime_overrides` 和 typed runtime mapping 合并为与签名无关的 factory args，并写入 worker spec；
+9. 子进程 import factory，只注入缺失且是否适用依赖 factory 签名的默认值，然后由 factory 构造 `ServerArgs` 和 `ModelConfig`。
 
 | 顺序 | 处理阶段 | 输入与输出 |
 |---|---|---|
@@ -143,25 +147,26 @@ English version: [Configuration Interface Refactoring Design Proposal](./configu
 | 2 | 应用 YAML 紧凑覆盖 | `stage_overrides` → typed runtime |
 | 3 | 应用动态 CLI | dotted CLI → 重建 `PipelineConfig` |
 | 4 | 应用专用 CLI | typed CLI helpers → 原地修改 `PipelineConfig` |
-| 5 | 运行时规划 | `PipelineConfig` → placement、process topology、worker spec |
-| 6 | worker 构造 | worker spec → stage factory → `ServerArgs` |
+| 5 | 运行时规划 | `PipelineConfig` → placement、process topology、父进程已解析的静态 factory args 和 worker spec |
+| 6 | worker 构造 | worker spec → import factory → 注入缺失的签名相关默认值 → `ServerArgs` |
 
 该顺序表面上提供了优先级，但优先级并不是一条统一规则。不同 helper 会选择“覆盖”“拒绝”“同步两个 alias”“同时写 `factory_args` 和 `runtime_overrides`”或“等到 worker 再报冲突”。
 
 ## 2.3 当前 factory 参数路径
 
-stage factory kwargs 由以下来源组合：
+stage factory kwargs 跨明确的父/子进程边界组合：
 
 ```text
 factory_args
 < runtime_overrides
 < typed runtime 映射
-+ signature-dependent defaults
+→ worker spec 中父进程已解析的静态 factory args
++ 子进程注入缺失的 signature-dependent defaults
 ```
 
 其中 `server_args_overrides` 在 `factory_args` 和 `runtime_overrides` 之间执行一层 dict merge；typed `runtime.max_seq_len` 和 `runtime.video_fps` 通过 `runtime_arg_map` 改名；typed `mem_fraction_static` 最终又写回 `server_args_overrides`。
 
-`model_path`、`gpu_id` 和 `total_gpu_memory_fraction` 不是普通用户 factory args。它们在 worker import factory 后，根据函数签名按需注入。`gpu_id`、process cumulative budget、NCCL port 和 IPC endpoints 由 planner/runner 派生。
+父进程在 spawn 前完成所有不需要检查 factory 签名的 merge。`model_path`、`gpu_id` 和 `total_gpu_memory_fraction` 不是普通用户 factory args：父进程计算候选值，子进程 import factory 后，仅当签名声明该参数且已解析静态参数中尚无该值时才注入。`gpu_id`、process cumulative budget、NCCL port 和具体 IPC/socket endpoint 由 planner/runner 派生。
 
 # 3. 当前设计的问题
 
@@ -347,8 +352,8 @@ Router launcher YAML
 1. **一个语义，一个 canonical path**：相同运行时功能不得同时暴露 typed 和 untyped public path。
 2. **输入 adapter 无业务逻辑**：YAML、CLI、Router 只产生 typed assignment/patch。
 3. **一次 resolve，一次完整 validation**：进入 runtime planner 后配置冻结。
-4. **用户配置与派生计划分离**：GPU logical placement 可以配置，`gpu_id`、endpoint、NCCL port 等 runtime 值不可配置。
-5. **显式覆盖，保留来源**：跨层覆盖允许，但必须可解释；同层重复定义直接失败。
+4. **用户配置与派生计划分离**：GPU logical placement 和 endpoint 分配根目录 `endpoints.base_path` 可以配置，`gpu_id`、具体 socket endpoint、NCCL port 等 runtime 值不可配置。
+5. **显式覆盖，保留来源**：跨层覆盖允许，但必须可解释；同 layer、相同 specificity 的重复定义直接失败。
 6. **兼容层有删除终点**：旧接口可以适配，但不能永久成为第二套 canonical schema。
 
 ## 4.3 非目标
@@ -412,11 +417,13 @@ pipeline:
 
   stages:
     preprocessing:
+      kind: python
       factory: example.create_preprocessing
       process: pipeline
       next: thinker
 
     thinker:
+      kind: sglang
       factory: example.create_thinker
       process: pipeline
       next: decode
@@ -427,6 +434,7 @@ pipeline:
           max_running_requests: 32
 
     decode:
+      kind: python
       factory: example.create_decode
       process: pipeline
       terminal: true
@@ -533,7 +541,37 @@ sgl-omni serve \
   --set pipeline.stages.thinker.placement.tp=2
 ```
 
-value 使用 YAML scalar/flow value 解析，因此 bool、null、number、list 和 dict 具有同一类型规则。path 必须存在于 public schema；不能写 runtime-derived 或 deprecated internal path。
+value 使用 YAML scalar/flow value 解析，因此 bool、null、number 和原子 list value 具有同一类型规则。`--set` 只能定位 configurable leaf；list 整体视为一个 leaf，不能按 index patch。通用 `--set` 不能替换 mapping/subtree；subtree replacement 只允许写在 `full` YAML 中。path 必须存在于 public schema；不能写 runtime-derived 或 deprecated internal path。
+
+通用 stage 参数还支持 selector-based broadcast patch：
+
+```yaml
+pipeline:
+  stage_defaults:
+    - select:
+        capability: sglang
+      runtime:
+        sglang:
+          max_running_requests: 32
+    - select:
+        roles: [thinker, generation]
+        exclude: [talker_ar]
+      placement:
+        tp: 2
+```
+
+selector 支持 `capability`、`roles`、`stages` 和 `exclude`；给出的正向 selector 必须全部匹配，`exclude` 再移除匹配项。resolver 在 duplicate 检查和 validation 前，把 broadcast 展开为具体 stage leaf patch。resolved storage 仍只保存 `pipeline.stages.<stage>...`，`ResolvedPipelineConfig` 中不保留 broadcast object。同一个 source 内 specificity 为 `capability broadcast < role/group selector < concrete stage`；不同 source 之间始终由 source layer 主导，specificity 不能越层。相同 specificity 写同一个展开 leaf 仍报错。
+
+对应 CLI 为：
+
+```bash
+sgl-omni serve \
+  --config qwen.yaml \
+  --set-for capability=sglang runtime.sglang.max_running_requests=32 \
+  --set pipeline.stages.thinker.runtime.sglang.max_running_requests=48
+```
+
+这里同一 CLI source 中的具体 stage assignment 覆盖 capability broadcast。`config explain` 展示每次 selector expansion 和被遮蔽的值；full export 输出展开后的 stage-local value，不输出 selector。
 
 ## 6.3 专用 CLI 的最终定位
 
@@ -546,7 +584,7 @@ CliAlias(
 )
 ```
 
-解析后产生普通 `ConfigPatch`。同一启动命令同时使用 alias 和 `--set` 写同一路径时直接报 duplicate assignment。
+解析后产生普通 patch。迁移 alias 在 CLI source 内具有明确 specificity：broadcast/global alias < role alias < 显式具体 `--set`。role alias 覆盖 broadcast alias 是兼容行为，不是 duplicate；被遮蔽的 broadcast value 保留在 provenance 中。相同 specificity 的两个 assignment 写同一 canonical leaf 仍报错。source layer precedence 始终优先于此规则。
 
 V2 稳定后，runtime 专用 CLI 分批删除，只保留 `--set` 和服务进程参数。这样最终接口不会长期维护“YAML 字段 + 专用 CLI 字段”两份定义。若项目决定长期保留极少数高频 alias，它们必须由 schema metadata 自动生成 help、类型和 patch，不允许拥有独立业务代码。
 
@@ -559,6 +597,7 @@ sgl-omni config schema
 sgl-omni config validate --config FILE
 sgl-omni config resolve --config FILE [--set ...]
 sgl-omni config explain --config FILE PATH [--set ...]
+sgl-omni config export --config FILE --format full
 sgl-omni config migrate --input v1.yaml --output v2.yaml
 ```
 
@@ -595,10 +634,18 @@ class ConfigSource(BaseModel):
     deprecated: bool = False
 
 
+class StageDeclaration(BaseModel):
+    name: str
+    kind: Literal["sglang", "python", "external"]
+    factory: str
+    extension_schema_id: str | None = None
+
+
 class ConfigPatch(BaseModel):
     op: Literal["set", "declare_stage"]
     path: ConfigPath
     value: object | None = None
+    declaration: StageDeclaration | None = None
     source: ConfigSource
     layer: int
 ```
@@ -606,7 +653,7 @@ class ConfigPatch(BaseModel):
 初版 patch protocol 的操作只包含 `set` 和 `declare_stage`：
 
 - `set` 设置一个 typed value；`null` 始终是普通值，用于清空允许为 null 的 optional field；
-- `declare_stage` 只由 `document_mode: full` 的 YAML adapter 产生，用于声明 stage name 和 stage type。
+- `declare_stage` 只由 `document_mode: full` 的 YAML adapter 产生，并携带 typed declaration payload。`name`、`kind` 和 `factory` 必填；stage 使用模型 extension 时提供 `extension_schema_id`。`kind` 选择合法 runtime namespace 和 capability rule，不能先创建 untyped stage 再附加 backend field。
 
 full document 从空 topology 开始，可以声明 stage；partial document 和 CLI `--set` 只能修改已经存在的 stage，不能创建或删除 stage。`stage_order` 中的名称必须与最终声明的 stages 一一对应，不能缺失、重复或引用未知 stage。初版 patch protocol 不提供删除继承 stage/map entry 的操作；需要改变 stage membership 时使用 full document。
 
@@ -635,15 +682,17 @@ adapter 输出有序 patch set。layer 固定为：
 
 layer 只解决跨来源 precedence，不解决同层歧义：
 
-- 同一个 document/CLI 中同 path 重复出现：报错；
-- 同层多个来源写同 path：报错，要求调用者明确顺序或合并 document；
+- 同一个 document/CLI 中，相同 specificity 重复出现同一 normalized path：报错；
+- 同 layer、相同 specificity 的多个来源写同 path：报错，要求调用者明确顺序或合并 document；
 - 高 layer 覆盖低 layer：允许并记录 provenance；
-- deprecated path 与 canonical path 同时指向同一 leaf：报错；
+- 同一 CLI source 中的 compatibility alias 按 broadcast < role < 显式具体 `--set` 处理；更具体的值覆盖较不具体的值并保留 provenance，相同 specificity 的重复仍报错；
+- 同一 Router source 中，`worker_defaults` < 具体 per-worker entry；entry 覆盖 defaults 时保留被遮蔽值的 provenance，相同 scope 内的重复仍报错；
 - 同 layer 的 parent subtree 与 child leaf assignment 重叠：报错；
 - 跨 layer 时先应用低层：高层 child 可以覆盖低层 parent 的对应 leaf，高层 parent 则整体替换低层 subtree；
-- list 始终视为 leaf，不执行按 index merge。
+- list 始终视为 leaf，不执行按 index merge；
+- 通用 `--set` 只能定位 configurable leaf；mapping/subtree replacement 只能使用 full YAML。
 
-YAML parser 必须开启 duplicate-key rejection，并保留每个 mapping/scalar 的文件、行、列信息。重复 YAML key、规范化后重复 path 以及 alias/canonical 重复必须在生成 `ConfigPatchSet` 时报告，不能先读成普通 dict 再让后值静默覆盖前值。
+YAML parser 必须开启 duplicate-key rejection，并保留每个 mapping/scalar 的文件、行、列信息。重复 YAML key、相同 specificity 下规范化后重复的 path，以及相同 specificity 的 alias/canonical 重复必须在生成 `ConfigPatchSet` 时报告，不能先读成普通 dict 再让后值静默覆盖前值。
 
 ## 7.3 `ConfigResolver`
 
@@ -651,12 +700,13 @@ resolver 顺序固定：
 
 1. 收集 adapter patches；
 2. 将 V1 path/alias 归一化为 canonical path；
-3. 结合 layer 执行 duplicate 和 subtree overlap 检查；
-4. 根据 target schema 解析 value；
-5. 按 layer 应用到 immutable base tree；
-6. 构造完整 `ResolvedPipelineConfig`；
-7. 执行 cross-field 和 model capability validation；
-8. 冻结配置并输出 provenance map。
+3. 把 selector broadcast 展开为具体 stage leaf patch，并记录 expansion provenance；
+4. 结合 layer 执行 specificity、duplicate 和 subtree overlap 检查；
+5. 根据 target schema 解析 value；
+6. 按 layer 应用到 immutable base tree；
+7. 构造完整 `ResolvedPipelineConfig`；
+8. 执行 cross-field 和 model capability validation；
+9. 冻结配置并输出 provenance map。
 
 resolver 不执行 GPU topology probe、不 import stage factory、不构造 `ServerArgs`。这些属于后续 planner/worker，但只能读取已经 resolve 的 typed fields。
 
@@ -693,11 +743,17 @@ pipeline.stages.<stage>.runtime.video_fps
 pipeline.stages.<stage>.runtime.sglang.mem_fraction_static
 pipeline.stages.<stage>.runtime.sglang.max_running_requests
 pipeline.stages.<stage>.runtime.sglang.max_total_tokens
+pipeline.stages.<stage>.runtime.sglang.encoder_mem_reserve
 pipeline.stages.<stage>.runtime.sglang.cuda_graph.*
+pipeline.stages.<stage>.runtime.sglang.upstream_args.<field>
 pipeline.stages.<stage>.runtime.compile.*
 pipeline.stages.<stage>.runtime.decode.*
 pipeline.stages.<stage>.runtime.prefill_coalesce.*
+pipeline.env_defaults.<NAME>
+pipeline.stages.<stage>.env.<NAME>
 ```
+
+两个环境 path 只保存已配置默认值。解析 configured default 时 stage value 覆盖 Pipeline default；spawn 时派生 `ResolvedProcessEnv`，继承进程环境仍优先。它们不会把任意 `os.environ` 读取收进配置 precedence。
 
 以下字段不再作为 public user interface：
 
@@ -708,8 +764,14 @@ runtime_arg_map
 gpu_id
 process_total_gpu_memory_fraction
 nccl_port
-endpoints
+具体 socket/IPC endpoints
 ```
+
+`pipeline.endpoints.base_path` 仍是用户可配置的分配策略输入。planner 在其下派生具体 socket path/endpoint；只有这些具体派生值禁止用户输入。
+
+`runtime.sglang.upstream_args` 是 stage-local、经过校验的逃生口，用于尚未提升到 Omni typed schema 的 SGLang 字段。其 schema 从精确 pin 的 upstream `ServerArgs` dataclass/schema 生成，同时 pin upstream version 和确定性的 schema fingerprint。它拒绝未知字段，并通过维护的 denylist 拒绝 Omni-owned、derived 或 unsafe 字段，包括 device/process/port/endpoint ownership。已经暴露为 Omni typed field 的字段也禁止出现在 `upstream_args`，从而避免双路径。每个接受的 leaf 都保留 provenance，完整组装后仍执行最终 upstream `ServerArgs` validation。因此该逃生口保持 **一个语义、一个路径**，而不是新增未经校验的 override dict。`kind`/capability 非 SGLang backend 的 stage 完全拒绝 `runtime.sglang`。
+
+`encoder_mem_reserve` 是 canonical SGLang-stage policy field，不再是 factory argument。只有 effective thinker `mem_fraction_static` 保持 `auto`/unset，且没有被任何 user source（包括 YAML、Router、selector expansion 或 alias）通过该 typed canonical path pin 时才合法。`mem_fraction_static` 已是 Omni typed field，因此本来就禁止出现在 `upstream_args`。resolver 根据 provenance 而不只是最终数值验证该约束。runtime derivation 随后从自动 thinker budget 中扣除 reserve 并应用现有 safety floor；它不修改 frozen policy，也不会静默覆盖 pinned fraction。
 
 模型专属、尚未进入公共 schema 的参数放在：
 
@@ -723,6 +785,8 @@ pipeline:
 ```
 
 extension model 仍必须由模型包注册 Pydantic schema；不允许裸 `dict[str, Any]` 覆盖公共字段。成熟的跨模型功能再从 extension 提升到公共 runtime namespace。
+
+full export 必须物化每个 effective typed/extension value，包括当前隐藏在 `factory_args` 或 Python factory default 中、会定义行为的值。例如 Qwen 模型配置中的 effective `talker_max_seq_len` 是 `32768`，而 factory 签名默认值是 `4096`；导出的 V2 document 必须显式包含 `32768`。在所有这类行为定义 factory default 都进入 public 或注册 extension schema、且 export/import 不依赖隐藏 Python default 前，该模型不能 opt in V2。
 
 ## 7.6 role 与 stage 的关系
 
@@ -778,7 +842,8 @@ Code review 可以据此拒绝任何绕过 canonical schema 的新公共配置�
 | GPU/TP/process placement | canonical source | 可用 `--set` 临时覆盖 | 属于 Pipeline，需统一 validation |
 | SGLang/runtime 参数 | canonical source | 可用 `--set` 临时覆盖 | 同一 path、同一类型、同一校验 |
 | HTTP bind/log/API policy | 不进入 Pipeline YAML | 专用 CLI | 属于服务进程，不属于模型 Pipeline |
-| runtime-derived endpoint/port/gpu id | 不可设置 | 不可设置 | planner/runner owner |
+| Endpoint 分配策略（`endpoints.base_path`） | canonical source | 可用 `--set` 临时覆盖 | 用户可配置的分配根目录 |
+| 具体 runtime-derived endpoint/port/gpu id | 不可设置 | 不可设置 | planner/runner owner |
 | Router worker pool | Router YAML | Router CLI 只选择 source/路由参数 | 与 worker Pipeline 分层 |
 
 CLI 和 YAML 因而仍有两种语法，但只有一套 Pipeline 语义：
@@ -795,28 +860,42 @@ CLI --set
 
 ## 9.1 structured worker config
 
-launcher YAML 移除自由字符串 `worker_extra_args`，改为：
+launcher YAML 移除自由字符串 `worker_extra_args`，改用共享默认值和显式 per-worker entry：
 
 ```yaml
 schema_version: 2
 
 launcher:
   backend: local
-  num_workers: 2
-  num_gpus_per_worker: 1
+  num_workers: 4
   worker_host: 127.0.0.1
   worker_base_port: 8011
   wait_timeout: 600
 
-  worker:
+  worker_defaults:
     config: examples/configs/qwen3_omni_colocated_h20_v2.yaml
     service:
       model_name: qwen3-omni
+    capabilities: [speech]
     patches:
       pipeline.stages.thinker.runtime.sglang.max_running_requests: 32
+
+  workers:
+    - index: 0
+      gpus: ["0"]
+      capabilities: [speech, streaming]
+      patches:
+        pipeline.stages.thinker.runtime.sglang.max_running_requests: 48
+    - index: 1
+      gpus: ["0"]  # 与 worker 0 有意共享 GPU。
+    - range: "2-3"
+      gpus: ["GPU-3b6e...", "MIG-GPU-7d2a.../1/0"]
+      capabilities: [chat]
 ```
 
-`worker.config` 与 `worker.model` 二选一，对应 worker `--config` 与 `--model-path` 模式。`worker.patches` 由 Router schema 校验 path/value，并作为结构化 patch 传递。
+`worker_defaults` 提供共享的 `config` 或 `model`（二选一）、service value、capability 和 patch。每个 `workers` entry 用 `index` 选择一个 worker，或用 `range` 选择包含端点的一组 worker，并可覆盖 `gpus`、capability 和 patch。同一 Router source 内先展开 `worker_defaults`，再应用具体 entry；entry patch 覆盖同 path default 并保留 provenance，不按同 scope duplicate 报错。entry 自身同 path 重复仍报错。允许不同 worker 使用重复的 physical GPU set：示例明确让 worker 0 和 1 都使用 physical GPU `0`。physical identifier 按原样保留，包括形似整数的字符串、UUID 和 MIG identifier；Router 不把它们转换成 logical ID。entry 必须恰好覆盖每个 worker，重叠的 index/range selector 报错。
+
+`num_gpus_per_worker` 只在没有任何显式 worker `gpus` 时作为 fallback；此时 Router 自动、互斥地切分可用设备。它不能与显式 per-worker GPU set 同时使用。分配实际可见设备集合后，Router 按 `0..len(worker.gpus)-1` 校验 Pipeline logical GPU ID，而不是使用全局数量。
 
 ## 9.2 worker 传递方式
 
@@ -832,19 +911,19 @@ patch file 内容是序列化的 `ConfigPatchSet`，不是 shell fragment。work
 
 后续如果 Router 与 worker 改为 Python API 或 supervisor protocol，仍复用 `ConfigPatchSet`，不改变配置语义。GPU visibility 继续由 Router 通过 subprocess env 管理，因为它是进程资源边界，不属于 Pipeline patch。
 
-Router 和 worker 使用同版本的 schema registry 与 `ConfigResolver`。Router 在创建 subprocess 前，对 `worker.config/model + worker.patches` 执行完整 dry-run resolve：
+Router 和 worker 使用同版本的 schema registry 与 `ConfigResolver`。Router 在创建 subprocess 前，对每个已选择 worker 的 `defaults + entry + config/model + patches` 执行完整 dry-run resolve：
 
 - 相对配置路径以 launcher YAML 所在目录为基准；
-- Router 必须能加载 worker 所需的 model config 和 extension schema；
+- Router 必须先解析已选择的 model/config identity，并精确加载该 worker 引用的 extension schema；无法完成此 lookup 时启动失败；
 - path、type、role 或 extension 无法解析时，在启动任何 worker 前失败；
 - worker 收到 patch file 后再次校验 schema version 和内容，但不得采用不同的 merge 规则。
 
 GPU 使用两个明确坐标系：
 
-- Router 独占物理 GPU 分配权，通过 `CUDA_VISIBLE_DEVICES` 建立每个 worker 的可见设备集合；
+- Router 是唯一有权分配 physical GPU 的组件，通过 `CUDA_VISIBLE_DEVICES` 建立每个 worker 的可见设备集合；显式 assignment 可以有意跨 worker 重叠；
 - Pipeline `placement.gpus` 始终使用 worker-local logical GPU ID，即可见设备重新编号后的 `0..N-1`。
 
-Router dry-run 必须验证所有 logical GPU ID 均位于 `[0, num_gpus_per_worker)`，并验证 TP size、GPU list 和 worker allocation 一致。Pipeline 不允许直接引用宿主机 physical GPU ID。
+Router dry-run 必须验证所有 logical GPU ID 均位于 `[0, len(actual worker visible GPU set))`，并验证 TP size、GPU list 和 worker allocation 一致。Pipeline 不允许直接引用宿主机 physical GPU ID。这个前置条件不要求 Router import 或加载所有已注册模型，只要求加载已选择的 worker model 及其引用的 extension。
 
 ## 9.3 Router 与 worker 的优先级
 
@@ -863,13 +942,14 @@ managed worker 的 layer 固定：
 | 冲突类型 | 示例 | V2 行为 |
 |---|---|---|
 | 同 source 重复 | 两个 `--set` 写同 path | 启动前报错 |
-| alias/canonical 重复 | typed CLI 与 `--set` 写同 path | 启动前报错 |
+| alias specificity | broadcast alias 与 role alias 写同 leaf | 更具体的 role value 生效，并记录被遮蔽值 |
+| 相同 specificity 的 alias/canonical 重复 | 两个 role alias 或两个显式 `--set` 写同 leaf | 启动前报错 |
 | typed/extension 重叠 | extension 试图设置公共 SGLang 字段 | schema 注册失败 |
 | parent/child 重叠 | 两个同层 patch source 分别设置 `runtime.sglang` 及其 child | 同层报错；跨层允许并记录 |
-| owner 违规 | 用户设置 `gpu_id` 或 endpoint | path 不公开，解析失败 |
+| owner 违规 | 用户设置 `gpu_id` 或具体 endpoint | path 不公开，解析失败；`endpoints.base_path` 仍可配置 |
 | capability 不支持 | 非 SGLang stage 设置 `runtime.sglang` | model validation 失败 |
 | cross-field 不一致 | TP=2 但只有一个 GPU | resolved model validation 失败 |
-| deprecated/canonical 重复 | V1 `runtime_overrides` 与 V2 field | migration error，不猜优先级 |
+| deprecated document/canonical 重复 | 同一 document layer 中 V1 `runtime_overrides` 与 V2 field | migration error；CLI alias 改按显式 specificity 规则处理 |
 
 ## 10.2 原子性
 
@@ -889,11 +969,11 @@ resolver 在内存中的 immutable tree 上应用所有 patches。任何 path、
 duplicate configuration for
 pipeline.stages.thinker.runtime.sglang.mem_fraction_static
 
-file:qwen.yaml:42 = 0.70
-cli:--thinker-mem-fraction-static = 0.65
+cli:--thinker-mem-fraction-static = 0.70
+cli:--generation-mem-fraction-static = 0.65
 
-The CLI alias and canonical field target the same setting.
-Remove one source or use `config explain` to inspect precedence.
+The two role aliases have equal specificity and resolve to the same stage.
+Remove one alias or use an explicit concrete `--set`.
 ```
 
 # 11. 配置编译与运行时边界
@@ -916,8 +996,8 @@ V2 编译链为：
 - ③是最后一次修改用户配置的步骤；
 - ④只生成派生 plan，不回写 Pipeline；
 - ⑤保存主进程 topology/hardware probe 可决定的 effective runtime values；
-- ⑥只整理跨进程 DTO；
-- ⑦才 import factory、构造 `ServerArgs` 和 `ModelConfig`；只能在该阶段确定的调整记录到 `WorkerRuntimeDerivation`。
+- ⑥在父进程解析与 factory 签名无关的参数，并整理进跨进程 DTO；
+- ⑦ import factory，只注入缺失的签名相关默认值，再构造 `ServerArgs` 和 `ModelConfig`；只能在该阶段确定的调整记录到 `WorkerRuntimeDerivation`。
 
 当前 `_apply_tensor_parallel_server_args_overrides()` 会基于 topology probe 修改 stage server args。V2 将其拆为：
 
@@ -937,9 +1017,10 @@ V2 编译链为：
 |---|---|
 | `sglang_omni/config/schema.py` | 增加 V2 public schema、name-keyed stages、typed runtime namespaces、frozen resolved model |
 | `sglang_omni/config/patch.py`（新增） | `ConfigPath`、`ConfigSource`、`ConfigPatch`、duplicate/overlap 检查 |
-| `sglang_omni/config/resolver.py`（新增） | layer merge、type conversion、provenance、完整 validation |
+| `sglang_omni/config/resolver.py`（新增） | selector expansion、specificity/layer merge、type conversion、provenance、完整 validation |
 | `sglang_omni/config/compat.py`（新增） | V1 YAML/dotted/typed CLI 到 V2 patch 的限时 adapter |
-| `sglang_omni/models/registry.py` | 注册 V2 model defaults、roles 和 extension schemas |
+| `sglang_omni/config/sglang_schema.py`（新增） | 生成并 fingerprint 精确 pinned `ServerArgs` passthrough schema，执行 ownership/unsafe denylist |
+| `sglang_omni/models/registry.py` | 注册 V2 model defaults、roles、stage kind/capability 和 extension schemas |
 
 `ConfigManager` 的文件加载职责并入 adapter/resolver。旧类在迁移期保留 facade，最终删除自定义 dotted merge。
 
@@ -948,7 +1029,7 @@ V2 编译链为：
 | 模块 | 改动 |
 |---|---|
 | `sglang_omni/cli/serve.py` | 参数解析后只构造 `ServerLaunchConfig` 和 patches；删除业务 mutation helper |
-| `sglang_omni/cli/config.py` | 增加 schema/validate/resolve/explain/migrate |
+| `sglang_omni/cli/config.py` | 增加 schema/validate/resolve/explain/migrate/export、selector expansion 展示和环境诊断 |
 | `sglang_omni/cli/__init__.py` | 关闭未知 option；开放覆盖统一走显式 `--set` |
 
 迁移期 typed CLI alias 可以继续在 `serve()` 签名中出现，但实现由 alias registry 自动生成 patch。
@@ -957,9 +1038,10 @@ V2 编译链为：
 
 | 模块 | 改动 |
 |---|---|
-| `sglang_omni/config/runtime.py` | 只把 typed resolved runtime 转成 factory kwargs；不再解决用户来源冲突 |
+| `sglang_omni/config/runtime.py` | 把 typed resolved runtime 转成父进程已解析的静态 factory kwargs；不再解决用户来源冲突 |
 | `sglang_omni/pipeline/runtime_config.py` | 只读 frozen resolved config，输出 placement/process 和 `DerivedRuntimePlan` |
-| `sglang_omni/pipeline/mp_runner.py` | 从 resolved config/plans 构造 spec，不接收 compatibility fields |
+| `sglang_omni/pipeline/mp_runner.py` | 从 resolved config/plans 构造 spec 和 `ResolvedProcessEnv`，保持 static args/signature injection 边界 |
+| `sglang_omni/pipeline/stage_workers.py` | 应用已配置环境默认值但不覆盖继承值，并输出 process environment 诊断 |
 | `sglang_omni/scheduling/sglang_backend/server_args_builder.py` | 从 typed SGLang config 构造 `ServerArgs`，保留明确的 derived runtime overrides |
 
 模型 factory 可以暂时继续接收 `server_args_overrides`，但该 dict 只能由 typed runtime adapter 内部生成，不再是 public YAML/CLI 入口。
@@ -968,7 +1050,7 @@ V2 编译链为：
 
 | 模块 | 改动 |
 |---|---|
-| `sglang_omni_router/launcher/config.py` | `worker.config/model/service/patches` schema |
+| `sglang_omni_router/launcher/config.py` | `worker_defaults`、index/range 选择的 `workers`、capability、physical GPU identifier 和 patch schema |
 | `sglang_omni_router/launcher/local.py` | 生成 patch file，不拼接 `worker_extra_args` |
 | `sglang_omni_router/serve.py` | worker source validation 与 structured launcher 接入 |
 
@@ -978,9 +1060,11 @@ V2 采用分阶段迁移，不要求一个版本内修改所有配置，但每�
 
 ## 13.1 Phase 0：建立 resolver，不改变默认行为
 
+- 首先运行 `2b45073c` 上完全未改动的 latest-main V1 实现，冻结独立 oracle：记录最终 Pipeline shape、factory kwargs、placement/process plans、worker specs 和用户可控 `ServerArgs` 字段。在任何 V1 输入经过新 adapter/resolver 前先生成这些 legacy golden；
+- 在当前行为外增加只读 provenance 重建和 `config resolve/explain`，此时不让新 resolver 成为 authoritative path；
 - 引入 `ConfigPatch`、provenance 和 `config resolve/explain`；
-- 当前模型默认、V1 YAML、dotted CLI 和 typed CLI 全部通过 compatibility adapter 产生 patch；
-- 用 golden tests 锁定最终 resolved value 和成功/失败行为；
+- 在不替换 V1 执行路径的 shadow mode 中，当前模型默认、V1 YAML、dotted CLI 和 typed CLI 同时通过 compatibility adapter 产生 patch；
+- 将 adapter/resolver 输出与独立的 untouched-V1 oracle 比较；V1 adapter 与 V2 通过同一 resolver 的对比只是补充，不能替代独立 oracle；
 - runtime 仍消费现有 `PipelineConfig` shape；
 - 新 resolver 发现的 V1 重复来源先记录 diagnostic，不改变当前成功/失败结果；
 - 内部测试的 V2 输入从一开始执行严格 duplicate/overlap 规则。
@@ -997,6 +1081,7 @@ V2 采用分阶段迁移，不要求一个版本内修改所有配置，但每�
 
 V2 document 不允许出现 V1 `stage_overrides`、`runtime_overrides` 或 public `factory_args.server_args_overrides`。
 V1 输入继续保留当前最终值语义，但新发现的重复来源输出 warning。
+模型只有在所有隐藏于 `factory_args` 或 factory default 中、会定义行为的值都进入 public 或注册 extension schema，并能通过 full export round-trip 后，才允许 opt in V2。
 
 ## 13.3 Phase 2：V2 默认
 
@@ -1045,14 +1130,17 @@ V1 输入继续保留当前最终值语义，但新发现的重复来源输出 w
 | path | 合法 field、unknown field、private/derived field、stage name |
 | type | scalar、null、list、dict、enum、invalid coercion |
 | document structure | duplicate YAML key、full/partial mode、stage declaration、`stage_order` 完整性 |
-| precedence | defaults、profile、YAML、Router patch、CLI |
-| duplicates | 同 source、同 layer、alias/canonical、parent/child |
+| precedence | defaults、profile、YAML、Router patch、CLI、source layer 主导 selector specificity |
+| selectors | capability/role/stage/exclude 匹配、展开、空选择、具体 stage storage/export |
+| duplicates | 同 source/specificity、同 layer、alias specificity、parent/child |
 | cross-layer subtree | 高层 child 覆盖低层 parent、高层 parent 替换低层 subtree、list 整体替换 |
 | provenance | 每次覆盖的旧值、source、location、deprecated 标记 |
 | atomicity | 任意 patch 失败时不产生 partial resolved config |
 | frozen config | resolver 返回后禁止 assignment |
 | role | role 到 stage 的唯一解析、unknown/unsupported role |
-| extension | 注册 schema、未知 key、禁止覆盖公共 namespace |
+| extension | 注册 schema、未知 key、禁止覆盖公共 namespace、隐藏 default 的 full-export round trip |
+| upstream args | 精确 pinned `ServerArgs` version/fingerprint、未知字段、denylist、typed field 重复、per-leaf provenance、最终 `ServerArgs` validation |
+| environment | `env_defaults`/stage `env` merge、继承环境不被覆盖、派生 `ResolvedProcessEnv`、外部读取诊断 |
 
 ## 14.2 CLI/YAML 等价性
 
@@ -1079,7 +1167,7 @@ CLI --set canonical path
 - Ming 完整 stages YAML；
 - TP 和 process isolation 配置。
 
-分别执行 V1 adapter 和迁移后的 V2 document，比较：
+每个 case 首先从完全未改动的 latest-main V1 实现捕获独立 golden，再把 V1 adapter 和迁移后的 V2 document 分别与该 oracle 比较：
 
 - stage topology 和顺序；
 - placement/TP/process；
@@ -1097,6 +1185,8 @@ runtime-derived endpoint 和临时 port 使用结构比较，不比较随机值�
 
 - typed `mem_fraction_static` 与旧 `server_args_overrides`；
 - global 与 per-role CLI；
+- broadcast alias、role alias 和显式 `--set` specificity，包括 shadowed provenance；
+- selector broadcast 与具体 stage override；
 - `--encoder-mem-reserve` 与 explicit fraction；
 - `tp_size` 与 GPU list；
 - generation role 与 thinker role 指向同/不同 stage；
@@ -1116,7 +1206,7 @@ runtime-derived endpoint 和临时 port 使用结构比较，不比较随机值�
 - worker-only effective value 只进入 `WorkerRuntimeDerivation` 并保留 source；
 - child process 不重新 resolve user config；
 - factory signature injection 只补缺失的 derived defaults；
-- user 不能设置 `gpu_id`、process cumulative budget、NCCL port 和 endpoint；
+- user 不能设置 `gpu_id`、process cumulative budget、NCCL port 和具体 endpoint，但 `endpoints.base_path` 仍可配置；
 - TP env mapping 与当前行为一致；
 - no-config/default model path 的 worker specs 与 golden 一致；
 - `ServerArgs.override()` 仍记录 worker 内 derived mutation source。
@@ -1133,7 +1223,12 @@ runtime-derived endpoint 和临时 port 使用结构比较，不比较随机值�
 - Router YAML path/type/role/extension 在启动 subprocess 前失败；
 - GPU 继续通过 environment 传递；
 - physical GPU assignment 与 worker-local logical GPU ID 转换正确；
-- logical GPU 越界、TP 和 worker allocation 不一致时启动前失败；
+- 校验 index/range coverage、per-worker capability/patch 和 selected-model/extension lookup；
+- 校验 `worker_defaults` < per-worker entry 的覆盖与 provenance，以及各自 scope 内的 duplicate rejection；
+- 保留跨 worker 重复的 physical GPU set，包括两个 worker 共享 GPU `0`；
+- 形似整数、UUID 和 MIG physical identifier 原样 round-trip；
+- logical GPU 根据每个 worker 的实际 visible set 检查越界，TP/allocation 不一致时启动前失败；
+- 只有没有显式 `gpus` 时才执行互斥的 `num_gpus_per_worker` 自动切分；
 - V1 `worker_extra_args` migration 能识别 `--config`、typed alias 和 `--set`；
 - 无法安全迁移的任意 shell token 明确失败，不静默丢弃。
 
@@ -1151,9 +1246,12 @@ runtime-derived endpoint 和临时 port 使用结构比较，不比较随机值�
 1. 官方 Pipeline 和 Router examples 全部通过 migration golden；
 2. structured Router 至少完成一条多 worker E2E；
 3. runtime 不再直接读取 public compatibility fields；
-4. 当前 Phase 的 warning/error matrix 在 CI 中固定；
-5. deprecated 入口使用量达到项目预先公布的迁移阈值；
-6. release notes 已给出下一 Phase 的目标版本和删除项。
+4. 当前 Phase 的 warning/error matrix 和完整 compatibility matrix 在 CI 中固定；
+5. 官方 examples、文档、测试和 CI 调用全部完成迁移；
+6. release notes 已提前公布在预定的 `N` 个 release 后删除；
+7. 进入删除 Phase 前，这 `N` 个已公布 release 已实际发布。
+
+repo state 和 release history 是可判定 gate。本地或显式 opt-in telemetry 只能用于诊断剩余使用，不能用不可观测的全局 deprecated usage threshold 阻止或授权 Phase 切换。
 
 # 15. 发布与文档
 

--- a/docs/design/configuration_interface_refactor_proposal_en.md
+++ b/docs/design/configuration_interface_refactor_proposal_en.md
@@ -1,0 +1,1201 @@
+# Configuration Interface Refactoring Design Proposal
+
+# 1. Background and Scope
+
+SGLang-Omni currently supports several configuration methods: model Python defaults, Pipeline YAML, dynamic dotted CLI options, dedicated typed CLI options, environment variables, and Router launcher YAML. Having multiple entry points is not itself a problem: YAML is suitable for storing static parameters for a complete deployment, CLI options are suitable for selecting configurations and applying dynamic temporary overrides, and environment variables are suitable for process-level injection. However, the current configuration logic has three main problems:
+
+1. **Inconsistent processing logic**: When the same configuration item is supplied through different entry points, it does not follow the same processing code. For example, when both YAML and CLI can set the same parameter, field addressing, type conversion, and parameter validation may need to be implemented repeatedly.
+2. **Unclear extension path for developers**: When adding a configuration item, developers do not know whether it should go into the typed schema, a CLI option, `factory_args`, `runtime_overrides`, or model-specific configuration, nor which modules must be updated together.
+3. **Unclear modification path for users**: Users do not know at which YAML level a configuration should be written, which CLI flag to use, or which value ultimately takes effect when multiple entry points set it simultaneously.
+
+In summary, the refactoring must address all three questions—whether the implementation is unified, how developers extend it, and how users configure it—rather than merely replacing the current merge implementation.
+
+## 1.1 One-Sentence Proposal
+
+**Define each parameter only once; use YAML for long-term storage and CLI for temporary overrides; regardless of where a value comes from, pass it to the same code for parsing and validation.**
+
+Before the refactoring, the same parameter may have multiple processing paths:
+
+```text
+The same parameter
+├── YAML typed field
+├── stage_overrides
+├── runtime_overrides
+├── factory_args
+├── dotted CLI
+└── typed CLI helper
+```
+
+Each path may contain its own field lookup, type conversion, precedence, and validation code.
+
+After the refactoring, a parameter has only one official address:
+
+```text
+One parameter
+└── One configuration path
+    ├── YAML: long-term storage
+    ├── CLI --set: temporary override
+    └── Router: structured input
+            ↓
+       The same configuration processor
+            ↓
+       Final read-only configuration
+```
+
+For example, `max_running_requests` is defined only as:
+
+```text
+pipeline.stages.thinker.runtime.sglang.max_running_requests
+```
+
+YAML can persistently set it:
+
+```yaml
+pipeline:
+  stages:
+    thinker:
+      runtime:
+        sglang:
+          max_running_requests: 32
+```
+
+CLI can temporarily override the same path:
+
+```bash
+sgl-omni serve \
+  --config config.yaml \
+  --set pipeline.stages.thinker.runtime.sglang.max_running_requests=32
+```
+
+Both forms ultimately enter the same type conversion, range validation, conflict detection, and precedence handling code.
+
+## 1.2 Solutions Corresponding to the Three Goals
+
+| Current problem | Rule after refactoring |
+|---|---|
+| YAML and CLI duplicate parameter processing | Convert every entry point into a unified configuration modification first, then pass it to the same processor |
+| Developers do not know where to add a parameter | Add shared parameters only to the public schema; model parameters only to model extensions; service parameters only to server config |
+| Users do not know where to modify a value | Put long-term configuration in YAML, use `--set` for temporary overrides, and use dedicated CLI options for service parameters such as host/port/log |
+
+When adding a shared parameter, a developer only needs to define its type, default, and validation once in the schema, then consume it in the runtime adapter. CLI help, YAML Schema, documentation, and equivalence tests are all generated from this definition.
+
+Users do not need to understand `factory_args`, `runtime_overrides`, or the internal planner. They only need to find the parameter's official path and decide whether this change should be "stored long-term in YAML" or "temporarily overridden through CLI."
+
+## 1.3 Terminology in This Document
+
+The remainder of this document uses three technical names for the simple flow above:
+
+- **canonical path**: the unique, official configuration address of a parameter;
+- **ConfigPatch**: a modification record that "sets an address to a value," while also recording whether the source is YAML, CLI, or Router;
+- **ConfigResolver**: the configuration processor that uniformly performs type conversion, precedence handling, conflict detection, and validation.
+
+These three names are not three new interfaces, but three stages in the same configuration processing pipeline.
+
+This document discusses only startup-time configuration. It does not change the request protocol, Stage payloads, scheduling algorithms, or field definitions in SGLang's internal `ServerArgs`. The code revision checked for the "current implementation" in this document is `42a124cd`; see `docs/developer_reference/configuration.md` for the complete current state.
+
+Tracking issue: [#1466](https://github.com/sgl-project/sglang-omni/issues/1466)
+
+Chinese version: [配置接口重构设计 Proposal](./configuration_interface_refactor_proposal.md)
+
+The refactoring goals are:
+
+1. **Unify configuration processing code**: Each user-facing semantic has only one canonical config path; YAML, CLI, and Router all enter the same parsing, type conversion, precedence, validation, and conflict-handling flow.
+2. **Establish a single developer extension interface**: Adding a shared configuration item modifies the typed schema only once; CLI, JSON Schema, documentation, patch types, and equivalence tests are generated from the schema. Model-specific parameters use an explicit extension schema rather than arbitrarily choosing among multiple pass-through dicts.
+3. **Establish a discoverable and explainable user interface**: Clearly define the responsibilities of YAML and CLI, and provide schema, validate, resolve, explain, and migrate tools so users can find valid configuration paths and confirm the source of final values.
+
+Configuration should be resolved once, fully validated, and frozen before entering placement/runtime; old interfaces remain compatible through phased migration, but two semantic systems will not be retained permanently.
+
+This document does not require all model configuration to be rewritten at once. The new interface first stabilizes the configuration boundary, then gradually migrates model-specific parameters.
+
+# 2. Current Configuration Interfaces and Execution Flow
+
+## 2.1 Configuration Sources
+
+The current public configuration sources can be divided into six categories:
+
+| Source | Current entry point | Main implementation |
+|---|---|---|
+| Model defaults | `PipelineConfig` subclasses, `Variants` | `models/*/config.py`, `config/manager.py` |
+| Pipeline YAML | `sgl-omni serve --config` | `ConfigManager.from_file()` |
+| Compact YAML overrides | `stage_overrides`, `runtime_overrides` | `config/manager.py`, `config/runtime.py` |
+| Dynamic CLI | `--stages.thinker... VALUE` | `ConfigManager.parse_extra_args()` |
+| Dedicated CLI | `--mem-fraction-static`, etc. | `apply_*_cli_overrides()` in `cli/serve.py` |
+| Router launcher | `--launcher-config`, `worker_extra_args` | `sglang_omni_router/launcher/*` |
+
+`sgl-omni serve` enables `ignore_unknown_options` for unknown options, so Typer first parses 41 dedicated parameters, after which the remaining tokens are parsed by `ConfigManager` as dotted overrides. The two types of CLI options are applied at different stages.
+
+## 2.2 Current Merge Order
+
+The current main process constructs the final `PipelineConfig` in the following order:
+
+1. If `--config` is present, construct the configuration class using `config_cls` from YAML; otherwise, identify the model architecture through `model_path`;
+2. Deep-merge YAML `stage_overrides` into typed `StageRuntimeConfig`;
+3. Apply the dotted CLI options in `ctx.args` to the dict produced by `model_dump()`, then rebuild the Pydantic model;
+4. An explicit `--model-path` overrides `model_path` from YAML;
+5. `serve.py` runs the memory, TP/GPU, process, CUDA graph, compile, decode, prefill, and generation batch helpers in sequence;
+6. `launch_server()` passes HTTP/API parameters separately from `PipelineConfig`;
+7. Runtime preparation constructs placement, process topology, endpoints, and worker specs;
+8. Worker subprocesses merge factory args, then construct `ServerArgs` and `ModelConfig` inside the factory.
+
+| Order | Processing stage | Input and output |
+|---|---|---|
+| 1 | Select base configuration | Model Python defaults or Pipeline YAML → `ConfigManager` |
+| 2 | Apply compact YAML overrides | `stage_overrides` → typed runtime |
+| 3 | Apply dynamic CLI | dotted CLI → rebuilt `PipelineConfig` |
+| 4 | Apply dedicated CLI | typed CLI helpers → in-place modification of `PipelineConfig` |
+| 5 | Runtime planning | `PipelineConfig` → placement, process topology, worker spec |
+| 6 | Worker construction | worker spec → stage factory → `ServerArgs` |
+
+This order appears to provide precedence, but precedence is not a single unified rule. Different helpers choose to "override," "reject," "synchronize two aliases," "write both `factory_args` and `runtime_overrides`," or "wait until the worker to report a conflict."
+
+## 2.3 Current Factory Parameter Path
+
+Stage factory kwargs are combined from the following sources:
+
+```text
+factory_args
+< runtime_overrides
+< typed runtime mapping
++ signature-dependent defaults
+```
+
+Here, `server_args_overrides` performs an additional dict merge between `factory_args` and `runtime_overrides`; typed `runtime.max_seq_len` and `runtime.video_fps` are renamed through `runtime_arg_map`; typed `mem_fraction_static` is ultimately written back to `server_args_overrides`.
+
+`model_path`, `gpu_id`, and `total_gpu_memory_fraction` are not ordinary user factory args. After importing the factory, the worker injects them as needed based on the function signature. `gpu_id`, the cumulative process budget, NCCL port, and IPC endpoints are derived by the planner/runner.
+
+# 3. Problems with the Current Design
+
+## 3.1 Multiple User Entry Points for the Same Semantic
+
+`mem_fraction_static` is the most complete example:
+
+| Entry point | Write location | Validation location |
+|---|---|---|
+| YAML typed runtime | `stage.runtime.sglang_server_args.mem_fraction_static` | Pydantic schema |
+| YAML compatibility override | `runtime_overrides.<stage>.server_args_overrides.mem_fraction_static` | runtime adapter |
+| Full stage YAML | `factory_args.server_args_overrides.mem_fraction_static` | runtime adapter |
+| dotted CLI | Can write any path above | Pydantic/runtime adapter after merge |
+| global typed CLI | `--mem-fraction-static` | `apply_mem_fraction_cli_overrides()` |
+| role typed CLI | `--thinker-mem-fraction-static`, etc. | The same helper and role map |
+
+The current code must explicitly detect duplicate sources between typed runtime and `server_args_overrides`. Such detection can only cover known conflicts and is easily omitted when a new source is added.
+
+Generation batch configuration has the same kind of problem. `max_running_requests` can come from:
+
+- Model factory defaults;
+- YAML `factory_args`;
+- YAML `runtime_overrides`;
+- dotted CLI;
+- `--thinker-max-running-requests`;
+- `--max-running-requests`;
+- Derivation or validation by the model's generation batch policy.
+
+Users see one feature, while the code maintains multiple paths.
+
+## 3.2 YAML Serves as Both a "Configuration Instance" and a "Patch"
+
+Current YAML can be:
+
+1. A template selection containing only `config_cls` and `model_path`;
+2. A compact patch with `stage_overrides`;
+3. A factory patch with `runtime_overrides`;
+4. A resolved-like configuration with full `stages`.
+
+The four forms enter different merge logic. In particular:
+
+- `stage_overrides` permits only typed `runtime`;
+- `runtime_overrides` is a free-form dict;
+- Full `stages` replaces the model's default list as a whole;
+- These forms can be mixed in the same YAML.
+
+Consequently, "where should this field be written" cannot be answered solely from the field's semantics; it also depends on which YAML form the user chose.
+
+## 3.3 CLI Is Both an Interface Layer and a Business Logic Layer
+
+`cli/serve.py` not only declares options, but is also responsible for:
+
+- Resolving public roles to model stages;
+- Modifying nested Pydantic objects;
+- Synchronizing `tp_size` and `parallelism.tp`;
+- Writing parameters into `factory_args` and `runtime_overrides`;
+- Checking whether a factory belongs to the supported set;
+- Performing GPU topology probes;
+- Re-running part of Pydantic validation.
+
+As a result, adding a runtime parameter usually requires modifying all of the following:
+
+1. Typer signature;
+2. CLI helper;
+3. Role map;
+4. Runtime adapter or factory;
+5. Tests;
+6. Documentation.
+
+CLI is no longer an input adapter, but a second configuration compiler.
+
+## 3.4 In-Place Mutation Bypasses Schema Validation
+
+The current Pydantic models do not enable `validate_assignment=True`. `ConfigManager.merge_config()` performs dump, deepcopy, and reconstruction, and therefore can run full validation; most typed CLI helpers directly modify:
+
+- `stage.gpu`
+- `stage.tp_size`
+- `stage.runtime.*`
+- `stage.factory_args`
+- `pipeline_config.runtime_overrides`
+
+Helpers must ensure atomicity and complete validation themselves. Some paths manually rebuild the entire config, while others perform only local range checks. Whether a configuration is valid depends on the specific helper that modified it rather than on the config schema itself.
+
+## 3.5 Dynamic Dotted CLI Lacks a Stable Contract
+
+Dynamic CLI converts `-` to `_`, traverses dicts/lists by `.`, and supports only bool, None, int, float, and string scalars. It has the following limitations:
+
+- It can write arbitrary internal fields, including compatibility fields that should not be public;
+- The stage list supports both numeric indices and names, and indices become unstable when the exported configuration changes;
+- Lists/dicts have no unified encoding;
+- A nonexistent path may raise `KeyError`/`IndexError`, with inconsistent error formats;
+- Available paths cannot be discovered from Typer help;
+- Renaming an internal field directly breaks user commands.
+
+Open-ended overrides are valuable, but they must target the public schema rather than directly exposing the internal structure of `model_dump()`.
+
+## 3.6 Router Converts Structured Configuration Back into Strings
+
+This involves two YAML files with different purposes:
+
+1. **Router launcher YAML**: Describes how many complete workers to launch and which GPUs and ports to allocate to them;
+2. **Pipeline YAML**: Describes which Pipeline, stage topology, and runtime parameters are used inside each worker.
+
+Current Router launcher YAML cannot describe a worker's Pipeline configuration structurally; it can only write worker arguments as a string:
+
+```yaml
+launcher:
+  model_path: Qwen/Qwen3-Omni
+  num_workers: 2
+  worker_extra_args: "--config examples/configs/qwen.yaml --colocate"
+```
+
+Router first generates a base command for a worker:
+
+```bash
+sgl-omni serve \
+  --model-path Qwen/Qwen3-Omni \
+  --host 127.0.0.1 \
+  --port 8011
+```
+
+At this point, `worker_extra_args` is still an ordinary string. Router uses `shlex.split()` to split it into:
+
+```python
+["--config", "examples/configs/qwen.yaml", "--colocate"]
+```
+
+It then appends these arguments to the base command:
+
+```bash
+sgl-omni serve \
+  --model-path Qwen/Qwen3-Omni \
+  --host 127.0.0.1 \
+  --port 8011 \
+  --config examples/configs/qwen.yaml \
+  --colocate
+```
+
+When Router starts this worker subprocess, it also sets the physical GPU through an environment variable:
+
+```bash
+CUDA_VISIBLE_DEVICES=0
+```
+
+Only after the worker starts does `sgl-omni serve` parse `--config`, after which `ConfigManager` loads the second Pipeline YAML. Therefore, the actual flow is:
+
+```text
+Router launcher YAML
+→ Read the worker_extra_args string
+→ shlex.split into worker CLI arguments
+→ Start the sgl-omni serve subprocess
+→ Worker parses --config
+→ ConfigManager loads Pipeline YAML
+```
+
+The problem is not that Router starts workers, but that Router only knows a string and does not understand what it configures. Field types, duplicate options, Pipeline file paths, and parameter compatibility can only be validated after the worker starts; the Router schema cannot describe or check the worker's actual configuration in advance.
+
+## 3.7 Final Configuration Lacks Provenance
+
+The current debug merged config only displays the final `PipelineConfig` and cannot answer:
+
+- Whether a value came from a model default, YAML, or CLI;
+- Which previous value it overrode;
+- Whether it was set through a deprecated path;
+- Whether it will later be modified by factory defaults or `ServerArgs.override()`.
+
+When multiple entry points conflict, maintainers can only work backward through the helper order in `serve()`.
+
+# 4. Design Principles and Non-Goals
+
+## 4.1 How the Three Core Goals Are Implemented
+
+| Core goal | Design mechanism | Acceptance criteria |
+|---|---|---|
+| Unify configuration processing code | canonical schema, `ConfigPatch`, single `ConfigResolver` | YAML, `--set`, and migration-period CLI aliases produce the same resolved value for the same field, with no entry-point-specific mutation helpers remaining |
+| Clarify the developer extension interface | public typed schema, model extension schema, schema metadata generating CLI/documentation/tests | A new public field is defined only once; a new model field can only enter a registered extension schema |
+| Clarify how users modify configuration | YAML/CLI responsibility boundary, name-keyed paths, `config schema/validate/resolve/explain/migrate` | Users can discover valid paths, validate configuration before startup, and see final values and override sources |
+
+All subsequent data structures, migration steps, and tests must serve these three goals. A design that only reduces internal code without reducing the decision burden for developers or users is not considered completion of this refactoring.
+
+## 4.2 Design Principles
+
+1. **One semantic, one canonical path**: The same runtime feature must not expose both typed and untyped public paths.
+2. **Input adapters contain no business logic**: YAML, CLI, and Router only produce typed assignments/patches.
+3. **Resolve once, validate fully once**: Configuration is frozen after entering the runtime planner.
+4. **Separate user configuration from derived plans**: GPU logical placement can be configured; runtime values such as `gpu_id`, endpoint, and NCCL port cannot.
+5. **Explicit overrides with retained sources**: Cross-layer overrides are allowed but must be explainable; duplicate definitions within the same layer fail immediately.
+6. **The compatibility layer has an explicit removal point**: Old interfaces may be adapted, but cannot permanently become a second canonical schema.
+
+## 4.3 Non-Goals
+
+- Do not copy all of SGLang's `ServerArgs` unchanged into Omni's top-level CLI;
+- Do not allow YAML to select transports such as ZMQ/CUDA IPC that are derived from locality/placement;
+- Do not change the runtime semantics of Stage/process/TP in this refactoring;
+- Do not allow request-time parameters into startup-time `PipelineConfig`;
+- Do not require Router and workers to share the same top-level schema; they share only the patch representation.
+
+# 5. New Design Overview
+
+The new design adds a unidirectional configuration compilation stage:
+
+```text
+Input documents
+→ adapters
+→ ConfigPatchSet
+→ ConfigResolver
+→ immutable ResolvedPipelineConfig
+→ runtime planners
+→ worker specs
+```
+
+| Order | Processing stage | Responsibility |
+|---|---|---|
+| 1 | Input adapters | Convert Python defaults, YAML, CLI, compatibility entry points, and Router into `ConfigPatch` objects |
+| 2 | `ConfigPatchSet` | Store all modifications and their sources without executing entry-point-specific business logic |
+| 3 | `ConfigResolver` | Uniformly handle types, precedence, duplicate definitions, conflicts, and full validation |
+| 4 | `ResolvedPipelineConfig` | Generate a complete, read-only final user configuration with provenance |
+| 5 | Runtime planners | Read only the final configuration and generate placement, process, and derived runtime plans |
+| 6 | Worker specs | Construct cross-process startup parameters from the final configuration and plans |
+
+All adapters depend only on the public schema and path registry. `ConfigResolver` is the only component that performs precedence, alias normalization, duplicate detection, and merging. The runtime planner no longer reads unresolved compatibility fields.
+
+# 6. New User Interface
+
+## 6.1 YAML Is the Persistent Declaration of a Pipeline
+
+Current YAML can either list all stages in full or specify only modifications based on model defaults, but the file itself does not clearly indicate which form it uses. V2 uses `document_mode` to distinguish these two purposes.
+
+### `full`: Complete Pipeline
+
+`full` starts construction from an empty topology and does not inherit the default stages of a model configuration class. The file must fully declare the entry stage, all stages, and construction order, so the entire Pipeline can be determined from the file alone. The `example.*` factories below are used only to demonstrate the structure.
+
+```yaml
+schema_version: 2
+document_mode: full
+
+model:
+  path: Qwen/Qwen3-Omni-30B-A3B-Instruct
+
+pipeline:
+  name: qwen3-omni-text
+  entry_stage: preprocessing
+
+  stage_order:
+    - preprocessing
+    - thinker
+    - decode
+
+  stages:
+    preprocessing:
+      factory: example.create_preprocessing
+      process: pipeline
+      next: thinker
+
+    thinker:
+      factory: example.create_thinker
+      process: pipeline
+      next: decode
+      placement:
+        gpus: [0]
+      runtime:
+        sglang:
+          max_running_requests: 32
+
+    decode:
+      factory: example.create_decode
+      process: pipeline
+      terminal: true
+```
+
+The names in `stage_order` must correspond one-to-one with those in `stages`; none may be missing, duplicated, or reference a nonexistent stage. `config export` outputs this complete form by default, making it suitable for archiving and exact reproduction.
+
+### `partial`: Modify a Few Fields on a Model Template
+
+`partial` must select a model template through `model.config` or a variant. The resolver first creates the template's default Pipeline and then applies the modifications written in YAML; stages and fields not written retain their model defaults.
+
+```yaml
+schema_version: 2
+document_mode: partial
+
+model:
+  path: Qwen/Qwen3-Omni-30B-A3B-Instruct
+  config: Qwen3OmniSpeechColocatedPipelineConfig
+
+pipeline:
+  stages:
+    thinker:
+      runtime:
+        sglang:
+          max_running_requests: 32
+```
+
+This example means exactly three steps:
+
+1. Create the default Pipeline for `Qwen3OmniSpeechColocatedPipelineConfig`;
+2. Find the stage named `thinker`;
+3. Change `max_running_requests` to 32.
+
+`partial` can omit unchanged content, but can only modify stages that already exist in the template; it cannot create or delete stages. Use `full` when the complete topology must change.
+
+### Why Stages Are Stored by Name
+
+Current configuration stores stages as a list, so dynamic CLI may need to use unstable numeric positions:
+
+```text
+stages.4.runtime...
+```
+
+V2 stores stages as a name-keyed mapping:
+
+```text
+pipeline.stages.thinker.runtime...
+```
+
+The stage name becomes a stable identity, allowing YAML and CLI to use the same path without depending on a list index. The mapping itself does not express construction order, so a `full` document additionally uses `stage_order`; `partial` directly inherits the template's existing order.
+
+The current `stage_overrides` exists because users need to modify a default stage list by stage name. In V2, `partial.pipeline.stages.<name>` is itself the canonical modification path, so a separate `stage_overrides` merge mechanism is no longer needed.
+
+## 6.2 CLI Retains Only Startup Parameters and Generic Patches
+
+The steady-state `serve` interface is divided into three groups:
+
+### Configuration Selection
+
+```text
+--config FILE
+```
+
+or:
+
+```text
+--model-path MODEL [--variant text|speech|...]
+```
+
+The two modes are mutually exclusive. `--model-path` is shorthand for "construct configuration from model defaults"; when `--config` already contains `model.path`, it cannot be overridden.
+
+### Service Process Parameters
+
+The following values do not belong to the Pipeline and remain CLI options:
+
+```text
+--host
+--port
+--model-name
+--log-level
+--allowed-local-media-path
+--allowed-media-domain
+--tts-batch-max-items
+--enable-realtime
+```
+
+They are received separately by `ServerLaunchConfig` and are not written into `PipelineConfig`. If service configuration needs to be stored in the future, a separate deployment document should be introduced rather than putting it into Pipeline YAML.
+
+### Temporary Pipeline Overrides
+
+Uniformly use the repeatable:
+
+```text
+--set PATH=VALUE
+```
+
+For example:
+
+```bash
+sgl-omni serve \
+  --config qwen.yaml \
+  --set pipeline.stages.thinker.runtime.sglang.max_running_requests=32 \
+  --set pipeline.stages.thinker.placement.gpus='[0,1]' \
+  --set pipeline.stages.thinker.placement.tp=2
+```
+
+The value is parsed as a YAML scalar/flow value, so booleans, nulls, numbers, lists, and mappings share the same type rules. The path must exist in the public schema; runtime-derived or deprecated internal paths cannot be written.
+
+## 6.3 Final Role of Dedicated CLI Options
+
+Existing dedicated runtime CLI options are retained during migration but no longer execute helpers. Each option declares only one canonical path:
+
+```python
+CliAlias(
+    option="--thinker-max-running-requests",
+    path="pipeline.stages.${role:thinker}.runtime.sglang.max_running_requests",
+)
+```
+
+Parsing produces an ordinary `ConfigPatch`. If the same startup command uses both an alias and `--set` to write the same path, it immediately reports a duplicate assignment.
+
+After V2 stabilizes, dedicated runtime CLI options are removed in batches, leaving only `--set` and service process parameters. This prevents the final interface from permanently maintaining two definitions—"YAML field + dedicated CLI field." If the project decides to retain a very small number of frequently used aliases, their help, types, and patches must be generated automatically from schema metadata; they may not have independent business logic.
+
+## 6.4 Configuration Tools
+
+Add:
+
+```bash
+sgl-omni config schema
+sgl-omni config validate --config FILE
+sgl-omni config resolve --config FILE [--set ...]
+sgl-omni config explain --config FILE PATH [--set ...]
+sgl-omni config migrate --input v1.yaml --output v2.yaml
+```
+
+`resolve` outputs the complete canonical Pipeline before freezing; `explain` outputs the final value, source chain, and whether a deprecated adapter was used. For example:
+
+```text
+pipeline.stages.thinker.runtime.sglang.max_running_requests = 32
+
+1. model-default:Qwen3OmniSpeechPipelineConfig  64
+2. file:qwen.yaml:41                           48
+3. cli:--set[0]                                32
+```
+
+## 6.5 User Configuration Decisions
+
+Users only need to select an entry point according to the following rules:
+
+1. Write Pipeline changes that must be stored, reviewed, or reproduced into YAML canonical paths;
+2. Use `--set` with the same canonical path for a temporary override of a Pipeline field in the current launch only;
+3. Use service process CLI options to modify host, port, logging, or API policy;
+4. If the field path is unknown, run `config schema` first; if the final value is uncertain, run `config resolve` or `config explain`;
+5. Do not directly set `factory_args`, `runtime_overrides`, or runtime-derived fields.
+
+Documentation and error messages therefore no longer need to answer "which of five entry points should be used for this value," but only "which canonical path does this value belong to, and should this change be persistent or temporary?"
+
+# 7. Core Internal Data Structures
+
+## 7.1 `ConfigPatch`
+
+```python
+class ConfigSource(BaseModel):
+    kind: Literal["model_default", "file", "cli", "router", "compat"]
+    location: str
+    deprecated: bool = False
+
+
+class ConfigPatch(BaseModel):
+    op: Literal["set", "declare_stage"]
+    path: ConfigPath
+    value: object | None = None
+    source: ConfigSource
+    layer: int
+```
+
+The initial patch protocol includes only `set` and `declare_stage`:
+
+- `set` sets a typed value; `null` is always an ordinary value used to clear an optional field that permits null;
+- `declare_stage` is produced only by the YAML adapter for `document_mode: full` and declares the stage name and stage type.
+
+A full document starts from an empty topology and can declare stages; a partial document and CLI `--set` can only modify existing stages and cannot create or delete stages. The names in `stage_order` must correspond one-to-one with the finally declared stages; none may be missing, duplicated, or reference an unknown stage. The initial patch protocol does not provide an operation for deleting inherited stages or mapping entries; use a full document to change stage membership.
+
+The initial patch protocol always replaces lists as a whole; it does not add order-sensitive operations such as appending or removing items. Complex lists should preferably be written in YAML.
+
+`ConfigPath` is not an arbitrary string traverser, but a path compiled from the public schema:
+
+- Supports name-keyed stages;
+- Validates whether a field is public/configurable;
+- Returns the target Pydantic type;
+- Prohibits access to `factory_args`, derived plans, and private fields;
+- Lists nearby valid paths in errors.
+
+## 7.2 `ConfigPatchSet`
+
+Adapters output an ordered patch set. Layers are fixed as:
+
+| Layer | Source |
+|---|---|
+| 0 | framework/schema defaults |
+| 10 | model Python defaults |
+| 20 | selected profile/variant |
+| 30 | user YAML |
+| 40 | Router structured worker patch |
+| 50 | worker CLI `--set` or migration-period alias |
+
+Layers resolve only cross-source precedence, not ambiguity within a layer:
+
+- The same path appears repeatedly in one document/CLI: error;
+- Multiple sources in the same layer write the same path: error, requiring the caller to define an explicit order or merge the documents;
+- A higher layer overrides a lower layer: allowed and recorded in provenance;
+- A deprecated path and canonical path both target the same leaf: error;
+- Parent subtree and child leaf assignments overlap in the same layer: error;
+- Across layers, apply the lower layer first: a higher-layer child can override the corresponding leaf of a lower-layer parent, while a higher-layer parent replaces the lower-layer subtree as a whole;
+- A list is always treated as a leaf and is not merged by index.
+
+The YAML parser must enable duplicate-key rejection and retain file, line, and column information for every mapping/scalar. Duplicate YAML keys, paths that duplicate after normalization, and alias/canonical duplicates must be reported while generating the `ConfigPatchSet`; they must not first be read into an ordinary dict where a later value silently overwrites an earlier one.
+
+## 7.3 `ConfigResolver`
+
+The resolver order is fixed:
+
+1. Collect adapter patches;
+2. Normalize V1 paths/aliases into canonical paths;
+3. Perform duplicate and subtree overlap checks with layers taken into account;
+4. Parse values according to the target schema;
+5. Apply them to an immutable base tree by layer;
+6. Construct the complete `ResolvedPipelineConfig`;
+7. Perform cross-field and model capability validation;
+8. Freeze the configuration and output the provenance map.
+
+The resolver does not perform GPU topology probes, import stage factories, or construct `ServerArgs`. These belong to subsequent planners/workers, which can only read already-resolved typed fields.
+
+## 7.4 `ResolvedPipelineConfig`
+
+The resolved config is separate from the user document:
+
+| Object | Content | User-settable |
+|---|---|---|
+| `PipelineConfigDocumentV2` | partial/full public document | Yes |
+| `ResolvedPipelineConfig` | Complete typed config after applying all defaults and patches | Generated through the resolver |
+| `StagePlacementPlan` | Actual GPU placement and memory accounting | No |
+| `ProcessTopologyPlan` | OS process membership and TP ranks | No |
+| `DerivedRuntimePlan` | Effective runtime values determinable by main-process topology/hardware probes | No |
+| `StageWorkerProcessSpec` | spawn payload, endpoints, queues, factory defaults | No |
+| `WorkerRuntimeDerivation` | Effective values and provenance determinable only during worker initialization | No |
+| `ServerArgs` / `ModelConfig` | SGLang runtime objects inside the worker | No |
+
+`ResolvedPipelineConfig` uses a frozen model, and runtime planners may not modify it in reverse. The resolver freezes only user intent, such as `custom_all_reduce: auto|on|off`, and may not depend on GPU topology or hardware probes.
+
+All topology-dependent effective values determinable in the main process are written by runtime planners into a complete `DerivedRuntimePlan`, with topology/hardware sources recorded; the worker spec carries the slice of the plan needed by the current worker, and the worker builder may only consume it, not supplement or modify that plan in reverse.
+
+Values determinable only after model loading or worker initialization enter a separate `WorkerRuntimeDerivation`, such as compatibility adjustments that depend on the actually loaded backend. It records provenance through worker startup diagnostics and `ServerArgs.override()` with a source, and does not write back into `DerivedRuntimePlan` or `ResolvedPipelineConfig`.
+
+`config explain` explains user configuration and input provenance. Runtime-planner diagnostics display `DerivedRuntimePlan`, while worker startup diagnostics display `WorkerRuntimeDerivation`; together they explain the final effective value.
+
+## 7.5 Canonical Runtime Namespace
+
+Public runtime parameters enter typed namespaces:
+
+```text
+pipeline.stages.<stage>.runtime.max_seq_len
+pipeline.stages.<stage>.runtime.video_fps
+pipeline.stages.<stage>.runtime.sglang.mem_fraction_static
+pipeline.stages.<stage>.runtime.sglang.max_running_requests
+pipeline.stages.<stage>.runtime.sglang.max_total_tokens
+pipeline.stages.<stage>.runtime.sglang.cuda_graph.*
+pipeline.stages.<stage>.runtime.compile.*
+pipeline.stages.<stage>.runtime.decode.*
+pipeline.stages.<stage>.runtime.prefill_coalesce.*
+```
+
+The following fields are no longer part of the public user interface:
+
+```text
+factory_args.server_args_overrides
+runtime_overrides
+runtime_arg_map
+gpu_id
+process_total_gpu_memory_fraction
+nccl_port
+endpoints
+```
+
+Model-specific parameters that have not yet entered the public schema are placed under:
+
+```yaml
+pipeline:
+  stages:
+    talker_ar:
+      extensions:
+        qwen3_omni:
+          partial_start: true
+```
+
+An extension model must still register a Pydantic schema through the model package; a bare `dict[str, Any]` may not override public fields. Mature cross-model features are later promoted from extensions into the public runtime namespace.
+
+## 7.6 Relationship Between Roles and Stages
+
+Existing CLI maintains separate thinker, talker, generation, and memory role maps through multiple class methods. V2 declares them uniformly in model config:
+
+```yaml
+pipeline:
+  roles:
+    thinker: thinker
+    talker: talker_ar
+    generation: talker_ar
+    code2wav: code2wav
+```
+
+Roles are used only for:
+
+- Migrating old typed CLI aliases;
+- Model capability validation;
+- Generating user-facing shortcuts/help.
+
+Canonical storage always uses a concrete stage path. The resolver resolves roles when producing patches rather than repeatedly resolving them in runtime helpers.
+
+## 7.7 The Single Process for Developers to Add Configuration
+
+Developers first determine field ownership:
+
+| New configuration type | Where it should be added | Where it should not be added |
+|---|---|---|
+| Pipeline/runtime field shared by multiple models | public typed schema | handwritten CLI helper, bare `factory_args` |
+| Field specific to one model | model-registered extension schema | global `serve()` signature |
+| HTTP server/process field | `ServerLaunchConfig` | `PipelineConfig` |
+| Topology/hardware-derived value | `DerivedRuntimePlan` | user YAML/CLI |
+| Value determinable only after worker initialization | `WorkerRuntimeDerivation` | resolver or Pipeline mutation |
+| Request-time field | request protocol/schema | startup-time configuration |
+
+The standard steps for adding a public typed field are fixed:
+
+1. Define the path, type, default, description, and capability constraint in the canonical schema;
+2. Consume the typed field in the resolved config → runtime consumer adapter;
+3. Automatically generate JSON Schema, CLI path help, and YAML/CLI equivalence tests from schema metadata;
+4. If compatibility with an old entry point is needed, add only a time-limited old path → canonical path mapping in `compat.py` and declare its removal Phase;
+5. Do not add a parameter-specific mutation helper to `serve.py`.
+
+Code review can use these rules to reject any new public configuration entry point that bypasses the canonical schema.
+
+# 8. Responsibility Boundary Between YAML and CLI
+
+The new interface establishes the following rules:
+
+| Configuration category | YAML | CLI | Reason |
+|---|---|---|---|
+| Model, stage topology | canonical source | Select only through `--config`/`--model-path` | Structurally complex and must be persisted |
+| GPU/TP/process placement | canonical source | Can be temporarily overridden with `--set` | Belongs to the Pipeline and requires unified validation |
+| SGLang/runtime parameters | canonical source | Can be temporarily overridden with `--set` | Same path, same type, same validation |
+| HTTP bind/log/API policy | Not included in Pipeline YAML | Dedicated CLI | Belongs to the service process, not the model Pipeline |
+| runtime-derived endpoint/port/gpu id | Not settable | Not settable | Owned by planner/runner |
+| Router worker pool | Router YAML | Router CLI only selects source/routing parameters | Layered separately from the worker Pipeline |
+
+CLI and YAML therefore still have two syntaxes, but only one set of Pipeline semantics:
+
+```text
+YAML leaf
+→ ConfigPatch(path, value, file source)
+
+CLI --set
+→ ConfigPatch(path, value, cli source)
+```
+
+# 9. Router Interface Refactoring
+
+## 9.1 Structured Worker Config
+
+Launcher YAML removes the free-form string `worker_extra_args` and changes to:
+
+```yaml
+schema_version: 2
+
+launcher:
+  backend: local
+  num_workers: 2
+  num_gpus_per_worker: 1
+  worker_host: 127.0.0.1
+  worker_base_port: 8011
+  wait_timeout: 600
+
+  worker:
+    config: examples/configs/qwen3_omni_colocated_h20_v2.yaml
+    service:
+      model_name: qwen3-omni
+    patches:
+      pipeline.stages.thinker.runtime.sglang.max_running_requests: 32
+```
+
+Exactly one of `worker.config` and `worker.model` is selected, corresponding to the worker `--config` and `--model-path` modes. `worker.patches` has paths/values validated by the Router schema and is passed as structured patches.
+
+## 9.2 Worker Transport
+
+The initial structured Router implementation may continue generating argv, but only as a machine interface:
+
+```text
+sgl-omni serve
+  --config ...
+  --config-patch-file /tmp/.../worker-0-patches.json
+```
+
+The patch file contains a serialized `ConfigPatchSet`, not a shell fragment. After validating the source and schema version, the worker passes it to the same resolver.
+
+If Router and workers later switch to a Python API or supervisor protocol, they still reuse `ConfigPatchSet` without changing configuration semantics. GPU visibility continues to be managed by Router through the subprocess environment because it is a process resource boundary, not a Pipeline patch.
+
+Router and workers use the same version of the schema registry and `ConfigResolver`. Before creating a subprocess, Router performs a complete dry-run resolve of `worker.config/model + worker.patches`:
+
+- Relative configuration paths are resolved relative to the directory containing the launcher YAML;
+- Router must be able to load the model config and extension schemas required by the worker;
+- If a path, type, role, or extension cannot be resolved, fail before starting any worker;
+- After receiving the patch file, the worker validates the schema version and content again, but may not use different merge rules.
+
+GPU uses two explicit coordinate systems:
+
+- Router has exclusive authority over physical GPU allocation and establishes each worker's visible device set through `CUDA_VISIBLE_DEVICES`;
+- Pipeline `placement.gpus` always uses worker-local logical GPU IDs, namely `0..N-1` after visible devices are renumbered.
+
+Router dry-run must validate that every logical GPU ID is within `[0, num_gpus_per_worker)` and that TP size, GPU list, and worker allocation are consistent. Pipeline may not directly reference host physical GPU IDs.
+
+## 9.3 Precedence Between Router and Worker
+
+The layers for managed workers are fixed:
+
+```text
+model defaults < worker Pipeline YAML < Router worker.patches < worker CLI emergency patch
+```
+
+`worker CLI emergency patch` is disallowed by default and enabled explicitly only in debug mode. Production configuration is determined entirely by Router YAML, preventing values generated by the supervisor from competing again with manually supplied argv.
+
+# 10. Configuration Conflicts and Error Model
+
+## 10.1 Conflict Categories
+
+| Conflict type | Example | V2 behavior |
+|---|---|---|
+| Duplicate in the same source | Two `--set` options write the same path | Error before startup |
+| alias/canonical duplicate | typed CLI and `--set` write the same path | Error before startup |
+| typed/extension overlap | An extension attempts to set a public SGLang field | Schema registration fails |
+| parent/child overlap | Two patch sources in the same layer set `runtime.sglang` and one of its children | Error in the same layer; allowed and recorded across layers |
+| Ownership violation | User sets `gpu_id` or endpoint | Path is not public; parsing fails |
+| Unsupported capability | A non-SGLang stage sets `runtime.sglang` | Model validation fails |
+| Cross-field inconsistency | TP=2 but only one GPU exists | Resolved model validation fails |
+| deprecated/canonical duplicate | V1 `runtime_overrides` and a V2 field | Migration error; do not guess precedence |
+
+## 10.2 Atomicity
+
+The resolver applies all patches to an immutable in-memory tree. If any path, type, conflict, or validation fails, it returns no partial config and does not enter the runtime planner.
+
+Errors must include:
+
+- canonical path;
+- source location;
+- previous value and its source;
+- conflict rule;
+- actionable remediation.
+
+For example:
+
+```text
+duplicate configuration for
+pipeline.stages.thinker.runtime.sglang.mem_fraction_static
+
+file:qwen.yaml:42 = 0.70
+cli:--thinker-mem-fraction-static = 0.65
+
+The CLI alias and canonical field target the same setting.
+Remove one source or use `config explain` to inspect precedence.
+```
+
+# 11. Configuration Compilation and Runtime Boundary
+
+The V2 compilation chain is:
+
+```text
+① Parse input documents
+→ ② Normalize patches
+→ ③ Resolve + validate + freeze
+→ ④ Build placement/process plans
+→ ⑤ Build derived runtime plan
+→ ⑥ Build worker specs
+→ ⑦ Construct worker runtime objects
+```
+
+Read it strictly as **① → ② → ③ → ④ → ⑤ → ⑥ → ⑦**:
+
+- After ②, all inputs use canonical paths;
+- ③ is the last step that modifies user configuration;
+- ④ only generates derived plans and does not write back to the Pipeline;
+- ⑤ stores effective runtime values determinable by main-process topology/hardware probes;
+- ⑥ only assembles cross-process DTOs;
+- ⑦ is when factories are imported and `ServerArgs` and `ModelConfig` are constructed; adjustments determinable only at this stage are recorded in `WorkerRuntimeDerivation`.
+
+The current `_apply_tensor_parallel_server_args_overrides()` modifies stage server args based on a topology probe. V2 splits this into:
+
+1. User configuration expresses `custom_all_reduce: auto|on|off`;
+2. The placement planner produces topology capabilities;
+3. The main-process runtime planner produces `DerivedRuntimePlan` from both;
+4. The worker builder only consumes the effective `ServerArgs` value in the plan;
+5. It does not modify the frozen Pipeline or repeat the same topology decision in the worker.
+
+Other topology-dependent parameters follow the same pattern.
+
+# 12. Scope of Changes
+
+## 12.1 Configuration Schema and Resolver
+
+| Module | Change |
+|---|---|
+| `sglang_omni/config/schema.py` | Add V2 public schema, name-keyed stages, typed runtime namespaces, frozen resolved model |
+| `sglang_omni/config/patch.py` (new) | `ConfigPath`, `ConfigSource`, `ConfigPatch`, duplicate/overlap checks |
+| `sglang_omni/config/resolver.py` (new) | layer merge, type conversion, provenance, full validation |
+| `sglang_omni/config/compat.py` (new) | Time-limited adapter from V1 YAML/dotted/typed CLI to V2 patches |
+| `sglang_omni/models/registry.py` | Register V2 model defaults, roles, and extension schemas |
+
+The file-loading responsibility of `ConfigManager` is moved into the adapter/resolver. The old class remains as a facade during migration, and its custom dotted merge is ultimately removed.
+
+## 12.2 CLI
+
+| Module | Change |
+|---|---|
+| `sglang_omni/cli/serve.py` | After parsing parameters, construct only `ServerLaunchConfig` and patches; remove business mutation helpers |
+| `sglang_omni/cli/config.py` | Add schema/validate/resolve/explain/migrate |
+| `sglang_omni/cli/__init__.py` | Disable unknown options; all open-ended overrides use explicit `--set` |
+
+During migration, typed CLI aliases may continue to appear in the `serve()` signature, but the alias registry automatically generates their patch implementation.
+
+## 12.3 Runtime
+
+| Module | Change |
+|---|---|
+| `sglang_omni/config/runtime.py` | Only convert typed resolved runtime into factory kwargs; no longer resolve conflicts between user sources |
+| `sglang_omni/pipeline/runtime_config.py` | Read only frozen resolved config and output placement/process and `DerivedRuntimePlan` |
+| `sglang_omni/pipeline/mp_runner.py` | Construct specs from resolved config/plans; do not receive compatibility fields |
+| `sglang_omni/scheduling/sglang_backend/server_args_builder.py` | Construct `ServerArgs` from typed SGLang config, retaining explicit derived runtime overrides |
+
+Model factories may temporarily continue receiving `server_args_overrides`, but this dict can only be generated internally by the typed runtime adapter and is no longer a public YAML/CLI entry point.
+
+## 12.4 Router
+
+| Module | Change |
+|---|---|
+| `sglang_omni_router/launcher/config.py` | `worker.config/model/service/patches` schema |
+| `sglang_omni_router/launcher/local.py` | Generate patch files instead of concatenating `worker_extra_args` |
+| `sglang_omni_router/serve.py` | Worker source validation and structured launcher integration |
+
+# 13. Phased Compatibility Plan
+
+V2 uses a phased migration. It does not require all configuration to be modified in one release, but every deprecated entry point has a removal phase.
+
+## 13.1 Phase 0: Establish the Resolver Without Changing Default Behavior
+
+- Introduce `ConfigPatch`, provenance, and `config resolve/explain`;
+- Current model defaults, V1 YAML, dotted CLI, and typed CLI all produce patches through compatibility adapters;
+- Use golden tests to lock down final resolved values and success/failure behavior;
+- Runtime continues consuming the existing `PipelineConfig` shape;
+- Duplicate V1 sources newly discovered by the resolver initially record diagnostics without changing current success/failure outcomes;
+- V2 inputs in internal tests follow strict duplicate/overlap rules from the beginning.
+
+The goal of this phase is to first obtain a single merge engine, not immediately change user syntax or validation behavior. Starting in Phase 1, V2 inputs fail strictly while V1 inputs warn about newly discovered duplicate sources; starting in Phase 2, semantically duplicate V1 inputs also fail.
+
+## 13.2 Phase 1: V2 Opt-In
+
+- Support `schema_version: 2`;
+- New documentation and exports display V2 by default, with a flag to retain V1 export;
+- Router supports structured worker configuration while remaining compatible with `worker_extra_args`;
+- Typed CLI aliases print the equivalent canonical `--set`;
+- Telemetry/logging counts deprecated-path usage without uploading actual configuration values.
+
+V2 documents may not contain V1 `stage_overrides`, `runtime_overrides`, or public `factory_args.server_args_overrides`.
+V1 inputs retain their current final-value semantics, but newly discovered duplicate sources produce warnings.
+
+## 13.3 Phase 2: V2 by Default
+
+- `config export`, official examples, cookbooks, and Router examples all switch to V2;
+- YAML without `schema_version` is treated as V1 and produces a warning;
+- Unknown dotted options are disabled, requiring explicit `--set`;
+- Runtime typed CLI aliases produce deprecation warnings;
+- Semantically duplicate V1 deprecated/canonical inputs become startup errors;
+- `worker_extra_args` produces a warning, and `config migrate` automatically converts recognizable parameters.
+
+## 13.4 Phase 3: Remove Old Entry Points
+
+At the next explicitly announced major/minor compatibility boundary:
+
+- Remove `stage_overrides`;
+- Remove public `runtime_overrides`;
+- Prohibit YAML from setting public `factory_args.server_args_overrides`;
+- Remove dynamic unknown-option dotted CLI;
+- Remove dedicated runtime typed CLI aliases;
+- Remove Router `worker_extra_args`;
+- Remove V1 path traversal from `ConfigManager.merge_config()`.
+
+When reading V1 YAML, provide a clear error and an offline migration command rather than continuing implicit compatibility in the server.
+
+## 13.5 Compatibility Behavior Table
+
+| Current interface | Phase 0 | Phase 1 | Phase 2 | Phase 3 |
+|---|---|---|---|---|
+| V1 Pipeline YAML | Supported | Supported + migratable | warning | Rejected |
+| `stage_overrides` | Supported | warning | warning | Rejected |
+| `runtime_overrides` | Supported | warning | warning | Rejected |
+| dotted unknown CLI | Supported | warning | Reject with `--set` guidance | Removed |
+| runtime typed CLI | Supported | warning | warning | Removed |
+| V2 YAML | Internal tests | opt-in | Default | Only format |
+| Router `worker_extra_args` | Supported | warning | warning | Rejected |
+| structured Router worker | Internal tests | opt-in | Default | Only format |
+
+# 14. Validation and Testing
+
+Validation is divided into resolver and runtime planning layers. The former proves that "the user declaration is unique and correctly typed," while the latter proves that "the resolved topology is executable."
+
+## 14.1 Resolver Unit Tests
+
+| Test category | Checks |
+|---|---|
+| path | Valid field, unknown field, private/derived field, stage name |
+| type | scalar, null, list, dict, enum, invalid coercion |
+| document structure | duplicate YAML key, full/partial mode, stage declaration, `stage_order` completeness |
+| precedence | defaults, profile, YAML, Router patch, CLI |
+| duplicates | same source, same layer, alias/canonical, parent/child |
+| cross-layer subtree | higher-layer child overrides lower-layer parent, higher-layer parent replaces lower-layer subtree, whole-list replacement |
+| provenance | previous value, source, location, and deprecated marker for each override |
+| atomicity | No partial resolved config is produced if any patch fails |
+| frozen config | Assignment is prohibited after the resolver returns |
+| role | Unique role-to-stage resolution, unknown/unsupported role |
+| extension | Registered schema, unknown key, prohibition on overriding public namespace |
+
+## 14.2 CLI/YAML Equivalence
+
+Create parameterized tests for every public typed field:
+
+```text
+YAML canonical leaf
+==
+CLI --set canonical path
+==
+migration-period typed CLI alias
+```
+
+All three inputs must produce the same `ResolvedPipelineConfig`, differing only in provenance. The parameter table is generated automatically from schema metadata to avoid handwritten tests omitting new fields.
+
+## 14.3 V1 Migration Golden Tests
+
+Select official examples:
+
+- Qwen3-Omni text/speech/colocated;
+- Qwen3-TTS;
+- Higgs, MOSS, FishAudio;
+- Single-stage ASR;
+- Ming full-stages YAML;
+- TP and process isolation configurations.
+
+Run the V1 adapter and migrated V2 document separately, comparing:
+
+- Stage topology and order;
+- placement/TP/process;
+- typed runtime;
+- Final factory kwargs;
+- placement/process plans;
+- worker specs;
+- User-controllable `ServerArgs` fields.
+
+Use structural comparison for runtime-derived endpoints and temporary ports rather than comparing random values.
+
+## 14.4 Conflict Regression
+
+The following must be covered:
+
+- typed `mem_fraction_static` and old `server_args_overrides`;
+- global and per-role CLI;
+- `--encoder-mem-reserve` and explicit fraction;
+- `tp_size` and GPU list;
+- generation role and thinker role targeting the same/different stages;
+- deprecated path and canonical path;
+- Router patch and worker CLI;
+- extension and public namespace.
+
+Every conflict assertion checks that the canonical path and both sources appear in the error.
+
+## 14.5 Runtime Boundary
+
+Verify:
+
+- The runtime planner does not modify frozen config;
+- Topology-dependent effective values enter only `DerivedRuntimePlan`;
+- The worker builder only consumes `DerivedRuntimePlan` and cannot supplement or repeat decisions;
+- Worker-only effective values enter only `WorkerRuntimeDerivation` and retain their sources;
+- Child processes do not resolve user configuration again;
+- Factory signature injection supplies only missing derived defaults;
+- Users cannot set `gpu_id`, cumulative process budget, NCCL port, or endpoint;
+- TP environment mapping matches current behavior;
+- Worker specs for the no-config/default model path match golden files;
+- `ServerArgs.override()` continues recording the source of worker-internal derived mutations.
+
+## 14.6 Router
+
+Verify:
+
+- Worker commands generated from structured configuration contain no shell-like extra args;
+- Patch files are independent per worker and use the correct schema version;
+- model/config are mutually exclusive;
+- Router uses the same registry/resolver version and completes a dry-run before starting subprocesses;
+- Launcher-relative config paths and model extension schemas resolve correctly;
+- Router YAML path/type/role/extension failures occur before starting subprocesses;
+- GPUs continue to be passed through the environment;
+- Physical GPU assignment is correctly converted to worker-local logical GPU IDs;
+- Out-of-range logical GPUs and inconsistencies between TP and worker allocation fail before startup;
+- V1 `worker_extra_args` migration recognizes `--config`, typed aliases, and `--set`;
+- Arbitrary shell tokens that cannot be migrated safely fail explicitly and are not silently discarded.
+
+## 14.7 Phase Admission Criteria
+
+Every migration Phase must have compatibility matrix tests asserting, for each old entry point:
+
+- success, warning, or error;
+- Final resolved value;
+- provenance/diagnostic;
+- Recommended migration command.
+
+Before entering the next Phase, all of the following must be satisfied:
+
+1. All official Pipeline and Router examples pass migration golden tests;
+2. Structured Router has completed at least one multi-worker E2E;
+3. Runtime no longer directly reads public compatibility fields;
+4. The warning/error matrix for the current Phase is fixed in CI;
+5. Usage of deprecated entry points has reached the migration threshold announced in advance by the project;
+6. Release notes specify the target version and removals for the next Phase.
+
+# 15. Release and Documentation
+
+When releasing V2, provide all of the following:
+
+1. V1 → V2 migration guide;
+2. CLI/YAML responsibility table;
+3. Canonical path reference and generated JSON Schema;
+4. Debugging examples for `config resolve/explain`;
+5. Removal versions for deprecated entry points;
+6. V1/V2 diffs for official examples;
+7. Router structured worker example.
+
+CLI `--help` no longer lists all model runtime fields; it only describes `--set` and points to:
+
+```bash
+sgl-omni config schema
+sgl-omni config resolve
+```
+
+Model-specific fields are displayed dynamically by the selected model config/extension schema rather than fixing every model option into one global `serve()` signature.
+
+# 16. Expected Result
+
+The stable relationship after refactoring is:
+
+```text
+YAML / CLI / Router
+        ↓
+The same ConfigPatch type
+        ↓
+The single ConfigResolver
+        ↓
+Frozen ResolvedPipelineConfig
+        ↓
+Read-only runtime planners
+```
+
+YAML and CLI retain different use cases:
+
+- YAML stores a complete, reviewable, reproducible Pipeline;
+- CLI selects configuration, sets service process parameters, and uses `--set` for temporary Pipeline patches;
+- Router YAML structurally references worker config and patches.
+
+They no longer define runtime parameter types, defaults, precedence, and mutation logic separately. When adding a shared configuration field, it only needs to be defined once in the canonical schema; CLI, JSON Schema, documentation, patch types, and equivalence tests are all generated from that definition.

--- a/docs/design/configuration_interface_refactor_proposal_en.md
+++ b/docs/design/configuration_interface_refactor_proposal_en.md
@@ -91,7 +91,7 @@ The remainder of this document uses three technical names for the simple flow ab
 
 These three names are not three new interfaces, but three stages in the same configuration processing pipeline.
 
-This document discusses only startup-time configuration. It does not change the request protocol, Stage payloads, scheduling algorithms, or field definitions in SGLang's internal `ServerArgs`. The code revision checked for the "current implementation" in this document is `42a124cd`; see `docs/developer_reference/configuration.md` for the complete current state.
+This document discusses only startup-time configuration. It does not change the request protocol, Stage payloads, scheduling algorithms, or field definitions in SGLang's internal `ServerArgs`. The code revision checked for the "current implementation" in this document is `2b45073c`; see `docs/developer_reference/configuration.md` for the complete current state.
 
 Tracking issue: [#1466](https://github.com/sgl-project/sglang-omni/issues/1466)
 
@@ -111,7 +111,7 @@ This document does not require all model configuration to be rewritten at once. 
 
 ## 2.1 Configuration Sources
 
-The current public configuration sources can be divided into six categories:
+The current public configuration sources can be divided into seven categories:
 
 | Source | Current entry point | Main implementation |
 |---|---|---|
@@ -120,9 +120,12 @@ The current public configuration sources can be divided into six categories:
 | Compact YAML overrides | `stage_overrides`, `runtime_overrides` | `config/manager.py`, `config/runtime.py` |
 | Dynamic CLI | `--stages.thinker... VALUE` | `ConfigManager.parse_extra_args()` |
 | Dedicated CLI | `--mem-fraction-static`, etc. | `apply_*_cli_overrides()` in `cli/serve.py` |
+| Configured environment defaults | Pipeline `env_defaults`, per-stage `StageConfig.env` | `config/schema.py`, `pipeline/mp_runner.py`, `pipeline/stage_workers.py` |
 | Router launcher | `--launcher-config`, `worker_extra_args` | `sglang_omni_router/launcher/*` |
 
 `sgl-omni serve` enables `ignore_unknown_options` for unknown options, so Typer first parses 41 dedicated parameters, after which the remaining tokens are parsed by `ConfigManager` as dotted overrides. The two types of CLI options are applied at different stages.
+
+Configured environment values have a narrower contract than the configuration layers below. Pipeline `env_defaults` are canonical configured defaults; `StageConfig.env` overlays them for that stage. At spawn, these defaults fill only variables absent from the inherited process environment and therefore never override `os.environ`. The resulting `ResolvedProcessEnv` is a derived process artifact that combines the inherited environment, configured defaults, and runner-owned additions such as rank/device variables; it is not another user precedence layer. Direct `os.environ` reads in libraries or runtime code remain external inputs and must be surfaced by environment diagnostics where relevant, not collected into one generic configuration layer.
 
 ## 2.2 Current Merge Order
 
@@ -135,7 +138,8 @@ The current main process constructs the final `PipelineConfig` in the following 
 5. `serve.py` runs the memory, TP/GPU, process, CUDA graph, compile, decode, prefill, and generation batch helpers in sequence;
 6. `launch_server()` passes HTTP/API parameters separately from `PipelineConfig`;
 7. Runtime preparation constructs placement, process topology, endpoints, and worker specs;
-8. Worker subprocesses merge factory args, then construct `ServerArgs` and `ModelConfig` inside the factory.
+8. Before spawn, the parent resolves signature-independent factory arguments (`factory_args`, `runtime_overrides`, and typed runtime mappings) into the worker spec;
+9. In the child, the worker imports the factory, injects only missing defaults whose applicability depends on its signature, and then the factory constructs `ServerArgs` and `ModelConfig`.
 
 | Order | Processing stage | Input and output |
 |---|---|---|
@@ -143,25 +147,26 @@ The current main process constructs the final `PipelineConfig` in the following 
 | 2 | Apply compact YAML overrides | `stage_overrides` → typed runtime |
 | 3 | Apply dynamic CLI | dotted CLI → rebuilt `PipelineConfig` |
 | 4 | Apply dedicated CLI | typed CLI helpers → in-place modification of `PipelineConfig` |
-| 5 | Runtime planning | `PipelineConfig` → placement, process topology, worker spec |
-| 6 | Worker construction | worker spec → stage factory → `ServerArgs` |
+| 5 | Runtime planning | `PipelineConfig` → placement, process topology, parent-resolved static factory args and worker spec |
+| 6 | Worker construction | worker spec → import factory → inject missing signature-dependent defaults → `ServerArgs` |
 
 This order appears to provide precedence, but precedence is not a single unified rule. Different helpers choose to "override," "reject," "synchronize two aliases," "write both `factory_args` and `runtime_overrides`," or "wait until the worker to report a conflict."
 
 ## 2.3 Current Factory Parameter Path
 
-Stage factory kwargs are combined from the following sources:
+Stage factory kwargs are combined across an explicit parent/child boundary:
 
 ```text
 factory_args
 < runtime_overrides
 < typed runtime mapping
-+ signature-dependent defaults
+→ parent-resolved static factory args in worker spec
++ child-injected missing signature-dependent defaults
 ```
 
 Here, `server_args_overrides` performs an additional dict merge between `factory_args` and `runtime_overrides`; typed `runtime.max_seq_len` and `runtime.video_fps` are renamed through `runtime_arg_map`; typed `mem_fraction_static` is ultimately written back to `server_args_overrides`.
 
-`model_path`, `gpu_id`, and `total_gpu_memory_fraction` are not ordinary user factory args. After importing the factory, the worker injects them as needed based on the function signature. `gpu_id`, the cumulative process budget, NCCL port, and IPC endpoints are derived by the planner/runner.
+The parent performs all merges that do not require inspecting the factory signature before spawn. `model_path`, `gpu_id`, and `total_gpu_memory_fraction` are not ordinary user factory args: the parent computes their candidate values, and after importing the factory the child injects a candidate only when the signature declares that parameter and the resolved static args did not already contain it. `gpu_id`, the cumulative process budget, NCCL port, and concrete IPC/socket endpoints are derived by the planner/runner.
 
 # 3. Problems with the Current Design
 
@@ -347,8 +352,8 @@ All subsequent data structures, migration steps, and tests must serve these thre
 1. **One semantic, one canonical path**: The same runtime feature must not expose both typed and untyped public paths.
 2. **Input adapters contain no business logic**: YAML, CLI, and Router only produce typed assignments/patches.
 3. **Resolve once, validate fully once**: Configuration is frozen after entering the runtime planner.
-4. **Separate user configuration from derived plans**: GPU logical placement can be configured; runtime values such as `gpu_id`, endpoint, and NCCL port cannot.
-5. **Explicit overrides with retained sources**: Cross-layer overrides are allowed but must be explainable; duplicate definitions within the same layer fail immediately.
+4. **Separate user configuration from derived plans**: GPU logical placement and the endpoint allocation root `endpoints.base_path` can be configured; runtime values such as `gpu_id`, a concrete socket endpoint, and NCCL port cannot.
+5. **Explicit overrides with retained sources**: Cross-layer overrides are allowed but must be explainable; equal-specificity duplicate definitions within the same layer fail immediately.
 6. **The compatibility layer has an explicit removal point**: Old interfaces may be adapted, but cannot permanently become a second canonical schema.
 
 ## 4.3 Non-Goals
@@ -412,11 +417,13 @@ pipeline:
 
   stages:
     preprocessing:
+      kind: python
       factory: example.create_preprocessing
       process: pipeline
       next: thinker
 
     thinker:
+      kind: sglang
       factory: example.create_thinker
       process: pipeline
       next: decode
@@ -427,6 +434,7 @@ pipeline:
           max_running_requests: 32
 
     decode:
+      kind: python
       factory: example.create_decode
       process: pipeline
       terminal: true
@@ -533,7 +541,37 @@ sgl-omni serve \
   --set pipeline.stages.thinker.placement.tp=2
 ```
 
-The value is parsed as a YAML scalar/flow value, so booleans, nulls, numbers, lists, and mappings share the same type rules. The path must exist in the public schema; runtime-derived or deprecated internal paths cannot be written.
+The value is parsed as a YAML scalar/flow value, so booleans, nulls, numbers, and atomic list values share the same type rules. `--set` targets configurable leaves only; a list is one leaf and cannot be patched by index. Generic `--set` cannot replace a mapping/subtree; subtree replacement is available only in a `full` YAML document. The path must exist in the public schema; runtime-derived or deprecated internal paths cannot be written.
+
+General stage arguments also support selector-based broadcast patches:
+
+```yaml
+pipeline:
+  stage_defaults:
+    - select:
+        capability: sglang
+      runtime:
+        sglang:
+          max_running_requests: 32
+    - select:
+        roles: [thinker, generation]
+        exclude: [talker_ar]
+      placement:
+        tp: 2
+```
+
+Selectors may use `capability`, `roles`, `stages`, and `exclude`; all supplied positive selectors must match, and `exclude` removes matches. The resolver expands each broadcast into concrete stage-leaf patches before duplicate checking and validation. Resolved storage remains only at `pipeline.stages.<stage>...`; no broadcast object survives in `ResolvedPipelineConfig`. Within one source, specificity is `capability broadcast < role/group selector < concrete stage`. Across different sources, the source layer always dominates specificity. Equal-specificity assignments to the same expanded leaf are errors.
+
+The CLI equivalent is:
+
+```bash
+sgl-omni serve \
+  --config qwen.yaml \
+  --set-for capability=sglang runtime.sglang.max_running_requests=32 \
+  --set pipeline.stages.thinker.runtime.sglang.max_running_requests=48
+```
+
+Here the concrete CLI assignment overrides the capability broadcast in the same CLI source. `config explain` shows every selector expansion and shadowed value; full export emits the expanded stage-local values, not selectors.
 
 ## 6.3 Final Role of Dedicated CLI Options
 
@@ -546,7 +584,7 @@ CliAlias(
 )
 ```
 
-Parsing produces an ordinary `ConfigPatch`. If the same startup command uses both an alias and `--set` to write the same path, it immediately reports a duplicate assignment.
+Parsing produces ordinary patches. Migration aliases have explicit specificity within the CLI source: broadcast/global alias < role alias < explicit concrete `--set`. A role alias overriding a broadcast alias is compatibility-preserving, not a duplicate; the shadowed broadcast value remains in provenance. Two assignments of the same specificity to the same canonical leaf remain errors. Source-layer precedence still dominates this rule.
 
 After V2 stabilizes, dedicated runtime CLI options are removed in batches, leaving only `--set` and service process parameters. This prevents the final interface from permanently maintaining two definitions—"YAML field + dedicated CLI field." If the project decides to retain a very small number of frequently used aliases, their help, types, and patches must be generated automatically from schema metadata; they may not have independent business logic.
 
@@ -559,6 +597,7 @@ sgl-omni config schema
 sgl-omni config validate --config FILE
 sgl-omni config resolve --config FILE [--set ...]
 sgl-omni config explain --config FILE PATH [--set ...]
+sgl-omni config export --config FILE --format full
 sgl-omni config migrate --input v1.yaml --output v2.yaml
 ```
 
@@ -595,10 +634,18 @@ class ConfigSource(BaseModel):
     deprecated: bool = False
 
 
+class StageDeclaration(BaseModel):
+    name: str
+    kind: Literal["sglang", "python", "external"]
+    factory: str
+    extension_schema_id: str | None = None
+
+
 class ConfigPatch(BaseModel):
     op: Literal["set", "declare_stage"]
     path: ConfigPath
     value: object | None = None
+    declaration: StageDeclaration | None = None
     source: ConfigSource
     layer: int
 ```
@@ -606,7 +653,7 @@ class ConfigPatch(BaseModel):
 The initial patch protocol includes only `set` and `declare_stage`:
 
 - `set` sets a typed value; `null` is always an ordinary value used to clear an optional field that permits null;
-- `declare_stage` is produced only by the YAML adapter for `document_mode: full` and declares the stage name and stage type.
+- `declare_stage` is produced only by the YAML adapter for `document_mode: full` and carries a typed declaration payload. `name`, `kind`, and `factory` are required; `extension_schema_id` is present when the stage uses a model extension. `kind` selects the legal runtime namespace and capability rules, so a declaration cannot first create an untyped stage and attach backend fields later.
 
 A full document starts from an empty topology and can declare stages; a partial document and CLI `--set` can only modify existing stages and cannot create or delete stages. The names in `stage_order` must correspond one-to-one with the finally declared stages; none may be missing, duplicated, or reference an unknown stage. The initial patch protocol does not provide an operation for deleting inherited stages or mapping entries; use a full document to change stage membership.
 
@@ -635,15 +682,17 @@ Adapters output an ordered patch set. Layers are fixed as:
 
 Layers resolve only cross-source precedence, not ambiguity within a layer:
 
-- The same path appears repeatedly in one document/CLI: error;
-- Multiple sources in the same layer write the same path: error, requiring the caller to define an explicit order or merge the documents;
+- The same normalized path appears repeatedly at the same specificity in one document/CLI: error;
+- Multiple sources in the same layer and at the same specificity write the same path: error, requiring the caller to define an explicit order or merge the documents;
 - A higher layer overrides a lower layer: allowed and recorded in provenance;
-- A deprecated path and canonical path both target the same leaf: error;
+- Compatibility aliases in one CLI source follow broadcast < role < explicit concrete `--set`; a more-specific value shadows a less-specific value with provenance, while equal-specificity duplicates are errors;
+- Within one Router source, `worker_defaults` < a concrete per-worker entry; an entry may shadow a default with provenance, while duplicates within the same scope remain errors;
 - Parent subtree and child leaf assignments overlap in the same layer: error;
 - Across layers, apply the lower layer first: a higher-layer child can override the corresponding leaf of a lower-layer parent, while a higher-layer parent replaces the lower-layer subtree as a whole;
-- A list is always treated as a leaf and is not merged by index.
+- A list is always treated as a leaf and is not merged by index;
+- Generic `--set` can address only configurable leaves; mapping/subtree replacement requires full YAML.
 
-The YAML parser must enable duplicate-key rejection and retain file, line, and column information for every mapping/scalar. Duplicate YAML keys, paths that duplicate after normalization, and alias/canonical duplicates must be reported while generating the `ConfigPatchSet`; they must not first be read into an ordinary dict where a later value silently overwrites an earlier one.
+The YAML parser must enable duplicate-key rejection and retain file, line, and column information for every mapping/scalar. Duplicate YAML keys, paths that duplicate after normalization at equal specificity, and same-specificity alias/canonical duplicates must be reported while generating the `ConfigPatchSet`; they must not first be read into an ordinary dict where a later value silently overwrites an earlier one.
 
 ## 7.3 `ConfigResolver`
 
@@ -651,12 +700,13 @@ The resolver order is fixed:
 
 1. Collect adapter patches;
 2. Normalize V1 paths/aliases into canonical paths;
-3. Perform duplicate and subtree overlap checks with layers taken into account;
-4. Parse values according to the target schema;
-5. Apply them to an immutable base tree by layer;
-6. Construct the complete `ResolvedPipelineConfig`;
-7. Perform cross-field and model capability validation;
-8. Freeze the configuration and output the provenance map.
+3. Expand selector broadcasts into concrete stage-leaf patches and record expansion provenance;
+4. Perform specificity, duplicate, and subtree overlap checks with layers taken into account;
+5. Parse values according to the target schema;
+6. Apply them to an immutable base tree by layer;
+7. Construct the complete `ResolvedPipelineConfig`;
+8. Perform cross-field and model capability validation;
+9. Freeze the configuration and output the provenance map.
 
 The resolver does not perform GPU topology probes, import stage factories, or construct `ServerArgs`. These belong to subsequent planners/workers, which can only read already-resolved typed fields.
 
@@ -693,11 +743,17 @@ pipeline.stages.<stage>.runtime.video_fps
 pipeline.stages.<stage>.runtime.sglang.mem_fraction_static
 pipeline.stages.<stage>.runtime.sglang.max_running_requests
 pipeline.stages.<stage>.runtime.sglang.max_total_tokens
+pipeline.stages.<stage>.runtime.sglang.encoder_mem_reserve
 pipeline.stages.<stage>.runtime.sglang.cuda_graph.*
+pipeline.stages.<stage>.runtime.sglang.upstream_args.<field>
 pipeline.stages.<stage>.runtime.compile.*
 pipeline.stages.<stage>.runtime.decode.*
 pipeline.stages.<stage>.runtime.prefill_coalesce.*
+pipeline.env_defaults.<NAME>
+pipeline.stages.<stage>.env.<NAME>
 ```
+
+The two environment paths store configured defaults only. Stage values override Pipeline defaults during configured-default resolution, while the inherited process environment still wins when `ResolvedProcessEnv` is derived at spawn. They do not absorb arbitrary `os.environ` reads into configuration precedence.
 
 The following fields are no longer part of the public user interface:
 
@@ -708,8 +764,14 @@ runtime_arg_map
 gpu_id
 process_total_gpu_memory_fraction
 nccl_port
-endpoints
+concrete socket/IPC endpoints
 ```
+
+`pipeline.endpoints.base_path` remains a user-configurable allocation policy input. The planner derives concrete socket paths/endpoints beneath it; only those concrete derived values are forbidden as user input.
+
+`runtime.sglang.upstream_args` is a stage-local, validated escape hatch for SGLang fields not yet promoted into Omni's typed schema. Its schema is generated from the exact pinned upstream `ServerArgs` dataclass/schema and carries both the upstream version and a deterministic schema fingerprint. It rejects unknown fields and a maintained denylist of Omni-owned, derived, or unsafe fields (including device/process/port/endpoint ownership). A field already exposed as a typed Omni field is also rejected under `upstream_args`, preventing duplicate paths. Every accepted leaf retains provenance, and the fully assembled object still runs final upstream `ServerArgs` validation. Thus the escape hatch preserves **one semantic, one path** rather than creating an unvalidated second override dict. A stage whose `kind`/capabilities are not SGLang-backed rejects `runtime.sglang` entirely.
+
+`encoder_mem_reserve` is a canonical SGLang-stage policy field rather than a factory argument. It is valid only when the effective thinker `mem_fraction_static` remains `auto`/unset and has not been pinned through that typed canonical path by any user source, including YAML, Router, selector expansion, or an alias. Because `mem_fraction_static` is already an Omni typed field, it is forbidden under `upstream_args` in the first place. The resolver uses provenance—not merely the final numeric value—to enforce this constraint. Runtime derivation then subtracts the reserve from the automatic thinker budget and applies the existing safety floor; it does not mutate the frozen policy or silently override a pinned fraction.
 
 Model-specific parameters that have not yet entered the public schema are placed under:
 
@@ -723,6 +785,8 @@ pipeline:
 ```
 
 An extension model must still register a Pydantic schema through the model package; a bare `dict[str, Any]` may not override public fields. Mature cross-model features are later promoted from extensions into the public runtime namespace.
+
+Full export must materialize every effective behavior-defining typed or extension value, including values currently hidden in `factory_args` or Python factory defaults. For example, Qwen's effective `talker_max_seq_len` is `32768` in the model configuration even though the factory signature defaults to `4096`; the exported V2 document must contain `32768`. A model cannot opt in to V2 until all such behavior-defining factory defaults are represented in a public or registered extension schema and therefore survive export/import without consulting hidden Python defaults.
 
 ## 7.6 Relationship Between Roles and Stages
 
@@ -778,7 +842,8 @@ The new interface establishes the following rules:
 | GPU/TP/process placement | canonical source | Can be temporarily overridden with `--set` | Belongs to the Pipeline and requires unified validation |
 | SGLang/runtime parameters | canonical source | Can be temporarily overridden with `--set` | Same path, same type, same validation |
 | HTTP bind/log/API policy | Not included in Pipeline YAML | Dedicated CLI | Belongs to the service process, not the model Pipeline |
-| runtime-derived endpoint/port/gpu id | Not settable | Not settable | Owned by planner/runner |
+| Endpoint allocation policy (`endpoints.base_path`) | canonical source | Can be temporarily overridden with `--set` | User-configurable root for allocation |
+| Concrete runtime-derived endpoint/port/gpu id | Not settable | Not settable | Owned by planner/runner |
 | Router worker pool | Router YAML | Router CLI only selects source/routing parameters | Layered separately from the worker Pipeline |
 
 CLI and YAML therefore still have two syntaxes, but only one set of Pipeline semantics:
@@ -795,28 +860,42 @@ CLI --set
 
 ## 9.1 Structured Worker Config
 
-Launcher YAML removes the free-form string `worker_extra_args` and changes to:
+Launcher YAML removes the free-form string `worker_extra_args` and uses shared defaults plus explicit per-worker entries:
 
 ```yaml
 schema_version: 2
 
 launcher:
   backend: local
-  num_workers: 2
-  num_gpus_per_worker: 1
+  num_workers: 4
   worker_host: 127.0.0.1
   worker_base_port: 8011
   wait_timeout: 600
 
-  worker:
+  worker_defaults:
     config: examples/configs/qwen3_omni_colocated_h20_v2.yaml
     service:
       model_name: qwen3-omni
+    capabilities: [speech]
     patches:
       pipeline.stages.thinker.runtime.sglang.max_running_requests: 32
+
+  workers:
+    - index: 0
+      gpus: ["0"]
+      capabilities: [speech, streaming]
+      patches:
+        pipeline.stages.thinker.runtime.sglang.max_running_requests: 48
+    - index: 1
+      gpus: ["0"]  # Intentional overlap with worker 0.
+    - range: "2-3"
+      gpus: ["GPU-3b6e...", "MIG-GPU-7d2a.../1/0"]
+      capabilities: [chat]
 ```
 
-Exactly one of `worker.config` and `worker.model` is selected, corresponding to the worker `--config` and `--model-path` modes. `worker.patches` has paths/values validated by the Router schema and is passed as structured patches.
+`worker_defaults` supplies `config` or `model` (exactly one), service values, capabilities, and patches shared by workers. Each `workers` entry selects one worker with `index` or an inclusive set with `range`, and may override `gpus`, capabilities, and patches. Within one Router source, defaults are expanded first and then the concrete entry is applied; an entry patch may shadow the same path from defaults with provenance rather than being treated as a same-scope duplicate. Repetition within the entry itself remains an error. Repeated physical GPU sets are valid: the example deliberately gives workers 0 and 1 physical GPU `0`. Physical identifiers are preserved as written, including integer-like strings, UUIDs, and MIG identifiers; Router does not coerce them into logical IDs. Entries must cover each worker exactly once and overlapping index/range selectors are errors.
+
+`num_gpus_per_worker` remains only as a fallback when no explicit worker `gpus` is provided; in that mode Router automatically and exclusively splits the available devices. It must not be combined with explicit per-worker GPU sets. After assigning a worker's actual visible set, Router validates Pipeline logical GPU IDs against `0..len(worker.gpus)-1`, not against a global count.
 
 ## 9.2 Worker Transport
 
@@ -832,19 +911,19 @@ The patch file contains a serialized `ConfigPatchSet`, not a shell fragment. Aft
 
 If Router and workers later switch to a Python API or supervisor protocol, they still reuse `ConfigPatchSet` without changing configuration semantics. GPU visibility continues to be managed by Router through the subprocess environment because it is a process resource boundary, not a Pipeline patch.
 
-Router and workers use the same version of the schema registry and `ConfigResolver`. Before creating a subprocess, Router performs a complete dry-run resolve of `worker.config/model + worker.patches`:
+Router and workers use the same version of the schema registry and `ConfigResolver`. Before creating a subprocess, Router performs a complete dry-run resolve of each selected worker's `defaults + entry + config/model + patches`:
 
 - Relative configuration paths are resolved relative to the directory containing the launcher YAML;
-- Router must be able to load the model config and extension schemas required by the worker;
+- Router must first resolve the selected model/config identity and load exactly the extension schemas referenced by that worker; inability to perform this lookup is a startup error;
 - If a path, type, role, or extension cannot be resolved, fail before starting any worker;
 - After receiving the patch file, the worker validates the schema version and content again, but may not use different merge rules.
 
 GPU uses two explicit coordinate systems:
 
-- Router has exclusive authority over physical GPU allocation and establishes each worker's visible device set through `CUDA_VISIBLE_DEVICES`;
+- Router is the sole component authorized to assign physical GPUs and establishes each worker's visible device set through `CUDA_VISIBLE_DEVICES`; explicit assignments may intentionally overlap across workers;
 - Pipeline `placement.gpus` always uses worker-local logical GPU IDs, namely `0..N-1` after visible devices are renumbered.
 
-Router dry-run must validate that every logical GPU ID is within `[0, num_gpus_per_worker)` and that TP size, GPU list, and worker allocation are consistent. Pipeline may not directly reference host physical GPU IDs.
+Router dry-run must validate that every logical GPU ID is within `[0, len(actual worker visible GPU set))` and that TP size, GPU list, and worker allocation are consistent. Pipeline may not directly reference host physical GPU IDs. This prerequisite does not require Router to import or load every registered model—only the selected worker model and referenced extensions.
 
 ## 9.3 Precedence Between Router and Worker
 
@@ -863,13 +942,14 @@ model defaults < worker Pipeline YAML < Router worker.patches < worker CLI emerg
 | Conflict type | Example | V2 behavior |
 |---|---|---|
 | Duplicate in the same source | Two `--set` options write the same path | Error before startup |
-| alias/canonical duplicate | typed CLI and `--set` write the same path | Error before startup |
+| alias specificity | broadcast alias and role alias target the same leaf | More-specific role value wins and shadowed value is recorded |
+| same-specificity alias/canonical duplicate | two role aliases, or two explicit `--set` values, write the same leaf | Error before startup |
 | typed/extension overlap | An extension attempts to set a public SGLang field | Schema registration fails |
 | parent/child overlap | Two patch sources in the same layer set `runtime.sglang` and one of its children | Error in the same layer; allowed and recorded across layers |
-| Ownership violation | User sets `gpu_id` or endpoint | Path is not public; parsing fails |
+| Ownership violation | User sets `gpu_id` or a concrete endpoint | Path is not public; parsing fails; `endpoints.base_path` remains configurable |
 | Unsupported capability | A non-SGLang stage sets `runtime.sglang` | Model validation fails |
 | Cross-field inconsistency | TP=2 but only one GPU exists | Resolved model validation fails |
-| deprecated/canonical duplicate | V1 `runtime_overrides` and a V2 field | Migration error; do not guess precedence |
+| deprecated-document/canonical duplicate | V1 `runtime_overrides` and a V2 field in the same document layer | Migration error; CLI aliases instead follow the explicit specificity rule |
 
 ## 10.2 Atomicity
 
@@ -889,11 +969,11 @@ For example:
 duplicate configuration for
 pipeline.stages.thinker.runtime.sglang.mem_fraction_static
 
-file:qwen.yaml:42 = 0.70
-cli:--thinker-mem-fraction-static = 0.65
+cli:--thinker-mem-fraction-static = 0.70
+cli:--generation-mem-fraction-static = 0.65
 
-The CLI alias and canonical field target the same setting.
-Remove one source or use `config explain` to inspect precedence.
+The two role aliases have equal specificity and resolve to the same stage.
+Remove one alias or use an explicit concrete `--set`.
 ```
 
 # 11. Configuration Compilation and Runtime Boundary
@@ -916,8 +996,8 @@ Read it strictly as **① → ② → ③ → ④ → ⑤ → ⑥ → ⑦**:
 - ③ is the last step that modifies user configuration;
 - ④ only generates derived plans and does not write back to the Pipeline;
 - ⑤ stores effective runtime values determinable by main-process topology/hardware probes;
-- ⑥ only assembles cross-process DTOs;
-- ⑦ is when factories are imported and `ServerArgs` and `ModelConfig` are constructed; adjustments determinable only at this stage are recorded in `WorkerRuntimeDerivation`.
+- ⑥ resolves signature-independent factory arguments in the parent and assembles them into cross-process DTOs;
+- ⑦ imports the factory, injects only missing signature-dependent defaults, and then constructs `ServerArgs` and `ModelConfig`; adjustments determinable only at this stage are recorded in `WorkerRuntimeDerivation`.
 
 The current `_apply_tensor_parallel_server_args_overrides()` modifies stage server args based on a topology probe. V2 splits this into:
 
@@ -937,9 +1017,10 @@ Other topology-dependent parameters follow the same pattern.
 |---|---|
 | `sglang_omni/config/schema.py` | Add V2 public schema, name-keyed stages, typed runtime namespaces, frozen resolved model |
 | `sglang_omni/config/patch.py` (new) | `ConfigPath`, `ConfigSource`, `ConfigPatch`, duplicate/overlap checks |
-| `sglang_omni/config/resolver.py` (new) | layer merge, type conversion, provenance, full validation |
+| `sglang_omni/config/resolver.py` (new) | selector expansion, specificity/layer merge, type conversion, provenance, full validation |
 | `sglang_omni/config/compat.py` (new) | Time-limited adapter from V1 YAML/dotted/typed CLI to V2 patches |
-| `sglang_omni/models/registry.py` | Register V2 model defaults, roles, and extension schemas |
+| `sglang_omni/config/sglang_schema.py` (new) | Generate and fingerprint the exact pinned `ServerArgs` passthrough schema and enforce the ownership/unsafe denylist |
+| `sglang_omni/models/registry.py` | Register V2 model defaults, roles, stage kinds/capabilities, and extension schemas |
 
 The file-loading responsibility of `ConfigManager` is moved into the adapter/resolver. The old class remains as a facade during migration, and its custom dotted merge is ultimately removed.
 
@@ -948,7 +1029,7 @@ The file-loading responsibility of `ConfigManager` is moved into the adapter/res
 | Module | Change |
 |---|---|
 | `sglang_omni/cli/serve.py` | After parsing parameters, construct only `ServerLaunchConfig` and patches; remove business mutation helpers |
-| `sglang_omni/cli/config.py` | Add schema/validate/resolve/explain/migrate |
+| `sglang_omni/cli/config.py` | Add schema/validate/resolve/explain/migrate/export, selector expansion display, and environment diagnostics |
 | `sglang_omni/cli/__init__.py` | Disable unknown options; all open-ended overrides use explicit `--set` |
 
 During migration, typed CLI aliases may continue to appear in the `serve()` signature, but the alias registry automatically generates their patch implementation.
@@ -957,9 +1038,10 @@ During migration, typed CLI aliases may continue to appear in the `serve()` sign
 
 | Module | Change |
 |---|---|
-| `sglang_omni/config/runtime.py` | Only convert typed resolved runtime into factory kwargs; no longer resolve conflicts between user sources |
+| `sglang_omni/config/runtime.py` | Convert typed resolved runtime into parent-resolved static factory kwargs; no longer resolve conflicts between user sources |
 | `sglang_omni/pipeline/runtime_config.py` | Read only frozen resolved config and output placement/process and `DerivedRuntimePlan` |
-| `sglang_omni/pipeline/mp_runner.py` | Construct specs from resolved config/plans; do not receive compatibility fields |
+| `sglang_omni/pipeline/mp_runner.py` | Construct specs and `ResolvedProcessEnv` from resolved config/plans; preserve the static-args/signature-injection boundary |
+| `sglang_omni/pipeline/stage_workers.py` | Apply configured environment defaults without overriding inherited values and emit process-environment diagnostics |
 | `sglang_omni/scheduling/sglang_backend/server_args_builder.py` | Construct `ServerArgs` from typed SGLang config, retaining explicit derived runtime overrides |
 
 Model factories may temporarily continue receiving `server_args_overrides`, but this dict can only be generated internally by the typed runtime adapter and is no longer a public YAML/CLI entry point.
@@ -968,7 +1050,7 @@ Model factories may temporarily continue receiving `server_args_overrides`, but 
 
 | Module | Change |
 |---|---|
-| `sglang_omni_router/launcher/config.py` | `worker.config/model/service/patches` schema |
+| `sglang_omni_router/launcher/config.py` | `worker_defaults` and index/range-selected `workers` schema, capabilities, physical GPU identifiers, and patches |
 | `sglang_omni_router/launcher/local.py` | Generate patch files instead of concatenating `worker_extra_args` |
 | `sglang_omni_router/serve.py` | Worker source validation and structured launcher integration |
 
@@ -978,9 +1060,11 @@ V2 uses a phased migration. It does not require all configuration to be modified
 
 ## 13.1 Phase 0: Establish the Resolver Without Changing Default Behavior
 
+- First freeze an independent oracle by running the untouched latest-main V1 implementation at `2b45073c` and recording its final outputs: resolved Pipeline shape, factory kwargs, placement/process plans, worker specs, and user-controlled `ServerArgs` fields. These legacy goldens are captured before routing V1 through any new adapter or resolver;
+- Add read-only provenance reconstruction plus `config resolve/explain` around current behavior, without making the new resolver authoritative;
 - Introduce `ConfigPatch`, provenance, and `config resolve/explain`;
-- Current model defaults, V1 YAML, dotted CLI, and typed CLI all produce patches through compatibility adapters;
-- Use golden tests to lock down final resolved values and success/failure behavior;
+- In shadow mode, current model defaults, V1 YAML, dotted CLI, and typed CLI also produce patches through compatibility adapters, without replacing the V1 execution path;
+- Compare adapter/resolver output against the independent untouched-V1 oracle; V1-adapter-versus-V2-through-the-same-resolver equivalence is supplementary and cannot replace that oracle;
 - Runtime continues consuming the existing `PipelineConfig` shape;
 - Duplicate V1 sources newly discovered by the resolver initially record diagnostics without changing current success/failure outcomes;
 - V2 inputs in internal tests follow strict duplicate/overlap rules from the beginning.
@@ -997,6 +1081,7 @@ The goal of this phase is to first obtain a single merge engine, not immediately
 
 V2 documents may not contain V1 `stage_overrides`, `runtime_overrides`, or public `factory_args.server_args_overrides`.
 V1 inputs retain their current final-value semantics, but newly discovered duplicate sources produce warnings.
+A model is not eligible for V2 opt-in until all behavior-defining values hidden in its `factory_args` or factory defaults are represented by public or registered extension schema and round-trip through full export.
 
 ## 13.3 Phase 2: V2 by Default
 
@@ -1045,14 +1130,17 @@ Validation is divided into resolver and runtime planning layers. The former prov
 | path | Valid field, unknown field, private/derived field, stage name |
 | type | scalar, null, list, dict, enum, invalid coercion |
 | document structure | duplicate YAML key, full/partial mode, stage declaration, `stage_order` completeness |
-| precedence | defaults, profile, YAML, Router patch, CLI |
-| duplicates | same source, same layer, alias/canonical, parent/child |
+| precedence | defaults, profile, YAML, Router patch, CLI, source layer dominating selector specificity |
+| selectors | capability/role/stage/exclude matching, expansion, empty selection, concrete stage storage/export |
+| duplicates | same source/specificity, same layer, alias specificity, parent/child |
 | cross-layer subtree | higher-layer child overrides lower-layer parent, higher-layer parent replaces lower-layer subtree, whole-list replacement |
 | provenance | previous value, source, location, and deprecated marker for each override |
 | atomicity | No partial resolved config is produced if any patch fails |
 | frozen config | Assignment is prohibited after the resolver returns |
 | role | Unique role-to-stage resolution, unknown/unsupported role |
-| extension | Registered schema, unknown key, prohibition on overriding public namespace |
+| extension | Registered schema, unknown key, prohibition on overriding public namespace, full-export round trip of hidden defaults |
+| upstream args | exact pinned `ServerArgs` version/fingerprint, unknown fields, denylist, typed-field duplication, per-leaf provenance, final `ServerArgs` validation |
+| environment | `env_defaults`/stage `env` merge, inherited-environment non-override, derived `ResolvedProcessEnv`, external-read diagnostics |
 
 ## 14.2 CLI/YAML Equivalence
 
@@ -1079,7 +1167,7 @@ Select official examples:
 - Ming full-stages YAML;
 - TP and process isolation configurations.
 
-Run the V1 adapter and migrated V2 document separately, comparing:
+For each case, first capture the output of the untouched latest-main V1 implementation as an independent golden. Then compare both the V1 adapter and migrated V2 document against that oracle:
 
 - Stage topology and order;
 - placement/TP/process;
@@ -1097,6 +1185,8 @@ The following must be covered:
 
 - typed `mem_fraction_static` and old `server_args_overrides`;
 - global and per-role CLI;
+- broadcast alias, role alias, and explicit `--set` specificity, including shadowed provenance;
+- selector broadcast and concrete-stage override;
 - `--encoder-mem-reserve` and explicit fraction;
 - `tp_size` and GPU list;
 - generation role and thinker role targeting the same/different stages;
@@ -1116,7 +1206,7 @@ Verify:
 - Worker-only effective values enter only `WorkerRuntimeDerivation` and retain their sources;
 - Child processes do not resolve user configuration again;
 - Factory signature injection supplies only missing derived defaults;
-- Users cannot set `gpu_id`, cumulative process budget, NCCL port, or endpoint;
+- Users cannot set `gpu_id`, cumulative process budget, NCCL port, or a concrete endpoint, while `endpoints.base_path` remains configurable;
 - TP environment mapping matches current behavior;
 - Worker specs for the no-config/default model path match golden files;
 - `ServerArgs.override()` continues recording the source of worker-internal derived mutations.
@@ -1133,7 +1223,12 @@ Verify:
 - Router YAML path/type/role/extension failures occur before starting subprocesses;
 - GPUs continue to be passed through the environment;
 - Physical GPU assignment is correctly converted to worker-local logical GPU IDs;
-- Out-of-range logical GPUs and inconsistencies between TP and worker allocation fail before startup;
+- Index/range coverage, per-worker capabilities/patches, and selected-model/extension lookup are validated;
+- `worker_defaults` < per-worker entry shadowing retains provenance, while duplicates within each scope are rejected;
+- Repeated physical GPU sets across workers are preserved, including two workers sharing GPU `0`;
+- Integer-like, UUID, and MIG physical identifiers round-trip unchanged;
+- Out-of-range logical GPUs are checked against each actual visible set, and TP/allocation inconsistencies fail before startup;
+- Exclusive `num_gpus_per_worker` splitting is used only when explicit `gpus` are absent;
 - V1 `worker_extra_args` migration recognizes `--config`, typed aliases, and `--set`;
 - Arbitrary shell tokens that cannot be migrated safely fail explicitly and are not silently discarded.
 
@@ -1151,9 +1246,12 @@ Before entering the next Phase, all of the following must be satisfied:
 1. All official Pipeline and Router examples pass migration golden tests;
 2. Structured Router has completed at least one multi-worker E2E;
 3. Runtime no longer directly reads public compatibility fields;
-4. The warning/error matrix for the current Phase is fixed in CI;
-5. Usage of deprecated entry points has reached the migration threshold announced in advance by the project;
-6. Release notes specify the target version and removals for the next Phase.
+4. The warning/error and full compatibility matrices for the current Phase are fixed in CI;
+5. All official examples, documentation, tests, and CI invocations have migrated;
+6. Release notes have announced the removal for a predetermined `N` releases;
+7. Those `N` announced releases have shipped before advancing to the removal Phase.
+
+Repository state and release history are the decidable gates. Local or explicitly opt-in telemetry may diagnose remaining use, but no unobservable global deprecated-usage threshold can block or authorize a Phase transition.
 
 # 15. Release and Documentation
 

--- a/docs/developer_reference/config.md
+++ b/docs/developer_reference/config.md
@@ -7,6 +7,10 @@ runtime overrides. `StageConfig` describes one logical stage: how to construct
 it, where it runs, where its normal results go, and whether it participates in
 fan-in or streaming edges.
 
+This page is the schema and topology reference. For how Python defaults,
+Pipeline YAML, command-line overrides, Router launcher YAML, and worker runtime
+arguments compose, see [Configuration Sources and Argument Flow](./configuration.md).
+
 The config layer is intentionally static. It should make topology, placement,
 and stage construction visible before the runtime starts; request-time behavior
 belongs in stages, schedulers, model runners, and model-local payload logic.

--- a/docs/developer_reference/configuration.md
+++ b/docs/developer_reference/configuration.md
@@ -7,14 +7,14 @@
 - 配置怎样从主进程传到 stage worker 和 SGLang；
 - 哪些值由用户设置，哪些值由 placement、process planner 或 worker 派生。
 
-字段和拓扑的逐项定义参见 [Config](./config.md)。本文描述的是配置如何进入这些字段并最终被运行时消费。结论基于当前 `sgl-omni serve`、Router 和对应单元测试，不覆盖 benchmark、CI 配置或模型内部 Hugging Face/Hydra 配置。
+字段和拓扑的逐项定义参见 [Config](./config.md)。本文描述的是配置如何进入这些字段并最终被运行时消费。结论核对到 `origin/main@2b45073c` 的 `sgl-omni serve`、Router 和对应单元测试，不覆盖 benchmark、CI 配置或模型内部 Hugging Face/Hydra 配置。
 
 ## 1. 总体心智模型
 
 配置不是一次 `CLI dict` 与 `YAML dict` 的简单合并。当前系统有三条相互衔接但 owner 不同的链路：
 
-1. **Pipeline 声明链路**：模型 Python 默认、Pipeline YAML、动态 dotted CLI 和专用 CLI 最终形成一个 `PipelineConfig`。
-2. **Worker 构造链路**：主进程把 `PipelineConfig` 编译为 placement、process topology 和可 pickle 的 worker spec；子进程再构造 factory kwargs、`ServerArgs` 和 `ModelConfig`。
+1. **Pipeline 声明链路**：模型 Python 默认、Pipeline YAML、动态 dotted CLI、专用 CLI 和配置中的环境默认值最终形成一个 `PipelineConfig`。
+2. **Worker 构造链路**：主进程把 `PipelineConfig` 编译为 placement、process topology、静态 factory kwargs 和可 pickle 的 worker spec；子进程导入 factory、补充签名相关的派生默认值，再构造 `ServerArgs` 和 `ModelConfig`。
 3. **Router 管理链路**：Router YAML 描述完整 worker 副本，Router 将其转换为多个 `sgl-omni serve` 命令和各自的环境变量。
 
 ```mermaid
@@ -24,9 +24,10 @@ flowchart LR
   DottedCli["dotted CLI"] --> PipelineConfig
   TypedCli["专用 typed CLI"] --> PipelineConfig
   PipelineConfig --> RuntimePlan["fusion / placement / topology / endpoints"]
-  RuntimePlan --> WorkerSpec[StageWorkerProcessSpec]
-  WorkerSpec --> FactoryArgs["子进程 factory kwargs"]
-  FactoryArgs --> ServerArgs[SGLang ServerArgs]
+  RuntimePlan --> FactoryArgs["主进程静态 factory kwargs"]
+  FactoryArgs --> WorkerSpec[StageWorkerProcessSpec]
+  WorkerSpec --> SignatureDefaults["子进程 signature defaults"]
+  SignatureDefaults --> ServerArgs[SGLang ServerArgs]
   ServerArgs --> ModelConfig[ModelConfig]
   RouterYaml["Router launcher YAML"] --> WorkerArgv["sgl-omni serve argv + env"]
   WorkerArgv --> PipelineYaml
@@ -84,13 +85,29 @@ config_cls: Qwen3OmniSpeechColocatedPipelineConfig
 model_path: Qwen/Qwen3-Omni-30B-A3B-Instruct
 
 stage_overrides:
+  image_encoder:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.025
+  audio_encoder:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.025
   thinker:
     runtime:
       resources:
         total_gpu_memory_fraction: 0.75
+  talker_ar:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.12
+  code2wav:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.02
 ```
 
-它不能设置 `gpu`、`process` 或 `factory_args`。这些字段应写入完整 `stages`，或使用对应 CLI。未知 stage、非 mapping 值、`runtime` 之外的 key 都会在加载时失败。
+它不能设置 `gpu`、`process` 或 `factory_args`。这些字段应写入完整 `stages`，或使用对应 CLI。未知 stage、非 mapping 值、`runtime` 之外的 key 都会在加载时失败。这个 colocated 配置必须为同 GPU 上的五个 GPU stage 全部提供预算；只设置 thinker 会触发 Qwen placement validation。
 
 `runtime_overrides` 则是兼容性更强的 per-stage factory 参数通道：
 
@@ -228,6 +245,9 @@ TP worker 还会在 spawn 周围由主进程临时设置：
 - `CUDA_VISIBLE_DEVICES`
 - `SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS=true`
 - `SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=false`
+- `SGLANG_OMNI_PLATFORM_SPEC`
+
+受影响 GPU 还会通过同一 worker env 路径补充 compatibility default，例如当前的 `FLASHINFER_USE_CUDA_NORM=1`。这些 derived/platform 变量与用户声明的 `env_defaults`/`StageConfig.env` 不是同一种 source。
 
 子进程因此只看到分配给本 rank 的设备，并把逻辑 `gpu_id` 规范化为本地设备 0。主进程在 `proc.start()` 后恢复自己的环境。
 
@@ -342,6 +362,7 @@ typed runtime 当前包括：
 - `model_path`
 - `gpu_id`
 - `total_gpu_memory_fraction`
+- `process_total_gpu_memory_fraction`
 
 仅当 factory 声明该参数且用户/前序合并尚未设置时才注入。这些是 fallback，不会覆盖显式 factory kwargs。
 
@@ -353,7 +374,8 @@ typed runtime 当前包括：
 | stage GPU | placement planner | `StageLaunchConfig.gpu_id` |
 | TP rank/size | stage config + runner | 每 rank spec |
 | NCCL port | 主进程 `_NcclPortAllocator` | factory arg |
-| IPC endpoints | runtime preparation | spec 中的字符串 |
+| IPC base path | `PipelineConfig.endpoints.base_path` | 用户配置随 Pipeline 进入 planner |
+| 具体 IPC socket endpoints | runtime preparation | spec 中的派生字符串 |
 | `total_gpu_memory_fraction` | typed stage resources | factory default |
 | cumulative process memory fraction | process 构造顺序 | `process_total_gpu_memory_fraction` factory default |
 | factory implementation | `StageConfig.factory` | dotted path，子进程 import |
@@ -434,7 +456,7 @@ Qwen colocated 示例只在 `stage_overrides.*.runtime.resources` 中声明物�
 
 ## 8. Router 的独立配置体系
 
-Router 不是 Pipeline 的另一种 YAML loader。它是独立 HTTP process，前置于多个完整 `sgl-omni serve` worker。
+Router 不是 Pipeline 的另一种 YAML loader。默认 `--router-processes=1` 时，它是一个独立 HTTP process，前置于多个完整 `sgl-omni serve` worker。`--router-processes>=2` 时，supervisor 复用同一 public listening socket 启动多个 data-plane process，并由独立 control-plane process 管理 registry、admin 和持久状态；对外 API 保持一致。
 
 ### 8.1 三种 worker source
 
@@ -461,16 +483,20 @@ Router worker 来源三选一：
 | `--max-payload-size` | `512 MiB` | Router request body 上限 |
 | `--max-connections` | auto | admission/pool 基准，默认 `128 × workers`，上限 4096 |
 | `--max-inflight` | `None` | 可选独立 admission cap；默认跟随 connections |
+| `--router-processes` | `1` | `1` 为单进程；`>=2` 启用 x86-64 Linux control-plane/data-plane split |
+| `--shutdown-drain-secs` | request timeout | multiprocess shutdown 等待 in-flight request 的时间 |
+| `--router-state-dir` | env/XDG/home | durable control-plane state 目录 |
 | `--health-failure-threshold` | `3` | 标记 unhealthy 前连续失败数 |
 | `--health-success-threshold` | `2` | 恢复 healthy 前连续成功数 |
 | `--health-check-timeout-secs` | `5` | 单次 health check 超时 |
 | `--health-check-interval-secs` | `10` | health check 间隔 |
 | `--health-check-endpoint` | `/health` | worker 健康端点 |
+| `--voice-owner-worker-url` | auto | 单进程模式 uploaded-voice owner；multiprocess 模式禁止 |
 | `--log-level` | `info` | Router/Uvicorn 日志；非法值当前回退为 `INFO` |
 | `--strict-limits` | `False` | nofile 不足时从 warning 改为启动失败 |
 | `--admin-api-key` | `None` | 直接传给 Router app，也可来自环境变量 |
 
-Router 自身的 host、port、policy、health 和连接参数只来自 CLI，不与 launcher YAML 合并。
+Router 自身的 host、port、policy、health、process count 和连接参数只来自 CLI，不与 launcher YAML 合并。multiprocess 模式下 `max_connections`/`max_inflight` 是全局 admission 与 shared upstream-pool 约束，并由 control/data plane 共同执行；不能按“每个独立 Uvicorn process 各有一份上限”理解。
 
 ### 8.3 Launcher YAML 到 worker argv
 
@@ -483,13 +509,15 @@ launcher:
   model_name: qwen3-omni
   num_workers: 2
   num_gpus_per_worker: 1
+  worker_gpu_ids: ["0", "0"]
+  worker_capabilities: [text, speech, audio_input, audio_output]
   worker_host: 127.0.0.1
   worker_base_port: 8011
   worker_extra_args: "--config examples/configs/qwen3_omni_colocated_h20.yaml --colocate"
   wait_timeout: 600
 ```
 
-`LocalLauncherConfig` 使用 `extra="forbid"`，校验 worker 数量、端口范围、GPU assignments 和 capabilities。每个 worker 的命令由 Router 重建：
+`LocalLauncherConfig` 使用 `extra="forbid"`，校验 worker 数量、端口范围、GPU assignments 和 capabilities。显式 `worker_gpu_ids` 必须与 worker 数量一致，但不同 worker 可以重复同一物理 GPU；上例表示两个 worker 都通过 `CUDA_VISIBLE_DEVICES=0` 使用 GPU 0。只有未提供该字段时，Router 才按 `num_workers * num_gpus_per_worker` 从可见设备中连续、互斥地自动切分。每个 worker 的命令由 Router 重建：
 
 ```text
 sgl-omni serve

--- a/docs/developer_reference/configuration.md
+++ b/docs/developer_reference/configuration.md
@@ -1,0 +1,590 @@
+# 配置来源与传参链路
+
+本文调研当前 `sgl-omni` 与 `sgl-omni-router` 的配置来源、覆盖顺序和运行时传递边界。重点回答：
+
+- 命令行参数与 Pipeline YAML 分别负责什么；
+- 同一值出现于多个来源时，哪一层生效；
+- 配置怎样从主进程传到 stage worker 和 SGLang；
+- 哪些值由用户设置，哪些值由 placement、process planner 或 worker 派生。
+
+字段和拓扑的逐项定义参见 [Config](./config.md)。本文描述的是配置如何进入这些字段并最终被运行时消费。结论基于当前 `sgl-omni serve`、Router 和对应单元测试，不覆盖 benchmark、CI 配置或模型内部 Hugging Face/Hydra 配置。
+
+## 1. 总体心智模型
+
+配置不是一次 `CLI dict` 与 `YAML dict` 的简单合并。当前系统有三条相互衔接但 owner 不同的链路：
+
+1. **Pipeline 声明链路**：模型 Python 默认、Pipeline YAML、动态 dotted CLI 和专用 CLI 最终形成一个 `PipelineConfig`。
+2. **Worker 构造链路**：主进程把 `PipelineConfig` 编译为 placement、process topology 和可 pickle 的 worker spec；子进程再构造 factory kwargs、`ServerArgs` 和 `ModelConfig`。
+3. **Router 管理链路**：Router YAML 描述完整 worker 副本，Router 将其转换为多个 `sgl-omni serve` 命令和各自的环境变量。
+
+```mermaid
+flowchart LR
+  PythonDefaults["模型 Python 默认"] --> PipelineConfig[PipelineConfig]
+  PipelineYaml["Pipeline YAML"] --> PipelineConfig
+  DottedCli["dotted CLI"] --> PipelineConfig
+  TypedCli["专用 typed CLI"] --> PipelineConfig
+  PipelineConfig --> RuntimePlan["fusion / placement / topology / endpoints"]
+  RuntimePlan --> WorkerSpec[StageWorkerProcessSpec]
+  WorkerSpec --> FactoryArgs["子进程 factory kwargs"]
+  FactoryArgs --> ServerArgs[SGLang ServerArgs]
+  ServerArgs --> ModelConfig[ModelConfig]
+  RouterYaml["Router launcher YAML"] --> WorkerArgv["sgl-omni serve argv + env"]
+  WorkerArgv --> PipelineYaml
+```
+
+安装入口位于 `pyproject.toml`：
+
+- `sgl-omni` → `sglang_omni.cli:app`
+- `sgl-omni-router` → `sglang_omni_router.serve:main`
+
+`sgl-omni serve` 使用 Typer/Click，并且只有该子命令启用了 `allow_extra_args=True` 和 `ignore_unknown_options=True`。因此它同时拥有固定的公共参数和开放的 dotted override。Router 使用 argparse，只接受显式注册的参数。
+
+## 2. 配置来源与职责
+
+### 2.1 模型 Python 默认
+
+每个模型包通过 `EntryClass` 注册一个 `PipelineConfig` 子类。未指定 `--config` 时，`ConfigManager.from_model_path()` 从 Hugging Face、原始 `config.json` 或 Mistral 元数据解析 architecture，再从 `PIPELINE_CONFIG_REGISTRY` 选择配置类。
+
+配置类是拓扑和模型默认值的 source of truth，包括：
+
+- stage 列表与 factory；
+- routing、fan-in、streaming；
+- GPU、TP 和 process 的默认布局；
+- `factory_args`、typed runtime 和环境变量默认值；
+- public role 到模型 stage 名的映射。
+
+例如 Qwen3-Omni 分别提供 text、speech 和 speech-colocated 配置类；`--text-only` 在没有 `--config` 时选择 `Variants["text"]`。相关实现位于：
+
+- `sglang_omni/config/manager.py`：`resolve_config_cls_for_model_path()`、`ConfigManager.from_model_path()`
+- `sglang_omni/models/registry.py`：配置类注册与按类名查找
+- `sglang_omni/models/qwen3_omni/config.py`：Qwen3-Omni variants 和 public role maps
+
+### 2.2 Pipeline YAML
+
+`sgl-omni serve --config FILE` 只加载显式给出的文件；没有按目录扫描、扩展名限制、include 或 `extends`。入口是 `ConfigManager.from_file()`，使用 `yaml.safe_load()`，顶层必须是 mapping。
+
+YAML 至少需要：
+
+```yaml
+config_cls: MossTTSPipelineConfig
+model_path: OpenMOSS-Team/MOSS-TTS-v1.5
+```
+
+`config_cls` 不是 Python import path，而是在模型 registry 中注册的配置类名。加载器用该类构造 Pydantic model，因此 YAML 继承了 Python 配置类没有显式覆盖的 topology/default。未知字段由各层 Pydantic model 的 `extra="forbid"` 拒绝。
+
+Pipeline YAML 有两种用法：
+
+1. **紧凑配置**：只选择 `config_cls` 并覆盖少量顶层字段、`runtime_overrides` 或 `stage_overrides`。`examples/configs/qwen3_omni_colocated_h20.yaml` 属于这种形式。
+2. **完整配置**：显式提供整个 `stages` 列表。此时列表整体替换配置类默认 stages，不执行按 stage 的列表合并。`examples/configs/ming_omni_tts.yaml` 是完整形式。
+
+`stage_overrides` 是加载器识别的紧凑语法，目前只允许按 stage 名深合并 typed `runtime`：
+
+```yaml
+config_cls: Qwen3OmniSpeechColocatedPipelineConfig
+model_path: Qwen/Qwen3-Omni-30B-A3B-Instruct
+
+stage_overrides:
+  thinker:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.75
+```
+
+它不能设置 `gpu`、`process` 或 `factory_args`。这些字段应写入完整 `stages`，或使用对应 CLI。未知 stage、非 mapping 值、`runtime` 之外的 key 都会在加载时失败。
+
+`runtime_overrides` 则是兼容性更强的 per-stage factory 参数通道：
+
+```yaml
+runtime_overrides:
+  thinker:
+    server_args_overrides:
+      max_running_requests: 4
+```
+
+二者名字相似但作用层不同：
+
+- `stage_overrides.<stage>.runtime` 修改 typed `StageRuntimeConfig`；
+- `runtime_overrides.<stage>` 在 factory kwargs 解析阶段覆盖 `factory_args`。
+
+### 2.3 动态 dotted CLI
+
+Typer 未识别的 `serve` 参数会保留在 `ctx.args`，由 `ConfigManager.parse_extra_args()` 处理。支持两种写法：
+
+```bash
+sgl-omni serve --config config.yaml \
+  --stages.thinker.runtime.resources.total-gpu-memory-fraction 0.35
+
+sgl-omni serve --config config.yaml \
+  --stages.4.tp-size=2
+```
+
+规则如下：
+
+- key/value 必须成对，也可写成 `--key=value`；
+- 去掉 key 前导 `-`，把 `-` 转为 `_`，`.` 保持为路径分隔符；
+- list 可用数字下标或元素的 `name` 寻址，因此 `stages.4` 与 `stages.thinker` 都可用；
+- 重复 key 由后值覆盖前值；
+- scalar 依次尝试 `true/false/none`、`int`、`float`，否则保留字符串；
+- 通用解析器不会把字符串转换成 list 或 dict。
+
+`tp_size` 与 `parallelism.tp` 是兼容别名。dotted CLI 只修改其中一个时，`ConfigManager` 会同步另一边；若最终值冲突，Pydantic validation 拒绝配置。
+
+该通道适合临时修改标量或精确定位内部字段，不适合表达复杂列表、dict 和完整 stage。它也是开放接口：可用路径取决于所选模型配置实例，不存在一张跨模型固定参数表。
+
+实现和证明测试：
+
+- `sglang_omni/config/manager.py`：`parse_extra_args()`、`merge_config()`、`_resolve_list_index()`、`_convert_scalar()`
+- `tests/unit_test/qwen3_omni/test_config_manager.py`：数字/命名 stage 路径、类型转换和 TP alias
+
+### 2.4 专用 typed CLI
+
+`sgl-omni serve` 还声明了 41 个稳定公共参数。Typer 负责基础类型转换；CLI helper 再执行范围、互斥、模型能力和 topology 校验。专用参数的目标分成两类：
+
+- **服务参数**：直接传给 `launch_server()`，不进入 `PipelineConfig`；
+- **Pipeline override**：修改 stage placement、typed runtime、`factory_args` 或 `server_args_overrides`。
+
+大多数可选 override 以 `None` 或 `"default"` 表示“保留 YAML/模型默认”，而不是写入一个新的默认值。
+
+#### 配置、拓扑与服务
+
+| 参数 | 默认值 | 最终作用域 | 说明 |
+| --- | --- | --- | --- |
+| `--model-path` | `None` | Pipeline | 无 YAML 时用于选择配置类；显式提供时还会覆盖 YAML `model_path` |
+| `--config` | `None` | 配置加载 | Pipeline YAML 路径 |
+| `--text-only` | `False` | 配置选择 | 无 YAML 时选择 text variant；不是对任意 YAML 删除 speech stage |
+| `--colocate` | `False` | 校验/日志 | 当前要求 Qwen colocated 配置，并要求同时给出 `--config` |
+| `--isolate-stage` | `None` | stage process | 可重复；`STAGE=STAGE` 的简写 |
+| `--stage-process` | `None` | stage process | 可重复；按 `STAGE=PROCESS` 分组或隔离 stage |
+| `--host` | `0.0.0.0` | HTTP server | 不进入 Pipeline |
+| `--port` | `8000` | HTTP server | 不进入 Pipeline |
+| `--model-name` | Pipeline name | API server | `/v1/models` 暴露的名称 |
+| `--log-level` | `info` | 主进程/server | 也控制是否打印 merged config；`debug` 会打印 |
+| `--allowed-local-media-path` | `None` | API server | `file://` 媒体允许目录 |
+| `--allowed-media-domain` | `None` | API server | 可重复，也支持单项逗号分隔 |
+| `--tts-batch-max-items` | `32` | API server | `/v1/audio/speech/batch` 最大 items |
+| `--enable-realtime` | `False` | API server | 挂载 `/v1/realtime` |
+
+#### 内存、量化、GPU 与 TP
+
+| 参数 | 默认值 | 写入位置 | 关键规则 |
+| --- | --- | --- | --- |
+| `--mem-fraction-static` | `None` | role stage typed runtime | supported SGLang AR stages 的全局 fallback |
+| `--thinker-mem-fraction-static` | `None` | thinker typed runtime | 高于 global flag |
+| `--talker-mem-fraction-static` | `None` | talker typed runtime | 高于 global flag |
+| `--encoder-mem-reserve` | `None` | thinker `factory_args` | 仅用于 auto-picked thinker fraction；与显式 thinker fraction 互斥 |
+| `--cpu-offload-gb` | `None` | thinker `server_args_overrides` | 必须非负 |
+| `--quantization` | `None` | thinker `server_args_overrides` | 必须是非空字符串 |
+| `--thinker-tp-size` | `None` | thinker `tp_size`/`parallelism.tp` | 同步两个 alias |
+| `--thinker-gpus` | `None` | thinker `gpu` | 接受 `0`、`0,1` 或 `[0, 1]` |
+| `--image-encoder-tp-size` | `None` | image encoder TP | 同步两个 alias |
+| `--image-encoder-gpus` | `None` | image encoder `gpu` | GPU 数量必须匹配 TP |
+| `--talker-gpu` | `None` | model-mapped talker stage | 依赖配置类 public role map |
+| `--code2wav-gpu` | `None` | model-mapped code2wav stage | 不支持的 pipeline 会拒绝 |
+
+`--mem-fraction-static` 的优先级只发生在专用 CLI 内部：
+
+```text
+per-role flag > global flag > 当前 Pipeline 值
+```
+
+先校验所有值再修改，避免只覆盖了一部分 stage。`--encoder-mem-reserve` 不能和 global/thinker memory flag 共用；如果 YAML 已通过 typed runtime 或兼容 `server_args_overrides` 固定 thinker fraction，也会拒绝。
+
+#### 执行优化和容量
+
+| 参数 | 默认值 | 写入位置 | 说明 |
+| --- | --- | --- | --- |
+| `--thinker-cuda-graph` | `default` | thinker `server_args_overrides` | `default/on/off` |
+| `--talker-cuda-graph` | `default` | mapped SGLang talker stage | `default/on/off` |
+| `--talker-partial-start` | `default` | Qwen talker `factory_args` | 仅支持声明的 Qwen talker factory |
+| `--thinker-torch-compile` | `default` | thinker `server_args_overrides` | `default/on/off` |
+| `--talker-torch-compile` | `default` | mapped SGLang talker stage | `default/on/off` |
+| `--thinker-torch-compile-max-bs` | `None` | thinker `server_args_overrides` | 必须大于 0 |
+| `--talker-torch-compile-max-bs` | `None` | mapped SGLang talker stage | 必须大于 0 |
+| `--decode-mode` | `None` | supported factories | `async/sync`，覆盖 `enable_async_decode` |
+| `--async-lookahead-min-batch-size` | `None` | supported factories | 与 `--decode-mode sync` 互斥 |
+| `--thinker-max-running-requests` | `None` | thinker `server_args_overrides` | thinker 专用容量 |
+| `--prefill-coalesce-requests` | `None` | supported factories | `< 2` 不启用 gate |
+| `--prefill-coalesce-wait-ms` | `None` | supported factories | 单独设置不一定启用 coalescing |
+| `--max-running-requests` | `None` | generation role stage | 通用 generation stage 容量 |
+| `--max-total-tokens` | `None` | generation role stage | KV pool token cap |
+| `--cuda-graph-max-bs` | `None` | generation role stage | generation CUDA graph batch cap |
+
+这些 flag 不靠固定 stage 名猜测所有模型。配置类通过 `mem_fraction_role_to_stage()`、`talker_role_to_stage()`、`generation_sglang_role_to_stage()` 等 class method 把公共 role 映射到模型 stage；缺少映射或 stage 时，CLI 明确报 unsupported。
+
+CLI 别名以 kebab-case 为主，部分参数保留 underscore 兼容形式。CUDA graph 还保留 `--thinker_CUDA_graph` 和 `--talker_CUDA_graph`。精确 spelling 以 `sglang_omni/cli/serve.py` 的 `serve()` 签名为准。
+
+### 2.5 环境变量
+
+Pipeline 和 stage 都可声明环境默认值：
+
+```text
+真实 os.environ > stage.env > pipeline.env_defaults
+```
+
+这里的 `>` 表示已存在的 operator 环境变量不会被配置覆盖；stage default 在合并 dict 时高于 pipeline default。若同一 OS process 中多个 stage 对同一变量声明不同默认值，启动前会拒绝，避免 process 级环境产生 stage 级歧义。
+
+TP worker 还会在 spawn 周围由主进程临时设置：
+
+- `CUDA_VISIBLE_DEVICES`
+- `SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS=true`
+- `SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=false`
+
+子进程因此只看到分配给本 rank 的设备，并把逻辑 `gpu_id` 规范化为本地设备 0。主进程在 `proc.start()` 后恢复自己的环境。
+
+相关实现位于 `sglang_omni/pipeline/mp_runner.py` 和 `sglang_omni/pipeline/stage_workers.py`。
+
+## 3. `serve` 的精确合并顺序
+
+### 3.1 主进程顺序
+
+`serve()` 中的实际顺序如下，从低到高读取：
+
+1. **基础配置**
+   - 有 `--config`：YAML 顶层构造模型配置类，再应用 YAML `stage_overrides`；
+   - 否则：由 `--model-path` 选择模型配置类，`--text-only` 可选择 text variant。
+2. **动态 dotted CLI**
+   - `ConfigManager.merge_config()` 对 `model_dump()` 的深拷贝修改路径，再用同一配置类整体重建并校验。
+3. **显式 `--model-path`**
+   - 通过 `model_copy(update=...)` 覆盖 YAML 内的路径。
+4. **专用 Pipeline CLI**
+   - memory fraction；
+   - encoder reserve；
+   - thinker ServerArgs；
+   - TP/GPU；
+   - process placement；
+   - CUDA graph；
+   - torch compile；
+   - decode mode；
+   - prefill coalescing；
+   - generation ServerArgs；
+   - talker partial start。
+5. **服务 CLI**
+   - `host`、`port`、API media policy、realtime 等直接传给 `launch_server()`。
+
+因此常规同字段覆盖可概括为：
+
+```text
+模型类默认
+< YAML 顶层
+< YAML stage_overrides
+< dotted CLI
+< 显式 --model-path / 专用 CLI
+```
+
+这不是无条件的“最后写入获胜”。遇到 owner 冲突时，系统会拒绝配置而不是挑选一个来源。例如：
+
+- typed `runtime.sglang_server_args.mem_fraction_static` 与 `factory_args/runtime_overrides.server_args_overrides.mem_fraction_static` 同时出现；
+- typed `runtime.max_seq_len` 映射目标同时出现在 `runtime_overrides`；
+- `gpu_id` 出现在 factory args，而不是由 `stage.gpu`/placement 派生；
+- `total_gpu_memory_fraction` 出现在非 typed runtime 路径；
+- `--encoder-mem-reserve` 与显式 thinker fraction 同时出现。
+
+另一个细节是，大部分专用 CLI helper 在当前 Pydantic 对象上原地修改。配置 model 没有启用 `validate_assignment=True`，因此 helper 必须先手工校验，或在关键步骤重建 model。不能假设任意属性赋值都会自动触发 Pydantic validator。
+
+### 3.2 如何观察最终结果
+
+`--colocate` 或 `--log-level debug` 会在启动前打印 merged `PipelineConfig`：
+
+```text
+==================== Merged Configuration ====================
+...
+==================================================
+```
+
+该输出能观察进入 runtime planner 前的 Pipeline 状态，但不包含随后派生的 endpoint、process cumulative budget、factory signature defaults，也不等于最终 `ServerArgs`。placement/topology 解析结果会在 server 启动日志中单独记录。
+
+`sgl-omni config view --model-path MODEL` 显示模型类默认配置；`config export` 将同一默认配置导出为 YAML。它们不会应用 `serve` 的 YAML、dotted CLI 或专用 CLI 覆盖。
+
+## 4. Pipeline 到 stage worker
+
+### 4.1 主进程只传 resolved spec
+
+`launch_server()` 创建 `MultiProcessPipelineRunner`。runtime preparation 依次处理：
+
+- `apply_fusion()`；
+- `StagePlacementPlan`；
+- `ProcessTopologyPlan`；
+- 每次运行独立的 IPC 目录和 ZMQ endpoints。
+
+随后 `_build_stage_groups()` 为每个逻辑 stage/rank 生成 `StageLaunchConfig`，并按 OS process 分组为 `StageWorkerProcessSpec`。使用 `multiprocessing` 的 `spawn` 启动时，被 pickle 的是这些普通 dataclass/dict/string/queue 组成的 spec，不是原始 argv，也不是完整 `PipelineConfig`。
+
+factory、route、merge 和 projection 都以 dotted import path 保存在 spec 中，子进程才导入。这样主进程不必加载模型侧依赖。
+
+关键代码：
+
+- `sglang_omni/pipeline/runtime_config.py`：`prepare_pipeline_runtime()`
+- `sglang_omni/pipeline/mp_runner.py`：`_build_stage_groups()`、单 rank/TP rank spec 构造
+- `sglang_omni/pipeline/stage_workers.py`：`StageLaunchConfig`、`StageWorkerProcessSpec`、`StageGroup.spawn()`
+
+### 4.2 factory kwargs 合并
+
+主进程先解析与 factory 签名无关的静态参数：
+
+```text
+factory_args
+< runtime_overrides
+< typed runtime 映射
+```
+
+其中 `server_args_overrides` 在 `factory_args` 与 `runtime_overrides` 之间做一层 dict merge；其他 key 直接由 `runtime_overrides` 覆盖。
+
+typed runtime 当前包括：
+
+- `runtime.max_seq_len`
+- `runtime.video_fps`
+- `runtime.sglang_server_args.mem_fraction_static`
+- `runtime.resources.total_gpu_memory_fraction`
+
+`max_seq_len`/`video_fps` 通过 stage 的 `runtime_arg_map` 转为具体 factory 参数名；没有映射会报错。typed `mem_fraction_static` 被放入 `server_args_overrides`。
+
+子进程导入 factory 后，才按其 signature 注入标准默认参数：
+
+- `model_path`
+- `gpu_id`
+- `total_gpu_memory_fraction`
+
+仅当 factory 声明该参数且用户/前序合并尚未设置时才注入。这些是 fallback，不会覆盖显式 factory kwargs。
+
+### 4.3 owner 与派生值
+
+| 值 | source of truth / owner | 跨进程形式 |
+| --- | --- | --- |
+| Pipeline topology | `PipelineConfig` | 展开为 worker spec 字段 |
+| stage GPU | placement planner | `StageLaunchConfig.gpu_id` |
+| TP rank/size | stage config + runner | 每 rank spec |
+| NCCL port | 主进程 `_NcclPortAllocator` | factory arg |
+| IPC endpoints | runtime preparation | spec 中的字符串 |
+| `total_gpu_memory_fraction` | typed stage resources | factory default |
+| cumulative process memory fraction | process 构造顺序 | `process_total_gpu_memory_fraction` factory default |
+| factory implementation | `StageConfig.factory` | dotted path，子进程 import |
+| `ServerArgs` | worker 内 stage factory | 不跨进程 |
+| `ModelConfig` | worker 内 `ModelWorker` | 不跨进程 |
+| `PortArgs` | worker 内 upstream runner | 不跨进程 |
+
+一个非 TP process 可以包含多个 stage；它们共享 OS process 和 event loop。TP stage 则每 rank 一个独占 process，只有 rank 0 拥有外部 stage IO。
+
+## 5. SGLang `ServerArgs` 链路
+
+SGLang AR stage factory 通常把模型 generation defaults 与 `server_args_overrides` 合并，再调用 `build_sglang_server_args()`。公共 builder 提供：
+
+- `model_path`
+- `trust_remote_code=True`
+- `tp_size=1`、`pp_size=1`
+- prefill/batch 默认值
+- `random_seed=123`
+- `context_length`
+
+显式 overrides 在公共默认值之后更新。Omni 还会把历史的 `cuda_graph_max_bs`/`cuda_graph_bs` 转为 SGLang 0.5.16 decode 字段，并拒绝冲突别名。`enable_dp_attention` 当前明确不支持。
+
+`ServerArgs` 在 worker 内创建，随后由同一进程的 `ModelWorker`、SGLang `ModelRunner` 和 `OmniScheduler` 共享。`ModelConfig.from_server_args()` 也在 worker 内执行，再应用模型 architecture/HF config 和 quantization 适配。
+
+解析后的少量 runtime mutation 必须通过仓库 wrapper `override_server_args(server_args, source, **updates)`，由 SGLang 0.5.16 的 `ServerArgs.override()` 记录 source。当前用途包括：
+
+- 延迟并恢复 CUDA graph capture；
+- auto memory fraction 上扣除 encoder reserve；
+- backend/quantization 兼容调整；
+- weight update 后同步 model path/version。
+
+因此 merged Pipeline dump 不是 `ServerArgs` 的最终快照。准确调试应同时检查：
+
+1. merged Pipeline；
+2. stage 最终 factory kwargs；
+3. worker 日志中的 SGLang runtime configuration；
+4. 带 source 的 `ServerArgs.override()`。
+
+主要实现：
+
+- `sglang_omni/scheduling/sglang_backend/server_args_builder.py`
+- `sglang_omni/scheduling/engine_factory.py`
+- `sglang_omni/model_runner/model_worker.py`
+- `sglang_omni/vendor/sglang/server_args.py`
+
+## 6. 两个显存 fraction 不同
+
+`total_gpu_memory_fraction` 和 `mem_fraction_static` 不能互换：
+
+- `runtime.resources.total_gpu_memory_fraction` 是 placement/process planner 使用的**物理 GPU 总显存预算**。多个 process/stage 同 GPU 时，planner 用它检查总和和构造顺序。
+- `runtime.sglang_server_args.mem_fraction_static` 是传给 SGLang 的**静态/KV 内存参数**，语义受 SGLang 模型权重加载后的可用显存影响。
+
+前者 owner 是 typed resources，后者 owner 是 typed SGLang runtime。为防止模糊来源：
+
+- `total_gpu_memory_fraction` 出现在 `factory_args`/`runtime_overrides` 会失败；
+- `mem_fraction_static` 同时由 typed runtime 和兼容 `server_args_overrides` 设置会失败；
+- `process_total_gpu_memory_fraction` 完全由 runner 根据同 process、同 GPU stage 的加载顺序派生，用户不能设置。
+
+Qwen colocated 示例只在 `stage_overrides.*.runtime.resources` 中声明物理预算；若不显式 pin `mem_fraction_static`，SGLang 可以继续 auto-size，再由可选 `encoder_mem_reserve` 扣除 encoder headroom。
+
+## 7. Process override 与配置安全边界
+
+`--isolate-stage` 和 `--stage-process` 修改的是 stage 的 OS process group，而不是 Pipeline routing。
+
+应用 override 时系统会：
+
+1. 深拷贝当前 config；
+2. 用真实 stage 名或模型公开 isolation role 解析目标；
+3. 拒绝 TP stage，因为 TP 已经是一 rank 一进程；
+4. 计算相对原 topology 新增的跨进程 edge；
+5. 只允许模型通过 `process_safe_edges()` 声明安全的 edge；
+6. 按 `process_edge_resources()` 补充缺失的 typed memory recommendation；
+7. 重建 topology 并验证最终 process group。
+
+安全性以 edge 为单位，因为同一个 stage 被移动后，只有真正跨进程的 handoff 才需要可序列化 payload 和 process-local state 重建能力。显存预算充足不代表 handoff 一定安全。
+
+实现位于 `sglang_omni/config/process_overrides.py`；对应测试覆盖 unknown role、重复 assignment、TP 拒绝、unsafe edge 和 resource recommendation。
+
+## 8. Router 的独立配置体系
+
+Router 不是 Pipeline 的另一种 YAML loader。它是独立 HTTP process，前置于多个完整 `sgl-omni serve` worker。
+
+### 8.1 三种 worker source
+
+Router worker 来源三选一：
+
+1. `--worker-urls URL...`：CLI 声明同构 worker pool；
+2. `--worker-config FILE.json`：JSON 声明每个 worker 的 URL、model 和 capabilities；
+3. `--launcher-config FILE.yaml`：Router 在本机启动并管理完整 worker 副本。
+
+`--launcher-config` 与 `--worker-urls`、`--worker-config` 互斥。`--model` 也不能与 launcher YAML 或 per-worker JSON 共用，因为 model 应由对应 worker source 提供。
+
+### 8.2 Router CLI 参数
+
+| 参数 | 默认值 | 作用 |
+| --- | --- | --- |
+| `--host` | `0.0.0.0` | Router bind host |
+| `--port` | `8000` | Router bind port |
+| `--worker-urls` | `None` | 同构 worker URLs |
+| `--worker-config` | `None` | 异构 worker JSON |
+| `--launcher-config` | `None` | managed local worker YAML |
+| `--policy` | `round_robin` | `round_robin/least_request/random` |
+| `--model` | `None` | `worker-urls` 模式的统一 model |
+| `--request-timeout-secs` | `1800` | 上游请求超时 |
+| `--max-payload-size` | `512 MiB` | Router request body 上限 |
+| `--max-connections` | auto | admission/pool 基准，默认 `128 × workers`，上限 4096 |
+| `--max-inflight` | `None` | 可选独立 admission cap；默认跟随 connections |
+| `--health-failure-threshold` | `3` | 标记 unhealthy 前连续失败数 |
+| `--health-success-threshold` | `2` | 恢复 healthy 前连续成功数 |
+| `--health-check-timeout-secs` | `5` | 单次 health check 超时 |
+| `--health-check-interval-secs` | `10` | health check 间隔 |
+| `--health-check-endpoint` | `/health` | worker 健康端点 |
+| `--log-level` | `info` | Router/Uvicorn 日志；非法值当前回退为 `INFO` |
+| `--strict-limits` | `False` | nofile 不足时从 warning 改为启动失败 |
+| `--admin-api-key` | `None` | 直接传给 Router app，也可来自环境变量 |
+
+Router 自身的 host、port、policy、health 和连接参数只来自 CLI，不与 launcher YAML 合并。
+
+### 8.3 Launcher YAML 到 worker argv
+
+Launcher YAML 固定包含顶层 `launcher`：
+
+```yaml
+launcher:
+  backend: local
+  model_path: Qwen/Qwen3-Omni-30B-A3B-Instruct
+  model_name: qwen3-omni
+  num_workers: 2
+  num_gpus_per_worker: 1
+  worker_host: 127.0.0.1
+  worker_base_port: 8011
+  worker_extra_args: "--config examples/configs/qwen3_omni_colocated_h20.yaml --colocate"
+  wait_timeout: 600
+```
+
+`LocalLauncherConfig` 使用 `extra="forbid"`，校验 worker 数量、端口范围、GPU assignments 和 capabilities。每个 worker 的命令由 Router 重建：
+
+```text
+sgl-omni serve
+  --model-path <launcher.model_path>
+  --host <launcher.worker_host>
+  --port <allocated port>
+  [--model-name <launcher.model_name>]
+  <shlex.split(worker_extra_args)>
+```
+
+GPU assignment 不写入 Pipeline，而通过每个 subprocess 的 `CUDA_VISIBLE_DEVICES` 传递。Router 等待所有 worker `/health` 成功后才创建可路由 pool；退出时终止这些 worker 的 process group。
+
+这里可以嵌套第二层 Pipeline YAML：`worker_extra_args` 中的 `--config` 由 worker 的 `ConfigManager` 加载。launcher 总是同时生成显式 `--model-path`，因此 worker 内该值会覆盖嵌套 Pipeline YAML 的 `model_path`。
+
+主要实现：
+
+- `sglang_omni_router/launcher/config.py`
+- `sglang_omni_router/launcher/local.py`
+- `sglang_omni_router/serve.py`
+- `sglang_omni_router/config.py`
+
+## 9. 校验、失败路径与当前限制
+
+### 9.1 分层校验
+
+配置校验并不集中在一处：
+
+- **Typer/argparse**：基本类型、choice、repeatable option；
+- **CLI helper**：range、互斥、model capability、role map、TP/GPU shape；
+- **Pydantic schema**：未知字段、stage 唯一性、routing、fan-in、TP alias、GPU list、process；
+- **runtime adapter**：typed/untyped source ownership和 factory 参数冲突；
+- **placement/topology planner**：同 GPU budget、process group 和 TP placement；
+- **worker factory/SGLang**：模型专属 batch、backend、quantization 和 CUDA graph 约束。
+
+典型失败包括：
+
+- YAML 缺少/未知 `config_cls`，或顶层不是 mapping；
+- dotted path 不存在、list index 越界、末尾 key 缺 value；
+- complex 值误用 dotted scalar 通道；
+- `next` 与 `terminal` 未二选一，或引用未知 stage；
+- `tp_size`、`parallelism.tp` 与 GPU list 不一致；
+- 非 TP stage 没有 `process`；
+- 同 GPU 多 process 缺少 typed memory budget，或总和超过 placement limit；
+- process override 新增了模型未声明安全的 cross-process edge；
+- 同一运行时值从 typed 与兼容 untyped 通道重复提供；
+- IPC Unix socket 路径超过系统长度限制；
+- worker startup 失败或超时。
+
+### 9.2 当前限制
+
+- 没有独立、版本化的 Pipeline YAML JSON Schema；实际 schema 由 `config_cls` 动态选择的 Pydantic 子类决定。
+- Pipeline YAML 没有 include/extends；可复用默认来自 Python 配置类继承。
+- dotted CLI 只做 scalar conversion，不能视为通用 YAML 替代。
+- 专用 CLI 与 model factory 参数尚未收敛成一个统一 override primitive，新增参数仍可能需要 role map 和专用 helper。
+- 部分 `ValueError`/`KeyError` 没有统一包装为 `typer.BadParameter`，错误展示格式可能不一致。
+- `sglang_omni/serve/launcher.py` 顶部 docstring 中的 `sglang-omni-server`/JSON 示例没有对应安装入口，当前公开入口是 `sgl-omni serve` 和 YAML。
+- Router `worker_extra_args` 是 shell-like 字符串，使用 `shlex.split()`；重复 launcher 已生成的 option 没有额外冲突检查，应避免重复 `--host`、`--port` 或 `--model-path`。
+
+## 10. 证据与验证入口
+
+核心源文件：
+
+- [`sglang_omni/cli/__init__.py`](../../sglang_omni/cli/__init__.py)：命令树与 extra args 策略
+- [`sglang_omni/cli/serve.py`](../../sglang_omni/cli/serve.py)：全部公共参数和应用顺序
+- [`sglang_omni/cli/config.py`](../../sglang_omni/cli/config.py)：默认配置查看/导出
+- [`sglang_omni/config/manager.py`](../../sglang_omni/config/manager.py)：YAML、dotted path、类型转换和 merge
+- [`sglang_omni/config/schema.py`](../../sglang_omni/config/schema.py)：typed schema 与 topology invariants
+- [`sglang_omni/config/runtime.py`](../../sglang_omni/config/runtime.py)：factory args merge 和 owner 检查
+- [`sglang_omni/config/process_overrides.py`](../../sglang_omni/config/process_overrides.py)：process placement override
+- [`sglang_omni/pipeline/runtime_config.py`](../../sglang_omni/pipeline/runtime_config.py)：runtime planning 和 IPC endpoints
+- [`sglang_omni/pipeline/mp_runner.py`](../../sglang_omni/pipeline/mp_runner.py)：worker spec 构造与 TP 展开
+- [`sglang_omni/pipeline/stage_workers.py`](../../sglang_omni/pipeline/stage_workers.py)：spawn、环境和子进程 factory 构造
+- [`sglang_omni/scheduling/sglang_backend/server_args_builder.py`](../../sglang_omni/scheduling/sglang_backend/server_args_builder.py)：`ServerArgs`
+- [`sglang_omni_router/serve.py`](../../sglang_omni_router/serve.py)：Router CLI 和 source selection
+- [`sglang_omni_router/launcher/config.py`](../../sglang_omni_router/launcher/config.py)：launcher YAML schema
+- [`sglang_omni_router/launcher/local.py`](../../sglang_omni_router/launcher/local.py)：worker argv/env
+
+关键单元测试：
+
+- [`tests/unit_test/qwen3_omni/test_config_manager.py`](../../tests/unit_test/qwen3_omni/test_config_manager.py)
+- [`tests/unit_test/qwen3_omni/test_cli.py`](../../tests/unit_test/qwen3_omni/test_cli.py)
+- [`tests/unit_test/pipeline/test_runtime_schema.py`](../../tests/unit_test/pipeline/test_runtime_schema.py)
+- [`tests/unit_test/pipeline/test_runtime_adapter.py`](../../tests/unit_test/pipeline/test_runtime_adapter.py)
+- [`tests/unit_test/pipeline/test_topology.py`](../../tests/unit_test/pipeline/test_topology.py)
+- [`tests/unit_test/pipeline/test_stage_process_env.py`](../../tests/unit_test/pipeline/test_stage_process_env.py)
+- [`tests/unit_test/pipeline/test_ipc.py`](../../tests/unit_test/pipeline/test_ipc.py)
+- [`tests/unit_test/serve/test_generation_server_args.py`](../../tests/unit_test/serve/test_generation_server_args.py)
+- [`tests/unit_test/scheduling/test_engine_factory.py`](../../tests/unit_test/scheduling/test_engine_factory.py)
+- [`tests/unit_test/router/test_core.py`](../../tests/unit_test/router/test_core.py)
+
+阅读或修改配置时，推荐按以下顺序定位：
+
+1. 用 `sgl-omni config view` 确认模型 Python 默认；
+2. 检查 YAML 是紧凑覆盖还是完整 stages replacement；
+3. 按 `serve()` 调用顺序确认 dotted 与专用 CLI 的最终写入；
+4. 在 `resolve_stage_static_factory_args()` 确认 stage factory kwargs；
+5. 在 worker 的 ServerArgs builder 和 runtime override 日志确认最终 SGLang 配置；
+6. 若问题只出现在多进程/TP，检查 worker spec、env mapping 和 placement/topology plan。

--- a/docs/developer_reference/main.md
+++ b/docs/developer_reference/main.md
@@ -19,6 +19,7 @@ HTTP API -> Client -> Coordinator -> Stage -> Scheduler -> ModelRunner -> model 
 | [Stage](./pipeline.md)            | Control-plane IO, relay IO, fan-in, stream routing, scheduler inbox/outbox bridging    |
 | [Scheduler](./pipeline.md)        | Per-stage execution loop and failure propagation to stage outbox                       |
 | [ModelRunner](./pipeline.md)      | AR forward preparation, model forward dispatch, output extraction                      |
+| [Configuration](./configuration.md) | CLI/YAML sources, precedence, runtime argument ownership, and Router worker configuration |
 | [Communication](./communication.md) | Control-plane messages and relay data transfer between stages                         |
 | [TTS Integration](./tts_model_integration.md) | Checklist and lifecycle rules for adding TTS model families                         |
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -114,6 +114,7 @@ Supported Models
    developer_reference/apiserver_design.md
    developer_reference/pipeline.md
    developer_reference/config.md
+   developer_reference/configuration.md
    developer_reference/communication.md
    developer_reference/reference_encode_service.md
    developer_reference/profiler.md


### PR DESCRIPTION
## Summary

- Document the current CLI, Pipeline YAML, Router YAML, and runtime configuration flow.
- Propose a canonical schema, source-aware `ConfigPatch`, and unified `ConfigResolver` with a phased compatibility plan.
- Provide the configuration interface refactor proposal in both English and Chinese.
- Add the configuration survey to the developer-reference navigation.

## Test plan

- [x] Run pre-commit checks on all changed documentation.
- [x] Verify that the English and Chinese proposals have matching heading and code-block structure.
- [ ] Run the full Sphinx documentation build; the local environment is currently missing `sphinx_tabs`.

## Tracking

Tracks #1466.
