### PR TITLE
[Perf][ARK-ASR] Fuse audio encoder QKV projections

### DIFF
--- a/sglang_omni/models/arkasr/audio_tower.py
+++ b/sglang_omni/models/arkasr/audio_tower.py
@@ -10,9 +10,14 @@ layers -> LayerNorm -> (merge_factor frame merge) -> 2-layer MLP to LLM hidden.
 
 from __future__ import annotations
 
+import math
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from sglang.srt.layers.linear import QKVParallelLinear, RowParallelLinear
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.utils import add_prefix
 from torch.nn.functional import scaled_dot_product_attention
 from transformers import WhisperConfig
 from transformers.models.whisper.modeling_whisper import WhisperEncoderLayer
@@ -68,25 +73,56 @@ def apply_rotary_pos_emb(x: torch.Tensor, rope_cache: torch.Tensor) -> torch.Ten
 class WhisperRoPESdpaAttention(nn.Module):
     """Whisper self-attention with RoPE, SDPA backend (matches checkpoint)."""
 
-    def __init__(self, embed_dim: int, num_heads: int, dropout: float = 0.0):
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        dropout: float = 0.0,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
         super().__init__()
         self.embed_dim = embed_dim
         self.num_heads = num_heads
         self.dropout = dropout
         self.head_dim = embed_dim // num_heads
-        self.q_proj = nn.Linear(embed_dim, embed_dim)
-        self.k_proj = nn.Linear(embed_dim, embed_dim, bias=False)
-        self.v_proj = nn.Linear(embed_dim, embed_dim)
-        self.out_proj = nn.Linear(embed_dim, embed_dim)
+        self.qkv_proj = QKVParallelLinear(
+            embed_dim,
+            self.head_dim,
+            num_heads,
+            bias=True,
+            quant_config=quant_config,
+            prefix=add_prefix("qkv_proj", prefix),
+        )
+        self.out_proj = RowParallelLinear(
+            embed_dim,
+            embed_dim,
+            bias=True,
+            quant_config=quant_config,
+            prefix=add_prefix("out_proj", prefix),
+        )
+        if quant_config is None:
+            self.reset_parameters()
         self.is_causal = False
+
+    def reset_parameters(self) -> None:
+        """Match the former nn.Linear initialization for standalone use."""
+        nn.init.kaiming_uniform_(self.qkv_proj.weight, a=math.sqrt(5))
+        nn.init.kaiming_uniform_(self.out_proj.weight, a=math.sqrt(5))
+        bound = 1 / math.sqrt(self.embed_dim)
+        if self.qkv_proj.bias is not None:
+            nn.init.uniform_(self.qkv_proj.bias, -bound, bound)
+            # The checkpoint has no K bias; keep the packed K slice equivalent.
+            nn.init.zeros_(self.qkv_proj.bias[self.embed_dim : 2 * self.embed_dim])
+        if self.out_proj.bias is not None:
+            nn.init.uniform_(self.out_proj.bias, -bound, bound)
 
     def forward(
         self, hidden_states, attention_mask=None, rotary_pos_emb=None, **kwargs
     ):
         bsz, q_len, _ = hidden_states.size()
-        q = self.q_proj(hidden_states)
-        k = self.k_proj(hidden_states)
-        v = self.v_proj(hidden_states)
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v = qkv.chunk(3, dim=-1)
         q = (
             q.view(bsz, q_len, self.num_heads, self.head_dim)
             .transpose(1, 2)
@@ -97,26 +133,30 @@ class WhisperRoPESdpaAttention(nn.Module):
         if rotary_pos_emb is not None:
             q = apply_rotary_pos_emb(q, rotary_pos_emb)
             k = apply_rotary_pos_emb(k, rotary_pos_emb)
-        target_dtype = self.q_proj.weight.dtype
-        q = q.to(target_dtype)
-        k = k.to(target_dtype)
-        v = v.to(target_dtype)
         attn = scaled_dot_product_attention(
             q, k, v, attn_mask=attention_mask, dropout_p=0.0, is_causal=self.is_causal
         )
         attn = attn.transpose(1, 2).contiguous().reshape(bsz, q_len, self.embed_dim)
-        return self.out_proj(attn), None, None
+        attn, _ = self.out_proj(attn)
+        return attn, None, None
 
 
 class WhisperSpecialEncoderLayer(WhisperEncoderLayer):
     """WhisperEncoderLayer with the self-attn swapped for the RoPE SDPA variant."""
 
-    def __init__(self, config: WhisperConfig):
+    def __init__(
+        self,
+        config: WhisperConfig,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
         super().__init__(config)
         self.self_attn = WhisperRoPESdpaAttention(
             embed_dim=self.embed_dim,
             num_heads=config.encoder_attention_heads,
             dropout=config.attention_dropout,
+            quant_config=quant_config,
+            prefix=add_prefix("self_attn", prefix),
         )
 
     def forward(
@@ -157,7 +197,12 @@ class ArkAudioTower(nn.Module):
     Consumes mel features (B, num_mel_bins, T) and returns (B, T_down, d_model).
     """
 
-    def __init__(self, config):
+    def __init__(
+        self,
+        config,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
         super().__init__()
         wc = config.whisper_config
         embed_dim = wc.d_model
@@ -167,7 +212,14 @@ class ArkAudioTower(nn.Module):
         self.embed_positions = nn.Embedding(wc.max_source_positions, embed_dim)
         self.embed_positions.requires_grad_(False)
         self.layers = nn.ModuleList(
-            [WhisperSpecialEncoderLayer(wc) for _ in range(wc.encoder_layers)]
+            [
+                WhisperSpecialEncoderLayer(
+                    wc,
+                    quant_config=quant_config,
+                    prefix=add_prefix(f"layers.{index}", prefix),
+                )
+                for index in range(wc.encoder_layers)
+            ]
         )
         self.use_rope = bool(getattr(config, "use_rope", True))
         if self.use_rope:
@@ -250,11 +302,20 @@ class ArkAudioTower(nn.Module):
 class ArkAudioMLPAdapter(nn.Module):
     """Whisper tower + merge_factor frame-merge + 2-layer MLP to LLM hidden."""
 
-    def __init__(self, config):
+    def __init__(
+        self,
+        config,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
         super().__init__()
         wc = config.whisper_config
         self.merge_factor = int(config.merge_factor)
-        self.whisper = ArkAudioTower(config)
+        self.whisper = ArkAudioTower(
+            config,
+            quant_config=quant_config,
+            prefix=add_prefix("whisper", prefix),
+        )
         self.layer_norm = nn.LayerNorm(wc.hidden_size)
         act_map = {"gelu": nn.GELU(), "relu": nn.ReLU(), "selu": nn.SELU()}
         act = act_map.get(getattr(config, "mlp_adapter_act", "gelu"), nn.GELU())

--- a/sglang_omni/models/arkasr/sglang_model.py
+++ b/sglang_omni/models/arkasr/sglang_model.py
@@ -46,7 +46,11 @@ class ArkasrForConditionalGeneration(nn.Module):
         self.audio_token_id = int(getattr(config, "audio_token_id", 151663))
 
         # audio_encoder = whisper tower + MLP frame-merge adapter (checkpoint name)
-        self.audio_encoder = ArkAudioMLPAdapter(config)
+        self.audio_encoder = ArkAudioMLPAdapter(
+            config,
+            quant_config=quant_config,
+            prefix=add_prefix("audio_encoder", prefix),
+        )
         self.language_model = Qwen2ForCausalLM(
             config,
             quant_config,
@@ -197,8 +201,35 @@ class ArkasrForConditionalGeneration(nn.Module):
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
         ]
+        audio_stacked_params = [
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+        ]
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         tie = bool(getattr(self.config, "tie_word_embeddings", False))
+
+        def load_audio_weight(name: str, loaded_weight: torch.Tensor) -> None:
+            for param_name, weight_name, shard_id in audio_stacked_params:
+                if weight_name not in name:
+                    continue
+                mapped = name.replace(weight_name, param_name)
+                if mapped.endswith(".bias") and mapped not in params_dict:
+                    return
+                if mapped not in params_dict:
+                    logger.debug("arkasr: skip unmatched audio weight %s", name)
+                    return
+                param = params_dict[mapped]
+                param.weight_loader(param, loaded_weight, shard_id)
+                return
+
+            if name.endswith(".bias") and name not in params_dict:
+                return
+            if name not in params_dict:
+                logger.debug("arkasr: skip unmatched audio weight %s", name)
+                return
+            param = params_dict[name]
+            getattr(param, "weight_loader", default_weight_loader)(param, loaded_weight)
 
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
@@ -217,17 +248,16 @@ class ArkasrForConditionalGeneration(nn.Module):
                     name = "language_model." + name
 
             if is_audio:
-                # audio tower params load directly (no qkv stacking: q/k/v are separate
-                # Linear layers in WhisperRoPESdpaAttention, matching the checkpoint)
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-                if name not in params_dict:
-                    logger.debug("arkasr: skip unmatched audio weight %s", name)
-                    continue
-                param = params_dict[name]
-                getattr(param, "weight_loader", default_weight_loader)(
-                    param, loaded_weight
-                )
+                load_audio_weight(name, loaded_weight)
+                if name.endswith(".self_attn.k_proj.weight"):
+                    load_audio_weight(
+                        name[: -len("weight")] + "bias",
+                        torch.zeros(
+                            loaded_weight.shape[0],
+                            dtype=loaded_weight.dtype,
+                            device=loaded_weight.device,
+                        ),
+                    )
                 continue
 
             for param_name, weight_name, shard_id in llm_stacked_params:

--- a/tests/unit_test/arkasr/conftest.py
+++ b/tests/unit_test/arkasr/conftest.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Iterator
+
+import pytest
+import sglang.srt.layers.linear as sglang_linear
+from sglang.srt.runtime_context import get_parallel
+
+
+@pytest.fixture(autouse=True)
+def _tp1_parallel_context(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Run CPU ARK model tests with the production stage's TP=1 topology."""
+    # RowParallelLinear enters the symmetric-memory context even at TP=1.
+    # CPU tests have no process group; the object is unused when symmetric
+    # allocation is disabled.
+    monkeypatch.setattr(sglang_linear, "get_tp_group", lambda: object())
+    with get_parallel().override(tp_rank=0, tp_size=1):
+        yield

--- a/tests/unit_test/arkasr/test_fused_projection.py
+++ b/tests/unit_test/arkasr/test_fused_projection.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Numerical parity tests for ARK-ASR audio projection fusion."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.nn.functional import scaled_dot_product_attention
+from transformers import WhisperConfig
+
+import sglang_omni.models.arkasr.audio_tower as audio_tower
+from sglang_omni.models.arkasr.configuration_arkasr import ArkasrConfig
+from sglang_omni.models.arkasr.sglang_model import ArkasrForConditionalGeneration
+
+
+def _tiny_config(*, use_rope: bool) -> ArkasrConfig:
+    whisper = WhisperConfig(
+        d_model=32,
+        encoder_layers=2,
+        encoder_attention_heads=4,
+        encoder_ffn_dim=64,
+        num_mel_bins=8,
+        max_source_positions=64,
+    )
+    return ArkasrConfig(
+        whisper_config=whisper,
+        merge_factor=4,
+        use_rope=use_rope,
+        hidden_size=48,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        intermediate_size=64,
+        vocab_size=256,
+        audio_token_id=151663,
+    )
+
+
+class _UnfusedWhisperRoPESdpaAttention(nn.Module):
+    """Reference implementation matching the checkpoint's separate projections."""
+
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        dropout: float = 0.0,
+        **_: object,
+    ) -> None:
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.dropout = dropout
+        self.head_dim = embed_dim // num_heads
+        self.q_proj = nn.Linear(embed_dim, embed_dim)
+        self.k_proj = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.v_proj = nn.Linear(embed_dim, embed_dim)
+        self.out_proj = nn.Linear(embed_dim, embed_dim)
+        self.is_causal = False
+
+    def _shape(self, states: torch.Tensor) -> torch.Tensor:
+        batch_size, seq_len, _ = states.shape
+        return (
+            states.view(batch_size, seq_len, self.num_heads, self.head_dim)
+            .transpose(1, 2)
+            .contiguous()
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        rotary_pos_emb: torch.Tensor | None = None,
+        **_: object,
+    ):
+        query = self._shape(self.q_proj(hidden_states))
+        key = self._shape(self.k_proj(hidden_states))
+        value = self._shape(self.v_proj(hidden_states))
+        if rotary_pos_emb is not None:
+            query = audio_tower.apply_rotary_pos_emb(query, rotary_pos_emb)
+            key = audio_tower.apply_rotary_pos_emb(key, rotary_pos_emb)
+        target_dtype = self.q_proj.weight.dtype
+        output = scaled_dot_product_attention(
+            query.to(target_dtype),
+            key.to(target_dtype),
+            value.to(target_dtype),
+            attn_mask=attention_mask,
+            dropout_p=0.0,
+            is_causal=self.is_causal,
+        )
+        output = (
+            output.transpose(1, 2)
+            .contiguous()
+            .reshape(
+                hidden_states.shape[0],
+                hidden_states.shape[1],
+                self.embed_dim,
+            )
+        )
+        return self.out_proj(output), None, None
+
+
+def _build_reference_and_candidate(
+    monkeypatch,
+    *,
+    use_rope: bool,
+    load_packed_attention: bool = True,
+) -> tuple[nn.Module, nn.Module]:
+    config = _tiny_config(use_rope=use_rope)
+    with monkeypatch.context() as context:
+        context.setattr(
+            audio_tower,
+            "WhisperRoPESdpaAttention",
+            _UnfusedWhisperRoPESdpaAttention,
+        )
+        torch.manual_seed(7)
+        reference = audio_tower.ArkAudioMLPAdapter(config).eval()
+
+    torch.manual_seed(11)
+    candidate = audio_tower.ArkAudioMLPAdapter(config).eval()
+
+    candidate_state = candidate.state_dict()
+    shared_state = {
+        name: tensor
+        for name, tensor in reference.state_dict().items()
+        if name in candidate_state and candidate_state[name].shape == tensor.shape
+    }
+    candidate.load_state_dict(shared_state, strict=False)
+
+    if not load_packed_attention:
+        return reference, candidate
+
+    for reference_layer, candidate_layer in zip(
+        reference.whisper.layers,
+        candidate.whisper.layers,
+    ):
+        reference_attention = reference_layer.self_attn
+        candidate_attention = candidate_layer.self_attn
+        packed_weight = candidate_attention.qkv_proj.weight
+        packed_weight.weight_loader(
+            packed_weight,
+            reference_attention.q_proj.weight,
+            "q",
+        )
+        packed_weight.weight_loader(
+            packed_weight,
+            reference_attention.k_proj.weight,
+            "k",
+        )
+        packed_weight.weight_loader(
+            packed_weight,
+            reference_attention.v_proj.weight,
+            "v",
+        )
+
+        packed_bias = candidate_attention.qkv_proj.bias
+        packed_bias.weight_loader(
+            packed_bias,
+            reference_attention.q_proj.bias,
+            "q",
+        )
+        packed_bias.weight_loader(
+            packed_bias,
+            torch.zeros_like(reference_attention.q_proj.bias),
+            "k",
+        )
+        packed_bias.weight_loader(
+            packed_bias,
+            reference_attention.v_proj.bias,
+            "v",
+        )
+
+    return reference, candidate
+
+
+def test_audio_adapter_exposes_one_packed_qkv_parameter(monkeypatch) -> None:
+    _, candidate = _build_reference_and_candidate(
+        monkeypatch,
+        use_rope=True,
+    )
+    parameter_names = set(dict(candidate.named_parameters()))
+
+    for layer_index in range(2):
+        prefix = f"whisper.layers.{layer_index}.self_attn"
+        assert f"{prefix}.qkv_proj.weight" in parameter_names
+        assert f"{prefix}.q_proj.weight" not in parameter_names
+        assert f"{prefix}.k_proj.weight" not in parameter_names
+        assert f"{prefix}.v_proj.weight" not in parameter_names
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("use_rope", [True, False])
+@pytest.mark.parametrize(
+    ("dtype", "atol", "rtol"),
+    [
+        (torch.float32, 1e-5, 1e-5),
+        (torch.bfloat16, 3e-2, 3e-2),
+        (torch.float16, 3e-2, 3e-2),
+    ],
+)
+def test_fused_audio_adapter_matches_unfused_reference(
+    monkeypatch,
+    use_rope: bool,
+    dtype: torch.dtype,
+    atol: float,
+    rtol: float,
+) -> None:
+    reference, candidate = _build_reference_and_candidate(
+        monkeypatch,
+        use_rope=use_rope,
+    )
+    reference.to(dtype)
+    candidate.to(dtype)
+    torch.manual_seed(23)
+    mel = torch.randn(2, 8, 40, dtype=dtype)
+    attention_mask = torch.tensor(
+        [
+            [1] * 33 + [0] * 7,
+            [1] * 40,
+        ],
+        dtype=torch.bool,
+    )
+
+    expected = reference(mel, attention_mask=attention_mask)
+    actual = candidate(mel, attention_mask=attention_mask)
+
+    torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+
+
+@torch.no_grad()
+def test_separate_audio_checkpoint_weights_load_into_fused_adapter(
+    monkeypatch,
+) -> None:
+    reference, candidate = _build_reference_and_candidate(
+        monkeypatch,
+        use_rope=True,
+        load_packed_attention=False,
+    )
+    model = ArkasrForConditionalGeneration.__new__(ArkasrForConditionalGeneration)
+    nn.Module.__init__(model)
+    model.config = _tiny_config(use_rope=True)
+    model.audio_encoder = candidate
+
+    model.load_weights(
+        (
+            f"audio_encoder.{name}",
+            parameter.detach().clone(),
+        )
+        for name, parameter in reference.named_parameters()
+    )
+
+    packed_bias = candidate.whisper.layers[0].self_attn.qkv_proj.bias
+    embed_dim = model.config.whisper_config.d_model
+    torch.testing.assert_close(
+        packed_bias[embed_dim : 2 * embed_dim],
+        torch.zeros(embed_dim),
+        atol=0,
+        rtol=0,
+    )
+
+    torch.manual_seed(31)
+    mel = torch.randn(2, 8, 40)
+    attention_mask = torch.tensor(
+        [
+            [1] * 29 + [0] * 11,
+            [1] * 40,
+        ],
+        dtype=torch.bool,
+    )
+    expected = reference(mel, attention_mask=attention_mask)
+    actual = candidate(mel, attention_mask=attention_mask)
+
+    torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)


### PR DESCRIPTION
## Summary
- replace ARK-ASR audio encoder's separate Q/K/V projections with one `QKVParallelLinear` and a row-parallel output projection for the current TP=1 serving path
- propagate `quant_config` and stable prefixes through the audio encoder hierarchy
- load separate checkpoint Q/K/V shards into the packed parameter and synthesize the checkpoint's missing K bias as zeros
- add FP32/BF16/FP16 numerical parity and checkpoint-loading coverage

## Related
- Part of #1396
- Adapts the fused-projection approach from #1590 to ARK-ASR

## Validation
- [x] `pre-commit run --files sglang_omni/models/arkasr/audio_tower.py sglang_omni/models/arkasr/sglang_model.py tests/unit_test/arkasr/conftest.py tests/unit_test/arkasr/test_fused_projection.py`
- [x] 51 runnable ARK-ASR unit tests passed
- [x] Confirmed the four excluded factory tests fail identically on unchanged `main` in the CPU container because SGLang reports an unknown platform
- [x] Run end-to-end ARK-ASR WER and throughput benchmarks on GPU