### PR TITLE
[Perf] transcription: soundfile fast path for the audio duration probe

### DIFF
--- a/sglang_omni/serve/speech_to_text.py
+++ b/sglang_omni/serve/speech_to_text.py
@@ -197,14 +197,47 @@ def resolve_speech_to_text_adapter(
     return resolve_adapter(architectures)
 
 
-def probe_audio_duration(audio_bytes: bytes) -> float:
-    """Best-effort audio duration (seconds) from raw upload bytes.
+# Codecs whose container header states the exact sample count, so
+# soundfile's frame count is arithmetic, not an estimate. Notably absent:
+# MPEG_LAYER_III, legal inside RIFF/WAVE, where libsndfile extrapolates
+# from early-frame bitrate and mismeasures VBR streams severalfold.
+_EXACT_LENGTH_SUBTYPES = frozenset(
+    {"PCM_S8", "PCM_U8", "PCM_16", "PCM_24", "PCM_32", "FLOAT", "DOUBLE"}
+)
 
-    Metadata-only: reads container headers, never decodes. PyAV wraps the
-    same FFmpeg demuxers load_audio decodes with, so any upload the engine
-    can read, this probe can measure (soundfile could not inspect M4A/WebM).
-    0.0 means unknown; callers treat that as "duration not available".
-    """
+# libsndfile reports this sentinel when the header omits the count, e.g. a
+# FLAC streamed with STREAMINFO total_samples 0.
+_UNKNOWN_LENGTH_FRAMES = 2**63 - 1
+
+
+def _looks_like_wav_or_flac(audio_bytes: bytes) -> bool:
+    # Cheap prefilter so only the two formats the fast path serves are ever
+    # handed to libsndfile; every other container goes straight to PyAV.
+    header = audio_bytes[:12]
+    if header[:4] in (b"RIFF", b"RF64") and header[8:12] == b"WAVE":
+        return True
+    return header[:4] == b"fLaC"
+
+
+def _soundfile_duration(audio_bytes: bytes) -> float:
+    if not _looks_like_wav_or_flac(audio_bytes):
+        return 0.0
+    try:
+        import soundfile as sf
+
+        info = sf.info(io.BytesIO(audio_bytes))
+        if (
+            info.samplerate
+            and info.subtype in _EXACT_LENGTH_SUBTYPES
+            and 0 < info.frames < _UNKNOWN_LENGTH_FRAMES
+        ):
+            return info.frames / float(info.samplerate)
+    except (RuntimeError, ValueError):
+        pass
+    return 0.0
+
+
+def _av_duration(audio_bytes: bytes) -> float:
     try:
         import av
 
@@ -219,6 +252,22 @@ def probe_audio_duration(audio_bytes: bytes) -> float:
     except Exception:
         logger.debug("Could not probe audio duration", exc_info=True)
     return 0.0
+
+
+def probe_audio_duration(audio_bytes: bytes) -> float:
+    """Best-effort audio duration (seconds) from raw upload bytes.
+
+    Metadata-only: reads container headers, never decodes. soundfile answers
+    WAV/FLAC in microseconds of CPU and only serves formats whose header
+    states the exact sample count; every other format (MP3, M4A, WebM, ...)
+    keeps the PyAV path, which wraps the same FFmpeg demuxers load_audio
+    decodes with, so their measurements are unchanged. 0.0 means unknown;
+    callers treat that as "duration not available".
+    """
+    duration_s = _soundfile_duration(audio_bytes)
+    if duration_s > 0:
+        return duration_s
+    return _av_duration(audio_bytes)
 
 
 def assemble_speech_to_text_response(

--- a/sglang_omni/serve/transcriptions.py
+++ b/sglang_omni/serve/transcriptions.py
@@ -120,6 +120,14 @@ def register_transcriptions(app: FastAPI) -> None:
             # Decode + split in a worker thread: decoding a long file is pure
             # CPU and would stall the event loop.
             plan = await asyncio.to_thread(plan_audio_chunks, audio_bytes, chunking)
+            if plan is not None:
+                try:
+                    # The probe admitted the decode on header metadata, which
+                    # can under-measure estimated containers; the plan knows
+                    # the decoded duration, so re-enforce the cap on truth.
+                    check_total_duration(plan.duration_s, chunking)
+                except ValueError as exc:
+                    raise HTTPException(status_code=400, detail=str(exc)) from exc
 
         if plan is None:
             gen_req = speech_to_text.build_speech_to_text_generate_request(

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -1754,6 +1754,28 @@ def test_upload_over_the_total_duration_limit_is_rejected() -> None:
     assert transcription_client.requests == []
 
 
+def test_total_duration_limit_is_re_enforced_on_the_decoded_audio(monkeypatch) -> None:
+    # A metadata probe can under-measure estimated containers; once the
+    # decode reveals the true duration the cap must still hold.
+    from sglang_omni.serve import transcriptions
+
+    monkeypatch.setattr(
+        transcriptions, "_probe_audio_duration", lambda audio_bytes: 1.5
+    )
+    transcription_client = ChunkRecordingTranscriptionClient()
+    client = _chunking_test_client(transcription_client, max_total_audio_s=2.0)
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={"model": "asr"},
+        files={"file": ("long.wav", _wav_upload(2.5), "audio/wav")},
+    )
+
+    assert response.status_code == 400
+    assert "accepts audio up to" in response.json()["detail"]
+    assert transcription_client.requests == []
+
+
 def test_long_audio_without_chunking_policy_stays_one_request() -> None:
     # No audio_chunking passed to create_app: models that have not declared a
     # policy keep today's single-request behaviour, byte for byte.

--- a/tests/unit_test/serve/test_speech_to_text.py
+++ b/tests/unit_test/serve/test_speech_to_text.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import io
 import json
+import wave
+from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
@@ -77,6 +80,84 @@ def test_assemble_uses_the_caller_probed_duration(monkeypatch) -> None:
     )
 
     assert json.loads(response.body)["usage"] == {"seconds": 3, "type": "duration"}
+
+
+def test_probe_measures_wav_without_the_av_fallback(monkeypatch) -> None:
+    monkeypatch.setattr(
+        speech_to_text,
+        "_av_duration",
+        lambda audio_bytes: pytest.fail("fell back to av for a wav upload"),
+    )
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as writer:
+        writer.setnchannels(1)
+        writer.setsampwidth(2)
+        writer.setframerate(16000)
+        writer.writeframes(b"\x00\x00" * 8000)
+
+    assert speech_to_text.probe_audio_duration(buffer.getvalue()) == pytest.approx(0.5)
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        pytest.param(
+            b"ID3\x04\x00\x00\x00\x00\x00\x00" + b"\xff\xfb\x90\x00" * 32, id="id3-mp3"
+        ),
+        pytest.param(b"\xff\xfb\x90\x00" * 64, id="bare-mp3-frames"),
+        pytest.param(b"\x1a\x45\xdf\xa3" + b"\x00" * 64, id="webm"),
+        pytest.param(b"\x00\x00\x00\x20ftypM4A " + b"\x00" * 64, id="m4a"),
+    ],
+)
+def test_probe_keeps_estimated_containers_on_av(monkeypatch, header) -> None:
+    import soundfile
+
+    monkeypatch.setattr(
+        soundfile,
+        "info",
+        lambda *args, **kwargs: pytest.fail(
+            "soundfile consulted for a container it can only estimate"
+        ),
+    )
+    monkeypatch.setattr(speech_to_text, "_av_duration", lambda audio_bytes: 86.0)
+
+    assert speech_to_text.probe_audio_duration(header) == 86.0
+
+
+def test_probe_falls_back_when_soundfile_cannot_measure(monkeypatch) -> None:
+    monkeypatch.setattr(speech_to_text, "_av_duration", lambda audio_bytes: 12.5)
+
+    assert speech_to_text.probe_audio_duration(b"fLaC" + b"\x00" * 64) == 12.5
+
+
+@pytest.mark.parametrize(
+    ("header", "info"),
+    [
+        pytest.param(
+            b"RIFF\x16\x2c\x0a\x00WAVEfmt ",
+            SimpleNamespace(
+                samplerate=44100, frames=1_471_236, subtype="MPEG_LAYER_III"
+            ),
+            id="mpeg-inside-wav",
+        ),
+        pytest.param(
+            b"fLaC" + b"\x00" * 64,
+            SimpleNamespace(samplerate=44100, frames=2**63 - 1, subtype="PCM_16"),
+            id="flac-unknown-length",
+        ),
+    ],
+)
+def test_probe_distrusts_inexact_soundfile_answers(monkeypatch, header, info) -> None:
+    import soundfile
+
+    monkeypatch.setattr(soundfile, "info", lambda *args, **kwargs: info)
+    monkeypatch.setattr(speech_to_text, "_av_duration", lambda audio_bytes: 100.0)
+
+    assert speech_to_text.probe_audio_duration(header) == 100.0
+
+
+def test_probe_returns_zero_for_unreadable_bytes() -> None:
+    assert speech_to_text.probe_audio_duration(b"\x00not-audio") == 0.0
 
 
 def test_verbose_response_uses_requested_task() -> None:


### PR DESCRIPTION
## Motivation

Every `/v1/audio/transcriptions` upload is probed for its duration on the API process before anything else runs: the result gates the streaming length limit, the chunk-vs-single decision, the pre-decode total-duration guard, and usage seconds. The probe opens a PyAV/FFmpeg demuxer context, which costs ~6 ms of API-process CPU per request even though it only reads header metadata (raised in the [#1347 review discussion](https://github.com/sgl-project/sglang-omni/pull/1347#discussion_r3752769003)).

For WAV that duration is plain header arithmetic that soundfile reads in ~0.03 ms, roughly 200x less. WAV dominates exactly the traffic that hits this endpoint hardest: TTS-verification loops, benchmark corpora, CI WER checkers, and programmatic clients.

A/B on one H100, `benchmarks/eval/benchmark_asr_seedtts` (Qwen3-ASR-1.7B, full SeedTTS EN set, 1088 WAV uploads, concurrency 1), main pinned at `2260553fb` vs this branch:

| metric | main | this PR | change |
|---|---|---|---|
| mean latency | 47.991 ms | 38.966 ms | -9.025 ms (-18.81%) |
| p95 latency | 57.809 ms | 48.182 ms | -9.627 ms |
| throughput | 20.773 req/s | 25.601 req/s | +23.24% |
| corpus WER | 0.0171004843 | 0.0171004843 | exact match |
| completed | 1088/1088 | 1088/1088 | zero failures |

An earlier round on the same host also measured +7.71% req/s and -2.44 API-process CPU points at concurrency 64.

## Modifications

1. `probe_audio_duration` consults `sf.info` first, but trusts it only under three conditions, each of which an adversarial input fails without it:
   * **Magic prefilter**: only `RIFF/RF64...WAVE` and `fLaC` bytes are handed to libsndfile at all; every other container (MP3, M4A, WebM, OGG, ...) keeps the PyAV path byte-for-byte.
   * **Subtype whitelist**: only linear encodings (`PCM_*`, `FLOAT`, `DOUBLE`). WAVE is a container and can legally carry MPEG Layer III, where libsndfile extrapolates the frame count from early-frame bitrate and mismeasures headerless VBR streams severalfold.
   * **Frame-count sanity**: `info.frames` must be a real count, not libsndfile's `SF_COUNT_MAX` sentinel, which it reports for FLAC streamed with `STREAMINFO total_samples = 0` (PyAV reports those as unknown; the probe now does too).

   Anything unknown or unlisted falls back to PyAV, so the probe is either exact or exactly main's current behaviour.

2. `check_total_duration` is re-enforced on `plan.duration_s` after the chunking decode. The pre-decode check necessarily runs on header metadata, which can under-measure regardless of probe backend (PyAV itself reports 86.2 s for a 100.08 s headerless VBR MP3); the decoded plan knows the true duration, so the operator's cap is re-checked against truth before any engine request is dispatched.

Format-trust matrix, 100 s fixtures (soundfile 0.14 / libsndfile 1.2.2, PyAV 18.1):

| upload | raw sf.info | PyAV | probe result |
|---|---|---|---|
| WAV (PCM or float) | 100.000 (exact) | 100.000 | 100.000 via soundfile, ~0.03 ms |
| FLAC | 100.000 (exact) | 100.000 | 100.000 via soundfile |
| OGG, CBR MP3, Xing VBR MP3 | 100.0-100.3 | 100.0 | PyAV's value |
| VBR MP3 without Xing header | **33.358** | 86.184 | 86.184 (PyAV) |
| MP3 inside RIFF/WAVE | **33.361** (`MPEG_LAYER_III`) | 100.049 | 100.049 (PyAV) |
| FLAC with unknown length | **frames = 2^63-1** | 0.0 (unknown) | 0.0 (unknown) |

No new dependency: soundfile is already used by `transcription_chunking.encode_wav`.

Not in scope: the streaming path has no decode point, so a metadata under-measure there keeps main's existing exposure unchanged; the transcription upload body limit (existing TODO) is a separate follow-up.

## Evidence

* H100 A/B table above; the WAV corpus exercises the fast path end to end, and corpus WER matches to every decimal with zero failed requests in either arm.
* Unit: 179 pass across `test_speech_to_text.py`, `test_openai_api.py`, `test_transcription_chunking.py`. New contract tests pin: estimated containers never reach soundfile; MPEG-in-WAV and sentinel-FLAC answers are distrusted (fakes carry the exact measured shapes); WAV measures without the PyAV fallback on a stdlib-`wave` fixture independent of libsndfile; the endpoint returns 400 when the decoded duration exceeds a cap the metadata probe under-measured.

## Checklist

- [x] Format your commit message following the conventions.
- [x] Add unit tests.
