### PR TITLE
[Perf][M-PR3] Query MOSS-TD embedding cache before mel extraction

### DIFF
--- a/sglang_omni/models/moss_transcribe_diarize/encoder_service.py
+++ b/sglang_omni/models/moss_transcribe_diarize/encoder_service.py
@@ -40,6 +40,9 @@ class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Te
         self._model = model
         self._max_batch_size = int(max_batch_size)
         self._device = next(model.whisper_encoder.parameters()).device
+        adaptor_reference = next(model.vq_adaptor.parameters())
+        self._dtype = adaptor_reference.dtype
+        self._hidden_size = int(model.config.text_config.hidden_size)
         self._stream = torch.cuda.Stream(device=self._device)
         self._cache = StageOutputCache(
             max_size=_CACHE_MAX_ENTRIES,
@@ -52,15 +55,62 @@ class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Te
 
     def encode_item(self, item: Any) -> None:
         """Blocks until item.precomputed_embeddings is attached."""
-        if item.hash is not None:
-            cached = self._cache.get(str(item.hash))
-        else:
-            cached = None
+        feature_lengths = getattr(item, "audio_feature_lengths", None)
+        if feature_lengths is None:
+            future = self._submit(item)
+            future.result(timeout=self.ENCODE_TIMEOUT_S)
+            return
+        expected_tokens = int(feature_lengths.sum())
+        key = self._cache_key(item)
+        cached = self._lookup_cached_embedding(key, expected_tokens)
         if cached is not None:
-            self.attach_embedding(item, cached.to(self._device, non_blocking=True))
+            self.attach_embedding(item, cached)
             return
         future = self._submit(item)
         future.result(timeout=self.ENCODE_TIMEOUT_S)
+
+    def lookup_cached_embedding(
+        self,
+        audio_fingerprint: str,
+        expected_tokens: int,
+    ) -> torch.Tensor | None:
+        """Return a validated cached embedding without starting an encode."""
+        return self._lookup_cached_embedding(str(audio_fingerprint), expected_tokens)
+
+    def _lookup_cached_embedding(
+        self,
+        key: str | None,
+        expected_tokens: int,
+    ) -> torch.Tensor | None:
+        cached = self._cache.get(key)
+        if cached is None:
+            return None
+        if self._is_valid(cached, expected_tokens):
+            return cached
+        logger.warning(
+            "MOSS-TD pre-LM cache entry %s failed validation "
+            "(shape=%s, dtype=%s); discarding it if unchanged before re-encoding",
+            key,
+            getattr(cached, "shape", None),
+            getattr(cached, "dtype", None),
+        )
+        self._cache.remove_if_same(key, cached)
+        return None
+
+    def _cache_key(self, item: Any) -> str | None:
+        fingerprint = getattr(item, "audio_fingerprint", None)
+        if fingerprint is None:
+            fingerprint = getattr(item, "hash", None)
+        return None if fingerprint is None else str(fingerprint)
+
+    def _is_valid(self, embedding: Any, expected_tokens: int) -> bool:
+        return (
+            isinstance(embedding, torch.Tensor)
+            and embedding.dim() == 2
+            and embedding.shape[0] == expected_tokens
+            and embedding.shape[1] == self._hidden_size
+            and embedding.dtype == self._dtype
+        )
 
     def _drain_batch(self) -> list[QueueEntry[Any]]:
         # note (yichi): never wait — a window costs 8~16ms at low concurrency, buys <=5ms at high.
@@ -99,7 +149,7 @@ class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Te
         ]
 
     def attach_embedding(self, item: Any, embedding: torch.Tensor) -> None:
-        item.precomputed_embeddings = embedding
+        item.precomputed_embeddings = embedding.to(self._device, non_blocking=True)
         item.feature = None
 
     def attach_before_synchronize(self) -> bool:
@@ -109,8 +159,7 @@ class BatchedAudioEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Te
         self._stream.synchronize()
 
     def cache_embedding(self, item: Any, embedding: torch.Tensor) -> None:
-        if item.hash is not None:
-            self._cache.put(str(item.hash), embedding)
+        self._cache.put(self._cache_key(item), embedding)
 
     def _handle_batch_failure(
         self,

--- a/sglang_omni/models/moss_transcribe_diarize/request_builders.py
+++ b/sglang_omni/models/moss_transcribe_diarize/request_builders.py
@@ -255,22 +255,42 @@ def _prompt_token_parts(
     )
 
 
+def _audio_feature_lengths_from_waveform(
+    processor: Any,
+    num_samples: int,
+) -> torch.Tensor:
+    """Derive the processor's per-chunk token lengths without extracting mel."""
+    feature_extractor = processor.feature_extractor
+    chunk_samples = int(feature_extractor.n_samples)
+    stride = (
+        int(feature_extractor.hop_length)
+        * _WHISPER_ENCODER_STRIDE
+        * int(processor.audio_merge_size)
+    )
+    if chunk_samples <= 0 or stride <= 0:
+        raise ValueError("MOSS-Transcribe-Diarize processor has invalid audio strides")
+    return torch.tensor(
+        [
+            (min(chunk_samples, num_samples - start) - 1) // stride + 1
+            for start in range(0, num_samples, chunk_samples)
+        ],
+        dtype=torch.long,
+    )
+
+
 def _extract_audio_features(
     processor: Any,
     audio: np.ndarray,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
     feature_extractor = processor.feature_extractor
     n_samples = int(feature_extractor.n_samples)
-    stride = (
-        int(feature_extractor.hop_length)
-        * _WHISPER_ENCODER_STRIDE
-        * int(processor.audio_merge_size)
+    audio_feature_lengths = _audio_feature_lengths_from_waveform(
+        processor,
+        int(audio.shape[0]),
     )
     chunks: list[np.ndarray] = []
-    token_lengths: list[int] = []
     for start in range(0, audio.shape[0], n_samples):
         chunk = audio[start : start + n_samples]
-        token_lengths.append((int(chunk.shape[0]) - 1) // stride + 1)
         if chunk.shape[0] < n_samples:
             chunk = np.pad(chunk, (0, n_samples - chunk.shape[0]))
         chunks.append(chunk)
@@ -281,16 +301,12 @@ def _extract_audio_features(
         padding="max_length",
         return_tensors="pt",
     )["input_features"]
-    audio_feature_lengths = torch.tensor(
-        token_lengths,
-        dtype=torch.long,
-        device=input_features.device,
-    )
+    audio_feature_lengths = audio_feature_lengths.to(input_features.device)
     return (
         input_features,
         audio_feature_lengths,
         torch.zeros_like(audio_feature_lengths),
-        sum(token_lengths),
+        int(audio_feature_lengths.sum().item()),
     )
 
 
@@ -347,12 +363,29 @@ def make_moss_transcribe_diarize_scheduler_adapters(
         max_length = min(
             int(params.get("max_length") or context_length), context_length
         )
-        (
-            features,
-            audio_feature_lengths,
-            audio_chunk_mapping,
-            audio_token_count,
-        ) = _extract_audio_features(processor, audio)
+        cached_embedding = None
+        if audio_encoder_service is not None:
+            audio_feature_lengths = _audio_feature_lengths_from_waveform(
+                processor,
+                len(audio),
+            )
+            cached_embedding = audio_encoder_service.lookup_cached_embedding(
+                fingerprint,
+                int(audio_feature_lengths.sum().item()),
+            )
+
+        if cached_embedding is None:
+            (
+                features,
+                audio_feature_lengths,
+                audio_chunk_mapping,
+                audio_token_count,
+            ) = _extract_audio_features(processor, audio)
+        else:
+            features = None
+            audio_chunk_mapping = torch.zeros_like(audio_feature_lengths)
+            audio_token_count = int(audio_feature_lengths.sum().item())
+
         if prompt == default_prompt:
             prefix_ids, suffix_ids = default_prompt_parts
         else:
@@ -381,13 +414,17 @@ def make_moss_transcribe_diarize_scheduler_adapters(
             model_specific_data={
                 "audio_feature_lengths": audio_feature_lengths,
                 "audio_chunk_mapping": audio_chunk_mapping,
+                "audio_fingerprint": fingerprint,
             },
         )
         audio_item.set_pad_value()
         audio_item.offsets = offsets
 
         if audio_encoder_service is not None:
-            audio_encoder_service.encode_item(audio_item)
+            if cached_embedding is None:
+                audio_encoder_service.encode_item(audio_item)
+            else:
+                audio_encoder_service.attach_embedding(audio_item, cached_embedding)
 
         padded_audio_span_ids = [
             audio_item.pad_value if token_id == audio_token_id else token_id

--- a/tests/unit_test/moss_transcribe_diarize/test_encoder_service.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_encoder_service.py
@@ -265,18 +265,60 @@ def test_non_oom_failure_logs_traceback_without_retaining_exception_state(
     )
 
 
-def test_cache_hit_attaches_embedding_without_submitting() -> None:
+def test_encode_item_rechecks_cache_after_preprocessing() -> None:
     service = object.__new__(BatchedAudioEncoderService)
     service._device = torch.device("cpu")
+    service._dtype = torch.float32
+    service._hidden_size = 3
     service._cache = StageOutputCache(max_size=4, max_bytes=1024, cache_device="cpu")
     cached = torch.arange(6, dtype=torch.float32).reshape(2, 3)
-    service._cache.put("7", cached)
-    item = SimpleNamespace(hash=7, feature=object(), precomputed_embeddings=None)
+    service._cache.put("fingerprint", cached)
+    item = SimpleNamespace(
+        hash=7,
+        audio_fingerprint="fingerprint",
+        audio_feature_lengths=torch.tensor([2]),
+        feature=object(),
+        precomputed_embeddings=None,
+    )
+    service._submit = lambda item: pytest.fail("cached item must not be submitted")
 
     service.encode_item(item)
 
     assert torch.equal(item.precomputed_embeddings, cached)
     assert item.feature is None
+
+
+@pytest.mark.parametrize(
+    "cached",
+    [
+        torch.ones(3, 3),
+        torch.ones(2, 4),
+        torch.ones(2, 3, dtype=torch.float64),
+    ],
+)
+def test_lookup_cached_embedding_evicts_invalid_entries(cached: torch.Tensor) -> None:
+    service = object.__new__(BatchedAudioEncoderService)
+    service._dtype = torch.float32
+    service._hidden_size = 3
+    service._cache = StageOutputCache(max_size=4, max_bytes=1024, cache_device="cpu")
+    service._cache.put("fingerprint", cached)
+
+    assert service.lookup_cached_embedding("fingerprint", 2) is None
+    assert len(service._cache) == 0
+
+
+def test_lookup_cached_embedding_returns_valid_entry() -> None:
+    service = object.__new__(BatchedAudioEncoderService)
+    service._dtype = torch.float32
+    service._hidden_size = 3
+    service._cache = StageOutputCache(max_size=4, max_bytes=1024, cache_device="cpu")
+    cached = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    service._cache.put("fingerprint", cached)
+
+    result = service.lookup_cached_embedding("fingerprint", 2)
+
+    assert result is not None
+    assert torch.equal(result, cached)
 
 
 def test_batch_failure_retries_moss_items_with_failure_isolation() -> None:
@@ -285,6 +327,7 @@ def test_batch_failure_retries_moss_items_with_failure_isolation() -> None:
     service._item_count = 0
     service._worker_state_lock = threading.Lock()
     service._worker_error = None
+    service._device = torch.device("cpu")
     service._cache = StageOutputCache(max_size=4, max_bytes=1024, cache_device="cpu")
     synchronized: list[None] = []
     service._stream = SimpleNamespace(synchronize=lambda: synchronized.append(None))

--- a/tests/unit_test/moss_transcribe_diarize/test_request_builders.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_request_builders.py
@@ -17,6 +17,7 @@ from sglang_omni.models.moss_transcribe_diarize.request_builders import (
     DEFAULT_TOP_K,
     DEFAULT_TOP_P,
     DEFAULT_TRANSCRIBE_DIARIZE_PROMPT,
+    _audio_feature_lengths_from_waveform,
     make_moss_transcribe_diarize_scheduler_adapters,
 )
 from sglang_omni.proto import EXPLICIT_GENERATION_PARAMS_KEY, OmniRequest, StagePayload
@@ -190,6 +191,7 @@ def _request_builder(
     processor: FakeProcessor | None = None,
     *,
     context_length: int = TEST_CONTEXT_LENGTH,
+    audio_encoder_service=None,
 ):
     processor = processor or FakeProcessor()
     request_builder, _ = make_moss_transcribe_diarize_scheduler_adapters(
@@ -197,6 +199,7 @@ def _request_builder(
         tokenizer=processor.tokenizer,
         max_new_tokens=32,
         context_length=context_length,
+        audio_encoder_service=audio_encoder_service,
     )
     return request_builder
 
@@ -296,6 +299,107 @@ def test_streamlined_request_builder_enforces_context_limit() -> None:
         match="Prompt/audio sequence exceeds max_length=5",
     ):
         request_builder(_payload())
+
+
+def test_embedding_cache_hit_skips_feature_extraction_and_encode() -> None:
+    class _EncoderService:
+        def __init__(self) -> None:
+            self.lookup: tuple[str, int] | None = None
+            self.embedding = torch.zeros((2, 4))
+
+        def lookup_cached_embedding(
+            self,
+            audio_fingerprint: str,
+            expected_tokens: int,
+        ) -> torch.Tensor:
+            self.lookup = (audio_fingerprint, expected_tokens)
+            return self.embedding
+
+        def attach_embedding(self, item, embedding: torch.Tensor) -> None:
+            item.precomputed_embeddings = embedding
+            item.feature = None
+
+        def encode_item(self, item) -> None:
+            raise AssertionError("encoder should not run on a cache hit")
+
+    processor = FakeProcessor()
+    encoder_service = _EncoderService()
+    request_builder = _request_builder(
+        processor,
+        audio_encoder_service=encoder_service,
+    )
+
+    data = request_builder(_payload())
+
+    item = data.req.multimodal_inputs.mm_items[0]
+    assert encoder_service.lookup == (data.req.extra_key, 2)
+    assert processor.processor_calls == 0
+    assert processor.feature_extractor.calls == 0
+    assert item.feature is None
+    assert item.precomputed_embeddings is encoder_service.embedding
+    assert item.audio_feature_lengths.tolist() == [2]
+    assert item.audio_chunk_mapping.tolist() == [0]
+
+
+def test_embedding_cache_miss_preserves_processor_and_encoder_path() -> None:
+    class _EncoderService:
+        def __init__(self) -> None:
+            self.lookup: tuple[str, int] | None = None
+            self.encoded_feature: torch.Tensor | None = None
+
+        def lookup_cached_embedding(
+            self,
+            audio_fingerprint: str,
+            expected_tokens: int,
+        ) -> None:
+            self.lookup = (audio_fingerprint, expected_tokens)
+            return None
+
+        def attach_embedding(self, item, embedding: torch.Tensor) -> None:
+            raise AssertionError("no cached embedding should be attached")
+
+        def encode_item(self, item) -> None:
+            self.encoded_feature = item.feature
+            item.precomputed_embeddings = torch.zeros((3, 4))
+            item.feature = None
+
+    processor = FakeProcessor()
+    encoder_service = _EncoderService()
+    request_builder = _request_builder(
+        processor,
+        audio_encoder_service=encoder_service,
+    )
+
+    data = request_builder(_payload())
+
+    assert encoder_service.lookup == (data.req.extra_key, 2)
+    assert processor.processor_calls == 0
+    assert processor.feature_extractor.calls == 1
+    assert encoder_service.encoded_feature is not None
+    assert data.req.multimodal_inputs.mm_items[0].feature is None
+
+
+@pytest.mark.parametrize(
+    ("num_samples", "expected"),
+    [
+        (1, [1]),
+        (1280, [1]),
+        (1281, [2]),
+        (480000, [375]),
+        (480001, [375, 1]),
+        (960123, [375, 375, 1]),
+    ],
+)
+def test_audio_feature_lengths_match_processor_chunk_boundaries(
+    num_samples: int,
+    expected: list[int],
+) -> None:
+    processor = FakeProcessor()
+    processor.feature_extractor.n_samples = 480000
+
+    assert _audio_feature_lengths_from_waveform(processor, num_samples).tolist() == (
+        expected
+    )
 
 
 def test_request_builder_replaces_audio_tokens_with_item_pad_value() -> None:


### PR DESCRIPTION
## Motivation

MOSS-Transcribe-Diarize currently runs processor fbank/mel extraction before
the pre-LM encoder service checks its completed embedding cache. Repeated audio
therefore still pays the CPU frontend cost even when the complete LM-ready
embedding is already cached.

Move the cache lookup immediately after the canonical 16 kHz waveform is
decoded, resampled, and fingerprinted. A valid hit builds the request directly
from the cached embedding; misses keep the existing processor, batched encoder,
retry, and cache-fill path.

## Modifications

1. `sglang_omni/models/moss_transcribe_diarize/request_builders.py`

   - Derive per-chunk audio token lengths from the canonical resampled waveform
     using the processor chunk size, hop length, Whisper encoder stride, and
     MOSS audio merge size before mel extraction.
   - Query the completed embedding cache with the full waveform fingerprint and
     expected token count.
   - On a valid hit, skip processor fbank/mel extraction and audio encoding,
     while using the processor's audio-token expansion helper to preserve the
     exact input IDs, time-marker span, context limit, and offsets.
   - On a miss, preserve the existing processor and batched encoder submission
     path and carry the full fingerprint on the multimodal item.

2. `sglang_omni/models/moss_transcribe_diarize/encoder_service.py`

   - Add a lookup-only cache API that does not start encoder work.
   - Validate the cached tensor rank, token count, text hidden size, and adaptor
     dtype, and evict an invalid entry only if it is still the observed object.
   - Recheck the cache in `encode_item()` after preprocessing, preserving the
     existing concurrent-miss batching behavior when another request fills the
     cache during processor work.
   - Prefer the full waveform fingerprint for cache writes while retaining the
     existing integer hash as a compatibility fallback.

3. `tests/unit_test/moss_transcribe_diarize/`

   - Prove a valid hit skips processor feature extraction and encoder execution.
   - Prove a miss preserves processor and encoder behavior.
   - Cover per-chunk token-length boundaries, valid lookup, invalid-entry
     eviction, and the post-preprocessing cache recheck.

## Related Issues

#1396

## Accuracy Test

**Setup:**

- OpenMOSS-Team/MOSS-Transcribe-Diarize revision
  `e8681d68e7042738ffca8ac8212bc8fcb1131ab8`.
- Full SeedTTS English (1,088 clips) revision
  `27f4c1adee83b5b29b7c4b375f6b976324bda308`.
- Non-streaming, concurrency 1 and 16, three measured repeats without an extra
  warmup.
- BF16, FlashAttention 3, decode CUDA graphs enabled, encoder torch.compile
  disabled, `max_running_requests=16`, `mem_fraction_static=0.80`.
- One H100 NVL. Baseline: `main @ ac47f19`; candidate:
  `perf/moss-td-early-embedding-cache @ bc908da`.

| Metric | Baseline | Candidate |
| --- | ---: | ---: |
| Corpus WER, c=1 | 0.018084 | 0.018084 |
| Corpus WER, c=16 | 0.018538 | 0.018563 |
| Maximum sample WER | 0.285714 | 0.285714 |
| Evaluated / total, c=1 | 3,264 / 3,264 | 3,264 / 3,264 |
| Evaluated / total, c=16 | 3,264 / 3,264 | 3,264 / 3,264 |
| Skipped requests | 0 | 0 |

The c=16 corpus-WER difference is 0.000025 absolute; its per-repeat range is
0.018538-0.018614, with unchanged maximum sample WER and complete coverage.

## Benchmark & Profiling

Same setup as described in the _Accuracy Test_ section.

| Concurrency | Metric | Baseline (mean +/- std) | Candidate (mean +/- std) | Delta |
| ---: | --- | ---: | ---: | ---: |
| 1 | Throughput (req/s) | 3.681 +/- 0.155 | 4.006 +/- 0.333 | +8.82% |
| 1 | Mean latency (s) | 0.2716 +/- 0.0118 | 0.2504 +/- 0.0219 | -7.78% |
| 1 | P95 latency (s) | 0.3071 +/- 0.0149 | 0.2887 +/- 0.0305 | -6.00% |
| 1 | Mean RTF | 0.0593 +/- 0.0026 | 0.0547 +/- 0.0049 | -7.82% |
| 16 | Throughput (req/s) | 40.893 +/- 0.156 | 44.956 +/- 0.475 | +9.94% |
| 16 | Mean latency (s) | 0.3884 +/- 0.0020 | 0.3532 +/- 0.0040 | -9.05% |
| 16 | P95 latency (s) | 0.4466 +/- 0.0043 | 0.4154 +/- 0.0060 | -7.01% |
| 16 | Mean RTF | 0.0849 +/- 0.0004 | 0.0771 +/- 0.0009 | -9.15% |

### Warm-cache summary

- For repeats 2-3 at c=1, throughput improves 11.34%, mean latency drops
  10.20%, P95 latency drops 9.19%, and mean RTF drops 10.30%.
- For repeats 2-3 at c=16, throughput improves 10.76%, mean latency drops
  9.79%, P95 latency drops 8.06%, and mean RTF drops 9.88%.
- The candidate served 6,528/6,528 requests with HTTP 200 and no request HTTP
  failures. Encoder progress stopped at 651 items during the first cold-cache
  pass and did not advance during warm repeats, confirming that warm requests
  used the early completed-embedding-cache path.

## Validation

- `pre-commit run --all-files` - passed.
- `/workspace/sglang-omni/.venv/bin/python -m pytest tests/unit_test/moss_transcribe_diarize -q`
  - 85 passed, 14 skipped.
- Real processor parity at model revision
  `e8681d68e7042738ffca8ac8212bc8fcb1131ab8` - exact per-chunk token lengths
  and full input IDs matched at sample counts `1`, `1279`, `1280`, `1281`,
  `479999`, `480000`, `480001`, `960000`, and `960123`.
- `git diff --check` - passed.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as long as
the label remains. Use `/tag-and-rerun-ci higgs` or `/tag-and-rerun-ci moss` to
select a TTS CI model, and `/tag-and-rerun-ci fun-asr` or
`/tag-and-rerun-ci qwen3-asr` to select an ASR CI model. One selector from each
family can be combined. Draft PRs are skipped even if labeled.
