### PR TITLE
[Docs][ROCm] Add MiniMax Music 3 setup for AMD GPUs

### DIFF
--- a/docs/cookbook/minimax_music3.md
+++ b/docs/cookbook/minimax_music3.md
@@ -31,6 +31,30 @@ source .venv/bin/activate
 uv pip install -v -e .   # drop -e for a non-editable install
 ```
 
+### AMD ROCm
+
+Use the SGLang 0.5.16 ROCm image for your accelerator. The `mi30x` image covers MI300X; use the `mi35x` tag for MI355X.
+
+```bash
+# Run from the sglang-omni repository root. Change mi30x to mi35x on MI355X.
+docker run --rm -it \
+  --network host --ipc host --security-opt seccomp=unconfined \
+  --ulimit memlock=-1:-1 \
+  --device /dev/kfd --device /dev/dri \
+  --group-add video --group-add render \
+  -v "$PWD":/workspace/sglang-omni \
+  -v "$HOME/.cache/huggingface":/root/.cache/huggingface \
+  lmsysorg/sglang:v0.5.16-rocm720-mi30x bash
+```
+
+The ROCm image already contains the pinned SGLang and PyTorch stack. Install the small Omni-only dependency that is absent from the image, then install this checkout without replacing the ROCm packages:
+
+```bash
+cd /workspace/sglang-omni
+python3 -m pip install --no-deps 'msgpack>=1.0.0'
+python3 -m pip install --no-deps -e .
+```
+
 **Single GPU** (colocate both stages):
 
 ```bash
@@ -43,7 +67,9 @@ CUDA_VISIBLE_DEVICES=0 sgl-omni serve --model-path MiniMaxAI/MiniMax-Music3 --po
 CUDA_VISIBLE_DEVICES=0,1 sgl-omni serve --model-path MiniMaxAI/MiniMax-Music3 --port 8000
 ```
 
-Default optimizations that are on without further flags: backbone decode CUDA graph, RVQ depth CUDA graph, compiled DIT blocks, compiled DAV decoder, and batched seeded sampling.
+On NVIDIA CUDA, the default optimizations are backbone decode CUDA graph, RVQ depth CUDA graph, compiled DIT blocks, compiled DAV decoder, and batched seeded sampling.
+
+On AMD ROCm, the same serve commands work without extra stage overrides. SGLang-Omni automatically disables the backbone and RVQ CUDA graphs; the AR stage uses AITER, while the compiled DIT/DAV acoustic stage uses Torch SDPA. This path is validated on MI300X and MI355X with ROCm 7.2.
 
 Classifier-free guidance is on in both stages and has no flag. See [Guidance](#guidance) for what it costs you, because the AR half changes how much a request occupies.
 


### PR DESCRIPTION
## Motivation

The published MiniMax Music 3 cookbook currently documents only the CUDA-oriented defaults and has no AMD installation guidance. MiniMax Music 3 has now been validated on MI300X and MI355X with ROCm 7.2, so AMD users need a reproducible container setup and an accurate description of which optimizations are enabled.

## Modifications

- Add an AMD ROCm prerequisite section with the pinned SGLang 0.5.16 `mi30x` and `mi35x` image tags.
- Document the required container devices, groups, mounts, and the no-dependencies editable installation flow that preserves the ROCm PyTorch stack.
- Clarify that NVIDIA keeps the backbone and RVQ CUDA graphs enabled.
- Document that ROCm automatically disables those graph paths while retaining AITER for AR and compiled Torch SDPA DIT/DAV acoustics.

## Related Issues

Companion documentation for runtime support in #1534.

## Accuracy Test

The documented default serve flow was validated without per-stage overrides against MiniMax Music 3 revision `bd348f9c49ea3c1b39f33ace3436f8fad435f24e`:

- MI300X (`gfx942`), ROCm 7.2, `lmsysorg/sglang:v0.5.16-rocm720-mi30x`: health and speech HTTP 200; non-silent 9.996-second, 32 kHz stereo WAV.
- MI355X (`gfx950`), ROCm 7.2, `lmsysorg/sglang:v0.5.16-rocm720-mi35x`: health and speech HTTP 200; non-silent 9.996-second, 32 kHz stereo WAV.

Both logs confirmed AITER attention, Torch SDPA acoustics, disabled generation/RVQ CUDA graphs, and `compile_acoustic=True`.

## Benchmark & Profiling

Not applicable; this PR changes documentation only and makes no performance claim.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests (not applicable; documentation-only change).
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed (not applicable; hardware validation is summarized above).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## Validation

- `pre-commit run --files docs/cookbook/minimax_music3.md`
- Full Sphinx HTML build: succeeded. The 25 warnings are existing repository-wide references/intersphinx warnings and do not originate from this page.
- Inspected the rendered `cookbook/minimax_music3.html` for the `AMD ROCm` heading, container tag, and platform-specific optimization text.
- Ran the documented `msgpack` plus `pip install --no-deps -e .` sequence successfully in `lmsysorg/sglang:v0.5.16-rocm720-mi30x`.
