### PR TITLE
[Perf][FishAudio S2-Pro] Compact non-streaming terminal waveform payload

### DIFF
--- a/sglang_omni/models/fishaudio_s2_pro/streaming_vocoder.py
+++ b/sglang_omni/models/fishaudio_s2_pro/streaming_vocoder.py
@@ -468,14 +468,34 @@ class S2ProVocoderScheduler(StreamingSimpleScheduler):
         audio_np: torch.Tensor,
     ) -> StagePayload:
         usage = payload.data.get("usage") or build_usage(state)
-        state.audio_samples = audio_np
-        state.sample_rate = self._codec.sample_rate
-        data = state.to_dict()
+        # The no-chunk streaming fallback retains its legacy stream schema;
+        # only the non-streaming terminal result uses the compact payload.
+        if self._is_streaming_payload(payload):
+            data = {
+                "audio_data": audio_np.tolist(),
+                "sample_rate": self._codec.sample_rate,
+                "modality": "audio",
+            }
+            if usage is not None:
+                data["usage"] = usage
+            if state.finish_reason is not None:
+                data["finish_reason"] = state.finish_reason
+            return StagePayload(
+                request_id=payload.request_id,
+                request=payload.request,
+                data=data,
+            )
+
+        data = audio_waveform_payload(
+            audio_np,
+            sample_rate=self._codec.sample_rate,
+            modality="audio",
+            source_hint="S2-Pro vocoder",
+        )
         if usage is not None:
             data["usage"] = usage
-        data["audio_data"] = audio_np.tolist()
-        data["sample_rate"] = self._codec.sample_rate
-        data["modality"] = "audio"
+        if state.finish_reason is not None:
+            data["finish_reason"] = state.finish_reason
         return StagePayload(
             request_id=payload.request_id,
             request=payload.request,

--- a/tests/unit_test/fishaudio_s2_pro/test_vocoder.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_vocoder.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 import torch
 
 from sglang_omni.models.fishaudio_s2_pro import stages
 from sglang_omni.models.fishaudio_s2_pro.payload_types import S2ProState
+from sglang_omni.models.fishaudio_s2_pro.streaming_vocoder import S2ProVocoderScheduler
+from sglang_omni.pipeline.control_plane import deserialize_message, serialize_message
+from sglang_omni.proto import CompleteMessage
 from sglang_omni.scheduling.messages import IncomingMessage
 from tests.unit_test.fixtures.fish_fakes import FakeFishCodec, make_s2pro_payload
 from tests.unit_test.pipeline.helpers import run_scheduler
@@ -28,16 +32,27 @@ def test_fish_vocoder_batches_and_trims_audio_by_code_length(
     assert scheduler._stream_stride == 40
     assert scheduler._stream_followup_stride == 45
 
+    usage_override = {
+        "prompt_tokens": 7,
+        "completion_tokens": 11,
+        "total_tokens": 18,
+        "engine_time_s": 0.75,
+    }
+
     def payload(request_id: str, code_len: int) -> object:
-        return make_s2pro_payload(
+        item = make_s2pro_payload(
             S2ProState(
                 output_codes=torch.arange(3 * code_len).reshape(3, code_len),
                 prompt_tokens=4,
                 completion_tokens=code_len,
                 engine_time_s=0.5,
+                finish_reason="length" if request_id == "req-short" else None,
             ),
             request_id=request_id,
         )
+        if request_id == "req-short":
+            item.data["usage"] = usage_override
+        return item
 
     first, second = run_scheduler(
         scheduler,
@@ -48,8 +63,121 @@ def test_fish_vocoder_batches_and_trims_audio_by_code_length(
         output_count=2,
     )
     outputs = {first.request_id: first.data, second.request_id: second.data}
+    short_data = outputs["req-short"].data
+    long_data = outputs["req-long"].data
+
+    restored = deserialize_message(
+        serialize_message(
+            CompleteMessage(
+                request_id="req-short",
+                from_stage="vocoder",
+                success=True,
+                result=short_data,
+            )
+        )
+    )
+    assert restored.result == short_data
 
     assert codec.calls == [(2, 2, 3)]
-    assert outputs["req-short"].data["audio_data"] == [1.0] * 8
-    assert outputs["req-long"].data["audio_data"] == [2.0] * 12
-    assert outputs["req-short"].data["usage"]["total_tokens"] == 6
+    short_audio = np.frombuffer(short_data["audio_waveform"], dtype=np.float32).reshape(
+        short_data["audio_waveform_shape"]
+    )
+    long_audio = np.frombuffer(long_data["audio_waveform"], dtype=np.float32).reshape(
+        long_data["audio_waveform_shape"]
+    )
+    np.testing.assert_array_equal(short_audio, np.ones(8, dtype=np.float32))
+    np.testing.assert_array_equal(long_audio, np.full(12, 2.0, dtype=np.float32))
+    assert short_data["audio_waveform_shape"] == [8]
+    assert long_data["audio_waveform_shape"] == [12]
+    assert short_data["audio_waveform_dtype"] == "float32"
+    assert long_data["audio_waveform_dtype"] == "float32"
+    assert short_data["sample_rate"] == long_data["sample_rate"] == 44100
+    assert short_data["modality"] == long_data["modality"] == "audio"
+    assert short_data["usage"] == usage_override
+    assert long_data["usage"]["total_tokens"] == 7
+    assert short_data["finish_reason"] == "length"
+    assert "finish_reason" not in long_data
+    assert set(short_data) == {
+        "audio_waveform",
+        "audio_waveform_shape",
+        "audio_waveform_dtype",
+        "sample_rate",
+        "modality",
+        "usage",
+        "finish_reason",
+    }
+    assert set(long_data) == {
+        "audio_waveform",
+        "audio_waveform_shape",
+        "audio_waveform_dtype",
+        "sample_rate",
+        "modality",
+        "usage",
+    }
+
+
+def test_fish_terminal_payload_does_not_mutate_input() -> None:
+    scheduler = S2ProVocoderScheduler(
+        FakeFishCodec(frame_length=4),
+        device="cpu",
+    )
+    state = S2ProState(
+        output_codes=torch.arange(3 * 2).reshape(3, 2),
+        prompt_tokens=1,
+        completion_tokens=2,
+    )
+    payload = make_s2pro_payload(state, request_id="req-terminal-ownership")
+    original_data = payload.data
+
+    result = scheduler._store_audio(
+        payload,
+        state,
+        torch.ones(8, dtype=torch.float32),
+    )
+
+    assert result is not payload
+    assert payload.data is original_data
+    assert "output_codes" in payload.data
+    assert "audio_waveform" not in payload.data
+    assert result.data["audio_waveform_shape"] == [8]
+
+
+def test_fish_stream_fallback_preserves_terminal_metadata() -> None:
+    usage = {
+        "prompt_tokens": 3,
+        "completion_tokens": 5,
+        "total_tokens": 8,
+    }
+    scheduler = S2ProVocoderScheduler(
+        FakeFishCodec(frame_length=4),
+        device="cpu",
+        stream_overlap_tokens=1,
+        stream_crossfade_samples=0,
+    )
+    payload = make_s2pro_payload(
+        S2ProState(
+            output_codes=torch.arange(3 * 2).reshape(3, 2),
+            prompt_tokens=1,
+            completion_tokens=2,
+            finish_reason="length",
+        ),
+        request_id="req-stream-fallback",
+        params={"stream": True},
+    )
+    payload.data["usage"] = usage
+    scheduler._on_streaming_new_request("req-stream-fallback", payload)
+
+    stream, final = scheduler.on_stream_done("req-stream-fallback")
+
+    assert stream.type == "stream"
+    np.testing.assert_array_equal(
+        stream.data["audio_data"], np.ones(8, dtype=np.float32)
+    )
+    assert stream.data["sample_rate"] == 44100
+    assert final.type == "result"
+    assert final.data.data == {
+        "modality": "audio",
+        "sample_rate": 44100,
+        "usage": usage,
+        "finish_reason": "length",
+    }


### PR DESCRIPTION
## Motivation

FishAudio S2-Pro's non-streaming vocoder currently materializes the decoded
float32 waveform twice before sending the terminal result:

- `state.audio_samples` is serialized through `S2ProState.to_dict()`;
- `audio_np.tolist()` creates a second Python float list under `audio_data`.

The terminal message also carries generation-only fields such as `output_codes`.
These fields are not needed by the coordinator or the public speech API, but they
increase Python object creation, msgpack work, and control-plane payload size.

## Modifications

- Use the existing `audio_waveform_payload()` representation for non-streaming
  terminal vocoder results.
- Preserve `sample_rate`, `modality`, usage precedence, and non-null
  `finish_reason`.
- Remove upstream generation state from the non-streaming terminal payload.
- Keep the no-chunk streaming fallback's existing `audio_data` schema to avoid
  changing streaming behavior.
- Return a fresh `StagePayload` on both terminal paths instead of mutating the
  input payload, preserving the process-local payload ownership contract.
- Add exact PCM, metadata, usage, finish-reason, payload ownership,
  control-plane round-trip, and streaming-fallback coverage.

No public `/v1/audio/speech` API, client decoder, model weights, or inference
algorithm is changed.

## Related Issues

N/A. This PR addresses an observed S2-Pro terminal serialization inefficiency.

## Accuracy Test

No model computation or weights changed.

- Batched short/long fake-codec outputs reconstruct exact expected float32
  samples.
- 1 s, 10 s, and 30 s baseline/candidate waveforms are bit-identical after
  decoding the compact bytes.
- The streaming fallback preserves the existing PCM samples and completion
  metadata.
- The terminal result does not mutate the input `StagePayload`.

## Benchmark & Profiling

### What the percentages mean

These percentages describe only the work needed to prepare and serialize the
final audio message. They do **not** mean that the model generates audio 90%
faster or that the full TTS request is 90% faster.

The old path turned every waveform sample into a Python number and also carried
the full generation state. The new path sends the same float32 samples as a
compact byte buffer and keeps only the metadata needed by the receiver. That is
why the savings are large for this particular part of the request.

For a concrete example, on a 30-second clip:

- preparing and serializing the final message drops from `109.713 ms` to
  `1.640 ms`, saving about `108.1 ms` in this isolated component;
- the serialized message drops from `23.822 MB` to `5.292 MB`, saving
  `18.530 MB` per terminal message;
- the decoded waveform samples remain exactly identical.

The end-to-end H200 serving measurements are reported separately below. They
show small, noise-level request-latency differences. The component benchmark
uses the exact pre-change `_store_audio()` logic and the candidate
implementation, feeds the same float32 waveform to both, and serializes both
results through `pipeline.control_plane.serialize_message(CompleteMessage(...))`.

### Component benchmark

Environment:

- CPU: Intel Xeon Platinum 8558
- Python 3.12.13
- PyTorch 2.11.0+cu130
- msgpack 1.2.1
- base: `12a004f01eb6e458b09ab249693ab172d2780724`
- 3 warmup iterations; 20/10/5 measured iterations for 1/10/30 s
- baseline and candidate measured alternately in the same process

#### Time spent preparing the final message

Each row shows **old → new** time. “Time saved” is the percentage reduction
relative to the old implementation.

| Audio | Prepare message (ms) | Time saved | Serialize message (ms) | Time saved | Both steps (ms) | Time saved |
|---:|---:|---:|---:|---:|---:|---:|
| 1 s | 0.786 → 0.065 | 91.73% | 2.126 → 0.121 | 94.31% | 2.912 → 0.186 | 93.61% |
| 10 s | 15.102 → 0.615 | 95.93% | 23.255 → 1.431 | 93.85% | 38.357 → 2.046 | 94.67% |
| 30 s | 44.199 → 0.534 | 98.79% | 65.514 → 1.106 | 98.31% | 109.713 → 1.640 | 98.51% |

#### Size of the final message

This is the size of the serialized message sent through the control plane. The
“new message share” column says how much of the old message remains; the last
column says how many times larger the old message was.

| Audio | Old message (MB) | New message (MB) | Bytes saved (MB) | Reduction | New message share | Old/new size |
|---:|---:|---:|---:|---:|---:|---:|
| 1 s | 0.795 | 0.177 | 0.618 | 77.74% | 22.26% | 4.49× |
| 10 s | 7.941 | 1.764 | 6.177 | 77.79% | 22.21% | 4.50× |
| 30 s | 23.822 | 5.292 | 18.530 | 77.79% | 22.21% | 4.50× |

The new message is not lossy-compressed. It contains the exact float32 samples
plus shape and dtype metadata. The old message is larger because it also
contains a Python float list and extra generation state. The decoded old and new
waveforms were `np.array_equal` for all three durations, and the focused unit
test round-trips the new message through `CompleteMessage` and the control-plane
msgpack serializer.

### End-to-end benchmark

Protocol:

- physical GPU 0, NVIDIA H200; one clean, restarted server per run
- non-streaming SeedTTS generation, 64 requests, warmup 4, seed 1234
- two baseline A/A runs followed by three alternating paired A/B runs at each
  concurrency
- all 16 measured runs completed 64/64 requests successfully
- model weights were downloaded from a public ModelScope mirror into a local
  path; the EN references are a 64-row local subset of
  `evalscope/Seed-TTS-Eval`

#### Serving results

| Concurrency | Mean latency (baseline → candidate) | Mean delta | p95 latency (baseline → candidate) | QPS (baseline → candidate) | QPS delta |
|---:|---:|---:|---:|---:|---:|
| 8 | 3.928 s → 3.816 s | -2.86% | 5.443 s → 5.249 s | 1.914 → 1.966 | +2.75% |
| 16 | 6.661 s → 6.541 s | -1.80% | 9.946 s → 10.297 s | 2.157 → 2.194 | +1.72% |

Baseline A/A mean-latency ranges were 3.713–3.747 s at concurrency 8 and
6.335–6.670 s at concurrency 16. The paired end-to-end deltas are therefore
treated as noise-level observations rather than a serving-speedup claim. The
reliable contribution evidence is the component payload reduction above.

## Limitations

- The component benchmark measures Python payload construction and msgpack
  serialization, not codec execution or network transfer on a production relay.
- The H200 measurement uses a 64-row local subset of SeedTTS EN data.
- The no-chunk streaming fallback intentionally retains the legacy Python-list
  schema.
- Full self-hosted GPU CI is required before merge.

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests.
- [x] No documentation or example update is needed; the public API is unchanged.
- [x] Provide component and serving benchmark results.
- [ ] Run self-hosted GPU CI after a maintainer applies the required CI label.

Validation completed locally:

```text
pytest -q tests/unit_test/fishaudio_s2_pro
108 passed, 14 warnings

pytest -q tests/unit_test/fishaudio_s2_pro/test_vocoder.py \
  tests/unit_test/fishaudio_s2_pro/test_streaming_vocoder.py
24 passed, 14 warnings

pytest -q tests/unit_test/ming_omni/test_streaming_e2e_glue.py
6 passed

pre-commit: all applicable hooks passed
wheel build: succeeded
git diff --check: passed
```

## CI

Please add the repository's required `run-ci` label after opening the PR. The
full repository CI has not been run locally. The self-hosted workflow will run
the repository's GPU test stages once the PR is non-draft and labeled.
