### PR TITLE
[Whisper] Enable long audio chunking for Whisper 

### DIFF
--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -95,6 +95,21 @@ the fields above. The route uses the ASR stage default unless the pipeline is
 configured another way. For smoke tests, keep the request minimal and use
 `response_format=json`.
 
+## Long Audio
+
+Whisper reads at most 30 seconds of audio in one request: the feature extractor works on a fixed 30-second mel window and drops everything past it.
+In SGLang-Omni, we transcribe longer uploads in chunks by splitting the audio at the quietest point near each 30-second boundary,
+running each chunk as its own engine request, and joining the transcripts back in order. The behavior follows these values, which Whisper
+declares in code (`WhisperASRPipelineConfig.audio_chunking`). They are fixed model defaults in this release:
+
+| Name | Value | Meaning                                                                                                                                                                     |
+|---|---|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `max_audio_clip_s` | `30` | Longest clip we send to the engine in one request, and therefore the chunk length. Unlike Qwen3-ASR this is not a scheduling choice: 30s is the hard edge of the model's mel window. |
+| `max_native_clip_s` | `30` | Same as the chunk length. Streaming cannot chunk, so `stream=true` takes audio up to 30s and gets HTTP 400 above that.                                                      |
+| `max_total_audio_s` | `3600` | Upper limit on the whole upload; you get HTTP 400 above it. This is a memory guard: we keep the decoded waveform in memory while its chunks run.                            |
+| `max_concurrent_chunks` | `8` | How many chunks of one request run in the engine at once. A per-request cap so one long upload can't crowd out everyone else's requests.                                    |
+| `min_tail_s` | `1` | Shortest final chunk worth transcribing; if the tail would be shorter, we move the previous cut earlier to absorb it, which keeps Whisper from hallucinating on very short clips.      |
+
 ## Benchmarking
 
 Use the shared SeedTTS benchmark for end-to-end concurrency, WER, latency, and throughput:

--- a/sglang_omni/models/whisper_asr/config.py
+++ b/sglang_omni/models/whisper_asr/config.py
@@ -5,15 +5,23 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from sglang_omni.config import PipelineConfig, StageConfig
+from sglang_omni.config import AudioChunkingConfig, PipelineConfig, StageConfig
 
 _PKG = "sglang_omni.models.whisper_asr"
+
+WHISPER_MAX_INPUT_SECONDS = 30
 
 
 class WhisperASRPipelineConfig(PipelineConfig):
     """Single-stage batched ASR pipeline for Whisper checkpoints."""
 
     architecture: ClassVar[str] = "WhisperForConditionalGeneration"
+    audio_chunking: ClassVar[AudioChunkingConfig] = AudioChunkingConfig(
+        allow_audio_chunking=True,
+        max_audio_clip_s=float(WHISPER_MAX_INPUT_SECONDS),
+        max_native_clip_s=float(WHISPER_MAX_INPUT_SECONDS),
+        min_tail_s=1.0,
+    )
 
     @classmethod
     def mem_fraction_role_to_stage(cls) -> dict[str, str]:

--- a/sglang_omni/models/whisper_asr/request_builders.py
+++ b/sglang_omni/models/whisper_asr/request_builders.py
@@ -18,11 +18,19 @@ from sglang.srt.managers.schedule_batch import (
 from sglang.srt.sampling.sampling_params import SamplingParams
 from transformers import GenerationConfig
 
+from sglang_omni.models.whisper_asr.config import WHISPER_MAX_INPUT_SECONDS
 from sglang_omni.preprocessing.transcription import prepare_audio
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 
 _WHISPER_SAMPLE_RATE = 16000
+
+_MAX_ENGINE_CLIP_S = float(WHISPER_MAX_INPUT_SECONDS)
+_MAX_ENGINE_CLIP_MESSAGE = (
+    f"Whisper ASR accepts audio up to {WHISPER_MAX_INPUT_SECONDS} seconds per "
+    "request (the model's mel window); send longer audio through "
+    "/v1/audio/transcriptions, which splits it into chunks"
+)
 # note (jiannan-17): Previous context = 1 start-of-prev token + up to 223 prompt tokens.
 MAX_PREV_CONTEXT_TOKENS = 224
 # note (jiannan-17): Standard Whisper decoder context is 448 positions.
@@ -132,7 +140,11 @@ def make_whisper_scheduler_adapters(
     def request_builder(payload: StagePayload) -> WhisperASRRequestData:
         params = payload.request.params or {}
         prepared = prepare_audio(
-            payload, source_name="Whisper ASR", target_sample_rate=_WHISPER_SAMPLE_RATE
+            payload,
+            source_name="Whisper ASR",
+            target_sample_rate=_WHISPER_SAMPLE_RATE,
+            max_duration_s=_MAX_ENGINE_CLIP_S,
+            max_duration_message=_MAX_ENGINE_CLIP_MESSAGE,
         )
         audio = prepared.waveform
         audio_duration_s = prepared.duration_s

--- a/tests/unit_test/serve/test_transcription_chunking.py
+++ b/tests/unit_test/serve/test_transcription_chunking.py
@@ -88,6 +88,20 @@ def test_qwen3_asr_pipeline_declares_chunking() -> None:
     assert declared.max_native_clip_s == 1200.0
 
 
+def test_whisper_asr_pipeline_declares_chunking() -> None:
+    from sglang_omni.models.whisper_asr.config import WhisperASRPipelineConfig
+
+    declared = WhisperASRPipelineConfig.audio_chunking
+    assert declared.allow_audio_chunking is True
+    # For Whisper the chunk length IS the native limit: the feature extractor
+    # truncates everything past its 30s mel window, so without chunking a
+    # longer upload silently loses all audio past the first 30 seconds.
+    assert declared.max_audio_clip_s == 30.0
+    assert declared.max_native_clip_s == 30.0
+    # Whisper hallucinates on very short clips; keep the tail at least 1s.
+    assert declared.min_tail_s == 1.0
+
+
 def test_disabled_config_never_chunks() -> None:
     config = AudioChunkingConfig(max_audio_clip_s=60.0)
 

--- a/tests/unit_test/whisper_asr/test_request_builders.py
+++ b/tests/unit_test/whisper_asr/test_request_builders.py
@@ -82,6 +82,34 @@ def _build(monkeypatch, params: dict | None = None):
     return _make_request_builder()(_make_payload(params))
 
 
+def test_request_builder_rejects_audio_past_the_mel_window(monkeypatch) -> None:
+    # Anything past the 30s window is rejected. Without the guard the feature
+    # extractor would silently drop everything past 30 seconds instead.
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(int(30.1 * 16000), dtype=np.float32),
+    )
+
+    with pytest.raises(ValueError, match="accepts audio up to"):
+        _make_request_builder()(_make_payload())
+
+
+def test_request_builder_accepts_a_full_window_chunk(monkeypatch) -> None:
+    # Exactly 30.0s must build: the serve-layer chunker cuts spans of up to
+    # exactly max_audio_clip_s samples, so the guard has to be a strict
+    # greater-than or every full-length chunk of a long upload would 400.
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(30 * 16000, dtype=np.float32),
+    )
+
+    data = _make_request_builder()(_make_payload())
+
+    assert data.audio_duration_s == pytest.approx(30.0)
+
+
 def test_request_builder_without_prompt_keeps_prefix_only(monkeypatch) -> None:
     data = _build(monkeypatch)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

as titled

## Modifications

Add chunking config in Whisper's config.py and add long audio guard in request builder. 
Also add unit test and update related doc.

## Related Issues

#1396 

## Accuracy Test

We don't have CI for long audio yet, so I had an agent run a smoke test. Method: take tests/data/query_to_cars.wav and concatenate it multiple times, inserting 0.6s of silence at each seam. Results: the original 4.6s audio is not chunked and transcribes normally; the concatenated 31.5s and 78.3s audio get split into two and three chunks respectively, and the transcripts come out correct.

## Benchmark & Profiling

N/A

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
