### PR TITLE
[CI] Register Qwen3-TTS 1.7B in the TTS model rotation

### DIFF
--- a/.claude/skills/tune-ci-thresholds/models/tts/config.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/tts/config.yaml
@@ -18,6 +18,9 @@
 # - Voice-clone artifacts live under per-variant dirs in pytest tmp_path:
 #   vc_nonstream_c16/ and vc_stream_c16/ (speed_results.json, wer_results.json,
 #   similarity_results.json and utmos_results.json for nonstream).
+# - Qwen3-TTS 1.7B is gated as a single instance, so it appears under
+#   test_tts_ci.py only and has no stage 5 (MPS) preset; its speed tables start
+#   empty with gate_thresholds=False and this calibration fills them.
 # - WER thresholds are corpus-level only; each TTS preset has its own symbol
 #   namespace in tts_ci_config.py (Higgs: HIGGS_VC_* / _HIGGS_VC_*; MOSS:
 #   MOSS_VC_* / _MOSS_VC_*). Per-sample WER caps and generation failure
@@ -33,12 +36,13 @@
 # - Auth: export HF_TOKEN before precheck/run unless the private TTS model
 #   weights are already present in the configured HF cache.
 name: tts
-description: "TTS CI (Higgs/MOSS SeedTTS EN)"
+description: "TTS CI (Higgs/MOSS/Qwen3-TTS SeedTTS EN)"
 hf_model_id: "bosonai/higgs-tts-3-4b"
 hf_model_ids_by_test:
   test_tts_ci.py:
     - "bosonai/higgs-tts-3-4b"
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
+    - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_tts_serving_ci.py:
     - "bosonai/higgs-tts-3-4b"
@@ -117,6 +121,17 @@ metric_sources:
         hf_model_ids:
           - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
           - "Qwen/Qwen3-ASR-1.7B"
+      # Gated as a single instance: the tuned single instance beats the
+      # same-card MPS-DP2 pool on this variant, so it has no stage 5 preset.
+      qwen3tts:
+        extra_env:
+          TTS_CI_MODEL: "qwen3tts"
+        gpus: 2
+        # discover: only QWEN3_TTS_VC_* constants
+        constant_filter: "^QWEN3_TTS_VC_"
+        hf_model_ids:
+          - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+          - "Qwen/Qwen3-ASR-1.7B"
     # Per-variant routing: each variant claims constants matching its
     # `constant_filter` regex (matched against the bare constant name with
     # any leading underscore stripped). Stage keys become
@@ -126,7 +141,7 @@ metric_sources:
       nonstream:
         # Higgs HIGGS_VC_* (not HIGGS_VC_STREAM_*); MOSS uses MOSS_VC_*.
         # via calibration_presets.<preset>.constant_filter in discover.
-        constant_filter: "^HIGGS_VC_(?!STREAM_).*|^MOSS_VC_(?!STREAM_).*"
+        constant_filter: "^HIGGS_VC_(?!STREAM_).*|^MOSS_VC_(?!STREAM_).*|^QWEN3_TTS_VC_(?!STREAM_).*"
         json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
         sample_counts:
           total: "summary.total_requests"
@@ -150,7 +165,7 @@ metric_sources:
           similarity_mean: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json::summary.speaker_similarity_mean"
           utmos_mean: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json::summary.utmos_mean"
       stream:
-        constant_filter: "^HIGGS_VC_STREAM_.*$|^MOSS_VC_STREAM_.*$"
+        constant_filter: "^HIGGS_VC_STREAM_.*$|^MOSS_VC_STREAM_.*$|^QWEN3_TTS_VC_STREAM_.*$"
         json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
         sample_counts:
           total: "summary.total_requests"

--- a/.claude/skills/tune-ci-thresholds/models/tts/config.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/tts/config.yaml
@@ -123,9 +123,9 @@ metric_sources:
           - "Qwen/Qwen3-ASR-1.7B"
       # Gated as a single instance: the tuned single instance beats the
       # same-card MPS-DP2 pool on this variant, so it has no stage 5 preset.
-      qwen3tts:
+      qwen3-tts:
         extra_env:
-          TTS_CI_MODEL: "qwen3tts"
+          TTS_CI_MODEL: "qwen3-tts"
         gpus: 2
         # discover: only QWEN3_TTS_VC_* constants
         constant_filter: "^QWEN3_TTS_VC_"

--- a/.claude/skills/tune-ci-thresholds/models/tts/stages.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/tts/stages.yaml
@@ -12,11 +12,11 @@ tts_higgs_nonstream_wer:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d92c8193135ad478aa6a75f560e2befaecce2e3819dcffecbf02d3e8ee60e0c8
-  last_discovered_at: 2026-08-10T07:42:53Z
+  test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
+  last_discovered_at: 2026-08-12T21:41:31Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 09f9d85b7353d0984f4258d7a1e52216a61e2e2663c974269a02138d8d71edc7
+  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json"
@@ -48,11 +48,11 @@ tts_higgs_nonstream_similarity:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d92c8193135ad478aa6a75f560e2befaecce2e3819dcffecbf02d3e8ee60e0c8
-  last_discovered_at: 2026-08-10T07:42:53Z
+  test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
+  last_discovered_at: 2026-08-12T21:41:31Z
   expected_samples: 50
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 09f9d85b7353d0984f4258d7a1e52216a61e2e2663c974269a02138d8d71edc7
+  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
@@ -84,11 +84,11 @@ tts_higgs_nonstream_utmos:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d92c8193135ad478aa6a75f560e2befaecce2e3819dcffecbf02d3e8ee60e0c8
-  last_discovered_at: 2026-08-10T07:42:53Z
+  test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
+  last_discovered_at: 2026-08-12T21:41:31Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 09f9d85b7353d0984f4258d7a1e52216a61e2e2663c974269a02138d8d71edc7
+  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json"
@@ -120,11 +120,11 @@ tts_higgs_nonstream_speed:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d92c8193135ad478aa6a75f560e2befaecce2e3819dcffecbf02d3e8ee60e0c8
-  last_discovered_at: 2026-08-10T07:42:53Z
+  test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
+  last_discovered_at: 2026-08-12T21:41:31Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 09f9d85b7353d0984f4258d7a1e52216a61e2e2663c974269a02138d8d71edc7
+  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
@@ -186,11 +186,11 @@ tts_moss_nonstream_wer:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d92c8193135ad478aa6a75f560e2befaecce2e3819dcffecbf02d3e8ee60e0c8
-  last_discovered_at: 2026-08-10T07:42:53Z
+  test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
+  last_discovered_at: 2026-08-12T21:41:31Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 09f9d85b7353d0984f4258d7a1e52216a61e2e2663c974269a02138d8d71edc7
+  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json"
@@ -222,11 +222,11 @@ tts_moss_nonstream_similarity:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d92c8193135ad478aa6a75f560e2befaecce2e3819dcffecbf02d3e8ee60e0c8
-  last_discovered_at: 2026-08-10T07:42:53Z
+  test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
+  last_discovered_at: 2026-08-12T21:41:31Z
   expected_samples: 50
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 09f9d85b7353d0984f4258d7a1e52216a61e2e2663c974269a02138d8d71edc7
+  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
@@ -258,11 +258,11 @@ tts_moss_nonstream_utmos:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d92c8193135ad478aa6a75f560e2befaecce2e3819dcffecbf02d3e8ee60e0c8
-  last_discovered_at: 2026-08-10T07:42:53Z
+  test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
+  last_discovered_at: 2026-08-12T21:41:31Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 09f9d85b7353d0984f4258d7a1e52216a61e2e2663c974269a02138d8d71edc7
+  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json"
@@ -294,11 +294,11 @@ tts_moss_nonstream_speed:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d92c8193135ad478aa6a75f560e2befaecce2e3819dcffecbf02d3e8ee60e0c8
-  last_discovered_at: 2026-08-10T07:42:53Z
+  test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
+  last_discovered_at: 2026-08-12T21:41:31Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 09f9d85b7353d0984f4258d7a1e52216a61e2e2663c974269a02138d8d71edc7
+  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
@@ -347,6 +347,180 @@ tts_moss_nonstream_speed:
         scale: 1
         digits: 4
       status: OK
+tts_qwen3tts_nonstream_wer:
+  test: tests/test_model/test_tts_ci.py
+  title: "TTS QWEN3TTS NONSTREAM Wer"
+  group: wer
+  extra_env:
+    TTS_CI_MODEL: "qwen3tts"
+  context_vars: []
+  variant: "nonstream"
+  calibration_preset: "qwen3tts"
+  gpus: 2
+  hf_model_ids:
+    - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+    - "Qwen/Qwen3-ASR-1.7B"
+  test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
+  last_discovered_at: 2026-08-12T21:41:31Z
+  expected_samples: 1088
+  threshold_file: "tests/test_model/tts_ci_config.py"
+  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  sample_counts:
+    total:
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json"
+      json_path: "summary.total_samples"
+    ok:
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json"
+      json_path: "summary.evaluated"
+  metrics:
+    corpus_wer:
+      source: "QWEN3_TTS_VC_WER_MAX_CORPUS"
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json"
+      json_path: "summary.wer_corpus"
+      worst: max
+      display:
+        label: "Corpus WER (%)"
+        scale: 100
+        digits: 2
+      status: OK
+tts_qwen3tts_nonstream_similarity:
+  test: tests/test_model/test_tts_ci.py
+  title: "TTS QWEN3TTS NONSTREAM Similarity"
+  group: similarity
+  extra_env:
+    TTS_CI_MODEL: "qwen3tts"
+  context_vars: []
+  variant: "nonstream"
+  calibration_preset: "qwen3tts"
+  gpus: 2
+  hf_model_ids:
+    - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+    - "Qwen/Qwen3-ASR-1.7B"
+  test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
+  last_discovered_at: 2026-08-12T21:41:31Z
+  expected_samples: 50
+  threshold_file: "tests/test_model/tts_ci_config.py"
+  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  sample_counts:
+    total:
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
+      json_path: "summary.total_samples"
+    ok:
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
+      json_path: "summary.evaluated"
+  metrics:
+    similarity_mean:
+      source: "QWEN3_TTS_VC_SIMILARITY_MEAN_MIN"
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
+      json_path: "summary.speaker_similarity_mean"
+      worst: min
+      display:
+        label: "Speaker sim mean"
+        scale: 1
+        digits: 4
+      status: OK
+tts_qwen3tts_nonstream_utmos:
+  test: tests/test_model/test_tts_ci.py
+  title: "TTS QWEN3TTS NONSTREAM Utmos"
+  group: utmos
+  extra_env:
+    TTS_CI_MODEL: "qwen3tts"
+  context_vars: []
+  variant: "nonstream"
+  calibration_preset: "qwen3tts"
+  gpus: 2
+  hf_model_ids:
+    - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+    - "Qwen/Qwen3-ASR-1.7B"
+  test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
+  last_discovered_at: 2026-08-12T21:41:31Z
+  expected_samples: 1088
+  threshold_file: "tests/test_model/tts_ci_config.py"
+  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  sample_counts:
+    total:
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json"
+      json_path: "summary.total_samples"
+    ok:
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json"
+      json_path: "summary.evaluated"
+  metrics:
+    utmos_mean:
+      source: "QWEN3_TTS_VC_UTMOS_MEAN_REFERENCE"
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json"
+      json_path: "summary.utmos_mean"
+      worst: min
+      display:
+        label: "UTMOS mean"
+        scale: 1
+        digits: 4
+      status: OK
+tts_qwen3tts_nonstream_speed:
+  test: tests/test_model/test_tts_ci.py
+  title: "TTS QWEN3TTS NONSTREAM Speed"
+  group: speed
+  extra_env:
+    TTS_CI_MODEL: "qwen3tts"
+  context_vars: []
+  variant: "nonstream"
+  calibration_preset: "qwen3tts"
+  gpus: 2
+  hf_model_ids:
+    - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+    - "Qwen/Qwen3-ASR-1.7B"
+  test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
+  last_discovered_at: 2026-08-12T21:41:31Z
+  expected_samples: 1088
+  threshold_file: "tests/test_model/tts_ci_config.py"
+  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  sample_counts:
+    total:
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
+      json_path: "summary.total_requests"
+    ok:
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
+      json_path: "summary.completed_requests"
+  metrics:
+    throughput_qps:
+      source: "_QWEN3_TTS_VC_NON_STREAM_P95['throughput_qps']"
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
+      json_path: "summary.throughput_qps"
+      worst: min
+      display:
+        label: "Throughput (req/s)"
+        scale: 1
+        digits: 3
+      status: OK
+    output_tok_per_req_s:
+      source: "_QWEN3_TTS_VC_NON_STREAM_P95['output_tok_per_req_s']"
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
+      json_path: "summary.output_tok_per_req_s"
+      worst: min
+      display:
+        label: "Output tok/req-s"
+        scale: 1
+        digits: 1
+      status: OK
+    latency_mean_s:
+      source: "_QWEN3_TTS_VC_NON_STREAM_P95['latency_mean_s']"
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
+      json_path: "summary.latency_mean_s"
+      worst: max
+      display:
+        label: "Latency mean (s)"
+        scale: 1
+        digits: 3
+      status: OK
+    rtf_mean:
+      source: "_QWEN3_TTS_VC_NON_STREAM_P95['rtf_mean']"
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
+      json_path: "summary.rtf_mean"
+      worst: max
+      display:
+        label: "RTF mean"
+        scale: 1
+        digits: 4
+      status: OK
 tts_higgs_stream_wer:
   test: tests/test_model/test_tts_ci.py
   title: "TTS HIGGS STREAM Wer"
@@ -360,11 +534,11 @@ tts_higgs_stream_wer:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d92c8193135ad478aa6a75f560e2befaecce2e3819dcffecbf02d3e8ee60e0c8
-  last_discovered_at: 2026-08-10T07:42:53Z
+  test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
+  last_discovered_at: 2026-08-12T21:41:31Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 09f9d85b7353d0984f4258d7a1e52216a61e2e2663c974269a02138d8d71edc7
+  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/wer_results.json"
@@ -396,11 +570,11 @@ tts_higgs_stream_speed:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d92c8193135ad478aa6a75f560e2befaecce2e3819dcffecbf02d3e8ee60e0c8
-  last_discovered_at: 2026-08-10T07:42:53Z
+  test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
+  last_discovered_at: 2026-08-12T21:41:31Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 09f9d85b7353d0984f4258d7a1e52216a61e2e2663c974269a02138d8d71edc7
+  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
@@ -452,11 +626,11 @@ tts_moss_stream_wer:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d92c8193135ad478aa6a75f560e2befaecce2e3819dcffecbf02d3e8ee60e0c8
-  last_discovered_at: 2026-08-10T07:42:53Z
+  test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
+  last_discovered_at: 2026-08-12T21:41:31Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 09f9d85b7353d0984f4258d7a1e52216a61e2e2663c974269a02138d8d71edc7
+  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/wer_results.json"
@@ -488,11 +662,11 @@ tts_moss_stream_speed:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d92c8193135ad478aa6a75f560e2befaecce2e3819dcffecbf02d3e8ee60e0c8
-  last_discovered_at: 2026-08-10T07:42:53Z
+  test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
+  last_discovered_at: 2026-08-12T21:41:31Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 09f9d85b7353d0984f4258d7a1e52216a61e2e2663c974269a02138d8d71edc7
+  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
@@ -531,6 +705,98 @@ tts_moss_stream_speed:
         scale: 1
         digits: 4
       status: OK
+tts_qwen3tts_stream_wer:
+  test: tests/test_model/test_tts_ci.py
+  title: "TTS QWEN3TTS STREAM Wer"
+  group: wer
+  extra_env:
+    TTS_CI_MODEL: "qwen3tts"
+  context_vars: []
+  variant: "stream"
+  calibration_preset: "qwen3tts"
+  gpus: 2
+  hf_model_ids:
+    - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+    - "Qwen/Qwen3-ASR-1.7B"
+  test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
+  last_discovered_at: 2026-08-12T21:41:31Z
+  expected_samples: 1088
+  threshold_file: "tests/test_model/tts_ci_config.py"
+  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  sample_counts:
+    total:
+      json_file: "test_voice_cloning_streaming0/vc_stream_c16/wer_results.json"
+      json_path: "summary.total_samples"
+    ok:
+      json_file: "test_voice_cloning_streaming0/vc_stream_c16/wer_results.json"
+      json_path: "summary.evaluated"
+  metrics:
+    corpus_wer:
+      source: "QWEN3_TTS_VC_STREAM_WER_MAX_CORPUS"
+      json_file: "test_voice_cloning_streaming0/vc_stream_c16/wer_results.json"
+      json_path: "summary.wer_corpus"
+      worst: max
+      display:
+        label: "Corpus WER (%)"
+        scale: 100
+        digits: 2
+      status: OK
+tts_qwen3tts_stream_speed:
+  test: tests/test_model/test_tts_ci.py
+  title: "TTS QWEN3TTS STREAM Speed"
+  group: speed
+  extra_env:
+    TTS_CI_MODEL: "qwen3tts"
+  context_vars: []
+  variant: "stream"
+  calibration_preset: "qwen3tts"
+  gpus: 2
+  hf_model_ids:
+    - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+    - "Qwen/Qwen3-ASR-1.7B"
+  test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
+  last_discovered_at: 2026-08-12T21:41:31Z
+  expected_samples: 1088
+  threshold_file: "tests/test_model/tts_ci_config.py"
+  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  sample_counts:
+    total:
+      json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
+      json_path: "summary.total_requests"
+    ok:
+      json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
+      json_path: "summary.completed_requests"
+  metrics:
+    throughput_qps:
+      source: "_QWEN3_TTS_VC_STREAM_P95['throughput_qps']"
+      json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
+      json_path: "summary.throughput_qps"
+      worst: min
+      display:
+        label: "Throughput (req/s)"
+        scale: 1
+        digits: 3
+      status: OK
+    latency_mean_s:
+      source: "_QWEN3_TTS_VC_STREAM_P95['latency_mean_s']"
+      json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
+      json_path: "summary.latency_mean_s"
+      worst: max
+      display:
+        label: "Latency mean (s)"
+        scale: 1
+        digits: 3
+      status: OK
+    rtf_mean:
+      source: "_QWEN3_TTS_VC_STREAM_P95['rtf_mean']"
+      json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
+      json_path: "summary.rtf_mean"
+      worst: max
+      display:
+        label: "RTF mean"
+        scale: 1
+        digits: 4
+      status: OK
 tts_serving_mixed_speech_normal_speed:
   test: tests/test_model/test_tts_serving_ci.py
   title: "TTS SERVING MIXED_SPEECH_NORMAL Speed"
@@ -539,7 +805,7 @@ tts_serving_mixed_speech_normal_speed:
   context_vars: []
   variant: "mixed_speech_normal"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-10T07:42:53Z
+  last_discovered_at: 2026-08-12T21:41:31Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -582,7 +848,7 @@ tts_serving_mixed_rest_stream_speed:
   context_vars: []
   variant: "mixed_rest_stream"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-10T07:42:53Z
+  last_discovered_at: 2026-08-12T21:41:31Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -645,7 +911,7 @@ tts_serving_mixed_batch32_speed:
   context_vars: []
   variant: "mixed_batch32"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-10T07:42:53Z
+  last_discovered_at: 2026-08-12T21:41:31Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -678,7 +944,7 @@ tts_serving_mixed_ws_normal_speed:
   context_vars: []
   variant: "mixed_ws_normal"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-10T07:42:53Z
+  last_discovered_at: 2026-08-12T21:41:31Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -721,7 +987,7 @@ tts_serving_mixed_ws_stream_speed:
   context_vars: []
   variant: "mixed_ws_stream"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-10T07:42:53Z
+  last_discovered_at: 2026-08-12T21:41:31Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -784,7 +1050,7 @@ tts_serving_mixed_long_speed:
   context_vars: []
   variant: "mixed_long"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-10T07:42:53Z
+  last_discovered_at: 2026-08-12T21:41:31Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -863,7 +1129,7 @@ tts_mps_dp2_higgs_speed:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 6d5a45b023ded77318085347a82d81752211379f132bd675487610ed1d5e4bd7
-  last_discovered_at: 2026-08-10T07:42:53Z
+  last_discovered_at: 2026-08-12T21:41:31Z
   expected_samples: 1088
   threshold_file: "tests/test_ci/tts_mps_ci_config.py"
   threshold_file_sha256: 13b6deecde2c217c0f1869077f8d4301e77378e98c80b5cc9ddb44732e3d23ab
@@ -935,7 +1201,7 @@ tts_mps_dp2_higgs_similarity:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 6d5a45b023ded77318085347a82d81752211379f132bd675487610ed1d5e4bd7
-  last_discovered_at: 2026-08-10T07:42:53Z
+  last_discovered_at: 2026-08-12T21:41:31Z
   expected_samples: 50
   threshold_file: "tests/test_ci/tts_mps_ci_config.py"
   threshold_file_sha256: 13b6deecde2c217c0f1869077f8d4301e77378e98c80b5cc9ddb44732e3d23ab
@@ -977,7 +1243,7 @@ tts_mps_dp2_moss_speed:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 6d5a45b023ded77318085347a82d81752211379f132bd675487610ed1d5e4bd7
-  last_discovered_at: 2026-08-10T07:42:53Z
+  last_discovered_at: 2026-08-12T21:41:31Z
   expected_samples: 1088
   threshold_file: "tests/test_ci/tts_mps_ci_config.py"
   threshold_file_sha256: 13b6deecde2c217c0f1869077f8d4301e77378e98c80b5cc9ddb44732e3d23ab
@@ -1049,7 +1315,7 @@ tts_mps_dp2_moss_similarity:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 6d5a45b023ded77318085347a82d81752211379f132bd675487610ed1d5e4bd7
-  last_discovered_at: 2026-08-10T07:42:53Z
+  last_discovered_at: 2026-08-12T21:41:31Z
   expected_samples: 50
   threshold_file: "tests/test_ci/tts_mps_ci_config.py"
   threshold_file_sha256: 13b6deecde2c217c0f1869077f8d4301e77378e98c80b5cc9ddb44732e3d23ab

--- a/.claude/skills/tune-ci-thresholds/models/tts/stages.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/tts/stages.yaml
@@ -13,10 +13,10 @@ tts_higgs_nonstream_wer:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json"
@@ -49,10 +49,10 @@ tts_higgs_nonstream_similarity:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 50
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
@@ -85,10 +85,10 @@ tts_higgs_nonstream_utmos:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json"
@@ -121,10 +121,10 @@ tts_higgs_nonstream_speed:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
@@ -187,10 +187,10 @@ tts_moss_nonstream_wer:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json"
@@ -223,10 +223,10 @@ tts_moss_nonstream_similarity:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 50
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
@@ -259,10 +259,10 @@ tts_moss_nonstream_utmos:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json"
@@ -295,10 +295,10 @@ tts_moss_nonstream_speed:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
@@ -347,24 +347,24 @@ tts_moss_nonstream_speed:
         scale: 1
         digits: 4
       status: OK
-tts_qwen3tts_nonstream_wer:
+tts_qwen3-tts_nonstream_wer:
   test: tests/test_model/test_tts_ci.py
-  title: "TTS QWEN3TTS NONSTREAM Wer"
+  title: "TTS QWEN3-TTS NONSTREAM Wer"
   group: wer
   extra_env:
-    TTS_CI_MODEL: "qwen3tts"
+    TTS_CI_MODEL: "qwen3-tts"
   context_vars: []
   variant: "nonstream"
-  calibration_preset: "qwen3tts"
+  calibration_preset: "qwen3-tts"
   gpus: 2
   hf_model_ids:
     - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json"
@@ -383,24 +383,24 @@ tts_qwen3tts_nonstream_wer:
         scale: 100
         digits: 2
       status: OK
-tts_qwen3tts_nonstream_similarity:
+tts_qwen3-tts_nonstream_similarity:
   test: tests/test_model/test_tts_ci.py
-  title: "TTS QWEN3TTS NONSTREAM Similarity"
+  title: "TTS QWEN3-TTS NONSTREAM Similarity"
   group: similarity
   extra_env:
-    TTS_CI_MODEL: "qwen3tts"
+    TTS_CI_MODEL: "qwen3-tts"
   context_vars: []
   variant: "nonstream"
-  calibration_preset: "qwen3tts"
+  calibration_preset: "qwen3-tts"
   gpus: 2
   hf_model_ids:
     - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 50
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
@@ -419,24 +419,24 @@ tts_qwen3tts_nonstream_similarity:
         scale: 1
         digits: 4
       status: OK
-tts_qwen3tts_nonstream_utmos:
+tts_qwen3-tts_nonstream_utmos:
   test: tests/test_model/test_tts_ci.py
-  title: "TTS QWEN3TTS NONSTREAM Utmos"
+  title: "TTS QWEN3-TTS NONSTREAM Utmos"
   group: utmos
   extra_env:
-    TTS_CI_MODEL: "qwen3tts"
+    TTS_CI_MODEL: "qwen3-tts"
   context_vars: []
   variant: "nonstream"
-  calibration_preset: "qwen3tts"
+  calibration_preset: "qwen3-tts"
   gpus: 2
   hf_model_ids:
     - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json"
@@ -455,24 +455,24 @@ tts_qwen3tts_nonstream_utmos:
         scale: 1
         digits: 4
       status: OK
-tts_qwen3tts_nonstream_speed:
+tts_qwen3-tts_nonstream_speed:
   test: tests/test_model/test_tts_ci.py
-  title: "TTS QWEN3TTS NONSTREAM Speed"
+  title: "TTS QWEN3-TTS NONSTREAM Speed"
   group: speed
   extra_env:
-    TTS_CI_MODEL: "qwen3tts"
+    TTS_CI_MODEL: "qwen3-tts"
   context_vars: []
   variant: "nonstream"
-  calibration_preset: "qwen3tts"
+  calibration_preset: "qwen3-tts"
   gpus: 2
   hf_model_ids:
     - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
@@ -535,10 +535,10 @@ tts_higgs_stream_wer:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/wer_results.json"
@@ -571,10 +571,10 @@ tts_higgs_stream_speed:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
@@ -627,10 +627,10 @@ tts_moss_stream_wer:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/wer_results.json"
@@ -663,10 +663,10 @@ tts_moss_stream_speed:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
@@ -705,24 +705,24 @@ tts_moss_stream_speed:
         scale: 1
         digits: 4
       status: OK
-tts_qwen3tts_stream_wer:
+tts_qwen3-tts_stream_wer:
   test: tests/test_model/test_tts_ci.py
-  title: "TTS QWEN3TTS STREAM Wer"
+  title: "TTS QWEN3-TTS STREAM Wer"
   group: wer
   extra_env:
-    TTS_CI_MODEL: "qwen3tts"
+    TTS_CI_MODEL: "qwen3-tts"
   context_vars: []
   variant: "stream"
-  calibration_preset: "qwen3tts"
+  calibration_preset: "qwen3-tts"
   gpus: 2
   hf_model_ids:
     - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/wer_results.json"
@@ -741,24 +741,24 @@ tts_qwen3tts_stream_wer:
         scale: 100
         digits: 2
       status: OK
-tts_qwen3tts_stream_speed:
+tts_qwen3-tts_stream_speed:
   test: tests/test_model/test_tts_ci.py
-  title: "TTS QWEN3TTS STREAM Speed"
+  title: "TTS QWEN3-TTS STREAM Speed"
   group: speed
   extra_env:
-    TTS_CI_MODEL: "qwen3tts"
+    TTS_CI_MODEL: "qwen3-tts"
   context_vars: []
   variant: "stream"
-  calibration_preset: "qwen3tts"
+  calibration_preset: "qwen3-tts"
   gpus: 2
   hf_model_ids:
     - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 01b25be81dfb6262c59fd508bee641a205df9680d2085fc8dbb9a6de9b4d5e5b
+  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
@@ -805,7 +805,7 @@ tts_serving_mixed_speech_normal_speed:
   context_vars: []
   variant: "mixed_speech_normal"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -848,7 +848,7 @@ tts_serving_mixed_rest_stream_speed:
   context_vars: []
   variant: "mixed_rest_stream"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -911,7 +911,7 @@ tts_serving_mixed_batch32_speed:
   context_vars: []
   variant: "mixed_batch32"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -944,7 +944,7 @@ tts_serving_mixed_ws_normal_speed:
   context_vars: []
   variant: "mixed_ws_normal"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -987,7 +987,7 @@ tts_serving_mixed_ws_stream_speed:
   context_vars: []
   variant: "mixed_ws_stream"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -1050,7 +1050,7 @@ tts_serving_mixed_long_speed:
   context_vars: []
   variant: "mixed_long"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -1129,7 +1129,7 @@ tts_mps_dp2_higgs_speed:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 6d5a45b023ded77318085347a82d81752211379f132bd675487610ed1d5e4bd7
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 1088
   threshold_file: "tests/test_ci/tts_mps_ci_config.py"
   threshold_file_sha256: 13b6deecde2c217c0f1869077f8d4301e77378e98c80b5cc9ddb44732e3d23ab
@@ -1201,7 +1201,7 @@ tts_mps_dp2_higgs_similarity:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 6d5a45b023ded77318085347a82d81752211379f132bd675487610ed1d5e4bd7
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 50
   threshold_file: "tests/test_ci/tts_mps_ci_config.py"
   threshold_file_sha256: 13b6deecde2c217c0f1869077f8d4301e77378e98c80b5cc9ddb44732e3d23ab
@@ -1243,7 +1243,7 @@ tts_mps_dp2_moss_speed:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 6d5a45b023ded77318085347a82d81752211379f132bd675487610ed1d5e4bd7
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 1088
   threshold_file: "tests/test_ci/tts_mps_ci_config.py"
   threshold_file_sha256: 13b6deecde2c217c0f1869077f8d4301e77378e98c80b5cc9ddb44732e3d23ab
@@ -1315,7 +1315,7 @@ tts_mps_dp2_moss_similarity:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 6d5a45b023ded77318085347a82d81752211379f132bd675487610ed1d5e4bd7
-  last_discovered_at: 2026-08-12T21:41:31Z
+  last_discovered_at: 2026-08-13T00:09:52Z
   expected_samples: 50
   threshold_file: "tests/test_ci/tts_mps_ci_config.py"
   threshold_file_sha256: 13b6deecde2c217c0f1869077f8d4301e77378e98c80b5cc9ddb44732e3d23ab

--- a/.claude/skills/tune-ci-thresholds/models/tts/stages.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/tts/stages.yaml
@@ -13,10 +13,10 @@ tts_higgs_nonstream_wer:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
+  threshold_file_sha256: 9c680b9950cf33f43f97932b98b4492ca99c8dd82955391bc197082bb8c35526
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json"
@@ -49,10 +49,10 @@ tts_higgs_nonstream_similarity:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 50
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
+  threshold_file_sha256: 9c680b9950cf33f43f97932b98b4492ca99c8dd82955391bc197082bb8c35526
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
@@ -85,10 +85,10 @@ tts_higgs_nonstream_utmos:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
+  threshold_file_sha256: 9c680b9950cf33f43f97932b98b4492ca99c8dd82955391bc197082bb8c35526
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json"
@@ -121,10 +121,10 @@ tts_higgs_nonstream_speed:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
+  threshold_file_sha256: 9c680b9950cf33f43f97932b98b4492ca99c8dd82955391bc197082bb8c35526
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
@@ -187,10 +187,10 @@ tts_moss_nonstream_wer:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
+  threshold_file_sha256: 9c680b9950cf33f43f97932b98b4492ca99c8dd82955391bc197082bb8c35526
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json"
@@ -223,10 +223,10 @@ tts_moss_nonstream_similarity:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 50
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
+  threshold_file_sha256: 9c680b9950cf33f43f97932b98b4492ca99c8dd82955391bc197082bb8c35526
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
@@ -259,10 +259,10 @@ tts_moss_nonstream_utmos:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
+  threshold_file_sha256: 9c680b9950cf33f43f97932b98b4492ca99c8dd82955391bc197082bb8c35526
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json"
@@ -295,10 +295,10 @@ tts_moss_nonstream_speed:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
+  threshold_file_sha256: 9c680b9950cf33f43f97932b98b4492ca99c8dd82955391bc197082bb8c35526
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
@@ -361,10 +361,10 @@ tts_qwen3-tts_nonstream_wer:
     - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
+  threshold_file_sha256: 9c680b9950cf33f43f97932b98b4492ca99c8dd82955391bc197082bb8c35526
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json"
@@ -397,10 +397,10 @@ tts_qwen3-tts_nonstream_similarity:
     - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 50
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
+  threshold_file_sha256: 9c680b9950cf33f43f97932b98b4492ca99c8dd82955391bc197082bb8c35526
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
@@ -433,10 +433,10 @@ tts_qwen3-tts_nonstream_utmos:
     - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
+  threshold_file_sha256: 9c680b9950cf33f43f97932b98b4492ca99c8dd82955391bc197082bb8c35526
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json"
@@ -469,10 +469,10 @@ tts_qwen3-tts_nonstream_speed:
     - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
+  threshold_file_sha256: 9c680b9950cf33f43f97932b98b4492ca99c8dd82955391bc197082bb8c35526
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
@@ -535,10 +535,10 @@ tts_higgs_stream_wer:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
+  threshold_file_sha256: 9c680b9950cf33f43f97932b98b4492ca99c8dd82955391bc197082bb8c35526
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/wer_results.json"
@@ -571,10 +571,10 @@ tts_higgs_stream_speed:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
+  threshold_file_sha256: 9c680b9950cf33f43f97932b98b4492ca99c8dd82955391bc197082bb8c35526
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
@@ -627,10 +627,10 @@ tts_moss_stream_wer:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
+  threshold_file_sha256: 9c680b9950cf33f43f97932b98b4492ca99c8dd82955391bc197082bb8c35526
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/wer_results.json"
@@ -663,10 +663,10 @@ tts_moss_stream_speed:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
+  threshold_file_sha256: 9c680b9950cf33f43f97932b98b4492ca99c8dd82955391bc197082bb8c35526
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
@@ -719,10 +719,10 @@ tts_qwen3-tts_stream_wer:
     - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
+  threshold_file_sha256: 9c680b9950cf33f43f97932b98b4492ca99c8dd82955391bc197082bb8c35526
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/wer_results.json"
@@ -755,10 +755,10 @@ tts_qwen3-tts_stream_speed:
     - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
+  threshold_file_sha256: 9c680b9950cf33f43f97932b98b4492ca99c8dd82955391bc197082bb8c35526
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
@@ -805,7 +805,7 @@ tts_serving_mixed_speech_normal_speed:
   context_vars: []
   variant: "mixed_speech_normal"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -848,7 +848,7 @@ tts_serving_mixed_rest_stream_speed:
   context_vars: []
   variant: "mixed_rest_stream"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -911,7 +911,7 @@ tts_serving_mixed_batch32_speed:
   context_vars: []
   variant: "mixed_batch32"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -944,7 +944,7 @@ tts_serving_mixed_ws_normal_speed:
   context_vars: []
   variant: "mixed_ws_normal"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -987,7 +987,7 @@ tts_serving_mixed_ws_stream_speed:
   context_vars: []
   variant: "mixed_ws_stream"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -1050,7 +1050,7 @@ tts_serving_mixed_long_speed:
   context_vars: []
   variant: "mixed_long"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -1129,7 +1129,7 @@ tts_mps_dp2_higgs_speed:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 6d5a45b023ded77318085347a82d81752211379f132bd675487610ed1d5e4bd7
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 1088
   threshold_file: "tests/test_ci/tts_mps_ci_config.py"
   threshold_file_sha256: 13b6deecde2c217c0f1869077f8d4301e77378e98c80b5cc9ddb44732e3d23ab
@@ -1201,7 +1201,7 @@ tts_mps_dp2_higgs_similarity:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 6d5a45b023ded77318085347a82d81752211379f132bd675487610ed1d5e4bd7
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 50
   threshold_file: "tests/test_ci/tts_mps_ci_config.py"
   threshold_file_sha256: 13b6deecde2c217c0f1869077f8d4301e77378e98c80b5cc9ddb44732e3d23ab
@@ -1243,7 +1243,7 @@ tts_mps_dp2_moss_speed:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 6d5a45b023ded77318085347a82d81752211379f132bd675487610ed1d5e4bd7
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 1088
   threshold_file: "tests/test_ci/tts_mps_ci_config.py"
   threshold_file_sha256: 13b6deecde2c217c0f1869077f8d4301e77378e98c80b5cc9ddb44732e3d23ab
@@ -1315,7 +1315,7 @@ tts_mps_dp2_moss_similarity:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 6d5a45b023ded77318085347a82d81752211379f132bd675487610ed1d5e4bd7
-  last_discovered_at: 2026-08-13T02:06:30Z
+  last_discovered_at: 2026-08-13T08:32:25Z
   expected_samples: 50
   threshold_file: "tests/test_ci/tts_mps_ci_config.py"
   threshold_file_sha256: 13b6deecde2c217c0f1869077f8d4301e77378e98c80b5cc9ddb44732e3d23ab

--- a/.claude/skills/tune-ci-thresholds/models/tts/stages.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/tts/stages.yaml
@@ -13,10 +13,10 @@ tts_higgs_nonstream_wer:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
+  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json"
@@ -49,10 +49,10 @@ tts_higgs_nonstream_similarity:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 50
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
+  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
@@ -85,10 +85,10 @@ tts_higgs_nonstream_utmos:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
+  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json"
@@ -121,10 +121,10 @@ tts_higgs_nonstream_speed:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
+  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
@@ -187,10 +187,10 @@ tts_moss_nonstream_wer:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
+  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json"
@@ -223,10 +223,10 @@ tts_moss_nonstream_similarity:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 50
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
+  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
@@ -259,10 +259,10 @@ tts_moss_nonstream_utmos:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
+  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json"
@@ -295,10 +295,10 @@ tts_moss_nonstream_speed:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
+  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
@@ -361,10 +361,10 @@ tts_qwen3-tts_nonstream_wer:
     - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
+  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json"
@@ -397,10 +397,10 @@ tts_qwen3-tts_nonstream_similarity:
     - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 50
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
+  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
@@ -433,10 +433,10 @@ tts_qwen3-tts_nonstream_utmos:
     - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
+  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json"
@@ -469,10 +469,10 @@ tts_qwen3-tts_nonstream_speed:
     - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
+  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
@@ -535,10 +535,10 @@ tts_higgs_stream_wer:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
+  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/wer_results.json"
@@ -571,10 +571,10 @@ tts_higgs_stream_speed:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
+  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
@@ -627,10 +627,10 @@ tts_moss_stream_wer:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
+  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/wer_results.json"
@@ -663,10 +663,10 @@ tts_moss_stream_speed:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
+  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
@@ -719,10 +719,10 @@ tts_qwen3-tts_stream_wer:
     - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
+  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/wer_results.json"
@@ -755,10 +755,10 @@ tts_qwen3-tts_stream_speed:
     - "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: c47edfe4eeabc8298eb4ee1fe235d2ac22299386dbf8e7f0cd1d6a341e5e61f9
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e4c1b13bf7d6c2115484bbdd5f0c5dd563a62e9d9d89638c88dce255f51c186e
+  threshold_file_sha256: 3d836f7428b4ded43062465989c55062c1385ed29fc5df2245c4ecb78841f5e3
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
@@ -805,7 +805,7 @@ tts_serving_mixed_speech_normal_speed:
   context_vars: []
   variant: "mixed_speech_normal"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -848,7 +848,7 @@ tts_serving_mixed_rest_stream_speed:
   context_vars: []
   variant: "mixed_rest_stream"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -911,7 +911,7 @@ tts_serving_mixed_batch32_speed:
   context_vars: []
   variant: "mixed_batch32"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -944,7 +944,7 @@ tts_serving_mixed_ws_normal_speed:
   context_vars: []
   variant: "mixed_ws_normal"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -987,7 +987,7 @@ tts_serving_mixed_ws_stream_speed:
   context_vars: []
   variant: "mixed_ws_stream"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -1050,7 +1050,7 @@ tts_serving_mixed_long_speed:
   context_vars: []
   variant: "mixed_long"
   test_file_sha256: 513f654ae8773c4abfe05f444c0b6f13739adbfb11f331a463f0955599021f31
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   observation_validity:
     json_file: "tts-serving-ci0/benchmark_validation.json"
     json_path: "valid"
@@ -1129,7 +1129,7 @@ tts_mps_dp2_higgs_speed:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 6d5a45b023ded77318085347a82d81752211379f132bd675487610ed1d5e4bd7
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 1088
   threshold_file: "tests/test_ci/tts_mps_ci_config.py"
   threshold_file_sha256: 13b6deecde2c217c0f1869077f8d4301e77378e98c80b5cc9ddb44732e3d23ab
@@ -1201,7 +1201,7 @@ tts_mps_dp2_higgs_similarity:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 6d5a45b023ded77318085347a82d81752211379f132bd675487610ed1d5e4bd7
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 50
   threshold_file: "tests/test_ci/tts_mps_ci_config.py"
   threshold_file_sha256: 13b6deecde2c217c0f1869077f8d4301e77378e98c80b5cc9ddb44732e3d23ab
@@ -1243,7 +1243,7 @@ tts_mps_dp2_moss_speed:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 6d5a45b023ded77318085347a82d81752211379f132bd675487610ed1d5e4bd7
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 1088
   threshold_file: "tests/test_ci/tts_mps_ci_config.py"
   threshold_file_sha256: 13b6deecde2c217c0f1869077f8d4301e77378e98c80b5cc9ddb44732e3d23ab
@@ -1315,7 +1315,7 @@ tts_mps_dp2_moss_similarity:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 6d5a45b023ded77318085347a82d81752211379f132bd675487610ed1d5e4bd7
-  last_discovered_at: 2026-08-13T00:09:52Z
+  last_discovered_at: 2026-08-13T02:06:30Z
   expected_samples: 50
   threshold_file: "tests/test_ci/tts_mps_ci_config.py"
   threshold_file_sha256: 13b6deecde2c217c0f1869077f8d4301e77378e98c80b5cc9ddb44732e3d23ab

--- a/.claude/skills/tune-ci-thresholds/tune.py
+++ b/.claude/skills/tune-ci-thresholds/tune.py
@@ -3739,10 +3739,16 @@ def _wait_pytest_with_watchdog(
     poll_s = _PYTEST_POLL_S
     if cpuset:
         ContentionSampler = _import_contention_sampler()
+        # Note: (Jiaxin Deng) root the own-work tree at the container init,
+        # not the pytest pid: stage supervisors double-fork at launch and
+        # reparent to init, so a pytest-rooted tree counts the run's own
+        # vocoder/preprocessing CPU as foreign and aborts on itself.
+        # /proc/stat core counters are host-global, so genuinely external
+        # intruders on the lane are still caught.
         sampler = ContentionSampler(
             parse_cpuset_spec(cpuset),
             interval_s=_CPUSET_MONITOR_INTERVAL_S,
-            root_pid=pytest_proc.pid,
+            root_pid=1,
         )
         sampler.start()
         poll_s = min(_PYTEST_POLL_S, _CPUSET_MONITOR_INTERVAL_S)

--- a/.claude/skills/tune-ci-thresholds/tune.py
+++ b/.claude/skills/tune-ci-thresholds/tune.py
@@ -2707,6 +2707,11 @@ def _load_yaml(path, top_is_dict=False):
             if ind(ln) < need: return r
             key, _, rest = ln.strip().partition(":")
             key, rest = key.strip(), rest.strip()
+            # Note: (Jiaxin Deng) quoted keys such as "0,1" in
+            # gpu_group_cpusets must lose their quotes like values do, or
+            # lane resolution parses '"0' as an int and dies.
+            if len(key) >= 2 and key[0] == '"' and key[-1] == '"':
+                key = key[1:-1]
             idx[0] += 1
             if rest: r[key] = sc(rest); continue
             if idx[0] < len(lines) and lines[idx[0]].lstrip().startswith("- "):

--- a/.github/workflows/omni-ci.yaml
+++ b/.github/workflows/omni-ci.yaml
@@ -123,22 +123,30 @@ jobs:
         env:
           RUN_HIGGS_LABEL: ${{ contains(fromJson(steps.pr.outputs.labels || '[]'), 'run-higgs') }}
           RUN_MOSS_LABEL: ${{ contains(fromJson(steps.pr.outputs.labels || '[]'), 'run-moss') }}
+          RUN_QWEN3TTS_LABEL: ${{ contains(fromJson(steps.pr.outputs.labels || '[]'), 'run-qwen3tts') }}
           TTS_CI_MODEL_OVERRIDE: ${{ github.event.inputs.tts_ci_model }}
           EXACT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          models=(higgs moss)
+          models=(higgs moss qwen3tts)
           override="${TTS_CI_MODEL_OVERRIDE,,}"
-          if [[ "${RUN_HIGGS_LABEL}" == "true" && "${RUN_MOSS_LABEL}" == "true" ]]; then
-            echo "::error::run-higgs and run-moss labels cannot both be set"
+          label_count=0
+          for flag in "${RUN_HIGGS_LABEL}" "${RUN_MOSS_LABEL}" "${RUN_QWEN3TTS_LABEL}"; do
+            [[ "${flag}" == "true" ]] && label_count=$((label_count + 1))
+          done
+          if [[ "${label_count}" -gt 1 ]]; then
+            echo "::error::run-higgs, run-moss and run-qwen3tts are mutually exclusive"
             exit 1
           fi
 
           selection_digest=""
           if [[ -n "${override}" ]]; then
-            if [[ "${override}" != "higgs" && "${override}" != "moss" ]]; then
-              echo "::error::unsupported tts_ci_model=${TTS_CI_MODEL_OVERRIDE}; expected higgs or moss"
-              exit 1
-            fi
+            case "${override}" in
+              higgs|moss|qwen3tts) ;;
+              *)
+                echo "::error::unsupported tts_ci_model=${TTS_CI_MODEL_OVERRIDE}; expected higgs, moss or qwen3tts"
+                exit 1
+                ;;
+            esac
             selected_model="${override}"
             selection_reason="workflow_dispatch_override"
           elif [[ "${RUN_HIGGS_LABEL}" == "true" ]]; then
@@ -147,28 +155,38 @@ jobs:
           elif [[ "${RUN_MOSS_LABEL}" == "true" ]]; then
             selected_model="moss"
             selection_reason="run-moss_label"
+          elif [[ "${RUN_QWEN3TTS_LABEL}" == "true" ]]; then
+            selected_model="qwen3tts"
+            selection_reason="run-qwen3tts_label"
           else
             selection_digest="$(printf "%s" "${GITHUB_RUN_ID}" | sha256sum | awk '{print $1}')"
-            selection_index=$((16#${selection_digest: -1} % 2))
+            selection_index=$((16#${selection_digest: -1} % ${#models[@]}))
             selected_model="${models[${selection_index}]}"
             selection_reason="stable_github_run_id_digest"
           fi
 
+          # Qwen3-TTS is gated as a single instance, so it resolves no MPS
+          # config and the MPS stage is skipped for it.
           if [[ "${selected_model}" == "higgs" ]]; then
             resolved_config="examples/mps_dp/configs/higgs_h100_dp3.yaml"
             expected_config_cls="HiggsTtsPipelineConfig"
-          else
+          elif [[ "${selected_model}" == "moss" ]]; then
             resolved_config="examples/mps_dp/configs/moss_local_h100_dp2.yaml"
             expected_config_cls="MossTTSLocalPipelineConfig"
+          else
+            resolved_config=""
+            expected_config_cls=""
           fi
-          if [[ ! -f "${resolved_config}" ]]; then
+          if [[ -n "${resolved_config}" && ! -f "${resolved_config}" ]]; then
             echo "::error::MPS config is missing for ${selected_model}: ${resolved_config}"
             exit 1
           fi
-          actual_config_cls="$(sed -n 's/^config_cls:[[:space:]]*//p' "${resolved_config}")"
-          if [[ "${actual_config_cls}" != "${expected_config_cls}" ]]; then
-            echo "::error::resolved config mismatch for ${selected_model}: ${actual_config_cls}; expected ${expected_config_cls}"
-            exit 1
+          if [[ -n "${resolved_config}" ]]; then
+            actual_config_cls="$(sed -n 's/^config_cls:[[:space:]]*//p' "${resolved_config}")"
+            if [[ "${actual_config_cls}" != "${expected_config_cls}" ]]; then
+              echo "::error::resolved config mismatch for ${selected_model}: ${actual_config_cls}; expected ${expected_config_cls}"
+              exit 1
+            fi
           fi
 
           output_dir="${RUNNER_TEMP}/tts-preflight"

--- a/.github/workflows/omni-ci.yaml
+++ b/.github/workflows/omni-ci.yaml
@@ -166,8 +166,8 @@ jobs:
             selection_reason="stable_github_run_id_digest"
           fi
 
-          # Qwen3-TTS is gated as a single instance, so it resolves no MPS
-          # config and the MPS stage is skipped for it.
+          # Note: (Jiaxin Deng) Qwen3-TTS is gated as a single instance, so
+          # it resolves no MPS config and the MPS stage is skipped for it.
           if [[ "${selected_model}" == "higgs" ]]; then
             resolved_config="examples/mps_dp/configs/higgs_h100_dp3.yaml"
             expected_config_cls="HiggsTtsPipelineConfig"

--- a/.github/workflows/omni-ci.yaml
+++ b/.github/workflows/omni-ci.yaml
@@ -27,7 +27,7 @@ on:
   workflow_dispatch:
     inputs:
       tts_ci_model:
-        description: "Optional TTS CI model preset to run (higgs, moss or qwen3tts). Leave empty for random."
+        description: "Optional TTS CI model preset to run (higgs, moss or qwen3-tts). Leave empty for random."
         required: false
         type: string
         default: ""
@@ -124,27 +124,27 @@ jobs:
         env:
           RUN_HIGGS_LABEL: ${{ contains(fromJson(steps.pr.outputs.labels || '[]'), 'run-higgs') }}
           RUN_MOSS_LABEL: ${{ contains(fromJson(steps.pr.outputs.labels || '[]'), 'run-moss') }}
-          RUN_QWEN3TTS_LABEL: ${{ contains(fromJson(steps.pr.outputs.labels || '[]'), 'run-qwen3tts') }}
+          RUN_QWEN3_TTS_LABEL: ${{ contains(fromJson(steps.pr.outputs.labels || '[]'), 'run-qwen3-tts') }}
           TTS_CI_MODEL_OVERRIDE: ${{ github.event.inputs.tts_ci_model }}
           EXACT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          models=(higgs moss qwen3tts)
+          models=(higgs moss qwen3-tts)
           override="${TTS_CI_MODEL_OVERRIDE,,}"
           label_count=0
-          for flag in "${RUN_HIGGS_LABEL}" "${RUN_MOSS_LABEL}" "${RUN_QWEN3TTS_LABEL}"; do
+          for flag in "${RUN_HIGGS_LABEL}" "${RUN_MOSS_LABEL}" "${RUN_QWEN3_TTS_LABEL}"; do
             [[ "${flag}" == "true" ]] && label_count=$((label_count + 1))
           done
           if [[ "${label_count}" -gt 1 ]]; then
-            echo "::error::run-higgs, run-moss and run-qwen3tts are mutually exclusive"
+            echo "::error::run-higgs, run-moss and run-qwen3-tts are mutually exclusive"
             exit 1
           fi
 
           selection_digest=""
           if [[ -n "${override}" ]]; then
             case "${override}" in
-              higgs|moss|qwen3tts) ;;
+              higgs|moss|qwen3-tts) ;;
               *)
-                echo "::error::unsupported tts_ci_model=${TTS_CI_MODEL_OVERRIDE}; expected higgs, moss or qwen3tts"
+                echo "::error::unsupported tts_ci_model=${TTS_CI_MODEL_OVERRIDE}; expected higgs, moss or qwen3-tts"
                 exit 1
                 ;;
             esac
@@ -156,9 +156,9 @@ jobs:
           elif [[ "${RUN_MOSS_LABEL}" == "true" ]]; then
             selected_model="moss"
             selection_reason="run-moss_label"
-          elif [[ "${RUN_QWEN3TTS_LABEL}" == "true" ]]; then
-            selected_model="qwen3tts"
-            selection_reason="run-qwen3tts_label"
+          elif [[ "${RUN_QWEN3_TTS_LABEL}" == "true" ]]; then
+            selected_model="qwen3-tts"
+            selection_reason="run-qwen3-tts_label"
           else
             selection_digest="$(printf "%s" "${GITHUB_RUN_ID}" | sha256sum | awk '{print $1}')"
             selection_index=$((16#${selection_digest: -1} % ${#models[@]}))

--- a/.github/workflows/omni-ci.yaml
+++ b/.github/workflows/omni-ci.yaml
@@ -27,7 +27,7 @@ on:
   workflow_dispatch:
     inputs:
       tts_ci_model:
-        description: "Optional TTS CI model preset to run (higgs or moss). Leave empty for random."
+        description: "Optional TTS CI model preset to run (higgs, moss or qwen3tts). Leave empty for random."
         required: false
         type: string
         default: ""
@@ -53,6 +53,7 @@ env:
         || format('/data/omni-ci/run-{0}', github.run_id) }}
   TTS_MODEL_PATH: bosonai/higgs-tts-3-4b
   MOSS_TTS_MODEL_PATH: OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5
+  QWEN3_TTS_MODEL_PATH: Qwen/Qwen3-TTS-12Hz-1.7B-Base
   QWEN3_ASR_MODEL_PATH: Qwen/Qwen3-ASR-1.7B
   MOSS_TRANSCRIBE_DIARIZE_MODEL_PATH: OpenMOSS-Team/MOSS-Transcribe-Diarize
   FUN_ASR_MODEL_PATH: FunAudioLLM/Fun-ASR-Nano-2512-hf
@@ -298,6 +299,7 @@ jobs:
             "${MOSS_TRANSCRIBE_DIARIZE_MODEL_PATH}" \
             "${TTS_MODEL_PATH}" \
             "${MOSS_TTS_MODEL_PATH}" \
+            "${QWEN3_TTS_MODEL_PATH}" \
             "${FUN_ASR_MODEL_PATH}"
 
       - name: Mark PR environment complete

--- a/.github/workflows/test-tts-ci.yaml
+++ b/.github/workflows/test-tts-ci.yaml
@@ -7,8 +7,12 @@ on:
         type: string
         default: higgs
       tts_mps_config:
+        description: >-
+          MPS-DP config for stage 5. Empty for models gated as a single
+          instance, which skips that stage.
         type: string
-        required: true
+        required: false
+        default: ""
       exact_sha:
         type: string
         required: true
@@ -272,7 +276,10 @@ jobs:
   stage-5-mps:
     name: stage 5 - MPS
     needs: stage-4-serving
-    if: always() && !cancelled()
+    # Qwen3-TTS is gated as a single instance: the tuned single instance beats
+    # the same-card pool there, so colocation is not the recommended topology
+    # and there is no MPS config to run.
+    if: always() && !cancelled() && inputs.tts_mps_config != ''
     runs-on: [self-hosted, h100]
     timeout-minutes: 25
     container:

--- a/.github/workflows/test-tts-ci.yaml
+++ b/.github/workflows/test-tts-ci.yaml
@@ -276,9 +276,9 @@ jobs:
   stage-5-mps:
     name: stage 5 - MPS
     needs: stage-4-serving
-    # Qwen3-TTS is gated as a single instance: the tuned single instance beats
-    # the same-card pool there, so colocation is not the recommended topology
-    # and there is no MPS config to run.
+    # Note: (Jiaxin Deng) Qwen3-TTS is gated as a single instance: the tuned
+    # single instance beats the same-card pool there, so colocation is not the
+    # recommended topology and there is no MPS config to run.
     if: always() && !cancelled() && inputs.tts_mps_config != ''
     runs-on: [self-hosted, h100]
     timeout-minutes: 25

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,10 @@ dependencies = [
     "logger",
     "httpx",
     "xxhash>=3.0.0",
-    # Qwen3-TTS: the documented install line for the model package is
-    # `--no-deps qwen-tts==0.1.1`, and --no-deps is exactly what drops sox, so
-    # `import qwen_tts` raises ModuleNotFoundError before a worker binds a port.
+    # Note: (Jiaxin Deng) the documented install line for the Qwen3-TTS model
+    # package is `--no-deps qwen-tts==0.1.1`, and --no-deps is exactly what drops
+    # sox, so `import qwen_tts` raises ModuleNotFoundError before a worker binds
+    # a port.
     "sox>=1.4.1",
     "av>=16.1.0",
     "qwen-vl-utils==0.0.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ dependencies = [
     "logger",
     "httpx",
     "xxhash>=3.0.0",
+    # Qwen3-TTS: the documented install line for the model package is
+    # `--no-deps qwen-tts==0.1.1`, and --no-deps is exactly what drops sox, so
+    # `import qwen_tts` raises ModuleNotFoundError before a worker binds a port.
+    "sox>=1.4.1",
     "av>=16.1.0",
     "qwen-vl-utils==0.0.11",
     "numba==0.65.1",  # Match SGLang 0.5.16

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -10,7 +10,7 @@ PERMISSIONS_FILE_PATH = ".github/CI_PERMISSIONS.json"
 TTS_MODEL_LABELS = {
     "higgs": "run-higgs",
     "moss": "run-moss",
-    "qwen3tts": "run-qwen3tts",
+    "qwen3-tts": "run-qwen3-tts",
 }
 ASR_MODEL_LABELS = {
     "fun-asr": "run-fun-asr",

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -10,6 +10,7 @@ PERMISSIONS_FILE_PATH = ".github/CI_PERMISSIONS.json"
 TTS_MODEL_LABELS = {
     "higgs": "run-higgs",
     "moss": "run-moss",
+    "qwen3tts": "run-qwen3tts",
 }
 ASR_MODEL_LABELS = {
     "fun-asr": "run-fun-asr",
@@ -55,7 +56,8 @@ def load_permissions(user_login):
 def parse_model_targets(tokens):
     tts_targets = [token for token in tokens[1:] if token in TTS_MODEL_LABELS]
     if len(set(tts_targets)) > 1:
-        return None, None, "Specify only one TTS CI model target: higgs or moss."
+        allowed = ", ".join(sorted(TTS_MODEL_LABELS))
+        return None, None, f"Specify only one TTS CI model target: {allowed}."
 
     asr_targets = [token for token in tokens[1:] if token in ASR_MODEL_LABELS]
     if len(set(asr_targets)) > 1:

--- a/tests/test_model/test_tts_ci.py
+++ b/tests/test_model/test_tts_ci.py
@@ -879,14 +879,16 @@ def test_voice_cloning_streaming_consistency(
             checks.fail(f"vc_stream_c{concurrency} results missing")
         if ns is None or st is None:
             continue
-        if _PRESET.gate_thresholds:
-            assert_streaming_consistency(
-                ns,
-                st,
-                expected_stream_count=len(ns),
-                max_failed_requests=0,
-                collector=checks,
-            )
+        # Note: (Jiaxin Deng) request coverage, the zero-failure budget and
+        # stream-vs-non-stream duration agreement are correctness, not tuned
+        # numbers, so they hold for a preset that is still observing.
+        assert_streaming_consistency(
+            ns,
+            st,
+            expected_stream_count=len(ns),
+            max_failed_requests=0,
+            collector=checks,
+        )
     checks.assert_all()
 
 

--- a/tests/test_model/tts_ci_config.py
+++ b/tests/test_model/tts_ci_config.py
@@ -29,10 +29,10 @@ class TtsCiThresholdPreset:
     stream_wer_corpus: float
     similarity_mean_min: float
     utmos_mean_min: float
-    # False while the values are seeds rather than worst-of-N observations from
-    # the CI runner. A seed can be an order of magnitude off for a topology it
-    # was not measured on, so gating on one fails builds for no reason or waves
-    # regressions through; the contract test refuses that combination.
+    # Note: (Jiaxin Deng) False while the values are seeds rather than
+    # worst-of-N observations from the CI runner. A seed can be far off for a
+    # topology it was not measured on, so gating on one fails builds for no
+    # reason or waves regressions through; a contract test refuses that pair.
     calibrated: bool = True
 
 
@@ -185,9 +185,9 @@ TTS_CI_PRESETS: dict[str, TtsCiPreset] = {
         model=TtsCiModelPreset(
             model_path="Qwen/Qwen3-TTS-12Hz-1.7B-Base",
             ref_format="references",
-            # The shipped defaults cap the AR engine at 16 running requests and
-            # colocate every stage in one process; both are what kept this
-            # variant behind, so CI measures the tuned operating point.
+            # Note: (Jiaxin Deng) the shipped defaults cap the AR engine at 16
+            # running requests and colocate every stage in one process; both are
+            # what kept this variant behind, so CI measures the tuned point.
             worker_extra_args=(
                 "--max-running-requests 64 "
                 "--cuda-graph-max-bs 64 "

--- a/tests/test_model/tts_ci_config.py
+++ b/tests/test_model/tts_ci_config.py
@@ -181,7 +181,7 @@ TTS_CI_PRESETS: dict[str, TtsCiPreset] = {
             utmos_mean_min=HIGGS_VC_UTMOS_MEAN_MIN,
         ),
     ),
-    "qwen3tts": TtsCiPreset(
+    "qwen3-tts": TtsCiPreset(
         model=TtsCiModelPreset(
             model_path="Qwen/Qwen3-TTS-12Hz-1.7B-Base",
             ref_format="references",

--- a/tests/test_model/tts_ci_config.py
+++ b/tests/test_model/tts_ci_config.py
@@ -29,6 +29,11 @@ class TtsCiThresholdPreset:
     stream_wer_corpus: float
     similarity_mean_min: float
     utmos_mean_min: float
+    # False while the values are seeds rather than worst-of-N observations from
+    # the CI runner. A seed can be an order of magnitude off for a topology it
+    # was not measured on, so gating on one fails builds for no reason or waves
+    # regressions through; the contract test refuses that combination.
+    calibrated: bool = True
 
 
 @dataclass(frozen=True)
@@ -116,21 +121,46 @@ MOSS_VC_STREAM_THRESHOLDS = apply_slack(
 # MPS-DP2 pool on peak throughput and holds a several-fold better first-audio
 # latency, so colocation is no longer the recommended topology for it.
 #
-# Note: (Jiaxin Deng) the model enters CI observing rather than gating. Numeric
-# thresholds only mean something once they come from a calibration run on the CI
-# runner itself, and a preset carrying invented numbers would either wave every
-# regression through or fail every run. `gate_thresholds=False` still exercises
-# the whole path (bring-up, streaming, consistency, WER reporting), so a crash or
-# a broken stream fails the stage; the numbers get filled from the calibration
-# stage and gating flips on in the follow-up.
-QWEN3_TTS_VC_WER_CORPUS_THRESHOLD = apply_wer_slack(0.0112)
-QWEN3_TTS_VC_STREAM_WER_CORPUS_THRESHOLD = apply_wer_slack(0.0112)
-QWEN3_TTS_VC_SIMILARITY_MEAN_MIN = 0.0
-QWEN3_TTS_VC_UTMOS_MEAN_MIN = 0.0
+# Note: (Jiaxin Deng) the model enters CI observing rather than gating: these
+# seeds come from a single-instance H100 benchmark, not from a calibration run
+# on the CI runner, so they are not fit to fail a build yet. They are written in
+# the same symbol shape the other presets use because that shape is what the
+# threshold calibration discovers and rewrites; an empty table or an inlined
+# literal is invisible to it, which would leave the model permanently
+# uncalibratable. Gating flips on with the calibrated values.
+QWEN3_TTS_VC_WER_MAX_CORPUS = 0.0112
+QWEN3_TTS_VC_WER_CORPUS_THRESHOLD = apply_wer_slack(QWEN3_TTS_VC_WER_MAX_CORPUS)
+QWEN3_TTS_VC_STREAM_WER_MAX_CORPUS = 0.0112
+QWEN3_TTS_VC_STREAM_WER_CORPUS_THRESHOLD = apply_wer_slack(
+    QWEN3_TTS_VC_STREAM_WER_MAX_CORPUS
+)
+QWEN3_TTS_VC_SIMILARITY_MEAN_MIN = 60.0
+QWEN3_TTS_VC_UTMOS_MEAN_REFERENCE = 3.9
+QWEN3_TTS_VC_UTMOS_MEAN_MIN = apply_mos_slack(QWEN3_TTS_VC_UTMOS_MEAN_REFERENCE)
 
-# Placeholders: replaced by the calibration run before gating is enabled.
-QWEN3_TTS_VC_NON_STREAM_THRESHOLDS: dict[int, dict[str, float]] = {}
-QWEN3_TTS_VC_STREAM_THRESHOLDS: dict[int, dict[str, float]] = {}
+_QWEN3_TTS_VC_NON_STREAM_P95 = {
+    16: {
+        "throughput_qps": 11.309,
+        "output_tok_per_req_s": 0.0,
+        "latency_mean_s": 2.021,
+        "rtf_mean": 0.3905,
+    }
+}
+
+_QWEN3_TTS_VC_STREAM_P95 = {
+    16: {
+        "throughput_qps": 11.309,
+        "latency_mean_s": 2.021,
+        "rtf_mean": 0.3905,
+    }
+}
+
+QWEN3_TTS_VC_NON_STREAM_THRESHOLDS = apply_slack(
+    _QWEN3_TTS_VC_NON_STREAM_P95, THRESHOLD_SLACK_HIGHER, THRESHOLD_SLACK_LOWER
+)
+QWEN3_TTS_VC_STREAM_THRESHOLDS = apply_slack(
+    _QWEN3_TTS_VC_STREAM_P95, THRESHOLD_SLACK_HIGHER, THRESHOLD_SLACK_LOWER
+)
 
 
 TTS_CI_PRESETS: dict[str, TtsCiPreset] = {
@@ -174,6 +204,7 @@ TTS_CI_PRESETS: dict[str, TtsCiPreset] = {
             stream_wer_corpus=QWEN3_TTS_VC_STREAM_WER_CORPUS_THRESHOLD,
             similarity_mean_min=QWEN3_TTS_VC_SIMILARITY_MEAN_MIN,
             utmos_mean_min=QWEN3_TTS_VC_UTMOS_MEAN_MIN,
+            calibrated=False,
         ),
     ),
     "moss": TtsCiPreset(

--- a/tests/test_model/tts_ci_config.py
+++ b/tests/test_model/tts_ci_config.py
@@ -121,37 +121,34 @@ MOSS_VC_STREAM_THRESHOLDS = apply_slack(
 # MPS-DP2 pool on peak throughput and holds a several-fold better first-audio
 # latency, so colocation is no longer the recommended topology for it.
 #
-# Note: (Jiaxin Deng) the model enters CI observing rather than gating: these
-# seeds come from a single-instance H100 benchmark, not from a calibration run
-# on the CI runner, so they are not fit to fail a build yet. They are written in
-# the same symbol shape the other presets use because that shape is what the
-# threshold calibration discovers and rewrites; an empty table or an inlined
-# literal is invisible to it, which would leave the model permanently
-# uncalibratable. Gating flips on with the calibrated values.
-QWEN3_TTS_VC_WER_MAX_CORPUS = 0.0112
+# Note: (Jiaxin Deng) calibrated on the CI host, lane 0,1 pinned cpuset
+# (2-15,66-79), worst-of-5 clean rounds with destructive rejection
+# (run .tune-runs/20260813T021112Z_tts_qwen3tts_r5). Raw pre-slack references
+# only; the CI slack calculation is unchanged.
+QWEN3_TTS_VC_WER_MAX_CORPUS = 0.011
 QWEN3_TTS_VC_WER_CORPUS_THRESHOLD = apply_wer_slack(QWEN3_TTS_VC_WER_MAX_CORPUS)
-QWEN3_TTS_VC_STREAM_WER_MAX_CORPUS = 0.0112
+QWEN3_TTS_VC_STREAM_WER_MAX_CORPUS = 0.0116
 QWEN3_TTS_VC_STREAM_WER_CORPUS_THRESHOLD = apply_wer_slack(
     QWEN3_TTS_VC_STREAM_WER_MAX_CORPUS
 )
-QWEN3_TTS_VC_SIMILARITY_MEAN_MIN = 60.0
-QWEN3_TTS_VC_UTMOS_MEAN_REFERENCE = 3.9
+QWEN3_TTS_VC_SIMILARITY_MEAN_MIN = 69.4295639038086
+QWEN3_TTS_VC_UTMOS_MEAN_REFERENCE = 4.195
 QWEN3_TTS_VC_UTMOS_MEAN_MIN = apply_mos_slack(QWEN3_TTS_VC_UTMOS_MEAN_REFERENCE)
 
 _QWEN3_TTS_VC_NON_STREAM_P95 = {
     16: {
-        "throughput_qps": 11.309,
-        "output_tok_per_req_s": 0.0,
-        "latency_mean_s": 2.021,
-        "rtf_mean": 0.3905,
+        "throughput_qps": 17.66,
+        "output_tok_per_req_s": 71.1,
+        "latency_mean_s": 0.901,
+        "rtf_mean": 0.2236,
     }
 }
 
 _QWEN3_TTS_VC_STREAM_P95 = {
     16: {
-        "throughput_qps": 11.309,
-        "latency_mean_s": 2.021,
-        "rtf_mean": 0.3905,
+        "throughput_qps": 15.324,
+        "latency_mean_s": 1.039,
+        "rtf_mean": 0.257,
     }
 }
 
@@ -195,7 +192,7 @@ TTS_CI_PRESETS: dict[str, TtsCiPreset] = {
                 "--isolate-stage vocoder"
             ),
             startup_timeout=300,
-            gate_thresholds=False,
+            gate_thresholds=True,
         ),
         thresholds=TtsCiThresholdPreset(
             non_stream_speed=QWEN3_TTS_VC_NON_STREAM_THRESHOLDS,
@@ -204,7 +201,6 @@ TTS_CI_PRESETS: dict[str, TtsCiPreset] = {
             stream_wer_corpus=QWEN3_TTS_VC_STREAM_WER_CORPUS_THRESHOLD,
             similarity_mean_min=QWEN3_TTS_VC_SIMILARITY_MEAN_MIN,
             utmos_mean_min=QWEN3_TTS_VC_UTMOS_MEAN_MIN,
-            calibrated=False,
         ),
     ),
     "moss": TtsCiPreset(

--- a/tests/test_model/tts_ci_config.py
+++ b/tests/test_model/tts_ci_config.py
@@ -111,6 +111,27 @@ MOSS_VC_STREAM_THRESHOLDS = apply_slack(
     _MOSS_VC_STREAM_P95, THRESHOLD_SLACK_HIGHER, THRESHOLD_SLACK_LOWER
 )
 
+# Qwen3-TTS 1.7B. This is the variant the community deploys, and it is gated as
+# a single instance: on one H100 the tuned single instance beats the same-card
+# MPS-DP2 pool on peak throughput and holds a several-fold better first-audio
+# latency, so colocation is no longer the recommended topology for it.
+#
+# Note: (Jiaxin Deng) the model enters CI observing rather than gating. Numeric
+# thresholds only mean something once they come from a calibration run on the CI
+# runner itself, and a preset carrying invented numbers would either wave every
+# regression through or fail every run. `gate_thresholds=False` still exercises
+# the whole path (bring-up, streaming, consistency, WER reporting), so a crash or
+# a broken stream fails the stage; the numbers get filled from the calibration
+# stage and gating flips on in the follow-up.
+QWEN3_TTS_VC_WER_CORPUS_THRESHOLD = apply_wer_slack(0.0112)
+QWEN3_TTS_VC_STREAM_WER_CORPUS_THRESHOLD = apply_wer_slack(0.0112)
+QWEN3_TTS_VC_SIMILARITY_MEAN_MIN = 0.0
+QWEN3_TTS_VC_UTMOS_MEAN_MIN = 0.0
+
+# Placeholders: replaced by the calibration run before gating is enabled.
+QWEN3_TTS_VC_NON_STREAM_THRESHOLDS: dict[int, dict[str, float]] = {}
+QWEN3_TTS_VC_STREAM_THRESHOLDS: dict[int, dict[str, float]] = {}
+
 
 TTS_CI_PRESETS: dict[str, TtsCiPreset] = {
     "higgs": TtsCiPreset(
@@ -128,6 +149,31 @@ TTS_CI_PRESETS: dict[str, TtsCiPreset] = {
             stream_wer_corpus=HIGGS_VC_STREAM_WER_CORPUS_THRESHOLD,
             similarity_mean_min=HIGGS_VC_SIMILARITY_MEAN_MIN,
             utmos_mean_min=HIGGS_VC_UTMOS_MEAN_MIN,
+        ),
+    ),
+    "qwen3tts": TtsCiPreset(
+        model=TtsCiModelPreset(
+            model_path="Qwen/Qwen3-TTS-12Hz-1.7B-Base",
+            ref_format="references",
+            # The shipped defaults cap the AR engine at 16 running requests and
+            # colocate every stage in one process; both are what kept this
+            # variant behind, so CI measures the tuned operating point.
+            worker_extra_args=(
+                "--max-running-requests 64 "
+                "--cuda-graph-max-bs 64 "
+                "--talker-torch-compile-max-bs 64 "
+                "--isolate-stage vocoder"
+            ),
+            startup_timeout=300,
+            gate_thresholds=False,
+        ),
+        thresholds=TtsCiThresholdPreset(
+            non_stream_speed=QWEN3_TTS_VC_NON_STREAM_THRESHOLDS,
+            stream_speed=QWEN3_TTS_VC_STREAM_THRESHOLDS,
+            wer_corpus=QWEN3_TTS_VC_WER_CORPUS_THRESHOLD,
+            stream_wer_corpus=QWEN3_TTS_VC_STREAM_WER_CORPUS_THRESHOLD,
+            similarity_mean_min=QWEN3_TTS_VC_SIMILARITY_MEAN_MIN,
+            utmos_mean_min=QWEN3_TTS_VC_UTMOS_MEAN_MIN,
         ),
     ),
     "moss": TtsCiPreset(

--- a/tests/unit_test/ci/test_tts_model_rotation_contract.py
+++ b/tests/unit_test/ci/test_tts_model_rotation_contract.py
@@ -63,16 +63,16 @@ def test_single_instance_models_skip_the_mps_stage() -> None:
     assert "||" not in condition, f"stage 5 condition is bypassable: {condition}"
 
 
-def test_qwen3_tts_enters_observing_not_gating() -> None:
-    """Thresholds are only meaningful once calibrated on the CI runner."""
+def test_qwen3_tts_gates_on_calibrated_thresholds() -> None:
+    """Gating is only valid because the values came from a calibration run."""
     _, preset = select_tts_ci_preset("qwen3-tts")
     assert preset.model.model_path == "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
-    assert preset.model.gate_thresholds is False
-    assert preset.thresholds.calibrated is False
-    # The tables carry seeds in the calibratable symbol shape, not empties: an
-    # empty table is invisible to the threshold calibration.
-    assert preset.thresholds.non_stream_speed
-    assert preset.thresholds.stream_speed
+    assert preset.model.gate_thresholds is True
+    assert preset.thresholds.calibrated is True
+    # Calibrated worst-of-N floors (17.66 and 15.324 pre-slack), not the
+    # pre-calibration seed of 11.309.
+    assert preset.thresholds.non_stream_speed[16]["throughput_qps_min"] > 11.309
+    assert preset.thresholds.stream_speed[16]["throughput_qps_min"] > 11.309
     # The tuned operating point, not the shipped defaults, is what CI measures.
     assert "--max-running-requests 64" in preset.model.worker_extra_args
     assert "--isolate-stage vocoder" in preset.model.worker_extra_args

--- a/tests/unit_test/ci/test_tts_model_rotation_contract.py
+++ b/tests/unit_test/ci/test_tts_model_rotation_contract.py
@@ -40,12 +40,12 @@ def test_rotation_offers_every_registered_preset() -> None:
         # the conflict error text, so deleting the selection branch entirely
         # would still pass.
         assert f"RUN_{model.upper()}_LABEL" in script, f"no label env for {model}"
-        assert f'selection_reason="run-{model}_label"' in script, (
-            f"no selection branch for {model}"
-        )
-        assert model in script.partition("case ")[2].partition(")")[0], (
-            f"dispatch override does not accept {model}"
-        )
+        assert (
+            f'selection_reason="run-{model}_label"' in script
+        ), f"no selection branch for {model}"
+        assert (
+            model in script.partition("case ")[2].partition(")")[0]
+        ), f"dispatch override does not accept {model}"
 
 
 def test_single_instance_models_skip_the_mps_stage() -> None:
@@ -142,12 +142,10 @@ def test_calibration_filters_can_claim_the_presets_constants() -> None:
     source = (REPO_ROOT / "tests/test_model/tts_ci_config.py").read_text(
         encoding="utf-8"
     )
-    constants = set(
-        re.findall(r"^_?([A-Z][A-Z0-9_]+)\s*[:=]", source, re.MULTILINE)
-    )
+    constants = set(re.findall(r"^_?([A-Z][A-Z0-9_]+)\s*[:=]", source, re.MULTILINE))
     presets = config["metric_sources"]["test_tts_ci.py"]["calibration_presets"]
     for name, preset in presets.items():
         pattern = re.compile(preset["constant_filter"])
-        assert [c for c in constants if pattern.match(c)], (
-            f"calibration filter for {name} claims no constant in tts_ci_config"
-        )
+        assert [
+            c for c in constants if pattern.match(c)
+        ], f"calibration filter for {name} claims no constant in tts_ci_config"

--- a/tests/unit_test/ci/test_tts_model_rotation_contract.py
+++ b/tests/unit_test/ci/test_tts_model_rotation_contract.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from tests.test_model.tts_ci_config import TTS_CI_PRESETS, select_tts_ci_preset
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+OMNI_WORKFLOW = REPO_ROOT / ".github/workflows/omni-ci.yaml"
+TTS_WORKFLOW = REPO_ROOT / ".github/workflows/test-tts-ci.yaml"
+
+
+def _workflow(path: Path) -> dict:
+    return yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def _select_step_script() -> str:
+    jobs = _workflow(OMNI_WORKFLOW)["jobs"]
+    preflight = jobs["preflight"]
+    step = next(s for s in preflight["steps"] if s.get("id") == "tts")
+    return step["run"]
+
+
+def test_rotation_offers_every_registered_preset() -> None:
+    """The workflow must be able to select every model the presets define."""
+    script = _select_step_script()
+    models_line = next(
+        line for line in script.splitlines() if line.strip().startswith("models=(")
+    )
+    rotation = set(models_line.split("(", 1)[1].split(")", 1)[0].split())
+    assert rotation == set(TTS_CI_PRESETS), (
+        f"workflow rotation {sorted(rotation)} does not match registered presets "
+        f"{sorted(TTS_CI_PRESETS)}"
+    )
+    for model in rotation:
+        assert f"run-{model}" in script, f"missing opt-in label for {model}"
+
+
+def test_single_instance_models_skip_the_mps_stage() -> None:
+    """A model without an MPS config must not drag the MPS stage along."""
+    script = _select_step_script()
+    assert 'resolved_config=""' in script, "no single-instance branch in preflight"
+
+    mps = _workflow(TTS_WORKFLOW)["jobs"]["stage-5-mps"]
+    assert (
+        "inputs.tts_mps_config != ''" in mps["if"]
+    ), "stage 5 must be conditional on an MPS config being resolved"
+
+
+def test_qwen3tts_enters_observing_not_gating() -> None:
+    """Thresholds are only meaningful once calibrated on the CI runner."""
+    _, preset = select_tts_ci_preset("qwen3tts")
+    assert preset.model.model_path == "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+    assert preset.model.gate_thresholds is False
+    assert not preset.thresholds.non_stream_speed
+    assert not preset.thresholds.stream_speed
+    # The tuned operating point, not the shipped defaults, is what CI measures.
+    assert "--max-running-requests 64" in preset.model.worker_extra_args
+    assert "--isolate-stage vocoder" in preset.model.worker_extra_args

--- a/tests/unit_test/ci/test_tts_model_rotation_contract.py
+++ b/tests/unit_test/ci/test_tts_model_rotation_contract.py
@@ -60,3 +60,44 @@ def test_qwen3tts_enters_observing_not_gating() -> None:
     # The tuned operating point, not the shipped defaults, is what CI measures.
     assert "--max-running-requests 64" in preset.model.worker_extra_args
     assert "--isolate-stage vocoder" in preset.model.worker_extra_args
+
+
+def test_every_registered_model_is_reachable_from_every_entry_point() -> None:
+    """Registration is only complete when all three entry points agree.
+
+    A model registered in the presets but missing from the slash-command map or
+    the calibration config is selectable by CI yet impossible to request or
+    calibrate, which is exactly how a model ends up with stale thresholds.
+    """
+    import ast
+
+    import yaml as _yaml
+
+    # Parsed rather than imported: the handler pulls in the GitHub SDK, which
+    # only exists on the CI runner.
+    handler = ast.parse(
+        (REPO_ROOT / "scripts/ci/utils/slash_command_handler.py").read_text(
+            encoding="utf-8"
+        )
+    )
+    labels = next(
+        ast.literal_eval(node.value)
+        for node in handler.body
+        if isinstance(node, ast.Assign)
+        and getattr(node.targets[0], "id", "") == "TTS_MODEL_LABELS"
+    )
+    assert set(labels) == set(TTS_CI_PRESETS), (
+        f"slash-command targets {sorted(labels)} do not match presets "
+        f"{sorted(TTS_CI_PRESETS)}"
+    )
+
+    calibration = _yaml.safe_load(
+        (
+            REPO_ROOT / ".claude/skills/tune-ci-thresholds/models/tts/config.yaml"
+        ).read_text(encoding="utf-8")
+    )
+    presets = calibration["metric_sources"]["test_tts_ci.py"]["calibration_presets"]
+    assert set(presets) == set(TTS_CI_PRESETS), (
+        f"calibration presets {sorted(presets)} do not match CI presets "
+        f"{sorted(TTS_CI_PRESETS)}"
+    )

--- a/tests/unit_test/ci/test_tts_model_rotation_contract.py
+++ b/tests/unit_test/ci/test_tts_model_rotation_contract.py
@@ -36,7 +36,16 @@ def test_rotation_offers_every_registered_preset() -> None:
         f"{sorted(TTS_CI_PRESETS)}"
     )
     for model in rotation:
-        assert f"run-{model}" in script, f"missing opt-in label for {model}"
+        # A bare substring check is not enough: the label name also appears in
+        # the conflict error text, so deleting the selection branch entirely
+        # would still pass.
+        assert f"RUN_{model.upper()}_LABEL" in script, f"no label env for {model}"
+        assert f'selection_reason="run-{model}_label"' in script, (
+            f"no selection branch for {model}"
+        )
+        assert model in script.partition("case ")[2].partition(")")[0], (
+            f"dispatch override does not accept {model}"
+        )
 
 
 def test_single_instance_models_skip_the_mps_stage() -> None:
@@ -45,9 +54,12 @@ def test_single_instance_models_skip_the_mps_stage() -> None:
     assert 'resolved_config=""' in script, "no single-instance branch in preflight"
 
     mps = _workflow(TTS_WORKFLOW)["jobs"]["stage-5-mps"]
+    condition = mps["if"]
     assert (
-        "inputs.tts_mps_config != ''" in mps["if"]
+        "inputs.tts_mps_config != ''" in condition
     ), "stage 5 must be conditional on an MPS config being resolved"
+    # A trailing `|| true` keeps the substring while making the guard inert.
+    assert "||" not in condition, f"stage 5 condition is bypassable: {condition}"
 
 
 def test_qwen3tts_enters_observing_not_gating() -> None:
@@ -55,8 +67,11 @@ def test_qwen3tts_enters_observing_not_gating() -> None:
     _, preset = select_tts_ci_preset("qwen3tts")
     assert preset.model.model_path == "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     assert preset.model.gate_thresholds is False
-    assert not preset.thresholds.non_stream_speed
-    assert not preset.thresholds.stream_speed
+    assert preset.thresholds.calibrated is False
+    # The tables carry seeds in the calibratable symbol shape, not empties: an
+    # empty table is invisible to the threshold calibration.
+    assert preset.thresholds.non_stream_speed
+    assert preset.thresholds.stream_speed
     # The tuned operating point, not the shipped defaults, is what CI measures.
     assert "--max-running-requests 64" in preset.model.worker_extra_args
     assert "--isolate-stage vocoder" in preset.model.worker_extra_args
@@ -101,3 +116,38 @@ def test_every_registered_model_is_reachable_from_every_entry_point() -> None:
         f"calibration presets {sorted(presets)} do not match CI presets "
         f"{sorted(TTS_CI_PRESETS)}"
     )
+
+
+def test_seed_thresholds_are_never_used_as_gates() -> None:
+    """Uncalibrated numbers must not be able to fail somebody else's build."""
+    for name, preset in TTS_CI_PRESETS.items():
+        if preset.model.gate_thresholds:
+            assert preset.thresholds.calibrated, (
+                f"{name} gates on thresholds that are still seeds; calibrate "
+                "before enabling gate_thresholds"
+            )
+
+
+def test_calibration_filters_can_claim_the_presets_constants() -> None:
+    """A filter matching nothing leaves a model silently uncalibratable."""
+    import re
+
+    import yaml as _yaml
+
+    config = _yaml.safe_load(
+        (
+            REPO_ROOT / ".claude/skills/tune-ci-thresholds/models/tts/config.yaml"
+        ).read_text(encoding="utf-8")
+    )
+    source = (REPO_ROOT / "tests/test_model/tts_ci_config.py").read_text(
+        encoding="utf-8"
+    )
+    constants = set(
+        re.findall(r"^_?([A-Z][A-Z0-9_]+)\s*[:=]", source, re.MULTILINE)
+    )
+    presets = config["metric_sources"]["test_tts_ci.py"]["calibration_presets"]
+    for name, preset in presets.items():
+        pattern = re.compile(preset["constant_filter"])
+        assert [c for c in constants if pattern.match(c)], (
+            f"calibration filter for {name} claims no constant in tts_ci_config"
+        )

--- a/tests/unit_test/ci/test_tts_model_rotation_contract.py
+++ b/tests/unit_test/ci/test_tts_model_rotation_contract.py
@@ -39,7 +39,8 @@ def test_rotation_offers_every_registered_preset() -> None:
         # A bare substring check is not enough: the label name also appears in
         # the conflict error text, so deleting the selection branch entirely
         # would still pass.
-        assert f"RUN_{model.upper()}_LABEL" in script, f"no label env for {model}"
+        env_name = f"RUN_{model.upper().replace('-', '_')}_LABEL"
+        assert env_name in script, f"no label env for {model}"
         assert (
             f'selection_reason="run-{model}_label"' in script
         ), f"no selection branch for {model}"
@@ -62,9 +63,9 @@ def test_single_instance_models_skip_the_mps_stage() -> None:
     assert "||" not in condition, f"stage 5 condition is bypassable: {condition}"
 
 
-def test_qwen3tts_enters_observing_not_gating() -> None:
+def test_qwen3_tts_enters_observing_not_gating() -> None:
     """Thresholds are only meaningful once calibrated on the CI runner."""
-    _, preset = select_tts_ci_preset("qwen3tts")
+    _, preset = select_tts_ci_preset("qwen3-tts")
     assert preset.model.model_path == "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     assert preset.model.gate_thresholds is False
     assert preset.thresholds.calibrated is False

--- a/tests/unit_test/ci/test_tts_mps_workflow_contract.py
+++ b/tests/unit_test/ci/test_tts_mps_workflow_contract.py
@@ -89,14 +89,15 @@ def test_cpu_selection_is_rerun_stable_and_conflicts_fail_before_h100() -> None:
     assert 'printf "%s" "${GITHUB_RUN_ID}" | sha256sum' in run
     assert "RUN_HIGGS_LABEL" in selection["env"]
     assert "RUN_MOSS_LABEL" in selection["env"]
-    assert "cannot both be set" in run
+    assert "RUN_QWEN3TTS_LABEL" in selection["env"]
+    assert "mutually exclusive" in run
     assert "GITHUB_RUN_ATTEMPT" not in run.partition("selection_digest=")[0]
     assert "tts_stage1_topology" not in omni["on"]["workflow_dispatch"]["inputs"]
     assert "pick-tts-model" not in omni["jobs"]
     assert "selected_model" in omni["jobs"]["preflight"]["outputs"]
 
 
-def test_mps_config_resolution_covers_both_selected_models() -> None:
+def test_mps_config_resolution_covers_the_colocated_models() -> None:
     omni = _workflow(OMNI_WORKFLOW)
     run = _step(omni["jobs"]["preflight"], "Select TTS model once")["run"]
     assert "examples/mps_dp/configs/higgs_h100_dp3.yaml" in run
@@ -104,3 +105,5 @@ def test_mps_config_resolution_covers_both_selected_models() -> None:
     assert "examples/mps_dp/configs/moss_local_h100_dp2.yaml" in run
     assert "MossTTSLocalPipelineConfig" in run
     assert "resolved config mismatch" in run
+    # Single-instance models resolve no config; stage 5 keys off that.
+    assert 'resolved_config=""' in run

--- a/tests/unit_test/ci/test_tts_mps_workflow_contract.py
+++ b/tests/unit_test/ci/test_tts_mps_workflow_contract.py
@@ -89,7 +89,7 @@ def test_cpu_selection_is_rerun_stable_and_conflicts_fail_before_h100() -> None:
     assert 'printf "%s" "${GITHUB_RUN_ID}" | sha256sum' in run
     assert "RUN_HIGGS_LABEL" in selection["env"]
     assert "RUN_MOSS_LABEL" in selection["env"]
-    assert "RUN_QWEN3TTS_LABEL" in selection["env"]
+    assert "RUN_QWEN3_TTS_LABEL" in selection["env"]
     assert "mutually exclusive" in run
     assert "GITHUB_RUN_ATTEMPT" not in run.partition("selection_digest=")[0]
     assert "tts_stage1_topology" not in omni["on"]["workflow_dispatch"]["inputs"]


### PR DESCRIPTION
## Why

`Qwen/Qwen3-TTS-12Hz-1.7B-Base` is the variant the community deploys and the one TTS model with no CI coverage. That is how it drifted to a 16-request admission cap while tuning went to the 0.6B, unnoticed until #1418. Open task in #1418 section 5.

## What

* `tts_ci_config.py`: a `qwen3-tts` preset (references ref format, the tuned serving flags, 300s startup), now carrying calibrated gating thresholds (below).
* `omni-ci.yaml`: rotation goes from two models to three, with a `run-qwen3-tts` opt-in label; weights join the setup prefetch.
* `test-tts-ci.yaml`: `tts_mps_config` becomes optional and stage 5 (MPS) is conditional on it.
* `slash_command_handler.py` and the TTS calibration config/stages: the model is now requestable and calibratable, not just selectable.
* `pyproject.toml`: `sox` becomes a declared dependency.
* `tune.py`, two fixes hit while calibrating: quoted `gpu_group_cpusets` keys parsed with their quotes (lane resolution raised `ValueError` for anyone using the host table), and the contention monitor rooted its own-work tree at the pytest pid, so stage supervisors that double-fork to init were counted as foreign load and the monitor aborted its own vocoder-heavy rounds. Rooted at container init instead; `/proc/stat` is host-global, so external intruders are still caught.

## Gated as a single instance

One H100, same card back to back, EN-1088, all cells 1088/1088:

| | single instance, tuned | DP2+MPS, same card |
|---|---|---|
| peak qps | **16.15** | 15.66 |
| TTFA p95 @c64 | **0.54s** | 2.80s |

Colocation is no longer the recommended topology here, so this model resolves no MPS config and stage 5 skips for it. CI measures the tuned operating point rather than the shipped defaults; once the defaults re-tune in #1418 section 2 lands, those flags become redundant.

## Calibration (thresholds now gate)

Calibrated on the CI host, GPU 0,1, pinned to the production lane cpuset `2-15,66-79`, worst-of-5 clean rounds with destructive rejection (run `20260813T021112Z_tts_qwen3tts_r5`, calibration commit `243247fa`, strict-audit 6/6 stages at 5/5, every round 1088/1088 samples, similarity 50/50). Raw pre-slack references only; the CI slack calculation is unchanged.

| Stage | Metric | Worst-of-5 | Median | Range | CV |
|---|---|---:|---:|---:|---:|
| nonstream WER | corpus (%) | 1.08 | 1.05 | 0.12 | 4.2% |
| nonstream similarity | mean | 69.60 | 69.73 | 0.80 | 0.5% |
| nonstream UTMOS | mean | 4.1950 | 4.1985 | 0.008 | 0.1% |
| nonstream speed | throughput (req/s) | 17.660 | 17.804 | 0.53 | 1.2% |
| nonstream speed | output tok/req-s | 71.1 | 71.6 | 1.5 | 0.9% |
| nonstream speed | latency mean (s) | 0.901 | 0.895 | 0.026 | 1.2% |
| nonstream speed | RTF mean | 0.2236 | 0.2213 | 0.006 | 1.2% |
| stream WER | corpus (%) | 1.16 | 1.02 | 0.16 | 6.0% |
| stream speed | throughput (req/s) | 15.324 | 15.558 | 0.72 | 1.9% |
| stream speed | latency mean (s) | 1.039 | 1.022 | 0.046 | 1.8% |
| stream speed | RTF mean | 0.2570 | 0.2505 | 0.013 | 2.1% |

One destructive round was rejected and replaced: its stream corpus WER was 6.08% against a rest-median of 1.02% (z=135.8), during the run's most contended window plus FlashInfer cold compile. A correctness metric moving that far is flagged as a suspected intermittent defect rather than noise; tracked with the #1418 section 4 investigation, excluded from aggregation.

`gate_thresholds` and `calibrated` flip to true; the observing-mode contract test now asserts the calibrated gating state. Post-apply validation round: all six stages green against the applied thresholds.

## Evidence run

A full `run-qwen3-tts` labeled CI run on this branch is green: qwen3-tts selected, stages 1 through 4 pass (stage 1 6m12s, faster than the higgs 9m05s), stage 5 skipped by design, the sox fix carried worker startup. Run 31654082999.

## Disclosures

* higgs and moss rotation frequency drops from 50% each to 37.5% / 31.2% (one hex nibble mod three; stable per run id).
* Stage 4 (serving) hardcodes the higgs preset, so a qwen3-tts run still exercises stage 4 against higgs.
* This branch edits `tts_ci_config.py`, which invalidates the recorded threshold-file hashes; `stages.yaml` is regenerated in the same commits, so the higgs/moss calibration chain is not blocked.
* The runtime dependency was missing: in the pinned CI image `import qwen_tts` raises `ModuleNotFoundError: No module named 'sox'` (the documented install line is `--no-deps qwen-tts==0.1.1`, and `--no-deps` is what drops sox). Also true of the calibration venv, so this failure was reproduced and fixed in both environments.

## Tests

`tests/unit_test/ci/test_tts_model_rotation_contract.py` (new, 6 cases): rotation matches the registered presets and every model needs a label env plus a selection branch; a single-instance model leaves stage 5 conditional and the guard is not bypassable; presets, slash-command targets and calibration presets agree; a calibration filter that claims no constant fails; gating on uncalibrated thresholds fails; the qwen3-tts preset gates on calibrated worst-of-N floors, not the seeds. Full `tests/unit_test/ci/`: 52 passed.
