### PR TITLE
[Qwen3-ASR]: Fix Qwen3-ASR cache reclamation test

### DIFF
--- a/tests/unit_test/qwen3_asr/test_encoder_service.py
+++ b/tests/unit_test/qwen3_asr/test_encoder_service.py
@@ -672,7 +672,17 @@ def test_the_device_cache_is_really_reclaimed_after_an_oom() -> None:
         device_module.synchronize()
         device_module.empty_cache()
         floor = device_module.memory_reserved()
-        block = torch.empty(64 * 1024 * 1024, dtype=torch.uint8, device=_DEVICE)
+        allocated = device_module.memory_allocated()
+        cached_slack = max(0, floor - allocated)
+        block = torch.empty(
+            cached_slack + 64 * 1024 * 1024,
+            dtype=torch.uint8,
+            device=_DEVICE,
+        )
+        device_module.synchronize()
+        reserved_with_block = device_module.memory_reserved()
+        assert reserved_with_block > floor
+
         del block
         device_module.synchronize()
         reserved_before = device_module.memory_reserved()


### PR DESCRIPTION
## Problem

`test_the_device_cache_is_really_reclaimed_after_an_oom` assumes that allocating a fixed 64 MiB tensor always increases `memory_reserved()` after `empty_cache()`. Existing allocator reservation can satisfy that allocation, causing the setup assertion to fail before `_recover_after_failure()` is exercised.

## Fix

- Size the probe allocation above the allocator's current cached slack.
- Verify allocator growth while the probe tensor is live.
- Retain the checks that deleting the probe leaves reclaimable reservation and recovery releases it.

## Validation

- `.venv/bin/pre-commit run --files tests/unit_test/qwen3_asr/test_encoder_service.py`
- `git diff --check origin/main...HEAD`

Unit tests and benchmarks were not run per repository instructions.