### PR TITLE
[Perf][ASR] Route load_audio's general path through the cached resample kernel

### DIFF
--- a/sglang_omni/utils/audio.py
+++ b/sglang_omni/utils/audio.py
@@ -242,11 +242,15 @@ def load_audio(
         trimmed, _ = librosa.effects.trim(audio.numpy(), top_db=trim_top_db)
         audio = torch.from_numpy(trimmed)
     if sample_rate != target_sample_rate:
-        audio = torchaudio.functional.resample(
+        # Note (Lixiang Wang): the fast WAV path already routes through the cached
+        # kernel; everything the fast path declines — non-WAV containers, mono=False,
+        # trim_top_db, WAV encodings _parse_wav_bytes rejects — used to rebuild the
+        # sinc kernel on every request instead.
+        audio = _cached_resample(
             audio,
             int(sample_rate),
             target_sample_rate,
-            **dict(resample_kwargs or {}),
+            resample_kwargs,
         )
     if mono:
         audio = audio.squeeze(0)

--- a/tests/unit_test/utils/test_audio.py
+++ b/tests/unit_test/utils/test_audio.py
@@ -310,6 +310,58 @@ def test_load_audio_fast_path_resamples(monkeypatch) -> None:
     assert samples.shape == (1600,)
 
 
+@pytest.mark.parametrize("sample_rate", [22050, 44100, 48000])
+def test_load_audio_general_path_matches_uncached_resample(
+    monkeypatch, sample_rate
+) -> None:
+    """Routing the general path through the cached kernel must not move a bit."""
+    import torchaudio
+
+    wav = _sine_wav_bytes(sample_rate=sample_rate)
+    monkeypatch.setattr(audio, "_is_riff_wav", lambda data: False)
+
+    cached = load_audio(wav, target_sample_rate=16000)
+
+    def uncached(waveform, orig_freq, new_freq, resample_kwargs):
+        return torchaudio.functional.resample(
+            waveform, int(orig_freq), int(new_freq), **dict(resample_kwargs or {})
+        )
+
+    monkeypatch.setattr(audio, "_cached_resample", uncached)
+    plain = load_audio(wav, target_sample_rate=16000)
+
+    assert cached.dtype == plain.dtype == np.float32
+    assert np.array_equal(cached, plain)
+
+
+def test_load_audio_general_path_uses_cached_kernel(monkeypatch) -> None:
+    # Note (Lixiang Wang): asserting the cache was consulted, not just that the
+    # output is right — a version that silently rebuilt the kernel every call
+    # would still pass the bit-identity test above.
+    monkeypatch.setattr(audio, "_is_riff_wav", lambda data: False)
+    audio._resample_kernel.cache_clear()
+    wav = _sine_wav_bytes(sample_rate=44100)
+
+    for _ in range(3):
+        load_audio(wav, target_sample_rate=16000)
+
+    info = audio._resample_kernel.cache_info()
+    assert info.misses == 1
+    assert info.hits == 2
+
+
+def test_load_audio_general_path_shares_the_kernel_with_the_fast_path() -> None:
+    audio._resample_kernel.cache_clear()
+    wav = _sine_wav_bytes(sample_rate=44100)
+
+    load_audio(wav, target_sample_rate=16000)  # fast path fills the cache
+    load_audio(wav, target_sample_rate=16000, mono=False)  # general path
+
+    info = audio._resample_kernel.cache_info()
+    assert info.misses == 1
+    assert info.hits == 1
+
+
 def test_load_audio_trims_before_resampling() -> None:
     import librosa
     import torch


### PR DESCRIPTION
## Motivation

#1516 added `_resample_kernel` / `_cached_resample` to `sglang_omni/utils/audio.py` and wired them
into `load_audio`'s fast WAV path. The general path still calls `torchaudio.functional.resample`
directly, so it rebuilds the sinc kernel on every call and never reaches the cache.

`load_audio` runs once per request: `prepare_audio()` in
`sglang_omni/preprocessing/transcription.py` is the shared entry point for all five ASR models
(`fun_asr`, `qwen3_asr`, `whisper_asr`, `arkasr`, `moss_transcribe_diarize`). The general path is
taken whenever the input is not a mono RIFF WAV that `_parse_wav_bytes` accepts — every MP3, FLAC
and OGG upload, plus `mono=False`, `trim_top_db`, and 24-bit PCM WAV. `/v1/audio/transcriptions`
accepts those formats. **WAV traffic is unaffected by this PR**; it already takes the cached fast
path.

Instrumenting the `lru_cache` shows the general path never consults it. 30 repeated `load_audio`
calls after one warm-up, 10 s of 44.1 kHz audio resampled to 16 kHz:

| input | on `main` | with this PR |
|---|---|---|
| WAV mono 16-bit (fast path) | hits=30 misses=0 currsize=1 | hits=30 misses=0 currsize=1 |
| MP3 mono | hits=0 misses=0 **currsize=0** | hits=30 misses=0 currsize=1 |
| WAV 24-bit PCM | hits=0 misses=0 **currsize=0** | hits=30 misses=0 currsize=1 |
| WAV `mono=False` | hits=0 misses=0 **currsize=0** | hits=30 misses=0 currsize=1 |
| WAV + `trim_top_db` | hits=0 misses=0 **currsize=0** | hits=30 misses=0 currsize=1 |

`currsize=0` means the cache was never reached, not that it missed.

py-spy on the loaded Qwen3-ASR stage worker (45 s at 50 Hz, concurrency 32, MP3 uploads, 547
samples), share of non-idle samples:

| frame | share |
|---|---:|
| `_run_request_builder` (`scheduling/omni_scheduler.py:905`) | 23.583% |
| `request_builder` (`models/qwen3_asr/request_builders.py`) | 22.121% |
| `prepare_audio` (`preprocessing/transcription.py:76`) | **21.755%** |
| `load_audio:226` (decode branch) | 10.420% |
| `load_audio:249` (the uncached `resample` call this PR changes) | **9.689%** |
| `torchaudio.functional.resample` | 5.850% |
| **`_get_sinc_resample_kernel` (self time)** | **5.667%** |
| `forward_batch_generation` (model forward) | 5.850% |

For comparison, #1516 measured the same function at **7.3%** of non-idle samples in a loaded
Fun-ASR process on H200, which is what motivated caching it on the WAV path.

Per-request phase medians from `--profile-events` (n=50, concurrency 32): request build
**40.514 ms (15.051% of the request)**, encoder+prefill 13.369 ms, decode 82.674 ms, end to end
269.174 ms.

How much the kernel costs depends on the rate pair, because its width scales with `orig/gcd`
(6 s float32 mono, 30 reps each):

| rate pair | build kernel | apply kernel | build share of `resample()` |
|---|---:|---:|---:|
| 22050 -> 16000 | 0.642 ms | 0.682 ms | **48.489%** |
| 44100 -> 16000 | 0.570 ms | 0.865 ms | **39.721%** |
| 24000 -> 16000 | 0.078 ms | 1.267 ms | 5.799% |
| 48000 -> 16000 | 0.089 ms | 2.490 ms | 3.451% |

#1516's benchmark used 48 kHz WAV, where `gcd` is large, the kernel is tiny and the gap is
invisible. 44.1 kHz and 22.05 kHz are the usual rates for uploaded MP3s.

## Modifications

`sglang_omni/utils/audio.py` — `load_audio` now calls `_cached_resample` instead of
`torchaudio.functional.resample`. `_cached_resample` already falls back to
`torchaudio.functional.resample` if the private torchaudio helpers move, so nothing changes when
that happens. The waveform is float32 on CPU at that point, so it shares the one cache entry with
the fast path rather than adding a second.

Left alone deliberately:

- `models/zonos2/components/speaker_encoder.py:83` already wraps `torchaudio.transforms.Resample`
  in `@cache`.
- `models/ming_tts/reference_encode.py:252,258` and `models/fishaudio_s2_pro/stages.py:208` sit
  behind per-reference caches (`ref_audio_cache`, 256 items / 64 MB, and
  `reference_path_cache_key` respectively), so they run on a cache miss only.
- `models/minimax_music3/acoustic.py:56` runs once per completed stream over the whole
  concatenated waveform, so kernel construction amortises against a large apply.
- `models/higgs_tts/audio_codec.py:298` and `models/moss_tts*/audio_tokenizer.py` are TTS
  reference-clip encode paths, not the per-request transcription path.

## Related Issues

Extends #1516. This contributes to the ASR optimisation work tracked in #1396.

## Accuracy Test

Added to `tests/unit_test/utils/test_audio.py`:

- `test_load_audio_general_path_matches_uncached_resample` — output is bit-identical
  (`np.array_equal`) to the previous implementation at 22.05 / 44.1 / 48 kHz -> 16 kHz.
- `test_load_audio_general_path_uses_cached_kernel` — asserts `misses == 1, hits == 2` across three
  calls. Bit-identity alone would still pass if the cache were never consulted, which is the
  failure mode #1516 reported catching in its first version.
- `test_load_audio_general_path_shares_the_kernel_with_the_fast_path` — one shared entry, not two.

Both cache assertions fail on `main` and pass with this change.

```
python -m pytest tests/unit_test/utils/test_audio.py \
                 tests/unit_test/preprocessing/test_resample_cache.py \
                 tests/unit_test/utils/test_fbank_cache.py -q
44 passed
pre-commit run --files sglang_omni/utils/audio.py tests/unit_test/utils/test_audio.py   # clean
```

Corpus WER is identical in every benchmark arm below: **0.00744**.

## Benchmark & Profiling

`benchmarks/eval/benchmark_asr_seedtts.py`, Qwen3-ASR-1.7B on one A800 80GB, concurrency 32,
seedtts-50 EN. Two MP3 corpora built from the **same 50 clips** — the corpus's native 24 kHz and a
44.1 kHz resample — so the only difference between them is the rate pair the front end has to
build a kernel for. torch 2.11.0 / sglang 0.5.16 / transformers 5.12.1.

Method: each arm is a full server restart; arms are interleaved and the order is reversed between
rounds (base-first and head-first) so warm-up drift cannot favour either arm; the first repeat of
every run is dropped as warm-up; 12 measured repeats per arm; medians reported.

| corpus | arm | req/s | lat mean | lat p95 | WER |
|---|---|---:|---:|---:|---:|
| MP3 24 kHz | main | 75.367 | 0.326 s | 0.390 s | 0.00744 |
| MP3 24 kHz | this PR | **82.632 (+9.640%)** | 0.292 s (-10.454%) | 0.356 s (-8.737%) | 0.00744 |
| MP3 44.1 kHz | main | 79.814 | 0.302 s | 0.367 s | 0.00744 |
| MP3 44.1 kHz | this PR | **89.238 (+11.806%)** | 0.271 s (-10.526%) | 0.327 s (-10.923%) | 0.00744 |

Mann-Whitney U over the 12 repeats per arm: p=0.024 for 24 kHz, p=0.0001 for 44.1 kHz.

The saving is a fixed per-request CPU cost on the request-build path, which is why it moves
throughput more than the isolated function timing suggests — the same effect #1516 reported when
caching this kernel on the WAV path gave +6.3% QPS.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
