### PR TITLE
[ASR][W-PR3] Establish profiler coverage for Whisper ASR

### DIFF
--- a/benchmarks/eval/benchmark_asr_seedtts.py
+++ b/benchmarks/eval/benchmark_asr_seedtts.py
@@ -46,6 +46,8 @@ Usage:
         --port 8000 --model-path FunAudioLLM/Fun-ASR-Nano-2512-hf \
         --concurrencies 32 --repeats 3 --warmup --stream
 
+    # Use whisper-base for a low-cost profiling smoke. Replace both model
+    # values below with openai/whisper-large-v3 for the canonical checkpoint.
     # Start the same Whisper checkpoint named by the benchmark request:
     sgl-omni serve \
         --model-path openai/whisper-base \

--- a/benchmarks/eval/benchmark_asr_seedtts.py
+++ b/benchmarks/eval/benchmark_asr_seedtts.py
@@ -6,7 +6,7 @@
 
 This script transcribes SeedTTS reference clips directly through a running ASR
 router and reports WER, request throughput, RTFx, RTF, latency, and worker
-routing balance. It supports both Qwen3-ASR and Fun-ASR-Nano through
+routing balance. It supports Qwen3-ASR, Fun-ASR-Nano, and Whisper ASR through
 ``--model-path``.
 
 Usage:
@@ -45,6 +45,20 @@ Usage:
     python -m benchmarks.eval.benchmark_asr_seedtts \
         --port 8000 --model-path FunAudioLLM/Fun-ASR-Nano-2512-hf \
         --concurrencies 32 --repeats 3 --warmup --stream
+
+    # Start the same Whisper checkpoint named by the benchmark request:
+    sgl-omni serve \
+        --model-path openai/whisper-base \
+        --model-name openai/whisper-base \
+        --port 8000
+
+    # In another shell, capture a separate request-event profile pass:
+    python -m benchmarks.eval.benchmark_asr_seedtts \
+        --port 8000 --model-path openai/whisper-base \
+        --max-samples 20 --concurrencies 1,2,4,8 \
+        --repeats 3 --warmup --profile-events \
+        --profile-event-dir /tmp/whisper_asr_profile \
+        --fingerprint --output whisper_profile.json
 
 Reference results on the full SeedTTS EN set (1088 clips, bf16, single RTX
 4080 SUPER 32 GB, DP=1, three repeats plus one discarded warmup per level):
@@ -104,6 +118,7 @@ from benchmarks.eval.asr_profiling import (
 from benchmarks.runtime_metrics import ResourceMonitor, collect_benchmark_provenance
 from benchmarks.tasks.asr import (
     FUN_ASR_MODEL_PATH,
+    OMNI_WHISPER_MODEL_PATH,
     QWEN3_ASR_MODEL_PATH,
     build_asr_eval_results,
     run_asr_transcription,
@@ -493,7 +508,8 @@ def parse_args() -> argparse.Namespace:
         help=(
             "ASR model id served by the router. Defaults to "
             f"{QWEN3_ASR_MODEL_PATH}; use "
-            f"{FUN_ASR_MODEL_PATH} for Fun-ASR-Nano."
+            f"{FUN_ASR_MODEL_PATH} for Fun-ASR-Nano or "
+            f"{OMNI_WHISPER_MODEL_PATH} for Whisper ASR."
         ),
     )
     parser.add_argument(

--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -110,6 +110,79 @@ does not include `language`; the translation target is English in both APIs.
 See the [audio translation support matrix](../basic_usage/audio_translations.md)
 for response formats and other ASR models.
 
+## Request-event profiling
+
+The shared SeedTTS benchmark can run one additional request-event-profiled pass
+after the normal measured repeats at each concurrency. This example uses
+`openai/whisper-base` to keep development profiling inexpensive; it is not a
+production model recommendation. Start the same checkpoint named by the
+benchmark request:
+
+```bash
+sgl-omni serve \
+  --model-path openai/whisper-base \
+  --model-name openai/whisper-base \
+  --port 8000
+```
+
+In another shell, run:
+
+```bash
+python -m benchmarks.eval.benchmark_asr_seedtts \
+  --port 8000 \
+  --model-path openai/whisper-base \
+  --max-samples 20 \
+  --concurrencies 1,2,4,8 \
+  --repeats 3 --warmup \
+  --profile-events \
+  --profile-event-dir /tmp/whisper_asr_profile \
+  --fingerprint \
+  --save-raw-dir /tmp/whisper_asr_raw \
+  --output /tmp/whisper_profile.json
+```
+
+The profiled pass is stored under each result's `profile` field and is not
+included in normal latency, throughput, or WER aggregates. Its JSONL writes
+add overhead, so use normal repeats for performance numbers and the profile
+pass for attribution.
+
+For Whisper, the main intervals are:
+
+| Interval | Meaning |
+|---|---|
+| `scheduler_request_build_start->scheduler_request_build_end` | Server-side request builder: audio decode/resample, feature extraction, and request-object construction |
+| `scheduler_request_build_end->scheduler_queue_enter` | Build-result collection and admission handoff |
+| `scheduler_queue_enter->scheduler_prefill_start` | Queue/admission delay |
+| `scheduler_prefill_start->scheduler_prefill_end` | Whisper encoder plus decoder prefill/first forward |
+| `scheduler_prefill_end->stage_complete` | Autoregressive decode plus result adaptation and stage-completion handling |
+| `stage_input_received->stage_complete` | Server-side ASR stage lifetime; not client HTTP end-to-end latency |
+
+The first-forward interval is not an encoder-only measurement. Whisper runs
+its encoder inside the batched first model forward.
+
+The benchmark process must be able to read the server-side event directory.
+The simplest setup runs the server and benchmark on the same host or container.
+For a router or data-parallel deployment, pass every direct worker profiling
+endpoint with `--profile-urls`; profiling only the router does not reach all
+worker-local recorders. This solves only the control plane. For automatic
+profile attachment, every worker must write to storage visible to the benchmark
+process during the run, preferably the same `event_dir` path on every host.
+Without shared storage, collect all worker JSONL afterward and render an offline
+report. That offline report does not repair the benchmark result JSON already
+written by `run_profiled_pass(...)`; its original `profile` field may be partial.
+
+Render any generated run directory again with:
+
+```bash
+python -m sglang_omni.profiler \
+  /tmp/whisper_asr_profile/<run-id> --format table
+```
+
+> **GPU baseline pending.** Before this PR leaves Draft, run the documented
+> 20-sample c1/c2/c4/c8 profile on one fixed GPU type and record the commit,
+> image digest, model and dataset revisions, WER, normal performance metrics,
+> and key interval counts here.
+
 ## Request Parameters
 
 | Parameter | Type | Default | Description |

--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -115,8 +115,10 @@ for response formats and other ASR models.
 The shared SeedTTS benchmark can run one additional request-event-profiled pass
 after the normal measured repeats at each concurrency. This example uses
 `openai/whisper-base` to keep development profiling inexpensive; it is not a
-production model recommendation. Start the same checkpoint named by the
-benchmark request:
+production model recommendation. Stop any server already using port 8000, then
+start the same checkpoint named by the benchmark request. To profile the
+canonical checkpoint used earlier on this page, replace every
+`openai/whisper-base` below with `openai/whisper-large-v3` in both shells:
 
 ```bash
 sgl-omni serve \

--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -178,11 +178,6 @@ python -m sglang_omni.profiler \
   /tmp/whisper_asr_profile/<run-id> --format table
 ```
 
-> **GPU baseline pending.** Before this PR leaves Draft, run the documented
-> 20-sample c1/c2/c4/c8 profile on one fixed GPU type and record the commit,
-> image digest, model and dataset revisions, WER, normal performance metrics,
-> and key interval counts here.
-
 ## Request Parameters
 
 | Parameter | Type | Default | Description |

--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -89,6 +89,7 @@ resp.raise_for_status()
 print(resp.json()["text"])
 ```
 
+<<<<<<< HEAD
 ## Translate Audio
 
 Whisper multilingual checkpoints can translate source speech to English via
@@ -109,76 +110,6 @@ For this endpoint, `language` is an optional source-language hint and a
 does not include `language`; the translation target is English in both APIs.
 See the [audio translation support matrix](../basic_usage/audio_translations.md)
 for response formats and other ASR models.
-
-## Request-event profiling
-
-The shared SeedTTS benchmark can run one additional request-event-profiled pass
-after the normal measured repeats at each concurrency. This example uses
-`openai/whisper-base` to keep development profiling inexpensive; it is not a
-production model recommendation. Stop any server already using port 8000, then
-start the same checkpoint named by the benchmark request. To profile the
-canonical checkpoint used earlier on this page, replace every
-`openai/whisper-base` below with `openai/whisper-large-v3` in both shells:
-
-```bash
-sgl-omni serve \
-  --model-path openai/whisper-base \
-  --model-name openai/whisper-base \
-  --port 8000
-```
-
-In another shell, run:
-
-```bash
-python -m benchmarks.eval.benchmark_asr_seedtts \
-  --port 8000 \
-  --model-path openai/whisper-base \
-  --max-samples 20 \
-  --concurrencies 1,2,4,8 \
-  --repeats 3 --warmup \
-  --profile-events \
-  --profile-event-dir /tmp/whisper_asr_profile \
-  --fingerprint \
-  --save-raw-dir /tmp/whisper_asr_raw \
-  --output /tmp/whisper_profile.json
-```
-
-The profiled pass is stored under each result's `profile` field and is not
-included in normal latency, throughput, or WER aggregates. Its JSONL writes
-add overhead, so use normal repeats for performance numbers and the profile
-pass for attribution.
-
-For Whisper, the main intervals are:
-
-| Interval | Meaning |
-|---|---|
-| `scheduler_request_build_start->scheduler_request_build_end` | Server-side request builder: audio decode/resample, feature extraction, and request-object construction |
-| `scheduler_request_build_end->scheduler_queue_enter` | Build-result collection and admission handoff |
-| `scheduler_queue_enter->scheduler_prefill_start` | Queue/admission delay |
-| `scheduler_prefill_start->scheduler_prefill_end` | Whisper encoder plus decoder prefill/first forward |
-| `scheduler_prefill_end->stage_complete` | Autoregressive decode plus result adaptation and stage-completion handling |
-| `stage_input_received->stage_complete` | Server-side ASR stage lifetime; not client HTTP end-to-end latency |
-
-The first-forward interval is not an encoder-only measurement. Whisper runs
-its encoder inside the batched first model forward.
-
-The benchmark process must be able to read the server-side event directory.
-The simplest setup runs the server and benchmark on the same host or container.
-For a router or data-parallel deployment, pass every direct worker profiling
-endpoint with `--profile-urls`; profiling only the router does not reach all
-worker-local recorders. This solves only the control plane. For automatic
-profile attachment, every worker must write to storage visible to the benchmark
-process during the run, preferably the same `event_dir` path on every host.
-Without shared storage, collect all worker JSONL afterward and render an offline
-report. That offline report does not repair the benchmark result JSON already
-written by `run_profiled_pass(...)`; its original `profile` field may be partial.
-
-Render any generated run directory again with:
-
-```bash
-python -m sglang_omni.profiler \
-  /tmp/whisper_asr_profile/<run-id> --format table
-```
 
 ## Request Parameters
 

--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -10,6 +10,76 @@ Install `sglang-omni` by following [Installation](../get_started/installation.md
 hf download openai/whisper-large-v3
 ```
 
+## Request-event profiling
+
+The shared SeedTTS benchmark can run one additional request-event-profiled pass
+after the normal measured repeats at each concurrency. This example uses
+`openai/whisper-base` to keep development profiling inexpensive; it is not a
+production model recommendation. Stop any server already using port 8000, then
+start the same checkpoint named by the benchmark request. To profile the
+canonical checkpoint used elsewhere on this page, replace every
+`openai/whisper-base` below with `openai/whisper-large-v3` in both shells:
+
+```bash
+sgl-omni serve \
+  --model-path openai/whisper-base \
+  --model-name openai/whisper-base \
+  --port 8000
+```
+
+In another shell, run:
+
+```bash
+python -m benchmarks.eval.benchmark_asr_seedtts \
+  --port 8000 \
+  --model-path openai/whisper-base \
+  --max-samples 20 \
+  --concurrencies 1,2,4,8 \
+  --repeats 3 --warmup \
+  --profile-events \
+  --profile-event-dir /tmp/whisper_asr_profile \
+  --fingerprint \
+  --save-raw-dir /tmp/whisper_asr_raw \
+  --output /tmp/whisper_profile.json
+```
+
+The profiled pass is stored under each result's `profile` field and is not
+included in normal latency, throughput, or WER aggregates. Its JSONL writes
+add overhead, so use normal repeats for performance numbers and the profile
+pass for attribution.
+
+For Whisper, the main intervals are:
+
+| Interval | Meaning |
+|---|---|
+| `scheduler_request_build_start->scheduler_request_build_end` | Server-side request builder: audio decode/resample, feature extraction, and request-object construction |
+| `scheduler_request_build_end->scheduler_queue_enter` | Build-result collection and admission handoff |
+| `scheduler_queue_enter->scheduler_prefill_start` | Queue/admission delay |
+| `scheduler_prefill_start->scheduler_prefill_end` | Whisper encoder plus decoder prefill/first forward |
+| `scheduler_prefill_end->stage_complete` | Autoregressive decode plus result adaptation and stage-completion handling |
+| `stage_input_received->stage_complete` | Server-side ASR stage lifetime; not client HTTP end-to-end latency |
+
+The first-forward interval is not an encoder-only measurement. Whisper runs
+its encoder inside the batched first model forward.
+
+The benchmark process must be able to read the server-side event directory.
+The simplest setup runs the server and benchmark on the same host or container.
+For a router or data-parallel deployment, pass every direct worker profiling
+endpoint with `--profile-urls`; profiling only the router does not reach all
+worker-local recorders. This solves only the control plane. For automatic
+profile attachment, every worker must write to storage visible to the benchmark
+process during the run, preferably the same `event_dir` path on every host.
+Without shared storage, collect all worker JSONL afterward and render an offline
+report. That offline report does not repair the benchmark result JSON already
+written by `run_profiled_pass(...)`; its original `profile` field may be partial.
+
+Render any generated run directory again with:
+
+```bash
+python -m sglang_omni.profiler \
+  /tmp/whisper_asr_profile/<run-id> --format table
+```
+
 ## Server Configuration
 
 Whisper ASR runs a single ASR stage on one GPU.
@@ -89,7 +159,6 @@ resp.raise_for_status()
 print(resp.json()["text"])
 ```
 
-<<<<<<< HEAD
 ## Translate Audio
 
 Whisper multilingual checkpoints can translate source speech to English via

--- a/tests/unit_test/benchmarks/test_asr_profiling.py
+++ b/tests/unit_test/benchmarks/test_asr_profiling.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import sys
 import time
 from types import SimpleNamespace
 
@@ -23,6 +24,7 @@ from benchmarks.eval.asr_profiling import (
     stop_request_profile,
 )
 from benchmarks.eval.benchmark_asr_seedtts import _aggregate, _print_table
+from benchmarks.tasks.asr import OMNI_WHISPER_MODEL_PATH
 
 
 class _FakeResponse:
@@ -34,6 +36,20 @@ class _FakeResponse:
 
     def json(self) -> dict:
         return self._payload
+
+
+def test_seedtts_help_advertises_whisper_model(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["benchmark_asr_seedtts", "--help"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        seedtts_benchmark.parse_args()
+
+    assert exc_info.value.code == 0
+    help_text = "".join(capsys.readouterr().out.split())
+    assert OMNI_WHISPER_MODEL_PATH in help_text
 
 
 def test_profile_control_posts_run_id_and_event_dir(


### PR DESCRIPTION
## Motivation

Whisper already uses the shared SeedTTS ASR benchmark, but its request-event
profiling workflow was not discoverable from the benchmark CLI or the Whisper
cookbook.

This PR establishes W-PR3 coverage without changing the profiler, scheduler,
or Whisper runtime path.

## Modifications

- Advertise the canonical Whisper model in the shared ASR benchmark `--help`.
- Add paired Whisper server and profiling benchmark examples.
- Document profile-pass separation, interval semantics, and shared-storage
  requirements.
- Add a focused regression test for the public CLI help.

## Related Issues

Part of #1396: [W-PR3 assignment](https://github.com/sgl-project/sglang-omni/issues/1396#issuecomment-5262102997).

Related shared profiling lifecycle: #1430.

## Accuracy Test

Not applicable to model execution. This PR changes benchmark documentation,
CLI help, and test coverage only. It does not modify Whisper inference or
accuracy computation.

Focused CPU validation:

- Post-review focused suite: `22 passed, 19 warnings`
- `compileall` passed
- `git diff --check` passed
- pre-commit passed on all three changed files

## Benchmark & Profiling

A real request-event collection smoke was run using:

- GPU: NVIDIA L40S
- Model: `openai/whisper-base`
- Revision: `e37978b90ca9030d5170a5c07aadb050351a65bb`

| Collection check | Result |
| --- | --- |
| Profiled requests | 2 completed, 0 failed |
| Raw event files / events | 2 / 24 (`asr`: 20, `coordinator`: 4) |
| Stage interval rows | 6 |
| Hop interval rows | 0 (expected for a single terminal stage) |
| Offline report rebuilt from JSONL matches the saved report | Yes, byte-identical |

Both requests returned:

> How many cars are there in the picture?

This is collection evidence only. The first request includes compilation and
CUDA Graph capture overhead, so no throughput or latency improvement is
claimed.

The GPU smoke was not repeated after the later test-import and documentation
changes because they did not alter the benchmark command, profiling lifecycle,
or serving path.

## Checklist

- [x] Format code with pre-commit.
- [x] Add focused unit coverage.
- [x] Update documentation and examples.
- [x] Verify real Whisper request-event collection.
- [x] Verify offline report reconstruction.
- [x] Keep the tracked diff limited to the three intended files.

## CI

CI runs on self-hosted runners and requires a maintainer to add the `run-ci`
label. Whisper currently has no dedicated CI selector, so this PR relies on the
focused tests and collection smoke above unless a maintainer requests an
additional selector run.
