### PR TITLE
[Perf][ARK-ASR] Enable breakable prefill CUDA graphs

### DIFF
--- a/sglang_omni/models/arkasr/engine_builder.py
+++ b/sglang_omni/models/arkasr/engine_builder.py
@@ -15,6 +15,10 @@ from sglang_omni.models.arkasr.encoder_service import (
     build_cache_namespace,
 )
 from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
+from sglang_omni.scheduling.generation_batch_policy import (
+    CudaGraphBackend,
+    build_default_prefill_cuda_graph_bs,
+)
 from sglang_omni.utils.gpu_compat import get_visible_gpu_sm_version
 
 logger = logging.getLogger(__name__)
@@ -23,6 +27,7 @@ logger = logging.getLogger(__name__)
 class ArkasrEngineBuilder(AsrEngineBuilder):
     model_name = "ARK-ASR"
     model_arch_override = "ArkasrForConditionalGeneration"
+    supports_breakable_prefill_cuda_graph = True
 
     def __init__(
         self,
@@ -119,6 +124,7 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
             "chunked_prefill_size": 4096,
             "sampling_backend": "pytorch",
             "dtype": dtype,
+            "cuda_graph_backend_prefill": CudaGraphBackend.BREAKABLE,
         }
         if self.mm_attention_backend is not None:
             defaults["mm_attention_backend"] = self.mm_attention_backend
@@ -127,6 +133,33 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
             if sm_version is not None and sm_version >= 100:
                 defaults["mm_attention_backend"] = "triton_attn"
         return defaults
+
+    def adjust_overrides(self, overrides: dict[str, Any]) -> None:
+        if "context_length" in overrides:
+            self.context_length = int(overrides.pop("context_length"))
+        if overrides.get("cuda_graph_backend_prefill") == CudaGraphBackend.DISABLED:
+            return
+        if "cuda_graph_bs_prefill" in overrides:
+            return
+
+        # SGLang clamps prefill max_bs to context_length after merging
+        # explicit buckets, so derive a ladder that remains coherent.
+        caps = [
+            self.context_length,
+            overrides["max_prefill_tokens"],
+            overrides.get("cuda_graph_max_bs_prefill"),
+            overrides.get("max_total_tokens"),
+        ]
+        if overrides["chunked_prefill_size"] > 0:
+            caps.append(overrides["chunked_prefill_size"])
+        ladder = build_default_prefill_cuda_graph_bs(
+            min(int(cap) for cap in caps if cap is not None)
+        )
+        overrides["cuda_graph_bs_prefill"] = ladder
+        overrides["cuda_graph_max_bs_prefill"] = max(ladder)
+
+    def customize_server_args(self, server_args: Any) -> None:
+        self.context_length = int(server_args.context_length)
 
     def setup_model_resources(
         self,

--- a/sglang_omni/models/arkasr/engine_builder.py
+++ b/sglang_omni/models/arkasr/engine_builder.py
@@ -15,11 +15,7 @@ from sglang_omni.models.arkasr.encoder_service import (
     build_cache_namespace,
 )
 from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
-from sglang_omni.scheduling.generation_batch_policy import (
-    CudaGraphBackend,
-    build_default_prefill_cuda_graph_bs,
-    clamp_prefill_cuda_graph_max_bs,
-)
+from sglang_omni.scheduling.generation_batch_policy import CudaGraphBackend
 from sglang_omni.utils.gpu_compat import get_visible_gpu_sm_version
 
 logger = logging.getLogger(__name__)
@@ -134,17 +130,6 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
             if sm_version is not None and sm_version >= 100:
                 defaults["mm_attention_backend"] = "triton_attn"
         return defaults
-
-    def adjust_overrides(self, overrides: dict[str, Any]) -> None:
-        if (
-            overrides.get("cuda_graph_backend_prefill") == CudaGraphBackend.DISABLED
-            or "cuda_graph_bs_prefill" in overrides
-        ):
-            return
-
-        overrides["cuda_graph_bs_prefill"] = build_default_prefill_cuda_graph_bs(
-            clamp_prefill_cuda_graph_max_bs(overrides)
-        )
 
     def setup_model_resources(
         self,

--- a/sglang_omni/models/arkasr/engine_builder.py
+++ b/sglang_omni/models/arkasr/engine_builder.py
@@ -142,8 +142,8 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
         if "cuda_graph_bs_prefill" in overrides:
             return
 
-        # SGLang clamps prefill max_bs to context_length after merging
-        # explicit buckets, so derive a ladder that remains coherent.
+        # Note: (musclemuller) SGLang clamps prefill max_bs to context_length
+        # after merging explicit buckets, so derive a ladder that remains coherent.
         caps = [
             self.context_length,
             overrides["max_prefill_tokens"],

--- a/sglang_omni/models/arkasr/engine_builder.py
+++ b/sglang_omni/models/arkasr/engine_builder.py
@@ -142,8 +142,8 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
         if "cuda_graph_bs_prefill" in overrides:
             return
 
-        # Note: (musclemuller) SGLang clamps prefill max_bs to context_length
-        # after merging explicit buckets, so derive a ladder that remains coherent.
+        # Note (musclemuller): Bound the ladder by every effective token cap so
+        # SGLang's post-merge max_bs clamp cannot invalidate explicit buckets.
         caps = [
             self.context_length,
             overrides["max_prefill_tokens"],

--- a/sglang_omni/models/arkasr/engine_builder.py
+++ b/sglang_omni/models/arkasr/engine_builder.py
@@ -18,6 +18,7 @@ from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
 from sglang_omni.scheduling.generation_batch_policy import (
     CudaGraphBackend,
     build_default_prefill_cuda_graph_bs,
+    clamp_prefill_cuda_graph_max_bs,
 )
 from sglang_omni.utils.gpu_compat import get_visible_gpu_sm_version
 
@@ -135,31 +136,15 @@ class ArkasrEngineBuilder(AsrEngineBuilder):
         return defaults
 
     def adjust_overrides(self, overrides: dict[str, Any]) -> None:
-        if "context_length" in overrides:
-            self.context_length = int(overrides.pop("context_length"))
-        if overrides.get("cuda_graph_backend_prefill") == CudaGraphBackend.DISABLED:
-            return
-        if "cuda_graph_bs_prefill" in overrides:
+        if (
+            overrides.get("cuda_graph_backend_prefill") == CudaGraphBackend.DISABLED
+            or "cuda_graph_bs_prefill" in overrides
+        ):
             return
 
-        # Note (musclemuller): Bound the ladder by every effective token cap so
-        # SGLang's post-merge max_bs clamp cannot invalidate explicit buckets.
-        caps = [
-            self.context_length,
-            overrides["max_prefill_tokens"],
-            overrides.get("cuda_graph_max_bs_prefill"),
-            overrides.get("max_total_tokens"),
-        ]
-        if overrides["chunked_prefill_size"] > 0:
-            caps.append(overrides["chunked_prefill_size"])
-        ladder = build_default_prefill_cuda_graph_bs(
-            min(int(cap) for cap in caps if cap is not None)
+        overrides["cuda_graph_bs_prefill"] = build_default_prefill_cuda_graph_bs(
+            clamp_prefill_cuda_graph_max_bs(overrides)
         )
-        overrides["cuda_graph_bs_prefill"] = ladder
-        overrides["cuda_graph_max_bs_prefill"] = max(ladder)
-
-    def customize_server_args(self, server_args: Any) -> None:
-        self.context_length = int(server_args.context_length)
 
     def setup_model_resources(
         self,

--- a/sglang_omni/models/arkasr/sglang_model.py
+++ b/sglang_omni/models/arkasr/sglang_model.py
@@ -66,6 +66,7 @@ class ArkasrForConditionalGeneration(nn.Module):
     def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
         return self.pattern.pad_input_tokens(input_ids, mm_inputs)
 
+    @torch.no_grad()
     def get_audio_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
         """Encode cache-miss audio items in bounded sequential microbatches.
 

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 import torch.nn as nn
 from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
+from sglang.srt.server_args import ServerArgs
 from transformers import WhisperConfig
 
 import sglang_omni.model_runner.base as model_runner_base
@@ -28,9 +29,6 @@ from sglang_omni.models.arkasr.request_builders import _build_suppressed_token_i
 from sglang_omni.models.arkasr.sglang_model import ArkasrForConditionalGeneration
 from sglang_omni.models.arkasr.stages import create_sglang_arkasr_executor
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
-from sglang_omni.scheduling.generation_batch_policy import (
-    build_generation_batch_overrides,
-)
 
 
 def _tiny_config():
@@ -54,6 +52,11 @@ def _tiny_config():
         vocab_size=256,
         audio_token_id=151663,
     )
+
+
+def _sglang_prefill_ladder(max_bs: int) -> list[int]:
+    unresolved = ServerArgs.__new__(ServerArgs)
+    return ServerArgs._generate_prefill_cuda_graph_batch_sizes(unresolved, max_bs)
 
 
 def test_arkasr_config_registered():
@@ -175,40 +178,12 @@ def test_arkasr_stage_default_enables_async_decode():
     assert signature.parameters["async_decode_min_batch_size"].default == 2
 
 
-def test_arkasr_prefill_graph_allows_unset_chunked_prefill_size() -> None:
-    builder = arkasr_builder.ArkasrEngineBuilder(
-        max_running_requests=32,
-        encoder_max_batch_size=8,
-        max_new_tokens=256,
-        enable_async_decode=True,
-        async_decode_min_batch_size=2,
-        mem_fraction_static=None,
-        mm_embedding_cache_size_bytes=0,
-        enable_torch_compile=False,
-        mm_attention_backend="fa3",
-        request_build_max_workers=8,
-        request_build_max_pending=32,
-        prefill_coalesce_requests=16,
-        prefill_coalesce_wait_ms=32.0,
-        prefill_coalesce_when_idle=True,
-        prefill_coalesce_requires_pending_builds=True,
-    )
-    overrides = build_generation_batch_overrides(
-        server_args_overrides={"chunked_prefill_size": None},
-        **builder.generation_defaults(dtype="bfloat16"),
-    )
-
-    builder.adjust_overrides(overrides)
-
-    assert overrides["cuda_graph_backend_prefill"] == "breakable"
-    assert overrides["cuda_graph_bs_prefill"][-1] == overrides["max_prefill_tokens"]
-
-
 def _stub_arkasr_engine_build(
     monkeypatch: pytest.MonkeyPatch,
     *,
     want_cuda_graph: bool,
     encoder_service: object,
+    resolved_chunked_prefill_size: int | None = None,
 ) -> SimpleNamespace:
     """Stub every out-of-process dependency of ArkasrEngineBuilder.build().
 
@@ -221,6 +196,7 @@ def _stub_arkasr_engine_build(
     encoder_service_kwargs: dict[str, object] = {}
     stream_builder_calls: list[dict[str, object]] = []
     stream_output_builder = object()
+    build_kwargs: dict[str, object] = {}
 
     encoder_batch_sizes: list[int] = []
     model_worker = SimpleNamespace(
@@ -283,14 +259,54 @@ def _stub_arkasr_engine_build(
     )
 
     def _fake_server_args_builder(model_path, context_length, **overrides):
-        server_args = SimpleNamespace(context_length=context_length, **overrides)
+        build_kwargs.update(overrides)
+        flat = dict(overrides)
+        if (
+            resolved_chunked_prefill_size is not None
+            and flat.get("chunked_prefill_size") is None
+        ):
+            flat["chunked_prefill_size"] = resolved_chunked_prefill_size
+        for name, default in (
+            ("attn_cp_size", 1),
+            ("dcp_size", 1),
+            ("lora_paths", None),
+            ("enable_lora", None),
+            ("moe_a2a_backend", "none"),
+        ):
+            flat.setdefault(name, default)
+        server_args = SimpleNamespace(context_length=context_length, **flat)
+        prefill_backend = (
+            overrides.get("cuda_graph_backend_prefill", "disabled")
+            if resolved_chunked_prefill_size is not None
+            else "disabled"
+        )
+        prefill_bs = overrides.get("cuda_graph_bs_prefill")
+        prefill_max_bs = overrides.get("cuda_graph_max_bs_prefill")
+        if resolved_chunked_prefill_size is not None:
+            if prefill_max_bs is None:
+                prefill_max_bs = server_args.chunked_prefill_size
+            if prefill_bs is None:
+                prefill_bs = _sglang_prefill_ladder(prefill_max_bs)
         server_args.cuda_graph_config = SimpleNamespace(
             decode=SimpleNamespace(
                 max_bs=overrides["cuda_graph_max_bs"],
                 bs=overrides["cuda_graph_bs"],
             ),
-            prefill=SimpleNamespace(backend="disabled", bs=None, max_bs=None),
+            prefill=SimpleNamespace(
+                backend=prefill_backend,
+                bs=prefill_bs,
+                max_bs=prefill_max_bs,
+            ),
         )
+        server_args._cuda_graph_config_locked = {
+            ("prefill", field)
+            for field, key in (
+                ("backend", "cuda_graph_backend_prefill"),
+                ("bs", "cuda_graph_bs_prefill"),
+                ("max_bs", "cuda_graph_max_bs_prefill"),
+            )
+            if key in overrides
+        }
         return server_args
 
     monkeypatch.setattr(
@@ -328,7 +344,33 @@ def _stub_arkasr_engine_build(
         infra_kwargs_seen=infra_kwargs_seen,
         encoder_batch_sizes=encoder_batch_sizes,
         model_worker=model_worker,
+        build_kwargs=build_kwargs,
     )
+
+
+def test_arkasr_prefill_graph_uses_resolved_auto_chunk_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _stub_arkasr_engine_build(
+        monkeypatch,
+        want_cuda_graph=False,
+        encoder_service=SimpleNamespace(close=lambda: None),
+        resolved_chunked_prefill_size=2048,
+    )
+
+    scheduler = create_sglang_arkasr_executor(
+        "AutoArk-AI/ARK-ASR-3B",
+        server_args_overrides={"chunked_prefill_size": None},
+    )
+
+    prefill = scheduler.server_args.cuda_graph_config.prefill
+    assert stub.build_kwargs["chunked_prefill_size"] is None
+    assert "cuda_graph_bs_prefill" not in stub.build_kwargs
+    assert "cuda_graph_max_bs_prefill" not in stub.build_kwargs
+    assert list(prefill.bs) == _sglang_prefill_ladder(2048)
+    assert prefill.max_bs == 2048
+    assert ("prefill", "bs") not in scheduler.server_args._cuda_graph_config_locked
+    assert stub.infra_kwargs_seen["enable_prefill_input_embeds"] is True
 
 
 @pytest.mark.parametrize("want_cuda_graph", [True, False])

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -212,21 +212,35 @@ def test_arkasr_prefill_graph_defaults() -> None:
     assert builder.supports_breakable_prefill_cuda_graph
     assert overrides["cuda_graph_backend_prefill"] == "breakable"
     assert overrides["cuda_graph_bs_prefill"] == (
-        build_default_prefill_cuda_graph_bs(builder.context_length)
+        build_default_prefill_cuda_graph_bs(4096)
     )
-    assert overrides["cuda_graph_max_bs_prefill"] == builder.context_length
+    assert overrides["cuda_graph_max_bs_prefill"] == 4096
 
 
-def test_arkasr_prefill_graph_respects_effective_token_cap() -> None:
+def test_arkasr_prefill_graph_allows_unset_chunked_prefill_size() -> None:
     builder = _make_engine_builder()
     overrides = build_generation_batch_overrides(
-        server_args_overrides={"context_length": 768, "max_total_tokens": 512},
+        server_args_overrides={"chunked_prefill_size": None},
         **builder.generation_defaults(dtype="bfloat16"),
     )
 
     builder.adjust_overrides(overrides)
 
-    assert builder.context_length == 768
+    assert overrides["cuda_graph_bs_prefill"] == (
+        build_default_prefill_cuda_graph_bs(4096)
+    )
+    assert overrides["cuda_graph_max_bs_prefill"] == 4096
+
+
+def test_arkasr_prefill_graph_respects_effective_token_cap() -> None:
+    builder = _make_engine_builder()
+    overrides = build_generation_batch_overrides(
+        server_args_overrides={"max_total_tokens": 512},
+        **builder.generation_defaults(dtype="bfloat16"),
+    )
+
+    builder.adjust_overrides(overrides)
+
     assert overrides["cuda_graph_bs_prefill"] == (
         build_default_prefill_cuda_graph_bs(512)
     )
@@ -469,8 +483,9 @@ def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
     assert stub.infra_kwargs_seen["enable_prefill_input_embeds"] is True
     assert stub.build_kwargs["cuda_graph_backend_prefill"] == "breakable"
     assert stub.build_kwargs["cuda_graph_bs_prefill"] == (
-        build_default_prefill_cuda_graph_bs(scheduler.server_args.context_length)
+        build_default_prefill_cuda_graph_bs(4096)
     )
+    assert stub.build_kwargs["cuda_graph_max_bs_prefill"] == 4096
     assert stub.attest_calls == (
         [(stub.model_worker.model_runner, scheduler.server_args)]
         if want_cuda_graph

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -10,12 +10,12 @@ import torch.nn as nn
 from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
 from transformers import WhisperConfig
 
-import sglang_omni.model_runner.base as model_runner_base
 import sglang_omni.models.arkasr.engine_builder as arkasr_builder
 import sglang_omni.platforms as platforms
 import sglang_omni.scheduling.bootstrap as bootstrap
 import sglang_omni.scheduling.omni_scheduler as omni_scheduler
 import sglang_omni.scheduling.sglang_backend as sglang_backend
+import sglang_omni.utils.cuda_graph_batch_validator as cuda_graph_batch_validator
 from sglang_omni.models.arkasr import request_builders
 from sglang_omni.models.arkasr.audio_lengths import (
     arkasr_audio_token_lengths,
@@ -28,6 +28,10 @@ from sglang_omni.models.arkasr.request_builders import _build_suppressed_token_i
 from sglang_omni.models.arkasr.sglang_model import ArkasrForConditionalGeneration
 from sglang_omni.models.arkasr.stages import create_sglang_arkasr_executor
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+from sglang_omni.scheduling.generation_batch_policy import (
+    build_default_prefill_cuda_graph_bs,
+    build_generation_batch_overrides,
+)
 
 
 def _tiny_config():
@@ -172,23 +176,100 @@ def test_arkasr_stage_default_enables_async_decode():
     assert signature.parameters["async_decode_min_batch_size"].default == 2
 
 
+def _make_engine_builder(
+    *,
+    context_length: int = 1636,
+) -> arkasr_builder.ArkasrEngineBuilder:
+    builder = arkasr_builder.ArkasrEngineBuilder(
+        max_running_requests=32,
+        encoder_max_batch_size=8,
+        max_new_tokens=256,
+        enable_async_decode=True,
+        async_decode_min_batch_size=2,
+        mem_fraction_static=None,
+        mm_embedding_cache_size_bytes=0,
+        enable_torch_compile=False,
+        mm_attention_backend="fa3",
+        request_build_max_workers=8,
+        request_build_max_pending=32,
+    )
+    builder.context_length = context_length
+    return builder
+
+
+def test_arkasr_prefill_graph_defaults() -> None:
+    builder = _make_engine_builder()
+    overrides = build_generation_batch_overrides(
+        **builder.generation_defaults(dtype="bfloat16"),
+    )
+
+    builder.adjust_overrides(overrides)
+
+    assert builder.supports_breakable_prefill_cuda_graph
+    assert overrides["cuda_graph_backend_prefill"] == "breakable"
+    assert overrides["cuda_graph_bs_prefill"] == (
+        build_default_prefill_cuda_graph_bs(builder.context_length)
+    )
+    assert overrides["cuda_graph_max_bs_prefill"] == builder.context_length
+
+
+def test_arkasr_prefill_graph_respects_effective_token_cap() -> None:
+    builder = _make_engine_builder()
+    overrides = build_generation_batch_overrides(
+        server_args_overrides={"context_length": 768, "max_total_tokens": 512},
+        **builder.generation_defaults(dtype="bfloat16"),
+    )
+
+    builder.adjust_overrides(overrides)
+
+    assert builder.context_length == 768
+    assert overrides["cuda_graph_bs_prefill"] == (
+        build_default_prefill_cuda_graph_bs(512)
+    )
+    assert overrides["cuda_graph_max_bs_prefill"] == 512
+
+
+def test_arkasr_prefill_graph_honors_explicit_buckets() -> None:
+    builder = _make_engine_builder()
+    overrides = build_generation_batch_overrides(
+        server_args_overrides={"cuda_graph_bs_prefill": [64, 128]},
+        **builder.generation_defaults(dtype="bfloat16"),
+    )
+
+    builder.adjust_overrides(overrides)
+
+    assert overrides["cuda_graph_bs_prefill"] == [64, 128]
+    assert overrides["cuda_graph_max_bs_prefill"] == 128
+
+
+def test_arkasr_prefill_graph_can_be_disabled() -> None:
+    builder = _make_engine_builder()
+    overrides = build_generation_batch_overrides(
+        server_args_overrides={"disable_prefill_cuda_graph": True},
+        **builder.generation_defaults(dtype="bfloat16"),
+    )
+
+    builder.adjust_overrides(overrides)
+
+    assert overrides["cuda_graph_backend_prefill"] == "disabled"
+    assert "cuda_graph_bs_prefill" not in overrides
+    assert "cuda_graph_max_bs_prefill" not in overrides
+
+
 def _stub_arkasr_engine_build(
     monkeypatch: pytest.MonkeyPatch,
     *,
     want_cuda_graph: bool,
     encoder_service: object,
 ) -> SimpleNamespace:
-    """Stub every out-of-process dependency of ArkasrEngineBuilder.build().
-
-    Returns the recorders the tests assert on. The worker stub stays minimal:
-    helper internals are already covered in
-    tests/unit_test/serve/test_sglang_bootstrap.py.
-    """
+    """Stub every out-of-process dependency of ArkasrEngineBuilder.build()."""
     graph_init_workers: list[object] = []
     adapter_kwargs: dict[str, object] = {}
     encoder_service_kwargs: dict[str, object] = {}
     stream_builder_calls: list[dict[str, object]] = []
     stream_output_builder = object()
+    attest_calls: list[tuple[object, object]] = []
+    build_kwargs: dict[str, object] = {}
 
     encoder_batch_sizes: list[int] = []
     model_worker = SimpleNamespace(
@@ -251,14 +332,33 @@ def _stub_arkasr_engine_build(
     )
 
     def _fake_server_args_builder(model_path, context_length, **overrides):
+        del model_path
+        build_kwargs.update(overrides)
         server_args = SimpleNamespace(context_length=context_length, **overrides)
+        for name, default in (
+            ("attn_cp_size", 1),
+            ("dcp_size", 1),
+            ("lora_paths", None),
+            ("enable_lora", None),
+            ("moe_a2a_backend", "none"),
+        ):
+            setattr(server_args, name, getattr(server_args, name, default))
+        prefill_bs = overrides.get("cuda_graph_bs_prefill")
         server_args.cuda_graph_config = SimpleNamespace(
             decode=SimpleNamespace(
                 max_bs=overrides["cuda_graph_max_bs"],
                 bs=overrides["cuda_graph_bs"],
             ),
-            prefill=SimpleNamespace(backend="disabled", bs=None, max_bs=None),
+            prefill=SimpleNamespace(
+                backend=overrides.get("cuda_graph_backend_prefill", "disabled"),
+                bs=prefill_bs,
+                max_bs=overrides.get("cuda_graph_max_bs_prefill"),
+            ),
         )
+        server_args._cuda_graph_config_locked = {
+            ("prefill", "backend"),
+            ("prefill", "bs"),
+        }
         return server_args
 
     monkeypatch.setattr(
@@ -281,11 +381,21 @@ def _stub_arkasr_engine_build(
         lambda worker: graph_init_workers.append(worker),
     )
     monkeypatch.setattr(
-        model_runner_base,
-        "ModelRunner",
-        lambda *args, **kwargs: object(),
+        cuda_graph_batch_validator,
+        "attest_prefill_cuda_graphs",
+        lambda model_runner, server_args: attest_calls.append(
+            (model_runner, server_args)
+        ),
     )
     monkeypatch.setattr(sglang_backend, "SGLangOutputProcessor", lambda **k: object())
+    monkeypatch.setattr(
+        arkasr_builder.ArkasrEngineBuilder,
+        "make_model_runner",
+        lambda self, model_worker, output_proc: SimpleNamespace(
+            model_worker=model_worker,
+            output_proc=output_proc,
+        ),
+    )
     monkeypatch.setattr(omni_scheduler, "OmniScheduler", SimpleNamespace)
     return SimpleNamespace(
         graph_init_workers=graph_init_workers,
@@ -293,6 +403,8 @@ def _stub_arkasr_engine_build(
         encoder_service_kwargs=encoder_service_kwargs,
         stream_builder_calls=stream_builder_calls,
         stream_output_builder=stream_output_builder,
+        attest_calls=attest_calls,
+        build_kwargs=build_kwargs,
         infra_kwargs_seen=infra_kwargs_seen,
         encoder_batch_sizes=encoder_batch_sizes,
         model_worker=model_worker,
@@ -349,6 +461,16 @@ def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
     assert (
         stub.infra_kwargs_seen["model_arch_override"]
         == "ArkasrForConditionalGeneration"
+    )
+    assert stub.infra_kwargs_seen["enable_prefill_input_embeds"] is True
+    assert stub.build_kwargs["cuda_graph_backend_prefill"] == "breakable"
+    assert stub.build_kwargs["cuda_graph_bs_prefill"] == (
+        build_default_prefill_cuda_graph_bs(scheduler.server_args.context_length)
+    )
+    assert stub.attest_calls == (
+        [(stub.model_worker.model_runner, scheduler.server_args)]
+        if want_cuda_graph
+        else []
     )
     assert stub.encoder_batch_sizes == [8]
     assert stub.encoder_service_kwargs["max_queue_size"] == 32

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -626,6 +626,16 @@ def test_ark_get_audio_feature_batched_matches_serial_and_uses_one_encoder_call(
     assert torch.allclose(batched, serial, atol=1e-5, rtol=1e-5)
 
 
+def test_ark_get_audio_feature_does_not_build_an_autograd_graph():
+    model = _tiny_ark_audio_mm_model()
+    item = _ark_audio_item(torch.randn(1, 8, 18), 18, hash_id=99)
+
+    output = model.get_audio_feature([item])
+
+    assert output.grad_fn is None
+    assert not output.requires_grad
+
+
 def test_ark_get_audio_feature_splits_large_batches_in_order():
     torch.manual_seed(4)
     model = _tiny_ark_audio_mm_model()

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -192,6 +192,10 @@ def _make_engine_builder(
         mm_attention_backend="fa3",
         request_build_max_workers=8,
         request_build_max_pending=32,
+        prefill_coalesce_requests=16,
+        prefill_coalesce_wait_ms=32.0,
+        prefill_coalesce_when_idle=True,
+        prefill_coalesce_requires_pending_builds=True,
     )
     builder.context_length = context_length
     return builder

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -10,12 +10,12 @@ import torch.nn as nn
 from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
 from transformers import WhisperConfig
 
+import sglang_omni.model_runner.base as model_runner_base
 import sglang_omni.models.arkasr.engine_builder as arkasr_builder
 import sglang_omni.platforms as platforms
 import sglang_omni.scheduling.bootstrap as bootstrap
 import sglang_omni.scheduling.omni_scheduler as omni_scheduler
 import sglang_omni.scheduling.sglang_backend as sglang_backend
-import sglang_omni.utils.cuda_graph_batch_validator as cuda_graph_batch_validator
 from sglang_omni.models.arkasr import request_builders
 from sglang_omni.models.arkasr.audio_lengths import (
     arkasr_audio_token_lengths,
@@ -29,7 +29,6 @@ from sglang_omni.models.arkasr.sglang_model import ArkasrForConditionalGeneratio
 from sglang_omni.models.arkasr.stages import create_sglang_arkasr_executor
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from sglang_omni.scheduling.generation_batch_policy import (
-    build_default_prefill_cuda_graph_bs,
     build_generation_batch_overrides,
 )
 
@@ -176,10 +175,7 @@ def test_arkasr_stage_default_enables_async_decode():
     assert signature.parameters["async_decode_min_batch_size"].default == 2
 
 
-def _make_engine_builder(
-    *,
-    context_length: int = 1636,
-) -> arkasr_builder.ArkasrEngineBuilder:
+def test_arkasr_prefill_graph_allows_unset_chunked_prefill_size() -> None:
     builder = arkasr_builder.ArkasrEngineBuilder(
         max_running_requests=32,
         encoder_max_batch_size=8,
@@ -197,28 +193,6 @@ def _make_engine_builder(
         prefill_coalesce_when_idle=True,
         prefill_coalesce_requires_pending_builds=True,
     )
-    builder.context_length = context_length
-    return builder
-
-
-def test_arkasr_prefill_graph_defaults() -> None:
-    builder = _make_engine_builder()
-    overrides = build_generation_batch_overrides(
-        **builder.generation_defaults(dtype="bfloat16"),
-    )
-
-    builder.adjust_overrides(overrides)
-
-    assert builder.supports_breakable_prefill_cuda_graph
-    assert overrides["cuda_graph_backend_prefill"] == "breakable"
-    assert overrides["cuda_graph_bs_prefill"] == (
-        build_default_prefill_cuda_graph_bs(4096)
-    )
-    assert overrides["cuda_graph_max_bs_prefill"] == 4096
-
-
-def test_arkasr_prefill_graph_allows_unset_chunked_prefill_size() -> None:
-    builder = _make_engine_builder()
     overrides = build_generation_batch_overrides(
         server_args_overrides={"chunked_prefill_size": None},
         **builder.generation_defaults(dtype="bfloat16"),
@@ -226,52 +200,8 @@ def test_arkasr_prefill_graph_allows_unset_chunked_prefill_size() -> None:
 
     builder.adjust_overrides(overrides)
 
-    assert overrides["cuda_graph_bs_prefill"] == (
-        build_default_prefill_cuda_graph_bs(4096)
-    )
-    assert overrides["cuda_graph_max_bs_prefill"] == 4096
-
-
-def test_arkasr_prefill_graph_respects_effective_token_cap() -> None:
-    builder = _make_engine_builder()
-    overrides = build_generation_batch_overrides(
-        server_args_overrides={"max_total_tokens": 512},
-        **builder.generation_defaults(dtype="bfloat16"),
-    )
-
-    builder.adjust_overrides(overrides)
-
-    assert overrides["cuda_graph_bs_prefill"] == (
-        build_default_prefill_cuda_graph_bs(512)
-    )
-    assert overrides["cuda_graph_max_bs_prefill"] == 512
-
-
-def test_arkasr_prefill_graph_honors_explicit_buckets() -> None:
-    builder = _make_engine_builder()
-    overrides = build_generation_batch_overrides(
-        server_args_overrides={"cuda_graph_bs_prefill": [64, 128]},
-        **builder.generation_defaults(dtype="bfloat16"),
-    )
-
-    builder.adjust_overrides(overrides)
-
-    assert overrides["cuda_graph_bs_prefill"] == [64, 128]
-    assert overrides["cuda_graph_max_bs_prefill"] == 128
-
-
-def test_arkasr_prefill_graph_can_be_disabled() -> None:
-    builder = _make_engine_builder()
-    overrides = build_generation_batch_overrides(
-        server_args_overrides={"disable_prefill_cuda_graph": True},
-        **builder.generation_defaults(dtype="bfloat16"),
-    )
-
-    builder.adjust_overrides(overrides)
-
-    assert overrides["cuda_graph_backend_prefill"] == "disabled"
-    assert "cuda_graph_bs_prefill" not in overrides
-    assert "cuda_graph_max_bs_prefill" not in overrides
+    assert overrides["cuda_graph_backend_prefill"] == "breakable"
+    assert overrides["cuda_graph_bs_prefill"][-1] == overrides["max_prefill_tokens"]
 
 
 def _stub_arkasr_engine_build(
@@ -280,14 +210,17 @@ def _stub_arkasr_engine_build(
     want_cuda_graph: bool,
     encoder_service: object,
 ) -> SimpleNamespace:
-    """Stub every out-of-process dependency of ArkasrEngineBuilder.build()."""
+    """Stub every out-of-process dependency of ArkasrEngineBuilder.build().
+
+    Returns the recorders the tests assert on. The worker stub stays minimal:
+    helper internals are already covered in
+    tests/unit_test/serve/test_sglang_bootstrap.py.
+    """
     graph_init_workers: list[object] = []
     adapter_kwargs: dict[str, object] = {}
     encoder_service_kwargs: dict[str, object] = {}
     stream_builder_calls: list[dict[str, object]] = []
     stream_output_builder = object()
-    attest_calls: list[tuple[object, object]] = []
-    build_kwargs: dict[str, object] = {}
 
     encoder_batch_sizes: list[int] = []
     model_worker = SimpleNamespace(
@@ -350,33 +283,14 @@ def _stub_arkasr_engine_build(
     )
 
     def _fake_server_args_builder(model_path, context_length, **overrides):
-        del model_path
-        build_kwargs.update(overrides)
         server_args = SimpleNamespace(context_length=context_length, **overrides)
-        for name, default in (
-            ("attn_cp_size", 1),
-            ("dcp_size", 1),
-            ("lora_paths", None),
-            ("enable_lora", None),
-            ("moe_a2a_backend", "none"),
-        ):
-            setattr(server_args, name, getattr(server_args, name, default))
-        prefill_bs = overrides.get("cuda_graph_bs_prefill")
         server_args.cuda_graph_config = SimpleNamespace(
             decode=SimpleNamespace(
                 max_bs=overrides["cuda_graph_max_bs"],
                 bs=overrides["cuda_graph_bs"],
             ),
-            prefill=SimpleNamespace(
-                backend=overrides.get("cuda_graph_backend_prefill", "disabled"),
-                bs=prefill_bs,
-                max_bs=overrides.get("cuda_graph_max_bs_prefill"),
-            ),
+            prefill=SimpleNamespace(backend="disabled", bs=None, max_bs=None),
         )
-        server_args._cuda_graph_config_locked = {
-            ("prefill", "backend"),
-            ("prefill", "bs"),
-        }
         return server_args
 
     monkeypatch.setattr(
@@ -399,21 +313,11 @@ def _stub_arkasr_engine_build(
         lambda worker: graph_init_workers.append(worker),
     )
     monkeypatch.setattr(
-        cuda_graph_batch_validator,
-        "attest_prefill_cuda_graphs",
-        lambda model_runner, server_args: attest_calls.append(
-            (model_runner, server_args)
-        ),
+        model_runner_base,
+        "ModelRunner",
+        lambda *args, **kwargs: object(),
     )
     monkeypatch.setattr(sglang_backend, "SGLangOutputProcessor", lambda **k: object())
-    monkeypatch.setattr(
-        arkasr_builder.ArkasrEngineBuilder,
-        "make_model_runner",
-        lambda self, model_worker, output_proc: SimpleNamespace(
-            model_worker=model_worker,
-            output_proc=output_proc,
-        ),
-    )
     monkeypatch.setattr(omni_scheduler, "OmniScheduler", SimpleNamespace)
     return SimpleNamespace(
         graph_init_workers=graph_init_workers,
@@ -421,8 +325,6 @@ def _stub_arkasr_engine_build(
         encoder_service_kwargs=encoder_service_kwargs,
         stream_builder_calls=stream_builder_calls,
         stream_output_builder=stream_output_builder,
-        attest_calls=attest_calls,
-        build_kwargs=build_kwargs,
         infra_kwargs_seen=infra_kwargs_seen,
         encoder_batch_sizes=encoder_batch_sizes,
         model_worker=model_worker,
@@ -479,17 +381,6 @@ def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
     assert (
         stub.infra_kwargs_seen["model_arch_override"]
         == "ArkasrForConditionalGeneration"
-    )
-    assert stub.infra_kwargs_seen["enable_prefill_input_embeds"] is True
-    assert stub.build_kwargs["cuda_graph_backend_prefill"] == "breakable"
-    assert stub.build_kwargs["cuda_graph_bs_prefill"] == (
-        build_default_prefill_cuda_graph_bs(4096)
-    )
-    assert stub.build_kwargs["cuda_graph_max_bs_prefill"] == 4096
-    assert stub.attest_calls == (
-        [(stub.model_worker.model_runner, scheduler.server_args)]
-        if want_cuda_graph
-        else []
     )
     assert stub.encoder_batch_sizes == [8]
     assert stub.encoder_service_kwargs["max_queue_size"] == 32


### PR DESCRIPTION
## Motivation
Enable SGLang's breakable prefill CUDA graph path for ARK-ASR, following the shared policy introduced for Qwen3-ASR in #1458 and the Fun-ASR adaptation in #1398. ARK's multimodal outer forward remains eager while the inner language-model body is captured.

## Modifications
- Mark ARK-ASR as supporting breakable prefill CUDA graphs.
- Enable breakable prefill by default independently of the pre-LM encoder setting.
- Derive the prefill capture ladder from effective context/token caps while preserving operator bucket, cap, and disable overrides.
- Enable the static input-embedding graph slot and prefill graph attestation through the shared engine path.
- Add unit coverage for policy, overrides, capture initialization, and attestation.

## Related Issues
- #1396 
- #1357 

## Accuracy Test

Both graph-disabled and graph-enabled configurations completed all 3,264 measured requests per concurrency (3 repeats × 1,088 samples), with zero skipped requests. Corpus WER was identical: `0.0111985472` at concurrency 1, 8, and 32.

## Benchmark & Profiling
Both benchmark variants enabled the pre-LM encoder, keeping it as a controlled variable; that benchmark configuration does not imply a code dependency.

- GPU: NVIDIA H100 SXM 80GB
- Target: Vast.ai direct container
- CI image: `hongccc/sglang-omni@sha256:374d0b1c30b2bff685b1716fc64a02ad3b3d0a90fe2ce73ce9861a6992c28101`
- Model revision: `1e28271b79edc97635783bea65abc89195a09ed3`
- Benchmarked source: `5a31d3a10f8c3d5e1afc54c89f2008b3c8469f31`, including #1429 (now merged into `main`)
- Method: same host/config/model/corpus, `enable_pre_lm_encoder=true` for both graph-disabled base and graph-enabled head, one application warmup, 3 measured repeats per concurrency

| concurrency | graph disabled req/s | graph enabled req/s | delta | disabled mean latency | enabled mean latency | WER |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 12.014 | 11.860 | -1.3% | 0.083s | 0.084s | 0.0112 |
| 8 | 59.719 | 66.092 | +10.7% | 0.134s | 0.121s | 0.0112 |
| 32 | 126.255 | 148.451 | +17.6% | 0.250s | 0.212s | 0.0112 |

A post-enabled graph-disabled spot pass produced 11.633, 57.812, and 123.079 req/s at concurrency 1, 8, and 32, respectively, supporting the c8/c32 improvement while showing expected run-order variance. The c1 result remains a small regression.

Capture evidence: breakable prefill captured and attested 41 buckets through 1,764 tokens in 3.73 seconds, using 0.43 GB. The pre-LM encoder reported zero failures.

The benchmark keeps pre-LM enabled in both variants; the implementation itself enables breakable prefill regardless of the pre-LM setting.

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests.
- [x] Provide throughput, latency, and accuracy results.
- [x] No documentation update needed; no public API change.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Draft PRs are skipped even if labeled.


