### PR TITLE
perf(s2pro): support configurable initial codec chunks

### DIFF
--- a/sglang_omni/models/fishaudio_s2_pro/request_builders.py
+++ b/sglang_omni/models/fishaudio_s2_pro/request_builders.py
@@ -14,6 +14,7 @@ from sglang_omni.models.fishaudio_s2_pro.payload_types import S2ProState
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
+from sglang_omni.scheduling.streaming_vocoder import INITIAL_CODEC_CHUNK_FRAMES_PARAM
 
 _S2PRO_GRAPH_TOP_K = 30
 
@@ -41,6 +42,7 @@ class S2ProSGLangRequestData(SGLangARRequestData):
     semantic_history_count: int = 0
     last_codebook_values: Any = None
     latest_stream_code_chunk: torch.Tensor | None = None
+    stream_metadata: dict[str, Any] | None = None
     finish_reason: str | None = None
     engine_start_s: float = 0.0
 
@@ -55,6 +57,24 @@ def validate_s2pro_top_k(top_k: int) -> None:
         raise ValueError(
             f"S2-Pro top_k must be -1 or between 1 and {_S2PRO_GRAPH_TOP_K}; got {top_k}"
         )
+
+
+def _build_s2pro_stream_metadata(params: Any) -> dict[str, Any] | None:
+    if not isinstance(params, dict) or not params.get("stream"):
+        return None
+    metadata: dict[str, Any] = {"modality": "audio_codes"}
+    value = params.get(INITIAL_CODEC_CHUNK_FRAMES_PARAM)
+    if value is not None:
+        try:
+            frames = int(value)
+        except (TypeError, ValueError) as exc:
+            raise TypeError(
+                f"{INITIAL_CODEC_CHUNK_FRAMES_PARAM} must be an integer"
+            ) from exc
+        if frames < 0:
+            raise ValueError(f"{INITIAL_CODEC_CHUNK_FRAMES_PARAM} must be >= 0")
+        metadata[INITIAL_CODEC_CHUNK_FRAMES_PARAM] = frames
+    return metadata
 
 
 def _ref_vq_fingerprint(vq_parts: list[torch.Tensor] | None) -> str | None:
@@ -191,6 +211,7 @@ def make_tts_scheduler_adapters(
         )
         req_data.engine_start_s = time.perf_counter()
         req_data.stage_payload = payload
+        req_data.stream_metadata = _build_s2pro_stream_metadata(payload.request.params)
         return req_data
 
     def result_adapter(data: S2ProSGLangRequestData) -> StagePayload:
@@ -209,7 +230,12 @@ def make_tts_scheduler_adapters(
         request_id: str, data: S2ProSGLangRequestData, req_output: Any
     ) -> list[OutgoingMessage]:
         del req_output
-        if not data.stage_payload.request.params.get("stream"):
+        stream_metadata = getattr(data, "stream_metadata", None)
+        if stream_metadata is None:
+            stream_metadata = _build_s2pro_stream_metadata(
+                data.stage_payload.request.params
+            )
+        if stream_metadata is None:
             return []
         codes = data.latest_stream_code_chunk
         if codes is None:
@@ -221,7 +247,7 @@ def make_tts_scheduler_adapters(
                 type="stream",
                 data=codes,
                 target="vocoder",
-                metadata={"modality": "audio_codes"},
+                metadata=stream_metadata,
             )
         ]
 

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -14,6 +14,12 @@ from typing import Any
 import torch
 
 from sglang_omni.models.fishaudio_s2_pro.payload_types import S2ProState
+from sglang_omni.models.fishaudio_s2_pro.streaming_vocoder import (
+    DEFAULT_S2PRO_INITIAL_CHUNK_FRAMES,
+    DEFAULT_S2PRO_STREAM_FOLLOWUP_STRIDE,
+    DEFAULT_S2PRO_STREAM_STRIDE,
+    S2ProVocoderScheduler,
+)
 from sglang_omni.preprocessing.cache_key import hash_bytes as _hash_bytes
 from sglang_omni.preprocessing.cache_key import (
     reference_path_cache_key as _reference_path_cache_key,
@@ -334,15 +340,12 @@ def create_vocoder_executor(
     gpu_id: int | None = None,
     max_batch_size: int = 8,
     max_batch_wait_ms: int = 2,
-    stream_stride: int = 40,
-    stream_followup_stride: int = 45,
+    stream_stride: int = DEFAULT_S2PRO_STREAM_STRIDE,
+    stream_followup_stride: int = DEFAULT_S2PRO_STREAM_FOLLOWUP_STRIDE,
+    initial_chunk_frames: int = DEFAULT_S2PRO_INITIAL_CHUNK_FRAMES,
     stream_overlap_tokens: int | None = 20,
     stream_crossfade_samples: int = 512,
 ):
-    from sglang_omni.models.fishaudio_s2_pro.streaming_vocoder import (
-        S2ProVocoderScheduler,
-    )
-
     if device is None:
         device = f"cuda:{gpu_id}" if gpu_id is not None else "cpu"
     checkpoint_dir = _resolve_checkpoint(model_path)
@@ -353,6 +356,7 @@ def create_vocoder_executor(
         device=device,
         stream_stride=stream_stride,
         stream_followup_stride=stream_followup_stride,
+        initial_chunk_frames=initial_chunk_frames,
         stream_overlap_tokens=stream_overlap_tokens,
         stream_crossfade_samples=stream_crossfade_samples,
         max_batch_size=max_batch_size,

--- a/sglang_omni/models/fishaudio_s2_pro/streaming_vocoder.py
+++ b/sglang_omni/models/fishaudio_s2_pro/streaming_vocoder.py
@@ -15,9 +15,14 @@ from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.pipeline_state import build_usage
 from sglang_omni.scheduling.streaming_simple_scheduler import StreamingSimpleScheduler
+from sglang_omni.scheduling.streaming_vocoder import resolve_initial_codec_chunk_frames
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_S2PRO_STREAM_STRIDE = 40
+DEFAULT_S2PRO_STREAM_FOLLOWUP_STRIDE = 45
+DEFAULT_S2PRO_INITIAL_CHUNK_FRAMES = 0
 
 
 @dataclass
@@ -28,6 +33,7 @@ class _StreamVocoderState:
     next_vocode_tokens: int = 0
     pending_tail: torch.Tensor | None = None
     total_tokens: int = 0
+    initial_chunk_frames: int | None = None
 
 
 def resolve_stream_overlap_tokens(
@@ -65,7 +71,14 @@ def build_stream_vocoder_chunk(
     total_tokens = state.total_tokens + int(codes.shape[1])
     state.total_tokens = total_tokens
 
-    next_vocode_tokens = state.next_vocode_tokens or stream_stride
+    next_vocode_tokens = state.next_vocode_tokens
+    if next_vocode_tokens <= 0:
+        initial_chunk_frames = state.initial_chunk_frames
+        next_vocode_tokens = (
+            initial_chunk_frames
+            if initial_chunk_frames is not None and initial_chunk_frames > 0
+            else stream_stride
+        )
     if total_tokens < next_vocode_tokens:
         state.next_vocode_tokens = next_vocode_tokens
         return None
@@ -282,8 +295,9 @@ class S2ProVocoderScheduler(StreamingSimpleScheduler):
         codec: Any,
         *,
         device: str,
-        stream_stride: int = 40,
-        stream_followup_stride: int = 45,
+        stream_stride: int = DEFAULT_S2PRO_STREAM_STRIDE,
+        stream_followup_stride: int = DEFAULT_S2PRO_STREAM_FOLLOWUP_STRIDE,
+        initial_chunk_frames: int = DEFAULT_S2PRO_INITIAL_CHUNK_FRAMES,
         stream_overlap_tokens: int | None = 20,
         stream_crossfade_samples: int = 512,
         max_batch_size: int = 8,
@@ -302,6 +316,11 @@ class S2ProVocoderScheduler(StreamingSimpleScheduler):
         self._device = torch.device(device)
         self._stream_stride = int(stream_stride)
         self._stream_followup_stride = int(stream_followup_stride)
+        self._default_initial_chunk_frames = resolve_initial_codec_chunk_frames(
+            None,
+            steady_chunk_frames=self._stream_stride,
+            default_frames=initial_chunk_frames,
+        )
         self._stream_overlap_tokens = resolve_stream_overlap_tokens(
             codec, stream_overlap_tokens
         )
@@ -323,13 +342,25 @@ class S2ProVocoderScheduler(StreamingSimpleScheduler):
         self._validate_payload_state(payload)
 
     def on_streaming_new_request(self, request_id: str, payload: StagePayload) -> None:
-        del payload
-        self._stream_states.setdefault(request_id, _StreamVocoderState())
+        state = self._stream_states.setdefault(request_id, _StreamVocoderState())
+        if state.initial_chunk_frames is None:
+            params = payload.request.params
+            state.initial_chunk_frames = resolve_initial_codec_chunk_frames(
+                params if isinstance(params, dict) else None,
+                steady_chunk_frames=self._stream_stride,
+                default_frames=self._default_initial_chunk_frames,
+            )
 
     def on_stream_chunk(
         self, request_id: str, chunk: StreamItem
     ) -> list[OutgoingMessage]:
         state = self._stream_states.setdefault(request_id, _StreamVocoderState())
+        if state.initial_chunk_frames is None:
+            state.initial_chunk_frames = resolve_initial_codec_chunk_frames(
+                chunk.metadata,
+                steady_chunk_frames=self._stream_stride,
+                default_frames=self._default_initial_chunk_frames,
+            )
         codes = chunk.data
         if not isinstance(codes, torch.Tensor):
             raise TypeError(

--- a/tests/unit_test/fishaudio_s2_pro/test_stream_metadata.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_stream_metadata.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.fishaudio_s2_pro.request_builders import (
+    make_tts_scheduler_adapters,
+)
+from sglang_omni.scheduling.streaming_vocoder import INITIAL_CODEC_CHUNK_FRAMES_PARAM
+from tests.unit_test.fixtures.fish_fakes import FakeFishTokenizer, make_s2pro_payload
+
+
+@pytest.fixture(autouse=True)
+def fast_sampling_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "sglang.srt.sampling.sampling_params.SamplingParams.normalize",
+        lambda self, tokenizer: None,
+    )
+    monkeypatch.setattr(
+        "sglang.srt.sampling.sampling_params.SamplingParams.verify",
+        lambda self, vocab_size: None,
+    )
+
+
+@pytest.mark.parametrize(
+    "override,expected",
+    [
+        (None, None),
+        (0, 0),
+        (5, 5),
+        (41, 41),
+    ],
+)
+def test_fish_stream_output_forwards_explicit_initial_chunk_override(
+    override: int | None,
+    expected: int | None,
+) -> None:
+    params = {"stream": True}
+    if override is not None:
+        params[INITIAL_CODEC_CHUNK_FRAMES_PARAM] = override
+    payload = make_s2pro_payload(params=params)
+    request_builder, _, stream_output_builder = make_tts_scheduler_adapters(
+        tokenizer=FakeFishTokenizer()
+    )
+
+    data = request_builder(payload)
+    data.latest_stream_code_chunk = torch.ones((11, 1), dtype=torch.long)
+    outputs = stream_output_builder(payload.request_id, data, None)
+
+    assert len(outputs) == 1
+    metadata = outputs[0].metadata
+    assert metadata is not None
+    if expected is None:
+        assert INITIAL_CODEC_CHUNK_FRAMES_PARAM not in metadata
+    else:
+        assert metadata[INITIAL_CODEC_CHUNK_FRAMES_PARAM] == expected
+
+    data.latest_stream_code_chunk = torch.ones((11, 1), dtype=torch.long)
+    followup = stream_output_builder(payload.request_id, data, None)
+    assert followup[0].metadata == metadata
+
+
+@pytest.mark.parametrize(
+    ("override", "error_type", "message"),
+    [
+        (-1, ValueError, f"{INITIAL_CODEC_CHUNK_FRAMES_PARAM} must be >= 0"),
+        (
+            "invalid",
+            TypeError,
+            f"{INITIAL_CODEC_CHUNK_FRAMES_PARAM} must be an integer",
+        ),
+    ],
+)
+def test_fish_request_builder_rejects_invalid_initial_chunk_override(
+    override: object,
+    error_type: type[Exception],
+    message: str,
+) -> None:
+    payload = make_s2pro_payload(
+        params={"stream": True, INITIAL_CODEC_CHUNK_FRAMES_PARAM: override}
+    )
+    request_builder, _, _ = make_tts_scheduler_adapters(tokenizer=FakeFishTokenizer())
+
+    with pytest.raises(error_type, match=message):
+        request_builder(payload)
+
+
+def test_fish_stream_output_direct_call_resolves_metadata_fallback() -> None:
+    _, _, stream_output_builder = make_tts_scheduler_adapters(
+        tokenizer=FakeFishTokenizer()
+    )
+    codes = torch.ones((11, 1), dtype=torch.long)
+    data = SimpleNamespace(
+        stage_payload=make_s2pro_payload(
+            params={"stream": True, INITIAL_CODEC_CHUNK_FRAMES_PARAM: 3}
+        ),
+        latest_stream_code_chunk=codes,
+    )
+
+    outputs = stream_output_builder("direct", data, None)
+
+    assert len(outputs) == 1
+    assert outputs[0].metadata == {
+        "modality": "audio_codes",
+        INITIAL_CODEC_CHUNK_FRAMES_PARAM: 3,
+    }
+    assert outputs[0].data is codes

--- a/tests/unit_test/fishaudio_s2_pro/test_streaming_vocoder.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_streaming_vocoder.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 import torch
 
+from sglang_omni.models.fishaudio_s2_pro import stages
 from sglang_omni.models.fishaudio_s2_pro.payload_types import S2ProState
 from sglang_omni.models.fishaudio_s2_pro.request_builders import apply_tts_result
 from sglang_omni.models.fishaudio_s2_pro.streaming_vocoder import (
@@ -21,14 +22,15 @@ from sglang_omni.models.fishaudio_s2_pro.streaming_vocoder import (
 from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling.messages import IncomingMessage
+from sglang_omni.scheduling.streaming_vocoder import INITIAL_CODEC_CHUNK_FRAMES_PARAM
 
 
 class _FakeCodec:
     sample_rate = 44100
-    frame_length = 4
     delay = 0
 
-    def __init__(self) -> None:
+    def __init__(self, *, frame_length: int = 4) -> None:
+        self.frame_length = frame_length
         self.calls: list[tuple[int, ...]] = []
 
     def from_indices(self, indices: torch.Tensor) -> torch.Tensor:
@@ -108,8 +110,13 @@ def _code(value: int = 1) -> torch.Tensor:
     return torch.full((11, 1), value, dtype=torch.long)
 
 
-def _chunk(value: int = 1) -> StreamItem:
-    return StreamItem(chunk_id=value, data=_code(value), from_stage="tts_engine")
+def _chunk(value: int = 1, *, metadata: dict | None = None) -> StreamItem:
+    return StreamItem(
+        chunk_id=value,
+        data=_code(value),
+        from_stage="tts_engine",
+        metadata=metadata,
+    )
 
 
 def _audio_tensor(payload: dict) -> torch.Tensor:
@@ -125,16 +132,24 @@ def _start_scheduler(
     *,
     stream_stride: int = 3,
     stream_followup_stride: int = 5,
+    initial_chunk_frames: int | None = None,
     stream_crossfade_samples: int = 0,
+    codec: _FakeCodec | None = None,
 ) -> tuple[S2ProVocoderScheduler, threading.Thread]:
+    initial_chunk_kwargs = (
+        {}
+        if initial_chunk_frames is None
+        else {"initial_chunk_frames": initial_chunk_frames}
+    )
     scheduler = S2ProVocoderScheduler(
-        _FakeCodec(),
+        codec or _FakeCodec(),
         device="cpu",
         stream_stride=stream_stride,
         stream_followup_stride=stream_followup_stride,
         stream_overlap_tokens=1,
         stream_crossfade_samples=stream_crossfade_samples,
         max_batch_wait_ms=1,
+        **initial_chunk_kwargs,
     )
     thread = threading.Thread(target=scheduler.start, daemon=True)
     thread.start()
@@ -167,6 +182,147 @@ def test_streaming_vocoder_chunk_cadence() -> None:
             scheduler.outbox.get(timeout=0.1)
     finally:
         _stop_scheduler(scheduler, thread)
+
+
+def test_streaming_vocoder_default_preserves_steady_then_followup_cadence() -> None:
+    scheduler, thread = _start_scheduler(stream_stride=6, stream_followup_stride=5)
+    try:
+        for value in range(1, 6):
+            scheduler.inbox.put(IncomingMessage("req", "stream_chunk", _chunk(value)))
+        with pytest.raises(queue.Empty):
+            scheduler.outbox.get(timeout=0.1)
+
+        scheduler.inbox.put(IncomingMessage("req", "stream_chunk", _chunk(6)))
+        first = scheduler.outbox.get(timeout=2.0)
+        assert first.type == "stream"
+        assert _audio_len(first.data) == 24
+
+        for value in range(7, 11):
+            scheduler.inbox.put(IncomingMessage("req", "stream_chunk", _chunk(value)))
+        with pytest.raises(queue.Empty):
+            scheduler.outbox.get(timeout=0.1)
+
+        scheduler.inbox.put(IncomingMessage("req", "stream_chunk", _chunk(11)))
+        followup = scheduler.outbox.get(timeout=2.0)
+        assert followup.type == "stream"
+    finally:
+        _stop_scheduler(scheduler, thread)
+
+
+def test_streaming_vocoder_consumes_initial_chunk_override_before_payload() -> None:
+    scheduler, thread = _start_scheduler(stream_stride=6, stream_followup_stride=5)
+    metadata = {INITIAL_CODEC_CHUNK_FRAMES_PARAM: 2}
+    try:
+        scheduler.inbox.put(
+            IncomingMessage("req", "stream_chunk", _chunk(1, metadata=metadata))
+        )
+        with pytest.raises(queue.Empty):
+            scheduler.outbox.get(timeout=0.1)
+
+        scheduler.inbox.put(
+            IncomingMessage("req", "stream_chunk", _chunk(2, metadata=metadata))
+        )
+        first = scheduler.outbox.get(timeout=2.0)
+        assert first.type == "stream"
+        assert _audio_len(first.data) == 8
+    finally:
+        _stop_scheduler(scheduler, thread)
+
+
+def test_initial_chunk_override_clamps_to_custom_steady_stride() -> None:
+    scheduler, thread = _start_scheduler(stream_stride=45)
+    metadata = {INITIAL_CODEC_CHUNK_FRAMES_PARAM: 100}
+    first_codes = torch.ones((11, 44), dtype=torch.long)
+    try:
+        scheduler.inbox.put(
+            IncomingMessage(
+                "req",
+                "stream_chunk",
+                StreamItem(
+                    chunk_id=1,
+                    data=first_codes,
+                    from_stage="tts_engine",
+                    metadata=metadata,
+                ),
+            )
+        )
+        with pytest.raises(queue.Empty):
+            scheduler.outbox.get(timeout=0.1)
+
+        scheduler.inbox.put(
+            IncomingMessage("req", "stream_chunk", _chunk(45, metadata=metadata))
+        )
+        first = scheduler.outbox.get(timeout=2.0)
+        assert first.type == "stream"
+        assert _audio_len(first.data) == 45 * 4
+    finally:
+        _stop_scheduler(scheduler, thread)
+
+
+def test_zero_initial_chunk_override_uses_steady_stride() -> None:
+    scheduler, thread = _start_scheduler(stream_stride=6, stream_followup_stride=5)
+    metadata = {INITIAL_CODEC_CHUNK_FRAMES_PARAM: 0}
+    try:
+        for value in range(1, 6):
+            scheduler.inbox.put(
+                IncomingMessage(
+                    "req",
+                    "stream_chunk",
+                    _chunk(value, metadata=metadata),
+                )
+            )
+        with pytest.raises(queue.Empty):
+            scheduler.outbox.get(timeout=0.1)
+
+        scheduler.inbox.put(
+            IncomingMessage("req", "stream_chunk", _chunk(6, metadata=metadata))
+        )
+        first = scheduler.outbox.get(timeout=2.0)
+        assert first.type == "stream"
+        assert _audio_len(first.data) == 24
+    finally:
+        _stop_scheduler(scheduler, thread)
+
+
+def test_four_frame_initial_chunk_crossfade_preserves_final_length() -> None:
+    scheduler, thread = _start_scheduler(
+        stream_stride=6,
+        stream_followup_stride=5,
+        initial_chunk_frames=4,
+        stream_crossfade_samples=512,
+        codec=_FakeCodec(frame_length=512),
+    )
+    try:
+        for value in range(1, 5):
+            scheduler.inbox.put(IncomingMessage("req", "stream_chunk", _chunk(value)))
+        first = scheduler.outbox.get(timeout=2.0)
+
+        scheduler.inbox.put(IncomingMessage("req", "new_request", _payload("req")))
+        scheduler.inbox.put(IncomingMessage("req", "stream_done"))
+        flush = scheduler.outbox.get(timeout=2.0)
+        final = scheduler.outbox.get(timeout=2.0)
+
+        assert first.type == flush.type == "stream"
+        assert _audio_len(first.data) + _audio_len(flush.data) == 4 * 512
+        assert final.type == "result"
+    finally:
+        _stop_scheduler(scheduler, thread)
+
+
+def test_vocoder_factory_forwards_initial_chunk_frames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    codec = _FakeCodec()
+    monkeypatch.setattr(stages, "_resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(stages, "_load_codec", lambda checkpoint, device: codec)
+
+    scheduler = stages.create_vocoder_executor(
+        "unused",
+        device="cpu",
+        initial_chunk_frames=2,
+    )
+
+    assert scheduler._default_initial_chunk_frames == 2
 
 
 def test_streaming_vocoder_sample_level_matches_contextual_full_decode() -> None:


### PR DESCRIPTION
## Motivation

S2-Pro used the steady streaming-vocoder stride (`40` codec frames) as its first decode threshold. The repository already provides `resolve_initial_codec_chunk_frames` for separating a model default or request override from the steady chunk size, and Zonos2/Higgs TTS already use that capability.

This ports the same lifecycle to S2-Pro without choosing a model-specific latency policy: the vocoder owns resolution against its actual steady stride, while the producer only carries an explicit request override. The default remains disabled (`0`), which preserves the existing 40-frame first threshold; an engine configuration or request can opt into a smaller first chunk.

## Modifications

- Add `initial_chunk_frames=0` to the S2-Pro vocoder scheduler and stage factory. Zero preserves the existing steady-stride first chunk.
- Resolve the per-request value from the first stream chunk metadata, including when chunks arrive before the terminal payload; fall back to request params when the payload arrives first.
- Validate and cache explicit `initial_codec_chunk_frames` request metadata in the TTS request adapter without applying an irreversible producer-side clamp. The vocoder remains the single clamp authority because it owns the actual `stream_stride`.
- Preserve `0` as the opt-out that uses the steady stride, and retain the existing `stream_followup_stride=45`, overlap, crossfade, and non-streaming paths.
- Add CPU regressions for unchanged default cadence, explicit override cadence, custom-stride clamping, invalid values, metadata reuse, chunk-before-payload ordering, stage forwarding, direct-call compatibility, and an explicitly configured 4-frame/512-sample crossfade plus final-flush length check.

## Related Issues

None. This is independent of #1570 and has no merge dependency on it.

## Accuracy Test

CPU-only focused unit tests pass without loading model weights or CUDA:

```text
35 passed
```

The crossfade regression explicitly configures 4 codec frames at 512 samples/frame with a 512-sample crossfade holdback. The first emitted chunk plus the final flush preserves all 2048 samples.

No codec weights are available in the public development environment, so model-level audio quality remains for maintainer CI or follow-up hardware validation.

## Benchmark & Profiling

This PR makes the initial scheduler boundary configurable while preserving the upstream default:

| S2-Pro streaming threshold | Before | After |
| --- | ---: | ---: |
| First codec chunk, unconfigured | 40 frames | 40 frames |
| First codec chunk, explicit override `4` | Not supported | 4 frames |
| Steady stride | 40 frames | 40 frames |
| Follow-up stride | 45 frames | 45 frames |

With an explicit override of 4, the first decode waits for 36 fewer generated codec frames by construction. This is opt-in: the PR makes no default latency change and does not claim a quantified end-to-end TTFA, RTF, or audio-quality result because no public H20 run was performed.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed. (No separate user-facing API documentation is required.)
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed. (Deterministic cadence and CPU contract tests are reported above; no end-to-end hardware claim.)
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
