### PR TITLE
[Perf] [Fun-CosyVoice3] AR incremental streaming output

### DIFF
--- a/sglang_omni/models/fun_cosyvoice3/request_builders.py
+++ b/sglang_omni/models/fun_cosyvoice3/request_builders.py
@@ -24,6 +24,7 @@ from sglang_omni.preprocessing.cache_key import (
 )
 from sglang_omni.proto import StagePayload
 from sglang_omni.sampling.seed import SAMPLING_SEED_MASK
+from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.reference_encoder import (
     KeyedReferenceEncodeHook,
     ReferenceEncodeService,
@@ -166,6 +167,9 @@ class CosyVoice3SGLangRequestData(SGLangARRequestData):
     output_codes: list[torch.Tensor] = None
     prompt_input_embeds: torch.Tensor | None = None
     engine_start_s: float = 0.0
+    # note (PoTaTo): number of speech tokens already shipped downstream as
+    # stream chunks; the stream output builder emits only the tail beyond it.
+    stream_output_code_count: int = 0
 
     def __post_init__(self):
         if self.output_codes is None:
@@ -840,3 +844,69 @@ def make_cosyvoice3_scheduler_adapters(*, model: Any):
         return apply_sglang_cosyvoice3_result(data.stage_payload, data)
 
     return request_builder, result_adapter
+
+
+def _cosyvoice3_stream_enabled(payload: StagePayload | None) -> bool:
+    """Streaming gate: the prepared state dict is authoritative (it folds the
+    ``tts_params``/``params`` stream flags parsed by ``build_cosyvoice3_state``);
+    the request params are only a fallback for unprepared payloads."""
+    data = getattr(payload, "data", None)
+    if isinstance(data, dict) and "stream" in data:
+        return bool(data["stream"])
+    params = getattr(getattr(payload, "request", None), "params", None)
+    return isinstance(params, dict) and bool(params.get("stream", False))
+
+
+def make_cosyvoice3_stream_output_builder():
+    """Emit generated speech tokens incrementally for streaming requests.
+
+    The builder ships the not-yet-emitted tail of ``output_codes`` after every
+    AR step. Speech codes only ever grow by sampled tokens (control ids are
+    dropped at collection time), so a cursor is sufficient for exactly-once
+    delivery. The terminal result payload still carries the full
+    ``audio_codes`` tensor; downstream consumers decide whether to use the
+    chunks (streaming vocoder) or the final payload (full decode).
+    """
+
+    def stream_output_builder(
+        request_id: str,
+        data: CosyVoice3SGLangRequestData,
+        req_output: Any,
+    ) -> list[OutgoingMessage]:
+        del req_output
+        if not _cosyvoice3_stream_enabled(data.stage_payload):
+            return []
+        req = data.req
+        if req is not None and int(getattr(req, "inflight_middle_chunks", 0) or 0) > 0:
+            return []
+
+        output_codes = data.output_codes
+        start = min(int(data.stream_output_code_count), len(output_codes))
+        if start >= len(output_codes):
+            return []
+
+        chunk = (
+            torch.cat([part.reshape(-1) for part in output_codes[start:]], dim=0)
+            .detach()
+            .cpu()
+            .to(dtype=torch.long)
+        )
+        row_index = int(data.stream_output_code_count)
+        data.stream_output_code_count = len(output_codes)
+        metadata = {
+            "modality": "audio_codes",
+            "stream": True,
+            "sample_rate": _SAMPLE_RATE,
+            "row_index": row_index,
+        }
+        return [
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                target="vocoder",
+                data=chunk,
+                metadata=metadata,
+            )
+        ]
+
+    return stream_output_builder

--- a/tests/unit_test/fun_cosyvoice3/test_stream_output.py
+++ b/tests/unit_test/fun_cosyvoice3/test_stream_output.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fun-CosyVoice3 AR streaming output builder contracts."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+
+from sglang_omni.models.fun_cosyvoice3.request_builders import (
+    CosyVoice3SGLangRequestData,
+    make_cosyvoice3_stream_output_builder,
+)
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+def _payload(
+    *,
+    data: dict[str, Any] | None = None,
+    params: dict[str, Any] | None = None,
+) -> StagePayload:
+    return StagePayload(
+        request_id="req-cosy",
+        request=OmniRequest(inputs="你好", params=params or {}),
+        data=data if data is not None else {},
+    )
+
+
+_DEFAULT_REQ = object()
+
+
+def _data(
+    payload: StagePayload,
+    *,
+    codes: list[int],
+    req: Any = _DEFAULT_REQ,
+) -> CosyVoice3SGLangRequestData:
+    if req is _DEFAULT_REQ:
+        req = SimpleNamespace(inflight_middle_chunks=0)
+    return CosyVoice3SGLangRequestData(
+        req=req,
+        stage_payload=payload,
+        output_codes=[torch.tensor([code], dtype=torch.long) for code in codes],
+    )
+
+
+def test_stream_builder_emits_only_new_codes_in_order() -> None:
+    builder = make_cosyvoice3_stream_output_builder()
+    payload = _payload(data={"stream": True})
+    data = _data(payload, codes=[7])
+
+    messages = builder("req-cosy", data, None)
+
+    assert len(messages) == 1
+    message = messages[0]
+    assert message.request_id == "req-cosy"
+    assert message.type == "stream"
+    assert message.target == "vocoder"
+    assert message.data.tolist() == [7]
+    assert message.data.ndim == 1
+    assert message.data.dtype == torch.long
+    assert message.data.device.type == "cpu"
+    assert message.metadata == {
+        "modality": "audio_codes",
+        "stream": True,
+        "sample_rate": 24000,
+        "row_index": 0,
+    }
+
+    # No new sampled codes: exactly-once cursor must not re-emit.
+    assert builder("req-cosy", data, None) == []
+
+    data.output_codes.append(torch.tensor([8], dtype=torch.long))
+    data.output_codes.append(torch.tensor([9], dtype=torch.long))
+    messages = builder("req-cosy", data, None)
+    assert len(messages) == 1
+    assert messages[0].data.tolist() == [8, 9]
+    assert messages[0].metadata["row_index"] == 1
+
+
+def test_stream_builder_skips_non_streaming_requests() -> None:
+    builder = make_cosyvoice3_stream_output_builder()
+    payload = _payload(data={"stream": False}, params={"stream": False})
+    data = _data(payload, codes=[7])
+
+    assert builder("req-cosy", data, None) == []
+    assert data.stream_output_code_count == 0
+
+
+def test_stream_builder_state_dict_is_authoritative_stream_gate() -> None:
+    # The prepared state folds tts_params.stream; params alone may stay empty.
+    builder = make_cosyvoice3_stream_output_builder()
+    payload = _payload(data={"stream": True}, params={})
+    data = _data(payload, codes=[7])
+
+    messages = builder("req-cosy", data, None)
+    assert len(messages) == 1
+    assert messages[0].data.tolist() == [7]
+
+
+def test_stream_builder_state_dict_stream_false_overrides_params() -> None:
+    builder = make_cosyvoice3_stream_output_builder()
+    payload = _payload(data={"stream": False}, params={"stream": True})
+    data = _data(payload, codes=[7])
+
+    assert builder("req-cosy", data, None) == []
+    assert data.stream_output_code_count == 0
+
+
+def test_stream_builder_falls_back_to_request_params_for_unprepared_payloads() -> None:
+    builder = make_cosyvoice3_stream_output_builder()
+    payload = _payload(data={}, params={"stream": True})
+    data = _data(payload, codes=[7])
+
+    messages = builder("req-cosy", data, None)
+    assert len(messages) == 1
+    assert messages[0].data.tolist() == [7]
+
+
+def test_stream_builder_suppresses_emission_during_chunked_prefill() -> None:
+    builder = make_cosyvoice3_stream_output_builder()
+    payload = _payload(data={"stream": True})
+    req = SimpleNamespace(inflight_middle_chunks=2)
+    data = _data(payload, codes=[7], req=req)
+
+    assert builder("req-cosy", data, None) == []
+    assert data.stream_output_code_count == 0
+
+    # Emission resumes with the full backlog once the prompt chunks drain.
+    req.inflight_middle_chunks = 0
+    messages = builder("req-cosy", data, None)
+    assert len(messages) == 1
+    assert messages[0].data.tolist() == [7]
+    assert messages[0].metadata["row_index"] == 0
+
+
+def test_stream_builder_tolerates_missing_scheduler_request() -> None:
+    builder = make_cosyvoice3_stream_output_builder()
+    payload = _payload(data={"stream": True})
+    data = _data(payload, codes=[7], req=None)
+
+    messages = builder("req-cosy", data, None)
+    assert len(messages) == 1
+    assert messages[0].data.tolist() == [7]


### PR DESCRIPTION
## Motivation

Part of #1652 (AR: Streaming output).

The AR-side producer for incremental streaming: emit Fun-CosyVoice3 speech tokens as they are generated, following the MOSS-TTS / Qwen3-TTS `stream_output_builder` pattern, so a streaming vocoder can start decoding before generation finishes.

## Modifications

1. `make_cosyvoice3_stream_output_builder()` ships the not-yet-emitted tail of `output_codes` after every AR step. Control ids are dropped at collection, so a per-request cursor gives exactly-once delivery. Emission is suppressed while chunked prefill is in flight.

2. Chunks are 1-D long CPU tensors to the vocoder stage, with `modality=audio_codes`, `sample_rate=24000`, and a `row_index` cursor in the metadata.

3. The stream gate reads the prepared state dict first and falls back to request params for unprepared payloads.

The builder is deliberately not wired into the scheduler in this PR. With the buffered vocoder there is no safe intermediate state: the stage runtime rejects stream chunks that arrive before the request payload unless the receiving stage opted in, and the buffered SimpleScheduler cannot consume them either. Activation belongs with the DiT chunk-wise vocoder, which lands the `stream_to` wiring, the receiver flag and the consumer together. #1656 implements that full path; this PR then serves as the producer-side reference for the scheduler-builder pattern.

## Related Issues

Part of #1652.

## Accuracy Test

- `tests/unit_test/fun_cosyvoice3/`: 47 passed
- Full `tests/unit_test` suite and pre-commit pass
- During development the builder was wired and smoke-tested end to end on H100 with the real checkpoint; that run is what surfaced the pre-payload rejection described above

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
