### PR TITLE
[Fix][TTS] Rebuild Qwen3-TTS and delay Moss re-prefill after retraction

### DIFF
--- a/sglang_omni/models/moss_tts/model_runner.py
+++ b/sglang_omni/models/moss_tts/model_runner.py
@@ -89,8 +89,7 @@ class MossTTSModelRunner(ModelRunner):
             req_len = int(req.extend_range.length)
             prefix_len = len(req.prefix_indices)
             if data.output_rows:
-                # Retraction re-prefill includes generated frames; drop the
-                # stranded decode-feedback row that the resumed prefill replaces.
+                # note (Richard Wang): prompt_rows is short by the generated tail
                 generated = torch.stack(data.output_rows, dim=0)
                 rows = torch.cat([rows.to(generated.device), generated], dim=0)
             current_rows = rows[prefix_len : prefix_len + req_len]
@@ -102,6 +101,7 @@ class MossTTSModelRunner(ModelRunner):
                     f"generated={len(data.output_rows)})"
                 )
             if data.output_rows:
+                # note (Richard Wang): leftover row would decode instead of new sample
                 data.pending_feedback_queue.clear()
             embeds = self.model._prepare_multi_modal_inputs(
                 current_rows.to(device=forward_batch.input_ids.device)

--- a/sglang_omni/models/moss_tts/model_runner.py
+++ b/sglang_omni/models/moss_tts/model_runner.py
@@ -88,7 +88,21 @@ class MossTTSModelRunner(ModelRunner):
                 raise RuntimeError("MOSS-TTS prefill requires prompt_rows")
             req_len = int(req.extend_range.length)
             prefix_len = len(req.prefix_indices)
+            if data.output_rows:
+                # Retraction re-prefill includes generated frames; drop the
+                # stranded decode-feedback row that the resumed prefill replaces.
+                generated = torch.stack(data.output_rows, dim=0)
+                rows = torch.cat([rows.to(generated.device), generated], dim=0)
             current_rows = rows[prefix_len : prefix_len + req_len]
+            if int(current_rows.shape[0]) != req_len:
+                raise RuntimeError(
+                    f"MOSS-TTS prefill row mismatch for {req.rid}: have "
+                    f"{int(current_rows.shape[0])} rows, need {req_len} "
+                    f"(prefix={prefix_len}, prompt={int(data.prompt_rows.shape[0])}, "
+                    f"generated={len(data.output_rows)})"
+                )
+            if data.output_rows:
+                data.pending_feedback_queue.clear()
             embeds = self.model._prepare_multi_modal_inputs(
                 current_rows.to(device=forward_batch.input_ids.device)
             )

--- a/sglang_omni/models/moss_tts/request_builders.py
+++ b/sglang_omni/models/moss_tts/request_builders.py
@@ -9,6 +9,7 @@ import os
 import re
 import threading
 import time
+import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -737,6 +738,7 @@ def build_sglang_moss_tts_request(
         sampling_params=sampling_params,
         eos_token_ids={int(cfg.im_end_token_id)},
         vocab_size=int(cfg.vocab_size_list[0]),
+        extra_key=f"moss_tts:{uuid.uuid4().hex}",
     )
     req.tokenizer = None
     req._input_embeds_are_projected = True

--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -369,6 +369,7 @@ class Qwen3TTSModelRunner(ModelRunner):
                     device=decode_feedback_embedding.weight.device
                 )
                 combined = self.model.get_input_embeddings()(token_id).reshape(-1)
+            QwenTalkerModelRunner._append_decode_input_history(sched_req.data, combined)
             rows.append(combined)
         with torch.no_grad():
             torch.stack(rows, dim=0, out=decode_feedback_embedding.weight[:batch_size])
@@ -402,10 +403,23 @@ class Qwen3TTSModelRunner(ModelRunner):
             req = data.req
             req_len = int(req.extend_range.length)
             prefix_len = len(req.prefix_indices)
-            prompt_embeds = data.prompt_input_embeds
-            if prompt_embeds is None:
+            if data.prefill_input_embeds is None:
+                data.prefill_input_embeds = data.prompt_input_embeds
+            if data.prefill_input_embeds is None:
                 raise RuntimeError("Qwen3-TTS prefill requires prompt_input_embeds")
-            pieces.append(prompt_embeds[prefix_len : prefix_len + req_len])
+            piece = QwenTalkerModelRunner._projected_prefill_slice(
+                sched_req=sched_req,
+                prefix_len=prefix_len,
+                extend_len=req_len,
+                device=forward_batch.input_ids.device,
+            )
+            if piece is None or int(piece.shape[0]) != req_len:
+                have = 0 if piece is None else int(piece.shape[0])
+                raise RuntimeError(
+                    f"Qwen3-TTS prefill embed mismatch for {req.rid}: "
+                    f"have {have} rows, need {req_len}"
+                )
+            pieces.append(piece)
         return torch.cat(pieces, dim=0).to(
             device=forward_batch.input_ids.device,
             dtype=next(self.model.parameters()).dtype,

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -10,6 +10,7 @@ import json
 import queue
 import threading
 import time
+import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -1199,6 +1200,7 @@ def build_sglang_qwen3_tts_request(
         sampling_params=sampling_params,
         eos_token_ids={int(model.config.codec_eos_token_id)},
         vocab_size=int(model.config.vocab_size),
+        extra_key=f"qwen3_tts:{uuid.uuid4().hex}",
     )
     req.tokenizer = None
     req._input_embeds_are_projected = True
@@ -1223,6 +1225,7 @@ def build_sglang_qwen3_tts_request(
         ref_code=prepared.ref_code,
         ref_code_len=ref_code_len,
         prompt_input_embeds=prepared.prompt_input_embeds,
+        prefill_input_embeds=prepared.prompt_input_embeds,
         semantic_sampling_seed=semantic_sampling_seed,
         subtalker_dosample=bool(gen_kwargs.get("subtalker_dosample", True)),
         subtalker_temperature=float(gen_kwargs.get("subtalker_temperature", 0.9)),

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -1348,6 +1348,7 @@ def _build_moss_sglang_request(*, request_id: str = "req-moss"):
 
 
 def test_moss_request_lifetime_extra_key_is_unique_and_survives_retract() -> None:
+    # note (Richard Wang): same rid can recur so extra_key must differ
     first = _build_moss_sglang_request(request_id="shared-moss-id")
     second = _build_moss_sglang_request(request_id="shared-moss-id")
 
@@ -1365,10 +1366,7 @@ def test_moss_request_lifetime_extra_key_is_unique_and_survives_retract() -> Non
 
 
 def test_moss_lifetime_extra_key_isolates_delay_slot_generated_prefix() -> None:
-    """Generated radix keys are text-channel IDs (rows[:, 0]). Continuing audio
-    frames share delay_slot while RVQ (actual KV) differs, so two same-prompt
-    lifetimes would collide without a per-request extra_key fence.
-    """
+    # note (Richard Wang): text channel keys can match while RVQ differs
     from array import array
 
     from sglang.srt.mem_cache.radix_cache import RadixKey
@@ -1685,6 +1683,7 @@ def test_moss_prefill_forward_uses_prompt_row_embeds() -> None:
 
 
 def _retract_runner(hidden_size: int = 2, decode_embedding=None):
+    # note (Richard Wang): skips __init__ to test _build_prefill_input_embeds
     from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
 
     model = SimpleNamespace(
@@ -1781,7 +1780,7 @@ def test_moss_reprefill_mismatch_does_not_clear_feedback_queue() -> None:
 
 
 def test_moss_reprefill_discards_stranded_feedback() -> None:
-    """Retraction resume must consume the newly sampled frame, not the old queue row."""
+    # note (Richard Wang): resume must consume the new frame, not the stale row
     embedding = torch.nn.Embedding(4, 3)
     runner = _retract_runner(hidden_size=3, decode_embedding=embedding)
     old_feedback = torch.full((3,), 1.0)

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import sys
 import types
+from collections import deque
 from contextlib import nullcontext
 from pathlib import Path
 from types import SimpleNamespace
@@ -53,6 +54,7 @@ def install_fake_sglang(monkeypatch: pytest.MonkeyPatch) -> None:
             sampling_params,
             eos_token_ids=None,
             vocab_size=None,
+            extra_key=None,
             **kwargs,
         ) -> None:
             del kwargs
@@ -62,6 +64,7 @@ def install_fake_sglang(monkeypatch: pytest.MonkeyPatch) -> None:
             self.sampling_params = sampling_params
             self.eos_token_ids = eos_token_ids
             self.vocab_size = vocab_size
+            self.extra_key = extra_key
             self.output_ids = []
             self.prefix_indices = []
             self.extend_range = SimpleNamespace(length=len(origin_input_ids))
@@ -1299,6 +1302,99 @@ def test_moss_preprocess_and_sglang_request_handoff(
     assert data.req.sampling_params.stop_token_ids == [151645]
 
 
+def _moss_delay_model() -> SimpleNamespace:
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            vocab_size_list=[200000, 1025, 1025],
+            im_end_token_id=151645,
+            im_start_token_id=151644,
+            audio_start_token_id=151652,
+            audio_assistant_gen_slot_token_id=151656,
+            audio_assistant_delay_slot_token_id=151662,
+        )
+    )
+
+
+class _ConstantMossProcessor:
+    def build_user_message(self, **kwargs):
+        return {"role": "user", **kwargs}
+
+    def __call__(self, conversations, mode):
+        del conversations, mode
+        return {
+            "input_ids": torch.tensor(
+                [
+                    [
+                        [1, 1024, 1024],
+                        [151644, 1024, 1024],
+                        [198, 1024, 1024],
+                    ]
+                ],
+                dtype=torch.long,
+            )
+        }
+
+
+def _build_moss_sglang_request(*, request_id: str = "req-moss"):
+    payload = make_payload(inputs="hello", request_id=request_id)
+    try:
+        set_moss_tts_preprocessing_context(processor=_ConstantMossProcessor())
+        prepared_payload = preprocess_moss_tts_payload(payload)
+        return build_sglang_moss_tts_request(
+            prepared_payload, model=_moss_delay_model()
+        )
+    finally:
+        clear_moss_tts_preprocessing_context()
+
+
+def test_moss_request_lifetime_extra_key_is_unique_and_survives_retract() -> None:
+    first = _build_moss_sglang_request(request_id="shared-moss-id")
+    second = _build_moss_sglang_request(request_id="shared-moss-id")
+
+    assert first.req.rid == second.req.rid == "shared-moss-id"
+    assert first.req.extra_key
+    assert second.req.extra_key
+    assert first.req.extra_key.startswith("moss_tts:")
+    assert second.req.extra_key.startswith("moss_tts:")
+    assert first.req.extra_key != second.req.extra_key
+    assert list(first.req.origin_input_ids) == list(second.req.origin_input_ids)
+
+    kept = first.req.extra_key
+    first.req.reset_for_retract()
+    assert first.req.extra_key == kept
+
+
+def test_moss_lifetime_extra_key_isolates_delay_slot_generated_prefix() -> None:
+    """Generated radix keys are text-channel IDs (rows[:, 0]). Continuing audio
+    frames share delay_slot while RVQ (actual KV) differs, so two same-prompt
+    lifetimes would collide without a per-request extra_key fence.
+    """
+    from array import array
+
+    from sglang.srt.mem_cache.radix_cache import RadixKey
+
+    delay_slot = int(_moss_delay_model().config.audio_assistant_delay_slot_token_id)
+    row_a = torch.tensor([delay_slot, 11, 22], dtype=torch.long)
+    row_b = torch.tensor([delay_slot, 99, 88], dtype=torch.long)
+    assert int(row_a[0]) == int(row_b[0])
+    assert not torch.equal(row_a[1:], row_b[1:])
+
+    first = _build_moss_sglang_request(request_id="shared-moss-id")
+    second = _build_moss_sglang_request(request_id="shared-moss-id")
+    gen_ids = [delay_slot, delay_slot]
+    fill_a = array("q", list(first.req.origin_input_ids) + gen_ids)
+    fill_b = array("q", list(second.req.origin_input_ids) + gen_ids)
+    assert fill_a == fill_b
+
+    colliding = RadixKey(fill_a, extra_key=None)
+    assert colliding.match(RadixKey(fill_b, extra_key=None)) == len(fill_a)
+
+    with pytest.raises(ValueError, match="matching extra_key"):
+        RadixKey(fill_a, first.req.extra_key).match(
+            RadixKey(fill_b, second.req.extra_key)
+        )
+
+
 def test_moss_delay_runner_samples_audio_and_appends_feedback() -> None:
     from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
 
@@ -1569,6 +1665,7 @@ def test_moss_prefill_forward_uses_prompt_row_embeds() -> None:
                 extend_range=SimpleNamespace(length=2), prefix_indices=[0]
             ),
             prompt_rows=prompt_rows,
+            output_rows=[],
         )
     )
     forward_batch = SimpleNamespace(
@@ -1585,6 +1682,128 @@ def test_moss_prefill_forward_uses_prompt_row_embeds() -> None:
         forward_batch.input_embeds,
         torch.tensor([[4.0, 5.0], [7.0, 8.0]]),
     )
+
+
+def _retract_runner(hidden_size: int = 2, decode_embedding=None):
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+
+    model = SimpleNamespace(
+        dtype=torch.float32,
+        hidden_size=hidden_size,
+        _prepare_multi_modal_inputs=lambda rows: rows.to(torch.float32)[
+            :, :hidden_size
+        ],
+    )
+    if decode_embedding is not None:
+        model._decode_input_embedding = decode_embedding
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    runner.model = model
+    return runner
+
+
+def _retract_sched_req(*, prompt_rows, output_rows, extend_len, feedback_queue):
+    return SimpleNamespace(
+        data=SimpleNamespace(
+            req=SimpleNamespace(
+                rid="a",
+                extend_range=SimpleNamespace(length=extend_len),
+                prefix_indices=[],
+            ),
+            prompt_rows=prompt_rows,
+            output_rows=output_rows,
+            pending_feedback_queue=feedback_queue,
+        )
+    )
+
+
+def test_moss_reprefill_after_retract_concatenates_output_rows() -> None:
+    prompt_rows = torch.tensor(
+        [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+        dtype=torch.long,
+    )
+    generated = [
+        torch.tensor([10, 11, 12], dtype=torch.long),
+        torch.tensor([13, 14, 15], dtype=torch.long),
+    ]
+    sched_req = _retract_sched_req(
+        prompt_rows=prompt_rows,
+        output_rows=generated,
+        extend_len=5,
+        feedback_queue=deque(),
+    )
+    forward_batch = SimpleNamespace(input_ids=torch.zeros(5, dtype=torch.long))
+
+    embeds = _retract_runner()._build_prefill_input_embeds(forward_batch, [sched_req])
+
+    assert torch.equal(
+        embeds,
+        torch.tensor(
+            [
+                [1.0, 2.0],
+                [4.0, 5.0],
+                [7.0, 8.0],
+                [10.0, 11.0],
+                [13.0, 14.0],
+            ]
+        ),
+    )
+
+
+def test_moss_reprefill_without_generated_rows_fails_loudly() -> None:
+    sched_req = _retract_sched_req(
+        prompt_rows=torch.zeros((3, 3), dtype=torch.long),
+        output_rows=[],
+        extend_len=5,
+        feedback_queue=[],
+    )
+    forward_batch = SimpleNamespace(input_ids=torch.zeros(5, dtype=torch.long))
+
+    with pytest.raises(RuntimeError, match="prefill row mismatch"):
+        _retract_runner()._build_prefill_input_embeds(forward_batch, [sched_req])
+
+
+def test_moss_reprefill_mismatch_does_not_clear_feedback_queue() -> None:
+    stranded = torch.full((2,), 7.5)
+    queue = deque([stranded])
+    sched_req = _retract_sched_req(
+        prompt_rows=torch.tensor([[1, 2, 3]], dtype=torch.long),
+        output_rows=[torch.tensor([4, 5, 6], dtype=torch.long)],
+        extend_len=3,
+        feedback_queue=queue,
+    )
+    forward_batch = SimpleNamespace(input_ids=torch.zeros(3, dtype=torch.long))
+
+    with pytest.raises(RuntimeError, match="prefill row mismatch"):
+        _retract_runner()._build_prefill_input_embeds(forward_batch, [sched_req])
+
+    assert len(queue) == 1
+    assert torch.equal(queue[0], stranded)
+
+
+def test_moss_reprefill_discards_stranded_feedback() -> None:
+    """Retraction resume must consume the newly sampled frame, not the old queue row."""
+    embedding = torch.nn.Embedding(4, 3)
+    runner = _retract_runner(hidden_size=3, decode_embedding=embedding)
+    old_feedback = torch.full((3,), 1.0)
+    new_feedback = torch.full((3,), 9.0)
+    sched_req = _retract_sched_req(
+        prompt_rows=torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.long),
+        output_rows=[torch.tensor([7, 8, 9], dtype=torch.long)],
+        extend_len=3,
+        feedback_queue=deque([old_feedback.clone()]),
+    )
+    data = sched_req.data
+    prefill_batch = SimpleNamespace(input_ids=torch.zeros(3, dtype=torch.long))
+
+    runner._build_prefill_input_embeds(prefill_batch, [sched_req])
+    assert list(data.pending_feedback_queue) == []
+
+    data.pending_feedback_queue.append(new_feedback)
+    decode_batch = SimpleNamespace(input_ids=torch.tensor([99], dtype=torch.long))
+    runner._write_decode_input_embedding(decode_batch, [sched_req])
+
+    assert torch.equal(embedding.weight[0].detach(), new_feedback)
+    assert list(data.pending_feedback_queue) == []
 
 
 def test_moss_decode_feedback_uses_row_id_embedding() -> None:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -68,6 +68,7 @@ def install_fake_sglang(monkeypatch: pytest.MonkeyPatch) -> None:
             sampling_params,
             eos_token_ids=None,
             vocab_size=None,
+            extra_key=None,
             **kwargs,
         ) -> None:
             del kwargs
@@ -77,9 +78,14 @@ def install_fake_sglang(monkeypatch: pytest.MonkeyPatch) -> None:
             self.sampling_params = sampling_params
             self.eos_token_ids = eos_token_ids
             self.vocab_size = vocab_size
+            self.extra_key = extra_key
             self.output_ids = []
             self.prefix_indices = []
             self.extend_range = SimpleNamespace(length=len(origin_input_ids))
+
+        def reset_for_retract(self) -> None:
+            self.prefix_indices = []
+            self.extend_range = None
 
     class FakeSamplingParams:
         def __init__(self, **kwargs) -> None:
@@ -2393,6 +2399,7 @@ def test_qwen3_tts_request_data_keeps_decode_tensors_on_prepared_device(
     )
 
     assert data.prompt_input_embeds is prepared.prompt_input_embeds
+    assert data.prefill_input_embeds is prepared.prompt_input_embeds
     assert data.ref_code is prepared.ref_code
     assert data.tts_pad_embed is prepared.tts_pad_embed
     assert data.stream_codec_output is True
@@ -2484,6 +2491,56 @@ def test_qwen3_tts_request_data_uses_public_seed_split(
     assert data.semantic_sampling_seed == expected_semantic_seed
     assert data.subtalker_sampling_seed == expected_subtalker_seed
     assert data.req.sampling_params.sampling_seed == expected_semantic_seed
+
+
+def _stage_qwen3_tts_prepared(payload: StagePayload) -> None:
+    prepared = Qwen3TTSPreparedRequest(
+        state=Qwen3TTSState(),
+        input_ids_list=[11, 12, 13],
+        input_ids=torch.tensor([11, 12, 13], dtype=torch.long),
+        attention_mask=torch.ones((1, 3), dtype=torch.long),
+        trailing_text_hidden=torch.randn(1, 4),
+        ref_code=None,
+        prompt_input_embeds=torch.randn(3, 4),
+        tts_pad_embed=torch.randn(4),
+        gen_kwargs={"max_new_tokens": 16},
+    )
+    payload.data = {
+        qwen3_request_builders._QWEN3_TTS_PREPARED_MARKER: payload.request_id
+    }
+    with qwen3_request_builders._PREPARED_REQUESTS_LOCK:
+        qwen3_request_builders._PREPARED_REQUESTS[payload.request_id] = prepared
+
+
+def _build_qwen3_tts_sglang_request(monkeypatch: pytest.MonkeyPatch):
+    install_fake_sglang(monkeypatch)
+    payload = make_payload(inputs="target")
+    _stage_qwen3_tts_prepared(payload)
+    return build_sglang_qwen3_tts_request(
+        payload,
+        model=SimpleNamespace(
+            config=SimpleNamespace(codec_eos_token_id=42, vocab_size=1200)
+        ),
+        wrapper=object(),
+    )
+
+
+def test_qwen3_tts_request_lifetime_extra_key_is_unique_and_survives_retract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = _build_qwen3_tts_sglang_request(monkeypatch)
+    second = _build_qwen3_tts_sglang_request(monkeypatch)
+
+    assert first.req.rid == second.req.rid
+    assert first.req.extra_key
+    assert second.req.extra_key
+    assert first.req.extra_key.startswith("qwen3_tts:")
+    assert second.req.extra_key.startswith("qwen3_tts:")
+    assert first.req.extra_key != second.req.extra_key
+
+    kept = first.req.extra_key
+    first.req.reset_for_retract()
+    assert first.req.extra_key == kept
 
 
 def test_qwen3_tts_prepared_payload_missing_state_fails_without_rebuild(

--- a/tests/unit_test/qwen3_tts/test_retract_prefill.py
+++ b/tests/unit_test/qwen3_tts/test_retract_prefill.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen3-TTS re-prefill after KV-pressure retraction (#1555)."""
+
+from __future__ import annotations
+
+from collections import deque
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.qwen3_tts.model_runner import Qwen3TTSModelRunner
+
+
+class _TinyModel(torch.nn.Module):
+    def __init__(self, hidden: int = 4) -> None:
+        super().__init__()
+        self.p = torch.nn.Parameter(torch.zeros(hidden))
+
+
+def _runner() -> Qwen3TTSModelRunner:
+    runner = Qwen3TTSModelRunner.__new__(Qwen3TTSModelRunner)
+    runner.model = _TinyModel()
+    return runner
+
+
+def _sched_req(
+    *,
+    prompt: torch.Tensor,
+    extend_len: int,
+    prefix_len: int = 0,
+    history: list[torch.Tensor] | None = None,
+    pending_feedback: list[torch.Tensor] | None = None,
+    pending_text: list[torch.Tensor] | None = None,
+    rid: str = "req",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        data=SimpleNamespace(
+            req=SimpleNamespace(
+                rid=rid,
+                prefix_indices=list(range(prefix_len)),
+                extend_range=SimpleNamespace(length=extend_len),
+            ),
+            prompt_input_embeds=prompt,
+            prefill_input_embeds=prompt,
+            decode_input_embeds=list(history or []),
+            pending_feedback_queue=deque(pending_feedback or []),
+            pending_text_queue=deque(pending_text or []),
+            thinker_chunks_done=True,
+            tts_pad_embed=torch.zeros(prompt.shape[-1], dtype=prompt.dtype),
+        )
+    )
+
+
+def test_write_feedback_buffers_records_decode_input_history() -> None:
+    embedding = torch.nn.Embedding(4, 2)
+    runner = Qwen3TTSModelRunner.__new__(Qwen3TTSModelRunner)
+    runner.model = SimpleNamespace(
+        _decode_feedback_embedding=embedding,
+        get_input_embeddings=lambda: embedding,
+    )
+    sched_req = SimpleNamespace(
+        data=SimpleNamespace(
+            pending_feedback_queue=deque([torch.tensor([1.0, 2.0])]),
+            pending_text_queue=deque([torch.tensor([20.0, 30.0])]),
+            decode_input_embeds=[],
+            thinker_chunks_done=True,
+            tts_pad_embed=torch.zeros(2),
+        )
+    )
+    forward_batch = SimpleNamespace(input_ids=torch.tensor([99], dtype=torch.long))
+
+    runner._write_feedback_buffers(forward_batch, [sched_req])
+
+    assert len(sched_req.data.decode_input_embeds) == 1
+    assert torch.equal(
+        sched_req.data.decode_input_embeds[0],
+        torch.tensor([21.0, 32.0]),
+    )
+    assert torch.equal(embedding.weight[0].detach(), torch.tensor([21.0, 32.0]))
+    assert forward_batch.input_ids.tolist() == [0]
+    assert list(sched_req.data.pending_feedback_queue) == []
+    assert list(sched_req.data.pending_text_queue) == []
+
+
+def test_reprefill_after_retract_replays_prompt_plus_generated() -> None:
+    """Production cadence: G generated tokens, history G-1, one queued row.
+
+    Issue #1555's 594 vs 460 mismatch is G=134 generated tokens on a prompt of
+    460. After initial prefill plus 133 decodes the invariant is G=134, H=133,
+    Q=1; re-prefill drains the leftover queue row.
+    """
+    prompt_len, generated_len, hidden = 460, 134, 4
+    prompt = torch.arange(prompt_len * hidden, dtype=torch.float32).reshape(
+        prompt_len, hidden
+    )
+    history = [
+        torch.full((hidden,), float(1000 + i), dtype=torch.float32)
+        for i in range(generated_len - 1)
+    ]
+    leftover = torch.full((hidden,), 2000.0, dtype=torch.float32)
+    extend_len = prompt_len + generated_len
+    sched_req = _sched_req(
+        prompt=prompt,
+        extend_len=extend_len,
+        history=history,
+        pending_feedback=[leftover],
+    )
+    forward_batch = SimpleNamespace(input_ids=torch.zeros(extend_len, dtype=torch.long))
+
+    out = _runner()._build_prefill_input_embeds(forward_batch, [sched_req])
+
+    assert out.shape[0] == extend_len
+    assert torch.equal(out[:prompt_len], prompt)
+    assert torch.equal(out[prompt_len:-1], torch.stack(history))
+    assert torch.equal(out[-1], leftover)
+    assert list(sched_req.data.pending_feedback_queue) == []
+    assert len(sched_req.data.decode_input_embeds) == generated_len
+
+
+def test_reprefill_replays_prompt_tail_and_generated_tail() -> None:
+    prompt = torch.arange(20, dtype=torch.float32).reshape(10, 2)
+    history = [
+        torch.tensor([100.0, 101.0]),
+        torch.tensor([200.0, 201.0]),
+        torch.tensor([300.0, 301.0]),
+    ]
+    sched_req = _sched_req(prompt=prompt, prefix_len=8, extend_len=5, history=history)
+    forward_batch = SimpleNamespace(input_ids=torch.zeros(5, dtype=torch.long))
+
+    out = _runner()._build_prefill_input_embeds(forward_batch, [sched_req])
+
+    expected = torch.cat([prompt[8:10], torch.stack(history)], dim=0)
+    assert torch.equal(out, expected)
+
+
+def test_reprefill_drains_leftover_feedback_when_history_is_short() -> None:
+    prompt = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+    history = [torch.tensor([10.0, 11.0])]
+    sched_req = _sched_req(
+        prompt=prompt,
+        extend_len=6,
+        history=history,
+        pending_feedback=[torch.tensor([3.0, 4.0])],
+        pending_text=[torch.tensor([30.0, 40.0])],
+    )
+    forward_batch = SimpleNamespace(input_ids=torch.zeros(6, dtype=torch.long))
+
+    out = _runner()._build_prefill_input_embeds(forward_batch, [sched_req])
+
+    expected = torch.cat(
+        [
+            prompt,
+            torch.stack([torch.tensor([10.0, 11.0]), torch.tensor([33.0, 44.0])]),
+        ],
+        dim=0,
+    )
+    assert torch.equal(out, expected)
+    assert len(sched_req.data.decode_input_embeds) == 2
+    assert list(sched_req.data.pending_feedback_queue) == []
+    assert list(sched_req.data.pending_text_queue) == []
+
+
+def test_reprefill_without_generated_history_fails_loudly() -> None:
+    prompt = torch.randn(460, 4)
+    sched_req = _sched_req(prompt=prompt, extend_len=594)
+    forward_batch = SimpleNamespace(input_ids=torch.zeros(594, dtype=torch.long))
+
+    with pytest.raises(RuntimeError, match="missing feedback/text input embeds"):
+        _runner()._build_prefill_input_embeds(forward_batch, [sched_req])
+
+
+def test_decode_then_retract_reprefill_roundtrip() -> None:
+    """N completed decodes leave G=N+1 tokens: history N plus one queued row."""
+    hidden, prompt_len, n_decode = 2, 8, 3
+    prompt = torch.arange(prompt_len * hidden, dtype=torch.float32).reshape(
+        prompt_len, hidden
+    )
+
+    class _Model(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self._decode_feedback_embedding = torch.nn.Embedding(8, hidden)
+            self.embed = torch.nn.Embedding(8, hidden)
+
+        def get_input_embeddings(self):
+            return self.embed
+
+    runner = Qwen3TTSModelRunner.__new__(Qwen3TTSModelRunner)
+    runner.model = _Model()
+    generated = n_decode + 1
+    sched_req = _sched_req(prompt=prompt, extend_len=prompt_len)
+    decode_batch = SimpleNamespace(input_ids=torch.tensor([99], dtype=torch.long))
+    for step in range(n_decode):
+        sched_req.data.pending_feedback_queue.append(
+            torch.full((hidden,), float(step + 1), dtype=torch.float32)
+        )
+        sched_req.data.pending_text_queue.append(torch.zeros(hidden))
+        runner._write_feedback_buffers(decode_batch, [sched_req])
+
+    leftover = torch.full((hidden,), float(generated), dtype=torch.float32)
+    sched_req.data.pending_feedback_queue.append(leftover)
+    sched_req.data.pending_text_queue.append(torch.zeros(hidden))
+    assert len(sched_req.data.decode_input_embeds) == n_decode
+    assert len(sched_req.data.pending_feedback_queue) == 1
+
+    sched_req.data.req.prefix_indices = []
+    sched_req.data.req.extend_range = SimpleNamespace(length=prompt_len + generated)
+    prefill_batch = SimpleNamespace(
+        input_ids=torch.zeros(prompt_len + generated, dtype=torch.long)
+    )
+    out = runner._build_prefill_input_embeds(prefill_batch, [sched_req])
+
+    assert out.shape[0] == prompt_len + generated
+    assert torch.equal(out[:prompt_len], prompt)
+    assert torch.equal(
+        out[prompt_len:-1],
+        torch.stack([torch.full((hidden,), float(i + 1)) for i in range(n_decode)]),
+    )
+    assert torch.equal(out[-1], leftover)
+    assert list(sched_req.data.pending_feedback_queue) == []
+    assert len(sched_req.data.decode_input_embeds) == generated
+
+
+def test_fresh_prefill_still_uses_prompt_only_buffer() -> None:
+    prompt = torch.arange(12, dtype=torch.float32).reshape(6, 2)
+    sched_req = _sched_req(prompt=prompt, prefix_len=1, extend_len=4)
+    forward_batch = SimpleNamespace(input_ids=torch.zeros(4, dtype=torch.long))
+
+    out = _runner()._build_prefill_input_embeds(forward_batch, [sched_req])
+
+    assert torch.equal(out, prompt[1:5])

--- a/tests/unit_test/qwen3_tts/test_retract_prefill.py
+++ b/tests/unit_test/qwen3_tts/test_retract_prefill.py
@@ -84,12 +84,7 @@ def test_write_feedback_buffers_records_decode_input_history() -> None:
 
 
 def test_reprefill_after_retract_replays_prompt_plus_generated() -> None:
-    """Production cadence: G generated tokens, history G-1, one queued row.
-
-    Issue #1555's 594 vs 460 mismatch is G=134 generated tokens on a prompt of
-    460. After initial prefill plus 133 decodes the invariant is G=134, H=133,
-    Q=1; re-prefill drains the leftover queue row.
-    """
+    # note (Richard Wang): 460 plus 134 is the #1555 594 vs 460 mismatch
     prompt_len, generated_len, hidden = 460, 134, 4
     prompt = torch.arange(prompt_len * hidden, dtype=torch.float32).reshape(
         prompt_len, hidden


### PR DESCRIPTION
## Motivation

After KV-pressure retraction, the scheduler re-prefills the prompt plus already-generated tokens. Qwen3-TTS and delay Moss previously sliced prompt-only projected buffers, so the runners could provide fewer embedding rows than the scheduler's extend length and KV allocation.

Reconstructed generated tails also need radix isolation. Both runners publish scalar scheduler IDs that do not fully identify the audio-conditioned embeddings written to KV.

## Modifications

- Rebuild Qwen3-TTS re-prefill inputs from the prompt plus recorded decode-input history, including the final queued feedback row.
- Rebuild delay-Moss inputs from `prompt_rows + output_rows` and clear feedback stranded by retraction after validating the reconstructed row count.
- Give every Qwen3-TTS and delay-Moss request lifetime a unique radix `extra_key`.
- Add focused Qwen cadence, Moss feedback-lifecycle, failure-ordering, and radix-isolation regressions.

## Related Issues

Addresses part of https://github.com/sgl-project/sglang-omni/issues/1555. Zonos2 retraction recovery remains out of scope, so this PR does not close that issue.

## Accuracy Test

```bash
pytest -q -rs tests/unit_test/moss_tts tests/unit_test/qwen3_tts
```

Result: `349 passed, 2 skipped`. Both skips require unavailable `flash_attn_varlen_func` and are unrelated to this change.

The regressions cover the observed Qwen `594`-vs-`460` mismatch, production feedback cadence, Moss reconstruction and stale-feedback lifecycle, row-mismatch failure ordering, and request-lifetime radix isolation. No model weights, logits, or sampling math change.

## Benchmark & Profiling

No benchmark was run. The request-lifetime `extra_key` disables cross-request radix-prefix sharing for Qwen3-TTS and delay Moss, while preserving same-request cache reuse across retractions. That is the conservative correctness fence. Content-addressed generated keys can recover safe cross-request sharing in a follow-up.