### PR TITLE
[Whisper ASR] Enable async decode on pre-LM (W-PR4)

### DIFF
--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -13,10 +13,23 @@ hf download openai/whisper-large-v3
 ## Server Configuration
 
 Whisper ASR runs a single ASR stage on one GPU.
+Async decode is enabled by default (`async_decode_min_batch_size=1`), allowing the
+shared one-step-lookahead path to overlap host-side result processing with the
+next GPU decode forward. Use `--decode-mode sync` to disable it, or tune the
+crossover with `--async-lookahead-min-batch-size`.
 
 ```bash
 sgl-omni serve \
   --model-path openai/whisper-large-v3 \
+  --port 8000
+```
+
+For example, force synchronous decode when comparing modes:
+
+```bash
+sgl-omni serve \
+  --model-path openai/whisper-large-v3 \
+  --decode-mode sync \
   --port 8000
 ```
 
@@ -114,6 +127,45 @@ End-to-end results used the 20-sample SeedTTS EN subset on a single H200 with `o
 
 All 480 measured requests completed successfully. Corpus WER was unchanged across eager and CUDA Graph modes at every concurrency.
 
+## Async Decode A/B (stacked on pre-LM)
+
+Compare sync and async decode with `--decode-mode` while keeping the model,
+sample subset, concurrency list, and repeat count identical across arms.
+Whisper already forces atomic encoder-prefix admission
+(`chunked_prefill_size=0`) and defaults to the pre-LM encoder path.
+
+```bash
+PORT_SYNC=8101
+PORT_ASYNC=8102
+
+# Arm A: sync decode (baseline; pre-LM still on)
+CUDA_VISIBLE_DEVICES=0 sgl-omni serve \
+  --model-path openai/whisper-base \
+  --decode-mode sync \
+  --port "${PORT_SYNC}"
+
+# Arm B: async decode with min batch size 1 (default)
+CUDA_VISIBLE_DEVICES=1 sgl-omni serve \
+  --model-path openai/whisper-base \
+  --decode-mode async \
+  --async-lookahead-min-batch-size 1 \
+  --port "${PORT_ASYNC}"
+
+for PORT in "${PORT_SYNC}" "${PORT_ASYNC}"; do
+  python -m benchmarks.eval.benchmark_asr_seedtts \
+    --port "${PORT}" \
+    --model-path openai/whisper-base \
+    --max-samples 20 \
+    --concurrencies 1,2,4,8 \
+    --repeats 3 --warmup \
+    --output "whisper_async_on_prelm_port${PORT}.json"
+done
+```
+
+Standalone async-decode A/B (without pre-LM) previously showed only a small
+c1 gain and regressions at high concurrency; re-run the recipe above on top of
+pre-LM before treating async as a default win.
+
 ## Known Limitations
 
 - This path is experimental and not yet correctness-validated. Prefer Qwen3-ASR
@@ -127,6 +179,8 @@ All 480 measured requests completed successfully. Corpus WER was unchanged acros
   admission (`chunked_prefill_size=0`). Raise `max_prefill_tokens` via
   `server_args_overrides` only when you need larger LM-side encoder CUDA Graph
   buckets with the encoder inside prefill.
+- Async decode is enabled by default; use `--decode-mode sync` for A/B
+  comparisons against the shared one-step-lookahead path.
 - Chunked prefill stays disabled because the Whisper encoder prefix must be
   admitted atomically. Requests that exceed the current prefill budget wait
   for the next batch instead of splitting the encoder prefix.

--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -22,7 +22,7 @@ sgl-omni serve \
 
 ## Encoder CUDA Graph
 
-The encoder CUDA Graph is enabled by default for the pipeline. The final bucket set is resolved from the serving prefill budget and the checkpoint's encoder prefix length; with the default 4,096-token budget and 1,500-token Whisper encoder prefix, only batches 1 and 2 are captured. To use eager encoder execution, override the pipeline configuration:
+The encoder CUDA Graph is enabled by default for the pipeline. The final bucket set is resolved from the serving prefill budget and the checkpoint's encoder prefix length. The default prefill budget is **4,096** tokens (`4096 // 1500 = 2`), so LM-side encoder graph batches **1/2** are captured when the encoder still runs inside prefill. With the default pre-LM path, high-concurrency encoder batching uses `pre_lm_max_batch_size` instead. To use eager encoder execution, override the pipeline configuration:
 
 ```yaml
 config_cls: WhisperASRPipelineConfig
@@ -34,7 +34,23 @@ runtime_overrides:
     enable_encoder_cuda_graph: false
 ```
 
-The graph is captured after SGLang's generation graphs. Raise `max_prefill_tokens` before configuring larger buckets. Each request uses the smallest captured bucket that fits its batch. Requests larger than every captured bucket, with a different feature shape, or without a successful capture run eagerly. Startup and first-replay logs identify the captured and executed buckets.
+The graph is captured after SGLang's generation graphs. Raise `max_prefill_tokens` further before configuring larger buckets (12/16). Each request uses the smallest captured bucket that fits its batch. Requests larger than every captured bucket, with a different feature shape, or without a successful capture run eagerly. Startup and first-replay logs identify the captured and executed buckets.
+
+## Pre-LM Encoder (W-PR7)
+
+By default Whisper runs the audio encoder on a dedicated pre-LM worker thread/stream **before** LM admission (same pattern as Qwen3-ASR / Fun-ASR). Encoder hidden states are attached as `precomputed_embeddings`; the scheduler prefill only writes cross-attention KV and still requires **atomic** encoder-prefix admission (`chunked_prefill_size=0`).
+
+```yaml
+runtime_overrides:
+  asr:
+    enable_pre_lm_encoder: true   # default
+    pre_lm_max_batch_size: 8
+    pre_lm_cache_max_entries: 4096
+    pre_lm_cache_size_bytes: 2147483648
+    pre_lm_max_batch_wait_ms: 0
+```
+
+Disable with `enable_pre_lm_encoder: false` to fall back to encoder-inside-prefill. Warm repeats of the same audio hit the CPU LRU and skip mel + encode. Raise `max_prefill_tokens` via `server_args_overrides` only if you need larger LM-side encoder CUDA Graph buckets without pre-LM.
 
 ## Transcribe Audio
 
@@ -108,9 +124,15 @@ All 480 measured requests completed successfully. Corpus WER was unchanged acros
 
 - This path is experimental and not yet correctness-validated. Prefer Qwen3-ASR
   for validated ASR serving.
-- Encoder CUDA Graph is opt-in and requires SGLang generation CUDA Graph to be
-  enabled. Validate the selected buckets before production use.
-- Chunked prefill is disabled because the Whisper encoder prefix must be
+- Encoder CUDA Graph is enabled by default and requires SGLang generation CUDA
+  Graph. Validate the selected buckets before production use.
+- Prefill budget defaults to 4,096 tokens (`⌊4096/1500⌋=2`) under atomic
+  admission (`chunked_prefill_size=0`). Raise `max_prefill_tokens` via
+  `server_args_overrides` only when you need larger LM-side encoder CUDA Graph
+  buckets without pre-LM.
+- Pre-LM encoder is enabled by default (`pre_lm_max_batch_size=8`); set
+  `enable_pre_lm_encoder: false` to run the encoder inside prefill again.
+- Chunked prefill stays disabled because the Whisper encoder prefix must be
   admitted atomically. Requests that exceed the current prefill budget wait
   for the next batch instead of splitting the encoder prefix.
 - Use `response_format=json`; other response formats are not validated for this

--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -163,8 +163,17 @@ done
 ```
 
 Standalone async-decode A/B (without pre-LM) previously showed only a small
-c1 gain and regressions at high concurrency; re-run the recipe above on top of
-pre-LM before treating async as a default win.
+c1 gain and regressions at high concurrency. Stacked on pre-LM (same SeedTTS
+EN 20-clip setup, H200, `openai/whisper-base`, FP16), async lookahead
+(`min_batch_size=1`) improved throughput at every measured concurrency with
+unchanged corpus WER `0.0415`:
+
+| Concurrency | Sync+preLM req/s | Async+preLM req/s | Throughput gain | Sync mean latency (s) | Async mean latency (s) |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 22.627 | 24.431 | +8.0% | 0.044 | 0.041 |
+| 2 | 40.258 | 43.586 | +8.3% | 0.049 | 0.046 |
+| 4 | 62.413 | 66.391 | +6.4% | 0.063 | 0.060 |
+| 8 | 81.039 | 86.206 | +6.4% | 0.094 | 0.087 |
 
 ## Known Limitations
 

--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -22,7 +22,12 @@ sgl-omni serve \
 
 ## Encoder CUDA Graph
 
-The encoder CUDA Graph is enabled by default for the pipeline. The final bucket set is resolved from the serving prefill budget and the checkpoint's encoder prefix length. The default prefill budget is **4,096** tokens (`4096 // 1500 = 2`), so LM-side encoder graph batches **1/2** are captured when the encoder still runs inside prefill. With the default pre-LM path, high-concurrency encoder batching uses `pre_lm_max_batch_size` instead. To use eager encoder execution, override the pipeline configuration:
+The encoder CUDA Graph is enabled by default for the pipeline. The final bucket
+set is resolved from the serving prefill budget and the checkpoint's encoder
+prefix length. The default prefill budget is **4,096** tokens
+(`4096 // 1500 = 2`), so LM-side encoder graph batches **1/2** are captured
+when the encoder runs inside prefill. To use eager encoder execution, override
+the pipeline configuration:
 
 ```yaml
 config_cls: WhisperASRPipelineConfig
@@ -34,23 +39,12 @@ runtime_overrides:
     enable_encoder_cuda_graph: false
 ```
 
-The graph is captured after SGLang's generation graphs. Raise `max_prefill_tokens` further before configuring larger buckets (12/16). Each request uses the smallest captured bucket that fits its batch. Requests larger than every captured bucket, with a different feature shape, or without a successful capture run eagerly. Startup and first-replay logs identify the captured and executed buckets.
-
-## Pre-LM Encoder (W-PR7)
-
-By default Whisper runs the audio encoder on a dedicated pre-LM worker thread/stream **before** LM admission (same pattern as Qwen3-ASR / Fun-ASR). Encoder hidden states are attached as `precomputed_embeddings`; the scheduler prefill only writes cross-attention KV and still requires **atomic** encoder-prefix admission (`chunked_prefill_size=0`).
-
-```yaml
-runtime_overrides:
-  asr:
-    enable_pre_lm_encoder: true   # default
-    pre_lm_max_batch_size: 8
-    pre_lm_cache_max_entries: 4096
-    pre_lm_cache_size_bytes: 2147483648
-    pre_lm_max_batch_wait_ms: 0
-```
-
-Disable with `enable_pre_lm_encoder: false` to fall back to encoder-inside-prefill. Warm repeats of the same audio hit the CPU LRU and skip mel + encode. Raise `max_prefill_tokens` via `server_args_overrides` only if you need larger LM-side encoder CUDA Graph buckets without pre-LM.
+The graph is captured after SGLang's generation graphs. Raise
+`max_prefill_tokens` further before configuring larger buckets (12/16). Each
+request uses the smallest captured bucket that fits its batch. Requests larger
+than every captured bucket, with a different feature shape, or without a
+successful capture run eagerly. Startup and first-replay logs identify the
+captured and executed buckets.
 
 ## Transcribe Audio
 
@@ -126,12 +120,13 @@ All 480 measured requests completed successfully. Corpus WER was unchanged acros
   for validated ASR serving.
 - Encoder CUDA Graph is enabled by default and requires SGLang generation CUDA
   Graph. Validate the selected buckets before production use.
+- Audio encoding runs before LM admission by default
+  (`pre_lm_max_batch_size=8`). Set `enable_pre_lm_encoder: false` under
+  `runtime_overrides.asr` to run the encoder inside prefill again.
 - Prefill budget defaults to 4,096 tokens (`⌊4096/1500⌋=2`) under atomic
   admission (`chunked_prefill_size=0`). Raise `max_prefill_tokens` via
   `server_args_overrides` only when you need larger LM-side encoder CUDA Graph
-  buckets without pre-LM.
-- Pre-LM encoder is enabled by default (`pre_lm_max_batch_size=8`); set
-  `enable_pre_lm_encoder: false` to run the encoder inside prefill again.
+  buckets with the encoder inside prefill.
 - Chunked prefill stays disabled because the Whisper encoder prefix must be
   admitted atomically. Requests that exceed the current prefill budget wait
   for the next batch instead of splitting the encoder prefix.

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -38,11 +38,12 @@ _ASYNC_DECODE_FACTORIES = frozenset(
         "create_sglang_moss_transcribe_diarize_executor",
         "sglang_omni.models.fun_asr.stages.create_sglang_fun_asr_executor",
         "sglang_omni.models.qwen3_asr.stages.create_sglang_qwen3_asr_executor",
+        "sglang_omni.models.whisper_asr.stages.create_sglang_whisper_asr_executor",
     }
 )
 _ASYNC_DECODE_SUPPORTED_MODELS = (
     "Higgs TTS, MOSS-TTS-Local, MOSS-Transcribe-Diarize, Fun-ASR, "
-    "Qwen3-ASR, and the Qwen3-Omni thinker"
+    "Qwen3-ASR, Whisper ASR, and the Qwen3-Omni thinker"
 )
 _PREFILL_COALESCE_FACTORIES = frozenset(
     {
@@ -1265,7 +1266,7 @@ def serve(
                 "default. Async mode enables one-step lookahead, "
                 "which can overlap the previous step's host-side collect with "
                 "the next GPU forward. Available for Higgs TTS, MOSS-TTS-Local, "
-                "MOSS-Transcribe-Diarize, Fun-ASR, and Qwen3-ASR."
+                "MOSS-Transcribe-Diarize, Fun-ASR, Qwen3-ASR, and Whisper ASR."
             ),
         ),
     ] = None,
@@ -1277,7 +1278,7 @@ def serve(
             help=(
                 "Decode batches smaller than this bypass async lookahead and "
                 "run synchronously (fast path). Model default: 1 for "
-                "Qwen3-ASR and 2 for other supported models."
+                "Qwen3-ASR and Whisper ASR, and 2 for other supported models."
             ),
         ),
     ] = None,

--- a/sglang_omni/models/whisper_asr/config.py
+++ b/sglang_omni/models/whisper_asr/config.py
@@ -33,6 +33,11 @@ class WhisperASRPipelineConfig(PipelineConfig):
             factory_args={
                 "device": "cuda:0",
                 "enable_encoder_cuda_graph": True,
+                "enable_pre_lm_encoder": True,
+                "pre_lm_cache_max_entries": 4096,
+                "pre_lm_cache_size_bytes": 2 * 1024**3,
+                "pre_lm_max_batch_size": 8,
+                "pre_lm_max_batch_wait_ms": 0,
             },
             gpu=0,
             terminal=True,

--- a/sglang_omni/models/whisper_asr/encoder_service.py
+++ b/sglang_omni/models/whisper_asr/encoder_service.py
@@ -1,0 +1,411 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Precompute and cache Whisper encoder hidden states before LM admission."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import contextlib
+import hashlib
+import json
+import logging
+import queue
+import threading
+import time
+from collections.abc import Iterator
+from typing import Any, cast
+
+import torch
+from sglang.srt.managers.schedule_batch import MultimodalInputFormat
+
+from sglang_omni.scheduling.pre_lm_encoder import PreLMEncoderService, QueueEntry
+from sglang_omni.scheduling.stage_cache import StageOutputCache
+
+logger = logging.getLogger(__name__)
+
+_CACHE_MAX_ENTRIES = 4096
+_CACHE_MAX_BYTES = 2 * 1024**3
+_SHUTDOWN = object()
+
+
+def build_cache_namespace(
+    model: Any,
+    *,
+    model_path: str,
+    feature_extractor: Any,
+) -> str:
+    """Digest identifying this process's encoder pipeline for cache keying."""
+    config = model.config
+    try:
+        model_config: Any = config.to_dict()
+    except AttributeError:
+        model_config = repr(config)
+    reference = next(model.model.encoder.parameters())
+    payload = {
+        "model_path": model_path,
+        "model_config": model_config,
+        "frontend": {
+            "feature_size": feature_extractor.feature_size,
+            "sampling_rate": feature_extractor.sampling_rate,
+            "hop_length": feature_extractor.hop_length,
+            "chunk_length": feature_extractor.chunk_length,
+            "n_fft": feature_extractor.n_fft,
+            "nb_max_frames": feature_extractor.nb_max_frames,
+            "padding_value": feature_extractor.padding_value,
+        },
+        "dtype": str(reference.dtype),
+        "device_type": reference.device.type,
+    }
+    blob = json.dumps(payload, sort_keys=True, default=str).encode()
+    return hashlib.blake2b(blob, digest_size=8).hexdigest()
+
+
+def _expected_audio_tokens(item: Any) -> int | None:
+    num_tokens = item.num_audio_tokens
+    return int(num_tokens) if num_tokens is not None else None
+
+
+class WhisperPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Tensor]):
+    """Encode before admission with single-flight deduplication and a CPU LRU."""
+
+    ENCODE_TIMEOUT_S = 300.0
+
+    def __init__(
+        self,
+        model: Any,
+        *,
+        cache_namespace: str,
+        cache_max_entries: int = _CACHE_MAX_ENTRIES,
+        cache_max_bytes: int = _CACHE_MAX_BYTES,
+        max_batch_size: int = 8,
+        max_batch_wait_ms: int = 0,
+    ) -> None:
+        self._model = model
+        reference = next(model.model.encoder.parameters())
+        self._device = reference.device
+        self._dtype = reference.dtype
+        self._hidden_size = int(model.config.d_model)
+        self._stream = (
+            torch.cuda.Stream(device=self._device)
+            if self._device.type == "cuda"
+            else None
+        )
+        self._cache = StageOutputCache(
+            max_size=cache_max_entries,
+            max_bytes=cache_max_bytes,
+            cache_device="cpu",
+        )
+        self._namespace = cache_namespace
+        self._max_batch_size = max(int(max_batch_size), 1)
+        self._max_batch_wait_s = max(float(max_batch_wait_ms), 0.0) / 1000.0
+        self._lock = threading.Lock()
+        self._lifecycle_lock = threading.Lock()
+        self._closed = False
+        self._inflight: dict[str, concurrent.futures.Future[torch.Tensor]] = {}
+        self._hits = 0
+        self._misses = 0
+        self._merged = 0
+        self._failed = 0
+        self._batch_count = 0
+        self._item_count = 0
+        self._queue_wait_count = 0
+        self._queue_wait_total_s = 0.0
+        self._queue_wait_max_s = 0.0
+        self._encoder_time_s = 0.0
+        super().__init__(worker_name="whisper-asr-audio-encode")
+
+    def close(self) -> None:
+        with self._lifecycle_lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._queue.put(_SHUTDOWN)
+        self._thread.join(timeout=5)
+
+    def _enqueue(
+        self,
+        item: Any,
+        future: concurrent.futures.Future[torch.Tensor],
+    ) -> None:
+        with self._lifecycle_lock:
+            if self._closed:
+                raise RuntimeError("Whisper ASR pre-LM encoder service is closed")
+            self._queue.put(
+                QueueEntry(
+                    item=item,
+                    future=future,
+                    enqueued_at=time.perf_counter(),
+                )
+            )
+
+    def encode_item(self, item: Any) -> None:
+        """Block until item.precomputed_embeddings holds encoder states."""
+        expected_tokens = _expected_audio_tokens(item)
+        if expected_tokens is None:
+            raise RuntimeError(
+                "Whisper pre-LM encode requires the item's num_audio_tokens"
+            )
+        key = self._cache_key(item)
+
+        if key is None:
+            future = self._submit(item)
+            future.result(timeout=self.ENCODE_TIMEOUT_S)
+            return
+
+        cached = self.lookup_cached_embedding(item.audio_fingerprint, expected_tokens)
+        if cached is not None:
+            self.attach_embedding(item, cached)
+            return
+
+        leader = False
+        with self._lock:
+            future = self._inflight.get(key)
+            if future is None:
+                cached = self._cache.get(key)
+                if cached is not None and self._is_valid(cached, expected_tokens):
+                    self._hits += 1
+                else:
+                    cached = None
+                    future = concurrent.futures.Future()
+                    self._inflight[key] = future
+                    leader = True
+                    self._misses += 1
+                    try:
+                        self._submit(item, future)
+                    except Exception:
+                        del self._inflight[key]
+                        raise
+            else:
+                self._merged += 1
+        if cached is not None:
+            self.attach_embedding(item, cached)
+            return
+        try:
+            embedding = future.result(timeout=self.ENCODE_TIMEOUT_S)
+        except Exception:
+            with self._lock:
+                self._failed += 1
+            raise
+        finally:
+            if leader:
+                with self._lock:
+                    if self._inflight.get(key) is future:
+                        del self._inflight[key]
+        if leader:
+            return
+        if not self._is_valid(embedding, expected_tokens):
+            with self._lock:
+                self._failed += 1
+            raise RuntimeError(
+                f"Whisper pre-LM encode leader for {key} returned an invalid "
+                f"embedding"
+            )
+        self.attach_embedding(item, embedding)
+
+    def lookup_cached_embedding(
+        self,
+        audio_fingerprint: str | None,
+        expected_tokens: int,
+    ) -> torch.Tensor | None:
+        """Return a validated cached embedding without starting an encode."""
+        key = self._cache_key_from_fingerprint(audio_fingerprint)
+        cached = self._cache.get(key)
+        if cached is None:
+            return None
+        if self._is_valid(cached, expected_tokens):
+            with self._lock:
+                self._hits += 1
+            return cached
+        logger.warning(
+            f"Whisper pre-LM cache entry {key} failed validation "
+            f"(shape={tuple(cached.shape)}, dtype={cached.dtype}); "
+            f"discarding it if unchanged before re-encoding"
+        )
+        self._cache.remove_if_same(key, cached)
+        return None
+
+    def stats(self) -> dict[str, int | float]:
+        with self._lock:
+            cache_lookups = self._hits + self._misses
+            return {
+                "hits": self._hits,
+                "misses": self._misses,
+                "merged": self._merged,
+                "failed": self._failed,
+                "cache_hit_rate": (
+                    self._hits / cache_lookups if cache_lookups else 0.0
+                ),
+                "batches": self._batch_count,
+                "items": self._item_count,
+                "queue_depth": self._queue.qsize(),
+                "queue_wait_avg_s": (
+                    self._queue_wait_total_s / self._queue_wait_count
+                    if self._queue_wait_count
+                    else 0.0
+                ),
+                "queue_wait_max_s": self._queue_wait_max_s,
+                "encoder_time_s": self._encoder_time_s,
+                "cache_entries": len(self._cache),
+                "cache_bytes": self._cache.current_bytes,
+                "cache_evictions": self._cache.eviction_count,
+            }
+
+    def _cache_key(self, item: Any) -> str | None:
+        return self._cache_key_from_fingerprint(item.audio_fingerprint)
+
+    def _cache_key_from_fingerprint(self, audio_fingerprint: str | None) -> str | None:
+        if audio_fingerprint is None:
+            return None
+        return f"{self._namespace}:{audio_fingerprint}"
+
+    def _is_valid(self, embedding: Any, expected_tokens: int) -> bool:
+        return (
+            isinstance(embedding, torch.Tensor)
+            and embedding.dim() == 2
+            and embedding.shape[0] == expected_tokens
+            and embedding.shape[1] == self._hidden_size
+            and embedding.dtype == self._dtype
+        )
+
+    def attach_embedding(self, item: Any, embedding: torch.Tensor) -> None:
+        embedding = embedding.to(self._device, non_blocking=True)
+        if self._stream is not None and embedding.is_cuda:
+            embedding.record_stream(torch.cuda.default_stream(self._device))
+        item.precomputed_embeddings = embedding
+        item.feature = None
+        item.format = MultimodalInputFormat.PRECOMPUTED_EMBEDDING
+
+    def _drain_batch(self) -> tuple[list[QueueEntry[Any]], bool]:
+        first = self._queue.get()
+        if first is _SHUTDOWN:
+            return [], True
+        batch = [cast(QueueEntry[Any], first)]
+        deadline = time.monotonic() + self._max_batch_wait_s
+        shutdown = False
+        while len(batch) < self._max_batch_size:
+            try:
+                remaining = deadline - time.monotonic()
+                queued = (
+                    self._queue.get(timeout=remaining)
+                    if remaining > 0
+                    else self._queue.get_nowait()
+                )
+            except queue.Empty:
+                break
+            if queued is _SHUTDOWN:
+                shutdown = True
+                break
+            batch.append(cast(QueueEntry[Any], queued))
+        return batch, shutdown
+
+    def _next_batch(self) -> tuple[list[QueueEntry[Any]], bool]:
+        return self._drain_batch()
+
+    @contextlib.contextmanager
+    def _batch_context(self) -> Iterator[None]:
+        with torch.inference_mode():
+            if self._stream is None:
+                yield
+            else:
+                with torch.cuda.stream(self._stream):
+                    yield
+
+    def encode_batch(self, items: list[Any]) -> torch.Tensor:
+        return self._model.encode_audio_features(items)
+
+    def split_embeddings(
+        self,
+        items: list[Any],
+        encoded: torch.Tensor,
+    ) -> list[torch.Tensor]:
+        if encoded.dim() != 3:
+            raise RuntimeError(
+                f"Whisper encoder output rank {encoded.dim()} != 3 "
+                f"(expected [B, T, H])"
+            )
+        if encoded.shape[0] != len(items):
+            raise RuntimeError(
+                f"Whisper encoder batch {encoded.shape[0]} != {len(items)} items"
+            )
+        if encoded.shape[2] != self._hidden_size or encoded.dtype != self._dtype:
+            raise RuntimeError(
+                f"Whisper encoder output {tuple(encoded.shape)} ({encoded.dtype}) "
+                f"!= expected hidden {self._hidden_size} ({self._dtype})"
+            )
+        parts: list[torch.Tensor] = []
+        for index, item in enumerate(items):
+            expected = _expected_audio_tokens(item)
+            if expected is None:
+                raise RuntimeError(
+                    "Whisper pre-LM encode item is missing its audio token count"
+                )
+            if encoded.shape[1] < expected:
+                raise RuntimeError(
+                    f"Whisper encoder T={encoded.shape[1]} < expected {expected}"
+                )
+            parts.append(encoded[index, :expected].clone())
+        return parts
+
+    def synchronize_batch(self) -> None:
+        if self._stream is not None:
+            self._stream.synchronize()
+
+    def cache_embedding(self, item: Any, embedding: torch.Tensor) -> None:
+        key = self._cache_key(item)
+        if key is not None:
+            self._cache.put(key, embedding)
+
+    def _retry_batch(self, batch: list[QueueEntry[Any]], _exc: Exception) -> bool:
+        if len(batch) == 1:
+            return False
+        logger.exception(
+            "Whisper batched audio encode failed for %d items; retrying per item",
+            len(batch),
+        )
+        return True
+
+    def _on_batch_start(self, batch: list[QueueEntry[Any]]) -> None:
+        dequeue_time = time.perf_counter()
+        queue_waits = [
+            dequeue_time - entry.enqueued_at
+            for entry in batch
+            if entry.enqueued_at is not None
+        ]
+        with self._lock:
+            self._queue_wait_count += len(queue_waits)
+            self._queue_wait_total_s += sum(queue_waits)
+            self._queue_wait_max_s = max(
+                self._queue_wait_max_s,
+                max(queue_waits, default=0.0),
+            )
+
+    def _on_batch_finished(
+        self,
+        batch: list[QueueEntry[Any]],
+        batch_exc: Exception | None,
+        retry_recovered: int | None,
+        elapsed_s: float,
+    ) -> None:
+        with self._lock:
+            self._encoder_time_s += elapsed_s
+            if batch_exc is not None:
+                if retry_recovered is not None:
+                    self._batch_count += retry_recovered
+                    self._item_count += retry_recovered
+                return
+            self._batch_count += 1
+            self._item_count += len(batch)
+            batch_count = self._batch_count
+            item_count = self._item_count
+        if batch_count % 50 == 1:
+            logger.info(
+                f"Whisper pre-LM encoder stage: {batch_count} batches, "
+                f"{item_count} items (avg "
+                f"{item_count / batch_count:.2f} items/batch, "
+                f"last batch: {len(batch)}), cache: {self.stats()}"
+            )
+
+
+__all__ = [
+    "WhisperPreLMEncoderService",
+    "build_cache_namespace",
+]

--- a/sglang_omni/models/whisper_asr/engine_builder.py
+++ b/sglang_omni/models/whisper_asr/engine_builder.py
@@ -55,6 +55,8 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
         pre_lm_cache_size_bytes: int = 2 * 1024**3,
         pre_lm_max_batch_size: int = 8,
         pre_lm_max_batch_wait_ms: int = 0,
+        enable_async_decode: bool = True,
+        async_decode_min_batch_size: int = 1,
     ) -> None:
         if pre_lm_max_batch_size < 1:
             raise ValueError(
@@ -76,6 +78,8 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
         self.pre_lm_cache_size_bytes = int(pre_lm_cache_size_bytes)
         self.pre_lm_max_batch_size = int(pre_lm_max_batch_size)
         self.pre_lm_max_batch_wait_ms = int(pre_lm_max_batch_wait_ms)
+        self.enable_async_decode = enable_async_decode
+        self.async_decode_min_batch_size = async_decode_min_batch_size
         self.processor: Any = None
         self.tokenizer: Any = None
         self.generation_config: Any = None
@@ -192,6 +196,12 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
             decoder_context_len=self.decoder_context_len,
             audio_encoder_service=self.audio_encoder_service,
         )
+
+    def extra_scheduler_kwargs(self) -> dict[str, Any]:
+        return {
+            "enable_async_decode": self.enable_async_decode,
+            "async_decode_min_batch_size": self.async_decode_min_batch_size,
+        }
 
     def extra_scheduler_callbacks(self) -> dict[str, Any]:
         if self.audio_encoder_service is None:

--- a/sglang_omni/models/whisper_asr/engine_builder.py
+++ b/sglang_omni/models/whisper_asr/engine_builder.py
@@ -6,6 +6,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from sglang_omni.models.whisper_asr.encoder_service import (
+    WhisperPreLMEncoderService,
+    build_cache_namespace,
+)
 from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
 
 logger = logging.getLogger(__name__)
@@ -46,7 +50,20 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
         mem_fraction_static: float,
         enable_encoder_cuda_graph: bool = False,
         encoder_graph_batch_buckets: list[int] | None = None,
+        enable_pre_lm_encoder: bool = True,
+        pre_lm_cache_max_entries: int = 4096,
+        pre_lm_cache_size_bytes: int = 2 * 1024**3,
+        pre_lm_max_batch_size: int = 8,
+        pre_lm_max_batch_wait_ms: int = 0,
     ) -> None:
+        if pre_lm_max_batch_size < 1:
+            raise ValueError(
+                f"pre_lm_max_batch_size must be >= 1, got {pre_lm_max_batch_size}"
+            )
+        if pre_lm_max_batch_wait_ms < 0:
+            raise ValueError(
+                f"pre_lm_max_batch_wait_ms must be >= 0, got {pre_lm_max_batch_wait_ms}"
+            )
         self.max_running_requests = max_running_requests
         self.max_new_tokens = max_new_tokens
         self.mem_fraction_static = mem_fraction_static
@@ -54,12 +71,18 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
         self.encoder_graph_batch_buckets = _normalize_encoder_graph_buckets(
             encoder_graph_batch_buckets
         )
+        self.enable_pre_lm_encoder = bool(enable_pre_lm_encoder)
+        self.pre_lm_cache_max_entries = int(pre_lm_cache_max_entries)
+        self.pre_lm_cache_size_bytes = int(pre_lm_cache_size_bytes)
+        self.pre_lm_max_batch_size = int(pre_lm_max_batch_size)
+        self.pre_lm_max_batch_wait_ms = int(pre_lm_max_batch_wait_ms)
         self.processor: Any = None
         self.tokenizer: Any = None
         self.generation_config: Any = None
         self.encoder_token_count = 0
         self.context_length = 0
         self.decoder_context_len = 0
+        self.audio_encoder_service: Any | None = None
 
     def pre_infra_setup(self, checkpoint_dir: str) -> None:
         from transformers import AutoConfig, AutoProcessor, GenerationConfig
@@ -77,12 +100,8 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
         self.context_length = (
             self.encoder_token_count + MAX_PREV_CONTEXT_TOKENS + self.max_new_tokens + 8
         )
-        # note (jiannan-17): prev_len + prefix_len + max_new_tokens <= decoder_context_len
         self.decoder_context_len = int(
-            getattr(
-                AutoConfig.from_pretrained(checkpoint_dir), "max_target_positions", 0
-            )
-            or 448
+            AutoConfig.from_pretrained(checkpoint_dir).max_target_positions or 448
         )
 
     def setup_model_resources(
@@ -111,6 +130,31 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
                 resolved_buckets,
                 int(self.processor.feature_extractor.nb_max_frames),
             )
+
+    def setup_runtime_resources(self, model: Any, server_args: Any) -> None:
+        del server_args
+        if not self.enable_pre_lm_encoder:
+            return
+
+        self.audio_encoder_service = WhisperPreLMEncoderService(
+            model,
+            cache_namespace=build_cache_namespace(
+                model,
+                model_path=self.checkpoint_dir,
+                feature_extractor=self.processor.feature_extractor,
+            ),
+            cache_max_entries=self.pre_lm_cache_max_entries,
+            cache_max_bytes=self.pre_lm_cache_size_bytes,
+            max_batch_size=self.pre_lm_max_batch_size,
+            max_batch_wait_ms=self.pre_lm_max_batch_wait_ms,
+        )
+        logger.info(
+            "Whisper pre-LM encoder enabled "
+            "(max_batch=%d, cache_entries=%d, cache_bytes=%d)",
+            self.pre_lm_max_batch_size,
+            self.pre_lm_cache_max_entries,
+            self.pre_lm_cache_size_bytes,
+        )
 
     def adjust_overrides(self, overrides: dict[str, Any]) -> None:
         if int(overrides.get("chunked_prefill_size") or 0) > 0:
@@ -146,4 +190,15 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
             encoder_token_count=self.encoder_token_count,
             max_new_tokens=self.max_new_tokens,
             decoder_context_len=self.decoder_context_len,
+            audio_encoder_service=self.audio_encoder_service,
         )
+
+    def extra_scheduler_callbacks(self) -> dict[str, Any]:
+        if self.audio_encoder_service is None:
+            return {}
+        return {"shutdown_callback": self.audio_encoder_service.close}
+
+    def cleanup_build_failure(self) -> None:
+        if self.audio_encoder_service is not None:
+            self.audio_encoder_service.close()
+            self.audio_encoder_service = None

--- a/sglang_omni/models/whisper_asr/request_builders.py
+++ b/sglang_omni/models/whisper_asr/request_builders.py
@@ -52,7 +52,7 @@ def _resolve_language(value: Any) -> str:
 
 
 def _build_logit_bias(generation_config: GenerationConfig) -> dict[str, float] | None:
-    suppress_tokens = getattr(generation_config, "suppress_tokens", None)
+    suppress_tokens = generation_config.suppress_tokens
     if not suppress_tokens:
         return None
     return {str(int(token_id)): -1.0e9 for token_id in suppress_tokens if token_id >= 0}
@@ -110,6 +110,7 @@ def make_whisper_scheduler_adapters(
     encoder_token_count: int,
     max_new_tokens: int,
     decoder_context_len: int | None = None,
+    audio_encoder_service: Any | None = None,
 ) -> tuple[
     Callable[[StagePayload], WhisperASRRequestData], Callable[[Any], StagePayload]
 ]:
@@ -121,7 +122,7 @@ def make_whisper_scheduler_adapters(
     # to generation_config.max_length, then to Whisper's default 448 positions.
     decoder_context_len = int(
         decoder_context_len
-        or getattr(generation_config, "max_length", None)
+        or generation_config.max_length
         or _DEFAULT_DECODER_CONTEXT_LEN
     )
 
@@ -162,21 +163,37 @@ def make_whisper_scheduler_adapters(
             )
         input_ids = [pad_token_id] * encoder_token_count + prompt_token_ids
 
-        features = processor.feature_extractor(
-            audio,
-            sampling_rate=_WHISPER_SAMPLE_RATE,
-            return_tensors="pt",
-        ).input_features
+        features = None
+        cached_embedding = None
+        if audio_encoder_service is not None:
+            cached_embedding = audio_encoder_service.lookup_cached_embedding(
+                fingerprint, encoder_token_count
+            )
+        if cached_embedding is None:
+            features = processor.feature_extractor(
+                audio,
+                sampling_rate=_WHISPER_SAMPLE_RATE,
+                return_tensors="pt",
+            ).input_features
+
+        audio_item = MultimodalDataItem(
+            modality=Modality.AUDIO,
+            hash=prepared.fingerprint_int,
+            feature=features,
+            model_specific_data={
+                "audio_fingerprint": fingerprint,
+                "num_audio_tokens": encoder_token_count,
+            },
+        )
         mm_inputs = MultimodalInputs(
-            mm_items=[
-                MultimodalDataItem(
-                    modality=Modality.AUDIO,
-                    hash=prepared.fingerprint_int,
-                    feature=features,
-                )
-            ],
+            mm_items=[audio_item],
             num_image_tokens=encoder_token_count,
         )
+        if audio_encoder_service is not None:
+            if cached_embedding is None:
+                audio_encoder_service.encode_item(audio_item)
+            else:
+                audio_encoder_service.attach_embedding(audio_item, cached_embedding)
 
         temperature = float(params.get("temperature") or 0.0)
         sampling_params = SamplingParams(

--- a/sglang_omni/models/whisper_asr/sglang_model.py
+++ b/sglang_omni/models/whisper_asr/sglang_model.py
@@ -9,6 +9,7 @@ CUDA Graph, and torch.compile paths apply to decode.
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Iterable, Tuple
 
 import torch
@@ -25,6 +26,8 @@ from transformers.activations import ACT2FN
 from sglang_omni.models.whisper_asr.encoder_cuda_graph import (
     WhisperEncoderCudaGraphRunner,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class WhisperEncoderAttention(nn.Module):
@@ -351,6 +354,36 @@ class WhisperForConditionalGeneration(nn.Module):
         )
         self._encoder_graph_runner.capture(batch_buckets)
 
+    def _run_encoder(self, audio_features: torch.Tensor) -> torch.Tensor:
+        """Run the Whisper encoder with CUDA-graph replay when available."""
+        if self._encoder_graph_runner is not None:
+            try:
+                return self._encoder_graph_runner.run(audio_features)
+            except Exception:
+                logger.exception(
+                    "Whisper encoder CUDA graph replay failed; falling back to eager"
+                )
+        return self.model.encoder(audio_features)
+
+    def encode_audio_features(self, items: list[Any]) -> torch.Tensor:
+        """Batch-encode mel features into encoder states [B, T, H]."""
+        if not items:
+            raise ValueError(
+                "Whisper encode_audio_features requires at least one audio item"
+            )
+        features: list[torch.Tensor] = []
+        reference = next(self.model.encoder.parameters())
+        for item in items:
+            feature = item.feature
+            if feature is None:
+                raise RuntimeError(
+                    "Whisper audio item is missing mel features; cannot encode"
+                )
+            if not isinstance(feature, torch.Tensor):
+                feature = torch.as_tensor(feature)
+            features.append(feature.to(device=reference.device, dtype=reference.dtype))
+        return self._run_encoder(torch.cat(features, dim=0))
+
     def _batch_audio_inputs(
         self,
         forward_batch: ForwardBatch,
@@ -374,6 +407,36 @@ class WhisperForConditionalGeneration(nn.Module):
         if not features:
             return None, None
         return torch.cat(features, dim=0), encoder_lens
+
+    def _batch_precomputed_encoder_states(
+        self,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor | None:
+        """Collect pre-LM encoder hiddens into a flat cross-attn tensor."""
+        if forward_batch.forward_mode.is_decode() or all(forward_batch.encoder_cached):
+            return None
+
+        parts: list[torch.Tensor] = []
+        for index, mm_input in enumerate(forward_batch.mm_inputs):
+            if forward_batch.encoder_cached[index] or mm_input is None:
+                continue
+            encoder_len = int(forward_batch.encoder_lens[index].item())
+            for item in mm_input.mm_items:
+                embedding = item.precomputed_embeddings
+                if embedding is None:
+                    continue
+                if not isinstance(embedding, torch.Tensor):
+                    embedding = torch.as_tensor(embedding)
+                if embedding.dim() != 2 or embedding.shape[0] < encoder_len:
+                    raise RuntimeError(
+                        "Whisper precomputed encoder states "
+                        f"{tuple(embedding.shape)} incompatible with "
+                        f"encoder_len={encoder_len}"
+                    )
+                parts.append(embedding[:encoder_len])
+        if not parts:
+            return None
+        return torch.cat(parts, dim=0)
 
     @staticmethod
     def _flat_encoder_result(
@@ -407,19 +470,22 @@ class WhisperForConditionalGeneration(nn.Module):
             get_is_capture_mode,
         )
 
-        audio_features, encoder_lens = self._batch_audio_inputs(forward_batch)
-        cross_attention_states = None
+        cross_attention_states = self._batch_precomputed_encoder_states(forward_batch)
+        audio_features, encoder_lens = (None, None)
+        if cross_attention_states is None:
+            audio_features, encoder_lens = self._batch_audio_inputs(forward_batch)
 
         if get_is_capture_mode():
             skip_cross_attention = False
         else:
             skip_cross_attention = forward_batch.encoder_lens.max() == 0
 
-        if audio_features is not None and encoder_lens is not None:
-            if self._encoder_graph_runner is not None:
-                encoder_states = self._encoder_graph_runner.run(audio_features)
-            else:
-                encoder_states = self.model.encoder(audio_features)
+        if (
+            cross_attention_states is None
+            and audio_features is not None
+            and encoder_lens is not None
+        ):
+            encoder_states = self._run_encoder(audio_features)
             cross_attention_states = self._flat_encoder_result(
                 encoder_states,
                 encoder_lens,

--- a/sglang_omni/models/whisper_asr/stages.py
+++ b/sglang_omni/models/whisper_asr/stages.py
@@ -21,6 +21,8 @@ def create_sglang_whisper_asr_executor(
     pre_lm_cache_size_bytes: int = 2 * 1024**3,
     pre_lm_max_batch_size: int = 8,
     pre_lm_max_batch_wait_ms: int = 0,
+    enable_async_decode: bool = True,
+    async_decode_min_batch_size: int = 1,
     server_args_overrides: dict[str, Any] | None = None,
 ):
     from sglang_omni.models.whisper_asr.engine_builder import WhisperASREngineBuilder
@@ -36,6 +38,8 @@ def create_sglang_whisper_asr_executor(
         pre_lm_cache_size_bytes=pre_lm_cache_size_bytes,
         pre_lm_max_batch_size=pre_lm_max_batch_size,
         pre_lm_max_batch_wait_ms=pre_lm_max_batch_wait_ms,
+        enable_async_decode=enable_async_decode,
+        async_decode_min_batch_size=async_decode_min_batch_size,
     ).build(
         model_path,
         device=device,

--- a/sglang_omni/models/whisper_asr/stages.py
+++ b/sglang_omni/models/whisper_asr/stages.py
@@ -16,6 +16,11 @@ def create_sglang_whisper_asr_executor(
     mem_fraction_static: float = 0.85,
     enable_encoder_cuda_graph: bool = False,
     encoder_graph_batch_buckets: list[int] | None = None,
+    enable_pre_lm_encoder: bool = True,
+    pre_lm_cache_max_entries: int = 4096,
+    pre_lm_cache_size_bytes: int = 2 * 1024**3,
+    pre_lm_max_batch_size: int = 8,
+    pre_lm_max_batch_wait_ms: int = 0,
     server_args_overrides: dict[str, Any] | None = None,
 ):
     from sglang_omni.models.whisper_asr.engine_builder import WhisperASREngineBuilder
@@ -26,6 +31,11 @@ def create_sglang_whisper_asr_executor(
         max_new_tokens=max_new_tokens,
         enable_encoder_cuda_graph=enable_encoder_cuda_graph,
         encoder_graph_batch_buckets=encoder_graph_batch_buckets,
+        enable_pre_lm_encoder=enable_pre_lm_encoder,
+        pre_lm_cache_max_entries=pre_lm_cache_max_entries,
+        pre_lm_cache_size_bytes=pre_lm_cache_size_bytes,
+        pre_lm_max_batch_size=pre_lm_max_batch_size,
+        pre_lm_max_batch_wait_ms=pre_lm_max_batch_wait_ms,
     ).build(
         model_path,
         device=device,

--- a/tests/unit_test/higgs_tts/test_cli_decode_mode.py
+++ b/tests/unit_test/higgs_tts/test_cli_decode_mode.py
@@ -20,6 +20,7 @@ from sglang_omni.models.moss_transcribe_diarize.config import (
 )
 from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
 from sglang_omni.models.qwen3_tts.config import Qwen3TTSPipelineConfig
+from sglang_omni.models.whisper_asr.config import WhisperASRPipelineConfig
 
 
 def _tts_engine_args(config: PipelineConfig) -> dict[str, object]:
@@ -94,7 +95,7 @@ def test_decode_mode_cli_rejects_unsupported_config():
         typer.BadParameter,
         match=(
             "Higgs TTS, MOSS-TTS-Local, MOSS-Transcribe-Diarize, Fun-ASR, "
-            "Qwen3-ASR, and the Qwen3-Omni thinker"
+            "Qwen3-ASR, Whisper ASR, and the Qwen3-Omni thinker"
         ),
     ):
         apply_decode_mode_cli_overrides(
@@ -134,6 +135,23 @@ def test_decode_mode_cli_applies_to_fun_asr_stage():
 
 def test_decode_mode_cli_applies_to_qwen3_asr_stage():
     config = Qwen3ASRPipelineConfig(model_path="dummy")
+    apply_decode_mode_cli_overrides(
+        config, decode_mode="async", async_lookahead_min_batch_size=4
+    )
+    stage = next(s for s in config.stages if s.name == "asr")
+    args = resolve_stage_factory_args(stage, config)
+    assert args["enable_async_decode"] is True
+    assert args["async_decode_min_batch_size"] == 4
+
+    apply_decode_mode_cli_overrides(
+        config, decode_mode="sync", async_lookahead_min_batch_size=None
+    )
+    args = resolve_stage_factory_args(stage, config)
+    assert args["enable_async_decode"] is False
+
+
+def test_decode_mode_cli_applies_to_whisper_asr_stage():
+    config = WhisperASRPipelineConfig(model_path="dummy")
     apply_decode_mode_cli_overrides(
         config, decode_mode="async", async_lookahead_min_batch_size=4
     )

--- a/tests/unit_test/whisper_asr/test_encoder_service.py
+++ b/tests/unit_test/whisper_asr/test_encoder_service.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import pytest
+import torch
+from sglang.srt.managers.schedule_batch import MultimodalInputFormat
+
+from sglang_omni.models.whisper_asr.encoder_service import (
+    WhisperPreLMEncoderService,
+    _expected_audio_tokens,
+    build_cache_namespace,
+)
+
+_HIDDEN_SIZE = 8
+_TOKENS = 4
+_NAMESPACE = "whisper-test"
+_SERVICES: list[WhisperPreLMEncoderService] = []
+
+
+@pytest.fixture(autouse=True)
+def _close_services() -> Iterator[None]:
+    yield
+    for service in _SERVICES:
+        service.close()
+    _SERVICES.clear()
+
+
+class _StubEncoder(torch.nn.Module):
+    def __init__(self, dtype: torch.dtype = torch.float32) -> None:
+        super().__init__()
+        self.proj = torch.nn.Linear(2, 2).to(dtype)
+        self.encode_calls = 0
+        self.fail = False
+        self.fail_multi_item = False
+        self.encode_gate: threading.Event | None = None
+
+    def forward(self, audio_features: torch.Tensor) -> torch.Tensor:
+        self.encode_calls += 1
+        gate = self.encode_gate
+        if gate is not None:
+            self.encode_gate = None
+            gate.wait(timeout=10)
+        if self.fail:
+            raise RuntimeError("boom")
+        if self.fail_multi_item and audio_features.shape[0] > 1:
+            raise RuntimeError("multi-item boom")
+        batch = audio_features.shape[0]
+        fill = float(audio_features.reshape(batch, -1)[:, 0].mean().item() + 1.0)
+        return torch.full(
+            (batch, _TOKENS, _HIDDEN_SIZE),
+            fill,
+            dtype=audio_features.dtype,
+            device=audio_features.device,
+        )
+
+
+class _StubModel(torch.nn.Module):
+    def __init__(self, dtype: torch.dtype = torch.float32) -> None:
+        super().__init__()
+        encoder = _StubEncoder(dtype=dtype)
+        self.model = SimpleNamespace(encoder=encoder)
+        self.config = SimpleNamespace(d_model=_HIDDEN_SIZE)
+        self._encoder = encoder
+
+    @property
+    def encode_calls(self) -> int:
+        return self._encoder.encode_calls
+
+    def encode_audio_features(self, items: list[object]) -> torch.Tensor:
+        features: list[torch.Tensor] = []
+        reference = next(self._encoder.parameters())
+        for item in items:
+            feature = getattr(item, "feature", None)
+            if feature is None:
+                raise RuntimeError("missing mel features")
+            if not isinstance(feature, torch.Tensor):
+                feature = torch.as_tensor(feature)
+            features.append(feature.to(device=reference.device, dtype=reference.dtype))
+        return self._encoder(torch.cat(features, dim=0))
+
+
+def _make_item(*, fingerprint: str = "fp", fill: float = 1.0) -> SimpleNamespace:
+    return SimpleNamespace(
+        feature=torch.full((1, 80, 16), fill),
+        precomputed_embeddings=None,
+        format=MultimodalInputFormat.NORMAL,
+        model_specific_data={
+            "audio_fingerprint": fingerprint,
+            "num_audio_tokens": _TOKENS,
+        },
+        audio_fingerprint=fingerprint,
+        num_audio_tokens=_TOKENS,
+    )
+
+
+def _make_service(
+    model: _StubModel | None = None,
+    *,
+    cache_max_entries: int = 16,
+    max_batch_size: int = 8,
+) -> WhisperPreLMEncoderService:
+    service = WhisperPreLMEncoderService(
+        model or _StubModel(),
+        cache_namespace=_NAMESPACE,
+        cache_max_entries=cache_max_entries,
+        cache_max_bytes=1 << 20,
+        max_batch_size=max_batch_size,
+    )
+    _SERVICES.append(service)
+    return service
+
+
+def test_expected_audio_tokens() -> None:
+    assert _expected_audio_tokens(SimpleNamespace(num_audio_tokens=12)) == 12
+    assert _expected_audio_tokens(SimpleNamespace(num_audio_tokens=None)) is None
+
+
+def test_build_cache_namespace_is_stable() -> None:
+    model = _StubModel()
+    fe = SimpleNamespace(
+        feature_size=80,
+        sampling_rate=16000,
+        hop_length=160,
+        chunk_length=30,
+        n_fft=400,
+        nb_max_frames=3000,
+        padding_value=0.0,
+    )
+    a = build_cache_namespace(model, model_path="m", feature_extractor=fe)
+    b = build_cache_namespace(model, model_path="m", feature_extractor=fe)
+    assert a == b
+    assert len(a) == 16
+
+
+def test_encode_item_attaches_and_clears_feature() -> None:
+    service = _make_service()
+    item = _make_item(fill=3.0)
+    service.encode_item(item)
+    assert item.feature is None
+    assert item.precomputed_embeddings is not None
+    assert tuple(item.precomputed_embeddings.shape) == (_TOKENS, _HIDDEN_SIZE)
+    assert item.format == MultimodalInputFormat.PRECOMPUTED_EMBEDDING
+    assert service.stats()["misses"] == 1
+    assert service.stats()["batches"] == 1
+
+
+def test_encode_item_hits_cache_on_second_call() -> None:
+    model = _StubModel()
+    service = _make_service(model)
+    first = _make_item(fingerprint="same", fill=2.0)
+    second = _make_item(fingerprint="same", fill=9.0)
+    service.encode_item(first)
+    service.encode_item(second)
+    assert model.encode_calls == 1
+    assert service.stats()["hits"] == 1
+    assert torch.equal(first.precomputed_embeddings, second.precomputed_embeddings)
+
+
+def test_encode_item_reuses_lookup_cached_embedding() -> None:
+    model = _StubModel()
+    service = _make_service(model)
+    item = _make_item(fingerprint="lookup-reuse")
+    service.encode_item(item)
+    again = _make_item(fingerprint="lookup-reuse", fill=0.0)
+    service.encode_item(again)
+    assert model.encode_calls == 1
+    assert again.feature is None
+
+
+def test_lookup_cached_embedding_skips_worker() -> None:
+    model = _StubModel()
+    service = _make_service(model)
+    item = _make_item(fingerprint="lookup")
+    service.encode_item(item)
+    cached = service.lookup_cached_embedding("lookup", _TOKENS)
+    assert cached is not None
+    assert model.encode_calls == 1
+    assert service.stats()["hits"] >= 1
+
+
+def test_no_fingerprint_does_not_cache() -> None:
+    model = _StubModel()
+    service = _make_service(model)
+    item = _make_item(fingerprint="ignored")
+    item.audio_fingerprint = None
+    item.model_specific_data["audio_fingerprint"] = None
+    service.encode_item(item)
+    assert item.precomputed_embeddings is not None
+    assert service.stats()["misses"] == 0
+    assert service.stats()["hits"] == 0
+    assert len(service._cache) == 0
+
+
+def test_close_rejects_new_encodes() -> None:
+    service = _make_service()
+    service.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        service.encode_item(_make_item())
+
+
+def test_batched_encode_retries_per_item_on_multi_failure() -> None:
+    model = _StubModel()
+    model._encoder.fail_multi_item = True
+    service = _make_service(model, max_batch_size=4)
+    items = [_make_item(fingerprint=f"b{i}", fill=float(i + 1)) for i in range(3)]
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
+        list(pool.map(service.encode_item, items))
+    assert all(item.precomputed_embeddings is not None for item in items)
+    assert model.encode_calls >= 3

--- a/tests/unit_test/whisper_asr/test_pipeline.py
+++ b/tests/unit_test/whisper_asr/test_pipeline.py
@@ -148,10 +148,19 @@ def test_whisper_asr_config_uses_single_batched_stage() -> None:
     assert config.stages[0].factory_args["pre_lm_max_batch_size"] == 8
     assert config.stages[0].factory_args["pre_lm_max_batch_wait_ms"] == 0
     assert "max_prefill_tokens" not in config.stages[0].factory_args
+    assert "enable_async_decode" not in config.stages[0].factory_args
+    assert "async_decode_min_batch_size" not in config.stages[0].factory_args
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("WhisperForConditionalGeneration")
         is WhisperASRPipelineConfig
     )
+
+
+def test_whisper_asr_stage_default_enables_async_decode() -> None:
+    signature = inspect.signature(whisper_asr_stages.create_sglang_whisper_asr_executor)
+
+    assert signature.parameters["enable_async_decode"].default is True
+    assert signature.parameters["async_decode_min_batch_size"].default == 1
 
 
 def test_whisper_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
@@ -234,8 +243,11 @@ def test_whisper_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
         _fake_create_infrastructure,
     )
 
-    whisper_asr_stages.create_sglang_whisper_asr_executor(
-        "dummy", enable_pre_lm_encoder=False
+    scheduler = whisper_asr_stages.create_sglang_whisper_asr_executor(
+        "dummy",
+        enable_pre_lm_encoder=False,
+        enable_async_decode=False,
+        async_decode_min_batch_size=4,
     )
 
     assert build_kwargs["cuda_graph_max_bs"] == 16
@@ -244,3 +256,90 @@ def test_whisper_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
     assert build_kwargs["context_length"] == 1500 + 224 + 256 + 8
     assert build_kwargs["chunked_prefill_size"] == 0
     assert build_kwargs["max_prefill_tokens"] == 4096
+    assert scheduler.enable_async_decode is False
+    assert scheduler.async_decode_min_batch_size == 4
+
+
+def test_whisper_asr_threads_default_async_decode(monkeypatch) -> None:
+    fake_processor = SimpleNamespace(
+        tokenizer=object(),
+        feature_extractor=SimpleNamespace(nb_max_frames=3000),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        SimpleNamespace(
+            AutoConfig=SimpleNamespace(
+                from_pretrained=lambda *args, **kwargs: SimpleNamespace(
+                    max_target_positions=448
+                )
+            ),
+            AutoProcessor=SimpleNamespace(
+                from_pretrained=lambda *args, **kwargs: fake_processor
+            ),
+            GenerationConfig=SimpleNamespace(
+                from_pretrained=lambda *args, **kwargs: object()
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        whisper_request_builders,
+        "make_whisper_scheduler_adapters",
+        lambda **kwargs: (object(), object()),
+    )
+    monkeypatch.setattr(
+        model_runner_base,
+        "ModelRunner",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        sglang_backend,
+        "SGLangOutputProcessor",
+        lambda **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        omni_scheduler,
+        "OmniScheduler",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    def _fake_server_args_builder(model_path, context_length, **overrides):
+        server_args = FakeServerArgs(**overrides)
+        server_args.cuda_graph_config = SimpleNamespace(
+            decode=SimpleNamespace(
+                max_bs=overrides["cuda_graph_max_bs"],
+                bs=overrides["cuda_graph_bs"],
+            ),
+            prefill=SimpleNamespace(backend="disabled", bs=None, max_bs=None),
+        )
+        return server_args
+
+    def _fake_create_infrastructure(server_args, gpu_id, **kwargs):
+        model_worker = SimpleNamespace(model_runner=SimpleNamespace(model=object()))
+        return False, (
+            model_worker,
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+        )
+
+    monkeypatch.setattr(
+        sglang_backend,
+        "build_sglang_server_args",
+        _fake_server_args_builder,
+    )
+    monkeypatch.setattr(
+        bootstrap,
+        "create_sglang_infrastructure_defer_cuda_graph",
+        _fake_create_infrastructure,
+    )
+
+    scheduler = whisper_asr_stages.create_sglang_whisper_asr_executor(
+        "dummy", enable_pre_lm_encoder=False
+    )
+
+    assert scheduler.enable_async_decode is True
+    assert scheduler.async_decode_min_batch_size == 1

--- a/tests/unit_test/whisper_asr/test_pipeline.py
+++ b/tests/unit_test/whisper_asr/test_pipeline.py
@@ -24,6 +24,8 @@ def test_whisper_encoder_cuda_graph_is_opt_in() -> None:
 
     assert signature.parameters["enable_encoder_cuda_graph"].default is False
     assert signature.parameters["encoder_graph_batch_buckets"].default is None
+    assert signature.parameters["enable_pre_lm_encoder"].default is True
+    assert signature.parameters["pre_lm_max_batch_size"].default == 8
 
 
 def test_whisper_encoder_cuda_graph_setup_is_ordered_after_generation_graphs() -> None:
@@ -111,6 +113,25 @@ def test_whisper_disables_chunked_prefill_for_atomic_encoder_prefix() -> None:
         builder.adjust_overrides({"chunked_prefill_size": 4096})
 
 
+def test_whisper_rejects_invalid_pre_lm_batch_knobs() -> None:
+    from sglang_omni.models.whisper_asr.engine_builder import WhisperASREngineBuilder
+
+    with pytest.raises(ValueError, match="pre_lm_max_batch_size must be >= 1"):
+        WhisperASREngineBuilder(
+            max_running_requests=4,
+            max_new_tokens=32,
+            mem_fraction_static=0.2,
+            pre_lm_max_batch_size=0,
+        )
+    with pytest.raises(ValueError, match="pre_lm_max_batch_wait_ms must be >= 0"):
+        WhisperASREngineBuilder(
+            max_running_requests=4,
+            max_new_tokens=32,
+            mem_fraction_static=0.2,
+            pre_lm_max_batch_wait_ms=-1,
+        )
+
+
 def test_whisper_asr_config_uses_single_batched_stage() -> None:
     config = WhisperASRPipelineConfig(model_path="openai/whisper-large-v3")
 
@@ -121,6 +142,12 @@ def test_whisper_asr_config_uses_single_batched_stage() -> None:
     assert config.stages[0].factory.endswith("create_sglang_whisper_asr_executor")
     assert config.stages[0].factory_args["device"] == "cuda:0"
     assert config.stages[0].factory_args["enable_encoder_cuda_graph"] is True
+    assert config.stages[0].factory_args["enable_pre_lm_encoder"] is True
+    assert config.stages[0].factory_args["pre_lm_cache_max_entries"] == 4096
+    assert config.stages[0].factory_args["pre_lm_cache_size_bytes"] == 2 * 1024**3
+    assert config.stages[0].factory_args["pre_lm_max_batch_size"] == 8
+    assert config.stages[0].factory_args["pre_lm_max_batch_wait_ms"] == 0
+    assert "max_prefill_tokens" not in config.stages[0].factory_args
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("WhisperForConditionalGeneration")
         is WhisperASRPipelineConfig
@@ -207,10 +234,13 @@ def test_whisper_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
         _fake_create_infrastructure,
     )
 
-    whisper_asr_stages.create_sglang_whisper_asr_executor("dummy")
+    whisper_asr_stages.create_sglang_whisper_asr_executor(
+        "dummy", enable_pre_lm_encoder=False
+    )
 
     assert build_kwargs["cuda_graph_max_bs"] == 16
     assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 12, 16]
     # note (jiannan-17): context_length = encoder_token_count + max_prev_tokens + max_new_tokens + 8
     assert build_kwargs["context_length"] == 1500 + 224 + 256 + 8
     assert build_kwargs["chunked_prefill_size"] == 0
+    assert build_kwargs["max_prefill_tokens"] == 4096

--- a/tests/unit_test/whisper_asr/test_request_builders.py
+++ b/tests/unit_test/whisper_asr/test_request_builders.py
@@ -53,7 +53,7 @@ def _make_request_builder():
     request_builder, _ = make_whisper_scheduler_adapters(
         processor=fake_processor,
         tokenizer=_FakeTokenizer(),
-        generation_config=SimpleNamespace(suppress_tokens=None),
+        generation_config=SimpleNamespace(suppress_tokens=None, max_length=None),
         encoder_token_count=_ENCODER_TOKEN_COUNT,
         max_new_tokens=32,
     )
@@ -189,3 +189,136 @@ def test_request_builder_guard_trips_on_over_budget_prev_context(
 
     with pytest.raises(ValueError, match="decoder budget exceeded"):
         _build(monkeypatch, {"prompt": "hello"})
+
+
+def test_request_builder_pre_lm_encode_attaches_embeddings(monkeypatch) -> None:
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(1600, dtype=np.float32),
+    )
+    calls: list[object] = []
+
+    class _Service:
+        def lookup_cached_embedding(self, fingerprint, expected_tokens):
+            return None
+
+        def encode_item(self, item):
+            calls.append(item)
+            item.precomputed_embeddings = torch.ones(
+                (_ENCODER_TOKEN_COUNT, 2), dtype=torch.float32
+            )
+            item.feature = None
+
+        def attach_embedding(self, item, embedding):
+            item.precomputed_embeddings = embedding
+            item.feature = None
+
+    fake_processor = SimpleNamespace(
+        feature_extractor=lambda audio, *, sampling_rate, return_tensors: (
+            SimpleNamespace(input_features=torch.zeros((1, 128, 3000)))
+        ),
+    )
+    request_builder, _ = make_whisper_scheduler_adapters(
+        processor=fake_processor,
+        tokenizer=_FakeTokenizer(),
+        generation_config=SimpleNamespace(suppress_tokens=None, max_length=None),
+        encoder_token_count=_ENCODER_TOKEN_COUNT,
+        max_new_tokens=32,
+        audio_encoder_service=_Service(),
+    )
+    data = request_builder(_make_payload())
+    assert len(calls) == 1
+    item = data.req.multimodal_inputs.mm_items[0]
+    assert item.feature is None
+    assert item.precomputed_embeddings is not None
+    assert item.num_audio_tokens == _ENCODER_TOKEN_COUNT
+
+
+def test_request_builder_pre_lm_cache_miss_extracts_and_encodes(monkeypatch) -> None:
+    mel_calls = {"n": 0}
+    lookups: list[tuple[str | None, int]] = []
+
+    def _feature_extractor(audio, *, sampling_rate, return_tensors):
+        mel_calls["n"] += 1
+        return SimpleNamespace(input_features=torch.zeros((1, 128, 3000)))
+
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(1600, dtype=np.float32),
+    )
+
+    class _Service:
+        def lookup_cached_embedding(self, fingerprint, expected_tokens):
+            lookups.append((fingerprint, expected_tokens))
+            return None
+
+        def encode_item(self, item):
+            assert item.feature is not None
+            item.precomputed_embeddings = torch.ones(
+                (_ENCODER_TOKEN_COUNT, 2), dtype=torch.float32
+            )
+            item.feature = None
+
+        def attach_embedding(self, item, embedding):
+            raise AssertionError("cache miss must encode, not attach")
+
+    fake_processor = SimpleNamespace(feature_extractor=_feature_extractor)
+    request_builder, _ = make_whisper_scheduler_adapters(
+        processor=fake_processor,
+        tokenizer=_FakeTokenizer(),
+        generation_config=SimpleNamespace(suppress_tokens=None, max_length=None),
+        encoder_token_count=_ENCODER_TOKEN_COUNT,
+        max_new_tokens=32,
+        audio_encoder_service=_Service(),
+    )
+    data = request_builder(_make_payload())
+    assert mel_calls["n"] == 1
+    assert lookups and lookups[0][1] == _ENCODER_TOKEN_COUNT
+    assert data.req.extra_key == lookups[0][0]
+    item = data.req.multimodal_inputs.mm_items[0]
+    assert item.feature is None
+    assert item.precomputed_embeddings is not None
+
+
+def test_request_builder_pre_lm_cache_hit_skips_mel(monkeypatch) -> None:
+    mel_calls = {"n": 0}
+
+    def _feature_extractor(audio, *, sampling_rate, return_tensors):
+        mel_calls["n"] += 1
+        return SimpleNamespace(input_features=torch.zeros((1, 128, 3000)))
+
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(1600, dtype=np.float32),
+    )
+
+    class _Service:
+        def lookup_cached_embedding(self, fingerprint, expected_tokens):
+            return torch.full((_ENCODER_TOKEN_COUNT, 2), 7.0)
+
+        def encode_item(self, item):
+            raise AssertionError("cache hit must not encode")
+
+        def attach_embedding(self, item, embedding):
+            item.precomputed_embeddings = embedding
+            item.feature = None
+
+    fake_processor = SimpleNamespace(feature_extractor=_feature_extractor)
+    request_builder, _ = make_whisper_scheduler_adapters(
+        processor=fake_processor,
+        tokenizer=_FakeTokenizer(),
+        generation_config=SimpleNamespace(suppress_tokens=None, max_length=None),
+        encoder_token_count=_ENCODER_TOKEN_COUNT,
+        max_new_tokens=32,
+        audio_encoder_service=_Service(),
+    )
+    data = request_builder(_make_payload())
+    assert mel_calls["n"] == 0
+    item = data.req.multimodal_inputs.mm_items[0]
+    assert item.feature is None
+    assert torch.equal(
+        item.precomputed_embeddings, torch.full((_ENCODER_TOKEN_COUNT, 2), 7.0)
+    )


### PR DESCRIPTION
Related: [#1396](https://github.com/sgl-project/sglang-omni/issues/1396)

## Motivation

Whisper already has the pre-LM encoder path ([#1497](https://github.com/sgl-project/sglang-omni/pull/1497)), so high-concurrency encoder admission is no longer the main limiter. Qwen3-ASR and Fun-ASR already default to the shared one-step-lookahead decode path (`--decode-mode`). Whisper was still sync-only, so host-side result collect could not overlap the next GPU decode forward.

Standalone async decode (without pre-LM) previously showed only a small c1 gain and regressions at high concurrency, because encoder admission remained the bottleneck. Stacking async on pre-LM gives a stable additional throughput gain at every measured concurrency while keeping corpus WER unchanged.

## Modifications

- Wired Whisper into the shared `--decode-mode` / `--async-lookahead-min-batch-size` CLI path (same allow-list as Qwen3-ASR / Fun-ASR).
- Defaulted Whisper to async decode with `async_decode_min_batch_size=1`, matching the Qwen3-ASR crossover.
- Threaded `enable_async_decode` / `async_decode_min_batch_size` through `stages` → `WhisperASREngineBuilder.extra_scheduler_kwargs`.
- Updated the Whisper cookbook with a sync vs async A/B recipe on top of pre-LM, plus unit coverage for stage defaults and CLI overrides.

## Related Issues

- ASR optimization roadmap: [#1396](https://github.com/sgl-project/sglang-omni/issues/1396) (W-PR4)
- Base / prerequisite: [#1497](https://github.com/sgl-project/sglang-omni/pull/1497) (W-PR7 pre-LM encoder)

## Accuracy Test

End-to-end A/B used `openai/whisper-base` FP16 on one NVIDIA H200, with pre-LM enabled on both arms. Corpus WER was identical for sync and async.

Smoke (20 SeedTTS EN clips, 3 measured repeats per concurrency):

| Concurrency | Evaluated | Corpus WER (sync) | Corpus WER (async) |
|---:|---:|---:|---:|
| 1 | 60/60 | 0.0415 | 0.0415 |
| 2 | 60/60 | 0.0415 | 0.0415 |
| 4 | 60/60 | 0.0415 | 0.0415 |
| 8 | 60/60 | 0.0415 | 0.0415 |

## Benchmark & Profiling

Hardware and model: one NVIDIA H200, `openai/whisper-base`, FP16.
Both arms keep pre-LM on (`pre_lm_max_batch_size=8`).
Baseline: `--decode-mode sync`. Candidate: `--decode-mode async --async-lookahead-min-batch-size 1` (default).

```bash
python -m benchmarks.eval.benchmark_asr_seedtts \
  --port 8000 --model-path openai/whisper-base \
  --max-samples 20 --concurrencies 1,2,4,8 \
  --repeats 3 --warmup --output whisper_async_on_prelm.json
```

### SeedTTS EN 20-clip subset (stacked on pre-LM)

Deltas are `Async / Sync - 1`. For throughput, **positive is better**; for latency, **negative is better**.

#### Relative change (async vs sync, both with pre-LM)

| Concurrency | Throughput change | Mean latency change | Corpus WER change |
|---:|---:|---:|---:|
| 1 | +8.0% | −6.8% | +0.000 pp |
| 2 | +8.3% | −6.1% | +0.000 pp |
| 4 | +6.4% | −4.8% | +0.000 pp |
| 8 | +6.4% | −7.4% | +0.000 pp |

#### Absolute metrics

| Config | Concurrency | Success / fail | Throughput (req/s) | Mean latency (s) | Corpus WER |
|---|---:|---:|---:|---:|---:|
| Sync + pre-LM | 1 | 60/0 | 22.627 | 0.044 | 4.15% |
| Sync + pre-LM | 2 | 60/0 | 40.258 | 0.049 | 4.15% |
| Sync + pre-LM | 4 | 60/0 | 62.413 | 0.063 | 4.15% |
| Sync + pre-LM | 8 | 60/0 | 81.039 | 0.094 | 4.15% |
| Async + pre-LM | 1 | 60/0 | 24.431 | 0.041 | 4.15% |
| Async + pre-LM | 2 | 60/0 | 43.586 | 0.046 | 4.15% |
| Async + pre-LM | 4 | 60/0 | 66.391 | 0.060 | 4.15% |
| Async + pre-LM | 8 | 60/0 | 86.206 | 0.087 | 4.15% |

Standalone async (pre-LM off) previously did not help high concurrency; the gain above is the stacked result on [#1497](https://github.com/sgl-project/sglang-omni/pull/1497).

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.