### PR TITLE
[ARK-ASR] Wire CLI role maps for mem-fraction and generation server args

### DIFF
--- a/sglang_omni/models/arkasr/config.py
+++ b/sglang_omni/models/arkasr/config.py
@@ -15,6 +15,14 @@ class ArkasrPipelineConfig(PipelineConfig):
 
     architecture: ClassVar[str] = "ArkasrForConditionalGeneration"
 
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"asr": "asr"}
+
+    @classmethod
+    def generation_sglang_role_to_stage(cls) -> dict[str, str]:
+        return {"generation": "asr"}
+
     model_path: str
     entry_stage: str = "asr"
     stages: list[StageConfig] = [

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -71,6 +71,10 @@ def test_arkasr_config_registered():
         PIPELINE_CONFIG_REGISTRY.get_config("ArkasrForConditionalGeneration")
         is ArkasrPipelineConfig
     )
+    assert ArkasrPipelineConfig.mem_fraction_role_to_stage() == {"asr": "asr"}
+    assert ArkasrPipelineConfig.generation_sglang_role_to_stage() == {
+        "generation": "asr"
+    }
 
 
 def test_arkasr_stage_defaults():

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -62,6 +62,10 @@ def test_arkasr_config_registered():
         PIPELINE_CONFIG_REGISTRY.get_config("ArkasrForConditionalGeneration")
         is ArkasrPipelineConfig
     )
+    assert ArkasrPipelineConfig.mem_fraction_role_to_stage() == {"asr": "asr"}
+    assert ArkasrPipelineConfig.generation_sglang_role_to_stage() == {
+        "generation": "asr"
+    }
 
 
 def test_arkasr_stage_defaults():

--- a/tests/unit_test/serve/test_generation_server_args.py
+++ b/tests/unit_test/serve/test_generation_server_args.py
@@ -12,6 +12,7 @@ import typer
 from sglang_omni.cli.serve import (
     _apply_stage_server_args_override,
     apply_backbone_server_args_cli_overrides,
+    apply_mem_fraction_cli_overrides,
     serve,
 )
 from sglang_omni.config import (
@@ -20,6 +21,7 @@ from sglang_omni.config import (
     StageConfig,
     compile_logical_processes,
 )
+from sglang_omni.models.arkasr.config import ArkasrPipelineConfig
 from sglang_omni.models.fishaudio_s2_pro.config import S2ProPipelineConfig
 from sglang_omni.models.fun_asr.config import FunASRPipelineConfig
 from sglang_omni.models.higgs_tts.config import HiggsTtsPipelineConfig
@@ -403,6 +405,8 @@ def test_generation_server_args_support_qwen3_omni_speech() -> None:
         Qwen3ASRPipelineConfig,
         WhisperASRPipelineConfig,
         FunASRPipelineConfig,
+        MossTranscribeDiarizePipelineConfig,
+        ArkasrPipelineConfig,
     ],
 )
 def test_generation_server_args_support_asr_configs(
@@ -411,7 +415,16 @@ def test_generation_server_args_support_asr_configs(
     # Note (Jiaxin Deng): the ASR role maps exist so the same-GPU DP launcher
     # can pin caps and mem fraction; losing either silently breaks that path.
     assert config_cls.mem_fraction_role_to_stage() == {"asr": "asr"}
+    assert config_cls.generation_sglang_role_to_stage() == {"generation": "asr"}
     config = config_cls(model_path="dummy")
+    apply_mem_fraction_cli_overrides(
+        config,
+        mem_fraction_static=0.75,
+        thinker_mem_fraction_static=None,
+        talker_mem_fraction_static=None,
+    )
+    asr = next(stage for stage in config.stages if stage.name == "asr")
+    assert asr.runtime.sglang_server_args.mem_fraction_static == 0.75
     _apply_generation_server_args(config)
 
     overrides = _stage_args(config, "asr")["server_args_overrides"]

--- a/tests/unit_test/serve/test_generation_server_args.py
+++ b/tests/unit_test/serve/test_generation_server_args.py
@@ -12,9 +12,11 @@ import typer
 from sglang_omni.cli.serve import (
     _apply_stage_server_args_override,
     apply_backbone_server_args_cli_overrides,
+    apply_mem_fraction_cli_overrides,
     serve,
 )
 from sglang_omni.config import PipelineConfig, StageConfig
+from sglang_omni.models.arkasr.config import ArkasrPipelineConfig
 from sglang_omni.models.fishaudio_s2_pro.config import S2ProPipelineConfig
 from sglang_omni.models.fun_asr.config import FunASRPipelineConfig
 from sglang_omni.models.higgs_tts.config import HiggsTtsPipelineConfig
@@ -382,6 +384,8 @@ def test_generation_server_args_support_qwen3_omni_speech() -> None:
         Qwen3ASRPipelineConfig,
         WhisperASRPipelineConfig,
         FunASRPipelineConfig,
+        MossTranscribeDiarizePipelineConfig,
+        ArkasrPipelineConfig,
     ],
 )
 def test_generation_server_args_support_asr_configs(
@@ -390,7 +394,16 @@ def test_generation_server_args_support_asr_configs(
     # Note (Jiaxin Deng): the ASR role maps exist so the same-GPU DP launcher
     # can pin caps and mem fraction; losing either silently breaks that path.
     assert config_cls.mem_fraction_role_to_stage() == {"asr": "asr"}
+    assert config_cls.generation_sglang_role_to_stage() == {"generation": "asr"}
     config = config_cls(model_path="dummy")
+    apply_mem_fraction_cli_overrides(
+        config,
+        mem_fraction_static=0.75,
+        thinker_mem_fraction_static=None,
+        talker_mem_fraction_static=None,
+    )
+    asr = next(stage for stage in config.stages if stage.name == "asr")
+    assert asr.runtime.sglang_server_args.mem_fraction_static == 0.75
     _apply_generation_server_args(config)
 
     overrides = _stage_args(config, "asr")["server_args_overrides"]


### PR DESCRIPTION
## Summary
- `ArkasrPipelineConfig` did not override `mem_fraction_role_to_stage()` / `generation_sglang_role_to_stage()`, so the empty base maps rejected cookbook CLI flags before load.
- `--mem-fraction-static` and `--max-running-requests` (and queued / total-tokens / cuda-graph-max-bs) failed with Click `BadParameter`, while Qwen3 / Fun / Whisper / MOSS already wired `asr`.
- Add the same two maps as the other single-stage ASR configs, and lock them in unit tests. No change to ARK scheduler/encoder defaults.

## Ref 
part of https://github.com/sgl-project/sglang-omni/issues/1396

## Test plan
- [x] `pytest tests/unit_test/serve/test_generation_server_args.py tests/unit_test/arkasr/test_pipeline.py`

- **before**    
<img width="3548" height="764" alt="img_v3_0214n_a91e63d9-b956-40f4-84b7-c1b59f984dag" src="https://github.com/user-attachments/assets/f0e4f8d7-922c-4c70-9a20-5aca6dabeced" />

- **after** 
<img width="3342" height="282" alt="img_v3_0214n_0ae16d43-43d9-4cd1-b19c-a0f0f4b5a8bg" src="https://github.com/user-attachments/assets/70900daf-4e15-4b12-8f2e-3f998446b334" />
<img width="3536" height="608" alt="img_v3_0214n_ad2f1c66-3d43-4b53-92ba-a45872d1570g" src="https://github.com/user-attachments/assets/f90a27e6-f5c6-4783-b121-beeac42d9ac2" />

 
