### PR TITLE
[Perf][ASR] Cache the audio front-end constant tables across requests

### DIFF
--- a/sglang_omni/models/fun_asr/configuration_fun_asr.py
+++ b/sglang_omni/models/fun_asr/configuration_fun_asr.py
@@ -254,9 +254,8 @@ def _fbank_with_cached_banks(
 ) -> torch.Tensor:
     """``kaldi.fbank`` for Fun-ASR's fixed options, with the mel table cached.
 
-    Note (Jiaxin Deng): bit-identity with ``kaldi.fbank`` under these options
-    is asserted in tests; options Fun-ASR never varies are inlined so the
-    cached table can be keyed by the few that do.
+    Note (Jiaxin Deng): the options Fun-ASR never varies are inlined so the
+    table can be keyed by the few that do; bit-identity is asserted in tests.
     """
     import torchaudio.compliance.kaldi as kaldi
 

--- a/sglang_omni/models/fun_asr/configuration_fun_asr.py
+++ b/sglang_omni/models/fun_asr/configuration_fun_asr.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
+import functools
+
 import numpy as np
 import torch
 from sglang.srt.multimodal.customized_mm_processor_utils import (
@@ -90,8 +92,6 @@ class FunAsrNanoFeatureExtractor(SequenceFeatureExtractor):
         (hamming window, energy_floor=0, dither=0, snip_edges=True).
         Returns ``(fbank, T_mel)`` where ``fbank`` is ``[T_mel, n_mels]``.
         """
-        import torchaudio.compliance.kaldi as kaldi
-
         wav = np.asarray(waveform, dtype=np.float32)
         if wav.ndim != 1:
             wav = wav.reshape(-1)
@@ -101,16 +101,13 @@ class FunAsrNanoFeatureExtractor(SequenceFeatureExtractor):
         wav_t = torch.from_numpy(wav).unsqueeze(0) * (1 << 15)
         # Cap frame_length for very short audio (funasr WavFrontend does this).
         frame_length = min(self.frame_length, wav.shape[0] / self.sampling_rate * 1000)
-        mat = kaldi.fbank(
+        mat = _fbank_with_cached_banks(
             wav_t,
             num_mel_bins=self.n_mels,
             frame_length=frame_length,
             frame_shift=self.frame_shift,
-            dither=0.0,
-            energy_floor=0.0,
             window_type=self.window,
             sample_frequency=self.sampling_rate,
-            snip_edges=True,
         )  # [T_mel, n_mels]
         return mat, mat.shape[0]
 
@@ -215,6 +212,83 @@ class FunAsrNanoFeatureExtractor(SequenceFeatureExtractor):
 # ---------------------------------------------------------------------------
 # Processor — feature extractor + tokenizer + placeholder expansion.
 # ---------------------------------------------------------------------------
+
+
+@functools.lru_cache(maxsize=16)
+def _cached_mel_banks(
+    num_mel_bins: int,
+    padded_window_size: int,
+    sample_frequency: float,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Mel filterbank padded to the rfft bin count, cached across requests.
+
+    Note (Jiaxin Deng): torchaudio rebuilds this table inside every
+    ``kaldi.fbank`` call; under load it is about a fifth of this process's CPU.
+    """
+    import torchaudio.compliance.kaldi as kaldi
+
+    banks, _ = kaldi.get_mel_banks(
+        num_mel_bins,
+        padded_window_size,
+        sample_frequency,
+        20.0,
+        0.0,
+        100.0,
+        -500.0,
+        1.0,
+    )
+    banks = banks.to(device=device, dtype=dtype)
+    return torch.nn.functional.pad(banks, (0, 1), mode="constant", value=0)
+
+
+def _fbank_with_cached_banks(
+    waveform: torch.Tensor,
+    *,
+    num_mel_bins: int,
+    frame_length: float,
+    frame_shift: float,
+    window_type: str,
+    sample_frequency: float,
+) -> torch.Tensor:
+    """``kaldi.fbank`` for Fun-ASR's fixed options, with the mel table cached.
+
+    Note (Jiaxin Deng): bit-identity with ``kaldi.fbank`` under these options
+    is asserted in tests; options Fun-ASR never varies are inlined so the
+    cached table can be keyed by the few that do.
+    """
+    import torchaudio.compliance.kaldi as kaldi
+
+    device, dtype = waveform.device, waveform.dtype
+    (
+        wav,
+        window_shift,
+        window_size,
+        padded_window_size,
+    ) = kaldi._get_waveform_and_window_properties(
+        waveform, 0, sample_frequency, frame_shift, frame_length, True, 0.97
+    )
+    strided_input, _ = kaldi._get_window(
+        wav,
+        padded_window_size,
+        window_size,
+        window_shift,
+        window_type,
+        0.42,
+        True,
+        True,
+        0.0,
+        0.0,
+        True,
+        0.97,
+    )
+    spectrum = torch.fft.rfft(strided_input).abs().pow(2.0)
+    banks = _cached_mel_banks(
+        num_mel_bins, padded_window_size, sample_frequency, device, dtype
+    )
+    mel_energies = torch.mm(spectrum, banks.T)
+    return torch.max(mel_energies, kaldi._get_epsilon(device, dtype)).log()
 
 
 class FunAsrNanoProcessor:

--- a/sglang_omni/models/fun_asr/configuration_fun_asr.py
+++ b/sglang_omni/models/fun_asr/configuration_fun_asr.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, ClassVar
-
 import functools
+from typing import Any, ClassVar
 
 import numpy as np
 import torch
@@ -19,6 +18,8 @@ from transformers import (
     PretrainedConfig,
 )
 from transformers.feature_extraction_sequence_utils import SequenceFeatureExtractor
+
+from sglang_omni.utils.audio_features import cached_fbank
 
 from .tool_funcs.audio_lengths import fun_asr_low_frame_rate_length
 
@@ -101,7 +102,7 @@ class FunAsrNanoFeatureExtractor(SequenceFeatureExtractor):
         wav_t = torch.from_numpy(wav).unsqueeze(0) * (1 << 15)
         # Cap frame_length for very short audio (funasr WavFrontend does this).
         frame_length = min(self.frame_length, wav.shape[0] / self.sampling_rate * 1000)
-        mat = _fbank_with_cached_banks(
+        mat = cached_fbank(
             wav_t,
             num_mel_bins=self.n_mels,
             frame_length=frame_length,
@@ -212,82 +213,6 @@ class FunAsrNanoFeatureExtractor(SequenceFeatureExtractor):
 # ---------------------------------------------------------------------------
 # Processor — feature extractor + tokenizer + placeholder expansion.
 # ---------------------------------------------------------------------------
-
-
-@functools.lru_cache(maxsize=16)
-def _cached_mel_banks(
-    num_mel_bins: int,
-    padded_window_size: int,
-    sample_frequency: float,
-    device: torch.device,
-    dtype: torch.dtype,
-) -> torch.Tensor:
-    """Mel filterbank padded to the rfft bin count, cached across requests.
-
-    Note (Jiaxin Deng): torchaudio rebuilds this table inside every
-    ``kaldi.fbank`` call; under load it is about a fifth of this process's CPU.
-    """
-    import torchaudio.compliance.kaldi as kaldi
-
-    banks, _ = kaldi.get_mel_banks(
-        num_mel_bins,
-        padded_window_size,
-        sample_frequency,
-        20.0,
-        0.0,
-        100.0,
-        -500.0,
-        1.0,
-    )
-    banks = banks.to(device=device, dtype=dtype)
-    return torch.nn.functional.pad(banks, (0, 1), mode="constant", value=0)
-
-
-def _fbank_with_cached_banks(
-    waveform: torch.Tensor,
-    *,
-    num_mel_bins: int,
-    frame_length: float,
-    frame_shift: float,
-    window_type: str,
-    sample_frequency: float,
-) -> torch.Tensor:
-    """``kaldi.fbank`` for Fun-ASR's fixed options, with the mel table cached.
-
-    Note (Jiaxin Deng): the options Fun-ASR never varies are inlined so the
-    table can be keyed by the few that do; bit-identity is asserted in tests.
-    """
-    import torchaudio.compliance.kaldi as kaldi
-
-    device, dtype = waveform.device, waveform.dtype
-    (
-        wav,
-        window_shift,
-        window_size,
-        padded_window_size,
-    ) = kaldi._get_waveform_and_window_properties(
-        waveform, 0, sample_frequency, frame_shift, frame_length, True, 0.97
-    )
-    strided_input, _ = kaldi._get_window(
-        wav,
-        padded_window_size,
-        window_size,
-        window_shift,
-        window_type,
-        0.42,
-        True,
-        True,
-        0.0,
-        0.0,
-        True,
-        0.97,
-    )
-    spectrum = torch.fft.rfft(strided_input).abs().pow(2.0)
-    banks = _cached_mel_banks(
-        num_mel_bins, padded_window_size, sample_frequency, device, dtype
-    )
-    mel_energies = torch.mm(spectrum, banks.T)
-    return torch.max(mel_energies, kaldi._get_epsilon(device, dtype)).log()
 
 
 class FunAsrNanoProcessor:

--- a/sglang_omni/models/fun_asr/configuration_fun_asr.py
+++ b/sglang_omni/models/fun_asr/configuration_fun_asr.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import functools
 from typing import Any, ClassVar
 
 import numpy as np

--- a/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
+++ b/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
@@ -22,8 +22,9 @@ from typing import Any, Iterable, Optional, Tuple
 import torch
 import torch.nn as nn
 import torchaudio
-import torchaudio.compliance.kaldi as kaldi
 from transformers import Qwen2Config, Qwen2Model, StaticCache
+
+from sglang_omni.utils.audio_features import cached_fbank
 
 from .configuration_bailing_talker import MingOmniTalkerConfig
 from .front.number_en import normalize_numbers
@@ -71,7 +72,7 @@ class SpkembExtractor:
         self.target_sr = target_sr
 
     def _extract_spk_embedding(self, speech):
-        feat = kaldi.fbank(speech, num_mel_bins=80, dither=0, sample_frequency=16000)
+        feat = cached_fbank(speech, num_mel_bins=80, sample_frequency=16000)
         feat = feat - feat.mean(dim=0, keepdim=True)
         embedding = (
             self.campplus_session.run(

--- a/sglang_omni/models/ming_tts/reference_encode.py
+++ b/sglang_omni/models/ming_tts/reference_encode.py
@@ -9,7 +9,6 @@ from typing import Any
 import onnxruntime
 import torch
 import torchaudio
-import torchaudio.compliance.kaldi as kaldi
 import torchaudio.functional as F
 
 from sglang_omni.models.ming_tts.audio_config import AudioVAEconfig
@@ -27,6 +26,7 @@ from sglang_omni.scheduling.reference_encoder import (
     KeyedReferenceEncodeHook,
     ReferenceEncodeService,
 )
+from sglang_omni.utils.audio_features import cached_fbank
 
 
 class MingSpeakerEmbeddingExtractor:
@@ -48,10 +48,9 @@ class MingSpeakerEmbeddingExtractor:
     def __call__(self, waveform: Any) -> Any:
         if not isinstance(waveform, torch.Tensor):
             waveform = torch.as_tensor(waveform)
-        feat = kaldi.fbank(
+        feat = cached_fbank(
             waveform,
             num_mel_bins=80,
-            dither=0,
             sample_frequency=self.target_sr,
         )
         feat = feat - feat.mean(dim=0, keepdim=True)

--- a/sglang_omni/utils/audio.py
+++ b/sglang_omni/utils/audio.py
@@ -134,7 +134,7 @@ def _resample_kernel(
     device: torch.device,
     dtype: torch.dtype,
 ) -> tuple[torch.Tensor, int]:
-    # Note: (Jiaxin Deng) the sinc kernel depends only on the rate pair, the
+    # Note (Jiaxin Deng): the sinc kernel depends only on the rate pair, the
     # options and the tensor type; torchaudio rebuilds it per call, which
     # shows as ~15% of the ASR serving process under load.
     return torchaudio.functional.functional._get_sinc_resample_kernel(

--- a/sglang_omni/utils/audio.py
+++ b/sglang_omni/utils/audio.py
@@ -3,8 +3,8 @@
 
 from __future__ import annotations
 
-import io
 import functools
+import io
 import math
 import os
 from collections.abc import Mapping

--- a/sglang_omni/utils/audio.py
+++ b/sglang_omni/utils/audio.py
@@ -134,9 +134,8 @@ def _resample_kernel(
     device: torch.device,
     dtype: torch.dtype,
 ) -> tuple[torch.Tensor, int]:
-    # Note (Jiaxin Deng): the sinc kernel depends only on the rate pair, the
-    # options and the tensor type; torchaudio rebuilds it per call, which
-    # shows as ~15% of the ASR serving process under load.
+    # Note (Jiaxin Deng): torchaudio rebuilds this per call even though it
+    # depends only on the rate pair, the options and the tensor type.
     return torchaudio.functional.functional._get_sinc_resample_kernel(
         orig_freq,
         new_freq,

--- a/sglang_omni/utils/audio.py
+++ b/sglang_omni/utils/audio.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import io
+import functools
+import math
 import os
 from collections.abc import Mapping
 from typing import Any
@@ -114,13 +116,60 @@ def _try_fast_wav_decode(
     if sample_rate == target_sample_rate:
         return audio
 
-    resampled = torchaudio.functional.resample(
+    resampled = _cached_resample(
         torch.from_numpy(audio),
         sample_rate,
         target_sample_rate,
-        **dict(resample_kwargs or {}),
+        resample_kwargs,
     )
     return resampled.numpy()
+
+
+@functools.lru_cache(maxsize=32)
+def _resample_kernel(
+    orig_freq: int,
+    new_freq: int,
+    gcd: int,
+    kwargs_items: tuple[tuple[str, Any], ...],
+    device: torch.device,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, int]:
+    # Note: (Jiaxin Deng) the sinc kernel depends only on the rate pair, the
+    # options and the tensor type; torchaudio rebuilds it per call, which
+    # shows as ~15% of the ASR serving process under load.
+    return torchaudio.functional.functional._get_sinc_resample_kernel(
+        orig_freq,
+        new_freq,
+        gcd,
+        device=device,
+        dtype=dtype,
+        **dict(kwargs_items),
+    )
+
+
+def _cached_resample(
+    waveform: torch.Tensor,
+    orig_freq: int,
+    new_freq: int,
+    resample_kwargs: Mapping[str, Any] | None,
+) -> torch.Tensor:
+    kwargs = dict(resample_kwargs or {})
+    orig_freq, new_freq = int(orig_freq), int(new_freq)
+    try:
+        gcd = math.gcd(orig_freq, new_freq)
+        kernel, width = _resample_kernel(
+            orig_freq,
+            new_freq,
+            gcd,
+            tuple(sorted(kwargs.items())),
+            waveform.device,
+            waveform.dtype,
+        )
+        return torchaudio.functional.functional._apply_sinc_resample_kernel(
+            waveform, orig_freq, new_freq, gcd, kernel, width
+        )
+    except (AttributeError, TypeError, RuntimeError):
+        return torchaudio.functional.resample(waveform, orig_freq, new_freq, **kwargs)
 
 
 def decode_audio_data_uri(value: str) -> bytes | None:

--- a/sglang_omni/utils/audio_features.py
+++ b/sglang_omni/utils/audio_features.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Kaldi-compliant fbank with the constant tables cached across requests."""
+
+from __future__ import annotations
+
+import functools
+
+import torch
+
+
+@functools.lru_cache(maxsize=32)
+def _mel_banks(
+    num_mel_bins: int,
+    padded_window_size: int,
+    sample_frequency: float,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Mel filterbank padded to the rfft bin count.
+
+    Note (Jiaxin Deng): torchaudio rebuilds this table inside every
+    ``kaldi.fbank`` call; under load it is about a fifth of an ASR process.
+    """
+    import torchaudio.compliance.kaldi as kaldi
+
+    banks, _ = kaldi.get_mel_banks(
+        num_mel_bins,
+        padded_window_size,
+        sample_frequency,
+        20.0,
+        0.0,
+        100.0,
+        -500.0,
+        1.0,
+    )
+    banks = banks.to(device=device, dtype=dtype)
+    return torch.nn.functional.pad(banks, (0, 1), mode="constant", value=0)
+
+
+def cached_fbank(
+    waveform: torch.Tensor,
+    *,
+    num_mel_bins: int = 23,
+    frame_length: float = 25.0,
+    frame_shift: float = 10.0,
+    window_type: str = "povey",
+    sample_frequency: float = 16000.0,
+) -> torch.Tensor:
+    """``kaldi.fbank`` with a cached mel table, for callers that keep the
+    remaining options at their Kaldi defaults (no dither, no energy column,
+    snip_edges, log fbank over the power spectrum).
+
+    Note (Jiaxin Deng): the defaults every caller shares are inlined so the
+    table can be keyed by the few that vary; bit-identity is asserted in tests.
+    """
+    import torchaudio.compliance.kaldi as kaldi
+
+    device, dtype = waveform.device, waveform.dtype
+    (
+        wav,
+        window_shift,
+        window_size,
+        padded_window_size,
+    ) = kaldi._get_waveform_and_window_properties(
+        waveform, 0, sample_frequency, frame_shift, frame_length, True, 0.97
+    )
+    strided_input, _ = kaldi._get_window(
+        wav,
+        padded_window_size,
+        window_size,
+        window_shift,
+        window_type,
+        0.42,
+        True,
+        True,
+        0.0,
+        0.0,
+        True,
+        0.97,
+    )
+    spectrum = torch.fft.rfft(strided_input).abs().pow(2.0)
+    banks = _mel_banks(
+        num_mel_bins, padded_window_size, sample_frequency, device, dtype
+    )
+    return torch.max(
+        torch.mm(spectrum, banks.T), kaldi._get_epsilon(device, dtype)
+    ).log()

--- a/tests/unit_test/fun_asr/test_fbank_cache.py
+++ b/tests/unit_test/fun_asr/test_fbank_cache.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The cached-table fbank must stay bit-identical to torchaudio's kaldi.fbank."""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+kaldi = pytest.importorskip("torchaudio.compliance.kaldi")
+
+from sglang_omni.models.fun_asr.configuration_fun_asr import (
+    _cached_mel_banks,
+    _fbank_with_cached_banks,
+)
+
+N_MELS = 80
+FRAME_SHIFT = 10.0
+WINDOW = "hamming"
+
+
+def _reference(wav, frame_length, sample_rate):
+    return kaldi.fbank(
+        wav,
+        num_mel_bins=N_MELS,
+        frame_length=frame_length,
+        frame_shift=FRAME_SHIFT,
+        dither=0.0,
+        energy_floor=0.0,
+        window_type=WINDOW,
+        sample_frequency=sample_rate,
+        snip_edges=True,
+    )
+
+
+def _wav(seconds, sample_rate, seed=0):
+    rng = np.random.default_rng(seed)
+    samples = rng.standard_normal(int(seconds * sample_rate), dtype=np.float32)
+    return torch.from_numpy(samples).unsqueeze(0) * (1 << 15)
+
+
+@pytest.mark.parametrize("seconds", [0.3, 1.0, 5.0])
+@pytest.mark.parametrize("sample_rate", [16000, 8000])
+def test_matches_kaldi_fbank_bit_exactly(seconds, sample_rate):
+    wav = _wav(seconds, sample_rate)
+    frame_length = min(25.0, seconds * 1000)
+    expected = _reference(wav, frame_length, sample_rate)
+    got = _fbank_with_cached_banks(
+        wav,
+        num_mel_bins=N_MELS,
+        frame_length=frame_length,
+        frame_shift=FRAME_SHIFT,
+        window_type=WINDOW,
+        sample_frequency=sample_rate,
+    )
+    assert got.shape == expected.shape
+    assert torch.equal(got, expected)
+
+
+def test_short_audio_caps_frame_length_like_the_caller():
+    # The caller shortens frame_length for clips below one window.
+    sample_rate = 16000
+    seconds = 0.012
+    wav = _wav(seconds, sample_rate, seed=3)
+    frame_length = min(25.0, seconds * 1000)
+    expected = _reference(wav, frame_length, sample_rate)
+    got = _fbank_with_cached_banks(
+        wav,
+        num_mel_bins=N_MELS,
+        frame_length=frame_length,
+        frame_shift=FRAME_SHIFT,
+        window_type=WINDOW,
+        sample_frequency=sample_rate,
+    )
+    assert torch.equal(got, expected)
+
+
+def test_mel_table_is_reused_across_calls():
+    _cached_mel_banks.cache_clear()
+    for i in range(4):
+        _fbank_with_cached_banks(
+            _wav(1.0, 16000, seed=i),
+            num_mel_bins=N_MELS,
+            frame_length=25.0,
+            frame_shift=FRAME_SHIFT,
+            window_type=WINDOW,
+            sample_frequency=16000,
+        )
+    info = _cached_mel_banks.cache_info()
+    assert info.misses == 1
+    assert info.hits == 3

--- a/tests/unit_test/preprocessing/test_resample_cache.py
+++ b/tests/unit_test/preprocessing/test_resample_cache.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The cached resample path must stay bit-identical to torchaudio's."""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+torchaudio = pytest.importorskip("torchaudio")
+
+from sglang_omni.utils.audio import _cached_resample, _resample_kernel
+
+
+@pytest.mark.parametrize(
+    "orig,target",
+    [(8000, 16000), (44100, 16000), (22050, 16000), (48000, 16000), (16000, 24000)],
+)
+def test_matches_torchaudio_bit_exactly(orig, target):
+    rng = np.random.default_rng(0)
+    wav = torch.from_numpy(rng.standard_normal(orig, dtype=np.float32))
+    expected = torchaudio.functional.resample(wav, orig, target)
+    got = _cached_resample(wav, orig, target, None)
+    assert got.shape == expected.shape
+    assert torch.equal(got, expected)
+
+
+def test_kwargs_are_honoured_and_keyed():
+    rng = np.random.default_rng(1)
+    wav = torch.from_numpy(rng.standard_normal(16000, dtype=np.float32))
+    kwargs = {"lowpass_filter_width": 16}
+    expected = torchaudio.functional.resample(wav, 16000, 8000, **kwargs)
+    got = _cached_resample(wav, 16000, 8000, kwargs)
+    assert torch.equal(got, expected)
+    # A different option must not reuse the first kernel.
+    other = _cached_resample(wav, 16000, 8000, {"lowpass_filter_width": 64})
+    assert not torch.equal(got, other)
+
+
+def test_kernel_is_reused_across_calls():
+    _resample_kernel.cache_clear()
+    rng = np.random.default_rng(2)
+    wav = torch.from_numpy(rng.standard_normal(16000, dtype=np.float32))
+    for _ in range(5):
+        _cached_resample(wav, 44100, 16000, None)
+    info = _resample_kernel.cache_info()
+    assert info.misses == 1
+    assert info.hits == 4

--- a/tests/unit_test/utils/test_fbank_cache.py
+++ b/tests/unit_test/utils/test_fbank_cache.py
@@ -7,17 +7,14 @@ import pytest
 torch = pytest.importorskip("torch")
 kaldi = pytest.importorskip("torchaudio.compliance.kaldi")
 
-from sglang_omni.models.fun_asr.configuration_fun_asr import (
-    _cached_mel_banks,
-    _fbank_with_cached_banks,
-)
+from sglang_omni.utils.audio_features import _mel_banks, cached_fbank
 
 N_MELS = 80
 FRAME_SHIFT = 10.0
 WINDOW = "hamming"
 
 
-def _reference(wav, frame_length, sample_rate):
+def _reference(wav, frame_length, sample_rate, window=WINDOW):
     return kaldi.fbank(
         wav,
         num_mel_bins=N_MELS,
@@ -25,7 +22,7 @@ def _reference(wav, frame_length, sample_rate):
         frame_shift=FRAME_SHIFT,
         dither=0.0,
         energy_floor=0.0,
-        window_type=WINDOW,
+        window_type=window,
         sample_frequency=sample_rate,
         snip_edges=True,
     )
@@ -43,7 +40,7 @@ def test_matches_kaldi_fbank_bit_exactly(seconds, sample_rate):
     wav = _wav(seconds, sample_rate)
     frame_length = min(25.0, seconds * 1000)
     expected = _reference(wav, frame_length, sample_rate)
-    got = _fbank_with_cached_banks(
+    got = cached_fbank(
         wav,
         num_mel_bins=N_MELS,
         frame_length=frame_length,
@@ -62,7 +59,7 @@ def test_short_audio_caps_frame_length_like_the_caller():
     wav = _wav(seconds, sample_rate, seed=3)
     frame_length = min(25.0, seconds * 1000)
     expected = _reference(wav, frame_length, sample_rate)
-    got = _fbank_with_cached_banks(
+    got = cached_fbank(
         wav,
         num_mel_bins=N_MELS,
         frame_length=frame_length,
@@ -74,9 +71,9 @@ def test_short_audio_caps_frame_length_like_the_caller():
 
 
 def test_mel_table_is_reused_across_calls():
-    _cached_mel_banks.cache_clear()
+    _mel_banks.cache_clear()
     for i in range(4):
-        _fbank_with_cached_banks(
+        cached_fbank(
             _wav(1.0, 16000, seed=i),
             num_mel_bins=N_MELS,
             frame_length=25.0,
@@ -84,6 +81,22 @@ def test_mel_table_is_reused_across_calls():
             window_type=WINDOW,
             sample_frequency=16000,
         )
-    info = _cached_mel_banks.cache_info()
+    info = _mel_banks.cache_info()
     assert info.misses == 1
     assert info.hits == 3
+
+
+@pytest.mark.parametrize("window", ["hamming", "povey"])
+def test_matches_for_each_window_type(window):
+    # Fun-ASR uses hamming, the Ming speaker encoders use the kaldi default.
+    wav = _wav(1.0, 16000, seed=7)
+    expected = _reference(wav, 25.0, 16000, window=window)
+    got = cached_fbank(
+        wav,
+        num_mel_bins=N_MELS,
+        frame_length=25.0,
+        frame_shift=FRAME_SHIFT,
+        window_type=window,
+        sample_frequency=16000,
+    )
+    assert torch.equal(got, expected)


### PR DESCRIPTION
## Motivation

A py-spy profile of the Fun-ASR serving process under load attributes about a quarter of its non-idle samples to rebuilding constant tables: `get_mel_banks` 10.8%, `_get_window` 7.2%, `_get_sinc_resample_kernel` 7.3%, `inverse_mel_scale` 2.2%. torchaudio 2.11 does not memoise any of them, so every request recomputes the mel filterbank, the window and the sinc resampling kernel from scratch even though they depend only on configuration.

## Modifications

* `sglang_omni/utils/audio.py`: memoise the sinc resample kernel by rate pair, options, device and dtype, then apply it directly. Falls back to `torchaudio.functional.resample` if those internals move. This path is shared, so every model that decodes audio at a rate other than the target benefits.
* `sglang_omni/utils/audio_features.py`: a `cached_fbank` helper that keeps the mel filterbank across requests. Used by Fun-ASR's `_extract_fbank` and by the two Ming speaker encoders (`ming_omni` talker, `ming_tts` reference encode), which rebuilt the same table per request. Zonos2 already builds its table once through torchaudio's `MelSpectrogram` module and is untouched.

## Accuracy Test

Bit-identity against the stock implementations is asserted, not approximated, all with `torch.equal`: 5 rate pairs for the resample path; 3 durations x 2 sample rates, the short-clip frame-length cap, and both window types (hamming for Fun-ASR, the kaldi default for Ming) for fbank. Each cache also asserts that it is actually hit, which caught a first version that silently fell back on every call.

## Benchmark

Fun-ASR on 1x H200, one 16-physical-core lane, c32 closed loop on `/v1/audio/transcriptions` with 48 kHz input, 80 s measured per round, arms interleaved, 2 rounds each:

| build | QPS | mean | p95 |
| --- | ---: | ---: | ---: |
| base | 154.5 | 0.207 s | 0.227 s |
| resample kernel cached | 164.2 (+6.3%) | 0.195 s | 0.216 s |
| both tables cached | **181.0 (+17.2%)** | 0.176 s | 0.196 s |

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.


