### PR TITLE
Simplify and centralize Prefill CUDA Graph bucket policy

### DIFF
--- a/sglang_omni/models/fun_asr/engine_builder.py
+++ b/sglang_omni/models/fun_asr/engine_builder.py
@@ -18,10 +18,7 @@ from sglang_omni.models.fun_asr.tool_funcs.audio_lengths import (
     fun_asr_low_frame_rate_length,
 )
 from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
-from sglang_omni.scheduling.generation_batch_policy import (
-    CudaGraphBackend,
-    build_default_prefill_cuda_graph_bs,
-)
+from sglang_omni.scheduling.generation_batch_policy import CudaGraphBackend
 from sglang_omni.utils.gpu_compat import get_visible_gpu_sm_version
 
 logger = logging.getLogger(__name__)
@@ -109,7 +106,7 @@ class FunASREngineBuilder(AsrEngineBuilder):
             "chunked_prefill_size": 4096,
             # Qualified capture budget; longer prefills run eager.
             "cuda_graph_backend_prefill": CudaGraphBackend.BREAKABLE,
-            "cuda_graph_bs_prefill": build_default_prefill_cuda_graph_bs(256),
+            "prefill_cuda_graph_capture_budget": 256,
             "sampling_backend": "pytorch",
             "dtype": dtype,
         }

--- a/sglang_omni/models/higgs_tts/engine_builder.py
+++ b/sglang_omni/models/higgs_tts/engine_builder.py
@@ -15,10 +15,7 @@ from sglang_omni.models.higgs_tts.vocoder_scheduler import (
     DEFAULT_HIGGS_STREAM_STRIDE,
 )
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
-from sglang_omni.scheduling.generation_batch_policy import (
-    CudaGraphBackend,
-    build_default_prefill_cuda_graph_bs,
-)
+from sglang_omni.scheduling.generation_batch_policy import CudaGraphBackend
 from sglang_omni.vendor.sglang.server_args import override_server_args
 
 logger = logging.getLogger(__name__)
@@ -86,7 +83,7 @@ class HiggsTtsEngineBuilder(TtsEngineBuilder):
             "chunked_prefill_size": 8192,
             # Qualified capture budget; longer prefills run eager.
             "cuda_graph_backend_prefill": CudaGraphBackend.BREAKABLE,
-            "cuda_graph_bs_prefill": build_default_prefill_cuda_graph_bs(512),
+            "prefill_cuda_graph_capture_budget": 512,
             "dtype": "bfloat16",
         }
 

--- a/sglang_omni/models/moss_transcribe_diarize/engine_builder.py
+++ b/sglang_omni/models/moss_transcribe_diarize/engine_builder.py
@@ -12,10 +12,7 @@ from sglang_omni.models.moss_transcribe_diarize.encoder_service import (
     BatchedAudioEncoderService,
 )
 from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
-from sglang_omni.scheduling.generation_batch_policy import (
-    CudaGraphBackend,
-    build_default_prefill_cuda_graph_bs,
-)
+from sglang_omni.scheduling.generation_batch_policy import CudaGraphBackend
 
 
 class MossTranscribeDiarizeEngineBuilder(AsrEngineBuilder):
@@ -103,14 +100,6 @@ class MossTranscribeDiarizeEngineBuilder(AsrEngineBuilder):
         )
 
     def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
-        # note (Xinyu): cached-prefix extends commonly contain one or two new
-        # tokens, so keep exact graph buckets below the shared ladder's 4-token
-        # floor instead of failing the prefill padding-factor replay guard.
-        prefill_cuda_graph_bs = [
-            1,
-            2,
-            *build_default_prefill_cuda_graph_bs(4096),
-        ]
         return {
             "max_running_requests": self.max_running_requests,
             "disable_cuda_graph": False,
@@ -122,7 +111,7 @@ class MossTranscribeDiarizeEngineBuilder(AsrEngineBuilder):
             "chunked_prefill_size": 4096,
             "sampling_backend": "pytorch",
             "cuda_graph_backend_prefill": CudaGraphBackend.BREAKABLE,
-            "cuda_graph_bs_prefill": prefill_cuda_graph_bs,
+            "prefill_cuda_graph_capture_budget": 4096,
             "dtype": dtype,
         }
 

--- a/sglang_omni/models/qwen3_asr/engine_builder.py
+++ b/sglang_omni/models/qwen3_asr/engine_builder.py
@@ -21,7 +21,6 @@ from sglang_omni.models.qwen3_asr.encoder_service import (
 from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
 from sglang_omni.scheduling.generation_batch_policy import (
     CudaGraphBackend,
-    build_default_prefill_cuda_graph_bs,
     get_decode_cuda_graph_bs,
 )
 from sglang_omni.utils.gpu_compat import get_visible_gpu_sm_version
@@ -129,6 +128,7 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
             "sampling_backend": "pytorch",
             "dtype": dtype,
             "cuda_graph_backend_prefill": CudaGraphBackend.BREAKABLE,
+            "prefill_cuda_graph_capture_budget": 4096,
         }
         if self.mm_attention_backend is not None:
             defaults["mm_attention_backend"] = self.mm_attention_backend
@@ -173,25 +173,6 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
     def adjust_overrides(self, overrides: dict[str, Any]) -> None:
         if "context_length" in overrides:
             self.context_length = int(overrides.pop("context_length"))
-        if overrides.get("cuda_graph_backend_prefill") == CudaGraphBackend.DISABLED:
-            return
-        if "cuda_graph_bs_prefill" in overrides:
-            return
-        # note(ratish): derived from the merged caps: a ladder past any of
-        # them fails startup or captures buckets that can never replay.
-        caps = [
-            overrides["max_prefill_tokens"],
-            overrides.get("cuda_graph_max_bs_prefill"),
-            overrides.get("max_total_tokens"),
-            self.context_length,
-        ]
-        if overrides["chunked_prefill_size"] > 0:
-            caps.append(overrides["chunked_prefill_size"])
-        ladder = build_default_prefill_cuda_graph_bs(
-            min(int(cap) for cap in caps if cap is not None)
-        )
-        overrides["cuda_graph_bs_prefill"] = ladder
-        overrides["cuda_graph_max_bs_prefill"] = max(ladder)
 
     def customize_server_args(self, server_args: Any) -> None:
         self.context_length = int(server_args.context_length)

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -76,6 +76,7 @@ class SGLangGenerationEngineBuilder(ABC):
             server_args_overrides
         )
         overrides = build_generation_batch_overrides(
+            context_length=self.context_length,
             server_args_overrides=server_args_overrides,
             **self.generation_defaults(dtype=dtype),
         )

--- a/sglang_omni/scheduling/generation_batch_policy.py
+++ b/sglang_omni/scheduling/generation_batch_policy.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass
 from numbers import Integral
 from typing import Any
 
@@ -19,13 +18,6 @@ _MISSING = object()
 # A prefill replay falls back to eager when the padded bucket exceeds this
 # multiple of the real token count.
 _PREFILL_PADDING_FACTOR = 2
-
-
-@dataclass(frozen=True)
-class PrefillBucketAnalysis:
-    bucket_count: int
-    max_bucket: int
-    eager_valleys: tuple[tuple[int, int], ...]
 
 
 def get_decode_cuda_graph_max_bs(server_args: Any) -> Any:
@@ -149,22 +141,6 @@ def resolve_prefill_cuda_graph_buckets(
     overrides["cuda_graph_max_bs_prefill"] = max(resolved_buckets)
 
 
-def analyze_prefill_cuda_graph_buckets(
-    buckets: Iterable[int],
-) -> PrefillBucketAnalysis:
-    normalized = tuple(int(bucket) for bucket in buckets)
-    valleys = []
-    for previous, next_bucket in zip(normalized, normalized[1:]):
-        eager_end = (next_bucket - 1) // _PREFILL_PADDING_FACTOR
-        if eager_end > previous:
-            valleys.append((previous + 1, eager_end))
-    return PrefillBucketAnalysis(
-        bucket_count=len(normalized),
-        max_bucket=max(normalized),
-        eager_valleys=tuple(valleys),
-    )
-
-
 def nested_prefill_overrides(overrides: Mapping[str, Any]) -> Mapping[str, Any]:
     """Extract the prefill section of a nested cuda_graph_config override."""
     config = overrides.get("cuda_graph_config")
@@ -187,9 +163,20 @@ def build_generation_batch_overrides(
     **stage_defaults: Any,
 ) -> dict[str, Any]:
     incoming = dict(server_args_overrides or {})
+    cuda_graph_config = incoming.get("cuda_graph_config")
+    if isinstance(cuda_graph_config, CudaGraphConfig):
+        cuda_graph_config = cuda_graph_config.to_dict()
+    if isinstance(cuda_graph_config, Mapping):
+        cuda_graph_config = dict(cuda_graph_config)
+        prefill_config = cuda_graph_config.get("prefill")
+        if isinstance(prefill_config, Mapping):
+            cuda_graph_config["prefill"] = dict(prefill_config)
+        incoming["cuda_graph_config"] = cuda_graph_config
+
     # note(ratish): the nested form wins in sglang; mirror its prefill
     # fields into the flat keys.
     nested_prefill = nested_prefill_overrides(incoming)
+    nested_prefill_keys = frozenset(nested_prefill)
     for nested_key, flat_key in (
         ("backend", "cuda_graph_backend_prefill"),
         ("bs", "cuda_graph_bs_prefill"),
@@ -253,6 +240,21 @@ def build_generation_batch_overrides(
         context_length=context_length,
         operator_supplied_buckets="cuda_graph_bs_prefill" in incoming,
     )
+
+    # Keep fields supplied through the authoritative nested config aligned
+    # with the resolved flat aliases that SGLang would otherwise overwrite.
+    if isinstance(nested_prefill, dict):
+        for nested_key, flat_key in (
+            ("backend", "cuda_graph_backend_prefill"),
+            ("bs", "cuda_graph_bs_prefill"),
+            ("max_bs", "cuda_graph_max_bs_prefill"),
+        ):
+            if nested_key not in nested_prefill_keys:
+                continue
+            if flat_key in overrides:
+                nested_prefill[nested_key] = overrides[flat_key]
+            else:
+                nested_prefill.pop(nested_key, None)
 
     return overrides
 
@@ -404,13 +406,17 @@ def _validate_prefill_graph_policy(
                 cap_value,
             )
 
-    analysis = analyze_prefill_cuda_graph_buckets(buckets)
-    if analysis.eager_valleys:
+    valleys = []
+    for previous, next_bucket in zip(buckets, buckets[1:]):
+        eager_end = (next_bucket - 1) // _PREFILL_PADDING_FACTOR
+        if eager_end > previous:
+            valleys.append((previous + 1, eager_end))
+    if valleys:
         logger.warning(
             "prefill CUDA graph bucket gaps exceed the %dx padding factor; "
             "prompt lengths inside %s fall back to eager",
             _PREFILL_PADDING_FACTOR,
-            list(analysis.eager_valleys),
+            valleys,
         )
 
 

--- a/sglang_omni/scheduling/generation_batch_policy.py
+++ b/sglang_omni/scheduling/generation_batch_policy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 from numbers import Integral
 from typing import Any
 
@@ -18,6 +19,13 @@ _MISSING = object()
 # A prefill replay falls back to eager when the padded bucket exceeds this
 # multiple of the real token count.
 _PREFILL_PADDING_FACTOR = 2
+
+
+@dataclass(frozen=True)
+class PrefillBucketAnalysis:
+    bucket_count: int
+    max_bucket: int
+    eager_valleys: tuple[tuple[int, int], ...]
 
 
 def get_decode_cuda_graph_max_bs(server_args: Any) -> Any:
@@ -58,7 +66,8 @@ def build_default_prefill_cuda_graph_bs(max_num_tokens: int) -> list[int]:
     if max_num_tokens < 1:
         raise ValueError("max_num_tokens must be >= 1")
 
-    values = list(range(4, 33, 4))
+    values = [1, 2]
+    values.extend(range(4, 33, 4))
     values.extend(range(48, 257, 16))
     values.extend(range(288, 513, 32))
     values.extend(range(576, 1025, 64))
@@ -68,6 +77,92 @@ def build_default_prefill_cuda_graph_bs(max_num_tokens: int) -> list[int]:
     if not values or values[-1] != max_num_tokens:
         values.append(max_num_tokens)
     return values
+
+
+def resolve_prefill_cuda_graph_capture_cap(
+    *,
+    default_capture_budget: int,
+    overrides: Mapping[str, Any],
+    context_length: int | None = None,
+) -> int:
+    caps = [
+        _normalize_positive_int(
+            "prefill_cuda_graph_capture_budget", default_capture_budget
+        )
+    ]
+    for field in (
+        "cuda_graph_max_bs_prefill",
+        "max_prefill_tokens",
+        "max_total_tokens",
+    ):
+        value = overrides.get(field)
+        if value is not None:
+            caps.append(_normalize_positive_int(field, value))
+
+    chunked_prefill_size = overrides.get("chunked_prefill_size")
+    if chunked_prefill_size is not None and int(chunked_prefill_size) > 0:
+        caps.append(
+            _normalize_positive_int("chunked_prefill_size", chunked_prefill_size)
+        )
+
+    resolved_context_length = overrides.get("context_length", context_length)
+    if resolved_context_length is not None:
+        caps.append(_normalize_positive_int("context_length", resolved_context_length))
+    return min(caps)
+
+
+def resolve_prefill_cuda_graph_buckets(
+    *,
+    default_capture_budget: int | None,
+    overrides: dict[str, Any],
+    context_length: int | None = None,
+    operator_supplied_buckets: bool = False,
+) -> None:
+    if overrides.get("cuda_graph_backend_prefill") == CudaGraphBackend.DISABLED:
+        overrides.pop("cuda_graph_bs_prefill", None)
+        overrides.pop("cuda_graph_max_bs_prefill", None)
+        return
+
+    buckets = overrides.get("cuda_graph_bs_prefill")
+    if operator_supplied_buckets:
+        normalized = _require_valid_cuda_graph_bs(
+            buckets, field="cuda_graph_bs_prefill"
+        )
+        overrides["cuda_graph_max_bs_prefill"] = max(normalized)
+        return
+
+    if default_capture_budget is None:
+        if buckets is None:
+            return
+        normalized = _require_valid_cuda_graph_bs(
+            buckets, field="cuda_graph_bs_prefill"
+        )
+        default_capture_budget = max(normalized)
+
+    capture_cap = resolve_prefill_cuda_graph_capture_cap(
+        default_capture_budget=default_capture_budget,
+        overrides=overrides,
+        context_length=context_length,
+    )
+    resolved_buckets = build_default_prefill_cuda_graph_bs(capture_cap)
+    overrides["cuda_graph_bs_prefill"] = resolved_buckets
+    overrides["cuda_graph_max_bs_prefill"] = max(resolved_buckets)
+
+
+def analyze_prefill_cuda_graph_buckets(
+    buckets: Iterable[int],
+) -> PrefillBucketAnalysis:
+    normalized = tuple(int(bucket) for bucket in buckets)
+    valleys = []
+    for previous, next_bucket in zip(normalized, normalized[1:]):
+        eager_end = (next_bucket - 1) // _PREFILL_PADDING_FACTOR
+        if eager_end > previous:
+            valleys.append((previous + 1, eager_end))
+    return PrefillBucketAnalysis(
+        bucket_count=len(normalized),
+        max_bucket=max(normalized),
+        eager_valleys=tuple(valleys),
+    )
 
 
 def nested_prefill_overrides(overrides: Mapping[str, Any]) -> Mapping[str, Any]:
@@ -86,6 +181,8 @@ def build_generation_batch_overrides(
     max_running_requests: int,
     cuda_graph_max_bs: int | None = None,
     torch_compile_max_bs: int | None = None,
+    prefill_cuda_graph_capture_budget: int | None = None,
+    context_length: int | None = None,
     server_args_overrides: Mapping[str, Any] | None = None,
     **stage_defaults: Any,
 ) -> dict[str, Any]:
@@ -150,23 +247,12 @@ def build_generation_batch_overrides(
         overrides.pop("cuda_graph_bs_prefill", None)
         overrides.pop("cuda_graph_max_bs_prefill", None)
 
-    # Reconcile the merged buckets with the cap: derive a missing cap from
-    # the buckets, and trim stage-default buckets to an operator cap. An
-    # operator-stated list is never trimmed; contradictions fail validation.
-    prefill_bs = overrides.get("cuda_graph_bs_prefill")
-    prefill_max_bs = overrides.get("cuda_graph_max_bs_prefill")
-    if prefill_bs and prefill_max_bs is None:
-        overrides["cuda_graph_max_bs_prefill"] = max(int(b) for b in prefill_bs)
-    elif (
-        prefill_bs
-        and "cuda_graph_bs_prefill" not in incoming
-        and int(prefill_max_bs) < max(int(b) for b in prefill_bs)
-    ):
-        cap = int(prefill_max_bs)
-        trimmed = [int(b) for b in prefill_bs if int(b) <= cap]
-        if not trimmed or trimmed[-1] != cap:
-            trimmed.append(cap)
-        overrides["cuda_graph_bs_prefill"] = trimmed
+    resolve_prefill_cuda_graph_buckets(
+        default_capture_budget=prefill_cuda_graph_capture_budget,
+        overrides=overrides,
+        context_length=context_length,
+        operator_supplied_buckets="cuda_graph_bs_prefill" in incoming,
+    )
 
     return overrides
 
@@ -254,8 +340,7 @@ def _validate_prefill_graph_policy(
     cuda_graph_enabled: bool,
     errors: list[str],
 ) -> None:
-    """Validate the declared prefill CUDA graph policy: breakable backend
-    only, with explicitly declared buckets."""
+    """Validate the resolved prefill CUDA graph policy."""
     backend = get_prefill_cuda_graph_backend(server_args)
     if backend == CudaGraphBackend.DISABLED:
         return
@@ -286,14 +371,6 @@ def _validate_prefill_graph_policy(
                 "set cuda_graph_backend_prefill='disabled'"
             )
 
-    if ("prefill", "bs") not in server_args._cuda_graph_config_locked:
-        errors.append(
-            "breakable prefill CUDA graphs require explicit "
-            "cuda_graph_bs_prefill buckets (sglang's generated ladder is "
-            "not an accepted shape policy)"
-        )
-        return
-
     prefill_cfg = server_args.cuda_graph_config.prefill
     buckets = _normalize_cuda_graph_bs(
         prefill_cfg.bs, errors, field="cuda_graph_bs_prefill"
@@ -303,9 +380,11 @@ def _validate_prefill_graph_policy(
 
     max_bs = prefill_cfg.max_bs
     if max_bs is not None and max(buckets) != int(max_bs):
-        errors.append(
+        logger.warning(
             "max(cuda_graph_bs_prefill) must match cuda_graph_max_bs_prefill "
-            f"({max(buckets)} != {max_bs})"
+            "(%d != %s); the resolved bucket list determines replay coverage",
+            max(buckets),
+            max_bs,
         )
 
     # Buckets above either per-forward token cap can never replay.
@@ -318,25 +397,20 @@ def _validate_prefill_graph_policy(
             and int(cap_value) > 0
             and max(buckets) > int(cap_value)
         ):
-            errors.append(
-                f"cuda_graph_bs_prefill buckets above {cap_name} are "
-                f"unreachable ({max(buckets)} > {cap_value})"
+            logger.warning(
+                "cuda_graph_bs_prefill buckets above %s are unreachable " "(%d > %s)",
+                cap_name,
+                max(buckets),
+                cap_value,
             )
 
-    # The largest eager-falling length under bucket nxt is
-    # (nxt - 1) // factor; a valley exists only when that reaches past the
-    # previous bucket.
-    valleys = []
-    for prev, nxt in zip(buckets, buckets[1:]):
-        eager_end = (nxt - 1) // _PREFILL_PADDING_FACTOR
-        if eager_end > prev:
-            valleys.append((prev + 1, eager_end))
-    if valleys:
+    analysis = analyze_prefill_cuda_graph_buckets(buckets)
+    if analysis.eager_valleys:
         logger.warning(
             "prefill CUDA graph bucket gaps exceed the %dx padding factor; "
             "prompt lengths inside %s fall back to eager",
             _PREFILL_PADDING_FACTOR,
-            valleys,
+            list(analysis.eager_valleys),
         )
 
 
@@ -401,4 +475,14 @@ def _normalize_cuda_graph_bs(
     if tuple(sorted(set(normalized))) != normalized:
         errors.append(f"{field} must be strictly increasing")
         return None
+    return normalized
+
+
+def _require_valid_cuda_graph_bs(
+    value: Iterable[Any], *, field: str
+) -> tuple[int, ...]:
+    errors: list[str] = []
+    normalized = _normalize_cuda_graph_bs(value, errors, field=field)
+    if normalized is None:
+        raise ValueError("; ".join(errors))
     return normalized

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -508,9 +508,6 @@ def _make_higgs_builder(**kwargs):
 
 def test_higgs_tts_engine_prefill_backend_policy() -> None:
     from sglang_omni.models.higgs_tts import CAPABILITIES
-    from sglang_omni.scheduling.generation_batch_policy import (
-        build_default_prefill_cuda_graph_bs,
-    )
 
     builder = _make_higgs_builder()
 
@@ -521,7 +518,8 @@ def test_higgs_tts_engine_prefill_backend_policy() -> None:
 
     defaults = builder.generation_defaults(dtype="bfloat16")
     assert defaults["cuda_graph_backend_prefill"] == "breakable"
-    assert defaults["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(512)
+    assert defaults["prefill_cuda_graph_capture_budget"] == 512
+    assert "cuda_graph_bs_prefill" not in defaults
 
     server_args = FakeServerArgs(
         cuda_graph_config=SimpleNamespace(prefill=SimpleNamespace(backend="disabled"))

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -105,13 +105,18 @@ def test_moss_transcribe_diarize_prefill_backend_policy() -> None:
     assert defaults["enable_torch_compile"] is False
     assert defaults["torch_compile_max_bs"] == 4
     assert defaults["cuda_graph_backend_prefill"] == "breakable"
-    assert defaults["cuda_graph_bs_prefill"] == [
-        1,
-        2,
-        *build_default_prefill_cuda_graph_bs(4096),
-    ]
+    assert defaults["prefill_cuda_graph_capture_budget"] == 4096
+    assert "cuda_graph_bs_prefill" not in defaults
+
+    overrides = build_generation_batch_overrides(
+        context_length=builder.context_length,
+        **defaults,
+    )
+    assert overrides["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(
+        4096
+    )
     assert (
-        max(defaults["cuda_graph_bs_prefill"])
+        max(overrides["cuda_graph_bs_prefill"])
         == defaults["max_prefill_tokens"]
         == defaults["chunked_prefill_size"]
         == 4096

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -108,10 +108,7 @@ def test_moss_transcribe_diarize_prefill_backend_policy() -> None:
     assert defaults["prefill_cuda_graph_capture_budget"] == 4096
     assert "cuda_graph_bs_prefill" not in defaults
 
-    overrides = build_generation_batch_overrides(
-        context_length=builder.context_length,
-        **defaults,
-    )
+    overrides = build_generation_batch_overrides(**defaults)
     assert overrides["cuda_graph_bs_prefill"] == build_default_prefill_cuda_graph_bs(
         4096
     )

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -441,7 +441,8 @@ def test_prefill_ladder_never_exceeds_the_context_length(
         mm_attention_backend="fa3", context_length=context_length
     )
     overrides = build_generation_batch_overrides(
-        **builder.generation_defaults(dtype="bfloat16")
+        context_length=builder.context_length,
+        **builder.generation_defaults(dtype="bfloat16"),
     )
 
     builder.adjust_overrides(overrides)
@@ -452,7 +453,8 @@ def test_prefill_ladder_never_exceeds_the_context_length(
 def test_qwen3_asr_prefill_ladder_is_accepted_by_the_shared_policy(caplog) -> None:
     builder = _make_engine_builder(mm_attention_backend="fa3")
     overrides = build_generation_batch_overrides(
-        **builder.generation_defaults(dtype="bfloat16")
+        context_length=builder.context_length,
+        **builder.generation_defaults(dtype="bfloat16"),
     )
     builder.adjust_overrides(overrides)
     server_args = _fake_server_args_builder({})("dummy", 1636, **overrides)

--- a/tests/unit_test/scheduling/test_prefill_graph_policy.py
+++ b/tests/unit_test/scheduling/test_prefill_graph_policy.py
@@ -99,15 +99,14 @@ def test_non_breakable_prefill_backend_is_rejected() -> None:
             )
 
 
-def test_breakable_requires_explicit_buckets() -> None:
-    with pytest.raises(ValueError, match="explicit"):
-        _validate(
-            _server_args(
-                prefill_backend="breakable",
-                prefill_bs=(4, 8, 16),
-                locked=frozenset(),
-            )
+def test_breakable_accepts_resolved_buckets_without_explicit_provenance() -> None:
+    _validate(
+        _server_args(
+            prefill_backend="breakable",
+            prefill_bs=(1, 2, 4, 8, 16),
+            locked=frozenset(),
         )
+    )
 
 
 def test_breakable_rejects_non_increasing_buckets() -> None:
@@ -135,8 +134,8 @@ def test_breakable_rejects_non_integral_bucket_types(
         )
 
 
-def test_breakable_rejects_max_bs_mismatch() -> None:
-    with pytest.raises(ValueError, match="cuda_graph_max_bs_prefill"):
+def test_breakable_warns_on_max_bs_mismatch(caplog) -> None:
+    with caplog.at_level(logging.WARNING):
         _validate(
             _server_args(
                 prefill_backend="breakable",
@@ -145,10 +144,11 @@ def test_breakable_rejects_max_bs_mismatch() -> None:
                 locked=_PREFILL_BS_LOCKED,
             )
         )
+    assert any("must match" in record.message for record in caplog.records)
 
 
-def test_breakable_rejects_buckets_above_chunked_prefill() -> None:
-    with pytest.raises(ValueError, match="chunked_prefill_size are unreachable"):
+def test_breakable_warns_on_buckets_above_chunked_prefill(caplog) -> None:
+    with caplog.at_level(logging.WARNING):
         _validate(
             _server_args(
                 prefill_backend="breakable",
@@ -157,10 +157,11 @@ def test_breakable_rejects_buckets_above_chunked_prefill() -> None:
                 chunked_prefill_size=8192,
             )
         )
+    assert any("chunked_prefill_size" in record.message for record in caplog.records)
 
 
-def test_breakable_rejects_buckets_above_max_prefill_tokens() -> None:
-    with pytest.raises(ValueError, match="max_prefill_tokens are unreachable"):
+def test_breakable_warns_on_buckets_above_max_prefill_tokens(caplog) -> None:
+    with caplog.at_level(logging.WARNING):
         _validate(
             _server_args(
                 prefill_backend="breakable",
@@ -170,6 +171,7 @@ def test_breakable_rejects_buckets_above_max_prefill_tokens() -> None:
                 max_prefill_tokens=16384,
             )
         )
+    assert any("max_prefill_tokens" in record.message for record in caplog.records)
 
 
 @pytest.mark.parametrize(
@@ -241,7 +243,16 @@ def test_operator_prefill_buckets_are_never_trimmed_by_a_nested_cap() -> None:
     )
 
     assert overrides["cuda_graph_bs_prefill"] == [128, 256]
-    assert overrides["cuda_graph_max_bs_prefill"] == 128
+    assert overrides["cuda_graph_max_bs_prefill"] == 256
+
+
+def test_malformed_operator_prefill_buckets_are_rejected() -> None:
+    with pytest.raises(ValueError, match="strictly increasing"):
+        build_generation_batch_overrides(
+            max_running_requests=4,
+            prefill_cuda_graph_capture_budget=512,
+            server_args_overrides={"cuda_graph_bs_prefill": [256, 128]},
+        )
 
 
 def test_nested_disabled_backend_overrides_a_stage_default() -> None:
@@ -316,15 +327,20 @@ def test_padding_gap_warning_requires_a_non_empty_eager_range(caplog) -> None:
 def test_default_prefill_ladder_matches_sglang_generated_ladder() -> None:
     ladder = build_default_prefill_cuda_graph_bs(512)
     assert ladder == (
-        list(range(4, 33, 4)) + list(range(48, 257, 16)) + list(range(288, 513, 32))
+        [1, 2]
+        + list(range(4, 33, 4))
+        + list(range(48, 257, 16))
+        + list(range(288, 513, 32))
     )
-    assert len(ladder) == 30
+    assert len(ladder) == 32
 
     off_grid = build_default_prefill_cuda_graph_bs(100)
     assert off_grid[-1] == 100
-    assert off_grid[:-1] == [4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96]
+    assert off_grid[:-1] == [1, 2, 4, 8, 12, 16, 20, 24, 28, 32, 48, 64, 80, 96]
 
-    assert build_default_prefill_cuda_graph_bs(2) == [2]
+    assert build_default_prefill_cuda_graph_bs(1) == [1]
+    assert build_default_prefill_cuda_graph_bs(2) == [1, 2]
+    assert build_default_prefill_cuda_graph_bs(3) == [1, 2, 3]
 
     _validate(
         _server_args(
@@ -359,10 +375,38 @@ def test_overrides_derive_prefill_max_bs_from_buckets() -> None:
     assert explicit["cuda_graph_max_bs_prefill"] == 256
 
 
+@pytest.mark.parametrize(
+    ("server_args_overrides", "context_length", "expected_cap"),
+    [
+        ({"max_prefill_tokens": 768}, None, 768),
+        ({"chunked_prefill_size": 640}, None, 640),
+        ({"max_total_tokens": 512}, None, 512),
+        ({"cuda_graph_max_bs_prefill": 384}, None, 384),
+        ({}, 256, 256),
+    ],
+)
+def test_generated_prefill_buckets_respect_effective_caps(
+    server_args_overrides: dict[str, int],
+    context_length: int | None,
+    expected_cap: int,
+) -> None:
+    overrides = build_generation_batch_overrides(
+        max_running_requests=4,
+        prefill_cuda_graph_capture_budget=1024,
+        context_length=context_length,
+        max_prefill_tokens=2048,
+        chunked_prefill_size=-1,
+        server_args_overrides=server_args_overrides,
+    )
+
+    assert max(overrides["cuda_graph_bs_prefill"]) == expected_cap
+    assert overrides["cuda_graph_max_bs_prefill"] == expected_cap
+
+
 def test_disable_overrides_win_over_default_prefill_backend() -> None:
     stage_defaults = {
         "cuda_graph_backend_prefill": "breakable",
-        "cuda_graph_bs_prefill": [128, 256],
+        "prefill_cuda_graph_capture_budget": 256,
     }
 
     for disable_key in ("disable_cuda_graph", "disable_prefill_cuda_graph"):

--- a/tests/unit_test/scheduling/test_prefill_graph_policy.py
+++ b/tests/unit_test/scheduling/test_prefill_graph_policy.py
@@ -234,16 +234,19 @@ def test_nested_prefill_max_bs_trims_a_stage_default_ladder() -> None:
 
 
 def test_operator_prefill_buckets_are_never_trimmed_by_a_nested_cap() -> None:
+    cuda_graph_config = {"prefill": {"max_bs": 128}}
     overrides = build_generation_batch_overrides(
         max_running_requests=4,
         server_args_overrides={
             "cuda_graph_bs_prefill": [128, 256],
-            "cuda_graph_config": {"prefill": {"max_bs": 128}},
+            "cuda_graph_config": cuda_graph_config,
         },
     )
 
     assert overrides["cuda_graph_bs_prefill"] == [128, 256]
     assert overrides["cuda_graph_max_bs_prefill"] == 256
+    assert overrides["cuda_graph_config"]["prefill"]["max_bs"] == 256
+    assert cuda_graph_config["prefill"]["max_bs"] == 128
 
 
 def test_malformed_operator_prefill_buckets_are_rejected() -> None:


### PR DESCRIPTION
## Summary

- extend the shared prefill CUDA Graph ladder with 1- and 2-token buckets
- centralize effective capture-cap and bucket resolution across model defaults and operator overrides
- preserve explicit operator bucket lists while deriving their effective `max_bs`
- remove lock-provenance validation and retain padding-gap/unreachable-bucket diagnostics as warnings
- migrate Qwen3-ASR, Fun-ASR, Higgs-TTS, and MOSS-Transcribe-Diarize to declare capture budgets instead of building ladders

## Impact

Model-qualified defaults are now generated against the minimum applicable prefill-token cap (`cuda_graph_max_bs_prefill`, `max_prefill_tokens`, positive `chunked_prefill_size`, `max_total_tokens`, and `context_length`). Explicit operator buckets remain unchanged, and SGLang-resolved ladders are accepted regardless of whether they were marked as explicitly supplied.

## Validation

- `.venv/bin/pre-commit run --files sglang_omni/scheduling/generation_batch_policy.py sglang_omni/scheduling/engine_factory.py sglang_omni/models/qwen3_asr/engine_builder.py sglang_omni/models/fun_asr/engine_builder.py sglang_omni/models/higgs_tts/engine_builder.py sglang_omni/models/moss_transcribe_diarize/engine_builder.py tests/unit_test/scheduling/test_prefill_graph_policy.py tests/unit_test/qwen3_asr/test_pipeline.py tests/unit_test/fun_asr/test_pipeline.py tests/unit_test/higgs_tts/test_pipeline.py tests/unit_test/moss_transcribe_diarize/test_pipeline.py`
- unit tests and benchmarks were not run, per repository instructions