### PR TITLE
[Whisper ASR] Separate encoder cache setup from decoder execution

### DIFF
--- a/sglang_omni/models/whisper_asr/sglang_model.py
+++ b/sglang_omni/models/whisper_asr/sglang_model.py
@@ -17,7 +17,9 @@ import torch.nn.functional as F
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.forward_context import get_attn_backend
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from torch import nn
 from transformers import WhisperConfig
@@ -182,6 +184,7 @@ class WhisperSGLangSelfAttention(nn.Module):
         key = key.view(-1, self.num_heads, self.head_dim)
         value = value.view(-1, self.num_heads, self.head_dim)
         attn_output = self.attn(query, key, value, forward_batch)
+        attn_output = attn_output.reshape(hidden_states.shape[:-1] + (self.embed_dim,))
         return self.out_proj(attn_output)
 
 
@@ -213,20 +216,29 @@ class WhisperSGLangCrossAttention(nn.Module):
             is_cross_attention=True,
         )
 
+    def cache_encoder_states(
+        self,
+        cross_attention_states: torch.Tensor,
+        cache_loc: torch.Tensor,
+    ) -> None:
+        key, value = self.kv_proj(cross_attention_states).chunk(2, dim=-1)
+        key = key.view(-1, self.num_heads, self.head_dim)
+        value = value.view(-1, self.num_heads, self.head_dim)
+        get_attn_backend().token_to_kv_pool.set_kv_buffer(
+            self.attn,
+            KVWriteLoc(cache_loc),
+            key,
+            value,
+        )
+
     def forward(
         self,
         hidden_states: torch.Tensor,
-        cross_attention_states: torch.Tensor | None,
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         query = self.q_proj(hidden_states).view(-1, self.num_heads, self.head_dim)
-        if cross_attention_states is None:
-            key = value = None
-        else:
-            key, value = self.kv_proj(cross_attention_states).chunk(2, dim=-1)
-            key = key.view(-1, self.num_heads, self.head_dim)
-            value = value.view(-1, self.num_heads, self.head_dim)
-        attn_output = self.attn(query, key, value, forward_batch)
+        attn_output = self.attn(query, None, None, forward_batch)
+        attn_output = attn_output.reshape(hidden_states.shape[:-1] + (self.embed_dim,))
         return self.out_proj(attn_output)
 
 
@@ -259,24 +271,17 @@ class WhisperDecoderLayer(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        cross_attention_states: torch.Tensor | None,
         forward_batch: ForwardBatch,
-        skip_cross_attention: bool,
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.self_attn_layer_norm(hidden_states)
         hidden_states = self.self_attn(hidden_states, forward_batch)
         hidden_states = residual + hidden_states
 
-        if not skip_cross_attention:
-            residual = hidden_states
-            hidden_states = self.encoder_attn_layer_norm(hidden_states)
-            hidden_states = self.encoder_attn(
-                hidden_states,
-                cross_attention_states,
-                forward_batch,
-            )
-            hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = self.encoder_attn_layer_norm(hidden_states)
+        hidden_states = self.encoder_attn(hidden_states, forward_batch)
+        hidden_states = residual + hidden_states
 
         residual = hidden_states
         hidden_states = self.final_layer_norm(hidden_states)
@@ -308,22 +313,25 @@ class WhisperDecoder(nn.Module):
         self,
         input_ids: torch.Tensor,
         positions: torch.Tensor,
-        cross_attention_states: torch.Tensor | None,
         forward_batch: ForwardBatch,
-        skip_cross_attention: bool,
+        input_embeds: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        hidden_states = self.embed_tokens(input_ids)
-        hidden_states = hidden_states + self.embed_positions(positions).to(
-            hidden_states.device
+        hidden_states = (
+            self.embed_input_ids(input_ids, positions)
+            if input_embeds is None
+            else input_embeds
         )
         for layer in self.layers:
-            hidden_states = layer(
-                hidden_states,
-                cross_attention_states,
-                forward_batch,
-                skip_cross_attention,
-            )
+            hidden_states = layer(hidden_states, forward_batch)
         return self.layer_norm(hidden_states)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> torch.Tensor:
+        hidden_states = self.embed_tokens(input_ids)
+        return hidden_states + self.embed_positions(positions).to(hidden_states.device)
 
 
 class WhisperModel(nn.Module):
@@ -335,6 +343,32 @@ class WhisperModel(nn.Module):
         super().__init__()
         self.encoder = WhisperEncoder(config)
         self.decoder = WhisperDecoder(config, quant_config=quant_config)
+
+    @property
+    def layers(self) -> nn.ModuleList:
+        return self.decoder.layers
+
+    def cache_encoder_states(
+        self,
+        encoder_states: torch.Tensor,
+        cache_loc: torch.Tensor,
+    ) -> None:
+        for layer in self.decoder.layers:
+            layer.encoder_attn.cache_encoder_states(encoder_states, cache_loc)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return self.decoder(
+            input_ids,
+            positions,
+            forward_batch,
+            input_embeds=input_embeds,
+        )
 
 
 class WhisperForConditionalGeneration(nn.Module):
@@ -482,9 +516,6 @@ class WhisperForConditionalGeneration(nn.Module):
         **kwargs: Any,
     ) -> Any:
         del kwargs
-        from sglang.srt.model_executor.runner_utils.capture_mode import (
-            get_is_capture_mode,
-        )
 
         cross_attention_states = self._batch_precomputed_encoder_states(forward_batch)
         if cross_attention_states is None:
@@ -496,17 +527,18 @@ class WhisperForConditionalGeneration(nn.Module):
                     encoder_lens,
                 )
 
-        if get_is_capture_mode():
-            skip_cross_attention = False
-        else:
-            skip_cross_attention = forward_batch.encoder_lens.max() == 0
+        if cross_attention_states is not None:
+            self.model.cache_encoder_states(
+                cross_attention_states,
+                forward_batch.encoder_out_cache_loc,
+            )
 
-        hidden_states = self.model.decoder(
-            input_ids=input_ids,
-            positions=positions,
-            cross_attention_states=cross_attention_states,
-            forward_batch=forward_batch,
-            skip_cross_attention=skip_cross_attention,
+        input_embeds = self.model.decoder.embed_input_ids(input_ids, positions)
+        hidden_states = self.model(
+            input_ids,
+            positions,
+            forward_batch,
+            input_embeds=input_embeds,
         )
         return self.logits_processor(
             input_ids, hidden_states, self.lm_head, forward_batch

--- a/tests/unit_test/whisper_asr/test_decoder_cache.py
+++ b/tests/unit_test/whisper_asr/test_decoder_cache.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+import torch
+from transformers import WhisperConfig
+
+from sglang_omni.models.whisper_asr import sglang_model
+from sglang_omni.models.whisper_asr.sglang_model import (
+    WhisperForConditionalGeneration,
+    WhisperModel,
+    WhisperSGLangCrossAttention,
+    WhisperSGLangSelfAttention,
+)
+
+
+def _tiny_whisper_config() -> WhisperConfig:
+    return WhisperConfig(
+        d_model=8,
+        encoder_layers=1,
+        decoder_layers=1,
+        encoder_attention_heads=2,
+        decoder_attention_heads=2,
+        encoder_ffn_dim=16,
+        decoder_ffn_dim=16,
+        vocab_size=32,
+        max_source_positions=8,
+        max_target_positions=8,
+        num_mel_bins=4,
+    )
+
+
+def test_whisper_model_exposes_decoder_body() -> None:
+    model = WhisperModel(_tiny_whisper_config())
+
+    assert model.layers is model.decoder.layers
+    assert "input_embeds" in inspect.signature(model.forward).parameters
+
+
+def test_whisper_cross_attention_caches_fused_encoder_kv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attention = WhisperSGLangCrossAttention(_tiny_whisper_config(), layer_id=1)
+    encoder_states = torch.randn(3, attention.embed_dim)
+    cache_loc = torch.arange(3, dtype=torch.int64)
+    writes: list[tuple[object, object, torch.Tensor, torch.Tensor]] = []
+    token_to_kv_pool = SimpleNamespace(
+        set_kv_buffer=lambda layer, loc, key, value: writes.append(
+            (layer, loc, key, value)
+        )
+    )
+    monkeypatch.setattr(
+        sglang_model,
+        "get_attn_backend",
+        lambda: SimpleNamespace(token_to_kv_pool=token_to_kv_pool),
+    )
+
+    attention.cache_encoder_states(encoder_states, cache_loc)
+
+    layer, write_loc, key, value = writes[0]
+    expected_key, expected_value = attention.kv_proj(encoder_states).chunk(2, dim=-1)
+    assert layer is attention.attn
+    assert write_loc.loc is cache_loc
+    torch.testing.assert_close(
+        key, expected_key.view(-1, attention.num_heads, attention.head_dim)
+    )
+    torch.testing.assert_close(
+        value, expected_value.view(-1, attention.num_heads, attention.head_dim)
+    )
+
+
+@pytest.mark.parametrize(
+    "attention_cls",
+    [WhisperSGLangSelfAttention, WhisperSGLangCrossAttention],
+)
+def test_whisper_attention_flattens_head_shaped_backend_output(
+    attention_cls: type[torch.nn.Module],
+) -> None:
+    class _HeadShapedAttention(torch.nn.Module):
+        def forward(self, query, key, value, forward_batch):
+            del key, value, forward_batch
+            return query
+
+    attention = attention_cls(_tiny_whisper_config(), layer_id=0)
+    attention.attn = _HeadShapedAttention()
+    attention.out_proj = torch.nn.Identity()
+    hidden_states = torch.randn(3, attention.embed_dim)
+
+    output = attention(hidden_states, SimpleNamespace())
+
+    assert output.shape == hidden_states.shape
+
+
+@pytest.mark.parametrize("use_precomputed_states", [True, False])
+def test_whisper_forward_caches_encoder_kv_before_decoder(
+    monkeypatch: pytest.MonkeyPatch,
+    use_precomputed_states: bool,
+) -> None:
+    class _LogitsProcessor(torch.nn.Module):
+        def forward(self, *args):
+            calls.append("logits")
+            return args[1]
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        sglang_model,
+        "LogitsProcessor",
+        lambda _config: _LogitsProcessor(),
+    )
+    model = WhisperForConditionalGeneration(_tiny_whisper_config())
+    input_ids = torch.tensor([1, 2])
+    positions = torch.tensor([0, 1])
+    encoder_states = torch.randn(3, model.config.d_model)
+    forward_batch = SimpleNamespace(
+        encoder_out_cache_loc=torch.arange(3, dtype=torch.int64)
+    )
+
+    monkeypatch.setattr(
+        model,
+        "_batch_precomputed_encoder_states",
+        lambda batch: encoder_states if use_precomputed_states else None,
+    )
+    monkeypatch.setattr(
+        model,
+        "_batch_audio_inputs",
+        lambda batch: (torch.randn(1, 4, 4), [3]),
+    )
+    monkeypatch.setattr(
+        model,
+        "_run_encoder",
+        lambda features: encoder_states.unsqueeze(0),
+    )
+    monkeypatch.setattr(
+        model.model,
+        "cache_encoder_states",
+        lambda states, loc: calls.append("cache"),
+    )
+    monkeypatch.setattr(
+        model.model.decoder,
+        "embed_input_ids",
+        lambda ids, pos: torch.randn(ids.shape[0], model.config.d_model),
+    )
+    monkeypatch.setattr(
+        model.model,
+        "forward",
+        lambda *args, **kwargs: calls.append("decoder")
+        or torch.randn(input_ids.shape[0], model.config.d_model),
+    )
+
+    model(input_ids, positions, forward_batch)
+
+    assert calls == ["cache", "decoder", "logits"]


### PR DESCRIPTION
## Summary
- precompute Whisper cross-attention K/V once after encoder execution and write it into SGLang's encoder KV cache
- make the decoder body consume cached cross-attention state while keeping token embedding outside the body
- preserve the current fused projection and default pre-LM encoder paths from `main`

This isolates the encoder/decoder execution-path change from #1530 so it can be benchmarked independently before evaluating breakable prefill CUDA Graphs.

## Test plan
- `pytest -q tests/unit_test/whisper_asr -m 'not benchmark'` (50 passed)
- `python3 -m py_compile sglang_omni/models/whisper_asr/sglang_model.py tests/unit_test/whisper_asr/test_decoder_cache.py`

## Benchmark plan
Benchmarking is intentionally pending. Use `openai/whisper-large-v3` to compare current `main` against this adopter path with prefill BCG disabled; then benchmark the stacked CUDA Graph PR separately.

## Related
- #1530
- #1396
