### PR TITLE
[CI] Run accelerator unit tests in a dedicated pytest job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,8 +43,42 @@ jobs:
       - name: Run test
         timeout-minutes: 30
         shell: bash
+        env:
+          # note (Jingwen): Hide CUDA from the default unit-test process. Tests
+          # that need an accelerator belong in the unit-test-accelerator job below.
+          CUDA_VISIBLE_DEVICES: ""
         run: |
           source omni/bin/activate
           export PYTHONPATH=$PWD
           bash .github/scripts/run_flaky_pytest.sh \
-            pytest tests/ -v -m "not benchmark" -x
+            pytest tests/ -v -m "not benchmark and not accelerator" -x
+
+  unit-test-accelerator:
+    name: unit-test-accelerator
+    runs-on: [self-hosted, h100]
+    container:
+      image: hongccc/sglang-omni@sha256:374d0b1c30b2bff685b1716fc64a02ad3b3d0a90fe2ce73ce9861a6992c28101
+      options: >-
+        --rm
+        -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
+        -v /dev/shm:/dev/shm
+        -v /data/omni-ci:/data/omni-ci
+        -v /data/cache/huggingface:/github/home/.cache/huggingface
+        -v /data/cache/huggingface:/root/.cache/huggingface
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/omni-setup
+        with:
+          venv-name: omni
+
+      - name: Run accelerator test
+        timeout-minutes: 30
+        shell: bash
+        run: |
+          source omni/bin/activate
+          export PYTHONPATH=$PWD
+          bash .github/scripts/run_flaky_pytest.sh \
+            pytest tests/ -v -m "accelerator and not benchmark"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,4 +81,4 @@ jobs:
           source omni/bin/activate
           export PYTHONPATH=$PWD
           bash .github/scripts/run_flaky_pytest.sh \
-            pytest tests/ -v -m "accelerator and not benchmark"
+            pytest tests/ -v -m "accelerator and not benchmark" -x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ pythonpath = ["."]
 markers = [
     "benchmark: performance benchmark tests (may require GPU and long runtime)",
     "tts_stage(name): select an in-file TTS benchmark CI stage",
-    "gpu: requires a CUDA device (auto-skipped without one)",
+    "accelerator: requires accelerator hardware",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject_rocm.toml
+++ b/pyproject_rocm.toml
@@ -99,7 +99,7 @@ pythonpath = ["."]
 markers = [
     "benchmark: performance benchmark tests (may require GPU and long runtime)",
     "tts_stage(name): select an in-file TTS benchmark CI stage",
-    "gpu: requires a CUDA-compatible accelerator (auto-skipped without one)",
+    "accelerator: requires accelerator hardware",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject_xpu.toml
+++ b/pyproject_xpu.toml
@@ -93,7 +93,7 @@ pythonpath = ["."]
 markers = [
     "benchmark: performance benchmark tests (may require GPU and long runtime)",
     "tts_stage(name): select an in-file TTS benchmark CI stage",
-    "gpu: requires an accelerator device (auto-skipped without one)",
+    "accelerator: requires accelerator hardware",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/README.md
+++ b/tests/README.md
@@ -246,8 +246,14 @@ filter runs.
   requirements.
 - `tts_stage(name)`: in-file CI stage selector for TTS benchmarks.
   Combined with `--tts-stage` (see `test_model/conftest.py`).
-- `gpu`: tests that require a CUDA device. Pair this marker with an availability
-  guard so the test skips cleanly when CUDA is unavailable.
+- `accelerator`: tests that require accelerator hardware. Pair this marker with
+  a backend-specific availability guard so the test skips cleanly when that
+  hardware is unavailable. The marker must be declared unconditionally; a
+  runtime or artifact-based skip does not assign the test to the accelerator
+  CI job. Marker filtering happens after test modules are imported, so keep
+  accelerator runtime probes such as `torch.cuda.is_available()` and
+  `torch.cuda.device_count()` out of module scope and collection-time skip
+  conditions. Perform them in the test body or a fixture instead.
 
 
 ## Root Files
@@ -390,8 +396,8 @@ python3 -m pytest tests/test_model/test_ming_tp_parity_ci.py -q -s
 
 Fast contract tests that should run without model downloads or real server
 startup. Keep these focused on the smallest component that owns the behavior.
-Most unit tests run on CPU. CUDA-only cases use the `gpu` marker and explicit
-availability guards.
+Most unit tests run on CPU. Accelerator-dependent cases use the `accelerator`
+marker and explicit backend availability guards.
 
 Expected command:
 
@@ -551,17 +557,17 @@ that happened to contain an older version of the test.
     fire rules, sub-batch decomposition, output equivalence, and lifecycle
   - Code2Wav CUDA Graph lifecycle, exact-shape replay, atomic rollback, memory
     budget enforcement, eager fallbacks, replay failures, and JSON-safe stats;
-    the `gpu`-marked cases exercise real CUDA stream restoration and graph
-    capture/replay. Run them with:
+    the `accelerator`-marked cases exercise real CUDA stream restoration and
+    graph capture/replay. Run them with:
 
     ```bash
-    pytest tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py -m gpu -q
+    pytest tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py -m accelerator -q
     ```
   - Code2Wav output overlap (depth-2 pipelined D2H): message-for-message byte
     identity against the synchronous path, first-window sync cadence,
     stream-done pending flush, lazy batched EOS scanning, pinned-slot pool
     lifecycle across abort/replay-failure/exhaustion, and profiler event
-    shape; the `gpu`-marked case runs real pinned buffers and CUDA events
+    shape; the `accelerator`-marked case runs real pinned buffers and CUDA events
   - logit-shaping helpers (e.g. repetition penalty) numerical equivalence with the original per-row scalar formulas.
   - Thinker prefill contracts: `OmniPrefillInputs` adoption for text and
     audio-input → text-output prefills, whole-batch fail-closed qualification,
@@ -739,7 +745,7 @@ that happened to contain an older version of the test.
 - `unit_test/dots_tts/`: dots.tts pipeline and registry contracts, request
   lowering, reference encoding, model-runner lifecycle, flow matching, bounded
   acoustic state, vocoder batching, and streaming cleanup. CUDA Graph parity in
-  `test_tail.py` is marked `gpu`; the remaining tests run on CPU.
+  `test_tail.py` is marked `accelerator`; the remaining tests run on CPU.
 
 - `unit_test/llada2_uni/`: LLaDA2-Uni request lowering to the upstream
   diffusion-language-model token-array contract.
@@ -747,7 +753,7 @@ that happened to contain an older version of the test.
 - `unit_test/minimax_music3/`: MiniMax Music 3 request validation, placement,
   acoustic configuration, hidden-frame buffering, deterministic sampling,
   attention and decoder contracts, abort handling, and relay tensor validation.
-  Kernel and CUDA Graph parity cases in `test_core.py` are marked `gpu`.
+  Kernel and CUDA Graph parity cases in `test_core.py` are marked `accelerator`.
 
 - `unit_test/preprocessing/`: Reference-audio cache identity, bit-exact cached
   resampling, audio-source resolution, duration validation, fingerprinting,

--- a/tests/test_ci/test_tts_mps_dp2.py
+++ b/tests/test_ci/test_tts_mps_dp2.py
@@ -113,7 +113,7 @@ DEFAULT_CONFIGS = {
     "higgs": "examples/mps_dp/configs/higgs_h100_dp3.yaml",
     "moss": "examples/mps_dp/configs/moss_local_h100_dp2.yaml",
 }
-pytestmark = [pytest.mark.benchmark, pytest.mark.gpu]
+pytestmark = [pytest.mark.benchmark, pytest.mark.accelerator]
 
 
 def _selected_model() -> str:

--- a/tests/test_model/test_rl_distributed_weight_update.py
+++ b/tests/test_model/test_rl_distributed_weight_update.py
@@ -68,14 +68,7 @@ def _two_gpus() -> bool:
         return False
 
 
-pytestmark = pytest.mark.skipif(
-    not (
-        _two_gpus()
-        and _resolve_base_dir()
-        and _resolve_snapshot(INSTRUCT_CACHE_DIRNAME)
-    ),
-    reason="requires 2 GPUs + Higgs 4B-base and 4B-instruct checkpoints in the HF cache",
-)
+pytestmark = pytest.mark.accelerator
 
 
 def _run_trainer() -> None:
@@ -192,6 +185,10 @@ def _tts_checksums(url: str) -> dict:
 
 def test_distributed_refit_matches_base_and_keeps_serving(tmp_path):
     base_dir = _resolve_base_dir()
+    if not (base_dir and _resolve_snapshot(INSTRUCT_CACHE_DIRNAME) and _two_gpus()):
+        pytest.skip(
+            "requires 2 GPUs + Higgs 4B-base and 4B-instruct checkpoints in the HF cache"
+        )
 
     proc_b, url_b = _boot_server(base_dir, BASE_REF_PORT, gpu=1)
     try:

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -256,6 +256,7 @@ def _stub_arkasr_engine_build(
     )
 
 
+@pytest.mark.accelerator
 @pytest.mark.parametrize("want_cuda_graph", [True, False])
 def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
     monkeypatch: pytest.MonkeyPatch, want_cuda_graph: bool
@@ -297,6 +298,7 @@ def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
     assert stub.encoder_service_kwargs["max_queue_size"] == 32
 
 
+@pytest.mark.accelerator
 def test_arkasr_pre_lm_encoder_reaches_request_builder_and_shutdown(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -317,6 +319,7 @@ def test_arkasr_pre_lm_encoder_reaches_request_builder_and_shutdown(
     assert stub.encoder_batch_sizes == [8]
 
 
+@pytest.mark.accelerator
 def test_arkasr_pre_lm_encoder_can_be_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_test/arkasr/test_pipeline.py
+++ b/tests/unit_test/arkasr/test_pipeline.py
@@ -11,6 +11,7 @@ from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
 from transformers import WhisperConfig
 
 import sglang_omni.models.arkasr.engine_builder as arkasr_builder
+import sglang_omni.platforms as platforms
 import sglang_omni.scheduling.bootstrap as bootstrap
 import sglang_omni.scheduling.omni_scheduler as omni_scheduler
 import sglang_omni.scheduling.sglang_backend as sglang_backend
@@ -173,6 +174,10 @@ def _stub_arkasr_engine_build(
     infra = (want_cuda_graph, (model_worker, None, None, None, None, None, None))
 
     monkeypatch.setattr(
+        platforms.current_platform, "get_device", lambda index: "cpu", raising=False
+    )
+
+    monkeypatch.setattr(
         arkasr_builder,
         "AutoTokenizer",
         SimpleNamespace(from_pretrained=lambda *a, **k: object()),
@@ -256,7 +261,6 @@ def _stub_arkasr_engine_build(
     )
 
 
-@pytest.mark.accelerator
 @pytest.mark.parametrize("want_cuda_graph", [True, False])
 def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
     monkeypatch: pytest.MonkeyPatch, want_cuda_graph: bool
@@ -298,7 +302,6 @@ def test_arkasr_factory_triggers_deferred_cuda_graph_capture(
     assert stub.encoder_service_kwargs["max_queue_size"] == 32
 
 
-@pytest.mark.accelerator
 def test_arkasr_pre_lm_encoder_reaches_request_builder_and_shutdown(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -319,7 +322,6 @@ def test_arkasr_pre_lm_encoder_reaches_request_builder_and_shutdown(
     assert stub.encoder_batch_sizes == [8]
 
 
-@pytest.mark.accelerator
 def test_arkasr_pre_lm_encoder_can_be_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_test/dots_tts/test_tail.py
+++ b/tests/unit_test/dots_tts/test_tail.py
@@ -377,7 +377,7 @@ def test_fused_dit_builds_modulations_with_bfloat16_weights() -> None:
     assert mods.dtype == torch.bfloat16
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 def test_batched_tail_cuda_graph_matches_eager_for_dynamic_slot_order() -> None:
     if not torch.cuda.is_available():
         pytest.skip("CUDA is required")

--- a/tests/unit_test/fishaudio_s2_pro/test_tts.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_tts.py
@@ -413,6 +413,7 @@ def test_fish_s2pro_decode_codebooks_keeps_eos_out_of_audio_embedding(
     assert int(audio_decoder.seen_embedding_ids[0][0].item()) == 0
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="multinomial_with_seed needs CUDA"
 )

--- a/tests/unit_test/fun_asr/test_pipeline.py
+++ b/tests/unit_test/fun_asr/test_pipeline.py
@@ -9,6 +9,7 @@ import pytest
 
 import sglang_omni.models.fun_asr.engine_builder as fun_asr_builder
 import sglang_omni.models.fun_asr.stages as fun_asr_stages
+import sglang_omni.platforms as platforms
 import sglang_omni.scheduling.bootstrap as bootstrap
 import sglang_omni.scheduling.engine_factory as engine_factory
 import sglang_omni.scheduling.omni_scheduler as omni_scheduler
@@ -103,7 +104,6 @@ def test_fun_asr_stage_default_enables_async_decode() -> None:
     assert signature.parameters["async_decode_min_batch_size"].default == 2
 
 
-@pytest.mark.accelerator
 def test_fun_asr_threads_generation_batch_and_request_build_policy(monkeypatch) -> None:
     from sglang_omni.scheduling.generation_batch_policy import (
         build_default_prefill_cuda_graph_bs,
@@ -119,6 +119,10 @@ def test_fun_asr_threads_generation_batch_and_request_build_policy(monkeypatch) 
         return SimpleNamespace(input_ids=[0] * len(text))
 
     adapter_kwargs: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        platforms.current_platform, "get_device", lambda index: "cpu", raising=False
+    )
 
     monkeypatch.setattr(
         fun_asr_builder.AutoTokenizer,

--- a/tests/unit_test/fun_asr/test_pipeline.py
+++ b/tests/unit_test/fun_asr/test_pipeline.py
@@ -103,6 +103,7 @@ def test_fun_asr_stage_default_enables_async_decode() -> None:
     assert signature.parameters["async_decode_min_batch_size"].default == 2
 
 
+@pytest.mark.accelerator
 def test_fun_asr_threads_generation_batch_and_request_build_policy(monkeypatch) -> None:
     from sglang_omni.scheduling.generation_batch_policy import (
         build_default_prefill_cuda_graph_bs,

--- a/tests/unit_test/higgs_tts/test_async_decode_runner.py
+++ b/tests/unit_test/higgs_tts/test_async_decode_runner.py
@@ -292,6 +292,7 @@ def test_rollout_logprob_host_staging_grows_with_async_batch(
     assert smaller.shape == (2, 8)
 
 
+@pytest.mark.accelerator
 def test_async_real_pinned_path_matches_sync():
     """CUDA-guarded: run the async path through the REAL _next_host_staging
     (pinned host buffer + non-blocking copy on a CUDA model) and confirm it

--- a/tests/unit_test/higgs_tts/test_batched_step.py
+++ b/tests/unit_test/higgs_tts/test_batched_step.py
@@ -75,6 +75,7 @@ def _assert_pools_equal(a: dict, b: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.accelerator
 def test_batched_matches_per_row_delay_window():
     """First N steps must force codebooks > delay_count to BOC."""
     B = 3
@@ -103,6 +104,7 @@ def test_batched_matches_per_row_delay_window():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.accelerator
 def test_batched_matches_per_row_eoc_winddown():
     """After delay, fire cb0=EOC and verify wind-down + done flag match."""
     B = 2
@@ -159,6 +161,7 @@ def test_batched_matches_per_row_eoc_winddown():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.accelerator
 def test_batched_done_row_returns_stop_and_freezes_state():
     """A row already marked generation_done must return STOP and not mutate."""
     pool = HiggsBatchedSamplerState(2, N, device=DEVICE)
@@ -196,6 +199,7 @@ def test_batched_done_row_returns_stop_and_freezes_state():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.accelerator
 def test_batched_matches_per_row_mixed_phases():
     """One row mid-delay, one mid-winddown, one fresh — batched == per-row."""
     pool_pr = HiggsBatchedSamplerState(3, N, device=DEVICE)
@@ -233,6 +237,7 @@ def test_batched_matches_per_row_mixed_phases():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.accelerator
 def test_batched_step_mixed_top_k_per_row_filter():
     """Regression: eager path must accept heterogeneous top_k per row.
     Row 0 uses ``K_MAX`` (no-op filter, mirrors ``top_k=None``); row 1
@@ -315,6 +320,7 @@ def test_batched_greedy_temperature_zero_is_deterministic_argmax():
         assert torch.equal(o, expected), "temperature=0 must be deterministic argmax"
 
 
+@pytest.mark.accelerator
 def test_batched_greedy_top_k_one_is_argmax():
     from sglang_omni.models.higgs_tts.sampler import _sample_independent_batched
 

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -773,7 +773,7 @@ def test_higgs_audio_encoder_uses_reference_code_cache(monkeypatch) -> None:
 
     scheduler = stages.create_audio_encoder_executor(
         "ckpt",
-        device="cuda:0",
+        device="cpu",
         num_codebooks=2,
     )
     # Ignore the construction-time codec warm-up call added by #612.
@@ -850,7 +850,7 @@ def test_higgs_audio_encoder_uses_shared_cache_for_uploaded_voice(
 
     scheduler = stages.create_audio_encoder_executor(
         "ckpt",
-        device="cuda:0",
+        device="cpu",
         num_codebooks=2,
     )
     fake_codec.calls = 0

--- a/tests/unit_test/higgs_tts/test_seeded_sampling.py
+++ b/tests/unit_test/higgs_tts/test_seeded_sampling.py
@@ -11,9 +11,12 @@ import torch
 
 from sglang_omni.models.higgs_tts.sampler import _sample_independent_batched
 
-pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="multinomial_with_seed needs CUDA"
-)
+pytestmark = [
+    pytest.mark.accelerator,
+    pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="multinomial_with_seed needs CUDA"
+    ),
+]
 
 B, N, V = 3, 8, 64
 

--- a/tests/unit_test/ming_omni/test_talker_voice_validation.py
+++ b/tests/unit_test/ming_omni/test_talker_voice_validation.py
@@ -720,6 +720,7 @@ def _stub_for_generate(talker: MingOmniTalker, num_steps_before_stop: int):
     talker.sampler_pool = SimpleNamespace(execute=_execute)
 
 
+@pytest.mark.accelerator
 def test_generate_emits_final_true_when_stop_token_fires(monkeypatch):
     """Stop-token exit terminates with last_chunk=True."""
     import torch as _torch
@@ -750,6 +751,7 @@ def test_generate_emits_final_true_when_stop_token_fires(monkeypatch):
     assert all(flag is False for flag in flags[:-1])
 
 
+@pytest.mark.accelerator
 def test_generate_emits_final_true_when_duration_cap_hits(monkeypatch):
     """Loop exit via effective_max_decode_steps ceiling must still emit a
     last_chunk=True so the streaming VAE flushes its tail."""

--- a/tests/unit_test/minimax_music3/test_core.py
+++ b/tests/unit_test/minimax_music3/test_core.py
@@ -77,7 +77,7 @@ def test_hidden_frame_buffer_uses_absolute_indexes_after_discard() -> None:
         buffer.concatenate(0, 10)
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_sample_topk_seeded_is_invariant_to_batch_composition() -> None:
     # A request's codes must not depend on which other requests share its
@@ -104,7 +104,7 @@ def test_sample_topk_seeded_is_invariant_to_batch_composition() -> None:
     assert torch.equal(batched, alone)
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_sample_topk_seeded_advances_with_the_draw_position() -> None:
     torch.manual_seed(0)
@@ -255,7 +255,7 @@ def test_dav_weight_norm_folding_preserves_output() -> None:
     assert remove_weight_norm(convolution) == 0
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_native_sdpa_matches_reference_without_diffusion_server_args() -> None:
     torch.manual_seed(17)
@@ -288,7 +288,7 @@ def test_native_sdpa_matches_reference_without_diffusion_server_args() -> None:
     torch.testing.assert_close(actual, expected, rtol=0, atol=1e-6)
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_rvq_cuda_graph_replays_per_bucket_and_clones_outputs() -> None:
     def depth_forward(
@@ -344,6 +344,7 @@ def test_rvq_cuda_graph_replays_per_bucket_and_clones_outputs() -> None:
     assert torch.equal(actual_codes, preserved_codes)
 
 
+@pytest.mark.accelerator
 def test_rvq_cuda_graph_declines_a_batch_larger_than_every_bucket() -> None:
     def depth_forward(hidden, c0, seeds, positions, forced, replay):
         del c0, seeds, positions, replay
@@ -392,7 +393,7 @@ class _TinyCacheDiffusion(torch.nn.Module):
         self.transformer = _TinyCacheTransformer()
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_cache_dit_block_adapter_runs_hidden_only_pattern() -> None:
     model = MiniMaxMusic3DIT.__new__(MiniMaxMusic3DIT)

--- a/tests/unit_test/model_runner/test_hidden_capture.py
+++ b/tests/unit_test/model_runner/test_hidden_capture.py
@@ -136,7 +136,7 @@ def test_static_capture_rejects_layer_input_dtype_mismatch() -> None:
         _run_layer(text_model.layers[0], torch.ones(2, 3, dtype=torch.float64), None)
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
 def test_static_capture_refreshes_two_layers_under_breakable_cuda_graph_replay() -> (
     None

--- a/tests/unit_test/moss_transcribe_diarize/test_encoder_cuda_graph.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_encoder_cuda_graph.py
@@ -16,7 +16,7 @@ from sglang_omni.models.moss_transcribe_diarize.encoder_cuda_graph import (
     WhisperEncoderCudaGraphRunner,
 )
 
-pytestmark = pytest.mark.gpu
+pytestmark = pytest.mark.accelerator
 
 _HAS_CUDA = torch.cuda.is_available()
 

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -396,6 +396,7 @@ def _stub_factory_env(monkeypatch: pytest.MonkeyPatch, *, want_cuda_graph: bool)
     return calls
 
 
+@pytest.mark.accelerator
 def test_factory_compiles_encoder_and_skips_cuda_graph_when_flag_on(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -420,6 +421,7 @@ def test_factory_compiles_encoder_and_skips_cuda_graph_when_flag_on(
     assert scheduler_kwargs["prefill_coalesce_after_builds_during_decode"] is True
 
 
+@pytest.mark.accelerator
 def test_factory_context_length_override_uses_final_server_value(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -296,6 +296,7 @@ def _stub_factory_env(monkeypatch: pytest.MonkeyPatch, *, want_cuda_graph: bool)
 
     from transformers import AutoProcessor
 
+    from sglang_omni import platforms
     from sglang_omni.models.moss_transcribe_diarize import (
         engine_builder,
         request_builders,
@@ -334,6 +335,10 @@ def _stub_factory_env(monkeypatch: pytest.MonkeyPatch, *, want_cuda_graph: bool)
         enable_prefill_input_embeds=False,
     )
     infra = (want_cuda_graph, (model_worker, None, None, None, None, None, None))
+
+    monkeypatch.setattr(
+        platforms.current_platform, "get_device", lambda index: "cpu", raising=False
+    )
 
     processor = SimpleNamespace(
         tokenizer=object(),
@@ -396,7 +401,6 @@ def _stub_factory_env(monkeypatch: pytest.MonkeyPatch, *, want_cuda_graph: bool)
     return calls
 
 
-@pytest.mark.accelerator
 def test_factory_compiles_encoder_and_skips_cuda_graph_when_flag_on(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -421,7 +425,6 @@ def test_factory_compiles_encoder_and_skips_cuda_graph_when_flag_on(
     assert scheduler_kwargs["prefill_coalesce_after_builds_during_decode"] is True
 
 
-@pytest.mark.accelerator
 def test_factory_context_length_override_uses_final_server_value(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_test/moss_tts/test_audio_tokenizer.py
+++ b/tests/unit_test/moss_tts/test_audio_tokenizer.py
@@ -714,6 +714,7 @@ def test_query_chunked_sdpa_matches_dense_reference(
     torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-4)
 
 
+@pytest.mark.accelerator
 def test_query_chunked_sdpa_matches_dense_reference_cuda() -> None:
     if not torch.cuda.is_available():
         pytest.skip("requires CUDA")
@@ -737,6 +738,7 @@ def test_query_chunked_sdpa_matches_dense_reference_cuda() -> None:
     torch.testing.assert_close(actual, expected, atol=4e-2, rtol=3e-2)
 
 
+@pytest.mark.accelerator
 def test_auto_backend_runs_query_chunked_sdpa_for_cuda_float32() -> None:
     if not torch.cuda.is_available():
         pytest.skip("requires CUDA")
@@ -811,6 +813,7 @@ def test_query_chunked_sdpa_handles_empty_and_zero_length_inputs() -> None:
     assert torch.count_nonzero(padded[1]) == 0
 
 
+@pytest.mark.accelerator
 def test_local_causal_attention_keeps_packed_flash_cuda() -> None:
     if not torch.cuda.is_available():
         pytest.skip("requires CUDA")
@@ -1059,6 +1062,7 @@ def test_projected_transformer_single_padded_input_uses_masked_pack() -> None:
     assert torch.equal(out_lengths, lengths)
 
 
+@pytest.mark.accelerator
 def test_sglang_packed_flash_matches_sdpa_reference_cuda() -> None:
     if not torch.cuda.is_available():
         pytest.skip("requires CUDA")
@@ -1096,6 +1100,7 @@ def test_sglang_packed_flash_matches_sdpa_reference_cuda() -> None:
     torch.testing.assert_close(flash_out, sdpa_out, atol=4e-2, rtol=3e-2)
 
 
+@pytest.mark.accelerator
 def test_sglang_local_packed_flash_matches_sdpa_reference_cuda() -> None:
     if not torch.cuda.is_available():
         pytest.skip("requires CUDA")
@@ -1181,6 +1186,7 @@ def test_cached_packed_rope_matches_moss_interleaved_reference() -> None:
     assert cache._cos.data_ptr() == cos_ptr
 
 
+@pytest.mark.accelerator
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 def test_exact_packed_rope_matches_reference_cuda(dtype: torch.dtype) -> None:
     if not torch.cuda.is_available():

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -2179,6 +2179,7 @@ def test_moss_compact_candidate_sampler_maps_greedy_indices() -> None:
     assert sampled.tolist() == [13, 12]
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="requires CUDA seeded sampler"
 )

--- a/tests/unit_test/moss_tts/test_sampling_cuda_graph.py
+++ b/tests/unit_test/moss_tts/test_sampling_cuda_graph.py
@@ -297,6 +297,7 @@ def _request_data(
     )
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_fixed_shape_sampling_matches_current_compacted_eager() -> None:
     device = torch.device("cuda")
@@ -372,6 +373,7 @@ def test_fixed_shape_sampling_matches_current_compacted_eager() -> None:
     assert torch.equal(eager_state, fixed.next_delay_state)
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_sampling_cuda_graph_replay_matches_fixed_shape_eager() -> None:
     device = torch.device("cuda")

--- a/tests/unit_test/moss_tts/test_sampling_kernels.py
+++ b/tests/unit_test/moss_tts/test_sampling_kernels.py
@@ -10,6 +10,8 @@ from sglang.srt.layers.sampler import multinomial_with_seed
 
 from sglang_omni.models.moss_tts.sampling_kernels import seeded_gumbel_argmax
 
+pytestmark = pytest.mark.accelerator
+
 _UINT32_MAX_HASH_POSITION = 1_707_985_137
 
 

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -1188,6 +1188,7 @@ def test_build_generation_kwargs_precedence():
     assert kwargs["audio_temperature"] == 1.2
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
 def test_decode_frame_graphed_matches_branchless_eager():
     """The captured frame graph must reproduce the branchless eager decode."""
@@ -1721,6 +1722,7 @@ def test_cached_reference_encoder_data_uri_duration_gate():
     assert len(enc._service._inflight) == 0
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="needs CUDA: post1 multinomial_with_seed is a Triton kernel (no CPU backend)",

--- a/tests/unit_test/moss_tts_local/test_s0_gate.py
+++ b/tests/unit_test/moss_tts_local/test_s0_gate.py
@@ -4,18 +4,20 @@
 Reproducer for this PR's bit-identity claim (the S0 gate cited in the
 Verification section), runnable by anyone via pytest; the upcoming #734 and #736
 changes reuse the same check. The frame-decode CUDA graph, replayed twice with
-identical fixed-seed inputs, must produce bit-identical output. Marked ``gpu``
-and auto-skipped without a CUDA device. Do not modify after initial commit.
+identical fixed-seed inputs, must produce bit-identical output. Marked
+``accelerator`` and auto-skipped without a CUDA device. Do not modify after
+initial commit.
 """
 from __future__ import annotations
 
 import pytest
 import torch
 
+pytestmark = pytest.mark.accelerator
+
 _N_VQ = 12
 
 
-@pytest.mark.gpu
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
 def test_s0_graph_replay_is_deterministic():
     """Two CUDA-graph replays with identical inputs must be bit-identical.

--- a/tests/unit_test/moss_tts_local/test_vocoder_cuda_graph.py
+++ b/tests/unit_test/moss_tts_local/test_vocoder_cuda_graph.py
@@ -10,7 +10,7 @@ import textwrap
 import pytest
 import torch
 
-pytestmark = pytest.mark.gpu
+pytestmark = pytest.mark.accelerator
 
 CODEC_MODEL_ID = "OpenMOSS-Team/MOSS-Audio-Tokenizer-v2"
 N_VQ = 12  # MOSS-TTS-Local v1.5 uses the first 12 RVQ codebooks

--- a/tests/unit_test/pipeline/test_async_decode.py
+++ b/tests/unit_test/pipeline/test_async_decode.py
@@ -387,6 +387,7 @@ def test_finalize_unions_finalize_skip_rids_hook():
     assert chunk_data.generation_steps == 0
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="pinned memory requires CUDA")
 def test_host_staging_pingpong():
     r = _StubRunner()
@@ -398,6 +399,7 @@ def test_host_staging_pingpong():
     assert b0.is_pinned() and tuple(b0.shape) == (8, 18) and b0.dtype == torch.float32
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="pinned memory requires CUDA")
 def test_default_launch_resolve_pinned_snapshot_pingpong():
     """Base (plain-LM) launch/resolve: launch snapshots the sampled ids into a
@@ -432,6 +434,7 @@ def test_default_launch_resolve_pinned_snapshot_pingpong():
     assert buf3 is buf1
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="pinned memory requires CUDA")
 def test_default_launch_staging_grows_then_slices_to_smaller_batch():
     r = ModelRunner.__new__(ModelRunner)

--- a/tests/unit_test/pipeline/test_comm_router.py
+++ b/tests/unit_test/pipeline/test_comm_router.py
@@ -57,6 +57,7 @@ def test_comm_router_uses_mooncake_only_for_remote_edges() -> None:
     )
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_comm_router_uses_cuda_ipc_for_mixed_gpu_payloads() -> None:
     router = CommRouter(
@@ -74,6 +75,7 @@ def test_comm_router_uses_cuda_ipc_for_mixed_gpu_payloads() -> None:
     assert router.outbound_payload("thinker", payload) is TransportKind.CUDA_IPC
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_comm_router_uses_shm_for_cuda_payloads_to_cpu_targets() -> None:
     router = CommRouter(
@@ -218,6 +220,7 @@ def test_comm_router_rejects_narrowed_direct_cuda_ipc_namespace() -> None:
     assert not router.can_use_direct_cuda_ipc("talker")
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_comm_router_uses_cuda_ipc_for_cuda_stream_chunks_only() -> None:
     router = CommRouter(

--- a/tests/unit_test/pipeline/test_gpu_memory.py
+++ b/tests/unit_test/pipeline/test_gpu_memory.py
@@ -7,12 +7,15 @@ import sys
 from types import ModuleType, SimpleNamespace
 
 import pytest
-from sglang.srt.utils import get_device
+import torch
 
 import sglang_omni.utils.gpu_memory as gpu_memory
 
 _ACCELERATOR_ONLY = pytest.mark.skipif(
-    get_device().partition(":")[0] not in ("cuda", "xpu"),
+    not (
+        torch.cuda.is_available()
+        or (hasattr(torch, "xpu") and torch.xpu.is_available())
+    ),
     reason="requires cuda or xpu",
 )
 
@@ -276,7 +279,7 @@ def test_get_gpu_device_info_falls_back_to_torch_when_nvml_import_fails(
     assert info.total_memory_bytes == 96 * 1024**3
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @_ACCELERATOR_ONLY
 def test_device_info_reports_real_memory_on_this_accelerator() -> None:
     """The live half, where an accelerator is actually present."""

--- a/tests/unit_test/pipeline/test_ipc.py
+++ b/tests/unit_test/pipeline/test_ipc.py
@@ -298,7 +298,7 @@ async def test_mp_runner_startup_failure_includes_child_factory_traceback(
     runner = mp_runner.MultiProcessPipelineRunner(config)
 
     with pytest.raises(RuntimeError, match="factory boom"):
-        await runner.start(timeout=10.0)
+        await runner.start(timeout=30.0)
 
     assert list(tmp_path.iterdir()) == []
 

--- a/tests/unit_test/pipeline/test_process_replicas_runtime.py
+++ b/tests/unit_test/pipeline/test_process_replicas_runtime.py
@@ -46,7 +46,7 @@ async def test_replicated_multistage_process_dispatch_stream_and_shutdown(
     )
     runner = MultiProcessPipelineRunner(config)
 
-    await runner.start(timeout=10.0)
+    await runner.start(timeout=30.0)
     processes = [process for group in runner._groups for process in group.processes]
     try:
         results = [

--- a/tests/unit_test/pipeline/test_replicas.py
+++ b/tests/unit_test/pipeline/test_replicas.py
@@ -479,7 +479,6 @@ class TestQwenReplicaPlacementPolicy:
                     "preprocessing",
                     "image_encoder",
                     "audio_encoder",
-                    "mm_aggregate",
                     "thinker",
                     "decode",
                     "talker_ar",

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -121,6 +121,7 @@ def test_aggregated_input_rejects_dynamic_sources_outside_static_fanin() -> None
         handler.receive("req-1", "preprocess", make_stage_payload())
 
 
+@pytest.mark.accelerator
 def test_stage_routes_results_streams_and_clears_abort_state() -> None:
     """Preserves result routing, stream forwarding, and abort cleanup."""
 
@@ -421,6 +422,7 @@ def test_relay_payload_and_cross_gpu_stream_contracts() -> None:
     asyncio.run(_run())
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_cuda_payload_round_trip_preserves_cpu_tensor_devices() -> None:
     async def _run() -> None:
@@ -1019,6 +1021,7 @@ def test_stage_sends_same_process_stream_chunk_as_local_object(monkeypatch) -> N
     ]
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_stage_sends_same_gpu_stream_chunk_as_direct_cuda_ipc(monkeypatch) -> None:
     monkeypatch.setattr(
@@ -1226,6 +1229,7 @@ def test_stage_receives_same_gpu_direct_cuda_ipc_payload(monkeypatch) -> None:
     asyncio.run(_run())
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_direct_cuda_ipc_payload_preserves_inline_cpu_tensors() -> None:
     payload = make_stage_payload(
@@ -1483,7 +1487,7 @@ def test_replica_bindings_not_recorded_after_abort() -> None:
     assert "req-1" not in stage._replica_bindings
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_stage_routes_audio_cuda_payload_over_relay_when_direct_is_disabled(
     monkeypatch,
@@ -1525,7 +1529,7 @@ def test_stage_routes_audio_cuda_payload_over_relay_when_direct_is_disabled(
     asyncio.run(_run())
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_unrelated_stage_still_uses_direct_ipc_for_small_cuda_payload() -> None:
     async def _run() -> None:
@@ -1555,7 +1559,7 @@ def test_unrelated_stage_still_uses_direct_ipc_for_small_cuda_payload() -> None:
     asyncio.run(_run())
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_small_cuda_payload_survives_the_relay_route_bitwise() -> None:
     """The scoped audio policy changes transport only; values stay untouched."""

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -121,9 +121,12 @@ def test_aggregated_input_rejects_dynamic_sources_outside_static_fanin() -> None
         handler.receive("req-1", "preprocess", make_stage_payload())
 
 
-@pytest.mark.accelerator
-def test_stage_routes_results_streams_and_clears_abort_state() -> None:
+def test_stage_routes_results_streams_and_clears_abort_state(monkeypatch) -> None:
     """Preserves result routing, stream forwarding, and abort cleanup."""
+
+    monkeypatch.setattr(
+        platforms.current_platform, "device_type", "cuda", raising=False
+    )
 
     async def _run() -> None:
         relay = FakeRelay()

--- a/tests/unit_test/pipeline/test_stage_process_env.py
+++ b/tests/unit_test/pipeline/test_stage_process_env.py
@@ -156,6 +156,7 @@ def test_xpu_tp_rank_keeps_its_card_despite_an_inherited_cuda_marker(
 
     monkeypatch.setattr(stage_workers, "current_platform", XPUOmniPlatform())
     monkeypatch.setenv("SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS", "true")
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
     monkeypatch.delenv("ZE_AFFINITY_MASK", raising=False)
     spec = StageLaunchConfig(
         stage_name="thinker",

--- a/tests/unit_test/pipeline/test_stage_streaming.py
+++ b/tests/unit_test/pipeline/test_stage_streaming.py
@@ -321,6 +321,7 @@ def test_outbox_drain_yields_after_ready_message_batch(monkeypatch) -> None:
     asyncio.run(_run())
 
 
+@pytest.mark.accelerator
 def test_explicit_scheduler_stream_target_keeps_stage_to_stage_routing() -> None:
     async def _run() -> None:
         control_plane = _FakeControlPlane()

--- a/tests/unit_test/pipeline/test_stage_streaming.py
+++ b/tests/unit_test/pipeline/test_stage_streaming.py
@@ -10,6 +10,7 @@ import pytest
 import torch
 from pydantic import ValidationError
 
+import sglang_omni.platforms as platforms
 from sglang_omni.comm import stage_io
 from sglang_omni.comm.data_ref import DataKind, DataRef, TransportKind
 from sglang_omni.comm.engine import CommEngine
@@ -321,8 +322,13 @@ def test_outbox_drain_yields_after_ready_message_batch(monkeypatch) -> None:
     asyncio.run(_run())
 
 
-@pytest.mark.accelerator
-def test_explicit_scheduler_stream_target_keeps_stage_to_stage_routing() -> None:
+def test_explicit_scheduler_stream_target_keeps_stage_to_stage_routing(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        platforms.current_platform, "device_type", "cuda", raising=False
+    )
+
     async def _run() -> None:
         control_plane = _FakeControlPlane()
         relay = _FakeRelay()

--- a/tests/unit_test/pipeline/test_topology.py
+++ b/tests/unit_test/pipeline/test_topology.py
@@ -470,7 +470,6 @@ def test_qwen3_omni_speech_default_topology_compiles() -> None:
         "preprocessing",
         "image_encoder",
         "audio_encoder",
-        "mm_aggregate",
         "thinker",
         "decode",
         "talker_ar",

--- a/tests/unit_test/qwen3_asr/test_encoder_cuda_graph.py
+++ b/tests/unit_test/qwen3_asr/test_encoder_cuda_graph.py
@@ -64,6 +64,7 @@ def test_get_audio_feature_routing(monkeypatch):
     assert torch.equal(get(model, [item]), torch.full((1, 65, 8), 7.0))
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_graph_matches_eager_tower():
     from sglang.srt.configs.qwen3_omni import Qwen3OmniMoeAudioEncoderConfig

--- a/tests/unit_test/qwen3_asr/test_encoder_service.py
+++ b/tests/unit_test/qwen3_asr/test_encoder_service.py
@@ -9,7 +9,6 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-from sglang.srt.utils import get_device
 
 from sglang_omni.models.qwen3_asr.encoder_service import (
     Qwen3ASRPreLMEncoderService,
@@ -18,9 +17,14 @@ from sglang_omni.models.qwen3_asr.encoder_service import (
 )
 
 _HIDDEN_SIZE = 4
-_DEVICE = get_device()
+if torch.cuda.is_available():
+    _DEVICE = "cuda"
+elif hasattr(torch, "xpu") and torch.xpu.is_available():
+    _DEVICE = "xpu"
+else:
+    _DEVICE = "cpu"
 requires_accelerator = pytest.mark.skipif(
-    _DEVICE.partition(":")[0] not in ("cuda", "xpu"),
+    _DEVICE == "cpu",
     reason="requires cuda or xpu",
 )
 _NAMESPACE = "testns"
@@ -661,7 +665,7 @@ def test_flat_2d_encoder_output_is_also_accepted() -> None:
     assert item.precomputed_embeddings.shape == (3, _HIDDEN_SIZE)
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @requires_accelerator
 def test_the_device_cache_is_really_reclaimed_after_an_oom() -> None:
     """The behaviour the fix exists for, on the live accelerator."""

--- a/tests/unit_test/qwen3_asr/test_sglang_model.py
+++ b/tests/unit_test/qwen3_asr/test_sglang_model.py
@@ -172,6 +172,7 @@ def test_get_audio_feature_rejects_mismatched_mask_shape() -> None:
         Qwen3ASRForConditionalGeneration.get_audio_feature(model, items)
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
 def test_get_audio_feature_normalizes_cpu_masks_for_cuda_features() -> None:
     tower = _RecordingAudioTower().cuda()

--- a/tests/unit_test/qwen3_omni/test_audio_feature_packing.py
+++ b/tests/unit_test/qwen3_omni/test_audio_feature_packing.py
@@ -64,6 +64,7 @@ def test_dtype_and_contiguity_preserved() -> None:
     assert out.is_contiguous()
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
 def test_accelerator_pack_matches_cpu_reference() -> None:
     lengths = [1000, 3000, 512]
@@ -74,6 +75,7 @@ def test_accelerator_pack_matches_cpu_reference() -> None:
     torch.testing.assert_close(out.cpu(), _reference(feats, mask))
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
 def test_accelerator_fallback_gather_matches_cpu_reference() -> None:
     feats = torch.randn(2, MEL, 16)

--- a/tests/unit_test/qwen3_omni/test_audio_layer_graph.py
+++ b/tests/unit_test/qwen3_omni/test_audio_layer_graph.py
@@ -184,7 +184,7 @@ class _RealTower(nn.Module):
         self.layers = nn.ModuleList(_RealLayer(dim) for _ in range(n))
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_capture_all_records_a_graph_for_every_bucket() -> None:
     tower = _RealTower().to(torch.device("cuda", 0), torch.bfloat16)
@@ -194,7 +194,7 @@ def test_capture_all_records_a_graph_for_every_bucket() -> None:
     assert sorted(runner._graphs) == sorted(DEFAULT_TOKEN_BUCKETS)
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_replay_matches_eager_varlen_across_bucket_boundaries() -> None:
     torch.manual_seed(0)

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -39,6 +39,14 @@ class _FactoryModel(FakeCode2WavModel):
         return self
 
 
+def _pin_cuda_platform(monkeypatch) -> None:
+    import sglang_omni.platforms as platforms
+
+    monkeypatch.setattr(
+        platforms.current_platform, "device_type", "cuda", raising=False
+    )
+
+
 class _FakeCudaGraphRunner:
     def __init__(self, model, *, replay_error: Exception | None = None) -> None:
         self.model = model
@@ -192,10 +200,10 @@ def test_qwen_code2wav_enabled_factory_rejects_missing_typed_budget_before_load(
     assert load_calls == 0
 
 
-@pytest.mark.accelerator
 def test_qwen_code2wav_factory_allows_batching_with_cuda_graph(
     monkeypatch,
 ) -> None:
+    _pin_cuda_platform(monkeypatch)
     model = _FactoryModel(num_quantizers=12)
     runner = SimpleNamespace(
         available_batch_sizes=lambda frames: (8, 4, 2, 1),
@@ -223,10 +231,10 @@ def test_qwen_code2wav_factory_allows_batching_with_cuda_graph(
     assert scheduler._chunk_aligned_dispatch is True
 
 
-@pytest.mark.accelerator
 def test_qwen_code2wav_factory_combines_batching_with_cuda_graph(
     monkeypatch,
 ) -> None:
+    _pin_cuda_platform(monkeypatch)
     captured_keys: list[tuple] = []
 
     class _RecordingRunner:
@@ -270,10 +278,10 @@ def test_qwen_code2wav_factory_combines_batching_with_cuda_graph(
     )
 
 
-@pytest.mark.accelerator
 def test_qwen_code2wav_factory_disables_batching_when_runner_disabled(
     monkeypatch,
 ) -> None:
+    _pin_cuda_platform(monkeypatch)
     build_calls: list[tuple] = []
 
     class _DisabledRunner:

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -192,6 +192,7 @@ def test_qwen_code2wav_enabled_factory_rejects_missing_typed_budget_before_load(
     assert load_calls == 0
 
 
+@pytest.mark.accelerator
 def test_qwen_code2wav_factory_allows_batching_with_cuda_graph(
     monkeypatch,
 ) -> None:
@@ -222,6 +223,7 @@ def test_qwen_code2wav_factory_allows_batching_with_cuda_graph(
     assert scheduler._chunk_aligned_dispatch is True
 
 
+@pytest.mark.accelerator
 def test_qwen_code2wav_factory_combines_batching_with_cuda_graph(
     monkeypatch,
 ) -> None:
@@ -268,6 +270,7 @@ def test_qwen_code2wav_factory_combines_batching_with_cuda_graph(
     )
 
 
+@pytest.mark.accelerator
 def test_qwen_code2wav_factory_disables_batching_when_runner_disabled(
     monkeypatch,
 ) -> None:

--- a/tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py
@@ -408,7 +408,7 @@ def test_cuda_api_restores_original_stream_when_capture_exit_raises(
     assert current["stream"] is original_stream
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
 def test_real_cuda_invalid_capture_preserves_current_stream() -> None:
     api = code2wav_cuda_graph._TorchCudaApi()
@@ -440,7 +440,7 @@ def test_real_cuda_invalid_capture_preserves_current_stream() -> None:
     assert current_after == original_stream
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
 def test_real_cuda_shared_pool_replays_batch_sizes_with_eager_parity() -> None:
     class _TinyCode2WavModel(torch.nn.Module):
@@ -484,7 +484,7 @@ def test_real_cuda_shared_pool_replays_batch_sizes_with_eager_parity() -> None:
         assert torch.equal(graph_output, eager)
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
 def test_real_cuda_output_overlap_pipeline_matches_sync_bitwise() -> None:
     """Real graph replay + the depth-2 pipelined D2H produce the exact bytes

--- a/tests/unit_test/qwen3_omni/test_code2wav_overlap.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_overlap.py
@@ -711,7 +711,7 @@ def test_overlap_borrowed_output_copied_before_next_replay(monkeypatch) -> None:
     ]
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
 def test_overlap_gpu_real_pinned_event_bitwise() -> None:
     def _run(*, overlap: bool) -> list[tuple]:

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -503,6 +503,7 @@ def _build_fake_predictor_graph_talker(device: torch.device) -> Qwen3OmniTalker:
     return talker
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="Qwen3-Omni predictor graph requires CUDA"
 )
@@ -570,6 +571,7 @@ def test_qwen_predictor_decode_graph_uses_configured_batch_buckets(
     assert (3, torch.int) not in talker._predictor_decode_graphs
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="Qwen3-Omni predictor graph requires CUDA"
 )
@@ -612,6 +614,7 @@ def test_qwen_predictor_decode_graph_matches_eager(monkeypatch: pytest.MonkeyPat
     torch.testing.assert_close(graph_embeds, eager_embeds)
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="Qwen3-Omni predictor graph requires CUDA"
 )
@@ -649,6 +652,7 @@ def test_qwen_predictor_decode_graph_covers_real_incremental_step(
     torch.testing.assert_close(graph_embeds, eager_embeds)
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.device_count() < 2,
     reason="requires two visible CUDA devices",
@@ -2190,6 +2194,7 @@ def test_talker_prepare_decode_buffers_steady_state_reuse() -> None:
     assert torch.equal(fake._suppress_mask, fresh._suppress_mask)
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason="sampling staging regression requires CUDA"
 )

--- a/tests/unit_test/qwen3_omni/test_talker_attention.py
+++ b/tests/unit_test/qwen3_omni/test_talker_attention.py
@@ -25,9 +25,13 @@ _DEVICE_DTYPE_PARAMS = [
         "cuda",
         torch.bfloat16,
         id="cuda-bf16",
-        marks=pytest.mark.skipif(
-            not torch.cuda.is_available(), reason="CUDA bf16 variant requires a GPU"
-        ),
+        marks=[
+            pytest.mark.accelerator,
+            pytest.mark.skipif(
+                not torch.cuda.is_available(),
+                reason="CUDA bf16 variant requires a GPU",
+            ),
+        ],
     ),
 ]
 

--- a/tests/unit_test/qwen3_omni/test_talker_token_readback.py
+++ b/tests/unit_test/qwen3_omni/test_talker_token_readback.py
@@ -160,6 +160,7 @@ def test_pingpong_alternates_slots_and_reuses_backing_buffer(monkeypatch):
     assert third is first
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_stage_token_ids_cuda_matches_reference():
     runner = _bare_runner()

--- a/tests/unit_test/qwen3_omni/test_thinker_fused_rope.py
+++ b/tests/unit_test/qwen3_omni/test_thinker_fused_rope.py
@@ -11,7 +11,6 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-from sglang.srt.utils import get_device
 
 from sglang_omni.models.qwen3_omni.components.thinker_fused_rope import (
     ThinkerFusedRopeGate,
@@ -19,9 +18,9 @@ from sglang_omni.models.qwen3_omni.components.thinker_fused_rope import (
 )
 from sglang_omni.platforms import current_platform
 
-_DEVICE = get_device()
 requires_xpu = pytest.mark.skipif(
-    _DEVICE.partition(":")[0] != "xpu", reason="describes the xpu policy"
+    not (hasattr(torch, "xpu") and torch.xpu.is_available()),
+    reason="requires XPU",
 )
 _MROPE_SECTION = [24, 20, 20]
 
@@ -280,6 +279,7 @@ def test_install_is_refused_while_a_prefill_graph_could_freeze_it(
     )
 
 
+@pytest.mark.accelerator
 @requires_xpu
 def test_install_succeeds_on_xpu() -> None:
     attn = _fake_attn()
@@ -345,14 +345,14 @@ def test_the_kernel_is_not_acquired_off_xpu(monkeypatch: pytest.MonkeyPatch) -> 
     )
 
 
-@pytest.mark.gpu
+@pytest.mark.accelerator
 @requires_xpu
 def test_the_kernel_matches_an_unfused_reference() -> None:
     kernel = current_platform.get_fused_qk_norm_rope_with_cos_sin_cache()
     if kernel is None:
         pytest.skip("this sgl_kernel build has no fused QK-norm-RoPE kernel")
 
-    device, dtype = torch.device(_DEVICE), torch.bfloat16
+    device, dtype = torch.device("xpu"), torch.bfloat16
     heads, kv_heads, dim, seq, eps, theta = 8, 2, 128, 6, 1e-6, 1000000.0
     torch.manual_seed(0)
     q = torch.randn(seq, heads * dim, device=device, dtype=dtype)

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -966,6 +966,7 @@ def test_qwen3_tts_reference_code_batcher_has_no_stream_for_cpu_device() -> None
         batcher.close()
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_qwen3_tts_reference_code_batcher_encodes_on_dedicated_cuda_stream() -> None:
     device = torch.device("cuda", torch.cuda.current_device())

--- a/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
+++ b/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
@@ -230,6 +230,7 @@ def _run_forward(talker, layer0, hidden, positions):
     return codes.detach().clone(), embeds.detach().clone()
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize(
@@ -261,6 +262,7 @@ def test_graph_bit_identity_sampled(batch_size: int, sampling_kwargs: dict):
     )
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 def test_graph_bit_identity_argmax(batch_size: int):
@@ -277,6 +279,7 @@ def test_graph_bit_identity_argmax(batch_size: int):
     assert torch.equal(graph_embeds, eager_embeds)
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_graph_bit_identity_argmax_none_positions():
     device = torch.device("cuda")
@@ -292,6 +295,7 @@ def test_graph_bit_identity_argmax_none_positions():
     assert torch.equal(graph_embeds, eager_embeds)
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_graph_padded_bucket_bit_identity():
     """Live bs=3 replays through the bucket-4 graph with padded rows."""
@@ -310,6 +314,7 @@ def test_graph_padded_bucket_bit_identity():
     assert torch.equal(graph_embeds, eager_embeds)
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_graph_multi_step_replay_bit_identity():
     """Consecutive steps reuse one captured graph and stay bit-identical."""
@@ -327,6 +332,7 @@ def test_graph_multi_step_replay_bit_identity():
     assert len(talker._predictor_graphs) == 1
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_mixed_sampled_argmax_rows_fall_back_to_eager():
     device = torch.device("cuda")
@@ -343,6 +349,7 @@ def test_mixed_sampled_argmax_rows_fall_back_to_eager():
     assert torch.equal(graph_embeds, eager_embeds)
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_kill_switch_disables_graph_path():
     device = torch.device("cuda")
@@ -373,6 +380,7 @@ def test_env_switch_parsing(monkeypatch: pytest.MonkeyPatch):
     assert sglang_model_module._predictor_graph_env_enabled() is True
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_capture_failure_disables_key_and_falls_back(
     monkeypatch: pytest.MonkeyPatch,
@@ -403,6 +411,7 @@ def test_capture_failure_disables_key_and_falls_back(
     assert len(calls) == 1, "disabled key must not retry capture"
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_capture_failure_restores_live_sub_state(monkeypatch: pytest.MonkeyPatch):
     device = torch.device("cuda")
@@ -457,6 +466,7 @@ class _NoHostReadbackTensor(torch.Tensor):
         return super().to(*args, **kwargs)
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_no_host_readback_on_graph_dispatch_and_replay():
     """Live per-step inputs must reach the graph via device-side copies only."""
@@ -479,6 +489,7 @@ def test_no_host_readback_on_graph_dispatch_and_replay():
         torch.cuda.synchronize()
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_no_host_readback_in_eager_chain():
     """The captured body itself must be free of host materialization."""
@@ -551,6 +562,7 @@ def test_quantize_predictor_top_k_ladder():
     assert quantize(9, 16) is None
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_graph_key_shared_across_request_top_k_values():
     """top_k=5 and top_k=7 land in the same ladder bucket and share one graph."""
@@ -571,6 +583,7 @@ def test_graph_key_shared_across_request_top_k_values():
     )
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_row_top_k_below_bucket_width_bit_identity():
     """Rows with k below the captured bucket width stay bit-identical to eager."""
@@ -593,6 +606,7 @@ def test_row_top_k_below_bucket_width_bit_identity():
     assert torch.equal(graph_embeds, eager_embeds)
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_replay_tracks_per_step_sampling_params():
     """One graph key, three replays with fresh temps/top_p/top_k/seeds per step;
@@ -622,6 +636,7 @@ def test_replay_tracks_per_step_sampling_params():
     assert len(talker._predictor_graphs) == 1
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_global_disable_after_max_capture_failures(monkeypatch: pytest.MonkeyPatch):
     device = torch.device("cuda")
@@ -655,6 +670,7 @@ def test_global_disable_after_max_capture_failures(monkeypatch: pytest.MonkeyPat
     assert len(calls) == 8, "globally disabled graphs must not attempt new captures"
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_capture_failure_resets_cuda_graph(monkeypatch: pytest.MonkeyPatch):
     """A failed capture must release its CUDA graph (pool) via reset()."""
@@ -683,6 +699,7 @@ def test_capture_failure_resets_cuda_graph(monkeypatch: pytest.MonkeyPatch):
     assert reset_calls, "failed capture must reset() its CUDAGraph"
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="seeded sampling kernel needs CUDA")
 def test_widened_top_k_masked_ranks_never_sampled():
     """Ranks past a row's true k remain impossible after log conversion."""
@@ -708,6 +725,7 @@ def test_widened_top_k_masked_ranks_never_sampled():
         )
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_graph_keys_share_memory_pool(monkeypatch: pytest.MonkeyPatch):
     """Distinct graph keys must capture into one model-owned memory pool."""
@@ -736,6 +754,7 @@ def test_graph_keys_share_memory_pool(monkeypatch: pytest.MonkeyPatch):
     assert pools[0] == talker._predictor_graph_pool
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="seeded sampling kernel needs CUDA")
 def test_top_p_removed_ranks_never_sampled():
     """Nucleus-removed ranks must be impossible, same rationale as the top-k mask."""
@@ -807,6 +826,7 @@ def test_resolve_predictor_graph_enabled(monkeypatch: pytest.MonkeyPatch):
     assert talker._resolve_predictor_graph_enabled() is False
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_server_disable_cuda_graph_gates_predictor(monkeypatch: pytest.MonkeyPatch):
     """server_args.disable_cuda_graph must gate the lazily resolved graph path."""

--- a/tests/unit_test/qwen3_tts/test_sampling_kernels.py
+++ b/tests/unit_test/qwen3_tts/test_sampling_kernels.py
@@ -11,9 +11,12 @@ from sglang_omni.models.qwen3_tts.sampling_kernels import (
     sample_from_sorted_logprobs_with_seed_small_k,
 )
 
-pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="Qwen3-TTS sampling kernel needs CUDA"
-)
+pytestmark = [
+    pytest.mark.accelerator,
+    pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="Qwen3-TTS sampling kernel needs CUDA"
+    ),
+]
 
 
 @pytest.mark.parametrize("batch_size,num_cols", [(1, 1), (3, 2), (7, 30), (16, 64)])

--- a/tests/unit_test/relay/test_cuda_ipc_relay.py
+++ b/tests/unit_test/relay/test_cuda_ipc_relay.py
@@ -668,16 +668,19 @@ def _run_paged_case(gpu: int) -> None:
         assert value is True
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_cuda_ipc_same_gpu_round_trip() -> None:
     _run_case(0, 0)
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_cuda_ipc_paged_multi_buffer_round_trip_with_storage_offsets() -> None:
     _run_paged_case(0)
 
 
+@pytest.mark.accelerator
 @pytest.mark.skipif(
     torch.cuda.device_count() < 2, reason="requires >= 2 GPUs for cross-GPU transfer"
 )

--- a/tests/unit_test/scheduling/test_stage_cache.py
+++ b/tests/unit_test/scheduling/test_stage_cache.py
@@ -168,6 +168,7 @@ def test_pin_memory_is_inert_without_cuda(monkeypatch: pytest.MonkeyPatch) -> No
     assert cached is not None and cached.device.type == "cpu"
 
 
+@pytest.mark.accelerator
 @_requires_cuda
 def test_pinned_cache_stores_device_tensors_in_page_locked_memory() -> None:
     cache = StageOutputCache(cache_device="cpu", pin_memory=True)
@@ -184,6 +185,7 @@ def test_pinned_cache_stores_device_tensors_in_page_locked_memory() -> None:
     assert all(t.is_pinned() for t in nested["a"])
 
 
+@pytest.mark.accelerator
 @_requires_cuda
 def test_pinned_cache_reuses_already_pinned_host_tensor() -> None:
     cache = StageOutputCache(cache_device="cpu", pin_memory=True)
@@ -195,6 +197,7 @@ def test_pinned_cache_reuses_already_pinned_host_tensor() -> None:
     assert cached_host.data_ptr() == host.data_ptr() and cached_host.is_pinned()
 
 
+@pytest.mark.accelerator
 @_requires_cuda
 def test_pinned_cache_falls_back_to_pageable_on_alloc_failure(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit_test/utils/test_ipc_weights_cuda.py
+++ b/tests/unit_test/utils/test_ipc_weights_cuda.py
@@ -25,9 +25,12 @@ from sglang_omni.pipeline.stage_workers import (
 )
 from sglang_omni.utils import ipc_weights
 
-pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="weight-share CUDA test requires CUDA"
-)
+pytestmark = [
+    pytest.mark.accelerator,
+    pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="weight-share CUDA test requires CUDA"
+    ),
+]
 
 
 class _Tiny(nn.Module):

--- a/tests/unit_test/whisper_asr/test_encoder_service.py
+++ b/tests/unit_test/whisper_asr/test_encoder_service.py
@@ -145,6 +145,7 @@ def test_pinning_is_off_without_cuda_device() -> None:
     assert service.stats()["pin_prewarm_s"] == 0.0
 
 
+@pytest.mark.accelerator
 @_requires_cuda
 def test_cuda_cache_entries_are_pinned_and_match_device_result() -> None:
     model = _cuda_model()
@@ -164,6 +165,7 @@ def test_cuda_cache_entries_are_pinned_and_match_device_result() -> None:
     assert service.stage_host_copy(anonymous, item.precomputed_embeddings) is None
 
 
+@pytest.mark.accelerator
 @_requires_cuda
 def test_cuda_hit_attaches_device_tensor_from_pinned_entry() -> None:
     model = _cuda_model()
@@ -178,6 +180,7 @@ def test_cuda_hit_attaches_device_tensor_from_pinned_entry() -> None:
     assert torch.equal(first.precomputed_embeddings, second.precomputed_embeddings)
 
 
+@pytest.mark.accelerator
 @_requires_cuda
 def test_pin_host_memory_flag_disables_pinning() -> None:
     service = _make_service(_cuda_model(), pin_host_memory=False)
@@ -189,6 +192,7 @@ def test_pin_host_memory_flag_disables_pinning() -> None:
     assert service.stats()["pin_prewarm_s"] == 0.0
 
 
+@pytest.mark.accelerator
 @_requires_cuda
 def test_pinned_allocation_failure_falls_back_to_pageable(
     monkeypatch: pytest.MonkeyPatch,
@@ -213,6 +217,7 @@ def test_pinned_allocation_failure_falls_back_to_pageable(
     assert torch.equal(cached.to("cuda"), item.precomputed_embeddings)
 
 
+@pytest.mark.accelerator
 @_requires_cuda
 def test_prewarm_covers_cache_capacity(monkeypatch: pytest.MonkeyPatch) -> None:
     allocations: list[int] = []


### PR DESCRIPTION
Supersedes #1661 with the isolation boundary moved outside pytest.

## Summary

- Keep the default `unit-test` job accelerator-free by hiding CUDA and deselecting accelerator-marked cases.
- Run accelerator-dependent tests in a separate H100 `unit-test-accelerator` job and a fresh pytest interpreter.
- Replace the hardware-vendor-specific `gpu` marker with `accelerator` across CUDA, ROCm, and XPU project manifests and tests.
- Keep host-only and mock-only XPU coverage in the default job; use backend-specific skip conditions for tests that require particular hardware.

## Why not `pytest --forked`

`pytest-forked` forks each worker only after the parent pytest process has imported conftests and collected test modules. Some of those imports already initialize CUDA, so every fork inherits poisoned CUDA runtime state and fails with `Cannot re-initialize CUDA in forked subprocess`.

A separate pytest invocation gives the accelerator suite a fresh interpreter without repeating the repository heavy import and collection cost once per test. The two unit-test jobs therefore cannot share a CUDA context, while the accelerator job remains about two minutes locally.

## XPU and other accelerators

There is no XPU CI runner or meaningful XPU-only unit-test stage today. Most tests under `tests/unit_test/xpu/` are source, script, or mocked platform tests and stay in the default job. The two fused-RoPE cases that require real XPU hardware use the common accelerator marker and skip on H100. A future XPU, NPU, MUSA, or ROCm runner can execute the same marker selection while backend-specific tests keep their own skip conditions.

## Validation

- Marker partition after rebasing onto `main`, excluding the locally unavailable optional `dots_tts` directory: 174 accelerator tests and 4,994 default tests; 46 benchmarks are excluded from both jobs.
- Accelerator suite on local H200: 172 passed and 2 XPU-only tests skipped in 135s.
- Focused default/XPU selection with `CUDA_VISIBLE_DEVICES=""`: 95 passed and 4 deselected.
- An intentionally unmarked test that allocates a CUDA tensor fails in the default environment with `RuntimeError: No CUDA GPUs are available`.
- `pre-commit run --all-files --show-diff-on-failure` passes.
