### PR TITLE
[ROCm] Implement AMD backend on the multi-hardware platform

### DIFF
--- a/sglang_omni/cli/check_gpu.py
+++ b/sglang_omni/cli/check_gpu.py
@@ -21,7 +21,7 @@ def check_gpu(
         bool,
         typer.Option(
             "--strict",
-            help="Exit nonzero when warnings are present or no CUDA GPU is visible.",
+            help="Exit nonzero when warnings are present or no GPU is visible.",
         ),
     ] = False,
 ) -> None:

--- a/sglang_omni/comm/router.py
+++ b/sglang_omni/comm/router.py
@@ -146,6 +146,15 @@ class CommRouter:
             return TransportKind.SHM
         return transport
 
+    def _remote_transport(self) -> TransportKind:
+        transport = current_platform.get_remote_transport()
+        if transport is None:
+            raise NotImplementedError(
+                f"cross-node transport is not supported on "
+                f"{current_platform.device_name}"
+            )
+        return transport
+
     def outbound(self, target: str) -> TransportKind:
         if target in self.same_process_targets:
             return TransportKind.LOCAL_OBJECT
@@ -153,7 +162,7 @@ class CommRouter:
 
     def _physical_outbound(self, target: str) -> TransportKind:
         if target in self.remote_stage_names:
-            return TransportKind.MOONCAKE
+            return self._remote_transport()
         if self.self_is_gpu and target in self.gpu_stage_names:
             return self._intra_node_transport(target)
         return TransportKind.SHM
@@ -165,7 +174,7 @@ class CommRouter:
                 f"{type(data).__name__}"
             )
         if target in self.remote_stage_names:
-            return TransportKind.MOONCAKE
+            return self._remote_transport()
         if data.device.type != current_platform.device_type:
             return TransportKind.SHM
         if self.self_is_gpu and target in self.gpu_stage_names:
@@ -177,7 +186,7 @@ class CommRouter:
 
     def inbound(self, from_stage: str) -> TransportKind:
         if from_stage in self.remote_stage_names:
-            return TransportKind.MOONCAKE
+            return self._remote_transport()
         if self.self_is_gpu and from_stage in self.gpu_stage_names:
             return current_platform.get_intra_node_transport()
         return TransportKind.SHM
@@ -212,7 +221,7 @@ class CommRouter:
 
     def outbound_payload(self, target: str, payload: Any) -> TransportKind:
         if target in self.remote_stage_names:
-            return TransportKind.MOONCAKE
+            return self._remote_transport()
         devices = _tensor_devices(getattr(payload, "data", payload))
         if not devices or devices == {"cpu"}:
             return TransportKind.SHM

--- a/sglang_omni/diagnostics/gpu.py
+++ b/sglang_omni/diagnostics/gpu.py
@@ -36,6 +36,7 @@ _BACKENDS = (
     ("communication", "nixl", "nixl._api"),
     ("communication", "mooncake", "mooncake.engine"),
 )
+_ROCM_BACKENDS = (("attention", "aiter", "aiter"),)
 _IMPORT_PROBE_TIMEOUT_SECONDS = 30.0
 _IMPORT_PROBE_CODE = "import importlib, sys; importlib.import_module(sys.argv[1])"
 
@@ -107,9 +108,11 @@ def _distribution_info(module: str) -> tuple[str | None, str | None]:
     return None, None
 
 
-def _backend_inventory() -> list[dict[str, Any]]:
+def _backend_inventory(
+    extra_backends: tuple[tuple[str, str, str], ...] = (),
+) -> list[dict[str, Any]]:
     backends = []
-    for category, name, module in _BACKENDS:
+    for category, name, module in (*extra_backends, *_BACKENDS):
         import_error = _module_import_error(module)
         distribution, version = _distribution_info(module)
         importable = import_error is None
@@ -264,6 +267,8 @@ def _logical_devices(
     visible_devices: list[int | str],
     inventory: list[dict[str, Any]],
     warnings: list[str],
+    *,
+    accelerator: str,
 ) -> list[dict[str, Any]]:
     if not torch.cuda.is_available():
         return []
@@ -298,26 +303,50 @@ def _logical_devices(
                 f"CUDA_VISIBLE_DEVICES entry {visible_device!r} is a MIG device; "
                 "physical GPU mapping and free memory are unsupported."
             )
+        torch_major = getattr(properties, "major", None)
+        torch_minor = getattr(properties, "minor", None)
         torch_cc = (
-            f"{properties.major}.{properties.minor}" if properties is not None else None
+            f"{torch_major}.{torch_minor}"
+            if torch_major is not None and torch_minor is not None
+            else None
         )
-        devices.append(
-            {
-                "logical_index": logical_index,
-                "visible_device": visible_device,
-                "physical_index": physical.get("physical_index"),
-                "uuid": physical.get("uuid")
-                or str(getattr(properties, "uuid", "") or "")
-                or None,
-                "pci_bus_id": physical.get("pci_bus_id"),
-                "name": physical.get("name") or getattr(properties, "name", None),
-                "compute_capability": physical.get("compute_capability") or torch_cc,
-                "total_memory_bytes": physical.get("total_memory_bytes")
-                or getattr(properties, "total_memory", None),
-                "free_memory_bytes": physical.get("free_memory_bytes"),
-            }
-        )
+        free_memory = physical.get("free_memory_bytes")
+        if free_memory is None and accelerator == "rocm":
+            try:
+                free_memory = int(torch.cuda.mem_get_info(logical_index)[0])
+            except Exception as exc:
+                warnings.append(
+                    "PyTorch ROCm memory query failed for "
+                    f"logical_index={logical_index}: {exc}"
+                )
+        device = {
+            "logical_index": logical_index,
+            "visible_device": visible_device,
+            "physical_index": physical.get("physical_index"),
+            "uuid": physical.get("uuid")
+            or str(getattr(properties, "uuid", "") or "")
+            or None,
+            "pci_bus_id": physical.get("pci_bus_id"),
+            "name": physical.get("name") or getattr(properties, "name", None),
+            "compute_capability": physical.get("compute_capability") or torch_cc,
+            "total_memory_bytes": physical.get("total_memory_bytes")
+            or getattr(properties, "total_memory", None),
+            "free_memory_bytes": free_memory,
+        }
+        if accelerator == "rocm":
+            device["compute_capability"] = None
+            device["gpu_architecture"] = getattr(properties, "gcnArchName", None)
+        devices.append(device)
     return devices
+
+
+def _accelerator_environment(torch: Any) -> tuple[str, str]:
+    version = getattr(torch, "version", None)
+    if getattr(version, "hip", None):
+        return "rocm", "cuda"
+    if getattr(version, "cuda", None):
+        return "cuda", "cuda"
+    return "cpu", "cpu"
 
 
 def collect_gpu_diagnostics(
@@ -329,37 +358,83 @@ def collect_gpu_diagnostics(
     """Collect diagnostics without loading model configuration or weights."""
 
     source_env = os.environ if env is None else env
-    visible_value = source_env.get("CUDA_VISIBLE_DEVICES")
-    visible_devices = parse_cuda_visible_devices(visible_value)
     torch = torch_module or importlib.import_module("torch")
-    pynvml = pynvml_module if pynvml_module is not None else _try_import_pynvml()
+    accelerator, device_type = _accelerator_environment(torch)
+    visible_variable = (
+        next(
+            (
+                name
+                for name in (
+                    "ROCR_VISIBLE_DEVICES",
+                    "HIP_VISIBLE_DEVICES",
+                    "CUDA_VISIBLE_DEVICES",
+                )
+                if source_env.get(name)
+            ),
+            "ROCR_VISIBLE_DEVICES",
+        )
+        if accelerator == "rocm"
+        else "CUDA_VISIBLE_DEVICES"
+    )
+    visible_value = source_env.get(visible_variable)
+    visible_devices = parse_cuda_visible_devices(visible_value)
+    pynvml = (
+        pynvml_module
+        if pynvml_module is not None
+        else (_try_import_pynvml() if accelerator == "cuda" else None)
+    )
 
     inventory, system, warnings = _nvml_inventory(pynvml)
     try:
-        devices = _logical_devices(torch, visible_devices, inventory, warnings)
+        devices = _logical_devices(
+            torch,
+            visible_devices,
+            inventory,
+            warnings,
+            accelerator=accelerator,
+        )
     finally:
         if pynvml is not None:
             _shutdown_nvml(pynvml)
 
-    backends = _backend_inventory()
+    backends = _backend_inventory(_ROCM_BACKENDS if accelerator == "rocm" else ())
     warnings.extend(
         backend["reason"]
         for backend in backends
         if backend["installed"] and not backend["importable"]
     )
+    environment = {
+        "cuda_visible_devices": source_env.get("CUDA_VISIBLE_DEVICES"),
+        **system,
+        "cuda_runtime_version": _cuda_runtime_version(),
+        "pytorch_version": getattr(torch, "__version__", None),
+        "pytorch_cuda_build": getattr(getattr(torch, "version", None), "cuda", None),
+        "cuda_available": bool(torch.cuda.is_available()),
+        "logical_device_count": len(devices),
+    }
+    if accelerator == "rocm":
+        environment.update(
+            {
+                "accelerator": accelerator,
+                "device_type": device_type,
+                "visible_devices_variable": visible_variable,
+                "rocr_visible_devices": source_env.get("ROCR_VISIBLE_DEVICES"),
+                "hip_visible_devices": source_env.get("HIP_VISIBLE_DEVICES"),
+                "pytorch_rocm_build": getattr(
+                    getattr(torch, "version", None), "hip", None
+                ),
+                "gpu_architectures": sorted(
+                    {
+                        str(device["gpu_architecture"])
+                        for device in devices
+                        if device.get("gpu_architecture")
+                    }
+                ),
+            }
+        )
     return {
         "schema_version": 1,
-        "environment": {
-            "cuda_visible_devices": visible_value,
-            **system,
-            "cuda_runtime_version": _cuda_runtime_version(),
-            "pytorch_version": getattr(torch, "__version__", None),
-            "pytorch_cuda_build": getattr(
-                getattr(torch, "version", None), "cuda", None
-            ),
-            "cuda_available": bool(torch.cuda.is_available()),
-            "logical_device_count": len(devices),
-        },
+        "environment": environment,
         "gpus": devices,
         "backends": backends,
         "warnings": warnings,
@@ -370,31 +445,57 @@ def render_gpu_diagnostics(report: Mapping[str, Any]) -> str:
     """Render a compact diagnostic summary for terminal output."""
 
     environment = report["environment"]
-    visible = environment["cuda_visible_devices"]
-    lines = [
-        "SGLang-Omni GPU diagnostics (no model loaded)",
-        f"CUDA_VISIBLE_DEVICES: {visible if visible is not None else '<unset>'}",
-        f"Driver: {environment['driver_version'] or 'unavailable'}",
-        (
-            "CUDA driver/runtime: "
-            f"{environment['cuda_driver_api_version'] or 'unavailable'} / "
-            f"{environment['cuda_runtime_version'] or 'unavailable'}"
-        ),
-        (
-            "PyTorch/CUDA build: "
-            f"{environment['pytorch_version'] or 'unavailable'} / "
-            f"{environment['pytorch_cuda_build'] or 'unavailable'}"
-        ),
-        "GPUs:",
-    ]
+    accelerator = environment.get("accelerator", "cuda")
+    if accelerator == "rocm":
+        visible_variable = environment["visible_devices_variable"]
+        visible = environment.get(visible_variable.lower())
+        lines = [
+            "SGLang-Omni GPU diagnostics (no model loaded)",
+            "Accelerator: rocm",
+            f"{visible_variable}: {visible if visible is not None else '<unset>'}",
+            (
+                "PyTorch/ROCm build: "
+                f"{environment['pytorch_version'] or 'unavailable'} / "
+                f"{environment.get('pytorch_rocm_build') or 'unavailable'}"
+            ),
+            "GPUs:",
+        ]
+    else:
+        visible = environment["cuda_visible_devices"]
+        lines = [
+            "SGLang-Omni GPU diagnostics (no model loaded)",
+            f"CUDA_VISIBLE_DEVICES: {visible if visible is not None else '<unset>'}",
+            f"Driver: {environment['driver_version'] or 'unavailable'}",
+            (
+                "CUDA driver/runtime: "
+                f"{environment['cuda_driver_api_version'] or 'unavailable'} / "
+                f"{environment['cuda_runtime_version'] or 'unavailable'}"
+            ),
+            (
+                "PyTorch/CUDA build: "
+                f"{environment['pytorch_version'] or 'unavailable'} / "
+                f"{environment['pytorch_cuda_build'] or 'unavailable'}"
+            ),
+            "GPUs:",
+        ]
     if not report["gpus"]:
-        lines.append("  No CUDA devices are visible to PyTorch.")
+        lines.append(
+            "  No ROCm devices are visible to PyTorch."
+            if accelerator == "rocm"
+            else "  No CUDA devices are visible to PyTorch."
+        )
     for device in report["gpus"]:
+        architecture = (
+            f"arch={device.get('gpu_architecture') or 'unknown'} "
+            if accelerator == "rocm"
+            else ""
+        )
         lines.append(
             f"  logical {device['logical_index']} -> physical "
             f"{device['physical_index']} visible={device['visible_device']} "
             f"name={device['name'] or 'unknown'} "
             f"cc={device['compute_capability'] or 'unknown'} "
+            f"{architecture}"
             f"memory={format_bytes_gib(device['free_memory_bytes'])}/"
             f"{format_bytes_gib(device['total_memory_bytes'])} "
             f"uuid={device['uuid'] or 'unknown'} "

--- a/sglang_omni/platforms/__init__.py
+++ b/sglang_omni/platforms/__init__.py
@@ -6,9 +6,10 @@ from sglang.srt import platforms as srt_platforms
 from sglang.srt.platforms.interface import SRTPlatform
 
 from sglang_omni.platforms.cpu import CPUOmniPlatform
-from sglang_omni.platforms.cuda import CUDAOmniPlatform, ROCMOmniPlatform
+from sglang_omni.platforms.cuda import CUDAOmniPlatform
 from sglang_omni.platforms.interface import OmniPlatform
 from sglang_omni.platforms.npu import NPUOmniPlatform
+from sglang_omni.platforms.rocm import ROCMOmniPlatform
 from sglang_omni.platforms.xpu import XPUOmniPlatform
 
 

--- a/sglang_omni/platforms/cuda.py
+++ b/sglang_omni/platforms/cuda.py
@@ -6,7 +6,6 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 from sglang.srt.platforms.cuda import CudaDeviceMixin
-from sglang.srt.platforms.rocm import RocmDeviceMixin
 
 from sglang_omni.platforms.interface import OmniPlatform
 from sglang_omni.quantization import resolve_quant_config
@@ -191,7 +190,3 @@ class CUDAOmniPlatform(CudaDeviceMixin, OmniPlatform):
             f"fp8_gemm_backend={fp8_gemm_backend}"
         )
         return effective_quantization
-
-
-class ROCMOmniPlatform(RocmDeviceMixin, CUDAOmniPlatform):
-    pass

--- a/sglang_omni/platforms/interface.py
+++ b/sglang_omni/platforms/interface.py
@@ -31,6 +31,12 @@ class OmniPlatform(DeviceMixin):
 
         return TransportKind.SHM
 
+    def get_remote_transport(self) -> TransportKind | None:
+        """Return the cross-node transport, or None when it is unsupported."""
+        from sglang_omni.comm.data_ref import TransportKind
+
+        return TransportKind.MOONCAKE
+
     def get_fused_qk_norm_rope(self):
         """Get the fused QK norm RoPE kernel if available, else return None."""
         return None

--- a/sglang_omni/platforms/rocm.py
+++ b/sglang_omni/platforms/rocm.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+from sglang.srt.platforms.rocm import RocmDeviceMixin
+
+from sglang_omni.platforms.interface import OmniPlatform
+
+if TYPE_CHECKING:
+    from sglang_omni.comm.data_ref import TransportKind
+    from sglang_omni.pipeline.stage_workers import StageLaunchConfig
+
+
+_VISIBLE_DEVICE_VARIABLES = (
+    "ROCR_VISIBLE_DEVICES",
+    "HIP_VISIBLE_DEVICES",
+    "CUDA_VISIBLE_DEVICES",
+)
+
+
+def _parse_visible_devices(name: str, value: str) -> list[str]:
+    devices = [item.strip() for item in value.split(",")]
+    if not devices or any(not item for item in devices):
+        raise ValueError(f"invalid {name} value {value!r}")
+    return devices
+
+
+def _resolve_physical_visible_devices(source_env: Mapping[str, str]) -> list[str]:
+    configured = {
+        name: _parse_visible_devices(name, value)
+        for name in _VISIBLE_DEVICE_VARIABLES
+        if (value := (source_env.get(name) or "").strip())
+    }
+    if not configured:
+        return []
+
+    if "ROCR_VISIBLE_DEVICES" in configured:
+        physical = configured["ROCR_VISIBLE_DEVICES"]
+    else:
+        first_name = next(
+            name for name in _VISIBLE_DEVICE_VARIABLES if name in configured
+        )
+        physical = configured[first_name]
+
+    logical = [str(index) for index in range(len(physical))]
+    for name, devices in configured.items():
+        if devices not in (physical, logical):
+            raise ValueError(
+                "conflicting ROCm visibility namespaces: "
+                f"ROCR/HIP/CUDA masks resolve to {physical!r}, but {name}={devices!r}"
+            )
+    return physical
+
+
+class ROCMOmniPlatform(RocmDeviceMixin, OmniPlatform):
+    """AMD ROCm implementation of Omni's shared accelerator contract.
+
+    ROCm intentionally does not inherit NVIDIA CUDA policy. PyTorch exposes HIP
+    devices through the CUDA-shaped device API, while backend selection,
+    visibility, transport qualification, and model capabilities remain
+    platform-specific.
+    """
+
+    def get_stage_process_env(
+        self,
+        spec: StageLaunchConfig,
+        env: Mapping[str, str] | None = None,
+    ) -> dict[str, str]:
+        if spec.tp_size <= 1:
+            return {}
+        if spec.gpu_id is None:
+            raise ValueError(f"tp stage {spec.stage_name!r} requires a GPU id")
+
+        source_env = env if env is not None else os.environ
+        visible_devices = _resolve_physical_visible_devices(source_env)
+        if visible_devices:
+            if spec.gpu_id >= len(visible_devices):
+                raise ValueError(
+                    f"tp stage {spec.stage_name!r} assigned gpu_id={spec.gpu_id}, "
+                    f"but ROCm visibility only exposes {visible_devices}"
+                )
+            physical_device = visible_devices[spec.gpu_id]
+        else:
+            physical_device = str(spec.gpu_id)
+
+        return {
+            # ROCr owns the physical-device selection. HIP and CUDA compatibility
+            # aliases then address the single exposed device as logical device 0.
+            "ROCR_VISIBLE_DEVICES": physical_device,
+            "HIP_VISIBLE_DEVICES": "0",
+            "CUDA_VISIBLE_DEVICES": "0",
+            "SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS": "true",
+            "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "false",
+        }
+
+    def get_intra_node_transport(self) -> TransportKind:
+        from sglang_omni.comm.data_ref import TransportKind
+
+        # CUDA-shaped HIP IPC APIs are not sufficient evidence for Omni's relay
+        # lifetime and failure semantics. Use the host-staged fallback until the
+        # ROCm IPC path is qualified independently.
+        return TransportKind.SHM
+
+    def get_remote_transport(self) -> TransportKind | None:
+        # Cross-node ROCm transport is a separate qualification and dependency
+        # layer. Fail before constructing CUDA-oriented Mooncake state.
+        return None

--- a/sglang_omni/utils/gpu_memory.py
+++ b/sglang_omni/utils/gpu_memory.py
@@ -274,10 +274,16 @@ def get_gpu_startup_lock_path(
     env: dict[str, str] | None = None,
     base_dir: str | Path | None = None,
 ) -> Path:
-    """Return the launch-time lock path for a CUDA logical GPU id."""
+    """Return the launch-time lock path for a logical accelerator id."""
 
     source_env = env if env is not None else os.environ
-    visible_devices = parse_cuda_visible_devices(source_env.get("CUDA_VISIBLE_DEVICES"))
+    # ROCm TP workers expose one physical GPU through ROCr and then present that
+    # device as logical zero through HIP/CUDA aliases. Prefer the physical ROCr
+    # selector so different ranks do not contend on the same startup lock.
+    visible_value = source_env.get("ROCR_VISIBLE_DEVICES") or source_env.get(
+        "CUDA_VISIBLE_DEVICES"
+    )
+    visible_devices = parse_cuda_visible_devices(visible_value)
     visible_device = resolve_visible_device_id(logical_gpu_id, visible_devices)
     safe_device = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(visible_device)).strip("_")
     if not safe_device:

--- a/tests/unit_test/diagnostics/test_gpu.py
+++ b/tests/unit_test/diagnostics/test_gpu.py
@@ -100,7 +100,7 @@ def test_collect_gpu_diagnostics_preserves_reordered_visible_mapping(
     fake_torch = _FakeTorch()
     fake_torch.cuda.properties.reverse()
     monkeypatch.setattr(gpu_diagnostics, "_cuda_runtime_version", lambda: "13.3")
-    monkeypatch.setattr(gpu_diagnostics, "_backend_inventory", lambda: [])
+    monkeypatch.setattr(gpu_diagnostics, "_backend_inventory", lambda *_: [])
 
     report = gpu_diagnostics.collect_gpu_diagnostics(
         env={"CUDA_VISIBLE_DEVICES": "1,0"},
@@ -127,6 +127,50 @@ def test_collect_gpu_diagnostics_preserves_reordered_visible_mapping(
     assert fake_nvml.shutdown_called is True
 
 
+def test_collect_gpu_diagnostics_reports_rocm_devices(monkeypatch) -> None:
+    class _FakeRocmCuda(_FakeCuda):
+        def __init__(self) -> None:
+            self.properties = [
+                SimpleNamespace(
+                    name="AMD Instinct MI355X",
+                    gcnArchName="gfx950:sramecc+:xnack-",
+                    total_memory=288 * 1024**3,
+                    uuid="",
+                )
+            ]
+
+        def mem_get_info(self, index: int) -> tuple[int, int]:
+            assert index == 0
+            return 280 * 1024**3, 288 * 1024**3
+
+    class _FakeRocmTorch:
+        __version__ = "2.11.0+rocm7.2"
+        version = SimpleNamespace(cuda=None, hip="7.2")
+
+        def __init__(self) -> None:
+            self.cuda = _FakeRocmCuda()
+
+    monkeypatch.setattr(gpu_diagnostics, "_backend_inventory", lambda *_: [])
+
+    report = gpu_diagnostics.collect_gpu_diagnostics(
+        env={"ROCR_VISIBLE_DEVICES": "3"},
+        torch_module=_FakeRocmTorch(),
+        pynvml_module=None,
+    )
+
+    assert report["environment"]["accelerator"] == "rocm"
+    assert report["environment"]["device_type"] == "cuda"
+    assert report["environment"]["visible_devices_variable"] == ("ROCR_VISIBLE_DEVICES")
+    assert report["environment"]["rocr_visible_devices"] == "3"
+    assert report["environment"]["pytorch_rocm_build"] == "7.2"
+    assert report["environment"]["gpu_architectures"] == ["gfx950:sramecc+:xnack-"]
+    assert report["gpus"][0]["gpu_architecture"] == "gfx950:sramecc+:xnack-"
+    assert report["gpus"][0]["free_memory_bytes"] == 280 * 1024**3
+    rendered = gpu_diagnostics.render_gpu_diagnostics(report)
+    assert "Accelerator: rocm" in rendered
+    assert "arch=gfx950:sramecc+:xnack-" in rendered
+
+
 def test_nvml_inventory_failure_is_isolated_per_physical_device(
     monkeypatch,
 ) -> None:
@@ -142,7 +186,7 @@ def test_nvml_inventory_failure_is_isolated_per_physical_device(
     fake_nvml = _PartiallyFailingNVML()
     fake_torch = _FakeTorch()
     monkeypatch.setattr(gpu_diagnostics, "_cuda_runtime_version", lambda: "13.3")
-    monkeypatch.setattr(gpu_diagnostics, "_backend_inventory", lambda: [])
+    monkeypatch.setattr(gpu_diagnostics, "_backend_inventory", lambda *_: [])
 
     report = gpu_diagnostics.collect_gpu_diagnostics(
         env={"CUDA_VISIBLE_DEVICES": "0,2"},
@@ -168,7 +212,7 @@ def test_nvml_inventory_failure_is_isolated_per_device_field(monkeypatch) -> Non
     fake_nvml = _PartiallyFailingNVML()
     fake_torch = _FakeTorch()
     monkeypatch.setattr(gpu_diagnostics, "_cuda_runtime_version", lambda: "13.3")
-    monkeypatch.setattr(gpu_diagnostics, "_backend_inventory", lambda: [])
+    monkeypatch.setattr(gpu_diagnostics, "_backend_inventory", lambda *_: [])
 
     report = gpu_diagnostics.collect_gpu_diagnostics(
         env={"CUDA_VISIBLE_DEVICES": "0,1"},
@@ -201,7 +245,7 @@ def test_mig_visible_device_emits_unsupported_mapping_warning(monkeypatch) -> No
         )
     ]
     monkeypatch.setattr(gpu_diagnostics, "_cuda_runtime_version", lambda: "13.3")
-    monkeypatch.setattr(gpu_diagnostics, "_backend_inventory", lambda: [])
+    monkeypatch.setattr(gpu_diagnostics, "_backend_inventory", lambda *_: [])
 
     report = gpu_diagnostics.collect_gpu_diagnostics(
         env={"CUDA_VISIBLE_DEVICES": "MIG-instance-uuid"},

--- a/tests/unit_test/pipeline/test_comm_router.py
+++ b/tests/unit_test/pipeline/test_comm_router.py
@@ -21,6 +21,12 @@ def _force_cuda_transport_policy(monkeypatch):
         raising=False,
     )
     monkeypatch.setattr(
+        platforms.current_platform,
+        "get_remote_transport",
+        lambda: TransportKind.MOONCAKE,
+        raising=False,
+    )
+    monkeypatch.setattr(
         platforms.current_platform, "device_type", "cuda", raising=False
     )
 
@@ -55,6 +61,31 @@ def test_comm_router_uses_mooncake_only_for_remote_edges() -> None:
     assert router.outbound_stream("remote_decode", torch.empty(1)) is (
         TransportKind.MOONCAKE
     )
+
+
+def test_comm_router_rejects_remote_edges_when_platform_has_no_transport(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        platforms.current_platform,
+        "get_remote_transport",
+        lambda: None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        platforms.current_platform, "device_name", "rocm", raising=False
+    )
+    router = CommRouter(
+        stage_name="thinker",
+        gpu_id=0,
+        same_process_targets=set(),
+        gpu_stage_names={"remote_decode"},
+        remote_stage_names={"remote_decode"},
+        comm_config={},
+    )
+
+    with pytest.raises(NotImplementedError, match="not supported on rocm"):
+        router.outbound("remote_decode")
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/unit_test/pipeline/test_gpu_memory.py
+++ b/tests/unit_test/pipeline/test_gpu_memory.py
@@ -330,6 +330,7 @@ def test_gpu_startup_lock_path_uses_visible_device_mapping(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
 ) -> None:
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3,MIG-GPU-deadbeef/1/2")
 
     first = gpu_memory.get_gpu_startup_lock_path(0, base_dir=tmp_path)
@@ -337,6 +338,22 @@ def test_gpu_startup_lock_path_uses_visible_device_mapping(
 
     assert first.name == "sglang_omni_gpu_3_startup.lock"
     assert second.name == "sglang_omni_gpu_MIG-GPU-deadbeef_1_2_startup.lock"
+
+
+def test_gpu_startup_lock_path_uses_physical_rocm_mapping(tmp_path) -> None:
+    first = gpu_memory.get_gpu_startup_lock_path(
+        0,
+        env={"ROCR_VISIBLE_DEVICES": "2", "CUDA_VISIBLE_DEVICES": "0"},
+        base_dir=tmp_path,
+    )
+    second = gpu_memory.get_gpu_startup_lock_path(
+        0,
+        env={"ROCR_VISIBLE_DEVICES": "3", "CUDA_VISIBLE_DEVICES": "0"},
+        base_dir=tmp_path,
+    )
+
+    assert first.name == "sglang_omni_gpu_2_startup.lock"
+    assert second.name == "sglang_omni_gpu_3_startup.lock"
 
 
 def test_gpu_startup_lock_releases_after_exception(

--- a/tests/unit_test/test_platforms.py
+++ b/tests/unit_test/test_platforms.py
@@ -48,12 +48,56 @@ def test_rocm_platform_keeps_cuda_compatible_tp_mapping() -> None:
     spec = SimpleNamespace(stage_name="thinker", tp_size=2, gpu_id=1)
 
     assert platform.is_rocm()
-    assert (
-        platform.get_stage_process_env(spec, {"CUDA_VISIBLE_DEVICES": "3,4"})[
-            "CUDA_VISIBLE_DEVICES"
-        ]
-        == "4"
+    updates = platform.get_stage_process_env(spec, {"CUDA_VISIBLE_DEVICES": "3,4"})
+
+    assert updates == {
+        "ROCR_VISIBLE_DEVICES": "4",
+        "HIP_VISIBLE_DEVICES": "0",
+        "CUDA_VISIBLE_DEVICES": "0",
+        "SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS": "true",
+        "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "false",
+    }
+
+
+def test_rocm_platform_prefers_rocr_physical_mapping() -> None:
+    platform = platforms._as_omni_platform(RocmSRTPlatform())
+    spec = SimpleNamespace(stage_name="thinker", tp_size=2, gpu_id=1)
+
+    updates = platform.get_stage_process_env(
+        spec,
+        {
+            "ROCR_VISIBLE_DEVICES": "3,4",
+            "HIP_VISIBLE_DEVICES": "0,1",
+            "CUDA_VISIBLE_DEVICES": "0,1",
+        },
     )
+
+    assert updates["ROCR_VISIBLE_DEVICES"] == "4"
+    assert updates["HIP_VISIBLE_DEVICES"] == "0"
+    assert updates["CUDA_VISIBLE_DEVICES"] == "0"
+
+
+def test_rocm_platform_rejects_conflicting_visibility_namespaces() -> None:
+    platform = platforms._as_omni_platform(RocmSRTPlatform())
+    spec = SimpleNamespace(stage_name="thinker", tp_size=2, gpu_id=1)
+
+    with pytest.raises(ValueError, match="conflicting ROCm visibility"):
+        platform.get_stage_process_env(
+            spec,
+            {
+                "ROCR_VISIBLE_DEVICES": "3,4",
+                "HIP_VISIBLE_DEVICES": "5,6",
+            },
+        )
+
+
+def test_rocm_platform_uses_host_staged_transport() -> None:
+    from sglang_omni.comm.data_ref import TransportKind
+
+    platform = platforms._as_omni_platform(RocmSRTPlatform())
+
+    assert platform.get_intra_node_transport() is TransportKind.SHM
+    assert platform.get_remote_transport() is None
 
 
 def test_srt_plugin_identity_round_trips_to_spawned_process() -> None:


### PR DESCRIPTION
## Motivation

Implements the AMD ROCm backend on SGLang-Omni's shared multi-hardware abstraction from #1310. The NPU and XPU backends already use this platform boundary; ROCm can reuse SGLang's CUDA-shaped HIP device operations without inheriting NVIDIA-specific backend policy.

This PR is now a standalone backend change based on current `main`. It is no longer stacked on the MiniMax Music 3 PR.

## Modifications

- Add a dedicated `ROCMOmniPlatform(RocmDeviceMixin, OmniPlatform)`.
- Keep ROCm platform policy separate from `CUDAOmniPlatform`.
- Translate inherited `ROCR_VISIBLE_DEVICES`, `HIP_VISIBLE_DEVICES`, and `CUDA_VISIBLE_DEVICES` into a consistent rank-local TP environment.
- Use the host-staged SHM relay for same-node ROCm transfers until HIP IPC lifetime, cancellation, peer-access, and abnormal-exit semantics are qualified.
- Reject cross-node ROCm edges before constructing CUDA-oriented Mooncake state; NIXL support remains a separate follow-up.
- Make GPU startup locks use the physical ROCr selector so TP ranks do not deadlock on the same logical-device lock.
- Extend model-free GPU diagnostics with ROCm build, gfx architecture, free-memory, visibility, and AITER inventory.

## Scope

This PR contains platform/backend support only.

Out of scope and kept separately reviewable:

- model eager/graph/kernel fallbacks (#1534 and #1545)
- NIXL distributed transport (#1546)
- ROCm installation images and scheduled CI (#1547)

## CUDA compatibility boundary

- CUDA still resolves to `CUDAOmniPlatform`.
- CUDA IPC remains CUDA's same-node transport.
- Mooncake remains CUDA's default remote transport.
- Existing CUDA diagnostic keys and schema version are preserved.
- No model defaults or serialized configuration fields change in this PR.

## Validation

- `pre-commit run --all-files`: passed.
- MI355X / gfx950 with `localhost/sglang-omni-rocm:gfx950`: 71 focused platform, router, diagnostics, and memory tests passed.
- Live ROCm probe resolved `ROCMOmniPlatform`, `device_type=cuda`, `intra_node_transport=shm`, no remote transport, ROCm 7.2, eight visible MI355X GPUs, and `gfx950:sramecc+:xnack-`.
