### PR TITLE
[Docs]: Refine hardware support table

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,8 @@ SGLang-Omni is a multi-stage serving runtime for omni, speech, and TTS models. I
 
 | Backend | Status | Notes |
 |---------|--------|-------|
-| **NVIDIA CUDA** | ✅ Supported | Default target; full model coverage. |
-| **Intel GPU (XPU)** | 🧪 Experimental | Intel Arc GPUs via PyTorch XPU. **Qwen3-ASR, Qwen3-TTS, and Qwen3-Omni serve end-to-end** (Omni thinker via multi-XPU tensor parallelism). Install per [Intel XPU guide](./docs/get_started/installation_xpu.md); the backend is auto-detected. |
-
-See [Installation — Intel XPU](./docs/get_started/installation_xpu.md).
+| **NVIDIA CUDA** | Supported | Default backend with full model coverage. |
+| **Intel GPU (XPU)** | Experimental | Intel Arc GPUs via PyTorch XPU. **Qwen3-ASR, Qwen3-TTS, and Qwen3-Omni serve end-to-end** (Omni thinker via multi-XPU tensor parallelism). Install per [Intel XPU guide](./docs/get_started/installation_xpu.md); the backend is auto-detected. |
 
 Additional model guides, including experimental and research-oriented paths, are available in the [Cookbook](https://sgl-project.github.io/sglang-omni/cookbook/).
 


### PR DESCRIPTION
## Motivation

The front-facing hardware support table uses decorative status emojis and repeats the Intel XPU installation link immediately below the table. This keeps the section direct and consistent while preserving its support information.

## Modifications

- Remove the status emojis from the NVIDIA CUDA and Intel XPU rows while retaining their written support levels.
- Replace the fragmented NVIDIA note with "Default backend with full model coverage."
- Remove the duplicate Intel XPU installation sentence; the same guide remains linked in the XPU row.

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the `run-ci` label.
