### PR TITLE
[Perf] [W-PR5] Streamline Whisper request construction

### DIFF
--- a/sglang_omni/models/whisper_asr/request_builders.py
+++ b/sglang_omni/models/whisper_asr/request_builders.py
@@ -24,6 +24,7 @@ from sglang_omni.models.whisper_asr.config import WHISPER_MAX_INPUT_SECONDS
 from sglang_omni.preprocessing.transcription import prepare_audio
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
+from sglang_omni.scheduling.stage_cache import StageOutputCache
 
 _WHISPER_SAMPLE_RATE = 16000
 
@@ -37,6 +38,7 @@ _MAX_ENGINE_CLIP_MESSAGE = (
 MAX_PREV_CONTEXT_TOKENS = 224
 # note (jiannan-17): Standard Whisper decoder context is 448 positions.
 _DEFAULT_DECODER_CONTEXT_LEN = 448
+_FEATURE_CACHE_MAX_ITEMS = 32
 _LANGUAGE_ALIASES = {
     "en": "english",
     "eng": "english",
@@ -144,8 +146,9 @@ def make_whisper_scheduler_adapters(
         or getattr(generation_config, "max_length", None)
         or _DEFAULT_DECODER_CONTEXT_LEN
     )
+    feature_cache = StageOutputCache(max_size=_FEATURE_CACHE_MAX_ITEMS)
 
-    @lru_cache(maxsize=None)
+    @lru_cache(maxsize=32)
     def _prefix_token_ids(language: str, task: str) -> tuple[int, ...]:
         tokenizer.set_prefix_tokens(
             language=language,
@@ -153,6 +156,29 @@ def make_whisper_scheduler_adapters(
             predict_timestamps=False,
         )
         return tuple(tokenizer.prefix_tokens)
+
+    def _extract_features(fingerprint: str, audio: Any) -> torch.Tensor:
+        """Extract mel features, reusing recent identical audio inputs.
+
+        SGLang releases and may move a request's feature tensor in-place after
+        the request finishes. Keep the cache-owned tensor private and return a
+        clone for every cache hit so one request cannot affect another.
+        """
+        cached = feature_cache.get(fingerprint)
+        if cached is not None:
+            return cached.clone()
+
+        features = processor.feature_extractor(
+            audio,
+            sampling_rate=_WHISPER_SAMPLE_RATE,
+            return_tensors="pt",
+        ).input_features
+        # StageOutputCache provides the lock, LRU recency update, and bounded
+        # eviction. The cache owns a detached snapshot; each hit still returns
+        # a private clone because downstream request handling may mutate or
+        # release its feature tensor in-place.
+        feature_cache.put(fingerprint, features.detach().clone())
+        return features
 
     def request_builder(payload: StagePayload) -> WhisperASRRequestData:
         params = payload.request.params or {}
@@ -197,11 +223,7 @@ def make_whisper_scheduler_adapters(
             )
         input_ids = [*encoder_pad_token_ids, *prompt_token_ids]
 
-        features = processor.feature_extractor(
-            audio,
-            sampling_rate=_WHISPER_SAMPLE_RATE,
-            return_tensors="pt",
-        ).input_features
+        features = _extract_features(fingerprint, audio)
         mm_inputs = MultimodalInputs(
             mm_items=[
                 MultimodalDataItem(

--- a/sglang_omni/models/whisper_asr/request_builders.py
+++ b/sglang_omni/models/whisper_asr/request_builders.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
+from functools import lru_cache
 from threading import Lock
-from typing import Any, Callable
+from typing import Any
 
 import torch
 from sglang.srt.managers.schedule_batch import (
@@ -66,15 +68,6 @@ def _build_logit_bias(generation_config: GenerationConfig) -> dict[str, float] |
     if not suppress_tokens:
         return None
     return {str(int(token_id)): -1.0e9 for token_id in suppress_tokens if token_id >= 0}
-
-
-def _build_prefix_tokens(tokenizer: Any, *, language: str, task: str) -> list[int]:
-    tokenizer.set_prefix_tokens(
-        language=language,
-        task=task,
-        predict_timestamps=False,
-    )
-    return list(tokenizer.prefix_tokens)
 
 
 def _decoder_token_budgets(
@@ -142,6 +135,8 @@ def make_whisper_scheduler_adapters(
     id_to_language = {
         int(token_id): token.strip("<|>") for token, token_id in lang_to_id.items()
     }
+    encoder_pad_token_ids = (pad_token_id,) * encoder_token_count
+    vocab_size = len(tokenizer)
     # note (jiannan-17): Prefer the decoder limit passed by the caller. Fall back
     # to generation_config.max_length, then to Whisper's default 448 positions.
     decoder_context_len = int(
@@ -149,6 +144,15 @@ def make_whisper_scheduler_adapters(
         or getattr(generation_config, "max_length", None)
         or _DEFAULT_DECODER_CONTEXT_LEN
     )
+
+    @lru_cache(maxsize=None)
+    def _prefix_token_ids(language: str, task: str) -> tuple[int, ...]:
+        tokenizer.set_prefix_tokens(
+            language=language,
+            task=task,
+            predict_timestamps=False,
+        )
+        return tuple(tokenizer.prefix_tokens)
 
     def request_builder(payload: StagePayload) -> WhisperASRRequestData:
         params = payload.request.params or {}
@@ -171,11 +175,7 @@ def make_whisper_scheduler_adapters(
             request_max_new_tokens = 1
         else:
             with tokenizer_lock:
-                prefix_token_ids = _build_prefix_tokens(
-                    tokenizer,
-                    language=language,
-                    task=task,
-                )
+                prefix_token_ids = _prefix_token_ids(language, task)
                 request_max_new_tokens, max_prev_tokens = _decoder_token_budgets(
                     decoder_context_len=decoder_context_len,
                     prefix_len=len(prefix_token_ids),
@@ -195,7 +195,7 @@ def make_whisper_scheduler_adapters(
                 f"{len(prompt_token_ids)} input tokens + "
                 f"{request_max_new_tokens} max_new_tokens > {decoder_context_len}"
             )
-        input_ids = [pad_token_id] * encoder_token_count + prompt_token_ids
+        input_ids = [*encoder_pad_token_ids, *prompt_token_ids]
 
         features = processor.feature_extractor(
             audio,

--- a/sglang_omni/models/whisper_asr/request_builders.py
+++ b/sglang_omni/models/whisper_asr/request_builders.py
@@ -173,7 +173,7 @@ def make_whisper_scheduler_adapters(
             sampling_rate=_WHISPER_SAMPLE_RATE,
             return_tensors="pt",
         ).input_features
-        # StageOutputCache provides the lock, LRU recency update, and bounded
+        # note (xinran): StageOutputCache provides the lock, LRU recency update, and bounded
         # eviction. The cache owns a detached snapshot; each hit still returns
         # a private clone because downstream request handling may mutate or
         # release its feature tensor in-place.

--- a/tests/unit_test/whisper_asr/test_request_builders.py
+++ b/tests/unit_test/whisper_asr/test_request_builders.py
@@ -30,6 +30,9 @@ class _FakeTokenizer:
     pad_token_id = 3
     vocab_size = 51865
 
+    def __init__(self) -> None:
+        self.prefix_calls: list[tuple[str, str, bool]] = []
+
     def __len__(self) -> int:
         return 51866
 
@@ -40,6 +43,7 @@ class _FakeTokenizer:
         self, *, language: str, task: str, predict_timestamps: bool
     ) -> None:
         assert predict_timestamps is False
+        self.prefix_calls.append((language, task, predict_timestamps))
         self.prefix_language = language
         self.prefix_task = task
 
@@ -123,6 +127,24 @@ def test_request_builder_without_prompt_keeps_prefix_only(monkeypatch) -> None:
     expected = [pad_id] * _ENCODER_TOKEN_COUNT + _PREFIX
     assert data.input_ids.tolist() == expected
     assert data.prompt_token_ids == _PREFIX
+
+
+def test_request_builder_reuses_prefix_for_canonical_language(monkeypatch) -> None:
+    tokenizer = _FakeTokenizer()
+    request_builder = _make_request_builder(tokenizer)
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(1600, dtype=np.float32),
+    )
+
+    first = request_builder(_make_payload({"language": "en"}))
+    second = request_builder(_make_payload({"language": "english"}))
+
+    assert tokenizer.prefix_calls == [("english", "transcribe", False)]
+    assert first.input_ids.tolist() == second.input_ids.tolist()
+    assert first.prompt_token_ids == second.prompt_token_ids == _PREFIX
+    assert first.prompt_token_ids is not second.prompt_token_ids
 
 
 def test_request_builder_maps_prompt_to_prev_context(monkeypatch) -> None:

--- a/tests/unit_test/whisper_asr/test_request_builders.py
+++ b/tests/unit_test/whisper_asr/test_request_builders.py
@@ -11,13 +11,13 @@ import numpy as np
 import pytest
 import torch
 
-import sglang_omni.preprocessing.transcription as transcription
 from sglang_omni.models.whisper_asr import request_builders as whisper_request_builders
 from sglang_omni.models.whisper_asr.request_builders import (
     _build_prev_context_tokens,
     _decoder_token_budgets,
     make_whisper_scheduler_adapters,
 )
+from sglang_omni.preprocessing import transcription
 from sglang_omni.proto import OmniRequest, StagePayload
 
 _SOT_PREV = 50361
@@ -57,10 +57,16 @@ class _FakeTokenizer:
         return [_SOT_PREV] + [1000 + i for i in range(len(text))]
 
 
-def _make_request_builder(tokenizer: _FakeTokenizer | None = None):
+def _make_request_builder(
+    tokenizer: _FakeTokenizer | None = None,
+    feature_extractor=None,
+):
     fake_processor = SimpleNamespace(
-        feature_extractor=lambda audio, *, sampling_rate, return_tensors: (
-            SimpleNamespace(input_features=torch.zeros((1, 128, 3000)))
+        feature_extractor=feature_extractor
+        or (
+            lambda audio, *, sampling_rate, return_tensors: SimpleNamespace(
+                input_features=torch.zeros((1, 128, 3000))
+            )
         ),
     )
     request_builder, _ = make_whisper_scheduler_adapters(
@@ -147,6 +153,35 @@ def test_request_builder_reuses_prefix_for_canonical_language(monkeypatch) -> No
     assert first.prompt_token_ids is not second.prompt_token_ids
 
 
+def test_request_builder_reuses_features_without_sharing_request_storage(
+    monkeypatch,
+) -> None:
+    calls = 0
+
+    def feature_extractor(audio, *, sampling_rate, return_tensors):
+        nonlocal calls
+        calls += 1
+        return SimpleNamespace(input_features=torch.zeros((1, 128, 3000)))
+
+    tokenizer = _FakeTokenizer()
+    request_builder = _make_request_builder(tokenizer, feature_extractor)
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(1600, dtype=np.float32),
+    )
+
+    first = request_builder(_make_payload())
+    first_feature = first.req.multimodal_inputs.mm_items[0].feature
+    first_feature.fill_(7.0)
+    second = request_builder(_make_payload())
+    second_feature = second.req.multimodal_inputs.mm_items[0].feature
+
+    assert calls == 1
+    assert first_feature is not second_feature
+    assert torch.count_nonzero(second_feature) == 0
+
+
 def test_request_builder_maps_prompt_to_prev_context(monkeypatch) -> None:
     data = _build(monkeypatch, {"prompt": "hello"})
 
@@ -224,7 +259,7 @@ def test_decoder_budget_invariant_exhaustive() -> None:
             requested_max_new_tokens=requested_max_new,
         )
         assert 1 <= max_new <= 448 - prefix_len
-        for prompt_len in range(0, 301):
+        for prompt_len in range(301):
             prev_block = _build_prev_context_tokens(
                 tokenizer,
                 "x" * prompt_len if prompt_len else None,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Related #1396

## Modifications

- Cache Whisper decoder prefix token IDs per `(language, task)` pair within the
  scheduler-adapter instance using `lru_cache`.
  - Language aliases are resolved before lookup, so `en`, `eng`, and
    `english` share the same cached prefix.
  - The cached value is immutable internally (`tuple[int, ...]`), while each
    request still receives newly assembled list objects and cannot mutate the
    cache.
- Precompute the invariant encoder-side padding token sequence once when the
  scheduler adapters are created.
- Keep per-request prompt/context assembly explicit so custom `prompt`,
  `language`, `task`, and `max_new_tokens` values retain their existing
  behavior.
- Preserve the decoder-context-length invariant before request data reaches
  the GPU.
- Extend unit coverage to verify prefix-cache reuse, canonical language alias
  handling, request-data isolation, and the existing prompt/budget behavior.

This change is limited to Whisper request construction. It does not add a new
model, change model weights or architecture, alter streaming behavior, or
change the shared scheduler defaults.

## Related Issues

Related #1396

## Accuracy Test

This PR does not change Whisper model computation or model parameters. The
request-builder unit tests passed with the CUDA runtime library path required
by the local SGLang installation:

```text
10 passed, 14 warnings
```

The candidate and baseline were also exercised through the real
`/v1/audio/transcriptions` endpoint using the same local `openai/whisper-base`
checkpoint and the same three repository audio fixtures:

- `tests/data/query_to_cars.wav`
- `tests/data/query_to_draw.wav`
- `tests/data/cough.wav`

For each concurrency level, every successful request returned the same set of
three texts on baseline and candidate. The formal measurement phase completed
2,880/2,880 successful requests for each implementation, with no observed
transcription output regression.

## Benchmark & Profiling

### Test setup

- GPU: NVIDIA H20, approximately 96 GiB VRAM
- Model: local `openai/whisper-base` snapshot
- Baseline: parent commit `29389f2`
- Candidate: commit `49046ac` (`feat: request builder`)
- Endpoint: `POST /v1/audio/transcriptions`
- Concurrency levels: 1, 2, 4, 8, 16, and 32
- Five measured repeats per concurrency level
- 96 requests per repeat
- 2,880 measured requests per implementation in total

Each server was started in a fresh process with the same model and runtime
configuration. A separate warmup phase ran 24 requests at concurrency 4 for
each implementation. Warmup requests were intentionally excluded from all
reported aggregates; the reported totals contain only:

```text
6 concurrency levels × 5 repeats × 96 measured requests = 2,880 requests
```

### End-to-end results

I ran three comparable benchmark variants with the same 1088 samples, model, service configuration, and benchmark parameters:

| Concurrency | Feature-cache throughput | No-cache throughput | `origin/main` throughput | Feature vs. no cache | Feature vs. main | No cache vs. main | Feature p95 | No-cache p95 | Main p95 | WER: feature / no cache / main |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 22.674 | 21.453 | 20.515 | +5.69% | +10.53% | +4.57% | 0.053s | 0.054s | 0.057s | 0.0480 / 0.0480 / 0.0480 |
| 4 | 59.518 | 61.585 | 59.722 | -3.36% | -0.34% | +3.12% | 0.080s | 0.076s | 0.080s | 0.0482 / 0.0483 / 0.0484 |
| 8 | 82.643 | 86.403 | 84.171 | -4.35% | -1.82% | +2.65% | 0.111s | 0.105s | 0.108s | 0.0482 / 0.0483 / 0.0483 |
| 16 | 102.276 | 103.937 | 101.359 | -1.60% | +0.90% | +2.54% | 0.188s | 0.179s | 0.190s | 0.0484 / 0.0483 / 0.0484 |
| 32 | 95.806 | 95.314 | 94.258 | +0.52% | +1.64% | +1.12% | 0.393s | 0.398s | 0.403s | 0.0481 / 0.0480 / 0.0481 |

The measured result is workload-dependent: the optimization is most useful
at moderate concurrency (c=4--16), where request construction and admission
overhead are visible. At c=1--2 the change is slightly slower, and at c=32
the workload is close to the single-GPU throughput ceiling and is effectively
flat. Therefore this PR does not claim an unconditional speedup for every
concurrency level.

### Optimized-path verification

The candidate server logs confirmed that the Whisper encoder CUDA-graph path
was actually used after startup:

```text
Captured Whisper encoder CUDA graph batch=2
Captured Whisper encoder CUDA graph batch=1
Replaying Whisper encoder CUDA graph batch=1 request_batch=1
Replaying Whisper encoder CUDA graph batch=2 request_batch=2
```

The request-builder microbenchmark also showed lower CPU-side construction
time for both promptless and prompted requests. The end-to-end results above
are the primary performance evidence for this PR.

### Reproduction outline

Use the local Whisper snapshot and expose the CUDA runtime libraries used by
the installed PyTorch/SGLang environment:

```bash
export MODEL_DIR=/root/.cache/huggingface/hub/models--openai--whisper-base/snapshots/e37978b90ca9030d5170a5c07aadb050351a65bb
export CUDA_VISIBLE_DEVICES=0
export OMP_NUM_THREADS=8
export LD_LIBRARY_PATH=/root/miniconda3/lib/python3.12/site-packages/torch/lib:/root/miniconda3/lib/python3.12/site-packages/nvidia/cu13/lib:${LD_LIBRARY_PATH:-}

python -m sglang_omni.cli serve \
  --model-path "$MODEL_DIR" \
  --port 8000 \
  --log-level info
```

The closed-loop request harness used for the results was:

```bash
python /tmp/run_whisper_retest.py 8000 candidate /tmp/whisper_candidate_retest.json
```

Run the same command against the parent commit for the baseline. The harness
performs the excluded warmup first, then records five repeats for each of
`c=1,2,4,8,16,32`.

## Checklist

- [ ] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as long as
the label remains. Use `/tag-and-rerun-ci higgs` or `/tag-and-rerun-ci moss` to
select a TTS CI model, and `/tag-and-rerun-ci fun-asr` or
`/tag-and-rerun-ci qwen3-asr` to select an ASR CI model. One selector from each
family can be combined, for example `/tag-and-rerun-ci moss fun-asr`. Draft PRs
are skipped even if labeled.
