### PR TITLE
[Model] Support SenseNova U1 (NEOChatModel, MoT interleaved understanding+generation)

### DIFF
--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -198,6 +198,7 @@ class Client:
                     finish_reason=chunk.finish_reason,
                     usage=chunk.usage,
                     stage_name=chunk.stage_name,
+                    omni_rollout=chunk.omni_rollout,
                 )
 
     # ------------------------------------------------------------------

--- a/sglang_omni/client/types.py
+++ b/sglang_omni/client/types.py
@@ -218,6 +218,7 @@ class CompletionStreamChunk:
     finish_reason: str | None = None
     usage: UsageInfo | None = None
     stage_name: str | None = None
+    omni_rollout: dict[str, Any] | None = None
 
 
 @dataclass

--- a/sglang_omni/models/sensenova_u1/__init__.py
+++ b/sglang_omni/models/sensenova_u1/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SenseNova U1 integration for SGLang-Omni.
+
+Keep package import lightweight because the pipeline registry imports every
+model package during discovery.
+"""
+
+__all__: list[str] = []

--- a/sglang_omni/models/sensenova_u1/config.py
+++ b/sglang_omni/models/sensenova_u1/config.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pipeline configuration for SenseNova U1 fallback paths."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from sglang_omni.config import (
+    PipelineConfig,
+    StageConfig,
+    StageResourceConfig,
+    StageRuntimeConfig,
+)
+
+_PKG = "sglang_omni.models.sensenova_u1"
+
+
+class SenseNovaU1PipelineConfig(PipelineConfig):
+    """Single-stage VQA pipeline for the M1/M2 understanding milestones.
+
+    The stage intentionally uses the official NEOChatModel-compatible HF path.
+    Native SGLang attention for U1 requires the M2 hybrid image-span mask and is
+    not claimed by this pipeline.
+    """
+
+    architecture: ClassVar[str] = "NEOChatModel"
+    architecture_aliases: ClassVar[tuple[str, ...]] = ("SenseNovaU1",)
+
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"understanding": "u1_vqa"}
+
+    model_path: str
+    entry_stage: str = "u1_vqa"
+    stages: list[StageConfig] = [
+        StageConfig(
+            name="u1_vqa",
+            process="u1_vqa",
+            factory=f"{_PKG}.stages.create_sensenova_u1_vqa_executor",
+            factory_args={
+                "device": "cuda:0",
+                "dtype": "bfloat16",
+                "max_new_tokens": 128,
+                "do_sample": False,
+                "attn_backend": "auto",
+                "max_concurrency": 1,
+            },
+            runtime=StageRuntimeConfig(
+                resources=StageResourceConfig(total_gpu_memory_fraction=0.75)
+            ),
+            gpu=0,
+            terminal=True,
+        )
+    ]
+
+
+class SenseNovaU1FlowPipelineConfig(SenseNovaU1PipelineConfig):
+    """Single-stage T2I/IT2I flow-matching pipeline for the M3 milestone."""
+
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"generation": "u1_flow"}
+
+    entry_stage: str = "u1_flow"
+    stages: list[StageConfig] = [
+        StageConfig(
+            name="u1_flow",
+            process="u1_flow",
+            factory=f"{_PKG}.stages.create_sensenova_u1_flow_executor",
+            factory_args={
+                "device": "cuda:0",
+                "dtype": "bfloat16",
+                "attn_backend": "auto",
+                "max_concurrency": 1,
+            },
+            runtime=StageRuntimeConfig(
+                resources=StageResourceConfig(total_gpu_memory_fraction=0.75)
+            ),
+            gpu=0,
+            terminal=True,
+        )
+    ]
+
+
+class SenseNovaU1InterleavePipelineConfig(SenseNovaU1PipelineConfig):
+    """Single-stage interleaved text-image generation pipeline for M4."""
+
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"interleave": "u1_interleave"}
+
+    entry_stage: str = "u1_interleave"
+    stages: list[StageConfig] = [
+        StageConfig(
+            name="u1_interleave",
+            process="u1_interleave",
+            factory=f"{_PKG}.stages.create_sensenova_u1_interleave_executor",
+            factory_args={
+                "device": "cuda:0",
+                "dtype": "bfloat16",
+                "attn_backend": "auto",
+                "max_concurrency": 1,
+            },
+            runtime=StageRuntimeConfig(
+                resources=StageResourceConfig(total_gpu_memory_fraction=0.75)
+            ),
+            gpu=0,
+            terminal=True,
+        )
+    ]
+
+
+EntryClass = SenseNovaU1PipelineConfig
+
+Variants = {
+    "default": SenseNovaU1PipelineConfig,
+    "flow": SenseNovaU1FlowPipelineConfig,
+    "interleave": SenseNovaU1InterleavePipelineConfig,
+}

--- a/sglang_omni/models/sensenova_u1/flow_matching.py
+++ b/sglang_omni/models/sensenova_u1/flow_matching.py
@@ -1,0 +1,362 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SenseNova U1 flow-matching image generation runner.
+
+This is the M3 HF-compatible in-pipeline path. It keeps U1 generation inside a
+SGLang-Omni stage lifecycle, while delegating the exact numerical kernels to
+the official NEOChatModel implementation already used by the M1/M2 fallback.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import math
+import time
+from contextlib import nullcontext
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import numpy as np
+import torch
+from PIL import Image
+
+from sglang_omni.proto import StagePayload
+from sglang_omni.models.sensenova_u1.hf_runner import (
+    DEFAULT_MODEL_DIR,
+    DEFAULT_VENDOR_ROOT,
+    SenseNovaU1UnderstandingRunner,
+    _coerce_image,
+    _extract_request,
+    _official_block_mask_scope,
+)
+
+NORM_MEAN = (0.5, 0.5, 0.5)
+NORM_STD = (0.5, 0.5, 0.5)
+
+
+@dataclass(frozen=True, slots=True)
+class FlowRequestParams:
+    mode: str
+    prompt: str
+    image_size: tuple[int, int] = (256, 256)
+    cfg_scale: float = 1.0
+    img_cfg_scale: float = 1.0
+    cfg_norm: str = "none"
+    timestep_shift: float = 1.0
+    enable_timestep_shift: bool = True
+    cfg_interval: tuple[float, float] = (0.0, 1.0)
+    num_steps: int = 2
+    batch_size: int = 1
+    t_eps: float = 0.05
+    think_mode: bool = False
+    seed: int = 20260813
+
+
+def denormalize_u1_image_tensor(batch: torch.Tensor) -> torch.Tensor:
+    """Convert U1 normalized image tensors from [-1, 1] into [0, 1]."""
+
+    mean = torch.tensor(NORM_MEAN, device=batch.device, dtype=batch.dtype).view(1, 3, 1, 1)
+    std = torch.tensor(NORM_STD, device=batch.device, dtype=batch.dtype).view(1, 3, 1, 1)
+    return (batch * std + mean).clamp(0, 1)
+
+
+def u1_tensor_to_pil(batch: torch.Tensor) -> list[Image.Image]:
+    arr = denormalize_u1_image_tensor(batch.float()).permute(0, 2, 3, 1).cpu().numpy()
+    arr = (arr * 255.0).round().astype(np.uint8)
+    return [Image.fromarray(a) for a in arr]
+
+
+def pil_to_data_url(image: Image.Image) -> str:
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    payload = base64.b64encode(buf.getvalue()).decode("ascii")
+    return f"data:image/png;base64,{payload}"
+
+
+def compare_pil_images(a: Image.Image, b: Image.Image) -> dict[str, Any]:
+    if a.size != b.size:
+        raise ValueError(f"Cannot compare images with different sizes: {a.size} vs {b.size}")
+    arr_a_u8 = np.asarray(a.convert("RGB"), dtype=np.uint8)
+    arr_b_u8 = np.asarray(b.convert("RGB"), dtype=np.uint8)
+    diff = arr_a_u8.astype(np.int16) - arr_b_u8.astype(np.int16)
+    mse = float(np.mean(diff.astype(np.float64) ** 2))
+    psnr = math.inf if mse == 0.0 else float(20.0 * math.log10(255.0 / math.sqrt(mse)))
+    a_float = arr_a_u8.astype(np.float64) / 255.0
+    b_float = arr_b_u8.astype(np.float64) / 255.0
+    mu_a = float(a_float.mean())
+    mu_b = float(b_float.mean())
+    var_a = float(((a_float - mu_a) ** 2).mean())
+    var_b = float(((b_float - mu_b) ** 2).mean())
+    cov = float(((a_float - mu_a) * (b_float - mu_b)).mean())
+    c1 = 0.01**2
+    c2 = 0.03**2
+    ssim = ((2 * mu_a * mu_b + c1) * (2 * cov + c2)) / (
+        (mu_a**2 + mu_b**2 + c1) * (var_a + var_b + c2)
+    )
+    return {
+        "width": a.size[0],
+        "height": a.size[1],
+        "mse_uint8": mse,
+        "psnr_db": psnr,
+        "ssim_global_rgb": float(ssim),
+        "pixel_max_abs_diff_uint8": int(np.abs(diff).max()),
+        "pixel_mean_abs_diff_uint8": float(np.abs(diff).mean()),
+        "exact_png_pixels": bool(np.array_equal(arr_a_u8, arr_b_u8)),
+        "ssim_implementation": "global_rgb_formula",
+    }
+
+
+class SenseNovaU1FlowMatchingRunner(SenseNovaU1UnderstandingRunner):
+    """T2I/IT2I runner for U1 flow matching inside SGLang-Omni."""
+
+    def __init__(
+        self,
+        model_path: str = DEFAULT_MODEL_DIR,
+        *,
+        vendor_root: str | None = None,
+        device: str = "cuda:0",
+        dtype: str | torch.dtype = "bfloat16",
+        attn_backend: str = "auto",
+        load_with_info: bool = False,
+    ) -> None:
+        super().__init__(
+            model_path=model_path,
+            vendor_root=vendor_root or DEFAULT_VENDOR_ROOT,
+            device=device,
+            dtype=dtype,
+            attn_backend=attn_backend,
+            load_with_info=load_with_info,
+        )
+
+    def _flow_params_from_request(self, inputs: Any, params: dict[str, Any]) -> tuple[FlowRequestParams, list[Any]]:
+        data = inputs if isinstance(inputs, dict) else {"prompt": str(inputs)}
+        merged = {**data, **params}
+        mode = str(merged.get("mode") or merged.get("task") or "t2i").lower()
+        if mode in {"text_to_image", "txt2img"}:
+            mode = "t2i"
+        if mode in {"image_to_image", "edit", "editing"}:
+            mode = "it2i"
+        if mode not in {"t2i", "it2i"}:
+            raise ValueError(f"Unsupported U1 flow mode: {mode!r}")
+        width = int(merged.get("width", merged.get("image_width", 256)))
+        height = int(merged.get("height", merged.get("image_height", 256)))
+        cfg_interval_value = merged.get("cfg_interval", (0.0, 1.0))
+        cfg_interval = tuple(float(x) for x in cfg_interval_value)
+        if len(cfg_interval) != 2:
+            raise ValueError("cfg_interval must contain exactly two floats.")
+        images = [_coerce_image(img) for img in (merged.get("images") or [])]
+        if "image" in merged:
+            images.append(_coerce_image(merged["image"]))
+        request = FlowRequestParams(
+            mode=mode,
+            prompt=str(merged.get("prompt", "")),
+            image_size=(width, height),
+            cfg_scale=float(merged.get("cfg_scale", 1.0)),
+            img_cfg_scale=float(merged.get("img_cfg_scale", 1.0)),
+            cfg_norm=str(merged.get("cfg_norm", "none")),
+            timestep_shift=float(merged.get("timestep_shift", 1.0)),
+            enable_timestep_shift=bool(merged.get("enable_timestep_shift", True)),
+            cfg_interval=(float(cfg_interval[0]), float(cfg_interval[1])),
+            num_steps=int(merged.get("num_steps", 2)),
+            batch_size=int(merged.get("batch_size", 1)),
+            t_eps=float(merged.get("t_eps", 0.05)),
+            think_mode=bool(merged.get("think_mode", False)),
+            seed=int(merged.get("seed", 20260813)),
+        )
+        return request, images
+
+    def scheduler_params(self, request: FlowRequestParams) -> dict[str, Any]:
+        assert self.model is not None
+        model = self.model
+        width, height = request.image_size
+        merge_size = int(1 / model.downsample_ratio)
+        token_h = height // (model.patch_size * merge_size)
+        token_w = width // (model.patch_size * merge_size)
+        grid_h = height // model.patch_size
+        grid_w = width // model.patch_size
+        image_seq_len = token_h * token_w
+
+        noise_scale = float(model.noise_scale)
+        if model.noise_scale_mode in ("resolution", "dynamic", "dynamic_sqrt"):
+            base = float(model.noise_scale_base_image_seq_len)
+            scale = math.sqrt((grid_h * grid_w) / (merge_size**2) / base)
+            noise_scale = scale * float(model.noise_scale)
+            if model.noise_scale_mode == "dynamic_sqrt":
+                noise_scale = math.sqrt(noise_scale)
+        noise_scale = min(noise_scale, float(model.noise_scale_max_value))
+
+        timesteps = torch.linspace(0.0, 1.0, request.num_steps + 1, device=self.torch_device)
+        if request.enable_timestep_shift:
+            timesteps = model._apply_time_schedule(
+                timesteps,
+                image_seq_len,
+                request.timestep_shift,
+            )
+        t_values = [float(x) for x in timesteps.detach().cpu().tolist()]
+        step_table = [
+            {
+                "step": i,
+                "t": t_values[i],
+                "t_next": t_values[i + 1],
+                "dt": t_values[i + 1] - t_values[i],
+                "use_cfg": bool(
+                    (
+                        t_values[i] > request.cfg_interval[0]
+                        and t_values[i] < request.cfg_interval[1]
+                    )
+                    or request.cfg_interval[0] == 0
+                ),
+            }
+            for i in range(request.num_steps)
+        ]
+        config_keys = [
+            "fm_head_dim",
+            "fm_head_layers",
+            "fm_head_mlp_ratio",
+            "timestep_shift",
+            "time_schedule",
+            "time_shift_type",
+            "base_shift",
+            "max_shift",
+            "base_image_seq_len",
+            "max_image_seq_len",
+            "noise_scale",
+            "noise_scale_mode",
+            "noise_scale_base_image_seq_len",
+            "noise_scale_max_value",
+            "add_noise_scale_embedding",
+            "P_mean",
+            "P_std",
+            "t_eps",
+            "use_pixel_head",
+            "use_adaLN",
+        ]
+        raw_config = {
+            key: getattr(model.config, key, getattr(model, key, None))
+            for key in config_keys
+        }
+        return {
+            "backend": "sglang_omni_sensenova_u1_flow_matching_hf_compatible",
+            "request": asdict(request),
+            "patch_size": int(model.patch_size),
+            "downsample_ratio": float(model.downsample_ratio),
+            "merge_size": merge_size,
+            "grid_h": grid_h,
+            "grid_w": grid_w,
+            "token_h": token_h,
+            "token_w": token_w,
+            "image_seq_len": image_seq_len,
+            "computed_noise_scale": noise_scale,
+            "raw_config": raw_config,
+            "timesteps": t_values,
+            "step_table": step_table,
+        }
+
+    @torch.inference_mode()
+    def generate_t2i_tensor(
+        self,
+        request: FlowRequestParams,
+        *,
+        use_official_hybrid_mask: bool = False,
+    ) -> tuple[torch.Tensor, str]:
+        assert self.model is not None and self.tokenizer is not None
+        ctx = _official_block_mask_scope() if use_official_hybrid_mask else nullcontext()
+        with ctx:
+            output = self.model.t2i_generate(
+                self.tokenizer,
+                request.prompt,
+                image_size=request.image_size,
+                cfg_scale=request.cfg_scale,
+                cfg_norm=request.cfg_norm,
+                timestep_shift=request.timestep_shift,
+                enable_timestep_shift=request.enable_timestep_shift,
+                cfg_interval=request.cfg_interval,
+                num_steps=request.num_steps,
+                batch_size=request.batch_size,
+                t_eps=request.t_eps,
+                think_mode=request.think_mode,
+                seed=request.seed,
+            )
+        if request.think_mode:
+            tensor, think_text = output
+            return tensor.detach(), str(think_text)
+        return output.detach(), ""
+
+    @torch.inference_mode()
+    def generate_it2i_tensor(
+        self,
+        request: FlowRequestParams,
+        images: list[Any],
+        *,
+        use_official_hybrid_mask: bool = False,
+    ) -> tuple[torch.Tensor, str]:
+        assert self.model is not None and self.tokenizer is not None
+        if not images:
+            raise ValueError("IT2I generation requires at least one input image.")
+        ctx = _official_block_mask_scope() if use_official_hybrid_mask else nullcontext()
+        with ctx:
+            output = self.model.it2i_generate(
+                self.tokenizer,
+                request.prompt,
+                [_coerce_image(image) for image in images],
+                image_size=request.image_size,
+                cfg_scale=request.cfg_scale,
+                img_cfg_scale=request.img_cfg_scale,
+                cfg_norm=request.cfg_norm,
+                timestep_shift=request.timestep_shift,
+                enable_timestep_shift=request.enable_timestep_shift,
+                cfg_interval=request.cfg_interval,
+                num_steps=request.num_steps,
+                batch_size=request.batch_size,
+                t_eps=request.t_eps,
+                think_mode=request.think_mode,
+                seed=request.seed,
+            )
+        if request.think_mode:
+            tensor, think_text = output
+            return tensor.detach(), str(think_text)
+        return output.detach(), ""
+
+    def complete_payload(self, payload: StagePayload) -> dict[str, Any]:
+        inputs, params, request_id = _extract_request(payload)
+        request, images = self._flow_params_from_request(inputs, params)
+        start = time.perf_counter()
+        if request.mode == "t2i":
+            tensor, think_text = self.generate_t2i_tensor(request)
+        else:
+            tensor, think_text = self.generate_it2i_tensor(request, images)
+        elapsed = time.perf_counter() - start
+        pil_images = u1_tensor_to_pil(tensor)
+        return {
+            "request_id": request_id,
+            "mode": request.mode,
+            "images": [
+                {
+                    "type": "image",
+                    "format": "png",
+                    "data": pil_to_data_url(img),
+                    "width": img.width,
+                    "height": img.height,
+                }
+                for img in pil_images
+            ],
+            "think_text": think_text,
+            "scheduler_params": self.scheduler_params(request),
+            "usage": {
+                "image_count": len(pil_images),
+                "num_steps": request.num_steps,
+                "engine_time_s": elapsed,
+            },
+            "stage_name": "u1_flow",
+            "backend": "hf_compatible_flow_matching_fallback",
+        }
+
+
+__all__ = [
+    "FlowRequestParams",
+    "SenseNovaU1FlowMatchingRunner",
+    "compare_pil_images",
+    "denormalize_u1_image_tensor",
+    "pil_to_data_url",
+    "u1_tensor_to_pil",
+]

--- a/sglang_omni/models/sensenova_u1/hf_runner.py
+++ b/sglang_omni/models/sensenova_u1/hf_runner.py
@@ -1,0 +1,660 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HF-compatible SenseNova U1 understanding runner.
+
+This is the M1 fallback path. It lives inside SGLang-Omni's pipeline registry
+and request lifecycle, but delegates U1 math to the official NEOChatModel
+implementation. The native SGLang attention path still needs the M2 hybrid
+image-span mask before it can claim parity.
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import io
+import json
+import os
+import sys
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from PIL import Image
+
+from sglang_omni.proto import StagePayload
+
+SENSENOVA_U1_VENDOR_ROOT_ENV = "SENSENOVA_U1_VENDOR_ROOT"
+SENSENOVA_U1_MODEL_PATH_ENV = "SENSENOVA_U1_MODEL_PATH"
+DEFAULT_VENDOR_ROOT: str | None = None
+DEFAULT_MODEL_DIR = os.environ.get(
+    SENSENOVA_U1_MODEL_PATH_ENV,
+    "sensenova/SenseNova-U1-8B-MoT-Interleaved",
+)
+DEFAULT_VQA_MIN_PIXELS = 65536
+DEFAULT_VQA_MAX_PIXELS = 4194304
+
+
+@dataclass(slots=True)
+class PreparedVQA:
+    question: str
+    query: str
+    input_ids: torch.Tensor
+    attention_mask: torch.Tensor
+    indexes: torch.Tensor
+    image_token_tag: torch.Tensor
+    pixel_values: torch.Tensor | None
+    grid_hw: torch.Tensor | None
+
+
+def _dtype_from_name(name: str) -> torch.dtype:
+    normalized = str(name).lower()
+    if normalized in {"bf16", "bfloat16"}:
+        return torch.bfloat16
+    if normalized in {"fp16", "float16", "half"}:
+        return torch.float16
+    if normalized in {"fp32", "float32"}:
+        return torch.float32
+    if normalized == "auto":
+        return torch.bfloat16
+    raise ValueError(f"Unsupported SenseNova U1 dtype: {name!r}")
+
+
+def _ensure_vendor_import(vendor_root: str | None) -> Path:
+    root_value = vendor_root or os.environ.get(SENSENOVA_U1_VENDOR_ROOT_ENV)
+    if not root_value:
+        spec = importlib.util.find_spec("sensenova_u1")
+        if spec is not None and spec.origin:
+            return Path(spec.origin).resolve().parent
+        raise FileNotFoundError(
+            "SenseNova-U1 Python package is not importable. Install it or set "
+            f"{SENSENOVA_U1_VENDOR_ROOT_ENV} to a checkout containing src/sensenova_u1."
+        )
+
+    root = Path(root_value)
+    src = root / "src"
+    if not src.exists():
+        raise FileNotFoundError(
+            f"SenseNova-U1 source not found at {src}. Set {SENSENOVA_U1_VENDOR_ROOT_ENV}."
+        )
+    src_str = str(src)
+    if src_str not in sys.path:
+        sys.path.insert(0, src_str)
+    return root
+
+
+def _load_raw_config(model_path: str) -> dict[str, Any]:
+    config_path = Path(model_path) / "config.json"
+    if not config_path.exists():
+        return {}
+    return json.loads(config_path.read_text())
+
+
+def _missing_attr(obj: Any, name: str) -> bool:
+    try:
+        getattr(obj, name)
+    except AttributeError:
+        return True
+    return False
+
+
+def _patch_llm_config_compat(config: Any, model_path: str) -> None:
+    """Restore raw U1 config fields hidden by newer Transformers Qwen3Config.
+
+    The public U1 source expects legacy attributes such as ``rope_theta``.
+    Transformers 4.57 can normalize Qwen3 rotary settings into newer internal
+    fields, which breaks the unmodified U1 implementation at construction time.
+    """
+
+    llm_config = getattr(config, "llm_config", None)
+    if llm_config is None:
+        return
+    raw_llm = (_load_raw_config(model_path).get("llm_config") or {})
+    if not isinstance(raw_llm, dict):
+        raw_llm = {}
+
+    for key, value in raw_llm.items():
+        if _missing_attr(llm_config, key):
+            setattr(llm_config, key, value)
+
+    rope_parameters = getattr(llm_config, "rope_parameters", None)
+    if _missing_attr(llm_config, "rope_theta"):
+        if isinstance(rope_parameters, dict) and "rope_theta" in rope_parameters:
+            setattr(llm_config, "rope_theta", rope_parameters["rope_theta"])
+        elif "rope_theta" in raw_llm:
+            setattr(llm_config, "rope_theta", raw_llm["rope_theta"])
+
+    layer_types = getattr(llm_config, "layer_types", None)
+    num_layers = int(getattr(llm_config, "num_hidden_layers"))
+    if not layer_types or len(layer_types) != num_layers:
+        use_swa = bool(getattr(llm_config, "use_sliding_window", False)) and (
+            getattr(llm_config, "sliding_window", None) is not None
+        )
+        max_window_layers = int(getattr(llm_config, "max_window_layers", 0) or 0)
+        setattr(
+            llm_config,
+            "layer_types",
+            [
+                "sliding_attention" if (use_swa and i >= max_window_layers) else "full_attention"
+                for i in range(num_layers)
+            ],
+        )
+
+
+def _patch_model_class_compat() -> None:
+    import sensenova_u1.models.neo_unify.modeling_neo_chat as modeling_neo_chat
+    import sensenova_u1.models.neo_unify.modeling_qwen3 as modeling_qwen3
+    import sensenova_u1.models.neo_unify.modeling_qwen3_moe as modeling_qwen3_moe
+
+    from sensenova_u1.models.neo_unify.modeling_neo_chat import NEOChatModel
+    from sensenova_u1.models.neo_unify.modeling_qwen3 import Qwen3RotaryEmbedding
+    from sglang_omni.models.sensenova_u1.hybrid_attention import create_u1_hybrid_mask
+    from transformers.masking_utils import create_causal_mask as hf_create_causal_mask
+
+    if not hasattr(NEOChatModel, "all_tied_weights_keys"):
+        # U1 checkpoints set tie_word_embeddings=false. Transformers 4.57's
+        # loader finalizer still expects the new instance attribute even when
+        # the model class does not call post_init().
+        NEOChatModel.all_tied_weights_keys = {}
+    if not hasattr(Qwen3RotaryEmbedding, "compute_default_rope_parameters"):
+        # Transformers 4.57's generic initializer recognizes any class named
+        # *RotaryEmbedding and calls this newer helper for default RoPE. U1's
+        # implementation already stores the correct initializer as rope_init_fn.
+        def _compute_default_rope_parameters(self, config=None, device=None, **_kwargs):
+            return self.rope_init_fn(config or self.config, device)
+
+        Qwen3RotaryEmbedding.compute_default_rope_parameters = (
+            _compute_default_rope_parameters
+        )
+
+    if not getattr(modeling_qwen3, "_sglang_omni_mask_compat", False):
+        def _create_causal_mask_compat(*args, **kwargs):
+            if "input_embeds" in kwargs and "inputs_embeds" not in kwargs:
+                kwargs["inputs_embeds"] = kwargs.pop("input_embeds")
+            kwargs.pop("cache_position", None)
+            return hf_create_causal_mask(*args, **kwargs)
+
+        modeling_qwen3.create_causal_mask = _create_causal_mask_compat
+        if hasattr(modeling_qwen3_moe, "create_causal_mask"):
+            modeling_qwen3_moe.create_causal_mask = _create_causal_mask_compat
+        modeling_qwen3._sglang_omni_mask_compat = True
+
+    for module in (modeling_qwen3, modeling_qwen3_moe, modeling_neo_chat):
+        if hasattr(module, "create_block_causal_mask"):
+            if not hasattr(module, "_sglang_omni_original_create_block_causal_mask"):
+                module._sglang_omni_original_create_block_causal_mask = (
+                    module.create_block_causal_mask
+                )
+            module.create_block_causal_mask = create_u1_hybrid_mask
+
+
+@contextmanager
+def _official_block_mask_scope():
+    """Temporarily restore official U1 block mask functions for references."""
+
+    import sensenova_u1.models.neo_unify.modeling_neo_chat as modeling_neo_chat
+    import sensenova_u1.models.neo_unify.modeling_qwen3 as modeling_qwen3
+    import sensenova_u1.models.neo_unify.modeling_qwen3_moe as modeling_qwen3_moe
+
+    modules = [modeling_qwen3, modeling_qwen3_moe, modeling_neo_chat]
+    saved: list[tuple[Any, Any]] = []
+    for module in modules:
+        if not hasattr(module, "create_block_causal_mask"):
+            continue
+        saved.append((module, module.create_block_causal_mask))
+        original = getattr(module, "_sglang_omni_original_create_block_causal_mask", None)
+        if original is not None:
+            module.create_block_causal_mask = original
+    try:
+        yield
+    finally:
+        for module, function in saved:
+            module.create_block_causal_mask = function
+
+
+def _image_from_data_url(value: str) -> Image.Image:
+    _, _, encoded = value.partition(",")
+    if not encoded:
+        raise ValueError("image data URL is missing base64 payload")
+    return Image.open(io.BytesIO(base64.b64decode(encoded)))
+
+
+def _coerce_image(value: Any) -> Any:
+    if isinstance(value, Image.Image):
+        return value
+    if isinstance(value, dict):
+        if "path" in value:
+            return value["path"]
+        if "image" in value:
+            return _coerce_image(value["image"])
+        if "image_url" in value:
+            image_url = value["image_url"]
+            if isinstance(image_url, dict):
+                image_url = image_url.get("url")
+            return _coerce_image(image_url)
+        if "url" in value:
+            return _coerce_image(value["url"])
+    if isinstance(value, str) and value.startswith("data:image/"):
+        return _image_from_data_url(value)
+    return value
+
+
+def _extract_text_and_images_from_content(content: Any) -> tuple[str, list[Any]]:
+    images: list[Any] = []
+    if isinstance(content, str):
+        return content, images
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                typ = item.get("type")
+                if typ == "text" or "text" in item:
+                    text = item.get("text")
+                    if isinstance(text, str):
+                        parts.append(text)
+                elif typ in {"image_url", "image"} or "image_url" in item or "image" in item:
+                    images.append(_coerce_image(item))
+        return "\n".join(part for part in parts if part), images
+    return str(content), images
+
+
+def _extract_request(payload_or_inputs: StagePayload | Any) -> tuple[Any, dict[str, Any], str]:
+    if isinstance(payload_or_inputs, StagePayload):
+        return (
+            payload_or_inputs.request.inputs,
+            payload_or_inputs.request.params,
+            payload_or_inputs.request_id,
+        )
+    return payload_or_inputs, {}, "local"
+
+
+def _extract_question_images_history(inputs: Any) -> tuple[str, list[Any], list[tuple[str, str]]]:
+    images: list[Any] = []
+    history: list[tuple[str, str]] = []
+
+    if isinstance(inputs, str):
+        return inputs, images, history
+
+    if isinstance(inputs, dict):
+        images.extend(_coerce_image(img) for img in inputs.get("images") or [])
+        if "image" in inputs:
+            images.append(_coerce_image(inputs["image"]))
+        if "question" in inputs:
+            return str(inputs["question"]), images, history
+        if "prompt" in inputs:
+            return str(inputs["prompt"]), images, history
+        if "messages" in inputs:
+            inputs = inputs["messages"]
+        else:
+            return str(inputs), images, history
+
+    if isinstance(inputs, list):
+        pending_user: str | None = None
+        for msg in inputs:
+            if not isinstance(msg, dict):
+                pending_user = str(msg)
+                continue
+            role = str(msg.get("role", "user"))
+            text, msg_images = _extract_text_and_images_from_content(msg.get("content", ""))
+            images.extend(_coerce_image(img) for img in msg_images)
+            if role == "user":
+                pending_user = text
+            elif role == "assistant" and pending_user is not None:
+                history.append((pending_user, text))
+                pending_user = None
+        return pending_user or "", images, history
+
+    return str(inputs), images, history
+
+
+class SenseNovaU1UnderstandingRunner:
+    def __init__(
+        self,
+        model_path: str = DEFAULT_MODEL_DIR,
+        *,
+        vendor_root: str | None = None,
+        device: str = "cuda:0",
+        dtype: str | torch.dtype = "bfloat16",
+        attn_backend: str = "auto",
+        min_pixels: int | None = None,
+        max_pixels: int | None = None,
+        load_with_info: bool = False,
+    ) -> None:
+        self.model_path = str(model_path)
+        self.vendor_root = _ensure_vendor_import(vendor_root)
+        self.device = str(device)
+        self.dtype = dtype if isinstance(dtype, torch.dtype) else _dtype_from_name(dtype)
+        self.attn_backend = attn_backend
+        self.min_pixels = min_pixels
+        self.max_pixels = max_pixels
+        self.model = None
+        self.tokenizer = None
+        self.loading_info: dict[str, Any] = {}
+        self.load(load_with_info=load_with_info)
+
+    def load(self, *, load_with_info: bool = False) -> None:
+        import sensenova_u1
+        from sensenova_u1 import check_checkpoint_compatibility
+        from transformers import AutoConfig, AutoModel, AutoTokenizer
+
+        _patch_model_class_compat()
+        sensenova_u1.set_attn_backend(self.attn_backend)
+        config = AutoConfig.from_pretrained(self.model_path)
+        _patch_llm_config_compat(config, self.model_path)
+        check_checkpoint_compatibility(config)
+        tokenizer = AutoTokenizer.from_pretrained(self.model_path)
+        kwargs = {"config": config, "torch_dtype": self.dtype}
+        if load_with_info:
+            model, info = AutoModel.from_pretrained(
+                self.model_path,
+                output_loading_info=True,
+                **kwargs,
+            )
+            self.loading_info = dict(info)
+        else:
+            model = AutoModel.from_pretrained(self.model_path, **kwargs)
+            self.loading_info = {}
+        self.model = model.eval().to(self.device)
+        self.tokenizer = tokenizer
+
+    @property
+    def torch_device(self) -> torch.device:
+        return torch.device(self.device)
+
+    def prepare(
+        self,
+        question: str,
+        images: list[Any] | None = None,
+        history: list[tuple[str, str]] | None = None,
+    ) -> PreparedVQA:
+        from sensenova_u1.models.neo_unify.conversation import get_conv_template
+        from sensenova_u1.models.neo_unify.utils import load_image_native
+
+        assert self.model is not None and self.tokenizer is not None
+        images = list(images or [])
+        if history is None:
+            history = []
+        if images and "<image>" not in question:
+            question = "<image>\n" + question
+
+        pixel_values_list: list[torch.Tensor] = []
+        grid_hw_list: list[torch.Tensor] = []
+        for image in images:
+            kwargs: dict[str, Any] = {
+                "patch_size": self.model.patch_size,
+                "downsample_ratio": self.model.downsample_ratio,
+            }
+            if self.min_pixels is not None:
+                kwargs["min_pixels"] = self.min_pixels
+            if self.max_pixels is not None:
+                kwargs["max_pixels"] = self.max_pixels
+            cur_pixel_values, cur_grid_hw = load_image_native(_coerce_image(image), **kwargs)
+            pixel_values_list.append(cur_pixel_values)
+            grid_hw_list.append(cur_grid_hw)
+
+        pixel_values = torch.cat(pixel_values_list, dim=0) if pixel_values_list else None
+        grid_hw = torch.cat(grid_hw_list, dim=0) if grid_hw_list else None
+        if pixel_values is not None:
+            pixel_values = pixel_values.to(self.torch_device, dtype=self.model.dtype)
+        if grid_hw is not None:
+            grid_hw = grid_hw.to(self.torch_device)
+
+        img_context_token = "<IMG_CONTEXT>"
+        img_start_token = "<img>"
+        img_end_token = "</img>"
+        self.model.img_context_token_id = self.tokenizer.convert_tokens_to_ids(img_context_token)
+        self.model.img_start_token_id = self.tokenizer.convert_tokens_to_ids(img_start_token)
+
+        template = get_conv_template(self.model.template)
+        template.system_message = self.model.system_message
+        for old_question, old_answer in history:
+            template.append_message(template.roles[0], old_question)
+            template.append_message(template.roles[1], old_answer)
+        template.append_message(template.roles[0], question)
+        template.append_message(template.roles[1], None)
+        query = template.get_prompt()
+
+        if grid_hw is not None:
+            for i in range(grid_hw.shape[0]):
+                num_patch_token = int(
+                    grid_hw[i, 0] * grid_hw[i, 1] * self.model.downsample_ratio**2
+                )
+                image_tokens = img_start_token + img_context_token * num_patch_token + img_end_token
+                query = query.replace("<image>", image_tokens, 1)
+
+        model_inputs = self.tokenizer(query, return_tensors="pt")
+        input_ids = model_inputs["input_ids"].to(self.torch_device)
+        indexes = self.model.get_thw_indexes(input_ids[0], grid_hw)
+        image_token_tag = input_ids[0] == self.model.img_context_token_id
+        return PreparedVQA(
+            question=question,
+            query=query,
+            input_ids=input_ids,
+            attention_mask=model_inputs["attention_mask"].to(self.torch_device),
+            indexes=indexes,
+            image_token_tag=image_token_tag,
+            pixel_values=pixel_values,
+            grid_hw=grid_hw,
+        )
+
+    def prefill_logits(self, prepared: PreparedVQA) -> torch.Tensor:
+        assert self.model is not None
+        input_ids = prepared.input_ids
+        if prepared.pixel_values is not None:
+            vit_embeds = self.model.extract_feature(
+                prepared.pixel_values,
+                grid_hw=prepared.grid_hw,
+            )
+            input_embeds = self.model.language_model.get_input_embeddings()(input_ids)
+            bsz, seqlen, channels = input_embeds.shape
+            flat_embeds = input_embeds.reshape(bsz * seqlen, channels)
+            flat_ids = input_ids.reshape(bsz * seqlen)
+            selected = flat_ids == self.model.img_context_token_id
+            flat_embeds[selected] = vit_embeds.reshape(-1, channels).to(flat_embeds.device)
+            input_embeds = flat_embeds.reshape(bsz, seqlen, channels)
+        else:
+            input_embeds = self.model.language_model.get_input_embeddings()(input_ids)
+
+        outputs = self.model.language_model(
+            inputs_embeds=input_embeds,
+            indexes=prepared.indexes,
+            attention_mask=prepared.attention_mask,
+            use_cache=True,
+        )
+        return outputs.logits[:, -1, :].detach().float()
+
+    def generate_ids(
+        self,
+        prepared: PreparedVQA,
+        *,
+        max_new_tokens: int = 128,
+        do_sample: bool = False,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        top_k: int | None = None,
+        repetition_penalty: float | None = None,
+    ) -> torch.Tensor:
+        assert self.model is not None and self.tokenizer is not None
+        from sensenova_u1.models.neo_unify.conversation import get_conv_template
+
+        template = get_conv_template(self.model.template)
+        eos_token_id = self.tokenizer.convert_tokens_to_ids(template.sep.strip())
+        generation_config: dict[str, Any] = {
+            "max_new_tokens": max_new_tokens,
+            "do_sample": do_sample,
+            "eos_token_id": eos_token_id,
+        }
+        if do_sample:
+            generation_config["temperature"] = temperature
+            generation_config["top_p"] = top_p
+            if top_k is not None:
+                generation_config["top_k"] = top_k
+        if repetition_penalty is not None:
+            generation_config["repetition_penalty"] = repetition_penalty
+
+        return self.model.generate(
+            pixel_values=prepared.pixel_values,
+            input_ids=prepared.input_ids,
+            grid_hw=prepared.grid_hw,
+            attention_mask=prepared.attention_mask,
+            **generation_config,
+        )
+
+    def decode_generated(self, output_ids: torch.Tensor) -> str:
+        assert self.model is not None and self.tokenizer is not None
+        from sensenova_u1.models.neo_unify.conversation import get_conv_template
+
+        template = get_conv_template(self.model.template)
+        response = self.tokenizer.batch_decode(output_ids, skip_special_tokens=True)[0]
+        return response.split(template.sep.strip())[0].strip()
+
+    def answer(self, question: str, images: list[Any] | None = None, **kwargs: Any) -> dict[str, Any]:
+        prepared = self.prepare(question, images)
+        start = time.perf_counter()
+        output_ids = self.generate_ids(prepared, **kwargs)
+        elapsed = time.perf_counter() - start
+        text = self.decode_generated(output_ids)
+        token_ids = output_ids[0].detach().cpu().tolist()
+        return {
+            "text": text,
+            "token_ids": token_ids,
+            "prompt_tokens": int(prepared.input_ids.numel()),
+            "completion_tokens": len(token_ids),
+            "engine_time_s": elapsed,
+            "finish_reason": "stop",
+        }
+
+    def reference_chat_capture(
+        self,
+        question: str,
+        images: list[Any] | None = None,
+        *,
+        max_new_tokens: int = 128,
+        do_sample: bool = False,
+        use_official_hybrid_mask: bool = False,
+    ) -> dict[str, Any]:
+        assert self.model is not None and self.tokenizer is not None
+        from sensenova_u1.models.neo_unify.utils import load_image_native
+
+        images = list(images or [])
+        pixel_values = None
+        grid_hw = None
+        if images:
+            pixel_values_list = []
+            grid_hw_list = []
+            for image in images:
+                cur_pixel_values, cur_grid_hw = load_image_native(
+                    _coerce_image(image),
+                    patch_size=self.model.patch_size,
+                    downsample_ratio=self.model.downsample_ratio,
+                    min_pixels=(
+                        self.min_pixels
+                        if self.min_pixels is not None
+                        else DEFAULT_VQA_MIN_PIXELS
+                    ),
+                    max_pixels=(
+                        self.max_pixels
+                        if self.max_pixels is not None
+                        else DEFAULT_VQA_MAX_PIXELS
+                    ),
+                )
+                pixel_values_list.append(cur_pixel_values)
+                grid_hw_list.append(cur_grid_hw)
+            pixel_values = torch.cat(pixel_values_list, dim=0).to(
+                self.torch_device, dtype=self.model.dtype
+            )
+            grid_hw = torch.cat(grid_hw_list, dim=0).to(self.torch_device)
+
+        captured: dict[str, Any] = {}
+        original_generate = self.model.generate
+
+        def _capture_generate(*args: Any, **kwargs: Any):
+            output = original_generate(*args, **kwargs)
+            captured["output_ids"] = output.detach().cpu()
+            return output
+
+        self.model.generate = _capture_generate
+        try:
+            start = time.perf_counter()
+            if use_official_hybrid_mask:
+                with _official_block_mask_scope():
+                    text = self.model.chat(
+                        self.tokenizer,
+                        pixel_values,
+                        question,
+                        {"max_new_tokens": max_new_tokens, "do_sample": do_sample},
+                        grid_hw=grid_hw,
+                    )
+            else:
+                text = self.model.chat(
+                    self.tokenizer,
+                    pixel_values,
+                    question,
+                    {"max_new_tokens": max_new_tokens, "do_sample": do_sample},
+                    grid_hw=grid_hw,
+                )
+            elapsed = time.perf_counter() - start
+        finally:
+            self.model.generate = original_generate
+
+        output_ids = captured["output_ids"]
+        return {
+            "text": text,
+            "token_ids": output_ids[0].tolist(),
+            "engine_time_s": elapsed,
+        }
+
+    def complete_payload(
+        self,
+        payload: StagePayload,
+        *,
+        max_new_tokens: int = 128,
+        do_sample: bool = False,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        top_k: int | None = None,
+        repetition_penalty: float | None = None,
+    ) -> dict[str, Any]:
+        inputs, params, request_id = _extract_request(payload)
+        question, images, history = _extract_question_images_history(inputs)
+        prepared = self.prepare(question, images, history)
+        start = time.perf_counter()
+        output_ids = self.generate_ids(
+            prepared,
+            max_new_tokens=int(params.get("max_new_tokens", max_new_tokens)),
+            do_sample=bool(params.get("do_sample", do_sample)),
+            temperature=float(params.get("temperature", temperature)),
+            top_p=float(params.get("top_p", top_p)),
+            top_k=params.get("top_k", top_k),
+            repetition_penalty=params.get("repetition_penalty", repetition_penalty),
+        )
+        elapsed = time.perf_counter() - start
+        token_ids = output_ids[0].detach().cpu().tolist()
+        return {
+            "request_id": request_id,
+            "text": self.decode_generated(output_ids),
+            "token_ids": token_ids,
+            "finish_reason": "stop",
+            "usage": {
+                "prompt_tokens": int(prepared.input_ids.numel()),
+                "completion_tokens": len(token_ids),
+                "total_tokens": int(prepared.input_ids.numel()) + len(token_ids),
+                "engine_time_s": elapsed,
+            },
+            "stage_name": "u1_vqa",
+            "backend": "hf_compatible_fallback",
+        }
+
+
+def logits_similarity(a: torch.Tensor, b: torch.Tensor) -> dict[str, float]:
+    a = a.detach().float().reshape(1, -1).cpu()
+    b = b.detach().float().reshape(1, -1).cpu()
+    return {
+        "cosine": float(F.cosine_similarity(a, b, dim=-1).item()),
+        "max_abs_diff": float((a - b).abs().max().item()),
+    }

--- a/sglang_omni/models/sensenova_u1/hybrid_attention.py
+++ b/sglang_omni/models/sensenova_u1/hybrid_attention.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SenseNova U1 hybrid prefill attention helpers.
+
+U1 assigns all ``<IMG_CONTEXT>`` tokens from one image span the same temporal
+index. Text rows remain causal; image rows may also attend to every token in
+their image span. The resulting dense mask is equivalent to the official
+``create_block_causal_mask(indexes[0])`` implementation and is used as the
+native Python reference before a fused backend grows the same row policy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+
+@dataclass(frozen=True, slots=True)
+class ImageSpan:
+    """Contiguous image-token span sharing one U1 temporal index."""
+
+    start: int
+    end: int
+    t_index: int
+
+    @property
+    def length(self) -> int:
+        return self.end - self.start
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "start": self.start,
+            "end": self.end,
+            "length": self.length,
+            "t_index": self.t_index,
+        }
+
+
+def _as_t_index(t_indexes: torch.Tensor) -> torch.Tensor:
+    if t_indexes.ndim == 2:
+        if t_indexes.shape[0] != 3:
+            raise ValueError(
+                "Expected U1 indexes with shape (3, L) when passing a 2D tensor."
+            )
+        return t_indexes[0]
+    if t_indexes.ndim != 1:
+        raise ValueError("Expected t_indexes with shape (L,) or indexes with shape (3, L).")
+    return t_indexes
+
+
+def build_image_token_tag_from_input_ids(
+    input_ids: torch.Tensor,
+    img_context_token_id: int,
+) -> torch.Tensor:
+    """Return a bool tag for per-token U1 image context rows."""
+
+    ids = input_ids.reshape(-1)
+    return ids == int(img_context_token_id)
+
+
+def build_image_token_tag_from_t_indexes(t_indexes: torch.Tensor) -> torch.Tensor:
+    """Infer image rows from repeated temporal indexes.
+
+    In U1 understanding prefixes, repeated temporal indexes are produced by
+    image context spans. This helper is useful for synthetic tests where token
+    ids are not available.
+    """
+
+    t_index = _as_t_index(t_indexes)
+    if t_index.numel() == 0:
+        return torch.empty_like(t_index, dtype=torch.bool)
+    _, inverse, counts = torch.unique(t_index, sorted=False, return_inverse=True, return_counts=True)
+    return counts[inverse] > 1
+
+
+def build_image_spans(
+    t_indexes: torch.Tensor,
+    image_token_tag: torch.Tensor | None = None,
+) -> list[ImageSpan]:
+    """Summarize contiguous image spans for evidence and debugging."""
+
+    t_index = _as_t_index(t_indexes).detach().cpu()
+    if image_token_tag is None:
+        tag = build_image_token_tag_from_t_indexes(t_index)
+    else:
+        tag = image_token_tag.reshape(-1).detach().cpu().bool()
+    if tag.numel() != t_index.numel():
+        raise ValueError("image_token_tag length must match t_indexes length.")
+
+    spans: list[ImageSpan] = []
+    start: int | None = None
+    cur_t: int | None = None
+    for pos, is_image in enumerate(tag.tolist()):
+        pos_t = int(t_index[pos].item())
+        if is_image and start is None:
+            start = pos
+            cur_t = pos_t
+        elif is_image and cur_t != pos_t:
+            spans.append(ImageSpan(start=start, end=pos, t_index=int(cur_t)))
+            start = pos
+            cur_t = pos_t
+        elif not is_image and start is not None:
+            spans.append(ImageSpan(start=start, end=pos, t_index=int(cur_t)))
+            start = None
+            cur_t = None
+    if start is not None:
+        spans.append(ImageSpan(start=start, end=tag.numel(), t_index=int(cur_t)))
+    return spans
+
+
+def build_m_block_summary(
+    image_token_tag: torch.Tensor,
+    *,
+    block_m: int,
+) -> list[dict[str, Any]]:
+    """Return the M-block OR-reduction described by U1's inference docs."""
+
+    if block_m <= 0:
+        raise ValueError("block_m must be positive.")
+    tag = image_token_tag.reshape(-1).detach().cpu().bool()
+    rows: list[dict[str, Any]] = []
+    for start in range(0, tag.numel(), block_m):
+        end = min(start + block_m, tag.numel())
+        block = tag[start:end]
+        rows.append(
+            {
+                "start": start,
+                "end": end,
+                "has_image": bool(block.any().item()),
+                "image_rows": [start + i for i, v in enumerate(block.tolist()) if v],
+            }
+        )
+    return rows
+
+
+def build_u1_hybrid_allowed_matrix(
+    t_indexes: torch.Tensor,
+    image_token_tag: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Build the boolean U1 hybrid attention matrix with shape ``(L, L)``."""
+
+    t_index = _as_t_index(t_indexes)
+    length = t_index.numel()
+    positions = torch.arange(length, device=t_index.device)
+    causal = positions.unsqueeze(0) <= positions.unsqueeze(1)
+    same_t = t_index.unsqueeze(0) == t_index.unsqueeze(1)
+    if image_token_tag is None:
+        return causal | same_t
+
+    tag = image_token_tag.reshape(-1).to(device=t_index.device, dtype=torch.bool)
+    if tag.numel() != length:
+        raise ValueError("image_token_tag length must match t_indexes length.")
+    same_image_span = same_t & tag.unsqueeze(0) & tag.unsqueeze(1)
+    return causal | same_image_span
+
+
+def create_u1_hybrid_mask(
+    index: torch.Tensor,
+    *,
+    image_token_tag: torch.Tensor | None = None,
+    dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    """Create U1's additive prefill attention mask with shape ``(1, 1, L, L)``."""
+
+    t_index = _as_t_index(index)
+    allowed = build_u1_hybrid_allowed_matrix(t_index, image_token_tag=image_token_tag)
+    mask_dtype = dtype or torch.get_default_dtype()
+    zero = torch.zeros((), device=t_index.device, dtype=mask_dtype)
+    neg_inf = torch.full((), float("-inf"), device=t_index.device, dtype=mask_dtype)
+    return torch.where(allowed[None, None, :, :], zero, neg_inf)
+
+
+def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    if n_rep == 1:
+        return hidden_states
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch, num_key_value_heads, n_rep, slen, head_dim
+    )
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+def u1_hybrid_attention_forward(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    t_indexes: torch.Tensor,
+    *,
+    image_token_tag: torch.Tensor | None = None,
+    scaling: float | None = None,
+    dropout: float = 0.0,
+    training: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Dense reference attention for U1 hybrid prefill rows.
+
+    Inputs follow the HF attention convention ``(B, H, L, D)`` and the output
+    follows the official U1 eager path convention ``(B, L, H, D)``.
+    """
+
+    if query.ndim != 4 or key.ndim != 4 or value.ndim != 4:
+        raise ValueError("query, key and value must all have shape (B, H, L, D).")
+    if key.shape[:3] != value.shape[:3] or key.shape[-1] != value.shape[-1]:
+        raise ValueError("key and value shapes are incompatible.")
+    if query.shape[0] != key.shape[0] or query.shape[-1] != key.shape[-1]:
+        raise ValueError("query/key batch or head_dim mismatch.")
+    if query.shape[2] != key.shape[2]:
+        raise ValueError("U1 prefill dense reference expects query and key lengths to match.")
+    if query.shape[1] % key.shape[1] != 0:
+        raise ValueError("query heads must be a multiple of key/value heads.")
+
+    num_key_value_groups = query.shape[1] // key.shape[1]
+    key_states = _repeat_kv(key, num_key_value_groups)
+    value_states = _repeat_kv(value, num_key_value_groups)
+    scale = scaling if scaling is not None else query.shape[-1] ** -0.5
+    attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scale
+    attn_weights = attn_weights + create_u1_hybrid_mask(
+        t_indexes,
+        image_token_tag=image_token_tag,
+        dtype=attn_weights.dtype,
+    )
+    attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_weights = F.dropout(attn_weights, p=dropout, training=training)
+    attn_output = torch.matmul(attn_weights, value_states)
+    return attn_output.transpose(1, 2).contiguous(), attn_weights

--- a/sglang_omni/models/sensenova_u1/interleave.py
+++ b/sglang_omni/models/sensenova_u1/interleave.py
@@ -1,0 +1,360 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SenseNova U1 interleaved text-image generation runner.
+
+This M4 path keeps the official NEOChatModel interleave loop inside an
+SGLang-Omni stage. The loop autoregressively emits text, switches into U1
+flow-matching when the model emits an image start token, re-encodes the
+generated image, and then continues text generation from the updated KV cache.
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import nullcontext
+from dataclasses import asdict, dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+from PIL import Image
+
+from sglang_omni.models.sensenova_u1.flow_matching import (
+    SenseNovaU1FlowMatchingRunner,
+    pil_to_data_url,
+    u1_tensor_to_pil,
+)
+from sglang_omni.models.sensenova_u1.hf_runner import (
+    DEFAULT_MODEL_DIR,
+    DEFAULT_VENDOR_ROOT,
+    _coerce_image,
+    _extract_request,
+    _extract_text_and_images_from_content,
+    _official_block_mask_scope,
+)
+from sglang_omni.proto import StagePayload
+
+
+DEFAULT_INTERLEAVE_SYSTEM_MESSAGE = (
+    "You are a multimodal assistant capable of reasoning with both text and images. "
+    "You support two modes:\n\n"
+    "Think Mode: When reasoning is needed, you MUST start with a <think></think> block "
+    "and place all reasoning inside it. You MUST interleave text with generated images "
+    "using tags like <image1>, <image2>. Images can ONLY be generated between <think> and "
+    "</think>, and may be referenced in the final answer.\n\n"
+    "Non-Think Mode: When no reasoning is needed, directly provide the answer without "
+    "reasoning. Do not use tags like <image1>, <image2>; present any images naturally "
+    "alongside the text.\n\n"
+    "After the think block, always provide a concise, user-facing final answer. The "
+    "answer may include text, images, or both. Match the user's language in both "
+    "reasoning and the final answer."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class InterleaveRequestParams:
+    prompt: str
+    image_size: tuple[int, int] = (256, 256)
+    cfg_scale: float = 1.0
+    img_cfg_scale: float = 1.0
+    cfg_norm: str = "none"
+    timestep_shift: float = 1.0
+    enable_timestep_shift: bool = True
+    cfg_interval: tuple[float, float] = (0.0, 1.0)
+    num_steps: int = 2
+    max_images: int = 1
+    max_new_tokens: int = 512
+    t_eps: float = 0.05
+    think_mode: bool = True
+    seed: int = 20260813
+    system_message: str = DEFAULT_INTERLEAVE_SYSTEM_MESSAGE
+
+
+@dataclass(slots=True)
+class InterleaveResult:
+    text: str
+    token_ids: list[int]
+    images: list[Image.Image]
+    stats: dict[str, Any]
+    elapsed_s: float
+
+
+def _stage_params(params: dict[str, Any], stage_name: str) -> dict[str, Any]:
+    merged = dict(params)
+    stage_params = params.get("stage_params")
+    if isinstance(stage_params, dict):
+        specific = stage_params.get(stage_name)
+        if isinstance(specific, dict):
+            merged.update(specific)
+    stage_sampling = params.get("stage_sampling")
+    if isinstance(stage_sampling, dict):
+        specific_sampling = stage_sampling.get(stage_name)
+        if isinstance(specific_sampling, dict):
+            merged.update(specific_sampling)
+    return merged
+
+
+def _positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _cfg_interval(value: Any) -> tuple[float, float]:
+    if value is None:
+        return (0.0, 1.0)
+    interval = tuple(float(x) for x in value)
+    if len(interval) != 2:
+        raise ValueError("cfg_interval must contain exactly two floats.")
+    return (interval[0], interval[1])
+
+
+def _extract_prompt_images_system(inputs: Any) -> tuple[str, list[Any], str | None]:
+    images: list[Any] = []
+    system_message: str | None = None
+
+    if isinstance(inputs, str):
+        return inputs, images, system_message
+
+    if isinstance(inputs, dict):
+        images.extend(_coerce_image(img) for img in inputs.get("images") or [])
+        if "image" in inputs:
+            images.append(_coerce_image(inputs["image"]))
+        if "system_message" in inputs:
+            system_message = str(inputs["system_message"])
+        if "prompt" in inputs:
+            return str(inputs["prompt"]), images, system_message
+        if "question" in inputs:
+            return str(inputs["question"]), images, system_message
+        if "messages" in inputs:
+            inputs = inputs["messages"]
+        else:
+            return str(inputs), images, system_message
+
+    if isinstance(inputs, list):
+        prompt_parts: list[str] = []
+        for msg in inputs:
+            if not isinstance(msg, dict):
+                prompt_parts.append(str(msg))
+                continue
+            role = str(msg.get("role", "user"))
+            text, msg_images = _extract_text_and_images_from_content(
+                msg.get("content", "")
+            )
+            images.extend(_coerce_image(img) for img in msg_images)
+            if role == "system" and text:
+                system_message = text
+            elif role == "user" and text:
+                prompt_parts.append(text)
+        return "\n".join(part for part in prompt_parts if part), images, system_message
+
+    return str(inputs), images, system_message
+
+
+def _params_from_payload(
+    inputs: Any,
+    params: dict[str, Any],
+) -> tuple[InterleaveRequestParams, list[Any]]:
+    prompt, images, system_from_messages = _extract_prompt_images_system(inputs)
+    params = _stage_params(params, "u1_interleave")
+
+    data = inputs if isinstance(inputs, dict) else {}
+    image_config = params.get("image_config")
+    if not isinstance(image_config, dict):
+        image_config = data.get("image_config") if isinstance(data, dict) else {}
+    if not isinstance(image_config, dict):
+        image_config = {}
+
+    width = _positive_int(
+        params.get("width", params.get("image_width", image_config.get("width"))),
+        256,
+    )
+    height = _positive_int(
+        params.get("height", params.get("image_height", image_config.get("height"))),
+        256,
+    )
+
+    chat_template_kwargs = params.get("chat_template_kwargs")
+    if not isinstance(chat_template_kwargs, dict):
+        chat_template_kwargs = {}
+    think_mode = bool(params.get("think_mode", True))
+    if "enable_thinking" in chat_template_kwargs:
+        think_mode = bool(chat_template_kwargs["enable_thinking"])
+
+    seed_value = params.get("seed", image_config.get("seed", 20260813))
+    system_message = str(
+        params.get(
+            "system_message",
+            system_from_messages or DEFAULT_INTERLEAVE_SYSTEM_MESSAGE,
+        )
+    )
+
+    request = InterleaveRequestParams(
+        prompt=str(params.get("prompt", prompt)),
+        image_size=(width, height),
+        cfg_scale=float(params.get("cfg_scale", 1.0)),
+        img_cfg_scale=float(params.get("img_cfg_scale", 1.0)),
+        cfg_norm=str(params.get("cfg_norm", "none")),
+        timestep_shift=float(params.get("timestep_shift", 1.0)),
+        enable_timestep_shift=bool(params.get("enable_timestep_shift", True)),
+        cfg_interval=_cfg_interval(params.get("cfg_interval", (0.0, 1.0))),
+        num_steps=int(params.get("num_steps", 2)),
+        max_images=int(params.get("max_images", 1)),
+        max_new_tokens=int(params.get("max_new_tokens", params.get("max_tokens", 512))),
+        t_eps=float(params.get("t_eps", 0.05)),
+        think_mode=think_mode,
+        seed=int(seed_value),
+        system_message=system_message,
+    )
+    return request, images
+
+
+def interleave_tensors_to_pil(image_tensors: list[torch.Tensor]) -> list[Image.Image]:
+    images: list[Image.Image] = []
+    for tensor in image_tensors:
+        if tensor.ndim == 3:
+            tensor = tensor.unsqueeze(0)
+        images.extend(u1_tensor_to_pil(tensor.detach()))
+    return images
+
+
+def interleave_segments(text: str, image_items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    parts = text.split("<image>")
+    segments: list[dict[str, Any]] = []
+    for idx, part in enumerate(parts):
+        if part:
+            segments.append({"type": "text", "text": part})
+        if idx < len(parts) - 1:
+            if idx < len(image_items):
+                segments.append({"type": "image", "image": image_items[idx]})
+            else:
+                segments.append({"type": "image", "image": None})
+    return segments
+
+
+class SenseNovaU1InterleaveRunner(SenseNovaU1FlowMatchingRunner):
+    """End-to-end U1 text-image-text generation runner."""
+
+    def __init__(
+        self,
+        model_path: str = DEFAULT_MODEL_DIR,
+        *,
+        vendor_root: str | None = None,
+        device: str = "cuda:0",
+        dtype: str | torch.dtype = "bfloat16",
+        attn_backend: str = "auto",
+        load_with_info: bool = False,
+    ) -> None:
+        super().__init__(
+            model_path=model_path,
+            vendor_root=vendor_root or DEFAULT_VENDOR_ROOT,
+            device=device,
+            dtype=dtype,
+            attn_backend=attn_backend,
+            load_with_info=load_with_info,
+        )
+
+    @torch.inference_mode()
+    def generate_interleave(
+        self,
+        request: InterleaveRequestParams,
+        images: list[Any] | None = None,
+        *,
+        use_official_hybrid_mask: bool = False,
+    ) -> InterleaveResult:
+        assert self.model is not None and self.tokenizer is not None
+        ctx = _official_block_mask_scope() if use_official_hybrid_mask else nullcontext()
+        generation_config = SimpleNamespace(max_new_tokens=request.max_new_tokens)
+        start = time.perf_counter()
+        with ctx:
+            text, image_tensors = self.model.interleave_gen(
+                self.tokenizer,
+                request.prompt,
+                images=[_coerce_image(image) for image in (images or [])],
+                generation_config=generation_config,
+                cfg_scale=request.cfg_scale,
+                img_cfg_scale=request.img_cfg_scale,
+                cfg_norm=request.cfg_norm,
+                max_images=request.max_images,
+                enable_timestep_shift=request.enable_timestep_shift,
+                timestep_shift=request.timestep_shift,
+                image_size=request.image_size,
+                num_steps=request.num_steps,
+                cfg_interval=request.cfg_interval,
+                t_eps=request.t_eps,
+                verbose=False,
+                system_message=request.system_message,
+                think_mode=request.think_mode,
+                seed=request.seed,
+            )
+        elapsed = time.perf_counter() - start
+        token_ids = self.tokenizer(
+            text,
+            add_special_tokens=False,
+        )["input_ids"]
+        stats = dict(getattr(self.model, "last_interleave_generation_stats", {}) or {})
+        return InterleaveResult(
+            text=str(text),
+            token_ids=[int(x) for x in token_ids],
+            images=interleave_tensors_to_pil(list(image_tensors)),
+            stats=stats,
+            elapsed_s=elapsed,
+        )
+
+    def complete_payload(self, payload: StagePayload) -> dict[str, Any]:
+        inputs, params, request_id = _extract_request(payload)
+        request, images = _params_from_payload(inputs, params)
+        result = self.generate_interleave(request, images)
+        image_items = [
+            {
+                "type": "image",
+                "format": "png",
+                "data": pil_to_data_url(image),
+                "width": image.width,
+                "height": image.height,
+                "index": idx,
+            }
+            for idx, image in enumerate(result.images)
+        ]
+        prompt_token_ids = self.tokenizer(  # type: ignore[operator]
+            request.prompt,
+            add_special_tokens=False,
+        )["input_ids"]
+        rollout = {
+            "type": "sensenova_u1_interleave",
+            "segments": interleave_segments(result.text, image_items),
+            "images": image_items,
+            "text": result.text,
+            "token_ids": result.token_ids,
+            "stats": result.stats,
+            "request": asdict(request),
+            "backend": "hf_compatible_interleave_fallback",
+        }
+        return {
+            "request_id": request_id,
+            "text": result.text,
+            "token_ids": result.token_ids,
+            "images": image_items,
+            "omni_rollout": rollout,
+            "finish_reason": result.stats.get("stop_reason", "stop"),
+            "usage": {
+                "prompt_tokens": len(prompt_token_ids),
+                "completion_tokens": len(result.token_ids),
+                "total_tokens": len(prompt_token_ids) + len(result.token_ids),
+                "engine_time_s": result.elapsed_s,
+                "generated_images": len(result.images),
+            },
+            "stage_name": "u1_interleave",
+            "backend": "hf_compatible_interleave_fallback",
+        }
+
+
+__all__ = [
+    "DEFAULT_INTERLEAVE_SYSTEM_MESSAGE",
+    "InterleaveRequestParams",
+    "InterleaveResult",
+    "SenseNovaU1InterleaveRunner",
+    "interleave_segments",
+    "interleave_tensors_to_pil",
+]

--- a/sglang_omni/models/sensenova_u1/stages.py
+++ b/sglang_omni/models/sensenova_u1/stages.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stage factories for SenseNova U1 fallback paths."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def create_sensenova_u1_vqa_executor(
+    model_path: str,
+    *,
+    device: str = "cuda:0",
+    dtype: str = "bfloat16",
+    vendor_root: str | None = None,
+    max_new_tokens: int = 128,
+    do_sample: bool = False,
+    temperature: float = 0.7,
+    top_p: float = 0.9,
+    top_k: int | None = None,
+    repetition_penalty: float | None = None,
+    attn_backend: str = "auto",
+    min_pixels: int | None = None,
+    max_pixels: int | None = None,
+    max_concurrency: int = 1,
+    load_with_info: bool = False,
+) -> Any:
+    from sglang_omni.models.sensenova_u1.hf_runner import (
+        SenseNovaU1UnderstandingRunner,
+    )
+    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+
+    runner = SenseNovaU1UnderstandingRunner(
+        model_path=model_path,
+        vendor_root=vendor_root,
+        device=device,
+        dtype=dtype,
+        attn_backend=attn_backend,
+        min_pixels=min_pixels,
+        max_pixels=max_pixels,
+        load_with_info=load_with_info,
+    )
+
+    def _complete(payload):
+        return runner.complete_payload(
+            payload,
+            max_new_tokens=max_new_tokens,
+            do_sample=do_sample,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            repetition_penalty=repetition_penalty,
+        )
+
+    return SimpleScheduler(_complete, max_concurrency=max_concurrency)
+
+
+def create_sensenova_u1_flow_executor(
+    model_path: str,
+    *,
+    device: str = "cuda:0",
+    dtype: str = "bfloat16",
+    vendor_root: str | None = None,
+    attn_backend: str = "auto",
+    max_concurrency: int = 1,
+) -> Any:
+    from sglang_omni.models.sensenova_u1.flow_matching import (
+        SenseNovaU1FlowMatchingRunner,
+    )
+    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+
+    runner = SenseNovaU1FlowMatchingRunner(
+        model_path=model_path,
+        vendor_root=vendor_root,
+        device=device,
+        dtype=dtype,
+        attn_backend=attn_backend,
+    )
+    return SimpleScheduler(
+        runner.complete_payload,
+        max_concurrency=max_concurrency,
+    )
+
+
+def create_sensenova_u1_interleave_executor(
+    model_path: str,
+    *,
+    device: str = "cuda:0",
+    dtype: str = "bfloat16",
+    vendor_root: str | None = None,
+    attn_backend: str = "auto",
+    max_concurrency: int = 1,
+) -> Any:
+    from sglang_omni.models.sensenova_u1.interleave import (
+        SenseNovaU1InterleaveRunner,
+    )
+    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+
+    runner = SenseNovaU1InterleaveRunner(
+        model_path=model_path,
+        vendor_root=vendor_root,
+        device=device,
+        dtype=dtype,
+        attn_backend=attn_backend,
+    )
+    return SimpleScheduler(
+        runner.complete_payload,
+        max_concurrency=max_concurrency,
+    )
+
+
+__all__ = [
+    "create_sensenova_u1_flow_executor",
+    "create_sensenova_u1_interleave_executor",
+    "create_sensenova_u1_vqa_executor",
+]

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -680,6 +680,31 @@ def _register_chat_completions(app: FastAPI) -> None:
         )
 
 
+def _images_from_omni_rollout(omni_rollout: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(omni_rollout, dict):
+        return []
+    images = omni_rollout.get("images") or []
+    output: list[dict[str, Any]] = []
+    for item in images:
+        if not isinstance(item, dict):
+            continue
+        url = item.get("data") or item.get("url")
+        image_url = item.get("image_url")
+        if isinstance(image_url, dict):
+            url = image_url.get("url", url)
+        if not isinstance(url, str) or not url.startswith("data:image/"):
+            continue
+        out_item: dict[str, Any] = {
+            "type": "image_url",
+            "image_url": {"url": url},
+        }
+        for key in ("width", "height", "index", "format"):
+            if item.get(key) is not None:
+                out_item[key] = item[key]
+        output.append(out_item)
+    return output
+
+
 async def _chat_non_stream(
     client: Client,
     gen_req: GenerateRequest,
@@ -721,6 +746,11 @@ async def _chat_non_stream(
             "data": result.audio.data,
             "transcript": result.audio.transcript,
         }
+
+    if "image" in requested_modalities:
+        images = _images_from_omni_rollout(result.omni_rollout)
+        if images:
+            message["images"] = images
 
     if "content" not in message and "audio" not in message:
         message["content"] = result.text
@@ -793,6 +823,9 @@ async def _chat_stream(
                     chunk.modality == "audio"
                     and chunk.audio_b64 is not None
                     and "audio" in requested_modalities
+                ) or (
+                    "image" in requested_modalities
+                    and bool(_images_from_omni_rollout(chunk.omni_rollout))
                 )
                 if not has_payload:
                     continue
@@ -826,6 +859,12 @@ async def _chat_stream(
                     data=chunk.audio_b64,
                 )
                 emit = True
+
+            if "image" in requested_modalities:
+                images = _images_from_omni_rollout(chunk.omni_rollout)
+                if images:
+                    delta.images = images
+                    emit = True
 
             if not emit:
                 continue
@@ -966,6 +1005,9 @@ def _build_chat_generate_request(req: ChatCompletionRequest) -> GenerateRequest:
         ("talker_top_k", req.talker_top_k),
         ("talker_repetition_penalty", req.talker_repetition_penalty),
         ("talker_max_new_tokens", req.talker_max_new_tokens),
+        ("image_config", req.image_config),
+        ("chat_template_kwargs", req.chat_template_kwargs),
+        ("n", req.n),
     ):
         if value is not None:
             extra_params[field_name] = value

--- a/sglang_omni/serve/protocol.py
+++ b/sglang_omni/serve/protocol.py
@@ -62,6 +62,9 @@ class ChatCompletionRequest(BaseModel):
 
     # Multi-modal output control
     modalities: list[str] | None = None  # e.g. ["text", "audio"]
+    image_config: dict[str, Any] | None = None
+    chat_template_kwargs: dict[str, Any] | None = None
+    n: int | None = None
 
     # Audio output configuration
     audio: dict[str, Any] | None = None  # {"voice": "...", "format": "wav"}
@@ -128,6 +131,7 @@ class ChatCompletionStreamDelta(BaseModel):
     role: str | None = None
     content: str | None = None
     audio: ChatCompletionAudio | None = None
+    images: list[dict[str, Any]] | None = None
 
 
 class ChatCompletionStreamChoice(BaseModel):

--- a/tests/unit_test/sensenova_u1/test_hybrid_attention.py
+++ b/tests/unit_test/sensenova_u1/test_hybrid_attention.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import torch
+from PIL import Image
+
+from sglang_omni.models.sensenova_u1.flow_matching import compare_pil_images
+from sglang_omni.models.sensenova_u1.hybrid_attention import (
+    build_image_spans,
+    build_image_token_tag_from_t_indexes,
+    build_m_block_summary,
+    build_u1_hybrid_allowed_matrix,
+    create_u1_hybrid_mask,
+    u1_hybrid_attention_forward,
+)
+
+
+def _naive_allowed(t_indexes: torch.Tensor, image_tag: torch.Tensor) -> torch.Tensor:
+    length = t_indexes.numel()
+    allowed = torch.zeros((length, length), dtype=torch.bool)
+    for row in range(length):
+        for col in range(length):
+            causal = col <= row
+            same_image_span = (
+                bool(image_tag[row])
+                and bool(image_tag[col])
+                and int(t_indexes[row]) == int(t_indexes[col])
+            )
+            allowed[row, col] = causal or same_image_span
+    return allowed
+
+
+def test_u1_hybrid_allowed_matrix_matches_naive_dense_policy() -> None:
+    t_indexes = torch.tensor([0, 1, 2, 2, 2, 3, 4, 4, 5])
+    image_tag = torch.tensor([False, False, True, True, True, False, True, True, False])
+
+    allowed = build_u1_hybrid_allowed_matrix(t_indexes, image_token_tag=image_tag)
+
+    assert torch.equal(allowed.cpu(), _naive_allowed(t_indexes, image_tag))
+    assert allowed[2, 4]
+    assert allowed[4, 2]
+    assert not allowed[1, 2]
+    assert not allowed[6, 8]
+
+
+def test_u1_hybrid_mask_and_span_summaries() -> None:
+    indexes = torch.tensor(
+        [
+            [0, 1, 2, 2, 2, 3, 4, 4, 5],
+            [0, 0, 0, 1, 2, 0, 0, 1, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ]
+    )
+    inferred_tag = build_image_token_tag_from_t_indexes(indexes)
+
+    assert inferred_tag.tolist() == [
+        False,
+        False,
+        True,
+        True,
+        True,
+        False,
+        True,
+        True,
+        False,
+    ]
+    assert [span.as_dict() for span in build_image_spans(indexes, inferred_tag)] == [
+        {"start": 2, "end": 5, "length": 3, "t_index": 2},
+        {"start": 6, "end": 8, "length": 2, "t_index": 4},
+    ]
+    assert build_m_block_summary(inferred_tag, block_m=4) == [
+        {"start": 0, "end": 4, "has_image": True, "image_rows": [2, 3]},
+        {"start": 4, "end": 8, "has_image": True, "image_rows": [4, 6, 7]},
+        {"start": 8, "end": 9, "has_image": False, "image_rows": []},
+    ]
+
+    mask = create_u1_hybrid_mask(indexes, image_token_tag=inferred_tag, dtype=torch.float32)
+    assert mask.shape == (1, 1, 9, 9)
+    assert mask[0, 0, 2, 4].item() == 0.0
+    assert mask[0, 0, 1, 2].item() == float("-inf")
+
+
+def test_u1_hybrid_attention_forward_matches_manual_softmax() -> None:
+    query = torch.tensor([[[[0.1, 0.2], [0.3, -0.1], [0.0, 0.5], [0.7, 0.2]]]])
+    key = torch.tensor([[[[0.2, 0.0], [0.1, 0.4], [0.6, -0.2], [0.3, 0.3]]]])
+    value = torch.tensor([[[[1.0, 0.0], [0.0, 1.0], [0.5, 0.5], [2.0, -1.0]]]])
+    t_indexes = torch.tensor([0, 1, 1, 2])
+    image_tag = torch.tensor([False, True, True, False])
+
+    out, weights = u1_hybrid_attention_forward(
+        query,
+        key,
+        value,
+        t_indexes,
+        image_token_tag=image_tag,
+    )
+
+    scores = torch.matmul(query, key.transpose(2, 3)) * (query.shape[-1] ** -0.5)
+    scores = scores + create_u1_hybrid_mask(
+        t_indexes,
+        image_token_tag=image_tag,
+        dtype=scores.dtype,
+    )
+    expected_weights = torch.softmax(scores.float(), dim=-1).to(query.dtype)
+    expected_out = torch.matmul(expected_weights, value).transpose(1, 2).contiguous()
+
+    assert torch.allclose(weights, expected_weights)
+    assert torch.allclose(out, expected_out)
+
+
+def test_compare_pil_images_reports_exact_and_shifted_metrics() -> None:
+    black = Image.fromarray(np.zeros((4, 4, 3), dtype=np.uint8), mode="RGB")
+    almost_black = Image.fromarray(np.ones((4, 4, 3), dtype=np.uint8), mode="RGB")
+
+    exact = compare_pil_images(black, black)
+    shifted = compare_pil_images(black, almost_black)
+
+    assert exact["pixel_max_abs_diff_uint8"] == 0
+    assert math.isinf(exact["psnr_db"])
+    assert exact["ssim_global_rgb"] == 1.0
+    assert shifted["pixel_max_abs_diff_uint8"] == 1
+    assert shifted["psnr_db"] < 50.0
+    assert shifted["ssim_global_rgb"] < 1.0

--- a/tests/unit_test/sensenova_u1/test_pipeline.py
+++ b/tests/unit_test/sensenova_u1/test_pipeline.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+from sglang_omni.config.manager import ConfigManager
+from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+from sglang_omni.models.sensenova_u1.config import (
+    SenseNovaU1FlowPipelineConfig,
+    SenseNovaU1InterleavePipelineConfig,
+    SenseNovaU1PipelineConfig,
+    Variants,
+)
+
+
+def _stage_names(config) -> list[str]:
+    return [stage.name for stage in config.stages]
+
+
+def test_sensenova_u1_pipeline_configs_register_architecture_and_alias() -> None:
+    assert PIPELINE_CONFIG_REGISTRY.get_config("NEOChatModel") is SenseNovaU1PipelineConfig
+    assert PIPELINE_CONFIG_REGISTRY.get_config("SenseNovaU1") is SenseNovaU1PipelineConfig
+
+    default = SenseNovaU1PipelineConfig(model_path="model")
+    flow = SenseNovaU1FlowPipelineConfig(model_path="model")
+    interleave = SenseNovaU1InterleavePipelineConfig(model_path="model")
+
+    assert _stage_names(default) == ["u1_vqa"]
+    assert _stage_names(flow) == ["u1_flow"]
+    assert _stage_names(interleave) == ["u1_interleave"]
+    assert default.mem_fraction_role_to_stage() == {"understanding": "u1_vqa"}
+    assert flow.mem_fraction_role_to_stage() == {"generation": "u1_flow"}
+    assert interleave.mem_fraction_role_to_stage() == {"interleave": "u1_interleave"}
+    assert default.stages[0].terminal is True
+    assert flow.stages[0].terminal is True
+    assert interleave.stages[0].terminal is True
+    assert default.stages[0].runtime.resources.total_gpu_memory_fraction == 0.75
+    assert interleave.stages[0].factory.endswith(
+        ".stages.create_sensenova_u1_interleave_executor"
+    )
+
+
+def test_sensenova_u1_config_manager_resolves_raw_hf_config_and_variant(tmp_path) -> None:
+    (tmp_path / "config.json").write_text(
+        json.dumps({"architectures": ["NEOChatModel"], "model_type": "neo_chat"})
+    )
+
+    manager = ConfigManager.from_model_path(str(tmp_path), variant="interleave")
+
+    assert isinstance(manager.config, SenseNovaU1InterleavePipelineConfig)
+    assert manager.config.model_path == str(tmp_path)
+    assert manager.config.entry_stage == "u1_interleave"
+    assert Variants["default"] is SenseNovaU1PipelineConfig
+    assert Variants["flow"] is SenseNovaU1FlowPipelineConfig
+    assert Variants["interleave"] is SenseNovaU1InterleavePipelineConfig

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -11,7 +11,11 @@ from fastapi.testclient import TestClient
 
 from sglang_omni.client import Client, GenerateChunk
 from sglang_omni.client.audio import encode_pcm
-from sglang_omni.client.types import GenerateRequest
+from sglang_omni.client.types import (
+    CompletionResult,
+    CompletionStreamChunk,
+    GenerateRequest,
+)
 from sglang_omni.pipeline.coordinator import Coordinator
 from sglang_omni.proto import (
     EXPLICIT_GENERATION_PARAMS_KEY,
@@ -299,6 +303,61 @@ class SuccessfulTranscriptionClient:
             text="hello world",
             finish_reason="stop",
         )
+
+
+class SuccessfulImageChatClient:
+    def __init__(self) -> None:
+        self.completion_requests: list[GenerateRequest] = []
+        self.stream_requests: list[GenerateRequest] = []
+        self.omni_rollout = {
+            "images": [
+                {
+                    "type": "image",
+                    "format": "png",
+                    "data": "data:image/png;base64,iVBORw0KGgo=",
+                    "width": 2,
+                    "height": 1,
+                    "index": 0,
+                },
+                {"type": "image", "data": "https://example.invalid/not-inline.png"},
+            ],
+        }
+
+    def health(self) -> dict[str, Any]:
+        return {"running": True}
+
+    async def completion(
+        self,
+        request: GenerateRequest,
+        *,
+        request_id: str,
+        audio_format: str = "wav",
+    ) -> CompletionResult:
+        del audio_format
+        self.completion_requests.append(request)
+        return CompletionResult(
+            request_id=request_id,
+            text="caption",
+            omni_rollout=self.omni_rollout,
+            finish_reason="stop",
+        )
+
+    async def completion_stream(
+        self,
+        request: GenerateRequest,
+        *,
+        request_id: str,
+        audio_format: str = "wav",
+    ):
+        del audio_format
+        self.stream_requests.append(request)
+        yield CompletionStreamChunk(
+            request_id=request_id,
+            text="caption",
+            modality="text",
+            omni_rollout=self.omni_rollout,
+        )
+        yield CompletionStreamChunk(request_id=request_id, finish_reason="stop")
 
 
 class ChunkRecordingTranscriptionClient:
@@ -1405,6 +1464,92 @@ def test_transcription_request_builds_asr_generate_request() -> None:
     assert gen_req.metadata == {"task": "asr"}
     assert gen_req.output_modalities == ["text"]
     assert gen_req.stream is False
+
+
+def test_chat_request_passes_image_generation_controls() -> None:
+    req = ChatCompletionRequest(
+        model="sensenova-u1",
+        messages=[{"role": "user", "content": "draw a red square"}],
+        modalities=["text", "image"],
+        image_config={"width": 256, "height": 256, "seed": 7},
+        chat_template_kwargs={"enable_thinking": False},
+        n=1,
+    )
+
+    gen_req = _build_chat_generate_request(req)
+
+    assert gen_req.output_modalities == ["text", "image"]
+    assert gen_req.extra_params["image_config"] == {
+        "width": 256,
+        "height": 256,
+        "seed": 7,
+    }
+    assert gen_req.extra_params["chat_template_kwargs"] == {"enable_thinking": False}
+    assert gen_req.extra_params["n"] == 1
+
+
+def test_chat_completion_non_stream_returns_inline_images() -> None:
+    image_client = SuccessfulImageChatClient()
+    client = TestClient(create_app(image_client, model_name="sensenova-u1"))
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "sensenova-u1",
+            "messages": [{"role": "user", "content": "draw a red square"}],
+            "modalities": ["text", "image"],
+            "image_config": {"width": 256, "height": 256},
+            "chat_template_kwargs": {"enable_thinking": False},
+            "n": 1,
+            "stream": False,
+        },
+    )
+
+    assert response.status_code == 200
+    message = response.json()["choices"][0]["message"]
+    assert message["content"] == "caption"
+    assert message["images"] == [
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+            "width": 2,
+            "height": 1,
+            "index": 0,
+            "format": "png",
+        }
+    ]
+    assert image_client.completion_requests[0].output_modalities == ["text", "image"]
+    assert image_client.completion_requests[0].extra_params["image_config"] == {
+        "width": 256,
+        "height": 256,
+    }
+    assert image_client.completion_requests[0].extra_params["chat_template_kwargs"] == {
+        "enable_thinking": False
+    }
+
+
+def test_chat_completion_stream_returns_inline_image_delta() -> None:
+    image_client = SuccessfulImageChatClient()
+    client = TestClient(create_app(image_client, model_name="sensenova-u1"))
+
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "sensenova-u1",
+            "messages": [{"role": "user", "content": "draw a red square"}],
+            "modalities": ["text", "image"],
+            "stream": True,
+        },
+    ) as response:
+        body = "".join(response.iter_text())
+
+    assert response.status_code == 200
+    assert '"content": "caption"' in body
+    assert '"images": [{"type": "image_url"' in body
+    assert "data:image/png;base64,iVBORw0KGgo=" in body
+    assert "not-inline.png" not in body
+    assert image_client.stream_requests[0].output_modalities == ["text", "image"]
 
 
 def test_transcription_request_preserves_explicit_empty_language() -> None:


### PR DESCRIPTION
## Summary

This PR adds an HF-compatible SenseNova U1 integration to SGLang-Omni for `NEOChatModel` / MoT interleaved understanding and generation.

The integration provides:

- `NEOChatModel` pipeline registration with the `SenseNovaU1` alias.
- A `u1_vqa` single-stage understanding pipeline using U1's native-resolution visual preprocessing and official HF-compatible math path.
- U1 hybrid image-span prefill attention helpers, including dense reference masking, image-span metadata, and M-block OR-reduction summaries.
- A `u1_flow` single-stage flow-matching image generation path for T2I and IT2I.
- A `u1_interleave` single-stage end-to-end interleaved text-image-text generation path.
- OpenAI-compatible image output plumbing: non-streaming chat returns `message.images`; streaming chat returns `delta.images`, with inline `image_url.url` data URLs.
- Unit coverage for SenseNova U1 pipeline registration, hybrid attention helpers, image metrics, and OpenAI-compatible image outputs.

The current implementation is intentionally HF-compatible and in-engine: it keeps SenseNova U1 inside the SGLang-Omni request/stage lifecycle while delegating U1 numerical kernels to the official `NEOChatModel` implementation. This establishes correctness and service/API behavior before a future native fused-attention / scheduler-performance pass.

## Why

SenseNova U1 is a unified MoT model for interleaved multimodal understanding and generation. Downstream rollout workloads need a single serving surface that can emit text and real generated image pixels in one response. The official deployment uses separate LightLLM + LightX2V engines; this PR instead exposes a single SGLang-Omni pipeline variant so interleaved generation can be used through SGLang-Omni's normal request and OpenAI-compatible serving paths.

## Implementation Notes

- `sglang_omni.models.sensenova_u1.config`
  - Registers `NEOChatModel` and alias `SenseNovaU1`.
  - Adds default, `flow`, and `interleave` variants.

- `sglang_omni.models.sensenova_u1.hf_runner`
  - Loads official SenseNova U1 model code from an installed package or `SENSENOVA_U1_VENDOR_ROOT`.
  - Uses `SENSENOVA_U1_MODEL_PATH` or the public HF repo id by default.
  - Patches compatibility gaps between the public U1 code and newer Transformers APIs.
  - Builds U1 native-resolution VQA prompts with `<img>/<IMG_CONTEXT></img>` expansion.

- `sglang_omni.models.sensenova_u1.hybrid_attention`
  - Implements the U1 dense hybrid mask: text rows stay causal; image rows can attend to the complete image span sharing the same temporal index.
  - Provides a dense attention reference used in parity tests.

- `sglang_omni.models.sensenova_u1.flow_matching`
  - Wraps U1 T2I/IT2I flow-matching generation in a SGLang-Omni stage.
  - Exposes scheduler parameters and image comparison helpers.

- `sglang_omni.models.sensenova_u1.interleave`
  - Wraps U1 `interleave_gen()` for text-image-text generation.
  - Returns `omni_rollout` metadata with generated images and text/image segments.

- OpenAI API plumbing
  - Carries `omni_rollout` through client stream chunks.
  - Adds `image_config`, `chat_template_kwargs`, and `n` fields to chat requests.
  - Emits generated images as OpenAI-style `image_url` objects in non-streaming and streaming chat responses.

## Validation

All evidence was produced on a single local H100 80GB with project-local environments only.

### M1 Understanding

- Weight loading: zero missing, unexpected, mismatched, or error keys.
- MoT generation parameters loaded: `551`.
- Logits parity vs official HF path: cosine `0.999992847442627`, max abs diff `0.0`.
- Greedy VQA decode: 20/20 prompts token-exact vs HF.
- Throughput: SGLang-Omni fallback `17.954721 tokens/s`; HF reference `18.056931 tokens/s`.

### M2 Hybrid Attention

- Dense mask unit cases passed.
- Hybrid attention parity vs official HF eager attention:
  - mask max abs diff `0.0`
  - attention output max abs diff `0.0`
  - attention weights max abs diff `0.0`
- Interleaved two-image greedy prompts: 3/3 token-exact.

### M3 Flow Matching

- T2I image parity vs HF:
  - pixel max abs diff `0`
  - PSNR `Infinity`
  - SSIM `1.0`
- IT2I image parity vs HF:
  - pixel max abs diff `0`
  - PSNR `Infinity`
  - SSIM `1.0`
- Scheduler parameters were logged and matched the U1 config, including `timestep_shift=1.0`, `time_schedule="standard"`, `time_shift_type="exponential"`, `base_shift=0.5`, `max_shift=1.15`, `noise_scale_mode="resolution"`, `P_mean=-0.8`, `P_std=0.8`, and `t_eps=0.05`.

### M4 Interleaved Generation

- 10/10 interleaved prompts passed.
- Text exact match vs HF: 10/10.
- Token exact match vs HF: 10/10.
- Each prompt generated one real PNG image.
- Image parity for every generated image:
  - pixel max abs diff `0`
  - PSNR `Infinity`
  - SSIM `1.0`
- OpenAI-style service probe returned HTTP 200 and emitted `delta.images[0].image_url.url`.
- Sequential batch throughput:
  - `0.0522067608 images/s`
  - `10.2377457853 tokens/s`
  - peak CUDA allocated/reserved `33.9568457603 / 34.5703125 GiB`

### M5 Unit / Regression Tests

Focused SenseNova U1 and image-output tests:

```bash
python -m pytest \
  tests/unit_test/sensenova_u1 \
  tests/unit_test/serve/test_openai_api.py::test_chat_request_passes_image_generation_controls \
  tests/unit_test/serve/test_openai_api.py::test_chat_completion_non_stream_returns_inline_images \
  tests/unit_test/serve/test_openai_api.py::test_chat_completion_stream_returns_inline_image_delta \
  -q
```

Result: `9 passed, 1 warning`.

OpenAI API regression file:

```bash
python -m pytest tests/unit_test/serve/test_openai_api.py -q
```

Result after providing FFmpeg shared libraries for `torchcodec`: `94 passed, 1 warning`.

## Known Limitations

- This is an HF-compatible in-engine fallback. It validates model behavior, image pixels, interleaved generation semantics, and OpenAI-compatible service shape, but it does not yet claim a native fused FlashInfer/RadixAttention U1 kernel.
- The hybrid attention implementation in this PR is a dense Python reference/helper. A production fused backend for the U1 image-span row policy remains future work.
- Flow-matching generation runs inside a single terminal stage with `max_concurrency=1` in the validated configuration. It does not yet implement cooperative per-flow-step interleaving with the native autoregressive scheduler.
- Throughput is correctness-oriented rather than optimized; the measured M4 batch wall throughput was `0.0522067608 images/s`.
