### PR TITLE
[Perf][Whisper ASR] Enable breakable prefill CUDA graphs

### DIFF
--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -37,6 +37,28 @@ stages:
 
 The graph is captured after SGLang's generation graphs. With pre-LM off, raise `max_prefill_tokens` before configuring larger LM-side buckets (12/16). Each request uses the smallest captured bucket that fits its batch. Requests larger than every captured bucket, with a different feature shape, or without a successful capture run eagerly. Startup and first-replay logs identify the captured and executed buckets.
 
+## Breakable Prefill CUDA Graph
+
+The decoder body uses SGLang's breakable prefill CUDA Graph backend by default.
+Whisper encoder states and cross-attention K/V are prepared outside the captured
+decoder body, while decoder-prefill token counts through 256 use the default
+capture ladder. Startup logs report the capture cost and confirm the active
+buckets with `prefill CUDA graphs attested`.
+
+To disable only the prefill graph while keeping decode and encoder CUDA Graphs
+enabled, override the ASR stage:
+
+```yaml
+config_cls: WhisperASRPipelineConfig
+name: whisper
+model_path: openai/whisper-large-v3
+
+runtime_overrides:
+  asr:
+    server_args_overrides:
+      cuda_graph_backend_prefill: disabled
+```
+
 ## Prefill Coalescing
 
 Whisper builds requests with eight worker threads by default, matching other pre-LM ASR pipelines. The coalescing gate targets two requests, while the default 6,144-token atomic budget lets the LM scheduler admit up to four 1,504-token Whisper requests together. A partial batch waits for at most 6 ms only while another request build is pending; a single request and a partial batch with no remaining build work are released immediately.

--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -41,9 +41,20 @@ The graph is captured after SGLang's generation graphs. With pre-LM off, raise `
 
 The decoder body uses SGLang's breakable prefill CUDA Graph backend by default.
 Whisper encoder states and cross-attention K/V are prepared outside the captured
-decoder body, while decoder-prefill token counts through 256 use the default
-capture ladder. Startup logs report the capture cost and confirm the active
-buckets with `prefill CUDA graphs attested`.
+decoder body. The default capture ladder is bounded by the effective prefill,
+total-token, and model-context limits. Startup logs report the capture cost and
+confirm the active buckets with `prefill CUDA graphs attested`.
+
+The current benchmark results were collected with
+`cuda_graph_max_bs_prefill=256`. To reproduce that capture profile and limit
+startup time and GPU memory, set the prefill graph cap explicitly:
+
+```yaml
+runtime_overrides:
+  asr:
+    server_args_overrides:
+      cuda_graph_max_bs_prefill: 256
+```
 
 To disable only the prefill graph while keeping decode and encoder CUDA Graphs
 enabled, override the ASR stage:

--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -41,9 +41,12 @@ The graph is captured after SGLang's generation graphs. With pre-LM off, raise `
 
 The decoder body uses SGLang's breakable prefill CUDA Graph backend by default.
 Whisper encoder states and cross-attention K/V are prepared outside the captured
-decoder body. The default capture ladder is bounded by the effective prefill,
-total-token, and model-context limits. Startup logs report the capture cost and
-confirm the active buckets with `prefill CUDA graphs attested`.
+decoder body. The default capture ladder stops at the largest decoder batch
+atomic admission can form: `max_prefill_tokens` divided by one request's
+encoder placeholders plus decoder tokens (1,500 + 232 for every Whisper size),
+times 232 decoder tokens, so 696 with the default 6,144 budget. Startup logs
+report the capture cost and confirm the active buckets with
+`prefill CUDA graphs attested`.
 
 The current benchmark results were collected with
 `cuda_graph_max_bs_prefill=256`. To reproduce that capture profile and limit

--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -41,12 +41,13 @@ The graph is captured after SGLang's generation graphs. With pre-LM off, raise `
 
 The decoder body uses SGLang's breakable prefill CUDA Graph backend by default.
 Whisper encoder states and cross-attention K/V are prepared outside the captured
-decoder body. The default capture ladder stops at the largest decoder batch
-atomic admission can form: `max_prefill_tokens` divided by one request's
-encoder placeholders plus decoder tokens (1,500 + 232 for every Whisper size),
-times 232 decoder tokens, so 696 with the default 6,144 budget. Startup logs
-report the capture cost and confirm the active buckets with
-`prefill CUDA graphs attested`.
+decoder body. The default capture ladder stops at the largest aggregate decoder
+token count atomic admission can form. The cap considers every reachable request
+count because a batch of more, shorter prompts can contain more decoder tokens
+than a batch sized from the longest possible request. With the default 6,144
+budget, 1,500 encoder placeholders, and at most 232 decoder tokens per request,
+the cap is 696. Startup logs report the capture cost and confirm the active
+buckets with `prefill CUDA graphs attested`.
 
 The current benchmark results were collected with
 `cuda_graph_max_bs_prefill=256`. To reproduce that capture profile and limit

--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -50,11 +50,23 @@ The current benchmark results were collected with
 startup time and GPU memory, set the prefill graph cap explicitly:
 
 ```yaml
-runtime_overrides:
+stages:
   asr:
-    server_args_overrides:
+    engine:
       cuda_graph_max_bs_prefill: 256
 ```
+
+Whisper runs three independently configured graph planes, each bucketed on its
+own axis; cross-attention K/V is written once per request between the first
+two and only read afterwards:
+
+| plane | bucket axis | config |
+|---|---|---|
+| encoder forward | batch size | `enable_encoder_cuda_graph`, encoder graph buckets |
+| decoder prefill body | aggregate prefill tokens | `cuda_graph_backend_prefill`, `cuda_graph_bs_prefill` |
+| decoder decode | batch size | `cuda_graph_bs`, `cuda_graph_max_bs` |
+
+Disabling one plane leaves the other two active.
 
 To disable only the prefill graph while keeping decode and encoder CUDA Graphs
 enabled, override the ASR stage:
@@ -64,9 +76,9 @@ config_cls: WhisperASRPipelineConfig
 name: whisper
 model_path: openai/whisper-large-v3
 
-runtime_overrides:
+stages:
   asr:
-    server_args_overrides:
+    engine:
       cuda_graph_backend_prefill: disabled
 ```
 

--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import dataclasses
 import logging
 from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
+from threading import Lock
 from typing import Any
 
 from sglang.srt.configs.model_config import ModelConfig
@@ -23,6 +25,7 @@ from sglang_omni.utils.gpu_memory import (
 )
 
 logger = logging.getLogger(__name__)
+_PREFILL_RUNNER_OVERRIDE_LOCK = Lock()
 
 
 def filter_weights_by_prefix(
@@ -440,7 +443,8 @@ class SGLModelRunner(ModelRunner):
         from sglang.srt.runtime_context import get_exec, get_flags
 
         get_flags().capture.enable_torch_compile = get_exec().graph.enable_torch_compile
-        result = super().init_cuda_graphs(capture_decode_cuda_graph)
+        with self._prefill_cuda_graph_runner_override():
+            result = super().init_cuda_graphs(capture_decode_cuda_graph)
         if self.token_to_kv_pool.post_capture_active:
             self.post_capture_resize_kv_pool()
         return result
@@ -472,6 +476,40 @@ class SGLModelRunner(ModelRunner):
                 "below max_running_requests that raises the reserved headroom."
             )
         return result
+
+    def _prefill_cuda_graph_runner_cls(self):
+        from sglang.srt.model_executor.cuda_graph_config import (
+            Backend as CudaGraphBackend,
+        )
+
+        if (
+            self._model_arch_override == "WhisperForConditionalGeneration"
+            and self.server_args.cuda_graph_config.prefill.backend
+            == CudaGraphBackend.BREAKABLE
+        ):
+            from sglang_omni.model_runner.whisper_prefill_cuda_graph_runner import (
+                WhisperPrefillCudaGraphRunner,
+            )
+
+            return WhisperPrefillCudaGraphRunner
+        return None
+
+    @contextmanager
+    def _prefill_cuda_graph_runner_override(self):
+        runner_cls = self._prefill_cuda_graph_runner_cls()
+        if runner_cls is None:
+            yield
+            return
+
+        from sglang.srt.model_executor.model_runner_components import cuda_graph_setup
+
+        with _PREFILL_RUNNER_OVERRIDE_LOCK:
+            original = cuda_graph_setup.PrefillCudaGraphRunner
+            cuda_graph_setup.PrefillCudaGraphRunner = runner_cls
+            try:
+                yield
+            finally:
+                cuda_graph_setup.PrefillCudaGraphRunner = original
 
     def _weight_update_blocked_reason(self) -> str | None:
         ws = self._weight_share_config

--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import dataclasses
 import logging
 from collections.abc import Iterator
-from contextlib import contextmanager
 from dataclasses import dataclass
 from threading import Lock
 from typing import Any
@@ -25,7 +24,27 @@ from sglang_omni.utils.gpu_memory import (
 )
 
 logger = logging.getLogger(__name__)
-_PREFILL_RUNNER_OVERRIDE_LOCK = Lock()
+_PREFILL_RUNNER_DISPATCH_LOCK = Lock()
+_PREFILL_RUNNER_DISPATCH_DEFAULT: type | None = None
+
+
+def _install_prefill_runner_dispatch() -> None:
+    """Let each model runner pick its own prefill graph runner class."""
+    global _PREFILL_RUNNER_DISPATCH_DEFAULT
+    from sglang.srt.model_executor.model_runner_components import cuda_graph_setup
+
+    with _PREFILL_RUNNER_DISPATCH_LOCK:
+        if _PREFILL_RUNNER_DISPATCH_DEFAULT is not None:
+            return
+        default_cls = cuda_graph_setup.PrefillCudaGraphRunner
+
+        def _dispatch_prefill_runner(model_runner):
+            select = getattr(model_runner, "_prefill_cuda_graph_runner_cls", None)
+            runner_cls = select() if select is not None else None
+            return (runner_cls or default_cls)(model_runner)
+
+        cuda_graph_setup.PrefillCudaGraphRunner = _dispatch_prefill_runner
+        _PREFILL_RUNNER_DISPATCH_DEFAULT = default_cls
 
 
 def filter_weights_by_prefix(
@@ -443,8 +462,8 @@ class SGLModelRunner(ModelRunner):
         from sglang.srt.runtime_context import get_exec, get_flags
 
         get_flags().capture.enable_torch_compile = get_exec().graph.enable_torch_compile
-        with self._prefill_cuda_graph_runner_override():
-            result = super().init_cuda_graphs(capture_decode_cuda_graph)
+        _install_prefill_runner_dispatch()
+        result = super().init_cuda_graphs(capture_decode_cuda_graph)
         if self.token_to_kv_pool.post_capture_active:
             self.post_capture_resize_kv_pool()
         return result
@@ -493,23 +512,6 @@ class SGLModelRunner(ModelRunner):
 
             return WhisperPrefillCudaGraphRunner
         return None
-
-    @contextmanager
-    def _prefill_cuda_graph_runner_override(self):
-        runner_cls = self._prefill_cuda_graph_runner_cls()
-        if runner_cls is None:
-            yield
-            return
-
-        from sglang.srt.model_executor.model_runner_components import cuda_graph_setup
-
-        with _PREFILL_RUNNER_OVERRIDE_LOCK:
-            original = cuda_graph_setup.PrefillCudaGraphRunner
-            cuda_graph_setup.PrefillCudaGraphRunner = runner_cls
-            try:
-                yield
-            finally:
-                cuda_graph_setup.PrefillCudaGraphRunner = original
 
     def _weight_update_blocked_reason(self) -> str | None:
         ws = self._weight_share_config

--- a/sglang_omni/model_runner/whisper_prefill_cuda_graph_runner.py
+++ b/sglang_omni/model_runner/whisper_prefill_cuda_graph_runner.py
@@ -43,9 +43,7 @@ class WhisperPrefillCudaGraphRunner(PrefillCudaGraphRunner):
         static_forward_batch = super().load_batch(forward_batch, **kwargs)
         static_forward_batch.encoder_lens_cpu = forward_batch.encoder_lens_cpu
         static_forward_batch.encoder_cached = forward_batch.encoder_cached
-        static_forward_batch.encoder_out_cache_loc = (
-            forward_batch.encoder_out_cache_loc
-        )
+        static_forward_batch.encoder_out_cache_loc = forward_batch.encoder_out_cache_loc
         return static_forward_batch
 
 

--- a/sglang_omni/model_runner/whisper_prefill_cuda_graph_runner.py
+++ b/sglang_omni/model_runner/whisper_prefill_cuda_graph_runner.py
@@ -15,6 +15,13 @@ from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
 class WhisperPrefillCudaGraphRunner(PrefillCudaGraphRunner):
     """Preserve encoder-decoder metadata omitted by SGLang's generic runner."""
 
+    def __init__(self, model_runner: Any) -> None:
+        decoder = model_runner.model.model.decoder
+        self_attention_layers = [layer.self_attn.attn for layer in decoder.layers]
+        cross_attention_layers = [layer.encoder_attn.attn for layer in decoder.layers]
+        model_runner.attention_layers = self_attention_layers + cross_attention_layers
+        super().__init__(model_runner)
+
     def capture_prepare(self, num_tokens: int) -> tuple[ForwardBatch, Any]:
         forward_batch, attn_backend = super().capture_prepare(num_tokens)
         encoder_lens_cpu = [1] * forward_batch.batch_size

--- a/sglang_omni/model_runner/whisper_prefill_cuda_graph_runner.py
+++ b/sglang_omni/model_runner/whisper_prefill_cuda_graph_runner.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Whisper-specific metadata adapter for breakable prefill CUDA graphs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
+    PrefillCudaGraphRunner,
+)
+
+
+class WhisperPrefillCudaGraphRunner(PrefillCudaGraphRunner):
+    """Preserve encoder-decoder metadata omitted by SGLang's generic runner."""
+
+    def capture_prepare(self, num_tokens: int) -> tuple[ForwardBatch, Any]:
+        forward_batch, attn_backend = super().capture_prepare(num_tokens)
+        encoder_lens_cpu = [1] * forward_batch.batch_size
+        forward_batch.encoder_lens = torch.tensor(
+            encoder_lens_cpu,
+            dtype=torch.int64,
+            device=self.device,
+        )
+        forward_batch.encoder_lens_cpu = encoder_lens_cpu
+        forward_batch.encoder_cached = [True] * forward_batch.batch_size
+        forward_batch.encoder_out_cache_loc = None
+        return forward_batch, attn_backend
+
+    def load_batch(
+        self,
+        forward_batch: ForwardBatch,
+        **kwargs: Any,
+    ) -> ForwardBatch:
+        static_forward_batch = super().load_batch(forward_batch, **kwargs)
+        static_forward_batch.encoder_lens_cpu = forward_batch.encoder_lens_cpu
+        static_forward_batch.encoder_cached = forward_batch.encoder_cached
+        static_forward_batch.encoder_out_cache_loc = (
+            forward_batch.encoder_out_cache_loc
+        )
+        return static_forward_batch
+
+
+__all__ = ["WhisperPrefillCudaGraphRunner"]

--- a/sglang_omni/model_runner/whisper_prefill_cuda_graph_runner.py
+++ b/sglang_omni/model_runner/whisper_prefill_cuda_graph_runner.py
@@ -20,6 +20,9 @@ class WhisperPrefillCudaGraphRunner(PrefillCudaGraphRunner):
         self_attention_layers = [layer.self_attn.attn for layer in decoder.layers]
         cross_attention_layers = [layer.encoder_attn.attn for layer in decoder.layers]
         model_runner.attention_layers = self_attention_layers + cross_attention_layers
+        # note (Junnan Li): radix_attention indexes this by layer_id, and
+        # cross-attention ids start at num_decoder_layers.
+        model_runner.mha_companion_layers = [None] * len(model_runner.attention_layers)
         super().__init__(model_runner)
 
     def capture_prepare(self, num_tokens: int) -> tuple[ForwardBatch, Any]:

--- a/sglang_omni/models/whisper_asr/engine_builder.py
+++ b/sglang_omni/models/whisper_asr/engine_builder.py
@@ -242,15 +242,10 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
         # Note (Akazaakane): Timestamped Whisper requests install an internal
         # per-request processor; this flag permits SGLang to execute it.
         overrides["enable_custom_logit_processor"] = True
-        if overrides.get("cuda_graph_backend_prefill") == CudaGraphBackend.DISABLED:
-            overrides.pop("cuda_graph_bs_prefill", None)
-            overrides.pop("cuda_graph_max_bs_prefill", None)
-            return
-        if "cuda_graph_bs_prefill" in overrides:
-            overrides.setdefault(
-                "cuda_graph_max_bs_prefill",
-                max(int(size) for size in overrides["cuda_graph_bs_prefill"]),
-            )
+        if (
+            overrides.get("cuda_graph_backend_prefill") == CudaGraphBackend.DISABLED
+            or "cuda_graph_bs_prefill" in overrides
+        ):
             return
 
         cap = min(

--- a/sglang_omni/models/whisper_asr/engine_builder.py
+++ b/sglang_omni/models/whisper_asr/engine_builder.py
@@ -11,10 +11,15 @@ from sglang_omni.models.whisper_asr.encoder_service import (
     build_cache_namespace,
 )
 from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
+from sglang_omni.scheduling.generation_batch_policy import (
+    CudaGraphBackend,
+    build_default_prefill_cuda_graph_bs,
+)
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_ENCODER_GRAPH_BATCH_BUCKETS = (1, 2, 4, 8, 12, 16)
+_WHISPER_PREFILL_GRAPH_MAX_TOKENS = 256
 
 
 def _normalize_encoder_graph_buckets(buckets: list[int] | None) -> tuple[int, ...]:
@@ -62,6 +67,7 @@ def _resolve_encoder_graph_buckets(
 class WhisperASREngineBuilder(AsrEngineBuilder):
     model_name = "Whisper ASR"
     model_arch_override = "WhisperForConditionalGeneration"
+    supports_breakable_prefill_cuda_graph = True
 
     def __init__(
         self,
@@ -236,6 +242,30 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
         # Note (Akazaakane): Timestamped Whisper requests install an internal
         # per-request processor; this flag permits SGLang to execute it.
         overrides["enable_custom_logit_processor"] = True
+        if overrides.get("cuda_graph_backend_prefill") == CudaGraphBackend.DISABLED:
+            overrides.pop("cuda_graph_bs_prefill", None)
+            overrides.pop("cuda_graph_max_bs_prefill", None)
+            return
+        if "cuda_graph_bs_prefill" in overrides:
+            overrides.setdefault(
+                "cuda_graph_max_bs_prefill",
+                max(int(size) for size in overrides["cuda_graph_bs_prefill"]),
+            )
+            return
+
+        cap = min(
+            int(value)
+            for value in (
+                _WHISPER_PREFILL_GRAPH_MAX_TOKENS,
+                overrides.get("max_prefill_tokens"),
+                overrides.get("cuda_graph_max_bs_prefill"),
+                overrides.get("max_total_tokens"),
+            )
+            if value is not None
+        )
+        ladder = build_default_prefill_cuda_graph_bs(cap)
+        overrides["cuda_graph_bs_prefill"] = ladder
+        overrides["cuda_graph_max_bs_prefill"] = max(ladder)
 
     def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
         return {
@@ -248,6 +278,7 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
             "chunked_prefill_size": 0,
             "sampling_backend": "pytorch",
             "dtype": dtype,
+            "cuda_graph_backend_prefill": CudaGraphBackend.BREAKABLE,
         }
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:

--- a/sglang_omni/models/whisper_asr/engine_builder.py
+++ b/sglang_omni/models/whisper_asr/engine_builder.py
@@ -19,7 +19,36 @@ from sglang_omni.scheduling.generation_batch_policy import (
 logger = logging.getLogger(__name__)
 
 _DEFAULT_ENCODER_GRAPH_BATCH_BUCKETS = (1, 2, 4, 8, 12, 16)
-_WHISPER_PREFILL_GRAPH_MAX_TOKENS = 256
+
+
+def _clamp_prefill_cuda_graph_max_bs(
+    overrides: dict[str, Any], *, context_length: int | None
+) -> int | None:
+    """Clamp the prefill graph budget to the reachable token limits.
+
+    Whisper admits its encoder prefix atomically (``chunked_prefill_size=0``),
+    so the shared policy has no chunk to derive a cap from; bound the ladder by
+    the effective prefill, total-token, and model-context limits instead.
+    Returns ``None`` when no limit is known yet (before model setup), leaving
+    the ladder to SGLang's own derivation.
+    """
+    if context_length is None or int(context_length) <= 0:
+        context_length = overrides.get("context_length")
+    caps = [
+        int(value)
+        for value in (
+            overrides.get("cuda_graph_max_bs_prefill"),
+            overrides.get("max_prefill_tokens"),
+            overrides.get("max_total_tokens"),
+            context_length,
+        )
+        if value is not None and int(value) > 0
+    ]
+    if not caps:
+        return None
+    cap = min(caps)
+    overrides["cuda_graph_max_bs_prefill"] = cap
+    return cap
 
 
 def _normalize_encoder_graph_buckets(buckets: list[int] | None) -> tuple[int, ...]:
@@ -248,19 +277,12 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
         ):
             return
 
-        cap = min(
-            int(value)
-            for value in (
-                _WHISPER_PREFILL_GRAPH_MAX_TOKENS,
-                overrides.get("max_prefill_tokens"),
-                overrides.get("cuda_graph_max_bs_prefill"),
-                overrides.get("max_total_tokens"),
-            )
-            if value is not None
+        cap = _clamp_prefill_cuda_graph_max_bs(
+            overrides, context_length=self.context_length
         )
-        ladder = build_default_prefill_cuda_graph_bs(cap)
-        overrides["cuda_graph_bs_prefill"] = ladder
-        overrides["cuda_graph_max_bs_prefill"] = max(ladder)
+        if cap is None:
+            return
+        overrides["cuda_graph_bs_prefill"] = build_default_prefill_cuda_graph_bs(cap)
 
     def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
         return {

--- a/sglang_omni/models/whisper_asr/engine_builder.py
+++ b/sglang_omni/models/whisper_asr/engine_builder.py
@@ -42,11 +42,23 @@ def _reachable_prefill_cuda_graph_max_bs(
     max_prefill_tokens = overrides.get("max_prefill_tokens")
     if encoder_token_count < 1 or not max_prefill_tokens or int(max_prefill_tokens) < 1:
         return None
-    per_request = encoder_token_count + _DECODER_PREFILL_TOKENS_PER_REQUEST
-    batch_requests = max(1, int(max_prefill_tokens) // per_request)
+    budget = int(max_prefill_tokens)
+    request_limit = max(1, budget // encoder_token_count)
     if max_running_requests is not None and int(max_running_requests) >= 1:
-        batch_requests = min(batch_requests, int(max_running_requests))
-    caps = [batch_requests * _DECODER_PREFILL_TOKENS_PER_REQUEST]
+        request_limit = min(request_limit, int(max_running_requests))
+
+    # The first whole request is always admissible. For larger batches, shorter
+    # decoder prompts can admit more requests than the maximum-size request does.
+    decoder_tokens_per_request = _DECODER_PREFILL_TOKENS_PER_REQUEST
+    reachable_cap = decoder_tokens_per_request
+    for request_count in range(1, request_limit + 1):
+        decoder_budget = max(0, budget - request_count * encoder_token_count)
+        reachable_cap = max(
+            reachable_cap,
+            min(request_count * decoder_tokens_per_request, decoder_budget),
+        )
+
+    caps = [reachable_cap]
     for key in ("cuda_graph_max_bs_prefill", "max_prefill_tokens", "max_total_tokens"):
         value = overrides.get(key)
         if value is not None and int(value) > 0:

--- a/sglang_omni/models/whisper_asr/engine_builder.py
+++ b/sglang_omni/models/whisper_asr/engine_builder.py
@@ -10,6 +10,7 @@ from sglang_omni.models.whisper_asr.encoder_service import (
     WhisperPreLMEncoderService,
     build_cache_namespace,
 )
+from sglang_omni.models.whisper_asr.request_builders import MAX_PREV_CONTEXT_TOKENS
 from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
 from sglang_omni.scheduling.generation_batch_policy import (
     CudaGraphBackend,
@@ -21,31 +22,35 @@ logger = logging.getLogger(__name__)
 _DEFAULT_ENCODER_GRAPH_BATCH_BUCKETS = (1, 2, 4, 8, 12, 16)
 
 
-def _clamp_prefill_cuda_graph_max_bs(
-    overrides: dict[str, Any], *, context_length: int | None
-) -> int | None:
-    """Clamp the prefill graph budget to the reachable token limits.
+_TASK_PREFIX_SLACK_TOKENS = 8
+_DECODER_PREFILL_TOKENS_PER_REQUEST = (
+    MAX_PREV_CONTEXT_TOKENS + _TASK_PREFIX_SLACK_TOKENS
+)
 
-    Whisper admits its encoder prefix atomically (``chunked_prefill_size=0``),
-    so the shared policy has no chunk to derive a cap from; bound the ladder by
-    the effective prefill, total-token, and model-context limits instead.
-    Returns ``None`` when no limit is known yet (before model setup), leaving
-    the ladder to SGLang's own derivation.
+
+def _reachable_prefill_cuda_graph_max_bs(
+    overrides: dict[str, Any],
+    *,
+    encoder_token_count: int,
+    max_running_requests: int | None,
+) -> int | None:
+    """Cap the prefill graph ladder at the largest decoder batch admission can form.
+
+    Admission charges each request its encoder placeholders as well, while the
+    graph sees only the admitted requests' decoder tokens.
     """
-    if context_length is None or int(context_length) <= 0:
-        context_length = overrides.get("context_length")
-    caps = [
-        int(value)
-        for value in (
-            overrides.get("cuda_graph_max_bs_prefill"),
-            overrides.get("max_prefill_tokens"),
-            overrides.get("max_total_tokens"),
-            context_length,
-        )
-        if value is not None and int(value) > 0
-    ]
-    if not caps:
+    max_prefill_tokens = overrides.get("max_prefill_tokens")
+    if encoder_token_count < 1 or not max_prefill_tokens or int(max_prefill_tokens) < 1:
         return None
+    per_request = encoder_token_count + _DECODER_PREFILL_TOKENS_PER_REQUEST
+    batch_requests = max(1, int(max_prefill_tokens) // per_request)
+    if max_running_requests is not None and int(max_running_requests) >= 1:
+        batch_requests = min(batch_requests, int(max_running_requests))
+    caps = [batch_requests * _DECODER_PREFILL_TOKENS_PER_REQUEST]
+    for key in ("cuda_graph_max_bs_prefill", "max_prefill_tokens", "max_total_tokens"):
+        value = overrides.get(key)
+        if value is not None and int(value) > 0:
+            caps.append(int(value))
     cap = min(caps)
     overrides["cuda_graph_max_bs_prefill"] = cap
     return cap
@@ -171,10 +176,6 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
     def pre_infra_setup(self, checkpoint_dir: str) -> None:
         from transformers import AutoConfig, AutoProcessor, GenerationConfig
 
-        from sglang_omni.models.whisper_asr.request_builders import (
-            MAX_PREV_CONTEXT_TOKENS,
-        )
-
         self.processor = AutoProcessor.from_pretrained(checkpoint_dir)
         self.tokenizer = self.processor.tokenizer
         self.generation_config = GenerationConfig.from_pretrained(checkpoint_dir)
@@ -182,7 +183,10 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
             self.processor.feature_extractor.nb_max_frames // 2
         )
         self.context_length = (
-            self.encoder_token_count + MAX_PREV_CONTEXT_TOKENS + self.max_new_tokens + 8
+            self.encoder_token_count
+            + MAX_PREV_CONTEXT_TOKENS
+            + self.max_new_tokens
+            + _TASK_PREFIX_SLACK_TOKENS
         )
         self.decoder_context_len = int(
             AutoConfig.from_pretrained(checkpoint_dir).max_target_positions or 448
@@ -277,8 +281,10 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
         ):
             return
 
-        cap = _clamp_prefill_cuda_graph_max_bs(
-            overrides, context_length=self.context_length
+        cap = _reachable_prefill_cuda_graph_max_bs(
+            overrides,
+            encoder_token_count=self.encoder_token_count,
+            max_running_requests=overrides.get("max_running_requests"),
         )
         if cap is None:
             return

--- a/sglang_omni/models/whisper_asr/engine_builder.py
+++ b/sglang_omni/models/whisper_asr/engine_builder.py
@@ -28,6 +28,41 @@ _DECODER_PREFILL_TOKENS_PER_REQUEST = (
 )
 
 
+def _max_reachable_decoder_prefill_tokens(
+    *,
+    budget: int,
+    encoder_token_count: int,
+    request_limit: int,
+) -> int:
+    """Return the largest decoder-token batch allowed by atomic admission."""
+    max_request_tokens = (
+        encoder_token_count + _DECODER_PREFILL_TOKENS_PER_REQUEST
+    )
+    lower_request_count = min(
+        request_limit,
+        max(1, budget // max_request_tokens),
+    )
+    upper_request_count = min(
+        request_limit,
+        max(1, (budget + max_request_tokens - 1) // max_request_tokens),
+    )
+
+    # note (xuanyili): This is the O(1) equivalent of enumerating request_count
+    # and maximizing min(request_count * decoder_tokens,
+    # budget - request_count * encoder_tokens). The lower envelope of those
+    # increasing and decreasing lines peaks next to their intersection.
+    lower_cap = min(
+        lower_request_count * _DECODER_PREFILL_TOKENS_PER_REQUEST,
+        max(0, budget - lower_request_count * encoder_token_count),
+    )
+    upper_cap = min(
+        upper_request_count * _DECODER_PREFILL_TOKENS_PER_REQUEST,
+        max(0, budget - upper_request_count * encoder_token_count),
+    )
+    # The scheduler always admits the first whole request.
+    return max(_DECODER_PREFILL_TOKENS_PER_REQUEST, lower_cap, upper_cap)
+
+
 def _reachable_prefill_cuda_graph_max_bs(
     overrides: dict[str, Any],
     *,
@@ -47,18 +82,13 @@ def _reachable_prefill_cuda_graph_max_bs(
     if max_running_requests is not None and int(max_running_requests) >= 1:
         request_limit = min(request_limit, int(max_running_requests))
 
-    # The first whole request is always admissible. For larger batches, shorter
-    # decoder prompts can admit more requests than the maximum-size request does.
-    decoder_tokens_per_request = _DECODER_PREFILL_TOKENS_PER_REQUEST
-    reachable_cap = decoder_tokens_per_request
-    for request_count in range(1, request_limit + 1):
-        decoder_budget = max(0, budget - request_count * encoder_token_count)
-        reachable_cap = max(
-            reachable_cap,
-            min(request_count * decoder_tokens_per_request, decoder_budget),
+    caps = [
+        _max_reachable_decoder_prefill_tokens(
+            budget=budget,
+            encoder_token_count=encoder_token_count,
+            request_limit=request_limit,
         )
-
-    caps = [reachable_cap]
+    ]
     for key in ("cuda_graph_max_bs_prefill", "max_prefill_tokens", "max_total_tokens"):
         value = overrides.get(key)
         if value is not None and int(value) > 0:

--- a/sglang_omni/models/whisper_asr/engine_builder.py
+++ b/sglang_omni/models/whisper_asr/engine_builder.py
@@ -35,9 +35,7 @@ def _max_reachable_decoder_prefill_tokens(
     request_limit: int,
 ) -> int:
     """Return the largest decoder-token batch allowed by atomic admission."""
-    max_request_tokens = (
-        encoder_token_count + _DECODER_PREFILL_TOKENS_PER_REQUEST
-    )
+    max_request_tokens = encoder_token_count + _DECODER_PREFILL_TOKENS_PER_REQUEST
     lower_request_count = min(
         request_limit,
         max(1, budget // max_request_tokens),

--- a/sglang_omni/models/whisper_asr/sglang_model.py
+++ b/sglang_omni/models/whisper_asr/sglang_model.py
@@ -19,7 +19,9 @@ import torch.nn.functional as F
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.forward_context import get_attn_backend
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from torch import nn
 from transformers import WhisperConfig
@@ -207,6 +209,7 @@ class WhisperSGLangSelfAttention(nn.Module):
         key = key.view(-1, self.num_heads, self.head_dim)
         value = value.view(-1, self.num_heads, self.head_dim)
         attn_output = self.attn(query, key, value, forward_batch)
+        attn_output = attn_output.reshape(hidden_states.shape[:-1] + (self.embed_dim,))
         return self.out_proj(attn_output)
 
 
@@ -238,20 +241,29 @@ class WhisperSGLangCrossAttention(nn.Module):
             is_cross_attention=True,
         )
 
+    def cache_encoder_states(
+        self,
+        cross_attention_states: torch.Tensor,
+        cache_loc: torch.Tensor,
+    ) -> None:
+        key, value = self.kv_proj(cross_attention_states).chunk(2, dim=-1)
+        key = key.view(-1, self.num_heads, self.head_dim)
+        value = value.view(-1, self.num_heads, self.head_dim)
+        get_attn_backend().token_to_kv_pool.set_kv_buffer(
+            self.attn,
+            KVWriteLoc(cache_loc),
+            key,
+            value,
+        )
+
     def forward(
         self,
         hidden_states: torch.Tensor,
-        cross_attention_states: torch.Tensor | None,
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         query = self.q_proj(hidden_states).view(-1, self.num_heads, self.head_dim)
-        if cross_attention_states is None:
-            key = value = None
-        else:
-            key, value = self.kv_proj(cross_attention_states).chunk(2, dim=-1)
-            key = key.view(-1, self.num_heads, self.head_dim)
-            value = value.view(-1, self.num_heads, self.head_dim)
-        attn_output = self.attn(query, key, value, forward_batch)
+        attn_output = self.attn(query, None, None, forward_batch)
+        attn_output = attn_output.reshape(hidden_states.shape[:-1] + (self.embed_dim,))
         return self.out_proj(attn_output)
 
 
@@ -284,24 +296,17 @@ class WhisperDecoderLayer(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        cross_attention_states: torch.Tensor | None,
         forward_batch: ForwardBatch,
-        skip_cross_attention: bool,
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.self_attn_layer_norm(hidden_states)
         hidden_states = self.self_attn(hidden_states, forward_batch)
         hidden_states = residual + hidden_states
 
-        if not skip_cross_attention:
-            residual = hidden_states
-            hidden_states = self.encoder_attn_layer_norm(hidden_states)
-            hidden_states = self.encoder_attn(
-                hidden_states,
-                cross_attention_states,
-                forward_batch,
-            )
-            hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = self.encoder_attn_layer_norm(hidden_states)
+        hidden_states = self.encoder_attn(hidden_states, forward_batch)
+        hidden_states = residual + hidden_states
 
         residual = hidden_states
         hidden_states = self.final_layer_norm(hidden_states)
@@ -333,22 +338,25 @@ class WhisperDecoder(nn.Module):
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,
-        cross_attention_states: torch.Tensor | None,
         forward_batch: ForwardBatch,
-        skip_cross_attention: bool,
+        input_embeds: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        hidden_states = self.embed_tokens(input_ids)
-        hidden_states = hidden_states + self.embed_positions(positions).to(
-            hidden_states.device
+        hidden_states = (
+            self.embed_input_ids(input_ids, positions)
+            if input_embeds is None
+            else input_embeds
         )
         for layer in self.layers:
-            hidden_states = layer(
-                hidden_states,
-                cross_attention_states,
-                forward_batch,
-                skip_cross_attention,
-            )
+            hidden_states = layer(hidden_states, forward_batch)
         return self.layer_norm(hidden_states)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> torch.Tensor:
+        hidden_states = self.embed_tokens(input_ids)
+        return hidden_states + self.embed_positions(positions).to(hidden_states.device)
 
 
 class WhisperModel(nn.Module):
@@ -360,6 +368,32 @@ class WhisperModel(nn.Module):
         super().__init__()
         self.encoder = WhisperEncoder(config)
         self.decoder = WhisperDecoder(config, quant_config=quant_config)
+
+    @property
+    def layers(self) -> nn.ModuleList:
+        return self.decoder.layers
+
+    def cache_encoder_states(
+        self,
+        encoder_states: torch.Tensor,
+        cache_loc: torch.Tensor,
+    ) -> None:
+        for layer in self.decoder.layers:
+            layer.encoder_attn.cache_encoder_states(encoder_states, cache_loc)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return self.decoder(
+            input_ids,
+            positions,
+            forward_batch,
+            input_embeds=input_embeds,
+        )
 
 
 class WhisperForConditionalGeneration(nn.Module):
@@ -507,9 +541,6 @@ class WhisperForConditionalGeneration(nn.Module):
         **kwargs: Any,
     ) -> Any:
         del kwargs
-        from sglang.srt.model_executor.runner_utils.capture_mode import (
-            get_is_capture_mode,
-        )
 
         cross_attention_states = self._batch_precomputed_encoder_states(forward_batch)
         if cross_attention_states is None:
@@ -521,17 +552,18 @@ class WhisperForConditionalGeneration(nn.Module):
                     encoder_lens,
                 )
 
-        if get_is_capture_mode():
-            skip_cross_attention = False
-        else:
-            skip_cross_attention = forward_batch.encoder_lens.max() == 0
+        if cross_attention_states is not None:
+            self.model.cache_encoder_states(
+                cross_attention_states,
+                forward_batch.encoder_out_cache_loc,
+            )
 
-        hidden_states = self.model.decoder(
-            input_ids=input_ids,
-            positions=positions,
-            cross_attention_states=cross_attention_states,
-            forward_batch=forward_batch,
-            skip_cross_attention=skip_cross_attention,
+        input_embeds = self.model.decoder.embed_input_ids(input_ids, positions)
+        hidden_states = self.model(
+            input_ids,
+            positions,
+            forward_batch,
+            input_embeds=input_embeds,
         )
         return self.logits_processor(
             input_ids, hidden_states, self.lm_head, forward_batch

--- a/sglang_omni/models/whisper_asr/sglang_model.py
+++ b/sglang_omni/models/whisper_asr/sglang_model.py
@@ -17,7 +17,9 @@ import torch.nn.functional as F
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.forward_context import get_attn_backend
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from torch import nn
 from transformers import WhisperConfig
@@ -182,6 +184,7 @@ class WhisperSGLangSelfAttention(nn.Module):
         key = key.view(-1, self.num_heads, self.head_dim)
         value = value.view(-1, self.num_heads, self.head_dim)
         attn_output = self.attn(query, key, value, forward_batch)
+        attn_output = attn_output.reshape(hidden_states.shape[:-1] + (self.embed_dim,))
         return self.out_proj(attn_output)
 
 
@@ -213,20 +216,29 @@ class WhisperSGLangCrossAttention(nn.Module):
             is_cross_attention=True,
         )
 
+    def cache_encoder_states(
+        self,
+        cross_attention_states: torch.Tensor,
+        cache_loc: torch.Tensor,
+    ) -> None:
+        key, value = self.kv_proj(cross_attention_states).chunk(2, dim=-1)
+        key = key.view(-1, self.num_heads, self.head_dim)
+        value = value.view(-1, self.num_heads, self.head_dim)
+        get_attn_backend().token_to_kv_pool.set_kv_buffer(
+            self.attn,
+            KVWriteLoc(cache_loc),
+            key,
+            value,
+        )
+
     def forward(
         self,
         hidden_states: torch.Tensor,
-        cross_attention_states: torch.Tensor | None,
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         query = self.q_proj(hidden_states).view(-1, self.num_heads, self.head_dim)
-        if cross_attention_states is None:
-            key = value = None
-        else:
-            key, value = self.kv_proj(cross_attention_states).chunk(2, dim=-1)
-            key = key.view(-1, self.num_heads, self.head_dim)
-            value = value.view(-1, self.num_heads, self.head_dim)
-        attn_output = self.attn(query, key, value, forward_batch)
+        attn_output = self.attn(query, None, None, forward_batch)
+        attn_output = attn_output.reshape(hidden_states.shape[:-1] + (self.embed_dim,))
         return self.out_proj(attn_output)
 
 
@@ -259,24 +271,17 @@ class WhisperDecoderLayer(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        cross_attention_states: torch.Tensor | None,
         forward_batch: ForwardBatch,
-        skip_cross_attention: bool,
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.self_attn_layer_norm(hidden_states)
         hidden_states = self.self_attn(hidden_states, forward_batch)
         hidden_states = residual + hidden_states
 
-        if not skip_cross_attention:
-            residual = hidden_states
-            hidden_states = self.encoder_attn_layer_norm(hidden_states)
-            hidden_states = self.encoder_attn(
-                hidden_states,
-                cross_attention_states,
-                forward_batch,
-            )
-            hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = self.encoder_attn_layer_norm(hidden_states)
+        hidden_states = self.encoder_attn(hidden_states, forward_batch)
+        hidden_states = residual + hidden_states
 
         residual = hidden_states
         hidden_states = self.final_layer_norm(hidden_states)
@@ -308,22 +313,25 @@ class WhisperDecoder(nn.Module):
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,
-        cross_attention_states: torch.Tensor | None,
         forward_batch: ForwardBatch,
-        skip_cross_attention: bool,
+        input_embeds: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        hidden_states = self.embed_tokens(input_ids)
-        hidden_states = hidden_states + self.embed_positions(positions).to(
-            hidden_states.device
+        hidden_states = (
+            self.embed_input_ids(input_ids, positions)
+            if input_embeds is None
+            else input_embeds
         )
         for layer in self.layers:
-            hidden_states = layer(
-                hidden_states,
-                cross_attention_states,
-                forward_batch,
-                skip_cross_attention,
-            )
+            hidden_states = layer(hidden_states, forward_batch)
         return self.layer_norm(hidden_states)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> torch.Tensor:
+        hidden_states = self.embed_tokens(input_ids)
+        return hidden_states + self.embed_positions(positions).to(hidden_states.device)
 
 
 class WhisperModel(nn.Module):
@@ -335,6 +343,32 @@ class WhisperModel(nn.Module):
         super().__init__()
         self.encoder = WhisperEncoder(config)
         self.decoder = WhisperDecoder(config, quant_config=quant_config)
+
+    @property
+    def layers(self) -> nn.ModuleList:
+        return self.decoder.layers
+
+    def cache_encoder_states(
+        self,
+        encoder_states: torch.Tensor,
+        cache_loc: torch.Tensor,
+    ) -> None:
+        for layer in self.decoder.layers:
+            layer.encoder_attn.cache_encoder_states(encoder_states, cache_loc)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return self.decoder(
+            input_ids,
+            positions,
+            forward_batch,
+            input_embeds=input_embeds,
+        )
 
 
 class WhisperForConditionalGeneration(nn.Module):
@@ -482,9 +516,6 @@ class WhisperForConditionalGeneration(nn.Module):
         **kwargs: Any,
     ) -> Any:
         del kwargs
-        from sglang.srt.model_executor.runner_utils.capture_mode import (
-            get_is_capture_mode,
-        )
 
         cross_attention_states = self._batch_precomputed_encoder_states(forward_batch)
         if cross_attention_states is None:
@@ -496,17 +527,18 @@ class WhisperForConditionalGeneration(nn.Module):
                     encoder_lens,
                 )
 
-        if get_is_capture_mode():
-            skip_cross_attention = False
-        else:
-            skip_cross_attention = forward_batch.encoder_lens.max() == 0
+        if cross_attention_states is not None:
+            self.model.cache_encoder_states(
+                cross_attention_states,
+                forward_batch.encoder_out_cache_loc,
+            )
 
-        hidden_states = self.model.decoder(
-            input_ids=input_ids,
-            positions=positions,
-            cross_attention_states=cross_attention_states,
-            forward_batch=forward_batch,
-            skip_cross_attention=skip_cross_attention,
+        input_embeds = self.model.decoder.embed_input_ids(input_ids, positions)
+        hidden_states = self.model(
+            input_ids,
+            positions,
+            forward_batch,
+            input_embeds=input_embeds,
         )
         return self.logits_processor(
             input_ids, hidden_states, self.lm_head, forward_batch

--- a/tests/unit_test/whisper_asr/test_decoder_cache.py
+++ b/tests/unit_test/whisper_asr/test_decoder_cache.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+import torch
+from transformers import WhisperConfig
+
+from sglang_omni.models.whisper_asr import sglang_model
+from sglang_omni.models.whisper_asr.sglang_model import (
+    WhisperForConditionalGeneration,
+    WhisperModel,
+    WhisperSGLangCrossAttention,
+    WhisperSGLangSelfAttention,
+)
+
+
+def _tiny_whisper_config() -> WhisperConfig:
+    return WhisperConfig(
+        d_model=8,
+        encoder_layers=1,
+        decoder_layers=1,
+        encoder_attention_heads=2,
+        decoder_attention_heads=2,
+        encoder_ffn_dim=16,
+        decoder_ffn_dim=16,
+        vocab_size=32,
+        max_source_positions=8,
+        max_target_positions=8,
+        num_mel_bins=4,
+    )
+
+
+def test_whisper_model_exposes_decoder_body() -> None:
+    model = WhisperModel(_tiny_whisper_config())
+
+    assert model.layers is model.decoder.layers
+    assert "input_embeds" in inspect.signature(model.forward).parameters
+
+
+def test_whisper_cross_attention_caches_fused_encoder_kv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attention = WhisperSGLangCrossAttention(_tiny_whisper_config(), layer_id=1)
+    encoder_states = torch.randn(3, attention.embed_dim)
+    cache_loc = torch.arange(3, dtype=torch.int64)
+    writes: list[tuple[object, object, torch.Tensor, torch.Tensor]] = []
+    token_to_kv_pool = SimpleNamespace(
+        set_kv_buffer=lambda layer, loc, key, value: writes.append(
+            (layer, loc, key, value)
+        )
+    )
+    monkeypatch.setattr(
+        sglang_model,
+        "get_attn_backend",
+        lambda: SimpleNamespace(token_to_kv_pool=token_to_kv_pool),
+    )
+
+    attention.cache_encoder_states(encoder_states, cache_loc)
+
+    layer, write_loc, key, value = writes[0]
+    expected_key, expected_value = attention.kv_proj(encoder_states).chunk(2, dim=-1)
+    assert layer is attention.attn
+    assert write_loc.loc is cache_loc
+    torch.testing.assert_close(
+        key, expected_key.view(-1, attention.num_heads, attention.head_dim)
+    )
+    torch.testing.assert_close(
+        value, expected_value.view(-1, attention.num_heads, attention.head_dim)
+    )
+
+
+@pytest.mark.parametrize(
+    "attention_cls",
+    [WhisperSGLangSelfAttention, WhisperSGLangCrossAttention],
+)
+def test_whisper_attention_flattens_head_shaped_backend_output(
+    attention_cls: type[torch.nn.Module],
+) -> None:
+    class _HeadShapedAttention(torch.nn.Module):
+        def forward(self, query, key, value, forward_batch):
+            del key, value, forward_batch
+            return query
+
+    attention = attention_cls(_tiny_whisper_config(), layer_id=0)
+    attention.attn = _HeadShapedAttention()
+    attention.out_proj = torch.nn.Identity()
+    hidden_states = torch.randn(3, attention.embed_dim)
+
+    output = attention(hidden_states, SimpleNamespace())
+
+    assert output.shape == hidden_states.shape
+
+
+@pytest.mark.parametrize("use_precomputed_states", [True, False])
+def test_whisper_forward_caches_encoder_kv_before_decoder(
+    monkeypatch: pytest.MonkeyPatch,
+    use_precomputed_states: bool,
+) -> None:
+    class _LogitsProcessor(torch.nn.Module):
+        def forward(self, *args):
+            calls.append("logits")
+            return args[1]
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        sglang_model,
+        "LogitsProcessor",
+        lambda _config: _LogitsProcessor(),
+    )
+    model = WhisperForConditionalGeneration(_tiny_whisper_config())
+    input_ids = torch.tensor([1, 2])
+    positions = torch.tensor([0, 1])
+    encoder_states = torch.randn(3, model.config.d_model)
+    forward_batch = SimpleNamespace(
+        encoder_out_cache_loc=torch.arange(3, dtype=torch.int64)
+    )
+
+    monkeypatch.setattr(
+        model,
+        "_batch_precomputed_encoder_states",
+        lambda batch: encoder_states if use_precomputed_states else None,
+    )
+    monkeypatch.setattr(
+        model,
+        "_batch_audio_inputs",
+        lambda batch: (torch.randn(1, 4, 4), [3]),
+    )
+    monkeypatch.setattr(
+        model,
+        "_run_encoder",
+        lambda features: encoder_states.unsqueeze(0),
+    )
+    monkeypatch.setattr(
+        model.model,
+        "cache_encoder_states",
+        lambda states, loc: calls.append("cache"),
+    )
+    monkeypatch.setattr(
+        model.model.decoder,
+        "embed_input_ids",
+        lambda ids, pos: torch.randn(ids.shape[0], model.config.d_model),
+    )
+    monkeypatch.setattr(
+        model.model,
+        "forward",
+        lambda *args, **kwargs: calls.append("decoder")
+        or torch.randn(input_ids.shape[0], model.config.d_model),
+    )
+
+    model(input_ids, positions, forward_batch)
+
+    assert calls == ["cache", "decoder", "logits"]

--- a/tests/unit_test/whisper_asr/test_pipeline.py
+++ b/tests/unit_test/whisper_asr/test_pipeline.py
@@ -21,6 +21,7 @@ from sglang_omni.models.whisper_asr.config import WhisperASRPipelineConfig
 from sglang_omni.scheduling.generation_batch_policy import (
     CudaGraphBackend,
     build_default_prefill_cuda_graph_bs,
+    build_generation_batch_overrides,
 )
 
 
@@ -169,41 +170,22 @@ def test_whisper_disables_chunked_prefill_for_atomic_encoder_prefix() -> None:
         builder.adjust_overrides({"chunked_prefill_size": 4096})
 
 
-@pytest.mark.parametrize(
-    ("overrides", "expected_prefill_bs"),
-    [
-        ({}, build_default_prefill_cuda_graph_bs(256)),
-        (
-            {"cuda_graph_max_bs_prefill": 128},
-            build_default_prefill_cuda_graph_bs(128),
-        ),
-        ({"cuda_graph_bs_prefill": [128, 256]}, [128, 256]),
-        ({"cuda_graph_backend_prefill": CudaGraphBackend.DISABLED}, None),
-    ],
-)
-def test_whisper_breakable_prefill_graph_policy(
-    overrides: dict[str, object],
-    expected_prefill_bs: list[int] | None,
-) -> None:
+def test_whisper_breakable_prefill_graph_policy() -> None:
     builder = whisper_asr_builder.WhisperASREngineBuilder(
         max_running_requests=4,
         max_new_tokens=32,
         mem_fraction_static=0.2,
     )
-    merged = {**builder.generation_defaults(dtype="float16"), **overrides}
+    merged = build_generation_batch_overrides(
+        **builder.generation_defaults(dtype="float16"),
+    )
 
     builder.adjust_overrides(merged)
 
     assert builder.supports_breakable_prefill_cuda_graph
-    assert merged["cuda_graph_backend_prefill"] == (
-        overrides.get("cuda_graph_backend_prefill", CudaGraphBackend.BREAKABLE)
-    )
-    if expected_prefill_bs is None:
-        assert "cuda_graph_bs_prefill" not in merged
-        assert "cuda_graph_max_bs_prefill" not in merged
-    else:
-        assert merged["cuda_graph_bs_prefill"] == expected_prefill_bs
-        assert merged["cuda_graph_max_bs_prefill"] == max(expected_prefill_bs)
+    assert merged["cuda_graph_backend_prefill"] == CudaGraphBackend.BREAKABLE
+    assert merged["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(256)
+    assert merged["cuda_graph_max_bs_prefill"] == 256
 
 
 def test_whisper_prefill_coalescing_defaults_are_forwarded() -> None:

--- a/tests/unit_test/whisper_asr/test_pipeline.py
+++ b/tests/unit_test/whisper_asr/test_pipeline.py
@@ -13,9 +13,15 @@ import sglang_omni.models.whisper_asr.stages as whisper_asr_stages
 import sglang_omni.scheduling.bootstrap as bootstrap
 import sglang_omni.scheduling.omni_scheduler as omni_scheduler
 import sglang_omni.scheduling.sglang_backend as sglang_backend
+import sglang_omni.utils.cuda_graph_batch_validator as cuda_graph_batch_validator
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+from sglang_omni.models.whisper_asr import engine_builder as whisper_asr_builder
 from sglang_omni.models.whisper_asr import request_builders as whisper_request_builders
 from sglang_omni.models.whisper_asr.config import WhisperASRPipelineConfig
+from sglang_omni.scheduling.generation_batch_policy import (
+    CudaGraphBackend,
+    build_default_prefill_cuda_graph_bs,
+)
 
 
 def _encoder_graph_builder(**kwargs):
@@ -163,6 +169,43 @@ def test_whisper_disables_chunked_prefill_for_atomic_encoder_prefix() -> None:
         builder.adjust_overrides({"chunked_prefill_size": 4096})
 
 
+@pytest.mark.parametrize(
+    ("overrides", "expected_prefill_bs"),
+    [
+        ({}, build_default_prefill_cuda_graph_bs(256)),
+        (
+            {"cuda_graph_max_bs_prefill": 128},
+            build_default_prefill_cuda_graph_bs(128),
+        ),
+        ({"cuda_graph_bs_prefill": [128, 256]}, [128, 256]),
+        ({"cuda_graph_backend_prefill": CudaGraphBackend.DISABLED}, None),
+    ],
+)
+def test_whisper_breakable_prefill_graph_policy(
+    overrides: dict[str, object],
+    expected_prefill_bs: list[int] | None,
+) -> None:
+    builder = whisper_asr_builder.WhisperASREngineBuilder(
+        max_running_requests=4,
+        max_new_tokens=32,
+        mem_fraction_static=0.2,
+    )
+    merged = {**builder.generation_defaults(dtype="float16"), **overrides}
+
+    builder.adjust_overrides(merged)
+
+    assert builder.supports_breakable_prefill_cuda_graph
+    assert merged["cuda_graph_backend_prefill"] == (
+        overrides.get("cuda_graph_backend_prefill", CudaGraphBackend.BREAKABLE)
+    )
+    if expected_prefill_bs is None:
+        assert "cuda_graph_bs_prefill" not in merged
+        assert "cuda_graph_max_bs_prefill" not in merged
+    else:
+        assert merged["cuda_graph_bs_prefill"] == expected_prefill_bs
+        assert merged["cuda_graph_max_bs_prefill"] == max(expected_prefill_bs)
+
+
 def test_whisper_prefill_coalescing_defaults_are_forwarded() -> None:
     from sglang_omni.models.whisper_asr.engine_builder import WhisperASREngineBuilder
 
@@ -262,6 +305,8 @@ def test_whisper_async_decode_dotted_overrides() -> None:
 def test_whisper_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
     build_kwargs: dict[str, object] = {}
     scheduler_kwargs: dict[str, object] = {}
+    graph_init_calls: list[object] = []
+    attest_calls: list[tuple[object, object]] = []
     fake_processor = SimpleNamespace(
         tokenizer=object(),
         feature_extractor=SimpleNamespace(nb_max_frames=3000),
@@ -314,13 +359,25 @@ def test_whisper_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
                 max_bs=overrides["cuda_graph_max_bs"],
                 bs=overrides["cuda_graph_bs"],
             ),
-            prefill=SimpleNamespace(backend="disabled", bs=None, max_bs=None),
+            prefill=SimpleNamespace(
+                backend=overrides.get("cuda_graph_backend_prefill", "disabled"),
+                bs=overrides.get("cuda_graph_bs_prefill"),
+                max_bs=overrides.get("cuda_graph_max_bs_prefill"),
+            ),
         )
+        server_args._cuda_graph_config_locked = {
+            ("prefill", field)
+            for field, key in (
+                ("backend", "cuda_graph_backend_prefill"),
+                ("bs", "cuda_graph_bs_prefill"),
+            )
+            if key in overrides
+        }
         return server_args
 
     def _fake_create_infrastructure(server_args, gpu_id, **kwargs):
         model_worker = SimpleNamespace(model_runner=SimpleNamespace(model=object()))
-        return False, (
+        return True, (
             model_worker,
             object(),
             object(),
@@ -337,6 +394,18 @@ def test_whisper_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
         bootstrap,
         "create_sglang_infrastructure_defer_cuda_graph",
         _fake_create_infrastructure,
+    )
+    monkeypatch.setattr(
+        bootstrap,
+        "init_sglang_cuda_graphs",
+        lambda model_worker: graph_init_calls.append(model_worker),
+    )
+    monkeypatch.setattr(
+        cuda_graph_batch_validator,
+        "attest_prefill_cuda_graphs",
+        lambda model_runner, server_args: attest_calls.append(
+            (model_runner, server_args)
+        ),
     )
 
     whisper_asr_stages.create_sglang_whisper_asr_executor(
@@ -355,3 +424,9 @@ def test_whisper_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
     assert build_kwargs["max_prefill_tokens"] == 6144
     assert scheduler_kwargs["enable_async_decode"] is False
     assert scheduler_kwargs["async_decode_min_batch_size"] == 4
+    assert build_kwargs["cuda_graph_backend_prefill"] == CudaGraphBackend.BREAKABLE
+    assert build_kwargs["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(
+        256
+    )
+    assert len(graph_init_calls) == 1
+    assert len(attest_calls) == 1

--- a/tests/unit_test/whisper_asr/test_pipeline.py
+++ b/tests/unit_test/whisper_asr/test_pipeline.py
@@ -176,6 +176,7 @@ def test_whisper_breakable_prefill_graph_policy() -> None:
         max_new_tokens=32,
         mem_fraction_static=0.2,
     )
+    builder.context_length = 1764
     merged = build_generation_batch_overrides(
         **builder.generation_defaults(dtype="float16"),
     )
@@ -184,8 +185,8 @@ def test_whisper_breakable_prefill_graph_policy() -> None:
 
     assert builder.supports_breakable_prefill_cuda_graph
     assert merged["cuda_graph_backend_prefill"] == CudaGraphBackend.BREAKABLE
-    assert merged["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(256)
-    assert merged["cuda_graph_max_bs_prefill"] == 256
+    assert merged["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(1764)
+    assert merged["cuda_graph_max_bs_prefill"] == 1764
 
 
 def test_whisper_prefill_coalescing_defaults_are_forwarded() -> None:

--- a/tests/unit_test/whisper_asr/test_pipeline.py
+++ b/tests/unit_test/whisper_asr/test_pipeline.py
@@ -199,6 +199,26 @@ def test_whisper_breakable_prefill_graph_policy() -> None:
     )
 
 
+def test_whisper_prefill_graph_cap_covers_shorter_request_batches() -> None:
+    builder = whisper_asr_builder.WhisperASREngineBuilder(
+        max_running_requests=3,
+        max_new_tokens=256,
+        mem_fraction_static=0.2,
+    )
+    builder.encoder_token_count = 1500
+    merged = build_generation_batch_overrides(
+        **builder.generation_defaults(dtype="float16"),
+        server_args_overrides={"max_prefill_tokens": 5120},
+    )
+
+    builder.adjust_overrides(merged)
+
+    assert merged["cuda_graph_max_bs_prefill"] == 620
+    assert 3 * 192 <= merged["cuda_graph_max_bs_prefill"]
+    assert 3 * 192 in merged["cuda_graph_bs_prefill"]
+    assert merged["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(620)
+
+
 def test_whisper_prefill_coalescing_defaults_are_forwarded() -> None:
     from sglang_omni.models.whisper_asr.engine_builder import WhisperASREngineBuilder
 

--- a/tests/unit_test/whisper_asr/test_pipeline.py
+++ b/tests/unit_test/whisper_asr/test_pipeline.py
@@ -176,7 +176,7 @@ def test_whisper_breakable_prefill_graph_policy() -> None:
         max_new_tokens=32,
         mem_fraction_static=0.2,
     )
-    builder.context_length = 1764
+    builder.encoder_token_count = 1500
     merged = build_generation_batch_overrides(
         **builder.generation_defaults(dtype="float16"),
     )
@@ -185,8 +185,18 @@ def test_whisper_breakable_prefill_graph_policy() -> None:
 
     assert builder.supports_breakable_prefill_cuda_graph
     assert merged["cuda_graph_backend_prefill"] == CudaGraphBackend.BREAKABLE
-    assert merged["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(1764)
-    assert merged["cuda_graph_max_bs_prefill"] == 1764
+    max_prefill_tokens = merged["max_prefill_tokens"]
+    encoder_tokens, decoder_tokens_per_request = 1500, 224 + 8
+    admitted_requests = max_prefill_tokens // (
+        encoder_tokens + decoder_tokens_per_request
+    )
+    assert admitted_requests == 3
+    expected_cap = admitted_requests * decoder_tokens_per_request
+    assert expected_cap == 696
+    assert merged["cuda_graph_max_bs_prefill"] == expected_cap
+    assert merged["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(
+        expected_cap
+    )
 
 
 def test_whisper_prefill_coalescing_defaults_are_forwarded() -> None:
@@ -417,10 +427,13 @@ def test_whisper_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
     assert scheduler_kwargs["enable_async_decode"] is False
     assert scheduler_kwargs["async_decode_min_batch_size"] == 4
     assert build_kwargs["cuda_graph_backend_prefill"] == CudaGraphBackend.BREAKABLE
-    # The prefill ladder is capped by the model context (1988 < max_prefill_tokens).
-    assert build_kwargs["cuda_graph_max_bs_prefill"] == 1500 + 224 + 256 + 8
+    admitted_requests = build_kwargs["max_prefill_tokens"] // (1500 + (224 + 8))
+    assert admitted_requests == 3
+    expected_cap = admitted_requests * (224 + 8)
+    assert expected_cap == 696
+    assert build_kwargs["cuda_graph_max_bs_prefill"] == expected_cap
     assert build_kwargs["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(
-        1500 + 224 + 256 + 8
+        expected_cap
     )
     assert len(graph_init_calls) == 1
     assert len(attest_calls) == 1

--- a/tests/unit_test/whisper_asr/test_pipeline.py
+++ b/tests/unit_test/whisper_asr/test_pipeline.py
@@ -337,6 +337,15 @@ def test_whisper_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
         build_kwargs["context_length"] = context_length
         build_kwargs.update(overrides)
         server_args = SimpleNamespace(**overrides)
+        for name, default in (
+            ("attn_cp_size", 1),
+            ("dcp_size", 1),
+            ("lora_paths", None),
+            ("enable_lora", None),
+            ("moe_a2a_backend", "none"),
+        ):
+            if not hasattr(server_args, name):
+                setattr(server_args, name, default)
         server_args.cuda_graph_config = SimpleNamespace(
             decode=SimpleNamespace(
                 max_bs=overrides["cuda_graph_max_bs"],
@@ -408,8 +417,10 @@ def test_whisper_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
     assert scheduler_kwargs["enable_async_decode"] is False
     assert scheduler_kwargs["async_decode_min_batch_size"] == 4
     assert build_kwargs["cuda_graph_backend_prefill"] == CudaGraphBackend.BREAKABLE
+    # The prefill ladder is capped by the model context (1988 < max_prefill_tokens).
+    assert build_kwargs["cuda_graph_max_bs_prefill"] == 1500 + 224 + 256 + 8
     assert build_kwargs["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(
-        256
+        1500 + 224 + 256 + 8
     )
     assert len(graph_init_calls) == 1
     assert len(attest_calls) == 1

--- a/tests/unit_test/whisper_asr/test_prefill_cuda_graph.py
+++ b/tests/unit_test/whisper_asr/test_prefill_cuda_graph.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
+
 from sglang_omni.model_runner.sglang_model_runner import SGLModelRunner
 from sglang_omni.model_runner.whisper_prefill_cuda_graph_runner import (
     WhisperPrefillCudaGraphRunner,

--- a/tests/unit_test/whisper_asr/test_prefill_cuda_graph.py
+++ b/tests/unit_test/whisper_asr/test_prefill_cuda_graph.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang_omni.model_runner.sglang_model_runner import SGLModelRunner
+from sglang_omni.model_runner.whisper_prefill_cuda_graph_runner import (
+    WhisperPrefillCudaGraphRunner,
+)
+
+
+@pytest.mark.parametrize("batch_size", [1])
+def test_whisper_prefill_capture_populates_encoder_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    batch_size: int,
+) -> None:
+    runner = object.__new__(WhisperPrefillCudaGraphRunner)
+    capture_batch = SimpleNamespace(
+        batch_size=batch_size,
+        encoder_lens=None,
+        encoder_lens_cpu=None,
+        encoder_cached=None,
+        encoder_out_cache_loc=None,
+    )
+    monkeypatch.setattr(
+        WhisperPrefillCudaGraphRunner.__mro__[1],
+        "capture_prepare",
+        lambda self, num_tokens: (capture_batch, object()),
+    )
+    runner.device = "cpu"
+
+    batch, _ = runner.capture_prepare(4)
+
+    assert batch.encoder_lens.tolist() == [1] * batch_size
+    assert batch.encoder_lens_cpu == [1] * batch_size
+    assert batch.encoder_cached == [True] * batch_size
+    assert batch.encoder_out_cache_loc is None
+
+
+@pytest.mark.parametrize("forward_mode", [ForwardMode.EXTEND, ForwardMode.MIXED])
+def test_whisper_prefill_replay_preserves_encoder_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    forward_mode: ForwardMode,
+) -> None:
+    runner = object.__new__(WhisperPrefillCudaGraphRunner)
+    static_batch = SimpleNamespace(
+        encoder_lens_cpu=None,
+        encoder_cached=None,
+        encoder_out_cache_loc=None,
+    )
+    live_batch = SimpleNamespace(
+        forward_mode=forward_mode,
+        encoder_lens_cpu=[7, 5],
+        encoder_cached=[False, True],
+        encoder_out_cache_loc=torch.tensor([11, 12, 13]),
+    )
+    monkeypatch.setattr(
+        WhisperPrefillCudaGraphRunner.__mro__[1],
+        "load_batch",
+        lambda self, forward_batch, **kwargs: static_batch,
+    )
+
+    replay_batch = runner.load_batch(live_batch)
+
+    assert replay_batch.encoder_lens_cpu == live_batch.encoder_lens_cpu
+    assert replay_batch.encoder_cached == live_batch.encoder_cached
+    assert replay_batch.encoder_out_cache_loc is live_batch.encoder_out_cache_loc
+
+
+@pytest.mark.parametrize(
+    ("architecture", "backend", "expected"),
+    [
+        (
+            "WhisperForConditionalGeneration",
+            "breakable",
+            WhisperPrefillCudaGraphRunner,
+        ),
+        ("WhisperForConditionalGeneration", "disabled", None),
+        ("Qwen3ASRForConditionalGeneration", "breakable", None),
+    ],
+)
+def test_model_runner_selects_whisper_prefill_adapter_only_when_needed(
+    architecture: str,
+    backend: str,
+    expected: type[WhisperPrefillCudaGraphRunner] | None,
+) -> None:
+    runner = object.__new__(SGLModelRunner)
+    runner._model_arch_override = architecture
+    runner.server_args = SimpleNamespace(
+        cuda_graph_config=SimpleNamespace(prefill=SimpleNamespace(backend=backend))
+    )
+
+    assert runner._prefill_cuda_graph_runner_cls() is expected
+
+
+@pytest.mark.parametrize(
+    ("architecture", "backend", "expects_override"),
+    [
+        ("WhisperForConditionalGeneration", "breakable", True),
+        ("WhisperForConditionalGeneration", "disabled", False),
+    ],
+)
+def test_model_runner_scopes_whisper_prefill_adapter_override(
+    architecture: str,
+    backend: str,
+    expects_override: bool,
+) -> None:
+    from sglang.srt.model_executor.model_runner_components import cuda_graph_setup
+
+    runner = object.__new__(SGLModelRunner)
+    runner._model_arch_override = architecture
+    runner.server_args = SimpleNamespace(
+        cuda_graph_config=SimpleNamespace(prefill=SimpleNamespace(backend=backend))
+    )
+    original = cuda_graph_setup.PrefillCudaGraphRunner
+
+    with runner._prefill_cuda_graph_runner_override():
+        expected = WhisperPrefillCudaGraphRunner if expects_override else original
+        assert cuda_graph_setup.PrefillCudaGraphRunner is expected
+
+    assert cuda_graph_setup.PrefillCudaGraphRunner is original

--- a/tests/unit_test/whisper_asr/test_prefill_cuda_graph.py
+++ b/tests/unit_test/whisper_asr/test_prefill_cuda_graph.py
@@ -41,6 +41,43 @@ def test_whisper_prefill_capture_populates_encoder_metadata(
     assert batch.encoder_out_cache_loc is None
 
 
+def test_whisper_prefill_runner_registers_self_and_cross_attention_layers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    self_attention_layers = [object(), object()]
+    cross_attention_layers = [object(), object()]
+    decoder_layers = [
+        SimpleNamespace(
+            self_attn=SimpleNamespace(attn=self_attention),
+            encoder_attn=SimpleNamespace(attn=cross_attention),
+        )
+        for self_attention, cross_attention in zip(
+            self_attention_layers, cross_attention_layers
+        )
+    ]
+    model_runner = SimpleNamespace(
+        model=SimpleNamespace(
+            model=SimpleNamespace(
+                decoder=SimpleNamespace(layers=decoder_layers),
+            )
+        ),
+        attention_layers=[],
+    )
+    initialized: list[object] = []
+    monkeypatch.setattr(
+        WhisperPrefillCudaGraphRunner.__mro__[1],
+        "__init__",
+        lambda self, runner: initialized.append(runner),
+    )
+
+    WhisperPrefillCudaGraphRunner(model_runner)
+
+    assert model_runner.attention_layers == (
+        self_attention_layers + cross_attention_layers
+    )
+    assert initialized == [model_runner]
+
+
 @pytest.mark.parametrize("forward_mode", [ForwardMode.EXTEND, ForwardMode.MIXED])
 def test_whisper_prefill_replay_preserves_encoder_metadata(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit_test/whisper_asr/test_prefill_cuda_graph.py
+++ b/tests/unit_test/whisper_asr/test_prefill_cuda_graph.py
@@ -76,6 +76,9 @@ def test_whisper_prefill_runner_registers_self_and_cross_attention_layers(
     assert model_runner.attention_layers == (
         self_attention_layers + cross_attention_layers
     )
+    assert model_runner.mha_companion_layers == [None] * len(
+        model_runner.attention_layers
+    )
     assert initialized == [model_runner]
 
 
@@ -135,29 +138,61 @@ def test_model_runner_selects_whisper_prefill_adapter_only_when_needed(
     assert runner._prefill_cuda_graph_runner_cls() is expected
 
 
-@pytest.mark.parametrize(
-    ("architecture", "backend", "expects_override"),
-    [
-        ("WhisperForConditionalGeneration", "breakable", True),
-        ("WhisperForConditionalGeneration", "disabled", False),
-    ],
-)
-def test_model_runner_scopes_whisper_prefill_adapter_override(
-    architecture: str,
-    backend: str,
-    expects_override: bool,
-) -> None:
+def _install_dispatch_for_test(monkeypatch: pytest.MonkeyPatch):
     from sglang.srt.model_executor.model_runner_components import cuda_graph_setup
+    from sglang.srt.model_executor.runner import PrefillCudaGraphRunner as stock_cls
+
+    import sglang_omni.model_runner.sglang_model_runner as runner_module
+
+    # monkeypatch teardown undoes the install.
+    monkeypatch.setattr(cuda_graph_setup, "PrefillCudaGraphRunner", stock_cls)
+    monkeypatch.setattr(runner_module, "_PREFILL_RUNNER_DISPATCH_DEFAULT", None)
+    runner_module._install_prefill_runner_dispatch()
+    return cuda_graph_setup, stock_cls
+
+
+def test_prefill_runner_dispatch_selects_by_instance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cuda_graph_setup, stock_cls = _install_dispatch_for_test(monkeypatch)
+
+    constructed: list[tuple[type, object]] = []
+    monkeypatch.setattr(
+        WhisperPrefillCudaGraphRunner,
+        "__init__",
+        lambda self, runner: constructed.append(
+            (WhisperPrefillCudaGraphRunner, runner)
+        ),
+    )
+    monkeypatch.setattr(
+        stock_cls,
+        "__init__",
+        lambda self, runner: constructed.append((stock_cls, runner)),
+    )
 
     runner = object.__new__(SGLModelRunner)
-    runner._model_arch_override = architecture
+    runner._model_arch_override = "WhisperForConditionalGeneration"
     runner.server_args = SimpleNamespace(
-        cuda_graph_config=SimpleNamespace(prefill=SimpleNamespace(backend=backend))
+        cuda_graph_config=SimpleNamespace(prefill=SimpleNamespace(backend="breakable"))
     )
-    original = cuda_graph_setup.PrefillCudaGraphRunner
 
-    with runner._prefill_cuda_graph_runner_override():
-        expected = WhisperPrefillCudaGraphRunner if expects_override else original
-        assert cuda_graph_setup.PrefillCudaGraphRunner is expected
+    cuda_graph_setup.PrefillCudaGraphRunner(runner)
 
-    assert cuda_graph_setup.PrefillCudaGraphRunner is original
+    assert constructed == [(WhisperPrefillCudaGraphRunner, runner)]
+
+
+def test_prefill_runner_dispatch_routes_selectorless_runner_to_stock_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cuda_graph_setup, stock_cls = _install_dispatch_for_test(monkeypatch)
+
+    constructed: list[object] = []
+    monkeypatch.setattr(
+        stock_cls, "__init__", lambda self, runner: constructed.append(runner)
+    )
+
+    foreign_runner = SimpleNamespace()
+    result = cuda_graph_setup.PrefillCudaGraphRunner(foreign_runner)
+
+    assert constructed == [foreign_runner]
+    assert type(result) is stock_cls


### PR DESCRIPTION
## Stack
- Base Draft PR: #1634 isolates the Whisper encoder/decoder cache execution-path change.
- This branch is rebased on `whisper-encoder-decoder-cache` so the base and CUDA Graph changes can be benchmarked independently.
- The GitHub base remains `main` because the stacked branches live in the contributor fork; the displayed diff will shrink after #1634 merges.

## Summary
- enable breakable prefill CUDA graphs by default for Whisper-ASR with a 256-token capture ladder
- preserve Whisper encoder metadata during prefill graph capture and replay with a model-specific runner adapter
- register decoder self-attention and cross-attention layers for graph capture

This follows the model-adoption patterns from #1398 and #1458.

## Test plan
- `pytest -q tests/unit_test/model_runner/test_cuda_graph_batch_validator.py tests/unit_test/scheduling/test_prefill_graph_policy.py tests/unit_test/qwen3_asr/test_pipeline.py tests/unit_test/whisper_asr -m 'not benchmark'` (159 passed)
- `python3 -m py_compile` for all changed Python files

## Benchmark plan
Use `openai/whisper-large-v3` and run the complete A/B/C comparison under both pre-LM encoder modes:

| Case | `enable_pre_lm_encoder` | Execution path |
|---|---:|---|
| A1 | `false` | current `main` pre-adopter eager path |
| B1 | `false` | #1634 adopter path with prefill BCG disabled |
| C1 | `false` | this PR with prefill BCG enabled |
| A2 | `true` (current `main` default) | current `main` pre-adopter eager path |
| B2 | `true` | #1634 adopter path with prefill BCG disabled |
| C2 | `true` | this PR with prefill BCG enabled |

Within each pre-LM mode, compare A versus B to detect regressions from the encoder/decoder execution-path change, then B versus C to isolate the CUDA Graph impact. Report throughput, latency, WER, capture time and memory, graph replay versus eager fallback coverage, and the corresponding boundaries.

Use both matrices to decide the default policy: enable prefill CUDA Graphs unconditionally only if they qualify without regression in both modes; otherwise gate the default on `enable_pre_lm_encoder` for the mode that qualifies. These qualification results are pending.

## Related Issues
- #1357
- #1396

## Historical whisper-base benchmark (pre-restack)

The following result was contributed by @ZemingL before the current-main restack. It is useful historical data, but it does not replace the planned `whisper-large-v3` A/B/C qualification above.

Runtime fixes and benchmarking by @ZemingL Thanks!
### Setup

- Baseline: `upstream/main@68abc7eec59ff7b0dce484cb501ffbbb338f9e46`
- Candidate used for performance measurement: `c7dee6dcb356803e96501d94fdc7be6ae8b956d5`
- Hardware: NVIDIA H100 80GB HBM3, driver 580.95.05
- CI image: `hongccc/sglang-omni@sha256:374d0b1c30b2bff685b1716fc64a02ad3b3d0a90fe2ce73ce9861a6992c28101`
- Model: `openai/whisper-base@e37978b90ca9030d5170a5c07aadb050351a65bb`, FP16
- Dataset: full SeedTTS EN split, 1,088 samples
- Concurrency: 1, 2, 4, 8, 16, 32
- Protocol: one discarded application warmup plus three measured repeats per concurrency; same host, image, cache, and command
- Full run order: candidate -> baseline. A post-baseline candidate spot run covered concurrency 16 and 32. The preceding 20-sample smoke used baseline -> candidate order.

The first GPU smoke exposed two candidate startup failures: BCG attention returned head-shaped tensors before Whisper's output projection, and the generic layer discovery omitted cross-attention layers. Commit `c7dee6dc` fixes both. After the fix, capture completed and the runtime attested all 22 buckets from 4 through 256 tokens.

| Concurrency | Main req/s | BCG req/s | Throughput | Main mean / p95 / p99 latency (ms) | BCG mean / p95 / p99 latency (ms) | Main / BCG WER |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 22.169 | 24.255 | +9.41% | 45.0 / 53.5 / 60.2 | 41.1 / 50.4 / 55.5 | 0.048275 / 0.048275 |
| 2 | 36.166 | 36.623 | +1.26% | 55.2 / 65.6 / 72.4 | 54.5 / 64.5 / 69.5 | 0.047972 / 0.048073 |
| 4 | 58.463 | 63.042 | +7.83% | 68.0 / 80.4 / 87.5 | 63.1 / 74.6 / 82.7 | 0.047972 / 0.047972 |
| 8 | 88.840 | 97.290 | +9.51% | 89.7 / 104.9 / 115.3 | 81.9 / 97.4 / 110.4 | 0.047972 / 0.048023 |
| 16 | 103.997 | 117.313 | +12.80% | 152.9 / 175.2 / 233.3 | 135.6 / 159.1 / 207.0 | 0.047972 / 0.048123 |
| 32 | 98.679 | 114.718 | +16.25% | 321.9 / 384.1 / 429.1 | 276.8 / 333.1 / 381.4 | 0.047972 / 0.048123 |

### Correctness and mechanism checks

- 19,584/19,584 measured requests succeeded per arm; no skipped or failed samples.
- At concurrency 1, all 3,264 returned transcripts matched exactly between main and BCG.
- Concurrent runs showed small repeat-to-repeat transcript variation in both arms; corpus WER stayed within 0.0480-0.0483.
- Prefill BCG capture: 1.69 seconds, 0.09 GB reported memory, buckets `[4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256]`.
- Post-baseline candidate spot run: 115.754 req/s at concurrency 16 and 116.868 req/s at concurrency 32, within -1.33% and +1.87% of the primary candidate run.
- Focused CPU tests after the fixes: 136 passed.



