### PR TITLE
[TTS] Keep WebSocket open across committed input segments

### DIFF
--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -397,12 +397,13 @@ async def main():
 asyncio.run(main())
 ```
 
-Each `input.commit` flushes text that does not end at the configured sentence
-or clause boundary. After all audio for that segment, the server emits
+Each `input.commit` forces a flush of any remaining buffered text (including text that does not end at the configured sentence
+or clause boundary). After all audio for that segment, the server emits
 `input.committed` with `segment_index`, `segment_sentences`, and cumulative
 `total_sentences`, then accepts more input on the same connection. An empty
-commit is valid and reports `segment_sentences: 0`. `input.done` performs the
-same final buffer flush, emits `session.done`, and closes the WebSocket.
+commit is valid: it flushes nothing and reports `segment_sentences: 0`.
+`input.done` performs the same final buffer flush, emits `session.done`, and
+closes the WebSocket.
 
 `split_granularity` can be `sentence` or `clause`. Unknown message types and
 malformed JSON return a WebSocket `error` event. Missing or invalid initial

--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -327,8 +327,9 @@ items, fail the HTTP request.
 
 Use `/v1/audio/speech/stream` for stateful text input over a persistent
 WebSocket. The first message must be `session.config`. Then send `input.text`
-messages and finish with `input.done`. The server acknowledges the initial
-configuration with `session.configured`.
+messages. Send `input.commit` to flush the current text segment while keeping
+the WebSocket open, or finish the session with `input.done`. The server
+acknowledges the initial configuration with `session.configured`.
 
 `stream_audio` defaults to `false`. With the default, each completed text
 segment returns one binary audio frame between `audio.start` and `audio.done`.
@@ -358,13 +359,27 @@ async def main():
         }))
         print(await ws.recv())
 
+        pcm_chunks = []
         await ws.send(json.dumps({
             "type": "input.text",
             "text": "Hello from the speech WebSocket. This is the second sentence.",
         }))
+        await ws.send(json.dumps({"type": "input.commit"}))
+
+        # input.committed is emitted after all audio for the segment. More
+        # input.text/input.commit pairs can follow on the same WebSocket.
+        while True:
+            message = await ws.recv()
+            if isinstance(message, bytes):
+                pcm_chunks.append(message)
+                continue
+            event = json.loads(message)
+            print(event)
+            if event["type"] == "input.committed":
+                break
+
         await ws.send(json.dumps({"type": "input.done"}))
 
-        pcm_chunks = []
         while True:
             message = await ws.recv()
             if isinstance(message, bytes):
@@ -381,6 +396,13 @@ async def main():
 
 asyncio.run(main())
 ```
+
+Each `input.commit` flushes text that does not end at the configured sentence
+or clause boundary. After all audio for that segment, the server emits
+`input.committed` with `segment_index`, `segment_sentences`, and cumulative
+`total_sentences`, then accepts more input on the same connection. An empty
+commit is valid and reports `segment_sentences: 0`. `input.done` performs the
+same final buffer flush, emits `session.done`, and closes the WebSocket.
 
 `split_granularity` can be `sentence` or `clause`. Unknown message types and
 malformed JSON return a WebSocket `error` event. Missing or invalid initial

--- a/sglang_omni/serve/speech_ws.py
+++ b/sglang_omni/serve/speech_ws.py
@@ -84,6 +84,8 @@ class SpeechWebSocketSession:
         self.config: SpeechStreamSessionConfig | None = None
         self.buffer = ""
         self.sentence_index = 0
+        self.committed_sentence_count = 0
+        self.segment_index = 0
         self.active_request_id: str | None = None
         self.buffered_receive_messages: deque[dict[str, Any]] = deque()
         self.buffered_receive_message_bytes = 0
@@ -161,6 +163,8 @@ class SpeechWebSocketSession:
             message_type = payload.get("type")
             if message_type == "input.text":
                 await self._handle_input_text(payload)
+            elif message_type == "input.commit":
+                await self._handle_input_commit()
             elif message_type == "input.done":
                 await self._handle_input_done()
                 return
@@ -193,11 +197,29 @@ class SpeechWebSocketSession:
         for sentence in self._pop_complete_segments():
             await self._generate_sentence(sentence)
 
-    async def _handle_input_done(self) -> None:
+    async def _flush_buffer(self) -> None:
         remaining = self.buffer.strip()
         self.buffer = ""
         if remaining:
             await self._generate_sentence(remaining)
+
+    async def _handle_input_commit(self) -> None:
+        await self._flush_buffer()
+        segment_sentences = self.sentence_index - self.committed_sentence_count
+        self.committed_sentence_count = self.sentence_index
+        await self._send_json(
+            {
+                "type": "input.committed",
+                "session_id": self.session_id,
+                "segment_index": self.segment_index,
+                "segment_sentences": segment_sentences,
+                "total_sentences": self.sentence_index,
+            }
+        )
+        self.segment_index += 1
+
+    async def _handle_input_done(self) -> None:
+        await self._flush_buffer()
         await self._send_json(
             {
                 "type": "session.done",

--- a/tests/unit_test/serve/test_speech_ws.py
+++ b/tests/unit_test/serve/test_speech_ws.py
@@ -318,6 +318,53 @@ def test_speech_websocket_streams_sentences_as_binary_frames() -> None:
     assert client_impl.generated_prompts == ["Hello.", "Second"]
 
 
+def test_speech_websocket_commit_flushes_segments_without_closing() -> None:
+    client_impl = StreamingSpeechClient()
+    client = TestClient(create_app(client_impl, model_name="tts"))
+
+    with client.websocket_connect("/v1/audio/speech/stream") as websocket:
+        websocket.send_json(_session_config(response_format="pcm", stream_audio=True))
+        assert websocket.receive_json()["type"] == "session.configured"
+
+        websocket.send_json({"type": "input.text", "text": "First segment."})
+        websocket.send_json({"type": "input.commit"})
+        assert websocket.receive_json()["type"] == "audio.start"
+        assert websocket.receive_bytes()
+        assert websocket.receive_json()["type"] == "audio.done"
+        first_commit = websocket.receive_json()
+
+        assert first_commit["type"] == "input.committed"
+        assert first_commit["segment_index"] == 0
+        assert first_commit["segment_sentences"] == 1
+        assert first_commit["total_sentences"] == 1
+
+        websocket.send_json({"type": "input.text", "text": "Second segment"})
+        websocket.send_json({"type": "input.commit"})
+        assert websocket.receive_json()["type"] == "audio.start"
+        assert websocket.receive_bytes()
+        assert websocket.receive_json()["type"] == "audio.done"
+        second_commit = websocket.receive_json()
+
+        assert second_commit["type"] == "input.committed"
+        assert second_commit["segment_index"] == 1
+        assert second_commit["segment_sentences"] == 1
+        assert second_commit["total_sentences"] == 2
+
+        websocket.send_json({"type": "input.commit"})
+        empty_commit = websocket.receive_json()
+        assert empty_commit["type"] == "input.committed"
+        assert empty_commit["segment_index"] == 2
+        assert empty_commit["segment_sentences"] == 0
+        assert empty_commit["total_sentences"] == 2
+
+        websocket.send_json({"type": "input.done"})
+        session_done = websocket.receive_json()
+        assert session_done["type"] == "session.done"
+        assert session_done["total_sentences"] == 2
+
+    assert client_impl.generated_prompts == ["First segment.", "Second segment"]
+
+
 def test_speech_websocket_config_uses_served_model_and_default_voice() -> None:
     async def run() -> None:
         speech_service = SpeechRequestValidator(default_model="served-model")


### PR DESCRIPTION
## Motivation

Long-lived voice sessions need to mark the end of an independently synthesized text segment without tearing down and reconfiguring `/v1/audio/speech/stream` after every turn. Today, `input.done` flushes the remaining text and closes the WebSocket.

## Modifications

- Add an `input.commit` client event that flushes the current text buffer without closing the session.
- Emit `input.committed` after the segment's audio completes, including segment and cumulative sentence counts.
- Preserve the existing final `input.done` → `session.done` → close behavior.
- Document persistent segment commits and add coverage for punctuated, unterminated, repeated, and empty commits.

## Related Issues

None.

## Accuracy Test

Not applicable; this changes only WebSocket session control and does not modify model inference.

## Benchmark & Profiling

Not applicable; no model or audio generation hot path is changed.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed. (Not applicable.)

## Test plan

- `python -m pytest tests/unit_test/serve/test_speech_ws.py -q` (38 passed)
- `python -m ruff check sglang_omni/serve/speech_ws.py tests/unit_test/serve/test_speech_ws.py`
- `python -m ruff format --check sglang_omni/serve/speech_ws.py tests/unit_test/serve/test_speech_ws.py`

Made with [Cursor](https://cursor.com)