### PR TITLE
[ASR][Perf] Establish request-event profiling for ARK-ASR

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -186,7 +186,7 @@ python -m benchmarks.eval.benchmark_omni_seedtts \
 | `eval/benchmark_omni_mmmu.py` | MMMU (VLM accuracy + speed) | Qwen3-Omni | `/v1/chat/completions` |
 | `eval/benchmark_omni_videomme.py` | Video-MME (video understanding) | Qwen3-Omni | `/v1/chat/completions` |
 | `eval/benchmark_omni_videoamme.py` | Video-AMME (video + audio question understanding) | Qwen3-Omni | `/v1/chat/completions` |
-| `eval/benchmark_asr_seedtts.py` | ASR concurrency scaling on SeedTTS EN/ZH | Qwen3-ASR, Fun-ASR | `/v1/audio/transcriptions` |
+| `eval/benchmark_asr_seedtts.py` | ASR concurrency scaling and request-event profiling on SeedTTS EN/ZH | Qwen3-ASR, Fun-ASR, ARK-ASR | `/v1/audio/transcriptions` |
 
 See [tts_serving/README.md](tts_serving/README.md) for the TTS serving
 benchmark design, harness contract, scenario matrix, and Docker usage.
@@ -207,12 +207,14 @@ and MOSS-TTS. MOSS-TTS additionally supports duration control through
 docstring (sequential phases on CI to reduce OOM risk).
 
 `benchmark_asr_seedtts.py` is a standalone ASR fan-out sweep (issue #646): it
-transcribes the SeedTTS *reference* clips directly against a running Qwen3-ASR
-or Fun-ASR router and reports WER + speed + per-worker routing balance per
-concurrency level. It reports evaluation coverage and RTFx (successful
+transcribes the SeedTTS *reference* clips directly against a running Qwen3-ASR,
+Fun-ASR, or ARK-ASR router and reports WER + speed + per-worker routing balance
+per concurrency level. It reports evaluation coverage and RTFx (successful
 input-audio seconds per wall-clock second) alongside the existing RTF. Use it
 to measure how ASR concurrency affects capacity, latency, and WER for a given
-workload.
+workload. Its optional `--profile-events` pass records request-level stage and
+hop breakdowns after measured repeats, keeping profiling overhead out of the
+reported benchmark metrics.
 
 Add `--stream` to exercise the transcription SSE path and report text TTFT and
 inter-chunk latency while retaining the terminal transcript for WER:

--- a/benchmarks/eval/benchmark_asr_seedtts.py
+++ b/benchmarks/eval/benchmark_asr_seedtts.py
@@ -6,7 +6,7 @@
 
 This script transcribes SeedTTS reference clips directly through a running ASR
 router and reports WER, request throughput, RTFx, RTF, latency, and worker
-routing balance. It supports both Qwen3-ASR and Fun-ASR-Nano through
+routing balance. It supports Qwen3-ASR, Fun-ASR-Nano, and ARK-ASR through
 ``--model-path``.
 
 Usage:
@@ -45,6 +45,12 @@ Usage:
     python -m benchmarks.eval.benchmark_asr_seedtts \
         --port 8000 --model-path FunAudioLLM/Fun-ASR-Nano-2512-hf \
         --concurrencies 32 --repeats 3 --warmup --stream
+
+    # Capture one dedicated ARK-ASR request-event pass after measured repeats:
+    python -m benchmarks.eval.benchmark_asr_seedtts \
+        --port 8000 --model-path AutoArk-AI/ARK-ASR-3B \
+        --concurrencies 1 --repeats 1 \
+        --profile-events --profile-event-dir /tmp/ark_asr_profile
 
 Reference results on the full SeedTTS EN set (1088 clips, bf16, single RTX
 4080 SUPER 32 GB, DP=1, three repeats plus one discarded warmup per level):
@@ -103,6 +109,7 @@ from benchmarks.eval.asr_profiling import (
 )
 from benchmarks.runtime_metrics import ResourceMonitor, collect_benchmark_provenance
 from benchmarks.tasks.asr import (
+    ARK_ASR_MODEL_PATH,
     FUN_ASR_MODEL_PATH,
     QWEN3_ASR_MODEL_PATH,
     build_asr_eval_results,
@@ -493,7 +500,8 @@ def parse_args() -> argparse.Namespace:
         help=(
             "ASR model id served by the router. Defaults to "
             f"{QWEN3_ASR_MODEL_PATH}; use "
-            f"{FUN_ASR_MODEL_PATH} for Fun-ASR-Nano."
+            f"{FUN_ASR_MODEL_PATH} for Fun-ASR-Nano or "
+            f"{ARK_ASR_MODEL_PATH} for ARK-ASR."
         ),
     )
     parser.add_argument(

--- a/benchmarks/tasks/asr.py
+++ b/benchmarks/tasks/asr.py
@@ -50,6 +50,7 @@ OMNI_WHISPER_SAMPLE_RATE = 16000
 QWEN3_ASR_MODEL_PATH = "Qwen/Qwen3-ASR-1.7B"
 QWEN3_ASR_REQUEST_TIMEOUT_S = 300
 FUN_ASR_MODEL_PATH = "FunAudioLLM/Fun-ASR-Nano-2512-hf"
+ARK_ASR_MODEL_PATH = "AutoArk-AI/ARK-ASR-3B"
 # note (aaron): ASR transcription fan-out for WER, not TTS generation concurrency.
 DEFAULT_ASR_TRANSCRIBE_CONCURRENCY = 32
 # note (aaron): warmup requests sent before the timed window, per unit of concurrency.

--- a/docs/cookbook/arkasr.md
+++ b/docs/cookbook/arkasr.md
@@ -229,6 +229,36 @@ The script reports corpus WER, throughput, and latency per concurrency level.
 Transcription accuracy tracks the official `transformers` checkpoint on the same
 audio.
 
+### Request-event profiling
+
+Add `--profile-events` to run one dedicated profiled pass after the measured
+repeats at each concurrency. The profiled pass is excluded from the reported
+accuracy and speed aggregates.
+
+```bash
+python -m benchmarks.eval.benchmark_asr_seedtts \
+  --port 8000 \
+  --model-path AutoArk-AI/ARK-ASR-3B \
+  --max-samples 20 \
+  --concurrencies 1 \
+  --repeats 1 \
+  --profile-events \
+  --profile-event-dir /tmp/ark_asr_profile \
+  --output ark_asr_profile.json
+```
+
+After successful collection, each result entry gains a `profile` object
+containing the profiled pass metrics, request count, and request-level
+`stage_breakdown` and `hop_breakdown`. ARK-ASR uses a single model stage, so an
+empty hop breakdown is expected. Its expected stage coverage includes audio
+preprocessing, request construction, queueing, first prefill, and decode
+completion.
+
+The event directory is a server-side path. Report generation therefore requires
+the benchmark process and every profiled worker to share that filesystem and
+event directory. For router or data-parallel deployments, pass every worker
+serve URL through comma-separated `--profile-urls`.
+
 ## Known Limitations
 
 - The endpoint accepts one uploaded file per request.

--- a/sglang_omni/models/arkasr/request_builders.py
+++ b/sglang_omni/models/arkasr/request_builders.py
@@ -25,6 +25,7 @@ from sglang.srt.managers.schedule_batch import (
 from sglang.srt.sampling.sampling_params import SamplingParams
 
 from sglang_omni.preprocessing.transcription import prepare_audio
+from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 from sglang_omni.scheduling.types import DeferredAdmission
@@ -127,32 +128,44 @@ def make_arkasr_scheduler_adapters(
         payload: StagePayload,
     ) -> ArkASRRequestData | DeferredAdmission:
         params = payload.request.params or {}
-        prepared = prepare_audio(
-            payload, source_name="ARK-ASR", target_sample_rate=_SAMPLE_RATE
+        _emit_event(
+            request_id=payload.request_id,
+            stage=None,
+            event_name="preprocess_start",
         )
-        audio = prepared.waveform
-        audio_duration_s = prepared.duration_s
-        fingerprint = prepared.fingerprint
-
-        # mel: pad to the clip's true length (short clips do not pay the full
-        # 30s of FFT). ARK's WhisperEncoder is variable-length; conv2 stride-2
-        # then merge_factor determines the audio-token count.
-        extracted = feature_extractor(
-            audio,
-            sampling_rate=_SAMPLE_RATE,
-            return_tensors="pt",
-            return_attention_mask=True,
-            padding="longest",
-            truncation=True,
-        )
-        features = extracted.input_features  # [num_mel_bins, T]
-        feature_attention_mask = getattr(extracted, "attention_mask", None)
-        if feature_attention_mask is None:
-            feature_attention_mask = torch.ones(
-                (features.shape[0], features.shape[-1]), dtype=torch.long
+        try:
+            prepared = prepare_audio(
+                payload, source_name="ARK-ASR", target_sample_rate=_SAMPLE_RATE
             )
-        num_mel_frames = int(feature_attention_mask.sum().item())
-        num_audio_tokens = arkasr_num_audio_tokens(num_mel_frames, merge_factor)
+            audio = prepared.waveform
+            audio_duration_s = prepared.duration_s
+            fingerprint = prepared.fingerprint
+
+            # mel: pad to the clip's true length (short clips do not pay the full
+            # 30s of FFT). ARK's WhisperEncoder is variable-length; conv2 stride-2
+            # then merge_factor determines the audio-token count.
+            extracted = feature_extractor(
+                audio,
+                sampling_rate=_SAMPLE_RATE,
+                return_tensors="pt",
+                return_attention_mask=True,
+                padding="longest",
+                truncation=True,
+            )
+            features = extracted.input_features  # [num_mel_bins, T]
+            feature_attention_mask = getattr(extracted, "attention_mask", None)
+            if feature_attention_mask is None:
+                feature_attention_mask = torch.ones(
+                    (features.shape[0], features.shape[-1]), dtype=torch.long
+                )
+            num_mel_frames = int(feature_attention_mask.sum().item())
+            num_audio_tokens = arkasr_num_audio_tokens(num_mel_frames, merge_factor)
+        finally:
+            _emit_event(
+                request_id=payload.request_id,
+                stage=None,
+                event_name="preprocess_end",
+            )
 
         input_ids = _build_prompt_ids(num_audio_tokens)
 

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -26,6 +26,7 @@ from sglang_omni.models.arkasr.request_builders import _build_suppressed_token_i
 from sglang_omni.models.arkasr.sglang_model import ArkasrForConditionalGeneration
 from sglang_omni.models.arkasr.stages import create_sglang_arkasr_executor
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+from sglang_omni.proto import OmniRequest, StagePayload
 from tests.unit_test.fakes import FakeServerArgs
 
 
@@ -521,6 +522,102 @@ def test_ark_suppressed_token_ids():
     assert 103 in ids and 104 in ids and 106 in ids  # <...> added tokens
     assert 105 not in ids  # normal token untouched
     assert ids == sorted(ids)  # deterministic order
+
+
+class _RequestBuilderTokenizer:
+    eos_token_id = 2
+    vocab_size = 200_000
+    all_special_ids: list[int] = []
+
+    def get_added_vocab(self) -> dict[str, int]:
+        return {}
+
+    def __call__(self, text: str, *, add_special_tokens: bool = False):
+        assert add_special_tokens is False
+        audio_token_count = text.count("<|audio|>")
+        return SimpleNamespace(input_ids=[10] + [151663] * audio_token_count + [11])
+
+
+def _ark_request_builder(feature_extractor):
+    request_builder, _ = request_builders.make_arkasr_scheduler_adapters(
+        tokenizer=_RequestBuilderTokenizer(),
+        max_new_tokens=16,
+        feature_extractor=feature_extractor,
+    )
+    return request_builder
+
+
+def _ark_payload() -> StagePayload:
+    return StagePayload(
+        request_id="req-ark-profile",
+        request=OmniRequest(inputs={"audio_bytes": b"wav"}, params={}),
+        data={},
+    )
+
+
+def test_ark_request_builder_emits_preprocess_profile_interval(monkeypatch) -> None:
+    events: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        request_builders,
+        "prepare_audio",
+        lambda *args, **kwargs: SimpleNamespace(
+            waveform=torch.zeros(1600),
+            duration_s=0.1,
+            fingerprint="audio-fingerprint",
+            fingerprint_int=123,
+        ),
+    )
+    monkeypatch.setattr(
+        request_builders,
+        "_emit_event",
+        lambda **event: events.append(event),
+    )
+    feature_extractor = lambda *args, **kwargs: SimpleNamespace(
+        input_features=torch.zeros((1, 128, 8)),
+        attention_mask=torch.ones((1, 8), dtype=torch.long),
+    )
+
+    _ark_request_builder(feature_extractor)(_ark_payload())
+
+    assert events == [
+        {
+            "request_id": "req-ark-profile",
+            "stage": None,
+            "event_name": "preprocess_start",
+        },
+        {
+            "request_id": "req-ark-profile",
+            "stage": None,
+            "event_name": "preprocess_end",
+        },
+    ]
+
+
+def test_ark_request_builder_closes_profile_interval_on_failure(monkeypatch) -> None:
+    events: list[str] = []
+    monkeypatch.setattr(
+        request_builders,
+        "prepare_audio",
+        lambda *args, **kwargs: SimpleNamespace(
+            waveform=torch.zeros(1600),
+            duration_s=0.1,
+            fingerprint="audio-fingerprint",
+            fingerprint_int=123,
+        ),
+    )
+    monkeypatch.setattr(
+        request_builders,
+        "_emit_event",
+        lambda **event: events.append(event["event_name"]),
+    )
+
+    def failing_feature_extractor(*args, **kwargs):
+        raise RuntimeError("mel extraction failed")
+
+    with pytest.raises(RuntimeError, match="mel extraction failed"):
+        _ark_request_builder(failing_feature_extractor)(_ark_payload())
+
+    assert events == ["preprocess_start", "preprocess_end"]
 
 
 def test_ark_encoder_layer_fp16_clamp():

--- a/tests/unit_test/benchmarks/test_asr_profiling.py
+++ b/tests/unit_test/benchmarks/test_asr_profiling.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import sys
 import time
 from types import SimpleNamespace
 
@@ -23,6 +24,7 @@ from benchmarks.eval.asr_profiling import (
     stop_request_profile,
 )
 from benchmarks.eval.benchmark_asr_seedtts import _aggregate, _print_table
+from benchmarks.tasks.asr import ARK_ASR_MODEL_PATH
 
 
 class _FakeResponse:
@@ -210,16 +212,94 @@ def test_seedtts_profiled_pass_delegates_shared_lifecycle(
     assert profile == {"pass_metrics": {"wall_clock_s": 2.0}}
 
 
-def test_build_stage_breakdown_pairs_queue_and_decode_intervals(tmp_path) -> None:
+def test_ark_asr_profiled_sweep_runs_after_measured_repeat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, str, int]] = []
+    args = SimpleNamespace(
+        model_path=ARK_ASR_MODEL_PATH,
+        profile_events=True,
+        repeats=2,
+        warmup=False,
+    )
+
+    async def fake_run_repeat(args, samples, concurrency, repeat):
+        del samples
+        calls.append(("measured", args.model_path, repeat))
+        return _repeat(concurrency, repeat, median=0.4)
+
+    async def fake_run_profiled_pass(args, samples, concurrency):
+        del samples
+        calls.append(("profiled", args.model_path, concurrency))
+        return {
+            "request_count": 1,
+            "stage_breakdown": [],
+            "hop_breakdown": [],
+        }
+
+    monkeypatch.setattr(seedtts_benchmark, "_run_repeat", fake_run_repeat)
+    monkeypatch.setattr(
+        seedtts_benchmark,
+        "_run_profiled_pass",
+        fake_run_profiled_pass,
+    )
+
+    aggregates = asyncio.run(seedtts_benchmark._sweep(args, [object()], [4]))
+
+    assert calls == [
+        ("measured", ARK_ASR_MODEL_PATH, 1),
+        ("measured", ARK_ASR_MODEL_PATH, 2),
+        ("profiled", ARK_ASR_MODEL_PATH, 4),
+    ]
+    assert aggregates[0]["profile"] == {
+        "request_count": 1,
+        "stage_breakdown": [],
+        "hop_breakdown": [],
+    }
+
+
+def test_ark_asr_cli_accepts_request_event_profile_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "benchmark_asr_seedtts",
+            "--port",
+            "8000",
+            "--model-path",
+            ARK_ASR_MODEL_PATH,
+            "--profile-events",
+            "--profile-urls",
+            "http://worker-0:8000,http://worker-1:8000",
+            "--profile-event-dir",
+            "/tmp/ark-asr-profile",
+        ],
+    )
+
+    args = seedtts_benchmark.parse_args()
+
+    assert args.model_path == ARK_ASR_MODEL_PATH
+    assert args.profile_events is True
+    assert args.profile_urls == "http://worker-0:8000,http://worker-1:8000"
+    assert args.profile_event_dir == "/tmp/ark-asr-profile"
+
+
+def test_build_ark_stage_breakdown_pairs_preprocess_queue_and_decode_intervals(
+    tmp_path,
+) -> None:
     base_ns = 1_000_000_000
     events = [
-        ("scheduler_request_build_start", base_ns),
-        ("scheduler_request_build_end", base_ns + 5_000_000),
-        ("scheduler_queue_enter", base_ns + 6_000_000),
-        ("scheduler_prefill_start", base_ns + 30_000_000),
-        ("scheduler_prefill_end", base_ns + 60_000_000),
-        ("scheduler_first_emit", base_ns + 80_000_000),
-        ("stage_complete", base_ns + 200_000_000),
+        ("preprocess_start", base_ns),
+        ("preprocess_end", base_ns + 4_000_000),
+        ("scheduler_request_build_start", base_ns + 5_000_000),
+        ("scheduler_request_build_end", base_ns + 10_000_000),
+        ("scheduler_queue_enter", base_ns + 11_000_000),
+        ("scheduler_prefill_start", base_ns + 35_000_000),
+        ("scheduler_prefill_end", base_ns + 65_000_000),
+        ("scheduler_first_emit", base_ns + 85_000_000),
+        ("stage_complete", base_ns + 205_000_000),
     ]
     event_file = tmp_path / "events_run_1.jsonl"
     with event_file.open("w") as handle:
@@ -243,6 +323,9 @@ def test_build_stage_breakdown_pairs_queue_and_decode_intervals(tmp_path) -> Non
     assert "timelines" not in report
     assert report["request_count"] == 1
     by_interval = {row["interval"]: row for row in report["stage_breakdown"]}
+    preprocess = by_interval["preprocess_start->preprocess_end"]
+    assert preprocess["stage"] == "asr"
+    assert preprocess["avg_ms"] == pytest.approx(4.0)
     build = by_interval["scheduler_request_build_start->scheduler_request_build_end"]
     assert build["avg_ms"] == pytest.approx(5.0)
     queue = by_interval["scheduler_queue_enter->scheduler_prefill_start"]


### PR DESCRIPTION
## Motivation

ARK-ASR uses the shared SeedTTS benchmark profiling lifecycle, but its model-specific request preprocessing was not visible in request-event stage breakdowns and the profiling workflow was not documented as supported. Establish explicit ARK-ASR profiler coverage following the MOSS-TD workflow from #1430.

## Modifications

- Emit scoped `preprocess_start` / `preprocess_end` request events around ARK-ASR audio loading and mel extraction, including failure-path closure.
- Register ARK-ASR as an explicit model for the shared SeedTTS benchmark and document its dedicated post-measurement profiling pass.
- Cover event emission, report assembly, CLI configuration, multi-worker profile URLs, and ordering after measured repeats with CPU-only unit tests.

## Related Issues

#1396

## Accuracy Test

This change adds profiler instrumentation, benchmark coverage, and documentation only. Request construction outputs and model execution are unchanged, and event emission remains a no-op when request profiling is inactive.

## Benchmark & Profiling

In progress. No benchmark or live profiling run was performed for this draft.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
