### PR TITLE
Track MUSA runtime backends in GPU diagnostics

### DIFF
--- a/sglang_omni/diagnostics/gpu.py
+++ b/sglang_omni/diagnostics/gpu.py
@@ -20,8 +20,10 @@ from sglang_omni.utils.gpu_memory import (
 )
 
 _BACKENDS = (
+    ("runtime", "torchada", "torchada"),
     ("attention", "flash-attn-4", "flash_attn.cute"),
     ("attention", "flashinfer", "flashinfer"),
+    ("attention", "mate", "mate"),
     ("attention", "triton", "triton"),
     ("attention", "torch-sdpa", "torch.nn.functional"),
     ("gemm", "sgl-deep-gemm", "deep_gemm"),

--- a/tests/unit_test/diagnostics/test_gpu.py
+++ b/tests/unit_test/diagnostics/test_gpu.py
@@ -280,6 +280,16 @@ def test_backend_inventory_resolves_cuda_variant_distributions(monkeypatch) -> N
     assert all(backend["importable"] for backend in backends)
 
 
+def test_backend_inventory_tracks_musa_runtime_and_attention_backends() -> None:
+    backend_keys = {
+        (category, name, module)
+        for category, name, module in gpu_diagnostics._BACKENDS
+    }
+
+    assert ("runtime", "torchada", "torchada") in backend_keys
+    assert ("attention", "mate", "mate") in backend_keys
+
+
 def test_module_import_probe_survives_hard_crash(tmp_path, monkeypatch) -> None:
     assert gpu_diagnostics._module_import_error("json") is None
 


### PR DESCRIPTION
## Summary

Add MUSA-related backend visibility to `sglang_omni.diagnostics.gpu`:

- report `torchada` as a runtime backend
- report `mate` as an attention backend
- add a regression test so these MUSA backend probes stay listed

This does not change model execution or backend selection. It is a low-risk diagnostics step toward the MUSA support roadmap, and helps users verify whether the runtime pieces required for MUSA and MATE attention are installed/importable.

## Validation

- `python -m py_compile sglang_omni/diagnostics/gpu.py tests/unit_test/diagnostics/test_gpu.py`
- `python -m pytest -q tests/unit_test/diagnostics/test_gpu.py`
