### PR TITLE
[TTS] Add dots.tts STTS continuous batching

### DIFF
--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -45,7 +45,7 @@ for details.
 | [MOSS-TTS](../cookbook/moss_tts.md) | `examples/configs/moss_tts.yaml` | Voice cloning via `ref_audio` or `references[0].audio_path` (+ `text`). Duration via `${token:N}` or `token_count`. Benchmark at `--max-concurrency 8` |
 | [MOSS-TTS Local](../cookbook/moss_tts_local.md) | `examples/configs/moss_tts_local.yaml` | 48 kHz stereo local-transformer MOSS-TTS; voice cloning / reference-less; streaming |
 | [Higgs TTS](../cookbook/higgs_tts.md) | `--model-path` only | Voice cloning, streaming; no example YAML required |
-| [dots.tts](../cookbook/dots_tts.md) | `examples/configs/dots_tts.yaml` (MeanFlow), `examples/configs/dots_tts_scm.yaml` (two-step sCM), `examples/configs/dots_tts_soar.yaml` (SOAR) | 48 kHz continuous-latent TTS with reference audio. MeanFlow and sCM use continuous batching; SOAR/base remain single-request. TP1 only |
+| [dots.tts](../cookbook/dots_tts.md) | `examples/configs/dots_tts.yaml` (MeanFlow), `examples/configs/dots_tts_scm.yaml` (two-step sCM), `examples/configs/dots_tts_stts.yaml` (STTS), `examples/configs/dots_tts_soar.yaml` (SOAR) | 48 kHz continuous-latent TTS with reference audio. MeanFlow and sCM use continuous batching; the STTS artifact additionally interleaves text and audio positions using its artifact cadence. SOAR/base remain single-request. TP1 only |
 | [ZONOS2](../cookbook/zonos2.md) | `--model-path Zyphra/zonos2` | MoE TTS, 9 DAC codebooks, voice cloning; needs Descript DAC extras (see cookbook) |
 
 ## Launch the Server

--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -45,7 +45,7 @@ for details.
 | [MOSS-TTS](../cookbook/moss_tts.md) | `examples/configs/moss_tts.yaml` | Voice cloning via `ref_audio` or `references[0].audio_path` (+ `text`). Duration via `${token:N}` or `token_count`. Benchmark at `--max-concurrency 8` |
 | [MOSS-TTS Local](../cookbook/moss_tts_local.md) | `examples/configs/moss_tts_local.yaml` | 48 kHz stereo local-transformer MOSS-TTS; voice cloning / reference-less; streaming |
 | [Higgs TTS](../cookbook/higgs_tts.md) | `--model-path` only | Voice cloning, streaming; no example YAML required |
-| [dots.tts](../cookbook/dots_tts.md) | `examples/configs/dots_tts.yaml` (MeanFlow), `examples/configs/dots_tts_soar.yaml` (SOAR) | 48 kHz continuous-latent TTS with reference audio. MeanFlow (`dots.tts-mf`) uses continuous batching (`max_running_requests=16` by default) with engine-wide `num_steps=4` and Euler. SOAR (`dots.tts-soar`) and base (`dots.tts-base`) are flow matching and run the single-request solver with CFG at `max_running_requests=1`; both use the SOAR config. All require `ref_audio` + `ref_text`. TP1 only |
+| [dots.tts](../cookbook/dots_tts.md) | `examples/configs/dots_tts.yaml` (MeanFlow), `examples/configs/dots_tts_scm.yaml` (two-step sCM), `examples/configs/dots_tts_soar.yaml` (SOAR) | 48 kHz continuous-latent TTS with reference audio. MeanFlow and sCM use continuous batching; SOAR/base remain single-request. TP1 only |
 | [ZONOS2](../cookbook/zonos2.md) | `--model-path Zyphra/zonos2` | MoE TTS, 9 DAC codebooks, voice cloning; needs Descript DAC extras (see cookbook) |
 
 ## Launch the Server
@@ -159,11 +159,23 @@ sgl-omni serve \
   --port 8000
 ```
 
+For dots.tts two-step sCM:
+
+```bash
+sgl-omni serve \
+  --model-path dots-studio/dots.tts-mf-2steps \
+  --config examples/configs/dots_tts_scm.yaml \
+  --allowed-media-domain huggingface.co \
+  --allowed-media-domain cas-bridge.xethub.hf.co \
+  --allowed-media-domain us.aws.cdn.hf.co \
+  --port 8000
+```
+
 `dots.tts-base` uses the same config; pass `--model-path dots-studio/dots.tts-base`.
 
-SOAR and base are flow-matching checkpoints, so they run the single-request solver
-(`max_running_requests=1`) with classifier-free guidance. Continuous batching is
-MeanFlow-only for now. `rednote-hilab/dots.tts-*` is the old org name and redirects to
+SOAR and base run the single-request solver (`max_running_requests=1`). The sCM
+artifacts fix Euler, NFE 2, and CFG 0 and support the batched acoustic tail; omit
+those request overrides. `rednote-hilab/dots.tts-*` is the old org name and redirects to
 `dots-studio/dots.tts-*`; both work as `--model-path`.
 
 For Ming-Omni-TTS on two 80 GB GPUs:

--- a/docs/cookbook/dots_tts.md
+++ b/docs/cookbook/dots_tts.md
@@ -2,7 +2,7 @@
 
 [dots.tts](https://huggingface.co/dots-studio/dots.tts-mf) is a text-to-speech model from rednote-hilab. It outputs 48 kHz speech and clones a speaker from a short reference clip plus its transcript.
 
-dots.tts is a continuous-latent model, not a codec model. The backbone emits no audio tokens. Each AR step gives a hidden state; a MeanFlow DiT uses it to sample one latent patch (4 frames × 128 dims); a semantic encoder turns the patch back into the next backbone input; an AudioVAE decodes latents to waveform. No codebook, no token sampler. So `temperature` and `top_k` do nothing here — use the solver knobs (`num_steps`, `guidance_scale`) instead.
+dots.tts is a continuous-latent model, not a codec model. The backbone emits no audio tokens. Each AR step gives a hidden state; an acoustic DiT uses it to sample one latent patch (4 frames × 128 dims); a semantic encoder turns the patch back into the next backbone input; an AudioVAE decodes latents to waveform. No codebook, no token sampler. So `temperature` and `top_k` do nothing here — use the solver knobs (`num_steps`, `guidance_scale`) instead.
 
 | Component | Spec |
 |---|---|
@@ -11,13 +11,14 @@ dots.tts is a continuous-latent model, not a codec model. The backbone emits no 
 | Latent patch | 4 frames × 128 dims (one patch ≈ 160 ms of audio) |
 | Context length | 2,048 tokens |
 | Sample rate | 48 kHz |
-| Solver | MeanFlow + Euler, engine-wide `num_steps=4` (SOAR: flow matching + CFG, `num_steps=10`) |
+| Solver | MeanFlow + Euler, engine-wide `num_steps=4`; SOAR uses flow matching + CFG; the two-step artifact uses its fixed sCM contract |
 
 ## Supported checkpoints
 
 | Checkpoint | Status |
 |---|---|
 | [`dots-studio/dots.tts-mf`](https://huggingface.co/dots-studio/dots.tts-mf) | MeanFlow. Continuous batching, `num_steps=4`. `examples/configs/dots_tts.yaml` |
+| [`dots-studio/dots.tts-mf-2steps`](https://huggingface.co/dots-studio/dots.tts-mf-2steps) | sCM. Artifact-locked Euler, `num_steps=2`, CFG `0`. Continuous batching with `examples/configs/dots_tts_scm.yaml` |
 | [`dots-studio/dots.tts-soar`](https://huggingface.co/dots-studio/dots.tts-soar) | Flow matching. Single request at a time (`max_running_requests=1`) with CFG, `num_steps=10`. `examples/configs/dots_tts_soar.yaml` |
 | [`dots-studio/dots.tts-base`](https://huggingface.co/dots-studio/dots.tts-base) | Flow matching, same as SOAR. Serve it with `examples/configs/dots_tts_soar.yaml` and `--model-path dots-studio/dots.tts-base` |
 
@@ -47,7 +48,21 @@ sgl-omni serve \
   --port 8000
 ```
 
-SOAR is a flow-matching checkpoint. It runs the single-request solver with classifier-free guidance, so its config pins `max_running_requests: 1` and `num_steps: 10`; continuous batching is MeanFlow-only. Every request example below works on either checkpoint — only the `model` field changes.
+SOAR is a legacy flow-matching checkpoint. It runs the single-request solver with classifier-free guidance, so its config pins `max_running_requests: 1` and `num_steps: 10`. MeanFlow and sCM checkpoints support continuous batching. Every request example below works on either checkpoint — only the `model` field changes.
+
+For the two-step sCM checkpoint, use its config and omit solver overrides from requests:
+
+```bash
+hf download dots-studio/dots.tts-mf-2steps
+
+sgl-omni serve \
+  --model-path dots-studio/dots.tts-mf-2steps \
+  --config examples/configs/dots_tts_scm.yaml \
+  --allowed-local-media-path docs/_static/audio \
+  --port 8000
+```
+
+The checkpoint declares Euler, NFE 2, CFG 0, and `tau_mid`. Serving applies those values automatically and rejects incompatible `ode_method`, `num_steps`, or `guidance_scale` overrides.
 
 `examples/configs/dots_tts.yaml` is the canonical MeanFlow deployment. It is already tuned; compiled acoustic tail and vocoder (`optimize: true`, on by default); continuous batching at `max_running_requests=16`; and the backbone decode CUDA graph. `--model-path` alone keeps the compiled tail and batching but leaves backbone decode eager, which is slower per request (see [Performance](#performance)). Use the config file.
 
@@ -179,10 +194,10 @@ Solver knobs go under `stage_params.latent_engine`. They are **not** top-level f
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `speaker_scale` | float | `1.5` | Scales the speaker x-vector before conditioning. Higher values push harder toward the reference timbre |
-| `guidance_scale` | float | `1.2` | Classifier-free guidance strength for the flow sampler |
+| `guidance_scale` | float | `1.2` or artifact value | Classifier-free guidance strength for the flow sampler. Fixed-step artifacts reject overrides |
 | `eos_threshold` | float | `0.8` | Probability above which the EOS head ends generation. Lower values cut utterances earlier |
-| `num_steps` | int | `4` (MF), `10` (SOAR) | Flow solver steps. MeanFlow fixes this engine-wide: another value fails the request. SOAR and base run one request at a time and honour it |
-| `ode_method` | string | `"euler"` | Flow solver. MeanFlow accepts only `euler` |
+| `num_steps` | int | `4` (MF), `10` (SOAR), artifact value | Flow solver steps. MeanFlow fixes this engine-wide; artifact-locked checkpoints reject overrides |
+| `ode_method` | string | `"euler"` or artifact value | Flow solver. MeanFlow and current fixed-step artifacts accept only `euler` |
 | `max_generate_length` | int | `500` | Cap on generated latent patches (≈ 160 ms each), bounded by the engine's `max_generate_length` |
 | `normalize_text` | bool | `false` | Run the upstream text normalizer (numbers, symbols) before tokenizing |
 

--- a/docs/cookbook/dots_tts.md
+++ b/docs/cookbook/dots_tts.md
@@ -19,6 +19,7 @@ dots.tts is a continuous-latent model, not a codec model. The backbone emits no 
 |---|---|
 | [`dots-studio/dots.tts-mf`](https://huggingface.co/dots-studio/dots.tts-mf) | MeanFlow. Continuous batching, `num_steps=4`. `examples/configs/dots_tts.yaml` |
 | [`dots-studio/dots.tts-mf-2steps`](https://huggingface.co/dots-studio/dots.tts-mf-2steps) | sCM. Artifact-locked Euler, `num_steps=2`, CFG `0`. Continuous batching with `examples/configs/dots_tts_scm.yaml` |
+| [`dots-studio/dots.tts-mf-2steps-stts`](https://huggingface.co/dots-studio/dots.tts-mf-2steps-stts) | Streaming TTS with artifact-declared text/audio cadence and batched sCM. `examples/configs/dots_tts_stts.yaml` |
 | [`dots-studio/dots.tts-soar`](https://huggingface.co/dots-studio/dots.tts-soar) | Flow matching. Single request at a time (`max_running_requests=1`) with CFG, `num_steps=10`. `examples/configs/dots_tts_soar.yaml` |
 | [`dots-studio/dots.tts-base`](https://huggingface.co/dots-studio/dots.tts-base) | Flow matching, same as SOAR. Serve it with `examples/configs/dots_tts_soar.yaml` and `--model-path dots-studio/dots.tts-base` |
 
@@ -63,6 +64,15 @@ sgl-omni serve \
 ```
 
 The checkpoint declares Euler, NFE 2, CFG 0, and `tau_mid`. Serving applies those values automatically and rejects incompatible `ode_method`, `num_steps`, or `guidance_scale` overrides.
+
+For STTS, swap to `dots.tts-mf-2steps-stts` and
+`examples/configs/dots_tts_stts.yaml`. Serving constructs the prompt/target
+interleave from the checkpoint's `streaming` config. Backbone rows at text
+positions stay in the continuous batch; only rows at audio positions enter the
+batched sCM acoustic tail, so requests with different text/audio phases do not
+serialize each other. The OpenAI speech API accepts normal `input` text; the
+low-level pipeline also accepts `text_token_ids` (or `input_ids`) for an upstream
+LLM token stream that has already been collected.
 
 `examples/configs/dots_tts.yaml` is the canonical MeanFlow deployment. It is already tuned; compiled acoustic tail and vocoder (`optimize: true`, on by default); continuous batching at `max_running_requests=16`; and the backbone decode CUDA graph. `--model-path` alone keeps the compiled tail and batching but leaves backbone decode eager, which is slower per request (see [Performance](#performance)). Use the config file.
 

--- a/examples/configs/dots_tts_scm.yaml
+++ b/examples/configs/dots_tts_scm.yaml
@@ -1,0 +1,14 @@
+config_cls: DotsTTSPipelineConfig
+model_path: dots-studio/dots.tts-mf-2steps
+runtime_overrides:
+  latent_engine:
+    optimize: true
+    num_steps: 2
+    max_generate_length: 500
+    server_args_overrides:
+      mem_fraction_static: 0.20
+      max_running_requests: 16
+      disable_cuda_graph: false
+      cuda_graph_max_bs: 16
+  vocoder:
+    optimize: true

--- a/examples/configs/dots_tts_stts.yaml
+++ b/examples/configs/dots_tts_stts.yaml
@@ -1,0 +1,20 @@
+config_cls: DotsTTSPipelineConfig
+model_path: dots-studio/dots.tts-mf-2steps-stts
+runtime_overrides:
+  reference_encode:
+    max_concurrency: 8
+    max_batch_size: 4
+    max_batch_wait_ms: 2
+  latent_engine:
+    optimize: true
+    num_steps: 2
+    max_generate_length: 500
+    server_args_overrides:
+      mem_fraction_static: 0.20
+      max_running_requests: 16
+      disable_cuda_graph: false
+      cuda_graph_max_bs: 16
+  vocoder:
+    optimize: true
+    max_batch_size: 8
+    max_batch_wait_ms: 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [
     # Gradio playground
     "gradio>=4.0.0",
     # dots.tts model operators; serving/runtime stays owned by sglang-omni
-    "dots.tts==0.2.1",
+    "dots.tts==0.3.1",
     # Ming-Omni
     "diffusers==0.37.0",      # Omni's own Ming-Omni pin; not an sglang core dependency
     "x-transformers",          # Ming talker rotary embeddings

--- a/sglang_omni/models/dots_tts/codec.py
+++ b/sglang_omni/models/dots_tts/codec.py
@@ -16,6 +16,7 @@ from safetensors.torch import load_file
 
 from sglang_omni.models.dots_tts.payload_types import (
     load_dots_tts_state,
+    materialize_streaming_schedule,
     store_dots_tts_state,
 )
 from sglang_omni.preprocessing.cache_key import (
@@ -300,6 +301,7 @@ class DotsReferenceEncoder:
                 artifact["latent_distribution"],
                 seed=state.seed,
             )
+        materialize_streaming_schedule(state)
         return store_dots_tts_state(payload, state)
 
 

--- a/sglang_omni/models/dots_tts/engine_builder.py
+++ b/sglang_omni/models/dots_tts/engine_builder.py
@@ -41,8 +41,8 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
         register_dots_tts_hf_config()
 
     def customize_server_args(self, server_args: Any) -> None:
-        # The compiled DiT path only serves max_running_requests=1; the batched
-        # tail is eager, so skip the process-global compile policy otherwise.
+        # The single-request DiT has its own compile path; batched checkpoints
+        # use the pooled acoustic tail instead.
         # The policy must exist before SGLang builds the model; applying it in
         # setup_model nests Dynamo under FX.
         if self.optimize and int(server_args.max_running_requests) == 1:
@@ -163,6 +163,7 @@ class DotsTTSEngineBuilder(TtsEngineBuilder):
             model.flow.validate_request(
                 num_steps=data.state.num_steps,
                 ode_method=data.state.ode_method,
+                guidance_scale=data.state.guidance_scale,
                 prompt_patch_count=int(data.prompt_span_positions.numel()),
                 total_span_count=int(data.span_positions.numel()),
             )

--- a/sglang_omni/models/dots_tts/flow_head.py
+++ b/sglang_omni/models/dots_tts/flow_head.py
@@ -408,11 +408,20 @@ class DotsTTSFlowHead(nn.Module):
         generation_schedule: torch.Tensor,
         prefill_end: int,
         decoded_latent_patches: list[torch.Tensor],
+        interleaved: bool = False,
     ) -> None:
         if hidden_states.ndim == 2:
             hidden_states = hidden_states.unsqueeze(0)
         decoded_count = len(decoded_latent_patches)
-        assert hidden_states.shape[:2] == (1, int(prefill_end) + decoded_count)
+        if (
+            hidden_states.size(0) != 1
+            or hidden_states.size(1) < int(prefill_end)
+            or (
+                not interleaved
+                and hidden_states.size(1) != int(prefill_end) + decoded_count
+            )
+        ):
+            raise RuntimeError("dots.tts re-prefill history does not match the request")
         if state.slot is not None:
             prompt_patches = state.prompt_patches
             if prompt_patches is None or state.all_mods is None:
@@ -437,10 +446,20 @@ class DotsTTSFlowHead(nn.Module):
                 )
                 return
             fm_parts = [prompt_fm_rows]
-            conditioning_hidden = hidden_states[
-                0,
-                prefill_end - 1 : prefill_end - 1 + decoded_count,
-            ]
+            if interleaved:
+                audio_positions = self._generated_audio_positions(
+                    generation_schedule,
+                    prefill_end=prefill_end,
+                    generated_count=hidden_states.size(1) - prefill_end,
+                    audio_span_token_ids=audio_span_token_ids,
+                    expected=decoded_count,
+                )
+                conditioning_hidden = hidden_states[0, audio_positions - 1]
+            else:
+                conditioning_hidden = hidden_states[
+                    0,
+                    prefill_end - 1 : prefill_end - 1 + decoded_count,
+                ]
             normalized = self.io.normalize(
                 torch.cat(
                     [
@@ -493,27 +512,67 @@ class DotsTTSFlowHead(nn.Module):
                     state, hidden_states[:, span_position : span_position + 1]
                 )
             cursor = next_position
-        if prefill_end > cursor:
+        if (not interleaved or not decoded_count) and prefill_end > cursor:
             self.append_hidden(state, hidden_states[:, prefill_end - 1 : prefill_end])
+        audio_positions = (
+            self._generated_audio_positions(
+                generation_schedule,
+                prefill_end=prefill_end,
+                generated_count=hidden_states.size(1) - prefill_end,
+                audio_span_token_ids=audio_span_token_ids,
+                expected=decoded_count,
+            )
+            if interleaved
+            else None
+        )
         for patch_index, patch in enumerate(decoded_latent_patches):
+            if audio_positions is not None:
+                position = int(audio_positions[patch_index])
+                self.append_hidden(state, hidden_states[:, position - 1 : position])
             self._append_history(
                 state,
                 self.io.normalize(patch.to(device=hidden_states.device)).to(
                     dtype=state.fm_sequence.dtype
                 ),
             )
-            next_hidden_position = prefill_end + patch_index
-            self.append_hidden(
-                state,
-                hidden_states[
-                    :,
-                    next_hidden_position : next_hidden_position + 1,
-                ],
-            )
+            if audio_positions is None:
+                next_hidden_position = prefill_end + patch_index
+                self.append_hidden(
+                    state,
+                    hidden_states[
+                        :,
+                        next_hidden_position : next_hidden_position + 1,
+                    ],
+                )
         if decoded_count:
             state.drop_regenerated_prompt_patch = False
             state.suppress_first_eos_check = False
             state.decoded_patches = decoded_count
+
+    @staticmethod
+    def _generated_audio_positions(
+        generation_schedule: torch.Tensor,
+        *,
+        prefill_end: int,
+        generated_count: int,
+        audio_span_token_ids: set[int],
+        expected: int,
+    ) -> torch.Tensor:
+        ids = torch.tensor(
+            sorted(audio_span_token_ids), device=generation_schedule.device
+        )
+        positions = torch.nonzero(
+            torch.isin(
+                generation_schedule[0, prefill_end : prefill_end + generated_count],
+                ids,
+            ),
+            as_tuple=False,
+        ).squeeze(-1) + int(prefill_end)
+        if positions.numel() != expected:
+            raise RuntimeError(
+                "dots.tts STTS replay audio positions do not match decoded patches"
+            )
+        return positions
 
     @torch.inference_mode()
     def append_hidden(self, state: DotsFlowState, hidden_states: torch.Tensor) -> None:

--- a/sglang_omni/models/dots_tts/flow_head.py
+++ b/sglang_omni/models/dots_tts/flow_head.py
@@ -68,9 +68,13 @@ class DotsTTSFlowHead(nn.Module):
         self.latent_dim = int(config.latent_dim)
         self.optimize = bool(optimize)
         self.mode = (
-            "meanflow"
-            if config.meanflow is not None and config.meanflow.enabled
-            else "flow_matching"
+            config.sampling.solver
+            if config.sampling is not None
+            else (
+                "meanflow"
+                if config.meanflow is not None and config.meanflow.enabled
+                else "flow_matching"
+            )
         )
         dit_mode = (
             "meanflow"
@@ -139,12 +143,26 @@ class DotsTTSFlowHead(nn.Module):
                 DiTSolver,
             )
 
-            self._dit_solver = DiTSolver(
-                DiTInferenceContext.from_core(self),
-                optimize=self.optimize,
-                bucket_resolver=self._bucket,
-                meanflow=self.mode == "meanflow",
-            )
+            context = DiTInferenceContext.from_core(self)
+            if self.mode == "scm":
+                from dots_tts.modules.backbone.scm_inference import SCMDiTSolver
+
+                sampling = self.config.sampling
+                if sampling is None:
+                    raise RuntimeError("sCM solver requires artifact sampling config")
+                self._dit_solver = SCMDiTSolver(
+                    context,
+                    optimize=self.optimize,
+                    bucket_resolver=self._bucket,
+                    tau_mid=sampling.tau_mid,
+                )
+            else:
+                self._dit_solver = DiTSolver(
+                    context,
+                    optimize=self.optimize,
+                    bucket_resolver=self._bucket,
+                    meanflow=self.mode == "meanflow",
+                )
         return self._dit_solver
 
     @property
@@ -159,14 +177,13 @@ class DotsTTSFlowHead(nn.Module):
         max_audio_patches: int,
         optimize: bool = False,
     ) -> None:
-        if self.mode != "meanflow":
-            # note (luojiaxuan): flow-matching checkpoints (SOAR, base) need the
-            # CFG double branch, which the batched tail does not implement. They
-            # serve on the single-request solver instead.
+        if self.mode not in {"meanflow", "scm"}:
+            # note (luojiaxuan): legacy flow-matching checkpoints need the CFG
+            # double branch, which the batched tail does not implement.
             raise ValueError(
-                "dots.tts continuous batching requires a MeanFlow checkpoint; "
+                "dots.tts continuous batching requires a MeanFlow or sCM checkpoint; "
                 f"this checkpoint is {self.mode}. Serve it with "
-                "max_running_requests=1 (see examples/configs/dots_tts_soar.yaml)"
+                "max_running_requests=1"
             )
         from sglang_omni.models.dots_tts.tail import (
             DotsTtsAcousticTail,
@@ -188,6 +205,13 @@ class DotsTTSFlowHead(nn.Module):
                 latent_patch_size=self.latent_patch_size,
                 latent_dim=self.latent_dim,
                 fm_hidden_size=self.fm_hidden_size,
+                solver=self.mode,
+                fm_sigma=float(self.config.fm_sigma),
+                tau_mid=(
+                    float(self.config.sampling.tau_mid)
+                    if self.config.sampling is not None
+                    else 1.3
+                ),
             ),
             device=parameter.device,
             dtype=parameter.dtype,
@@ -201,9 +225,17 @@ class DotsTTSFlowHead(nn.Module):
         *,
         num_steps: int,
         ode_method: str,
+        guidance_scale: float | None = None,
         prompt_patch_count: int | None = None,
         total_span_count: int | None = None,
     ) -> None:
+        sampling = self.config.sampling
+        if sampling is not None:
+            sampling.resolve(
+                ode_method=ode_method,
+                num_steps=num_steps,
+                guidance_scale=guidance_scale,
+            )
         if not self.is_batched:
             return
         if int(num_steps) != self._batched_nfe:
@@ -251,18 +283,7 @@ class DotsTTSFlowHead(nn.Module):
                 if speaker_embedding is not None:
                     speaker_embedding = speaker_embedding.to(device=device, dtype=dtype)
                     g_cond = self.xvec_proj(speaker_embedding * float(speaker_scale))
-                grid = torch.linspace(
-                    0.0,
-                    1.0,
-                    int(self._batched_nfe) + 1,
-                    device=device,
-                    dtype=dtype,
-                )
-                all_mods = self._tail.dit.build_mods(
-                    grid[:-1],
-                    duration=grid[1:] - grid[:-1],
-                    g_cond=g_cond,
-                )
+                all_mods = self._tail.build_mods(g_cond)
                 prompt_latents = prompt_latents.to(device=device, dtype=dtype)
                 prompt_embeddings = self._tail.encode_prompt_patches(
                     slot, self._patch_encoder_input(prompt_latents)
@@ -558,7 +579,9 @@ class DotsTTSFlowHead(nn.Module):
             normalized_patch = solver.decode_next(
                 state.dit_state,
                 sequence=state.fm_sequence,
-                cfg_sequence=state.fm_cfg_sequence,
+                cfg_sequence=(
+                    state.fm_cfg_sequence if self.mode == "flow_matching" else None
+                ),
                 fm_seq_len=state.fm_seq_len,
                 null_g_cond=state.fm_null_g_cond,
                 g_cond=state.g_cond,

--- a/sglang_omni/models/dots_tts/model_runner.py
+++ b/sglang_omni/models/dots_tts/model_runner.py
@@ -84,19 +84,41 @@ class DotsTTSModelRunner(ModelRunner):
                 assert prefix_len == 0, "dots.tts radix prefix reuse is disabled"
                 prompt_len = embeddings.size(1)
                 generated_count = req_len - prompt_len
-                assert (
-                    generated_count
-                    == len(data.req.output_ids)
-                    == len(data.decoded_latent_patches)
+                assert generated_count == len(
+                    data.req.output_ids
                 ), "dots.tts re-prefill history must match generated tokens"
                 request_rows = [embeddings[0]]
                 if generated_count:
-                    request_rows.append(
-                        self.model.flow.replay_feedback(
-                            flow_state,
-                            data.decoded_latent_patches,
-                        ).to(device=device, dtype=embeddings.dtype)
-                    )
+                    feedback = self.model.flow.replay_feedback(
+                        flow_state,
+                        data.decoded_latent_patches,
+                    ).to(device=device, dtype=embeddings.dtype)
+                    if getattr(data.state, "interleaved", False):
+                        generated_ids = torch.tensor(
+                            data.req.output_ids,
+                            device=device,
+                            dtype=torch.long,
+                        )
+                        generated = self.model.get_input_embeddings()(
+                            generated_ids
+                        ).clone()
+                        audio_mask = torch.isin(
+                            generated_ids,
+                            torch.tensor(
+                                data.state.audio_span_token_ids,
+                                device=device,
+                                dtype=torch.long,
+                            ),
+                        )
+                        if int(audio_mask.sum()) != feedback.size(0):
+                            raise RuntimeError(
+                                "dots.tts STTS replay tokens do not match audio patches"
+                            )
+                        generated[audio_mask] = feedback
+                        request_rows.append(generated)
+                    else:
+                        assert generated_count == len(data.decoded_latent_patches)
+                        request_rows.append(feedback)
                 rows.append(torch.cat(request_rows, dim=0))
             forward_batch.input_embeds = torch.cat(rows, dim=0)
         except BaseException:
@@ -122,7 +144,12 @@ class DotsTTSModelRunner(ModelRunner):
             if not queue:
                 raise RuntimeError("dots.tts decode is missing its latent feedback")
             feedback = queue.popleft()
-            if feedback.ndim > 1:
+            if isinstance(feedback, int):
+                token = torch.tensor(
+                    [feedback], device=forward_batch.input_ids.device, dtype=torch.long
+                )
+                feedback = self.model.get_input_embeddings()(token)[0]
+            elif feedback.ndim > 1:
                 feedback = feedback.reshape(-1, feedback.shape[-1])[-1]
             rows.append(feedback)
         buffer = self.model.graph_feedback_buffer
@@ -190,17 +217,29 @@ class DotsTTSModelRunner(ModelRunner):
                 generation_schedule=data.generation_schedule.to(hidden.device),
                 prefill_end=data.prefill_end,
                 decoded_latent_patches=data.decoded_latent_patches,
+                interleaved=getattr(data.state, "interleaved", False),
             )
             last_hidden.append(request_hidden[0, -1])
             offset += length
         if offset != hidden.size(0):
             raise RuntimeError("dots.tts prefill hidden rows do not match requests")
-        launch_buf = self._launch_flow_batch(
-            result,
-            requests,
-            torch.stack(last_hidden),
-            append_hidden=False,
-        )
+        hidden = torch.stack(last_hidden)
+        if all(
+            getattr(request.data.state, "interleaved", False) for request in requests
+        ):
+            launch_buf = self._advance_interleaved_batch(
+                result,
+                requests,
+                hidden,
+                initial=[not request.data.req.output_ids for request in requests],
+            )
+        else:
+            launch_buf = self._launch_flow_batch(
+                result,
+                requests,
+                hidden,
+                append_hidden=False,
+            )
         self._resolve_flow_finish(launch_buf)
 
     def post_decode(
@@ -224,6 +263,15 @@ class DotsTTSModelRunner(ModelRunner):
             raise RuntimeError(
                 f"dots.tts expected rank-2/3 decode hidden, got {hidden.ndim}"
             )
+        interleaved = [
+            getattr(request.data.state, "interleaved", False) for request in requests
+        ]
+        if any(interleaved):
+            if not all(interleaved):
+                raise RuntimeError(
+                    "dots.tts STTS and non-STTS requests cannot share a decode batch"
+                )
+            return self._advance_interleaved_batch(result, requests, hidden)
         return self._launch_flow_batch(result, requests, hidden, append_hidden=True)
 
     def post_decode_resolve(
@@ -246,16 +294,39 @@ class DotsTTSModelRunner(ModelRunner):
         append_hidden: bool,
     ) -> _DotsFlowLaunchBuf:
         data_rows = [request.data for request in requests]
+        launch = self._decode_flow_rows(requests, hidden, append_hidden=append_hidden)
+        result.next_token_ids = torch.tensor(
+            [data.control_token_id for data in data_rows],
+            dtype=torch.long,
+            device=hidden.device,
+        )
+        return launch
+
+    def _decode_flow_rows(
+        self,
+        requests: list,
+        hidden: torch.Tensor,
+        *,
+        append_hidden: bool,
+    ) -> _DotsFlowLaunchBuf:
+        data_rows = [request.data for request in requests]
         steps = self.model.flow.decode_batch(
             [data.flow_state for data in data_rows],
             hidden_states=hidden,
             num_steps=[data.state.num_steps for data in data_rows],
             ode_methods=[data.state.ode_method for data in data_rows],
             guidance_scales=[data.state.guidance_scale for data in data_rows],
-            eos_thresholds=[data.state.eos_threshold for data in data_rows],
+            eos_thresholds=[
+                (
+                    data.state.eos_threshold
+                    if not getattr(data.state, "interleaved", False)
+                    or data.text_finished
+                    else float("inf")
+                )
+                for data in data_rows
+            ],
             append_hidden=append_hidden,
         )
-        next_token_ids = []
         for data, step in zip(data_rows, steps, strict=True):
             data.pending_feedback_queue.append(step.feedback_embedding.detach())
             decoded_latent = step.latent_patch.detach()
@@ -263,17 +334,60 @@ class DotsTTSModelRunner(ModelRunner):
             if step.emit:
                 data.latest_latent_patch = decoded_latent
                 data.latent_patches.append(decoded_latent)
-            next_token_ids.append(data.control_token_id)
-        result.next_token_ids = torch.tensor(
-            next_token_ids,
-            dtype=torch.long,
-            device=hidden.device,
-        )
         return _DotsFlowLaunchBuf(
             data_rows=data_rows,
             steps=steps,
             batched=bool(self.model.flow.is_batched),
         )
+
+    def _advance_interleaved_batch(
+        self,
+        result: Any,
+        requests: list,
+        hidden: torch.Tensor,
+        *,
+        initial: list[bool] | None = None,
+    ) -> _DotsFlowLaunchBuf | None:
+        initial = initial or [False] * len(requests)
+        next_ids: list[int] = []
+        audio_requests = []
+        audio_rows = []
+        for row, request in enumerate(requests):
+            data = request.data
+            if initial[row]:
+                audio_requests.append(request)
+                audio_rows.append(row)
+                next_ids.append(data.control_token_id)
+                continue
+            schedule = data.generation_schedule[0]
+            if data.interleave_cursor >= schedule.numel():
+                next_ids.append(data.control_token_id)
+                continue
+            token_id = int(schedule[data.interleave_cursor])
+            data.interleave_cursor += 1
+            if token_id in data.state.audio_span_token_ids:
+                audio_requests.append(request)
+                audio_rows.append(row)
+                next_ids.append(data.control_token_id)
+            else:
+                data.pending_feedback_queue.append(token_id)
+                data.text_finished |= token_id == data.text_cond_end_id
+                next_ids.append(token_id)
+        launch = None
+        if audio_requests:
+            if any(initial) and not all(initial) and not self.model.flow.is_batched:
+                raise RuntimeError(
+                    "dots.tts STTS mixed initial/replay prefill requires batched tail"
+                )
+            launch = self._decode_flow_rows(
+                audio_requests,
+                hidden[audio_rows],
+                append_hidden=not all(initial),
+            )
+        result.next_token_ids = torch.tensor(
+            next_ids, dtype=torch.long, device=hidden.device
+        )
+        return launch
 
     def _resolve_flow_finish(self, launch_buf: _DotsFlowLaunchBuf | None) -> None:
         if launch_buf is None:

--- a/sglang_omni/models/dots_tts/payload_types.py
+++ b/sglang_omni/models/dots_tts/payload_types.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 import torch
 
@@ -27,6 +28,8 @@ class DotsTTSState(DeclarativeStateBase):
     stream: bool = wire(False, codec="bool")
     eos_threshold: float = wire(0.8, codec="float")
     generation_schedule: torch.Tensor | None = wire(None, codec="typed_tensor")
+    interleaved: bool = wire(False, codec="bool")
+    streaming_schedule: dict[str, Any] | None = None
     audio_span_token_ids: list[int] = wire(default_factory=list, codec="list")
     latent_patch_size: int = wire(4, codec="int_or")
     vocab_size: int = wire(0, codec="int")
@@ -34,6 +37,51 @@ class DotsTTSState(DeclarativeStateBase):
     speaker_embedding: torch.Tensor | None = wire(None, codec="typed_tensor")
     generated_latents: torch.Tensor | None = wire(None, codec="typed_tensor")
     finish_reason: str | None = None
+
+
+def materialize_streaming_schedule(state: DotsTTSState) -> None:
+    """Build the paired STTS schedule once prompt patch count is known."""
+    spec = state.streaming_schedule
+    if spec is None:
+        return
+    from dots_tts.runtime_double_streaming import build_interleave_token_sequence
+
+    prompt_patches = state.prompt_latents
+    if prompt_patches is None:
+        raise ValueError("dots.tts STTS requires reference audio with its transcript")
+    prompt_span_count = int(prompt_patches.shape[1]) // int(state.latent_patch_size) + 1
+    target_span_count = int(spec["max_audio_patches"]) - prompt_span_count
+    if target_span_count <= 0:
+        raise ValueError(
+            "dots.tts STTS max_generate_length must exceed the reference audio "
+            f"span count ({prompt_span_count})"
+        )
+    cadence = {
+        "interleave_mode": spec["interleave_mode"],
+        "initial_lookahead": spec["initial_lookahead"],
+        "ta_per_tta": spec["ta_per_tta"],
+        "warmup_ta": spec["warmup_ta"],
+    }
+    audio_span_id = int(spec["audio_span_id"])
+    prompt = build_interleave_token_sequence(
+        text_tokens=list(spec["prompt_text_ids"]),
+        audio_tokens=[audio_span_id] * prompt_span_count + [int(spec["audio_end_id"])],
+        text_cond_end_id=int(spec["text_cond_end_id"]),
+        **cadence,
+    )
+    target = build_interleave_token_sequence(
+        text_tokens=list(spec["text_ids"]),
+        audio_tokens=[audio_span_id] * target_span_count,
+        text_cond_end_id=int(spec["text_cond_end_id"]),
+        **cadence,
+    )
+    schedule = [*spec["prefix_ids"], *prompt, *spec["prefix_ids"], *target]
+    if len(schedule) > int(spec["max_sequence_length"]):
+        raise ValueError(
+            "dots.tts STTS schedule exceeds context length "
+            f"{spec['max_sequence_length']}"
+        )
+    state.generation_schedule = torch.tensor([schedule], dtype=torch.long)
 
 
 def load_dots_tts_state(payload: StagePayload) -> DotsTTSState:

--- a/sglang_omni/models/dots_tts/request_builders.py
+++ b/sglang_omni/models/dots_tts/request_builders.py
@@ -43,6 +43,9 @@ class DotsTTSSGLangRequestData(SGLangARRequestData):
     chunk_id: int = 0
     control_token_id: int = 0
     engine_start_s: float = 0.0
+    interleave_cursor: int = 0
+    text_cond_end_id: int = -1
+    text_finished: bool = False
 
 
 def build_sglang_dots_tts_request(
@@ -85,8 +88,10 @@ def build_sglang_dots_tts_request(
             "dots.tts prompt prefill requires one regenerated prompt patch "
             "and at least one payload patch"
         )
-    generation_budget = remaining_spans
-    if state.max_new_tokens is not None:
+    generation_budget = (
+        int(schedule.shape[1]) - prefill_end if state.interleaved else remaining_spans
+    )
+    if state.max_new_tokens is not None and not state.interleaved:
         generation_budget = min(
             generation_budget,
             int(state.max_new_tokens) + discarded_patch_count,
@@ -126,6 +131,10 @@ def build_sglang_dots_tts_request(
         input_embeds_are_projected=True,
         control_token_id=control_token_id,
         engine_start_s=time.perf_counter(),
+        interleave_cursor=prefill_end + 1,
+        text_cond_end_id=int(
+            (state.streaming_schedule or {}).get("text_cond_end_id", -1)
+        ),
         stream_metadata={
             "modality": "audio_latents",
             "stream": bool(state.stream),

--- a/sglang_omni/models/dots_tts/stages.py
+++ b/sglang_omni/models/dots_tts/stages.py
@@ -237,6 +237,36 @@ def preprocess_dots_tts_payload(
             f"dots.tts schedule exceeds context length {max_sequence_length}"
         )
 
+    ode_method = _first_not_none(
+        inputs.get("ode_method"),
+        tts_params.get("ode_method"),
+        engine_params.get("ode_method"),
+        params.get("ode_method"),
+    )
+    num_steps = _first_not_none(
+        inputs.get("num_steps"),
+        tts_params.get("num_steps"),
+        engine_params.get("num_steps"),
+        params.get("num_steps"),
+    )
+    guidance_scale = _first_not_none(
+        inputs.get("guidance_scale"),
+        tts_params.get("guidance_scale"),
+        engine_params.get("guidance_scale"),
+        params.get("guidance_scale"),
+    )
+    sampling = model_config.sampling
+    if sampling is None:
+        ode_method = "euler" if ode_method is None else str(ode_method)
+        num_steps = default_num_steps if num_steps is None else int(num_steps)
+        guidance_scale = 1.2 if guidance_scale is None else float(guidance_scale)
+    else:
+        ode_method, num_steps, guidance_scale = sampling.resolve(
+            ode_method=ode_method,
+            num_steps=num_steps,
+            guidance_scale=guidance_scale,
+        )
+
     state = DotsTTSState(
         sample_rate=int(model_config.vocoder.sample_rate),
         prompt_audio_path=prompt_audio,
@@ -250,33 +280,9 @@ def preprocess_dots_tts_payload(
                 default=1.5,
             )
         ),
-        ode_method=str(
-            _first_not_none(
-                inputs.get("ode_method"),
-                tts_params.get("ode_method"),
-                engine_params.get("ode_method"),
-                params.get("ode_method"),
-                default="euler",
-            )
-        ),
-        num_steps=int(
-            _first_not_none(
-                inputs.get("num_steps"),
-                tts_params.get("num_steps"),
-                engine_params.get("num_steps"),
-                params.get("num_steps"),
-                default=default_num_steps,
-            )
-        ),
-        guidance_scale=float(
-            _first_not_none(
-                inputs.get("guidance_scale"),
-                tts_params.get("guidance_scale"),
-                engine_params.get("guidance_scale"),
-                params.get("guidance_scale"),
-                default=1.2,
-            )
-        ),
+        ode_method=str(ode_method),
+        num_steps=int(num_steps),
+        guidance_scale=float(guidance_scale),
         eos_threshold=float(
             _first_not_none(
                 inputs.get("eos_threshold"),

--- a/sglang_omni/models/dots_tts/stages.py
+++ b/sglang_omni/models/dots_tts/stages.py
@@ -105,6 +105,7 @@ def preprocess_dots_tts_payload(
         DEFAULT_INSTRUCTION_TTS_TEMPLATE,
         DEFAULT_TEXT_TO_AUDIO_TEMPLATE,
         DEFAULT_TRAIN_TEMPLATE,
+        TTS_INTERLEAVE_PREFIX,
     )
     from dots_tts.utils.text import (
         attach_language_tag,
@@ -114,7 +115,9 @@ def preprocess_dots_tts_payload(
     )
     from dots_tts.utils.tokenizer import (
         AUDIO_COMP_SPAN_TOKEN,
+        AUDIO_GEN_END_TOKEN,
         AUDIO_GEN_SPAN_TOKEN,
+        TEXT_COND_END_TOKEN,
         require_token_id,
     )
 
@@ -134,8 +137,14 @@ def preprocess_dots_tts_payload(
         else {}
     )
 
-    text = str(_first_not_none(inputs.get("input"), inputs.get("text"), default=""))
-    if not text.strip():
+    raw_text = _first_not_none(inputs.get("input"), inputs.get("text"), default="")
+    text_token_ids = _first_not_none(
+        inputs.get("text_token_ids"), inputs.get("input_ids")
+    )
+    if text_token_ids is None and isinstance(raw_text, list):
+        text_token_ids = raw_text
+    text = "" if isinstance(raw_text, list) else str(raw_text)
+    if not text.strip() and not text_token_ids:
         raise ValueError("dots.tts requires non-empty input text")
     prompt_audio = _first_not_none(
         _reference_path(inputs.get("prompt_audio_path")),
@@ -225,17 +234,51 @@ def preprocess_dots_tts_payload(
         raise ValueError(
             f"dots.tts max_generate_length must be in [1, {max_generate_length}]"
         )
-    schedule_spec = build_generation_schedule(
-        text=f"{normalized_prompt_text}{text}",
-        tokenizer=tokenizer,
-        template=templates[template_name],
-        max_audio_tokens=request_limit,
-    )
-    schedule = torch.tensor([schedule_spec["schedule_ids"]], dtype=torch.long)
-    if schedule.numel() > int(max_sequence_length):
-        raise ValueError(
-            f"dots.tts schedule exceeds context length {max_sequence_length}"
+    streaming = getattr(model_config, "streaming", None)
+    streaming_schedule = None
+    if streaming is not None:
+        if not normalized_prompt_text or not prompt_audio:
+            raise ValueError(
+                "dots.tts STTS continuous batching requires reference audio "
+                "with its transcript"
+            )
+        if text_token_ids is None:
+            text_token_ids = tokenizer.encode(text, add_special_tokens=False)
+        if not isinstance(text_token_ids, list) or not all(
+            isinstance(token_id, int) and token_id >= 0 for token_id in text_token_ids
+        ):
+            raise ValueError("dots.tts STTS text_token_ids must be non-negative ints")
+        streaming_schedule = {
+            "prefix_ids": tokenizer.encode(
+                TTS_INTERLEAVE_PREFIX, add_special_tokens=False
+            ),
+            "prompt_text_ids": tokenizer.encode(
+                normalized_prompt_text, add_special_tokens=False
+            ),
+            "text_ids": text_token_ids,
+            "audio_span_id": require_token_id(tokenizer, AUDIO_GEN_SPAN_TOKEN),
+            "audio_end_id": require_token_id(tokenizer, AUDIO_GEN_END_TOKEN),
+            "text_cond_end_id": require_token_id(tokenizer, TEXT_COND_END_TOKEN),
+            "max_audio_patches": request_limit,
+            "max_sequence_length": int(max_sequence_length),
+            "interleave_mode": streaming.interleave_mode,
+            "initial_lookahead": streaming.initial_lookahead,
+            "ta_per_tta": streaming.ta_per_tta,
+            "warmup_ta": streaming.warmup_ta,
+        }
+        schedule = torch.empty((1, 0), dtype=torch.long)
+    else:
+        schedule_spec = build_generation_schedule(
+            text=f"{normalized_prompt_text}{text}",
+            tokenizer=tokenizer,
+            template=templates[template_name],
+            max_audio_tokens=request_limit,
         )
+        schedule = torch.tensor([schedule_spec["schedule_ids"]], dtype=torch.long)
+        if schedule.numel() > int(max_sequence_length):
+            raise ValueError(
+                f"dots.tts schedule exceeds context length {max_sequence_length}"
+            )
 
     ode_method = _first_not_none(
         inputs.get("ode_method"),
@@ -312,6 +355,8 @@ def preprocess_dots_tts_payload(
         ),
         stream=bool(params.get("stream", False)),
         generation_schedule=schedule,
+        interleaved=streaming is not None,
+        streaming_schedule=streaming_schedule,
         audio_span_token_ids=[
             require_token_id(tokenizer, AUDIO_GEN_SPAN_TOKEN),
             require_token_id(tokenizer, AUDIO_COMP_SPAN_TOKEN),

--- a/sglang_omni/models/dots_tts/tail.py
+++ b/sglang_omni/models/dots_tts/tail.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from collections import Counter
 from dataclasses import dataclass
 from functools import partial
@@ -167,11 +168,18 @@ class DotsTtsTailSpec:
     latent_patch_size: int
     latent_dim: int
     fm_hidden_size: int
+    solver: str = "meanflow"
+    fm_sigma: float = 0.0
+    tau_mid: float = 1.3
 
     def __post_init__(self) -> None:
         for name in ("nfe", "patch_capacity", "num_slots"):
             if int(getattr(self, name)) <= 0:
                 raise ValueError(f"dots.tts tail {name} must be positive")
+        if self.solver not in {"meanflow", "scm"}:
+            raise ValueError(f"unsupported dots.tts batched solver {self.solver!r}")
+        if self.solver == "scm" and self.nfe != 2:
+            raise ValueError("dots.tts batched sCM requires nfe=2")
 
     @property
     def unit_len(self) -> int:
@@ -422,7 +430,22 @@ class DotsTtsAcousticTail:
 
         self._mods_width = int(dit.fused_adaln[-1].out_features)
         self._allocate_pools(self._mods_width)
-        self._times = torch.linspace(0.0, 1.0, spec.nfe + 1, device=device, dtype=dtype)
+        if spec.solver == "scm":
+            from dots_tts.modules.backbone.scm_inference import _to_flow_matching
+
+            self._taus = torch.tensor(
+                [math.pi / 2, spec.tau_mid], device=device, dtype=torch.float32
+            )
+            _, self._times = _to_flow_matching(
+                torch.zeros(spec.nfe, 1, 1, device=device),
+                self._taus,
+                spec.fm_sigma,
+            )
+        else:
+            self._taus = None
+            self._times = torch.linspace(
+                0.0, 1.0, spec.nfe + 1, device=device, dtype=dtype
+            )
         self._dit_layer_index = torch.arange(self._dit_layers, device=device)
         self._encoder_layer_index = torch.arange(self._encoder_layers, device=device)
         self._fm_seq_len = [0] * spec.num_slots
@@ -624,6 +647,15 @@ class DotsTtsAcousticTail:
         generator = self._generators[int(slot)]
         return None if generator is None else generator.get_state().clone()
 
+    def build_mods(self, g_cond: torch.Tensor | None) -> torch.Tensor:
+        if self.spec.solver == "scm":
+            return self.dit.build_mods(self._times, g_cond=g_cond)
+        return self.dit.build_mods(
+            self._times[:-1],
+            duration=self._times[1:] - self._times[:-1],
+            g_cond=g_cond,
+        )
+
     def fm_seq_len(self, slot: int) -> int:
         return self._fm_seq_len[int(slot)]
 
@@ -744,6 +776,7 @@ class DotsTtsAcousticTail:
             persistent, device=self.device, dtype=torch.long
         )
         noise = self._sample_noise(slots)
+        renoise = self._sample_noise(slots) if spec.solver == "scm" else None
         direct_kv = len(slots) == spec.num_slots and sorted(slots) == list(
             range(spec.num_slots)
         )
@@ -753,6 +786,7 @@ class DotsTtsAcousticTail:
             work_persistent = persistent_index.index_select(0, order)
             work_hidden = fm_hidden_rows.index_select(0, order)
             work_noise = noise.index_select(0, order)
+            work_renoise = None if renoise is None else renoise.index_select(0, order)
             self._dit_contiguous_view_steps += spec.nfe
             if self._dit_contiguous_view_steps == spec.nfe:
                 logger.info("dots.tts contiguous DiT KV view is active")
@@ -761,6 +795,7 @@ class DotsTtsAcousticTail:
             work_persistent = persistent_index
             work_hidden = fm_hidden_rows
             work_noise = noise
+            work_renoise = renoise
         graph = self._select_graph(self._meanflow_graphs, len(slots), capacity)
         if graph is None:
             self._graph_misses["meanflow"] += 1
@@ -770,6 +805,7 @@ class DotsTtsAcousticTail:
                 capacity,
                 work_hidden,
                 work_noise,
+                work_renoise,
                 direct_kv=direct_kv,
             )
         else:
@@ -777,11 +813,16 @@ class DotsTtsAcousticTail:
             graph.inputs["starts"].copy_(work_persistent)
             graph.inputs["hidden"].copy_(work_hidden)
             graph.inputs["noise"].copy_(work_noise)
+            if work_renoise is not None:
+                graph.inputs["renoise"].copy_(work_renoise)
             graph.graph.replay()
             latent = graph.output.clone()
             self._graph_replays["meanflow"] += 1
             if self._graph_replays["meanflow"] == 1:
-                logger.info("dots.tts batched MeanFlow CUDA graph replay is active")
+                logger.info(
+                    "dots.tts batched %s CUDA graph replay is active",
+                    self.spec.solver,
+                )
         if direct_kv:
             latent = latent.index_select(0, slot_index)
         for slot in slots:
@@ -795,6 +836,7 @@ class DotsTtsAcousticTail:
         capacity: int,
         fm_hidden_rows: torch.Tensor,
         noise: torch.Tensor,
+        renoise: torch.Tensor | None = None,
         *,
         direct_kv: bool = False,
     ) -> torch.Tensor:
@@ -805,11 +847,12 @@ class DotsTtsAcousticTail:
         window[:, spec.unit_len :] = fm_hidden_rows.unsqueeze(1).to(self.dtype)
         if not direct_kv:
             self._window[slot_index] = window
-        latent = self._run_meanflow(
+        latent = self._run_solver(
             slot_index,
             persistent_index,
             capacity,
             noise,
+            renoise,
             direct_kv=direct_kv,
         )
         window = (
@@ -824,12 +867,13 @@ class DotsTtsAcousticTail:
             self._window[slot_index] = window
         return latent
 
-    def _run_meanflow(
+    def _run_solver(
         self,
         slot_index: torch.Tensor,
         persistent_index: torch.Tensor,
         capacity: int,
         latent: torch.Tensor,
+        renoise: torch.Tensor | None,
         *,
         direct_kv: bool = False,
     ) -> torch.Tensor:
@@ -858,6 +902,17 @@ class DotsTtsAcousticTail:
         layer_index = self._dit_layer_index.reshape(self._dit_layers, 1, 1)
         batch_index = slot_index.reshape(1, rows, 1)
         promote = slice(capacity, capacity + unit)
+        if spec.solver == "scm":
+            from dots_tts.modules.backbone.scm_inference import (
+                _denoise,
+                _to_flow_matching,
+            )
+
+            assert self._taus is not None and renoise is not None
+            latent, _ = _to_flow_matching(
+                latent, self._taus[:1].expand(latent.size(0)), spec.fm_sigma
+            )
+            latent = latent.to(self.dtype)
         with sdpa_kernel(_TAIL_SDPA_BACKENDS):
             for ode_index in range(spec.nfe):
                 if direct_kv:
@@ -906,8 +961,24 @@ class DotsTtsAcousticTail:
                 velocity = self.dit.apply_final_layer(
                     value[:, latent_slice], final_mods
                 )
-                duration = self._times[ode_index + 1] - self._times[ode_index]
-                latent = (latent + duration * velocity).clone()
+                if spec.solver == "scm":
+                    tau = self._taus[ode_index : ode_index + 1].expand(rows)
+                    latent = _denoise(latent, velocity, tau, spec.fm_sigma).to(
+                        self.dtype
+                    )
+                    if ode_index + 1 < spec.nfe:
+                        next_tau = self._taus[ode_index + 1 : ode_index + 2].expand(
+                            rows
+                        )
+                        x_tau = (
+                            torch.cos(next_tau)[:, None, None] * latent
+                            + torch.sin(next_tau)[:, None, None] * renoise
+                        )
+                        latent, _ = _to_flow_matching(x_tau, next_tau, spec.fm_sigma)
+                        latent = latent.to(self.dtype)
+                else:
+                    duration = self._times[ode_index + 1] - self._times[ode_index]
+                    latent = (latent + duration * velocity).clone()
                 self._dit_k[ode_index][layer_index, batch_index, :, token_index] = keys[
                     :, :, :, promote
                 ].permute(0, 1, 3, 2, 4)
@@ -1093,7 +1164,7 @@ class DotsTtsAcousticTail:
         current_stream.wait_stream(self._capture_stream)
         torch.cuda.synchronize(self.device)
         logger.info(
-            "dots.tts acoustic-tail CUDA graphs: meanflow=%d semantic_encoder=%d "
+            "dots.tts acoustic-tail CUDA graphs: solver=%d semantic_encoder=%d "
             "batch_buckets=%s context_patch_buckets=%s",
             len(self._meanflow_graphs),
             len(self._encoder_graphs),
@@ -1132,14 +1203,20 @@ class DotsTtsAcousticTail:
                     dtype=self.dtype,
                 ),
             }
-            run = lambda: self._sample_patches_core(
-                inputs["slots"],
-                inputs["starts"],
-                capacity,
-                inputs["hidden"],
-                inputs["noise"],
-                direct_kv=batch_size == self.spec.num_slots,
-            )
+            if self.spec.solver == "scm":
+                inputs["renoise"] = torch.zeros_like(inputs["noise"])
+
+            def run():
+                return self._sample_patches_core(
+                    inputs["slots"],
+                    inputs["starts"],
+                    capacity,
+                    inputs["hidden"],
+                    inputs["noise"],
+                    inputs.get("renoise"),
+                    direct_kv=batch_size == self.spec.num_slots,
+                )
+
         else:
             inputs = {
                 "slots": slots,
@@ -1152,12 +1229,14 @@ class DotsTtsAcousticTail:
                     dtype=self.dtype,
                 ),
             }
-            run = lambda: self._encode_feedback_core(
-                inputs["slots"],
-                inputs["starts"],
-                capacity,
-                inputs["latent"],
-            )
+
+            def run():
+                return self._encode_feedback_core(
+                    inputs["slots"],
+                    inputs["starts"],
+                    capacity,
+                    inputs["latent"],
+                )
 
         graph = torch.cuda.CUDAGraph()
         try:
@@ -1188,10 +1267,10 @@ class DotsTtsAcousticTail:
         if self._meanflow_graphs and self._encoder_graphs:
             return (
                 "CUDA graph batched tail with eager fallback "
-                f"(meanflow={len(self._meanflow_graphs)}, "
+                f"(solver={len(self._meanflow_graphs)}, "
                 f"semantic_encoder={len(self._encoder_graphs)})"
             )
-        return "fused eager batched tail"
+        return f"fused eager batched {self.spec.solver} tail"
 
 
 __all__ = [

--- a/tests/README.md
+++ b/tests/README.md
@@ -112,6 +112,11 @@ tests/
     ├── qwen3_tts/
     │   ├── test_pipeline.py
     │   └── test_predictor_cuda_graph.py
+    ├── dots_tts/
+    │   ├── test_flow_head.py
+    │   ├── test_model_runner.py
+    │   ├── test_preprocessing.py
+    │   └── test_tail.py
     ├── higgs_tts/
     │   ├── test_async_decode_runner.py
     │   ├── test_batched_step.py

--- a/tests/unit_test/dots_tts/test_flow_head.py
+++ b/tests/unit_test/dots_tts/test_flow_head.py
@@ -16,7 +16,12 @@ PATCH_SIZE = 2
 NFE = 2
 
 
-def _flow_head(tmp_path) -> DotsTTSFlowHead:
+def _flow_head(
+    tmp_path,
+    *,
+    meanflow: bool = True,
+    sampling: dict | None = None,
+) -> DotsTTSFlowHead:
     torch.save(
         {"mean": torch.zeros(LATENT_DIM), "var": torch.ones(LATENT_DIM)},
         tmp_path / "latent_stats.pt",
@@ -41,8 +46,12 @@ def _flow_head(tmp_path) -> DotsTTSFlowHead:
             "rotary_bias": True,
         },
         "vocoder": {"sample_rate": 48000},
-        "meanflow": {"enabled": True, "use_duration_embedding": True},
+        "meanflow": (
+            {"enabled": True, "use_duration_embedding": True} if meanflow else None
+        ),
     }
+    if sampling is not None:
+        config["sampling"] = sampling
     flow = DotsTTSFlowHead(
         config,
         llm_hidden_size=LLM_HIDDEN,
@@ -334,6 +343,7 @@ def test_flow_rematerialization_matches_uninterrupted_next_step(
 def test_validate_request_batched_gates_prompt_and_span_budget() -> None:
     flow = SimpleNamespace(
         is_batched=True,
+        config=SimpleNamespace(sampling=None),
         _batched_nfe=4,
         _tail=SimpleNamespace(spec=SimpleNamespace(patch_capacity=9)),
     )
@@ -360,7 +370,7 @@ def test_validate_request_batched_gates_prompt_and_span_budget() -> None:
             total_span_count=10,
         )
 
-    single = SimpleNamespace(is_batched=False)
+    single = SimpleNamespace(is_batched=False, config=SimpleNamespace(sampling=None))
     validate(
         single,
         num_steps=8,
@@ -436,6 +446,30 @@ def test_flow_matching_checkpoint_runs_the_single_request_solver(tmp_path) -> No
     assert step.latent_patch.shape == (1, PATCH_SIZE, LATENT_DIM)
     assert torch.isfinite(step.latent_patch).all()
     assert torch.isfinite(step.feedback_embedding).all()
+
+
+def test_scm_checkpoint_uses_artifact_solver_contract(tmp_path) -> None:
+    from dots_tts.modules.backbone.scm_inference import SCMDiTSolver
+
+    sampling = {
+        "solver": "scm",
+        "ode_method": "euler",
+        "num_steps": 2,
+        "guidance_scale": 0.0,
+        "tau_mid": 1.3,
+    }
+    flow = _flow_head(tmp_path, meanflow=False, sampling=sampling)
+
+    assert flow.mode == "scm"
+    assert isinstance(flow._solver(), SCMDiTSolver)
+    flow.validate_request(num_steps=2, ode_method="euler", guidance_scale=0.0)
+    with pytest.raises(ValueError, match="scm artifact requires"):
+        flow.validate_request(num_steps=1, ode_method="euler", guidance_scale=0.0)
+
+    batched_flow = _flow_head(tmp_path, meanflow=False, sampling=sampling)
+    batched_flow.init_batched_tail(num_slots=2, nfe=2, max_audio_patches=8)
+    assert batched_flow.is_batched
+    assert batched_flow._tail.spec.solver == "scm"
 
 
 def test_batched_eos_resolve_reads_staged_flags(tmp_path) -> None:

--- a/tests/unit_test/dots_tts/test_flow_head.py
+++ b/tests/unit_test/dots_tts/test_flow_head.py
@@ -2,18 +2,98 @@
 
 from __future__ import annotations
 
+from collections import deque
 from types import SimpleNamespace
 
 import pytest
 import torch
 
 from sglang_omni.models.dots_tts.flow_head import DotsTTSFlowHead
+from sglang_omni.models.dots_tts.model_runner import DotsTTSModelRunner
 
 LLM_HIDDEN = 48
 FM_HIDDEN = 32
 LATENT_DIM = 6
 PATCH_SIZE = 2
 NFE = 2
+
+
+def test_stts_decode_batches_only_audio_phase_rows() -> None:
+    feedback = torch.randn(LLM_HIDDEN)
+    step = SimpleNamespace(
+        feedback_embedding=feedback,
+        latent_patch=torch.randn(1, PATCH_SIZE, LATENT_DIM),
+        emit=True,
+        finished=False,
+    )
+
+    class _Flow:
+        is_batched = True
+
+        def decode_batch(self, states, *, hidden_states, **_kwargs):
+            assert states == ["audio-state"]
+            assert hidden_states.shape == (1, LLM_HIDDEN)
+            return [step]
+
+    def _request(schedule, cursor, flow_state):
+        state = SimpleNamespace(
+            interleaved=True,
+            audio_span_token_ids=[7],
+            num_steps=2,
+            ode_method="euler",
+            guidance_scale=0.0,
+            eos_threshold=0.8,
+        )
+        data = SimpleNamespace(
+            state=state,
+            generation_schedule=torch.tensor([schedule]),
+            interleave_cursor=cursor,
+            text_cond_end_id=9,
+            text_finished=False,
+            control_token_id=7,
+            flow_state=flow_state,
+            pending_feedback_queue=deque(),
+            decoded_latent_patches=[],
+            latent_patches=[],
+            latest_latent_patch=None,
+        )
+        return SimpleNamespace(data=data)
+
+    audio = _request([1, 7], 1, "audio-state")
+    text = _request([1, 9, 7], 1, "text-state")
+    runner = DotsTTSModelRunner.__new__(DotsTTSModelRunner)
+    runner.model = SimpleNamespace(flow=_Flow())
+    result = SimpleNamespace(next_token_ids=None)
+
+    launch = runner._advance_interleaved_batch(
+        result, [audio, text], torch.randn(2, LLM_HIDDEN)
+    )
+
+    assert launch.data_rows == [audio.data]
+    assert result.next_token_ids.tolist() == [7, 9]
+    assert torch.equal(audio.data.pending_feedback_queue.popleft(), feedback)
+    assert text.data.pending_feedback_queue.popleft() == 9
+    assert text.data.text_finished
+
+
+def test_stts_replay_finds_audio_conditioning_positions() -> None:
+    positions = DotsTTSFlowHead._generated_audio_positions(
+        torch.tensor([[3, 7, 4, 5, 7, 6]]),
+        prefill_end=1,
+        generated_count=4,
+        audio_span_token_ids={7},
+        expected=2,
+    )
+
+    assert positions.tolist() == [1, 4]
+    with pytest.raises(RuntimeError, match="do not match decoded patches"):
+        DotsTTSFlowHead._generated_audio_positions(
+            torch.tensor([[3, 7, 4]]),
+            prefill_end=1,
+            generated_count=2,
+            audio_span_token_ids={7},
+            expected=2,
+        )
 
 
 def _flow_head(
@@ -451,25 +531,109 @@ def test_flow_matching_checkpoint_runs_the_single_request_solver(tmp_path) -> No
 def test_scm_checkpoint_uses_artifact_solver_contract(tmp_path) -> None:
     from dots_tts.modules.backbone.scm_inference import SCMDiTSolver
 
-    sampling = {
-        "solver": "scm",
-        "ode_method": "euler",
-        "num_steps": 2,
-        "guidance_scale": 0.0,
-        "tau_mid": 1.3,
-    }
-    flow = _flow_head(tmp_path, meanflow=False, sampling=sampling)
+    flow = _flow_head(
+        tmp_path,
+        meanflow=False,
+        sampling={
+            "solver": "scm",
+            "ode_method": "euler",
+            "num_steps": 2,
+            "guidance_scale": 0.0,
+            "tau_mid": 1.3,
+        },
+    )
 
     assert flow.mode == "scm"
     assert isinstance(flow._solver(), SCMDiTSolver)
     flow.validate_request(num_steps=2, ode_method="euler", guidance_scale=0.0)
     with pytest.raises(ValueError, match="scm artifact requires"):
         flow.validate_request(num_steps=1, ode_method="euler", guidance_scale=0.0)
-
-    batched_flow = _flow_head(tmp_path, meanflow=False, sampling=sampling)
+    state, _ = flow.new_request(
+        max_audio_patch_count=8,
+        prompt_latents=None,
+        speaker_embedding=torch.randn(1, 512),
+        speaker_scale=1.5,
+        rng=42,
+    )
+    flow.append_hidden(state, torch.randn(1, 1, LLM_HIDDEN))
+    step = flow.decode_next(
+        state,
+        hidden_states=torch.randn(1, 1, LLM_HIDDEN),
+        num_steps=2,
+        ode_method="euler",
+        guidance_scale=0.0,
+        eos_threshold=0.8,
+    )
+    assert step.latent_patch.shape == (1, PATCH_SIZE, LATENT_DIM)
+    assert torch.isfinite(step.latent_patch).all()
+    batched_flow = _flow_head(
+        tmp_path,
+        meanflow=False,
+        sampling={
+            "solver": "scm",
+            "ode_method": "euler",
+            "num_steps": 2,
+            "guidance_scale": 0.0,
+            "tau_mid": 1.3,
+        },
+    )
     batched_flow.init_batched_tail(num_slots=2, nfe=2, max_audio_patches=8)
     assert batched_flow.is_batched
     assert batched_flow._tail.spec.solver == "scm"
+
+
+@pytest.mark.gpu
+def test_batched_scm_runs_on_cuda(tmp_path) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    flow = _flow_head(
+        tmp_path,
+        meanflow=False,
+        sampling={
+            "solver": "scm",
+            "ode_method": "euler",
+            "num_steps": 2,
+            "guidance_scale": 0.0,
+            "tau_mid": 1.3,
+        },
+    ).to(device="cuda", dtype=torch.bfloat16)
+    flow.init_batched_tail(num_slots=2, nfe=2, max_audio_patches=8, optimize=True)
+    prompt_latents = torch.randn(
+        1, 2 * PATCH_SIZE, LATENT_DIM, device="cuda", dtype=torch.bfloat16
+    )
+    states = []
+    for seed in (11, 12):
+        state, _ = flow.new_request(
+            max_audio_patch_count=8,
+            prompt_latents=prompt_latents,
+            speaker_embedding=None,
+            speaker_scale=1.0,
+            rng=seed,
+        )
+        flow.initialize_history(
+            state,
+            hidden_states=torch.randn(
+                1, 3, LLM_HIDDEN, device="cuda", dtype=torch.bfloat16
+            ),
+            prompt_span_positions=torch.tensor([1, 2], device="cuda"),
+            audio_span_token_ids={1},
+            generation_schedule=torch.tensor([[0, 1, 1, 1]], device="cuda"),
+            prefill_end=3,
+            decoded_latent_patches=[],
+        )
+        states.append(state)
+    steps = flow.decode_batch(
+        states,
+        hidden_states=torch.randn(2, LLM_HIDDEN, device="cuda", dtype=torch.bfloat16),
+        num_steps=[2, 2],
+        ode_methods=["euler", "euler"],
+        guidance_scales=[0.0, 0.0],
+        eos_thresholds=[2.0, 2.0],
+        append_hidden=False,
+    )
+
+    assert flow.resolve_batched_eos() == [False, False]
+    assert all(torch.isfinite(step.latent_patch).all() for step in steps)
 
 
 def test_batched_eos_resolve_reads_staged_flags(tmp_path) -> None:

--- a/tests/unit_test/dots_tts/test_model_runner.py
+++ b/tests/unit_test/dots_tts/test_model_runner.py
@@ -109,6 +109,7 @@ def test_dots_prefill_batches_request_embeddings_in_scheduler_order() -> None:
                 is_retracted=retracted,
             ),
             state=SimpleNamespace(
+                interleaved=False,
                 prompt_latents=torch.zeros(1, 4, 2),
                 speaker_embedding=torch.zeros(1, 8),
                 speaker_scale=speaker_scale,
@@ -132,6 +133,58 @@ def test_dots_prefill_batches_request_embeddings_in_scheduler_order() -> None:
     assert suspended == [old_flow_state]
     torch.testing.assert_close(restored_rng[0], torch.tensor([7], dtype=torch.uint8))
     assert restored_rng[1] == 42
+
+
+def test_dots_stts_reprefill_replays_text_tokens_and_audio_feedback() -> None:
+    class _Flow:
+        def suspend_request(self, _state):
+            return torch.tensor([7], dtype=torch.uint8)
+
+        def new_request(self, **_kwargs):
+            return object(), torch.zeros(1, 1, 4)
+
+        def replay_feedback(self, _state, _patches):
+            return torch.full((1, 4), 33.0)
+
+    embedding = nn.Embedding.from_pretrained(
+        torch.arange(48, dtype=torch.float32).reshape(12, 4)
+    )
+    runner = object.__new__(DotsTTSModelRunner)
+    runner.model = SimpleNamespace(flow=_Flow(), get_input_embeddings=lambda: embedding)
+    data = SimpleNamespace(
+        flow_state=object(),
+        generation_schedule=torch.tensor([[1, 2, 3, 4, 9]]),
+        span_positions=torch.tensor([1]),
+        prompt_span_positions=torch.tensor([1]),
+        prefill_end=3,
+        pending_feedback_queue=deque(),
+        decoded_latent_patches=[torch.zeros(1, 2, 2)],
+        req=SimpleNamespace(
+            prefix_indices=[],
+            extend_range=SimpleNamespace(length=5),
+            output_ids=[4, 9],
+            is_retracted=True,
+        ),
+        state=SimpleNamespace(
+            interleaved=True,
+            audio_span_token_ids=[9],
+            prompt_latents=torch.zeros(1, 4, 2),
+            speaker_embedding=None,
+            speaker_scale=1.0,
+            seed=42,
+        ),
+    )
+    request = SimpleNamespace(request_id="stts", data=data)
+    runner._request_data = {"stts": data}
+    forward_batch = SimpleNamespace(
+        input_ids=torch.tensor([1, 2, 3, 4, 9]), input_embeds=None
+    )
+
+    runner.before_prefill(forward_batch, object(), [request])
+
+    assert forward_batch.input_embeds.shape == (5, 4)
+    torch.testing.assert_close(forward_batch.input_embeds[3], embedding.weight[4])
+    torch.testing.assert_close(forward_batch.input_embeds[4], torch.full((4,), 33.0))
 
 
 def test_dots_prefill_failure_releases_materialized_slots() -> None:

--- a/tests/unit_test/dots_tts/test_preprocessing.py
+++ b/tests/unit_test/dots_tts/test_preprocessing.py
@@ -76,6 +76,7 @@ def _preprocess(payload: StagePayload, tokenizer: _RecordingTokenizer) -> DotsTT
         model_config=SimpleNamespace(
             patch_size=4,
             vocoder=SimpleNamespace(sample_rate=48000),
+            sampling=None,
         ),
         max_generate_length=20,
         max_sequence_length=128,
@@ -111,3 +112,27 @@ def test_preprocessing_rejects_unconsumed_extra_references() -> None:
 
     with pytest.raises(ValueError, match="at most one reference"):
         _preprocess(payload, _RecordingTokenizer())
+
+
+def test_preprocessing_uses_artifact_sampling_contract() -> None:
+    from dots_tts.models.dots_tts.config import SamplingConfig
+
+    tokenizer = _RecordingTokenizer()
+    result = preprocess_dots_tts_payload(
+        _payload(),
+        tokenizer=tokenizer,
+        model_config=SimpleNamespace(
+            patch_size=4,
+            vocoder=SimpleNamespace(sample_rate=48000),
+            sampling=SamplingConfig(solver="scm"),
+        ),
+        max_generate_length=20,
+        max_sequence_length=128,
+    )
+    state = DotsTTSState.from_dict(result.data)
+
+    assert (state.ode_method, state.num_steps, state.guidance_scale) == (
+        "euler",
+        2,
+        0.0,
+    )

--- a/tests/unit_test/dots_tts/test_preprocessing.py
+++ b/tests/unit_test/dots_tts/test_preprocessing.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+import torch
 
-from sglang_omni.models.dots_tts.payload_types import DotsTTSState
+from sglang_omni.models.dots_tts.payload_types import (
+    DotsTTSState,
+    materialize_streaming_schedule,
+)
 from sglang_omni.models.dots_tts.stages import preprocess_dots_tts_payload
 from sglang_omni.proto import OmniRequest, StagePayload
 
@@ -17,8 +21,10 @@ class _RecordingTokenizer:
     def __init__(self) -> None:
         from dots_tts.utils.tokenizer import (
             AUDIO_COMP_SPAN_TOKEN,
+            AUDIO_GEN_END_TOKEN,
             AUDIO_GEN_SPAN_TOKEN,
             AUDIO_GEN_START_TOKEN,
+            TEXT_COND_END_TOKEN,
         )
 
         self.encoded_text: list[str] = []
@@ -26,6 +32,8 @@ class _RecordingTokenizer:
             AUDIO_GEN_START_TOKEN: 101,
             AUDIO_GEN_SPAN_TOKEN: 102,
             AUDIO_COMP_SPAN_TOKEN: 103,
+            AUDIO_GEN_END_TOKEN: 104,
+            TEXT_COND_END_TOKEN: 105,
         }
 
     def encode(self, text: str, *, add_special_tokens: bool) -> list[int]:
@@ -69,14 +77,21 @@ def _payload(
     )
 
 
-def _preprocess(payload: StagePayload, tokenizer: _RecordingTokenizer) -> DotsTTSState:
+def _preprocess(
+    payload: StagePayload,
+    tokenizer: _RecordingTokenizer,
+    *,
+    sampling=None,
+    streaming=None,
+) -> DotsTTSState:
     result = preprocess_dots_tts_payload(
         payload,
         tokenizer=tokenizer,
         model_config=SimpleNamespace(
             patch_size=4,
             vocoder=SimpleNamespace(sample_rate=48000),
-            sampling=None,
+            sampling=sampling,
+            streaming=streaming,
         ),
         max_generate_length=20,
         max_sequence_length=128,
@@ -117,22 +132,45 @@ def test_preprocessing_rejects_unconsumed_extra_references() -> None:
 def test_preprocessing_uses_artifact_sampling_contract() -> None:
     from dots_tts.models.dots_tts.config import SamplingConfig
 
-    tokenizer = _RecordingTokenizer()
-    result = preprocess_dots_tts_payload(
-        _payload(),
-        tokenizer=tokenizer,
-        model_config=SimpleNamespace(
-            patch_size=4,
-            vocoder=SimpleNamespace(sample_rate=48000),
-            sampling=SamplingConfig(solver="scm"),
-        ),
-        max_generate_length=20,
-        max_sequence_length=128,
-    )
-    state = DotsTTSState.from_dict(result.data)
+    sampling = SamplingConfig(solver="scm")
+    state = _preprocess(_payload(), _RecordingTokenizer(), sampling=sampling)
 
     assert (state.ode_method, state.num_steps, state.guidance_scale) == (
         "euler",
         2,
         0.0,
     )
+
+    with pytest.raises(ValueError, match="scm artifact requires"):
+        _preprocess(
+            _payload(params={"stage_params": {"latent_engine": {"num_steps": 1}}}),
+            _RecordingTokenizer(),
+            sampling=sampling,
+        )
+
+
+def test_stts_schedule_uses_artifact_cadence_after_reference_encode() -> None:
+    from dots_tts.models.dots_tts.config import SamplingConfig, StreamingConfig
+
+    tokenizer = _RecordingTokenizer()
+    state = _preprocess(
+        _payload(),
+        tokenizer,
+        sampling=SamplingConfig(solver="scm"),
+        streaming=StreamingConfig(
+            interleave_mode="buffered_ratio",
+            initial_lookahead=3,
+            ta_per_tta=1,
+            warmup_ta=0,
+        ),
+    )
+
+    assert state.interleaved
+    assert state.generation_schedule.numel() == 0
+    state.prompt_latents = torch.zeros(1, 8, 6)
+    materialize_streaming_schedule(state)
+
+    schedule = state.generation_schedule[0].tolist()
+    audio_id = state.streaming_schedule["audio_span_id"]
+    assert schedule.count(audio_id) == 20
+    assert state.streaming_schedule["interleave_mode"] == "buffered_ratio"

--- a/tests/unit_test/dots_tts/test_tail.py
+++ b/tests/unit_test/dots_tts/test_tail.py
@@ -46,7 +46,7 @@ def test_batched_tail_mask_hides_padding_and_preserves_causality() -> None:
 
 
 class _TailModel(torch.nn.Module):
-    def __init__(self) -> None:
+    def __init__(self, *, mode: str = "meanflow") -> None:
         super().__init__()
         self.velocity_field_predictor = DiT(
             in_dim=FM_HIDDEN,
@@ -60,7 +60,7 @@ class _TailModel(torch.nn.Module):
                 qk_norm=True,
                 rotary_bias=True,
             ),
-            mode="meanflow",
+            mode=mode,
         )
         self.coordinate_proj = torch.nn.Linear(LATENT_DIM, FM_HIDDEN)
         self.latent_proj = torch.nn.Linear(LATENT_DIM, FM_HIDDEN)
@@ -93,6 +93,7 @@ def _build_tail(
     dtype: torch.dtype = torch.float32,
     patch_capacity: int = 8,
     optimize: bool = False,
+    solver: str = "meanflow",
 ):
     encoder = _patch_encoder().to(device=device, dtype=dtype)
     with torch.no_grad():
@@ -111,6 +112,7 @@ def _build_tail(
             latent_patch_size=PATCH_SIZE,
             latent_dim=LATENT_DIM,
             fm_hidden_size=FM_HIDDEN,
+            solver=solver,
         ),
         device=device,
         dtype=dtype,
@@ -156,6 +158,50 @@ def _reference_meanflow(
     return latent
 
 
+def _reference_scm(
+    dit: torch.nn.Module,
+    coordinate_proj: torch.nn.Module,
+    sequence: torch.Tensor,
+    fm_seq_len: int,
+    g_cond: torch.Tensor,
+    initial_noise: torch.Tensor,
+    renoise: torch.Tensor,
+) -> torch.Tensor:
+    from dots_tts.modules.backbone.scm_inference import _denoise, _to_flow_matching
+
+    total = fm_seq_len + PATCH_SIZE
+    x_base = sequence.new_zeros(1, total, FM_HIDDEN)
+    x_base[:, :fm_seq_len] = sequence[:, :fm_seq_len]
+    mask = torch.zeros((1, total, total), dtype=torch.bool)
+    block_start = fm_seq_len - 1
+    mask[:, :block_start, :block_start] = torch.ones(
+        block_start, block_start, dtype=torch.bool
+    ).tril()
+    mask[:, block_start:fm_seq_len, :fm_seq_len] = True
+    mask[:, block_start:fm_seq_len, fm_seq_len:] = True
+    mask[:, fm_seq_len:, :] = True
+    positions = torch.arange(total, dtype=torch.float32).reshape(1, total)
+    taus = torch.tensor([torch.pi / 2, 1.3])
+    x_tau = initial_noise
+    for step, tau in enumerate(taus):
+        tau = tau.reshape(1)
+        latent, flow_time = _to_flow_matching(x_tau, tau, 0.0)
+        value = x_base.clone()
+        value[:, fm_seq_len:] = coordinate_proj(latent)
+        velocity = dit(
+            x=value,
+            timesteps=flow_time,
+            attn_mask=mask,
+            pos_ids=positions,
+            g_cond=g_cond,
+        )[:, fm_seq_len:]
+        denoised = _denoise(latent, velocity, tau, 0.0)
+        if step == 1:
+            return denoised
+        x_tau = torch.cos(taus[1]) * denoised + torch.sin(taus[1]) * renoise
+    raise AssertionError("unreachable")
+
+
 @pytest.mark.parametrize("slots", [1, 2])
 def test_kv_cached_tail_matches_full_recompute(slots: int) -> None:
     torch.manual_seed(1234)
@@ -190,6 +236,40 @@ def test_kv_cached_tail_matches_full_recompute(slots: int) -> None:
 
     torch.testing.assert_close(actual, expected, rtol=2e-4, atol=2e-4)
     assert acoustic_tail._dit_contiguous_view_steps == (NFE if slots == 1 else 0)
+
+
+def test_kv_cached_scm_tail_matches_full_recompute() -> None:
+    torch.manual_seed(1234)
+    model = _TailModel(mode="flow_matching").eval()
+    acoustic_tail = _build_tail(model, slots=1, solver="scm")
+    unit = acoustic_tail.spec.unit_len
+    g_cond = torch.randn(1, FM_HIDDEN)
+    prompt_rows = torch.randn(3 * unit, FM_HIDDEN)
+    slot = acoustic_tail.acquire_slot()
+    acoustic_tail.seed_fm_history(
+        slot, fm_rows=prompt_rows, all_mods=acoustic_tail.build_mods(g_cond)
+    )
+    sequence = torch.zeros(1, acoustic_tail.spec.dit_cache_tokens + unit, FM_HIDDEN)
+    sequence[0, : prompt_rows.size(0)] = prompt_rows
+    hidden = torch.randn(1, FM_HIDDEN)
+    sequence[0, prompt_rows.size(0)] = hidden[0]
+
+    generator = torch.Generator().manual_seed(9)
+    initial_noise = torch.randn(1, PATCH_SIZE, LATENT_DIM, generator=generator)
+    renoise = torch.randn(1, PATCH_SIZE, LATENT_DIM, generator=generator)
+    expected = _reference_scm(
+        acoustic_tail.dit,
+        model.coordinate_proj,
+        sequence,
+        prompt_rows.size(0) + 1,
+        g_cond,
+        initial_noise,
+        renoise,
+    )
+    acoustic_tail.initialize_slot_rng(slot, 9)
+    actual = acoustic_tail.sample_patches([slot], fm_hidden_rows=hidden)
+
+    torch.testing.assert_close(actual, expected, rtol=2e-4, atol=2e-4)
 
 
 def test_tail_slots_are_bounded_and_reusable() -> None:


### PR DESCRIPTION
## Dependency

Depends on #1488. Review and merge that PR first; this branch will be rebased onto `main` afterward so the final diff contains only STTS changes.

## Summary

- load the checkpoint-declared STTS cadence and construct paired prompt/target interleave schedules
- accept regular text or already-collected `text_token_ids` / `input_ids`
- keep text-phase and audio-phase requests in the same backbone continuous batch
- run the batched sCM acoustic tail only for rows whose next position is audio
- preserve interleaved text/audio history across scheduler retraction and re-prefill
- provide a deployment config for `dots-studio/dots.tts-mf-2steps-stts`

## Why

The STTS checkpoint added by [dots.tts PR #40](https://github.com/studio-dots-ai/dots.tts/pull/40) changes the runtime from an audio-only recurrent loop to an artifact-defined text/audio interleave. Treating every backbone step as an audio step either produces the wrong history or serializes requests with different phases, which defeats continuous batching.

## Impact

STTS requests can share the existing SGLang backbone batch even when their text/audio phases differ. Text rows feed token embeddings back to the backbone; audio rows use the pooled sCM tail and return latent feedback. Reference encoding and vocoder stages retain their existing batching paths.

This PR supports normal HTTP text input and low-level token arrays that have already been collected. Live per-token WebSocket append is intentionally not included; it should use a generic incremental ingress rather than a dots.tts-specific transport.

## Validation

- H200: `python -m pytest -q tests/unit_test/dots_tts` — 106 passed
- H200 real checkpoint: four concurrent `dots.tts-mf-2steps-stts` speech requests — all HTTP 200 in one backbone prefill batch
- H200 real checkpoint: two concurrent `dots.tts-mf-2steps` regression requests — all HTTP 200
- `ruff check sglang_omni/models/dots_tts tests/unit_test/dots_tts`
- `git diff --check`
