### PR TITLE
[AMD][ROCm] Add the ROCm backend and support Qwen3-Omni text-only mode

### DIFF
--- a/sglang_omni/platforms/__init__.py
+++ b/sglang_omni/platforms/__init__.py
@@ -6,9 +6,10 @@ from sglang.srt import platforms as srt_platforms
 from sglang.srt.platforms.interface import SRTPlatform
 
 from sglang_omni.platforms.cpu import CPUOmniPlatform
-from sglang_omni.platforms.cuda import CUDAOmniPlatform, ROCMOmniPlatform
+from sglang_omni.platforms.cuda import CUDAOmniPlatform
 from sglang_omni.platforms.interface import OmniPlatform
 from sglang_omni.platforms.npu import NPUOmniPlatform
+from sglang_omni.platforms.rocm import ROCMOmniPlatform
 from sglang_omni.platforms.xpu import XPUOmniPlatform
 
 

--- a/sglang_omni/platforms/cuda.py
+++ b/sglang_omni/platforms/cuda.py
@@ -6,7 +6,6 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 from sglang.srt.platforms.cuda import CudaDeviceMixin
-from sglang.srt.platforms.rocm import RocmDeviceMixin
 
 from sglang_omni.platforms.interface import OmniPlatform
 from sglang_omni.quantization import resolve_quant_config
@@ -191,7 +190,3 @@ class CUDAOmniPlatform(CudaDeviceMixin, OmniPlatform):
             f"fp8_gemm_backend={fp8_gemm_backend}"
         )
         return effective_quantization
-
-
-class ROCMOmniPlatform(RocmDeviceMixin, CUDAOmniPlatform):
-    pass

--- a/sglang_omni/platforms/rocm.py
+++ b/sglang_omni/platforms/rocm.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+from sglang.srt.platforms.rocm import RocmDeviceMixin
+
+from sglang_omni.platforms.interface import OmniPlatform
+
+if TYPE_CHECKING:
+    from sglang.srt.configs.model_config import ModelConfig
+    from sglang.srt.server_args import ServerArgs
+
+    from sglang_omni.pipeline.stage_workers import StageLaunchConfig
+
+
+class ROCMOmniPlatform(RocmDeviceMixin, OmniPlatform):
+    """ROCm policy with PyTorch's CUDA-compatible HIP device surface."""
+
+    def get_stage_process_env(
+        self,
+        spec: StageLaunchConfig,
+        env: Mapping[str, str] | None = None,
+    ) -> dict[str, str]:
+        if spec.tp_size <= 1:
+            return {}
+
+        source_env = env if env is not None else os.environ
+        original_visible = source_env.get("CUDA_VISIBLE_DEVICES")
+        if spec.gpu_id is None:
+            raise ValueError(f"tp stage {spec.stage_name!r} requires a GPU id")
+        if original_visible:
+            visible_devices = [item.strip() for item in original_visible.split(",")]
+            if spec.gpu_id >= len(visible_devices):
+                raise ValueError(
+                    f"tp stage {spec.stage_name!r} assigned gpu_id={spec.gpu_id}, "
+                    f"but CUDA_VISIBLE_DEVICES only exposes {visible_devices}"
+                )
+            mapped_gpu = visible_devices[spec.gpu_id]
+        else:
+            mapped_gpu = str(spec.gpu_id)
+
+        return {
+            "CUDA_VISIBLE_DEVICES": mapped_gpu,
+            "SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS": "true",
+            "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "false",
+        }
+
+    def get_intra_node_transport(self):
+        from sglang_omni.comm.data_ref import TransportKind
+
+        return TransportKind.SHM
+
+    def get_fused_qk_norm_rope(self):
+        # sgl-kernel's AOT op is CUDA-only, while the native QK-norm + RoPE
+        # path works through PyTorch's HIP backend.
+        return None
+
+    def apply_model_worker_backend_policy(
+        self,
+        server_args: ServerArgs,
+        model_config: ModelConfig,
+        model_arch_override: str | None,
+    ) -> str | None:
+        effective_quantization = super().apply_model_worker_backend_policy(
+            server_args, model_config, model_arch_override
+        )
+
+        if model_arch_override in (
+            "Qwen3OmniTalker",
+            "Qwen3OmniThinkerForCausalLM",
+        ) and server_args.moe_runner_backend in ("flashinfer_cutlass", "cutlass"):
+            raise ValueError(
+                "Qwen3-Omni on AMD ROCm cannot use "
+                f"moe_runner_backend={server_args.moe_runner_backend!r}; the "
+                "CUTLASS MoE runners are NVIDIA CUDA-only. Leave the backend as "
+                "'auto' or pass 'aiter' or 'triton'."
+            )
+
+        return effective_quantization
+
+    def enable_code2wav_graph(self) -> bool:
+        return False

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -145,15 +145,16 @@ def test_non_cuda_platforms_disable_the_code2wav_graph() -> None:
     would reach the CUDA-only runner, so every non-CUDA platform declares itself.
     """
     from sglang_omni.platforms.cpu import CPUOmniPlatform
-    from sglang_omni.platforms.cuda import CUDAOmniPlatform, ROCMOmniPlatform
+    from sglang_omni.platforms.cuda import CUDAOmniPlatform
     from sglang_omni.platforms.npu import NPUOmniPlatform
+    from sglang_omni.platforms.rocm import ROCMOmniPlatform
     from sglang_omni.platforms.xpu import XPUOmniPlatform
 
     assert XPUOmniPlatform().enable_code2wav_graph() is False
     assert NPUOmniPlatform().enable_code2wav_graph() is False
     assert CPUOmniPlatform().enable_code2wav_graph() is False
     assert CUDAOmniPlatform().enable_code2wav_graph() is True
-    assert ROCMOmniPlatform().enable_code2wav_graph() is True
+    assert ROCMOmniPlatform().enable_code2wav_graph() is False
 
 
 def test_the_code2wav_stage_takes_its_graph_flag_from_the_platform() -> None:

--- a/tests/unit_test/test_platforms.py
+++ b/tests/unit_test/test_platforms.py
@@ -12,7 +12,9 @@ from sglang.srt.platforms.rocm import RocmSRTPlatform
 import sglang_omni.platforms as platforms
 import sglang_omni.platforms.xpu as xpu_platform
 from sglang_omni.platforms.cpu import CPUOmniPlatform
+from sglang_omni.platforms.cuda import CUDAOmniPlatform
 from sglang_omni.platforms.interface import OmniPlatform
+from sglang_omni.platforms.rocm import ROCMOmniPlatform
 
 
 class _VendorDeviceMixin(DeviceMixin):
@@ -48,12 +50,52 @@ def test_rocm_platform_keeps_cuda_compatible_tp_mapping() -> None:
     spec = SimpleNamespace(stage_name="thinker", tp_size=2, gpu_id=1)
 
     assert platform.is_rocm()
+    assert not isinstance(platform, CUDAOmniPlatform)
+    assert platform.device_type == "cuda"
     assert (
         platform.get_stage_process_env(spec, {"CUDA_VISIBLE_DEVICES": "3,4"})[
             "CUDA_VISIBLE_DEVICES"
         ]
         == "4"
     )
+
+
+def test_rocm_platform_uses_conservative_omni_capabilities() -> None:
+    from sglang_omni.comm.data_ref import TransportKind
+
+    platform = ROCMOmniPlatform()
+
+    assert platform.get_intra_node_transport() is TransportKind.SHM
+    assert platform.get_fused_qk_norm_rope() is None
+
+
+def test_rocm_talker_keeps_auto_moe_backend() -> None:
+    server_args = SimpleNamespace(
+        quantization=None,
+        moe_runner_backend="auto",
+    )
+    model_config = SimpleNamespace(quantization=None)
+
+    ROCMOmniPlatform().apply_model_worker_backend_policy(
+        server_args,
+        model_config,
+        "Qwen3OmniTalker",
+    )
+
+    assert server_args.moe_runner_backend == "auto"
+
+
+@pytest.mark.parametrize("backend", ["flashinfer_cutlass", "cutlass"])
+def test_rocm_qwen3_omni_rejects_cutlass_moe_backends(backend: str) -> None:
+    server_args = SimpleNamespace(quantization=None, moe_runner_backend=backend)
+    model_config = SimpleNamespace(quantization=None)
+
+    with pytest.raises(ValueError, match="NVIDIA CUDA-only"):
+        ROCMOmniPlatform().apply_model_worker_backend_policy(
+            server_args,
+            model_config,
+            "Qwen3OmniThinkerForCausalLM",
+        )
 
 
 def test_srt_plugin_identity_round_trips_to_spawned_process() -> None:


### PR DESCRIPTION
## Motivation

SGLang-Omni currently implements ROCm by inheriting the CUDA backend. PyTorch on ROCm intentionally exposes a CUDA-compatible device API, but inheriting the whole CUDA backend also brings in NVIDIA-only choices such as CUDA IPC, CUTLASS MoE backends, and CUDA-only fused operators.

This PR adds a standalone ROCm backend and uses it to support Qwen3-Omni in text-only mode on AMD GPUs. This first PR covers the Thinker text-input/text-output path; Talker and audio output are left for follow-up work.

This initial support was validated on gfx950 (AMD Instinct MI355X). Support for gfx942 will be added in follow-up work.

## Modifications

- Add an independent `ROCMOmniPlatform(RocmDeviceMixin, OmniPlatform)` instead of inheriting `CUDAOmniPlatform`.
- Keep the CUDA-compatible device namespace required by PyTorch HIP while giving ROCm its own transport, fused-op, MoE backend, and graph capability decisions.
- Support Qwen3-Omni text-only serving with both eager decoding and decode graph replay on ROCm.

## Accuracy Test

The test was run on one AMD Instinct MI355X with BF16 and Thinker TP=1. The runtime used Docker image built from [#1632](https://github.com/sgl-project/sglang-omni/pull/1632).

Qwen3-Omni text-only with decode graph enabled:

- GSM8K official test split, first 100 samples, greedy decoding
- Accuracy: 99/100 (99%)
- Failed requests: 0
- Invalid responses: 0

## Unit Test

Since there's no CI for ROCm at the moment, here're the unit tests we did:

- `test_rocm_platform_keeps_cuda_compatible_tp_mapping` confirms that ROCm resolves to the standalone backend while preserving PyTorch HIP's CUDA-compatible device namespace and TP device mapping.
- `test_rocm_platform_uses_conservative_omni_capabilities` keeps ROCm on SHM and the native QK norm/RoPE fallback instead of CUDA IPC and the CUDA-only fused op.
- `test_rocm_talker_keeps_auto_moe_backend` leaves the Talker's `auto` MoE backend to SGLang instead of changing it to a CUDA CUTLASS backend.
- `test_rocm_qwen3_omni_rejects_cutlass_moe_backends` rejects explicitly selected CUDA-only CUTLASS backends early with a clear error.
- `test_non_cuda_platforms_disable_the_code2wav_graph` keeps the unvalidated Code2Wav graph path disabled on ROCm.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.