### PR TITLE
Harden docs workflows against apt mirror stalls

### DIFF
--- a/.github/workflows/docs-check.yaml
+++ b/.github/workflows/docs-check.yaml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   build-docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -30,7 +31,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y pandoc parallel retry
+          timeout 5m sudo apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            update
+          sudo apt-get install -y pandoc parallel retry
           pip install -r docs/requirements.txt
 
       - name: Build documentation

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   deploy-github-pages:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: write
     steps:
@@ -26,7 +27,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y pandoc parallel retry
+          timeout 5m sudo apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            update
+          sudo apt-get install -y pandoc parallel retry
           pip install -r docs/requirements.txt
 
       - name: Build documentation


### PR DESCRIPTION
## Summary

- cap the docs publish and docs check jobs at 45 minutes
- bound `apt-get update` to five minutes
- add apt mirror retries and 30-second HTTP/HTTPS timeouts in both workflows

## Why

A GitHub-hosted Ubuntu runner stalled in `apt-get update` while contacting the Azure/Ubuntu package mirror. With no job timeout configured, the docs publish job consumed the default six-hour GitHub Actions limit before it was canceled. This was an external infrastructure flake, unrelated to the Whisper ASR changes in #1620.

The five-minute apt bound prevents the same mirror outage from tying up CI, while the 45-minute job timeout leaves room for dependency installation, documentation compilation, and deployment.

## Validation

- `.venv/bin/pre-commit run --files .github/workflows/publish-docs.yaml .github/workflows/docs-check.yaml`
