### PR TITLE
[Feat] Wire Ming-Omni talker max_conc through config, scheduler, and CLI

### DIFF
--- a/examples/launchers/ming_omni.py
+++ b/examples/launchers/ming_omni.py
@@ -275,6 +275,16 @@ def _build_ming_speech_server_parser() -> argparse.ArgumentParser:
             "non-streaming 7-stage speech path."
         ),
     )
+    target.add_argument(
+        "--talker-max-conc",
+        type=int,
+        default=None,
+        help=(
+            "Override Ming talker concurrency for the non-streaming speech path "
+            "(CFM CUDA-graph pool + stage scheduler). Default comes from "
+            "talker/config.json (usually 1)."
+        ),
+    )
     add_server_args(target, model_name="ming-omni")
     return target
 
@@ -309,6 +319,22 @@ def launch_ming_speech_server(args: argparse.Namespace) -> None:
     set_stage_gpu(config, "thinker", thinker_gpus)
     set_stage_gpu(config, talker_stage, int(args.gpu_talker))
     validate_gpus()
+
+    if args.talker_max_conc is not None:
+        if args.enable_streaming_tts:
+            raise ValueError(
+                "--talker-max-conc currently supports only the non-streaming "
+                "Ming talker path"
+            )
+        if args.talker_max_conc < 1:
+            raise ValueError(
+                f"--talker-max-conc must be >= 1, got {args.talker_max_conc}"
+            )
+        apply_stage_factory_updates(
+            config,
+            stage_name="talker",
+            updates={"max_conc": int(args.talker_max_conc)},
+        )
 
     server_updates: dict[str, object] = {}
     if tp_size > 1:

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -63,9 +63,7 @@ _PREFILL_COALESCE_SUPPORTED_MODELS = (
 _QWEN_PARTIAL_START_TALKER_FACTORY = (
     "sglang_omni.models.qwen3_omni.stages.create_talker_ar_executor_from_config"
 )
-_MING_TALKER_FACTORY = (
-    "sglang_omni.models.ming_omni.stages.create_talker_executor"
-)
+_MING_TALKER_FACTORY = "sglang_omni.models.ming_omni.stages.create_talker_executor"
 
 
 def launch_server(*args: object, **kwargs: object) -> object:

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -63,6 +63,9 @@ _PREFILL_COALESCE_SUPPORTED_MODELS = (
 _QWEN_PARTIAL_START_TALKER_FACTORY = (
     "sglang_omni.models.qwen3_omni.stages.create_talker_ar_executor_from_config"
 )
+_MING_TALKER_FACTORY = (
+    "sglang_omni.models.ming_omni.stages.create_talker_executor"
+)
 
 
 def launch_server(*args: object, **kwargs: object) -> object:
@@ -826,6 +829,40 @@ def apply_partial_start_cli_overrides(
     return pipeline_config
 
 
+def apply_talker_max_conc_cli_override(
+    pipeline_config: PipelineConfig,
+    *,
+    talker_max_conc: int | None,
+) -> PipelineConfig:
+    if talker_max_conc is None:
+        return pipeline_config
+    if talker_max_conc < 1:
+        raise typer.BadParameter("--talker-max-conc must be >= 1")
+
+    stage_name = _resolve_talker_stage(
+        pipeline_config,
+        flag_name="--talker-max-conc",
+    )
+    matching_stages = _find_matching_stages(
+        pipeline_config,
+        stage_name=stage_name,
+        reason="talker max_conc override",
+    )
+    for stage in matching_stages:
+        if stage.factory != _MING_TALKER_FACTORY:
+            raise typer.BadParameter(
+                "--talker-max-conc currently supports only the Ming-Omni "
+                f"non-streaming talker; stage {stage.name!r} uses factory "
+                f"{stage.factory!r}"
+            )
+    _apply_factory_args_updates(
+        pipeline_config,
+        matching_stages,
+        {"max_conc": int(talker_max_conc)},
+    )
+    return pipeline_config
+
+
 def _apply_factory_args_updates(
     pipeline_config: PipelineConfig,
     stages: list[StageConfig],
@@ -1172,6 +1209,18 @@ def serve(
             help="Override GPU id for supported talker stage.",
         ),
     ] = None,
+    talker_max_conc: Annotated[
+        int | None,
+        typer.Option(
+            "--talker-max-conc",
+            "--talker_max_conc",
+            help=(
+                "Override Ming-Omni talker concurrency (CFM CUDA-graph pool and "
+                "stage scheduler). Default comes from talker/config.json "
+                "(usually 1)."
+            ),
+        ),
+    ] = None,
     code2wav_gpu: Annotated[
         int | None,
         typer.Option(
@@ -1467,6 +1516,10 @@ def serve(
     merged_config = apply_partial_start_cli_overrides(
         merged_config,
         talker_partial_start=talker_partial_start,
+    )
+    merged_config = apply_talker_max_conc_cli_override(
+        merged_config,
+        talker_max_conc=talker_max_conc,
     )
 
     if _should_print_merged_config(colocate=colocate, log_level=log_level):

--- a/sglang_omni/models/ming_omni/components/talker_executor.py
+++ b/sglang_omni/models/ming_omni/components/talker_executor.py
@@ -45,11 +45,13 @@ class MingTalkerExecutor:
         talker_model_path: str | None = None,
         device: str = "cuda",
         voice: str = DEFAULT_VOICE,
+        max_conc: int | None = None,
     ):
         self._model_path = model_path
         self._talker_model_path = talker_model_path or str(Path(model_path) / "talker")
         self._device = device
         self._voice = voice
+        self._max_conc_override = max_conc
         self._results: asyncio.Queue[StagePayload] = asyncio.Queue()
         self._aborted: set[str] = set()
 
@@ -71,6 +73,7 @@ class MingTalkerExecutor:
             MingOmniTalker,
             MingOmniTalkerConfig,
             SpkembExtractor,
+            normalize_max_conc,
         )
         from sglang_omni.models.ming_omni.talker.audio_vae.modeling_audio_vae import (
             AudioVAE,
@@ -86,6 +89,8 @@ class MingTalkerExecutor:
         # 1. Load config from checkpoint
         t0 = time.time()
         config = MingOmniTalkerConfig.from_pretrained_dir(self._talker_model_path)
+        if self._max_conc_override is not None:
+            config.max_conc = normalize_max_conc(self._max_conc_override)
 
         # 2. Create model (no weights yet)
         self._talker = MingOmniTalker(config)

--- a/sglang_omni/models/ming_omni/pipeline/stages.py
+++ b/sglang_omni/models/ming_omni/pipeline/stages.py
@@ -342,6 +342,7 @@ def create_talker_executor(
     talker_model_path: str | None = None,
     device: str = "cuda",
     voice: str = "DB30",
+    max_conc: int | None = None,
 ) -> MingTalkerExecutor:
     """Create the Ming TTS talker executor.
 
@@ -356,6 +357,7 @@ def create_talker_executor(
         talker_model_path=talker_model_path,
         device=device,
         voice=voice,
+        max_conc=max_conc,
     )
 
 

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -326,19 +326,31 @@ def create_talker_executor(
     talker_model_path: str | None = None,
     device: str = "cuda",
     voice: str = "DB30",
+    max_conc: int | None = None,
 ):
+    from pathlib import Path
+
     from sglang_omni.models.ming_omni.components.talker_executor import (
         MingTalkerExecutor,
+    )
+    from sglang_omni.models.ming_omni.talker.configuration_bailing_talker import (
+        resolve_talker_max_conc,
     )
     from sglang_omni.models.weight_loader import resolve_model_path
     from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
     local_path = resolve_model_path(model_path)
+    resolved_talker_path = talker_model_path or str(Path(local_path) / "talker")
+    effective_max_conc = resolve_talker_max_conc(
+        resolved_talker_path,
+        max_conc=max_conc,
+    )
     executor = MingTalkerExecutor(
         model_path=local_path,
-        talker_model_path=talker_model_path,
+        talker_model_path=resolved_talker_path,
         device=device,
         voice=voice,
+        max_conc=effective_max_conc,
     )
     started = False
 
@@ -352,7 +364,7 @@ def create_talker_executor(
         await executor.add_request(payload)
         return await executor.get_result()
 
-    return SimpleScheduler(_talk)
+    return SimpleScheduler(_talk, max_concurrency=effective_max_conc)
 
 
 def create_streaming_talker_executor(

--- a/sglang_omni/models/ming_omni/talker/__init__.py
+++ b/sglang_omni/models/ming_omni/talker/__init__.py
@@ -2,7 +2,11 @@
 """Vendored Ming TTS talker components."""
 
 from .audio_vae.modeling_audio_vae import AudioVAE
-from .configuration_bailing_talker import MingOmniTalkerConfig
+from .configuration_bailing_talker import (
+    MingOmniTalkerConfig,
+    normalize_max_conc,
+    resolve_talker_max_conc,
+)
 from .modeling_ming_omni_talker import MingOmniTalker, SpkembExtractor
 
 __all__ = [
@@ -10,4 +14,6 @@ __all__ = [
     "MingOmniTalkerConfig",
     "SpkembExtractor",
     "AudioVAE",
+    "normalize_max_conc",
+    "resolve_talker_max_conc",
 ]

--- a/sglang_omni/models/ming_omni/talker/configuration_bailing_talker.py
+++ b/sglang_omni/models/ming_omni/talker/configuration_bailing_talker.py
@@ -40,7 +40,7 @@ class MingOmniTalkerConfig:
         self.history_patch_size = history_patch_size
         self.latent_dim = latent_dim
         self.spk_dim = spk_dim
-        self.max_conc = max_conc
+        self.max_conc = normalize_max_conc(max_conc)
 
     @classmethod
     def from_pretrained_dir(cls, model_dir: str) -> MingOmniTalkerConfig:
@@ -74,4 +74,32 @@ class MingOmniTalkerConfig:
             history_patch_size=raw.get("history_patch_size", 32),
             latent_dim=raw.get("latent_dim", 64),
             spk_dim=raw.get("spk_dim", 192),
+            max_conc=raw.get("max_conc", 1),
         )
+
+
+def normalize_max_conc(value: int | None, *, default: int = 1) -> int:
+    """Normalize talker concurrency to an int >= 1."""
+    if value is None:
+        return default
+    conc = int(value)
+    if conc < 1:
+        raise ValueError(f"max_conc must be >= 1, got {conc}")
+    return conc
+
+
+def resolve_talker_max_conc(
+    talker_model_path: str,
+    max_conc: int | None = None,
+) -> int:
+    """Resolve effective talker max_conc.
+
+    Explicit overrides win. Otherwise read from the talker checkpoint config,
+    falling back to 1 when the config file is missing.
+    """
+    if max_conc is not None:
+        return normalize_max_conc(max_conc)
+    try:
+        return MingOmniTalkerConfig.from_pretrained_dir(talker_model_path).max_conc
+    except FileNotFoundError:
+        return 1

--- a/tests/unit_test/ming_omni/test_omni_serve.py
+++ b/tests/unit_test/ming_omni/test_omni_serve.py
@@ -13,6 +13,7 @@ from sglang_omni.cli.serve import (
     apply_mem_fraction_cli_overrides,
     apply_parallelism_cli_overrides,
     apply_partial_start_cli_overrides,
+    apply_talker_max_conc_cli_override,
     apply_thinker_server_args_cli_overrides,
     apply_torch_compile_cli_overrides,
 )
@@ -21,6 +22,7 @@ from sglang_omni.config.manager import ConfigManager
 from sglang_omni.models.ming_omni.config import (
     MingOmniPipelineConfig,
     MingOmniSpeechPipelineConfig,
+    MingOmniStreamingSpeechPipelineConfig,
 )
 from sglang_omni.models.qwen3_omni.config import Qwen3OmniSpeechPipelineConfig
 from sglang_omni.models.registry import (
@@ -469,6 +471,50 @@ def test_ming_cli_talker_gpu_targets_talker_stage() -> None:
 
     assert _stage(config, "thinker").gpu == [0, 1]
     assert _stage(config, "talker").gpu == 3
+
+
+def test_ming_cli_talker_max_conc_targets_talker_factory_args() -> None:
+    config = MingOmniSpeechPipelineConfig(model_path="dummy")
+
+    apply_talker_max_conc_cli_override(config, talker_max_conc=3)
+
+    assert _stage(config, "talker").factory_args["max_conc"] == 3
+
+
+def test_ming_cli_talker_max_conc_none_is_noop() -> None:
+    config = MingOmniSpeechPipelineConfig(model_path="dummy")
+    before = dict(_stage(config, "talker").factory_args)
+
+    apply_talker_max_conc_cli_override(config, talker_max_conc=None)
+
+    assert _stage(config, "talker").factory_args == before
+
+
+def test_ming_cli_rejects_talker_max_conc_below_one() -> None:
+    config = MingOmniSpeechPipelineConfig(model_path="dummy")
+
+    with pytest.raises(typer.BadParameter, match="--talker-max-conc must be >= 1"):
+        apply_talker_max_conc_cli_override(config, talker_max_conc=0)
+
+
+def test_ming_cli_rejects_talker_max_conc_on_streaming_talker() -> None:
+    config = MingOmniStreamingSpeechPipelineConfig(model_path="dummy")
+
+    with pytest.raises(
+        typer.BadParameter,
+        match="--talker-max-conc currently supports only the Ming-Omni",
+    ):
+        apply_talker_max_conc_cli_override(config, talker_max_conc=3)
+
+
+def test_ming_text_cli_rejects_talker_max_conc_with_stable_message() -> None:
+    config = MingOmniPipelineConfig(model_path="dummy")
+
+    with pytest.raises(
+        typer.BadParameter,
+        match="--talker-max-conc is not supported by MingOmniPipelineConfig",
+    ):
+        apply_talker_max_conc_cli_override(config, talker_max_conc=3)
 
 
 @pytest.mark.parametrize("mode", ["on", "off"])

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -234,6 +234,7 @@ def test_ming_speech_launcher_places_thinker_tp_and_talker(monkeypatch) -> None:
         mem_fraction_static=0.8,
         cpu_offload_gb=None,
         enable_streaming_tts=False,
+        talker_max_conc=None,
         host="127.0.0.1",
         port=8000,
         model_name="ming-omni",

--- a/tests/unit_test/ming_omni/test_talker_max_conc.py
+++ b/tests/unit_test/ming_omni/test_talker_max_conc.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from sglang_omni.models.ming_omni.talker.configuration_bailing_talker import (
+    MingOmniTalkerConfig,
+    normalize_max_conc,
+    resolve_talker_max_conc,
+)
+
+
+def test_normalize_max_conc_rejects_non_positive() -> None:
+    with pytest.raises(ValueError, match="max_conc must be >= 1"):
+        normalize_max_conc(0)
+
+
+def test_from_pretrained_dir_reads_max_conc(tmp_path: Path) -> None:
+    talker_dir = tmp_path / "talker"
+    talker_dir.mkdir()
+    (talker_dir / "config.json").write_text(
+        json.dumps({"steps": 10, "max_conc": 3}),
+        encoding="utf-8",
+    )
+
+    config = MingOmniTalkerConfig.from_pretrained_dir(str(talker_dir))
+
+    assert config.max_conc == 3
+    assert config.steps == 10
+
+
+def test_from_pretrained_dir_defaults_max_conc_to_one(tmp_path: Path) -> None:
+    talker_dir = tmp_path / "talker"
+    talker_dir.mkdir()
+    (talker_dir / "config.json").write_text("{}", encoding="utf-8")
+
+    config = MingOmniTalkerConfig.from_pretrained_dir(str(talker_dir))
+
+    assert config.max_conc == 1
+
+
+def test_resolve_talker_max_conc_override_wins(tmp_path: Path) -> None:
+    talker_dir = tmp_path / "talker"
+    talker_dir.mkdir()
+    (talker_dir / "config.json").write_text(
+        json.dumps({"max_conc": 2}),
+        encoding="utf-8",
+    )
+
+    assert resolve_talker_max_conc(str(talker_dir), max_conc=4) == 4
+    assert resolve_talker_max_conc(str(talker_dir)) == 2
+
+
+def test_resolve_talker_max_conc_missing_config_defaults_to_one(
+    tmp_path: Path,
+) -> None:
+    assert resolve_talker_max_conc(str(tmp_path / "missing")) == 1
+
+
+def _install_talker_executor_fake(
+    monkeypatch,
+    *,
+    tmp_path: Path,
+    captured: dict[str, object],
+) -> None:
+    class FakeMingTalkerExecutor:
+        def __init__(self, **kwargs):
+            captured["executor_kwargs"] = kwargs
+
+        def should_generate_audio(self, payload):
+            return True
+
+        def build_empty_audio_result(self, payload):
+            return payload
+
+        async def start(self):
+            return None
+
+        async def add_request(self, payload):
+            return None
+
+        async def get_result(self):
+            return SimpleNamespace(request_id="req")
+
+    talker_module = ModuleType("sglang_omni.models.ming_omni.components.talker_executor")
+    talker_module.MingTalkerExecutor = FakeMingTalkerExecutor
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.models.ming_omni.components.talker_executor",
+        talker_module,
+    )
+
+    weight_loader_module = ModuleType("sglang_omni.models.weight_loader")
+    weight_loader_module.resolve_model_path = lambda model_path: str(tmp_path)
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.models.weight_loader",
+        weight_loader_module,
+    )
+
+
+def test_create_talker_executor_wires_scheduler_max_concurrency(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    talker_dir = tmp_path / "talker"
+    talker_dir.mkdir()
+    (talker_dir / "config.json").write_text(
+        json.dumps({"max_conc": 3}),
+        encoding="utf-8",
+    )
+
+    captured: dict[str, object] = {}
+    _install_talker_executor_fake(monkeypatch, tmp_path=tmp_path, captured=captured)
+
+    from sglang_omni.models.ming_omni.stages import create_talker_executor
+
+    scheduler = create_talker_executor(
+        model_path=str(tmp_path),
+        talker_model_path=str(talker_dir),
+        device="cuda:1",
+        voice="DB30",
+    )
+
+    assert scheduler._max_concurrency == 3
+    assert captured["executor_kwargs"]["max_conc"] == 3
+
+
+def test_create_talker_executor_cli_override_beats_config(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    talker_dir = tmp_path / "talker"
+    talker_dir.mkdir()
+    (talker_dir / "config.json").write_text(
+        json.dumps({"max_conc": 2}),
+        encoding="utf-8",
+    )
+
+    captured: dict[str, object] = {}
+    _install_talker_executor_fake(monkeypatch, tmp_path=tmp_path, captured=captured)
+
+    from sglang_omni.models.ming_omni.stages import create_talker_executor
+
+    scheduler = create_talker_executor(
+        model_path=str(tmp_path),
+        talker_model_path=str(talker_dir),
+        max_conc=5,
+    )
+
+    assert scheduler._max_concurrency == 5
+    assert captured["executor_kwargs"]["max_conc"] == 5

--- a/tests/unit_test/ming_omni/test_talker_max_conc.py
+++ b/tests/unit_test/ming_omni/test_talker_max_conc.py
@@ -88,7 +88,9 @@ def _install_talker_executor_fake(
         async def get_result(self):
             return SimpleNamespace(request_id="req")
 
-    talker_module = ModuleType("sglang_omni.models.ming_omni.components.talker_executor")
+    talker_module = ModuleType(
+        "sglang_omni.models.ming_omni.components.talker_executor"
+    )
     talker_module.MingTalkerExecutor = FakeMingTalkerExecutor
     monkeypatch.setitem(
         sys.modules,


### PR DESCRIPTION
## Summary
- Load `max_conc` from Ming talker `config.json` and keep graph-pool / stage-scheduler concurrency in sync.
- Add `--talker-max-conc` for `sgl-omni serve` and the Ming speech launcher (non-streaming talker only).
- Default remains `1` (no behavior change unless explicitly overridden).

## Motivation
Ming talker already had an internal `max_conc` for the CFM CUDA-graph pool, but:
1. `from_pretrained_dir()` did not read it from checkpoint config.
2. `SimpleScheduler` was hard-coded to `max_concurrency=1`.

This left concurrency untunable from the serving path.

Related: #254 (Phase 1.2 / 3.1 talker concurrency wiring).

## Changes
- `MingOmniTalkerConfig`: read/normalize `max_conc`; helpers to resolve effective concurrency.
- `create_talker_executor`: pass resolved `max_conc` into both `MingTalkerExecutor` and `SimpleScheduler`.
- CLI / launcher: `--talker-max-conc N` → talker `factory_args["max_conc"]`.
- Reject unsupported targets (text-only / streaming talker) with a clear error.
- Unit tests for config load, override precedence, scheduler wiring, and CLI validation.

## Usage
```bash
sgl-omni serve --model-path inclusionAI/Ming-flash-omni-2.0 \
  --talker-gpu 1 --talker-max-conc 3
```

## Test plan 
- [x] Unit: tests/unit_test/ming_omni/test_talker_max_conc.py
- [x] Unit: Ming CLI max_conc cases in test_omni_serve.py