### PR TITLE
perf(qwen3-asr): vectorize decode-step mrope positions

### DIFF
--- a/sglang_omni/models/qwen3_asr/engine_builder.py
+++ b/sglang_omni/models/qwen3_asr/engine_builder.py
@@ -9,7 +9,7 @@ from typing import Any
 from sglang.srt.managers.mm_utils import init_mm_embedding_cache
 from transformers import AutoFeatureExtractor, AutoTokenizer
 
-from sglang_omni.models.qwen3_asr import request_builders
+from sglang_omni.models.qwen3_asr import mrope_fast_path, request_builders
 from sglang_omni.models.qwen3_asr.audio_lengths import (
     qwen3_asr_max_audio_tokens,
     qwen3_asr_max_output_tokens,
@@ -142,6 +142,9 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
 
     def validate_before_infrastructure(self, server_args: Any) -> None:
         super().validate_before_infrastructure(server_args)
+        # Replace the per-request decode mrope-position loop with a vectorized
+        # equivalent before any forward runs.
+        mrope_fast_path.apply_asr_mrope_fast_path()
         logger.info(
             "Qwen3-ASR runtime profile: dtype=%s attention_backend=%s "
             "mm_attention_backend=%s cuda_graph=%s cuda_graph_bs=%s "

--- a/sglang_omni/models/qwen3_asr/mrope_fast_path.py
+++ b/sglang_omni/models/qwen3_asr/mrope_fast_path.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Vectorized decode-step MRoPE positions for degenerate ASR inputs.
+
+Qwen3-ASR inherits mrope_section from the Omni thinker config, so sglang treats
+the model as mrope and rebuilds mrope_positions per request on every decode
+step. ASR has no spatial axes, so that work is pure overhead.
+
+Can set env SGLANG_OMNI_ASR_FAST_MROPE=0 to disable.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+# Attribute stamped by request_builders on MultimodalInputs it constructs with
+# degenerate (text-equivalent) mrope: identical rows, delta == 0.
+DEGENERATE_MROPE_FLAG = "_asr_degenerate_mrope"
+
+_orig_compute_mrope_positions: Any = None
+
+
+def _all_degenerate(multimodal_inputs: list[Any]) -> bool:
+    for mm_input in multimodal_inputs:
+        if mm_input is not None and not getattr(mm_input, DEGENERATE_MROPE_FLAG, False):
+            return False
+    return True
+
+
+def _fast_compute_mrope_positions(self: Any, model_runner: Any, batch: Any) -> None:
+    """Drop-in replacement for ForwardBatch._compute_mrope_positions.
+
+    Upstream rebuilds the positions with a per-request loop on every decode
+    step -- one (3, 1) tensor per request, then a concatenate and a device copy, ref:
+    https://github.com/sgl-project/sglang/blob/v0.5.16/python/sglang/srt/model_executor/forward_batch_info.py#L1095-L1109
+    Every degenerate ASR request lands on seq_len - 1, so the loop collapses into one broadcast.
+    """
+    if not (self.forward_mode.is_decode() and _all_degenerate(batch.multimodal_inputs)):
+        _orig_compute_mrope_positions(self, model_runner, batch)
+        return
+
+    row = self.seq_lens_cpu.to(torch.int64) - 1
+    mrope_positions = (
+        row.unsqueeze(0)
+        .expand(3, -1)
+        .contiguous()
+        .to(device=model_runner.device, non_blocking=True)
+    )
+
+    self.mrope_positions = mrope_positions
+
+
+def apply_asr_mrope_fast_path() -> None:
+    """Patch ForwardBatch._compute_mrope_positions with the fast path."""
+    global _orig_compute_mrope_positions
+
+    if os.environ.get("SGLANG_OMNI_ASR_FAST_MROPE", "1") == "0":
+        logger.info("[qwen3-asr] fast mrope decode path disabled via env")
+        return
+    if _orig_compute_mrope_positions is not None:
+        return
+
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+    _orig_compute_mrope_positions = (
+        ForwardBatch._compute_mrope_positions
+    )  # save the original function
+    ForwardBatch._compute_mrope_positions = (
+        _fast_compute_mrope_positions  # replace with the fast path
+    )
+    logger.info("[qwen3-asr] fast mrope decode path applied")

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -36,6 +36,7 @@ from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 from sglang_omni.utils.audio import AudioDecodeError
 
+from . import mrope_fast_path
 from .audio_lengths import (
     QWEN3_ASR_OUTPUT_TOKENS_PER_SECOND,
     qwen3_asr_num_audio_tokens,
@@ -316,6 +317,9 @@ def make_qwen3_asr_scheduler_adapters(
         positions = torch.arange(seq_len, dtype=torch.long)
         mm_inputs.mrope_positions = positions.unsqueeze(0).expand(3, -1).clone()
         mm_inputs.mrope_position_delta = torch.tensor([0], dtype=torch.long)
+        # Mark the input as degenerate-mrope so the vectorized decode fast path
+        # (mrope_fast_path.py) can skip the per-request position loop for it.
+        setattr(mm_inputs, mrope_fast_path.DEGENERATE_MROPE_FLAG, True)
 
         temperature = float(params.get("temperature") or 0.0)
         logger.debug(

--- a/tests/unit_test/models/qwen3_asr/test_mrope_fast_path.py
+++ b/tests/unit_test/models/qwen3_asr/test_mrope_fast_path.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Byte-identity tests for the vectorized ASR decode mrope fast path."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+
+from sglang_omni.models.qwen3_asr import mrope_fast_path
+
+_RUNNER = SimpleNamespace(device="cpu")
+_FAST = mrope_fast_path._fast_compute_mrope_positions
+_ORIG = ForwardBatch._compute_mrope_positions
+
+
+@pytest.fixture(autouse=True)
+def _upstream(monkeypatch):
+    monkeypatch.setattr(
+        "sglang.srt.model_executor.forward_batch_info.get_server_args",
+        lambda: SimpleNamespace(rl_on_policy_target=None),
+    )
+    monkeypatch.setattr(mrope_fast_path, "_orig_compute_mrope_positions", _ORIG)
+
+
+def _mm_input(prompt_len: int, *, delta: int = 0, degenerate: bool = True):
+    """Mirror what request_builders constructs for a Qwen3-ASR request."""
+    positions = torch.arange(prompt_len, dtype=torch.long)
+    mm = SimpleNamespace(
+        mrope_positions=positions.unsqueeze(0).expand(3, -1).clone(),
+        mrope_position_delta=torch.tensor([delta], dtype=torch.long),
+        mrope_position_delta_repeated_cache=None,
+    )
+    if degenerate:
+        setattr(mm, mrope_fast_path.DEGENERATE_MROPE_FLAG, True)
+    return mm
+
+
+def _run(fn, mode, seq_lens, mm_inputs, **batch_fields):
+    fb = object.__new__(ForwardBatch)
+    fb.forward_mode = mode
+    fb.seq_lens_cpu = torch.tensor(seq_lens, dtype=torch.int64)
+    fb.mrope_positions = None
+    fn(fb, _RUNNER, SimpleNamespace(multimodal_inputs=mm_inputs, **batch_fields))
+    return fb.mrope_positions
+
+
+@pytest.mark.parametrize(
+    "seq_lens,prompt_lens",
+    [
+        ([73], [65]),
+        ([73, 5, 129, 1], [65, 3, 100, 1]),
+        ([2048, 1, 512], [2000, 1, 500]),
+        ([10, 44], [None, 30]),  # a request with no multimodal input
+    ],
+)
+def test_decode_matches_upstream(seq_lens, prompt_lens):
+    mm = [None if p is None else _mm_input(p) for p in prompt_lens]
+
+    fast = _run(_FAST, ForwardMode.DECODE, seq_lens, mm)
+
+    assert torch.equal(fast, _run(_ORIG, ForwardMode.DECODE, seq_lens, mm))
+    expected = (
+        (torch.tensor(seq_lens, dtype=torch.int64) - 1).unsqueeze(0).expand(3, -1)
+    )
+    assert torch.equal(fast, expected)
+
+
+def test_non_degenerate_falls_back():
+    mm = [_mm_input(40, delta=7, degenerate=False)]
+
+    fast = _run(_FAST, ForwardMode.DECODE, [50], mm)
+
+    assert torch.equal(fast, _run(_ORIG, ForwardMode.DECODE, [50], mm))
+    # delta is honoured, so the seq_len - 1 shortcut was not taken
+    assert fast[0, 0].item() == 50 + 7 - 1
+
+
+def test_extend_falls_back():
+    mm = [_mm_input(20)]
+    fields = {"extend_lens": [4], "prefix_lens": [16]}
+
+    fast = _run(_FAST, ForwardMode.EXTEND, [20], mm, **fields)
+
+    assert torch.equal(fast, _run(_ORIG, ForwardMode.EXTEND, [20], mm, **fields))


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Qwen3-ASR inherits mrope_section from the Omni thinker config, so sglang rebuilds mrope_positions with a per-request loop on every decode step. ASR has no spatial axes, so every request's position is seq_len - 1 and the loop is pure overhead.

## Modifications

In this pr, we replace it with a single broadcast for decode batches stamped degenerate by the ASR request builder; everything else falls back to upstream.

Concretely, `sglang_omni/models/qwen3_asr/mrope_fast_path.py` monkey-patches `ForwardBatch._compute_mrope_positions` when engine build (from `Qwen3ASREngineBuilder.validate_before_infrastructure`, which runs in the process
that owns the decode loop), keeping the original bound as the fallback. The computation lives in sglang, so patching is how we override it without vendoring or forking that file.


## Related Issues

#1396 

## Accuracy Test

I test locally and measured on A6000, PE values are unchanged, and WER is also unaffected. 400 SeedTTS-EN clips at concurrency 32: decode launch.build 4.28ms -> 0.82ms per step, throughput +5.4% cold /+36.8% warm, corpus WER 0.0140 on both.


<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
