### PR TITLE
[LLaDA2-Uni] Add thinker tensor parallelism and CUDA graph support

### DIFF
--- a/sglang_omni/models/llada2_uni/components/thinker.py
+++ b/sglang_omni/models/llada2_uni/components/thinker.py
@@ -13,7 +13,10 @@ from transformers import PretrainedConfig
 
 from sglang_omni.models.weight_loader import default_weight_loader
 from sglang_omni.vendor.sglang.core import ForwardBatch
-from sglang_omni.vendor.sglang.distributed import get_tensor_model_parallel_world_size
+from sglang_omni.vendor.sglang.distributed import (
+    get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_reduce,
+)
 from sglang_omni.vendor.sglang.layers import (
     AttentionType,
     MergedColumnParallelLinear,
@@ -166,6 +169,7 @@ class LLaDA2MoeMLP(nn.Module):
         config: PretrainedConfig,
         intermediate_size: int,
         quant_config: Optional[QuantizationConfig] = None,
+        reduce_results: bool = True,
     ):
         super().__init__()
         self.gate_up_proj = MergedColumnParallelLinear(
@@ -179,6 +183,7 @@ class LLaDA2MoeMLP(nn.Module):
             config.hidden_size,
             bias=False,
             quant_config=quant_config,
+            reduce_results=reduce_results,
         )
         self.act_fn = SiluAndMul()
 
@@ -269,7 +274,10 @@ class LLaDA2MoeSparseMoeBlock(nn.Module):
                 config.moe_intermediate_size * config.num_shared_experts
             )
             self.shared_experts = LLaDA2MoeMLP(
-                config, shared_intermediate, quant_config
+                config,
+                shared_intermediate,
+                quant_config,
+                reduce_results=False,
             )
         else:
             self.shared_experts = None
@@ -310,13 +318,17 @@ class LLaDA2MoeSparseMoeBlock(nn.Module):
             topk_ids=topk_ids,
             router_logits=router_logits,
         )
+        # Both expert paths return per-rank partials. Accumulate them in FP32
+        # before the single collective to preserve LLaDA2-Uni TP accuracy.
         y = self.experts(hidden_states, topk_output)
-
-        # Add shared expert output
+        output_dtype = y.dtype
         if self.shared_experts is not None:
-            y = y + self.shared_experts(identity)
+            y = y.float() + self.shared_experts(identity).float()
 
-        return y
+        if get_tensor_model_parallel_world_size() > 1:
+            y = tensor_model_parallel_all_reduce(y)
+
+        return y.to(output_dtype)
 
     def _group_limited_topk(
         self, scores: torch.Tensor

--- a/sglang_omni/models/llada2_uni/stages.py
+++ b/sglang_omni/models/llada2_uni/stages.py
@@ -83,21 +83,27 @@ def create_sglang_dllm_thinker_executor_from_config(
     model_path: str,
     *,
     gpu_id: int = 0,
+    tp_rank: int = 0,
+    tp_size: int = 1,
+    nccl_port: int | None = None,
     thinker_max_seq_len: int = 8192,
     dllm_algorithm: str = "LowConfidence",
     dllm_algorithm_config: str | None = None,
     server_args_overrides: dict[str, Any] | None = None,
 ):
     """Create an DllmScheduler for the LLaDA2-Uni thinker."""
+    if tp_size < 1:
+        raise ValueError(f"tp_size must be >= 1, got {tp_size}")
+
     from sglang_omni.models.llada2_uni.bootstrap import create_dllm_thinker_scheduler
     from sglang_omni.scheduling.sglang_backend import build_sglang_server_args
 
     overrides: dict[str, Any] = {
         "attention_backend": "flashinfer",
-        "disable_cuda_graph": True,
         "sampling_backend": "pytorch",
     }
     overrides.update(server_args_overrides or {})
+    overrides["tp_size"] = tp_size
 
     server_args = build_sglang_server_args(
         model_path,
@@ -112,7 +118,12 @@ def create_sglang_dllm_thinker_executor_from_config(
         server_args.dllm_algorithm,
         server_args.mem_fraction_static,
     )
-    return create_dllm_thinker_scheduler(server_args, gpu_id)
+    return create_dllm_thinker_scheduler(
+        server_args,
+        gpu_id,
+        tp_rank=tp_rank,
+        nccl_port=nccl_port,
+    )
 
 
 def create_decode_executor(model_path: str):

--- a/sglang_omni/scheduling/dllm_scheduler.py
+++ b/sglang_omni/scheduling/dllm_scheduler.py
@@ -70,6 +70,10 @@ class DllmScheduler:
         self._waiting_queue: list[Req] = []
         self._staging_queue: list[Req] = []
 
+        self.tp_rank = getattr(tp_worker, "tp_rank", 0)
+        self.tp_size = server_args.tp_size
+        self.requires_tp_work_fanout = self.tp_size > 1
+
     def start(self) -> None:
         self._running = True
         self._event_loop()

--- a/tests/unit_test/llada2_uni/test_cuda_graph.py
+++ b/tests/unit_test/llada2_uni/test_cuda_graph.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from sglang_omni.models.llada2_uni import stages
+
+
+def _capture_server_args_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    server_args_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    bootstrap_module = ModuleType("sglang_omni.models.llada2_uni.bootstrap")
+
+    def fake_create_scheduler(
+        server_args,
+        gpu_id,
+        *,
+        tp_rank,
+        nccl_port,
+    ):
+        return "scheduler"
+
+    bootstrap_module.create_dllm_thinker_scheduler = fake_create_scheduler
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.models.llada2_uni.bootstrap",
+        bootstrap_module,
+    )
+
+    backend_module = ModuleType("sglang_omni.scheduling.sglang_backend")
+
+    def fake_build_server_args(model_path, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            dllm_algorithm=kwargs["dllm_algorithm"],
+            mem_fraction_static=kwargs.get("mem_fraction_static"),
+        )
+
+    backend_module.build_sglang_server_args = fake_build_server_args
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.scheduling.sglang_backend",
+        backend_module,
+    )
+
+    result = stages.create_sglang_dllm_thinker_executor_from_config(
+        "model",
+        server_args_overrides=server_args_overrides,
+    )
+
+    assert result == "scheduler"
+    return captured
+
+
+def test_thinker_enables_cuda_graph_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    build_kwargs = _capture_server_args_kwargs(monkeypatch)
+
+    assert "disable_cuda_graph" not in build_kwargs
+
+
+def test_thinker_preserves_explicit_cuda_graph_opt_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    build_kwargs = _capture_server_args_kwargs(
+        monkeypatch,
+        server_args_overrides={"disable_cuda_graph": True},
+    )
+
+    assert build_kwargs["disable_cuda_graph"] is True

--- a/tests/unit_test/llada2_uni/test_thinker_tp.py
+++ b/tests/unit_test/llada2_uni/test_thinker_tp.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import pytest
+
+from sglang_omni.models.llada2_uni import stages
+
+
+def test_thinker_factory_propagates_tp_runtime_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    bootstrap_module = ModuleType("sglang_omni.models.llada2_uni.bootstrap")
+
+    def fake_create_scheduler(
+        server_args,
+        gpu_id,
+        *,
+        tp_rank,
+        nccl_port,
+    ):
+        captured["scheduler"] = {
+            "server_args": server_args,
+            "gpu_id": gpu_id,
+            "tp_rank": tp_rank,
+            "nccl_port": nccl_port,
+        }
+        return "scheduler"
+
+    bootstrap_module.create_dllm_thinker_scheduler = fake_create_scheduler
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.models.llada2_uni.bootstrap",
+        bootstrap_module,
+    )
+
+    backend_module = ModuleType("sglang_omni.scheduling.sglang_backend")
+
+    def fake_build_server_args(model_path, **kwargs):
+        captured["build_kwargs"] = {"model_path": model_path, **kwargs}
+        server_args = SimpleNamespace(
+            dllm_algorithm=kwargs["dllm_algorithm"],
+            mem_fraction_static=kwargs.get("mem_fraction_static"),
+        )
+        captured["built_server_args"] = server_args
+        return server_args
+
+    backend_module.build_sglang_server_args = fake_build_server_args
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.scheduling.sglang_backend",
+        backend_module,
+    )
+
+    result = stages.create_sglang_dllm_thinker_executor_from_config(
+        "model",
+        gpu_id=3,
+        tp_rank=2,
+        tp_size=4,
+        nccl_port=29500,
+    )
+
+    assert result == "scheduler"
+    assert captured["build_kwargs"]["tp_size"] == 4
+    scheduler_args = captured["scheduler"]
+    assert scheduler_args["server_args"] is captured["built_server_args"]
+    assert scheduler_args["gpu_id"] == 3
+    assert scheduler_args["tp_rank"] == 2
+    assert scheduler_args["nccl_port"] == 29500
+
+
+def test_sparse_moe_disables_inner_tp_reductions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("sglang")
+    from torch import nn
+
+    from sglang_omni.models.llada2_uni.components import thinker as thinker_module
+
+    captured: dict[str, Any] = {}
+
+    class RoutedExperts(nn.Module):
+        def __init__(self, **kwargs):
+            super().__init__()
+            captured["routed_reduce_results"] = kwargs["reduce_results"]
+
+    class SharedExperts(nn.Module):
+        def __init__(
+            self,
+            config,
+            intermediate_size,
+            quant_config=None,
+            reduce_results=True,
+        ):
+            super().__init__()
+            captured["shared_reduce_results"] = reduce_results
+
+    monkeypatch.setattr(
+        thinker_module,
+        "get_moe_impl_class",
+        lambda quant_config: RoutedExperts,
+    )
+    monkeypatch.setattr(thinker_module, "LLaDA2MoeMLP", SharedExperts)
+
+    config = SimpleNamespace(
+        num_experts=4,
+        num_experts_per_tok=2,
+        n_group=2,
+        topk_group=1,
+        routed_scaling_factor=1.0,
+        router_dtype=None,
+        hidden_size=8,
+        moe_router_enable_expert_bias=False,
+        moe_intermediate_size=16,
+        num_shared_experts=1,
+    )
+    thinker_module.LLaDA2MoeSparseMoeBlock(config, layer_id=3)
+
+    assert captured == {
+        "routed_reduce_results": False,
+        "shared_reduce_results": False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("tp_size", "with_shared_expert", "expected_collectives"),
+    [(1, True, 0), (4, True, 1), (4, False, 1)],
+)
+def test_sparse_moe_reduces_tp_partials_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tp_size: int,
+    with_shared_expert: bool,
+    expected_collectives: int,
+) -> None:
+    pytest.importorskip("sglang")
+    import torch
+    from torch import nn
+
+    from sglang_omni.models.llada2_uni.components import thinker as thinker_module
+    from sglang_omni.models.llada2_uni.components.thinker import (
+        LLaDA2MoeSparseMoeBlock,
+    )
+
+    class RoutedExperts(nn.Module):
+        def forward(self, hidden_states, topk_output):
+            return hidden_states * 2
+
+    class SharedExperts(nn.Module):
+        def forward(self, hidden_states):
+            return hidden_states * 3
+
+    class Gate(nn.Module):
+        expert_bias = None
+
+        def forward(self, hidden_states):
+            return torch.zeros((hidden_states.shape[0], 1))
+
+    block = LLaDA2MoeSparseMoeBlock.__new__(LLaDA2MoeSparseMoeBlock)
+    nn.Module.__init__(block)
+    block.experts = RoutedExperts()
+    block.shared_experts = SharedExperts() if with_shared_expert else None
+    block.gate = Gate()
+    block.num_experts_per_tok = 1
+    block.routed_scaling_factor = 1.0
+    block._group_limited_topk = lambda scores: (
+        torch.ones_like(scores),
+        torch.zeros_like(scores, dtype=torch.int64),
+    )
+
+    reduced_inputs: list[torch.Tensor] = []
+    monkeypatch.setattr(
+        thinker_module,
+        "get_tensor_model_parallel_world_size",
+        lambda: tp_size,
+    )
+
+    def fake_all_reduce(value: torch.Tensor) -> torch.Tensor:
+        reduced_inputs.append(value.clone())
+        return value + 1
+
+    monkeypatch.setattr(
+        thinker_module,
+        "tensor_model_parallel_all_reduce",
+        fake_all_reduce,
+    )
+
+    hidden_states = torch.randn((6, 8), dtype=torch.bfloat16)
+    output = block(hidden_states)
+
+    routed_output = (hidden_states * 2).float()
+    expected_partial = (
+        routed_output + (hidden_states * 3).float()
+        if with_shared_expert
+        else routed_output.bfloat16()
+    )
+    expected_output = expected_partial + (1 if tp_size > 1 else 0)
+
+    assert len(reduced_inputs) == expected_collectives
+    if reduced_inputs:
+        expected_reduce_dtype = torch.float32 if with_shared_expert else torch.bfloat16
+        assert reduced_inputs[0].dtype == expected_reduce_dtype
+        torch.testing.assert_close(reduced_inputs[0], expected_partial)
+    torch.testing.assert_close(output, expected_output.bfloat16())

--- a/tests/unit_test/scheduling/test_dllm_scheduler.py
+++ b/tests/unit_test/scheduling/test_dllm_scheduler.py
@@ -47,6 +47,35 @@ def _scheduler(*, fdfo: bool, block_size: int = 4) -> DllmScheduler:
     return scheduler
 
 
+@pytest.mark.parametrize(
+    ("tp_size", "tp_rank", "expected_fanout"),
+    [(1, 0, False), (4, 1, True)],
+)
+def test_dllm_scheduler_declares_tp_work_fanout(
+    tp_size: int,
+    tp_rank: int,
+    expected_fanout: bool,
+) -> None:
+    scheduler = DllmScheduler(
+        tp_worker=SimpleNamespace(tp_rank=tp_rank),
+        tree_cache=object(),
+        req_to_token_pool=object(),
+        token_to_kv_pool_allocator=object(),
+        server_args=SimpleNamespace(
+            tp_size=tp_size,
+            chunked_prefill_size=128,
+        ),
+        model_config=object(),
+        dllm_config=SimpleNamespace(block_size=128),
+        request_builder=lambda payload: payload,
+        result_adapter=lambda result: result,
+    )
+
+    assert scheduler.tp_rank == tp_rank
+    assert scheduler.tp_size == tp_size
+    assert scheduler.requires_tp_work_fanout is expected_fanout
+
+
 def test_model_worker_fdfo_forwards_carried_states_and_all_result_fields() -> None:
     carried_states = [{"round": 1}, None]
     next_states = [{"round": 2}, None]


### PR DESCRIPTION
## Status

Draft for scope and design feedback. This PR covers LLaDA2-Uni thinker tensor-parallel correctness and model-level decode CUDA graph support. Real-model parity, GPU validation, and performance measurements are required before either part becomes Ready.

## Motivation

The pipeline already launches TP stage processes, but the thinker factory did not propagate `tp_rank`, `tp_size`, or the NCCL port. `DllmScheduler` also did not opt into TP work fanout, so follower ranks did not receive the leader payload.

The sparse MoE block mixed a globally reduced shared-expert result with rank-local routed-expert partials. For LLaDA2-Uni, both paths must be combined and reduced in FP32; lower-precision accumulation/reduction caused an accuracy regression in TP validation.

The model factory also forced `disable_cuda_graph=True`, preventing reuse of the generic SGLang decode CUDA graph path. Removing that model-level opt-out is expected to reduce repeated decode launch overhead, but this Draft claims no measured speedup.

This work addresses the TP and related thinker-execution items in #445. It does not add EP.

## Modifications

- Accept and validate pipeline-injected TP rank, size, GPU ID, and NCCL rendezvous settings.
- Make stage topology authoritative over an optional conflicting `tp_size` server override.
- Forward rank and rendezvous data through the existing SGLang bootstrap.
- Expose TP rank/size and `requires_tp_work_fanout` on `DllmScheduler`; fan out only for TP greater than 1.
- Keep routed and shared MoE outputs rank-local, combine them in FP32, perform one TP all-reduce, and cast back to the routed output dtype. TP=1 avoids the collective.
- Stop forcing `disable_cuda_graph=True` and reuse the existing server-args builder, bootstrap, and decode graph runtime.
- Preserve explicit eager fallback with `server_args_overrides={"disable_cuda_graph": True}`. The generic eager-prefill default is unchanged.
- Add focused tests for TP propagation, fanout, inner-reduction disabling, collective count and dtype, default CUDA graph behavior, and explicit opt-out.

## Scope and reuse

The TP factory plumbing, scheduler fanout contract, explicit CUDA graph override, and generic bootstrap are reusable by other model stages. The sparse-MoE reduction order and mandatory FP32 combine/reduce are LLaDA2-Uni correctness requirements; other models must validate their own numerical and sharding semantics.

Out of scope:

- expert parallelism
- image API, CFG, image decoder, or image-generation scheduler wiring
- production throughput and latency tuning

## Planned split

After maintainer feedback, this umbrella Draft will be replaced by two independently reviewable Ready PRs:

1. **Thinker TP correctness:** runtime propagation, scheduler fanout, MoE collective semantics, and TP=1/2/4 T2T/I2T parity.
2. **Model-level CUDA graph:** default decode graph enablement, explicit eager opt-out, eager/graph parity, memory, warm latency, and TP validation.

## Related Issues

Part of #445. This PR must not close the full LLaDA2-Uni support issue.

## Accuracy Test

### Local verification

- Focused CUDA graph and thinker TP tests: **3 passed, 4 skipped**
- Pipeline topology and placement regression tests: **72 passed, 2 deselected**
- Ruff check and format check: **passed**
- Python `compileall`: **passed**
- `git diff --check`: **passed**

Real-model TP parity, GPU execution, eager/CUDA-graph parity, and TP=2/4 validation have not been run for this Draft.

## Benchmark & Profiling

No performance result is claimed. Before the split PRs become Ready, validation will report TP=1/2/4 parity, latency, throughput, memory, collective overhead, eager/graph parity, graph capture overhead, and explicit eager fallback.

## Contributors

- @kunchengit
- @btw616
- @LiRongchuan

## Checklist

- [x] Format and static checks completed.
- [x] Focused unit tests added.
- [x] Model/runtime boundary and explicit opt-out documented.
- [ ] Real-model TP accuracy and GPU measurements pending.
- [ ] Eager/CUDA graph parity and benchmarks pending.
- [ ] For reviewers: If you have not contributed and are only assisting with merging main, please remove yourself as a co-author when merging.

## CI

This PR is intentionally a Draft. Self-hosted GPU CI and real-model validation will be requested after initial scope and design feedback.