### PR TITLE
[TTS] Support dots.tts two-step sCM serving

### DIFF
--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -45,7 +45,7 @@ for details.
 | [MOSS-TTS](../cookbook/moss_tts.md) | `examples/configs/moss_tts.yaml` | Voice cloning via `ref_audio` or `references[0].audio_path` (+ `text`). Duration via `${token:N}` or `token_count`. Benchmark at `--max-concurrency 8` |
 | [MOSS-TTS Local](../cookbook/moss_tts_local.md) | `examples/configs/moss_tts_local.yaml` | 48 kHz stereo local-transformer MOSS-TTS; voice cloning / reference-less; streaming |
 | [Higgs TTS](../cookbook/higgs_tts.md) | `--model-path` only | Voice cloning, streaming; no example YAML required |
-| [dots.tts](../cookbook/dots_tts.md) | `examples/configs/dots_tts.yaml` (MeanFlow), `examples/configs/dots_tts_soar.yaml` (SOAR) | 48 kHz continuous-latent TTS with reference audio. MeanFlow (`dots.tts-mf`) uses continuous batching (`max_running_requests=16` by default) with engine-wide `num_steps=4` and Euler. SOAR (`dots.tts-soar`) and base (`dots.tts-base`) are flow matching and run the single-request solver with CFG at `max_running_requests=1`; both use the SOAR config. All require `ref_audio` + `ref_text`. TP1 only |
+| [dots.tts](../cookbook/dots_tts.md) | `examples/configs/dots_tts.yaml` (MeanFlow), `examples/configs/dots_tts_scm.yaml` (two-step sCM), `examples/configs/dots_tts_soar.yaml` (SOAR) | 48 kHz continuous-latent TTS with reference audio. MeanFlow and sCM use continuous batching; SOAR/base remain single-request. TP1 only |
 | [ZONOS2](../cookbook/zonos2.md) | `--model-path Zyphra/zonos2` | MoE TTS, 9 DAC codebooks, voice cloning; needs Descript DAC extras (see cookbook) |
 
 ## Launch the Server
@@ -159,11 +159,23 @@ sgl-omni serve \
   --port 8000
 ```
 
+For dots.tts two-step sCM:
+
+```bash
+sgl-omni serve \
+  --model-path dots-studio/dots.tts-mf-2steps \
+  --config examples/configs/dots_tts_scm.yaml \
+  --allowed-media-domain huggingface.co \
+  --allowed-media-domain cas-bridge.xethub.hf.co \
+  --allowed-media-domain us.aws.cdn.hf.co \
+  --port 8000
+```
+
 `dots.tts-base` uses the same config; pass `--model-path dots-studio/dots.tts-base`.
 
-SOAR and base are flow-matching checkpoints, so they run the single-request solver
-(`max_running_requests=1`) with classifier-free guidance. Continuous batching is
-MeanFlow-only for now. `rednote-hilab/dots.tts-*` is the old org name and redirects to
+SOAR and base run the single-request solver (`max_running_requests=1`). The sCM
+artifacts fix Euler, NFE 2, and CFG 0 and support the batched acoustic tail; omit
+those request overrides. `rednote-hilab/dots.tts-*` is the old org name and redirects to
 `dots-studio/dots.tts-*`; both work as `--model-path`.
 
 For Ming-Omni-TTS on two 80 GB GPUs:

--- a/docs/cookbook/dots_tts.md
+++ b/docs/cookbook/dots_tts.md
@@ -2,7 +2,7 @@
 
 [dots.tts](https://huggingface.co/dots-studio/dots.tts-mf) is a text-to-speech model from rednote-hilab. It outputs 48 kHz speech and clones a speaker from a short reference clip plus its transcript.
 
-dots.tts is a continuous-latent model, not a codec model. The backbone emits no audio tokens. Each AR step gives a hidden state; a MeanFlow DiT uses it to sample one latent patch (4 frames × 128 dims); a semantic encoder turns the patch back into the next backbone input; an AudioVAE decodes latents to waveform. No codebook, no token sampler. So `temperature` and `top_k` do nothing here — use the solver knobs (`num_steps`, `guidance_scale`) instead.
+dots.tts is a continuous-latent model, not a codec model. The backbone emits no audio tokens. Each AR step gives a hidden state; an acoustic DiT uses it to sample one latent patch (4 frames × 128 dims); a semantic encoder turns the patch back into the next backbone input; an AudioVAE decodes latents to waveform. No codebook, no token sampler. So `temperature` and `top_k` do nothing here — use the solver knobs (`num_steps`, `guidance_scale`) instead.
 
 | Component | Spec |
 |---|---|
@@ -11,13 +11,14 @@ dots.tts is a continuous-latent model, not a codec model. The backbone emits no 
 | Latent patch | 4 frames × 128 dims (one patch ≈ 160 ms of audio) |
 | Context length | 2,048 tokens |
 | Sample rate | 48 kHz |
-| Solver | MeanFlow + Euler, engine-wide `num_steps=4` (SOAR: flow matching + CFG, `num_steps=10`) |
+| Solver | MeanFlow + Euler, engine-wide `num_steps=4`; SOAR uses flow matching + CFG; the two-step artifact uses its fixed sCM contract |
 
 ## Supported checkpoints
 
 | Checkpoint | Status |
 |---|---|
 | [`dots-studio/dots.tts-mf`](https://huggingface.co/dots-studio/dots.tts-mf) | MeanFlow. Continuous batching, `num_steps=4`. `examples/configs/dots_tts.yaml` |
+| [`dots-studio/dots.tts-mf-2steps`](https://huggingface.co/dots-studio/dots.tts-mf-2steps) | sCM. Artifact-locked Euler, `num_steps=2`, CFG `0`. Continuous batching with `examples/configs/dots_tts_scm.yaml` |
 | [`dots-studio/dots.tts-soar`](https://huggingface.co/dots-studio/dots.tts-soar) | Flow matching. Single request at a time (`max_running_requests=1`) with CFG, `num_steps=10`. `examples/configs/dots_tts_soar.yaml` |
 | [`dots-studio/dots.tts-base`](https://huggingface.co/dots-studio/dots.tts-base) | Flow matching, same as SOAR. Serve it with `examples/configs/dots_tts_soar.yaml` and `--model-path dots-studio/dots.tts-base` |
 
@@ -47,7 +48,21 @@ sgl-omni serve \
   --port 8000
 ```
 
-SOAR is a flow-matching checkpoint. It runs the single-request solver with classifier-free guidance, so its config pins `max_running_requests: 1` and `num_steps: 10`; continuous batching is MeanFlow-only. Every request example below works on either checkpoint — only the `model` field changes.
+SOAR is a legacy flow-matching checkpoint. It runs the single-request solver with classifier-free guidance, so its config pins `max_running_requests: 1` and `num_steps: 10`. MeanFlow and sCM checkpoints support continuous batching. Every request example below works on either checkpoint — only the `model` field changes.
+
+For the two-step sCM checkpoint, use its config and omit solver overrides from requests:
+
+```bash
+hf download dots-studio/dots.tts-mf-2steps
+
+sgl-omni serve \
+  --model-path dots-studio/dots.tts-mf-2steps \
+  --config examples/configs/dots_tts_scm.yaml \
+  --allowed-local-media-path docs/_static/audio \
+  --port 8000
+```
+
+The checkpoint declares Euler, NFE 2, CFG 0, and `tau_mid`. Serving applies those values automatically and rejects incompatible `ode_method`, `num_steps`, or `guidance_scale` overrides.
 
 `examples/configs/dots_tts.yaml` is the canonical MeanFlow deployment. It is already tuned; compiled acoustic tail and vocoder (`optimize: true`, on by default); continuous batching at `max_running_requests=16`; and the backbone decode CUDA graph. `--model-path` alone keeps the compiled tail and batching but leaves backbone decode eager, which is slower per request (see [Performance](#performance)). Use the config file.
 
@@ -179,10 +194,10 @@ Solver knobs go under `stage_params.latent_engine`. They are **not** top-level f
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `speaker_scale` | float | `1.5` | Scales the speaker x-vector before conditioning. Higher values push harder toward the reference timbre |
-| `guidance_scale` | float | `1.2` | Classifier-free guidance strength for the flow sampler |
+| `guidance_scale` | float | `1.2` or artifact value | Classifier-free guidance strength for the flow sampler. Fixed-step artifacts reject overrides |
 | `eos_threshold` | float | `0.8` | Probability above which the EOS head ends generation. Lower values cut utterances earlier |
-| `num_steps` | int | `4` (MF), `10` (SOAR) | Flow solver steps. MeanFlow fixes this engine-wide: another value fails the request. SOAR and base run one request at a time and honour it |
-| `ode_method` | string | `"euler"` | Flow solver. MeanFlow accepts only `euler` |
+| `num_steps` | int | `4` (MF), `10` (SOAR), artifact value | Flow solver steps. MeanFlow fixes this engine-wide; artifact-locked checkpoints reject overrides |
+| `ode_method` | string | `"euler"` or artifact value | Flow solver. MeanFlow and current fixed-step artifacts accept only `euler` |
 | `max_generate_length` | int | `500` | Cap on generated latent patches (≈ 160 ms each), bounded by the engine's `max_generate_length` |
 | `normalize_text` | bool | `false` | Run the upstream text normalizer (numbers, symbols) before tokenizing |
 

--- a/examples/configs/dots_tts_scm.yaml
+++ b/examples/configs/dots_tts_scm.yaml
@@ -1,0 +1,14 @@
+config_cls: DotsTTSPipelineConfig
+model_path: dots-studio/dots.tts-mf-2steps
+runtime_overrides:
+  latent_engine:
+    optimize: true
+    num_steps: 2
+    max_generate_length: 500
+    server_args_overrides:
+      mem_fraction_static: 0.20
+      max_running_requests: 16
+      disable_cuda_graph: false
+      cuda_graph_max_bs: 16
+  vocoder:
+    optimize: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
     # Gradio playground
     "gradio>=4.0.0",
     # dots.tts model operators; serving/runtime stays owned by sglang-omni
-    "dots.tts==0.2.1",
+    "dots.tts==0.3.1",
     # Ming-Omni
     "diffusers==0.37.0",      # Omni's own Ming-Omni pin; not an sglang core dependency
     "x-transformers",          # Ming talker rotary embeddings

--- a/sglang_omni/models/dots_tts/engine_builder.py
+++ b/sglang_omni/models/dots_tts/engine_builder.py
@@ -41,8 +41,8 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
         register_dots_tts_hf_config()
 
     def customize_server_args(self, server_args: Any) -> None:
-        # The compiled DiT path only serves max_running_requests=1; the batched
-        # tail is eager, so skip the process-global compile policy otherwise.
+        # The single-request DiT has its own compile path; batched checkpoints
+        # use the pooled acoustic tail instead.
         # The policy must exist before SGLang builds the model; applying it in
         # setup_model nests Dynamo under FX.
         if self.optimize and int(server_args.max_running_requests) == 1:
@@ -163,6 +163,7 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
             model.flow.validate_request(
                 num_steps=data.state.num_steps,
                 ode_method=data.state.ode_method,
+                guidance_scale=data.state.guidance_scale,
                 prompt_patch_count=int(data.prompt_span_positions.numel()),
                 total_span_count=int(data.span_positions.numel()),
             )

--- a/sglang_omni/models/dots_tts/flow_head.py
+++ b/sglang_omni/models/dots_tts/flow_head.py
@@ -68,9 +68,13 @@ class DotsTTSFlowHead(nn.Module):
         self.latent_dim = int(config.latent_dim)
         self.optimize = bool(optimize)
         self.mode = (
-            "meanflow"
-            if config.meanflow is not None and config.meanflow.enabled
-            else "flow_matching"
+            config.sampling.solver
+            if config.sampling is not None
+            else (
+                "meanflow"
+                if config.meanflow is not None and config.meanflow.enabled
+                else "flow_matching"
+            )
         )
         dit_mode = (
             "meanflow"
@@ -139,12 +143,26 @@ class DotsTTSFlowHead(nn.Module):
                 DiTSolver,
             )
 
-            self._dit_solver = DiTSolver(
-                DiTInferenceContext.from_core(self),
-                optimize=self.optimize,
-                bucket_resolver=self._bucket,
-                meanflow=self.mode == "meanflow",
-            )
+            context = DiTInferenceContext.from_core(self)
+            if self.mode == "scm":
+                from dots_tts.modules.backbone.scm_inference import SCMDiTSolver
+
+                sampling = self.config.sampling
+                if sampling is None:
+                    raise RuntimeError("sCM solver requires artifact sampling config")
+                self._dit_solver = SCMDiTSolver(
+                    context,
+                    optimize=self.optimize,
+                    bucket_resolver=self._bucket,
+                    tau_mid=sampling.tau_mid,
+                )
+            else:
+                self._dit_solver = DiTSolver(
+                    context,
+                    optimize=self.optimize,
+                    bucket_resolver=self._bucket,
+                    meanflow=self.mode == "meanflow",
+                )
         return self._dit_solver
 
     @property
@@ -159,14 +177,13 @@ class DotsTTSFlowHead(nn.Module):
         max_audio_patches: int,
         optimize: bool = False,
     ) -> None:
-        if self.mode != "meanflow":
-            # note (luojiaxuan): flow-matching checkpoints (SOAR, base) need the
-            # CFG double branch, which the batched tail does not implement. They
-            # serve on the single-request solver instead.
+        if self.mode not in {"meanflow", "scm"}:
+            # note (luojiaxuan): legacy flow-matching checkpoints need the CFG
+            # double branch, which the batched tail does not implement.
             raise ValueError(
-                "dots.tts continuous batching requires a MeanFlow checkpoint; "
+                "dots.tts continuous batching requires a MeanFlow or sCM checkpoint; "
                 f"this checkpoint is {self.mode}. Serve it with "
-                "max_running_requests=1 (see examples/configs/dots_tts_soar.yaml)"
+                "max_running_requests=1"
             )
         from sglang_omni.models.dots_tts.tail import (
             DotsTtsAcousticTail,
@@ -188,6 +205,13 @@ class DotsTTSFlowHead(nn.Module):
                 latent_patch_size=self.latent_patch_size,
                 latent_dim=self.latent_dim,
                 fm_hidden_size=self.fm_hidden_size,
+                solver=self.mode,
+                fm_sigma=float(self.config.fm_sigma),
+                tau_mid=(
+                    float(self.config.sampling.tau_mid)
+                    if self.config.sampling is not None
+                    else 1.3
+                ),
             ),
             device=parameter.device,
             dtype=parameter.dtype,
@@ -201,9 +225,17 @@ class DotsTTSFlowHead(nn.Module):
         *,
         num_steps: int,
         ode_method: str,
+        guidance_scale: float | None = None,
         prompt_patch_count: int | None = None,
         total_span_count: int | None = None,
     ) -> None:
+        sampling = self.config.sampling
+        if sampling is not None:
+            sampling.resolve(
+                ode_method=ode_method,
+                num_steps=num_steps,
+                guidance_scale=guidance_scale,
+            )
         if not self.is_batched:
             return
         if int(num_steps) != self._batched_nfe:
@@ -251,18 +283,7 @@ class DotsTTSFlowHead(nn.Module):
                 if speaker_embedding is not None:
                     speaker_embedding = speaker_embedding.to(device=device, dtype=dtype)
                     g_cond = self.xvec_proj(speaker_embedding * float(speaker_scale))
-                grid = torch.linspace(
-                    0.0,
-                    1.0,
-                    int(self._batched_nfe) + 1,
-                    device=device,
-                    dtype=dtype,
-                )
-                all_mods = self._tail.dit.build_mods(
-                    grid[:-1],
-                    duration=grid[1:] - grid[:-1],
-                    g_cond=g_cond,
-                )
+                all_mods = self._tail.build_mods(g_cond)
                 prompt_latents = prompt_latents.to(device=device, dtype=dtype)
                 prompt_embeddings = self._tail.encode_prompt_patches(
                     slot, self._patch_encoder_input(prompt_latents)
@@ -558,7 +579,9 @@ class DotsTTSFlowHead(nn.Module):
             normalized_patch = solver.decode_next(
                 state.dit_state,
                 sequence=state.fm_sequence,
-                cfg_sequence=state.fm_cfg_sequence,
+                cfg_sequence=(
+                    state.fm_cfg_sequence if self.mode == "flow_matching" else None
+                ),
                 fm_seq_len=state.fm_seq_len,
                 null_g_cond=state.fm_null_g_cond,
                 g_cond=state.g_cond,

--- a/sglang_omni/models/dots_tts/stages.py
+++ b/sglang_omni/models/dots_tts/stages.py
@@ -237,6 +237,36 @@ def preprocess_dots_tts_payload(
             f"dots.tts schedule exceeds context length {max_sequence_length}"
         )
 
+    ode_method = _first_not_none(
+        inputs.get("ode_method"),
+        tts_params.get("ode_method"),
+        engine_params.get("ode_method"),
+        params.get("ode_method"),
+    )
+    num_steps = _first_not_none(
+        inputs.get("num_steps"),
+        tts_params.get("num_steps"),
+        engine_params.get("num_steps"),
+        params.get("num_steps"),
+    )
+    guidance_scale = _first_not_none(
+        inputs.get("guidance_scale"),
+        tts_params.get("guidance_scale"),
+        engine_params.get("guidance_scale"),
+        params.get("guidance_scale"),
+    )
+    sampling = model_config.sampling
+    if sampling is None:
+        ode_method = "euler" if ode_method is None else str(ode_method)
+        num_steps = default_num_steps if num_steps is None else int(num_steps)
+        guidance_scale = 1.2 if guidance_scale is None else float(guidance_scale)
+    else:
+        ode_method, num_steps, guidance_scale = sampling.resolve(
+            ode_method=ode_method,
+            num_steps=num_steps,
+            guidance_scale=guidance_scale,
+        )
+
     state = DotsTTSState(
         sample_rate=int(model_config.vocoder.sample_rate),
         prompt_audio_path=prompt_audio,
@@ -250,33 +280,9 @@ def preprocess_dots_tts_payload(
                 default=1.5,
             )
         ),
-        ode_method=str(
-            _first_not_none(
-                inputs.get("ode_method"),
-                tts_params.get("ode_method"),
-                engine_params.get("ode_method"),
-                params.get("ode_method"),
-                default="euler",
-            )
-        ),
-        num_steps=int(
-            _first_not_none(
-                inputs.get("num_steps"),
-                tts_params.get("num_steps"),
-                engine_params.get("num_steps"),
-                params.get("num_steps"),
-                default=default_num_steps,
-            )
-        ),
-        guidance_scale=float(
-            _first_not_none(
-                inputs.get("guidance_scale"),
-                tts_params.get("guidance_scale"),
-                engine_params.get("guidance_scale"),
-                params.get("guidance_scale"),
-                default=1.2,
-            )
-        ),
+        ode_method=str(ode_method),
+        num_steps=int(num_steps),
+        guidance_scale=float(guidance_scale),
         eos_threshold=float(
             _first_not_none(
                 inputs.get("eos_threshold"),

--- a/sglang_omni/models/dots_tts/tail.py
+++ b/sglang_omni/models/dots_tts/tail.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from collections import Counter
 from dataclasses import dataclass
 from functools import partial
@@ -167,11 +168,18 @@ class DotsTtsTailSpec:
     latent_patch_size: int
     latent_dim: int
     fm_hidden_size: int
+    solver: str = "meanflow"
+    fm_sigma: float = 0.0
+    tau_mid: float = 1.3
 
     def __post_init__(self) -> None:
         for name in ("nfe", "patch_capacity", "num_slots"):
             if int(getattr(self, name)) <= 0:
                 raise ValueError(f"dots.tts tail {name} must be positive")
+        if self.solver not in {"meanflow", "scm"}:
+            raise ValueError(f"unsupported dots.tts batched solver {self.solver!r}")
+        if self.solver == "scm" and self.nfe != 2:
+            raise ValueError("dots.tts batched sCM requires nfe=2")
 
     @property
     def unit_len(self) -> int:
@@ -422,7 +430,22 @@ class DotsTtsAcousticTail:
 
         self._mods_width = int(dit.fused_adaln[-1].out_features)
         self._allocate_pools(self._mods_width)
-        self._times = torch.linspace(0.0, 1.0, spec.nfe + 1, device=device, dtype=dtype)
+        if spec.solver == "scm":
+            from dots_tts.modules.backbone.scm_inference import _to_flow_matching
+
+            self._taus = torch.tensor(
+                [math.pi / 2, spec.tau_mid], device=device, dtype=torch.float32
+            )
+            _, self._times = _to_flow_matching(
+                torch.zeros(spec.nfe, 1, 1, device=device),
+                self._taus,
+                spec.fm_sigma,
+            )
+        else:
+            self._taus = None
+            self._times = torch.linspace(
+                0.0, 1.0, spec.nfe + 1, device=device, dtype=dtype
+            )
         self._dit_layer_index = torch.arange(self._dit_layers, device=device)
         self._encoder_layer_index = torch.arange(self._encoder_layers, device=device)
         self._fm_seq_len = [0] * spec.num_slots
@@ -624,6 +647,15 @@ class DotsTtsAcousticTail:
         generator = self._generators[int(slot)]
         return None if generator is None else generator.get_state().clone()
 
+    def build_mods(self, g_cond: torch.Tensor | None) -> torch.Tensor:
+        if self.spec.solver == "scm":
+            return self.dit.build_mods(self._times, g_cond=g_cond)
+        return self.dit.build_mods(
+            self._times[:-1],
+            duration=self._times[1:] - self._times[:-1],
+            g_cond=g_cond,
+        )
+
     def fm_seq_len(self, slot: int) -> int:
         return self._fm_seq_len[int(slot)]
 
@@ -744,6 +776,7 @@ class DotsTtsAcousticTail:
             persistent, device=self.device, dtype=torch.long
         )
         noise = self._sample_noise(slots)
+        renoise = self._sample_noise(slots) if spec.solver == "scm" else None
         direct_kv = len(slots) == spec.num_slots and sorted(slots) == list(
             range(spec.num_slots)
         )
@@ -753,6 +786,7 @@ class DotsTtsAcousticTail:
             work_persistent = persistent_index.index_select(0, order)
             work_hidden = fm_hidden_rows.index_select(0, order)
             work_noise = noise.index_select(0, order)
+            work_renoise = None if renoise is None else renoise.index_select(0, order)
             self._dit_contiguous_view_steps += spec.nfe
             if self._dit_contiguous_view_steps == spec.nfe:
                 logger.info("dots.tts contiguous DiT KV view is active")
@@ -761,6 +795,7 @@ class DotsTtsAcousticTail:
             work_persistent = persistent_index
             work_hidden = fm_hidden_rows
             work_noise = noise
+            work_renoise = renoise
         graph = self._select_graph(self._meanflow_graphs, len(slots), capacity)
         if graph is None:
             self._graph_misses["meanflow"] += 1
@@ -770,6 +805,7 @@ class DotsTtsAcousticTail:
                 capacity,
                 work_hidden,
                 work_noise,
+                work_renoise,
                 direct_kv=direct_kv,
             )
         else:
@@ -777,11 +813,16 @@ class DotsTtsAcousticTail:
             graph.inputs["starts"].copy_(work_persistent)
             graph.inputs["hidden"].copy_(work_hidden)
             graph.inputs["noise"].copy_(work_noise)
+            if work_renoise is not None:
+                graph.inputs["renoise"].copy_(work_renoise)
             graph.graph.replay()
             latent = graph.output.clone()
             self._graph_replays["meanflow"] += 1
             if self._graph_replays["meanflow"] == 1:
-                logger.info("dots.tts batched MeanFlow CUDA graph replay is active")
+                logger.info(
+                    "dots.tts batched %s CUDA graph replay is active",
+                    self.spec.solver,
+                )
         if direct_kv:
             latent = latent.index_select(0, slot_index)
         for slot in slots:
@@ -795,6 +836,7 @@ class DotsTtsAcousticTail:
         capacity: int,
         fm_hidden_rows: torch.Tensor,
         noise: torch.Tensor,
+        renoise: torch.Tensor | None = None,
         *,
         direct_kv: bool = False,
     ) -> torch.Tensor:
@@ -805,11 +847,12 @@ class DotsTtsAcousticTail:
         window[:, spec.unit_len :] = fm_hidden_rows.unsqueeze(1).to(self.dtype)
         if not direct_kv:
             self._window[slot_index] = window
-        latent = self._run_meanflow(
+        latent = self._run_solver(
             slot_index,
             persistent_index,
             capacity,
             noise,
+            renoise,
             direct_kv=direct_kv,
         )
         window = (
@@ -824,12 +867,13 @@ class DotsTtsAcousticTail:
             self._window[slot_index] = window
         return latent
 
-    def _run_meanflow(
+    def _run_solver(
         self,
         slot_index: torch.Tensor,
         persistent_index: torch.Tensor,
         capacity: int,
         latent: torch.Tensor,
+        renoise: torch.Tensor | None,
         *,
         direct_kv: bool = False,
     ) -> torch.Tensor:
@@ -858,6 +902,17 @@ class DotsTtsAcousticTail:
         layer_index = self._dit_layer_index.reshape(self._dit_layers, 1, 1)
         batch_index = slot_index.reshape(1, rows, 1)
         promote = slice(capacity, capacity + unit)
+        if spec.solver == "scm":
+            from dots_tts.modules.backbone.scm_inference import (
+                _denoise,
+                _to_flow_matching,
+            )
+
+            assert self._taus is not None and renoise is not None
+            latent, _ = _to_flow_matching(
+                latent, self._taus[:1].expand(latent.size(0)), spec.fm_sigma
+            )
+            latent = latent.to(self.dtype)
         with sdpa_kernel(_TAIL_SDPA_BACKENDS):
             for ode_index in range(spec.nfe):
                 if direct_kv:
@@ -906,8 +961,24 @@ class DotsTtsAcousticTail:
                 velocity = self.dit.apply_final_layer(
                     value[:, latent_slice], final_mods
                 )
-                duration = self._times[ode_index + 1] - self._times[ode_index]
-                latent = (latent + duration * velocity).clone()
+                if spec.solver == "scm":
+                    tau = self._taus[ode_index : ode_index + 1].expand(rows)
+                    latent = _denoise(latent, velocity, tau, spec.fm_sigma).to(
+                        self.dtype
+                    )
+                    if ode_index + 1 < spec.nfe:
+                        next_tau = self._taus[ode_index + 1 : ode_index + 2].expand(
+                            rows
+                        )
+                        x_tau = (
+                            torch.cos(next_tau)[:, None, None] * latent
+                            + torch.sin(next_tau)[:, None, None] * renoise
+                        )
+                        latent, _ = _to_flow_matching(x_tau, next_tau, spec.fm_sigma)
+                        latent = latent.to(self.dtype)
+                else:
+                    duration = self._times[ode_index + 1] - self._times[ode_index]
+                    latent = (latent + duration * velocity).clone()
                 self._dit_k[ode_index][layer_index, batch_index, :, token_index] = keys[
                     :, :, :, promote
                 ].permute(0, 1, 3, 2, 4)
@@ -1093,7 +1164,7 @@ class DotsTtsAcousticTail:
         current_stream.wait_stream(self._capture_stream)
         torch.cuda.synchronize(self.device)
         logger.info(
-            "dots.tts acoustic-tail CUDA graphs: meanflow=%d semantic_encoder=%d "
+            "dots.tts acoustic-tail CUDA graphs: solver=%d semantic_encoder=%d "
             "batch_buckets=%s context_patch_buckets=%s",
             len(self._meanflow_graphs),
             len(self._encoder_graphs),
@@ -1132,14 +1203,20 @@ class DotsTtsAcousticTail:
                     dtype=self.dtype,
                 ),
             }
-            run = lambda: self._sample_patches_core(
-                inputs["slots"],
-                inputs["starts"],
-                capacity,
-                inputs["hidden"],
-                inputs["noise"],
-                direct_kv=batch_size == self.spec.num_slots,
-            )
+            if self.spec.solver == "scm":
+                inputs["renoise"] = torch.zeros_like(inputs["noise"])
+
+            def run():
+                return self._sample_patches_core(
+                    inputs["slots"],
+                    inputs["starts"],
+                    capacity,
+                    inputs["hidden"],
+                    inputs["noise"],
+                    inputs.get("renoise"),
+                    direct_kv=batch_size == self.spec.num_slots,
+                )
+
         else:
             inputs = {
                 "slots": slots,
@@ -1152,12 +1229,14 @@ class DotsTtsAcousticTail:
                     dtype=self.dtype,
                 ),
             }
-            run = lambda: self._encode_feedback_core(
-                inputs["slots"],
-                inputs["starts"],
-                capacity,
-                inputs["latent"],
-            )
+
+            def run():
+                return self._encode_feedback_core(
+                    inputs["slots"],
+                    inputs["starts"],
+                    capacity,
+                    inputs["latent"],
+                )
 
         graph = torch.cuda.CUDAGraph()
         try:
@@ -1188,10 +1267,10 @@ class DotsTtsAcousticTail:
         if self._meanflow_graphs and self._encoder_graphs:
             return (
                 "CUDA graph batched tail with eager fallback "
-                f"(meanflow={len(self._meanflow_graphs)}, "
+                f"(solver={len(self._meanflow_graphs)}, "
                 f"semantic_encoder={len(self._encoder_graphs)})"
             )
-        return "fused eager batched tail"
+        return f"fused eager batched {self.spec.solver} tail"
 
 
 __all__ = [

--- a/tests/unit_test/dots_tts/test_flow_head.py
+++ b/tests/unit_test/dots_tts/test_flow_head.py
@@ -16,7 +16,12 @@ PATCH_SIZE = 2
 NFE = 2
 
 
-def _flow_head(tmp_path) -> DotsTTSFlowHead:
+def _flow_head(
+    tmp_path,
+    *,
+    meanflow: bool = True,
+    sampling: dict | None = None,
+) -> DotsTTSFlowHead:
     torch.save(
         {"mean": torch.zeros(LATENT_DIM), "var": torch.ones(LATENT_DIM)},
         tmp_path / "latent_stats.pt",
@@ -41,8 +46,12 @@ def _flow_head(tmp_path) -> DotsTTSFlowHead:
             "rotary_bias": True,
         },
         "vocoder": {"sample_rate": 48000},
-        "meanflow": {"enabled": True, "use_duration_embedding": True},
+        "meanflow": (
+            {"enabled": True, "use_duration_embedding": True} if meanflow else None
+        ),
     }
+    if sampling is not None:
+        config["sampling"] = sampling
     flow = DotsTTSFlowHead(
         config,
         llm_hidden_size=LLM_HIDDEN,
@@ -334,6 +343,7 @@ def test_flow_rematerialization_matches_uninterrupted_next_step(
 def test_validate_request_batched_gates_prompt_and_span_budget() -> None:
     flow = SimpleNamespace(
         is_batched=True,
+        config=SimpleNamespace(sampling=None),
         _batched_nfe=4,
         _tail=SimpleNamespace(spec=SimpleNamespace(patch_capacity=9)),
     )
@@ -360,7 +370,7 @@ def test_validate_request_batched_gates_prompt_and_span_budget() -> None:
             total_span_count=10,
         )
 
-    single = SimpleNamespace(is_batched=False)
+    single = SimpleNamespace(is_batched=False, config=SimpleNamespace(sampling=None))
     validate(
         single,
         num_steps=8,
@@ -436,6 +446,30 @@ def test_flow_matching_checkpoint_runs_the_single_request_solver(tmp_path) -> No
     assert step.latent_patch.shape == (1, PATCH_SIZE, LATENT_DIM)
     assert torch.isfinite(step.latent_patch).all()
     assert torch.isfinite(step.feedback_embedding).all()
+
+
+def test_scm_checkpoint_uses_artifact_solver_contract(tmp_path) -> None:
+    from dots_tts.modules.backbone.scm_inference import SCMDiTSolver
+
+    sampling = {
+        "solver": "scm",
+        "ode_method": "euler",
+        "num_steps": 2,
+        "guidance_scale": 0.0,
+        "tau_mid": 1.3,
+    }
+    flow = _flow_head(tmp_path, meanflow=False, sampling=sampling)
+
+    assert flow.mode == "scm"
+    assert isinstance(flow._solver(), SCMDiTSolver)
+    flow.validate_request(num_steps=2, ode_method="euler", guidance_scale=0.0)
+    with pytest.raises(ValueError, match="scm artifact requires"):
+        flow.validate_request(num_steps=1, ode_method="euler", guidance_scale=0.0)
+
+    batched_flow = _flow_head(tmp_path, meanflow=False, sampling=sampling)
+    batched_flow.init_batched_tail(num_slots=2, nfe=2, max_audio_patches=8)
+    assert batched_flow.is_batched
+    assert batched_flow._tail.spec.solver == "scm"
 
 
 def test_batched_eos_resolve_reads_staged_flags(tmp_path) -> None:

--- a/tests/unit_test/dots_tts/test_preprocessing.py
+++ b/tests/unit_test/dots_tts/test_preprocessing.py
@@ -76,6 +76,7 @@ def _preprocess(payload: StagePayload, tokenizer: _RecordingTokenizer) -> DotsTT
         model_config=SimpleNamespace(
             patch_size=4,
             vocoder=SimpleNamespace(sample_rate=48000),
+            sampling=None,
         ),
         max_generate_length=20,
         max_sequence_length=128,
@@ -111,3 +112,27 @@ def test_preprocessing_rejects_unconsumed_extra_references() -> None:
 
     with pytest.raises(ValueError, match="at most one reference"):
         _preprocess(payload, _RecordingTokenizer())
+
+
+def test_preprocessing_uses_artifact_sampling_contract() -> None:
+    from dots_tts.models.dots_tts.config import SamplingConfig
+
+    tokenizer = _RecordingTokenizer()
+    result = preprocess_dots_tts_payload(
+        _payload(),
+        tokenizer=tokenizer,
+        model_config=SimpleNamespace(
+            patch_size=4,
+            vocoder=SimpleNamespace(sample_rate=48000),
+            sampling=SamplingConfig(solver="scm"),
+        ),
+        max_generate_length=20,
+        max_sequence_length=128,
+    )
+    state = DotsTTSState.from_dict(result.data)
+
+    assert (state.ode_method, state.num_steps, state.guidance_scale) == (
+        "euler",
+        2,
+        0.0,
+    )

--- a/tests/unit_test/dots_tts/test_tail.py
+++ b/tests/unit_test/dots_tts/test_tail.py
@@ -46,7 +46,7 @@ def test_batched_tail_mask_hides_padding_and_preserves_causality() -> None:
 
 
 class _TailModel(torch.nn.Module):
-    def __init__(self) -> None:
+    def __init__(self, *, mode: str = "meanflow") -> None:
         super().__init__()
         self.velocity_field_predictor = DiT(
             in_dim=FM_HIDDEN,
@@ -60,7 +60,7 @@ class _TailModel(torch.nn.Module):
                 qk_norm=True,
                 rotary_bias=True,
             ),
-            mode="meanflow",
+            mode=mode,
         )
         self.coordinate_proj = torch.nn.Linear(LATENT_DIM, FM_HIDDEN)
         self.latent_proj = torch.nn.Linear(LATENT_DIM, FM_HIDDEN)
@@ -93,6 +93,7 @@ def _build_tail(
     dtype: torch.dtype = torch.float32,
     patch_capacity: int = 8,
     optimize: bool = False,
+    solver: str = "meanflow",
 ):
     encoder = _patch_encoder().to(device=device, dtype=dtype)
     with torch.no_grad():
@@ -111,6 +112,7 @@ def _build_tail(
             latent_patch_size=PATCH_SIZE,
             latent_dim=LATENT_DIM,
             fm_hidden_size=FM_HIDDEN,
+            solver=solver,
         ),
         device=device,
         dtype=dtype,
@@ -156,6 +158,50 @@ def _reference_meanflow(
     return latent
 
 
+def _reference_scm(
+    dit: torch.nn.Module,
+    coordinate_proj: torch.nn.Module,
+    sequence: torch.Tensor,
+    fm_seq_len: int,
+    g_cond: torch.Tensor,
+    initial_noise: torch.Tensor,
+    renoise: torch.Tensor,
+) -> torch.Tensor:
+    from dots_tts.modules.backbone.scm_inference import _denoise, _to_flow_matching
+
+    total = fm_seq_len + PATCH_SIZE
+    x_base = sequence.new_zeros(1, total, FM_HIDDEN)
+    x_base[:, :fm_seq_len] = sequence[:, :fm_seq_len]
+    mask = torch.zeros((1, total, total), dtype=torch.bool)
+    block_start = fm_seq_len - 1
+    mask[:, :block_start, :block_start] = torch.ones(
+        block_start, block_start, dtype=torch.bool
+    ).tril()
+    mask[:, block_start:fm_seq_len, :fm_seq_len] = True
+    mask[:, block_start:fm_seq_len, fm_seq_len:] = True
+    mask[:, fm_seq_len:, :] = True
+    positions = torch.arange(total, dtype=torch.float32).reshape(1, total)
+    taus = torch.tensor([torch.pi / 2, 1.3])
+    x_tau = initial_noise
+    for step, tau in enumerate(taus):
+        tau = tau.reshape(1)
+        latent, flow_time = _to_flow_matching(x_tau, tau, 0.0)
+        value = x_base.clone()
+        value[:, fm_seq_len:] = coordinate_proj(latent)
+        velocity = dit(
+            x=value,
+            timesteps=flow_time,
+            attn_mask=mask,
+            pos_ids=positions,
+            g_cond=g_cond,
+        )[:, fm_seq_len:]
+        denoised = _denoise(latent, velocity, tau, 0.0)
+        if step == 1:
+            return denoised
+        x_tau = torch.cos(taus[1]) * denoised + torch.sin(taus[1]) * renoise
+    raise AssertionError("unreachable")
+
+
 @pytest.mark.parametrize("slots", [1, 2])
 def test_kv_cached_tail_matches_full_recompute(slots: int) -> None:
     torch.manual_seed(1234)
@@ -190,6 +236,40 @@ def test_kv_cached_tail_matches_full_recompute(slots: int) -> None:
 
     torch.testing.assert_close(actual, expected, rtol=2e-4, atol=2e-4)
     assert acoustic_tail._dit_contiguous_view_steps == (NFE if slots == 1 else 0)
+
+
+def test_kv_cached_scm_tail_matches_full_recompute() -> None:
+    torch.manual_seed(1234)
+    model = _TailModel(mode="flow_matching").eval()
+    acoustic_tail = _build_tail(model, slots=1, solver="scm")
+    unit = acoustic_tail.spec.unit_len
+    g_cond = torch.randn(1, FM_HIDDEN)
+    prompt_rows = torch.randn(3 * unit, FM_HIDDEN)
+    slot = acoustic_tail.acquire_slot()
+    acoustic_tail.seed_fm_history(
+        slot, fm_rows=prompt_rows, all_mods=acoustic_tail.build_mods(g_cond)
+    )
+    sequence = torch.zeros(1, acoustic_tail.spec.dit_cache_tokens + unit, FM_HIDDEN)
+    sequence[0, : prompt_rows.size(0)] = prompt_rows
+    hidden = torch.randn(1, FM_HIDDEN)
+    sequence[0, prompt_rows.size(0)] = hidden[0]
+
+    generator = torch.Generator().manual_seed(9)
+    initial_noise = torch.randn(1, PATCH_SIZE, LATENT_DIM, generator=generator)
+    renoise = torch.randn(1, PATCH_SIZE, LATENT_DIM, generator=generator)
+    expected = _reference_scm(
+        acoustic_tail.dit,
+        model.coordinate_proj,
+        sequence,
+        prompt_rows.size(0) + 1,
+        g_cond,
+        initial_noise,
+        renoise,
+    )
+    acoustic_tail.initialize_slot_rng(slot, 9)
+    actual = acoustic_tail.sample_patches([slot], fm_hidden_rows=hidden)
+
+    torch.testing.assert_close(actual, expected, rtol=2e-4, atol=2e-4)
 
 
 def test_tail_slots_are_bounded_and_reusable() -> None:


### PR DESCRIPTION
## Summary

- upgrade the dots.tts runtime dependency to 0.3.1
- select and validate the solver contract from checkpoint metadata
- add sCM support to the single-request and pooled continuous-batching acoustic tails
- provide a deployment config for `dots-studio/dots.tts-mf-2steps`

## Why

The two-step checkpoint introduced by [dots.tts PR #33](https://github.com/studio-dots-ai/dots.tts/pull/33) uses an artifact-declared sCM solver contract (Euler, NFE 2, CFG 0, and `tau_mid`). The serving path previously inferred only MeanFlow versus legacy flow matching and could not load or batch this checkpoint correctly.

## Impact

`dots-studio/dots.tts-mf-2steps` can now use the existing pooled acoustic tail and backbone CUDA graphs with continuous batching. Incompatible request-level solver overrides fail early instead of silently changing the checkpoint contract. Existing MeanFlow, SOAR, and base behavior remains unchanged.

## Validation

- H200: `python -m pytest -q tests/unit_test/dots_tts` — 101 passed
- `ruff check sglang_omni/models/dots_tts tests/unit_test/dots_tts`
- `git diff --check`

## Follow-up

STTS interleaved input and mixed-phase continuous batching are intentionally split into a dependent follow-up PR.
