### PR TITLE
[Perf] Qwen3-ASR encoder CUDA graph

### DIFF
--- a/sglang_omni/models/qwen3_asr/config.py
+++ b/sglang_omni/models/qwen3_asr/config.py
@@ -56,6 +56,7 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
                 "pre_lm_cache_size_bytes": 2 * 1024**3,
                 "pre_lm_max_batch_size": 8,
                 "pre_lm_max_batch_wait_ms": 0,
+                "enable_encoder_cuda_graph": True,
             },
             gpu=0,
             terminal=True,

--- a/sglang_omni/models/qwen3_asr/encoder_cuda_graph.py
+++ b/sglang_omni/models/qwen3_asr/encoder_cuda_graph.py
@@ -11,10 +11,13 @@ buckets only need to track total token count.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
+from typing import Any
 
 import torch
 
 logger = logging.getLogger(__name__)
+
 
 def build_buckets(max_batch: int, max_tokens_per_clip: int) -> tuple[int, ...]:
     """Return token-count bucket sizes for encoder CUDA-graph capture.
@@ -30,7 +33,12 @@ def build_buckets(max_batch: int, max_tokens_per_clip: int) -> tuple[int, ...]:
 
     Buckets are power-of-two sizes from 128 up to max_batch * max_tokens_per_clip.
     """
-    ceiling = max(int(max_batch) * int(max_tokens_per_clip), 1)
+    if max_batch < 1 or max_tokens_per_clip < 1:
+        raise ValueError(
+            f"build_buckets needs positive limits, got max_batch={max_batch} "
+            f"max_tokens_per_clip={max_tokens_per_clip}"
+        )
+    ceiling = int(max_batch) * int(max_tokens_per_clip)
     buckets: list[int] = []
     step = 128
     while step < ceiling:
@@ -41,8 +49,285 @@ def build_buckets(max_batch: int, max_tokens_per_clip: int) -> tuple[int, ...]:
 
 
 def pick_bucket(total_tokens: int, buckets: tuple[int, ...]) -> int | None:
-    """Smallest bucket that fits, or None (caller falls back to eager)."""
-    for bucket in buckets:
-        if total_tokens <= bucket:
-            return bucket
+    """Pick the smallest bucket that fits, or None (caller will fall back to eager)."""
+    for bucket_size in buckets:
+        if total_tokens <= bucket_size:
+            return bucket_size
     return None
+
+
+@dataclass
+class _CapturedGraph:
+    graph: torch.cuda.CUDAGraph
+    hidden_states: torch.Tensor  # [bucket, hidden] static input
+    cu_seqlens: torch.Tensor  # [max_windows + 1] static window boundaries
+    output: torch.Tensor  # [bucket, output_dim] static result
+
+
+class Qwen3ASREncoderLayerStackGraphRunner:
+    """Captures the audio tower's transformer stack (post-conv) per bucket.
+
+    The chunk/conv front end stays eager; callers hand over the packed
+    hidden_states it produced plus the window boundaries, and get back the
+    projected embeddings. max_seqlen is the architectural cap on tokens per
+    attention window; materializing it once on the host removes the per-layer
+    sync inside VisionAttention.
+    """
+
+    def __init__(
+        self,
+        audio_tower: Any,
+        *,
+        buckets: tuple[int, ...],
+        max_batch_size: int,
+    ) -> None:
+        self._tower = audio_tower
+        param = next(audio_tower.parameters())
+        self._device = param.device
+        self._dtype = param.dtype
+        cfg = audio_tower.config
+
+        chunk_tokens = _get_feat_extract_output_lengths_int(cfg.n_window * 2)
+        self._max_seqlen = chunk_tokens * (cfg.n_window_infer // (cfg.n_window * 2))
+        self._max_windows_for = (
+            lambda bucket_size: max_batch_size + bucket_size // self._max_seqlen + 1
+        )
+        top = buckets[-1]
+        self._buckets = buckets[:-1] + (top + self._max_windows_for(top),)
+        self._graphs: dict[int, _CapturedGraph] = {} # bucket size -> recorded graph
+        self._failed: set[int] = set()
+
+    @property
+    def tokens_per_window(self) -> int:
+        return self._max_seqlen
+
+    def capture_all(self) -> None:
+        """Capture every bucket up front. A failed bucket stays eager."""
+        for bucket_size in self._buckets:
+            if bucket_size in self._graphs or bucket_size in self._failed:
+                continue
+            try:
+                self._graphs[bucket_size] = self._capture(bucket_size)
+            except Exception as exc:
+                logger.warning(
+                    "[qwen3-asr] encoder graph capture failed for bucket=%d: %s; "
+                    "bucket stays eager",
+                    bucket_size,
+                    exc,
+                )
+                self._failed.add(bucket_size)
+
+    def _layer_stack(
+        self, hidden_states: torch.Tensor, cu_seqlens: torch.Tensor
+    ) -> torch.Tensor:
+        """The computation we capture: 24 layers + ln_post + proj chain."""
+        tower = self._tower
+        h = hidden_states
+        for layer in tower.layers:
+            residual = h
+            h = layer.self_attn_layer_norm(h)
+            h = layer.self_attn(x=h, cu_seqlens=cu_seqlens, max_seqlen=self._max_seqlen)
+            h = residual + h
+            residual = h
+            h = layer.final_layer_norm(h)
+            h, _ = layer.fc1(h)
+            h = layer.activation_fn(h)
+            h, _ = layer.fc2(h)
+            h = residual + h
+        h = tower.ln_post(h)
+        h = tower.proj1(h)[0]
+        h = tower.act(h)
+        return tower.proj2(h)[0]
+
+    def _capture(self, bucket_size: int) -> _CapturedGraph:
+        """Record one graph for a bucket-sized packed input."""
+        device, dtype = self._device, self._dtype
+        d_model = self._tower.ln_post.normalized_shape[0]
+        static_hs = torch.zeros(bucket_size, d_model, device=device, dtype=dtype)
+
+        max_windows = self._max_windows_for(bucket_size)
+        base, rem = divmod(bucket_size, max_windows)
+        sizes = [base + 1] * rem + [base] * (max_windows - rem)
+        bounds = [0]
+        for size in sizes:
+            bounds.append(bounds[-1] + size)
+        static_cu = torch.tensor(bounds, dtype=torch.int32, device=device)
+
+        def run_once() -> torch.Tensor:
+            with torch.no_grad():
+                return self._layer_stack(static_hs, static_cu)
+
+        side = torch.cuda.Stream(device)
+        side.wait_stream(torch.cuda.current_stream(device))
+        with torch.cuda.stream(side):
+            for _ in range(3):
+                run_once()
+        torch.cuda.current_stream(device).wait_stream(side)
+        torch.cuda.synchronize(device)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, capture_error_mode="thread_local"):
+            static_out = run_once()
+        logger.info(
+            "[qwen3-asr] captured encoder layer-stack graph bucket=%d windows=%d out=%s",
+            bucket_size,
+            max_windows,
+            tuple(static_out.shape),
+        )
+        return _CapturedGraph(
+            graph=graph,
+            hidden_states=static_hs,
+            cu_seqlens=static_cu,
+            output=static_out,
+        )
+
+    def run(
+        self, hidden_states: torch.Tensor, window_lens: list[int]
+    ) -> torch.Tensor | None:
+        """Replay the recorded graph for a batch of hidden states."""
+        total = int(hidden_states.shape[0])
+        if not window_lens or sum(window_lens) != total:
+            return None
+        if max(window_lens) > self._max_seqlen:
+            return None
+
+        plan = self._plan(total, len(window_lens))
+        if plan is None:
+            return None
+        bucket_size, dummy_sizes = plan
+        if bucket_size in self._failed:
+            return None
+
+        entry = self._graphs.get(bucket_size)
+        if entry is None:
+            try:
+                entry = self._capture(bucket_size)
+            except Exception as exc:
+                logger.warning(
+                    "[qwen3-asr] encoder graph capture failed for bucket=%d: %s; "
+                    "bucket stays eager",
+                    bucket_size,
+                    exc,
+                )
+                self._failed.add(bucket_size)
+                return None
+            self._graphs[bucket_size] = entry
+
+        bounds = [0]
+        for size in window_lens + dummy_sizes:
+            bounds.append(bounds[-1] + size)
+        cu = torch.tensor(bounds, dtype=torch.int32)
+
+        entry.hidden_states[:total].copy_(hidden_states)
+        entry.cu_seqlens.copy_(cu, non_blocking=True)
+        entry.graph.replay()
+        out = entry.output
+        if out.dim() == 3:  # attention backends emit [1, tokens, dim]
+            out = out.squeeze(0)
+        return out[:total].clone()
+
+    def _plan(self, total: int, real_windows: int) -> tuple[int, list[int]] | None:
+        """Pick a bucket and the dummy-window sizes that absorb its padding."""
+
+        for bucket_size in self._buckets:
+            if bucket_size < total:
+                continue
+            slots = self._max_windows_for(bucket_size) - real_windows
+            pad = bucket_size - total
+            if slots < 0:
+                continue
+            if slots == 0:
+                if pad == 0:
+                    return bucket_size, []
+                continue
+            if not (slots <= pad <= slots * self._max_seqlen):
+                continue
+            base, rem = divmod(pad, slots)
+            sizes = [base + 1] * rem + [base] * (slots - rem)
+            return bucket_size, sizes
+        return None
+
+
+def _get_feat_extract_output_lengths_int(frames: int) -> int:
+    """Compute conv output length for a mel-frame count."""
+    from .audio_lengths import qwen3_asr_num_audio_tokens
+
+    return int(qwen3_asr_num_audio_tokens(frames))
+
+
+def eager_preamble(
+    tower: Any, input_features: torch.Tensor, feature_lens: torch.Tensor
+) -> torch.Tensor:
+
+    import torch.nn.functional as F
+
+    chunk_width = tower.n_window * 2
+    chunk_num = torch.ceil(feature_lens / chunk_width).long()
+    chunk_lengths = torch.tensor(
+        [chunk_width] * chunk_num.sum(),
+        dtype=torch.long,
+        device=feature_lens.device,
+    )
+    tail_chunk_index = F.pad(chunk_num, (1, 0), value=-1).cumsum(0)[1:]
+    chunk_lengths[tail_chunk_index] = feature_lens % chunk_width
+    chunk_lengths[chunk_lengths == 0] = chunk_width
+
+    chunk_list = input_features.T.split(chunk_lengths.tolist(), dim=0)
+    padded_feature = torch.nn.utils.rnn.pad_sequence(
+        chunk_list, batch_first=True
+    ).transpose(1, 2)
+
+    feature_lens_after_cnn = _get_feat_extract_output_lengths_tensor(chunk_lengths)
+    max_len_after_cnn = (
+        int(feature_lens_after_cnn.max().item())
+        if feature_lens_after_cnn.numel()
+        else 0
+    )
+    idx = torch.arange(max_len_after_cnn, device=padded_feature.device)
+    padded_mask_after_cnn = idx.unsqueeze(0) < feature_lens_after_cnn.unsqueeze(1)
+
+    padded_feature = padded_feature.unsqueeze(1)
+    if padded_feature.size(0) <= tower.conv_chunksize:
+        padded_embed = F.gelu(tower.conv2d1(padded_feature))
+        padded_embed = F.gelu(tower.conv2d2(padded_embed))
+        padded_embed = F.gelu(tower.conv2d3(padded_embed))
+    else:
+        padded_embeds = []
+        for chunk in padded_feature.split(tower.conv_chunksize, dim=0):
+            x = F.gelu(tower.conv2d1(chunk))
+            x = F.gelu(tower.conv2d2(x))
+            x = F.gelu(tower.conv2d3(x))
+            padded_embeds.append(x)
+        padded_embed = torch.cat(padded_embeds, dim=0)
+
+    b, c, f, t = padded_embed.size()
+    padded_embed = tower.conv_out(
+        padded_embed.permute(0, 3, 1, 2).contiguous().view(b, t, c * f)
+    )[0]
+    positional_embedding = (
+        tower.positional_embedding.positional_embedding[: padded_embed.shape[1], :]
+        .unsqueeze(0)
+        .to(padded_embed.dtype)
+    )
+    padded_embed = padded_embed + positional_embedding
+    return padded_embed[padded_mask_after_cnn]
+
+
+def _get_feat_extract_output_lengths_tensor(
+    input_lengths: torch.Tensor,
+) -> torch.Tensor:
+    leave = input_lengths % 100
+    feat = (leave - 1) // 2 + 1
+    return ((feat - 1) // 2 + 1 - 1) // 2 + 1 + (input_lengths // 100) * 13
+
+
+def window_lens_from_token_counts(
+    token_counts: list[int], *, tokens_per_window: int
+) -> list[int]:
+    out: list[int] = []
+    for count in token_counts:
+        full, rem = divmod(int(count), tokens_per_window)
+        out.extend([tokens_per_window] * full)
+        if rem:
+            out.append(rem)
+    return out

--- a/sglang_omni/models/qwen3_asr/encoder_cuda_graph.py
+++ b/sglang_omni/models/qwen3_asr/encoder_cuda_graph.py
@@ -48,14 +48,6 @@ def build_buckets(max_batch: int, max_tokens_per_clip: int) -> tuple[int, ...]:
     return tuple(buckets)
 
 
-def pick_bucket(total_tokens: int, buckets: tuple[int, ...]) -> int | None:
-    """Pick the smallest bucket that fits, or None (caller will fall back to eager)."""
-    for bucket_size in buckets:
-        if total_tokens <= bucket_size:
-            return bucket_size
-    return None
-
-
 @dataclass
 class _CapturedGraph:
     graph: torch.cuda.CUDAGraph

--- a/sglang_omni/models/qwen3_asr/encoder_cuda_graph.py
+++ b/sglang_omni/models/qwen3_asr/encoder_cuda_graph.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bucketed CUDA graphs for the Qwen3-ASR audio encoder layer stack.
+
+The chunk/conv front end reads each clip's length, so its shapes and control
+flow change from request to request — we leave it on the eager path. What
+we capture is the 24-layer transformer stack and the output projection that
+follow. By then the batch is packed as [total_tokens, hidden], so capture
+buckets only need to track total token count.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+def build_buckets(max_batch: int, max_tokens_per_clip: int) -> tuple[int, ...]:
+    """Return token-count bucket sizes for encoder CUDA-graph capture.
+
+    Each captured graph pads the packed [total_tokens, hidden] encoder
+    input up to one of these sizes. The caller supplies two deployment
+    limits:
+    1. max_batch: pre_lm_max_batch_size on the per-LM encoder service
+      (maximum clips in one encode batch).
+    2. max_tokens_per_clip: encoder output tokens for the longest clip the
+      pipeline admits; derived from AudioChunkingConfig.max_audio_clip_s
+      via qwen3_asr_num_audio_tokens.
+
+    Buckets are power-of-two sizes from 128 up to max_batch * max_tokens_per_clip.
+    """
+    ceiling = max(int(max_batch) * int(max_tokens_per_clip), 1)
+    buckets: list[int] = []
+    step = 128
+    while step < ceiling:
+        buckets.append(step)
+        step *= 2
+    buckets.append(ceiling)
+    return tuple(buckets)
+
+
+def pick_bucket(total_tokens: int, buckets: tuple[int, ...]) -> int | None:
+    """Smallest bucket that fits, or None (caller falls back to eager)."""
+    for bucket in buckets:
+        if total_tokens <= bucket:
+            return bucket
+    return None

--- a/sglang_omni/models/qwen3_asr/encoder_cuda_graph.py
+++ b/sglang_omni/models/qwen3_asr/encoder_cuda_graph.py
@@ -94,7 +94,7 @@ class Qwen3ASREncoderLayerStackGraphRunner:
         )
         top = buckets[-1]
         self._buckets = buckets[:-1] + (top + self._max_windows_for(top),)
-        self._graphs: dict[int, _CapturedGraph] = {} # bucket size -> recorded graph
+        self._graphs: dict[int, _CapturedGraph] = {}  # bucket size -> recorded graph
         self._failed: set[int] = set()
 
     @property

--- a/sglang_omni/models/qwen3_asr/engine_builder.py
+++ b/sglang_omni/models/qwen3_asr/engine_builder.py
@@ -59,6 +59,7 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
         pre_lm_cache_size_bytes: int = 2 * 1024**3,
         pre_lm_max_batch_size: int = 8,
         pre_lm_max_batch_wait_ms: int = 0,
+        enable_encoder_cuda_graph: bool = True,
     ) -> None:
         if pre_lm_max_batch_size < 1:
             raise ValueError(
@@ -93,6 +94,7 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
         self.pre_lm_cache_size_bytes = pre_lm_cache_size_bytes
         self.pre_lm_max_batch_size = pre_lm_max_batch_size
         self.pre_lm_max_batch_wait_ms = pre_lm_max_batch_wait_ms
+        self.enable_encoder_cuda_graph = enable_encoder_cuda_graph
         self.tokenizer: Any = None
         self.feature_extractor: Any = None
         self.context_length = 0
@@ -205,6 +207,19 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
     ) -> None:
         del generation_cuda_graph_enabled
         self._log_memory_checkpoint("post_cuda_graph_capture")
+        if self.enable_encoder_cuda_graph:
+            from sglang_omni.models.qwen3_asr.audio_lengths import (
+                qwen3_asr_num_audio_tokens,
+            )
+            from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
+
+            clip_s = Qwen3ASRPipelineConfig.audio_chunking.max_audio_clip_s
+            max_tokens_per_clip = qwen3_asr_num_audio_tokens(int(clip_s * 100))
+            model.init_encoder_graphs(
+                max_batch_size=self.pre_lm_max_batch_size,
+                max_tokens_per_clip=max_tokens_per_clip,
+            )
+            self._log_memory_checkpoint("post_encoder_graph_capture")
         init_mm_embedding_cache(self.mm_embedding_cache_size_bytes)
         if self.enable_pre_lm_encoder:
             # note (luojiaxuan): constructed after SGLang's generation CUDA

--- a/sglang_omni/models/qwen3_asr/sglang_model.py
+++ b/sglang_omni/models/qwen3_asr/sglang_model.py
@@ -25,6 +25,12 @@ from sglang.srt.models.qwen3_omni_moe import Qwen3OmniMoeAudioEncoder
 from sglang.srt.utils import add_prefix
 
 from .configuration_qwen3_asr import Qwen3ASRConfig
+from .encoder_cuda_graph import (
+    Qwen3ASREncoderLayerStackGraphRunner,
+    build_buckets,
+    eager_preamble,
+    window_lens_from_token_counts,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -144,6 +150,18 @@ class Qwen3ASRForConditionalGeneration(nn.Module):
         )
         _enable_fused_asr_qk_norm_rope(self.language_model)
         self.pattern = MultiModalityDataPaddingPatternMultimodalTokens()
+        self._encoder_graph_runner: Qwen3ASREncoderLayerStackGraphRunner | None = None
+
+    def init_encoder_graphs(
+        self, *, max_batch_size: int, max_tokens_per_clip: int
+    ) -> None:
+        runner = Qwen3ASREncoderLayerStackGraphRunner(
+            self.audio_tower,
+            buckets=build_buckets(max_batch_size, max_tokens_per_clip),
+            max_batch_size=max_batch_size,
+        )
+        runner.capture_all()
+        self._encoder_graph_runner = runner
 
     def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
         return self.pattern.pad_input_tokens(input_ids, mm_inputs)
@@ -209,6 +227,23 @@ class Qwen3ASRForConditionalGeneration(nn.Module):
             input_features = input_features.permute(0, 2, 1).reshape(
                 -1, input_features.shape[1]
             )
+
+        runner = self._encoder_graph_runner
+        if runner is not None:
+            token_counts = [
+                (item.model_specific_data or {}).get("num_audio_tokens")
+                for item in items
+            ]
+            if all(count is not None for count in token_counts):
+                window_lens = window_lens_from_token_counts(
+                    token_counts, tokens_per_window=runner.tokens_per_window
+                )
+                hidden = eager_preamble(
+                    self.audio_tower, input_features, audio_feature_lengths
+                )
+                graphed = runner.run(hidden, window_lens)
+                if graphed is not None:
+                    return graphed.unsqueeze(0)
 
         audio_outputs = self.audio_tower(
             input_features,

--- a/sglang_omni/models/qwen3_asr/stages.py
+++ b/sglang_omni/models/qwen3_asr/stages.py
@@ -33,6 +33,7 @@ def create_sglang_qwen3_asr_executor(
     pre_lm_cache_size_bytes: int = 2 * 1024**3,
     pre_lm_max_batch_size: int = 8,
     pre_lm_max_batch_wait_ms: int = 0,
+    enable_encoder_cuda_graph: bool = True,
     server_args_overrides: dict[str, Any] | None = None,
 ):
     from sglang_omni.models.qwen3_asr.engine_builder import Qwen3ASREngineBuilder
@@ -63,6 +64,7 @@ def create_sglang_qwen3_asr_executor(
         pre_lm_cache_size_bytes=pre_lm_cache_size_bytes,
         pre_lm_max_batch_size=pre_lm_max_batch_size,
         pre_lm_max_batch_wait_ms=pre_lm_max_batch_wait_ms,
+        enable_encoder_cuda_graph=enable_encoder_cuda_graph,
     ).build(
         model_path,
         device=device,

--- a/tests/README.md
+++ b/tests/README.md
@@ -143,6 +143,7 @@ tests/
     │   ├── test_core.py
     │   └── test_request_builders.py
     ├── qwen3_asr/
+    │   ├── test_encoder_cuda_graph.py
     │   ├── test_pipeline.py
     │   └── test_request_builders.py
     ├── fun_asr/
@@ -481,6 +482,9 @@ that happened to contain an older version of the test.
     text round-trips for byte-level BPE output.
   - invalid encoded-audio classification versus operational loader failures,
     including transcription-route HTTP 400/500 mapping.
+  - encoder CUDA graph runner: config-derived token buckets, dummy-window
+    padding invariants, get_audio_feature routing with eager fallback, and a
+    CUDA-only graph-vs-eager parity check of the captured layer stack.
 - `unit_test/arkasr/`: ARK-ASR-3B unit tests:
   - asynchronous pre-LM encoder submission, bounded queue backpressure,
     single-flight deduplication, CPU cache validation, and failure recovery

--- a/tests/unit_test/qwen3_asr/test_encoder_cuda_graph.py
+++ b/tests/unit_test/qwen3_asr/test_encoder_cuda_graph.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.qwen3_asr import sglang_model
+from sglang_omni.models.qwen3_asr.encoder_cuda_graph import (
+    Qwen3ASREncoderLayerStackGraphRunner,
+    build_buckets,
+    window_lens_from_token_counts,
+)
+
+
+def test_build_buckets_rejects_bad_limits():
+    with pytest.raises(ValueError):
+        build_buckets(0, 780)
+
+
+def _plan_only_runner(max_batch=8, max_tokens_per_clip=780):
+    r = object.__new__(Qwen3ASREncoderLayerStackGraphRunner)
+    r._max_seqlen = 104
+    r._max_windows_for = lambda b: max_batch + b // 104 + 1
+    raw = build_buckets(max_batch, max_tokens_per_clip)
+    r._buckets = raw[:-1] + (raw[-1] + r._max_windows_for(raw[-1]),)
+    return r
+
+
+@pytest.mark.parametrize("total,windows", [(65, 1), (260, 4), (6240, 64), (104, 1)])
+def test_plan_invariants(total, windows):
+    r = _plan_only_runner()
+    bucket_size, dummies = r._plan(total, windows)
+    assert total + sum(dummies) == bucket_size
+    assert all(1 <= d <= r._max_seqlen for d in dummies)
+    assert windows + len(dummies) == r._max_windows_for(bucket_size)
+    assert r._plan(r._buckets[-1] + 1, 1) is None
+
+
+def test_get_audio_feature_routing(monkeypatch):
+    monkeypatch.setattr(sglang_model, "eager_preamble", lambda *a: torch.zeros(65, 4))
+    tower = torch.nn.Linear(4, 4)
+    tower.dtype = torch.float32
+    tower.forward = lambda feats, feature_lens: SimpleNamespace(
+        last_hidden_state=torch.full((1, 65, 8), 7.0)
+    )
+    model = object.__new__(sglang_model.Qwen3ASRForConditionalGeneration)
+    torch.nn.Module.__init__(model)
+    model.audio_tower = tower
+    item = SimpleNamespace(
+        feature=torch.zeros(1, 128, 500),
+        feature_attention_mask=None,
+        model_specific_data={"num_audio_tokens": 65},
+    )
+    get = sglang_model.Qwen3ASRForConditionalGeneration.get_audio_feature
+
+    model._encoder_graph_runner = SimpleNamespace(
+        tokens_per_window=104, run=lambda h, w: torch.ones(65, 8)
+    )
+    assert torch.equal(get(model, [item]), torch.ones(1, 65, 8))
+
+    model._encoder_graph_runner = SimpleNamespace(
+        tokens_per_window=104, run=lambda h, w: None
+    )
+    assert torch.equal(get(model, [item]), torch.full((1, 65, 8), 7.0))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_graph_matches_eager_tower():
+    from sglang.srt.configs.qwen3_omni import Qwen3OmniMoeAudioEncoderConfig
+    from sglang.srt.distributed import (
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+    from sglang.srt.distributed.parallel_state import model_parallel_is_initialized
+    from sglang.srt.runtime_context import get_context
+    from sglang.srt.server_args import ServerArgs
+
+    from sglang_omni.models.qwen3_asr.audio_lengths import qwen3_asr_num_audio_tokens
+    from sglang_omni.models.qwen3_asr.encoder_cuda_graph import eager_preamble
+
+    get_context().set_server_args(
+        ServerArgs(model_path="Qwen/Qwen3-ASR-1.7B", mm_attention_backend="triton_attn")
+    )
+    if not model_parallel_is_initialized():
+        init_distributed_environment(
+            backend="nccl",
+            world_size=1,
+            rank=0,
+            local_rank=0,
+            distributed_init_method="tcp://127.0.0.1:29601",
+        )
+        initialize_model_parallel(tensor_model_parallel_size=1)
+    from sglang.srt.models.qwen3_omni_moe import Qwen3OmniMoeAudioEncoder
+
+    cfg = Qwen3OmniMoeAudioEncoderConfig(
+        d_model=64,
+        encoder_layers=2,
+        encoder_attention_heads=4,
+        encoder_ffn_dim=128,
+        output_dim=32,
+        num_mel_bins=128,
+        n_window=50,
+        n_window_infer=800,
+    )
+    torch.manual_seed(0)
+    tower = Qwen3OmniMoeAudioEncoder(cfg).cuda().eval().to(torch.bfloat16)
+    with torch.no_grad():
+        for name, prm in tower.named_parameters():
+            if prm.dim() >= 2:
+                prm.normal_(0.0, 0.02)
+            elif "weight" in name:
+                prm.fill_(1.0)
+            else:
+                prm.zero_()
+
+    runner = Qwen3ASREncoderLayerStackGraphRunner(
+        tower, buckets=build_buckets(4, 104), max_batch_size=4
+    )
+    runner.capture_all()
+    assert runner._graphs and not runner._failed
+
+    # [500] and [450] share a bucket, so the second replay also checks that
+    # stale rows from the first never leak into the output.
+    for frame_lens in ([500], [450], [300, 500, 120], [800, 800, 800, 800]):
+        feats = (torch.randn(128, sum(frame_lens), device="cuda") * 0.05).to(
+            torch.bfloat16
+        )
+        lens = torch.tensor(frame_lens, device="cuda", dtype=torch.long)
+        with torch.no_grad():
+            ref = tower(feats, feature_lens=lens).last_hidden_state.squeeze(0)
+        wl = window_lens_from_token_counts(
+            [qwen3_asr_num_audio_tokens(f) for f in frame_lens],
+            tokens_per_window=runner.tokens_per_window,
+        )
+        out = runner.run(eager_preamble(tower, feats, lens), wl)
+        diff = (out.float() - ref.float()).abs().max().item()
+        assert diff < 3e-2, f"{frame_lens}: max|diff|={diff}"
+
+    assert (
+        runner.run(
+            torch.zeros(9999, 64, device="cuda", dtype=torch.bfloat16),
+            [104] * 96 + [15],
+        )
+        is None
+    )

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -353,7 +353,9 @@ def _patch_engine_dependencies(
         recorded.infra_kwargs.append(dict(kwargs))
         model_worker = SimpleNamespace(
             gpu_id=gpu_id,
-            model_runner=SimpleNamespace(model=object()),
+            model_runner=SimpleNamespace(
+                model=SimpleNamespace(init_encoder_graphs=lambda **kwargs: None)
+            ),
         )
         return want_cuda_graph, (
             model_worker,
@@ -414,7 +416,7 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch, caplog) -> None:
     ]
     assert "cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64]" in caplog.text
     assert "mm_attention_backend" not in build_kwargs
-    assert recorded.memory_queries == [0, 0, 0]
+    assert recorded.memory_queries == [0, 0, 0, 0]
     assert recorded.adapter_kwargs["context_length"] == 2048
     assert scheduler.enable_async_decode is False
     assert scheduler.async_decode_min_batch_size == 4

--- a/tests/unit_test/qwen3_asr/test_sglang_model.py
+++ b/tests/unit_test/qwen3_asr/test_sglang_model.py
@@ -138,7 +138,7 @@ def test_fused_asr_qk_norm_rope_falls_back_before_projection() -> None:
 
 def test_get_audio_feature_preserves_masks_in_mixed_batch() -> None:
     tower = _RecordingAudioTower()
-    model = SimpleNamespace(audio_tower=tower)
+    model = SimpleNamespace(_encoder_graph_runner=None, audio_tower=tower)
     items = [
         SimpleNamespace(
             feature=torch.tensor([[[1.0, 2.0, 90.0, 91.0]]]),
@@ -158,7 +158,9 @@ def test_get_audio_feature_preserves_masks_in_mixed_batch() -> None:
 
 
 def test_get_audio_feature_rejects_mismatched_mask_shape() -> None:
-    model = SimpleNamespace(audio_tower=_RecordingAudioTower())
+    model = SimpleNamespace(
+        _encoder_graph_runner=None, audio_tower=_RecordingAudioTower()
+    )
     items = [
         SimpleNamespace(
             feature=torch.ones((1, 2, 4)),
@@ -173,7 +175,7 @@ def test_get_audio_feature_rejects_mismatched_mask_shape() -> None:
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
 def test_get_audio_feature_normalizes_cpu_masks_for_cuda_features() -> None:
     tower = _RecordingAudioTower().cuda()
-    model = SimpleNamespace(audio_tower=tower)
+    model = SimpleNamespace(_encoder_graph_runner=None, audio_tower=tower)
     items = [
         SimpleNamespace(
             feature=torch.tensor([[[1.0, 2.0, 90.0, 91.0]]], device="cuda"),


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Add encoder cuda graph (transformer only) for Qwen3 ASR
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

Added `sglang_omni/models/qwen3_asr/encoder_cuda_graph.py`, wired it up, and add related unit tests.

## Related Issues

#1396 

## Accuracy Test

see benchmark results, the WER keeps normal

## Benchmark & Profiling

Run benchmark under Qwen/Qwen3-ASR-1.7B on H100, use pipecat-ai/stt-benchmark-data data set with c=1,8,16,32,64 × 3 repeats + 1 warmup:

| Concurrency | Config | Success | Throughput (req/s) | Mean latency (ms) | P50 (ms) | P95 (ms) | P99 (ms) | Mean RTF | P95 RTF | Corpus WER |
|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | main 12a004f0 | 2997/3000 | 13.291 | 75.07 | 86.94 | 101.33 | 110.57 | 0.0088 | 0.0146 | 0.0187 |
|  | bucketed branch | 2997/3000 | 14.362 | 69.44 | 81.48 | 94.66 | 103.97 | 0.0080 | 0.0128 | 0.0187 |
|  | Δ (branch / base) |  | 1.08× | 1.08× | 1.07× | 1.07× | 1.06× | 1.10× | 1.14× | +0.000 pt |
| 8 | main 12a004f0 | 2997/3000 | 56.023 | 141.95 | 153.59 | 189.24 | 201.88 | 0.0176 | 0.0337 | 0.0188 |
|  | bucketed branch | 2997/3000 | 62.170 | 127.82 | 134.70 | 177.83 | 189.54 | 0.0156 | 0.0298 | 0.0187 |
|  | Δ (branch / base) |  | 1.11× | 1.11× | 1.14× | 1.06× | 1.07× | 1.13× | 1.13× | −0.001 pt |
| 16 | main 12a004f0 | 2997/3000 | 96.135 | 164.75 | 174.61 | 223.15 | 242.91 | 0.0206 | 0.0392 | 0.0187 |
|  | bucketed branch | 2997/3000 | 106.778 | 148.33 | 157.37 | 206.24 | 226.31 | 0.0180 | 0.0335 | 0.0188 |
|  | Δ (branch / base) |  | 1.11× | 1.11× | 1.11× | 1.08× | 1.07× | 1.14× | 1.17× | +0.004 pt |
| 32 | main 12a004f0 | 2997/3000 | 148.768 | 211.69 | 222.07 | 287.09 | 335.90 | 0.0265 | 0.0514 | 0.0187 |
|  | bucketed branch | 2997/3000 | 170.860 | 184.47 | 203.84 | 253.77 | 300.23 | 0.0222 | 0.0406 | 0.0187 |
|  | Δ (branch / base) |  | 1.15× | 1.15× | 1.09× | 1.13× | 1.12× | 1.19× | 1.27× | +0.007 pt |
| 64 | main 12a004f0 | 2997/3000 | 146.914 | 422.49 | 428.12 | 526.99 | 693.92 | 0.0561 | 0.1169 | 0.0187 |
|  | bucketed branch | 2997/3000 | 226.602 | 274.26 | 289.78 | 457.10 | 648.39 | 0.0327 | 0.0603 | 0.0187 |
|  | Δ (branch / base) |  | 1.54× | 1.54× | 1.48× | 1.15× | 1.07× | 1.71× | 1.94× | +0.000 pt |
## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
