### PR TITLE
[Qwen3-TTS] Remove unprofitable Talker compile path

### DIFF
--- a/docs/cookbook/qwen3_tts.md
+++ b/docs/cookbook/qwen3_tts.md
@@ -91,8 +91,8 @@ enable_deterministic_inference: true
 
 When enabled, the same prompt, reference audio, and seed produce byte-identical
 PCM across runtime batch sizes. This mode reduces throughput because it
-serializes reference preprocessing and vocoder decoding and disables Talker
-compilation and the initial vocoder CUDA Graph, so it is disabled by default.
+serializes reference preprocessing and vocoder decoding and disables both the
+initial and follow-up vocoder CUDA Graphs, so it is disabled by default.
 
 ### Overload / admission policy
 

--- a/sglang_omni/models/qwen3_tts/__init__.py
+++ b/sglang_omni/models/qwen3_tts/__init__.py
@@ -10,7 +10,7 @@ CAPABILITIES = ModelCapabilities(
     supports_batch_vocoder=True,
     supports_streaming_vocoder=True,
     supports_cuda_graph=True,
-    supports_torch_compile=True,
+    supports_torch_compile=False,
     supports_breakable_prefill_cuda_graph=False,
 )
 

--- a/sglang_omni/models/qwen3_tts/config.py
+++ b/sglang_omni/models/qwen3_tts/config.py
@@ -48,8 +48,8 @@ class Qwen3TTSPipelineConfig(PipelineConfig):
 
     model_path: str
     # note (0xtoward): Keep deterministic inference opt-in because it serializes
-    # preprocessing and vocoder decoding and disables Talker compilation and the
-    # vocoder CUDA graphs, reducing throughput.
+    # preprocessing and vocoder decoding and disables the vocoder CUDA graphs,
+    # reducing throughput.
     enable_deterministic_inference: bool = False
     stages: list[StageConfig] = [
         StageConfig(

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -8,9 +8,17 @@ from typing import Any
 
 from sglang_omni.models.qwen3_tts import request_builders
 from sglang_omni.models.qwen3_tts import stages as qwen3_stages
-from sglang_omni.platforms import current_platform
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
-from sglang_omni.vendor.sglang.server_args import override_server_args
+
+
+def _is_truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+    return False
 
 
 class Qwen3TtsEngineBuilder(TtsEngineBuilder):
@@ -49,7 +57,7 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             "dtype": dtype,
             "disable_cuda_graph": False,
             "disable_overlap_schedule": True,
-            "enable_torch_compile": True,
+            "enable_torch_compile": False,
             "mem_fraction_static": 0.85,
             "max_prefill_tokens": 8192,
             "sampling_backend": "pytorch",
@@ -93,28 +101,9 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
             wrapper=self.wrapper,
         )
 
-    def compile_model(self, model: Any, server_args: Any) -> None:
-        if current_platform.is_rocm():
-            override_server_args(
-                server_args,
-                "sglang_omni.qwen3_tts.rocm",
-                enable_torch_compile=False,
-            )
-            return
-        if server_args.enable_deterministic_inference:
-            override_server_args(
-                server_args,
-                "sglang_omni.qwen3_tts.deterministic_inference",
-                enable_torch_compile=False,
-            )
-            return
-        if bool(server_args.enable_torch_compile):
-            qwen3_stages._compile_qwen3_tts_backbone(model)
-            override_server_args(
-                server_args,
-                "sglang_omni.qwen3_tts.compile_complete",
-                enable_torch_compile=False,
-            )
+    def adjust_overrides(self, overrides: dict[str, Any]) -> None:
+        if _is_truthy(overrides.get("enable_torch_compile", False)):
+            raise ValueError("Qwen3-TTS torch.compile is not supported")
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
         model_runner_mod = importlib.import_module(

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -313,8 +313,6 @@ class Qwen3TTSTalkerTextModel(nn.Module):
 
         residual = None
         layers = self.layers
-        if is_decode:
-            layers = getattr(self, "_compiled_decode_layers", self.layers)
         for idx in range(self.start_layer, self.end_layer):
             hidden_states, residual = layers[idx](
                 positions=positions,

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -103,24 +103,6 @@ def _load_qwen3_tts_generate_defaults(checkpoint_dir: str) -> dict[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
-def _compile_qwen3_tts_backbone(model: Any) -> None:
-    """Compile decoder blocks while leaving decode-input staging eager."""
-
-    text_model = model.model
-    layers = text_model.layers
-
-    from sglang.srt.compilation.torch_compile_decoration import set_torch_compile_config
-
-    set_torch_compile_config()
-    compile_mode = os.environ.get(
-        "SGLANG_TORCH_COMPILE_MODE",
-        "max-autotune-no-cudagraphs",
-    )
-    text_model._compiled_decode_layers = [
-        torch.compile(layer, mode=compile_mode) for layer in layers
-    ]
-
-
 def create_preprocessing_executor(
     model_path: str,
     *,

--- a/tests/unit_test/models/test_model_capabilities.py
+++ b/tests/unit_test/models/test_model_capabilities.py
@@ -45,7 +45,7 @@ EXPECTED_MODEL_CAPABILITIES = {
         supports_batch_vocoder=True,
         supports_streaming_vocoder=True,
         supports_cuda_graph=True,
-        supports_torch_compile=True,
+        supports_torch_compile=False,
         supports_breakable_prefill_cuda_graph=False,
     ),
     "HiggsMultimodalQwen3ForConditionalGeneration": ModelCapabilities(
@@ -230,7 +230,7 @@ def test_launcher_model_capabilities_log_summary() -> None:
         "batch_vocoder": True,
         "streaming_vocoder": True,
         "cuda_graph": True,
-        "torch_compile": True,
+        "torch_compile": False,
         "breakable_prefill_cuda_graph": False,
     }
 

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -4478,6 +4478,7 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
     build_kwargs: dict = {}
     infrastructure_saw_deferred_capture: list[bool] = []
     init_graph_calls: list[bool] = []
+
     class FakeModel:
         def load_speech_tokenizer(self, tokenizer) -> None:
             self.speech_tokenizer = tokenizer
@@ -4562,6 +4563,7 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
             lambda request_id, data, output: [],
         ),
     )
+
     def fake_build_sglang_server_args(model_path, context_length, **kwargs):
         del model_path, context_length
         build_kwargs.update(kwargs)
@@ -4685,6 +4687,39 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
     assert scheduler.server_args.enable_torch_compile is False
     assert scheduler.server_args.torch_compile_max_bs == 64
     clear_qwen3_tts_preprocessing_context()
+
+
+def test_qwen3_tts_engine_probes_runtime_before_checkpoint_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.qwen3_tts import engine_builder as engine_builder_mod
+    from sglang_omni.scheduling import engine_factory
+
+    checkpoint_resolutions: list[str] = []
+
+    def fake_resolve_checkpoint(model_path: str) -> str:
+        checkpoint_resolutions.append(model_path)
+        raise AssertionError("_resolve_checkpoint should not run before qwen_tts probe")
+
+    original_import_module = engine_builder_mod.importlib.import_module
+
+    def fake_import_module(name: str, package: str | None = None):
+        if name == "qwen_tts":
+            raise ImportError("missing qwen_tts")
+        return original_import_module(name, package)
+
+    monkeypatch.setattr(engine_factory, "_resolve_checkpoint", fake_resolve_checkpoint)
+    monkeypatch.setattr(
+        engine_builder_mod.importlib, "import_module", fake_import_module
+    )
+
+    with pytest.raises(ImportError, match="missing qwen_tts"):
+        engine_builder_mod.Qwen3TtsEngineBuilder().resolve_checkpoint(
+            "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
+        )
+
+    assert checkpoint_resolutions == []
+
 
 def test_qwen3_tts_cli_mem_fraction_static_pins_tts_engine() -> None:
     from sglang_omni.cli.serve import patches_from_broadcast_flags

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -4150,7 +4150,6 @@ def test_qwen3_tts_decode_forward_rejects_invalid_feedback_row(
     torch.nn.Module.__init__(model)
     model.codec_embedding = torch.nn.Embedding(8, 4)
     model.layers = torch.nn.ModuleList([])
-    model._compiled_decode_layers = model.layers
     model.start_layer = 0
     model.end_layer = 0
     model.norm = torch.nn.Identity()
@@ -4410,106 +4409,30 @@ def test_qwen3_tts_sampled_subtalker_requires_semantic_positions(
         )
 
 
-def test_qwen3_tts_compile_backbone_requires_text_layers(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    install_fake_sglang(monkeypatch)
-    from sglang_omni.models.qwen3_tts.stages import _compile_qwen3_tts_backbone
-
-    with pytest.raises(AttributeError):
-        _compile_qwen3_tts_backbone(SimpleNamespace())
-
-
-def test_qwen3_tts_compile_backbone_compiles_every_layer(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    install_fake_sglang(monkeypatch)
-    from sglang_omni.models.qwen3_tts.stages import _compile_qwen3_tts_backbone
-
-    set_config_calls = []
-    compiled = []
-    cuda_graph_runner = types.ModuleType(
-        "sglang.srt.compilation.torch_compile_decoration"
-    )
-    cuda_graph_runner.set_torch_compile_config = lambda: set_config_calls.append(True)
-    monkeypatch.setitem(
-        sys.modules,
-        "sglang.srt.compilation.torch_compile_decoration",
-        cuda_graph_runner,
-    )
-
-    def fake_compile(layer, *, mode):
-        compiled.append((layer, mode))
-        return f"compiled-{len(compiled)}"
-
-    monkeypatch.setattr(torch, "compile", fake_compile)
-    layers = [object(), object(), object()]
-    text_model = SimpleNamespace(layers=layers)
-    model = SimpleNamespace(model=text_model)
-
-    _compile_qwen3_tts_backbone(model)
-
-    assert set_config_calls == [True]
-    assert compiled == [(layer, "max-autotune-no-cudagraphs") for layer in layers]
-    assert text_model._compiled_decode_layers == [
-        "compiled-1",
-        "compiled-2",
-        "compiled-3",
-    ]
-
-
-def test_qwen3_tts_deterministic_inference_skips_private_compile(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Keep deterministic inference out of the private compile path."""
+def test_qwen3_tts_engine_disables_torch_compile_by_default() -> None:
     from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
 
-    compiled = []
-    monkeypatch.setattr(
-        qwen3_stages,
-        "_compile_qwen3_tts_backbone",
-        lambda model: compiled.append(model),
-    )
-    server_args = SimpleNamespace(
-        enable_deterministic_inference=True,
-        enable_torch_compile=True,
-    )
+    defaults = Qwen3TtsEngineBuilder().generation_defaults(dtype="bfloat16")
 
-    Qwen3TtsEngineBuilder().compile_model(object(), server_args)
-
-    assert compiled == []
-    assert server_args.enable_torch_compile is False
+    assert defaults["enable_torch_compile"] is False
 
 
-def test_qwen3_tts_rocm_disables_private_compile(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from sglang_omni.models.qwen3_tts import engine_builder as engine_builder_mod
+@pytest.mark.parametrize("value", [True, 1, "1", "true", " yes ", "on"])
+def test_qwen3_tts_engine_rejects_torch_compile(value) -> None:
+    from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
 
-    monkeypatch.setattr(
-        engine_builder_mod,
-        "current_platform",
-        SimpleNamespace(is_rocm=lambda: True),
-    )
-    builder = engine_builder_mod.Qwen3TtsEngineBuilder()
-    compiled = []
-    monkeypatch.setattr(
-        qwen3_stages,
-        "_compile_qwen3_tts_backbone",
-        lambda model: compiled.append(model),
-    )
-    server_args = SimpleNamespace(
-        enable_deterministic_inference=False,
-        enable_torch_compile=True,
-    )
-
-    builder.compile_model(object(), server_args)
-
-    assert compiled == []
-    assert server_args.enable_torch_compile is False
+    with pytest.raises(ValueError, match="Qwen3-TTS torch.compile is not supported"):
+        Qwen3TtsEngineBuilder().adjust_overrides({"enable_torch_compile": value})
 
 
-def test_qwen3_tts_engine_accepts_64_batch_policy_and_reenables_cuda_graph(
+@pytest.mark.parametrize("value", [False, 0, "false", "no", "", None])
+def test_qwen3_tts_engine_accepts_disabled_torch_compile(value) -> None:
+    from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
+
+    Qwen3TtsEngineBuilder().adjust_overrides({"enable_torch_compile": value})
+
+
+def test_qwen3_tts_engine_accepts_64_batch_policy_and_enables_cuda_graph(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     install_fake_sglang(monkeypatch)
@@ -4517,7 +4440,6 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_reenables_cuda_graph(
     from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
     from transformers.utils import generic
 
-    from sglang_omni.models.qwen3_tts import engine_builder as engine_builder_mod
     from sglang_omni.models.qwen3_tts import model_runner as model_runner_mod
     from sglang_omni.models.qwen3_tts import request_builders as request_builders_mod
     from sglang_omni.models.qwen3_tts import stages
@@ -4527,12 +4449,6 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_reenables_cuda_graph(
     from sglang_omni.scheduling import bootstrap as bootstrap_mod
     from sglang_omni.scheduling import omni_scheduler as scheduler_mod
     from sglang_omni.scheduling import sglang_backend
-
-    monkeypatch.setattr(
-        engine_builder_mod,
-        "current_platform",
-        SimpleNamespace(is_rocm=lambda: False),
-    )
 
     check_model_inputs_calls = []
     expected_cuda_graph_bs = [
@@ -4562,8 +4478,6 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_reenables_cuda_graph(
     build_kwargs: dict = {}
     infrastructure_saw_deferred_capture: list[bool] = []
     init_graph_calls: list[bool] = []
-    compile_calls: list[bool] = []
-
     class FakeModel:
         def load_speech_tokenizer(self, tokenizer) -> None:
             self.speech_tokenizer = tokenizer
@@ -4648,12 +4562,6 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_reenables_cuda_graph(
             lambda request_id, data, output: [],
         ),
     )
-    monkeypatch.setattr(
-        stages,
-        "_compile_qwen3_tts_backbone",
-        lambda model: compile_calls.append(model),
-    )
-
     def fake_build_sglang_server_args(model_path, context_length, **kwargs):
         del model_path, context_length
         build_kwargs.update(kwargs)
@@ -4733,7 +4641,7 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_reenables_cuda_graph(
     assert build_kwargs["disable_cuda_graph"] is False
     assert build_kwargs["cuda_graph_bs"] == expected_cuda_graph_bs
     assert build_kwargs["cuda_graph_max_bs"] == 64
-    assert build_kwargs["enable_torch_compile"] is True
+    assert build_kwargs["enable_torch_compile"] is False
     assert build_kwargs["sampling_backend"] == "pytorch"
     assert build_kwargs["mem_fraction_static"] == 0.7
     assert build_kwargs["max_running_requests"] == 64
@@ -4744,7 +4652,7 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_reenables_cuda_graph(
         "cuda_graph_max_bs": 64,
         "cuda_graph_bs": expected_cuda_graph_bs,
         "torch_compile_max_bs": 64,
-        "enable_torch_compile": True,
+        "enable_torch_compile": False,
     }
 
     def target():
@@ -4770,7 +4678,6 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_reenables_cuda_graph(
     )
 
     assert infrastructure_saw_deferred_capture == [True]
-    assert len(compile_calls) == 1
     assert init_graph_calls == [True]
     assert scheduler.server_args.cuda_graph_bs == expected_cuda_graph_bs
     assert scheduler.server_args.cuda_graph_max_bs == 64
@@ -4778,39 +4685,6 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_reenables_cuda_graph(
     assert scheduler.server_args.enable_torch_compile is False
     assert scheduler.server_args.torch_compile_max_bs == 64
     clear_qwen3_tts_preprocessing_context()
-
-
-def test_qwen3_tts_engine_probes_runtime_before_checkpoint_resolution(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from sglang_omni.models.qwen3_tts import engine_builder as engine_builder_mod
-    from sglang_omni.scheduling import engine_factory
-
-    checkpoint_resolutions: list[str] = []
-
-    def fake_resolve_checkpoint(model_path: str) -> str:
-        checkpoint_resolutions.append(model_path)
-        raise AssertionError("_resolve_checkpoint should not run before qwen_tts probe")
-
-    original_import_module = engine_builder_mod.importlib.import_module
-
-    def fake_import_module(name: str, package: str | None = None):
-        if name == "qwen_tts":
-            raise ImportError("missing qwen_tts")
-        return original_import_module(name, package)
-
-    monkeypatch.setattr(engine_factory, "_resolve_checkpoint", fake_resolve_checkpoint)
-    monkeypatch.setattr(
-        engine_builder_mod.importlib, "import_module", fake_import_module
-    )
-
-    with pytest.raises(ImportError, match="missing qwen_tts"):
-        engine_builder_mod.Qwen3TtsEngineBuilder().resolve_checkpoint(
-            "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
-        )
-
-    assert checkpoint_resolutions == []
-
 
 def test_qwen3_tts_cli_mem_fraction_static_pins_tts_engine() -> None:
     from sglang_omni.cli.serve import patches_from_broadcast_flags


### PR DESCRIPTION
## Motivation

Qwen3-TTS privately compiles each Talker decoder layer while CUDA Graph remains
enabled. A fixed-length H100 A/B/A comparison shows no reproducible end-to-end
benefit from this path. The compile path also adds launch overhead and produces
unstable kernel selection across fresh caches.

## Modifications

- Remove the private Talker decoder-layer `torch.compile` path.
- Keep Qwen3-TTS CUDA Graph enabled.
- Mark Qwen3-TTS as not supporting SGLang `torch.compile`.
- Reject compile-on CLI arguments before server launch.
- Continue to accept explicit compile-off and shared compile max-batch settings; the latter remains part of the common SGLang batch policy but does not enable model compilation.
- Keep direct access to `self.layers` in the decode hot path.
- Add capability, engine, CLI, and launch-boundary tests.

## Related Issues

Part of #1608.

## Accuracy Test

Current-head targeted verification passes on H100 against current main:

```text
15 Qwen3-TTS compile-path tests passed
35 model-capability tests passed
```

The earlier broader H100 run passed 204 directly affected tests.

The compile A/B/A arms all returned exactly 64 tokens,
`finish_reason=length`, and a 245,804-byte WAV. The compile-removal ABBA check
produced one exact C1 WAV hash across all arms.

## Benchmark & Profiling

Protocol: one H100 80 GB; synchronous decode; CUDA Graph on; fixed seed and
input; exactly 64 generated tokens; 30 measured requests per arm; order
`compile-on A -> compile-off -> compile-on B`.

| Arm | C1 wall | C1 engine | C4 wall | C8 wall |
| --- | ---: | ---: | ---: | ---: |
| compile-on A | 0.566786 s | 0.494674 s | 0.835568 s | 0.935240 s |
| compile-off | 0.559900 s | 0.493761 s | 0.749759 s | 0.901976 s |
| compile-on B | 0.564591 s | 0.494933 s | 0.755342 s | 0.841942 s |

Relative to the midpoint of the two compile-on medians, compile-off is 1.02%
faster for C1 wall, 0.21% faster for C1 engine, and 5.74% faster for C4. It is
1.51% slower for C8, below the 2% decision gate. The two compile-on C8 arms
differ by 10.5%.

Per decode step, compile reduces Talker GPU time from 1.789084 ms to 1.665111
ms, but increases Talker kernels from 367 to 423. It also increases median
`cudaGraphLaunch` CPU time from about 1.84 ms to 3.0788 ms and the
Predictor-to-Talker launch gap from 3.62-3.66 ms to 5.7243 ms. The local GPU
saving does not become an end-to-end saving.

The final removal was compared with the previous compile-off code in ABBA
order, with 30 C1 and 30 controlled-C4 measurements per arm:

| Metric | Previous compile-off | Compile removed | Change |
| --- | ---: | ---: | ---: |
| C1 wall midpoint | 0.565655 s | 0.566197 s | +0.10% |
| C1 engine midpoint | 0.495170 s | 0.498873 s | +0.75% |
| Controlled C4 wall midpoint | 0.751217 s | 0.736219 s | -2.00% |

All changes are within the 2% regression gate. The before/after compile-off
profiles have identical Predictor and Talker kernel counts and identical kernel
sequence hashes. Their GPU sums differ by less than 0.2%.

## Checklist

- [x] Format the changed files with pre-commit.
- [x] Add unit tests.
- [x] Provide latency and profiling evidence.
- [ ] For reviewers: If you have not contributed to this PR and only assist
  with merging main, remove yourself as a co-author when merging.

## CI

GPU CI requires a maintainer to add the `run-ci` label.
