### PR TITLE
[NPU] Add Ascend installation manifest and helper

### DIFF
--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -6,6 +6,8 @@ Two install paths. Docker is recommended — UCX, flash-attn, sglang, and CUDA a
 
 > **Intel GPU (XPU)?** This page targets **NVIDIA CUDA**. For Intel Arc GPUs, see [Installation — Intel XPU](./installation_xpu.md), which uses [`pyproject_xpu.toml`](../../pyproject_xpu.toml) + the PyTorch XPU wheel index instead of the CUDA-only pins below.
 
+> **Ascend NPU?** See [Installation — Ascend NPU](./installation_npu.md) for the supported software stack, prerequisites, and installation helper.
+
 ## 🐳 Option A: Docker (recommended)
 
 **1. Pull the image**

--- a/docs/get_started/installation_npu.md
+++ b/docs/get_started/installation_npu.md
@@ -34,11 +34,11 @@ bash scripts/npu/install_npu.sh --check
 bash scripts/npu/install_npu.sh
 ```
 
-The precheck accepts the SGLang `0.5.18` release line (`>=0.5.18,<0.5.19`).
-This includes development, pre-release, post-release, and local builds whose
-numeric release segment is `0.5.18`, such as `0.5.18.dev7+g<git-sha>`. It rejects
-all `0.5.19` builds. On a mismatch it reports both the supported range and the
-installed version. The precheck also verifies the required Python packages,
+The precheck accepts the SGLang `0.5.18` release line. This includes development,
+pre-release, post-release, and local builds whose numeric release segment starts
+with `0.5.18`, such as `0.5.18.dev7+g<git-sha>`. It rejects other release lines,
+including all `0.5.19` builds. On a mismatch it reports both the supported line
+and the installed version. The precheck also verifies the required Python packages,
 matching `torch` and `torch_npu` major-minor versions, NPU availability, and a
 small NPU matrix multiplication. Run `bash scripts/npu/install_npu.sh --help`
 for optional extras, non-editable installation, and environments where devices

--- a/docs/get_started/installation_npu.md
+++ b/docs/get_started/installation_npu.md
@@ -67,6 +67,7 @@ restores the CUDA one:
 ```bash
 git clone https://github.com/sgl-project/sglang-omni.git
 cd sglang-omni
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
 
 # dry-run first — shows the commands, installs nothing
 PYTHON=$(which python) scripts/npu/install_npu.sh --check
@@ -74,6 +75,11 @@ PYTHON=$(which python) scripts/npu/install_npu.sh --check
 # editable install
 PYTHON=$(which python) scripts/npu/install_npu.sh
 ```
+
+The preflight verifies matching torch/torch_npu major-minor versions, at least one
+available NPU, and a small NPU MatMul. On a container build host where devices are
+intentionally not exposed, pass `--skip-device-check`; dependency imports and version
+checks still run.
 
 Pick extras with `--extras` (comma-separated):
 

--- a/docs/get_started/installation_npu.md
+++ b/docs/get_started/installation_npu.md
@@ -34,8 +34,9 @@ bash scripts/npu/install_npu.sh --check
 bash scripts/npu/install_npu.sh
 ```
 
-The precheck verifies the required Python packages, matching `torch` and
-`torch_npu` major-minor versions, NPU availability, and a small NPU matrix
-multiplication. Run `bash scripts/npu/install_npu.sh --help` for optional extras,
-non-editable installation, and environments where devices are intentionally not
-exposed during the build.
+The precheck verifies the exact supported SGLang release (local build metadata
+such as `0.5.18+ascend` is accepted), the required Python packages, matching
+`torch` and `torch_npu` major-minor versions, NPU availability, and a small NPU
+matrix multiplication. Run `bash scripts/npu/install_npu.sh --help` for optional
+extras, non-editable installation, and environments where devices are
+intentionally not exposed during the build.

--- a/docs/get_started/installation_npu.md
+++ b/docs/get_started/installation_npu.md
@@ -34,9 +34,11 @@ bash scripts/npu/install_npu.sh --check
 bash scripts/npu/install_npu.sh
 ```
 
-The precheck verifies the exact supported SGLang release (local build metadata
-such as `0.5.18+ascend` is accepted), the required Python packages, matching
-`torch` and `torch_npu` major-minor versions, NPU availability, and a small NPU
-matrix multiplication. Run `bash scripts/npu/install_npu.sh --help` for optional
-extras, non-editable installation, and environments where devices are
-intentionally not exposed during the build.
+The precheck verifies the supported SGLang release. It accepts the stable
+release, local builds such as `0.5.18+ascend`, and traceable source builds from
+the same release line such as `0.5.18.dev7+g<git-sha>`. It also verifies the
+required Python packages, matching `torch` and `torch_npu` major-minor versions,
+NPU availability, and a small NPU matrix multiplication. Run
+`bash scripts/npu/install_npu.sh --help` for optional extras, non-editable
+installation, and environments where devices are intentionally not exposed
+during the build.

--- a/docs/get_started/installation_npu.md
+++ b/docs/get_started/installation_npu.md
@@ -1,0 +1,176 @@
+# 🚀 Installation — Huawei Ascend NPU
+
+Installs `sglang-omni` for **Huawei Ascend NPUs**. The default
+[installation](./installation.md) pins CUDA-only wheels and would clobber a `torch+npu` stack.
+Mirroring upstream SGLang ([Ascend NPU docs](https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu),
+`docker/npu.Dockerfile`), the NPU path uses a **separate `pyproject_npu.toml`** plus a pre-installed
+`torch_npu` / `triton-ascend` stack.
+
+## Why a separate pyproject
+
+`pip install -e .` resolves the CUDA [`pyproject.toml`](../../pyproject.toml), whose torch
+family and CUDA-only wheels would replace the `torch+npu` stack.
+[`pyproject_npu.toml`](../../pyproject_npu.toml) encodes the NPU replacements.
+
+Core deps cover the supported models (Qwen3-ASR / TTS / Omni) plus the API server;
+`[eval]` adds SeedTTS/WER tooling and `[all]` aliases it. Other model families
+(S2-Pro, Ming-Omni, Voxtral-TTS) are CUDA-only and are not offered here.
+
+> **`--no-build-isolation` is required** — without it pip emits a legacy in-tree
+> `egg-info` instead of a PEP 660 editable install. The installer always passes it.
+> Because of that pip does not install build requirements either, so this
+> environment's own `setuptools` must be **≥ 77.0.0**: older releases reject the
+> PEP 639 license metadata with ``invalid pyproject.toml config: `project.license` ``.
+> The installer checks this before building; upgrade with
+> `pip install -U 'setuptools>=77.0.0'`.
+
+## Prerequisites
+
+The NPU stack is **not** installed by `pyproject_npu.toml` or the install script.
+You must set up the following components first, following the
+[SGLang Ascend NPU guide](https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu):
+
+| Component | Version | Install |
+|-----------|---------|---------|
+| CANN toolkit | 9.0.0 | [Installation guide](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/900/softwareinst/instg/instg_0008.html) |
+| HDK (driver/firmware) | 25.5.2 | [Download](https://www.hiascend.com/hardware/firmware-drivers/community) |
+| torch (CPU) | 2.10.0 | `pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --index-url https://download.pytorch.org/whl/cpu` |
+| torch_npu | 2.10.0 | [gitcode.com/Ascend/pytorch/releases](https://gitcode.com/Ascend/pytorch/releases) (arch-specific wheel) |
+| triton-ascend | 3.2.1.dev20260530 | `pip install triton-ascend==3.2.1.dev20260530 --extra-index-url=https://mirrors.huaweicloud.com/ascend/repos/pypi/nightly --trusted-host mirrors.huaweicloud.com` |
+| memfabric-hybrid | 1.0.8 | `pip install memfabric-hybrid==1.0.8` (PD disaggregation only) |
+| sgl-kernel-npu | latest | [sgl-project/sgl-kernel-npu](https://github.com/sgl-project/sgl-kernel-npu) releases |
+
+> **Python 3.11 only** — upstream SGLang's NPU build currently supports `python==3.11`.
+> Use conda if your system Python differs: `conda create -n sglang-omni-npu python=3.11`.
+
+### torch_npu installation
+
+`torch_npu` wheels are arch-specific and hosted on Huawei's gitcode mirror, not on PyPI.
+Download the matching wheel for your architecture:
+
+```bash
+# aarch64 (Atlas 800I A2 / A3)
+pip install https://gitcode.com/Ascend/pytorch/releases/download/v26.0.0-pytorch2.10.0/torch_npu-2.10.0-cp311-cp311-manylinux_2_28_aarch64.whl
+
+# x86_64
+pip install https://gitcode.com/Ascend/pytorch/releases/download/v26.0.0-pytorch2.10.0/torch_npu-2.10.0-cp311-cp311-manylinux_2_28_x86_64.whl
+```
+
+## 🛠️ Install sglang-omni
+
+The helper swaps in `pyproject_npu.toml`, installs with `--no-build-isolation`, then
+restores the CUDA one:
+
+```bash
+git clone https://github.com/sgl-project/sglang-omni.git
+cd sglang-omni
+
+# dry-run first — shows the commands, installs nothing
+PYTHON=$(which python) scripts/npu/install_npu.sh --check
+
+# editable install
+PYTHON=$(which python) scripts/npu/install_npu.sh
+```
+
+Pick extras with `--extras` (comma-separated):
+
+```bash
+scripts/npu/install_npu.sh --extras eval           # core + SeedTTS/WER eval + tests
+scripts/npu/install_npu.sh --extras all            # alias for eval
+```
+
+Or do it manually (the same steps the script automates):
+
+```bash
+cp pyproject.toml .pyproject.cuda.bak
+cp pyproject_npu.toml pyproject.toml
+pip install -e . --no-build-isolation
+cp -f .pyproject.cuda.bak pyproject.toml && rm .pyproject.cuda.bak   # restore CUDA pyproject
+```
+
+### SGLang (installed separately)
+
+`sglang` is intentionally **not** pinned, so the install above leaves an existing NPU build alone.
+It cannot be pinned even as a range: every published wheel requires `flashinfer_python[cu13]` and the
+`nvidia-*` runtime, so **any** specifier pulls the CUDA stack over `torch+npu`. Build from source:
+
+```bash
+git clone https://github.com/sgl-project/sglang && cd sglang
+git checkout v0.5.16   # the pinned release
+cd python && cp pyproject_npu.toml pyproject.toml
+pip install -e . --no-build-isolation
+```
+
+Use that commit: the NPU port targets this SGLang revision's APIs and does not carry
+version-compatibility shims. A VCS requirement (`pip install "sglang @ git+…"`) does **not** work:
+pip reads the checkout's `python/pyproject.toml`, which pins CUDA torch; only the swap above
+selects the NPU manifest.
+
+## Verify
+
+```bash
+# import works from anywhere now (package installed, not just cwd-on-path)
+python -c "import sglang_omni, torch; print(sglang_omni.__file__, torch.__version__)"
+which sgl-omni
+
+# device-layer unit tests (CPU, no NPU) — needs pytest, which ships in the
+# `[eval]` extra (install with `.[eval]`, or `pip install pytest` first)
+pytest tests/unit_test/test_platforms.py -v
+```
+
+## Serve
+
+### Qwen3-ASR (speech-to-text, single NPU)
+
+```bash
+sgl-omni serve --model-path /path/to/Qwen3-ASR-1.7B --host 0.0.0.0 --port 8000
+# transcribe:
+curl -s -X POST http://localhost:8000/v1/audio/transcriptions \
+  -F "file=@sample.wav" -F "model=/path/to/Qwen3-ASR-1.7B"
+```
+
+### Qwen3-TTS (text-to-speech, single NPU)
+
+Qwen3-TTS needs the upstream `qwen-tts` package, which is not pinned in `pyproject_npu.toml`.
+Install it with `--no-deps` to avoid version conflicts:
+
+```bash
+apt-get update && apt-get install -y sox   # the Python sox package shells out to it
+pip install --no-deps sox einops
+pip install --no-deps qwen-tts==0.1.1
+```
+
+```bash
+sgl-omni serve --model-path /path/to/Qwen3-TTS-12Hz-1.7B-Base --host 0.0.0.0 --port 8000
+# Base checkpoint clones a reference voice — pass ref_audio (+ ref_text):
+curl -s -X POST http://localhost:8000/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{"model":"/path/to/Qwen3-TTS-12Hz-1.7B-Base","input":"Hello from Ascend NPU.",
+       "voice":"default","ref_audio":"/path/to/ref.wav","ref_text":"reference transcript",
+       "response_format":"wav"}' -o out.wav
+```
+
+### Qwen3-Omni (30B-A3B MoE, multi-NPU tensor parallel)
+
+The 30B MoE does not fit one card; shard the thinker across NPUs with tensor parallelism.
+`--text-only` serves the thinker (chat) without the talker/speech stages:
+
+```bash
+# thinker across 8 cards (TP=8). Large shards over shared storage load slowly, so give
+# startup more headroom than the default 600 s.
+export SGLANG_OMNI_STARTUP_TIMEOUT=1800
+sgl-omni serve --model-path /path/to/Qwen3-Omni-30B-A3B-Instruct \
+  --text-only --thinker-tp-size 8 --thinker-gpus 0,1,2,3,4,5,6,7 \
+  --host 0.0.0.0 --port 8000
+# chat:
+curl -s -X POST http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"/path/to/Qwen3-Omni-30B-A3B-Instruct",
+       "messages":[{"role":"user","content":"What is Ascend NPU?"}],"max_tokens":64}'
+```
+
+Health check for any of the above: `curl http://localhost:8000/v1/models`.
+
+> **Expected on NPU:** `Failed to import mooncake` / `Failed to import nixl` warnings are harmless
+> — those CUDA-only transfer backends are omitted; tensors move through the `shm` relay instead
+> (or `memfabric` if installed).

--- a/docs/get_started/installation_npu.md
+++ b/docs/get_started/installation_npu.md
@@ -18,7 +18,7 @@ linked documentation. Python 3.11 is the verified configuration.
 | `triton-ascend` | Match the selected PyTorch and CANN releases | Yes | Yes | [Official documentation](https://gitcode.com/Ascend/triton-ascend/blob/main/docs/en/quick_start.md) |
 | `sgl-kernel-npu` | Match PyTorch, Python, CANN, hardware, and architecture | Yes | Yes | [Official documentation](https://github.com/sgl-project/sgl-kernel-npu/releases) |
 | `memfabric-hybrid` | Compatible release | No (PD disaggregation only) | Yes | [Official documentation](https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu) |
-| SGLang for NPU | `v0.5.16` | Yes | Yes | [Official documentation](https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu) |
+| SGLang for NPU | `v0.5.18` | Yes | Yes | [Official documentation](https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu) |
 
 ## Install sglang-omni
 

--- a/docs/get_started/installation_npu.md
+++ b/docs/get_started/installation_npu.md
@@ -37,8 +37,8 @@ bash scripts/npu/install_npu.sh
 The precheck accepts the SGLang `0.5.18` release line. This includes development,
 pre-release, post-release, and local builds whose numeric release segment starts
 with `0.5.18`, such as `0.5.18.dev7+g<git-sha>`. It rejects other release lines,
-including all `0.5.19` builds. On a mismatch it reports both the supported line
-and the installed version. The precheck also verifies the required Python packages,
+including later releases. On a mismatch it reports both the supported line and
+the installed version. The precheck also verifies the required Python packages,
 matching `torch` and `torch_npu` major-minor versions, NPU availability, and a
 small NPU matrix multiplication. Run `bash scripts/npu/install_npu.sh --help`
 for optional extras, non-editable installation, and environments where devices

--- a/docs/get_started/installation_npu.md
+++ b/docs/get_started/installation_npu.md
@@ -34,11 +34,12 @@ bash scripts/npu/install_npu.sh --check
 bash scripts/npu/install_npu.sh
 ```
 
-The precheck verifies the supported SGLang release. It accepts the stable
-release, local builds such as `0.5.18+ascend`, and traceable source builds from
-the same release line such as `0.5.18.dev7+g<git-sha>`. It also verifies the
-required Python packages, matching `torch` and `torch_npu` major-minor versions,
-NPU availability, and a small NPU matrix multiplication. Run
-`bash scripts/npu/install_npu.sh --help` for optional extras, non-editable
-installation, and environments where devices are intentionally not exposed
-during the build.
+The precheck accepts the SGLang `0.5.18` release line (`>=0.5.18,<0.5.19`).
+This includes development, pre-release, post-release, and local builds whose
+numeric release segment is `0.5.18`, such as `0.5.18.dev7+g<git-sha>`. It rejects
+all `0.5.19` builds. On a mismatch it reports both the supported range and the
+installed version. The precheck also verifies the required Python packages,
+matching `torch` and `torch_npu` major-minor versions, NPU availability, and a
+small NPU matrix multiplication. Run `bash scripts/npu/install_npu.sh --help`
+for optional extras, non-editable installation, and environments where devices
+are intentionally not exposed during the build.

--- a/docs/get_started/installation_npu.md
+++ b/docs/get_started/installation_npu.md
@@ -1,8 +1,9 @@
-# Installation — Huawei Ascend NPU
+# Installation — Ascend NPU
 
 Install the Ascend software stack and NPU build of SGLang before installing
-`sglang-omni`. The helper script installs only `sglang-omni`; it does not install
-or change any prerequisite in the table below.
+`sglang-omni`. The helper script
+[`install_npu.sh`](../../scripts/npu/install_npu.sh) installs only
+`sglang-omni`; it does not install or change any prerequisite in the table below.
 
 ## Prerequisites
 

--- a/docs/get_started/installation_npu.md
+++ b/docs/get_started/installation_npu.md
@@ -1,155 +1,40 @@
-# 🚀 Installation — Huawei Ascend NPU
+# Installation — Huawei Ascend NPU
 
-Installs `sglang-omni` for **Huawei Ascend NPUs**. The default
-[installation](./installation.md) pins CUDA-only wheels and would clobber a `torch+npu` stack.
-Mirroring upstream SGLang ([Ascend NPU docs](https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu),
-`docker/npu.Dockerfile`), the NPU path uses a **separate `pyproject_npu.toml`** plus a pre-installed
-`torch_npu` / `triton-ascend` stack.
-
-## Why a separate pyproject
-
-`pip install -e .` resolves the CUDA [`pyproject.toml`](../../pyproject.toml), whose torch
-family and CUDA-only wheels would replace the `torch+npu` stack.
-[`pyproject_npu.toml`](../../pyproject_npu.toml) encodes the NPU replacements.
-
-Core dependencies cover Qwen3-Omni plus the API server;
-`[eval]` adds SeedTTS/WER tooling, `[all]` aliases it, and `[fun-cosyvoice3]`
-adds the Fun-CosyVoice3 dependencies. Other model families
-(S2-Pro, Ming-Omni, Voxtral-TTS) are CUDA-only and are not offered here.
+Install the Ascend software stack and NPU build of SGLang before installing
+`sglang-omni`. The helper script installs only `sglang-omni`; it does not install
+or change any prerequisite in the table below.
 
 ## Prerequisites
 
-The NPU stack is **not** installed by `pyproject_npu.toml` or the install script.
-You must set up the following components first, following the
-[SGLang Ascend NPU guide](https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu):
+Select mutually compatible versions for your Ascend hardware by following the
+linked documentation. Python 3.11 is the verified configuration.
 
-| Component | Version | Install |
-|-----------|---------|---------|
-| CANN toolkit | 9.0.0 | [Installation guide](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/900/softwareinst/instg/instg_0008.html) |
-| HDK (driver/firmware) | 25.5.2 | [Download](https://www.hiascend.com/hardware/firmware-drivers/community) |
-| torch (CPU) | 2.10.0 | `pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --index-url https://download.pytorch.org/whl/cpu` |
-| torch_npu | 2.10.0 | [gitcode.com/Ascend/pytorch/releases](https://gitcode.com/Ascend/pytorch/releases) (arch-specific wheel) |
-| triton-ascend | 3.2.1.dev20260530 | `pip install triton-ascend==3.2.1.dev20260530 --extra-index-url=https://mirrors.huaweicloud.com/ascend/repos/pypi/nightly --trusted-host mirrors.huaweicloud.com` |
-| memfabric-hybrid | 1.0.8 | `pip install memfabric-hybrid==1.0.8` (PD disaggregation only) |
-| sgl-kernel-npu | latest | [sgl-project/sgl-kernel-npu](https://github.com/sgl-project/sgl-kernel-npu) releases |
+| Component | Version | Required | Manual installation | Installation |
+|-----------|---------|----------|---------------------|--------------|
+| CANN toolkit | Compatible release | Yes | Yes | [Official documentation](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/900/softwareinst/instg/instg_0008.html) |
+| HDK (driver and firmware) | Match the hardware and CANN release | Yes | Yes | [Official documentation](https://www.hiascend.com/hardware/firmware-drivers/community) |
+| PyTorch and `torch_npu` | Matching releases | Yes | Yes | [Official documentation](https://www.hiascend.com/developer/software/ai-frameworks/pytorch/download?versionId=177&ids=89dda9ba9de741349efa03687a487678%2C204%2C200%2C1%2C6%2C177%2C) |
+| `triton-ascend` | Match the selected PyTorch and CANN releases | Yes | Yes | [Official documentation](https://gitcode.com/Ascend/triton-ascend/blob/main/docs/en/quick_start.md) |
+| `sgl-kernel-npu` | Match PyTorch, Python, CANN, hardware, and architecture | Yes | Yes | [Official documentation](https://github.com/sgl-project/sgl-kernel-npu/releases) |
+| `memfabric-hybrid` | Compatible release | No (PD disaggregation only) | Yes | [Official documentation](https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu) |
+| SGLang for NPU | `v0.5.16` | Yes | Yes | [Official documentation](https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu) |
 
-> **Python 3.11 is the verified configuration.** The wheel examples below are
-> CPython 3.11 builds; select matching `torch_npu` wheels if you use another
-> supported Python version. To reproduce the verified environment, use
-> `conda create -n sglang-omni-npu python=3.11`.
-
-### torch_npu installation
-
-`torch_npu` wheels are arch-specific and hosted on Huawei's gitcode mirror, not on PyPI.
-Download the matching wheel for your architecture:
-
-```bash
-# aarch64 (Atlas 800I A2 / A3)
-pip install https://gitcode.com/Ascend/pytorch/releases/download/v26.0.0-pytorch2.10.0/torch_npu-2.10.0-cp311-cp311-manylinux_2_28_aarch64.whl
-
-# x86_64
-pip install https://gitcode.com/Ascend/pytorch/releases/download/v26.0.0-pytorch2.10.0/torch_npu-2.10.0-cp311-cp311-manylinux_2_28_x86_64.whl
-```
-
-## 🛠️ Install sglang-omni
-
-The helper swaps in `pyproject_npu.toml`, installs the package, then restores the
-CUDA manifest:
+## Install sglang-omni
 
 ```bash
 git clone https://github.com/sgl-project/sglang-omni.git
 cd sglang-omni
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
 
-# dry-run first — shows the commands, installs nothing
-PYTHON=$(which python) scripts/npu/install_npu.sh --check
+# Check the environment and show the installation command without changing files.
+bash scripts/npu/install_npu.sh --check
 
-# editable install
-PYTHON=$(which python) scripts/npu/install_npu.sh
+# Install sglang-omni in editable mode.
+bash scripts/npu/install_npu.sh
 ```
 
-The preflight verifies matching torch/torch_npu major-minor versions, at least one
-available NPU, and a small NPU MatMul. On a container build host where devices are
-intentionally not exposed, pass `--skip-device-check`; dependency imports and version
-checks still run.
-
-Pick extras with `--extras` (comma-separated):
-
-```bash
-scripts/npu/install_npu.sh --extras eval           # core + SeedTTS/WER eval + tests
-scripts/npu/install_npu.sh --extras all            # alias for eval
-scripts/npu/install_npu.sh --extras fun-cosyvoice3 # Fun-CosyVoice3 runtime
-```
-
-Or do it manually (the same steps the script automates):
-
-```bash
-cp pyproject.toml .pyproject.cuda.bak
-cp pyproject_npu.toml pyproject.toml
-pip install -e .
-cp -f .pyproject.cuda.bak pyproject.toml && rm .pyproject.cuda.bak   # restore CUDA pyproject
-```
-
-### SGLang (installed separately)
-
-`sglang` is intentionally **not** pinned, so the install above leaves an existing NPU build alone.
-It cannot be pinned even as a range: every published wheel requires `flashinfer_python[cu13]` and the
-`nvidia-*` runtime, so **any** specifier pulls the CUDA stack over `torch+npu`. Build from source:
-
-```bash
-git clone https://github.com/sgl-project/sglang && cd sglang
-git checkout v0.5.16   # the pinned release
-cd python && cp pyproject_npu.toml pyproject.toml
-pip install -e . --no-build-isolation
-```
-
-Use that commit: the NPU port targets this SGLang revision's APIs and does not carry
-version-compatibility shims. A VCS requirement (`pip install "sglang @ git+…"`) does **not** work:
-pip reads the checkout's `python/pyproject.toml`, which pins CUDA torch; only the swap above
-selects the NPU manifest.
-
-## Verify
-
-```bash
-# import works from anywhere now (package installed, not just cwd-on-path)
-python -c "import sglang_omni, torch; print(sglang_omni.__file__, torch.__version__)"
-which sgl-omni
-
-# device-layer unit tests (CPU, no NPU) — needs pytest, which ships in the
-# `[eval]` extra (install with `.[eval]`, or `pip install pytest` first)
-pytest tests/unit_test/test_platforms.py -v
-```
-
-## Serve
-
-### Qwen3-Omni text-only (30B-A3B MoE, multi-NPU tensor parallel)
-
-This is the model path currently validated on Ascend NPU. Qwen3-ASR and
-Qwen3-TTS have not yet been validated on NPU and are therefore not claimed as
-supported here.
-
-The 30B MoE does not fit one card; shard the thinker across NPUs with tensor parallelism.
-`--text-only` serves the thinker (chat) without the talker/speech stages. The text-only
-config normally puts every stage in the `pipeline` process, so give the TP thinker an
-otherwise-unused process name before enabling TP:
-
-```bash
-# thinker across 8 cards (TP=8). Large shards over shared storage load slowly, so give
-# startup more headroom than the default 600 s.
-export SGLANG_OMNI_STARTUP_TIMEOUT=1800
-sgl-omni serve --model-path /path/to/Qwen3-Omni-30B-A3B-Instruct \
-  --text-only --stages.thinker.process thinker \
-  --thinker-tp-size 8 --thinker-gpus 0,1,2,3,4,5,6,7 \
-  --host 0.0.0.0 --port 8000
-# chat:
-curl -s -X POST http://localhost:8000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{"model":"/path/to/Qwen3-Omni-30B-A3B-Instruct",
-       "messages":[{"role":"user","content":"What is Ascend NPU?"}],"max_tokens":64}'
-```
-
-Health check for any of the above: `curl http://localhost:8000/v1/models`.
-
-> **Expected on NPU:** `Failed to import mooncake` / `Failed to import nixl` warnings are harmless
-> — those CUDA-only transfer backends are omitted; tensors move through the `shm` relay instead
-> (or `memfabric` if installed).
+The precheck verifies the required Python packages, matching `torch` and
+`torch_npu` major-minor versions, NPU availability, and a small NPU matrix
+multiplication. Run `bash scripts/npu/install_npu.sh --help` for optional extras,
+non-editable installation, and environments where devices are intentionally not
+exposed during the build.

--- a/docs/get_started/installation_npu.md
+++ b/docs/get_started/installation_npu.md
@@ -12,18 +12,10 @@ Mirroring upstream SGLang ([Ascend NPU docs](https://docs.sglang.io/docs/hardwar
 family and CUDA-only wheels would replace the `torch+npu` stack.
 [`pyproject_npu.toml`](../../pyproject_npu.toml) encodes the NPU replacements.
 
-Core deps cover the supported models (Qwen3-ASR / TTS / Omni) plus the API server;
+Core dependencies cover Qwen3-Omni plus the API server;
 `[eval]` adds SeedTTS/WER tooling, `[all]` aliases it, and `[fun-cosyvoice3]`
 adds the Fun-CosyVoice3 dependencies. Other model families
 (S2-Pro, Ming-Omni, Voxtral-TTS) are CUDA-only and are not offered here.
-
-> **`--no-build-isolation` is required** — without it pip emits a legacy in-tree
-> `egg-info` instead of a PEP 660 editable install. The installer always passes it.
-> Because of that pip does not install build requirements either, so this
-> environment's own `setuptools` must be **≥ 77.0.0**: older releases reject the
-> PEP 639 license metadata with ``invalid pyproject.toml config: `project.license` ``.
-> The installer checks this before building; upgrade with
-> `pip install -U 'setuptools>=77.0.0'`.
 
 ## Prerequisites
 
@@ -61,8 +53,8 @@ pip install https://gitcode.com/Ascend/pytorch/releases/download/v26.0.0-pytorch
 
 ## 🛠️ Install sglang-omni
 
-The helper swaps in `pyproject_npu.toml`, installs with `--no-build-isolation`, then
-restores the CUDA one:
+The helper swaps in `pyproject_npu.toml`, installs the package, then restores the
+CUDA manifest:
 
 ```bash
 git clone https://github.com/sgl-project/sglang-omni.git
@@ -94,7 +86,7 @@ Or do it manually (the same steps the script automates):
 ```bash
 cp pyproject.toml .pyproject.cuda.bak
 cp pyproject_npu.toml pyproject.toml
-pip install -e . --no-build-isolation
+pip install -e .
 cp -f .pyproject.cuda.bak pyproject.toml && rm .pyproject.cuda.bak   # restore CUDA pyproject
 ```
 
@@ -130,37 +122,11 @@ pytest tests/unit_test/test_platforms.py -v
 
 ## Serve
 
-### Qwen3-ASR (speech-to-text, single NPU)
+### Qwen3-Omni text-only (30B-A3B MoE, multi-NPU tensor parallel)
 
-```bash
-sgl-omni serve --model-path /path/to/Qwen3-ASR-1.7B --host 0.0.0.0 --port 8000
-# transcribe:
-curl -s -X POST http://localhost:8000/v1/audio/transcriptions \
-  -F "file=@sample.wav" -F "model=/path/to/Qwen3-ASR-1.7B"
-```
-
-### Qwen3-TTS (text-to-speech, single NPU)
-
-Qwen3-TTS needs the upstream `qwen-tts` package, which is not pinned in `pyproject_npu.toml`.
-Install it with `--no-deps` to avoid version conflicts:
-
-```bash
-apt-get update && apt-get install -y sox   # the Python sox package shells out to it
-pip install --no-deps sox einops
-pip install --no-deps qwen-tts==0.1.1
-```
-
-```bash
-sgl-omni serve --model-path /path/to/Qwen3-TTS-12Hz-1.7B-Base --host 0.0.0.0 --port 8000
-# Base checkpoint clones a reference voice — pass ref_audio (+ ref_text):
-curl -s -X POST http://localhost:8000/v1/audio/speech \
-  -H "Content-Type: application/json" \
-  -d '{"model":"/path/to/Qwen3-TTS-12Hz-1.7B-Base","input":"Hello from Ascend NPU.",
-       "voice":"default","ref_audio":"/path/to/ref.wav","ref_text":"reference transcript",
-       "response_format":"wav"}' -o out.wav
-```
-
-### Qwen3-Omni (30B-A3B MoE, multi-NPU tensor parallel)
+This is the model path currently validated on Ascend NPU. Qwen3-ASR and
+Qwen3-TTS have not yet been validated on NPU and are therefore not claimed as
+supported here.
 
 The 30B MoE does not fit one card; shard the thinker across NPUs with tensor parallelism.
 `--text-only` serves the thinker (chat) without the talker/speech stages. The text-only

--- a/docs/get_started/installation_npu.md
+++ b/docs/get_started/installation_npu.md
@@ -13,7 +13,8 @@ family and CUDA-only wheels would replace the `torch+npu` stack.
 [`pyproject_npu.toml`](../../pyproject_npu.toml) encodes the NPU replacements.
 
 Core deps cover the supported models (Qwen3-ASR / TTS / Omni) plus the API server;
-`[eval]` adds SeedTTS/WER tooling and `[all]` aliases it. Other model families
+`[eval]` adds SeedTTS/WER tooling, `[all]` aliases it, and `[fun-cosyvoice3]`
+adds the Fun-CosyVoice3 dependencies. Other model families
 (S2-Pro, Ming-Omni, Voxtral-TTS) are CUDA-only and are not offered here.
 
 > **`--no-build-isolation` is required** — without it pip emits a legacy in-tree
@@ -40,8 +41,10 @@ You must set up the following components first, following the
 | memfabric-hybrid | 1.0.8 | `pip install memfabric-hybrid==1.0.8` (PD disaggregation only) |
 | sgl-kernel-npu | latest | [sgl-project/sgl-kernel-npu](https://github.com/sgl-project/sgl-kernel-npu) releases |
 
-> **Python 3.11 only** — upstream SGLang's NPU build currently supports `python==3.11`.
-> Use conda if your system Python differs: `conda create -n sglang-omni-npu python=3.11`.
+> **Python 3.11 is the verified configuration.** The wheel examples below are
+> CPython 3.11 builds; select matching `torch_npu` wheels if you use another
+> supported Python version. To reproduce the verified environment, use
+> `conda create -n sglang-omni-npu python=3.11`.
 
 ### torch_npu installation
 
@@ -77,6 +80,7 @@ Pick extras with `--extras` (comma-separated):
 ```bash
 scripts/npu/install_npu.sh --extras eval           # core + SeedTTS/WER eval + tests
 scripts/npu/install_npu.sh --extras all            # alias for eval
+scripts/npu/install_npu.sh --extras fun-cosyvoice3 # Fun-CosyVoice3 runtime
 ```
 
 Or do it manually (the same steps the script automates):
@@ -153,14 +157,17 @@ curl -s -X POST http://localhost:8000/v1/audio/speech \
 ### Qwen3-Omni (30B-A3B MoE, multi-NPU tensor parallel)
 
 The 30B MoE does not fit one card; shard the thinker across NPUs with tensor parallelism.
-`--text-only` serves the thinker (chat) without the talker/speech stages:
+`--text-only` serves the thinker (chat) without the talker/speech stages. The text-only
+config normally puts every stage in the `pipeline` process, so give the TP thinker an
+otherwise-unused process name before enabling TP:
 
 ```bash
 # thinker across 8 cards (TP=8). Large shards over shared storage load slowly, so give
 # startup more headroom than the default 600 s.
 export SGLANG_OMNI_STARTUP_TIMEOUT=1800
 sgl-omni serve --model-path /path/to/Qwen3-Omni-30B-A3B-Instruct \
-  --text-only --thinker-tp-size 8 --thinker-gpus 0,1,2,3,4,5,6,7 \
+  --text-only --stages.thinker.process thinker \
+  --thinker-tp-size 8 --thinker-gpus 0,1,2,3,4,5,6,7 \
   --host 0.0.0.0 --port 8000
 # chat:
 curl -s -X POST http://localhost:8000/v1/chat/completions \

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,6 +86,7 @@ Supported Models
    :caption: Get Started
 
    get_started/installation.md
+   get_started/installation_npu.md
    get_started/installation_xpu.md
 
 

--- a/pyproject_npu.toml
+++ b/pyproject_npu.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 # installed manually before pip-installing sglang-omni.
 #
 # CUDA-only wheels (flashinfer, nixl-cu13, mooncake, flash-attn-4, cache-dit …)
-# are dropped; sglang is verified against v0.5.16 but cannot be pinned here --
+# are dropped; sglang is verified against v0.5.18 but cannot be pinned here --
 # every published wheel pulls CUDA torch.
 
 [project]
@@ -55,7 +55,7 @@ dependencies = [
 
     # --- Model loading / HF -------------------------------------------------
     "accelerate>=0.27.0",
-    "transformers==5.12.1",        # Match SGLang 0.5.16, as the CUDA pyproject does
+    "transformers==5.12.1",        # Match the pinned SGLang stack
     "safetensors>=0.4.3",
     "pillow>=10.0.0",
     "huggingface-hub[hf_xet]>=0.36.0",

--- a/pyproject_npu.toml
+++ b/pyproject_npu.toml
@@ -50,14 +50,8 @@ dependencies = [
     # mapping (CANN / torch / torch_npu / triton-ascend / memfabric):
     #   https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu
     #
-    # Example install sequence (CANN 9.0.0, see installation_npu.md for details):
-    #   pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 \
-    #       --index-url https://download.pytorch.org/whl/cpu
-    #   pip install torch_npu==2.10.0  # arch-specific wheel from gitcode.com/Ascend/pytorch
-    #   pip install triton-ascend==3.2.1.dev20260530 \
-    #       --extra-index-url=https://mirrors.huaweicloud.com/ascend/repos/pypi/nightly \
-    #       --trusted-host mirrors.huaweicloud.com
-    #   pip install memfabric-hybrid==1.0.8  # PD disaggregation only
+    # Select a mutually compatible stack from the official Ascend for PyTorch page:
+    #   https://www.hiascend.com/developer/software/ai-frameworks/pytorch/download
 
     # --- Model loading / HF -------------------------------------------------
     "accelerate>=0.27.0",

--- a/pyproject_npu.toml
+++ b/pyproject_npu.toml
@@ -1,7 +1,6 @@
 [build-system]
-# >=77 for the PEP 639 license fields below, which 76.1 and older reject; that also
-# covers the PEP 660 build_editable an editable install needs. Installs here pass
-# --no-build-isolation, so pip never enforces this -- scripts/npu/install_npu.sh does.
+# >=77 for the PEP 639 license fields below, which 76.1 and older reject; this also
+# covers the PEP 660 build_editable hook used by editable installs.
 requires = ["setuptools>=77.0.0"]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject_npu.toml
+++ b/pyproject_npu.toml
@@ -1,0 +1,126 @@
+[build-system]
+# >=77 for the PEP 639 license fields below, which 76.1 and older reject; that also
+# covers the PEP 660 build_editable an editable install needs. Installs here pass
+# --no-build-isolation, so pip never enforces this -- scripts/npu/install_npu.sh does.
+requires = ["setuptools>=77.0.0"]
+build-backend = "setuptools.build_meta"
+
+# Huawei Ascend NPU variant of pyproject.toml (see docs/get_started/installation_npu.md).
+# Mirrors upstream SGLang's pyproject_npu.toml where srt_npu = [] — torch,
+# torch_npu, triton-ascend, and memfabric are NOT pinned here and must be
+# installed manually before pip-installing sglang-omni.
+#
+# CUDA-only wheels (flashinfer, nixl-cu13, mooncake, flash-attn-4, cache-dit …)
+# are dropped; sglang is verified against v0.5.16 but cannot be pinned here --
+# every published wheel pulls CUDA torch.
+
+[project]
+name = "sglang-omni"
+dynamic = ["version"]
+description = "Multi-stage pipeline framework for omni models (Huawei Ascend NPU build)"
+readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+requires-python = ">=3.10,<3.13"
+dependencies = [
+    # --- Core framework (device-agnostic) ----------------------------------
+    "pyzmq>=25.0.0",
+    "msgpack>=1.0.0",
+    "msgspec",
+    "numpy>=1.24.0",
+    "pydantic>=2.0.0",
+    "PyYAML>=6.0",
+    "httpx",
+    "xxhash>=3.0.0",
+    "pybase64>=1.4.0",       # fast base64 decode for inline media (utils/audio.py)
+    "tabulate",
+    "pandas",
+    "typer>=0.9.0",
+
+    # --- PyTorch + torch_npu (Ascend CANN) ---------------------------------
+    # NOTE: torch, torch_npu, triton-ascend, and memfabric are intentionally
+    # NOT pinned here, matching upstream SGLang's pyproject_npu.toml where
+    # srt_npu = [].  These packages must be installed manually before
+    # pip-installing sglang-omni, because:
+    #   1. torch_npu wheels are arch-specific (aarch64/x86) and often hosted
+    #      on Huawei OBS rather than PyPI;
+    #   2. triton-ascend requires a Huawei cloud mirror index;
+    #   3. versions are tightly coupled to the host CANN toolkit release.
+    #
+    # Refer to the SGLang Ascend NPU install guide for the component version
+    # mapping (CANN / torch / torch_npu / triton-ascend / memfabric):
+    #   https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu
+    #
+    # Example install sequence (adjust versions to match your CANN release):
+    #   pip install torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cpu
+    #   pip install torch_npu==2.10.0
+    #   pip install triton-ascend==3.2.1.dev20260530 \
+    #       --extra-index-url=https://mirrors.huaweicloud.com/ascend/repos/pypi/nightly \
+    #       --trusted-host mirrors.huaweicloud.com
+    #   pip install memfabric-hybrid==1.0.8
+
+    # --- Model loading / HF -------------------------------------------------
+    "accelerate>=0.27.0",
+    "transformers==5.12.1",        # Match SGLang 0.5.16, as the CUDA pyproject does
+    "safetensors>=0.4.3",
+    "pillow>=10.0.0",
+    "huggingface-hub>=0.36.0",
+    "datasets>=2.14.0",
+
+    # NOTE: sglang is intentionally NOT pinned here (see the header).
+
+    # --- API server ---------------------------------------------------------
+    "fastapi>=0.110.0",
+    "uvicorn>=0.23.0",
+    "websockets>=12.0",
+    "openai==2.6.1",
+    "openai-harmony==0.0.4",
+    # /v1/realtime — server-side VAD
+    "silero-vad>=5.1",
+    "onnxruntime>=1.17",
+
+    # --- Multimodal preprocessing (needed by Qwen3-Omni/ASR/TTS) ------------
+    "qwen-vl-utils==0.0.11",
+    "librosa>=0.11.0",
+    "av>=16.1.0",
+    "soundfile>=0.12.0",
+    "scipy>=1.10.0",
+]
+
+[project.optional-dependencies]
+# SeedTTS speaker-sim / WER eval + tests (device-agnostic).
+eval = [
+    "s3prl>=0.4.18",
+    "jiwer",
+    "openai-whisper==20250625",
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+]
+# `all` aliases `eval`.
+all = [
+    "s3prl>=0.4.18", "jiwer", "openai-whisper==20250625",
+    "pytest>=7.0.0", "pytest-asyncio>=0.21.0",
+]
+
+[project.scripts]
+sgl-omni = "sglang_omni.cli:app"
+sgl-omni-router = "sglang_omni_router.serve:main"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+markers = [
+    "benchmark: performance benchmark tests (may require GPU and long runtime)",
+    "tts_stage(name): select an in-file TTS benchmark CI stage",
+    "gpu: requires an accelerator device (auto-skipped without one)",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["sglang_omni*"]
+
+[tool.setuptools.dynamic]
+version = {attr = "sglang_omni.__version__"}
+
+[tool.setuptools.package-data]
+"sglang_omni.models.fishaudio_s2_pro" = ["fish_speech/configs/*.yaml"]
+"sglang_omni.models.higgs_tts" = ["configs/*.json"]

--- a/pyproject_npu.toml
+++ b/pyproject_npu.toml
@@ -65,7 +65,7 @@ dependencies = [
     "transformers==5.12.1",        # Match SGLang 0.5.16, as the CUDA pyproject does
     "safetensors>=0.4.3",
     "pillow>=10.0.0",
-    "huggingface-hub>=0.36.0",
+    "huggingface-hub[hf_xet]>=0.36.0",
     "datasets>=2.14.0",
 
     # NOTE: sglang is intentionally NOT pinned here (see the header).
@@ -82,6 +82,7 @@ dependencies = [
 
     # --- Multimodal preprocessing (needed by Qwen3-Omni/ASR/TTS) ------------
     "qwen-vl-utils==0.0.11",
+    "sox>=1.4.1",
     "librosa>=0.11.0",
     "av>=16.1.0",
     "soundfile>=0.12.0",
@@ -102,10 +103,33 @@ all = [
     "s3prl>=0.4.18", "jiwer", "openai-whisper==20250625",
     "pytest>=7.0.0", "pytest-asyncio>=0.21.0",
 ]
+fun-cosyvoice3 = [
+    "conformer==0.3.2",
+    "HyperPyYAML==1.2.3",
+    "pyworld==0.3.4",
+    "wetext==0.0.4",
+    "inflect==7.3.1",
+    "gdown==5.1.0",
+    "lightning==2.6.5",
+    "matplotlib==3.11.1",
+]
 
 [project.scripts]
 sgl-omni = "sglang_omni.cli:app"
 sgl-omni-router = "sglang_omni_router.serve:main"
+
+[project.entry-points."sglang.serve_backends"]
+omni = "sglang_omni.cli.sglang_backend:create_backend"
+
+[project.urls]
+Documentation = "https://sgl-project.github.io/sglang-omni/"
+Issues = "https://github.com/sgl-project/sglang-omni/issues"
+Repository = "https://github.com/sgl-project/sglang-omni"
+
+[tool.uv]
+override-dependencies = [
+    "protobuf>=6.31.1,<7.0.0",
+]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
@@ -125,3 +149,4 @@ version = {attr = "sglang_omni.__version__"}
 [tool.setuptools.package-data]
 "sglang_omni.models.fishaudio_s2_pro" = ["fish_speech/configs/*.yaml"]
 "sglang_omni.models.higgs_tts" = ["configs/*.json"]
+"sglang_omni.models.zonos2" = ["moe_configs/*/*.json"]

--- a/pyproject_npu.toml
+++ b/pyproject_npu.toml
@@ -4,7 +4,7 @@
 requires = ["setuptools>=77.0.0"]
 build-backend = "setuptools.build_meta"
 
-# Huawei Ascend NPU variant of pyproject.toml (see docs/get_started/installation_npu.md).
+# Ascend NPU variant of pyproject.toml (see docs/get_started/installation_npu.md).
 # Mirrors upstream SGLang's pyproject_npu.toml where srt_npu = [] — torch,
 # torch_npu, triton-ascend, and memfabric are NOT pinned here and must be
 # installed manually before pip-installing sglang-omni.
@@ -16,7 +16,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "sglang-omni"
 dynamic = ["version"]
-description = "Multi-stage pipeline framework for omni models (Huawei Ascend NPU build)"
+description = "Multi-stage pipeline framework for omni models (Ascend NPU build)"
 readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
@@ -42,8 +42,8 @@ dependencies = [
     # srt_npu = [].  These packages must be installed manually before
     # pip-installing sglang-omni, because:
     #   1. torch_npu wheels are arch-specific (aarch64/x86) and often hosted
-    #      on Huawei OBS rather than PyPI;
-    #   2. triton-ascend requires a Huawei cloud mirror index;
+    #      in Ascend repositories rather than PyPI;
+    #   2. triton-ascend requires an Ascend package index;
     #   3. versions are tightly coupled to the host CANN toolkit release.
     #
     # Refer to the SGLang Ascend NPU install guide for the component version

--- a/pyproject_npu.toml
+++ b/pyproject_npu.toml
@@ -51,13 +51,14 @@ dependencies = [
     # mapping (CANN / torch / torch_npu / triton-ascend / memfabric):
     #   https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu
     #
-    # Example install sequence (adjust versions to match your CANN release):
-    #   pip install torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cpu
-    #   pip install torch_npu==2.10.0
+    # Example install sequence (CANN 9.0.0, see installation_npu.md for details):
+    #   pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 \
+    #       --index-url https://download.pytorch.org/whl/cpu
+    #   pip install torch_npu==2.10.0  # arch-specific wheel from gitcode.com/Ascend/pytorch
     #   pip install triton-ascend==3.2.1.dev20260530 \
     #       --extra-index-url=https://mirrors.huaweicloud.com/ascend/repos/pypi/nightly \
     #       --trusted-host mirrors.huaweicloud.com
-    #   pip install memfabric-hybrid==1.0.8
+    #   pip install memfabric-hybrid==1.0.8  # PD disaggregation only
 
     # --- Model loading / HF -------------------------------------------------
     "accelerate>=0.27.0",

--- a/scripts/npu/install_npu.sh
+++ b/scripts/npu/install_npu.sh
@@ -8,8 +8,7 @@ PYPROJECT="${REPO_ROOT}/pyproject.toml"
 PYPROJECT_NPU="${REPO_ROOT}/pyproject_npu.toml"
 BACKUP="${REPO_ROOT}/.pyproject.cuda.bak"
 LOCK="${REPO_ROOT}/.pyproject.npu.lock"
-SGLANG_MIN_RELEASE="0.5.18"
-SGLANG_MAX_RELEASE="0.5.19"
+SGLANG_SUPPORTED_RELEASE="0.5.18"
 
 EDITABLE="-e"
 CHECK_ONLY=0
@@ -107,13 +106,13 @@ print_summary() {
 }
 
 check_sglang_version() {
-  local supported_range=">=${SGLANG_MIN_RELEASE},<${SGLANG_MAX_RELEASE}"
+  local supported_line="${SGLANG_SUPPORTED_RELEASE} release line"
   local installed_version="not installed"
 
   if ! installed_version="$("${PYBIN}" -c 'from importlib.metadata import version; print(version("sglang"))' 2>/dev/null)"; then
     {
       echo "ERROR: SGLang version check failed."
-      echo "  supported: ${supported_range}"
+      echo "  supported: ${supported_line}"
       echo "  installed: not installed"
       echo "Install a supported Ascend NPU release:"
       echo "  https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu"
@@ -122,9 +121,9 @@ check_sglang_version() {
   fi
 
   # Compare the numeric release segment rather than PEP 440 precedence. This
-  # deliberately treats dev, pre, final, post, and local builds on the 0.5.18
-  # release line as supported, while excluding every 0.5.19 build.
-  if ! "${PYBIN}" - "${installed_version}" "${SGLANG_MIN_RELEASE}" "${SGLANG_MAX_RELEASE}" <<'PY'
+  # treats dev, pre, final, post, and local builds on the configured release
+  # line as supported while excluding every other release line.
+  if ! "${PYBIN}" - "${installed_version}" "${SGLANG_SUPPORTED_RELEASE}" <<'PY'
 import sys
 
 try:
@@ -137,14 +136,13 @@ try:
 except InvalidVersion:
     raise SystemExit(1)
 
-minimum = Version(sys.argv[2]).release
-maximum = Version(sys.argv[3]).release
-raise SystemExit(0 if minimum <= installed < maximum else 1)
+supported = Version(sys.argv[2]).release
+raise SystemExit(0 if installed[: len(supported)] == supported else 1)
 PY
   then
     {
       echo "ERROR: SGLang version check failed."
-      echo "  supported: ${supported_range}"
+      echo "  supported: ${supported_line}"
       echo "  installed: ${installed_version}"
       echo "Install a supported Ascend NPU release:"
       echo "  https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu"
@@ -364,7 +362,7 @@ verify_install() {
     echo "  [ok] sglang is importable"
   else
     echo "  [warn] sglang is not installed. Follow the Ascend NPU guide for"
-    echo "         a supported SGLang source installation (${SGLANG_MIN_RELEASE} <= version < ${SGLANG_MAX_RELEASE}):"
+    echo "         a supported SGLang ${SGLANG_SUPPORTED_RELEASE} release-line installation:"
     echo "         https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu"
   fi
 

--- a/scripts/npu/install_npu.sh
+++ b/scripts/npu/install_npu.sh
@@ -107,7 +107,9 @@ print_summary() {
 
 check_sglang_version() {
   local expected_version="${SGLANG_VERIFIED_VERSION#v}"
+  local expected_pattern
   local installed_version
+  local local_version=""
   local public_version
 
   if ! installed_version="$("${PYBIN}" -c 'from importlib.metadata import version; print(version("sglang"))' 2>/dev/null)"; then
@@ -117,10 +119,17 @@ check_sglang_version() {
     return 1
   fi
 
-  # Accept local build metadata such as 0.5.18+ascend while requiring the
-  # verified public release exactly. Pre/post releases remain mismatches.
+  # Accept the stable release (with optional local metadata) and traceable
+  # source builds from the same release line, e.g. 0.5.18.dev7+g<git-sha>.
   public_version="${installed_version%%+*}"
-  if [[ "${public_version}" != "${expected_version}" ]]; then
+  if [[ "${installed_version}" == *+* ]]; then
+    local_version="${installed_version#*+}"
+  fi
+  expected_pattern="${expected_version//./\.}"
+
+  if [[ "${public_version}" != "${expected_version}" ]] &&
+     ! [[ "${public_version}" =~ ^${expected_pattern}\.dev[0-9]+$ &&
+          "${local_version}" =~ ^g[0-9a-f]+$ ]]; then
     echo "ERROR: sglang ${installed_version} is installed, but ${expected_version} is required." >&2
     echo "Install the verified Ascend NPU release before installing sglang-omni:" >&2
     echo "  https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu" >&2

--- a/scripts/npu/install_npu.sh
+++ b/scripts/npu/install_npu.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Install sglang-omni for Huawei Ascend NPU: swap in pyproject_npu.toml and install
+# against the pre-installed torch_npu / triton-ascend stack (the CUDA pyproject would
+# clobber a working torch+npu stack). See docs/get_started/installation_npu.md.
+#
+# Prerequisites (NOT installed by this script — see installation_npu.md):
+#   - CANN toolkit 9.0.0
+#   - torch + torch_npu (matching versions)
+#   - triton-ascend
+#   - memfabric-hybrid (for PD disaggregation)
+#   - sgl-kernel-npu (custom operators)
+#
+# Usage:
+#   scripts/npu/install_npu.sh                    # lean core, editable
+#   scripts/npu/install_npu.sh --extras eval      # core + eval/tests
+#   scripts/npu/install_npu.sh --no-editable      # non-editable
+#   scripts/npu/install_npu.sh --check            # dry-run: show what would run
+#
+# Never deletes your pyproject.toml: it is backed up and restored on exit.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EDITABLE="-e"
+CHECK_ONLY=0
+EXTRAS=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-editable) EDITABLE=""; shift ;;
+    --check)       CHECK_ONLY=1; shift ;;
+    --extras)      EXTRAS="${2:-}"; shift 2 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+PYPROJECT="${REPO_ROOT}/pyproject.toml"
+PYPROJECT_NPU="${REPO_ROOT}/pyproject_npu.toml"
+BACKUP="${REPO_ROOT}/.pyproject.cuda.bak"
+
+SGLANG_VERIFIED_VERSION="v0.5.16"
+
+[[ -f "${PYPROJECT_NPU}" ]] || { echo "ERROR: ${PYPROJECT_NPU} not found" >&2; exit 1; }
+
+PYBIN="${PYTHON:-python}"
+
+# Build the install target, e.g. ".[eval]" or "."
+TARGET="."
+if [[ -n "${EXTRAS}" ]]; then
+  TARGET=".[${EXTRAS}]"
+fi
+
+echo "=== sglang-omni Huawei Ascend NPU install ==="
+echo "  repo:        ${REPO_ROOT}"
+echo "  python:      $(${PYBIN} -c 'import sys; print(sys.executable)')"
+echo "  target:      ${TARGET}"
+echo "  editable:    $([[ -n "${EDITABLE}" ]] && echo yes || echo no)"
+
+# --- Pre-flight: verify NPU stack is installed ---------------------------
+# torch, torch_npu, triton-ascend, and memfabric are intentionally NOT pinned
+# in pyproject_npu.toml (matching upstream SGLang's pyproject_npu.toml where
+# srt_npu = []).  They must be installed BEFORE running this script.
+${PYBIN} - <<'PY' || exit 1
+import sys
+
+errors = []
+
+try:
+    import torch
+    print(f"  torch:       {torch.__version__}")
+except ImportError:
+    errors.append("torch is not installed. Install CPU torch first:\n"
+                  "  pip install torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cpu")
+
+try:
+    import torch_npu
+    print(f"  torch_npu:   {torch_npu.__version__}")
+except ImportError:
+    errors.append("torch_npu is not installed. Install from Huawei OBS:\n"
+                  "  pip install torch_npu==2.10.0  # or from https://gitcode.com/Ascend/pytorch/releases")
+
+try:
+    import triton
+    print(f"  triton:      {triton.__version__}")
+except ImportError:
+    errors.append("triton-ascend is not installed. Install from Huawei cloud mirror:\n"
+                  "  pip install triton-ascend==3.2.1.dev20260530 \\\n"
+                  "    --extra-index-url=https://mirrors.huaweicloud.com/ascend/repos/pypi/nightly \\\n"
+                  "    --trusted-host mirrors.huaweicloud.com")
+
+try:
+    import memfabric
+    print(f"  memfabric:   {memfabric.__version__}")
+except ImportError:
+    # memfabric is only needed for PD disaggregation; warn, don't error
+    print("  memfabric:   not installed (only needed for PD disaggregation)")
+
+if errors:
+    print()
+    print("ERROR: NPU prerequisites are missing.", file=sys.stderr)
+    for e in errors:
+        print(f"  - {e}", file=sys.stderr)
+    print(file=sys.stderr)
+    print("See docs/get_started/installation_npu.md for the full install sequence.", file=sys.stderr)
+    sys.exit(1)
+PY
+
+# --- Verify setuptools >= 77 (same rationale as XPU) ---------------------
+# --no-build-isolation is REQUIRED (see docs/get_started/installation_npu.md):
+# with build isolation, pip spins up an isolated build env whose fallback
+# setuptools emits a legacy in-tree egg-info instead of a PEP 660 editable .pth
+# — the package then isn't importable outside the repo and no sgl-omni console
+# script is created. Without isolation the build uses this env's setuptools, so the
+# build requirement in pyproject_npu.toml is never enforced by pip -- check it here
+# instead of failing later in metadata generation.
+"${PYBIN}" - <<'PY' || exit 1
+import sys
+
+import setuptools
+import setuptools.build_meta
+
+version = tuple(
+    int("".join(char for char in part if char.isdigit()) or 0)
+    for part in setuptools.__version__.split(".")[:2]
+)
+if version < (77, 0):
+    sys.exit(
+        f"setuptools {setuptools.__version__} is too old: pyproject_npu.toml uses "
+        "the PEP 639 license fields, which 76.1 and older reject with 'invalid "
+        "pyproject.toml config: `project.license`'. --no-build-isolation means pip "
+        "will not upgrade it for you, so run: pip install -U 'setuptools>=77.0.0'"
+    )
+if not hasattr(setuptools.build_meta, "build_editable"):
+    sys.exit(
+        f"setuptools {setuptools.__version__} lacks PEP 660 support; an editable "
+        "install would emit a legacy egg-info."
+    )
+PY
+NOISO="--no-build-isolation"
+INSTALL_CMD="${PYBIN} -m pip install ${EDITABLE} ${TARGET} ${NOISO}"
+
+# --- Serialize the swap (same flock pattern as XPU) ----------------------
+LOCK="${REPO_ROOT}/.pyproject.npu.lock"
+if ! command -v flock >/dev/null 2>&1; then
+  echo "ERROR: flock is required to serialize the pyproject swap" >&2
+  exit 1
+fi
+exec 9>"${LOCK}" || { echo "ERROR: cannot open lock ${LOCK}" >&2; exit 1; }
+if ! flock -n 9; then
+  echo "ERROR: another ${0##*/} holds ${LOCK}; wait for it to finish" >&2
+  exit 1
+fi
+
+# A leftover backup means a previous run died after the swap (SIGKILL, OOM, power
+# loss -- INT/TERM are trapped below). pyproject.toml is then the NPU manifest and
+# this backup holds the only copy of the original, so the cp below would destroy it.
+# Refuse instead, and hand back the recovery step. Checked before the trap is armed
+# so exiting here cannot itself touch either file.
+if [[ -e "${BACKUP}" ]]; then
+  {
+    echo "ERROR: leftover backup found: ${BACKUP}"
+    echo
+    echo "A previous run was interrupted after swapping pyproject.toml, so that"
+    echo "backup is the only copy of your original manifest. Restore it first:"
+    echo
+    echo "  cp ${BACKUP} ${PYPROJECT} && rm ${BACKUP}"
+    echo
+    echo "Then re-run this script."
+  } >&2
+  exit 1
+fi
+
+if [[ "${CHECK_ONLY}" -eq 1 ]]; then
+  echo
+  echo "[--check] would run:"
+  echo "  cp pyproject.toml .pyproject.cuda.bak"
+  echo "  cp pyproject_npu.toml pyproject.toml"
+  echo "  ${INSTALL_CMD}"
+  echo "  # then restore pyproject.toml from backup"
+  exit 0
+fi
+
+# Restore the CUDA pyproject.toml no matter how we exit. Use cp (not mv) so a
+# partial/interrupted restore still leaves the backup in place, and also sweep
+# the in-tree build artifacts an editable build may drop.
+restore() {
+  if [[ -f "${BACKUP}" ]]; then
+    cp -f "${BACKUP}" "${PYPROJECT}"
+    rm -f "${BACKUP}"
+    echo "restored original pyproject.toml"
+  fi
+  rm -rf "${REPO_ROOT}/sglang_omni.egg-info" "${REPO_ROOT}/build" 2>/dev/null || true
+}
+trap restore EXIT INT TERM
+
+cp -f "${PYPROJECT}" "${BACKUP}"
+cp -f "${PYPROJECT_NPU}" "${PYPROJECT}"
+echo "swapped in pyproject_npu.toml"
+
+echo ">>> ${INSTALL_CMD}"
+${INSTALL_CMD}
+
+# Restore immediately (don't wait for EXIT) so verification below runs against a
+# clean tree and a setuptools editable .pth (not the swapped file).
+restore
+trap - EXIT INT TERM
+
+echo
+echo "=== verifying install ==="
+VERIFY_RC=0
+# import must work from OUTSIDE the repo (proves a real install, not cwd-on-path)
+if (cd / && "${PYBIN}" -c "import sglang_omni" 2>/dev/null); then
+  echo "  [ok] import sglang_omni works from outside the repo"
+else
+  echo "  [FAIL] import sglang_omni does NOT work outside the repo (editable .pth missing)"
+  VERIFY_RC=1
+fi
+if "${PYBIN}" -m pip show sglang-omni >/dev/null 2>&1; then
+  echo "  [ok] pip shows sglang-omni: $(${PYBIN} -m pip show sglang-omni 2>/dev/null | awk '/^Version:/{print $2}')"
+else
+  echo "  [FAIL] pip does not show sglang-omni"
+  VERIFY_RC=1
+fi
+if command -v sgl-omni >/dev/null 2>&1 || [[ -x "$(dirname "$(${PYBIN} -c 'import sys;print(sys.executable)')")/sgl-omni" ]]; then
+  echo "  [ok] sgl-omni console script present"
+else
+  echo "  [warn] sgl-omni not on PATH (check the env's bin dir)"
+fi
+
+# SGLang is never installed by this script (it cannot be pinned for NPU), so
+# report whether it is importable at all.
+if "${PYBIN}" -c "import sglang" >/dev/null 2>&1; then
+  echo "  [ok] sglang is importable"
+else
+  echo "  [warn] sglang is NOT installed — it is intentionally not a dependency here."
+  echo "         Build the NPU SGLang from source (${SGLANG_VERIFIED_VERSION}):"
+  echo "           git clone https://github.com/sgl-project/sglang && cd sglang"
+  echo "           git checkout ${SGLANG_VERIFIED_VERSION}"
+  echo "           cd python && cp pyproject_npu.toml pyproject.toml"
+  echo "           pip install -e . --no-build-isolation"
+fi
+
+if [[ "${VERIFY_RC}" -ne 0 ]]; then
+  echo
+  echo "INSTALL VERIFICATION FAILED. If setuptools fell back to legacy egg-info,"
+  echo "retry with a PEP 660 editable build, e.g.:"
+  echo "  ${PYBIN} -m pip install -e . --config-settings editable_mode=strict"
+  exit 1
+fi
+
+echo
+echo "=== done. Next: ==="
+echo "  sgl-omni serve --model-path <path-to-model> --port 8000"

--- a/scripts/npu/install_npu.sh
+++ b/scripts/npu/install_npu.sh
@@ -105,7 +105,34 @@ print_summary() {
   echo "  editable:    $([[ -n "${EDITABLE}" ]] && echo yes || echo no)"
 }
 
+check_sglang_version() {
+  local expected_version="${SGLANG_VERIFIED_VERSION#v}"
+  local installed_version
+  local public_version
+
+  if ! installed_version="$("${PYBIN}" -c 'from importlib.metadata import version; print(version("sglang"))' 2>/dev/null)"; then
+    echo "ERROR: sglang ${expected_version} is required but is not installed." >&2
+    echo "Follow the Ascend NPU installation guide:" >&2
+    echo "  https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu" >&2
+    return 1
+  fi
+
+  # Accept local build metadata such as 0.5.18+ascend while requiring the
+  # verified public release exactly. Pre/post releases remain mismatches.
+  public_version="${installed_version%%+*}"
+  if [[ "${public_version}" != "${expected_version}" ]]; then
+    echo "ERROR: sglang ${installed_version} is installed, but ${expected_version} is required." >&2
+    echo "Install the verified Ascend NPU release before installing sglang-omni:" >&2
+    echo "  https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu" >&2
+    return 1
+  fi
+
+  echo "  sglang:      ${installed_version}"
+}
+
 precheck() {
+  check_sglang_version
+
   # These packages must be installed before running this script. Keep version
   # selection in the official compatibility guides rather than hard-coding an
   # example stack here.
@@ -205,7 +232,7 @@ if torch is not None and torch_npu is not None:
             errors.append(f"NPU health check failed: {exc}")
 
 if errors:
-    print("\nERROR: NPU prerequisites are missing.", file=sys.stderr)
+    print("\nERROR: NPU prerequisites are missing or incompatible.", file=sys.stderr)
     for error in errors:
         print(f"  - {error}", file=sys.stderr)
     print(

--- a/scripts/npu/install_npu.sh
+++ b/scripts/npu/install_npu.sh
@@ -8,7 +8,8 @@ PYPROJECT="${REPO_ROOT}/pyproject.toml"
 PYPROJECT_NPU="${REPO_ROOT}/pyproject_npu.toml"
 BACKUP="${REPO_ROOT}/.pyproject.cuda.bak"
 LOCK="${REPO_ROOT}/.pyproject.npu.lock"
-SGLANG_VERIFIED_VERSION="v0.5.18"
+SGLANG_MIN_RELEASE="0.5.18"
+SGLANG_MAX_RELEASE="0.5.19"
 
 EDITABLE="-e"
 CHECK_ONLY=0
@@ -106,33 +107,48 @@ print_summary() {
 }
 
 check_sglang_version() {
-  local expected_version="${SGLANG_VERIFIED_VERSION#v}"
-  local expected_pattern
-  local installed_version
-  local local_version=""
-  local public_version
+  local supported_range=">=${SGLANG_MIN_RELEASE},<${SGLANG_MAX_RELEASE}"
+  local installed_version="not installed"
 
   if ! installed_version="$("${PYBIN}" -c 'from importlib.metadata import version; print(version("sglang"))' 2>/dev/null)"; then
-    echo "ERROR: sglang ${expected_version} is required but is not installed." >&2
-    echo "Follow the Ascend NPU installation guide:" >&2
-    echo "  https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu" >&2
+    {
+      echo "ERROR: SGLang version check failed."
+      echo "  supported: ${supported_range}"
+      echo "  installed: not installed"
+      echo "Install a supported Ascend NPU release:"
+      echo "  https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu"
+    } >&2
     return 1
   fi
 
-  # Accept the stable release (with optional local metadata) and traceable
-  # source builds from the same release line, e.g. 0.5.18.dev7+g<git-sha>.
-  public_version="${installed_version%%+*}"
-  if [[ "${installed_version}" == *+* ]]; then
-    local_version="${installed_version#*+}"
-  fi
-  expected_pattern="${expected_version//./\.}"
+  # Compare the numeric release segment rather than PEP 440 precedence. This
+  # deliberately treats dev, pre, final, post, and local builds on the 0.5.18
+  # release line as supported, while excluding every 0.5.19 build.
+  if ! "${PYBIN}" - "${installed_version}" "${SGLANG_MIN_RELEASE}" "${SGLANG_MAX_RELEASE}" <<'PY'
+import sys
 
-  if [[ "${public_version}" != "${expected_version}" ]] &&
-     ! [[ "${public_version}" =~ ^${expected_pattern}\.dev[0-9]+$ &&
-          "${local_version}" =~ ^g[0-9a-f]+$ ]]; then
-    echo "ERROR: sglang ${installed_version} is installed, but ${expected_version} is required." >&2
-    echo "Install the verified Ascend NPU release before installing sglang-omni:" >&2
-    echo "  https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu" >&2
+try:
+    from packaging.version import InvalidVersion, Version
+except ImportError:
+    from pip._vendor.packaging.version import InvalidVersion, Version
+
+try:
+    installed = Version(sys.argv[1]).release
+except InvalidVersion:
+    raise SystemExit(1)
+
+minimum = Version(sys.argv[2]).release
+maximum = Version(sys.argv[3]).release
+raise SystemExit(0 if minimum <= installed < maximum else 1)
+PY
+  then
+    {
+      echo "ERROR: SGLang version check failed."
+      echo "  supported: ${supported_range}"
+      echo "  installed: ${installed_version}"
+      echo "Install a supported Ascend NPU release:"
+      echo "  https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu"
+    } >&2
     return 1
   fi
 
@@ -348,7 +364,7 @@ verify_install() {
     echo "  [ok] sglang is importable"
   else
     echo "  [warn] sglang is not installed. Follow the Ascend NPU guide for"
-    echo "         the SGLang ${SGLANG_VERIFIED_VERSION} source installation:"
+    echo "         a supported SGLang source installation (${SGLANG_MIN_RELEASE} <= version < ${SGLANG_MAX_RELEASE}):"
     echo "         https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu"
   fi
 

--- a/scripts/npu/install_npu.sh
+++ b/scripts/npu/install_npu.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Install sglang-omni against a pre-installed Huawei Ascend NPU stack.
+# Install sglang-omni against a pre-installed Ascend NPU stack.
 
 set -euo pipefail
 
@@ -98,7 +98,7 @@ configure_install() {
 }
 
 print_summary() {
-  echo "=== sglang-omni Huawei Ascend NPU install ==="
+  echo "=== sglang-omni Ascend NPU install ==="
   echo "  repo:        ${REPO_ROOT}"
   echo "  python:      $("${PYBIN}" -c 'import sys; print(sys.executable)')"
   echo "  target:      ${TARGET}"

--- a/scripts/npu/install_npu.sh
+++ b/scripts/npu/install_npu.sh
@@ -1,88 +1,127 @@
 #!/usr/bin/env bash
-# Install sglang-omni for Huawei Ascend NPU: swap in pyproject_npu.toml and install
-# against the pre-installed torch_npu / triton-ascend stack (the CUDA pyproject would
-# clobber a working torch+npu stack). See docs/get_started/installation_npu.md.
-#
-# Prerequisites (NOT installed by this script — see installation_npu.md):
-#   - CANN toolkit 9.0.0
-#   - torch + torch_npu (matching versions)
-#   - triton-ascend
-#   - memfabric-hybrid (for PD disaggregation)
-#   - sgl-kernel-npu (custom operators)
-#
-# Usage:
-#   scripts/npu/install_npu.sh                    # lean core, editable
-#   scripts/npu/install_npu.sh --extras eval      # core + eval/tests
-#   scripts/npu/install_npu.sh --no-editable      # non-editable
-#   scripts/npu/install_npu.sh --skip-device-check # build host has no visible NPU
-#   scripts/npu/install_npu.sh --check            # dry-run: show what would run
-#
-# Never deletes your pyproject.toml: it is backed up and restored on exit.
+# Install sglang-omni against a pre-installed Huawei Ascend NPU stack.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PYPROJECT="${REPO_ROOT}/pyproject.toml"
+PYPROJECT_NPU="${REPO_ROOT}/pyproject_npu.toml"
+BACKUP="${REPO_ROOT}/.pyproject.cuda.bak"
+LOCK="${REPO_ROOT}/.pyproject.npu.lock"
+SGLANG_VERIFIED_VERSION="v0.5.16"
+
 EDITABLE="-e"
 CHECK_ONLY=0
 SKIP_DEVICE_CHECK=0
 EXTRAS=""
-
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --no-editable) EDITABLE=""; shift ;;
-    --check)       CHECK_ONLY=1; shift ;;
-    --skip-device-check) SKIP_DEVICE_CHECK=1; shift ;;
-    --extras)
-      [[ $# -ge 2 && -n "${2:-}" ]] || { echo "ERROR: --extras requires a value" >&2; exit 2; }
-      EXTRAS="$2"; shift 2 ;;
-    -h|--help)
-      sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
-      exit 0 ;;
-    *) echo "unknown arg: $1" >&2; exit 2 ;;
-  esac
-done
-
-PYPROJECT="${REPO_ROOT}/pyproject.toml"
-PYPROJECT_NPU="${REPO_ROOT}/pyproject_npu.toml"
-BACKUP="${REPO_ROOT}/.pyproject.cuda.bak"
-
-SGLANG_VERIFIED_VERSION="v0.5.16"
-
-[[ -f "${PYPROJECT_NPU}" ]] || { echo "ERROR: ${PYPROJECT_NPU} not found" >&2; exit 1; }
-
-PYBIN="${PYTHON:-python}"
-
-# Build the install target, e.g. ".[eval]" or "."
 TARGET="."
-if [[ -n "${EXTRAS}" ]]; then
-  IFS=',' read -r -a EXTRA_NAMES <<< "${EXTRAS}"
-  for extra in "${EXTRA_NAMES[@]}"; do
-    case "${extra}" in
-      eval|all|fun-cosyvoice3) ;;
+PYBIN="${PYTHON:-python}"
+INSTALL_CMD=()
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/npu/install_npu.sh [OPTIONS]
+
+Install sglang-omni against an existing Ascend software stack. Prerequisites
+are checked but never installed or modified by this script.
+
+Options:
+  --extras NAME[,NAME]  Install eval, all, or fun-cosyvoice3 extras.
+  --no-editable         Perform a non-editable installation.
+  --skip-device-check   Skip NPU availability and MatMul checks.
+  --check               Check prerequisites and show commands without installing.
+  -h, --help            Show this help message.
+EOF
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --no-editable)
+        EDITABLE=""
+        shift
+        ;;
+      --check)
+        CHECK_ONLY=1
+        shift
+        ;;
+      --skip-device-check)
+        SKIP_DEVICE_CHECK=1
+        shift
+        ;;
+      --extras)
+        [[ $# -ge 2 && -n "${2:-}" ]] || {
+          echo "ERROR: --extras requires a value" >&2
+          exit 2
+        }
+        EXTRAS="$2"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
       *)
-        echo "ERROR: unsupported extra '${extra}'; choose eval, all, or fun-cosyvoice3" >&2
+        echo "ERROR: unknown argument: $1" >&2
+        usage >&2
         exit 2
         ;;
     esac
   done
-  TARGET=".[${EXTRAS}]"
-fi
+}
 
-echo "=== sglang-omni Huawei Ascend NPU install ==="
-echo "  repo:        ${REPO_ROOT}"
-echo "  python:      $("${PYBIN}" -c 'import sys; print(sys.executable)')"
-echo "  target:      ${TARGET}"
-echo "  editable:    $([[ -n "${EDITABLE}" ]] && echo yes || echo no)"
+configure_install() {
+  [[ -f "${PYPROJECT_NPU}" ]] || {
+    echo "ERROR: ${PYPROJECT_NPU} not found" >&2
+    exit 1
+  }
 
-# --- Pre-flight: verify NPU stack is installed ---------------------------
-# torch, torch_npu, triton-ascend, and memfabric are intentionally NOT pinned
-# in pyproject_npu.toml (matching upstream SGLang's pyproject_npu.toml where
-# srt_npu = []).  They must be installed BEFORE running this script.
-SGLANG_OMNI_SKIP_NPU_DEVICE_CHECK="${SKIP_DEVICE_CHECK}" "${PYBIN}" - <<'PY' || exit 1
+  if [[ -n "${EXTRAS}" ]]; then
+    local extra
+    local -a extra_names
+    IFS=',' read -r -a extra_names <<< "${EXTRAS}"
+    for extra in "${extra_names[@]}"; do
+      case "${extra}" in
+        eval|all|fun-cosyvoice3) ;;
+        *)
+          echo "ERROR: unsupported extra '${extra}'; choose eval, all, or fun-cosyvoice3" >&2
+          exit 2
+          ;;
+      esac
+    done
+    TARGET=".[${EXTRAS}]"
+  fi
+
+  INSTALL_CMD=("${PYBIN}" -m pip install)
+  [[ -n "${EDITABLE}" ]] && INSTALL_CMD+=("${EDITABLE}")
+  INSTALL_CMD+=("${TARGET}")
+}
+
+print_summary() {
+  echo "=== sglang-omni Huawei Ascend NPU install ==="
+  echo "  repo:        ${REPO_ROOT}"
+  echo "  python:      $("${PYBIN}" -c 'import sys; print(sys.executable)')"
+  echo "  target:      ${TARGET}"
+  echo "  editable:    $([[ -n "${EDITABLE}" ]] && echo yes || echo no)"
+}
+
+precheck() {
+  # These packages must be installed before running this script. Keep version
+  # selection in the official compatibility guides rather than hard-coding an
+  # example stack here.
+  SGLANG_OMNI_SKIP_NPU_DEVICE_CHECK="${SKIP_DEVICE_CHECK}" "${PYBIN}" - <<'PY'
 import os
 import sys
 from importlib.metadata import PackageNotFoundError, version
 from re import match
+
+ASCEND_PYTORCH_URL = (
+    "https://www.hiascend.com/developer/software/ai-frameworks/pytorch/download"
+)
+TRITON_ASCEND_URL = (
+    "https://gitcode.com/Ascend/triton-ascend/blob/main/docs/en/quick_start.md"
+)
+SGL_KERNEL_NPU_URL = "https://github.com/sgl-project/sgl-kernel-npu/releases"
 
 errors = []
 torch = None
@@ -90,41 +129,51 @@ torch_npu = None
 
 try:
     import torch
+
     print(f"  torch:       {torch.__version__}")
 except ImportError:
-    errors.append("torch is not installed. Install CPU torch first:\n"
-                  "  pip install torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cpu")
+    errors.append(
+        "torch is not installed. Select a compatible release from:\n"
+        f"    {ASCEND_PYTORCH_URL}"
+    )
 
 try:
     import torch_npu
+
     print(f"  torch_npu:   {torch_npu.__version__}")
 except ImportError:
-    errors.append("torch_npu is not installed. Install from Huawei OBS:\n"
-                  "  pip install torch_npu==2.10.0  # or from https://gitcode.com/Ascend/pytorch/releases")
+    errors.append(
+        "torch_npu is not installed. Select the matching release from:\n"
+        f"    {ASCEND_PYTORCH_URL}"
+    )
 
 try:
     import triton
+
     triton_ascend_version = version("triton-ascend")
     print(f"  triton:      {triton.__version__} (triton-ascend {triton_ascend_version})")
 except (ImportError, PackageNotFoundError):
-    errors.append("triton-ascend is not installed. Install from Huawei cloud mirror:\n"
-                  "  pip install triton-ascend==3.2.1.dev20260530 \\\n"
-                  "    --extra-index-url=https://mirrors.huaweicloud.com/ascend/repos/pypi/nightly \\\n"
-                  "    --trusted-host mirrors.huaweicloud.com")
+    errors.append(
+        "triton-ascend is not installed. Follow the official documentation:\n"
+        f"    {TRITON_ASCEND_URL}"
+    )
 
 try:
     import memfabric
+
     print(f"  memfabric:   {memfabric.__version__}")
 except ImportError:
-    # memfabric is only needed for PD disaggregation; warn, don't error
     print("  memfabric:   not installed (only needed for PD disaggregation)")
 
 try:
     import sgl_kernel_npu
+
     print(f"  sgl-kernel:  {getattr(sgl_kernel_npu, '__version__', 'installed')}")
 except ImportError:
-    errors.append("sgl-kernel-npu is not installed. Install a release from:\n"
-                  "  https://github.com/sgl-project/sgl-kernel-npu/releases")
+    errors.append(
+        "sgl-kernel-npu is not installed. Select a compatible release from:\n"
+        f"    {SGL_KERNEL_NPU_URL}"
+    )
 
 if torch is not None and torch_npu is not None:
     def major_minor(value):
@@ -156,56 +205,51 @@ if torch is not None and torch_npu is not None:
             errors.append(f"NPU health check failed: {exc}")
 
 if errors:
-    print()
-    print("ERROR: NPU prerequisites are missing.", file=sys.stderr)
-    for e in errors:
-        print(f"  - {e}", file=sys.stderr)
-    print(file=sys.stderr)
-    print("See docs/get_started/installation_npu.md for the full install sequence.", file=sys.stderr)
+    print("\nERROR: NPU prerequisites are missing.", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    print(
+        "\nSee docs/get_started/installation_npu.md for prerequisite links.",
+        file=sys.stderr,
+    )
     sys.exit(1)
 PY
-
-INSTALL_CMD=("${PYBIN}" -m pip install)
-[[ -n "${EDITABLE}" ]] && INSTALL_CMD+=("${EDITABLE}")
-INSTALL_CMD+=("${TARGET}")
+}
 
 print_install_command() {
   printf '%q ' "${INSTALL_CMD[@]}"
   printf '\n'
 }
 
-# --- Serialize the swap (same flock pattern as XPU) ----------------------
-LOCK="${REPO_ROOT}/.pyproject.npu.lock"
-if ! command -v flock >/dev/null 2>&1; then
-  echo "ERROR: flock is required to serialize the pyproject swap" >&2
-  exit 1
-fi
-exec 9>"${LOCK}" || { echo "ERROR: cannot open lock ${LOCK}" >&2; exit 1; }
-if ! flock -n 9; then
-  echo "ERROR: another ${0##*/} holds ${LOCK}; wait for it to finish" >&2
-  exit 1
-fi
+acquire_lock() {
+  if ! command -v flock >/dev/null 2>&1; then
+    echo "ERROR: flock is required to serialize the pyproject swap" >&2
+    exit 1
+  fi
+  exec 9>"${LOCK}" || {
+    echo "ERROR: cannot open lock ${LOCK}" >&2
+    exit 1
+  }
+  if ! flock -n 9; then
+    echo "ERROR: another ${0##*/} holds ${LOCK}; wait for it to finish" >&2
+    exit 1
+  fi
+}
 
-# A leftover backup means a previous run died after the swap (SIGKILL, OOM, power
-# loss -- INT/TERM are trapped below). pyproject.toml is then the NPU manifest and
-# this backup holds the only copy of the original, so the cp below would destroy it.
-# Refuse instead, and hand back the recovery step. Checked before the trap is armed
-# so exiting here cannot itself touch either file.
-if [[ -e "${BACKUP}" ]]; then
+check_stale_backup() {
+  [[ ! -e "${BACKUP}" ]] && return
   {
     echo "ERROR: leftover backup found: ${BACKUP}"
     echo
-    echo "A previous run was interrupted after swapping pyproject.toml, so that"
-    echo "backup is the only copy of your original manifest. Restore it first:"
+    echo "A previous run was interrupted after swapping pyproject.toml."
+    echo "Restore the original manifest before re-running this script:"
     echo
     echo "  cp ${BACKUP} ${PYPROJECT} && rm ${BACKUP}"
-    echo
-    echo "Then re-run this script."
   } >&2
   exit 1
-fi
+}
 
-if [[ "${CHECK_ONLY}" -eq 1 ]]; then
+show_dry_run() {
   echo
   echo "[--check] would run:"
   echo "  cp pyproject.toml .pyproject.cuda.bak"
@@ -213,12 +257,8 @@ if [[ "${CHECK_ONLY}" -eq 1 ]]; then
   printf '  '
   print_install_command
   echo "  # then restore pyproject.toml from backup"
-  exit 0
-fi
+}
 
-# Restore the CUDA pyproject.toml no matter how we exit. Use cp (not mv) so a
-# partial/interrupted restore still leaves the backup in place, and also sweep
-# the in-tree build artifacts an editable build may drop.
 restore() {
   if [[ -f "${BACKUP}" ]]; then
     cp -f "${BACKUP}" "${PYPROJECT}"
@@ -227,62 +267,81 @@ restore() {
   fi
   rm -rf "${REPO_ROOT}/sglang_omni.egg-info" "${REPO_ROOT}/build" 2>/dev/null || true
 }
-trap restore EXIT INT TERM
 
-cp -f "${PYPROJECT}" "${BACKUP}"
-cp -f "${PYPROJECT_NPU}" "${PYPROJECT}"
-echo "swapped in pyproject_npu.toml"
+install_project() {
+  trap restore EXIT INT TERM
 
-printf '>>> '
-print_install_command
-"${INSTALL_CMD[@]}"
+  cp -f "${PYPROJECT}" "${BACKUP}"
+  cp -f "${PYPROJECT_NPU}" "${PYPROJECT}"
+  echo "swapped in pyproject_npu.toml"
 
-# Restore immediately (don't wait for EXIT) so verification below runs against a
-# clean tree and the installed editable metadata (not the swapped file).
-restore
-trap - EXIT INT TERM
+  printf '>>> '
+  print_install_command
+  "${INSTALL_CMD[@]}"
 
-echo
-echo "=== verifying install ==="
-VERIFY_RC=0
-# import must work from OUTSIDE the repo (proves a real install, not cwd-on-path)
-if (cd / && "${PYBIN}" -c "import sglang_omni" 2>/dev/null); then
-  echo "  [ok] import sglang_omni works from outside the repo"
-else
-  echo "  [FAIL] import sglang_omni does NOT work outside the repo (editable .pth missing)"
-  VERIFY_RC=1
-fi
-if "${PYBIN}" -m pip show sglang-omni >/dev/null 2>&1; then
-  echo "  [ok] pip shows sglang-omni: $(${PYBIN} -m pip show sglang-omni 2>/dev/null | awk '/^Version:/{print $2}')"
-else
-  echo "  [FAIL] pip does not show sglang-omni"
-  VERIFY_RC=1
-fi
-if command -v sgl-omni >/dev/null 2>&1 || [[ -x "$(dirname "$(${PYBIN} -c 'import sys;print(sys.executable)')")/sgl-omni" ]]; then
-  echo "  [ok] sgl-omni console script present"
-else
-  echo "  [warn] sgl-omni not on PATH (check the env's bin dir)"
-fi
+  restore
+  trap - EXIT INT TERM
+}
 
-# SGLang is never installed by this script (it cannot be pinned for NPU), so
-# report whether it is importable at all.
-if "${PYBIN}" -c "import sglang" >/dev/null 2>&1; then
-  echo "  [ok] sglang is importable"
-else
-  echo "  [warn] sglang is NOT installed — it is intentionally not a dependency here."
-  echo "         Build the NPU SGLang from source (${SGLANG_VERIFIED_VERSION}):"
-  echo "           git clone https://github.com/sgl-project/sglang && cd sglang"
-  echo "           git checkout ${SGLANG_VERIFIED_VERSION}"
-  echo "           cd python && cp pyproject_npu.toml pyproject.toml"
-  echo "           pip install -e . --no-build-isolation"
-fi
+verify_install() {
+  local verify_rc=0
 
-if [[ "${VERIFY_RC}" -ne 0 ]]; then
   echo
-  echo "INSTALL VERIFICATION FAILED. Review the pip build output above."
-  exit 1
-fi
+  echo "=== verifying install ==="
+  if (cd / && "${PYBIN}" -c "import sglang_omni" 2>/dev/null); then
+    echo "  [ok] import sglang_omni works from outside the repo"
+  else
+    echo "  [FAIL] import sglang_omni does NOT work outside the repo"
+    verify_rc=1
+  fi
 
-echo
-echo "=== done. Next: ==="
-echo "  sgl-omni serve --model-path <path-to-model> --port 8000"
+  if "${PYBIN}" -m pip show sglang-omni >/dev/null 2>&1; then
+    echo "  [ok] pip shows sglang-omni: $("${PYBIN}" -m pip show sglang-omni 2>/dev/null | awk '/^Version:/{print $2}')"
+  else
+    echo "  [FAIL] pip does not show sglang-omni"
+    verify_rc=1
+  fi
+
+  if command -v sgl-omni >/dev/null 2>&1 || [[ -x "$(dirname "$("${PYBIN}" -c 'import sys;print(sys.executable)')")/sgl-omni" ]]; then
+    echo "  [ok] sgl-omni console script present"
+  else
+    echo "  [warn] sgl-omni not on PATH (check the environment's bin directory)"
+  fi
+
+  if "${PYBIN}" -c "import sglang" >/dev/null 2>&1; then
+    echo "  [ok] sglang is importable"
+  else
+    echo "  [warn] sglang is not installed. Follow the Ascend NPU guide for"
+    echo "         the SGLang ${SGLANG_VERIFIED_VERSION} source installation:"
+    echo "         https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu"
+  fi
+
+  if [[ "${verify_rc}" -ne 0 ]]; then
+    echo
+    echo "INSTALL VERIFICATION FAILED. Review the pip build output above."
+    return 1
+  fi
+}
+
+main() {
+  parse_args "$@"
+  configure_install
+  print_summary
+  precheck
+  acquire_lock
+  check_stale_backup
+
+  if [[ "${CHECK_ONLY}" -eq 1 ]]; then
+    show_dry_run
+    return
+  fi
+
+  install_project
+  verify_install
+
+  echo
+  echo "=== done. Next: ==="
+  echo "  sgl-omni serve --model-path <path-to-model> --port 8000"
+}
+
+main "$@"

--- a/scripts/npu/install_npu.sh
+++ b/scripts/npu/install_npu.sh
@@ -8,7 +8,7 @@ PYPROJECT="${REPO_ROOT}/pyproject.toml"
 PYPROJECT_NPU="${REPO_ROOT}/pyproject_npu.toml"
 BACKUP="${REPO_ROOT}/.pyproject.cuda.bak"
 LOCK="${REPO_ROOT}/.pyproject.npu.lock"
-SGLANG_VERIFIED_VERSION="v0.5.16"
+SGLANG_VERIFIED_VERSION="v0.5.18"
 
 EDITABLE="-e"
 CHECK_ONLY=0

--- a/scripts/npu/install_npu.sh
+++ b/scripts/npu/install_npu.sh
@@ -14,6 +14,7 @@
 #   scripts/npu/install_npu.sh                    # lean core, editable
 #   scripts/npu/install_npu.sh --extras eval      # core + eval/tests
 #   scripts/npu/install_npu.sh --no-editable      # non-editable
+#   scripts/npu/install_npu.sh --skip-device-check # build host has no visible NPU
 #   scripts/npu/install_npu.sh --check            # dry-run: show what would run
 #
 # Never deletes your pyproject.toml: it is backed up and restored on exit.
@@ -23,13 +24,17 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 EDITABLE="-e"
 CHECK_ONLY=0
+SKIP_DEVICE_CHECK=0
 EXTRAS=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --no-editable) EDITABLE=""; shift ;;
     --check)       CHECK_ONLY=1; shift ;;
-    --extras)      EXTRAS="${2:-}"; shift 2 ;;
+    --skip-device-check) SKIP_DEVICE_CHECK=1; shift ;;
+    --extras)
+      [[ $# -ge 2 && -n "${2:-}" ]] || { echo "ERROR: --extras requires a value" >&2; exit 2; }
+      EXTRAS="$2"; shift 2 ;;
     -h|--help)
       sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0 ;;
@@ -50,12 +55,22 @@ PYBIN="${PYTHON:-python}"
 # Build the install target, e.g. ".[eval]" or "."
 TARGET="."
 if [[ -n "${EXTRAS}" ]]; then
+  IFS=',' read -r -a EXTRA_NAMES <<< "${EXTRAS}"
+  for extra in "${EXTRA_NAMES[@]}"; do
+    case "${extra}" in
+      eval|all|fun-cosyvoice3) ;;
+      *)
+        echo "ERROR: unsupported extra '${extra}'; choose eval, all, or fun-cosyvoice3" >&2
+        exit 2
+        ;;
+    esac
+  done
   TARGET=".[${EXTRAS}]"
 fi
 
 echo "=== sglang-omni Huawei Ascend NPU install ==="
 echo "  repo:        ${REPO_ROOT}"
-echo "  python:      $(${PYBIN} -c 'import sys; print(sys.executable)')"
+echo "  python:      $("${PYBIN}" -c 'import sys; print(sys.executable)')"
 echo "  target:      ${TARGET}"
 echo "  editable:    $([[ -n "${EDITABLE}" ]] && echo yes || echo no)"
 
@@ -63,10 +78,15 @@ echo "  editable:    $([[ -n "${EDITABLE}" ]] && echo yes || echo no)"
 # torch, torch_npu, triton-ascend, and memfabric are intentionally NOT pinned
 # in pyproject_npu.toml (matching upstream SGLang's pyproject_npu.toml where
 # srt_npu = []).  They must be installed BEFORE running this script.
-${PYBIN} - <<'PY' || exit 1
+SGLANG_OMNI_SKIP_NPU_DEVICE_CHECK="${SKIP_DEVICE_CHECK}" "${PYBIN}" - <<'PY' || exit 1
+import os
 import sys
+from importlib.metadata import PackageNotFoundError, version
+from re import match
 
 errors = []
+torch = None
+torch_npu = None
 
 try:
     import torch
@@ -84,8 +104,9 @@ except ImportError:
 
 try:
     import triton
-    print(f"  triton:      {triton.__version__}")
-except ImportError:
+    triton_ascend_version = version("triton-ascend")
+    print(f"  triton:      {triton.__version__} (triton-ascend {triton_ascend_version})")
+except (ImportError, PackageNotFoundError):
     errors.append("triton-ascend is not installed. Install from Huawei cloud mirror:\n"
                   "  pip install triton-ascend==3.2.1.dev20260530 \\\n"
                   "    --extra-index-url=https://mirrors.huaweicloud.com/ascend/repos/pypi/nightly \\\n"
@@ -97,6 +118,42 @@ try:
 except ImportError:
     # memfabric is only needed for PD disaggregation; warn, don't error
     print("  memfabric:   not installed (only needed for PD disaggregation)")
+
+try:
+    import sgl_kernel_npu
+    print(f"  sgl-kernel:  {getattr(sgl_kernel_npu, '__version__', 'installed')}")
+except ImportError:
+    errors.append("sgl-kernel-npu is not installed. Install a release from:\n"
+                  "  https://github.com/sgl-project/sgl-kernel-npu/releases")
+
+if torch is not None and torch_npu is not None:
+    def major_minor(value):
+        parsed = match(r"^(\d+)\.(\d+)", value)
+        return parsed.groups() if parsed else None
+
+    if major_minor(torch.__version__) != major_minor(torch_npu.__version__):
+        errors.append(
+            f"torch {torch.__version__} and torch_npu {torch_npu.__version__} "
+            "must have matching major.minor versions"
+        )
+
+    if os.environ["SGLANG_OMNI_SKIP_NPU_DEVICE_CHECK"] == "1":
+        print("  NPU health:  skipped (--skip-device-check)")
+    else:
+        try:
+            if not torch.npu.is_available():
+                raise RuntimeError("torch.npu.is_available() returned False")
+            count = torch.npu.device_count()
+            if count < 1:
+                raise RuntimeError(f"torch.npu.device_count() returned {count}")
+            lhs = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="npu")
+            actual = (lhs @ lhs).cpu()
+            expected = torch.tensor([[7.0, 10.0], [15.0, 22.0]])
+            if not torch.equal(actual, expected):
+                raise RuntimeError(f"MatMul result mismatch: {actual}")
+            print(f"  NPU devices: {count}; MatMul: ok")
+        except Exception as exc:
+            errors.append(f"NPU health check failed: {exc}")
 
 if errors:
     print()
@@ -140,7 +197,14 @@ if not hasattr(setuptools.build_meta, "build_editable"):
     )
 PY
 NOISO="--no-build-isolation"
-INSTALL_CMD="${PYBIN} -m pip install ${EDITABLE} ${TARGET} ${NOISO}"
+INSTALL_CMD=("${PYBIN}" -m pip install)
+[[ -n "${EDITABLE}" ]] && INSTALL_CMD+=("${EDITABLE}")
+INSTALL_CMD+=("${TARGET}" "${NOISO}")
+
+print_install_command() {
+  printf '%q ' "${INSTALL_CMD[@]}"
+  printf '\n'
+}
 
 # --- Serialize the swap (same flock pattern as XPU) ----------------------
 LOCK="${REPO_ROOT}/.pyproject.npu.lock"
@@ -178,7 +242,8 @@ if [[ "${CHECK_ONLY}" -eq 1 ]]; then
   echo "[--check] would run:"
   echo "  cp pyproject.toml .pyproject.cuda.bak"
   echo "  cp pyproject_npu.toml pyproject.toml"
-  echo "  ${INSTALL_CMD}"
+  printf '  '
+  print_install_command
   echo "  # then restore pyproject.toml from backup"
   exit 0
 fi
@@ -200,8 +265,9 @@ cp -f "${PYPROJECT}" "${BACKUP}"
 cp -f "${PYPROJECT_NPU}" "${PYPROJECT}"
 echo "swapped in pyproject_npu.toml"
 
-echo ">>> ${INSTALL_CMD}"
-${INSTALL_CMD}
+printf '>>> '
+print_install_command
+"${INSTALL_CMD[@]}"
 
 # Restore immediately (don't wait for EXIT) so verification below runs against a
 # clean tree and a setuptools editable .pth (not the swapped file).

--- a/scripts/npu/install_npu.sh
+++ b/scripts/npu/install_npu.sh
@@ -165,41 +165,9 @@ if errors:
     sys.exit(1)
 PY
 
-# --- Verify setuptools >= 77 (same rationale as XPU) ---------------------
-# --no-build-isolation is REQUIRED (see docs/get_started/installation_npu.md):
-# with build isolation, pip spins up an isolated build env whose fallback
-# setuptools emits a legacy in-tree egg-info instead of a PEP 660 editable .pth
-# — the package then isn't importable outside the repo and no sgl-omni console
-# script is created. Without isolation the build uses this env's setuptools, so the
-# build requirement in pyproject_npu.toml is never enforced by pip -- check it here
-# instead of failing later in metadata generation.
-"${PYBIN}" - <<'PY' || exit 1
-import sys
-
-import setuptools
-import setuptools.build_meta
-
-version = tuple(
-    int("".join(char for char in part if char.isdigit()) or 0)
-    for part in setuptools.__version__.split(".")[:2]
-)
-if version < (77, 0):
-    sys.exit(
-        f"setuptools {setuptools.__version__} is too old: pyproject_npu.toml uses "
-        "the PEP 639 license fields, which 76.1 and older reject with 'invalid "
-        "pyproject.toml config: `project.license`'. --no-build-isolation means pip "
-        "will not upgrade it for you, so run: pip install -U 'setuptools>=77.0.0'"
-    )
-if not hasattr(setuptools.build_meta, "build_editable"):
-    sys.exit(
-        f"setuptools {setuptools.__version__} lacks PEP 660 support; an editable "
-        "install would emit a legacy egg-info."
-    )
-PY
-NOISO="--no-build-isolation"
 INSTALL_CMD=("${PYBIN}" -m pip install)
 [[ -n "${EDITABLE}" ]] && INSTALL_CMD+=("${EDITABLE}")
-INSTALL_CMD+=("${TARGET}" "${NOISO}")
+INSTALL_CMD+=("${TARGET}")
 
 print_install_command() {
   printf '%q ' "${INSTALL_CMD[@]}"
@@ -270,7 +238,7 @@ print_install_command
 "${INSTALL_CMD[@]}"
 
 # Restore immediately (don't wait for EXIT) so verification below runs against a
-# clean tree and a setuptools editable .pth (not the swapped file).
+# clean tree and the installed editable metadata (not the swapped file).
 restore
 trap - EXIT INT TERM
 
@@ -311,9 +279,7 @@ fi
 
 if [[ "${VERIFY_RC}" -ne 0 ]]; then
   echo
-  echo "INSTALL VERIFICATION FAILED. If setuptools fell back to legacy egg-info,"
-  echo "retry with a PEP 660 editable build, e.g.:"
-  echo "  ${PYBIN} -m pip install -e . --config-settings editable_mode=strict"
+  echo "INSTALL VERIFICATION FAILED. Review the pip build output above."
   exit 1
 fi
 

--- a/tests/unit_test/npu/test_install_script.py
+++ b/tests/unit_test/npu/test_install_script.py
@@ -84,7 +84,8 @@ def test_supported_extras_are_preserved_as_one_argument(repo: Path, extra: str) 
     result = _run(repo, "--check", "--extras", extra)
 
     assert result.returncode == 0
-    assert f".\\[{extra}\\]" in result.stdout
+    # Bash versions differ on whether printf %q escapes commas.
+    assert f".\\[{extra}\\]" in result.stdout.replace("\\,", ",")
 
 
 def test_unknown_extra_is_rejected(repo: Path) -> None:

--- a/tests/unit_test/npu/test_install_script.py
+++ b/tests/unit_test/npu/test_install_script.py
@@ -27,16 +27,24 @@ def repo(tmp_path: Path) -> Path:
     fake_python = root / "fake python"
     fake_python.write_text(
         "#!/usr/bin/env bash\n"
-        'if [[ "$1" == "-c" ]]; then printf \'%s\\n\' "$0"; fi\n'
+        'if [[ "$1" == "-c" && "$2" == *\'version("sglang")\'* ]]; then\n'
+        '  [[ "${FAKE_SGLANG_INSTALLED:-1}" == "1" ]] || exit 1\n'
+        "  printf '%s\\n' \"${FAKE_SGLANG_VERSION:-0.5.18}\"\n"
+        'elif [[ "$1" == "-c" ]]; then\n'
+        "  printf '%s\\n' \"$0\"\n"
+        "fi\n"
         "exit 0\n"
     )
     fake_python.chmod(0o755)
     return root
 
 
-def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+def _run(
+    repo: Path, *args: str, env_overrides: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["PYTHON"] = str(repo / "fake python")
+    env.update(env_overrides or {})
     return subprocess.run(
         ["bash", "scripts/npu/install_npu.sh", *args],
         cwd=repo,
@@ -75,6 +83,30 @@ def test_install_uses_build_isolation_by_default(repo: Path) -> None:
 
     assert result.returncode == 0
     assert "--no-build-isolation" not in result.stdout
+
+
+@pytest.mark.parametrize("installed", ["0.5.18", "0.5.18+ascend"])
+def test_matching_sglang_version_is_accepted(repo: Path, installed: str) -> None:
+    result = _run(repo, "--check", env_overrides={"FAKE_SGLANG_VERSION": installed})
+
+    assert result.returncode == 0
+    assert f"sglang:      {installed}" in result.stdout
+
+
+def test_mismatched_sglang_version_is_rejected(repo: Path) -> None:
+    result = _run(repo, "--check", env_overrides={"FAKE_SGLANG_VERSION": "0.5.16"})
+
+    assert result.returncode != 0
+    assert "sglang 0.5.16 is installed, but 0.5.18 is required" in result.stderr
+    assert "would run" not in result.stdout
+
+
+def test_missing_sglang_is_rejected(repo: Path) -> None:
+    result = _run(repo, "--check", env_overrides={"FAKE_SGLANG_INSTALLED": "0"})
+
+    assert result.returncode != 0
+    assert "sglang 0.5.18 is required but is not installed" in result.stderr
+    assert "would run" not in result.stdout
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_test/npu/test_install_script.py
+++ b/tests/unit_test/npu/test_install_script.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Safety and argument tests for the Ascend NPU install helper."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path("scripts/npu/install_npu.sh")
+_ORIGINAL_MARKER = "# ORIGINAL-CUDA-MANIFEST"
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    (root / "scripts" / "npu").mkdir(parents=True)
+    shutil.copy(_SCRIPT, root / "scripts" / "npu" / "install_npu.sh")
+    (root / "pyproject.toml").write_text(f'{_ORIGINAL_MARKER}\n[project]\nname = "x"\n')
+    (root / "pyproject_npu.toml").write_text('[project]\nname = "x-npu"\n')
+
+    # A space in the executable path catches accidental shell word splitting.
+    fake_python = root / "fake python"
+    fake_python.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [[ "$1" == "-c" ]]; then printf \'%s\\n\' "$0"; fi\n'
+        "exit 0\n"
+    )
+    fake_python.chmod(0o755)
+    return root
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHON"] = str(repo / "fake python")
+    return subprocess.run(
+        ["bash", "scripts/npu/install_npu.sh", *args],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+def test_rerun_after_interrupted_swap_preserves_original(repo: Path) -> None:
+    backup = repo / ".pyproject.cuda.bak"
+    shutil.copy(repo / "pyproject.toml", backup)
+    shutil.copy(repo / "pyproject_npu.toml", repo / "pyproject.toml")
+
+    result = _run(repo, "--check")
+
+    assert result.returncode != 0
+    assert _ORIGINAL_MARKER in backup.read_text()
+    assert "leftover backup" in result.stderr
+    assert "git checkout" not in result.stderr
+
+
+def test_clean_dry_run_does_not_modify_manifest(repo: Path) -> None:
+    result = _run(repo, "--check")
+
+    assert result.returncode == 0
+    assert "would run" in result.stdout
+    assert (repo / "pyproject.toml").read_text().startswith(_ORIGINAL_MARKER)
+    assert not (repo / ".pyproject.cuda.bak").exists()
+
+
+@pytest.mark.parametrize(
+    "extra", ["eval", "all", "fun-cosyvoice3", "eval,fun-cosyvoice3"]
+)
+def test_supported_extras_are_preserved_as_one_argument(repo: Path, extra: str) -> None:
+    result = _run(repo, "--check", "--extras", extra)
+
+    assert result.returncode == 0
+    assert f".\\[{extra}\\]" in result.stdout
+
+
+def test_unknown_extra_is_rejected(repo: Path) -> None:
+    result = _run(repo, "--check", "--extras", "eval] --index-url bad [")
+
+    assert result.returncode == 2
+    assert "unsupported extra" in result.stderr
+
+
+def test_missing_extra_value_is_rejected(repo: Path) -> None:
+    result = _run(repo, "--extras")
+
+    assert result.returncode == 2
+    assert "requires a value" in result.stderr
+
+
+def test_skip_device_check_flag_is_accepted(repo: Path) -> None:
+    result = _run(repo, "--check", "--skip-device-check")
+
+    assert result.returncode == 0
+
+
+def test_second_run_refuses_while_lock_is_held(repo: Path) -> None:
+    lock = repo / ".pyproject.npu.lock"
+    lock.touch()
+    holder = subprocess.Popen(["flock", str(lock), "sleep", "10"])
+    try:
+        time.sleep(0.2)
+        result = _run(repo, "--check")
+    finally:
+        holder.kill()
+        holder.wait()
+
+    assert result.returncode != 0
+    assert "holds" in result.stderr
+    assert _ORIGINAL_MARKER in (repo / "pyproject.toml").read_text()
+    assert not (repo / ".pyproject.cuda.bak").exists()

--- a/tests/unit_test/npu/test_install_script.py
+++ b/tests/unit_test/npu/test_install_script.py
@@ -70,6 +70,13 @@ def test_clean_dry_run_does_not_modify_manifest(repo: Path) -> None:
     assert not (repo / ".pyproject.cuda.bak").exists()
 
 
+def test_install_uses_build_isolation_by_default(repo: Path) -> None:
+    result = _run(repo, "--check")
+
+    assert result.returncode == 0
+    assert "--no-build-isolation" not in result.stdout
+
+
 @pytest.mark.parametrize(
     "extra", ["eval", "all", "fun-cosyvoice3", "eval,fun-cosyvoice3"]
 )

--- a/tests/unit_test/npu/test_install_script.py
+++ b/tests/unit_test/npu/test_install_script.py
@@ -85,7 +85,9 @@ def test_install_uses_build_isolation_by_default(repo: Path) -> None:
     assert "--no-build-isolation" not in result.stdout
 
 
-@pytest.mark.parametrize("installed", ["0.5.18", "0.5.18+ascend"])
+@pytest.mark.parametrize(
+    "installed", ["0.5.18", "0.5.18+ascend", "0.5.18.dev7+gec43c1f20"]
+)
 def test_matching_sglang_version_is_accepted(repo: Path, installed: str) -> None:
     result = _run(repo, "--check", env_overrides={"FAKE_SGLANG_VERSION": installed})
 
@@ -93,11 +95,15 @@ def test_matching_sglang_version_is_accepted(repo: Path, installed: str) -> None
     assert f"sglang:      {installed}" in result.stdout
 
 
-def test_mismatched_sglang_version_is_rejected(repo: Path) -> None:
-    result = _run(repo, "--check", env_overrides={"FAKE_SGLANG_VERSION": "0.5.16"})
+@pytest.mark.parametrize(
+    "installed",
+    ["0.5.16", "0.5.18.dev7", "0.5.18rc1", "0.5.19.dev1+g1234567"],
+)
+def test_mismatched_sglang_version_is_rejected(repo: Path, installed: str) -> None:
+    result = _run(repo, "--check", env_overrides={"FAKE_SGLANG_VERSION": installed})
 
     assert result.returncode != 0
-    assert "sglang 0.5.16 is installed, but 0.5.18 is required" in result.stderr
+    assert f"sglang {installed} is installed, but 0.5.18 is required" in result.stderr
     assert "would run" not in result.stdout
 
 

--- a/tests/unit_test/npu/test_npu_install_script.py
+++ b/tests/unit_test/npu/test_npu_install_script.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Safety and argument tests for the Ascend NPU install helper."""
+"""Test safety and argument handling for the Ascend NPU install helper."""
 
 from __future__ import annotations
 
@@ -30,6 +30,11 @@ def repo(tmp_path: Path) -> Path:
         'if [[ "$1" == "-c" && "$2" == *\'version("sglang")\'* ]]; then\n'
         '  [[ "${FAKE_SGLANG_INSTALLED:-1}" == "1" ]] || exit 1\n'
         "  printf '%s\\n' \"${FAKE_SGLANG_VERSION:-0.5.18}\"\n"
+        'elif [[ "$1" == "-" && $# -ge 2 ]]; then\n'
+        '  case "$2" in\n'
+        "    0.5.18|0.5.18.*|0.5.18+*|0.5.18a*|0.5.18b*|0.5.18rc*) exit 0 ;;\n"
+        "    *) exit 1 ;;\n"
+        "  esac\n"
         'elif [[ "$1" == "-c" ]]; then\n'
         "  printf '%s\\n' \"$0\"\n"
         "fi\n"
@@ -86,7 +91,14 @@ def test_install_uses_build_isolation_by_default(repo: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    "installed", ["0.5.18", "0.5.18+ascend", "0.5.18.dev7+gec43c1f20"]
+    "installed",
+    [
+        "0.5.18.dev7+gec43c1f20",
+        "0.5.18rc1",
+        "0.5.18",
+        "0.5.18+ascend",
+        "0.5.18.post1",
+    ],
 )
 def test_matching_sglang_version_is_accepted(repo: Path, installed: str) -> None:
     result = _run(repo, "--check", env_overrides={"FAKE_SGLANG_VERSION": installed})
@@ -97,13 +109,19 @@ def test_matching_sglang_version_is_accepted(repo: Path, installed: str) -> None
 
 @pytest.mark.parametrize(
     "installed",
-    ["0.5.16", "0.5.18.dev7", "0.5.18rc1", "0.5.19.dev1+g1234567"],
+    [
+        "0.5.16",
+        "0.5.17.post1",
+        "0.5.19.dev1",
+        "0.5.19",
+    ],
 )
 def test_mismatched_sglang_version_is_rejected(repo: Path, installed: str) -> None:
     result = _run(repo, "--check", env_overrides={"FAKE_SGLANG_VERSION": installed})
 
     assert result.returncode != 0
-    assert f"sglang {installed} is installed, but 0.5.18 is required" in result.stderr
+    assert "supported: >=0.5.18,<0.5.19" in result.stderr
+    assert f"installed: {installed}" in result.stderr
     assert "would run" not in result.stdout
 
 
@@ -111,7 +129,8 @@ def test_missing_sglang_is_rejected(repo: Path) -> None:
     result = _run(repo, "--check", env_overrides={"FAKE_SGLANG_INSTALLED": "0"})
 
     assert result.returncode != 0
-    assert "sglang 0.5.18 is required but is not installed" in result.stderr
+    assert "supported: >=0.5.18,<0.5.19" in result.stderr
+    assert "installed: not installed" in result.stderr
     assert "would run" not in result.stdout
 
 

--- a/tests/unit_test/npu/test_npu_install_script.py
+++ b/tests/unit_test/npu/test_npu_install_script.py
@@ -98,6 +98,7 @@ def test_install_uses_build_isolation_by_default(repo: Path) -> None:
         "0.5.18",
         "0.5.18+ascend",
         "0.5.18.post1",
+        "0.5.18.1",
     ],
 )
 def test_matching_sglang_version_is_accepted(repo: Path, installed: str) -> None:
@@ -120,7 +121,7 @@ def test_mismatched_sglang_version_is_rejected(repo: Path, installed: str) -> No
     result = _run(repo, "--check", env_overrides={"FAKE_SGLANG_VERSION": installed})
 
     assert result.returncode != 0
-    assert "supported: >=0.5.18,<0.5.19" in result.stderr
+    assert "supported: 0.5.18 release line" in result.stderr
     assert f"installed: {installed}" in result.stderr
     assert "would run" not in result.stdout
 
@@ -129,7 +130,7 @@ def test_missing_sglang_is_rejected(repo: Path) -> None:
     result = _run(repo, "--check", env_overrides={"FAKE_SGLANG_INSTALLED": "0"})
 
     assert result.returncode != 0
-    assert "supported: >=0.5.18,<0.5.19" in result.stderr
+    assert "supported: 0.5.18 release line" in result.stderr
     assert "installed: not installed" in result.stderr
     assert "would run" not in result.stdout
 


### PR DESCRIPTION
## Motivation

The default `pyproject.toml` includes CUDA-specific dependencies that can conflict with an existing Ascend `torch_npu` environment. This PR adds a separate, maintainable installation path for Ascend NPU without changing the externally managed accelerator software stack.

Part of #1597.

## Modifications

- Add `pyproject_npu.toml` with an Ascend-compatible dependency set and optional extras while leaving `torch`, `torch_npu`, `triton-ascend`, `sgl-kernel-npu`, and SGLang under user/upstream version management.
- Align the documented NPU installation baseline with the SGLang `0.5.18` release line.
- Keep the supported SGLang release in one configuration value so future upgrades do not require maintaining a duplicated upper-bound version.
- Add executable `scripts/npu/install_npu.sh`, organized into focused argument parsing, precheck, install, cleanup, verification, and `main` functions.
- Add prechecks for:
  - installed SGLang belonging to the supported `0.5.18` release line, including development, pre-release, final, post-release, and local builds such as `0.5.18.dev7+g<git-sha>`
  - `torch`/`torch_npu` major-minor compatibility
  - `triton-ascend` and `sgl-kernel-npu` imports
  - NPU availability/count and a minimal MatMul
  - `--skip-device-check` for build hosts without exposed devices
- Preserve the original CUDA manifest with locking, stale-backup detection, and restore-on-exit behavior.
- Add `docs/get_started/installation_npu.md`, distinguishing required/manual prerequisites, linking to authoritative compatibility documentation, and providing one recommended installation path.
- Expose the NPU guide through the Get Started toctree and general installation page.
- Add install-script tests for supported SGLang release-line variants, mismatch and missing cases, interrupted recovery, locking, dry-run behavior, extras, build-isolation defaults, and executable paths containing spaces.
- Use the unique test filename `test_npu_install_script.py` to avoid pytest import collisions with the existing XPU installer tests.

## Validation

Completed locally:

- Relevant pre-commit hooks pass, including the executable-shebang check.
- `bash -n scripts/npu/install_npu.sh`
- `pyproject_npu.toml` parses successfully.
- `python -m pytest tests/unit_test/npu/test_npu_install_script.py -q -k "not second_run_refuses_while_lock_is_held"`: 21 passed, 1 deselected.
- Joint collection of the NPU and XPU installer suites: 24 tests collected without module-name conflicts.
- `python .github/update_ci_permission.py --sort-only`: already sorted, no changes.
- `git diff --check`

The local host is Windows and does not provide a real Linux `flock` or Ascend NPU environment. Run the final Linux/Ascend validation with:

```bash
source /usr/local/Ascend/ascend-toolkit/set_env.sh
pytest -q tests/unit_test/npu/test_npu_install_script.py
bash scripts/npu/install_npu.sh --check
bash scripts/npu/install_npu.sh
sgl-omni --help
```
## Accuracy Test

N/A — packaging, installation, and documentation only.

## Benchmark & Profiling

N/A — no inference-path changes.

## Checklist

- [x] Format code according to pre-commit conventions.
- [x] Add unit tests.
- [x] Update documentation.
- [ ] Run the full Linux/Ascend validation commands above and attach the output.
