### PR TITLE
[Perf] Enable FlashInfer decode for MOSS-TD

### DIFF
--- a/sglang_omni/models/moss_transcribe_diarize/engine_builder.py
+++ b/sglang_omni/models/moss_transcribe_diarize/engine_builder.py
@@ -120,6 +120,8 @@ class MossTranscribeDiarizeEngineBuilder(AsrEngineBuilder):
             "mem_fraction_static": self.mem_fraction_static,
             "max_prefill_tokens": 4096,
             "chunked_prefill_size": 4096,
+            "decode_attention_backend": "flashinfer",
+            "kv_cache_dtype": "bfloat16",
             "sampling_backend": "pytorch",
             "cuda_graph_backend_prefill": CudaGraphBackend.BREAKABLE,
             "cuda_graph_bs_prefill": prefill_cuda_graph_bs,

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -97,13 +97,15 @@ def test_moss_transcribe_diarize_config_uses_single_batched_stage() -> None:
     }
 
 
-def test_moss_transcribe_diarize_prefill_backend_policy() -> None:
+def test_moss_transcribe_diarize_generation_backend_policy() -> None:
     builder = _make_moss_engine_builder()
 
     assert type(builder).supports_breakable_prefill_cuda_graph is True
     defaults = builder.generation_defaults(dtype="bfloat16")
     assert defaults["enable_torch_compile"] is False
     assert defaults["torch_compile_max_bs"] == 4
+    assert defaults["decode_attention_backend"] == "flashinfer"
+    assert defaults["kv_cache_dtype"] == "bfloat16"
     assert defaults["cuda_graph_backend_prefill"] == "breakable"
     assert defaults["cuda_graph_bs_prefill"] == [
         1,
@@ -137,6 +139,21 @@ def test_moss_transcribe_diarize_compile_cap_survives_batch_overrides() -> None:
         **builder.generation_defaults(dtype="bfloat16"),
     )
     assert operator["torch_compile_max_bs"] == 8
+
+
+def test_moss_transcribe_diarize_preserves_explicit_decode_overrides() -> None:
+    builder = _make_moss_engine_builder()
+
+    overrides = build_generation_batch_overrides(
+        server_args_overrides={
+            "decode_attention_backend": "fa3",
+            "kv_cache_dtype": "auto",
+        },
+        **builder.generation_defaults(dtype="bfloat16"),
+    )
+
+    assert overrides["decode_attention_backend"] == "fa3"
+    assert overrides["kv_cache_dtype"] == "auto"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Motivation

Improve MOSS-Transcribe-Diarize long-audio decode performance with the FlashInfer decode backend while preserving the existing FA3 prefill path. The benchmark grid below includes the full SeedTTS, AISHELL4, and Google Time concurrency coverage so the long-audio gains and short-audio tradeoffs are visible together.

## Modifications

- Use `flashinfer` as the MOSS-Transcribe-Diarize decode attention backend.
- Keep the decode KV cache explicitly in `bfloat16`, matching the validated candidate configuration.
- Preserve explicit operator overrides for both settings.
- Add unit coverage for the defaults and override precedence.

## Related Issues

N/A

## Accuracy Test

**Setup:** MOSS-Transcribe-Diarize on one NVIDIA H100 80GB GPU with the profiler disabled. Main uses FA3 prefill/decode; Candidate uses FA3 prefill, FlashInfer decode, and BF16 KV cache.

- SeedTTS: 1,088 samples per repeat, C=1/8/16/32/64, three fresh repeats per cell, `max_running_requests=64`, decode CUDA graph max batch size 64. Both variants use frozen commit `1ed7017`.
- AISHELL4 and Google Time: 20 and 25 samples per repeat respectively, C=1/4/16, `max_running_requests=16`. Candidate uses `1ed7017`; Main contains runs from `a5249361`.

### SeedTTS

| C | Main WER | Candidate WER | Delta (pp) |
|---:|---:|---:|---:|
| 1 | 1.815981% | 1.808414% | -0.007567 |
| 8 | 1.853814% | 1.838680% | -0.015133 |
| 16 | 1.853814% | 1.838680% | -0.015133 |
| 32 | 1.853814% | 1.838680% | -0.015133 |
| 64 | 1.853814% | 1.838680% | -0.015133 |

### AISHELL4 and Google Time

| Dataset | C | Main cpCER | Candidate cpCER | cpCER delta (pp) | Main DER | Candidate DER | DER delta (pp) |
|---|---:|---:|---:|---:|---:|---:|---:|
| AISHELL4 | 1 | 13.500% | 13.503% | +0.003 | 9.299% | 9.226% | -0.074 |
| AISHELL4 | 4 | 14.730% | 14.060% | -0.671 | 10.059% | 9.661% | -0.398 |
| AISHELL4 | 16 | 14.026% | 14.231% | +0.205 | 9.706% | 9.770% | +0.064 |
| Google Time | 1 | 33.742% | 33.691% | -0.051 | 31.236% | 31.088% | -0.148 |
| Google Time | 4 | 34.451% | 33.713% | -0.738 | 31.738% | 31.063% | -0.674 |
| Google Time | 16 | 35.392% | 35.248% | -0.143 | 32.488% | 32.316% | -0.172 |

## Benchmark & Profiling

Same setup as described in the _Accuracy Test_ section. 

### SeedTTS

| C | Main throughput (samples/s) | Candidate throughput (samples/s) | Throughput delta | Main mean latency (ms) | Candidate mean latency (ms) | Main P95 (ms) | Candidate P95 (ms) |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 23.564 ± 0.175 | 22.443 ± 0.358 | -4.76% | 42.326 ± 0.305 | 44.454 ± 0.698 | 48.649 | 51.167 |
| 8 | 118.022 ± 1.897 | 113.452 ± 1.834 | -3.87% | 67.394 ± 1.077 | 70.157 ± 1.165 | 83.745 | 85.204 |
| 16 | 193.892 ± 1.414 | 186.323 ± 1.112 | -3.90% | 81.898 ± 0.529 | 85.195 ± 0.458 | 99.707 | 103.863 |
| 32 | 282.846 ± 0.673 | 278.015 ± 2.195 | -1.71% | 111.679 ± 0.220 | 113.814 ± 1.080 | 135.257 | 137.045 |
| 64 | 346.222 ± 18.248 | 350.548 ± 5.416 | +1.25% | 181.508 ± 10.537 | 179.011 ± 2.743 | 285.271 | 222.427 |

### AISHELL4 and Google Time

| Dataset | C | Main QPS | Candidate QPS | QPS delta | Main mean latency (s) | Candidate mean latency (s) | Main P95 (s) | Candidate P95 (s) |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| AISHELL4 | 1 | 0.02517 | 0.02475 | -1.66% | 39.719 | 40.387 | 48.533 | 48.880 |
| AISHELL4 | 4 | 0.03650 | 0.04037 | +10.59% | 103.113 | 92.607 | 133.840 | 115.130 |
| AISHELL4 | 16 | 0.04420 | 0.04470 | +1.13% | 277.000 | 278.046 | 346.031 | 349.292 |
| Google Time | 1 | 0.02019 | 0.01993 | -1.31% | 49.481 | 50.145 | 57.281 | 57.700 |
| Google Time | 4 | 0.02606 | 0.03005 | +15.32% | 148.613 | 128.230 | 176.760 | 150.904 |
| Google Time | 16 | 0.03339 | 0.03433 | +2.82% | 401.708 | 392.125 | 578.404 | 574.041 |

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed. No documentation update is needed for this model-local default.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
