### PR TITLE
fix(profiler): capture execution traces and select the profiler activity by backend

### DIFF
--- a/sglang_omni/profiler/torch_profiler.py
+++ b/sglang_omni/profiler/torch_profiler.py
@@ -9,6 +9,7 @@ import subprocess
 import threading
 from contextlib import nullcontext
 
+import torch
 from torch.profiler import ProfilerActivity, profile
 
 from .base_profiler import ProfilerBase
@@ -18,6 +19,23 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+
+def _gpu_activity() -> ProfilerActivity | None:
+    """The accelerator activity for the live backend, or None on a CPU build.
+
+    ``ProfilerActivity.CUDA`` exists as an enum member on a ``+xpu`` torch build,
+    so passing it unconditionally raises nothing and silently records a CPU-only
+    trace -- every XPU kernel missing, with no error to explain it. Select by what
+    the process can actually see instead. Mirrors the activity mapping in SGLang's
+    ``SchedulerProfilerManager``.
+    """
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        return getattr(ProfilerActivity, "XPU", None)
+    if torch.cuda.is_available():
+        # CUDA activity covers NVIDIA and AMD (ROCm) builds alike.
+        return getattr(ProfilerActivity, "CUDA", None)
+    return None
 
 
 class TorchProfiler(ProfilerBase):
@@ -32,10 +50,48 @@ class TorchProfiler(ProfilerBase):
 
     _active_run_id: str | None = None
     _lock = threading.Lock()
+    _et_observer = None
+    _trace_exported: bool = False
 
     @classmethod
     def get_active_run_id(cls) -> str | None:
         return cls._active_run_id
+
+    @classmethod
+    def _make_et_observer(cls, et_file: str, rank: int):
+        """Register an ExecutionTraceObserver for ``et_file``, or None."""
+        observer_cls = getattr(torch.profiler, "ExecutionTraceObserver", None)
+        if observer_cls is None:
+            logger.warning(
+                "[Rank %s] SGLANG_TORCH_PROFILER_RECORD_ET=1 but this torch build "
+                "has no torch.profiler.ExecutionTraceObserver; no .et.json written",
+                rank,
+            )
+            return None
+        try:
+            os.makedirs(os.path.dirname(et_file), exist_ok=True)
+            observer = observer_cls()
+            observer.register_callback(et_file)
+            return observer
+        except Exception as e:
+            logger.warning(
+                "[Rank %s] Failed to register execution trace observer: %s", rank, e
+            )
+            return None
+
+    @classmethod
+    def _unregister_et_observer(cls, rank: int) -> None:
+        """Close the ET file. Skipping this leaves a truncated .et.json."""
+        if cls._et_observer is None:
+            return
+        try:
+            cls._et_observer.unregister_callback()
+        except Exception as e:
+            logger.warning(
+                "[Rank %s] Failed to unregister execution trace observer: %s", rank, e
+            )
+        finally:
+            cls._et_observer = None
 
     @classmethod
     def start(cls, trace_path_template: str, run_id: str | None = None) -> str:
@@ -43,6 +99,10 @@ class TorchProfiler(ProfilerBase):
         Start the profiler with the given trace path template.
         """
         with cls._lock:
+            # Resolve the rank before the cleanup branch below: both the
+            # already-active early return and its warning interpolate it, so
+            # reading it afterwards made either path raise UnboundLocalError.
+            rank = cls._get_rank()
 
             # 1. Cleanup any existing profiler
             if cls._profiler is not None:
@@ -61,11 +121,10 @@ class TorchProfiler(ProfilerBase):
                     logger.warning(
                         "[Rank %s] Failed to stop existing profiler: %s", rank, e
                     )
+                cls._unregister_et_observer(rank)
                 cls._profiler = None
                 cls._active_run_id = None
                 cls._trace_template = ""
-
-            rank = cls._get_rank()
 
             # 2. Make path absolute
             trace_path_template = os.path.abspath(trace_path_template)
@@ -82,12 +141,15 @@ class TorchProfiler(ProfilerBase):
             )
 
             # 3. Define the on_trace_ready handler
+            cls._trace_exported = False
+
             def trace_handler(p):
                 nonlocal json_file
 
                 # A. Export JSON Trace
                 try:
                     p.export_chrome_trace(json_file)
+                    cls._trace_exported = True
                     logger.info(f"[Rank {rank}] Trace exported to {json_file}")
 
                     try:
@@ -105,11 +167,38 @@ class TorchProfiler(ProfilerBase):
                 except Exception as e:
                     logger.warning(f"[Rank {rank}] Failed to export trace: {e}")
 
+            # Chakra Execution Trace (ET): the graph-level artifact PARAM replay
+            # and MTSA consume, written alongside the chrome trace as
+            # *_rank<N>.et.json. Opt-in like the other expensive flags, and armed
+            # before profile() so the observer can be handed to it.
+            et_kwargs = {}
+            if os.environ.get("SGLANG_TORCH_PROFILER_RECORD_ET") == "1":
+                et_file = f"{trace_path_template}_rank{rank}.et.json"
+                observer = cls._make_et_observer(et_file, rank)
+                if observer is not None:
+                    cls._et_observer = observer
+                    et_kwargs["execution_trace_observer"] = observer
+                    logger.info(
+                        "[Rank %s] Execution trace will be written to %s",
+                        rank,
+                        et_file,
+                    )
+
             # No ``schedule``: record continuously between start/stop.
             # Expensive flags are env-var opt-in (default off keeps the
             # trace tens of MB; all on can hit multi-GB).
+            activities = [ProfilerActivity.CPU]
+            gpu_activity = _gpu_activity()
+            if gpu_activity is not None:
+                activities.append(gpu_activity)
+            else:
+                logger.warning(
+                    "[Rank %s] No accelerator activity available; "
+                    "recording a CPU-only trace",
+                    rank,
+                )
             cls._profiler = profile(
-                activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+                activities=activities,
                 on_trace_ready=trace_handler,
                 record_shapes=os.environ.get("SGLANG_TORCH_PROFILER_RECORD_SHAPES")
                 == "1",
@@ -117,6 +206,7 @@ class TorchProfiler(ProfilerBase):
                 == "1",
                 with_stack=os.environ.get("SGLANG_TORCH_PROFILER_WITH_STACK") == "1",
                 with_flops=os.environ.get("SGLANG_TORCH_PROFILER_WITH_FLOPS") == "1",
+                **et_kwargs,
             )
 
             # 5. Start profiling
@@ -154,13 +244,29 @@ class TorchProfiler(ProfilerBase):
             gz_path = f"{json_path}.gz"
 
             profiler = cls._profiler
+            et_path = f"{base_path}.et.json" if cls._et_observer is not None else None
             try:
                 profiler.stop()
             except Exception as e:
                 logger.warning("[Rank %s] Profiler stop failed: %s", rank, e)
 
-            # No schedule → on_trace_ready isn't fired on stop, so
-            # export here.
+            # Unregister before export: the observer must be closed for the
+            # .et.json to be complete, and it must happen even if stop() raised.
+            cls._unregister_et_observer(rank)
+            if et_path is not None:
+                logger.info("[Rank %s] Execution trace written to %s", rank, et_path)
+
+            # Without a ``schedule`` some torch versions fire on_trace_ready on
+            # stop() and some do not, so export only if the handler did not
+            # already. Exporting twice raises "Trace is already saved", which the
+            # old unconditional path logged as a failed export on every stop.
+            if cls._trace_exported:
+                cls._profiler = None
+                cls._active_run_id = None
+                cls._trace_template = ""
+                cls._trace_exported = False
+                return {"trace": gz_path, "table": None, "execution_trace": et_path}
+
             try:
                 os.makedirs(os.path.dirname(json_path), exist_ok=True)
                 profiler.export_chrome_trace(json_path)
@@ -185,7 +291,7 @@ class TorchProfiler(ProfilerBase):
             cls._active_run_id = None
             cls._trace_template = ""
 
-            return {"trace": gz_path, "table": None}
+            return {"trace": gz_path, "table": None, "execution_trace": et_path}
 
     @classmethod
     def step(cls):


### PR DESCRIPTION
`TorchProfiler` cannot profile on XPU at all, and emits no Chakra execution trace on any backend. Four fixes, all in `sglang_omni/profiler/torch_profiler.py`.

## XPU profiling raises instead of degrading

`activities` was hardcoded to `[ProfilerActivity.CPU, ProfilerActivity.CUDA]`. `ProfilerActivity.CUDA` exists as an enum member on a `+xpu` torch build, so nothing catches this at import time — it raises when `/start_profile` is served:

```
RuntimeError: Fail to enable Kineto Profiler on XPU. The error code is 2.
The detailed error message is: PTI_ERROR_NOT_IMPLEMENTED
```

`_gpu_activity()` now resolves the accelerator from the live backend: XPU when `torch.xpu.is_available()`, else CUDA (which covers NVIDIA and ROCm alike), else `None` with a warning that the trace will be CPU-only. This mirrors the activity mapping in SGLang's `SchedulerProfilerManager`.

Measured on Intel Arc Pro B60 with a 64×64 matmul, each in a clean process:

| activities | result |
| --- | --- |
| `[CPU, CUDA]` | `RuntimeError: ... PTI_ERROR_NOT_IMPLEMENTED` |
| `[CPU, XPU]` | ok — 3 XPU kernels captured |

## No Chakra execution trace

The profiler wrote chrome traces only, so there was nothing for PARAM/Chakra replay or graph-level tooling to consume. An `ExecutionTraceObserver` is now attached when `SGLANG_TORCH_PROFILER_RECORD_ET=1`, writing `<template>_rank<N>.et.json` beside the chrome trace, and `stop()` returns its path under an `execution_trace` key.

Opt-in via env var to match the file's existing convention for expensive options (`..._RECORD_SHAPES`, `..._WITH_STACK`, `..._WITH_FLOPS`), and gracefully skipped with a warning on a torch build lacking `torch.profiler.ExecutionTraceObserver`.

The observer is unregistered in `stop()` **before** export, and on the restart path, because unregistering is what closes the file — leaving it registered yields a `.et.json` truncated mid-write.

## `UnboundLocalError` on the already-active path

`start()` read `rank` at lines 50 and 54 but assigned it at line 68, so both the idempotent early return and its "already active, restarting" warning raised `UnboundLocalError` instead of doing their job. `rank` is now resolved before the cleanup branch.

## Misleading "Failed to export trace" on every stop

`stop()` exported the chrome trace unconditionally, but `on_trace_ready` does fire on `stop()` in current torch, so the second export raised `Trace is already saved` and was logged as a failed export on a run that had in fact succeeded. The handler now records that it exported and `stop()` skips the redundant call.

## Verification

- `tests/unit_test/profiler`: **31 passed**.
- End-to-end on Qwen3-ASR-1.7B on a single Intel Arc Pro B60, via `/start_profile` → `/v1/audio/transcriptions` → `/stop_profile`: a **30,445-node** execution trace (schema `1.1.1-chakra.0.0.4`; `aten::linear` ×1667, `aten::matmul` ×1584) alongside a chrome trace carrying **5,577 XPU kernels** and 5,668 `xpu_runtime` events. Transcription output was correct.
- Independent of any in-flight XPU enablement work: `torch_profiler.py` is untouched by it, and this branch is a single commit on current `main`.

CUDA behaviour is unchanged — `_gpu_activity()` returns `ProfilerActivity.CUDA` there, exactly what was hardcoded before. I have not been able to test on CUDA hardware; a check from someone who can would be welcome.