### PR TITLE
[Perf][Fun-CosyVoice3] Batch HiFT vocoder inference

### DIFF
--- a/sglang_omni/models/fun_cosyvoice3/stages.py
+++ b/sglang_omni/models/fun_cosyvoice3/stages.py
@@ -505,11 +505,14 @@ class _CosyVoice3Vocoder(BatchVocoderBase):
             for index, (state, codes) in enumerate(items)
         ]
         results: list[tuple[Any, int] | None] = [None] * len(prepared)
-        buckets: dict[int, list[_PreparedFlowRequest]] = defaultdict(list)
+        flow_buckets: dict[int, list[_PreparedFlowRequest]] = defaultdict(list)
         for request in prepared:
-            buckets[self._flow_bucket_key(request.flow_input)].append(request)
+            flow_buckets[self._flow_bucket_key(request.flow_input)].append(request)
 
-        for bucket in buckets.values():
+        mel_buckets: dict[int, list[tuple[_PreparedFlowRequest, torch.Tensor]]] = (
+            defaultdict(list)
+        )
+        for bucket in flow_buckets.values():
             with torch.autocast(
                 device_type=current_platform.device_type,
                 dtype=self._compute_dtype,
@@ -518,11 +521,20 @@ class _CosyVoice3Vocoder(BatchVocoderBase):
                 mel_list = self._flow.inference(
                     [request.flow_input for request in bucket]
                 )
-                for request, mel in zip(bucket, mel_list, strict=True):
-                    results[request.index] = (
-                        self._mel2wav(mel),
-                        request.sample_rate,
-                    )
+            for request, mel in zip(bucket, mel_list, strict=True):
+                mel_buckets[int(mel.shape[-1])].append((request, mel))
+
+        # HiFT has no per-row length mask, and right-padding changes valid tail
+        # samples through its right-context and ISTFT boundary handling.
+        for bucket in mel_buckets.values():
+            with torch.autocast(
+                device_type=current_platform.device_type,
+                dtype=self._compute_dtype,
+                enabled=self._compute_dtype is not None,
+            ):
+                waveforms = self._mel2wav_batch([item[1] for item in bucket])
+            for (request, _mel), waveform in zip(bucket, waveforms, strict=True):
+                results[request.index] = (waveform, request.sample_rate)
 
         if any(result is None for result in results):
             raise RuntimeError("Fun-CosyVoice3 vocoder did not decode every request")
@@ -584,9 +596,23 @@ class _CosyVoice3Vocoder(BatchVocoderBase):
             * self._flow_batch_bucket_frames
         )
 
-    def _mel2wav(self, tts_mel: torch.Tensor) -> torch.Tensor:
-        tts_speech, _ = self._hift.inference(speech_feat=tts_mel, finalize=True)
-        return tts_speech.detach().cpu()
+    def _mel2wav_batch(self, mel_tensors: list[torch.Tensor]) -> list[torch.Tensor]:
+        speech_feat = (
+            mel_tensors[0] if len(mel_tensors) == 1 else torch.cat(mel_tensors, dim=0)
+        )
+        tts_speech, _ = self._hift.inference(
+            speech_feat=speech_feat,
+            finalize=True,
+        )
+        if tts_speech.shape[0] != len(mel_tensors):
+            raise RuntimeError(
+                "Fun-CosyVoice3 HiFT returned an unexpected batch size: "
+                f"expected {len(mel_tensors)}, got {tts_speech.shape[0]}"
+            )
+        return [
+            tts_speech[index : index + 1].detach().cpu()
+            for index in range(len(mel_tensors))
+        ]
 
     def store_result(
         self,

--- a/tests/unit_test/fun_cosyvoice3/test_vocoder.py
+++ b/tests/unit_test/fun_cosyvoice3/test_vocoder.py
@@ -23,7 +23,13 @@ class _FakeHiFT(torch.nn.Module):
 
     def inference(self, *, speech_feat, finalize):
         self.calls.append((speech_feat, finalize))
-        return torch.arange(speech_feat.shape[-1]).reshape(1, -1).float(), None
+        return speech_feat[:, 0].clone(), None
+
+
+class _WrongBatchHiFT(_FakeHiFT):
+    def inference(self, *, speech_feat, finalize):
+        self.calls.append((speech_feat, finalize))
+        return speech_feat[:1, 0].clone(), None
 
 
 class _FakeEstimator(torch.nn.Module):
@@ -418,3 +424,38 @@ def test_pipeline_config_sets_flow_batch_bucket_by_default() -> None:
         "flow_batch_admission_frames": 2000,
         "enable_dit_torch_compile": False,
     }
+
+
+def test_cosyvoice3_vocoder_batches_hift_by_exact_mel_length(monkeypatch) -> None:
+    flow = _BatchCapableFakeFlow()
+    hift = _FakeHiFT()
+    batch_calls: list[list] = []
+    _install_fake_batch_adapter(monkeypatch, batch_calls)
+    vocoder = stages._CosyVoice3Vocoder(flow, hift)
+    items = [
+        (_state(), _codes(2, 1)),
+        (_state(), _codes(3, 3)),
+        (_state(), _codes(2, 6)),
+    ]
+
+    results = asyncio.run(vocoder.decode_batch(items))
+
+    assert [len(call) for call in batch_calls] == [3]
+    assert [call[0].shape for call in hift.calls] == [(2, 80, 4), (1, 80, 6)]
+    assert [result[0].shape for result in results] == [(1, 4), (1, 6), (1, 4)]
+    assert [result[0][0, 0].item() for result in results] == [1, 3, 6]
+
+
+def test_cosyvoice3_vocoder_rejects_unexpected_hift_batch_size(monkeypatch) -> None:
+    flow = _BatchCapableFakeFlow()
+    hift = _WrongBatchHiFT()
+    batch_calls: list[list] = []
+    _install_fake_batch_adapter(monkeypatch, batch_calls)
+    vocoder = stages._CosyVoice3Vocoder(flow, hift)
+    items = [
+        (_state(), _codes(2, 1)),
+        (_state(), _codes(2, 3)),
+    ]
+
+    with pytest.raises(RuntimeError, match="unexpected batch size"):
+        asyncio.run(vocoder.decode_batch(items))


### PR DESCRIPTION
## Motivation

Fun-CosyVoice3's vocoder scheduler can coalesce requests, but HiFT was still invoked once per request. This implements the HiFT batch-inference item from the CosyVoice3 optimization roadmap without changing the existing Flow batching behavior.

## Modifications

- retain the existing Flow inference path and group its resulting mel tensors by exact frame length
- invoke HiFT once per compatible group without padding variable-length mel tensors
- restore waveforms to original request order and preserve each request's sample rate
- reject unexpected HiFT output batch cardinality
- add unit coverage for mixed-length grouping, batched tensor shapes, output ordering, and cardinality errors

## Related Issues

Related to #1652.

## Accuracy Test

- Fun-CosyVoice3 unit suite: 42 passed
- focused vocoder suite: 8 passed
- adjacent dots.tts and Fish Audio vocoder suites: 14 passed
- changed-line coverage: 100% (48/48)

The batching path only combines equal-length mel tensors; it does not pad variable-length inputs.

A paired real-checkpoint HiFT replay on H100 used three fixed speech-feature tensors extracted with the pinned CosyVoice frontend (207, 230, and 267 mel frames). Each batch repeated the same tensor so serial and batched calls consumed identical inputs. All output cardinality checks passed, all waveforms were finite, and batch-size-one output was exactly identical.

For batch sizes 2, 4, and 8, the observed numerical differences versus serial inference were input-dependent: RMS difference ranged from `3.88e-4` to `3.60e-3`, SNR from `26.38` to `37.94 dB`, and maximum absolute difference reached `0.0730`. At batch 8:

- 207 frames: RMS `0.003601`, SNR `26.38 dB`
- 230 frames: RMS `0.002045`, SNR `33.84 dB`
- 267 frames: RMS `0.000894`, SNR `30.69 dB`

These differences are larger than the earlier independent validation on another mel set (`3e-4` to `1.8e-3`, `41-57 dB`), indicating that the numerical delta depends on the input. No perceptual-equivalence claim is made from these metrics alone. The earlier real-checkpoint serving validation reported sane waveforms, correct ordering/sample rates, and no request failures: https://github.com/sgl-project/sglang-omni/pull/1655#issuecomment-5377558074.

## Benchmark & Profiling

### HiFT-only replay

The benchmark ran on one NVIDIA H100 80GB HBM3 with driver `595.71.05`, PyTorch `2.13.0+cu130`, CUDA `13.0`, bf16 autocast, and `FunAudioLLM/Fun-CosyVoice3-0.5B-2512`. Each cell used one warmup followed by three measured repeats of 100 iterations. The input fixture SHA-256 was `ced543960dda907d533446d9d79e1921be924adb77ce68333f37110839953409`.

The replay loads the same checkpoint HiFT object once and alternates the two call shapes across repeats:

- serial: invoke HiFT once per mel
- batched: concatenate equal-length mels and invoke HiFT once, then split outputs

At batch 8, mean GPU-only latency per item improved by about 3x:

- 207 frames: `45.030 ± 5.163 ms` → `15.457 ± 3.174 ms` (`2.91x`)
- 230 frames: `44.085 ± 5.892 ms` → `14.681 ± 0.742 ms` (`3.00x`)
- 267 frames: `44.919 ± 7.562 ms` → `15.102 ± 3.116 ms` (`2.97x`)

Including output splitting and CPU transfer, batch-8 latency per item improved by `3.03x`, `3.26x`, and `3.04x` for the same three lengths. GPU-only speedup was `1.94-1.98x` at batch 2, `2.34-2.80x` at batch 4, and `2.91-3.00x` at batch 8. Batch-size-one timing varied between `0.85x` and `1.07x` because of repeat/order noise, while its outputs remained exactly equal.

At batch 8, peak allocated memory was approximately `457/494/550 MiB` for 207/230/267 frames, versus `177/181/190 MiB` for serial calls. All 144 timing records were finite and positive, and all 12 accuracy records passed shape, cardinality, and finite-output validation.

This is a mechanism-level benchmark: the checkpoint-provided HiFT implementation is identical between Base and Head; the PR changes call orchestration. Measuring serial and batched calls against the same loaded object and identical mel inputs isolates that change. It intentionally excludes AR generation, Flow, HTTP, preprocessing, scheduler queueing, and mixed-length grouping. No new end-to-end replay was run as part of this validation; independent end-to-end results are linked above.

## End-to-end Benchmark (subsequent validation)

A subsequent end-to-end serving benchmark compared this PR against its exact base using the direct-container, prebuilt-application-image approach. Both application images were built from the same pinned CI image and differed only in the sglang-omni source revision:

- Base: `ef9479460420933d58c243d50befe18e6fe8ce9d`
- Head: `01f93554999c58823c3666233fa8c1fd56a1c635`
- Parent CI image: `hongccc/sglang-omni@sha256:02a85f00438c901c72a2eb2ef738974a807f63af3d13084445604f3344067b19`

The runs used one H100 NVL (`95,830 MiB`, driver `580.82.09`, CUDA `13.0.3`) and retained the same physical GPU UUID across all image activations. To mitigate temporal effects, complete outer blocks were interleaved `Base A -> Head A -> Head B -> Base B`, with a fresh managed server in every block.

The workload used `FunAudioLLM/Fun-CosyVoice3-0.5B-2512`, the pinned first 128 rows of the English SeedTTS split, voice cloning with flat references, non-streaming WAV, bf16/default precision, one warmup request, `max_running_requests=64`, and `cuda_graph_max_bs=64`. The 128-row prefix was used because an initial c=1 rate check showed that four full 1,088-row c=1 blocks alone would exceed the bounded benchmark budget. All 12 measured points completed `128/128` requests with zero failures.

Base and Head below are arithmetic means of their two outer blocks. Delta is `(Head / Base - 1) * 100`; positive is better for throughput and worse for latency/RTF.

| Conc. | Metric | Base | Head | Delta |
|---:|---|---:|---:|---:|
| 1 | Audio throughput (audio s/s) | 4.1245 | 4.1195 | -0.12% |
| 1 | Request throughput (req/s) | 0.9740 | 0.9735 | -0.05% |
| 1 | Mean latency (s) | 1.0265 | 1.0275 | +0.10% |
| 1 | P95 latency (s) | 1.5480 | 1.5610 | +0.84% |
| 1 | Mean RTF | 0.2612 | 0.2617 | +0.15% |
| 1 | P95 RTF | 0.4568 | 0.4582 | +0.28% |
| 8 | Audio throughput (audio s/s) | 15.8595 | 16.2740 | +2.61% |
| 8 | Request throughput (req/s) | 3.4525 | 3.5575 | +3.04% |
| 8 | Mean latency (s) | 2.2830 | 2.2265 | -2.47% |
| 8 | P95 latency (s) | 3.0710 | 3.1295 | +1.90% |
| 8 | Mean RTF | 0.5688 | 0.5556 | -2.31% |
| 8 | P95 RTF | 0.9086 | 0.8976 | -1.22% |
| 16 | Audio throughput (audio s/s) | 15.6205 | 17.8915 | +14.54% |
| 16 | Request throughput (req/s) | 3.4560 | 3.4115 | -1.29% |
| 16 | Mean latency (s) | 4.4835 | 4.5570 | +1.64% |
| 16 | P95 latency (s) | 5.7810 | 5.8450 | +1.11% |
| 16 | Mean RTF | 1.1240 | 1.1037 | -1.80% |
| 16 | P95 RTF | 1.8610 | 1.6966 | -8.83% |

The end-to-end result does **not** show a large request-level improvement. The c=1 control is unchanged. At c=8, aggregate changes are small and the paired-order audio-throughput deltas disagree (`-5.18%` and `+11.09%`). At c=16, audio throughput is `+14.54%`, but Head also generated about 16% more output tokens/audio duration; request throughput is `-1.29%`, mean latency is `+1.64%`, and P95 latency is `+1.11%`. Mean/P95 RTF improve by `1.80%`/`8.83%`. Thus, the mechanism-level HiFT speedup does not translate into a large end-to-end request-level gain for this tested workload.

Published benchmark images:

- Base: `rfgleamchaser/sglang-omni-benchmark@sha256:4726e3b81065dbe639d627a16cd2e248be3d3148321cb78c0bff0680bbd4bbd4`
- Head: `rfgleamchaser/sglang-omni-benchmark@sha256:a2e6e325d3d80bd0c4e9b9b257d13112f741830329c2a8309d649dbe733b5985`

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed. (No user-facing documentation change required.)
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
