### PR TITLE
Fix coordinator admission cleanup on submit failure

### DIFF
--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -387,12 +387,13 @@ class Coordinator:
             request = OmniRequest(inputs=request)
 
         # Track request
-        self._requests[request_id] = RequestInfo(
+        request_info = RequestInfo(
             request_id=request_id,
             state=RequestState.PENDING,
             current_stage=self.entry_stage,
             terminal_stages=self._resolve_terminal_stages(request),
         )
+        self._requests[request_id] = request_info
 
         # Create future for completion
         loop = asyncio.get_running_loop()
@@ -400,6 +401,7 @@ class Coordinator:
         self._completion_futures[request_id] = future
         if stream_queue is not None:
             self._stream_queues[request_id] = stream_queue
+        partial_results = self._partial_results.get(request_id)
 
         payload = StagePayload(
             request_id=request_id,
@@ -416,11 +418,27 @@ class Coordinator:
 
         # Submit to entry stage
         entry_info = self._stages[self.entry_stage]
-        await self.control_plane.submit_to_stage(
-            self.entry_stage,
-            entry_info.control_endpoint,
-            SubmitMessage(request_id=request_id, data=payload),
-        )
+        try:
+            await self.control_plane.submit_to_stage(
+                self.entry_stage,
+                entry_info.control_endpoint,
+                SubmitMessage(request_id=request_id, data=payload),
+            )
+        except BaseException:
+            # Identity checks keep a failed admission from releasing state that a
+            # re-entrant callback may have replaced with a new owner.
+            if self._requests.get(request_id) is request_info:
+                self._requests.pop(request_id, None)
+            if self._completion_futures.get(request_id) is future:
+                self._completion_futures.pop(request_id, None)
+            if (
+                stream_queue is not None
+                and self._stream_queues.get(request_id) is stream_queue
+            ):
+                self._stream_queues.pop(request_id, None)
+            if self._partial_results.get(request_id) is partial_results:
+                self._partial_results.pop(request_id, None)
+            raise
 
         # Update state
         info = self._requests.get(request_id)

--- a/tests/unit_test/pipeline/test_coordinator.py
+++ b/tests/unit_test/pipeline/test_coordinator.py
@@ -309,6 +309,153 @@ def test_coordinator_fail_pending_requests_resolves_waiters() -> None:
     asyncio.run(_run())
 
 
+def test_coordinator_submit_failure_releases_request_id_for_retry() -> None:
+    class FailOnceControlPlane(RecordingCoordinatorControlPlane):
+        def __init__(self) -> None:
+            super().__init__()
+            self.fail_next_submit = True
+
+        async def submit_to_stage(self, stage: str, endpoint: str, msg) -> None:
+            if self.fail_next_submit:
+                self.fail_next_submit = False
+                raise RuntimeError("entry stage unavailable")
+            await super().submit_to_stage(stage, endpoint, msg)
+
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["decode"],
+        )
+        control_plane = FailOnceControlPlane()
+        coordinator.control_plane = control_plane
+        coordinator.register_stage("preprocess", "inproc://preprocess")
+
+        with pytest.raises(RuntimeError, match="entry stage unavailable"):
+            await coordinator._submit_request("req-1", "first attempt")
+
+        assert coordinator._requests == {}
+        assert coordinator._completion_futures == {}
+        assert coordinator._stream_queues == {}
+        assert coordinator._partial_results == {}
+
+        await coordinator._submit_request("req-1", "retry")
+        assert [msg.request_id for _, _, msg in control_plane.submitted] == ["req-1"]
+
+        future = coordinator._completion_futures["req-1"]
+        assert await coordinator.abort("req-1") is True
+        with pytest.raises(asyncio.CancelledError):
+            await future
+
+    asyncio.run(_run())
+
+
+def test_coordinator_stream_admission_failure_cleans_state_without_abort() -> None:
+    class FailingSubmitControlPlane(RecordingCoordinatorControlPlane):
+        async def submit_to_stage(self, stage: str, endpoint: str, msg) -> None:
+            raise RuntimeError("entry stage unavailable")
+
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["decode"],
+        )
+        control_plane = FailingSubmitControlPlane()
+        coordinator.control_plane = control_plane
+        coordinator.register_stage("preprocess", "inproc://preprocess")
+
+        stream = coordinator.stream("req-1", "hello")
+        with pytest.raises(RuntimeError, match="entry stage unavailable"):
+            await anext(stream)
+
+        assert coordinator._requests == {}
+        assert coordinator._completion_futures == {}
+        assert coordinator._stream_queues == {}
+        assert coordinator._partial_results == {}
+        assert control_plane.aborts == []
+
+    asyncio.run(_run())
+
+
+def test_coordinator_cancelled_admission_releases_all_state() -> None:
+    class BlockingSubmitControlPlane(RecordingCoordinatorControlPlane):
+        def __init__(self) -> None:
+            super().__init__()
+            self.submit_started = asyncio.Event()
+
+        async def submit_to_stage(self, stage: str, endpoint: str, msg) -> None:
+            self.submit_started.set()
+            await asyncio.Event().wait()
+
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["decode"],
+        )
+        control_plane = BlockingSubmitControlPlane()
+        coordinator.control_plane = control_plane
+        coordinator.register_stage("preprocess", "inproc://preprocess")
+
+        stream_event = asyncio.create_task(anext(coordinator.stream("req-1", "hello")))
+        await control_plane.submit_started.wait()
+        stream_event.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await stream_event
+
+        assert coordinator._requests == {}
+        assert coordinator._completion_futures == {}
+        assert coordinator._stream_queues == {}
+        assert coordinator._partial_results == {}
+        assert control_plane.aborts == []
+
+    asyncio.run(_run())
+
+
+def test_coordinator_cancelled_submit_releases_request_id() -> None:
+    class BlockingSubmitControlPlane(RecordingCoordinatorControlPlane):
+        def __init__(self) -> None:
+            super().__init__()
+            self.submit_started = asyncio.Event()
+
+        async def submit_to_stage(self, stage: str, endpoint: str, msg) -> None:
+            self.submit_started.set()
+            await asyncio.Event().wait()
+
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["decode"],
+        )
+        control_plane = BlockingSubmitControlPlane()
+        coordinator.control_plane = control_plane
+        coordinator.register_stage("preprocess", "inproc://preprocess")
+
+        submit = asyncio.create_task(coordinator._submit_request("req-1", "hello"))
+        await control_plane.submit_started.wait()
+        submit.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await submit
+
+        assert coordinator._requests == {}
+        assert coordinator._completion_futures == {}
+        assert coordinator._stream_queues == {}
+        assert coordinator._partial_results == {}
+
+        coordinator.control_plane = RecordingCoordinatorControlPlane()
+        await coordinator._submit_request("req-1", "retry")
+
+    asyncio.run(_run())
+
+
 async def _drive_stream_until_registered(coordinator: Coordinator, request_id: str):
     """Start consuming a stream and return (task, error_sink, future) once the
     request's completion future has been created."""


### PR DESCRIPTION
Addresses item 2 from #1307: coordinator state leak when initial submission fails or is cancelled.

Scope:
- roll back admission-owned coordinator state when initial `submit_to_stage()` raises or is cancelled;
- preserve `CancelledError`;
- verify the same request id can retry after failed admission;
- keep relay generation and process-replica routing out of this PR.

Tested:
- `uv run --no-project --with pytest --with pytest-asyncio --with torch --with pyzmq --with msgpack --with msgspec --with pydantic --with pyyaml --with numpy python -m pytest -q tests/unit_test/pipeline/test_coordinator.py`