### PR TITLE
[Perf][Qwen3-TTS] Add breakable Prefill CUDA Graph support

### DIFF
--- a/sglang_omni/models/qwen3_tts/__init__.py
+++ b/sglang_omni/models/qwen3_tts/__init__.py
@@ -11,7 +11,7 @@ CAPABILITIES = ModelCapabilities(
     supports_streaming_vocoder=True,
     supports_cuda_graph=True,
     supports_torch_compile=False,
-    supports_breakable_prefill_cuda_graph=False,
+    supports_breakable_prefill_cuda_graph=True,
 )
 
 __all__ = ["CAPABILITIES", "config"]

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import importlib
 from typing import Any
 
-from sglang_omni.models.qwen3_tts import request_builders
+from sglang_omni.models.qwen3_tts import CAPABILITIES, request_builders
 from sglang_omni.models.qwen3_tts import stages as qwen3_stages
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
 
@@ -25,6 +25,9 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
     model_name = "Qwen3-TTS"
     context_length = 8192
     model_arch_override = "Qwen3TTSTalker"
+    supports_breakable_prefill_cuda_graph = (
+        CAPABILITIES.supports_breakable_prefill_cuda_graph
+    )
 
     def __init__(self, *, attn_implementation: str | None = None) -> None:
         self.attn_implementation = attn_implementation

--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 from typing import Any
 
 import torch
-from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.sampling.penaltylib import BatchedRepetitionPenalizer
 
 from sglang_omni.model_runner.base import ModelRunner
-from sglang_omni.model_runner.sglang_execution import attn_forward_context
+from sglang_omni.model_runner.prefill_inputs import (
+    OmniPrefillInputs,
+    attach_omni_prefill_inputs,
+)
 from sglang_omni.models.qwen3_omni.talker_model_runner import QwenTalkerModelRunner
 from sglang_omni.scheduling.types import RequestOutput
 
@@ -42,20 +44,16 @@ class Qwen3TTSModelRunner(ModelRunner):
         schedule_batch: Any,
         requests: list,
     ) -> None:
-        del forward_batch, schedule_batch
-        self.model.prepare_decode_buffers(requests)
-
-    def custom_prefill_forward(
-        self,
-        forward_batch: Any,
-        schedule_batch: Any,
-        requests: list,
-    ) -> GenerationBatchResult | None:
         del schedule_batch
-        input_embeds = self._build_prefill_input_embeds(forward_batch, requests)
-        return self._forward_with_input_embeds(
+        self.model.prepare_decode_buffers(requests)
+        attach_omni_prefill_inputs(
             forward_batch,
-            input_embeds,
+            OmniPrefillInputs(
+                input_embeds=self._build_prefill_input_embeds(
+                    forward_batch,
+                    requests,
+                ),
+            ),
         )
 
     def before_decode(
@@ -369,33 +367,4 @@ class Qwen3TTSModelRunner(ModelRunner):
         return torch.cat(pieces, dim=0).to(
             device=forward_batch.input_ids.device,
             dtype=next(self.model.parameters()).dtype,
-        )
-
-    def _forward_with_input_embeds(
-        self,
-        forward_batch: Any,
-        input_embeds: torch.Tensor,
-    ) -> GenerationBatchResult:
-        model_runner = self.tp_worker.model_runner
-        model_dtype = next(self.model.parameters()).dtype
-        model_runner.attn_backend.init_forward_metadata(forward_batch)
-
-        positions = forward_batch.positions
-        if forward_batch.mrope_positions is not None:
-            positions = forward_batch.mrope_positions
-        input_embeds = input_embeds.to(
-            device=forward_batch.input_ids.device,
-            dtype=model_dtype,
-        )
-        with attn_forward_context(model_runner.attn_backend):
-            logits_output = self.model(
-                input_ids=forward_batch.input_ids,
-                positions=positions,
-                forward_batch=forward_batch,
-                input_embeds=input_embeds,
-                input_embeds_are_projected=True,
-            )
-        return GenerationBatchResult(
-            logits_output=logits_output,
-            can_run_cuda_graph=False,
         )

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -12,6 +12,9 @@ import torch
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
 from sglang.srt.layers.sampler import multinomial_with_seed
+from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
+    eager_on_graph,
+)
 from sglang.srt.utils import add_prefix
 from torch import nn
 
@@ -46,6 +49,11 @@ _PREDICTOR_GRAPH_MAX_FAILURES = 8
 # Note: (Jiaxin Deng) 50 is on the ladder because it is the family checkpoint
 # default, keeping the dominant signature's kernel width exactly as before.
 _PREDICTOR_TOP_K_LADDER = (4, 8, 16, 32, 50, 64, 128, 256, 512, 1024)
+
+
+def _install_breakable_prefill_qk_norm_rope_graph_break(attention: Any) -> None:
+    """Keep Qwen3-TTS QK norm and RoPE outside breakable graph segments."""
+    attention.apply_qk_norm_rope = eager_on_graph(True)(attention.apply_qk_norm_rope)
 
 
 def _predictor_graph_env_enabled() -> bool:
@@ -205,6 +213,11 @@ class Qwen3TTSTalkerDecoderLayer(nn.Module):
             dual_chunk_attention_config=None,
             alt_stream=None,
         )
+        # Capturing the packed QKV normalization and RoPE block corrupts
+        # Qwen3-TTS prefill replay. Keep this narrow block eager while the
+        # surrounding projections and MLP remain captured. Decode execution
+        # runs outside the breakable-prefill context and is unchanged.
+        _install_breakable_prefill_qk_norm_rope_graph_break(self.self_attn)
         self.mlp = Qwen3OmniMoeTalkerDenseMLP(
             config.hidden_size,
             config.intermediate_size,
@@ -380,6 +393,11 @@ class Qwen3TTSCodePredictor(nn.Module):
 
 class Qwen3TTSTalker(nn.Module):
     """Qwen3-TTS Base talker with SGLang-managed KV cache for the main AR loop."""
+
+    # The outer forward substitutes ForwardBatch.mrope_positions whenever they
+    # are present. Prefill CUDA graph runners capture the inner text model
+    # directly and use this marker to preserve that position contract.
+    is_mrope_enabled = True
 
     def __init__(self, config: Any, quant_config: Any = None, prefix: str = "") -> None:
         del quant_config
@@ -1102,8 +1120,9 @@ class Qwen3TTSTalker(nn.Module):
         forward_batch: ForwardBatch,
         input_embeds: Optional[torch.Tensor] = None,
         input_embeds_are_projected: bool = False,
+        omni_prefill_rids: list[str] | None = None,
     ) -> LogitsProcessorOutput:
-        del input_embeds_are_projected
+        del input_embeds_are_projected, omni_prefill_rids
         if forward_batch.mrope_positions is not None:
             positions = forward_batch.mrope_positions
 

--- a/tests/unit_test/models/test_model_capabilities.py
+++ b/tests/unit_test/models/test_model_capabilities.py
@@ -46,7 +46,7 @@ EXPECTED_MODEL_CAPABILITIES = {
         supports_streaming_vocoder=True,
         supports_cuda_graph=True,
         supports_torch_compile=False,
-        supports_breakable_prefill_cuda_graph=False,
+        supports_breakable_prefill_cuda_graph=True,
     ),
     "HiggsMultimodalQwen3ForConditionalGeneration": ModelCapabilities(
         supports_reference_audio=True,
@@ -231,7 +231,7 @@ def test_launcher_model_capabilities_log_summary() -> None:
         "streaming_vocoder": True,
         "cuda_graph": True,
         "torch_compile": False,
-        "breakable_prefill_cuda_graph": False,
+        "breakable_prefill_cuda_graph": True,
     }
 
 

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -16,6 +16,7 @@ import pytest
 import torch
 
 from sglang_omni.config.runtime import resolve_stage_factory_kwargs
+from sglang_omni.model_runner.prefill_inputs import get_omni_prefill_inputs
 from sglang_omni.models.qwen3_omni.pending_text_queue import PendingTextTensorQueue
 from sglang_omni.models.qwen3_tts import request_builders as qwen3_request_builders
 from sglang_omni.models.qwen3_tts import stages as qwen3_stages
@@ -150,6 +151,15 @@ def install_fake_sglang(monkeypatch: pytest.MonkeyPatch) -> None:
             "sglang.srt.layers.logits_processor"
         ),
         "sglang.srt.layers.sampler": types.ModuleType("sglang.srt.layers.sampler"),
+        "sglang.srt.model_executor": types.ModuleType("sglang.srt.model_executor"),
+        "sglang.srt.model_executor.runner_backend_utils": types.ModuleType(
+            "sglang.srt.model_executor.runner_backend_utils"
+        ),
+        "sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph": (
+            types.ModuleType(
+                "sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph"
+            )
+        ),
         "sglang.srt.model_loader": types.ModuleType("sglang.srt.model_loader"),
         "sglang.srt.model_loader.weight_utils": types.ModuleType(
             "sglang.srt.model_loader.weight_utils"
@@ -169,6 +179,8 @@ def install_fake_sglang(monkeypatch: pytest.MonkeyPatch) -> None:
         "sglang.srt",
         "sglang.srt.managers",
         "sglang.srt.layers",
+        "sglang.srt.model_executor",
+        "sglang.srt.model_executor.runner_backend_utils",
         "sglang.srt.model_loader",
         "sglang.srt.sampling",
     ):
@@ -176,6 +188,7 @@ def install_fake_sglang(monkeypatch: pytest.MonkeyPatch) -> None:
     modules["sglang"].srt = modules["sglang.srt"]
     modules["sglang.srt"].managers = modules["sglang.srt.managers"]
     modules["sglang.srt"].layers = modules["sglang.srt.layers"]
+    modules["sglang.srt"].model_executor = modules["sglang.srt.model_executor"]
     modules["sglang.srt"].model_loader = modules["sglang.srt.model_loader"]
     modules["sglang.srt"].sampling = modules["sglang.srt.sampling"]
     modules["sglang.srt"].utils = modules["sglang.srt.utils"]
@@ -187,6 +200,12 @@ def install_fake_sglang(monkeypatch: pytest.MonkeyPatch) -> None:
         "sglang.srt.layers.logits_processor"
     ]
     modules["sglang.srt.layers"].sampler = modules["sglang.srt.layers.sampler"]
+    modules["sglang.srt.model_executor"].runner_backend_utils = modules[
+        "sglang.srt.model_executor.runner_backend_utils"
+    ]
+    modules["sglang.srt.model_executor.runner_backend_utils"].breakable_cuda_graph = (
+        modules["sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph"]
+    )
     modules["sglang.srt.model_loader"].weight_utils = modules[
         "sglang.srt.model_loader.weight_utils"
     ]
@@ -206,6 +225,9 @@ def install_fake_sglang(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     modules["sglang.srt.layers.sampler"].multinomial_with_seed = multinomial_with_seed
     modules["sglang.srt.layers.sampler"].sampler_calls = sampler_calls
+    modules[
+        "sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph"
+    ].eager_on_graph = lambda enabled: lambda function: function
     modules["sglang.srt.model_loader.weight_utils"].default_weight_loader = (
         default_weight_loader
     )
@@ -274,6 +296,88 @@ def test_qwen3_tts_deterministic_inference_configures_pipeline() -> None:
     assert vocoder["enable_deterministic_inference"]
     assert vocoder["initial_cuda_graph"] is False
     assert vocoder["followup_cuda_graph"] is False
+
+
+def test_qwen3_tts_breakable_prefill_is_compatible_but_not_default_enabled() -> None:
+    """Compatibility permits explicit opt-in without changing shipped defaults."""
+    from sglang_omni.models.qwen3_tts import CAPABILITIES
+    from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
+
+    builder = Qwen3TtsEngineBuilder()
+    defaults = builder.generation_defaults(dtype="bfloat16")
+
+    assert CAPABILITIES.supports_breakable_prefill_cuda_graph is True
+    assert (
+        type(builder).supports_breakable_prefill_cuda_graph
+        is CAPABILITIES.supports_breakable_prefill_cuda_graph
+    )
+    assert "cuda_graph_backend_prefill" not in defaults
+    assert "cuda_graph_bs_prefill" not in defaults
+    assert defaults["disable_cuda_graph"] is False
+
+
+def test_qwen3_tts_breakable_prefill_breaks_around_qk_norm_rope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang(monkeypatch)
+    from sglang_omni.models.qwen3_tts import sglang_model
+
+    events: list[tuple[str, object]] = []
+
+    def fake_eager_on_graph(enabled: bool):
+        events.append(("enabled", enabled))
+
+        def decorate(function):
+            def wrapped(*args, **kwargs):
+                events.append(("wrapped", (args, kwargs)))
+                return function(*args, **kwargs)
+
+            return wrapped
+
+        return decorate
+
+    class FakeAttention(torch.nn.Module):
+        def __init__(self, **kwargs) -> None:
+            super().__init__()
+
+        def apply_qk_norm_rope(self, qkv, positions, forward_batch):
+            events.append(("inner", (qkv, positions, forward_batch)))
+            return qkv, positions, forward_batch
+
+    class FakeModule(torch.nn.Module):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__()
+
+    monkeypatch.setattr(sglang_model, "eager_on_graph", fake_eager_on_graph)
+    monkeypatch.setattr(
+        sglang_model,
+        "Qwen3OmniMoeThinkerTextAttention",
+        FakeAttention,
+    )
+    monkeypatch.setattr(sglang_model, "Qwen3OmniMoeTalkerDenseMLP", FakeModule)
+    monkeypatch.setattr(sglang_model, "RMSNorm", FakeModule)
+
+    config = SimpleNamespace(
+        hidden_size=1024,
+        num_attention_heads=16,
+        num_key_value_heads=8,
+        rope_theta=1_000_000,
+        rope_scaling=None,
+        max_position_embeddings=32_768,
+        head_dim=128,
+        rms_norm_eps=1e-6,
+        attention_bias=False,
+        intermediate_size=3072,
+    )
+    layer = sglang_model.Qwen3TTSTalkerDecoderLayer(config, layer_id=0)
+
+    expected = (object(), object(), object())
+    assert layer.self_attn.apply_qk_norm_rope(*expected) == expected
+    assert events == [
+        ("enabled", True),
+        ("wrapped", (expected, {})),
+        ("inner", expected),
+    ]
 
 
 @pytest.mark.parametrize(
@@ -4256,27 +4360,105 @@ def test_qwen3_tts_ar_scheduler_abort_cleans_prepared_state() -> None:
         qwen3_request_builders.cleanup_prepared_qwen3_tts_request(request_id)
 
 
-def test_qwen3_tts_prefill_prepares_subtalker_buffers_before_forward(
+def test_qwen3_tts_prefill_attaches_runner_composed_embeddings_to_sidecar(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Prefill conditioning stays outside upstream graph-admission fields."""
     install_fake_sglang(monkeypatch)
     from sglang_omni.models.qwen3_tts.model_runner import Qwen3TTSModelRunner
 
     calls: list[str] = []
+    input_embeds = torch.ones(3, 2)
     runner = Qwen3TTSModelRunner.__new__(Qwen3TTSModelRunner)
     runner.model = SimpleNamespace(
         prepare_decode_buffers=lambda requests: calls.append("prepare")
     )
     runner._build_prefill_input_embeds = (
-        lambda forward_batch, requests: calls.append("embeds") or object()
+        lambda forward_batch, requests: calls.append("embeds") or input_embeds
     )
-    runner._forward_with_input_embeds = (
-        lambda forward_batch, input_embeds: calls.append("forward") or "result"
+    mm_inputs = [object()]
+    forward_batch = SimpleNamespace(
+        input_ids=torch.zeros(3, dtype=torch.long),
+        input_embeds=None,
+        replace_embeds=None,
+        mm_inputs=mm_inputs,
     )
 
-    runner.before_prefill(object(), object(), [object()])
-    assert runner.custom_prefill_forward(object(), object(), [object()]) == "result"
-    assert calls == ["prepare", "embeds", "forward"]
+    runner.before_prefill(forward_batch, object(), [object()])
+
+    sidecar = get_omni_prefill_inputs(forward_batch)
+    assert sidecar is not None
+    assert sidecar.input_embeds is input_embeds
+    assert forward_batch.input_embeds is None
+    assert forward_batch.mm_inputs is mm_inputs
+    assert calls == ["prepare", "embeds"]
+
+
+def test_qwen3_tts_prefill_uses_shared_late_bound_forward_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The standard generation path late-binds Qwen conditioning and request ids."""
+    install_fake_sglang(monkeypatch)
+    from sglang_omni.model_runner.sglang_model_runner import SGLModelRunner
+    from sglang_omni.models.qwen3_tts.model_runner import Qwen3TTSModelRunner
+
+    input_embeds = torch.arange(6, dtype=torch.float32).view(3, 2)
+    received: dict[str, object] = {}
+
+    class FakeTalker:
+        def prepare_decode_buffers(self, requests) -> None:
+            received["prepared_requests"] = requests
+
+        def __call__(self, **kwargs):
+            received.update(kwargs)
+            return "logits"
+
+    runner = Qwen3TTSModelRunner.__new__(Qwen3TTSModelRunner)
+    runner.model = FakeTalker()
+    runner._build_prefill_input_embeds = lambda _batch, _requests: input_embeds
+
+    shared_runner = SGLModelRunner.__new__(SGLModelRunner)
+    shared_runner.support_pp = False
+    shared_runner.is_generation = True
+
+    def forward_batch_generation(forward_batch):
+        kwargs = shared_runner._extend_forward_kwargs(forward_batch, object())
+        logits_output = runner.model(
+            input_ids=forward_batch.input_ids,
+            positions=forward_batch.positions,
+            forward_batch=forward_batch,
+            **kwargs,
+        )
+        return SimpleNamespace(logits_output=logits_output, next_token_ids=None)
+
+    runner.tp_worker = SimpleNamespace(
+        forward_batch_generation=forward_batch_generation
+    )
+    requests = [SimpleNamespace(request_id="request-a")]
+    forward_batch = SimpleNamespace(
+        input_ids=torch.zeros(3, dtype=torch.long),
+        input_embeds=None,
+        replace_embeds=None,
+        replace_positions=None,
+        mm_inputs=[None],
+        batch_size=1,
+        rids=["request-a"],
+        positions=torch.arange(3),
+    )
+    schedule_batch = SimpleNamespace(is_prefill_only=True)
+
+    result = runner._prepare_and_forward(
+        forward_batch,
+        schedule_batch,
+        requests,
+        is_prefill=True,
+    )
+
+    assert result.logits_output == "logits"
+    assert received["input_embeds"] is input_embeds
+    assert received["omni_prefill_rids"] is forward_batch.rids
+    assert forward_batch.input_embeds is None
+    assert get_omni_prefill_inputs(forward_batch) is None
 
 
 def test_qwen3_tts_sampling_installs_semantic_seed_tensor(
@@ -5192,39 +5374,46 @@ def test_qwen3_tts_cli_rejects_out_of_range_mem_fraction() -> None:
         ConfigManager(config).merge_config([], extra_patches=patches)
 
 
-def test_qwen3_tts_prefill_publishes_sglang_forward_context() -> None:
-    from sglang.srt.model_executor.forward_context import (
-        get_forward_context,
-        has_forward_context,
-    )
+def test_qwen3_tts_talker_forward_accepts_shared_prefill_request_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shared request-id transport does not alter Talker prefill results."""
+    install_fake_sglang(monkeypatch)
+    from sglang_omni.models.qwen3_tts.sglang_model import Qwen3TTSTalker
 
-    from sglang_omni.models.qwen3_tts.model_runner import Qwen3TTSModelRunner
+    input_embeds = torch.arange(6, dtype=torch.float32).view(3, 2)
+    received: dict[str, object] = {}
 
-    runner = Qwen3TTSModelRunner.__new__(Qwen3TTSModelRunner)
-    attn_backend = SimpleNamespace(init_forward_metadata=lambda _batch: None)
-    runner.tp_worker = SimpleNamespace(
-        model_runner=SimpleNamespace(attn_backend=attn_backend)
-    )
+    def backbone(**kwargs):
+        received.update(kwargs)
+        return kwargs["input_embeds"]
 
-    seen = []
-
-    def model(**kwargs):
-        seen.append(get_forward_context().attn_backend)
-        return "logits"
-
-    model.parameters = lambda: iter([torch.zeros(1, dtype=torch.float32)])
-    runner.model = model
+    talker = Qwen3TTSTalker.__new__(Qwen3TTSTalker)
+    talker.model = backbone
+    talker.codec_head = lambda hidden_states: (hidden_states + 1, None)
     forward_batch = SimpleNamespace(
-        positions=torch.tensor([0]),
+        input_ids=torch.zeros(3, dtype=torch.long),
         mrope_positions=None,
-        input_ids=torch.tensor([1]),
+        forward_mode=SimpleNamespace(is_extend=lambda: True),
+        extend_seq_lens=torch.tensor([3]),
+    )
+    request_ids = ["request-a"]
+
+    result = Qwen3TTSTalker.forward(
+        talker,
+        input_ids=forward_batch.input_ids,
+        positions=torch.arange(3),
+        forward_batch=forward_batch,
+        input_embeds=input_embeds,
+        omni_prefill_rids=request_ids,
     )
 
-    assert not has_forward_context()
-    result = runner._forward_with_input_embeds(forward_batch, torch.ones(1, 2))
-
-    assert seen == [attn_backend]
-    assert result.logits_output == "logits"
+    assert received["input_embeds"] is input_embeds
+    assert Qwen3TTSTalker.is_mrope_enabled is True
+    torch.testing.assert_close(
+        result.next_token_logits,
+        input_embeds[-1:] + 1,
+    )
 
 
 def _make_prep_talker(monkeypatch):

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -4420,6 +4420,7 @@ def test_qwen3_tts_prefill_uses_shared_late_bound_forward_transport(
     shared_runner = SGLModelRunner.__new__(SGLModelRunner)
     shared_runner.support_pp = False
     shared_runner.is_generation = True
+    shared_runner.dtype = torch.float32
 
     def forward_batch_generation(forward_batch):
         kwargs = shared_runner._extend_forward_kwargs(forward_batch, object())


### PR DESCRIPTION
## Motivation

Qwen3-TTS constructs request-specific input embeddings before prefill. Its previous custom prefill forward path always forced eager execution, so the model could not use the shared breakable Prefill CUDA Graph implementation.

This change adopts the existing Omni prefill sidecar and late-bound forward contract. Qwen3-TTS can now explicitly opt into breakable prefill while preserving eager fallback for uncaptured shapes.

Breakable prefill remains **disabled by default** for Qwen3-TTS.

## Modifications

- Declare Qwen3-TTS compatible with breakable Prefill CUDA Graphs in its model capability and engine builder.
- Replace the custom eager-only prefill forward with `OmniPrefillInputs` sidecar attachment and the shared `SGLModelRunner` transport path.
- Keep request-specific embeddings out of graph-admission fields and late-bind them during model forward.
- Preserve Qwen3-TTS MRoPE positions when the shared prefill graph runner captures the inner model.
- Keep the packed QK normalization and RoPE block eager with `eager_on_graph`; capturing that narrow block corrupted Qwen3-TTS prefill replay during qualification.
- Add unit coverage for capability/default policy, sidecar transport, MRoPE, and the graph break.

## Benchmarking

This validation covers **Qwen3-TTS only**. WER is calculated from generated speech as a TTS accuracy metric; it is not a standalone ASR benchmark result.

### Result

- **Performance:** head with breakable prefill improved TTS throughput and mean latency at every tested concurrency in both non-streaming and streaming modes.
- **Accuracy:** all **17,408/17,408** generated outputs completed and were evaluated; no requests were skipped.
- **Caveat:** head streaming at concurrency 16 produced one 163.84-second repetition, inflating raw corpus WER from 1.097% to 8.256%. Excluding samples above 50% WER, head was 1.114% versus 1.097% base.

### Setup

- Base: `dd41c4e8054e2f7bc4835d32a334b9201ed046c8`
- Head: `aa878fdd310dba8906450639bfd62a216d1b254d`
- Target: Vast.ai direct container; NVIDIA H100 80GB HBM3; driver 595.71.05
- CI image: `hongccc/sglang-omni@sha256:374d0b1c30b2bff685b1716fc64a02ad3b3d0a90fe2ce73ce9861a6992c28101`
- Model: `Qwen/Qwen3-TTS-12Hz-0.6B-Base@5d83992436eae1d760afd27aff78a71d676296fc`
- Dataset: Seed-TTS EN, all 1,088 samples, revision `27f4c1adee83b5b29b7c4b375f6b976324bda308`
- Concurrency: 1, 8, 16, and 32
- Controls: request seed 42, radix cache disabled, 48-request discarded warmup, one full-corpus measured pass per point

### Non-streaming

| Concurrency | Throughput base → head | Throughput Δ | Mean latency Δ | P99 latency Δ | Raw WER base → head | Filtered WER base → head |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 1.851 → 1.922 req/s | +3.84% | -3.70% | -2.58% | 1.222% → 1.273% | 1.222% → 1.182% |
| 8 | 8.019 → 8.383 req/s | +4.54% | -4.32% | -6.79% | 1.164% → 1.164% | 1.164% → 1.164% |
| 16 | 10.648 → 11.517 req/s | +8.16% | -7.62% | -7.80% | 1.197% → 1.139% | 1.197% → 1.139% |
| 32 | 9.914 → 10.869 req/s | +9.63% | -8.81% | -8.86% | 1.155% → 1.130% | 1.155% → 1.130% |

### Streaming

| Concurrency | Throughput Δ | Mean latency Δ | TTFP mean Δ | TTFP P95 Δ | TTFP P99 Δ | Raw WER base → head | Filtered WER base → head |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | +4.16% | -3.99% | -8.08% | -7.94% | -13.65% | 1.214% → 1.080% | 1.214% → 1.080% |
| 8 | +8.16% | -7.53% | -9.33% | -14.11% | -14.59% | 1.181% → 1.089% | 1.181% → 1.089% |
| 16 | +10.52% | -9.51% | -13.43% | -18.90% | -18.32% | 1.097% → 8.256% | 1.097% → 1.114% |
| 32 | +6.94% | -6.40% | -7.21% | -1.79% | +1.40% | 1.114% → 1.105% | 1.114% → 1.105% |

Streaming playback continuity remained effectively perfect: C50/C100/C200 were 99.63–100%, with mean underrun between 0 and 0.0004 seconds.

### Accuracy outliers

- Non-streaming concurrency 1 head: `common_voice_en_22793454-common_voice_en_22793458`, 12.16-second output and 78.57% sample WER. Excluding >50%-WER samples changes corpus WER from 1.273% to 1.182%.
- Streaming concurrency 16 head: `common_voice_en_17920116-common_voice_en_17920112`, 163.84-second output and 28,433% sample WER. Excluding >50%-WER samples changes corpus WER from 8.256% to 1.114%.
- Apart from those two head outliers, no point had a sample above 50% WER. Head filtered WER was equal or better at 6/8 points and slightly worse at streaming concurrency 16 and 32.

### Limitations

- TTS has one measured full-corpus pass per point, so small deltas and rare runaway-generation rates need repeat confirmation.
- Base eager versus head breakable measures the end-to-end PR-enabled deployment delta, not a same-head feature-toggle-only attribution.

## Related work

- #1364 introduced the shared breakable Prefill CUDA Graph infrastructure and the first TTS adopter.
- #1575 demonstrates the shared sidecar adopter pattern used here.
- Related to #1357.

## Checklist

- [x] Format code according to project conventions.
- [x] Add unit tests.
- [x] Provide GPU functional qualification.
- [x] Measure full-corpus Qwen3-TTS accuracy and performance across streaming and non-streaming concurrency 1/8/16/32.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
