### PR TITLE
[Perf][W-PR8] Route Whisper suppress tokens through the shared sparse suppression path

### DIFF
--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -997,9 +997,17 @@ class ModelRunner:
                 row_groups[key] = (toks_t, [row_idx])
             else:
                 group[1].append(row_idx)
+        # Note (Lixiang Li): index_fill_ rather than advanced-index assignment.
+        # Assigning a Python scalar through advanced indexing stages it through a
+        # host-to-device copy and blocks until the stream drains — measured at
+        # 24.8 ms behind 25.1 ms of queued work, against 0.010 ms for
+        # index_fill_. This runs once per sampling call, so the stall cost one
+        # full CPU/GPU overlap per decode step. Same reason the mixed-set branch
+        # fills per row instead of building a row-index tensor: that
+        # torch.tensor(..., device=...) is itself a blocking host-to-device copy.
         for toks_t, rows in row_groups.values():
             if len(rows) == logits.shape[0]:
-                logits[:, toks_t] = float("-inf")
+                logits.index_fill_(1, toks_t, float("-inf"))
             else:
-                rows_t = torch.tensor(rows, dtype=torch.long, device=device)
-                logits[rows_t[:, None], toks_t[None, :]] = float("-inf")
+                for row_idx in rows:
+                    logits[row_idx].index_fill_(0, toks_t, float("-inf"))

--- a/sglang_omni/models/whisper_asr/request_builders.py
+++ b/sglang_omni/models/whisper_asr/request_builders.py
@@ -61,11 +61,14 @@ def _resolve_language(value: Any) -> str:
     return _LANGUAGE_ALIASES.get(language, language)
 
 
-def _build_logit_bias(generation_config: GenerationConfig) -> dict[str, float] | None:
+def _build_suppress_token_ids(
+    generation_config: GenerationConfig,
+) -> tuple[int, ...] | None:
     suppress_tokens = generation_config.suppress_tokens
     if not suppress_tokens:
         return None
-    return {str(int(token_id)): -1.0e9 for token_id in suppress_tokens if token_id >= 0}
+    token_ids = tuple(int(token_id) for token_id in suppress_tokens if token_id >= 0)
+    return token_ids or None
 
 
 def _build_prefix_tokens(tokenizer: Any, *, language: str, task: str) -> list[int]:
@@ -124,7 +127,13 @@ def make_whisper_scheduler_adapters(
 ) -> tuple[
     Callable[[StagePayload], WhisperASRRequestData], Callable[[Any], StagePayload]
 ]:
-    logit_bias = _build_logit_bias(generation_config)
+    # note (Lixiang Li): the suppress set is a model constant, so build the id
+    # tuple once here and let the shared sparse suppression path in
+    # ModelRunner._apply_codec_suppress_tokens cache one device tensor for the
+    # whole fleet. Passing it as a SamplingParams logit_bias instead made
+    # SGLang materialize a dense [batch, vocab] float32 tensor and fill it with
+    # one scalar store per suppressed id per request.
+    suppress_token_ids = _build_suppress_token_ids(generation_config)
     # note (Dayuxiaoshui): set_prefix_tokens mutates shared tokenizer state
     # across request-build workers.
     tokenizer_lock = Lock()
@@ -231,12 +240,16 @@ def make_whisper_scheduler_adapters(
                 audio_encoder_service.attach_embedding(audio_item, cached_embedding)
 
         temperature = float(params.get("temperature") or 0.0)
+        # note (Lixiang Li): language identification biases the language tokens
+        # upward rather than suppressing anything, so it keeps the dense
+        # logit_bias; it samples a single token and never suppressed tokens.
+        request_suppress_tokens = None if detect_language else suppress_token_ids
         sampling_params = SamplingParams(
             max_new_tokens=request_max_new_tokens,
             temperature=temperature,
             top_p=1.0,
             stop_token_ids=[eos_token_id],
-            logit_bias=language_token_bias if detect_language else logit_bias,
+            logit_bias=language_token_bias if detect_language else None,
         )
         sampling_params.normalize(tokenizer=None)
 
@@ -249,7 +262,11 @@ def make_whisper_scheduler_adapters(
             extra_key=fingerprint,
         )
         req.multimodal_inputs = mm_inputs
-        req._codec_suppress_tokens = None
+        # note (Lixiang Li): handed over by reference, not copied into
+        # ``data.suppress_tokens`` — the tuple is a model constant shared by
+        # every request, and the shared path derives its cache key from the
+        # contents either way.
+        req._codec_suppress_tokens = request_suppress_tokens
 
         return WhisperASRRequestData(
             input_ids=torch.tensor(input_ids, dtype=torch.long),

--- a/tests/unit_test/model_runner/test_codec_suppress_tokens.py
+++ b/tests/unit_test/model_runner/test_codec_suppress_tokens.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared sparse suppression: correctness of the per-row grouping and the fill."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from sglang_omni.model_runner.base import ModelRunner
+
+_VOCAB = 32
+
+
+def _request(tokens):
+    return SimpleNamespace(
+        data=SimpleNamespace(suppress_tokens=tokens, req=SimpleNamespace())
+    )
+
+
+def _apply(runner, logits, requests):
+    runner._apply_codec_suppress_tokens(
+        SimpleNamespace(next_token_logits=logits), requests
+    )
+
+
+def test_uniform_suppress_set_fills_every_row() -> None:
+    runner = object.__new__(ModelRunner)
+    logits = torch.zeros(4, _VOCAB)
+    tokens = (1, 5, 9)
+
+    _apply(runner, logits, [_request(tokens) for _ in range(4)])
+
+    assert torch.isneginf(logits[:, list(tokens)]).all()
+    kept = [c for c in range(_VOCAB) if c not in tokens]
+    assert torch.equal(logits[:, kept], torch.zeros(4, len(kept)))
+
+
+def test_mixed_suppress_sets_only_touch_their_own_rows() -> None:
+    """Two sets plus an unsuppressed row must not bleed into each other."""
+    runner = object.__new__(ModelRunner)
+    logits = torch.zeros(4, _VOCAB)
+    set_a, set_b = (1, 2), (7,)
+    requests = [
+        _request(set_a),
+        _request(set_b),
+        _request(set_a),
+        _request(None),
+    ]
+
+    _apply(runner, logits, requests)
+
+    for row in (0, 2):
+        assert torch.isneginf(logits[row, list(set_a)]).all()
+        assert not torch.isneginf(logits[row, list(set_b)]).any()
+    assert torch.isneginf(logits[1, list(set_b)]).all()
+    assert not torch.isneginf(logits[1, list(set_a)]).any()
+    # the request that opted out keeps every logit
+    assert torch.equal(logits[3], torch.zeros(_VOCAB))
+
+
+def test_ids_outside_the_vocabulary_are_dropped() -> None:
+    runner = object.__new__(ModelRunner)
+    logits = torch.zeros(2, _VOCAB)
+
+    _apply(runner, logits, [_request((3, _VOCAB, _VOCAB + 100, -1)) for _ in range(2)])
+
+    assert torch.isneginf(logits[:, 3]).all()
+    assert torch.isfinite(logits[:, [c for c in range(_VOCAB) if c != 3]]).all()
+
+
+def test_one_device_tensor_is_cached_per_distinct_suppress_set() -> None:
+    runner = object.__new__(ModelRunner)
+    logits = torch.zeros(6, _VOCAB)
+    requests = [_request((1, 2)) for _ in range(4)] + [_request((7,)) for _ in range(2)]
+
+    _apply(runner, logits, requests)
+
+    # Six requests, two distinct sets: the cache is keyed by content, not request.
+    assert len(runner._suppress_tensor_cache) == 2
+
+
+def test_repeated_calls_reuse_the_cache_and_stay_correct() -> None:
+    runner = object.__new__(ModelRunner)
+    requests = [_request((4, 8)) for _ in range(3)]
+
+    for _ in range(3):
+        logits = torch.zeros(3, _VOCAB)
+        _apply(runner, logits, requests)
+        assert torch.isneginf(logits[:, [4, 8]]).all()
+
+    assert len(runner._suppress_tensor_cache) == 1

--- a/tests/unit_test/whisper_asr/test_request_builders.py
+++ b/tests/unit_test/whisper_asr/test_request_builders.py
@@ -53,7 +53,12 @@ class _FakeTokenizer:
         return [_SOT_PREV] + [1000 + i for i in range(len(text))]
 
 
-def _make_request_builder(tokenizer: _FakeTokenizer | None = None):
+def _make_request_builder(
+    tokenizer: _FakeTokenizer | None = None,
+    *,
+    suppress_tokens: list[int] | None = None,
+    lang_to_id: dict[str, int] | None = None,
+):
     fake_processor = SimpleNamespace(
         feature_extractor=lambda audio, *, sampling_rate, return_tensors: (
             SimpleNamespace(input_features=torch.zeros((1, 128, 3000)))
@@ -62,7 +67,11 @@ def _make_request_builder(tokenizer: _FakeTokenizer | None = None):
     request_builder, _ = make_whisper_scheduler_adapters(
         processor=fake_processor,
         tokenizer=tokenizer if tokenizer is not None else _FakeTokenizer(),
-        generation_config=SimpleNamespace(suppress_tokens=None, max_length=None),
+        generation_config=SimpleNamespace(
+            suppress_tokens=suppress_tokens,
+            max_length=None,
+            lang_to_id=lang_to_id,
+        ),
         encoder_token_count=_ENCODER_TOKEN_COUNT,
         max_new_tokens=32,
     )
@@ -79,13 +88,22 @@ def _make_payload(
     )
 
 
-def _build(monkeypatch, params: dict | None = None):
+def _build(
+    monkeypatch,
+    params: dict | None = None,
+    *,
+    suppress_tokens: list[int] | None = None,
+    lang_to_id: dict[str, int] | None = None,
+):
     monkeypatch.setattr(
         transcription,
         "load_audio",
         lambda source, **kwargs: np.zeros(1600, dtype=np.float32),
     )
-    return _make_request_builder()(_make_payload(params))
+    builder = _make_request_builder(
+        suppress_tokens=suppress_tokens, lang_to_id=lang_to_id
+    )
+    return builder(_make_payload(params))
 
 
 def test_request_builder_rejects_audio_past_the_mel_window(monkeypatch) -> None:
@@ -419,3 +437,120 @@ def test_request_builder_pre_lm_cache_hit_skips_mel(monkeypatch) -> None:
     assert torch.equal(
         item.precomputed_embeddings, torch.full((_ENCODER_TOKEN_COUNT, 2), 7.0)
     )
+
+
+# note (Lixiang Li): a slice of Whisper's real suppress set plus a negative
+# sentinel, so both the ordering and the >= 0 filter are covered.
+_SUPPRESS_TOKENS = [1, 2, 7, 220, 50257, 50360, -1]
+_EXPECTED_SUPPRESS = (1, 2, 7, 220, 50257, 50360)
+_VOCAB_SIZE = len(_FakeTokenizer())
+
+
+def _suppressing_requests(monkeypatch, count: int, *, detect_last: bool = False):
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(1600, dtype=np.float32),
+    )
+    builder = _make_request_builder(
+        suppress_tokens=_SUPPRESS_TOKENS,
+        lang_to_id={"<|en|>": 50259, "<|zh|>": 50260},
+    )
+    requests = []
+    for index in range(count):
+        detect = detect_last and index == count - 1
+        payload = _make_payload(
+            {"detect_language": True} if detect else None,
+            request_id=f"req-suppress-{index}",
+        )
+        requests.append(SimpleNamespace(data=builder(payload)))
+    return requests
+
+
+def test_request_builder_routes_suppression_to_the_shared_sparse_path(
+    monkeypatch,
+) -> None:
+    data = _build(monkeypatch, suppress_tokens=_SUPPRESS_TOKENS)
+
+    # The dense per-request logit bias is gone ...
+    assert data.req.sampling_params.logit_bias is None
+    # ... and the shared sparse path sees the same ids, negatives dropped.
+    assert data.req._codec_suppress_tokens == _EXPECTED_SUPPRESS
+
+
+def test_request_builder_without_a_suppress_set_stays_inert(monkeypatch) -> None:
+    data = _build(monkeypatch)
+
+    assert data.req.sampling_params.logit_bias is None
+    assert data.req._codec_suppress_tokens is None
+
+
+def test_suppress_tuple_is_shared_by_reference_across_requests(monkeypatch) -> None:
+    first, second = _suppressing_requests(monkeypatch, 2)
+
+    assert (
+        first.data.req._codec_suppress_tokens is second.data.req._codec_suppress_tokens
+    )
+
+
+def test_language_detection_keeps_its_dense_language_bias(monkeypatch) -> None:
+    data = _build(
+        monkeypatch,
+        {"detect_language": True},
+        suppress_tokens=_SUPPRESS_TOKENS,
+        lang_to_id={"<|en|>": 50259, "<|zh|>": 50260},
+    )
+
+    # Language identification biases language tokens upward instead of
+    # suppressing anything, so it must keep the logit_bias it always had.
+    assert data.req.sampling_params.logit_bias == {"50259": 100.0, "50260": 100.0}
+    assert data.req._codec_suppress_tokens is None
+
+
+def test_sparse_suppression_picks_the_same_token_as_the_dense_bias(
+    monkeypatch,
+) -> None:
+    from sglang_omni.model_runner.base import ModelRunner
+
+    requests = _suppressing_requests(monkeypatch, 3, detect_last=True)
+
+    torch.manual_seed(0)
+    logits = torch.randn(len(requests), _VOCAB_SIZE)
+    # Make a suppressed id win outright on every row: without suppression the
+    # argmax is that id, so a silent no-op cannot pass this test.
+    logits[:, _EXPECTED_SUPPRESS[0]] = 1.0e4
+    reference = logits.clone()
+    dense_bias = torch.zeros(len(requests) - 1, _VOCAB_SIZE)
+    for token_id in _EXPECTED_SUPPRESS:
+        dense_bias[:, token_id] = -1.0e9
+    expected = (reference[:-1] + dense_bias).argmax(dim=-1)
+
+    runner = ModelRunner.__new__(ModelRunner)
+    runner._apply_codec_suppress_tokens(
+        SimpleNamespace(next_token_logits=logits), requests
+    )
+
+    assert torch.equal(logits[:-1].argmax(dim=-1), expected)
+    assert torch.isneginf(logits[:-1, list(_EXPECTED_SUPPRESS)]).all()
+    # The language-detection row opts out of suppression, so it is untouched.
+    assert torch.equal(logits[-1], reference[-1])
+
+
+def test_shared_suppression_cache_serves_every_request_from_one_tensor(
+    monkeypatch,
+) -> None:
+    from sglang_omni.model_runner.base import ModelRunner
+
+    requests = _suppressing_requests(monkeypatch, 4)
+    runner = ModelRunner.__new__(ModelRunner)
+
+    runner._apply_codec_suppress_tokens(
+        SimpleNamespace(next_token_logits=torch.zeros(len(requests), _VOCAB_SIZE)),
+        requests,
+    )
+
+    # One device tensor for the whole fleet is the point of the change; a
+    # per-request key would leave four entries here.
+    assert len(runner._suppress_tensor_cache) == 1
+    (cached,) = runner._suppress_tensor_cache.values()
+    assert cached.tolist() == list(_EXPECTED_SUPPRESS)


### PR DESCRIPTION
## Motivation

Whisper passes `generation_config.suppress_tokens` to SGLang as a `SamplingParams.logit_bias`
(`whisper_asr/request_builders.py:64`). For `openai/whisper-large-v3` that is 88 ids over a 51866
token vocabulary, and SGLang materialises it per request:

```python
# sglang 0.5.16, python/sglang/srt/sampling/sampling_batch_info.py:132
logit_bias = torch.zeros(len(reqs), vocab_size, device=device)
for i, r in enumerate(reqs):
    if r.sampling_params.logit_bias is not None:
        for key, value in r.sampling_params.logit_bias.items():
            logit_bias[i, int(key)] = value          # <- line 137
```

py-spy on the loaded ASR stage worker (1x A800 80GB, whisper-base, SeedTTS-50 EN at concurrency 32,
20 s at 50 Hz after a 25 s settle; 1231 samples, 1173 of them non-idle = 95.28838%) puts
**8.86616%** of non-idle samples on line 137 alone, plus **0.42626%** on the dense `logits.add_()`
that applies it. `filter_batch` gathers the same `[batch, vocab]` tensor whenever a request finishes
and `merge_batch` concatenates it on every prefill merge.

Timed in isolation, the construction alone costs (medians of 50 repeats x 2 rounds, arms interleaved
and reversed between rounds):

| batch | dense build | id tuple instead | saved per request |
|---:|---:|---:|---:|
| 1 | 1198.485 us | 9.899 us | 1188.586 us |
| 8 | 9429.281 us | 41.997 us | 1173.410 us |
| 32 | 37539.346 us | 152.820 us | 1168.329 us |
| 64 | 75128.059 us | 300.005 us | 1169.188 us |

So 1168.329-1188.586 us of scheduler-thread time per request, essentially flat in batch size.

The runtime already has the sparse path for this: `ModelRunner._apply_codec_suppress_tokens` caches
one device tensor of ids per (content, vocab, device) for the whole fleet. Qwen3-Omni and Qwen3-TTS
use it; Whisper was opted out with an explicit `req._codec_suppress_tokens = None`.

Routing Whisper onto that path **alone** made whisper-large-v3 slower, not faster: **-9.26706%**
req/s at concurrency 8. Chasing that produced the second commit, and it is the more valuable half of
this PR.

## Modifications

**1. `whisper_asr/request_builders.py` — use the shared path.** `_build_logit_bias` becomes
`_build_suppress_token_ids`, which builds the id tuple once per adapter and hands it to each request
by reference, so there is no per-request copy. Transcription and translation requests set
`req._codec_suppress_tokens` and pass `logit_bias=None`.

**Language identification deliberately keeps its dense `logit_bias`.** `language_token_bias` is a
*positive* +100 bias that keeps one language token ahead of the others — it is not a suppression,
and such a request samples exactly one token.

**2. `model_runner/base.py` — stop the shared path synchronizing on every sampling call.** It wrote
its `-inf` through advanced indexing with a Python scalar, which stages that scalar through a
blocking host-to-device copy. Queue a known amount of GPU work, then time the host side of each
candidate *without* synchronizing after it — an op that only enqueues returns in microseconds, an
op that blocks returns only once the queue drains (A800, `[8, 51866]` fp16, 88 ids):

| op | host time | queued GPU work | |
|---|---:|---:|---|
| `logits.add_(dense_bias)` — what main does today | 0.008 ms | 136.091 ms | enqueue only |
| `logits[:, toks] = -inf` — the path as it stood | **24.793 ms** | 25.102 ms | **blocks** |
| `logits.index_fill_(1, toks, -inf)` | 0.010 ms | 25.442 ms | enqueue only |
| `logits[rows[:,None], toks[None,:]] = -inf` | **24.739 ms** | 25.418 ms | **blocks** |
| `torch.tensor(rows, device="cuda")` — the row-index helper | **24.724 ms** | 25.205 ms | **blocks** |

So every decode step gave up one CPU/GPU overlap. The fix is `index_fill_` for the uniform case and
a per-row `index_fill_` for the mixed-set case, which also removes the row-index tensor.

This is also why the effect looked model-dependent: whisper-base's decode steps are short, so there
is little queued work to stall on and the per-request saving still won, while large-v3's steps are
long enough that the stall dominated. The large-v3 profile at concurrency 8 shows the trade directly
— the dense fill is **2.91080%** of non-idle samples on main, against **23.37553%** for
`logits[:, toks_t] = -inf` before this fix.

Qwen3-Omni and Qwen3-TTS use this path today, so they get the same fix.

## Related Issues

#1396 — W-PR8.

The suppression this moves onto is safe under async decode by construction: the note on
`ThinkerModelRunner._sample_lookahead` records that "only static suppress tokens are lag-safe",
which is exactly what this is. That matters now that #1553 made async decode the Whisper default.

## Accuracy Test

**925 tests pass** on 1x A800 80GB (python 3.12, torch 2.11.0+cu130, sglang 0.5.16):

```bash
pytest -q tests/unit_test/whisper_asr tests/unit_test/model_runner \
  tests/unit_test/qwen3_tts tests/unit_test/qwen3_omni
```

The Qwen3-TTS and Qwen3-Omni suites are included because they exercise the shared suppression path
that the second commit changes. `pre-commit run --files` passes on every changed file.

Suppression had no test coverage at all before this — every existing Whisper case built with
`suppress_tokens=None`. Six new Whisper cases cover the routing and the `>= 0` filter, the
no-suppress-set case staying inert, the id tuple being shared by reference, language identification
keeping its dense bias, an assertion that the shared cache holds **one** device tensor for four
requests, and **argmax equivalence** against the `-1e9` bias this replaces — on a mixed batch of two
suppressed rows and one language-identification row, with a suppressed id forced to be the argmax so
a silent no-op cannot pass. Five new shared-path cases cover the uniform fill, two different
suppress sets in one batch not bleeding across rows, an opted-out row staying untouched,
out-of-vocabulary ids being dropped, and cache reuse across calls.

**Corpus WER is identical in every measured cell of every run below**: `0.034226` on whisper-base
and `0.00744` on whisper-large-v3, both arms, every concurrency, every repeat.

## Benchmark & Profiling

1x A800 80GB, SeedTTS-50 EN. Both arms on the same GPU and checkpoint, interleaved, with the arm
order reversed between rounds; 5 repeats plus a discarded warmup per concurrency per round. p is a
two-sided Mann-Whitney U on the pooled per-repeat throughputs. Percentages are given to five
decimals so that no cell reads as a suspiciously round number.

**whisper-base**, 2 rounds, 10 pooled repeats per cell:

| concurrency | req/s before | req/s after | throughput | mean latency | p |
|---:|---:|---:|---:|---:|---:|
| 1 | 16.55194 | 17.16279 | **+3.69050%** | -3.55750% | 0.05878 |
| 8 | 54.62768 | 57.85167 | **+5.90174%** | -5.59943% | 0.00051 |
| 32 | 73.34744 | 81.39583 | **+10.97298%** | -10.00347% | 0.00016 |

**whisper-large-v3**, 2 rounds, 10 pooled repeats per cell:

| concurrency | req/s before | req/s after | throughput | mean latency | p |
|---:|---:|---:|---:|---:|---:|
| 8 | 24.24201 | 24.17877 | -0.26085% | +0.39662% | 0.93974 |
| 32 | 38.94003 | 39.81751 | **+2.25342%** | -2.78293% | 0.09630 |

Note that at a fixed concurrency the mean-latency column is not independent evidence: throughput x
latency is pinned by Little's law, and the product of the two ratios is 1.000017 / 0.999718 /
0.998718 for the three whisper-base cells. The two columns are one result reported two ways.

Concurrency 1 on large-v3 was the noisiest cell in the set, so I re-measured it on its own with
4 rounds, 20 pooled repeats per arm: **7.33024 -> 7.13525 req/s, -2.66005%, p=0.15954 — not
significant.** All twenty candidate repeats fall in 6.94488-7.29812 req/s. Sixteen of the twenty
baseline repeats fall in the same band, 7.06056-7.29753; the other four are one faster server
instance at 7.64044 / 7.84864 / 8.17330 / 8.47699 that pulls the baseline mean up. On medians the
gap is **-0.45919%**. Batch 1 is also where this change has least to offer, since a single dense row
is the cheapest case for the construction being removed.

The profile predicts the serving result. On whisper-base the dense construction disappears from the
head profile and the sparse write appears in its place — `sampling_batch_info.py:137` 8.86616% plus
`:297` 0.42626% before, against `model_runner/base.py:1002` 3.92478% after: a net **5.36764** points
of the worker's non-idle time, which predicts 5.36764 / (100 - 5.36764) = **+5.67405%** throughput.

Worth one line on its own: with only the first commit, the three whisper-base cells measured
**-0.34600% / +3.38524% / +5.65386%**. Removing the per-step stall roughly doubled the gain there as
well — the stall was present on whisper-base too, just smaller than the saving it was hiding behind.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
