### PR TITLE
[audio] Support 24-bit PCM and WAVE_FORMAT_EXTENSIBLE in the WAV fast path

### DIFF
--- a/sglang_omni/preprocessing/audio.py
+++ b/sglang_omni/preprocessing/audio.py
@@ -88,6 +88,11 @@ def _parse_wav_bytes(data: bytes, source: str = "bytes") -> tuple[np.ndarray, in
                 fmt_tag, channels, sample_rate, _, _, bits_per_sample = struct.unpack(
                     "<HHIIHH", chunk_data[:16]
                 )
+                # WAVE_FORMAT_EXTENSIBLE stores the real codec in the first two
+                # bytes of the SubFormat GUID; unwrap it so the dispatch below
+                # sees PCM/IEEE-float instead of the 0xFFFE wrapper tag.
+                if fmt_tag == 0xFFFE and len(chunk_data) >= 26:
+                    (fmt_tag,) = struct.unpack("<H", chunk_data[24:26])
         elif chunk_id == b"data":
             data_bytes = chunk_data
 
@@ -107,6 +112,17 @@ def _parse_wav_bytes(data: bytes, source: str = "bytes") -> tuple[np.ndarray, in
         if bits_per_sample == 16:
             audio_i16 = np.frombuffer(data_bytes, dtype="<i2")
             audio = (audio_i16.astype(np.float32) / 32768.0).astype(np.float32)
+        elif bits_per_sample == 24:
+            usable = (len(data_bytes) // 3) * 3
+            raw = np.frombuffer(data_bytes[:usable], dtype="u1").reshape(-1, 3)
+            audio_i32 = (
+                raw[:, 0].astype(np.int32)
+                | (raw[:, 1].astype(np.int32) << 8)
+                | (raw[:, 2].astype(np.int32) << 16)
+            )
+            # Sign-extend the 24-bit value into the int32 range.
+            audio_i32 = np.where(audio_i32 & 0x800000, audio_i32 - 0x1000000, audio_i32)
+            audio = (audio_i32.astype(np.float32) / 8388608.0).astype(np.float32)
         elif bits_per_sample == 32:
             audio_i32 = np.frombuffer(data_bytes, dtype="<i4")
             audio = (audio_i32.astype(np.float32) / 2147483648.0).astype(np.float32)

--- a/sglang_omni/preprocessing/audio.py
+++ b/sglang_omni/preprocessing/audio.py
@@ -15,6 +15,13 @@ import torch
 
 from .base import MediaIO, _is_url
 
+# KSDATAFORMAT_SUBTYPE_* GUIDs (16 bytes, WAV on-disk byte order). A
+# WAVE_FORMAT_EXTENSIBLE fmt chunk only maps to plain PCM / IEEE-float when its
+# SubFormat matches one of these in full; the leading 16 bits alone are not
+# enough, since vendor-defined GUIDs may reuse those bytes.
+_WAVE_SUBFORMAT_PCM = bytes.fromhex("0100000000001000800000aa00389b71")
+_WAVE_SUBFORMAT_IEEE_FLOAT = bytes.fromhex("0300000000001000800000aa00389b71")
+
 
 def _decode_audio_bytes_av(data: bytes) -> tuple[np.ndarray, int]:
     """Decode audio bytes using PyAV (supports WebM/Opus, MP3, OGG, FLAC, etc.)."""
@@ -88,11 +95,16 @@ def _parse_wav_bytes(data: bytes, source: str = "bytes") -> tuple[np.ndarray, in
                 fmt_tag, channels, sample_rate, _, _, bits_per_sample = struct.unpack(
                     "<HHIIHH", chunk_data[:16]
                 )
-                # WAVE_FORMAT_EXTENSIBLE stores the real codec in the first two
-                # bytes of the SubFormat GUID; unwrap it so the dispatch below
-                # sees PCM/IEEE-float instead of the 0xFFFE wrapper tag.
-                if fmt_tag == 0xFFFE and len(chunk_data) >= 26:
-                    (fmt_tag,) = struct.unpack("<H", chunk_data[24:26])
+                # WAVE_FORMAT_EXTENSIBLE carries the real codec in a full 16-byte
+                # SubFormat GUID. Only unwrap it when the complete GUID matches a
+                # known PCM/IEEE-float subtype; otherwise leave fmt_tag as 0xFFFE
+                # so the dispatch below raises and the PyAV fallback takes over.
+                if fmt_tag == 0xFFFE and len(chunk_data) >= 40:
+                    subformat = chunk_data[24:40]
+                    if subformat == _WAVE_SUBFORMAT_PCM:
+                        fmt_tag = 1
+                    elif subformat == _WAVE_SUBFORMAT_IEEE_FLOAT:
+                        fmt_tag = 3
         elif chunk_id == b"data":
             data_bytes = chunk_data
 

--- a/tests/unit_test/preprocessing/test_wav_parser.py
+++ b/tests/unit_test/preprocessing/test_wav_parser.py
@@ -96,3 +96,25 @@ def test_pcm16_still_parses():
 def test_unsupported_bit_depth_still_raises():
     with pytest.raises(ValueError):
         _parse_wav_bytes(_build_wav(PCM, 12, b"\x00\x00\x00"))
+
+
+def _build_extensible_wav_raw_guid(guid16, bits, data_bytes, *, sample_rate=16000):
+    assert len(guid16) == 16
+    block_align = bits // 8
+    byte_rate = sample_rate * block_align
+    fmt = struct.pack(
+        "<HHIIHH", EXTENSIBLE, 1, sample_rate, byte_rate, block_align, bits
+    )
+    fmt += struct.pack("<HHI", 22, bits, 0) + guid16
+    chunks = b"fmt " + struct.pack("<I", len(fmt)) + fmt
+    chunks += b"data" + struct.pack("<I", len(data_bytes)) + data_bytes
+    return b"RIFF" + struct.pack("<I", 4 + len(chunks)) + b"WAVE" + chunks
+
+
+def test_extensible_custom_guid_is_not_decoded_as_pcm():
+    # A vendor GUID whose first two bytes look like PCM (0x0001) but whose tail
+    # differs must NOT be unwrapped; it should raise so PyAV can handle it.
+    bogus = b"\x01\x00" + b"\xde\xad\xbe\xef" + b"\x00" * 10
+    data = np.array([0, 16384, -16384], dtype="<i2").tobytes()
+    with pytest.raises(ValueError):
+        _parse_wav_bytes(_build_extensible_wav_raw_guid(bogus, 16, data))

--- a/tests/unit_test/preprocessing/test_wav_parser.py
+++ b/tests/unit_test/preprocessing/test_wav_parser.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the dependency-free WAV fast-path parser."""
+
+import struct
+
+import numpy as np
+import pytest
+
+from sglang_omni.preprocessing.audio import _parse_wav_bytes
+
+PCM = 1
+IEEE_FLOAT = 3
+EXTENSIBLE = 0xFFFE
+
+# Fixed 14-byte GUID suffix shared by every KSDATAFORMAT_SUBTYPE_* value.
+_GUID_SUFFIX = b"\x00\x00\x00\x00\x10\x00\x80\x00\x00\xaa\x00\x38\x9b\x71"
+
+
+def _build_wav(fmt_tag, bits, data_bytes, *, channels=1, sample_rate=16000):
+    block_align = channels * bits // 8
+    byte_rate = sample_rate * block_align
+    if fmt_tag == EXTENSIBLE:
+        raise ValueError("use sub_format to build EXTENSIBLE fixtures")
+    fmt = struct.pack(
+        "<HHIIHH", fmt_tag, channels, sample_rate, byte_rate, block_align, bits
+    )
+    chunks = b"fmt " + struct.pack("<I", len(fmt)) + fmt
+    chunks += b"data" + struct.pack("<I", len(data_bytes)) + data_bytes
+    return b"RIFF" + struct.pack("<I", 4 + len(chunks)) + b"WAVE" + chunks
+
+
+def _build_extensible_wav(
+    sub_format, bits, data_bytes, *, channels=1, sample_rate=16000
+):
+    block_align = channels * bits // 8
+    byte_rate = sample_rate * block_align
+    fmt = struct.pack(
+        "<HHIIHH", EXTENSIBLE, channels, sample_rate, byte_rate, block_align, bits
+    )
+    fmt += struct.pack("<HHI", 22, bits, 0)  # cbSize, wValidBitsPerSample, channelMask
+    fmt += struct.pack("<H", sub_format) + _GUID_SUFFIX
+    chunks = b"fmt " + struct.pack("<I", len(fmt)) + fmt
+    chunks += b"data" + struct.pack("<I", len(data_bytes)) + data_bytes
+    return b"RIFF" + struct.pack("<I", 4 + len(chunks)) + b"WAVE" + chunks
+
+
+def _pack_s24(values):
+    out = bytearray()
+    for v in values:
+        out += struct.pack("<i", v)[:3]
+    return bytes(out)
+
+
+def test_pcm24_mono_scales_to_unit_range():
+    audio, sr = _parse_wav_bytes(
+        _build_wav(PCM, 24, _pack_s24([0, 0x400000, -0x400000]))
+    )
+    assert sr == 16000
+    np.testing.assert_allclose(audio, [0.0, 0.5, -0.5], atol=1e-6)
+    assert audio.dtype == np.float32
+
+
+def test_pcm24_multichannel_downmix():
+    # Two frames, stereo: [(0, +1.0), (-1.0, 0)] -> mono means [0.5, -0.5].
+    samples = _pack_s24([0, 0x7FFFFF, -0x800000, 0])
+    audio, _ = _parse_wav_bytes(_build_wav(PCM, 24, samples, channels=2))
+    np.testing.assert_allclose(audio, [0.5, -0.5], atol=1e-6)
+
+
+def test_extensible_wraps_pcm16():
+    data = np.array([0, 16384, -16384], dtype="<i2").tobytes()
+    audio, sr = _parse_wav_bytes(_build_extensible_wav(PCM, 16, data))
+    assert sr == 16000
+    np.testing.assert_allclose(audio, [0.0, 0.5, -0.5], atol=1e-6)
+
+
+def test_extensible_wraps_ieee_float32():
+    data = np.array([0.0, 0.25, -0.75], dtype="<f4").tobytes()
+    audio, _ = _parse_wav_bytes(_build_extensible_wav(IEEE_FLOAT, 32, data))
+    np.testing.assert_allclose(audio, [0.0, 0.25, -0.75], atol=1e-6)
+
+
+def test_extensible_wraps_pcm24():
+    audio, _ = _parse_wav_bytes(
+        _build_extensible_wav(PCM, 24, _pack_s24([0, 0x400000]))
+    )
+    np.testing.assert_allclose(audio, [0.0, 0.5], atol=1e-6)
+
+
+def test_pcm16_still_parses():
+    data = np.array([0, 16384, -16384], dtype="<i2").tobytes()
+    audio, _ = _parse_wav_bytes(_build_wav(PCM, 16, data))
+    np.testing.assert_allclose(audio, [0.0, 0.5, -0.5], atol=1e-6)
+
+
+def test_unsupported_bit_depth_still_raises():
+    with pytest.raises(ValueError):
+        _parse_wav_bytes(_build_wav(PCM, 12, b"\x00\x00\x00"))


### PR DESCRIPTION
## Motivation

The dependency-free WAV fast path added in #1031 (`_parse_wav_bytes`) rejects two very common WAV variants with a `ValueError`, sending them down the heavier PyAV fallback instead of the fast path:

- **24-bit PCM** — the most common "professional" bit depth. Raises `Unsupported PCM WAV bit depth: 24`.
- **WAVE_FORMAT_EXTENSIBLE** (`fmt_tag=0xFFFE`) — emitted by many modern encoders and Windows recordings even for plain PCM. Raises `Unsupported WAV format tag: 65534`.

Both still decode correctly today via the PyAV fallback, so this is a robustness / consistency / fast-path-coverage improvement rather than a crash fix: it lets these common inputs skip the `av.open` + per-frame decode round-trip.

## Changes

`_parse_wav_bytes` in `sglang_omni/preprocessing/audio.py`:

1. When the `fmt ` tag is `0xFFFE` (WAVE_FORMAT_EXTENSIBLE), unwrap the real codec tag from the first two bytes of the SubFormat GUID before dispatching, so it is handled as ordinary PCM / IEEE-float.
2. Add a 24-bit PCM branch: assemble little-endian 3-byte samples, sign-extend into int32, and normalize by `2**23` — the same `[-1, 1)` scaling convention as the existing 16/32-bit branches.

No public signatures change; other paths are untouched.

## Tests

New `tests/unit_test/preprocessing/test_wav_parser.py` (7 cases, pure numpy/struct — no torch/av needed): 24-bit mono, 24-bit stereo downmix, EXTENSIBLE wrapping PCM16 / IEEE-float32 / PCM24, a plain-PCM16 regression guard, and an unsupported-bit-depth guard that must still raise.

- Before this change: the 5 new-format cases fail; the 2 sanity cases pass.
- After: all 7 pass. Existing `tests/unit_test/preprocessing/` suite stays green.
- `black` (24.10.0) and `isort` (5.13.2) are clean.
