### PR TITLE
[Perf][ARK-ASR] Query embedding cache before mel extraction

### DIFF
--- a/sglang_omni/models/arkasr/encoder_service.py
+++ b/sglang_omni/models/arkasr/encoder_service.py
@@ -230,24 +230,16 @@ class ArkasrPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
         if key is None:
             return self._track_submission(self._submit(item))
 
-        cached = self._cache.get(key)
+        cached = self.lookup_cached_embedding(
+            getattr(item, "audio_fingerprint", None), expected_tokens
+        )
         if cached is not None:
-            if self._is_valid(cached, expected_tokens):
-                with self._lock:
-                    self._hits += 1
-                self.attach_embedding(item, cached)
-                future: concurrent.futures.Future[torch.Tensor] = (
-                    concurrent.futures.Future()
-                )
-                future.set_result(cached)
-                return self._track_submission(future)
-            logger.warning(
-                f"ARK-ASR pre-LM cache entry {key} failed validation "
-                f"(shape={tuple(cached.shape)}, dtype={cached.dtype}); "
-                f"discarding it if unchanged before re-encoding"
+            self.attach_embedding(item, cached)
+            future: concurrent.futures.Future[torch.Tensor] = (
+                concurrent.futures.Future()
             )
-            self._cache.remove_if_same(key, cached)
-            cached = None
+            future.set_result(cached)
+            return self._track_submission(future)
 
         follower_of: concurrent.futures.Future[torch.Tensor] | None = None
         leader = False
@@ -345,6 +337,30 @@ class ArkasrPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
             if self._inflight.get(key) is future:
                 del self._inflight[key]
 
+    def lookup_cached_embedding(
+        self,
+        audio_fingerprint: str | None,
+        expected_tokens: int,
+    ) -> torch.Tensor | None:
+        """Return a validated cached embedding without starting an encode."""
+        key = self._cache_key_from_fingerprint(audio_fingerprint)
+        cached = self._cache.get(key)
+        if cached is None:
+            return None
+        if self._is_valid(cached, expected_tokens):
+            with self._lock:
+                self._hits += 1
+            return cached
+        logger.warning(
+            "ARK-ASR pre-LM cache entry %s failed validation "
+            "(shape=%s, dtype=%s); discarding it if unchanged before re-encoding",
+            key,
+            getattr(cached, "shape", None),
+            getattr(cached, "dtype", None),
+        )
+        self._cache.remove_if_same(key, cached)
+        return None
+
     def stats(self) -> dict[str, int | float]:
         with self._lock:
             cache_lookups = self._hits + self._misses
@@ -376,10 +392,14 @@ class ArkasrPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
             }
 
     def _cache_key(self, item: Any) -> str | None:
-        item_hash = getattr(item, "audio_fingerprint", None)
-        if item_hash is None:
+        return self._cache_key_from_fingerprint(
+            getattr(item, "audio_fingerprint", None)
+        )
+
+    def _cache_key_from_fingerprint(self, audio_fingerprint: str | None) -> str | None:
+        if audio_fingerprint is None:
             return None
-        return f"{self._namespace}:{item_hash}"
+        return f"{self._namespace}:{audio_fingerprint}"
 
     def _is_valid(self, embedding: Any, expected_tokens: int) -> bool:
         return (

--- a/sglang_omni/models/arkasr/request_builders.py
+++ b/sglang_omni/models/arkasr/request_builders.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """StagePayload <-> SGLang request adapters for ARK-ASR-3B.
 
-Mirrors the checkpoint's processor: mel features via WhisperFeatureExtractor,
-prompt = ``<|user|>...<|begin_of_audio|>{N audio tokens}<|end_of_audio|>
+Mirrors the checkpoint's processor: reuse a cached LM-ready embedding when
+available, otherwise extract mel features via WhisperFeatureExtractor. The
+prompt is ``<|user|>...<|begin_of_audio|>{N audio tokens}<|end_of_audio|>
 Please transcribe this audio.<|assistant|>``, then the ``<|audio|>`` (id
 151663) placeholders are scattered with encoder output by the model's
 general_mm_embed_routine. ARK's LM is a dense Qwen2 (1-D RoPE, no MRoPE).
@@ -12,8 +13,9 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
 
 import torch
 from sglang.srt.managers.schedule_batch import (
@@ -88,6 +90,25 @@ def _build_suppressed_token_ids(tokenizer: Any) -> list[int]:
     return sorted(bad)
 
 
+def _estimate_audio_tokens(
+    num_samples: int,
+    feature_extractor: Any,
+    merge_factor: int,
+) -> int:
+    """Predict the truncated Whisper mel length without computing the FFT."""
+    try:
+        hop_length = int(feature_extractor.hop_length)
+        max_mel_frames = int(feature_extractor.nb_max_frames)
+    except AttributeError as exc:
+        raise ValueError(
+            "ARK-ASR feature extractor is missing audio length metadata"
+        ) from exc
+    if hop_length <= 0 or max_mel_frames <= 0:
+        raise ValueError("ARK-ASR feature extractor has invalid audio length metadata")
+    mel_frames = min(int(num_samples) // hop_length, max_mel_frames)
+    return arkasr_num_audio_tokens(mel_frames, merge_factor)
+
+
 def make_arkasr_scheduler_adapters(
     *,
     tokenizer: Any,
@@ -134,25 +155,40 @@ def make_arkasr_scheduler_adapters(
         audio_duration_s = prepared.duration_s
         fingerprint = prepared.fingerprint
 
-        # mel: pad to the clip's true length (short clips do not pay the full
-        # 30s of FFT). ARK's WhisperEncoder is variable-length; conv2 stride-2
-        # then merge_factor determines the audio-token count.
-        extracted = feature_extractor(
-            audio,
-            sampling_rate=_SAMPLE_RATE,
-            return_tensors="pt",
-            return_attention_mask=True,
-            padding="longest",
-            truncation=True,
-        )
-        features = extracted.input_features  # [num_mel_bins, T]
-        feature_attention_mask = getattr(extracted, "attention_mask", None)
-        if feature_attention_mask is None:
-            feature_attention_mask = torch.ones(
-                (features.shape[0], features.shape[-1]), dtype=torch.long
+        estimated_audio_tokens = None
+        cached_embedding = None
+        if audio_encoder_service is not None:
+            estimated_audio_tokens = _estimate_audio_tokens(
+                len(audio), feature_extractor, merge_factor
             )
-        num_mel_frames = int(feature_attention_mask.sum().item())
-        num_audio_tokens = arkasr_num_audio_tokens(num_mel_frames, merge_factor)
+            cached_embedding = audio_encoder_service.lookup_cached_embedding(
+                fingerprint, estimated_audio_tokens
+            )
+
+        if cached_embedding is None:
+            # Pad to the clip's true length (short clips do not pay the full
+            # 30s FFT), while preserving the checkpoint's 30s truncation.
+            extracted = feature_extractor(
+                audio,
+                sampling_rate=_SAMPLE_RATE,
+                return_tensors="pt",
+                return_attention_mask=True,
+                padding="longest",
+                truncation=True,
+            )
+            features = extracted.input_features  # [num_mel_bins, T]
+            feature_attention_mask = getattr(extracted, "attention_mask", None)
+            if feature_attention_mask is None:
+                feature_attention_mask = torch.ones(
+                    (features.shape[0], features.shape[-1]), dtype=torch.long
+                )
+            num_mel_frames = int(feature_attention_mask.sum().item())
+            num_audio_tokens = arkasr_num_audio_tokens(num_mel_frames, merge_factor)
+        else:
+            features = None
+            feature_attention_mask = None
+            assert estimated_audio_tokens is not None
+            num_audio_tokens = estimated_audio_tokens
 
         input_ids = _build_prompt_ids(num_audio_tokens)
 
@@ -197,6 +233,9 @@ def make_arkasr_scheduler_adapters(
         )
         sampling_params.normalize(tokenizer=None)
 
+        if cached_embedding is not None:
+            audio_encoder_service.attach_embedding(audio_item, cached_embedding)
+
         req = Req(
             rid=payload.request_id,
             origin_input_text="",
@@ -219,7 +258,7 @@ def make_arkasr_scheduler_adapters(
             engine_start_s=time.perf_counter(),
             stage_payload=payload,
         )
-        if audio_encoder_service is None:
+        if audio_encoder_service is None or cached_embedding is not None:
             return req_data
         return DeferredAdmission(
             value=req_data,

--- a/tests/unit_test/arkasr/test_encoder_service.py
+++ b/tests/unit_test/arkasr/test_encoder_service.py
@@ -50,7 +50,7 @@ class _StubModel(torch.nn.Module):
         self.encode_delay_s = 0.0
         self.grad_enabled_during_encode: bool | None = None
 
-    def get_audio_feature(self, items):  # noqa: ANN001
+    def get_audio_feature(self, items):
         self.grad_enabled_during_encode = torch.is_grad_enabled()
         self.encode_calls += 1
         self.encode_batch_sizes.append(len(items))
@@ -236,7 +236,7 @@ def test_batch_context_unwinds_inference_mode_when_stream_context_fails(
     service = object.__new__(ArkasrPreLMEncoderService)
     service._stream = object()
 
-    def fail_stream(_stream):  # noqa: ANN001, ANN202
+    def fail_stream(_stream):
         raise RuntimeError("stream context failed")
 
     monkeypatch.setattr(torch.cuda, "stream", fail_stream)
@@ -261,6 +261,22 @@ def test_cache_hit_skips_reencode() -> None:
     assert torch.equal(first.precomputed_embeddings, second.precomputed_embeddings)
     assert second.feature is None
     assert service.stats()["hits"] == 1
+
+
+def test_lookup_cached_embedding_returns_only_valid_entries() -> None:
+    model = _StubModel()
+    service = _make_service(model)
+    item = _item(11, 3)
+    service.encode_item(item)
+
+    cached = service.lookup_cached_embedding(item.audio_fingerprint, 3)
+
+    assert cached is not None
+    assert torch.equal(cached, item.precomputed_embeddings.cpu())
+    assert service.stats()["hits"] == 1
+
+    assert service.lookup_cached_embedding(item.audio_fingerprint, 4) is None
+    assert len(service._cache) == 0
 
 
 def test_extended_audio_never_reuses_prefix_embedding() -> None:
@@ -335,7 +351,7 @@ def test_stale_cache_miss_rechecks_before_starting_duplicate_encode(
     release_stale_reader = threading.Event()
     original_get = service._cache.get
 
-    def controlled_get(key: str | None):  # noqa: ANN202
+    def controlled_get(key: str | None):
         cached = original_get(key)
         if (
             threading.current_thread().name == "stale-cache-reader"

--- a/tests/unit_test/arkasr/test_request_builders.py
+++ b/tests/unit_test/arkasr/test_request_builders.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import concurrent.futures
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from sglang_omni.models.arkasr.request_builders import make_arkasr_scheduler_adapters
+from sglang_omni.preprocessing import transcription
+from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.scheduling.types import DeferredAdmission
+
+_AUDIO_TOKEN_ID = 151663
+_HIDDEN_SIZE = 4
+
+
+class _FakeTokenizer:
+    eos_token_id = 2
+    vocab_size = 200000
+    all_special_ids = [2]
+
+    def get_added_vocab(self) -> dict[str, int]:
+        return {}
+
+    def __call__(self, text: str, *, add_special_tokens: bool = False):
+        assert not add_special_tokens
+        audio_tokens = text.count("<|audio|>")
+        return SimpleNamespace(input_ids=[1, *([_AUDIO_TOKEN_ID] * audio_tokens), 2])
+
+
+class _FeatureExtractor:
+    hop_length = 160
+    nb_max_frames = 3000
+
+    def __init__(
+        self,
+        mel_frames: int = 100,
+        *,
+        return_attention_mask: bool = True,
+    ) -> None:
+        self.calls = 0
+        self.mel_frames = mel_frames
+        self.return_attention_mask = return_attention_mask
+
+    def __call__(self, *args, **kwargs):
+        self.calls += 1
+        result = SimpleNamespace(input_features=torch.zeros((1, 128, self.mel_frames)))
+        if self.return_attention_mask:
+            result.attention_mask = torch.ones((1, self.mel_frames), dtype=torch.long)
+        return result
+
+
+def _payload(request_id: str) -> StagePayload:
+    return StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs={"audio_bytes": b"wav"}),
+        data={},
+    )
+
+
+@pytest.mark.parametrize(
+    ("num_samples", "expected_tokens"),
+    [
+        (16000, 12),
+        (31 * 16000, 375),
+    ],
+)
+def test_arkasr_embedding_cache_hit_skips_mel_extraction(
+    monkeypatch: pytest.MonkeyPatch,
+    num_samples: int,
+    expected_tokens: int,
+) -> None:
+    class _EncoderService:
+        def __init__(self) -> None:
+            self.lookup: tuple[str, int] | None = None
+            self.embedding = torch.zeros((expected_tokens, _HIDDEN_SIZE))
+
+        def lookup_cached_embedding(
+            self,
+            audio_fingerprint: str,
+            expected_audio_tokens: int,
+        ) -> torch.Tensor:
+            self.lookup = (audio_fingerprint, expected_audio_tokens)
+            return self.embedding
+
+        def attach_embedding(self, item, embedding: torch.Tensor) -> None:
+            item.precomputed_embeddings = embedding
+            item.feature = None
+
+        def submit_item(self, item):
+            raise AssertionError("a cache hit must not submit encoder work")
+
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(num_samples, dtype=np.float32),
+    )
+    feature_extractor = _FeatureExtractor()
+    encoder_service = _EncoderService()
+    request_builder, _ = make_arkasr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=32,
+        feature_extractor=feature_extractor,
+        audio_encoder_service=encoder_service,
+    )
+
+    data = request_builder(_payload(f"cache-hit-{num_samples}"))
+
+    item = data.req.multimodal_inputs.mm_items[0]
+    assert encoder_service.lookup == (data.req.extra_key, expected_tokens)
+    assert feature_extractor.calls == 0
+    assert item.feature is None
+    assert item.precomputed_embeddings is encoder_service.embedding
+    assert item.num_audio_tokens == expected_tokens
+
+
+@pytest.mark.parametrize("return_attention_mask", [True, False])
+def test_arkasr_embedding_cache_miss_extracts_and_encodes(
+    monkeypatch: pytest.MonkeyPatch,
+    return_attention_mask: bool,
+) -> None:
+    class _EncoderService:
+        def __init__(self) -> None:
+            self.lookup: tuple[str, int] | None = None
+            self.encoded_tokens: int | None = None
+
+        def lookup_cached_embedding(
+            self,
+            audio_fingerprint: str,
+            expected_audio_tokens: int,
+        ) -> None:
+            self.lookup = (audio_fingerprint, expected_audio_tokens)
+
+        def attach_embedding(self, item, embedding: torch.Tensor) -> None:
+            raise AssertionError("a cache miss must not attach a cached embedding")
+
+        def submit_item(self, item):
+            self.encoded_tokens = item.num_audio_tokens
+            embedding = torch.zeros((item.num_audio_tokens, _HIDDEN_SIZE))
+            item.precomputed_embeddings = embedding
+            item.feature = None
+            future: concurrent.futures.Future[torch.Tensor] = (
+                concurrent.futures.Future()
+            )
+            future.set_result(embedding)
+            return future
+
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(16000, dtype=np.float32),
+    )
+    feature_extractor = _FeatureExtractor(return_attention_mask=return_attention_mask)
+    encoder_service = _EncoderService()
+    request_builder, _ = make_arkasr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=32,
+        feature_extractor=feature_extractor,
+        audio_encoder_service=encoder_service,
+    )
+
+    data = request_builder(_payload("cache-miss"))
+
+    assert isinstance(data, DeferredAdmission)
+    data.ready.result()
+    item = data.value.req.multimodal_inputs.mm_items[0]
+    assert encoder_service.lookup == (data.value.req.extra_key, 12)
+    assert feature_extractor.calls == 1
+    assert encoder_service.encoded_tokens == 12
+    assert item.feature is None
+    assert item.precomputed_embeddings.shape == (12, _HIDDEN_SIZE)
+
+
+@pytest.mark.parametrize(
+    "feature_extractor",
+    [
+        SimpleNamespace(nb_max_frames=3000),
+        SimpleNamespace(hop_length=160),
+        SimpleNamespace(hop_length=0, nb_max_frames=3000),
+        SimpleNamespace(hop_length=160, nb_max_frames=0),
+    ],
+)
+def test_arkasr_embedding_cache_requires_valid_audio_length_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    feature_extractor: SimpleNamespace,
+) -> None:
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(16000, dtype=np.float32),
+    )
+    encoder_service = SimpleNamespace(
+        lookup_cached_embedding=lambda *args: pytest.fail(
+            "invalid metadata must fail before cache lookup"
+        )
+    )
+    request_builder, _ = make_arkasr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=32,
+        feature_extractor=feature_extractor,
+        audio_encoder_service=encoder_service,
+    )
+
+    with pytest.raises(ValueError, match="audio length metadata"):
+        request_builder(_payload("invalid-metadata"))


### PR DESCRIPTION
## Motivation

ARK-ASR's draft pre-LM encoder service (#1429) caches complete LM-ready audio embeddings, but request construction still runs Whisper mel extraction before discovering a cache hit. This is the ARK-ASR counterpart to Qwen3-ASR #1422.

## Modifications

- add a validated lookup-only API to the ARK-ASR pre-LM embedding cache;
- estimate ARK's truncated Whisper audio-token count before the mel FFT;
- skip feature extraction and encoder submission on cache hits;
- preserve actual mask-derived token counts, single-flight encoding, and cache fill on misses;
- cover valid/invalid lookup entries, cache hits, cache misses, frontend truncation, invalid frontend metadata, and missing attention masks.

## Related Issues

- Tracking issue: #1396
- Depends on: #1429
- Reference implementation: #1422

## Accuracy Test

Full SeedTTS EN validation retained identical accuracy:

- corpus WER: `0.0111985 → 0.0111985` at every measured concurrency;
- evaluated: 19,584 measured requests per revision (39,168 total);
- skipped/failed evaluation requests: `0 → 0`.

Unit tests additionally verify identical prompt span/token-count construction on cache hits and the unchanged miss path.

## Benchmark & Profiling

Direct-container benchmark on one Vast.ai **H100 SXM 80GB** using the exact CI image (no nested Docker):

`hongccc/sglang-omni@sha256:374d0b1c30b2bff685b1716fc64a02ad3b3d0a90fe2ce73ce9861a6992c28101`

- base: `eed842b79400f458181056e2a72f73f3ed80d552` (#1429 head)
- head: `42b8b9c4058bd788fad3c9ff81ddf26fcaa39df9`
- model: `AutoArk-AI/ARK-ASR-3B` at `1e28271b79edc97635783bea65abc89195a09ed3`
- dataset: SeedTTS EN at `27f4c1adee83b5b29b7c4b375f6b976324bda308` (1,088 samples)
- order: base → head → head → base, with a fresh server process for each run
- each process: concurrencies `1,8,32`; one discarded application warmup and three measured repeats
- aggregation: arithmetic mean of six measured repeats per revision/concurrency

| Concurrency | Throughput base → head | Δ | Mean latency base → head | Δ | P95 latency base → head | Δ | Mean RTF base → head | Δ |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 13.449 → 13.648 req/s | **+1.48%** | 0.0742 → 0.0731 s | **-1.45%** | 0.0910 → 0.0897 s | **-1.40%** | 0.01607 → 0.01584 | **-1.42%** |
| 8 | 53.527 → 54.227 req/s | **+1.31%** | 0.1490 → 0.1471 s | **-1.32%** | 0.1938 → 0.1913 s | **-1.29%** | 0.03228 → 0.03186 | **-1.31%** |
| 32 | 100.681 → 104.506 req/s | **+3.80%** | 0.3158 → 0.3046 s | **-3.53%** | 0.4141 → 0.4060 s | **-1.95%** | 0.06831 → 0.06588 | **-3.56%** |

The throughput direction reproduced in both order pairs. At concurrency 32, the per-order gains were `+5.06%` (base → head) and `+2.51%` (head → base).

This is the benchmark branch of the Docker GPU workflow; Nsight Compute was not used because this change targets host-side mel extraction and no hardware-counter analysis was requested.

## Local Verification

- `pre-commit run --from-ref HEAD^ --to-ref HEAD`
- `pytest -q tests/unit_test/arkasr/test_encoder_service.py tests/unit_test/arkasr/test_request_builders.py` — 31 passed
- new executable line coverage — 51/51 (100%)
- two independent high-signal review passes — no findings

The broader `test_pipeline.py` collection has four pre-existing CPU-platform failures in the borrowed local environment (`current_platform.get_device()` is unavailable); directly affected tests pass.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
