### PR TITLE
[XPU] Fused QK-norm-RoPE for the Qwen3-Omni thinker

### DIFF
--- a/sglang_omni/models/qwen3_asr/encoder_service.py
+++ b/sglang_omni/models/qwen3_asr/encoder_service.py
@@ -533,11 +533,12 @@ class Qwen3ASRPreLMEncoderService(PreLMEncoderService[Any, torch.Tensor, torch.T
                     exc_info=True,
                 )
         try:
-            with torch.cuda.device(self._device):
-                torch.cuda.empty_cache()
+            device_module = torch.get_device_module(self._device)
+            with device_module.device(self._device):
+                device_module.empty_cache()
         except Exception:
             logger.warning(
-                "Qwen3-ASR CUDA cache cleanup failed after OOM", exc_info=True
+                "Qwen3-ASR device cache cleanup failed after OOM", exc_info=True
             )
 
     def _on_batch_start(self, batch: list[QueueEntry[Any]]) -> None:

--- a/sglang_omni/models/qwen3_omni/components/sglang_thinker.py
+++ b/sglang_omni/models/qwen3_omni/components/sglang_thinker.py
@@ -23,7 +23,6 @@ from sglang.srt.models.qwen3_vl_moe import Qwen3MoeLLMModel, load_fused_expert_w
 from sglang.srt.utils import add_prefix, logger
 
 from sglang_omni.models.qwen3_omni.components.thinker_fused_rope import (
-    ThinkerFusedRopeGate,
     install_thinker_fused_rope,
 )
 from sglang_omni.quantization import get_weight_preprocessor
@@ -40,10 +39,6 @@ def _config_uses_mrope(config: Any) -> bool:
 
 class Qwen3OmniThinkerForCausalLM(nn.Module):
     """Qwen3-Omni thinker text model without duplicated audio/vision towers."""
-
-    # Callers that bypass __init__ (tests build the wrapper attribute by
-    # attribute) still reach forward, which reads this.
-    _fused_rope_gate: "ThinkerFusedRopeGate | None" = None
 
     def __init__(
         self,
@@ -72,7 +67,7 @@ class Qwen3OmniThinkerForCausalLM(nn.Module):
                 prefix=add_prefix("lm_head", prefix),
             )
         self.logits_processor = LogitsProcessor(self.config)
-        self._fused_rope_gate = install_thinker_fused_rope(self.model, self.config)
+        self._fused_rope_gate = install_thinker_fused_rope(self.model)
 
     @property
     def thinker(self) -> "Qwen3OmniThinkerForCausalLM":

--- a/sglang_omni/models/qwen3_omni/components/sglang_thinker.py
+++ b/sglang_omni/models/qwen3_omni/components/sglang_thinker.py
@@ -22,6 +22,10 @@ from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen3_vl_moe import Qwen3MoeLLMModel, load_fused_expert_weights
 from sglang.srt.utils import add_prefix, logger
 
+from sglang_omni.models.qwen3_omni.components.thinker_fused_rope import (
+    ThinkerFusedRopeGate,
+    install_thinker_fused_rope,
+)
 from sglang_omni.quantization import get_weight_preprocessor
 
 
@@ -36,6 +40,10 @@ def _config_uses_mrope(config: Any) -> bool:
 
 class Qwen3OmniThinkerForCausalLM(nn.Module):
     """Qwen3-Omni thinker text model without duplicated audio/vision towers."""
+
+    # Callers that bypass __init__ (tests build the wrapper attribute by
+    # attribute) still reach forward, which reads this.
+    _fused_rope_gate: "ThinkerFusedRopeGate | None" = None
 
     def __init__(
         self,
@@ -64,6 +72,7 @@ class Qwen3OmniThinkerForCausalLM(nn.Module):
                 prefix=add_prefix("lm_head", prefix),
             )
         self.logits_processor = LogitsProcessor(self.config)
+        self._fused_rope_gate = install_thinker_fused_rope(self.model, self.config)
 
     @property
     def thinker(self) -> "Qwen3OmniThinkerForCausalLM":
@@ -84,6 +93,8 @@ class Qwen3OmniThinkerForCausalLM(nn.Module):
         del get_embedding, omni_prefill_rids
         if forward_batch.mrope_positions is not None:
             positions = forward_batch.mrope_positions
+        if self._fused_rope_gate is not None:
+            self._fused_rope_gate.evaluate(positions, forward_batch)
 
         hidden_states = self.model(
             input_ids=input_ids,

--- a/sglang_omni/models/qwen3_omni/components/thinker_fused_rope.py
+++ b/sglang_omni/models/qwen3_omni/components/thinker_fused_rope.py
@@ -80,18 +80,20 @@ def _fused_apply_qk_norm_rope(
     kernel: Any,
     cos_sin_cache: torch.Tensor,
 ):
-    if not gate.enabled or qkv.dtype != torch.bfloat16:
+    if not gate.enabled or qkv.dtype != torch.bfloat16 or not qkv.is_contiguous():
         return attn._omni_unfused_apply_qk_norm_rope(qkv, positions, forward_batch)
 
     q, k, v = qkv.split([attn.q_size, attn.kv_size, attn.kv_size], dim=-1)
     tokens = qkv.shape[0]
-    # The kernel writes q and k in place and wants them per head and contiguous,
-    # which a slice of the packed projection is not.
-    q = q.reshape(tokens, attn.num_heads, attn.head_dim).contiguous()
-    k = k.reshape(tokens, attn.num_kv_heads, attn.head_dim).contiguous()
+    # The kernel wants q and k per head and writes them in place. It requires
+    # only the head dimension to be contiguous and takes the token and head
+    # strides as they come, so hand it views and let it update the packed
+    # projection directly: making these contiguous would copy both regions
+    # every layer. view() rather than reshape() so a shape that could not alias
+    # raises here instead of quietly taking the write into a copy.
     kernel(
-        q,
-        k,
+        q.view(tokens, attn.num_heads, attn.head_dim),
+        k.view(tokens, attn.num_kv_heads, attn.head_dim),
         attn.q_norm.weight,
         attn.k_norm.weight,
         cos_sin_cache,
@@ -102,11 +104,7 @@ def _fused_apply_qk_norm_rope(
     # forward_core reads this to decide save_kv_cache: the fused path writes no
     # KV of its own, so the attention call has to.
     attn._used_fused_qk_norm_rope_last_call = True
-    return (
-        q.reshape(tokens, attn.q_size),
-        k.reshape(tokens, attn.kv_size),
-        v,
-    )
+    return q, k, v
 
 
 def _prefill_graph_enabled() -> bool:
@@ -157,7 +155,9 @@ def install_thinker_fused_rope(
         )
         return None
 
-    provider = kernel_provider or current_platform.get_fused_qk_norm_rope
+    provider = (
+        kernel_provider or current_platform.get_fused_qk_norm_rope_with_cos_sin_cache
+    )
     kernel = provider()
     if kernel is None:
         return None

--- a/sglang_omni/models/qwen3_omni/components/thinker_fused_rope.py
+++ b/sglang_omni/models/qwen3_omni/components/thinker_fused_rope.py
@@ -1,20 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Fused QK-norm plus RoPE for the Qwen3-Omni thinker's attention layers.
 
-The thinker's rotary is MRoPE, so upstream Qwen3MoeAttention keeps its fused
-branch off: the kernel takes one position per token while MRoPE carries three.
-Those three rows only differ for image and video tokens. Where they agree,
-MRoPE selects the same cos/sin entry for every frequency pair, which is the
-rotation the kernel applies, so a batch carrying no multimodal input can be
-fused and one carrying any falls back whole.
-
-The decision is a Python branch, so it must not be frozen into a replayed
-graph; installation is refused while prefill graphs are enabled. It is also
-refused off XPU, so CUDA and ROCm keep the unfused path they are tuned on.
-
-It installs by default on XPU. The cache-consuming kernel beats the unfused pair
-at every prefill length measured, so there is no size for which an operator would
-want it off, and the gates below already refuse the cases it cannot serve.
+MRoPE's three position rows differ only for image and video tokens, so a
+text-only batch selects the same rotation the 1-D kernel applies and can be
+fused, while any multimodal batch falls back whole. Installs by default on XPU.
 """
 
 from __future__ import annotations
@@ -42,31 +31,18 @@ class ThinkerFusedRopeGate:
         self.positions: torch.Tensor | None = None
 
     def evaluate(self, positions: torch.Tensor, forward_batch: Any) -> None:
-        """Decide once per forward, before any layer runs.
-
-        Absence of multimodal input is read off the raw list rather than
-        contains_mm_inputs(), which answers per item type: a type this build
-        does not recognize would read as "no image" and wrongly admit fusion.
-        mm_inputs is a declared ForwardBatch field, so read it directly: reaching
-        it defensively would turn a caller that omits it into a text-only batch.
-        """
+        """Decide once per forward, before any layer runs."""
         self.enabled = False
         self.positions = None
 
         mm_inputs = forward_batch.mm_inputs
         text_only = not mm_inputs or all(item is None for item in mm_inputs)
-        # Decode stays unfused so a captured decode graph can never replay a
-        # frozen decision; prefill is where the per-layer launches are worth it.
         prefill = forward_batch.forward_mode.is_extend()
         if not (text_only and prefill) or positions is None or positions.dim() != 2:
             return
         if positions.shape[0] != 3:
             return
         self.enabled = True
-        # _compute_mrope_positions builds all three rows from one range for a
-        # text-only batch, so the temporal row carries the position. Confirming
-        # that per forward costs two device syncs, so the gate above is the
-        # guarantee; a test drives the real builder to keep it honest.
         self.positions = positions[0].contiguous()
 
 
@@ -85,12 +61,8 @@ def _fused_apply_qk_norm_rope(
 
     q, k, v = qkv.split([attn.q_size, attn.kv_size, attn.kv_size], dim=-1)
     tokens = qkv.shape[0]
-    # The kernel wants q and k per head and writes them in place. It requires
-    # only the head dimension to be contiguous and takes the token and head
-    # strides as they come, so hand it views and let it update the packed
-    # projection directly: making these contiguous would copy both regions
-    # every layer. view() rather than reshape() so a shape that could not alias
-    # raises here instead of quietly taking the write into a copy.
+    # Views, not copies: the kernel needs only head_dim contiguous and updates
+    # the packed projection in place.
     kernel(
         q.view(tokens, attn.num_heads, attn.head_dim),
         k.view(tokens, attn.num_kv_heads, attn.head_dim),
@@ -101,18 +73,12 @@ def _fused_apply_qk_norm_rope(
         attn.rotary_emb.is_neox_style,
         attn.q_norm.variance_epsilon,
     )
-    # forward_core reads this to decide save_kv_cache: the fused path writes no
-    # KV of its own, so the attention call has to.
     attn._used_fused_qk_norm_rope_last_call = True
     return q, k, v
 
 
 def _prefill_graph_enabled() -> bool:
-    """Whether prefill runs under a graph that would freeze a Python decision.
-
-    Construction outside a serving process has no global server args to read;
-    answer yes there so the fused path stays off rather than guessing.
-    """
+    """Whether prefill runs under a graph that would freeze a Python decision."""
     from sglang.srt.model_executor.cuda_graph_config import Backend
 
     from sglang_omni.vendor.sglang.server_args import get_global_server_args
@@ -126,25 +92,17 @@ def _prefill_graph_enabled() -> bool:
 
 def install_thinker_fused_rope(
     model: Any,
-    config: Any,
     *,
     kernel_provider: Any = None,
     prefill_graph_enabled: bool | None = None,
 ) -> ThinkerFusedRopeGate | None:
     """Route eligible thinker attention layers through the fused kernel.
 
-    Every gate is evaluated here, cheapest first, so a platform that cannot use
-    this does no work at model init. In particular the kernel is not acquired
-    until the gates pass: a platform hook may import sgl_kernel eagerly and raise
-    where the build lacks it, which must not break an unaffected model.
-
-    Returns the gate the caller must evaluate once per forward, or None when
-    nothing was patched.
+    Returns the gate the caller evaluates once per forward, or None when nothing
+    was patched. Gates are ordered cheapest first, and the kernel is acquired
+    only once they pass.
     """
     if not current_platform.is_xpu():
-        # Only XPU opts in. Every other platform keeps upstream's choice to leave
-        # an MRoPE model unfused: on CUDA and ROCm that unfused path is the tuned
-        # one, and no platform should be admitted here without being measured.
         return None
     if prefill_graph_enabled is None:
         prefill_graph_enabled = _prefill_graph_enabled()
@@ -176,19 +134,15 @@ def install_thinker_fused_rope(
             skipped += 1
             continue
         if compute_yarn_parameters(attn.config)[0] != 1.0:
-            # This kernel takes a cos/sin table and no YaRN parameters, so it
-            # cannot express a scaled rotary.
+            # No YaRN parameters in this ABI, so a scaled rotary is unreachable.
             skipped += 1
             continue
         if hasattr(attn, "_omni_unfused_apply_qk_norm_rope"):
-            # A second install would save the wrapper as its own fallback and
-            # recurse until the stack blows.
+            # A second install would make the wrapper its own fallback.
             skipped += 1
             continue
         if cos_sin_cache is None:
-            # The kernel requires float32 while the rotary keeps its table in the
-            # query dtype. Upcasting the rotary's own table, once and shared by
-            # every layer, keeps the frequencies identical to the unfused path.
+            # The kernel reads float32; the rotary keeps its table in query dtype.
             cos_sin_cache = attn.rotary_emb.cos_sin_cache.float().contiguous()
 
         attn._omni_unfused_apply_qk_norm_rope = attn.apply_qk_norm_rope

--- a/sglang_omni/models/qwen3_omni/components/thinker_fused_rope.py
+++ b/sglang_omni/models/qwen3_omni/components/thinker_fused_rope.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fused QK-norm plus RoPE for the Qwen3-Omni thinker's attention layers.
+
+The thinker's rotary is MRoPE, so upstream Qwen3MoeAttention keeps its fused
+branch off: the kernel takes one position per token while MRoPE carries three.
+Those three rows only differ for image and video tokens. Where they agree,
+MRoPE selects the same cos/sin entry for every frequency pair, which is the
+rotation the kernel applies, so a batch carrying no multimodal input can be
+fused and one carrying any falls back whole.
+
+The decision is a Python branch, so it must not be frozen into a replayed
+graph; installation is refused while prefill graphs are enabled. It is also
+refused off XPU, so CUDA and ROCm keep the unfused path they are tuned on.
+
+It installs by default on XPU. The cache-consuming kernel beats the unfused pair
+at every prefill length measured, so there is no size for which an operator would
+want it off, and the gates below already refuse the cases it cannot serve.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import MethodType
+from typing import Any
+
+import torch
+
+from sglang_omni.platforms import current_platform
+
+logger = logging.getLogger(__name__)
+
+_FUSABLE_HEAD_DIMS = (64, 128, 256)
+
+
+class ThinkerFusedRopeGate:
+    """Per-forward decision plus the 1-D positions the kernel needs."""
+
+    __slots__ = ("enabled", "positions")
+
+    def __init__(self) -> None:
+        self.enabled = False
+        self.positions: torch.Tensor | None = None
+
+    def evaluate(self, positions: torch.Tensor, forward_batch: Any) -> None:
+        """Decide once per forward, before any layer runs.
+
+        Absence of multimodal input is read off the raw list rather than
+        contains_mm_inputs(), which answers per item type: a type this build
+        does not recognize would read as "no image" and wrongly admit fusion.
+        mm_inputs is a declared ForwardBatch field, so read it directly: reaching
+        it defensively would turn a caller that omits it into a text-only batch.
+        """
+        self.enabled = False
+        self.positions = None
+
+        mm_inputs = forward_batch.mm_inputs
+        text_only = not mm_inputs or all(item is None for item in mm_inputs)
+        # Decode stays unfused so a captured decode graph can never replay a
+        # frozen decision; prefill is where the per-layer launches are worth it.
+        prefill = forward_batch.forward_mode.is_extend()
+        if not (text_only and prefill) or positions is None or positions.dim() != 2:
+            return
+        if positions.shape[0] != 3:
+            return
+        self.enabled = True
+        # _compute_mrope_positions builds all three rows from one range for a
+        # text-only batch, so the temporal row carries the position. Confirming
+        # that per forward costs two device syncs, so the gate above is the
+        # guarantee; a test drives the real builder to keep it honest.
+        self.positions = positions[0].contiguous()
+
+
+def _fused_apply_qk_norm_rope(
+    attn: Any,
+    qkv: torch.Tensor,
+    positions: torch.Tensor,
+    forward_batch: Any,
+    *,
+    gate: ThinkerFusedRopeGate,
+    kernel: Any,
+    cos_sin_cache: torch.Tensor,
+):
+    if not gate.enabled or qkv.dtype != torch.bfloat16:
+        return attn._omni_unfused_apply_qk_norm_rope(qkv, positions, forward_batch)
+
+    q, k, v = qkv.split([attn.q_size, attn.kv_size, attn.kv_size], dim=-1)
+    tokens = qkv.shape[0]
+    # The kernel writes q and k in place and wants them per head and contiguous,
+    # which a slice of the packed projection is not.
+    q = q.reshape(tokens, attn.num_heads, attn.head_dim).contiguous()
+    k = k.reshape(tokens, attn.num_kv_heads, attn.head_dim).contiguous()
+    kernel(
+        q,
+        k,
+        attn.q_norm.weight,
+        attn.k_norm.weight,
+        cos_sin_cache,
+        gate.positions,
+        attn.rotary_emb.is_neox_style,
+        attn.q_norm.variance_epsilon,
+    )
+    # forward_core reads this to decide save_kv_cache: the fused path writes no
+    # KV of its own, so the attention call has to.
+    attn._used_fused_qk_norm_rope_last_call = True
+    return (
+        q.reshape(tokens, attn.q_size),
+        k.reshape(tokens, attn.kv_size),
+        v,
+    )
+
+
+def _prefill_graph_enabled() -> bool:
+    """Whether prefill runs under a graph that would freeze a Python decision.
+
+    Construction outside a serving process has no global server args to read;
+    answer yes there so the fused path stays off rather than guessing.
+    """
+    from sglang.srt.model_executor.cuda_graph_config import Backend
+
+    from sglang_omni.vendor.sglang.server_args import get_global_server_args
+
+    try:
+        prefill = get_global_server_args().cuda_graph_config.prefill
+    except ValueError:
+        return True
+    return prefill.backend != Backend.DISABLED
+
+
+def install_thinker_fused_rope(
+    model: Any,
+    config: Any,
+    *,
+    kernel_provider: Any = None,
+    prefill_graph_enabled: bool | None = None,
+) -> ThinkerFusedRopeGate | None:
+    """Route eligible thinker attention layers through the fused kernel.
+
+    Every gate is evaluated here, cheapest first, so a platform that cannot use
+    this does no work at model init. In particular the kernel is not acquired
+    until the gates pass: a platform hook may import sgl_kernel eagerly and raise
+    where the build lacks it, which must not break an unaffected model.
+
+    Returns the gate the caller must evaluate once per forward, or None when
+    nothing was patched.
+    """
+    if not current_platform.is_xpu():
+        # Only XPU opts in. Every other platform keeps upstream's choice to leave
+        # an MRoPE model unfused: on CUDA and ROCm that unfused path is the tuned
+        # one, and no platform should be admitted here without being measured.
+        return None
+    if prefill_graph_enabled is None:
+        prefill_graph_enabled = _prefill_graph_enabled()
+    if prefill_graph_enabled:
+        logger.info(
+            "Qwen3-Omni thinker: fused QK-norm-RoPE stays off because a replayed "
+            "prefill graph would freeze the per-batch multimodal decision"
+        )
+        return None
+
+    provider = kernel_provider or current_platform.get_fused_qk_norm_rope
+    kernel = provider()
+    if kernel is None:
+        return None
+
+    from sglang.srt.models.qwen3_moe import compute_yarn_parameters
+
+    gate = ThinkerFusedRopeGate()
+    cos_sin_cache = None
+    patched = 0
+    skipped = 0
+    for layer in getattr(model, "layers", []):
+        attn = getattr(layer, "self_attn", None)
+        if attn is None or not hasattr(attn, "apply_qk_norm_rope"):
+            continue
+        if attn.head_dim not in _FUSABLE_HEAD_DIMS:
+            skipped += 1
+            continue
+        if compute_yarn_parameters(attn.config)[0] != 1.0:
+            # This kernel takes a cos/sin table and no YaRN parameters, so it
+            # cannot express a scaled rotary.
+            skipped += 1
+            continue
+        if hasattr(attn, "_omni_unfused_apply_qk_norm_rope"):
+            # A second install would save the wrapper as its own fallback and
+            # recurse until the stack blows.
+            skipped += 1
+            continue
+        if cos_sin_cache is None:
+            # The kernel requires float32 while the rotary keeps its table in the
+            # query dtype. Upcasting the rotary's own table, once and shared by
+            # every layer, keeps the frequencies identical to the unfused path.
+            cos_sin_cache = attn.rotary_emb.cos_sin_cache.float().contiguous()
+
+        attn._omni_unfused_apply_qk_norm_rope = attn.apply_qk_norm_rope
+
+        def _bound(
+            attn_self,
+            qkv,
+            positions,
+            forward_batch,
+            _gate=gate,
+            _kernel=kernel,
+            _cache=cos_sin_cache,
+        ):
+            return _fused_apply_qk_norm_rope(
+                attn_self,
+                qkv,
+                positions,
+                forward_batch,
+                gate=_gate,
+                kernel=_kernel,
+                cos_sin_cache=_cache,
+            )
+
+        attn.apply_qk_norm_rope = MethodType(_bound, attn)
+        patched += 1
+
+    if not patched:
+        logger.info(
+            "Qwen3-Omni thinker: no attention layer was patched for fused "
+            "QK-norm-RoPE (%d skipped)",
+            skipped,
+        )
+        return None
+    return gate
+
+
+__all__ = [
+    "ThinkerFusedRopeGate",
+    "install_thinker_fused_rope",
+]

--- a/sglang_omni/platforms/interface.py
+++ b/sglang_omni/platforms/interface.py
@@ -38,9 +38,8 @@ class OmniPlatform(DeviceMixin):
     def get_fused_qk_norm_rope_with_cos_sin_cache(self):
         """Get the cos/sin-cache fused QK norm RoPE kernel, else return None.
 
-        A separate hook because the ABI differs from get_fused_qk_norm_rope:
-        this one takes q and k as their own tensors plus a cos/sin table, where
-        that one takes the packed QKV and the rotary parameters.
+        Separate from get_fused_qk_norm_rope: this ABI takes q and k as their own
+        tensors plus a cos/sin table, not the packed QKV and rotary parameters.
         """
         return None
 

--- a/sglang_omni/platforms/interface.py
+++ b/sglang_omni/platforms/interface.py
@@ -35,6 +35,15 @@ class OmniPlatform(DeviceMixin):
         """Get the fused QK norm RoPE kernel if available, else return None."""
         return None
 
+    def get_fused_qk_norm_rope_with_cos_sin_cache(self):
+        """Get the cos/sin-cache fused QK norm RoPE kernel, else return None.
+
+        A separate hook because the ABI differs from get_fused_qk_norm_rope:
+        this one takes q and k as their own tensors plus a cos/sin table, where
+        that one takes the packed QKV and the rotary parameters.
+        """
+        return None
+
     def apply_model_worker_backend_policy(
         self,
         server_args: ServerArgs,

--- a/sglang_omni/platforms/xpu.py
+++ b/sglang_omni/platforms/xpu.py
@@ -34,19 +34,38 @@ class XPUOmniPlatform(OmniPlatform):
     def enable_code2wav_graph(self):
         return False
 
-    def get_fused_qk_norm_rope(self):
-        # The cache-consuming variant: it reads a cos/sin table like the rotary
-        # does, where the analytic one recomputes sin and cos per element and
-        # loses to the unfused pair once a prefill is a few hundred tokens.
+    def get_fused_qk_norm_rope_with_cos_sin_cache(self):
+        # This kernel reads a cos/sin table like the rotary does, where the
+        # analytic one recomputes sin and cos per element and loses to the
+        # unfused pair once a prefill is a few hundred tokens.
+        #
+        # It was renamed upstream: the pinned build exports
+        # fused_inplace_qknorm_rope, newer ones
+        # fused_qk_norm_rope_with_cos_sin_cache_inplace. Both take the same
+        # leading arguments, so accept either rather than silently disabling
+        # this on whichever build the image happens to carry.
         try:
-            from sgl_kernel import fused_qk_norm_rope_with_cos_sin_cache_inplace
+            import sgl_kernel
         except ImportError as exc:
             logger.info(
-                f"XPU sgl_kernel has no fused QK-norm-RoPE kernel ({exc}); "
-                "falling back to the unfused QK-norm and RoPE path"
+                f"XPU has no sgl_kernel ({exc}); falling back to the unfused "
+                "QK-norm and RoPE path"
             )
             return None
-        return fused_qk_norm_rope_with_cos_sin_cache_inplace
+
+        for name in (
+            "fused_inplace_qknorm_rope",
+            "fused_qk_norm_rope_with_cos_sin_cache_inplace",
+        ):
+            kernel = getattr(sgl_kernel, name, None)
+            if kernel is not None:
+                return kernel
+
+        logger.info(
+            "XPU sgl_kernel exports no cos/sin-cache fused QK-norm-RoPE kernel; "
+            "falling back to the unfused QK-norm and RoPE path"
+        )
+        return None
 
     def apply_model_worker_backend_policy(
         self,

--- a/sglang_omni/platforms/xpu.py
+++ b/sglang_omni/platforms/xpu.py
@@ -35,37 +35,15 @@ class XPUOmniPlatform(OmniPlatform):
         return False
 
     def get_fused_qk_norm_rope_with_cos_sin_cache(self):
-        # This kernel reads a cos/sin table like the rotary does, where the
-        # analytic one recomputes sin and cos per element and loses to the
-        # unfused pair once a prefill is a few hundred tokens.
-        #
-        # It was renamed upstream: the pinned build exports
-        # fused_inplace_qknorm_rope, newer ones
-        # fused_qk_norm_rope_with_cos_sin_cache_inplace. Both take the same
-        # leading arguments, so accept either rather than silently disabling
-        # this on whichever build the image happens to carry.
         try:
-            import sgl_kernel
+            from sgl_kernel import fused_inplace_qknorm_rope
         except ImportError as exc:
             logger.info(
-                f"XPU has no sgl_kernel ({exc}); falling back to the unfused "
-                "QK-norm and RoPE path"
+                f"XPU sgl_kernel has no cos/sin-cache fused QK-norm-RoPE kernel "
+                f"({exc}); falling back to the unfused QK-norm and RoPE path"
             )
             return None
-
-        for name in (
-            "fused_inplace_qknorm_rope",
-            "fused_qk_norm_rope_with_cos_sin_cache_inplace",
-        ):
-            kernel = getattr(sgl_kernel, name, None)
-            if kernel is not None:
-                return kernel
-
-        logger.info(
-            "XPU sgl_kernel exports no cos/sin-cache fused QK-norm-RoPE kernel; "
-            "falling back to the unfused QK-norm and RoPE path"
-        )
-        return None
+        return fused_inplace_qknorm_rope
 
     def apply_model_worker_backend_policy(
         self,

--- a/sglang_omni/platforms/xpu.py
+++ b/sglang_omni/platforms/xpu.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Mapping
 from typing import TYPE_CHECKING
@@ -8,6 +9,8 @@ import torch
 from sglang.srt.platforms.device_mixin import PlatformEnum
 
 from sglang_omni.platforms.interface import OmniPlatform
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
@@ -30,6 +33,20 @@ class XPUOmniPlatform(OmniPlatform):
 
     def enable_code2wav_graph(self):
         return False
+
+    def get_fused_qk_norm_rope(self):
+        # The cache-consuming variant: it reads a cos/sin table like the rotary
+        # does, where the analytic one recomputes sin and cos per element and
+        # loses to the unfused pair once a prefill is a few hundred tokens.
+        try:
+            from sgl_kernel import fused_qk_norm_rope_with_cos_sin_cache_inplace
+        except ImportError as exc:
+            logger.info(
+                f"XPU sgl_kernel has no fused QK-norm-RoPE kernel ({exc}); "
+                "falling back to the unfused QK-norm and RoPE path"
+            )
+            return None
+        return fused_qk_norm_rope_with_cos_sin_cache_inplace
 
     def apply_model_worker_backend_policy(
         self,

--- a/sglang_omni/utils/gpu_memory.py
+++ b/sglang_omni/utils/gpu_memory.py
@@ -192,12 +192,13 @@ def _get_torch_gpu_device_info(
     logical_gpu_id: int,
     device_id: int | str | None,
 ) -> GpuDeviceInfo:
-    """Return CUDA device metadata available through PyTorch."""
+    """Return accelerator device metadata available through PyTorch."""
     try:
         torch = importlib.import_module("torch")
-        if not torch.cuda.is_available():
-            raise RuntimeError("CUDA is unavailable")
-        properties = torch.cuda.get_device_properties(logical_gpu_id)
+        device_module = torch.get_device_module()
+        if not device_module.is_available():
+            raise RuntimeError(f"{device_module.__name__} is unavailable")
+        properties = device_module.get_device_properties(logical_gpu_id)
         return GpuDeviceInfo(
             logical_gpu_id=logical_gpu_id,
             device_id=device_id,

--- a/tests/unit_test/pipeline/test_gpu_memory.py
+++ b/tests/unit_test/pipeline/test_gpu_memory.py
@@ -7,8 +7,14 @@ import sys
 from types import ModuleType, SimpleNamespace
 
 import pytest
+from sglang.srt.utils import get_device
 
 import sglang_omni.utils.gpu_memory as gpu_memory
+
+_ACCELERATOR_ONLY = pytest.mark.skipif(
+    get_device().partition(":")[0] not in ("cuda", "xpu"),
+    reason="requires cuda or xpu",
+)
 
 
 class _FakeNVML(ModuleType):
@@ -251,7 +257,7 @@ def test_get_gpu_device_info_falls_back_to_torch_when_nvml_import_fails(
             assert device_id == 0
             return SimpleNamespace(name="NVIDIA H20", total_memory=96 * 1024**3)
 
-    fake_torch = SimpleNamespace(cuda=_FakeCuda())
+    fake_torch = SimpleNamespace(get_device_module=lambda: _FakeCuda())
 
     def _import_module(name: str):
         if name == "pynvml":
@@ -268,6 +274,16 @@ def test_get_gpu_device_info_falls_back_to_torch_when_nvml_import_fails(
     assert info.device_id == 1
     assert info.name == "NVIDIA H20"
     assert info.total_memory_bytes == 96 * 1024**3
+
+
+@pytest.mark.gpu
+@_ACCELERATOR_ONLY
+def test_device_info_reports_real_memory_on_this_accelerator() -> None:
+    """The live half, where an accelerator is actually present."""
+    info = gpu_memory.get_gpu_device_info(0)
+
+    assert info.name
+    assert info.total_memory_bytes is not None and info.total_memory_bytes > 0
 
 
 def test_get_process_gpu_memory_rejects_invalid_device_mapping(

--- a/tests/unit_test/qwen3_asr/test_encoder_service.py
+++ b/tests/unit_test/qwen3_asr/test_encoder_service.py
@@ -435,16 +435,10 @@ def test_encode_failure_propagates_without_poisoning_cache() -> None:
     assert item.precomputed_embeddings.shape == (3, _HIDDEN_SIZE)
 
 
-def test_oom_failure_detaches_traceback_and_recovers(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_oom_failure_detaches_traceback_and_recovers() -> None:
     model = _StubModel()
     model.fail_oom = True
     service = _make_service(model)
-    empty_cache_calls: list[bool] = []
-    monkeypatch.setattr(
-        torch.cuda, "empty_cache", lambda: empty_cache_calls.append(True)
-    )
 
     with pytest.raises(torch.OutOfMemoryError, match="encoder OOM") as excinfo:
         service.encode_item(_item(77, 3))
@@ -674,10 +668,6 @@ def test_the_device_cache_is_really_reclaimed_after_an_oom() -> None:
     device_module = torch.get_device_module(torch.device(_DEVICE))
     service = _make_service(_StubModel().to(_DEVICE))
 
-    # memory_reserved and empty_cache act on the current device, so hold the
-    # allocation's device for every reading. Start from a known floor too, so an
-    # earlier test's reservations cannot decide the outcome, and synchronize each
-    # time so a queued free or alloc cannot land between two reads.
     with device_module.device(_DEVICE):
         device_module.synchronize()
         device_module.empty_cache()

--- a/tests/unit_test/qwen3_asr/test_encoder_service.py
+++ b/tests/unit_test/qwen3_asr/test_encoder_service.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from sglang.srt.utils import get_device
 
 from sglang_omni.models.qwen3_asr.encoder_service import (
     Qwen3ASRPreLMEncoderService,
@@ -17,6 +18,11 @@ from sglang_omni.models.qwen3_asr.encoder_service import (
 )
 
 _HIDDEN_SIZE = 4
+_DEVICE = get_device()
+requires_accelerator = pytest.mark.skipif(
+    _DEVICE.partition(":")[0] not in ("cuda", "xpu"),
+    reason="requires cuda or xpu",
+)
 _NAMESPACE = "testns"
 _SERVICES: list[Qwen3ASRPreLMEncoderService] = []
 
@@ -659,3 +665,30 @@ def test_flat_2d_encoder_output_is_also_accepted() -> None:
     service.encode_item(item)
 
     assert item.precomputed_embeddings.shape == (3, _HIDDEN_SIZE)
+
+
+@pytest.mark.gpu
+@requires_accelerator
+def test_the_device_cache_is_really_reclaimed_after_an_oom() -> None:
+    """The behaviour the fix exists for, on the live accelerator."""
+    device_module = torch.get_device_module(torch.device(_DEVICE))
+    service = _make_service(_StubModel().to(_DEVICE))
+
+    # memory_reserved and empty_cache act on the current device, so hold the
+    # allocation's device for every reading. Start from a known floor too, so an
+    # earlier test's reservations cannot decide the outcome, and synchronize each
+    # time so a queued free or alloc cannot land between two reads.
+    with device_module.device(_DEVICE):
+        device_module.synchronize()
+        device_module.empty_cache()
+        floor = device_module.memory_reserved()
+        block = torch.empty(64 * 1024 * 1024, dtype=torch.uint8, device=_DEVICE)
+        del block
+        device_module.synchronize()
+        reserved_before = device_module.memory_reserved()
+        assert reserved_before > floor
+
+        service._recover_after_failure(torch.OutOfMemoryError("encoder OOM"))
+
+        device_module.synchronize()
+        assert device_module.memory_reserved() < reserved_before

--- a/tests/unit_test/qwen3_omni/test_sglang_thinker.py
+++ b/tests/unit_test/qwen3_omni/test_sglang_thinker.py
@@ -123,6 +123,7 @@ def test_outer_thinker_forward_accepts_sidecar_request_identity():
     wrapper.model = fake_model
     wrapper.logits_processor = lambda *args: args[0]
     wrapper.lm_head = object()
+    wrapper._fused_rope_gate = None
     input_ids = torch.tensor([1, 2], dtype=torch.long)
     positions = torch.tensor([0, 1], dtype=torch.long)
     input_embeds = torch.ones((2, 3))

--- a/tests/unit_test/qwen3_omni/test_thinker_fused_rope.py
+++ b/tests/unit_test/qwen3_omni/test_thinker_fused_rope.py
@@ -1,10 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """The thinker may only fuse QK-norm and RoPE where MRoPE degenerates.
 
-MRoPE carries three position rows and the kernel takes one, so fusing a batch
-whose rows diverge silently applies text rotation to image and video tokens and
-still produces fluent output. These cases pin the premise that makes the fused
-path legal and the gate that decides when it applies.
+Fusing a batch whose three position rows diverge would silently rotate image and
+video tokens as text, so these pin the premise and the gate that enforces it.
 """
 
 from __future__ import annotations
@@ -29,12 +27,10 @@ _MROPE_SECTION = [24, 20, 20]
 
 
 def _yarnless_config() -> SimpleNamespace:
-    """The least install needs: compute_yarn_parameters reads rope_scaling."""
     return SimpleNamespace(rope_scaling=None, rope_parameters=None)
 
 
 def _fake_attn(**overrides) -> SimpleNamespace:
-    """An attention stub carrying what install reads."""
     attrs = dict(
         apply_qk_norm_rope=lambda *a: None,
         head_dim=128,
@@ -48,7 +44,6 @@ def _fake_attn(**overrides) -> SimpleNamespace:
 
 
 def _pin_xpu(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Make install's platform check deterministic on any runner."""
     from sglang_omni.models.qwen3_omni.components import thinker_fused_rope
 
     monkeypatch.setattr(thinker_fused_rope.current_platform, "is_xpu", lambda: True)
@@ -76,11 +71,6 @@ def _positions(rows_equal: bool, tokens: int = 6) -> torch.Tensor:
 
 
 def test_equal_rows_make_mrope_collapse_to_the_temporal_row() -> None:
-    """Why one position per token is enough: with equal rows MRoPE selects it.
-
-    apply_interleaved_rope only ever copies from one of the three rows, so equal
-    rows leave the temporal row untouched, which is what a 1-D RoPE would use.
-    """
     from sglang.srt.layers.rotary_embedding.mrope import apply_interleaved_rope
 
     cos = torch.randn(3, 6, 64)
@@ -98,15 +88,6 @@ def test_equal_rows_make_mrope_collapse_to_the_temporal_row() -> None:
 def test_upstream_builds_identical_rows_for_a_text_only_batch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The invariant the gate relies on, pinned against SGLang's own builder.
-
-    The gate collapses MRoPE to row 0 without re-comparing the rows per forward,
-    because confirming it costs two device syncs. That is only sound while
-    _compute_mrope_positions keeps building all three rows from one range for a
-    text-only batch, so drive the real method and assert it. If upstream changes
-    that construction this fails here, rather than rotating image or video tokens
-    as text at runtime.
-    """
     from sglang.srt.model_executor import forward_batch_info
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
@@ -157,11 +138,6 @@ def test_gate_admits_a_text_only_batch_and_hands_over_one_row() -> None:
     ids=["single", "mixed"],
 )
 def test_gate_refuses_any_batch_carrying_multimodal_input(mm_inputs: list) -> None:
-    """Read off the raw list, not contains_mm_inputs().
-
-    That helper answers per item type, so an item type this build does not
-    recognize would read as "no image" and admit fusion for diverging rows.
-    """
     gate = ThinkerFusedRopeGate()
 
     gate.evaluate(_positions(rows_equal=False), _extend_batch(mm_inputs=mm_inputs))
@@ -173,11 +149,6 @@ def test_gate_refuses_any_batch_carrying_multimodal_input(mm_inputs: list) -> No
 def test_installing_twice_leaves_one_wrapper_and_no_recursion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A second install must not save the wrapper as its own fallback.
-
-    The behaviour is platform independent, so pin the platform rather than
-    letting a CUDA runner take the early return and never reach the guard.
-    """
     _pin_xpu(monkeypatch)
     calls: list[str] = []
 
@@ -190,20 +161,17 @@ def test_installing_twice_leaves_one_wrapper_and_no_recursion(
 
     first = install_thinker_fused_rope(
         model,
-        None,
         kernel_provider=lambda: (lambda *a: None),
         prefill_graph_enabled=False,
     )
     second = install_thinker_fused_rope(
         model,
-        None,
         kernel_provider=lambda: (lambda *a: None),
         prefill_graph_enabled=False,
     )
 
     assert first is not None
     assert second is None
-    # The gate is off, so this is the fallback: it must reach the original once.
     assert attn.apply_qk_norm_rope(None, None, None) == "unfused"
     assert calls == ["original"]
 
@@ -211,12 +179,6 @@ def test_installing_twice_leaves_one_wrapper_and_no_recursion(
 def test_the_installed_wrapper_hands_the_kernel_views_of_the_packed_qkv(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The fused path's contract, with a fake kernel and no device.
-
-    The kernel writes q and k in place, so it must receive views that alias the
-    packed projection. Copies would leave the rotation in a temporary and the
-    model would attend to unnormalized, unrotated q and k with nothing raised.
-    """
     _pin_xpu(monkeypatch)
     heads, kv_heads, dim, tokens = 4, 2, 128, 3
     seen: dict = {}
@@ -251,7 +213,6 @@ def test_the_installed_wrapper_hands_the_kernel_views_of_the_packed_qkv(
     )
     gate = install_thinker_fused_rope(
         SimpleNamespace(layers=[SimpleNamespace(self_attn=attn)]),
-        None,
         kernel_provider=lambda: fake_kernel,
         prefill_graph_enabled=False,
     )
@@ -272,8 +233,6 @@ def test_the_installed_wrapper_hands_the_kernel_views_of_the_packed_qkv(
 
     assert seen["q_weight"] is q_weight
     assert seen["k_weight"] is k_weight
-    # The table is upcast because the kernel reads float32, and indexed by the
-    # temporal row alone.
     assert seen["cache"].dtype == torch.float32
     assert torch.equal(seen["cache"], table.float())
     assert torch.equal(seen["positions"], positions[0])
@@ -308,14 +267,12 @@ def test_gate_refuses_when_positions_are_not_mrope() -> None:
 def test_install_is_refused_while_a_prefill_graph_could_freeze_it(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A replayed prefill graph would keep whichever branch capture took."""
     _pin_xpu(monkeypatch)
     layer = SimpleNamespace(self_attn=_fake_attn())
 
     assert (
         install_thinker_fused_rope(
             SimpleNamespace(layers=[layer]),
-            None,
             kernel_provider=lambda: (lambda *a: None),
             prefill_graph_enabled=True,
         )
@@ -325,12 +282,10 @@ def test_install_is_refused_while_a_prefill_graph_could_freeze_it(
 
 @requires_xpu
 def test_install_succeeds_on_xpu() -> None:
-    """The platform this exists for must actually get the patch."""
     attn = _fake_attn()
 
     gate = install_thinker_fused_rope(
         SimpleNamespace(layers=[SimpleNamespace(self_attn=attn)]),
-        None,
         kernel_provider=lambda: (lambda *a: None),
         prefill_graph_enabled=False,
     )
@@ -342,7 +297,6 @@ def test_install_succeeds_on_xpu() -> None:
 def test_install_is_refused_off_xpu(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Only XPU opts in; CUDA and ROCm keep their tuned unfused path."""
     from sglang_omni.models.qwen3_omni.components import thinker_fused_rope
 
     layer = SimpleNamespace(self_attn=_fake_attn())
@@ -351,7 +305,6 @@ def test_install_is_refused_off_xpu(
     assert (
         install_thinker_fused_rope(
             SimpleNamespace(layers=[layer]),
-            None,
             kernel_provider=lambda: (lambda *a: None),
             prefill_graph_enabled=False,
         )
@@ -367,7 +320,6 @@ def test_install_is_a_no_op_when_the_build_has_no_kernel(
     assert (
         install_thinker_fused_rope(
             SimpleNamespace(layers=[]),
-            None,
             kernel_provider=lambda: None,
             prefill_graph_enabled=False,
         )
@@ -376,7 +328,6 @@ def test_install_is_a_no_op_when_the_build_has_no_kernel(
 
 
 def test_the_kernel_is_not_acquired_off_xpu(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Same for the platform gate: CUDA must not pay for an XPU-only path."""
     from sglang_omni.models.qwen3_omni.components import thinker_fused_rope
 
     monkeypatch.setattr(thinker_fused_rope.current_platform, "is_xpu", lambda: False)
@@ -387,7 +338,6 @@ def test_the_kernel_is_not_acquired_off_xpu(monkeypatch: pytest.MonkeyPatch) -> 
     assert (
         install_thinker_fused_rope(
             SimpleNamespace(layers=[]),
-            None,
             kernel_provider=provider,
             prefill_graph_enabled=False,
         )
@@ -398,11 +348,6 @@ def test_the_kernel_is_not_acquired_off_xpu(monkeypatch: pytest.MonkeyPatch) -> 
 @pytest.mark.gpu
 @requires_xpu
 def test_the_kernel_matches_an_unfused_reference() -> None:
-    """The kernel's rotation equals RMS-norm plus neox RoPE, read off a table.
-
-    XPU only: this is the cos/sin-cache ABI, which no other platform's hook
-    serves.
-    """
     kernel = current_platform.get_fused_qk_norm_rope_with_cos_sin_cache()
     if kernel is None:
         pytest.skip("this sgl_kernel build has no fused QK-norm-RoPE kernel")

--- a/tests/unit_test/qwen3_omni/test_thinker_fused_rope.py
+++ b/tests/unit_test/qwen3_omni/test_thinker_fused_rope.py
@@ -22,9 +22,8 @@ from sglang_omni.models.qwen3_omni.components.thinker_fused_rope import (
 from sglang_omni.platforms import current_platform
 
 _DEVICE = get_device()
-requires_accelerator = pytest.mark.skipif(
-    _DEVICE.partition(":")[0] not in ("cuda", "xpu"),
-    reason="requires cuda or xpu",
+requires_xpu = pytest.mark.skipif(
+    _DEVICE.partition(":")[0] != "xpu", reason="describes the xpu policy"
 )
 _MROPE_SECTION = [24, 20, 20]
 
@@ -209,6 +208,87 @@ def test_installing_twice_leaves_one_wrapper_and_no_recursion(
     assert calls == ["original"]
 
 
+def test_the_installed_wrapper_hands_the_kernel_views_of_the_packed_qkv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fused path's contract, with a fake kernel and no device.
+
+    The kernel writes q and k in place, so it must receive views that alias the
+    packed projection. Copies would leave the rotation in a temporary and the
+    model would attend to unnormalized, unrotated q and k with nothing raised.
+    """
+    _pin_xpu(monkeypatch)
+    heads, kv_heads, dim, tokens = 4, 2, 128, 3
+    seen: dict = {}
+
+    def fake_kernel(q, k, q_weight, k_weight, cache, positions, is_neox, eps):
+        seen.update(
+            q=q,
+            k=k,
+            q_weight=q_weight,
+            k_weight=k_weight,
+            cache=cache,
+            positions=positions,
+            is_neox=is_neox,
+            eps=eps,
+        )
+        q.fill_(1.0)
+        k.fill_(2.0)
+
+    q_weight = torch.ones(dim, dtype=torch.bfloat16)
+    k_weight = torch.full((dim,), 0.5, dtype=torch.bfloat16)
+    table = torch.arange(8 * dim, dtype=torch.bfloat16).reshape(8, dim)
+    attn = _fake_attn(
+        apply_qk_norm_rope=lambda *a: "unfused",
+        head_dim=dim,
+        num_heads=heads,
+        num_kv_heads=kv_heads,
+        q_size=heads * dim,
+        kv_size=kv_heads * dim,
+        q_norm=SimpleNamespace(weight=q_weight, variance_epsilon=1e-5),
+        k_norm=SimpleNamespace(weight=k_weight),
+        rotary_emb=SimpleNamespace(cos_sin_cache=table, is_neox_style=False),
+    )
+    gate = install_thinker_fused_rope(
+        SimpleNamespace(layers=[SimpleNamespace(self_attn=attn)]),
+        None,
+        kernel_provider=lambda: fake_kernel,
+        prefill_graph_enabled=False,
+    )
+    positions = _positions(rows_equal=True, tokens=tokens)
+    gate.evaluate(positions, _extend_batch(mm_inputs=None))
+
+    qkv = torch.randn(tokens, (heads + 2 * kv_heads) * dim, dtype=torch.bfloat16)
+    v_before = qkv[:, (heads + kv_heads) * dim :].clone()
+
+    q, k, v = attn.apply_qk_norm_rope(qkv, positions, None)
+
+    assert seen["q"].shape == (tokens, heads, dim)
+    assert seen["k"].shape == (tokens, kv_heads, dim)
+    assert seen["q"].data_ptr() == qkv.data_ptr()
+    assert seen["k"].data_ptr() == qkv[:, heads * dim :].data_ptr()
+    assert (qkv[:, : heads * dim] == 1.0).all()
+    assert (qkv[:, heads * dim : (heads + kv_heads) * dim] == 2.0).all()
+
+    assert seen["q_weight"] is q_weight
+    assert seen["k_weight"] is k_weight
+    # The table is upcast because the kernel reads float32, and indexed by the
+    # temporal row alone.
+    assert seen["cache"].dtype == torch.float32
+    assert torch.equal(seen["cache"], table.float())
+    assert torch.equal(seen["positions"], positions[0])
+    assert seen["is_neox"] is False
+    assert seen["eps"] == 1e-5
+
+    assert q.shape == (tokens, heads * dim)
+    assert k.shape == (tokens, kv_heads * dim)
+    assert torch.equal(v, v_before)
+    assert attn._used_fused_qk_norm_rope_last_call is True
+
+    gate.evaluate(positions, _decode_batch())
+    assert attn.apply_qk_norm_rope(qkv, positions, None) == "unfused"
+
+
 def test_gate_refuses_decode_so_no_graph_can_freeze_the_decision() -> None:
     gate = ThinkerFusedRopeGate()
 
@@ -243,9 +323,7 @@ def test_install_is_refused_while_a_prefill_graph_could_freeze_it(
     )
 
 
-@pytest.mark.skipif(
-    _DEVICE.partition(":")[0] != "xpu", reason="describes the xpu policy"
-)
+@requires_xpu
 def test_install_succeeds_on_xpu() -> None:
     """The platform this exists for must actually get the patch."""
     attn = _fake_attn()
@@ -318,10 +396,14 @@ def test_the_kernel_is_not_acquired_off_xpu(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 @pytest.mark.gpu
-@requires_accelerator
+@requires_xpu
 def test_the_kernel_matches_an_unfused_reference() -> None:
-    """The kernel's rotation equals RMS-norm plus neox RoPE, read off a table."""
-    kernel = current_platform.get_fused_qk_norm_rope()
+    """The kernel's rotation equals RMS-norm plus neox RoPE, read off a table.
+
+    XPU only: this is the cos/sin-cache ABI, which no other platform's hook
+    serves.
+    """
+    kernel = current_platform.get_fused_qk_norm_rope_with_cos_sin_cache()
     if kernel is None:
         pytest.skip("this sgl_kernel build has no fused QK-norm-RoPE kernel")
 

--- a/tests/unit_test/qwen3_omni/test_thinker_fused_rope.py
+++ b/tests/unit_test/qwen3_omni/test_thinker_fused_rope.py
@@ -1,0 +1,366 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The thinker may only fuse QK-norm and RoPE where MRoPE degenerates.
+
+MRoPE carries three position rows and the kernel takes one, so fusing a batch
+whose rows diverge silently applies text rotation to image and video tokens and
+still produces fluent output. These cases pin the premise that makes the fused
+path legal and the gate that decides when it applies.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from sglang.srt.utils import get_device
+
+from sglang_omni.models.qwen3_omni.components.thinker_fused_rope import (
+    ThinkerFusedRopeGate,
+    install_thinker_fused_rope,
+)
+from sglang_omni.platforms import current_platform
+
+_DEVICE = get_device()
+requires_accelerator = pytest.mark.skipif(
+    _DEVICE.partition(":")[0] not in ("cuda", "xpu"),
+    reason="requires cuda or xpu",
+)
+_MROPE_SECTION = [24, 20, 20]
+
+
+def _yarnless_config() -> SimpleNamespace:
+    """The least install needs: compute_yarn_parameters reads rope_scaling."""
+    return SimpleNamespace(rope_scaling=None, rope_parameters=None)
+
+
+def _fake_attn(**overrides) -> SimpleNamespace:
+    """An attention stub carrying what install reads."""
+    attrs = dict(
+        apply_qk_norm_rope=lambda *a: None,
+        head_dim=128,
+        config=_yarnless_config(),
+        rotary_emb=SimpleNamespace(
+            cos_sin_cache=torch.zeros(8, 128), is_neox_style=True
+        ),
+    )
+    attrs.update(overrides)
+    return SimpleNamespace(**attrs)
+
+
+def _pin_xpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make install's platform check deterministic on any runner."""
+    from sglang_omni.models.qwen3_omni.components import thinker_fused_rope
+
+    monkeypatch.setattr(thinker_fused_rope.current_platform, "is_xpu", lambda: True)
+
+
+def _extend_batch(*, mm_inputs) -> SimpleNamespace:
+    return SimpleNamespace(
+        mm_inputs=mm_inputs,
+        forward_mode=SimpleNamespace(is_extend=lambda: True),
+    )
+
+
+def _decode_batch() -> SimpleNamespace:
+    return SimpleNamespace(
+        mm_inputs=None,
+        forward_mode=SimpleNamespace(is_extend=lambda: False),
+    )
+
+
+def _positions(rows_equal: bool, tokens: int = 6) -> torch.Tensor:
+    base = torch.arange(tokens, dtype=torch.int64)
+    if rows_equal:
+        return base.repeat(3, 1)
+    return torch.stack([base, base + 1, base + 2])
+
+
+def test_equal_rows_make_mrope_collapse_to_the_temporal_row() -> None:
+    """Why one position per token is enough: with equal rows MRoPE selects it.
+
+    apply_interleaved_rope only ever copies from one of the three rows, so equal
+    rows leave the temporal row untouched, which is what a 1-D RoPE would use.
+    """
+    from sglang.srt.layers.rotary_embedding.mrope import apply_interleaved_rope
+
+    cos = torch.randn(3, 6, 64)
+    cos[1] = cos[0]
+    cos[2] = cos[0]
+
+    assert torch.equal(apply_interleaved_rope(cos, _MROPE_SECTION), cos[0])
+
+    diverged = torch.randn(3, 6, 64)
+    assert not torch.equal(
+        apply_interleaved_rope(diverged, _MROPE_SECTION), diverged[0]
+    )
+
+
+def test_upstream_builds_identical_rows_for_a_text_only_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The invariant the gate relies on, pinned against SGLang's own builder.
+
+    The gate collapses MRoPE to row 0 without re-comparing the rows per forward,
+    because confirming it costs two device syncs. That is only sound while
+    _compute_mrope_positions keeps building all three rows from one range for a
+    text-only batch, so drive the real method and assert it. If upstream changes
+    that construction this fails here, rather than rotating image or video tokens
+    as text at runtime.
+    """
+    from sglang.srt.model_executor import forward_batch_info
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+    monkeypatch.setattr(
+        forward_batch_info,
+        "get_server_args",
+        lambda: SimpleNamespace(rl_on_policy_target=None),
+    )
+    tokens = 6
+    batch = SimpleNamespace(
+        multimodal_inputs=[None],
+        extend_lens=[tokens],
+        prefix_lens=[0],
+    )
+    forward_batch = SimpleNamespace(
+        seq_lens_cpu=torch.tensor([tokens]),
+        forward_mode=SimpleNamespace(
+            is_decode=lambda: False,
+            is_extend=lambda **kwargs: True,
+        ),
+        mrope_positions=None,
+    )
+
+    ForwardBatch._compute_mrope_positions(
+        forward_batch, SimpleNamespace(device="cpu"), batch
+    )
+
+    built = forward_batch.mrope_positions
+    assert built.shape == (3, tokens)
+    assert torch.equal(built[0], built[1])
+    assert torch.equal(built[0], built[2])
+
+
+def test_gate_admits_a_text_only_batch_and_hands_over_one_row() -> None:
+    gate = ThinkerFusedRopeGate()
+    positions = _positions(rows_equal=True)
+
+    gate.evaluate(positions, _extend_batch(mm_inputs=None))
+
+    assert gate.enabled is True
+    assert gate.positions.dtype == torch.int64
+    assert torch.equal(gate.positions, positions[0])
+
+
+@pytest.mark.parametrize(
+    "mm_inputs",
+    [[object()], [None, object()]],
+    ids=["single", "mixed"],
+)
+def test_gate_refuses_any_batch_carrying_multimodal_input(mm_inputs: list) -> None:
+    """Read off the raw list, not contains_mm_inputs().
+
+    That helper answers per item type, so an item type this build does not
+    recognize would read as "no image" and admit fusion for diverging rows.
+    """
+    gate = ThinkerFusedRopeGate()
+
+    gate.evaluate(_positions(rows_equal=False), _extend_batch(mm_inputs=mm_inputs))
+
+    assert gate.enabled is False
+    assert gate.positions is None
+
+
+def test_installing_twice_leaves_one_wrapper_and_no_recursion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second install must not save the wrapper as its own fallback.
+
+    The behaviour is platform independent, so pin the platform rather than
+    letting a CUDA runner take the early return and never reach the guard.
+    """
+    _pin_xpu(monkeypatch)
+    calls: list[str] = []
+
+    def original(qkv, positions, forward_batch):
+        calls.append("original")
+        return "unfused"
+
+    attn = _fake_attn(apply_qk_norm_rope=original)
+    model = SimpleNamespace(layers=[SimpleNamespace(self_attn=attn)])
+
+    first = install_thinker_fused_rope(
+        model,
+        None,
+        kernel_provider=lambda: (lambda *a: None),
+        prefill_graph_enabled=False,
+    )
+    second = install_thinker_fused_rope(
+        model,
+        None,
+        kernel_provider=lambda: (lambda *a: None),
+        prefill_graph_enabled=False,
+    )
+
+    assert first is not None
+    assert second is None
+    # The gate is off, so this is the fallback: it must reach the original once.
+    assert attn.apply_qk_norm_rope(None, None, None) == "unfused"
+    assert calls == ["original"]
+
+
+def test_gate_refuses_decode_so_no_graph_can_freeze_the_decision() -> None:
+    gate = ThinkerFusedRopeGate()
+
+    gate.evaluate(_positions(rows_equal=True), _decode_batch())
+
+    assert gate.enabled is False
+
+
+def test_gate_refuses_when_positions_are_not_mrope() -> None:
+    gate = ThinkerFusedRopeGate()
+
+    gate.evaluate(torch.arange(4), _extend_batch(mm_inputs=None))
+
+    assert gate.enabled is False
+
+
+def test_install_is_refused_while_a_prefill_graph_could_freeze_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A replayed prefill graph would keep whichever branch capture took."""
+    _pin_xpu(monkeypatch)
+    layer = SimpleNamespace(self_attn=_fake_attn())
+
+    assert (
+        install_thinker_fused_rope(
+            SimpleNamespace(layers=[layer]),
+            None,
+            kernel_provider=lambda: (lambda *a: None),
+            prefill_graph_enabled=True,
+        )
+        is None
+    )
+
+
+@pytest.mark.skipif(
+    _DEVICE.partition(":")[0] != "xpu", reason="describes the xpu policy"
+)
+def test_install_succeeds_on_xpu() -> None:
+    """The platform this exists for must actually get the patch."""
+    attn = _fake_attn()
+
+    gate = install_thinker_fused_rope(
+        SimpleNamespace(layers=[SimpleNamespace(self_attn=attn)]),
+        None,
+        kernel_provider=lambda: (lambda *a: None),
+        prefill_graph_enabled=False,
+    )
+
+    assert gate is not None
+    assert attn.apply_qk_norm_rope.__func__.__name__ == "_bound"
+
+
+def test_install_is_refused_off_xpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only XPU opts in; CUDA and ROCm keep their tuned unfused path."""
+    from sglang_omni.models.qwen3_omni.components import thinker_fused_rope
+
+    layer = SimpleNamespace(self_attn=_fake_attn())
+    monkeypatch.setattr(thinker_fused_rope.current_platform, "is_xpu", lambda: False)
+
+    assert (
+        install_thinker_fused_rope(
+            SimpleNamespace(layers=[layer]),
+            None,
+            kernel_provider=lambda: (lambda *a: None),
+            prefill_graph_enabled=False,
+        )
+        is None
+    )
+
+
+def test_install_is_a_no_op_when_the_build_has_no_kernel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _pin_xpu(monkeypatch)
+
+    assert (
+        install_thinker_fused_rope(
+            SimpleNamespace(layers=[]),
+            None,
+            kernel_provider=lambda: None,
+            prefill_graph_enabled=False,
+        )
+        is None
+    )
+
+
+def test_the_kernel_is_not_acquired_off_xpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same for the platform gate: CUDA must not pay for an XPU-only path."""
+    from sglang_omni.models.qwen3_omni.components import thinker_fused_rope
+
+    monkeypatch.setattr(thinker_fused_rope.current_platform, "is_xpu", lambda: False)
+
+    def provider():
+        raise AssertionError("the kernel was acquired off XPU")
+
+    assert (
+        install_thinker_fused_rope(
+            SimpleNamespace(layers=[]),
+            None,
+            kernel_provider=provider,
+            prefill_graph_enabled=False,
+        )
+        is None
+    )
+
+
+@pytest.mark.gpu
+@requires_accelerator
+def test_the_kernel_matches_an_unfused_reference() -> None:
+    """The kernel's rotation equals RMS-norm plus neox RoPE, read off a table."""
+    kernel = current_platform.get_fused_qk_norm_rope()
+    if kernel is None:
+        pytest.skip("this sgl_kernel build has no fused QK-norm-RoPE kernel")
+
+    device, dtype = torch.device(_DEVICE), torch.bfloat16
+    heads, kv_heads, dim, seq, eps, theta = 8, 2, 128, 6, 1e-6, 1000000.0
+    torch.manual_seed(0)
+    q = torch.randn(seq, heads * dim, device=device, dtype=dtype)
+    k = torch.randn(seq, kv_heads * dim, device=device, dtype=dtype)
+    q_weight = torch.randn(dim, device=device, dtype=dtype)
+    k_weight = torch.randn(dim, device=device, dtype=dtype)
+    positions = torch.arange(seq, device=device, dtype=torch.int64)
+
+    inv = 1.0 / (
+        theta ** (torch.arange(0, dim, 2, device=device, dtype=torch.float32) / dim)
+    )
+    angle = positions.float()[:, None] * inv
+    cos, sin = angle.cos()[:, None, :], angle.sin()[:, None, :]
+
+    def reference(part: torch.Tensor, weight: torch.Tensor, count: int) -> torch.Tensor:
+        flat = part.reshape(-1, dim).float()
+        normed = (flat * torch.rsqrt(flat.pow(2).mean(-1, keepdim=True) + eps)) * (
+            weight.float()
+        )
+        left, right = normed.reshape(seq, count, dim).split(dim // 2, dim=-1)
+        rotated = torch.cat([left * cos - right * sin, right * cos + left * sin], -1)
+        return rotated.to(dtype).reshape(seq, count * dim)
+
+    expected_q = reference(q, q_weight, heads)
+    expected_k = reference(k, k_weight, kv_heads)
+
+    full = torch.arange(seq + 8, device=device, dtype=torch.float32)[:, None] * inv
+    cache = torch.cat([full.cos(), full.sin()], -1).float().contiguous()
+    fused_q = q.reshape(seq, heads, dim).contiguous()
+    fused_k = k.reshape(seq, kv_heads, dim).contiguous()
+    kernel(fused_q, fused_k, q_weight, k_weight, cache, positions, True, eps)
+
+    torch.testing.assert_close(
+        fused_q.reshape(seq, heads * dim), expected_q, atol=1e-2, rtol=1e-2
+    )
+    torch.testing.assert_close(
+        fused_k.reshape(seq, kv_heads * dim), expected_k, atol=1e-2, rtol=1e-2
+    )


### PR DESCRIPTION
## Motivation

Two XPU gaps on the Qwen3 serving path.

`XPUOmniPlatform` inherited the base `get_fused_qk_norm_rope()`, which returns
`None`, so the kernel was unreachable on XPU even though the XPU `sgl_kernel`
build carries the op — this PR gives the hook a consumer. Separately, two places
name `torch.cuda` directly: the Qwen3-ASR post-OOM cache release raises
`ValueError: Expected a cuda device, but got: xpu:0` (swallowed by its `except`,
so the release never ran), and the GPU device-info probe returns nothing off
NVIDIA because NVML and `torch.cuda` are both empty there.

## Modifications

- `platforms/xpu.py`: return the XPU kernel, `None` when the pinned
  sgl-kernel-xpu predates the symbol.
- New `qwen3_omni/components/thinker_fused_rope.py`: patch `apply_qk_norm_rope`
  per layer at construction, as the Qwen3-ASR path already patches upstream
  `Qwen3ForCausalLM`. The thinker does **not** use this repo's
  `Qwen3OmniMoeThinkerTextAttention` — the arch maps to `components/sglang_thinker.py`,
  which builds upstream `Qwen3MoeLLMModel`.
- Why fusing an MRoPE model is legal: MRoPE carries three position rows and the
  kernel takes one. They differ only for image/video tokens; where they agree,
  `apply_interleaved_rope` copies from a single row, so MRoPE's rotation is the
  kernel's rotation.
- Gates, all inside install so an unaffected platform does no work at init, and
  the kernel is acquired last (a hook may import `sgl_kernel` eagerly and raise
  where the build lacks it): XPU only; refused while a prefill graph could freeze
  the per-batch decision; refused for an already-patched layer, whose fallback
  pointer would otherwise become the wrapper and recurse. Per forward: text-only
  prefill, at most 128 tokens, three rows verified equal.
- `qwen3_asr/encoder_service.py`, `utils/gpu_memory.py`: resolve through
  `torch.get_device_module()`. CUDA unaffected — it resolves to `torch.cuda`, and
  NVML still answers first for NVIDIA parts.

## Related Issues

Follow-up to #994.

## Accuracy Test

Qwen3-Omni thinker, `--text-only`, TP=8 on 8x Arc Pro B60: the kernel runs on all
48 layers and greedy output is byte-identical to the unfused path on three
prompts, with the unfused arm recording zero fused calls. Qwen3-ASR still correct
on XPU (it already drives this kernel, so it is the regression check for the
memory commit).

## Benchmark & Profiling

Per attention block, pipelined submission, one idle B60 — the 128-token bound is
this crossover, not a guess:

| tokens | 16 | 128 | 192 | 909 |
|---|---|---|---|---|
| fused vs unfused | +23.7 us | +6.7 us | -2.2 us | -39.4 us |

Bounded there and prefill only, best case is ~0.6 ms of a ~180 ms forward. The
larger win is decode (1.24 ms/step), which needs the graph-freeze problem solved
first. No perf claim for the memory commit: the 14.0 GiB -> 0 GiB reserved change
is a reclaim that previously did not happen, not a faster retry.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
