### PR TITLE
[Fix] Gate CLI quantization by pipeline capability

### DIFF
--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -622,6 +622,8 @@ def apply_backbone_server_args_cli_overrides(
         quantization = quantization.strip()
         if not quantization:
             raise typer.BadParameter("--quantization must not be empty")
+        if not type(pipeline_config).supports_quantization_override:
+            _raise_unsupported_flag(pipeline_config, "--quantization")
         backbone_updates["quantization"] = quantization
     if backbone_updates:
         _apply_stage_server_args_override(

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -289,6 +289,7 @@ class PipelineConfig(BaseModel):
     architecture: ClassVar[str | None] = None
     architecture_aliases: ClassVar[tuple[str, ...]] = ()
     requires_model_capabilities: ClassVar[bool] = False
+    supports_quantization_override: ClassVar[bool] = False
     tensor_parallel_disable_custom_all_reduce_stages: ClassVar[tuple[str, ...]] = ()
     required_speech_reference_count: ClassVar[int | None] = None
     speech_reference_text_required: ClassVar[bool] = False

--- a/sglang_omni/models/dots_tts/config.py
+++ b/sglang_omni/models/dots_tts/config.py
@@ -14,6 +14,7 @@ class DotsTTSPipelineConfig(PipelineConfig):
     """preprocess -> reference encode -> SGLang latent AR -> AudioVAE."""
 
     architecture: ClassVar[str] = "DotsTTSForConditionalGeneration"
+    supports_quantization_override: ClassVar[bool] = True
     requires_model_capabilities: ClassVar[bool] = True
     required_speech_reference_count: ClassVar[int | None] = 1
     speech_reference_text_required: ClassVar[bool] = True

--- a/sglang_omni/models/fun_asr/config.py
+++ b/sglang_omni/models/fun_asr/config.py
@@ -12,6 +12,7 @@ _PKG = "sglang_omni.models.fun_asr"
 class FunASRPipelineConfig(PipelineConfig):
 
     architecture: ClassVar[str] = "FunAsrNanoForConditionalGeneration"
+    supports_quantization_override: ClassVar[bool] = True
     architecture_aliases: ClassVar[tuple[str, ...]] = (
         "FunASRNano",
         "FunASRForConditionalGeneration",

--- a/sglang_omni/models/higgs_tts/config.py
+++ b/sglang_omni/models/higgs_tts/config.py
@@ -27,6 +27,7 @@ class HiggsTtsPipelineConfig(PipelineConfig):
     """
 
     architecture: ClassVar[str] = "HiggsMultimodalQwen3ForConditionalGeneration"
+    supports_quantization_override: ClassVar[bool] = True
     requires_model_capabilities: ClassVar[bool] = True
 
     @classmethod

--- a/sglang_omni/models/ming_omni/config.py
+++ b/sglang_omni/models/ming_omni/config.py
@@ -227,6 +227,7 @@ def _ming_streaming_speech_stages() -> list[StageConfig]:
 class _MingOmniBasePipelineConfig(PipelineConfig):
     architecture: ClassVar[str] = "BailingMM2NativeForConditionalGeneration"
     architecture_aliases: ClassVar[tuple[str, ...]] = ("BailingMoeV2ForCausalLM",)
+    supports_quantization_override: ClassVar[bool] = True
     tensor_parallel_disable_custom_all_reduce_stages: ClassVar[tuple[str, ...]] = (
         THINKER_STAGE,
     )

--- a/sglang_omni/models/ming_tts/config.py
+++ b/sglang_omni/models/ming_tts/config.py
@@ -24,6 +24,7 @@ class MingTTSPipelineConfig(PipelineConfig):
     """
 
     architecture: ClassVar[str] = "BailingMMNativeForConditionalGeneration"
+    supports_quantization_override: ClassVar[bool] = True
     requires_model_capabilities: ClassVar[bool] = True
 
     @classmethod

--- a/sglang_omni/models/moss_transcribe_diarize/config.py
+++ b/sglang_omni/models/moss_transcribe_diarize/config.py
@@ -22,6 +22,7 @@ class MossTranscribeDiarizePipelineConfig(PipelineConfig):
     """Single-stage batched ASR/diarization pipeline for MOSS-TD checkpoints."""
 
     architecture: ClassVar[str] = "MossTranscribeDiarizeForConditionalGeneration"
+    supports_quantization_override: ClassVar[bool] = True
 
     @classmethod
     def mem_fraction_role_to_stage(cls) -> dict[str, str]:

--- a/sglang_omni/models/moss_tts/config.py
+++ b/sglang_omni/models/moss_tts/config.py
@@ -16,6 +16,7 @@ class MossTTSPipelineConfig(PipelineConfig):
     """MOSS-TTS Delay pipeline: preprocessing -> AR engine -> vocoder."""
 
     architecture: ClassVar[str] = "MossTTSDelayModel"
+    supports_quantization_override: ClassVar[bool] = True
     requires_model_capabilities: ClassVar[bool] = True
     architecture_aliases: ClassVar[tuple[str, ...]] = (
         "MossTTSDelay",

--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -100,6 +100,7 @@ class MossTTSLocalPipelineConfig(PipelineConfig):
     """Single-GPU MOSS-TTS Local pipeline."""
 
     architecture: ClassVar[str] = "MossTTSLocalModel"
+    supports_quantization_override: ClassVar[bool] = True
     requires_model_capabilities: ClassVar[bool] = True
     architecture_aliases: ClassVar[tuple[str, ...]] = (
         "MossTTSLocal",

--- a/sglang_omni/models/qwen3_asr/config.py
+++ b/sglang_omni/models/qwen3_asr/config.py
@@ -15,6 +15,7 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
     """Single-stage batched ASR pipeline for Qwen3-ASR checkpoints."""
 
     architecture: ClassVar[str] = "Qwen3ASRForConditionalGeneration"
+    supports_quantization_override: ClassVar[bool] = True
     audio_chunking: ClassVar[AudioChunkingConfig] = AudioChunkingConfig(
         allow_audio_chunking=True,
         max_audio_clip_s=60.0,

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -284,6 +284,7 @@ _SPEECH_DEFAULT_PROCESSES = {
 
 class _Qwen3OmniBasePipelineConfig(PipelineConfig):
     architecture: ClassVar[str] = "Qwen3OmniMoeForConditionalGeneration"
+    supports_quantization_override: ClassVar[bool] = True
     tensor_parallel_disable_custom_all_reduce_stages: ClassVar[tuple[str, ...]] = (
         THINKER_STAGE,
     )

--- a/sglang_omni/models/whisper_asr/config.py
+++ b/sglang_omni/models/whisper_asr/config.py
@@ -14,6 +14,7 @@ class WhisperASRPipelineConfig(PipelineConfig):
     """Single-stage batched ASR pipeline for Whisper checkpoints."""
 
     architecture: ClassVar[str] = "WhisperForConditionalGeneration"
+    supports_quantization_override: ClassVar[bool] = True
 
     @classmethod
     def mem_fraction_role_to_stage(cls) -> dict[str, str]:

--- a/sglang_omni/models/zonos2/config.py
+++ b/sglang_omni/models/zonos2/config.py
@@ -90,6 +90,7 @@ class Zonos2PipelineConfig(PipelineConfig):
     """Single-GPU colocated default."""
 
     architecture: ClassVar[str] = "Zonos2ForCausalLM"
+    supports_quantization_override: ClassVar[bool] = True
     architecture_aliases: ClassVar[tuple[str, ...]] = (
         "Zonos2",
         "Zonos2Model",

--- a/tests/unit_test/serve/test_generation_server_args.py
+++ b/tests/unit_test/serve/test_generation_server_args.py
@@ -15,9 +15,14 @@ from sglang_omni.cli.serve import (
     serve,
 )
 from sglang_omni.config import PipelineConfig, StageConfig
+from sglang_omni.models.dots_tts.config import DotsTTSPipelineConfig
 from sglang_omni.models.fishaudio_s2_pro.config import S2ProPipelineConfig
 from sglang_omni.models.fun_asr.config import FunASRPipelineConfig
 from sglang_omni.models.higgs_tts.config import HiggsTtsPipelineConfig
+from sglang_omni.models.ming_tts.config import MingTTSPipelineConfig
+from sglang_omni.models.moss_transcribe_diarize.config import (
+    MossTranscribeDiarizePipelineConfig,
+)
 from sglang_omni.models.moss_tts.config import MossTTSPipelineConfig
 from sglang_omni.models.moss_tts_local.config import MossTTSLocalPipelineConfig
 from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
@@ -25,6 +30,7 @@ from sglang_omni.models.qwen3_omni.config import Qwen3OmniSpeechPipelineConfig
 from sglang_omni.models.qwen3_tts.config import Qwen3TTSPipelineConfig
 from sglang_omni.models.voxtral_tts.config import VoxtralTTSPipelineConfig
 from sglang_omni.models.whisper_asr.config import WhisperASRPipelineConfig
+from sglang_omni.models.zonos2.config import Zonos2PipelineConfig
 
 TEST_MAX_TOTAL_TOKENS = 82000
 
@@ -316,8 +322,26 @@ def test_generation_server_args_declared_stage_must_exist() -> None:
         _apply_generation_server_args(config)
 
 
-def test_quantization_routes_to_generation_stage_without_thinker() -> None:
-    config = HiggsTtsPipelineConfig(model_path="dummy")
+@pytest.mark.parametrize(
+    ("config_cls", "stage_name"),
+    [
+        (DotsTTSPipelineConfig, "latent_engine"),
+        (HiggsTtsPipelineConfig, "tts_engine"),
+        (MingTTSPipelineConfig, "tts_engine"),
+        (MossTTSPipelineConfig, "tts_engine"),
+        (MossTTSLocalPipelineConfig, "tts_engine"),
+        (Zonos2PipelineConfig, "tts_engine"),
+        (FunASRPipelineConfig, "asr"),
+        (MossTranscribeDiarizePipelineConfig, "asr"),
+        (Qwen3ASRPipelineConfig, "asr"),
+        (WhisperASRPipelineConfig, "asr"),
+    ],
+)
+def test_quantization_routes_only_for_declared_generation_stages(
+    config_cls: type[PipelineConfig],
+    stage_name: str,
+) -> None:
+    config = config_cls(model_path="dummy")
 
     apply_backbone_server_args_cli_overrides(
         config,
@@ -325,7 +349,7 @@ def test_quantization_routes_to_generation_stage_without_thinker() -> None:
         quantization="fp8",
     )
 
-    overrides = _stage_args(config, "tts_engine")["server_args_overrides"]
+    overrides = _stage_args(config, stage_name)["server_args_overrides"]
     assert overrides == {"quantization": "fp8"}
 
 
@@ -390,3 +414,34 @@ def test_quantization_rejects_pipeline_without_thinker_or_generation() -> None:
             cpu_offload_gb=None,
             quantization="fp8",
         )
+
+
+@pytest.mark.parametrize(
+    "config_cls",
+    [Qwen3TTSPipelineConfig, S2ProPipelineConfig, VoxtralTTSPipelineConfig],
+)
+def test_quantization_rejects_generation_stage_without_quantization_support(
+    config_cls: type[PipelineConfig],
+) -> None:
+    config = config_cls(model_path="dummy")
+
+    with pytest.raises(typer.BadParameter, match="--quantization is not supported"):
+        apply_backbone_server_args_cli_overrides(
+            config,
+            cpu_offload_gb=None,
+            quantization="fp8",
+        )
+
+
+def test_cpu_offload_still_routes_without_quantization_support() -> None:
+    config = Qwen3TTSPipelineConfig(model_path="dummy")
+
+    apply_backbone_server_args_cli_overrides(
+        config,
+        cpu_offload_gb=4,
+        quantization=None,
+    )
+
+    assert _stage_args(config, "tts_engine")["server_args_overrides"] == {
+        "cpu_offload_gb": 4
+    }


### PR DESCRIPTION
## Summary

- require pipeline configs to explicitly opt into `--quantization`
- reject Qwen3-TTS, Fish S2-Pro, and Voxtral-TTS instead of recording a no-op FP8 override
- keep `--cpu-offload-gb` routed through the existing generation-stage contract
- preserve FP8 routing for pipelines whose model layers consume `quant_config`

## Root cause

PR #1312 used `generation_sglang_role_to_stage()` as the quantization capability check. That role only identifies the stage used by shared generation tuning flags; it does not prove that the stage's model forwards SGLang's `quant_config` into its weight layers.

Qwen3-TTS and Voxtral-TTS discard `quant_config`, while Fish S2-Pro never forwards it into its decoder layers. The CLI therefore accepted `--quantization fp8` and benchmark provenance recorded FP8 even though those model weights remained unquantized.

## Validation

- reproduced the regression first: 3 failures for Qwen3-TTS, Fish S2-Pro, and Voxtral-TTS
- `74 passed` for generation-server-args and Ming-Omni CLI tests
- `737 passed` for the full serve suite plus affected model pipeline tests
- all pre-commit hooks passed

Validation ran on `hyper01-omni` in the `sglang-omni-hayden-dots-tts` container.

Follow-up to #1312.
