### PR TITLE
[Model] Support SenseNova U1 (NEOChatModel, MoT interleaved understanding+generation)

### DIFF
--- a/docs/cookbook/sensenova_u1.md
+++ b/docs/cookbook/sensenova_u1.md
@@ -1,0 +1,74 @@
+# SenseNova U1
+
+[SenseNova U1](https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Interleaved)
+is a unified model for image understanding, image generation, and interleaved
+text-image generation. The default SGLang-Omni pipeline runs the native
+language/MoT tower, native-resolution vision encoder, flow-matching image head,
+and interleave state machine in one process.
+
+## Launch
+
+```bash
+sgl-omni serve \
+  --model-path sensenova/SenseNova-U1-8B-MoT-Interleaved \
+  --port 8000
+```
+
+The `default` and `interleave` variants return text plus inline PNG images. The
+`flow` variant runs T2I or IT2I only.
+
+## Checkpoint Trust
+
+The native model weights are loaded by SGLang, but the tokenizer is created
+with `AutoTokenizer.from_pretrained(..., trust_remote_code=True)`. Only serve a
+checkpoint repository that you trust and have configured intentionally. For a
+production deployment, pin the checkpoint revision or use a reviewed local
+snapshot rather than an unpinned repository.
+
+## Request Limits
+
+SenseNova U1 validates generation controls before allocating request GPU
+tensors. Invalid values return a request error.
+
+| Control | Deployment limit |
+|---|---:|
+| `width`, `height` | Positive, divisible by 32, each at most 2048 |
+| Image pixels | At most 1,048,576 |
+| `num_steps` | 1 to 64 |
+| Input images | At most 4 |
+| `max_images` | 1 to 4 |
+| `max_new_tokens` | 1 to 2048 |
+| Total prefix, text, and generated-image tokens | At most 4096 |
+| Native flow `batch_size` | 1 |
+
+The exact token budget is checked again after CPU tokenization and image
+preprocessing, before vision embeddings or flow noise are allocated on the
+GPU.
+
+## Runtime Cache Bounds
+
+The exact eager text path keeps a small LRU for repeated prefixes and decode
+CUDA graphs. Production defaults are:
+
+| Setting | Default |
+|---|---:|
+| `eager_prefix_cache_max_entries` | 4 |
+| `eager_decode_graph_cache_max_entries` | 2 |
+| `eager_decode_graph_max_captures` | 4 |
+| `eager_prefix_cache_max_tokens` | 2048 |
+| `eager_decode_graph_max_total_tokens` | 1024 |
+
+Entries are evicted least-recently-used, GPU tensor and graph references are
+released on eviction, and all entries are cleared when the stage stops. CUDA
+graph capture also has a lifetime budget because CUDA graph-private allocator
+pools are not reliably reclaimed while the process remains alive. After four
+new graph shapes have been captured, an uncached shape uses the exact eager
+path; already-cached hot shapes continue to replay. Requests above the
+per-entry token limits also run through the exact eager path.
+
+## Current Scope
+
+- The validated production path is single-node and single-GPU.
+- The custom U1 hybrid attention mask is implemented for the Triton backend.
+- Flow steps execute in-process; cooperative scheduling between a flow step
+  and unrelated autoregressive requests remains future work.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,6 +76,9 @@ Supported Models
    * - `inclusionAI/LLaDA2.0-Uni <https://huggingface.co/inclusionAI/LLaDA2.0-Uni>`_
      - Multimodal
      - Text + image understanding and generation
+   * - `sensenova/SenseNova-U1-8B-MoT-Interleaved <https://huggingface.co/sensenova/SenseNova-U1-8B-MoT-Interleaved>`_
+     - Multimodal
+     - Native image understanding and interleaved text-image generation
 
 
 .. toctree::
@@ -107,6 +110,7 @@ Supported Models
    cookbook/qwen3_omni.md
    cookbook/ming_omni.md
    cookbook/llada2_uni.md
+   cookbook/sensenova_u1.md
 
 .. toctree::
    :maxdepth: 1

--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -198,6 +198,7 @@ class Client:
                     finish_reason=chunk.finish_reason,
                     usage=chunk.usage,
                     stage_name=chunk.stage_name,
+                    omni_rollout=chunk.omni_rollout,
                 )
 
     # ------------------------------------------------------------------

--- a/sglang_omni/client/types.py
+++ b/sglang_omni/client/types.py
@@ -218,6 +218,7 @@ class CompletionStreamChunk:
     finish_reason: str | None = None
     usage: UsageInfo | None = None
     stage_name: str | None = None
+    omni_rollout: dict[str, Any] | None = None
 
 
 @dataclass

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -42,6 +42,7 @@ _ARCH_CONFIG_MAP: dict[str, tuple[str, str | None]] = {
     "MossTTSDelaySGLangModel": ("language_config", None),
     "MossTTSLocalSGLangModel": ("language_config", None),
     "MossTranscribeDiarizeForConditionalGeneration": ("text_config", None),
+    "SenseNovaU1NativeForCausalLM": ("llm_config", None),
 }
 
 
@@ -139,6 +140,12 @@ class ModelWorker:
         model_config.num_key_value_heads = text_cfg.num_key_value_heads
         model_config.hidden_size = text_cfg.hidden_size
         model_config.num_hidden_layers = text_cfg.num_hidden_layers
+        if arch == "SenseNovaU1NativeForCausalLM":
+            model_config.model_is_mrope = True
+            model_config.is_multimodal = True
+            model_config.head_dim = int(text_cfg.head_dim)
+            model_config.v_head_dim = model_config.head_dim
+            model_config.vocab_size = int(text_cfg.vocab_size)
         if arch == "MingTTSSGLangModel":
             model_config.head_dim = int(text_cfg.head_dim)
             model_config.v_head_dim = model_config.head_dim

--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -444,6 +444,7 @@ class SGLModelRunner(ModelRunner):
             "FunAsrNanoForConditionalGeneration": "sglang_omni.models.fun_asr.sglang_model:FunAsrNanoForConditionalGeneration",
             "ArkasrForConditionalGeneration": "sglang_omni.models.arkasr.sglang_model:ArkasrForConditionalGeneration",
             "DotsTTSForConditionalGeneration": "sglang_omni.models.dots_tts.sglang_model:DotsTTSSGLangModel",
+            "SenseNovaU1NativeForCausalLM": "sglang_omni.models.sensenova_u1.sglang_model:SenseNovaU1NativeForCausalLM",
         }
         for arch, path in sglang_omni_models.items():
             module_path, _, attr = path.partition(":")

--- a/sglang_omni/models/sensenova_u1/__init__.py
+++ b/sglang_omni/models/sensenova_u1/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SenseNova U1 integration for SGLang-Omni.
+
+Keep package import lightweight because the pipeline registry imports every
+model package during discovery.
+"""
+
+__all__: list[str] = []

--- a/sglang_omni/models/sensenova_u1/attention_backend.py
+++ b/sglang_omni/models/sensenova_u1/attention_backend.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SenseNova U1 adapters for the upstream SGLang Triton attention backend."""
+
+from __future__ import annotations
+
+import inspect
+import types
+from typing import Any
+
+import torch
+
+
+CUSTOM_MASK_DENSE_ATTENTION_CALLS = 0
+
+
+def _custom_mask_dense_attention_fwd(
+    q_extend: torch.Tensor,
+    k_extend: torch.Tensor,
+    v_extend: torch.Tensor,
+    o_extend: torch.Tensor,
+    qo_indptr: torch.Tensor,
+    custom_mask: torch.Tensor,
+    mask_indptr: torch.Tensor,
+    k_scale: float,
+    v_scale: float,
+    sm_scale: float | None,
+) -> None:
+    """Exact short custom-mask path for requests without cached prefix KV."""
+
+    global CUSTOM_MASK_DENSE_ATTENTION_CALLS
+    CUSTOM_MASK_DENSE_ATTENTION_CALLS += 1
+
+    scale = sm_scale or 1.0 / (q_extend.shape[-1] ** 0.5)
+    batch_size = int(qo_indptr.shape[0]) - 1
+    kv_group_num = q_extend.shape[1] // k_extend.shape[1]
+    for seq_idx in range(batch_size):
+        q_start = int(qo_indptr[seq_idx].item())
+        q_end = int(qo_indptr[seq_idx + 1].item())
+        q_len = q_end - q_start
+        if q_len == 0:
+            continue
+        mask_start = int(mask_indptr[seq_idx].item())
+        mask_end = int(mask_indptr[seq_idx + 1].item())
+        expected_mask_len = q_len * q_len
+        if mask_end - mask_start != expected_mask_len:
+            raise RuntimeError(
+                "U1 dense custom-mask attention only supports no-prefix masks: "
+                f"mask_len={mask_end - mask_start}, q_len={q_len}"
+            )
+
+        q = q_extend[q_start:q_end]
+        k = k_extend[q_start:q_end]
+        v = v_extend[q_start:q_end]
+        if kv_group_num != 1:
+            k = k.repeat_interleave(kv_group_num, dim=1)
+            v = v.repeat_interleave(kv_group_num, dim=1)
+
+        allowed = custom_mask[mask_start:mask_end].view(q_len, q_len).bool()
+        scores = torch.einsum("qhd,khd->hqk", q.float(), k.float())
+        scores.mul_(float(scale) * float(k_scale))
+        scores.masked_fill_(
+            ~allowed.to(device=scores.device, dtype=torch.bool).unsqueeze(0),
+            torch.finfo(scores.dtype).min,
+        )
+        probs = torch.softmax(scores, dim=-1).to(v.dtype)
+        out = torch.einsum("hqk,khd->qhd", probs, v)
+        if float(v_scale) != 1.0:
+            out = out * float(v_scale)
+        o_extend[q_start:q_end].copy_(out.to(dtype=o_extend.dtype))
+
+
+def _build_extend_wrapper(original):
+    signature = inspect.signature(original)
+
+    def u1_extend_attention_fwd(*args, **kwargs):
+        bound = signature.bind(*args, **kwargs)
+        bound.apply_defaults()
+        values = bound.arguments
+        custom_mask = values["custom_mask"]
+        if (
+            custom_mask is not None
+            and int(values["max_len_extend"]) <= 512
+            and values["kv_indices"].numel() == 0
+            and not values["skip_prefix"]
+            and not values["skip_extend"]
+            and values["lse_extend"] is None
+            and values["sinks"] is None
+            and values["score_mod"] is None
+            and values["aux_tensors"] is None
+            and int(values["sliding_window_size"]) == -1
+            and float(values["logit_cap"]) == 0.0
+            and int(values["xai_temperature_len"]) <= 0
+            and int(values["page_size"]) == 1
+        ):
+            _custom_mask_dense_attention_fwd(
+                values["q_extend"],
+                values["k_extend"],
+                values["v_extend"],
+                values["o_extend"],
+                values["qo_indptr"],
+                custom_mask,
+                values["mask_indptr"],
+                values["k_scale"],
+                values["v_scale"],
+                values["sm_scale"],
+            )
+            return None
+
+        if custom_mask is not None:
+            # The custom mask already contains the complete U1 causal/image row
+            # policy. Disabling the kernel's separate causal truncation keeps
+            # current-image KV visible across Triton M blocks.
+            values["is_causal"] = False
+        return original(*bound.args, **bound.kwargs)
+
+    return u1_extend_attention_fwd
+
+
+def _inject_custom_mask_metadata(backend: Any, forward_batch: Any) -> None:
+    custom_mask = getattr(forward_batch, "cross_attention_custom_mask", None)
+    if custom_mask is None:
+        return
+    metadata = getattr(backend, "forward_metadata", None)
+    if metadata is None:
+        raise RuntimeError("U1 Triton metadata was not initialized")
+    batch_size = int(forward_batch.batch_size)
+    seq_mask_len = forward_batch.extend_seq_lens * (
+        forward_batch.extend_prefix_lens + forward_batch.extend_seq_lens
+    )
+    mask_indptr = backend.mask_indptr
+    mask_indptr[1 : batch_size + 1] = torch.cumsum(
+        seq_mask_len[:batch_size],
+        dim=0,
+    )
+    metadata.custom_mask = custom_mask
+    metadata.mask_indptr = mask_indptr[: batch_size + 1]
+
+
+def install_sensenova_u1_triton_attention_adapter(model_runner: Any) -> None:
+    """Install U1 custom-mask behavior without modifying the SGLang checkout."""
+
+    from sglang.kernels.ops.attention import extend_attention as extend_module
+    from sglang.srt.layers.attention import triton_backend
+
+    original_attr = "_sensenova_u1_original_extend_attention_fwd"
+    if not hasattr(extend_module, original_attr):
+        original = extend_module.extend_attention_fwd
+        setattr(extend_module, original_attr, original)
+        wrapper = _build_extend_wrapper(original)
+        extend_module.extend_attention_fwd = wrapper
+        triton_backend.extend_attention_fwd = wrapper
+
+    backend = model_runner.attn_backend
+    if type(backend).__name__ != "TritonAttnBackend":
+        return
+    if getattr(backend, "_sensenova_u1_metadata_adapter_installed", False):
+        return
+
+    original_init = backend.init_forward_metadata
+
+    def init_forward_metadata_with_u1(self, forward_batch):
+        result = original_init(forward_batch)
+        _inject_custom_mask_metadata(self, forward_batch)
+        return result
+
+    backend.init_forward_metadata = types.MethodType(
+        init_forward_metadata_with_u1,
+        backend,
+    )
+    backend._sensenova_u1_metadata_adapter_installed = True
+
+
+__all__ = [
+    "CUSTOM_MASK_DENSE_ATTENTION_CALLS",
+    "install_sensenova_u1_triton_attention_adapter",
+]

--- a/sglang_omni/models/sensenova_u1/config.py
+++ b/sglang_omni/models/sensenova_u1/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Pipeline configuration for SenseNova U1 fallback paths."""
+"""Pipeline configuration for native SenseNova U1 serving paths."""
 
 from __future__ import annotations
 
@@ -16,32 +16,25 @@ _PKG = "sglang_omni.models.sensenova_u1"
 
 
 class SenseNovaU1PipelineConfig(PipelineConfig):
-    """Single-stage VQA pipeline for the M1/M2 understanding milestones.
-
-    The stage intentionally uses the official NEOChatModel-compatible HF path.
-    Native SGLang attention for U1 requires the M2 hybrid image-span mask and is
-    not claimed by this pipeline.
-    """
+    """Default native interleaved text-image generation pipeline."""
 
     architecture: ClassVar[str] = "NEOChatModel"
     architecture_aliases: ClassVar[tuple[str, ...]] = ("SenseNovaU1",)
 
     @classmethod
     def mem_fraction_role_to_stage(cls) -> dict[str, str]:
-        return {"understanding": "u1_vqa"}
+        return {"interleave": "u1_interleave"}
 
     model_path: str
-    entry_stage: str = "u1_vqa"
+    entry_stage: str = "u1_interleave"
     stages: list[StageConfig] = [
         StageConfig(
-            name="u1_vqa",
-            process="u1_vqa",
-            factory=f"{_PKG}.stages.create_sensenova_u1_vqa_executor",
+            name="u1_interleave",
+            process="u1_interleave",
+            factory=f"{_PKG}.stages.create_sensenova_u1_interleave_executor",
             factory_args={
                 "device": "cuda:0",
                 "dtype": "bfloat16",
-                "max_new_tokens": 128,
-                "do_sample": False,
                 "attn_backend": "auto",
                 "max_concurrency": 1,
             },
@@ -83,26 +76,59 @@ class SenseNovaU1FlowPipelineConfig(SenseNovaU1PipelineConfig):
 
 
 class SenseNovaU1InterleavePipelineConfig(SenseNovaU1PipelineConfig):
-    """Single-stage interleaved text-image generation pipeline for M4."""
+    """Explicit alias for the default native interleave pipeline."""
+
+
+class SenseNovaU1NativePipelineConfig(SenseNovaU1PipelineConfig):
+    """Native language-tower load/forward diagnostic pipeline for M6."""
 
     @classmethod
     def mem_fraction_role_to_stage(cls) -> dict[str, str]:
-        return {"interleave": "u1_interleave"}
+        return {"native_language": "u1_native"}
 
-    entry_stage: str = "u1_interleave"
+    entry_stage: str = "u1_native"
     stages: list[StageConfig] = [
         StageConfig(
-            name="u1_interleave",
-            process="u1_interleave",
-            factory=f"{_PKG}.stages.create_sensenova_u1_interleave_executor",
+            name="u1_native",
+            process="u1_native",
+            factory=f"{_PKG}.stages.create_sensenova_u1_native_executor",
+            factory_args={
+                "device": "cpu",
+                "dtype": "bfloat16",
+                "load_weights": False,
+            },
+            terminal=True,
+        )
+    ]
+
+
+class SenseNovaU1NativeServingPipelineConfig(SenseNovaU1PipelineConfig):
+    """Native SGLang language/MoT serving path for M6 attention validation."""
+
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"native_serving": "u1_native_serving"}
+
+    entry_stage: str = "u1_native_serving"
+    stages: list[StageConfig] = [
+        StageConfig(
+            name="u1_native_serving",
+            process="u1_native_serving",
+            factory=f"{_PKG}.stages.create_sensenova_u1_native_serving_executor",
             factory_args={
                 "device": "cuda:0",
                 "dtype": "bfloat16",
-                "attn_backend": "auto",
-                "max_concurrency": 1,
+                "attention_backend": "triton",
+                "mem_fraction_static": 0.65,
+                "max_total_tokens": 4096,
+                "max_running_requests": 16,
+                "max_concurrency": 16,
+                "max_batch_wait_ms": 10,
+                "enable_cuda_graph": True,
+                "cuda_graph_bs": [1, 8, 16],
             },
             runtime=StageRuntimeConfig(
-                resources=StageResourceConfig(total_gpu_memory_fraction=0.75)
+                resources=StageResourceConfig(total_gpu_memory_fraction=0.70)
             ),
             gpu=0,
             terminal=True,
@@ -116,4 +142,6 @@ Variants = {
     "default": SenseNovaU1PipelineConfig,
     "flow": SenseNovaU1FlowPipelineConfig,
     "interleave": SenseNovaU1InterleavePipelineConfig,
+    "native": SenseNovaU1NativePipelineConfig,
+    "native_serving": SenseNovaU1NativeServingPipelineConfig,
 }

--- a/sglang_omni/models/sensenova_u1/config.py
+++ b/sglang_omni/models/sensenova_u1/config.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pipeline configuration for SenseNova U1 fallback paths."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from sglang_omni.config import (
+    PipelineConfig,
+    StageConfig,
+    StageResourceConfig,
+    StageRuntimeConfig,
+)
+
+_PKG = "sglang_omni.models.sensenova_u1"
+
+
+class SenseNovaU1PipelineConfig(PipelineConfig):
+    """Single-stage VQA pipeline for the M1/M2 understanding milestones.
+
+    The stage intentionally uses the official NEOChatModel-compatible HF path.
+    Native SGLang attention for U1 requires the M2 hybrid image-span mask and is
+    not claimed by this pipeline.
+    """
+
+    architecture: ClassVar[str] = "NEOChatModel"
+    architecture_aliases: ClassVar[tuple[str, ...]] = ("SenseNovaU1",)
+
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"understanding": "u1_vqa"}
+
+    model_path: str
+    entry_stage: str = "u1_vqa"
+    stages: list[StageConfig] = [
+        StageConfig(
+            name="u1_vqa",
+            process="u1_vqa",
+            factory=f"{_PKG}.stages.create_sensenova_u1_vqa_executor",
+            factory_args={
+                "device": "cuda:0",
+                "dtype": "bfloat16",
+                "max_new_tokens": 128,
+                "do_sample": False,
+                "attn_backend": "auto",
+                "max_concurrency": 1,
+            },
+            runtime=StageRuntimeConfig(
+                resources=StageResourceConfig(total_gpu_memory_fraction=0.75)
+            ),
+            gpu=0,
+            terminal=True,
+        )
+    ]
+
+
+class SenseNovaU1FlowPipelineConfig(SenseNovaU1PipelineConfig):
+    """Single-stage T2I/IT2I flow-matching pipeline for the M3 milestone."""
+
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"generation": "u1_flow"}
+
+    entry_stage: str = "u1_flow"
+    stages: list[StageConfig] = [
+        StageConfig(
+            name="u1_flow",
+            process="u1_flow",
+            factory=f"{_PKG}.stages.create_sensenova_u1_flow_executor",
+            factory_args={
+                "device": "cuda:0",
+                "dtype": "bfloat16",
+                "attn_backend": "auto",
+                "max_concurrency": 1,
+            },
+            runtime=StageRuntimeConfig(
+                resources=StageResourceConfig(total_gpu_memory_fraction=0.75)
+            ),
+            gpu=0,
+            terminal=True,
+        )
+    ]
+
+
+class SenseNovaU1InterleavePipelineConfig(SenseNovaU1PipelineConfig):
+    """Single-stage interleaved text-image generation pipeline for M4."""
+
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"interleave": "u1_interleave"}
+
+    entry_stage: str = "u1_interleave"
+    stages: list[StageConfig] = [
+        StageConfig(
+            name="u1_interleave",
+            process="u1_interleave",
+            factory=f"{_PKG}.stages.create_sensenova_u1_interleave_executor",
+            factory_args={
+                "device": "cuda:0",
+                "dtype": "bfloat16",
+                "attn_backend": "auto",
+                "max_concurrency": 1,
+            },
+            runtime=StageRuntimeConfig(
+                resources=StageResourceConfig(total_gpu_memory_fraction=0.75)
+            ),
+            gpu=0,
+            terminal=True,
+        )
+    ]
+
+
+EntryClass = SenseNovaU1PipelineConfig
+
+Variants = {
+    "default": SenseNovaU1PipelineConfig,
+    "flow": SenseNovaU1FlowPipelineConfig,
+    "interleave": SenseNovaU1InterleavePipelineConfig,
+}

--- a/sglang_omni/models/sensenova_u1/config.py
+++ b/sglang_omni/models/sensenova_u1/config.py
@@ -37,6 +37,12 @@ class SenseNovaU1PipelineConfig(PipelineConfig):
                 "dtype": "bfloat16",
                 "attn_backend": "auto",
                 "max_concurrency": 1,
+                "max_total_tokens": 4096,
+                "eager_prefix_cache_max_entries": 4,
+                "eager_decode_graph_cache_max_entries": 2,
+                "eager_decode_graph_max_captures": 4,
+                "eager_prefix_cache_max_tokens": 2048,
+                "eager_decode_graph_max_total_tokens": 1024,
             },
             runtime=StageRuntimeConfig(
                 resources=StageResourceConfig(total_gpu_memory_fraction=0.75)
@@ -65,6 +71,12 @@ class SenseNovaU1FlowPipelineConfig(SenseNovaU1PipelineConfig):
                 "dtype": "bfloat16",
                 "attn_backend": "auto",
                 "max_concurrency": 1,
+                "max_total_tokens": 4096,
+                "eager_prefix_cache_max_entries": 4,
+                "eager_decode_graph_cache_max_entries": 2,
+                "eager_decode_graph_max_captures": 4,
+                "eager_prefix_cache_max_tokens": 2048,
+                "eager_decode_graph_max_total_tokens": 1024,
             },
             runtime=StageRuntimeConfig(
                 resources=StageResourceConfig(total_gpu_memory_fraction=0.75)
@@ -126,6 +138,11 @@ class SenseNovaU1NativeServingPipelineConfig(SenseNovaU1PipelineConfig):
                 "max_batch_wait_ms": 10,
                 "enable_cuda_graph": True,
                 "cuda_graph_bs": [1, 8, 16],
+                "eager_prefix_cache_max_entries": 4,
+                "eager_decode_graph_cache_max_entries": 2,
+                "eager_decode_graph_max_captures": 4,
+                "eager_prefix_cache_max_tokens": 2048,
+                "eager_decode_graph_max_total_tokens": 1024,
             },
             runtime=StageRuntimeConfig(
                 resources=StageResourceConfig(total_gpu_memory_fraction=0.70)

--- a/sglang_omni/models/sensenova_u1/flow_matching.py
+++ b/sglang_omni/models/sensenova_u1/flow_matching.py
@@ -10,16 +10,36 @@ from __future__ import annotations
 
 import base64
 import io
+import json
 import math
+import os
 import time
 from contextlib import nullcontext
 from dataclasses import asdict, dataclass
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
 import torch
+import torchvision.transforms as T
 from PIL import Image
+from safetensors import safe_open
+from torch import nn
+from transformers import AutoTokenizer
 
+from sglang_omni.models.sensenova_u1.native_serving import (
+    SenseNovaU1NativeServingExecutor,
+)
+from sglang_omni.models.sensenova_u1.native_vision import (
+    SenseNovaU1NativeVisionModel,
+)
+from sglang_omni.models.sensenova_u1.sglang_model import (
+    _blocked_hf_modeling_modules,
+    assert_no_hf_modeling_imported,
+    block_hf_modeling_imports,
+)
+from sglang_omni.models.weight_loader import resolve_dtype
 from sglang_omni.proto import StagePayload
 from sglang_omni.models.sensenova_u1.hf_runner import (
     DEFAULT_MODEL_DIR,
@@ -32,6 +52,27 @@ from sglang_omni.models.sensenova_u1.hf_runner import (
 
 NORM_MEAN = (0.5, 0.5, 0.5)
 NORM_STD = (0.5, 0.5, 0.5)
+IMAGENET_MEAN = (0.485, 0.456, 0.406)
+IMAGENET_STD = (0.229, 0.224, 0.225)
+SYSTEM_MESSAGE_FOR_GEN = (
+    "You are an image generation and editing assistant that accurately understands and executes "
+    "user intent.\n\nYou support two modes:\n\n1. Think Mode:\nIf the task requires reasoning, you "
+    "MUST start with a <think></think> block. Put all reasoning inside the block using plain text. "
+    "DO NOT include any image tags. Keep it reasonable and directly useful for producing the final "
+    "image.\n\n2. Non-Think Mode:\nIf no reasoning is needed, directly produce the final image.\n\n"
+    "Task Types:\n\nA. Text-to-Image Generation:\n"
+    "- Generate a high-quality image based on the user's description.\n"
+    "- Ensure visual clarity, semantic consistency, and completeness.\n"
+    "- DO NOT introduce elements that contradict or override the user's intent.\n\n"
+    "B. Image Editing:\n"
+    "- Use the provided image(s) as input or reference for modification or transformation.\n"
+    "- The result can be an edited image or a new image based on the reference(s).\n"
+    "- Preserve all unspecified attributes unless explicitly changed.\n\n"
+    "General Rules:\n"
+    "- For any visible text in the image, follow the language specified for the rendered text in "
+    "the user's description, not the language of the prompt. If no language is specified, use the "
+    "user's input language."
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -50,6 +91,291 @@ class FlowRequestParams:
     t_eps: float = 0.05
     think_mode: bool = False
     seed: int = 20260813
+
+
+@dataclass(slots=True)
+class NativeFlowPrefix:
+    input_ids: torch.Tensor
+    indexes: torch.Tensor
+    image_token_tag: torch.Tensor
+    input_embeds: torch.Tensor
+    cache_extra_key: str | None
+    cache_insert_log: dict[str, Any]
+    cache_reuse_enabled: bool = False
+
+
+@dataclass(slots=True)
+class NativeFlowRunStats:
+    prefix_tokens: int
+    image_tokens: int
+    forward_elapsed_s: list[float]
+    backend_name: str | None = None
+    hf_modeling_imported_after: list[str] | None = None
+    hidden_prefill_logs: list[dict[str, Any]] | None = None
+    prefix_cache_enabled: bool = False
+    prefix_cache_log: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "prefix_tokens": int(self.prefix_tokens),
+            "image_tokens": int(self.image_tokens),
+            "forward_elapsed_s": [float(x) for x in self.forward_elapsed_s],
+            "forward_elapsed_sum_s": float(sum(self.forward_elapsed_s)),
+            "backend_name": self.backend_name,
+            "hf_modeling_imported_after": self.hf_modeling_imported_after or [],
+            "hidden_prefill_logs": self.hidden_prefill_logs or [],
+            "prefix_cache_enabled": bool(self.prefix_cache_enabled),
+            "prefix_cache_log": self.prefix_cache_log or {},
+        }
+
+
+class NativeTimestepEmbedder(nn.Module):
+    """Native copy of U1's small timestep MLP; avoids importing HF modeling code."""
+
+    def __init__(self, hidden_size: int, frequency_embedding_size: int = 256) -> None:
+        super().__init__()
+        self.mlp = nn.Sequential(
+            nn.Linear(frequency_embedding_size, hidden_size, bias=True),
+            nn.SiLU(),
+            nn.Linear(hidden_size, hidden_size, bias=True),
+        )
+        self.frequency_embedding_size = int(frequency_embedding_size)
+
+    @staticmethod
+    def timestep_embedding(
+        t: torch.Tensor,
+        dim: int,
+        max_period: float = 10000.0,
+    ) -> torch.Tensor:
+        half = dim // 2
+        freqs = torch.exp(
+            -math.log(max_period)
+            * torch.arange(start=0, end=half, dtype=torch.float32, device=t.device)
+            / half
+        )
+        args = t[:, None].float() * freqs[None]
+        embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        if dim % 2:
+            embedding = torch.cat(
+                [embedding, torch.zeros_like(embedding[:, :1])],
+                dim=-1,
+            )
+        return embedding
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        t_freq = self.timestep_embedding(t, self.frequency_embedding_size)
+        return self.mlp(t_freq.to(self.mlp[0].weight.dtype))
+
+
+class SenseNovaU1NativeFlowModules(nn.Module):
+    """Native U1 flow modules for the public Interleaved checkpoint."""
+
+    def __init__(self, model_path: str | Path, *, params_dtype: torch.dtype) -> None:
+        super().__init__()
+        self.raw_config = _load_raw_config(model_path)
+        llm_config = self.raw_config["llm_config"]
+        hidden_size = int(llm_config["hidden_size"])
+        patch_size = int(self.raw_config.get("patch_size", 16))
+        merge_size = int(1 / float(self.raw_config.get("downsample_ratio", 0.5)))
+        output_dim = 3 * (patch_size * merge_size) ** 2
+        if bool(self.raw_config.get("use_pixel_head", False)):
+            raise NotImplementedError("native U1 flow path does not support use_pixel_head")
+        if int(self.raw_config.get("fm_head_layers", 2)) > 2:
+            raise NotImplementedError("native U1 flow path does not support deep fm_head")
+
+        self.vision_model_mot_gen = SenseNovaU1NativeVisionModel.from_model_path(
+            model_path,
+            params_dtype=params_dtype,
+        )
+        self.timestep_embedder = NativeTimestepEmbedder(hidden_size)
+        self.fm_head = nn.Sequential(
+            nn.Linear(hidden_size, 4096, bias=True),
+            nn.GELU(),
+            nn.Linear(4096, output_dim, bias=True),
+        )
+        self.add_noise_scale_embedding = bool(
+            self.raw_config.get("add_noise_scale_embedding", False)
+        )
+        if self.add_noise_scale_embedding:
+            self.noise_scale_embedder = NativeTimestepEmbedder(hidden_size)
+        self.to(dtype=params_dtype)
+
+    def load_weights(self, model_path: str | Path) -> dict[str, Any]:
+        expected = set(dict(self.named_parameters()))
+        loaded: set[str] = set()
+        unexpected: list[str] = []
+        errors: list[str] = []
+        model_path = Path(model_path)
+        index_file = model_path / "model.safetensors.index.json"
+        weight_map = json.loads(index_file.read_text(encoding="utf-8"))["weight_map"]
+        shards: dict[str, list[str]] = {}
+        for key, shard_name in weight_map.items():
+            if key.startswith("fm_modules."):
+                shards.setdefault(shard_name, []).append(key)
+
+        params = dict(self.named_parameters())
+        for shard_name in sorted(shards):
+            with safe_open(str(model_path / shard_name), framework="pt", device="cpu") as f:
+                for full_key in sorted(shards[shard_name]):
+                    name = full_key[len("fm_modules.") :]
+                    if name.startswith("vision_model_mot_gen.embeddings."):
+                        name = (
+                            "vision_model_mot_gen."
+                            + name[len("vision_model_mot_gen.embeddings.") :]
+                        )
+                    tensor = f.get_tensor(full_key)
+                    param = params.get(name)
+                    if param is None:
+                        unexpected.append(name)
+                        continue
+                    if tuple(param.shape) != tuple(tensor.shape):
+                        errors.append(
+                            f"{name}: param={tuple(param.shape)} checkpoint={tuple(tensor.shape)}"
+                        )
+                        continue
+                    with torch.no_grad():
+                        param.copy_(tensor.to(device=param.device, dtype=param.dtype))
+                    loaded.add(name)
+
+        missing = sorted(expected - loaded)
+        return {
+            "loaded_keys": sorted(loaded),
+            "loaded_count": len(loaded),
+            "missing_keys": missing,
+            "missing_count": len(missing),
+            "unexpected_keys": sorted(unexpected),
+            "unexpected_count": len(unexpected),
+            "errors": errors,
+            "error_count": len(errors),
+            "ok": not missing and not unexpected and not errors,
+        }
+
+
+def _load_raw_config(model_path: str | Path) -> dict[str, Any]:
+    return json.loads((Path(model_path) / "config.json").read_text(encoding="utf-8"))
+
+
+def _to_namespace(value: Any) -> Any:
+    if isinstance(value, dict):
+        return SimpleNamespace(**{k: _to_namespace(v) for k, v in value.items()})
+    if isinstance(value, list):
+        return [_to_namespace(v) for v in value]
+    return value
+
+
+def _round_by_factor(number: float, factor: int) -> int:
+    return round(number / factor) * factor
+
+
+def _ceil_by_factor(number: float, factor: int) -> int:
+    return math.ceil(number / factor) * factor
+
+
+def _floor_by_factor(number: float, factor: int) -> int:
+    return math.floor(number / factor) * factor
+
+
+def _smart_resize(
+    height: int,
+    width: int,
+    *,
+    factor: int,
+    min_pixels: int,
+    max_pixels: int,
+) -> tuple[int, int]:
+    if max(height, width) / min(height, width) > 200:
+        raise ValueError("absolute image aspect ratio must be smaller than 200")
+    h_bar = max(factor, _round_by_factor(height, factor))
+    w_bar = max(factor, _round_by_factor(width, factor))
+    if h_bar * w_bar > max_pixels:
+        beta = math.sqrt((height * width) / max_pixels)
+        h_bar = max(factor, _floor_by_factor(height / beta, factor))
+        w_bar = max(factor, _floor_by_factor(width / beta, factor))
+    elif h_bar * w_bar < min_pixels:
+        beta = math.sqrt(min_pixels / (height * width))
+        h_bar = _ceil_by_factor(height * beta, factor)
+        w_bar = _ceil_by_factor(width * beta, factor)
+    return h_bar, w_bar
+
+
+def load_image_native_tensor(
+    image: Any,
+    *,
+    patch_size: int,
+    downsample_ratio: float,
+    min_pixels: int = 65536,
+    max_pixels: int = 4194304,
+    upscale: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    image = _coerce_image(image)
+    if not isinstance(image, Image.Image):
+        image = Image.open(image)
+    if image.mode == "RGBA":
+        background = Image.new("RGB", image.size, (255, 255, 255))
+        background.paste(image, mask=image.split()[3])
+        image = background.convert("RGB")
+    else:
+        image = image.convert("RGB")
+    if upscale:
+        image = image.resize((image.width * 2, image.height * 2), Image.BILINEAR)
+
+    factor = int(patch_size // downsample_ratio)
+    resized_h, resized_w = _smart_resize(
+        image.height,
+        image.width,
+        factor=factor,
+        min_pixels=min_pixels,
+        max_pixels=max_pixels,
+    )
+    image = image.resize((resized_w, resized_h))
+    transform = T.Compose(
+        [
+            T.Lambda(lambda img: img.convert("RGB") if img.mode != "RGB" else img),
+            T.ToTensor(),
+            T.Normalize(mean=IMAGENET_MEAN, std=IMAGENET_STD),
+        ]
+    )
+    pixel_values = transform(image).to(torch.float32)
+    c, h, w = pixel_values.shape
+    grid_h = h // patch_size
+    grid_w = w // patch_size
+    flat = (
+        pixel_values.view(c, grid_h, patch_size, grid_w, patch_size)
+        .permute(1, 3, 0, 2, 4)
+        .reshape(grid_h * grid_w, c * patch_size**2)
+    )
+    return flat, torch.tensor([[grid_h, grid_w]], dtype=torch.long)
+
+
+def _build_neo_prompt(
+    *,
+    user_text: str,
+    system_message: str,
+    assistant_append: str | None = None,
+) -> str:
+    prompt = ""
+    if system_message:
+        prompt += f"<|im_start|>system\n{system_message}<|im_end|>\n"
+    prompt += f"<|im_start|>user\n{user_text}<|im_end|>\n"
+    prompt += "<|im_start|>assistant\n"
+    if assistant_append is not None:
+        prompt += assistant_append
+    return prompt
+
+
+def build_abs_positions_from_grid_hw(
+    grid_hw: torch.Tensor,
+    *,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    grid_hw = grid_hw.reshape(-1, 2).to(dtype=torch.long)
+    hs: list[torch.Tensor] = []
+    ws: list[torch.Tensor] = []
+    for h, w in grid_hw.detach().cpu().tolist():
+        idx = torch.arange(int(h) * int(w), device=device, dtype=torch.long)
+        hs.append(idx // int(w))
+        ws.append(idx % int(w))
+    return torch.cat(ws), torch.cat(hs)
 
 
 def denormalize_u1_image_tensor(batch: torch.Tensor) -> torch.Tensor:
@@ -106,7 +432,7 @@ def compare_pil_images(a: Image.Image, b: Image.Image) -> dict[str, Any]:
     }
 
 
-class SenseNovaU1FlowMatchingRunner(SenseNovaU1UnderstandingRunner):
+class SenseNovaU1FlowMatchingFallbackRunner(SenseNovaU1UnderstandingRunner):
     """T2I/IT2I runner for U1 flow matching inside SGLang-Omni."""
 
     def __init__(
@@ -236,7 +562,7 @@ class SenseNovaU1FlowMatchingRunner(SenseNovaU1UnderstandingRunner):
             for key in config_keys
         }
         return {
-            "backend": "sglang_omni_sensenova_u1_flow_matching_hf_compatible",
+            "backend": "sglang_omni_sensenova_u1_flow_matching_hf_compatible_official_mask",
             "request": asdict(request),
             "patch_size": int(model.patch_size),
             "downsample_ratio": float(model.downsample_ratio),
@@ -257,7 +583,7 @@ class SenseNovaU1FlowMatchingRunner(SenseNovaU1UnderstandingRunner):
         self,
         request: FlowRequestParams,
         *,
-        use_official_hybrid_mask: bool = False,
+        use_official_hybrid_mask: bool = True,
     ) -> tuple[torch.Tensor, str]:
         assert self.model is not None and self.tokenizer is not None
         ctx = _official_block_mask_scope() if use_official_hybrid_mask else nullcontext()
@@ -288,7 +614,7 @@ class SenseNovaU1FlowMatchingRunner(SenseNovaU1UnderstandingRunner):
         request: FlowRequestParams,
         images: list[Any],
         *,
-        use_official_hybrid_mask: bool = False,
+        use_official_hybrid_mask: bool = True,
     ) -> tuple[torch.Tensor, str]:
         assert self.model is not None and self.tokenizer is not None
         if not images:
@@ -348,15 +674,835 @@ class SenseNovaU1FlowMatchingRunner(SenseNovaU1UnderstandingRunner):
                 "engine_time_s": elapsed,
             },
             "stage_name": "u1_flow",
-            "backend": "hf_compatible_flow_matching_fallback",
+            "backend": "hf_compatible_flow_matching_fallback_official_mask",
+        }
+
+
+class SenseNovaU1FlowMatchingRunner:
+    """Native SGLang U1 T2I/IT2I flow-matching runner.
+
+    The runner avoids official U1 HF modeling imports. Prefixes are inserted
+    through the existing SGLang/RadixAttention serving executor; each denoise
+    step extends that prefix with generated image tokens, captures the native
+    MoT hidden states, and applies native-loaded flow modules.
+    """
+
+    def __init__(
+        self,
+        model_path: str = DEFAULT_MODEL_DIR,
+        *,
+        vendor_root: str | None = None,
+        device: str = "cuda:0",
+        dtype: str | torch.dtype = "bfloat16",
+        attn_backend: str = "triton",
+        attention_backend: str | None = None,
+        load_with_info: bool = False,
+        mem_fraction_static: float = 0.65,
+        max_total_tokens: int = 8192,
+        max_running_requests: int = 2,
+    ) -> None:
+        del vendor_root, load_with_info
+        assert_no_hf_modeling_imported(context="before native flow runner init")
+        self.model_path = str(model_path)
+        self.device = str(device)
+        self.torch_device = torch.device(device)
+        self.dtype = dtype if isinstance(dtype, torch.dtype) else resolve_dtype(dtype)
+        self.raw_config = _load_raw_config(model_path)
+        self.config = _to_namespace(self.raw_config)
+        self.llm_config = _to_namespace(self.raw_config["llm_config"])
+        self.patch_size = int(self.raw_config.get("patch_size", 16))
+        self.downsample_ratio = float(self.raw_config.get("downsample_ratio", 0.5))
+        self.noise_scale = float(self.raw_config.get("noise_scale", 1.0))
+        self.noise_scale_mode = str(self.raw_config.get("noise_scale_mode", "constant"))
+        self.noise_scale_base_image_seq_len = int(
+            self.raw_config.get("noise_scale_base_image_seq_len", 64)
+        )
+        self.add_noise_scale_embedding = bool(
+            self.raw_config.get("add_noise_scale_embedding", False)
+        )
+        self.noise_scale_max_value = float(
+            self.raw_config.get("noise_scale_max_value", 1.0)
+        )
+        self.time_schedule = str(self.raw_config.get("time_schedule", "standard"))
+        self.time_shift_type = str(self.raw_config.get("time_shift_type", "exponential"))
+        self.base_shift = float(self.raw_config.get("base_shift", 0.5))
+        self.max_shift = float(self.raw_config.get("max_shift", 1.15))
+        self.base_image_seq_len = int(self.raw_config.get("base_image_seq_len", 64))
+        self.max_image_seq_len = int(self.raw_config.get("max_image_seq_len", 4096))
+        self.last_native_flow_stats: dict[str, Any] = {}
+        self.native_flow_prefill_cuda_graph_enabled = (
+            self._native_flow_prefill_cuda_graph_enabled()
+        )
+        if isinstance(dtype, str):
+            dtype_arg = dtype
+        elif dtype is torch.bfloat16:
+            dtype_arg = "bfloat16"
+        elif dtype is torch.float16:
+            dtype_arg = "float16"
+        elif dtype is torch.float32:
+            dtype_arg = "float32"
+        else:
+            dtype_arg = "bfloat16"
+
+        backend_arg = attention_backend or attn_backend
+        if backend_arg == "auto":
+            backend_arg = "triton"
+
+        with block_hf_modeling_imports():
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                model_path,
+                trust_remote_code=True,
+            )
+            self.executor = SenseNovaU1NativeServingExecutor(
+                model_path,
+                device=device,
+                dtype=dtype_arg,
+                attention_backend=backend_arg,
+                mem_fraction_static=mem_fraction_static,
+                max_total_tokens=max_total_tokens,
+                max_running_requests=max_running_requests,
+                enable_radix_cache=True,
+                prefill_cuda_graph_backend=(
+                    "breakable"
+                    if self.native_flow_prefill_cuda_graph_enabled
+                    else "disabled"
+                ),
+                prefill_cuda_graph_bs=[64],
+            )
+            self.fm_modules = SenseNovaU1NativeFlowModules(
+                model_path,
+                params_dtype=next(
+                    self.executor.model_worker.model_runner.model.parameters()
+                ).dtype,
+            ).to(device=self.torch_device)
+            self.fm_modules.eval()
+            self.flow_load_report = self.fm_modules.load_weights(model_path)
+            if not self.flow_load_report["ok"]:
+                raise RuntimeError(
+                    "native U1 flow module load failed: "
+                    f"{self.flow_load_report}"
+                )
+        self.img_context_token_id = int(
+            self.tokenizer.convert_tokens_to_ids("<IMG_CONTEXT>")
+        )
+        self.img_start_token_id = int(self.tokenizer.convert_tokens_to_ids("<img>"))
+        self.img_end_token_id = int(self.tokenizer.convert_tokens_to_ids("</img>"))
+        assert_no_hf_modeling_imported(context="after native flow runner init")
+
+    def _calculate_dynamic_mu(self, image_seq_len: int) -> float:
+        denom = self.max_image_seq_len - self.base_image_seq_len
+        if denom == 0:
+            return float(self.base_shift)
+        m = (self.max_shift - self.base_shift) / denom
+        b = self.base_shift - m * self.base_image_seq_len
+        return float(image_seq_len) * m + b
+
+    def _apply_time_schedule(
+        self,
+        t: torch.Tensor,
+        image_seq_len: int,
+        timestep_shift: float,
+    ) -> torch.Tensor:
+        schedule = self.time_schedule
+        if timestep_shift != 1:
+            schedule = "standard"
+        sigma = 1 - t
+        if schedule == "standard":
+            shift = timestep_shift
+            sigma = shift * sigma / (1 + (shift - 1) * sigma)
+        elif schedule == "dynamic":
+            mu_t = t.new_tensor(self._calculate_dynamic_mu(image_seq_len))
+            if self.time_shift_type == "exponential":
+                shift = torch.exp(mu_t)
+                sigma = shift * sigma / (1 + (shift - 1) * sigma)
+            elif self.time_shift_type == "linear":
+                sigma = mu_t / (mu_t + (1 / sigma - 1))
+            else:
+                raise ValueError(f"Unsupported time_shift_type: {self.time_shift_type}")
+        else:
+            raise ValueError(f"Unsupported time_schedule: {schedule}")
+        return 1 - sigma
+
+    def scheduler_params(self, request: FlowRequestParams) -> dict[str, Any]:
+        width, height = request.image_size
+        merge_size = int(1 / self.downsample_ratio)
+        token_h = height // (self.patch_size * merge_size)
+        token_w = width // (self.patch_size * merge_size)
+        grid_h = height // self.patch_size
+        grid_w = width // self.patch_size
+        image_seq_len = token_h * token_w
+        noise_scale = self._computed_noise_scale(grid_h, grid_w, merge_size)
+        timesteps = torch.linspace(0.0, 1.0, request.num_steps + 1, device=self.torch_device)
+        if request.enable_timestep_shift:
+            timesteps = self._apply_time_schedule(
+                timesteps,
+                image_seq_len,
+                request.timestep_shift,
+            )
+        t_values = [float(x) for x in timesteps.detach().cpu().tolist()]
+        raw_keys = [
+            "fm_head_dim",
+            "fm_head_layers",
+            "fm_head_mlp_ratio",
+            "timestep_shift",
+            "time_schedule",
+            "time_shift_type",
+            "base_shift",
+            "max_shift",
+            "base_image_seq_len",
+            "max_image_seq_len",
+            "noise_scale",
+            "noise_scale_mode",
+            "noise_scale_base_image_seq_len",
+            "noise_scale_max_value",
+            "add_noise_scale_embedding",
+            "P_mean",
+            "P_std",
+            "t_eps",
+            "use_pixel_head",
+            "use_adaLN",
+        ]
+        return {
+            "backend": "sglang_native_sensenova_u1_full_sequence_flow",
+            "request": asdict(request),
+            "patch_size": self.patch_size,
+            "downsample_ratio": self.downsample_ratio,
+            "merge_size": merge_size,
+            "grid_h": grid_h,
+            "grid_w": grid_w,
+            "token_h": token_h,
+            "token_w": token_w,
+            "image_seq_len": image_seq_len,
+            "computed_noise_scale": noise_scale,
+            "raw_config": {key: self.raw_config.get(key) for key in raw_keys},
+            "timesteps": t_values,
+            "step_table": [
+                {
+                    "step": i,
+                    "t": t_values[i],
+                    "t_next": t_values[i + 1],
+                    "dt": t_values[i + 1] - t_values[i],
+                    "use_cfg": bool(
+                        (
+                            t_values[i] > request.cfg_interval[0]
+                            and t_values[i] < request.cfg_interval[1]
+                        )
+                        or request.cfg_interval[0] == 0
+                    ),
+                }
+                for i in range(request.num_steps)
+            ],
+            "flow_load_report": self.flow_load_report,
+        }
+
+    @staticmethod
+    def patchify(
+        images: torch.Tensor,
+        patch_size: int,
+        *,
+        channel_first: bool = False,
+    ) -> torch.Tensor:
+        h, w = images.shape[2] // patch_size, images.shape[3] // patch_size
+        x = images.reshape(images.shape[0], 3, h, patch_size, w, patch_size)
+        if channel_first:
+            x = torch.einsum("nchpwq->nhwcpq", x)
+        else:
+            x = torch.einsum("nchpwq->nhwpqc", x)
+        return x.reshape(images.shape[0], h * w, patch_size**2 * 3)
+
+    @staticmethod
+    def unpatchify(
+        x: torch.Tensor,
+        patch_size: int,
+        h: int,
+        w: int,
+    ) -> torch.Tensor:
+        h_tokens = h // patch_size
+        w_tokens = w // patch_size
+        x = x.reshape(x.shape[0], h_tokens, w_tokens, patch_size, patch_size, 3)
+        x = torch.einsum("nhwpqc->nchpwq", x)
+        return x.reshape(x.shape[0], 3, h, w)
+
+    def _computed_noise_scale(self, grid_h: int, grid_w: int, merge_size: int) -> float:
+        noise_scale = self.noise_scale
+        if self.noise_scale_mode in ("resolution", "dynamic", "dynamic_sqrt"):
+            base = float(self.noise_scale_base_image_seq_len)
+            scale = math.sqrt((grid_h * grid_w) / (merge_size**2) / base)
+            noise_scale = scale * float(self.noise_scale)
+            if self.noise_scale_mode == "dynamic_sqrt":
+                noise_scale = math.sqrt(noise_scale)
+        return min(noise_scale, self.noise_scale_max_value)
+
+    def _build_t2i_image_indexes(
+        self,
+        token_h: int,
+        token_w: int,
+        text_len: int,
+        *,
+        device: torch.device,
+    ) -> torch.Tensor:
+        t_image = torch.full(
+            (token_h * token_w,),
+            int(text_len),
+            dtype=torch.long,
+            device=device,
+        )
+        idx = torch.arange(token_h * token_w, device=device, dtype=torch.long)
+        h_image = idx // token_w
+        w_image = idx % token_w
+        return torch.stack([t_image, h_image, w_image], dim=0)
+
+    def _get_thw_indexes(
+        self,
+        input_ids: torch.Tensor,
+        grid_hw: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        input_ids = input_ids.reshape(-1)
+        img_start_shift = torch.cat(
+            [
+                torch.zeros(1, dtype=torch.long, device=input_ids.device),
+                (input_ids == self.img_start_token_id).long(),
+            ],
+            dim=0,
+        )[:-1]
+        not_img_token = (input_ids != self.img_context_token_id).long()
+        t_indexes = (img_start_shift + not_img_token).cumsum(0) - 1
+        h_indexes = torch.zeros_like(t_indexes)
+        w_indexes = torch.zeros_like(t_indexes)
+        if grid_hw is not None:
+            selected = input_ids == self.img_context_token_id
+            if bool(selected.any().item()):
+                merge_size = int(1 / self.downsample_ratio)
+                abs_w, abs_h = build_abs_positions_from_grid_hw(
+                    grid_hw // merge_size,
+                    device=input_ids.device,
+                )
+                h_indexes[selected] = abs_h.to(t_indexes.dtype)
+                w_indexes[selected] = abs_w.to(t_indexes.dtype)
+        return torch.stack([t_indexes, h_indexes, w_indexes], dim=0)
+
+    def _token_embeds(self, input_ids: torch.Tensor) -> torch.Tensor:
+        model = self.executor.model_worker.model_runner.model
+        device = torch.device(self.executor.model_worker.device)
+        dtype = next(model.parameters()).dtype
+        flat_ids = input_ids.reshape(-1).to(device=device, dtype=torch.long)
+        with torch.inference_mode(), block_hf_modeling_imports():
+            return model.get_input_embeddings()(flat_ids).to(dtype=dtype)
+
+    @staticmethod
+    def _native_flow_prefix_cache_enabled() -> bool:
+        value = os.environ.get(
+            "SENSENOVA_U1_NATIVE_FLOW_PREFIX_CACHE",
+            "",
+        ).lower()
+        return value not in {"0", "false", "no", "off"}
+
+    @staticmethod
+    def _native_flow_prefill_cuda_graph_enabled() -> bool:
+        value = os.environ.get(
+            "SENSENOVA_U1_NATIVE_FLOW_PREFILL_CUDA_GRAPH",
+            "",
+        ).lower()
+        return value not in {"0", "false", "no", "off"}
+
+    def _load_input_images(
+        self,
+        images: list[Any],
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        if not images:
+            return None, None
+        pixel_values = []
+        grid_hw = []
+        max_pixels = min(2048 * 2048, (4096 * 4096) // max(1, len(images)))
+        for image in images:
+            cur_pixels, cur_grid = load_image_native_tensor(
+                image,
+                patch_size=self.patch_size,
+                downsample_ratio=self.downsample_ratio,
+                min_pixels=512 * 512,
+                max_pixels=max_pixels,
+                upscale=False,
+            )
+            pixel_values.append(cur_pixels)
+            grid_hw.append(cur_grid)
+        return torch.cat(pixel_values, dim=0), torch.cat(grid_hw, dim=0)
+
+    def _replace_image_tokens(self, query: str, grid_hw: torch.Tensor | None) -> str:
+        if grid_hw is None:
+            return query
+        for i in range(int(grid_hw.shape[0])):
+            num_patch_token = int(
+                grid_hw[i, 0] * grid_hw[i, 1] * self.downsample_ratio**2
+            )
+            image_tokens = (
+                "<img>"
+                + "<IMG_CONTEXT>" * num_patch_token
+                + "</img>"
+            )
+            query = query.replace("<image>", image_tokens, 1)
+        return query
+
+    def _build_prefix(
+        self,
+        *,
+        prompt: str,
+        images: list[Any],
+        system_message: str,
+        assistant_append: str,
+    ) -> NativeFlowPrefix:
+        image_count = prompt.count("<image>")
+        if len(images) > image_count:
+            if image_count == 0 and len(images) > 1:
+                prompt = "".join(
+                    f"Image-{idx + 1}:<image>\n" for idx in range(len(images))
+                ) + prompt
+            else:
+                prompt = "<image>\n" * (len(images) - image_count) + prompt
+        pixel_values, grid_hw = self._load_input_images(images)
+        query = _build_neo_prompt(
+            user_text=prompt,
+            system_message=system_message,
+            assistant_append=assistant_append,
+        )
+        query = self._replace_image_tokens(query, grid_hw)
+        input_ids = self.tokenizer(query, return_tensors="pt")["input_ids"][0]
+        indexes = self._get_thw_indexes(input_ids, grid_hw)
+        image_token_tag = input_ids == self.img_context_token_id
+        if pixel_values is not None and grid_hw is not None:
+            input_embeds = self.executor.compose_input_embeds(
+                input_ids=input_ids,
+                image_token_tag=image_token_tag,
+                pixel_values=pixel_values,
+                grid_hw=grid_hw,
+            )
+            if input_embeds is None:
+                raise RuntimeError("native prefix image compose returned no embeds")
+        else:
+            input_embeds = self._token_embeds(input_ids)
+
+        cache_reuse_enabled = self._native_flow_prefix_cache_enabled()
+        cache_extra_key = (
+            self.executor._cache_extra_key(
+                image_token_tag=image_token_tag,
+                pixel_values=pixel_values,
+                grid_hw=grid_hw,
+                input_embeds=input_embeds,
+            )
+            if cache_reuse_enabled
+            else None
+        )
+        return NativeFlowPrefix(
+            input_ids=input_ids.to(dtype=torch.long),
+            indexes=indexes.to(dtype=torch.long),
+            image_token_tag=image_token_tag.to(dtype=torch.bool),
+            input_embeds=input_embeds.detach(),
+            cache_extra_key=cache_extra_key,
+            cache_insert_log={
+                "skipped": not cache_reuse_enabled,
+                "reason": (
+                    "pending_static_prefix_insert"
+                    if cache_reuse_enabled
+                    else "native_flow_prefix_cache_disabled"
+                ),
+                "prefix_tokens": int(input_ids.numel()),
+                "image_token_count": int(image_token_tag.sum().item()),
+            },
+            cache_reuse_enabled=cache_reuse_enabled,
+        )
+
+    def _prime_prefix_cache(self, prefix: NativeFlowPrefix) -> None:
+        if not prefix.cache_reuse_enabled:
+            return
+        cached_prefix_len = self.executor.cached_prefix_length(
+            input_ids=prefix.input_ids,
+            cache_extra_key=prefix.cache_extra_key,
+        )
+        if cached_prefix_len == int(prefix.input_ids.numel()):
+            prefix.cache_insert_log = {
+                "skipped": True,
+                "reason": "static_prefix_already_cached",
+                "prefix_tokens": int(prefix.input_ids.numel()),
+                "image_token_count": int(prefix.image_token_tag.sum().item()),
+                "cache_extra_key": prefix.cache_extra_key,
+                "cache_hit_tokens": cached_prefix_len,
+            }
+            return
+        result = self.executor.run_prefill(
+            request_id=f"u1-native-flow-prefix-{time.time_ns()}",
+            input_ids=prefix.input_ids,
+            indexes=prefix.indexes,
+            image_token_tag=prefix.image_token_tag,
+            image_gen_indicators=torch.zeros_like(
+                prefix.image_token_tag,
+                dtype=torch.bool,
+            ),
+            input_embeds=prefix.input_embeds,
+            cache_extra_key=prefix.cache_extra_key,
+            cache_insert=True,
+        )
+        prefix.cache_extra_key = result.cache_extra_key
+        prefix.cache_insert_log = {
+            "skipped": False,
+            "reason": "static_prefix_inserted",
+            "prefix_tokens": int(prefix.input_ids.numel()),
+            "image_token_count": int(prefix.image_token_tag.sum().item()),
+            "cache_extra_key": result.cache_extra_key,
+            "cache_inserted": bool(result.cache_inserted),
+            "cache_hit_tokens_before_insert": cached_prefix_len,
+            "forward_elapsed_s": float(result.forward_elapsed_s),
+            "forward_batch_log": result.forward_batch_log,
+        }
+        if not result.cache_inserted:
+            raise RuntimeError("native flow static prefix was not inserted into Radix cache")
+
+    def _predict_v(
+        self,
+        *,
+        prefix: NativeFlowPrefix,
+        image_embeds: torch.Tensor,
+        indexes_image: torch.Tensor,
+        t: torch.Tensor,
+        z: torch.Tensor,
+        request_id: str,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
+        bsz, image_token_num, _ = image_embeds.shape
+        if bsz != 1:
+            raise NotImplementedError("native full-sequence flow currently supports batch_size=1")
+        device = self.torch_device
+        img_ids = torch.full(
+            (image_token_num,),
+            self.img_context_token_id,
+            dtype=torch.long,
+        )
+        full_input_ids = torch.cat([prefix.input_ids.cpu(), img_ids.cpu()], dim=0)
+        full_indexes = torch.cat(
+            [prefix.indexes.cpu(), indexes_image.detach().cpu()],
+            dim=1,
+        )
+        full_image_tag = torch.cat(
+            [
+                prefix.image_token_tag.cpu(),
+                torch.ones(image_token_num, dtype=torch.bool),
+            ],
+            dim=0,
+        )
+        full_gen = torch.cat(
+            [
+                torch.zeros(prefix.input_ids.numel(), dtype=torch.bool),
+                torch.ones(image_token_num, dtype=torch.bool),
+            ],
+            dim=0,
+        )
+        full_embeds = torch.cat(
+            [
+                prefix.input_embeds.to(device=device),
+                image_embeds.reshape(image_token_num, -1).to(device=device),
+            ],
+            dim=0,
+        )
+        hidden_result = self.executor.run_hidden_prefill(
+            {
+                "request_id": request_id,
+                "input_ids": full_input_ids,
+                "indexes": full_indexes,
+                "image_token_tag": full_image_tag,
+                "image_gen_indicators": full_gen,
+                "input_embeds": full_embeds,
+                "cache_extra_key": prefix.cache_extra_key,
+            },
+            cache_insert=False,
+        )
+        if prefix.cache_reuse_enabled:
+            prefix_lens = list(
+                hidden_result.forward_batch_log.get(
+                    "extend_prefix_lens_cpu",
+                    [],
+                )
+            )
+            extend_lens = list(
+                hidden_result.forward_batch_log.get(
+                    "extend_seq_lens_cpu",
+                    [],
+                )
+            )
+            expected_prefix_len = int(prefix.input_ids.numel())
+            if prefix_lens != [expected_prefix_len]:
+                raise RuntimeError(
+                    "native flow prefix cache miss: "
+                    f"expected_prefix_len={expected_prefix_len} actual={prefix_lens}"
+                )
+            if extend_lens != [image_token_num]:
+                raise RuntimeError(
+                    "native flow cached extend length mismatch: "
+                    f"expected_image_tokens={image_token_num} actual={extend_lens}"
+                )
+        image_hidden = hidden_result.hidden_states[-image_token_num:].view(
+            bsz,
+            image_token_num,
+            -1,
+        )
+        x_pred = self.fm_modules.fm_head(image_hidden).view_as(z).to(z.device)
+        v_pred = (x_pred - z) / (1 - t).clamp_min(float(self.raw_config.get("t_eps", 0.05)))
+        return v_pred, hidden_result.to_dict()
+
+    def _generate_conditioned_tensor(
+        self,
+        request: FlowRequestParams,
+        *,
+        images: list[Any],
+        system_message: str,
+        assistant_append: str,
+    ) -> tuple[torch.Tensor, NativeFlowRunStats]:
+        if request.batch_size != 1:
+            raise NotImplementedError("native U1 flow supports batch_size=1 in this path")
+        if request.cfg_scale != 1.0 or request.img_cfg_scale != 1.0:
+            raise NotImplementedError("native U1 flow path currently supports cfg scales of 1.0")
+        assert_no_hf_modeling_imported(context="before native flow generation")
+        width, height = request.image_size
+        merge_size = int(1 / self.downsample_ratio)
+        token_h = height // (self.patch_size * merge_size)
+        token_w = width // (self.patch_size * merge_size)
+        grid_h = height // self.patch_size
+        grid_w = width // self.patch_size
+        image_token_num = token_h * token_w
+        gen_grid_hw = torch.tensor(
+            [[grid_h, grid_w]],
+            dtype=torch.long,
+            device=self.torch_device,
+        )
+        prefix = self._build_prefix(
+            prompt=request.prompt,
+            images=images,
+            system_message=system_message,
+            assistant_append=assistant_append,
+        )
+        self._prime_prefix_cache(prefix)
+        image_t_index = int(prefix.indexes[0].max().item()) + 1
+        indexes_image = self._build_t2i_image_indexes(
+            token_h,
+            token_w,
+            image_t_index,
+            device=self.torch_device,
+        )
+        noise_scale = self._computed_noise_scale(grid_h, grid_w, merge_size)
+        generator = torch.Generator(self.torch_device).manual_seed(request.seed)
+        image_prediction = noise_scale * torch.randn(
+            (1, 3, height, width),
+            device=self.torch_device,
+            dtype=next(self.fm_modules.parameters()).dtype,
+            generator=generator,
+        )
+        timesteps = torch.linspace(
+            0.0,
+            1.0,
+            request.num_steps + 1,
+            device=self.torch_device,
+        )
+        if request.enable_timestep_shift:
+            timesteps = self._apply_time_schedule(
+                timesteps,
+                image_token_num,
+                request.timestep_shift,
+            )
+
+        forward_elapsed: list[float] = []
+        hidden_logs: list[dict[str, Any]] = []
+        backend_name = None
+        for step_i in range(request.num_steps):
+            t = timesteps[step_i]
+            t_next = timesteps[step_i + 1]
+            z = self.patchify(image_prediction, self.patch_size * merge_size)
+            image_input = self.patchify(
+                image_prediction,
+                self.patch_size,
+                channel_first=True,
+            )
+            image_embeds = self.fm_modules.vision_model_mot_gen(
+                image_input.view(grid_h * grid_w, -1),
+                gen_grid_hw,
+            ).view(1, image_token_num, -1)
+            t_expanded = t.expand(image_token_num)
+            timestep_embeddings = self.fm_modules.timestep_embedder(
+                t_expanded,
+            ).view(1, image_token_num, -1)
+            if self.add_noise_scale_embedding:
+                noise_scale_tensor = torch.full_like(
+                    t_expanded,
+                    noise_scale / self.noise_scale_max_value,
+                )
+                timestep_embeddings = timestep_embeddings + self.fm_modules.noise_scale_embedder(
+                    noise_scale_tensor,
+                ).view(1, image_token_num, -1)
+            image_embeds = image_embeds + timestep_embeddings.to(image_embeds.dtype)
+            v_pred, hidden_log = self._predict_v(
+                prefix=prefix,
+                image_embeds=image_embeds,
+                indexes_image=indexes_image,
+                t=t,
+                z=z,
+                request_id=f"u1-native-flow-step-{time.time_ns()}",
+            )
+            forward_elapsed.append(float(hidden_log["forward_elapsed_s"]))
+            backend_name = str(hidden_log["backend_name"])
+            hidden_logs.append(hidden_log)
+            z = z + (t_next - t) * v_pred
+            image_prediction = self.unpatchify(
+                z,
+                self.patch_size * merge_size,
+                height,
+                width,
+            )
+
+        stats = NativeFlowRunStats(
+            prefix_tokens=int(prefix.input_ids.numel()),
+            image_tokens=image_token_num,
+            forward_elapsed_s=forward_elapsed,
+            backend_name=backend_name,
+            hf_modeling_imported_after=_blocked_hf_modeling_modules(),
+            hidden_prefill_logs=hidden_logs,
+            prefix_cache_enabled=prefix.cache_reuse_enabled,
+            prefix_cache_log=prefix.cache_insert_log,
+        )
+        self.last_native_flow_stats = stats.to_dict()
+        assert_no_hf_modeling_imported(context="after native flow generation")
+        return image_prediction.detach(), stats
+
+    def _flow_params_from_request(self, inputs: Any, params: dict[str, Any]) -> tuple[FlowRequestParams, list[Any]]:
+        data = inputs if isinstance(inputs, dict) else {"prompt": str(inputs)}
+        merged = {**data, **params}
+        mode = str(merged.get("mode") or merged.get("task") or "t2i").lower()
+        if mode in {"text_to_image", "txt2img"}:
+            mode = "t2i"
+        if mode in {"image_to_image", "edit", "editing"}:
+            mode = "it2i"
+        if mode not in {"t2i", "it2i"}:
+            raise ValueError(f"Unsupported U1 flow mode: {mode!r}")
+        width = int(merged.get("width", merged.get("image_width", 256)))
+        height = int(merged.get("height", merged.get("image_height", 256)))
+        cfg_interval_value = merged.get("cfg_interval", (0.0, 1.0))
+        cfg_interval = tuple(float(x) for x in cfg_interval_value)
+        if len(cfg_interval) != 2:
+            raise ValueError("cfg_interval must contain exactly two floats.")
+        images = [_coerce_image(img) for img in (merged.get("images") or [])]
+        if "image" in merged:
+            images.append(_coerce_image(merged["image"]))
+        request = FlowRequestParams(
+            mode=mode,
+            prompt=str(merged.get("prompt", "")),
+            image_size=(width, height),
+            cfg_scale=float(merged.get("cfg_scale", 1.0)),
+            img_cfg_scale=float(merged.get("img_cfg_scale", 1.0)),
+            cfg_norm=str(merged.get("cfg_norm", "none")),
+            timestep_shift=float(merged.get("timestep_shift", 1.0)),
+            enable_timestep_shift=bool(merged.get("enable_timestep_shift", True)),
+            cfg_interval=(float(cfg_interval[0]), float(cfg_interval[1])),
+            num_steps=int(merged.get("num_steps", 2)),
+            batch_size=int(merged.get("batch_size", 1)),
+            t_eps=float(merged.get("t_eps", 0.05)),
+            think_mode=bool(merged.get("think_mode", False)),
+            seed=int(merged.get("seed", 20260813)),
+        )
+        return request, images
+
+    @torch.inference_mode()
+    def generate_t2i_tensor(
+        self,
+        request: FlowRequestParams,
+        *,
+        use_official_hybrid_mask: bool = False,
+    ) -> tuple[torch.Tensor, str]:
+        if use_official_hybrid_mask:
+            raise RuntimeError("native flow runner cannot use official HF hybrid mask")
+        if request.think_mode:
+            raise NotImplementedError("native flow path currently supports think_mode=False")
+        return self._generate_conditioned_tensor(
+            request,
+            images=[],
+            system_message=SYSTEM_MESSAGE_FOR_GEN,
+            assistant_append="<think>\n\n</think>\n\n<img>",
+        )[0], ""
+
+    @torch.inference_mode()
+    def generate_it2i_tensor(
+        self,
+        request: FlowRequestParams,
+        images: list[Any],
+        *,
+        use_official_hybrid_mask: bool = False,
+    ) -> tuple[torch.Tensor, str]:
+        if use_official_hybrid_mask:
+            raise RuntimeError("native flow runner cannot use official HF hybrid mask")
+        if not images:
+            raise ValueError("IT2I generation requires at least one input image.")
+        if request.think_mode:
+            raise NotImplementedError("native flow path currently supports think_mode=False")
+        return self._generate_conditioned_tensor(
+            request,
+            images=[_coerce_image(image) for image in images],
+            system_message=SYSTEM_MESSAGE_FOR_GEN,
+            assistant_append="<think>\n\n</think>\n\n<img>",
+        )[0], ""
+
+    @torch.inference_mode()
+    def generate_interleave_image_tensor(
+        self,
+        request: FlowRequestParams,
+        images: list[Any],
+        *,
+        system_message: str,
+        assistant_prefix: str = "<think>\n\n</think>\n\n<img>",
+    ) -> tuple[torch.Tensor, NativeFlowRunStats]:
+        return self._generate_conditioned_tensor(
+            request,
+            images=[_coerce_image(image) for image in images],
+            system_message=system_message,
+            assistant_append=assistant_prefix,
+        )
+
+    def complete_payload(self, payload: StagePayload) -> dict[str, Any]:
+        inputs, params, request_id = _extract_request(payload)
+        request, images = self._flow_params_from_request(inputs, params)
+        start = time.perf_counter()
+        if request.mode == "t2i":
+            tensor, think_text = self.generate_t2i_tensor(request)
+        else:
+            tensor, think_text = self.generate_it2i_tensor(request, images)
+        elapsed = time.perf_counter() - start
+        pil_images = u1_tensor_to_pil(tensor)
+        return {
+            "request_id": request_id,
+            "mode": request.mode,
+            "images": [
+                {
+                    "type": "image",
+                    "format": "png",
+                    "data": pil_to_data_url(img),
+                    "width": img.width,
+                    "height": img.height,
+                }
+                for img in pil_images
+            ],
+            "think_text": think_text,
+            "scheduler_params": self.scheduler_params(request),
+            "native_flow_stats": self.last_native_flow_stats,
+            "usage": {
+                "image_count": len(pil_images),
+                "num_steps": request.num_steps,
+                "engine_time_s": elapsed,
+            },
+            "stage_name": "u1_flow",
+            "backend": "native_sglang_flow_matching",
         }
 
 
 __all__ = [
     "FlowRequestParams",
+    "SenseNovaU1FlowMatchingFallbackRunner",
     "SenseNovaU1FlowMatchingRunner",
+    "SenseNovaU1NativeFlowModules",
     "compare_pil_images",
     "denormalize_u1_image_tensor",
+    "load_image_native_tensor",
     "pil_to_data_url",
     "u1_tensor_to_pil",
 ]

--- a/sglang_omni/models/sensenova_u1/flow_matching.py
+++ b/sglang_omni/models/sensenova_u1/flow_matching.py
@@ -1,0 +1,362 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SenseNova U1 flow-matching image generation runner.
+
+This is the M3 HF-compatible in-pipeline path. It keeps U1 generation inside a
+SGLang-Omni stage lifecycle, while delegating the exact numerical kernels to
+the official NEOChatModel implementation already used by the M1/M2 fallback.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import math
+import time
+from contextlib import nullcontext
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import numpy as np
+import torch
+from PIL import Image
+
+from sglang_omni.proto import StagePayload
+from sglang_omni.models.sensenova_u1.hf_runner import (
+    DEFAULT_MODEL_DIR,
+    DEFAULT_VENDOR_ROOT,
+    SenseNovaU1UnderstandingRunner,
+    _coerce_image,
+    _extract_request,
+    _official_block_mask_scope,
+)
+
+NORM_MEAN = (0.5, 0.5, 0.5)
+NORM_STD = (0.5, 0.5, 0.5)
+
+
+@dataclass(frozen=True, slots=True)
+class FlowRequestParams:
+    mode: str
+    prompt: str
+    image_size: tuple[int, int] = (256, 256)
+    cfg_scale: float = 1.0
+    img_cfg_scale: float = 1.0
+    cfg_norm: str = "none"
+    timestep_shift: float = 1.0
+    enable_timestep_shift: bool = True
+    cfg_interval: tuple[float, float] = (0.0, 1.0)
+    num_steps: int = 2
+    batch_size: int = 1
+    t_eps: float = 0.05
+    think_mode: bool = False
+    seed: int = 20260813
+
+
+def denormalize_u1_image_tensor(batch: torch.Tensor) -> torch.Tensor:
+    """Convert U1 normalized image tensors from [-1, 1] into [0, 1]."""
+
+    mean = torch.tensor(NORM_MEAN, device=batch.device, dtype=batch.dtype).view(1, 3, 1, 1)
+    std = torch.tensor(NORM_STD, device=batch.device, dtype=batch.dtype).view(1, 3, 1, 1)
+    return (batch * std + mean).clamp(0, 1)
+
+
+def u1_tensor_to_pil(batch: torch.Tensor) -> list[Image.Image]:
+    arr = denormalize_u1_image_tensor(batch.float()).permute(0, 2, 3, 1).cpu().numpy()
+    arr = (arr * 255.0).round().astype(np.uint8)
+    return [Image.fromarray(a) for a in arr]
+
+
+def pil_to_data_url(image: Image.Image) -> str:
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    payload = base64.b64encode(buf.getvalue()).decode("ascii")
+    return f"data:image/png;base64,{payload}"
+
+
+def compare_pil_images(a: Image.Image, b: Image.Image) -> dict[str, Any]:
+    if a.size != b.size:
+        raise ValueError(f"Cannot compare images with different sizes: {a.size} vs {b.size}")
+    arr_a_u8 = np.asarray(a.convert("RGB"), dtype=np.uint8)
+    arr_b_u8 = np.asarray(b.convert("RGB"), dtype=np.uint8)
+    diff = arr_a_u8.astype(np.int16) - arr_b_u8.astype(np.int16)
+    mse = float(np.mean(diff.astype(np.float64) ** 2))
+    psnr = math.inf if mse == 0.0 else float(20.0 * math.log10(255.0 / math.sqrt(mse)))
+    a_float = arr_a_u8.astype(np.float64) / 255.0
+    b_float = arr_b_u8.astype(np.float64) / 255.0
+    mu_a = float(a_float.mean())
+    mu_b = float(b_float.mean())
+    var_a = float(((a_float - mu_a) ** 2).mean())
+    var_b = float(((b_float - mu_b) ** 2).mean())
+    cov = float(((a_float - mu_a) * (b_float - mu_b)).mean())
+    c1 = 0.01**2
+    c2 = 0.03**2
+    ssim = ((2 * mu_a * mu_b + c1) * (2 * cov + c2)) / (
+        (mu_a**2 + mu_b**2 + c1) * (var_a + var_b + c2)
+    )
+    return {
+        "width": a.size[0],
+        "height": a.size[1],
+        "mse_uint8": mse,
+        "psnr_db": psnr,
+        "ssim_global_rgb": float(ssim),
+        "pixel_max_abs_diff_uint8": int(np.abs(diff).max()),
+        "pixel_mean_abs_diff_uint8": float(np.abs(diff).mean()),
+        "exact_png_pixels": bool(np.array_equal(arr_a_u8, arr_b_u8)),
+        "ssim_implementation": "global_rgb_formula",
+    }
+
+
+class SenseNovaU1FlowMatchingRunner(SenseNovaU1UnderstandingRunner):
+    """T2I/IT2I runner for U1 flow matching inside SGLang-Omni."""
+
+    def __init__(
+        self,
+        model_path: str = DEFAULT_MODEL_DIR,
+        *,
+        vendor_root: str | None = None,
+        device: str = "cuda:0",
+        dtype: str | torch.dtype = "bfloat16",
+        attn_backend: str = "auto",
+        load_with_info: bool = False,
+    ) -> None:
+        super().__init__(
+            model_path=model_path,
+            vendor_root=vendor_root or DEFAULT_VENDOR_ROOT,
+            device=device,
+            dtype=dtype,
+            attn_backend=attn_backend,
+            load_with_info=load_with_info,
+        )
+
+    def _flow_params_from_request(self, inputs: Any, params: dict[str, Any]) -> tuple[FlowRequestParams, list[Any]]:
+        data = inputs if isinstance(inputs, dict) else {"prompt": str(inputs)}
+        merged = {**data, **params}
+        mode = str(merged.get("mode") or merged.get("task") or "t2i").lower()
+        if mode in {"text_to_image", "txt2img"}:
+            mode = "t2i"
+        if mode in {"image_to_image", "edit", "editing"}:
+            mode = "it2i"
+        if mode not in {"t2i", "it2i"}:
+            raise ValueError(f"Unsupported U1 flow mode: {mode!r}")
+        width = int(merged.get("width", merged.get("image_width", 256)))
+        height = int(merged.get("height", merged.get("image_height", 256)))
+        cfg_interval_value = merged.get("cfg_interval", (0.0, 1.0))
+        cfg_interval = tuple(float(x) for x in cfg_interval_value)
+        if len(cfg_interval) != 2:
+            raise ValueError("cfg_interval must contain exactly two floats.")
+        images = [_coerce_image(img) for img in (merged.get("images") or [])]
+        if "image" in merged:
+            images.append(_coerce_image(merged["image"]))
+        request = FlowRequestParams(
+            mode=mode,
+            prompt=str(merged.get("prompt", "")),
+            image_size=(width, height),
+            cfg_scale=float(merged.get("cfg_scale", 1.0)),
+            img_cfg_scale=float(merged.get("img_cfg_scale", 1.0)),
+            cfg_norm=str(merged.get("cfg_norm", "none")),
+            timestep_shift=float(merged.get("timestep_shift", 1.0)),
+            enable_timestep_shift=bool(merged.get("enable_timestep_shift", True)),
+            cfg_interval=(float(cfg_interval[0]), float(cfg_interval[1])),
+            num_steps=int(merged.get("num_steps", 2)),
+            batch_size=int(merged.get("batch_size", 1)),
+            t_eps=float(merged.get("t_eps", 0.05)),
+            think_mode=bool(merged.get("think_mode", False)),
+            seed=int(merged.get("seed", 20260813)),
+        )
+        return request, images
+
+    def scheduler_params(self, request: FlowRequestParams) -> dict[str, Any]:
+        assert self.model is not None
+        model = self.model
+        width, height = request.image_size
+        merge_size = int(1 / model.downsample_ratio)
+        token_h = height // (model.patch_size * merge_size)
+        token_w = width // (model.patch_size * merge_size)
+        grid_h = height // model.patch_size
+        grid_w = width // model.patch_size
+        image_seq_len = token_h * token_w
+
+        noise_scale = float(model.noise_scale)
+        if model.noise_scale_mode in ("resolution", "dynamic", "dynamic_sqrt"):
+            base = float(model.noise_scale_base_image_seq_len)
+            scale = math.sqrt((grid_h * grid_w) / (merge_size**2) / base)
+            noise_scale = scale * float(model.noise_scale)
+            if model.noise_scale_mode == "dynamic_sqrt":
+                noise_scale = math.sqrt(noise_scale)
+        noise_scale = min(noise_scale, float(model.noise_scale_max_value))
+
+        timesteps = torch.linspace(0.0, 1.0, request.num_steps + 1, device=self.torch_device)
+        if request.enable_timestep_shift:
+            timesteps = model._apply_time_schedule(
+                timesteps,
+                image_seq_len,
+                request.timestep_shift,
+            )
+        t_values = [float(x) for x in timesteps.detach().cpu().tolist()]
+        step_table = [
+            {
+                "step": i,
+                "t": t_values[i],
+                "t_next": t_values[i + 1],
+                "dt": t_values[i + 1] - t_values[i],
+                "use_cfg": bool(
+                    (
+                        t_values[i] > request.cfg_interval[0]
+                        and t_values[i] < request.cfg_interval[1]
+                    )
+                    or request.cfg_interval[0] == 0
+                ),
+            }
+            for i in range(request.num_steps)
+        ]
+        config_keys = [
+            "fm_head_dim",
+            "fm_head_layers",
+            "fm_head_mlp_ratio",
+            "timestep_shift",
+            "time_schedule",
+            "time_shift_type",
+            "base_shift",
+            "max_shift",
+            "base_image_seq_len",
+            "max_image_seq_len",
+            "noise_scale",
+            "noise_scale_mode",
+            "noise_scale_base_image_seq_len",
+            "noise_scale_max_value",
+            "add_noise_scale_embedding",
+            "P_mean",
+            "P_std",
+            "t_eps",
+            "use_pixel_head",
+            "use_adaLN",
+        ]
+        raw_config = {
+            key: getattr(model.config, key, getattr(model, key, None))
+            for key in config_keys
+        }
+        return {
+            "backend": "sglang_omni_sensenova_u1_flow_matching_hf_compatible",
+            "request": asdict(request),
+            "patch_size": int(model.patch_size),
+            "downsample_ratio": float(model.downsample_ratio),
+            "merge_size": merge_size,
+            "grid_h": grid_h,
+            "grid_w": grid_w,
+            "token_h": token_h,
+            "token_w": token_w,
+            "image_seq_len": image_seq_len,
+            "computed_noise_scale": noise_scale,
+            "raw_config": raw_config,
+            "timesteps": t_values,
+            "step_table": step_table,
+        }
+
+    @torch.inference_mode()
+    def generate_t2i_tensor(
+        self,
+        request: FlowRequestParams,
+        *,
+        use_official_hybrid_mask: bool = False,
+    ) -> tuple[torch.Tensor, str]:
+        assert self.model is not None and self.tokenizer is not None
+        ctx = _official_block_mask_scope() if use_official_hybrid_mask else nullcontext()
+        with ctx:
+            output = self.model.t2i_generate(
+                self.tokenizer,
+                request.prompt,
+                image_size=request.image_size,
+                cfg_scale=request.cfg_scale,
+                cfg_norm=request.cfg_norm,
+                timestep_shift=request.timestep_shift,
+                enable_timestep_shift=request.enable_timestep_shift,
+                cfg_interval=request.cfg_interval,
+                num_steps=request.num_steps,
+                batch_size=request.batch_size,
+                t_eps=request.t_eps,
+                think_mode=request.think_mode,
+                seed=request.seed,
+            )
+        if request.think_mode:
+            tensor, think_text = output
+            return tensor.detach(), str(think_text)
+        return output.detach(), ""
+
+    @torch.inference_mode()
+    def generate_it2i_tensor(
+        self,
+        request: FlowRequestParams,
+        images: list[Any],
+        *,
+        use_official_hybrid_mask: bool = False,
+    ) -> tuple[torch.Tensor, str]:
+        assert self.model is not None and self.tokenizer is not None
+        if not images:
+            raise ValueError("IT2I generation requires at least one input image.")
+        ctx = _official_block_mask_scope() if use_official_hybrid_mask else nullcontext()
+        with ctx:
+            output = self.model.it2i_generate(
+                self.tokenizer,
+                request.prompt,
+                [_coerce_image(image) for image in images],
+                image_size=request.image_size,
+                cfg_scale=request.cfg_scale,
+                img_cfg_scale=request.img_cfg_scale,
+                cfg_norm=request.cfg_norm,
+                timestep_shift=request.timestep_shift,
+                enable_timestep_shift=request.enable_timestep_shift,
+                cfg_interval=request.cfg_interval,
+                num_steps=request.num_steps,
+                batch_size=request.batch_size,
+                t_eps=request.t_eps,
+                think_mode=request.think_mode,
+                seed=request.seed,
+            )
+        if request.think_mode:
+            tensor, think_text = output
+            return tensor.detach(), str(think_text)
+        return output.detach(), ""
+
+    def complete_payload(self, payload: StagePayload) -> dict[str, Any]:
+        inputs, params, request_id = _extract_request(payload)
+        request, images = self._flow_params_from_request(inputs, params)
+        start = time.perf_counter()
+        if request.mode == "t2i":
+            tensor, think_text = self.generate_t2i_tensor(request)
+        else:
+            tensor, think_text = self.generate_it2i_tensor(request, images)
+        elapsed = time.perf_counter() - start
+        pil_images = u1_tensor_to_pil(tensor)
+        return {
+            "request_id": request_id,
+            "mode": request.mode,
+            "images": [
+                {
+                    "type": "image",
+                    "format": "png",
+                    "data": pil_to_data_url(img),
+                    "width": img.width,
+                    "height": img.height,
+                }
+                for img in pil_images
+            ],
+            "think_text": think_text,
+            "scheduler_params": self.scheduler_params(request),
+            "usage": {
+                "image_count": len(pil_images),
+                "num_steps": request.num_steps,
+                "engine_time_s": elapsed,
+            },
+            "stage_name": "u1_flow",
+            "backend": "hf_compatible_flow_matching_fallback",
+        }
+
+
+__all__ = [
+    "FlowRequestParams",
+    "SenseNovaU1FlowMatchingRunner",
+    "compare_pil_images",
+    "denormalize_u1_image_tensor",
+    "pil_to_data_url",
+    "u1_tensor_to_pil",
+]

--- a/sglang_omni/models/sensenova_u1/flow_matching.py
+++ b/sglang_omni/models/sensenova_u1/flow_matching.py
@@ -28,6 +28,17 @@ from safetensors import safe_open
 from torch import nn
 from transformers import AutoTokenizer
 
+from sglang_omni.models.sensenova_u1.limits import (
+    U1_MAX_TOTAL_TOKENS,
+    generated_image_token_count,
+    parse_int_param,
+    validate_image_count,
+    validate_image_size,
+    validate_input_image_count,
+    validate_num_steps,
+    validate_token_budget_components,
+    validate_total_token_budget,
+)
 from sglang_omni.models.sensenova_u1.native_serving import (
     SenseNovaU1NativeServingExecutor,
 )
@@ -432,6 +443,75 @@ def compare_pil_images(a: Image.Image, b: Image.Image) -> dict[str, Any]:
     }
 
 
+def _validated_flow_params_from_request(
+    inputs: Any,
+    params: dict[str, Any],
+    *,
+    max_total_tokens: int,
+) -> tuple[FlowRequestParams, list[Any]]:
+    data = inputs if isinstance(inputs, dict) else {"prompt": str(inputs)}
+    merged = {**data, **params}
+    mode = str(merged.get("mode") or merged.get("task") or "t2i").lower()
+    if mode in {"text_to_image", "txt2img"}:
+        mode = "t2i"
+    if mode in {"image_to_image", "edit", "editing"}:
+        mode = "it2i"
+    if mode not in {"t2i", "it2i"}:
+        raise ValueError(f"Unsupported U1 flow mode: {mode!r}")
+    width, height = validate_image_size(
+        merged.get("width", merged.get("image_width", 256)),
+        merged.get("height", merged.get("image_height", 256)),
+    )
+    cfg_interval_value = merged.get("cfg_interval", (0.0, 1.0))
+    try:
+        cfg_interval = tuple(float(x) for x in cfg_interval_value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("cfg_interval must contain exactly two floats.") from exc
+    if len(cfg_interval) != 2:
+        raise ValueError("cfg_interval must contain exactly two floats.")
+    raw_images = merged.get("images")
+    if raw_images is None:
+        raw_images = []
+    if not isinstance(raw_images, (list, tuple)):
+        raise ValueError("images must be a list or tuple.")
+    raw_images = list(raw_images)
+    if "image" in merged:
+        raw_images.append(merged["image"])
+    validate_input_image_count(raw_images)
+    images = [_coerce_image(img) for img in raw_images]
+    num_steps = validate_num_steps(merged.get("num_steps", 2))
+    batch_size = validate_image_count(
+        merged.get("batch_size", 1),
+        name="batch_size",
+        maximum=1,
+    )
+    validate_total_token_budget(
+        image_size=(width, height),
+        image_count=batch_size,
+        max_total_tokens=max_total_tokens,
+    )
+    request = FlowRequestParams(
+        mode=mode,
+        prompt=str(merged.get("prompt", "")),
+        image_size=(width, height),
+        cfg_scale=float(merged.get("cfg_scale", 1.0)),
+        img_cfg_scale=float(merged.get("img_cfg_scale", 1.0)),
+        cfg_norm=str(merged.get("cfg_norm", "none")),
+        timestep_shift=float(merged.get("timestep_shift", 1.0)),
+        enable_timestep_shift=bool(merged.get("enable_timestep_shift", True)),
+        cfg_interval=(float(cfg_interval[0]), float(cfg_interval[1])),
+        num_steps=num_steps,
+        batch_size=batch_size,
+        t_eps=float(merged.get("t_eps", 0.05)),
+        think_mode=bool(merged.get("think_mode", False)),
+        seed=parse_int_param(
+            merged.get("seed", 20260813),
+            name="seed",
+        ),
+    )
+    return request, images
+
+
 class SenseNovaU1FlowMatchingFallbackRunner(SenseNovaU1UnderstandingRunner):
     """T2I/IT2I runner for U1 flow matching inside SGLang-Omni."""
 
@@ -454,42 +534,16 @@ class SenseNovaU1FlowMatchingFallbackRunner(SenseNovaU1UnderstandingRunner):
             load_with_info=load_with_info,
         )
 
-    def _flow_params_from_request(self, inputs: Any, params: dict[str, Any]) -> tuple[FlowRequestParams, list[Any]]:
-        data = inputs if isinstance(inputs, dict) else {"prompt": str(inputs)}
-        merged = {**data, **params}
-        mode = str(merged.get("mode") or merged.get("task") or "t2i").lower()
-        if mode in {"text_to_image", "txt2img"}:
-            mode = "t2i"
-        if mode in {"image_to_image", "edit", "editing"}:
-            mode = "it2i"
-        if mode not in {"t2i", "it2i"}:
-            raise ValueError(f"Unsupported U1 flow mode: {mode!r}")
-        width = int(merged.get("width", merged.get("image_width", 256)))
-        height = int(merged.get("height", merged.get("image_height", 256)))
-        cfg_interval_value = merged.get("cfg_interval", (0.0, 1.0))
-        cfg_interval = tuple(float(x) for x in cfg_interval_value)
-        if len(cfg_interval) != 2:
-            raise ValueError("cfg_interval must contain exactly two floats.")
-        images = [_coerce_image(img) for img in (merged.get("images") or [])]
-        if "image" in merged:
-            images.append(_coerce_image(merged["image"]))
-        request = FlowRequestParams(
-            mode=mode,
-            prompt=str(merged.get("prompt", "")),
-            image_size=(width, height),
-            cfg_scale=float(merged.get("cfg_scale", 1.0)),
-            img_cfg_scale=float(merged.get("img_cfg_scale", 1.0)),
-            cfg_norm=str(merged.get("cfg_norm", "none")),
-            timestep_shift=float(merged.get("timestep_shift", 1.0)),
-            enable_timestep_shift=bool(merged.get("enable_timestep_shift", True)),
-            cfg_interval=(float(cfg_interval[0]), float(cfg_interval[1])),
-            num_steps=int(merged.get("num_steps", 2)),
-            batch_size=int(merged.get("batch_size", 1)),
-            t_eps=float(merged.get("t_eps", 0.05)),
-            think_mode=bool(merged.get("think_mode", False)),
-            seed=int(merged.get("seed", 20260813)),
+    def _flow_params_from_request(
+        self,
+        inputs: Any,
+        params: dict[str, Any],
+    ) -> tuple[FlowRequestParams, list[Any]]:
+        return _validated_flow_params_from_request(
+            inputs,
+            params,
+            max_total_tokens=U1_MAX_TOTAL_TOKENS,
         )
-        return request, images
 
     def scheduler_params(self, request: FlowRequestParams) -> dict[str, Any]:
         assert self.model is not None
@@ -698,8 +752,13 @@ class SenseNovaU1FlowMatchingRunner:
         attention_backend: str | None = None,
         load_with_info: bool = False,
         mem_fraction_static: float = 0.65,
-        max_total_tokens: int = 8192,
+        max_total_tokens: int = U1_MAX_TOTAL_TOKENS,
         max_running_requests: int = 2,
+        eager_prefix_cache_max_entries: int = 4,
+        eager_decode_graph_cache_max_entries: int = 2,
+        eager_decode_graph_max_captures: int = 4,
+        eager_prefix_cache_max_tokens: int = 2048,
+        eager_decode_graph_max_total_tokens: int = 1024,
     ) -> None:
         del vendor_root, load_with_info
         assert_no_hf_modeling_imported(context="before native flow runner init")
@@ -729,6 +788,9 @@ class SenseNovaU1FlowMatchingRunner:
         self.max_shift = float(self.raw_config.get("max_shift", 1.15))
         self.base_image_seq_len = int(self.raw_config.get("base_image_seq_len", 64))
         self.max_image_seq_len = int(self.raw_config.get("max_image_seq_len", 4096))
+        self.max_total_tokens = int(max_total_tokens)
+        if self.max_total_tokens <= 0:
+            raise ValueError("max_total_tokens must be positive")
         self.last_native_flow_stats: dict[str, Any] = {}
         self.native_flow_prefill_cuda_graph_enabled = (
             self._native_flow_prefill_cuda_graph_enabled()
@@ -762,6 +824,17 @@ class SenseNovaU1FlowMatchingRunner:
                 max_total_tokens=max_total_tokens,
                 max_running_requests=max_running_requests,
                 enable_radix_cache=True,
+                eager_prefix_cache_max_entries=eager_prefix_cache_max_entries,
+                eager_decode_graph_cache_max_entries=(
+                    eager_decode_graph_cache_max_entries
+                ),
+                eager_decode_graph_max_captures=(
+                    eager_decode_graph_max_captures
+                ),
+                eager_prefix_cache_max_tokens=eager_prefix_cache_max_tokens,
+                eager_decode_graph_max_total_tokens=(
+                    eager_decode_graph_max_total_tokens
+                ),
                 prefill_cuda_graph_backend=(
                     "breakable"
                     if self.native_flow_prefill_cuda_graph_enabled
@@ -788,6 +861,9 @@ class SenseNovaU1FlowMatchingRunner:
         self.img_start_token_id = int(self.tokenizer.convert_tokens_to_ids("<img>"))
         self.img_end_token_id = int(self.tokenizer.convert_tokens_to_ids("</img>"))
         assert_no_hf_modeling_imported(context="after native flow runner init")
+
+    def shutdown(self) -> None:
+        self.executor.shutdown()
 
     def _calculate_dynamic_mu(self, image_seq_len: int) -> float:
         denom = self.max_image_seq_len - self.base_image_seq_len
@@ -1049,6 +1125,7 @@ class SenseNovaU1FlowMatchingRunner:
         images: list[Any],
         system_message: str,
         assistant_append: str,
+        reserved_image_tokens: int = 0,
     ) -> NativeFlowPrefix:
         image_count = prompt.count("<image>")
         if len(images) > image_count:
@@ -1066,6 +1143,12 @@ class SenseNovaU1FlowMatchingRunner:
         )
         query = self._replace_image_tokens(query, grid_hw)
         input_ids = self.tokenizer(query, return_tensors="pt")["input_ids"][0]
+        validate_token_budget_components(
+            prefix_tokens=int(input_ids.numel()),
+            text_tokens=0,
+            image_tokens=int(reserved_image_tokens),
+            max_total_tokens=self.max_total_tokens,
+        )
         indexes = self._get_thw_indexes(input_ids, grid_hw)
         image_token_tag = input_ids == self.img_context_token_id
         if pixel_values is not None and grid_hw is not None:
@@ -1253,18 +1336,34 @@ class SenseNovaU1FlowMatchingRunner:
         system_message: str,
         assistant_append: str,
     ) -> tuple[torch.Tensor, NativeFlowRunStats]:
-        if request.batch_size != 1:
-            raise NotImplementedError("native U1 flow supports batch_size=1 in this path")
+        width, height = validate_image_size(*request.image_size)
+        num_steps = validate_num_steps(request.num_steps)
+        batch_size = validate_image_count(
+            request.batch_size,
+            name="batch_size",
+            maximum=1,
+        )
+        validate_input_image_count(images)
+        if batch_size != 1:
+            raise NotImplementedError(
+                "native U1 flow supports batch_size=1 in this path"
+            )
         if request.cfg_scale != 1.0 or request.img_cfg_scale != 1.0:
             raise NotImplementedError("native U1 flow path currently supports cfg scales of 1.0")
         assert_no_hf_modeling_imported(context="before native flow generation")
-        width, height = request.image_size
         merge_size = int(1 / self.downsample_ratio)
         token_h = height // (self.patch_size * merge_size)
         token_w = width // (self.patch_size * merge_size)
         grid_h = height // self.patch_size
         grid_w = width // self.patch_size
         image_token_num = token_h * token_w
+        if image_token_num != generated_image_token_count((width, height)):
+            raise RuntimeError("native U1 generated image token geometry mismatch")
+        validate_total_token_budget(
+            image_size=(width, height),
+            image_count=batch_size,
+            max_total_tokens=self.max_total_tokens,
+        )
         gen_grid_hw = torch.tensor(
             [[grid_h, grid_w]],
             dtype=torch.long,
@@ -1275,6 +1374,7 @@ class SenseNovaU1FlowMatchingRunner:
             images=images,
             system_message=system_message,
             assistant_append=assistant_append,
+            reserved_image_tokens=image_token_num,
         )
         self._prime_prefix_cache(prefix)
         image_t_index = int(prefix.indexes[0].max().item()) + 1
@@ -1295,7 +1395,7 @@ class SenseNovaU1FlowMatchingRunner:
         timesteps = torch.linspace(
             0.0,
             1.0,
-            request.num_steps + 1,
+            num_steps + 1,
             device=self.torch_device,
         )
         if request.enable_timestep_shift:
@@ -1308,7 +1408,7 @@ class SenseNovaU1FlowMatchingRunner:
         forward_elapsed: list[float] = []
         hidden_logs: list[dict[str, Any]] = []
         backend_name = None
-        for step_i in range(request.num_steps):
+        for step_i in range(num_steps):
             t = timesteps[step_i]
             t_next = timesteps[step_i + 1]
             z = self.patchify(image_prediction, self.patch_size * merge_size)
@@ -1367,42 +1467,16 @@ class SenseNovaU1FlowMatchingRunner:
         assert_no_hf_modeling_imported(context="after native flow generation")
         return image_prediction.detach(), stats
 
-    def _flow_params_from_request(self, inputs: Any, params: dict[str, Any]) -> tuple[FlowRequestParams, list[Any]]:
-        data = inputs if isinstance(inputs, dict) else {"prompt": str(inputs)}
-        merged = {**data, **params}
-        mode = str(merged.get("mode") or merged.get("task") or "t2i").lower()
-        if mode in {"text_to_image", "txt2img"}:
-            mode = "t2i"
-        if mode in {"image_to_image", "edit", "editing"}:
-            mode = "it2i"
-        if mode not in {"t2i", "it2i"}:
-            raise ValueError(f"Unsupported U1 flow mode: {mode!r}")
-        width = int(merged.get("width", merged.get("image_width", 256)))
-        height = int(merged.get("height", merged.get("image_height", 256)))
-        cfg_interval_value = merged.get("cfg_interval", (0.0, 1.0))
-        cfg_interval = tuple(float(x) for x in cfg_interval_value)
-        if len(cfg_interval) != 2:
-            raise ValueError("cfg_interval must contain exactly two floats.")
-        images = [_coerce_image(img) for img in (merged.get("images") or [])]
-        if "image" in merged:
-            images.append(_coerce_image(merged["image"]))
-        request = FlowRequestParams(
-            mode=mode,
-            prompt=str(merged.get("prompt", "")),
-            image_size=(width, height),
-            cfg_scale=float(merged.get("cfg_scale", 1.0)),
-            img_cfg_scale=float(merged.get("img_cfg_scale", 1.0)),
-            cfg_norm=str(merged.get("cfg_norm", "none")),
-            timestep_shift=float(merged.get("timestep_shift", 1.0)),
-            enable_timestep_shift=bool(merged.get("enable_timestep_shift", True)),
-            cfg_interval=(float(cfg_interval[0]), float(cfg_interval[1])),
-            num_steps=int(merged.get("num_steps", 2)),
-            batch_size=int(merged.get("batch_size", 1)),
-            t_eps=float(merged.get("t_eps", 0.05)),
-            think_mode=bool(merged.get("think_mode", False)),
-            seed=int(merged.get("seed", 20260813)),
+    def _flow_params_from_request(
+        self,
+        inputs: Any,
+        params: dict[str, Any],
+    ) -> tuple[FlowRequestParams, list[Any]]:
+        return _validated_flow_params_from_request(
+            inputs,
+            params,
+            max_total_tokens=self.max_total_tokens,
         )
-        return request, images
 
     @torch.inference_mode()
     def generate_t2i_tensor(

--- a/sglang_omni/models/sensenova_u1/hf_config.py
+++ b/sglang_omni/models/sensenova_u1/hf_config.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native-only config loader for SenseNova U1 SGLang serving."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from transformers import PretrainedConfig, Qwen3Config
+
+_parser_registered = False
+
+_U1_LLM_EXTRA_FIELDS = (
+    "rope_theta",
+    "rope_theta_hw",
+    "max_position_embeddings_hw",
+    "pure_llm",
+    "use_deepep",
+)
+
+
+def _build_u1_llm_config(raw: Qwen3Config | dict[str, Any] | None) -> Qwen3Config | None:
+    if raw is None or isinstance(raw, Qwen3Config):
+        return raw
+    cfg = Qwen3Config(**raw)
+    for key in _U1_LLM_EXTRA_FIELDS:
+        if key in raw:
+            setattr(cfg, key, raw[key])
+    return cfg
+
+
+class SenseNovaU1NativeConfig(PretrainedConfig):
+    """Top-level U1 config without importing official HF modeling code."""
+
+    model_type = "neo_chat"
+    sub_configs = {"llm_config": Qwen3Config}
+
+    def __init__(
+        self,
+        llm_config: Qwen3Config | dict[str, Any] | None = None,
+        vision_config: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        kwargs.pop("auto_map", None)
+        llm_config = _build_u1_llm_config(llm_config)
+        self.llm_config = llm_config
+        self.vision_config = dict(vision_config or {})
+        super().__init__(**kwargs)
+        self.architectures = ["SenseNovaU1NativeForCausalLM"]
+
+    @classmethod
+    def from_dict(
+        cls,
+        config_dict: dict[str, Any],
+        **kwargs: Any,
+    ) -> "SenseNovaU1NativeConfig":
+        clean = dict(config_dict)
+        clean.pop("auto_map", None)
+        return super().from_dict(clean, **kwargs)
+
+
+def register_sensenova_u1_native_config_parser() -> None:
+    """Register a parser that reads U1 config.json without remote code."""
+
+    global _parser_registered
+    if _parser_registered:
+        return
+
+    from sglang.srt.configs.model_config_parser_registry import (
+        ModelConfigParserBase,
+        register_model_config_parser,
+    )
+
+    @register_model_config_parser("sensenova_u1_native")
+    class SenseNovaU1NativeModelConfigParser(ModelConfigParserBase):
+        def parse(
+            self,
+            model,
+            trust_remote_code: bool,
+            revision: str | None = None,
+            **kwargs: Any,
+        ):
+            del trust_remote_code, revision
+            config_path = Path(str(model)) / "config.json"
+            raw = json.loads(config_path.read_text(encoding="utf-8"))
+            config = SenseNovaU1NativeConfig.from_dict(
+                raw,
+                name_or_path=str(model),
+                **kwargs,
+            )
+            text_config = config.llm_config
+            for key, value in vars(text_config).items():
+                if not hasattr(config, key) and value is not None:
+                    setattr(config, key, value)
+            return config
+
+    _parser_registered = True
+
+
+__all__ = [
+    "SenseNovaU1NativeConfig",
+    "register_sensenova_u1_native_config_parser",
+]

--- a/sglang_omni/models/sensenova_u1/hf_runner.py
+++ b/sglang_omni/models/sensenova_u1/hf_runner.py
@@ -1,0 +1,660 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HF-compatible SenseNova U1 understanding runner.
+
+This is the M1 fallback path. It lives inside SGLang-Omni's pipeline registry
+and request lifecycle, but delegates U1 math to the official NEOChatModel
+implementation. The native SGLang attention path still needs the M2 hybrid
+image-span mask before it can claim parity.
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import io
+import json
+import os
+import sys
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from PIL import Image
+
+from sglang_omni.proto import StagePayload
+
+SENSENOVA_U1_VENDOR_ROOT_ENV = "SENSENOVA_U1_VENDOR_ROOT"
+SENSENOVA_U1_MODEL_PATH_ENV = "SENSENOVA_U1_MODEL_PATH"
+DEFAULT_VENDOR_ROOT: str | None = None
+DEFAULT_MODEL_DIR = os.environ.get(
+    SENSENOVA_U1_MODEL_PATH_ENV,
+    "sensenova/SenseNova-U1-8B-MoT-Interleaved",
+)
+DEFAULT_VQA_MIN_PIXELS = 65536
+DEFAULT_VQA_MAX_PIXELS = 4194304
+
+
+@dataclass(slots=True)
+class PreparedVQA:
+    question: str
+    query: str
+    input_ids: torch.Tensor
+    attention_mask: torch.Tensor
+    indexes: torch.Tensor
+    image_token_tag: torch.Tensor
+    pixel_values: torch.Tensor | None
+    grid_hw: torch.Tensor | None
+
+
+def _dtype_from_name(name: str) -> torch.dtype:
+    normalized = str(name).lower()
+    if normalized in {"bf16", "bfloat16"}:
+        return torch.bfloat16
+    if normalized in {"fp16", "float16", "half"}:
+        return torch.float16
+    if normalized in {"fp32", "float32"}:
+        return torch.float32
+    if normalized == "auto":
+        return torch.bfloat16
+    raise ValueError(f"Unsupported SenseNova U1 dtype: {name!r}")
+
+
+def _ensure_vendor_import(vendor_root: str | None) -> Path:
+    root_value = vendor_root or os.environ.get(SENSENOVA_U1_VENDOR_ROOT_ENV)
+    if not root_value:
+        spec = importlib.util.find_spec("sensenova_u1")
+        if spec is not None and spec.origin:
+            return Path(spec.origin).resolve().parent
+        raise FileNotFoundError(
+            "SenseNova-U1 Python package is not importable. Install it or set "
+            f"{SENSENOVA_U1_VENDOR_ROOT_ENV} to a checkout containing src/sensenova_u1."
+        )
+
+    root = Path(root_value)
+    src = root / "src"
+    if not src.exists():
+        raise FileNotFoundError(
+            f"SenseNova-U1 source not found at {src}. Set {SENSENOVA_U1_VENDOR_ROOT_ENV}."
+        )
+    src_str = str(src)
+    if src_str not in sys.path:
+        sys.path.insert(0, src_str)
+    return root
+
+
+def _load_raw_config(model_path: str) -> dict[str, Any]:
+    config_path = Path(model_path) / "config.json"
+    if not config_path.exists():
+        return {}
+    return json.loads(config_path.read_text())
+
+
+def _missing_attr(obj: Any, name: str) -> bool:
+    try:
+        getattr(obj, name)
+    except AttributeError:
+        return True
+    return False
+
+
+def _patch_llm_config_compat(config: Any, model_path: str) -> None:
+    """Restore raw U1 config fields hidden by newer Transformers Qwen3Config.
+
+    The public U1 source expects legacy attributes such as ``rope_theta``.
+    Transformers 4.57 can normalize Qwen3 rotary settings into newer internal
+    fields, which breaks the unmodified U1 implementation at construction time.
+    """
+
+    llm_config = getattr(config, "llm_config", None)
+    if llm_config is None:
+        return
+    raw_llm = (_load_raw_config(model_path).get("llm_config") or {})
+    if not isinstance(raw_llm, dict):
+        raw_llm = {}
+
+    for key, value in raw_llm.items():
+        if _missing_attr(llm_config, key):
+            setattr(llm_config, key, value)
+
+    rope_parameters = getattr(llm_config, "rope_parameters", None)
+    if _missing_attr(llm_config, "rope_theta"):
+        if isinstance(rope_parameters, dict) and "rope_theta" in rope_parameters:
+            setattr(llm_config, "rope_theta", rope_parameters["rope_theta"])
+        elif "rope_theta" in raw_llm:
+            setattr(llm_config, "rope_theta", raw_llm["rope_theta"])
+
+    layer_types = getattr(llm_config, "layer_types", None)
+    num_layers = int(getattr(llm_config, "num_hidden_layers"))
+    if not layer_types or len(layer_types) != num_layers:
+        use_swa = bool(getattr(llm_config, "use_sliding_window", False)) and (
+            getattr(llm_config, "sliding_window", None) is not None
+        )
+        max_window_layers = int(getattr(llm_config, "max_window_layers", 0) or 0)
+        setattr(
+            llm_config,
+            "layer_types",
+            [
+                "sliding_attention" if (use_swa and i >= max_window_layers) else "full_attention"
+                for i in range(num_layers)
+            ],
+        )
+
+
+def _patch_model_class_compat() -> None:
+    import sensenova_u1.models.neo_unify.modeling_neo_chat as modeling_neo_chat
+    import sensenova_u1.models.neo_unify.modeling_qwen3 as modeling_qwen3
+    import sensenova_u1.models.neo_unify.modeling_qwen3_moe as modeling_qwen3_moe
+
+    from sensenova_u1.models.neo_unify.modeling_neo_chat import NEOChatModel
+    from sensenova_u1.models.neo_unify.modeling_qwen3 import Qwen3RotaryEmbedding
+    from sglang_omni.models.sensenova_u1.hybrid_attention import create_u1_hybrid_mask
+    from transformers.masking_utils import create_causal_mask as hf_create_causal_mask
+
+    if not hasattr(NEOChatModel, "all_tied_weights_keys"):
+        # U1 checkpoints set tie_word_embeddings=false. Transformers 4.57's
+        # loader finalizer still expects the new instance attribute even when
+        # the model class does not call post_init().
+        NEOChatModel.all_tied_weights_keys = {}
+    if not hasattr(Qwen3RotaryEmbedding, "compute_default_rope_parameters"):
+        # Transformers 4.57's generic initializer recognizes any class named
+        # *RotaryEmbedding and calls this newer helper for default RoPE. U1's
+        # implementation already stores the correct initializer as rope_init_fn.
+        def _compute_default_rope_parameters(self, config=None, device=None, **_kwargs):
+            return self.rope_init_fn(config or self.config, device)
+
+        Qwen3RotaryEmbedding.compute_default_rope_parameters = (
+            _compute_default_rope_parameters
+        )
+
+    if not getattr(modeling_qwen3, "_sglang_omni_mask_compat", False):
+        def _create_causal_mask_compat(*args, **kwargs):
+            if "input_embeds" in kwargs and "inputs_embeds" not in kwargs:
+                kwargs["inputs_embeds"] = kwargs.pop("input_embeds")
+            kwargs.pop("cache_position", None)
+            return hf_create_causal_mask(*args, **kwargs)
+
+        modeling_qwen3.create_causal_mask = _create_causal_mask_compat
+        if hasattr(modeling_qwen3_moe, "create_causal_mask"):
+            modeling_qwen3_moe.create_causal_mask = _create_causal_mask_compat
+        modeling_qwen3._sglang_omni_mask_compat = True
+
+    for module in (modeling_qwen3, modeling_qwen3_moe, modeling_neo_chat):
+        if hasattr(module, "create_block_causal_mask"):
+            if not hasattr(module, "_sglang_omni_original_create_block_causal_mask"):
+                module._sglang_omni_original_create_block_causal_mask = (
+                    module.create_block_causal_mask
+                )
+            module.create_block_causal_mask = create_u1_hybrid_mask
+
+
+@contextmanager
+def _official_block_mask_scope():
+    """Temporarily restore official U1 block mask functions for references."""
+
+    import sensenova_u1.models.neo_unify.modeling_neo_chat as modeling_neo_chat
+    import sensenova_u1.models.neo_unify.modeling_qwen3 as modeling_qwen3
+    import sensenova_u1.models.neo_unify.modeling_qwen3_moe as modeling_qwen3_moe
+
+    modules = [modeling_qwen3, modeling_qwen3_moe, modeling_neo_chat]
+    saved: list[tuple[Any, Any]] = []
+    for module in modules:
+        if not hasattr(module, "create_block_causal_mask"):
+            continue
+        saved.append((module, module.create_block_causal_mask))
+        original = getattr(module, "_sglang_omni_original_create_block_causal_mask", None)
+        if original is not None:
+            module.create_block_causal_mask = original
+    try:
+        yield
+    finally:
+        for module, function in saved:
+            module.create_block_causal_mask = function
+
+
+def _image_from_data_url(value: str) -> Image.Image:
+    _, _, encoded = value.partition(",")
+    if not encoded:
+        raise ValueError("image data URL is missing base64 payload")
+    return Image.open(io.BytesIO(base64.b64decode(encoded)))
+
+
+def _coerce_image(value: Any) -> Any:
+    if isinstance(value, Image.Image):
+        return value
+    if isinstance(value, dict):
+        if "path" in value:
+            return value["path"]
+        if "image" in value:
+            return _coerce_image(value["image"])
+        if "image_url" in value:
+            image_url = value["image_url"]
+            if isinstance(image_url, dict):
+                image_url = image_url.get("url")
+            return _coerce_image(image_url)
+        if "url" in value:
+            return _coerce_image(value["url"])
+    if isinstance(value, str) and value.startswith("data:image/"):
+        return _image_from_data_url(value)
+    return value
+
+
+def _extract_text_and_images_from_content(content: Any) -> tuple[str, list[Any]]:
+    images: list[Any] = []
+    if isinstance(content, str):
+        return content, images
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                typ = item.get("type")
+                if typ == "text" or "text" in item:
+                    text = item.get("text")
+                    if isinstance(text, str):
+                        parts.append(text)
+                elif typ in {"image_url", "image"} or "image_url" in item or "image" in item:
+                    images.append(_coerce_image(item))
+        return "\n".join(part for part in parts if part), images
+    return str(content), images
+
+
+def _extract_request(payload_or_inputs: StagePayload | Any) -> tuple[Any, dict[str, Any], str]:
+    if isinstance(payload_or_inputs, StagePayload):
+        return (
+            payload_or_inputs.request.inputs,
+            payload_or_inputs.request.params,
+            payload_or_inputs.request_id,
+        )
+    return payload_or_inputs, {}, "local"
+
+
+def _extract_question_images_history(inputs: Any) -> tuple[str, list[Any], list[tuple[str, str]]]:
+    images: list[Any] = []
+    history: list[tuple[str, str]] = []
+
+    if isinstance(inputs, str):
+        return inputs, images, history
+
+    if isinstance(inputs, dict):
+        images.extend(_coerce_image(img) for img in inputs.get("images") or [])
+        if "image" in inputs:
+            images.append(_coerce_image(inputs["image"]))
+        if "question" in inputs:
+            return str(inputs["question"]), images, history
+        if "prompt" in inputs:
+            return str(inputs["prompt"]), images, history
+        if "messages" in inputs:
+            inputs = inputs["messages"]
+        else:
+            return str(inputs), images, history
+
+    if isinstance(inputs, list):
+        pending_user: str | None = None
+        for msg in inputs:
+            if not isinstance(msg, dict):
+                pending_user = str(msg)
+                continue
+            role = str(msg.get("role", "user"))
+            text, msg_images = _extract_text_and_images_from_content(msg.get("content", ""))
+            images.extend(_coerce_image(img) for img in msg_images)
+            if role == "user":
+                pending_user = text
+            elif role == "assistant" and pending_user is not None:
+                history.append((pending_user, text))
+                pending_user = None
+        return pending_user or "", images, history
+
+    return str(inputs), images, history
+
+
+class SenseNovaU1UnderstandingRunner:
+    def __init__(
+        self,
+        model_path: str = DEFAULT_MODEL_DIR,
+        *,
+        vendor_root: str | None = None,
+        device: str = "cuda:0",
+        dtype: str | torch.dtype = "bfloat16",
+        attn_backend: str = "auto",
+        min_pixels: int | None = None,
+        max_pixels: int | None = None,
+        load_with_info: bool = False,
+    ) -> None:
+        self.model_path = str(model_path)
+        self.vendor_root = _ensure_vendor_import(vendor_root)
+        self.device = str(device)
+        self.dtype = dtype if isinstance(dtype, torch.dtype) else _dtype_from_name(dtype)
+        self.attn_backend = attn_backend
+        self.min_pixels = min_pixels
+        self.max_pixels = max_pixels
+        self.model = None
+        self.tokenizer = None
+        self.loading_info: dict[str, Any] = {}
+        self.load(load_with_info=load_with_info)
+
+    def load(self, *, load_with_info: bool = False) -> None:
+        import sensenova_u1
+        from sensenova_u1 import check_checkpoint_compatibility
+        from transformers import AutoConfig, AutoModel, AutoTokenizer
+
+        _patch_model_class_compat()
+        sensenova_u1.set_attn_backend(self.attn_backend)
+        config = AutoConfig.from_pretrained(self.model_path)
+        _patch_llm_config_compat(config, self.model_path)
+        check_checkpoint_compatibility(config)
+        tokenizer = AutoTokenizer.from_pretrained(self.model_path)
+        kwargs = {"config": config, "torch_dtype": self.dtype}
+        if load_with_info:
+            model, info = AutoModel.from_pretrained(
+                self.model_path,
+                output_loading_info=True,
+                **kwargs,
+            )
+            self.loading_info = dict(info)
+        else:
+            model = AutoModel.from_pretrained(self.model_path, **kwargs)
+            self.loading_info = {}
+        self.model = model.eval().to(self.device)
+        self.tokenizer = tokenizer
+
+    @property
+    def torch_device(self) -> torch.device:
+        return torch.device(self.device)
+
+    def prepare(
+        self,
+        question: str,
+        images: list[Any] | None = None,
+        history: list[tuple[str, str]] | None = None,
+    ) -> PreparedVQA:
+        from sensenova_u1.models.neo_unify.conversation import get_conv_template
+        from sensenova_u1.models.neo_unify.utils import load_image_native
+
+        assert self.model is not None and self.tokenizer is not None
+        images = list(images or [])
+        if history is None:
+            history = []
+        if images and "<image>" not in question:
+            question = "<image>\n" + question
+
+        pixel_values_list: list[torch.Tensor] = []
+        grid_hw_list: list[torch.Tensor] = []
+        for image in images:
+            kwargs: dict[str, Any] = {
+                "patch_size": self.model.patch_size,
+                "downsample_ratio": self.model.downsample_ratio,
+            }
+            if self.min_pixels is not None:
+                kwargs["min_pixels"] = self.min_pixels
+            if self.max_pixels is not None:
+                kwargs["max_pixels"] = self.max_pixels
+            cur_pixel_values, cur_grid_hw = load_image_native(_coerce_image(image), **kwargs)
+            pixel_values_list.append(cur_pixel_values)
+            grid_hw_list.append(cur_grid_hw)
+
+        pixel_values = torch.cat(pixel_values_list, dim=0) if pixel_values_list else None
+        grid_hw = torch.cat(grid_hw_list, dim=0) if grid_hw_list else None
+        if pixel_values is not None:
+            pixel_values = pixel_values.to(self.torch_device, dtype=self.model.dtype)
+        if grid_hw is not None:
+            grid_hw = grid_hw.to(self.torch_device)
+
+        img_context_token = "<IMG_CONTEXT>"
+        img_start_token = "<img>"
+        img_end_token = "</img>"
+        self.model.img_context_token_id = self.tokenizer.convert_tokens_to_ids(img_context_token)
+        self.model.img_start_token_id = self.tokenizer.convert_tokens_to_ids(img_start_token)
+
+        template = get_conv_template(self.model.template)
+        template.system_message = self.model.system_message
+        for old_question, old_answer in history:
+            template.append_message(template.roles[0], old_question)
+            template.append_message(template.roles[1], old_answer)
+        template.append_message(template.roles[0], question)
+        template.append_message(template.roles[1], None)
+        query = template.get_prompt()
+
+        if grid_hw is not None:
+            for i in range(grid_hw.shape[0]):
+                num_patch_token = int(
+                    grid_hw[i, 0] * grid_hw[i, 1] * self.model.downsample_ratio**2
+                )
+                image_tokens = img_start_token + img_context_token * num_patch_token + img_end_token
+                query = query.replace("<image>", image_tokens, 1)
+
+        model_inputs = self.tokenizer(query, return_tensors="pt")
+        input_ids = model_inputs["input_ids"].to(self.torch_device)
+        indexes = self.model.get_thw_indexes(input_ids[0], grid_hw)
+        image_token_tag = input_ids[0] == self.model.img_context_token_id
+        return PreparedVQA(
+            question=question,
+            query=query,
+            input_ids=input_ids,
+            attention_mask=model_inputs["attention_mask"].to(self.torch_device),
+            indexes=indexes,
+            image_token_tag=image_token_tag,
+            pixel_values=pixel_values,
+            grid_hw=grid_hw,
+        )
+
+    def prefill_logits(self, prepared: PreparedVQA) -> torch.Tensor:
+        assert self.model is not None
+        input_ids = prepared.input_ids
+        if prepared.pixel_values is not None:
+            vit_embeds = self.model.extract_feature(
+                prepared.pixel_values,
+                grid_hw=prepared.grid_hw,
+            )
+            input_embeds = self.model.language_model.get_input_embeddings()(input_ids)
+            bsz, seqlen, channels = input_embeds.shape
+            flat_embeds = input_embeds.reshape(bsz * seqlen, channels)
+            flat_ids = input_ids.reshape(bsz * seqlen)
+            selected = flat_ids == self.model.img_context_token_id
+            flat_embeds[selected] = vit_embeds.reshape(-1, channels).to(flat_embeds.device)
+            input_embeds = flat_embeds.reshape(bsz, seqlen, channels)
+        else:
+            input_embeds = self.model.language_model.get_input_embeddings()(input_ids)
+
+        outputs = self.model.language_model(
+            inputs_embeds=input_embeds,
+            indexes=prepared.indexes,
+            attention_mask=prepared.attention_mask,
+            use_cache=True,
+        )
+        return outputs.logits[:, -1, :].detach().float()
+
+    def generate_ids(
+        self,
+        prepared: PreparedVQA,
+        *,
+        max_new_tokens: int = 128,
+        do_sample: bool = False,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        top_k: int | None = None,
+        repetition_penalty: float | None = None,
+    ) -> torch.Tensor:
+        assert self.model is not None and self.tokenizer is not None
+        from sensenova_u1.models.neo_unify.conversation import get_conv_template
+
+        template = get_conv_template(self.model.template)
+        eos_token_id = self.tokenizer.convert_tokens_to_ids(template.sep.strip())
+        generation_config: dict[str, Any] = {
+            "max_new_tokens": max_new_tokens,
+            "do_sample": do_sample,
+            "eos_token_id": eos_token_id,
+        }
+        if do_sample:
+            generation_config["temperature"] = temperature
+            generation_config["top_p"] = top_p
+            if top_k is not None:
+                generation_config["top_k"] = top_k
+        if repetition_penalty is not None:
+            generation_config["repetition_penalty"] = repetition_penalty
+
+        return self.model.generate(
+            pixel_values=prepared.pixel_values,
+            input_ids=prepared.input_ids,
+            grid_hw=prepared.grid_hw,
+            attention_mask=prepared.attention_mask,
+            **generation_config,
+        )
+
+    def decode_generated(self, output_ids: torch.Tensor) -> str:
+        assert self.model is not None and self.tokenizer is not None
+        from sensenova_u1.models.neo_unify.conversation import get_conv_template
+
+        template = get_conv_template(self.model.template)
+        response = self.tokenizer.batch_decode(output_ids, skip_special_tokens=True)[0]
+        return response.split(template.sep.strip())[0].strip()
+
+    def answer(self, question: str, images: list[Any] | None = None, **kwargs: Any) -> dict[str, Any]:
+        prepared = self.prepare(question, images)
+        start = time.perf_counter()
+        output_ids = self.generate_ids(prepared, **kwargs)
+        elapsed = time.perf_counter() - start
+        text = self.decode_generated(output_ids)
+        token_ids = output_ids[0].detach().cpu().tolist()
+        return {
+            "text": text,
+            "token_ids": token_ids,
+            "prompt_tokens": int(prepared.input_ids.numel()),
+            "completion_tokens": len(token_ids),
+            "engine_time_s": elapsed,
+            "finish_reason": "stop",
+        }
+
+    def reference_chat_capture(
+        self,
+        question: str,
+        images: list[Any] | None = None,
+        *,
+        max_new_tokens: int = 128,
+        do_sample: bool = False,
+        use_official_hybrid_mask: bool = False,
+    ) -> dict[str, Any]:
+        assert self.model is not None and self.tokenizer is not None
+        from sensenova_u1.models.neo_unify.utils import load_image_native
+
+        images = list(images or [])
+        pixel_values = None
+        grid_hw = None
+        if images:
+            pixel_values_list = []
+            grid_hw_list = []
+            for image in images:
+                cur_pixel_values, cur_grid_hw = load_image_native(
+                    _coerce_image(image),
+                    patch_size=self.model.patch_size,
+                    downsample_ratio=self.model.downsample_ratio,
+                    min_pixels=(
+                        self.min_pixels
+                        if self.min_pixels is not None
+                        else DEFAULT_VQA_MIN_PIXELS
+                    ),
+                    max_pixels=(
+                        self.max_pixels
+                        if self.max_pixels is not None
+                        else DEFAULT_VQA_MAX_PIXELS
+                    ),
+                )
+                pixel_values_list.append(cur_pixel_values)
+                grid_hw_list.append(cur_grid_hw)
+            pixel_values = torch.cat(pixel_values_list, dim=0).to(
+                self.torch_device, dtype=self.model.dtype
+            )
+            grid_hw = torch.cat(grid_hw_list, dim=0).to(self.torch_device)
+
+        captured: dict[str, Any] = {}
+        original_generate = self.model.generate
+
+        def _capture_generate(*args: Any, **kwargs: Any):
+            output = original_generate(*args, **kwargs)
+            captured["output_ids"] = output.detach().cpu()
+            return output
+
+        self.model.generate = _capture_generate
+        try:
+            start = time.perf_counter()
+            if use_official_hybrid_mask:
+                with _official_block_mask_scope():
+                    text = self.model.chat(
+                        self.tokenizer,
+                        pixel_values,
+                        question,
+                        {"max_new_tokens": max_new_tokens, "do_sample": do_sample},
+                        grid_hw=grid_hw,
+                    )
+            else:
+                text = self.model.chat(
+                    self.tokenizer,
+                    pixel_values,
+                    question,
+                    {"max_new_tokens": max_new_tokens, "do_sample": do_sample},
+                    grid_hw=grid_hw,
+                )
+            elapsed = time.perf_counter() - start
+        finally:
+            self.model.generate = original_generate
+
+        output_ids = captured["output_ids"]
+        return {
+            "text": text,
+            "token_ids": output_ids[0].tolist(),
+            "engine_time_s": elapsed,
+        }
+
+    def complete_payload(
+        self,
+        payload: StagePayload,
+        *,
+        max_new_tokens: int = 128,
+        do_sample: bool = False,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        top_k: int | None = None,
+        repetition_penalty: float | None = None,
+    ) -> dict[str, Any]:
+        inputs, params, request_id = _extract_request(payload)
+        question, images, history = _extract_question_images_history(inputs)
+        prepared = self.prepare(question, images, history)
+        start = time.perf_counter()
+        output_ids = self.generate_ids(
+            prepared,
+            max_new_tokens=int(params.get("max_new_tokens", max_new_tokens)),
+            do_sample=bool(params.get("do_sample", do_sample)),
+            temperature=float(params.get("temperature", temperature)),
+            top_p=float(params.get("top_p", top_p)),
+            top_k=params.get("top_k", top_k),
+            repetition_penalty=params.get("repetition_penalty", repetition_penalty),
+        )
+        elapsed = time.perf_counter() - start
+        token_ids = output_ids[0].detach().cpu().tolist()
+        return {
+            "request_id": request_id,
+            "text": self.decode_generated(output_ids),
+            "token_ids": token_ids,
+            "finish_reason": "stop",
+            "usage": {
+                "prompt_tokens": int(prepared.input_ids.numel()),
+                "completion_tokens": len(token_ids),
+                "total_tokens": int(prepared.input_ids.numel()) + len(token_ids),
+                "engine_time_s": elapsed,
+            },
+            "stage_name": "u1_vqa",
+            "backend": "hf_compatible_fallback",
+        }
+
+
+def logits_similarity(a: torch.Tensor, b: torch.Tensor) -> dict[str, float]:
+    a = a.detach().float().reshape(1, -1).cpu()
+    b = b.detach().float().reshape(1, -1).cpu()
+    return {
+        "cosine": float(F.cosine_similarity(a, b, dim=-1).item()),
+        "max_abs_diff": float((a - b).abs().max().item()),
+    }

--- a/sglang_omni/models/sensenova_u1/hf_runner.py
+++ b/sglang_omni/models/sensenova_u1/hf_runner.py
@@ -191,6 +191,81 @@ def _patch_model_class_compat() -> None:
             module.create_block_causal_mask = create_u1_hybrid_mask
 
 
+def _refresh_official_vision_rope_cache(vision_model: Any) -> None:
+    """Rebuild non-persistent NEOVision RoPE buffers after HF loading.
+
+    Transformers 4.57 can leave the public U1 vision tower's non-persistent
+    cos/sin buffers with invalid values after ``AutoModel.from_pretrained``.
+    The official source computes those buffers deterministically in
+    ``NEOVisionEmbeddings.__init__``; refresh them here so HF oracle runs use
+    the intended vision path rather than corrupted compatibility-load state.
+    """
+
+    embeddings = getattr(vision_model, "embeddings", None)
+    config = getattr(vision_model, "config", None)
+    if embeddings is None or config is None:
+        return
+
+    device = next(vision_model.parameters()).device
+    embed_dim = int(getattr(config, "hidden_size"))
+    rope_dim_part = embed_dim // 2
+    max_position = int(getattr(config, "max_position_embeddings_vision"))
+    base = float(getattr(config, "rope_theta_vision"))
+    inv_freq = 1.0 / (
+        base
+        ** (
+            torch.arange(0, rope_dim_part, 2, device=device, dtype=torch.float32)
+            / rope_dim_part
+        )
+    )
+    positions = torch.arange(max_position, device=device, dtype=torch.float32)
+    freqs = torch.outer(positions, inv_freq)
+    cos = torch.cos(freqs)
+    sin = torch.sin(freqs)
+    embeddings.cos_cached_x = cos
+    embeddings.sin_cached_x = sin
+    embeddings.cos_cached_y = cos.clone()
+    embeddings.sin_cached_y = sin.clone()
+
+
+def _refresh_official_u1_rope_caches(model: Any) -> None:
+    vision_model = getattr(model, "vision_model", None)
+    if vision_model is not None:
+        _refresh_official_vision_rope_cache(vision_model)
+    fm_modules = getattr(model, "fm_modules", None)
+    if fm_modules is not None and "vision_model_mot_gen" in fm_modules:
+        _refresh_official_vision_rope_cache(fm_modules["vision_model_mot_gen"])
+
+
+def _force_official_llm_attn_implementation(model: Any, backend: str) -> None:
+    """Apply an explicit Transformers backend after U1 model construction.
+
+    Public U1 resets ``llm_config._attn_implementation`` to ``"eager"``
+    inside ``NEOChatModel.__init__``. The package-level backend flag therefore
+    does not switch the understanding tower by itself.
+    """
+
+    if backend not in {"eager", "sdpa"}:
+        return
+    language_model = getattr(model, "language_model", None)
+    if language_model is None:
+        return
+    configs: list[Any] = [
+        getattr(getattr(model, "config", None), "llm_config", None),
+        getattr(language_model, "config", None),
+        getattr(getattr(language_model, "model", None), "config", None),
+    ]
+    configs.extend(
+        getattr(module, "config", None) for module in language_model.modules()
+    )
+    seen: set[int] = set()
+    for config in configs:
+        if config is None or id(config) in seen:
+            continue
+        seen.add(id(config))
+        config._attn_implementation = backend
+
+
 @contextmanager
 def _official_block_mask_scope():
     """Temporarily restore official U1 block mask functions for references."""
@@ -344,22 +419,32 @@ class SenseNovaU1UnderstandingRunner:
 
         _patch_model_class_compat()
         sensenova_u1.set_attn_backend(self.attn_backend)
-        config = AutoConfig.from_pretrained(self.model_path)
+        config = AutoConfig.from_pretrained(self.model_path, trust_remote_code=True)
         _patch_llm_config_compat(config, self.model_path)
         check_checkpoint_compatibility(config)
-        tokenizer = AutoTokenizer.from_pretrained(self.model_path)
+        tokenizer = AutoTokenizer.from_pretrained(
+            self.model_path,
+            trust_remote_code=True,
+        )
         kwargs = {"config": config, "torch_dtype": self.dtype}
         if load_with_info:
             model, info = AutoModel.from_pretrained(
                 self.model_path,
                 output_loading_info=True,
+                trust_remote_code=True,
                 **kwargs,
             )
             self.loading_info = dict(info)
         else:
-            model = AutoModel.from_pretrained(self.model_path, **kwargs)
+            model = AutoModel.from_pretrained(
+                self.model_path,
+                trust_remote_code=True,
+                **kwargs,
+            )
             self.loading_info = {}
         self.model = model.eval().to(self.device)
+        _force_official_llm_attn_implementation(self.model, self.attn_backend)
+        _refresh_official_u1_rope_caches(self.model)
         self.tokenizer = tokenizer
 
     @property

--- a/sglang_omni/models/sensenova_u1/hybrid_attention.py
+++ b/sglang_omni/models/sensenova_u1/hybrid_attention.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SenseNova U1 hybrid prefill attention helpers.
+
+U1 assigns all ``<IMG_CONTEXT>`` tokens from one image span the same temporal
+index. Text rows remain causal; image rows may also attend to every token in
+their image span. The resulting dense mask is equivalent to the official
+``create_block_causal_mask(indexes[0])`` implementation and is used as the
+native Python reference before a fused backend grows the same row policy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+
+@dataclass(frozen=True, slots=True)
+class ImageSpan:
+    """Contiguous image-token span sharing one U1 temporal index."""
+
+    start: int
+    end: int
+    t_index: int
+
+    @property
+    def length(self) -> int:
+        return self.end - self.start
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "start": self.start,
+            "end": self.end,
+            "length": self.length,
+            "t_index": self.t_index,
+        }
+
+
+def _as_t_index(t_indexes: torch.Tensor) -> torch.Tensor:
+    if t_indexes.ndim == 2:
+        if t_indexes.shape[0] != 3:
+            raise ValueError(
+                "Expected U1 indexes with shape (3, L) when passing a 2D tensor."
+            )
+        return t_indexes[0]
+    if t_indexes.ndim != 1:
+        raise ValueError("Expected t_indexes with shape (L,) or indexes with shape (3, L).")
+    return t_indexes
+
+
+def build_image_token_tag_from_input_ids(
+    input_ids: torch.Tensor,
+    img_context_token_id: int,
+) -> torch.Tensor:
+    """Return a bool tag for per-token U1 image context rows."""
+
+    ids = input_ids.reshape(-1)
+    return ids == int(img_context_token_id)
+
+
+def build_image_token_tag_from_t_indexes(t_indexes: torch.Tensor) -> torch.Tensor:
+    """Infer image rows from repeated temporal indexes.
+
+    In U1 understanding prefixes, repeated temporal indexes are produced by
+    image context spans. This helper is useful for synthetic tests where token
+    ids are not available.
+    """
+
+    t_index = _as_t_index(t_indexes)
+    if t_index.numel() == 0:
+        return torch.empty_like(t_index, dtype=torch.bool)
+    _, inverse, counts = torch.unique(t_index, sorted=False, return_inverse=True, return_counts=True)
+    return counts[inverse] > 1
+
+
+def build_image_spans(
+    t_indexes: torch.Tensor,
+    image_token_tag: torch.Tensor | None = None,
+) -> list[ImageSpan]:
+    """Summarize contiguous image spans for evidence and debugging."""
+
+    t_index = _as_t_index(t_indexes).detach().cpu()
+    if image_token_tag is None:
+        tag = build_image_token_tag_from_t_indexes(t_index)
+    else:
+        tag = image_token_tag.reshape(-1).detach().cpu().bool()
+    if tag.numel() != t_index.numel():
+        raise ValueError("image_token_tag length must match t_indexes length.")
+
+    spans: list[ImageSpan] = []
+    start: int | None = None
+    cur_t: int | None = None
+    for pos, is_image in enumerate(tag.tolist()):
+        pos_t = int(t_index[pos].item())
+        if is_image and start is None:
+            start = pos
+            cur_t = pos_t
+        elif is_image and cur_t != pos_t:
+            spans.append(ImageSpan(start=start, end=pos, t_index=int(cur_t)))
+            start = pos
+            cur_t = pos_t
+        elif not is_image and start is not None:
+            spans.append(ImageSpan(start=start, end=pos, t_index=int(cur_t)))
+            start = None
+            cur_t = None
+    if start is not None:
+        spans.append(ImageSpan(start=start, end=tag.numel(), t_index=int(cur_t)))
+    return spans
+
+
+def build_m_block_summary(
+    image_token_tag: torch.Tensor,
+    *,
+    block_m: int,
+) -> list[dict[str, Any]]:
+    """Return the M-block OR-reduction described by U1's inference docs."""
+
+    if block_m <= 0:
+        raise ValueError("block_m must be positive.")
+    tag = image_token_tag.reshape(-1).detach().cpu().bool()
+    rows: list[dict[str, Any]] = []
+    for start in range(0, tag.numel(), block_m):
+        end = min(start + block_m, tag.numel())
+        block = tag[start:end]
+        rows.append(
+            {
+                "start": start,
+                "end": end,
+                "has_image": bool(block.any().item()),
+                "image_rows": [start + i for i, v in enumerate(block.tolist()) if v],
+            }
+        )
+    return rows
+
+
+def build_u1_hybrid_allowed_matrix(
+    t_indexes: torch.Tensor,
+    image_token_tag: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Build the boolean U1 hybrid attention matrix with shape ``(L, L)``."""
+
+    t_index = _as_t_index(t_indexes)
+    length = t_index.numel()
+    positions = torch.arange(length, device=t_index.device)
+    causal = positions.unsqueeze(0) <= positions.unsqueeze(1)
+    same_t = t_index.unsqueeze(0) == t_index.unsqueeze(1)
+    if image_token_tag is None:
+        return causal | same_t
+
+    tag = image_token_tag.reshape(-1).to(device=t_index.device, dtype=torch.bool)
+    if tag.numel() != length:
+        raise ValueError("image_token_tag length must match t_indexes length.")
+    same_image_span = same_t & tag.unsqueeze(0) & tag.unsqueeze(1)
+    return causal | same_image_span
+
+
+def create_u1_hybrid_mask(
+    index: torch.Tensor,
+    *,
+    image_token_tag: torch.Tensor | None = None,
+    dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    """Create U1's additive prefill attention mask with shape ``(1, 1, L, L)``."""
+
+    t_index = _as_t_index(index)
+    allowed = build_u1_hybrid_allowed_matrix(t_index, image_token_tag=image_token_tag)
+    mask_dtype = dtype or torch.get_default_dtype()
+    zero = torch.zeros((), device=t_index.device, dtype=mask_dtype)
+    neg_inf = torch.full((), float("-inf"), device=t_index.device, dtype=mask_dtype)
+    return torch.where(allowed[None, None, :, :], zero, neg_inf)
+
+
+def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    if n_rep == 1:
+        return hidden_states
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch, num_key_value_heads, n_rep, slen, head_dim
+    )
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+def u1_hybrid_attention_forward(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    t_indexes: torch.Tensor,
+    *,
+    image_token_tag: torch.Tensor | None = None,
+    scaling: float | None = None,
+    dropout: float = 0.0,
+    training: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Dense reference attention for U1 hybrid prefill rows.
+
+    Inputs follow the HF attention convention ``(B, H, L, D)`` and the output
+    follows the official U1 eager path convention ``(B, L, H, D)``.
+    """
+
+    if query.ndim != 4 or key.ndim != 4 or value.ndim != 4:
+        raise ValueError("query, key and value must all have shape (B, H, L, D).")
+    if key.shape[:3] != value.shape[:3] or key.shape[-1] != value.shape[-1]:
+        raise ValueError("key and value shapes are incompatible.")
+    if query.shape[0] != key.shape[0] or query.shape[-1] != key.shape[-1]:
+        raise ValueError("query/key batch or head_dim mismatch.")
+    if query.shape[2] != key.shape[2]:
+        raise ValueError("U1 prefill dense reference expects query and key lengths to match.")
+    if query.shape[1] % key.shape[1] != 0:
+        raise ValueError("query heads must be a multiple of key/value heads.")
+
+    num_key_value_groups = query.shape[1] // key.shape[1]
+    key_states = _repeat_kv(key, num_key_value_groups)
+    value_states = _repeat_kv(value, num_key_value_groups)
+    scale = scaling if scaling is not None else query.shape[-1] ** -0.5
+    attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scale
+    attn_weights = attn_weights + create_u1_hybrid_mask(
+        t_indexes,
+        image_token_tag=image_token_tag,
+        dtype=attn_weights.dtype,
+    )
+    attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_weights = F.dropout(attn_weights, p=dropout, training=training)
+    attn_output = torch.matmul(attn_weights, value_states)
+    return attn_output.transpose(1, 2).contiguous(), attn_weights

--- a/sglang_omni/models/sensenova_u1/hybrid_attention.py
+++ b/sglang_omni/models/sensenova_u1/hybrid_attention.py
@@ -156,6 +156,91 @@ def build_u1_hybrid_allowed_matrix(
     return causal | same_image_span
 
 
+def build_u1_hybrid_backend_mask(
+    indexes: torch.Tensor,
+    image_token_tag: torch.Tensor,
+    extend_seq_lens: list[int] | torch.Tensor,
+    extend_prefix_lens: list[int] | torch.Tensor | None = None,
+) -> tuple[torch.Tensor | None, torch.Tensor]:
+    """Build a flattened backend custom mask for SGLang prefill attention.
+
+    SGLang's extend kernels receive only this round's query/KV tensors plus a
+    cached prefix. They consume one flat mask per request with row-major shape
+    ``q_len x (prefix_len + q_len)``. Prefix columns are already before every
+    query row, so they remain visible; current-chunk columns use U1's hybrid
+    causal/image-span policy.
+    """
+
+    if indexes.ndim != 2 or indexes.shape[0] != 3:
+        raise ValueError("indexes must have shape (3, total_extend_tokens).")
+    tag = image_token_tag.reshape(-1).to(device=indexes.device, dtype=torch.bool)
+    if tag.numel() != indexes.shape[1]:
+        raise ValueError("image_token_tag length must match indexes length.")
+
+    if isinstance(extend_seq_lens, torch.Tensor):
+        seq_lens = [int(x) for x in extend_seq_lens.detach().cpu().tolist()]
+    else:
+        seq_lens = [int(x) for x in extend_seq_lens]
+    if extend_prefix_lens is None:
+        prefix_lens = [0] * len(seq_lens)
+    elif isinstance(extend_prefix_lens, torch.Tensor):
+        prefix_lens = [int(x) for x in extend_prefix_lens.detach().cpu().tolist()]
+    else:
+        prefix_lens = [int(x) for x in extend_prefix_lens]
+    if len(seq_lens) != len(prefix_lens):
+        raise ValueError("extend_seq_lens and extend_prefix_lens length mismatch.")
+
+    parts: list[torch.Tensor] = []
+    indptr = [0]
+    token_offset = 0
+    for q_len, prefix_len in zip(seq_lens, prefix_lens):
+        if q_len < 0 or prefix_len < 0:
+            raise ValueError("extend lengths and prefix lengths must be non-negative.")
+        if q_len == 0:
+            indptr.append(indptr[-1])
+            continue
+        req_indexes = indexes[:, token_offset : token_offset + q_len]
+        req_tag = tag[token_offset : token_offset + q_len]
+        if req_indexes.shape[1] != q_len or req_tag.numel() != q_len:
+            raise ValueError(
+                "indexes/image_token_tag do not cover all extend tokens."
+            )
+
+        t = req_indexes[0]
+        key_pos = torch.arange(q_len, device=indexes.device)
+        query_pos = torch.arange(q_len, device=indexes.device)
+        causal = key_pos.unsqueeze(0) <= query_pos.unsqueeze(1)
+        same_t = t.unsqueeze(1) == t.unsqueeze(0)
+        same_image_span = (
+            same_t
+            & req_tag.unsqueeze(1)
+            & req_tag.unsqueeze(0)
+        )
+        current_allowed = causal | same_image_span
+        if prefix_len:
+            prefix_allowed = torch.ones(
+                (q_len, prefix_len), dtype=torch.bool, device=indexes.device
+            )
+            allowed = torch.cat([prefix_allowed, current_allowed], dim=1)
+        else:
+            allowed = current_allowed
+        flat = allowed.reshape(-1).to(dtype=torch.uint8)
+        parts.append(flat)
+        indptr.append(indptr[-1] + int(flat.numel()))
+        token_offset += q_len
+
+    if token_offset != indexes.shape[1]:
+        raise ValueError("extend lengths do not consume all provided indexes tokens.")
+
+    indptr_tensor = torch.tensor(indptr, dtype=torch.int64, device=indexes.device)
+    if not parts:
+        return None, indptr_tensor
+    mask = torch.cat(parts, dim=0)
+    if not bool(image_token_tag.reshape(-1).to(dtype=torch.bool).any().item()):
+        return None, indptr_tensor
+    return mask, indptr_tensor
+
+
 def create_u1_hybrid_mask(
     index: torch.Tensor,
     *,

--- a/sglang_omni/models/sensenova_u1/interleave.py
+++ b/sglang_omni/models/sensenova_u1/interleave.py
@@ -26,6 +26,18 @@ from sglang_omni.models.sensenova_u1.hf_runner import (
     _extract_request,
     _extract_text_and_images_from_content,
 )
+from sglang_omni.models.sensenova_u1.limits import (
+    U1_MAX_TOTAL_TOKENS,
+    generated_image_span_token_count,
+    parse_int_param,
+    validate_image_count,
+    validate_image_size,
+    validate_input_image_count,
+    validate_max_new_tokens,
+    validate_num_steps,
+    validate_token_budget_components,
+    validate_total_token_budget,
+)
 from sglang_omni.models.sensenova_u1.sglang_model import (
     _blocked_hf_modeling_modules,
     assert_no_hf_modeling_imported,
@@ -92,18 +104,13 @@ def _stage_params(params: dict[str, Any], stage_name: str) -> dict[str, Any]:
     return merged
 
 
-def _positive_int(value: Any, default: int) -> int:
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError):
-        return default
-    return parsed if parsed > 0 else default
-
-
 def _cfg_interval(value: Any) -> tuple[float, float]:
     if value is None:
         return (0.0, 1.0)
-    interval = tuple(float(x) for x in value)
+    try:
+        interval = tuple(float(x) for x in value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("cfg_interval must contain exactly two floats.") from exc
     if len(interval) != 2:
         raise ValueError("cfg_interval must contain exactly two floats.")
     return (interval[0], interval[1])
@@ -117,7 +124,12 @@ def _extract_prompt_images_system(inputs: Any) -> tuple[str, list[Any], str | No
         return inputs, images, system_message
 
     if isinstance(inputs, dict):
-        images.extend(_coerce_image(img) for img in inputs.get("images") or [])
+        raw_images = inputs.get("images")
+        if raw_images is None:
+            raw_images = []
+        if not isinstance(raw_images, (list, tuple)):
+            raise ValueError("images must be a list or tuple.")
+        images.extend(_coerce_image(img) for img in raw_images)
         if "image" in inputs:
             images.append(_coerce_image(inputs["image"]))
         if "system_message" in inputs:
@@ -165,14 +177,19 @@ def _params_from_payload(
     if not isinstance(image_config, dict):
         image_config = {}
 
-    width = _positive_int(
-        params.get("width", params.get("image_width", image_config.get("width"))),
-        256,
+    width_value = params.get(
+        "width",
+        params.get("image_width", image_config.get("width", 256)),
     )
-    height = _positive_int(
-        params.get("height", params.get("image_height", image_config.get("height"))),
-        256,
+    height_value = params.get(
+        "height",
+        params.get("image_height", image_config.get("height", 256)),
     )
+    width, height = validate_image_size(
+        256 if width_value is None else width_value,
+        256 if height_value is None else height_value,
+    )
+    validate_input_image_count(images)
 
     chat_template_kwargs = params.get("chat_template_kwargs")
     if not isinstance(chat_template_kwargs, dict):
@@ -182,6 +199,19 @@ def _params_from_payload(
         think_mode = bool(chat_template_kwargs["enable_thinking"])
 
     seed_value = params.get("seed", image_config.get("seed", 20260813))
+    num_steps = validate_num_steps(params.get("num_steps", 2))
+    max_images = validate_image_count(
+        params.get("max_images", 1),
+        name="max_images",
+    )
+    max_new_tokens = validate_max_new_tokens(
+        params.get("max_new_tokens", params.get("max_tokens", 512))
+    )
+    validate_total_token_budget(
+        image_size=(width, height),
+        image_count=max_images,
+        max_new_tokens=max_new_tokens,
+    )
     system_message = str(
         params.get(
             "system_message",
@@ -198,12 +228,12 @@ def _params_from_payload(
         timestep_shift=float(params.get("timestep_shift", 1.0)),
         enable_timestep_shift=bool(params.get("enable_timestep_shift", True)),
         cfg_interval=_cfg_interval(params.get("cfg_interval", (0.0, 1.0))),
-        num_steps=int(params.get("num_steps", 2)),
-        max_images=int(params.get("max_images", 1)),
-        max_new_tokens=int(params.get("max_new_tokens", params.get("max_tokens", 512))),
+        num_steps=num_steps,
+        max_images=max_images,
+        max_new_tokens=max_new_tokens,
         t_eps=float(params.get("t_eps", 0.05)),
         think_mode=think_mode,
-        seed=int(seed_value),
+        seed=parse_int_param(seed_value, name="seed"),
         system_message=system_message,
     )
     return request, images
@@ -251,6 +281,12 @@ class SenseNovaU1InterleaveRunner(SenseNovaU1FlowMatchingRunner):
         dtype: str | torch.dtype = "bfloat16",
         attn_backend: str = "auto",
         load_with_info: bool = False,
+        max_total_tokens: int = U1_MAX_TOTAL_TOKENS,
+        eager_prefix_cache_max_entries: int = 4,
+        eager_decode_graph_cache_max_entries: int = 2,
+        eager_decode_graph_max_captures: int = 4,
+        eager_prefix_cache_max_tokens: int = 2048,
+        eager_decode_graph_max_total_tokens: int = 1024,
     ) -> None:
         super().__init__(
             model_path=model_path,
@@ -259,6 +295,18 @@ class SenseNovaU1InterleaveRunner(SenseNovaU1FlowMatchingRunner):
             dtype=dtype,
             attn_backend=attn_backend,
             load_with_info=load_with_info,
+            max_total_tokens=max_total_tokens,
+            eager_prefix_cache_max_entries=eager_prefix_cache_max_entries,
+            eager_decode_graph_cache_max_entries=(
+                eager_decode_graph_cache_max_entries
+            ),
+            eager_decode_graph_max_captures=(
+                eager_decode_graph_max_captures
+            ),
+            eager_prefix_cache_max_tokens=eager_prefix_cache_max_tokens,
+            eager_decode_graph_max_total_tokens=(
+                eager_decode_graph_max_total_tokens
+            ),
         )
 
     def _build_condition_prefix(
@@ -271,6 +319,8 @@ class SenseNovaU1InterleaveRunner(SenseNovaU1FlowMatchingRunner):
         think_mode: bool,
         assistant_append: str | None = None,
         prompt_image_count: int | None = None,
+        reserved_text_tokens: int = 0,
+        reserved_image_tokens: int = 0,
     ) -> NativeFlowPrefix:
         prompt_image_count = len(images) if prompt_image_count is None else int(prompt_image_count)
         prompt = _apply_prompt_image_prefix(prompt, prompt_image_count)
@@ -287,6 +337,12 @@ class SenseNovaU1InterleaveRunner(SenseNovaU1FlowMatchingRunner):
         )
         query = self._replace_image_tokens(query, grid_hw)
         input_ids = self.tokenizer(query, return_tensors="pt")["input_ids"][0]
+        validate_token_budget_components(
+            prefix_tokens=int(input_ids.numel()),
+            text_tokens=int(reserved_text_tokens),
+            image_tokens=int(reserved_image_tokens),
+            max_total_tokens=self.max_total_tokens,
+        )
         indexes = self._get_thw_indexes(input_ids, grid_hw)
         image_token_tag = input_ids == self.img_context_token_id
         if pixel_values is not None and grid_hw is not None:
@@ -507,8 +563,22 @@ class SenseNovaU1InterleaveRunner(SenseNovaU1FlowMatchingRunner):
         if use_official_hybrid_mask:
             raise RuntimeError("native interleave runner cannot use official HF mask")
         assert_no_hf_modeling_imported(context="before native interleave generation")
+        image_size = validate_image_size(*request.image_size)
+        num_steps = validate_num_steps(request.num_steps)
+        max_images = validate_image_count(
+            request.max_images,
+            name="max_images",
+        )
+        max_new_tokens = validate_max_new_tokens(request.max_new_tokens)
+        validate_total_token_budget(
+            image_size=image_size,
+            image_count=max_images,
+            max_new_tokens=max_new_tokens,
+            max_total_tokens=self.max_total_tokens,
+        )
         start = time.perf_counter()
         input_images = [_coerce_image(image) for image in (images or [])]
+        validate_input_image_count(input_images)
         base_assistant = self._base_assistant_append(request.think_mode)
         generated_text = ""
         generated_image_tensors: list[torch.Tensor] = []
@@ -521,10 +591,14 @@ class SenseNovaU1InterleaveRunner(SenseNovaU1FlowMatchingRunner):
         forced_image_requests = 0
         terminal_reason = "max_new_tokens"
         prefix: NativeFlowPrefix | None = None
+        generated_image_span_tokens = generated_image_span_token_count(
+            image_size
+        )
 
-        while current_generated_tokens < int(request.max_new_tokens):
-            remaining_tokens = int(request.max_new_tokens) - current_generated_tokens
-            suppress_image = len(generated_images) >= max(1, int(request.max_images))
+        while current_generated_tokens < max_new_tokens:
+            remaining_tokens = max_new_tokens - current_generated_tokens
+            remaining_image_slots = max_images - len(generated_images)
+            suppress_image = remaining_image_slots <= 0
             prefix = self._build_condition_prefix(
                 prompt=request.prompt,
                 system_message=request.system_message,
@@ -533,6 +607,10 @@ class SenseNovaU1InterleaveRunner(SenseNovaU1FlowMatchingRunner):
                 think_mode=request.think_mode,
                 assistant_append=base_assistant + generated_text,
                 prompt_image_count=len(input_images),
+                reserved_text_tokens=remaining_tokens,
+                reserved_image_tokens=(
+                    max(remaining_image_slots, 0) * generated_image_span_tokens
+                ),
             )
             text, segment_token_ids, decode_stats = self._generate_text_until_boundary(
                 prefix=prefix,
@@ -557,6 +635,8 @@ class SenseNovaU1InterleaveRunner(SenseNovaU1FlowMatchingRunner):
                     request,
                     seed=int(request.seed),
                 )
+                if flow_request.num_steps != num_steps:
+                    raise RuntimeError("interleave flow num_steps changed unexpectedly")
                 image_tensor, flow_stats = self.generate_interleave_image_tensor(
                     flow_request,
                     input_images,

--- a/sglang_omni/models/sensenova_u1/interleave.py
+++ b/sglang_omni/models/sensenova_u1/interleave.py
@@ -1,0 +1,360 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SenseNova U1 interleaved text-image generation runner.
+
+This M4 path keeps the official NEOChatModel interleave loop inside an
+SGLang-Omni stage. The loop autoregressively emits text, switches into U1
+flow-matching when the model emits an image start token, re-encodes the
+generated image, and then continues text generation from the updated KV cache.
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import nullcontext
+from dataclasses import asdict, dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+from PIL import Image
+
+from sglang_omni.models.sensenova_u1.flow_matching import (
+    SenseNovaU1FlowMatchingRunner,
+    pil_to_data_url,
+    u1_tensor_to_pil,
+)
+from sglang_omni.models.sensenova_u1.hf_runner import (
+    DEFAULT_MODEL_DIR,
+    DEFAULT_VENDOR_ROOT,
+    _coerce_image,
+    _extract_request,
+    _extract_text_and_images_from_content,
+    _official_block_mask_scope,
+)
+from sglang_omni.proto import StagePayload
+
+
+DEFAULT_INTERLEAVE_SYSTEM_MESSAGE = (
+    "You are a multimodal assistant capable of reasoning with both text and images. "
+    "You support two modes:\n\n"
+    "Think Mode: When reasoning is needed, you MUST start with a <think></think> block "
+    "and place all reasoning inside it. You MUST interleave text with generated images "
+    "using tags like <image1>, <image2>. Images can ONLY be generated between <think> and "
+    "</think>, and may be referenced in the final answer.\n\n"
+    "Non-Think Mode: When no reasoning is needed, directly provide the answer without "
+    "reasoning. Do not use tags like <image1>, <image2>; present any images naturally "
+    "alongside the text.\n\n"
+    "After the think block, always provide a concise, user-facing final answer. The "
+    "answer may include text, images, or both. Match the user's language in both "
+    "reasoning and the final answer."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class InterleaveRequestParams:
+    prompt: str
+    image_size: tuple[int, int] = (256, 256)
+    cfg_scale: float = 1.0
+    img_cfg_scale: float = 1.0
+    cfg_norm: str = "none"
+    timestep_shift: float = 1.0
+    enable_timestep_shift: bool = True
+    cfg_interval: tuple[float, float] = (0.0, 1.0)
+    num_steps: int = 2
+    max_images: int = 1
+    max_new_tokens: int = 512
+    t_eps: float = 0.05
+    think_mode: bool = True
+    seed: int = 20260813
+    system_message: str = DEFAULT_INTERLEAVE_SYSTEM_MESSAGE
+
+
+@dataclass(slots=True)
+class InterleaveResult:
+    text: str
+    token_ids: list[int]
+    images: list[Image.Image]
+    stats: dict[str, Any]
+    elapsed_s: float
+
+
+def _stage_params(params: dict[str, Any], stage_name: str) -> dict[str, Any]:
+    merged = dict(params)
+    stage_params = params.get("stage_params")
+    if isinstance(stage_params, dict):
+        specific = stage_params.get(stage_name)
+        if isinstance(specific, dict):
+            merged.update(specific)
+    stage_sampling = params.get("stage_sampling")
+    if isinstance(stage_sampling, dict):
+        specific_sampling = stage_sampling.get(stage_name)
+        if isinstance(specific_sampling, dict):
+            merged.update(specific_sampling)
+    return merged
+
+
+def _positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _cfg_interval(value: Any) -> tuple[float, float]:
+    if value is None:
+        return (0.0, 1.0)
+    interval = tuple(float(x) for x in value)
+    if len(interval) != 2:
+        raise ValueError("cfg_interval must contain exactly two floats.")
+    return (interval[0], interval[1])
+
+
+def _extract_prompt_images_system(inputs: Any) -> tuple[str, list[Any], str | None]:
+    images: list[Any] = []
+    system_message: str | None = None
+
+    if isinstance(inputs, str):
+        return inputs, images, system_message
+
+    if isinstance(inputs, dict):
+        images.extend(_coerce_image(img) for img in inputs.get("images") or [])
+        if "image" in inputs:
+            images.append(_coerce_image(inputs["image"]))
+        if "system_message" in inputs:
+            system_message = str(inputs["system_message"])
+        if "prompt" in inputs:
+            return str(inputs["prompt"]), images, system_message
+        if "question" in inputs:
+            return str(inputs["question"]), images, system_message
+        if "messages" in inputs:
+            inputs = inputs["messages"]
+        else:
+            return str(inputs), images, system_message
+
+    if isinstance(inputs, list):
+        prompt_parts: list[str] = []
+        for msg in inputs:
+            if not isinstance(msg, dict):
+                prompt_parts.append(str(msg))
+                continue
+            role = str(msg.get("role", "user"))
+            text, msg_images = _extract_text_and_images_from_content(
+                msg.get("content", "")
+            )
+            images.extend(_coerce_image(img) for img in msg_images)
+            if role == "system" and text:
+                system_message = text
+            elif role == "user" and text:
+                prompt_parts.append(text)
+        return "\n".join(part for part in prompt_parts if part), images, system_message
+
+    return str(inputs), images, system_message
+
+
+def _params_from_payload(
+    inputs: Any,
+    params: dict[str, Any],
+) -> tuple[InterleaveRequestParams, list[Any]]:
+    prompt, images, system_from_messages = _extract_prompt_images_system(inputs)
+    params = _stage_params(params, "u1_interleave")
+
+    data = inputs if isinstance(inputs, dict) else {}
+    image_config = params.get("image_config")
+    if not isinstance(image_config, dict):
+        image_config = data.get("image_config") if isinstance(data, dict) else {}
+    if not isinstance(image_config, dict):
+        image_config = {}
+
+    width = _positive_int(
+        params.get("width", params.get("image_width", image_config.get("width"))),
+        256,
+    )
+    height = _positive_int(
+        params.get("height", params.get("image_height", image_config.get("height"))),
+        256,
+    )
+
+    chat_template_kwargs = params.get("chat_template_kwargs")
+    if not isinstance(chat_template_kwargs, dict):
+        chat_template_kwargs = {}
+    think_mode = bool(params.get("think_mode", True))
+    if "enable_thinking" in chat_template_kwargs:
+        think_mode = bool(chat_template_kwargs["enable_thinking"])
+
+    seed_value = params.get("seed", image_config.get("seed", 20260813))
+    system_message = str(
+        params.get(
+            "system_message",
+            system_from_messages or DEFAULT_INTERLEAVE_SYSTEM_MESSAGE,
+        )
+    )
+
+    request = InterleaveRequestParams(
+        prompt=str(params.get("prompt", prompt)),
+        image_size=(width, height),
+        cfg_scale=float(params.get("cfg_scale", 1.0)),
+        img_cfg_scale=float(params.get("img_cfg_scale", 1.0)),
+        cfg_norm=str(params.get("cfg_norm", "none")),
+        timestep_shift=float(params.get("timestep_shift", 1.0)),
+        enable_timestep_shift=bool(params.get("enable_timestep_shift", True)),
+        cfg_interval=_cfg_interval(params.get("cfg_interval", (0.0, 1.0))),
+        num_steps=int(params.get("num_steps", 2)),
+        max_images=int(params.get("max_images", 1)),
+        max_new_tokens=int(params.get("max_new_tokens", params.get("max_tokens", 512))),
+        t_eps=float(params.get("t_eps", 0.05)),
+        think_mode=think_mode,
+        seed=int(seed_value),
+        system_message=system_message,
+    )
+    return request, images
+
+
+def interleave_tensors_to_pil(image_tensors: list[torch.Tensor]) -> list[Image.Image]:
+    images: list[Image.Image] = []
+    for tensor in image_tensors:
+        if tensor.ndim == 3:
+            tensor = tensor.unsqueeze(0)
+        images.extend(u1_tensor_to_pil(tensor.detach()))
+    return images
+
+
+def interleave_segments(text: str, image_items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    parts = text.split("<image>")
+    segments: list[dict[str, Any]] = []
+    for idx, part in enumerate(parts):
+        if part:
+            segments.append({"type": "text", "text": part})
+        if idx < len(parts) - 1:
+            if idx < len(image_items):
+                segments.append({"type": "image", "image": image_items[idx]})
+            else:
+                segments.append({"type": "image", "image": None})
+    return segments
+
+
+class SenseNovaU1InterleaveRunner(SenseNovaU1FlowMatchingRunner):
+    """End-to-end U1 text-image-text generation runner."""
+
+    def __init__(
+        self,
+        model_path: str = DEFAULT_MODEL_DIR,
+        *,
+        vendor_root: str | None = None,
+        device: str = "cuda:0",
+        dtype: str | torch.dtype = "bfloat16",
+        attn_backend: str = "auto",
+        load_with_info: bool = False,
+    ) -> None:
+        super().__init__(
+            model_path=model_path,
+            vendor_root=vendor_root or DEFAULT_VENDOR_ROOT,
+            device=device,
+            dtype=dtype,
+            attn_backend=attn_backend,
+            load_with_info=load_with_info,
+        )
+
+    @torch.inference_mode()
+    def generate_interleave(
+        self,
+        request: InterleaveRequestParams,
+        images: list[Any] | None = None,
+        *,
+        use_official_hybrid_mask: bool = False,
+    ) -> InterleaveResult:
+        assert self.model is not None and self.tokenizer is not None
+        ctx = _official_block_mask_scope() if use_official_hybrid_mask else nullcontext()
+        generation_config = SimpleNamespace(max_new_tokens=request.max_new_tokens)
+        start = time.perf_counter()
+        with ctx:
+            text, image_tensors = self.model.interleave_gen(
+                self.tokenizer,
+                request.prompt,
+                images=[_coerce_image(image) for image in (images or [])],
+                generation_config=generation_config,
+                cfg_scale=request.cfg_scale,
+                img_cfg_scale=request.img_cfg_scale,
+                cfg_norm=request.cfg_norm,
+                max_images=request.max_images,
+                enable_timestep_shift=request.enable_timestep_shift,
+                timestep_shift=request.timestep_shift,
+                image_size=request.image_size,
+                num_steps=request.num_steps,
+                cfg_interval=request.cfg_interval,
+                t_eps=request.t_eps,
+                verbose=False,
+                system_message=request.system_message,
+                think_mode=request.think_mode,
+                seed=request.seed,
+            )
+        elapsed = time.perf_counter() - start
+        token_ids = self.tokenizer(
+            text,
+            add_special_tokens=False,
+        )["input_ids"]
+        stats = dict(getattr(self.model, "last_interleave_generation_stats", {}) or {})
+        return InterleaveResult(
+            text=str(text),
+            token_ids=[int(x) for x in token_ids],
+            images=interleave_tensors_to_pil(list(image_tensors)),
+            stats=stats,
+            elapsed_s=elapsed,
+        )
+
+    def complete_payload(self, payload: StagePayload) -> dict[str, Any]:
+        inputs, params, request_id = _extract_request(payload)
+        request, images = _params_from_payload(inputs, params)
+        result = self.generate_interleave(request, images)
+        image_items = [
+            {
+                "type": "image",
+                "format": "png",
+                "data": pil_to_data_url(image),
+                "width": image.width,
+                "height": image.height,
+                "index": idx,
+            }
+            for idx, image in enumerate(result.images)
+        ]
+        prompt_token_ids = self.tokenizer(  # type: ignore[operator]
+            request.prompt,
+            add_special_tokens=False,
+        )["input_ids"]
+        rollout = {
+            "type": "sensenova_u1_interleave",
+            "segments": interleave_segments(result.text, image_items),
+            "images": image_items,
+            "text": result.text,
+            "token_ids": result.token_ids,
+            "stats": result.stats,
+            "request": asdict(request),
+            "backend": "hf_compatible_interleave_fallback",
+        }
+        return {
+            "request_id": request_id,
+            "text": result.text,
+            "token_ids": result.token_ids,
+            "images": image_items,
+            "omni_rollout": rollout,
+            "finish_reason": result.stats.get("stop_reason", "stop"),
+            "usage": {
+                "prompt_tokens": len(prompt_token_ids),
+                "completion_tokens": len(result.token_ids),
+                "total_tokens": len(prompt_token_ids) + len(result.token_ids),
+                "engine_time_s": result.elapsed_s,
+                "generated_images": len(result.images),
+            },
+            "stage_name": "u1_interleave",
+            "backend": "hf_compatible_interleave_fallback",
+        }
+
+
+__all__ = [
+    "DEFAULT_INTERLEAVE_SYSTEM_MESSAGE",
+    "InterleaveRequestParams",
+    "InterleaveResult",
+    "SenseNovaU1InterleaveRunner",
+    "interleave_segments",
+    "interleave_tensors_to_pil",
+]

--- a/sglang_omni/models/sensenova_u1/interleave.py
+++ b/sglang_omni/models/sensenova_u1/interleave.py
@@ -1,25 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
-"""SenseNova U1 interleaved text-image generation runner.
-
-This M4 path keeps the official NEOChatModel interleave loop inside an
-SGLang-Omni stage. The loop autoregressively emits text, switches into U1
-flow-matching when the model emits an image start token, re-encodes the
-generated image, and then continues text generation from the updated KV cache.
-"""
+"""SenseNova U1 interleaved text-image generation runner."""
 
 from __future__ import annotations
 
+import os
 import time
-from contextlib import nullcontext
 from dataclasses import asdict, dataclass
-from types import SimpleNamespace
 from typing import Any
 
 import torch
 from PIL import Image
 
 from sglang_omni.models.sensenova_u1.flow_matching import (
+    FlowRequestParams,
+    NativeFlowPrefix,
     SenseNovaU1FlowMatchingRunner,
+    _build_neo_prompt,
     pil_to_data_url,
     u1_tensor_to_pil,
 )
@@ -29,7 +25,10 @@ from sglang_omni.models.sensenova_u1.hf_runner import (
     _coerce_image,
     _extract_request,
     _extract_text_and_images_from_content,
-    _official_block_mask_scope,
+)
+from sglang_omni.models.sensenova_u1.sglang_model import (
+    _blocked_hf_modeling_modules,
+    assert_no_hf_modeling_imported,
 )
 from sglang_omni.proto import StagePayload
 
@@ -233,6 +232,13 @@ def interleave_segments(text: str, image_items: list[dict[str, Any]]) -> list[di
     return segments
 
 
+def _apply_prompt_image_prefix(prompt: str, image_count: int) -> str:
+    prompt_image_count = prompt.count("<image>")
+    if image_count > prompt_image_count:
+        prompt = "<image>\n" * (image_count - prompt_image_count) + prompt
+    return prompt
+
+
 class SenseNovaU1InterleaveRunner(SenseNovaU1FlowMatchingRunner):
     """End-to-end U1 text-image-text generation runner."""
 
@@ -255,6 +261,241 @@ class SenseNovaU1InterleaveRunner(SenseNovaU1FlowMatchingRunner):
             load_with_info=load_with_info,
         )
 
+    def _build_condition_prefix(
+        self,
+        *,
+        prompt: str,
+        images: list[Any],
+        generated_image_tensors: list[torch.Tensor] | None = None,
+        system_message: str,
+        think_mode: bool,
+        assistant_append: str | None = None,
+        prompt_image_count: int | None = None,
+    ) -> NativeFlowPrefix:
+        prompt_image_count = len(images) if prompt_image_count is None else int(prompt_image_count)
+        prompt = _apply_prompt_image_prefix(prompt, prompt_image_count)
+        pixel_values, grid_hw = self._load_interleave_prefix_images(
+            images,
+            generated_image_tensors or [],
+        )
+        if assistant_append is None:
+            assistant_append = None if think_mode else "<think>\n\n</think>\n\n"
+        query = _build_neo_prompt(
+            user_text=prompt,
+            system_message=system_message,
+            assistant_append=assistant_append,
+        )
+        query = self._replace_image_tokens(query, grid_hw)
+        input_ids = self.tokenizer(query, return_tensors="pt")["input_ids"][0]
+        indexes = self._get_thw_indexes(input_ids, grid_hw)
+        image_token_tag = input_ids == self.img_context_token_id
+        if pixel_values is not None and grid_hw is not None:
+            input_embeds = self.executor.compose_input_embeds(
+                input_ids=input_ids,
+                image_token_tag=image_token_tag,
+                pixel_values=pixel_values,
+                grid_hw=grid_hw,
+            )
+            if input_embeds is None:
+                raise RuntimeError("native interleave image compose returned no embeds")
+        else:
+            input_embeds = self._token_embeds(input_ids)
+        return NativeFlowPrefix(
+            input_ids=input_ids.to(dtype=torch.long),
+            indexes=indexes.to(dtype=torch.long),
+            image_token_tag=image_token_tag.to(dtype=torch.bool),
+            input_embeds=input_embeds.detach(),
+            cache_extra_key=None,
+            cache_insert_log={
+                "skipped": True,
+                "reason": "native_interleave_text_state_machine_no_prefix_insert",
+                "prefix_tokens": int(input_ids.numel()),
+                "image_token_count": int(image_token_tag.sum().item()),
+            },
+        )
+
+    def _generated_tensor_to_native_pixels(
+        self,
+        image_tensor: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        tensor = image_tensor.detach()
+        if tensor.ndim == 4:
+            tensor = tensor[0]
+        if tensor.ndim != 3:
+            raise ValueError(
+                "generated interleave image tensor must have shape [3,H,W] or [1,3,H,W]"
+            )
+        pred_img = tensor.unsqueeze(0).to(
+            device=self.torch_device,
+            dtype=torch.bfloat16,
+        )
+        raw_img = pred_img * 0.5 + 0.5
+        mean = torch.tensor(
+            [0.485, 0.456, 0.406],
+            dtype=raw_img.dtype,
+            device=raw_img.device,
+        ).view(1, 3, 1, 1)
+        std = torch.tensor(
+            [0.229, 0.224, 0.225],
+            dtype=raw_img.dtype,
+            device=raw_img.device,
+        ).view(1, 3, 1, 1)
+        pixel_values = (raw_img - mean) / std
+        c, h, w = pixel_values[0].shape
+        ps = self.patch_size
+        if h % ps != 0 or w % ps != 0:
+            raise ValueError(
+                f"generated image shape {(h, w)} must be divisible by patch_size={ps}"
+            )
+        grid_h = h // ps
+        grid_w = w // ps
+        flat = (
+            pixel_values[0]
+            .view(c, grid_h, ps, grid_w, ps)
+            .permute(1, 3, 0, 2, 4)
+            .reshape(grid_h * grid_w, c * ps**2)
+        )
+        return (
+            flat.cpu(),
+            torch.tensor([[grid_h, grid_w]], dtype=torch.long),
+        )
+
+    def _load_interleave_prefix_images(
+        self,
+        input_images: list[Any],
+        generated_image_tensors: list[torch.Tensor],
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        pixel_parts: list[torch.Tensor] = []
+        grid_parts: list[torch.Tensor] = []
+        if input_images:
+            pixel_values, grid_hw = self._load_input_images(input_images)
+            if pixel_values is not None and grid_hw is not None:
+                pixel_parts.append(pixel_values.cpu())
+                grid_parts.append(grid_hw.cpu())
+        for image_tensor in generated_image_tensors:
+            pixel_values, grid_hw = self._generated_tensor_to_native_pixels(image_tensor)
+            pixel_parts.append(pixel_values)
+            grid_parts.append(grid_hw)
+        if not pixel_parts:
+            return None, None
+        return torch.cat(pixel_parts, dim=0), torch.cat(grid_parts, dim=0)
+
+    def _generate_text_until_boundary(
+        self,
+        *,
+        prefix: NativeFlowPrefix,
+        max_new_tokens: int,
+        suppress_token_ids: list[int] | None = None,
+    ) -> tuple[str, list[int], dict[str, Any]]:
+        eos_token_id = int(self.tokenizer.convert_tokens_to_ids("<|im_end|>"))
+        max_new_tokens = max(int(max_new_tokens), 0)
+        if max_new_tokens == 0:
+            return "", [], {
+                "stop_reason": "max_new_tokens",
+                "generated_tokens": 0,
+                "raw_generated_token_ids": [],
+                "terminal_token_id": None,
+                "eos_token_id": eos_token_id,
+                "img_start_token_id": self.img_start_token_id,
+                "native_decode_stats": None,
+                "native_decode_mode": self._native_interleave_text_decode_mode(),
+            }
+
+        decode_mode = self._native_interleave_text_decode_mode()
+        if decode_mode == "eager_text_decode":
+            decode_result = self.executor.run_eager_text_decode(
+                input_ids=prefix.input_ids,
+                indexes=prefix.indexes,
+                image_token_tag=prefix.image_token_tag,
+                input_embeds=prefix.input_embeds,
+                decode_steps=max_new_tokens,
+                suppress_token_ids=suppress_token_ids,
+            )
+            raw_ids = [int(x) for x in decode_result.generated_token_ids]
+        else:
+            if suppress_token_ids:
+                raise NotImplementedError(
+                    "native interleave image-cap suppression currently requires eager text decode"
+                )
+            decode_result = self.executor.run_greedy_decode_batch(
+                [
+                    {
+                        "request_id": f"u1-native-interleave-text-{time.time_ns()}",
+                        "input_ids": prefix.input_ids,
+                        "indexes": prefix.indexes,
+                        "image_token_tag": prefix.image_token_tag,
+                        "input_embeds": prefix.input_embeds,
+                        "cache_extra_key": prefix.cache_extra_key,
+                    }
+                ],
+                decode_steps=max_new_tokens,
+                suppress_token_ids=suppress_token_ids,
+            )
+            raw_ids = [int(x) for x in decode_result.generated_token_ids[0]]
+        text_token_ids: list[int] = []
+        terminal_token_id: int | None = None
+        stop_reason = "max_new_tokens"
+        for token_id in raw_ids:
+            if token_id == eos_token_id:
+                terminal_token_id = token_id
+                stop_reason = "eos"
+                break
+            if token_id == self.img_start_token_id:
+                terminal_token_id = token_id
+                stop_reason = "image_start_pending_native_flow"
+                break
+            text_token_ids.append(token_id)
+            if len(text_token_ids) >= max_new_tokens:
+                stop_reason = "max_new_tokens"
+                break
+        text = self.tokenizer.decode(text_token_ids, skip_special_tokens=True)
+        return text, text_token_ids, {
+            "stop_reason": stop_reason,
+            "generated_tokens": len(text_token_ids),
+            "raw_generated_token_ids": raw_ids,
+            "terminal_token_id": terminal_token_id,
+            "eos_token_id": eos_token_id,
+            "img_start_token_id": self.img_start_token_id,
+            "native_decode_mode": decode_mode,
+            "native_decode_stats": decode_result.to_dict(),
+        }
+
+    def _base_assistant_append(self, think_mode: bool) -> str:
+        return "" if think_mode else "<think>\n\n</think>\n\n"
+
+    def _flow_request_from_interleave(
+        self,
+        request: InterleaveRequestParams,
+        *,
+        seed: int,
+    ) -> FlowRequestParams:
+        return FlowRequestParams(
+            mode="t2i",
+            prompt=request.prompt,
+            image_size=request.image_size,
+            cfg_scale=request.cfg_scale,
+            img_cfg_scale=request.img_cfg_scale,
+            cfg_norm=request.cfg_norm,
+            timestep_shift=request.timestep_shift,
+            enable_timestep_shift=request.enable_timestep_shift,
+            cfg_interval=request.cfg_interval,
+            num_steps=request.num_steps,
+            batch_size=1,
+            t_eps=request.t_eps,
+            think_mode=False,
+            seed=seed,
+        )
+
+    @staticmethod
+    def _native_interleave_text_decode_mode() -> str:
+        value = os.environ.get(
+            "SENSENOVA_U1_NATIVE_INTERLEAVE_EAGER_TEXT_DECODE",
+            "",
+        ).lower()
+        if value in {"0", "false", "no", "off"}:
+            return "sglang_cached_decode"
+        return "eager_text_decode"
+
     @torch.inference_mode()
     def generate_interleave(
         self,
@@ -263,41 +504,139 @@ class SenseNovaU1InterleaveRunner(SenseNovaU1FlowMatchingRunner):
         *,
         use_official_hybrid_mask: bool = False,
     ) -> InterleaveResult:
-        assert self.model is not None and self.tokenizer is not None
-        ctx = _official_block_mask_scope() if use_official_hybrid_mask else nullcontext()
-        generation_config = SimpleNamespace(max_new_tokens=request.max_new_tokens)
+        if use_official_hybrid_mask:
+            raise RuntimeError("native interleave runner cannot use official HF mask")
+        assert_no_hf_modeling_imported(context="before native interleave generation")
         start = time.perf_counter()
-        with ctx:
-            text, image_tensors = self.model.interleave_gen(
-                self.tokenizer,
-                request.prompt,
-                images=[_coerce_image(image) for image in (images or [])],
-                generation_config=generation_config,
-                cfg_scale=request.cfg_scale,
-                img_cfg_scale=request.img_cfg_scale,
-                cfg_norm=request.cfg_norm,
-                max_images=request.max_images,
-                enable_timestep_shift=request.enable_timestep_shift,
-                timestep_shift=request.timestep_shift,
-                image_size=request.image_size,
-                num_steps=request.num_steps,
-                cfg_interval=request.cfg_interval,
-                t_eps=request.t_eps,
-                verbose=False,
+        input_images = [_coerce_image(image) for image in (images or [])]
+        base_assistant = self._base_assistant_append(request.think_mode)
+        generated_text = ""
+        generated_image_tensors: list[torch.Tensor] = []
+        generated_images: list[Image.Image] = []
+        decode_stats_by_segment: list[dict[str, Any]] = []
+        flow_stats_by_image: list[dict[str, Any]] = []
+        image_elapsed_s: list[float] = []
+        current_generated_tokens = 0
+        forced_image_cap = False
+        forced_image_requests = 0
+        terminal_reason = "max_new_tokens"
+        prefix: NativeFlowPrefix | None = None
+
+        while current_generated_tokens < int(request.max_new_tokens):
+            remaining_tokens = int(request.max_new_tokens) - current_generated_tokens
+            suppress_image = len(generated_images) >= max(1, int(request.max_images))
+            prefix = self._build_condition_prefix(
+                prompt=request.prompt,
                 system_message=request.system_message,
+                images=input_images,
+                generated_image_tensors=generated_image_tensors,
                 think_mode=request.think_mode,
-                seed=request.seed,
+                assistant_append=base_assistant + generated_text,
+                prompt_image_count=len(input_images),
             )
+            text, segment_token_ids, decode_stats = self._generate_text_until_boundary(
+                prefix=prefix,
+                max_new_tokens=remaining_tokens,
+                suppress_token_ids=[self.img_start_token_id] if suppress_image else None,
+            )
+            native_decode_stats = decode_stats.get("native_decode_stats") or {}
+            if suppress_image:
+                suppressed_hits = int(native_decode_stats.get("suppressed_token_hits", 0))
+                if suppressed_hits > 0:
+                    forced_image_cap = True
+                    forced_image_requests += suppressed_hits
+            generated_text += text
+            current_generated_tokens += len(segment_token_ids)
+            decode_stats_by_segment.append(decode_stats)
+
+            stop_reason = str(decode_stats["stop_reason"])
+            if stop_reason == "image_start_pending_native_flow" and not suppress_image:
+                image_started_at = time.perf_counter()
+                flow_assistant_prefix = base_assistant + generated_text + "<img>"
+                flow_request = self._flow_request_from_interleave(
+                    request,
+                    seed=int(request.seed),
+                )
+                image_tensor, flow_stats = self.generate_interleave_image_tensor(
+                    flow_request,
+                    input_images,
+                    system_message=request.system_message,
+                    assistant_prefix=flow_assistant_prefix,
+                )
+                generated_image_tensors.append(image_tensor.detach())
+                generated_images.extend(u1_tensor_to_pil(image_tensor.detach()))
+                generated_text += "<image>"
+                image_elapsed_s.append(time.perf_counter() - image_started_at)
+                flow_stats_by_image.append(flow_stats.to_dict())
+                continue
+
+            terminal_reason = "eos" if stop_reason == "eos" else "max_new_tokens"
+            break
+
         elapsed = time.perf_counter() - start
-        token_ids = self.tokenizer(
-            text,
-            add_special_tokens=False,
-        )["input_ids"]
-        stats = dict(getattr(self.model, "last_interleave_generation_stats", {}) or {})
+        guard_after = _blocked_hf_modeling_modules()
+        assert_no_hf_modeling_imported(context="after native interleave generation")
+        stop_reason = (
+            f"forced_cap_then_{terminal_reason}"
+            if forced_image_cap
+            else terminal_reason
+        )
+        token_ids = [
+            int(x)
+            for x in self.tokenizer(
+                generated_text,
+                add_special_tokens=False,
+            )["input_ids"]
+        ]
+        stats = {
+            "forced_native_single_image": False,
+            "text_only_state_machine": len(generated_images) == 0,
+            "image_state_machine_implemented": True,
+            "native_full_prefill_interleave_state_machine": True,
+            "forced_image_cap": forced_image_cap,
+            "forced_image_requests": forced_image_requests,
+            "natural_eos": terminal_reason == "eos" and not forced_image_cap,
+            "eos_reached": terminal_reason == "eos",
+            "stop_reason": stop_reason,
+            "generated_tokens": current_generated_tokens,
+            "generated_images": len(generated_images),
+            "image_elapsed_s": image_elapsed_s,
+            "condition_prefix_tokens": int(prefix.input_ids.numel()) if prefix else 0,
+            "condition_prefix_image_tokens": (
+                int(prefix.image_token_tag.sum().item()) if prefix else 0
+            ),
+            "native_decode_mode": (
+                decode_stats_by_segment[-1]["native_decode_mode"]
+                if decode_stats_by_segment
+                else self._native_interleave_text_decode_mode()
+            ),
+            "native_decode_segments": decode_stats_by_segment,
+            "native_flow_stats": {
+                "runs": flow_stats_by_image,
+                "hf_modeling_imported_after": guard_after,
+            },
+            "raw_generated_token_ids": [
+                int(token_id)
+                for segment in decode_stats_by_segment
+                for token_id in segment["raw_generated_token_ids"]
+            ],
+            "terminal_token_id": (
+                decode_stats_by_segment[-1]["terminal_token_id"]
+                if decode_stats_by_segment
+                else None
+            ),
+            "eos_token_id": (
+                decode_stats_by_segment[-1]["eos_token_id"]
+                if decode_stats_by_segment
+                else int(self.tokenizer.convert_tokens_to_ids("<|im_end|>"))
+            ),
+            "img_start_token_id": self.img_start_token_id,
+            "hf_modeling_imported_after": guard_after,
+        }
         return InterleaveResult(
-            text=str(text),
+            text=str(generated_text),
             token_ids=[int(x) for x in token_ids],
-            images=interleave_tensors_to_pil(list(image_tensors)),
+            images=generated_images,
             stats=stats,
             elapsed_s=elapsed,
         )
@@ -329,7 +668,7 @@ class SenseNovaU1InterleaveRunner(SenseNovaU1FlowMatchingRunner):
             "token_ids": result.token_ids,
             "stats": result.stats,
             "request": asdict(request),
-            "backend": "hf_compatible_interleave_fallback",
+            "backend": "native_sglang_interleave_text_state_machine",
         }
         return {
             "request_id": request_id,
@@ -346,7 +685,7 @@ class SenseNovaU1InterleaveRunner(SenseNovaU1FlowMatchingRunner):
                 "generated_images": len(result.images),
             },
             "stage_name": "u1_interleave",
-            "backend": "hf_compatible_interleave_fallback",
+            "backend": "native_sglang_interleave_text_state_machine",
         }
 
 

--- a/sglang_omni/models/sensenova_u1/limits.py
+++ b/sglang_omni/models/sensenova_u1/limits.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Production request limits for SenseNova U1 image generation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+U1_IMAGE_SIZE_DIVISOR = 32
+U1_GENERATED_IMAGE_TOKEN_OVERHEAD = 2
+U1_MAX_IMAGE_DIMENSION = 2048
+U1_MAX_IMAGE_PIXELS = 1024 * 1024
+U1_MAX_DIFFUSION_STEPS = 64
+U1_MAX_GENERATED_IMAGES = 4
+U1_MAX_INPUT_IMAGES = 4
+U1_MAX_NEW_TOKENS = 2048
+U1_MAX_TOTAL_TOKENS = 4096
+
+
+def parse_int_param(value: Any, *, name: str, default: int | None = None) -> int:
+    if value is None:
+        if default is None:
+            raise ValueError(f"{name} is required.")
+        return int(default)
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be an integer, not a boolean.")
+    if isinstance(value, float) and not value.is_integer():
+        raise ValueError(f"{name} must be an integer.")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an integer.") from exc
+
+
+def validate_image_size(width: Any, height: Any) -> tuple[int, int]:
+    parsed_width = parse_int_param(width, name="width")
+    parsed_height = parse_int_param(height, name="height")
+    for name, value in (("width", parsed_width), ("height", parsed_height)):
+        if value <= 0:
+            raise ValueError(f"{name} must be positive.")
+        if value > U1_MAX_IMAGE_DIMENSION:
+            raise ValueError(
+                f"{name} exceeds the deployment maximum "
+                f"{U1_MAX_IMAGE_DIMENSION}: {value}."
+            )
+        if value % U1_IMAGE_SIZE_DIVISOR != 0:
+            raise ValueError(
+                f"{name} must be divisible by {U1_IMAGE_SIZE_DIVISOR}: {value}."
+            )
+    pixels = parsed_width * parsed_height
+    if pixels > U1_MAX_IMAGE_PIXELS:
+        raise ValueError(
+            "image pixel count exceeds the deployment maximum "
+            f"{U1_MAX_IMAGE_PIXELS}: {pixels}."
+        )
+    return parsed_width, parsed_height
+
+
+def validate_num_steps(value: Any) -> int:
+    num_steps = parse_int_param(value, name="num_steps")
+    if num_steps <= 0:
+        raise ValueError("num_steps must be positive.")
+    if num_steps > U1_MAX_DIFFUSION_STEPS:
+        raise ValueError(
+            "num_steps exceeds the deployment maximum "
+            f"{U1_MAX_DIFFUSION_STEPS}: {num_steps}."
+        )
+    return num_steps
+
+
+def validate_image_count(
+    value: Any,
+    *,
+    name: str,
+    maximum: int = U1_MAX_GENERATED_IMAGES,
+) -> int:
+    image_count = parse_int_param(value, name=name)
+    if image_count <= 0:
+        raise ValueError(f"{name} must be positive.")
+    if image_count > maximum:
+        raise ValueError(
+            f"{name} exceeds the deployment maximum {maximum}: {image_count}."
+        )
+    return image_count
+
+
+def validate_input_image_count(images: list[Any]) -> None:
+    if len(images) > U1_MAX_INPUT_IMAGES:
+        raise ValueError(
+            "input image count exceeds the deployment maximum "
+            f"{U1_MAX_INPUT_IMAGES}: {len(images)}."
+        )
+
+
+def validate_max_new_tokens(value: Any) -> int:
+    max_new_tokens = parse_int_param(value, name="max_new_tokens")
+    if max_new_tokens <= 0:
+        raise ValueError("max_new_tokens must be positive.")
+    if max_new_tokens > U1_MAX_NEW_TOKENS:
+        raise ValueError(
+            "max_new_tokens exceeds the deployment maximum "
+            f"{U1_MAX_NEW_TOKENS}: {max_new_tokens}."
+        )
+    return max_new_tokens
+
+
+def generated_image_token_count(image_size: tuple[int, int]) -> int:
+    width, height = validate_image_size(*image_size)
+    return (width // U1_IMAGE_SIZE_DIVISOR) * (
+        height // U1_IMAGE_SIZE_DIVISOR
+    )
+
+
+def generated_image_span_token_count(image_size: tuple[int, int]) -> int:
+    return (
+        generated_image_token_count(image_size)
+        + U1_GENERATED_IMAGE_TOKEN_OVERHEAD
+    )
+
+
+def validate_total_token_budget(
+    *,
+    image_size: tuple[int, int],
+    image_count: int,
+    max_new_tokens: int = 0,
+    prefix_tokens: int = 0,
+    max_total_tokens: int = U1_MAX_TOTAL_TOKENS,
+) -> int:
+    if prefix_tokens < 0:
+        raise ValueError("prefix_tokens must be non-negative.")
+    if max_new_tokens < 0:
+        raise ValueError("max_new_tokens must be non-negative.")
+    if max_total_tokens <= 0:
+        raise ValueError("max_total_tokens must be positive.")
+    image_tokens = generated_image_span_token_count(image_size)
+    return validate_token_budget_components(
+        prefix_tokens=prefix_tokens,
+        text_tokens=max_new_tokens,
+        image_tokens=int(image_count) * image_tokens,
+        max_total_tokens=max_total_tokens,
+        detail=f"images={image_count}x{image_tokens}",
+    )
+
+
+def validate_token_budget_components(
+    *,
+    prefix_tokens: int,
+    text_tokens: int,
+    image_tokens: int,
+    max_total_tokens: int = U1_MAX_TOTAL_TOKENS,
+    detail: str | None = None,
+) -> int:
+    if prefix_tokens < 0:
+        raise ValueError("prefix_tokens must be non-negative.")
+    if text_tokens < 0:
+        raise ValueError("text_tokens must be non-negative.")
+    if image_tokens < 0:
+        raise ValueError("image_tokens must be non-negative.")
+    if max_total_tokens <= 0:
+        raise ValueError("max_total_tokens must be positive.")
+    total_tokens = (
+        int(prefix_tokens)
+        + int(text_tokens)
+        + int(image_tokens)
+    )
+    if total_tokens > max_total_tokens:
+        detail_text = f", {detail}" if detail else ""
+        raise ValueError(
+            "request token budget exceeds the deployment maximum "
+            f"{max_total_tokens}: prefix={prefix_tokens}, "
+            f"text={text_tokens}, image_tokens={image_tokens}{detail_text}, "
+            f"total={total_tokens}."
+        )
+    return total_tokens
+
+
+__all__ = [
+    "U1_IMAGE_SIZE_DIVISOR",
+    "U1_GENERATED_IMAGE_TOKEN_OVERHEAD",
+    "U1_MAX_DIFFUSION_STEPS",
+    "U1_MAX_GENERATED_IMAGES",
+    "U1_MAX_IMAGE_DIMENSION",
+    "U1_MAX_IMAGE_PIXELS",
+    "U1_MAX_INPUT_IMAGES",
+    "U1_MAX_NEW_TOKENS",
+    "U1_MAX_TOTAL_TOKENS",
+    "generated_image_token_count",
+    "generated_image_span_token_count",
+    "parse_int_param",
+    "validate_image_count",
+    "validate_image_size",
+    "validate_input_image_count",
+    "validate_max_new_tokens",
+    "validate_num_steps",
+    "validate_token_budget_components",
+    "validate_total_token_budget",
+]

--- a/sglang_omni/models/sensenova_u1/native_serving.py
+++ b/sglang_omni/models/sensenova_u1/native_serving.py
@@ -1,0 +1,2185 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded native SGLang serving probe for SenseNova U1."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import time
+from array import array
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from sglang.srt.managers.schedule_batch import MultimodalInputs, Req
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardBatch
+from sglang.srt.sampling.sampling_params import SamplingParams
+
+from sglang_omni.model_runner.prefill_inputs import (
+    OmniPrefillInputs,
+    attach_omni_prefill_inputs,
+)
+from sglang_omni.models.sensenova_u1.native_vision import (
+    SenseNovaU1NativeVisionModel,
+)
+from sglang_omni.models.sensenova_u1.sglang_model import (
+    assert_no_hf_modeling_imported,
+    block_hf_modeling_imports,
+    load_u1_llm_config,
+)
+from sglang_omni.scheduling.sglang_backend.server_args_builder import (
+    build_sglang_server_args,
+)
+
+_CACHE_EXTRA_KEY_NOT_SET = object()
+
+
+@dataclass(slots=True)
+class NativeServingResult:
+    request_id: str
+    next_token_id: int
+    logits_shape: list[int]
+    logits_dtype: str
+    logits_device: str
+    logits_all_finite: bool
+    forward_elapsed_s: float
+    backend_name: str
+    prepare_metadata: dict[str, Any] | None
+    forward_batch_log: dict[str, Any]
+    input_embeds_used: bool = False
+    input_embeds_shape: list[int] | None = None
+    batch_index: int = 0
+    batch_size: int = 1
+    cache_inserted: bool = False
+    cache_extra_key: str | None = None
+    next_token_logits: torch.Tensor | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data = {
+            "request_id": self.request_id,
+            "next_token_id": self.next_token_id,
+            "logits_shape": self.logits_shape,
+            "logits_dtype": self.logits_dtype,
+            "logits_device": self.logits_device,
+            "logits_all_finite": self.logits_all_finite,
+            "forward_elapsed_s": self.forward_elapsed_s,
+            "backend_name": self.backend_name,
+            "prepare_metadata": self.prepare_metadata,
+            "forward_batch_log": self.forward_batch_log,
+            "input_embeds_used": self.input_embeds_used,
+            "input_embeds_shape": self.input_embeds_shape,
+            "batch_index": self.batch_index,
+            "batch_size": self.batch_size,
+            "cache_inserted": self.cache_inserted,
+            "cache_extra_key": self.cache_extra_key,
+        }
+        if self.next_token_logits is not None:
+            logits = self.next_token_logits.float().reshape(-1)
+            top_values, top_indices = torch.topk(logits, k=min(5, logits.numel()))
+            data.update(
+                {
+                    "logits_min": float(logits.min().item()),
+                    "logits_max": float(logits.max().item()),
+                    "logits_l2": float(torch.linalg.vector_norm(logits).item()),
+                    "logits_top5_token_ids": [
+                        int(x) for x in top_indices.detach().cpu().tolist()
+                    ],
+                    "logits_top5_values": [
+                        float(x) for x in top_values.detach().cpu().tolist()
+                    ],
+                }
+            )
+        return data
+
+
+@dataclass(slots=True)
+class NativeHiddenPrefillResult:
+    request_id: str
+    hidden_states: torch.Tensor
+    forward_elapsed_s: float
+    backend_name: str
+    prepare_metadata: dict[str, Any] | None
+    forward_batch_log: dict[str, Any]
+    input_embeds_used: bool
+    input_embeds_shape: list[int] | None
+    cache_inserted: bool
+    cache_extra_key: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "request_id": self.request_id,
+            "hidden_states_shape": list(self.hidden_states.shape),
+            "hidden_states_dtype": str(self.hidden_states.dtype),
+            "hidden_states_device": str(self.hidden_states.device),
+            "hidden_states_all_finite": bool(
+                torch.isfinite(self.hidden_states).all().item()
+            ),
+            "forward_elapsed_s": self.forward_elapsed_s,
+            "backend_name": self.backend_name,
+            "prepare_metadata": self.prepare_metadata,
+            "forward_batch_log": self.forward_batch_log,
+            "input_embeds_used": self.input_embeds_used,
+            "input_embeds_shape": self.input_embeds_shape,
+            "cache_inserted": bool(self.cache_inserted),
+            "cache_extra_key": self.cache_extra_key,
+        }
+
+
+@dataclass(slots=True)
+class NativeDecodeBenchmarkResult:
+    request_count: int
+    decode_steps: int
+    prompt_tokens: int
+    generated_tokens: int
+    prefill_elapsed_s: float
+    decode_elapsed_s: float
+    total_elapsed_s: float
+    generated_token_ids: list[list[int]]
+    per_step_elapsed_s: list[float]
+    prefill_forward_batch_log: dict[str, Any]
+    decode_forward_batch_logs: list[dict[str, Any]]
+    release_log: dict[str, Any] | None
+    logits_all_finite: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        decode_generated_tokens = self.request_count * max(self.decode_steps - 1, 0)
+        total_tps = (
+            self.generated_tokens / self.total_elapsed_s
+            if self.total_elapsed_s > 0
+            else float("inf")
+        )
+        decode_tps = (
+            decode_generated_tokens / self.decode_elapsed_s
+            if self.decode_elapsed_s > 0
+            else float("inf")
+        )
+        return {
+            "request_count": self.request_count,
+            "decode_steps": self.decode_steps,
+            "prompt_tokens": self.prompt_tokens,
+            "generated_tokens": self.generated_tokens,
+            "decode_generated_tokens": decode_generated_tokens,
+            "prefill_elapsed_s": self.prefill_elapsed_s,
+            "decode_elapsed_s": self.decode_elapsed_s,
+            "total_elapsed_s": self.total_elapsed_s,
+            "generated_tokens_per_s_total": total_tps,
+            "generated_tokens_per_s_decode_only": decode_tps,
+            "generated_token_ids": self.generated_token_ids,
+            "per_step_elapsed_s": self.per_step_elapsed_s,
+            "prefill_forward_batch_log": self.prefill_forward_batch_log,
+            "decode_forward_batch_logs": self.decode_forward_batch_logs,
+            "release_log": self.release_log,
+            "logits_all_finite": self.logits_all_finite,
+        }
+
+
+@dataclass(slots=True)
+class NativeEagerTextDecodeResult:
+    decode_steps: int
+    prompt_tokens: int
+    generated_token_ids: list[int]
+    prefill_elapsed_s: float
+    decode_elapsed_s: float
+    total_elapsed_s: float
+    per_step_elapsed_s: list[float]
+    step_logs: list[dict[str, Any]]
+    logits_all_finite: bool
+    next_token_logits: torch.Tensor | None = None
+    captured_layer_hidden_states: list[torch.Tensor] | None = None
+    full_loop_cuda_graph_used: bool = False
+    full_loop_cuda_graph_created: bool = False
+    full_loop_cuda_graph_key: str | None = None
+    eager_prefix_cache_hit: bool = False
+    eager_prefix_cache_key: str | None = None
+    full_loop_initial_cache_copy_skipped: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        suppress_hits = [
+            int(log["suppressed_argmax_token_id"])
+            for log in self.step_logs
+            if log.get("suppressed_argmax_token_id") is not None
+        ]
+        return {
+            "decode_steps": self.decode_steps,
+            "prompt_tokens": self.prompt_tokens,
+            "generated_tokens": len(self.generated_token_ids),
+            "generated_token_ids": self.generated_token_ids,
+            "prefill_elapsed_s": self.prefill_elapsed_s,
+            "decode_elapsed_s": self.decode_elapsed_s,
+            "total_elapsed_s": self.total_elapsed_s,
+            "generated_tokens_per_s_total": (
+                len(self.generated_token_ids) / self.total_elapsed_s
+                if self.total_elapsed_s > 0
+                else float("inf")
+            ),
+            "generated_tokens_per_s_decode_only": (
+                max(len(self.generated_token_ids) - 1, 0) / self.decode_elapsed_s
+                if self.decode_elapsed_s > 0
+                else float("inf")
+            ),
+            "per_step_elapsed_s": self.per_step_elapsed_s,
+            "step_logs": self.step_logs,
+            "logits_all_finite": self.logits_all_finite,
+            "suppressed_token_hits": len(suppress_hits),
+            "suppressed_argmax_token_ids": suppress_hits,
+            "full_loop_cuda_graph_used": self.full_loop_cuda_graph_used,
+            "full_loop_cuda_graph_created": self.full_loop_cuda_graph_created,
+            "full_loop_cuda_graph_key": self.full_loop_cuda_graph_key,
+            "eager_prefix_cache_hit": self.eager_prefix_cache_hit,
+            "eager_prefix_cache_key": self.eager_prefix_cache_key,
+            "full_loop_initial_cache_copy_skipped": (
+                self.full_loop_initial_cache_copy_skipped
+            ),
+            "captured_layer_hidden_shapes": (
+                None
+                if self.captured_layer_hidden_states is None
+                else [list(t.shape) for t in self.captured_layer_hidden_states]
+            ),
+        }
+
+
+@dataclass(slots=True)
+class _NativeEagerDecodeGraph:
+    graphs: list[torch.cuda.CUDAGraph]
+    graph_pool: Any
+    initial_caches: list[tuple[torch.Tensor, torch.Tensor]]
+    input_token: torch.Tensor
+    decode_indexes: list[torch.Tensor]
+    generated_tokens: list[torch.Tensor]
+    last_logits: torch.Tensor
+    final_caches: list[tuple[torch.Tensor, torch.Tensor]]
+    cache_history: list[list[tuple[torch.Tensor, torch.Tensor]]]
+    source_prefix_cache_key: str | None
+    prefix_len: int
+    verified_finite: bool
+
+
+def _tensor_from_payload(value: Any, *, dtype: torch.dtype) -> torch.Tensor:
+    if isinstance(value, torch.Tensor):
+        return value.to(dtype=dtype)
+    return torch.tensor(value, dtype=dtype)
+
+
+def _update_hash_with_tensor(hasher: "hashlib._Hash", tensor: torch.Tensor) -> None:
+    cpu = tensor.detach().cpu().contiguous()
+    hasher.update(str(tuple(cpu.shape)).encode("utf-8"))
+    hasher.update(str(cpu.dtype).encode("utf-8"))
+    if cpu.dtype == torch.bfloat16:
+        cpu = cpu.view(torch.int16)
+    elif cpu.dtype == torch.bool:
+        cpu = cpu.to(torch.uint8)
+    hasher.update(cpu.numpy().tobytes())
+
+
+class SenseNovaU1NativeServingExecutor:
+    """Small native SGLang executor for M6 serving-attention validation.
+
+    The executor intentionally accepts already-expanded U1 prompt token ids and
+    image metadata. It verifies the SGLang-native language/MoT tower,
+    ForwardBatch metadata transport, and attention backend mask path without
+    reusing the older HF NEOChatModel fallback.
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        device: str = "cuda:0",
+        dtype: str = "bfloat16",
+        attention_backend: str = "triton",
+        mem_fraction_static: float = 0.65,
+        max_total_tokens: int = 4096,
+        max_running_requests: int = 2,
+        enable_radix_cache: bool = True,
+        disable_cuda_graph: bool = True,
+        cuda_graph_bs: list[int] | None = None,
+        enable_deterministic_inference: bool = False,
+        prefill_cuda_graph_backend: str = "disabled",
+        prefill_cuda_graph_bs: list[int] | None = None,
+    ) -> None:
+        assert_no_hf_modeling_imported(context="before native serving executor")
+        from sglang_omni.models.sensenova_u1.hf_config import (
+            register_sensenova_u1_native_config_parser,
+        )
+
+        register_sensenova_u1_native_config_parser()
+        gpu_id = int(device.split(":")[-1]) if ":" in device else 0
+        self.model_path = model_path
+        self.config = load_u1_llm_config(model_path)
+        self.vocab_size = int(self.config.vocab_size)
+        self.max_running_requests = max(int(max_running_requests), 1)
+        self.enable_radix_cache = bool(enable_radix_cache)
+        if cuda_graph_bs is None:
+            cuda_graph_bs = [self.max_running_requests]
+        cuda_graph_bs = sorted({int(value) for value in cuda_graph_bs})
+        prefill_cuda_graph_backend = str(prefill_cuda_graph_backend).lower()
+        prefill_cuda_graph_enabled = prefill_cuda_graph_backend != "disabled"
+        if prefill_cuda_graph_bs is None:
+            prefill_cuda_graph_bs = [64]
+        prefill_cuda_graph_bs = sorted(
+            {int(value) for value in prefill_cuda_graph_bs}
+        )
+        cuda_graph_overrides = (
+            {
+                "cuda_graph_bs": cuda_graph_bs,
+                "cuda_graph_max_bs": max(cuda_graph_bs),
+            }
+            if not disable_cuda_graph
+            else {}
+        )
+        if prefill_cuda_graph_enabled:
+            cuda_graph_overrides.update(
+                {
+                    "cuda_graph_backend_prefill": prefill_cuda_graph_backend,
+                    "cuda_graph_bs_prefill": prefill_cuda_graph_bs,
+                    "cuda_graph_max_bs_prefill": max(prefill_cuda_graph_bs),
+                    "enable_return_hidden_states": True,
+                }
+            )
+            if disable_cuda_graph:
+                cuda_graph_overrides["cuda_graph_backend_decode"] = "disabled"
+        server_args = build_sglang_server_args(
+            model_path,
+            context_length=min(int(self.config.max_position_embeddings), max_total_tokens),
+            max_prefill_tokens=max_total_tokens,
+            max_running_requests=self.max_running_requests,
+            mem_fraction_static=mem_fraction_static,
+            dtype=dtype,
+            model_config_parser="sensenova_u1_native",
+            attention_backend=attention_backend,
+            sampling_backend="pytorch",
+            disable_cuda_graph=(
+                disable_cuda_graph and not prefill_cuda_graph_enabled
+            ),
+            disable_overlap_schedule=True,
+            enable_deterministic_inference=enable_deterministic_inference,
+            disable_radix_cache=not self.enable_radix_cache,
+            chunked_prefill_size=None,
+            max_total_tokens=max_total_tokens,
+            **cuda_graph_overrides,
+        )
+        with block_hf_modeling_imports():
+            from sglang_omni.scheduling import bootstrap as scheduling_bootstrap
+
+            (
+                self.model_worker,
+                self.tree_cache,
+                self.req_to_token_pool,
+                self.token_to_kv_pool_allocator,
+                self.prefill_manager,
+                self.decode_manager,
+                self.model_config,
+            ) = scheduling_bootstrap.create_sglang_infrastructure(
+                server_args,
+                gpu_id,
+                model_arch_override="SenseNovaU1NativeForCausalLM",
+                total_gpu_memory_fraction=mem_fraction_static,
+                defer_cuda_graph_capture=prefill_cuda_graph_enabled,
+                enable_prefill_input_embeds=True,
+            )
+            from sglang_omni.models.sensenova_u1.attention_backend import (
+                install_sensenova_u1_triton_attention_adapter,
+            )
+
+            install_sensenova_u1_triton_attention_adapter(
+                self.model_worker.model_runner
+            )
+            if prefill_cuda_graph_enabled:
+                text_model = self.model_worker.model_runner.model.model
+                text_model.force_mot_gen_for_prefill_graph_capture = True
+                try:
+                    scheduling_bootstrap.init_sglang_cuda_graphs(
+                        self.model_worker
+                    )
+                finally:
+                    text_model.force_mot_gen_for_prefill_graph_capture = False
+        self.server_args = server_args
+        self.prefill_cuda_graph_enabled = prefill_cuda_graph_enabled
+        self._eager_text_decode_graphs: dict[
+            tuple[int, int, int, str],
+            _NativeEagerDecodeGraph,
+        ] = {}
+        self._eager_text_prefill_cache: dict[
+            str,
+            tuple[
+                torch.Tensor,
+                list[tuple[torch.Tensor, torch.Tensor]],
+                bool,
+            ],
+        ] = {}
+        dtype_obj = next(self.model_worker.model_runner.model.parameters()).dtype
+        device_obj = torch.device(self.model_worker.device)
+        self.vision_model = SenseNovaU1NativeVisionModel.from_model_path(
+            model_path,
+            params_dtype=dtype_obj,
+        ).to(device=device_obj, dtype=dtype_obj)
+        self.vision_model.eval()
+        self.vision_load_report = self.vision_model.load_weights(model_path)
+        if not self.vision_load_report.ok:
+            raise RuntimeError(
+                "native U1 vision load failed: "
+                f"{self.vision_load_report.to_dict()}"
+            )
+        assert_no_hf_modeling_imported(context="after native serving executor")
+
+    def _make_req(
+        self,
+        *,
+        request_id: str,
+        input_ids: torch.Tensor,
+        indexes: torch.Tensor,
+        image_token_tag: torch.Tensor,
+        image_gen_indicators: torch.Tensor | None,
+        max_new_tokens: int = 1,
+        cache_extra_key: str | None = None,
+        has_projected_input_embeds: bool = False,
+    ) -> Req:
+        sampling_params = SamplingParams(
+            max_new_tokens=int(max_new_tokens),
+            temperature=0.0,
+            top_p=1.0,
+            top_k=-1,
+        )
+        sampling_params.normalize(None)
+        sampling_params.verify(self.vocab_size)
+        input_list = [int(x) for x in input_ids.detach().cpu().tolist()]
+        req = Req(
+            rid=request_id,
+            origin_input_text="",
+            origin_input_ids=array("q", input_list),
+            sampling_params=sampling_params,
+            vocab_size=self.vocab_size,
+            extra_key=cache_extra_key,
+        )
+        req.tokenizer = None
+        req._codec_suppress_tokens = None
+        req._input_embeds_are_projected = bool(has_projected_input_embeds)
+        req.omni_model_inputs = None
+        mm_inputs = MultimodalInputs(mm_items=[])
+        mm_inputs.mrope_positions = indexes.detach().cpu().to(dtype=torch.long)
+        mm_inputs.mrope_position_delta = torch.zeros(1, dtype=torch.long)
+        mm_inputs.u1_image_token_tag = image_token_tag.detach().cpu().to(dtype=torch.bool)
+        if image_gen_indicators is not None:
+            mm_inputs.u1_image_gen_indicators = (
+                image_gen_indicators.detach().cpu().to(dtype=torch.bool)
+            )
+        req.multimodal_inputs = mm_inputs
+        return req
+
+    @staticmethod
+    def _cache_extra_key(
+        *,
+        image_token_tag: torch.Tensor,
+        pixel_values: torch.Tensor | None,
+        grid_hw: torch.Tensor | None,
+        input_embeds: torch.Tensor | None,
+    ) -> str | None:
+        if not bool(image_token_tag.reshape(-1).bool().any().item()):
+            return None
+        hasher = hashlib.sha256()
+        hasher.update(b"sensenova-u1-native-image-cache-v1")
+        _update_hash_with_tensor(hasher, image_token_tag.reshape(-1).bool())
+        if grid_hw is not None:
+            _update_hash_with_tensor(hasher, grid_hw.to(dtype=torch.long))
+        if pixel_values is not None:
+            _update_hash_with_tensor(hasher, pixel_values)
+        elif input_embeds is not None:
+            tag = image_token_tag.reshape(-1).to(dtype=torch.bool, device=input_embeds.device)
+            image_embeds = input_embeds.reshape(-1, input_embeds.shape[-1])[tag]
+            _update_hash_with_tensor(hasher, image_embeds)
+        return "u1-image:" + hasher.hexdigest()[:32]
+
+    def compose_input_embeds(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        image_token_tag: torch.Tensor,
+        pixel_values: torch.Tensor | None,
+        grid_hw: torch.Tensor | None,
+    ) -> torch.Tensor | None:
+        """Build text embeddings with native vision features pasted into image spans."""
+
+        if pixel_values is None and grid_hw is None:
+            return None
+        if pixel_values is None or grid_hw is None:
+            raise ValueError("pixel_values and grid_hw must be provided together.")
+        assert_no_hf_modeling_imported(context="before native input embedding compose")
+        model = self.model_worker.model_runner.model
+        device = torch.device(self.model_worker.device)
+        dtype = next(model.parameters()).dtype
+        flat_ids = input_ids.reshape(-1).to(device=device, dtype=torch.long)
+        tag = image_token_tag.reshape(-1).to(device=device, dtype=torch.bool)
+        with torch.inference_mode(), block_hf_modeling_imports():
+            input_embeds = model.get_input_embeddings()(flat_ids).to(dtype=dtype)
+            vit_embeds = self.vision_model(
+                pixel_values.to(device=device, dtype=dtype),
+                grid_hw.to(device=device, dtype=torch.long),
+            ).to(device=device, dtype=input_embeds.dtype)
+        image_token_count = int(tag.sum().item())
+        if image_token_count != int(vit_embeds.shape[0]):
+            raise ValueError(
+                "image token count does not match native vision embeddings: "
+                f"tokens={image_token_count} embeds={vit_embeds.shape[0]}"
+            )
+        input_embeds = input_embeds.clone()
+        input_embeds[tag] = vit_embeds.reshape(image_token_count, -1)
+        assert_no_hf_modeling_imported(context="after native input embedding compose")
+        return input_embeds
+
+    def _pool_snapshot(self) -> dict[str, int | None]:
+        token_available = None
+        try:
+            token_available = int(self.token_to_kv_pool_allocator.available_size())
+        except Exception:
+            token_available = None
+        return {
+            "req_available": int(self.req_to_token_pool.available_size()),
+            "token_available": token_available,
+        }
+
+    def _cache_snapshot(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "cache_type": type(self.tree_cache).__name__,
+            "radix_cache_enabled": self.enable_radix_cache,
+            "pool": self._pool_snapshot(),
+        }
+        for name in ("total_size", "evictable_size", "full_evictable_size"):
+            value = getattr(self.tree_cache, name, None)
+            if callable(value):
+                try:
+                    data[name] = int(value())
+                except Exception:
+                    data[name] = None
+        for name in ("disable", "protected_size_", "evictable_size_"):
+            if hasattr(self.tree_cache, name):
+                try:
+                    data[name] = getattr(self.tree_cache, name)
+                except Exception:
+                    data[name] = None
+        return data
+
+    def cached_prefix_length(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        cache_extra_key: str | None,
+    ) -> int:
+        """Return the current Radix match length without scheduling a forward."""
+
+        from sglang.srt.mem_cache.base_prefix_cache import (
+            MatchPrefixParams,
+        )
+        from sglang.srt.mem_cache.radix_cache import RadixKey
+
+        token_ids = array(
+            "q",
+            [int(x) for x in input_ids.detach().cpu().reshape(-1).tolist()],
+        )
+        result = self.tree_cache.match_prefix(
+            MatchPrefixParams(
+                key=RadixKey(
+                    token_ids=token_ids,
+                    extra_key=cache_extra_key,
+                )
+            )
+        )
+        return int(len(result.device_indices))
+
+    def _finish_prefill_batch(
+        self,
+        batch: Any,
+        *,
+        cache_insert: bool,
+    ) -> dict[str, Any]:
+        from sglang.srt.mem_cache.common import release_kv_cache
+
+        before = self._pool_snapshot()
+        before_cache = self._cache_snapshot()
+        finished: list[dict[str, Any]] = []
+        for req in list(batch.reqs):
+            if getattr(req, "req_pool_idx", None) is None:
+                continue
+            committed_len = int(req.effective_kv_committed_len())
+            prefix_len = int(len(getattr(req, "prefix_indices", [])))
+            release_kv_cache(req, self.tree_cache, is_insert=cache_insert)
+            finished.append(
+                {
+                    "rid": str(req.rid),
+                    "committed_len": committed_len,
+                    "prefix_len": prefix_len,
+                    "cache_insert": bool(cache_insert),
+                    "cache_extra_key": getattr(req, "extra_key", None),
+                }
+            )
+        return {
+            "released_reqs": len(finished),
+            "finished_reqs": finished,
+            "before": before,
+            "before_cache": before_cache,
+            "after": self._pool_snapshot(),
+            "after_cache": self._cache_snapshot(),
+        }
+
+    def _prepare_prefill_request(
+        self,
+        *,
+        request_id: str,
+        input_ids: torch.Tensor,
+        indexes: torch.Tensor,
+        image_token_tag: torch.Tensor,
+        image_gen_indicators: torch.Tensor | None = None,
+        input_embeds: torch.Tensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        grid_hw: torch.Tensor | None = None,
+        max_new_tokens: int = 1,
+        cache_extra_key: str | None | object = _CACHE_EXTRA_KEY_NOT_SET,
+    ) -> dict[str, Any]:
+        device = torch.device(self.model_worker.device)
+        input_ids = input_ids.to(device=device, dtype=torch.long)
+        indexes = indexes.to(device=device, dtype=torch.long)
+        image_token_tag = image_token_tag.to(device=device, dtype=torch.bool)
+        if image_gen_indicators is not None:
+            image_gen_indicators = image_gen_indicators.to(device=device, dtype=torch.bool)
+        if indexes.shape != (3, input_ids.numel()):
+            raise ValueError("indexes must have shape (3, len(input_ids)).")
+        if image_token_tag.numel() != input_ids.numel():
+            raise ValueError("image_token_tag length must match input_ids.")
+        if input_embeds is not None:
+            input_embeds = input_embeds.to(
+                device=device,
+                dtype=next(self.model_worker.model_runner.model.parameters()).dtype,
+            )
+            if input_embeds.ndim == 3:
+                input_embeds = input_embeds.reshape(-1, input_embeds.shape[-1])
+            if input_embeds.shape[0] != input_ids.numel():
+                raise ValueError("input_embeds rows must match input_ids length.")
+        else:
+            input_embeds = self.compose_input_embeds(
+                input_ids=input_ids,
+                image_token_tag=image_token_tag,
+                pixel_values=pixel_values,
+                grid_hw=grid_hw,
+            )
+
+        req = self._make_req(
+            request_id=request_id,
+            input_ids=input_ids,
+            indexes=indexes,
+            image_token_tag=image_token_tag,
+            image_gen_indicators=image_gen_indicators,
+            max_new_tokens=max_new_tokens,
+            cache_extra_key=(
+                self._cache_extra_key(
+                    image_token_tag=image_token_tag,
+                    pixel_values=pixel_values,
+                    grid_hw=grid_hw,
+                    input_embeds=input_embeds,
+                )
+                if cache_extra_key is _CACHE_EXTRA_KEY_NOT_SET
+                else cache_extra_key
+            ),
+            has_projected_input_embeds=input_embeds is not None,
+        )
+        return {
+            "request_id": request_id,
+            "input_ids": input_ids,
+            "indexes": indexes,
+            "image_token_tag": image_token_tag,
+            "image_gen_indicators": image_gen_indicators,
+            "input_embeds": input_embeds,
+            "req": req,
+            "cache_extra_key": req.extra_key,
+        }
+
+    def run_hidden_prefill(
+        self,
+        request: dict[str, Any],
+        *,
+        cache_insert: bool = False,
+    ) -> NativeHiddenPrefillResult:
+        """Run one native extend prefill and return full extend-token hidden states."""
+
+        assert_no_hf_modeling_imported(context="before native hidden prefill")
+        device = torch.device(self.model_worker.device)
+        prepared = [self._prepare_prefill_request(**request)]
+        for item in prepared:
+            self.prefill_manager.add_one_request(item["req"])
+        batch = self.prefill_manager.schedule_next_batch(
+            self.decode_manager.running_batch,
+            num_allocatable_reqs=1,
+        )
+        if batch is None or len(batch.reqs) != 1:
+            raise RuntimeError(
+                "native hidden prefill failed to schedule one request: "
+                f"waiting_queue={len(getattr(self.prefill_manager, 'waiting_queue', []))} "
+                f"chunked_req={getattr(getattr(self.prefill_manager, 'chunked_req', None), 'rid', None)} "
+                f"running_batch_size={self.decode_manager.running_batch.batch_size()} "
+                f"running_batch_full={getattr(self.decode_manager.running_batch, 'batch_is_full', None)} "
+                f"request_tokens={int(request['input_ids'].numel())} "
+                f"image_tokens={int(request['image_token_tag'].reshape(-1).sum().item())} "
+                f"pool={self._pool_snapshot()} cache={self._cache_snapshot()}"
+            )
+
+        try:
+            from sglang_omni.model_runner.base import resolve_deferred_prefill_inputs
+
+            resolve_deferred_prefill_inputs(
+                batch,
+                torch.device(self.model_worker.device),
+            )
+            forward_batch = ForwardBatch.init_new(
+                batch,
+                self.model_worker.model_runner,
+                capture_hidden_mode=CaptureHiddenMode.FULL,
+                return_hidden_states_before_norm=False,
+            )
+            forward_batch_log = {
+                "forward_mode": str(forward_batch.forward_mode),
+                "batch_size": int(forward_batch.batch_size),
+                "input_ids_shape": list(forward_batch.input_ids.shape),
+                "positions_shape": list(forward_batch.positions.shape),
+                "mrope_positions_shape": (
+                    None
+                    if forward_batch.mrope_positions is None
+                    else list(forward_batch.mrope_positions.shape)
+                ),
+                "extend_seq_lens_cpu": list(forward_batch.extend_seq_lens_cpu or []),
+                "extend_prefix_lens_cpu": list(
+                    forward_batch.extend_prefix_lens_cpu or []
+                ),
+                "rids": list(forward_batch.rids or []),
+                "requested_batch_size": 1,
+                "scheduled_batch_size": int(forward_batch.batch_size),
+                "radix_cache_enabled": self.enable_radix_cache,
+            }
+            sidecar_input_embeds = self._attach_prefill_sidecar(
+                prepared=prepared,
+                forward_batch=forward_batch,
+                forward_batch_log=forward_batch_log,
+            )
+            if self.prefill_cuda_graph_enabled:
+                self.model_worker.model_runner.model.prepare_forward_batch(
+                    forward_batch
+                )
+
+            torch.cuda.synchronize(device) if device.type == "cuda" else None
+            start = time.perf_counter()
+            with torch.inference_mode(), block_hf_modeling_imports():
+                batch_result = self.model_worker.forward_batch_generation(
+                    forward_batch,
+                    batch=batch,
+                )
+            torch.cuda.synchronize(device) if device.type == "cuda" else None
+            elapsed = time.perf_counter() - start
+            forward_batch_log["can_run_cuda_graph"] = bool(
+                getattr(batch_result, "can_run_cuda_graph", False)
+            )
+
+            logits_output = batch_result.logits_output
+            hidden_states = None if logits_output is None else logits_output.hidden_states
+            if hidden_states is None:
+                raise RuntimeError("native hidden prefill did not return hidden states")
+            if isinstance(hidden_states, dict):
+                raise RuntimeError("native hidden prefill returned dict hidden states")
+            hidden_states = hidden_states.detach()
+
+            prepare = getattr(
+                self.model_worker.model_runner.model,
+                "last_forward_batch_prepare",
+                None,
+            )
+            attn_metadata = getattr(
+                self.model_worker.model_runner.attn_backend,
+                "forward_metadata",
+                None,
+            )
+            if attn_metadata is not None:
+                backend_mask = getattr(attn_metadata, "custom_mask", None)
+                backend_mask_indptr = getattr(attn_metadata, "mask_indptr", None)
+                forward_batch_log["backend_forward_metadata"] = {
+                    "class": type(attn_metadata).__name__,
+                    "custom_mask_present": backend_mask is not None,
+                    "custom_mask_numel": (
+                        None if backend_mask is None else int(backend_mask.numel())
+                    ),
+                    "mask_indptr": (
+                        None
+                        if backend_mask_indptr is None
+                        else [
+                            int(x)
+                            for x in backend_mask_indptr.detach().cpu().tolist()
+                        ]
+                    ),
+                }
+            states = forward_batch.model_specific_states or {}
+            forward_batch_log["model_specific_state_keys"] = sorted(states.keys())
+            forward_batch_log["resource_release"] = self._finish_prefill_batch(
+                batch,
+                cache_insert=cache_insert,
+            )
+            batch = None
+            assert_no_hf_modeling_imported(context="after native hidden prefill")
+            return NativeHiddenPrefillResult(
+                request_id=str(prepared[0]["request_id"]),
+                hidden_states=hidden_states,
+                forward_elapsed_s=elapsed,
+                backend_name=type(self.model_worker.model_runner.attn_backend).__name__,
+                prepare_metadata=prepare,
+                forward_batch_log=forward_batch_log,
+                input_embeds_used=sidecar_input_embeds is not None,
+                input_embeds_shape=(
+                    None
+                    if sidecar_input_embeds is None
+                    else list(sidecar_input_embeds.shape)
+                ),
+                cache_inserted=bool(cache_insert),
+                cache_extra_key=prepared[0]["cache_extra_key"],
+            )
+        finally:
+            if batch is not None:
+                self._finish_prefill_batch(batch, cache_insert=False)
+
+    @staticmethod
+    def _sample_next_token_ids(
+        batch_result: Any,
+        *,
+        suppress_token_ids: list[int] | None = None,
+    ) -> list[int]:
+        suppress_ids = sorted({int(x) for x in (suppress_token_ids or [])})
+        if suppress_ids:
+            logits = batch_result.logits_output.next_token_logits
+            if logits is None:
+                raise RuntimeError("native decode benchmark produced no logits")
+            filtered = logits.float().clone()
+            filtered[:, suppress_ids] = torch.finfo(filtered.dtype).min
+            return [
+                int(x)
+                for x in torch.argmax(filtered, dim=-1).detach().cpu().tolist()
+            ]
+
+        next_token_ids = getattr(batch_result, "next_token_ids", None)
+        if next_token_ids is not None:
+            if isinstance(next_token_ids, torch.Tensor):
+                values = next_token_ids.detach().reshape(-1).cpu().tolist()
+                return [int(x) for x in values]
+            if isinstance(next_token_ids, list):
+                values: list[int] = []
+                for item in next_token_ids:
+                    if isinstance(item, torch.Tensor):
+                        flat = item.detach().reshape(-1).cpu().tolist()
+                        values.append(int(flat[0]))
+                    elif isinstance(item, (list, tuple)):
+                        values.append(int(item[0]))
+                    else:
+                        values.append(int(item))
+                return values
+
+        logits = batch_result.logits_output.next_token_logits
+        if logits is None:
+            raise RuntimeError("native decode benchmark produced no logits")
+        return [int(x) for x in torch.argmax(logits.float(), dim=-1).cpu().tolist()]
+
+    @staticmethod
+    def _zero_text_decode_hw_axes(forward_batch: ForwardBatch) -> None:
+        """Match U1 official AR text decode indexes: [t_index, 0, 0]."""
+
+        mrope_positions = getattr(forward_batch, "mrope_positions", None)
+        if mrope_positions is not None and mrope_positions.ndim == 2:
+            mrope_positions[1:].zero_()
+
+    def _attach_prefill_sidecar(
+        self,
+        *,
+        prepared: list[dict[str, Any]],
+        forward_batch: ForwardBatch,
+        forward_batch_log: dict[str, Any],
+    ) -> torch.Tensor | None:
+        extend_lens = list(forward_batch.extend_seq_lens_cpu or [])
+        prefix_lens = list(forward_batch.extend_prefix_lens_cpu or [])
+        sidecar_input_embeds = None
+        if any(item["input_embeds"] is not None for item in prepared):
+            if not all(item["input_embeds"] is not None for item in prepared):
+                raise RuntimeError(
+                    "native serving batch cannot mix projected input_embeds and "
+                    "plain token embeddings yet"
+                )
+            if not extend_lens:
+                extend_lens = [int(forward_batch.input_ids.numel())]
+            if not prefix_lens:
+                prefix_lens = [0] * len(extend_lens)
+            if len(extend_lens) != len(prepared):
+                raise RuntimeError(
+                    "native serving batch lens mismatch: "
+                    f"lens={len(extend_lens)} requests={len(prepared)}"
+                )
+            parts = []
+            for item, prefix_len, extend_len in zip(prepared, prefix_lens, extend_lens):
+                embeds = item["input_embeds"]
+                if embeds is None:
+                    raise RuntimeError("missing projected input_embeds")
+                parts.append(
+                    embeds[int(prefix_len) : int(prefix_len) + int(extend_len)]
+                    .contiguous()
+                )
+            sidecar_input_embeds = torch.cat(parts, dim=0)
+            attach_omni_prefill_inputs(
+                forward_batch,
+                OmniPrefillInputs(input_embeds=sidecar_input_embeds),
+            )
+            forward_batch_log["omni_prefill_input_embeds_shape"] = list(
+                sidecar_input_embeds.shape
+            )
+        return sidecar_input_embeds
+
+    def run_prefill_batch(
+        self,
+        requests: list[dict[str, Any]],
+        *,
+        cache_insert: bool = False,
+    ) -> list[NativeServingResult]:
+        assert_no_hf_modeling_imported(context="before native prefill batch")
+        if not requests:
+            return []
+        device = torch.device(self.model_worker.device)
+        if len(requests) > self.max_running_requests:
+            raise ValueError(
+                "native prefill batch exceeds max_running_requests: "
+                f"batch={len(requests)} max={self.max_running_requests}"
+            )
+        prepared = [self._prepare_prefill_request(**item) for item in requests]
+        cache_before_schedule = self._cache_snapshot()
+        for item in prepared:
+            self.prefill_manager.add_one_request(item["req"])
+        batch = self.prefill_manager.schedule_next_batch(
+            self.decode_manager.running_batch,
+            num_allocatable_reqs=len(prepared),
+        )
+        if batch is None:
+            raise RuntimeError("native serving prefill manager returned no batch")
+        if len(batch.reqs) != len(prepared):
+            raise RuntimeError(
+                "native serving prefill manager did not schedule the full batch: "
+                f"scheduled={len(batch.reqs)} requested={len(prepared)}"
+            )
+
+        from sglang_omni.model_runner.base import resolve_deferred_prefill_inputs
+
+        resolve_deferred_prefill_inputs(
+            batch,
+            torch.device(self.model_worker.device),
+        )
+        forward_batch = ForwardBatch.init_new(
+            batch,
+            self.model_worker.model_runner,
+            capture_hidden_mode=CaptureHiddenMode.NULL,
+            return_hidden_states_before_norm=False,
+        )
+        forward_batch_log = {
+            "forward_mode": str(forward_batch.forward_mode),
+            "batch_size": int(forward_batch.batch_size),
+            "input_ids_shape": list(forward_batch.input_ids.shape),
+            "positions_shape": list(forward_batch.positions.shape),
+            "mrope_positions_shape": (
+                None
+                if forward_batch.mrope_positions is None
+                else list(forward_batch.mrope_positions.shape)
+            ),
+            "extend_seq_lens_cpu": list(forward_batch.extend_seq_lens_cpu or []),
+            "extend_prefix_lens_cpu": list(forward_batch.extend_prefix_lens_cpu or []),
+            "rids": list(forward_batch.rids or []),
+            "requested_batch_size": len(prepared),
+            "scheduled_batch_size": int(forward_batch.batch_size),
+            "radix_cache_enabled": self.enable_radix_cache,
+            "cache_before_schedule": cache_before_schedule,
+        }
+        extend_lens = list(forward_batch.extend_seq_lens_cpu or [])
+        prefix_lens = list(forward_batch.extend_prefix_lens_cpu or [])
+        sidecar_input_embeds = self._attach_prefill_sidecar(
+            prepared=prepared,
+            forward_batch=forward_batch,
+            forward_batch_log=forward_batch_log,
+        )
+        if self.prefill_cuda_graph_enabled:
+            self.model_worker.model_runner.model.prepare_forward_batch(
+                forward_batch
+            )
+        per_request_log = []
+        for idx, (item, req) in enumerate(zip(prepared, batch.reqs)):
+            prefix_len = int(prefix_lens[idx]) if idx < len(prefix_lens) else 0
+            extend_len = int(extend_lens[idx]) if idx < len(extend_lens) else 0
+            per_request_log.append(
+                {
+                    "batch_index": idx,
+                    "rid": str(req.rid),
+                    "input_tokens": int(item["input_ids"].numel()),
+                    "prefix_len": prefix_len,
+                    "extend_len": extend_len,
+                    "cache_hit": prefix_len > 0,
+                    "cache_extra_key": item["cache_extra_key"],
+                    "image_token_count": int(item["image_token_tag"].sum().item()),
+                }
+            )
+        forward_batch_log["per_request"] = per_request_log
+        forward_batch_log["cache_hit_requests"] = sum(
+            1 for item in per_request_log if item["cache_hit"]
+        )
+        forward_batch_log["cache_hit_tokens"] = sum(
+            int(item["prefix_len"]) for item in per_request_log
+        )
+
+        torch.cuda.synchronize(device) if device.type == "cuda" else None
+        dense_calls_before = None
+        dense_calls_after = None
+        try:
+            from sglang_omni.models.sensenova_u1 import (
+                attention_backend as _u1_attn,
+            )
+
+            dense_calls_before = int(
+                getattr(_u1_attn, "CUSTOM_MASK_DENSE_ATTENTION_CALLS", 0)
+            )
+        except Exception:
+            _u1_attn = None
+        start = time.perf_counter()
+        with torch.inference_mode(), block_hf_modeling_imports():
+            batch_result = self.model_worker.forward_batch_generation(
+                forward_batch,
+                batch=batch,
+            )
+        torch.cuda.synchronize(device) if device.type == "cuda" else None
+        if _u1_attn is not None:
+            dense_calls_after = int(
+                getattr(_u1_attn, "CUSTOM_MASK_DENSE_ATTENTION_CALLS", 0)
+            )
+            forward_batch_log["custom_mask_dense_attention_calls_delta"] = (
+                dense_calls_after - (dense_calls_before or 0)
+            )
+        elapsed = time.perf_counter() - start
+        forward_batch_log["can_run_cuda_graph"] = bool(
+            getattr(batch_result, "can_run_cuda_graph", False)
+        )
+        logits = batch_result.logits_output.next_token_logits
+        if logits is None:
+            raise RuntimeError("native serving prefill produced no logits")
+        if int(logits.shape[0]) != len(prepared):
+            raise RuntimeError(
+                "native serving logits batch size mismatch: "
+                f"logits={list(logits.shape)} requests={len(prepared)}"
+            )
+        prepare = getattr(
+            self.model_worker.model_runner.model,
+            "last_forward_batch_prepare",
+            None,
+        )
+        attn_metadata = getattr(
+            self.model_worker.model_runner.attn_backend,
+            "forward_metadata",
+            None,
+        )
+        if attn_metadata is not None:
+            backend_mask = getattr(attn_metadata, "custom_mask", None)
+            backend_mask_indptr = getattr(attn_metadata, "mask_indptr", None)
+            forward_batch_log["backend_forward_metadata"] = {
+                "class": type(attn_metadata).__name__,
+                "custom_mask_present": backend_mask is not None,
+                "custom_mask_numel": (
+                    None if backend_mask is None else int(backend_mask.numel())
+                ),
+                "mask_indptr": (
+                    None
+                    if backend_mask_indptr is None
+                    else [int(x) for x in backend_mask_indptr.detach().cpu().tolist()]
+                ),
+            }
+        if forward_batch.cross_attention_custom_mask is not None:
+            forward_batch_log["custom_mask_shape"] = [
+                int(forward_batch.cross_attention_custom_mask.numel())
+            ]
+            forward_batch_log["custom_mask_dtype"] = str(
+                forward_batch.cross_attention_custom_mask.dtype
+            )
+        states = forward_batch.model_specific_states or {}
+        forward_batch_log["model_specific_state_keys"] = sorted(states.keys())
+        forward_batch_log["resource_release"] = self._finish_prefill_batch(
+            batch,
+            cache_insert=cache_insert,
+        )
+
+        assert_no_hf_modeling_imported(context="after native prefill batch")
+        results: list[NativeServingResult] = []
+        for idx, item in enumerate(prepared):
+            row_logits = logits[idx : idx + 1]
+            next_token_id = int(torch.argmax(row_logits[0].float()).item())
+            item_log = dict(forward_batch_log)
+            item_log["this_request"] = per_request_log[idx]
+            results.append(
+                NativeServingResult(
+                    request_id=str(item["request_id"]),
+                    next_token_id=next_token_id,
+                    logits_shape=list(row_logits.shape),
+                    logits_dtype=str(row_logits.dtype),
+                    logits_device=str(row_logits.device),
+                    logits_all_finite=bool(torch.isfinite(row_logits).all().item()),
+                    forward_elapsed_s=elapsed,
+                    backend_name=type(self.model_worker.model_runner.attn_backend).__name__,
+                    prepare_metadata=prepare,
+                    forward_batch_log=item_log,
+                    input_embeds_used=sidecar_input_embeds is not None,
+                    input_embeds_shape=(
+                        None
+                        if sidecar_input_embeds is None
+                        else list(sidecar_input_embeds.shape)
+                    ),
+                    batch_index=idx,
+                    batch_size=len(prepared),
+                    cache_inserted=bool(cache_insert),
+                    cache_extra_key=item["cache_extra_key"],
+                    next_token_logits=row_logits.detach().float().cpu(),
+                )
+            )
+        return results
+
+    def run_greedy_decode_batch(
+        self,
+        requests: list[dict[str, Any]],
+        *,
+        decode_steps: int,
+        suppress_token_ids: list[int] | None = None,
+    ) -> NativeDecodeBenchmarkResult:
+        """Run a fixed-step greedy decode benchmark on the native SGLang path.
+
+        This intentionally bypasses tokenizer streaming and stop handling so the
+        benchmark measures the same number of generated tokens for every batch.
+        It still uses SGLang's ScheduleBatch, ForwardBatch, RadixAttention, and
+        KV-cache allocation path.
+        """
+
+        assert_no_hf_modeling_imported(context="before native greedy decode batch")
+        if decode_steps <= 0:
+            raise ValueError("decode_steps must be positive")
+        if not requests:
+            raise ValueError("requests must be non-empty")
+        if len(requests) > self.max_running_requests:
+            raise ValueError(
+                "native decode batch exceeds max_running_requests: "
+                f"batch={len(requests)} max={self.max_running_requests}"
+            )
+
+        device = torch.device(self.model_worker.device)
+        prepared = [
+            self._prepare_prefill_request(**item, max_new_tokens=decode_steps)
+            for item in requests
+        ]
+        batch = None
+        release_log = None
+        generated: list[list[int]] = [[] for _ in prepared]
+        per_step_elapsed_s: list[float] = []
+        decode_logs: list[dict[str, Any]] = []
+        logits_all_finite = True
+        total_start = time.perf_counter()
+        try:
+            for item in prepared:
+                self.prefill_manager.add_one_request(item["req"])
+            batch = self.prefill_manager.schedule_next_batch(
+                self.decode_manager.running_batch,
+                num_allocatable_reqs=len(prepared),
+            )
+            if batch is None:
+                raise RuntimeError("native decode prefill manager returned no batch")
+            if len(batch.reqs) != len(prepared):
+                raise RuntimeError(
+                    "native decode benchmark did not schedule the full batch: "
+                    f"scheduled={len(batch.reqs)} requested={len(prepared)}"
+                )
+
+            from sglang_omni.model_runner.base import resolve_deferred_prefill_inputs
+
+            resolve_deferred_prefill_inputs(
+                batch,
+                torch.device(self.model_worker.device),
+            )
+            forward_batch = ForwardBatch.init_new(
+                batch,
+                self.model_worker.model_runner,
+                capture_hidden_mode=CaptureHiddenMode.NULL,
+                return_hidden_states_before_norm=False,
+            )
+            prefill_log = {
+                "forward_mode": str(forward_batch.forward_mode),
+                "batch_size": int(forward_batch.batch_size),
+                "input_ids_shape": list(forward_batch.input_ids.shape),
+                "positions_shape": list(forward_batch.positions.shape),
+                "mrope_positions_shape": (
+                    None
+                    if forward_batch.mrope_positions is None
+                    else list(forward_batch.mrope_positions.shape)
+                ),
+                "extend_seq_lens_cpu": list(forward_batch.extend_seq_lens_cpu or []),
+                "extend_prefix_lens_cpu": list(forward_batch.extend_prefix_lens_cpu or []),
+                "rids": list(forward_batch.rids or []),
+                "requested_batch_size": len(prepared),
+                "scheduled_batch_size": int(forward_batch.batch_size),
+                "radix_cache_enabled": self.enable_radix_cache,
+            }
+            sidecar_input_embeds = self._attach_prefill_sidecar(
+                prepared=prepared,
+                forward_batch=forward_batch,
+                forward_batch_log=prefill_log,
+            )
+
+            torch.cuda.synchronize(device) if device.type == "cuda" else None
+            prefill_start = time.perf_counter()
+            with torch.inference_mode(), block_hf_modeling_imports():
+                batch_result = self.model_worker.forward_batch_generation(
+                    forward_batch,
+                    batch=batch,
+                )
+            torch.cuda.synchronize(device) if device.type == "cuda" else None
+            prefill_elapsed = time.perf_counter() - prefill_start
+            prefill_logits = batch_result.logits_output.next_token_logits
+            logits_all_finite = bool(
+                logits_all_finite
+                and prefill_logits is not None
+                and torch.isfinite(prefill_logits).all().item()
+            )
+            next_ids = self._sample_next_token_ids(
+                batch_result,
+                suppress_token_ids=suppress_token_ids,
+            )
+            if len(next_ids) != len(prepared):
+                raise RuntimeError(
+                    f"prefill sampled {len(next_ids)} ids for {len(prepared)} requests"
+                )
+            for req, token_id, out in zip(batch.reqs, next_ids, generated):
+                req.output_ids.append(int(token_id))
+                out.append(int(token_id))
+            batch.input_ids = torch.tensor(
+                next_ids,
+                dtype=torch.int64,
+                device=device,
+            )
+
+            decode_elapsed = 0.0
+            for step_idx in range(1, decode_steps):
+                if not batch.check_decode_mem():
+                    raise RuntimeError("native decode benchmark ran out of KV memory")
+                batch.prepare_for_decode()
+                forward_batch = ForwardBatch.init_new(
+                    batch,
+                    self.model_worker.model_runner,
+                    capture_hidden_mode=CaptureHiddenMode.NULL,
+                    return_hidden_states_before_norm=False,
+                )
+                self._zero_text_decode_hw_axes(forward_batch)
+                step_log = {
+                    "step": step_idx,
+                    "forward_mode": str(forward_batch.forward_mode),
+                    "batch_size": int(forward_batch.batch_size),
+                    "input_ids_shape": list(forward_batch.input_ids.shape),
+                    "positions_shape": list(forward_batch.positions.shape),
+                    "mrope_positions_shape": (
+                        None
+                        if forward_batch.mrope_positions is None
+                        else list(forward_batch.mrope_positions.shape)
+                    ),
+                    "mrope_positions": (
+                        None
+                        if forward_batch.mrope_positions is None
+                        else [
+                            [int(v) for v in row]
+                            for row in forward_batch.mrope_positions.detach()
+                            .cpu()
+                            .tolist()
+                        ]
+                    ),
+                    "seq_lens_cpu": (
+                        None
+                        if forward_batch.seq_lens_cpu is None
+                        else [int(x) for x in forward_batch.seq_lens_cpu.tolist()]
+                    ),
+                    "rids": list(forward_batch.rids or []),
+                }
+                torch.cuda.synchronize(device) if device.type == "cuda" else None
+                step_start = time.perf_counter()
+                with torch.inference_mode(), block_hf_modeling_imports():
+                    batch_result = self.model_worker.forward_batch_generation(
+                        forward_batch,
+                        batch=batch,
+                    )
+                torch.cuda.synchronize(device) if device.type == "cuda" else None
+                step_elapsed = time.perf_counter() - step_start
+                step_log["can_run_cuda_graph"] = bool(
+                    getattr(batch_result, "can_run_cuda_graph", False)
+                )
+                decode_elapsed += step_elapsed
+                per_step_elapsed_s.append(step_elapsed)
+                logits = batch_result.logits_output.next_token_logits
+                logits_all_finite = bool(
+                    logits_all_finite
+                    and logits is not None
+                    and torch.isfinite(logits).all().item()
+                )
+                next_ids = self._sample_next_token_ids(
+                    batch_result,
+                    suppress_token_ids=suppress_token_ids,
+                )
+                if len(next_ids) != len(prepared):
+                    raise RuntimeError(
+                        f"decode step {step_idx} sampled {len(next_ids)} ids "
+                        f"for {len(prepared)} requests"
+                    )
+                for req, token_id, out in zip(batch.reqs, next_ids, generated):
+                    req.output_ids.append(int(token_id))
+                    out.append(int(token_id))
+                batch.input_ids = torch.tensor(
+                    next_ids,
+                    dtype=torch.int64,
+                    device=device,
+                )
+                decode_logs.append(step_log)
+
+            total_elapsed = time.perf_counter() - total_start
+            release_log = self._finish_prefill_batch(batch, cache_insert=False)
+            batch = None
+            assert_no_hf_modeling_imported(context="after native greedy decode batch")
+            prompt_tokens = sum(int(item["input_ids"].numel()) for item in prepared)
+            return NativeDecodeBenchmarkResult(
+                request_count=len(prepared),
+                decode_steps=decode_steps,
+                prompt_tokens=prompt_tokens,
+                generated_tokens=len(prepared) * decode_steps,
+                prefill_elapsed_s=prefill_elapsed,
+                decode_elapsed_s=decode_elapsed,
+                total_elapsed_s=total_elapsed,
+                generated_token_ids=generated,
+                per_step_elapsed_s=per_step_elapsed_s,
+                prefill_forward_batch_log=prefill_log,
+                decode_forward_batch_logs=decode_logs,
+                release_log=release_log,
+                logits_all_finite=logits_all_finite,
+            )
+        finally:
+            if batch is not None:
+                self._finish_prefill_batch(batch, cache_insert=False)
+
+    def run_eager_text_decode(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        indexes: torch.Tensor,
+        image_token_tag: torch.Tensor,
+        decode_steps: int,
+        input_embeds: torch.Tensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        grid_hw: torch.Tensor | None = None,
+        forced_token_ids: list[int] | None = None,
+        suppress_token_ids: list[int] | None = None,
+        capture_step: int | None = None,
+    ) -> NativeEagerTextDecodeResult:
+        """Run HF-style eager cached text decode with native weights.
+
+        This path is scoped to U1 interleave text-state validation: it does not
+        import official U1 modeling code and it keeps the SGLang-loaded native
+        weights, but it mirrors HF DynamicCache/eager attention numerics for
+        single-request text continuation.
+        """
+
+        assert_no_hf_modeling_imported(context="before native eager text decode")
+        if decode_steps <= 0:
+            raise ValueError("decode_steps must be positive")
+        device = torch.device(self.model_worker.device)
+        model = self.model_worker.model_runner.model
+        dtype = next(model.parameters()).dtype
+        input_ids = input_ids.to(device=device, dtype=torch.long).reshape(-1)
+        indexes = indexes.to(device=device, dtype=torch.long)
+        image_token_tag = image_token_tag.to(device=device, dtype=torch.bool).reshape(-1)
+        if input_embeds is not None:
+            input_embeds = input_embeds.to(device=device, dtype=dtype)
+            if input_embeds.ndim == 3:
+                input_embeds = input_embeds.reshape(-1, input_embeds.shape[-1])
+        else:
+            input_embeds = self.compose_input_embeds(
+                input_ids=input_ids,
+                image_token_tag=image_token_tag,
+                pixel_values=pixel_values,
+                grid_hw=grid_hw,
+            )
+        if indexes.shape != (3, input_ids.numel()):
+            raise ValueError("indexes must have shape (3, len(input_ids)).")
+        if image_token_tag.numel() != input_ids.numel():
+            raise ValueError("image_token_tag length must match input_ids.")
+        if input_embeds is not None and input_embeds.shape[0] != input_ids.numel():
+            raise ValueError("input_embeds rows must match input_ids length.")
+        suppress_ids = sorted({int(x) for x in (suppress_token_ids or [])})
+        bf16_argmax = self._native_eager_bf16_argmax_enabled()
+        lm_head_linear = self._native_eager_lm_head_linear_enabled()
+        direct_embedding = self._native_eager_direct_embedding_enabled()
+        compiled_add_rms = self._native_eager_compiled_add_rms_enabled()
+        compiled_add_rms_layers = os.environ.get(
+            "SENSENOVA_U1_NATIVE_EAGER_COMPILED_ADD_RMS_LAYERS",
+            "",
+        )
+
+        def _select_next_token(logits_tensor: torch.Tensor) -> tuple[int, int | None]:
+            if bf16_argmax and not suppress_ids:
+                return int(torch.argmax(logits_tensor[0]).item()), None
+            scores = logits_tensor[0].float()
+            raw_argmax = int(torch.argmax(scores).item())
+            if suppress_ids and raw_argmax in suppress_ids:
+                scores = scores.clone()
+                scores[suppress_ids] = torch.finfo(scores.dtype).min
+                return int(torch.argmax(scores).item()), raw_argmax
+            return raw_argmax, None
+
+        generated: list[int] = []
+        step_logs: list[dict[str, Any]] = []
+        per_step_elapsed_s: list[float] = []
+        logits_all_finite = True
+        captured_layer_hidden_states: list[torch.Tensor] | None = None
+        total_start = time.perf_counter()
+        repeat_kv_cache = self._native_eager_repeated_kv_cache_enabled()
+        use_static_kv_cache = self._native_eager_static_kv_cache_enabled()
+        eager_prefix_cache_key = (
+            self._eager_text_prefix_cache_key(
+                input_ids=input_ids,
+                indexes=indexes,
+                image_token_tag=image_token_tag,
+                input_embeds=input_embeds,
+                repeat_kv_cache=repeat_kv_cache,
+            )
+            if self._native_eager_prefix_cache_enabled()
+            else None
+        )
+        eager_prefix_cache_hit = bool(
+            eager_prefix_cache_key is not None
+            and eager_prefix_cache_key in self._eager_text_prefill_cache
+        )
+        torch.cuda.synchronize(device) if device.type == "cuda" else None
+        prefill_start = time.perf_counter()
+        if eager_prefix_cache_hit:
+            logits, caches, prefill_logits_finite = self._eager_text_prefill_cache[
+                eager_prefix_cache_key
+            ]
+        else:
+            with torch.inference_mode(), block_hf_modeling_imports():
+                hidden_states, caches = model.model.eager_text_prefill_with_cache(
+                    input_ids,
+                    torch.arange(
+                        input_ids.numel(),
+                        device=device,
+                        dtype=torch.long,
+                    ),
+                    input_embeds=input_embeds,
+                    indexes=indexes,
+                    image_token_tag=image_token_tag,
+                    repeat_kv_cache=repeat_kv_cache,
+                )
+                logits = model.eager_text_logits(hidden_states)
+            prefill_logits_finite = bool(torch.isfinite(logits).all().item())
+            if eager_prefix_cache_key is not None:
+                self._eager_text_prefill_cache[eager_prefix_cache_key] = (
+                    logits.detach(),
+                    caches,
+                    prefill_logits_finite,
+                )
+        torch.cuda.synchronize(device) if device.type == "cuda" else None
+        prefill_elapsed = time.perf_counter() - prefill_start
+        logits_all_finite = prefill_logits_finite
+        next_token_id, suppressed_argmax = _select_next_token(logits)
+        generated.append(next_token_id)
+        step_logs.append(
+            {
+                "step": 0,
+                "mode": "prefill",
+                "predicts_token_index": 0,
+                "predicted_token_id": next_token_id,
+                "suppressed_argmax_token_id": suppressed_argmax,
+                "suppress_token_ids": suppress_ids,
+                "cache_seq_len_after": int(caches[0][0].shape[0]) if caches else 0,
+                "indexes": [
+                    [int(v) for v in row[-5:]]
+                    for row in indexes.detach().cpu().tolist()
+                ],
+            }
+        )
+
+        decode_elapsed = 0.0
+        last_logits = logits.detach().float().cpu()
+        full_loop_graph_used = bool(
+            device.type == "cuda"
+            and self._native_eager_full_loop_cuda_graph_enabled()
+            and decode_steps > 1
+            and forced_token_ids is None
+            and not suppress_ids
+            and capture_step is None
+        )
+        if full_loop_graph_used:
+            graph_key = (
+                int(caches[0][0].shape[0]),
+                int(indexes[0].max().item()),
+                int(decode_steps),
+                repeat_kv_cache,
+                use_static_kv_cache,
+                bf16_argmax,
+                lm_head_linear,
+                direct_embedding,
+                compiled_add_rms,
+                compiled_add_rms_layers,
+                self._native_eager_graph_mode(),
+            )
+            graph_created = graph_key not in self._eager_text_decode_graphs
+            if graph_created:
+                self._eager_text_decode_graphs[graph_key] = (
+                    self._capture_eager_text_decode_graph(
+                        model=model,
+                        caches=caches,
+                        input_token_id=next_token_id,
+                        start_t_index=int(graph_key[1]),
+                        decode_steps=decode_steps,
+                        device=device,
+                        source_prefix_cache_key=eager_prefix_cache_key,
+                        graph_mode=str(graph_key[10]),
+                        repeat_kv_cache=bool(graph_key[3]),
+                        use_static_kv_cache=bool(graph_key[4]),
+                        bf16_argmax=bool(graph_key[5]),
+                    )
+                )
+            graph_runner = self._eager_text_decode_graphs[graph_key]
+            torch.cuda.synchronize(device)
+            decode_start = time.perf_counter()
+            skip_initial_copy = bool(
+                eager_prefix_cache_hit
+                and eager_prefix_cache_key is not None
+                and graph_runner.source_prefix_cache_key
+                == eager_prefix_cache_key
+            )
+            if not skip_initial_copy:
+                for (static_k, static_v), (live_k, live_v) in zip(
+                    graph_runner.initial_caches,
+                    caches,
+                ):
+                    static_k[: live_k.shape[0]].copy_(live_k)
+                    static_v[: live_v.shape[0]].copy_(live_v)
+                graph_runner.input_token.fill_(next_token_id)
+                graph_runner.source_prefix_cache_key = eager_prefix_cache_key
+            for graph in graph_runner.graphs:
+                graph.replay()
+            torch.cuda.synchronize(device)
+            decode_elapsed = time.perf_counter() - decode_start
+            tail_ids = [
+                int(x)
+                for x in torch.cat(
+                    graph_runner.generated_tokens,
+                ).detach().cpu().tolist()
+            ]
+            generated.extend(tail_ids)
+            fast_result = bool(
+                skip_initial_copy
+                and self._native_eager_fast_result_enabled()
+            )
+            if fast_result:
+                last_logits = None
+                logits_all_finite = bool(
+                    logits_all_finite and graph_runner.verified_finite
+                )
+            else:
+                last_logits = graph_runner.last_logits.detach().float().cpu()
+                logits_all_finite = bool(
+                    logits_all_finite
+                    and torch.isfinite(graph_runner.last_logits).all().item()
+                )
+            average_step_s = decode_elapsed / max(len(tail_ids), 1)
+            per_step_elapsed_s.extend([average_step_s] * len(tail_ids))
+            if not fast_result:
+                for step_idx, token_id in enumerate(tail_ids, start=1):
+                    step_logs.append(
+                        {
+                            "step": step_idx,
+                            "mode": "decode_full_loop_cuda_graph",
+                            "predicts_token_index": step_idx,
+                            "predicted_token_id": token_id,
+                            "suppressed_argmax_token_id": None,
+                            "suppress_token_ids": [],
+                            "decode_indexes": [
+                                [int(v) for v in row]
+                                for row in graph_runner.decode_indexes[
+                                    step_idx - 1
+                                ].detach().cpu().tolist()
+                            ],
+                            "cache_seq_len_after": graph_key[0] + step_idx,
+                            "elapsed_s": average_step_s,
+                        }
+                    )
+            total_elapsed = time.perf_counter() - total_start
+            assert_no_hf_modeling_imported(
+                context="after native eager text decode"
+            )
+            return NativeEagerTextDecodeResult(
+                decode_steps=decode_steps,
+                prompt_tokens=int(input_ids.numel()),
+                generated_token_ids=generated,
+                prefill_elapsed_s=prefill_elapsed,
+                decode_elapsed_s=decode_elapsed,
+                total_elapsed_s=total_elapsed,
+                per_step_elapsed_s=per_step_elapsed_s,
+                step_logs=step_logs,
+                logits_all_finite=logits_all_finite,
+                next_token_logits=last_logits,
+                captured_layer_hidden_states=None,
+                full_loop_cuda_graph_used=True,
+                full_loop_cuda_graph_created=graph_created,
+                full_loop_cuda_graph_key=":".join(str(x) for x in graph_key),
+                eager_prefix_cache_hit=eager_prefix_cache_hit,
+                eager_prefix_cache_key=eager_prefix_cache_key,
+                full_loop_initial_cache_copy_skipped=skip_initial_copy,
+            )
+
+        for step_idx in range(1, decode_steps):
+            if forced_token_ids is not None and step_idx - 1 < len(forced_token_ids):
+                input_token_id = int(forced_token_ids[step_idx - 1])
+            else:
+                input_token_id = int(generated[-1])
+            past_t_index = int(indexes[0].max().item()) + step_idx - 1
+            decode_indexes = torch.tensor(
+                [[past_t_index + 1], [0], [0]],
+                device=device,
+                dtype=torch.long,
+            )
+            input_token = torch.tensor([input_token_id], device=device, dtype=torch.long)
+            torch.cuda.synchronize(device) if device.type == "cuda" else None
+            step_start = time.perf_counter()
+            capture_layer_outputs: list[torch.Tensor] | None = (
+                [] if capture_step is not None and step_idx == int(capture_step) else None
+            )
+            with torch.inference_mode(), block_hf_modeling_imports():
+                hidden_states, caches = model.model.eager_text_decode_with_cache(
+                    input_token,
+                    decode_indexes[0],
+                    caches,
+                    indexes=decode_indexes,
+                    capture_layer_outputs=capture_layer_outputs,
+                    repeat_kv_cache=repeat_kv_cache,
+                )
+                logits = model.eager_text_logits(hidden_states)
+            if capture_layer_outputs is not None:
+                captured_layer_hidden_states = capture_layer_outputs
+            torch.cuda.synchronize(device) if device.type == "cuda" else None
+            step_elapsed = time.perf_counter() - step_start
+            decode_elapsed += step_elapsed
+            per_step_elapsed_s.append(step_elapsed)
+            logits_all_finite = bool(
+                logits_all_finite and torch.isfinite(logits).all().item()
+            )
+            next_token_id, suppressed_argmax = _select_next_token(logits)
+            generated.append(next_token_id)
+            last_logits = logits.detach().float().cpu()
+            step_logs.append(
+                {
+                    "step": step_idx,
+                    "mode": "decode",
+                    "input_token_id": input_token_id,
+                    "predicts_token_index": step_idx,
+                    "predicted_token_id": next_token_id,
+                    "suppressed_argmax_token_id": suppressed_argmax,
+                    "suppress_token_ids": suppress_ids,
+                    "decode_indexes": [
+                        [int(v) for v in row]
+                        for row in decode_indexes.detach().cpu().tolist()
+                    ],
+                    "cache_seq_len_after": int(caches[0][0].shape[0]) if caches else 0,
+                    "elapsed_s": step_elapsed,
+                }
+            )
+
+        total_elapsed = time.perf_counter() - total_start
+        assert_no_hf_modeling_imported(context="after native eager text decode")
+        return NativeEagerTextDecodeResult(
+            decode_steps=decode_steps,
+            prompt_tokens=int(input_ids.numel()),
+            generated_token_ids=generated,
+            prefill_elapsed_s=prefill_elapsed,
+            decode_elapsed_s=decode_elapsed,
+            total_elapsed_s=total_elapsed,
+            per_step_elapsed_s=per_step_elapsed_s,
+            step_logs=step_logs,
+            logits_all_finite=logits_all_finite,
+            next_token_logits=last_logits,
+            captured_layer_hidden_states=captured_layer_hidden_states,
+            eager_prefix_cache_hit=eager_prefix_cache_hit,
+            eager_prefix_cache_key=eager_prefix_cache_key,
+        )
+
+    @staticmethod
+    def _native_eager_full_loop_cuda_graph_enabled() -> bool:
+        value = os.environ.get(
+            "SENSENOVA_U1_NATIVE_EAGER_TEXT_FULL_LOOP_CUDA_GRAPH",
+            "",
+        ).lower()
+        return value not in {"0", "false", "no", "off"}
+
+    @staticmethod
+    def _native_eager_prefix_cache_enabled() -> bool:
+        value = os.environ.get(
+            "SENSENOVA_U1_NATIVE_EAGER_TEXT_PREFIX_CACHE",
+            "",
+        ).lower()
+        return value not in {"0", "false", "no", "off"}
+
+    @staticmethod
+    def _native_eager_repeated_kv_cache_enabled() -> bool:
+        return os.environ.get(
+            "SENSENOVA_U1_NATIVE_EAGER_REPEATED_KV_CACHE",
+            "",
+        ).lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _native_eager_static_kv_cache_enabled() -> bool:
+        return os.environ.get(
+            "SENSENOVA_U1_NATIVE_EAGER_STATIC_KV_CACHE",
+            "",
+        ).lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _native_eager_bf16_argmax_enabled() -> bool:
+        return os.environ.get(
+            "SENSENOVA_U1_NATIVE_EAGER_BF16_ARGMAX",
+            "",
+        ).lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _native_eager_lm_head_linear_enabled() -> bool:
+        return os.environ.get(
+            "SENSENOVA_U1_NATIVE_EAGER_LM_HEAD_LINEAR",
+            "",
+        ).lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _native_eager_fast_result_enabled() -> bool:
+        return os.environ.get(
+            "SENSENOVA_U1_NATIVE_EAGER_FAST_RESULT",
+            "",
+        ).lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _native_eager_direct_embedding_enabled() -> bool:
+        return os.environ.get(
+            "SENSENOVA_U1_NATIVE_EAGER_DIRECT_EMBEDDING",
+            "",
+        ).lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _native_eager_compiled_add_rms_enabled() -> bool:
+        return os.environ.get(
+            "SENSENOVA_U1_NATIVE_EAGER_COMPILED_ADD_RMS",
+            "",
+        ).lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _native_eager_graph_mode() -> str:
+        value = os.environ.get(
+            "SENSENOVA_U1_NATIVE_EAGER_TEXT_GRAPH_MODE",
+            "segmented",
+        ).lower()
+        if value not in {"segmented", "monolithic"}:
+            raise ValueError(
+                "SENSENOVA_U1_NATIVE_EAGER_TEXT_GRAPH_MODE must be "
+                "'segmented' or 'monolithic'"
+            )
+        return value
+
+    @staticmethod
+    def _eager_text_prefix_cache_key(
+        *,
+        input_ids: torch.Tensor,
+        indexes: torch.Tensor,
+        image_token_tag: torch.Tensor,
+        input_embeds: torch.Tensor | None,
+        repeat_kv_cache: bool,
+    ) -> str:
+        hasher = hashlib.sha256()
+        hasher.update(b"sensenova-u1-native-eager-prefix-v1")
+        hasher.update(
+            b":repeated-kv" if repeat_kv_cache else b":compact-kv"
+        )
+        _update_hash_with_tensor(hasher, input_ids.to(dtype=torch.long))
+        _update_hash_with_tensor(hasher, indexes.to(dtype=torch.long))
+        tag = image_token_tag.to(dtype=torch.bool)
+        _update_hash_with_tensor(hasher, tag)
+        if bool(tag.any().item()) and input_embeds is not None:
+            _update_hash_with_tensor(hasher, input_embeds)
+        return "u1-eager-prefix:" + hasher.hexdigest()[:32]
+
+    @staticmethod
+    def _run_eager_text_decode_graph_step(
+        *,
+        model: Any,
+        input_token: torch.Tensor,
+        caches: list[tuple[torch.Tensor, torch.Tensor]],
+        indexes: torch.Tensor,
+        repeat_kv_cache: bool,
+        use_static_kv_cache: bool,
+        cache_position: int,
+        bf16_argmax: bool,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        list[tuple[torch.Tensor, torch.Tensor]],
+    ]:
+        if use_static_kv_cache:
+            hidden_states, caches = (
+                model.model.eager_text_decode_with_static_cache(
+                    input_token,
+                    indexes[0],
+                    caches,
+                    cache_position=cache_position,
+                    indexes=indexes,
+                    repeat_kv_cache=repeat_kv_cache,
+                )
+            )
+        else:
+            hidden_states, caches = model.model.eager_text_decode_with_cache(
+                input_token,
+                indexes[0],
+                caches,
+                indexes=indexes,
+                repeat_kv_cache=repeat_kv_cache,
+            )
+        logits = model.eager_text_logits(hidden_states)
+        next_token = torch.argmax(
+            logits if bf16_argmax else logits.float(),
+            dim=-1,
+        ).to(dtype=torch.long)
+        return next_token, logits, caches
+
+    @classmethod
+    def _run_eager_text_decode_graph_body(
+        cls,
+        *,
+        model: Any,
+        input_token: torch.Tensor,
+        initial_caches: list[tuple[torch.Tensor, torch.Tensor]],
+        decode_indexes: list[torch.Tensor],
+        repeat_kv_cache: bool,
+        use_static_kv_cache: bool,
+        prefix_len: int,
+        bf16_argmax: bool,
+    ) -> tuple[
+        list[torch.Tensor],
+        torch.Tensor,
+        list[tuple[torch.Tensor, torch.Tensor]],
+        list[list[tuple[torch.Tensor, torch.Tensor]]],
+    ]:
+        current_token = input_token
+        current_caches = initial_caches
+        generated_tokens: list[torch.Tensor] = []
+        cache_history: list[list[tuple[torch.Tensor, torch.Tensor]]] = []
+        last_logits = None
+        for step_offset, indexes in enumerate(decode_indexes):
+            current_token, logits, current_caches = (
+                cls._run_eager_text_decode_graph_step(
+                    model=model,
+                    input_token=current_token,
+                    caches=current_caches,
+                    indexes=indexes,
+                    repeat_kv_cache=repeat_kv_cache,
+                    use_static_kv_cache=use_static_kv_cache,
+                    cache_position=prefix_len + step_offset,
+                    bf16_argmax=bf16_argmax,
+                )
+            )
+            generated_tokens.append(current_token)
+            cache_history.append(current_caches)
+            last_logits = logits
+        if last_logits is None:
+            raise RuntimeError("monolithic CUDA graph requires a decode step")
+        return generated_tokens, last_logits, current_caches, cache_history
+
+    def _capture_eager_text_decode_graph(
+        self,
+        *,
+        model: Any,
+        caches: list[tuple[torch.Tensor, torch.Tensor]],
+        input_token_id: int,
+        start_t_index: int,
+        decode_steps: int,
+        device: torch.device,
+        source_prefix_cache_key: str | None,
+        graph_mode: str,
+        repeat_kv_cache: bool,
+        use_static_kv_cache: bool,
+        bf16_argmax: bool,
+    ) -> _NativeEagerDecodeGraph:
+        prefix_len = int(caches[0][0].shape[0])
+        if use_static_kv_cache:
+            capacity = prefix_len + decode_steps - 1
+            initial_caches = [
+                (
+                    torch.empty(
+                        (capacity, *k.shape[1:]),
+                        device=k.device,
+                        dtype=k.dtype,
+                    ),
+                    torch.empty(
+                        (capacity, *v.shape[1:]),
+                        device=v.device,
+                        dtype=v.dtype,
+                    ),
+                )
+                for k, v in caches
+            ]
+        else:
+            initial_caches = [
+                (torch.empty_like(k), torch.empty_like(v))
+                for k, v in caches
+            ]
+        for (static_k, static_v), (live_k, live_v) in zip(
+            initial_caches,
+            caches,
+        ):
+            static_k[: live_k.shape[0]].copy_(live_k)
+            static_v[: live_v.shape[0]].copy_(live_v)
+        input_token = torch.full(
+            (1,),
+            int(input_token_id),
+            device=device,
+            dtype=torch.long,
+        )
+        decode_indexes = [
+            torch.tensor(
+                [[start_t_index + step_idx], [0], [0]],
+                device=device,
+                dtype=torch.long,
+            )
+            for step_idx in range(1, decode_steps)
+        ]
+
+        capture_stream = torch.cuda.Stream(device=device)
+        graph_pool = torch.cuda.graph_pool_handle()
+        capture_stream.wait_stream(torch.cuda.current_stream(device))
+        if graph_mode == "monolithic":
+            with torch.cuda.stream(capture_stream):
+                warmup_outputs = self._run_eager_text_decode_graph_body(
+                    model=model,
+                    input_token=input_token,
+                    initial_caches=initial_caches,
+                    decode_indexes=decode_indexes,
+                    repeat_kv_cache=repeat_kv_cache,
+                    use_static_kv_cache=use_static_kv_cache,
+                    prefix_len=prefix_len,
+                    bf16_argmax=bf16_argmax,
+                )
+            capture_stream.synchronize()
+            del warmup_outputs
+
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(
+                graph,
+                pool=graph_pool,
+                stream=capture_stream,
+            ):
+                (
+                    generated_tokens,
+                    last_logits,
+                    final_caches,
+                    cache_history,
+                ) = self._run_eager_text_decode_graph_body(
+                    model=model,
+                    input_token=input_token,
+                    initial_caches=initial_caches,
+                    decode_indexes=decode_indexes,
+                    repeat_kv_cache=repeat_kv_cache,
+                    use_static_kv_cache=use_static_kv_cache,
+                    prefix_len=prefix_len,
+                    bf16_argmax=bf16_argmax,
+                )
+            capture_stream.synchronize()
+            verified_finite = bool(torch.isfinite(last_logits).all().item())
+            torch.cuda.current_stream(device).wait_stream(capture_stream)
+            return _NativeEagerDecodeGraph(
+                graphs=[graph],
+                graph_pool=graph_pool,
+                initial_caches=initial_caches,
+                input_token=input_token,
+                decode_indexes=decode_indexes,
+                generated_tokens=generated_tokens,
+                last_logits=last_logits,
+                final_caches=final_caches,
+                cache_history=cache_history,
+                source_prefix_cache_key=source_prefix_cache_key,
+                prefix_len=prefix_len,
+                verified_finite=verified_finite,
+            )
+
+        graphs: list[torch.cuda.CUDAGraph] = []
+        generated_tokens: list[torch.Tensor] = []
+        cache_history: list[list[tuple[torch.Tensor, torch.Tensor]]] = []
+        current_token = input_token
+        current_caches = initial_caches
+        last_logits = None
+        for step_offset, indexes in enumerate(decode_indexes):
+            with torch.cuda.stream(capture_stream):
+                warmup_outputs = self._run_eager_text_decode_graph_step(
+                    model=model,
+                    input_token=current_token,
+                    caches=current_caches,
+                    indexes=indexes,
+                    repeat_kv_cache=repeat_kv_cache,
+                    use_static_kv_cache=use_static_kv_cache,
+                    cache_position=prefix_len + step_offset,
+                    bf16_argmax=bf16_argmax,
+                )
+            capture_stream.synchronize()
+            del warmup_outputs
+
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(
+                graph,
+                pool=graph_pool,
+                stream=capture_stream,
+            ):
+                next_token, logits, next_caches = (
+                    self._run_eager_text_decode_graph_step(
+                        model=model,
+                        input_token=current_token,
+                        caches=current_caches,
+                        indexes=indexes,
+                        repeat_kv_cache=repeat_kv_cache,
+                        use_static_kv_cache=use_static_kv_cache,
+                        cache_position=prefix_len + step_offset,
+                        bf16_argmax=bf16_argmax,
+                    )
+                )
+            graphs.append(graph)
+            generated_tokens.append(next_token)
+            cache_history.append(next_caches)
+            current_token = next_token
+            current_caches = next_caches
+            last_logits = logits
+        if last_logits is None:
+            raise RuntimeError("segmented CUDA graph requires a decode step")
+        capture_stream.synchronize()
+        verified_finite = bool(torch.isfinite(last_logits).all().item())
+        torch.cuda.current_stream(device).wait_stream(capture_stream)
+        return _NativeEagerDecodeGraph(
+            graphs=graphs,
+            graph_pool=graph_pool,
+            initial_caches=initial_caches,
+            input_token=input_token,
+            decode_indexes=decode_indexes,
+            generated_tokens=generated_tokens,
+            last_logits=last_logits,
+            final_caches=current_caches,
+            cache_history=cache_history,
+            source_prefix_cache_key=source_prefix_cache_key,
+            prefix_len=prefix_len,
+            verified_finite=verified_finite,
+        )
+
+    def run_prefill(
+        self,
+        *,
+        request_id: str,
+        input_ids: torch.Tensor,
+        indexes: torch.Tensor,
+        image_token_tag: torch.Tensor,
+        image_gen_indicators: torch.Tensor | None = None,
+        input_embeds: torch.Tensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        grid_hw: torch.Tensor | None = None,
+        cache_extra_key: str | None | object = _CACHE_EXTRA_KEY_NOT_SET,
+        cache_insert: bool = False,
+    ) -> NativeServingResult:
+        return self.run_prefill_batch(
+            [
+                {
+                    "request_id": request_id,
+                    "input_ids": input_ids,
+                    "indexes": indexes,
+                    "image_token_tag": image_token_tag,
+                    "image_gen_indicators": image_gen_indicators,
+                    "input_embeds": input_embeds,
+                    "pixel_values": pixel_values,
+                    "grid_hw": grid_hw,
+                    "cache_extra_key": cache_extra_key,
+                }
+            ],
+            cache_insert=cache_insert,
+        )[0]
+
+    def complete_payload(self, payload: Any) -> dict[str, Any]:
+        data = dict(getattr(payload, "data", None) or payload or {})
+        input_ids = _tensor_from_payload(data["input_ids"], dtype=torch.long)
+        indexes = _tensor_from_payload(data["indexes"], dtype=torch.long)
+        image_token_tag = _tensor_from_payload(data["image_token_tag"], dtype=torch.bool)
+        image_gen_indicators = data.get("image_gen_indicators")
+        if image_gen_indicators is not None:
+            image_gen_indicators = _tensor_from_payload(
+                image_gen_indicators,
+                dtype=torch.bool,
+            )
+        result = self.run_prefill(
+            request_id=str(getattr(payload, "request_id", "native-u1-req")),
+            input_ids=input_ids,
+            indexes=indexes,
+            image_token_tag=image_token_tag,
+            image_gen_indicators=image_gen_indicators,
+            cache_insert=True,
+        )
+        out = result.to_dict()
+        out["text"] = str(result.next_token_id)
+        out["finish_reason"] = "length"
+        out["usage"] = {
+            "prompt_tokens": int(input_ids.numel()),
+            "completion_tokens": 1,
+            "total_tokens": int(input_ids.numel()) + 1,
+        }
+        return out
+
+    def complete_payload_batch(self, payloads: list[Any]) -> list[dict[str, Any]]:
+        requests: list[dict[str, Any]] = []
+        token_counts: list[int] = []
+        for payload in payloads:
+            data = dict(getattr(payload, "data", None) or payload or {})
+            input_ids = _tensor_from_payload(data["input_ids"], dtype=torch.long)
+            indexes = _tensor_from_payload(data["indexes"], dtype=torch.long)
+            image_token_tag = _tensor_from_payload(
+                data["image_token_tag"],
+                dtype=torch.bool,
+            )
+            image_gen_indicators = data.get("image_gen_indicators")
+            if image_gen_indicators is not None:
+                image_gen_indicators = _tensor_from_payload(
+                    image_gen_indicators,
+                    dtype=torch.bool,
+                )
+            token_counts.append(int(input_ids.numel()))
+            requests.append(
+                {
+                    "request_id": str(getattr(payload, "request_id", "native-u1-req")),
+                    "input_ids": input_ids,
+                    "indexes": indexes,
+                    "image_token_tag": image_token_tag,
+                    "image_gen_indicators": image_gen_indicators,
+                }
+            )
+        results = self.run_prefill_batch(requests, cache_insert=True)
+        outs: list[dict[str, Any]] = []
+        for result, prompt_tokens in zip(results, token_counts):
+            out = result.to_dict()
+            out["text"] = str(result.next_token_id)
+            out["finish_reason"] = "length"
+            out["usage"] = {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": 1,
+                "total_tokens": prompt_tokens + 1,
+            }
+            outs.append(out)
+        return outs
+
+
+__all__ = [
+    "NativeEagerTextDecodeResult",
+    "NativeHiddenPrefillResult",
+    "NativeServingResult",
+    "SenseNovaU1NativeServingExecutor",
+]

--- a/sglang_omni/models/sensenova_u1/native_serving.py
+++ b/sglang_omni/models/sensenova_u1/native_serving.py
@@ -7,6 +7,7 @@ import hashlib
 import os
 import time
 from array import array
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any
 
@@ -296,6 +297,11 @@ class SenseNovaU1NativeServingExecutor:
         enable_deterministic_inference: bool = False,
         prefill_cuda_graph_backend: str = "disabled",
         prefill_cuda_graph_bs: list[int] | None = None,
+        eager_prefix_cache_max_entries: int = 4,
+        eager_decode_graph_cache_max_entries: int = 2,
+        eager_decode_graph_max_captures: int = 4,
+        eager_prefix_cache_max_tokens: int = 2048,
+        eager_decode_graph_max_total_tokens: int = 1024,
     ) -> None:
         assert_no_hf_modeling_imported(context="before native serving executor")
         from sglang_omni.models.sensenova_u1.hf_config import (
@@ -308,7 +314,32 @@ class SenseNovaU1NativeServingExecutor:
         self.config = load_u1_llm_config(model_path)
         self.vocab_size = int(self.config.vocab_size)
         self.max_running_requests = max(int(max_running_requests), 1)
+        self.max_total_tokens = int(max_total_tokens)
+        if self.max_total_tokens <= 0:
+            raise ValueError("max_total_tokens must be positive")
         self.enable_radix_cache = bool(enable_radix_cache)
+        self.eager_prefix_cache_max_entries = max(
+            int(eager_prefix_cache_max_entries),
+            0,
+        )
+        self.eager_decode_graph_cache_max_entries = max(
+            int(eager_decode_graph_cache_max_entries),
+            0,
+        )
+        self.eager_decode_graph_max_captures = max(
+            int(eager_decode_graph_max_captures),
+            0,
+        )
+        self.eager_prefix_cache_max_tokens = int(eager_prefix_cache_max_tokens)
+        self.eager_decode_graph_max_total_tokens = int(
+            eager_decode_graph_max_total_tokens
+        )
+        if self.eager_prefix_cache_max_tokens <= 0:
+            raise ValueError("eager_prefix_cache_max_tokens must be positive")
+        if self.eager_decode_graph_max_total_tokens <= 0:
+            raise ValueError(
+                "eager_decode_graph_max_total_tokens must be positive"
+            )
         if cuda_graph_bs is None:
             cuda_graph_bs = [self.max_running_requests]
         cuda_graph_bs = sorted({int(value) for value in cuda_graph_bs})
@@ -395,18 +426,21 @@ class SenseNovaU1NativeServingExecutor:
                     text_model.force_mot_gen_for_prefill_graph_capture = False
         self.server_args = server_args
         self.prefill_cuda_graph_enabled = prefill_cuda_graph_enabled
-        self._eager_text_decode_graphs: dict[
-            tuple[int, int, int, str],
+        self._eager_text_decode_graphs: OrderedDict[
+            tuple[Any, ...],
             _NativeEagerDecodeGraph,
-        ] = {}
-        self._eager_text_prefill_cache: dict[
+        ] = OrderedDict()
+        self._eager_text_prefill_cache: OrderedDict[
             str,
             tuple[
                 torch.Tensor,
                 list[tuple[torch.Tensor, torch.Tensor]],
                 bool,
             ],
-        ] = {}
+        ] = OrderedDict()
+        self._eager_text_decode_graph_evictions = 0
+        self._eager_text_decode_graph_captures = 0
+        self._eager_text_prefill_cache_evictions = 0
         dtype_obj = next(self.model_worker.model_runner.model.parameters()).dtype
         device_obj = torch.device(self.model_worker.device)
         self.vision_model = SenseNovaU1NativeVisionModel.from_model_path(
@@ -558,6 +592,205 @@ class SenseNovaU1NativeServingExecutor:
                     data[name] = None
         return data
 
+    @staticmethod
+    def _tensor_bytes(tensor: torch.Tensor) -> int:
+        return int(tensor.numel()) * int(tensor.element_size())
+
+    @classmethod
+    def _prefix_cache_entry_tensor_bytes(
+        cls,
+        entry: tuple[
+            torch.Tensor,
+            list[tuple[torch.Tensor, torch.Tensor]],
+            bool,
+        ],
+    ) -> int:
+        logits, caches, _ = entry
+        tensors = [logits]
+        tensors.extend(tensor for pair in caches for tensor in pair)
+        return sum(cls._tensor_bytes(tensor) for tensor in tensors)
+
+    @classmethod
+    def _decode_graph_tensor_bytes(cls, runner: _NativeEagerDecodeGraph) -> int:
+        tensors: list[torch.Tensor] = []
+        tensors.extend(tensor for pair in runner.initial_caches for tensor in pair)
+        tensors.extend(runner.decode_indexes)
+        tensors.extend(runner.generated_tokens)
+        tensors.extend(tensor for pair in runner.final_caches for tensor in pair)
+        tensors.extend(
+            tensor
+            for cache_step in runner.cache_history
+            for pair in cache_step
+            for tensor in pair
+        )
+        tensors.extend([runner.input_token, runner.last_logits])
+        seen: set[int] = set()
+        retained_bytes = 0
+        for tensor in tensors:
+            if not isinstance(tensor, torch.Tensor) or id(tensor) in seen:
+                continue
+            seen.add(id(tensor))
+            retained_bytes += cls._tensor_bytes(tensor)
+        return retained_bytes
+
+    @staticmethod
+    def _release_prefix_cache_entry(
+        entry: tuple[
+            torch.Tensor,
+            list[tuple[torch.Tensor, torch.Tensor]],
+            bool,
+        ],
+    ) -> None:
+        _, caches, _ = entry
+        caches.clear()
+
+    @staticmethod
+    def _release_decode_graph(runner: _NativeEagerDecodeGraph) -> None:
+        for graph in runner.graphs:
+            reset = getattr(graph, "reset", None)
+            if callable(reset):
+                reset()
+        runner.graphs.clear()
+        runner.initial_caches.clear()
+        runner.decode_indexes.clear()
+        runner.generated_tokens.clear()
+        runner.final_caches.clear()
+        runner.cache_history.clear()
+        runner.source_prefix_cache_key = None
+        runner.graph_pool = None
+        runner.input_token = None  # type: ignore[assignment]
+        runner.last_logits = None  # type: ignore[assignment]
+
+    def eager_runtime_cache_snapshot(self) -> dict[str, Any]:
+        return {
+            "prefix_cache_entries": len(self._eager_text_prefill_cache),
+            "prefix_cache_max_entries": self.eager_prefix_cache_max_entries,
+            "prefix_cache_max_tokens": self.eager_prefix_cache_max_tokens,
+            "prefix_cache_evictions": self._eager_text_prefill_cache_evictions,
+            "prefix_cache_tensor_bytes": sum(
+                self._prefix_cache_entry_tensor_bytes(entry)
+                for entry in self._eager_text_prefill_cache.values()
+            ),
+            "decode_graph_entries": len(self._eager_text_decode_graphs),
+            "decode_graph_max_entries": self.eager_decode_graph_cache_max_entries,
+            "decode_graph_captures": self._eager_text_decode_graph_captures,
+            "decode_graph_max_captures": self.eager_decode_graph_max_captures,
+            "decode_graph_max_total_tokens": (
+                self.eager_decode_graph_max_total_tokens
+            ),
+            "decode_graph_evictions": self._eager_text_decode_graph_evictions,
+            "decode_graph_tensor_bytes": sum(
+                self._decode_graph_tensor_bytes(runner)
+                for runner in self._eager_text_decode_graphs.values()
+            ),
+        }
+
+    def clear_eager_runtime_caches(self) -> dict[str, Any]:
+        before = self.eager_runtime_cache_snapshot()
+        while self._eager_text_prefill_cache:
+            _, entry = self._eager_text_prefill_cache.popitem(last=False)
+            self._release_prefix_cache_entry(entry)
+        while self._eager_text_decode_graphs:
+            _, runner = self._eager_text_decode_graphs.popitem(last=False)
+            self._release_decode_graph(runner)
+        return {
+            "before": before,
+            "after": self.eager_runtime_cache_snapshot(),
+        }
+
+    def shutdown(self) -> None:
+        self.clear_eager_runtime_caches()
+
+    def _get_eager_prefix_cache_entry(
+        self,
+        key: str,
+    ) -> tuple[
+        torch.Tensor,
+        list[tuple[torch.Tensor, torch.Tensor]],
+        bool,
+    ] | None:
+        entry = self._eager_text_prefill_cache.pop(key, None)
+        if entry is not None:
+            self._eager_text_prefill_cache[key] = entry
+        return entry
+
+    def _put_eager_prefix_cache_entry(
+        self,
+        key: str,
+        entry: tuple[
+            torch.Tensor,
+            list[tuple[torch.Tensor, torch.Tensor]],
+            bool,
+        ],
+    ) -> None:
+        if self.eager_prefix_cache_max_entries <= 0:
+            self._release_prefix_cache_entry(entry)
+            return
+        existing = self._eager_text_prefill_cache.pop(key, None)
+        if existing is not None:
+            self._release_prefix_cache_entry(existing)
+        while (
+            len(self._eager_text_prefill_cache)
+            >= self.eager_prefix_cache_max_entries
+        ):
+            _, evicted = self._eager_text_prefill_cache.popitem(last=False)
+            self._release_prefix_cache_entry(evicted)
+            self._eager_text_prefill_cache_evictions += 1
+        self._eager_text_prefill_cache[key] = entry
+
+    def _get_eager_decode_graph(
+        self,
+        key: tuple[Any, ...],
+    ) -> _NativeEagerDecodeGraph | None:
+        runner = self._eager_text_decode_graphs.pop(key, None)
+        if runner is not None:
+            self._eager_text_decode_graphs[key] = runner
+        return runner
+
+    def _put_eager_decode_graph(
+        self,
+        key: tuple[Any, ...],
+        runner: _NativeEagerDecodeGraph,
+    ) -> None:
+        if self.eager_decode_graph_cache_max_entries <= 0:
+            self._release_decode_graph(runner)
+            return
+        existing = self._eager_text_decode_graphs.pop(key, None)
+        if existing is not None:
+            self._release_decode_graph(existing)
+        while (
+            len(self._eager_text_decode_graphs)
+            >= self.eager_decode_graph_cache_max_entries
+        ):
+            _, evicted = self._eager_text_decode_graphs.popitem(last=False)
+            self._release_decode_graph(evicted)
+            self._eager_text_decode_graph_evictions += 1
+        self._eager_text_decode_graphs[key] = runner
+
+    def _reserve_eager_decode_graph_slot(
+        self,
+        key: tuple[Any, ...],
+    ) -> None:
+        existing = self._eager_text_decode_graphs.pop(key, None)
+        if existing is not None:
+            self._release_decode_graph(existing)
+        while (
+            len(self._eager_text_decode_graphs)
+            >= self.eager_decode_graph_cache_max_entries
+        ):
+            _, evicted = self._eager_text_decode_graphs.popitem(last=False)
+            self._release_decode_graph(evicted)
+            self._eager_text_decode_graph_evictions += 1
+
+    def _try_reserve_eager_decode_graph_capture(self) -> bool:
+        if (
+            self._eager_text_decode_graph_captures
+            >= self.eager_decode_graph_max_captures
+        ):
+            return False
+        self._eager_text_decode_graph_captures += 1
+        return True
+
     def cached_prefix_length(
         self,
         *,
@@ -599,8 +832,14 @@ class SenseNovaU1NativeServingExecutor:
         for req in list(batch.reqs):
             if getattr(req, "req_pool_idx", None) is None:
                 continue
-            committed_len = int(req.effective_kv_committed_len())
-            prefix_len = int(len(getattr(req, "prefix_indices", [])))
+            try:
+                committed_len = int(req.effective_kv_committed_len())
+            except (AttributeError, RuntimeError, TypeError, ValueError):
+                committed_len = None
+            try:
+                prefix_len = int(len(getattr(req, "prefix_indices", [])))
+            except (AttributeError, RuntimeError, TypeError, ValueError):
+                prefix_len = None
             release_kv_cache(req, self.tree_cache, is_insert=cache_insert)
             finished.append(
                 {
@@ -619,6 +858,112 @@ class SenseNovaU1NativeServingExecutor:
             "after": self._pool_snapshot(),
             "after_cache": self._cache_snapshot(),
         }
+
+    def _detach_prefill_manager_requests(
+        self,
+        reqs: list[Any],
+    ) -> dict[str, Any]:
+        owned = {id(req) for req in reqs}
+        waiting_queue = getattr(self.prefill_manager, "waiting_queue", None)
+        waiting_removed = 0
+        if isinstance(waiting_queue, list):
+            waiting_removed = sum(id(req) in owned for req in waiting_queue)
+            waiting_queue[:] = [req for req in waiting_queue if id(req) not in owned]
+        chunked_removed = False
+        chunked_req = getattr(self.prefill_manager, "chunked_req", None)
+        if chunked_req is not None and id(chunked_req) in owned:
+            inflight = int(getattr(chunked_req, "inflight_middle_chunks", 0) or 0)
+            if inflight > 0:
+                chunked_req.inflight_middle_chunks = inflight - 1
+            self.prefill_manager.chunked_req = None
+            chunked_removed = True
+        return {
+            "waiting_removed": waiting_removed,
+            "waiting_remaining": (
+                None if not isinstance(waiting_queue, list) else len(waiting_queue)
+            ),
+            "chunked_removed": chunked_removed,
+        }
+
+    def _cleanup_prefill_attempt(
+        self,
+        *,
+        prepared: list[dict[str, Any]],
+        batch: Any | None,
+        cache_insert: bool,
+    ) -> dict[str, Any]:
+        from sglang.srt.mem_cache.common import release_kv_cache
+
+        reqs = [item["req"] for item in prepared]
+        manager_cleanup = self._detach_prefill_manager_requests(reqs)
+        if batch is None:
+            release_log = {
+                "released_reqs": 0,
+                "finished_reqs": [],
+                "before": self._pool_snapshot(),
+                "before_cache": self._cache_snapshot(),
+            }
+        else:
+            release_log = self._finish_prefill_batch(
+                batch,
+                cache_insert=cache_insert,
+            )
+        orphan_releases = []
+        for req in reqs:
+            if getattr(req, "req_pool_idx", None) is None:
+                continue
+            release_kv_cache(req, self.tree_cache, is_insert=False)
+            orphan_releases.append(str(req.rid))
+        release_log["orphan_released_rids"] = orphan_releases
+        release_log["manager_cleanup"] = manager_cleanup
+        release_log["after"] = self._pool_snapshot()
+        release_log["after_cache"] = self._cache_snapshot()
+        return release_log
+
+    def _collect_prefill_metadata(
+        self,
+        *,
+        forward_batch: ForwardBatch,
+        forward_batch_log: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        prepare = getattr(
+            self.model_worker.model_runner.model,
+            "last_forward_batch_prepare",
+            None,
+        )
+        attn_metadata = getattr(
+            self.model_worker.model_runner.attn_backend,
+            "forward_metadata",
+            None,
+        )
+        if attn_metadata is not None:
+            backend_mask = getattr(attn_metadata, "custom_mask", None)
+            backend_mask_indptr = getattr(attn_metadata, "mask_indptr", None)
+            forward_batch_log["backend_forward_metadata"] = {
+                "class": type(attn_metadata).__name__,
+                "custom_mask_present": backend_mask is not None,
+                "custom_mask_numel": (
+                    None if backend_mask is None else int(backend_mask.numel())
+                ),
+                "mask_indptr": (
+                    None
+                    if backend_mask_indptr is None
+                    else [
+                        int(x)
+                        for x in backend_mask_indptr.detach().cpu().tolist()
+                    ]
+                ),
+            }
+        if forward_batch.cross_attention_custom_mask is not None:
+            forward_batch_log["custom_mask_shape"] = [
+                int(forward_batch.cross_attention_custom_mask.numel())
+            ]
+            forward_batch_log["custom_mask_dtype"] = str(
+                forward_batch.cross_attention_custom_mask.dtype
+            )
+        states = forward_batch.model_specific_states or {}
+        forward_batch_log["model_specific_state_keys"] = sorted(states.keys())
+        return prepare
 
     def _prepare_prefill_request(
         self,
@@ -948,196 +1293,222 @@ class SenseNovaU1NativeServingExecutor:
             )
         prepared = [self._prepare_prefill_request(**item) for item in requests]
         cache_before_schedule = self._cache_snapshot()
-        for item in prepared:
-            self.prefill_manager.add_one_request(item["req"])
-        batch = self.prefill_manager.schedule_next_batch(
-            self.decode_manager.running_batch,
-            num_allocatable_reqs=len(prepared),
-        )
-        if batch is None:
-            raise RuntimeError("native serving prefill manager returned no batch")
-        if len(batch.reqs) != len(prepared):
-            raise RuntimeError(
-                "native serving prefill manager did not schedule the full batch: "
-                f"scheduled={len(batch.reqs)} requested={len(prepared)}"
-            )
-
-        from sglang_omni.model_runner.base import resolve_deferred_prefill_inputs
-
-        resolve_deferred_prefill_inputs(
-            batch,
-            torch.device(self.model_worker.device),
-        )
-        forward_batch = ForwardBatch.init_new(
-            batch,
-            self.model_worker.model_runner,
-            capture_hidden_mode=CaptureHiddenMode.NULL,
-            return_hidden_states_before_norm=False,
-        )
-        forward_batch_log = {
-            "forward_mode": str(forward_batch.forward_mode),
-            "batch_size": int(forward_batch.batch_size),
-            "input_ids_shape": list(forward_batch.input_ids.shape),
-            "positions_shape": list(forward_batch.positions.shape),
-            "mrope_positions_shape": (
-                None
-                if forward_batch.mrope_positions is None
-                else list(forward_batch.mrope_positions.shape)
-            ),
-            "extend_seq_lens_cpu": list(forward_batch.extend_seq_lens_cpu or []),
-            "extend_prefix_lens_cpu": list(forward_batch.extend_prefix_lens_cpu or []),
-            "rids": list(forward_batch.rids or []),
-            "requested_batch_size": len(prepared),
-            "scheduled_batch_size": int(forward_batch.batch_size),
-            "radix_cache_enabled": self.enable_radix_cache,
-            "cache_before_schedule": cache_before_schedule,
-        }
-        extend_lens = list(forward_batch.extend_seq_lens_cpu or [])
-        prefix_lens = list(forward_batch.extend_prefix_lens_cpu or [])
-        sidecar_input_embeds = self._attach_prefill_sidecar(
-            prepared=prepared,
-            forward_batch=forward_batch,
-            forward_batch_log=forward_batch_log,
-        )
-        if self.prefill_cuda_graph_enabled:
-            self.model_worker.model_runner.model.prepare_forward_batch(
-                forward_batch
-            )
-        per_request_log = []
-        for idx, (item, req) in enumerate(zip(prepared, batch.reqs)):
-            prefix_len = int(prefix_lens[idx]) if idx < len(prefix_lens) else 0
-            extend_len = int(extend_lens[idx]) if idx < len(extend_lens) else 0
-            per_request_log.append(
-                {
-                    "batch_index": idx,
-                    "rid": str(req.rid),
-                    "input_tokens": int(item["input_ids"].numel()),
-                    "prefix_len": prefix_len,
-                    "extend_len": extend_len,
-                    "cache_hit": prefix_len > 0,
-                    "cache_extra_key": item["cache_extra_key"],
-                    "image_token_count": int(item["image_token_tag"].sum().item()),
-                }
-            )
-        forward_batch_log["per_request"] = per_request_log
-        forward_batch_log["cache_hit_requests"] = sum(
-            1 for item in per_request_log if item["cache_hit"]
-        )
-        forward_batch_log["cache_hit_tokens"] = sum(
-            int(item["prefix_len"]) for item in per_request_log
-        )
-
-        torch.cuda.synchronize(device) if device.type == "cuda" else None
-        dense_calls_before = None
-        dense_calls_after = None
+        batch = None
+        cleanup_complete = False
         try:
-            from sglang_omni.models.sensenova_u1 import (
-                attention_backend as _u1_attn,
+            for item in prepared:
+                self.prefill_manager.add_one_request(item["req"])
+            batch = self.prefill_manager.schedule_next_batch(
+                self.decode_manager.running_batch,
+                num_allocatable_reqs=len(prepared),
+            )
+            if batch is None:
+                raise RuntimeError("native serving prefill manager returned no batch")
+            if len(batch.reqs) != len(prepared):
+                raise RuntimeError(
+                    "native serving prefill manager did not schedule the full batch: "
+                    f"scheduled={len(batch.reqs)} requested={len(prepared)}"
+                )
+
+            from sglang_omni.model_runner.base import (
+                resolve_deferred_prefill_inputs,
             )
 
-            dense_calls_before = int(
-                getattr(_u1_attn, "CUSTOM_MASK_DENSE_ATTENTION_CALLS", 0)
+            resolve_deferred_prefill_inputs(
+                batch,
+                torch.device(self.model_worker.device),
             )
-        except Exception:
-            _u1_attn = None
-        start = time.perf_counter()
-        with torch.inference_mode(), block_hf_modeling_imports():
-            batch_result = self.model_worker.forward_batch_generation(
-                forward_batch,
-                batch=batch,
+            forward_batch = ForwardBatch.init_new(
+                batch,
+                self.model_worker.model_runner,
+                capture_hidden_mode=CaptureHiddenMode.NULL,
+                return_hidden_states_before_norm=False,
             )
-        torch.cuda.synchronize(device) if device.type == "cuda" else None
-        if _u1_attn is not None:
-            dense_calls_after = int(
-                getattr(_u1_attn, "CUSTOM_MASK_DENSE_ATTENTION_CALLS", 0)
-            )
-            forward_batch_log["custom_mask_dense_attention_calls_delta"] = (
-                dense_calls_after - (dense_calls_before or 0)
-            )
-        elapsed = time.perf_counter() - start
-        forward_batch_log["can_run_cuda_graph"] = bool(
-            getattr(batch_result, "can_run_cuda_graph", False)
-        )
-        logits = batch_result.logits_output.next_token_logits
-        if logits is None:
-            raise RuntimeError("native serving prefill produced no logits")
-        if int(logits.shape[0]) != len(prepared):
-            raise RuntimeError(
-                "native serving logits batch size mismatch: "
-                f"logits={list(logits.shape)} requests={len(prepared)}"
-            )
-        prepare = getattr(
-            self.model_worker.model_runner.model,
-            "last_forward_batch_prepare",
-            None,
-        )
-        attn_metadata = getattr(
-            self.model_worker.model_runner.attn_backend,
-            "forward_metadata",
-            None,
-        )
-        if attn_metadata is not None:
-            backend_mask = getattr(attn_metadata, "custom_mask", None)
-            backend_mask_indptr = getattr(attn_metadata, "mask_indptr", None)
-            forward_batch_log["backend_forward_metadata"] = {
-                "class": type(attn_metadata).__name__,
-                "custom_mask_present": backend_mask is not None,
-                "custom_mask_numel": (
-                    None if backend_mask is None else int(backend_mask.numel())
-                ),
-                "mask_indptr": (
+            forward_batch_log = {
+                "forward_mode": str(forward_batch.forward_mode),
+                "batch_size": int(forward_batch.batch_size),
+                "input_ids_shape": list(forward_batch.input_ids.shape),
+                "positions_shape": list(forward_batch.positions.shape),
+                "mrope_positions_shape": (
                     None
-                    if backend_mask_indptr is None
-                    else [int(x) for x in backend_mask_indptr.detach().cpu().tolist()]
+                    if forward_batch.mrope_positions is None
+                    else list(forward_batch.mrope_positions.shape)
                 ),
+                "extend_seq_lens_cpu": list(
+                    forward_batch.extend_seq_lens_cpu or []
+                ),
+                "extend_prefix_lens_cpu": list(
+                    forward_batch.extend_prefix_lens_cpu or []
+                ),
+                "rids": list(forward_batch.rids or []),
+                "requested_batch_size": len(prepared),
+                "scheduled_batch_size": int(forward_batch.batch_size),
+                "radix_cache_enabled": self.enable_radix_cache,
+                "cache_before_schedule": cache_before_schedule,
             }
-        if forward_batch.cross_attention_custom_mask is not None:
-            forward_batch_log["custom_mask_shape"] = [
-                int(forward_batch.cross_attention_custom_mask.numel())
-            ]
-            forward_batch_log["custom_mask_dtype"] = str(
-                forward_batch.cross_attention_custom_mask.dtype
+            extend_lens = list(forward_batch.extend_seq_lens_cpu or [])
+            prefix_lens = list(forward_batch.extend_prefix_lens_cpu or [])
+            sidecar_input_embeds = self._attach_prefill_sidecar(
+                prepared=prepared,
+                forward_batch=forward_batch,
+                forward_batch_log=forward_batch_log,
             )
-        states = forward_batch.model_specific_states or {}
-        forward_batch_log["model_specific_state_keys"] = sorted(states.keys())
-        forward_batch_log["resource_release"] = self._finish_prefill_batch(
-            batch,
-            cache_insert=cache_insert,
-        )
+            if self.prefill_cuda_graph_enabled:
+                self.model_worker.model_runner.model.prepare_forward_batch(
+                    forward_batch
+                )
+            per_request_log = []
+            for idx, (item, req) in enumerate(zip(prepared, batch.reqs)):
+                prefix_len = (
+                    int(prefix_lens[idx]) if idx < len(prefix_lens) else 0
+                )
+                extend_len = (
+                    int(extend_lens[idx]) if idx < len(extend_lens) else 0
+                )
+                per_request_log.append(
+                    {
+                        "batch_index": idx,
+                        "rid": str(req.rid),
+                        "input_tokens": int(item["input_ids"].numel()),
+                        "prefix_len": prefix_len,
+                        "extend_len": extend_len,
+                        "cache_hit": prefix_len > 0,
+                        "cache_extra_key": item["cache_extra_key"],
+                        "image_token_count": int(
+                            item["image_token_tag"].sum().item()
+                        ),
+                    }
+                )
+            forward_batch_log["per_request"] = per_request_log
+            forward_batch_log["cache_hit_requests"] = sum(
+                1 for item in per_request_log if item["cache_hit"]
+            )
+            forward_batch_log["cache_hit_tokens"] = sum(
+                int(item["prefix_len"]) for item in per_request_log
+            )
 
-        assert_no_hf_modeling_imported(context="after native prefill batch")
-        results: list[NativeServingResult] = []
-        for idx, item in enumerate(prepared):
-            row_logits = logits[idx : idx + 1]
-            next_token_id = int(torch.argmax(row_logits[0].float()).item())
-            item_log = dict(forward_batch_log)
-            item_log["this_request"] = per_request_log[idx]
-            results.append(
-                NativeServingResult(
-                    request_id=str(item["request_id"]),
-                    next_token_id=next_token_id,
-                    logits_shape=list(row_logits.shape),
-                    logits_dtype=str(row_logits.dtype),
-                    logits_device=str(row_logits.device),
-                    logits_all_finite=bool(torch.isfinite(row_logits).all().item()),
-                    forward_elapsed_s=elapsed,
-                    backend_name=type(self.model_worker.model_runner.attn_backend).__name__,
-                    prepare_metadata=prepare,
-                    forward_batch_log=item_log,
-                    input_embeds_used=sidecar_input_embeds is not None,
-                    input_embeds_shape=(
-                        None
-                        if sidecar_input_embeds is None
-                        else list(sidecar_input_embeds.shape)
-                    ),
-                    batch_index=idx,
-                    batch_size=len(prepared),
-                    cache_inserted=bool(cache_insert),
-                    cache_extra_key=item["cache_extra_key"],
-                    next_token_logits=row_logits.detach().float().cpu(),
+            torch.cuda.synchronize(device) if device.type == "cuda" else None
+            dense_calls_before = None
+            try:
+                from sglang_omni.models.sensenova_u1 import (
+                    attention_backend as _u1_attn,
+                )
+
+                dense_calls_before = int(
+                    getattr(
+                        _u1_attn,
+                        "CUSTOM_MASK_DENSE_ATTENTION_CALLS",
+                        0,
+                    )
+                )
+            except (AttributeError, ImportError):
+                _u1_attn = None
+            start = time.perf_counter()
+            with torch.inference_mode(), block_hf_modeling_imports():
+                batch_result = self.model_worker.forward_batch_generation(
+                    forward_batch,
+                    batch=batch,
+                )
+            torch.cuda.synchronize(device) if device.type == "cuda" else None
+            if _u1_attn is not None:
+                dense_calls_after = int(
+                    getattr(
+                        _u1_attn,
+                        "CUSTOM_MASK_DENSE_ATTENTION_CALLS",
+                        0,
+                    )
+                )
+                forward_batch_log[
+                    "custom_mask_dense_attention_calls_delta"
+                ] = dense_calls_after - (dense_calls_before or 0)
+            elapsed = time.perf_counter() - start
+            forward_batch_log["can_run_cuda_graph"] = bool(
+                getattr(batch_result, "can_run_cuda_graph", False)
+            )
+            logits_output = getattr(batch_result, "logits_output", None)
+            logits = (
+                None
+                if logits_output is None
+                else getattr(logits_output, "next_token_logits", None)
+            )
+            if logits is None:
+                raise RuntimeError("native serving prefill produced no logits")
+            if int(logits.shape[0]) != len(prepared):
+                raise RuntimeError(
+                    "native serving logits batch size mismatch: "
+                    f"logits={list(logits.shape)} requests={len(prepared)}"
+                )
+            prepare = self._collect_prefill_metadata(
+                forward_batch=forward_batch,
+                forward_batch_log=forward_batch_log,
+            )
+            result_rows = []
+            for idx in range(len(prepared)):
+                row_logits = logits[idx : idx + 1]
+                result_rows.append(
+                    {
+                        "next_token_id": int(
+                            torch.argmax(row_logits[0].float()).item()
+                        ),
+                        "logits_shape": list(row_logits.shape),
+                        "logits_dtype": str(row_logits.dtype),
+                        "logits_device": str(row_logits.device),
+                        "logits_all_finite": bool(
+                            torch.isfinite(row_logits).all().item()
+                        ),
+                        "next_token_logits": row_logits.detach().float().cpu(),
+                    }
+                )
+
+            forward_batch_log["resource_release"] = (
+                self._cleanup_prefill_attempt(
+                    prepared=prepared,
+                    batch=batch,
+                    cache_insert=cache_insert,
                 )
             )
-        return results
+            batch = None
+            cleanup_complete = True
+            assert_no_hf_modeling_imported(context="after native prefill batch")
+            results: list[NativeServingResult] = []
+            for idx, (item, row) in enumerate(zip(prepared, result_rows)):
+                item_log = dict(forward_batch_log)
+                item_log["this_request"] = per_request_log[idx]
+                results.append(
+                    NativeServingResult(
+                        request_id=str(item["request_id"]),
+                        next_token_id=row["next_token_id"],
+                        logits_shape=row["logits_shape"],
+                        logits_dtype=row["logits_dtype"],
+                        logits_device=row["logits_device"],
+                        logits_all_finite=row["logits_all_finite"],
+                        forward_elapsed_s=elapsed,
+                        backend_name=type(
+                            self.model_worker.model_runner.attn_backend
+                        ).__name__,
+                        prepare_metadata=prepare,
+                        forward_batch_log=item_log,
+                        input_embeds_used=sidecar_input_embeds is not None,
+                        input_embeds_shape=(
+                            None
+                            if sidecar_input_embeds is None
+                            else list(sidecar_input_embeds.shape)
+                        ),
+                        batch_index=idx,
+                        batch_size=len(prepared),
+                        cache_inserted=bool(cache_insert),
+                        cache_extra_key=item["cache_extra_key"],
+                        next_token_logits=row["next_token_logits"],
+                    )
+                )
+            return results
+        finally:
+            if not cleanup_complete:
+                self._cleanup_prefill_attempt(
+                    prepared=prepared,
+                    batch=batch,
+                    cache_insert=False,
+                )
 
     def run_greedy_decode_batch(
         self,
@@ -1439,6 +1810,11 @@ class SenseNovaU1NativeServingExecutor:
         total_start = time.perf_counter()
         repeat_kv_cache = self._native_eager_repeated_kv_cache_enabled()
         use_static_kv_cache = self._native_eager_static_kv_cache_enabled()
+        eager_prefix_cache_eligible = bool(
+            self._native_eager_prefix_cache_enabled()
+            and self.eager_prefix_cache_max_entries > 0
+            and int(input_ids.numel()) <= self.eager_prefix_cache_max_tokens
+        )
         eager_prefix_cache_key = (
             self._eager_text_prefix_cache_key(
                 input_ids=input_ids,
@@ -1447,19 +1823,20 @@ class SenseNovaU1NativeServingExecutor:
                 input_embeds=input_embeds,
                 repeat_kv_cache=repeat_kv_cache,
             )
-            if self._native_eager_prefix_cache_enabled()
+            if eager_prefix_cache_eligible
             else None
         )
-        eager_prefix_cache_hit = bool(
-            eager_prefix_cache_key is not None
-            and eager_prefix_cache_key in self._eager_text_prefill_cache
+        prefix_cache_entry = (
+            None
+            if eager_prefix_cache_key is None
+            else self._get_eager_prefix_cache_entry(eager_prefix_cache_key)
         )
+        eager_prefix_cache_hit = prefix_cache_entry is not None
         torch.cuda.synchronize(device) if device.type == "cuda" else None
         prefill_start = time.perf_counter()
         if eager_prefix_cache_hit:
-            logits, caches, prefill_logits_finite = self._eager_text_prefill_cache[
-                eager_prefix_cache_key
-            ]
+            assert prefix_cache_entry is not None
+            logits, caches, prefill_logits_finite = prefix_cache_entry
         else:
             with torch.inference_mode(), block_hf_modeling_imports():
                 hidden_states, caches = model.model.eager_text_prefill_with_cache(
@@ -1477,10 +1854,13 @@ class SenseNovaU1NativeServingExecutor:
                 logits = model.eager_text_logits(hidden_states)
             prefill_logits_finite = bool(torch.isfinite(logits).all().item())
             if eager_prefix_cache_key is not None:
-                self._eager_text_prefill_cache[eager_prefix_cache_key] = (
-                    logits.detach(),
-                    caches,
-                    prefill_logits_finite,
+                self._put_eager_prefix_cache_entry(
+                    eager_prefix_cache_key,
+                    (
+                        logits.detach(),
+                        caches,
+                        prefill_logits_finite,
+                    ),
                 )
         torch.cuda.synchronize(device) if device.type == "cuda" else None
         prefill_elapsed = time.perf_counter() - prefill_start
@@ -1512,6 +1892,9 @@ class SenseNovaU1NativeServingExecutor:
             and forced_token_ids is None
             and not suppress_ids
             and capture_step is None
+            and self.eager_decode_graph_cache_max_entries > 0
+            and int(input_ids.numel()) + int(decode_steps)
+            <= self.eager_decode_graph_max_total_tokens
         )
         if full_loop_graph_used:
             graph_key = (
@@ -1527,10 +1910,14 @@ class SenseNovaU1NativeServingExecutor:
                 compiled_add_rms_layers,
                 self._native_eager_graph_mode(),
             )
-            graph_created = graph_key not in self._eager_text_decode_graphs
+            graph_runner = self._get_eager_decode_graph(graph_key)
+            graph_created = graph_runner is None
             if graph_created:
-                self._eager_text_decode_graphs[graph_key] = (
-                    self._capture_eager_text_decode_graph(
+                if not self._try_reserve_eager_decode_graph_capture():
+                    full_loop_graph_used = False
+                else:
+                    self._reserve_eager_decode_graph_slot(graph_key)
+                    graph_runner = self._capture_eager_text_decode_graph(
                         model=model,
                         caches=caches,
                         input_token_id=next_token_id,
@@ -1543,8 +1930,13 @@ class SenseNovaU1NativeServingExecutor:
                         use_static_kv_cache=bool(graph_key[4]),
                         bf16_argmax=bool(graph_key[5]),
                     )
-                )
-            graph_runner = self._eager_text_decode_graphs[graph_key]
+                    self._eager_text_decode_graphs[graph_key] = graph_runner
+            if not full_loop_graph_used:
+                graph_runner = None
+            if graph_runner is None:
+                graph_created = False
+        if full_loop_graph_used:
+            assert graph_runner is not None
             torch.cuda.synchronize(device)
             decode_start = time.perf_counter()
             skip_initial_copy = bool(

--- a/sglang_omni/models/sensenova_u1/native_vision.py
+++ b/sglang_omni/models/sensenova_u1/native_vision.py
@@ -1,0 +1,386 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native SenseNova U1 vision embedding path used by M6 probes.
+
+This mirrors the small public ``NEOVisionModel`` tower without importing the
+official HF modeling modules.  The tower is intentionally narrow: it covers the
+native-resolution patch/dense embedding path required to compose VQA prefill
+embeddings for the SGLang-native language model.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Mapping
+
+import torch
+from torch import nn
+
+from sglang_omni.models.weight_loader import resolve_dtype
+
+
+def _to_namespace(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return SimpleNamespace(**{k: _to_namespace(v) for k, v in value.items()})
+    if isinstance(value, list):
+        return [_to_namespace(v) for v in value]
+    return value
+
+
+def _llm_hidden_size(value: Any) -> int:
+    if isinstance(value, (list, tuple)):
+        return int(value[0])
+    return int(value)
+
+
+def load_u1_vision_config(model_path: str | Path) -> SimpleNamespace:
+    config_path = Path(model_path) / "config.json"
+    with config_path.open("r", encoding="utf-8") as f:
+        raw = json.load(f)
+    vision = dict(raw["vision_config"])
+    vision.setdefault("patch_size", raw.get("patch_size", 16))
+    vision.setdefault("downsample_ratio", raw.get("downsample_ratio", 0.5))
+    vision.setdefault("torch_dtype", raw.get("torch_dtype", "bfloat16"))
+    return _to_namespace(vision)
+
+
+@dataclass(slots=True)
+class SenseNovaU1VisionLoadReport:
+    loaded_keys: list[str] = field(default_factory=list)
+    missing_keys: list[str] = field(default_factory=list)
+    unexpected_keys: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.missing_keys and not self.unexpected_keys and not self.errors
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data.update(
+            {
+                "loaded_count": len(self.loaded_keys),
+                "missing_count": len(self.missing_keys),
+                "unexpected_count": len(self.unexpected_keys),
+                "error_count": len(self.errors),
+                "ok": self.ok,
+            }
+        )
+        return data
+
+
+def precompute_rope_freqs_sincos(
+    dim: int,
+    max_position: int,
+    *,
+    base: float = 10000.0,
+    device: torch.device | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, device=device).float() / dim))
+    t = torch.arange(max_position, device=device).type_as(inv_freq)
+    freqs = torch.outer(t, inv_freq)
+    return torch.cos(freqs), torch.sin(freqs)
+
+
+def build_abs_positions_from_grid_hw(
+    grid_hw: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    device = grid_hw.device
+    grid_hw = grid_hw.to(device=device, dtype=torch.long)
+    heights = grid_hw[:, 0]
+    widths = grid_hw[:, 1]
+    patch_counts = heights * widths
+    total = int(patch_counts.sum().item())
+    patch_to_sample = torch.repeat_interleave(
+        torch.arange(grid_hw.shape[0], device=device),
+        patch_counts,
+    )
+    patch_id = torch.arange(total, device=device)
+    offsets = torch.cumsum(
+        torch.cat([torch.zeros(1, device=device, dtype=torch.long), patch_counts[:-1]]),
+        dim=0,
+    )
+    within = patch_id - offsets[patch_to_sample]
+    width_per_patch = widths[patch_to_sample]
+    abs_x = within % width_per_patch
+    abs_y = within // width_per_patch
+    return abs_x, abs_y
+
+
+def apply_rotary_emb_1d(
+    x: torch.Tensor,
+    cos_cached: torch.Tensor,
+    sin_cached: torch.Tensor,
+    positions: torch.Tensor,
+) -> torch.Tensor:
+    cos = cos_cached[positions]
+    sin = sin_cached[positions]
+    x1 = x[..., 0::2]
+    x2 = x[..., 1::2]
+    out = torch.empty_like(x)
+    out[..., 0::2] = x1 * cos - x2 * sin
+    out[..., 1::2] = x1 * sin + x2 * cos
+    return out
+
+
+def apply_2d_rotary_pos_emb(
+    x: torch.Tensor,
+    cos_cached_x: torch.Tensor,
+    sin_cached_x: torch.Tensor,
+    cos_cached_y: torch.Tensor,
+    sin_cached_y: torch.Tensor,
+    abs_positions_x: torch.Tensor,
+    abs_positions_y: torch.Tensor,
+) -> torch.Tensor:
+    dim_half = x.shape[-1] // 2
+    x_part_1 = x[..., :dim_half]
+    x_part_2 = x[..., dim_half:]
+    rotated_1 = apply_rotary_emb_1d(
+        x_part_1,
+        cos_cached_x,
+        sin_cached_x,
+        abs_positions_x,
+    )
+    rotated_2 = apply_rotary_emb_1d(
+        x_part_2,
+        cos_cached_y,
+        sin_cached_y,
+        abs_positions_y,
+    )
+    return torch.cat((rotated_1, rotated_2), dim=-1)
+
+
+def _rope_cache_matches(
+    cos_x: torch.Tensor,
+    sin_x: torch.Tensor,
+    cos_y: torch.Tensor,
+    sin_y: torch.Tensor,
+    *,
+    device: torch.device,
+    max_position: int,
+    dim: int,
+) -> bool:
+    cache_shape = (max_position, dim // 2)
+    return (
+        cos_x.device == device
+        and sin_x.device == device
+        and cos_y.device == device
+        and sin_y.device == device
+        and cos_x.dtype == torch.float32
+        and sin_x.dtype == torch.float32
+        and cos_y.dtype == torch.float32
+        and sin_y.dtype == torch.float32
+        and tuple(cos_x.shape) == cache_shape
+        and tuple(sin_x.shape) == cache_shape
+        and tuple(cos_y.shape) == cache_shape
+        and tuple(sin_y.shape) == cache_shape
+    )
+
+
+class SenseNovaU1NativeVisionModel(nn.Module):
+    expected_weight_keys = {
+        "patch_embedding.weight",
+        "patch_embedding.bias",
+        "dense_embedding.weight",
+        "dense_embedding.bias",
+    }
+
+    def __init__(
+        self,
+        config: Any,
+        *,
+        params_dtype: torch.dtype | str | None = None,
+    ) -> None:
+        super().__init__()
+        self.config = _to_namespace(config)
+        dtype = resolve_dtype(params_dtype or getattr(self.config, "torch_dtype", None))
+        self.embed_dim = int(self.config.hidden_size)
+        self.llm_embed_dim = _llm_hidden_size(self.config.llm_hidden_size)
+        self.patch_size = int(self.config.patch_size)
+        self.downsample_factor = int(1 / float(self.config.downsample_ratio))
+
+        self.patch_embedding = nn.Conv2d(
+            in_channels=int(self.config.num_channels),
+            out_channels=self.embed_dim,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+            dtype=dtype,
+        )
+        self.dense_embedding = nn.Conv2d(
+            in_channels=self.embed_dim,
+            out_channels=self.llm_embed_dim,
+            kernel_size=self.downsample_factor,
+            stride=self.downsample_factor,
+            dtype=dtype,
+        )
+        self.gelu = nn.GELU()
+
+        rope_dim_part = self.embed_dim // 2
+        self.rope_dim_part = rope_dim_part
+        cos_x, sin_x = precompute_rope_freqs_sincos(
+            rope_dim_part,
+            int(self.config.max_position_embeddings_vision),
+            base=float(self.config.rope_theta_vision),
+        )
+        cos_y, sin_y = precompute_rope_freqs_sincos(
+            rope_dim_part,
+            int(self.config.max_position_embeddings_vision),
+            base=float(self.config.rope_theta_vision),
+        )
+        self.register_buffer("cos_cached_x", cos_x, persistent=False)
+        self.register_buffer("sin_cached_x", sin_x, persistent=False)
+        self.register_buffer("cos_cached_y", cos_y, persistent=False)
+        self.register_buffer("sin_cached_y", sin_y, persistent=False)
+
+    @classmethod
+    def from_model_path(
+        cls,
+        model_path: str | Path,
+        *,
+        params_dtype: torch.dtype | str | None = None,
+    ) -> "SenseNovaU1NativeVisionModel":
+        return cls(load_u1_vision_config(model_path), params_dtype=params_dtype)
+
+    def load_weights(self, model_path: str | Path) -> SenseNovaU1VisionLoadReport:
+        model_path = Path(model_path)
+        index_file = model_path / "model.safetensors.index.json"
+        with index_file.open("r", encoding="utf-8") as f:
+            weight_map = json.load(f)["weight_map"]
+
+        shards: dict[str, list[str]] = {}
+        for key, shard_name in weight_map.items():
+            if key.startswith("vision_model."):
+                shards.setdefault(shard_name, []).append(key)
+
+        loaded: set[str] = set()
+        errors: list[str] = []
+        from safetensors import safe_open
+
+        params = dict(self.named_parameters())
+        for shard_name in sorted(shards):
+            with safe_open(str(model_path / shard_name), framework="pt", device="cpu") as f:
+                for full_key in sorted(shards[shard_name]):
+                    name = full_key[len("vision_model.") :]
+                    if name.startswith("embeddings."):
+                        name = name[len("embeddings.") :]
+                    tensor = f.get_tensor(full_key)
+                    param = params.get(name)
+                    if param is None:
+                        errors.append(f"unexpected parameter target {name}")
+                        continue
+                    if tuple(param.shape) != tuple(tensor.shape):
+                        errors.append(
+                            f"shape mismatch for {name}: param={tuple(param.shape)} "
+                            f"checkpoint={tuple(tensor.shape)}"
+                        )
+                        continue
+                    with torch.no_grad():
+                        param.copy_(tensor.to(device=param.device, dtype=param.dtype))
+                    loaded.add(name)
+
+        unexpected = sorted(loaded - self.expected_weight_keys)
+        missing = sorted(self.expected_weight_keys - loaded)
+        return SenseNovaU1VisionLoadReport(
+            loaded_keys=sorted(loaded),
+            missing_keys=missing,
+            unexpected_keys=unexpected,
+            errors=errors,
+        )
+
+    def _ensure_fp32_rope_cache(self, device: torch.device) -> None:
+        """Keep vision RoPE cache aligned with full HF NEOChatModel.
+
+        The HF runner loads weights in bf16, then calls ``model.to(device)``
+        without a dtype, so non-persistent vision RoPE caches stay fp32. Native
+        serving moves this module with ``dtype=bf16`` for weights; refresh the
+        caches in fp32 before RoPE so high-frequency spatial rotations match.
+        """
+
+        max_position = int(self.config.max_position_embeddings_vision)
+        if _rope_cache_matches(
+            self.cos_cached_x,
+            self.sin_cached_x,
+            self.cos_cached_y,
+            self.sin_cached_y,
+            device=device,
+            max_position=max_position,
+            dim=self.rope_dim_part,
+        ):
+            return
+        cos_x, sin_x = precompute_rope_freqs_sincos(
+            self.rope_dim_part,
+            max_position,
+            base=float(self.config.rope_theta_vision),
+            device=device,
+        )
+        cos_y, sin_y = precompute_rope_freqs_sincos(
+            self.rope_dim_part,
+            max_position,
+            base=float(self.config.rope_theta_vision),
+            device=device,
+        )
+        self.cos_cached_x = cos_x
+        self.sin_cached_x = sin_x
+        self.cos_cached_y = cos_y
+        self.sin_cached_y = sin_y
+
+    def _apply_2d_rotary_pos_emb(
+        self,
+        patch_embeds: torch.Tensor,
+        grid_hw: torch.Tensor,
+    ) -> torch.Tensor:
+        self._ensure_fp32_rope_cache(patch_embeds.device)
+        abs_pos_x, abs_pos_y = build_abs_positions_from_grid_hw(grid_hw)
+        embeddings = apply_2d_rotary_pos_emb(
+            patch_embeds.float(),
+            self.cos_cached_x,
+            self.sin_cached_x,
+            self.cos_cached_y,
+            self.sin_cached_y,
+            abs_pos_x,
+            abs_pos_y,
+        )
+        return embeddings.to(self.patch_embedding.weight.dtype)
+
+    def forward(self, pixel_values: torch.Tensor, grid_hw: torch.Tensor) -> torch.Tensor:
+        if pixel_values.ndim != 2:
+            raise ValueError(
+                f"pixel_values must be 2D native-resolution patches, got {pixel_values.ndim}D"
+            )
+        grid_hw = grid_hw.to(device=pixel_values.device, dtype=torch.long)
+        pixels = pixel_values.reshape(-1, 3, self.patch_size, self.patch_size)
+        patch_embeds = self.gelu(self.patch_embedding(pixels)).reshape(-1, self.embed_dim)
+        patch_embeds = self._apply_2d_rotary_pos_emb(patch_embeds, grid_hw)
+        expected_patches = int((grid_hw[:, 0] * grid_hw[:, 1]).sum().item())
+        if expected_patches != int(patch_embeds.shape[0]):
+            raise ValueError(
+                f"grid_hw patch count {expected_patches} != patch embeddings {patch_embeds.shape[0]}"
+            )
+
+        patches: list[torch.Tensor] = []
+        cur = 0
+        for row in grid_hw:
+            h = int(row[0].item())
+            w = int(row[1].item())
+            img = patch_embeds[cur : cur + h * w].reshape(h, w, -1).unsqueeze(0)
+            img = self.dense_embedding(img.permute(0, 3, 1, 2))
+            img = img.permute(0, 2, 3, 1)
+            patches.append(img.reshape(-1, img.shape[-1]))
+            cur += h * w
+        embeddings = torch.cat(patches, dim=0)
+        expected_tokens = expected_patches // (self.downsample_factor**2)
+        if int(embeddings.shape[0]) != expected_tokens:
+            raise ValueError(
+                f"vision embeddings {embeddings.shape[0]} != expected image tokens {expected_tokens}"
+            )
+        return embeddings
+
+
+__all__ = [
+    "SenseNovaU1NativeVisionModel",
+    "SenseNovaU1VisionLoadReport",
+    "build_abs_positions_from_grid_hw",
+    "load_u1_vision_config",
+]

--- a/sglang_omni/models/sensenova_u1/sglang_model.py
+++ b/sglang_omni/models/sensenova_u1/sglang_model.py
@@ -1,0 +1,2037 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native SGLang language tower for SenseNova U1.
+
+This module intentionally does not import the official HF ``NEOChatModel``.
+The classes here cover the U1 language tower with SGLang-native layers. Vision
+and flow-matching modules remain separate work items; this file is the first
+native load/forward milestone for the text/MoT backbone.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Iterable, Iterator, Mapping
+
+import torch
+from sglang.srt.layers.logits_processor import LogitsProcessor, LogitsProcessorOutput
+from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
+from torch import nn
+
+from sglang_omni.models.sensenova_u1.hybrid_attention import (
+    build_image_spans,
+    build_image_token_tag_from_t_indexes,
+    build_u1_hybrid_allowed_matrix,
+    build_u1_hybrid_backend_mask,
+)
+from sglang_omni.models.weight_loader import default_weight_loader, resolve_dtype
+from sglang_omni.vendor.sglang.core import ForwardBatch
+from sglang_omni.vendor.sglang.distributed import get_tensor_model_parallel_world_size
+from sglang_omni.vendor.sglang.layers import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RMSNorm,
+    RadixAttention,
+    RowParallelLinear,
+    VocabParallelEmbedding,
+    get_rope,
+)
+from sglang_omni.vendor.sglang.utils import add_prefix
+
+
+HF_MODELING_MODULE_PREFIXES: tuple[str, ...] = (
+    "sensenova_u1.models.neo_unify.modeling_neo_chat",
+    "sensenova_u1.models.neo_unify.modeling_qwen3",
+    "sensenova_u1.models.neo_unify.modeling_qwen3_moe",
+    "sensenova_u1.models.neo_unify.modeling_neo_vit",
+    "sensenova_u1.models.neo_unify.modeling_fm_modules",
+)
+
+
+def _blocked_hf_modeling_modules() -> list[str]:
+    candidates = (
+        "sensenova_u1.models.neo_unify",
+        *HF_MODELING_MODULE_PREFIXES,
+    )
+    # Importing any descendant necessarily installs its parent module in
+    # sys.modules, so exact parent lookups preserve the guard while avoiding a
+    # full scan of every loaded Python module on each native forward boundary.
+    return sorted(name for name in candidates if name in sys.modules)
+
+
+def assert_no_hf_modeling_imported(*, context: str) -> None:
+    """Fail if the native serving path imported official U1 modeling code."""
+    imported = _blocked_hf_modeling_modules()
+    if imported:
+        joined = ", ".join(imported)
+        raise RuntimeError(f"{context}: HF U1 modeling modules imported: {joined}")
+
+
+class _HFModelingBlocker:
+    def find_spec(self, fullname: str, path: Any = None, target: Any = None):
+        del path, target
+        if any(
+            fullname == prefix or fullname.startswith(prefix + ".")
+            for prefix in HF_MODELING_MODULE_PREFIXES
+        ):
+            raise ImportError(
+                "Native SenseNova U1 serving path must not import official HF "
+                f"modeling module {fullname!r}"
+            )
+        return None
+
+
+@contextmanager
+def block_hf_modeling_imports() -> Iterator[None]:
+    """Install a temporary import guard for official U1 HF modeling modules."""
+    blocker = _HFModelingBlocker()
+    sys.meta_path.insert(0, blocker)
+    try:
+        yield
+    finally:
+        try:
+            sys.meta_path.remove(blocker)
+        except ValueError:
+            pass
+
+
+@dataclass(slots=True)
+class SenseNovaU1LoadReport:
+    loaded_language_keys: list[str] = field(default_factory=list)
+    missing_language_keys: list[str] = field(default_factory=list)
+    unexpected_language_keys: list[str] = field(default_factory=list)
+    ignored_non_language_keys: dict[str, int] = field(default_factory=dict)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def loaded_count(self) -> int:
+        return len(self.loaded_language_keys)
+
+    @property
+    def missing_count(self) -> int:
+        return len(self.missing_language_keys)
+
+    @property
+    def unexpected_count(self) -> int:
+        return len(self.unexpected_language_keys)
+
+    @property
+    def error_count(self) -> int:
+        return len(self.errors)
+
+    @property
+    def ok(self) -> bool:
+        return (
+            self.missing_count == 0
+            and self.unexpected_count == 0
+            and self.error_count == 0
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data.update(
+            {
+                "loaded_count": self.loaded_count,
+                "missing_count": self.missing_count,
+                "unexpected_count": self.unexpected_count,
+                "error_count": self.error_count,
+                "ok": self.ok,
+            }
+        )
+        return data
+
+
+def _get_attr(config: Any, name: str, default: Any = None) -> Any:
+    if isinstance(config, Mapping):
+        return config.get(name, default)
+    return getattr(config, name, default)
+
+
+def _to_namespace(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return SimpleNamespace(**{k: _to_namespace(v) for k, v in value.items()})
+    if isinstance(value, list):
+        return [_to_namespace(v) for v in value]
+    return value
+
+
+def load_u1_llm_config(model_path: str | Path) -> SimpleNamespace:
+    """Read U1 ``llm_config`` from config.json without importing HF code."""
+    config_path = Path(model_path) / "config.json"
+    with config_path.open("r", encoding="utf-8") as f:
+        raw = json.load(f)
+    llm_config = raw.get("llm_config", raw)
+    cfg = _to_namespace(llm_config)
+    if not hasattr(cfg, "layer_types") or cfg.layer_types is None:
+        cfg.layer_types = ["full_attention"] * int(cfg.num_hidden_layers)
+    if not hasattr(cfg, "tie_word_embeddings"):
+        cfg.tie_word_embeddings = bool(raw.get("tie_word_embeddings", False))
+    if not hasattr(cfg, "torch_dtype"):
+        cfg.torch_dtype = raw.get("torch_dtype", "bfloat16")
+    return cfg
+
+
+def expected_language_weight_keys(config: Any) -> set[str]:
+    cfg = _to_namespace(config)
+    keys: set[str] = {
+        "lm_head.weight",
+        "model.embed_tokens.weight",
+        "model.norm.weight",
+        "model.norm_mot_gen.weight",
+    }
+    attn_suffixes = (
+        "q_proj.weight",
+        "k_proj.weight",
+        "v_proj.weight",
+        "o_proj.weight",
+        "q_proj_mot_gen.weight",
+        "k_proj_mot_gen.weight",
+        "v_proj_mot_gen.weight",
+        "o_proj_mot_gen.weight",
+        "q_norm.weight",
+        "q_norm_hw.weight",
+        "k_norm.weight",
+        "k_norm_hw.weight",
+        "q_norm_mot_gen.weight",
+        "q_norm_hw_mot_gen.weight",
+        "k_norm_mot_gen.weight",
+        "k_norm_hw_mot_gen.weight",
+    )
+    layer_suffixes = (
+        "input_layernorm.weight",
+        "input_layernorm_mot_gen.weight",
+        "post_attention_layernorm.weight",
+        "post_attention_layernorm_mot_gen.weight",
+        "mlp.gate_proj.weight",
+        "mlp.up_proj.weight",
+        "mlp.down_proj.weight",
+        "mlp_mot_gen.gate_proj.weight",
+        "mlp_mot_gen.up_proj.weight",
+        "mlp_mot_gen.down_proj.weight",
+    )
+    for idx in range(int(cfg.num_hidden_layers)):
+        layer = f"model.layers.{idx}"
+        keys.update(f"{layer}.{suffix}" for suffix in layer_suffixes)
+        keys.update(f"{layer}.self_attn.{suffix}" for suffix in attn_suffixes)
+    return keys
+
+
+def scan_checkpoint_key_summary(model_path: str | Path) -> dict[str, int]:
+    index_file = Path(model_path) / "model.safetensors.index.json"
+    with index_file.open("r", encoding="utf-8") as f:
+        weight_map = json.load(f)["weight_map"]
+    summary: dict[str, int] = {}
+    for key in weight_map:
+        top = key.split(".", 1)[0]
+        summary[top] = summary.get(top, 0) + 1
+    return summary
+
+
+def iter_language_safetensors(
+    model_path: str | Path,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Stream language-model weights from sharded safetensors.
+
+    Yields names with the leading ``language_model.`` stripped so they match
+    this module's native parameter tree.
+    """
+    model_path = Path(model_path)
+    index_file = model_path / "model.safetensors.index.json"
+    with index_file.open("r", encoding="utf-8") as f:
+        weight_map = json.load(f)["weight_map"]
+
+    shards: dict[str, list[str]] = {}
+    for key, shard_name in weight_map.items():
+        if key.startswith("language_model."):
+            shards.setdefault(shard_name, []).append(key)
+
+    from safetensors import safe_open
+
+    for shard_name in sorted(shards):
+        with safe_open(str(model_path / shard_name), framework="pt", device="cpu") as f:
+            for key in sorted(shards[shard_name]):
+                yield key[len("language_model.") :], f.get_tensor(key)
+
+
+def _load_parameter(
+    params: dict[str, nn.Parameter],
+    target_name: str,
+    loaded_weight: torch.Tensor,
+    shard_id: str | int | None = None,
+) -> None:
+    param = params[target_name]
+    if loaded_weight.device != param.device or loaded_weight.dtype != param.dtype:
+        loaded_weight = loaded_weight.to(device=param.device, dtype=param.dtype)
+    loader = getattr(param, "weight_loader", default_weight_loader)
+    if shard_id is None:
+        loader(param, loaded_weight)
+    else:
+        loader(param, loaded_weight, shard_id)
+
+
+def _direct_or_stacked_target(name: str) -> tuple[str, str | int | None] | None:
+    if ".self_attn." in name:
+        if ".q_proj_mot_gen.weight" in name:
+            return name.replace(".q_proj_mot_gen.weight", ".qkv_proj_mot_gen.weight"), "q"
+        if ".k_proj_mot_gen.weight" in name:
+            return name.replace(".k_proj_mot_gen.weight", ".qkv_proj_mot_gen.weight"), "k"
+        if ".v_proj_mot_gen.weight" in name:
+            return name.replace(".v_proj_mot_gen.weight", ".qkv_proj_mot_gen.weight"), "v"
+        if ".q_proj.weight" in name:
+            return name.replace(".q_proj.weight", ".qkv_proj.weight"), "q"
+        if ".k_proj.weight" in name:
+            return name.replace(".k_proj.weight", ".qkv_proj.weight"), "k"
+        if ".v_proj.weight" in name:
+            return name.replace(".v_proj.weight", ".qkv_proj.weight"), "v"
+        return name, None
+
+    if ".mlp_mot_gen." in name:
+        return name, None
+
+    if ".mlp." in name:
+        return name, None
+
+    return name, None
+
+
+def _rms_norm(norm: RMSNorm, x: torch.Tensor) -> torch.Tensor:
+    orig_dtype = x.dtype
+    xf = x.float()
+    variance = xf.pow(2).mean(dim=-1, keepdim=True)
+    xf = xf * torch.rsqrt(variance + norm.variance_epsilon)
+    return norm.weight.to(dtype=orig_dtype) * xf.to(orig_dtype)
+
+
+def _eager_add_rms_impl(
+    residual: torch.Tensor,
+    update: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    hidden = residual + update
+    hidden_f = hidden.float()
+    variance = hidden_f.pow(2).mean(dim=-1, keepdim=True)
+    normed = hidden_f * torch.rsqrt(variance + eps)
+    normed = weight.to(dtype=hidden.dtype) * normed.to(hidden.dtype)
+    return hidden, normed
+
+
+_compiled_eager_add_rms = torch.compile(
+    _eager_add_rms_impl,
+    fullgraph=True,
+    dynamic=False,
+)
+
+
+def _repeat_kv(
+    states: torch.Tensor,
+    *,
+    num_query_heads: int,
+    num_kv_heads: int,
+) -> torch.Tensor:
+    if num_query_heads == num_kv_heads:
+        return states
+    repeat = num_query_heads // num_kv_heads
+    return states.repeat_interleave(repeat, dim=1)
+
+
+class _StandaloneRotaryEmbedding(nn.Module):
+    """Minimal Neox-style RoPE for standalone smoke without server args."""
+
+    def __init__(
+        self,
+        head_size: int,
+        *,
+        max_position: int,
+        base: float,
+        dtype: torch.dtype | None,
+    ) -> None:
+        super().__init__()
+        self.head_size = head_size
+        self.max_position = max_position
+        self.base = base
+        arange = torch.arange(0, head_size, 2, dtype=torch.float32)
+        inv_freq = 1.0 / (base ** (arange / head_size))
+        positions = torch.arange(max_position, dtype=torch.float32)
+        freqs = torch.einsum("i,j->ij", positions, inv_freq)
+        cache = torch.cat([freqs.cos(), freqs.sin()], dim=-1)
+        self.register_buffer("cos_sin_cache", cache, persistent=False)
+
+    @staticmethod
+    def _apply_rope(
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+    ) -> torch.Tensor:
+        x = x.view(x.shape[0], -1, x.shape[-1])
+        cos = cos.unsqueeze(1).to(dtype=x.dtype, device=x.device)
+        sin = sin.unsqueeze(1).to(dtype=x.dtype, device=x.device)
+        x1, x2 = torch.chunk(x, 2, dim=-1)
+        out = torch.cat([x1 * cos - x2 * sin, x2 * cos + x1 * sin], dim=-1)
+        return out
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        positions = positions.flatten().to(device=self.cos_sin_cache.device)
+        capture_active = bool(
+            positions.device.type == "cuda"
+            and torch.cuda.is_current_stream_capturing()
+        )
+        if not capture_active and int(positions.max().item()) >= self.max_position:
+            raise ValueError(
+                f"standalone RoPE position {int(positions.max().item())} exceeds "
+                f"max_position {self.max_position}"
+            )
+        cache = self.cos_sin_cache.index_select(0, positions)
+        cos, sin = cache.chunk(2, dim=-1)
+        query_shape = query.shape
+        key_shape = key.shape
+        query = query.view(query.shape[0], -1, self.head_size)
+        key = key.view(key.shape[0], -1, self.head_size)
+        query = self._apply_rope(query, cos, sin).reshape(query_shape)
+        key = self._apply_rope(key, cos, sin).reshape(key_shape)
+        return query, key
+
+
+class SenseNovaU1NativeMLP(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        *,
+        layer_id: int | None = None,
+        prefix: str = "",
+        params_dtype: torch.dtype | None = None,
+        tp_rank: int | None = None,
+        tp_size: int | None = None,
+        standalone: bool = False,
+    ) -> None:
+        super().__init__()
+        self.layer_id = None if layer_id is None else int(layer_id)
+        self.tp_size = self._resolve_tp_size(tp_size)
+        self.standalone = tp_rank == 0 and tp_size == 1
+        self.gate_proj = ColumnParallelLinear(
+            config.hidden_size,
+            config.intermediate_size,
+            bias=False,
+            params_dtype=params_dtype,
+            prefix=add_prefix("gate_proj", prefix),
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+        )
+        self.up_proj = ColumnParallelLinear(
+            config.hidden_size,
+            config.intermediate_size,
+            bias=False,
+            params_dtype=params_dtype,
+            prefix=add_prefix("up_proj", prefix),
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+        )
+        self.down_proj = RowParallelLinear(
+            config.intermediate_size,
+            config.hidden_size,
+            bias=False,
+            params_dtype=params_dtype,
+            prefix=add_prefix("down_proj", prefix),
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+        )
+
+    @staticmethod
+    def _resolve_tp_size(tp_size: int | None) -> int:
+        if tp_size is not None:
+            return int(tp_size)
+        try:
+            return int(get_tensor_model_parallel_world_size())
+        except Exception:
+            return 1
+
+    def _is_single_rank_diagnostic_path(self) -> bool:
+        return int(self.tp_size) == 1
+
+    @staticmethod
+    def _use_fp32_down_projection() -> bool:
+        return os.environ.get("SENSENOVA_U1_NATIVE_MLP_DOWN_FP32", "").lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+
+    @staticmethod
+    def _fp32_residual_add_enabled() -> bool:
+        return os.environ.get(
+            "SENSENOVA_U1_NATIVE_MLP_FP32_RESIDUAL_ADD", ""
+        ).lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+
+    def _layer_selected_for_fp32_residual_add(self) -> bool:
+        raw = os.environ.get(
+            "SENSENOVA_U1_NATIVE_MLP_FP32_RESIDUAL_ADD_LAYERS", ""
+        ).strip()
+        if not raw:
+            return True
+        if self.layer_id is None:
+            return False
+        selected: set[int] = set()
+        for item in raw.split(","):
+            item = item.strip()
+            if not item:
+                continue
+            if item in {"*", "all", "ALL"}:
+                return True
+            if "-" in item:
+                start, end = item.split("-", 1)
+                selected.update(range(int(start), int(end) + 1))
+            else:
+                selected.add(int(item))
+        return self.layer_id in selected
+
+    def _use_fp32_residual_add(self) -> bool:
+        return (
+            self._fp32_residual_add_enabled()
+            and self._layer_selected_for_fp32_residual_add()
+        )
+
+    def apply_down_proj(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        use_fp32_down = self._use_fp32_down_projection()
+        use_fp32_add = self._use_fp32_residual_add()
+        if use_fp32_down or use_fp32_add:
+            if not self._is_single_rank_diagnostic_path():
+                raise RuntimeError(
+                    "SENSENOVA_U1_NATIVE_MLP_DOWN_FP32 and "
+                    "SENSENOVA_U1_NATIVE_MLP_FP32_RESIDUAL_ADD are only supported "
+                    "for single-rank diagnostic paths"
+                )
+            original_dtype = hidden_states.dtype
+            down = torch.nn.functional.linear(
+                hidden_states.float(),
+                self.down_proj.weight.float(),
+                (
+                    self.down_proj.bias.float()
+                    if self.down_proj.bias is not None
+                    else None
+                ),
+            )
+            if use_fp32_add:
+                return down
+            return down.to(dtype=original_dtype)
+        if self.standalone:
+            return torch.nn.functional.linear(
+                hidden_states,
+                self.down_proj.weight,
+                self.down_proj.bias,
+            )
+        hidden_states, _ = self.down_proj(hidden_states)
+        return hidden_states
+
+    def apply_residual_add(
+        self,
+        residual: torch.Tensor,
+        mlp_output: torch.Tensor,
+    ) -> torch.Tensor:
+        if self._use_fp32_residual_add():
+            if not self._is_single_rank_diagnostic_path():
+                raise RuntimeError(
+                    "SENSENOVA_U1_NATIVE_MLP_FP32_RESIDUAL_ADD is only supported "
+                    "for single-rank diagnostic paths"
+                )
+            return (residual.float() + mlp_output.float()).to(dtype=residual.dtype)
+        return residual + mlp_output
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self.standalone:
+            gate = torch.nn.functional.linear(
+                hidden_states,
+                self.gate_proj.weight,
+                self.gate_proj.bias,
+            )
+            up = torch.nn.functional.linear(
+                hidden_states,
+                self.up_proj.weight,
+                self.up_proj.bias,
+            )
+        else:
+            gate, _ = self.gate_proj(hidden_states)
+            up, _ = self.up_proj(hidden_states)
+        hidden_states = torch.nn.functional.silu(gate) * up
+        return self.apply_down_proj(hidden_states)
+
+
+class SenseNovaU1NativeAttention(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        *,
+        layer_id: int,
+        prefix: str = "",
+        params_dtype: torch.dtype | None = None,
+        tp_rank: int | None = None,
+        tp_size: int | None = None,
+        standalone: bool = False,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.layer_id = layer_id
+        self.standalone = standalone
+        self.tp_size = self._resolve_tp_size(tp_size)
+        self.hidden_size = int(config.hidden_size)
+        self.total_num_heads = int(config.num_attention_heads)
+        self.total_num_kv_heads = int(config.num_key_value_heads)
+        self.head_dim = int(getattr(config, "head_dim", self.hidden_size // self.total_num_heads))
+        self.t_dim = self.head_dim // 2
+        self.hw_dim = self.head_dim // 4
+        self.q_size = self.total_num_heads * self.head_dim
+        self.kv_size = self.total_num_kv_heads * self.head_dim
+        self.scaling = self.head_dim**-0.5
+
+        self.qkv_proj = QKVParallelLinear(
+            self.hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_num_kv_heads,
+            bias=bool(getattr(config, "attention_bias", False)),
+            params_dtype=params_dtype,
+            prefix=add_prefix("qkv_proj", prefix),
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+        )
+        self.qkv_proj_mot_gen = QKVParallelLinear(
+            self.hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_num_kv_heads,
+            bias=bool(getattr(config, "attention_bias", False)),
+            params_dtype=params_dtype,
+            prefix=add_prefix("qkv_proj_mot_gen", prefix),
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+        )
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            self.hidden_size,
+            bias=bool(getattr(config, "attention_bias", False)),
+            params_dtype=params_dtype,
+            prefix=add_prefix("o_proj", prefix),
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+        )
+        self.o_proj_mot_gen = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            self.hidden_size,
+            bias=bool(getattr(config, "attention_bias", False)),
+            params_dtype=params_dtype,
+            prefix=add_prefix("o_proj_mot_gen", prefix),
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+        )
+
+        self.q_norm = RMSNorm(self.t_dim, eps=config.rms_norm_eps)
+        self.q_norm_mot_gen = RMSNorm(self.t_dim, eps=config.rms_norm_eps)
+        self.q_norm_hw = RMSNorm(self.t_dim, eps=config.rms_norm_eps)
+        self.q_norm_hw_mot_gen = RMSNorm(self.t_dim, eps=config.rms_norm_eps)
+        self.k_norm = RMSNorm(self.t_dim, eps=config.rms_norm_eps)
+        self.k_norm_mot_gen = RMSNorm(self.t_dim, eps=config.rms_norm_eps)
+        self.k_norm_hw = RMSNorm(self.t_dim, eps=config.rms_norm_eps)
+        self.k_norm_hw_mot_gen = RMSNorm(self.t_dim, eps=config.rms_norm_eps)
+
+        self.rotary_emb = _StandaloneRotaryEmbedding(
+            self.t_dim,
+            max_position=int(config.max_position_embeddings),
+            base=float(config.rope_theta),
+            dtype=params_dtype,
+        )
+        self.rotary_emb_hw = _StandaloneRotaryEmbedding(
+            self.hw_dim,
+            max_position=int(config.max_position_embeddings_hw),
+            base=float(config.rope_theta_hw),
+            dtype=params_dtype,
+        )
+        self.attn = RadixAttention(
+            self.total_num_heads,
+            self.head_dim,
+            self.scaling,
+            num_kv_heads=self.total_num_kv_heads,
+            layer_id=layer_id,
+            prefix=add_prefix("attn", prefix),
+        )
+
+    def _project_qkv(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        use_mot_gen: bool,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+        torch.Tensor,
+    ]:
+        qkv_proj = self.qkv_proj_mot_gen if use_mot_gen else self.qkv_proj
+        if self._use_separate_qkv_projection():
+            if not self._is_single_rank_diagnostic_path():
+                raise RuntimeError(
+                    "SENSENOVA_U1_NATIVE_SEPARATE_QKV_PROJ is only supported "
+                    "for single-rank paths"
+                )
+            q_weight, k_weight, v_weight = qkv_proj.weight.split(
+                [self.q_size, self.kv_size, self.kv_size],
+                dim=0,
+            )
+            if qkv_proj.bias is None:
+                q_bias = k_bias = v_bias = None
+            else:
+                q_bias, k_bias, v_bias = qkv_proj.bias.split(
+                    [self.q_size, self.kv_size, self.kv_size],
+                    dim=0,
+                )
+            q = torch.nn.functional.linear(hidden_states, q_weight, q_bias)
+            k = torch.nn.functional.linear(hidden_states, k_weight, k_bias)
+            v = torch.nn.functional.linear(hidden_states, v_weight, v_bias)
+        elif self.standalone:
+            qkv = torch.nn.functional.linear(hidden_states, qkv_proj.weight, qkv_proj.bias)
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        else:
+            qkv, _ = qkv_proj(hidden_states)
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q = q.view(-1, self.total_num_heads, self.head_dim)
+        k = k.view(-1, self.total_num_kv_heads, self.head_dim)
+        v = v.view(-1, self.total_num_kv_heads, self.head_dim)
+
+        q_t, q_hw = q.split([self.t_dim, self.t_dim], dim=-1)
+        k_t, k_hw = k.split([self.t_dim, self.t_dim], dim=-1)
+        if use_mot_gen:
+            q_t = _rms_norm(self.q_norm_mot_gen, q_t)
+            q_hw = _rms_norm(self.q_norm_hw_mot_gen, q_hw)
+            k_t = _rms_norm(self.k_norm_mot_gen, k_t)
+            k_hw = _rms_norm(self.k_norm_hw_mot_gen, k_hw)
+        else:
+            q_t = _rms_norm(self.q_norm, q_t)
+            q_hw = _rms_norm(self.q_norm_hw, q_hw)
+            k_t = _rms_norm(self.k_norm, k_t)
+            k_hw = _rms_norm(self.k_norm_hw, k_hw)
+        q_h, q_w = q_hw.split([self.hw_dim, self.hw_dim], dim=-1)
+        k_h, k_w = k_hw.split([self.hw_dim, self.hw_dim], dim=-1)
+        return (
+            q_t.reshape(q.shape[0], -1),
+            k_t.reshape(k.shape[0], -1),
+            (
+                q_h.reshape(q.shape[0], -1),
+                k_h.reshape(k.shape[0], -1),
+                q_w.reshape(q.shape[0], -1),
+                k_w.reshape(k.shape[0], -1),
+            ),
+            v.reshape(v.shape[0], -1),
+        )
+
+    @staticmethod
+    def _resolve_tp_size(tp_size: int | None) -> int:
+        if tp_size is not None:
+            return int(tp_size)
+        try:
+            return int(get_tensor_model_parallel_world_size())
+        except Exception:
+            return 1
+
+    def _is_single_rank_diagnostic_path(self) -> bool:
+        return int(self.tp_size) == 1
+
+    def _separate_qkv_projection_enabled(self) -> bool:
+        raw = os.environ.get("SENSENOVA_U1_NATIVE_SEPARATE_QKV_PROJ")
+        if raw is None:
+            return self._is_single_rank_diagnostic_path()
+        return raw.lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+
+    def _layer_selected_for_separate_qkv_projection(self) -> bool:
+        raw = os.environ.get(
+            "SENSENOVA_U1_NATIVE_SEPARATE_QKV_PROJ_LAYERS", ""
+        ).strip()
+        if not raw:
+            return True
+        selected: set[int] = set()
+        for item in raw.split(","):
+            item = item.strip()
+            if not item:
+                continue
+            if item in {"*", "all", "ALL"}:
+                return True
+            if "-" in item:
+                start, end = item.split("-", 1)
+                selected.update(range(int(start), int(end) + 1))
+            else:
+                selected.add(int(item))
+        return self.layer_id in selected
+
+    def _use_separate_qkv_projection(self) -> bool:
+        return (
+            self._separate_qkv_projection_enabled()
+            and self._layer_selected_for_separate_qkv_projection()
+        )
+
+    def _apply_split_rope(
+        self,
+        q_t: torch.Tensor,
+        k_t: torch.Tensor,
+        hw_parts: tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+        indexes: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        q_h, k_h, q_w, k_w = hw_parts
+        q_t, k_t = self.rotary_emb(indexes[0], q_t, k_t)
+        q_h, k_h = self.rotary_emb_hw(indexes[1], q_h, k_h)
+        q_w, k_w = self.rotary_emb_hw(indexes[2], q_w, k_w)
+
+        q_t = q_t.view(-1, self.total_num_heads, self.t_dim)
+        k_t = k_t.view(-1, self.total_num_kv_heads, self.t_dim)
+        q_h = q_h.view(-1, self.total_num_heads, self.hw_dim)
+        k_h = k_h.view(-1, self.total_num_kv_heads, self.hw_dim)
+        q_w = q_w.view(-1, self.total_num_heads, self.hw_dim)
+        k_w = k_w.view(-1, self.total_num_kv_heads, self.hw_dim)
+        q = torch.cat([q_t, q_h, q_w], dim=-1).reshape(-1, self.q_size)
+        k = torch.cat([k_t, k_h, k_w], dim=-1).reshape(-1, self.kv_size)
+        return q, k
+
+    def _native_qkv(
+        self,
+        hidden_states: torch.Tensor,
+        indexes: torch.Tensor,
+        *,
+        use_mot_gen: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        q_t, k_t, hw_parts, v = self._project_qkv(
+            hidden_states, use_mot_gen=use_mot_gen
+        )
+        q, k = self._apply_split_rope(q_t, k_t, hw_parts, indexes)
+        return q, k, v
+
+    def _eager_attention(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        *,
+        causal: bool,
+        allowed: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        q_len = q.shape[0]
+        k_len = k.shape[0]
+        q = q.view(q_len, self.total_num_heads, self.head_dim)
+        k = k.view(k_len, self.total_num_kv_heads, self.head_dim)
+        v = v.view(k_len, self.total_num_kv_heads, self.head_dim)
+        k = _repeat_kv(
+            k,
+            num_query_heads=self.total_num_heads,
+            num_kv_heads=self.total_num_kv_heads,
+        )
+        v = _repeat_kv(
+            v,
+            num_query_heads=self.total_num_heads,
+            num_kv_heads=self.total_num_kv_heads,
+        )
+        scores = torch.einsum("qhd,khd->hqk", q.float(), k.float()) * self.scaling
+        if allowed is not None:
+            allowed = allowed.to(device=scores.device, dtype=torch.bool)
+            scores = scores.masked_fill(
+                ~allowed.unsqueeze(0),
+                torch.finfo(scores.dtype).min,
+            )
+        elif causal:
+            if q_len != k_len:
+                raise ValueError("causal eager attention requires q_len == k_len")
+            mask = torch.ones(
+                (q_len, k_len), device=scores.device, dtype=torch.bool
+            ).tril()
+            scores = scores.masked_fill(~mask.unsqueeze(0), torch.finfo(scores.dtype).min)
+        probs = torch.softmax(scores, dim=-1).to(v.dtype)
+        out = torch.einsum("hqk,khd->qhd", probs, v)
+        return out.reshape(q_len, self.q_size)
+
+    def _sdpa_attention(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        *,
+        causal: bool,
+        allowed: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        q_len = q.shape[0]
+        k_len = k.shape[0]
+        q = q.view(q_len, self.total_num_heads, self.head_dim)
+        k = k.view(k_len, self.total_num_kv_heads, self.head_dim)
+        v = v.view(k_len, self.total_num_kv_heads, self.head_dim)
+        # Match the official U1 SDPA fallback: materialize GQA K/V repeats
+        # before calling SDPA instead of relying on enable_gqa=True.
+        k = _repeat_kv(
+            k,
+            num_query_heads=self.total_num_heads,
+            num_kv_heads=self.total_num_kv_heads,
+        )
+        v = _repeat_kv(
+            v,
+            num_query_heads=self.total_num_heads,
+            num_kv_heads=self.total_num_kv_heads,
+        )
+        q_bhsd = q.unsqueeze(0).transpose(1, 2)
+        k_bhsd = k.unsqueeze(0).transpose(1, 2)
+        v_bhsd = v.unsqueeze(0).transpose(1, 2)
+        attn_mask = None
+        if allowed is not None:
+            attn_mask = allowed.to(device=q.device, dtype=torch.bool).view(
+                1,
+                1,
+                q_len,
+                k_len,
+            )
+        out = torch.nn.functional.scaled_dot_product_attention(
+            q_bhsd,
+            k_bhsd,
+            v_bhsd,
+            attn_mask=attn_mask,
+            dropout_p=0.0,
+            is_causal=causal and attn_mask is None,
+            scale=self.scaling,
+        )
+        return out.transpose(1, 2).reshape(q_len, self.q_size)
+
+    def _official_eager_attention(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        *,
+        causal: bool,
+        allowed: torch.Tensor | None = None,
+        kv_already_repeated: bool = False,
+    ) -> torch.Tensor:
+        """Match the public U1 eager attention math used by HF prefill."""
+
+        q_len = q.shape[0]
+        k_len = k.shape[0]
+        q = q.view(q_len, self.total_num_heads, self.head_dim)
+        cache_heads = (
+            self.total_num_heads
+            if kv_already_repeated
+            else self.total_num_kv_heads
+        )
+        k = k.view(k_len, cache_heads, self.head_dim)
+        v = v.view(k_len, cache_heads, self.head_dim)
+        if not kv_already_repeated:
+            k = _repeat_kv(
+                k,
+                num_query_heads=self.total_num_heads,
+                num_kv_heads=self.total_num_kv_heads,
+            )
+            v = _repeat_kv(
+                v,
+                num_query_heads=self.total_num_heads,
+                num_kv_heads=self.total_num_kv_heads,
+            )
+        q_bhsd = q.transpose(0, 1).unsqueeze(0)
+        k_bhsd = k.transpose(0, 1).unsqueeze(0)
+        v_bhsd = v.transpose(0, 1).unsqueeze(0)
+        attn_weights = torch.matmul(q_bhsd, k_bhsd.transpose(2, 3)) * self.scaling
+
+        mask = None
+        if allowed is not None:
+            allowed = allowed.to(device=attn_weights.device, dtype=torch.bool)
+            mask = torch.where(
+                allowed.view(1, 1, q_len, k_len),
+                torch.zeros((), device=attn_weights.device, dtype=attn_weights.dtype),
+                torch.full(
+                    (),
+                    float("-inf"),
+                    device=attn_weights.device,
+                    dtype=attn_weights.dtype,
+                ),
+            )
+        elif causal:
+            if q_len != k_len:
+                raise ValueError("causal official eager attention requires q_len == k_len")
+            allowed_causal = torch.ones(
+                (q_len, k_len),
+                device=attn_weights.device,
+                dtype=torch.bool,
+            ).tril()
+            mask = torch.where(
+                allowed_causal.view(1, 1, q_len, k_len),
+                torch.zeros((), device=attn_weights.device, dtype=attn_weights.dtype),
+                torch.full(
+                    (),
+                    float("-inf"),
+                    device=attn_weights.device,
+                    dtype=attn_weights.dtype,
+                ),
+            )
+        if mask is not None:
+            attn_weights = attn_weights + mask
+
+        attn_weights = torch.nn.functional.softmax(
+            attn_weights,
+            dim=-1,
+            dtype=torch.float32,
+        ).to(q_bhsd.dtype)
+        out = torch.matmul(attn_weights, v_bhsd)
+        return out.transpose(1, 2).contiguous().reshape(q_len, self.q_size)
+
+    def repeat_eager_kv_cache(self, states: torch.Tensor) -> torch.Tensor:
+        seq_len = int(states.shape[0])
+        states = states.view(
+            seq_len,
+            self.total_num_kv_heads,
+            self.head_dim,
+        )
+        return _repeat_kv(
+            states,
+            num_query_heads=self.total_num_heads,
+            num_kv_heads=self.total_num_kv_heads,
+        ).reshape(seq_len, self.q_size)
+
+    def _apply_o_proj(
+        self,
+        attn_output: torch.Tensor,
+        *,
+        use_mot_gen: bool,
+    ) -> torch.Tensor:
+        o_proj = self.o_proj_mot_gen if use_mot_gen else self.o_proj
+        if self.standalone:
+            return torch.nn.functional.linear(
+                attn_output,
+                o_proj.weight,
+                o_proj.bias,
+            )
+        attn_output, _ = o_proj(attn_output)
+        return attn_output
+
+    def _forward_one_path(
+        self,
+        hidden_states: torch.Tensor,
+        indexes: torch.Tensor,
+        forward_batch: ForwardBatch | None,
+        *,
+        use_mot_gen: bool,
+    ) -> torch.Tensor:
+        q, k, v = self._native_qkv(
+            hidden_states,
+            indexes,
+            use_mot_gen=use_mot_gen,
+        )
+        if forward_batch is None:
+            attn_output = self._eager_attention(q, k, v, causal=not use_mot_gen)
+        else:
+            attn_output = self.attn(q, k, v, forward_batch)
+        return self._apply_o_proj(attn_output, use_mot_gen=use_mot_gen)
+
+    def _forward_mixed_path(
+        self,
+        hidden_states: torch.Tensor,
+        indexes: torch.Tensor,
+        forward_batch: ForwardBatch | None,
+        image_gen_indicators: torch.Tensor,
+    ) -> torch.Tensor:
+        und_q, und_k, und_v = self._native_qkv(
+            hidden_states,
+            indexes,
+            use_mot_gen=False,
+        )
+        gen_q, gen_k, gen_v = self._native_qkv(
+            hidden_states,
+            indexes,
+            use_mot_gen=True,
+        )
+        token_mask = image_gen_indicators[:, None].to(
+            device=hidden_states.device,
+            dtype=torch.bool,
+        )
+        q = torch.where(token_mask, gen_q, und_q)
+        k = torch.where(token_mask, gen_k, und_k)
+        v = torch.where(token_mask, gen_v, und_v)
+        if forward_batch is None:
+            allowed = build_u1_hybrid_allowed_matrix(indexes[0], image_gen_indicators)
+            attn_output = self._eager_attention(
+                q,
+                k,
+                v,
+                causal=False,
+                allowed=allowed,
+            )
+        else:
+            attn_output = self.attn(q, k, v, forward_batch)
+
+        und = self._apply_o_proj(attn_output, use_mot_gen=False)
+        gen = self._apply_o_proj(attn_output, use_mot_gen=True)
+        return torch.where(token_mask, gen, und)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        indexes: torch.Tensor,
+        forward_batch: ForwardBatch | None,
+        image_gen_indicators: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if image_gen_indicators is None or not bool(image_gen_indicators.any()):
+            return self._forward_one_path(
+                hidden_states, indexes, forward_batch, use_mot_gen=False
+            )
+        if bool(image_gen_indicators.all()):
+            return self._forward_one_path(
+                hidden_states, indexes, forward_batch, use_mot_gen=True
+            )
+
+        return self._forward_mixed_path(
+            hidden_states,
+            indexes,
+            forward_batch,
+            image_gen_indicators,
+        )
+
+
+class SenseNovaU1NativeDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        *,
+        layer_id: int,
+        prefix: str = "",
+        params_dtype: torch.dtype | None = None,
+        tp_rank: int | None = None,
+        tp_size: int | None = None,
+        standalone: bool = False,
+    ) -> None:
+        super().__init__()
+        self.layer_id = int(layer_id)
+        self.self_attn = SenseNovaU1NativeAttention(
+            config,
+            layer_id=layer_id,
+            prefix=add_prefix("self_attn", prefix),
+            params_dtype=params_dtype,
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+            standalone=standalone,
+        )
+        self.mlp = SenseNovaU1NativeMLP(
+            config,
+            layer_id=layer_id,
+            prefix=add_prefix("mlp", prefix),
+            params_dtype=params_dtype,
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+        )
+        self.mlp_mot_gen = SenseNovaU1NativeMLP(
+            config,
+            layer_id=layer_id,
+            prefix=add_prefix("mlp_mot_gen", prefix),
+            params_dtype=params_dtype,
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+        )
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.input_layernorm_mot_gen = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.post_attention_layernorm_mot_gen = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def _use_compiled_eager_add_rms(self) -> bool:
+        enabled = os.environ.get(
+            "SENSENOVA_U1_NATIVE_EAGER_COMPILED_ADD_RMS",
+            "",
+        ).lower() in {"1", "true", "yes", "on"}
+        if not enabled:
+            return False
+        raw = os.environ.get(
+            "SENSENOVA_U1_NATIVE_EAGER_COMPILED_ADD_RMS_LAYERS",
+            "",
+        ).strip()
+        if not raw:
+            return True
+        selected: set[int] = set()
+        for item in raw.split(","):
+            item = item.strip()
+            if not item:
+                continue
+            if item in {"*", "all", "ALL"}:
+                return True
+            if "-" in item:
+                start, end = item.split("-", 1)
+                selected.update(range(int(start), int(end) + 1))
+            else:
+                selected.add(int(item))
+        return self.layer_id in selected
+
+    def _eager_post_attention_norm(
+        self,
+        residual: torch.Tensor,
+        update: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self._use_compiled_eager_add_rms():
+            return _compiled_eager_add_rms(
+                residual,
+                update,
+                self.post_attention_layernorm.weight,
+                self.post_attention_layernorm.variance_epsilon,
+            )
+        hidden = residual + update
+        return hidden, _rms_norm(self.post_attention_layernorm, hidden)
+
+    def _forward_one_path(
+        self,
+        hidden_states: torch.Tensor,
+        indexes: torch.Tensor,
+        forward_batch: ForwardBatch | None,
+        *,
+        use_mot_gen: bool,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        norm = self.input_layernorm_mot_gen if use_mot_gen else self.input_layernorm
+        hidden_states = _rms_norm(norm, hidden_states)
+        hidden_states = self.self_attn._forward_one_path(
+            hidden_states,
+            indexes,
+            forward_batch,
+            use_mot_gen=use_mot_gen,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        norm = (
+            self.post_attention_layernorm_mot_gen
+            if use_mot_gen
+            else self.post_attention_layernorm
+        )
+        mlp = self.mlp_mot_gen if use_mot_gen else self.mlp
+        hidden_states = mlp(_rms_norm(norm, hidden_states))
+        return mlp.apply_residual_add(residual, hidden_states)
+
+    def eager_text_prefill_with_cache(
+        self,
+        hidden_states: torch.Tensor,
+        indexes: torch.Tensor,
+        *,
+        allowed: torch.Tensor | None = None,
+        repeat_kv_cache: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """HF-style full prefill for understanding/text tokens plus raw KV."""
+
+        residual = hidden_states
+        hidden_states = _rms_norm(self.input_layernorm, hidden_states)
+        q, k, v = self.self_attn._native_qkv(
+            hidden_states,
+            indexes,
+            use_mot_gen=False,
+        )
+        attn_output = self.self_attn._official_eager_attention(
+            q,
+            k,
+            v,
+            causal=allowed is None,
+            allowed=allowed,
+        )
+        attention_update = self.self_attn._apply_o_proj(
+            attn_output,
+            use_mot_gen=False,
+        )
+
+        hidden_states, mlp_input = self._eager_post_attention_norm(
+            residual,
+            attention_update,
+        )
+        residual = hidden_states
+        hidden_states = self.mlp(mlp_input)
+        hidden_states = self.mlp.apply_residual_add(residual, hidden_states)
+        if repeat_kv_cache:
+            k = self.self_attn.repeat_eager_kv_cache(k)
+            v = self.self_attn.repeat_eager_kv_cache(v)
+        return hidden_states, k.detach(), v.detach()
+
+    def eager_text_decode_with_cache(
+        self,
+        hidden_states: torch.Tensor,
+        indexes: torch.Tensor,
+        past_k: torch.Tensor,
+        past_v: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """HF-style single-token cached text decode plus updated raw KV."""
+
+        residual = hidden_states
+        hidden_states = _rms_norm(self.input_layernorm, hidden_states)
+        q, k_cur, v_cur = self.self_attn._native_qkv(
+            hidden_states,
+            indexes,
+            use_mot_gen=False,
+        )
+        k = torch.cat([past_k, k_cur], dim=0)
+        v = torch.cat([past_v, v_cur], dim=0)
+        attn_output = self.self_attn._official_eager_attention(
+            q,
+            k,
+            v,
+            causal=False,
+        )
+        attention_update = self.self_attn._apply_o_proj(
+            attn_output,
+            use_mot_gen=False,
+        )
+
+        hidden_states, mlp_input = self._eager_post_attention_norm(
+            residual,
+            attention_update,
+        )
+        residual = hidden_states
+        hidden_states = self.mlp(mlp_input)
+        hidden_states = self.mlp.apply_residual_add(residual, hidden_states)
+        return hidden_states, k.detach(), v.detach()
+
+    def eager_text_decode_with_repeated_cache(
+        self,
+        hidden_states: torch.Tensor,
+        indexes: torch.Tensor,
+        past_k: torch.Tensor,
+        past_v: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Exact eager decode with history already expanded to query heads."""
+
+        residual = hidden_states
+        hidden_states = _rms_norm(self.input_layernorm, hidden_states)
+        q, k_cur, v_cur = self.self_attn._native_qkv(
+            hidden_states,
+            indexes,
+            use_mot_gen=False,
+        )
+        k_cur = self.self_attn.repeat_eager_kv_cache(k_cur)
+        v_cur = self.self_attn.repeat_eager_kv_cache(v_cur)
+        k = torch.cat([past_k, k_cur], dim=0)
+        v = torch.cat([past_v, v_cur], dim=0)
+        attn_output = self.self_attn._official_eager_attention(
+            q,
+            k,
+            v,
+            causal=False,
+            kv_already_repeated=True,
+        )
+        attention_update = self.self_attn._apply_o_proj(
+            attn_output,
+            use_mot_gen=False,
+        )
+
+        hidden_states, mlp_input = self._eager_post_attention_norm(
+            residual,
+            attention_update,
+        )
+        residual = hidden_states
+        hidden_states = self.mlp(mlp_input)
+        hidden_states = self.mlp.apply_residual_add(residual, hidden_states)
+        return hidden_states, k.detach(), v.detach()
+
+    def eager_text_decode_with_static_cache(
+        self,
+        hidden_states: torch.Tensor,
+        indexes: torch.Tensor,
+        cache_k: torch.Tensor,
+        cache_v: torch.Tensor,
+        *,
+        cache_position: int,
+        repeat_kv_cache: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Exact eager decode writing the current KV into fixed buffers."""
+
+        residual = hidden_states
+        hidden_states = _rms_norm(self.input_layernorm, hidden_states)
+        q, k_cur, v_cur = self.self_attn._native_qkv(
+            hidden_states,
+            indexes,
+            use_mot_gen=False,
+        )
+        if repeat_kv_cache:
+            k_cur = self.self_attn.repeat_eager_kv_cache(k_cur)
+            v_cur = self.self_attn.repeat_eager_kv_cache(v_cur)
+        cache_k[cache_position : cache_position + 1].copy_(k_cur)
+        cache_v[cache_position : cache_position + 1].copy_(v_cur)
+        k = cache_k[: cache_position + 1]
+        v = cache_v[: cache_position + 1]
+        attn_output = self.self_attn._official_eager_attention(
+            q,
+            k,
+            v,
+            causal=False,
+            kv_already_repeated=repeat_kv_cache,
+        )
+        attention_update = self.self_attn._apply_o_proj(
+            attn_output,
+            use_mot_gen=False,
+        )
+
+        hidden_states, mlp_input = self._eager_post_attention_norm(
+            residual,
+            attention_update,
+        )
+        residual = hidden_states
+        hidden_states = self.mlp(mlp_input)
+        hidden_states = self.mlp.apply_residual_add(residual, hidden_states)
+        return hidden_states, cache_k, cache_v
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        indexes: torch.Tensor,
+        forward_batch: ForwardBatch | None,
+        image_gen_indicators: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if image_gen_indicators is None or not bool(image_gen_indicators.any()):
+            return self._forward_one_path(
+                hidden_states, indexes, forward_batch, use_mot_gen=False
+            )
+        if bool(image_gen_indicators.all()):
+            return self._forward_one_path(
+                hidden_states, indexes, forward_batch, use_mot_gen=True
+            )
+        token_mask = image_gen_indicators[:, None].to(
+            device=hidden_states.device,
+            dtype=torch.bool,
+        )
+
+        residual = hidden_states
+        und_normed = _rms_norm(self.input_layernorm, hidden_states)
+        gen_normed = _rms_norm(self.input_layernorm_mot_gen, hidden_states)
+        mixed_normed = torch.where(token_mask, gen_normed, und_normed)
+        hidden_states = self.self_attn(
+            mixed_normed,
+            indexes,
+            forward_batch,
+            image_gen_indicators=image_gen_indicators,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        und_normed = _rms_norm(self.post_attention_layernorm, hidden_states)
+        gen_normed = _rms_norm(self.post_attention_layernorm_mot_gen, hidden_states)
+        mixed_normed = torch.where(token_mask, gen_normed, und_normed)
+        und = self.mlp(mixed_normed)
+        gen = self.mlp_mot_gen(mixed_normed)
+        return self.mlp.apply_residual_add(
+            residual,
+            torch.where(token_mask, gen, und),
+        )
+
+
+class SenseNovaU1NativeTextModel(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        *,
+        params_dtype: torch.dtype | None = None,
+        prefix: str = "",
+        standalone: bool = False,
+    ) -> None:
+        super().__init__()
+        self.config = _to_namespace(config)
+        self.standalone = standalone
+        tp_rank = 0 if standalone else None
+        tp_size = 1 if standalone else None
+        self.embed_tokens = VocabParallelEmbedding(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            params_dtype=params_dtype,
+            prefix=add_prefix("embed_tokens", prefix),
+            enable_tp=not standalone,
+        )
+        self.layers = nn.ModuleList(
+            [
+                SenseNovaU1NativeDecoderLayer(
+                    self.config,
+                    layer_id=idx,
+                    prefix=add_prefix(f"layers.{idx}", prefix),
+                    params_dtype=params_dtype,
+                    tp_rank=tp_rank,
+                    tp_size=tp_size,
+                    standalone=standalone,
+                )
+                for idx in range(int(self.config.num_hidden_layers))
+            ]
+        )
+        self.norm = RMSNorm(self.config.hidden_size, eps=self.config.rms_norm_eps)
+        self.norm_mot_gen = RMSNorm(
+            self.config.hidden_size, eps=self.config.rms_norm_eps
+        )
+        self.force_mot_gen_for_prefill_graph_capture = False
+
+    @staticmethod
+    def _prepare_indexes(
+        positions: torch.Tensor,
+        indexes: torch.Tensor | None,
+    ) -> torch.Tensor:
+        if indexes is not None:
+            return indexes.to(device=positions.device, dtype=torch.long)
+        if positions.ndim == 2 and positions.shape[0] == 3:
+            return positions.to(dtype=torch.long)
+        flat_positions = positions.flatten().to(dtype=torch.long)
+        zeros = torch.zeros_like(flat_positions)
+        return torch.stack([flat_positions, zeros, zeros])
+
+    @staticmethod
+    def _use_direct_eager_embedding() -> bool:
+        return os.environ.get(
+            "SENSENOVA_U1_NATIVE_EAGER_DIRECT_EMBEDDING",
+            "",
+        ).lower() in {"1", "true", "yes", "on"}
+
+    def _eager_embed(self, input_ids: torch.Tensor) -> torch.Tensor:
+        if self.standalone or self._use_direct_eager_embedding():
+            return torch.nn.functional.embedding(
+                input_ids,
+                self.embed_tokens.weight[: self.config.vocab_size],
+            )
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch | None,
+        input_embeds: torch.Tensor | None = None,
+        *,
+        image_gen_indicators: torch.Tensor | None = None,
+        indexes: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if input_embeds is None:
+            if self.standalone:
+                hidden_states = torch.nn.functional.embedding(
+                    input_ids,
+                    self.embed_tokens.weight[: self.config.vocab_size],
+                )
+            else:
+                hidden_states = self.embed_tokens(input_ids)
+        else:
+            hidden_states = input_embeds
+        if hidden_states.ndim == 3:
+            hidden_states = hidden_states.reshape(-1, hidden_states.shape[-1])
+        indexes = self._prepare_indexes(positions, indexes)
+        if (
+            self.force_mot_gen_for_prefill_graph_capture
+            and image_gen_indicators is None
+            and forward_batch is not None
+        ):
+            for layer in self.layers:
+                hidden_states = layer._forward_one_path(
+                    hidden_states,
+                    indexes,
+                    forward_batch,
+                    use_mot_gen=True,
+                )
+            return _rms_norm(self.norm_mot_gen, hidden_states)
+        if image_gen_indicators is not None:
+            image_gen_indicators = image_gen_indicators.flatten().to(
+                device=hidden_states.device, dtype=torch.bool
+            )
+
+        for layer in self.layers:
+            hidden_states = layer(
+                hidden_states,
+                indexes,
+                forward_batch,
+                image_gen_indicators=image_gen_indicators,
+            )
+
+        if image_gen_indicators is None or not bool(image_gen_indicators.any()):
+            return _rms_norm(self.norm, hidden_states)
+        if bool(image_gen_indicators.all()):
+            return _rms_norm(self.norm_mot_gen, hidden_states)
+        und = _rms_norm(self.norm, hidden_states)
+        gen = _rms_norm(self.norm_mot_gen, hidden_states)
+        return torch.where(image_gen_indicators[:, None], gen, und)
+
+    def eager_text_prefill_with_cache(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        *,
+        input_embeds: torch.Tensor | None = None,
+        indexes: torch.Tensor | None = None,
+        image_token_tag: torch.Tensor | None = None,
+        repeat_kv_cache: bool = False,
+    ) -> tuple[torch.Tensor, list[tuple[torch.Tensor, torch.Tensor]]]:
+        """Run native HF-style eager prefill and return per-layer KV cache."""
+
+        if input_embeds is None:
+            hidden_states = self._eager_embed(input_ids)
+        else:
+            hidden_states = input_embeds
+        if hidden_states.ndim == 3:
+            hidden_states = hidden_states.reshape(-1, hidden_states.shape[-1])
+        indexes = self._prepare_indexes(positions, indexes)
+        allowed = None
+        if image_token_tag is not None and bool(image_token_tag.reshape(-1).any().item()):
+            allowed = build_u1_hybrid_allowed_matrix(
+                indexes[0],
+                image_token_tag.reshape(-1).to(
+                    device=indexes.device,
+                    dtype=torch.bool,
+                ),
+            )
+
+        caches: list[tuple[torch.Tensor, torch.Tensor]] = []
+        for layer in self.layers:
+            hidden_states, k, v = layer.eager_text_prefill_with_cache(
+                hidden_states,
+                indexes,
+                allowed=allowed,
+                repeat_kv_cache=repeat_kv_cache,
+            )
+            caches.append((k, v))
+        hidden_states = _rms_norm(self.norm, hidden_states)
+        return hidden_states, caches
+
+    def eager_text_decode_with_cache(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        caches: list[tuple[torch.Tensor, torch.Tensor]],
+        *,
+        indexes: torch.Tensor | None = None,
+        capture_layer_outputs: list[torch.Tensor] | None = None,
+        repeat_kv_cache: bool = False,
+    ) -> tuple[torch.Tensor, list[tuple[torch.Tensor, torch.Tensor]]]:
+        """Run one HF-style cached text decode step and update KV cache."""
+
+        hidden_states = self._eager_embed(input_ids)
+        if hidden_states.ndim == 3:
+            hidden_states = hidden_states.reshape(-1, hidden_states.shape[-1])
+        indexes = self._prepare_indexes(positions, indexes)
+        if len(caches) != len(self.layers):
+            raise ValueError(
+                "eager text decode cache layer count mismatch: "
+                f"caches={len(caches)} layers={len(self.layers)}"
+            )
+
+        new_caches: list[tuple[torch.Tensor, torch.Tensor]] = []
+        for layer, (past_k, past_v) in zip(self.layers, caches):
+            if repeat_kv_cache:
+                hidden_states, k, v = (
+                    layer.eager_text_decode_with_repeated_cache(
+                        hidden_states,
+                        indexes,
+                        past_k,
+                        past_v,
+                    )
+                )
+            else:
+                hidden_states, k, v = layer.eager_text_decode_with_cache(
+                    hidden_states,
+                    indexes,
+                    past_k,
+                    past_v,
+                )
+            if capture_layer_outputs is not None:
+                capture_layer_outputs.append(hidden_states.detach().cpu())
+            new_caches.append((k, v))
+        hidden_states = _rms_norm(self.norm, hidden_states)
+        if capture_layer_outputs is not None:
+            capture_layer_outputs.append(hidden_states.detach().cpu())
+        return hidden_states, new_caches
+
+    def eager_text_decode_with_static_cache(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        caches: list[tuple[torch.Tensor, torch.Tensor]],
+        *,
+        cache_position: int,
+        indexes: torch.Tensor | None = None,
+        repeat_kv_cache: bool = False,
+    ) -> tuple[torch.Tensor, list[tuple[torch.Tensor, torch.Tensor]]]:
+        hidden_states = self._eager_embed(input_ids)
+        if hidden_states.ndim == 3:
+            hidden_states = hidden_states.reshape(-1, hidden_states.shape[-1])
+        indexes = self._prepare_indexes(positions, indexes)
+        if len(caches) != len(self.layers):
+            raise ValueError(
+                "eager static cache layer count mismatch: "
+                f"caches={len(caches)} layers={len(self.layers)}"
+            )
+
+        for layer, (cache_k, cache_v) in zip(self.layers, caches):
+            hidden_states, _, _ = layer.eager_text_decode_with_static_cache(
+                hidden_states,
+                indexes,
+                cache_k,
+                cache_v,
+                cache_position=cache_position,
+                repeat_kv_cache=repeat_kv_cache,
+            )
+        return _rms_norm(self.norm, hidden_states), caches
+
+
+class SenseNovaU1NativeForCausalLM(nn.Module):
+    """SGLang-native U1 language tower with MoT dual-tower weights."""
+
+    def __init__(
+        self,
+        config: Any,
+        quant_config: Any | None = None,
+        prefix: str = "",
+        params_dtype: torch.dtype | str | None = None,
+        standalone: bool = False,
+    ) -> None:
+        del quant_config
+        super().__init__()
+        if _get_attr(config, "llm_config") is not None:
+            config = _get_attr(config, "llm_config")
+        self.config = _to_namespace(config)
+        dtype = resolve_dtype(params_dtype or _get_attr(self.config, "torch_dtype", None))
+        self.standalone = standalone
+        self.is_mrope_enabled = True
+        self.model = SenseNovaU1NativeTextModel(
+            self.config,
+            params_dtype=dtype,
+            prefix=add_prefix("model", prefix),
+            standalone=standalone,
+        )
+        self.lm_head = ParallelLMHead(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            bias=False,
+            params_dtype=dtype,
+            prefix=add_prefix("lm_head", prefix),
+            enable_tp=not standalone,
+        )
+        self.logits_processor = None if standalone else LogitsProcessor(self.config)
+        self._expected_language_keys = expected_language_weight_keys(self.config)
+        self._last_load_report: SenseNovaU1LoadReport | None = None
+        self._last_forward_batch_prepare: dict[str, Any] | None = None
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    @property
+    def last_load_report(self) -> SenseNovaU1LoadReport | None:
+        return self._last_load_report
+
+    @property
+    def last_forward_batch_prepare(self) -> dict[str, Any] | None:
+        return self._last_forward_batch_prepare
+
+    @staticmethod
+    def _lens_to_list(value: Any) -> list[int]:
+        if value is None:
+            return []
+        if isinstance(value, torch.Tensor):
+            return [int(v) for v in value.detach().cpu().tolist()]
+        return [int(v) for v in value]
+
+    @staticmethod
+    def _slice_mm_tensor(
+        value: Any,
+        *,
+        prefix_len: int,
+        extend_len: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> torch.Tensor | None:
+        if value is None:
+            return None
+        tensor = torch.as_tensor(value)
+        if tensor.ndim == 2 and tensor.shape[0] == 3:
+            tensor = tensor[:, prefix_len : prefix_len + extend_len]
+        else:
+            tensor = tensor.reshape(-1)[prefix_len : prefix_len + extend_len]
+        return tensor.to(device=device, dtype=dtype, non_blocking=True)
+
+    def prepare_forward_batch(self, forward_batch: ForwardBatch) -> None:
+        """Attach U1 per-token metadata before SGLang attention planning."""
+
+        if not forward_batch.forward_mode.is_extend():
+            self._last_forward_batch_prepare = {
+                "forward_mode": str(forward_batch.forward_mode),
+                "metadata_attached": False,
+                "reason": "non_extend",
+            }
+            return
+
+        indexes = getattr(forward_batch, "mrope_positions", None)
+        if indexes is None:
+            indexes = SenseNovaU1NativeTextModel._prepare_indexes(
+                forward_batch.positions,
+                None,
+            )
+        indexes = indexes.to(device=forward_batch.input_ids.device, dtype=torch.long)
+
+        extend_lens = self._lens_to_list(forward_batch.extend_seq_lens_cpu)
+        prefix_lens = self._lens_to_list(forward_batch.extend_prefix_lens_cpu)
+        if not extend_lens and forward_batch.extend_seq_lens is not None:
+            extend_lens = self._lens_to_list(forward_batch.extend_seq_lens)
+        if not prefix_lens:
+            prefix_lens = [0] * len(extend_lens)
+
+        mm_inputs = getattr(forward_batch, "mm_inputs", None) or []
+        image_tags: list[torch.Tensor] = []
+        image_gen_flags: list[torch.Tensor] = []
+        for idx, extend_len in enumerate(extend_lens):
+            prefix_len = prefix_lens[idx] if idx < len(prefix_lens) else 0
+            mm_input = mm_inputs[idx] if idx < len(mm_inputs) else None
+            tag = None
+            gen = None
+            if mm_input is not None:
+                tag = self._slice_mm_tensor(
+                    getattr(mm_input, "u1_image_token_tag", None),
+                    prefix_len=prefix_len,
+                    extend_len=extend_len,
+                    device=indexes.device,
+                    dtype=torch.bool,
+                )
+                gen = self._slice_mm_tensor(
+                    getattr(mm_input, "u1_image_gen_indicators", None),
+                    prefix_len=prefix_len,
+                    extend_len=extend_len,
+                    device=indexes.device,
+                    dtype=torch.bool,
+                )
+            if tag is None:
+                start = sum(extend_lens[:idx])
+                stop = start + extend_len
+                tag = build_image_token_tag_from_t_indexes(indexes[:, start:stop])
+            if gen is None:
+                gen = torch.zeros(extend_len, device=indexes.device, dtype=torch.bool)
+            image_tags.append(tag.reshape(-1))
+            image_gen_flags.append(gen.reshape(-1))
+
+        if image_tags:
+            image_token_tag = torch.cat(image_tags).to(device=indexes.device)
+        else:
+            image_token_tag = torch.zeros(
+                indexes.shape[1], device=indexes.device, dtype=torch.bool
+            )
+        if image_gen_flags:
+            image_gen_indicators = torch.cat(image_gen_flags).to(device=indexes.device)
+        else:
+            image_gen_indicators = torch.zeros_like(image_token_tag)
+
+        custom_mask, mask_indptr = build_u1_hybrid_backend_mask(
+            indexes,
+            image_token_tag,
+            extend_lens,
+            prefix_lens,
+        )
+        forward_batch.cross_attention_custom_mask = custom_mask
+        states = dict(forward_batch.model_specific_states or {})
+        states["sensenova_u1"] = {
+            "indexes": indexes,
+            "image_token_tag": image_token_tag,
+            "image_gen_indicators": image_gen_indicators,
+            "custom_mask_indptr": mask_indptr,
+        }
+        forward_batch.model_specific_states = states
+
+        self._last_forward_batch_prepare = {
+            "forward_mode": str(forward_batch.forward_mode),
+            "metadata_attached": True,
+            "num_tokens": int(indexes.shape[1]),
+            "extend_seq_lens": extend_lens,
+            "extend_prefix_lens": prefix_lens,
+            "image_token_count": int(image_token_tag.sum().item()),
+            "image_gen_count": int(image_gen_indicators.sum().item()),
+            "custom_mask_numel": 0 if custom_mask is None else int(custom_mask.numel()),
+            "custom_mask_dtype": None if custom_mask is None else str(custom_mask.dtype),
+            "custom_mask_device": None if custom_mask is None else str(custom_mask.device),
+            "mask_indptr": [int(x) for x in mask_indptr.detach().cpu().tolist()],
+            "image_spans": [
+                span.as_dict()
+                for span in build_image_spans(indexes[0], image_token_tag)
+            ],
+        }
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch | None,
+        *,
+        input_embeds: torch.Tensor | None = None,
+        image_gen_indicators: torch.Tensor | None = None,
+        indexes: torch.Tensor | None = None,
+        omni_prefill_rids: Any | None = None,
+    ) -> LogitsProcessorOutput:
+        del omni_prefill_rids
+        states = (
+            None
+            if forward_batch is None
+            else (forward_batch.model_specific_states or {}).get("sensenova_u1")
+        )
+        if states is not None:
+            if indexes is None:
+                indexes = states.get("indexes")
+            if image_gen_indicators is None:
+                image_gen_indicators = states.get("image_gen_indicators")
+        if indexes is None and forward_batch is not None:
+            mrope_positions = getattr(forward_batch, "mrope_positions", None)
+            if mrope_positions is not None:
+                indexes = mrope_positions
+        hidden_states = self.model(
+            input_ids=input_ids,
+            positions=positions,
+            forward_batch=forward_batch,
+            input_embeds=input_embeds,
+            image_gen_indicators=image_gen_indicators,
+            indexes=indexes,
+        )
+        if forward_batch is not None:
+            if self.logits_processor is None:
+                raise RuntimeError(
+                    "SenseNova U1 standalone native model cannot process a "
+                    "ForwardBatch; instantiate under SGLang runtime instead."
+                )
+            return self.logits_processor(
+                input_ids,
+                hidden_states,
+                self.lm_head,
+                forward_batch,
+            )
+
+        last_hidden = hidden_states[-1:]
+        logits = torch.matmul(
+            last_hidden.to(self.lm_head.weight.dtype),
+            self.lm_head.weight.T,
+        )
+        logits = logits[..., : self.config.vocab_size].to(last_hidden.dtype)
+        return LogitsProcessorOutput(
+            next_token_logits=logits,
+            hidden_states=hidden_states,
+        )
+
+    def eager_text_logits(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        last_hidden = hidden_states[-1:].to(self.lm_head.weight.dtype)
+        if os.environ.get(
+            "SENSENOVA_U1_NATIVE_EAGER_LM_HEAD_LINEAR",
+            "",
+        ).lower() in {"1", "true", "yes", "on"}:
+            logits = torch.nn.functional.linear(
+                last_hidden,
+                self.lm_head.weight,
+            )
+        else:
+            logits = torch.matmul(
+                last_hidden,
+                self.lm_head.weight.T,
+            )
+        return logits[..., : self.config.vocab_size].to(hidden_states.dtype)
+
+    def load_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> SenseNovaU1LoadReport:
+        params = dict(self.named_parameters())
+        loaded: set[str] = set()
+        unexpected: list[str] = []
+        ignored: dict[str, int] = {}
+        errors: list[str] = []
+
+        for raw_name, loaded_weight in weights:
+            if raw_name.startswith("language_model."):
+                name = raw_name[len("language_model.") :]
+            elif raw_name in self._expected_language_keys:
+                name = raw_name
+            else:
+                top = raw_name.split(".", 1)[0]
+                ignored[top] = ignored.get(top, 0) + 1
+                continue
+            if name not in self._expected_language_keys:
+                unexpected.append(name)
+                continue
+            target = _direct_or_stacked_target(name)
+            if target is None:
+                unexpected.append(name)
+                continue
+            target_name, shard_id = target
+            if target_name not in params:
+                errors.append(f"{name} -> {target_name}: target parameter not found")
+                continue
+            try:
+                _load_parameter(params, target_name, loaded_weight, shard_id)
+            except Exception as exc:  # pragma: no cover - recorded in evidence
+                errors.append(f"{name} -> {target_name}: {type(exc).__name__}: {exc}")
+                continue
+            loaded.add(name)
+
+        report = SenseNovaU1LoadReport(
+            loaded_language_keys=sorted(loaded),
+            missing_language_keys=sorted(self._expected_language_keys - loaded),
+            unexpected_language_keys=sorted(unexpected),
+            ignored_non_language_keys=ignored,
+            errors=errors,
+        )
+        self._last_load_report = report
+        return report
+
+
+class SenseNovaU1NativeLoadExecutor:
+    """Minimal native executor used for import-guard and load smoke checks."""
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        device: str = "cpu",
+        dtype: str | torch.dtype = "bfloat16",
+        load_weights: bool = False,
+        standalone: bool = True,
+    ) -> None:
+        assert_no_hf_modeling_imported(context="before native U1 executor init")
+        self.model_path = model_path
+        self.config = load_u1_llm_config(model_path)
+        self.model = SenseNovaU1NativeForCausalLM(
+            self.config,
+            params_dtype=dtype,
+            standalone=standalone,
+        )
+        if load_weights:
+            report = self.model.load_weights(iter_language_safetensors(model_path))
+            if not report.ok:
+                raise RuntimeError(f"native U1 load failed: {report.to_dict()}")
+        self.model.to(device=device, dtype=resolve_dtype(dtype))
+        self.model.eval()
+        assert_no_hf_modeling_imported(context="after native U1 executor init")
+
+    def complete_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+        del payload
+        raise NotImplementedError(
+            "SenseNova U1 native serving scheduler is not complete yet; this "
+            "executor exists only for M6 native model-load/import-guard smoke."
+        )
+
+
+__all__ = [
+    "HF_MODELING_MODULE_PREFIXES",
+    "SenseNovaU1LoadReport",
+    "SenseNovaU1NativeForCausalLM",
+    "SenseNovaU1NativeLoadExecutor",
+    "assert_no_hf_modeling_imported",
+    "block_hf_modeling_imports",
+    "expected_language_weight_keys",
+    "iter_language_safetensors",
+    "load_u1_llm_config",
+    "scan_checkpoint_key_summary",
+]

--- a/sglang_omni/models/sensenova_u1/stages.py
+++ b/sglang_omni/models/sensenova_u1/stages.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stage factories for SenseNova U1 fallback paths."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def create_sensenova_u1_vqa_executor(
+    model_path: str,
+    *,
+    device: str = "cuda:0",
+    dtype: str = "bfloat16",
+    vendor_root: str | None = None,
+    max_new_tokens: int = 128,
+    do_sample: bool = False,
+    temperature: float = 0.7,
+    top_p: float = 0.9,
+    top_k: int | None = None,
+    repetition_penalty: float | None = None,
+    attn_backend: str = "auto",
+    min_pixels: int | None = None,
+    max_pixels: int | None = None,
+    max_concurrency: int = 1,
+    load_with_info: bool = False,
+) -> Any:
+    from sglang_omni.models.sensenova_u1.hf_runner import (
+        SenseNovaU1UnderstandingRunner,
+    )
+    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+
+    runner = SenseNovaU1UnderstandingRunner(
+        model_path=model_path,
+        vendor_root=vendor_root,
+        device=device,
+        dtype=dtype,
+        attn_backend=attn_backend,
+        min_pixels=min_pixels,
+        max_pixels=max_pixels,
+        load_with_info=load_with_info,
+    )
+
+    def _complete(payload):
+        return runner.complete_payload(
+            payload,
+            max_new_tokens=max_new_tokens,
+            do_sample=do_sample,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            repetition_penalty=repetition_penalty,
+        )
+
+    return SimpleScheduler(_complete, max_concurrency=max_concurrency)
+
+
+def create_sensenova_u1_flow_executor(
+    model_path: str,
+    *,
+    device: str = "cuda:0",
+    dtype: str = "bfloat16",
+    vendor_root: str | None = None,
+    attn_backend: str = "auto",
+    max_concurrency: int = 1,
+) -> Any:
+    from sglang_omni.models.sensenova_u1.flow_matching import (
+        SenseNovaU1FlowMatchingRunner,
+    )
+    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+
+    runner = SenseNovaU1FlowMatchingRunner(
+        model_path=model_path,
+        vendor_root=vendor_root,
+        device=device,
+        dtype=dtype,
+        attn_backend=attn_backend,
+    )
+    return SimpleScheduler(
+        runner.complete_payload,
+        max_concurrency=max_concurrency,
+    )
+
+
+def create_sensenova_u1_interleave_executor(
+    model_path: str,
+    *,
+    device: str = "cuda:0",
+    dtype: str = "bfloat16",
+    vendor_root: str | None = None,
+    attn_backend: str = "auto",
+    max_concurrency: int = 1,
+) -> Any:
+    from sglang_omni.models.sensenova_u1.interleave import (
+        SenseNovaU1InterleaveRunner,
+    )
+    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+
+    runner = SenseNovaU1InterleaveRunner(
+        model_path=model_path,
+        vendor_root=vendor_root,
+        device=device,
+        dtype=dtype,
+        attn_backend=attn_backend,
+    )
+    return SimpleScheduler(
+        runner.complete_payload,
+        max_concurrency=max_concurrency,
+    )
+
+
+__all__ = [
+    "create_sensenova_u1_flow_executor",
+    "create_sensenova_u1_interleave_executor",
+    "create_sensenova_u1_vqa_executor",
+]

--- a/sglang_omni/models/sensenova_u1/stages.py
+++ b/sglang_omni/models/sensenova_u1/stages.py
@@ -14,6 +14,12 @@ def create_sensenova_u1_flow_executor(
     vendor_root: str | None = None,
     attn_backend: str = "auto",
     max_concurrency: int = 1,
+    max_total_tokens: int = 4096,
+    eager_prefix_cache_max_entries: int = 4,
+    eager_decode_graph_cache_max_entries: int = 2,
+    eager_decode_graph_max_captures: int = 4,
+    eager_prefix_cache_max_tokens: int = 2048,
+    eager_decode_graph_max_total_tokens: int = 1024,
 ) -> Any:
     from sglang_omni.models.sensenova_u1.flow_matching import (
         SenseNovaU1FlowMatchingRunner,
@@ -32,11 +38,22 @@ def create_sensenova_u1_flow_executor(
             device=device,
             dtype=dtype,
             attn_backend=attn_backend,
+            max_total_tokens=max_total_tokens,
+            eager_prefix_cache_max_entries=eager_prefix_cache_max_entries,
+            eager_decode_graph_cache_max_entries=(
+                eager_decode_graph_cache_max_entries
+            ),
+            eager_decode_graph_max_captures=eager_decode_graph_max_captures,
+            eager_prefix_cache_max_tokens=eager_prefix_cache_max_tokens,
+            eager_decode_graph_max_total_tokens=(
+                eager_decode_graph_max_total_tokens
+            ),
         )
     assert_no_hf_modeling_imported(context="after native U1 flow stage factory")
     return SimpleScheduler(
         runner.complete_payload,
         max_concurrency=max_concurrency,
+        shutdown_callback=runner.shutdown,
     )
 
 
@@ -48,6 +65,12 @@ def create_sensenova_u1_interleave_executor(
     vendor_root: str | None = None,
     attn_backend: str = "auto",
     max_concurrency: int = 1,
+    max_total_tokens: int = 4096,
+    eager_prefix_cache_max_entries: int = 4,
+    eager_decode_graph_cache_max_entries: int = 2,
+    eager_decode_graph_max_captures: int = 4,
+    eager_prefix_cache_max_tokens: int = 2048,
+    eager_decode_graph_max_total_tokens: int = 1024,
 ) -> Any:
     from sglang_omni.models.sensenova_u1.interleave import (
         SenseNovaU1InterleaveRunner,
@@ -68,6 +91,16 @@ def create_sensenova_u1_interleave_executor(
             device=device,
             dtype=dtype,
             attn_backend=attn_backend,
+            max_total_tokens=max_total_tokens,
+            eager_prefix_cache_max_entries=eager_prefix_cache_max_entries,
+            eager_decode_graph_cache_max_entries=(
+                eager_decode_graph_cache_max_entries
+            ),
+            eager_decode_graph_max_captures=eager_decode_graph_max_captures,
+            eager_prefix_cache_max_tokens=eager_prefix_cache_max_tokens,
+            eager_decode_graph_max_total_tokens=(
+                eager_decode_graph_max_total_tokens
+            ),
         )
     assert_no_hf_modeling_imported(
         context="after native U1 interleave stage factory"
@@ -75,6 +108,7 @@ def create_sensenova_u1_interleave_executor(
     return SimpleScheduler(
         runner.complete_payload,
         max_concurrency=max_concurrency,
+        shutdown_callback=runner.shutdown,
     )
 
 
@@ -116,6 +150,11 @@ def create_sensenova_u1_native_serving_executor(
     max_batch_wait_ms: int = 10,
     enable_cuda_graph: bool = True,
     cuda_graph_bs: list[int] | None = None,
+    eager_prefix_cache_max_entries: int = 4,
+    eager_decode_graph_cache_max_entries: int = 2,
+    eager_decode_graph_max_captures: int = 4,
+    eager_prefix_cache_max_tokens: int = 2048,
+    eager_decode_graph_max_total_tokens: int = 1024,
 ) -> Any:
     from sglang_omni.models.sensenova_u1.native_serving import (
         SenseNovaU1NativeServingExecutor,
@@ -139,6 +178,15 @@ def create_sensenova_u1_native_serving_executor(
             enable_radix_cache=True,
             disable_cuda_graph=not enable_cuda_graph,
             cuda_graph_bs=cuda_graph_bs or [1, 8, 16],
+            eager_prefix_cache_max_entries=eager_prefix_cache_max_entries,
+            eager_decode_graph_cache_max_entries=(
+                eager_decode_graph_cache_max_entries
+            ),
+            eager_decode_graph_max_captures=eager_decode_graph_max_captures,
+            eager_prefix_cache_max_tokens=eager_prefix_cache_max_tokens,
+            eager_decode_graph_max_total_tokens=(
+                eager_decode_graph_max_total_tokens
+            ),
         )
     assert_no_hf_modeling_imported(context="after native U1 serving stage factory")
     return SimpleScheduler(
@@ -147,7 +195,7 @@ def create_sensenova_u1_native_serving_executor(
         max_batch_size=max_concurrency,
         max_batch_wait_ms=max_batch_wait_ms,
         max_concurrency=1,
-        shutdown_callback=lambda: None,
+        shutdown_callback=executor.shutdown,
     )
 
 

--- a/sglang_omni/models/sensenova_u1/stages.py
+++ b/sglang_omni/models/sensenova_u1/stages.py
@@ -1,57 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Stage factories for SenseNova U1 fallback paths."""
+"""Stage factories for native SenseNova U1 serving paths."""
 
 from __future__ import annotations
 
 from typing import Any
-
-
-def create_sensenova_u1_vqa_executor(
-    model_path: str,
-    *,
-    device: str = "cuda:0",
-    dtype: str = "bfloat16",
-    vendor_root: str | None = None,
-    max_new_tokens: int = 128,
-    do_sample: bool = False,
-    temperature: float = 0.7,
-    top_p: float = 0.9,
-    top_k: int | None = None,
-    repetition_penalty: float | None = None,
-    attn_backend: str = "auto",
-    min_pixels: int | None = None,
-    max_pixels: int | None = None,
-    max_concurrency: int = 1,
-    load_with_info: bool = False,
-) -> Any:
-    from sglang_omni.models.sensenova_u1.hf_runner import (
-        SenseNovaU1UnderstandingRunner,
-    )
-    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
-
-    runner = SenseNovaU1UnderstandingRunner(
-        model_path=model_path,
-        vendor_root=vendor_root,
-        device=device,
-        dtype=dtype,
-        attn_backend=attn_backend,
-        min_pixels=min_pixels,
-        max_pixels=max_pixels,
-        load_with_info=load_with_info,
-    )
-
-    def _complete(payload):
-        return runner.complete_payload(
-            payload,
-            max_new_tokens=max_new_tokens,
-            do_sample=do_sample,
-            temperature=temperature,
-            top_p=top_p,
-            top_k=top_k,
-            repetition_penalty=repetition_penalty,
-        )
-
-    return SimpleScheduler(_complete, max_concurrency=max_concurrency)
 
 
 def create_sensenova_u1_flow_executor(
@@ -66,15 +18,22 @@ def create_sensenova_u1_flow_executor(
     from sglang_omni.models.sensenova_u1.flow_matching import (
         SenseNovaU1FlowMatchingRunner,
     )
+    from sglang_omni.models.sensenova_u1.sglang_model import (
+        assert_no_hf_modeling_imported,
+        block_hf_modeling_imports,
+    )
     from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
-    runner = SenseNovaU1FlowMatchingRunner(
-        model_path=model_path,
-        vendor_root=vendor_root,
-        device=device,
-        dtype=dtype,
-        attn_backend=attn_backend,
-    )
+    assert_no_hf_modeling_imported(context="before native U1 flow stage factory")
+    with block_hf_modeling_imports():
+        runner = SenseNovaU1FlowMatchingRunner(
+            model_path=model_path,
+            vendor_root=vendor_root,
+            device=device,
+            dtype=dtype,
+            attn_backend=attn_backend,
+        )
+    assert_no_hf_modeling_imported(context="after native U1 flow stage factory")
     return SimpleScheduler(
         runner.complete_payload,
         max_concurrency=max_concurrency,
@@ -93,14 +52,25 @@ def create_sensenova_u1_interleave_executor(
     from sglang_omni.models.sensenova_u1.interleave import (
         SenseNovaU1InterleaveRunner,
     )
+    from sglang_omni.models.sensenova_u1.sglang_model import (
+        assert_no_hf_modeling_imported,
+        block_hf_modeling_imports,
+    )
     from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
-    runner = SenseNovaU1InterleaveRunner(
-        model_path=model_path,
-        vendor_root=vendor_root,
-        device=device,
-        dtype=dtype,
-        attn_backend=attn_backend,
+    assert_no_hf_modeling_imported(
+        context="before native U1 interleave stage factory"
+    )
+    with block_hf_modeling_imports():
+        runner = SenseNovaU1InterleaveRunner(
+            model_path=model_path,
+            vendor_root=vendor_root,
+            device=device,
+            dtype=dtype,
+            attn_backend=attn_backend,
+        )
+    assert_no_hf_modeling_imported(
+        context="after native U1 interleave stage factory"
     )
     return SimpleScheduler(
         runner.complete_payload,
@@ -108,8 +78,82 @@ def create_sensenova_u1_interleave_executor(
     )
 
 
+def create_sensenova_u1_native_executor(
+    model_path: str,
+    *,
+    device: str = "cpu",
+    dtype: str = "bfloat16",
+    load_weights: bool = False,
+) -> Any:
+    from sglang_omni.models.sensenova_u1.sglang_model import (
+        SenseNovaU1NativeLoadExecutor,
+        assert_no_hf_modeling_imported,
+        block_hf_modeling_imports,
+    )
+
+    assert_no_hf_modeling_imported(context="before native U1 stage factory")
+    with block_hf_modeling_imports():
+        executor = SenseNovaU1NativeLoadExecutor(
+            model_path=model_path,
+            device=device,
+            dtype=dtype,
+            load_weights=load_weights,
+        )
+    assert_no_hf_modeling_imported(context="after native U1 stage factory")
+    return executor
+
+
+def create_sensenova_u1_native_serving_executor(
+    model_path: str,
+    *,
+    device: str = "cuda:0",
+    dtype: str = "bfloat16",
+    attention_backend: str = "triton",
+    mem_fraction_static: float = 0.65,
+    max_total_tokens: int = 4096,
+    max_running_requests: int = 2,
+    max_concurrency: int = 4,
+    max_batch_wait_ms: int = 10,
+    enable_cuda_graph: bool = True,
+    cuda_graph_bs: list[int] | None = None,
+) -> Any:
+    from sglang_omni.models.sensenova_u1.native_serving import (
+        SenseNovaU1NativeServingExecutor,
+    )
+    from sglang_omni.models.sensenova_u1.sglang_model import (
+        assert_no_hf_modeling_imported,
+        block_hf_modeling_imports,
+    )
+    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+
+    assert_no_hf_modeling_imported(context="before native U1 serving stage factory")
+    with block_hf_modeling_imports():
+        executor = SenseNovaU1NativeServingExecutor(
+            model_path=model_path,
+            device=device,
+            dtype=dtype,
+            attention_backend=attention_backend,
+            mem_fraction_static=mem_fraction_static,
+            max_total_tokens=max_total_tokens,
+            max_running_requests=max(max_running_requests, max_concurrency),
+            enable_radix_cache=True,
+            disable_cuda_graph=not enable_cuda_graph,
+            cuda_graph_bs=cuda_graph_bs or [1, 8, 16],
+        )
+    assert_no_hf_modeling_imported(context="after native U1 serving stage factory")
+    return SimpleScheduler(
+        executor.complete_payload,
+        batch_compute_fn=executor.complete_payload_batch,
+        max_batch_size=max_concurrency,
+        max_batch_wait_ms=max_batch_wait_ms,
+        max_concurrency=1,
+        shutdown_callback=lambda: None,
+    )
+
+
 __all__ = [
     "create_sensenova_u1_flow_executor",
     "create_sensenova_u1_interleave_executor",
-    "create_sensenova_u1_vqa_executor",
+    "create_sensenova_u1_native_executor",
+    "create_sensenova_u1_native_serving_executor",
 ]

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -680,6 +680,31 @@ def _register_chat_completions(app: FastAPI) -> None:
         )
 
 
+def _images_from_omni_rollout(omni_rollout: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(omni_rollout, dict):
+        return []
+    images = omni_rollout.get("images") or []
+    output: list[dict[str, Any]] = []
+    for item in images:
+        if not isinstance(item, dict):
+            continue
+        url = item.get("data") or item.get("url")
+        image_url = item.get("image_url")
+        if isinstance(image_url, dict):
+            url = image_url.get("url", url)
+        if not isinstance(url, str) or not url.startswith("data:image/"):
+            continue
+        out_item: dict[str, Any] = {
+            "type": "image_url",
+            "image_url": {"url": url},
+        }
+        for key in ("width", "height", "index", "format"):
+            if item.get(key) is not None:
+                out_item[key] = item[key]
+        output.append(out_item)
+    return output
+
+
 async def _chat_non_stream(
     client: Client,
     gen_req: GenerateRequest,
@@ -721,6 +746,11 @@ async def _chat_non_stream(
             "data": result.audio.data,
             "transcript": result.audio.transcript,
         }
+
+    if "image" in requested_modalities:
+        images = _images_from_omni_rollout(result.omni_rollout)
+        if images:
+            message["images"] = images
 
     if "content" not in message and "audio" not in message:
         message["content"] = result.text
@@ -793,6 +823,9 @@ async def _chat_stream(
                     chunk.modality == "audio"
                     and chunk.audio_b64 is not None
                     and "audio" in requested_modalities
+                ) or (
+                    "image" in requested_modalities
+                    and bool(_images_from_omni_rollout(chunk.omni_rollout))
                 )
                 if not has_payload:
                     continue
@@ -826,6 +859,12 @@ async def _chat_stream(
                     data=chunk.audio_b64,
                 )
                 emit = True
+
+            if "image" in requested_modalities:
+                images = _images_from_omni_rollout(chunk.omni_rollout)
+                if images:
+                    delta.images = images
+                    emit = True
 
             if not emit:
                 continue
@@ -966,6 +1005,9 @@ def _build_chat_generate_request(req: ChatCompletionRequest) -> GenerateRequest:
         ("talker_top_k", req.talker_top_k),
         ("talker_repetition_penalty", req.talker_repetition_penalty),
         ("talker_max_new_tokens", req.talker_max_new_tokens),
+        ("image_config", req.image_config),
+        ("chat_template_kwargs", req.chat_template_kwargs),
+        ("n", req.n),
     ):
         if value is not None:
             extra_params[field_name] = value

--- a/sglang_omni/serve/protocol.py
+++ b/sglang_omni/serve/protocol.py
@@ -62,6 +62,9 @@ class ChatCompletionRequest(BaseModel):
 
     # Multi-modal output control
     modalities: list[str] | None = None  # e.g. ["text", "audio"]
+    image_config: dict[str, Any] | None = None
+    chat_template_kwargs: dict[str, Any] | None = None
+    n: int | None = None
 
     # Audio output configuration
     audio: dict[str, Any] | None = None  # {"voice": "...", "format": "wav"}
@@ -128,6 +131,7 @@ class ChatCompletionStreamDelta(BaseModel):
     role: str | None = None
     content: str | None = None
     audio: ChatCompletionAudio | None = None
+    images: list[dict[str, Any]] | None = None
 
 
 class ChatCompletionStreamChoice(BaseModel):

--- a/sglang_omni/vendor/sglang/layers.py
+++ b/sglang_omni/vendor/sglang/layers.py
@@ -26,6 +26,7 @@ from sglang.srt.layers.activation import SiluAndMul
 from sglang.srt.layers.communicator import LayerCommunicator, LayerScatterModes
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import (
+    ColumnParallelLinear,
     MergedColumnParallelLinear,
     QKVParallelLinear,
     ReplicatedLinear,
@@ -102,6 +103,7 @@ __all__ = [
     "get_layer_id",
     "RMSNorm",
     "SiluAndMul",
+    "ColumnParallelLinear",
     "MergedColumnParallelLinear",
     "QKVParallelLinear",
     "ReplicatedLinear",

--- a/tests/unit_test/sensenova_u1/test_hybrid_attention.py
+++ b/tests/unit_test/sensenova_u1/test_hybrid_attention.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import torch
+from PIL import Image
+
+from sglang_omni.models.sensenova_u1.flow_matching import compare_pil_images
+from sglang_omni.models.sensenova_u1.hybrid_attention import (
+    build_image_spans,
+    build_image_token_tag_from_t_indexes,
+    build_m_block_summary,
+    build_u1_hybrid_allowed_matrix,
+    create_u1_hybrid_mask,
+    u1_hybrid_attention_forward,
+)
+
+
+def _naive_allowed(t_indexes: torch.Tensor, image_tag: torch.Tensor) -> torch.Tensor:
+    length = t_indexes.numel()
+    allowed = torch.zeros((length, length), dtype=torch.bool)
+    for row in range(length):
+        for col in range(length):
+            causal = col <= row
+            same_image_span = (
+                bool(image_tag[row])
+                and bool(image_tag[col])
+                and int(t_indexes[row]) == int(t_indexes[col])
+            )
+            allowed[row, col] = causal or same_image_span
+    return allowed
+
+
+def test_u1_hybrid_allowed_matrix_matches_naive_dense_policy() -> None:
+    t_indexes = torch.tensor([0, 1, 2, 2, 2, 3, 4, 4, 5])
+    image_tag = torch.tensor([False, False, True, True, True, False, True, True, False])
+
+    allowed = build_u1_hybrid_allowed_matrix(t_indexes, image_token_tag=image_tag)
+
+    assert torch.equal(allowed.cpu(), _naive_allowed(t_indexes, image_tag))
+    assert allowed[2, 4]
+    assert allowed[4, 2]
+    assert not allowed[1, 2]
+    assert not allowed[6, 8]
+
+
+def test_u1_hybrid_mask_and_span_summaries() -> None:
+    indexes = torch.tensor(
+        [
+            [0, 1, 2, 2, 2, 3, 4, 4, 5],
+            [0, 0, 0, 1, 2, 0, 0, 1, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ]
+    )
+    inferred_tag = build_image_token_tag_from_t_indexes(indexes)
+
+    assert inferred_tag.tolist() == [
+        False,
+        False,
+        True,
+        True,
+        True,
+        False,
+        True,
+        True,
+        False,
+    ]
+    assert [span.as_dict() for span in build_image_spans(indexes, inferred_tag)] == [
+        {"start": 2, "end": 5, "length": 3, "t_index": 2},
+        {"start": 6, "end": 8, "length": 2, "t_index": 4},
+    ]
+    assert build_m_block_summary(inferred_tag, block_m=4) == [
+        {"start": 0, "end": 4, "has_image": True, "image_rows": [2, 3]},
+        {"start": 4, "end": 8, "has_image": True, "image_rows": [4, 6, 7]},
+        {"start": 8, "end": 9, "has_image": False, "image_rows": []},
+    ]
+
+    mask = create_u1_hybrid_mask(indexes, image_token_tag=inferred_tag, dtype=torch.float32)
+    assert mask.shape == (1, 1, 9, 9)
+    assert mask[0, 0, 2, 4].item() == 0.0
+    assert mask[0, 0, 1, 2].item() == float("-inf")
+
+
+def test_u1_hybrid_attention_forward_matches_manual_softmax() -> None:
+    query = torch.tensor([[[[0.1, 0.2], [0.3, -0.1], [0.0, 0.5], [0.7, 0.2]]]])
+    key = torch.tensor([[[[0.2, 0.0], [0.1, 0.4], [0.6, -0.2], [0.3, 0.3]]]])
+    value = torch.tensor([[[[1.0, 0.0], [0.0, 1.0], [0.5, 0.5], [2.0, -1.0]]]])
+    t_indexes = torch.tensor([0, 1, 1, 2])
+    image_tag = torch.tensor([False, True, True, False])
+
+    out, weights = u1_hybrid_attention_forward(
+        query,
+        key,
+        value,
+        t_indexes,
+        image_token_tag=image_tag,
+    )
+
+    scores = torch.matmul(query, key.transpose(2, 3)) * (query.shape[-1] ** -0.5)
+    scores = scores + create_u1_hybrid_mask(
+        t_indexes,
+        image_token_tag=image_tag,
+        dtype=scores.dtype,
+    )
+    expected_weights = torch.softmax(scores.float(), dim=-1).to(query.dtype)
+    expected_out = torch.matmul(expected_weights, value).transpose(1, 2).contiguous()
+
+    assert torch.allclose(weights, expected_weights)
+    assert torch.allclose(out, expected_out)
+
+
+def test_compare_pil_images_reports_exact_and_shifted_metrics() -> None:
+    black = Image.fromarray(np.zeros((4, 4, 3), dtype=np.uint8), mode="RGB")
+    almost_black = Image.fromarray(np.ones((4, 4, 3), dtype=np.uint8), mode="RGB")
+
+    exact = compare_pil_images(black, black)
+    shifted = compare_pil_images(black, almost_black)
+
+    assert exact["pixel_max_abs_diff_uint8"] == 0
+    assert math.isinf(exact["psnr_db"])
+    assert exact["ssim_global_rgb"] == 1.0
+    assert shifted["pixel_max_abs_diff_uint8"] == 1
+    assert shifted["psnr_db"] < 50.0
+    assert shifted["ssim_global_rgb"] < 1.0

--- a/tests/unit_test/sensenova_u1/test_native_model.py
+++ b/tests/unit_test/sensenova_u1/test_native_model.py
@@ -998,6 +998,7 @@ def test_sensenova_u1_native_stage_factory_fails_if_hf_modeling_imported(
         create_sensenova_u1_flow_executor,
         create_sensenova_u1_interleave_executor,
         create_sensenova_u1_native_executor,
+        create_sensenova_u1_native_serving_executor,
     )
 
     polluted_name = "sensenova_u1.models.neo_unify.modeling_neo_chat"
@@ -1013,6 +1014,10 @@ def test_sensenova_u1_native_stage_factory_fails_if_hf_modeling_imported(
             device="cpu",
         ),
         lambda: create_sensenova_u1_interleave_executor(
+            str(MODEL_PATH),
+            device="cpu",
+        ),
+        lambda: create_sensenova_u1_native_serving_executor(
             str(MODEL_PATH),
             device="cpu",
         ),

--- a/tests/unit_test/sensenova_u1/test_native_model.py
+++ b/tests/unit_test/sensenova_u1/test_native_model.py
@@ -1,0 +1,1025 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+from sglang_omni.models.sensenova_u1.config import (
+    SenseNovaU1NativeServingPipelineConfig,
+    SenseNovaU1NativePipelineConfig,
+    Variants,
+)
+
+
+MODEL_PATH = Path("/mnt/afs/fanyijiat/models/SenseNova-U1-8B-MoT-Interleaved-bd39")
+
+
+def test_sensenova_u1_native_pipeline_variant_is_registered() -> None:
+    assert PIPELINE_CONFIG_REGISTRY.get_config("NEOChatModel").architecture == "NEOChatModel"
+    assert Variants["native"] is SenseNovaU1NativePipelineConfig
+    native = SenseNovaU1NativePipelineConfig(model_path="model")
+    native_serving = SenseNovaU1NativeServingPipelineConfig(model_path="model")
+    assert native.entry_stage == "u1_native"
+    assert native_serving.entry_stage == "u1_native_serving"
+    assert native.stages[0].factory.endswith(
+        "create_sensenova_u1_native_executor"
+    )
+    assert native_serving.stages[0].factory.endswith(
+        "create_sensenova_u1_native_serving_executor"
+    )
+    assert native_serving.stages[0].factory_args["max_concurrency"] > 1
+    assert native_serving.stages[0].factory_args["max_running_requests"] >= (
+        native_serving.stages[0].factory_args["max_concurrency"]
+    )
+    assert Variants["native_serving"] is SenseNovaU1NativeServingPipelineConfig
+
+
+def test_sensenova_u1_native_expected_language_keys_match_checkpoint() -> None:
+    from sglang_omni.models.sensenova_u1.sglang_model import (
+        expected_language_weight_keys,
+        load_u1_llm_config,
+    )
+
+    config = load_u1_llm_config(MODEL_PATH)
+    expected = expected_language_weight_keys(config)
+    index = json.loads((MODEL_PATH / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+    language_keys = {
+        key[len("language_model.") :]
+        for key in index
+        if key.startswith("language_model.")
+    }
+
+    assert len(language_keys) == 1096
+    assert language_keys == expected
+
+
+def test_sensenova_u1_native_vision_loader_maps_checkpoint_keys() -> None:
+    from sglang_omni.models.sensenova_u1.native_vision import (
+        SenseNovaU1NativeVisionModel,
+    )
+
+    model = SenseNovaU1NativeVisionModel.from_model_path(
+        MODEL_PATH,
+        params_dtype="float32",
+    )
+    report = model.load_weights(MODEL_PATH)
+
+    assert report.ok
+    assert len(report.loaded_keys) == 4
+
+
+def test_sensenova_u1_native_vision_refreshes_rope_cache_after_dtype_cast() -> None:
+    from sglang_omni.models.sensenova_u1.native_vision import (
+        SenseNovaU1NativeVisionModel,
+    )
+
+    model = SenseNovaU1NativeVisionModel.from_model_path(
+        MODEL_PATH,
+        params_dtype="bfloat16",
+    )
+    model.to(dtype=torch.bfloat16)
+    assert model.cos_cached_x.dtype == torch.bfloat16
+
+    model._ensure_fp32_rope_cache(torch.device("cpu"))
+
+    assert model.cos_cached_x.dtype == torch.float32
+    assert model.sin_cached_x.dtype == torch.float32
+    assert model.cos_cached_y.dtype == torch.float32
+    assert model.sin_cached_y.dtype == torch.float32
+    assert model.cos_cached_x[0, 0].item() == pytest.approx(1.0)
+
+
+def test_sensenova_u1_interleave_uses_verified_text_decode_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.sensenova_u1.interleave import (
+        SenseNovaU1InterleaveRunner,
+    )
+
+    env_name = "SENSENOVA_U1_NATIVE_INTERLEAVE_EAGER_TEXT_DECODE"
+    monkeypatch.delenv(env_name, raising=False)
+    assert (
+        SenseNovaU1InterleaveRunner._native_interleave_text_decode_mode()
+        == "eager_text_decode"
+    )
+
+    monkeypatch.setenv(env_name, "0")
+    assert (
+        SenseNovaU1InterleaveRunner._native_interleave_text_decode_mode()
+        == "sglang_cached_decode"
+    )
+
+
+def test_sensenova_u1_separate_qkv_defaults_to_single_rank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.sensenova_u1.sglang_model import (
+        SenseNovaU1NativeAttention,
+    )
+
+    env_name = "SENSENOVA_U1_NATIVE_SEPARATE_QKV_PROJ"
+    monkeypatch.delenv(env_name, raising=False)
+    attention = object.__new__(SenseNovaU1NativeAttention)
+    attention.layer_id = 0
+    attention.tp_size = 1
+    assert attention._use_separate_qkv_projection()
+
+    attention.tp_size = 2
+    assert not attention._use_separate_qkv_projection()
+
+    monkeypatch.setenv(env_name, "1")
+    assert attention._use_separate_qkv_projection()
+
+    attention.tp_size = 1
+    monkeypatch.setenv(env_name, "0")
+    assert not attention._use_separate_qkv_projection()
+
+
+def test_sensenova_u1_hf_runner_forces_requested_transformers_backend() -> None:
+    from sglang_omni.models.sensenova_u1.hf_runner import (
+        _force_official_llm_attn_implementation,
+    )
+
+    shared_config = SimpleNamespace(_attn_implementation="eager")
+    language_model = torch.nn.Module()
+    language_model.config = shared_config
+    language_model.model = SimpleNamespace(config=shared_config)
+    model = SimpleNamespace(
+        config=SimpleNamespace(llm_config=shared_config),
+        language_model=language_model,
+    )
+
+    _force_official_llm_attn_implementation(model, "sdpa")
+
+    assert shared_config._attn_implementation == "sdpa"
+
+
+def test_sensenova_u1_flow_prefix_cache_is_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.sensenova_u1.flow_matching import (
+        SenseNovaU1FlowMatchingRunner,
+    )
+
+    env_name = "SENSENOVA_U1_NATIVE_FLOW_PREFIX_CACHE"
+    monkeypatch.delenv(env_name, raising=False)
+    assert SenseNovaU1FlowMatchingRunner._native_flow_prefix_cache_enabled()
+
+    monkeypatch.setenv(env_name, "0")
+    assert not SenseNovaU1FlowMatchingRunner._native_flow_prefix_cache_enabled()
+    monkeypatch.setenv(env_name, "1")
+    assert SenseNovaU1FlowMatchingRunner._native_flow_prefix_cache_enabled()
+
+    graph_env_name = "SENSENOVA_U1_NATIVE_FLOW_PREFILL_CUDA_GRAPH"
+    monkeypatch.delenv(graph_env_name, raising=False)
+    assert SenseNovaU1FlowMatchingRunner._native_flow_prefill_cuda_graph_enabled()
+
+    monkeypatch.setenv(graph_env_name, "false")
+    assert not SenseNovaU1FlowMatchingRunner._native_flow_prefill_cuda_graph_enabled()
+
+    eager_graph_env_name = "SENSENOVA_U1_NATIVE_EAGER_TEXT_FULL_LOOP_CUDA_GRAPH"
+    monkeypatch.delenv(eager_graph_env_name, raising=False)
+    assert (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_full_loop_cuda_graph_enabled()
+    )
+    monkeypatch.setenv(eager_graph_env_name, "off")
+    assert not (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_full_loop_cuda_graph_enabled()
+    )
+
+    eager_prefix_env_name = "SENSENOVA_U1_NATIVE_EAGER_TEXT_PREFIX_CACHE"
+    monkeypatch.delenv(eager_prefix_env_name, raising=False)
+    assert (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_prefix_cache_enabled()
+    )
+    monkeypatch.setenv(eager_prefix_env_name, "0")
+    assert not (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_prefix_cache_enabled()
+    )
+
+    graph_mode_env_name = "SENSENOVA_U1_NATIVE_EAGER_TEXT_GRAPH_MODE"
+    monkeypatch.delenv(graph_mode_env_name, raising=False)
+    assert (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_graph_mode()
+        == "segmented"
+    )
+    monkeypatch.setenv(graph_mode_env_name, "monolithic")
+    assert (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_graph_mode()
+        == "monolithic"
+    )
+
+    repeated_kv_env_name = "SENSENOVA_U1_NATIVE_EAGER_REPEATED_KV_CACHE"
+    monkeypatch.delenv(repeated_kv_env_name, raising=False)
+    assert not (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_repeated_kv_cache_enabled()
+    )
+    monkeypatch.setenv(repeated_kv_env_name, "1")
+    assert (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_repeated_kv_cache_enabled()
+    )
+
+    static_kv_env_name = "SENSENOVA_U1_NATIVE_EAGER_STATIC_KV_CACHE"
+    monkeypatch.delenv(static_kv_env_name, raising=False)
+    assert not (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_static_kv_cache_enabled()
+    )
+    monkeypatch.setenv(static_kv_env_name, "yes")
+    assert (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_static_kv_cache_enabled()
+    )
+
+    bf16_argmax_env_name = "SENSENOVA_U1_NATIVE_EAGER_BF16_ARGMAX"
+    monkeypatch.delenv(bf16_argmax_env_name, raising=False)
+    assert not (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_bf16_argmax_enabled()
+    )
+    monkeypatch.setenv(bf16_argmax_env_name, "on")
+    assert (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_bf16_argmax_enabled()
+    )
+
+    lm_head_env_name = "SENSENOVA_U1_NATIVE_EAGER_LM_HEAD_LINEAR"
+    monkeypatch.delenv(lm_head_env_name, raising=False)
+    assert not (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_lm_head_linear_enabled()
+    )
+    monkeypatch.setenv(lm_head_env_name, "true")
+    assert (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_lm_head_linear_enabled()
+    )
+
+    fast_result_env_name = "SENSENOVA_U1_NATIVE_EAGER_FAST_RESULT"
+    monkeypatch.delenv(fast_result_env_name, raising=False)
+    assert not (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_fast_result_enabled()
+    )
+    monkeypatch.setenv(fast_result_env_name, "true")
+    assert (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_fast_result_enabled()
+    )
+
+    direct_embedding_env_name = "SENSENOVA_U1_NATIVE_EAGER_DIRECT_EMBEDDING"
+    monkeypatch.delenv(direct_embedding_env_name, raising=False)
+    assert not (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_direct_embedding_enabled()
+    )
+    monkeypatch.setenv(direct_embedding_env_name, "1")
+    assert (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_direct_embedding_enabled()
+    )
+
+    compiled_add_rms_env_name = "SENSENOVA_U1_NATIVE_EAGER_COMPILED_ADD_RMS"
+    monkeypatch.delenv(compiled_add_rms_env_name, raising=False)
+    assert not (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_compiled_add_rms_enabled()
+    )
+    monkeypatch.setenv(compiled_add_rms_env_name, "true")
+    assert (
+        __import__(
+            "sglang_omni.models.sensenova_u1.native_serving",
+            fromlist=["SenseNovaU1NativeServingExecutor"],
+        )
+        .SenseNovaU1NativeServingExecutor
+        ._native_eager_compiled_add_rms_enabled()
+    )
+
+
+def test_sensenova_u1_flow_skips_cached_prefix_refresh() -> None:
+    from sglang_omni.models.sensenova_u1.flow_matching import (
+        NativeFlowPrefix,
+        SenseNovaU1FlowMatchingRunner,
+    )
+
+    class FakeExecutor:
+        @staticmethod
+        def cached_prefix_length(
+            *,
+            input_ids: torch.Tensor,
+            cache_extra_key: str | None,
+        ) -> int:
+            assert cache_extra_key == "image-key"
+            return int(input_ids.numel())
+
+        @staticmethod
+        def run_prefill(**_: object) -> None:
+            raise AssertionError("cached prefix must not run another forward")
+
+    runner = object.__new__(SenseNovaU1FlowMatchingRunner)
+    runner.executor = FakeExecutor()
+    prefix = NativeFlowPrefix(
+        input_ids=torch.tensor([1, 2, 3], dtype=torch.long),
+        indexes=torch.zeros((3, 3), dtype=torch.long),
+        image_token_tag=torch.tensor([False, True, False]),
+        input_embeds=torch.zeros((3, 4)),
+        cache_extra_key="image-key",
+        cache_insert_log={},
+        cache_reuse_enabled=True,
+    )
+
+    runner._prime_prefix_cache(prefix)
+
+    assert prefix.cache_insert_log == {
+        "skipped": True,
+        "reason": "static_prefix_already_cached",
+        "prefix_tokens": 3,
+        "image_token_count": 1,
+        "cache_extra_key": "image-key",
+        "cache_hit_tokens": 3,
+    }
+
+
+def test_sensenova_u1_cached_decode_sampler_suppresses_tokens() -> None:
+    from sglang_omni.models.sensenova_u1.native_serving import (
+        SenseNovaU1NativeServingExecutor,
+    )
+
+    batch_result = SimpleNamespace(
+        next_token_ids=torch.tensor([2]),
+        logits_output=SimpleNamespace(
+            next_token_logits=torch.tensor([[0.0, 3.0, 5.0, 4.0]])
+        ),
+    )
+
+    assert SenseNovaU1NativeServingExecutor._sample_next_token_ids(
+        batch_result
+    ) == [2]
+    assert SenseNovaU1NativeServingExecutor._sample_next_token_ids(
+        batch_result,
+        suppress_token_ids=[2],
+    ) == [3]
+
+
+def test_sensenova_u1_rms_norm_matches_u1_hf_cast_order() -> None:
+    from sglang_omni.models.sensenova_u1.sglang_model import _rms_norm
+    from sglang_omni.vendor.sglang.layers import RMSNorm
+
+    norm = RMSNorm(4, eps=1e-6)
+    norm.weight.data = torch.tensor([1.0, 1.5, 0.75, -2.0], dtype=torch.bfloat16)
+    x = torch.tensor(
+        [[0.125, -1.5, 3.0, -8.0], [2.25, -0.5, 0.75, 1.0]],
+        dtype=torch.bfloat16,
+    )
+
+    xf = x.float()
+    expected = norm.weight * (
+        xf * torch.rsqrt(xf.pow(2).mean(dim=-1, keepdim=True) + norm.variance_epsilon)
+    ).to(x.dtype)
+
+    assert torch.equal(_rms_norm(norm, x), expected)
+
+
+def test_sensenova_u1_native_tiny_forward_smoke(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.sensenova_u1.sglang_model import (
+        SenseNovaU1NativeForCausalLM,
+        assert_no_hf_modeling_imported,
+        block_hf_modeling_imports,
+    )
+
+    config = SimpleNamespace(
+        hidden_size=16,
+        intermediate_size=32,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        num_hidden_layers=1,
+        vocab_size=32,
+        rms_norm_eps=1e-6,
+        attention_bias=False,
+        max_position_embeddings=128,
+        max_position_embeddings_hw=128,
+        rope_theta=5000000.0,
+        rope_theta_hw=10000.0,
+        torch_dtype="float32",
+        tie_word_embeddings=False,
+    )
+    with block_hf_modeling_imports():
+        model = SenseNovaU1NativeForCausalLM(
+            config,
+            params_dtype="float32",
+            standalone=True,
+        )
+        assert model.is_mrope_enabled
+        monkeypatch.setenv(
+            "SENSENOVA_U1_NATIVE_EAGER_COMPILED_ADD_RMS",
+            "1",
+        )
+        monkeypatch.setenv(
+            "SENSENOVA_U1_NATIVE_EAGER_COMPILED_ADD_RMS_LAYERS",
+            "30-41",
+        )
+        assert not model.model.layers[0]._use_compiled_eager_add_rms()
+        monkeypatch.setenv(
+            "SENSENOVA_U1_NATIVE_EAGER_COMPILED_ADD_RMS_LAYERS",
+            "0",
+        )
+        assert model.model.layers[0]._use_compiled_eager_add_rms()
+        monkeypatch.delenv(
+            "SENSENOVA_U1_NATIVE_EAGER_COMPILED_ADD_RMS",
+            raising=False,
+        )
+        monkeypatch.delenv(
+            "SENSENOVA_U1_NATIVE_EAGER_COMPILED_ADD_RMS_LAYERS",
+            raising=False,
+        )
+        torch.manual_seed(0)
+        for param in model.parameters():
+            param.data.normal_(mean=0.0, std=0.02)
+        model.eval()
+        input_ids = torch.tensor([1, 2, 3], dtype=torch.long)
+        positions = torch.arange(input_ids.numel(), dtype=torch.long)
+        with torch.inference_mode():
+            output = model(input_ids, positions, None)
+            generated_output = model(
+                input_ids,
+                positions,
+                None,
+                image_gen_indicators=torch.ones(
+                    input_ids.numel(),
+                    dtype=torch.bool,
+                ),
+            )
+            indexes = torch.stack(
+                [
+                    positions,
+                    torch.zeros_like(positions),
+                    torch.zeros_like(positions),
+                ]
+            )
+            base_hidden, base_caches = model.model.eager_text_prefill_with_cache(
+                input_ids,
+                positions,
+                indexes=indexes,
+            )
+            repeated_hidden, repeated_caches = (
+                model.model.eager_text_prefill_with_cache(
+                    input_ids,
+                    positions,
+                    indexes=indexes,
+                    repeat_kv_cache=True,
+                )
+            )
+            next_id = torch.tensor([4], dtype=torch.long)
+            next_indexes = torch.tensor([[3], [0], [0]], dtype=torch.long)
+            base_decode, base_next_caches = (
+                model.model.eager_text_decode_with_cache(
+                    next_id,
+                    next_indexes[0],
+                    base_caches,
+                    indexes=next_indexes,
+                )
+            )
+            repeated_decode, repeated_next_caches = (
+                model.model.eager_text_decode_with_cache(
+                    next_id,
+                    next_indexes[0],
+                    repeated_caches,
+                    indexes=next_indexes,
+                    repeat_kv_cache=True,
+                )
+            )
+            static_caches = [
+                (
+                    torch.empty(
+                        (4, *cache_k.shape[1:]),
+                        dtype=cache_k.dtype,
+                    ),
+                    torch.empty(
+                        (4, *cache_v.shape[1:]),
+                        dtype=cache_v.dtype,
+                    ),
+                )
+                for cache_k, cache_v in repeated_caches
+            ]
+            for (static_k, static_v), (cache_k, cache_v) in zip(
+                static_caches,
+                repeated_caches,
+            ):
+                static_k[:3].copy_(cache_k)
+                static_v[:3].copy_(cache_v)
+            static_decode, static_next_caches = (
+                model.model.eager_text_decode_with_static_cache(
+                    next_id,
+                    next_indexes[0],
+                    static_caches,
+                    cache_position=3,
+                    indexes=next_indexes,
+                    repeat_kv_cache=True,
+                )
+            )
+            eager_matmul_logits = model.eager_text_logits(base_hidden)
+            monkeypatch.setenv(
+                "SENSENOVA_U1_NATIVE_EAGER_LM_HEAD_LINEAR",
+                "1",
+            )
+            eager_linear_logits = model.eager_text_logits(base_hidden)
+            eager_embedding = model.model._eager_embed(input_ids)
+            direct_embedding = torch.nn.functional.embedding(
+                input_ids,
+                model.model.embed_tokens.weight[: config.vocab_size],
+            )
+    assert_no_hf_modeling_imported(context="tiny native forward")
+    assert output.next_token_logits is not None
+    assert tuple(output.next_token_logits.shape) == (1, 32)
+    assert torch.isfinite(output.next_token_logits).all()
+    assert generated_output.next_token_logits is not None
+    assert torch.isfinite(generated_output.next_token_logits).all()
+    assert torch.equal(base_hidden, repeated_hidden)
+    assert torch.equal(base_decode, repeated_decode)
+    assert torch.equal(repeated_decode, static_decode)
+    assert torch.equal(eager_matmul_logits, eager_linear_logits)
+    assert torch.equal(eager_embedding, direct_embedding)
+    bf16_scores = torch.tensor(
+        [[1.0, 2.0, 1.5, 2.0]],
+        dtype=torch.bfloat16,
+    )
+    assert torch.equal(
+        torch.argmax(bf16_scores, dim=-1),
+        torch.argmax(bf16_scores.float(), dim=-1),
+    )
+    attention = model.model.layers[0].self_attn
+    assert torch.equal(
+        repeated_caches[0][0],
+        attention.repeat_eager_kv_cache(base_caches[0][0]),
+    )
+    assert torch.equal(
+        repeated_caches[0][1],
+        attention.repeat_eager_kv_cache(base_caches[0][1]),
+    )
+    assert torch.equal(
+        repeated_next_caches[0][0],
+        attention.repeat_eager_kv_cache(base_next_caches[0][0]),
+    )
+    assert torch.equal(
+        repeated_next_caches[0][1],
+        attention.repeat_eager_kv_cache(base_next_caches[0][1]),
+    )
+    assert torch.equal(
+        static_next_caches[0][0][:4],
+        repeated_next_caches[0][0],
+    )
+    assert torch.equal(
+        static_next_caches[0][1][:4],
+        repeated_next_caches[0][1],
+    )
+
+
+def test_sensenova_u1_backend_mask_layout_matches_dense_reference() -> None:
+    from sglang_omni.models.sensenova_u1.hybrid_attention import (
+        build_u1_hybrid_allowed_matrix,
+        build_u1_hybrid_backend_mask,
+    )
+
+    indexes = torch.tensor(
+        [
+            [0, 1, 2, 2, 2, 3, 4],
+            [0, 0, 0, 1, 2, 0, 0],
+            [0, 0, 0, 1, 2, 0, 0],
+        ],
+        dtype=torch.long,
+    )
+    image_token_tag = torch.tensor([0, 0, 1, 1, 1, 0, 0], dtype=torch.bool)
+    mask, indptr = build_u1_hybrid_backend_mask(
+        indexes,
+        image_token_tag,
+        [7],
+        [0],
+    )
+    dense = build_u1_hybrid_allowed_matrix(indexes[0], image_token_tag)
+
+    assert mask is not None
+    assert indptr.tolist() == [0, 49]
+    assert torch.equal(mask.bool().view(7, 7), dense)
+
+
+def test_sensenova_u1_backend_mask_allows_image_span_across_kernel_blocks() -> None:
+    from sglang_omni.models.sensenova_u1.hybrid_attention import (
+        build_u1_hybrid_allowed_matrix,
+        build_u1_hybrid_backend_mask,
+    )
+
+    prefix_len = 12
+    image_len = 144
+    suffix_len = 4
+    total_len = prefix_len + image_len + suffix_len
+    t_indexes = torch.arange(total_len, dtype=torch.long)
+    t_indexes[prefix_len : prefix_len + image_len] = prefix_len
+    indexes = torch.stack(
+        [
+            t_indexes,
+            torch.zeros(total_len, dtype=torch.long),
+            torch.zeros(total_len, dtype=torch.long),
+        ]
+    )
+    image_token_tag = torch.zeros(total_len, dtype=torch.bool)
+    image_token_tag[prefix_len : prefix_len + image_len] = True
+
+    mask, indptr = build_u1_hybrid_backend_mask(
+        indexes,
+        image_token_tag,
+        [total_len],
+        [0],
+    )
+    dense = build_u1_hybrid_allowed_matrix(indexes[0], image_token_tag)
+
+    assert mask is not None
+    assert indptr.tolist() == [0, total_len * total_len]
+    assert torch.equal(mask.bool().view(total_len, total_len), dense)
+    first_image_row = prefix_len
+    last_image_col = prefix_len + image_len - 1
+    assert mask.bool().view(total_len, total_len)[first_image_row, last_image_col]
+
+
+def test_sensenova_u1_backend_mask_allows_cached_prefix_and_full_generated_image() -> None:
+    from sglang_omni.models.sensenova_u1.hybrid_attention import (
+        build_u1_hybrid_backend_mask,
+    )
+
+    prefix_len = 37
+    image_len = 64
+    indexes = torch.stack(
+        [
+            torch.full((image_len,), prefix_len, dtype=torch.long),
+            torch.arange(image_len, dtype=torch.long) // 8,
+            torch.arange(image_len, dtype=torch.long) % 8,
+        ]
+    )
+    image_token_tag = torch.ones(image_len, dtype=torch.bool)
+
+    mask, indptr = build_u1_hybrid_backend_mask(
+        indexes,
+        image_token_tag,
+        [image_len],
+        [prefix_len],
+    )
+
+    assert mask is not None
+    assert indptr.tolist() == [0, image_len * (prefix_len + image_len)]
+    assert torch.all(mask.bool().view(image_len, prefix_len + image_len))
+
+
+def test_sensenova_u1_attention_adapter_owns_custom_mask_policy() -> None:
+    from sglang_omni.models.sensenova_u1.attention_backend import (
+        _build_extend_wrapper,
+        _inject_custom_mask_metadata,
+    )
+
+    captured = {}
+
+    def original(
+        *,
+        custom_mask,
+        is_causal,
+        kv_indices,
+        max_len_extend,
+        skip_prefix=False,
+        skip_extend=False,
+        lse_extend=None,
+        sinks=None,
+        score_mod=None,
+        aux_tensors=None,
+        sliding_window_size=-1,
+        logit_cap=0.0,
+        xai_temperature_len=-1,
+        page_size=1,
+    ):
+        captured["is_causal"] = is_causal
+        return "delegated"
+
+    wrapped = _build_extend_wrapper(original)
+    result = wrapped(
+        custom_mask=torch.ones(1, dtype=torch.uint8),
+        is_causal=True,
+        kv_indices=torch.tensor([1], dtype=torch.long),
+        max_len_extend=1,
+    )
+    assert result == "delegated"
+    assert captured["is_causal"] is False
+
+    backend = SimpleNamespace(
+        forward_metadata=SimpleNamespace(custom_mask=None, mask_indptr=None),
+        mask_indptr=torch.zeros(3, dtype=torch.int64),
+    )
+    forward_batch = SimpleNamespace(
+        batch_size=2,
+        extend_seq_lens=torch.tensor([3, 2], dtype=torch.int64),
+        extend_prefix_lens=torch.tensor([4, 5], dtype=torch.int64),
+        cross_attention_custom_mask=torch.ones(35, dtype=torch.uint8),
+    )
+    _inject_custom_mask_metadata(backend, forward_batch)
+    assert backend.forward_metadata.custom_mask is (
+        forward_batch.cross_attention_custom_mask
+    )
+    assert backend.forward_metadata.mask_indptr.tolist() == [0, 21, 35]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_sensenova_u1_custom_mask_extend_attention_matches_dense_no_prefix() -> None:
+    from sglang.kernels.ops.attention.extend_attention import (
+        extend_attention_fwd as upstream_extend_attention_fwd,
+    )
+
+    from sglang_omni.models.sensenova_u1.attention_backend import (
+        _build_extend_wrapper,
+    )
+    from sglang_omni.models.sensenova_u1.hybrid_attention import (
+        build_u1_hybrid_allowed_matrix,
+        build_u1_hybrid_backend_mask,
+    )
+
+    extend_attention_fwd = _build_extend_wrapper(
+        upstream_extend_attention_fwd
+    )
+
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    prefix_len = 12
+    image_len = 144
+    suffix_len = 4
+    total_len = prefix_len + image_len + suffix_len
+    num_q_heads = 4
+    num_kv_heads = 2
+    head_dim = 16
+    scaling = head_dim**-0.5
+
+    t_indexes = torch.arange(total_len, device=device, dtype=torch.long)
+    t_indexes[prefix_len : prefix_len + image_len] = prefix_len
+    indexes = torch.stack(
+        [
+            t_indexes,
+            torch.zeros(total_len, device=device, dtype=torch.long),
+            torch.zeros(total_len, device=device, dtype=torch.long),
+        ]
+    )
+    image_token_tag = torch.zeros(total_len, device=device, dtype=torch.bool)
+    image_token_tag[prefix_len : prefix_len + image_len] = True
+
+    q = torch.randn(
+        total_len,
+        num_q_heads,
+        head_dim,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    k = torch.randn(
+        total_len,
+        num_kv_heads,
+        head_dim,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    v = torch.randn(
+        total_len,
+        num_kv_heads,
+        head_dim,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    k_rep = k.repeat_interleave(num_q_heads // num_kv_heads, dim=1)
+    v_rep = v.repeat_interleave(num_q_heads // num_kv_heads, dim=1)
+    allowed = build_u1_hybrid_allowed_matrix(indexes[0], image_token_tag)
+    scores = torch.einsum("qhd,khd->hqk", q.float(), k_rep.float()) * scaling
+    scores = scores.masked_fill(
+        ~allowed.unsqueeze(0),
+        torch.finfo(scores.dtype).min,
+    )
+    expected = torch.einsum(
+        "hqk,khd->qhd",
+        torch.softmax(scores, dim=-1).to(v.dtype),
+        v_rep,
+    )
+
+    custom_mask, mask_indptr = build_u1_hybrid_backend_mask(
+        indexes,
+        image_token_tag,
+        [total_len],
+        [0],
+    )
+    assert custom_mask is not None
+    actual = torch.empty_like(q)
+    extend_attention_fwd(
+        q.contiguous(),
+        k.contiguous(),
+        v.contiguous(),
+        actual,
+        torch.empty(1, num_kv_heads, head_dim, device=device, dtype=k.dtype),
+        torch.empty(1, num_kv_heads, head_dim, device=device, dtype=v.dtype),
+        torch.tensor([0, total_len], device=device, dtype=torch.int64),
+        torch.tensor([0, 0], device=device, dtype=torch.int64),
+        torch.empty(0, device=device, dtype=torch.int64),
+        custom_mask,
+        True,
+        mask_indptr,
+        total_len,
+        1.0,
+        1.0,
+        sm_scale=scaling,
+    )
+
+    assert torch.equal(actual, expected)
+
+
+def test_sensenova_u1_prepare_forward_batch_installs_metadata() -> None:
+    from sglang.srt.managers.schedule_batch import MultimodalInputs
+    from sglang.srt.model_executor.forward_batch_info import ForwardMode
+
+    from sglang_omni.models.sensenova_u1.sglang_model import (
+        SenseNovaU1NativeForCausalLM,
+    )
+
+    config = SimpleNamespace(
+        hidden_size=16,
+        intermediate_size=32,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        num_hidden_layers=1,
+        vocab_size=32,
+        rms_norm_eps=1e-6,
+        attention_bias=False,
+        max_position_embeddings=128,
+        max_position_embeddings_hw=128,
+        rope_theta=5000000.0,
+        rope_theta_hw=10000.0,
+        torch_dtype="float32",
+        tie_word_embeddings=False,
+    )
+    model = SenseNovaU1NativeForCausalLM(
+        config,
+        params_dtype="float32",
+        standalone=True,
+    )
+    indexes = torch.tensor(
+        [
+            [0, 1, 2, 2, 2, 3, 4],
+            [0, 0, 0, 1, 2, 0, 0],
+            [0, 0, 0, 1, 2, 0, 0],
+        ],
+        dtype=torch.long,
+    )
+    tag = torch.tensor([0, 0, 1, 1, 1, 0, 0], dtype=torch.bool)
+    mm_inputs = MultimodalInputs(mm_items=[])
+    mm_inputs.mrope_positions = indexes
+    mm_inputs.u1_image_token_tag = tag
+    fb = SimpleNamespace(
+        forward_mode=ForwardMode.EXTEND,
+        positions=torch.arange(7, dtype=torch.long),
+        input_ids=torch.arange(7, dtype=torch.long),
+        mrope_positions=indexes,
+        extend_seq_lens_cpu=[7],
+        extend_prefix_lens_cpu=[0],
+        extend_seq_lens=torch.tensor([7], dtype=torch.int32),
+        extend_prefix_lens=torch.tensor([0], dtype=torch.int32),
+        mm_inputs=[mm_inputs],
+        model_specific_states=None,
+        cross_attention_custom_mask=None,
+    )
+
+    model.prepare_forward_batch(fb)  # type: ignore[arg-type]
+
+    states = fb.model_specific_states["sensenova_u1"]
+    assert torch.equal(states["indexes"], indexes)
+    assert torch.equal(states["image_token_tag"], tag)
+    assert fb.cross_attention_custom_mask is not None
+    assert model.last_forward_batch_prepare["custom_mask_numel"] == 49
+
+
+def test_sensenova_u1_native_stage_factory_fails_if_hf_modeling_imported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.sensenova_u1.stages import (
+        create_sensenova_u1_flow_executor,
+        create_sensenova_u1_interleave_executor,
+        create_sensenova_u1_native_executor,
+    )
+
+    polluted_name = "sensenova_u1.models.neo_unify.modeling_neo_chat"
+    monkeypatch.setitem(sys.modules, polluted_name, types.ModuleType(polluted_name))
+    factories = [
+        lambda: create_sensenova_u1_native_executor(
+            str(MODEL_PATH),
+            device="cpu",
+            load_weights=False,
+        ),
+        lambda: create_sensenova_u1_flow_executor(
+            str(MODEL_PATH),
+            device="cpu",
+        ),
+        lambda: create_sensenova_u1_interleave_executor(
+            str(MODEL_PATH),
+            device="cpu",
+        ),
+    ]
+    for factory in factories:
+        with pytest.raises(
+            RuntimeError,
+            match="HF U1 modeling modules imported",
+        ):
+            factory()

--- a/tests/unit_test/sensenova_u1/test_pipeline.py
+++ b/tests/unit_test/sensenova_u1/test_pipeline.py
@@ -49,6 +49,13 @@ def test_sensenova_u1_pipeline_configs_register_architecture_and_alias() -> None
     assert serving_args["max_concurrency"] == 16
     assert serving_args["enable_cuda_graph"] is True
     assert serving_args["cuda_graph_bs"] == [1, 8, 16]
+    assert serving_args["eager_prefix_cache_max_entries"] == 4
+    assert serving_args["eager_decode_graph_cache_max_entries"] == 2
+    assert serving_args["eager_decode_graph_max_captures"] == 4
+    assert serving_args["eager_prefix_cache_max_tokens"] == 2048
+    assert serving_args["eager_decode_graph_max_total_tokens"] == 1024
+    assert default.stages[0].factory_args["max_total_tokens"] == 4096
+    assert flow.stages[0].factory_args["max_total_tokens"] == 4096
 
 
 def test_sensenova_u1_config_manager_resolves_raw_hf_config_and_variant(tmp_path) -> None:

--- a/tests/unit_test/sensenova_u1/test_pipeline.py
+++ b/tests/unit_test/sensenova_u1/test_pipeline.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+from sglang_omni.config.manager import ConfigManager
+from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+from sglang_omni.models.sensenova_u1.config import (
+    SenseNovaU1FlowPipelineConfig,
+    SenseNovaU1InterleavePipelineConfig,
+    SenseNovaU1PipelineConfig,
+    Variants,
+)
+
+
+def _stage_names(config) -> list[str]:
+    return [stage.name for stage in config.stages]
+
+
+def test_sensenova_u1_pipeline_configs_register_architecture_and_alias() -> None:
+    assert PIPELINE_CONFIG_REGISTRY.get_config("NEOChatModel") is SenseNovaU1PipelineConfig
+    assert PIPELINE_CONFIG_REGISTRY.get_config("SenseNovaU1") is SenseNovaU1PipelineConfig
+
+    default = SenseNovaU1PipelineConfig(model_path="model")
+    flow = SenseNovaU1FlowPipelineConfig(model_path="model")
+    interleave = SenseNovaU1InterleavePipelineConfig(model_path="model")
+
+    assert _stage_names(default) == ["u1_vqa"]
+    assert _stage_names(flow) == ["u1_flow"]
+    assert _stage_names(interleave) == ["u1_interleave"]
+    assert default.mem_fraction_role_to_stage() == {"understanding": "u1_vqa"}
+    assert flow.mem_fraction_role_to_stage() == {"generation": "u1_flow"}
+    assert interleave.mem_fraction_role_to_stage() == {"interleave": "u1_interleave"}
+    assert default.stages[0].terminal is True
+    assert flow.stages[0].terminal is True
+    assert interleave.stages[0].terminal is True
+    assert default.stages[0].runtime.resources.total_gpu_memory_fraction == 0.75
+    assert interleave.stages[0].factory.endswith(
+        ".stages.create_sensenova_u1_interleave_executor"
+    )
+
+
+def test_sensenova_u1_config_manager_resolves_raw_hf_config_and_variant(tmp_path) -> None:
+    (tmp_path / "config.json").write_text(
+        json.dumps({"architectures": ["NEOChatModel"], "model_type": "neo_chat"})
+    )
+
+    manager = ConfigManager.from_model_path(str(tmp_path), variant="interleave")
+
+    assert isinstance(manager.config, SenseNovaU1InterleavePipelineConfig)
+    assert manager.config.model_path == str(tmp_path)
+    assert manager.config.entry_stage == "u1_interleave"
+    assert Variants["default"] is SenseNovaU1PipelineConfig
+    assert Variants["flow"] is SenseNovaU1FlowPipelineConfig
+    assert Variants["interleave"] is SenseNovaU1InterleavePipelineConfig

--- a/tests/unit_test/sensenova_u1/test_pipeline.py
+++ b/tests/unit_test/sensenova_u1/test_pipeline.py
@@ -9,6 +9,7 @@ from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from sglang_omni.models.sensenova_u1.config import (
     SenseNovaU1FlowPipelineConfig,
     SenseNovaU1InterleavePipelineConfig,
+    SenseNovaU1NativeServingPipelineConfig,
     SenseNovaU1PipelineConfig,
     Variants,
 )
@@ -25,20 +26,29 @@ def test_sensenova_u1_pipeline_configs_register_architecture_and_alias() -> None
     default = SenseNovaU1PipelineConfig(model_path="model")
     flow = SenseNovaU1FlowPipelineConfig(model_path="model")
     interleave = SenseNovaU1InterleavePipelineConfig(model_path="model")
+    native_serving = SenseNovaU1NativeServingPipelineConfig(model_path="model")
 
-    assert _stage_names(default) == ["u1_vqa"]
+    assert _stage_names(default) == ["u1_interleave"]
     assert _stage_names(flow) == ["u1_flow"]
     assert _stage_names(interleave) == ["u1_interleave"]
-    assert default.mem_fraction_role_to_stage() == {"understanding": "u1_vqa"}
+    assert default.mem_fraction_role_to_stage() == {"interleave": "u1_interleave"}
     assert flow.mem_fraction_role_to_stage() == {"generation": "u1_flow"}
     assert interleave.mem_fraction_role_to_stage() == {"interleave": "u1_interleave"}
     assert default.stages[0].terminal is True
     assert flow.stages[0].terminal is True
     assert interleave.stages[0].terminal is True
     assert default.stages[0].runtime.resources.total_gpu_memory_fraction == 0.75
+    assert default.stages[0].factory.endswith(
+        ".stages.create_sensenova_u1_interleave_executor"
+    )
     assert interleave.stages[0].factory.endswith(
         ".stages.create_sensenova_u1_interleave_executor"
     )
+    serving_args = native_serving.stages[0].factory_args
+    assert serving_args["max_running_requests"] == 16
+    assert serving_args["max_concurrency"] == 16
+    assert serving_args["enable_cuda_graph"] is True
+    assert serving_args["cuda_graph_bs"] == [1, 8, 16]
 
 
 def test_sensenova_u1_config_manager_resolves_raw_hf_config_and_variant(tmp_path) -> None:
@@ -47,10 +57,18 @@ def test_sensenova_u1_config_manager_resolves_raw_hf_config_and_variant(tmp_path
     )
 
     manager = ConfigManager.from_model_path(str(tmp_path), variant="interleave")
+    default_manager = ConfigManager.from_model_path(str(tmp_path))
 
     assert isinstance(manager.config, SenseNovaU1InterleavePipelineConfig)
+    assert isinstance(default_manager.config, SenseNovaU1PipelineConfig)
     assert manager.config.model_path == str(tmp_path)
+    assert default_manager.config.entry_stage == "u1_interleave"
     assert manager.config.entry_stage == "u1_interleave"
     assert Variants["default"] is SenseNovaU1PipelineConfig
     assert Variants["flow"] is SenseNovaU1FlowPipelineConfig
     assert Variants["interleave"] is SenseNovaU1InterleavePipelineConfig
+    assert all(
+        "create_sensenova_u1_vqa_executor" not in stage.factory
+        for variant in Variants.values()
+        for stage in variant(model_path="model").stages
+    )

--- a/tests/unit_test/sensenova_u1/test_safety.py
+++ b/tests/unit_test/sensenova_u1/test_safety.py
@@ -1,0 +1,540 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from types import MethodType, SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+from PIL import Image
+
+from sglang_omni.models.sensenova_u1.flow_matching import (
+    SenseNovaU1FlowMatchingRunner,
+    _validated_flow_params_from_request,
+)
+from sglang_omni.models.sensenova_u1.interleave import (
+    SenseNovaU1InterleaveRunner,
+    _params_from_payload,
+)
+from sglang_omni.models.sensenova_u1.limits import (
+    U1_MAX_TOTAL_TOKENS,
+)
+from sglang_omni.models.sensenova_u1.native_serving import (
+    SenseNovaU1NativeServingExecutor,
+    _NativeEagerDecodeGraph,
+)
+
+
+def _cache_only_executor() -> SenseNovaU1NativeServingExecutor:
+    executor = object.__new__(SenseNovaU1NativeServingExecutor)
+    executor._eager_text_prefill_cache = OrderedDict()
+    executor._eager_text_decode_graphs = OrderedDict()
+    executor._eager_text_prefill_cache_evictions = 0
+    executor._eager_text_decode_graph_evictions = 0
+    executor._eager_text_decode_graph_captures = 0
+    executor.eager_prefix_cache_max_entries = 4
+    executor.eager_decode_graph_cache_max_entries = 2
+    executor.eager_decode_graph_max_captures = 4
+    executor.eager_prefix_cache_max_tokens = 2048
+    executor.eager_decode_graph_max_total_tokens = 1024
+    return executor
+
+
+def _prefix_cache_entry(
+    length: int,
+) -> tuple[torch.Tensor, list[tuple[torch.Tensor, torch.Tensor]], bool]:
+    caches = [
+        (
+            torch.zeros((length, 2), dtype=torch.bfloat16),
+            torch.zeros((length, 2), dtype=torch.bfloat16),
+        )
+        for _ in range(2)
+    ]
+    return torch.zeros((1, 8), dtype=torch.bfloat16), caches, True
+
+
+class _FakeCudaGraph:
+    def __init__(self) -> None:
+        self.reset_called = False
+
+    def reset(self) -> None:
+        self.reset_called = True
+
+
+def _decode_graph_runner(length: int) -> _NativeEagerDecodeGraph:
+    initial_caches = [
+        (
+            torch.zeros((length, 2), dtype=torch.bfloat16),
+            torch.zeros((length, 2), dtype=torch.bfloat16),
+        )
+    ]
+    final_caches = [
+        (
+            torch.zeros((length + 1, 2), dtype=torch.bfloat16),
+            torch.zeros((length + 1, 2), dtype=torch.bfloat16),
+        )
+    ]
+    return _NativeEagerDecodeGraph(
+        graphs=[_FakeCudaGraph()],  # type: ignore[list-item]
+        graph_pool=object(),
+        initial_caches=initial_caches,
+        input_token=torch.zeros(1, dtype=torch.long),
+        decode_indexes=[torch.zeros((3, 1), dtype=torch.long)],
+        generated_tokens=[torch.zeros(1, dtype=torch.long)],
+        last_logits=torch.zeros((1, 8), dtype=torch.bfloat16),
+        final_caches=final_caches,
+        cache_history=[final_caches],
+        source_prefix_cache_key=f"prefix-{length}",
+        prefix_len=length,
+        verified_finite=True,
+    )
+
+
+def test_sensenova_u1_eager_caches_are_bounded_lru_and_release_references() -> None:
+    executor = _cache_only_executor()
+    prefix_cycle_bytes = []
+    evicted_prefix_caches = None
+    for cycle in range(3):
+        for length in (8, 16, 24, 32, 40, 48):
+            entry = _prefix_cache_entry(length)
+            if cycle == 0 and length == 8:
+                evicted_prefix_caches = entry[1]
+            executor._put_eager_prefix_cache_entry(
+                f"prefix-{cycle}-{length}",
+                entry,
+            )
+            assert len(executor._eager_text_prefill_cache) <= 4
+        prefix_cycle_bytes.append(
+            executor.eager_runtime_cache_snapshot()[
+                "prefix_cache_tensor_bytes"
+            ]
+        )
+
+    assert prefix_cycle_bytes[0] == prefix_cycle_bytes[1] == prefix_cycle_bytes[2]
+    assert evicted_prefix_caches == []
+    assert executor._eager_text_prefill_cache_evictions == 14
+
+    graph_cycle_bytes = []
+    first_graph = None
+    first_cuda_graph = None
+    for cycle in range(3):
+        for length in (8, 16, 24, 32):
+            graph = _decode_graph_runner(length)
+            if cycle == 0 and length == 8:
+                first_graph = graph
+                first_cuda_graph = graph.graphs[0]
+            executor._put_eager_decode_graph(
+                (cycle, length),
+                graph,
+            )
+            assert len(executor._eager_text_decode_graphs) <= 2
+        graph_cycle_bytes.append(
+            executor.eager_runtime_cache_snapshot()[
+                "decode_graph_tensor_bytes"
+            ]
+        )
+
+    assert graph_cycle_bytes[0] == graph_cycle_bytes[1] == graph_cycle_bytes[2]
+    assert first_graph is not None
+    assert first_cuda_graph is not None
+    assert first_cuda_graph.reset_called
+    assert first_graph.graphs == []
+    assert first_graph.initial_caches == []
+    assert first_graph.input_token is None
+    assert first_graph.graph_pool is None
+    assert executor._eager_text_decode_graph_evictions == 10
+
+    cleared = executor.clear_eager_runtime_caches()
+    assert cleared["after"]["prefix_cache_entries"] == 0
+    assert cleared["after"]["prefix_cache_tensor_bytes"] == 0
+    assert cleared["after"]["decode_graph_entries"] == 0
+    assert cleared["after"]["decode_graph_tensor_bytes"] == 0
+
+
+def test_sensenova_u1_decode_graph_capture_attempts_have_lifetime_budget() -> None:
+    executor = _cache_only_executor()
+
+    assert [
+        executor._try_reserve_eager_decode_graph_capture()
+        for _ in range(5)
+    ] == [True, True, True, True, False]
+    assert (
+        executor.eager_runtime_cache_snapshot()["decode_graph_captures"]
+        == 4
+    )
+
+    executor.clear_eager_runtime_caches()
+
+    assert not executor._try_reserve_eager_decode_graph_capture()
+
+
+class _FakePool:
+    def __init__(self, available: int) -> None:
+        self.available = available
+
+    def available_size(self) -> int:
+        return self.available
+
+
+class _FakeReq:
+    def __init__(self, rid: str, token_count: int) -> None:
+        self.rid = rid
+        self.token_count = token_count
+        self.req_pool_idx = None
+        self.kv = None
+        self.prefix_indices = []
+        self.extra_key = None
+        self.inflight_middle_chunks = 0
+
+    def effective_kv_committed_len(self) -> int:
+        return self.token_count
+
+
+class _FakePrefillManager:
+    def __init__(
+        self,
+        req_pool: _FakePool,
+        token_pool: _FakePool,
+        *,
+        partial: bool,
+    ) -> None:
+        self.req_pool = req_pool
+        self.token_pool = token_pool
+        self.partial = partial
+        self.waiting_queue: list[_FakeReq] = []
+        self.chunked_req = None
+
+    def add_one_request(self, req: _FakeReq) -> None:
+        self.waiting_queue.append(req)
+
+    def schedule_next_batch(
+        self,
+        running_batch: Any,
+        num_allocatable_reqs: int,
+    ) -> Any:
+        del running_batch
+        count = 1 if self.partial else num_allocatable_reqs
+        selected = self.waiting_queue[:count]
+        self.waiting_queue = self.waiting_queue[count:]
+        for index, req in enumerate(selected):
+            self.req_pool.available -= 1
+            self.token_pool.available -= req.token_count
+            req.req_pool_idx = index + 1
+            req.kv = object()
+        return SimpleNamespace(reqs=selected)
+
+
+def _prefill_fault_executor(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    fault: str,
+    partial: bool = False,
+) -> tuple[
+    SenseNovaU1NativeServingExecutor,
+    list[_FakeReq],
+    dict[str, int],
+]:
+    from sglang.srt.mem_cache import common as cache_common
+    from sglang_omni.model_runner import base as model_runner_base
+    from sglang_omni.models.sensenova_u1 import native_serving
+
+    req_pool = _FakePool(8)
+    token_pool = _FakePool(128)
+    baseline = {
+        "req_available": req_pool.available,
+        "token_available": token_pool.available,
+    }
+    reqs = [_FakeReq("req-0", 7), _FakeReq("req-1", 11)]
+    manager = _FakePrefillManager(
+        req_pool,
+        token_pool,
+        partial=partial,
+    )
+    executor = object.__new__(SenseNovaU1NativeServingExecutor)
+    executor.max_running_requests = 2
+    executor.enable_radix_cache = True
+    executor.prefill_cuda_graph_enabled = False
+    executor.req_to_token_pool = req_pool
+    executor.token_to_kv_pool_allocator = token_pool
+    executor.tree_cache = SimpleNamespace(
+        disable=False,
+        protected_size_=0,
+        evictable_size_=0,
+        total_size=lambda: 0,
+        evictable_size=lambda: 0,
+        full_evictable_size=lambda: 0,
+    )
+    executor.prefill_manager = manager
+    executor.decode_manager = SimpleNamespace(
+        running_batch=SimpleNamespace(),
+    )
+    model = SimpleNamespace(last_forward_batch_prepare={"ok": True})
+    model_runner = SimpleNamespace(
+        model=model,
+        attn_backend=SimpleNamespace(forward_metadata=None),
+    )
+
+    def forward_batch_generation(forward_batch: Any, *, batch: Any) -> Any:
+        del forward_batch, batch
+        if fault == "forward":
+            raise RuntimeError("injected forward failure")
+        logits = torch.zeros((2, 4))
+        if fault == "logits":
+            logits = torch.zeros((1, 4))
+        return SimpleNamespace(
+            can_run_cuda_graph=False,
+            logits_output=SimpleNamespace(next_token_logits=logits),
+        )
+
+    executor.model_worker = SimpleNamespace(
+        device="cpu",
+        model_runner=model_runner,
+        forward_batch_generation=forward_batch_generation,
+    )
+    prepared_by_id = {req.rid: req for req in reqs}
+
+    def prepare(self: Any, **item: Any) -> dict[str, Any]:
+        req = prepared_by_id[item["request_id"]]
+        return {
+            "request_id": item["request_id"],
+            "input_ids": item["input_ids"],
+            "indexes": item["indexes"],
+            "image_token_tag": item["image_token_tag"],
+            "image_gen_indicators": None,
+            "input_embeds": None,
+            "req": req,
+            "cache_extra_key": None,
+        }
+
+    executor._prepare_prefill_request = MethodType(prepare, executor)
+
+    def release_kv_cache(req: _FakeReq, tree_cache: Any, *, is_insert: bool) -> None:
+        del tree_cache, is_insert
+        req_pool.available += 1
+        token_pool.available += req.token_count
+        req.req_pool_idx = None
+        req.kv = None
+
+    monkeypatch.setattr(cache_common, "release_kv_cache", release_kv_cache)
+    monkeypatch.setattr(
+        model_runner_base,
+        "resolve_deferred_prefill_inputs",
+        lambda batch, device: None,
+    )
+
+    def init_new(
+        batch: Any,
+        model_runner_arg: Any,
+        **kwargs: Any,
+    ) -> Any:
+        del model_runner_arg, kwargs
+        batch_size = len(batch.reqs)
+        return SimpleNamespace(
+            forward_mode="EXTEND",
+            batch_size=batch_size,
+            input_ids=torch.arange(batch_size),
+            positions=torch.arange(batch_size),
+            mrope_positions=None,
+            extend_seq_lens_cpu=[1] * batch_size,
+            extend_prefix_lens_cpu=[0] * batch_size,
+            rids=[req.rid for req in batch.reqs],
+            cross_attention_custom_mask=None,
+            model_specific_states={},
+        )
+
+    monkeypatch.setattr(
+        native_serving,
+        "ForwardBatch",
+        SimpleNamespace(init_new=init_new),
+    )
+    if fault == "sidecar":
+
+        def fail_sidecar(self: Any, **kwargs: Any) -> None:
+            del self, kwargs
+            raise RuntimeError("injected sidecar failure")
+
+        executor._attach_prefill_sidecar = MethodType(fail_sidecar, executor)
+    if fault == "metadata":
+
+        def fail_metadata(self: Any, **kwargs: Any) -> None:
+            del self, kwargs
+            raise RuntimeError("injected metadata failure")
+
+        executor._collect_prefill_metadata = MethodType(fail_metadata, executor)
+    return executor, reqs, baseline
+
+
+@pytest.mark.parametrize("fault", ["sidecar", "forward", "logits", "metadata"])
+def test_sensenova_u1_prefill_faults_restore_scheduler_and_kv_baseline(
+    monkeypatch: pytest.MonkeyPatch,
+    fault: str,
+) -> None:
+    executor, reqs, baseline = _prefill_fault_executor(
+        monkeypatch,
+        fault=fault,
+    )
+    requests = [
+        {
+            "request_id": req.rid,
+            "input_ids": torch.arange(req.token_count),
+            "indexes": torch.zeros((3, req.token_count), dtype=torch.long),
+            "image_token_tag": torch.zeros(req.token_count, dtype=torch.bool),
+        }
+        for req in reqs
+    ]
+
+    with pytest.raises(RuntimeError, match="injected|logits batch size mismatch"):
+        executor.run_prefill_batch(requests, cache_insert=True)
+
+    assert executor.prefill_manager.waiting_queue == []
+    assert executor.prefill_manager.chunked_req is None
+    assert executor._pool_snapshot() == baseline
+    assert executor._cache_snapshot()["total_size"] == 0
+    assert all(req.req_pool_idx is None and req.kv is None for req in reqs)
+
+
+def test_sensenova_u1_partial_prefill_failure_restores_all_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor, reqs, baseline = _prefill_fault_executor(
+        monkeypatch,
+        fault="none",
+        partial=True,
+    )
+    requests = [
+        {
+            "request_id": req.rid,
+            "input_ids": torch.arange(req.token_count),
+            "indexes": torch.zeros((3, req.token_count), dtype=torch.long),
+            "image_token_tag": torch.zeros(req.token_count, dtype=torch.bool),
+        }
+        for req in reqs
+    ]
+
+    with pytest.raises(RuntimeError, match="did not schedule the full batch"):
+        executor.run_prefill_batch(requests)
+
+    assert executor.prefill_manager.waiting_queue == []
+    assert executor._pool_snapshot() == baseline
+    assert all(req.req_pool_idx is None and req.kv is None for req in reqs)
+
+
+@pytest.mark.parametrize(
+    "params, message",
+    [
+        ({"width": 0}, "width must be positive"),
+        ({"width": 33}, "width must be divisible"),
+        ({"width": 2080}, "width exceeds"),
+        ({"width": 2048, "height": 1024}, "pixel count exceeds"),
+        ({"num_steps": 0}, "num_steps must be positive"),
+        ({"num_steps": 65}, "num_steps exceeds"),
+        ({"max_images": 0}, "max_images must be positive"),
+        ({"max_images": 5}, "max_images exceeds"),
+        ({"max_new_tokens": 0}, "max_new_tokens must be positive"),
+        ({"max_new_tokens": 2049}, "max_new_tokens exceeds"),
+        (
+            {
+                "width": 1024,
+                "height": 1024,
+                "max_images": 3,
+                "max_new_tokens": 2048,
+            },
+            "token budget exceeds",
+        ),
+        ({"width": "wide"}, "width must be an integer"),
+    ],
+)
+def test_sensenova_u1_interleave_rejects_malformed_or_oversized_payloads(
+    params: dict[str, Any],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        _params_from_payload("draw a lighthouse", params)
+
+
+@pytest.mark.parametrize(
+    "params, message",
+    [
+        ({"height": -32}, "height must be positive"),
+        ({"height": 48}, "height must be divisible"),
+        ({"num_steps": "many"}, "num_steps must be an integer"),
+        ({"num_steps": 65}, "num_steps exceeds"),
+        ({"batch_size": 0}, "batch_size must be positive"),
+        ({"batch_size": 2}, "batch_size exceeds"),
+        ({"images": "not-a-list"}, "images must be a list"),
+    ],
+)
+def test_sensenova_u1_flow_rejects_malformed_or_oversized_payloads(
+    params: dict[str, Any],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        _validated_flow_params_from_request(
+            {"prompt": "draw a lighthouse"},
+            params,
+            max_total_tokens=U1_MAX_TOTAL_TOKENS,
+        )
+
+
+def test_sensenova_u1_rejects_excess_input_images() -> None:
+    images = [Image.new("RGB", (32, 32)) for _ in range(5)]
+    with pytest.raises(ValueError, match="input image count exceeds"):
+        _params_from_payload(
+            {"prompt": "compare", "images": images},
+            {},
+        )
+
+
+def test_sensenova_u1_exact_prefix_budget_precedes_gpu_embedding_compose() -> None:
+    runner = object.__new__(SenseNovaU1FlowMatchingRunner)
+    runner.max_total_tokens = 32
+    runner.tokenizer = lambda text, return_tensors: {
+        "input_ids": torch.arange(40).view(1, -1)
+    }
+    runner._load_input_images = lambda images: (None, None)
+    runner._replace_image_tokens = lambda query, grid_hw: query
+    runner._get_thw_indexes = lambda input_ids, grid_hw: torch.zeros(
+        (3, input_ids.numel()),
+        dtype=torch.long,
+    )
+    runner._token_embeds = lambda input_ids: pytest.fail(
+        "GPU embedding allocation must not run for an oversized prefix"
+    )
+
+    with pytest.raises(ValueError, match="token budget exceeds"):
+        runner._build_prefix(
+            prompt="oversized",
+            images=[],
+            system_message="system",
+            assistant_append="<img>",
+            reserved_image_tokens=1,
+        )
+
+
+def test_sensenova_u1_interleave_exact_budget_precedes_gpu_embedding_compose() -> None:
+    runner = object.__new__(SenseNovaU1InterleaveRunner)
+    runner.max_total_tokens = 32
+    runner.tokenizer = lambda text, return_tensors: {
+        "input_ids": torch.arange(40).view(1, -1)
+    }
+    runner.img_context_token_id = 7
+    runner._load_interleave_prefix_images = lambda images, generated: (None, None)
+    runner._replace_image_tokens = lambda query, grid_hw: query
+    runner._get_thw_indexes = lambda input_ids, grid_hw: torch.zeros(
+        (3, input_ids.numel()),
+        dtype=torch.long,
+    )
+    runner._token_embeds = lambda input_ids: pytest.fail(
+        "GPU embedding allocation must not run for an oversized prefix"
+    )
+
+    with pytest.raises(ValueError, match="token budget exceeds"):
+        runner._build_condition_prefix(
+            prompt="oversized",
+            images=[],
+            system_message="system",
+            think_mode=True,
+            reserved_text_tokens=1,
+        )

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -11,7 +11,11 @@ from fastapi.testclient import TestClient
 
 from sglang_omni.client import Client, GenerateChunk
 from sglang_omni.client.audio import encode_pcm
-from sglang_omni.client.types import GenerateRequest
+from sglang_omni.client.types import (
+    CompletionResult,
+    CompletionStreamChunk,
+    GenerateRequest,
+)
 from sglang_omni.pipeline.coordinator import Coordinator
 from sglang_omni.proto import (
     EXPLICIT_GENERATION_PARAMS_KEY,
@@ -299,6 +303,61 @@ class SuccessfulTranscriptionClient:
             text="hello world",
             finish_reason="stop",
         )
+
+
+class SuccessfulImageChatClient:
+    def __init__(self) -> None:
+        self.completion_requests: list[GenerateRequest] = []
+        self.stream_requests: list[GenerateRequest] = []
+        self.omni_rollout = {
+            "images": [
+                {
+                    "type": "image",
+                    "format": "png",
+                    "data": "data:image/png;base64,iVBORw0KGgo=",
+                    "width": 2,
+                    "height": 1,
+                    "index": 0,
+                },
+                {"type": "image", "data": "https://example.invalid/not-inline.png"},
+            ],
+        }
+
+    def health(self) -> dict[str, Any]:
+        return {"running": True}
+
+    async def completion(
+        self,
+        request: GenerateRequest,
+        *,
+        request_id: str,
+        audio_format: str = "wav",
+    ) -> CompletionResult:
+        del audio_format
+        self.completion_requests.append(request)
+        return CompletionResult(
+            request_id=request_id,
+            text="caption",
+            omni_rollout=self.omni_rollout,
+            finish_reason="stop",
+        )
+
+    async def completion_stream(
+        self,
+        request: GenerateRequest,
+        *,
+        request_id: str,
+        audio_format: str = "wav",
+    ):
+        del audio_format
+        self.stream_requests.append(request)
+        yield CompletionStreamChunk(
+            request_id=request_id,
+            text="caption",
+            modality="text",
+            omni_rollout=self.omni_rollout,
+        )
+        yield CompletionStreamChunk(request_id=request_id, finish_reason="stop")
 
 
 class ChunkRecordingTranscriptionClient:
@@ -1405,6 +1464,92 @@ def test_transcription_request_builds_asr_generate_request() -> None:
     assert gen_req.metadata == {"task": "asr"}
     assert gen_req.output_modalities == ["text"]
     assert gen_req.stream is False
+
+
+def test_chat_request_passes_image_generation_controls() -> None:
+    req = ChatCompletionRequest(
+        model="sensenova-u1",
+        messages=[{"role": "user", "content": "draw a red square"}],
+        modalities=["text", "image"],
+        image_config={"width": 256, "height": 256, "seed": 7},
+        chat_template_kwargs={"enable_thinking": False},
+        n=1,
+    )
+
+    gen_req = _build_chat_generate_request(req)
+
+    assert gen_req.output_modalities == ["text", "image"]
+    assert gen_req.extra_params["image_config"] == {
+        "width": 256,
+        "height": 256,
+        "seed": 7,
+    }
+    assert gen_req.extra_params["chat_template_kwargs"] == {"enable_thinking": False}
+    assert gen_req.extra_params["n"] == 1
+
+
+def test_chat_completion_non_stream_returns_inline_images() -> None:
+    image_client = SuccessfulImageChatClient()
+    client = TestClient(create_app(image_client, model_name="sensenova-u1"))
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "sensenova-u1",
+            "messages": [{"role": "user", "content": "draw a red square"}],
+            "modalities": ["text", "image"],
+            "image_config": {"width": 256, "height": 256},
+            "chat_template_kwargs": {"enable_thinking": False},
+            "n": 1,
+            "stream": False,
+        },
+    )
+
+    assert response.status_code == 200
+    message = response.json()["choices"][0]["message"]
+    assert message["content"] == "caption"
+    assert message["images"] == [
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+            "width": 2,
+            "height": 1,
+            "index": 0,
+            "format": "png",
+        }
+    ]
+    assert image_client.completion_requests[0].output_modalities == ["text", "image"]
+    assert image_client.completion_requests[0].extra_params["image_config"] == {
+        "width": 256,
+        "height": 256,
+    }
+    assert image_client.completion_requests[0].extra_params["chat_template_kwargs"] == {
+        "enable_thinking": False
+    }
+
+
+def test_chat_completion_stream_returns_inline_image_delta() -> None:
+    image_client = SuccessfulImageChatClient()
+    client = TestClient(create_app(image_client, model_name="sensenova-u1"))
+
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "sensenova-u1",
+            "messages": [{"role": "user", "content": "draw a red square"}],
+            "modalities": ["text", "image"],
+            "stream": True,
+        },
+    ) as response:
+        body = "".join(response.iter_text())
+
+    assert response.status_code == 200
+    assert '"content": "caption"' in body
+    assert '"images": [{"type": "image_url"' in body
+    assert "data:image/png;base64,iVBORw0KGgo=" in body
+    assert "not-inline.png" not in body
+    assert image_client.stream_requests[0].output_modalities == ["text", "image"]
 
 
 def test_transcription_request_preserves_explicit_empty_language() -> None:


### PR DESCRIPTION
## Summary

This PR adds native SGLang-Omni support for SenseNova U1
(`NEOChatModel`), including interleaved image understanding and generation.

The implementation includes:

- a native SGLang language/MoT model with direct checkpoint loading;
- native-resolution U1 vision encoding;
- U1 text/image hybrid attention masks in the real Triton serving path;
- native T2I/IT2I flow matching;
- native text-image-text interleaved generation;
- Radix prefix reuse, continuous batching, and CUDA graph acceleration;
- OpenAI-compatible inline image responses.

Official SenseNova U1 HF modeling is used only by validation scripts as an
oracle. Public serving factories fail fast if HF U1 modeling is imported.

## Why

SenseNova U1 is a unified multimodal model that can understand and generate
interleaved text and images. Downstream rollout workloads need a single native
engine instead of forwarding computation to Transformers or coordinating
separate autoregressive and image-generation services.

## Implementation

### Native model and weights

- Adds `SenseNovaU1NativeForCausalLM`.
- Uses SGLang `QKVParallelLinear`, `RowParallelLinear`,
  `VocabParallelEmbedding`, `RadixAttention`, and `LogitsProcessor`.
- Loads the U1 understanding and MoT generation towers directly from sharded
  safetensors.
- Implements split temporal/spatial RoPE with the checkpoint's independent
  text and image frequencies.
- Loads all 1,096 language-model keys with zero missing, unexpected, or error
  keys.

### Vision and hybrid attention

- Adds a native U1 vision model and native-resolution preprocessing.
- Implements the U1 row policy where text remains causal while image rows can
  attend to the complete image span.
- Passes custom masks through the actual SGLang Triton attention backend.
- Supports cached-prefix masks with a full current generated-image span.

### Flow matching and interleave

- Loads the U1 flow head, timestep/noise embedders, and generation vision tower
  directly from checkpoint weights.
- Reuses static condition-prefix KV through the Radix cache.
- Uses a breakable prefill CUDA graph for fixed generated-image token shapes.
- Implements native text boundary decode, flow image generation, official-order
  BF16 image re-embedding, and post-image continuation.
- Uses segmented exact eager CUDA graphs for interleaved text generation.

### Serving isolation

- Makes native interleave the public default variant.
- Keeps public `flow`, `interleave`, `native`, and `native_serving` variants on
  native implementations.
- Removes the HF VQA serving factory from public stages.
- Adds import guards to native flow/interleave/serving factories.

### Production safety bounds

- Uses a configurable 4-entry eager prefix LRU and 2-entry eager decode-graph
  LRU.
- Limits eager prefix entries to 2,048 tokens and decode graphs to 1,024 total
  tokens.
- Caps decode-graph capture at four lifetime attempts per executor. After the
  budget is exhausted, uncached shapes use the exact eager path while cached
  hot shapes continue to replay.
- Calls `CUDAGraph.reset()` and drops retained graph/tensor references on
  eviction; stage shutdown clears both eager caches.
- Guarantees prefill cleanup with `try/finally`, including sidecar, forward,
  logits-validation, metadata, and partial-batch failures.
- Validates image dimensions, pixels, diffusion steps, input/output image
  counts, output tokens, and the exact total-token budget before request GPU
  tensor allocation.
- Documents that tokenizer loading uses `trust_remote_code=True` and therefore
  requires a trusted, intentionally configured checkpoint.

## Validation

All results below were produced on one local H100 80GB. Each performance case
uses one unmeasured warmup/precompile pass followed by three measured repeats;
the median excludes model load.

### Cross-implementation correctness

- Fixed-input logits cosine: `0.9999924302`
- Logits max absolute difference: `0.0308227539`
- Greedy prompt matches: `20/20`
- Greedy token-step matches: `160/160`
- Native/HF image comparisons: `12/12`
- Minimum PSNR: `46.7483550 dB`
- Minimum SSIM: `0.99903745`
- Exact PNG count: `0`
- Ten-sample causal interleave correctness: `10/10`
- Same-image post-image continuation: `10/10` token exact

### Warmed performance

| Workload | HF | Native | Speedup |
|---|---:|---:|---:|
| Text bs=1 | 23.3347 tok/s | 58.4513 tok/s | 2.5049x |
| Text bs=8 | 23.2775 tok/s | 387.1545 tok/s | 16.6321x |
| Text bs=16 | 23.3750 tok/s | 729.8184 tok/s | 31.2222x |
| T2I, 256x256, 2 steps | 0.160354 s | 0.050109 s | 3.2001x |
| Interleave first-image fixed work | 6.296434 s | 2.350700 s | 2.6785x |

All text speed cases are token exact. T2I reaches PSNR `51.3745` and SSIM
`0.999650`; interleave reaches PSNR `51.0354` and SSIM `0.999623`.

The fixed-work interleave benchmark uses the shared exact 125-token pre-image
prefix, one image, and one post-image token so accepted pixel differences do
not change the measured amount of text work.

### Tests

```bash
python -m pytest \
  tests/unit_test/sensenova_u1/test_pipeline.py \
  tests/unit_test/sensenova_u1/test_native_model.py \
  tests/unit_test/sensenova_u1/test_hybrid_attention.py \
  tests/unit_test/sensenova_u1/test_safety.py -q
```

Result: `54 passed`.

The safety suite includes malformed/oversized payload rejection, LRU stress,
explicit graph reference release, lifetime capture budgeting, sidecar/forward/
logits/metadata fault injection, partial scheduling, and request/KV pool
baseline restoration.

Actual H100 cache stress across three cycles of varied prompt/decode lengths:

- prefix entries: `4/4`
- decode graph entries: `2/2`
- decode graph capture attempts: `4/4`
- cycle-end prefix retained bytes:
  `[122326016, 122326016, 122326016]`
- cycle-end graph retained bytes:
  `[598591696, 598591696, 598591696]`
- allocated growth after the warm cycle: `0` bytes
- reserved growth after the warm cycle: `4194304` bytes
- explicit clear returns both entry counts and retained bytes to zero

No-environment fixed-work spot after the safety changes:

- T2I: `3.1463x`, PSNR `51.3745`, SSIM `0.999650`
- interleave: `2.6776x`, PSNR `51.0354`, SSIM `0.999623`
- output PNG/text artifacts are byte-identical to the previously accepted
  no-environment run
- public HF import guard passes, including the native-serving factory

Review commits:

- `f40b0fd760b699a6006b0a55360f5f174dacf30b`
- `9fad08481aad342a19380eaa4a0f84c4f5f24db9`

## Known Limitations

- Validation is currently single-node and single-GPU.
- The production custom-mask path validated here is Triton; FlashInfer/FA3
  parity remains follow-up work.
- CUDA graph capture adds cold-start work that is excluded from warmed
  go/no-go measurements and retained separately in the evidence.
- CUDA graph-private allocator pools are not reliably reclaimed during process
  lifetime. The executor therefore limits new graph capture attempts to four;
  later uncached shapes use the exact eager path.
- Cooperative scheduling between individual flow steps and unrelated
  autoregressive requests remains future scheduler work.
