### PR TITLE
[Fix] transcription: skip no-speech chunks instead of hallucinating text

### DIFF
--- a/sglang_omni/serve/transcription_chunking.py
+++ b/sglang_omni/serve/transcription_chunking.py
@@ -21,6 +21,10 @@ logger = logging.getLogger(__name__)
 
 TARGET_SAMPLE_RATE = 16000
 
+# Note (Jiaxin Deng): peak amplitude below -60 dBFS means a chunk holds no
+# speech at all; decoding one anyway free-runs into repeated hallucinated text.
+SILENT_CHUNK_PEAK_THRESHOLD = 1e-3
+
 # Half-open [start, end) sample range of one chunk.
 Span = tuple[int, int]
 
@@ -142,6 +146,7 @@ class ChunkSpan:
     end_sample: int
     start_s: float
     end_s: float
+    has_speech: bool = True
 
     @property
     def duration_s(self) -> float:
@@ -229,6 +234,9 @@ def plan_audio_chunks(
                 end_sample=end,
                 start_s=start / sample_rate,
                 end_s=end / sample_rate,
+                has_speech=bool(
+                    np.max(np.abs(waveform[start:end])) >= SILENT_CHUNK_PEAK_THRESHOLD
+                ),
             )
             for index, (start, end) in enumerate(spans)
         ],

--- a/sglang_omni/serve/transcriptions.py
+++ b/sglang_omni/serve/transcriptions.py
@@ -290,6 +290,8 @@ async def _transcribe_audio_chunks(
     in_flight: set[str] = set()
 
     async def run_chunk(span: ChunkSpan) -> str:
+        if not span.has_speech:
+            return ""
         async with semaphore:
             # Encode inside the semaphore so at most max_concurrent chunk
             # WAVs exist at a time.

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -1518,6 +1518,36 @@ def test_long_audio_is_transcribed_chunk_by_chunk() -> None:
     assert response.json()["usage"] == {"seconds": 3, "type": "duration"}
 
 
+def test_noise_floor_chunks_are_skipped_not_transcribed() -> None:
+    # A TTS-runaway-shaped upload: loud speech then a ~-70 dBFS noise floor.
+    # Floor-only chunks hallucinate when decoded, so they must never be sent.
+    import numpy as np
+
+    from sglang_omni.serve.transcription_chunking import encode_wav
+
+    rng = np.random.default_rng(0)
+    loud = rng.uniform(-0.5, 0.5, 8000).astype(np.float32)
+    floor = rng.uniform(-3e-4, 3e-4, 32000).astype(np.float32)
+    upload = encode_wav(np.concatenate([loud, floor]), 16000)
+
+    transcription_client = ChunkRecordingTranscriptionClient()
+    client = _chunking_test_client(transcription_client)
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={"model": "asr"},
+        files={"file": ("runaway.wav", upload, "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    # Only the chunk holding speech reached the engine; the floor-only
+    # chunks were answered locally with empty text.
+    assert len(transcription_client.requests) == 1
+    assert response.json()["text"] == "part0"
+    # usage still reports the whole upload, skipped chunks included.
+    assert response.json()["usage"] == {"seconds": 3, "type": "duration"}
+
+
 def test_streamed_long_audio_is_rejected_explicitly() -> None:
     # Streaming cannot chunk; without this 400 a too-long upload would run
     # as a single request and truncate (observed live: 243s audio came back

--- a/tests/unit_test/serve/test_transcription_chunking.py
+++ b/tests/unit_test/serve/test_transcription_chunking.py
@@ -377,6 +377,31 @@ def test_plan_spans_cover_the_whole_upload() -> None:
     assert plan.spans[-1].end_s == pytest.approx(plan.duration_s)
 
 
+def test_plan_marks_noise_floor_chunks_as_speechless() -> None:
+    # A TTS-runaway-shaped clip: a short sentence, then a long ~-70 dBFS
+    # noise floor whose chunks must never reach the engine (they hallucinate).
+    rng = np.random.default_rng(0)
+    speech = _speech(_SAMPLE_RATE // 2)
+    noise_floor = rng.uniform(-3e-4, 3e-4, 2 * _SAMPLE_RATE).astype(np.float32)
+    plan = _plan(np.concatenate([speech, noise_floor]))
+
+    assert plan is not None
+    assert plan.spans[0].has_speech is True
+    # The speech ends at 0.5s and every cut lands past 0.75s, so all later
+    # spans hold nothing but the noise floor.
+    for span in plan.spans[1:]:
+        assert span.has_speech is False
+
+
+def test_plan_keeps_quiet_speech() -> None:
+    # -40 dBFS: very quiet but real speech, far above the skip threshold.
+    plan = _plan(_speech(40_000) * 0.01)
+
+    assert plan is not None
+    for span in plan.spans:
+        assert span.has_speech is True
+
+
 def test_encoded_chunk_round_trips_sample_for_sample() -> None:
     # The core correctness claim of planning: the bytes handed to the engine
     # are exactly the slice of audio the span describes.


### PR DESCRIPTION
# [Fix] transcription: skip no-speech chunks instead of hallucinating text

## Motivation

Since #1347 the TTS CI (higgs) fails intermittently, about 40% of runs on 2026-08-12:

```
FAILED tests/test_ci/test_tts_mps_dp2.py::test_tts_mps_non_streaming
AssertionError: Corpus WER 0.0255 (2.55%) > threshold 0.0136 (1%)
```

Root cause chain, all steps reproduced live on one H200:

1. Higgs TTS has a pre-existing, intermittent runaway on a few SeedTTS EN samples: generation never emits EOS, hits the 2048-token cap, and the WAV comes out 81.64s long (a short sentence, then ~75s of about -70 dBFS vocoder noise floor). Visible in CI results since at least 2026-08-04, e.g. sample `common_voice_en_23589975` at 81.64s in older runs too.
2. Before #1347 the WER transcriber sent that clip as one request (under the ~115s cap) and Qwen3-ASR returned the sentence plus at most a few inserted words: the runaway cost ~0.3 WER on that one sample and the corpus gate passed.
3. After #1347 the clip is split at the 60s default. The tail chunk holds only noise floor, and the WER harness forces `language=en`. A forced-language decode of no-speech audio has no acoustic anchor and free-runs: it returns "I'm not sure." repeated 47 times. That single sample then carries ~185 insertions, lifting corpus WER from ~0.95% to ~2.55%, over the 1.36% gate.

Measured on the same real runaway WAV (fished from a live higgs run, sample `common_voice_en_23589975`, 81.64s):

| transcription path | language | result |
|---|---|---|
| single request (pre-#1347 behaviour) | en | clean, no hallucination |
| chunked at 60s (current main) | en | "I'm not sure." x47 |
| chunked at 60s (current main) | none | clean |
| tail chunk alone (58s-81.6s, noise floor only) | en | pure "I'm not sure." loop |
| chunked at 60s, this PR | en | clean, tail chunk skipped |

## Modifications

* `plan_audio_chunks` marks each span `has_speech` from its peak amplitude; below -60 dBFS (1e-3) a chunk holds no speech. The real runaway noise floor peaks at -71 dBFS; even whispered speech is far above -60.
* `_transcribe_audio_chunks` answers no-speech chunks with empty text locally instead of sending an engine request. `join_transcript_parts` and `build_verbose_response_from_chunks` already handle empty chunk texts, so the response shape is unchanged.

Not in scope: the higgs runaway itself (pre-existing model behaviour, tracked separately) and single-request uploads of pure silence (unchanged behaviour, also present before #1347).

## Evidence

* Unit: `test_plan_marks_noise_floor_chunks_as_speechless`, `test_plan_keeps_quiet_speech`, `test_noise_floor_chunks_are_skipped_not_transcribed` (fails before the fix with 6 engine requests, passes after with 1). Full `test_transcription_chunking.py` + `test_openai_api.py`: 163 passed.
* Live H200: table above; after the fix the chunked transcript of the runaway WAV with `language=en` matches the pre-#1347 single-request transcript.

## Checklist

- [x] Format your commit message following the conventions.
- [x] Add unit tests.
