### PR TITLE
[Feature] Per-stage absolute KV cache byte budgets (reworks #1452)

### DIFF
--- a/docs/basic_usage/mps_dp.md
+++ b/docs/basic_usage/mps_dp.md
@@ -135,7 +135,12 @@ Identical `--mem-fraction-static` flags do **not** mean identical KV capacity. `
 
 ![What same-GPU DP spends in VRAM and what it reclaims](../_static/image/same-gpu-dp-vram.svg)
 
-Memory profiling does not coordinate KV allocation across independent replica processes. For `N > 1`, the launcher therefore requires one common `max_total_tokens` value, either from the pipeline config or from `MAX_TOTAL_TOKENS`. SGLang treats this value as an upper bound; the launcher rejects startup unless every replica resolves exactly that capacity. The cap applies independently to each replica; it is not divided across the pool. It is also independent of the request-level `max_new_tokens` limit and does not distribute requests between replicas.
+Memory profiling does not coordinate KV allocation across independent replica processes. For `N > 1`, every replica must resolve the same KV capacity, which can come from either sizing knob but never both:
+
+* `engine.kv_cache_bytes` in the pipeline config sizes every replica's pool deterministically; the launcher verifies all replicas resolved the same capacity and rejects a simultaneous `MAX_TOTAL_TOKENS`, since a lower token cap would silently shrink the byte-derived pool.
+* Without a byte budget, the launcher requires one common `max_total_tokens` value, from the pipeline config or from `MAX_TOTAL_TOKENS`, and rejects startup unless every replica resolves exactly that capacity.
+
+Either cap applies independently to each replica; it is not divided across the pool. It is also independent of the request-level `max_new_tokens` limit and does not distribute requests between replicas.
 
 The H100 Higgs DP3 profile uses `100000` tokens per replica. The H200 Higgs DP8 profile uses `30000` tokens per replica, preserving GPU memory headroom for non-KV runtime allocations, including the colocated audio encoder and vocoder. These values are specific to their configurations, not universal hardware defaults. Recalculate the cap after changing the model, GPU, runtime, replica count, memory settings, or CUDA-graph settings. If a replica cannot allocate the common cap, lower it or reduce the replica count.
 

--- a/docs/basic_usage/mps_dp.md
+++ b/docs/basic_usage/mps_dp.md
@@ -59,6 +59,15 @@ Start replicas one after another and give each an explicit memory budget
 reasons described under the script recipe below. Route traffic with the
 [Omni Router](omni_router.md).
 
+Process-level replicas can size their pools in bytes instead, with
+`engine.kv_cache_bytes` per stage and `total_reserve_bytes` for the replica's
+full footprint. The budgets are then checked against the card before any
+replica is spawned: colocation requires a declared footprint, the summed
+reserves and fractions must fit the card, and the summed KV pools alone must
+too. `engine.kv_cache_bytes` and `engine.max_total_tokens` are mutually
+exclusive on one stage, since the lower token cap would silently shrink the
+byte-derived pool.
+
 The runtime owns the full lifecycle. Every managed process is verified against
 the daemon's client list before serving starts, because a process that misses
 the pipe directory silently falls back to time slicing. A watchdog fails the

--- a/examples/mps_dp/config.py
+++ b/examples/mps_dp/config.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -13,6 +15,7 @@ from sglang_omni.config.runtime import (
     resolve_stage_factory_kwargs,
     resolve_stage_typed_kwargs,
 )
+from sglang_omni.utils.gpu_memory import format_bytes_gib, get_gpu_device_info
 
 # Note (Jiaxin Deng): the machine-readable weight-share support registry:
 # pipeline configs whose documented launch.sh command passed shared-DP
@@ -35,14 +38,13 @@ WEIGHT_SHARE_VALIDATED_CONFIGS: dict[str, str] = {
 }
 
 
-def resolve_max_total_tokens(
+def _resolve_generation_stage(
     config_path: str | Path,
-    max_total_tokens_override: int | None = None,
     *,
     require_single_sglang_engine: bool = False,
     weight_share: bool = False,
-) -> tuple[str, int | None]:
-    """Return the generation stage name and its KV cap (None when unpinned)."""
+) -> tuple[Any, Any, Any]:
+    """Return the pipeline config, its type, and the generation stage."""
 
     pipeline_config = ConfigManager.from_file(str(config_path)).config
     config_type = type(pipeline_config)
@@ -81,6 +83,152 @@ def resolve_max_total_tokens(
         raise ValueError(
             f"generation stage {stage_name!r} is missing from the pipeline"
         )
+    return pipeline_config, config_type, stage
+
+
+def _resolve_mps_memory_budget(
+    config_path: str | Path,
+    gpu_id: int,
+    replicas: int,
+    *,
+    allow_missing_budget: bool,
+    weight_share: bool = False,
+) -> dict[str, int | str] | None:
+    if replicas <= 0:
+        raise ValueError("replicas must be a positive integer")
+
+    _, config_type, stage = _resolve_generation_stage(
+        config_path, weight_share=weight_share
+    )
+    kv_cache_bytes = stage.engine.kv_cache_bytes if stage.engine is not None else None
+    total_reserve_bytes = stage.total_reserve_bytes
+    if kv_cache_bytes is None and not allow_missing_budget:
+        raise ValueError(
+            f"{config_type.__name__} generation stage {stage.name!r} must define "
+            "positive engine.kv_cache_bytes for MPS byte-budget preflight"
+        )
+    if kv_cache_bytes is None and total_reserve_bytes is None:
+        return None
+
+    device_info = get_gpu_device_info(gpu_id)
+    if device_info.total_memory_bytes is None:
+        name = device_info.name or "unknown GPU"
+        raise ValueError(
+            f"GPU {gpu_id} ({name}) total VRAM metadata is unavailable; cannot "
+            "preflight byte budgets"
+        )
+    total_memory_bytes = device_info.total_memory_bytes
+    gpu_name = device_info.name or "unknown GPU"
+
+    budget: dict[str, int | str] = {
+        "gpu_id": gpu_id,
+        "gpu_name": gpu_name,
+        "gpu_device_id": (
+            "unknown" if device_info.device_id is None else device_info.device_id
+        ),
+        "replicas": replicas,
+        "weight_share": "1" if weight_share else "0",
+        "total_vram_bytes": total_memory_bytes,
+        "total_vram_gib": format_bytes_gib(total_memory_bytes),
+    }
+
+    # Note (Jiaxin Deng): the pass criteria only ever multiply numbers the user
+    # wrote; the KV bound holds with WEIGHT_SHARE too (KV pools stay private).
+    if kv_cache_bytes is not None:
+        total_kv_bytes = replicas * kv_cache_bytes
+        if total_kv_bytes > total_memory_bytes:
+            raise ValueError(
+                "MPS byte-budget preflight exceeds physical VRAM: "
+                f"GPU {gpu_id} ({gpu_name}) has "
+                f"{format_bytes_gib(total_memory_bytes)}, but {replicas} "
+                f"replicas x kv_cache_bytes={format_bytes_gib(kv_cache_bytes)} "
+                f"= {format_bytes_gib(total_kv_bytes)} of KV pools alone. Lower "
+                "engine.kv_cache_bytes or reduce the replica count."
+            )
+        budget["per_replica_kv_cache_bytes"] = kv_cache_bytes
+        budget["per_replica_kv_cache_gib"] = format_bytes_gib(kv_cache_bytes)
+        budget["total_kv_cache_bytes"] = total_kv_bytes
+        budget["total_kv_cache_gib"] = format_bytes_gib(total_kv_bytes)
+
+    if total_reserve_bytes is None:
+        if replicas >= 2:
+            even_split = total_memory_bytes // replicas
+            print(
+                "warning: total_reserve_bytes is not set; the "
+                f"{replicas}-replica total footprint (weights, activations, CUDA "
+                "graphs) is NOT validated, only the KV pool lower bound. Size "
+                "each replica against roughly the even split of GPU "
+                f"{gpu_id} ({format_bytes_gib(even_split)}) and set "
+                "total_reserve_bytes explicitly to enable the full check.",
+                file=sys.stderr,
+            )
+        return budget
+
+    budget["per_replica_total_reserve_bytes"] = total_reserve_bytes
+    budget["per_replica_total_reserve_gib"] = format_bytes_gib(total_reserve_bytes)
+    if weight_share:
+        # One full reservation covers replica 0 (weights resident once); every
+        # further replica still owns a private KV pool.
+        shared_floor_bytes = total_reserve_bytes
+        if kv_cache_bytes is not None:
+            shared_floor_bytes += (replicas - 1) * kv_cache_bytes
+        if shared_floor_bytes > total_memory_bytes:
+            raise ValueError(
+                "MPS byte-budget preflight exceeds physical VRAM: "
+                f"GPU {gpu_id} ({gpu_name}) has "
+                f"{format_bytes_gib(total_memory_bytes)}, but one replica's "
+                "total_reserve_bytes="
+                f"{format_bytes_gib(total_reserve_bytes)} plus {replicas - 1} "
+                "further private KV pool(s) totals "
+                f"{format_bytes_gib(shared_floor_bytes)}. Lower "
+                "total_reserve_bytes or engine.kv_cache_bytes, or "
+                "reduce the replica count."
+            )
+        print(
+            "warning: WEIGHT_SHARE=1 - MPS byte-budget preflight only checked "
+            "the KV pool lower bound and one replica's reservation "
+            f"({format_bytes_gib(total_reserve_bytes)}) against GPU {gpu_id} "
+            f"VRAM ({format_bytes_gib(total_memory_bytes)}). The {replicas}-way "
+            "total is NOT validated, because the shared weight size is unknown "
+            "until a replica boots. Use autodp.sh to size shared-weight DP "
+            "from a measured footprint.",
+            file=sys.stderr,
+        )
+        return budget
+
+    requested_total_bytes = replicas * total_reserve_bytes
+    budget["requested_total_bytes"] = requested_total_bytes
+    budget["requested_total_gib"] = format_bytes_gib(requested_total_bytes)
+    if requested_total_bytes > total_memory_bytes:
+        raise ValueError(
+            "MPS byte-budget preflight exceeds physical VRAM: "
+            f"GPU {gpu_id} ({gpu_name}) has "
+            f"{format_bytes_gib(total_memory_bytes)}, but {replicas} replicas x "
+            f"total_reserve_bytes={format_bytes_gib(total_reserve_bytes)} "
+            f"requested={format_bytes_gib(requested_total_bytes)}. Lower "
+            "total_reserve_bytes or reduce the replica count."
+        )
+    return budget
+
+
+def _serialize_mps_memory_budget_manifest(budget: dict[str, int | str]) -> str:
+    return "\n".join(f"mps_budget_{key}={value}" for key, value in budget.items())
+
+
+def resolve_max_total_tokens(
+    config_path: str | Path,
+    max_total_tokens_override: int | None = None,
+    *,
+    require_single_sglang_engine: bool = False,
+    weight_share: bool = False,
+) -> int | None:
+    """Return the effective generation-stage KV cap, or None when unpinned."""
+
+    pipeline_config, _, stage = _resolve_generation_stage(
+        config_path,
+        require_single_sglang_engine=require_single_sglang_engine,
+        weight_share=weight_share,
+    )
 
     value = max_total_tokens_override
     if value is None:
@@ -97,13 +245,23 @@ def resolve_max_total_tokens(
             resolve_stage_typed_kwargs(stage).get("server_args_overrides") or {}
         )
         value = overrides.get("max_total_tokens")
+    if (
+        value is not None
+        and stage.engine is not None
+        and stage.engine.kv_cache_bytes is not None
+    ):
+        raise ValueError(
+            "engine.kv_cache_bytes and max_total_tokens both pin the "
+            "generation stage's KV capacity; keep exactly one (a lower token "
+            "cap would silently shrink the byte-derived pool)"
+        )
     if value is None:
-        return stage_name, None
+        return stage.name, None
     if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
         raise ValueError(
             "the generation stage must define a positive integer max_total_tokens"
         )
-    return stage_name, value
+    return stage.name, value
 
 
 def main() -> None:
@@ -120,16 +278,41 @@ def main() -> None:
             "the dotted serve flag (--STAGE.engine.max_total_tokens)."
         ),
     )
+    parser.add_argument("--print-mps-memory-budget", action="store_true")
+    parser.add_argument("--print-kv-cache-bytes", action="store_true")
+    parser.add_argument("--gpu-id", type=int)
+    parser.add_argument("--replicas", type=int)
     args = parser.parse_args()
     try:
-        stage_name, value = resolve_max_total_tokens(
-            args.config,
-            args.max_total_tokens,
-            require_single_sglang_engine=args.require_single_sglang_engine,
-            weight_share=args.weight_share,
-        )
-        if value is not None:
-            print(f"{stage_name} {value}" if args.print_stage else value)
+        if args.print_kv_cache_bytes:
+            _, _, stage = _resolve_generation_stage(
+                args.config, weight_share=args.weight_share
+            )
+            if stage.engine is not None and stage.engine.kv_cache_bytes is not None:
+                print(stage.engine.kv_cache_bytes)
+        elif args.print_mps_memory_budget:
+            if args.gpu_id is None or args.replicas is None:
+                parser.error(
+                    "--print-mps-memory-budget requires both --gpu-id and " "--replicas"
+                )
+            budget = _resolve_mps_memory_budget(
+                args.config,
+                gpu_id=args.gpu_id,
+                replicas=args.replicas,
+                allow_missing_budget=True,
+                weight_share=args.weight_share,
+            )
+            if budget is not None:
+                print(_serialize_mps_memory_budget_manifest(budget))
+        else:
+            stage_name, value = resolve_max_total_tokens(
+                args.config,
+                args.max_total_tokens,
+                require_single_sglang_engine=args.require_single_sglang_engine,
+                weight_share=args.weight_share,
+            )
+            if value is not None:
+                print(f"{stage_name} {value}" if args.print_stage else value)
     except (OSError, KeyError, ValueError, yaml.YAMLError) as exc:
         parser.error(str(exc))
 

--- a/examples/mps_dp/launch.sh
+++ b/examples/mps_dp/launch.sh
@@ -403,7 +403,7 @@ up() {
     engine_stage=${ENGINE_STAGE:-tts_engine}
   fi
   if [ "$n" -gt 1 ] && [ -z "$expected_max_total_tokens" ] && [ -z "$kv_cache_bytes" ]; then
-    die "MAX_TOTAL_TOKENS is required for N=$n so every replica has the same KV capacity (or declare runtime.memory.kv_cache_bytes in CONFIG)"
+    die "MAX_TOTAL_TOKENS is required for N=$n so every replica has the same KV capacity (or declare engine.kv_cache_bytes in CONFIG)"
   fi
   if [ -n "$expected_max_total_tokens" ]; then
     [[ "$expected_max_total_tokens" =~ ^[1-9][0-9]*$ ]] \

--- a/examples/mps_dp/launch.sh
+++ b/examples/mps_dp/launch.sh
@@ -337,6 +337,9 @@ up() {
   local extra_args=() mem_args=()
   local expected_max_total_tokens=${MAX_TOTAL_TOKENS:-}
   local engine_stage=""
+  local kv_cache_bytes=""
+  local mps_budget_manifest=""
+  local uuid=""
   local model_path_manifest=$model
   if [ -n "$config" ]; then
     [ -z "${MODEL:-}" ] || die "MODEL cannot be combined with CONFIG"
@@ -347,6 +350,16 @@ up() {
     model_path_manifest=from_config
     if [ -n "$model_name" ]; then
       model_name_args=(--model-name "$model_name")
+    fi
+    local kv_probe_args=("$config" --print-kv-cache-bytes)
+    if [ "$weight_share" = 1 ]; then
+      kv_probe_args+=(--weight-share)
+    fi
+    kv_cache_bytes=$("$PYTHON_BIN" "$SCRIPT_DIR/config.py" \
+      "${kv_probe_args[@]}") \
+      || die "could not resolve kv_cache_bytes from $config"
+    if [ -n "$kv_cache_bytes" ] && [ -n "${MAX_TOTAL_TOKENS:-}" ]; then
+      die "MAX_TOTAL_TOKENS conflicts with engine.kv_cache_bytes in $config; a lower token cap would silently shrink the byte-derived KV pool, keep exactly one"
     fi
     local config_resolver_args=("$config")
     if [ -n "$expected_max_total_tokens" ]; then
@@ -364,6 +377,16 @@ up() {
       || die "could not resolve max_total_tokens from $config"
     engine_stage=${resolved_stage_and_tokens%% *}
     expected_max_total_tokens=${resolved_stage_and_tokens##* }
+    # Note (Aditya Vaid Sharma): nvidia-smi resolves GPU_ID physically, so the
+    # budget helper runs in a single-UUID namespace and queries logical GPU 0.
+    uuid=$(nvidia-smi --query-gpu=uuid --format=csv,noheader -i "$gpu")
+    local budget_args=("$config" --print-mps-memory-budget --gpu-id 0 --replicas "$n")
+    if [ "$weight_share" = 1 ]; then
+      budget_args+=(--weight-share)
+    fi
+    mps_budget_manifest=$(env CUDA_VISIBLE_DEVICES="$uuid" \
+      "$PYTHON_BIN" "$SCRIPT_DIR/config.py" "${budget_args[@]}") \
+      || die "could not resolve MPS memory budget from $config"
   else
     # Note (Jiaxin Deng): without a pipeline config the supported-model check
     # cannot run until engine startup, which is after the MPS daemon and state
@@ -379,8 +402,8 @@ up() {
     # the stage name from the pipeline itself.
     engine_stage=${ENGINE_STAGE:-tts_engine}
   fi
-  if [ "$n" -gt 1 ] && [ -z "$expected_max_total_tokens" ]; then
-    die "MAX_TOTAL_TOKENS is required for N=$n so every replica has the same KV capacity"
+  if [ "$n" -gt 1 ] && [ -z "$expected_max_total_tokens" ] && [ -z "$kv_cache_bytes" ]; then
+    die "MAX_TOTAL_TOKENS is required for N=$n so every replica has the same KV capacity (or declare runtime.memory.kv_cache_bytes in CONFIG)"
   fi
   if [ -n "$expected_max_total_tokens" ]; then
     [[ "$expected_max_total_tokens" =~ ^[1-9][0-9]*$ ]] \
@@ -391,6 +414,14 @@ up() {
     extra_args+=("--${engine_stage}.engine.max_total_tokens" "$expected_max_total_tokens")
   fi
   if [ -n "${SERVE_EXTRA_ARGS:-}" ]; then
+    # Note (Jiaxin Deng): the byte-budget preflight resolves CONFIG alone, so a
+    # memory override smuggled in here would be validated by nothing and would
+    # silently replace the budget the MPS sizing was computed from.
+    case " $SERVE_EXTRA_ARGS " in
+      *kv_cache_bytes*|*total_reserve_bytes*|*mem-fraction-static*|*mem_fraction_static*)
+        die "SERVE_EXTRA_ARGS must not set a memory budget (kv_cache_bytes, total_reserve_bytes or mem_fraction_static); the preflight validates CONFIG only, declare it there"
+        ;;
+    esac
     # Extra sgl-omni serve flags, word-split intentionally (e.g.
     # "--tts_engine.engine.max_running_requests 32"). Applied identically to every replica.
     # shellcheck disable=SC2206
@@ -417,8 +448,10 @@ up() {
     fi
   done
 
-  local uuid node run state
-  uuid=$(nvidia-smi --query-gpu=uuid --format=csv,noheader -i "$gpu")
+  local node run state
+  if [ -z "$uuid" ]; then
+    uuid=$(nvidia-smi --query-gpu=uuid --format=csv,noheader -i "$gpu")
+  fi
   node=$(resolve_numa "$gpu")
   # Note (Jiaxin Deng): a caller (autodp) may pin RUN_ID so it can tear down exactly
   # the run it started, instead of rediscovering the newest dir.
@@ -447,6 +480,9 @@ up() {
     echo "base_port=$base_port"; echo "core_blocks=$CORE_BLOCKS"
     echo "max_total_tokens=${expected_max_total_tokens:-auto/profiled}"
     echo "weight_share=$weight_share"
+    if [ -n "$mps_budget_manifest" ]; then
+      printf '%s\n' "$mps_budget_manifest"
+    fi
   } > "$state/manifest"
   if [ "$weight_share" = 1 ]; then mkdir -p "$state/ipc_weights"; chmod 700 "$state/ipc_weights"; fi
 
@@ -474,6 +510,7 @@ up() {
     || die "MPS control daemon PID $control_pid exited during startup"
 
   local pid leader_start log resolved_tokens ws_env
+  local first_resolved_tokens=""
   for ((i=0; i<n; i++)); do
     port=$((base_port+i))
     log=$state/logs/replica_$i.log
@@ -527,8 +564,19 @@ up() {
     if [ "$n" -gt 1 ]; then
       [ -n "$resolved_tokens" ] \
         || die "replica $i is healthy but its resolved KV capacity is missing from $log"
-      [ "$resolved_tokens" = "$expected_max_total_tokens" ] \
-        || die "replica $i resolved $resolved_tokens KV tokens; expected $expected_max_total_tokens"
+      if [ -n "$expected_max_total_tokens" ]; then
+        [ "$resolved_tokens" = "$expected_max_total_tokens" ] \
+          || die "replica $i resolved $resolved_tokens KV tokens; expected $expected_max_total_tokens"
+      else
+        # Byte-budget mode: every replica must derive the same capacity from
+        # the shared kv_cache_bytes declaration.
+        if [ -z "$first_resolved_tokens" ]; then
+          first_resolved_tokens=$resolved_tokens
+        else
+          [ "$resolved_tokens" = "$first_resolved_tokens" ] \
+            || die "replica $i resolved $resolved_tokens KV tokens; replica 0 resolved $first_resolved_tokens"
+        fi
+      fi
     fi
     echo "replica $i KV #tokens: ${resolved_tokens:-not found}"
   done

--- a/sglang_omni/config/path.py
+++ b/sglang_omni/config/path.py
@@ -178,7 +178,9 @@ _REMOVED_FIELD_GUIDANCE: dict[str, str] = {
     "runtime": (
         "the runtime group was removed: resources.total_gpu_memory_fraction "
         "is now the stage-level gpu_memory_fraction, sglang_server_args is "
-        "now engine.* and the remaining fields moved to factory.*"
+        "now engine.*, memory.kv_cache_bytes is now engine.kv_cache_bytes, "
+        "memory.total_reserve_bytes and enforce_total_reserve are stage-level "
+        "fields, and the remaining fields moved to factory.*"
     ),
     "runtime_arg_map": (
         "runtime_arg_map was removed: stage factories take canonical "

--- a/sglang_omni/config/placement.py
+++ b/sglang_omni/config/placement.py
@@ -120,13 +120,16 @@ def validate_gpu_capacity(plan: StagePlacementPlan) -> None:
 
     Fractions and byte reserves are combined in the byte domain, so mixed
     fraction/byte colocation cannot overcommit a card while each domain's own
-    sum still looks fine. Skipped when device metadata is unavailable.
+    sum still looks fine. The KV pools summed over every stage instance on a
+    card, replica instances included, are a hard lower bound on their own, so
+    they are checked even when no stage declares a total reserve. Skipped when
+    device metadata is unavailable.
     """
 
     from sglang_omni.utils.gpu_memory import format_bytes_gib, get_gpu_device_info
 
     for gpu_id, gpu in sorted(plan.gpus.items()):
-        if gpu.total_reserve_bytes <= 0:
+        if gpu.total_reserve_bytes <= 0 and gpu.total_kv_cache_bytes <= 0:
             continue
         info = get_gpu_device_info(gpu_id)
         if info.total_memory_bytes is None:
@@ -135,7 +138,7 @@ def validate_gpu_capacity(plan: StagePlacementPlan) -> None:
             gpu.total_gpu_memory_fraction * info.total_memory_bytes
             + gpu.total_reserve_bytes
         )
-        if declared > info.total_memory_bytes:
+        if gpu.total_reserve_bytes > 0 and declared > info.total_memory_bytes:
             raise ValueError(
                 f"GPU {gpu_id} declared budgets exceed physical memory: "
                 f"fraction {gpu.total_gpu_memory_fraction:.3f} of "
@@ -143,6 +146,19 @@ def validate_gpu_capacity(plan: StagePlacementPlan) -> None:
                 f"total_reserve_bytes {format_bytes_gib(gpu.total_reserve_bytes)} "
                 f"= {format_bytes_gib(int(declared))}. Lower the stage budgets "
                 "or move a stage to another GPU."
+            )
+        if gpu.total_kv_cache_bytes > info.total_memory_bytes:
+            kv_stages = sorted(
+                placement.stage_name
+                for placement in plan.stages.values()
+                if placement.kv_cache_bytes and gpu_id in placement.gpu_ids
+            )
+            raise ValueError(
+                f"GPU {gpu_id} declared KV pools alone exceed physical memory: "
+                f"{format_bytes_gib(info.total_memory_bytes)} of VRAM against "
+                f"{format_bytes_gib(gpu.total_kv_cache_bytes)} summed over "
+                f"engine.kv_cache_bytes of {', '.join(kv_stages)}. Lower "
+                "engine.kv_cache_bytes or reduce the replica count."
             )
 
 

--- a/sglang_omni/config/placement.py
+++ b/sglang_omni/config/placement.py
@@ -18,6 +18,8 @@ class StagePlacement:
     gpu_ids: tuple[int, ...]
     tp_size: int
     total_gpu_memory_fraction: float | None
+    kv_cache_bytes: int | None = None
+    total_reserve_bytes: int | None = None
 
 
 @dataclass(frozen=True)
@@ -27,6 +29,8 @@ class GpuPlacement:
     total_gpu_memory_fraction: float
     has_memory_fraction: bool
     missing_fraction_stage_names: tuple[str, ...]
+    total_kv_cache_bytes: int
+    total_reserve_bytes: int
 
 
 @dataclass(frozen=True)
@@ -64,22 +68,27 @@ class StagePlacementPlanner:
     ) -> StagePlacementPlan:
         stages = stages_cfg if stages_cfg is not None else self._config.stages
         placements: dict[str, StagePlacement] = {}
-        gpu_entries: dict[int, list[tuple[str, float | None]]] = defaultdict(list)
+        gpu_entries: dict[int, list[StagePlacement]] = defaultdict(list)
 
         for stage in stages:
             gpu_ids = _resolve_stage_gpu_ids(stage)
             if not gpu_ids:
                 continue
 
-            fraction = stage.gpu_memory_fraction
-            placements[stage.name] = StagePlacement(
+            kv_cache_bytes = (
+                stage.engine.kv_cache_bytes if stage.engine is not None else None
+            )
+            placement = StagePlacement(
                 stage_name=stage.name,
                 gpu_ids=gpu_ids,
                 tp_size=stage.tp_size,
-                total_gpu_memory_fraction=fraction,
+                total_gpu_memory_fraction=stage.gpu_memory_fraction,
+                kv_cache_bytes=kv_cache_bytes,
+                total_reserve_bytes=stage.total_reserve_bytes,
             )
+            placements[stage.name] = placement
             for gpu_id in gpu_ids:
-                gpu_entries[gpu_id].append((stage.name, fraction))
+                gpu_entries[gpu_id].append(placement)
 
         gpu_plans = {
             gpu_id: _build_gpu_placement(gpu_id, entries)
@@ -104,6 +113,37 @@ class StagePlacementPlanner:
                     f"{gpu.total_gpu_memory_fraction:.3f} exceeds placement limit "
                     f"{limit:.3f}"
                 )
+
+
+def validate_gpu_capacity(plan: StagePlacementPlan) -> None:
+    """Fail before spawn when declared budgets exceed a GPU's physical memory.
+
+    Fractions and byte reserves are combined in the byte domain, so mixed
+    fraction/byte colocation cannot overcommit a card while each domain's own
+    sum still looks fine. Skipped when device metadata is unavailable.
+    """
+
+    from sglang_omni.utils.gpu_memory import format_bytes_gib, get_gpu_device_info
+
+    for gpu_id, gpu in sorted(plan.gpus.items()):
+        if gpu.total_reserve_bytes <= 0:
+            continue
+        info = get_gpu_device_info(gpu_id)
+        if info.total_memory_bytes is None:
+            continue
+        declared = (
+            gpu.total_gpu_memory_fraction * info.total_memory_bytes
+            + gpu.total_reserve_bytes
+        )
+        if declared > info.total_memory_bytes:
+            raise ValueError(
+                f"GPU {gpu_id} declared budgets exceed physical memory: "
+                f"fraction {gpu.total_gpu_memory_fraction:.3f} of "
+                f"{format_bytes_gib(info.total_memory_bytes)} plus "
+                f"total_reserve_bytes {format_bytes_gib(gpu.total_reserve_bytes)} "
+                f"= {format_bytes_gib(int(declared))}. Lower the stage budgets "
+                "or move a stage to another GPU."
+            )
 
 
 def build_stage_placement_plan(
@@ -166,25 +206,34 @@ def _resolve_stage_gpu_ids(stage: StageConfig) -> tuple[int, ...]:
 
 def _build_gpu_placement(
     gpu_id: int,
-    entries: list[tuple[str, float | None]],
+    entries: list[StagePlacement],
 ) -> GpuPlacement:
     total = 0.0
+    total_kv_cache_bytes = 0
+    total_reserve_bytes = 0
     has_memory_fraction = False
     missing: set[str] = set()
     stage_names: list[str] = []
-    for stage_name, fraction in entries:
-        stage_names.append(stage_name)
-        if fraction is None:
-            missing.add(stage_name)
-            continue
-        has_memory_fraction = True
-        total += fraction
+    for entry in entries:
+        stage_names.append(entry.stage_name)
+        if entry.total_gpu_memory_fraction is None:
+            missing.add(entry.stage_name)
+        else:
+            has_memory_fraction = True
+            total += entry.total_gpu_memory_fraction
+
+        if entry.kv_cache_bytes is not None:
+            total_kv_cache_bytes += entry.kv_cache_bytes
+        if entry.total_reserve_bytes is not None:
+            total_reserve_bytes += entry.total_reserve_bytes
     return GpuPlacement(
         gpu_id=gpu_id,
         stage_names=tuple(stage_names),
         total_gpu_memory_fraction=total,
         has_memory_fraction=has_memory_fraction,
         missing_fraction_stage_names=tuple(sorted(missing)),
+        total_kv_cache_bytes=total_kv_cache_bytes,
+        total_reserve_bytes=total_reserve_bytes,
     )
 
 

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -151,6 +151,13 @@ class EngineArgs(BaseModel):
                 "pipeline's built-in defaults, set mem_fraction_static: null "
                 "on the same stage"
             )
+        if self.kv_cache_bytes is not None and self.max_total_tokens is not None:
+            raise ValueError(
+                "engine.kv_cache_bytes cannot be set together with "
+                "engine.max_total_tokens; both pin the generation stage's KV "
+                "capacity, and the lower token cap silently shrinks the "
+                "byte-derived pool"
+            )
 
     def overrides(self) -> dict[str, Any]:
         """Return the keys set on this block, declared and free-form alike.

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from typing import Any, ClassVar, Literal
 
@@ -40,6 +41,39 @@ def stage_process_name(stage: "StageConfig") -> str:
 logger = logging.getLogger(__name__)
 
 MAX_SPEECH_INPUT_CHARS: int = 4096
+
+
+def parse_memory_bytes(field_name: str, value: int | str | None) -> int | None:
+    """Parse a byte count given as an int or an exact binary-size string."""
+
+    format_error = (
+        f"{field_name} must be a positive integer byte count or an "
+        "exact binary-size string ending in KiB, MiB, GiB, or TiB"
+    )
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(format_error)
+    if isinstance(value, int):
+        if value <= 0:
+            raise ValueError(f"{field_name} must be positive")
+        return value
+    if not isinstance(value, str):
+        raise ValueError(format_error)
+
+    match = re.fullmatch(r"([0-9]+)(KiB|MiB|GiB|TiB)", value)
+    if match is None:
+        raise ValueError(format_error)
+    quantity = int(match.group(1))
+    if quantity <= 0:
+        raise ValueError(f"{field_name} must be positive")
+    unit_multipliers = {
+        "KiB": 1024,
+        "MiB": 1024**2,
+        "GiB": 1024**3,
+        "TiB": 1024**4,
+    }
+    return quantity * unit_multipliers[match.group(2)]
 
 
 class CommConfig(BaseModel):
@@ -91,10 +125,32 @@ class EngineArgs(BaseModel):
     cpu_offload_gb: int | None = Field(default=None, ge=0)
     quantization: str | None = Field(default=None, min_length=1)
     disable_custom_all_reduce: bool | None = None
+    kv_cache_bytes: int | None = Field(
+        default=None,
+        description=(
+            "Authoritative KV pool size in bytes, per rank; accepts an int or "
+            "an exact binary-size string such as 2GiB. Consumed by the omni "
+            "KV configurator, never forwarded to SGLang ServerArgs."
+        ),
+    )
+
+    _NON_SERVER_KEYS: ClassVar[frozenset[str]] = frozenset({"kv_cache_bytes"})
+
+    @field_validator("kv_cache_bytes", mode="before")
+    @classmethod
+    def _parse_kv_cache_bytes(cls, value: int | str | None) -> int | None:
+        return parse_memory_bytes("engine.kv_cache_bytes", value)
 
     def model_post_init(self, __context: Any = None) -> None:
         if self.quantization is not None and not self.quantization.strip():
             raise ValueError("engine.quantization must not be empty")
+        if self.kv_cache_bytes is not None and self.mem_fraction_static is not None:
+            raise ValueError(
+                "engine.kv_cache_bytes cannot be set together with "
+                "engine.mem_fraction_static; if the fraction comes from the "
+                "pipeline's built-in defaults, set mem_fraction_static: null "
+                "on the same stage"
+            )
 
     def overrides(self) -> dict[str, Any]:
         """Return the keys set on this block, declared and free-form alike.
@@ -107,7 +163,7 @@ class EngineArgs(BaseModel):
         return {
             key: value
             for key, value in self.model_dump().items()
-            if value is not None or key in extra
+            if (value is not None or key in extra) and key not in self._NON_SERVER_KEYS
         }
 
 
@@ -276,6 +332,25 @@ class StageConfig(BaseModel):
             "that process's budget."
         ),
     )
+    total_reserve_bytes: int | None = Field(
+        default=None,
+        description=(
+            "Per-replica total physical VRAM budget in bytes (weights, KV, "
+            "activations); accepts an int or an exact binary-size string. "
+            "Drives placement capacity checks and MPS preflight arithmetic, "
+            "and unless enforce_total_reserve is false it is enforced at "
+            "stage startup through a per-process torch allocator cap, so a "
+            "stage that outgrows its budget fails itself instead of a "
+            "co-tenant. The cap bounds torch allocations only; declared "
+            "budgets need headroom above the measured model footprint."
+        ),
+    )
+    enforce_total_reserve: bool = True
+
+    @field_validator("total_reserve_bytes", mode="before")
+    @classmethod
+    def _parse_total_reserve_bytes(cls, value: int | str | None) -> int | None:
+        return parse_memory_bytes("total_reserve_bytes", value)
 
     # --- Consumer groups ---
     engine: EngineArgs | None = None
@@ -329,6 +404,26 @@ class StageConfig(BaseModel):
             raise ValueError(
                 f"Stage {self.name!r} is not an engine stage; the engine block "
                 "only exists on stages whose factory drives an SGLang engine"
+            )
+        if (
+            self.total_reserve_bytes is not None
+            and self.gpu_memory_fraction is not None
+        ):
+            raise ValueError(
+                f"Stage {self.name!r}: total_reserve_bytes and "
+                "gpu_memory_fraction declare the same budget in two units; "
+                "keep exactly one (set the other to null if it comes from the "
+                "pipeline's built-in defaults)"
+            )
+        kv = self.engine.kv_cache_bytes if self.engine is not None else None
+        if (
+            kv is not None
+            and self.total_reserve_bytes is not None
+            and kv > self.total_reserve_bytes
+        ):
+            raise ValueError(
+                f"Stage {self.name!r}: engine.kv_cache_bytes must not exceed "
+                "total_reserve_bytes"
             )
 
         gpu = self.gpu

--- a/sglang_omni/config/topology.py
+++ b/sglang_omni/config/topology.py
@@ -389,6 +389,18 @@ def _render_missing_fraction_stages(
     return ", ".join(rendered)
 
 
+def _stage_lacks_declared_memory_budget(stage: StageConfig) -> bool:
+    """True when a stage does not declare its total GPU footprint.
+
+    Colocation needs each stage on a shared GPU to declare how much of the card
+    it intends to use in total. ``gpu_memory_fraction`` states that directly;
+    on the byte path only ``total_reserve_bytes`` does, because
+    ``engine.kv_cache_bytes`` covers the KV pool alone and says nothing about
+    weights, activations, or graphs.
+    """
+    return stage.gpu_memory_fraction is None and stage.total_reserve_bytes is None
+
+
 def _validate_gpu_process_colocation(
     config: PipelineConfig,
     gpu_placement: StagePlacementPlan,
@@ -420,7 +432,7 @@ def _validate_gpu_process_colocation(
         gpu_processes[gpu_id].add(process_name)
         if stage.name in replica_device_stage_names:
             replica_gpus.add(gpu_id)
-        if stage.gpu_memory_fraction is None:
+        if _stage_lacks_declared_memory_budget(stage):
             missing_fraction[gpu_id].add(stage.name)
 
     for group in topology_plan.groups:
@@ -452,8 +464,8 @@ def _validate_gpu_process_colocation(
                 else "is shared by multiple process groups"
             )
             raise ValueError(
-                f"GPU {gpu_id} {sharing} without "
-                "gpu_memory_fraction: "
+                f"GPU {gpu_id} {sharing} without a declared total "
+                "footprint (gpu_memory_fraction or total_reserve_bytes): "
                 f"{_render_missing_fraction_stages(missing, gpu_placement)}"
             )
         total = gpu_placement.gpus[gpu_id].total_gpu_memory_fraction

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -31,6 +31,7 @@ class ModelWorkerConfig:
     weight_prefix: str | None = None
     nccl_port: int | None = None
     total_gpu_memory_fraction: float | None = None
+    kv_cache_bytes: int | None = None
     enable_prefill_input_embeds: bool = False
 
 
@@ -70,6 +71,7 @@ class ModelWorker:
         self.weight_prefix = config.weight_prefix
         self.nccl_port = config.nccl_port
         self.total_gpu_memory_fraction = config.total_gpu_memory_fraction
+        self.kv_cache_bytes = config.kv_cache_bytes
         self.enable_prefill_input_embeds = config.enable_prefill_input_embeds
 
         self.gpu_id = gpu_id
@@ -243,6 +245,7 @@ class ModelWorker:
             model_arch_override=self.model_arch_override,
             weight_prefix=self.weight_prefix,
             total_gpu_memory_fraction=self.total_gpu_memory_fraction,
+            kv_cache_bytes=self.kv_cache_bytes,
         )
 
     def _init_dllm_algorithm(self):

--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -38,6 +38,21 @@ def filter_weights_by_prefix(
             yield name[len(prefix) :], tensor
 
 
+def _free_gpu_memory_bytes(device: Any, gpu_id: int) -> int:
+    """Currently free GPU memory in bytes, min-reduced across the world group."""
+    from sglang.srt.distributed.parallel_state import get_world_group
+    from sglang.srt.utils.common import get_available_gpu_memory
+
+    world_group = get_world_group()
+    free_gib = get_available_gpu_memory(
+        device,
+        gpu_id,
+        distributed=world_group.world_size > 1,
+        cpu_group=world_group.cpu_group,
+    )
+    return int(free_gib * (1 << 30))
+
+
 @dataclass(slots=True, kw_only=True)
 class _OmniKVCacheConfigurator(KVCacheConfigurator):
     """KV-cache configurator that honors an Omni colocated-stage memory budget.
@@ -48,6 +63,7 @@ class _OmniKVCacheConfigurator(KVCacheConfigurator):
     """
 
     total_gpu_memory_fraction: float | None = None
+    kv_cache_bytes: int | None = None
 
     def _profile_available_bytes(self, pre_model_load_memory: float) -> int:
         """Profile KV-cache headroom for colocated SGLang AR stages.
@@ -58,6 +74,14 @@ class _OmniKVCacheConfigurator(KVCacheConfigurator):
         another process can change global free memory while this process is
         loading weights, making the global delta too small or negative.
 
+        When ``kv_cache_bytes`` is declared it is authoritative: it becomes the
+        KV pool budget directly, with an explicit free-memory check so an
+        over-committed card fails with actionable numbers instead of a bare
+        CUDA OOM during pool allocation. The check covers pool allocation only;
+        later capture-time pressure is handled by the post-capture guard.
+        ``kv_cache_bytes`` is a per-rank pool size: every TP rank's engine
+        allocates the full amount on its assigned GPU.
+
         When a stage total-memory budget is provided, compute cache headroom as
         total GPU memory times that budget minus this stage's measured memory.
         NVML process accounting is preferred. If NVML cannot identify the
@@ -66,6 +90,35 @@ class _OmniKVCacheConfigurator(KVCacheConfigurator):
         upstream SGLang profiling semantics for ordinary non-colocated AR
         serving.
         """
+        if self.kv_cache_bytes is not None:
+            if self.kv_cache_bytes <= 0:
+                raise ValueError("kv_cache_bytes must be positive")
+            if self.mambaish_config is not None:
+                # Note (Jiaxin Deng): the byte branch bypasses upstream's mamba
+                # cache derivation; refuse rather than boot with it unsized.
+                raise ValueError(
+                    "engine.kv_cache_bytes does not support "
+                    "mamba/hybrid models yet; use fraction-based sizing"
+                )
+            free_bytes = self._free_gpu_memory_bytes()
+            if free_bytes < self.kv_cache_bytes:
+                raise ValueError(
+                    "Insufficient free GPU memory for the declared KV byte "
+                    f"budget after model load: requested kv_cache_bytes="
+                    f"{format_bytes_gib(self.kv_cache_bytes)} "
+                    f"({self.kv_cache_bytes} bytes), free="
+                    f"{format_bytes_gib(free_bytes)} ({free_bytes} bytes) on "
+                    f"gpu_id={self.gpu_id}. Lower engine.kv_cache_bytes "
+                    "or free memory on this GPU."
+                )
+            logger.info(
+                f"SGLang AR memory profile: gpu_mem_accounting=kv_cache_bytes "
+                f"gpu_id={self.gpu_id} "
+                f"kv_cache_bytes={format_bytes_gib(self.kv_cache_bytes)} "
+                f"free={format_bytes_gib(free_bytes)}"
+            )
+            return self.kv_cache_bytes
+
         if self.total_gpu_memory_fraction is None:
             return KVCacheConfigurator._profile_available_bytes(
                 self, pre_model_load_memory
@@ -92,6 +145,9 @@ class _OmniKVCacheConfigurator(KVCacheConfigurator):
             total_memory,
             process_memory,
         )
+
+    def _free_gpu_memory_bytes(self) -> int:
+        return _free_gpu_memory_bytes(self.device, self.gpu_id)
 
     def _profile_available_bytes_from_stage_load_delta(
         self,
@@ -170,9 +226,11 @@ class SGLModelRunner(ModelRunner):
         model_arch_override: str | None = None,
         weight_prefix: str | None = None,
         total_gpu_memory_fraction: float | None = None,
+        kv_cache_bytes: int | None = None,
     ) -> None:
         self._weight_prefix = weight_prefix
         self._total_gpu_memory_fraction = total_gpu_memory_fraction
+        self._kv_cache_bytes = kv_cache_bytes
         self._model_arch_override = model_arch_override
         self._weight_share_config = None
         self._weight_share_record = None
@@ -387,6 +445,34 @@ class SGLModelRunner(ModelRunner):
             self.post_capture_resize_kv_pool()
         return result
 
+    def post_capture_resize_kv_pool(self):
+        """Back the KV pool post-capture without silently shrinking a byte budget.
+
+        SGLang 0.5.16's post-capture sizing re-derives the pool from live free
+        memory, which can only shrink the pool below the declared
+        ``kv_cache_bytes`` when capture-time allocations ate into it. A byte
+        budget is authoritative, so a shrink must fail loudly instead of
+        serving with a silently clamped pool.
+        """
+        if self._kv_cache_bytes is None:
+            return super().post_capture_resize_kv_pool()
+
+        tokens_before = self.max_total_num_tokens
+        result = super().post_capture_resize_kv_pool()
+        if self.max_total_num_tokens < tokens_before:
+            free_bytes = _free_gpu_memory_bytes(self.device, self.gpu_id)
+            raise RuntimeError(
+                "Post-capture KV sizing cannot honor the declared byte budget: "
+                f"kv_cache_bytes={format_bytes_gib(self._kv_cache_bytes)} sized "
+                f"the pool at {tokens_before} tokens, but free memory minus the "
+                f"post-capture headroom only backs {self.max_total_num_tokens} "
+                f"tokens (free={format_bytes_gib(free_bytes)}, "
+                f"gpu_id={self.gpu_id}). Lower engine.kv_cache_bytes, "
+                "free memory on this GPU, or close a decode graph max_bs gap "
+                "below max_running_requests that raises the reserved headroom."
+            )
+        return result
+
     def _weight_update_blocked_reason(self) -> str | None:
         ws = self._weight_share_config
         if ws is None:
@@ -488,4 +574,5 @@ class SGLModelRunner(ModelRunner):
                 if field.init
             },
             total_gpu_memory_fraction=self._total_gpu_memory_fraction,
+            kv_cache_bytes=self._kv_cache_bytes,
         )

--- a/sglang_omni/models/qwen3_asr/engine_builder.py
+++ b/sglang_omni/models/qwen3_asr/engine_builder.py
@@ -273,10 +273,13 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
         # Replace the per-request decode mrope-position loop with a vectorized
         # equivalent before any forward runs.
         mrope_fast_path.apply_asr_mrope_fast_path()
+        from sglang_omni.scheduling.stage_kv_budget import peek_stage_kv_cache_bytes
+
+        kv_cache_bytes = peek_stage_kv_cache_bytes()
         logger.info(
             "Qwen3-ASR runtime profile: dtype=%s attention_backend=%s "
             "mm_attention_backend=%s cuda_graph=%s cuda_graph_bs=%s "
-            "torch_compile=%s max_running_requests=%s mem_fraction_static=%s",
+            "torch_compile=%s max_running_requests=%s kv_sizing=%s",
             getattr(server_args, "dtype", None),
             getattr(server_args, "attention_backend", None),
             getattr(server_args, "mm_attention_backend", None),
@@ -284,7 +287,12 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
             get_decode_cuda_graph_bs(server_args),
             getattr(server_args, "enable_torch_compile", False),
             getattr(server_args, "max_running_requests", None),
-            getattr(server_args, "mem_fraction_static", None),
+            (
+                f"kv_cache_bytes={kv_cache_bytes}"
+                if kv_cache_bytes is not None
+                else "mem_fraction_static="
+                f"{getattr(server_args, 'mem_fraction_static', None)}"
+            ),
         )
         self._log_memory_checkpoint("pre_model_load")
 

--- a/sglang_omni/models/qwen3_omni/placement.py
+++ b/sglang_omni/models/qwen3_omni/placement.py
@@ -120,15 +120,23 @@ class Qwen3OmniPlacementPolicy:
             )
 
     def _validate_colocated_qwen_runtime(self, stage_map) -> None:
+        # Note (Jiaxin Deng): the schema forbids fraction next to kv_cache_bytes,
+        # so requiring the fraction would outlaw every colocated byte budget.
         missing_budgets = [
             stage_name
             for stage_name in sorted(_COLOCATED_BUDGET_STAGES)
-            if stage_map[stage_name].gpu_memory_fraction is None
+            if (
+                stage_map[stage_name].gpu_memory_fraction is None
+                and (
+                    stage_map[stage_name].engine is None
+                    or stage_map[stage_name].engine.kv_cache_bytes is None
+                )
+            )
         ]
         if missing_budgets:
             raise ValueError(
-                "Qwen colocated speech requires gpu_memory_fraction for "
-                f"{missing_budgets}"
+                "Qwen colocated speech requires gpu_memory_fraction or "
+                f"engine.kv_cache_bytes for {missing_budgets}"
             )
 
         for stage_name in _AR_STAGES:

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -1065,13 +1065,24 @@ def create_sglang_thinker_executor_from_config(
         server_args=server_args,
     )
     if total_gpu_memory_fraction is None:
-        encoder_reserve_applied = _apply_qwen_thinker_encoder_reserve(
-            server_args,
-            has_explicit_mem_fraction_static=(
-                memory_contract.mem_fraction_static_pinned
-            ),
-            encoder_mem_reserve=encoder_mem_reserve,
-        )
+        from sglang_omni.scheduling.stage_kv_budget import peek_stage_kv_cache_bytes
+
+        # Note (Jiaxin Deng): under a byte budget the KV configurator ignores
+        # mem_fraction_static, so an encoder reserve would be a silent no-op.
+        if peek_stage_kv_cache_bytes() is not None:
+            logger.info(
+                "thinker declares engine.kv_cache_bytes; skipping the "
+                f"encoder_mem_reserve={encoder_mem_reserve} fraction adjustment"
+            )
+            encoder_reserve_applied = False
+        else:
+            encoder_reserve_applied = _apply_qwen_thinker_encoder_reserve(
+                server_args,
+                has_explicit_mem_fraction_static=(
+                    memory_contract.mem_fraction_static_pinned
+                ),
+                encoder_mem_reserve=encoder_mem_reserve,
+            )
         effective_total_gpu_memory_fraction = total_gpu_memory_fraction
         applied_encoder_reserve = (
             encoder_mem_reserve if encoder_reserve_applied else 0.0

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -17,6 +17,7 @@ from sglang_omni.config.placement import (
     StagePlacementPlan,
     resolve_gpu_stage_names,
     resolve_stage_gpu_ids,
+    validate_gpu_capacity,
 )
 from sglang_omni.config.runtime import (
     requires_factory_gpu_id,
@@ -289,6 +290,18 @@ def _resolve_same_process_targets(
     return same_process_targets
 
 
+def _stage_byte_budget_kwargs(stage_cfg: StageConfig) -> dict[str, Any]:
+    """Spec fields carrying the stage's byte budgets to the worker process."""
+
+    return {
+        "kv_cache_bytes": (
+            stage_cfg.engine.kv_cache_bytes if stage_cfg.engine is not None else None
+        ),
+        "total_reserve_bytes": stage_cfg.total_reserve_bytes,
+        "enforce_total_reserve": stage_cfg.enforce_total_reserve,
+    }
+
+
 def _build_single_stage_spec(
     *,
     stage_cfg: StageConfig,
@@ -312,6 +325,7 @@ def _build_single_stage_spec(
         factory_arg_defaults=resolve_stage_factory_arg_defaults(
             stage_cfg, config, gpu_id=gpu_id
         ),
+        **_stage_byte_budget_kwargs(stage_cfg),
         comm_config=comm_config,
         recv_endpoint=recv_endpoint,
         **stage_kwargs,
@@ -360,6 +374,7 @@ def _build_tp_stage_specs(
                     factory_arg_defaults=resolve_stage_factory_arg_defaults(
                         stage_cfg, config, gpu_id=gpu_id
                     ),
+                    **_stage_byte_budget_kwargs(stage_cfg),
                     comm_config=comm_config,
                     recv_endpoint=recv_endpoint,
                     follower_work_queues=follower_work_queues,
@@ -384,6 +399,7 @@ def _build_tp_stage_specs(
                 factory_arg_defaults=resolve_stage_factory_arg_defaults(
                     stage_cfg, config, gpu_id=gpu_id
                 ),
+                **_stage_byte_budget_kwargs(stage_cfg),
                 comm_config=comm_config,
                 recv_endpoint="",
                 internal_work_queue=follower_work_queues[idx],
@@ -501,6 +517,7 @@ class MultiProcessPipelineRunner:
             )
             self._prep = prep
             self._ipc_runtime_dir = prep.runtime_dir
+            validate_gpu_capacity(prep.placement_plan)
             groups = _build_stage_groups(
                 self._config,
                 ctx,

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -68,6 +68,11 @@ class StageLaunchConfig:
     factory_arg_defaults: dict[str, Any] = field(default_factory=dict)
     require_factory_gpu_id: bool = False
     env_defaults: dict[str, str] = field(default_factory=dict)
+    # Note (Jiaxin Deng): the byte budgets are first-class fields, never
+    # factory kwargs, so no factory signature can accidentally absorb them.
+    kv_cache_bytes: int | None = None
+    total_reserve_bytes: int | None = None
+    enforce_total_reserve: bool = True
 
     # Routing: static next stage(s)
     next_stages: str | list[str] | None = None
@@ -797,6 +802,49 @@ def _construct_stage(
     return stage
 
 
+# Summed declared reserves per device for this OS process; colocated stages
+# sharing a worker accumulate into one allocator cap.
+_process_reserve_bytes: dict[int, int] = {}
+
+
+def _apply_total_reserve_cap(
+    spec: StageLaunchConfig,
+    gpu_id: int | None,
+    log: logging.Logger,
+) -> None:
+    """Cap this process's torch allocator at its summed declared reserves.
+
+    Note (Jiaxin Deng): with the cap, a stage that outgrows its declared
+    budget OOMs itself instead of a co-tenant on the same GPU, which makes
+    the failure attributable.
+    """
+
+    if (
+        spec.total_reserve_bytes is None
+        or not spec.enforce_total_reserve
+        or gpu_id is None
+    ):
+        return
+    import torch
+
+    if not torch.cuda.is_available():
+        return
+    device = int(gpu_id)
+    total = torch.cuda.get_device_properties(device).total_memory
+    _process_reserve_bytes[device] = (
+        _process_reserve_bytes.get(device, 0) + spec.total_reserve_bytes
+    )
+    fraction = min(1.0, _process_reserve_bytes[device] / total)
+    torch.cuda.set_per_process_memory_fraction(fraction, device)
+    log.info(
+        "Stage %s: torch allocator capped at %d bytes on cuda:%d (fraction %.4f)",
+        spec.stage_name,
+        _process_reserve_bytes[device],
+        device,
+        fraction,
+    )
+
+
 def _construct_scheduler(
     spec: StageLaunchConfig,
     gpu_id: int | None,
@@ -804,6 +852,9 @@ def _construct_scheduler(
 ) -> Any:
     """Build a scheduler, serializing GPU factory work per visible device."""
 
+    from sglang_omni.scheduling.stage_kv_budget import stage_kv_cache_budget
+
+    _apply_total_reserve_cap(spec, gpu_id, log)
     factory = import_string(spec.factory)
     factory_args = apply_typed_stage_kwargs(
         factory,
@@ -811,6 +862,7 @@ def _construct_scheduler(
         spec.typed_kwargs,
         stage_name=spec.stage_name,
     )
+    kv_cache_bytes = spec.kv_cache_bytes
     factory_args = resolve_factory_signature_args(
         factory,
         factory_args,
@@ -818,12 +870,19 @@ def _construct_scheduler(
         require_gpu_id=spec.require_factory_gpu_id,
         stage_name=spec.stage_name,
     )
+
+    def _invoke() -> Any:
+        if kv_cache_bytes is None:
+            return factory(**factory_args)
+        with stage_kv_cache_budget(spec.stage_name, kv_cache_bytes):
+            return factory(**factory_args)
+
     if gpu_id is None:
-        return factory(**factory_args)
+        return _invoke()
 
     with gpu_startup_lock(int(gpu_id)) as lock_path:
         log.info(f"Acquired GPU startup lock for stage {spec.stage_name}: {lock_path}")
-        return factory(**factory_args)
+        return _invoke()
 
 
 def _prepare_accelerator_environment(

--- a/sglang_omni/scheduling/bootstrap.py
+++ b/sglang_omni/scheduling/bootstrap.py
@@ -117,6 +117,7 @@ def create_sglang_infrastructure(
 
     from sglang_omni.model_runner.model_worker import ModelWorker, ModelWorkerConfig
     from sglang_omni.scheduling.sglang_backend import create_tree_cache
+    from sglang_omni.scheduling.stage_kv_budget import consume_stage_kv_cache_bytes
 
     if get_context().is_config_namespace_published("model"):
         raise RuntimeError(
@@ -127,16 +128,25 @@ def create_sglang_infrastructure(
 
     logger.info(_describe_sglang_runtime_configuration(server_args, gpu_id))
 
+    kv_cache_bytes = consume_stage_kv_cache_bytes()
     worker_config = ModelWorkerConfig(
         model_arch_override=model_arch_override,
         weight_prefix=weight_prefix,
         nccl_port=nccl_port,
         total_gpu_memory_fraction=total_gpu_memory_fraction,
+        kv_cache_bytes=kv_cache_bytes,
         enable_prefill_input_embeds=enable_prefill_input_embeds,
     )
     from sglang.srt.utils.tensor_bridge import use_mlx
 
     if use_mlx():
+        # Note (Jiaxin Deng): the MLX worker sizes no SGLang KV pool, so a
+        # declared byte budget could only be ignored; refuse instead.
+        if kv_cache_bytes is not None:
+            raise ValueError(
+                "engine.kv_cache_bytes is not supported on the MLX path; "
+                "remove it or run this stage on CUDA"
+            )
         from sglang_omni.model_runner.mlx_model_worker import create_mlx_model_worker
 
         model_worker = create_mlx_model_worker(

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from numbers import Integral
@@ -16,6 +17,8 @@ from sglang_omni.scheduling.generation_batch_policy import (
     validate_generation_batch_policy,
 )
 from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoint
+
+logger = logging.getLogger(__name__)
 
 
 def _operator_selected_prefill_graph_backend(
@@ -121,6 +124,18 @@ class SGLangGenerationEngineBuilder(ABC):
                     f"{self.model_name} does not support a context_length override"
                 )
             overrides.pop("context_length")
+        # Note (Jiaxin Deng): user fractions were rejected upstream; what remains
+        # is a builder KV-tuned default, dropped so headroom derives cleanly.
+        from sglang_omni.scheduling.stage_kv_budget import peek_stage_kv_cache_bytes
+
+        if peek_stage_kv_cache_bytes() is not None:
+            builder_default_fraction = overrides.pop("mem_fraction_static", None)
+            if builder_default_fraction is not None:
+                logger.info(
+                    f"{self.model_name}: clearing builder default "
+                    f"mem_fraction_static={builder_default_fraction} because the "
+                    "stage declares runtime.memory.kv_cache_bytes"
+                )
         # Left unset, SGLang re-detects off a CUDA-first ladder that can contradict
         # placement. It owns the type, not the index.
         resolved_type = torch.device(device).type

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -134,7 +134,7 @@ class SGLangGenerationEngineBuilder(ABC):
                 logger.info(
                     f"{self.model_name}: clearing builder default "
                     f"mem_fraction_static={builder_default_fraction} because the "
-                    "stage declares runtime.memory.kv_cache_bytes"
+                    "stage declares engine.kv_cache_bytes"
                 )
         # Left unset, SGLang re-detects off a CUDA-first ladder that can contradict
         # placement. It owns the type, not the index.

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -1287,8 +1287,13 @@ class OmniScheduler:
         if required_tokens <= kv_capacity:
             return None
 
+        kv_cache_bytes = getattr(
+            getattr(self, "tp_worker", None), "kv_cache_bytes", None
+        )
         mem_fraction = self.server_args.mem_fraction_static
-        if mem_fraction is not None:
+        if kv_cache_bytes is not None:
+            mem_hint = " Try raising runtime.memory.kv_cache_bytes."
+        elif mem_fraction is not None:
             mem_hint = (
                 f" Current mem_fraction_static is {mem_fraction:.3f}; try setting "
                 "--thinker-mem-fraction-static higher."

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -1292,7 +1292,7 @@ class OmniScheduler:
         )
         mem_fraction = self.server_args.mem_fraction_static
         if kv_cache_bytes is not None:
-            mem_hint = " Try raising runtime.memory.kv_cache_bytes."
+            mem_hint = " Try raising engine.kv_cache_bytes."
         elif mem_fraction is not None:
             mem_hint = (
                 f" Current mem_fraction_static is {mem_fraction:.3f}; try setting "

--- a/sglang_omni/scheduling/stage_kv_budget.py
+++ b/sglang_omni/scheduling/stage_kv_budget.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Deliver a stage's declared KV byte budget to its SGLang engine bootstrap.
+
+A stage's ``runtime.memory.kv_cache_bytes`` must reach the KV-cache
+configurator without threading a new keyword argument through every model's
+factory and engine-builder signature. The stage worker scopes the budget
+around the single factory invocation choke point, and
+``create_sglang_infrastructure`` consumes it at the single engine construction
+choke point, so model files need no per-model plumbing and a newly added model
+is covered automatically.
+"""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+
+@dataclass
+class _StageKvBudget:
+    stage_name: str
+    kv_cache_bytes: int
+    consumed: bool = False
+
+
+_local = threading.local()
+
+
+def _current() -> _StageKvBudget | None:
+    return getattr(_local, "budget", None)
+
+
+@contextmanager
+def stage_kv_cache_budget(stage_name: str, kv_cache_bytes: int):
+    """Scope a declared KV byte budget around one stage factory invocation.
+
+    Raises on exit when the budget was never consumed: the stage declared
+    ``runtime.memory.kv_cache_bytes`` but its factory did not construct an
+    SGLang engine, so honoring the budget is impossible and silently ignoring
+    it would fake a guarantee the deployment relies on.
+    """
+    active = _current()
+    if active is not None:
+        raise RuntimeError(
+            f"stage_kv_cache_budget for stage {stage_name!r} cannot nest inside "
+            f"the active scope for stage {active.stage_name!r}"
+        )
+    budget = _StageKvBudget(stage_name=stage_name, kv_cache_bytes=kv_cache_bytes)
+    _local.budget = budget
+    try:
+        yield
+    finally:
+        _local.budget = None
+    if not budget.consumed:
+        raise RuntimeError(
+            f"Stage {stage_name!r} declares runtime.memory.kv_cache_bytes but its "
+            "factory did not build an SGLang engine that consumes a KV byte "
+            "budget; remove the setting or place it on a stage with a KV cache"
+        )
+
+
+def consume_stage_kv_cache_bytes() -> int | None:
+    """Return the scoped budget for engine construction, marking it consumed.
+
+    A second consumption in the same scope raises: two engines each sized to
+    the full stage budget would silently commit twice the declared bytes.
+    """
+    budget = _current()
+    if budget is None:
+        return None
+    if budget.consumed:
+        raise RuntimeError(
+            f"Stage {budget.stage_name!r} declares one "
+            "runtime.memory.kv_cache_bytes budget but its factory constructed "
+            "a second SGLang engine; a stage byte budget covers exactly one "
+            "engine's KV pool"
+        )
+    budget.consumed = True
+    return budget.kv_cache_bytes
+
+
+def peek_stage_kv_cache_bytes() -> int | None:
+    """Return the scoped budget without consuming it."""
+    budget = _current()
+    if budget is None:
+        return None
+    return budget.kv_cache_bytes

--- a/sglang_omni/scheduling/stage_kv_budget.py
+++ b/sglang_omni/scheduling/stage_kv_budget.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Deliver a stage's declared KV byte budget to its SGLang engine bootstrap.
 
-A stage's ``runtime.memory.kv_cache_bytes`` must reach the KV-cache
+A stage's ``engine.kv_cache_bytes`` must reach the KV-cache
 configurator without threading a new keyword argument through every model's
 factory and engine-builder signature. The stage worker scopes the budget
 around the single factory invocation choke point, and
@@ -36,7 +36,7 @@ def stage_kv_cache_budget(stage_name: str, kv_cache_bytes: int):
     """Scope a declared KV byte budget around one stage factory invocation.
 
     Raises on exit when the budget was never consumed: the stage declared
-    ``runtime.memory.kv_cache_bytes`` but its factory did not construct an
+    ``engine.kv_cache_bytes`` but its factory did not construct an
     SGLang engine, so honoring the budget is impossible and silently ignoring
     it would fake a guarantee the deployment relies on.
     """
@@ -54,7 +54,7 @@ def stage_kv_cache_budget(stage_name: str, kv_cache_bytes: int):
         _local.budget = None
     if not budget.consumed:
         raise RuntimeError(
-            f"Stage {stage_name!r} declares runtime.memory.kv_cache_bytes but its "
+            f"Stage {stage_name!r} declares engine.kv_cache_bytes but its "
             "factory did not build an SGLang engine that consumes a KV byte "
             "budget; remove the setting or place it on a stage with a KV cache"
         )
@@ -72,7 +72,7 @@ def consume_stage_kv_cache_bytes() -> int | None:
     if budget.consumed:
         raise RuntimeError(
             f"Stage {budget.stage_name!r} declares one "
-            "runtime.memory.kv_cache_bytes budget but its factory constructed "
+            "engine.kv_cache_bytes budget but its factory constructed "
             "a second SGLang engine; a stage byte budget covers exactly one "
             "engine's KV pool"
         )

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -130,14 +130,19 @@ def _stage_runtime_log_summary(pipeline_config: PipelineConfig) -> dict[str, Any
     summary: dict[str, Any] = {}
     for stage in pipeline_config.stages:
         fraction = stage.gpu_memory_fraction
+        kv_cache_bytes = (
+            stage.engine.kv_cache_bytes if stage.engine is not None else None
+        )
         mem_fraction = (
             stage.engine.mem_fraction_static if stage.engine is not None else None
         )
-        if stage.gpu is None and fraction is None:
+        if stage.gpu is None and fraction is None and kv_cache_bytes is None:
             continue
         summary[stage.name] = {
             "gpu": stage.gpu,
             "total_gpu_memory_fraction": fraction,
+            "kv_cache_bytes": kv_cache_bytes,
+            "total_reserve_bytes": stage.total_reserve_bytes,
             "mem_fraction_static": mem_fraction,
         }
     return summary
@@ -188,6 +193,8 @@ def _placement_log_summary(
                 "stages": list(gpu.stage_names),
                 "total_gpu_memory_fraction": round(gpu.total_gpu_memory_fraction, 3),
                 "missing_fraction_stages": list(gpu.missing_fraction_stage_names),
+                "total_kv_cache_bytes": gpu.total_kv_cache_bytes,
+                "total_reserve_bytes": gpu.total_reserve_bytes,
             }
             for gpu_id, gpu in placement_plan.gpus.items()
         },

--- a/tests/unit_test/fakes.py
+++ b/tests/unit_test/fakes.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import contextlib
+from types import SimpleNamespace
 
 
 class FakeExecutionBridge:
@@ -30,3 +31,12 @@ class FakeExecutionBridge:
 
     def record_completion(self):
         return self.device_module.Event()
+
+
+class FakeServerArgs(SimpleNamespace):
+    """ServerArgs double exposing the override() mutation entry point."""
+
+    def override(self, source: str, **fields: object) -> None:
+        del source
+        for name, value in fields.items():
+            setattr(self, name, value)

--- a/tests/unit_test/fixtures/pipeline_fakes.py
+++ b/tests/unit_test/fixtures/pipeline_fakes.py
@@ -568,3 +568,12 @@ def make_noop_projector(marker: str) -> Callable[[StagePayload], StagePayload]:
         )
 
     return _project
+
+
+def make_scheduler_consuming_kv_budget(**kwargs: Any) -> FakeScheduler:
+    from sglang_omni.scheduling.stage_kv_budget import consume_stage_kv_cache_bytes
+
+    scheduler = FakeScheduler()
+    scheduler.consumed_kv_cache_bytes = consume_stage_kv_cache_bytes()
+    scheduler.factory_kwargs = kwargs
+    return scheduler

--- a/tests/unit_test/pipeline/test_kv_budget_contract.py
+++ b/tests/unit_test/pipeline/test_kv_budget_contract.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Registry-wide contract: every registered model accepts a KV byte budget.
+
+The budget is delivered through the stage worker's ambient scope, so no model
+factory signature can miss it. What can still fail per model is the config
+resolution layer: a stage whose model config pins a conflicting memory
+setting, or a validation path that trips over the new typed field. Walking the
+registry makes such a regression fail here instead of on a user's deployment.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import sglang_omni.models
+from sglang_omni.config.runtime import (
+    resolve_stage_factory_kwargs,
+    resolve_stage_typed_kwargs,
+)
+from sglang_omni.models.registry import import_pipeline_configs
+
+_KV_BYTES = 2 * 1024**3
+
+
+def _registered_config_classes():
+    configs = import_pipeline_configs("sglang_omni.models", "config")
+    # Note (Jiaxin Deng): dedupe aliases so each config class is exercised once.
+    seen: dict[type, str] = {}
+    for arch, config_cls in sorted(configs.items()):
+        seen.setdefault(config_cls, arch)
+    return sorted(
+        ((arch, config_cls) for config_cls, arch in seen.items()),
+        key=lambda item: item[1].__name__,
+    )
+
+
+def _stage_with_kv_budget(stage):
+    """Rebuild the stage with a byte budget through real validation."""
+    data = stage.model_dump()
+    engine = dict(data.get("engine") or {})
+    engine["kv_cache_bytes"] = _KV_BYTES
+    engine["mem_fraction_static"] = None
+    data["engine"] = engine
+    return type(stage).model_validate(data)
+
+
+def test_registry_discovery_covers_every_model_package():
+    """import_pipeline_configs skips import failures; a skipped package would
+    make the walk below silently vacuous for that model, so pin coverage."""
+    packages_with_configs = {
+        path.parent.name
+        for path in Path(sglang_omni.models.__file__).parent.glob("*/config.py")
+    }
+    discovered_packages = {
+        config_cls.__module__.rsplit(".", 2)[-2]
+        for _, config_cls in _registered_config_classes()
+    }
+
+    missing = packages_with_configs - discovered_packages
+    assert not missing, f"registry silently skipped model packages: {sorted(missing)}"
+
+
+@pytest.mark.parametrize(
+    ("arch", "config_cls"),
+    _registered_config_classes(),
+    ids=lambda value: value if isinstance(value, str) else value.__name__,
+)
+def test_every_registered_model_stage_accepts_a_kv_byte_budget(arch, config_cls):
+    del arch
+    config = config_cls(model_path="dummy")
+
+    if not any(
+        config_cls.stage_config_cls(stage.name).engine_stage for stage in config.stages
+    ):
+        pytest.skip(
+            f"{config_cls.__name__} declares no SGLang engine stage; byte "
+            "budgets do not apply"
+        )
+
+    accepted = 0
+    for index, stage in enumerate(config.stages):
+        if not config_cls.stage_config_cls(stage.name).engine_stage:
+            continue
+        budgeted = _stage_with_kv_budget(stage)
+        config.stages[index] = budgeted
+
+        # The budget rides StageLaunchConfig.kv_cache_bytes, which the spec
+        # constructors read from stage.engine; it must never surface as a
+        # factory kwarg or a ServerArgs override.
+        assert budgeted.engine.kv_cache_bytes == _KV_BYTES
+        kwargs = resolve_stage_factory_kwargs(budgeted, config)
+        typed = resolve_stage_typed_kwargs(budgeted)
+        assert "kv_cache_bytes" not in kwargs
+        assert "kv_cache_bytes" not in (kwargs.get("server_args_overrides") or {})
+        assert "kv_cache_bytes" not in (typed.get("server_args_overrides") or {})
+        accepted += 1
+
+    assert accepted > 0, f"{config_cls.__name__} accepted a byte budget on no stage"

--- a/tests/unit_test/pipeline/test_placement.py
+++ b/tests/unit_test/pipeline/test_placement.py
@@ -342,3 +342,58 @@ def test_placement_policy_hook_runs_after_generic_plan() -> None:
 
     with pytest.raises(ValueError, match="policy rejected thinker"):
         build_stage_placement_plan(config)
+
+
+def test_gpu_capacity_check_rejects_kv_pools_over_vram(monkeypatch) -> None:
+    import sglang_omni.utils.gpu_memory as gpu_memory
+    from sglang_omni.config.placement import validate_gpu_capacity
+
+    config = PipelineConfig(
+        model_path="dummy",
+        stages=[
+            _stage("thinker", gpu=0, kv_cache_bytes=100 * 1024**3, terminal=True),
+        ],
+    )
+    plan = build_stage_placement_plan(config)
+    monkeypatch.setattr(
+        gpu_memory,
+        "get_gpu_device_info",
+        lambda gpu_id: SimpleNamespace(total_memory_bytes=80 * 1024**3),
+    )
+
+    with pytest.raises(ValueError, match="KV pools alone exceed physical memory"):
+        validate_gpu_capacity(plan)
+
+
+def test_gpu_capacity_check_sums_replica_kv_pools(monkeypatch) -> None:
+    import sglang_omni.utils.gpu_memory as gpu_memory
+    from sglang_omni.config.placement import validate_gpu_capacity
+    from sglang_omni.config.schema import ProcessConfig
+    from sglang_omni.config.topology import compile_logical_processes
+    from sglang_omni.pipeline.replicas import expand_replica_stages
+
+    config = PipelineConfig(
+        model_path="dummy",
+        stages=[
+            _stage("thinker", gpu=0, kv_cache_bytes=60 * 1024**3, terminal=True),
+        ],
+        processes={
+            "pipeline": ProcessConfig(num_replicas=2, replica_devices=[0, 0]),
+        },
+    )
+    logical_plan, stages_cfg = compile_logical_processes(config)
+    stages_cfg, replica_topology = expand_replica_stages(stages_cfg, logical_plan)
+    plan = build_stage_placement_plan(
+        config,
+        stages_cfg=stages_cfg,
+        replica_instances=replica_topology.replicas,
+    )
+    monkeypatch.setattr(
+        gpu_memory,
+        "get_gpu_device_info",
+        lambda gpu_id: SimpleNamespace(total_memory_bytes=80 * 1024**3),
+    )
+
+    assert plan.gpus[0].total_kv_cache_bytes == 120 * 1024**3
+    with pytest.raises(ValueError, match="KV pools alone exceed physical memory"):
+        validate_gpu_capacity(plan)

--- a/tests/unit_test/pipeline/test_placement.py
+++ b/tests/unit_test/pipeline/test_placement.py
@@ -1,9 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from sglang_omni.config import (
+    EngineArgs,
+    EngineStageConfig,
     PipelineConfig,
     StageConfig,
     build_stage_placement_plan,
@@ -18,10 +22,27 @@ def _stage(
     *,
     gpu: int | list[int] | None = None,
     fraction: float | None = None,
+    kv_cache_bytes: int | None = None,
+    total_reserve_bytes: int | None = None,
     tp_size: int = 1,
     terminal: bool = False,
     next_stage: str | None = None,
 ) -> StageConfig:
+    # Note (Jiaxin Deng): the engine block only exists on engine stages, so a
+    # byte-budgeted test stage must be an EngineStageConfig.
+    if kv_cache_bytes is not None:
+        return EngineStageConfig(
+            name=name,
+            process="pipeline",
+            factory_path=_FACTORY,
+            gpu=gpu,
+            tp_size=tp_size,
+            gpu_memory_fraction=fraction,
+            total_reserve_bytes=total_reserve_bytes,
+            engine=EngineArgs(kv_cache_bytes=kv_cache_bytes),
+            next=next_stage,
+            terminal=terminal,
+        )
     return StageConfig(
         name=name,
         process="pipeline",
@@ -29,9 +50,168 @@ def _stage(
         gpu=gpu,
         tp_size=tp_size,
         gpu_memory_fraction=fraction,
+        total_reserve_bytes=total_reserve_bytes,
         next=next_stage,
         terminal=terminal,
     )
+
+
+def test_same_gpu_colocation_sums_kv_byte_budgets() -> None:
+    config = PipelineConfig(
+        model_path="dummy",
+        stages=[
+            _stage(
+                "preprocess",
+                gpu=0,
+                kv_cache_bytes=1024**3,
+                next_stage="thinker",
+            ),
+            _stage(
+                "thinker",
+                gpu=0,
+                kv_cache_bytes=2 * 1024**3,
+                terminal=True,
+            ),
+        ],
+    )
+
+    plan = build_stage_placement_plan(config)
+
+    assert plan.stages["preprocess"].kv_cache_bytes == 1024**3
+    assert plan.stages["thinker"].kv_cache_bytes == 2 * 1024**3
+    assert plan.gpus[0].total_kv_cache_bytes == 3 * 1024**3
+    assert plan.gpus[0].total_reserve_bytes == 0
+
+
+def test_tp_kv_cache_bytes_is_per_rank_per_assigned_gpu() -> None:
+    stage = _stage(
+        "thinker",
+        gpu=[0, 1],
+        kv_cache_bytes=2 * 1024**3,
+        tp_size=2,
+        terminal=True,
+    )
+    config = PipelineConfig(model_path="dummy", stages=[stage])
+
+    plan = build_stage_placement_plan(config)
+
+    assert plan.stages["thinker"].kv_cache_bytes == 2 * 1024**3
+    assert plan.gpus[0].total_kv_cache_bytes == 2 * 1024**3
+    assert plan.gpus[1].total_kv_cache_bytes == 2 * 1024**3
+
+
+def test_mixed_fraction_and_byte_stages_sum_in_their_own_domains() -> None:
+    config = PipelineConfig(
+        model_path="dummy",
+        stages=[
+            _stage("preprocess", gpu=0, fraction=0.10, next_stage="thinker"),
+            _stage(
+                "thinker",
+                gpu=0,
+                kv_cache_bytes=2 * 1024**3,
+                total_reserve_bytes=8 * 1024**3,
+                terminal=True,
+            ),
+        ],
+    )
+
+    plan = build_stage_placement_plan(config)
+
+    assert plan.stages["preprocess"].kv_cache_bytes is None
+    assert plan.gpus[0].total_kv_cache_bytes == 2 * 1024**3
+    assert plan.gpus[0].total_reserve_bytes == 8 * 1024**3
+    assert plan.gpus[0].total_gpu_memory_fraction == pytest.approx(0.10)
+
+
+def test_placement_summary_includes_kv_cache_bytes(monkeypatch) -> None:
+    pytest.importorskip("sglang")
+    pytest.importorskip("uvicorn")
+    from sglang_omni.serve import launcher
+
+    config = PipelineConfig(
+        model_path="dummy",
+        stages=[
+            _stage("preprocess", gpu=0, fraction=0.10, next_stage="thinker"),
+            _stage("thinker", gpu=0, kv_cache_bytes=2 * 1024**3, terminal=True),
+        ],
+    )
+    plan = build_stage_placement_plan(config)
+    process_plan = SimpleNamespace(groups=(), tp_stage_to_processes={})
+
+    monkeypatch.setattr(
+        launcher,
+        "get_gpu_device_info",
+        lambda gpu_id: SimpleNamespace(
+            device_id=gpu_id,
+            name=f"gpu-{gpu_id}",
+            total_memory_bytes=24 * 1024**3,
+        ),
+    )
+
+    summary = launcher._placement_log_summary(
+        plan,
+        process_plan,
+        config,
+    )
+
+    assert summary["stage_runtime"]["thinker"]["kv_cache_bytes"] == 2 * 1024**3
+    assert summary["gpus"][0]["total_kv_cache_bytes"] == 2 * 1024**3
+    assert summary["gpus"][0]["total_reserve_bytes"] == 0
+
+
+def test_gpu_capacity_check_rejects_combined_overcommit(monkeypatch) -> None:
+    import sglang_omni.utils.gpu_memory as gpu_memory
+    from sglang_omni.config.placement import validate_gpu_capacity
+
+    config = PipelineConfig(
+        model_path="dummy",
+        stages=[
+            _stage("preprocess", gpu=0, fraction=0.90, next_stage="thinker"),
+            _stage(
+                "thinker",
+                gpu=0,
+                kv_cache_bytes=2 * 1024**3,
+                total_reserve_bytes=20 * 1024**3,
+                terminal=True,
+            ),
+        ],
+    )
+    plan = build_stage_placement_plan(config)
+    monkeypatch.setattr(
+        gpu_memory,
+        "get_gpu_device_info",
+        lambda gpu_id: SimpleNamespace(total_memory_bytes=80 * 1024**3),
+    )
+
+    with pytest.raises(ValueError, match="exceed physical memory"):
+        validate_gpu_capacity(plan)
+
+
+def test_gpu_capacity_check_passes_within_card(monkeypatch) -> None:
+    import sglang_omni.utils.gpu_memory as gpu_memory
+    from sglang_omni.config.placement import validate_gpu_capacity
+
+    config = PipelineConfig(
+        model_path="dummy",
+        stages=[
+            _stage("preprocess", gpu=0, fraction=0.50, next_stage="thinker"),
+            _stage(
+                "thinker",
+                gpu=0,
+                kv_cache_bytes=2 * 1024**3,
+                total_reserve_bytes=20 * 1024**3,
+                terminal=True,
+            ),
+        ],
+    )
+    plan = build_stage_placement_plan(config)
+    monkeypatch.setattr(
+        gpu_memory,
+        "get_gpu_device_info",
+        lambda gpu_id: SimpleNamespace(total_memory_bytes=80 * 1024**3),
+    )
+
+    validate_gpu_capacity(plan)
 
 
 def test_same_gpu_placement_records_missing_memory_fraction_stages() -> None:

--- a/tests/unit_test/pipeline/test_runtime_adapter.py
+++ b/tests/unit_test/pipeline/test_runtime_adapter.py
@@ -174,3 +174,17 @@ def test_a_plain_stage_carries_no_server_args() -> None:
     args = resolve_stage_factory_args(stage, config)
 
     assert "server_args_overrides" not in args
+
+
+def test_kv_cache_bytes_never_reaches_server_args_overrides() -> None:
+    """The byte budget rides the worker spec, not ServerArgs."""
+    from sglang_omni.config import EngineArgs
+    from sglang_omni.config.runtime import resolve_stage_typed_kwargs
+
+    stage = _stage(engine=EngineArgs(kv_cache_bytes="2GiB", max_running_requests=8))
+
+    kwargs = resolve_stage_typed_kwargs(stage)
+
+    overrides = kwargs["server_args_overrides"]
+    assert overrides["max_running_requests"] == 8
+    assert "kv_cache_bytes" not in overrides

--- a/tests/unit_test/pipeline/test_runtime_schema.py
+++ b/tests/unit_test/pipeline/test_runtime_schema.py
@@ -141,3 +141,60 @@ def test_pipeline_accepts_placement_config() -> None:
 def test_invalid_placement_limit_raises() -> None:
     with pytest.raises(ValueError, match="max_total_gpu_memory_fraction_per_gpu"):
         PlacementConfig(max_total_gpu_memory_fraction_per_gpu=1.1)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (2 * 1024**3, 2 * 1024**3),
+        ("512KiB", 512 * 1024),
+        ("128MiB", 128 * 1024**2),
+        ("2GiB", 2 * 1024**3),
+        ("1TiB", 1024**4),
+    ],
+)
+def test_engine_kv_cache_bytes_parses_sizes(value, expected) -> None:
+    from sglang_omni.config import EngineArgs
+
+    assert EngineArgs(kv_cache_bytes=value).kv_cache_bytes == expected
+
+
+@pytest.mark.parametrize("value", [0, -1, True, "2GB", "1.5GiB", "GiB", " 2GiB"])
+def test_engine_kv_cache_bytes_rejects_bad_values(value) -> None:
+    from sglang_omni.config import EngineArgs
+
+    with pytest.raises(ValueError):
+        EngineArgs(kv_cache_bytes=value)
+
+
+def test_engine_kv_cache_bytes_rejects_mem_fraction_static() -> None:
+    from sglang_omni.config import EngineArgs
+
+    with pytest.raises(ValueError, match="keep exactly one|cannot be set together"):
+        EngineArgs(kv_cache_bytes="2GiB", mem_fraction_static=0.7)
+
+
+def test_stage_total_reserve_rejects_gpu_memory_fraction() -> None:
+    from sglang_omni.config import StageConfig
+
+    with pytest.raises(ValueError, match="same budget in two units"):
+        StageConfig(
+            name="a",
+            factory_path="x.y",
+            terminal=True,
+            gpu_memory_fraction=0.5,
+            total_reserve_bytes="8GiB",
+        )
+
+
+def test_stage_rejects_kv_above_total_reserve() -> None:
+    from sglang_omni.config import EngineArgs, EngineStageConfig
+
+    with pytest.raises(ValueError, match="must not exceed"):
+        EngineStageConfig(
+            name="a",
+            factory_path="x.y",
+            terminal=True,
+            total_reserve_bytes="2GiB",
+            engine=EngineArgs(kv_cache_bytes="4GiB"),
+        )

--- a/tests/unit_test/pipeline/test_runtime_schema.py
+++ b/tests/unit_test/pipeline/test_runtime_schema.py
@@ -198,3 +198,10 @@ def test_stage_rejects_kv_above_total_reserve() -> None:
             total_reserve_bytes="2GiB",
             engine=EngineArgs(kv_cache_bytes="4GiB"),
         )
+
+
+def test_engine_kv_cache_bytes_rejects_max_total_tokens() -> None:
+    from sglang_omni.config import EngineArgs
+
+    with pytest.raises(ValueError, match="cannot be set together"):
+        EngineArgs(kv_cache_bytes="2GiB", max_total_tokens=4096)

--- a/tests/unit_test/pipeline/test_topology.py
+++ b/tests/unit_test/pipeline/test_topology.py
@@ -218,3 +218,78 @@ def test_tp_process_names_must_be_unique_across_tp_stages() -> None:
                 _stage("b", gpu=[2, 3], tp_size=2, process="model", terminal=True),
             ],
         )
+
+
+def _byte_budget_stage(
+    name: str,
+    *,
+    process: str,
+    kv_cache_bytes: int | None,
+    total_reserve_bytes: int | None,
+    next_stage: str | None = None,
+    terminal: bool = False,
+) -> StageConfig:
+    from sglang_omni.config import EngineArgs, EngineStageConfig
+
+    return EngineStageConfig(
+        name=name,
+        factory_path=_FACTORY,
+        gpu=0,
+        process=process,
+        total_reserve_bytes=total_reserve_bytes,
+        engine=EngineArgs(kv_cache_bytes=kv_cache_bytes),
+        next=next_stage,
+        terminal=terminal,
+    )
+
+
+def test_colocation_accepts_byte_budgeted_stages_with_total_reserve() -> None:
+    config = PipelineConfig(
+        model_path="dummy",
+        stages=[
+            _byte_budget_stage(
+                "a",
+                process="p1",
+                kv_cache_bytes=1024**3,
+                total_reserve_bytes=4 * 1024**3,
+                next_stage="b",
+            ),
+            _byte_budget_stage(
+                "b",
+                process="p2",
+                kv_cache_bytes=1024**3,
+                total_reserve_bytes=4 * 1024**3,
+                terminal=True,
+            ),
+        ],
+    )
+
+    _topology(config)
+
+
+def test_colocation_rejects_kv_only_stage_without_total_reserve() -> None:
+    """kv_cache_bytes covers the KV pool alone; sharing a GPU requires the
+    stage's total footprint, so a byte-budgeted colocated stage must also
+    declare total_reserve_bytes."""
+    config = PipelineConfig(
+        model_path="dummy",
+        stages=[
+            _byte_budget_stage(
+                "a",
+                process="p1",
+                kv_cache_bytes=1024**3,
+                total_reserve_bytes=None,
+                next_stage="b",
+            ),
+            _byte_budget_stage(
+                "b",
+                process="p2",
+                kv_cache_bytes=1024**3,
+                total_reserve_bytes=4 * 1024**3,
+                terminal=True,
+            ),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="declared total footprint"):
+        _topology(config)

--- a/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
+++ b/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
@@ -15,7 +15,9 @@ import sglang_omni.models.qwen3_omni.stages as qwen_stages
 from sglang_omni.platforms import current_platform
 
 
-def _configurator(*, total_gpu_memory_fraction: float | None):
+def _configurator(
+    *, total_gpu_memory_fraction: float | None, kv_cache_bytes: int | None = None
+):
     """Build the profiling surface without upstream's full field set.
 
     ``_OmniKVCacheConfigurator`` is a slots dataclass with ~25 required fields,
@@ -28,7 +30,117 @@ def _configurator(*, total_gpu_memory_fraction: float | None):
     configurator.device = "cuda"
     configurator.server_args = SimpleNamespace(mem_fraction_static=0.9)
     configurator.total_gpu_memory_fraction = total_gpu_memory_fraction
+    configurator.kv_cache_bytes = kv_cache_bytes
+    configurator.mambaish_config = None
     return configurator
+
+
+def test_kv_cache_bytes_budget_is_returned_verbatim(monkeypatch) -> None:
+    configurator = _configurator(
+        total_gpu_memory_fraction=None, kv_cache_bytes=2 * 1024**3
+    )
+    monkeypatch.setattr(
+        runner_mod, "_free_gpu_memory_bytes", lambda device, gpu_id: 50 * 1024**3
+    )
+
+    assert configurator._profile_available_bytes(0) == 2 * 1024**3
+
+
+def test_kv_cache_bytes_budget_wins_over_stage_fraction(monkeypatch) -> None:
+    configurator = _configurator(
+        total_gpu_memory_fraction=0.4, kv_cache_bytes=2 * 1024**3
+    )
+    monkeypatch.setattr(
+        runner_mod, "_free_gpu_memory_bytes", lambda device, gpu_id: 50 * 1024**3
+    )
+
+    assert configurator._profile_available_bytes(0) == 2 * 1024**3
+
+
+def test_kv_cache_bytes_rejects_mambaish_models() -> None:
+    """The byte branch bypasses upstream's mamba cache derivation; it must
+    refuse instead of booting a mamba model with the cache never sized."""
+    configurator = _configurator(
+        total_gpu_memory_fraction=None, kv_cache_bytes=2 * 1024**3
+    )
+    configurator.mambaish_config = object()
+
+    with pytest.raises(ValueError, match="mamba"):
+        configurator._profile_available_bytes(0)
+
+
+def test_kv_cache_bytes_over_free_memory_raises_actionable_error(monkeypatch) -> None:
+    configurator = _configurator(
+        total_gpu_memory_fraction=None, kv_cache_bytes=8 * 1024**3
+    )
+    monkeypatch.setattr(
+        runner_mod, "_free_gpu_memory_bytes", lambda device, gpu_id: 3 * 1024**3
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        configurator._profile_available_bytes(0)
+
+    message = str(exc_info.value)
+    assert "8.00GiB" in message
+    assert "3.00GiB" in message
+    assert "gpu_id=0" in message
+
+
+def test_post_capture_resize_shrinking_a_byte_budget_raises(monkeypatch) -> None:
+    from sglang.srt.model_executor.model_runner import ModelRunner
+
+    runner = runner_mod.SGLModelRunner.__new__(runner_mod.SGLModelRunner)
+    runner._kv_cache_bytes = 4 * 1024**3
+    runner.max_total_num_tokens = 1000
+    runner.gpu_id = 0
+    runner.device = "cuda"
+
+    def _shrinking_resize(self):
+        self.max_total_num_tokens = 600
+
+    monkeypatch.setattr(ModelRunner, "post_capture_resize_kv_pool", _shrinking_resize)
+    monkeypatch.setattr(
+        runner_mod, "_free_gpu_memory_bytes", lambda device, gpu_id: 1024**3
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        runner.post_capture_resize_kv_pool()
+
+    message = str(exc_info.value)
+    assert "4.00GiB" in message
+    assert "1000" in message
+    assert "600" in message
+
+
+def test_post_capture_resize_without_byte_budget_delegates(monkeypatch) -> None:
+    from sglang.srt.model_executor.model_runner import ModelRunner
+
+    runner = runner_mod.SGLModelRunner.__new__(runner_mod.SGLModelRunner)
+    runner._kv_cache_bytes = None
+    runner.max_total_num_tokens = 1000
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        ModelRunner,
+        "post_capture_resize_kv_pool",
+        lambda self: calls.append("upstream"),
+    )
+
+    runner.post_capture_resize_kv_pool()
+
+    assert calls == ["upstream"]
+
+
+def test_post_capture_resize_preserving_byte_budget_passes(monkeypatch) -> None:
+    from sglang.srt.model_executor.model_runner import ModelRunner
+
+    runner = runner_mod.SGLModelRunner.__new__(runner_mod.SGLModelRunner)
+    runner._kv_cache_bytes = 4 * 1024**3
+    runner.max_total_num_tokens = 1000
+
+    monkeypatch.setattr(ModelRunner, "post_capture_resize_kv_pool", lambda self: None)
+
+    runner.post_capture_resize_kv_pool()
 
 
 def _patch_thinker_startup(monkeypatch) -> list[dict[str, object]]:

--- a/tests/unit_test/scheduling/test_engine_factory.py
+++ b/tests/unit_test/scheduling/test_engine_factory.py
@@ -10,6 +10,7 @@ from typing import Any
 import pytest
 
 import sglang_omni.platforms as platforms
+from tests.unit_test.fakes import FakeServerArgs
 
 TEST_MAX_TOTAL_TOKENS = 82000
 
@@ -422,6 +423,141 @@ def test_tts_engine_builder_phase_order_and_override_contract(monkeypatch) -> No
     assert init_graph_calls == [True]
     assert scheduler.kwargs["server_args"].disable_cuda_graph is False
     assert scheduler.kwargs["model_runner"].outbox == "outbox"
+
+
+def _build_minimal_tts_builder_harness(monkeypatch):
+    """Fakes for exercising ``build()`` without CUDA graphs or a real engine."""
+    from sglang_omni.scheduling import bootstrap, sglang_backend
+    from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
+    from sglang_omni.scheduling.stage_kv_budget import consume_stage_kv_cache_bytes
+
+    monkeypatch.setattr(
+        platforms.current_platform, "device_type", "cuda", raising=False
+    )
+    monkeypatch.setattr(
+        "sglang.srt.utils.get_device", lambda device_id=None: f"cuda:{device_id}"
+    )
+
+    build_kwargs: dict[str, Any] = {}
+    consumed: list[int | None] = []
+
+    class FakeModel:
+        pass
+
+    class FakeWorker:
+        def __init__(self, server_args: Any) -> None:
+            self.model_runner = SimpleNamespace(
+                model=FakeModel(), server_args=server_args
+            )
+            self.model_config = SimpleNamespace(is_multimodal=False)
+            self.enable_prefill_input_embeds = False
+
+    def fake_build_sglang_server_args(
+        checkpoint_dir: str, *, context_length: int, **kwargs: Any
+    ) -> Any:
+        build_kwargs.update(kwargs)
+        return FakeServerArgs(
+            checkpoint_dir=checkpoint_dir,
+            context_length=context_length,
+            cuda_graph_bs=None,
+            cuda_graph_max_bs=None,
+            cuda_graph_config=SimpleNamespace(
+                decode=SimpleNamespace(max_bs=None, bs=None),
+                prefill=SimpleNamespace(backend="disabled", bs=None, max_bs=None),
+            ),
+            disable_cuda_graph=True,
+            enable_torch_compile=False,
+            max_running_requests=kwargs["max_running_requests"],
+            mem_fraction_static=kwargs.get("mem_fraction_static"),
+            torch_compile_max_bs=None,
+        )
+
+    def fake_create_sglang_infrastructure(
+        server_args: Any, gpu_id: int, **kwargs: Any
+    ) -> tuple[Any, ...]:
+        consumed.append(consume_stage_kv_cache_bytes())
+        return (
+            FakeWorker(server_args),
+            "tree_cache",
+            "req_pool",
+            "kv_pool",
+            "model_config",
+        )
+
+    monkeypatch.setattr(
+        sglang_backend, "build_sglang_server_args", fake_build_sglang_server_args
+    )
+    monkeypatch.setattr(
+        bootstrap, "create_sglang_infrastructure", fake_create_sglang_infrastructure
+    )
+    monkeypatch.setattr(
+        sglang_backend,
+        "SGLangOutputProcessor",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    class MinimalBuilder(TtsEngineBuilder):
+        model_name = "Test TTS"
+        context_length = 123
+
+        def resolve_checkpoint(self, model_path: str) -> str:
+            return model_path
+
+        def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
+            return {
+                "max_running_requests": 4,
+                "dtype": dtype,
+                "disable_cuda_graph": True,
+                "mem_fraction_static": 0.2,
+            }
+
+        def setup_model(self, **kwargs: Any) -> None:
+            pass
+
+        def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
+            return SimpleNamespace(model_worker=model_worker)
+
+        def make_adapters(self, model: Any) -> tuple[Any, Any]:
+            return "request_builder", "result_adapter"
+
+        def make_scheduler(self, **kwargs: Any) -> Any:
+            return SimpleNamespace(outbox="outbox")
+
+    return MinimalBuilder, build_kwargs, consumed
+
+
+def test_byte_budget_clears_builder_default_mem_fraction(monkeypatch, caplog) -> None:
+    """A KV-tuned builder default (e.g. dots 0.20) must not shape ServerArgs when
+    the byte budget owns KV sizing, or post-capture headroom inherits it."""
+    import logging
+
+    from sglang_omni.scheduling import engine_factory
+    from sglang_omni.scheduling.stage_kv_budget import stage_kv_cache_budget
+
+    MinimalBuilder, build_kwargs, consumed = _build_minimal_tts_builder_harness(
+        monkeypatch
+    )
+
+    with caplog.at_level(logging.INFO, logger=engine_factory.logger.name):
+        with stage_kv_cache_budget("tts_engine", 2 * 1024**3):
+            MinimalBuilder().build("model", device="cuda:0", gpu_id=0)
+
+    assert "mem_fraction_static" not in build_kwargs
+    assert consumed == [2 * 1024**3]
+    assert "clearing builder default mem_fraction_static=0.2" in caplog.text
+
+
+def test_without_byte_budget_builder_default_mem_fraction_is_kept(
+    monkeypatch,
+) -> None:
+    MinimalBuilder, build_kwargs, consumed = _build_minimal_tts_builder_harness(
+        monkeypatch
+    )
+
+    MinimalBuilder().build("model", device="cuda:0", gpu_id=0)
+
+    assert build_kwargs["mem_fraction_static"] == 0.2
+    assert consumed == [None]
 
 
 def test_asr_engine_builder_phase_order_and_failure_cleanup(monkeypatch) -> None:

--- a/tests/unit_test/scheduling/test_stage_kv_budget.py
+++ b/tests/unit_test/scheduling/test_stage_kv_budget.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The ambient KV byte budget scope and its stage-worker wiring.
+
+The budget must reach the engine bootstrap without touching model factory
+signatures, and a declared budget that no engine consumes must fail startup
+instead of being silently dropped.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from sglang_omni.pipeline.stage_workers import StageLaunchConfig, _construct_scheduler
+from sglang_omni.scheduling.stage_kv_budget import (
+    consume_stage_kv_cache_bytes,
+    peek_stage_kv_cache_bytes,
+    stage_kv_cache_budget,
+)
+from tests.unit_test.fixtures.pipeline_fakes import fake_factory_path
+
+_LOG = logging.getLogger(__name__)
+
+
+def test_consume_outside_scope_returns_none() -> None:
+    assert consume_stage_kv_cache_bytes() is None
+    assert peek_stage_kv_cache_bytes() is None
+
+
+def test_scope_delivers_budget_once_consumed() -> None:
+    with stage_kv_cache_budget("thinker", 2 * 1024**3):
+        assert peek_stage_kv_cache_bytes() == 2 * 1024**3
+        assert consume_stage_kv_cache_bytes() == 2 * 1024**3
+    assert consume_stage_kv_cache_bytes() is None
+
+
+def test_second_consume_in_one_scope_raises() -> None:
+    """Two engines each taking the full stage budget would silently commit
+    twice the declared bytes."""
+    with stage_kv_cache_budget("thinker", 2 * 1024**3):
+        assert consume_stage_kv_cache_bytes() == 2 * 1024**3
+        with pytest.raises(RuntimeError, match="second SGLang engine"):
+            consume_stage_kv_cache_bytes()
+    assert peek_stage_kv_cache_bytes() is None
+
+
+def test_unconsumed_scope_raises_on_exit() -> None:
+    with pytest.raises(RuntimeError, match="'vocoder'.*did not build"):
+        with stage_kv_cache_budget("vocoder", 1024**3):
+            pass
+    assert peek_stage_kv_cache_bytes() is None
+
+
+def test_peek_does_not_count_as_consumption() -> None:
+    with pytest.raises(RuntimeError, match="did not build"):
+        with stage_kv_cache_budget("thinker", 1024**3):
+            peek_stage_kv_cache_bytes()
+
+
+def test_factory_exception_is_not_masked_by_consumption_check() -> None:
+    with pytest.raises(ValueError, match="factory boom"):
+        with stage_kv_cache_budget("thinker", 1024**3):
+            raise ValueError("factory boom")
+    assert peek_stage_kv_cache_bytes() is None
+
+
+def test_nested_scopes_are_rejected() -> None:
+    with pytest.raises(RuntimeError, match="cannot nest"):
+        with stage_kv_cache_budget("thinker", 1024**3):
+            with stage_kv_cache_budget("talker_ar", 1024**3):
+                pass
+
+
+def _spec(factory_name: str, kv_cache_bytes: int | None = None) -> StageLaunchConfig:
+    return StageLaunchConfig(
+        stage_name="thinker",
+        factory=fake_factory_path(factory_name),
+        kv_cache_bytes=kv_cache_bytes,
+    )
+
+
+def test_construct_scheduler_scopes_budget_around_factory() -> None:
+    spec = _spec(
+        "make_scheduler_consuming_kv_budget",
+        kv_cache_bytes=3 * 1024**3,
+    )
+
+    scheduler = _construct_scheduler(spec, None, _LOG)
+
+    assert scheduler.consumed_kv_cache_bytes == 3 * 1024**3
+    assert "kv_cache_bytes" not in scheduler.factory_kwargs
+
+
+def test_construct_scheduler_fails_when_budget_is_not_consumed() -> None:
+    spec = _spec("make_scheduler", kv_cache_bytes=3 * 1024**3)
+
+    with pytest.raises(RuntimeError, match="'thinker'.*did not build"):
+        _construct_scheduler(spec, None, _LOG)
+
+
+def test_construct_scheduler_without_budget_opens_no_scope() -> None:
+    spec = _spec("make_scheduler_consuming_kv_budget")
+
+    scheduler = _construct_scheduler(spec, None, _LOG)
+
+    assert scheduler.consumed_kv_cache_bytes is None
+
+
+def test_total_reserve_cap_accumulates_across_colocated_stages(monkeypatch):
+    import sys
+    from types import SimpleNamespace
+
+    import sglang_omni.pipeline.stage_workers as stage_workers
+
+    calls: list[tuple[float, int]] = []
+    fake_cuda = SimpleNamespace(
+        is_available=lambda: True,
+        get_device_properties=lambda device: SimpleNamespace(total_memory=100),
+        set_per_process_memory_fraction=lambda fraction, device: calls.append(
+            (round(fraction, 4), device)
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(cuda=fake_cuda))
+    monkeypatch.setattr(stage_workers, "_process_reserve_bytes", {})
+
+    first = StageLaunchConfig(stage_name="a", total_reserve_bytes=30)
+    second = StageLaunchConfig(stage_name="b", total_reserve_bytes=50)
+    stage_workers._apply_total_reserve_cap(first, 0, _LOG)
+    stage_workers._apply_total_reserve_cap(second, 0, _LOG)
+
+    assert calls == [(0.3, 0), (0.8, 0)]
+
+
+def test_total_reserve_cap_respects_opt_out_and_absence(monkeypatch):
+    import sys
+    from types import SimpleNamespace
+
+    import sglang_omni.pipeline.stage_workers as stage_workers
+
+    calls: list[tuple[float, int]] = []
+    fake_cuda = SimpleNamespace(
+        is_available=lambda: True,
+        get_device_properties=lambda device: SimpleNamespace(total_memory=100),
+        set_per_process_memory_fraction=lambda fraction, device: calls.append(
+            (fraction, device)
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(cuda=fake_cuda))
+    monkeypatch.setattr(stage_workers, "_process_reserve_bytes", {})
+
+    opted_out = StageLaunchConfig(
+        stage_name="a", total_reserve_bytes=30, enforce_total_reserve=False
+    )
+    undeclared = StageLaunchConfig(stage_name="b")
+    stage_workers._apply_total_reserve_cap(opted_out, 0, _LOG)
+    stage_workers._apply_total_reserve_cap(undeclared, 0, _LOG)
+
+    assert calls == []

--- a/tests/unit_test/serve/test_mps_dp_support.py
+++ b/tests/unit_test/serve/test_mps_dp_support.py
@@ -27,6 +27,7 @@ from sglang_omni.models.moss_tts_local.config import MossTTSLocalPipelineConfig
 from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
 from sglang_omni.models.whisper_asr.config import WhisperASRPipelineConfig
 from sglang_omni.utils import ipc_weights
+from sglang_omni.utils.gpu_memory import GpuDeviceInfo
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 MPS_DP_DIR = REPO_ROOT / "examples" / "mps_dp"
@@ -56,6 +57,13 @@ def _write_yaml(tmp_path: Path, config_cls: str, name: str = "probe") -> Path:
         encoding="utf-8",
     )
     return path
+
+
+def _strict_budget(*args, **kwargs):
+    """Strict-mode resolve: tests always want the missing-budget error."""
+    return mps_dp_config._resolve_mps_memory_budget(
+        *args, allow_missing_budget=False, **kwargs
+    )
 
 
 def test_registry_matches_weight_share_policies():
@@ -131,6 +139,206 @@ def test_weight_share_rejected_for_unvalidated_configs(tmp_path, config_cls):
         mps_dp_config.resolve_max_total_tokens(yaml_path, weight_share=True)
 
 
+def _write_budget_yaml(
+    tmp_path: Path,
+    *,
+    kv_cache_bytes: str,
+    total_reserve_bytes: str | None = None,
+) -> Path:
+    path = tmp_path / "budget-probe.yaml"
+    lines = [
+        "config_cls: Qwen3ASRPipelineConfig",
+        "name: budget-probe",
+        "model_path: dummy/none",
+        "stages:",
+        "  asr:",
+        "    engine:",
+        f"      kv_cache_bytes: {kv_cache_bytes}",
+    ]
+    if total_reserve_bytes is not None:
+        lines.append(f"    total_reserve_bytes: {total_reserve_bytes}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def gpu_with_16gib(monkeypatch):
+    monkeypatch.setattr(
+        mps_dp_config,
+        "get_gpu_device_info",
+        lambda gpu_id: GpuDeviceInfo(
+            logical_gpu_id=gpu_id,
+            device_id=gpu_id,
+            name="RTX 4070 Ti",
+            total_memory_bytes=16 * 1024**3,
+        ),
+    )
+
+
+def test_budget_rejects_kv_pools_over_physical_vram(tmp_path, gpu_with_16gib):
+    yaml_path = _write_budget_yaml(tmp_path, kv_cache_bytes="9GiB")
+    with pytest.raises(ValueError, match="18.00GiB of KV pools"):
+        _strict_budget(yaml_path, gpu_id=0, replicas=2)
+
+
+def test_kv_hard_bound_applies_with_weight_share_too(tmp_path, gpu_with_16gib):
+    yaml_path = _write_budget_yaml(tmp_path, kv_cache_bytes="9GiB")
+    with pytest.raises(ValueError, match="KV pools"):
+        _strict_budget(yaml_path, gpu_id=0, replicas=2, weight_share=True)
+
+
+def test_budget_rejects_declared_reserve_total_over_physical_vram(
+    tmp_path, gpu_with_16gib
+):
+    yaml_path = _write_budget_yaml(
+        tmp_path, kv_cache_bytes="6GiB", total_reserve_bytes="9GiB"
+    )
+    with pytest.raises(ValueError, match="requested=18.00GiB"):
+        _strict_budget(yaml_path, gpu_id=0, replicas=2)
+
+
+def test_budget_within_vram_passes_with_declared_reserve(tmp_path, gpu_with_16gib):
+    yaml_path = _write_budget_yaml(
+        tmp_path, kv_cache_bytes="6GiB", total_reserve_bytes="8GiB"
+    )
+
+    budget = _strict_budget(yaml_path, gpu_id=0, replicas=2)
+
+    assert budget["per_replica_kv_cache_bytes"] == 6 * 1024**3
+    assert budget["total_kv_cache_bytes"] == 12 * 1024**3
+    assert budget["requested_total_bytes"] == 16 * 1024**3
+
+
+def test_omitted_reserve_passes_kv_bound_and_warns_for_dp(
+    tmp_path, gpu_with_16gib, capsys
+):
+    """No invented reserve default: kv-only DP2 must pass the hard bound, and
+    the unvalidated total footprint is called out instead of being charged a
+    number the user never wrote."""
+    yaml_path = _write_budget_yaml(tmp_path, kv_cache_bytes="6GiB")
+
+    budget = _strict_budget(yaml_path, gpu_id=0, replicas=2)
+
+    assert budget["total_kv_cache_bytes"] == 12 * 1024**3
+    assert "requested_total_bytes" not in budget
+    err = capsys.readouterr().err
+    assert "NOT validated" in err
+    assert "8.00GiB" in err
+
+
+def test_omitted_reserve_single_replica_does_not_warn(tmp_path, gpu_with_16gib, capsys):
+    yaml_path = _write_budget_yaml(tmp_path, kv_cache_bytes="6GiB")
+
+    _strict_budget(yaml_path, gpu_id=0, replicas=1)
+
+    assert capsys.readouterr().err == ""
+
+
+def test_kv_error_only_cites_user_written_numbers(tmp_path, gpu_with_16gib):
+    yaml_path = _write_budget_yaml(tmp_path, kv_cache_bytes="9GiB")
+
+    with pytest.raises(ValueError) as exc_info:
+        _strict_budget(yaml_path, gpu_id=0, replicas=2)
+
+    message = str(exc_info.value)
+    assert "total_reserve_bytes" not in message
+    assert "even split" not in message
+
+
+def test_weight_share_budget_skips_reserve_total_check(
+    tmp_path, gpu_with_16gib, capsys
+):
+    yaml_path = _write_budget_yaml(
+        tmp_path, kv_cache_bytes="6GiB", total_reserve_bytes="9GiB"
+    )
+
+    budget = _strict_budget(yaml_path, gpu_id=0, replicas=2, weight_share=True)
+
+    assert budget["per_replica_total_reserve_bytes"] == 9 * 1024**3
+    assert "requested_total_bytes" not in budget
+    assert "2-way total is NOT validated" in capsys.readouterr().err
+
+
+def test_weight_share_still_bounds_one_replica_reserve(tmp_path, gpu_with_16gib):
+    """The weight-share warning claims one replica's reservation was checked
+    against VRAM; the check must actually exist."""
+    yaml_path = _write_budget_yaml(
+        tmp_path, kv_cache_bytes="6GiB", total_reserve_bytes="20GiB"
+    )
+
+    with pytest.raises(ValueError, match="one replica"):
+        _strict_budget(yaml_path, gpu_id=0, replicas=2, weight_share=True)
+
+
+def _write_reserve_only_yaml(tmp_path: Path) -> Path:
+    path = tmp_path / "reserve-only.yaml"
+    path.write_text(
+        "\n".join(
+            [
+                "config_cls: Qwen3ASRPipelineConfig",
+                "name: reserve-only",
+                "model_path: dummy/none",
+                "stages:",
+                "  asr:",
+                "    total_reserve_bytes: 9GiB",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_reserve_only_config_still_gets_the_reserve_bound(tmp_path, gpu_with_16gib):
+    """A legacy-fraction migration config declaring only total_reserve_bytes
+    must not skip preflight entirely."""
+    yaml_path = _write_reserve_only_yaml(tmp_path)
+
+    with pytest.raises(ValueError, match="total_reserve_bytes"):
+        mps_dp_config._resolve_mps_memory_budget(
+            yaml_path, gpu_id=0, replicas=2, allow_missing_budget=True
+        )
+
+
+def test_reserve_only_config_within_vram_passes_without_kv_fields(
+    tmp_path, gpu_with_16gib
+):
+    yaml_path = _write_reserve_only_yaml(tmp_path)
+
+    budget = mps_dp_config._resolve_mps_memory_budget(
+        yaml_path, gpu_id=0, replicas=1, allow_missing_budget=True
+    )
+
+    assert budget is not None
+    assert budget["per_replica_total_reserve_bytes"] == 9 * 1024**3
+    assert "per_replica_kv_cache_bytes" not in budget
+
+
+def test_missing_kv_budget_is_required_but_may_be_skipped(tmp_path, gpu_with_16gib):
+    yaml_path = _write_yaml(tmp_path, "Qwen3ASRPipelineConfig")
+
+    with pytest.raises(ValueError, match="kv_cache_bytes"):
+        _strict_budget(yaml_path, gpu_id=0, replicas=2)
+
+    assert (
+        mps_dp_config._resolve_mps_memory_budget(
+            yaml_path, gpu_id=0, replicas=2, allow_missing_budget=True
+        )
+        is None
+    )
+
+
+def test_budget_manifest_serialization_has_single_vram_key(tmp_path, gpu_with_16gib):
+    yaml_path = _write_budget_yaml(
+        tmp_path, kv_cache_bytes="6GiB", total_reserve_bytes="8GiB"
+    )
+
+    budget = _strict_budget(yaml_path, gpu_id=0, replicas=2)
+    manifest = mps_dp_config._serialize_mps_memory_budget_manifest(budget)
+
+    assert "mps_budget_total_vram_bytes=" in manifest
+
+
 def test_docs_table_matches_the_code_registries():
     text = DOCS_PAGE.read_text(encoding="utf-8")
     supported_rows = [
@@ -204,3 +412,47 @@ class TestLaunchFailsClosedBeforeResources:
         # launch still fails closed before any state is created.
         if shutil.which("nvidia-smi"):
             assert "RUN_ID must be a single" in proc.stdout + proc.stderr
+
+
+def _engine_stage_name(config_cls) -> str:
+    config = config_cls(model_path="dummy")
+    return next(
+        stage.name
+        for stage in config.stages
+        if config_cls.stage_config_cls(stage.name).engine_stage
+    )
+
+
+def test_kv_budget_rejects_a_second_token_cap_knob(tmp_path):
+    stage = _engine_stage_name(WhisperASRPipelineConfig)
+    yaml_path = tmp_path / "probe.yaml"
+    yaml_path.write_text(
+        "config_cls: WhisperASRPipelineConfig\n"
+        "name: probe\n"
+        "model_path: dummy/none\n"
+        "stages:\n"
+        f"  {stage}:\n"
+        "    engine:\n"
+        "      kv_cache_bytes: 2GiB\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="keep exactly one"):
+        mps_dp_config.resolve_max_total_tokens(yaml_path, 30000)
+
+
+def test_kv_only_config_resolves_unpinned(tmp_path):
+    stage = _engine_stage_name(WhisperASRPipelineConfig)
+    yaml_path = tmp_path / "probe.yaml"
+    yaml_path.write_text(
+        "config_cls: WhisperASRPipelineConfig\n"
+        "name: probe\n"
+        "model_path: dummy/none\n"
+        "stages:\n"
+        f"  {stage}:\n"
+        "    engine:\n"
+        "      kv_cache_bytes: 2GiB\n",
+        encoding="utf-8",
+    )
+    resolved_stage, value = mps_dp_config.resolve_max_total_tokens(yaml_path)
+    assert resolved_stage == stage
+    assert value is None

--- a/tests/unit_test/serve/test_sglang_bootstrap.py
+++ b/tests/unit_test/serve/test_sglang_bootstrap.py
@@ -439,3 +439,67 @@ def test_defer_cuda_graph_leaves_disabled_graph_capture_disabled(monkeypatch) ->
     assert want_cuda_graph is False
     assert seen == [(True, False)]
     assert server_args.disable_cuda_graph is True
+
+
+def test_create_sglang_infrastructure_consumes_scoped_kv_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.scheduling.stage_kv_budget import stage_kv_cache_budget
+
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        bootstrap,
+        "_describe_sglang_runtime_configuration",
+        lambda _server_args, _gpu_id: "runtime configuration",
+    )
+
+    class FakeRunner:
+        model = object()
+
+        def alloc_memory_pool(self) -> None:
+            pass
+
+        def init_attention_backends(self) -> None:
+            pass
+
+        def init_cuda_graphs(self) -> None:
+            pass
+
+    class FakeWorker:
+        model_config = SimpleNamespace(is_multimodal=False)
+        enable_prefill_input_embeds = False
+
+        def __init__(self, *, config, **kwargs) -> None:
+            del kwargs
+            captured["kv_cache_bytes"] = config.kv_cache_bytes
+            self.model_runner = FakeRunner()
+
+        def get_memory_pool(self):
+            return "req_pool", "kv_pool"
+
+    monkeypatch.setattr(model_worker_module, "ModelWorker", FakeWorker)
+    monkeypatch.setattr(
+        sglang_backend,
+        "create_tree_cache",
+        lambda *args: ("tree_cache", args),
+    )
+
+    server_args = SimpleNamespace(
+        attention_backend=None,
+        decode_attention_backend=None,
+        prefill_attention_backend=None,
+        sampling_backend=None,
+        page_size=1,
+        disable_overlap_schedule=False,
+        chunked_prefill_size=8,
+        max_prefill_tokens=16,
+    )
+
+    with stage_kv_cache_budget("thinker", 2 * 1024**3):
+        bootstrap.create_sglang_infrastructure(server_args, 0)
+    assert captured["kv_cache_bytes"] == 2 * 1024**3
+
+    captured.clear()
+    bootstrap.create_sglang_infrastructure(server_args, 0)
+    assert captured["kv_cache_bytes"] is None


### PR DESCRIPTION
## Motivation

Implements the absolute byte budget for KV memory from #1399 section 4.4: fraction based sizing makes the KV pool depend on card size and co-tenant behavior, a byte budget makes it deterministic. Reworks #1452 by @adityavaid on top of current main, keeping its schema surface, size string parser, deprecation path, configurator injection point, and preflight framework; every commit carries Co-authored-by credit.

```yaml
stages:
  - name: thinker
    total_reserve_bytes: 10GiB    # declared per replica total VRAM budget
    engine:
      kv_cache_bytes: 2GiB        # engine KV pool size, authoritative, per rank
```

Integer bytes or exact KiB/MiB/GiB/TiB strings, `engine.kv_cache_bytes <= total_reserve_bytes` enforced. The branch sits on the grouped config surface from #1494.

## Modifications

* Delivery: the budget rides typed `StageLaunchConfig` fields into a scoped ambient value around the single stage factory invocation point, consumed inside `create_sglang_infrastructure`. It never enters factory kwargs by construction, and zero model files change, so no model can miss the plumbing (the per-model kwarg threading in #1452 broke MiniMax). A declared budget that no engine consumes fails startup, and a registry walking contract test covers every model config.
* Mixing guard at one launch choke point: with `kv_cache_bytes` declared, every user source of `mem_fraction_static` is rejected (typed field, CLI flags including `--encoder-mem-reserve`, direct and nested factory args or runtime overrides). Builder built-in default fractions are cleared with a log line. moss_tts_local pins a typed default and fails closed by design.
* Colocation validates in the byte domain: a byte-budgeted stage sharing a GPU must declare `total_reserve_bytes` (kv alone says nothing about weights or graphs), and startup fails before spawn when `fraction x VRAM + sum(reserves)` exceeds the card, so mixed fraction/byte layouts cannot overcommit. Colocated Qwen accepts either budget form per stage.
* `total_reserve_bytes` is enforced: stage startup caps the process's torch allocator at the summed declared reserves (accumulating across colocated stages in one worker), so a stage that outgrows its budget fails itself instead of a co-tenant. `enforce_total_reserve: false` opts out. The cap bounds torch allocations only; declared budgets need headroom above the measured model footprint for CUDA context overhead.
* Engine authority: the KV configurator returns `kv_cache_bytes` verbatim after an explicit free-memory check (actionable error instead of a bare CUDA OOM), the SGLang 0.5.16 post-capture resize raises instead of silently shrinking a byte-budgeted pool, and mamba/hybrid models are refused rather than mis-sized.
* mps_dp preflight: hard bound `replicas x kv_cache_bytes <= VRAM` with and without WEIGHT_SHARE (the shared floor also charges every further replica's private KV pool), plus reserve bounds when `total_reserve_bytes` is declared. An omitted reserve produces a warning, never an invented default, and errors cite only numbers the user wrote. Byte-budgeted MPS no longer requires `max_total_tokens`: replicas are verified equal against each other, and declaring both knobs on one stage is rejected in `EngineArgs`, since a lower token cap silently shrinks the byte-derived pool (measured at 1/3 to 1/6 of the declared budget across five models). The same bounds hold on the runtime native path merged after this branch's base (`processes.num_replicas` plus `runtime.mps`): the token cap exclusion lives in the schema, and `validate_gpu_capacity` checks the summed KV pools of the replica expanded stages against the card before spawn, so neither bound depends on the `examples/mps_dp` launcher.

## Testing

Base sgl-project/main 215e32a6, sglang 0.5.16, H200.

* Full unit suite: 5069 passed, 3 skipped. The one intermittent failure (a 10s spawn timeout in test_ipc under heavy co-tenant load) reproduces identically on pristine main in back-to-back runs, unrelated to this diff.
* GPU smoke: an over-committed layout (2 x 80GiB KV) is rejected at preflight before any resource exists; qwen3_asr DP2 with an 8GiB budget boots, logs `gpu_mem_accounting=kv_cache_bytes`, and serves correct transcriptions on both replicas; N=1 with `SGLANG_ENABLE_POST_CAPTURE_KV_SIZING=1` keeps the byte derived pool size and serves.
* An adversarial dual review (Codex plus independent verifiers) ran before opening; confirmed findings are closed in the final commit.
* Five-model H200 campaign (qwen3_asr, whisper, moss_td, higgs, moss_tts_local): preflight manifests, single-replica and same-GPU DP2 MPS boots with real inference smokes all pass; with no token cap the resolved pool matches the declared bytes exactly (16GiB -> 149,796 tokens at 112KiB per token).
* Review round 1 is addressed in the two newest commits: typed spec fields, byte-domain colocation capacity check, allocator cap, MPS token-cap decoupling, deprecation warnings dropped.
* Rebased onto main at 216e946d, which carries the native MPS runtime from #1635. Rerun on H200 in a container matching main's sglang 0.5.18 pin: the full unit suite is 5826 passed, 5 skipped, no failures.
* Native launch path smoke on one H200 (`processes.num_replicas` with `--mps on`, Qwen3-ASR 1.7B), all before any replica exists: a 200GiB KV pool on a 140.40GiB card is rejected, two same-GPU replicas at `total_reserve_bytes=100GiB` are rejected, and `engine.kv_cache_bytes` beside `engine.max_total_tokens` fails config load. The accepted layout (8GiB KV plus a 40GiB reserve per replica) boots both replicas on one card, each logging `gpu_mem_accounting=kv_cache_bytes kv_cache_bytes=8.00GiB`, and serves a correct transcription.



