### PR TITLE
[AMD][ROCm] Add Docker development image

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1.7
+
+# Build on the validated SGLang ROCm stack without replacing GPU-coupled components.
+ARG SGLANG_IMAGE=lmsysorg/sglang:v0.5.16-rocm720-mi35x@sha256:54ac680bad1832b8acd469533ae66f608b525cec3449bbd5f3d0238351e9b965
+
+FROM ${SGLANG_IMAGE} AS runtime
+
+ARG OMNI_REPO=https://github.com/sgl-project/sglang-omni.git
+ARG OMNI_REF=main
+
+ENV PATH=/opt/ucx/bin:${PATH} \
+    SGLANG_OMNI_REPO_DIR=/workspace/sglang-omni
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ffmpeg \
+        libsndfile1 \
+        sox \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install project dependencies in a separate cacheable layer.
+RUN python3 -m pip install --no-cache-dir uv
+
+COPY pyproject_rocm.toml /tmp/pyproject.toml
+RUN uv pip install --no-build-isolation \
+        -r /tmp/pyproject.toml
+
+RUN git clone "${OMNI_REPO}" "${SGLANG_OMNI_REPO_DIR}" \
+    && git -C "${SGLANG_OMNI_REPO_DIR}" checkout --detach "${OMNI_REF}"
+
+WORKDIR ${SGLANG_OMNI_REPO_DIR}
+
+# Keep ROCm project metadata at the source root for consistent editable installs.
+RUN cp /tmp/pyproject.toml pyproject.toml \
+    && python3 -m pip install --no-cache-dir --no-deps --no-build-isolation -e . \
+    && rm /tmp/pyproject.toml
+
+RUN python3 - <<'PY'
+import torch
+
+assert torch.version.hip, "the inherited PyTorch build is not ROCm-enabled"
+import nixl  # noqa: F401
+import sglang  # noqa: F401
+import sglang_omni  # noqa: F401
+PY
+
+RUN ucx_info -v | grep -q -- '--with-rocm'
+
+CMD ["/bin/bash"]

--- a/pyproject_rocm.toml
+++ b/pyproject_rocm.toml
@@ -1,0 +1,114 @@
+[build-system]
+requires = ["setuptools>=77.0.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sglang-omni"
+dynamic = ["version"]
+description = "Multi-stage pipeline framework for omni models"
+readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+requires-python = ">=3.10,<3.13"
+dependencies = [
+    # Core dependencies
+    "pyzmq>=25.0.0",
+    "msgpack>=1.0.0",
+    "msgspec",
+    "numpy>=1.24.0,<2.3",
+    "pydantic>=2.0.0",
+    "PyYAML>=6.0",
+    "pybase64>=1.4.0",
+    # Torch, torchvision, torchaudio, SGLang, AITER, Triton, FlashInfer,
+    # NIXL, and the ROCm runtime are inherited from the SGLang base image.
+    "accelerate>=0.27.0",
+    "transformers==5.12.1",
+    "safetensors>=0.4.3",
+    "pillow>=10.0.0",
+    "huggingface-hub[hf_xet]>=0.36.0",
+    "datasets>=2.14.0",
+    "fastapi>=0.110.0",
+    "uvicorn>=0.23.0",
+    "cache-dit==1.3.0",
+    "addict==2.4.0",
+    "imageio==2.36.0",
+    "imageio-ffmpeg==0.5.1",
+    "logger",
+    "httpx",
+    "xxhash>=3.0.0",
+    "sox>=1.4.1",
+    "av>=16.1.0",
+    "qwen-vl-utils==0.0.11",
+    "numba==0.65.1",
+    "librosa>=0.11.0",
+    "pandas",
+    "tabulate",
+    "typer>=0.9.0",
+    "openai==2.6.1",
+    "openai-harmony==0.0.4",
+    "soundfile>=0.12.0",
+    "mistral_common[audio]>=1.11.0",
+    "silero-vad>=5.1",
+    "onnxruntime>=1.17",
+    "websockets>=12.0",
+    # Testing
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+    "jiwer",
+    "zhon>=2.0.2",
+    "scipy>=1.10.0",
+    "openai-whisper==20250625",
+    "s3prl>=0.4.18",
+    # S2-Pro
+    "tiktoken",
+    "hydra-core",
+    "omegaconf",
+    "torchcodec==0.11.1",
+    # Gradio playground
+    "gradio>=4.0.0",
+    # dots.tts model operators
+    "dots.tts==0.2.1",
+    # Ming-Omni
+    "diffusers==0.37.0",
+    "x-transformers",
+    # ZONOS2 written-to-spoken text normalization
+    "nemo_text_processing==1.2.0",
+]
+
+[project.optional-dependencies]
+audar-tts = [
+    "llama-cpp-python==0.3.34",
+    "neucodec==0.0.6",
+]
+
+[project.scripts]
+sgl-omni = "sglang_omni.cli:app"
+sgl-omni-router = "sglang_omni_router.serve:main"
+
+[project.entry-points."sglang.serve_backends"]
+omni = "sglang_omni.cli.sglang_backend:create_backend"
+
+[project.urls]
+Documentation = "https://sgl-project.github.io/sglang-omni/"
+Issues = "https://github.com/sgl-project/sglang-omni/issues"
+Repository = "https://github.com/sgl-project/sglang-omni"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+markers = [
+    "benchmark: performance benchmark tests (may require GPU and long runtime)",
+    "tts_stage(name): select an in-file TTS benchmark CI stage",
+    "gpu: requires a CUDA-compatible accelerator (auto-skipped without one)",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["sglang_omni*"]
+
+[tool.setuptools.dynamic]
+version = {attr = "sglang_omni.__version__"}
+
+[tool.setuptools.package-data]
+"sglang_omni.models.fishaudio_s2_pro" = ["fish_speech/configs/*.yaml"]
+"sglang_omni.models.higgs_tts" = ["configs/*.json"]
+"sglang_omni.models.zonos2" = ["moe_configs/*/*.json"]

--- a/pyproject_rocm.toml
+++ b/pyproject_rocm.toml
@@ -54,6 +54,7 @@ dependencies = [
     # Testing
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
+    "ruff==0.11.10",
     "jiwer",
     "zhon>=2.0.2",
     "scipy>=1.10.0",


### PR DESCRIPTION
<!-- Suggested PR title: [AMD][ROCm] Add Docker development image -->

## Motivation

SGLang-Omni does not currently provide a ROCm development image. The default project metadata also declares CUDA-specific packages, so installing it directly on a ROCm base can produce an inconsistent environment or CUDA package metadata.

This PR adds a ROCm 7.2 development image for `gfx950`, using a pinned SGLang ROCm base and platform-specific project metadata.

## Modifications

- Add `docker/rocm.Dockerfile` based on a digest-pinned SGLang ROCm image.
- Add `pyproject_rocm.toml` for application and model dependencies while inheriting Torch, SGLang, AITER, Triton, FlashInfer, NIXL, UCX, and the ROCm runtime from the base image.
- Install project dependencies in a separate cacheable layer.
- Clone SGLang-Omni during the image build and check out `OMNI_REF` in detached mode. Runtime startup does not update the source tree.
- Keep the ROCm project metadata at the source root so subsequent editable installs cannot resolve the CUDA dependency set.
- Install SGLang-Omni with `--no-deps` to preserve the GPU-coupled stack from the pinned base image.
- Add small build-time checks for the ROCm PyTorch build, required imports, and UCX ROCm support.

The public build interface is:

```bash
docker build \
  --file docker/rocm.Dockerfile \
  --build-arg OMNI_REF=<exact-commit-sha> \
  --tag sglang-omni:rocm-dev \
  .
```

## Validation

- `pyproject_rocm.toml`, `git diff --check`, pre-commit, and Docker BuildKit `--check` pass.
- A real image build succeeds with an exact `OMNI_REF`; the image source `HEAD` and permanent ROCm metadata overlay match the requested inputs.
- The installed SGLang-Omni metadata contains no CUDA-specific requirements and introduces no SGLang-Omni `pip check` errors.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed. 
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
