### PR TITLE
[LLaDA2-Uni] Support multiple in-flight stage payloads

### DIFF
--- a/sglang_omni/comm/engine.py
+++ b/sglang_omni/comm/engine.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """Omni communication engine facade used by pipeline stages."""
+
 from __future__ import annotations
 
 import asyncio
 import logging
 from contextlib import suppress
 from dataclasses import dataclass
+from itertools import count
 from typing import Any, Callable
 from uuid import uuid4
 
@@ -113,6 +115,7 @@ class CommEngine:
         ] = {}
         self._send_workers: dict[str, asyncio.Task] = {}
         self._pending: dict[str, _PendingTransfer] = {}
+        self._payload_send_sequence = count()
         # Failed pending KV transfers stay pinned until this dying process exits.
         self._retained_pending_kv_transfers: list[_PendingTransfer] = []
         self._kv_pools: dict[str, KVPool] = {}
@@ -659,6 +662,10 @@ class CommEngine:
         control_ms = -1.0
         try:
             write_start = _comm_now_ns()
+            payload_object_id = (
+                f"{job.request_id}:payload:{job.from_stage}:{job.to_stage}:"
+                f"{next(self._payload_send_sequence)}"
+            )
             data_ref, op = await stage_io.write_payload(
                 job.relay,
                 job.request_id,
@@ -666,6 +673,7 @@ class CommEngine:
                 transport=job.transport,
                 from_stage=job.from_stage,
                 to_stage=job.to_stage,
+                object_id=payload_object_id,
             )
             write_ms = _comm_elapsed_ms(write_start)
             object_id = data_ref.object_id

--- a/sglang_omni/comm/stage_io.py
+++ b/sglang_omni/comm/stage_io.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Adapters between stage objects and data-plane refs."""
+
 from __future__ import annotations
 
 import base64
@@ -47,8 +48,7 @@ def relay_device(relay: Relay) -> str:
     device = relay.device
     if not isinstance(device, str):
         raise TypeError(
-            f"{type(relay).__name__}.device must be str, got "
-            f"{type(device).__name__}"
+            f"{type(relay).__name__}.device must be str, got {type(device).__name__}"
         )
     return device
 
@@ -275,8 +275,7 @@ def deserialize_direct_cuda_ipc_stream_chunk(
         return data, None
     if not isinstance(raw_metadata, dict):
         raise TypeError(
-            "direct CUDA IPC metadata must be dict, got "
-            f"{type(raw_metadata).__name__}"
+            f"direct CUDA IPC metadata must be dict, got {type(raw_metadata).__name__}"
         )
     metadata = deserialize_direct_ipc_metadata(raw_metadata)
     if not isinstance(metadata, dict):
@@ -295,6 +294,7 @@ async def write_payload(
     transport: TransportKind,
     from_stage: str | None = None,
     to_stage: str | None = None,
+    object_id: str | None = None,
 ) -> tuple[DataRef, Any]:
     data_without_tensors, tensors = extract_tensors(payload.data)
     packed, entries = _pack_tensors(tensors, device=relay_device(relay))
@@ -310,7 +310,9 @@ async def write_payload(
     )
     data_ref = DataRef(
         version=1,
-        object_id=f"{request_id}:payload:{from_stage or ''}:{to_stage or ''}",
+        object_id=(
+            object_id or f"{request_id}:payload:{from_stage or ''}:{to_stage or ''}"
+        ),
         kind=DataKind.STAGE_PAYLOAD,
         transport=transport,
         layout=DataLayout.PACKED_TENSORS,

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -6,6 +6,7 @@ stream chunk routing, abort tracking, profiling.
 
 Dispatches all compute to scheduler (OmniScheduler or SimpleScheduler).
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -144,6 +145,7 @@ class Stage:
         self._active_requests: set[str] = set()
         self._stream_queue: StreamQueue | None = None
         self._stream_chunk_counters: dict[tuple[str, str], int] = {}
+        self._inflight_work_pending: dict[str, int] = {}
         self._first_stream_chunk_seen: set[str] = set()
         self._local_stream_targets: dict[str, set[str]] = {}
         self._nonlocal_stream_targets: dict[str, set[str]] = {}
@@ -298,7 +300,13 @@ class Stage:
                 if isinstance(msg, ShutdownMessage):
                     break
                 if isinstance(msg, TPWorkMessage):
-                    await self._execute(msg.data)
+                    if msg.request_id in self._aborted:
+                        continue
+                    self._active_requests.add(msg.request_id)
+                    await self._execute(
+                        msg.data,
+                        track_inflight_work=self._tracks_multiple_inflight_work(),
+                    )
                     continue
                 await self._handle_message(msg)
         except asyncio.CancelledError:
@@ -408,7 +416,10 @@ class Stage:
         )
 
         payload = msg.data  # StagePayload from coordinator
-        await self._execute(payload)
+        await self._execute(
+            payload,
+            track_inflight_work=self._tracks_multiple_inflight_work(),
+        )
 
     async def _on_data_ready(
         self,
@@ -453,7 +464,6 @@ class Stage:
             await self._send_data_ack(
                 msg, data_ref, success=False, error=_error_text(exc)
             )
-            self._comm.cleanup(request_id)
             await self._wait_for_receive_predecessor(predecessor)
             await self._send_failure(request_id, f"relay read failed: {exc}")
             return
@@ -559,7 +569,10 @@ class Stage:
                 event_name="stage_aggregate_ready",
                 metadata={"from_stage": from_stage},
             )
-            await self._execute(merged)
+            await self._execute(
+                merged,
+                track_inflight_work=self._tracks_multiple_inflight_work(),
+            )
 
     async def _on_stream_chunk(
         self,
@@ -663,8 +676,6 @@ class Stage:
         if self._open_pre_payload_stream_if_allowed(request_id):
             self._route_stream_item(request_id, item)
             return
-        with suppress(Exception):
-            self.scheduler.abort(request_id)
         await self._send_failure(
             request_id,
             (
@@ -689,8 +700,6 @@ class Stage:
             request_id,
             error,
         )
-        with suppress(Exception):
-            self.scheduler.abort(request_id)
         await self._send_failure(request_id, str(error))
 
     def _data_ref_from_message(self, msg: DataReadyMessage) -> DataRef:
@@ -821,8 +830,6 @@ class Stage:
 
         if is_done:
             if not self._open_pre_payload_stream_if_allowed(request_id):
-                with suppress(Exception):
-                    self.scheduler.abort(request_id)
                 await self._send_failure(
                     request_id,
                     (
@@ -856,8 +863,26 @@ class Stage:
             IncomingMessage(request_id=request_id, type="stream_chunk", data=item)
         )
 
-    async def _execute(self, payload: Any) -> None:
+    def _tracks_multiple_inflight_work(self) -> bool:
+        return bool(
+            getattr(
+                self.scheduler,
+                "allow_multiple_inflight_per_request",
+                False,
+            )
+        )
+
+    async def _execute(
+        self,
+        payload: Any,
+        *,
+        track_inflight_work: bool = False,
+    ) -> None:
         request_id = payload.request_id
+        if track_inflight_work:
+            self._inflight_work_pending[request_id] = (
+                self._inflight_work_pending.get(request_id, 0) + 1
+            )
         _emit_event(
             request_id=request_id,
             stage=self.name,
@@ -1044,6 +1069,20 @@ class Stage:
             elif out.type == "error":
                 await self._send_failure(out.request_id, str(out.data))
 
+    def _complete_inflight_work(self, request_id: str) -> bool:
+        pending = self._inflight_work_pending.get(request_id, 0)
+        if pending <= 1:
+            self._inflight_work_pending.pop(request_id, None)
+            return False
+        self._inflight_work_pending[request_id] = pending - 1
+        return True
+
+    def _finish_inflight_work(self, request_id: str) -> None:
+        if request_id not in self._active_requests:
+            return
+        if not self._complete_inflight_work(request_id):
+            self._clear_request_state(request_id)
+
     async def _drain_outbox_follower(self) -> None:
         """Drain follower outbox without emitting external stage traffic."""
         loop = asyncio.get_running_loop()
@@ -1055,8 +1094,11 @@ class Stage:
             except _queue_mod.Empty:
                 continue
 
+            if out.request_id not in self._active_requests:
+                continue
+
             if out.type == "result":
-                self._clear_request_state(out.request_id)
+                self._finish_inflight_work(out.request_id)
             elif out.type == "stream":
                 continue
             elif out.type == "error":
@@ -1067,7 +1109,15 @@ class Stage:
     async def _route_result(self, request_id: str, result: Any) -> None:
         """Route a completed result to next stage(s) or complete at coordinator."""
         if not self._owns_external_io:
-            self._clear_request_state(request_id)
+            self._finish_inflight_work(request_id)
+            return
+        next_stages = self.get_next(request_id, result)
+        if next_stages is None and self._tracks_multiple_inflight_work():
+            await self._send_failure(
+                request_id,
+                f"Stage {self.name}: a terminal stage cannot use multiple "
+                "in-flight work per request",
+            )
             return
         # Send stream done to the active stream targets for this request.
         stream_targets = self._stream_targets
@@ -1087,7 +1137,6 @@ class Stage:
                 is_done=True,
             )
 
-        next_stages = self.get_next(request_id, result)
         if next_stages is None:
             # Terminal: notify coordinator
             _emit_event(
@@ -1124,7 +1173,7 @@ class Stage:
                     stream_targets_for_request=stream_targets_for_request,
                 )
 
-        self._clear_request_state(request_id)
+        self._finish_inflight_work(request_id)
 
     async def _send_to_stage(
         self,
@@ -1544,22 +1593,29 @@ class Stage:
         await self.control_plane.send_stream(msg)
 
     async def _send_failure(self, request_id: str, error: str) -> None:
-        self._record_aborted_request_id(request_id)
-        if not self._owns_external_io:
-            self._clear_request_state(request_id)
-            raise RuntimeError(f"Follower stage {self.name} failed: {error}")
-        await self.control_plane.send_complete(
-            CompleteMessage(
-                request_id=request_id,
-                from_stage=self.name,
-                success=False,
-                error=error,
+        if not self._record_aborted_request_id(request_id):
+            return
+        with suppress(Exception):
+            self.scheduler.abort(request_id)
+        with suppress(Exception):
+            self._comm.cleanup(request_id)
+        try:
+            if not self._owns_external_io:
+                raise RuntimeError(f"Follower stage {self.name} failed: {error}")
+            await self.control_plane.send_complete(
+                CompleteMessage(
+                    request_id=request_id,
+                    from_stage=self.name,
+                    success=False,
+                    error=error,
+                )
             )
-        )
-        self._clear_request_state(request_id)
+        finally:
+            self._clear_request_state(request_id)
 
     def _clear_request_state(self, request_id: str) -> None:
         self._active_requests.discard(request_id)
+        self._inflight_work_pending.pop(request_id, None)
         self.input_handler.cancel(request_id)
         if self._stream_queue is not None:
             self._stream_queue.close(request_id)
@@ -1586,11 +1642,7 @@ class Stage:
             if request_id not in self._aborted
         ]
         for request_id in active_request_ids:
-            with suppress(Exception):
-                self.scheduler.abort(request_id)
             await self._send_failure(request_id, error)
-            with suppress(Exception):
-                self._comm.cleanup(request_id)
         self.control_plane.close()
 
     async def _abort_listener(self) -> None:
@@ -1606,16 +1658,20 @@ class Stage:
             if self._scheduler_crash_error is None and self._running:
                 logger.exception("Stage %s abort listener crashed", self.name)
 
-    def _record_aborted_request_id(self, request_id: str) -> None:
+    def _record_aborted_request_id(self, request_id: str) -> bool:
+        if request_id in self._aborted:
+            return False
         self._aborted.add(request_id)
         if len(self._aborted) > 10000:
             excess = len(self._aborted) - 5000
             it = iter(self._aborted)
             to_remove = [next(it) for _ in range(excess)]
             self._aborted -= set(to_remove)
+        return True
 
     def _on_abort(self, request_id: str) -> None:
-        self._record_aborted_request_id(request_id)
+        if not self._record_aborted_request_id(request_id):
+            return
         self._comm.cleanup(request_id)
         self._clear_request_state(request_id)
         self.scheduler.abort(request_id)

--- a/sglang_omni/scheduling/simple_scheduler.py
+++ b/sglang_omni/scheduling/simple_scheduler.py
@@ -6,6 +6,7 @@ No KV cache, no batching. Just: inbox.get() → run function → outbox.put().
 
 Same inbox/outbox interface as OmniScheduler so Stage doesn't need branching.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -42,6 +43,7 @@ class SimpleScheduler:
         max_concurrency: int = 1,
         abort_callback: Callable[[str], None] | None = None,
         shutdown_callback: Callable[[], None] | None = None,
+        allow_multiple_inflight_per_request: bool = False,
     ):
         self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
         self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
@@ -66,6 +68,7 @@ class SimpleScheduler:
             )
         self._abort_callback = abort_callback
         self._shutdown_callback = shutdown_callback
+        self.allow_multiple_inflight_per_request = allow_multiple_inflight_per_request
         self._shutdown_lock = threading.Lock()
         self._aborted: set[str] = set()
         self._abort_lock = threading.Lock()
@@ -80,13 +83,9 @@ class SimpleScheduler:
         except Exception:
             logger.exception("SimpleScheduler: abort cleanup failed for %s", request_id)
 
-    def _consume_if_aborted(self, request_id: str) -> bool:
+    def _is_aborted(self, request_id: str) -> bool:
         with self._abort_lock:
-            if request_id not in self._aborted:
-                return False
-            self._aborted.discard(request_id)
-        self._cleanup_aborted_request(request_id)
-        return True
+            return request_id in self._aborted
 
     def _message_cost(self, msg: IncomingMessage) -> int:
         if self._request_cost_fn is None or msg.type != "new_request":
@@ -159,17 +158,17 @@ class SimpleScheduler:
     def _run_single(
         self, msg: IncomingMessage, loop: asyncio.AbstractEventLoop
     ) -> None:
-        if self._consume_if_aborted(msg.request_id):
+        if self._is_aborted(msg.request_id):
             return
         try:
             result = self._fn(msg.data)
             if asyncio.iscoroutine(result):
                 result = loop.run_until_complete(result)
         except Exception:
-            if self._consume_if_aborted(msg.request_id):
+            if self._is_aborted(msg.request_id):
                 return
             raise
-        if self._consume_if_aborted(msg.request_id):
+        if self._is_aborted(msg.request_id):
             return
         self._emit_result(msg.request_id, result, self.outbox)
 
@@ -178,21 +177,25 @@ class SimpleScheduler:
         batch: list[IncomingMessage],
         loop: asyncio.AbstractEventLoop,
     ) -> None:
-        if self._batch_fn is None or len(batch) <= 1:
-            for msg in batch:
+        active_batch = [msg for msg in batch if not self._is_aborted(msg.request_id)]
+        if not active_batch:
+            return
+        if self._batch_fn is None or len(active_batch) <= 1:
+            for msg in active_batch:
                 self._run_single(msg, loop)
             return
 
-        payloads = [msg.data for msg in batch]
+        payloads = [msg.data for msg in active_batch]
         results = self._batch_fn(payloads)
         if asyncio.iscoroutine(results):
             results = loop.run_until_complete(results)
-        if len(results) != len(batch):
+        if len(results) != len(active_batch):
             raise ValueError(
-                f"batch_compute_fn returned {len(results)} results for {len(batch)} requests"
+                "batch_compute_fn returned "
+                f"{len(results)} results for {len(active_batch)} requests"
             )
-        for msg, result in zip(batch, results):
-            if self._consume_if_aborted(msg.request_id):
+        for msg, result in zip(active_batch, results):
+            if self._is_aborted(msg.request_id):
                 continue
             self._emit_result(msg.request_id, result, self.outbox)
 
@@ -223,7 +226,7 @@ class SimpleScheduler:
                     continue
 
                 if msg.type == "new_request":
-                    if self._consume_if_aborted(msg.request_id):
+                    if self._is_aborted(msg.request_id):
                         continue
                     batch = [msg]
                     try:
@@ -234,7 +237,7 @@ class SimpleScheduler:
                             "SimpleScheduler: compute_fn failed for %s", msg.request_id
                         )
                         for failed_msg in batch:
-                            if self._consume_if_aborted(failed_msg.request_id):
+                            if self._is_aborted(failed_msg.request_id):
                                 continue
                             self._emit_error(
                                 failed_msg.request_id,
@@ -272,17 +275,17 @@ class SimpleScheduler:
                     continue
                 if msg.type != "new_request":
                     continue
-                if self._consume_if_aborted(msg.request_id):
+                if self._is_aborted(msg.request_id):
                     continue
                 try:
                     result = await asyncio.to_thread(
                         self._run_compute_in_thread, msg.data
                     )
-                    if self._consume_if_aborted(msg.request_id):
+                    if self._is_aborted(msg.request_id):
                         continue
                     self._emit_result(msg.request_id, result, self.outbox)
                 except Exception as exc:
-                    if self._consume_if_aborted(msg.request_id):
+                    if self._is_aborted(msg.request_id):
                         continue
                     logger.exception(
                         "SimpleScheduler: compute_fn failed for %s", msg.request_id
@@ -309,9 +312,11 @@ class SimpleScheduler:
 
     def abort(self, request_id: str) -> None:
         with self._abort_lock:
+            is_new_abort = request_id not in self._aborted
             self._aborted.add(request_id)
             if len(self._aborted) > 10000:
                 excess = len(self._aborted) - 5000
                 for stale_request_id in list(self._aborted)[:excess]:
                     self._aborted.discard(stale_request_id)
-        self._cleanup_aborted_request(request_id)
+        if is_new_abort:
+            self._cleanup_aborted_request(request_id)

--- a/tests/unit_test/pipeline/test_comm_engine_ack.py
+++ b/tests/unit_test/pipeline/test_comm_engine_ack.py
@@ -141,6 +141,60 @@ def test_comm_engine_releases_sender_op_after_data_ack() -> None:
     asyncio.run(_run())
 
 
+def test_comm_engine_assigns_unique_ids_to_inflight_payloads() -> None:
+    async def _run() -> None:
+        relay = _AckedRelay()
+        control_plane = RecordingStageControlPlane()
+        engine = CommEngine(
+            CommRouter(
+                stage_name="producer",
+                gpu_id=None,
+                same_process_targets=set(),
+                gpu_stage_names=set(),
+                comm_config={"ack_timeout_s": 1.0},
+                injected_relay=relay,
+            )
+        )
+
+        refs = []
+        for sequence in (1, 2):
+            refs.append(
+                await engine.send_payload(
+                    relay=relay,
+                    control_plane=control_plane,
+                    request_id="req-1",
+                    payload=make_stage_payload(
+                        request_id="req-1",
+                        data={"sequence": sequence, "x": torch.ones(2)},
+                    ),
+                    transport=TransportKind.SHM,
+                    from_stage="producer",
+                    to_stage="consumer",
+                    target_endpoint="inproc://consumer",
+                )
+            )
+
+        assert refs[0].object_id != refs[1].object_id
+        assert {
+            DataRef.from_dict(message.data_ref).object_id
+            for _, _, message in control_plane.sent_to_stage
+        } == {ref.object_id for ref in refs}
+
+        for ref in refs:
+            engine.ack_transfer(
+                DataAckMessage(
+                    request_id="req-1",
+                    from_stage="consumer",
+                    to_stage="producer",
+                    object_id=ref.object_id,
+                )
+            )
+        await _wait_until(lambda: all(op.waited for op in relay.ops))
+        assert all(op.acked for op in relay.ops)
+
+    asyncio.run(_run())
+
+
 def test_comm_engine_ignores_unknown_data_ack() -> None:
     engine = CommEngine(
         CommRouter(

--- a/tests/unit_test/pipeline/test_simple_scheduler_concurrent.py
+++ b/tests/unit_test/pipeline/test_simple_scheduler_concurrent.py
@@ -60,6 +60,69 @@ def test_stop_runs_shutdown_callback_once() -> None:
     assert shutdowns == [None]
 
 
+def test_abort_suppresses_all_queued_work_and_cleans_up_once() -> None:
+    computed: list[str] = []
+    cleanups: list[str] = []
+    scheduler = SimpleScheduler(
+        lambda payload: computed.append(payload) or payload,
+        abort_callback=cleanups.append,
+    )
+    scheduler.abort("req-abort")
+    scheduler.abort("req-abort")
+    loop = asyncio.new_event_loop()
+
+    try:
+        scheduler._run_single(
+            IncomingMessage("req-abort", "new_request", "first"), loop
+        )
+        scheduler._run_single(
+            IncomingMessage("req-abort", "new_request", "second"), loop
+        )
+    finally:
+        loop.close()
+
+    assert computed == []
+    assert scheduler.outbox.empty()
+    assert cleanups == ["req-abort"]
+
+
+def test_batch_compute_excludes_aborted_work() -> None:
+    computed: list[str] = []
+
+    def compute_batch(payloads: list[str]) -> list[str]:
+        computed.extend(payloads)
+        return [payload.upper() for payload in payloads]
+
+    def compute_one(payload: str) -> str:
+        computed.append(payload)
+        return payload.upper()
+
+    scheduler = SimpleScheduler(
+        compute_one,
+        batch_compute_fn=compute_batch,
+        max_batch_size=2,
+    )
+    scheduler.abort("req-abort")
+    loop = asyncio.new_event_loop()
+
+    try:
+        scheduler._run_batch(
+            [
+                IncomingMessage("req-abort", "new_request", "discard"),
+                IncomingMessage("req-active", "new_request", "keep"),
+            ],
+            loop,
+        )
+    finally:
+        loop.close()
+
+    result = scheduler.outbox.get_nowait()
+    assert computed == ["keep"]
+    assert result.request_id == "req-active"
+    assert result.data == "KEEP"
+    assert scheduler.outbox.empty()
+
+
 def test_max_concurrency_runs_sync_fn_in_parallel() -> None:
     """Two sync ``compute_fn`` invocations must be in flight simultaneously
     when ``max_concurrency=2``, not serialized."""

--- a/tests/unit_test/pipeline/test_stage_streaming.py
+++ b/tests/unit_test/pipeline/test_stage_streaming.py
@@ -14,11 +14,20 @@ from sglang_omni.comm.data_ref import DataKind, DataRef, TransportKind
 from sglang_omni.comm.engine import CommEngine
 from sglang_omni.config.schema import StageConfig
 from sglang_omni.models.fishaudio_s2_pro.config import S2ProPipelineConfig
+from sglang_omni.pipeline.stage.input import InputHandler
 from sglang_omni.pipeline.stage.runtime import Stage
 from sglang_omni.pipeline.stage.stream_queue import StreamItem, StreamQueue
-from sglang_omni.proto import DataReadyMessage, OmniRequest, StagePayload
+from sglang_omni.pipeline.tp_control import TPWorkMessage
+from sglang_omni.proto import (
+    DataReadyMessage,
+    OmniRequest,
+    ShutdownMessage,
+    StagePayload,
+    SubmitMessage,
+)
 from sglang_omni.relay.shm import ShmRelay
 from sglang_omni.scheduling.messages import OutgoingMessage
+from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
 
 class _FakeControlPlane:
@@ -45,6 +54,18 @@ class _FakeControlPlane:
         self.completions.append(msg)
 
 
+class _BlockingCompleteControlPlane(_FakeControlPlane):
+    def __init__(self) -> None:
+        super().__init__()
+        self.complete_started = asyncio.Event()
+        self.release_complete = asyncio.Event()
+
+    async def send_complete(self, msg) -> None:
+        self.completions.append(msg)
+        self.complete_started.set()
+        await self.release_complete.wait()
+
+
 class _FakeRelay:
     def __init__(self) -> None:
         self.device = "cpu"
@@ -66,6 +87,100 @@ class _FakeRelay:
 
     def cleanup(self, request_id: str) -> None:
         pass
+
+
+class _CountingRelay(_FakeRelay):
+    def __init__(self) -> None:
+        super().__init__()
+        self.cleaned: list[str] = []
+
+    def cleanup(self, request_id: str) -> None:
+        self.cleaned.append(request_id)
+
+
+class _CountingInput(InputHandler):
+    def __init__(self) -> None:
+        self.cancelled: list[str] = []
+
+    def receive(
+        self, request_id: str, from_stage: str, data: StagePayload
+    ) -> StagePayload:
+        del request_id, from_stage
+        return data
+
+    def cancel(self, request_id: str) -> None:
+        self.cancelled.append(request_id)
+
+
+class _FakeLocalDispatcher:
+    def __init__(self) -> None:
+        self.payloads: list[StagePayload] = []
+
+    async def send_payload(
+        self,
+        *,
+        from_stage: str,
+        to_stage: str,
+        request_id: str,
+        payload: StagePayload,
+    ) -> None:
+        del from_stage, to_stage, request_id
+        self.payloads.append(payload)
+
+
+class _BlockingLocalDispatcher(_FakeLocalDispatcher):
+    def __init__(self) -> None:
+        super().__init__()
+        self.first_send_started = asyncio.Event()
+        self.release_first_send = asyncio.Event()
+
+    async def send_payload(
+        self,
+        *,
+        from_stage: str,
+        to_stage: str,
+        request_id: str,
+        payload: StagePayload,
+    ) -> None:
+        await super().send_payload(
+            from_stage=from_stage,
+            to_stage=to_stage,
+            request_id=request_id,
+            payload=payload,
+        )
+        if len(self.payloads) == 1:
+            self.first_send_started.set()
+            await self.release_first_send.wait()
+
+
+class _QueuedFollowerControlPlane(_FakeControlPlane):
+    def __init__(self) -> None:
+        super().__init__()
+        self.work: asyncio.Queue = asyncio.Queue()
+        self.aborts: asyncio.Queue = asyncio.Queue()
+
+    async def recv(self):
+        return await self.work.get()
+
+    async def recv_abort(self):
+        return await self.aborts.get()
+
+
+class _PassiveScheduler:
+    def __init__(self, *, allow_multiple_inflight_per_request: bool) -> None:
+        self.inbox = queue.Queue()
+        self.outbox = queue.Queue()
+        self.allow_multiple_inflight_per_request = allow_multiple_inflight_per_request
+        self.aborted: list[str] = []
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def abort(self, request_id: str) -> None:
+        self.aborted.append(request_id)
 
 
 class _DoneOp:
@@ -812,5 +927,525 @@ def test_stage_drops_payload_after_abort_during_relay_read() -> None:
         await stage._on_data_ready(await _make_relay_payload(relay, payload))
 
         assert scheduler.inbox.empty()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.parametrize("stream_first", [False, True])
+def test_stage_preserves_payload_and_stream_arrival_order(stream_first: bool) -> None:
+    async def _run() -> None:
+        scheduler = SimpleNamespace(
+            outbox=queue.Queue(),
+            inbox=queue.Queue(),
+            abort=lambda request_id: None,
+        )
+        stage = Stage(
+            name="relay_consumer",
+            role="single",
+            get_next=lambda request_id, output: None,
+            gpu_id=None,
+            endpoints={},
+            control_plane=_FakeControlPlane(),
+            relay=_FakeRelay(),
+            scheduler=scheduler,
+            can_accept_stream_before_payload=True,
+        )
+        stage._stream_queue = StreamQueue(max_pending=4)
+        payload = StagePayload(
+            request_id="req",
+            request=OmniRequest(inputs="payload"),
+            data={"kind": "payload"},
+        )
+
+        async def receive_stream() -> None:
+            await stage.receive_local_stream_chunk(
+                "req",
+                "producer",
+                0,
+                torch.tensor([1]),
+                {"kind": "chunk"},
+            )
+
+        async def receive_payload() -> None:
+            await stage.receive_local_payload("req", "producer", payload)
+
+        arrivals = (
+            (receive_stream, receive_payload)
+            if stream_first
+            else (receive_payload, receive_stream)
+        )
+        for receive in arrivals:
+            await receive()
+
+        assert [scheduler.inbox.get_nowait().type for _ in range(2)] == (
+            ["stream_chunk", "new_request"]
+            if stream_first
+            else ["new_request", "stream_chunk"]
+        )
+
+    asyncio.run(_run())
+
+
+def test_stage_keeps_request_active_until_all_payload_work_finishes() -> None:
+    async def _run() -> None:
+        control_plane = _FakeControlPlane()
+        local_dispatcher = _FakeLocalDispatcher()
+        input_handler = _CountingInput()
+        scheduler = SimpleScheduler(
+            lambda payload: payload,
+            allow_multiple_inflight_per_request=True,
+        )
+        stage = Stage(
+            name="relay_consumer",
+            role="single",
+            get_next=lambda request_id, output: "collector",
+            gpu_id=None,
+            endpoints={"collector": "inproc://collector"},
+            control_plane=control_plane,
+            input_handler=input_handler,
+            relay=_FakeRelay(),
+            scheduler=scheduler,
+            same_process_targets={"collector"},
+            local_dispatcher=local_dispatcher,
+        )
+
+        results = []
+        for sequence in (1, 2):
+            payload = StagePayload(
+                request_id="req",
+                request=OmniRequest(inputs="payload"),
+                data={"sequence": sequence},
+            )
+            await stage.receive_local_payload("req", "producer", payload)
+            incoming = scheduler.inbox.get_nowait()
+            results.append(incoming.data)
+
+        assert stage._inflight_work_pending == {"req": 2}
+        await stage._route_result("req", results[0])
+        assert stage._inflight_work_pending == {"req": 1}
+        assert "req" in stage._active_requests
+        assert input_handler.cancelled == []
+
+        await stage._route_result("req", results[1])
+
+        assert [payload.data for payload in local_dispatcher.payloads] == [
+            {"sequence": 1},
+            {"sequence": 2},
+        ]
+        assert control_plane.completions == []
+        assert "req" not in stage._active_requests
+        assert "req" not in stage._inflight_work_pending
+
+    asyncio.run(_run())
+
+
+def test_stage_does_not_clear_new_work_received_while_routing_result() -> None:
+    async def _run() -> None:
+        local_dispatcher = _BlockingLocalDispatcher()
+        input_handler = _CountingInput()
+        scheduler = SimpleScheduler(
+            lambda payload: payload,
+            allow_multiple_inflight_per_request=True,
+        )
+        stage = Stage(
+            name="relay_consumer",
+            role="single",
+            get_next=lambda request_id, output: "collector",
+            gpu_id=None,
+            endpoints={"collector": "inproc://collector"},
+            control_plane=_FakeControlPlane(),
+            input_handler=input_handler,
+            relay=_FakeRelay(),
+            scheduler=scheduler,
+            same_process_targets={"collector"},
+            local_dispatcher=local_dispatcher,
+        )
+
+        first_payload = StagePayload(
+            request_id="req",
+            request=OmniRequest(inputs="payload"),
+            data={"sequence": 1},
+        )
+        await stage.receive_local_payload("req", "producer", first_payload)
+        first_result = scheduler.inbox.get_nowait().data
+        first_route = asyncio.create_task(stage._route_result("req", first_result))
+        await asyncio.wait_for(local_dispatcher.first_send_started.wait(), timeout=1.0)
+
+        second_payload = StagePayload(
+            request_id="req",
+            request=OmniRequest(inputs="payload"),
+            data={"sequence": 2},
+        )
+        await stage.receive_local_payload("req", "producer", second_payload)
+        second_result = scheduler.inbox.get_nowait().data
+        local_dispatcher.release_first_send.set()
+        await asyncio.wait_for(first_route, timeout=1.0)
+
+        assert stage._inflight_work_pending == {"req": 1}
+        assert stage._active_requests == {"req"}
+        assert input_handler.cancelled == []
+
+        await stage._route_result("req", second_result)
+
+        assert [payload.data for payload in local_dispatcher.payloads] == [
+            {"sequence": 1},
+            {"sequence": 2},
+        ]
+        assert "req" not in stage._active_requests
+        assert "req" not in stage._inflight_work_pending
+        assert input_handler.cancelled == ["req"]
+
+    asyncio.run(_run())
+
+
+def test_stage_tracks_submit_while_new_payload_arrives_during_result_routing() -> None:
+    async def _run() -> None:
+        local_dispatcher = _BlockingLocalDispatcher()
+        input_handler = _CountingInput()
+        scheduler = SimpleScheduler(
+            lambda payload: payload,
+            allow_multiple_inflight_per_request=True,
+        )
+        stage = Stage(
+            name="relay_consumer",
+            role="single",
+            get_next=lambda request_id, output: "collector",
+            gpu_id=None,
+            endpoints={"collector": "inproc://collector"},
+            control_plane=_FakeControlPlane(),
+            input_handler=input_handler,
+            relay=_FakeRelay(),
+            scheduler=scheduler,
+            same_process_targets={"collector"},
+            local_dispatcher=local_dispatcher,
+        )
+
+        first_payload = StagePayload(
+            request_id="req",
+            request=OmniRequest(inputs="payload"),
+            data={"sequence": 1},
+        )
+        await stage._on_submit(SubmitMessage(request_id="req", data=first_payload))
+        first_result = scheduler.inbox.get_nowait().data
+        first_route = asyncio.create_task(stage._route_result("req", first_result))
+        await asyncio.wait_for(local_dispatcher.first_send_started.wait(), timeout=1.0)
+
+        second_payload = StagePayload(
+            request_id="req",
+            request=OmniRequest(inputs="payload"),
+            data={"sequence": 2},
+        )
+        await stage.receive_local_payload("req", "producer", second_payload)
+        second_result = scheduler.inbox.get_nowait().data
+        local_dispatcher.release_first_send.set()
+        await asyncio.wait_for(first_route, timeout=1.0)
+
+        assert stage._inflight_work_pending == {"req": 1}
+        assert stage._active_requests == {"req"}
+        assert input_handler.cancelled == []
+
+        await stage._route_result("req", second_result)
+
+        assert [payload.data for payload in local_dispatcher.payloads] == [
+            {"sequence": 1},
+            {"sequence": 2},
+        ]
+        assert "req" not in stage._active_requests
+        assert "req" not in stage._inflight_work_pending
+        assert input_handler.cancelled == ["req"]
+
+    asyncio.run(_run())
+
+
+def test_stage_rejects_multiple_inflight_results_at_terminal_stage() -> None:
+    async def _run() -> None:
+        control_plane = _FakeControlPlane()
+        input_handler = _CountingInput()
+        scheduler_cleanups: list[str] = []
+        scheduler = SimpleScheduler(
+            lambda payload: payload,
+            abort_callback=scheduler_cleanups.append,
+            allow_multiple_inflight_per_request=True,
+        )
+        stage = Stage(
+            name="terminal_consumer",
+            role="single",
+            get_next=lambda request_id, output: None,
+            gpu_id=None,
+            endpoints={},
+            control_plane=control_plane,
+            input_handler=input_handler,
+            relay=_FakeRelay(),
+            scheduler=scheduler,
+        )
+
+        results = []
+        for sequence in (1, 2):
+            payload = StagePayload(
+                request_id="req",
+                request=OmniRequest(inputs="payload"),
+                data={"sequence": sequence},
+            )
+            await stage.receive_local_payload("req", "producer", payload)
+            results.append(scheduler.inbox.get_nowait().data)
+
+        await stage._route_result("req", results[0])
+
+        assert len(control_plane.completions) == 1
+        assert control_plane.completions[0].success is False
+        assert "terminal stage" in control_plane.completions[0].error
+        assert scheduler_cleanups == ["req"]
+        assert input_handler.cancelled == ["req"]
+        assert "req" not in stage._active_requests
+        assert "req" not in stage._inflight_work_pending
+
+    asyncio.run(_run())
+
+
+def test_terminal_rejection_blocks_new_work_while_failure_is_sent() -> None:
+    async def _run() -> None:
+        control_plane = _BlockingCompleteControlPlane()
+        scheduler = SimpleScheduler(
+            lambda payload: payload,
+            allow_multiple_inflight_per_request=True,
+        )
+        stage = Stage(
+            name="terminal_consumer",
+            role="single",
+            get_next=lambda request_id, output: None,
+            gpu_id=None,
+            endpoints={},
+            control_plane=control_plane,
+            relay=_FakeRelay(),
+            scheduler=scheduler,
+            is_terminal=True,
+        )
+        first_payload = StagePayload(
+            request_id="req",
+            request=OmniRequest(inputs="payload"),
+            data={"sequence": 1},
+        )
+        await stage.receive_local_payload("req", "producer", first_payload)
+        first_result = scheduler.inbox.get_nowait().data
+        route_task = asyncio.create_task(stage._route_result("req", first_result))
+        await asyncio.wait_for(control_plane.complete_started.wait(), timeout=1.0)
+
+        second_payload = StagePayload(
+            request_id="req",
+            request=OmniRequest(inputs="payload"),
+            data={"sequence": 2},
+        )
+        await stage.receive_local_payload("req", "producer", second_payload)
+
+        assert scheduler.inbox.empty()
+        assert len(control_plane.completions) == 1
+        assert control_plane.completions[0].success is False
+        control_plane.release_complete.set()
+        await asyncio.wait_for(route_task, timeout=1.0)
+
+        assert "req" in stage._aborted
+        assert "req" not in stage._active_requests
+        assert "req" not in stage._inflight_work_pending
+
+    asyncio.run(_run())
+
+
+def test_stage_failure_cleans_multiple_inflight_work_once() -> None:
+    async def _run() -> None:
+        scheduler_cleanups: list[str] = []
+        scheduler = SimpleScheduler(
+            lambda payload: payload,
+            abort_callback=scheduler_cleanups.append,
+            allow_multiple_inflight_per_request=True,
+        )
+        relay = _CountingRelay()
+        input_handler = _CountingInput()
+        control_plane = _FakeControlPlane()
+        stage = Stage(
+            name="relay_consumer",
+            role="single",
+            get_next=lambda request_id, output: None,
+            gpu_id=None,
+            endpoints={},
+            control_plane=control_plane,
+            input_handler=input_handler,
+            relay=relay,
+            scheduler=scheduler,
+        )
+
+        for sequence in (1, 2):
+            payload = StagePayload(
+                request_id="req",
+                request=OmniRequest(inputs="payload"),
+                data={"sequence": sequence},
+            )
+            await stage.receive_local_payload("req", "producer", payload)
+            scheduler.inbox.get_nowait()
+
+        scheduler.outbox.put(
+            OutgoingMessage(
+                request_id="req",
+                type="error",
+                data=RuntimeError("relay failed"),
+            )
+        )
+        scheduler.outbox.put(
+            OutgoingMessage(
+                request_id="req",
+                type="result",
+                data=StagePayload(
+                    request_id="req",
+                    request=OmniRequest(inputs="payload"),
+                    data={"sequence": 2},
+                ),
+            )
+        )
+
+        await stage._drain_outbox_external()
+        stage._on_abort("req")
+        await stage._send_failure("req", "duplicate failure")
+
+        assert len(control_plane.completions) == 1
+        assert control_plane.completions[0].success is False
+        assert control_plane.completions[0].error == "relay failed"
+        assert scheduler_cleanups == ["req"]
+        assert relay.cleaned == ["req"]
+        assert input_handler.cancelled == ["req"]
+        assert "req" not in stage._inflight_work_pending
+
+    asyncio.run(_run())
+
+
+def test_follower_cleans_multiple_inflight_work_after_last_result() -> None:
+    async def _run() -> None:
+        scheduler = SimpleScheduler(
+            lambda payload: payload,
+            allow_multiple_inflight_per_request=True,
+        )
+        input_handler = _CountingInput()
+        stage = Stage(
+            name="relay_follower",
+            role="follower",
+            get_next=lambda request_id, output: None,
+            gpu_id=None,
+            endpoints={},
+            control_plane=_FakeControlPlane(),
+            input_handler=input_handler,
+            relay=_FakeRelay(),
+            scheduler=scheduler,
+        )
+
+        for sequence in (1, 2):
+            payload = StagePayload(
+                request_id="req",
+                request=OmniRequest(inputs="payload"),
+                data={"sequence": sequence},
+            )
+            await stage.receive_local_payload("req", "producer", payload)
+            incoming = scheduler.inbox.get_nowait()
+            scheduler.outbox.put(
+                OutgoingMessage(request_id="req", type="result", data=incoming.data)
+            )
+
+        await stage._drain_outbox_follower()
+
+        assert input_handler.cancelled == ["req"]
+        assert "req" not in stage._active_requests
+        assert "req" not in stage._inflight_work_pending
+
+    asyncio.run(_run())
+
+
+def test_tp_follower_tracks_multiple_work_messages_for_same_request() -> None:
+    async def _run() -> None:
+        control_plane = _QueuedFollowerControlPlane()
+        scheduler = _PassiveScheduler(allow_multiple_inflight_per_request=True)
+        stage = Stage(
+            name="relay_follower",
+            role="follower",
+            get_next=lambda request_id, output: None,
+            gpu_id=None,
+            endpoints={},
+            control_plane=control_plane,
+            relay=_FakeRelay(),
+            scheduler=scheduler,
+        )
+        run_task = asyncio.create_task(stage.run())
+
+        try:
+            for sequence in (1, 2):
+                payload = StagePayload(
+                    request_id="req",
+                    request=OmniRequest(inputs="payload"),
+                    data={"sequence": sequence},
+                )
+                control_plane.work.put_nowait(
+                    TPWorkMessage(request_id="req", data=payload)
+                )
+
+            received = [
+                await asyncio.wait_for(
+                    asyncio.to_thread(scheduler.inbox.get, True, 1.0),
+                    timeout=2.0,
+                )
+                for _ in range(2)
+            ]
+
+            assert [message.data.data for message in received] == [
+                {"sequence": 1},
+                {"sequence": 2},
+            ]
+            assert stage._inflight_work_pending == {"req": 2}
+            assert stage._active_requests == {"req"}
+        finally:
+            control_plane.work.put_nowait(ShutdownMessage())
+            await asyncio.wait_for(run_task, timeout=2.0)
+
+    asyncio.run(_run())
+
+
+@pytest.mark.parametrize("message_type", ["result", "error"])
+def test_follower_ignores_stale_output_after_abort(message_type: str) -> None:
+    async def _run() -> None:
+        scheduler_cleanups: list[str] = []
+        scheduler = SimpleScheduler(
+            lambda payload: payload,
+            abort_callback=scheduler_cleanups.append,
+            allow_multiple_inflight_per_request=True,
+        )
+        relay = _CountingRelay()
+        input_handler = _CountingInput()
+        stage = Stage(
+            name="relay_follower",
+            role="follower",
+            get_next=lambda request_id, output: None,
+            gpu_id=None,
+            endpoints={},
+            control_plane=_FakeControlPlane(),
+            input_handler=input_handler,
+            relay=relay,
+            scheduler=scheduler,
+        )
+        payload = StagePayload(
+            request_id="req",
+            request=OmniRequest(inputs="payload"),
+            data={"sequence": 1},
+        )
+        await stage.receive_local_payload("req", "producer", payload)
+        scheduler.inbox.get_nowait()
+        stage._on_abort("req")
+
+        scheduler.outbox.put(
+            OutgoingMessage(
+                request_id="req",
+                type=message_type,
+                data=payload if message_type == "result" else RuntimeError("stale"),
+            )
+        )
+        await stage._drain_outbox_follower()
+
+        assert scheduler_cleanups == ["req"]
+        assert relay.cleaned == ["req"]
+        assert input_handler.cancelled == ["req"]
 
     asyncio.run(_run())


### PR DESCRIPTION
## Status

This is a Draft for review of the generic transfer and request-lifecycle contract. It does not add model-specific image-generation behavior and has been validated with unit and static checks only.

## Motivation

A pipeline request may produce multiple payloads that overlap in flight. The previous lifecycle assumed one transfer and one result per request:

- concurrent payloads for the same source, destination, and request reused the same shared-memory object ID;
- the first routed result could clear request state while later work was still active;
- an abort marker could be consumed once, allowing already queued or late work to run;
- stale TP-follower output could repeat cleanup or surface an error after cancellation.

This capability was extracted to support LLaDA2-Uni interleaved image generation. Its transfer and lifecycle contracts are deliberately model-independent, so other models and pipelines with multiple in-flight stage payloads can reuse it.

Stream-before-payload delivery and stream-chunk relay are separate existing capabilities and are not reimplemented here. This PR is also separate from #1455, which focuses on SSE text-output streaming.

## Modifications

- Assign a unique transfer identity to each `CommEngine` payload while preserving the legacy `StageIO` default when no identity is supplied.
- Add an explicit, default-off scheduler capability for multiple in-flight work items per request.
- Track work consistently across coordinator submissions, upstream stage payloads, and TP follower fanout, including task re-entry while downstream sends are awaiting.
- Keep abort state persistent, filter aborted batches and stale follower output, and make request cleanup idempotent.
- Reject terminal stages that opt into multiple in-flight work until result aggregation semantics are defined, avoiding premature success.
- Add focused regression coverage for transfer identity, ordering, concurrent admission, TP fanout, abort races, stale output, terminal-stage rejection, and cleanup-once behavior.

### Scope boundaries

This PR does **not** implement LLaDA2-Uni request grouping, image API fields, image segment assembly, SSE streaming, or terminal multi-result aggregation.

## Related Issues

Part of #445. This PR does not close the roadmap issue.

Related but non-overlapping: #1455.

## Accuracy Test

No model math or model architecture is changed.

### Local verification

- Focused communication, scheduler, and stage tests: **42 passed, 4 deselected**
- Adjacent KV-transfer, router, and streaming-scheduler regression tests: **27 passed, 3 skipped**
- Ruff check and format check: **passed**
- Python `compileall`: **passed**
- `git diff --check`: **passed**

No GPU or full-runtime validation has been run for this Draft.

## Benchmark & Profiling

Not applicable. This PR makes a correctness and lifecycle change and makes no throughput or latency claim.

## Contributors

- @kunchengit
- @Anmuliar

## Checklist

- [x] Format the changed code.
- [x] Add focused unit tests.
- [x] Document the transfer and lifecycle contract.
- [ ] Complete broader runtime validation before marking the PR Ready.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

This PR is intentionally opened as a Draft. Self-hosted GPU CI has not been requested.