### PR TITLE
feat: Add realtime support for NVIDIA NemotronLabs VoiceChat 11B

### DIFF
--- a/benchmarks/eval/benchmark_nemotron_voicechat.py
+++ b/benchmarks/eval/benchmark_nemotron_voicechat.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Prepare and benchmark the Nemotron VoiceChat realtime workload."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import hashlib
+import json
+import math
+import statistics
+import time
+import wave
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import soundfile as sf
+import soxr
+import websockets
+
+INPUT_RATE = 16_000
+SOURCE_RATE = 24_000
+SGLANG_OUTPUT_RATE = 22_050
+NIM_OUTPUT_RATE = 24_000
+FRAME_SAMPLES = 1_280
+FRAME_BYTES = FRAME_SAMPLES * 2
+FRAME_SECONDS = FRAME_SAMPLES / INPUT_RATE
+SOURCE_FRAME_SAMPLES = round(SOURCE_RATE * FRAME_SECONDS)
+TRAILING_SILENCE_SECONDS = 2.0
+DEFAULT_PROMPT = "You are a helpful, concise voice assistant."
+AUDIO_EVENT_TYPES = {
+    "response.audio.delta",
+    "response.output_audio.delta",
+}
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def percentile(values: list[float], probability: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = (len(ordered) - 1) * probability
+    lower = math.floor(index)
+    upper = math.ceil(index)
+    if lower == upper:
+        return ordered[lower]
+    return ordered[lower] * (upper - index) + ordered[upper] * (index - lower)
+
+
+def summarize(values: list[float]) -> dict[str, float | int | None]:
+    return {
+        "count": len(values),
+        "mean": statistics.fmean(values) if values else None,
+        "p50": percentile(values, 0.50),
+        "p95": percentile(values, 0.95),
+        "p99": percentile(values, 0.99),
+        "min": min(values) if values else None,
+        "max": max(values) if values else None,
+    }
+
+
+def aggregate_report(report: dict[str, Any]) -> dict[str, Any]:
+    first_audio = []
+    native_intervals = []
+    paired_intervals = []
+    transcripts = set()
+    audio_event_counts = set()
+    output_sample_counts = set()
+
+    for run in report["runs"]:
+        if run["first_audio_ms"] is not None:
+            first_audio.append(run["first_audio_ms"])
+        transcripts.add(run["text"])
+        audio_event_counts.add(run["audio_event_count"])
+        output_sample_counts.add(run["output_samples"])
+
+        arrivals = [
+            event["arrival_ms"]
+            for event in run["events"]
+            if event["type"] in AUDIO_EVENT_TYPES
+        ]
+        native_intervals.extend(
+            current - previous for previous, current in zip(arrivals, arrivals[1:])
+        )
+
+        # Each response event contains 80 ms of audio for both backends. Pair
+        # adjacent events to compare an equivalent 160 ms media duration.
+        paired_arrivals = arrivals[1::2]
+        close_sent_ms = run.get("session_close_sent_ms")
+        paired_intervals.extend(
+            current - previous
+            for previous, current in zip(paired_arrivals, paired_arrivals[1:])
+            if close_sent_ms is None or not (previous < close_sent_ms <= current)
+        )
+
+    return {
+        "first_audio_ms": summarize(first_audio),
+        "native_audio_event_interval_ms": summarize(native_intervals),
+        "paired_160ms_interval_ms": summarize(paired_intervals),
+        "transcripts": sorted(transcripts),
+        "audio_event_counts": sorted(audio_event_counts),
+        "output_sample_counts": sorted(output_sample_counts),
+    }
+
+
+def prepare_input(source_path: Path, output_path: Path) -> dict[str, Any]:
+    """Match the NIM file client and produce exact 80 ms model frames."""
+    audio, sample_rate = sf.read(source_path, dtype="float32")
+    if sample_rate != SOURCE_RATE or audio.ndim != 1:
+        raise ValueError(
+            f"Expected mono {SOURCE_RATE} Hz source, got "
+            f"shape={audio.shape}, rate={sample_rate}"
+        )
+
+    audio = np.concatenate(
+        (
+            audio,
+            np.zeros(
+                round(TRAILING_SILENCE_SECONDS * SOURCE_RATE),
+                dtype=np.float32,
+            ),
+        )
+    )
+    source_frames = []
+    for offset in range(0, len(audio), SOURCE_FRAME_SAMPLES):
+        frame = audio[offset : offset + SOURCE_FRAME_SAMPLES]
+        if len(frame) < SOURCE_FRAME_SAMPLES:
+            frame = np.pad(frame, (0, SOURCE_FRAME_SAMPLES - len(frame)))
+        pcm = (frame * 32768.0).astype("<i2")
+        source_frames.append(pcm.astype(np.float32) / 32768.0)
+
+    resampler = soxr.ResampleStream(SOURCE_RATE, INPUT_RATE, 1, dtype="float32")
+    converted = [resampler.resample_chunk(frame) for frame in source_frames]
+    converted.append(
+        resampler.resample_chunk(np.array([], dtype=np.float32), last=True)
+    )
+    model_audio = np.concatenate(converted)
+    expected_samples = len(source_frames) * FRAME_SAMPLES
+    if len(model_audio) != expected_samples:
+        raise RuntimeError(
+            f"Expected {expected_samples} converted samples, got {len(model_audio)}"
+        )
+    model_pcm = (model_audio * 32768.0).astype("<i2")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(output_path), "wb") as output:
+        output.setnchannels(1)
+        output.setsampwidth(2)
+        output.setframerate(INPUT_RATE)
+        output.writeframes(model_pcm.tobytes())
+
+    return {
+        "source_path": str(source_path),
+        "source_sha256": sha256(source_path),
+        "output_path": str(output_path),
+        "output_sha256": sha256(output_path),
+        "trailing_silence_seconds": TRAILING_SILENCE_SECONDS,
+        "frame_samples": FRAME_SAMPLES,
+        "frames": len(source_frames),
+        "samples": len(model_pcm),
+    }
+
+
+def load_frames(path: Path) -> list[bytes]:
+    with wave.open(str(path), "rb") as source:
+        metadata = (
+            source.getnchannels(),
+            source.getsampwidth(),
+            source.getframerate(),
+        )
+        raw = source.readframes(source.getnframes())
+    expected = (1, 2, INPUT_RATE)
+    if metadata != expected:
+        raise ValueError(f"Expected WAV metadata {expected}, got {metadata}")
+    if len(raw) == 0 or len(raw) % FRAME_BYTES:
+        raise ValueError(f"Input must contain complete {FRAME_SAMPLES}-sample frames")
+    return [
+        raw[offset : offset + FRAME_BYTES] for offset in range(0, len(raw), FRAME_BYTES)
+    ]
+
+
+def write_pcm16(path: Path, pcm: bytes, sample_rate: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as output:
+        output.setnchannels(1)
+        output.setsampwidth(2)
+        output.setframerate(sample_rate)
+        output.writeframes(pcm)
+
+
+async def run_sglang_session(
+    *, url: str, frames: list[bytes], prompt: str, drain_timeout: float
+) -> tuple[dict[str, Any], bytes]:
+    output = bytearray()
+    events = []
+    audio_arrival_ms = []
+    committed = asyncio.Event()
+
+    async with websockets.connect(
+        url, max_size=8 * 1024 * 1024, ping_interval=20, ping_timeout=60
+    ) as socket:
+        created = json.loads(await socket.recv())
+        session = created.get("session", {})
+        expected = (
+            "session.created",
+            INPUT_RATE,
+            SGLANG_OUTPUT_RATE,
+            FRAME_SAMPLES,
+        )
+        actual = (
+            created.get("type"),
+            session.get("input_sample_rate"),
+            session.get("output_sample_rate"),
+            session.get("frame_samples"),
+        )
+        if actual != expected:
+            raise RuntimeError(f"Unexpected realtime session: {created}")
+        await socket.send(
+            json.dumps(
+                {
+                    "type": "session.update",
+                    "session": {"instructions": prompt},
+                }
+            )
+        )
+        updated = json.loads(await socket.recv())
+        if updated.get("type") != "session.updated":
+            raise RuntimeError(f"Expected session.updated, got {updated}")
+
+        origin_ns = time.perf_counter_ns()
+
+        async def receive_events() -> None:
+            async for raw_event in socket:
+                received_ns = time.perf_counter_ns()
+                event = json.loads(raw_event)
+                event_type = event.get("type")
+                record = {
+                    "type": event_type,
+                    "arrival_ms": (received_ns - origin_ns) / 1e6,
+                }
+                if "frame_index" in event:
+                    record["frame_index"] = event["frame_index"]
+                if event_type == "response.audio.delta":
+                    pcm = base64.b64decode(event["delta"], validate=True)
+                    output.extend(pcm)
+                    audio_arrival_ms.append(record["arrival_ms"])
+                    record["samples"] = len(pcm) // 2
+                elif event_type == "response.text.delta":
+                    record["delta"] = event.get("delta", "")
+                elif event_type == "input_audio_buffer.committed":
+                    committed.set()
+                elif event_type == "error":
+                    raise RuntimeError(event.get("error", {}).get("message", event))
+                events.append(record)
+
+        receiver = asyncio.create_task(receive_events())
+        frame_records = []
+        try:
+            for index, frame in enumerate(frames):
+                deadline_ns = origin_ns + int(index * FRAME_SECONDS * 1e9)
+                remaining_ns = deadline_ns - time.perf_counter_ns()
+                if remaining_ns > 0:
+                    await asyncio.sleep(remaining_ns / 1e9)
+                send_start_ns = time.perf_counter_ns()
+                await socket.send(
+                    json.dumps(
+                        {
+                            "type": "input_audio_buffer.append",
+                            "audio": base64.b64encode(frame).decode("ascii"),
+                        }
+                    )
+                )
+                sent_ns = time.perf_counter_ns()
+                frame_records.append(
+                    {
+                        "index": index,
+                        "send_lateness_ms": max(0, send_start_ns - deadline_ns) / 1e6,
+                        "send_duration_ms": (sent_ns - send_start_ns) / 1e6,
+                    }
+                )
+            await socket.send(json.dumps({"type": "input_audio_buffer.commit"}))
+            await asyncio.wait_for(committed.wait(), timeout=drain_timeout)
+            stream_done_ns = time.perf_counter_ns()
+            await socket.send(json.dumps({"type": "session.close"}))
+            close_sent_ns = time.perf_counter_ns()
+            await asyncio.wait_for(receiver, timeout=drain_timeout)
+        finally:
+            if not receiver.done():
+                receiver.cancel()
+                await asyncio.gather(receiver, return_exceptions=True)
+
+    intervals = [
+        current - previous
+        for previous, current in zip(audio_arrival_ms, audio_arrival_ms[1:])
+    ]
+    return (
+        {
+            "first_audio_ms": audio_arrival_ms[0] if audio_arrival_ms else None,
+            "stream_total_ms": (stream_done_ns - origin_ns) / 1e6,
+            "session_close_sent_ms": (close_sent_ns - origin_ns) / 1e6,
+            "audio_event_count": len(audio_arrival_ms),
+            "output_samples": len(output) // 2,
+            "audio_interval_ms": summarize(intervals),
+            "send_lateness_ms": summarize(
+                [record["send_lateness_ms"] for record in frame_records]
+            ),
+            "text": "".join(
+                event.get("delta", "")
+                for event in events
+                if event["type"] == "response.text.delta"
+            ),
+            "frames": frame_records,
+            "events": events,
+        },
+        bytes(output),
+    )
+
+
+async def benchmark_sglang(args: argparse.Namespace) -> dict[str, Any]:
+    frames = load_frames(args.input_wav)
+    report = benchmark_metadata(
+        args, "sglang-omni-websocket", frames, SGLANG_OUTPUT_RATE
+    )
+    for index in range(args.warmup_runs):
+        record, _ = await run_sglang_session(
+            url=args.url,
+            frames=frames,
+            prompt=args.prompt,
+            drain_timeout=args.drain_timeout,
+        )
+        record["run"] = index + 1
+        report["warmup"].append(record)
+    for index in range(args.runs):
+        record, pcm = await run_sglang_session(
+            url=args.url,
+            frames=frames,
+            prompt=args.prompt,
+            drain_timeout=args.drain_timeout,
+        )
+        record["run"] = index + 1
+        report["runs"].append(record)
+        write_pcm16(
+            args.output_dir / f"run-{index + 1}.wav",
+            pcm,
+            SGLANG_OUTPUT_RATE,
+        )
+        print_run(record)
+    return report
+
+
+async def run_nim_session(
+    *, url: str, frames: list[bytes], prompt: str, drain_timeout: float
+) -> tuple[dict[str, Any], bytes]:
+    output = bytearray()
+    events = []
+    audio_arrival_ms = []
+    session_end = asyncio.Event()
+
+    async with websockets.connect(
+        url, max_size=8 * 1024 * 1024, ping_interval=20, ping_timeout=60
+    ) as socket:
+        created = json.loads(await socket.recv())
+        if created.get("type") != "session.created":
+            raise RuntimeError(f"Expected session.created, got {created}")
+        await socket.send(
+            json.dumps(
+                {
+                    "type": "session.update",
+                    "session": {
+                        "audio": {
+                            "input": {
+                                "format": {
+                                    "type": "audio/pcm",
+                                    "rate": INPUT_RATE,
+                                }
+                            },
+                            "output": {"format": "pcm16"},
+                        },
+                        "instructions": prompt,
+                        "tools": [],
+                    },
+                }
+            )
+        )
+        updated = json.loads(await socket.recv())
+        if updated.get("type") != "session.updated":
+            raise RuntimeError(f"Expected session.updated, got {updated}")
+
+        origin_ns = time.perf_counter_ns()
+
+        async def receive_events() -> None:
+            async for raw_event in socket:
+                received_ns = time.perf_counter_ns()
+                event = json.loads(raw_event)
+                event_type = event.get("type")
+                record = {
+                    "type": event_type,
+                    "arrival_ms": (received_ns - origin_ns) / 1e6,
+                }
+                if event_type == "response.output_audio.delta":
+                    pcm = base64.b64decode(event["delta"], validate=True)
+                    output.extend(pcm)
+                    audio_arrival_ms.append(record["arrival_ms"])
+                    record["samples"] = len(pcm) // 2
+                elif event_type == "response.output_audio_transcript.delta":
+                    record["delta"] = event.get("delta", "")
+                elif event_type == "response.output_audio_transcript.done":
+                    record["transcript"] = event.get("transcript", "")
+                elif event_type == "session.end":
+                    record["stats"] = event.get("stats", {})
+                    session_end.set()
+                elif event_type == "error":
+                    raise RuntimeError(event.get("error", {}).get("message", event))
+                events.append(record)
+
+        receiver = asyncio.create_task(receive_events())
+        frame_records = []
+        try:
+            for index, frame in enumerate(frames):
+                deadline_ns = origin_ns + int(index * FRAME_SECONDS * 1e9)
+                remaining_ns = deadline_ns - time.perf_counter_ns()
+                if remaining_ns > 0:
+                    await asyncio.sleep(remaining_ns / 1e9)
+                send_start_ns = time.perf_counter_ns()
+                await socket.send(
+                    json.dumps(
+                        {
+                            "type": "input_audio_buffer.append",
+                            "audio": base64.b64encode(frame).decode("ascii"),
+                        }
+                    )
+                )
+                sent_ns = time.perf_counter_ns()
+                frame_records.append(
+                    {
+                        "index": index,
+                        "send_lateness_ms": max(0, send_start_ns - deadline_ns) / 1e6,
+                        "send_duration_ms": (sent_ns - send_start_ns) / 1e6,
+                    }
+                )
+            await asyncio.sleep(2.0)
+            await socket.send(json.dumps({"type": "session.close"}))
+            close_sent_ns = time.perf_counter_ns()
+            await asyncio.wait_for(session_end.wait(), timeout=drain_timeout)
+            stream_done_ns = time.perf_counter_ns()
+            receiver.cancel()
+            await asyncio.gather(receiver, return_exceptions=True)
+        finally:
+            if not receiver.done():
+                receiver.cancel()
+                await asyncio.gather(receiver, return_exceptions=True)
+
+    intervals = [
+        current - previous
+        for previous, current in zip(audio_arrival_ms, audio_arrival_ms[1:])
+    ]
+    transcripts = [
+        event["transcript"]
+        for event in events
+        if event["type"] == "response.output_audio_transcript.done"
+        and event.get("transcript")
+    ]
+    text = " ".join(transcripts) or "".join(
+        event.get("delta", "")
+        for event in events
+        if event["type"] == "response.output_audio_transcript.delta"
+    )
+    return (
+        {
+            "first_audio_ms": audio_arrival_ms[0] if audio_arrival_ms else None,
+            "stream_total_ms": (stream_done_ns - origin_ns) / 1e6,
+            "session_close_sent_ms": (close_sent_ns - origin_ns) / 1e6,
+            "audio_event_count": len(audio_arrival_ms),
+            "output_samples": len(output) // 2,
+            "audio_interval_ms": summarize(intervals),
+            "send_lateness_ms": summarize(
+                [record["send_lateness_ms"] for record in frame_records]
+            ),
+            "text": text,
+            "frames": frame_records,
+            "events": events,
+        },
+        bytes(output),
+    )
+
+
+async def benchmark_nim(args: argparse.Namespace) -> dict[str, Any]:
+    frames = load_frames(args.input_wav)
+    report = benchmark_metadata(args, "nvidia-nim-websocket", frames, NIM_OUTPUT_RATE)
+    for index in range(args.warmup_runs):
+        record, _ = await run_nim_session(
+            url=args.url,
+            frames=frames,
+            prompt=args.prompt,
+            drain_timeout=args.drain_timeout,
+        )
+        record["run"] = index + 1
+        report["warmup"].append(record)
+    for index in range(args.runs):
+        record, pcm = await run_nim_session(
+            url=args.url,
+            frames=frames,
+            prompt=args.prompt,
+            drain_timeout=args.drain_timeout,
+        )
+        record["run"] = index + 1
+        report["runs"].append(record)
+        write_pcm16(
+            args.output_dir / f"run-{index + 1}.wav",
+            pcm,
+            NIM_OUTPUT_RATE,
+        )
+        print_run(record)
+    return report
+
+
+def benchmark_metadata(
+    args,
+    engine: str,
+    frames: list[bytes],
+    output_sample_rate: int,
+) -> dict[str, Any]:
+    return {
+        "engine": engine,
+        "url": args.url,
+        "input_wav": str(args.input_wav),
+        "input_sha256": sha256(args.input_wav),
+        "input_sample_rate": INPUT_RATE,
+        "input_frame_samples": FRAME_SAMPLES,
+        "input_frame_count": len(frames),
+        "output_sample_rate": output_sample_rate,
+        "prompt": args.prompt,
+        "paced": True,
+        "warmup_runs": args.warmup_runs,
+        "warmup": [],
+        "runs": [],
+    }
+
+
+def print_run(record: dict[str, Any]) -> None:
+    print(
+        f"run={record['run']} first_audio_ms={record['first_audio_ms']:.3f} "
+        f"audio_events={record['audio_event_count']} text={record['text']!r}",
+        flush=True,
+    )
+
+
+def add_benchmark_arguments(parser: argparse.ArgumentParser, default_url: str) -> None:
+    parser.add_argument("--url", default=default_url)
+    parser.add_argument("--input-wav", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT)
+    parser.add_argument("--warmup-runs", type=int, default=1)
+    parser.add_argument("--runs", type=int, default=20)
+    parser.add_argument("--drain-timeout", type=float, default=300.0)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare = subparsers.add_parser("prepare")
+    prepare.add_argument("source_wav", type=Path)
+    prepare.add_argument("output_wav", type=Path)
+
+    sglang = subparsers.add_parser("sglang")
+    add_benchmark_arguments(sglang, "ws://127.0.0.1:18080/v1/realtime")
+
+    nim = subparsers.add_parser("nim")
+    add_benchmark_arguments(nim, "ws://127.0.0.1:9000/v1/realtime")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    if args.command == "prepare":
+        print(json.dumps(prepare_input(args.source_wav, args.output_wav), indent=2))
+        return
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    if args.command == "sglang":
+        report = asyncio.run(benchmark_sglang(args))
+    else:
+        report = asyncio.run(benchmark_nim(args))
+    report["summary"] = aggregate_report(report)
+    output_json = args.output_dir / "raw.json"
+    output_json.write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps(report["summary"], indent=2))
+    print(f"wrote {output_json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/cookbook/nemotron_voicechat.md
+++ b/docs/cookbook/nemotron_voicechat.md
@@ -1,0 +1,272 @@
+# NVIDIA NemotronLabs VoiceChat 11B
+
+[NVIDIA-NemotronLabs-VoiceChat-11B](https://huggingface.co/nvidia/NVIDIA-NemotronLabs-VoiceChat-11B)
+is a frame-locked, full-duplex speech-to-speech model. SGLang-Omni runs it as
+four colocated stages on one H100:
+
+```text
+16 kHz PCM -> perception (Conformer) -> thinker (Nemotron-H)
+           -> talker (EarTTS) -> code2wav (RVQ-VAE) -> 22.05 kHz PCM
+```
+
+The realtime endpoint consumes 1,280-sample PCM16 frames (80 ms) continuously.
+It does not wait for voice-activity detection or a turn boundary, so microphone
+input continues while assistant audio is playing.
+
+## Prerequisites
+
+Use NVIDIA's VoiceChat runtime environment, which supplies the checkpoint's
+`nemo.collections.speechlm2` modules, and install SGLang-Omni in that
+environment. SGLang-Omni registers its VoiceChat models at runtime and works
+with its pinned published SGLang package; no separate SGLang source checkout is
+required.
+
+Prepare an absolute data directory outside the repository with this layout:
+
+```text
+/absolute/path/to/voicechat-data/
+├── checkpoint/
+│   ├── config.json
+│   └── model.safetensors
+└── converted/
+    ├── duplex/
+    │   ├── config.json
+    │   └── model.safetensors.index.json
+    └── eartts/
+        ├── config.json
+        ├── model.safetensors
+        └── speaker_latents/
+            └── <speaker>.pt
+```
+
+`checkpoint` is the unchanged Hugging Face snapshot. Do not point
+`--model-path` at only the snapshot or only the converted folder; it must
+point at their common `voicechat-data` parent.
+
+Set `VOICECHAT_DATA` to that absolute parent directory, download the snapshot,
+and create the two runtime stage directories:
+
+```bash
+export VOICECHAT_DATA=/absolute/path/to/voicechat-data
+
+mkdir -p "$VOICECHAT_DATA/checkpoint" "$VOICECHAT_DATA/converted"
+hf download nvidia/NVIDIA-NemotronLabs-VoiceChat-11B \
+  --local-dir "$VOICECHAT_DATA/checkpoint"
+
+python -m sglang_omni.models.nemotron_voicechat.convert_duplex \
+  --checkpoint "$VOICECHAT_DATA/checkpoint" \
+  --config "$VOICECHAT_DATA/checkpoint/config.json" \
+  --output "$VOICECHAT_DATA/converted/duplex"
+
+python -m sglang_omni.models.nemotron_voicechat.convert_eartts \
+  --config "$VOICECHAT_DATA/checkpoint/config.json" \
+  --model "$VOICECHAT_DATA/checkpoint/model.safetensors" \
+  --output "$VOICECHAT_DATA/converted/eartts"
+```
+
+The EarTTS conversion instantiates NVIDIA's trained character-aware subword
+encoder and should run with a GPU in the VoiceChat runtime environment. Reduce
+`--precompute-batch-size` from its default of `256` if needed. Authenticate
+with the Hugging Face CLI before downloading if model access requires accepted
+terms; do not put access tokens in commands or checked-in files.
+
+## Launch
+
+Pass the absolute `voicechat-data` parent to the provided configuration:
+
+```bash
+export VOICECHAT_DATA=/absolute/path/to/voicechat-data
+
+sgl-omni serve \
+  --model-path "$VOICECHAT_DATA" \
+  --config examples/configs/nemotron_voicechat_h100.yaml \
+  --enable-realtime \
+  --host 0.0.0.0 \
+  --port 18080
+```
+
+Startup runs two disposable silent frames through all four stages and closes
+that session before accepting traffic. This warms the perception graph,
+autoregressive engines, and codec without leaking conversational state into a
+real client session.
+
+Connect a realtime WebSocket client to `ws://HOST:18080/v1/realtime`. Send
+base64-encoded mono PCM16 through `input_audio_buffer.append`; chunks may contain
+any whole number of PCM16 samples because the server assembles exact 1,280-sample
+model frames. Assistant audio arrives in `response.audio.delta` events as raw
+22.05 kHz PCM16 base64. Send `input_audio_buffer.commit` to drain the current
+queue, and `session.close` before disconnecting when possible.
+
+## Live microphone client
+
+The example client captures and resamples microphone audio, streams it while
+playing the model response, prints returned text, and saves the response to a
+WAV file. Install its optional audio dependency on the client machine:
+
+```bash
+# macOS
+brew install portaudio
+python -m pip install pyaudio websockets
+
+# Ubuntu/Debian
+sudo apt-get install portaudio19-dev
+python -m pip install pyaudio websockets
+```
+
+If the server is on a remote host, forward its realtime port from the client
+machine and leave the tunnel running:
+
+```bash
+ssh -N -L 18080:127.0.0.1:18080 USER@SERVER_HOST
+```
+
+From the SGLang-Omni repository root, list the available audio devices:
+
+```bash
+python examples/nemotron_voicechat_client.py --list-devices
+```
+
+Then start a full-duplex session. Device indices are optional when the default
+input and output devices are correct:
+
+```bash
+python examples/nemotron_voicechat_client.py \
+  --url ws://127.0.0.1:18080/v1/realtime \
+  --input-device-index INPUT_INDEX \
+  --output-device-index OUTPUT_INDEX \
+  --output-wav response.wav
+```
+
+Use headphones to prevent speaker output from feeding back into the microphone.
+Speak at any time during the session, including while the assistant is speaking,
+and press Enter to stop. Use `--microphone-seconds N` for a fixed-duration run
+or `--no-playback` to save the returned audio without playing it.
+
+## Reproduce the latency benchmark
+
+The benchmark uses file input, not microphone input. The reported workload
+starts with `/s2s/what_is_your_name.wav` from the pinned NIM image, appends two
+seconds of silence, converts it to 137 PCM16 frames at 16 kHz, and sends one
+1,280-sample frame every 80 ms. One complete session is discarded before 20
+fresh sessions are measured.
+
+Extract the public fixture and prepare the exact input:
+
+```bash
+export NIM_IMAGE=nvcr.io/nim/nvidia/nemotron-labs-voicechat@sha256:6e69ff2aac955be2cb65b0de4f5b6d7c0b5e45ca0a1d42a2b153e9b54efb059b
+export VOICECHAT_BENCH=/absolute/path/to/voicechat-benchmark
+
+mkdir -p "$VOICECHAT_BENCH"
+docker create --name voicechat-nim-files "$NIM_IMAGE"
+docker cp voicechat-nim-files:/s2s/what_is_your_name.wav \
+  "$VOICECHAT_BENCH/what_is_your_name.wav"
+docker rm voicechat-nim-files
+
+python benchmarks/eval/benchmark_nemotron_voicechat.py prepare \
+  "$VOICECHAT_BENCH/what_is_your_name.wav" \
+  "$VOICECHAT_BENCH/what_is_your_name_137x80ms_16k_pcm16.wav"
+```
+
+The source SHA-256 should be
+`34137b55b03d6ccd0e054c98f9d973b93ab7e18a2c8f30efef92425cc71e6dfa`;
+the prepared WAV SHA-256 should be
+`77aa93a6cc36ec7f9371a91c14bb1a4048240a0d6d5b907ea961e84c29fa103d`.
+`VOICECHAT_BENCH` is only an output directory; it is not the checkpoint path
+used by `--model-path`.
+
+With the SGLang-Omni server running, reproduce the 20 measured sessions:
+
+```bash
+python benchmarks/eval/benchmark_nemotron_voicechat.py sglang \
+  --url ws://127.0.0.1:18080/v1/realtime \
+  --input-wav "$VOICECHAT_BENCH/what_is_your_name_137x80ms_16k_pcm16.wav" \
+  --output-dir "$VOICECHAT_BENCH/sglang" \
+  --warmup-runs 1 \
+  --runs 20
+```
+
+The command writes every response WAV and a `raw.json` containing the input
+hash, frame schedule, arrival timestamps, transcript, and aggregate summary.
+
+For the matched comparison, create a NIM Triton model repository from the same
+published checkpoint. `VOICECHAT_NIM_MODEL_REPO` must be an absolute, empty
+output directory; it is not the SGLang `--model-path`:
+
+```bash
+export VOICECHAT_NIM_MODEL_REPO=/absolute/path/to/nim-model-repository
+
+mkdir -p "$VOICECHAT_NIM_MODEL_REPO"
+docker run --rm --gpus all \
+  -v "$VOICECHAT_DATA/checkpoint:/checkpoint:ro" \
+  -v "$VOICECHAT_NIM_MODEL_REPO:/data/models" \
+  -e NEMO_CHECKPOINT_PATH=/checkpoint \
+  -e MODEL_REPOSITORY=/data/models \
+  --entrypoint /s2s/deploy_s2s_model.sh \
+  "$NIM_IMAGE"
+```
+
+Launch the pinned NIM image as described in NVIDIA's
+[deployment guide](https://github.com/NVIDIA-NeMo/Speech/blob/nemotron-labs-voicechat/voicechat_realtime_instructions/deploy.md).
+This is the command used for the reference results:
+
+```bash
+docker run --rm --gpus all --network host --shm-size 8g \
+  -v "$VOICECHAT_NIM_MODEL_REPO:/data/models:ro" \
+  -e MODEL_REPOSITORY=/data/models \
+  -e NIM_HTTP_API_PORT=9000 \
+  "$NIM_IMAGE"
+```
+
+After `http://127.0.0.1:9000/v1/realtime/health` reports `ok`, send the same
+prepared 16 kHz PCM16 frames through its public WebSocket endpoint:
+
+```bash
+python benchmarks/eval/benchmark_nemotron_voicechat.py nim \
+  --url ws://127.0.0.1:9000/v1/realtime \
+  --input-wav "$VOICECHAT_BENCH/what_is_your_name_137x80ms_16k_pcm16.wav" \
+  --output-dir "$VOICECHAT_BENCH/nim" \
+  --warmup-runs 1 \
+  --runs 20
+```
+
+Both commands measure from the first audio-frame send to the first audio-event
+arrival at their public WebSocket endpoints. They use identical input bytes,
+80 ms pacing, prompt, warmup count, and run count. Native output sample rates
+and chunk sizes remain unchanged and are recorded in each `raw.json`.
+
+### Reference results
+
+These results were collected on August 21, 2026, with both servers running
+separately on the same H100 PCIe. The SGLang-Omni server used this PR with
+`sglang==0.5.16`. NIM used the pinned image above. All 20 measured sessions
+from both backends returned `I am your AI voice assistant.`.
+
+| Backend | Runs | Mean first audio | Median | p95 | Min | Max |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| NVIDIA NIM 2.0.0 | 20 | 315.59 ms | 315.96 ms | 317.77 ms | 311.91 ms | 322.31 ms |
+| SGLang-Omni | 20 | 173.93 ms | 174.59 ms | 175.34 ms | 169.89 ms | 175.44 ms |
+
+The public NIM endpoint delivers two 80 ms audio events back-to-back in each
+160 ms emission batch. SGLang-Omni delivers one 80 ms event at a time. The
+paired row below groups adjacent SGLang events using their arrival timestamps
+to compare the same 160 ms media duration:
+
+| Delivery | Intervals | Mean gap | Median gap | p95 gap | p99 gap |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| NIM 160 ms emission batch | 1,320 | 160.04 ms | 162.24 ms | 164.98 ms | 166.47 ms |
+| SGLang native 80 ms event | 2,720 | 79.47 ms | 79.46 ms | 86.02 ms | 89.60 ms |
+| SGLang paired to 160 ms | 1,340 | 159.40 ms | 159.65 ms | 165.89 ms | 168.78 ms |
+
+The NIM cadence row excludes the final batch whose interval crosses
+`session.close`. The reference file client deliberately waits two seconds
+after the input file before closing, so that last gap measures the shutdown
+policy rather than steady-state audio delivery. The benchmark records the
+close timestamp and applies this rule when producing
+`paired_160ms_interval_ms`.
+
+## Current limits
+
+- The supplied one-H100 configuration admits one full-duplex session.
+- Inputs must be mono PCM16 at 16 kHz; clients must resample microphone audio.
+- The SGLang thinker uses bfloat16 for latency. Use float32 when producing a
+  token-for-token reference comparison.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -109,6 +109,7 @@ Supported Models
    cookbook/moss_transcribe_diarize.md
    cookbook/whisper_asr.md
    cookbook/qwen3_omni.md
+   cookbook/nemotron_voicechat.md
    cookbook/ming_omni.md
    cookbook/llada2_uni.md
 

--- a/examples/configs/nemotron_voicechat_h100.yaml
+++ b/examples/configs/nemotron_voicechat_h100.yaml
@@ -1,0 +1,31 @@
+config_cls: NemotronVoiceChatPipelineConfig
+model_path: /path/to/voicechat-data
+name: nvidia-nemotronlabs-voicechat-11b
+stages:
+  perception:
+    factory:
+      dtype: float32
+      use_cudagraph: true
+      max_sessions: 1
+    gpu_memory_fraction: 0.12
+  thinker:
+    factory:
+      dtype: bfloat16
+      context_length: 8192
+      max_sessions: 1
+    engine:
+      mem_fraction_static: 0.45
+    gpu_memory_fraction: 0.52
+  talker:
+    factory:
+      dtype: float32
+      context_length: 8192
+      max_sessions: 1
+    engine:
+      mem_fraction_static: 0.20
+    gpu_memory_fraction: 0.22
+  code2wav:
+    factory:
+      dtype: float32
+      max_sessions: 1
+    gpu_memory_fraction: 0.08

--- a/examples/nemotron_voicechat_client.py
+++ b/examples/nemotron_voicechat_client.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Microphone client for the Nemotron VoiceChat realtime endpoint."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import json
+import math
+import sys
+import time
+import wave
+from array import array
+from pathlib import Path
+
+import websockets
+
+INPUT_RATE = 16_000
+OUTPUT_RATE = 22_050
+FRAME_SAMPLES = 1_280
+FRAME_BYTES = FRAME_SAMPLES * 2
+
+
+def resample_pcm16(pcm: bytes, source_rate: int, target_rate: int) -> bytes:
+    """Linearly resample mono little-endian PCM16 without extra dependencies."""
+    if source_rate == target_rate or not pcm:
+        return pcm
+    samples = array("h")
+    samples.frombytes(pcm)
+    if sys.byteorder != "little":
+        samples.byteswap()
+    output_count = round(len(samples) * target_rate / source_rate)
+    output = array("h")
+    for index in range(output_count):
+        position = index * source_rate / target_rate
+        left = min(int(position), len(samples) - 1)
+        right = min(left + 1, len(samples) - 1)
+        fraction = position - left
+        output.append(
+            round(samples[left] * (1.0 - fraction) + samples[right] * fraction)
+        )
+    if sys.byteorder != "little":
+        output.byteswap()
+    return output.tobytes()
+
+
+def _load_pyaudio():
+    try:
+        import pyaudio
+    except ImportError as error:
+        raise RuntimeError(
+            "Microphone capture and playback require PyAudio. Install PortAudio, "
+            "then run `python -m pip install pyaudio`."
+        ) from error
+    return pyaudio
+
+
+def list_audio_devices() -> None:
+    pyaudio = _load_pyaudio()
+    audio = pyaudio.PyAudio()
+    try:
+        for index in range(audio.get_device_count()):
+            info = audio.get_device_info_by_index(index)
+            print(
+                f"{index}: {info['name']} "
+                f"(inputs={info['maxInputChannels']}, "
+                f"outputs={info['maxOutputChannels']}, "
+                f"default_rate={info['defaultSampleRate']})"
+            )
+    finally:
+        audio.terminate()
+
+
+class AudioDevices:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.pyaudio = _load_pyaudio()
+        self.audio = self.pyaudio.PyAudio()
+        self.input_stream = None
+        self.output_stream = None
+        self.input_frames_read = 0
+        try:
+            input_info = self._device_info(args.input_device_index, capture=True)
+            self.input_rate = round(input_info["defaultSampleRate"])
+            self.input_frame_samples = round(self.input_rate * 0.08)
+
+            input_kwargs = {
+                "format": self.pyaudio.paInt16,
+                "channels": 1,
+                "rate": self.input_rate,
+                "input": True,
+                "frames_per_buffer": self.input_frame_samples,
+            }
+            if args.input_device_index is not None:
+                input_kwargs["input_device_index"] = args.input_device_index
+            self.input_stream = self.audio.open(**input_kwargs)
+            print(
+                f"input device: {input_info['name']} at {self.input_rate} Hz "
+                f"(resampled to {INPUT_RATE} Hz)"
+            )
+
+            if not args.no_playback:
+                output_info = self._device_info(args.output_device_index, capture=False)
+                self.output_rate = round(output_info["defaultSampleRate"])
+                output_kwargs = {
+                    "format": self.pyaudio.paInt16,
+                    "channels": 1,
+                    "rate": self.output_rate,
+                    "output": True,
+                    "frames_per_buffer": round(self.output_rate * 0.08),
+                }
+                if args.output_device_index is not None:
+                    output_kwargs["output_device_index"] = args.output_device_index
+                self.output_stream = self.audio.open(**output_kwargs)
+                print(
+                    f"output device: {output_info['name']} at {self.output_rate} Hz "
+                    f"(resampled from {OUTPUT_RATE} Hz)"
+                )
+        except Exception:
+            self.close()
+            raise
+
+    def _device_info(self, index: int | None, *, capture: bool):
+        if index is not None:
+            return self.audio.get_device_info_by_index(index)
+        if capture:
+            return self.audio.get_default_input_device_info()
+        return self.audio.get_default_output_device_info()
+
+    def read(self) -> bytes:
+        pcm = self.input_stream.read(
+            self.input_frame_samples, exception_on_overflow=False
+        )
+        samples = array("h")
+        samples.frombytes(pcm)
+        peak = max((abs(sample) for sample in samples), default=0)
+        rms = math.sqrt(
+            sum(sample * sample for sample in samples) / max(1, len(samples))
+        )
+        self.input_frames_read += 1
+        if self.input_frames_read == 1 or self.input_frames_read % 12 == 0:
+            print(f"microphone level: rms={rms:.0f} peak={peak}", flush=True)
+        return resample_pcm16(pcm, self.input_rate, INPUT_RATE)
+
+    def write(self, pcm: bytes) -> None:
+        if self.output_stream is not None:
+            self.output_stream.write(resample_pcm16(pcm, OUTPUT_RATE, self.output_rate))
+
+    def close(self) -> None:
+        for stream in (self.input_stream, self.output_stream):
+            if stream is not None:
+                try:
+                    stream.stop_stream()
+                finally:
+                    stream.close()
+        self.input_stream = None
+        self.output_stream = None
+        if self.audio is not None:
+            self.audio.terminate()
+            self.audio = None
+
+
+def validate_session_created(event: dict) -> None:
+    if event.get("type") != "session.created":
+        raise RuntimeError(f"Expected session.created, got {event.get('type')!r}")
+    session = event.get("session", {})
+    expected = {
+        "input_audio_format": "pcm16",
+        "input_sample_rate": INPUT_RATE,
+        "output_audio_format": "pcm16",
+        "output_sample_rate": OUTPUT_RATE,
+        "frame_samples": FRAME_SAMPLES,
+    }
+    mismatches = {
+        key: (session.get(key), value)
+        for key, value in expected.items()
+        if session.get(key) != value
+    }
+    if mismatches:
+        details = ", ".join(
+            f"{key}={actual!r} (expected {expected_value!r})"
+            for key, (actual, expected_value) in mismatches.items()
+        )
+        raise RuntimeError(f"Incompatible realtime session: {details}")
+
+
+async def _send_frame(socket, frame: bytes) -> None:
+    await socket.send(
+        json.dumps(
+            {
+                "type": "input_audio_buffer.append",
+                "audio": base64.b64encode(frame).decode("ascii"),
+            }
+        )
+    )
+
+
+async def _send_microphone(socket, receiver, devices, duration: float | None) -> None:
+    print("Microphone streaming started.")
+    stop_waiter = None
+    deadline = None
+    if duration is None:
+        stop_waiter = asyncio.create_task(
+            asyncio.to_thread(input, "Press Enter to stop the session.\n")
+        )
+    else:
+        deadline = time.monotonic() + duration
+
+    try:
+        while True:
+            if stop_waiter is not None and stop_waiter.done():
+                await stop_waiter
+                break
+            if deadline is not None and time.monotonic() >= deadline:
+                break
+            frame = await asyncio.to_thread(devices.read)
+            await _send_frame(socket, frame)
+            if receiver.done():
+                await receiver
+    finally:
+        if stop_waiter is not None and not stop_waiter.done():
+            stop_waiter.cancel()
+
+
+async def _send_trailing_silence(socket, receiver, seconds: float) -> None:
+    silence = bytes(FRAME_BYTES)
+    next_frame_at = asyncio.get_running_loop().time()
+    for _ in range(math.ceil(seconds * INPUT_RATE / FRAME_SAMPLES)):
+        await _send_frame(socket, silence)
+        if receiver.done():
+            await receiver
+        next_frame_at += 0.08
+        await asyncio.sleep(max(0, next_frame_at - asyncio.get_running_loop().time()))
+
+
+async def run(args: argparse.Namespace) -> None:
+    devices = AudioDevices(args)
+    output = bytearray()
+    try:
+        async with websockets.connect(
+            args.url, max_size=8 * 1024 * 1024, ping_timeout=60
+        ) as socket:
+            created = json.loads(await socket.recv())
+            validate_session_created(created)
+            print(json.dumps(created, indent=2))
+            await socket.send(
+                json.dumps(
+                    {
+                        "type": "session.update",
+                        "session": {"instructions": args.instructions},
+                    }
+                )
+            )
+            print(await socket.recv())
+
+            committed = asyncio.Event()
+
+            async def receive_output() -> None:
+                async for raw_event in socket:
+                    event = json.loads(raw_event)
+                    event_type = event.get("type")
+                    if event_type == "error":
+                        raise RuntimeError(event["error"]["message"])
+                    if event_type == "input_audio_buffer.committed":
+                        committed.set()
+                    elif event_type == "response.text.delta":
+                        print(event.get("delta", ""), end="", flush=True)
+                    elif event_type == "response.audio.delta":
+                        pcm = base64.b64decode(event["delta"], validate=True)
+                        output.extend(pcm)
+                        await asyncio.to_thread(devices.write, pcm)
+
+            receiver = asyncio.create_task(receive_output())
+            await _send_microphone(socket, receiver, devices, args.microphone_seconds)
+            await _send_trailing_silence(socket, receiver, args.trailing_silence)
+            await socket.send(json.dumps({"type": "input_audio_buffer.commit"}))
+
+            commit_waiter = asyncio.create_task(committed.wait())
+            done, _ = await asyncio.wait(
+                {commit_waiter, receiver},
+                timeout=args.drain_timeout,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if not done:
+                commit_waiter.cancel()
+                raise TimeoutError("Timed out while draining queued audio frames.")
+            if receiver in done:
+                await receiver
+                if not commit_waiter.done():
+                    commit_waiter.cancel()
+                    raise RuntimeError(
+                        "Realtime session ended before queued audio was committed."
+                    )
+            await commit_waiter
+            await socket.send(json.dumps({"type": "session.close"}))
+            await receiver
+            print()
+    finally:
+        devices.close()
+
+    args.output_wav.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(args.output_wav), "wb") as destination:
+        destination.setnchannels(1)
+        destination.setsampwidth(2)
+        destination.setframerate(OUTPUT_RATE)
+        destination.writeframes(output)
+    print(f"wrote {len(output) // 2} samples to {args.output_wav}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default="ws://127.0.0.1:18080/v1/realtime")
+    parser.add_argument("--output-wav", type=Path, default=Path("response.wav"))
+    parser.add_argument(
+        "--instructions", default="You are a helpful, concise voice assistant."
+    )
+    parser.add_argument("--input-device-index", type=int)
+    parser.add_argument("--output-device-index", type=int)
+    parser.add_argument("--list-devices", action="store_true")
+    parser.add_argument("--no-playback", action="store_true")
+    parser.add_argument("--trailing-silence", type=float, default=2.0)
+    parser.add_argument(
+        "--microphone-seconds",
+        type=float,
+        help="Stop microphone capture automatically after this many seconds.",
+    )
+    parser.add_argument("--drain-timeout", type=float, default=600.0)
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    if args.list_devices:
+        list_audio_devices()
+        return
+    if args.trailing_silence < 0:
+        parser.error("--trailing-silence cannot be negative")
+    if args.microphone_seconds is not None and args.microphone_seconds <= 0:
+        parser.error("--microphone-seconds must be positive")
+    try:
+        asyncio.run(run(args))
+    except KeyboardInterrupt:
+        print("interrupted", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/sglang_omni/config/__init__.py
+++ b/sglang_omni/config/__init__.py
@@ -19,6 +19,7 @@ from sglang_omni.config.schema import (
     PipelineConfig,
     PlacementConfig,
     ProcessConfig,
+    RealtimeAudioConfig,
     StageConfig,
 )
 from sglang_omni.config.topology import (
@@ -52,6 +53,7 @@ __all__ = [
     "compile_logical_processes",
     "PipelineConfig",
     "ProcessConfig",
+    "RealtimeAudioConfig",
     "StageConfig",
     "EngineStageConfig",
     "EngineArgs",

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -423,6 +423,31 @@ class AudioChunkingConfig(BaseModel):
         return max(int(self.max_audio_clip_s * sample_rate), 1)
 
 
+class RealtimeAudioConfig(BaseModel):
+    """Pipeline-owned audio framing for the WebSocket realtime endpoint.
+
+    ``turn`` preserves the existing VAD/utterance behavior. ``frame`` is for
+    lockstep duplex models that consume every fixed-duration PCM frame while
+    the user and assistant may speak at the same time.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    mode: Literal["turn", "frame"] = "turn"
+    input_sample_rate: int = Field(default=16_000, gt=0)
+    output_sample_rate: int = Field(default=24_000, gt=0)
+    frame_samples: int | None = Field(default=None, gt=0)
+    max_pending_frames: int = Field(default=256, ge=1)
+    max_inflight_frames: int = Field(default=4, ge=1)
+    warmup_frames: int = Field(default=0, ge=0)
+
+    def model_post_init(self, __context: Any = None) -> None:
+        if self.mode == "frame" and self.frame_samples is None:
+            raise ValueError("frame-mode realtime audio requires frame_samples")
+        if self.mode == "turn" and self.frame_samples is not None:
+            raise ValueError("turn-mode realtime audio must not set frame_samples")
+
+
 class PipelineConfig(BaseModel):
     """Top-level pipeline configuration.
 
@@ -441,6 +466,7 @@ class PipelineConfig(BaseModel):
     speech_reference_text_excludes_instructions: ClassVar[bool] = False
     additional_speech_languages: ClassVar[frozenset[str]] = frozenset()
     audio_chunking: ClassVar[AudioChunkingConfig] = AudioChunkingConfig()
+    realtime_audio: ClassVar[RealtimeAudioConfig] = RealtimeAudioConfig()
 
     stage_config_types: ClassVar[dict[str, type[StageConfig]]] = {}
     """Stage name -> ``StageConfig`` subclass for this pipeline's stage types.

--- a/sglang_omni/models/nemotron_voicechat/__init__.py
+++ b/sglang_omni/models/nemotron_voicechat/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""NVIDIA NemotronLabs VoiceChat pipeline."""

--- a/sglang_omni/models/nemotron_voicechat/audio_runtime.py
+++ b/sglang_omni/models/nemotron_voicechat/audio_runtime.py
@@ -1,0 +1,269 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Stateful NeMo perception and RVQ-VAE stages for VoiceChat."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import torch
+from safetensors import safe_open
+from torch import nn
+
+from .payload_types import FRAME_SAMPLES, OUTPUT_FRAME_SAMPLES
+
+
+class _PerceptionHolder(nn.Module):
+    def __init__(self, config: dict[str, Any]) -> None:
+        super().__init__()
+        from omegaconf import DictConfig
+
+        self.cfg = DictConfig(config)
+
+
+def _checkpoint_files(model_path: str) -> tuple[Path, Path, dict[str, Any]]:
+    root = Path(model_path).expanduser().resolve()
+    if not (root / "config.json").is_file() and (root / "checkpoint").is_dir():
+        root = root / "checkpoint"
+    config_path = root / "config.json"
+    weights_path = root / "model.safetensors"
+    if not config_path.is_file():
+        raise FileNotFoundError(f"VoiceChat config not found: {config_path}")
+    if not weights_path.is_file():
+        raise FileNotFoundError(f"VoiceChat weights not found: {weights_path}")
+    return root, weights_path, json.loads(config_path.read_text())
+
+
+def _copy_checkpoint_prefix(module: nn.Module, checkpoint: Path, prefix: str) -> int:
+    targets = module.state_dict()
+    copied: set[str] = set()
+    unexpected: list[str] = []
+    with safe_open(checkpoint, framework="pt", device="cpu") as handle:
+        # ``safe_open`` exposes keys but is not itself iterable.
+        for checkpoint_name in handle.keys():  # noqa: SIM118
+            if not checkpoint_name.startswith(prefix):
+                continue
+            name = checkpoint_name[len(prefix) :]
+            target = targets.get(name)
+            if target is None:
+                unexpected.append(checkpoint_name)
+                continue
+            source = handle.get_tensor(checkpoint_name)
+            if source.shape != target.shape:
+                raise ValueError(
+                    f"Shape mismatch for {checkpoint_name}: checkpoint "
+                    f"{tuple(source.shape)}, module {tuple(target.shape)}"
+                )
+            target.copy_(source)
+            copied.add(name)
+    if not copied:
+        raise ValueError(f"No VoiceChat tensors matched checkpoint prefix {prefix!r}")
+    missing = sorted(set(targets) - copied)
+    if missing or unexpected:
+        details = []
+        if missing:
+            details.append(f"missing {len(missing)} module tensors: {missing[:5]}")
+        if unexpected:
+            details.append(
+                f"unexpected {len(unexpected)} checkpoint tensors: {unexpected[:5]}"
+            )
+        raise ValueError(
+            f"Incomplete VoiceChat checkpoint coverage for prefix {prefix!r}: "
+            + "; ".join(details)
+        )
+    return len(copied)
+
+
+def _validate_max_sessions(max_sessions: int) -> int:
+    value = int(max_sessions)
+    if value < 1:
+        raise ValueError("VoiceChat max_sessions must be positive")
+    return value
+
+
+@dataclass
+class _PerceptionSession:
+    audio_buffer: torch.Tensor
+    cache: Any
+    next_frame_index: int = 0
+
+
+class VoiceChatPerceptionRuntime:
+    """Streaming 16 kHz PCM -> one acoustic embedding per 80 ms frame."""
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        device: str,
+        use_cudagraph: bool = True,
+        max_sessions: int = 1,
+    ) -> None:
+        from nemo.collections.speechlm2.inference.model_wrappers.perception_cache import (
+            PerceptionCacheManager,
+        )
+        from nemo.collections.speechlm2.parts.pretrained import setup_speech_encoder
+
+        _, weights, config = _checkpoint_files(model_path)
+        self.device = torch.device(device)
+        holder = _PerceptionHolder(config["model"]["stt"]["model"])
+        setup_speech_encoder(holder, pretrained_weights=False)
+        self.loaded_tensors = _copy_checkpoint_prefix(
+            holder.perception, weights, "stt_model.perception."
+        )
+        self.model = holder.perception.to(self.device, torch.float32).eval()
+        self.model.requires_grad_(False)
+        model_view = SimpleNamespace(stt_model=SimpleNamespace(perception=self.model))
+        self.cache_manager = PerceptionCacheManager(
+            model_view,
+            device=self.device,
+            dtype=torch.float32,
+            use_cudagraph=use_cudagraph,
+        )
+        if not self.cache_manager.setup():
+            raise RuntimeError("The VoiceChat perception encoder is not streamable")
+        self.max_sessions = _validate_max_sessions(max_sessions)
+        self.sessions: dict[str, _PerceptionSession] = {}
+
+    def _session(self, session_id: str) -> _PerceptionSession:
+        session = self.sessions.get(session_id)
+        if session is not None:
+            return session
+        if len(self.sessions) >= self.max_sessions:
+            raise RuntimeError("VoiceChat perception session capacity is exhausted")
+        session = _PerceptionSession(
+            audio_buffer=torch.empty((1, 0), dtype=torch.float32, device=self.device),
+            cache=self.cache_manager.get_initial_state(batch_size=1),
+        )
+        self.sessions[session_id] = session
+        return session
+
+    @torch.inference_mode()
+    def step(
+        self, session_id: str, frame_index: int, pcm16_base64: str
+    ) -> torch.Tensor:
+        session = self._session(session_id)
+        if frame_index != session.next_frame_index:
+            raise ValueError(
+                f"VoiceChat perception expected frame {session.next_frame_index}, "
+                f"got {frame_index}"
+            )
+        raw = base64.b64decode(pcm16_base64, validate=True)
+        pcm = np.frombuffer(raw, dtype="<i2")
+        if pcm.size != FRAME_SAMPLES:
+            raise ValueError(
+                f"VoiceChat expects {FRAME_SAMPLES} PCM16 samples per frame; "
+                f"got {pcm.size}"
+            )
+        frame = torch.from_numpy(pcm.astype(np.float32) / 32768.0).to(self.device)
+        session.audio_buffer = torch.cat(
+            (session.audio_buffer, frame.unsqueeze(0)), dim=1
+        )
+        encoded, session.cache, _ = self.cache_manager.step(
+            audio_input=session.audio_buffer,
+            frame_idx=frame_index,
+            num_frames_per_chunk=1,
+            perception_cache=session.cache,
+        )
+        if encoded.shape[1] != 1:
+            raise RuntimeError(
+                f"Expected one encoded frame, got {tuple(encoded.shape)}"
+            )
+        session.next_frame_index += 1
+        return encoded[:, 0, :].float().cpu()
+
+    def close(self, session_id: str) -> None:
+        self.sessions.pop(session_id, None)
+
+
+@dataclass
+class _CodecSession:
+    cache: Any
+    next_frame_index: int = 0
+
+
+class VoiceChatCodecRuntime:
+    """Streaming 31-code RVQ frames -> 22.05 kHz float PCM."""
+
+    def __init__(self, model_path: str, *, device: str, max_sessions: int = 1) -> None:
+        from nemo.collections.speechlm2.modules.ear_tts_vae_codec import RVQVAEModel
+        from omegaconf import DictConfig
+
+        _, weights, config = _checkpoint_files(model_path)
+        self.device = torch.device(device)
+        codec_config = config["model"]["speech_generation"]["model"]["codec_config"]
+        self.model = RVQVAEModel(DictConfig(codec_config))
+        self.loaded_tensors = _copy_checkpoint_prefix(
+            self.model, weights, "tts_model.audio_codec."
+        )
+        self.model = self.model.to(self.device, torch.float32).eval()
+        self.model.requires_grad_(False)
+        with safe_open(weights, framework="pt", device="cpu") as handle:
+            self.control_codes = handle.get_tensor("tts_model._control_codes").to(
+                self.device
+            )
+            self.silence_codes = handle.get_tensor("tts_model.codec_silence_tokens").to(
+                self.device
+            )
+        self.max_sessions = _validate_max_sessions(max_sessions)
+        self.sessions: dict[str, _CodecSession] = {}
+
+    def _session(self, session_id: str) -> _CodecSession:
+        from nemo.collections.speechlm2.modules.ear_tts_vae_codec import (
+            CausalConv1dCache,
+        )
+
+        session = self.sessions.get(session_id)
+        if session is not None:
+            return session
+        if len(self.sessions) >= self.max_sessions:
+            raise RuntimeError("VoiceChat codec session capacity is exhausted")
+        session = _CodecSession(cache=CausalConv1dCache())
+        self.sessions[session_id] = session
+        return session
+
+    @torch.inference_mode()
+    def step(self, session_id: str, frame_index: int, codes: list[int]) -> np.ndarray:
+        from nemo.collections.speechlm2.models.duplex_ear_tts import (
+            replace_control_speech_codes,
+        )
+
+        session = self._session(session_id)
+        if frame_index != session.next_frame_index:
+            raise ValueError(
+                f"VoiceChat codec expected frame {session.next_frame_index}, "
+                f"got {frame_index}"
+            )
+        if len(codes) != int(self.silence_codes.numel()):
+            raise ValueError(
+                f"VoiceChat codec expects {self.silence_codes.numel()} codes, "
+                f"got {len(codes)}"
+            )
+        tensor = torch.tensor(codes, dtype=torch.long, device=self.device).reshape(
+            1, 1, -1
+        )
+        tensor = replace_control_speech_codes(
+            tensor, self.control_codes, self.silence_codes
+        )
+        lengths = torch.ones(1, dtype=torch.long, device=self.device)
+        audio, _ = self.model.decode(tensor, lengths, cache=session.cache)
+        result = audio.reshape(-1).float().cpu().numpy()
+        if result.size != OUTPUT_FRAME_SAMPLES:
+            raise RuntimeError(
+                f"VoiceChat codec produced {result.size} samples; "
+                f"expected {OUTPUT_FRAME_SAMPLES}"
+            )
+        session.next_frame_index += 1
+        return np.clip(result, -1.0, 1.0)
+
+    def close(self, session_id: str) -> None:
+        self.sessions.pop(session_id, None)
+
+
+__all__ = ["VoiceChatCodecRuntime", "VoiceChatPerceptionRuntime"]

--- a/sglang_omni/models/nemotron_voicechat/config.py
+++ b/sglang_omni/models/nemotron_voicechat/config.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pipeline configuration for NVIDIA NemotronLabs VoiceChat 11B."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from sglang_omni.config import (
+    EngineArgs,
+    EngineStageConfig,
+    FactoryArgs,
+    PipelineConfig,
+    RealtimeAudioConfig,
+    StageConfig,
+)
+
+from .payload_types import FRAME_SAMPLES, INPUT_SAMPLE_RATE, OUTPUT_SAMPLE_RATE
+
+_PKG = "sglang_omni.models.nemotron_voicechat"
+
+PERCEPTION_STAGE = "perception"
+THINKER_STAGE = "thinker"
+TALKER_STAGE = "talker"
+CODE2WAV_STAGE = "code2wav"
+
+
+class NemotronVoiceChatPipelineConfig(PipelineConfig):
+    """Frame-locked full-duplex speech-to-speech pipeline.
+
+    Perception and codec use the checkpoint's NeMo modules. The two
+    autoregressive stages use SGLang and retain a streaming KV session keyed by
+    the realtime session id.
+    """
+
+    architecture: ClassVar[str] = "NemotronVoiceChatForConditionalGeneration"
+    stage_config_types: ClassVar[dict[str, type[StageConfig]]] = {
+        THINKER_STAGE: EngineStageConfig,
+        TALKER_STAGE: EngineStageConfig,
+    }
+    realtime_audio: ClassVar[RealtimeAudioConfig] = RealtimeAudioConfig(
+        mode="frame",
+        input_sample_rate=INPUT_SAMPLE_RATE,
+        output_sample_rate=OUTPUT_SAMPLE_RATE,
+        frame_samples=FRAME_SAMPLES,
+        max_pending_frames=256,
+        max_inflight_frames=4,
+        warmup_frames=2,
+    )
+
+    model_path: str
+    entry_stage: str = PERCEPTION_STAGE
+    stages: list[StageConfig] = [  # noqa: RUF012 - Pydantic copies model defaults
+        StageConfig(
+            name=PERCEPTION_STAGE,
+            process=PERCEPTION_STAGE,
+            factory_path=f"{_PKG}.stages.create_perception_executor",
+            factory=FactoryArgs(dtype="float32"),
+            gpu=0,
+            gpu_memory_fraction=0.12,
+            next=THINKER_STAGE,
+        ),
+        EngineStageConfig(
+            name=THINKER_STAGE,
+            process=THINKER_STAGE,
+            factory_path=f"{_PKG}.stages.create_thinker_executor",
+            factory=FactoryArgs(dtype="bfloat16", context_length=8192),
+            engine=EngineArgs(mem_fraction_static=0.45),
+            gpu=0,
+            gpu_memory_fraction=0.52,
+            next=TALKER_STAGE,
+        ),
+        EngineStageConfig(
+            name=TALKER_STAGE,
+            process=TALKER_STAGE,
+            factory_path=f"{_PKG}.stages.create_talker_executor",
+            factory=FactoryArgs(dtype="float32", context_length=8192),
+            engine=EngineArgs(mem_fraction_static=0.20),
+            gpu=0,
+            gpu_memory_fraction=0.22,
+            next=CODE2WAV_STAGE,
+        ),
+        StageConfig(
+            name=CODE2WAV_STAGE,
+            process=CODE2WAV_STAGE,
+            factory_path=f"{_PKG}.stages.create_code2wav_executor",
+            factory=FactoryArgs(dtype="float32"),
+            gpu=0,
+            gpu_memory_fraction=0.08,
+            terminal=True,
+        ),
+    ]
+
+    @classmethod
+    def code2wav_stage(cls) -> str | None:
+        return CODE2WAV_STAGE
+
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"thinker": THINKER_STAGE, "talker": TALKER_STAGE}
+
+    @classmethod
+    def generation_sglang_role_to_stage(cls) -> dict[str, str]:
+        return {"generation": THINKER_STAGE}
+
+    @classmethod
+    def talker_sglang_role_to_stage(cls) -> dict[str, str]:
+        return {"talker": TALKER_STAGE}
+
+    def model_post_init(self, __context: Any = None) -> None:  # noqa: PYI063
+        super().model_post_init(__context)
+        expected = {
+            PERCEPTION_STAGE: THINKER_STAGE,
+            THINKER_STAGE: TALKER_STAGE,
+            TALKER_STAGE: CODE2WAV_STAGE,
+            CODE2WAV_STAGE: None,
+        }
+        stages = {stage.name: stage for stage in self.stages}
+        if set(stages) != set(expected):
+            raise ValueError(
+                "Nemotron VoiceChat requires exactly perception, thinker, "
+                f"talker, and code2wav stages; got {sorted(stages)}"
+            )
+        if self.resolved_entry_stage != PERCEPTION_STAGE:
+            raise ValueError("Nemotron VoiceChat entry_stage must be 'perception'")
+        for name, next_stage in expected.items():
+            stage = stages[name]
+            if stage.next != next_stage or stage.terminal != (next_stage is None):
+                raise ValueError(
+                    f"Invalid Nemotron VoiceChat topology at {name!r}: "
+                    f"expected next={next_stage!r}, terminal={next_stage is None}"
+                )
+
+
+EntryClass = NemotronVoiceChatPipelineConfig

--- a/sglang_omni/models/nemotron_voicechat/configuration.py
+++ b/sglang_omni/models/nemotron_voicechat/configuration.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Configuration for NVIDIA VoiceChat's EarTTS generation stage."""
+
+from transformers import PretrainedConfig
+
+
+class EarTTSConfig(PretrainedConfig):
+    model_type = "eartts"
+
+    def __init__(
+        self,
+        hidden_size=1152,
+        context_hidden_size=1536,
+        intermediate_size=4608,
+        num_hidden_layers=28,
+        num_attention_heads=16,
+        num_key_value_heads=16,
+        head_dim=72,
+        vocab_size=2,
+        max_position_embeddings=131072,
+        num_quantizers=31,
+        codebook_size=1024,
+        num_iter=8,
+        top_p_or_k=0.8,
+        noise_scale=0.8,
+        exponent=3.0,
+        latent_size=512,
+        mog_low_rank=64,
+        mog_num_layers=3,
+        mog_num_predictions=1024,
+        mog_min_log_std=-4.0,
+        mog_eps=1e-6,
+        query_pre_attn_scalar=256.0,
+        attention_bias=False,
+        rms_norm_eps=1e-6,
+        layer_types=None,
+        sliding_window=4096,
+        rope_local_base_freq=10000.0,
+        rope_theta=1000000.0,
+        rope_scaling=None,
+        rope_parameters=None,
+        hidden_activation="gelu_pytorch_tanh",
+        final_logit_softcapping=None,
+        attn_logits_soft_cap=None,
+        use_bidirectional_attention=False,
+        is_causal=True,
+        emb_vocab_size=151936,
+        use_gated_fusion_for_text_audio=True,
+        use_audio_prompt_frozen_projection=False,
+        pad_token_id=0,
+        tie_word_embeddings=True,
+        dtype="float32",
+        **kwargs,
+    ):
+        self.hidden_size = hidden_size
+        self.context_hidden_size = context_hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.vocab_size = vocab_size
+        self.max_position_embeddings = max_position_embeddings
+        self.num_quantizers = num_quantizers
+        self.codebook_size = codebook_size
+        self.num_iter = num_iter
+        self.top_p_or_k = top_p_or_k
+        self.noise_scale = noise_scale
+        self.exponent = exponent
+        self.latent_size = latent_size
+        self.mog_low_rank = mog_low_rank
+        self.mog_num_layers = mog_num_layers
+        self.mog_num_predictions = mog_num_predictions
+        self.mog_min_log_std = mog_min_log_std
+        self.mog_eps = mog_eps
+        self.query_pre_attn_scalar = query_pre_attn_scalar
+        self.attention_bias = attention_bias
+        self.rms_norm_eps = rms_norm_eps
+        self.layer_types = layer_types or ["full_attention"] * num_hidden_layers
+        self.sliding_window = sliding_window
+        self.rope_local_base_freq = rope_local_base_freq
+        self.rope_theta = rope_theta
+        self.hidden_activation = hidden_activation
+        self.final_logit_softcapping = final_logit_softcapping
+        self.attn_logits_soft_cap = attn_logits_soft_cap
+        self.use_bidirectional_attention = use_bidirectional_attention
+        self.is_causal = is_causal
+        self.emb_vocab_size = emb_vocab_size
+        self.use_gated_fusion_for_text_audio = use_gated_fusion_for_text_audio
+        self.use_audio_prompt_frozen_projection = use_audio_prompt_frozen_projection
+        super().__init__(
+            pad_token_id=pad_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            dtype=dtype,
+            **kwargs,
+        )
+        # Gemma3 uses a per-attention-type RoPE map. Set it after the base
+        # constructor so Transformers does not validate it as a flat schema.
+        self.rope_scaling = rope_scaling
+        self.rope_parameters = rope_parameters or {
+            "sliding_attention": {
+                "rope_type": "default",
+                "rope_theta": rope_local_base_freq,
+            },
+            "full_attention": {"rope_type": "default", "rope_theta": rope_theta},
+        }

--- a/sglang_omni/models/nemotron_voicechat/convert_duplex.py
+++ b/sglang_omni/models/nemotron_voicechat/convert_duplex.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Convert the unified VoiceChat checkpoint into an SGLang Duplex stage.
+
+Each retained tensor is written as its own safetensors shard. This bounds host
+RAM to the largest tensor and produces an index SGLang can stream.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from safetensors import safe_open
+from safetensors.torch import save_file
+from transformers import AutoConfig, AutoTokenizer
+
+PREFIXES = (
+    "stt_model.llm.",
+    "stt_model.lm_head.",
+    "stt_model.function_head.",
+    "stt_model.embed_tokens.",
+)
+
+
+def _model_file(path: Path) -> Path:
+    return path / "model.safetensors" if path.is_dir() else path
+
+
+def _resolve_base_model(config_path: Path, base_model: str | None) -> str:
+    if base_model is not None:
+        return base_model
+    config = json.loads(config_path.read_text())
+    try:
+        return config["model"]["stt"]["model"]["pretrained_llm"]
+    except KeyError as error:
+        raise ValueError(
+            "Could not find model.stt.model.pretrained_llm in --config; "
+            "pass --base-model explicitly."
+        ) from error
+
+
+def _stt_config(config_path: Path) -> dict:
+    config = json.loads(config_path.read_text())
+    try:
+        return config["model"]["stt"]["model"]
+    except KeyError as error:
+        raise ValueError("Could not find model.stt.model in --config.") from error
+
+
+def _configure_duplex_config(config, stt_config: dict):
+    config.architectures = ["NemotronDuplexHForCausalLM"]
+    config.predict_user_text = False
+    config.use_function_head = True
+    # Temporal Mamba state is sensitive to accumulated low-precision drift.
+    # Keep it in fp32 even when model weights run in bf16 for online latency.
+    config.mamba_ssm_dtype = "float32"
+    config.duplex_text_channel_weight = float(
+        stt_config.get("duplex_text_channel_weight", 1.0)
+    )
+    config.duplex_user_channel_weight = float(
+        stt_config.get("duplex_user_channel_weight", 1.0)
+    )
+    config.duplex_function_channel_weight = float(
+        stt_config.get("duplex_function_channel_weight", 1.0)
+    )
+    config.fuse_method = "add"
+    return config
+
+
+def convert(
+    checkpoint: Path,
+    output: Path,
+    base_model: str | None,
+    config_path: Path,
+) -> None:
+    source = _model_file(checkpoint)
+    output.mkdir(parents=True, exist_ok=True)
+    base_model = _resolve_base_model(config_path, base_model)
+    stt_config = _stt_config(config_path)
+    if bool(stt_config.get("predict_user_text", False)):
+        raise ValueError("The converter does not support predict_user_text=True.")
+    if not bool(stt_config.get("use_function_head", False)):
+        raise ValueError("The published checkpoint requires use_function_head=True.")
+    if (stt_config.get("fuse_method", "add") or "add") != "add":
+        raise ValueError("The converter only supports fuse_method='add'.")
+
+    config = AutoConfig.from_pretrained(base_model, trust_remote_code=False)
+    config = _configure_duplex_config(config, stt_config)
+    tokenizer = AutoTokenizer.from_pretrained(base_model, trust_remote_code=False)
+    pad_token = stt_config.get("pad_token", "<SPECIAL_12>")
+    pad_token_id = tokenizer.convert_tokens_to_ids(pad_token)
+    if pad_token_id is None or pad_token_id < 0:
+        raise ValueError(f"Could not resolve VoiceChat pad token {pad_token!r}.")
+    config.pad_token_id = pad_token_id
+    config.save_pretrained(output)
+    tokenizer.save_pretrained(output)
+
+    with safe_open(source, framework="pt", device="cpu") as handle:
+        keys = [key for key in handle.keys() if key.startswith(PREFIXES)]
+        if not keys:
+            raise ValueError(f"No Duplex tensors found in {source}")
+        if "stt_model.function_head.weight" not in keys:
+            raise ValueError(
+                f"Checkpoint {source} is missing stt_model.function_head.weight"
+            )
+        weight_map: dict[str, str] = {}
+        total_size = 0
+        total = len(keys)
+        for index, key in enumerate(keys, 1):
+            tensor = handle.get_tensor(key)
+            filename = f"model-{index:05d}-of-{total:05d}.safetensors"
+            save_file({key: tensor}, output / filename)
+            weight_map[key] = filename
+            total_size += tensor.numel() * tensor.element_size()
+            del tensor
+
+    (output / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {"metadata": {"total_size": total_size}, "weight_map": weight_map},
+            indent=2,
+        )
+    )
+    (output / "voicechat_source.json").write_text(
+        json.dumps(
+            {
+                "source_checkpoint": str(checkpoint),
+                "source_config": str(config_path),
+                "base_model": base_model,
+                "stage": "nemotron_duplex_h",
+            },
+            indent=2,
+        )
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--checkpoint", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--base-model")
+    args = parser.parse_args()
+    convert(args.checkpoint, args.output, args.base_model, args.config)
+
+
+if __name__ == "__main__":
+    main()

--- a/sglang_omni/models/nemotron_voicechat/convert_eartts.py
+++ b/sglang_omni/models/nemotron_voicechat/convert_eartts.py
@@ -1,0 +1,199 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Convert VoiceChat's EarTTS subtree into an SGLang checkpoint.
+
+The NVIDIA VoiceChat environment is required to bake the trained
+character-aware subword encoder's deterministic vocabulary lookup table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+from transformers import AutoConfig
+
+
+def _load_tts_weights(model_path: Path) -> dict[str, torch.Tensor]:
+    result = {}
+    with safe_open(model_path, framework="pt", device="cpu") as handle:
+        for key in handle.keys():
+            if key.startswith("tts_model."):
+                result[key[len("tts_model.") :]] = handle.get_tensor(key)
+    if not result:
+        raise ValueError(f"No tts_model tensors found in {model_path}")
+    return result
+
+
+def _precompute_subwords(model, batch_size: int) -> torch.Tensor:
+    import tqdm
+
+    module = model.tts_model.embed_subword.eval()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    module.to(device)
+    mapping = module.subword_id_to_char_ids
+    vocab_size = max(int(key) for key in mapping) + 1
+    hidden_size = module.proj_embedding.out_features
+    dtype = next(module.parameters()).dtype
+    table = torch.zeros(vocab_size, hidden_size, dtype=dtype, device=device)
+    with torch.no_grad():
+        for start in tqdm.tqdm(range(0, vocab_size, batch_size)):
+            end = min(start + batch_size, vocab_size)
+            ids = torch.arange(start, end, device=device).unsqueeze(0)
+            mask = torch.ones_like(ids, dtype=torch.bool)
+            table[start:end] = module(ids, mask).squeeze(0).to(dtype)
+    return table.cpu()
+
+
+def _runtime_config(cfg, vocab_size: int) -> dict:
+    from omegaconf import OmegaConf
+
+    backbone_dict = OmegaConf.to_container(
+        cfg.model.tts_config.backbone_config, resolve=True
+    )
+    backbone_type = cfg.model.tts_config.get("backbone_type")
+    backbone = AutoConfig.for_model(backbone_type, **backbone_dict)
+    output = {
+        "architectures": ["EarTTSForCausalLM"],
+        "model_type": "eartts",
+        "vocab_size": 2,
+        "emb_vocab_size": vocab_size,
+        "backbone_type": backbone_type,
+    }
+    for key in (
+        "hidden_size",
+        "intermediate_size",
+        "num_hidden_layers",
+        "num_attention_heads",
+        "num_key_value_heads",
+        "head_dim",
+        "max_position_embeddings",
+        "rope_theta",
+        "rope_local_base_freq",
+        "sliding_window",
+        "layer_types",
+        "query_pre_attn_scalar",
+        "attention_bias",
+        "rms_norm_eps",
+        "hidden_activation",
+    ):
+        if hasattr(backbone, key):
+            value = getattr(backbone, key)
+            output[key] = list(value) if isinstance(value, tuple) else value
+    for key in ("latent_size", "codebook_size", "num_quantizers", "exponent"):
+        output[key] = cfg.model.tts_config[key]
+    for key in ("num_layers", "low_rank", "num_predictions", "min_log_std", "eps"):
+        output[f"mog_{key}"] = cfg.model.tts_config.mog_head_config[key]
+    output.update(
+        num_iter=8,
+        noise_scale=cfg.model.get("inference_noise_scale", 0.8),
+        top_p_or_k=cfg.model.get("inference_top_p_or_k", 0.8),
+        use_gated_fusion_for_text_audio=(
+            cfg.model.tts_config.use_gated_fusion_for_text_audio
+        ),
+        use_audio_prompt_frozen_projection=(
+            cfg.model.tts_config.use_audio_prompt_frozen_projection
+        ),
+        dtype="float32",
+    )
+    return output
+
+
+def convert(
+    config_path: Path,
+    model_path: Path,
+    output: Path,
+    batch_size: int,
+    base_model: str | None = None,
+) -> None:
+    from nemo.collections.speechlm2.models.duplex_ear_tts import DuplexEARTTS
+    from omegaconf import DictConfig, OmegaConf
+
+    output.mkdir(parents=True, exist_ok=True)
+    full_config = json.loads(config_path.read_text())
+    cfg = DictConfig(full_config["model"]["speech_generation"])
+    cfg.model.tts_config.use_unshifthed_prompt = True
+    cfg.data.add_audio_prompt_after_description = True
+    cfg.model.subword_mask_exactly_as_eartts = False
+    cfg.model.context_hidden_mask_exactly_as_eartts = False
+    cfg.model.tts_config.disable_eos_prediction = True
+    cfg.model.inference_force_speech_silence_on_eos = True
+    cfg.model.use_word_sep_tokenizer = False
+    cfg.model.num_delay_speech_tokens = 0
+    cfg.data.source_sample_rate = 22050
+    cfg.data.target_sample_rate = 22050
+    cfg.model.pretrained_model = None
+    if base_model is not None:
+        cfg.model.pretrained_lm_name = base_model
+        cfg.model.tts_config.cas_config.pretrained_tokenizer_name = base_model
+
+    model = DuplexEARTTS(OmegaConf.to_container(cfg, resolve=True)).eval()
+    outer_weights = _load_tts_weights(model_path)
+    model.load_state_dict(outer_weights, strict=False)
+    subword_table = _precompute_subwords(model, batch_size)
+    silence = model.codec_silence_tokens.detach().cpu().to(torch.int32)
+
+    weights = {
+        key[len("tts_model.") :]: value
+        for key, value in outer_weights.items()
+        if key.startswith("tts_model.")
+    }
+    rvq = torch.nn.functional.pad(weights["rvq_embs"], [0, 0, 0, 1])
+    converted = {
+        "model.total_emb.bos_emb": weights["bos_emb"],
+        "model.total_emb.embed_subword.embed_subwords.weight": subword_table,
+        # This projection is used by both input fusion and MaskGIT. Safetensors
+        # rejects two keys backed by the same storage, so clone the input copy.
+        "model.total_emb.embed_code.weight": weights["embed_code.weight"].clone(),
+        "model.sil_tokens": silence,
+    }
+    for index, table in enumerate(rvq):
+        converted[f"model.total_emb.rvq_embs.{index}.weight"] = table
+    for key, value in weights.items():
+        if (
+            key.startswith("gated_fusion_audio_text.")
+            or key == "audio_prompt_projection_W"
+        ):
+            converted[f"model.total_emb.{key}"] = value
+        if key.startswith("backbone."):
+            converted[f"model.{key}"] = value
+        if key.startswith(("rvq_embs", "embed_code", "mog_head")):
+            converted[f"model.sampler.{key}"] = value
+    # The backbone token embedding is unused because every call supplies fused
+    # audio/text embeddings; do not create a shape-incompatible placeholder.
+    save_file(converted, output / "model.safetensors")
+    (output / "config.json").write_text(
+        json.dumps(_runtime_config(cfg, subword_table.shape[0]), indent=2)
+    )
+    speaker_dir = output / "speaker_latents"
+    for key, value in outer_weights.items():
+        if "audio_prompt_latents." in key:
+            speaker_dir.mkdir(exist_ok=True)
+            torch.save(
+                value, speaker_dir / f"{key.split('audio_prompt_latents.')[-1]}.pt"
+            )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--base-model")
+    parser.add_argument("--precompute-batch-size", type=int, default=256)
+    args = parser.parse_args()
+    convert(
+        args.config,
+        args.model,
+        args.output,
+        args.precompute_batch_size,
+        args.base_model,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/sglang_omni/models/nemotron_voicechat/engine_builder.py
+++ b/sglang_omni/models/nemotron_voicechat/engine_builder.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+"""In-process SGLang engine builders for Nemotron VoiceChat."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import torch
+from transformers import AutoConfig, AutoTokenizer
+
+from sglang_omni.scheduling.engine_factory import SGLangGenerationEngineBuilder
+
+from .request_builders import TalkerAdapters, ThinkerAdapters
+
+
+def resolve_stage_path(model_path: str, stage: str, explicit: str | None) -> str:
+    if explicit is not None:
+        path = Path(explicit).expanduser().resolve()
+    else:
+        root = Path(model_path).expanduser().resolve()
+        candidates = (root / "converted" / stage, root / stage)
+        path = next(
+            (candidate for candidate in candidates if candidate.is_dir()), candidates[0]
+        )
+    if not (path / "config.json").is_file():
+        raise FileNotFoundError(
+            f"VoiceChat {stage} config not found at {path / 'config.json'}; "
+            "model_path must point to the deployment root containing "
+            "checkpoint/ and converted/{duplex,eartts}/"
+        )
+    return str(path)
+
+
+class _VoiceChatEngineBuilder(SGLangGenerationEngineBuilder):
+    context_length = 8192
+
+    def __init__(
+        self,
+        *,
+        context_length: int,
+        max_sessions: int,
+        total_gpu_memory_fraction: float | None,
+    ) -> None:
+        self.context_length = int(context_length)
+        self.max_sessions = int(max_sessions)
+        if self.max_sessions < 1:
+            raise ValueError("VoiceChat max_sessions must be positive")
+        self.total_gpu_memory_fraction = total_gpu_memory_fraction
+
+    def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
+        return {
+            # Every persistent streaming session retains one request-pool slot
+            # for committed KV while its next turn needs a transient slot.
+            "max_running_requests": 2 * self.max_sessions,
+            "dtype": dtype,
+            "disable_overlap_schedule": True,
+            # Acoustic, function-token, and codec inputs change while token IDs
+            # remain fixed, so replaying token-keyed graphs would be incorrect.
+            "disable_cuda_graph": True,
+            "enable_streaming_session": True,
+            "max_prefill_tokens": self.context_length,
+            "mem_fraction_static": self.total_gpu_memory_fraction,
+            "trust_remote_code": False,
+        }
+
+    def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
+        from .model_runner import VoiceChatModelRunner
+
+        return VoiceChatModelRunner(model_worker, output_proc)
+
+    def extra_scheduler_kwargs(self) -> dict[str, Any]:
+        # Session admission mutates append-only state and must remain ordered.
+        return {
+            "request_build_max_workers": 1,
+            "enable_streaming_sessions": True,
+        }
+
+
+class VoiceChatThinkerEngineBuilder(_VoiceChatEngineBuilder):
+    model_name = "Nemotron VoiceChat thinker"
+
+    def __init__(self, *, duplex_model_path: str | None = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.duplex_model_path = duplex_model_path
+        self.config: Any = None
+        self.tokenizer: Any = None
+
+    def resolve_checkpoint(self, model_path: str) -> str:
+        return resolve_stage_path(model_path, "duplex", self.duplex_model_path)
+
+    def pre_infra_setup(self, checkpoint_dir: str) -> None:
+        from .registration import register_voicechat_models
+
+        register_voicechat_models()
+        self.config = AutoConfig.from_pretrained(
+            checkpoint_dir, trust_remote_code=False
+        )
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            checkpoint_dir, trust_remote_code=False
+        )
+
+    def make_adapters(self, model: Any) -> tuple[Any, Any]:
+        del model
+        adapters = ThinkerAdapters(
+            config=self.config,
+            tokenizer=self.tokenizer,
+            context_length=self.context_length,
+        )
+        return adapters.request_builder, adapters.result_adapter
+
+
+class VoiceChatTalkerEngineBuilder(_VoiceChatEngineBuilder):
+    model_name = "Nemotron VoiceChat talker"
+
+    def __init__(
+        self,
+        *,
+        eartts_model_path: str | None = None,
+        speaker_latent_path: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.eartts_model_path = eartts_model_path
+        self.speaker_latent_path = speaker_latent_path
+        self.config: Any = None
+        self.speaker: torch.Tensor | None = None
+
+    def resolve_checkpoint(self, model_path: str) -> str:
+        return resolve_stage_path(model_path, "eartts", self.eartts_model_path)
+
+    def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
+        if dtype != "float32":
+            raise ValueError("VoiceChat EarTTS requires dtype='float32'")
+        defaults = super().generation_defaults(dtype=dtype)
+        # NVIDIA's reference enables TensorFloat32 for EarTTS. Preserve FP32
+        # storage/range while allowing its large matmuls to use tensor cores.
+        defaults["enable_tf32_matmul"] = True
+        defaults["attention_backend"] = "torch_native"
+        defaults["chunked_prefill_size"] = -1
+        return defaults
+
+    def pre_infra_setup(self, checkpoint_dir: str) -> None:
+        from .registration import register_voicechat_models
+
+        register_voicechat_models()
+        self.config = AutoConfig.from_pretrained(
+            checkpoint_dir, trust_remote_code=False
+        )
+        speaker_path = self.speaker_latent_path
+        if speaker_path is None:
+            candidates = sorted((Path(checkpoint_dir) / "speaker_latents").glob("*.pt"))
+            if not candidates:
+                raise FileNotFoundError(
+                    f"No VoiceChat speaker latent found under {checkpoint_dir}/speaker_latents"
+                )
+            speaker_path = str(candidates[0])
+        speaker = torch.load(speaker_path, map_location="cpu", weights_only=True)
+        if speaker.ndim == 3 and speaker.shape[0] == 1:
+            speaker = speaker.squeeze(0)
+        if speaker.ndim != 2:
+            raise ValueError(
+                f"VoiceChat speaker latent must be rank 2, got {tuple(speaker.shape)}"
+            )
+        self.speaker = speaker
+
+    def make_adapters(self, model: Any) -> tuple[Any, Any]:
+        del model
+        assert self.speaker is not None
+        adapters = TalkerAdapters(
+            config=self.config,
+            speaker=self.speaker,
+            context_length=self.context_length,
+        )
+        return adapters.request_builder, adapters.result_adapter
+
+
+__all__ = ["VoiceChatTalkerEngineBuilder", "VoiceChatThinkerEngineBuilder"]

--- a/sglang_omni/models/nemotron_voicechat/model_runner.py
+++ b/sglang_omni/models/nemotron_voicechat/model_runner.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model-output bridge for VoiceChat's per-frame auxiliary tokens."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sglang_omni.model_runner.base import ModelRunner
+
+
+class VoiceChatModelRunner(ModelRunner):
+    """Bridge VoiceChat's per-frame payload around SGLang's eager batch copy."""
+
+    @staticmethod
+    def _custom_inputs(requests: list[Any]) -> list[dict[str, Any]]:
+        return [request.data.custom_inputs for request in requests]
+
+    def _install_custom_inputs(self, requests: list[Any]) -> None:
+        # SGLang's eager runner copies ForwardBatch through a fixed-field
+        # registry before calling the model, so dynamically adding a field to
+        # ForwardBatch is not preserved. The model-local, one-shot payload
+        # survives that copy and is safe because VoiceChat disables overlap.
+        self.model.set_voicechat_custom_inputs(self._custom_inputs(requests))
+
+    def before_prefill(
+        self, forward_batch: Any, schedule_batch: Any, requests: list[Any]
+    ) -> None:
+        del forward_batch, schedule_batch
+        self._install_custom_inputs(requests)
+
+    def before_decode(
+        self,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list[Any],
+        *,
+        is_lookahead: bool = False,
+    ) -> None:
+        del forward_batch, schedule_batch, is_lookahead
+        self._install_custom_inputs(requests)
+
+    def post_process_outputs(
+        self,
+        result: Any,
+        scheduler_output: Any,
+        outputs: dict[str, Any],
+    ) -> None:
+        logits_output = result.logits_output
+        customized = None if logits_output is None else logits_output.customized_info
+        if not isinstance(customized, dict):
+            return
+        for index, sched_req in enumerate(scheduler_output.requests):
+            output = outputs[sched_req.request_id]
+            if output.extra is None:
+                output.extra = {}
+            for key, values in customized.items():
+                if index >= len(values):
+                    raise RuntimeError(
+                        f"VoiceChat customized_info {key!r} has {len(values)} "
+                        f"rows for batch index {index}"
+                    )
+                output.extra[key] = values[index]
+
+
+__all__ = ["VoiceChatModelRunner"]

--- a/sglang_omni/models/nemotron_voicechat/payload_types.py
+++ b/sglang_omni/models/nemotron_voicechat/payload_types.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Typed state passed through the frame-locked VoiceChat pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+INPUT_SAMPLE_RATE = 16_000
+OUTPUT_SAMPLE_RATE = 22_050
+FRAME_SAMPLES = 1_280
+OUTPUT_FRAME_SAMPLES = 1_764
+
+VoiceChatEvent = Literal["audio_frame", "session_close"]
+
+
+@dataclass(slots=True)
+class VoiceChatFrameState:
+    event: VoiceChatEvent
+    session_id: str
+    frame_index: int | None = None
+    pcm16: str | None = None
+    instructions: str | None = None
+    acoustic_embedding: Any = None
+    text_token: int | None = None
+    text_delta: str | None = None
+    function_token: int | None = None
+    audio_codes: list[int] | None = None
+    audio_data: Any = None
+    timings_ms: dict[str, float] = field(default_factory=dict)
+
+    @classmethod
+    def from_data(cls, data: Any) -> VoiceChatFrameState:
+        if not isinstance(data, dict):
+            raise TypeError("VoiceChat stage payload data must be an object")
+        # The coordinator wraps a pipeline's user input at the entry stage so
+        # generic preprocessors can distinguish it from stage-produced data.
+        # Downstream VoiceChat stages receive the unwrapped state directly.
+        if set(data) == {"raw_inputs"} and isinstance(data["raw_inputs"], dict):
+            data = data["raw_inputs"]
+        event = data.get("event")
+        if event not in ("audio_frame", "session_close"):
+            raise ValueError(f"Unsupported VoiceChat event: {event!r}")
+        session_id = data.get("session_id")
+        if not isinstance(session_id, str) or not session_id:
+            raise ValueError("VoiceChat event requires a non-empty session_id")
+        state = cls(
+            event=event,
+            session_id=session_id,
+            frame_index=data.get("frame_index"),
+            pcm16=data.get("pcm16"),
+            instructions=data.get("instructions"),
+            acoustic_embedding=data.get("acoustic_embedding"),
+            text_token=data.get("text_token"),
+            text_delta=data.get("text_delta"),
+            function_token=data.get("function_token"),
+            audio_codes=data.get("audio_codes"),
+            audio_data=data.get("audio_data"),
+            timings_ms=dict(data.get("timings_ms") or {}),
+        )
+        state.validate()
+        return state
+
+    def validate(self) -> None:
+        if self.event == "session_close":
+            return
+        if not isinstance(self.frame_index, int) or self.frame_index < 0:
+            raise ValueError("VoiceChat audio_frame requires frame_index >= 0")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in {
+                "event": self.event,
+                "session_id": self.session_id,
+                "frame_index": self.frame_index,
+                "pcm16": self.pcm16,
+                "instructions": self.instructions,
+                "acoustic_embedding": self.acoustic_embedding,
+                "text_token": self.text_token,
+                "text_delta": self.text_delta,
+                "function_token": self.function_token,
+                "audio_codes": self.audio_codes,
+                "audio_data": self.audio_data,
+                "timings_ms": self.timings_ms,
+            }.items()
+            if value is not None
+        }

--- a/sglang_omni/models/nemotron_voicechat/registration.py
+++ b/sglang_omni/models/nemotron_voicechat/registration.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime registration for VoiceChat's SGLang-backed stages."""
+
+from __future__ import annotations
+
+_registered = False
+
+
+def register_voicechat_models() -> None:
+    """Register VoiceChat configs and models before SGLang builds an engine."""
+    global _registered
+    if _registered:
+        return
+
+    from sglang.srt.models.registry import ModelRegistry
+    from transformers import AutoConfig
+
+    from .configuration import EarTTSConfig
+    from .talker import EarTTSForCausalLM
+    from .thinker import NemotronDuplexHForCausalLM
+
+    AutoConfig.register(EarTTSConfig.model_type, EarTTSConfig, exist_ok=True)
+    ModelRegistry.models["NemotronDuplexHForCausalLM"] = NemotronDuplexHForCausalLM
+    ModelRegistry.models["EarTTSForCausalLM"] = EarTTSForCausalLM
+    _registered = True
+
+
+__all__ = ["register_voicechat_models"]

--- a/sglang_omni/models/nemotron_voicechat/request_builders.py
+++ b/sglang_omni/models/nemotron_voicechat/request_builders.py
@@ -1,0 +1,343 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SGLang request/result adapters for Nemotron VoiceChat AR stages."""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import Future
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.sampling.sampling_params import SamplingParams
+
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.sglang_backend.request_data import SGLangARRequestData
+from sglang_omni.scheduling.types import DeferredAdmission, FollowupAdmission
+
+from .payload_types import VoiceChatFrameState
+
+
+@dataclass
+class VoiceChatRequestData(SGLangARRequestData):
+    kind: str = "frame"
+    started_s: float = 0.0
+    custom_inputs: dict[str, Any] = field(default_factory=dict)
+    followup: VoiceChatRequestData | None = None
+
+
+@dataclass
+class _ThinkerSessionState:
+    next_frame_to_build: int = 0
+    next_frame_to_finish: int = 0
+    function_token: int | None = None
+    pending: dict[int, tuple[VoiceChatRequestData, Future[None]]] = field(
+        default_factory=dict
+    )
+
+
+@dataclass
+class _TalkerSessionState:
+    next_frame_to_build: int = 0
+    next_frame_to_finish: int = 0
+    previous_audio_codes: list[int] | None = None
+    pending: dict[int, tuple[VoiceChatRequestData, Future[None]]] = field(
+        default_factory=dict
+    )
+
+
+def _close_pending(
+    pending: dict[int, tuple[VoiceChatRequestData, Future[None]]],
+    session_id: str,
+) -> None:
+    error = RuntimeError(f"VoiceChat session {session_id!r} closed")
+    for _, ready in pending.values():
+        if not ready.done():
+            ready.set_exception(error)
+    pending.clear()
+
+
+def _sampling_params(tokenizer: Any, vocab_size: int) -> SamplingParams:
+    params = SamplingParams(max_new_tokens=1, temperature=0.0)
+    params.normalize(tokenizer)
+    params.verify(vocab_size)
+    return params
+
+
+def _request(
+    *,
+    request_id: str,
+    input_ids: list[int],
+    tokenizer: Any,
+    vocab_size: int,
+) -> Req:
+    req = Req(
+        rid=request_id,
+        origin_input_text="",
+        origin_input_ids=input_ids,
+        sampling_params=_sampling_params(tokenizer, vocab_size),
+        vocab_size=vocab_size,
+    )
+    req.tokenizer = tokenizer
+    return req
+
+
+def _custom_output(data: VoiceChatRequestData, key: str) -> Any:
+    if key not in data.extra_model_outputs:
+        raise RuntimeError(f"VoiceChat request did not produce {key!r}")
+    return data.extra_model_outputs[key]
+
+
+class ThinkerAdapters:
+    def __init__(self, *, config: Any, tokenizer: Any, context_length: int) -> None:
+        self.config = config
+        self.tokenizer = tokenizer
+        self.context_length = int(context_length)
+        self._sessions: dict[str, _ThinkerSessionState] = {}
+
+    def request_builder(
+        self, payload: StagePayload
+    ) -> VoiceChatRequestData | DeferredAdmission:
+        state = VoiceChatFrameState.from_data(payload.data)
+        if state.event == "session_close":
+            session = self._sessions.pop(state.session_id, None)
+            if session is not None:
+                _close_pending(session.pending, state.session_id)
+            return VoiceChatRequestData(
+                stage_payload=payload,
+                streaming_session_id=state.session_id,
+                close_streaming_session=True,
+            )
+        if state.acoustic_embedding is None:
+            raise ValueError("VoiceChat thinker requires acoustic_embedding")
+
+        session = self._sessions.setdefault(state.session_id, _ThinkerSessionState())
+        frame_index = int(state.frame_index)
+        if frame_index != session.next_frame_to_build:
+            raise ValueError(
+                f"VoiceChat thinker expected frame {session.next_frame_to_build}, "
+                f"got {state.frame_index}"
+            )
+        if frame_index == 0:
+            prompt = state.instructions or "You are a helpful realtime voice assistant."
+            prompt_ids = [
+                int(self.config.bos_token_id),
+                *self.tokenizer.encode(prompt, add_special_tokens=False),
+                int(self.config.eos_token_id),
+            ]
+            input_ids = [*prompt_ids, int(self.config.pad_token_id)]
+            custom_inputs = {
+                "is_initial_prefill": True,
+                "prompt_length": len(prompt_ids),
+                "acoustic_embedding": state.acoustic_embedding,
+            }
+        else:
+            input_ids = []
+            custom_inputs = {
+                "acoustic_embedding": state.acoustic_embedding,
+            }
+        state.acoustic_embedding = None
+        data = VoiceChatRequestData(
+            req=_request(
+                request_id=payload.request_id,
+                input_ids=input_ids,
+                tokenizer=self.tokenizer,
+                vocab_size=int(self.config.vocab_size),
+            ),
+            custom_inputs=custom_inputs,
+            stage_payload=StagePayload(
+                payload.request_id, payload.request, state.to_dict()
+            ),
+            streaming_session_id=state.session_id,
+            streaming_session_capacity=self.context_length,
+            started_s=time.perf_counter(),
+        )
+        session.next_frame_to_build += 1
+        if frame_index == 0:
+            return data
+        if (
+            frame_index == session.next_frame_to_finish
+            and session.function_token is not None
+        ):
+            data.custom_inputs["input_function_ids"] = [session.function_token]
+            return data
+        ready: Future[None] = Future()
+        session.pending[frame_index] = (data, ready)
+        return DeferredAdmission(value=data, ready=ready)
+
+    def result_adapter(self, data: VoiceChatRequestData) -> StagePayload:
+        payload = data.stage_payload
+        state = VoiceChatFrameState.from_data(payload.data)
+        if data.close_streaming_session:
+            return payload
+        if not data.output_ids:
+            raise RuntimeError("VoiceChat thinker did not produce a text token")
+        session = self._sessions.get(state.session_id)
+        if session is None:
+            raise RuntimeError(
+                f"VoiceChat thinker session {state.session_id!r} is closed"
+            )
+        frame_index = int(state.frame_index)
+        if frame_index != session.next_frame_to_finish:
+            raise RuntimeError(
+                f"VoiceChat thinker finished frame {frame_index} while expecting "
+                f"frame {session.next_frame_to_finish}"
+            )
+        state.text_token = int(data.output_ids[-1])
+        state.function_token = int(_custom_output(data, "function_tokens"))
+        state.text_delta = self.tokenizer.decode(
+            [state.text_token],
+            skip_special_tokens=True,
+            clean_up_tokenization_spaces=False,
+        )
+        state.timings_ms["thinker"] = (time.perf_counter() - data.started_s) * 1000
+        session.function_token = state.function_token
+        session.next_frame_to_finish += 1
+        pending = session.pending.pop(session.next_frame_to_finish, None)
+        if pending is not None:
+            pending_data, ready = pending
+            pending_data.custom_inputs["input_function_ids"] = [session.function_token]
+            ready.set_result(None)
+        return StagePayload(payload.request_id, payload.request, state.to_dict())
+
+
+class TalkerAdapters:
+    def __init__(
+        self,
+        *,
+        config: Any,
+        speaker: torch.Tensor,
+        context_length: int,
+    ) -> None:
+        self.config = config
+        self.speaker = speaker
+        self.context_length = int(context_length)
+        self._sessions: dict[str, _TalkerSessionState] = {}
+
+    def _frame_data(
+        self,
+        payload: StagePayload,
+        state: VoiceChatFrameState,
+        previous_audio_codes: list[int] | None,
+        *,
+        started_s: float,
+    ) -> VoiceChatRequestData:
+        return VoiceChatRequestData(
+            req=_request(
+                request_id=payload.request_id,
+                input_ids=[],
+                tokenizer=None,
+                vocab_size=int(self.config.vocab_size),
+            ),
+            custom_inputs={
+                "text_token": int(state.text_token),
+                "previous_audio_codes": previous_audio_codes,
+            },
+            stage_payload=payload,
+            streaming_session_id=state.session_id,
+            streaming_session_capacity=self.context_length,
+            kind="frame",
+            started_s=started_s,
+        )
+
+    def request_builder(
+        self, payload: StagePayload
+    ) -> VoiceChatRequestData | DeferredAdmission:
+        state = VoiceChatFrameState.from_data(payload.data)
+        if state.event == "session_close":
+            session = self._sessions.pop(state.session_id, None)
+            if session is not None:
+                _close_pending(session.pending, state.session_id)
+            return VoiceChatRequestData(
+                stage_payload=payload,
+                streaming_session_id=state.session_id,
+                close_streaming_session=True,
+            )
+        if state.text_token is None:
+            raise ValueError("VoiceChat talker requires text_token")
+
+        session = self._sessions.setdefault(state.session_id, _TalkerSessionState())
+        frame_index = int(state.frame_index)
+        if frame_index != session.next_frame_to_build:
+            raise ValueError(
+                f"VoiceChat talker expected frame {session.next_frame_to_build}, "
+                f"got {state.frame_index}"
+            )
+        started_s = time.perf_counter()
+        frame = self._frame_data(
+            payload,
+            state,
+            session.previous_audio_codes,
+            started_s=started_s,
+        )
+        session.next_frame_to_build += 1
+        if frame_index > 0:
+            if (
+                frame_index == session.next_frame_to_finish
+                and session.previous_audio_codes is not None
+            ):
+                return frame
+            ready: Future[None] = Future()
+            session.pending[frame_index] = (frame, ready)
+            return DeferredAdmission(value=frame, ready=ready)
+
+        prefill = VoiceChatRequestData(
+            req=_request(
+                request_id=payload.request_id,
+                input_ids=[0] * int(self.speaker.shape[0]),
+                tokenizer=None,
+                vocab_size=int(self.config.vocab_size),
+            ),
+            custom_inputs={
+                "is_speaker_prefill": True,
+                "speaker_latent": self.speaker,
+            },
+            stage_payload=payload,
+            streaming_session_id=state.session_id,
+            streaming_session_capacity=self.context_length,
+            kind="speaker_prefill",
+            started_s=started_s,
+            followup=frame,
+        )
+        return prefill
+
+    def result_adapter(
+        self, data: VoiceChatRequestData
+    ) -> StagePayload | FollowupAdmission:
+        if data.close_streaming_session:
+            return data.stage_payload
+        if data.kind == "speaker_prefill":
+            if data.followup is None:
+                raise RuntimeError("VoiceChat speaker prefill lost its frame follow-up")
+            return FollowupAdmission(data.followup)
+
+        payload = data.stage_payload
+        state = VoiceChatFrameState.from_data(payload.data)
+        session = self._sessions.get(state.session_id)
+        if session is None:
+            raise RuntimeError(
+                f"VoiceChat talker session {state.session_id!r} is closed"
+            )
+        frame_index = int(state.frame_index)
+        if frame_index != session.next_frame_to_finish:
+            raise RuntimeError(
+                f"VoiceChat talker finished frame {frame_index} while expecting "
+                f"frame {session.next_frame_to_finish}"
+            )
+        codes = _custom_output(data, "audio_codes")
+        state.audio_codes = [int(code) for code in codes]
+        state.timings_ms["talker"] = (time.perf_counter() - data.started_s) * 1000
+        session.previous_audio_codes = state.audio_codes
+        session.next_frame_to_finish += 1
+        pending = session.pending.pop(session.next_frame_to_finish, None)
+        if pending is not None:
+            pending_data, ready = pending
+            pending_data.custom_inputs["previous_audio_codes"] = list(
+                session.previous_audio_codes
+            )
+            ready.set_result(None)
+        return StagePayload(payload.request_id, payload.request, state.to_dict())
+
+
+__all__ = ["TalkerAdapters", "ThinkerAdapters", "VoiceChatRequestData"]

--- a/sglang_omni/models/nemotron_voicechat/stages.py
+++ b/sglang_omni/models/nemotron_voicechat/stages.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stage factories for NVIDIA NemotronLabs VoiceChat 11B."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni.utils.audio_payload import audio_waveform_payload
+from sglang_omni.utils.device import place_device_spec
+
+from .payload_types import OUTPUT_SAMPLE_RATE, VoiceChatFrameState
+
+
+def _output(payload: StagePayload, state: VoiceChatFrameState) -> StagePayload:
+    return StagePayload(
+        request_id=payload.request_id,
+        request=payload.request,
+        data=state.to_dict(),
+    )
+
+
+def create_perception_executor(
+    model_path: str,
+    *,
+    device: str = "cuda:0",
+    gpu_id: int | None = None,
+    dtype: str = "float32",
+    use_cudagraph: bool = True,
+    max_sessions: int = 1,
+) -> SimpleScheduler:
+    if dtype != "float32":
+        raise ValueError("VoiceChat perception requires dtype='float32'")
+    from .audio_runtime import VoiceChatPerceptionRuntime
+
+    runtime = VoiceChatPerceptionRuntime(
+        model_path,
+        device=place_device_spec(device, gpu_id),
+        use_cudagraph=use_cudagraph,
+        max_sessions=max_sessions,
+    )
+
+    def compute(payload: StagePayload) -> StagePayload:
+        state = VoiceChatFrameState.from_data(payload.data)
+        if state.event == "session_close":
+            runtime.close(state.session_id)
+            return _output(payload, state)
+        if not isinstance(state.pcm16, str):
+            raise TypeError("VoiceChat perception requires base64 PCM16 data")
+        started = time.perf_counter()
+        state.acoustic_embedding = runtime.step(
+            state.session_id, int(state.frame_index), state.pcm16
+        )
+        state.timings_ms["perception"] = (time.perf_counter() - started) * 1000
+        # Raw PCM is no longer needed after perception and would otherwise be
+        # copied through every downstream process.
+        state.pcm16 = None
+        return _output(payload, state)
+
+    return SimpleScheduler(compute)
+
+
+def create_thinker_executor(model_path: str, **kwargs: Any) -> Any:
+    from .engine_builder import VoiceChatThinkerEngineBuilder
+
+    context_length = int(kwargs.pop("context_length", 8192))
+    max_sessions = int(kwargs.pop("max_sessions", 1))
+    total_gpu_memory_fraction = kwargs.pop("total_gpu_memory_fraction", None)
+    duplex_model_path = kwargs.pop("duplex_model_path", None)
+    return VoiceChatThinkerEngineBuilder(
+        context_length=context_length,
+        max_sessions=max_sessions,
+        total_gpu_memory_fraction=total_gpu_memory_fraction,
+        duplex_model_path=duplex_model_path,
+    ).build(model_path, **kwargs)
+
+
+def create_talker_executor(model_path: str, **kwargs: Any) -> Any:
+    from .engine_builder import VoiceChatTalkerEngineBuilder
+
+    context_length = int(kwargs.pop("context_length", 8192))
+    max_sessions = int(kwargs.pop("max_sessions", 1))
+    total_gpu_memory_fraction = kwargs.pop("total_gpu_memory_fraction", None)
+    eartts_model_path = kwargs.pop("eartts_model_path", None)
+    speaker_latent_path = kwargs.pop("speaker_latent_path", None)
+    return VoiceChatTalkerEngineBuilder(
+        context_length=context_length,
+        max_sessions=max_sessions,
+        total_gpu_memory_fraction=total_gpu_memory_fraction,
+        eartts_model_path=eartts_model_path,
+        speaker_latent_path=speaker_latent_path,
+    ).build(model_path, **kwargs)
+
+
+def create_code2wav_executor(
+    model_path: str,
+    *,
+    device: str = "cuda:0",
+    gpu_id: int | None = None,
+    dtype: str = "float32",
+    max_sessions: int = 1,
+) -> SimpleScheduler:
+    if dtype != "float32":
+        raise ValueError("VoiceChat code2wav requires dtype='float32'")
+    from .audio_runtime import VoiceChatCodecRuntime
+
+    runtime = VoiceChatCodecRuntime(
+        model_path,
+        device=place_device_spec(device, gpu_id),
+        max_sessions=max_sessions,
+    )
+
+    def compute(payload: StagePayload) -> StagePayload:
+        state = VoiceChatFrameState.from_data(payload.data)
+        if state.event == "session_close":
+            runtime.close(state.session_id)
+            return StagePayload(
+                request_id=payload.request_id,
+                request=payload.request,
+                data={"closed": True, "session_id": state.session_id},
+            )
+        if state.audio_codes is None:
+            raise ValueError("VoiceChat code2wav requires audio_codes")
+        started = time.perf_counter()
+        audio = runtime.step(
+            state.session_id, int(state.frame_index), state.audio_codes
+        )
+        state.timings_ms["code2wav"] = (time.perf_counter() - started) * 1000
+        audio_payload = audio_waveform_payload(
+            audio,
+            sample_rate=OUTPUT_SAMPLE_RATE,
+            modality="audio",
+            source_hint="Nemotron VoiceChat code2wav",
+        )
+        return StagePayload(
+            request_id=payload.request_id,
+            request=payload.request,
+            data={
+                **audio_payload,
+                "text": state.text_delta or "",
+                "token_ids": [state.text_token] if state.text_token is not None else [],
+                "omni_rollout": {
+                    "frame_index": state.frame_index,
+                    "text_token": state.text_token,
+                    "function_token": state.function_token,
+                    "timings_ms": state.timings_ms,
+                },
+            },
+        )
+
+    return SimpleScheduler(compute)
+
+
+__all__ = [
+    "create_code2wav_executor",
+    "create_perception_executor",
+    "create_talker_executor",
+    "create_thinker_executor",
+]

--- a/sglang_omni/models/nemotron_voicechat/talker.py
+++ b/sglang_omni/models/nemotron_voicechat/talker.py
@@ -1,0 +1,394 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""EarTTS stage for NVIDIA NemotronLabs VoiceChat online inference.
+
+Adapted from NVIDIA NeMo's vLLM-Omni EarTTS implementation. The transformer
+backbone runs eagerly because per-turn codec inputs change independently of the
+placeholder token used for KV state. The fixed-shape MaskGIT sampler is compiled
+separately on CUDA and covered by the server's startup warm-up.
+"""
+
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+from sglang.srt.layers.layernorm import Gemma3RMSNorm
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.gemma3_causal import Gemma3ForCausalLM
+from torch import nn
+from transformers.generation.logits_process import TopKLogitsWarper, TopPLogitsWarper
+
+TEXT_PAD_TOKEN_ID = 12
+EOS_TOKEN_ID = 2
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.zeros(dim))
+
+    def forward(self, x):
+        out = x.float() * torch.rsqrt(
+            x.float().pow(2).mean(-1, keepdim=True) + self.eps
+        )
+        return (out * (1.0 + self.weight.float())).type_as(x)
+
+
+class MLP(nn.Module):
+    def __init__(self, hidden_size: int, intermediate_size: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
+
+    def forward(self, x):
+        return self.down_proj(
+            nn.functional.gelu(self.gate_proj(x), approximate="tanh") * self.up_proj(x)
+        )
+
+
+class MLPLayer(nn.Module):
+    def __init__(self, hidden_size: int, intermediate_size: int, eps: float):
+        super().__init__()
+        self.pre_norm = RMSNorm(hidden_size, eps)
+        self.mlp = MLP(hidden_size, intermediate_size)
+        self.post_norm = RMSNorm(hidden_size, eps)
+
+    def forward(self, x):
+        return x + self.post_norm(self.mlp(self.pre_norm(x)))
+
+
+class GatedProjectedSumRMSNorm(nn.Module):
+    def __init__(self, hidden_size: int, num_codebooks: int):
+        super().__init__()
+        self.num_codebooks = num_codebooks
+        self.audio_proj = nn.Linear(hidden_size, hidden_size)
+        self.text_proj = nn.Linear(hidden_size, hidden_size)
+        self.gate = nn.Parameter(torch.zeros(hidden_size), requires_grad=False)
+        self.residual_scale = nn.Parameter(torch.tensor(0.5), requires_grad=False)
+        self.final_norm = RMSNorm(hidden_size)
+
+    def forward(self, audio_emb, text_emb):
+        audio_h = self.audio_proj(audio_emb / self.num_codebooks)
+        text_h = self.text_proj(text_emb)
+        dtype = audio_h.dtype
+        mixed = torch.sigmoid(self.gate).to(dtype) * audio_h
+        mixed += (1 - torch.sigmoid(self.gate)).to(dtype) * text_h
+        mixed *= torch.sigmoid(self.residual_scale).to(dtype)
+        return self.final_norm(mixed.float()).to(dtype)
+
+
+class EarTTSInputEmbedding(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.rvq_embs = nn.ModuleList(
+            [
+                nn.Embedding(config.codebook_size + 1, config.latent_size)
+                for _ in range(config.num_quantizers)
+            ]
+        )
+        self.embed_code = nn.Linear(config.latent_size, config.hidden_size, bias=False)
+        self.embed_subword = nn.Embedding(config.emb_vocab_size, config.hidden_size)
+        self.bos_emb = nn.Parameter(torch.empty(config.hidden_size))
+        self.use_gated_fusion_for_text_audio = config.use_gated_fusion_for_text_audio
+        self.use_audio_prompt_frozen_projection = (
+            config.use_audio_prompt_frozen_projection
+        )
+        if self.use_gated_fusion_for_text_audio:
+            self.gated_fusion_audio_text = GatedProjectedSumRMSNorm(
+                config.hidden_size, config.num_quantizers
+            )
+        if self.use_audio_prompt_frozen_projection:
+            self.audio_prompt_projection_W = nn.Parameter(
+                torch.empty(config.hidden_size, config.hidden_size), requires_grad=False
+            )
+
+    def forward(self, acoustic, text, text_mask, bos_mask, speaker_latent):
+        audio = sum(emb(acoustic[:, i]) for i, emb in enumerate(self.rvq_embs))
+        audio = self.embed_code(audio)
+        if self.use_audio_prompt_frozen_projection:
+            provided = speaker_latent.abs().sum(-1, keepdim=True) > 0
+            replace = (bos_mask.unsqueeze(-1) == 0) & provided
+            audio = torch.where(replace, speaker_latent, audio)
+        audio = audio + bos_mask.unsqueeze(-1) * self.bos_emb
+        text_emb = self.embed_subword(text) * text_mask.unsqueeze(-1)
+        if self.use_gated_fusion_for_text_audio:
+            return self.gated_fusion_audio_text(audio, text_emb)
+        return audio + text_emb
+
+
+def _gumbel_like(x, eps=1e-8):
+    u = torch.rand_like(x)
+    return -torch.log(-torch.log(u + eps) + eps)
+
+
+def _batch_matmul(x, w, indices):
+    return torch.bmm(w[indices], x.unsqueeze(2)).squeeze(2)
+
+
+class MoGHead(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        h, n, rank = config.hidden_size, config.mog_num_predictions, config.mog_low_rank
+        self.out_size, self.num_predictions, self.low_rank = config.latent_size, n, rank
+        self.min_log_std = config.mog_min_log_std
+        self.logits_warper = (
+            TopPLogitsWarper(config.top_p_or_k)
+            if isinstance(config.top_p_or_k, float)
+            else TopKLogitsWarper(config.top_p_or_k)
+        )
+        self.mlp_stack = nn.Sequential(
+            *[
+                MLPLayer(h, config.intermediate_size, config.mog_eps)
+                for _ in range(config.mog_num_layers)
+            ],
+            RMSNorm(h, config.mog_eps),
+        )
+        self.proj_logits = nn.Linear(h, n, bias=False)
+        self.proj_mus = nn.Linear(h, n * rank, bias=False)
+        self.proj_logs = nn.Linear(h, 1, bias=False)
+        self.proj_else = nn.Linear(h, config.latent_size, bias=False)
+        self.low_mat = nn.Parameter(torch.empty(n, config.latent_size, rank))
+
+    def forward(self, x):
+        x = self.mlp_stack(x)
+        logits = self.logits_warper(None, self.proj_logits(x))
+        indices = (nn.functional.log_softmax(logits, -1) + _gumbel_like(logits)).argmax(
+            -1
+        )
+        mus = _batch_matmul(
+            x,
+            self.proj_mus.weight.view(self.num_predictions, self.low_rank, -1),
+            indices,
+        )
+        mus = _batch_matmul(mus, self.low_mat, indices)
+        logs = self.proj_logs(x).clamp_min(self.min_log_std)
+        return mus * torch.exp(logs) + self.proj_else(x), logs
+
+
+class MaskGITSampler(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.num_quantizers = config.num_quantizers
+        self.codebook_size = config.codebook_size
+        self.noise_scale = config.noise_scale
+        rates = torch.linspace(0.0, 1.0, config.num_iter + 1)[:-1]
+        masks = torch.ceil(
+            (1 - rates.pow(config.exponent)).pow(1 / config.exponent)
+            * config.num_quantizers
+        ).to(torch.int64)
+        shifted = torch.cat((masks[1:], torch.zeros(1, dtype=torch.int64)))
+        self.num_to_sample = [int(v) for v in (masks - shifted) if v]
+        self.rvq_embs = nn.Parameter(
+            torch.empty(config.num_quantizers, config.codebook_size, config.latent_size)
+        )
+        self.embed_code = nn.Linear(config.latent_size, config.hidden_size, bias=False)
+        self.mog_head = MoGHead(config)
+        self._compiled_forward = torch.compile(
+            self._forward_impl, fullgraph=True, mode="reduce-overhead"
+        )
+
+    def _depthsum(self, codes):
+        tables = nn.functional.pad(self.rvq_embs, [0, 0, 0, 1])
+        return sum(
+            nn.functional.embedding(codes[i], tables[i]) for i in range(len(tables))
+        )
+
+    def _forward_impl(self, hidden):
+        codes = torch.full(
+            (self.num_quantizers, hidden.shape[0]),
+            self.codebook_size,
+            dtype=torch.long,
+            device=hidden.device,
+        )
+        depth = 0
+        for count in self.num_to_sample:
+            mu, logs = self.mog_head(self.embed_code(self._depthsum(codes)) + hidden)
+            residual = mu + torch.exp(logs) * torch.randn_like(mu) * self.noise_scale
+            for i in range(depth, depth + count):
+                selected = (
+                    self.rvq_embs[i].pow(2).sum(-1) - 2 * residual @ self.rvq_embs[i].T
+                ).argmin(-1)
+                residual = residual - nn.functional.embedding(
+                    selected, self.rvq_embs[i]
+                )
+                codes[i] = selected
+            depth += count
+        return codes.T
+
+    def forward(self, hidden):
+        # The production stream always samples one fixed-shape CUDA frame. Keep
+        # CPU tests eager, while allowing the startup warm-up to compile and
+        # capture this launch-heavy loop before the first client arrives.
+        if hidden.is_cuda:
+            return self._compiled_forward(hidden)
+        return self._forward_impl(hidden)
+
+
+class EarTTSForCausalLM(nn.Module):
+    """Streaming EarTTS stage with per-frame custom inputs."""
+
+    def __init__(self, *, config, quant_config=None, prefix=""):
+        super().__init__()
+        self.config = config
+        self.total_emb = EarTTSInputEmbedding(config)
+        self.backbone = Gemma3ForCausalLM(config, quant_config, prefix="backbone")
+        # Released SGLang versions route CUDA Gemma norms through kernels that
+        # accept FP16/BF16 only. EarTTS must remain FP32 for output quality, so
+        # keep this model's norms on their equivalent native implementation.
+        for module in self.backbone.modules():
+            if isinstance(module, Gemma3RMSNorm):
+                module.forward = module.forward_native
+        self.sampler = MaskGITSampler(config)
+        self._voicechat_custom_inputs: list[dict[str, Any]] | None = None
+        self.register_buffer(
+            "sil_tokens", torch.zeros(config.num_quantizers, dtype=torch.int32)
+        )
+
+    def get_attention_sliding_window_size(self):
+        return self.backbone.get_attention_sliding_window_size()
+
+    def set_voicechat_custom_inputs(self, custom_inputs: list[dict[str, Any]]) -> None:
+        self._voicechat_custom_inputs = custom_inputs
+
+    def _take_voicechat_custom_inputs(self) -> list[dict[str, Any]] | None:
+        custom_inputs = self._voicechat_custom_inputs
+        self._voicechat_custom_inputs = None
+        return custom_inputs
+
+    def _prepare_inputs(self, input_ids, forward_batch):
+        items = self._take_voicechat_custom_inputs()
+        if items is None or any(item is None for item in items):
+            raise ValueError("EarTTS requires custom_inputs for every request.")
+        lengths = forward_batch.extend_seq_lens_cpu or [1] * forward_batch.batch_size
+        acoustic, text, text_mask, bos_mask, latent = [], [], [], [], []
+        decode_rows, offset = [], 0
+        device = input_ids.device
+        dtype = self.total_emb.bos_emb.dtype
+        for request_index, (item, length) in enumerate(
+            zip(items, lengths, strict=True)
+        ):
+            if item.get("is_speaker_prefill", False):
+                speaker = torch.as_tensor(
+                    item["speaker_latent"], device=device, dtype=dtype
+                )
+                if speaker.shape != (length, self.config.hidden_size):
+                    raise ValueError(
+                        "speaker_latent must match the prefill token span."
+                    )
+                ac = self.sil_tokens.to(device=device, dtype=torch.long).expand(
+                    length, -1
+                )
+                tx = torch.full(
+                    (length,), TEXT_PAD_TOKEN_ID, device=device, dtype=torch.long
+                )
+                tx[-1] = EOS_TOKEN_ID
+                tm = torch.zeros(length, device=device, dtype=torch.long)
+                tm[max(0, length - 2) :] = 1
+                bm = torch.zeros(length, device=device, dtype=torch.long)
+                bm[-1] = 1
+            else:
+                token = int(item["text_token"])
+                previous = item.get("previous_audio_codes")
+                if token == EOS_TOKEN_ID:
+                    ac = self.sil_tokens.to(device=device, dtype=torch.long).reshape(
+                        1, -1
+                    )
+                elif previous is None:
+                    ac = torch.full(
+                        (1, self.config.num_quantizers),
+                        self.config.codebook_size,
+                        device=device,
+                        dtype=torch.long,
+                    )
+                else:
+                    ac = torch.as_tensor(
+                        previous, device=device, dtype=torch.long
+                    ).reshape(1, -1)
+                tx = torch.tensor([token], device=device)
+                tm = torch.ones(1, device=device, dtype=torch.long)
+                bm = torch.zeros(1, device=device, dtype=torch.long)
+                speaker = torch.zeros(
+                    1, self.config.hidden_size, device=device, dtype=dtype
+                )
+                if length != 1:
+                    raise ValueError("EarTTS decode turns must contain one token.")
+                decode_rows.append((request_index, offset))
+            acoustic.append(ac)
+            text.append(tx)
+            text_mask.append(tm)
+            bos_mask.append(bm)
+            latent.append(speaker)
+            offset += length
+        return (
+            tuple(map(torch.cat, (acoustic, text, text_mask, bos_mask, latent))),
+            decode_rows,
+        )
+
+    @torch.no_grad()
+    def forward(self, input_ids, positions, forward_batch: ForwardBatch, **_):
+        prepared, decode_rows = self._prepare_inputs(input_ids, forward_batch)
+        embeddings = self.total_emb(*prepared)
+        hidden = self.backbone.model(input_ids, positions, forward_batch, embeddings)
+        batch = forward_batch.batch_size
+        logits = torch.full((batch, 2), -torch.inf, device=input_ids.device)
+        logits[:, 0] = 0
+        output = LogitsProcessorOutput(next_token_logits=logits)
+        frames = [[0] * self.config.num_quantizers for _ in range(batch)]
+        if decode_rows:
+            sampled = self.sampler(hidden[[row for _, row in decode_rows]]).tolist()
+            for (request_index, _), codes in zip(decode_rows, sampled, strict=True):
+                frames[request_index] = codes
+        output.customized_info = {"audio_codes": frames}
+        return output
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        params = dict(self.named_parameters())
+        buffers = dict(self.named_buffers())
+        loaded_params = set()
+        for name, weight in weights:
+            if name.startswith("model.backbone."):
+                suffix = name[len("model.backbone.") :]
+                if suffix == "embed_tokens.weight":
+                    continue
+                backbone_params = self.backbone.load_weights(
+                    [(f"model.{suffix}", weight)]
+                )
+                loaded_params.update(
+                    f"backbone.{param_name}" for param_name in backbone_params
+                )
+                continue
+            name = name.replace("model.total_emb.", "total_emb.", 1)
+            name = name.replace("model.sampler.", "sampler.", 1)
+            name = name.replace("sampler_module.sampler.", "sampler.", 1)
+            name = name.replace("model.sil_tokens", "sil_tokens", 1)
+            name = name.replace(
+                "total_emb.embed_subword.embed_subwords.",
+                "total_emb.embed_subword.",
+                1,
+            )
+            target = params.get(name, buffers.get(name))
+            if target is not None:
+                loader = getattr(target, "weight_loader", default_weight_loader)
+                loader(target, weight)
+                loaded_params.add(name)
+
+        # EarTTS never reads the backbone token embedding because every call
+        # supplies fused audio/text embeddings. All other parameters, plus the
+        # codec silence-token buffer, must come from the converted checkpoint.
+        required = set(params)
+        required.discard("backbone.model.embed_tokens.weight")
+        required.add("sil_tokens")
+        missing = required - loaded_params
+        if missing:
+            raise RuntimeError(
+                "Some EarTTS weights are not initialized from the checkpoint: "
+                f"{sorted(missing)}"
+            )
+        return loaded_params
+
+
+EntryClass = EarTTSForCausalLM

--- a/sglang_omni/models/nemotron_voicechat/thinker.py
+++ b/sglang_omni/models/nemotron_voicechat/thinker.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Nemotron VoiceChat thinker stage for online SGLang inference.
+
+The acoustic perception encoder remains in NeMo. This module consumes its
+per-frame embedding and extends SGLang's existing Nemotron-H implementation
+with the parallel autoregressive function-token stream used by VoiceChat.
+
+Adapted from NVIDIA NeMo's vLLM-Omni NemotronDuplexH implementation.
+"""
+
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+from sglang.srt.layers.vocab_parallel_embedding import (
+    DEFAULT_VOCAB_PADDING_SIZE,
+    ParallelLMHead,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.models.nemotron_h import NemotronHForCausalLM
+from sglang.srt.utils import add_prefix
+
+
+class NemotronDuplexHForCausalLM(NemotronHForCausalLM):
+    """Nemotron-H with acoustic input plus text and function-token outputs."""
+
+    def __init__(self, *, config, quant_config=None, prefix: str = ""):
+        super().__init__(config=config, quant_config=quant_config, prefix=prefix)
+        if config.predict_user_text:
+            raise NotImplementedError(
+                "NemotronDuplexH does not implement predict_user_text=True; "
+                "the published VoiceChat checkpoint disables that channel."
+            )
+        if not config.use_function_head:
+            raise ValueError(
+                "NemotronDuplexH requires use_function_head=True for the "
+                "published VoiceChat checkpoint."
+            )
+        if config.fuse_method != "add":
+            raise NotImplementedError(
+                "NemotronDuplexH only supports fuse_method='add'."
+            )
+        self.function_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            org_num_embeddings=config.vocab_size,
+            padding_size=DEFAULT_VOCAB_PADDING_SIZE,
+            quant_config=quant_config,
+            prefix=add_prefix("function_head", prefix),
+        )
+        self.text_channel_weight = float(config.duplex_text_channel_weight)
+        self.user_channel_weight = float(config.duplex_user_channel_weight)
+        self.function_channel_weight = float(config.duplex_function_channel_weight)
+        self.pad_token_id = int(config.pad_token_id)
+        self._voicechat_custom_inputs: list[dict[str, Any]] | None = None
+
+    def set_voicechat_custom_inputs(self, custom_inputs: list[dict[str, Any]]) -> None:
+        self._voicechat_custom_inputs = custom_inputs
+
+    def _take_voicechat_custom_inputs(self) -> list[dict[str, Any]] | None:
+        custom_inputs = self._voicechat_custom_inputs
+        self._voicechat_custom_inputs = None
+        return custom_inputs
+
+    def _combined_embeddings(
+        self, input_ids: torch.Tensor, forward_batch: ForwardBatch
+    ) -> torch.Tensor:
+        custom_inputs = self._take_voicechat_custom_inputs()
+        if custom_inputs is None or any(item is None for item in custom_inputs):
+            raise ValueError(
+                "NemotronDuplexH requires custom_inputs for every request."
+            )
+
+        combined = torch.empty(
+            (input_ids.shape[0], self.config.hidden_size),
+            device=input_ids.device,
+            dtype=self.model.embed_tokens.weight.dtype,
+        )
+        lengths = (
+            forward_batch.extend_seq_lens_cpu
+            if forward_batch.extend_seq_lens_cpu is not None
+            else [1] * forward_batch.batch_size
+        )
+        offset = 0
+        for item, length in zip(custom_inputs, lengths, strict=True):
+            end = offset + length
+            if item.get("is_initial_prefill", False):
+                prompt_length = int(item["prompt_length"])
+                if length != prompt_length + 1:
+                    raise ValueError(
+                        "Initial VoiceChat prefill must contain the prompt plus "
+                        "one acoustic-frame placeholder."
+                    )
+                acoustic = torch.as_tensor(
+                    item["acoustic_embedding"],
+                    device=input_ids.device,
+                    dtype=combined.dtype,
+                ).reshape(1, -1)
+                if acoustic.shape[-1] != combined.shape[-1]:
+                    raise ValueError(
+                        "acoustic_embedding hidden size does not match the model."
+                    )
+                timeline = torch.cat(
+                    [self.model.embed_tokens(input_ids[offset : end - 1]), acoustic],
+                    dim=0,
+                )
+                pad_ids = torch.full(
+                    (length,), self.pad_token_id, device=input_ids.device
+                )
+                pad_embeddings = self.model.embed_tokens(pad_ids)
+                combined[offset:end] = (
+                    pad_embeddings * self.text_channel_weight
+                    + timeline * self.user_channel_weight
+                    + pad_embeddings * self.function_channel_weight
+                )
+            else:
+                function_ids = torch.as_tensor(
+                    item["input_function_ids"],
+                    device=input_ids.device,
+                    dtype=torch.long,
+                ).reshape(-1)
+                if function_ids.numel() == 1 and length != 1:
+                    function_ids = function_ids.expand(length)
+                acoustic = torch.as_tensor(
+                    item["acoustic_embedding"],
+                    device=input_ids.device,
+                    dtype=combined.dtype,
+                ).reshape(length, -1)
+                if function_ids.numel() != length:
+                    raise ValueError(
+                        "input_function_ids must align with scheduled tokens."
+                    )
+                if acoustic.shape != combined[offset:end].shape:
+                    raise ValueError(
+                        "acoustic_embedding must have shape "
+                        f"({length}, {combined.shape[-1]})."
+                    )
+                combined[offset:end] = (
+                    self.model.embed_tokens(input_ids[offset:end])
+                    * self.text_channel_weight
+                    + acoustic * self.user_channel_weight
+                    + self.model.embed_tokens(function_ids)
+                    * self.function_channel_weight
+                )
+            offset = end
+        return combined
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor | None = None,
+        pp_proxy_tensors: PPProxyTensors | None = None,
+    ):
+        if input_embeds is not None:
+            raise ValueError("NemotronDuplexH does not accept input_embeds.")
+        combined = self._combined_embeddings(input_ids, forward_batch)
+        hidden_states = self.model.forward(
+            input_ids, positions, forward_batch, pp_proxy_tensors, combined
+        )
+        if not self.pp_group.is_last_rank:
+            return hidden_states
+
+        output = self.logits_processor(
+            input_ids, hidden_states, self.lm_head, forward_batch
+        )
+        function_output = self.logits_processor(
+            input_ids, hidden_states, self.function_head, forward_batch
+        )
+        function_tokens = torch.argmax(function_output.next_token_logits, dim=-1)
+        output.customized_info = {"function_tokens": function_tokens.tolist()}
+        return output
+
+    @staticmethod
+    def _map_voicechat_weight_name(name: str) -> str:
+        mappings = (
+            ("stt_model.llm.backbone.", "model."),
+            ("stt_model.llm.", "model."),
+            ("stt_model.embed_tokens.", "model.embed_tokens."),
+            ("stt_model.lm_head.", "lm_head."),
+            ("stt_model.function_head.", "function_head."),
+        )
+        for old, new in mappings:
+            if name.startswith(old):
+                return new + name[len(old) :]
+        return name
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> None:
+        saw_function_head = False
+
+        def mapped_weights():
+            nonlocal saw_function_head
+            for name, weight in weights:
+                if name == "stt_model.function_head.weight":
+                    saw_function_head = True
+                yield self._map_voicechat_weight_name(name), weight
+
+        super().load_weights(mapped_weights())
+        if not saw_function_head:
+            raise ValueError(
+                "Checkpoint is missing 'stt_model.function_head.weight'; "
+                "reconvert it with the VoiceChat Duplex converter."
+            )
+
+
+EntryClass = NemotronDuplexHForCausalLM

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -61,7 +61,7 @@ from sglang_omni.proto.admin import (
     ADMIN_WEIGHTS_CHECKER,
 )
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
-from sglang_omni.scheduling.types import DeferredAdmission
+from sglang_omni.scheduling.types import DeferredAdmission, FollowupAdmission
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +154,11 @@ class _NoOpGrammarManager:
 
 
 class OmniScheduler:
+    # Streaming sessions are an opt-in extension. Keeping the disabled value
+    # on the class also preserves tests and embedders that construct a partial
+    # scheduler with object.__new__.
+    _streaming_sessions_enabled = False
+
     """Stage-facing scheduler for AR stages.
 
     Public contract (used by Stage):
@@ -195,6 +200,7 @@ class OmniScheduler:
         prefill_coalesce_after_builds_during_decode: bool = False,
         request_build_max_workers: int = 1,
         request_build_max_pending: int | None = None,
+        enable_streaming_sessions: bool = False,
         shutdown_callback: Callable[[], None] | None = None,
     ):
         self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
@@ -253,6 +259,7 @@ class OmniScheduler:
 
         # --- Core scheduling state (read/written by upstream methods) -----
         self.server_args = server_args
+        self._streaming_sessions_enabled = bool(enable_streaming_sessions)
         self.model_config = model_config
         self.gpu_id = tp_worker.gpu_id
         self.tp_rank = tp_worker.tp_rank
@@ -560,13 +567,17 @@ class OmniScheduler:
         self.ngram_embedding_manager = NgramEmbeddingManager(
             enabled=False, table=None, n=0, k=0
         )
-        # Upstream pool_stats_observer.streaming_session_count iterates
-        # self.session_controller.sessions.values() during decode stats
-        # reporting. We don't host SGLang's interactive-session feature, so a
-        # stub with an empty sessions dict is sufficient.
+        # Session support is opt-in. Existing Omni models retain the lightweight
+        # observer stub; frame-streaming models use SGLang's real controller and
+        # StreamingSession cache wrapper.
         from types import SimpleNamespace
 
-        self.session_controller = SimpleNamespace(sessions={})
+        if self._streaming_sessions_enabled:
+            from sglang.srt.session.session_controller import SessionController
+
+            self.session_controller = SessionController(self.tree_cache)
+        else:
+            self.session_controller = SimpleNamespace(sessions={})
         self.dllm_manager = SimpleNamespace(any_staging_reqs=lambda: False)
         self.load_snapshot_writer = None
         self.kv_events_publisher = SimpleNamespace(
@@ -832,6 +843,8 @@ class OmniScheduler:
 
     def process_input_requests(self, recv_reqs):
         """Convert incoming payloads to SGLang Reqs and enqueue."""
+        if self._streaming_sessions_enabled:
+            self.session_controller.maybe_reap(time.monotonic())
         self._drain_request_admission_results()
         self._drain_request_build_results()
         recv_reqs, rejected = self._stage_request_build_payloads(recv_reqs)
@@ -1153,7 +1166,30 @@ class OmniScheduler:
         request_admission_lock_held: bool = False,
     ) -> None:
         req_id = payload.request_id
+        with self._request_admission_lock:
+            if req_id in self._aborted_request_ids:
+                return
         self._deferred_request_payloads.pop(req_id, None)
+        if self._streaming_sessions_enabled and req_data.close_streaming_session:
+            from sglang.srt.managers.io_struct import CloseSessionReqInput
+
+            session_id = req_data.streaming_session_id
+            if session_id is None:
+                raise RuntimeError(
+                    "A close_streaming_session request requires an enabled session id"
+                )
+            self.session_controller.close(CloseSessionReqInput(session_id=session_id))
+            result = self._result_adapter(req_data)
+            self.outbox.put(
+                OutgoingMessage(request_id=req_id, type="result", data=result)
+            )
+            return
+
+        if (
+            self._streaming_sessions_enabled
+            and req_data.streaming_session_id is not None
+        ):
+            self._attach_streaming_session(req_data)
         req = req_data.req
         self._normalize_req_token_arrays(req)
         req_id = req.rid
@@ -1659,6 +1695,24 @@ class OmniScheduler:
                 continue
 
             self._first_emit_done.discard(rid)
+            if isinstance(result, FollowupAdmission):
+                followup = result.value
+                try:
+                    with self._request_admission_lock:
+                        self._completed_request_ids.pop(rid, None)
+                    self._enqueue_built_request(
+                        followup.stage_payload,
+                        False,
+                        followup,
+                    )
+                except Exception as exc:
+                    logger.exception(
+                        "OmniScheduler follow-up admission failed for request %s",
+                        rid,
+                    )
+                    self._emit_request_error(rid, exc)
+                    self.abort(rid)
+                continue
             self.outbox.put(
                 OutgoingMessage(
                     request_id=rid,
@@ -1666,6 +1720,66 @@ class OmniScheduler:
                     data=result,
                 )
             )
+
+    def _attach_streaming_session(self, req_data: Any) -> None:
+        """Convert a builder-produced Req into an append-only session turn."""
+        if not self._streaming_sessions_enabled:
+            raise RuntimeError(
+                "streaming_session_id requires enable_streaming_sessions=True"
+            )
+
+        from array import array
+
+        from sglang.srt.managers.io_struct import (
+            OpenSessionReqInput,
+            SessionParams,
+            TokenizedGenerateReqInput,
+        )
+
+        session_id = req_data.streaming_session_id
+        session = self.session_controller.get(session_id)
+        if session is None:
+            capacity = req_data.streaming_session_capacity or self.max_req_len
+            opened = self.session_controller.open(
+                OpenSessionReqInput(
+                    capacity_of_str_len=int(capacity),
+                    session_id=session_id,
+                    streaming=True,
+                    timeout=req_data.streaming_session_timeout,
+                )
+            )
+            if not opened.success:
+                raise RuntimeError(f"Failed to open streaming session {session_id!r}")
+            session = self.session_controller.get(session_id)
+        assert session is not None
+
+        raw_req = req_data.req
+        tokenized = TokenizedGenerateReqInput(
+            rid=raw_req.rid,
+            input_text=None,
+            input_ids=array("q", raw_req.origin_input_ids),
+            input_embeds=None,
+            mm_inputs=None,
+            token_type_ids=None,
+            sampling_params=raw_req.sampling_params,
+            return_logprob=req_data.return_logprob,
+            logprob_start_len=-1,
+            top_logprobs_num=0,
+            token_ids_logprob=None,
+            stream=False,
+            return_sampling_mask=False,
+            session_id=session_id,
+            session_params=SessionParams(id=session_id, rid=None),
+        )
+        # Omni AR stages run with skip_tokenizer_init. VoiceChat continuation
+        # turns are tokenized by their model adapter and never need BOS removal,
+        # so keep the scheduler-side Req tokenizer-free as upstream does.
+        req_data.req = session.create_req(
+            tokenized,
+            None,
+            self.model_config.vocab_size,
+            eos_token_ids=self.model_config.hf_eos_token_id,
+        )
 
     def _on_stream_chunk(self, request_id: str, chunk: Any) -> None:
         if request_id in self._completed_request_ids:

--- a/sglang_omni/scheduling/sglang_backend/cache.py
+++ b/sglang_omni/scheduling/sglang_backend/cache.py
@@ -28,6 +28,12 @@ def create_tree_cache(
     if server_args.disable_radix_cache:
         from sglang.srt.mem_cache.chunk_cache import ChunkCache
 
-        return ChunkCache(params)
+        cache = ChunkCache(params)
+    else:
+        cache = RadixCache(params)
 
-    return RadixCache(params)
+    if server_args.enable_streaming_session and not cache.supports_streaming_session():
+        from sglang.srt.session.streaming_session import StreamingSession
+
+        cache = StreamingSession(cache)
+    return cache

--- a/sglang_omni/scheduling/types.py
+++ b/sglang_omni/scheduling/types.py
@@ -35,6 +35,13 @@ class DeferredAdmission:
     ready: Future[Any]
 
 
+@dataclass(slots=True)
+class FollowupAdmission:
+    """Replace an internal AR result with another request on the same stage."""
+
+    value: Any
+
+
 @dataclass
 class SchedulerOutput:
     requests: list[SchedulerRequest]
@@ -85,6 +92,10 @@ class ARRequestData:
     max_new_tokens: int | None = None
     enforce_request_limits: bool = False
     temperature: float = 0.0
+    streaming_session_id: str | None = None
+    streaming_session_capacity: int | None = None
+    streaming_session_timeout: float | None = None
+    close_streaming_session: bool = False
 
 
 def sampled_logprobs_to_list(next_token_logprobs: Any) -> list[float] | None:

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -25,6 +25,7 @@ Export a config to JSON::
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import logging
 import os
@@ -32,6 +33,7 @@ import signal
 import socket
 import threading
 import time
+import uuid
 from contextlib import contextmanager, suppress
 from typing import Any
 
@@ -39,7 +41,7 @@ import uvicorn
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from sglang_omni.client import Client
+from sglang_omni.client import Client, GenerateRequest, SamplingParams
 from sglang_omni.config import PipelineConfig
 from sglang_omni.models.model_capabilities import get_model_capabilities
 from sglang_omni.pipeline.mp_runner import MultiProcessPipelineRunner
@@ -57,6 +59,55 @@ from sglang_omni.utils.gpu_memory import (
 logger = logging.getLogger(__name__)
 
 _HANDLED_SIGNALS = (signal.SIGINT, signal.SIGTERM)
+
+
+async def _warmup_frame_realtime_pipeline(
+    client: Client,
+    pipeline_config: PipelineConfig,
+    *,
+    enabled: bool,
+) -> None:
+    config = type(pipeline_config).realtime_audio
+    if not enabled or config.mode != "frame" or config.warmup_frames == 0:
+        return
+    assert config.frame_samples is not None
+    session_id = f"warmup-{uuid.uuid4().hex}"
+    silence = base64.b64encode(bytes(config.frame_samples * 2)).decode("ascii")
+    started = time.perf_counter()
+    try:
+        for frame_index in range(config.warmup_frames):
+            request = GenerateRequest(
+                model=pipeline_config.name,
+                prompt={
+                    "event": "audio_frame",
+                    "session_id": session_id,
+                    "frame_index": frame_index,
+                    "pcm16": silence,
+                    "instructions": "You are a helpful realtime voice assistant.",
+                },
+                sampling=SamplingParams(temperature=0.0, max_new_tokens=1),
+                output_modalities=["text", "audio"],
+                stream=False,
+            )
+            async for _ in client.generate(
+                request, request_id=f"{session_id}-{frame_index}"
+            ):
+                pass
+    finally:
+        close_request = GenerateRequest(
+            model=pipeline_config.name,
+            prompt={"event": "session_close", "session_id": session_id},
+            sampling=SamplingParams(temperature=0.0, max_new_tokens=1),
+            output_modalities=["audio"],
+            stream=False,
+        )
+        async for _ in client.generate(close_request, request_id=f"{session_id}-close"):
+            pass
+    logger.info(
+        "Frame-realtime warmup completed: frames=%d duration_ms=%.1f",
+        config.warmup_frames,
+        (time.perf_counter() - started) * 1000,
+    )
 
 
 class _PipelineUvicornServer(uvicorn.Server):
@@ -414,6 +465,9 @@ async def _run_server(
     try:
         cl_kwargs = client_kwargs or {}
         client = Client(coordinator, **cl_kwargs)
+        await _warmup_frame_realtime_pipeline(
+            client, pipeline_config, enabled=enable_realtime
+        )
         app = create_app(
             client,
             model_name=model_name or pipeline_config.name,
@@ -438,6 +492,7 @@ async def _run_server(
             supports_realtime_audio_output=(
                 type(pipeline_config).code2wav_stage() is not None
             ),
+            realtime_audio=type(pipeline_config).realtime_audio,
             allowed_local_media_path=allowed_local_media_path,
             allowed_media_domains=allowed_media_domains,
             tts_batch_max_items=tts_batch_max_items,

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -57,7 +57,7 @@ from sglang_omni.client.audio import (
     encode_pcm,
     select_audio_delta,
 )
-from sglang_omni.config import AudioChunkingConfig
+from sglang_omni.config import AudioChunkingConfig, RealtimeAudioConfig
 from sglang_omni.http.admin_auth import (
     make_admin_auth_dependency,
     resolve_admin_api_key,
@@ -185,6 +185,7 @@ def create_app(
     additional_speech_languages: frozenset[str] = frozenset(),
     enable_realtime: bool = False,
     supports_realtime_audio_output: bool = False,
+    realtime_audio: RealtimeAudioConfig | None = None,
     allowed_local_media_path: str | None = None,
     allowed_media_domains: list[str] | None = None,
     admin_api_key: str | None = None,
@@ -214,6 +215,7 @@ def create_app(
             endpoint (OpenAI Realtime API).
         supports_realtime_audio_output: Whether the mounted realtime endpoint
             can request streamed audio from the configured pipeline.
+        realtime_audio: Pipeline-owned turn- or fixed-frame realtime behavior.
         allowed_local_media_path: Directory allowed for ``file://`` TTS
             reference audio.
         allowed_media_domains: Domains allowed for remote TTS reference audio.
@@ -250,6 +252,7 @@ def create_app(
     )  # allow_audio_chunking default false
     app.state.realtime_enabled = enable_realtime
     app.state.supports_realtime_audio_output = supports_realtime_audio_output
+    app.state.realtime_audio = realtime_audio or RealtimeAudioConfig()
     app.state.speaker_sample_store = SpeakerSampleStore()
     app.state.speech_service = SpeechRequestValidator(
         default_model=app.state.model_name,
@@ -1193,6 +1196,7 @@ def _register_realtime(app: FastAPI) -> None:
         client=client,
         model_name=model_name,
         supports_audio_output=app.state.supports_realtime_audio_output,
+        audio_config=app.state.realtime_audio,
     )
     app.state.realtime_manager = manager
 

--- a/sglang_omni/serve/realtime/frame_session.py
+++ b/sglang_omni/serve/realtime/frame_session.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fixed-frame realtime session for lockstep duplex audio pipelines."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import uuid
+from contextlib import aclosing
+from typing import Any
+
+from fastapi import WebSocket
+from starlette.websockets import WebSocketState
+
+from sglang_omni.client import Client, GenerateRequest, SamplingParams
+from sglang_omni.config import RealtimeAudioConfig
+
+
+class FrameRealtimeSession:
+    """Continuously submit exact PCM frames without a VAD turn boundary.
+
+    The model pipeline owns conversation state. Each coordinator request is one
+    frame and carries a stable session id, so stage schedulers can retain their
+    model-specific caches without putting those caches in the serving layer.
+    """
+
+    def __init__(
+        self,
+        websocket: WebSocket,
+        *,
+        client: Client,
+        model_name: str,
+        config: RealtimeAudioConfig,
+        session_id: str | None = None,
+    ) -> None:
+        if config.mode != "frame" or config.frame_samples is None:
+            raise ValueError("FrameRealtimeSession requires frame-mode audio config")
+        self.websocket = websocket
+        self.client = client
+        self.model_name = model_name
+        self.config = config
+        self.session_id = session_id or f"sess_{uuid.uuid4().hex}"
+        self.instructions = "You are a helpful realtime voice assistant."
+        self.closed = False
+        self._partial_pcm = bytearray()
+        self._frames: asyncio.Queue[bytes | None] = asyncio.Queue(
+            maxsize=config.max_pending_frames
+        )
+        self._worker: asyncio.Task[None] | None = None
+        self._inflight: set[asyncio.Task[None]] = set()
+        self._inflight_slots = asyncio.Semaphore(config.max_inflight_frames)
+        self._frame_error: BaseException | None = None
+        self._active_request_ids: set[str] = set()
+        self._frame_index = 0
+
+    async def run(self) -> None:
+        await self.send(
+            {
+                "type": "session.created",
+                "session": {
+                    "id": self.session_id,
+                    "model": self.model_name,
+                    "modalities": ["text", "audio"],
+                    "input_audio_format": "pcm16",
+                    "input_sample_rate": self.config.input_sample_rate,
+                    "output_audio_format": "pcm16",
+                    "output_sample_rate": self.config.output_sample_rate,
+                    "frame_samples": self.config.frame_samples,
+                },
+            }
+        )
+        self._worker = asyncio.create_task(self._drain_frames())
+        while not self.closed:
+            message = await self.websocket.receive()
+            if message["type"] == "websocket.disconnect":
+                break
+            if message["type"] != "websocket.receive":
+                continue
+            raw = message.get("text")
+            if raw is None:
+                raise ValueError("Realtime events must be JSON text messages")
+            event = json.loads(raw)
+            if not isinstance(event, dict):
+                raise TypeError("Top-level payload must be a JSON object")
+            await self.dispatch(event)
+
+    async def dispatch(self, event: dict[str, Any]) -> None:
+        event_type = event.get("type")
+        if event_type == "session.update":
+            session = event.get("session") or {}
+            if not isinstance(session, dict):
+                raise ValueError("session.update.session must be an object")
+            instructions = session.get("instructions")
+            if instructions is not None:
+                self.instructions = str(instructions)
+            await self.send(
+                {
+                    "type": "session.updated",
+                    "session": {
+                        "id": self.session_id,
+                        "instructions": self.instructions,
+                        "input_sample_rate": self.config.input_sample_rate,
+                        "output_sample_rate": self.config.output_sample_rate,
+                        "frame_samples": self.config.frame_samples,
+                    },
+                }
+            )
+            return
+        if event_type == "input_audio_buffer.append":
+            await self._append_audio(event.get("audio"))
+            return
+        if event_type == "input_audio_buffer.clear":
+            self._partial_pcm.clear()
+            await self.send({"type": "input_audio_buffer.cleared"})
+            return
+        if event_type == "input_audio_buffer.commit":
+            await self._flush_partial_frame()
+            await self._frames.join()
+            if self._frame_error is not None:
+                error = self._frame_error
+                self._frame_error = None
+                raise RuntimeError("Realtime frame generation failed") from error
+            await self.send({"type": "input_audio_buffer.committed"})
+            return
+        if event_type == "session.close":
+            self.closed = True
+            return
+        if event_type == "response.cancel":
+            # VoiceChat's output is one lockstep frame, not a cancellable turn.
+            return
+        raise ValueError(f"Unsupported frame-realtime event type: {event_type!r}")
+
+    async def _append_audio(self, encoded: Any) -> None:
+        if not isinstance(encoded, str):
+            raise TypeError("input_audio_buffer.append.audio must be base64 text")
+        raw = base64.b64decode(encoded, validate=True)
+        if len(raw) % 2:
+            raise ValueError("PCM16 input must contain complete 16-bit samples")
+        self._partial_pcm.extend(raw)
+        frame_bytes = int(self.config.frame_samples) * 2
+        while len(self._partial_pcm) >= frame_bytes:
+            frame = bytes(self._partial_pcm[:frame_bytes])
+            del self._partial_pcm[:frame_bytes]
+            await self._frames.put(frame)
+
+    async def _flush_partial_frame(self) -> None:
+        if not self._partial_pcm:
+            return
+        frame_bytes = int(self.config.frame_samples) * 2
+        frame = bytes(self._partial_pcm) + bytes(frame_bytes - len(self._partial_pcm))
+        self._partial_pcm.clear()
+        await self._frames.put(frame)
+
+    async def _drain_frames(self) -> None:
+        try:
+            while True:
+                frame = await self._frames.get()
+                if frame is None:
+                    self._frames.task_done()
+                    break
+                await self._inflight_slots.acquire()
+                frame_index = self._frame_index
+                self._frame_index += 1
+                task = asyncio.create_task(
+                    self._run_frame_and_report(frame, frame_index)
+                )
+                self._inflight.add(task)
+                task.add_done_callback(self._frame_done)
+            if self._inflight:
+                await asyncio.gather(*self._inflight)
+        finally:
+            for task in self._inflight:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*self._inflight, return_exceptions=True)
+            self._inflight.clear()
+
+    def _frame_done(self, task: asyncio.Task[None]) -> None:
+        self._inflight.discard(task)
+        self._inflight_slots.release()
+        self._frames.task_done()
+        if not task.cancelled() and task.exception() is not None:
+            self._frame_error = task.exception()
+
+    async def _run_frame_and_report(self, frame: bytes, frame_index: int) -> None:
+        try:
+            await self._run_frame(frame, frame_index)
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:  # noqa: BLE001 - report frame failures to the client
+            self._frame_error = error
+            if not self.closed:
+                await self.send(
+                    {
+                        "type": "error",
+                        "error": {
+                            "type": "server_error",
+                            "code": "frame_generation_failed",
+                            "message": str(error),
+                        },
+                    }
+                )
+
+    async def _run_frame(self, frame: bytes, frame_index: int) -> None:
+        request_id = f"rt-{self.session_id}-{frame_index}"
+        self._active_request_ids.add(request_id)
+        request = GenerateRequest(
+            model=self.model_name,
+            prompt={
+                "event": "audio_frame",
+                "session_id": self.session_id,
+                "frame_index": frame_index,
+                "pcm16": base64.b64encode(frame).decode("ascii"),
+                "instructions": self.instructions,
+            },
+            sampling=SamplingParams(temperature=0.0, max_new_tokens=1),
+            output_modalities=["text", "audio"],
+            stream=True,
+        )
+        try:
+            stream = self.client.completion_stream(
+                request, request_id=request_id, audio_format="pcm"
+            )
+            async with aclosing(stream):
+                async for chunk in stream:
+                    if chunk.text:
+                        await self.send(
+                            {
+                                "type": "response.text.delta",
+                                "delta": chunk.text,
+                                "frame_index": frame_index,
+                            }
+                        )
+                    if chunk.audio_b64:
+                        await self.send(
+                            {
+                                "type": "response.audio.delta",
+                                "delta": chunk.audio_b64,
+                                "sample_rate": self.config.output_sample_rate,
+                                "frame_index": frame_index,
+                            }
+                        )
+        finally:
+            self._active_request_ids.discard(request_id)
+
+    async def _close_model_session(self) -> None:
+        request_id = f"rt-{self.session_id}-close"
+        request = GenerateRequest(
+            model=self.model_name,
+            prompt={"event": "session_close", "session_id": self.session_id},
+            sampling=SamplingParams(temperature=0.0, max_new_tokens=1),
+            output_modalities=["audio"],
+            stream=False,
+        )
+        async for _ in self.client.generate(request, request_id=request_id):
+            pass
+
+    async def send(self, event: dict[str, Any]) -> None:
+        if self.closed or self.websocket.application_state != WebSocketState.CONNECTED:
+            return
+        event.setdefault("event_id", f"evt_{uuid.uuid4().hex}")
+        await self.websocket.send_text(json.dumps(event))
+
+    async def teardown(self) -> None:
+        if self.closed and self._worker is None:
+            return
+        self.closed = True
+        if self._active_request_ids:
+            await asyncio.gather(
+                *(
+                    self.client.abort(request_id)
+                    for request_id in self._active_request_ids
+                ),
+                return_exceptions=True,
+            )
+        if self._worker is not None:
+            self._worker.cancel()
+            await asyncio.gather(self._worker, return_exceptions=True)
+            self._worker = None
+        try:
+            await self._close_model_session()
+        finally:
+            if self.websocket.client_state == WebSocketState.CONNECTED:
+                await self.websocket.close()
+
+
+__all__ = ["FrameRealtimeSession"]

--- a/sglang_omni/serve/realtime/manager.py
+++ b/sglang_omni/serve/realtime/manager.py
@@ -5,6 +5,8 @@ import logging
 from fastapi import WebSocket
 
 from sglang_omni.client import Client
+from sglang_omni.config import RealtimeAudioConfig
+from sglang_omni.serve.realtime.frame_session import FrameRealtimeSession
 from sglang_omni.serve.realtime.session import RealtimeSession
 
 logger = logging.getLogger(__name__)
@@ -17,19 +19,29 @@ class RealtimeSessionManager:
         client: Client,
         model_name: str,
         supports_audio_output: bool = False,
+        audio_config: RealtimeAudioConfig | None = None,
     ) -> None:
         self.client = client
         self.model_name = model_name
         self.supports_audio_output = supports_audio_output
-        self.sessions: dict[str, RealtimeSession] = {}
+        self.audio_config = audio_config or RealtimeAudioConfig()
+        self.sessions: dict[str, RealtimeSession | FrameRealtimeSession] = {}
 
-    def open(self, websocket: WebSocket) -> RealtimeSession:
-        session = RealtimeSession(
-            websocket,
-            client=self.client,
-            model_name=self.model_name,
-            supports_audio_output=self.supports_audio_output,
-        )
+    def open(self, websocket: WebSocket) -> RealtimeSession | FrameRealtimeSession:
+        if self.audio_config.mode == "frame":
+            session = FrameRealtimeSession(
+                websocket,
+                client=self.client,
+                model_name=self.model_name,
+                config=self.audio_config,
+            )
+        else:
+            session = RealtimeSession(
+                websocket,
+                client=self.client,
+                model_name=self.model_name,
+                supports_audio_output=self.supports_audio_output,
+            )
         self.sessions[session.session_id] = session
         logger.info(f"Realtime session opened: {session.session_id}")
         return session

--- a/tests/unit_test/nemotron_voicechat/test_audio_runtime.py
+++ b/tests/unit_test/nemotron_voicechat/test_audio_runtime.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from sglang_omni.models.nemotron_voicechat.audio_runtime import (
+    _copy_checkpoint_prefix,
+    _validate_max_sessions,
+)
+
+
+def test_checkpoint_prefix_requires_exact_module_coverage(tmp_path) -> None:
+    source = torch.nn.Linear(2, 3)
+    checkpoint = tmp_path / "model.safetensors"
+    save_file(
+        {f"voice.{name}": tensor for name, tensor in source.state_dict().items()},
+        checkpoint,
+    )
+    target = torch.nn.Linear(2, 3)
+
+    assert _copy_checkpoint_prefix(target, checkpoint, "voice.") == 2
+    for name, tensor in source.state_dict().items():
+        torch.testing.assert_close(target.state_dict()[name], tensor)
+
+
+def test_checkpoint_prefix_rejects_missing_or_unexpected_tensors(tmp_path) -> None:
+    module = torch.nn.Linear(2, 3)
+    missing = tmp_path / "missing.safetensors"
+    save_file({"voice.weight": module.weight.detach()}, missing)
+    with pytest.raises(ValueError, match="missing 1 module tensors"):
+        _copy_checkpoint_prefix(module, missing, "voice.")
+
+    unexpected = tmp_path / "unexpected.safetensors"
+    tensors = {f"voice.{name}": tensor for name, tensor in module.state_dict().items()}
+    tensors["voice.extra"] = torch.zeros(1)
+    save_file(tensors, unexpected)
+    with pytest.raises(ValueError, match="unexpected 1 checkpoint tensors"):
+        _copy_checkpoint_prefix(module, unexpected, "voice.")
+
+
+def test_max_sessions_must_be_positive() -> None:
+    assert _validate_max_sessions(1) == 1
+    with pytest.raises(ValueError, match="must be positive"):
+        _validate_max_sessions(0)

--- a/tests/unit_test/nemotron_voicechat/test_benchmark.py
+++ b/tests/unit_test/nemotron_voicechat/test_benchmark.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+from pathlib import Path
+
+BENCHMARK_PATH = (
+    Path(__file__).parents[3]
+    / "benchmarks"
+    / "eval"
+    / "benchmark_nemotron_voicechat.py"
+)
+BENCHMARK_SPEC = importlib.util.spec_from_file_location(
+    "benchmark_nemotron_voicechat", BENCHMARK_PATH
+)
+assert BENCHMARK_SPEC is not None and BENCHMARK_SPEC.loader is not None
+benchmark = importlib.util.module_from_spec(BENCHMARK_SPEC)
+BENCHMARK_SPEC.loader.exec_module(benchmark)
+
+
+def audio_event(arrival_ms):
+    return {
+        "type": "response.output_audio.delta",
+        "arrival_ms": arrival_ms,
+    }
+
+
+def test_aggregate_report_pairs_80ms_events_and_excludes_close_flush_gap():
+    report = {
+        "runs": [
+            {
+                "first_audio_ms": 100.0,
+                "session_close_sent_ms": 500.0,
+                "audio_event_count": 6,
+                "output_samples": 11_520,
+                "text": "I am your AI voice assistant.",
+                "events": [
+                    audio_event(100),
+                    audio_event(101),
+                    audio_event(260),
+                    audio_event(261),
+                    audio_event(700),
+                    audio_event(701),
+                ],
+            }
+        ]
+    }
+
+    summary = benchmark.aggregate_report(report)
+
+    assert summary["first_audio_ms"]["mean"] == 100.0
+    assert summary["native_audio_event_interval_ms"]["count"] == 5
+    assert summary["paired_160ms_interval_ms"] == {
+        "count": 1,
+        "mean": 160.0,
+        "p50": 160.0,
+        "p95": 160.0,
+        "p99": 160.0,
+        "min": 160.0,
+        "max": 160.0,
+    }
+    assert summary["transcripts"] == ["I am your AI voice assistant."]
+    assert summary["audio_event_counts"] == [6]
+    assert summary["output_sample_counts"] == [11_520]

--- a/tests/unit_test/nemotron_voicechat/test_client.py
+++ b/tests/unit_test/nemotron_voicechat/test_client.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+from array import array
+from pathlib import Path
+
+import pytest
+
+CLIENT_PATH = Path(__file__).parents[3] / "examples" / "nemotron_voicechat_client.py"
+CLIENT_SPEC = importlib.util.spec_from_file_location(
+    "nemotron_voicechat_client", CLIENT_PATH
+)
+assert CLIENT_SPEC is not None and CLIENT_SPEC.loader is not None
+client = importlib.util.module_from_spec(CLIENT_SPEC)
+CLIENT_SPEC.loader.exec_module(client)
+
+
+def test_resample_pcm16_uses_exact_80ms_device_frame_sizes():
+    microphone = array("h", range(1_920)).tobytes()
+    model_input = client.resample_pcm16(microphone, 24_000, client.INPUT_RATE)
+    assert len(model_input) // 2 == client.FRAME_SAMPLES
+
+    model_output = array("h", range(1_764)).tobytes()
+    playback = client.resample_pcm16(model_output, client.OUTPUT_RATE, 48_000)
+    assert len(playback) // 2 == 3_840
+
+
+def test_validate_session_created_accepts_voicechat_audio_contract():
+    client.validate_session_created(
+        {
+            "type": "session.created",
+            "session": {
+                "input_audio_format": "pcm16",
+                "input_sample_rate": client.INPUT_RATE,
+                "output_audio_format": "pcm16",
+                "output_sample_rate": client.OUTPUT_RATE,
+                "frame_samples": client.FRAME_SAMPLES,
+            },
+        }
+    )
+
+
+def test_validate_session_created_rejects_incompatible_audio_contract():
+    with pytest.raises(RuntimeError, match="output_sample_rate=24000"):
+        client.validate_session_created(
+            {
+                "type": "session.created",
+                "session": {
+                    "input_audio_format": "pcm16",
+                    "input_sample_rate": client.INPUT_RATE,
+                    "output_audio_format": "pcm16",
+                    "output_sample_rate": 24_000,
+                    "frame_samples": client.FRAME_SAMPLES,
+                },
+            }
+        )
+
+
+def test_client_defaults_to_microphone_with_playback():
+    args = client.build_parser().parse_args([])
+
+    assert args.url == "ws://127.0.0.1:18080/v1/realtime"
+    assert not args.no_playback
+    assert args.trailing_silence == 2.0

--- a/tests/unit_test/nemotron_voicechat/test_config.py
+++ b/tests/unit_test/nemotron_voicechat/test_config.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sglang_omni.config.manager import ConfigManager
+from sglang_omni.models.nemotron_voicechat.config import (
+    CODE2WAV_STAGE,
+    NemotronVoiceChatPipelineConfig,
+)
+from sglang_omni.models.nemotron_voicechat.payload_types import (
+    FRAME_SAMPLES,
+    VoiceChatFrameState,
+)
+from sglang_omni.serve.launcher import _warmup_frame_realtime_pipeline
+
+
+def test_voicechat_pipeline_is_fixed_frame_and_audio_terminal() -> None:
+    config = NemotronVoiceChatPipelineConfig(model_path="/checkpoint")
+
+    assert config.realtime_audio.mode == "frame"
+    assert config.realtime_audio.frame_samples == FRAME_SAMPLES
+    assert type(config).code2wav_stage() == CODE2WAV_STAGE
+    assert config.terminal_stages == [CODE2WAV_STAGE]
+    assert [stage.name for stage in config.stages] == [
+        "perception",
+        "thinker",
+        "talker",
+        "code2wav",
+    ]
+
+
+def test_voicechat_pipeline_rejects_topology_changes() -> None:
+    defaults = NemotronVoiceChatPipelineConfig(model_path="/checkpoint")
+    stages = [stage.model_copy(deep=True) for stage in defaults.stages]
+    stages[1].next = "code2wav"
+
+    with pytest.raises(ValueError, match="Invalid Nemotron VoiceChat topology"):
+        NemotronVoiceChatPipelineConfig(model_path="/checkpoint", stages=stages)
+
+
+def test_voicechat_h100_example_uses_builder_session_capacity_defaults() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    config = ConfigManager.from_file(
+        str(repo_root / "examples/configs/nemotron_voicechat_h100.yaml")
+    ).config
+    stages = {stage.name: stage for stage in config.stages}
+
+    assert isinstance(config, NemotronVoiceChatPipelineConfig)
+    thinker_factory = stages["thinker"].factory.model_dump(exclude_none=True)
+    talker_factory = stages["talker"].factory.model_dump(exclude_none=True)
+    assert "server_args_overrides" not in thinker_factory
+    assert "server_args_overrides" not in talker_factory
+    assert "attention_backend" not in talker_factory
+    assert stages["thinker"].engine is not None
+    assert stages["talker"].engine is not None
+    assert stages["thinker"].engine.mem_fraction_static == 0.45
+    assert stages["talker"].engine.mem_fraction_static == 0.20
+
+
+def test_voicechat_frame_state_requires_monotonic_frame_metadata() -> None:
+    state = VoiceChatFrameState.from_data(
+        {
+            "event": "audio_frame",
+            "session_id": "session",
+            "frame_index": 0,
+            "pcm16": "AA==",
+        }
+    )
+    assert state.frame_index == 0
+
+    wrapped = VoiceChatFrameState.from_data(
+        {
+            "raw_inputs": {
+                "event": "audio_frame",
+                "session_id": "session",
+                "frame_index": 1,
+                "pcm16": "AA==",
+            }
+        }
+    )
+    assert wrapped.frame_index == 1
+
+    with pytest.raises(ValueError, match="frame_index"):
+        VoiceChatFrameState.from_data(
+            {
+                "event": "audio_frame",
+                "session_id": "session",
+                "frame_index": -1,
+                "pcm16": "AA==",
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_voicechat_warmup_is_skipped_when_realtime_is_disabled() -> None:
+    class UnexpectedClient:
+        def generate(self, *args, **kwargs):
+            raise AssertionError("warmup must not submit a request")
+
+    config = NemotronVoiceChatPipelineConfig(model_path="/checkpoint")
+    await _warmup_frame_realtime_pipeline(
+        UnexpectedClient(),  # type: ignore[arg-type]
+        config,
+        enabled=False,
+    )

--- a/tests/unit_test/nemotron_voicechat/test_models.py
+++ b/tests/unit_test/nemotron_voicechat/test_models.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+import torch
+from transformers import AutoConfig
+
+from sglang_omni.models.nemotron_voicechat.configuration import EarTTSConfig
+from sglang_omni.models.nemotron_voicechat.convert_duplex import (
+    _configure_duplex_config,
+)
+from sglang_omni.models.nemotron_voicechat.registration import register_voicechat_models
+from sglang_omni.models.nemotron_voicechat.talker import (
+    EarTTSForCausalLM,
+    MaskGITSampler,
+)
+from sglang_omni.models.nemotron_voicechat.thinker import NemotronDuplexHForCausalLM
+
+
+def test_voicechat_models_register_with_sglang() -> None:
+    from sglang.srt.models.registry import ModelRegistry
+
+    register_voicechat_models()
+
+    assert ModelRegistry.models["NemotronDuplexHForCausalLM"] is (
+        NemotronDuplexHForCausalLM
+    )
+    assert ModelRegistry.models["EarTTSForCausalLM"] is EarTTSForCausalLM
+
+
+def test_eartts_auto_config_roundtrip(tmp_path) -> None:
+    register_voicechat_models()
+    config = EarTTSConfig(
+        architectures=["EarTTSForCausalLM"],
+        hidden_size=16,
+        num_hidden_layers=2,
+    )
+    (tmp_path / "config.json").write_text(json.dumps(config.to_dict()))
+
+    loaded = AutoConfig.from_pretrained(tmp_path)
+
+    assert isinstance(loaded, EarTTSConfig)
+    assert loaded.architectures == ["EarTTSForCausalLM"]
+    assert loaded.rope_parameters["full_attention"]["rope_theta"] == 1_000_000
+
+
+def test_maskgit_outputs_one_valid_code_per_quantizer() -> None:
+    torch.manual_seed(1)
+    config = EarTTSConfig(
+        hidden_size=8,
+        intermediate_size=16,
+        num_quantizers=3,
+        codebook_size=4,
+        latent_size=4,
+        num_iter=2,
+        exponent=3.0,
+        mog_low_rank=2,
+        mog_num_layers=1,
+        mog_num_predictions=5,
+        top_p_or_k=1.0,
+    )
+    sampler = MaskGITSampler(config)
+
+    codes = sampler(torch.randn(2, config.hidden_size))
+
+    assert codes.shape == (2, config.num_quantizers)
+    assert codes.dtype == torch.long
+    assert torch.all(codes >= 0)
+    assert torch.all(codes < config.codebook_size)
+
+
+class _FakeEarTTSBackbone:
+    def load_weights(self, weights):
+        [(name, _)] = weights
+        return {name}
+
+
+def _fake_eartts_model():
+    model = SimpleNamespace(backbone=_FakeEarTTSBackbone())
+    params = [
+        ("backbone.model.embed_tokens.weight", torch.nn.Parameter(torch.zeros(1))),
+        ("backbone.model.layers.0.weight", torch.nn.Parameter(torch.zeros(1))),
+        ("total_emb.bos_emb", torch.nn.Parameter(torch.zeros(1))),
+    ]
+    buffers = [("sil_tokens", torch.zeros(1, dtype=torch.int32))]
+    model.named_parameters = lambda: iter(params)
+    model.named_buffers = lambda: iter(buffers)
+    return model
+
+
+def test_eartts_weight_loader_requires_complete_checkpoint() -> None:
+    model = _fake_eartts_model()
+
+    with pytest.raises(RuntimeError, match="total_emb.bos_emb"):
+        EarTTSForCausalLM.load_weights(
+            model,
+            [
+                ("model.backbone.layers.0.weight", torch.ones(1)),
+                ("model.sil_tokens", torch.ones(1, dtype=torch.int32)),
+            ],
+        )
+
+
+def test_eartts_weight_loader_accepts_complete_checkpoint() -> None:
+    model = _fake_eartts_model()
+
+    loaded = EarTTSForCausalLM.load_weights(
+        model,
+        [
+            ("model.backbone.layers.0.weight", torch.ones(1)),
+            ("model.total_emb.bos_emb", torch.ones(1)),
+            ("model.sil_tokens", torch.ones(1, dtype=torch.int32)),
+        ],
+    )
+
+    assert loaded == {
+        "backbone.model.layers.0.weight",
+        "total_emb.bos_emb",
+        "sil_tokens",
+    }
+
+
+def test_duplex_unified_checkpoint_name_mapping() -> None:
+    mapper = NemotronDuplexHForCausalLM._map_voicechat_weight_name
+
+    assert mapper("stt_model.llm.backbone.layers.0.weight") == ("model.layers.0.weight")
+    assert mapper("stt_model.llm.layers.0.weight") == "model.layers.0.weight"
+    assert mapper("stt_model.function_head.weight") == "function_head.weight"
+
+
+def test_duplex_conversion_pins_voicechat_runtime_config() -> None:
+    config = _configure_duplex_config(
+        SimpleNamespace(),
+        {
+            "duplex_text_channel_weight": 1,
+            "duplex_user_channel_weight": 1,
+            "duplex_function_channel_weight": 2,
+        },
+    )
+
+    assert config.architectures == ["NemotronDuplexHForCausalLM"]
+    assert config.predict_user_text is False
+    assert config.use_function_head is True
+    assert config.mamba_ssm_dtype == "float32"
+    assert config.duplex_text_channel_weight == 1.0
+    assert config.duplex_user_channel_weight == 1.0
+    assert config.duplex_function_channel_weight == 2.0
+    assert config.fuse_method == "add"

--- a/tests/unit_test/nemotron_voicechat/test_request_builders.py
+++ b/tests/unit_test/nemotron_voicechat/test_request_builders.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.nemotron_voicechat.engine_builder import (
+    VoiceChatTalkerEngineBuilder,
+    VoiceChatThinkerEngineBuilder,
+)
+from sglang_omni.models.nemotron_voicechat.model_runner import VoiceChatModelRunner
+from sglang_omni.models.nemotron_voicechat.request_builders import (
+    TalkerAdapters,
+    ThinkerAdapters,
+)
+from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.scheduling.types import (
+    DeferredAdmission,
+    FollowupAdmission,
+    RequestOutput,
+)
+
+
+class _Tokenizer:
+    bos_token_id = 1
+
+    def encode(self, text: str, *, add_special_tokens: bool) -> list[int]:
+        assert text
+        assert not add_special_tokens
+        return [10, 11]
+
+    def decode(self, ids: list[int], **_: object) -> str:
+        return f"token-{ids[0]}"
+
+
+def test_engine_builders_reserve_session_and_inflight_request_slots() -> None:
+    common = {
+        "context_length": 64,
+        "max_sessions": 3,
+        "total_gpu_memory_fraction": 0.5,
+    }
+    thinker = VoiceChatThinkerEngineBuilder(**common)
+    talker = VoiceChatTalkerEngineBuilder(**common)
+
+    for builder in (thinker, talker):
+        assert builder.extra_scheduler_kwargs() == {
+            "request_build_max_workers": 1,
+            "enable_streaming_sessions": True,
+        }
+    assert thinker.generation_defaults(dtype="bfloat16")["max_running_requests"] == 6
+    assert thinker.generation_defaults(dtype="bfloat16")["disable_cuda_graph"] is True
+    talker_defaults = talker.generation_defaults(dtype="float32")
+    assert talker_defaults["max_running_requests"] == 6
+    assert talker_defaults["enable_tf32_matmul"] is True
+    assert talker_defaults["disable_cuda_graph"] is True
+    assert talker_defaults["chunked_prefill_size"] == -1
+
+    with pytest.raises(ValueError, match="requires dtype='float32'"):
+        talker.generation_defaults(dtype="bfloat16")
+
+
+def _payload(frame_index: int, **data: object) -> StagePayload:
+    return StagePayload(
+        request_id=f"request-{frame_index}",
+        request=OmniRequest(inputs={}),
+        data={
+            "event": "audio_frame",
+            "session_id": "session-1",
+            "frame_index": frame_index,
+            **data,
+        },
+    )
+
+
+def test_thinker_carries_function_token_between_session_turns() -> None:
+    config = SimpleNamespace(
+        bos_token_id=1,
+        eos_token_id=2,
+        pad_token_id=3,
+        vocab_size=32,
+    )
+    adapters = ThinkerAdapters(
+        config=config,
+        tokenizer=_Tokenizer(),
+        context_length=64,
+    )
+    first = adapters.request_builder(
+        _payload(0, acoustic_embedding=torch.ones(1, 2), instructions="Be concise")
+    )
+    assert list(first.req.origin_input_ids) == [1, 10, 11, 2, 3]
+    assert first.custom_inputs["is_initial_prefill"] is True
+    second_deferred = adapters.request_builder(
+        _payload(1, acoustic_embedding=torch.ones(1, 2))
+    )
+    assert isinstance(second_deferred, DeferredAdmission)
+    assert not second_deferred.ready.done()
+    first.output_ids = [7]
+    first.extra_model_outputs = {"function_tokens": 9}
+
+    output = adapters.result_adapter(first)
+    assert output.data["text_token"] == 7
+    assert output.data["function_token"] == 9
+    assert output.data["text_delta"] == "token-7"
+
+    assert second_deferred.ready.done()
+    second = second_deferred.value
+    assert list(second.req.origin_input_ids) == []
+    assert second.custom_inputs["input_function_ids"] == [9]
+    second.output_ids = [8]
+    second.extra_model_outputs = {"function_tokens": 10}
+    adapters.result_adapter(second)
+
+    third = adapters.request_builder(_payload(2, acoustic_embedding=torch.ones(1, 2)))
+    assert not isinstance(third, DeferredAdmission)
+    assert third.custom_inputs["input_function_ids"] == [10]
+
+
+def test_talker_chains_speaker_prefill_before_first_frame() -> None:
+    adapters = TalkerAdapters(
+        config=SimpleNamespace(vocab_size=2),
+        speaker=torch.ones(3, 4),
+        context_length=64,
+    )
+    prefill = adapters.request_builder(_payload(0, text_token=5))
+    assert prefill.kind == "speaker_prefill"
+    assert prefill.req.rid == prefill.stage_payload.request_id
+    assert list(prefill.req.origin_input_ids) == [0, 0, 0]
+    assert prefill.followup is not None
+    assert prefill.followup.custom_inputs == {
+        "text_token": 5,
+        "previous_audio_codes": None,
+    }
+    second_deferred = adapters.request_builder(_payload(1, text_token=6))
+    assert isinstance(second_deferred, DeferredAdmission)
+    assert not second_deferred.ready.done()
+
+    followup = adapters.result_adapter(prefill)
+    assert isinstance(followup, FollowupAdmission)
+    frame = followup.value
+    frame.extra_model_outputs = {"audio_codes": [4, 3, 2]}
+    output = adapters.result_adapter(frame)
+    assert output.data["audio_codes"] == [4, 3, 2]
+
+    assert second_deferred.ready.done()
+    second = second_deferred.value
+    assert second.custom_inputs == {
+        "text_token": 6,
+        "previous_audio_codes": [4, 3, 2],
+    }
+    second.extra_model_outputs = {"audio_codes": [7, 8, 9]}
+    adapters.result_adapter(second)
+
+    third = adapters.request_builder(_payload(2, text_token=7))
+    assert not isinstance(third, DeferredAdmission)
+    assert third.custom_inputs == {
+        "text_token": 7,
+        "previous_audio_codes": [7, 8, 9],
+    }
+
+
+def test_model_runner_preserves_customized_info_per_request() -> None:
+    runner = object.__new__(VoiceChatModelRunner)
+    result = SimpleNamespace(
+        logits_output=SimpleNamespace(customized_info={"audio_codes": [[1, 2], [3, 4]]})
+    )
+    scheduler_output = SimpleNamespace(
+        requests=[
+            SimpleNamespace(request_id="a"),
+            SimpleNamespace(request_id="b"),
+        ]
+    )
+    outputs = {
+        "a": RequestOutput(request_id="a"),
+        "b": RequestOutput(request_id="b"),
+    }
+
+    runner.post_process_outputs(result, scheduler_output, outputs)
+
+    assert outputs["a"].extra == {"audio_codes": [1, 2]}
+    assert outputs["b"].extra == {"audio_codes": [3, 4]}
+
+
+def test_model_runner_installs_model_local_custom_inputs() -> None:
+    runner = object.__new__(VoiceChatModelRunner)
+    installed = []
+    runner.model = SimpleNamespace(set_voicechat_custom_inputs=installed.append)
+    requests = [
+        SimpleNamespace(data=SimpleNamespace(custom_inputs={"frame": 1})),
+        SimpleNamespace(data=SimpleNamespace(custom_inputs={"frame": 2})),
+    ]
+
+    runner.before_prefill(object(), object(), requests)
+
+    assert installed == [[{"frame": 1}, {"frame": 2}]]

--- a/tests/unit_test/serve/test_realtime_frame_session.py
+++ b/tests/unit_test/serve/test_realtime_frame_session.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+from starlette.websockets import WebSocketState
+
+from sglang_omni.client.types import CompletionStreamChunk
+from sglang_omni.config import RealtimeAudioConfig
+from sglang_omni.serve.realtime.frame_session import FrameRealtimeSession
+
+
+class RecordingWebSocket:
+    application_state = WebSocketState.CONNECTED
+    client_state = WebSocketState.CONNECTED
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    async def send_text(self, payload: str) -> None:
+        self.events.append(json.loads(payload))
+
+    async def close(self) -> None:
+        self.application_state = WebSocketState.DISCONNECTED
+        self.client_state = WebSocketState.DISCONNECTED
+
+
+class RecordingClient:
+    def __init__(self) -> None:
+        self.requests: list[Any] = []
+        self.aborted: list[str] = []
+
+    async def completion_stream(
+        self, request: Any, *, request_id: str, audio_format: str
+    ) -> AsyncIterator[CompletionStreamChunk]:
+        self.requests.append(request)
+        assert audio_format == "pcm"
+        yield CompletionStreamChunk(
+            request_id=request_id,
+            modality="audio",
+            audio_b64="AQI=",
+            finish_reason="stop",
+        )
+
+    async def abort(self, request_id: str) -> None:
+        self.aborted.append(request_id)
+
+
+def _session(
+    frame_samples: int = 4,
+) -> tuple[FrameRealtimeSession, RecordingWebSocket, RecordingClient]:
+    websocket = RecordingWebSocket()
+    client = RecordingClient()
+    session = FrameRealtimeSession(
+        websocket,  # type: ignore[arg-type]
+        client=client,  # type: ignore[arg-type]
+        model_name="voicechat",
+        config=RealtimeAudioConfig(
+            mode="frame",
+            input_sample_rate=16_000,
+            output_sample_rate=22_050,
+            frame_samples=frame_samples,
+        ),
+    )
+    return session, websocket, client
+
+
+@pytest.mark.asyncio
+async def test_append_splits_arbitrary_chunks_into_exact_pcm_frames() -> None:
+    session, _, _ = _session(frame_samples=4)
+    raw = bytes(range(12))
+
+    await session.dispatch(
+        {
+            "type": "input_audio_buffer.append",
+            "audio": base64.b64encode(raw).decode(),
+        }
+    )
+
+    assert session._frames.qsize() == 1
+    assert await session._frames.get() == raw[:8]
+    session._frames.task_done()
+    assert bytes(session._partial_pcm) == raw[8:]
+
+
+@pytest.mark.asyncio
+async def test_commit_pads_partial_frame_and_waits_for_generation() -> None:
+    session, websocket, client = _session(frame_samples=4)
+    session._worker = asyncio.create_task(session._drain_frames())
+    try:
+        raw = bytes(range(6))
+        await session.dispatch(
+            {
+                "type": "input_audio_buffer.append",
+                "audio": base64.b64encode(raw).decode(),
+            }
+        )
+        await session.dispatch({"type": "input_audio_buffer.commit"})
+
+        assert len(client.requests) == 1
+        assert base64.b64decode(client.requests[0].prompt["pcm16"]) == raw + bytes(2)
+        assert websocket.events[-1]["type"] == "input_audio_buffer.committed"
+    finally:
+        await session._frames.put(None)
+        await session._worker
+        session._worker = None
+
+
+@pytest.mark.asyncio
+async def test_frame_request_carries_stable_session_and_emits_audio_delta() -> None:
+    session, websocket, client = _session()
+    await session.dispatch(
+        {"type": "session.update", "session": {"instructions": "Be concise."}}
+    )
+
+    await session._run_frame(bytes(8), frame_index=7)
+
+    assert client.requests[0].prompt == {
+        "event": "audio_frame",
+        "session_id": session.session_id,
+        "frame_index": 7,
+        "pcm16": base64.b64encode(bytes(8)).decode("ascii"),
+        "instructions": "Be concise.",
+    }
+    audio = [
+        event for event in websocket.events if event["type"] == "response.audio.delta"
+    ]
+    assert audio == [
+        {
+            "type": "response.audio.delta",
+            "delta": "AQI=",
+            "sample_rate": 22_050,
+            "frame_index": 7,
+            "event_id": audio[0]["event_id"],
+        }
+    ]


### PR DESCRIPTION
## Motivation

Add realtime, full-duplex support for NVIDIA NemotronLabs VoiceChat 11B.

## Modifications

- Add the thinker and talker models to SGLang-Omni.
- Run the Conformer and code2wav stages using the checkpoint’s NeMo implementations.
- Add the realtime WebSocket path and session handling.
- Add checkpoint conversion, startup warmup, and unit tests.
- Add a microphone client and reproducible benchmark driver.
- Add a VoiceChat cookbook covering setup, live microphone use, and benchmarking.
- Works with `sglang==0.5.18` and does not require SGLang core changes.

Collected the comparison results in Accuracy and Benchmark tests below using `sglang==0.5.16`, as recorded in the cookbook. Revalidated end to end with `sglang==0.5.18`

## Related Issues

## Accuracy Test

Compared this implementation with NVIDIA NIM for accuracy and latency.

Tested the published checkpoint end to end on a single H100 with live microphone input using `examples/nemotron_voicechat_client.py`. It produced valid text and audio responses while continuing to accept microphone input during playback.

The file-based test used the file at `/s2s/what_is_your_name.wav` in the pinned NIM image:

`nvcr.io/nim/nvidia/nemotron-labs-voicechat@sha256:6e69ff2aac955be2cb65b0de4f5b6d7c0b5e45ca0a1d42a2b153e9b54efb059b`

Both NIM and SGLang-Omni returned `I am your AI voice assistant.` in all 20 measured runs.

## Benchmark & Profiling

Compared this implementation with the [official NemotronLabs VoiceChat NIM](https://github.com/NVIDIA-NeMo/Speech/blob/nemotron-labs-voicechat/voicechat_realtime_instructions/deploy.md).

Both backends were tested through their public `/v1/realtime` WebSocket endpoints on the same H100 PCIe. The test used identical prepared audio bytes, 80 ms input pacing, prompt, warmup count, and run count. Timing starts immediately before the first input frame is sent and ends when the first audio event is received.

The benchmark discarded one full-session warmup and then measured 20 sessions per backend.

The commands used to prepare the input and run both backends are in `docs/cookbook/nemotron_voicechat.md`. The benchmark driver is `benchmarks/eval/benchmark_nemotron_voicechat.py`.

### Time to first audio

| Backend | Runs | Mean | Median | p95 | Min | Max |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| NVIDIA NIM 2.0.0 | 20 | 315.59 ms | 315.96 ms | 317.77 ms | 311.91 ms | 322.31 ms |
| SGLang-Omni | 20 | 173.93 ms | 174.59 ms | 175.34 ms | 169.89 ms | 175.44 ms |

### Audio delivery cadence

The public NIM endpoint sends two 80 ms audio events back-to-back in each 160 ms emission batch. SGLang-Omni sends one 80 ms event at a time. The paired SGLang row groups adjacent events by their recorded arrival timestamps to compare the same 160 ms audio duration.

| Delivery | Intervals | Mean gap | Median gap | p95 gap | p99 gap |
| --- | ---: | ---: | ---: | ---: | ---: |
| NIM 160 ms emission batch | 1,320 | 160.04 ms | 162.24 ms | 164.98 ms | 166.47 ms |
| SGLang native 80 ms event | 2,720 | 79.47 ms | 79.46 ms | 86.02 ms | 89.60 ms |
| SGLang paired to 160 ms | 1,340 | 159.40 ms | 159.65 ms | 165.89 ms | 168.78 ms |

The NIM cadence row excludes the final batch whose interval crosses `session.close`. The reference file client waits two seconds after finishing the input file before closing, so that final gap measures the shutdown policy rather than steady-state audio delivery.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.