### PR TITLE
[Perf] Enable decoder compile and tiny prefill graphs for MOSS-TD

### DIFF
--- a/docs/cookbook/moss_transcribe_diarize.md
+++ b/docs/cookbook/moss_transcribe_diarize.md
@@ -75,13 +75,9 @@ At c=1 with longer audio, AR Decode takes 94%+ of total time — the leverage is
 
 The optimization stack mirrors [what we built for TTS](https://github.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/blob/main/sglang/sglang-omni/tts-optimization.md), sharing the same core infrastructure with ASR-specific adaptations.
 
-**CUDA Graph.** The LLM decode step pads batch size to predefined buckets (1, 2, 4, 8, …) and replays a captured CUDA graph, eliminating kernel launch overhead on every token. This is the single biggest optimization for AR Decode. Breakable prefill graphs use token-count buckets beginning at 1 and 2 so cached-prefix extends do not fall back to eager. The Whisper encoder gets the same treatment, bucketed over chunk count (`encoder_chunk_buckets`, default `1..8` ≈ 4 min of audio).
+**CUDA Graph.** The LLM decode step pads batch size to predefined buckets (1, 2, 4, 8, …) and replays a captured CUDA graph, eliminating kernel launch overhead on every token. This is the single biggest optimization for AR Decode. Breakable prefill graphs bucket over token count instead, and the ladder starts at 1 and 2: a fully cached prefix still re-prefills its last token, and that 1-token extend would otherwise pad to the 4-token floor and exceed SGLang's 2x padding guard, falling back to eager. The 2-token bucket sits exactly on that guard, so it replays either way and only saves the padding. The Whisper encoder gets the same treatment, bucketed over chunk count (`encoder_chunk_buckets`, default `1..8` ≈ 4 min of audio).
 
-**Decoder Torch Compile.** The default pipeline compiles Qwen3 decoder shapes
-through batch size 4 and uses the eager decoder above that cap. Override the cap
-with `--talker-torch-compile-max-bs`, or disable decoder compilation with
-`--talker-torch-compile off`. This setting is independent of the encoder
-compile option below.
+**Decoder Torch Compile.** The default pipeline compiles Qwen3 decoder shapes through batch size 4 and uses the eager decoder above that cap. Override the cap with `--torch-compile-max-bs`, or disable decoder compilation with `--torch-compile off`. Compilation runs once per captured decode bucket at startup (`max-autotune-no-cudagraphs`), so cold start pays an autotuning cost before the server accepts traffic. This setting is independent of the encoder compile option below.
 
 **Encoder Torch Compile (opt-in).** `encoder_torch_compile=True` swaps the encoder CUDA graph for `torch.compile` (default mode) with kernel fusion. The two are mutually exclusive. Reduce-overhead mode must not be used: its cudagraph trees corrupt memory alongside the decode CUDA graphs that always run in this process (illegal memory access after ~60s of serving). The cost is a one-time per-bucket compile at startup; `dynamic=False` means only the warmed chunk counts are accelerated, anything else runs eager.
 

--- a/docs/cookbook/moss_transcribe_diarize.md
+++ b/docs/cookbook/moss_transcribe_diarize.md
@@ -78,7 +78,7 @@ The optimization stack mirrors [what we built for TTS](https://github.com/zhaoch
 **CUDA Graph.** The LLM decode step pads batch size to predefined buckets (1, 2, 4, 8, …) and replays a captured CUDA graph, eliminating kernel launch overhead on every token. This is the single biggest optimization for AR Decode. Breakable prefill graphs use token-count buckets beginning at 1 and 2 so cached-prefix extends do not fall back to eager. The Whisper encoder gets the same treatment, bucketed over chunk count (`encoder_chunk_buckets`, default `1..8` ≈ 4 min of audio).
 
 **Decoder Torch Compile.** The default pipeline compiles Qwen3 decoder shapes
-through batch size 8 and uses the eager decoder above that cap. Override the cap
+through batch size 4 and uses the eager decoder above that cap. Override the cap
 with `--talker-torch-compile-max-bs`, or disable decoder compilation with
 `--talker-torch-compile off`. This setting is independent of the encoder
 compile option below.

--- a/docs/cookbook/moss_transcribe_diarize.md
+++ b/docs/cookbook/moss_transcribe_diarize.md
@@ -77,6 +77,12 @@ The optimization stack mirrors [what we built for TTS](https://github.com/zhaoch
 
 **CUDA Graph.** The LLM decode step pads batch size to predefined buckets (1, 2, 4, 8, …) and replays a captured CUDA graph, eliminating kernel launch overhead on every token. This is the single biggest optimization for AR Decode. The Whisper encoder gets the same treatment, bucketed over chunk count (`encoder_chunk_buckets`, default `1..8` ≈ 4 min of audio).
 
+**Decoder Torch Compile.** The default pipeline compiles Qwen3 decoder shapes
+through batch size 8 and uses the eager decoder above that cap. Override the cap
+with `--talker-torch-compile-max-bs`, or disable decoder compilation with
+`--talker-torch-compile off`. This setting is independent of the encoder
+compile option below.
+
 **Encoder Torch Compile (opt-in).** `encoder_torch_compile=True` swaps the encoder CUDA graph for `torch.compile` (default mode) with kernel fusion. The two are mutually exclusive. Reduce-overhead mode must not be used: its cudagraph trees corrupt memory alongside the decode CUDA graphs that always run in this process (illegal memory access after ~60s of serving). The cost is a one-time per-bucket compile at startup; `dynamic=False` means only the warmed chunk counts are accelerated, anything else runs eager.
 
 **Async Decode.** Same one-step lookahead as TTS: launch the current decode step's GPU work, then resolve the previous step's host-side work (D2H copy, finish detection, result dispatch) in parallel. MOSS-TD enables lookahead starting at batch size 1 by default. Set `--async-lookahead-min-batch-size 2` to keep batch-size-1 decode synchronous, or use `--decode-mode sync` to disable lookahead for the stage. Two alternating pinned host buffers prevent read/write races between the GPU's async D2H write and the CPU's read. For the full mechanism and code pointers, see [Asynchronous Decode + Lookahead](https://github.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/blob/main/sglang/sglang-omni/tts-optimization.md#asynchronous-decode--lookahead) in the TTS optimization guide.

--- a/docs/cookbook/moss_transcribe_diarize.md
+++ b/docs/cookbook/moss_transcribe_diarize.md
@@ -75,10 +75,10 @@ At c=1 with longer audio, AR Decode takes 94%+ of total time — the leverage is
 
 The optimization stack mirrors [what we built for TTS](https://github.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/blob/main/sglang/sglang-omni/tts-optimization.md), sharing the same core infrastructure with ASR-specific adaptations.
 
-**CUDA Graph.** The LLM decode step pads batch size to predefined buckets (1, 2, 4, 8, …) and replays a captured CUDA graph, eliminating kernel launch overhead on every token. This is the single biggest optimization for AR Decode. The Whisper encoder gets the same treatment, bucketed over chunk count (`encoder_chunk_buckets`, default `1..8` ≈ 4 min of audio).
+**CUDA Graph.** The LLM decode step pads batch size to predefined buckets (1, 2, 4, 8, …) and replays a captured CUDA graph, eliminating kernel launch overhead on every token. This is the single biggest optimization for AR Decode. Breakable prefill graphs use token-count buckets beginning at 1 and 2 so cached-prefix extends do not fall back to eager. The Whisper encoder gets the same treatment, bucketed over chunk count (`encoder_chunk_buckets`, default `1..8` ≈ 4 min of audio).
 
 **Decoder Torch Compile.** The default pipeline compiles Qwen3 decoder shapes
-through batch size 4 and uses the eager decoder above that cap. Override the cap
+through batch size 8 and uses the eager decoder above that cap. Override the cap
 with `--talker-torch-compile-max-bs`, or disable decoder compilation with
 `--talker-torch-compile off`. This setting is independent of the encoder
 compile option below.

--- a/docs/cookbook/moss_transcribe_diarize.md
+++ b/docs/cookbook/moss_transcribe_diarize.md
@@ -78,7 +78,7 @@ The optimization stack mirrors [what we built for TTS](https://github.com/zhaoch
 **CUDA Graph.** The LLM decode step pads batch size to predefined buckets (1, 2, 4, 8, …) and replays a captured CUDA graph, eliminating kernel launch overhead on every token. This is the single biggest optimization for AR Decode. The Whisper encoder gets the same treatment, bucketed over chunk count (`encoder_chunk_buckets`, default `1..8` ≈ 4 min of audio).
 
 **Decoder Torch Compile.** The default pipeline compiles Qwen3 decoder shapes
-through batch size 8 and uses the eager decoder above that cap. Override the cap
+through batch size 4 and uses the eager decoder above that cap. Override the cap
 with `--talker-torch-compile-max-bs`, or disable decoder compilation with
 `--talker-torch-compile off`. This setting is independent of the encoder
 compile option below.

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -969,6 +969,8 @@ def apply_torch_compile_cli_overrides(
     talker_torch_compile: str,
     thinker_torch_compile_max_bs: int | None,
     talker_torch_compile_max_bs: int | None,
+    torch_compile: str = "default",
+    torch_compile_max_bs: int | None = None,
 ) -> PipelineConfig:
     thinker_mode = _normalize_stage_toggle_mode(
         "thinker_torch_compile", thinker_torch_compile
@@ -976,6 +978,7 @@ def apply_torch_compile_cli_overrides(
     talker_mode = _normalize_stage_toggle_mode(
         "talker_torch_compile", talker_torch_compile
     )
+    generation_mode = _normalize_stage_toggle_mode("torch_compile", torch_compile)
     _apply_stage_torch_compile_override(
         pipeline_config,
         stage_name="thinker",
@@ -996,6 +999,27 @@ def apply_torch_compile_cli_overrides(
             ),
             mode=talker_mode,
             max_bs=talker_torch_compile_max_bs,
+        )
+    # note (Jeffro): single-stage pipelines (ASR, single-stage TTS) expose no
+    # talker role, so the role-qualified flags cannot reach their SGLang stage.
+    # Route the neutral flags through the generation role the same way
+    # --max-running-requests does.
+    if generation_mode != "default" or torch_compile_max_bs is not None:
+        generation_flag = (
+            "--torch-compile"
+            if generation_mode != "default"
+            else "--torch-compile-max-bs"
+        )
+        generation_stage = (
+            type(pipeline_config).generation_sglang_role_to_stage().get("generation")
+        )
+        if generation_stage is None:
+            _raise_unsupported_flag(pipeline_config, generation_flag)
+        _apply_stage_torch_compile_override(
+            pipeline_config,
+            stage_name=generation_stage,
+            mode=generation_mode,
+            max_bs=torch_compile_max_bs,
         )
     return pipeline_config
 
@@ -1270,6 +1294,27 @@ def serve(
             help="Override torch_compile_max_bs for supported SGLang talker stage.",
         ),
     ] = None,
+    torch_compile: Annotated[
+        str,
+        typer.Option(
+            "--torch-compile",
+            "--torch_compile",
+            help=(
+                "torch.compile mode for the SGLang generation stage: "
+                "default|on|off. Use this for single-stage pipelines (ASR, "
+                "single-stage TTS) that expose no talker role."
+            ),
+        ),
+    ] = "default",
+    torch_compile_max_bs: Annotated[
+        int | None,
+        typer.Option(
+            "--torch-compile-max-bs",
+            "--torch_compile_max_bs",
+            min=1,
+            help="Override torch_compile_max_bs for the SGLang generation stage.",
+        ),
+    ] = None,
     enable_realtime: Annotated[
         bool,
         typer.Option(
@@ -1455,6 +1500,8 @@ def serve(
         talker_torch_compile=talker_torch_compile,
         thinker_torch_compile_max_bs=thinker_torch_compile_max_bs,
         talker_torch_compile_max_bs=talker_torch_compile_max_bs,
+        torch_compile=torch_compile,
+        torch_compile_max_bs=torch_compile_max_bs,
     )
     merged_config = apply_decode_mode_cli_overrides(
         merged_config,

--- a/sglang_omni/models/moss_transcribe_diarize/config.py
+++ b/sglang_omni/models/moss_transcribe_diarize/config.py
@@ -44,6 +44,8 @@ class MossTranscribeDiarizePipelineConfig(PipelineConfig):
                 "max_running_requests": 16,
                 "encoder_cache_size_bytes": 4 * 1024**3,
                 "encoder_max_batch_size": _ENCODER_MAX_BATCH_SIZE,
+                "enable_torch_compile": True,
+                "torch_compile_max_bs": 8,
                 "request_build_max_workers": _REQUEST_BUILD_MAX_WORKERS,
                 "request_build_max_pending": 16,
                 "prefill_coalesce_requests": 4,

--- a/sglang_omni/models/moss_transcribe_diarize/config.py
+++ b/sglang_omni/models/moss_transcribe_diarize/config.py
@@ -45,7 +45,7 @@ class MossTranscribeDiarizePipelineConfig(PipelineConfig):
                 "encoder_cache_size_bytes": 4 * 1024**3,
                 "encoder_max_batch_size": _ENCODER_MAX_BATCH_SIZE,
                 "enable_torch_compile": True,
-                "torch_compile_max_bs": 4,
+                "torch_compile_max_bs": 8,
                 "request_build_max_workers": _REQUEST_BUILD_MAX_WORKERS,
                 "request_build_max_pending": 16,
                 "prefill_coalesce_requests": 4,

--- a/sglang_omni/models/moss_transcribe_diarize/config.py
+++ b/sglang_omni/models/moss_transcribe_diarize/config.py
@@ -45,7 +45,7 @@ class MossTranscribeDiarizePipelineConfig(PipelineConfig):
                 "encoder_cache_size_bytes": 4 * 1024**3,
                 "encoder_max_batch_size": _ENCODER_MAX_BATCH_SIZE,
                 "enable_torch_compile": True,
-                "torch_compile_max_bs": 8,
+                "torch_compile_max_bs": 4,
                 "request_build_max_workers": _REQUEST_BUILD_MAX_WORKERS,
                 "request_build_max_pending": 16,
                 "prefill_coalesce_requests": 4,

--- a/sglang_omni/models/moss_transcribe_diarize/engine_builder.py
+++ b/sglang_omni/models/moss_transcribe_diarize/engine_builder.py
@@ -35,6 +35,7 @@ class MossTranscribeDiarizeEngineBuilder(AsrEngineBuilder):
         mm_embedding_cache_size_bytes: int,
         encoder_cache_size_bytes: int,
         enable_torch_compile: bool,
+        torch_compile_max_bs: int,
         enable_async_decode: bool,
         async_decode_min_batch_size: int,
         prefill_coalesce_requests: int,
@@ -56,6 +57,7 @@ class MossTranscribeDiarizeEngineBuilder(AsrEngineBuilder):
         self.mm_embedding_cache_size_bytes = mm_embedding_cache_size_bytes
         self.encoder_cache_size_bytes = encoder_cache_size_bytes
         self.enable_torch_compile = enable_torch_compile
+        self.torch_compile_max_bs = torch_compile_max_bs
         self.enable_async_decode = enable_async_decode
         self.async_decode_min_batch_size = async_decode_min_batch_size
         self.prefill_coalesce_requests = prefill_coalesce_requests
@@ -106,6 +108,7 @@ class MossTranscribeDiarizeEngineBuilder(AsrEngineBuilder):
             "disable_cuda_graph": False,
             "disable_overlap_schedule": True,
             "enable_torch_compile": self.enable_torch_compile,
+            "torch_compile_max_bs": self.torch_compile_max_bs,
             "mem_fraction_static": self.mem_fraction_static,
             "max_prefill_tokens": 4096,
             "chunked_prefill_size": 4096,

--- a/sglang_omni/models/moss_transcribe_diarize/engine_builder.py
+++ b/sglang_omni/models/moss_transcribe_diarize/engine_builder.py
@@ -103,6 +103,14 @@ class MossTranscribeDiarizeEngineBuilder(AsrEngineBuilder):
         )
 
     def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
+        # note (Xinyu): cached-prefix extends commonly contain one or two new
+        # tokens, so keep exact graph buckets below the shared ladder's 4-token
+        # floor instead of failing the prefill padding-factor replay guard.
+        prefill_cuda_graph_bs = [
+            1,
+            2,
+            *build_default_prefill_cuda_graph_bs(4096),
+        ]
         return {
             "max_running_requests": self.max_running_requests,
             "disable_cuda_graph": False,
@@ -114,7 +122,7 @@ class MossTranscribeDiarizeEngineBuilder(AsrEngineBuilder):
             "chunked_prefill_size": 4096,
             "sampling_backend": "pytorch",
             "cuda_graph_backend_prefill": CudaGraphBackend.BREAKABLE,
-            "cuda_graph_bs_prefill": build_default_prefill_cuda_graph_bs(4096),
+            "cuda_graph_bs_prefill": prefill_cuda_graph_bs,
             "dtype": dtype,
         }
 

--- a/sglang_omni/models/moss_transcribe_diarize/stages.py
+++ b/sglang_omni/models/moss_transcribe_diarize/stages.py
@@ -80,7 +80,7 @@ def create_sglang_moss_transcribe_diarize_executor(
     mm_embedding_cache_size_bytes: int = 0,
     encoder_cache_size_bytes: int = 0,
     enable_torch_compile: bool = False,
-    torch_compile_max_bs: int = 8,
+    torch_compile_max_bs: int = 4,
     # note (yichi): MOSS-TD overlaps host collect starting at batch size 1;
     # --decode-mode sync remains the operator opt-out.
     enable_async_decode: bool = True,

--- a/sglang_omni/models/moss_transcribe_diarize/stages.py
+++ b/sglang_omni/models/moss_transcribe_diarize/stages.py
@@ -80,6 +80,7 @@ def create_sglang_moss_transcribe_diarize_executor(
     mm_embedding_cache_size_bytes: int = 0,
     encoder_cache_size_bytes: int = 0,
     enable_torch_compile: bool = False,
+    torch_compile_max_bs: int = 8,
     # note (yichi): MOSS-TD overlaps host collect starting at batch size 1;
     # --decode-mode sync remains the operator opt-out.
     enable_async_decode: bool = True,
@@ -116,6 +117,7 @@ def create_sglang_moss_transcribe_diarize_executor(
         mm_embedding_cache_size_bytes=mm_embedding_cache_size_bytes,
         encoder_cache_size_bytes=encoder_cache_size_bytes,
         enable_torch_compile=enable_torch_compile,
+        torch_compile_max_bs=torch_compile_max_bs,
         enable_async_decode=enable_async_decode,
         async_decode_min_batch_size=async_decode_min_batch_size,
         encoder_chunk_buckets=buckets,

--- a/sglang_omni/models/moss_transcribe_diarize/stages.py
+++ b/sglang_omni/models/moss_transcribe_diarize/stages.py
@@ -80,7 +80,7 @@ def create_sglang_moss_transcribe_diarize_executor(
     mm_embedding_cache_size_bytes: int = 0,
     encoder_cache_size_bytes: int = 0,
     enable_torch_compile: bool = False,
-    torch_compile_max_bs: int = 4,
+    torch_compile_max_bs: int = 8,
     # note (yichi): MOSS-TD overlaps host collect starting at batch size 1;
     # --decode-mode sync remains the operator opt-out.
     enable_async_decode: bool = True,

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -23,6 +23,7 @@ from sglang_omni.models.moss_transcribe_diarize.stages import (
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from sglang_omni.scheduling.generation_batch_policy import (
     build_default_prefill_cuda_graph_bs,
+    build_generation_batch_overrides,
 )
 
 
@@ -115,6 +116,27 @@ def test_moss_transcribe_diarize_prefill_backend_policy() -> None:
         == defaults["chunked_prefill_size"]
         == 4096
     )
+
+
+def test_moss_transcribe_diarize_compile_cap_survives_batch_overrides() -> None:
+    """torch_compile_max_bs must bind to the named builder parameter. If it
+    ever lands in **stage_defaults instead, the merge silently replaces the
+    stage cap with max_running_requests."""
+    builder = _make_moss_engine_builder()
+
+    overrides = build_generation_batch_overrides(
+        server_args_overrides=None,
+        **builder.generation_defaults(dtype="bfloat16"),
+    )
+
+    assert overrides["torch_compile_max_bs"] == 4
+    assert overrides["max_running_requests"] == 16
+
+    operator = build_generation_batch_overrides(
+        server_args_overrides={"torch_compile_max_bs": 8},
+        **builder.generation_defaults(dtype="bfloat16"),
+    )
+    assert operator["torch_compile_max_bs"] == 8
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -35,7 +35,7 @@ def _make_moss_engine_builder() -> MossTranscribeDiarizeEngineBuilder:
         mm_embedding_cache_size_bytes=0,
         encoder_cache_size_bytes=0,
         enable_torch_compile=False,
-        torch_compile_max_bs=8,
+        torch_compile_max_bs=4,
         enable_async_decode=True,
         async_decode_min_batch_size=2,
         prefill_coalesce_requests=0,
@@ -67,7 +67,7 @@ def test_moss_transcribe_diarize_config_uses_single_batched_stage() -> None:
     assert config.stages[0].factory_args["device"] == "cuda:0"
     assert config.stages[0].factory_args["max_running_requests"] == 16
     assert config.stages[0].factory_args["enable_torch_compile"] is True
-    assert config.stages[0].factory_args["torch_compile_max_bs"] == 8
+    assert config.stages[0].factory_args["torch_compile_max_bs"] == 4
     assert config.stages[0].factory_args["encoder_max_batch_size"] == 2
     assert config.stages[0].factory_args["request_build_max_workers"] == 8
     assert config.stages[0].factory_args["request_build_max_pending"] == 16
@@ -102,7 +102,7 @@ def test_moss_transcribe_diarize_prefill_backend_policy() -> None:
     assert type(builder).supports_breakable_prefill_cuda_graph is True
     defaults = builder.generation_defaults(dtype="bfloat16")
     assert defaults["enable_torch_compile"] is False
-    assert defaults["torch_compile_max_bs"] == 8
+    assert defaults["torch_compile_max_bs"] == 4
     assert defaults["cuda_graph_backend_prefill"] == "breakable"
     assert defaults["cuda_graph_bs_prefill"] == [
         1,
@@ -180,7 +180,7 @@ def test_moss_transcribe_diarize_stage_reserves_encoder_headroom() -> None:
     assert signature.parameters["max_running_requests"].default == 16
     assert signature.parameters["mem_fraction_static"].default == 0.80
     assert signature.parameters["enable_torch_compile"].default is False
-    assert signature.parameters["torch_compile_max_bs"].default == 8
+    assert signature.parameters["torch_compile_max_bs"].default == 4
     assert signature.parameters["request_build_max_workers"].default == 8
     assert signature.parameters["request_build_max_pending"].default == 16
     assert signature.parameters["enable_async_decode"].default is True

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -35,7 +35,7 @@ def _make_moss_engine_builder() -> MossTranscribeDiarizeEngineBuilder:
         mm_embedding_cache_size_bytes=0,
         encoder_cache_size_bytes=0,
         enable_torch_compile=False,
-        torch_compile_max_bs=4,
+        torch_compile_max_bs=8,
         enable_async_decode=True,
         async_decode_min_batch_size=2,
         prefill_coalesce_requests=0,
@@ -67,7 +67,7 @@ def test_moss_transcribe_diarize_config_uses_single_batched_stage() -> None:
     assert config.stages[0].factory_args["device"] == "cuda:0"
     assert config.stages[0].factory_args["max_running_requests"] == 16
     assert config.stages[0].factory_args["enable_torch_compile"] is True
-    assert config.stages[0].factory_args["torch_compile_max_bs"] == 4
+    assert config.stages[0].factory_args["torch_compile_max_bs"] == 8
     assert config.stages[0].factory_args["encoder_max_batch_size"] == 2
     assert config.stages[0].factory_args["request_build_max_workers"] == 8
     assert config.stages[0].factory_args["request_build_max_pending"] == 16
@@ -102,11 +102,13 @@ def test_moss_transcribe_diarize_prefill_backend_policy() -> None:
     assert type(builder).supports_breakable_prefill_cuda_graph is True
     defaults = builder.generation_defaults(dtype="bfloat16")
     assert defaults["enable_torch_compile"] is False
-    assert defaults["torch_compile_max_bs"] == 4
+    assert defaults["torch_compile_max_bs"] == 8
     assert defaults["cuda_graph_backend_prefill"] == "breakable"
-    assert defaults["cuda_graph_bs_prefill"] == (
-        build_default_prefill_cuda_graph_bs(4096)
-    )
+    assert defaults["cuda_graph_bs_prefill"] == [
+        1,
+        2,
+        *build_default_prefill_cuda_graph_bs(4096),
+    ]
     assert (
         max(defaults["cuda_graph_bs_prefill"])
         == defaults["max_prefill_tokens"]
@@ -178,7 +180,7 @@ def test_moss_transcribe_diarize_stage_reserves_encoder_headroom() -> None:
     assert signature.parameters["max_running_requests"].default == 16
     assert signature.parameters["mem_fraction_static"].default == 0.80
     assert signature.parameters["enable_torch_compile"].default is False
-    assert signature.parameters["torch_compile_max_bs"].default == 4
+    assert signature.parameters["torch_compile_max_bs"].default == 8
     assert signature.parameters["request_build_max_workers"].default == 8
     assert signature.parameters["request_build_max_pending"].default == 16
     assert signature.parameters["enable_async_decode"].default is True

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -35,6 +35,7 @@ def _make_moss_engine_builder() -> MossTranscribeDiarizeEngineBuilder:
         mm_embedding_cache_size_bytes=0,
         encoder_cache_size_bytes=0,
         enable_torch_compile=False,
+        torch_compile_max_bs=8,
         enable_async_decode=True,
         async_decode_min_batch_size=2,
         prefill_coalesce_requests=0,
@@ -65,6 +66,8 @@ def test_moss_transcribe_diarize_config_uses_single_batched_stage() -> None:
     )
     assert config.stages[0].factory_args["device"] == "cuda:0"
     assert config.stages[0].factory_args["max_running_requests"] == 16
+    assert config.stages[0].factory_args["enable_torch_compile"] is True
+    assert config.stages[0].factory_args["torch_compile_max_bs"] == 8
     assert config.stages[0].factory_args["encoder_max_batch_size"] == 2
     assert config.stages[0].factory_args["request_build_max_workers"] == 8
     assert config.stages[0].factory_args["request_build_max_pending"] == 16
@@ -98,6 +101,8 @@ def test_moss_transcribe_diarize_prefill_backend_policy() -> None:
 
     assert type(builder).supports_breakable_prefill_cuda_graph is True
     defaults = builder.generation_defaults(dtype="bfloat16")
+    assert defaults["enable_torch_compile"] is False
+    assert defaults["torch_compile_max_bs"] == 8
     assert defaults["cuda_graph_backend_prefill"] == "breakable"
     assert defaults["cuda_graph_bs_prefill"] == (
         build_default_prefill_cuda_graph_bs(4096)
@@ -172,6 +177,8 @@ def test_moss_transcribe_diarize_stage_reserves_encoder_headroom() -> None:
 
     assert signature.parameters["max_running_requests"].default == 16
     assert signature.parameters["mem_fraction_static"].default == 0.80
+    assert signature.parameters["enable_torch_compile"].default is False
+    assert signature.parameters["torch_compile_max_bs"].default == 8
     assert signature.parameters["request_build_max_workers"].default == 8
     assert signature.parameters["request_build_max_pending"].default == 16
     assert signature.parameters["enable_async_decode"].default is True

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -35,7 +35,7 @@ def _make_moss_engine_builder() -> MossTranscribeDiarizeEngineBuilder:
         mm_embedding_cache_size_bytes=0,
         encoder_cache_size_bytes=0,
         enable_torch_compile=False,
-        torch_compile_max_bs=8,
+        torch_compile_max_bs=4,
         enable_async_decode=True,
         async_decode_min_batch_size=2,
         prefill_coalesce_requests=0,
@@ -67,7 +67,7 @@ def test_moss_transcribe_diarize_config_uses_single_batched_stage() -> None:
     assert config.stages[0].factory_args["device"] == "cuda:0"
     assert config.stages[0].factory_args["max_running_requests"] == 16
     assert config.stages[0].factory_args["enable_torch_compile"] is True
-    assert config.stages[0].factory_args["torch_compile_max_bs"] == 8
+    assert config.stages[0].factory_args["torch_compile_max_bs"] == 4
     assert config.stages[0].factory_args["encoder_max_batch_size"] == 2
     assert config.stages[0].factory_args["request_build_max_workers"] == 8
     assert config.stages[0].factory_args["request_build_max_pending"] == 16
@@ -102,7 +102,7 @@ def test_moss_transcribe_diarize_prefill_backend_policy() -> None:
     assert type(builder).supports_breakable_prefill_cuda_graph is True
     defaults = builder.generation_defaults(dtype="bfloat16")
     assert defaults["enable_torch_compile"] is False
-    assert defaults["torch_compile_max_bs"] == 8
+    assert defaults["torch_compile_max_bs"] == 4
     assert defaults["cuda_graph_backend_prefill"] == "breakable"
     assert defaults["cuda_graph_bs_prefill"] == (
         build_default_prefill_cuda_graph_bs(4096)
@@ -178,7 +178,7 @@ def test_moss_transcribe_diarize_stage_reserves_encoder_headroom() -> None:
     assert signature.parameters["max_running_requests"].default == 16
     assert signature.parameters["mem_fraction_static"].default == 0.80
     assert signature.parameters["enable_torch_compile"].default is False
-    assert signature.parameters["torch_compile_max_bs"].default == 8
+    assert signature.parameters["torch_compile_max_bs"].default == 4
     assert signature.parameters["request_build_max_workers"].default == 8
     assert signature.parameters["request_build_max_pending"].default == 16
     assert signature.parameters["enable_async_decode"].default is True

--- a/tests/unit_test/serve/test_generation_server_args.py
+++ b/tests/unit_test/serve/test_generation_server_args.py
@@ -18,6 +18,9 @@ from sglang_omni.config import PipelineConfig, StageConfig
 from sglang_omni.models.fishaudio_s2_pro.config import S2ProPipelineConfig
 from sglang_omni.models.fun_asr.config import FunASRPipelineConfig
 from sglang_omni.models.higgs_tts.config import HiggsTtsPipelineConfig
+from sglang_omni.models.moss_transcribe_diarize.config import (
+    MossTranscribeDiarizePipelineConfig,
+)
 from sglang_omni.models.moss_tts.config import MossTTSPipelineConfig
 from sglang_omni.models.moss_tts_local.config import MossTTSLocalPipelineConfig
 from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
@@ -258,6 +261,68 @@ def test_talker_torch_compile_max_bs_rejects_unsupported_pipeline(
         match=(r"--talker-torch-compile-max-bs is not supported by " r"PipelineConfig"),
     ):
         serve(**_serve_kwargs(talker_torch_compile_max_bs=64))
+
+    launch_server.assert_not_called()
+
+
+@patch("sglang_omni.cli.serve.launch_server")
+@patch("sglang_omni.cli.serve.ConfigManager.from_model_path")
+def test_torch_compile_flags_reach_single_stage_generation(
+    from_model_path,
+    launch_server,
+) -> None:
+    """MOSS-TD exposes no talker role, so the neutral flags are its only CLI
+    control over the default-on decoder compile."""
+    config = MossTranscribeDiarizePipelineConfig(model_path="dummy")
+    from_model_path.return_value = _DummyManager(config)
+
+    serve(**_serve_kwargs(torch_compile="off", torch_compile_max_bs=8))
+
+    launched_config = launch_server.call_args.args[0]
+    overrides = _stage_args(launched_config, "asr")["server_args_overrides"]
+    assert overrides["enable_torch_compile"] is False
+    assert overrides["torch_compile_max_bs"] == 8
+
+
+@patch("sglang_omni.cli.serve.launch_server")
+@patch("sglang_omni.cli.serve.ConfigManager.from_model_path")
+def test_torch_compile_default_leaves_generation_stage_untouched(
+    from_model_path,
+    launch_server,
+) -> None:
+    config = MossTranscribeDiarizePipelineConfig(model_path="dummy")
+    from_model_path.return_value = _DummyManager(config)
+
+    serve(**_serve_kwargs())
+
+    launched_config = launch_server.call_args.args[0]
+    assert "server_args_overrides" not in _stage_args(launched_config, "asr")
+
+
+@patch("sglang_omni.cli.serve.launch_server")
+@patch("sglang_omni.cli.serve.ConfigManager.from_model_path")
+def test_torch_compile_rejects_unsupported_pipeline(
+    from_model_path,
+    launch_server,
+) -> None:
+    config = PipelineConfig(
+        model_path="dummy",
+        stages=[
+            StageConfig(
+                name="stage",
+                process="pipeline",
+                factory="tests.unit_test.fixtures.pipeline_fakes.dummy_factory",
+                terminal=True,
+            )
+        ],
+    )
+    from_model_path.return_value = _DummyManager(config)
+
+    with pytest.raises(
+        typer.BadParameter,
+        match=r"--torch-compile is not supported by PipelineConfig",
+    ):
+        serve(**_serve_kwargs(torch_compile="off"))
 
     launch_server.assert_not_called()
 


### PR DESCRIPTION

## Motivation

MOSS-Transcribe-Diarize is dominated by autoregressive decoder work at low
concurrency. Cached-prefix extends also commonly contain only one or two new
tokens, while the shared prefill CUDA graph ladder starts at four tokens, so
those small prefills fall back to eager execution.

This change enables decoder `torch.compile` for the low-batch regime and adds
exact prefill CUDA graph buckets for the one- and two-token cases.

## Modifications

1. `sglang_omni/models/moss_transcribe_diarize/config.py` and `stages.py`
   - Enable decoder `torch.compile` in the default MOSS-TD pipeline.
   - Set and propagate `torch_compile_max_bs=4`, retaining eager decoder
     execution above the low-concurrency compile cap.
2. `sglang_omni/models/moss_transcribe_diarize/engine_builder.py`
   - Forward the model-specific compile batch-size cap to the generation
     engine.
   - Prepend exact token-count buckets `[1, 2]` to the breakable prefill CUDA
     graph ladder so tiny cached-prefix extends can replay a graph.
3. `tests/unit_test/moss_transcribe_diarize/test_pipeline.py`
   - Cover the default compile policy, batch-size cap propagation, and extended
     prefill graph ladder.
4. `docs/cookbook/moss_transcribe_diarize.md`
   - Document the decoder compile default, override/disable controls, and tiny
     prefill graph buckets.

## Related Issues
#1396 

## Accuracy Test

**Setup:**

- Model: `OpenMOSS-Team/MOSS-Transcribe-Diarize` at
  `e8681d68e7042738ffca8ac8212bc8fcb1131ab8`, BF16, FA3.
- Dataset: SeedTTS-EN, all 1,088 samples, revision
  `27f4c1adee83b5b29b7c4b375f6b976324bda308`.
- Hardware: NVIDIA H200, physical GPU 4; context length 131,072;
  `max_running_requests=16`; one warmup plus three measured repeats at each
  concurrency.
- Baseline: `main` @ `bf289b79`, eager decoder. Candidate:
  `perf/moss-td-compile-coalescing-20260815` @ `53be4311`, decoder compile
  through BS 4 with prefill buckets `[1,2,4,...,4096]`.
- Candidate is based on latest `upstream/main` @ `7afba0ec`; an architecture
  audit found no intervening changes to the MOSS-TD generation, scheduler,
  CUDA graph, compile, or benchmark paths.

| Concurrency | Main corpus WER | Candidate corpus WER | Delta |
|---:|---:|---:|---:|
| 1 | 0.018538 | 0.018084 | -0.000454 |
| 2 | 0.018538 | 0.018387 | -0.000151 |
| 4 | 0.018538 | 0.018513 | -0.000025 |
| 8 | 0.018261 | 0.018210 | -0.000050 |
| 16 | 0.018336 | 0.018311 | -0.000025 |

## Benchmark & Profiling

Same setup as described in the _Accuracy Test_ section. 

| Concurrency | Main (mean +/- population std) | BS4 + P[1,2] (mean +/- population std) | Delta |
|---:|---:|---:|---:|
| 1 | 14.396 +/- 0.375 | 18.261 +/- 0.164 | +26.85% |
| 2 | 23.673 +/- 0.075 | 27.273 +/- 0.019 | +15.20% |
| 4 | 46.971 +/- 0.089 | 50.585 +/- 0.078 | +7.70% |
| 8 | 95.259 +/- 2.190 | 94.303 +/- 0.149 | -1.00% |
| 16 | 158.444 +/- 1.139 | 154.672 +/- 1.640 | -2.38% |

### Summary:

- The candidate improves c=1/c=2/c=4 throughput by 26.85%/15.20%/7.70%.
- The c=8 candidate statistic uses repeats 1 and 3 (94.453 and 94.154
  samples/s). A post-hoc median/MAD sensitivity check flags repeat 2 (91.206
  samples/s, modified z=-6.67) as a low outlier, so it is excluded.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
