### PR TITLE
[CI] CPU-only unit tests; GPU tests move to a forked gpu-unit-test stage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,8 +43,46 @@ jobs:
       - name: Run test
         timeout-minutes: 30
         shell: bash
+        env:
+          # The unit-test stage is CPU-only: accelerators are hidden so any
+          # test that needs one fails loudly here instead of flaking, and the
+          # conftest guard refuses to run if a device is still visible.
+          CUDA_VISIBLE_DEVICES: ""
+          OMNI_UNIT_CPU_ONLY: "1"
         run: |
           source omni/bin/activate
           export PYTHONPATH=$PWD
           bash .github/scripts/run_flaky_pytest.sh \
-            pytest tests/ -v -m "not benchmark" -x
+            pytest tests/ -v -m "not benchmark and not gpu" -x
+
+  gpu-unit-test:
+    name: gpu-unit-test
+    runs-on: [self-hosted, h100]
+    container:
+      image: hongccc/sglang-omni@sha256:374d0b1c30b2bff685b1716fc64a02ad3b3d0a90fe2ce73ce9861a6992c28101
+      options: >-
+        --rm
+        -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
+        -v /dev/shm:/dev/shm
+        -v /data/omni-ci:/data/omni-ci
+        -v /data/cache/huggingface:/github/home/.cache/huggingface
+        -v /data/cache/huggingface:/root/.cache/huggingface
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/omni-setup
+        with:
+          venv-name: omni
+
+      - name: Run gpu test
+        timeout-minutes: 30
+        shell: bash
+        run: |
+          source omni/bin/activate
+          export PYTHONPATH=$PWD
+          # --forked: one process (and one fresh CUDA context) per test, so
+          # accumulated allocator/graph state can never leak across tests.
+          bash .github/scripts/run_flaky_pytest.sh \
+            pytest tests/ -v -m "gpu and not benchmark" --forked

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,8 @@ dependencies = [
     # Testing
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
+    "pytest-forked>=1.6.0",   # gpu-unit-test: fresh process (and CUDA context) per test
+
     "jiwer",
     "zhon>=2.0.2",            # note (yzxiao): shared Chinese WER normalization uses zhon.hanzi punctuation.
     "scipy>=1.10.0",

--- a/tests/unit_test/accel.py
+++ b/tests/unit_test/accel.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared accelerator detection for unit tests.
+
+``sglang.srt.utils.get_device()`` raises when the host exposes no accelerator,
+which must not break test collection on CPU-only machines.
+"""
+
+from sglang.srt.utils import get_device
+
+
+def get_device_or_cpu() -> str:
+    try:
+        return get_device()
+    except RuntimeError:
+        return "cpu"
+
+
+def has_accelerator() -> bool:
+    return get_device_or_cpu().partition(":")[0] in ("cuda", "xpu")

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -256,6 +256,7 @@ def _stub_arkasr_engine_build(
     )
 
 
+@pytest.mark.gpu
 @pytest.mark.parametrize("want_cuda_graph", [True, False])
 def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
     monkeypatch: pytest.MonkeyPatch, want_cuda_graph: bool
@@ -297,6 +298,7 @@ def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
     assert stub.encoder_service_kwargs["max_queue_size"] == 32
 
 
+@pytest.mark.gpu
 def test_arkasr_pre_lm_encoder_reaches_request_builder_and_shutdown(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -317,6 +319,7 @@ def test_arkasr_pre_lm_encoder_reaches_request_builder_and_shutdown(
     assert stub.encoder_batch_sizes == [8]
 
 
+@pytest.mark.gpu
 def test_arkasr_pre_lm_encoder_can_be_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_test/conftest.py
+++ b/tests/unit_test/conftest.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared pytest configuration for the unit-test tree.
+
+Two jobs run this tree:
+- unit-test: CPU only. The job sets ``OMNI_UNIT_CPU_ONLY=1`` and hides
+  accelerators, and deselects ``gpu``-marked tests with ``-m "not gpu"``.
+- gpu-test: runs ``-m gpu`` with one forked process per test so every test
+  gets a fresh CUDA context.
+"""
+
+import os
+
+import pytest
+
+from tests.unit_test.accel import has_accelerator
+
+_CPU_ONLY_ENV = "OMNI_UNIT_CPU_ONLY"
+
+# Import-time guard so a workflow edit cannot silently hand the CPU-only
+# unit-test job an accelerator again (hook-based checks fire too late when
+# this conftest is loaded mid-collection).
+if os.environ.get(_CPU_ONLY_ENV) == "1" and has_accelerator():
+    raise RuntimeError(
+        f"{_CPU_ONLY_ENV}=1 but an accelerator is visible; run the unit-test "
+        'stage with accelerators hidden (e.g. CUDA_VISIBLE_DEVICES="").'
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if has_accelerator():
+        return
+    skip_gpu = pytest.mark.skip(reason="requires an accelerator (gpu marker)")
+    for item in items:
+        if "gpu" in item.keywords:
+            item.add_marker(skip_gpu)

--- a/tests/unit_test/fishaudio_s2_pro/test_tts.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_tts.py
@@ -413,6 +413,7 @@ def test_fish_s2pro_decode_codebooks_keeps_eos_out_of_audio_embedding(
     assert int(audio_decoder.seen_embedding_ids[0][0].item()) == 0
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="multinomial_with_seed needs CUDA"
 )

--- a/tests/unit_test/fun_asr/test_pipeline.py
+++ b/tests/unit_test/fun_asr/test_pipeline.py
@@ -103,6 +103,7 @@ def test_fun_asr_stage_default_enables_async_decode() -> None:
     assert signature.parameters["async_decode_min_batch_size"].default == 2
 
 
+@pytest.mark.gpu
 def test_fun_asr_threads_generation_batch_and_request_build_policy(monkeypatch) -> None:
     from sglang_omni.scheduling.generation_batch_policy import (
         build_default_prefill_cuda_graph_bs,

--- a/tests/unit_test/higgs_tts/test_async_decode_runner.py
+++ b/tests/unit_test/higgs_tts/test_async_decode_runner.py
@@ -292,6 +292,7 @@ def test_rollout_logprob_host_staging_grows_with_async_batch(
     assert smaller.shape == (2, 8)
 
 
+@pytest.mark.gpu
 def test_async_real_pinned_path_matches_sync():
     """CUDA-guarded: run the async path through the REAL _next_host_staging
     (pinned host buffer + non-blocking copy on a CUDA model) and confirm it

--- a/tests/unit_test/higgs_tts/test_batched_step.py
+++ b/tests/unit_test/higgs_tts/test_batched_step.py
@@ -75,6 +75,7 @@ def _assert_pools_equal(a: dict, b: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.gpu
 def test_batched_matches_per_row_delay_window():
     """First N steps must force codebooks > delay_count to BOC."""
     B = 3
@@ -103,6 +104,7 @@ def test_batched_matches_per_row_delay_window():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.gpu
 def test_batched_matches_per_row_eoc_winddown():
     """After delay, fire cb0=EOC and verify wind-down + done flag match."""
     B = 2
@@ -159,6 +161,7 @@ def test_batched_matches_per_row_eoc_winddown():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.gpu
 def test_batched_done_row_returns_stop_and_freezes_state():
     """A row already marked generation_done must return STOP and not mutate."""
     pool = HiggsBatchedSamplerState(2, N, device=DEVICE)
@@ -196,6 +199,7 @@ def test_batched_done_row_returns_stop_and_freezes_state():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.gpu
 def test_batched_matches_per_row_mixed_phases():
     """One row mid-delay, one mid-winddown, one fresh — batched == per-row."""
     pool_pr = HiggsBatchedSamplerState(3, N, device=DEVICE)
@@ -233,6 +237,7 @@ def test_batched_matches_per_row_mixed_phases():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.gpu
 def test_batched_step_mixed_top_k_per_row_filter():
     """Regression: eager path must accept heterogeneous top_k per row.
     Row 0 uses ``K_MAX`` (no-op filter, mirrors ``top_k=None``); row 1
@@ -315,6 +320,7 @@ def test_batched_greedy_temperature_zero_is_deterministic_argmax():
         assert torch.equal(o, expected), "temperature=0 must be deterministic argmax"
 
 
+@pytest.mark.gpu
 def test_batched_greedy_top_k_one_is_argmax():
     from sglang_omni.models.higgs_tts.sampler import _sample_independent_batched
 

--- a/tests/unit_test/higgs_tts/test_seeded_sampling.py
+++ b/tests/unit_test/higgs_tts/test_seeded_sampling.py
@@ -11,9 +11,12 @@ import torch
 
 from sglang_omni.models.higgs_tts.sampler import _sample_independent_batched
 
-pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="multinomial_with_seed needs CUDA"
-)
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="multinomial_with_seed needs CUDA"
+    ),
+]
 
 B, N, V = 3, 8, 64
 

--- a/tests/unit_test/ming_omni/test_talker_voice_validation.py
+++ b/tests/unit_test/ming_omni/test_talker_voice_validation.py
@@ -720,6 +720,7 @@ def _stub_for_generate(talker: MingOmniTalker, num_steps_before_stop: int):
     talker.sampler_pool = SimpleNamespace(execute=_execute)
 
 
+@pytest.mark.gpu
 def test_generate_emits_final_true_when_stop_token_fires(monkeypatch):
     """Stop-token exit terminates with last_chunk=True."""
     import torch as _torch
@@ -750,6 +751,7 @@ def test_generate_emits_final_true_when_stop_token_fires(monkeypatch):
     assert all(flag is False for flag in flags[:-1])
 
 
+@pytest.mark.gpu
 def test_generate_emits_final_true_when_duration_cap_hits(monkeypatch):
     """Loop exit via effective_max_decode_steps ceiling must still emit a
     last_chunk=True so the streaming VAE flushes its tail."""

--- a/tests/unit_test/minimax_music3/test_core.py
+++ b/tests/unit_test/minimax_music3/test_core.py
@@ -344,6 +344,7 @@ def test_rvq_cuda_graph_replays_per_bucket_and_clones_outputs() -> None:
     assert torch.equal(actual_codes, preserved_codes)
 
 
+@pytest.mark.gpu
 def test_rvq_cuda_graph_declines_a_batch_larger_than_every_bucket() -> None:
     def depth_forward(hidden, c0, seeds, positions, forced, replay):
         del c0, seeds, positions, replay

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -396,6 +396,7 @@ def _stub_factory_env(monkeypatch: pytest.MonkeyPatch, *, want_cuda_graph: bool)
     return calls
 
 
+@pytest.mark.gpu
 def test_factory_compiles_encoder_and_skips_cuda_graph_when_flag_on(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -420,6 +421,7 @@ def test_factory_compiles_encoder_and_skips_cuda_graph_when_flag_on(
     assert scheduler_kwargs["prefill_coalesce_after_builds_during_decode"] is True
 
 
+@pytest.mark.gpu
 def test_factory_context_length_override_uses_final_server_value(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_test/moss_tts/test_audio_tokenizer.py
+++ b/tests/unit_test/moss_tts/test_audio_tokenizer.py
@@ -411,6 +411,7 @@ def test_local_causal_flash_plan_skips_identity_kv_gather() -> None:
     assert plan.kv_indices is None
 
 
+@pytest.mark.gpu
 def test_local_causal_attention_keeps_packed_flash_cuda() -> None:
     if not torch.cuda.is_available():
         pytest.skip("requires CUDA")
@@ -640,6 +641,7 @@ def test_projected_transformer_single_padded_input_uses_masked_pack() -> None:
     assert torch.equal(out_lengths, lengths)
 
 
+@pytest.mark.gpu
 def test_sglang_packed_flash_matches_sdpa_reference_cuda() -> None:
     if not torch.cuda.is_available():
         pytest.skip("requires CUDA")
@@ -674,6 +676,7 @@ def test_sglang_packed_flash_matches_sdpa_reference_cuda() -> None:
     torch.testing.assert_close(flash_out, sdpa_out, atol=4e-2, rtol=3e-2)
 
 
+@pytest.mark.gpu
 def test_sglang_chunked_local_flash_matches_sdpa_reference_cuda() -> None:
     if not torch.cuda.is_available():
         pytest.skip("requires CUDA")
@@ -761,6 +764,7 @@ def test_cached_packed_rope_matches_moss_interleaved_reference() -> None:
     assert cache._cos.data_ptr() == cos_ptr
 
 
+@pytest.mark.gpu
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 def test_exact_packed_rope_matches_reference_cuda(dtype: torch.dtype) -> None:
     if not torch.cuda.is_available():

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -2179,6 +2179,7 @@ def test_moss_compact_candidate_sampler_maps_greedy_indices() -> None:
     assert sampled.tolist() == [13, 12]
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="requires CUDA seeded sampler"
 )

--- a/tests/unit_test/moss_tts/test_sampling_cuda_graph.py
+++ b/tests/unit_test/moss_tts/test_sampling_cuda_graph.py
@@ -297,6 +297,7 @@ def _request_data(
     )
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_fixed_shape_sampling_matches_current_compacted_eager() -> None:
     device = torch.device("cuda")
@@ -372,6 +373,7 @@ def test_fixed_shape_sampling_matches_current_compacted_eager() -> None:
     assert torch.equal(eager_state, fixed.next_delay_state)
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_sampling_cuda_graph_replay_matches_fixed_shape_eager() -> None:
     device = torch.device("cuda")

--- a/tests/unit_test/moss_tts/test_sampling_kernels.py
+++ b/tests/unit_test/moss_tts/test_sampling_kernels.py
@@ -10,6 +10,8 @@ from sglang.srt.layers.sampler import multinomial_with_seed
 
 from sglang_omni.models.moss_tts.sampling_kernels import seeded_gumbel_argmax
 
+pytestmark = pytest.mark.gpu
+
 _UINT32_MAX_HASH_POSITION = 1_707_985_137
 
 

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -1194,6 +1194,7 @@ def test_build_generation_kwargs_precedence():
     assert kwargs["audio_temperature"] == 1.2
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
 def test_decode_frame_graphed_matches_branchless_eager():
     """The captured frame graph must reproduce the branchless eager decode."""
@@ -1727,6 +1728,7 @@ def test_cached_reference_encoder_data_uri_duration_gate():
     assert len(enc._service._inflight) == 0
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="needs CUDA: post1 multinomial_with_seed is a Triton kernel (no CPU backend)",

--- a/tests/unit_test/moss_tts_local/test_s0_gate.py
+++ b/tests/unit_test/moss_tts_local/test_s0_gate.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import pytest
 import torch
 
+pytestmark = pytest.mark.gpu
+
 _N_VQ = 12
 
 

--- a/tests/unit_test/moss_tts_local/test_vocoder_cuda_graph.py
+++ b/tests/unit_test/moss_tts_local/test_vocoder_cuda_graph.py
@@ -89,6 +89,7 @@ def _decode_chunks(session, slot_seqs, chunk_t):
     return {s: torch.cat(parts[s], dim=-1) for s in slots}
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
 def test_some_graphs_captured(session_bundle):
     _, _, _, captured = session_bundle
@@ -128,6 +129,7 @@ def test_cuda_graph_capture_uses_thread_local_error_mode():
     ), "MOSS vocoder CUDA graph capture must use thread-local error mode"
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
 @pytest.mark.parametrize("chunk_t", CHUNK_TS)
 @pytest.mark.parametrize("n_active", [1, 8])
@@ -155,6 +157,7 @@ def test_streaming_pcm_bit_identical(session_bundle, chunk_t, n_active):
         )
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
 @pytest.mark.parametrize("chunk_t", [5, 25])
 def test_graph_tracks_eager_across_chunkings(session_bundle, chunk_t):
@@ -179,6 +182,7 @@ def test_graph_tracks_eager_across_chunkings(session_bundle, chunk_t):
     )
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
 def test_replay_failure_disables_runner_and_serves_eager_bit_identical(session_bundle):
     """A replay exception disables the runner (future steps go eager, bit-identical to a pure-eager
@@ -221,6 +225,7 @@ def test_replay_failure_disables_runner_and_serves_eager_bit_identical(session_b
         session._cg_runner = runner
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
 def test_vram_guard_skips_capture_and_falls_back_to_eager(session_bundle):
     """Below the configured VRAM headroom, warmup skips capture (empty graph set, serving uses eager);
@@ -242,6 +247,7 @@ def test_vram_guard_skips_capture_and_falls_back_to_eager(session_bundle):
     ), "VRAM guard must skip all captures under insufficient headroom"
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
 def test_capture_failure_falls_back_to_eager(session_bundle):
     """A capture exception is caught per-T, that T dropped, serving uses eager; forced via _capture_frame_count raising. (A real mid-capture OOM does not wedge the CUDA context, verified empirically.)"""

--- a/tests/unit_test/pipeline/test_async_decode.py
+++ b/tests/unit_test/pipeline/test_async_decode.py
@@ -387,6 +387,7 @@ def test_finalize_unions_finalize_skip_rids_hook():
     assert chunk_data.generation_steps == 0
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="pinned memory requires CUDA")
 def test_host_staging_pingpong():
     r = _StubRunner()
@@ -398,6 +399,7 @@ def test_host_staging_pingpong():
     assert b0.is_pinned() and tuple(b0.shape) == (8, 18) and b0.dtype == torch.float32
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="pinned memory requires CUDA")
 def test_default_launch_resolve_pinned_snapshot_pingpong():
     """Base (plain-LM) launch/resolve: launch snapshots the sampled ids into a
@@ -432,6 +434,7 @@ def test_default_launch_resolve_pinned_snapshot_pingpong():
     assert buf3 is buf1
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="pinned memory requires CUDA")
 def test_default_launch_staging_grows_then_slices_to_smaller_batch():
     r = ModelRunner.__new__(ModelRunner)

--- a/tests/unit_test/pipeline/test_comm_router.py
+++ b/tests/unit_test/pipeline/test_comm_router.py
@@ -57,6 +57,7 @@ def test_comm_router_uses_mooncake_only_for_remote_edges() -> None:
     )
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_comm_router_uses_cuda_ipc_for_mixed_gpu_payloads() -> None:
     router = CommRouter(
@@ -74,6 +75,7 @@ def test_comm_router_uses_cuda_ipc_for_mixed_gpu_payloads() -> None:
     assert router.outbound_payload("thinker", payload) is TransportKind.CUDA_IPC
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_comm_router_uses_shm_for_cuda_payloads_to_cpu_targets() -> None:
     router = CommRouter(
@@ -218,6 +220,7 @@ def test_comm_router_rejects_narrowed_direct_cuda_ipc_namespace() -> None:
     assert not router.can_use_direct_cuda_ipc("talker")
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_comm_router_uses_cuda_ipc_for_cuda_stream_chunks_only() -> None:
     router = CommRouter(

--- a/tests/unit_test/pipeline/test_gpu_memory.py
+++ b/tests/unit_test/pipeline/test_gpu_memory.py
@@ -7,12 +7,12 @@ import sys
 from types import ModuleType, SimpleNamespace
 
 import pytest
-from sglang.srt.utils import get_device
 
 import sglang_omni.utils.gpu_memory as gpu_memory
+from tests.unit_test.accel import has_accelerator
 
 _ACCELERATOR_ONLY = pytest.mark.skipif(
-    get_device().partition(":")[0] not in ("cuda", "xpu"),
+    not has_accelerator(),
     reason="requires cuda or xpu",
 )
 

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -121,6 +121,7 @@ def test_aggregated_input_rejects_dynamic_sources_outside_static_fanin() -> None
         handler.receive("req-1", "preprocess", make_stage_payload())
 
 
+@pytest.mark.gpu
 def test_stage_routes_results_streams_and_clears_abort_state() -> None:
     """Preserves result routing, stream forwarding, and abort cleanup."""
 
@@ -421,6 +422,7 @@ def test_relay_payload_and_cross_gpu_stream_contracts() -> None:
     asyncio.run(_run())
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_cuda_payload_round_trip_preserves_cpu_tensor_devices() -> None:
     async def _run() -> None:
@@ -1019,6 +1021,7 @@ def test_stage_sends_same_process_stream_chunk_as_local_object(monkeypatch) -> N
     ]
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_stage_sends_same_gpu_stream_chunk_as_direct_cuda_ipc(monkeypatch) -> None:
     monkeypatch.setattr(
@@ -1226,6 +1229,7 @@ def test_stage_receives_same_gpu_direct_cuda_ipc_payload(monkeypatch) -> None:
     asyncio.run(_run())
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_direct_cuda_ipc_payload_preserves_inline_cpu_tensors() -> None:
     payload = make_stage_payload(

--- a/tests/unit_test/pipeline/test_stage_process_env.py
+++ b/tests/unit_test/pipeline/test_stage_process_env.py
@@ -143,6 +143,7 @@ def test_xpu_tp_process_env_requires_gpu_id() -> None:
         )
 
 
+@pytest.mark.gpu
 def test_xpu_tp_rank_keeps_its_card_despite_an_inherited_cuda_marker(
     monkeypatch,
 ) -> None:

--- a/tests/unit_test/pipeline/test_stage_streaming.py
+++ b/tests/unit_test/pipeline/test_stage_streaming.py
@@ -321,6 +321,7 @@ def test_outbox_drain_yields_after_ready_message_batch(monkeypatch) -> None:
     asyncio.run(_run())
 
 
+@pytest.mark.gpu
 def test_explicit_scheduler_stream_target_keeps_stage_to_stage_routing() -> None:
     async def _run() -> None:
         control_plane = _FakeControlPlane()

--- a/tests/unit_test/qwen3_asr/test_encoder_cuda_graph.py
+++ b/tests/unit_test/qwen3_asr/test_encoder_cuda_graph.py
@@ -64,6 +64,7 @@ def test_get_audio_feature_routing(monkeypatch):
     assert torch.equal(get(model, [item]), torch.full((1, 65, 8), 7.0))
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_graph_matches_eager_tower():
     from sglang.srt.configs.qwen3_omni import Qwen3OmniMoeAudioEncoderConfig

--- a/tests/unit_test/qwen3_asr/test_encoder_service.py
+++ b/tests/unit_test/qwen3_asr/test_encoder_service.py
@@ -9,18 +9,18 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-from sglang.srt.utils import get_device
 
 from sglang_omni.models.qwen3_asr.encoder_service import (
     Qwen3ASRPreLMEncoderService,
     _expected_audio_tokens,
     build_cache_namespace,
 )
+from tests.unit_test.accel import get_device_or_cpu, has_accelerator
 
 _HIDDEN_SIZE = 4
-_DEVICE = get_device()
+_DEVICE = get_device_or_cpu()
 requires_accelerator = pytest.mark.skipif(
-    _DEVICE.partition(":")[0] not in ("cuda", "xpu"),
+    not has_accelerator(),
     reason="requires cuda or xpu",
 )
 _NAMESPACE = "testns"

--- a/tests/unit_test/qwen3_asr/test_sglang_model.py
+++ b/tests/unit_test/qwen3_asr/test_sglang_model.py
@@ -172,6 +172,7 @@ def test_get_audio_feature_rejects_mismatched_mask_shape() -> None:
         Qwen3ASRForConditionalGeneration.get_audio_feature(model, items)
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
 def test_get_audio_feature_normalizes_cpu_masks_for_cuda_features() -> None:
     tower = _RecordingAudioTower().cuda()

--- a/tests/unit_test/qwen3_omni/test_audio_feature_packing.py
+++ b/tests/unit_test/qwen3_omni/test_audio_feature_packing.py
@@ -64,6 +64,7 @@ def test_dtype_and_contiguity_preserved() -> None:
     assert out.is_contiguous()
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
 def test_accelerator_pack_matches_cpu_reference() -> None:
     lengths = [1000, 3000, 512]
@@ -74,6 +75,7 @@ def test_accelerator_pack_matches_cpu_reference() -> None:
     torch.testing.assert_close(out.cpu(), _reference(feats, mask))
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
 def test_accelerator_fallback_gather_matches_cpu_reference() -> None:
     feats = torch.randn(2, MEL, 16)

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -192,6 +192,7 @@ def test_qwen_code2wav_enabled_factory_rejects_missing_typed_budget_before_load(
     assert load_calls == 0
 
 
+@pytest.mark.gpu
 def test_qwen_code2wav_factory_allows_batching_with_cuda_graph(
     monkeypatch,
 ) -> None:
@@ -222,6 +223,7 @@ def test_qwen_code2wav_factory_allows_batching_with_cuda_graph(
     assert scheduler._chunk_aligned_dispatch is True
 
 
+@pytest.mark.gpu
 def test_qwen_code2wav_factory_combines_batching_with_cuda_graph(
     monkeypatch,
 ) -> None:
@@ -268,6 +270,7 @@ def test_qwen_code2wav_factory_combines_batching_with_cuda_graph(
     )
 
 
+@pytest.mark.gpu
 def test_qwen_code2wav_factory_disables_batching_when_runner_disabled(
     monkeypatch,
 ) -> None:

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -503,6 +503,7 @@ def _build_fake_predictor_graph_talker(device: torch.device) -> Qwen3OmniTalker:
     return talker
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="Qwen3-Omni predictor graph requires CUDA"
 )
@@ -570,6 +571,7 @@ def test_qwen_predictor_decode_graph_uses_configured_batch_buckets(
     assert (3, torch.int) not in talker._predictor_decode_graphs
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="Qwen3-Omni predictor graph requires CUDA"
 )
@@ -612,6 +614,7 @@ def test_qwen_predictor_decode_graph_matches_eager(monkeypatch: pytest.MonkeyPat
     torch.testing.assert_close(graph_embeds, eager_embeds)
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="Qwen3-Omni predictor graph requires CUDA"
 )
@@ -649,6 +652,7 @@ def test_qwen_predictor_decode_graph_covers_real_incremental_step(
     torch.testing.assert_close(graph_embeds, eager_embeds)
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.device_count() < 2,
     reason="requires two visible CUDA devices",
@@ -2190,6 +2194,7 @@ def test_talker_prepare_decode_buffers_steady_state_reuse() -> None:
     assert torch.equal(fake._suppress_mask, fresh._suppress_mask)
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="sampling staging regression requires CUDA"
 )

--- a/tests/unit_test/qwen3_omni/test_talker_attention.py
+++ b/tests/unit_test/qwen3_omni/test_talker_attention.py
@@ -17,6 +17,8 @@ from tests.unit_test.fixtures.qwen_predictor import (
     build_real_step_predictor_graph_talker,
 )
 
+pytestmark = pytest.mark.gpu
+
 # note (EdwardZhang1108): cpu/fp32 covers the math backend; cuda/bf16 locks the
 # production-dtype evidence into CI instead of living only in the PR description.
 _DEVICE_DTYPE_PARAMS = [

--- a/tests/unit_test/qwen3_omni/test_talker_token_readback.py
+++ b/tests/unit_test/qwen3_omni/test_talker_token_readback.py
@@ -160,6 +160,7 @@ def test_pingpong_alternates_slots_and_reuses_backing_buffer(monkeypatch):
     assert third is first
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_stage_token_ids_cuda_matches_reference():
     runner = _bare_runner()

--- a/tests/unit_test/qwen3_omni/test_thinker_fused_rope.py
+++ b/tests/unit_test/qwen3_omni/test_thinker_fused_rope.py
@@ -11,15 +11,15 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-from sglang.srt.utils import get_device
 
 from sglang_omni.models.qwen3_omni.components.thinker_fused_rope import (
     ThinkerFusedRopeGate,
     install_thinker_fused_rope,
 )
 from sglang_omni.platforms import current_platform
+from tests.unit_test.accel import get_device_or_cpu
 
-_DEVICE = get_device()
+_DEVICE = get_device_or_cpu()
 requires_xpu = pytest.mark.skipif(
     _DEVICE.partition(":")[0] != "xpu", reason="describes the xpu policy"
 )
@@ -280,6 +280,7 @@ def test_install_is_refused_while_a_prefill_graph_could_freeze_it(
     )
 
 
+@pytest.mark.gpu
 @requires_xpu
 def test_install_succeeds_on_xpu() -> None:
     attn = _fake_attn()

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -966,6 +966,7 @@ def test_qwen3_tts_reference_code_batcher_has_no_stream_for_cpu_device() -> None
         batcher.close()
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_qwen3_tts_reference_code_batcher_encodes_on_dedicated_cuda_stream() -> None:
     device = torch.device("cuda", torch.cuda.current_device())

--- a/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
+++ b/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
@@ -230,6 +230,7 @@ def _run_forward(talker, layer0, hidden, positions):
     return codes.detach().clone(), embeds.detach().clone()
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize(
@@ -261,6 +262,7 @@ def test_graph_bit_identity_sampled(batch_size: int, sampling_kwargs: dict):
     )
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 def test_graph_bit_identity_argmax(batch_size: int):
@@ -277,6 +279,7 @@ def test_graph_bit_identity_argmax(batch_size: int):
     assert torch.equal(graph_embeds, eager_embeds)
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_graph_bit_identity_argmax_none_positions():
     device = torch.device("cuda")
@@ -292,6 +295,7 @@ def test_graph_bit_identity_argmax_none_positions():
     assert torch.equal(graph_embeds, eager_embeds)
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_graph_padded_bucket_bit_identity():
     """Live bs=3 replays through the bucket-4 graph with padded rows."""
@@ -310,6 +314,7 @@ def test_graph_padded_bucket_bit_identity():
     assert torch.equal(graph_embeds, eager_embeds)
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_graph_multi_step_replay_bit_identity():
     """Consecutive steps reuse one captured graph and stay bit-identical."""
@@ -327,6 +332,7 @@ def test_graph_multi_step_replay_bit_identity():
     assert len(talker._predictor_graphs) == 1
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_mixed_sampled_argmax_rows_fall_back_to_eager():
     device = torch.device("cuda")
@@ -343,6 +349,7 @@ def test_mixed_sampled_argmax_rows_fall_back_to_eager():
     assert torch.equal(graph_embeds, eager_embeds)
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_kill_switch_disables_graph_path():
     device = torch.device("cuda")
@@ -373,6 +380,7 @@ def test_env_switch_parsing(monkeypatch: pytest.MonkeyPatch):
     assert sglang_model_module._predictor_graph_env_enabled() is True
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_capture_failure_disables_key_and_falls_back(
     monkeypatch: pytest.MonkeyPatch,
@@ -403,6 +411,7 @@ def test_capture_failure_disables_key_and_falls_back(
     assert len(calls) == 1, "disabled key must not retry capture"
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_capture_failure_restores_live_sub_state(monkeypatch: pytest.MonkeyPatch):
     device = torch.device("cuda")
@@ -457,6 +466,7 @@ class _NoHostReadbackTensor(torch.Tensor):
         return super().to(*args, **kwargs)
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_no_host_readback_on_graph_dispatch_and_replay():
     """Live per-step inputs must reach the graph via device-side copies only."""
@@ -479,6 +489,7 @@ def test_no_host_readback_on_graph_dispatch_and_replay():
         torch.cuda.synchronize()
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_no_host_readback_in_eager_chain():
     """The captured body itself must be free of host materialization."""
@@ -551,6 +562,7 @@ def test_quantize_predictor_top_k_ladder():
     assert quantize(9, 16) is None
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_graph_key_shared_across_request_top_k_values():
     """top_k=5 and top_k=7 land in the same ladder bucket and share one graph."""
@@ -571,6 +583,7 @@ def test_graph_key_shared_across_request_top_k_values():
     )
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_row_top_k_below_bucket_width_bit_identity():
     """Rows with k below the captured bucket width stay bit-identical to eager."""
@@ -593,6 +606,7 @@ def test_row_top_k_below_bucket_width_bit_identity():
     assert torch.equal(graph_embeds, eager_embeds)
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_replay_tracks_per_step_sampling_params():
     """One graph key, three replays with fresh temps/top_p/top_k/seeds per step;
@@ -622,6 +636,7 @@ def test_replay_tracks_per_step_sampling_params():
     assert len(talker._predictor_graphs) == 1
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_global_disable_after_max_capture_failures(monkeypatch: pytest.MonkeyPatch):
     device = torch.device("cuda")
@@ -655,6 +670,7 @@ def test_global_disable_after_max_capture_failures(monkeypatch: pytest.MonkeyPat
     assert len(calls) == 8, "globally disabled graphs must not attempt new captures"
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_capture_failure_resets_cuda_graph(monkeypatch: pytest.MonkeyPatch):
     """A failed capture must release its CUDA graph (pool) via reset()."""
@@ -683,6 +699,7 @@ def test_capture_failure_resets_cuda_graph(monkeypatch: pytest.MonkeyPatch):
     assert reset_calls, "failed capture must reset() its CUDAGraph"
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="seeded sampling kernel needs CUDA")
 def test_widened_top_k_masked_ranks_never_sampled():
     """Ranks past a row's true k remain impossible after log conversion."""
@@ -708,6 +725,7 @@ def test_widened_top_k_masked_ranks_never_sampled():
         )
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_graph_keys_share_memory_pool(monkeypatch: pytest.MonkeyPatch):
     """Distinct graph keys must capture into one model-owned memory pool."""
@@ -736,6 +754,7 @@ def test_graph_keys_share_memory_pool(monkeypatch: pytest.MonkeyPatch):
     assert pools[0] == talker._predictor_graph_pool
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="seeded sampling kernel needs CUDA")
 def test_top_p_removed_ranks_never_sampled():
     """Nucleus-removed ranks must be impossible, same rationale as the top-k mask."""
@@ -807,6 +826,7 @@ def test_resolve_predictor_graph_enabled(monkeypatch: pytest.MonkeyPatch):
     assert talker._resolve_predictor_graph_enabled() is False
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_server_disable_cuda_graph_gates_predictor(monkeypatch: pytest.MonkeyPatch):
     """server_args.disable_cuda_graph must gate the lazily resolved graph path."""

--- a/tests/unit_test/qwen3_tts/test_sampling_kernels.py
+++ b/tests/unit_test/qwen3_tts/test_sampling_kernels.py
@@ -11,9 +11,12 @@ from sglang_omni.models.qwen3_tts.sampling_kernels import (
     sample_from_sorted_logprobs_with_seed_small_k,
 )
 
-pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="Qwen3-TTS sampling kernel needs CUDA"
-)
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="Qwen3-TTS sampling kernel needs CUDA"
+    ),
+]
 
 
 @pytest.mark.parametrize("batch_size,num_cols", [(1, 1), (3, 2), (7, 30), (16, 64)])

--- a/tests/unit_test/relay/test_cuda_ipc_relay.py
+++ b/tests/unit_test/relay/test_cuda_ipc_relay.py
@@ -668,16 +668,19 @@ def _run_paged_case(gpu: int) -> None:
         assert value is True
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_cuda_ipc_same_gpu_round_trip() -> None:
     _run_case(0, 0)
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_cuda_ipc_paged_multi_buffer_round_trip_with_storage_offsets() -> None:
     _run_paged_case(0)
 
 
+@pytest.mark.gpu
 @pytest.mark.skipif(
     torch.cuda.device_count() < 2, reason="requires >= 2 GPUs for cross-GPU transfer"
 )

--- a/tests/unit_test/scheduling/test_stage_cache.py
+++ b/tests/unit_test/scheduling/test_stage_cache.py
@@ -168,6 +168,7 @@ def test_pin_memory_is_inert_without_cuda(monkeypatch: pytest.MonkeyPatch) -> No
     assert cached is not None and cached.device.type == "cpu"
 
 
+@pytest.mark.gpu
 @_requires_cuda
 def test_pinned_cache_stores_device_tensors_in_page_locked_memory() -> None:
     cache = StageOutputCache(cache_device="cpu", pin_memory=True)
@@ -184,6 +185,7 @@ def test_pinned_cache_stores_device_tensors_in_page_locked_memory() -> None:
     assert all(t.is_pinned() for t in nested["a"])
 
 
+@pytest.mark.gpu
 @_requires_cuda
 def test_pinned_cache_reuses_already_pinned_host_tensor() -> None:
     cache = StageOutputCache(cache_device="cpu", pin_memory=True)
@@ -195,6 +197,7 @@ def test_pinned_cache_reuses_already_pinned_host_tensor() -> None:
     assert cached_host.data_ptr() == host.data_ptr() and cached_host.is_pinned()
 
 
+@pytest.mark.gpu
 @_requires_cuda
 def test_pinned_cache_falls_back_to_pageable_on_alloc_failure(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit_test/utils/test_ipc_weights_cuda.py
+++ b/tests/unit_test/utils/test_ipc_weights_cuda.py
@@ -25,9 +25,12 @@ from sglang_omni.pipeline.stage_workers import (
 )
 from sglang_omni.utils import ipc_weights
 
-pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="weight-share CUDA test requires CUDA"
-)
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="weight-share CUDA test requires CUDA"
+    ),
+]
 
 
 class _Tiny(nn.Module):

--- a/tests/unit_test/whisper_asr/test_encoder_service.py
+++ b/tests/unit_test/whisper_asr/test_encoder_service.py
@@ -145,6 +145,7 @@ def test_pinning_is_off_without_cuda_device() -> None:
     assert service.stats()["pin_prewarm_s"] == 0.0
 
 
+@pytest.mark.gpu
 @_requires_cuda
 def test_cuda_cache_entries_are_pinned_and_match_device_result() -> None:
     model = _cuda_model()
@@ -164,6 +165,7 @@ def test_cuda_cache_entries_are_pinned_and_match_device_result() -> None:
     assert service.stage_host_copy(anonymous, item.precomputed_embeddings) is None
 
 
+@pytest.mark.gpu
 @_requires_cuda
 def test_cuda_hit_attaches_device_tensor_from_pinned_entry() -> None:
     model = _cuda_model()
@@ -178,6 +180,7 @@ def test_cuda_hit_attaches_device_tensor_from_pinned_entry() -> None:
     assert torch.equal(first.precomputed_embeddings, second.precomputed_embeddings)
 
 
+@pytest.mark.gpu
 @_requires_cuda
 def test_pin_host_memory_flag_disables_pinning() -> None:
     service = _make_service(_cuda_model(), pin_host_memory=False)
@@ -189,6 +192,7 @@ def test_pin_host_memory_flag_disables_pinning() -> None:
     assert service.stats()["pin_prewarm_s"] == 0.0
 
 
+@pytest.mark.gpu
 @_requires_cuda
 def test_pinned_allocation_failure_falls_back_to_pageable(
     monkeypatch: pytest.MonkeyPatch,
@@ -213,6 +217,7 @@ def test_pinned_allocation_failure_falls_back_to_pageable(
     assert torch.equal(cached.to("cuda"), item.precomputed_embeddings)
 
 
+@pytest.mark.gpu
 @_requires_cuda
 def test_prewarm_covers_cache_capacity(monkeypatch: pytest.MonkeyPatch) -> None:
     allocations: list[int] = []


### PR DESCRIPTION
## Problem

The unit-test job runs ~5,200 tests in **one process sharing one CUDA context**. Allocator segments, cached CUDA graphs, leaked NCCL groups, and pending GC from thousands of earlier tests are still live when GPU tests run late in the suite, so state-sensitive tests fail nondeterministically. Two recent examples blocked unrelated PRs for days:

- `qwen3_asr` cache-reclamation assert (fixed by #1657, but only after every PR was red for ~a day at 45% of the suite)
- `qwen3_tts` `test_predictor_cuda_graph` — transient `CUBLAS_STATUS_EXECUTION_FAILED` inside graph capture → `cudaErrorStreamCaptureInvalidated` (run 32539612569 failed attempts 1–2 at *different* parametrizations, passed attempt 3)

## Change

**unit-test becomes CPU-only.** The job hides accelerators (`CUDA_VISIBLE_DEVICES=""`) and deselects `-m "not gpu"`. Enforcement is self-sustaining: any future test that touches the GPU without a `gpu` marker fails loudly and deterministically in unit CI, and a conftest guard (`OMNI_UNIT_CPU_ONLY=1`) refuses to run if a device is still visible, so a workflow edit can't silently regress this.

**New `gpu-unit-test` stage** (one container, same image/runner) runs `-m "gpu and not benchmark" --forked`: pytest-forked gives each test its own process and therefore its own fresh CUDA context — cross-test GPU-state interference becomes structurally impossible. The isolation unit for CUDA is the process, not the container, so this costs a fork (~seconds total across 176 tests), not 176 container launches.

## How the gpu set was determined (measured, not guessed)

Ran the full suite on a CPU-only host and recorded, via a pytest plugin, every test that **failed** (21) or **skipped for an accelerator reason** (~150) — those exact node IDs got the marker. Also fixed 3 files that called `sglang.srt.utils.get_device()` at import time, which raises on accelerator-less hosts and previously broke collection for the entire files (`pipeline/test_gpu_memory.py`, `qwen3_asr/test_encoder_service.py`, `qwen3_omni/test_thinker_fused_rope.py`) — their CPU tests now run everywhere.

## Verification

- Partition is exact: unit selects **5,011**, gpu selects **176**, total **5,187** = previous selection; no test is lost or double-counted.
- Full unit suite with the production env (`CUDA_VISIBLE_DEVICES="" OMNI_UNIT_CPU_ONLY=1 -m "not benchmark and not gpu"`): **5,007 passed, 0 failed**, and the only remaining accelerator-reason skip is in `tests/test_model/` (outside this tree, self-guarded, left as is).
- `pytest-forked` verified compatible with pytest 9.x.
- pre-commit hooks pass on all changed files.
