### PR TITLE
[ROCm] Add portable model fallbacks

### DIFF
--- a/sglang_omni/cli/check_gpu.py
+++ b/sglang_omni/cli/check_gpu.py
@@ -21,7 +21,7 @@ def check_gpu(
         bool,
         typer.Option(
             "--strict",
-            help="Exit nonzero when warnings are present or no CUDA GPU is visible.",
+            help="Exit nonzero when warnings are present or no accelerator is visible.",
         ),
     ] = False,
 ) -> None:
@@ -33,9 +33,13 @@ def check_gpu(
     else:
         typer.echo(render_gpu_diagnostics(report))
 
-    if strict and (
-        report["warnings"]
-        or not report["environment"]["cuda_available"]
-        or not report["gpus"]
-    ):
-        raise typer.Exit(code=1)
+    if strict:
+        environment = report["environment"]
+        accelerator = environment.get("accelerator")
+        no_accelerator = (
+            accelerator == "cpu"
+            if accelerator is not None
+            else not environment["cuda_available"]
+        )
+        if report["warnings"] or no_accelerator or not report["gpus"]:
+            raise typer.Exit(code=1)

--- a/sglang_omni/comm/data_ref.py
+++ b/sglang_omni/comm/data_ref.py
@@ -12,6 +12,7 @@ class TransportKind(str, Enum):
     LOCAL_OBJECT = "local_object"
     CUDA_IPC = "cuda_ipc"
     SHM = "shm"
+    NIXL = "nixl"
     MOONCAKE = "mooncake"
 
 

--- a/sglang_omni/diagnostics/gpu.py
+++ b/sglang_omni/diagnostics/gpu.py
@@ -36,6 +36,7 @@ _BACKENDS = (
     ("communication", "nixl", "nixl._api"),
     ("communication", "mooncake", "mooncake.engine"),
 )
+_ROCM_BACKENDS = (("attention", "aiter", "aiter"),)
 _IMPORT_PROBE_TIMEOUT_SECONDS = 30.0
 _IMPORT_PROBE_CODE = "import importlib, sys; importlib.import_module(sys.argv[1])"
 
@@ -107,9 +108,11 @@ def _distribution_info(module: str) -> tuple[str | None, str | None]:
     return None, None
 
 
-def _backend_inventory() -> list[dict[str, Any]]:
+def _backend_inventory(
+    extra_backends: tuple[tuple[str, str, str], ...] = (),
+) -> list[dict[str, Any]]:
     backends = []
-    for category, name, module in _BACKENDS:
+    for category, name, module in (*extra_backends, *_BACKENDS):
         import_error = _module_import_error(module)
         distribution, version = _distribution_info(module)
         importable = import_error is None
@@ -264,6 +267,8 @@ def _logical_devices(
     visible_devices: list[int | str],
     inventory: list[dict[str, Any]],
     warnings: list[str],
+    *,
+    accelerator: str,
 ) -> list[dict[str, Any]]:
     if not torch.cuda.is_available():
         return []
@@ -298,26 +303,82 @@ def _logical_devices(
                 f"CUDA_VISIBLE_DEVICES entry {visible_device!r} is a MIG device; "
                 "physical GPU mapping and free memory are unsupported."
             )
+        torch_major = getattr(properties, "major", None)
+        torch_minor = getattr(properties, "minor", None)
         torch_cc = (
-            f"{properties.major}.{properties.minor}" if properties is not None else None
+            f"{torch_major}.{torch_minor}"
+            if torch_major is not None and torch_minor is not None
+            else None
         )
-        devices.append(
-            {
-                "logical_index": logical_index,
-                "visible_device": visible_device,
-                "physical_index": physical.get("physical_index"),
-                "uuid": physical.get("uuid")
-                or str(getattr(properties, "uuid", "") or "")
-                or None,
-                "pci_bus_id": physical.get("pci_bus_id"),
-                "name": physical.get("name") or getattr(properties, "name", None),
-                "compute_capability": physical.get("compute_capability") or torch_cc,
-                "total_memory_bytes": physical.get("total_memory_bytes")
-                or getattr(properties, "total_memory", None),
-                "free_memory_bytes": physical.get("free_memory_bytes"),
-            }
-        )
+        gpu_architecture = getattr(properties, "gcnArchName", None)
+        free_memory = physical.get("free_memory_bytes")
+        if free_memory is None and accelerator == "rocm":
+            try:
+                free_memory = int(torch.cuda.mem_get_info(logical_index)[0])
+            except Exception as exc:
+                warnings.append(
+                    f"PyTorch ROCm memory query failed for logical_index="
+                    f"{logical_index}: {exc}"
+                )
+        device = {
+            "logical_index": logical_index,
+            "visible_device": visible_device,
+            "physical_index": physical.get("physical_index"),
+            "uuid": physical.get("uuid")
+            or str(getattr(properties, "uuid", "") or "")
+            or None,
+            "pci_bus_id": physical.get("pci_bus_id"),
+            "name": physical.get("name") or getattr(properties, "name", None),
+            "compute_capability": physical.get("compute_capability") or torch_cc,
+            "total_memory_bytes": physical.get("total_memory_bytes")
+            or getattr(properties, "total_memory", None),
+            "free_memory_bytes": free_memory,
+        }
+        if accelerator == "rocm":
+            device["compute_capability"] = None
+            device["gpu_architecture"] = gpu_architecture
+        devices.append(device)
     return devices
+
+
+def _accelerator_environment(torch: Any) -> tuple[str, str | None]:
+    version = getattr(torch, "version", None)
+    rocm_version = getattr(version, "hip", None)
+    if rocm_version:
+        return "rocm", "cuda"
+    cuda_version = getattr(version, "cuda", None)
+    if cuda_version:
+        return "cuda", "cuda"
+    xpu = getattr(torch, "xpu", None)
+    if xpu is not None and bool(xpu.is_available()):
+        return "xpu", "xpu"
+    return "cpu", "cpu"
+
+
+def _selected_backend_policy(
+    accelerator: str, backends: list[dict[str, Any]]
+) -> dict[str, str]:
+    available = {item["name"] for item in backends if item["importable"]}
+    if accelerator == "rocm":
+        return {
+            "attention": "aiter" if "aiter" in available else "torch-sdpa",
+            "moe": "auto (AITER/Triton)",
+            "intra_node_transport": "gpu_ipc",
+            "remote_transport": "nixl",
+        }
+    if accelerator == "cuda":
+        return {
+            "attention": "flashinfer" if "flashinfer" in available else "auto",
+            "moe": "auto",
+            "intra_node_transport": "gpu_ipc",
+            "remote_transport": "mooncake",
+        }
+    return {
+        "attention": "platform default",
+        "moe": "platform default",
+        "intra_node_transport": "shm",
+        "remote_transport": "unsupported",
+    }
 
 
 def collect_gpu_diagnostics(
@@ -329,41 +390,92 @@ def collect_gpu_diagnostics(
     """Collect diagnostics without loading model configuration or weights."""
 
     source_env = os.environ if env is None else env
-    visible_value = source_env.get("CUDA_VISIBLE_DEVICES")
-    visible_devices = parse_cuda_visible_devices(visible_value)
     torch = torch_module or importlib.import_module("torch")
-    pynvml = pynvml_module if pynvml_module is not None else _try_import_pynvml()
+    accelerator, device_type = _accelerator_environment(torch)
+    visible_variable = (
+        next(
+            (
+                name
+                for name in (
+                    "ROCR_VISIBLE_DEVICES",
+                    "HIP_VISIBLE_DEVICES",
+                    "CUDA_VISIBLE_DEVICES",
+                )
+                if source_env.get(name)
+            ),
+            "ROCR_VISIBLE_DEVICES",
+        )
+        if accelerator == "rocm"
+        else "CUDA_VISIBLE_DEVICES"
+    )
+    visible_value = source_env.get(visible_variable)
+    visible_devices = parse_cuda_visible_devices(visible_value)
+    pynvml = (
+        pynvml_module
+        if pynvml_module is not None
+        else (_try_import_pynvml() if accelerator == "cuda" else None)
+    )
 
     inventory, system, warnings = _nvml_inventory(pynvml)
     try:
-        devices = _logical_devices(torch, visible_devices, inventory, warnings)
+        devices = _logical_devices(
+            torch,
+            visible_devices,
+            inventory,
+            warnings,
+            accelerator=accelerator,
+        )
     finally:
         if pynvml is not None:
             _shutdown_nvml(pynvml)
 
-    backends = _backend_inventory()
+    backends = _backend_inventory(_ROCM_BACKENDS if accelerator == "rocm" else ())
     warnings.extend(
         backend["reason"]
         for backend in backends
         if backend["installed"] and not backend["importable"]
     )
-    return {
+    environment = {
+        "cuda_visible_devices": source_env.get("CUDA_VISIBLE_DEVICES"),
+        **system,
+        "cuda_runtime_version": _cuda_runtime_version(),
+        "pytorch_version": getattr(torch, "__version__", None),
+        "pytorch_cuda_build": getattr(getattr(torch, "version", None), "cuda", None),
+        "cuda_available": bool(torch.cuda.is_available()),
+        "logical_device_count": len(devices),
+    }
+    if accelerator == "rocm":
+        environment.update(
+            {
+                "accelerator": accelerator,
+                "device_type": device_type,
+                "visible_devices_variable": visible_variable,
+                "rocr_visible_devices": source_env.get("ROCR_VISIBLE_DEVICES"),
+                "hip_visible_devices": source_env.get("HIP_VISIBLE_DEVICES"),
+                "pytorch_rocm_build": getattr(
+                    getattr(torch, "version", None), "hip", None
+                ),
+                "gpu_architectures": sorted(
+                    {
+                        str(device["gpu_architecture"])
+                        for device in devices
+                        if device.get("gpu_architecture")
+                    }
+                ),
+            }
+        )
+    report = {
         "schema_version": 1,
-        "environment": {
-            "cuda_visible_devices": visible_value,
-            **system,
-            "cuda_runtime_version": _cuda_runtime_version(),
-            "pytorch_version": getattr(torch, "__version__", None),
-            "pytorch_cuda_build": getattr(
-                getattr(torch, "version", None), "cuda", None
-            ),
-            "cuda_available": bool(torch.cuda.is_available()),
-            "logical_device_count": len(devices),
-        },
+        "environment": environment,
         "gpus": devices,
         "backends": backends,
         "warnings": warnings,
     }
+    if accelerator == "rocm":
+        report["selected_backend_policy"] = _selected_backend_policy(
+            accelerator, backends
+        )
+    return report
 
 
 def render_gpu_diagnostics(report: Mapping[str, Any]) -> str:
@@ -371,30 +483,62 @@ def render_gpu_diagnostics(report: Mapping[str, Any]) -> str:
 
     environment = report["environment"]
     visible = environment["cuda_visible_devices"]
-    lines = [
-        "SGLang-Omni GPU diagnostics (no model loaded)",
-        f"CUDA_VISIBLE_DEVICES: {visible if visible is not None else '<unset>'}",
-        f"Driver: {environment['driver_version'] or 'unavailable'}",
-        (
-            "CUDA driver/runtime: "
-            f"{environment['cuda_driver_api_version'] or 'unavailable'} / "
-            f"{environment['cuda_runtime_version'] or 'unavailable'}"
-        ),
-        (
-            "PyTorch/CUDA build: "
-            f"{environment['pytorch_version'] or 'unavailable'} / "
-            f"{environment['pytorch_cuda_build'] or 'unavailable'}"
-        ),
-        "GPUs:",
-    ]
+    accelerator = environment.get("accelerator", "cuda")
+    if accelerator != "rocm":
+        lines = [
+            "SGLang-Omni GPU diagnostics (no model loaded)",
+            f"CUDA_VISIBLE_DEVICES: {visible if visible is not None else '<unset>'}",
+            f"Driver: {environment['driver_version'] or 'unavailable'}",
+            (
+                "CUDA driver/runtime: "
+                f"{environment['cuda_driver_api_version'] or 'unavailable'} / "
+                f"{environment['cuda_runtime_version'] or 'unavailable'}"
+            ),
+            (
+                "PyTorch/CUDA build: "
+                f"{environment['pytorch_version'] or 'unavailable'} / "
+                f"{environment['pytorch_cuda_build'] or 'unavailable'}"
+            ),
+            "GPUs:",
+        ]
+    else:
+        visible_variable = environment["visible_devices_variable"]
+        visible = environment.get(visible_variable.lower())
+        lines = [
+            "SGLang-Omni GPU diagnostics (no model loaded)",
+            "Accelerator: rocm",
+            f"{visible_variable}: {visible if visible is not None else '<unset>'}",
+            f"Driver: {environment['driver_version'] or 'unavailable'}",
+            (
+                "CUDA-compatible driver/runtime: "
+                f"{environment['cuda_driver_api_version'] or 'unavailable'} / "
+                f"{environment['cuda_runtime_version'] or 'unavailable'}"
+            ),
+            (
+                "PyTorch/ROCm build: "
+                f"{environment['pytorch_version'] or 'unavailable'} / "
+                f"{environment.get('pytorch_rocm_build') or 'unavailable'}"
+            ),
+            "GPUs:",
+        ]
     if not report["gpus"]:
-        lines.append("  No CUDA devices are visible to PyTorch.")
+        lines.append(
+            "  No ROCm devices are visible to PyTorch."
+            if accelerator == "rocm"
+            else "  No CUDA devices are visible to PyTorch."
+        )
     for device in report["gpus"]:
+        architecture_text = (
+            f"arch={device.get('gpu_architecture') or 'unknown'} "
+            if accelerator == "rocm"
+            else ""
+        )
         lines.append(
             f"  logical {device['logical_index']} -> physical "
             f"{device['physical_index']} visible={device['visible_device']} "
             f"name={device['name'] or 'unknown'} "
             f"cc={device['compute_capability'] or 'unknown'} "
+            f"{architecture_text}"
             f"memory={format_bytes_gib(device['free_memory_bytes'])}/"
             f"{format_bytes_gib(device['total_memory_bytes'])} "
             f"uuid={device['uuid'] or 'unknown'} "
@@ -417,6 +561,12 @@ def render_gpu_diagnostics(report: Mapping[str, Any]) -> str:
             f"version={backend['version'] or '-'}"
         )
 
+    if accelerator == "rocm":
+        lines.append("Selected policy:")
+        lines.extend(
+            f"  {name}: {value}"
+            for name, value in report.get("selected_backend_policy", {}).items()
+        )
     if report["warnings"]:
         lines.append("Warnings:")
         lines.extend(f"  {warning}" for warning in report["warnings"])

--- a/sglang_omni/models/accelerator_support.py
+++ b/sglang_omni/models/accelerator_support.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Machine-readable accelerator support declarations for model pipelines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable
+
+
+class AcceleratorSupportStatus(str, Enum):
+    SUPPORTED = "supported"
+    PREVIEW = "preview"
+    UNSUPPORTED = "unsupported"
+
+
+@dataclass(frozen=True)
+class ModelAcceleratorSupport:
+    """Validation state for one canonical architecture on one accelerator."""
+
+    architecture: str
+    accelerator: str
+    status: AcceleratorSupportStatus
+    gpu_architectures: tuple[str, ...]
+    validated_features: frozenset[str] = frozenset()
+    limitations: tuple[str, ...] = ()
+    evidence: str | None = None
+
+    def supports_gpu_architecture(self, gpu_architecture: str) -> bool:
+        normalized = gpu_architecture.strip().lower().split(":", 1)[0]
+        return (
+            self.status is AcceleratorSupportStatus.SUPPORTED
+            and normalized in self.gpu_architectures
+        )
+
+
+_ROCM_ARCHITECTURES = ("gfx942", "gfx950")
+_PREVIEW_LIMITATION = (
+    "Single-request functional E2E passed on gfx942 and gfx950; the complete "
+    "CUDA feature contract and scheduled stability gates remain pending.",
+)
+
+
+def _rocm_preview(architecture: str) -> ModelAcceleratorSupport:
+    return ModelAcceleratorSupport(
+        architecture=architecture,
+        accelerator="rocm",
+        status=AcceleratorSupportStatus.PREVIEW,
+        gpu_architectures=_ROCM_ARCHITECTURES,
+        limitations=_PREVIEW_LIMITATION,
+        evidence="Dual-architecture functional matrix: 18/18 on gfx942 and gfx950",
+    )
+
+
+_ROCM_SUPPORT = {
+    architecture: _rocm_preview(architecture)
+    for architecture in (
+        "ArkasrForConditionalGeneration",
+        "AudarTTSForConditionalGeneration",
+        "DotsTTSForConditionalGeneration",
+        "FishQwen3OmniForCausalLM",
+        "FunAsrNanoForConditionalGeneration",
+        "HiggsMultimodalQwen3ForConditionalGeneration",
+        "LLaDA2MoeModelLM",
+        "BailingMM2NativeForConditionalGeneration",
+        "BailingMMNativeForConditionalGeneration",
+        "MossTranscribeDiarizeForConditionalGeneration",
+        "MossTTSDelayModel",
+        "MossTTSLocalModel",
+        "Qwen3ASRForConditionalGeneration",
+        "Qwen3OmniMoeForConditionalGeneration",
+        "Qwen3TTSForConditionalGeneration",
+        "VoxtralTTSForConditionalGeneration",
+        "WhisperForConditionalGeneration",
+        "Zonos2ForCausalLM",
+    )
+}
+_ROCM_SUPPORT["MiniMaxMusic3ForConditionalGeneration"] = ModelAcceleratorSupport(
+    architecture="MiniMaxMusic3ForConditionalGeneration",
+    accelerator="rocm",
+    status=AcceleratorSupportStatus.SUPPORTED,
+    gpu_architectures=_ROCM_ARCHITECTURES,
+    validated_features=frozenset(
+        {
+            "openai-audio-speech-api",
+            "eager-generation",
+            "compiled-acoustic-dit-dav",
+            "aiter-autoregressive-stage",
+            "torch-sdpa-acoustic-stage",
+        }
+    ),
+    limitations=(
+        "Generation and RVQ device graphs are disabled; DIT and DAV remain compiled.",
+    ),
+    evidence="PR #1534: ROCm 7.2 E2E generation on MI300X and MI355X",
+)
+
+
+def _canonical_architecture(architecture: str) -> str | None:
+    from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+
+    config_cls = PIPELINE_CONFIG_REGISTRY.configs.get(architecture)
+    if config_cls is None:
+        return None
+    return str(config_cls.architecture)
+
+
+def get_model_accelerator_support(
+    architecture: str,
+    accelerator: str,
+) -> ModelAcceleratorSupport | None:
+    """Return declared support for a registered architecture and accelerator."""
+
+    canonical = _canonical_architecture(architecture)
+    if canonical is None:
+        return None
+    normalized_accelerator = accelerator.strip().lower()
+    if normalized_accelerator == "rocm":
+        return _ROCM_SUPPORT.get(canonical)
+    return None
+
+
+def iter_model_accelerator_support(
+    accelerator: str | None = None,
+) -> Iterable[ModelAcceleratorSupport]:
+    """Iterate declarations in stable architecture order."""
+
+    normalized = accelerator.strip().lower() if accelerator is not None else None
+    declarations = _ROCM_SUPPORT.values() if normalized in (None, "rocm") else ()
+    return iter(sorted(declarations, key=lambda item: item.architecture))
+
+
+__all__ = [
+    "AcceleratorSupportStatus",
+    "ModelAcceleratorSupport",
+    "get_model_accelerator_support",
+    "iter_model_accelerator_support",
+]

--- a/sglang_omni/models/audar_tts/config.py
+++ b/sglang_omni/models/audar_tts/config.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 from pydantic import Field
 
 from sglang_omni.config import PipelineConfig, StageConfig
+from sglang_omni.platforms import current_platform
 
 _PKG = "sglang_omni.models.audar_tts"
 
@@ -32,6 +33,10 @@ def _stages() -> list[StageConfig]:
             process="pipeline",
             factory=f"{_PKG}.stages.create_tts_engine_executor",
             gpu=0,
+            # llama.cpp 0.3.34 can abort during asynchronous GGML-HIP decode.
+            # Scope the workaround to this ROCm worker and preserve any
+            # operator-provided value through env-default semantics.
+            env=({"AMD_SERIALIZE_KERNEL": "3"} if current_platform.is_rocm() else {}),
             next="vocoder",
         ),
         StageConfig(

--- a/sglang_omni/models/fishaudio_s2_pro/engine_builder.py
+++ b/sglang_omni/models/fishaudio_s2_pro/engine_builder.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from sglang_omni.models.fishaudio_s2_pro import request_builders
 from sglang_omni.models.fishaudio_s2_pro import stages as fish_stages
+from sglang_omni.platforms import current_platform
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
 from sglang_omni.utils.gpu_compat import get_visible_gpu_sm_version
 from sglang_omni.vendor.sglang.server_args import override_server_args
@@ -23,6 +24,11 @@ _VALIDATED_AUTO_ATTENTION_BACKENDS = {
 
 
 def _resolve_fast_ar_attention_backend(*, gpu_id: int) -> str:
+    if current_platform.is_rocm():
+        # Fast-AR uses the owned PyTorch SDPA cache path on ROCm; this value is
+        # the compatible SGLang backend for the separate Slow-AR layers.
+        return "aiter"
+
     sm_version = get_visible_gpu_sm_version(gpu_id)
     if sm_version is None:
         raise RuntimeError(
@@ -75,7 +81,11 @@ class FishS2ProEngineBuilder(TtsEngineBuilder):
         dtype: str,
     ) -> dict[str, Any]:
         del dtype
-        sm_version = get_visible_gpu_sm_version(self.gpu_id)
+        sm_version = (
+            None
+            if current_platform.is_rocm()
+            else get_visible_gpu_sm_version(self.gpu_id)
+        )
         return {
             "max_running_requests": 64,
             "disable_cuda_graph": False,

--- a/sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/audio_decoder.py
+++ b/sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/audio_decoder.py
@@ -21,6 +21,7 @@ from sglang_omni.models.fishaudio_s2_pro.fish_speech.models.text2semantic.utils 
     apply_rotary_emb,
     precompute_freqs_cis,
 )
+from sglang_omni.platforms import current_platform
 
 FISH_BATCH_INVARIANT = os.getenv("FISH_BATCH_INVARIANT", "false").lower() in (
     "true",
@@ -81,6 +82,57 @@ def _flashinfer_kvcache_attention(
     return torch.stack(outputs, dim=0)
 
 
+def _torch_kvcache_attention(
+    *,
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    k: torch.Tensor | None,
+    v: torch.Tensor | None,
+    causal: bool,
+    cache_position: int,
+) -> torch.Tensor:
+    """Portable Fast-AR cache attention used by ROCm."""
+    if k is None or v is None:
+        raise ValueError("PyTorch Fast-AR attention requires k and v")
+    if q.shape[0] != k.shape[0] or q.shape[0] != v.shape[0]:
+        raise ValueError("Fast-AR q, k, and v batch sizes must match")
+    if cache_position < 0:
+        raise ValueError("PyTorch Fast-AR attention requires cache_position")
+
+    cache_end = cache_position + int(k.shape[1])
+    k_cache[:, cache_position:cache_end].copy_(k)
+    v_cache[:, cache_position:cache_end].copy_(v)
+
+    query = q.transpose(1, 2)
+    key = k_cache[:, :cache_end].transpose(1, 2)
+    value = v_cache[:, :cache_end].transpose(1, 2)
+    if query.shape[1] != key.shape[1]:
+        if query.shape[1] % key.shape[1] != 0:
+            raise ValueError("Fast-AR query heads must be divisible by KV heads")
+        repeats = query.shape[1] // key.shape[1]
+        key = key.repeat_interleave(repeats, dim=1)
+        value = value.repeat_interleave(repeats, dim=1)
+
+    attention_mask = None
+    if causal:
+        query_positions = torch.arange(
+            cache_position,
+            cache_end,
+            device=q.device,
+        )
+        key_positions = torch.arange(cache_end, device=q.device)
+        attention_mask = key_positions.unsqueeze(0) <= query_positions.unsqueeze(1)
+
+    output = F.scaled_dot_product_attention(
+        query,
+        key,
+        value,
+        attn_mask=attention_mask,
+    )
+    return output.transpose(1, 2)
+
+
 @torch.library.custom_op(
     "mylib::flash_attn_kvcache", mutates_args=("k_cache", "v_cache")
 )
@@ -97,6 +149,16 @@ def flash_attn_kvcache_op(
 ) -> torch.Tensor:
     if q.device.type != "cuda" or q.device.index is None:
         raise RuntimeError("FishAudio S2-Pro Fast-AR attention requires CUDA")
+    if current_platform.is_rocm():
+        return _torch_kvcache_attention(
+            q=q,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            k=k,
+            v=v,
+            causal=causal,
+            cache_position=cache_position,
+        )
     if _fast_ar_uses_fa3(q.device.index):
         from sgl_kernel.flash_attn import flash_attn_with_kvcache
 

--- a/sglang_omni/models/fun_asr/config.py
+++ b/sglang_omni/models/fun_asr/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import ClassVar
 
 from sglang_omni.config import PipelineConfig, StageConfig
+from sglang_omni.platforms import current_platform
 
 _PKG = "sglang_omni.models.fun_asr"
 
@@ -37,7 +38,7 @@ class FunASRPipelineConfig(PipelineConfig):
                 "max_running_requests": 32,
                 "max_new_tokens": 200,
                 "enable_encoder_torch_compile": False,
-                "enable_encoder_cuda_graph": True,
+                "enable_encoder_cuda_graph": current_platform.supports_device_graphs(),
                 "enable_pre_lm_encoder": True,
                 "pre_lm_cache_max_entries": 4096,
                 "pre_lm_cache_size_bytes": 2 * 1024**3,

--- a/sglang_omni/models/higgs_tts/sampler.py
+++ b/sglang_omni/models/higgs_tts/sampler.py
@@ -13,9 +13,20 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import torch
-from sgl_kernel import top_k_renorm_prob as _fused_top_k_renorm
-from sgl_kernel import top_p_renorm_prob as _fused_top_p_renorm
 from sglang.srt.layers.sampler import multinomial_with_seed
+
+from sglang_omni.platforms import current_platform
+
+if not current_platform.is_rocm():
+    from sgl_kernel import top_k_renorm_prob as _fused_top_k_renorm
+    from sgl_kernel import top_p_renorm_prob as _fused_top_p_renorm
+else:
+    try:
+        from sgl_kernel import top_k_renorm_prob as _fused_top_k_renorm
+        from sgl_kernel import top_p_renorm_prob as _fused_top_p_renorm
+    except ImportError:  # ROCm wheels may omit the sampling extension entirely.
+        _fused_top_k_renorm = None
+        _fused_top_p_renorm = None
 
 from sglang_omni.models.higgs_tts.utils import BOC_ID, EOC_ID
 
@@ -123,6 +134,36 @@ class HiggsBatchedSamplerState:
 
 
 _GREEDY_TEMP_THRESHOLD = 1e-5
+
+
+def _has_sgl_kernel_op(name: str) -> bool:
+    try:
+        getattr(torch.ops.sgl_kernel, name)
+    except AttributeError:
+        return False
+    return True
+
+
+def _top_k_renorm_torch(probs: torch.Tensor, top_k: torch.Tensor) -> torch.Tensor:
+    sorted_probs, sorted_indices = torch.sort(probs, dim=-1, descending=True)
+    ranks = torch.arange(probs.shape[-1], device=probs.device).view(1, -1)
+    keep = ranks < top_k.view(-1, 1)
+    filtered = torch.zeros_like(probs)
+    filtered.scatter_(-1, sorted_indices, torch.where(keep, sorted_probs, 0.0))
+    return filtered / filtered.sum(dim=-1, keepdim=True).clamp_min(
+        torch.finfo(filtered.dtype).tiny
+    )
+
+
+def _top_p_renorm_torch(probs: torch.Tensor, top_p: torch.Tensor) -> torch.Tensor:
+    sorted_probs, sorted_indices = torch.sort(probs, dim=-1, descending=True)
+    cumulative_before = sorted_probs.cumsum(dim=-1) - sorted_probs
+    keep = cumulative_before < top_p.view(-1, 1)
+    filtered = torch.zeros_like(probs)
+    filtered.scatter_(-1, sorted_indices, torch.where(keep, sorted_probs, 0.0))
+    return filtered / filtered.sum(dim=-1, keepdim=True).clamp_min(
+        torch.finfo(filtered.dtype).tiny
+    )
 
 
 def _sample_independent(
@@ -265,10 +306,20 @@ def _sample_independent_batched(
             .to(torch.int32)
             .contiguous()
         )
-        probs = _fused_top_k_renorm(probs, tk)
+        if current_platform.is_rocm() and (
+            _fused_top_k_renorm is None or not _has_sgl_kernel_op("top_k_renorm_probs")
+        ):
+            probs = _top_k_renorm_torch(probs, tk)
+        else:
+            probs = _fused_top_k_renorm(probs, tk)
     if top_p is not None:
         tp = top_p.view(B, 1).expand(B, N).reshape(B * N).to(torch.float32).contiguous()
-        probs = _fused_top_p_renorm(probs, tp)
+        if current_platform.is_rocm() and (
+            _fused_top_p_renorm is None or not _has_sgl_kernel_op("top_p_renorm_probs")
+        ):
+            probs = _top_p_renorm_torch(probs, tp)
+        else:
+            probs = _fused_top_p_renorm(probs, tp)
 
     codes_flat = probs.multinomial(num_samples=1).squeeze(-1)
     if seeds_B is not None:

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -48,6 +48,7 @@ from sglang_omni.models.higgs_tts.vocoder_scheduler import (
     DEFAULT_HIGGS_STREAM_STRIDE,
     HiggsStreamingVocoderScheduler,
 )
+from sglang_omni.platforms import current_platform
 
 # _REF_PATH_HASH_MEMO is the shared memo object, re-exported so tests can
 # reset it; the underscored alias keeps this module's historical API.
@@ -515,6 +516,8 @@ def create_vocoder_executor(
 
     Codec weights are extracted from the TTS checkpoint itself.
     """
+    if not current_platform.supports_device_graphs():
+        decode_cuda_graph_frame_counts = ()
     if compile_decode and decode_cuda_graph_frame_counts:
         raise ValueError(
             "compile_decode and decode_cuda_graph_frame_counts are mutually exclusive"

--- a/sglang_omni/models/llada2_uni/stages.py
+++ b/sglang_omni/models/llada2_uni/stages.py
@@ -7,8 +7,13 @@ import logging
 from typing import Any
 
 from sglang_omni.models.llada2_uni.config import IMAGE_STAGE, THINKER_STAGE
+from sglang_omni.platforms import current_platform
 
 logger = logging.getLogger(__name__)
+
+
+def _dllm_attention_backend() -> str:
+    return "aiter" if current_platform.is_rocm() else "flashinfer"
 
 
 def _event_to_dict(event) -> dict[str, Any]:
@@ -93,7 +98,7 @@ def create_sglang_dllm_thinker_executor_from_config(
     from sglang_omni.scheduling.sglang_backend import build_sglang_server_args
 
     overrides: dict[str, Any] = {
-        "attention_backend": "flashinfer",
+        "attention_backend": _dllm_attention_backend(),
         "disable_cuda_graph": True,
         "sampling_backend": "pytorch",
     }

--- a/sglang_omni/models/ming_omni/talker/audio_vae/vae_modules.py
+++ b/sglang_omni/models/ming_omni/talker/audio_vae/vae_modules.py
@@ -3,7 +3,16 @@ import torch.nn as nn
 import torch.nn.functional as F
 from transformers import Qwen2Config, Qwen2Model
 
+from sglang_omni.platforms import current_platform
+
 from .istft import ISTFTHead
+
+
+def _qwen2_config(backbone_args):
+    config = Qwen2Config.from_dict(config_dict=backbone_args)
+    if current_platform.is_rocm():
+        config._attn_implementation = "sdpa"
+    return config
 
 
 class StreamingLinearUpsample(nn.Module):
@@ -71,7 +80,7 @@ class Encoder(nn.Module):
         self, encoder_args, input_dim=320, hop_size=320, latent_dim=64, patch_size=-1
     ):
         super().__init__()
-        config = Qwen2Config.from_dict(config_dict=encoder_args)
+        config = _qwen2_config(encoder_args)
         self.encoder = Qwen2Model(config)
         self.input_dim = input_dim
         self.hop_size = hop_size
@@ -135,7 +144,7 @@ class Encoder(nn.Module):
 class Decoder(nn.Module):
     def __init__(self, decoder_args, output_dim=320, latent_dim=64, patch_size=-1):
         super().__init__()
-        config = Qwen2Config.from_dict(config_dict=decoder_args)
+        config = _qwen2_config(decoder_args)
         self.decoder = Qwen2Model(config)
         self.output_dim = output_dim
         self.latent_dim = latent_dim

--- a/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
+++ b/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
@@ -24,6 +24,7 @@ import torch.nn as nn
 import torchaudio
 from transformers import Qwen2Config, Qwen2Model, StaticCache
 
+from sglang_omni.platforms import current_platform
 from sglang_omni.utils.audio_features import cached_fbank
 
 from .configuration_bailing_talker import MingOmniTalkerConfig
@@ -37,6 +38,12 @@ from .talker_module.dit import DiT
 logger = logging.getLogger(__name__)
 
 _TOKEN_DONE = object()
+
+
+def _cache_positions(past_seen_tokens, new_token_count: int, device):
+    """Build cache positions when Transformers returns a scalar tensor length."""
+    return torch.arange(new_token_count, device=device) + past_seen_tokens
+
 
 # ---------- Optional: onnxruntime for speaker embedding ----------
 try:
@@ -543,11 +550,18 @@ class MingOmniTalker(nn.Module):
                     )
                 else:
                     past_seen_tokens = past_key_values.get_seq_length()
-                    cache_position = torch.arange(
-                        past_seen_tokens,
-                        past_seen_tokens + inputs_embeds.shape[1],
-                        device=inputs_embeds.device,
-                    )
+                    if current_platform.is_rocm():
+                        cache_position = _cache_positions(
+                            past_seen_tokens,
+                            inputs_embeds.shape[1],
+                            inputs_embeds.device,
+                        )
+                    else:
+                        cache_position = torch.arange(
+                            past_seen_tokens,
+                            past_seen_tokens + inputs_embeds.shape[1],
+                            device=inputs_embeds.device,
+                        )
 
                     if model_graph is None:
                         model_graph = torch.cuda.CUDAGraph()
@@ -998,12 +1012,25 @@ class MingOmniTalker(nn.Module):
         speech_parts = []
         spk_emb_list = []
         for x in prompt_wav_path:
-            speech_tmp, sample_rate = torchaudio.load(x, backend="soundfile")
+            if current_platform.is_rocm():
+                from sglang_omni.utils.audio import load_audio
+
+                sample_rate = int(audio_detokenizer.config.sample_rate)
+                speech_tmp = torch.from_numpy(
+                    load_audio(
+                        x,
+                        source_name="Ming voice prompt",
+                        target_sample_rate=sample_rate,
+                        mono=True,
+                    )
+                ).unsqueeze(0)
+            else:
+                speech_tmp, sample_rate = torchaudio.load(x, backend="soundfile")
+                if sample_rate != audio_detokenizer.config.sample_rate:
+                    speech_tmp = torchaudio.transforms.Resample(
+                        sample_rate, audio_detokenizer.config.sample_rate
+                    )(speech_tmp)
             speech_tmp1 = speech_tmp.clone()
-            if sample_rate != audio_detokenizer.config.sample_rate:
-                speech_tmp = torchaudio.transforms.Resample(
-                    sample_rate, audio_detokenizer.config.sample_rate
-                )(speech_tmp)
             speech_parts.append(speech_tmp)
 
             if self.spkemb_extractor is not None:

--- a/sglang_omni/models/minimax_music3/config.py
+++ b/sglang_omni/models/minimax_music3/config.py
@@ -9,6 +9,7 @@ from typing import ClassVar
 from pydantic import Field
 
 from sglang_omni.config import PipelineConfig, PlacementConfig, StageConfig
+from sglang_omni.platforms import current_platform
 
 from .constants import DEFAULT_DIT_CFG_SCALE, DEFAULT_DIT_STEPS
 
@@ -27,6 +28,7 @@ def _visible_gpu_count() -> int:
 
 
 def _stages(*, acoustic_gpu: int) -> list[StageConfig]:
+    is_rocm = current_platform.is_rocm()
     return [
         StageConfig(
             name="preprocessing",
@@ -38,7 +40,12 @@ def _stages(*, acoustic_gpu: int) -> list[StageConfig]:
             name="minimax_music3_ar",
             process="minimax_music3_ar",
             factory=f"{_PKG}.stages.create_ar_executor",
-            factory_args={"max_concurrency": 16},
+            factory_args={
+                "max_concurrency": 16,
+                "server_args_overrides": (
+                    {"disable_cuda_graph": True} if is_rocm else {}
+                ),
+            },
             gpu=0,
             next="dit_dav",
             stream_to=["dit_dav"],

--- a/sglang_omni/models/minimax_music3/engine_builder.py
+++ b/sglang_omni/models/minimax_music3/engine_builder.py
@@ -112,10 +112,14 @@ class MiniMaxMusic3EngineBuilder(TtsEngineBuilder):
     def setup_model_resources(
         self, model: Any, server_args: Any, *, generation_cuda_graph_enabled: bool
     ) -> None:
-        del generation_cuda_graph_enabled
         from .sglang_model import enable_rvq_depth_cuda_graph
 
-        del server_args
+        if bool(server_args.disable_cuda_graph) or not generation_cuda_graph_enabled:
+            logger.info(
+                "MiniMax Music 3: RVQ depth CUDA graph disabled with the "
+                "generation CUDA graph"
+            )
+            return
         enable_rvq_depth_cuda_graph(
             model, _rvq_graph_buckets(self.max_running_requests)
         )

--- a/sglang_omni/models/minimax_music3/rvq_decoder.py
+++ b/sglang_omni/models/minimax_music3/rvq_decoder.py
@@ -150,6 +150,7 @@ class RVQDepthDecoder(nn.Module):
 
 
 _TOP_K = 50
+_PHILOX_VALUES_PER_COUNTER = 4
 
 
 def sample_topk(
@@ -180,11 +181,23 @@ def sample_topk_seeded(
     Returns:
         [rows] sampled column indices.
     """
-    from sglang.srt.layers.sampler import multinomial_with_seed
-
     values = torch.nan_to_num(logits.float(), nan=-1e9, posinf=1e9, neginf=-1e9)
     threshold = torch.topk(values, _TOP_K, dim=-1).values[..., -1, None]
     values = values.masked_fill(values < threshold, -float("inf"))
+
+    if torch.version.hip is not None:
+        probs = torch.nan_to_num(F.softmax(values, dim=-1), nan=0.0)
+        probs = probs / probs.sum(dim=-1, keepdim=True).clamp_min(1e-12)
+        samples: list[Tensor] = []
+        for row, seed, position in zip(probs, seeds, positions, strict=True):
+            generator = torch.Generator(device=values.device)
+            generator.manual_seed(int(seed.item()))
+            generator.set_offset(int(position.item()) * _PHILOX_VALUES_PER_COUNTER)
+            samples.append(torch.multinomial(row, 1, generator=generator))
+        return torch.cat(samples)
+
+    from sglang.srt.layers.sampler import multinomial_with_seed
+
     return multinomial_with_seed(values, seeds, positions).squeeze(-1)
 
 

--- a/sglang_omni/models/moss_tts/vocoder_decoder.py
+++ b/sglang_omni/models/moss_tts/vocoder_decoder.py
@@ -29,6 +29,7 @@ except ImportError:
 from sglang_omni.models.moss_tts.vocoder_kernels import (
     apply_exact_interleaved_rope_inplace,
 )
+from sglang_omni.platforms import current_platform
 
 # note (Zhang Yiyang): FA3 local-window attention diverges from SDPA when one
 # varlen sequence spans multiple 128-token query tiles. Pack each tile as an
@@ -448,7 +449,9 @@ class MossAudioTokenizerAttention(nn.Module):
         self.context = source.context
         self.rope = source.rope
         self._legacy_api = not hasattr(source, "resolve_attention_implementation")
-        self._flash_attn_varlen = flash_attn_varlen_func
+        self._flash_attn_varlen = (
+            None if current_platform.is_rocm() else flash_attn_varlen_func
+        )
         max_period = self.rope.max_period if self.rope is not None else 10000.0
         self._packed_rope_cache = packed_rope_cache or _MossPackedRopeCache(
             max_period=max_period
@@ -462,6 +465,12 @@ class MossAudioTokenizerAttention(nn.Module):
             # Prefer packed FlashAttention when its device and dtype requirements
             # are satisfied.
             preferred = _FLASH_ATTENTION_BACKEND
+        if (
+            current_platform.is_rocm()
+            and preferred == _FLASH_ATTENTION_BACKEND
+            and self._flash_attn_varlen is None
+        ):
+            return "sdpa"
         if preferred == _FLASH_ATTENTION_BACKEND and self._can_run_packed_flash(x):
             return _FLASH_ATTENTION_BACKEND
         resolver = getattr(self.source, "resolve_attention_implementation", None)

--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -15,6 +15,7 @@ from sglang_omni.config import (
     StageRuntimeConfig,
 )
 from sglang_omni.config.runtime import resolve_stage_static_factory_args
+from sglang_omni.platforms import current_platform
 from sglang_omni.utils.cpu import bounded_intraop_threads
 
 _PKG = "sglang_omni.models.moss_tts_local"
@@ -240,7 +241,10 @@ class MossTTSLocalPipelineConfig(PipelineConfig):
                     "ref_audio_cache_max_bytes", self.ref_audio_cache_max_bytes
                 )
             if stage.factory.endswith("create_vocoder_executor"):
-                stage.factory_args.setdefault("cuda_graph", self.cuda_graph)
+                stage.factory_args.setdefault(
+                    "cuda_graph",
+                    self.cuda_graph and current_platform.supports_device_graphs(),
+                )
                 stage.factory_args.setdefault(
                     "cuda_graph_frames", self.cuda_graph_frames
                 )

--- a/sglang_omni/models/qwen3_asr/sglang_model.py
+++ b/sglang_omni/models/qwen3_asr/sglang_model.py
@@ -6,7 +6,6 @@ from typing import Any, Iterable, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
-from sgl_kernel import fused_qk_norm_rope
 from sglang.srt.configs.qwen3_omni import Qwen3OmniMoeAudioEncoderConfig
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.managers.mm_utils import (
@@ -24,9 +23,15 @@ from sglang.srt.models.qwen3 import Qwen3ForCausalLM
 from sglang.srt.models.qwen3_omni_moe import Qwen3OmniMoeAudioEncoder
 from sglang.srt.utils import add_prefix
 
+from sglang_omni.platforms import current_platform
+
 from .configuration_qwen3_asr import Qwen3ASRConfig
 
 logger = logging.getLogger(__name__)
+if current_platform.is_rocm():
+    fused_qk_norm_rope = current_platform.get_fused_qk_norm_rope()
+else:
+    from sgl_kernel import fused_qk_norm_rope
 
 _MROPE_ONLY_KEYS = frozenset({"interleaved", "mrope_interleaved", "mrope_section"})
 
@@ -92,6 +97,9 @@ def _enable_fused_asr_qk_norm_rope(language_model: nn.Module) -> None:
     # note (luojiaxuan): the CUDA kernel operates in place on packed QKV and
     # replaces split + two RMSNorm launches + RoPE for the equivalent text
     # positions. Keep the original bound method for non-bfloat16 fallbacks.
+    if fused_qk_norm_rope is None:
+        logger.info("Qwen3-ASR fused QK norm RoPE is unavailable; using native path")
+        return
     for layer in language_model.model.layers:
         attention = layer.self_attn
         if attention.head_dim not in (64, 128, 256):
@@ -225,8 +233,12 @@ class Qwen3ASRForConditionalGeneration(nn.Module):
     ) -> torch.Tensor:
         if forward_batch.mrope_positions is not None:
             positions = forward_batch.mrope_positions[0]
+        # The optional fused kernel consumes int32 position ids, while the
+        # native SGLang rotary op (used on ROCm) dispatches on torch.long.
+        # Keep the conversion aligned with the path installed above rather
+        # than making the native fallback inherit a CUDA-kernel constraint.
         positions = positions.to(
-            dtype=torch.int32,
+            dtype=torch.int32 if fused_qk_norm_rope is not None else torch.long,
             device=input_ids.device,
             non_blocking=True,
         ).contiguous()

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -23,6 +23,7 @@ from sglang_omni.models.qwen3_tts.streaming_vocoder import (
     DEFAULT_QWEN3_TTS_STREAM_STRIDE,
     Qwen3TTSStreamingVocoderScheduler,
 )
+from sglang_omni.platforms import current_platform
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from sglang_omni.scheduling.threaded_simple_scheduler import ThreadedSimpleScheduler
 from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoint
@@ -184,6 +185,9 @@ def create_vocoder_executor(
     initial_cuda_graph: bool = True,
 ) -> SimpleScheduler:
     device = resolve_device_spec(device, gpu_id)
+    initial_cuda_graph = (
+        initial_cuda_graph and current_platform.supports_device_graphs()
+    )
     tokenizer = _load_qwen3_tts_tokenizer(
         model_path,
         device=device,

--- a/sglang_omni/models/whisper_asr/config.py
+++ b/sglang_omni/models/whisper_asr/config.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import ClassVar
 
 from sglang_omni.config import AudioChunkingConfig, PipelineConfig, StageConfig
+from sglang_omni.platforms import current_platform
 
 _PKG = "sglang_omni.models.whisper_asr"
 
@@ -40,7 +41,7 @@ class WhisperASRPipelineConfig(PipelineConfig):
             factory=f"{_PKG}.stages.create_sglang_whisper_asr_executor",
             factory_args={
                 "device": "cuda:0",
-                "enable_encoder_cuda_graph": True,
+                "enable_encoder_cuda_graph": current_platform.supports_device_graphs(),
                 "request_build_max_workers": 2,
                 "request_build_max_pending": 16,
                 "prefill_coalesce_requests": 2,

--- a/sglang_omni/models/whisper_asr/engine_builder.py
+++ b/sglang_omni/models/whisper_asr/engine_builder.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from sglang_omni.platforms import current_platform
 from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
 
 logger = logging.getLogger(__name__)
@@ -139,7 +140,7 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
         overrides["chunked_prefill_size"] = 0
 
     def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
-        return {
+        defaults = {
             "max_running_requests": self.max_running_requests,
             "disable_cuda_graph": False,
             "disable_overlap_schedule": True,
@@ -150,6 +151,14 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
             "sampling_backend": "pytorch",
             "dtype": dtype,
         }
+        # SGLang's encoder-decoder auto-resolution currently selects
+        # FlashInfer before its ROCm availability guard, leaving an undefined
+        # wrapper symbol at backend construction. AITER currently returns an
+        # empty decode for Whisper cross-attention and Triton rejects
+        # encoder-decoder models, so use SGLang's portable native backend.
+        if current_platform.is_rocm():
+            defaults["attention_backend"] = "torch_native"
+        return defaults
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:
         del model

--- a/sglang_omni/models/whisper_asr/sglang_model.py
+++ b/sglang_omni/models/whisper_asr/sglang_model.py
@@ -25,6 +25,7 @@ from transformers.activations import ACT2FN
 from sglang_omni.models.whisper_asr.encoder_cuda_graph import (
     WhisperEncoderCudaGraphRunner,
 )
+from sglang_omni.platforms import current_platform
 
 
 class WhisperEncoderAttention(nn.Module):
@@ -161,6 +162,8 @@ class WhisperSGLangSelfAttention(nn.Module):
         key = self.k_proj(hidden_states).view(-1, self.num_heads, self.head_dim)
         value = self.v_proj(hidden_states).view(-1, self.num_heads, self.head_dim)
         attn_output = self.attn(query, key, value, forward_batch)
+        if current_platform.is_rocm():
+            attn_output = attn_output.reshape(-1, self.embed_dim)
         return self.out_proj(attn_output)
 
 
@@ -208,6 +211,8 @@ class WhisperSGLangCrossAttention(nn.Module):
                 -1, self.num_heads, self.head_dim
             )
         attn_output = self.attn(query, key, value, forward_batch)
+        if current_platform.is_rocm():
+            attn_output = attn_output.reshape(-1, self.embed_dim)
         return self.out_proj(attn_output)
 
 

--- a/sglang_omni/platforms/cuda.py
+++ b/sglang_omni/platforms/cuda.py
@@ -18,6 +18,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_ROCM_VISIBLE_DEVICE_VARIABLES = (
+    "ROCR_VISIBLE_DEVICES",
+    "HIP_VISIBLE_DEVICES",
+    "CUDA_VISIBLE_DEVICES",
+)
+
 
 def _is_h20_device() -> bool:
     """True only on NVIDIA H20 (word-boundary match so "H200" isn't caught)."""
@@ -46,6 +52,51 @@ def _is_fp8_cutlass_moe_supported() -> bool:
         cutlass_fp8_supported()
         and (is_sm90_supported() or is_sm100_supported() or is_sm120_supported())
     )
+
+
+def _split_visible_devices(value: str) -> list[str]:
+    devices = [item.strip() for item in value.split(",")]
+    if not devices or any(not item for item in devices):
+        raise ValueError(f"invalid visible-device list {value!r}")
+    return devices
+
+
+def _map_rocm_visible_device(
+    *, spec: StageLaunchConfig, source_env: Mapping[str, str]
+) -> str:
+    """Map a logical rank without applying HIP visibility aliases twice.
+
+    ROCr applies its physical mask before HIP/CUDA aliases. Consequently,
+    ``ROCR_VISIBLE_DEVICES=3,4`` must pair with aliases ``0,1`` rather than
+    ``3,4``; repeating the physical ids can hide every device except rank 0.
+    """
+
+    configured = {
+        name: _split_visible_devices(value)
+        for name in _ROCM_VISIBLE_DEVICE_VARIABLES
+        if (value := (source_env.get(name) or "").strip())
+    }
+    if not configured:
+        return str(spec.gpu_id)
+
+    canonical_name = next(
+        name for name in _ROCM_VISIBLE_DEVICE_VARIABLES if name in configured
+    )
+    visible_devices = configured[canonical_name]
+    logical_devices = [str(index) for index in range(len(visible_devices))]
+    for name, devices in configured.items():
+        if devices not in (visible_devices, logical_devices):
+            raise ValueError(
+                f"tp stage {spec.stage_name!r} has conflicting accelerator "
+                f"visibility: {canonical_name}={','.join(visible_devices)!r}, "
+                f"{name}={','.join(devices)!r}"
+            )
+    if spec.gpu_id >= len(visible_devices):
+        raise ValueError(
+            f"tp stage {spec.stage_name!r} assigned gpu_id={spec.gpu_id}, "
+            f"but {canonical_name} only exposes {visible_devices}"
+        )
+    return visible_devices[spec.gpu_id]
 
 
 class CUDAOmniPlatform(CudaDeviceMixin, OmniPlatform):
@@ -82,6 +133,9 @@ class CUDAOmniPlatform(CudaDeviceMixin, OmniPlatform):
         from sglang_omni.comm.data_ref import TransportKind
 
         return TransportKind.CUDA_IPC
+
+    def supports_device_graphs(self) -> bool:
+        return True
 
     def get_fused_qk_norm_rope(self):
         from sgl_kernel import fused_qk_norm_rope
@@ -193,5 +247,84 @@ class CUDAOmniPlatform(CudaDeviceMixin, OmniPlatform):
         return effective_quantization
 
 
-class ROCMOmniPlatform(RocmDeviceMixin, CUDAOmniPlatform):
-    pass
+class ROCMOmniPlatform(RocmDeviceMixin, OmniPlatform):
+    """ROCm policy kept separate from NVIDIA CUDA backend selection."""
+
+    def get_stage_process_env(
+        self,
+        spec: StageLaunchConfig,
+        env: Mapping[str, str] | None = None,
+    ) -> dict[str, str]:
+        if spec.tp_size <= 1:
+            return {}
+
+        source_env = env if env is not None else os.environ
+        mapped_gpu = _map_rocm_visible_device(spec=spec, source_env=source_env)
+        return {
+            # ROCr uses physical ids; HIP and CUDA aliases operate on the
+            # resulting logical namespace. A rank-local process therefore
+            # sees physical ``mapped_gpu`` as logical device zero.
+            "ROCR_VISIBLE_DEVICES": mapped_gpu,
+            "HIP_VISIBLE_DEVICES": "0",
+            "CUDA_VISIBLE_DEVICES": "0",
+            "SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS": "true",
+            "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "false",
+        }
+
+    def get_intra_node_transport(self) -> TransportKind:
+        from sglang_omni.comm.data_ref import TransportKind
+
+        # PyTorch exposes CUDA-compatible storage and event IPC APIs on ROCm.
+        return TransportKind.CUDA_IPC
+
+    def get_default_remote_transport(self) -> TransportKind:
+        from sglang_omni.comm.data_ref import TransportKind
+
+        return TransportKind.NIXL
+
+    def enable_code2wav_graph(self):
+        # The owned code2wav runner directly constructs CUDA graph objects. Keep
+        # ROCm eager until that path is qualified independently on both targets.
+        return False
+
+    def supports_device_graphs(self) -> bool:
+        # Individual SGLang graph paths may work through torch.cuda on HIP, but
+        # Omni does not advertise the primitive until its owned graph runners pass.
+        return False
+
+    def apply_model_worker_backend_policy(
+        self,
+        server_args: ServerArgs,
+        model_config: ModelConfig,
+        model_arch_override: str | None,
+    ) -> str | None:
+        effective_quantization = super().apply_model_worker_backend_policy(
+            server_args, model_config, model_arch_override
+        )
+
+        moe_backend = str(server_args.moe_runner_backend or "").strip().lower()
+        if moe_backend in ("cutlass", "flashinfer_cutlass"):
+            raise ValueError(
+                f"{model_arch_override or 'model'} on ROCm cannot use "
+                f"moe_runner_backend={server_args.moe_runner_backend!r}; CUTLASS "
+                "and FlashInfer runners are NVIDIA-only. Use 'auto', 'aiter', "
+                "or 'triton'."
+            )
+
+        fp8_backend = str(server_args.fp8_gemm_runner_backend or "").strip().lower()
+        if fp8_backend in ("cutlass", "deep_gemm"):
+            raise ValueError(
+                f"{model_arch_override or 'model'} on ROCm cannot use "
+                f"fp8_gemm_runner_backend={server_args.fp8_gemm_runner_backend!r}; "
+                "use 'auto', 'aiter', or 'triton'."
+            )
+
+        logger.info(
+            "Configured ROCm backend policy: arch=%s effective_quantization=%s "
+            "moe_runner_backend=%s fp8_gemm_backend=%s",
+            model_arch_override,
+            effective_quantization,
+            server_args.moe_runner_backend,
+            server_args.fp8_gemm_runner_backend,
+        )
+        return effective_quantization

--- a/sglang_omni/platforms/interface.py
+++ b/sglang_omni/platforms/interface.py
@@ -31,6 +31,12 @@ class OmniPlatform(DeviceMixin):
 
         return TransportKind.SHM
 
+    def get_default_remote_transport(self) -> TransportKind:
+        """Return the platform default for an explicitly remote stage edge."""
+        from sglang_omni.comm.data_ref import TransportKind
+
+        return TransportKind.MOONCAKE
+
     def get_fused_qk_norm_rope(self):
         """Get the fused QK norm RoPE kernel if available, else return None."""
         return None
@@ -52,3 +58,7 @@ class OmniPlatform(DeviceMixin):
     def enable_code2wav_graph(self):
         """Check if current platform support Graph for code2wav in Qwen3-Omni"""
         return True
+
+    def supports_device_graphs(self) -> bool:
+        """Whether device-graph capture is a supported Omni runtime primitive."""
+        return False

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -27,6 +27,18 @@ def _operator_selected_prefill_graph_backend(
     return "backend" in nested_prefill_overrides(server_args_overrides)
 
 
+def _apply_platform_graph_policy(
+    overrides: dict[str, Any], *, supports_device_graphs: bool
+) -> None:
+    if supports_device_graphs:
+        return
+    overrides["disable_cuda_graph"] = True
+    overrides["disable_prefill_cuda_graph"] = True
+    overrides["cuda_graph_backend_prefill"] = CudaGraphBackend.DISABLED
+    overrides.pop("cuda_graph_bs_prefill", None)
+    overrides.pop("cuda_graph_max_bs_prefill", None)
+
+
 class SGLangGenerationEngineBuilder(ABC):
     """Build the model-neutral parts of a SGLang AR engine stage.
 
@@ -78,6 +90,15 @@ class SGLangGenerationEngineBuilder(ABC):
         overrides = build_generation_batch_overrides(
             server_args_overrides=server_args_overrides,
             **self.generation_defaults(dtype=dtype),
+        )
+        from sglang_omni.platforms import current_platform
+
+        # Owned CUDA-graph runners are not assumed portable merely because
+        # PyTorch exposes them through a cuda-compatible namespace. Keep the
+        # entire generation lifecycle eager until the platform opts in.
+        _apply_platform_graph_policy(
+            overrides,
+            supports_device_graphs=current_platform.supports_device_graphs(),
         )
         self.adjust_overrides(overrides)
         # Left unset, SGLang re-detects off a CUDA-first ladder that can contradict

--- a/sglang_omni/utils/audio.py
+++ b/sglang_omni/utils/audio.py
@@ -81,7 +81,24 @@ def _is_invalid_audio_source(source: bytes | str) -> bool:
 def _load_with_torchaudio(
     source: bytes | str, *, source_name: str
 ) -> tuple[torch.Tensor, int]:
-    _ensure_torchaudio_decoder_ready()
+    try:
+        _ensure_torchaudio_decoder_ready()
+    except ImportError:
+        if not torch.version.hip:
+            raise
+        import soundfile
+
+        decoder_source = io.BytesIO(source) if isinstance(source, bytes) else source
+        try:
+            samples, sample_rate = soundfile.read(
+                decoder_source, dtype="float32", always_2d=True
+            )
+        except soundfile.LibsndfileError as exc:
+            raise AudioDecodeError(
+                f"Could not decode {source_name} audio input"
+            ) from exc
+        return torch.from_numpy(np.ascontiguousarray(samples.T)), int(sample_rate)
+
     decoder_source = io.BytesIO(source) if isinstance(source, bytes) else source
     try:
         return torchaudio.load(decoder_source)
@@ -217,6 +234,7 @@ def load_audio(
     if isinstance(source, bytes):
         # Note (akazaakane): The direct WAV/NumPy path avoids torchaudio decoder
         # startup when mono=True without changing channel-preserving loads.
+        fast = None
         if mono and trim_top_db is None and _is_riff_wav(source):
             fast = _try_fast_wav_decode(
                 source, target_sample_rate, resample_kwargs=resample_kwargs
@@ -225,6 +243,25 @@ def load_audio(
                 return fast
         audio, sample_rate = _load_with_torchaudio(source, source_name=source_name)
     elif isinstance(source, str):
+        # Torch 2.9 routes torchaudio.load through TorchCodec, but published
+        # TorchCodec wheels are not ABI-compatible with the ROCm 7.2 image.
+        # Keep the native WAV path available for local reference audio too.
+        fast = None
+        if torch.version.hip and mono and trim_top_db is None:
+            try:
+                with open(source, "rb") as audio_file:
+                    prefix = audio_file.read(12)
+                    if _is_riff_wav(prefix):
+                        data = prefix + audio_file.read()
+                        fast = _try_fast_wav_decode(
+                            data,
+                            target_sample_rate,
+                            resample_kwargs=resample_kwargs,
+                        )
+            except OSError:
+                pass
+        if fast is not None:
+            return fast
         audio, sample_rate = _load_with_torchaudio(source, source_name=source_name)
     else:
         raise ValueError(

--- a/sglang_omni/utils/gpu_memory.py
+++ b/sglang_omni/utils/gpu_memory.py
@@ -277,7 +277,15 @@ def get_gpu_startup_lock_path(
     """Return the launch-time lock path for a CUDA logical GPU id."""
 
     source_env = env if env is not None else os.environ
-    visible_devices = parse_cuda_visible_devices(source_env.get("CUDA_VISIBLE_DEVICES"))
+    # ROCm TP workers are narrowed with a physical ROCR id while their HIP/CUDA
+    # aliases both become logical device zero. Using CUDA_VISIBLE_DEVICES here
+    # would make every rank contend on the same lock and deadlock distributed
+    # initialization while rank zero holds it. Prefer the physical ROCr mapping
+    # whenever it is available.
+    visible_devices_value = source_env.get("ROCR_VISIBLE_DEVICES") or source_env.get(
+        "CUDA_VISIBLE_DEVICES"
+    )
+    visible_devices = parse_cuda_visible_devices(visible_devices_value)
     visible_device = resolve_visible_device_id(logical_gpu_id, visible_devices)
     safe_device = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(visible_device)).strip("_")
     if not safe_device:

--- a/tests/unit_test/diagnostics/test_gpu.py
+++ b/tests/unit_test/diagnostics/test_gpu.py
@@ -100,7 +100,7 @@ def test_collect_gpu_diagnostics_preserves_reordered_visible_mapping(
     fake_torch = _FakeTorch()
     fake_torch.cuda.properties.reverse()
     monkeypatch.setattr(gpu_diagnostics, "_cuda_runtime_version", lambda: "13.3")
-    monkeypatch.setattr(gpu_diagnostics, "_backend_inventory", lambda: [])
+    monkeypatch.setattr(gpu_diagnostics, "_backend_inventory", lambda *_: [])
 
     report = gpu_diagnostics.collect_gpu_diagnostics(
         env={"CUDA_VISIBLE_DEVICES": "1,0"},
@@ -122,9 +122,59 @@ def test_collect_gpu_diagnostics_preserves_reordered_visible_mapping(
         "backends",
         "warnings",
     }
+    assert report["schema_version"] == 1
+    assert "accelerator" not in report["environment"]
     rendered = gpu_diagnostics.render_gpu_diagnostics(report)
     assert "logical 0 -> physical 1" in rendered
     assert fake_nvml.shutdown_called is True
+
+
+def test_collect_gpu_diagnostics_reports_rocm_architecture_and_policy(
+    monkeypatch,
+) -> None:
+    class _FakeRocmCuda(_FakeCuda):
+        def __init__(self) -> None:
+            self.properties = [
+                SimpleNamespace(
+                    name="AMD Instinct MI355X",
+                    gcnArchName="gfx950:sramecc+:xnack-",
+                    total_memory=288 * 1024**3,
+                    uuid="",
+                )
+            ]
+
+        def mem_get_info(self, index: int) -> tuple[int, int]:
+            assert index == 0
+            return 280 * 1024**3, 288 * 1024**3
+
+    class _FakeRocmTorch:
+        __version__ = "2.11.0+rocm7.2"
+        version = SimpleNamespace(cuda=None, hip="7.2")
+
+        def __init__(self) -> None:
+            self.cuda = _FakeRocmCuda()
+
+    monkeypatch.setattr(gpu_diagnostics, "_backend_inventory", lambda *_: [])
+
+    report = gpu_diagnostics.collect_gpu_diagnostics(
+        env={"ROCR_VISIBLE_DEVICES": "3"},
+        torch_module=_FakeRocmTorch(),
+        pynvml_module=None,
+    )
+
+    assert report["environment"]["accelerator"] == "rocm"
+    assert report["environment"]["device_type"] == "cuda"
+    assert report["environment"]["visible_devices_variable"] == ("ROCR_VISIBLE_DEVICES")
+    assert report["environment"]["cuda_visible_devices"] is None
+    assert report["environment"]["rocr_visible_devices"] == "3"
+    assert report["environment"]["pytorch_rocm_build"] == "7.2"
+    assert report["environment"]["gpu_architectures"] == ["gfx950:sramecc+:xnack-"]
+    assert report["gpus"][0]["gpu_architecture"] == "gfx950:sramecc+:xnack-"
+    assert report["gpus"][0]["free_memory_bytes"] == 280 * 1024**3
+    assert report["selected_backend_policy"]["remote_transport"] == "nixl"
+    rendered = gpu_diagnostics.render_gpu_diagnostics(report)
+    assert "Accelerator: rocm" in rendered
+    assert "arch=gfx950:sramecc+:xnack-" in rendered
 
 
 def test_nvml_inventory_failure_is_isolated_per_physical_device(
@@ -142,7 +192,7 @@ def test_nvml_inventory_failure_is_isolated_per_physical_device(
     fake_nvml = _PartiallyFailingNVML()
     fake_torch = _FakeTorch()
     monkeypatch.setattr(gpu_diagnostics, "_cuda_runtime_version", lambda: "13.3")
-    monkeypatch.setattr(gpu_diagnostics, "_backend_inventory", lambda: [])
+    monkeypatch.setattr(gpu_diagnostics, "_backend_inventory", lambda *_: [])
 
     report = gpu_diagnostics.collect_gpu_diagnostics(
         env={"CUDA_VISIBLE_DEVICES": "0,2"},
@@ -168,7 +218,7 @@ def test_nvml_inventory_failure_is_isolated_per_device_field(monkeypatch) -> Non
     fake_nvml = _PartiallyFailingNVML()
     fake_torch = _FakeTorch()
     monkeypatch.setattr(gpu_diagnostics, "_cuda_runtime_version", lambda: "13.3")
-    monkeypatch.setattr(gpu_diagnostics, "_backend_inventory", lambda: [])
+    monkeypatch.setattr(gpu_diagnostics, "_backend_inventory", lambda *_: [])
 
     report = gpu_diagnostics.collect_gpu_diagnostics(
         env={"CUDA_VISIBLE_DEVICES": "0,1"},
@@ -201,7 +251,7 @@ def test_mig_visible_device_emits_unsupported_mapping_warning(monkeypatch) -> No
         )
     ]
     monkeypatch.setattr(gpu_diagnostics, "_cuda_runtime_version", lambda: "13.3")
-    monkeypatch.setattr(gpu_diagnostics, "_backend_inventory", lambda: [])
+    monkeypatch.setattr(gpu_diagnostics, "_backend_inventory", lambda *_: [])
 
     report = gpu_diagnostics.collect_gpu_diagnostics(
         env={"CUDA_VISIBLE_DEVICES": "MIG-instance-uuid"},

--- a/tests/unit_test/higgs_tts/test_batched_step.py
+++ b/tests/unit_test/higgs_tts/test_batched_step.py
@@ -15,6 +15,8 @@ from sglang_omni.models.higgs_tts.sampler import (
     K_MAX,
     STOP_CODE,
     HiggsBatchedSamplerState,
+    _top_k_renorm_torch,
+    _top_p_renorm_torch,
     batched_step,
     step,
 )
@@ -26,6 +28,18 @@ DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 GREEDY_TOP_K = 1
 N = 8
 V = 1026
+
+
+def test_torch_sampling_renorm_fallbacks_support_per_row_limits() -> None:
+    probs = torch.tensor([[0.5, 0.3, 0.2], [0.6, 0.25, 0.15]])
+
+    top_k = _top_k_renorm_torch(probs, torch.tensor([1, 2]))
+    top_p = _top_p_renorm_torch(probs, torch.tensor([0.5, 0.7]))
+
+    assert torch.allclose(top_k.sum(dim=-1), torch.ones(2))
+    assert torch.equal(top_k.ne(0).sum(dim=-1), torch.tensor([1, 2]))
+    assert torch.allclose(top_p.sum(dim=-1), torch.ones(2))
+    assert torch.equal(top_p.ne(0).sum(dim=-1), torch.tensor([1, 2]))
 
 
 def _peaky_logits(target_codes_BN: torch.Tensor) -> torch.Tensor:

--- a/tests/unit_test/minimax_music3/test_core.py
+++ b/tests/unit_test/minimax_music3/test_core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -11,6 +12,7 @@ from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_c
 from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
 from torch.nn import functional as F
 
+from sglang_omni.models.minimax_music3 import config as minimax_music3_config
 from sglang_omni.models.minimax_music3.acoustic import (
     MiniMaxMusic3AcousticScheduler,
     _resolve_acoustic_dtype,
@@ -225,6 +227,71 @@ def test_minimax_music3_default_follows_the_visible_gpus(
     assert MiniMaxMusic3PipelineConfig.mem_fraction_role_to_stage() == {
         "talker": "minimax_music3_ar"
     }
+
+
+@pytest.mark.parametrize(
+    ("is_rocm", "server_args_overrides"),
+    [
+        (False, {}),
+        (True, {"disable_cuda_graph": True}),
+    ],
+)
+def test_minimax_music3_rocm_disables_generation_graphs(
+    monkeypatch: pytest.MonkeyPatch,
+    is_rocm: bool,
+    server_args_overrides: dict[str, bool],
+) -> None:
+    monkeypatch.setattr(
+        minimax_music3_config,
+        "current_platform",
+        SimpleNamespace(is_rocm=lambda: is_rocm),
+    )
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
+
+    config = MiniMaxMusic3PipelineConfig(model_path="/models/minimax")
+    stages = {stage.name: stage for stage in config.stages}
+
+    assert (
+        stages["minimax_music3_ar"].factory_args["server_args_overrides"]
+        == server_args_overrides
+    )
+    assert stages["dit_dav"].factory_args["compile_acoustic"] is True
+
+
+@pytest.mark.parametrize(
+    ("disable_cuda_graph", "generation_cuda_graph_enabled", "expected_buckets"),
+    [
+        (False, True, [2, 4, 8, 16, 32]),
+        (True, True, None),
+        (False, False, None),
+    ],
+)
+def test_minimax_music3_rvq_graph_follows_generation_graph_state(
+    monkeypatch: pytest.MonkeyPatch,
+    disable_cuda_graph: bool,
+    generation_cuda_graph_enabled: bool,
+    expected_buckets: list[int] | None,
+) -> None:
+    from sglang_omni.models.minimax_music3 import sglang_model
+    from sglang_omni.models.minimax_music3.engine_builder import (
+        MiniMaxMusic3EngineBuilder,
+    )
+
+    captured: list[tuple[object, list[int]]] = []
+    monkeypatch.setattr(
+        sglang_model,
+        "enable_rvq_depth_cuda_graph",
+        lambda model, buckets: captured.append((model, buckets)),
+    )
+    model = object()
+
+    MiniMaxMusic3EngineBuilder().setup_model_resources(
+        model,
+        SimpleNamespace(disable_cuda_graph=disable_cuda_graph),
+        generation_cuda_graph_enabled=generation_cuda_graph_enabled,
+    )
+
+    assert captured == ([] if expected_buckets is None else [(model, expected_buckets)])
 
 
 def test_native_attention_preserves_checkpoint_state_dict_keys() -> None:

--- a/tests/unit_test/models/test_accelerator_support.py
+++ b/tests/unit_test/models/test_accelerator_support.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from sglang_omni.models.accelerator_support import (
+    AcceleratorSupportStatus,
+    get_model_accelerator_support,
+    iter_model_accelerator_support,
+)
+from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+
+
+def _canonical_architectures() -> set[str]:
+    return {
+        str(config_cls.architecture)
+        for config_cls in set(PIPELINE_CONFIG_REGISTRY.configs.values())
+    }
+
+
+def test_rocm_declarations_cover_every_canonical_model() -> None:
+    declarations = list(iter_model_accelerator_support("rocm"))
+
+    assert {item.architecture for item in declarations} == _canonical_architectures()
+    assert len(declarations) == 19
+    assert all(item.gpu_architectures == ("gfx942", "gfx950") for item in declarations)
+
+
+def test_minimax_music3_is_supported_on_both_rocm_targets() -> None:
+    support = get_model_accelerator_support(
+        "MiniMaxMusic3ForConditionalGeneration", "ROCm"
+    )
+
+    assert support is not None
+    assert support.status is AcceleratorSupportStatus.SUPPORTED
+    assert support.supports_gpu_architecture("GFX942")
+    assert support.supports_gpu_architecture("gfx950")
+    assert "eager-generation" in support.validated_features
+    with pytest.raises(FrozenInstanceError):
+        support.status = AcceleratorSupportStatus.PREVIEW
+
+
+def test_registered_alias_resolves_canonical_support() -> None:
+    alias = get_model_accelerator_support("MossTTSDelay", "rocm")
+    canonical = get_model_accelerator_support("MossTTSDelayModel", "rocm")
+
+    assert alias == canonical
+    assert alias is not None
+    assert not alias.supports_gpu_architecture("gfx942:sramecc+:xnack-")
+
+
+def test_unknown_model_or_accelerator_has_no_declaration() -> None:
+    assert get_model_accelerator_support("Unknown", "rocm") is None
+    assert (
+        get_model_accelerator_support("MiniMaxMusic3ForConditionalGeneration", "cuda")
+        is None
+    )

--- a/tests/unit_test/moss_tts/test_vocoder_decoder.py
+++ b/tests/unit_test/moss_tts/test_vocoder_decoder.py
@@ -374,6 +374,22 @@ def test_packed_flash_unavailable_uses_source_attention(monkeypatch) -> None:
     assert torch.equal(out_lengths, lengths)
 
 
+def test_rocm_forces_v2_vocoder_attention_to_sdpa(monkeypatch) -> None:
+    monkeypatch.setattr(vocoder_decoder.current_platform, "is_rocm", lambda: True)
+    source = _FallbackProjectedStage()
+    attention = source.transformer.layers[0].self_attn
+    attention.attention_implementation = "flash_attention_2"
+
+    wrapper = MossAudioTokenizerProjectedTransformer(source)
+
+    wrapped_attention = wrapper.transformer.layers[0].self_attn
+    assert attention.attention_implementation == "flash_attention_2"
+    assert wrapped_attention._flash_attn_varlen is None
+    assert wrapped_attention.resolve_attention_implementation(torch.randn(2, 6)) == (
+        "sdpa"
+    )
+
+
 def test_local_causal_flash_plan_chunks_queries_and_overlaps_keys() -> None:
     cu_seqlens = torch.tensor([0, 320, 577], dtype=torch.int32)
 
@@ -643,6 +659,8 @@ def test_projected_transformer_single_padded_input_uses_masked_pack() -> None:
 def test_sglang_packed_flash_matches_sdpa_reference_cuda() -> None:
     if not torch.cuda.is_available():
         pytest.skip("requires CUDA")
+    if vocoder_decoder.current_platform.is_rocm():
+        pytest.skip("ROCm uses the SDPA vocoder path")
     if vocoder_decoder.flash_attn_varlen_func is None:
         pytest.skip("requires SGLang flash_attn_varlen_func")
 
@@ -677,6 +695,8 @@ def test_sglang_packed_flash_matches_sdpa_reference_cuda() -> None:
 def test_sglang_chunked_local_flash_matches_sdpa_reference_cuda() -> None:
     if not torch.cuda.is_available():
         pytest.skip("requires CUDA")
+    if vocoder_decoder.current_platform.is_rocm():
+        pytest.skip("ROCm uses the SDPA vocoder path")
     if vocoder_decoder.flash_attn_varlen_func is None:
         pytest.skip("requires SGLang flash_attn_varlen_func")
 
@@ -877,6 +897,7 @@ def test_vocoder_decoder_wraps_legacy_moss_audio_tokenizer_fields() -> None:
     assert wrapped_layer.ffn.linear2 is source_layer.linear2
     assert wrapped_layer.ffn.activation is source_layer.activation
 
+    attention._flash_attn_varlen = lambda *args, **kwargs: None
     attention._can_run_packed_flash = lambda _: True
     assert attention.resolve_attention_implementation(torch.randn(2, 6)) == (
         "flash_attention_2"

--- a/tests/unit_test/pipeline/test_gpu_memory.py
+++ b/tests/unit_test/pipeline/test_gpu_memory.py
@@ -330,6 +330,7 @@ def test_gpu_startup_lock_path_uses_visible_device_mapping(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
 ) -> None:
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3,MIG-GPU-deadbeef/1/2")
 
     first = gpu_memory.get_gpu_startup_lock_path(0, base_dir=tmp_path)
@@ -337,6 +338,22 @@ def test_gpu_startup_lock_path_uses_visible_device_mapping(
 
     assert first.name == "sglang_omni_gpu_3_startup.lock"
     assert second.name == "sglang_omni_gpu_MIG-GPU-deadbeef_1_2_startup.lock"
+
+
+def test_gpu_startup_lock_path_uses_physical_rocm_mapping(tmp_path) -> None:
+    first = gpu_memory.get_gpu_startup_lock_path(
+        0,
+        env={"ROCR_VISIBLE_DEVICES": "2", "CUDA_VISIBLE_DEVICES": "0"},
+        base_dir=tmp_path,
+    )
+    second = gpu_memory.get_gpu_startup_lock_path(
+        0,
+        env={"ROCR_VISIBLE_DEVICES": "3", "CUDA_VISIBLE_DEVICES": "0"},
+        base_dir=tmp_path,
+    )
+
+    assert first.name == "sglang_omni_gpu_2_startup.lock"
+    assert second.name == "sglang_omni_gpu_3_startup.lock"
 
 
 def test_gpu_startup_lock_releases_after_exception(

--- a/tests/unit_test/pipeline/test_stage_process_env.py
+++ b/tests/unit_test/pipeline/test_stage_process_env.py
@@ -15,7 +15,7 @@ from sglang_omni.pipeline.stage_workers import (
     StageWorkerProcessSpec,
     _patched_spawn_env,
 )
-from sglang_omni.platforms.cuda import CUDAOmniPlatform
+from sglang_omni.platforms.cuda import CUDAOmniPlatform, ROCMOmniPlatform
 from tests.unit_test.fixtures.pipeline_fakes import FakeScheduler, fake_factory_path
 
 cuda_platform = CUDAOmniPlatform()
@@ -157,6 +157,7 @@ def test_xpu_tp_rank_keeps_its_card_despite_an_inherited_cuda_marker(
     monkeypatch.setattr(stage_workers, "current_platform", XPUOmniPlatform())
     monkeypatch.setenv("SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS", "true")
     monkeypatch.delenv("ZE_AFFINITY_MASK", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
     spec = StageLaunchConfig(
         stage_name="thinker",
         role="follower",
@@ -211,6 +212,31 @@ def test_spawn_env_applies_stage_defaults_before_child_start(monkeypatch) -> Non
         assert os.environ["SGLANG_TEST_STAGE_ENV"] == "default"
 
     assert "SGLANG_TEST_STAGE_ENV" not in os.environ
+
+
+def test_spawn_env_applies_audar_rocm_stage_default_before_child_start(
+    monkeypatch,
+) -> None:
+    from sglang_omni.models.audar_tts import config as audar_config
+
+    monkeypatch.delenv("AMD_SERIALIZE_KERNEL", raising=False)
+    monkeypatch.setattr(stage_workers, "current_platform", ROCMOmniPlatform())
+    monkeypatch.setattr(audar_config, "current_platform", ROCMOmniPlatform())
+    tts_stage = next(
+        stage for stage in audar_config._stages() if stage.name == "tts_engine"
+    )
+    spec = StageLaunchConfig(
+        stage_name="tts_engine",
+        factory=tts_stage.factory,
+        tp_size=1,
+        gpu_id=0,
+        env_defaults=tts_stage.env,
+    )
+
+    with _patched_spawn_env(_worker_spec(spec)):
+        assert os.environ["AMD_SERIALIZE_KERNEL"] == "3"
+
+    assert "AMD_SERIALIZE_KERNEL" not in os.environ
 
 
 def test_spawn_env_preserves_operator_stage_defaults(monkeypatch) -> None:

--- a/tests/unit_test/qwen3_asr/test_prefill_graph_positions.py
+++ b/tests/unit_test/qwen3_asr/test_prefill_graph_positions.py
@@ -66,6 +66,22 @@ def test_capture_selects_value_equal_positions_to_eager(
 
 
 @pytest.mark.parametrize(
+    ("kernel", "expected_dtype"),
+    [(None, torch.int64), (lambda *args: None, torch.int32)],
+)
+def test_eager_positions_use_dtype_required_by_rope_path(
+    monkeypatch: pytest.MonkeyPatch,
+    kernel,
+    expected_dtype: torch.dtype,
+) -> None:
+    monkeypatch.setattr(sglang_model, "fused_qk_norm_rope", kernel)
+
+    positions = _eager_positions(monkeypatch, _forward_batch(carries_mrope=True))
+
+    assert positions.dtype == expected_dtype
+
+
+@pytest.mark.parametrize(
     ("positions_dtype", "expect_same_object"),
     [(torch.int64, False), (torch.int32, True)],
 )

--- a/tests/unit_test/qwen3_asr/test_sglang_model.py
+++ b/tests/unit_test/qwen3_asr/test_sglang_model.py
@@ -87,7 +87,7 @@ def test_asr_text_rope_drops_only_multimodal_parameters() -> None:
     assert original["mrope_section"] == [24, 20, 20]
 
 
-def test_fused_asr_qk_norm_rope_is_bound_per_attention() -> None:
+def test_fused_asr_qk_norm_rope_is_bound_per_attention(monkeypatch) -> None:
     def original(positions, hidden_states):
         return positions, hidden_states
 
@@ -108,6 +108,7 @@ def test_fused_asr_qk_norm_rope_is_bound_per_attention() -> None:
         )
     )
 
+    monkeypatch.setattr(sglang_model, "fused_qk_norm_rope", lambda *args: None)
     sglang_model._enable_fused_asr_qk_norm_rope(language_model)
 
     assert supported._asr_unfused_forward_prepare_native is original
@@ -116,6 +117,22 @@ def test_fused_asr_qk_norm_rope_is_bound_per_attention() -> None:
         is sglang_model._fused_asr_forward_prepare_native
     )
     assert unsupported.forward_prepare_native is original
+
+
+def test_fused_asr_qk_norm_rope_stays_native_when_kernel_is_unavailable(
+    monkeypatch,
+) -> None:
+    original = object()
+    attention = SimpleNamespace(head_dim=128, forward_prepare_native=original)
+    language_model = SimpleNamespace(
+        model=SimpleNamespace(layers=[SimpleNamespace(self_attn=attention)])
+    )
+    monkeypatch.setattr(sglang_model, "fused_qk_norm_rope", None)
+
+    sglang_model._enable_fused_asr_qk_norm_rope(language_model)
+
+    assert attention.forward_prepare_native is original
+    assert not hasattr(attention, "_asr_unfused_forward_prepare_native")
 
 
 def test_fused_asr_qk_norm_rope_falls_back_before_projection() -> None:

--- a/tests/unit_test/qwen3_asr/test_sglang_model.py
+++ b/tests/unit_test/qwen3_asr/test_sglang_model.py
@@ -62,7 +62,10 @@ def test_forward_uses_available_mrope_positions(
 
     expected_positions = mrope_positions[0] if use_mrope_positions else positions
     assert torch.equal(seen_positions, expected_positions)
-    assert seen_positions.dtype == torch.int32
+    expected_dtype = (
+        torch.int32 if sglang_model.fused_qk_norm_rope is not None else torch.long
+    )
+    assert seen_positions.dtype == expected_dtype
     assert actual is output
 
 

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -153,7 +153,7 @@ def test_non_cuda_platforms_disable_the_code2wav_graph() -> None:
     assert NPUOmniPlatform().enable_code2wav_graph() is False
     assert CPUOmniPlatform().enable_code2wav_graph() is False
     assert CUDAOmniPlatform().enable_code2wav_graph() is True
-    assert ROCMOmniPlatform().enable_code2wav_graph() is True
+    assert ROCMOmniPlatform().enable_code2wav_graph() is False
 
 
 def test_the_code2wav_stage_takes_its_graph_flag_from_the_platform() -> None:

--- a/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
+++ b/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
@@ -10,12 +10,13 @@ import pytest
 
 from sglang_omni.model_runner import model_worker
 from sglang_omni.platforms import cuda
-from sglang_omni.platforms.cuda import CUDAOmniPlatform
+from sglang_omni.platforms.cuda import CUDAOmniPlatform, ROCMOmniPlatform
 from sglang_omni.platforms.xpu import XPUOmniPlatform
 from sglang_omni.utils.misc import model_config_has_moe
 from tests.unit_test.fakes import FakeServerArgs
 
 cuda_platform = CUDAOmniPlatform()
+rocm_platform = ROCMOmniPlatform()
 
 
 class _StrictServerArgsDouble:
@@ -90,6 +91,51 @@ def _model_config(
         hf_text_config=SimpleNamespace(**attrs),
         hf_config=SimpleNamespace(quantization_config=quantization_config),
     )
+
+
+@pytest.mark.parametrize(
+    ("moe_backend", "fp8_backend", "error_match"),
+    [
+        ("cutlass", "auto", "CUTLASS and FlashInfer"),
+        ("flashinfer_cutlass", "auto", "CUTLASS and FlashInfer"),
+        ("auto", "deep_gemm", "fp8_gemm_runner_backend"),
+        ("auto", "cutlass", "fp8_gemm_runner_backend"),
+    ],
+)
+def test_rocm_backend_policy_rejects_nvidia_only_runners(
+    moe_backend: str,
+    fp8_backend: str,
+    error_match: str,
+) -> None:
+    args = _server_args(
+        moe_runner_backend=moe_backend,
+        fp8_gemm_runner_backend=fp8_backend,
+    )
+
+    with pytest.raises(ValueError, match=error_match):
+        rocm_platform.apply_model_worker_backend_policy(
+            args,
+            _model_config(quantization=None),
+            "Qwen3OmniTalker",
+        )
+
+
+@pytest.mark.parametrize("backend", ["auto", "aiter", "triton"])
+def test_rocm_backend_policy_preserves_portable_runners(backend: str) -> None:
+    args = _server_args(
+        moe_runner_backend=backend,
+        fp8_gemm_runner_backend=backend,
+    )
+
+    result = rocm_platform.apply_model_worker_backend_policy(
+        args,
+        _model_config(quantization=None),
+        "Qwen3OmniTalker",
+    )
+
+    assert result is None
+    assert args.moe_runner_backend == backend
+    assert args.fp8_gemm_runner_backend == backend
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_test/rocm/test_model_fallbacks.py
+++ b/tests/unit_test/rocm/test_model_fallbacks.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+
+def _platform(*, rocm: bool) -> SimpleNamespace:
+    return SimpleNamespace(is_rocm=lambda: rocm)
+
+
+def test_fishaudio_uses_aiter_for_slow_ar_on_rocm(monkeypatch) -> None:
+    from sglang_omni.models.fishaudio_s2_pro import engine_builder
+
+    monkeypatch.setattr(engine_builder, "current_platform", _platform(rocm=True))
+    monkeypatch.setattr(
+        engine_builder,
+        "get_visible_gpu_sm_version",
+        lambda _gpu_id: (_ for _ in ()).throw(AssertionError("CUDA SM queried")),
+    )
+
+    assert engine_builder._resolve_fast_ar_attention_backend(gpu_id=0) == "aiter"
+
+
+def test_fishaudio_torch_fast_ar_updates_cache() -> None:
+    from sglang_omni.models.fishaudio_s2_pro.fish_speech.models.text2semantic import (
+        audio_decoder,
+    )
+
+    q = torch.randn(2, 1, 4, 8)
+    k = torch.randn(2, 1, 2, 8)
+    v = torch.randn(2, 1, 2, 8)
+    k_cache = torch.zeros(2, 4, 2, 8)
+    v_cache = torch.zeros(2, 4, 2, 8)
+
+    output = audio_decoder._torch_kvcache_attention(
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        k=k,
+        v=v,
+        causal=True,
+        cache_position=2,
+    )
+
+    assert output.shape == q.shape
+    assert torch.equal(k_cache[:, 2:3], k)
+    assert torch.equal(v_cache[:, 2:3], v)
+
+
+def test_llada_selects_platform_attention_backend(monkeypatch) -> None:
+    from sglang_omni.models.llada2_uni import stages
+
+    monkeypatch.setattr(stages, "current_platform", _platform(rocm=True))
+    assert stages._dllm_attention_backend() == "aiter"
+
+    monkeypatch.setattr(stages, "current_platform", _platform(rocm=False))
+    assert stages._dllm_attention_backend() == "flashinfer"
+
+
+def test_ming_audio_vae_uses_sdpa_on_rocm(monkeypatch) -> None:
+    from sglang_omni.models.ming_omni.talker.audio_vae import vae_modules
+
+    model_args = {"_attn_implementation": "flash_attention_2"}
+    monkeypatch.setattr(vae_modules, "current_platform", _platform(rocm=True))
+    assert vae_modules._qwen2_config(model_args)._attn_implementation == "sdpa"
+
+    monkeypatch.setattr(vae_modules, "current_platform", _platform(rocm=False))
+    assert (
+        vae_modules._qwen2_config(model_args)._attn_implementation
+        == "flash_attention_2"
+    )
+
+
+def test_ming_talker_accepts_tensor_cache_length() -> None:
+    from sglang_omni.models.ming_omni.talker.modeling_ming_omni_talker import (
+        _cache_positions,
+    )
+
+    positions = _cache_positions(torch.tensor(7), 3, torch.device("cpu"))
+
+    assert torch.equal(positions, torch.tensor([7, 8, 9]))

--- a/tests/unit_test/scheduling/test_engine_factory.py
+++ b/tests/unit_test/scheduling/test_engine_factory.py
@@ -29,6 +29,37 @@ def test_engine_builder_import_is_cpu_only() -> None:
     assert issubclass(TtsEngineBuilder, SGLangGenerationEngineBuilder)
 
 
+def test_non_graph_platform_forces_generation_and_prefill_eager() -> None:
+    from sglang_omni.scheduling.engine_factory import _apply_platform_graph_policy
+    from sglang_omni.scheduling.generation_batch_policy import CudaGraphBackend
+
+    overrides = {
+        "disable_cuda_graph": False,
+        "disable_prefill_cuda_graph": False,
+        "cuda_graph_backend_prefill": CudaGraphBackend.BREAKABLE,
+        "cuda_graph_bs_prefill": [4, 8],
+        "cuda_graph_max_bs_prefill": 8,
+    }
+
+    _apply_platform_graph_policy(overrides, supports_device_graphs=False)
+
+    assert overrides["disable_cuda_graph"] is True
+    assert overrides["disable_prefill_cuda_graph"] is True
+    assert overrides["cuda_graph_backend_prefill"] == CudaGraphBackend.DISABLED
+    assert "cuda_graph_bs_prefill" not in overrides
+    assert "cuda_graph_max_bs_prefill" not in overrides
+
+
+def test_graph_platform_preserves_generation_policy() -> None:
+    from sglang_omni.scheduling.engine_factory import _apply_platform_graph_policy
+
+    overrides = {"disable_cuda_graph": False}
+
+    _apply_platform_graph_policy(overrides, supports_device_graphs=True)
+
+    assert overrides == {"disable_cuda_graph": False}
+
+
 def test_asr_engine_builder_preserves_model_path() -> None:
     from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
 
@@ -91,6 +122,12 @@ def test_tts_engine_builder_phase_order_and_override_contract(monkeypatch) -> No
 
     monkeypatch.setattr(
         platforms.current_platform, "device_type", "cuda", raising=False
+    )
+    monkeypatch.setattr(
+        platforms.current_platform,
+        "supports_device_graphs",
+        lambda: True,
+        raising=False,
     )
     monkeypatch.setattr(
         "sglang.srt.utils.get_device", lambda device_id=None: f"cuda:{device_id}"

--- a/tests/unit_test/test_platforms.py
+++ b/tests/unit_test/test_platforms.py
@@ -48,12 +48,55 @@ def test_rocm_platform_keeps_cuda_compatible_tp_mapping() -> None:
     spec = SimpleNamespace(stage_name="thinker", tp_size=2, gpu_id=1)
 
     assert platform.is_rocm()
-    assert (
-        platform.get_stage_process_env(spec, {"CUDA_VISIBLE_DEVICES": "3,4"})[
-            "CUDA_VISIBLE_DEVICES"
-        ]
-        == "4"
+    updates = platform.get_stage_process_env(spec, {"ROCR_VISIBLE_DEVICES": "3,4"})
+
+    assert updates["ROCR_VISIBLE_DEVICES"] == "4"
+    assert updates["HIP_VISIBLE_DEVICES"] == "0"
+    assert updates["CUDA_VISIBLE_DEVICES"] == "0"
+    assert updates["SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS"] == "true"
+
+
+def test_rocm_platform_accepts_logical_aliases_after_rocr_mask() -> None:
+    platform = platforms._as_omni_platform(RocmSRTPlatform())
+    spec = SimpleNamespace(stage_name="thinker", tp_size=2, gpu_id=1)
+
+    updates = platform.get_stage_process_env(
+        spec,
+        {
+            "ROCR_VISIBLE_DEVICES": "3,4",
+            "HIP_VISIBLE_DEVICES": "0,1",
+            "CUDA_VISIBLE_DEVICES": "0,1",
+        },
     )
+
+    assert updates["ROCR_VISIBLE_DEVICES"] == "4"
+    assert updates["HIP_VISIBLE_DEVICES"] == "0"
+    assert updates["CUDA_VISIBLE_DEVICES"] == "0"
+
+
+def test_rocm_platform_rejects_conflicting_visibility_namespaces() -> None:
+    platform = platforms._as_omni_platform(RocmSRTPlatform())
+    spec = SimpleNamespace(stage_name="thinker", tp_size=2, gpu_id=1)
+
+    with pytest.raises(ValueError, match="conflicting accelerator visibility"):
+        platform.get_stage_process_env(
+            spec,
+            {
+                "ROCR_VISIBLE_DEVICES": "3,4",
+                "HIP_VISIBLE_DEVICES": "5,6",
+            },
+        )
+
+
+def test_rocm_platform_uses_nixl_and_disables_owned_graphs() -> None:
+    from sglang_omni.comm.data_ref import TransportKind
+
+    platform = platforms._as_omni_platform(RocmSRTPlatform())
+
+    assert platform.get_intra_node_transport() is TransportKind.CUDA_IPC
+    assert platform.get_default_remote_transport() is TransportKind.NIXL
+    assert platform.enable_code2wav_graph() is False
+    assert platform.supports_device_graphs() is False
 
 
 def test_srt_plugin_identity_round_trips_to_spawned_process() -> None:

--- a/tests/unit_test/utils/test_audio.py
+++ b/tests/unit_test/utils/test_audio.py
@@ -154,6 +154,21 @@ def test_load_audio_accepts_file_uri(tmp_path) -> None:
     assert samples.shape == (1600,)
 
 
+def test_load_audio_accepts_local_wav_without_torchcodec(monkeypatch, tmp_path) -> None:
+    path = tmp_path / "reference.wav"
+    path.write_bytes(_wav_bytes())
+
+    monkeypatch.setattr(
+        audio,
+        "_ensure_torchaudio_decoder_ready",
+        lambda: pytest.fail("local PCM WAV should not require TorchCodec"),
+    )
+
+    samples = load_audio(str(path))
+
+    assert samples.shape == (1600,)
+
+
 class _FakeHTTPResponse:
     def __init__(self, content: bytes) -> None:
         self.content = content
@@ -312,6 +327,7 @@ def test_load_audio_fast_path_resamples(monkeypatch) -> None:
 
 def test_load_audio_trims_before_resampling() -> None:
     import librosa
+    import soundfile
     import torch
     import torchaudio
 
@@ -325,7 +341,10 @@ def test_load_audio_trims_before_resampling() -> None:
         wav_file.setframerate(sample_rate)
         wav_file.writeframes((values * 32767).astype("<i2").tobytes())
     wav = buffer.getvalue()
-    raw, sample_rate = torchaudio.load(io.BytesIO(wav))
+    raw_values, sample_rate = soundfile.read(
+        io.BytesIO(wav), dtype="float32", always_2d=True
+    )
+    raw = torch.from_numpy(raw_values.T.copy())
     expected, _ = librosa.effects.trim(raw.numpy(), top_db=30)
     resample_kwargs = {
         "lowpass_filter_width": 64,

--- a/tests/unit_test/whisper_asr/test_pipeline.py
+++ b/tests/unit_test/whisper_asr/test_pipeline.py
@@ -16,6 +16,7 @@ import sglang_omni.scheduling.sglang_backend as sglang_backend
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from sglang_omni.models.whisper_asr import request_builders as whisper_request_builders
 from sglang_omni.models.whisper_asr.config import WhisperASRPipelineConfig
+from sglang_omni.platforms import current_platform
 from tests.unit_test.fakes import FakeServerArgs
 
 
@@ -123,6 +124,21 @@ def test_whisper_disables_chunked_prefill_for_atomic_encoder_prefix() -> None:
         builder.adjust_overrides({"chunked_prefill_size": 4096})
 
 
+def test_whisper_selects_native_attention_on_rocm(monkeypatch) -> None:
+    from sglang_omni.models.whisper_asr import engine_builder
+
+    builder = engine_builder.WhisperASREngineBuilder(
+        max_running_requests=4,
+        max_new_tokens=32,
+        mem_fraction_static=0.2,
+    )
+    monkeypatch.setattr(engine_builder.current_platform, "is_rocm", lambda: True)
+
+    defaults = builder.generation_defaults(dtype="bfloat16")
+
+    assert defaults["attention_backend"] == "torch_native"
+
+
 def test_whisper_prefill_coalescing_defaults_are_forwarded() -> None:
     from sglang_omni.models.whisper_asr.engine_builder import WhisperASREngineBuilder
 
@@ -152,7 +168,10 @@ def test_whisper_asr_config_uses_single_batched_stage() -> None:
     assert config.gpu_placement == {"asr": 0}
     assert config.stages[0].factory.endswith("create_sglang_whisper_asr_executor")
     assert config.stages[0].factory_args["device"] == "cuda:0"
-    assert config.stages[0].factory_args["enable_encoder_cuda_graph"] is True
+    assert (
+        config.stages[0].factory_args["enable_encoder_cuda_graph"]
+        is current_platform.supports_device_graphs()
+    )
     assert config.stages[0].factory_args["request_build_max_workers"] == 2
     assert config.stages[0].factory_args["request_build_max_pending"] == 16
     assert config.stages[0].factory_args["prefill_coalesce_requests"] == 2

--- a/tests/unit_test/whisper_asr/test_sglang_model.py
+++ b/tests/unit_test/whisper_asr/test_sglang_model.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from sglang_omni.models.whisper_asr.sglang_model import (
+    WhisperSGLangCrossAttention,
+    WhisperSGLangSelfAttention,
+)
+
+
+class _HeadShapedAttention(nn.Module):
+    def forward(self, query, key, value, forward_batch):
+        del key, value, forward_batch
+        return query
+
+
+def _attention_shell(cls):
+    attention = cls.__new__(cls)
+    nn.Module.__init__(attention)
+    attention.embed_dim = 4
+    attention.num_heads = 2
+    attention.head_dim = 2
+    attention.q_proj = nn.Identity()
+    attention.k_proj = nn.Identity()
+    attention.v_proj = nn.Identity()
+    attention.out_proj = nn.Identity()
+    attention.attn = _HeadShapedAttention()
+    return attention
+
+
+def test_whisper_self_attention_flattens_native_backend_heads() -> None:
+    attention = _attention_shell(WhisperSGLangSelfAttention)
+
+    output = attention(torch.ones(3, 4), object())
+
+    assert output.shape == (3, 4)
+
+
+def test_whisper_cross_attention_flattens_native_backend_heads() -> None:
+    attention = _attention_shell(WhisperSGLangCrossAttention)
+
+    output = attention(torch.ones(3, 4), torch.ones(5, 4), object())
+
+    assert output.shape == (3, 4)


### PR DESCRIPTION
## Summary

- add ROCm fallbacks for the additional ASR, TTS, omni, and diffusion model paths validated today
- gate fused kernels, graph capture, position dtypes, samplers, and audio/vocoder fallbacks by platform capability
- add a model accelerator-support registry and regression tests for all declared ROCm architectures

## Stack

Depends on #1534 and #1544. Review the final commit(s) after #1544 when focusing on the model-portability delta.

## CUDA compatibility boundary

- CUDA keeps the original fused `sgl_kernel` imports and execution paths.
- ROCm fallbacks are guarded by `current_platform.is_rocm()`, `torch.version.hip`, or an explicit capability result; they do not replace the CUDA implementation.
- CUDA graph behavior is unchanged on platforms that report graph support.
- Existing model defaults, serialized config fields, and checkpoint keys remain unchanged.

## Portability

The model paths contain no fixed GPU IDs, host paths, node names, or machine-specific architecture checks. Platform selection and inherited visibility determine behavior at runtime.

## Validation

- MI355X / gfx950: 90 model-portability tests passed, with 2 intentional skips.
- During implementation, all 19 declared model contracts passed functionally on both MI300X / gfx942 and MI355X / gfx950.
- The exact published top-of-stack head also passes the 190-test ROCm smoke suite; the scheduled matrix in the final stack will rerun all model contracts on both architectures.
