### PR TITLE
[Feat] Add LLaDA2-Uni tensor parallel support

### DIFF
--- a/sglang_omni/models/llada2_uni/components/thinker.py
+++ b/sglang_omni/models/llada2_uni/components/thinker.py
@@ -13,7 +13,10 @@ from transformers import PretrainedConfig
 
 from sglang_omni.models.weight_loader import default_weight_loader
 from sglang_omni.vendor.sglang.core import ForwardBatch
-from sglang_omni.vendor.sglang.distributed import get_tensor_model_parallel_world_size
+from sglang_omni.vendor.sglang.distributed import (
+    get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_reduce,
+)
 from sglang_omni.vendor.sglang.layers import (
     AttentionType,
     MergedColumnParallelLinear,
@@ -27,6 +30,7 @@ from sglang_omni.vendor.sglang.layers import (
     VocabParallelEmbedding,
     get_moe_impl_class,
     get_rope,
+    should_skip_post_experts_all_reduce,
 )
 from sglang_omni.vendor.sglang.models import (
     apply_qk_norm,
@@ -34,6 +38,32 @@ from sglang_omni.vendor.sglang.models import (
     enable_fused_set_kv_buffer,
 )
 from sglang_omni.vendor.sglang.utils import make_layers
+
+
+def _get_local_attention_head_counts(
+    num_heads: int,
+    num_kv_heads: int,
+    tp_size: int,
+) -> tuple[int, int]:
+    if tp_size < 1:
+        raise ValueError(f"Tensor parallel size must be positive, got {tp_size}")
+    if num_heads % tp_size != 0:
+        raise ValueError(
+            f"Attention heads ({num_heads}) must be divisible by TP size ({tp_size})"
+        )
+    if num_kv_heads >= tp_size:
+        if num_kv_heads % tp_size != 0:
+            raise ValueError(
+                f"KV heads ({num_kv_heads}) must be divisible by TP size ({tp_size})"
+            )
+        local_kv_heads = num_kv_heads // tp_size
+    else:
+        if tp_size % num_kv_heads != 0:
+            raise ValueError(
+                f"TP size ({tp_size}) must be divisible by KV heads ({num_kv_heads})"
+            )
+        local_kv_heads = 1
+    return num_heads // tp_size, local_kv_heads
 
 
 class LLaDA2MoeAttention(nn.Module):
@@ -55,8 +85,13 @@ class LLaDA2MoeAttention(nn.Module):
         self.use_qk_norm = config.use_qk_norm
 
         tp_size = get_tensor_model_parallel_world_size()
-        self.num_heads_per_tp = self.num_heads // tp_size
-        self.num_kv_heads_per_tp = max(1, self.num_kv_heads // tp_size)
+        self.num_heads_per_tp, self.num_kv_heads_per_tp = (
+            _get_local_attention_head_counts(
+                self.num_heads,
+                self.num_kv_heads,
+                tp_size,
+            )
+        )
         self.q_size = self.num_heads_per_tp * self.head_dim
         self.kv_size = self.num_kv_heads_per_tp * self.head_dim
 
@@ -166,6 +201,7 @@ class LLaDA2MoeMLP(nn.Module):
         config: PretrainedConfig,
         intermediate_size: int,
         quant_config: Optional[QuantizationConfig] = None,
+        reduce_results: bool = True,
     ):
         super().__init__()
         self.gate_up_proj = MergedColumnParallelLinear(
@@ -178,6 +214,7 @@ class LLaDA2MoeMLP(nn.Module):
             intermediate_size,
             config.hidden_size,
             bias=False,
+            reduce_results=reduce_results,
             quant_config=quant_config,
         )
         self.act_fn = SiluAndMul()
@@ -231,6 +268,7 @@ class LLaDA2MoeSparseMoeBlock(nn.Module):
         super().__init__()
         self.config = config
         self.layer_id = layer_id
+        self.tp_size = get_tensor_model_parallel_world_size()
         self.num_experts = config.num_experts
         self.num_experts_per_tok = config.num_experts_per_tok
         self.n_group = config.n_group
@@ -269,7 +307,10 @@ class LLaDA2MoeSparseMoeBlock(nn.Module):
                 config.moe_intermediate_size * config.num_shared_experts
             )
             self.shared_experts = LLaDA2MoeMLP(
-                config, shared_intermediate, quant_config
+                config,
+                shared_intermediate,
+                quant_config,
+                reduce_results=False,
             )
         else:
             self.shared_experts = None
@@ -315,6 +356,11 @@ class LLaDA2MoeSparseMoeBlock(nn.Module):
         # Add shared expert output
         if self.shared_experts is not None:
             y = y + self.shared_experts(identity)
+
+        if self.tp_size > 1 and not should_skip_post_experts_all_reduce(
+            is_tp_path=True,
+        ):
+            y = tensor_model_parallel_all_reduce(y)
 
         return y
 

--- a/sglang_omni/models/llada2_uni/config.py
+++ b/sglang_omni/models/llada2_uni/config.py
@@ -17,14 +17,19 @@ DECODE_STAGE = "decode"
 DEFAULT_THINKER_MAX_NEW_TOKENS = 2048
 
 
-class LLaDA2UniPipelineConfig(PipelineConfig):
-    """4-stage DLLM pipeline: preprocessing → image_encoder → thinker → decode."""
-
+class _LLaDA2UniBasePipelineConfig(PipelineConfig):
     architecture: ClassVar[str] = "LLaDA2MoeModelLM"
+    tensor_parallel_disable_custom_all_reduce_stages: ClassVar[tuple[str, ...]] = (
+        THINKER_STAGE,
+    )
 
     @classmethod
     def mem_fraction_role_to_stage(cls) -> dict[str, str]:
         return {THINKER_STAGE: THINKER_STAGE}
+
+
+class LLaDA2UniPipelineConfig(_LLaDA2UniBasePipelineConfig):
+    """4-stage DLLM pipeline: preprocessing → image_encoder → thinker → decode."""
 
     model_path: str
     stages: list[StageConfig] = [
@@ -61,8 +66,38 @@ class LLaDA2UniPipelineConfig(PipelineConfig):
     ]
 
 
+class LLaDA2UniTextPipelineConfig(_LLaDA2UniBasePipelineConfig):
+    """3-stage text DLLM pipeline: preprocessing → thinker → decode."""
+
+    model_path: str
+    stages: list[StageConfig] = [
+        StageConfig(
+            name=PREPROCESSING_STAGE,
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_preprocessing_executor",
+            factory_args={"thinker_max_seq_len": 8192},
+            runtime_arg_map={"max_seq_len": "thinker_max_seq_len"},
+            next=THINKER_STAGE,
+        ),
+        StageConfig(
+            name=THINKER_STAGE,
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_sglang_dllm_thinker_executor_from_config",
+            factory_args={"thinker_max_seq_len": 8192},
+            gpu=0,
+            next=DECODE_STAGE,
+        ),
+        StageConfig(
+            name=DECODE_STAGE,
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_decode_executor",
+            terminal=True,
+        ),
+    ]
+
+
 EntryClass = LLaDA2UniPipelineConfig
 
 Variants = {
-    "text": LLaDA2UniPipelineConfig,
+    "text": LLaDA2UniTextPipelineConfig,
 }

--- a/sglang_omni/models/llada2_uni/stages.py
+++ b/sglang_omni/models/llada2_uni/stages.py
@@ -83,6 +83,9 @@ def create_sglang_dllm_thinker_executor_from_config(
     model_path: str,
     *,
     gpu_id: int = 0,
+    tp_rank: int = 0,
+    tp_size: int = 1,
+    nccl_port: int | None = None,
     thinker_max_seq_len: int = 8192,
     dllm_algorithm: str = "LowConfidence",
     dllm_algorithm_config: str | None = None,
@@ -98,6 +101,7 @@ def create_sglang_dllm_thinker_executor_from_config(
         "sampling_backend": "pytorch",
     }
     overrides.update(server_args_overrides or {})
+    overrides["tp_size"] = tp_size
 
     server_args = build_sglang_server_args(
         model_path,
@@ -112,7 +116,12 @@ def create_sglang_dllm_thinker_executor_from_config(
         server_args.dllm_algorithm,
         server_args.mem_fraction_static,
     )
-    return create_dllm_thinker_scheduler(server_args, gpu_id)
+    return create_dllm_thinker_scheduler(
+        server_args,
+        gpu_id,
+        tp_rank=tp_rank,
+        nccl_port=nccl_port,
+    )
 
 
 def create_decode_executor(model_path: str):

--- a/sglang_omni/scheduling/dllm_scheduler.py
+++ b/sglang_omni/scheduling/dllm_scheduler.py
@@ -48,6 +48,7 @@ class DllmScheduler:
     ):
         self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
         self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
+        self.requires_tp_work_fanout: bool = True
 
         self._request_builder = request_builder
         self._result_adapter = result_adapter

--- a/tests/unit_test/llada2_uni/test_config.py
+++ b/tests/unit_test/llada2_uni/test_config.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from sglang_omni.models.llada2_uni.config import (
+    DECODE_STAGE,
+    IMAGE_STAGE,
+    PREPROCESSING_STAGE,
+    THINKER_STAGE,
+    LLaDA2UniTextPipelineConfig,
+    Variants,
+)
+
+
+def test_text_variant_omits_image_encoder() -> None:
+    config = LLaDA2UniTextPipelineConfig(model_path="/models/llada2")
+    stages = {stage.name: stage for stage in config.stages}
+
+    assert Variants["text"] is LLaDA2UniTextPipelineConfig
+    assert IMAGE_STAGE not in stages
+    assert stages[PREPROCESSING_STAGE].next == THINKER_STAGE
+    assert stages[THINKER_STAGE].next == DECODE_STAGE
+    assert stages[DECODE_STAGE].terminal is True
+
+
+def test_text_variant_disables_custom_all_reduce_for_tp() -> None:
+    updates = LLaDA2UniTextPipelineConfig.tensor_parallel_server_args_overrides(
+        stage_name=THINKER_STAGE,
+        tp_size=2,
+    )
+
+    assert updates == {"disable_custom_all_reduce": True}

--- a/tests/unit_test/llada2_uni/test_stages.py
+++ b/tests/unit_test/llada2_uni/test_stages.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from sglang_omni.models.llada2_uni import stages
+
+
+def test_thinker_factory_forwards_tensor_parallel_runtime(
+    monkeypatch,
+) -> None:
+    captured = {}
+    server_args = SimpleNamespace(
+        dllm_algorithm="LowConfidence",
+        mem_fraction_static=0.6,
+    )
+
+    def fake_build_server_args(model_path, **kwargs):
+        captured["model_path"] = model_path
+        captured["server_args_kwargs"] = kwargs
+        return server_args
+
+    def fake_create_scheduler(value, gpu_id, **kwargs):
+        captured["server_args"] = value
+        captured["gpu_id"] = gpu_id
+        captured["scheduler_kwargs"] = kwargs
+        return "scheduler"
+
+    monkeypatch.setattr(
+        "sglang_omni.scheduling.sglang_backend.build_sglang_server_args",
+        fake_build_server_args,
+    )
+    monkeypatch.setattr(
+        "sglang_omni.models.llada2_uni.bootstrap.create_dllm_thinker_scheduler",
+        fake_create_scheduler,
+    )
+
+    result = stages.create_sglang_dllm_thinker_executor_from_config(
+        "/models/llada2",
+        gpu_id=0,
+        tp_rank=1,
+        tp_size=2,
+        nccl_port=23456,
+        server_args_overrides={"max_running_requests": 4},
+    )
+
+    assert result == "scheduler"
+    assert captured["model_path"] == "/models/llada2"
+    assert captured["server_args_kwargs"]["tp_size"] == 2
+    assert captured["server_args_kwargs"]["max_running_requests"] == 4
+    assert captured["server_args"] is server_args
+    assert captured["gpu_id"] == 0
+    assert captured["scheduler_kwargs"] == {
+        "tp_rank": 1,
+        "nccl_port": 23456,
+    }
+
+
+def test_dllm_scheduler_requires_tp_work_fanout() -> None:
+    from sglang_omni.scheduling.dllm_scheduler import DllmScheduler
+
+    scheduler = DllmScheduler(
+        tp_worker=object(),
+        tree_cache=object(),
+        req_to_token_pool=object(),
+        token_to_kv_pool_allocator=object(),
+        server_args=SimpleNamespace(
+            chunked_prefill_size=32,
+            max_running_requests=2,
+        ),
+        model_config=object(),
+        dllm_config=SimpleNamespace(
+            block_size=32,
+            max_running_requests=2,
+        ),
+        request_builder=lambda value: value,
+        result_adapter=lambda value: value,
+    )
+
+    assert scheduler.requires_tp_work_fanout is True

--- a/tests/unit_test/llada2_uni/test_thinker_tp.py
+++ b/tests/unit_test/llada2_uni/test_thinker_tp.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from types import MethodType
+
+import pytest
+import torch
+from torch import nn
+
+from sglang_omni.models.llada2_uni.components import thinker
+
+
+@pytest.mark.parametrize(
+    ("tp_size", "expected"),
+    [
+        (1, (16, 4)),
+        (2, (8, 2)),
+        (4, (4, 1)),
+        (8, (2, 1)),
+        (16, (1, 1)),
+    ],
+)
+def test_attention_head_partitioning(tp_size, expected) -> None:
+    assert thinker._get_local_attention_head_counts(16, 4, tp_size) == expected
+
+
+@pytest.mark.parametrize("tp_size", [0, 3, 6, 32])
+def test_attention_head_partitioning_rejects_invalid_tp_size(tp_size) -> None:
+    with pytest.raises(ValueError):
+        thinker._get_local_attention_head_counts(16, 4, tp_size)
+
+
+class _Gate(nn.Module):
+    expert_bias = None
+
+    def forward(self, hidden_states):
+        return torch.zeros(
+            hidden_states.shape[0],
+            2,
+            dtype=hidden_states.dtype,
+        )
+
+
+class _Experts(nn.Module):
+    def forward(self, hidden_states, topk_output):
+        return hidden_states + 1
+
+
+class _SharedExperts(nn.Module):
+    def forward(self, hidden_states):
+        return hidden_states + 2
+
+
+def test_sparse_moe_reduces_combined_routed_and_shared_output(
+    monkeypatch,
+) -> None:
+    block = object.__new__(thinker.LLaDA2MoeSparseMoeBlock)
+    nn.Module.__init__(block)
+    block.tp_size = 2
+    block.num_experts_per_tok = 1
+    block.routed_scaling_factor = 1.0
+    block.gate = _Gate()
+    block.experts = _Experts()
+    block.shared_experts = _SharedExperts()
+    block._group_limited_topk = MethodType(
+        lambda self, scores: (
+            torch.ones(scores.shape[0], 1),
+            torch.zeros(scores.shape[0], 1, dtype=torch.long),
+        ),
+        block,
+    )
+    reduced = []
+
+    monkeypatch.setattr(
+        thinker,
+        "should_skip_post_experts_all_reduce",
+        lambda **kwargs: False,
+    )
+    monkeypatch.setattr(
+        thinker,
+        "tensor_model_parallel_all_reduce",
+        lambda value: reduced.append(value.clone()) or value * 2,
+    )
+
+    output = block(torch.tensor([[3.0, 4.0]]))
+
+    assert len(reduced) == 1
+    assert torch.equal(reduced[0], torch.tensor([[9.0, 11.0]]))
+    assert torch.equal(output, torch.tensor([[18.0, 22.0]]))


### PR DESCRIPTION


## Motivation

Add tensor parallel (TP) support for the LLaDA2-Uni thinker stage in sglang-omni.

The LLaDA2-Uni thinker is a diffusion LLM with a 20-layer MoE backbone, 256 routed experts, and one shared expert. TP support is needed to run the model across multiple GPUs when a single GPU does not provide enough practical memory headroom.

## Modifications

- Added a text-only LLaDA2-Uni pipeline variant with preprocessing, thinker, and decode stages.
- Passed `tp_rank`, `tp_size`, and `nccl_port` from the pipeline stage factory into the LLaDA2 thinker scheduler.
- Enabled TP work fanout so the leader scheduler replicates request work to TP follower ranks.
- Disabled custom all-reduce for the thinker TP stage because the current multi-process topology exposes each rank as local `cuda:0`, which is incompatible with symmetric-memory custom all-reduce setup.
- Changed routed and shared MoE outputs to use one unified post-expert TP all-reduce.
- Added Q/KV attention-head partition validation for supported TP sizes and clear errors for invalid configurations.
- Added unit tests for pipeline configuration, TP runtime propagation, dLLM fanout requirements, attention-head partitioning, and MoE reduction semantics.

## Related Issues

Related #445

## Accuracy Test

The TP=1 and TP=2 smoke tests produced the same deterministic response for the same request and sampling settings.

Request prompt: `Hello`

Sampling: `temperature=0`, `max_tokens=16`

Model-side accuracy evaluation: not yet run on a task-level benchmark; this change is limited to TP execution and communication semantics.

## Benchmark & Profiling

Hardware: NVIDIA H200

Model dtype: BF16

Request: one text request with prompt length 17 and `max_tokens=15` or `16`

TP=1, same-NUMA GPU4, block size 32, 15 tokens: approximately `0.46 s` steady-state

TP=1, same-NUMA GPU4, block size 32, 16 tokens: approximately `1.20 s` steady-state

TP=2, same-NUMA GPUs 4 and 5, block size 32, 15 tokens: approximately `0.57-0.68 s`

TP=2, same-NUMA GPUs 4 and 5, block size 32, 16 tokens: approximately `1.74-1.77 s`

TP=2 reduced thinker weight memory from approximately `30.4 GB` on one GPU to approximately `15.2 GB` per GPU.

The single-request TP=2 path is slower than TP=1 because each diffusion forward contains many small tensor-parallel collectives. The primary validated benefit is reduced per-GPU memory usage.

The 15-to-16-token latency jump is caused by dLLM block scheduling: the 17-token prompt leaves 15 positions in the first 32-token generation block, so requesting 16 tokens starts a second block.

Profiling observed approximately 41 tensor-parallel all-reduces per full forward and approximately 46 diffusion rounds for the 16-token request.

## Checklist

- [x] Format code with pre-commit-compatible formatting checks.
- [x] Add unit tests.
- [x] Update documentation and developer reference notes.
- [x] Provide TP latency and memory measurements for the validated H200 smoke tests.
- [ ] Run a task-level accuracy benchmark for LLaDA2-Uni.
- [ ] Enable custom all-reduce after a topology-safe multi-process symmetric-memory setup is available.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the `run-ci` label. Once labeled, every subsequent push re-triggers CI as long as the label remains. Use `/tag-and-rerun-ci higgs` or `/tag-and-rerun-ci moss` to select a TTS CI model, and `/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR CI model. One selector from each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.