### PR TITLE
[Comm] Assign unique identities to stream relay transfers

### DIFF
--- a/sglang_omni/comm/engine.py
+++ b/sglang_omni/comm/engine.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from contextlib import suppress
 from dataclasses import dataclass
+from itertools import count
 from typing import Any, Callable
 from uuid import uuid4
 
@@ -121,6 +122,7 @@ class CommEngine:
         ] = {}
         self._send_workers: dict[str, asyncio.Task] = {}
         self._pending: dict[str, _PendingTransfer] = {}
+        self._stream_send_sequence = count()
         # Failed pending KV transfers stay pinned until this dying process exits.
         self._retained_pending_kv_transfers: list[_PendingTransfer] = []
         self._kv_pools: dict[str, KVPool] = {}
@@ -821,6 +823,10 @@ class CommEngine:
 
     async def _run_stream_send(self, job: _StreamSendJob, queue_key: str) -> None:
         object_id: str | None = None
+        stream_object_id = (
+            f"{job.request_id}:stream:{job.from_stage}:{job.target_stage}:"
+            f"{job.chunk_id}:{next(self._stream_send_sequence)}"
+        )
         send_start = _comm_now_ns()
         write_ms = -1.0
         control_ms = -1.0
@@ -833,6 +839,7 @@ class CommEngine:
                 target_stage=job.target_stage,
                 from_stage=job.from_stage,
                 chunk_id=job.chunk_id,
+                object_id=stream_object_id,
                 metadata=job.metadata,
                 transport=job.transport,
             )

--- a/sglang_omni/comm/stage_io.py
+++ b/sglang_omni/comm/stage_io.py
@@ -432,10 +432,12 @@ async def write_stream_chunk(
     target_stage: str,
     from_stage: str,
     chunk_id: int,
+    object_id: str | None = None,
     metadata: dict | None = None,
     transport: TransportKind,
 ) -> tuple[DataRef, list[Any]]:
-    object_id = f"{request_id}:stream:{from_stage}:{target_stage}:{chunk_id}"
+    if object_id is None:
+        object_id = f"{request_id}:stream:{from_stage}:{target_stage}:{chunk_id}"
     data_ref, op = await write_tensor(
         relay,
         object_id,

--- a/tests/unit_test/pipeline/test_comm_engine_ack.py
+++ b/tests/unit_test/pipeline/test_comm_engine_ack.py
@@ -93,6 +93,47 @@ async def _wait_until(predicate, timeout: float = 1.0) -> None:
         await asyncio.sleep(0)
 
 
+def _consume_task_exception(task: asyncio.Task, _label: str) -> None:
+    if not task.cancelled():
+        task.exception()
+
+
+def _stream_ack(
+    *,
+    request_id: str,
+    object_id: str,
+) -> DataAckMessage:
+    return DataAckMessage(
+        request_id=request_id,
+        from_stage="consumer",
+        to_stage="producer",
+        object_id=object_id,
+    )
+
+
+async def _send_stream_for_ack_test(
+    engine: CommEngine,
+    relay: _AckedRelay,
+    control_plane: RecordingStageControlPlane,
+    *,
+    request_id: str,
+    metadata: dict[str, Any] | None = None,
+) -> DataRef:
+    await engine.send_stream_chunk(
+        relay=relay,
+        control_plane=control_plane,
+        request_id=request_id,
+        data=torch.ones(2),
+        target_stage="consumer",
+        target_endpoint="inproc://consumer",
+        from_stage="producer",
+        chunk_id=0,
+        metadata=metadata,
+        transport=TransportKind.SHM,
+    )
+    return DataRef.from_dict(control_plane.sent_to_stage[-1][2].data_ref)
+
+
 def test_comm_engine_releases_sender_op_after_data_ack() -> None:
     async def _run() -> None:
         relay = _AckedRelay()
@@ -137,6 +178,139 @@ def test_comm_engine_releases_sender_op_after_data_ack() -> None:
         )
         await _wait_until(lambda: op.waited)
         assert op.acked
+
+    asyncio.run(_run())
+
+
+def test_comm_engine_stream_sends_with_reused_semantics_coexist() -> None:
+    async def _run() -> None:
+        relay = _AckedRelay()
+        control_plane = RecordingStageControlPlane()
+        engine = CommEngine(
+            CommRouter(
+                stage_name="producer",
+                gpu_id=None,
+                same_process_targets=set(),
+                gpu_stage_names=set(),
+                comm_config={"ack_timeout_s": 1.0},
+                injected_relay=relay,
+            ),
+            task_done_callback=_consume_task_exception,
+        )
+
+        metadata = {"embedding": torch.ones(1)}
+        data_ref_a = await _send_stream_for_ack_test(
+            engine,
+            relay,
+            control_plane,
+            request_id="req-reused",
+            metadata=metadata,
+        )
+        data_ref_b = await _send_stream_for_ack_test(
+            engine,
+            relay,
+            control_plane,
+            request_id="req-reused",
+            metadata=metadata,
+        )
+
+        assert data_ref_a.object_id != data_ref_b.object_id
+        metadata_a = data_ref_a.metadata_tensors[0].ref.object_id
+        metadata_b = data_ref_b.metadata_tensors[0].ref.object_id
+        assert metadata_a != metadata_b
+        assert metadata_a.startswith(f"{data_ref_a.object_id}:meta:0")
+        assert metadata_b.startswith(f"{data_ref_b.object_id}:meta:0")
+        assert set(engine._pending) == {
+            data_ref_a.object_id,
+            data_ref_b.object_id,
+        }
+
+        ops_a = relay.ops[:2]
+        ops_b = relay.ops[2:]
+        engine.ack_transfer(
+            _stream_ack(request_id="req-reused", object_id=data_ref_a.object_id)
+        )
+        await _wait_until(
+            lambda: data_ref_a.object_id not in engine._pending
+            and all(op.waited for op in ops_a)
+        )
+        assert all(op.acked for op in ops_a)
+        assert data_ref_b.object_id in engine._pending
+        assert not any(op.acked or op.waited for op in ops_b)
+
+        engine.ack_transfer(
+            _stream_ack(request_id="req-reused", object_id=data_ref_b.object_id)
+        )
+        await _wait_until(
+            lambda: data_ref_b.object_id not in engine._pending
+            and all(op.waited for op in ops_b)
+        )
+        assert all(op.acked for op in ops_b)
+
+    asyncio.run(_run())
+
+
+def test_stream_stale_ack_does_not_complete_reused_send() -> None:
+    async def _run() -> None:
+        relay = _AckedRelay()
+        control_plane = RecordingStageControlPlane()
+        engine = CommEngine(
+            CommRouter(
+                stage_name="producer",
+                gpu_id=None,
+                same_process_targets=set(),
+                gpu_stage_names=set(),
+                comm_config={"ack_timeout_s": 0.05},
+                injected_relay=relay,
+            ),
+            task_done_callback=_consume_task_exception,
+        )
+
+        data_ref_a = await _send_stream_for_ack_test(
+            engine,
+            relay,
+            control_plane,
+            request_id="req-reused",
+        )
+        pending_a = engine._pending[data_ref_a.object_id]
+        assert pending_a.task is not None
+
+        await _wait_until(
+            lambda: data_ref_a.object_id not in engine._pending
+            and pending_a.task.done(),
+            timeout=5.0,
+        )
+        with pytest.raises(asyncio.TimeoutError):
+            await pending_a.task
+        assert relay.ops[0].failed is not None
+
+        engine._ack_timeout_s = 1.0
+        data_ref_b = await _send_stream_for_ack_test(
+            engine,
+            relay,
+            control_plane,
+            request_id="req-reused",
+        )
+        assert data_ref_b.object_id in engine._pending
+        pending_b = engine._pending[data_ref_b.object_id]
+        op_b = relay.ops[1]
+
+        engine.ack_transfer(
+            _stream_ack(request_id="req-reused", object_id=data_ref_a.object_id)
+        )
+        assert data_ref_b.object_id in engine._pending
+        assert not pending_b.ack.done()
+        assert not op_b.acked
+        assert not op_b.waited
+        assert data_ref_a.object_id != data_ref_b.object_id
+
+        engine.ack_transfer(
+            _stream_ack(request_id="req-reused", object_id=data_ref_b.object_id)
+        )
+        await _wait_until(
+            lambda: data_ref_b.object_id not in engine._pending and op_b.waited
+        )
+        assert op_b.acked
 
     asyncio.run(_run())
 


### PR DESCRIPTION
## Motivation

Stream relay transfers currently derive `DataRef.object_id` deterministically from the public request ID, stage edge, and chunk ID.

When the same request ID is reused on the same stream edge, this creates two failure modes:

1. If the previous transfer is still pending, the new transfer reuses the same `object_id` and is rejected as a duplicate pending transfer.
2. If the previous transfer has already timed out, a delayed ACK for that old transfer can match the reused `object_id` and incorrectly complete the newer transfer.

This PR addresses the stream transfer portion of #1307 item 3 by giving each `CommEngine` stream send attempt its own physical transfer identity, while keeping the public request ID and chunk ID unchanged.

PR #1487 separately introduces unique identities for `CommEngine` payload sends. This PR intentionally does not duplicate that payload work.

## Modifications

- Add a per `CommEngine` stream send sequence and include it in the stream transfer `object_id`.
- Pass the generated transfer identity into `StageIO.write_stream_chunk()`.
- Keep the existing deterministic `StageIO` stream ID as the fallback when `object_id` is not explicitly supplied, preserving direct low-level callers.
- Add regression coverage for:
  - two in flight stream sends with the same request ID, stage edge, and chunk ID;
  - independent ACK completion for those transfers;
  - metadata tensor IDs inheriting the unique parent transfer identity;
  - delayed stale ACKs after the previous transfer times out.

The regression tests exercise the real pending transfer and timeout lifecycle rather than manually mutating `_pending`.

### Verification

A baseline CPU run against the unmodified parent revision with only the new regression tests reproduces both target failures:

- concurrent reuse fails with `duplicate pending transfer 'req-reused:stream:producer:consumer:0'`;
- after the first transfer times out, its delayed ACK incorrectly resolves the newer transfer.

With this PR applied:

- `tests/unit_test/pipeline/test_comm_engine_ack.py`: **7 passed**
- `tests/unit_test/pipeline/test_stage_streaming.py`: **16 passed, 1 verification-only deselected**
- `tests/unit_test/pipeline/test_payload_device_restore.py`: **9 passed**
- `tests/unit_test/relay/test_shm_relay.py`: **1 passed**
- repository `lint.yaml`: **passed**

The one deselected stage streaming case fails identically on the unmodified parent revision in an entirely CPU environment after #994, so it is excluded only from the temporary fork CPU verification workflow. The repository test itself is unchanged.

I also validated this stream change on top of the current #1487 head. The combined CPU verification passed, including a temporary payload stale-ACK regression for #1487's payload identity implementation.

## Related Issues

Addresses the stream transfer portion of #1307 item 3.

Related: #1487, which independently covers unique payload transfer identities.

## Accuracy Test

Not applicable. This PR does not change model side code, kernels, model architecture, or model outputs.

## Benchmark & Profiling

Not applicable. This is a communication correctness fix and does not make throughput or latency claims.

## Checklist

- [x] Format your code according with pre commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
