### PR TITLE
[Refactor][MOSS-TTS] Consolidate the MOSS-Audio-Tokenizer attention backend

### DIFF
--- a/sglang_omni/models/moss_tts/attention.py
+++ b/sglang_omni/models/moss_tts/attention.py
@@ -12,6 +12,8 @@ from itertools import accumulate
 import torch
 import torch.nn.functional as F
 from sglang.jit_kernel.flash_attention import flash_attn_varlen_func
+
+# note (Zhang Yiyang): SGLang 0.5.16 exposes _is_fa3_supported from sglang.jit_kernel.flash_attention_v3; when upgrading SGLang, update this import if upstream moves the predicate to sglang.kernels.ops.attention.
 from sglang.jit_kernel.flash_attention_v3 import _is_fa3_supported
 from torch import nn
 

--- a/sglang_omni/models/moss_tts/attention.py
+++ b/sglang_omni/models/moss_tts/attention.py
@@ -1,0 +1,882 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Attention backends and packed execution for MOSS-Audio-Tokenizer."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from functools import cache
+from itertools import accumulate
+
+import torch
+import torch.nn.functional as F
+from sglang.jit_kernel.flash_attention import flash_attn_varlen_func
+from sglang.jit_kernel.flash_attention_v3 import _is_fa3_supported
+from torch import nn
+
+from sglang_omni.models.moss_tts.vocoder_kernels import (
+    apply_exact_interleaved_rope_inplace,
+)
+
+# note (Zhang Yiyang): Bound SDPA fallback memory with query chunks.
+_SDPA_QUERY_CHUNK_SIZE = 512
+# note (Zhang Yiyang): Keep 128-token local-causal tiles for A800 audio stability.
+_LOCAL_CAUSAL_FLASH_QUERY_CHUNK_SIZE = 128
+# note (Zhang Yiyang): Use the direct local-window kernel on Hopper and newer SMs.
+_PACKED_FLASH_DIRECT_MIN_SM = 90
+_HF_FLASH_ATTENTION_CONFIG = "flash_attention_2"
+PACKED_FLASH_ATTENTION_BACKEND = "packed_flash_attention"
+_SDPA_ATTENTION_BACKEND = "sdpa"
+AUTO_ATTENTION_BACKEND = "auto"
+_SUPPORTED_ATTENTION_BACKENDS: frozenset[str] = frozenset(
+    {
+        AUTO_ATTENTION_BACKEND,
+        PACKED_FLASH_ATTENTION_BACKEND,
+        _SDPA_ATTENTION_BACKEND,
+    }
+)
+
+
+def validate_attention_backend(attention_backend: str) -> str:
+    if attention_backend not in _SUPPORTED_ATTENTION_BACKENDS:
+        raise ValueError(
+            "attention_backend must be 'auto', 'packed_flash_attention', "
+            "or 'sdpa'; "
+            f"got {attention_backend!r}"
+        )
+    return attention_backend
+
+
+def _preferred_attention_backend(
+    attention_backend: str,
+    attention_implementation: str | None,
+) -> str:
+    if attention_backend != AUTO_ATTENTION_BACKEND:
+        return attention_backend
+    if attention_implementation == _SDPA_ATTENTION_BACKEND:
+        return _SDPA_ATTENTION_BACKEND
+    return PACKED_FLASH_ATTENTION_BACKEND
+
+
+def _packed_flash_device_unavailable_reason(device: torch.device) -> str | None:
+    device = torch.device(device)
+    if device.type != "cuda":
+        return f"device type {device.type!r} is not CUDA"
+    if not torch.cuda.is_available():
+        return "the CUDA runtime is unavailable"
+    if not _is_fa3_supported():
+        return "SGLang packed FlashAttention (FA3) is unavailable"
+    return None
+
+
+@cache
+def _packed_flash_requires_query_chunks(device: torch.device) -> bool:
+    device = torch.device(device)
+    if device.type != "cuda" or not torch.cuda.is_available():
+        return True
+    major, minor = torch.cuda.get_device_capability(device)
+    sm = major * 10 + minor
+    return sm < _PACKED_FLASH_DIRECT_MIN_SM
+
+
+@dataclass(frozen=True)
+class AttentionBackendResolution:
+    backend: str
+    fallback_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class _LocalCausalFlashPlan:
+    cu_seqlens_q: torch.Tensor
+    cu_seqlens_k: torch.Tensor
+    kv_indices: torch.Tensor | None
+    max_seqlen_q: int
+    max_seqlen_k: int
+    context: int
+
+
+def merge_attention_backend_resolutions(
+    resolutions: Sequence[AttentionBackendResolution],
+) -> AttentionBackendResolution:
+    if not resolutions:
+        return AttentionBackendResolution(_SDPA_ATTENTION_BACKEND)
+    backends = {resolution.backend for resolution in resolutions}
+    if len(backends) != 1:
+        raise RuntimeError(
+            "MOSS-Audio-Tokenizer Transformer layers resolved different "
+            f"attention backends: {sorted(backends)}"
+        )
+    fallback_reasons = list(
+        dict.fromkeys(
+            resolution.fallback_reason
+            for resolution in resolutions
+            if resolution.fallback_reason is not None
+        )
+    )
+    return AttentionBackendResolution(
+        resolutions[0].backend,
+        fallback_reason="; ".join(fallback_reasons) or None,
+    )
+
+
+def _build_local_causal_flash_plan(
+    cu_seqlens: torch.Tensor,
+    *,
+    context: int,
+    query_chunk_size: int = _LOCAL_CAUSAL_FLASH_QUERY_CHUNK_SIZE,
+    sequence_lengths: Sequence[int] | None = None,
+) -> _LocalCausalFlashPlan:
+    if context <= 0:
+        raise ValueError(f"local causal context must be positive, got {context}")
+    if query_chunk_size <= 0:
+        raise ValueError(f"query_chunk_size must be positive, got {query_chunk_size}")
+
+    if sequence_lengths is None:
+        sequence_lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).to("cpu").tolist()
+    else:
+        sequence_lengths = [int(length) for length in sequence_lengths]
+        if len(sequence_lengths) != int(cu_seqlens.shape[0]) - 1:
+            raise ValueError(
+                "sequence_lengths must match the number of packed sequences"
+            )
+    q_lengths: list[int] = []
+    k_lengths: list[int] = []
+    key_starts: list[int] = []
+    packed_offset = 0
+    kv_cursor = 0
+    needs_kv_gather = False
+    for sequence_length in sequence_lengths:
+        for query_start in range(0, sequence_length, query_chunk_size):
+            query_end = min(query_start + query_chunk_size, sequence_length)
+            key_start = max(0, query_start - context + 1)
+            key_end = query_end
+            q_lengths.append(query_end - query_start)
+            k_lengths.append(key_end - key_start)
+            absolute_key_start = packed_offset + key_start
+            absolute_key_end = packed_offset + key_end
+            key_starts.append(absolute_key_start)
+            needs_kv_gather |= absolute_key_start != kv_cursor
+            kv_cursor = absolute_key_end
+        packed_offset += sequence_length
+
+    if not q_lengths:
+        raise ValueError("local causal flash plan requires at least one query token")
+
+    q_lengths_tensor = torch.tensor(
+        q_lengths,
+        device=cu_seqlens.device,
+        dtype=torch.int32,
+    )
+    k_lengths_tensor = torch.tensor(
+        k_lengths,
+        device=cu_seqlens.device,
+        dtype=torch.int32,
+    )
+    cu_seqlens_q = torch.zeros(
+        len(q_lengths) + 1,
+        device=cu_seqlens.device,
+        dtype=torch.int32,
+    )
+    cu_seqlens_k = torch.zeros_like(cu_seqlens_q)
+    cu_seqlens_q[1:] = torch.cumsum(q_lengths_tensor, dim=0)
+    cu_seqlens_k[1:] = torch.cumsum(k_lengths_tensor, dim=0)
+    kv_indices = None
+    if needs_kv_gather or kv_cursor != packed_offset:
+        packed_kv_length = sum(k_lengths)
+        k_lengths_long = k_lengths_tensor.to(torch.long)
+        key_starts_tensor = torch.tensor(
+            key_starts,
+            device=cu_seqlens.device,
+            dtype=torch.long,
+        )
+        chunk_offsets = key_starts_tensor - cu_seqlens_k[:-1].to(torch.long)
+        repeated_offsets = torch.repeat_interleave(
+            chunk_offsets,
+            k_lengths_long,
+            output_size=packed_kv_length,
+        )
+        kv_indices = (
+            torch.arange(
+                packed_kv_length,
+                device=cu_seqlens.device,
+                dtype=torch.long,
+            )
+            + repeated_offsets
+        )
+    return _LocalCausalFlashPlan(
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        kv_indices=kv_indices,
+        max_seqlen_q=max(q_lengths),
+        max_seqlen_k=max(k_lengths),
+        context=context,
+    )
+
+
+def _gather_local_flash_kv(
+    x: torch.Tensor,
+    kv_indices: torch.Tensor | None,
+) -> torch.Tensor:
+    return x if kv_indices is None else x.index_select(0, kv_indices)
+
+
+def _single_module(module: nn.Module, singular: str, plural: str) -> nn.Module:
+    child = getattr(module, singular, None)
+    if child is not None:
+        return child
+    modules = getattr(module, plural, None)
+    if modules is None or len(modules) != 1:
+        raise ValueError(
+            f"MOSS-Audio-Tokenizer expects one {singular!r} module; "
+            f"got {plural}={modules!r}"
+        )
+    return modules[0]
+
+
+class PositionIdsCache:
+    def __init__(self) -> None:
+        self._items: dict[tuple[str, int | None], torch.Tensor] = {}
+
+    def get(
+        self,
+        *,
+        device: torch.device,
+        max_seqlen: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if max_seqlen <= 0:
+            raise ValueError(f"max_seqlen must be positive, got {max_seqlen}")
+        key = (device.type, device.index)
+        position_ids = self._items.get(key)
+        if position_ids is None or position_ids.shape[0] < max_seqlen:
+            position_ids = torch.arange(max_seqlen, device=device, dtype=torch.long)
+            self._items[key] = position_ids
+        cu_seqlens = torch.tensor([0, max_seqlen], dtype=torch.int32, device=device)
+        return cu_seqlens, position_ids[:max_seqlen]
+
+
+def pack_padded_sequence(
+    x: torch.Tensor,
+    input_lengths: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    batch_size, max_seqlen, _ = x.shape
+    positions = torch.arange(max_seqlen, device=x.device, dtype=torch.long)
+    valid_mask = positions.view(1, max_seqlen) < input_lengths.view(batch_size, 1)
+    packed_x = x[valid_mask]
+    cu_seqlens = torch.zeros(batch_size + 1, dtype=torch.int32, device=x.device)
+    cu_seqlens[1:] = torch.cumsum(input_lengths.to(torch.int32), dim=0)
+    position_ids = positions.view(1, max_seqlen).expand(batch_size, -1)[valid_mask]
+    return packed_x, valid_mask, cu_seqlens, position_ids
+
+
+def pack_padded_sequence_from_host_lengths(
+    x: torch.Tensor,
+    input_lengths: torch.Tensor,
+    input_lengths_cpu: Sequence[int],
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pack with matching device/host lengths without synchronizing the device."""
+
+    batch_size, max_seqlen, hidden_size = x.shape
+    lengths = list(map(int, input_lengths_cpu))
+    if len(lengths) != batch_size:
+        raise ValueError("input_lengths_cpu must match the decoder batch size")
+    if input_lengths.ndim != 1 or int(input_lengths.numel()) != batch_size:
+        raise ValueError("input_lengths must match the decoder batch size")
+    if input_lengths.device != x.device:
+        raise ValueError("input_lengths and decoder inputs must share one device")
+    if any(length < 0 or length > max_seqlen for length in lengths):
+        raise ValueError("input_lengths_cpu must be within the padded sequence")
+
+    total_tokens = sum(lengths)
+    cu_seqlens = torch.tensor(
+        [0, *accumulate(lengths)],
+        device=x.device,
+        dtype=torch.int32,
+    )
+    batch_ids = torch.repeat_interleave(
+        torch.arange(batch_size, device=x.device, dtype=torch.long),
+        input_lengths,
+        output_size=total_tokens,
+    )
+    position_ids = torch.arange(total_tokens, device=x.device, dtype=torch.long)
+    position_ids = position_ids - cu_seqlens[:-1].to(torch.long).index_select(
+        0, batch_ids
+    )
+    flat_indices = batch_ids * max_seqlen + position_ids
+    packed_x = x.reshape(batch_size * max_seqlen, hidden_size).index_select(
+        0, flat_indices
+    )
+    return packed_x, flat_indices, cu_seqlens, position_ids
+
+
+def pack_unpadded_sequence(
+    x: torch.Tensor,
+    position_ids_cache: "PositionIdsCache",
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    assert x.shape[0] == 1, f"expected a single unpadded sequence, got {x.shape[0]}"
+    _, max_seqlen, _ = x.shape
+    packed_x = x.reshape(max_seqlen, x.shape[-1])
+    cu_seqlens, position_ids = position_ids_cache.get(
+        device=x.device,
+        max_seqlen=max_seqlen,
+    )
+    return packed_x, cu_seqlens, position_ids
+
+
+def unpack_packed_sequence(
+    packed_x: torch.Tensor,
+    valid_mask: torch.Tensor,
+    batch_size: int,
+    max_seqlen: int,
+) -> torch.Tensor:
+    x = packed_x.new_zeros(batch_size, max_seqlen, packed_x.shape[-1])
+    x[valid_mask] = packed_x
+    return x
+
+
+def unpack_packed_sequence_from_indices(
+    packed_x: torch.Tensor,
+    flat_indices: torch.Tensor,
+    batch_size: int,
+    max_seqlen: int,
+) -> torch.Tensor:
+    x = packed_x.new_zeros(batch_size * max_seqlen, packed_x.shape[-1])
+    x.index_copy_(0, flat_indices, packed_x)
+    return x.view(batch_size, max_seqlen, packed_x.shape[-1])
+
+
+def unpack_unpadded_sequence(
+    packed_x: torch.Tensor,
+) -> torch.Tensor:
+    return packed_x.reshape(1, packed_x.shape[0], packed_x.shape[-1])
+
+
+class MossPackedRopeCache:
+    def __init__(self, *, max_period: float) -> None:
+        self.max_period = float(max_period)
+        self._device: torch.device | None = None
+        self._head_dim = 0
+        self._cos: torch.Tensor | None = None
+        self._sin: torch.Tensor | None = None
+        self._cos_sin: torch.Tensor | None = None
+
+    def get(
+        self,
+        *,
+        device: torch.device,
+        head_dim: int,
+        max_positions: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if max_positions <= 0:
+            raise ValueError(f"max_positions must be positive, got {max_positions}")
+        if head_dim <= 0 or head_dim % 2 != 0:
+            raise ValueError(f"RoPE requires an even head_dim, got {head_dim}")
+        if (
+            self._cos is not None
+            and self._sin is not None
+            and self._cos_sin is not None
+            and self._device == device
+            and self._head_dim == head_dim
+            and self._cos.shape[0] >= max_positions
+        ):
+            return self._cos[:max_positions], self._sin[:max_positions]
+
+        half_dim = head_dim // 2
+        ds = torch.arange(half_dim, device=device, dtype=torch.float32)
+        freqs = torch.exp(ds * (-math.log(self.max_period) * 2 / head_dim))
+        positions = torch.arange(
+            max_positions, device=device, dtype=torch.float32
+        ).view(-1, 1)
+        phase = positions * freqs.view(1, -1)
+        self._device = device
+        self._head_dim = head_dim
+        self._cos = torch.cos(phase)
+        self._sin = torch.sin(phase)
+        self._cos_sin = torch.cat((self._cos, self._sin), dim=-1)
+        return self._cos, self._sin
+
+    def get_cos_sin_cache(
+        self,
+        *,
+        device: torch.device,
+        head_dim: int,
+        max_positions: int,
+    ) -> torch.Tensor:
+        self.get(
+            device=device,
+            head_dim=head_dim,
+            max_positions=max_positions,
+        )
+        assert self._cos_sin is not None
+        return self._cos_sin[:max_positions]
+
+
+def _apply_cached_packed_rope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    position_ids: torch.Tensor,
+    *,
+    max_positions: int,
+    cache: MossPackedRopeCache,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if k.shape != q.shape:
+        raise ValueError(
+            f"Expected k.shape == q.shape, got k={tuple(k.shape)} q={tuple(q.shape)}"
+        )
+    if q.dim() != 3:
+        raise ValueError(
+            f"packed RoPE expects [tokens, heads, dim], got {tuple(q.shape)}"
+        )
+    _, _, head_dim = q.shape
+    if head_dim <= 0 or head_dim % 2 != 0:
+        raise ValueError(f"RoPE requires an even head_dim, got {head_dim}")
+    if q.device.type == "cuda":
+        cos_sin_cache = cache.get_cos_sin_cache(
+            device=q.device,
+            head_dim=head_dim,
+            max_positions=max_positions,
+        )
+        if apply_exact_interleaved_rope_inplace(
+            q,
+            k,
+            cos_sin_cache,
+            position_ids,
+        ):
+            return q, k
+
+    cos_cache, sin_cache = cache.get(
+        device=q.device,
+        head_dim=head_dim,
+        max_positions=max_positions,
+    )
+    if position_ids.numel() == max_positions:
+        cos = cos_cache.view(max_positions, 1, head_dim // 2)
+        sin = sin_cache.view(max_positions, 1, head_dim // 2)
+    else:
+        cos = cos_cache.index_select(0, position_ids).view(
+            position_ids.numel(), 1, head_dim // 2
+        )
+        sin = sin_cache.index_select(0, position_ids).view(
+            position_ids.numel(), 1, head_dim // 2
+        )
+
+    dims = q.shape[:-1]
+    q_pair = q.view(*dims, head_dim // 2, 2)
+    k_pair = k.view(*dims, head_dim // 2, 2)
+    qr, qi = q_pair[..., 0].float(), q_pair[..., 1].float()
+    kr, ki = k_pair[..., 0].float(), k_pair[..., 1].float()
+
+    qor = qr * cos - qi * sin
+    qoi = qr * sin + qi * cos
+    kor = kr * cos - ki * sin
+    koi = kr * sin + ki * cos
+
+    q_out = torch.stack([qor.to(q.dtype), qoi.to(q.dtype)], dim=-1).view(
+        *dims, head_dim
+    )
+    k_out = torch.stack([kor.to(k.dtype), koi.to(k.dtype)], dim=-1).view(
+        *dims, head_dim
+    )
+    return q_out, k_out
+
+
+def _run_query_chunked_sdpa(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    input_lengths: torch.Tensor,
+    causal: bool,
+    context: int | None,
+) -> torch.Tensor:
+    """Run dense local attention without materializing the full score matrix."""
+    batch_size, _, sequence_length, _ = q.shape
+    positions = torch.arange(sequence_length, device=q.device, dtype=torch.long)
+    output_chunks = []
+    for query_start in range(0, sequence_length, _SDPA_QUERY_CHUNK_SIZE):
+        query_end = min(
+            query_start + _SDPA_QUERY_CHUNK_SIZE,
+            sequence_length,
+        )
+        key_end = query_end if causal else sequence_length
+        key_start = max(0, query_start - context + 1) if context is not None else 0
+        query_positions = positions[query_start:query_end]
+        key_positions = positions[key_start:key_end]
+        valid_keys = key_positions.view(1, 1, -1) < input_lengths.view(-1, 1, 1)
+        if not causal and context is None:
+            attention_mask = valid_keys[:, None, :, :].expand(
+                -1,
+                1,
+                query_end - query_start,
+                -1,
+            )
+        else:
+            delta = query_positions.view(1, -1, 1) - key_positions.view(1, 1, -1)
+            attention_mask = torch.ones(
+                (1, query_end - query_start, key_end - key_start),
+                device=q.device,
+                dtype=torch.bool,
+            )
+            if causal:
+                attention_mask &= delta >= 0
+            if context is not None:
+                attention_mask &= delta < context
+            attention_mask = (attention_mask & valid_keys)[:, None, :, :]
+        output_chunks.append(
+            F.scaled_dot_product_attention(
+                q[:, :, query_start:query_end],
+                k[:, :, key_start:key_end],
+                v[:, :, key_start:key_end],
+                attn_mask=attention_mask,
+                dropout_p=0.0,
+            )
+        )
+    output = torch.cat(output_chunks, dim=2)
+    valid_queries = positions.view(1, -1) < input_lengths.view(-1, 1)
+    return torch.where(
+        valid_queries.view(batch_size, 1, sequence_length, 1),
+        output,
+        torch.zeros((), device=q.device, dtype=output.dtype),
+    )
+
+
+def _flash_window_size(causal: bool, context: int | None) -> tuple[int, int]:
+    if context is None or not causal:
+        return (-1, -1)
+    # note (Zhang Yiyang): Map total-token context to FlashAttention's prior-key window.
+    return (max(int(context) - 1, 0), 0)
+
+
+def _run_packed_flash_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor,
+    max_seqlen: int,
+    causal: bool,
+    context: int | None,
+    local_flash_plan: _LocalCausalFlashPlan | None,
+    flash_attn_varlen: Callable[..., torch.Tensor],
+) -> torch.Tensor:
+    """Run packed attention through SGLang's packed FlashAttention kernel."""
+    if (
+        causal
+        and context is not None
+        and _packed_flash_requires_query_chunks(q.device)
+        and max_seqlen > _LOCAL_CAUSAL_FLASH_QUERY_CHUNK_SIZE
+    ):
+        context = int(context)
+        plan = local_flash_plan or _build_local_causal_flash_plan(
+            cu_seqlens,
+            context=context,
+        )
+        if plan.context != context:
+            raise ValueError(
+                f"local flash plan context {plan.context} does not match "
+                f"attention context {context}"
+            )
+        return flash_attn_varlen(
+            q,
+            _gather_local_flash_kv(k, plan.kv_indices),
+            _gather_local_flash_kv(v, plan.kv_indices),
+            plan.cu_seqlens_q,
+            plan.cu_seqlens_k,
+            plan.max_seqlen_q,
+            plan.max_seqlen_k,
+            causal=True,
+            window_size=_flash_window_size(causal, context),
+        )
+    return flash_attn_varlen(
+        q,
+        k,
+        v,
+        cu_seqlens,
+        cu_seqlens,
+        max_seqlen,
+        max_seqlen,
+        causal=causal,
+        window_size=_flash_window_size(causal, context),
+    )
+
+
+def _merge_attention_heads(output: torch.Tensor, embed_dim: int) -> torch.Tensor:
+    if output.dim() == 4:
+        output = output.transpose(1, 2)
+    elif output.dim() != 3:
+        raise ValueError(
+            "attention output must have shape [batch, heads, seq, dim] or "
+            f"[tokens, heads, dim], got {tuple(output.shape)}"
+        )
+    return output.reshape(*output.shape[:-2], embed_dim)
+
+
+class MossAudioTokenizerAttention(nn.Module):
+    """MOSS-Audio-Tokenizer local-causal attention over codec frames."""
+
+    def __init__(
+        self,
+        *,
+        in_proj: nn.Module,
+        out_proj: nn.Module,
+        embed_dim: int,
+        num_heads: int,
+        causal: bool,
+        context: int | None,
+        rope: nn.Module | None,
+        attention_implementation: str | None,
+        attention_backend: str = AUTO_ATTENTION_BACKEND,
+        packed_rope_cache: MossPackedRopeCache | None = None,
+    ) -> None:
+        super().__init__()
+        self.in_proj = in_proj
+        self.out_proj = out_proj
+        self.embed_dim = int(embed_dim)
+        self.num_heads = int(num_heads)
+        if self.embed_dim % self.num_heads:
+            raise ValueError(
+                "embed_dim must be divisible by num_heads: "
+                f"{self.embed_dim}, {self.num_heads}"
+            )
+        self.head_dim = self.embed_dim // self.num_heads
+        if self.embed_dim != self.num_heads * self.head_dim:
+            raise ValueError(
+                f"invalid attention shape: embed_dim={self.embed_dim}, "
+                f"num_heads={self.num_heads}, head_dim={self.head_dim}"
+            )
+        self.causal = bool(causal)
+        self.context = None if context is None else int(context)
+        self.rope = rope
+        if attention_implementation not in (
+            None,
+            _HF_FLASH_ATTENTION_CONFIG,
+            _SDPA_ATTENTION_BACKEND,
+        ):
+            raise ValueError(
+                "attention_implementation must be None, 'flash_attention_2', "
+                f"or 'sdpa'; got {attention_implementation!r}"
+            )
+        self.attention_implementation = attention_implementation
+        self.attention_backend = validate_attention_backend(attention_backend)
+        self._flash_attn_varlen = flash_attn_varlen_func
+        max_period = self.rope.max_period if self.rope is not None else 10000.0
+        self._packed_rope_cache = packed_rope_cache or MossPackedRopeCache(
+            max_period=max_period
+        )
+
+    @classmethod
+    def from_module(
+        cls,
+        module: nn.Module,
+        *,
+        attention_backend: str = AUTO_ATTENTION_BACKEND,
+        packed_rope_cache: MossPackedRopeCache | None = None,
+    ) -> MossAudioTokenizerAttention:
+        return cls(
+            in_proj=_single_module(module, "in_proj", "in_projs"),
+            out_proj=_single_module(module, "out_proj", "out_projs"),
+            embed_dim=int(module.embed_dim),
+            num_heads=int(module.num_heads),
+            causal=bool(module.causal),
+            context=module.context,
+            rope=module.rope,
+            attention_implementation=getattr(
+                module,
+                "attention_implementation",
+                None,
+            ),
+            attention_backend=attention_backend,
+            packed_rope_cache=packed_rope_cache,
+        )
+
+    def resolve_attention_backend(
+        self,
+        device: torch.device,
+        dtype: torch.dtype | None,
+    ) -> AttentionBackendResolution:
+        preferred = _preferred_attention_backend(
+            self.attention_backend,
+            self.attention_implementation,
+        )
+        if preferred == _SDPA_ATTENTION_BACKEND:
+            return AttentionBackendResolution(_SDPA_ATTENTION_BACKEND)
+
+        unavailable_reason = self._packed_flash_unavailable_reason(device, dtype)
+        if unavailable_reason is None:
+            return AttentionBackendResolution(PACKED_FLASH_ATTENTION_BACKEND)
+        if self.attention_backend == PACKED_FLASH_ATTENTION_BACKEND:
+            raise RuntimeError(
+                "MOSS-Audio-Tokenizer "
+                "attention_backend='packed_flash_attention' "
+                f"is unavailable for device={device}, dtype={dtype}: "
+                f"{unavailable_reason}"
+            )
+        return AttentionBackendResolution(
+            _SDPA_ATTENTION_BACKEND,
+            fallback_reason=unavailable_reason,
+        )
+
+    def _packed_flash_unavailable_reason(
+        self,
+        device: torch.device,
+        dtype: torch.dtype | None,
+    ) -> str | None:
+        if dtype is not torch.bfloat16:
+            return f"packed FlashAttention requires torch.bfloat16; got {dtype}"
+        return _packed_flash_device_unavailable_reason(device)
+
+    def supports_packed_attention(
+        self,
+        device: torch.device,
+        dtype: torch.dtype | None,
+    ) -> bool:
+        if (
+            _preferred_attention_backend(
+                self.attention_backend,
+                self.attention_implementation,
+            )
+            != PACKED_FLASH_ATTENTION_BACKEND
+        ):
+            return False
+        return self._packed_flash_unavailable_reason(device, dtype) is None
+
+    @staticmethod
+    def get_backend_dtype(x: torch.Tensor) -> torch.dtype:
+        backend_dtype = x.dtype
+        if x.device.type != "cuda":
+            return backend_dtype
+        try:
+            autocast_enabled = torch.is_autocast_enabled("cuda")
+        except TypeError:
+            autocast_enabled = torch.is_autocast_enabled()
+        if autocast_enabled:
+            try:
+                backend_dtype = torch.get_autocast_dtype("cuda")
+            except TypeError:
+                backend_dtype = torch.get_autocast_gpu_dtype()
+        return backend_dtype
+
+    def build_local_causal_flash_plan(
+        self,
+        cu_seqlens: torch.Tensor,
+        *,
+        max_seqlen: int,
+        sequence_lengths: Sequence[int] | None = None,
+    ) -> _LocalCausalFlashPlan | None:
+        if (
+            not self.causal
+            or self.context is None
+            or not _packed_flash_requires_query_chunks(cu_seqlens.device)
+            or max_seqlen <= _LOCAL_CAUSAL_FLASH_QUERY_CHUNK_SIZE
+        ):
+            return None
+        return _build_local_causal_flash_plan(
+            cu_seqlens,
+            context=int(self.context),
+            sequence_lengths=sequence_lengths,
+        )
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor | None = None,
+        max_seqlen: int | None = None,
+        position_ids: torch.Tensor | None = None,
+        input_lengths: torch.Tensor | None = None,
+        local_flash_plan: _LocalCausalFlashPlan | None = None,
+    ) -> torch.Tensor:
+        backend = self.resolve_attention_backend(
+            query.device,
+            self.get_backend_dtype(query),
+        ).backend
+        is_packed = backend == PACKED_FLASH_ATTENTION_BACKEND
+        if is_packed:
+            if query.dim() != 2:
+                raise ValueError(
+                    "packed flash attention expects a 2D tensor, "
+                    f"got {tuple(query.shape)}"
+                )
+            if cu_seqlens is None or max_seqlen is None or position_ids is None:
+                raise ValueError(
+                    "packed flash attention requires cu_seqlens, max_seqlen, "
+                    "and position_ids"
+                )
+        else:
+            if query.dim() != 3:
+                raise ValueError(
+                    f"dense attention expects a 3D tensor, got {tuple(query.shape)}"
+                )
+            if input_lengths is None:
+                raise ValueError("dense attention requires input_lengths")
+            if query.shape[1] == 0:
+                return self.out_proj(query)
+
+        q, k, v = self._project_qkv(query)
+        if is_packed:
+            q, k = self._apply_packed_rope(
+                q,
+                k,
+                position_ids,
+                max_positions=max_seqlen,
+            )
+            output = _run_packed_flash_attention(
+                q,
+                k,
+                v,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+                causal=self.causal,
+                context=self.context,
+                local_flash_plan=local_flash_plan,
+                flash_attn_varlen=self._flash_attn_varlen,
+            )
+        else:
+            if self.rope is not None:
+                offset = torch.zeros(
+                    query.shape[0],
+                    device=query.device,
+                    dtype=torch.long,
+                )
+                q, k = self.rope(q, k, offset)
+            output = _run_query_chunked_sdpa(
+                q,
+                k,
+                v,
+                input_lengths=input_lengths,
+                causal=self.causal,
+                context=self.context,
+            )
+        return self.out_proj(_merge_attention_heads(output, self.embed_dim))
+
+    def _project_qkv(
+        self, x: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        projected = self.in_proj(x)
+        if x.dim() == 3:
+            projected = projected.reshape(
+                x.shape[0], x.shape[1], 3, self.num_heads, self.head_dim
+            ).permute(2, 0, 3, 1, 4)
+            return projected[0], projected[1], projected[2]
+        if x.dim() == 2:
+            projected = projected.view(x.shape[0], 3, self.num_heads, self.head_dim)
+            return projected[:, 0], projected[:, 1], projected[:, 2]
+        raise ValueError(f"expected a 2D or 3D tensor, got {tuple(x.shape)}")
+
+    def _apply_packed_rope(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        position_ids: torch.Tensor,
+        *,
+        max_positions: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.rope is None:
+            return q, k
+        return _apply_cached_packed_rope(
+            q,
+            k,
+            position_ids,
+            max_positions=max_positions,
+            cache=self._packed_rope_cache,
+        )

--- a/sglang_omni/models/moss_tts/audio_tokenizer.py
+++ b/sglang_omni/models/moss_tts/audio_tokenizer.py
@@ -1,15 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Shared MOSS-Audio-Tokenizer runtime."""
+"""MOSS-Audio-Tokenizer runtime."""
 
 from __future__ import annotations
 
-import importlib
 import logging
-import math
 from collections.abc import Iterator, Sequence
 from contextlib import nullcontext
-from dataclasses import dataclass
-from itertools import accumulate
 from typing import Any
 
 import torch
@@ -17,15 +13,23 @@ import torchaudio
 from torch import nn
 from transformers import AutoModel
 
-try:
-    from sglang.jit_kernel.flash_attention import flash_attn_varlen_func
-except ImportError:
-    flash_attn_varlen_func = None
-
-from sglang_omni.models.moss_tts.hf_loading import moss_transformers_processor_compat
-from sglang_omni.models.moss_tts.vocoder_kernels import (
-    apply_exact_interleaved_rope_inplace,
+from sglang_omni.models.moss_tts.attention import (
+    AUTO_ATTENTION_BACKEND,
+    PACKED_FLASH_ATTENTION_BACKEND,
+    AttentionBackendResolution,
+    MossAudioTokenizerAttention,
+    MossPackedRopeCache,
+    PositionIdsCache,
+    merge_attention_backend_resolutions,
+    pack_padded_sequence,
+    pack_padded_sequence_from_host_lengths,
+    pack_unpadded_sequence,
+    unpack_packed_sequence,
+    unpack_packed_sequence_from_indices,
+    unpack_unpadded_sequence,
+    validate_attention_backend,
 )
+from sglang_omni.models.moss_tts.hf_loading import moss_transformers_processor_compat
 
 logger = logging.getLogger(__name__)
 
@@ -34,648 +38,83 @@ _LOUDNESS_TARGET_DBFS = -20.0
 _LOUDNESS_GAIN_MIN_DB = -3.0
 _LOUDNESS_GAIN_MAX_DB = 3.0
 
-# note (Zhang Yiyang): FA3 local-window attention diverges from SDPA when one
-# varlen sequence spans multiple 128-token query tiles. Pack each tile as an
-# independent sequence in one kernel launch.
-_FA3_LOCAL_WINDOW_QUERY_TILE_SIZE = 128
-_HF_FLASH_ATTENTION_2_IMPLEMENTATION = "flash_attention_2"
-_PACKED_FLASH_ATTENTION_BACKEND = "packed_flash_attention"
 
+class _MossAudioTokenizerV1FeedForward(nn.Module):
+    """Expose MOSS-Audio-Tokenizer v1 Linear-GELU-Linear weights."""
 
-def _single_module(source: nn.Module, singular: str, plural: str) -> nn.Module:
-    module = getattr(source, singular, None)
-    if module is not None:
-        return module
-    modules = getattr(source, plural, None)
-    if modules is None or len(modules) != 1:
-        raise ValueError(
-            f"MOSS vocoder expects one {singular!r} module; "
-            f"got {plural}={modules!r}"
-        )
-    return modules[0]
-
-
-class _V1WeightsFeedForward(nn.Module):
-    """Expose the v1-weight Linear-GELU-Linear fields as one callable module."""
-
-    def __init__(self, source: nn.Module) -> None:
+    def __init__(
+        self,
+        linear1: nn.Module,
+        linear2: nn.Module,
+        activation: Any,
+    ) -> None:
         super().__init__()
-        self.linear1 = source.linear1
-        self.linear2 = source.linear2
-        self.activation = source.activation
+        self.linear1 = linear1
+        self.linear2 = linear2
+        self.activation = activation
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.linear2(self.activation(self.linear1(x)))
 
 
-def _feed_forward(source: nn.Module) -> nn.Module:
-    ffn = getattr(source, "ffn", None)
+def _feed_forward(module: nn.Module) -> nn.Module:
+    ffn = getattr(module, "ffn", None)
     if ffn is not None:
         return ffn
     if (
-        getattr(source, "linear1", None) is None
-        or getattr(source, "linear2", None) is None
+        getattr(module, "linear1", None) is None
+        or getattr(module, "linear2", None) is None
     ):
-        raise ValueError("MOSS vocoder transformer layer has no supported FFN")
-    return _V1WeightsFeedForward(source)
-
-
-@dataclass(frozen=True)
-class _LocalCausalFlashPlan:
-    cu_seqlens_q: torch.Tensor
-    cu_seqlens_k: torch.Tensor
-    kv_indices: torch.Tensor | None
-    max_seqlen_q: int
-    max_seqlen_k: int
-    context: int
-
-
-def _build_local_causal_flash_plan(
-    cu_seqlens: torch.Tensor,
-    *,
-    context: int,
-    query_chunk_size: int = _FA3_LOCAL_WINDOW_QUERY_TILE_SIZE,
-    sequence_lengths: Sequence[int] | None = None,
-) -> _LocalCausalFlashPlan:
-    if context <= 0:
-        raise ValueError(f"local causal context must be positive, got {context}")
-    if query_chunk_size <= 0:
-        raise ValueError(f"query_chunk_size must be positive, got {query_chunk_size}")
-
-    if sequence_lengths is None:
-        sequence_lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).to("cpu").tolist()
-    else:
-        sequence_lengths = [int(length) for length in sequence_lengths]
-        if len(sequence_lengths) != int(cu_seqlens.shape[0]) - 1:
-            raise ValueError(
-                "sequence_lengths must match the number of packed sequences"
-            )
-    q_lengths: list[int] = []
-    k_lengths: list[int] = []
-    key_starts: list[int] = []
-    packed_offset = 0
-    kv_cursor = 0
-    needs_kv_gather = False
-    for sequence_length in sequence_lengths:
-        sequence_length = int(sequence_length)
-        for query_start in range(0, sequence_length, query_chunk_size):
-            query_end = min(query_start + query_chunk_size, sequence_length)
-            key_start = max(0, query_start - context + 1)
-            key_end = query_end
-            q_lengths.append(query_end - query_start)
-            k_lengths.append(key_end - key_start)
-            absolute_key_start = packed_offset + key_start
-            absolute_key_end = packed_offset + key_end
-            key_starts.append(absolute_key_start)
-            needs_kv_gather |= absolute_key_start != kv_cursor
-            kv_cursor = absolute_key_end
-        packed_offset += sequence_length
-
-    if not q_lengths:
-        raise ValueError("local causal flash plan requires at least one query token")
-
-    q_lengths_tensor = torch.tensor(
-        q_lengths, device=cu_seqlens.device, dtype=torch.int32
+        raise ValueError("MOSS-Audio-Tokenizer transformer layer has no supported FFN")
+    return _MossAudioTokenizerV1FeedForward(
+        module.linear1,
+        module.linear2,
+        module.activation,
     )
-    k_lengths_tensor = torch.tensor(
-        k_lengths, device=cu_seqlens.device, dtype=torch.int32
-    )
-    cu_seqlens_q = torch.zeros(
-        len(q_lengths) + 1, device=cu_seqlens.device, dtype=torch.int32
-    )
-    cu_seqlens_k = torch.zeros_like(cu_seqlens_q)
-    cu_seqlens_q[1:] = torch.cumsum(q_lengths_tensor, dim=0)
-    cu_seqlens_k[1:] = torch.cumsum(k_lengths_tensor, dim=0)
-    kv_indices = None
-    if needs_kv_gather or kv_cursor != packed_offset:
-        packed_kv_length = sum(k_lengths)
-        k_lengths_long = k_lengths_tensor.to(torch.long)
-        key_starts_tensor = torch.tensor(
-            key_starts, device=cu_seqlens.device, dtype=torch.long
-        )
-        chunk_offsets = key_starts_tensor - cu_seqlens_k[:-1].to(torch.long)
-        repeated_offsets = torch.repeat_interleave(
-            chunk_offsets,
-            k_lengths_long,
-            output_size=packed_kv_length,
-        )
-        kv_indices = (
-            torch.arange(packed_kv_length, device=cu_seqlens.device, dtype=torch.long)
-            + repeated_offsets
-        )
-    return _LocalCausalFlashPlan(
-        cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_k=cu_seqlens_k,
-        kv_indices=kv_indices,
-        max_seqlen_q=max(q_lengths),
-        max_seqlen_k=max(k_lengths),
-        context=context,
-    )
-
-
-def _gather_local_flash_kv(
-    x: torch.Tensor,
-    kv_indices: torch.Tensor | None,
-) -> torch.Tensor:
-    return x if kv_indices is None else x.index_select(0, kv_indices)
-
-
-class _PositionIdsCache:
-    def __init__(self) -> None:
-        self._items: dict[tuple[str, int | None], torch.Tensor] = {}
-
-    def get(
-        self,
-        *,
-        device: torch.device,
-        max_seqlen: int,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        if max_seqlen <= 0:
-            raise ValueError(f"max_seqlen must be positive, got {max_seqlen}")
-        key = (device.type, device.index)
-        position_ids = self._items.get(key)
-        if position_ids is None or position_ids.shape[0] < max_seqlen:
-            position_ids = torch.arange(max_seqlen, device=device, dtype=torch.long)
-            self._items[key] = position_ids
-        cu_seqlens = torch.tensor([0, max_seqlen], dtype=torch.int32, device=device)
-        return cu_seqlens, position_ids[:max_seqlen]
-
-
-def _pack_padded_sequence(
-    x: torch.Tensor,
-    input_lengths: torch.Tensor,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    batch_size, max_seqlen, _ = x.shape
-    positions = torch.arange(max_seqlen, device=x.device, dtype=torch.long)
-    valid_mask = positions.view(1, max_seqlen) < input_lengths.view(batch_size, 1)
-    packed_x = x[valid_mask]
-    cu_seqlens = torch.zeros(batch_size + 1, dtype=torch.int32, device=x.device)
-    cu_seqlens[1:] = torch.cumsum(input_lengths.to(torch.int32), dim=0)
-    position_ids = positions.view(1, max_seqlen).expand(batch_size, -1)[valid_mask]
-    return packed_x, valid_mask, cu_seqlens, position_ids
-
-
-def _pack_padded_sequence_from_host_lengths(
-    x: torch.Tensor,
-    input_lengths: torch.Tensor,
-    input_lengths_cpu: Sequence[int],
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Pack with matching device/host lengths without synchronizing the device."""
-
-    batch_size, max_seqlen, hidden_size = x.shape
-    lengths = list(map(int, input_lengths_cpu))
-    if len(lengths) != batch_size:
-        raise ValueError("input_lengths_cpu must match the decoder batch size")
-    if input_lengths.ndim != 1 or int(input_lengths.numel()) != batch_size:
-        raise ValueError("input_lengths must match the decoder batch size")
-    if input_lengths.device != x.device:
-        raise ValueError("input_lengths and decoder inputs must share one device")
-    if any(length < 0 or length > max_seqlen for length in lengths):
-        raise ValueError("input_lengths_cpu must be within the padded sequence")
-
-    total_tokens = sum(lengths)
-    cu_seqlens = torch.tensor(
-        [0, *accumulate(lengths)],
-        device=x.device,
-        dtype=torch.int32,
-    )
-    batch_ids = torch.repeat_interleave(
-        torch.arange(batch_size, device=x.device, dtype=torch.long),
-        input_lengths,
-        output_size=total_tokens,
-    )
-    position_ids = torch.arange(total_tokens, device=x.device, dtype=torch.long)
-    position_ids = position_ids - cu_seqlens[:-1].to(torch.long).index_select(
-        0, batch_ids
-    )
-    flat_indices = batch_ids * max_seqlen + position_ids
-    packed_x = x.reshape(batch_size * max_seqlen, hidden_size).index_select(
-        0, flat_indices
-    )
-    return packed_x, flat_indices, cu_seqlens, position_ids
-
-
-def _pack_unpadded_sequence(
-    x: torch.Tensor,
-    position_ids_cache: "_PositionIdsCache",
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    assert x.shape[0] == 1, f"expected a single unpadded sequence, got {x.shape[0]}"
-    _, max_seqlen, _ = x.shape
-    packed_x = x.reshape(max_seqlen, x.shape[-1])
-    cu_seqlens, position_ids = position_ids_cache.get(
-        device=x.device,
-        max_seqlen=max_seqlen,
-    )
-    return packed_x, cu_seqlens, position_ids
-
-
-def _unpack_packed_sequence(
-    packed_x: torch.Tensor,
-    valid_mask: torch.Tensor,
-    batch_size: int,
-    max_seqlen: int,
-) -> torch.Tensor:
-    x = packed_x.new_zeros(batch_size, max_seqlen, packed_x.shape[-1])
-    x[valid_mask] = packed_x
-    return x
-
-
-def _unpack_packed_sequence_from_indices(
-    packed_x: torch.Tensor,
-    flat_indices: torch.Tensor,
-    batch_size: int,
-    max_seqlen: int,
-) -> torch.Tensor:
-    x = packed_x.new_zeros(batch_size * max_seqlen, packed_x.shape[-1])
-    x.index_copy_(0, flat_indices, packed_x)
-    return x.view(batch_size, max_seqlen, packed_x.shape[-1])
-
-
-def _unpack_unpadded_sequence(
-    packed_x: torch.Tensor,
-) -> torch.Tensor:
-    return packed_x.reshape(1, packed_x.shape[0], packed_x.shape[-1])
-
-
-class _MossPackedRopeCache:
-    def __init__(self, *, max_period: float) -> None:
-        self.max_period = float(max_period)
-        self._device: torch.device | None = None
-        self._head_dim = 0
-        self._cos: torch.Tensor | None = None
-        self._sin: torch.Tensor | None = None
-        self._cos_sin: torch.Tensor | None = None
-
-    def get(
-        self,
-        *,
-        device: torch.device,
-        head_dim: int,
-        max_positions: int,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        if max_positions <= 0:
-            raise ValueError(f"max_positions must be positive, got {max_positions}")
-        if head_dim <= 0 or head_dim % 2 != 0:
-            raise ValueError(f"RoPE requires an even head_dim, got {head_dim}")
-        if (
-            self._cos is not None
-            and self._sin is not None
-            and self._cos_sin is not None
-            and self._device == device
-            and self._head_dim == head_dim
-            and self._cos.shape[0] >= max_positions
-        ):
-            return self._cos[:max_positions], self._sin[:max_positions]
-
-        half_dim = head_dim // 2
-        ds = torch.arange(half_dim, device=device, dtype=torch.float32)
-        freqs = torch.exp(ds * (-math.log(self.max_period) * 2 / head_dim))
-        positions = torch.arange(
-            max_positions, device=device, dtype=torch.float32
-        ).view(-1, 1)
-        phase = positions * freqs.view(1, -1)
-        self._device = device
-        self._head_dim = head_dim
-        self._cos = torch.cos(phase)
-        self._sin = torch.sin(phase)
-        self._cos_sin = torch.cat((self._cos, self._sin), dim=-1)
-        return self._cos, self._sin
-
-    def get_cos_sin_cache(
-        self,
-        *,
-        device: torch.device,
-        head_dim: int,
-        max_positions: int,
-    ) -> torch.Tensor:
-        self.get(
-            device=device,
-            head_dim=head_dim,
-            max_positions=max_positions,
-        )
-        assert self._cos_sin is not None
-        return self._cos_sin[:max_positions]
-
-
-def _apply_cached_packed_rope(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    position_ids: torch.Tensor,
-    *,
-    max_positions: int,
-    cache: _MossPackedRopeCache,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    if k.shape != q.shape:
-        raise ValueError(
-            f"Expected k.shape == q.shape, got k={tuple(k.shape)} q={tuple(q.shape)}"
-        )
-    if q.dim() != 3:
-        raise ValueError(
-            f"packed RoPE expects [tokens, heads, dim], got {tuple(q.shape)}"
-        )
-    _, _, head_dim = q.shape
-    if head_dim <= 0 or head_dim % 2 != 0:
-        raise ValueError(f"RoPE requires an even head_dim, got {head_dim}")
-    if q.device.type == "cuda":
-        cos_sin_cache = cache.get_cos_sin_cache(
-            device=q.device,
-            head_dim=head_dim,
-            max_positions=max_positions,
-        )
-        if apply_exact_interleaved_rope_inplace(
-            q,
-            k,
-            cos_sin_cache,
-            position_ids,
-        ):
-            return q, k
-
-    cos_cache, sin_cache = cache.get(
-        device=q.device,
-        head_dim=head_dim,
-        max_positions=max_positions,
-    )
-    if position_ids.numel() == max_positions:
-        cos = cos_cache.view(max_positions, 1, head_dim // 2)
-        sin = sin_cache.view(max_positions, 1, head_dim // 2)
-    else:
-        cos = cos_cache.index_select(0, position_ids).view(
-            position_ids.numel(), 1, head_dim // 2
-        )
-        sin = sin_cache.index_select(0, position_ids).view(
-            position_ids.numel(), 1, head_dim // 2
-        )
-
-    dims = q.shape[:-1]
-    q_pair = q.view(*dims, head_dim // 2, 2)
-    k_pair = k.view(*dims, head_dim // 2, 2)
-    qr, qi = q_pair[..., 0].float(), q_pair[..., 1].float()
-    kr, ki = k_pair[..., 0].float(), k_pair[..., 1].float()
-
-    qor = qr * cos - qi * sin
-    qoi = qr * sin + qi * cos
-    kor = kr * cos - ki * sin
-    koi = kr * sin + ki * cos
-
-    q_out = torch.stack([qor.to(q.dtype), qoi.to(q.dtype)], dim=-1).view(
-        *dims, head_dim
-    )
-    k_out = torch.stack([kor.to(k.dtype), koi.to(k.dtype)], dim=-1).view(
-        *dims, head_dim
-    )
-    return q_out, k_out
-
-
-class MossAudioTokenizerAttention(nn.Module):
-    """MOSS local-causal self attention over dense or packed decoder frames."""
-
-    def __init__(
-        self,
-        source: nn.Module,
-        *,
-        packed_rope_cache: _MossPackedRopeCache | None = None,
-    ) -> None:
-        super().__init__()
-        object.__setattr__(self, "source", source)
-        self.in_proj = _single_module(source, "in_proj", "in_projs")
-        self.out_proj = _single_module(source, "out_proj", "out_projs")
-        self.embed_dim = int(source.embed_dim)
-        self.num_heads = int(source.num_heads)
-        self.head_dim = int(
-            getattr(source, "head_dim", self.embed_dim // self.num_heads)
-        )
-        if self.embed_dim != self.num_heads * self.head_dim:
-            raise ValueError(
-                f"invalid attention shape: embed_dim={self.embed_dim}, "
-                f"num_heads={self.num_heads}, head_dim={self.head_dim}"
-            )
-        self.causal = bool(source.causal)
-        self.context = source.context
-        self.rope = source.rope
-        self._uses_v1_weights_attention_api = not hasattr(
-            source, "resolve_attention_implementation"
-        )
-        self._flash_attn_varlen = flash_attn_varlen_func
-        max_period = self.rope.max_period if self.rope is not None else 10000.0
-        self._packed_rope_cache = packed_rope_cache or _MossPackedRopeCache(
-            max_period=max_period
-        )
-
-    def resolve_attention_implementation(self, x: torch.Tensor) -> str:
-        preferred = getattr(self.source, "attention_implementation", None)
-        if preferred is None:
-            # note (Zhang Yiyang): The MOSS-Audio-Tokenizer v1-weights attention
-            # has no backend selector, but implements the same local-causal
-            # operation. Prefer packed FlashAttention when its device and dtype
-            # requirements are satisfied.
-            preferred = _HF_FLASH_ATTENTION_2_IMPLEMENTATION
-        if (
-            preferred == _HF_FLASH_ATTENTION_2_IMPLEMENTATION
-            and self._can_run_packed_flash(x)
-        ):
-            return _PACKED_FLASH_ATTENTION_BACKEND
-        resolver = getattr(self.source, "resolve_attention_implementation", None)
-        if resolver is None:
-            return "sdpa"
-        resolved = resolver(x, is_streaming=False)
-        if resolved == _HF_FLASH_ATTENTION_2_IMPLEMENTATION:
-            return _PACKED_FLASH_ATTENTION_BACKEND
-        return resolved
-
-    def supports_packed_flash(
-        self,
-        device: torch.device,
-        dtype: torch.dtype | None,
-    ) -> bool:
-        if dtype is None or self._flash_attn_varlen is None or device.type != "cuda":
-            return False
-        preferred = getattr(self.source, "attention_implementation", None)
-        if preferred not in (None, _HF_FLASH_ATTENTION_2_IMPLEMENTATION):
-            return False
-        if getattr(self.source, "_get_backend_check_dtype", None) is not None:
-            # note (Zhang Yiyang): Preserve the v2/Local contract, whose packed
-            # path is BF16-only.
-            return dtype == torch.bfloat16
-        return dtype in (torch.float16, torch.bfloat16)
-
-    def _can_run_packed_flash(self, x: torch.Tensor) -> bool:
-        dtype_resolver = getattr(self.source, "_get_backend_check_dtype", None)
-        if dtype_resolver is not None:
-            backend_dtype = dtype_resolver(x)
-        else:
-            backend_dtype = x.dtype
-            try:
-                autocast_enabled = torch.is_autocast_enabled("cuda")
-            except TypeError:
-                autocast_enabled = torch.is_autocast_enabled()
-            if autocast_enabled:
-                try:
-                    backend_dtype = torch.get_autocast_dtype("cuda")
-                except TypeError:
-                    backend_dtype = torch.get_autocast_gpu_dtype()
-        return self.supports_packed_flash(x.device, backend_dtype)
-
-    def forward(
-        self,
-        query: torch.Tensor,
-        *,
-        cu_seqlens: torch.Tensor | None = None,
-        max_seqlen: int | None = None,
-        position_ids: torch.Tensor | None = None,
-        input_lengths: torch.Tensor | None = None,
-        local_flash_plan: _LocalCausalFlashPlan | None = None,
-    ) -> torch.Tensor:
-        backend = self.resolve_attention_implementation(query)
-        if backend == _PACKED_FLASH_ATTENTION_BACKEND:
-            if query.dim() != 2:
-                raise ValueError(
-                    "packed flash attention expects a 2D tensor, "
-                    f"got {tuple(query.shape)}"
-                )
-            if cu_seqlens is None or max_seqlen is None or position_ids is None:
-                raise ValueError(
-                    "packed flash attention requires cu_seqlens, max_seqlen, "
-                    "and position_ids"
-                )
-            return self._forward_packed_flash(
-                query,
-                cu_seqlens=cu_seqlens,
-                max_seqlen=max_seqlen,
-                position_ids=position_ids,
-                local_flash_plan=local_flash_plan,
-            )
-        if query.dim() != 3:
-            raise ValueError(
-                f"dense attention expects a 3D tensor, got {tuple(query.shape)}"
-            )
-        if input_lengths is None:
-            raise ValueError("dense attention requires input_lengths")
-        if self._uses_v1_weights_attention_api:
-            return self.source(query, query, query)
-        return self.source(query, input_lengths=input_lengths)
-
-    def _project_qkv(
-        self, x: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        projected = self.in_proj(x)
-        if x.dim() == 3:
-            projected = projected.reshape(
-                x.shape[0], x.shape[1], 3, self.num_heads, self.head_dim
-            ).permute(2, 0, 3, 1, 4)
-            return projected[0], projected[1], projected[2]
-        if x.dim() == 2:
-            projected = projected.view(x.shape[0], 3, self.num_heads, self.head_dim)
-            return projected[:, 0], projected[:, 1], projected[:, 2]
-        raise ValueError(f"expected a 2D or 3D tensor, got {tuple(x.shape)}")
-
-    def _apply_packed_rope(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        position_ids: torch.Tensor,
-        *,
-        max_positions: int,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        if self.rope is None:
-            return q, k
-        return _apply_cached_packed_rope(
-            q,
-            k,
-            position_ids,
-            max_positions=max_positions,
-            cache=self._packed_rope_cache,
-        )
-
-    def _forward_packed_flash(
-        self,
-        x: torch.Tensor,
-        *,
-        cu_seqlens: torch.Tensor,
-        max_seqlen: int,
-        position_ids: torch.Tensor,
-        local_flash_plan: _LocalCausalFlashPlan | None,
-    ) -> torch.Tensor:
-        q, k, v = self._project_qkv(x)
-        q, k = self._apply_packed_rope(
-            q,
-            k,
-            position_ids,
-            max_positions=max_seqlen,
-        )
-        assert self._flash_attn_varlen is not None
-        if (
-            self.causal
-            and self.context is not None
-            and max_seqlen > _FA3_LOCAL_WINDOW_QUERY_TILE_SIZE
-        ):
-            context = int(self.context)
-            plan = local_flash_plan or _build_local_causal_flash_plan(
-                cu_seqlens,
-                context=context,
-            )
-            if plan.context != context:
-                raise ValueError(
-                    f"local flash plan context {plan.context} does not match "
-                    f"attention context {context}"
-                )
-            packed_k = _gather_local_flash_kv(k, plan.kv_indices)
-            packed_v = _gather_local_flash_kv(v, plan.kv_indices)
-            out = self._flash_attn_varlen(
-                q.contiguous(),
-                packed_k.contiguous(),
-                packed_v.contiguous(),
-                plan.cu_seqlens_q,
-                plan.cu_seqlens_k,
-                plan.max_seqlen_q,
-                plan.max_seqlen_k,
-                causal=True,
-                window_size=self._flash_window_size(),
-            )
-            return self.out_proj(out.reshape(x.shape[0], self.embed_dim))
-
-        out = self._flash_attn_varlen(
-            q.contiguous(),
-            k.contiguous(),
-            v.contiguous(),
-            cu_seqlens,
-            cu_seqlens,
-            max_seqlen,
-            max_seqlen,
-            causal=self.causal,
-            window_size=self._flash_window_size(),
-        )
-        return self.out_proj(out.reshape(x.shape[0], self.embed_dim))
-
-    def _flash_window_size(self) -> tuple[int, int]:
-        if self.context is None or not self.causal:
-            return (-1, -1)
-        # note (Zhang Yiyang): MOSS's SDPA local mask keeps `context` total tokens
-        # including the current query token. FlashAttention's left-window argument
-        # counts prior keys.
-        return (max(int(self.context) - 1, 0), 0)
 
 
 class MossAudioTokenizerTransformerLayer(nn.Module):
-    """One MOSS vocoder transformer layer."""
+    """One shared MOSS-Audio-Tokenizer transformer layer."""
 
     def __init__(
         self,
-        source: nn.Module,
         *,
-        packed_rope_cache: _MossPackedRopeCache | None = None,
+        norm1: nn.Module,
+        self_attn: MossAudioTokenizerAttention,
+        layer_scale_1: nn.Module,
+        norm2: nn.Module,
+        ffn: nn.Module,
+        layer_scale_2: nn.Module,
     ) -> None:
         super().__init__()
-        object.__setattr__(self, "source", source)
-        self.norm1 = source.norm1
-        self.norm2 = source.norm2
-        self.layer_scale_1 = source.layer_scale_1
-        self.layer_scale_2 = source.layer_scale_2
-        self.ffn = _feed_forward(source)
-        self.self_attn = MossAudioTokenizerAttention(
-            source.self_attn,
-            packed_rope_cache=packed_rope_cache,
+        self.norm1 = norm1
+        self.self_attn = self_attn
+        self.layer_scale_1 = layer_scale_1
+        self.norm2 = norm2
+        self.ffn = ffn
+        self.layer_scale_2 = layer_scale_2
+        assert callable(self.ffn), "MOSS-Audio-Tokenizer layer requires an FFN"
+
+    @classmethod
+    def from_module(
+        cls,
+        module: nn.Module,
+        *,
+        attention_backend: str = AUTO_ATTENTION_BACKEND,
+        packed_rope_cache: MossPackedRopeCache | None = None,
+    ) -> MossAudioTokenizerTransformerLayer:
+        return cls(
+            norm1=module.norm1,
+            self_attn=MossAudioTokenizerAttention.from_module(
+                module.self_attn,
+                attention_backend=attention_backend,
+                packed_rope_cache=packed_rope_cache,
+            ),
+            layer_scale_1=module.layer_scale_1,
+            norm2=module.norm2,
+            ffn=_feed_forward(module),
+            layer_scale_2=module.layer_scale_2,
         )
-        assert callable(self.ffn), "MOSS vocoder transformer layer requires an FFN"
 
     def forward(self, x: torch.Tensor, **kwargs: Any) -> torch.Tensor:
         residual = x
@@ -688,38 +127,64 @@ class MossAudioTokenizerTransformerLayer(nn.Module):
 
 
 class MossAudioTokenizerTransformer(nn.Module):
-    """MOSS vocoder transformer body."""
+    """Shared MOSS-Audio-Tokenizer transformer body."""
 
-    def __init__(self, source: nn.Module) -> None:
+    def __init__(
+        self,
+        *,
+        layers: Sequence[MossAudioTokenizerTransformerLayer],
+        positional_embedding: str,
+        positional_scale: float,
+        max_period: float,
+    ) -> None:
         super().__init__()
-        object.__setattr__(self, "source", source)
-        packed_rope_cache = _MossPackedRopeCache(max_period=source.max_period)
-        self.layers = nn.ModuleList(
-            [
-                MossAudioTokenizerTransformerLayer(
+        self.layers = nn.ModuleList(layers)
+        self.positional_embedding = positional_embedding
+        self.positional_scale = float(positional_scale)
+        self.max_period = float(max_period)
+
+    @classmethod
+    def from_module(
+        cls,
+        module: nn.Module,
+        *,
+        attention_backend: str = AUTO_ATTENTION_BACKEND,
+    ) -> MossAudioTokenizerTransformer:
+        max_period = float(module.max_period)
+        packed_rope_cache = MossPackedRopeCache(max_period=max_period)
+        return cls(
+            layers=[
+                MossAudioTokenizerTransformerLayer.from_module(
                     layer,
+                    attention_backend=attention_backend,
                     packed_rope_cache=packed_rope_cache,
                 )
-                for layer in source.layers
+                for layer in module.layers
+            ],
+            positional_embedding=module.positional_embedding,
+            positional_scale=float(module.positional_scale),
+            max_period=max_period,
+        )
+
+    def resolve_attention_backend(
+        self,
+        device: torch.device,
+        dtype: torch.dtype | None,
+    ) -> AttentionBackendResolution:
+        return merge_attention_backend_resolutions(
+            [
+                layer.self_attn.resolve_attention_backend(device, dtype)
+                for layer in self.layers
             ]
         )
-        self.positional_embedding = source.positional_embedding
-        self.positional_scale = float(source.positional_scale)
-        self.max_period = source.max_period
-        self._remote_module = importlib.import_module(source.__class__.__module__)
-        self._create_sin_embedding = self._remote_module.create_sin_embedding
 
-    def resolve_attention_implementation(self, x: torch.Tensor) -> str:
-        assert len(self.layers) > 0, "MOSS vocoder transformer must have layers"
-        return self.layers[0].self_attn.resolve_attention_implementation(x)
-
-    def supports_packed_flash(
+    def supports_packed_attention(
         self,
         device: torch.device,
         dtype: torch.dtype | None,
     ) -> bool:
         return bool(self.layers) and all(
-            layer.self_attn.supports_packed_flash(device, dtype)
+            layer.self_attn.supports_packed_attention(device, dtype)
             for layer in self.layers
         )
 
@@ -734,7 +199,7 @@ class MossAudioTokenizerTransformer(nn.Module):
                         "packed transformer inputs require position_ids for "
                         "sinusoidal embeddings"
                     )
-            pos_emb = self._create_sin_embedding(
+            pos_emb = create_sin_embedding(
                 positions,
                 x.shape[-1],
                 max_period=self.max_period,
@@ -747,15 +212,38 @@ class MossAudioTokenizerTransformer(nn.Module):
 
 
 class MossAudioTokenizerProjectedTransformer(nn.Module):
-    """Projected transformer decoder stage with the MOSS input/output layout."""
+    """Shared projected Transformer stage with the MOSS-Audio-Tokenizer tensor layout."""
 
-    def __init__(self, source: nn.Module) -> None:
+    def __init__(
+        self,
+        *,
+        input_proj: nn.Module,
+        transformer: MossAudioTokenizerTransformer,
+        output_proj: nn.Module,
+    ) -> None:
         super().__init__()
-        object.__setattr__(self, "source", source)
-        self.input_proj = source.input_proj
-        self.output_proj = source.output_proj
-        self.transformer = MossAudioTokenizerTransformer(source.transformer)
-        self._position_ids_cache = _PositionIdsCache()
+        self.module_type = "Transformer"
+        self.downsample_ratio = 1
+        self.input_proj = input_proj
+        self.transformer = transformer
+        self.output_proj = output_proj
+        self._position_ids_cache = PositionIdsCache()
+
+    @classmethod
+    def from_module(
+        cls,
+        module: nn.Module,
+        *,
+        attention_backend: str = AUTO_ATTENTION_BACKEND,
+    ) -> MossAudioTokenizerProjectedTransformer:
+        return cls(
+            input_proj=module.input_proj,
+            transformer=MossAudioTokenizerTransformer.from_module(
+                module.transformer,
+                attention_backend=attention_backend,
+            ),
+            output_proj=module.output_proj,
+        )
 
     def forward(
         self,
@@ -766,8 +254,11 @@ class MossAudioTokenizerProjectedTransformer(nn.Module):
         **kwargs: Any,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         x = self.input_proj(x.transpose(1, 2))
-        backend = self.transformer.resolve_attention_implementation(x)
-        if backend == _PACKED_FLASH_ATTENTION_BACKEND:
+        backend = self.transformer.resolve_attention_backend(
+            x.device,
+            MossAudioTokenizerAttention.get_backend_dtype(x),
+        ).backend
+        if backend == PACKED_FLASH_ATTENTION_BACKEND:
             batch_size, max_seqlen, _ = x.shape
             if input_lengths_cpu is not None:
                 if len(input_lengths_cpu) != batch_size:
@@ -782,7 +273,7 @@ class MossAudioTokenizerProjectedTransformer(nn.Module):
             else:
                 is_unpadded_single = batch_size == 1 and max_valid_seqlen == max_seqlen
                 if is_unpadded_single:
-                    packed_x, cu_seqlens, position_ids = _pack_unpadded_sequence(
+                    packed_x, cu_seqlens, position_ids = pack_unpadded_sequence(
                         x,
                         self._position_ids_cache,
                     )
@@ -790,7 +281,7 @@ class MossAudioTokenizerProjectedTransformer(nn.Module):
                     flat_indices = None
                 elif input_lengths_cpu is not None:
                     packed_x, flat_indices, cu_seqlens, position_ids = (
-                        _pack_padded_sequence_from_host_lengths(
+                        pack_padded_sequence_from_host_lengths(
                             x,
                             input_lengths,
                             input_lengths_cpu,
@@ -799,21 +290,15 @@ class MossAudioTokenizerProjectedTransformer(nn.Module):
                     valid_mask = None
                 else:
                     packed_x, valid_mask, cu_seqlens, position_ids = (
-                        _pack_padded_sequence(x, input_lengths)
+                        pack_padded_sequence(x, input_lengths)
                     )
                     flat_indices = None
                 first_attention = self.transformer.layers[0].self_attn
-                local_flash_plan = None
-                if (
-                    first_attention.causal
-                    and first_attention.context is not None
-                    and max_valid_seqlen > _FA3_LOCAL_WINDOW_QUERY_TILE_SIZE
-                ):
-                    local_flash_plan = _build_local_causal_flash_plan(
-                        cu_seqlens,
-                        context=int(first_attention.context),
-                        sequence_lengths=input_lengths_cpu,
-                    )
+                local_flash_plan = first_attention.build_local_causal_flash_plan(
+                    cu_seqlens,
+                    max_seqlen=max_valid_seqlen,
+                    sequence_lengths=input_lengths_cpu,
+                )
                 packed_x = self.transformer(
                     packed_x,
                     cu_seqlens=cu_seqlens,
@@ -824,9 +309,9 @@ class MossAudioTokenizerProjectedTransformer(nn.Module):
                     **kwargs,
                 )
                 if is_unpadded_single:
-                    x = _unpack_unpadded_sequence(packed_x)
+                    x = unpack_unpadded_sequence(packed_x)
                 elif flat_indices is not None:
-                    x = _unpack_packed_sequence_from_indices(
+                    x = unpack_packed_sequence_from_indices(
                         packed_x,
                         flat_indices,
                         batch_size,
@@ -834,7 +319,7 @@ class MossAudioTokenizerProjectedTransformer(nn.Module):
                     )
                 else:
                     assert valid_mask is not None
-                    x = _unpack_packed_sequence(
+                    x = unpack_packed_sequence(
                         packed_x,
                         valid_mask,
                         batch_size,
@@ -844,34 +329,45 @@ class MossAudioTokenizerProjectedTransformer(nn.Module):
             x = self.transformer(x, input_lengths=input_lengths, **kwargs)
         return self.output_proj(x).transpose(1, 2), input_lengths
 
-    def supports_packed_flash(
+    def supports_packed_attention(
         self,
         device: torch.device,
         dtype: torch.dtype | None,
     ) -> bool:
-        return self.transformer.supports_packed_flash(device, dtype)
+        return self.transformer.supports_packed_attention(device, dtype)
+
+
+# note (Zhang Yiyang): Non-streaming decoder wrapper.
 
 
 class MossAudioTokenizerVocoderDecoder(nn.Module):
-    """Iterable MOSS vocoder decoder with patched projected transformers."""
+    """Iterable MOSS-Audio-Tokenizer vocoder decoder with patched projected transformers."""
 
-    def __init__(self, source: nn.Module) -> None:
+    def __init__(
+        self,
+        decoder: nn.Module,
+        *,
+        attention_backend: str = AUTO_ATTENTION_BACKEND,
+    ) -> None:
         super().__init__()
-        source_stages = list(source)
-        assert source_stages, "MOSS vocoder decoder must be a non-empty stage list"
-        self.stages = nn.ModuleList(
-            [self._wrap_stage(stage) for stage in source_stages]
-        )
+        stages = list(decoder)
+        assert (
+            stages
+        ), "MOSS-Audio-Tokenizer vocoder decoder must be a non-empty stage list"
+        self.attention_backend = validate_attention_backend(attention_backend)
+        self.stages = nn.ModuleList([self._wrap_stage(stage) for stage in stages])
 
-    @staticmethod
-    def _wrap_stage(stage: nn.Module) -> nn.Module:
+    def _wrap_stage(self, stage: nn.Module) -> nn.Module:
         module_type = stage.module_type
         if module_type == "Transformer":
-            return MossAudioTokenizerProjectedTransformer(stage)
+            return MossAudioTokenizerProjectedTransformer.from_module(
+                stage,
+                attention_backend=self.attention_backend,
+            )
         if module_type == "PatchedPretransform":
             return stage
         raise ValueError(
-            f"unsupported MOSS vocoder decoder stage {stage.__class__.__name__} "
+            f"unsupported MOSS-Audio-Tokenizer vocoder decoder stage {stage.__class__.__name__} "
             f"with module_type={module_type!r}"
         )
 
@@ -884,7 +380,7 @@ class MossAudioTokenizerVocoderDecoder(nn.Module):
     def __getitem__(self, index: int) -> nn.Module:
         return self.stages[index]
 
-    def supports_packed_flash(
+    def supports_packed_attention(
         self,
         device: str | torch.device,
         dtype: torch.dtype | None,
@@ -896,7 +392,8 @@ class MossAudioTokenizerVocoderDecoder(nn.Module):
             if isinstance(stage, MossAudioTokenizerProjectedTransformer)
         ]
         return bool(transformer_stages) and all(
-            stage.supports_packed_flash(device, dtype) for stage in transformer_stages
+            stage.supports_packed_attention(device, dtype)
+            for stage in transformer_stages
         )
 
     @staticmethod
@@ -908,7 +405,9 @@ class MossAudioTokenizerVocoderDecoder(nn.Module):
             return list(map(int, input_lengths))
         patch_size = int(getattr(stage, "patch_size", 0))
         if patch_size <= 0:
-            raise ValueError("MOSS patched pretransform requires patch_size > 0")
+            raise ValueError(
+                "MOSS-Audio-Tokenizer patched pretransform requires patch_size > 0"
+            )
         if bool(getattr(stage, "is_downsample", False)):
             return [int(length) // patch_size for length in input_lengths]
         return [int(length) * patch_size for length in input_lengths]
@@ -941,6 +440,32 @@ class MossAudioTokenizerVocoderDecoder(nn.Module):
             if cpu_lengths is not None:
                 cpu_lengths = self._update_cpu_lengths(stage, cpu_lengths)
         return x, input_lengths
+
+
+def create_sin_embedding(
+    positions: torch.Tensor,
+    dim: int,
+    *,
+    max_period: float = 10_000,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Create the sinusoidal embedding expected by the shared stage wrapper."""
+
+    if dim % 2:
+        raise ValueError(f"sinusoidal embedding requires an even dim, got {dim}")
+    half_dim = dim // 2
+    if half_dim <= 1:
+        raise ValueError(f"sinusoidal embedding requires dim >= 4, got {dim}")
+    positions = positions.to(dtype).unsqueeze(-1)
+    dimensions = torch.arange(half_dim, device=positions.device, dtype=dtype)
+    period = torch.full(
+        (),
+        float(max_period),
+        device=positions.device,
+        dtype=dtype,
+    )
+    phase = positions / (period ** (dimensions / (half_dim - 1)))
+    return torch.cat((torch.cos(phase), torch.sin(phase)), dim=-1)
 
 
 def _torch_dtype(dtype: str | torch.dtype) -> torch.dtype:
@@ -1024,7 +549,7 @@ class MossTTSAudioTokenizer:
         audio_codes_lengths = encoded.audio_codes_lengths
         if audio_codes is None or audio_codes_lengths is None:
             raise RuntimeError(
-                "MOSS-TTS audio tokenizer encode returned empty "
+                "MOSS-Audio-Tokenizer encode returned empty "
                 "audio_codes/audio_codes_lengths"
             )
         codes_cpu = audio_codes.detach().to(device="cpu", dtype=torch.long)
@@ -1098,7 +623,7 @@ class MossTTSAudioTokenizer:
         audio_lengths = decoded.audio_lengths
         if audio is None or audio_lengths is None:
             raise RuntimeError(
-                "MOSS-TTS audio tokenizer decode returned empty audio/audio_lengths"
+                "MOSS-Audio-Tokenizer decode returned empty audio/audio_lengths"
             )
         audio_cpu = audio.detach().to(device="cpu", dtype=torch.float32)
         lengths_cpu = audio_lengths.detach().to("cpu")
@@ -1124,7 +649,7 @@ def load_moss_tts_audio_tokenizer(
     device: str = "cpu",
     dtype: str | torch.dtype = "float32",
 ) -> MossTTSAudioTokenizer:
-    logger.info(f"Loading MOSS-TTS audio tokenizer from {model_path} on {device}")
+    logger.info(f"Loading MOSS-Audio-Tokenizer from {model_path} on {device}")
     try:
         with moss_transformers_processor_compat():
             model = AutoModel.from_pretrained(

--- a/sglang_omni/models/moss_tts/vocoder.py
+++ b/sglang_omni/models/moss_tts/vocoder.py
@@ -148,7 +148,7 @@ class MossTTSVocoder(BatchVocoderBase):
                 nonstream_decoder = MossAudioTokenizerVocoderDecoder(
                     self._codec.decoder
                 )
-                supports_packed_flash = nonstream_decoder.supports_packed_flash(
+                supports_packed_attention = nonstream_decoder.supports_packed_attention(
                     codec_device,
                     self._compute_dtype,
                 )
@@ -158,7 +158,7 @@ class MossTTSVocoder(BatchVocoderBase):
                     "packed decoder; falling back to standalone codec decode"
                 )
             else:
-                if supports_packed_flash:
+                if supports_packed_attention:
                     self._quantizer.to(dtype=torch.float32)
                     try:
                         self._quantizer_decoder = MossAudioTokenizerQuantizerDecoder(

--- a/tests/README.md
+++ b/tests/README.md
@@ -635,7 +635,10 @@ that happened to contain an older version of the test.
   - preprocessing handoff and abort cleanup behavior
   - delay-pattern runner, codec splitting, and seeded sampling contracts
   - incremental delay-row emission, bounded overlap decode parity, early-done
-    final-tail handling, and streaming abort cleanup.
+    final-tail handling, and streaming abort cleanup
+  - shared MOSS-Audio-Tokenizer transformer and vocoder decoder packing,
+    local-causal FlashAttention window equivalence, CUDA bf16 packed-vs-SDPA
+    parity, zero-length handling, and flash-unavailable fallback.
 
 - `unit_test/moss_tts_local/`: MOSS-TTS Local unit tests:
   - pipeline config, request builders, and scheduler adapter contracts
@@ -644,10 +647,7 @@ that happened to contain an older version of the test.
   - synchronous frame-decode parity harness and S0 gate coverage
   - streaming vocoder session lifecycle, per-request chunk-threshold and
     coalescing contracts, decode-failure isolation, and non-streaming full-sequence
-    decode through the codec path
-  - MOSS-TTS Local vocoder decoder packing, local-causal FlashAttention window
-    equivalence, CUDA bf16 packed-vs-SDPA parity, zero-length handling, and
-    flash-unavailable fallback.
+    decode through the codec path.
 
 - `unit_test/zonos2/`: ZONOS2 unit tests:
   - pipeline configuration, text normalization, and speaker/component caches

--- a/tests/unit_test/moss_tts/test_audio_tokenizer.py
+++ b/tests/unit_test/moss_tts/test_audio_tokenizer.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+"""Shared MOSS-Audio-Tokenizer transformer and decoder tests."""
 
 from __future__ import annotations
 
@@ -9,7 +10,7 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-import sglang_omni.models.moss_tts.audio_tokenizer as audio_tokenizer
+import sglang_omni.models.moss_tts.attention as attention_impl
 import sglang_omni.models.moss_tts.vocoder_kernels as vocoder_kernels
 from sglang_omni.models.moss_tts.audio_tokenizer import (
     MossAudioTokenizerAttention,
@@ -17,17 +18,6 @@ from sglang_omni.models.moss_tts.audio_tokenizer import (
     MossAudioTokenizerTransformerLayer,
     MossAudioTokenizerVocoderDecoder,
 )
-
-
-def create_sin_embedding(
-    positions: torch.Tensor,
-    dim: int,
-    *,
-    max_period: float,
-    dtype: torch.dtype,
-) -> torch.Tensor:
-    del max_period
-    return torch.zeros(*positions.shape, dim, device=positions.device, dtype=dtype)
 
 
 class _FakeLayerScale(nn.Module):
@@ -51,11 +41,6 @@ class _FakeAttention(nn.Module):
         self.attention_implementation = "sdpa"
         self.in_proj = nn.Linear(hidden_size, 3 * hidden_size, bias=False)
         self.out_proj = nn.Linear(hidden_size, hidden_size, bias=False)
-
-    def resolve_attention_implementation(
-        self, _: torch.Tensor, *, is_streaming: bool = False
-    ) -> str:
-        return "sdpa"
 
     def _get_backend_check_dtype(self, x: torch.Tensor) -> torch.dtype:
         return x.dtype
@@ -115,9 +100,6 @@ class _FallbackTransformer(nn.Module):
         self.positional_embedding = "rope"
         self.positional_scale = 1.0
         self.max_period = 10000.0
-
-    def resolve_attention_implementation(self, _: torch.Tensor) -> str:
-        return "sdpa"
 
 
 class _FallbackProjectedStage(nn.Module):
@@ -201,7 +183,7 @@ class _CountingLayer(_FakeLayer):
         self.layer_scale_2 = _CountingLayerScale(hidden_size)
 
 
-class _V1WeightsAttention(nn.Module):
+class _MossAudioTokenizerV1Attention(nn.Module):
     def __init__(self, hidden_size: int) -> None:
         super().__init__()
         self.embed_dim = hidden_size
@@ -226,11 +208,11 @@ class _V1WeightsAttention(nn.Module):
         return query
 
 
-class _V1WeightsLayer(nn.Module):
+class _MossAudioTokenizerV1Layer(nn.Module):
     def __init__(self, hidden_size: int) -> None:
         super().__init__()
         self.norm1 = nn.LayerNorm(hidden_size)
-        self.self_attn = _V1WeightsAttention(hidden_size)
+        self.self_attn = _MossAudioTokenizerV1Attention(hidden_size)
         self.layer_scale_1 = _FakeLayerScale(hidden_size)
         self.norm2 = nn.LayerNorm(hidden_size)
         self.linear1 = nn.Linear(hidden_size, hidden_size * 2)
@@ -239,20 +221,20 @@ class _V1WeightsLayer(nn.Module):
         self.layer_scale_2 = _FakeLayerScale(hidden_size)
 
 
-class _V1WeightsTransformer(_FallbackTransformer):
+class _MossAudioTokenizerV1Transformer(_FallbackTransformer):
     def __init__(self, hidden_size: int) -> None:
         nn.Module.__init__(self)
-        self.layers = nn.ModuleList([_V1WeightsLayer(hidden_size)])
+        self.layers = nn.ModuleList([_MossAudioTokenizerV1Layer(hidden_size)])
         self.positional_embedding = "rope"
         self.positional_scale = 1.0
         self.max_period = 10000.0
 
 
-class _V1WeightsProjectedStage(_FallbackProjectedStage):
+class _MossAudioTokenizerV1ProjectedStage(_FallbackProjectedStage):
     def __init__(self) -> None:
         nn.Module.__init__(self)
         self.input_proj = nn.Linear(3, 6)
-        self.transformer = _V1WeightsTransformer(6)
+        self.transformer = _MossAudioTokenizerV1Transformer(6)
         self.output_proj = nn.Linear(6, 7)
         self.is_streaming = False
         self.module_type = "Transformer"
@@ -261,7 +243,7 @@ class _V1WeightsProjectedStage(_FallbackProjectedStage):
 
 def test_projected_transformer_sdpa_path_does_not_reenter_source_stage() -> None:
     source = _FallbackProjectedStage()
-    wrapper = MossAudioTokenizerProjectedTransformer(source)
+    wrapper = MossAudioTokenizerProjectedTransformer.from_module(source)
     x = torch.randn(2, 3, 4)
     lengths = torch.tensor([4, 3])
 
@@ -272,11 +254,11 @@ def test_projected_transformer_sdpa_path_does_not_reenter_source_stage() -> None
     assert torch.equal(out_lengths, lengths)
 
 
-def test_projected_transformer_shares_packed_rope_cache_across_layers() -> None:
+def test_projected_transformer_shares_attention_caches_across_layers() -> None:
     source = _FallbackProjectedStage()
     source.transformer.layers.append(_FakeLayer(6))
 
-    wrapper = MossAudioTokenizerProjectedTransformer(source)
+    wrapper = MossAudioTokenizerProjectedTransformer.from_module(source)
     caches = [
         layer.self_attn._packed_rope_cache for layer in wrapper.transformer.layers
     ]
@@ -291,9 +273,9 @@ def test_projected_transformer_uses_sglang_packed_flash_path() -> None:
         "flash_attention_2"
     )
     source.transformer.layers[0].self_attn.context = None
-    wrapper = MossAudioTokenizerProjectedTransformer(source)
+    wrapper = MossAudioTokenizerProjectedTransformer.from_module(source)
     attn = wrapper.transformer.layers[0].self_attn
-    attn._can_run_packed_flash = lambda _: True  # type: ignore[method-assign]
+    attn._packed_flash_unavailable_reason = lambda *args: None
     calls = []
 
     def fake_flash_attn(
@@ -329,55 +311,10 @@ def test_projected_transformer_uses_sglang_packed_flash_path() -> None:
     assert torch.equal(out_lengths, lengths)
 
 
-def test_projected_transformer_uses_host_lengths_without_tensor_max(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    source = _FallbackProjectedStage()
-    source.transformer.layers[0].self_attn.attention_implementation = (
-        "flash_attention_2"
-    )
-    source.transformer.layers[0].self_attn.context = None
-    wrapper = MossAudioTokenizerProjectedTransformer(source)
-    attention = wrapper.transformer.layers[0].self_attn
-    attention._can_run_packed_flash = lambda _: True  # type: ignore[method-assign]
-    attention._flash_attn_varlen = lambda q, *_, **__: q
-
-    def fail_max(*_: object, **__: object) -> None:
-        raise AssertionError("host lengths must avoid reading the length tensor")
-
-    monkeypatch.setattr(torch.Tensor, "max", fail_max)
-    x = torch.randn(1, 3, 4)
-    lengths = torch.tensor([4])
-
-    out, out_lengths = wrapper(x, lengths, input_lengths_cpu=[4])
-
-    assert out.shape == (1, 7, 4)
-    assert out_lengths is lengths
-
-
-def test_packed_flash_unavailable_uses_source_attention(monkeypatch) -> None:
-    monkeypatch.setattr(audio_tokenizer, "flash_attn_varlen_func", None)
-    source = _FallbackProjectedStage()
-    source.transformer.layers[0].self_attn.attention_implementation = (
-        "flash_attention_2"
-    )
-    source.transformer.layers[0].self_attn.context = None
-    wrapper = MossAudioTokenizerProjectedTransformer(source)
-    x = torch.randn(2, 3, 4)
-    lengths = torch.tensor([4, 3])
-
-    out, out_lengths = wrapper(x, lengths)
-
-    assert wrapper.transformer.layers[0].self_attn._flash_attn_varlen is None
-    assert source.seen_input_shape is None
-    assert out.shape == (2, 7, 4)
-    assert torch.equal(out_lengths, lengths)
-
-
 def test_local_causal_flash_plan_chunks_queries_and_overlaps_keys() -> None:
     cu_seqlens = torch.tensor([0, 320, 577], dtype=torch.int32)
 
-    plan = audio_tokenizer._build_local_causal_flash_plan(
+    plan = attention_impl._build_local_causal_flash_plan(
         cu_seqlens,
         context=125,
     )
@@ -403,12 +340,475 @@ def test_local_causal_flash_plan_chunks_queries_and_overlaps_keys() -> None:
 def test_local_causal_flash_plan_skips_identity_kv_gather() -> None:
     cu_seqlens = torch.tensor([0, 80, 180], dtype=torch.int32)
 
-    plan = audio_tokenizer._build_local_causal_flash_plan(
+    plan = attention_impl._build_local_causal_flash_plan(
         cu_seqlens,
         context=125,
     )
 
     assert plan.kv_indices is None
+
+
+def test_projected_transformer_chunks_local_packed_flash_queries() -> None:
+    source = _FallbackProjectedStage()
+    source.transformer.layers[0].self_attn.attention_implementation = (
+        "flash_attention_2"
+    )
+    source.transformer.layers[0].self_attn.context = 125
+    wrapper = MossAudioTokenizerProjectedTransformer.from_module(source)
+    attention = wrapper.transformer.layers[0].self_attn
+    attention._packed_flash_unavailable_reason = lambda *args: None
+    calls = []
+
+    def fake_flash_attn(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cu_q: torch.Tensor,
+        cu_k: torch.Tensor,
+        max_q: int,
+        max_k: int,
+        *,
+        causal: bool,
+        window_size: tuple[int, int],
+    ) -> torch.Tensor:
+        calls.append(
+            (
+                q.shape,
+                k.shape,
+                v.shape,
+                cu_q.clone(),
+                cu_k.clone(),
+                max_q,
+                max_k,
+                causal,
+                window_size,
+            )
+        )
+        return q
+
+    attention._flash_attn_varlen = fake_flash_attn
+    x = torch.randn(2, 3, 320)
+    lengths = torch.tensor([320, 257])
+
+    out, out_lengths = wrapper(x, lengths)
+
+    assert len(calls) == 1
+    q_shape, k_shape, v_shape, cu_q, cu_k, max_q, max_k, causal, window_size = calls[0]
+    assert q_shape == (577, 2, 3)
+    assert k_shape == v_shape == (1073, 2, 3)
+    assert cu_q.tolist() == [0, 128, 256, 320, 448, 576, 577]
+    assert cu_k.tolist() == [0, 128, 380, 568, 696, 948, 1073]
+    assert max_q == 128
+    assert max_k == 252
+    assert causal is True
+    assert window_size == (124, 0)
+    assert out.shape == (2, 7, 320)
+    assert torch.equal(out_lengths, lengths)
+
+
+def test_projected_transformer_skips_local_plan_for_direct_sm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _FallbackProjectedStage()
+    source.transformer.layers[0].self_attn.attention_implementation = (
+        "flash_attention_2"
+    )
+    source.transformer.layers[0].self_attn.context = 125
+    wrapper = MossAudioTokenizerProjectedTransformer.from_module(source)
+    attention = wrapper.transformer.layers[0].self_attn
+    attention._packed_flash_unavailable_reason = lambda *args: None
+    monkeypatch.setattr(
+        attention_impl,
+        "_packed_flash_requires_query_chunks",
+        lambda device: False,
+    )
+    calls = []
+
+    def fake_flash_attn(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cu_q: torch.Tensor,
+        cu_k: torch.Tensor,
+        max_q: int,
+        max_k: int,
+        *,
+        causal: bool,
+        window_size: tuple[int, int],
+    ) -> torch.Tensor:
+        calls.append((cu_q.clone(), cu_k.clone(), max_q, max_k, causal, window_size))
+        return q
+
+    attention._flash_attn_varlen = fake_flash_attn
+    out, out_lengths = wrapper(
+        torch.randn(2, 3, 320),
+        torch.tensor([320, 257]),
+    )
+
+    assert len(calls) == 1
+    cu_q, cu_k, max_q, max_k, causal, window_size = calls[0]
+    assert cu_q.tolist() == [0, 320, 577]
+    assert torch.equal(cu_q, cu_k)
+    assert max_q == max_k == 320
+    assert causal is True
+    assert window_size == (124, 0)
+    assert out.shape == (2, 7, 320)
+    assert torch.equal(out_lengths, torch.tensor([320, 257]))
+
+
+def test_projected_transformer_reuses_local_flash_plan_across_layers() -> None:
+    source = _FallbackProjectedStage()
+    source.transformer.layers.append(_FakeLayer(6))
+    for layer in source.transformer.layers:
+        layer.self_attn.attention_implementation = "flash_attention_2"
+        layer.self_attn.context = 125
+    wrapper = MossAudioTokenizerProjectedTransformer.from_module(source)
+    calls = []
+
+    def fake_flash_attn(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cu_q: torch.Tensor,
+        cu_k: torch.Tensor,
+        max_q: int,
+        max_k: int,
+        *,
+        causal: bool,
+        window_size: tuple[int, int],
+    ) -> torch.Tensor:
+        calls.append((cu_q.data_ptr(), cu_k.data_ptr()))
+        return q
+
+    for layer in wrapper.transformer.layers:
+        layer.self_attn._packed_flash_unavailable_reason = lambda *args: None
+        layer.self_attn._flash_attn_varlen = fake_flash_attn
+
+    _, out_lengths = wrapper(
+        torch.randn(2, 3, 320),
+        torch.tensor([320, 257]),
+    )
+
+    assert len(calls) == 2
+    assert calls[0] == calls[1]
+    assert torch.equal(out_lengths, torch.tensor([320, 257]))
+
+
+def test_projected_transformer_uses_host_lengths_without_tensor_max(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _FallbackProjectedStage()
+    source.transformer.layers[0].self_attn.attention_implementation = (
+        "flash_attention_2"
+    )
+    source.transformer.layers[0].self_attn.context = None
+    wrapper = MossAudioTokenizerProjectedTransformer.from_module(source)
+    attention = wrapper.transformer.layers[0].self_attn
+    attention._packed_flash_unavailable_reason = lambda *args: None
+    attention._flash_attn_varlen = lambda q, *_, **__: q
+
+    def fail_max(*_: object, **__: object) -> None:
+        raise AssertionError("host lengths must avoid reading the length tensor")
+
+    monkeypatch.setattr(torch.Tensor, "max", fail_max)
+    x = torch.randn(1, 3, 4)
+    lengths = torch.tensor([4])
+
+    out, out_lengths = wrapper(x, lengths, input_lengths_cpu=[4])
+
+    assert out.shape == (1, 7, 4)
+    assert out_lengths is lengths
+
+
+def test_attention_backend_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        attention_impl,
+        "_packed_flash_device_unavailable_reason",
+        lambda device: "test kernel unavailable",
+    )
+    source = _FakeAttention(hidden_size=6)
+    source.attention_implementation = "flash_attention_2"
+
+    automatic = MossAudioTokenizerAttention.from_module(source)
+    resolution = automatic.resolve_attention_backend(
+        torch.device("cuda"),
+        torch.bfloat16,
+    )
+    assert resolution.backend == "sdpa"
+    assert resolution.fallback_reason == "test kernel unavailable"
+
+    sdpa = MossAudioTokenizerAttention.from_module(
+        source,
+        attention_backend="sdpa",
+    )
+    assert (
+        sdpa.resolve_attention_backend(torch.device("cuda"), torch.bfloat16).backend
+        == "sdpa"
+    )
+
+    strict_packed_flash = MossAudioTokenizerAttention.from_module(
+        source,
+        attention_backend="packed_flash_attention",
+    )
+    with pytest.raises(RuntimeError, match="test kernel unavailable"):
+        strict_packed_flash.resolve_attention_backend(
+            torch.device("cuda"),
+            torch.bfloat16,
+        )
+    with pytest.raises(ValueError, match="packed_flash_attention"):
+        MossAudioTokenizerAttention.from_module(
+            source,
+            attention_backend="flash_attention_2",
+        )
+
+
+@pytest.mark.parametrize(
+    ("capability", "requires_chunks"),
+    [((8, 0), True), ((8, 9), True), ((9, 0), False), ((10, 0), False)],
+)
+def test_packed_flash_query_chunk_policy_uses_sm(
+    monkeypatch: pytest.MonkeyPatch,
+    capability: tuple[int, int],
+    requires_chunks: bool,
+) -> None:
+    attention_impl._packed_flash_requires_query_chunks.cache_clear()
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_capability",
+        lambda device: capability,
+    )
+
+    assert (
+        attention_impl._packed_flash_requires_query_chunks(torch.device("cuda"))
+        is requires_chunks
+    )
+
+
+def test_packed_flash_query_chunk_policy_caches_device_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attention_impl._packed_flash_requires_query_chunks.cache_clear()
+    calls = []
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    def get_device_capability(device: torch.device) -> tuple[int, int]:
+        calls.append(device)
+        return (9, 0)
+
+    monkeypatch.setattr(torch.cuda, "get_device_capability", get_device_capability)
+    device = torch.device("cuda")
+
+    assert not attention_impl._packed_flash_requires_query_chunks(device)
+    assert not attention_impl._packed_flash_requires_query_chunks(device)
+    assert calls == [device]
+
+
+def test_packed_flash_policy_uses_sglang_fa3_predicate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+
+    def sglang_fa3_supported() -> bool:
+        calls.append(True)
+        return True
+
+    monkeypatch.setattr(
+        attention_impl,
+        "_is_fa3_supported",
+        sglang_fa3_supported,
+    )
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    assert (
+        attention_impl._packed_flash_device_unavailable_reason(torch.device("cuda"))
+        is None
+    )
+    assert calls == [True]
+
+
+def test_packed_flash_policy_requires_sglang_fa3(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        attention_impl,
+        "_is_fa3_supported",
+        lambda: False,
+    )
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    reason = attention_impl._packed_flash_device_unavailable_reason(
+        torch.device("cuda")
+    )
+    assert reason == "SGLang packed FlashAttention (FA3) is unavailable"
+
+
+def test_auto_backend_falls_back_when_sglang_fa3_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        attention_impl,
+        "_is_fa3_supported",
+        lambda: False,
+    )
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    source = _FakeAttention(hidden_size=6)
+    source.attention_implementation = "flash_attention_2"
+    attention = MossAudioTokenizerAttention.from_module(source)
+    resolution = attention.resolve_attention_backend(
+        torch.device("cuda"),
+        torch.bfloat16,
+    )
+
+    assert resolution.backend == "sdpa"
+    assert (
+        resolution.fallback_reason
+        == "SGLang packed FlashAttention (FA3) is unavailable"
+    )
+
+
+def test_attention_backend_auto_falls_back_for_cuda_float32(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        attention_impl,
+        "_packed_flash_device_unavailable_reason",
+        lambda device: None,
+    )
+    source = _FakeAttention(hidden_size=6)
+    source.attention_implementation = "flash_attention_2"
+    attention = MossAudioTokenizerAttention.from_module(source)
+    attention._flash_attn_varlen = lambda *args, **kwargs: None
+
+    resolution = attention.resolve_attention_backend(
+        torch.device("cuda"),
+        torch.float32,
+    )
+
+    assert resolution.backend == "sdpa"
+    assert "requires torch.bfloat16" in str(resolution.fallback_reason)
+
+
+@pytest.mark.parametrize(
+    ("causal", "context"),
+    [(True, 125), (False, None)],
+)
+def test_query_chunked_sdpa_matches_dense_reference(
+    causal: bool,
+    context: int | None,
+) -> None:
+    torch.manual_seed(0)
+    source = _ReferenceAttention(hidden_size=12, num_heads=3)
+    source.causal = causal
+    source.context = context
+    wrapper = MossAudioTokenizerAttention.from_module(
+        source,
+        attention_backend="sdpa",
+    )
+    x = torch.randn(2, 641, 12)
+    input_lengths = torch.tensor([641, 517])
+
+    expected = source(x, input_lengths=input_lengths)
+    actual = wrapper(x, input_lengths=input_lengths)
+
+    torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-4)
+
+
+def test_query_chunked_sdpa_matches_dense_reference_cuda() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+
+    torch.manual_seed(0)
+    source = _ReferenceAttention(hidden_size=128, num_heads=2).to(
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    source.context = 125
+    wrapper = MossAudioTokenizerAttention.from_module(
+        source,
+        attention_backend="sdpa",
+    )
+    x = torch.randn(2, 641, 128, device="cuda", dtype=torch.bfloat16)
+    input_lengths = torch.tensor([641, 517], device="cuda")
+
+    expected = source(x, input_lengths=input_lengths)
+    actual = wrapper(x, input_lengths=input_lengths)
+
+    torch.testing.assert_close(actual, expected, atol=4e-2, rtol=3e-2)
+
+
+def test_auto_backend_runs_query_chunked_sdpa_for_cuda_float32() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+
+    torch.manual_seed(0)
+    source = _ReferenceAttention(hidden_size=128, num_heads=2).to(device="cuda")
+    source.attention_implementation = "flash_attention_2"
+    source.context = 125
+    wrapper = MossAudioTokenizerAttention.from_module(source)
+    x = torch.randn(2, 641, 128, device="cuda")
+    input_lengths = torch.tensor([641, 517], device="cuda")
+
+    expected = source(x, input_lengths=input_lengths)
+    actual = wrapper(x, input_lengths=input_lengths)
+
+    assert wrapper.resolve_attention_backend(x.device, x.dtype).backend == "sdpa"
+    torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-4)
+
+
+def test_query_chunked_sdpa_bounds_local_attention_shapes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _FakeAttention(hidden_size=6)
+    source.context = 125
+    wrapper = MossAudioTokenizerAttention.from_module(
+        source,
+        attention_backend="sdpa",
+    )
+    original_sdpa = F.scaled_dot_product_attention
+    shapes = []
+
+    def record_sdpa(
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        *args,
+        **kwargs,
+    ) -> torch.Tensor:
+        shapes.append((query.shape[-2], key.shape[-2]))
+        return original_sdpa(query, key, value, *args, **kwargs)
+
+    monkeypatch.setattr(F, "scaled_dot_product_attention", record_sdpa)
+    output = wrapper(
+        torch.randn(2, 1200, 6),
+        input_lengths=torch.tensor([1200, 701]),
+    )
+
+    assert output.shape == (2, 1200, 6)
+    assert [query_length for query_length, _ in shapes] == [512, 512, 176]
+    assert all(query_length <= 512 for query_length, _ in shapes)
+    assert all(key_length <= source.context + 511 for _, key_length in shapes)
+
+
+def test_query_chunked_sdpa_handles_empty_and_zero_length_inputs() -> None:
+    source = _FakeAttention(hidden_size=6)
+    wrapper = MossAudioTokenizerAttention.from_module(
+        source,
+        attention_backend="sdpa",
+    )
+
+    empty = wrapper(
+        torch.empty(2, 0, 6),
+        input_lengths=torch.zeros(2, dtype=torch.long),
+    )
+    padded = wrapper(
+        torch.randn(2, 513, 6),
+        input_lengths=torch.tensor([513, 0]),
+    )
+
+    assert empty.shape == (2, 0, 6)
+    assert torch.isfinite(padded).all()
+    assert torch.count_nonzero(padded[1]) == 0
 
 
 def test_local_causal_attention_keeps_packed_flash_cuda() -> None:
@@ -419,11 +819,17 @@ def test_local_causal_attention_keeps_packed_flash_cuda() -> None:
     source.attention_implementation = "flash_attention_2"
     source.causal = True
     source.context = 4
-    attn = MossAudioTokenizerAttention(source)
+    attn = MossAudioTokenizerAttention.from_module(
+        source,
+        attention_backend="packed_flash_attention",
+    )
     attn._flash_attn_varlen = lambda *_, **__: torch.empty(0, device="cuda")
     x = torch.empty(1, 6, device="cuda", dtype=torch.bfloat16)
 
-    assert attn._can_run_packed_flash(x)
+    assert (
+        attn.resolve_attention_backend(x.device, x.dtype).backend
+        == "packed_flash_attention"
+    )
 
 
 def test_projected_transformer_skips_flash_for_zero_valid_length(monkeypatch) -> None:
@@ -432,9 +838,9 @@ def test_projected_transformer_skips_flash_for_zero_valid_length(monkeypatch) ->
         "flash_attention_2"
     )
     source.transformer.layers[0].self_attn.context = None
-    wrapper = MossAudioTokenizerProjectedTransformer(source)
+    wrapper = MossAudioTokenizerProjectedTransformer.from_module(source)
     attn = wrapper.transformer.layers[0].self_attn
-    attn._can_run_packed_flash = lambda _: True  # type: ignore[method-assign]
+    attn._packed_flash_unavailable_reason = lambda *args: None
 
     def fail_flash(*_: object, **__: object) -> None:
         raise AssertionError("zero-length input must not call flash attention")
@@ -443,7 +849,7 @@ def test_projected_transformer_skips_flash_for_zero_valid_length(monkeypatch) ->
         raise AssertionError("zero-length input must not pack padded frames")
 
     attn._flash_attn_varlen = fail_flash
-    monkeypatch.setattr(audio_tokenizer, "_pack_padded_sequence", fail_pack)
+    monkeypatch.setattr(attention_impl, "pack_padded_sequence", fail_pack)
     x = torch.randn(2, 3, 4)
     lengths = torch.tensor([0, 0])
 
@@ -469,9 +875,9 @@ def test_flash_window_size_matches_moss_local_mask(
     source = _FakeAttention(hidden_size=6)
     source.context = context
     source.causal = causal
-    attn = MossAudioTokenizerAttention(source)
+    attn = MossAudioTokenizerAttention.from_module(source)
 
-    assert attn._flash_window_size() == expected
+    assert attention_impl._flash_window_size(attn.causal, attn.context) == expected
 
 
 def test_flash_window_size_keeps_same_keys_as_moss_mask() -> None:
@@ -479,8 +885,11 @@ def test_flash_window_size_keeps_same_keys_as_moss_mask() -> None:
     seqlen = 7
     source = _FakeAttention(hidden_size=6)
     source.context = context
-    attn = MossAudioTokenizerAttention(source)
-    left_window, right_window = attn._flash_window_size()
+    attn = MossAudioTokenizerAttention.from_module(source)
+    left_window, right_window = attention_impl._flash_window_size(
+        attn.causal,
+        attn.context,
+    )
     positions = torch.arange(seqlen)
     moss_mask = (positions.view(seqlen, 1) - positions.view(1, seqlen) >= 0) & (
         positions.view(seqlen, 1) - positions.view(1, seqlen) < context
@@ -502,9 +911,9 @@ def test_projected_transformer_uses_single_unpadded_pack_fast_path(
         "flash_attention_2"
     )
     source.transformer.layers[0].self_attn.context = None
-    wrapper = MossAudioTokenizerProjectedTransformer(source)
+    wrapper = MossAudioTokenizerProjectedTransformer.from_module(source)
     attn = wrapper.transformer.layers[0].self_attn
-    attn._can_run_packed_flash = lambda _: True  # type: ignore[method-assign]
+    attn._packed_flash_unavailable_reason = lambda *args: None
     calls = []
 
     def fail_masked_pack(_: torch.Tensor, __: torch.Tensor) -> None:
@@ -525,7 +934,7 @@ def test_projected_transformer_uses_single_unpadded_pack_fast_path(
         calls.append((q.shape, cu_q.clone(), cu_k.clone(), max_q, max_k))
         return q
 
-    monkeypatch.setattr(audio_tokenizer, "_pack_padded_sequence", fail_masked_pack)
+    monkeypatch.setattr(attention_impl, "pack_padded_sequence", fail_masked_pack)
     attn._flash_attn_varlen = fake_flash_attn
     x = torch.randn(1, 3, 4)
     lengths = torch.tensor([4])
@@ -547,13 +956,13 @@ def test_projected_transformer_uses_single_unpadded_pack_fast_path(
 
 
 def test_single_unpadded_pack_position_cache_grows_and_slices() -> None:
-    cache = audio_tokenizer._PositionIdsCache()
+    cache = attention_impl.PositionIdsCache()
     x_short = torch.randn(1, 4, 6)
     x_long = torch.randn(1, 6, 6)
 
-    _, cu_short_1, pos_short_1 = audio_tokenizer._pack_unpadded_sequence(x_short, cache)
-    _, cu_long, pos_long = audio_tokenizer._pack_unpadded_sequence(x_long, cache)
-    _, cu_short_2, pos_short_2 = audio_tokenizer._pack_unpadded_sequence(x_short, cache)
+    _, cu_short_1, pos_short_1 = attention_impl.pack_unpadded_sequence(x_short, cache)
+    _, cu_long, pos_long = attention_impl.pack_unpadded_sequence(x_long, cache)
+    _, cu_short_2, pos_short_2 = attention_impl.pack_unpadded_sequence(x_short, cache)
 
     assert cu_short_1.tolist() == [0, 4]
     assert cu_long.tolist() == [0, 6]
@@ -568,23 +977,23 @@ def test_host_length_pack_and_unpack_matches_masked_path() -> None:
     x = torch.randn(3, 5, 7)
     lengths = torch.tensor([5, 2, 4], dtype=torch.int32)
     expected_packed, valid_mask, expected_cu, expected_positions = (
-        audio_tokenizer._pack_padded_sequence(x, lengths)
+        attention_impl.pack_padded_sequence(x, lengths)
     )
 
     packed, flat_indices, cu_seqlens, position_ids = (
-        audio_tokenizer._pack_padded_sequence_from_host_lengths(
+        attention_impl.pack_padded_sequence_from_host_lengths(
             x,
             lengths,
             [5, 2, 4],
         )
     )
-    expected_unpacked = audio_tokenizer._unpack_packed_sequence(
+    expected_unpacked = attention_impl.unpack_packed_sequence(
         expected_packed,
         valid_mask,
         batch_size=3,
         max_seqlen=5,
     )
-    unpacked = audio_tokenizer._unpack_packed_sequence_from_indices(
+    unpacked = attention_impl.unpack_packed_sequence_from_indices(
         packed,
         flat_indices,
         batch_size=3,
@@ -603,9 +1012,9 @@ def test_projected_transformer_single_padded_input_uses_masked_pack() -> None:
         "flash_attention_2"
     )
     source.transformer.layers[0].self_attn.context = None
-    wrapper = MossAudioTokenizerProjectedTransformer(source)
+    wrapper = MossAudioTokenizerProjectedTransformer.from_module(source)
     attn = wrapper.transformer.layers[0].self_attn
-    attn._can_run_packed_flash = lambda _: True  # type: ignore[method-assign]
+    attn._packed_flash_unavailable_reason = lambda *args: None
     calls = []
 
     def fake_flash_attn(
@@ -620,7 +1029,16 @@ def test_projected_transformer_single_padded_input_uses_masked_pack() -> None:
         causal: bool,
         window_size: tuple[int, int],
     ) -> torch.Tensor:
-        calls.append((q.shape, cu_q.clone(), cu_k.clone(), max_q, max_k))
+        calls.append(
+            (
+                q.shape,
+                cu_q.clone(),
+                cu_k.clone(),
+                max_q,
+                max_k,
+                tuple(tensor.is_contiguous() for tensor in (q, k, v)),
+            )
+        )
         return q
 
     attn._flash_attn_varlen = fake_flash_attn
@@ -630,12 +1048,13 @@ def test_projected_transformer_single_padded_input_uses_masked_pack() -> None:
     out, out_lengths = wrapper(x, lengths)
 
     assert len(calls) == 1
-    q_shape, cu_q, cu_k, max_q, max_k = calls[0]
+    q_shape, cu_q, cu_k, max_q, max_k, qkv_contiguous = calls[0]
     assert q_shape[0] == 2
     assert cu_q.tolist() == [0, 2]
     assert cu_k.tolist() == [0, 2]
     assert max_q == 2
     assert max_k == 2
+    assert qkv_contiguous == (False, False, False)
     assert out.shape == (1, 7, 4)
     assert torch.equal(out_lengths, lengths)
 
@@ -643,8 +1062,11 @@ def test_projected_transformer_single_padded_input_uses_masked_pack() -> None:
 def test_sglang_packed_flash_matches_sdpa_reference_cuda() -> None:
     if not torch.cuda.is_available():
         pytest.skip("requires CUDA")
-    if audio_tokenizer.flash_attn_varlen_func is None:
-        pytest.skip("requires SGLang flash_attn_varlen_func")
+    unavailable_reason = attention_impl._packed_flash_device_unavailable_reason(
+        torch.device("cuda")
+    )
+    if unavailable_reason is not None:
+        pytest.skip(unavailable_reason)
 
     torch.manual_seed(0)
     device = torch.device("cuda")
@@ -653,12 +1075,12 @@ def test_sglang_packed_flash_matches_sdpa_reference_cuda() -> None:
     )
     source.attention_implementation = "flash_attention_2"
     source.context = None
-    wrapper = MossAudioTokenizerAttention(source)
+    wrapper = MossAudioTokenizerAttention.from_module(source)
     x = torch.randn(2, 6, 128, device=device, dtype=torch.bfloat16)
     input_lengths = torch.tensor([6, 4], device=device)
 
     packed_x, valid_mask, cu_seqlens, position_ids = (
-        audio_tokenizer._pack_padded_sequence(x, input_lengths)
+        attention_impl.pack_padded_sequence(x, input_lengths)
     )
     packed_out = wrapper(
         packed_x,
@@ -666,7 +1088,7 @@ def test_sglang_packed_flash_matches_sdpa_reference_cuda() -> None:
         max_seqlen=6,
         position_ids=position_ids,
     )
-    flash_out = audio_tokenizer._unpack_packed_sequence(
+    flash_out = attention_impl.unpack_packed_sequence(
         packed_out, valid_mask, batch_size=2, max_seqlen=6
     )
     sdpa_out = source(x, input_lengths=input_lengths)
@@ -674,11 +1096,14 @@ def test_sglang_packed_flash_matches_sdpa_reference_cuda() -> None:
     torch.testing.assert_close(flash_out, sdpa_out, atol=4e-2, rtol=3e-2)
 
 
-def test_sglang_chunked_local_flash_matches_sdpa_reference_cuda() -> None:
+def test_sglang_local_packed_flash_matches_sdpa_reference_cuda() -> None:
     if not torch.cuda.is_available():
         pytest.skip("requires CUDA")
-    if audio_tokenizer.flash_attn_varlen_func is None:
-        pytest.skip("requires SGLang flash_attn_varlen_func")
+    unavailable_reason = attention_impl._packed_flash_device_unavailable_reason(
+        torch.device("cuda")
+    )
+    if unavailable_reason is not None:
+        pytest.skip(unavailable_reason)
 
     torch.manual_seed(0)
     device = torch.device("cuda")
@@ -687,25 +1112,20 @@ def test_sglang_chunked_local_flash_matches_sdpa_reference_cuda() -> None:
     )
     source.attention_implementation = "flash_attention_2"
     source.context = 400
-    wrapper = MossAudioTokenizerAttention(source)
+    wrapper = MossAudioTokenizerAttention.from_module(source)
     x = torch.randn(2, 1024, 128, device=device, dtype=torch.bfloat16)
     input_lengths = torch.tensor([1024, 701], device=device)
 
     packed_x, valid_mask, cu_seqlens, position_ids = (
-        audio_tokenizer._pack_padded_sequence(x, input_lengths)
-    )
-    local_flash_plan = audio_tokenizer._build_local_causal_flash_plan(
-        cu_seqlens,
-        context=400,
+        attention_impl.pack_padded_sequence(x, input_lengths)
     )
     packed_out = wrapper(
         packed_x,
         cu_seqlens=cu_seqlens,
         max_seqlen=1024,
         position_ids=position_ids,
-        local_flash_plan=local_flash_plan,
     )
-    flash_out = audio_tokenizer._unpack_packed_sequence(
+    flash_out = attention_impl.unpack_packed_sequence(
         packed_out, valid_mask, batch_size=2, max_seqlen=1024
     )
     sdpa_out = source(x, input_lengths=input_lengths)
@@ -718,9 +1138,9 @@ def test_cached_packed_rope_matches_moss_interleaved_reference() -> None:
     k = torch.randn(5, 2, 6)
     position_ids = torch.tensor([0, 1, 2, 3, 4])
     max_period = 10000.0
-    cache = audio_tokenizer._MossPackedRopeCache(max_period=max_period)
+    cache = attention_impl.MossPackedRopeCache(max_period=max_period)
 
-    out_q, out_k = audio_tokenizer._apply_cached_packed_rope(
+    out_q, out_k = attention_impl._apply_cached_packed_rope(
         q,
         k,
         position_ids,
@@ -776,18 +1196,18 @@ def test_exact_packed_rope_matches_reference_cuda(dtype: torch.dtype) -> None:
         [0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 5],
         device="cuda",
     )
-    cache = audio_tokenizer._MossPackedRopeCache(max_period=10000.0)
-    reference_q, reference_k = audio_tokenizer._apply_cached_packed_rope(
+    cache = attention_impl.MossPackedRopeCache(max_period=10000.0)
+    reference_q, reference_k = attention_impl._apply_cached_packed_rope(
         q.cpu(),
         k.cpu(),
         position_ids.cpu(),
         max_positions=6,
-        cache=audio_tokenizer._MossPackedRopeCache(max_period=10000.0),
+        cache=attention_impl.MossPackedRopeCache(max_period=10000.0),
     )
     assert not q.is_contiguous()
     assert not k.is_contiguous()
 
-    actual_q, actual_k = audio_tokenizer._apply_cached_packed_rope(
+    actual_q, actual_k = attention_impl._apply_cached_packed_rope(
         q,
         k,
         position_ids,
@@ -801,7 +1221,7 @@ def test_exact_packed_rope_matches_reference_cuda(dtype: torch.dtype) -> None:
 
 def test_transformer_layer_uses_source_modules_for_primitive_ops() -> None:
     source = _CountingLayer(hidden_size=6)
-    wrapper = MossAudioTokenizerTransformerLayer(source)
+    wrapper = MossAudioTokenizerTransformerLayer.from_module(source)
     x = torch.randn(2, 4, 6)
 
     _ = wrapper(x, input_lengths=torch.tensor([4, 4]))
@@ -838,21 +1258,33 @@ def test_vocoder_decoder_computes_output_lengths_on_host() -> None:
     assert wrapped.output_lengths([3, 5]) == [12, 20]
 
 
-def test_vocoder_decoder_requires_packed_flash_for_every_transformer() -> None:
-    v1_weights_source = _V1WeightsProjectedStage()
-    v1_weights_decoder = MossAudioTokenizerVocoderDecoder(
-        nn.ModuleList([v1_weights_source])
+def test_vocoder_decoder_requires_packed_attention_for_every_transformer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        attention_impl,
+        "_packed_flash_device_unavailable_reason",
+        lambda device: None if device.type == "cuda" else "not CUDA",
     )
-    v1_weights_attention = v1_weights_decoder[0].transformer.layers[0].self_attn
-    v1_weights_attention._flash_attn_varlen = lambda *args, **kwargs: None
+    moss_audio_tokenizer_v1_source = _MossAudioTokenizerV1ProjectedStage()
+    moss_audio_tokenizer_v1_decoder = MossAudioTokenizerVocoderDecoder(
+        nn.ModuleList([moss_audio_tokenizer_v1_source])
+    )
+    moss_audio_tokenizer_v1_attention = (
+        moss_audio_tokenizer_v1_decoder[0].transformer.layers[0].self_attn
+    )
+    moss_audio_tokenizer_v1_attention._flash_attn_varlen = lambda *args, **kwargs: None
 
-    assert v1_weights_decoder.supports_packed_flash("cuda", torch.bfloat16)
-    assert v1_weights_decoder.supports_packed_flash("cuda", torch.float16)
-    assert not v1_weights_decoder.supports_packed_flash("cpu", torch.bfloat16)
-    assert not v1_weights_decoder.supports_packed_flash("cuda", None)
-
-    v1_weights_attention._flash_attn_varlen = None
-    assert not v1_weights_decoder.supports_packed_flash("cuda", torch.bfloat16)
+    assert moss_audio_tokenizer_v1_decoder.supports_packed_attention(
+        "cuda", torch.bfloat16
+    )
+    assert not moss_audio_tokenizer_v1_decoder.supports_packed_attention(
+        "cuda", torch.float16
+    )
+    assert not moss_audio_tokenizer_v1_decoder.supports_packed_attention(
+        "cpu", torch.bfloat16
+    )
+    assert not moss_audio_tokenizer_v1_decoder.supports_packed_attention("cuda", None)
 
     local_source = _FallbackProjectedStage()
     local_source.transformer.layers[0].self_attn.attention_implementation = (
@@ -862,12 +1294,12 @@ def test_vocoder_decoder_requires_packed_flash_for_every_transformer() -> None:
     local_attention = local[0].transformer.layers[0].self_attn
     local_attention._flash_attn_varlen = lambda *args, **kwargs: None
 
-    assert local.supports_packed_flash("cuda", torch.bfloat16)
-    assert not local.supports_packed_flash("cuda", torch.float16)
+    assert local.supports_packed_attention("cuda", torch.bfloat16)
+    assert not local.supports_packed_attention("cuda", torch.float16)
 
 
-def test_vocoder_decoder_wraps_v1_weights_moss_audio_tokenizer_fields() -> None:
-    source = _V1WeightsProjectedStage()
+def test_vocoder_decoder_wraps_moss_audio_tokenizer_v1_weight_fields() -> None:
+    source = _MossAudioTokenizerV1ProjectedStage()
     wrapped = MossAudioTokenizerVocoderDecoder(nn.ModuleList([source]))
     source_layer = source.transformer.layers[0]
     wrapped_layer = wrapped[0].transformer.layers[0]
@@ -879,12 +1311,13 @@ def test_vocoder_decoder_wraps_v1_weights_moss_audio_tokenizer_fields() -> None:
     assert wrapped_layer.ffn.linear2 is source_layer.linear2
     assert wrapped_layer.ffn.activation is source_layer.activation
 
-    attention._can_run_packed_flash = lambda _: True
-    assert attention.resolve_attention_implementation(torch.randn(2, 6)) == (
-        "packed_flash_attention"
+    attention._packed_flash_unavailable_reason = lambda *args: None
+    assert (
+        attention.resolve_attention_backend(torch.device("cpu"), torch.float32).backend
+        == "packed_flash_attention"
     )
 
-    attention._can_run_packed_flash = lambda _: False
+    attention._packed_flash_unavailable_reason = lambda *args: "unavailable"
     x = torch.randn(2, 3, 4)
     lengths = torch.tensor([4, 3])
     out, out_lengths = wrapped(x, lengths)

--- a/tests/unit_test/moss_tts/test_vocoder.py
+++ b/tests/unit_test/moss_tts/test_vocoder.py
@@ -38,7 +38,7 @@ class _AlwaysPackedVocoderDecoder(nn.Module):
     def __len__(self) -> int:
         return len(self.stages)
 
-    def supports_packed_flash(self, device, dtype) -> bool:
+    def supports_packed_attention(self, device, dtype) -> bool:
         del device, dtype
         return True
 
@@ -60,7 +60,7 @@ class _AlwaysPackedVocoderDecoder(nn.Module):
 
 
 class _NeverPackedVocoderDecoder(_AlwaysPackedVocoderDecoder):
-    def supports_packed_flash(self, device, dtype) -> bool:
+    def supports_packed_attention(self, device, dtype) -> bool:
         del device, dtype
         return False
 


### PR DESCRIPTION
## Motivation

MOSS-TTS Delay and MOSS-TTS Local execute the same non-streaming MOSS-Audio-Tokenizer local-causal decoder attention, but the repository did not have a single, explicit backend policy for it. Backend selection, packed-sequence preparation, RoPE handling, and model-layout adaptation were coupled in the same implementation. The packed path was also tied to the Hugging Face `flash_attention_2` configuration name, making its behavior difficult to reason about across CUDA versions, dtypes, and GPU architectures.

We compared the available implementations and execution strategies for this workload: FlashInfer FA2, SGLang packed FlashAttention, full-sequence versus 128-token tiled packed execution, and query-chunked SDPA versus HF duration-based streaming. The comparison showed that one backend should not be forced across all environments: packed FlashAttention is the fast path when supported, 128-token tiling is required for the `SM < 90` path, and query-chunked SDPA is the portable fallback. FlashInfer did not provide a demonstrated end-to-end benefit, so it is not added to the runtime policy.

This PR consolidates the shared MOSS-Audio-Tokenizer attention runtime and makes the selection policy explicit and testable. It preserves the decoder math and source weights, supports both v1 and v2 module layouts, and removes redundant Q/K/V contiguous copies.

## Modifications

- Add `sglang_omni/models/moss_tts/attention.py` with the shared MOSS-Audio-Tokenizer attention implementation:
  - explicit `auto`, `packed_flash_attention`, and `sdpa` backend policies;
  - SGLang's `_is_fa3_supported()` predicate for packed-kernel eligibility;
  - BF16-only packed FlashAttention eligibility on CUDA (FP16 is intentionally not added);
  - query-chunked SDPA fallback for CPU, FP32, explicit SDPA, or unavailable packed kernels;
  - per-device caching for the SM-based direct-versus-tiled routing decision;
  - packed/unpacked sequence helpers, cached packed RoPE, and the equivalent local-causal FlashAttention window `(context - 1, 0)`;
  - direct Q/K/V views passed to the packed kernel, without redundant `.contiguous()` copies.
- Simplify `audio_tokenizer.py` into the shared transformer and decoder wrappers plus codec loading:
  - use explicit `from_module()` constructors that reuse the source modules;
  - support both MOSS-Audio-Tokenizer v1 weight fields and v2 `ffn` fields;
  - resolve one consistent attention backend across all transformer layers;
  - use direct packed FA3 on `SM >= 90` and restore a shared 128-token local-window plan with overlapping K/V gathers on `SM < 90` for cross-architecture compatibility.
- Expand the MOSS-Audio-Tokenizer unit coverage for backend policy and fallback, SGLang FA3 capability checks, local-window equivalence, query-chunked SDPA, zero-length and packed/unpacked inputs, v1/v2 layouts, and CUDA BF16 parity.
- Update `tests/README.md` so the shared attention and decoder tests are listed under `unit_test/moss_tts`.

The change is limited to the non-streaming packed decoder path. Delay streaming uses the original codec `model.decode()` path, and MOSS-TTS Local streaming uses the persistent `codec.streaming()` / `_decode_frame()` session. No streaming attention implementation is replaced by this PR.

## Related Issues

#1233 

## Accuracy Test

The following end-to-end A/B on one NVIDIA H200. Each consumer has five base rounds and five PR rounds, with alternating execution order, seed 42, and concurrency 16.

| Item | MOSS-TTS Delay | MOSS-TTS Local |
| --- | ---: | ---: |
| Checkpoint | `OpenMOSS-Team/MOSS-TTS-v1.5` | `OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5` |
| Samples per round | 1,088 | 1,088 |
| Base/PR rounds | 5 / 5 | 5 / 5 |
| Concurrency | 16 | 16 |
| Requests (base + PR) | 10,880 | 10,880 |
| Failed requests | 0 | 0 |

Quality values are five-round means. WER is shown as a percentage; its delta is the paired base-to-PR change in percentage points.

| Model | Metric | Base | PR | Delta |
| --- | --- | ---: | ---: | ---: |
| Delay | Corpus WER | 2.0715% | 2.1636% | +0.0921 pp |
| Delay | WavLM speaker similarity | 69.0227 | 68.9378 | -0.0849 |
| Delay | UTMOS | 3.9442 | 3.9443 | +0.0001 |
| Local | Corpus WER | 2.1619% | 2.0916% | -0.0703 pp |
| Local | WavLM speaker similarity | 65.3359 | 65.1872 | -0.1487 |
| Local | UTMOS | 3.9667 | 3.9659 | -0.0008 |

All 21,760 generation requests completed successfully. Every generated WAV was finite, with the expected 24 kHz Delay or 48 kHz Local sample rate. The WER, speaker-similarity, UTMOS, and audio-integrity gates passed for both consumers.

One Delay PR round showed a throughput outlier (`7.826 req/s`). The paired base and PR round was rerun with the same seed, dataset, hardware, and concurrency; the replacement values were `8.848` and `8.872 req/s`. The results below use the replacement run.

A focused H200 long-sequence check repeated codec frames to cross the local-window boundary and produced a finite 64-second, 48 kHz stereo waveform. Manual listening found no audible artifact. A follow-up A800 run exposed severe audio corruption without 128-token tiling, which led to the current `SM < 90` tiled path. The targeted A800 correctness and long-audio gates remain outstanding.

## Benchmark & Profiling

The following results are five-round means from the H200 concurrency-16 base-versus-PR campaign. Speed deltas are paired base-to-PR means; negative latency and RTF deltas are improvements.

| Model | Metric | Base | PR | Delta |
| --- | --- | ---: | ---: | ---: |
| Delay | Throughput (req/s) | 8.6042 | 8.8040 | +2.400% |
| Delay | Mean latency (s) | 1.8546 | 1.8106 | -2.297% |
| Delay | P95 latency (s) | 2.3470 | 2.2734 | -2.933% |
| Delay | Mean RTF | 0.42786 | 0.41750 | -2.349% |
| Delay | Audio throughput (audio-s/s) | 38.5438 | 39.4376 | +2.397% |
| Local | Throughput (req/s) | 11.4686 | 11.8250 | +3.109% |
| Local | Mean latency (s) | 1.3888 | 1.3462 | -3.066% |
| Local | P95 latency (s) | 1.9022 | 1.8660 | -1.900% |
| Local | Mean RTF | 0.32738 | 0.31722 | -3.103% |
| Local | Audio throughput (audio-s/s) | 50.4762 | 52.0458 | +3.110% |


## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr` or `/tag-and-rerun-ci qwen3-asr` to select an ASR
CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
