### PR TITLE
[NPU] Qwen3-Omni talker support

### DIFF
--- a/sglang_omni/comm/router.py
+++ b/sglang_omni/comm/router.py
@@ -8,6 +8,7 @@ from typing import Any
 import torch
 
 from sglang_omni.comm.data_ref import TransportKind
+from sglang_omni.platforms import current_platform
 from sglang_omni.relay.base import Relay, create_relay
 
 
@@ -77,7 +78,7 @@ class CommRouter:
         if target in self.remote_stage_names:
             return TransportKind.MOONCAKE
         if self.self_is_gpu and target in self.gpu_stage_names:
-            return TransportKind.CUDA_IPC
+            return current_platform.get_intra_node_transport()
         return TransportKind.SHM
 
     def outbound_stream(self, target: str, data: torch.Tensor) -> TransportKind:
@@ -91,7 +92,7 @@ class CommRouter:
         if not data.is_cuda:
             return TransportKind.SHM
         if self.self_is_gpu and target in self.gpu_stage_names:
-            return TransportKind.CUDA_IPC
+            return current_platform.get_intra_node_transport()
         raise ValueError(
             f"cuda stream chunk cannot be sent from {self.stage_name!r} to "
             f"non-GPU target {target!r}"
@@ -101,7 +102,7 @@ class CommRouter:
         if from_stage in self.remote_stage_names:
             return TransportKind.MOONCAKE
         if self.self_is_gpu and from_stage in self.gpu_stage_names:
-            return TransportKind.CUDA_IPC
+            return current_platform.get_intra_node_transport()
         return TransportKind.SHM
 
     def relay(self, kind: TransportKind) -> Relay:
@@ -138,9 +139,12 @@ class CommRouter:
         devices = _tensor_devices(getattr(payload, "data", payload))
         if not devices or devices == {"cpu"}:
             return TransportKind.SHM
-        if "cuda" in devices and devices <= {"cpu", "cuda"}:
+        if current_platform.device_type in devices and devices <= {
+            "cpu",
+            current_platform.device_type,
+        }:
             if self.self_is_gpu and target in self.gpu_stage_names:
-                return TransportKind.CUDA_IPC
+                return current_platform.get_intra_node_transport()
             return TransportKind.SHM
         raise ValueError(f"mixed or unsupported tensor devices in payload: {devices}")
 

--- a/sglang_omni/comm/router.py
+++ b/sglang_omni/comm/router.py
@@ -62,7 +62,10 @@ class CommRouter:
         return target in self.same_process_targets
 
     def can_use_direct_cuda_ipc(self, target: str) -> bool:
-        return target in self._direct_cuda_ipc_targets
+        return (
+            target in self._direct_cuda_ipc_targets
+            and current_platform.get_intra_node_transport() == TransportKind.CUDA_IPC
+        )
 
     def outbound(self, target: str) -> TransportKind:
         if target in self.same_process_targets:

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -7,11 +7,13 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
+from sglang_omni.platforms import current_platform
 from sglang_omni.quantization import (
     needs_quant_config_normalization,
     normalize_quant_config,
     resolve_quant_config,
 )
+from sglang_omni.utils.misc import normalize_quantization
 from sglang_omni.vendor.sglang.server_args import override_server_args
 
 if TYPE_CHECKING:
@@ -150,7 +152,7 @@ class ModelWorker:
         # model_worker backend policy.
         _apply_omni_quantization_adapters(self.model_config)
 
-        effective_quantization = _apply_model_worker_backend_policy(
+        effective_quantization = current_platform.apply_model_worker_backend_policy(
             self.server_args,
             self.model_config,
             self.model_arch_override,
@@ -447,116 +449,6 @@ def _resolve_nccl_port() -> int:
     return port
 
 
-def _apply_model_worker_backend_policy(
-    server_args: ServerArgs,
-    model_config: ModelConfig,
-    model_arch_override: str | None,
-) -> str | None:
-    """Apply Omni backend policy after checkpoint quantization is known."""
-
-    effective_quantization = _normalize_quantization(model_config.quantization)
-    server_quantization = _normalize_quantization(server_args.quantization)
-    if server_quantization is not None:
-        effective_quantization = server_quantization
-
-    moe_runner_backend = server_args.moe_runner_backend
-    is_qwen3_omni_arch = model_arch_override in (
-        "Qwen3OmniTalker",
-        "Qwen3OmniThinkerForCausalLM",
-    )
-    if is_qwen3_omni_arch and server_args.ep_size != 1:
-        raise ValueError(
-            "Qwen3-Omni ModelWorker does not support expert parallelism; "
-            "use ep_size=1."
-        )
-    has_moe = _model_config_has_moe(model_config)
-    has_native_fp8_block_quant = _model_config_has_native_fp8_block_quant(model_config)
-
-    if (
-        model_arch_override == "Qwen3OmniTalker"
-        and effective_quantization is None
-        and moe_runner_backend == "auto"
-    ):
-        # Note:(Chenchen Hong) flashinfer_cutlass MoE deadlocks CUDA-graph
-        # capture on H20 (no H20 kernel coverage); triton captures cleanly there.
-        override_server_args(
-            server_args,
-            "sglang-omni-qwen3-backend-policy",
-            moe_runner_backend=("triton" if _is_h20_device() else "flashinfer_cutlass"),
-        )
-        moe_runner_backend = server_args.moe_runner_backend
-
-    if (
-        is_qwen3_omni_arch
-        and effective_quantization == "fp8"
-        and has_moe
-        and moe_runner_backend == "auto"
-        and has_native_fp8_block_quant
-        and _is_fp8_cutlass_moe_supported()
-    ):
-        override_server_args(
-            server_args,
-            "sglang-omni-qwen3-backend-policy",
-            moe_runner_backend="cutlass",
-        )
-        moe_runner_backend = server_args.moe_runner_backend
-
-    if (
-        is_qwen3_omni_arch
-        and effective_quantization == "fp8"
-        and has_moe
-        and moe_runner_backend == "cutlass"
-    ):
-        if not has_native_fp8_block_quant:
-            raise ValueError(
-                "Qwen3-Omni FP8 CUTLASS MoE requires a native serialized "
-                "block-FP8 checkpoint with weight_block_size."
-            )
-
-    if (
-        is_qwen3_omni_arch
-        and effective_quantization == "fp8"
-        and moe_runner_backend == "flashinfer_cutlass"
-    ):
-        raise ValueError(
-            "Qwen3-Omni native FP8 checkpoints cannot use "
-            "moe_runner_backend='flashinfer_cutlass'. Leave the backend as "
-            "'auto' so Omni selects a native-FP8-compatible MoE runner."
-        )
-
-    fp8_gemm_backend = _normalize_quantization(server_args.fp8_gemm_runner_backend)
-    if (
-        model_arch_override == "Qwen3OmniTalker"
-        and effective_quantization == "fp8"
-        and has_native_fp8_block_quant
-        and fp8_gemm_backend in (None, "auto")
-    ):
-        # Projected talker prefill has request-dependent FP8 dense GEMM shapes
-        # outside decode CUDA graph replay; DeepGEMM can otherwise JIT there.
-        override_server_args(
-            server_args,
-            "sglang-omni-qwen3-backend-policy",
-            fp8_gemm_runner_backend="triton",
-        )
-        fp8_gemm_backend = server_args.fp8_gemm_runner_backend
-
-    server_quantization = server_args.quantization
-    logger.info(
-        f"Configured SGLang backend policy: arch={model_arch_override} "
-        f"effective_quantization={effective_quantization} "
-        f"server_quantization={server_quantization} "
-        f"moe_runner_backend={moe_runner_backend} "
-        f"fp8_gemm_backend={fp8_gemm_backend}"
-    )
-    return effective_quantization
-
-
-def _normalize_quantization(value: object) -> str | None:
-    if value is None:
-        return None
-    return str(value).lower()
-
-
 def _model_config_has_moe(model_config: ModelConfig) -> bool:
     return hasattr(model_config.hf_text_config, "num_experts_per_tok")
 
@@ -566,23 +458,9 @@ def _model_config_has_native_fp8_block_quant(model_config: ModelConfig) -> bool:
     if quant_dict is None:
         return False
     return (
-        _normalize_quantization(quant_dict.get("quant_method")) == "fp8"
+        normalize_quantization(quant_dict.get("quant_method")) == "fp8"
         and quant_dict.get("weight_block_size") is not None
     )
-
-
-def _is_h20_device() -> bool:
-    """True only on NVIDIA H20 (word-boundary match so "H200" isn't caught)."""
-    try:
-        import re
-
-        import torch
-
-        if not torch.cuda.is_available():
-            return False
-        return bool(re.search(r"\bH20\b", torch.cuda.get_device_name(0)))
-    except Exception:
-        return False
 
 
 def _is_fp8_cutlass_moe_supported() -> bool:

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -152,6 +152,11 @@ class ModelWorker:
         # model_worker backend policy.
         _apply_omni_quantization_adapters(self.model_config)
 
+        _apply_model_worker_backend_common_policy(
+            self.server_args,
+            self.model_arch_override,
+        )
+
         effective_quantization = current_platform.apply_model_worker_backend_policy(
             self.server_args,
             self.model_config,
@@ -447,6 +452,21 @@ def _resolve_nccl_port() -> int:
 
     os.environ["MASTER_PORT"] = str(port)
     return port
+
+
+def _apply_model_worker_backend_common_policy(
+    server_args: ServerArgs,
+    model_arch_override: str | None,
+) -> str | None:
+    is_qwen3_omni_arch = model_arch_override in (
+        "Qwen3OmniTalker",
+        "Qwen3OmniThinkerForCausalLM",
+    )
+    if is_qwen3_omni_arch and server_args.ep_size != 1:
+        raise ValueError(
+            "Qwen3-Omni ModelWorker does not support expert parallelism; "
+            "use ep_size=1."
+        )
 
 
 def _apply_omni_quantization_adapters(model_config: ModelConfig) -> None:

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -449,21 +449,6 @@ def _resolve_nccl_port() -> int:
     return port
 
 
-def _is_fp8_cutlass_moe_supported() -> bool:
-    """Mirror SGLang 0.5.16's CUTLASS FP8 MoE assertions."""
-    from sglang.srt.layers.quantization.fp8_utils import cutlass_fp8_supported
-    from sglang.srt.utils import (
-        is_sm90_supported,
-        is_sm100_supported,
-        is_sm120_supported,
-    )
-
-    return bool(
-        cutlass_fp8_supported()
-        and (is_sm90_supported() or is_sm100_supported() or is_sm120_supported())
-    )
-
-
 def _apply_omni_quantization_adapters(model_config: ModelConfig) -> None:
     """Apply Omni-specific quantization adapters before SGLang builds its config.
 

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -13,7 +13,7 @@ from sglang_omni.quantization import (
     normalize_quant_config,
     resolve_quant_config,
 )
-from sglang_omni.utils.misc import normalize_quantization
+from sglang_omni.utils.misc import model_config_has_moe
 from sglang_omni.vendor.sglang.server_args import override_server_args
 
 if TYPE_CHECKING:
@@ -449,20 +449,6 @@ def _resolve_nccl_port() -> int:
     return port
 
 
-def _model_config_has_moe(model_config: ModelConfig) -> bool:
-    return hasattr(model_config.hf_text_config, "num_experts_per_tok")
-
-
-def _model_config_has_native_fp8_block_quant(model_config: ModelConfig) -> bool:
-    quant_dict = resolve_quant_config(model_config.hf_config)
-    if quant_dict is None:
-        return False
-    return (
-        normalize_quantization(quant_dict.get("quant_method")) == "fp8"
-        and quant_dict.get("weight_block_size") is not None
-    )
-
-
 def _is_fp8_cutlass_moe_supported() -> bool:
     """Mirror SGLang 0.5.16's CUTLASS FP8 MoE assertions."""
     from sglang.srt.layers.quantization.fp8_utils import cutlass_fp8_supported
@@ -501,7 +487,7 @@ def _initialize_model_worker_backend_globals(
 ) -> None:
     """Initialize backend globals needed by direct workers before model loading."""
 
-    if _model_config_has_moe(model_config):
+    if model_config_has_moe(model_config):
         from sglang.srt.layers.moe import initialize_moe_config
 
         initialize_moe_config(server_args)

--- a/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
@@ -58,28 +58,30 @@ class _TorchCudaApi:
     """Small injectable boundary around CUDA-only operations."""
 
     def device_context(self, device: torch.device) -> AbstractContextManager[Any]:
-        return torch.cuda.device(device)
+        return torch.get_device_module().device(device)
 
     def memory_stats(self, device: torch.device) -> dict[str, int]:
-        free_bytes, total_bytes = torch.cuda.mem_get_info(device)
+        free_bytes, total_bytes = torch.get_device_module().mem_get_info(device)
         return {
-            "allocated_bytes": int(torch.cuda.memory_allocated(device)),
-            "reserved_bytes": int(torch.cuda.memory_reserved(device)),
-            "max_reserved_bytes": int(torch.cuda.max_memory_reserved(device)),
+            "allocated_bytes": int(torch.get_device_module().memory_allocated(device)),
+            "reserved_bytes": int(torch.get_device_module().memory_reserved(device)),
+            "max_reserved_bytes": int(
+                torch.get_device_module().max_memory_reserved(device)
+            ),
             "free_bytes": int(free_bytes),
             "total_bytes": int(total_bytes),
         }
 
     def empty_cache(self) -> None:
-        torch.cuda.empty_cache()
+        torch.get_device_module().empty_cache()
 
     def new_static_input(
         self, shape: tuple[int, int, int], *, device: torch.device
     ) -> torch.Tensor:
         return torch.zeros(shape, dtype=torch.long, device=device)
 
-    def new_stream(self, device: torch.device) -> torch.cuda.Stream:
-        return torch.cuda.Stream(device=device)
+    def new_stream(self, device: torch.device) -> torch.Stream:
+        return torch.get_device_module().Stream(device=device)
 
     def warmup(
         self,
@@ -88,17 +90,17 @@ class _TorchCudaApi:
         *,
         iterations: int,
         device: torch.device,
-        stream: torch.cuda.Stream,
+        stream: torch.Stream,
     ) -> None:
-        current_stream = torch.cuda.current_stream(device)
+        current_stream = torch.get_device_module().current_stream(device)
         stream.wait_stream(current_stream)
-        with torch.cuda.stream(stream), torch.inference_mode():
+        with torch.get_device_module().stream(stream), torch.inference_mode():
             for _ in range(iterations):
                 model(static_input)
         current_stream.wait_stream(stream)
 
     def graph_pool_handle(self) -> Any:
-        return torch.cuda.graph_pool_handle()
+        return torch.get_device_module().graph_pool_handle()
 
     def capture(
         self,
@@ -106,14 +108,14 @@ class _TorchCudaApi:
         static_input: torch.Tensor,
         *,
         pool: Any,
-        stream: torch.cuda.Stream,
-    ) -> tuple[torch.cuda.CUDAGraph, torch.Tensor]:
-        current_stream = torch.cuda.current_stream(static_input.device)
+        stream: torch.Stream,
+    ) -> tuple[Any, torch.Tensor]:
+        current_stream = torch.get_device_module().current_stream(static_input.device)
         stream.wait_stream(current_stream)
-        graph = torch.cuda.CUDAGraph()
+        graph = torch.get_device_module().CUDAGraph()
         try:
             with torch.inference_mode():
-                with torch.cuda.graph(
+                with torch.get_device_module().graph(
                     graph,
                     pool=pool,
                     stream=stream,
@@ -121,15 +123,15 @@ class _TorchCudaApi:
                 ):
                     static_output = model(static_input)
         finally:
-            # torch.cuda.graph.__exit__ calls capture_end before restoring its
+            # torch.get_device_module().graph.__exit__ calls capture_end before restoring its
             # stream context. If capture_end raises, restore explicitly using
             # the original stream's device-aware identity.
-            torch.cuda.set_stream(current_stream)
+            torch.get_device_module().set_stream(current_stream)
         current_stream.wait_stream(stream)
         return graph, static_output
 
     def synchronize(self, device: torch.device) -> None:
-        torch.cuda.synchronize(device)
+        torch.get_device_module().synchronize(device)
 
     def is_cuda_tensor(self, tensor: torch.Tensor) -> bool:
         return tensor.is_cuda
@@ -159,7 +161,7 @@ class Code2WavCudaGraphRunner:
     ) -> None:
         self._model = model
         self._device = torch.device(device)
-        if self._device.type != "cuda" or self._device.index is None:
+        if self._device.type == "cpu" or self._device.index is None:
             raise ValueError("Code2Wav CUDA graphs require a concrete CUDA device")
         self._num_quantizers = int(num_quantizers)
         if self._num_quantizers <= 0:

--- a/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
@@ -58,30 +58,28 @@ class _TorchCudaApi:
     """Small injectable boundary around CUDA-only operations."""
 
     def device_context(self, device: torch.device) -> AbstractContextManager[Any]:
-        return torch.get_device_module().device(device)
+        return torch.cuda.device(device)
 
     def memory_stats(self, device: torch.device) -> dict[str, int]:
-        free_bytes, total_bytes = torch.get_device_module().mem_get_info(device)
+        free_bytes, total_bytes = torch.cuda.mem_get_info(device)
         return {
-            "allocated_bytes": int(torch.get_device_module().memory_allocated(device)),
-            "reserved_bytes": int(torch.get_device_module().memory_reserved(device)),
-            "max_reserved_bytes": int(
-                torch.get_device_module().max_memory_reserved(device)
-            ),
+            "allocated_bytes": int(torch.cuda.memory_allocated(device)),
+            "reserved_bytes": int(torch.cuda.memory_reserved(device)),
+            "max_reserved_bytes": int(torch.cuda.max_memory_reserved(device)),
             "free_bytes": int(free_bytes),
             "total_bytes": int(total_bytes),
         }
 
     def empty_cache(self) -> None:
-        torch.get_device_module().empty_cache()
+        torch.cuda.empty_cache()
 
     def new_static_input(
         self, shape: tuple[int, int, int], *, device: torch.device
     ) -> torch.Tensor:
         return torch.zeros(shape, dtype=torch.long, device=device)
 
-    def new_stream(self, device: torch.device) -> torch.Stream:
-        return torch.get_device_module().Stream(device=device)
+    def new_stream(self, device: torch.device) -> torch.cuda.Stream:
+        return torch.cuda.Stream(device=device)
 
     def warmup(
         self,
@@ -90,17 +88,17 @@ class _TorchCudaApi:
         *,
         iterations: int,
         device: torch.device,
-        stream: torch.Stream,
+        stream: torch.cuda.Stream,
     ) -> None:
-        current_stream = torch.get_device_module().current_stream(device)
+        current_stream = torch.cuda.current_stream(device)
         stream.wait_stream(current_stream)
-        with torch.get_device_module().stream(stream), torch.inference_mode():
+        with torch.cuda.stream(stream), torch.inference_mode():
             for _ in range(iterations):
                 model(static_input)
         current_stream.wait_stream(stream)
 
     def graph_pool_handle(self) -> Any:
-        return torch.get_device_module().graph_pool_handle()
+        return torch.cuda.graph_pool_handle()
 
     def capture(
         self,
@@ -108,14 +106,14 @@ class _TorchCudaApi:
         static_input: torch.Tensor,
         *,
         pool: Any,
-        stream: torch.Stream,
-    ) -> tuple[Any, torch.Tensor]:
-        current_stream = torch.get_device_module().current_stream(static_input.device)
+        stream: torch.cuda.Stream,
+    ) -> tuple[torch.cuda.CUDAGraph, torch.Tensor]:
+        current_stream = torch.cuda.current_stream(static_input.device)
         stream.wait_stream(current_stream)
-        graph = torch.get_device_module().CUDAGraph()
+        graph = torch.cuda.CUDAGraph()
         try:
             with torch.inference_mode():
-                with torch.get_device_module().graph(
+                with torch.cuda.graph(
                     graph,
                     pool=pool,
                     stream=stream,
@@ -123,15 +121,15 @@ class _TorchCudaApi:
                 ):
                     static_output = model(static_input)
         finally:
-            # torch.get_device_module().graph.__exit__ calls capture_end before restoring its
+            # torch.cuda.graph.__exit__ calls capture_end before restoring its
             # stream context. If capture_end raises, restore explicitly using
             # the original stream's device-aware identity.
-            torch.get_device_module().set_stream(current_stream)
+            torch.cuda.set_stream(current_stream)
         current_stream.wait_stream(stream)
         return graph, static_output
 
     def synchronize(self, device: torch.device) -> None:
-        torch.get_device_module().synchronize(device)
+        torch.cuda.synchronize(device)
 
     def is_cuda_tensor(self, tensor: torch.Tensor) -> bool:
         return tensor.is_cuda
@@ -161,7 +159,7 @@ class Code2WavCudaGraphRunner:
     ) -> None:
         self._model = model
         self._device = torch.device(device)
-        if self._device.type == "cpu" or self._device.index is None:
+        if self._device.type != "cuda" or self._device.index is None:
             raise ValueError("Code2Wav CUDA graphs require a concrete CUDA device")
         self._num_quantizers = int(num_quantizers)
         if self._num_quantizers <= 0:

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -266,7 +266,7 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         graph_eligible: bool = False,
     ) -> tuple[torch.Tensor, dict[str, Any]]:
         with torch.no_grad():
-            torch.get_device_module().set_device(self._device)
+            torch.get_device_module(self._device).set_device(self._device)
             if self._cuda_graph_runner is None:
                 result = Code2WavRunResult(
                     output=self._model(codes),

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -21,6 +21,7 @@ from sglang_omni.models.qwen3_omni.components.code2wav_cuda_graph import (
     Code2WavRunResult,
     GraphKey,
 )
+from sglang_omni.platforms import current_platform
 from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.profiler.event_recorder import get_recorder as _get_event_recorder
 from sglang_omni.profiler.event_recorder import get_recorder as _get_recorder
@@ -265,8 +266,7 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         graph_eligible: bool = False,
     ) -> tuple[torch.Tensor, dict[str, Any]]:
         with torch.no_grad():
-            if self._device.type == "cuda":
-                torch.cuda.set_device(self._device)
+            torch.get_device_module().set_device(self._device)
             if self._cuda_graph_runner is None:
                 result = Code2WavRunResult(
                     output=self._model(codes),
@@ -531,10 +531,13 @@ def create_code2wav_scheduler(
             "runtime.resources.total_gpu_memory_fraction"
         )
     if gpu_id is not None:
-        device = f"cuda:{gpu_id}"
-    concrete_device = torch.device(device)
-    if concrete_device.type == "cuda" and concrete_device.index is None:
-        concrete_device = torch.device("cuda", torch.cuda.current_device())
+        concrete_device = current_platform.get_device(gpu_id)
+    else:
+        concrete_device = torch.device(device)
+    if concrete_device.type != "cpu" and concrete_device.index is None:
+        concrete_device = current_platform.get_device(
+            torch.get_device_module().current_device()
+        )
     device = str(concrete_device)
     stream_chunk_size = max(int(stream_chunk_size), 1)
     left_context_size = max(int(left_context_size), 0)

--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -23,6 +23,7 @@ from sglang_omni.models.qwen3_omni.hf_config import (
     Qwen3OmniMoeTalkerConfig,
     Qwen3OmniMoeTalkerTextConfig,
 )
+from sglang_omni.platforms import current_platform
 from sglang_omni.quantization import get_weight_preprocessor
 from sglang_omni.sampling.seed import (
     SAMPLING_SEED_MASK,
@@ -447,7 +448,7 @@ class Qwen3OmniMoeTalkerTextModel(nn.Module):
         )
 
         # Decoder layers
-        alt_stream = torch.cuda.Stream()
+        alt_stream = torch.get_device_module().Stream()
         self.layers = make_layers(
             config.num_hidden_layers,
             lambda idx, prefix: Qwen3OmniMoeTalkerDecoderLayer(
@@ -578,7 +579,7 @@ class Qwen3OmniMoeTalkerCodePredictor(nn.Module):
         )
 
         # 5 dense decoder layers
-        alt_stream = torch.cuda.Stream()
+        alt_stream = torch.get_device_module().Stream()
         self.model.layers = nn.ModuleList()
         for idx in range(cp_config.num_hidden_layers):
             # Create a decoder layer similar to Thinker but with dense MLP
@@ -973,7 +974,7 @@ class Qwen3OmniTalker(nn.Module):
             device=device,
         )
         self._sampling_staging_event = (
-            torch.cuda.Event() if device.type == "cuda" else None
+            torch.get_device_module().Event() if device.type != "cpu" else None
         )
         self._decode_prep_rids: list | None = None
         self._decode_prep_out_lens: list[int] = []
@@ -1381,7 +1382,7 @@ class Qwen3OmniTalker(nn.Module):
             custom_params=None,
             custom_logit_processor=None,
             sampling_seed=self._sampling_seeds[:batch_size],
-            device="cuda",
+            device=current_platform.device_type,
             logit_bias=None,
         )
 

--- a/sglang_omni/models/qwen3_omni/components/thinker_model.py
+++ b/sglang_omni/models/qwen3_omni/components/thinker_model.py
@@ -4,12 +4,12 @@ import re
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import torch
-from sgl_kernel import fused_qk_norm_rope
 from torch import nn
 from transformers import PretrainedConfig
 
 from sglang_omni.models.qwen3_omni.hf_config import Qwen3OmniMoeTextConfig
 from sglang_omni.models.weight_loader import default_weight_loader
+from sglang_omni.platforms import current_platform
 from sglang_omni.quantization import get_weight_preprocessor
 from sglang_omni.utils import add_prefix
 from sglang_omni.vendor.sglang.core import ForwardBatch
@@ -44,6 +44,8 @@ from sglang_omni.vendor.sglang.models import (
 )
 from sglang_omni.vendor.sglang.server_args import get_global_server_args
 from sglang_omni.vendor.sglang.utils import make_layers
+
+fused_qk_norm_rope = current_platform.get_fused_qk_norm_rope()
 
 logger = logging.getLogger(__name__)
 
@@ -159,7 +161,7 @@ class Qwen3OmniMoeThinkerTextAttention(nn.Module):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         dual_chunk_attention_config: Optional[dict[str, Any]] = None,
-        alt_stream: Optional[torch.cuda.Stream] = None,
+        alt_stream: Optional[torch.Stream] = None,
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -230,6 +232,7 @@ class Qwen3OmniMoeThinkerTextAttention(nn.Module):
         self.use_fused_qk_norm_rope = (
             get_global_server_args().enable_fused_qk_norm_rope
             and self.compatible_with_fused_qk_norm_rope
+            and fused_qk_norm_rope is not None
         )
         self._used_fused_qk_norm_rope_last_call = False
         self._used_fused_set_kv_buffer_last_call = False
@@ -471,7 +474,7 @@ class Qwen3OmniMoeThinkerTextDecoderLayer(nn.Module):
         layer_id: int,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
-        alt_stream: Optional[torch.cuda.Stream] = None,
+        alt_stream: Optional[torch.Stream] = None,
     ) -> None:
         super().__init__()
         self.config = config
@@ -623,7 +626,7 @@ class Qwen3OmniMoeThinkerTextModel(nn.Module):
             prefix=add_prefix(prefix, "embed_tokens"),
         )
 
-        alt_stream = torch.cuda.Stream()
+        alt_stream = torch.get_device_module().Stream()
         result = make_layers(
             config.num_hidden_layers,
             lambda idx, prefix: Qwen3OmniMoeThinkerTextDecoderLayer(

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -211,7 +211,7 @@ def _code2wav_stage(*, gpu: int, process: str) -> StageConfig:
         factory=f"{_PKG}.components.code2wav_scheduler.create_code2wav_scheduler",
         factory_args={
             "device": current_platform.device_type,
-            "enable_cuda_graph": True,
+            "enable_cuda_graph": current_platform.enable_code2wav_graph(),
         },
         gpu=gpu,
         runtime=StageRuntimeConfig(

--- a/sglang_omni/platforms/cuda.py
+++ b/sglang_omni/platforms/cuda.py
@@ -33,6 +33,21 @@ def _is_h20_device() -> bool:
         return False
 
 
+def _is_fp8_cutlass_moe_supported() -> bool:
+    """Mirror SGLang 0.5.16's CUTLASS FP8 MoE assertions."""
+    from sglang.srt.layers.quantization.fp8_utils import cutlass_fp8_supported
+    from sglang.srt.utils import (
+        is_sm90_supported,
+        is_sm100_supported,
+        is_sm120_supported,
+    )
+
+    return bool(
+        cutlass_fp8_supported()
+        and (is_sm90_supported() or is_sm100_supported() or is_sm120_supported())
+    )
+
+
 class CUDAOmniPlatform(CudaDeviceMixin, OmniPlatform):
     def get_stage_process_env(
         self,

--- a/sglang_omni/platforms/cuda.py
+++ b/sglang_omni/platforms/cuda.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Mapping
 from typing import TYPE_CHECKING
@@ -8,10 +9,14 @@ from sglang.srt.platforms.cuda import CudaDeviceMixin
 from sglang.srt.platforms.rocm import RocmDeviceMixin
 
 from sglang_omni.platforms.interface import OmniPlatform
-from sglang_omni.utils.misc import normalize_quantization
+from sglang_omni.quantization import resolve_quant_config
+from sglang_omni.utils.misc import model_config_has_moe, normalize_quantization
+from sglang_omni.vendor.sglang.server_args import override_server_args
 
 if TYPE_CHECKING:
     from sglang_omni.pipeline.stage_workers import StageLaunchConfig
+
+logger = logging.getLogger(__name__)
 
 
 def _is_h20_device() -> bool:
@@ -90,9 +95,12 @@ class CUDAOmniPlatform(CudaDeviceMixin, OmniPlatform):
                 "Qwen3-Omni ModelWorker does not support expert parallelism; "
                 "use ep_size=1."
             )
-        has_moe = _model_config_has_moe(model_config)
-        has_native_fp8_block_quant = _model_config_has_native_fp8_block_quant(
-            model_config
+        has_moe = model_config_has_moe(model_config)
+        quant_dict = resolve_quant_config(model_config.hf_config)
+        has_native_fp8_block_quant = (
+            quant_dict is not None
+            and normalize_quantization(quant_dict.get("quant_method")) == "fp8"
+            and quant_dict.get("weight_block_size") is not None
         )
 
         if (

--- a/sglang_omni/platforms/cuda.py
+++ b/sglang_omni/platforms/cuda.py
@@ -8,9 +8,24 @@ from sglang.srt.platforms.cuda import CudaDeviceMixin
 from sglang.srt.platforms.rocm import RocmDeviceMixin
 
 from sglang_omni.platforms.interface import OmniPlatform
+from sglang_omni.utils.misc import normalize_quantization
 
 if TYPE_CHECKING:
     from sglang_omni.pipeline.stage_workers import StageLaunchConfig
+
+
+def _is_h20_device() -> bool:
+    """True only on NVIDIA H20 (word-boundary match so "H200" isn't caught)."""
+    try:
+        import re
+
+        import torch
+
+        if not torch.cuda.is_available():
+            return False
+        return bool(re.search(r"\bH20\b", torch.cuda.get_device_name(0)))
+    except Exception:
+        return False
 
 
 class CUDAOmniPlatform(CudaDeviceMixin, OmniPlatform):
@@ -42,6 +57,123 @@ class CUDAOmniPlatform(CudaDeviceMixin, OmniPlatform):
             "SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS": "true",
             "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "false",
         }
+
+    def get_intra_node_transport(self) -> TransportKind:
+        from sglang_omni.comm.data_ref import TransportKind
+
+        return TransportKind.CUDA_IPC
+
+    def get_fused_qk_norm_rope(self):
+        from sgl_kernel import fused_qk_norm_rope
+
+        return fused_qk_norm_rope
+
+    def apply_model_worker_backend_policy(
+        self,
+        server_args: ServerArgs,
+        model_config: ModelConfig,
+        model_arch_override: str | None,
+    ) -> str | None:
+
+        effective_quantization = normalize_quantization(model_config.quantization)
+        server_quantization = normalize_quantization(server_args.quantization)
+        if server_quantization is not None:
+            effective_quantization = server_quantization
+
+        moe_runner_backend = server_args.moe_runner_backend
+        is_qwen3_omni_arch = model_arch_override in (
+            "Qwen3OmniTalker",
+            "Qwen3OmniThinkerForCausalLM",
+        )
+        if is_qwen3_omni_arch and server_args.ep_size != 1:
+            raise ValueError(
+                "Qwen3-Omni ModelWorker does not support expert parallelism; "
+                "use ep_size=1."
+            )
+        has_moe = _model_config_has_moe(model_config)
+        has_native_fp8_block_quant = _model_config_has_native_fp8_block_quant(
+            model_config
+        )
+
+        if (
+            model_arch_override == "Qwen3OmniTalker"
+            and effective_quantization is None
+            and moe_runner_backend == "auto"
+        ):
+            # Note:(Chenchen Hong) flashinfer_cutlass MoE deadlocks CUDA-graph
+            # capture on H20 (no H20 kernel coverage); triton captures cleanly there.
+            override_server_args(
+                server_args,
+                "sglang-omni-qwen3-backend-policy",
+                moe_runner_backend=(
+                    "triton" if _is_h20_device() else "flashinfer_cutlass"
+                ),
+            )
+            moe_runner_backend = server_args.moe_runner_backend
+
+        if (
+            is_qwen3_omni_arch
+            and effective_quantization == "fp8"
+            and has_moe
+            and moe_runner_backend == "auto"
+            and has_native_fp8_block_quant
+            and _is_fp8_cutlass_moe_supported()
+        ):
+            override_server_args(
+                server_args,
+                "sglang-omni-qwen3-backend-policy",
+                moe_runner_backend="cutlass",
+            )
+            moe_runner_backend = server_args.moe_runner_backend
+
+        if (
+            is_qwen3_omni_arch
+            and effective_quantization == "fp8"
+            and has_moe
+            and moe_runner_backend == "cutlass"
+        ):
+            if not has_native_fp8_block_quant:
+                raise ValueError(
+                    "Qwen3-Omni FP8 CUTLASS MoE requires a native serialized "
+                    "block-FP8 checkpoint with weight_block_size."
+                )
+
+        if (
+            is_qwen3_omni_arch
+            and effective_quantization == "fp8"
+            and moe_runner_backend == "flashinfer_cutlass"
+        ):
+            raise ValueError(
+                "Qwen3-Omni native FP8 checkpoints cannot use "
+                "moe_runner_backend='flashinfer_cutlass'. Leave the backend as "
+                "'auto' so Omni selects a native-FP8-compatible MoE runner."
+            )
+
+        fp8_gemm_backend = normalize_quantization(server_args.fp8_gemm_runner_backend)
+        if (
+            model_arch_override == "Qwen3OmniTalker"
+            and effective_quantization == "fp8"
+            and has_native_fp8_block_quant
+            and fp8_gemm_backend in (None, "auto")
+        ):
+            # Projected talker prefill has request-dependent FP8 dense GEMM shapes
+            # outside decode CUDA graph replay; DeepGEMM can otherwise JIT there.
+            override_server_args(
+                server_args,
+                "sglang-omni-qwen3-backend-policy",
+                fp8_gemm_runner_backend="triton",
+            )
+            fp8_gemm_backend = server_args.fp8_gemm_runner_backend
+
+        server_quantization = server_args.quantization
+        logger.info(
+            f"Configured SGLang backend policy: arch={model_arch_override} "
+            f"effective_quantization={effective_quantization} "
+            f"server_quantization={server_quantization} "
+            f"moe_runner_backend={moe_runner_backend} "
+            f"fp8_gemm_backend={fp8_gemm_backend}"
+        )
+        return effective_quantization
 
 
 class ROCMOmniPlatform(RocmDeviceMixin, CUDAOmniPlatform):

--- a/sglang_omni/platforms/cuda.py
+++ b/sglang_omni/platforms/cuda.py
@@ -80,21 +80,15 @@ class CUDAOmniPlatform(CudaDeviceMixin, OmniPlatform):
         model_arch_override: str | None,
     ) -> str | None:
 
-        effective_quantization = normalize_quantization(model_config.quantization)
-        server_quantization = normalize_quantization(server_args.quantization)
-        if server_quantization is not None:
-            effective_quantization = server_quantization
+        effective_quantization = super().apply_model_worker_backend_policy(
+            server_args, model_config, model_arch_override
+        )
 
         moe_runner_backend = server_args.moe_runner_backend
         is_qwen3_omni_arch = model_arch_override in (
             "Qwen3OmniTalker",
             "Qwen3OmniThinkerForCausalLM",
         )
-        if is_qwen3_omni_arch and server_args.ep_size != 1:
-            raise ValueError(
-                "Qwen3-Omni ModelWorker does not support expert parallelism; "
-                "use ep_size=1."
-            )
         has_moe = model_config_has_moe(model_config)
         quant_dict = resolve_quant_config(model_config.hf_config)
         has_native_fp8_block_quant = (

--- a/sglang_omni/platforms/interface.py
+++ b/sglang_omni/platforms/interface.py
@@ -47,17 +47,6 @@ class OmniPlatform(DeviceMixin):
         server_quantization = normalize_quantization(server_args.quantization)
         if server_quantization is not None:
             effective_quantization = server_quantization
-
-        is_qwen3_omni_arch = model_arch_override in (
-            "Qwen3OmniTalker",
-            "Qwen3OmniThinkerForCausalLM",
-        )
-        if is_qwen3_omni_arch and server_args.ep_size != 1:
-            raise ValueError(
-                "Qwen3-Omni ModelWorker does not support expert parallelism; "
-                "use ep_size=1."
-            )
-
         return effective_quantization
 
     def enable_code2wav_graph(self):

--- a/sglang_omni/platforms/interface.py
+++ b/sglang_omni/platforms/interface.py
@@ -7,7 +7,10 @@ from typing import TYPE_CHECKING
 
 from sglang.srt.platforms.device_mixin import DeviceMixin
 
+from sglang_omni.utils.misc import normalize_quantization
+
 if TYPE_CHECKING:
+    from sglang_omni.comm.data_ref import TransportKind
     from sglang_omni.pipeline.stage_workers import StageLaunchConfig
 
 
@@ -21,3 +24,26 @@ class OmniPlatform(DeviceMixin):
     ) -> dict[str, str]:
         """Return per-process environment overrides needed before child startup."""
         return {}
+
+    def get_intra_node_transport(self) -> TransportKind:
+        from sglang_omni.comm.data_ref import TransportKind
+
+        return TransportKind.SHM
+
+    def get_fused_qk_norm_rope(self):
+        """Get the fused QK norm RoPE kernel if available, else return None."""
+        return None
+
+    def apply_model_worker_backend_policy(
+        self,
+        server_args: ServerArgs,
+        model_config: ModelConfig,
+        model_arch_override: str | None,
+    ) -> str | None:
+        """Apply Omni backend policy after checkpoint quantization is known."""
+
+        effective_quantization = normalize_quantization(model_config.quantization)
+        server_quantization = normalize_quantization(server_args.quantization)
+        if server_quantization is not None:
+            effective_quantization = server_quantization
+        return effective_quantization

--- a/sglang_omni/platforms/interface.py
+++ b/sglang_omni/platforms/interface.py
@@ -47,4 +47,15 @@ class OmniPlatform(DeviceMixin):
         server_quantization = normalize_quantization(server_args.quantization)
         if server_quantization is not None:
             effective_quantization = server_quantization
+
+        is_qwen3_omni_arch = model_arch_override in (
+            "Qwen3OmniTalker",
+            "Qwen3OmniThinkerForCausalLM",
+        )
+        if is_qwen3_omni_arch and server_args.ep_size != 1:
+            raise ValueError(
+                "Qwen3-Omni ModelWorker does not support expert parallelism; "
+                "use ep_size=1."
+            )
+
         return effective_quantization

--- a/sglang_omni/platforms/interface.py
+++ b/sglang_omni/platforms/interface.py
@@ -26,6 +26,7 @@ class OmniPlatform(DeviceMixin):
         return {}
 
     def get_intra_node_transport(self) -> TransportKind:
+        """Get TransportKind between devices on the same node"""
         from sglang_omni.comm.data_ref import TransportKind
 
         return TransportKind.SHM

--- a/sglang_omni/platforms/interface.py
+++ b/sglang_omni/platforms/interface.py
@@ -59,3 +59,7 @@ class OmniPlatform(DeviceMixin):
             )
 
         return effective_quantization
+
+    def enable_code2wav_graph(self):
+        """Check if current platform support Graph for code2wav in Qwen3-Omni"""
+        return True

--- a/sglang_omni/platforms/npu.py
+++ b/sglang_omni/platforms/npu.py
@@ -16,3 +16,6 @@ class NPUOmniPlatform(OmniPlatform):
 
     def set_device(self, device: "torch.device") -> None:
         torch.npu.set_device(device)
+
+    def enable_code2wav_graph(self):
+        return False

--- a/sglang_omni/utils/misc.py
+++ b/sglang_omni/utils/misc.py
@@ -101,3 +101,7 @@ def normalize_quantization(value: object) -> str | None:
     if value is None:
         return None
     return str(value).lower()
+
+
+def model_config_has_moe(model_config: ModelConfig) -> bool:
+    return hasattr(model_config.hf_text_config, "num_experts_per_tok")

--- a/sglang_omni/utils/misc.py
+++ b/sglang_omni/utils/misc.py
@@ -95,3 +95,9 @@ def broadcast_pyobj(
         serialized_data = bytes(tensor_data.cpu().numpy())
         data = pickle.loads(serialized_data)
         return data
+
+
+def normalize_quantization(value: object) -> str | None:
+    if value is None:
+        return None
+    return str(value).lower()

--- a/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
+++ b/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
@@ -9,6 +9,7 @@ from types import ModuleType, SimpleNamespace
 import pytest
 
 from sglang_omni.model_runner import model_worker
+from sglang_omni.platforms import cuda
 from tests.unit_test.fakes import FakeServerArgs
 
 
@@ -357,7 +358,7 @@ def test_model_worker_backend_policy_precedence(
         "_is_fp8_cutlass_moe_supported",
         lambda: case.cutlass_supported,
     )
-    monkeypatch.setattr(model_worker, "_is_h20_device", lambda: False)
+    monkeypatch.setattr(cuda, "_is_h20_device", lambda: False)
     server_args = _server_args(
         quantization=case.server_quantization,
         moe_runner_backend=case.initial_moe_backend,
@@ -372,14 +373,14 @@ def test_model_worker_backend_policy_precedence(
 
     if case.error_match:
         with pytest.raises(ValueError, match=case.error_match):
-            model_worker._apply_model_worker_backend_policy(
+            current_platform.apply_model_worker_backend_policy(
                 server_args,
                 model_config,
                 case.model_arch_override,
             )
         return
 
-    effective_quantization = model_worker._apply_model_worker_backend_policy(
+    effective_quantization = current_platform.apply_model_worker_backend_policy(
         server_args,
         model_config,
         case.model_arch_override,
@@ -412,7 +413,7 @@ def test_model_worker_backend_policy_uses_strict_server_args_override(
         has_moe=True,
     )
 
-    effective_quantization = model_worker._apply_model_worker_backend_policy(
+    effective_quantization = current_platform.apply_model_worker_backend_policy(
         server_args,
         model_config,
         "Qwen3OmniTalker",
@@ -525,11 +526,11 @@ class FullConfigureBackendPolicyCase:
 
 
 # Test cases covering the ordering issue: the Omni quantization adapters
-# run BEFORE _apply_model_worker_backend_policy(), so only Talker FP8
+# run BEFORE apply_model_worker_backend_policy(), so only Talker FP8
 # with native block quant should get triton GEMM; Thinker and non-Qwen
 # should preserve auto. The adapters are a no-op for FP8 (they only
 # normalize stage-local names for methods like AutoRound), so all FP8
-# backend policy stays owned by _apply_model_worker_backend_policy().
+# backend policy stays owned by apply_model_worker_backend_policy().
 CONFIGURE_BACKEND_POLICY_CASES = [
     FullConfigureBackendPolicyCase(
         name="talker_fp8_auto_gemm_becomes_triton",
@@ -689,7 +690,7 @@ def test_configure_backend_policy_fp8_gemm_ordering(
 
     The ordering in _configure_backend_policy() is:
         1. _apply_omni_quantization_adapters()  (no-op for FP8)
-        2. _apply_model_worker_backend_policy()
+        2. apply_model_worker_backend_policy()
 
     Only step 2 (arch-aware) should set fp8_gemm_runner_backend="triton"
     for Talker FP8. Step 1 must NOT touch FP8 backend selection.
@@ -712,7 +713,7 @@ def test_configure_backend_policy_fp8_gemm_ordering(
     )
 
     # Patch _is_h20_device so we get deterministic BF16 policy.
-    monkeypatch.setattr(model_worker, "_is_h20_device", lambda: False)
+    monkeypatch.setattr(cuda, "_is_h20_device", lambda: False)
 
     # Build mock model config matching the shape ModelConfig expects.
     quant_config_in = (
@@ -754,9 +755,9 @@ def test_configure_backend_policy_fp8_gemm_ordering(
     # ordering in _configure_backend_policy().
     model_worker._apply_omni_quantization_adapters(model_config)
 
-    # Step 2: run the REAL _apply_model_worker_backend_policy().
+    # Step 2: run the REAL apply_model_worker_backend_policy().
     # This is the arch-aware step that sets Talker FP8 Triton.
-    _ = model_worker._apply_model_worker_backend_policy(
+    _ = current_platform.apply_model_worker_backend_policy(
         server_args,
         model_config,
         case.model_arch_override,

--- a/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
+++ b/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
@@ -377,6 +377,10 @@ def test_model_worker_backend_policy_precedence(
 
     if case.error_match:
         with pytest.raises(ValueError, match=case.error_match):
+            model_worker._apply_model_worker_backend_common_policy(
+                server_args,
+                case.model_arch_override,
+            )
             cuda_platform.apply_model_worker_backend_policy(
                 server_args,
                 model_config,
@@ -384,6 +388,10 @@ def test_model_worker_backend_policy_precedence(
             )
         return
 
+    model_worker._apply_model_worker_backend_common_policy(
+        server_args,
+        case.model_arch_override,
+    )
     effective_quantization = cuda_platform.apply_model_worker_backend_policy(
         server_args,
         model_config,
@@ -417,6 +425,10 @@ def test_model_worker_backend_policy_uses_strict_server_args_override(
         has_moe=True,
     )
 
+    model_worker._apply_model_worker_backend_common_policy(
+        server_args,
+        "Qwen3OmniTalker",
+    )
     effective_quantization = cuda_platform.apply_model_worker_backend_policy(
         server_args,
         model_config,
@@ -761,6 +773,10 @@ def test_configure_backend_policy_fp8_gemm_ordering(
 
     # Step 2: run the REAL apply_model_worker_backend_policy().
     # This is the arch-aware step that sets Talker FP8 Triton.
+    model_worker._apply_model_worker_backend_common_policy(
+        server_args,
+        case.model_arch_override,
+    )
     _ = cuda_platform.apply_model_worker_backend_policy(
         server_args,
         model_config,

--- a/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
+++ b/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
@@ -9,9 +9,12 @@ from types import ModuleType, SimpleNamespace
 import pytest
 
 from sglang_omni.model_runner import model_worker
-from sglang_omni.platforms import cuda, current_platform
+from sglang_omni.platforms import cuda
+from sglang_omni.platforms.cuda import CUDAOmniPlatform
 from sglang_omni.utils.misc import model_config_has_moe
 from tests.unit_test.fakes import FakeServerArgs
+
+cuda_platform = CUDAOmniPlatform()
 
 
 class _StrictServerArgsDouble:
@@ -374,14 +377,14 @@ def test_model_worker_backend_policy_precedence(
 
     if case.error_match:
         with pytest.raises(ValueError, match=case.error_match):
-            current_platform.apply_model_worker_backend_policy(
+            cuda_platform.apply_model_worker_backend_policy(
                 server_args,
                 model_config,
                 case.model_arch_override,
             )
         return
 
-    effective_quantization = current_platform.apply_model_worker_backend_policy(
+    effective_quantization = cuda_platform.apply_model_worker_backend_policy(
         server_args,
         model_config,
         case.model_arch_override,
@@ -414,7 +417,7 @@ def test_model_worker_backend_policy_uses_strict_server_args_override(
         has_moe=True,
     )
 
-    effective_quantization = current_platform.apply_model_worker_backend_policy(
+    effective_quantization = cuda_platform.apply_model_worker_backend_policy(
         server_args,
         model_config,
         "Qwen3OmniTalker",
@@ -758,7 +761,7 @@ def test_configure_backend_policy_fp8_gemm_ordering(
 
     # Step 2: run the REAL apply_model_worker_backend_policy().
     # This is the arch-aware step that sets Talker FP8 Triton.
-    _ = current_platform.apply_model_worker_backend_policy(
+    _ = cuda_platform.apply_model_worker_backend_policy(
         server_args,
         model_config,
         case.model_arch_override,

--- a/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
+++ b/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
@@ -9,7 +9,7 @@ from types import ModuleType, SimpleNamespace
 import pytest
 
 from sglang_omni.model_runner import model_worker
-from sglang_omni.platforms import cuda
+from sglang_omni.platforms import cuda, current_platform
 from sglang_omni.utils.misc import model_config_has_moe
 from tests.unit_test.fakes import FakeServerArgs
 
@@ -355,7 +355,7 @@ def test_model_worker_backend_policy_precedence(
 ) -> None:
     """Covers quantization, architecture, MoE, hardware, and explicit override precedence."""
     monkeypatch.setattr(
-        model_worker,
+        cuda,
         "_is_fp8_cutlass_moe_supported",
         lambda: case.cutlass_supported,
     )
@@ -397,7 +397,7 @@ def test_model_worker_backend_policy_uses_strict_server_args_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        model_worker,
+        cuda,
         "_is_fp8_cutlass_moe_supported",
         lambda: True,
     )
@@ -477,7 +477,7 @@ def test_fp8_cutlass_moe_support_matches_sglang_0_5_16_contract(
         sm120_supported=sm120_supported,
     )
 
-    assert model_worker._is_fp8_cutlass_moe_supported() is expected_supported
+    assert cuda._is_fp8_cutlass_moe_supported() is expected_supported
 
 
 def test_backend_global_initialization_for_fp8_moe_model(monkeypatch) -> None:

--- a/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
+++ b/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
@@ -10,6 +10,7 @@ import pytest
 
 from sglang_omni.model_runner import model_worker
 from sglang_omni.platforms import cuda
+from sglang_omni.utils.misc import model_config_has_moe
 from tests.unit_test.fakes import FakeServerArgs
 
 
@@ -440,7 +441,7 @@ def test_model_config_has_moe_prefers_effective_text_config() -> None:
         hf_text_config=SimpleNamespace(num_experts_per_tok=8),
     )
 
-    assert model_worker._model_config_has_moe(model_config)
+    assert model_config_has_moe(model_config)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Support Qwen3-Omni talker on Ascend NPU to enable audio output

## Modifications

replaced `torch.cuda` with general `torch.get_device_module()`
added new functions to `current_platform`
- `get_intra_node_transport` to allow every platform choose their backend for move between devices on the same node
- `get_fused_qk_norm_rope` to import sgl-kernel only for CUDA
- `apply_model_worker_backend_policy` moved from `model_worker` as it has many CUDA related adjustment

`normalize_quantization` and `model_config_has_moe` moved from `model_worker` to `utils/misc.py`

## Accuracy Test

```
sgl-omni serve --model-path /home/weights/Qwen/Qwen3-Omni-30B-A3B-Instruct/ --thinker-cuda-graph off --thinker-gpus 2,3 --thinker-tp-size 2 --talker-gpu 1 --code2wav-gpu 0 --talker-cuda-graph off --image-encoder-gpus 0
```
```
curl -X POST http://localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d '{"model": "qwen3-omni", "messages": [{"role": "user", "content": "Say the word \"generate\" exactly ten times in a row. Do not add any other words. Example: one, one, one... Repeat it exactly 10 times."}], "temperature": 0.01, "top_p": 0.1, "presence_penalty": 0.0, "frequency_penalty": 0.0, "modalities": ["text", "audio"]}' -o output.json
```

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
