### PR TITLE
Add New Intel member into CI permission list

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -23,7 +23,7 @@
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
         "reason": "custom override"
-    },    
+    },
     "zhaochenyang20": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,

--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -19,6 +19,11 @@
         "can_rerun_failed_ci": true,
         "reason": "custom override"
     },
+    "siju-samuel": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "reason": "custom override"
+    },    
     "zhaochenyang20": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
Add the following IDs into CI_PERMISSIONS.json file.
@siju-samuel 
## Motivation

Intel is contributing the XPU enablement work for SGLang-Omni, which needs CI runs
on the self-hosted GPU runners. CI is gated behind the `run-ci` label, and only
accounts listed in `.github/CI_PERMISSIONS.json` may apply it or re-run a failed
job. Adding my account lets me label and re-run CI on my own PRs instead of asking
a maintainer each time.

## Modifications

Add a `siju-samuel` entry to `.github/CI_PERMISSIONS.json` with
`can_tag_run_ci_label` and `can_rerun_failed_ci`, matching the existing entries.
The file stays valid JSON and remains in the sorted order that
`.github/update_ci_permission.py --sort-only` produces.

No code or workflow logic changes.

## Related Issues

None.

## Accuracy Test

Not applicable — configuration only, no model or kernel code.

## Benchmark & Profiling

Not applicable — no runtime code paths change.

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.

cc: @Ratish1 
