### PR TITLE
Optimize repeated Fun-ASR audio requests

### DIFF
--- a/sglang_omni/models/fun_asr/encoder_service.py
+++ b/sglang_omni/models/fun_asr/encoder_service.py
@@ -164,20 +164,12 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
             future.result(timeout=self.ENCODE_TIMEOUT_S)
             return
 
-        cached = self._cache.get(key)
+        cached = self.lookup_cached_embedding(
+            getattr(item, "audio_fingerprint", None), expected_tokens
+        )
         if cached is not None:
-            if self._is_valid(cached, expected_tokens):
-                with self._lock:
-                    self._hits += 1
-                self.attach_embedding(item, cached)
-                return
-            logger.warning(
-                f"Fun-ASR pre-LM cache entry {key} failed validation "
-                f"(shape={tuple(cached.shape)}, dtype={cached.dtype}); "
-                f"discarding it if unchanged before re-encoding"
-            )
-            self._cache.remove_if_same(key, cached)
-            cached = None
+            self.attach_embedding(item, cached)
+            return
 
         leader = False
         with self._lock:
@@ -252,11 +244,40 @@ class FunASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.Ten
                 "cache_evictions": self._cache.eviction_count,
             }
 
-    def _cache_key(self, item: Any) -> str | None:
-        item_hash = getattr(item, "audio_fingerprint", None)
-        if item_hash is None:
+    def lookup_cached_embedding(
+        self,
+        audio_fingerprint: str | None,
+        expected_tokens: int,
+    ) -> torch.Tensor | None:
+        """Return a validated completed embedding without starting an encode."""
+        key = self._cache_key_from_fingerprint(audio_fingerprint)
+        if key is None:
             return None
-        return f"{self._namespace}:{item_hash}"
+        cached = self._cache.get(key)
+        if cached is None:
+            return None
+        if self._is_valid(cached, expected_tokens):
+            with self._lock:
+                self._hits += 1
+            return cached
+        logger.warning(
+            f"Fun-ASR pre-LM cache entry {key} failed validation "
+            f"(shape={getattr(cached, 'shape', None)}, "
+            f"dtype={getattr(cached, 'dtype', None)}); "
+            f"discarding it if unchanged before re-encoding"
+        )
+        self._cache.remove_if_same(key, cached)
+        return None
+
+    def _cache_key_from_fingerprint(self, fingerprint: str | None) -> str | None:
+        if fingerprint is None:
+            return None
+        return f"{self._namespace}:{fingerprint}"
+
+    def _cache_key(self, item: Any) -> str | None:
+        return self._cache_key_from_fingerprint(
+            getattr(item, "audio_fingerprint", None)
+        )
 
     def _is_valid(self, embedding: Any, expected_tokens: int) -> bool:
         return (

--- a/sglang_omni/models/fun_asr/request_builders.py
+++ b/sglang_omni/models/fun_asr/request_builders.py
@@ -26,7 +26,10 @@ from sglang_omni.scheduling.token_text_streaming import (
 )
 
 from .configuration_fun_asr import AUDIO_PLACEHOLDER_TOKEN as _AUDIO_PAD
-from .tool_funcs.audio_lengths import fun_asr_low_frame_rate_length
+from .tool_funcs.audio_lengths import (
+    fun_asr_low_frame_rate_length,
+    fun_asr_num_audio_tokens,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -194,25 +197,50 @@ def make_fun_asr_scheduler_adapters(
         audio_duration_s = prepared.duration_s
         fingerprint = prepared.fingerprint
 
-        extracted = feature_extractor(
-            audio,
-            sampling_rate=_SAMPLE_RATE,
-            return_tensors="pt",
-            return_attention_mask=True,
-            padding="longest",
-        )
-        features = extracted["input_features"]  # [1, 560, T_lfr]
-        feature_attention_mask = extracted.get("attention_mask")
-        if feature_attention_mask is None:
-            feature_attention_mask = torch.ones(
-                (features.shape[0], features.shape[-1]), dtype=torch.long
+        estimated_audio_tokens = None
+        cached_embedding = None
+        if audio_encoder_service is not None:
+            try:
+                estimated_audio_tokens = fun_asr_num_audio_tokens(
+                    len(audio),
+                    frame_length_samples=int(feature_extractor.n_fft),
+                    frame_shift_samples=int(feature_extractor.hop_length),
+                    lfr_n=int(feature_extractor.lfr_n),
+                )
+            except AttributeError as exc:
+                raise ValueError(
+                    "Fun-ASR feature extractor is missing n_fft, hop_length, or lfr_n"
+                ) from exc
+            cached_embedding = audio_encoder_service.lookup_cached_embedding(
+                fingerprint, estimated_audio_tokens
             )
-        num_lfr_frames = int(feature_attention_mask.sum().item())
-        num_audio_tokens = int(fun_asr_low_frame_rate_length(num_lfr_frames))
-        logger.debug(
-            f"[fun-asr] lfr_frames={num_lfr_frames} "
-            f"num_audio_tokens={num_audio_tokens} feat_shape={tuple(features.shape)}"
-        )
+
+        if cached_embedding is None:
+            extracted = feature_extractor(
+                audio,
+                sampling_rate=_SAMPLE_RATE,
+                return_tensors="pt",
+                return_attention_mask=True,
+                padding="longest",
+            )
+            features = extracted["input_features"]  # [1, 560, T_lfr]
+            feature_attention_mask = extracted.get("attention_mask")
+            if feature_attention_mask is None:
+                feature_attention_mask = torch.ones(
+                    (features.shape[0], features.shape[-1]), dtype=torch.long
+                )
+            num_lfr_frames = int(feature_attention_mask.sum().item())
+            num_audio_tokens = int(fun_asr_low_frame_rate_length(num_lfr_frames))
+            logger.debug(
+                f"[fun-asr] lfr_frames={num_lfr_frames} "
+                f"num_audio_tokens={num_audio_tokens} "
+                f"feat_shape={tuple(features.shape)}"
+            )
+        else:
+            features = None
+            feature_attention_mask = None
+            assert estimated_audio_tokens is not None
+            num_audio_tokens = estimated_audio_tokens
 
         lang_raw = params.get("language")
         language = _resolve_language(lang_raw)
@@ -288,7 +316,9 @@ def make_fun_asr_scheduler_adapters(
         )
         sampling_params.normalize(tokenizer=None)
 
-        if audio_encoder_service is not None:
+        if cached_embedding is not None:
+            audio_encoder_service.attach_embedding(audio_item, cached_embedding)
+        elif audio_encoder_service is not None:
             audio_encoder_service.encode_item(audio_item)
 
         req = Req(

--- a/sglang_omni/models/fun_asr/tool_funcs/audio_lengths.py
+++ b/sglang_omni/models/fun_asr/tool_funcs/audio_lengths.py
@@ -12,6 +12,34 @@ def fun_asr_low_frame_rate_length(lfr_frames: int) -> int:
     return out
 
 
+def fun_asr_num_audio_tokens(
+    num_samples: int,
+    *,
+    frame_length_samples: int,
+    frame_shift_samples: int,
+    lfr_n: int,
+) -> int:
+    """Derive Fun-ASR adaptor tokens from a resampled waveform length."""
+    values = {
+        "num_samples": num_samples,
+        "frame_length_samples": frame_length_samples,
+        "frame_shift_samples": frame_shift_samples,
+        "lfr_n": lfr_n,
+    }
+    for name, value in values.items():
+        if value <= 0:
+            raise ValueError(f"{name} must be positive, got {value}")
+
+    mel_frames = (
+        1
+        if num_samples < frame_length_samples
+        else 1 + (num_samples - frame_length_samples) // frame_shift_samples
+    )
+    lfr_frames = (mel_frames + lfr_n - 1) // lfr_n
+    return fun_asr_low_frame_rate_length(lfr_frames)
+
+
 __all__ = [
     "fun_asr_low_frame_rate_length",
+    "fun_asr_num_audio_tokens",
 ]

--- a/tests/unit_test/fun_asr/test_audio_lengths.py
+++ b/tests/unit_test/fun_asr/test_audio_lengths.py
@@ -1,0 +1,81 @@
+import random
+
+import numpy as np
+import pytest
+
+from sglang_omni.models.fun_asr.configuration_fun_asr import FunAsrNanoFeatureExtractor
+from sglang_omni.models.fun_asr.tool_funcs.audio_lengths import (
+    fun_asr_low_frame_rate_length,
+    fun_asr_num_audio_tokens,
+)
+
+
+@pytest.mark.parametrize(
+    ("num_samples", "expected_tokens"),
+    [
+        (2, 1),
+        (400, 1),
+        (8079, 1),
+        (8080, 2),
+        (16000, 3),
+        (480000, 63),
+    ],
+)
+def test_fun_asr_num_audio_tokens_matches_hand_checked_boundaries(
+    num_samples: int, expected_tokens: int
+) -> None:
+    assert (
+        fun_asr_num_audio_tokens(
+            num_samples,
+            frame_length_samples=400,
+            frame_shift_samples=160,
+            lfr_n=6,
+        )
+        == expected_tokens
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"num_samples": 0},
+        {"num_samples": 16000, "frame_length_samples": 0},
+        {"num_samples": 16000, "frame_shift_samples": 0},
+        {"num_samples": 16000, "lfr_n": 0},
+    ],
+)
+def test_fun_asr_num_audio_tokens_rejects_invalid_lengths(kwargs: dict) -> None:
+    params = {
+        "num_samples": 16000,
+        "frame_length_samples": 400,
+        "frame_shift_samples": 160,
+        "lfr_n": 6,
+    }
+    params.update(kwargs)
+
+    with pytest.raises(ValueError, match="must be positive"):
+        fun_asr_num_audio_tokens(**params)
+
+
+def test_fun_asr_num_audio_tokens_matches_real_feature_extractor() -> None:
+    extractor = FunAsrNanoFeatureExtractor()
+    sample_counts = [2, 80, 159, 160, 399, 400, 559, 560, 8079, 8080]
+    sample_counts.extend(random.Random(20260812).sample(range(80, 480001), 12))
+
+    for num_samples in sample_counts:
+        extracted = extractor(
+            np.zeros(num_samples, dtype=np.float32),
+            sampling_rate=extractor.sampling_rate,
+            return_tensors="pt",
+            return_attention_mask=True,
+            padding="longest",
+        )
+        lfr_frames = int(extracted["attention_mask"].sum().item())
+        expected_tokens = fun_asr_low_frame_rate_length(lfr_frames)
+
+        assert fun_asr_num_audio_tokens(
+            num_samples,
+            frame_length_samples=extractor.n_fft,
+            frame_shift_samples=extractor.hop_length,
+            lfr_n=extractor.lfr_n,
+        ) == int(expected_tokens), num_samples

--- a/tests/unit_test/fun_asr/test_encoder_service.py
+++ b/tests/unit_test/fun_asr/test_encoder_service.py
@@ -158,6 +158,36 @@ def test_cache_hit_skips_reencode() -> None:
     assert service.stats()["hits"] == 1
 
 
+def test_lookup_cached_embedding_returns_valid_completed_entry() -> None:
+    model = _StubModel()
+    service = _make_service(model)
+    item = _item(11, 3)
+    service.encode_item(item)
+
+    cached = service.lookup_cached_embedding(item.audio_fingerprint, 3)
+
+    assert cached is not None
+    assert torch.equal(cached, item.precomputed_embeddings.cpu())
+    assert service.stats()["hits"] == 1
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        torch.zeros((4, _HIDDEN_SIZE), dtype=torch.float32),
+        torch.zeros((3, _HIDDEN_SIZE), dtype=torch.float64),
+    ],
+)
+def test_lookup_cached_embedding_evicts_invalid_entry(invalid: torch.Tensor) -> None:
+    service = _make_service(_StubModel(dtype=torch.float32))
+    key = f"{_NAMESPACE}:invalid"
+    service._cache.put(key, invalid)
+
+    assert service.lookup_cached_embedding("invalid", 3) is None
+    assert service._cache.get(key) is None
+    assert service.stats()["hits"] == 0
+
+
 def test_extended_audio_never_reuses_prefix_embedding() -> None:
     model = _StubModel()
     service = _make_service(model)

--- a/tests/unit_test/fun_asr/test_request_builders.py
+++ b/tests/unit_test/fun_asr/test_request_builders.py
@@ -21,6 +21,11 @@ _AUDIO_PAD_ID = 42  # arbitrary sentinel distinct from vocabulary ids below
 
 
 class _UnexpectedEncoderService:
+    def lookup_cached_embedding(
+        self, _audio_fingerprint: str, _expected_tokens: int
+    ) -> None:
+        return None
+
     def encode_item(self, _item: object) -> None:
         pytest.fail("invalid requests must not be encoded")
 
@@ -84,6 +89,9 @@ def _feature_extractor(num_lfr_frames: int):
             "attention_mask": torch.ones((1, num_lfr_frames), dtype=torch.long),
         }
 
+    _call.n_fft = 400
+    _call.hop_length = 160
+    _call.lfr_n = 6
     return _call
 
 
@@ -144,6 +152,11 @@ def test_fun_asr_request_builder_encodes_after_offsets_are_final(monkeypatch) ->
     observed: dict[str, object] = {}
 
     class _EncoderService:
+        def lookup_cached_embedding(
+            self, _audio_fingerprint: str, _expected_tokens: int
+        ) -> None:
+            return None
+
         def encode_item(self, item) -> None:
             observed["offsets"] = item.offsets
             observed["num_audio_tokens"] = item.num_audio_tokens
@@ -171,6 +184,117 @@ def test_fun_asr_request_builder_encodes_after_offsets_are_final(monkeypatch) ->
     assert observed["audio_fingerprint"] == audio_fingerprint(audio)
     assert item.feature is None
     assert item.precomputed_embeddings.shape[0] == 3
+
+
+def test_fun_asr_embedding_cache_hit_skips_feature_extraction(monkeypatch) -> None:
+    audio = np.zeros(16000, dtype=np.float32)
+    monkeypatch.setattr(transcription, "load_audio", lambda source, **kwargs: audio)
+    embedding = torch.zeros((3, 4), dtype=torch.float32)
+
+    class _UnexpectedFeatureExtractor:
+        n_fft = 400
+        hop_length = 160
+        lfr_n = 6
+
+        def __call__(self, *args, **kwargs):
+            raise AssertionError("feature extractor should not be called")
+
+    class _EncoderService:
+        def lookup_cached_embedding(
+            self, fingerprint: str, expected_tokens: int
+        ) -> torch.Tensor | None:
+            assert fingerprint == audio_fingerprint(audio)
+            assert expected_tokens == 3
+            return embedding
+
+        def attach_embedding(self, item, cached: torch.Tensor) -> None:
+            item.precomputed_embeddings = cached
+            item.feature = None
+
+        def encode_item(self, item) -> None:
+            raise AssertionError("encoder should not run on a cache hit")
+
+    request_builder, _ = request_builders.make_fun_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=16,
+        feature_extractor=_UnexpectedFeatureExtractor(),
+        audio_encoder_service=_EncoderService(),
+    )
+    payload = StagePayload(
+        request_id="req-fun-asr-cache-hit",
+        request=OmniRequest(inputs={"audio_bytes": b"wav"}),
+        data={},
+    )
+
+    data = request_builder(payload)
+
+    item = data.req.multimodal_inputs.mm_items[0]
+    assert data.num_audio_tokens == 3
+    assert item.feature is None
+    assert item.precomputed_embeddings is embedding
+    assert item.offsets[0][1] - item.offsets[0][0] + 1 == 3
+
+
+def test_fun_asr_embedding_cache_miss_extracts_and_encodes(monkeypatch) -> None:
+    audio = np.zeros(16000, dtype=np.float32)
+    monkeypatch.setattr(transcription, "load_audio", lambda source, **kwargs: audio)
+    extractor = _feature_extractor(17)
+
+    class _EncoderService:
+        def lookup_cached_embedding(
+            self, fingerprint: str, expected_tokens: int
+        ) -> None:
+            assert fingerprint == audio_fingerprint(audio)
+            assert expected_tokens == 3
+            return None
+
+        def encode_item(self, item) -> None:
+            assert item.feature is not None
+            item.precomputed_embeddings = torch.zeros((item.num_audio_tokens, 4))
+            item.feature = None
+
+    request_builder, _ = request_builders.make_fun_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=16,
+        feature_extractor=extractor,
+        audio_encoder_service=_EncoderService(),
+    )
+    payload = StagePayload(
+        request_id="req-fun-asr-cache-miss",
+        request=OmniRequest(inputs={"audio_bytes": b"wav"}),
+        data={},
+    )
+
+    data = request_builder(payload)
+
+    item = data.req.multimodal_inputs.mm_items[0]
+    assert data.num_audio_tokens == 3
+    assert item.feature is None
+    assert item.precomputed_embeddings.shape == (3, 4)
+
+
+def test_fun_asr_without_encoder_service_keeps_extracted_feature(monkeypatch) -> None:
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(16000, dtype=np.float32),
+    )
+    request_builder, _ = request_builders.make_fun_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=16,
+        feature_extractor=_feature_extractor(17),
+    )
+    payload = StagePayload(
+        request_id="req-fun-asr-no-cache",
+        request=OmniRequest(inputs={"audio_bytes": b"wav"}),
+        data={},
+    )
+
+    data = request_builder(payload)
+
+    item = data.req.multimodal_inputs.mm_items[0]
+    assert item.feature.shape == (1, 560, 17)
+    assert item.precomputed_embeddings is None
 
 
 def test_fun_asr_request_builder_language_prompt(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- look up completed Fun-ASR pre-LM embeddings before Kaldi fbank/LFR extraction
- derive the expected adaptor-token count exactly from the resampled waveform length and feature-extractor configuration
- validate cached shape, hidden size, and dtype before reuse; evict stale entries and retain the existing encode path on misses

## Why

Fun-ASR already caches pre-LM embeddings, but request construction performs CPU feature extraction before checking that cache. Repeated requests for the same audio therefore still pay the fbank/LFR cost. This moves the completed-cache lookup ahead of extraction without changing cold-request behavior.

This contributes to the Fun-ASR optimization work tracked in #1396.

## Validation

- `python -m pytest -q tests/unit_test/fun_asr -ra`: 90 passed
- `pre-commit run --files <six changed files>`: passed
- `git diff --cached --check`: passed
- `python -m py_compile <six changed files>`: passed
- exact token-count parity checked against the real `FunAsrNanoFeatureExtractor` across boundaries and seeded waveform lengths

## H100 benchmark

Compared `origin/main@b203b0d5` with this branch on one NVIDIA H100 80GB, `FunAudioLLM/Fun-ASR-Nano-2512-hf`, identical OpenAI transcription requests, after one cache-populating request.

| Audio | Repeats | Metric | Main | This PR | Change |
|---|---:|---:|---:|---:|---:|
| 4.62 s | 40 | median | 53.30 ms | 50.96 ms | -4.4% |
| 4.62 s | 40 | p95 | 57.82 ms | 55.78 ms | -3.5% |
| 18.48 s | 20 | median | 129.12 ms | 118.95 ms | -7.9% |
| 18.48 s | 20 | mean | 131.38 ms | 120.38 ms | -8.4% |
| 18.48 s | 20 | p95 | 142.39 ms | 126.63 ms | -11.1% |

All repeated outputs matched their cold-request transcript exactly on both main and this branch.