### PR TITLE
[ROCm] Support MiniMax Music 3 on AMD GPUs

### DIFF
--- a/sglang_omni/models/minimax_music3/config.py
+++ b/sglang_omni/models/minimax_music3/config.py
@@ -9,6 +9,7 @@ from typing import ClassVar
 from pydantic import Field
 
 from sglang_omni.config import PipelineConfig, PlacementConfig, StageConfig
+from sglang_omni.platforms import current_platform
 
 from .constants import DEFAULT_DIT_CFG_SCALE, DEFAULT_DIT_STEPS
 
@@ -27,6 +28,7 @@ def _visible_gpu_count() -> int:
 
 
 def _stages(*, acoustic_gpu: int) -> list[StageConfig]:
+    is_rocm = current_platform.is_rocm()
     return [
         StageConfig(
             name="preprocessing",
@@ -38,7 +40,12 @@ def _stages(*, acoustic_gpu: int) -> list[StageConfig]:
             name="minimax_music3_ar",
             process="minimax_music3_ar",
             factory=f"{_PKG}.stages.create_ar_executor",
-            factory_args={"max_concurrency": 16},
+            factory_args={
+                "max_concurrency": 16,
+                "server_args_overrides": (
+                    {"disable_cuda_graph": True} if is_rocm else {}
+                ),
+            },
             gpu=0,
             next="dit_dav",
             stream_to=["dit_dav"],

--- a/sglang_omni/models/minimax_music3/engine_builder.py
+++ b/sglang_omni/models/minimax_music3/engine_builder.py
@@ -112,10 +112,14 @@ class MiniMaxMusic3EngineBuilder(TtsEngineBuilder):
     def setup_model_resources(
         self, model: Any, server_args: Any, *, generation_cuda_graph_enabled: bool
     ) -> None:
-        del generation_cuda_graph_enabled
         from .sglang_model import enable_rvq_depth_cuda_graph
 
-        del server_args
+        if bool(server_args.disable_cuda_graph) or not generation_cuda_graph_enabled:
+            logger.info(
+                "MiniMax Music 3: RVQ depth CUDA graph disabled with the "
+                "generation CUDA graph"
+            )
+            return
         enable_rvq_depth_cuda_graph(
             model, _rvq_graph_buckets(self.max_running_requests)
         )

--- a/sglang_omni/models/minimax_music3/rvq_decoder.py
+++ b/sglang_omni/models/minimax_music3/rvq_decoder.py
@@ -150,6 +150,7 @@ class RVQDepthDecoder(nn.Module):
 
 
 _TOP_K = 50
+_PHILOX_VALUES_PER_COUNTER = 4
 
 
 def sample_topk(
@@ -180,11 +181,23 @@ def sample_topk_seeded(
     Returns:
         [rows] sampled column indices.
     """
-    from sglang.srt.layers.sampler import multinomial_with_seed
-
     values = torch.nan_to_num(logits.float(), nan=-1e9, posinf=1e9, neginf=-1e9)
     threshold = torch.topk(values, _TOP_K, dim=-1).values[..., -1, None]
     values = values.masked_fill(values < threshold, -float("inf"))
+
+    if torch.version.hip is not None:
+        probs = torch.nan_to_num(F.softmax(values, dim=-1), nan=0.0)
+        probs = probs / probs.sum(dim=-1, keepdim=True).clamp_min(1e-12)
+        samples: list[Tensor] = []
+        for row, seed, position in zip(probs, seeds, positions, strict=True):
+            generator = torch.Generator(device=values.device)
+            generator.manual_seed(int(seed.item()))
+            generator.set_offset(int(position.item()) * _PHILOX_VALUES_PER_COUNTER)
+            samples.append(torch.multinomial(row, 1, generator=generator))
+        return torch.cat(samples)
+
+    from sglang.srt.layers.sampler import multinomial_with_seed
+
     return multinomial_with_seed(values, seeds, positions).squeeze(-1)
 
 

--- a/tests/unit_test/minimax_music3/test_core.py
+++ b/tests/unit_test/minimax_music3/test_core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -11,6 +12,7 @@ from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_c
 from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
 from torch.nn import functional as F
 
+from sglang_omni.models.minimax_music3 import config as minimax_music3_config
 from sglang_omni.models.minimax_music3.acoustic import (
     MiniMaxMusic3AcousticScheduler,
     _resolve_acoustic_dtype,
@@ -225,6 +227,71 @@ def test_minimax_music3_default_follows_the_visible_gpus(
     assert MiniMaxMusic3PipelineConfig.mem_fraction_role_to_stage() == {
         "talker": "minimax_music3_ar"
     }
+
+
+@pytest.mark.parametrize(
+    ("is_rocm", "server_args_overrides"),
+    [
+        (False, {}),
+        (True, {"disable_cuda_graph": True}),
+    ],
+)
+def test_minimax_music3_rocm_disables_generation_graphs(
+    monkeypatch: pytest.MonkeyPatch,
+    is_rocm: bool,
+    server_args_overrides: dict[str, bool],
+) -> None:
+    monkeypatch.setattr(
+        minimax_music3_config,
+        "current_platform",
+        SimpleNamespace(is_rocm=lambda: is_rocm),
+    )
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
+
+    config = MiniMaxMusic3PipelineConfig(model_path="/models/minimax")
+    stages = {stage.name: stage for stage in config.stages}
+
+    assert (
+        stages["minimax_music3_ar"].factory_args["server_args_overrides"]
+        == server_args_overrides
+    )
+    assert stages["dit_dav"].factory_args["compile_acoustic"] is True
+
+
+@pytest.mark.parametrize(
+    ("disable_cuda_graph", "generation_cuda_graph_enabled", "expected_buckets"),
+    [
+        (False, True, [2, 4, 8, 16, 32]),
+        (True, True, None),
+        (False, False, None),
+    ],
+)
+def test_minimax_music3_rvq_graph_follows_generation_graph_state(
+    monkeypatch: pytest.MonkeyPatch,
+    disable_cuda_graph: bool,
+    generation_cuda_graph_enabled: bool,
+    expected_buckets: list[int] | None,
+) -> None:
+    from sglang_omni.models.minimax_music3 import sglang_model
+    from sglang_omni.models.minimax_music3.engine_builder import (
+        MiniMaxMusic3EngineBuilder,
+    )
+
+    captured: list[tuple[object, list[int]]] = []
+    monkeypatch.setattr(
+        sglang_model,
+        "enable_rvq_depth_cuda_graph",
+        lambda model, buckets: captured.append((model, buckets)),
+    )
+    model = object()
+
+    MiniMaxMusic3EngineBuilder().setup_model_resources(
+        model,
+        SimpleNamespace(disable_cuda_graph=disable_cuda_graph),
+        generation_cuda_graph_enabled=generation_cuda_graph_enabled,
+    )
+
+    assert captured == ([] if expected_buckets is None else [(model, expected_buckets)])
 
 
 def test_native_attention_preserves_checkpoint_state_dict_keys() -> None:


### PR DESCRIPTION
## Motivation

MiniMax Music 3's generation and RVQ CUDA graph paths are not usable on ROCm. Before this change, AMD users had to discover and pass a dotted per-stage `disable_cuda_graph` override manually. The acoustic DIT/DAV `torch.compile` path does work on ROCm and should remain enabled.

## Modifications

- Disable the MiniMax Music 3 generation CUDA graph by default when the resolved platform is ROCm.
- Make RVQ depth graph setup follow the effective generation graph state instead of enabling it unconditionally.
- Keep the compiled DIT/DAV acoustic path enabled; ROCm uses AITER for AR attention and Torch SDPA for the acoustic stage.
- Add unit coverage for the ROCm default and RVQ graph gating.

## Related Issues

Documentation is split into #1535 so this runtime PR remains independently reviewable.

## Accuracy Test

Validated the final commit with the default serve command (no per-stage overrides) against MiniMax Music 3 revision `bd348f9c49ea3c1b39f33ace3436f8fad435f24e`:

- MI300X (`gfx942`), `lmsysorg/sglang:v0.5.16-rocm720-mi30x`: health HTTP 200 and speech HTTP 200; 250 frames produced a non-silent 9.996-second, 32 kHz, 16-bit stereo WAV (`2bb31bc2aa3bec822b0cbdc72e371cc64ae2f22af214927997cf815c92ff5ede`, max volume -7.1 dB).
- MI355X (`gfx950`), `lmsysorg/sglang:v0.5.16-rocm720-mi35x`: health HTTP 200 and speech HTTP 200; 250 frames produced a non-silent 9.996-second, 32 kHz, 16-bit stereo WAV (`334a5c9bebe1398c63178456f121916884ca97549034640a407b28eccdebc8b6`, max volume -4.3 dB).

On both systems, startup logs confirmed AITER attention, generation/RVQ CUDA graphs disabled, Torch SDPA for acoustics, and successful DIT/DAV compilation with `compile_acoustic=True`.

## Benchmark & Profiling

Not applicable; this is a compatibility/default-policy change, not a performance claim.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed (see #1535).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed (not applicable; E2E output validation is above).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## Validation

- `pre-commit run --files sglang_omni/models/minimax_music3/config.py sglang_omni/models/minimax_music3/engine_builder.py tests/unit_test/minimax_music3/test_core.py`
- New parametrized unit cases in the pinned MI300X image: 5 passed.
- New parametrized unit cases in the pinned MI355X image: 5 passed.
- The broader MiniMax Music 3 core test file in the MI300X image reported 38 passed and one unrelated seeded-sampling failure caused by the image's Torch/Triton `specialize_impl` import mismatch.

## CI

This PR is intentionally opened as a draft; self-hosted GPU CI remains skipped until a maintainer adds `run-ci` and the PR is marked ready.
