### PR TITLE
Use MATE varlen attention for MOSS TTS on MUSA

### DIFF
--- a/sglang_omni/models/moss_tts/audio_tokenizer.py
+++ b/sglang_omni/models/moss_tts/audio_tokenizer.py
@@ -10,6 +10,7 @@ from collections.abc import Iterator, Sequence
 from contextlib import nullcontext
 from dataclasses import dataclass
 from itertools import accumulate
+from types import SimpleNamespace
 from typing import Any
 
 import torch
@@ -19,8 +20,16 @@ from transformers import AutoModel
 
 try:
     from sglang.jit_kernel.flash_attention import flash_attn_varlen_func
+
+    _flash_attn_varlen_backend = "sglang"
 except ImportError:
-    flash_attn_varlen_func = None
+    try:
+        from mate import flash_attn_varlen_func
+
+        _flash_attn_varlen_backend = "mate"
+    except ImportError:
+        flash_attn_varlen_func = None
+        _flash_attn_varlen_backend = None
 
 from sglang_omni.models.moss_tts.hf_loading import moss_transformers_processor_compat
 from sglang_omni.models.moss_tts.vocoder_kernels import (
@@ -40,6 +49,15 @@ _LOUDNESS_GAIN_MAX_DB = 3.0
 _FA3_LOCAL_WINDOW_QUERY_TILE_SIZE = 128
 _HF_FLASH_ATTENTION_2_IMPLEMENTATION = "flash_attention_2"
 _PACKED_FLASH_ATTENTION_BACKEND = "packed_flash_attention"
+
+
+def _attention_device(device: str | torch.device) -> torch.device | SimpleNamespace:
+    try:
+        return torch.device(device)
+    except RuntimeError:
+        if isinstance(device, str):
+            return SimpleNamespace(type=device.split(":", 1)[0])
+        raise
 
 
 def _single_module(source: nn.Module, singular: str, plural: str) -> nn.Module:
@@ -456,6 +474,7 @@ class MossAudioTokenizerAttention(nn.Module):
             source, "resolve_attention_implementation"
         )
         self._flash_attn_varlen = flash_attn_varlen_func
+        self._flash_attn_varlen_backend = _flash_attn_varlen_backend
         max_period = self.rope.max_period if self.rope is not None else 10000.0
         self._packed_rope_cache = packed_rope_cache or _MossPackedRopeCache(
             max_period=max_period
@@ -487,7 +506,12 @@ class MossAudioTokenizerAttention(nn.Module):
         device: torch.device,
         dtype: torch.dtype | None,
     ) -> bool:
-        if dtype is None or self._flash_attn_varlen is None or device.type != "cuda":
+        if dtype is None or self._flash_attn_varlen is None:
+            return False
+        if self._flash_attn_varlen_backend == "mate":
+            if device.type not in ("cuda", "musa"):
+                return False
+        elif device.type != "cuda":
             return False
         preferred = getattr(self.source, "attention_implementation", None)
         if preferred not in (None, _HF_FLASH_ATTENTION_2_IMPLEMENTATION):
@@ -889,7 +913,7 @@ class MossAudioTokenizerVocoderDecoder(nn.Module):
         device: str | torch.device,
         dtype: torch.dtype | None,
     ) -> bool:
-        device = torch.device(device)
+        device = _attention_device(device)
         transformer_stages = [
             stage
             for stage in self.stages

--- a/tests/unit_test/moss_tts/test_audio_tokenizer.py
+++ b/tests/unit_test/moss_tts/test_audio_tokenizer.py
@@ -866,6 +866,19 @@ def test_vocoder_decoder_requires_packed_flash_for_every_transformer() -> None:
     assert not local.supports_packed_flash("cuda", torch.float16)
 
 
+def test_vocoder_decoder_allows_mate_varlen_attention_on_musa() -> None:
+    source = _V1WeightsProjectedStage()
+    decoder = MossAudioTokenizerVocoderDecoder(nn.ModuleList([source]))
+    attention = decoder[0].transformer.layers[0].self_attn
+    attention._flash_attn_varlen = lambda *args, **kwargs: None
+    attention._flash_attn_varlen_backend = "mate"
+
+    assert decoder.supports_packed_flash("musa", torch.bfloat16)
+
+    attention._flash_attn_varlen_backend = "sglang"
+    assert not decoder.supports_packed_flash("musa", torch.bfloat16)
+
+
 def test_vocoder_decoder_wraps_v1_weights_moss_audio_tokenizer_fields() -> None:
     source = _V1WeightsProjectedStage()
     wrapped = MossAudioTokenizerVocoderDecoder(nn.ModuleList([source]))


### PR DESCRIPTION
## Summary

Add a MUSA-friendly packed attention fallback for the MOSS TTS audio tokenizer.

When SGLang's flash-attention varlen kernel is unavailable, this falls back to `mate.flash_attn_varlen_func`. The existing CUDA path keeps using the SGLang flash-attention implementation when available, while the MATE fallback allows packed flash attention to be enabled on MUSA devices.

This PR intentionally only handles the varlen attention API because the current MATE package exposes `flash_attn_varlen_func`; it does not try to emulate ordinary `flash_attn_func`.

## Validation

- Inspected the MUSA runtime image and confirmed `mate 0.2.4.dev20260710` exposes `flash_attn_varlen_func`
- `python -m py_compile sglang_omni/models/moss_tts/audio_tokenizer.py tests/unit_test/moss_tts/test_audio_tokenizer.py`
- `python -m pytest -q tests/unit_test/moss_tts/test_audio_tokenizer.py`
