### PR TITLE
Add MUSA platform support

### DIFF
--- a/sglang_omni/platforms/__init__.py
+++ b/sglang_omni/platforms/__init__.py
@@ -1,6 +1,10 @@
 import os
 import pkgutil
 
+try:
+    import torchada  # noqa: F401
+except ImportError:
+    pass
 import torch
 from sglang.srt import platforms as srt_platforms
 from sglang.srt.platforms.interface import SRTPlatform

--- a/sglang_omni/platforms/__init__.py
+++ b/sglang_omni/platforms/__init__.py
@@ -8,6 +8,7 @@ from sglang.srt.platforms.interface import SRTPlatform
 from sglang_omni.platforms.cpu import CPUOmniPlatform
 from sglang_omni.platforms.cuda import CUDAOmniPlatform, ROCMOmniPlatform
 from sglang_omni.platforms.interface import OmniPlatform
+from sglang_omni.platforms.musa import MUSAOmniPlatform
 from sglang_omni.platforms.npu import NPUOmniPlatform
 
 
@@ -35,6 +36,8 @@ def _load_platform_class(qualname: str) -> type[OmniPlatform]:
 
 
 def _as_omni_platform(platform: SRTPlatform) -> OmniPlatform:
+    if platform.is_musa():
+        return MUSAOmniPlatform()
     if platform.is_cuda():
         return CUDAOmniPlatform()
     if platform.is_rocm():

--- a/sglang_omni/platforms/musa.py
+++ b/sglang_omni/platforms/musa.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MUSA platform hooks for SGLang Omni."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang_omni.platforms.interface import OmniPlatform
+from sglang_omni.utils.misc import normalize_quantization
+from sglang_omni.vendor.sglang.server_args import override_server_args
+
+if TYPE_CHECKING:
+    from sglang_omni.pipeline.stage_workers import StageLaunchConfig
+
+
+class MUSAOmniPlatform(OmniPlatform):
+    device_name = "musa"
+    device_type = "musa"
+
+    def is_musa(self) -> bool:
+        try:
+            import torchada  # noqa: F401
+        except ImportError:
+            return False
+        return hasattr(torch.version, "musa") and torch.version.musa is not None
+
+    def get_stage_process_env(
+        self,
+        spec: StageLaunchConfig,
+        env: Mapping[str, str] | None = None,
+    ) -> dict[str, str]:
+        if spec.tp_size <= 1:
+            return {}
+
+        source_env = env if env is not None else os.environ
+        original_visible = source_env.get("MUSA_VISIBLE_DEVICES")
+        if spec.gpu_id is None:
+            raise ValueError(f"tp stage {spec.stage_name!r} requires a GPU id")
+        if original_visible:
+            visible_devices = [item.strip() for item in original_visible.split(",")]
+            if spec.gpu_id >= len(visible_devices):
+                raise ValueError(
+                    f"tp stage {spec.stage_name!r} assigned gpu_id={spec.gpu_id}, "
+                    f"but MUSA_VISIBLE_DEVICES only exposes {visible_devices}"
+                )
+            mapped_gpu = visible_devices[spec.gpu_id]
+        else:
+            mapped_gpu = str(spec.gpu_id)
+
+        return {
+            "MUSA_VISIBLE_DEVICES": mapped_gpu,
+            "SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS": "true",
+            "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "false",
+        }
+
+    def get_intra_node_transport(self) -> TransportKind:
+        from sglang_omni.comm.data_ref import TransportKind
+
+        return TransportKind.CUDA_IPC
+
+    def apply_model_worker_backend_policy(
+        self,
+        server_args: ServerArgs,
+        model_config: ModelConfig,
+        model_arch_override: str | None,
+    ) -> str | None:
+        effective_quantization = super().apply_model_worker_backend_policy(
+            server_args, model_config, model_arch_override
+        )
+
+        if server_args.moe_runner_backend == "auto":
+            override_server_args(
+                server_args,
+                "sglang-omni-musa-backend-policy",
+                moe_runner_backend="triton",
+            )
+
+        if normalize_quantization(server_args.fp8_gemm_runner_backend) in (
+            None,
+            "auto",
+        ):
+            override_server_args(
+                server_args,
+                "sglang-omni-musa-backend-policy",
+                fp8_gemm_runner_backend="deep_gemm",
+            )
+
+        return effective_quantization

--- a/sglang_omni/platforms/musa.py
+++ b/sglang_omni/platforms/musa.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 import torch
+from sglang.srt.platforms.device_mixin import PlatformEnum
 
 from sglang_omni.platforms.interface import OmniPlatform
 from sglang_omni.utils.misc import normalize_quantization
@@ -18,15 +19,37 @@ if TYPE_CHECKING:
 
 
 class MUSAOmniPlatform(OmniPlatform):
+    _enum = PlatformEnum.MUSA
     device_name = "musa"
     device_type = "musa"
 
-    def is_musa(self) -> bool:
-        try:
-            import torchada  # noqa: F401
-        except ImportError:
-            return False
-        return hasattr(torch.version, "musa") and torch.version.musa is not None
+    def get_device(self, local_rank: int) -> torch.device:
+        return torch.device("musa", local_rank)
+
+    def set_device(self, device: torch.device | int) -> None:
+        torch.musa.set_device(device)
+
+    def get_device_name(self, device_id: int = 0) -> str:
+        return torch.cuda.get_device_name(device_id)
+
+    def get_device_total_memory(self, device_id: int = 0) -> int:
+        return int(torch.cuda.get_device_properties(device_id).total_memory)
+
+    def get_current_memory_usage(self, device: torch.device | None = None) -> float:
+        torch.cuda.reset_peak_memory_stats(device)
+        return float(torch.cuda.max_memory_allocated(device))
+
+    def empty_cache(self) -> None:
+        torch.cuda.empty_cache()
+
+    def synchronize(self) -> None:
+        torch.cuda.synchronize()
+
+    def get_available_memory(self, device_id: int = 0) -> tuple[int, int]:
+        return tuple(int(v) for v in torch.cuda.mem_get_info(device_id))
+
+    def get_torch_distributed_backend_str(self) -> str:
+        return "mccl"
 
     def get_stage_process_env(
         self,

--- a/tests/unit_test/test_platforms.py
+++ b/tests/unit_test/test_platforms.py
@@ -11,6 +11,7 @@ from sglang.srt.platforms.rocm import RocmSRTPlatform
 import sglang_omni.platforms as platforms
 from sglang_omni.platforms.cpu import CPUOmniPlatform
 from sglang_omni.platforms.interface import OmniPlatform
+from sglang_omni.platforms.musa import MUSAOmniPlatform
 
 
 class _VendorDeviceMixin(DeviceMixin):
@@ -51,6 +52,20 @@ def test_rocm_platform_keeps_cuda_compatible_tp_mapping() -> None:
             "CUDA_VISIBLE_DEVICES"
         ]
         == "4"
+    )
+
+
+def test_musa_platform_uses_musa_visible_devices() -> None:
+    platform = MUSAOmniPlatform()
+    spec = SimpleNamespace(stage_name="thinker", tp_size=2, gpu_id=1)
+
+    assert platform.is_musa()
+    assert platform.device_type == "musa"
+    assert (
+        platform.get_stage_process_env(spec, {"MUSA_VISIBLE_DEVICES": "2,5"})[
+            "MUSA_VISIBLE_DEVICES"
+        ]
+        == "5"
     )
 
 


### PR DESCRIPTION
## Summary

Add a dedicated MUSA Omni platform so SGLang-Omni can recognize and launch on MUSA devices.

The platform keeps the integration thin and CUDA-compatible via `torchada`, while exposing MUSA-specific process environment handling and backend defaults:

- register `MUSAOmniPlatform` in platform dispatch
- detect MUSA before CUDA so `torchada` CUDA compatibility does not hide the MUSA platform
- map per-stage `MUSA_VISIBLE_DEVICES` for TP worker launches
- use CUDA IPC for intra-node transport
- default MoE runner backend to `triton`
- default FP8 GEMM runner backend to `deep_gemm`

## Validation

- `python -m py_compile sglang_omni/platforms/__init__.py sglang_omni/platforms/musa.py`
- Generated a text-to-video sample on a MUSA GPU using the official `damo-vilab/text-to-video-ms-1.7b-legacy` parameters:
  - `DPMSolverMultistepScheduler`
  - `num_inference_steps=25`
  - `num_frames=16`
  - `height=256`, `width=256`
  - output verified as H.264 MP4, 256x256, 16 frames, 8 fps
