### PR TITLE
[Scheduler] Drop the compensating free of stale overrun step slots

### DIFF
--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -2380,34 +2380,18 @@ class OmniScheduler:
         except Exception as exc:
             self._handle_batch_failure(batch, exc)
 
-    def _free_overrun_step_slots(self, out_cache_loc, drop_indices) -> None:
-        """Free the per-step decode KV slot for rows whose request finished or
-        retracted in a prior step (the lookahead overrun): ``prepare_for_decode``
-        allocated it but ``cache_finished_req`` truncates below it, so it leaks.
-
-        Only under RadixCache + page_size=1; ChunkCache/paged already free the slot
-        with the request, so compensating here would double-free — hence the gate.
-        """
-        if not drop_indices:
-            return
-        if self.page_size != 1 or self.server_args.disable_radix_cache:
-            return
-        if out_cache_loc is None:
-            logger.warning("overrun step-slot free skipped: out_cache_loc is None")
-            return
-        assert max(drop_indices) < out_cache_loc.numel(), (
-            f"overrun drop index {max(drop_indices)} out of range "
-            f"({out_cache_loc.numel()} step slots)"
-        )
-        idx = torch.tensor(drop_indices, dtype=torch.long, device=out_cache_loc.device)
-        self.token_to_kv_pool_allocator.free(out_cache_loc[idx])
-
     def _drop_stale_overrun(self, batch):
         """Drop reqs finished OR retracted by the just-completed drain from the
         stale fast-path batch, so run_batch does not forward/finalize them again
         (double-free of already-freed KV). Returns the filtered batch, or None if
         it empties. Mirrors the finished/is_retracted pre-drop in
         _resolve_and_process; the fast path previously dropped only finished.
+
+        The dropped rows' step slots need no compensating free: the batch's
+        prepare already advanced req.kv_committed_len over them, and the
+        drain's release_kv_cache frees or caches every committed slot, so
+        a second free here would put a slot on the free list that the radix
+        tree (or another request) still owns.
         """
         if batch is None or not batch.reqs:
             return batch
@@ -2434,12 +2418,6 @@ class OmniScheduler:
             starts = [0] * len(lens)
             for i in range(1, len(lens)):
                 starts[i] = starts[i - 1] + lens[i - 1]
-            drop_tokens = [
-                t
-                for i, d in enumerate(drop)
-                if d
-                for t in range(starts[i], starts[i] + lens[i])
-            ]
             keep_tokens = [
                 t for i in keep for t in range(starts[i], starts[i] + lens[i])
             ]
@@ -2453,7 +2431,6 @@ class OmniScheduler:
             prefix_lens = batch.prefix_lens
             extend_logprob_start_lens = batch.extend_logprob_start_lens
             lp_token_ids = batch.extend_input_logprob_token_ids
-            self._free_overrun_step_slots(out_cache_loc, drop_tokens)
             batch.filter_batch(keep_indices=keep)
             if input_ids is not None:
                 batch.input_ids = input_ids[keep_tokens]
@@ -2487,9 +2464,6 @@ class OmniScheduler:
                     ]
                     batch.extend_input_logprob_token_ids = lp_token_ids[keep_lp_tokens]
         else:
-            self._free_overrun_step_slots(
-                out_cache_loc, [i for i, d in enumerate(drop) if d]
-            )
             batch.filter_batch(keep_indices=keep)
             if out_cache_loc is not None:
                 batch.out_cache_loc = out_cache_loc[keep]

--- a/tests/unit_test/pipeline/test_async_decode.py
+++ b/tests/unit_test/pipeline/test_async_decode.py
@@ -451,63 +451,142 @@ def test_default_launch_staging_grows_then_slices_to_smaller_batch():
     assert small.next_token_ids.tolist() == [7, 8]
 
 
-# ---------------------------------------------------------------------------
-# Lookahead-overrun step-slot reclamation: allocator balance and the
-# cache-implementation gate (RadixCache + page_size=1 only; see
-# OmniScheduler._free_overrun_step_slots).
-# ---------------------------------------------------------------------------
+def _real_radix_pools(size=64):
+    from sglang.srt.mem_cache.allocator.token import TokenToKVPoolAllocator
+    from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+    from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, ReqToTokenPool
+    from sglang.srt.mem_cache.radix_cache import RadixCache
 
-
-def _scheduler_with_allocator(page_size=1, disable_radix_cache=False):
-    freed: list[int] = []
-    s = OmniScheduler.__new__(OmniScheduler)
-    s.page_size = page_size
-    s.server_args = types.SimpleNamespace(disable_radix_cache=disable_radix_cache)
-    s.token_to_kv_pool_allocator = types.SimpleNamespace(
-        free=lambda t: freed.extend(t.tolist())
+    kv = MHATokenToKVPool(
+        size=size,
+        page_size=1,
+        dtype=torch.float16,
+        head_num=1,
+        head_dim=8,
+        layer_num=1,
+        device="cpu",
+        enable_memory_saver=False,
     )
-    return s, freed
+    allocator = TokenToKVPoolAllocator(
+        size=size, dtype=torch.float16, device="cpu", kvcache=kv, need_sort=False
+    )
+    req_to_token_pool = ReqToTokenPool(
+        size=4, max_context_len=64, device="cpu", enable_memory_saver=False
+    )
+    cache = RadixCache(
+        CacheInitParams(
+            disable=False,
+            req_to_token_pool=req_to_token_pool,
+            token_to_kv_pool_allocator=allocator,
+            page_size=1,
+        )
+    )
+    return allocator, req_to_token_pool, cache
 
 
-def test_free_overrun_step_slots_frees_exactly_the_dropped_rows():
-    s, freed = _scheduler_with_allocator()
-    s._free_overrun_step_slots(torch.tensor([100, 101, 102]), [0, 2])
-    assert freed == [100, 102]
-    s._free_overrun_step_slots(torch.tensor([100, 101, 102]), [])
-    assert freed == [100, 102]
+def _decoding_req(allocator, req_to_token_pool, rid, prompt, outputs):
+    from sglang.srt.managers.schedule_batch import Req, ReqKvInfo
+    from sglang.srt.sampling.sampling_params import SamplingParams
+
+    req = Req(rid, "", list(prompt), SamplingParams(max_new_tokens=8))
+    req_to_token_pool.alloc([req])
+    n = len(prompt)
+    slots = allocator.alloc(n)
+    req_to_token_pool.write((req.req_pool_idx, slice(0, n)), slots.to(torch.int32))
+    req.kv = ReqKvInfo(kv_allocated_len=n, swa_evicted_seqlen=0)
+    req.kv_committed_len = n
+    req.output_ids = [outputs[0]]
+    for tok in outputs[1:]:
+        _commit_step_slot(allocator, req_to_token_pool, req)
+        req.output_ids.append(tok)
+    return req
 
 
-def test_free_overrun_step_slots_skips_under_chunk_cache():
-    # ChunkCache's cache_finished_req frees [:kv_committed_len] — the overrun
-    # slot included — so the compensating free would double-free the slot and
-    # let two requests share it.
-    s, freed = _scheduler_with_allocator(disable_radix_cache=True)
-    s._free_overrun_step_slots(torch.tensor([100, 101]), [1])
-    assert freed == []
+def _commit_step_slot(allocator, req_to_token_pool, req):
+    slot = allocator.alloc(1)
+    pos = req.kv.kv_allocated_len
+    req_to_token_pool.write(
+        (req.req_pool_idx, slice(pos, pos + 1)), slot.to(torch.int32)
+    )
+    req.kv.kv_allocated_len += 1
+    req.kv_committed_len += 1
+    return int(slot[0])
 
 
-def test_free_overrun_step_slots_skips_under_paged_allocator():
-    # Paged allocators free whole pages; the overrun slot's page was already
-    # freed with the request's tail tokens.
-    s, freed = _scheduler_with_allocator(page_size=16)
-    s._free_overrun_step_slots(torch.tensor([100, 101]), [1])
-    assert freed == []
+class _StaleDecodeBatch:
+    def __init__(self, reqs, out_cache_loc):
+        from sglang.srt.model_executor.forward_batch_info import ForwardMode
+
+        self.reqs = list(reqs)
+        self.out_cache_loc = out_cache_loc
+        self.forward_mode = ForwardMode.DECODE
+        self.decoding_reqs = None
+
+    def filter_batch(self, keep_indices=None):
+        self.reqs = [self.reqs[i] for i in keep_indices]
+        self.out_cache_loc = None
 
 
-def test_free_overrun_step_slots_asserts_on_out_of_range_drop_index():
-    # A decode batch carries exactly one slot per row; a drop index beyond
-    # numel means the batch is not decode-shaped — fail loudly instead of
-    # freeing the wrong slot or silently reintroducing the leak.
-    s, freed = _scheduler_with_allocator()
-    with pytest.raises(AssertionError, match="out of range"):
-        s._free_overrun_step_slots(torch.tensor([100]), [1])
-    assert freed == []
+def test_drop_stale_overrun_leaves_drained_rows_single_owned():
+    from sglang.srt.managers.schedule_batch import FINISH_MATCHED_TOKEN
+    from sglang.srt.mem_cache.common import release_kv_cache
+    from sglang.srt.mem_cache.radix_cache import MatchPrefixParams, RadixKey
+    from sglang.srt.runtime_context import get_context
 
+    with get_context().override_server_args(page_size=1):
+        allocator, req_to_token_pool, cache = _real_radix_pools()
+        total = allocator.available_size()
+        survivor = _decoding_req(allocator, req_to_token_pool, "s", [1, 2], [20])
+        finished = _decoding_req(allocator, req_to_token_pool, "f", [3, 4], [30, 31])
+        retracted = _decoding_req(allocator, req_to_token_pool, "r", [5, 6], [40])
+        step_slots = [
+            _commit_step_slot(allocator, req_to_token_pool, req)
+            for req in (survivor, finished, retracted)
+        ]
 
-def test_free_overrun_step_slots_skips_none_out_cache_loc():
-    s, freed = _scheduler_with_allocator()
-    s._free_overrun_step_slots(None, [0])
-    assert freed == []
+        finished.finished_reason = FINISH_MATCHED_TOKEN(matched=31)
+        release_kv_cache(finished, cache)
+        retracted.is_retracted = True
+        release_kv_cache(retracted, cache, is_insert=False)
+
+        s = OmniScheduler.__new__(OmniScheduler)
+        s.page_size = 1
+        s.server_args = types.SimpleNamespace(disable_radix_cache=False)
+        s.token_to_kv_pool_allocator = allocator
+        batch = _StaleDecodeBatch(
+            [survivor, finished, retracted], torch.tensor(step_slots)
+        )
+        out = s._drop_stale_overrun(batch)
+
+        assert out is batch
+        assert [req.rid for req in out.reqs] == ["s"]
+        assert out.out_cache_loc.tolist() == [step_slots[0]]
+
+        survivor_slots = survivor.kv.kv_allocated_len
+        assert (
+            allocator.available_size() + cache.evictable_size()
+            == total - survivor_slots
+        )
+        free = allocator.free_pages.tolist()
+        cached = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey([3, 4, 30, 31]))
+        ).device_indices.tolist()
+        assert step_slots[0] not in free and step_slots[0] not in cached
+        assert free.count(step_slots[1]) == 0 and cached.count(step_slots[1]) == 1
+        assert free.count(step_slots[2]) == 1 and step_slots[2] not in cached
+
+        assert (
+            s._drop_stale_overrun(
+                _StaleDecodeBatch([finished, retracted], torch.tensor(step_slots[1:]))
+            )
+            is None
+        )
+        assert (
+            allocator.available_size() + cache.evictable_size()
+            == total - survivor_slots
+        )
+        clean = _StaleDecodeBatch([survivor], torch.tensor(step_slots[:1]))
+        assert s._drop_stale_overrun(clean) is clean
 
 
 def test_batch_is_decode():
@@ -1011,23 +1090,15 @@ class _MixedBatch:
         self.return_logprob = any(r.return_logprob for r in self.reqs)
 
 
-def _drop_stale_scheduler(freed):
-    s = OmniScheduler.__new__(OmniScheduler)
-    s.page_size = 1
-    s.server_args = types.SimpleNamespace(disable_radix_cache=False)
-    s.token_to_kv_pool_allocator = types.SimpleNamespace(
-        free=lambda t: freed.extend(t.tolist())
-    )
-    return s
+def _drop_stale_scheduler():
+    return OmniScheduler.__new__(OmniScheduler)
 
 
 def test_drop_stale_overrun_mixed_reslices_per_token():
-    freed = []
-    s = _drop_stale_scheduler(freed)
+    s = _drop_stale_scheduler()
     batch = _MixedBatch(lens=[3, 1, 1], done=[False, True, False])
     out = s._drop_stale_overrun(batch)
     assert out is batch
-    assert freed == [103]
     assert out.out_cache_loc.tolist() == [100, 101, 102, 104]
     assert out.input_ids.tolist() == [0, 1, 2, 4]
     assert out.extend_lens == [3, 1]
@@ -1037,11 +1108,9 @@ def test_drop_stale_overrun_mixed_reslices_per_token():
 
 
 def test_drop_stale_overrun_extend_multitoken_drop():
-    freed = []
-    s = _drop_stale_scheduler(freed)
+    s = _drop_stale_scheduler()
     batch = _MixedBatch(lens=[2, 3], done=[True, False])
     out = s._drop_stale_overrun(batch)
-    assert freed == [100, 101]
     assert out.out_cache_loc.tolist() == [102, 103, 104]
     assert out.input_ids.tolist() == [2, 3, 4]
     assert out.extend_lens == [3]
@@ -1050,21 +1119,19 @@ def test_drop_stale_overrun_extend_multitoken_drop():
 
 
 def test_drop_stale_overrun_reslices_deferred_prefill_tokens():
-    freed = []
-    s = _drop_stale_scheduler(freed)
+    s = _drop_stale_scheduler()
     batch = _MixedBatch(lens=[2, 3], done=[True, False])
     batch.prefill_input_ids_cpu = batch.input_ids
     batch.input_ids = None
 
     out = s._drop_stale_overrun(batch)
 
-    assert freed == [100, 101]
     assert out.input_ids is None
     assert out.prefill_input_ids_cpu.tolist() == [2, 3, 4]
 
 
 def test_drop_stale_overrun_rejects_mixed_deferred_prefill():
-    s = _drop_stale_scheduler([])
+    s = _drop_stale_scheduler()
     batch = _MixedBatch(lens=[2, 3], done=[True, False])
     batch.mix_running_indices = torch.tensor([1])
 
@@ -1073,8 +1140,7 @@ def test_drop_stale_overrun_rejects_mixed_deferred_prefill():
 
 
 def test_drop_stale_overrun_reslices_logprob_token_ids():
-    freed = []
-    s = _drop_stale_scheduler(freed)
+    s = _drop_stale_scheduler()
     batch = _MixedBatch(
         lens=[3, 2, 2],
         done=[False, True, False],
@@ -1089,8 +1155,7 @@ def test_drop_stale_overrun_reslices_logprob_token_ids():
 
 
 def test_drop_stale_overrun_drops_last_logprob_req():
-    freed = []
-    s = _drop_stale_scheduler(freed)
+    s = _drop_stale_scheduler()
     batch = _MixedBatch(lens=[2, 2], done=[True, False], logprob=[True, False])
     out = s._drop_stale_overrun(batch)
     assert out.return_logprob is False
@@ -1099,8 +1164,7 @@ def test_drop_stale_overrun_drops_last_logprob_req():
 
 def test_drop_stale_overrun_filters_decoding_reqs():
     # dropped folded-decode row must also be removed from decoding_reqs
-    freed = []
-    s = _drop_stale_scheduler(freed)
+    s = _drop_stale_scheduler()
     batch = _MixedBatch(lens=[3, 1, 1], done=[False, True, False])
     batch.decoding_reqs = [batch.reqs[1], batch.reqs[2]]
     live_decode = batch.reqs[2]

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -569,10 +569,11 @@ def test_omni_scheduler_fast_path_drops_retracted_req() -> None:
     """The synchronous fast path runs after _resolve_pending_async, whose drain can
     retract a req still present in the stale batch. The fast path must drop finished
     AND retracted reqs (not only finished) before run_batch, or a retracted req is
-    forwarded/finalized again and re-frees its already-freed KV.
+    forwarded/finalized again. The dropped rows' step slots are not freed here:
+    the drain's release_kv_cache already covered them (see the real-pool test in
+    test_async_decode.py).
     """
     captured: dict = {}
-    freed: list[int] = []
 
     class FakeBatch:
         def __init__(self, reqs):
@@ -587,11 +588,6 @@ def test_omni_scheduler_fast_path_drops_retracted_req() -> None:
             self.out_cache_loc = None
 
     scheduler = object.__new__(OmniScheduler)
-    scheduler.page_size = 1
-    scheduler.server_args = SimpleNamespace(disable_radix_cache=False)
-    scheduler.token_to_kv_pool_allocator = SimpleNamespace(
-        free=lambda t: freed.extend(t.tolist())
-    )
     keep = SimpleNamespace(rid="keep", finished=lambda: False, is_retracted=False)
     retr = SimpleNamespace(rid="retr", finished=lambda: False, is_retracted=True)
 
@@ -600,21 +596,16 @@ def test_omni_scheduler_fast_path_drops_retracted_req() -> None:
     assert captured["keep_indices"] == [0]
     assert [r.rid for r in out.reqs] == ["keep"]
     assert out.out_cache_loc.tolist() == [100]
-    assert freed == [101]
 
     # all dropped -> None so run_batch is skipped
-    freed.clear()
     fin = SimpleNamespace(rid="fin", finished=lambda: True, is_retracted=False)
     assert scheduler._drop_stale_overrun(FakeBatch([retr, fin])) is None
-    assert freed == [100, 101]
 
     # nothing stale -> batch returned unchanged, filter_batch never called
     captured.clear()
-    freed.clear()
     clean = FakeBatch([keep])
     assert scheduler._drop_stale_overrun(clean) is clean
     assert "keep_indices" not in captured
-    assert freed == []
 
 
 def test_omni_scheduler_abort_propagates_immediate_kv_cleanup_failure(


### PR DESCRIPTION
## Motivation

With async decode, a request that finishes at step N is already inside launched step N+1 (the lookahead overrun). `_drop_stale_overrun` removes such rows from a batch built before the drain, and since #966 it also freed the row's step slot (`_free_overrun_step_slots`, gated to RadixCache with page_size 1) on the assumption that the finish path truncated below that slot.

Under sglang 0.5.16 that assumption no longer holds. `prepare_for_decode` bumps `req.kv_committed_len` over the allocated step slot, and `release_kv_cache` hands the full committed range to `cache_finished_req` and frees any tail up to `kv_allocated_len`, so the slot is accounted exactly once by upstream. Upstream's overlap loop has the same overrun and deliberately adds no compensating free (`batch_result_processor.py`: "all the over-allocated tokens will be freed in `release_kv_cache`"). Omni's extra free therefore puts a slot that the radix tree already owns onto the free list: two owners for one KV page, silent.

## Modifications

- Remove `_free_overrun_step_slots`, both call sites and the `drop_tokens` bookkeeping in `_drop_stale_overrun`; document why no compensating free is needed.
- Tests: a real-pool regression (`RadixCache`, page_size 1, real `Req`s) that drains a finished row (`release_kv_cache`, insert) and a retracted row (`release_kv_cache`, no insert), then runs the real `_drop_stale_overrun` on the stale batch holding their committed step slots and asserts exact ownership: allocator plus radix accounting equals total, the finished row's slot is in the tree exactly once, the retracted row's slot is on the free list exactly once, the survivor's slot is neither. It fails on the parent (two phantom pages) and passes here. `test_scheduler.py`'s fast-path drop test keeps the drop semantics and no longer expects a compensating free.

Known follow-up, not in this PR: on the sync fast path the stale row's step slot was committed by `prepare_for_decode` before the drain released the request, so `release_kv_cache` inserts that never-forwarded slot into the radix tree keyed by prompt plus outputs plus EOS. Before this PR the same slot was also on the free list (double owned); after it the slot is single-owned but its KV content was never written. Reachable only on the same min-batch-size-2 transition; the fix is to not commit the stale slot for a row that will not be forwarded (roll back before the drain, or forward the row and skip its result as upstream's overlap loop does).

## Related Issues

Follow-up to #966 after the 0.5.16 bump.

## Accuracy Test

`pytest -q tests/unit_test/pipeline/test_async_decode.py`: 31 passed, 3 skipped. Full unit tree (`--continue-on-collection-errors`) failure and error set identical to main at `dd41c4e8` (pre-existing environment failures only).

H100 proof (ARK-ASR-3B, SeedTTS EN, concurrency 2, RadixCache on, one pass per arm), with an experiment-only idle accounting check (upstream's `SchedulerInvariantChecker._check_all_pools` called at scheduler idle) on both arms:

- This branch: 1088/1088, WER 0.0112, accounting clean.
- Same branch with the removal reverted (free restored) and an experiment-only counter on the free: the free ran 16 times on 16 distinct slots; the accounting check reported `memory leak detected` 73 times, the first at the same timestamp as the first free; it settled at `available + evictable = total + 16` at idle. Each restored free adds exactly one phantom page.

The path is reachable only on models with `async_decode_min_batch_size` 2 and RadixCache on (Whisper has RadixCache disabled; Qwen3-ASR uses min batch size 1), which is why the ArkASR concurrency-2 workload is the reproducer.

## Benchmark & Profiling

No steady-path change; throughput on the proof runs was sanity only (fix 19.06 req/s vs reverted 18.56 req/s at c2, not a comparison).
