### PR TITLE
[Comm] Trace the paged KV transfer path, transport selection, and stream reads

### DIFF
--- a/sglang_omni/comm/engine.py
+++ b/sglang_omni/comm/engine.py
@@ -344,7 +344,7 @@ class CommEngine:
             "comm_stream_read",
             object_id=data_ref.object_id,
             transport=data_ref.transport.value,
-            bytes=data.nbytes,
+            bytes=data_ref.buffer.length,
             elapsed_ms=round(_comm_elapsed_ms(read_start), 6),
         )
         return data, metadata
@@ -446,6 +446,7 @@ class CommEngine:
                 source_pool_id=source_pool_id,
                 source_page_indices=source_page_indices,
                 destination_ref=ready.destination_ref,
+                transfer_id=transfer_id,
             )
             data_ref = DataRef(
                 version=1,
@@ -678,6 +679,7 @@ class CommEngine:
                 source_page_indices=state.request.source_page_indices,
                 destination_page_indices=state.destination.page_indices,
                 request_id=request_id,
+                transfer_id=data_ref.object_id,
             )
             await op.wait_for_completion(timeout=self._ack_timeout_s)
             if state.abort_error is not None:
@@ -690,19 +692,7 @@ class CommEngine:
                 num_pages=len(state.destination.page_indices),
                 elapsed_ms=round(_comm_elapsed_ms(read_start), 6),
             )
-        except asyncio.CancelledError as exc:
-            _comm_trace(
-                "comm_kv_read_failed",
-                transfer_id=data_ref.object_id,
-                request_id=request_id,
-                error=type(exc).__name__,
-                detail=exc,
-                elapsed_ms=round(_comm_elapsed_ms(read_start), 6),
-            )
-            with suppress(Exception):
-                state.receiver.abort(state.request, state.destination, exc)
-            raise
-        except Exception as exc:
+        except (asyncio.CancelledError, Exception) as exc:
             _comm_trace(
                 "comm_kv_read_failed",
                 transfer_id=data_ref.object_id,

--- a/sglang_omni/comm/engine.py
+++ b/sglang_omni/comm/engine.py
@@ -336,9 +336,18 @@ class CommEngine:
         relay: Relay,
         data_ref: DataRef,
     ) -> tuple[torch.Tensor, dict[str, Any] | None]:
-        return await stage_io.read_stream_chunk(
+        read_start = _comm_now_ns()
+        data, metadata = await stage_io.read_stream_chunk(
             relay, data_ref, self.local_payload_device
         )
+        _comm_trace(
+            "comm_stream_read",
+            object_id=data_ref.object_id,
+            transport=data_ref.transport.value,
+            bytes=data.nbytes,
+            elapsed_ms=round(_comm_elapsed_ms(read_start), 6),
+        )
+        return data, metadata
 
     def register_kv_pool(self, pool: KVPool) -> None:
         self._kv_pools[pool.pool_id] = pool
@@ -946,6 +955,7 @@ class CommEngine:
                 to_stage=job.target_stage,
                 chunk_id=job.chunk_id,
                 transport=job.transport.value,
+                bytes=job.data.nbytes,
                 queue_key=queue_key,
                 queue_wait_ms=round((send_start - job.enqueued_ns) / 1_000_000.0, 6),
                 write_ms=round(write_ms, 6),

--- a/sglang_omni/comm/engine.py
+++ b/sglang_omni/comm/engine.py
@@ -363,6 +363,20 @@ class CommEngine:
         transfer_id = transfer_id or (
             f"{request_id}:kv_pages:{from_stage}:{to_stage}:{uuid4().hex}"
         )
+        num_pages = len(source_page_indices)
+        send_start = _comm_now_ns()
+        _comm_trace(
+            "comm_kv_send_start",
+            request_id=request_id,
+            transfer_id=transfer_id,
+            from_stage=from_stage,
+            to_stage=to_stage,
+            source_pool_id=source_pool_id,
+            target_pool_id=target_pool_id,
+            num_pages=num_pages,
+            tp_rank=self.tp_rank,
+            tp_size=self.tp_size,
+        )
         try:
             pool = self._kv_pools.get(source_pool_id)
             if pool is None:
@@ -388,6 +402,7 @@ class CommEngine:
             relay.register_kv_pool(pool)
 
             ready_future = asyncio.get_running_loop().create_future()
+            prepare_start = _comm_now_ns()
             self._kv_ready[transfer_id] = ready_future
             self._outbound_kv_requests[transfer_id] = request_id
             await send_to_endpoint(
@@ -408,6 +423,13 @@ class CommEngine:
             ready = await asyncio.wait_for(
                 ready_future,
                 timeout=self._ack_timeout_s,
+            )
+            _comm_trace(
+                "comm_kv_ready",
+                transfer_id=transfer_id,
+                success=ready.success,
+                error=ready.error,
+                wait_ms=round(_comm_elapsed_ms(prepare_start), 6),
             )
             if not ready.success:
                 raise RuntimeError(ready.error)
@@ -452,7 +474,24 @@ class CommEngine:
                 raise
             pending_task = self._arm_pending(data_ref.object_id)
             await asyncio.shield(pending_task)
+            _comm_trace(
+                "comm_kv_transfer_complete",
+                transfer_id=transfer_id,
+                num_pages=num_pages,
+                bytes=op.metadata.get("transfer_info", {}).get("size", -1),
+                elapsed_ms=round(_comm_elapsed_ms(send_start), 6),
+            )
             return data_ref
+        except BaseException as exc:
+            _comm_trace(
+                "comm_kv_transfer_failed",
+                transfer_id=transfer_id,
+                num_pages=num_pages,
+                error=type(exc).__name__,
+                detail=exc,
+                elapsed_ms=round(_comm_elapsed_ms(send_start), 6),
+            )
+            raise
         finally:
             self._kv_ready.pop(transfer_id, None)
             self._outbound_kv_requests.pop(transfer_id, None)
@@ -581,6 +620,15 @@ class CommEngine:
                 receiver=receiver,
                 destination=destination,
             )
+            _comm_trace(
+                "comm_kv_prepare_ready",
+                request_id=message.request_id,
+                transfer_id=message.transfer_id,
+                from_stage=message.from_stage,
+                to_stage=message.to_stage,
+                destination_pool_id=destination.pool_id,
+                num_pages=len(destination.page_indices),
+            )
             return KVTransferReadyMessage(
                 request_id=message.request_id,
                 transfer_id=message.transfer_id,
@@ -612,6 +660,7 @@ class CommEngine:
         if state is None:
             raise KeyError(f"unknown inbound KV transfer {data_ref.object_id!r}")
 
+        read_start = _comm_now_ns()
         try:
             state.copy_started = True
             op = await relay.get_kv_pages(
@@ -625,11 +674,34 @@ class CommEngine:
             if state.abort_error is not None:
                 raise state.abort_error
             state.receiver.commit(state.request, state.destination)
+            _comm_trace(
+                "comm_kv_read_complete",
+                transfer_id=data_ref.object_id,
+                request_id=request_id,
+                num_pages=len(state.destination.page_indices),
+                elapsed_ms=round(_comm_elapsed_ms(read_start), 6),
+            )
         except asyncio.CancelledError as exc:
+            _comm_trace(
+                "comm_kv_read_failed",
+                transfer_id=data_ref.object_id,
+                request_id=request_id,
+                error=type(exc).__name__,
+                detail=exc,
+                elapsed_ms=round(_comm_elapsed_ms(read_start), 6),
+            )
             with suppress(Exception):
                 state.receiver.abort(state.request, state.destination, exc)
             raise
         except Exception as exc:
+            _comm_trace(
+                "comm_kv_read_failed",
+                transfer_id=data_ref.object_id,
+                request_id=request_id,
+                error=type(exc).__name__,
+                detail=exc,
+                elapsed_ms=round(_comm_elapsed_ms(read_start), 6),
+            )
             with suppress(Exception):
                 state.receiver.abort(state.request, state.destination, exc)
             raise
@@ -641,6 +713,16 @@ class CommEngine:
         message: KVTransferPrepareMessage,
         error: str,
     ) -> KVTransferReadyMessage:
+        _comm_trace(
+            "comm_kv_prepare_rejected",
+            request_id=message.request_id,
+            transfer_id=message.transfer_id,
+            from_stage=message.from_stage,
+            to_stage=message.to_stage,
+            target_pool_id=message.target_pool_id,
+            num_pages=len(message.source_page_indices),
+            error=error,
+        )
         return KVTransferReadyMessage(
             request_id=message.request_id,
             transfer_id=message.transfer_id,
@@ -1001,6 +1083,13 @@ class CommEngine:
     ) -> None:
         self._pending.pop(object_id, None)
         self._retained_pending_kv_transfers.append(pending)
+        _comm_trace(
+            "comm_kv_pending_retained",
+            object_id=object_id,
+            retained_count=len(self._retained_pending_kv_transfers),
+            num_ops=len(pending.ops),
+            error=type(error).__name__,
+        )
         logger.error(
             "Retaining pending KV transfer %s after sender failure: %s",
             object_id,

--- a/sglang_omni/comm/router.py
+++ b/sglang_omni/comm/router.py
@@ -60,7 +60,7 @@ class CommRouter:
         self.comm_config = dict(comm_config or {})
         self.injected_relay = injected_relay
         self._relays: dict[TransportKind, Relay] = {}
-        self._traced_transports: dict[tuple[str, str], TransportKind] = {}
+        self._traced_transports: dict[tuple[str, str], str] = {}
         self._cuda_ipc_peer_cache: dict[str, bool] = {}
 
     def _cuda_ipc_peer_available(self, target: str) -> bool:
@@ -149,39 +149,52 @@ class CommRouter:
             return TransportKind.SHM
         return transport
 
+    def note_transport_choice(
+        self,
+        direction: str,
+        target: str,
+        transport: str,
+    ) -> None:
+        """Record the transport an edge uses, the first time and on every change.
+
+        The routing methods run once per transfer, so emitting on every call
+        would bury the log. An edge that changes transport mid-run still reads as
+        healthy in every other counter, so record the change itself.
+
+        Takes a plain string because the same-GPU direct path names a transport
+        (``torch_cuda_ipc``) that TransportKind does not carry.
+        """
+        if not _comm_trace_enabled():
+            return
+        key = (direction, target)
+        previous = self._traced_transports.get(key)
+        if previous == transport:
+            return
+        self._traced_transports[key] = transport
+        _comm_trace(
+            "comm_transport_selected",
+            stage=self.stage_name,
+            direction=direction,
+            peer_stage=target,
+            transport=transport,
+            previous=previous,
+        )
+
     def _note_transport(
         self,
         direction: str,
         target: str,
         kind: TransportKind,
     ) -> TransportKind:
-        """Record the transport an edge uses, the first time and on every change.
-
-        These methods run once per transfer, so emitting every call would bury
-        the log. An edge that changes transport mid-run still reads as healthy in
-        every other counter, so record the change itself.
-        """
-        if not _comm_trace_enabled():
-            return kind
-        key = (direction, target)
-        previous = self._traced_transports.get(key)
-        if previous is kind:
-            return kind
-        self._traced_transports[key] = kind
-        _comm_trace(
-            "comm_transport_selected",
-            stage=self.stage_name,
-            direction=direction,
-            peer_stage=target,
-            transport=kind.value,
-            previous=None if previous is None else previous.value,
-        )
+        self.note_transport_choice(direction, target, kind.value)
         return kind
 
     def outbound(self, target: str) -> TransportKind:
         if target in self.same_process_targets:
-            return self._note_transport("outbound", target, TransportKind.LOCAL_OBJECT)
-        return self._note_transport("outbound", target, self._physical_outbound(target))
+            kind = TransportKind.LOCAL_OBJECT
+        else:
+            kind = self._physical_outbound(target)
+        return self._note_transport("outbound", target, kind)
 
     def _physical_outbound(self, target: str) -> TransportKind:
         if target in self.remote_stage_names:
@@ -197,26 +210,26 @@ class CommRouter:
                 f"{type(data).__name__}"
             )
         if target in self.remote_stage_names:
-            return self._note_transport("stream", target, TransportKind.MOONCAKE)
-        if data.device.type != current_platform.device_type:
-            return self._note_transport("stream", target, TransportKind.SHM)
-        if self.self_is_gpu and target in self.gpu_stage_names:
-            return self._note_transport(
-                "stream", target, self._intra_node_transport(target)
+            kind = TransportKind.MOONCAKE
+        elif data.device.type != current_platform.device_type:
+            kind = TransportKind.SHM
+        elif self.self_is_gpu and target in self.gpu_stage_names:
+            kind = self._intra_node_transport(target)
+        else:
+            raise ValueError(
+                f"{current_platform.device_type} stream chunk cannot be sent from "
+                f"{self.stage_name!r} to non-GPU target {target!r}"
             )
-        raise ValueError(
-            f"{current_platform.device_type} stream chunk cannot be sent from "
-            f"{self.stage_name!r} to non-GPU target {target!r}"
-        )
+        return self._note_transport("stream", target, kind)
 
     def inbound(self, from_stage: str) -> TransportKind:
         if from_stage in self.remote_stage_names:
-            return self._note_transport("inbound", from_stage, TransportKind.MOONCAKE)
-        if self.self_is_gpu and from_stage in self.gpu_stage_names:
-            return self._note_transport(
-                "inbound", from_stage, current_platform.get_intra_node_transport()
-            )
-        return self._note_transport("inbound", from_stage, TransportKind.SHM)
+            kind = TransportKind.MOONCAKE
+        elif self.self_is_gpu and from_stage in self.gpu_stage_names:
+            kind = current_platform.get_intra_node_transport()
+        else:
+            kind = TransportKind.SHM
+        return self._note_transport("inbound", from_stage, kind)
 
     def relay(self, kind: TransportKind) -> Relay:
         if kind is TransportKind.LOCAL_OBJECT:
@@ -248,20 +261,24 @@ class CommRouter:
 
     def outbound_payload(self, target: str, payload: Any) -> TransportKind:
         if target in self.remote_stage_names:
-            return self._note_transport("payload", target, TransportKind.MOONCAKE)
-        devices = _tensor_devices(getattr(payload, "data", payload))
-        if not devices or devices == {"cpu"}:
-            return self._note_transport("payload", target, TransportKind.SHM)
-        if current_platform.device_type in devices and devices <= {
-            "cpu",
-            current_platform.device_type,
-        }:
-            if self.self_is_gpu and target in self.gpu_stage_names:
-                return self._note_transport(
-                    "payload", target, self._intra_node_transport(target)
+            kind = TransportKind.MOONCAKE
+        else:
+            devices = _tensor_devices(getattr(payload, "data", payload))
+            if not devices or devices == {"cpu"}:
+                kind = TransportKind.SHM
+            elif current_platform.device_type in devices and devices <= {
+                "cpu",
+                current_platform.device_type,
+            }:
+                if self.self_is_gpu and target in self.gpu_stage_names:
+                    kind = self._intra_node_transport(target)
+                else:
+                    kind = TransportKind.SHM
+            else:
+                raise ValueError(
+                    f"mixed or unsupported tensor devices in payload: {devices}"
                 )
-            return self._note_transport("payload", target, TransportKind.SHM)
-        raise ValueError(f"mixed or unsupported tensor devices in payload: {devices}")
+        return self._note_transport("payload", target, kind)
 
     def relay_for_stream(
         self, target: str, data: torch.Tensor

--- a/sglang_omni/comm/router.py
+++ b/sglang_omni/comm/router.py
@@ -10,6 +10,8 @@ import torch
 
 from sglang_omni.comm.data_ref import TransportKind
 from sglang_omni.platforms import current_platform
+from sglang_omni.profiler.comm_trace import emit as _comm_trace
+from sglang_omni.profiler.comm_trace import enabled as _comm_trace_enabled
 from sglang_omni.relay.base import Relay, create_relay
 
 logger = logging.getLogger(__name__)
@@ -58,6 +60,7 @@ class CommRouter:
         self.comm_config = dict(comm_config or {})
         self.injected_relay = injected_relay
         self._relays: dict[TransportKind, Relay] = {}
+        self._traced_transports: dict[tuple[str, str], TransportKind] = {}
         self._cuda_ipc_peer_cache: dict[str, bool] = {}
 
     def _cuda_ipc_peer_available(self, target: str) -> bool:
@@ -146,10 +149,39 @@ class CommRouter:
             return TransportKind.SHM
         return transport
 
+    def _note_transport(
+        self,
+        direction: str,
+        target: str,
+        kind: TransportKind,
+    ) -> TransportKind:
+        """Record the transport an edge uses, the first time and on every change.
+
+        These methods run once per transfer, so emitting every call would bury
+        the log. An edge that changes transport mid-run still reads as healthy in
+        every other counter, so record the change itself.
+        """
+        if not _comm_trace_enabled():
+            return kind
+        key = (direction, target)
+        previous = self._traced_transports.get(key)
+        if previous is kind:
+            return kind
+        self._traced_transports[key] = kind
+        _comm_trace(
+            "comm_transport_selected",
+            stage=self.stage_name,
+            direction=direction,
+            peer_stage=target,
+            transport=kind.value,
+            previous=None if previous is None else previous.value,
+        )
+        return kind
+
     def outbound(self, target: str) -> TransportKind:
         if target in self.same_process_targets:
-            return TransportKind.LOCAL_OBJECT
-        return self._physical_outbound(target)
+            return self._note_transport("outbound", target, TransportKind.LOCAL_OBJECT)
+        return self._note_transport("outbound", target, self._physical_outbound(target))
 
     def _physical_outbound(self, target: str) -> TransportKind:
         if target in self.remote_stage_names:
@@ -165,11 +197,13 @@ class CommRouter:
                 f"{type(data).__name__}"
             )
         if target in self.remote_stage_names:
-            return TransportKind.MOONCAKE
+            return self._note_transport("stream", target, TransportKind.MOONCAKE)
         if data.device.type != current_platform.device_type:
-            return TransportKind.SHM
+            return self._note_transport("stream", target, TransportKind.SHM)
         if self.self_is_gpu and target in self.gpu_stage_names:
-            return self._intra_node_transport(target)
+            return self._note_transport(
+                "stream", target, self._intra_node_transport(target)
+            )
         raise ValueError(
             f"{current_platform.device_type} stream chunk cannot be sent from "
             f"{self.stage_name!r} to non-GPU target {target!r}"
@@ -177,10 +211,12 @@ class CommRouter:
 
     def inbound(self, from_stage: str) -> TransportKind:
         if from_stage in self.remote_stage_names:
-            return TransportKind.MOONCAKE
+            return self._note_transport("inbound", from_stage, TransportKind.MOONCAKE)
         if self.self_is_gpu and from_stage in self.gpu_stage_names:
-            return current_platform.get_intra_node_transport()
-        return TransportKind.SHM
+            return self._note_transport(
+                "inbound", from_stage, current_platform.get_intra_node_transport()
+            )
+        return self._note_transport("inbound", from_stage, TransportKind.SHM)
 
     def relay(self, kind: TransportKind) -> Relay:
         if kind is TransportKind.LOCAL_OBJECT:
@@ -212,17 +248,19 @@ class CommRouter:
 
     def outbound_payload(self, target: str, payload: Any) -> TransportKind:
         if target in self.remote_stage_names:
-            return TransportKind.MOONCAKE
+            return self._note_transport("payload", target, TransportKind.MOONCAKE)
         devices = _tensor_devices(getattr(payload, "data", payload))
         if not devices or devices == {"cpu"}:
-            return TransportKind.SHM
+            return self._note_transport("payload", target, TransportKind.SHM)
         if current_platform.device_type in devices and devices <= {
             "cpu",
             current_platform.device_type,
         }:
             if self.self_is_gpu and target in self.gpu_stage_names:
-                return self._intra_node_transport(target)
-            return TransportKind.SHM
+                return self._note_transport(
+                    "payload", target, self._intra_node_transport(target)
+                )
+            return self._note_transport("payload", target, TransportKind.SHM)
         raise ValueError(f"mixed or unsupported tensor devices in payload: {devices}")
 
     def relay_for_stream(

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -27,6 +27,7 @@ from sglang_omni.comm.router import CommRouter
 from sglang_omni.pipeline.stage.input import DirectInput, InputHandler
 from sglang_omni.pipeline.stage.stream_queue import StreamItem, StreamQueue
 from sglang_omni.pipeline.tp_control import TPLeaderFanout, TPWorkMessage
+from sglang_omni.profiler.comm_trace import emit as _comm_trace
 from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.profiler.event_recorder import get_recorder as _get_recorder
 from sglang_omni.profiler.event_recorder import set_active_stage as _set_active_stage
@@ -583,6 +584,18 @@ class Stage:
                 request_id=msg.request_id,
                 from_stage=msg.from_stage,
                 chunk_id=msg.chunk_id,
+            )
+            # This branch never reaches CommEngine.read_stream_chunk, so it
+            # emits the read event itself. Without it the held-byte accounting
+            # for an edge misses every same-GPU chunk.
+            _comm_trace(
+                "comm_stream_read",
+                request_id=msg.request_id,
+                from_stage=msg.from_stage,
+                to_stage=self.name,
+                chunk_id=msg.chunk_id,
+                transport="torch_cuda_ipc",
+                bytes=data.nbytes,
             )
             await self._route_stream_item_or_fail(request_id, item)
             return
@@ -1398,6 +1411,18 @@ class Stage:
                     "modality": chunk_modality,
                     "transport": "torch_cuda_ipc",
                 },
+            )
+            # This branch skips the stream send worker and router.outbound_stream,
+            # so it records both the transport it chose and the bytes it sent.
+            self._comm.router.note_transport_choice("stream", target, "torch_cuda_ipc")
+            _comm_trace(
+                "comm_stream_send",
+                request_id=request_id,
+                from_stage=self.name,
+                to_stage=target,
+                chunk_id=chunk_id,
+                transport="torch_cuda_ipc",
+                bytes=data.nbytes,
             )
             await self.control_plane.send_to_stage(
                 target,

--- a/sglang_omni/relay/cuda_ipc.py
+++ b/sglang_omni/relay/cuda_ipc.py
@@ -1023,6 +1023,7 @@ class CudaIpcRelay(Relay):
         source_pool_id: str,
         source_page_indices: tuple[int, ...],
         destination_ref: dict[str, Any],
+        transfer_id: str | None = None,
     ) -> _ReceiverAckOperation:
         pool = self._kv_pools.get(source_pool_id)
         if pool is None:
@@ -1050,6 +1051,7 @@ class CudaIpcRelay(Relay):
         relay_info["cuda_ipc_kv"]["ready_event"] = ready_event.ipc_handle()
         _comm_trace(
             "cuda_ipc_kv_put",
+            transfer_id=transfer_id,
             source_pool_id=source_pool_id,
             num_pages=len(source_page_indices),
             bytes=relay_info["transfer_info"]["size"],
@@ -1071,6 +1073,7 @@ class CudaIpcRelay(Relay):
         source_page_indices: tuple[int, ...],
         destination_page_indices: tuple[int, ...],
         request_id: str,
+        transfer_id: str | None = None,
     ) -> CudaIpcGetOperation:
         destination = self._kv_pools.get(destination_pool_id)
         if destination is None:
@@ -1090,6 +1093,7 @@ class CudaIpcRelay(Relay):
             ):
                 _comm_trace(
                     "cuda_ipc_kv_peer_access_denied",
+                    transfer_id=transfer_id,
                     request_id=request_id,
                     source_device_id=source_device_id,
                     destination_device_id=destination_device_id,
@@ -1161,6 +1165,7 @@ class CudaIpcRelay(Relay):
         )
         _comm_trace(
             "cuda_ipc_kv_get",
+            transfer_id=transfer_id,
             request_id=request_id,
             destination_pool_id=destination_pool_id,
             num_pages=len(source_page_indices),

--- a/sglang_omni/relay/cuda_ipc.py
+++ b/sglang_omni/relay/cuda_ipc.py
@@ -1048,6 +1048,13 @@ class CudaIpcRelay(Relay):
         }
         relay_info["cuda_ipc_kv"] = dict(relay_info["cuda_ipc_kv"])
         relay_info["cuda_ipc_kv"]["ready_event"] = ready_event.ipc_handle()
+        _comm_trace(
+            "cuda_ipc_kv_put",
+            source_pool_id=source_pool_id,
+            num_pages=len(source_page_indices),
+            bytes=relay_info["transfer_info"]["size"],
+            device_id=device.index if device.index is not None else 0,
+        )
         return _ReceiverAckOperation(
             relay_info,
             held_references=(
@@ -1081,6 +1088,12 @@ class CudaIpcRelay(Relay):
                     source_device_id,
                 )
             ):
+                _comm_trace(
+                    "cuda_ipc_kv_peer_access_denied",
+                    request_id=request_id,
+                    source_device_id=source_device_id,
+                    destination_device_id=destination_device_id,
+                )
                 raise RuntimeError(
                     "direct CUDA-IPC KV transfer requires GPU peer access; "
                     f"cuda:{destination_device_id} cannot access "
@@ -1091,6 +1104,7 @@ class CudaIpcRelay(Relay):
         source_registration_id = source_meta["registration_id"]
         remote_pool_key = (source_engine_id, source_registration_id)
         source_buffers = self._remote_kv_pools.get(remote_pool_key)
+        remote_pool_cached = source_buffers is not None
         if source_buffers is None:
             source_buffers = tuple(
                 _load_cuda_storage_handle(storage, device=destination_device)
@@ -1144,6 +1158,17 @@ class CudaIpcRelay(Relay):
         transfer_size = sum(
             buffer.bytes_per_page * len(source_page_indices)
             for buffer in destination.buffers
+        )
+        _comm_trace(
+            "cuda_ipc_kv_get",
+            request_id=request_id,
+            destination_pool_id=destination_pool_id,
+            num_pages=len(source_page_indices),
+            bytes=transfer_size,
+            source_device_id=source_device_id,
+            destination_device_id=destination_device_id,
+            cross_device=source_device_id != destination_device_id,
+            remote_pool_cached=remote_pool_cached,
         )
         return CudaIpcGetOperation(
             done_event,

--- a/tests/unit_test/fixtures/trace_capture.py
+++ b/tests/unit_test/fixtures/trace_capture.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Capture helper for SGLANG_OMNI_COMM_TRACE events in tests.
+
+Consumers of ``sglang_omni.profiler.comm_trace`` bind ``emit`` via
+from-imports, so monkeypatching ``comm_trace.emit`` does not intercept their
+calls. Instead this enables the env gate and attaches a logging handler to the
+``sglang_omni.comm_trace`` logger, decoding each ``COMM_TRACE {json}`` line
+back into a dict.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+
+class _CommTraceHandler(logging.Handler):
+    def __init__(self, events: list[dict]) -> None:
+        super().__init__(level=logging.INFO)
+        self.events = events
+
+    def emit(self, record: logging.LogRecord) -> None:
+        message = record.getMessage()
+        prefix = "COMM_TRACE "
+        if message.startswith(prefix):
+            self.events.append(json.loads(message[len(prefix) :]))
+
+
+@contextmanager
+def capture_comm_trace(monkeypatch, *, enable: bool = True) -> Iterator[list[dict]]:
+    """Yield the list of decoded trace events.
+
+    ``enable=False`` leaves the env gate unset and still attaches the handler,
+    so a test can assert that the layer emits nothing when tracing is off.
+    """
+    if enable:
+        monkeypatch.setenv("SGLANG_OMNI_COMM_TRACE", "1")
+    else:
+        monkeypatch.delenv("SGLANG_OMNI_COMM_TRACE", raising=False)
+    events: list[dict] = []
+    handler = _CommTraceHandler(events)
+    trace_logger = logging.getLogger("sglang_omni.comm_trace")
+    previous_level = trace_logger.level
+    trace_logger.addHandler(handler)
+    trace_logger.setLevel(logging.INFO)
+    try:
+        yield events
+    finally:
+        trace_logger.removeHandler(handler)
+        trace_logger.setLevel(previous_level)
+
+
+def events_named(events: list[dict], name: str) -> list[dict]:
+    return [event for event in events if event["event"] == name]

--- a/tests/unit_test/pipeline/test_kv_transfer.py
+++ b/tests/unit_test/pipeline/test_kv_transfer.py
@@ -65,8 +65,9 @@ class _PagedRelay(FakeRelay):
         source_pool_id: str,
         source_page_indices: tuple[int, ...],
         destination_ref: dict[str, Any],
+        transfer_id: str | None = None,
     ) -> FakeOp:
-        del source_pool_id, destination_ref
+        del source_pool_id, destination_ref, transfer_id
         op = FakeOp(
             {
                 "transfer_info": {"size": len(source_page_indices)},
@@ -87,6 +88,7 @@ class _PagedRelay(FakeRelay):
         source_page_indices: tuple[int, ...],
         destination_page_indices: tuple[int, ...],
         request_id: str,
+        transfer_id: str | None = None,
     ) -> FakeOp:
         assert metadata["fake_kv"] is True
         self.received_source_tp_ranks.append(metadata["source_tp_rank"])
@@ -161,6 +163,7 @@ class _BlockingPagedRelay(_PagedRelay):
         source_page_indices: tuple[int, ...],
         destination_page_indices: tuple[int, ...],
         request_id: str,
+        transfer_id: str | None = None,
     ) -> FakeOp:
         del metadata
         self.get_calls.append(

--- a/tests/unit_test/pipeline/test_kv_transfer.py
+++ b/tests/unit_test/pipeline/test_kv_transfer.py
@@ -26,6 +26,7 @@ from sglang_omni.proto import (
     KVTransferReadyMessage,
 )
 from tests.unit_test.fixtures.pipeline_fakes import FakeOp, FakeRelay
+from tests.unit_test.fixtures.trace_capture import capture_comm_trace
 
 
 @pytest.fixture(autouse=True)
@@ -603,3 +604,232 @@ def test_kv_cleanup_aborts_reserved_destination() -> None:
     destination.cleanup("request")
 
     assert receiver.aborted == ["request"]
+
+
+# --- trace events on the paged KV path -------------------------------------
+#
+# These tests use the fake relay, so they cover the engine-side events only.
+# `cuda_ipc_kv_put` and `cuda_ipc_kv_get` live in CudaIpcRelay and need a GPU.
+
+
+def _kv_events(events: list[dict]) -> list[str]:
+    return [
+        event["event"]
+        for event in events
+        if event["event"].startswith(("comm_kv", "cuda_ipc_kv"))
+    ]
+
+
+def _first(events: list[dict], name: str) -> dict:
+    for event in events:
+        if event["event"] == name:
+            return event
+    raise AssertionError(f"no {name} event in {[e['event'] for e in events]}")
+
+
+def test_kv_transfer_traces_every_step_of_a_successful_transfer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with capture_comm_trace(monkeypatch) as events:
+
+        async def _run() -> None:
+            relay, source, destination = await _start_pair()
+            try:
+                source.register_kv_pool(_pool("source_pool"))
+                destination.register_kv_pool(_pool("destination_pool"))
+                destination.register_kv_receiver("destination_pool", _Receiver((0, 3)))
+                await source.send_kv_pages(
+                    request_id="request",
+                    transfer_id="transfer",
+                    source_pool_id="source_pool",
+                    source_page_indices=(1, 4),
+                    target_pool_id="destination_pool",
+                    to_stage="destination",
+                    lease=Mock(),
+                )
+            finally:
+                await source.close()
+                await destination.close()
+
+        asyncio.run(_run())
+
+    assert _kv_events(events) == [
+        "comm_kv_send_start",
+        "comm_kv_prepare_ready",
+        "comm_kv_ready",
+        "comm_kv_read_complete",
+        "comm_kv_transfer_complete",
+    ]
+
+    start = _first(events, "comm_kv_send_start")
+    assert start["transfer_id"] == "transfer"
+    assert start["from_stage"] == "source"
+    assert start["to_stage"] == "destination"
+    assert start["num_pages"] == 2
+
+    ready = _first(events, "comm_kv_ready")
+    assert ready["success"] is True
+    assert ready["error"] is None
+    assert ready["wait_ms"] >= 0.0
+
+    complete = _first(events, "comm_kv_transfer_complete")
+    assert complete["num_pages"] == 2
+    assert complete["elapsed_ms"] >= 0.0
+
+
+def test_kv_transfer_traces_a_transport_rejection_as_a_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with capture_comm_trace(monkeypatch) as events:
+
+        async def _run() -> None:
+            source = CommEngine(
+                CommRouter(
+                    stage_name="source",
+                    gpu_id=None,
+                    same_process_targets=set(),
+                    gpu_stage_names=set(),
+                    injected_relay=_PagedRelay(),
+                )
+            )
+            source.register_kv_pool(_pool("source_pool"))
+            with pytest.raises(NotImplementedError, match="only cuda_ipc"):
+                await source.send_kv_pages(
+                    request_id="request",
+                    source_pool_id="source_pool",
+                    source_page_indices=(0,),
+                    target_pool_id="destination_pool",
+                    to_stage="destination",
+                    lease=Mock(),
+                )
+
+        asyncio.run(_run())
+
+    assert _kv_events(events) == ["comm_kv_send_start", "comm_kv_transfer_failed"]
+    failed = _first(events, "comm_kv_transfer_failed")
+    assert failed["error"] == "NotImplementedError"
+    assert "only cuda_ipc" in failed["detail"]
+
+
+def test_kv_transfer_traces_a_receiver_rejection_on_both_sides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with capture_comm_trace(monkeypatch) as events:
+
+        async def _run() -> None:
+            relay, source, destination = await _start_pair()
+            try:
+                source.register_kv_pool(_pool("source_pool"))
+                destination.register_kv_pool(_pool("destination_pool"))
+                destination.register_kv_receiver(
+                    "destination_pool", _FailingReceiver((0,))
+                )
+                with pytest.raises(RuntimeError, match="rank-local reserve failed"):
+                    await source.send_kv_pages(
+                        request_id="request",
+                        transfer_id="transfer",
+                        source_pool_id="source_pool",
+                        source_page_indices=(1,),
+                        target_pool_id="destination_pool",
+                        to_stage="destination",
+                        lease=Mock(),
+                    )
+            finally:
+                await source.close()
+                await destination.close()
+
+        asyncio.run(_run())
+
+    assert _kv_events(events) == [
+        "comm_kv_send_start",
+        "comm_kv_prepare_rejected",
+        "comm_kv_ready",
+        "comm_kv_transfer_failed",
+    ]
+
+    # The receiver names the reason, so the sender does not have to guess it.
+    rejected = _first(events, "comm_kv_prepare_rejected")
+    assert rejected["transfer_id"] == "transfer"
+    assert rejected["target_pool_id"] == "destination_pool"
+    assert "rank-local reserve failed" in rejected["error"]
+
+    ready = _first(events, "comm_kv_ready")
+    assert ready["success"] is False
+    assert "rank-local reserve failed" in ready["error"]
+
+
+def test_kv_ack_timeout_traces_the_retained_transfer_with_a_running_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with capture_comm_trace(monkeypatch) as events:
+
+        async def _run() -> None:
+            relay, source, destination = await _start_pair()
+
+            async def drop_data_ready(
+                sockets: dict[str, Any], target_endpoint: str, message: Any
+            ) -> None:
+                if isinstance(message, DataReadyMessage):
+                    return
+                await send_to_endpoint(sockets, target_endpoint, message)
+
+            monkeypatch.setattr(
+                "sglang_omni.comm.engine.send_to_endpoint",
+                drop_data_ready,
+            )
+            source._ack_timeout_s = 0.1
+            source.register_kv_pool(_pool("source_pool"))
+            destination.register_kv_pool(_pool("destination_pool"))
+            destination.register_kv_receiver("destination_pool", _Receiver((0,)))
+            try:
+                with pytest.raises(TimeoutError):
+                    await source.send_kv_pages(
+                        request_id="request",
+                        transfer_id="transfer",
+                        source_pool_id="source_pool",
+                        source_page_indices=(1,),
+                        target_pool_id="destination_pool",
+                        to_stage="destination",
+                        lease=Mock(),
+                    )
+                assert len(source._retained_pending_kv_transfers) == 1
+            finally:
+                await source.close()
+                await destination.close()
+
+        asyncio.run(_run())
+
+    retained = _first(events, "comm_kv_pending_retained")
+    assert retained["object_id"] == "transfer"
+    assert retained["retained_count"] == 1
+    assert retained["num_ops"] == 1
+    assert "comm_kv_transfer_failed" in _kv_events(events)
+
+
+def test_kv_transfer_emits_nothing_when_the_env_gate_is_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with capture_comm_trace(monkeypatch, enable=False) as events:
+
+        async def _run() -> None:
+            relay, source, destination = await _start_pair()
+            try:
+                source.register_kv_pool(_pool("source_pool"))
+                destination.register_kv_pool(_pool("destination_pool"))
+                destination.register_kv_receiver("destination_pool", _Receiver((0, 3)))
+                await source.send_kv_pages(
+                    request_id="request",
+                    transfer_id="transfer",
+                    source_pool_id="source_pool",
+                    source_page_indices=(1, 4),
+                    target_pool_id="destination_pool",
+                    to_stage="destination",
+                    lease=Mock(),
+                )
+            finally:
+                await source.close()
+                await destination.close()
+
+        asyncio.run(_run())
+
+    assert events == []


### PR DESCRIPTION
## Motivation

The paged KV transfer path emits no trace events. Thirteen functions across `comm/engine.py` and `relay/cuda_ipc.py`, about 500 lines, contain no `_comm_trace` call. The eight events the comm layer already has all sit on the slot-pool path, and paged KV transfer uses pre-registered pools and page indices instead of slots, so none of them fire for it.

Prefill/decode disaggregation will run its traffic over this path. Today that traffic would produce no log line at all.

Two smaller gaps come from the same measurement work:

- **The router never records which transport an edge picked.** An edge that falls back keeps working, so every counter still reads as healthy. We lost an eight-hour soak to this: one edge moved from `cuda_ipc` to `shm` after the first request, the run reported balanced ACK counts and flat memory, and the path under test carried no traffic. Nothing in the log said so.
- **The direct-IPC stream path records only its sender.** That path has no byte ceiling — when the consumer falls behind, held bytes grow linearly at (produce − consume) × chunk size. Measuring that needs both rates, and `comm_stream_send` carried no byte count.

## Modifications

Three commits, one per concern.

**1. Trace the paged KV transfer path.** Nine events on the engine side, three on the relay side, covering both success and failure:

| event | fires when |
|---|---|
| `comm_kv_send_start` | the sender starts a transfer |
| `comm_kv_ready` | the peer answered the prepare round trip |
| `comm_kv_transfer_complete` | the transfer finished |
| `comm_kv_transfer_failed` | the transfer raised |
| `comm_kv_prepare_ready` | the receiver reserved its destination pages |
| `comm_kv_prepare_rejected` | the receiver refused, with the reason |
| `comm_kv_read_complete` | the receiver finished its copy |
| `comm_kv_read_failed` | the receiver copy raised |
| `comm_kv_pending_retained` | a failed transfer kept its pending entry |
| `cuda_ipc_kv_put` | the source exported its pages |
| `cuda_ipc_kv_get` | the destination copied them |
| `cuda_ipc_kv_peer_access_denied` | the two GPUs cannot reach each other |

`comm_kv_prepare_rejected` sits in `_kv_ready_failure`, which every receiver-side rejection already funnels through: wrong transport, unknown pool, layout mismatch, and a failed reserve all reach it.

`comm_kv_pending_retained` reports `len(_retained_pending_kv_transfers)`. That list is append-only and `close()` does not drain it, so the count is the only signal that it grows.

**2. Record which transport each edge selects.** `comm_transport_selected` fires the first time an edge resolves a transport and again whenever the answer changes. These methods run once per transfer, so emitting every call would bury the log.

**3. Trace direct-IPC stream reads.** Adds `comm_stream_read` on the consumer and a `bytes` field to `comm_stream_send`. Held bytes per edge are then the running difference of the two, straight from the log.

**4. Cover the same-GPU fast paths** (added after review). The direct CUDA-IPC branches in `runtime.py` skip `CommEngine.read_stream_chunk` on receive and the stream send worker on send, so the accounting above missed every same-GPU chunk. Both branches now emit their own `comm_stream_send` / `comm_stream_read` with `transport="torch_cuda_ipc"`. The send branch also skips `router.outbound_stream`, so it records its transport choice through a new `note_transport_choice` entry point, which takes a plain string because `TransportKind` does not carry `torch_cuda_ipc`.

**5. Correlate relay events with the lifecycle** (added after review). `put_kv_pages` carried no id and `get_kv_pages` carried only `request_id`, so concurrent transfers within one request could not be joined to their `comm_kv_*` events. `transfer_id` now threads through both and lands on `cuda_ipc_kv_put`, `cuda_ipc_kv_get`, and `cuda_ipc_kv_peer_access_denied`.

### Cost when the gate is unset

Every event stays behind `SGLANG_OMNI_COMM_TRACE`, which `emit()` checks on its first line. Two details keep the closed path free:

- Exception objects are passed to the trace call rather than `str(exc)`, so the formatting happens inside `emit()`. Trace-call arguments are evaluated before the early return, and a custom `__str__` that raised would otherwise mask the original exception on the failure path.
- The router's dedup map is only touched after `_comm_trace_enabled()` returns true, so a closed run costs one `getenv` call.

## Related Issues

Part of #1593. Relates to #862 Phase 3 and to the paged KV work in #1315 / #1382.

## Accuracy Test

Not applicable. No model-side code changes.

## Benchmark & Profiling

Not applicable. The added calls return on the first line of `emit()` unless `SGLANG_OMNI_COMM_TRACE` is set.

Verified on `b79b1e08`, in a container without GPUs:

| suite | clean `b79b1e08` | this branch |
|---|---|---|
| `tests/unit_test/pipeline/` + `tests/unit_test/relay/` | 3 failed, 453 passed, 12 skipped | 3 failed, **458** passed, 12 skipped |

The same three tests fail on both; they need a CUDA device that this container does not have. The five extra passes are the new tests.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
