### PR TITLE
[Release] Prepare SGLang-Omni 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 ## News
 
 - [2026/08] 🎵 Day-0 support for [MiniMax Music 3](https://huggingface.co/MiniMaxAI/MiniMax-Music3): lyrics + caption → 32 kHz stereo song on `/v1/audio/speech`. \[[Cookbook](https://sgl-project.github.io/sglang-omni/cookbook/minimax_music3.html)\]
-- [2026/08] 🚀 SGLang-Omni **v0.1.1** is on [PyPI](https://pypi.org/project/sglang-omni/). Install with `uv pip install "sglang-omni==0.1.1"`. \[[Installation](https://sgl-project.github.io/sglang-omni/get_started/installation.html)\] \[[Release notes](https://sgl-project.github.io/sglang-omni/get_started/release_notes.html)\]
+- [2026/08] 🚀 SGLang-Omni **v0.1.2** is on [PyPI](https://pypi.org/project/sglang-omni/). Install with `uv pip install "sglang-omni==0.1.2"`. \[[Installation](https://sgl-project.github.io/sglang-omni/get_started/installation.html)\] \[[Release notes](https://sgl-project.github.io/sglang-omni/get_started/release_notes.html)\]
 - [2026/08] 🚀 TTS architecture refactor: shared pipeline state, engine construction, reference encoding, capability metadata, and vocoder scheduling. \[[Roadmap](https://github.com/sgl-project/sglang-omni/issues/985)\] \[[Blog](https://github.com/zhaochenyang20/Awesome-ML-SYS-Tutorial/blob/main/sglang/sglang-omni/tts-refactor.md)\]
 - [2026/06] 🔥 MOSS-TTS Local Transformer v1.5 on SGLang-Omni with native-streaming 48 kHz speech. \[[Blog](https://lmsys.org/blog/2026-06-17-moss-tts-local-v15/)\] \[[Cookbook](https://sgl-project.github.io/sglang-omni/cookbook/moss_tts_local.html)\]
 - [2026/06] 🔥 Higgs Audio v3 TTS for real-time, controllable speech. \[[Blog](https://lmsys.org/blog/2026-06-04-higgs-audio-v3-tts/)\] \[[Cookbook](https://sgl-project.github.io/sglang-omni/cookbook/higgs_tts.html)\]

--- a/docs/cookbook/qwen3_omni.md
+++ b/docs/cookbook/qwen3_omni.md
@@ -14,7 +14,7 @@ docker run -it --shm-size 32g --gpus all hongccc/sglang-omni:dev /bin/zsh
 
 ```bash
 uv venv .venv -p 3.12 && source .venv/bin/activate
-uv pip install "sglang-omni==0.1.1"
+uv pip install "sglang-omni==0.1.2"
 ```
 
 See [Installation](../get_started/installation.md) for Docker digests and source installs.

--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -1,6 +1,6 @@
 # 🚀 Installation
 
-Current stable release: **v0.1.1** on [PyPI](https://pypi.org/project/sglang-omni/).
+Current stable release: **v0.1.2** on [PyPI](https://pypi.org/project/sglang-omni/).
 
 Two install paths. Docker is recommended — UCX, flash-attn, sglang, and CUDA are prebuilt.
 
@@ -39,7 +39,7 @@ docker run -it \
 uv venv .venv -p 3.12
 source .venv/bin/activate
 
-uv pip install "sglang-omni==0.1.1"
+uv pip install "sglang-omni==0.1.2"
 ```
 
 ## 🛠️ Option B: Manual install
@@ -55,7 +55,7 @@ Then:
 uv venv .venv -p 3.12
 source .venv/bin/activate
 
-uv pip install "sglang-omni==0.1.1"
+uv pip install "sglang-omni==0.1.2"
 ```
 
 Latest on the index without a pin: `uv pip install sglang-omni`.

--- a/docs/get_started/release_notes.md
+++ b/docs/get_started/release_notes.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## v0.1.2
+
+Install: `uv pip install "sglang-omni==0.1.2"`.
+
+Highlights since v0.1.1:
+
+- **Models and hardware**: MiniMax Music 3 and experimental Intel XPU support for Qwen3-ASR, Qwen3-TTS, and Qwen3-Omni
+- **ASR**: automatic Qwen3-ASR language detection, `/v1/audio/translations`, long-audio support, and performance improvements
+- **TTS and omni**: improved Qwen3-TTS playback continuity and Qwen3-Omni prefill and Code2Wav performance
+- **Serving and runtime**: `sglang serve --model-type omni`, realtime barge-in, and communication and runtime fixes
+
 ## v0.1.1
 
 First PyPI release. Install: `uv pip install "sglang-omni==0.1.1"`.

--- a/sglang_omni/__init__.py
+++ b/sglang_omni/__init__.py
@@ -12,7 +12,7 @@ from importlib import import_module
 
 # This is the single source for both runtime and distribution metadata. Keep
 # release bumps here; setuptools reads it through tool.setuptools.dynamic.
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 _EXPORTS: dict[str, tuple[str, str]] = {
     # client


### PR DESCRIPTION
## Motivation

Prepare SGLang-Omni 0.1.2 as the next pinnable PyPI release from the latest merged `main` cutoff.

## Modifications

- Bump the single package version source from 0.1.1 to 0.1.2.
- Update the stable installation and Qwen3-Omni cookbook pins to 0.1.2.
- Refresh the existing README release announcement and add concise 0.1.2 release notes covering the changes since 0.1.1.

## Related Issues

Related to #1399.

## Accuracy Test

Not applicable; this PR changes release metadata and documentation only.

## Benchmark & Profiling

Not applicable; this PR does not change runtime or model behavior.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests. Not applicable for release metadata and documentation changes.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed. Not applicable for this PR.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
