### PR TITLE
[Qwen3-Omni Perf] Talker: mixed-chunk by default, plus an opt-in prefill/decode interleave

### DIFF
--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -844,6 +844,37 @@ def apply_partial_start_cli_overrides(
     return pipeline_config
 
 
+def apply_talker_prefill_interleave_cli_overrides(
+    pipeline_config: PipelineConfig,
+    *,
+    talker_prefill_decode_interleave: str,
+) -> PipelineConfig:
+    mode = _normalize_stage_toggle_mode(
+        "talker_prefill_decode_interleave", talker_prefill_decode_interleave
+    )
+    if mode == "default":
+        return pipeline_config
+    flag_name = "--talker-prefill-decode-interleave"
+    stage_name = _resolve_talker_stage(pipeline_config, flag_name=flag_name)
+    matching_stages = _find_matching_stages(
+        pipeline_config,
+        stage_name=stage_name,
+        reason="talker prefill interleave overrides",
+    )
+    for stage in matching_stages:
+        if stage.factory != _QWEN_PARTIAL_START_TALKER_FACTORY:
+            raise typer.BadParameter(
+                f"{flag_name} currently supports only the Qwen3-Omni "
+                f"talker; stage {stage.name!r} uses factory {stage.factory!r}"
+            )
+    _apply_factory_args_updates(
+        pipeline_config,
+        matching_stages,
+        {"prefill_decode_interleave": mode == "on"},
+    )
+    return pipeline_config
+
+
 def _apply_factory_args_updates(
     pipeline_config: PipelineConfig,
     stages: list[StageConfig],
@@ -1260,6 +1291,19 @@ def serve(
             ),
         ),
     ] = "default",
+    talker_prefill_decode_interleave: Annotated[
+        str,
+        typer.Option(
+            "--talker-prefill-decode-interleave",
+            "--talker_prefill_decode_interleave",
+            help=(
+                "default|on|off. When on, the Qwen3-Omni talker guarantees a "
+                "decode step between prefill steps so ongoing audio streams "
+                "keep their decode cadence while queued prefills trickle in. "
+                "'default' uses the pipeline config default (off)."
+            ),
+        ),
+    ] = "default",
     thinker_torch_compile: Annotated[
         str,
         typer.Option(
@@ -1555,6 +1599,10 @@ def serve(
     merged_config = apply_partial_start_cli_overrides(
         merged_config,
         talker_partial_start=talker_partial_start,
+    )
+    merged_config = apply_talker_prefill_interleave_cli_overrides(
+        merged_config,
+        talker_prefill_decode_interleave=talker_prefill_decode_interleave,
     )
 
     if _should_print_merged_config(colocate=colocate, log_level=log_level):

--- a/sglang_omni/models/qwen3_omni/bootstrap.py
+++ b/sglang_omni/models/qwen3_omni/bootstrap.py
@@ -164,6 +164,7 @@ def create_talker_scheduler(
     total_gpu_memory_fraction: float | None = None,
     enable_partial_start: bool = False,
     partial_start_min_chunks: int = 5,
+    prefill_decode_interleave: bool = False,
 ):
     """Create the Qwen talker scheduler."""
     del speech_enabled
@@ -288,6 +289,7 @@ def create_talker_scheduler(
         enable_partial_start=enable_partial_start,
         partial_start_min_chunks=partial_start_min_chunks,
         im_end_token_id=root_config.im_end_token_id,
+        prefill_decode_interleave=prefill_decode_interleave,
     )
 
     model_runner = QwenTalkerModelRunner(

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -1077,6 +1077,7 @@ def create_talker_ar_executor_from_config(
     total_gpu_memory_fraction: float | None = None,
     enable_partial_start: bool = False,
     partial_start_min_chunks: int = 5,
+    prefill_decode_interleave: bool = False,
 ):
     """Returns OmniScheduler for talker."""
     from sglang_omni.models.qwen3_omni.bootstrap import create_talker_scheduler
@@ -1132,6 +1133,7 @@ def create_talker_ar_executor_from_config(
         total_gpu_memory_fraction=total_gpu_memory_fraction,
         enable_partial_start=enable_partial_start,
         partial_start_min_chunks=partial_start_min_chunks,
+        prefill_decode_interleave=prefill_decode_interleave,
     )
     post_load_process_mem = get_process_gpu_memory_bytes(gpu_id)
     logger.info(

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -201,6 +201,7 @@ class OmniScheduler:
         prefill_coalesce_when_idle: bool = False,
         prefill_coalesce_requires_pending_builds: bool = False,
         prefill_coalesce_after_builds_during_decode: bool = False,
+        prefill_decode_interleave: bool = False,
         request_build_max_workers: int = 1,
         request_build_max_pending: int | None = None,
         shutdown_callback: Callable[[], None] | None = None,
@@ -315,6 +316,8 @@ class OmniScheduler:
         self.prefill_coalesce_after_builds_during_decode = bool(
             prefill_coalesce_after_builds_during_decode
         )
+        self.prefill_decode_interleave = bool(prefill_decode_interleave)
+        self._interleave_defer_prefill = False
 
         # Token / memory info (upstream reads from tp_worker.get_worker_info)
         mr = tp_worker.model_runner
@@ -1332,6 +1335,24 @@ class OmniScheduler:
         return plan.batch_to_run
 
     def get_new_batch_prefill(self, running_batch):
+        if not self.prefill_decode_interleave:
+            return self._get_new_batch_prefill_coalesced(running_batch)
+        if (
+            self._interleave_defer_prefill
+            and self.chunked_req is None
+            and running_batch is not None
+            and not running_batch.is_empty()
+            and not running_batch.is_prefill_only
+        ):
+            self._interleave_defer_prefill = False
+            return NextBatchPlan(batch_to_run=None, running_batch=running_batch)
+        self._interleave_defer_prefill = False
+        plan = self._get_new_batch_prefill_coalesced(running_batch)
+        if plan.batch_to_run is not None:
+            self._interleave_defer_prefill = True
+        return plan
+
+    def _get_new_batch_prefill_coalesced(self, running_batch):
         # Note: (maydomine) batch prefill admissions to amortize the fixed step
         # cost; the oldest-request deadline survives partial admission and aborts.
         #

--- a/tests/README.md
+++ b/tests/README.md
@@ -98,6 +98,7 @@ tests/
     │   ├── test_streaming.py
     │   ├── test_talker.py
     │   ├── test_talker_prefill_embed_cache.py
+    │   ├── test_talker_prefill_interleave.py
     │   ├── test_talker_emit_snapshot.py
     │   ├── test_talker_feedback_write.py
     │   ├── test_talker_row_ownership.py

--- a/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
+++ b/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
@@ -369,6 +369,7 @@ def test_qwen_talker_ar_threads_explicit_generation_batch_policy(monkeypatch) ->
                 "cuda_graph_bs": server_args.cuda_graph_bs,
                 "torch_compile_max_bs": server_args.torch_compile_max_bs,
                 "weight_prefix": kwargs["weight_prefix"],
+                "prefill_decode_interleave": kwargs["prefill_decode_interleave"],
             }
         )
         return object()
@@ -390,7 +391,9 @@ def test_qwen_talker_ar_threads_explicit_generation_batch_policy(monkeypatch) ->
         lambda gpu_id: None,
     )
 
-    qwen_stages.create_talker_ar_executor_from_config("dummy")
+    qwen_stages.create_talker_ar_executor_from_config(
+        "dummy", prefill_decode_interleave=True
+    )
 
     assert build_calls == [
         {
@@ -412,6 +415,7 @@ def test_qwen_talker_ar_threads_explicit_generation_batch_policy(monkeypatch) ->
             "cuda_graph_bs": [1, 2, 4, 8, 12, 16, 24, 32],
             "torch_compile_max_bs": 32,
             "weight_prefix": "talker.",
+            "prefill_decode_interleave": True,
         }
     ]
 

--- a/tests/unit_test/qwen3_omni/test_talker_prefill_interleave.py
+++ b/tests/unit_test/qwen3_omni/test_talker_prefill_interleave.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import inspect
+import threading
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+pytest.importorskip("sglang")
+
+from sglang.srt.managers.schedule_batch import NextBatchPlan  # noqa: E402
+
+from sglang_omni.cli.serve import (  # noqa: E402
+    apply_talker_prefill_interleave_cli_overrides,
+)
+from sglang_omni.config import resolve_stage_factory_args  # noqa: E402
+from sglang_omni.models.qwen3_omni.config import (  # noqa: E402
+    Qwen3OmniSpeechPipelineConfig,
+)
+from sglang_omni.scheduling import omni_scheduler  # noqa: E402
+from sglang_omni.scheduling.omni_scheduler import OmniScheduler  # noqa: E402
+
+_UPSTREAM_BATCH = object()
+
+
+class _StubScheduler:
+    def __init__(
+        self,
+        *,
+        prefill_decode_interleave: bool = False,
+        running_is_empty: bool = False,
+        running_is_prefill_only: bool = False,
+    ) -> None:
+        self.prefill_decode_interleave = prefill_decode_interleave
+        self._interleave_defer_prefill = False
+        self.prefill_coalesce_requests = 0
+        self.prefill_coalesce_wait_s = 0.06
+        self.prefill_coalesce_when_idle = False
+        self.prefill_coalesce_requires_pending_builds = False
+        self.prefill_coalesce_after_builds_during_decode = False
+        self.chunked_req = None
+        self.waiting_queue: list = []
+        self.running_batch = SimpleNamespace(
+            is_empty=lambda: running_is_empty,
+            is_prefill_only=running_is_prefill_only,
+        )
+        self._request_admission_lock = threading.RLock()
+        self._pending_request_builds: dict = {}
+        self._pending_request_admissions: dict = {}
+        self._backlogged_request_build_payloads: list = []
+
+    def _get_new_batch_prefill_coalesced(self, running_batch):
+        return OmniScheduler._get_new_batch_prefill_coalesced(self, running_batch)
+
+    def get_new_batch_prefill(self):
+        plan = OmniScheduler.get_new_batch_prefill(self, self.running_batch)
+        return plan.batch_to_run
+
+
+@pytest.fixture()
+def upstream():
+    with mock.patch.object(
+        omni_scheduler._Upstream,
+        "get_new_batch_prefill",
+        return_value=NextBatchPlan(batch_to_run=_UPSTREAM_BATCH, running_batch=None),
+    ) as patched:
+        yield patched
+
+
+def test_interleave_off_never_defers(upstream):
+    sched = _StubScheduler(prefill_decode_interleave=False)
+    for _ in range(3):
+        assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+    assert upstream.call_count == 3
+
+
+def test_interleave_alternates_prefill_and_decode(upstream):
+    sched = _StubScheduler(prefill_decode_interleave=True)
+
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+    assert sched.get_new_batch_prefill() is None
+    assert upstream.call_count == 1
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+    assert upstream.call_count == 2
+
+
+def test_interleave_defer_preserves_running_batch(upstream):
+    sched = _StubScheduler(prefill_decode_interleave=True)
+    sched.get_new_batch_prefill()
+    plan = OmniScheduler.get_new_batch_prefill(sched, sched.running_batch)
+    assert plan.batch_to_run is None
+    assert plan.running_batch is sched.running_batch
+
+
+def test_interleave_skips_defer_without_decode_work(upstream):
+    sched = _StubScheduler(prefill_decode_interleave=True, running_is_empty=True)
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+    assert upstream.call_count == 2
+
+
+def test_interleave_skips_defer_for_prefill_only_running_batch(upstream):
+    sched = _StubScheduler(prefill_decode_interleave=True, running_is_prefill_only=True)
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+    assert upstream.call_count == 2
+
+
+def test_interleave_chunked_prefill_bypasses_defer(upstream):
+    sched = _StubScheduler(prefill_decode_interleave=True)
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+    sched.chunked_req = object()
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+    assert upstream.call_count == 2
+
+
+def test_interleave_empty_upstream_plan_does_not_arm_defer():
+    sched = _StubScheduler(prefill_decode_interleave=True)
+    with mock.patch.object(
+        omni_scheduler._Upstream,
+        "get_new_batch_prefill",
+        return_value=NextBatchPlan(batch_to_run=None, running_batch=None),
+    ) as patched:
+        assert sched.get_new_batch_prefill() is None
+        assert sched.get_new_batch_prefill() is None
+        assert patched.call_count == 2
+    assert sched._interleave_defer_prefill is False
+
+
+def test_scheduler_default_keeps_interleave_off():
+    sig = inspect.signature(OmniScheduler.__init__)
+    assert sig.parameters["prefill_decode_interleave"].default is False
+
+
+def test_cli_override_sets_talker_factory_args():
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+    apply_talker_prefill_interleave_cli_overrides(
+        config,
+        talker_prefill_decode_interleave="on",
+    )
+    talker = next(stage for stage in config.stages if stage.name == "talker_ar")
+    talker_args = resolve_stage_factory_args(talker, config)
+    assert talker_args["prefill_decode_interleave"] is True
+
+
+def test_cli_override_off_disables_interleave():
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+    apply_talker_prefill_interleave_cli_overrides(
+        config,
+        talker_prefill_decode_interleave="off",
+    )
+    talker = next(stage for stage in config.stages if stage.name == "talker_ar")
+    talker_args = resolve_stage_factory_args(talker, config)
+    assert talker_args["prefill_decode_interleave"] is False
+
+
+def test_cli_override_default_is_noop():
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+    apply_talker_prefill_interleave_cli_overrides(
+        config,
+        talker_prefill_decode_interleave="default",
+    )
+    talker = next(stage for stage in config.stages if stage.name == "talker_ar")
+    talker_args = resolve_stage_factory_args(talker, config)
+    assert "prefill_decode_interleave" not in talker_args

--- a/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
+++ b/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
@@ -64,7 +64,7 @@ class _StubScheduler:
     def get_new_batch_prefill(self):
         # sglang 0.5.16 takes running_batch in and hands back a NextBatchPlan;
         # unwrap it so the assertions below stay about the gate decision.
-        plan = OmniScheduler.get_new_batch_prefill(self, self.running_batch)
+        plan = OmniScheduler._get_new_batch_prefill_coalesced(self, self.running_batch)
         return plan.batch_to_run
 
 


### PR DESCRIPTION
## Motivation

When prefills arrive while talker decodes are running, an optional scheduler policy can defer one prefill turn so decode work gets a chance to run.

## Modifications

- Narrowed the PR to the interleave-only implementation `fe351bb0`.
- CLI → factory → Qwen talker scheduler → `OmniScheduler` wiring is covered by a production factory-path regression.
- The old mixed-chunk default change is deliberately removed; it was a no-op under the current default configuration and should not be part of this PR.
- Disabled is the default and delegates to the existing coalesced scheduler behavior.

## Accuracy Test

Unit coverage includes disabled/default/on CLI behavior and scheduler no-defer behavior when the gate is off.

## Benchmark & Profiling

Current-main H200 c8/n128 paired cold boots both completed with zero failures and identical text cohorts:

- QPS: +14.8% and +1.3%.
- Mean latency: −13.0% and −1.9%.
- First-audio time was not uniformly better (second boot +7.3%).

This supports the narrowed opt-in feature and no broad performance claim. c1/c32 have not been rerun for this rebuilt head.

## Validation

- Official-image targeted suite: 46 passed.
- `git diff --check`, Black, isort, and compilation checks: pass.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.

## CI

Please add the `run-ci` label for this narrowed, default-off change.
