### PR TITLE
[Feature] apply stagewise offload to Minimax-Music3.

### DIFF
--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -643,6 +643,87 @@ def apply_backbone_server_args_cli_overrides(
     return pipeline_config
 
 
+def _parse_layerwise_offload_components(value: str | None) -> frozenset[str]:
+    if value is None:
+        return frozenset()
+    components = frozenset(
+        part.strip().lower() for part in value.split(",") if part.strip()
+    )
+    if not components:
+        raise typer.BadParameter("--layerwise-offload-components must not be empty")
+    return components
+
+
+def apply_layerwise_offload_cli_overrides(
+    pipeline_config: PipelineConfig,
+    *,
+    layerwise_offload_components: str | None,
+) -> PipelineConfig:
+    components = _parse_layerwise_offload_components(layerwise_offload_components)
+    if not components:
+        return pipeline_config
+
+    role_to_stage = type(pipeline_config).layerwise_offload_role_to_stage()
+    if not role_to_stage:
+        _raise_unsupported_flag(pipeline_config, "--layerwise-offload-components")
+
+    unknown = components - role_to_stage.keys()
+    if unknown:
+        raise typer.BadParameter(
+            "--layerwise-offload-components does not support: "
+            f"{', '.join(sorted(unknown))}; supported: "
+            f"{', '.join(sorted(role_to_stage))}"
+        )
+    missing = role_to_stage.keys() - components
+    if missing:
+        raise typer.BadParameter(
+            "--layerwise-offload-components currently requires all of: "
+            f"{', '.join(sorted(role_to_stage))} (missing "
+            f"{', '.join(sorted(missing))})"
+        )
+
+    ar_stage_name = role_to_stage["ar"]
+    dit_stage_name = role_to_stage["dit"]
+    ar_stages = _find_matching_stages(
+        pipeline_config,
+        stage_name=ar_stage_name,
+        reason="--layerwise-offload-components",
+    )
+    dit_stages = _find_matching_stages(
+        pipeline_config,
+        stage_name=dit_stage_name,
+        reason="--layerwise-offload-components",
+    )
+    for ar_stage, dit_stage in zip(ar_stages, dit_stages, strict=True):
+        if ar_stage.gpu != dit_stage.gpu:
+            raise typer.BadParameter(
+                "--layerwise-offload-components ar,dit requires the "
+                f"{ar_stage_name!r} and {dit_stage_name!r} stages on the "
+                f"same GPU (currently {ar_stage.gpu!r} and "
+                f"{dit_stage.gpu!r}); use the 'single-gpu' config variant"
+            )
+
+    pipeline_config = apply_stage_process_overrides(
+        pipeline_config,
+        stage_processes=[f"{dit_stage_name}={ar_stage_name}"],
+    )
+    matching_stages = _find_matching_stages(
+        pipeline_config,
+        stage_name=ar_stage_name,
+        reason="--layerwise-offload-components",
+    ) + _find_matching_stages(
+        pipeline_config,
+        stage_name=dit_stage_name,
+        reason="--layerwise-offload-components",
+    )
+    _apply_factory_args_updates(
+        pipeline_config,
+        matching_stages,
+        {"enable_serial_offload": True},
+    )
+    return pipeline_config
+
+
 def apply_parallelism_cli_overrides(
     pipeline_config: PipelineConfig,
     *,
@@ -1177,6 +1258,18 @@ def serve(
             ),
         ),
     ] = None,
+    layerwise_offload_components: Annotated[
+        str | None,
+        typer.Option(
+            "--layerwise-offload-components",
+            "--layerwise_offload_components",
+            help=(
+                "Comma-separated components to run request-serially, each "
+                "offloading itself from the GPU before the next one runs, so "
+                "a multi-stage pipeline can fit on one small GPU."
+            ),
+        ),
+    ] = None,
     log_level: Annotated[
         Literal["debug", "info", "warning", "error", "critical"],
         typer.Option(help="Log level (default: info)."),
@@ -1488,6 +1581,10 @@ def serve(
         cpu_offload_gb=cpu_offload_gb,
         quantization=quantization,
         thinker_max_running_requests=thinker_max_running_requests,
+    )
+    merged_config = apply_layerwise_offload_cli_overrides(
+        merged_config,
+        layerwise_offload_components=layerwise_offload_components,
     )
     merged_config = apply_parallelism_cli_overrides(
         merged_config,

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -251,6 +251,71 @@ def apply_tensor_parallel_engine_overrides(
     return config_cls(**data)
 
 
+def _parse_stage_offload_components(value: str | None) -> frozenset[str]:
+    if value is None:
+        return frozenset()
+    components = frozenset(
+        part.strip().lower() for part in value.split(",") if part.strip()
+    )
+    if not components:
+        raise typer.BadParameter("--stage-offload-components must not be empty")
+    return components
+
+
+def apply_stage_offload_cli_overrides(
+    pipeline_config: PipelineConfig,
+    *,
+    stage_offload_components: str | None,
+) -> PipelineConfig:
+    components = _parse_stage_offload_components(stage_offload_components)
+    if not components:
+        return pipeline_config
+
+    role_to_stage = type(pipeline_config).stage_offload_role_to_stage()
+    if not role_to_stage:
+        raise typer.BadParameter(
+            "--stage-offload-components is not supported by this pipeline"
+        )
+
+    unknown = components - role_to_stage.keys()
+    if unknown:
+        raise typer.BadParameter(
+            "--stage-offload-components does not support: "
+            f"{', '.join(sorted(unknown))}; supported: "
+            f"{', '.join(sorted(role_to_stage))}"
+        )
+    missing = role_to_stage.keys() - components
+    if missing:
+        raise typer.BadParameter(
+            "--stage-offload-components currently requires all of: "
+            f"{', '.join(sorted(role_to_stage))} (missing "
+            f"{', '.join(sorted(missing))})"
+        )
+
+    ar_stage = pipeline_config.stage_named(role_to_stage["ar"])
+    dit_stage = pipeline_config.stage_named(role_to_stage["dit"])
+    if ar_stage.gpu != dit_stage.gpu:
+        raise typer.BadParameter(
+            "--stage-offload-components ar,dit requires the "
+            f"{ar_stage.name!r} and {dit_stage.name!r} stages on the same GPU "
+            f"(currently {ar_stage.gpu!r} and {dit_stage.gpu!r}); use the "
+            "'single-gpu' config variant"
+        )
+
+    config_cls = type(pipeline_config)
+    data = pipeline_config.model_dump()
+    process = ar_stage.process or ar_stage.name
+    writes: dict[str, object] = {
+        f"stages.{ar_stage.name}.process": process,
+        f"stages.{dit_stage.name}.process": process,
+        f"stages.{ar_stage.name}.factory.enable_serial_offload": True,
+        f"stages.{dit_stage.name}.factory.enable_serial_offload": True,
+    }
+    for path_text, value in writes.items():
+        ConfigPath.parse(path_text, config_cls).write(data, value)
+    return config_cls(**data)
+
+
 def serve(
     ctx: typer.Context,
     model_path: Annotated[
@@ -325,6 +390,17 @@ def serve(
                 "A dotted per-stage flag (--<stage>.engine.mem_fraction_static) "
                 "overrides this for that stage. If omitted, SGLang chooses "
                 "the value automatically."
+            ),
+        ),
+    ] = None,
+    stage_offload_components: Annotated[
+        str | None,
+        typer.Option(
+            "--stage-offload-components",
+            "--stage_offload_components",
+            help=(
+                "Comma-separated components to run request-serially, each "
+                "offloading itself from the GPU before the next one runs."
             ),
         ),
     ] = None,
@@ -414,6 +490,10 @@ def serve(
         raise typer.BadParameter(str(exc)) from exc
     if colocate:
         _validate_colocate_config(merged_config)
+    merged_config = apply_stage_offload_cli_overrides(
+        merged_config,
+        stage_offload_components=stage_offload_components,
+    )
     merged_config = apply_tensor_parallel_engine_overrides(merged_config)
 
     if _should_print_merged_config(colocate=colocate, log_level=log_level):

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -363,6 +363,11 @@ class PipelineConfig(BaseModel):
         return {}
 
     @classmethod
+    def layerwise_offload_role_to_stage(cls) -> dict[str, str]:
+        """Class-level public role map for ``--layerwise-offload-components``."""
+        return {}
+
+    @classmethod
     def encoder_mem_reserve_role_to_stage(cls) -> dict[str, str]:
         """Class-level public role map for encoder memory reserve overrides."""
         return {}

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -555,6 +555,11 @@ class PipelineConfig(BaseModel):
         return {}
         return {}
 
+    @classmethod
+    def stage_offload_role_to_stage(cls) -> dict[str, str]:
+        """Map serial-offload component roles to stage names."""
+        return {}
+
     def resolved_env_defaults(self) -> dict[str, str]:
         """Process-environment defaults, evaluated at launch.
 

--- a/sglang_omni/models/minimax_music3/acoustic.py
+++ b/sglang_omni/models/minimax_music3/acoustic.py
@@ -37,6 +37,7 @@ from .constants import (
 from .dav import MiniMaxMusic3DAV, remove_weight_norm, select_decoder_state
 from .dit import MiniMaxMusic3DIT
 from .payload_types import MiniMaxMusic3State
+from .serial_offload import get_coordinator, move_module_to_device
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +131,7 @@ class MiniMaxMusic3AcousticDecoder:
         cache_dit_max_warmup_steps: int = 4,
         cache_dit_residual_diff_threshold: float = 0.08,
         cache_dit_max_continuous_cached_steps: int = 1,
+        serial_offload: bool = False,
     ) -> None:
         if not torch.cuda.is_available():
             raise RuntimeError("MiniMax Music 3 acoustic inference requires CUDA")
@@ -159,6 +161,25 @@ class MiniMaxMusic3AcousticDecoder:
             "breakable_cuda_graph", breakable_cuda_graph
         )
         self.breakable_cuda_graph = False
+        self._serial_offload = _boolean("serial_offload", serial_offload)
+        if self._serial_offload:
+            # Moving the module between CPU and GPU each request invalidates
+            # both torch.compile's device-bound guards and any CUDA graph's
+            # captured (now stale) memory addresses, so neither is safe here.
+            if self.compile_acoustic:
+                logger.warning(
+                    "MiniMax Music 3 serial offload disables compile_acoustic "
+                    "(torch.compile does not tolerate the repeated CPU/GPU "
+                    "moves that --layerwise-offload-components ar,dit performs)"
+                )
+                self.compile_acoustic = False
+            if self.breakable_cuda_graph_requested:
+                logger.warning(
+                    "MiniMax Music 3 serial offload disables breakable_cuda_graph "
+                    "(a captured CUDA graph would reference memory freed or "
+                    "relocated once the module moves off the GPU)"
+                )
+                self.breakable_cuda_graph_requested = False
         if self.cache_dit and self.breakable_cuda_graph_requested:
             raise ValueError(
                 "MiniMax Music 3 cache_dit and breakable_cuda_graph cannot be enabled together"
@@ -195,6 +216,29 @@ class MiniMaxMusic3AcousticDecoder:
         logger.info(
             f"MiniMax Music 3 acoustic runtime dit_steps={self.dit_steps} dit_cfg_scale={self.dit_cfg_scale:.3f} attention_backend={self.attention_backend} cache_dit={self.cache_dit} compile_acoustic={self.compile_acoustic} breakable_cuda_graph={self.breakable_cuda_graph} breakable_cuda_graph_requested={self.breakable_cuda_graph_requested}"
         )
+        self._resident_on_gpu = True
+        if self._serial_offload:s
+            self.offload_to_cpu()
+
+    @property
+    def serial_offload(self) -> bool:
+        return self._serial_offload
+
+    def ensure_gpu_resident(self) -> None:
+        """Restore DIT/DAV to the GPU; a cheap no-op once already resident."""
+        if self._resident_on_gpu:
+            return
+        move_module_to_device(self.dit, self.device)
+        move_module_to_device(self.dav, self.device)
+        self._resident_on_gpu = True
+
+    def offload_to_cpu(self) -> None:
+        """Move DIT/DAV off the GPU; a cheap no-op once already offloaded."""
+        if not self._resident_on_gpu:
+            return
+        move_module_to_device(self.dit, torch.device("cpu"))
+        move_module_to_device(self.dav, torch.device("cpu"))
+        self._resident_on_gpu = False
 
     def _build_dit(
         self,
@@ -275,6 +319,7 @@ class MiniMaxMusic3AcousticDecoder:
     ) -> tuple[Tensor, Tensor, Tensor]:
         if should_abort is not None and should_abort():
             raise InterruptedError("MiniMax Music 3 acoustic generation aborted")
+        self.ensure_gpu_resident()
         hidden = hidden.unsqueeze(0).to(
             device=self.device, dtype=self.dtype, non_blocking=True
         )
@@ -462,6 +507,9 @@ class MiniMaxMusic3AcousticScheduler(StreamingSimpleScheduler):
             state.final_state = None
             state.last_latent = None
             state.last_condition = None
+        if self._decoder.serial_offload:
+            self._decoder.offload_to_cpu()
+            get_coordinator().end_dit_handoff()
 
 
 __all__ = [

--- a/sglang_omni/models/minimax_music3/acoustic.py
+++ b/sglang_omni/models/minimax_music3/acoustic.py
@@ -38,6 +38,7 @@ from .constants import (
 from .dav import MiniMaxMusic3DAV, remove_weight_norm, select_decoder_state
 from .dit import MiniMaxMusic3DIT
 from .payload_types import MiniMaxMusic3State
+from .serial_offload import StageResidency, get_coordinator
 
 logger = logging.getLogger(__name__)
 
@@ -131,6 +132,7 @@ class MiniMaxMusic3AcousticDecoder:
         cache_dit_max_warmup_steps: int = 4,
         cache_dit_residual_diff_threshold: float = 0.08,
         cache_dit_max_continuous_cached_steps: int = 1,
+        serial_offload: bool = False,
     ) -> None:
         if not (current_platform.is_cuda() or current_platform.is_musa()):
             raise RuntimeError(
@@ -162,6 +164,30 @@ class MiniMaxMusic3AcousticDecoder:
             "breakable_cuda_graph", breakable_cuda_graph
         )
         self.breakable_cuda_graph = False
+        self._serial_offload = _boolean("serial_offload", serial_offload)
+        if self._serial_offload:
+            # Moving the module between CPU and GPU each request invalidates
+            # both torch.compile's device-bound guards and any CUDA graph's
+            # captured (now stale) memory addresses, so neither is safe here.
+            if self.compile_acoustic:
+                logger.warning(
+                    "MiniMax Music 3 serial offload disables compile_acoustic "
+                    "(torch.compile does not tolerate the repeated CPU/GPU "
+                    "moves that --stage-offload-components ar,dit performs)"
+                )
+                self.compile_acoustic = False
+            if self.breakable_cuda_graph_requested:
+                logger.warning(
+                    "MiniMax Music 3 serial offload disables breakable_cuda_graph "
+                    "(a captured CUDA graph would reference memory freed or "
+                    "relocated once the module moves off the GPU)"
+                )
+                self.breakable_cuda_graph_requested = False
+        # Serial offload parks DIT/DAV on the host between requests, so load
+        # them straight there. Staging the checkpoint through the GPU would
+        # peak with AR and DIT/DAV both fully resident, which is precisely the
+        # peak this mode exists to avoid.
+        self._load_device = torch.device("cpu") if self._serial_offload else self.device
         if self.cache_dit and self.breakable_cuda_graph_requested:
             raise ValueError(
                 "MiniMax Music 3 cache_dit and breakable_cuda_graph cannot be enabled together"
@@ -198,6 +224,28 @@ class MiniMaxMusic3AcousticDecoder:
         logger.info(
             f"MiniMax Music 3 acoustic runtime dit_steps={self.dit_steps} dit_cfg_scale={self.dit_cfg_scale:.3f} attention_backend={self.attention_backend} cache_dit={self.cache_dit} compile_acoustic={self.compile_acoustic} breakable_cuda_graph={self.breakable_cuda_graph} breakable_cuda_graph_requested={self.breakable_cuda_graph_requested}"
         )
+        self._residency: StageResidency | None = None
+        if self._serial_offload:
+            self._residency = StageResidency(
+                {"dit": self.dit, "dav": self.dav},
+                self.device,
+                resident=False,
+                label="dit/dav",
+            )
+
+    @property
+    def serial_offload(self) -> bool:
+        return self._serial_offload
+
+    def ensure_gpu_resident(self) -> None:
+        """Restore DIT/DAV to the GPU; a cheap no-op once already resident."""
+        if self._residency is not None:
+            self._residency.wake()
+
+    def offload_to_cpu(self) -> None:
+        """Drop the DIT/DAV GPU replica; a no-op once already offloaded."""
+        if self._residency is not None:
+            self._residency.sleep()
 
     def _build_dit(
         self,
@@ -210,9 +258,9 @@ class MiniMaxMusic3AcousticDecoder:
         cache_dit_max_continuous_cached_steps: int,
     ) -> None:
         logger.info(
-            f"Loading MiniMax Music 3 PyTorch DIT from {dit_path} on device={self.device} dtype={self.dtype}"
+            f"Loading MiniMax Music 3 PyTorch DIT from {dit_path} on device={self._load_device} dtype={self.dtype}"
         )
-        state = load_torch_state(dit_path, device=self.device)
+        state = load_torch_state(dit_path, device=self._load_device)
         logger.info(
             f"MiniMax Music 3 DIT checkpoint variant=FM8/ELMo condition_hidden=32768 state_keys={len(state)}"
         )
@@ -250,7 +298,7 @@ class MiniMaxMusic3AcousticDecoder:
     def _build_dav(self, dav_path: str) -> int:
         """Load the DAV decoder and return how many weight norms were folded."""
         logger.info(f"Loading MiniMax Music 3 DAV from {dav_path}")
-        state = load_torch_state(dav_path, device=self.device)
+        state = load_torch_state(dav_path, device=self._load_device)
         with torch.device("meta"):
             self.dav = MiniMaxMusic3DAV()
         self.dav.load_state_dict(select_decoder_state(state), strict=True, assign=True)
@@ -278,6 +326,7 @@ class MiniMaxMusic3AcousticDecoder:
     ) -> tuple[Tensor, Tensor, Tensor]:
         if should_abort is not None and should_abort():
             raise InterruptedError("MiniMax Music 3 acoustic generation aborted")
+        self.ensure_gpu_resident()
         hidden = hidden.unsqueeze(0).to(
             device=self.device, dtype=self.dtype, non_blocking=True
         )
@@ -465,6 +514,9 @@ class MiniMaxMusic3AcousticScheduler(StreamingSimpleScheduler):
             state.final_state = None
             state.last_latent = None
             state.last_condition = None
+        if self._decoder.serial_offload:
+            self._decoder.offload_to_cpu()
+            get_coordinator().end_dit_handoff(request_id)
 
 
 __all__ = [

--- a/sglang_omni/models/minimax_music3/config.py
+++ b/sglang_omni/models/minimax_music3/config.py
@@ -101,6 +101,10 @@ class MiniMaxMusic3PipelineConfig(PipelineConfig):
         return {"generation": "minimax_music3_ar"}
 
     @classmethod
+    def layerwise_offload_role_to_stage(cls) -> dict[str, str]:
+        return {"ar": "minimax_music3_ar", "dit": "dit_dav"}
+
+    @classmethod
     def process_safe_edges(cls) -> frozenset[tuple[str, str]]:
         return frozenset({("minimax_music3_ar", "dit_dav")})
 

--- a/sglang_omni/models/minimax_music3/config.py
+++ b/sglang_omni/models/minimax_music3/config.py
@@ -41,6 +41,15 @@ class DitDavFactoryArgs(FactoryArgs):
     cache_dit: bool | None = None
     compile_acoustic: bool | None = None
     breakable_cuda_graph: bool | None = None
+    enable_serial_offload: bool | None = None
+
+
+class ArFactoryArgs(FactoryArgs):
+    enable_serial_offload: bool | None = None
+
+
+class ArStageConfig(EngineStageConfig):
+    factory: ArFactoryArgs = Field(default_factory=ArFactoryArgs)
 
 
 class DitDavStageConfig(StageConfig):
@@ -55,11 +64,11 @@ def _stages(*, acoustic_gpu: int) -> list[StageConfig]:
             factory_path=f"{_PKG}.stages.create_preprocessing_executor",
             next="minimax_music3_ar",
         ),
-        EngineStageConfig(
+        ArStageConfig(
             name="minimax_music3_ar",
             process="minimax_music3_ar",
             factory_path=f"{_PKG}.stages.create_ar_executor",
-            factory=FactoryArgs(max_concurrency=16),
+            factory=ArFactoryArgs(max_concurrency=16),
             gpu=0,
             next="dit_dav",
             stream_to=["dit_dav"],
@@ -103,7 +112,7 @@ class MiniMaxMusic3PipelineConfig(PipelineConfig):
     requires_model_capabilities: ClassVar[bool] = True
 
     stage_config_types: ClassVar[dict[str, type[StageConfig]]] = {
-        "minimax_music3_ar": EngineStageConfig,
+        "minimax_music3_ar": ArStageConfig,
         "dit_dav": DitDavStageConfig,
     }
 
@@ -121,6 +130,10 @@ class MiniMaxMusic3PipelineConfig(PipelineConfig):
     @classmethod
     def process_local_edges(cls) -> frozenset[tuple[str, str]]:
         return frozenset({("preprocessing", "minimax_music3_ar")})
+
+    @classmethod
+    def stage_offload_role_to_stage(cls) -> dict[str, str]:
+        return {"ar": "minimax_music3_ar", "dit": "dit_dav"}
 
 
 class MiniMaxMusic3SingleGPUPipelineConfig(MiniMaxMusic3PipelineConfig):

--- a/sglang_omni/models/minimax_music3/engine_builder.py
+++ b/sglang_omni/models/minimax_music3/engine_builder.py
@@ -31,10 +31,13 @@ class MiniMaxMusic3EngineBuilder(TtsEngineBuilder):
     context_length = 10240
     model_arch_override = "Qwen3ForCausalLM"
 
-    def __init__(self, *, max_running_requests: int = 16) -> None:
+    def __init__(
+        self, *, max_running_requests: int = 16, enable_serial_offload: bool = False
+    ) -> None:
         self.max_running_requests = int(max_running_requests)
         if self.max_running_requests <= 0:
             raise ValueError("MiniMax Music 3 max_running_requests must be positive")
+        self._enable_serial_offload = bool(enable_serial_offload)
         self._model_runner: Any | None = None
         self._checkpoint_root: str | None = None
 
@@ -112,10 +115,15 @@ class MiniMaxMusic3EngineBuilder(TtsEngineBuilder):
     def setup_model_resources(
         self, model: Any, server_args: Any, *, generation_cuda_graph_enabled: bool
     ) -> None:
-        del generation_cuda_graph_enabled
+        del generation_cuda_graph_enabled, server_args
+        if self._enable_serial_offload:
+            logger.info(
+                "MiniMax Music 3 serial offload: skipping RVQ depth CUDA "
+                "graph capture"
+            )
+            return
         from .sglang_model import enable_rvq_depth_cuda_graph
 
-        del server_args
         enable_rvq_depth_cuda_graph(
             model, _rvq_graph_buckets(self.max_running_requests)
         )

--- a/sglang_omni/models/minimax_music3/model_runner.py
+++ b/sglang_omni/models/minimax_music3/model_runner.py
@@ -18,6 +18,7 @@ from sglang_omni.sampling.seed import derive_sampling_seed
 from .chunking import ChunkWindow, chunk_windows
 from .constants import AR_CHUNK_FRAMES, AR_CHUNK_HOP_FRAMES
 from .rvq_decoder import sample_topk_seeded
+from .serial_offload import get_coordinator
 from .sglang_model import apply_cfg, depth_decode, embed_audio_frames, select_c0_logits
 
 logger = logging.getLogger(__name__)
@@ -95,6 +96,7 @@ class MiniMaxMusic3ModelRunner(ModelRunner):
             logger.warning(
                 f"MiniMax Music 3 is replaying reference code trajectories from {self._forced_codes_dir}; generated audio is the reference's, not this model's"
             )
+        self._serial_offload = get_coordinator()
 
     def requested_capture_hidden_mode_prefill(
         self, schedule_batch: Any, requests: list
@@ -198,6 +200,7 @@ class MiniMaxMusic3ModelRunner(ModelRunner):
         logger.info(
             f"MiniMax Music 3 AR done request={request_id} frames={ar_state.generated_frames} prompt_tokens={req_data.prompt_tokens} finish_reason={ar_state.finish_reason} peak_buffer_frames={ar_state.frames.peak_frames} elapsed={time.perf_counter() - ar_state.started_s:.1f}s"
         )
+        self._serial_offload.begin_dit_handoff()
 
     def reset_request(self, request_id: str) -> None:
         data = self._request_data.pop(request_id, None)
@@ -285,7 +288,8 @@ class MiniMaxMusic3ModelRunner(ModelRunner):
             ar_state.frames.append(frame_hidden[index : index + 1])
             ar_state.generated_frames += 1
             self._log_progress(cond_requests[index].request_id, ar_state)
-            self._emit_ready_window(cond_requests[index].request_id, ar_state)
+            if not self._serial_offload.enabled:
+                self._emit_ready_window(cond_requests[index].request_id, ar_state)
         result.next_token_ids = model.c0_logit_ids[sampled.repeat_interleave(2)]
 
     def _start_request(self, request_id: str, data: Any, device: torch.device) -> None:

--- a/sglang_omni/models/minimax_music3/model_runner.py
+++ b/sglang_omni/models/minimax_music3/model_runner.py
@@ -18,6 +18,7 @@ from sglang_omni.sampling.seed import derive_sampling_seed
 from .chunking import ChunkWindow, chunk_windows
 from .constants import AR_CHUNK_FRAMES, AR_CHUNK_HOP_FRAMES
 from .rvq_decoder import sample_topk_seeded
+from .serial_offload import get_coordinator
 from .sglang_model import apply_cfg, depth_decode, embed_audio_frames, select_c0_logits
 
 logger = logging.getLogger(__name__)
@@ -95,6 +96,7 @@ class MiniMaxMusic3ModelRunner(ModelRunner):
             logger.warning(
                 f"MiniMax Music 3 is replaying reference code trajectories from {self._forced_codes_dir}; generated audio is the reference's, not this model's"
             )
+        self._serial_offload = get_coordinator()
 
     def requested_capture_hidden_mode_prefill(
         self, schedule_batch: Any, requests: list
@@ -198,6 +200,7 @@ class MiniMaxMusic3ModelRunner(ModelRunner):
         logger.info(
             f"MiniMax Music 3 AR done request={request_id} frames={ar_state.generated_frames} prompt_tokens={req_data.prompt_tokens} finish_reason={ar_state.finish_reason} peak_buffer_frames={ar_state.frames.peak_frames} elapsed={time.perf_counter() - ar_state.started_s:.1f}s"
         )
+        self._serial_offload.begin_dit_handoff(request_id)
 
     def reset_request(self, request_id: str) -> None:
         data = self._request_data.pop(request_id, None)
@@ -285,7 +288,8 @@ class MiniMaxMusic3ModelRunner(ModelRunner):
             ar_state.frames.append(frame_hidden[index : index + 1])
             ar_state.generated_frames += 1
             self._log_progress(cond_requests[index].request_id, ar_state)
-            self._emit_ready_window(cond_requests[index].request_id, ar_state)
+            if not self._serial_offload.enabled:
+                self._emit_ready_window(cond_requests[index].request_id, ar_state)
         result.next_token_ids = model.c0_logit_ids[sampled.repeat_interleave(2)]
 
     def _start_request(self, request_id: str, data: Any, device: torch.device) -> None:

--- a/sglang_omni/models/minimax_music3/scheduler.py
+++ b/sglang_omni/models/minimax_music3/scheduler.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler
 
+from .serial_offload import get_coordinator
 from .sglang_request_builder import cfg_uncond_rid, is_cfg_uncond_rid
 
 
@@ -61,6 +62,8 @@ class MiniMaxMusic3Scheduler(OmniScheduler):
 
     def _pair_admission_limit(self, queue: list, running_batch: Any) -> int:
         """How many leading queue entries the adder may see, always whole pairs."""
+        if not get_coordinator().ar_can_admit():
+            return 0
         allocatable = int(self.get_num_allocatable_reqs(len(running_batch.reqs)))
         limit = min(len(queue), max(0, allocatable))
         limit -= limit % 2

--- a/sglang_omni/models/minimax_music3/serial_offload.py
+++ b/sglang_omni/models/minimax_music3/serial_offload.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def move_module_to_device(module: Any, device: torch.device) -> None:
+
+    source_device = None
+    try:
+        source_device = next(module.parameters()).device
+    except StopIteration:
+        pass
+    module.to(device)
+    if source_device is not None and source_device.type == "cuda":
+        torch.cuda.synchronize(source_device)
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+    else:
+        torch.cuda.empty_cache()
+
+
+class SerialOffloadCoordinator:
+    """Process-wide GPU residency coordinator (see module docstring)."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._enabled = False
+        self._ar_active = True
+        self._ar_model: Any | None = None
+        self._ar_device: torch.device | None = None
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def register_ar(self, model: Any, device: torch.device) -> None:
+        with self._lock:
+            self._ar_model = model
+            self._ar_device = device
+            self._enabled = True
+            self._ar_active = True
+        logger.info(
+            f"MiniMax Music 3 serial offload enabled device={device}; AR "
+            "starts GPU-resident, DIT/DAV starts offloaded"
+        )
+
+    def ar_can_admit(self) -> bool:
+        """Whether AR may admit a new request onto the GPU right now."""
+        if not self._enabled:
+            return True
+        with self._lock:
+            return self._ar_active
+
+    def begin_dit_handoff(self) -> None:
+        if not self._enabled:
+            return
+        with self._lock:
+            if self._ar_model is None:
+                raise RuntimeError(
+                    "MiniMax Music 3 serial offload is enabled but the AR "
+                    "backbone was never registered"
+                )
+            if not self._ar_active:
+                return
+            move_module_to_device(self._ar_model, torch.device("cpu"))
+            self._ar_active = False
+        logger.info("MiniMax Music 3 serial offload: AR -> CPU (DIT/DAV's turn)")
+
+    def end_dit_handoff(self) -> None:
+        if not self._enabled:
+            return
+        with self._lock:
+            if self._ar_model is None:
+                raise RuntimeError(
+                    "MiniMax Music 3 serial offload is enabled but the AR "
+                    "backbone was never registered"
+                )
+            if self._ar_active:
+                return
+            move_module_to_device(self._ar_model, self._ar_device)
+            self._ar_active = True
+        logger.info("MiniMax Music 3 serial offload: AR -> GPU (AR's turn)")
+
+
+_COORDINATOR = SerialOffloadCoordinator()
+
+
+def get_coordinator() -> SerialOffloadCoordinator:
+    return _COORDINATOR
+
+
+__all__ = ["SerialOffloadCoordinator", "get_coordinator", "move_module_to_device"]

--- a/sglang_omni/models/minimax_music3/serial_offload.py
+++ b/sglang_omni/models/minimax_music3/serial_offload.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Serial GPU residency for the MiniMax Music 3 AR and DIT/DAV stages.
+
+``--stage-offload-components ar,dit`` colocates both stages in one process
+and lets only one of them hold GPU weights at a time: AR generates a whole
+request, hands off to DIT/DAV, and stays off the GPU until DIT/DAV is finished
+with that request.
+
+The handoff is keyed by request id rather than by a single boolean. AR wakes
+when nothing is outstanding, so a duplicated, out-of-order, or late terminal
+event cannot wake AR while DIT/DAV is still decoding, and an event that names
+a request nobody handed off cannot wake AR early.
+
+A handoff that never ends stops admission for good, because ``ar_can_admit``
+gates the AR scheduler's queue. That is reported rather than force-corrected:
+waking AR while DIT/DAV still holds the GPU is how this configuration runs out
+of memory, so a stuck server is preferable to a crashed one, and the log names
+the requests still outstanding.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+STALL_REPORT_SECONDS = 900.0
+_GIB = 1024.0**3
+
+
+def _owned_tensors(
+    modules: dict[str, Any],
+) -> list[tuple[tuple[str, str], torch.Tensor]]:
+    """Every tensor owned by a stage's modules, tied tensors listed once.
+
+    ``named_parameters``/``named_buffers`` de-duplicate by default, so a tied
+    weight appears under one name per module. De-duplicate once more across the
+    group so modules that share a tensor still get one canonical host copy.
+    Residency mutates the tensor object in place, so every name that shares it
+    follows along and the tying survives the round trip.
+    """
+    owned: list[tuple[tuple[str, str], torch.Tensor]] = []
+    seen: set[int] = set()
+    for module_name, module in modules.items():
+        for tensor_name, tensor in (
+            *module.named_parameters(),
+            *module.named_buffers(),
+        ):
+            if id(tensor) in seen:
+                continue
+            seen.add(id(tensor))
+            owned.append(((module_name, tensor_name), tensor))
+    return owned
+
+
+def _gpu_memory_note(device: torch.device) -> str:
+    """Device occupancy, for attributing what a handoff actually frees.
+
+    ``torch_*`` covers only this process's caching allocator, while ``free``
+    is the whole device, so a gap between them is memory held outside torch's
+    allocator. Reporting both is what distinguishes weights coming off the GPU
+    from the pools that stay put -- notably the SGLang KV cache, which
+    ``mem_fraction_static`` reserves for the life of the process and which no
+    weight offload releases.
+    """
+    if device.type != "cuda":
+        return "cpu"
+    free, total = torch.cuda.mem_get_info(device)
+    return (
+        f"free={free / _GIB:.2f}/{total / _GIB:.2f}GiB "
+        f"torch_allocated={torch.cuda.memory_allocated(device) / _GIB:.2f}GiB "
+        f"torch_reserved={torch.cuda.memory_reserved(device) / _GIB:.2f}GiB"
+    )
+
+
+class StageResidency:
+    """GPU residency for a group of stage modules whose weights never change.
+
+    Inference never writes these weights, so the host copy is canonical: it is
+    filled once and every wake refills the GPU from it. Sleeping then only
+    drops the GPU replica -- no device-to-host copy and no fresh host
+    allocation per request, which is what ``module.to()`` in both directions
+    was paying for on every single handoff.
+
+    Reusing one host copy also stops the sleep path handing the caching
+    allocator a differently sized block each round trip. That is what lets a
+    long-running server fragment its way into an OOM after tens of requests
+    rather than failing on the first one.
+    """
+
+    def __init__(
+        self,
+        modules: dict[str, Any],
+        device: torch.device,
+        *,
+        resident: bool = True,
+        label: str = "stage",
+    ):
+        if not modules:
+            raise ValueError("StageResidency requires at least one module")
+        self._modules = dict(modules)
+        self._device = torch.device(device)
+        self._resident = bool(resident)
+        self._label = label
+        self._host: dict[tuple[str, str], torch.Tensor] = {}
+        if not self._resident:
+            # Built on the host: retain its existing storage through a distinct
+            # tensor handle. Keeping the Parameter itself here would alias the
+            # object whose ``.data`` wake replaces, moving the supposed host
+            # copy onto the GPU along with the module.
+            self._host = {
+                name: tensor.detach() for name, tensor in _owned_tensors(self._modules)
+            }
+        weight_bytes = sum(
+            tensor.numel() * tensor.element_size()
+            for _, tensor in _owned_tensors(self._modules)
+        )
+        logger.info(
+            f"MiniMax Music 3 residency {label}: {weight_bytes / _GIB:.2f}GiB of "
+            f"weights, starts {'resident' if self._resident else 'offloaded'} "
+            f"({_gpu_memory_note(self._device)})"
+        )
+
+    @property
+    def resident(self) -> bool:
+        return self._resident
+
+    def sleep(self) -> None:
+        """Drop the GPU replica; a cheap no-op once already asleep."""
+        if not self._resident:
+            return
+        owned = _owned_tensors(self._modules)
+        if not self._host:
+            self._host = {
+                name: tensor.detach().to("cpu", copy=True) for name, tensor in owned
+            }
+        for name, tensor in owned:
+            tensor.data = self._host[name]
+        self._resident = False
+        logger.info(
+            f"MiniMax Music 3 residency {self._label} -> host "
+            f"({_gpu_memory_note(self._device)})"
+        )
+
+    def wake(self) -> None:
+        """Refill the GPU replica from the host copy; no-op once resident."""
+        if self._resident:
+            return
+        for name, tensor in _owned_tensors(self._modules):
+            tensor.data = self._host[name].to(
+                self._device, copy=True, non_blocking=True
+            )
+        if self._device.type == "cuda":
+            torch.cuda.synchronize(self._device)
+        self._resident = True
+        logger.info(
+            f"MiniMax Music 3 residency {self._label} -> gpu "
+            f"({_gpu_memory_note(self._device)})"
+        )
+
+
+class SerialOffloadCoordinator:
+    """Process-wide GPU residency coordinator (see module docstring)."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._enabled = False
+        self._ar_active = True
+        self._ar: StageResidency | None = None
+        self._outstanding: set[str] = set()
+        self._paused_at: float | None = None
+        self._stall_reported = False
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def register_ar(self, model: Any, device: torch.device) -> None:
+        with self._lock:
+            self._ar = StageResidency({"ar": model}, device, label="ar")
+            self._enabled = True
+            self._ar_active = True
+        logger.info(
+            f"MiniMax Music 3 serial offload enabled device={device}; AR "
+            "starts GPU-resident, DIT/DAV starts offloaded"
+        )
+
+    def ar_can_admit(self) -> bool:
+        """Whether AR may admit a new request onto the GPU right now."""
+        if not self._enabled:
+            return True
+        with self._lock:
+            if self._ar_active:
+                return True
+            self._report_stall_locked()
+            return False
+
+    def begin_dit_handoff(self, request_id: str) -> None:
+        """Hand the GPU to DIT/DAV for *request_id* and take AR off it."""
+        if not self._enabled:
+            return
+        with self._lock:
+            self._require_ar_locked()
+            self._outstanding.add(request_id)
+            if not self._ar_active:
+                return
+            self._ar.sleep()
+            self._ar_active = False
+            self._paused_at = time.monotonic()
+            self._stall_reported = False
+        logger.info(
+            f"MiniMax Music 3 serial offload: AR -> CPU (DIT/DAV's turn, "
+            f"request={request_id})"
+        )
+
+    def end_dit_handoff(self, request_id: str) -> None:
+        """Retire *request_id*; give the GPU back once nothing is outstanding.
+
+        Safe to call for a request that never handed off, and safe to call
+        more than once: both leave the outstanding set unchanged.
+        """
+        if not self._enabled:
+            return
+        with self._lock:
+            self._require_ar_locked()
+            self._outstanding.discard(request_id)
+            if self._ar_active or self._outstanding:
+                return
+            self._ar.wake()
+            self._ar_active = True
+            self._paused_at = None
+            self._stall_reported = False
+        logger.info(
+            f"MiniMax Music 3 serial offload: AR -> GPU (AR's turn, "
+            f"request={request_id})"
+        )
+
+    def _require_ar_locked(self) -> None:
+        if self._ar is None:
+            raise RuntimeError(
+                "MiniMax Music 3 serial offload is enabled but the AR "
+                "backbone was never registered"
+            )
+
+    def _report_stall_locked(self) -> None:
+        """Name the outstanding requests once AR has been parked too long."""
+        if self._paused_at is None or self._stall_reported:
+            return
+        elapsed = time.monotonic() - self._paused_at
+        if elapsed < STALL_REPORT_SECONDS:
+            return
+        self._stall_reported = True
+        logger.error(
+            f"MiniMax Music 3 serial offload: AR has been off the GPU for "
+            f"{elapsed:.0f}s and is still waiting on "
+            f"{sorted(self._outstanding)}; AR admits nothing until DIT/DAV "
+            "retires them, so this server needs a restart if the requests "
+            "are gone"
+        )
+
+
+_COORDINATOR = SerialOffloadCoordinator()
+
+
+def get_coordinator() -> SerialOffloadCoordinator:
+    return _COORDINATOR
+
+
+__all__ = [
+    "STALL_REPORT_SECONDS",
+    "StageResidency",
+    "SerialOffloadCoordinator",
+    "get_coordinator",
+]

--- a/sglang_omni/models/minimax_music3/stages.py
+++ b/sglang_omni/models/minimax_music3/stages.py
@@ -42,6 +42,7 @@ def create_ar_executor(
     device: str | None = None,
     max_concurrency: int = _DEFAULT_AR_CONCURRENCY,
     server_args_overrides: dict[str, Any] | None = None,
+    enable_serial_offload: bool = False,
     **_: Any,
 ):
     if device is None:
@@ -57,8 +58,23 @@ def create_ar_executor(
     requested = overrides.get("max_running_requests")
     if requested is not None:
         max_concurrency = int(requested)
+    if enable_serial_offload:
+        if max_concurrency != 1:
+            logger.warning(
+                f"MiniMax Music 3 serial offload forces max_concurrency=1 "
+                f"(requested {max_concurrency}); AR and DIT/DAV must never "
+                "both hold GPU memory at once"
+            )
+        max_concurrency = 1
+        overrides["max_running_requests"] = 1
+        if not overrides.get("disable_cuda_graph"):
+            logger.info(
+                "MiniMax Music 3 serial offload forces disable_cuda_graph=True"
+            )
+        overrides["disable_cuda_graph"] = True
     builder = MiniMaxMusic3EngineBuilder(
-        max_running_requests=max(int(max_concurrency), 1)
+        max_running_requests=max(int(max_concurrency), 1),
+        enable_serial_offload=enable_serial_offload,
     )
     scheduler = builder.build(
         model_path,
@@ -67,8 +83,15 @@ def create_ar_executor(
         dtype="bfloat16",
         server_args_overrides=overrides or None,
     )
+    if enable_serial_offload:
+        from .serial_offload import get_coordinator
+
+        assert builder._model_runner is not None
+        get_coordinator().register_ar(
+            builder._model_runner.model, builder._model_runner.device
+        )
     logger.info(
-        f"MiniMax Music 3 AR executor ready (OmniScheduler) device={device} max_running_requests={builder.max_running_requests}"
+        f"MiniMax Music 3 AR executor ready (OmniScheduler) device={device} max_running_requests={builder.max_running_requests} serial_offload={enable_serial_offload}"
     )
     return scheduler
 
@@ -91,6 +114,7 @@ def create_dit_dav_executor(
     cache_dit_max_warmup_steps: int = 4,
     cache_dit_residual_diff_threshold: float = 0.08,
     cache_dit_max_continuous_cached_steps: int = 1,
+    enable_serial_offload: bool = False,
     **_: Any,
 ) -> MiniMaxMusic3AcousticScheduler:
     if device is None:
@@ -113,9 +137,10 @@ def create_dit_dav_executor(
         cache_dit_max_warmup_steps=cache_dit_max_warmup_steps,
         cache_dit_residual_diff_threshold=cache_dit_residual_diff_threshold,
         cache_dit_max_continuous_cached_steps=cache_dit_max_continuous_cached_steps,
+        serial_offload=enable_serial_offload,
     )
     logger.info(
-        f"MiniMax Music 3 acoustic executor ready device={decoder.device} dtype={decoder.dtype} dit_steps={decoder.dit_steps} dit_cfg_scale={decoder.dit_cfg_scale:.3f} attention_backend={decoder.attention_backend} compile_acoustic={decoder.compile_acoustic} sample_rate={OUTPUT_SAMPLE_RATE}"
+        f"MiniMax Music 3 acoustic executor ready device={decoder.device} dtype={decoder.dtype} dit_steps={decoder.dit_steps} dit_cfg_scale={decoder.dit_cfg_scale:.3f} attention_backend={decoder.attention_backend} compile_acoustic={decoder.compile_acoustic} serial_offload={enable_serial_offload} sample_rate={OUTPUT_SAMPLE_RATE}"
     )
     return MiniMaxMusic3AcousticScheduler(decoder)
 

--- a/sglang_omni/models/minimax_music3/stages.py
+++ b/sglang_omni/models/minimax_music3/stages.py
@@ -43,6 +43,7 @@ def create_ar_executor(
     device: str | None = None,
     max_concurrency: int = _DEFAULT_AR_CONCURRENCY,
     server_args_overrides: dict[str, Any] | None = None,
+    enable_serial_offload: bool = False,
 ):
     if device is None:
         if gpu_id is None or not (
@@ -93,6 +94,7 @@ def create_dit_dav_executor(
     cache_dit_max_warmup_steps: int = 4,
     cache_dit_residual_diff_threshold: float = 0.08,
     cache_dit_max_continuous_cached_steps: int = 1,
+    enable_serial_offload: bool = False,
 ) -> MiniMaxMusic3AcousticScheduler:
     if device is None:
         if gpu_id is None or not (

--- a/tests/unit_test/minimax_music3/test_serial_offload.py
+++ b/tests/unit_test/minimax_music3/test_serial_offload.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Serial offload coordinator behind --layerwise-offload-components ar,dit."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sglang_omni.models.minimax_music3.serial_offload import (
+    SerialOffloadCoordinator,
+    get_coordinator,
+    move_module_to_device,
+)
+
+
+def test_get_coordinator_returns_a_process_wide_singleton() -> None:
+    assert get_coordinator() is get_coordinator()
+
+
+def test_disabled_coordinator_never_blocks_admission_and_handoffs_are_noops() -> None:
+    coordinator = SerialOffloadCoordinator()
+
+    assert coordinator.enabled is False
+    assert coordinator.ar_can_admit() is True
+    coordinator.begin_dit_handoff()
+    coordinator.end_dit_handoff()
+    assert coordinator.ar_can_admit() is True
+
+
+def test_register_ar_enables_the_coordinator_and_starts_ar_active() -> None:
+    coordinator = SerialOffloadCoordinator()
+    model = torch.nn.Linear(2, 2)
+
+    coordinator.register_ar(model, torch.device("cpu"))
+
+    assert coordinator.enabled is True
+    assert coordinator.ar_can_admit() is True
+
+
+def test_begin_dit_handoff_moves_ar_off_the_gpu_and_blocks_admission() -> None:
+    coordinator = SerialOffloadCoordinator()
+    model = torch.nn.Linear(2, 2)
+    coordinator.register_ar(model, torch.device("cpu"))
+
+    coordinator.begin_dit_handoff()
+
+    assert coordinator.ar_can_admit() is False
+
+
+def test_end_dit_handoff_restores_ar_and_reopens_admission() -> None:
+    coordinator = SerialOffloadCoordinator()
+    model = torch.nn.Linear(2, 2)
+    coordinator.register_ar(model, torch.device("cpu"))
+    coordinator.begin_dit_handoff()
+
+    coordinator.end_dit_handoff()
+
+    assert coordinator.ar_can_admit() is True
+
+
+def test_handoff_calls_are_idempotent() -> None:
+    coordinator = SerialOffloadCoordinator()
+    model = torch.nn.Linear(2, 2)
+    coordinator.register_ar(model, torch.device("cpu"))
+
+    coordinator.begin_dit_handoff()
+    coordinator.begin_dit_handoff()
+    assert coordinator.ar_can_admit() is False
+
+    coordinator.end_dit_handoff()
+    coordinator.end_dit_handoff()
+    assert coordinator.ar_can_admit() is True
+
+
+def test_handoff_without_registration_raises_if_force_enabled() -> None:
+    """Defensive guard for a caller that enables without registering."""
+    coordinator = SerialOffloadCoordinator()
+    coordinator._enabled = True
+
+    with pytest.raises(RuntimeError, match="never registered"):
+        coordinator.begin_dit_handoff()
+    with pytest.raises(RuntimeError, match="never registered"):
+        coordinator.end_dit_handoff()
+
+
+def test_move_module_to_device_relocates_every_parameter() -> None:
+    module = torch.nn.Linear(2, 2)
+
+    move_module_to_device(module, torch.device("cpu"))
+
+    assert next(module.parameters()).device.type == "cpu"
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_serial_offload_round_trip_moves_weights_between_devices() -> None:
+    coordinator = SerialOffloadCoordinator()
+    device = torch.device("cuda:0")
+    model = torch.nn.Linear(4, 4).to(device)
+    coordinator.register_ar(model, device)
+
+    coordinator.begin_dit_handoff()
+    assert next(model.parameters()).device.type == "cpu"
+
+    coordinator.end_dit_handoff()
+    assert next(model.parameters()).device == device

--- a/tests/unit_test/minimax_music3/test_serial_offload.py
+++ b/tests/unit_test/minimax_music3/test_serial_offload.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Serial offload coordinator behind --stage-offload-components ar,dit."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sglang_omni.models.minimax_music3.serial_offload import (
+    STALL_REPORT_SECONDS,
+    SerialOffloadCoordinator,
+    StageResidency,
+    get_coordinator,
+)
+
+
+def _registered() -> SerialOffloadCoordinator:
+    coordinator = SerialOffloadCoordinator()
+    coordinator.register_ar(torch.nn.Linear(2, 2), torch.device("cpu"))
+    return coordinator
+
+
+def test_get_coordinator_returns_a_process_wide_singleton() -> None:
+    assert get_coordinator() is get_coordinator()
+
+
+def test_disabled_coordinator_never_blocks_admission_and_handoffs_are_noops() -> None:
+    coordinator = SerialOffloadCoordinator()
+
+    assert coordinator.enabled is False
+    assert coordinator.ar_can_admit() is True
+    coordinator.begin_dit_handoff("req-1")
+    coordinator.end_dit_handoff("req-1")
+    assert coordinator.ar_can_admit() is True
+
+
+def test_register_ar_enables_the_coordinator_and_starts_ar_active() -> None:
+    coordinator = _registered()
+
+    assert coordinator.enabled is True
+    assert coordinator.ar_can_admit() is True
+
+
+def test_begin_dit_handoff_moves_ar_off_the_gpu_and_blocks_admission() -> None:
+    coordinator = _registered()
+
+    coordinator.begin_dit_handoff("req-1")
+
+    assert coordinator.ar_can_admit() is False
+
+
+def test_end_dit_handoff_restores_ar_and_reopens_admission() -> None:
+    coordinator = _registered()
+    coordinator.begin_dit_handoff("req-1")
+
+    coordinator.end_dit_handoff("req-1")
+
+    assert coordinator.ar_can_admit() is True
+
+
+def test_handoff_calls_are_idempotent() -> None:
+    coordinator = _registered()
+
+    coordinator.begin_dit_handoff("req-1")
+    coordinator.begin_dit_handoff("req-1")
+    assert coordinator.ar_can_admit() is False
+
+    coordinator.end_dit_handoff("req-1")
+    coordinator.end_dit_handoff("req-1")
+    assert coordinator.ar_can_admit() is True
+
+
+def test_ar_stays_parked_until_every_outstanding_request_retires() -> None:
+    """The wake is driven by the outstanding set, not by the last event."""
+    coordinator = _registered()
+    coordinator.begin_dit_handoff("req-1")
+    coordinator.begin_dit_handoff("req-2")
+
+    coordinator.end_dit_handoff("req-1")
+    assert coordinator.ar_can_admit() is False
+
+    coordinator.end_dit_handoff("req-2")
+    assert coordinator.ar_can_admit() is True
+
+
+def test_end_for_a_request_that_never_handed_off_does_not_wake_ar() -> None:
+    coordinator = _registered()
+    coordinator.begin_dit_handoff("req-1")
+
+    coordinator.end_dit_handoff("req-unknown")
+
+    assert coordinator.ar_can_admit() is False
+
+
+def test_a_stalled_handoff_is_reported_once_and_never_force_woken(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    coordinator = _registered()
+    coordinator.begin_dit_handoff("req-1")
+    # Backdate the pause past the reporting threshold.
+    coordinator._paused_at -= STALL_REPORT_SECONDS + 1.0
+
+    with caplog.at_level("ERROR"):
+        assert coordinator.ar_can_admit() is False
+        assert coordinator.ar_can_admit() is False
+
+    stall_records = [r for r in caplog.records if "off the GPU for" in r.message]
+    assert len(stall_records) == 1
+    assert "req-1" in stall_records[0].message
+
+
+def test_handoff_without_registration_raises_if_force_enabled() -> None:
+    """Defensive guard for a caller that enables without registering."""
+    coordinator = SerialOffloadCoordinator()
+    coordinator._enabled = True
+
+    with pytest.raises(RuntimeError, match="never registered"):
+        coordinator.begin_dit_handoff("req-1")
+    with pytest.raises(RuntimeError, match="never registered"):
+        coordinator.end_dit_handoff("req-1")
+
+
+def test_residency_sleep_and_wake_preserve_weights_and_state() -> None:
+    module = torch.nn.Linear(2, 2)
+    expected = module.weight.detach().clone()
+    residency = StageResidency({"module": module}, torch.device("cpu"))
+
+    residency.sleep()
+    assert residency.resident is False
+    residency.wake()
+
+    assert residency.resident is True
+    assert torch.equal(module.weight, expected)
+
+
+def test_residency_reuses_one_host_copy_instead_of_recopying_each_sleep() -> None:
+    """The weights are immutable, so only the first sleep may snapshot them."""
+    module = torch.nn.Linear(2, 2)
+    residency = StageResidency({"module": module}, torch.device("cpu"))
+
+    residency.sleep()
+    snapshot = residency._host[("module", "weight")]
+    residency.wake()
+    residency.sleep()
+
+    assert residency._host[("module", "weight")] is snapshot
+
+
+def test_a_host_built_module_is_asleep_and_never_snapshots_from_the_gpu() -> None:
+    module = torch.nn.Linear(2, 2)
+    residency = StageResidency({"module": module}, torch.device("cpu"), resident=False)
+
+    assert residency.resident is False
+    assert residency._host[("module", "weight")] is not module.weight
+    assert residency._host[("module", "weight")].data_ptr() == module.weight.data_ptr()
+
+    residency.wake()
+    assert residency.resident is True
+
+
+def test_residency_keeps_tied_weights_tied_across_a_round_trip() -> None:
+    module = torch.nn.Linear(4, 4)
+    tied = torch.nn.Linear(4, 4)
+    tied.weight = module.weight
+    parent = torch.nn.Sequential(module, tied)
+    residency = StageResidency({"module": parent}, torch.device("cpu"))
+
+    residency.sleep()
+    residency.wake()
+
+    assert module.weight is tied.weight
+    assert module.weight.data_ptr() == tied.weight.data_ptr()
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_serial_offload_round_trip_moves_weights_between_devices() -> None:
+    coordinator = SerialOffloadCoordinator()
+    device = torch.device("cuda:0")
+    model = torch.nn.Linear(4, 4).to(device)
+    coordinator.register_ar(model, device)
+
+    coordinator.begin_dit_handoff("req-1")
+    assert next(model.parameters()).device.type == "cpu"
+
+    coordinator.end_dit_handoff("req-1")
+    assert next(model.parameters()).device == device
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_host_built_residency_keeps_canonical_copy_on_cpu() -> None:
+    device = torch.device("cuda:0")
+    model = torch.nn.Linear(4, 4)
+    expected = model.weight.detach().clone()
+    residency = StageResidency({"module": model}, device, resident=False)
+    host_weight = residency._host[("module", "weight")]
+
+    residency.wake()
+    assert model.weight.device == device
+    assert host_weight.device.type == "cpu"
+
+    residency.sleep()
+    assert model.weight.device.type == "cpu"
+    assert model.weight.data_ptr() == host_weight.data_ptr()
+    assert torch.equal(model.weight, expected)
+
+    residency.wake()
+    assert model.weight.device == device
+    assert host_weight.device.type == "cpu"
+    assert torch.equal(model.weight.cpu(), expected)
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_stage_group_wakes_once_and_keeps_allocator_blocks_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    device = torch.device("cuda:0")
+    dit = torch.nn.Linear(4, 4)
+    dav = torch.nn.Linear(4, 4)
+    residency = StageResidency(
+        {"dit": dit, "dav": dav}, device, resident=False, label="dit/dav"
+    )
+    synchronize_calls: list[torch.device] = []
+    empty_cache_calls = 0
+    synchronize = torch.cuda.synchronize
+    empty_cache = torch.cuda.empty_cache
+
+    def tracked_synchronize(target: torch.device) -> None:
+        synchronize_calls.append(target)
+        synchronize(target)
+
+    def tracked_empty_cache() -> None:
+        nonlocal empty_cache_calls
+        empty_cache_calls += 1
+        empty_cache()
+
+    monkeypatch.setattr(torch.cuda, "synchronize", tracked_synchronize)
+    monkeypatch.setattr(torch.cuda, "empty_cache", tracked_empty_cache)
+
+    residency.wake()
+    assert next(dit.parameters()).device == device
+    assert next(dav.parameters()).device == device
+    assert synchronize_calls == [device]
+
+    residency.sleep()
+    assert next(dit.parameters()).device.type == "cpu"
+    assert next(dav.parameters()).device.type == "cpu"
+    assert empty_cache_calls == 0

--- a/tests/unit_test/serve/test_layerwise_offload_cli_overrides.py
+++ b/tests/unit_test/serve/test_layerwise_offload_cli_overrides.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""--layerwise-offload-components ar,dit CLI wiring."""
+
+from __future__ import annotations
+
+import pytest
+import typer
+
+from sglang_omni.cli.serve import apply_layerwise_offload_cli_overrides
+from sglang_omni.config import PipelineConfig, StageConfig
+from sglang_omni.models.higgs_tts.config import HiggsTtsPipelineConfig
+from sglang_omni.models.minimax_music3.config import (
+    MiniMaxMusic3DualGPUPipelineConfig,
+    MiniMaxMusic3SingleGPUPipelineConfig,
+)
+
+
+def _stage(config: PipelineConfig, name: str) -> StageConfig:
+    return next(stage for stage in config.stages if stage.name == name)
+
+
+def test_absent_flag_is_a_no_op() -> None:
+    config = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    result = apply_layerwise_offload_cli_overrides(
+        config, layerwise_offload_components=None
+    )
+
+    assert result is config
+    assert "enable_serial_offload" not in _stage(result, "minimax_music3_ar").factory_args
+
+
+def test_ar_and_dit_colocates_both_stages_and_flags_their_factory_args() -> None:
+    config = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    result = apply_layerwise_offload_cli_overrides(
+        config, layerwise_offload_components="ar,dit"
+    )
+
+    ar_stage = _stage(result, "minimax_music3_ar")
+    dit_stage = _stage(result, "dit_dav")
+    assert ar_stage.process == dit_stage.process
+    assert ar_stage.factory_args["enable_serial_offload"] is True
+    assert dit_stage.factory_args["enable_serial_offload"] is True
+    # The override deep-copies, matching every other apply_*_cli_overrides.
+    assert "enable_serial_offload" not in _stage(config, "minimax_music3_ar").factory_args
+
+
+def test_whitespace_and_case_are_normalized() -> None:
+    config = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    result = apply_layerwise_offload_cli_overrides(
+        config, layerwise_offload_components=" AR , Dit "
+    )
+
+    assert _stage(result, "dit_dav").process == _stage(result, "minimax_music3_ar").process
+
+
+def test_partial_component_list_is_rejected() -> None:
+    config = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    with pytest.raises(typer.BadParameter, match="requires all of"):
+        apply_layerwise_offload_cli_overrides(config, layerwise_offload_components="ar")
+
+
+def test_unknown_component_is_rejected() -> None:
+    config = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    with pytest.raises(typer.BadParameter, match="does not support"):
+        apply_layerwise_offload_cli_overrides(
+            config, layerwise_offload_components="ar,dit,talker"
+        )
+
+
+def test_empty_flag_value_is_rejected() -> None:
+    config = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    with pytest.raises(typer.BadParameter, match="must not be empty"):
+        apply_layerwise_offload_cli_overrides(config, layerwise_offload_components=" , ")
+
+
+def test_unsupported_pipeline_is_rejected() -> None:
+    config = HiggsTtsPipelineConfig(model_path="dummy")
+
+    with pytest.raises(typer.BadParameter, match="not supported"):
+        apply_layerwise_offload_cli_overrides(config, layerwise_offload_components="ar,dit")
+
+
+def test_mismatched_gpu_placement_is_rejected() -> None:
+    config = MiniMaxMusic3DualGPUPipelineConfig(model_path="/models/minimax")
+    assert _stage(config, "minimax_music3_ar").gpu != _stage(config, "dit_dav").gpu
+
+    with pytest.raises(typer.BadParameter, match="same GPU"):
+        apply_layerwise_offload_cli_overrides(config, layerwise_offload_components="ar,dit")

--- a/tests/unit_test/serve/test_stage_offload_cli_overrides.py
+++ b/tests/unit_test/serve/test_stage_offload_cli_overrides.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""--stage-offload-components ar,dit CLI wiring."""
+
+from __future__ import annotations
+
+import pytest
+import typer
+
+from sglang_omni.cli.serve import apply_stage_offload_cli_overrides
+from sglang_omni.config import PipelineConfig, StageConfig
+from sglang_omni.models.higgs_tts.config import HiggsTtsPipelineConfig
+from sglang_omni.models.minimax_music3.config import (
+    MiniMaxMusic3DualGPUPipelineConfig,
+    MiniMaxMusic3SingleGPUPipelineConfig,
+)
+
+
+def _stage(config: PipelineConfig, name: str) -> StageConfig:
+    return next(stage for stage in config.stages if stage.name == name)
+
+
+def test_absent_flag_is_a_no_op() -> None:
+    config = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    result = apply_stage_offload_cli_overrides(config, stage_offload_components=None)
+
+    assert result is config
+    assert _stage(result, "minimax_music3_ar").factory.enable_serial_offload is None
+
+
+def test_ar_and_dit_colocates_both_stages_and_flags_their_factory_args() -> None:
+    config = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    result = apply_stage_offload_cli_overrides(
+        config, stage_offload_components="ar,dit"
+    )
+
+    ar_stage = _stage(result, "minimax_music3_ar")
+    dit_stage = _stage(result, "dit_dav")
+    assert ar_stage.process == dit_stage.process
+    assert ar_stage.factory.enable_serial_offload is True
+    assert dit_stage.factory.enable_serial_offload is True
+    # The override deep-copies, matching every other apply_*_cli_overrides.
+    assert _stage(config, "minimax_music3_ar").factory.enable_serial_offload is None
+
+
+def test_whitespace_and_case_are_normalized() -> None:
+    config = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    result = apply_stage_offload_cli_overrides(
+        config, stage_offload_components=" AR , Dit "
+    )
+
+    assert (
+        _stage(result, "dit_dav").process == _stage(result, "minimax_music3_ar").process
+    )
+
+
+def test_partial_component_list_is_rejected() -> None:
+    config = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    with pytest.raises(typer.BadParameter, match="requires all of"):
+        apply_stage_offload_cli_overrides(config, stage_offload_components="ar")
+
+
+def test_unknown_component_is_rejected() -> None:
+    config = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    with pytest.raises(typer.BadParameter, match="does not support"):
+        apply_stage_offload_cli_overrides(
+            config, stage_offload_components="ar,dit,talker"
+        )
+
+
+def test_empty_flag_value_is_rejected() -> None:
+    config = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    with pytest.raises(typer.BadParameter, match="must not be empty"):
+        apply_stage_offload_cli_overrides(config, stage_offload_components=" , ")
+
+
+def test_unsupported_pipeline_is_rejected() -> None:
+    config = HiggsTtsPipelineConfig(model_path="dummy")
+
+    with pytest.raises(typer.BadParameter, match="not supported"):
+        apply_stage_offload_cli_overrides(config, stage_offload_components="ar,dit")
+
+
+def test_mismatched_gpu_placement_is_rejected() -> None:
+    config = MiniMaxMusic3DualGPUPipelineConfig(model_path="/models/minimax")
+    assert _stage(config, "minimax_music3_ar").gpu != _stage(config, "dit_dav").gpu
+
+    with pytest.raises(typer.BadParameter, match="same GPU"):
+        apply_stage_offload_cli_overrides(config, stage_offload_components="ar,dit")


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Current sglang-omni doesn't support inference with single model for low VRAM GPUs, which causes OOM issues on several consumer-level GPUs.

This PR helps introduce a feature from sglang: `stage-wise-offload`, which inference models like Minimax-Music3 in a queue.

## Modifications

<!-- Describe the changes made in this PR. -->

A new parameter is introduced into sglang-omni, however, this feature is still under communication.

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

The same as #1605 

Related to #1618 

## Accuracy Test

This feature has no influence on Accuracy if `quantize` isn't enabled.
<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
