### PR TITLE
[Qwen3-Omni Perf] Encoder batching: tunable micro-batch wait + in-batch dedup

### DIFF
--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -276,21 +276,21 @@ def _nested_tensor_bytes(value: Any) -> int:
 def _encoder_batch_wait_ms() -> int:
     raw = os.getenv("SGLANG_OMNI_ENCODER_BATCH_WAIT_MS", "")
     if not raw:
-        return 50
+        return 0
     try:
         value = int(raw)
     except ValueError:
         logger.warning(
-            "Ignoring non-integer SGLANG_OMNI_ENCODER_BATCH_WAIT_MS=%r; using 50",
+            "Ignoring non-integer SGLANG_OMNI_ENCODER_BATCH_WAIT_MS=%r; using 0",
             raw,
         )
-        return 50
+        return 0
     if value < 0:
         logger.warning(
-            "Ignoring negative SGLANG_OMNI_ENCODER_BATCH_WAIT_MS=%d; using 50",
+            "Ignoring negative SGLANG_OMNI_ENCODER_BATCH_WAIT_MS=%d; using 0",
             value,
         )
-        return 50
+        return 0
     return value
 
 
@@ -897,8 +897,8 @@ def create_image_encoder_executor(
                     metadata={"modality": "image", "batch_size": len(payloads)},
                 )
 
-    # Preserve the calibrated image-encoder batching shape and add a small
-    # batch_wait so video benchmarks at concurrency=16 batch together.
+    # Preserve the calibrated image-encoder batching shape while allowing
+    # deployments to opt into a batch wait through the shared encoder knob.
     return SimpleScheduler(
         _encode,
         batch_compute_fn=_encode_batch,

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -662,6 +662,9 @@ def _batch_audio_encoder_payloads(
 ) -> list[StagePayload]:
     results: list[StagePayload | None] = [None] * len(payloads)
     active: list[tuple[int, StagePayload, Any, Any]] = []
+    duplicate_waiters: dict[str, list[tuple[int, StagePayload, Any]]] = {}
+    active_cache_keys: set[str] = set()
+    active_cache_leaders: dict[str, str] = {}
 
     for idx, payload in enumerate(payloads):
         state = load_state(payload)
@@ -695,7 +698,23 @@ def _batch_audio_encoder_payloads(
             )
             continue
 
+        cache_key = request.cache_key
+        if cache_key is not None and cache_key in active_cache_keys:
+            duplicate_waiters.setdefault(cache_key, []).append((idx, payload, state))
+            _trace_encoder_cache(
+                AUDIO_STAGE,
+                "dedup_same_batch",
+                request_id=payload.request_id,
+                cache_key=cache_key,
+                input_bytes=_nested_tensor_bytes(request.model_inputs),
+                detail=f"leader={active_cache_leaders[cache_key]}",
+            )
+            continue
+
         active.append((idx, payload, state, request))
+        if cache_key is not None:
+            active_cache_keys.add(cache_key)
+            active_cache_leaders[cache_key] = payload.request_id
 
     if not active:
         return [result for result in results if result is not None]
@@ -737,6 +756,7 @@ def _batch_audio_encoder_payloads(
     embeds = combined["audio_embeds"]
     row_cursor = 0
     token_cursor = 0
+    computed_by_cache_key: dict[str, dict[str, Any]] = {}
     for item in normalized:
         row_end = row_cursor + item["count"]
         req_output_lengths = output_lengths[row_cursor:row_end]
@@ -755,10 +775,20 @@ def _batch_audio_encoder_payloads(
             cache=cache,
             result=stage_result,
         )
+        if item["request"].cache_key is not None:
+            computed_by_cache_key[item["request"].cache_key] = stage_result
         apply_encoder_result(item["state"], stage_name=AUDIO_STAGE, result=stage_result)
         results[item["idx"]] = store_state(item["payload"], item["state"])
         row_cursor = row_end
         token_cursor = token_end
+
+    for cache_key, waiters in duplicate_waiters.items():
+        stage_result = computed_by_cache_key.get(cache_key)
+        if stage_result is None:
+            continue
+        for idx, payload, state in waiters:
+            apply_encoder_result(state, stage_name=AUDIO_STAGE, result=stage_result)
+            results[idx] = store_state(payload, state)
 
     return [result for result in results if result is not None]
 

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -273,6 +273,27 @@ def _nested_tensor_bytes(value: Any) -> int:
     return 0
 
 
+def _encoder_batch_wait_ms() -> int:
+    raw = os.getenv("SGLANG_OMNI_ENCODER_BATCH_WAIT_MS", "")
+    if not raw:
+        return 50
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "Ignoring non-integer SGLANG_OMNI_ENCODER_BATCH_WAIT_MS=%r; using 50",
+            raw,
+        )
+        return 50
+    if value < 0:
+        logger.warning(
+            "Ignoring negative SGLANG_OMNI_ENCODER_BATCH_WAIT_MS=%d; using 50",
+            value,
+        )
+        return 50
+    return value
+
+
 def _encoder_cache_trace_enabled() -> bool:
     value = os.getenv("SGLANG_OMNI_TRACE_ENCODER_CACHE", "")
     return value.lower() not in ("", "0", "false", "no")
@@ -852,7 +873,7 @@ def create_image_encoder_executor(
         _encode,
         batch_compute_fn=_encode_batch,
         max_batch_size=32,
-        max_batch_wait_ms=50,
+        max_batch_wait_ms=_encoder_batch_wait_ms(),
         request_cost_fn=_create_image_encoder_request_cost_fn(model),
         max_batch_cost=QWEN3_IMAGE_ENCODER_BATCH_BUDGET_BYTES,
     )
@@ -924,7 +945,7 @@ def create_audio_encoder_executor(
         _encode,
         batch_compute_fn=_encode_batch,
         max_batch_size=32,
-        max_batch_wait_ms=50,
+        max_batch_wait_ms=_encoder_batch_wait_ms(),
     )
 
 

--- a/tests/unit_test/qwen3_omni/test_audio_encoder_batch_dedup.py
+++ b/tests/unit_test/qwen3_omni/test_audio_encoder_batch_dedup.py
@@ -1,13 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Same-batch dedup for the Qwen3-Omni audio encoder batch path."""
+"""Qwen3-Omni encoder batching behavior."""
 from __future__ import annotations
 
 from typing import Any
 
+import pytest
 import torch
 
 from sglang_omni.models.qwen3_omni.payload_types import Qwen3OmniPipelineState
-from sglang_omni.models.qwen3_omni.stages import _batch_audio_encoder_payloads
+from sglang_omni.models.qwen3_omni.stages import (
+    _batch_audio_encoder_payloads,
+    _encoder_batch_wait_ms,
+)
 from sglang_omni.proto import OmniRequest, StagePayload
 
 
@@ -24,6 +28,18 @@ class _FakeAudioEncoder:
             "audio_feature_lengths": lengths,
             "audio_output_lengths": lengths,
         }
+
+
+@pytest.mark.parametrize("raw", [None, "invalid", "-1"])
+def test_encoder_batch_wait_falls_back_to_zero(
+    monkeypatch: pytest.MonkeyPatch, raw: str | None
+) -> None:
+    if raw is None:
+        monkeypatch.delenv("SGLANG_OMNI_ENCODER_BATCH_WAIT_MS", raising=False)
+    else:
+        monkeypatch.setenv("SGLANG_OMNI_ENCODER_BATCH_WAIT_MS", raw)
+
+    assert _encoder_batch_wait_ms() == 0
 
 
 def _payload(request_id: str, cache_key: str, time_steps: int) -> StagePayload:

--- a/tests/unit_test/qwen3_omni/test_audio_encoder_batch_dedup.py
+++ b/tests/unit_test/qwen3_omni/test_audio_encoder_batch_dedup.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Same-batch dedup for the Qwen3-Omni audio encoder batch path."""
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from sglang_omni.models.qwen3_omni.payload_types import Qwen3OmniPipelineState
+from sglang_omni.models.qwen3_omni.stages import _batch_audio_encoder_payloads
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+class _FakeAudioEncoder:
+    def __init__(self) -> None:
+        self.calls: list[int] = []
+
+    def __call__(self, **kwargs: Any) -> dict[str, torch.Tensor]:
+        lengths = kwargs["audio_feature_lengths"].to(dtype=torch.long).view(-1)
+        self.calls.append(int(lengths.shape[0]))
+        total = int(lengths.sum().item())
+        return {
+            "audio_embeds": torch.arange(total, dtype=torch.float32).unsqueeze(1),
+            "audio_feature_lengths": lengths,
+            "audio_output_lengths": lengths,
+        }
+
+
+def _payload(request_id: str, cache_key: str, time_steps: int) -> StagePayload:
+    return StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs="hi"),
+        data={
+            "encoder_inputs": {
+                "audio_encoder": {
+                    "cache_key": cache_key,
+                    "input_features": torch.ones(4, time_steps),
+                    "audio_feature_lengths": torch.tensor([time_steps]),
+                }
+            }
+        },
+    )
+
+
+def test_audio_encoder_batch_dedups_same_cache_key() -> None:
+    model = _FakeAudioEncoder()
+    payloads = [
+        _payload("req-a1", "spk-a", 3),
+        _payload("req-b", "spk-b", 5),
+        _payload("req-a2", "spk-a", 3),
+    ]
+
+    out = _batch_audio_encoder_payloads(payloads, model=model, cache=None)
+
+    assert model.calls == [2]
+    assert len(out) == 3
+    states = [Qwen3OmniPipelineState.from_dict(p.data) for p in out]
+    embeds = [s.encoder_outs["audio_encoder"]["audio_embeds"] for s in states]
+    assert all(e.shape[0] == n for e, n in zip(embeds, [3, 5, 3]))
+    assert torch.equal(embeds[0], embeds[2])
+
+
+def test_audio_encoder_batch_without_cache_keys_runs_every_request() -> None:
+    model = _FakeAudioEncoder()
+    payloads = [_payload("req-1", "k1", 3), _payload("req-2", "k2", 3)]
+    for payload in payloads:
+        payload.data["encoder_inputs"]["audio_encoder"].pop("cache_key")
+
+    out = _batch_audio_encoder_payloads(payloads, model=model, cache=None)
+
+    assert model.calls == [2]
+    assert len(out) == 2


### PR DESCRIPTION
## Summary

This PR makes Qwen3-Omni encoder micro-batch waiting tunable, defaults the wait to zero, and deduplicates identical audio-encoder cache keys within the same batch.

### Encoder batch wait

`SGLANG_OMNI_ENCODER_BATCH_WAIT_MS` now defaults to `0`. Set it to a non-negative integer such as `50` to opt into a batching window.

The final configuration was benchmarked with a same-GPU, paired three-arm design on one H200 using SeedTTS EN, natural EOS, temperature 0, and interleaved boots:

- A: `main` at `0f7521ac`
- B: PR head at `a1d559e8`, knob unset (the prior `50 ms` default)
- C: PR head at `a1d559e8`, `SGLANG_OMNI_ENCODER_BATCH_WAIT_MS=0`

The table below is the final PR behavior, C (`wait=0` plus same-batch dedup), compared with A (`main`). Positive QPS and negative latency deltas are improvements.

| Concurrency / n | Cohort | QPS | TTFT mean | TTFT p95 | TTFA mean | TTFA p95 |
|---|---:|---:|---:|---:|---:|---:|
| c1 / 48 | 1 | +0.4% | −30.4% | −7.4% | −7.0% | +15.6% |
| c8 / 64 | 1 | −0.4% | −27.8% | +8.3% | −20.3% | −12.5% |
| c32 / 384 | 1 / 2 | +2.3% / +1.9% | −17.3% / −21.8% | −3.9% / −34.9% | −10.6% / +5.1% | −33.8% / −14.9% |
| c64 / 768 | 1 / 2 | −0.2% / −3.7% | −22.2% / −5.8% | −27.2% / −22.5% | +1.6% / +1.5% | −0.1% / −2.8% |

Conclusions:

- c32 is a clear net win: both cohorts improve QPS, TTFT mean/p95, and TTFA p95. TTFA mean is mixed (−10.6% / +5.1%).
- c64 is a latency/throughput trade-off: TTFT mean and p95 improve in both cohorts, while QPS is flat to −3.7% and TTFA mean regresses by about 1.5%.
- c1 and c8 each have one cohort, so treat their tail results as directional; mean TTFT improves by about 28–30% with essentially flat QPS.
- The text MD5 gate matched across arms and all measured requests completed without failures.

The isolated C-vs-B comparison shows that zero wait can trade throughput for latency at high concurrency: QPS changed by −5.5% / −6.4% at c32 and −2.2% / −5.6% at c64. Same-batch dedup offsets that cost in the end-to-end C-vs-A comparison above.

These measurements cover the speech/audio-encoder path. The image encoder uses the same knob but was not benchmarked separately.

### Same-batch audio encoder dedup

Voice-clone batches frequently carry identical reference audio. The audio encoder now computes each cache key once per batch and fans the result out to duplicate requests. A unit test covers both deduplicated and non-keyed batches.

### Removed from this PR

Concurrent preprocessing dispatch was removed after same-card paired validation showed a non-reproducible benefit with negative expected value, and the shared `AsyncClient` event-loop ownership issue raised in review remains unresolved. It can be revisited separately if a stable win is demonstrated.

## Validation

- `python -m pytest -q tests/unit_test/qwen3_omni/test_audio_encoder_batch_dedup.py` — 5 passed
- Same-GPU paired benchmark described above; all requests completed and cross-arm text MD5 gates matched
