### PR TITLE
[Whisper ASR] Disable persistent encoder cache by default

### DIFF
--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -36,6 +36,16 @@ runtime_overrides:
 
 The graph is captured after SGLang's generation graphs. With pre-LM off, raise `max_prefill_tokens` before configuring larger LM-side buckets (12/16). Each request uses the smallest captured bucket that fits its batch. Requests larger than every captured bucket, with a different feature shape, or without a successful capture run eagerly. Startup and first-replay logs identify the captured and executed buckets.
 
+## Pre-LM Encoder Cache
+
+Pre-LM encoding still merges concurrent requests for the same audio, but its persistent CPU embedding cache is disabled by default because most ASR traffic contains unique audio. This avoids copying each new `[1500, hidden_size]` encoder output from the GPU before request construction can finish. Workloads that repeatedly transcribe the same audio can opt into the bounded cache by setting a positive entry limit; the default byte limit remains 2 GiB:
+
+```yaml
+runtime_overrides:
+  asr:
+    pre_lm_cache_max_entries: 4096
+```
+
 ## Prefill Coalescing
 
 Whisper builds requests with eight worker threads by default, matching other pre-LM ASR pipelines. The coalescing gate targets two requests, while the default 6,144-token atomic budget lets the LM scheduler admit up to four 1,504-token Whisper requests together. A partial batch waits for at most 6 ms only while another request build is pending; a single request and a partial batch with no remaining build work are released immediately.
@@ -229,6 +239,15 @@ The async-decode comparison used the 128-sample SeedTTS EN subset on the same H2
 
 All 4,608 measured requests across both modes completed successfully, and all 2,304 paired transcripts matched exactly. Batch size 1 uses the synchronous fast path, so its 1.6% difference is run-to-run noise rather than async work. At concurrency 32, request-stage profiling measured 614.3 ms synchronous versus 585.5 ms asynchronous P95 from prefill completion to request completion. A separate async-only `openai/whisper-base` budget comparison showed why 6,144 is the default: relative to 4,096, scheduler queue P95 fell from 92.2 ms to 52.2 ms and throughput rose from 134.83 to 166.69 req/s.
 
+The pre-LM cache comparison used the same H200 with `openai/whisper-large-v3` in FP16 and 128 SeedTTS EN samples at concurrency 32. Every old-default pass started with an empty persistent CPU cache, so the workload measured cache-miss behavior for unique audio. The new default retained concurrent single-flight merging but set `pre_lm_cache_max_entries=0`.
+
+| Mode | Cold-cache repeats | Throughput | P95 latency | Corpus WER |
+|---|---:|---:|---:|---:|
+| Old default persistent cache | 3 | 52.71 req/s | 0.994 s | 0.0084 |
+| New default (`pre_lm_cache_max_entries=0`) | 3 | 57.96 req/s | 0.803 s | 0.0084 |
+
+Disabling the persistent cache improved throughput by 10.0% and reduced P95 latency by 19.2%. A separate six-concurrency validation produced identical transcripts for all 2,304 paired requests. A 64-request Torch-profiler pass at concurrency 32 verified that the intended path ran: 3.84 MiB embedding Device-to-Host copies fell from 40 to 0, and total pageable Device-to-Host GPU time fell from 38.036 ms to 0.531 ms. Profiler-affected throughput was excluded from the table.
+
 ## Known Limitations
 
 - Whisper ASR remains experimental. Validate checkpoint-specific accuracy and
@@ -237,10 +256,7 @@ All 4,608 measured requests across both modes completed successfully, and all 2,
   and `vtt` are not supported and return HTTP 400.
 - Encoder CUDA Graph is enabled by default and requires SGLang generation CUDA
   Graph. Validate the selected buckets before production use.
-- Audio encoding runs before LM admission by default
-  (`pre_lm_max_batch_size=8`, `request_build_max_workers=8`). Set
-  `enable_pre_lm_encoder: false` under `runtime_overrides.asr` to run the
-  encoder inside prefill again.
+- Audio encoding runs before LM admission by default (`pre_lm_max_batch_size=8`, `request_build_max_workers=8`). Its persistent CPU embedding cache is disabled by default; set a positive `pre_lm_cache_max_entries` for repeated-audio workloads. Set `enable_pre_lm_encoder: false` under `runtime_overrides.asr` to run the encoder inside prefill again.
 - Prefill budget defaults to 6,144 tokens (`⌊6144/1500⌋=4`) under atomic
   admission (`chunked_prefill_size=0`). This caps LM-side prefill batching
   independently of the pre-LM encoder batch limit.

--- a/sglang_omni/models/whisper_asr/config.py
+++ b/sglang_omni/models/whisper_asr/config.py
@@ -56,7 +56,7 @@ class WhisperASRPipelineConfig(PipelineConfig):
                 "prefill_coalesce_requires_pending_builds": True,
                 "prefill_coalesce_after_builds_during_decode": False,
                 "enable_pre_lm_encoder": True,
-                "pre_lm_cache_max_entries": 4096,
+                "pre_lm_cache_max_entries": 0,
                 "pre_lm_cache_size_bytes": 2 * 1024**3,
                 "pre_lm_max_batch_size": 8,
                 "pre_lm_max_batch_wait_ms": 0,

--- a/sglang_omni/models/whisper_asr/encoder_service.py
+++ b/sglang_omni/models/whisper_asr/encoder_service.py
@@ -22,7 +22,7 @@ from sglang_omni.scheduling.stage_cache import StageOutputCache
 
 logger = logging.getLogger(__name__)
 
-_CACHE_MAX_ENTRIES = 4096
+_CACHE_MAX_ENTRIES = 0
 _CACHE_MAX_BYTES = 2 * 1024**3
 _SHUTDOWN = object()
 

--- a/sglang_omni/models/whisper_asr/engine_builder.py
+++ b/sglang_omni/models/whisper_asr/engine_builder.py
@@ -81,7 +81,7 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
         prefill_coalesce_requires_pending_builds: bool = True,
         prefill_coalesce_after_builds_during_decode: bool = False,
         enable_pre_lm_encoder: bool = True,
-        pre_lm_cache_max_entries: int = 4096,
+        pre_lm_cache_max_entries: int = 0,
         pre_lm_cache_size_bytes: int = 2 * 1024**3,
         pre_lm_max_batch_size: int = 8,
         pre_lm_max_batch_wait_ms: int = 0,

--- a/sglang_omni/models/whisper_asr/stages.py
+++ b/sglang_omni/models/whisper_asr/stages.py
@@ -26,7 +26,7 @@ def create_sglang_whisper_asr_executor(
     prefill_coalesce_requires_pending_builds: bool = True,
     prefill_coalesce_after_builds_during_decode: bool = False,
     enable_pre_lm_encoder: bool = True,
-    pre_lm_cache_max_entries: int = 4096,
+    pre_lm_cache_max_entries: int = 0,
     pre_lm_cache_size_bytes: int = 2 * 1024**3,
     pre_lm_max_batch_size: int = 8,
     pre_lm_max_batch_wait_ms: int = 0,

--- a/sglang_omni/scheduling/stage_cache.py
+++ b/sglang_omni/scheduling/stage_cache.py
@@ -78,7 +78,7 @@ class StageOutputCache:
             return entry.data
 
     def put(self, key: str | None, data: Any) -> None:
-        if key is None:
+        if key is None or self.max_size == 0 or self.max_bytes == 0:
             return
         key = str(key)
         size_bytes = self._size_fn(data)

--- a/tests/unit_test/scheduling/test_stage_cache.py
+++ b/tests/unit_test/scheduling/test_stage_cache.py
@@ -37,11 +37,19 @@ def test_stage_output_cache_rejects_negative_capacity(capacity: str) -> None:
 
 @pytest.mark.parametrize("capacity", ["max_size", "max_bytes"])
 def test_stage_output_cache_allows_zero_capacity(capacity: str) -> None:
-    cache = StageOutputCache(**{capacity: 0})
+    size_calls = 0
+
+    def size_fn(_value: object) -> int:
+        nonlocal size_calls
+        size_calls += 1
+        return 1
+
+    cache = StageOutputCache(**{capacity: 0}, size_fn=size_fn)
 
     cache.put("key", b"value")
 
     assert cache.get("key") is None
+    assert size_calls == 0
 
 
 def test_remove_if_same_preserves_a_replacement() -> None:

--- a/tests/unit_test/whisper_asr/test_encoder_service.py
+++ b/tests/unit_test/whisper_asr/test_encoder_service.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import threading
+import time
 from collections.abc import Iterator
 from types import SimpleNamespace
 
@@ -38,9 +40,11 @@ class _StubEncoder(torch.nn.Module):
         self.fail = False
         self.fail_multi_item = False
         self.encode_gate: threading.Event | None = None
+        self.encode_started = threading.Event()
 
     def forward(self, audio_features: torch.Tensor) -> torch.Tensor:
         self.encode_calls += 1
+        self.encode_started.set()
         gate = self.encode_gate
         if gate is not None:
             self.encode_gate = None
@@ -196,6 +200,31 @@ def test_no_fingerprint_does_not_cache() -> None:
     assert len(service._cache) == 0
 
 
+def test_zero_capacity_cache_preserves_single_flight() -> None:
+    model = _StubModel()
+    encode_gate = threading.Event()
+    model._encoder.encode_gate = encode_gate
+    service = _make_service(model, cache_max_entries=0)
+    first = _make_item(fingerprint="same", fill=2.0)
+    second = _make_item(fingerprint="same", fill=9.0)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        first_result = pool.submit(service.encode_item, first)
+        assert model._encoder.encode_started.wait(timeout=5)
+        second_result = pool.submit(service.encode_item, second)
+        deadline = time.monotonic() + 5
+        while service.stats()["merged"] == 0 and time.monotonic() < deadline:
+            time.sleep(0.001)
+        encode_gate.set()
+        first_result.result(timeout=5)
+        second_result.result(timeout=5)
+
+    assert model.encode_calls == 1
+    assert service.stats()["merged"] == 1
+    assert len(service._cache) == 0
+    assert torch.equal(first.precomputed_embeddings, second.precomputed_embeddings)
+
+
 def test_close_rejects_new_encodes() -> None:
     service = _make_service()
     service.close()
@@ -208,8 +237,6 @@ def test_batched_encode_retries_per_item_on_multi_failure() -> None:
     model._encoder.fail_multi_item = True
     service = _make_service(model, max_batch_size=4)
     items = [_make_item(fingerprint=f"b{i}", fill=float(i + 1)) for i in range(3)]
-    import concurrent.futures
-
     with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
         list(pool.map(service.encode_item, items))
     assert all(item.precomputed_embeddings is not None for item in items)

--- a/tests/unit_test/whisper_asr/test_pipeline.py
+++ b/tests/unit_test/whisper_asr/test_pipeline.py
@@ -58,6 +58,8 @@ def test_whisper_stage_defaults() -> None:
         is False
     )
     assert signature.parameters["enable_pre_lm_encoder"].default is True
+    assert signature.parameters["pre_lm_cache_max_entries"].default == 0
+    assert signature.parameters["pre_lm_cache_size_bytes"].default == 2 * 1024**3
     assert signature.parameters["pre_lm_max_batch_size"].default == 8
 
 
@@ -231,7 +233,7 @@ def test_whisper_asr_config_uses_single_batched_stage() -> None:
         is False
     )
     assert config.stages[0].factory_args["enable_pre_lm_encoder"] is True
-    assert config.stages[0].factory_args["pre_lm_cache_max_entries"] == 4096
+    assert config.stages[0].factory_args["pre_lm_cache_max_entries"] == 0
     assert config.stages[0].factory_args["pre_lm_cache_size_bytes"] == 2 * 1024**3
     assert config.stages[0].factory_args["pre_lm_max_batch_size"] == 8
     assert config.stages[0].factory_args["pre_lm_max_batch_wait_ms"] == 0


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Whisper's pre-LM encoder service previously enabled a persistent CPU embedding cache with a 4,096-entry limit by default. This helps workloads that repeatedly transcribe the same audio, but typical ASR traffic contains unique audio and therefore pays the cache-miss cost without receiving reuse. For `openai/whisper-large-v3`, every miss copies a `[1500, 1280]` FP16 encoder output, or 3.84 MiB, from the GPU to CPU before request construction can finish. This PR disables persistent caching by default for Whisper while preserving concurrent single-flight merging for identical audio and keeping the bounded cache available as an explicit opt-in.

## Modifications

- Set Whisper's default `pre_lm_cache_max_entries` from `4096` to `0` consistently across pipeline configuration, engine construction, stage creation, and the encoder service.
- Make `StageOutputCache.put` return before calculating tensor size when either the entry or byte capacity is zero.
- Preserve in-flight request merging when persistent cache capacity is zero and add regression coverage for this behavior.
- Document the new default, the repeated-audio opt-in configuration, and the measured accuracy and performance results in the Whisper cookbook.

## Related Issues

Related to https://github.com/sgl-project/sglang-omni/issues/1396.

## Accuracy Test

Accuracy was evaluated with `openai/whisper-large-v3` in FP16 on the pinned 128-sample SeedTTS EN subset. Corpus WER remained `0.0084` with both the old persistent-cache default and the new default. A separate concurrency sweep at `c=1,2,4,8,16,32` produced identical transcripts for all 2,304 paired requests. This change does not alter model computation, tensor shape, dtype, device placement, or decoder behavior.

## Benchmark & Profiling

The end-to-end comparison ran on one H200 with `openai/whisper-large-v3` in FP16, 128 SeedTTS EN samples, concurrency 32, and three measured cold-cache repeats per mode. Each old-default repeat started with an empty persistent cache so both modes processed the same unique-audio workload.

| Mode | Cold-cache repeats | Throughput | P95 latency | Corpus WER |
|---|---:|---:|---:|---:|
| Old default persistent cache | 3 | 52.71 req/s | 0.994 s | 0.0084 |
| New default (`pre_lm_cache_max_entries=0`) | 3 | 57.96 req/s | 0.803 s | 0.0084 |

The new default improved throughput by 10.0% and reduced P95 latency by 19.2%. A 64-request Torch-profiler pass at concurrency 32 confirmed that the intended path ran: 3.84 MiB embedding Device-to-Host copies fell from 40 to 0, while total pageable Device-to-Host GPU time fell from 38.036 ms to 0.531 ms. Profiler-affected throughput was excluded from the table.

The benchmark client command was:

```bash
python -m benchmarks.eval.benchmark_asr_seedtts \
  --port 8000 \
  --model-path openai/whisper-large-v3 \
  --model-revision 06f233fe06e710322aca913c1bc4249a0d71fce1 \
  --dataset-revision 27f4c1adee83b5b29b7c4b375f6b976324bda308 \
  --max-samples 128 \
  --concurrencies 32 \
  --repeats 3 \
  --warmup \
  --dtype float16 \
  --cuda-graph \
  --torch-compile \
  --max-running-requests 32 \
  --mem-fraction-static 0.30 \
  --fingerprint \
  --output whisper_cache.json
```

The baseline server used `pre_lm_cache_max_entries: 4096`; the optimized server used the new default, `pre_lm_cache_max_entries: 0`. The GPU, checkpoint revision, dataset revision, server settings, and client command were otherwise identical.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the `run-ci` label. Once labeled, every subsequent push re-triggers CI as long as the label remains. Use `/tag-and-rerun-ci higgs` or `/tag-and-rerun-ci moss` to select a TTS CI model, and `/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR CI model. One selector from each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.