### PR TITLE
[Perf] Restore fast WAV duration probing for ASR

### DIFF
--- a/sglang_omni/serve/speech_to_text.py
+++ b/sglang_omni/serve/speech_to_text.py
@@ -220,7 +220,10 @@ def probe_audio_duration(audio_bytes: bytes) -> float:
             if info.samplerate:
                 return max(info.frames / float(info.samplerate), 0.0)
         except (RuntimeError, ValueError):
-            pass
+            logger.debug(
+                "WAV duration fast path failed; falling back to PyAV",
+                exc_info=True,
+            )
 
     try:
         import av

--- a/sglang_omni/serve/speech_to_text.py
+++ b/sglang_omni/serve/speech_to_text.py
@@ -200,11 +200,28 @@ def resolve_speech_to_text_adapter(
 def probe_audio_duration(audio_bytes: bytes) -> float:
     """Best-effort audio duration (seconds) from raw upload bytes.
 
-    Metadata-only: reads container headers, never decodes. PyAV wraps the
-    same FFmpeg demuxers load_audio decodes with, so any upload the engine
-    can read, this probe can measure (soundfile could not inspect M4A/WebM).
-    0.0 means unknown; callers treat that as "duration not available".
+    Metadata-only: reads container headers, never decodes. WAV uploads take a
+    libsndfile fast path; other formats and malformed WAV headers fall back to
+    the same PyAV/FFmpeg demuxers that ``load_audio`` uses. 0.0 means unknown;
+    callers treat that as "duration not available".
     """
+    # note (Xinyu): SeedTTS is entirely RIFF/WAVE, where opening FFmpeg through
+    # PyAV costs several milliseconds more per request than reading the header.
+    is_wav = (
+        len(audio_bytes) >= 12
+        and audio_bytes[:4] in {b"RIFF", b"RIFX", b"RF64"}
+        and audio_bytes[8:12] == b"WAVE"
+    )
+    if is_wav:
+        try:
+            import soundfile as sf
+
+            info = sf.info(io.BytesIO(audio_bytes))
+            if info.samplerate:
+                return max(info.frames / float(info.samplerate), 0.0)
+        except (RuntimeError, ValueError):
+            pass
+
     try:
         import av
 

--- a/tests/unit_test/serve/test_speech_to_text.py
+++ b/tests/unit_test/serve/test_speech_to_text.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import io
 import json
+import wave
 
 import pytest
 from fastapi import HTTPException
@@ -24,6 +26,16 @@ def _build_request(*, task: str = "transcribe"):
         temperature=None,
         task=task,
     )
+
+
+def _wav_bytes(*, duration_s: float = 0.25, sample_rate: int = 16_000) -> bytes:
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(b"\0\0" * int(duration_s * sample_rate))
+    return buffer.getvalue()
 
 
 def test_transcription_builder_import_keeps_shared_callable() -> None:
@@ -77,6 +89,69 @@ def test_assemble_uses_the_caller_probed_duration(monkeypatch) -> None:
     )
 
     assert json.loads(response.body)["usage"] == {"seconds": 3, "type": "duration"}
+
+
+def test_probe_audio_duration_uses_soundfile_fast_path_for_wav(monkeypatch) -> None:
+    import av
+
+    monkeypatch.setattr(
+        av,
+        "open",
+        lambda *args, **kwargs: pytest.fail("WAV duration probe fell back to PyAV"),
+    )
+
+    assert speech_to_text.probe_audio_duration(_wav_bytes()) == pytest.approx(0.25)
+
+
+def test_probe_audio_duration_uses_pyav_for_non_wav(monkeypatch) -> None:
+    import av
+    import soundfile as sf
+
+    class FakeContainer:
+        duration = 2_500_000
+        streams = ()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    monkeypatch.setattr(
+        sf,
+        "info",
+        lambda *args, **kwargs: pytest.fail(
+            "non-WAV duration probe used the soundfile fast path"
+        ),
+    )
+    monkeypatch.setattr(av, "open", lambda *args, **kwargs: FakeContainer())
+
+    assert speech_to_text.probe_audio_duration(b"not-a-wav") == pytest.approx(2.5)
+
+
+def test_probe_audio_duration_falls_back_when_wav_fast_path_fails(
+    monkeypatch,
+) -> None:
+    import av
+    import soundfile as sf
+
+    class FakeContainer:
+        duration = 1_500_000
+        streams = ()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    def fail_soundfile_probe(*args, **kwargs):
+        raise RuntimeError("bad WAV")
+
+    monkeypatch.setattr(sf, "info", fail_soundfile_probe)
+    monkeypatch.setattr(av, "open", lambda *args, **kwargs: FakeContainer())
+
+    assert speech_to_text.probe_audio_duration(_wav_bytes()) == pytest.approx(1.5)
 
 
 def test_verbose_response_uses_requested_task() -> None:


### PR DESCRIPTION
## Motivation

Speech-to-text request validation probes the uploaded audio duration before dispatch. After duration probing moved to PyAV for broader container support, WAV uploads also paid the cost of opening the FFmpeg demuxer. This adds several milliseconds to every request and is especially visible for SeedTTS at low concurrency, even though WAV duration is available directly from the container header.

Restore the lightweight libsndfile metadata path for WAV while preserving PyAV coverage for other formats and malformed WAV inputs.

## Modifications

1. `sglang_omni/serve/speech_to_text.py`
   - Detect RIFF, RIFX, and RF64 containers whose form type is `WAVE`.
   - Read valid WAV duration with `soundfile.info` without decoding audio or opening FFmpeg.
   - Fall through to the existing PyAV probe for non-WAV inputs and when the WAV fast path cannot read the header.

2. `tests/unit_test/serve/test_speech_to_text.py`
   - Verify valid WAV input uses the soundfile path without calling PyAV.
   - Verify non-WAV input skips soundfile and continues through PyAV.
   - Verify an unreadable WAV header falls back to PyAV.

## Related Issues

#1396 

## Accuracy Test

**Setup:**

- Compared refs: c=1,2,4 use baseline `main @ 68abc7ee` and candidate
  `c0cd5d0d`; c=8,16 use baseline `main @ d0edde03` and candidate `8b5f7b54`.
- Model: `Qwen/Qwen3-ASR-1.7B` checkpoint `7278e1e70fe206f11671096ffdd38061171dd6e5`.
- Dataset: SeedTTS EN revision `27f4c1adee83b5b29b7c4b375f6b976324bda308`, 1,088 WAV clips.
- Hardware: NVIDIA H200, GPU 7. Each concurrency uses one discarded warmup and three measured full-corpus repeats.
- Candidate server: `--max-running-requests 64 --cuda-graph-max-bs 64 --mem-fraction-static 0.90` with FA3 and CUDA graphs enabled.

| Concurrency | Baseline corpus WER | Candidate corpus WER | Evaluated requests per variant |
| ---: | ---: | ---: | ---: |
| 1 | 1.218% | 1.203% | 3,264 / 3,264 |
| 2 | 1.218% | 1.218% | 3,264 / 3,264 |
| 4 | 1.218% | 1.213% | 3,264 / 3,264 |
| 8 | 1.218% | 1.218% | 3,264 / 3,264 |
| 16 | 1.218% | 1.218% | 3,264 / 3,264 |

All candidate requests completed successfully with no skipped samples.

## Benchmark & Profiling

Same model, dataset, hardware, and repeat configuration as described in the
_Accuracy Test_ section.

| Concurrency | Baseline throughput (mean +/- std) | Candidate throughput (mean +/- std) | Delta |
| ---: | ---: | ---: | ---: |
| 1 | 20.908 +/- 0.068 req/s | 24.687 +/- 0.215 req/s | +18.08% |
| 2 | 26.473 +/- 0.064 req/s | 33.449 +/- 1.073 req/s | +26.35% |
| 4 | 51.052 +/- 0.101 req/s | 66.298 +/- 0.446 req/s | +29.86% |
| 8 | 92.228 +/- 0.465 req/s | 117.020 +/- 1.602 req/s | +26.88% |
| 16 | 155.368 +/- 1.137 req/s | 175.982 +/- 2.648 req/s | +13.27% |

| Concurrency | Baseline mean latency | Candidate mean latency | Delta |
| ---: | ---: | ---: | ---: |
| 1 | 47.66 ms | 40.37 ms | -15.30% |
| 2 | 75.35 ms | 59.68 ms | -20.79% |
| 4 | 77.84 ms | 59.90 ms | -23.04% |
| 8 | 86.27 ms | 68.02 ms | -21.15% |
| 16 | 102.31 ms | 90.13 ms | -11.90% |

The production `asyncio.to_thread` duration probe microbenchmark dropped from 7.192 ms to 0.108 ms per cached SeedTTS WAV file, a 98.49% reduction (about 7.084 ms saved per request).


## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.