### PR TITLE
[Perf][MOSS-TTS-Local] Fuse the seeded frame sampler into one Triton kernel

### DIFF
--- a/sglang_omni/models/moss_tts/model_runner.py
+++ b/sglang_omni/models/moss_tts/model_runner.py
@@ -707,7 +707,11 @@ class MossTTSModelRunner(ModelRunner):
         active = (top_p_row > 0.0) & (top_p_row < 1.0)
         if not skip_inactive_check and not bool(active.any()):
             return scores
-        sorted_scores, sorted_indices = torch.sort(scores, descending=True, dim=-1)
+        # Note (Jiaxin Deng): input order on ties is the one contract the graphed,
+        # branchless and eager paths share; an unstable sort breaks it per backend.
+        sorted_scores, sorted_indices = torch.sort(
+            scores, descending=True, dim=-1, stable=True
+        )
         probs = torch.softmax(sorted_scores, dim=-1)
         cumulative = torch.cumsum(probs, dim=-1)
         remove = cumulative > top_p_row.unsqueeze(1)

--- a/sglang_omni/models/moss_tts/sampling_kernels.py
+++ b/sglang_omni/models/moss_tts/sampling_kernels.py
@@ -151,6 +151,9 @@ def multinomial_with_seed_and_token_ids(
 
 
 _F64_MIN = tl.constexpr(-1.7976931348623157e308)
+# Note (Jiaxin Deng): sglang caps log(uniform) at both ends, so a hash of
+# UINT32_MAX no longer yields +inf gumbel; the fused draw follows the cap.
+_F64_LOG_CAP = tl.constexpr(-(2.0**-32))
 
 # Note (Jiaxin Deng): single-block cap; larger vocabularies keep the sort-based
 # path because one program can no longer hold the row.
@@ -243,9 +246,8 @@ def _fused_seeded_sample_kernel(
     hash_value ^= 16
     hash_value = fmix32(hash_value)
     uniform = hash_value.to(tl.float64) / _UINT32_MAX_F64
-    log_uniform = libdevice.log(uniform)
-    neg_log_uniform = -tl.maximum(log_uniform, _F64_MIN)
-    gumbel = -libdevice.log(neg_log_uniform)
+    log_uniform = tl.minimum(tl.maximum(libdevice.log(uniform), _F64_MIN), _F64_LOG_CAP)
+    gumbel = -libdevice.log(-log_uniform)
     value = final_sorted.to(tl.float64) + gumbel
 
     is_nan = value != value

--- a/sglang_omni/models/moss_tts/sampling_kernels.py
+++ b/sglang_omni/models/moss_tts/sampling_kernels.py
@@ -282,7 +282,14 @@ def sample_seeded_fused(
     seeds: torch.Tensor,
     positions: torch.Tensor,
 ) -> torch.Tensor:
-    """Single-kernel drop-in for :func:`sample_seeded_branchless` (vocab <= 2048)."""
+    """Single-kernel seeded sampler for vocab <= 2048.
+
+    Numerically equivalent to :func:`sample_seeded_branchless` rather than bit
+    identical by construction: the in-kernel softmax and cumsum reduce in a
+    different order than aten, so at an exact nucleus boundary the kept set may
+    differ by the boundary token. The tie order (input order), the greedy and
+    NaN fallbacks, and the seeded draw are exact.
+    """
 
     rows, vocab = logits.shape
     if vocab > MAX_FUSED_SAMPLE_VOCAB:

--- a/sglang_omni/models/moss_tts/sampling_kernels.py
+++ b/sglang_omni/models/moss_tts/sampling_kernels.py
@@ -218,10 +218,12 @@ def _fused_seeded_sample_kernel(
     p_active = (top_p > 0.0) & (top_p < 1.0)
     row_max = tl.max(masked_sorted, axis=0)
     finite_max = row_max > -float("inf")
+    # Note (Jiaxin Deng): masking on == -inf lets NaN and +inf lanes poison z the
+    # way torch.softmax poisons the baseline row, so both fall back identically.
     exp_term = tl.where(
-        masked_sorted > -float("inf"),
-        tl.exp(masked_sorted - tl.where(finite_max, row_max, 0.0)),
+        masked_sorted == -float("inf"),
         0.0,
+        tl.exp(masked_sorted - tl.where(finite_max, row_max, 0.0)),
     )
     z = tl.sum(exp_term, axis=0)
     probs_sorted = tl.where(z > 0, exp_term / z, 0.0)
@@ -256,9 +258,17 @@ def _fused_seeded_sample_kernel(
     )
     sampled = tl.where(nan_index != 2147483647, nan_index, max_index)
 
-    max_logit = tl.max(tl.where(valid, logits, -float("inf")), axis=0)
-    greedy = tl.min(tl.where(valid & (logits == max_logit), idx, 2147483647), axis=0)
-    use_fallback = (~do_sample) | (z <= 0)
+    # Note (Jiaxin Deng): torch.argmax ranks NaN above every number, so a NaN row
+    # must select its first NaN lane; comparing against a NaN max matches none.
+    logit_is_nan = logits != logits
+    nan_greedy = tl.min(tl.where(valid & logit_is_nan, idx, 2147483647), axis=0)
+    finite = valid & ~logit_is_nan
+    max_logit = tl.max(tl.where(finite, logits, -float("inf")), axis=0)
+    finite_greedy = tl.min(
+        tl.where(finite & (logits == max_logit), idx, 2147483647), axis=0
+    )
+    greedy = tl.where(nan_greedy != 2147483647, nan_greedy, finite_greedy)
+    use_fallback = (~do_sample) | (z <= 0) | (z != z)
     result = tl.where(use_fallback, greedy.to(tl.int64), sampled)
     tl.store(output_ptr + row, result)
 
@@ -325,7 +335,11 @@ def sample_seeded_branchless(
 
     k_active = (top_k > 0) & (top_k < vocab)
     k_clamped = top_k.clamp(min=1, max=vocab)
-    sorted_scores, sorted_indices = torch.sort(scores, descending=True, dim=-1)
+    # Note (Jiaxin Deng): an unstable sort leaves the tie order backend dependent
+    # (a two lane row reverses on cu130) and that picks the token at a nucleus edge.
+    sorted_scores, sorted_indices = torch.sort(
+        scores, descending=True, dim=-1, stable=True
+    )
     kth = sorted_scores.gather(1, (k_clamped - 1).unsqueeze(1))
     threshold = torch.where(
         k_active.unsqueeze(1), kth, torch.full_like(kth, float("-inf"))

--- a/sglang_omni/models/moss_tts/sampling_kernels.py
+++ b/sglang_omni/models/moss_tts/sampling_kernels.py
@@ -276,16 +276,21 @@ def sample_seeded_fused(
         raise ValueError(
             f"fused seeded sampler supports vocab <= {MAX_FUSED_SAMPLE_VOCAB}, got {vocab}"
         )
+    if rows == 0:
+        return torch.empty(0, device=logits.device, dtype=torch.int64)
+    if top_k.dtype.is_floating_point or top_k.dtype == torch.bool:
+        raise TypeError(f"top_k must be an integer tensor, got {top_k.dtype}")
+    top_k = top_k.to(torch.int64)
     logits = logits.float().contiguous()
     out = torch.empty(rows, device=logits.device, dtype=torch.int64)
     block = triton.next_power_of_2(vocab)
     _fused_seeded_sample_kernel[(rows,)](
         logits,
-        temperature.float(),
-        top_p.float(),
-        top_k.to(torch.int64),
-        seeds,
-        positions,
+        temperature.float().contiguous(),
+        top_p.float().contiguous(),
+        top_k.contiguous(),
+        seeds.to(torch.int64).contiguous(),
+        positions.to(torch.int64).contiguous(),
         out,
         VOCAB=vocab,
         ROW_STRIDE=logits.stride(0),

--- a/sglang_omni/models/moss_tts/sampling_kernels.py
+++ b/sglang_omni/models/moss_tts/sampling_kernels.py
@@ -278,7 +278,7 @@ def sample_seeded_fused(
         )
     if rows == 0:
         return torch.empty(0, device=logits.device, dtype=torch.int64)
-    if top_k.dtype.is_floating_point or top_k.dtype == torch.bool:
+    if top_k.dtype.is_floating_point or top_k.dtype.is_complex or top_k.dtype == torch.bool:
         raise TypeError(f"top_k must be an integer tensor, got {top_k.dtype}")
     top_k = top_k.to(torch.int64)
     logits = logits.float().contiguous()

--- a/sglang_omni/models/moss_tts/sampling_kernels.py
+++ b/sglang_omni/models/moss_tts/sampling_kernels.py
@@ -187,8 +187,11 @@ def _fused_seeded_sample_kernel(
 
     # Note (Jiaxin Deng): key packs orderable score bits above a complemented
     # index so equal scores keep input order, matching cub's stable radix sort
-    # (torch.sort) bit-for-bit at nucleus tie boundaries.
-    bits = scores.to(tl.int32, bitcast=True)
+    # (torch.sort) bit-for-bit at nucleus tie boundaries. -0.0 canonicalizes to
+    # +0.0 first: the zeros compare equal numerically, so bit-distinct keys
+    # would break that input-order tie rule.
+    key_scores = tl.where(scores == 0.0, 0.0, scores)
+    bits = key_scores.to(tl.int32, bitcast=True)
     orderable = (bits ^ ((bits >> 31) | -2147483648)).to(tl.uint32).to(tl.int64)
     biased = orderable - tl.full((), 2147483648, tl.int64)
     idx64 = idx.to(tl.int64)

--- a/sglang_omni/models/moss_tts/sampling_kernels.py
+++ b/sglang_omni/models/moss_tts/sampling_kernels.py
@@ -150,6 +150,151 @@ def multinomial_with_seed_and_token_ids(
     return torch.argmax(noise, dim=1)
 
 
+_F64_MIN = tl.constexpr(-1.7976931348623157e308)
+
+# Note (Jiaxin Deng): single-block cap; larger vocabularies keep the sort-based
+# path because one program can no longer hold the row.
+MAX_FUSED_SAMPLE_VOCAB = 2048
+
+
+@triton.jit
+def _fused_seeded_sample_kernel(
+    logits_ptr,
+    temperature_ptr,
+    top_p_ptr,
+    top_k_ptr,
+    seeds_ptr,
+    positions_ptr,
+    output_ptr,
+    VOCAB: tl.constexpr,
+    ROW_STRIDE: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    idx = tl.arange(0, BLOCK)
+    valid = idx < VOCAB
+
+    logits = tl.load(
+        logits_ptr + row * ROW_STRIDE + idx, mask=valid, other=-float("inf")
+    ).to(tl.float32)
+
+    temp = tl.load(temperature_ptr + row).to(tl.float32)
+    top_p = tl.load(top_p_ptr + row).to(tl.float32)
+    top_k = tl.load(top_k_ptr + row).to(tl.int64)
+    do_sample = temp > 0
+    safe_temp = tl.where(do_sample, temp, 1.0)
+    scores = logits / safe_temp
+
+    # Note (Jiaxin Deng): key packs orderable score bits above a complemented
+    # index so equal scores keep input order, matching cub's stable radix sort
+    # (torch.sort) bit-for-bit at nucleus tie boundaries.
+    bits = scores.to(tl.int32, bitcast=True)
+    orderable = (bits ^ ((bits >> 31) | -2147483648)).to(tl.uint32).to(tl.int64)
+    biased = orderable - tl.full((), 2147483648, tl.int64)
+    idx64 = idx.to(tl.int64)
+    inv_idx = tl.full((), 4294967295, tl.int64) - idx64
+    key = (biased << 32) + inv_idx
+    key = tl.where(valid, key, tl.full(key.shape, -9223372036854775807, tl.int64))
+    skey = tl.sort(key, descending=True)
+
+    s_idx = tl.full((), 4294967295, tl.int64) - (skey - ((skey >> 32) << 32))
+    s_bits_orderable = (skey >> 32) + tl.full((), 2147483648, tl.int64)
+    s_bits = s_bits_orderable.to(tl.int32)
+    s_bits = s_bits ^ (((~s_bits) >> 31) | -2147483648)
+    s_scores = s_bits.to(tl.float32, bitcast=True)
+    lane = tl.arange(0, BLOCK)
+    s_valid = lane < VOCAB
+    s_scores = tl.where(s_valid, s_scores, -float("inf"))
+
+    k_active = (top_k > 0) & (top_k < VOCAB)
+    k_clamped = tl.minimum(tl.maximum(top_k, 1), VOCAB)
+    kth = tl.sum(tl.where(lane.to(tl.int64) == k_clamped - 1, s_scores, 0.0), axis=0)
+    threshold = tl.where(k_active, kth, -float("inf"))
+    masked_sorted = tl.where(s_scores < threshold, -float("inf"), s_scores)
+
+    p_active = (top_p > 0.0) & (top_p < 1.0)
+    row_max = tl.max(masked_sorted, axis=0)
+    finite_max = row_max > -float("inf")
+    exp_term = tl.where(
+        masked_sorted > -float("inf"),
+        tl.exp(masked_sorted - tl.where(finite_max, row_max, 0.0)),
+        0.0,
+    )
+    z = tl.sum(exp_term, axis=0)
+    probs_sorted = tl.where(z > 0, exp_term / z, 0.0)
+    inclusive = tl.cumsum(probs_sorted, axis=0)
+    remove = ((inclusive - probs_sorted) > top_p) & p_active
+    final_sorted = tl.where(remove, -float("inf"), masked_sorted)
+
+    # Match multinomial_with_seed exactly, including hash_value == UINT32_MAX;
+    # the hash keys on original token ids so lane order is irrelevant.
+    seed = tl.load(seeds_ptr + row).to(tl.uint64)
+    position = tl.load(positions_ptr + row).to(tl.uint32)
+    hash_value: tl.uint32 = 0
+    hash_value = murmur3_mix(hash_value, (seed & 0xFFFFFFFF).to(tl.uint32))
+    hash_value = murmur3_mix(hash_value, ((seed >> 32) & 0xFFFFFFFF).to(tl.uint32))
+    hash_value = murmur3_mix(hash_value, position)
+    hash_value = murmur3_mix(hash_value, s_idx.to(tl.uint32))
+    hash_value ^= 16
+    hash_value = fmix32(hash_value)
+    uniform = hash_value.to(tl.float64) / _UINT32_MAX_F64
+    log_uniform = libdevice.log(uniform)
+    neg_log_uniform = -tl.maximum(log_uniform, _F64_MIN)
+    gumbel = -libdevice.log(neg_log_uniform)
+    value = final_sorted.to(tl.float64) + gumbel
+
+    is_nan = value != value
+    nan_index = tl.min(tl.where(s_valid & is_nan, s_idx, 2147483647), axis=0)
+    non_nan = tl.where(s_valid & ~is_nan, value, -float("inf"))
+    max_value = tl.max(non_nan, axis=0)
+    max_index = tl.min(
+        tl.where(s_valid & ~is_nan & (non_nan == max_value), s_idx, 2147483647),
+        axis=0,
+    )
+    sampled = tl.where(nan_index != 2147483647, nan_index, max_index)
+
+    max_logit = tl.max(tl.where(valid, logits, -float("inf")), axis=0)
+    greedy = tl.min(tl.where(valid & (logits == max_logit), idx, 2147483647), axis=0)
+    use_fallback = (~do_sample) | (z <= 0)
+    result = tl.where(use_fallback, greedy.to(tl.int64), sampled)
+    tl.store(output_ptr + row, result)
+
+
+def sample_seeded_fused(
+    logits: torch.Tensor,
+    *,
+    temperature: torch.Tensor,
+    top_p: torch.Tensor,
+    top_k: torch.Tensor,
+    seeds: torch.Tensor,
+    positions: torch.Tensor,
+) -> torch.Tensor:
+    """Single-kernel drop-in for :func:`sample_seeded_branchless` (vocab <= 2048)."""
+
+    rows, vocab = logits.shape
+    if vocab > MAX_FUSED_SAMPLE_VOCAB:
+        raise ValueError(
+            f"fused seeded sampler supports vocab <= {MAX_FUSED_SAMPLE_VOCAB}, got {vocab}"
+        )
+    logits = logits.float().contiguous()
+    out = torch.empty(rows, device=logits.device, dtype=torch.int64)
+    block = triton.next_power_of_2(vocab)
+    _fused_seeded_sample_kernel[(rows,)](
+        logits,
+        temperature.float(),
+        top_p.float(),
+        top_k.to(torch.int64),
+        seeds,
+        positions,
+        out,
+        VOCAB=vocab,
+        ROW_STRIDE=logits.stride(0),
+        BLOCK=block,
+        num_warps=8 if block >= 1024 else 4,
+    )
+    return out
+
+
 def sample_seeded_branchless(
     logits: torch.Tensor,
     *,
@@ -196,7 +341,9 @@ def sample_seeded_branchless(
 
 
 __all__ = [
+    "MAX_FUSED_SAMPLE_VOCAB",
     "multinomial_with_seed_and_token_ids",
     "sample_seeded_branchless",
+    "sample_seeded_fused",
     "seeded_gumbel_argmax",
 ]

--- a/sglang_omni/models/moss_tts/sampling_kernels.py
+++ b/sglang_omni/models/moss_tts/sampling_kernels.py
@@ -281,7 +281,11 @@ def sample_seeded_fused(
         )
     if rows == 0:
         return torch.empty(0, device=logits.device, dtype=torch.int64)
-    if top_k.dtype.is_floating_point or top_k.dtype.is_complex or top_k.dtype == torch.bool:
+    if (
+        top_k.dtype.is_floating_point
+        or top_k.dtype.is_complex
+        or top_k.dtype == torch.bool
+    ):
         raise TypeError(f"top_k must be an integer tensor, got {top_k.dtype}")
     top_k = top_k.to(torch.int64)
     logits = logits.float().contiguous()

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -395,7 +395,9 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             self._compiled_frame_sampler = self._compile_branchless_sampler()
             self._sample_seeded_branchless = self._compiled_frame_sampler
 
-    def _fused_or_branchless_sampler(self, logits: torch.Tensor, **kwargs) -> torch.Tensor:
+    def _fused_or_branchless_sampler(
+        self, logits: torch.Tensor, **kwargs
+    ) -> torch.Tensor:
         if logits.shape[-1] <= MAX_FUSED_SAMPLE_VOCAB:
             return sample_seeded_fused(logits, **kwargs)
         if self._large_vocab_frame_sampler is None:

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -138,6 +138,7 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         # its addresses are fixed for the process lifetime.
         self._state_pool = MossTTSLocalDecodeStatePool(self)
         self._compiled_frame_sampler: Callable[..., torch.Tensor] | None = None
+        self._large_vocab_frame_sampler: Callable[..., torch.Tensor] | None = None
         self._frame_compile_configured = False
 
     def acquire_row(self, rid: str) -> int:
@@ -372,29 +373,34 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         set_torch_compile_config()
         self._frame_compile_configured = True
 
+    def _compile_branchless_sampler(self):
+        compile_mode = os.environ.get(
+            "SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs"
+        )
+        self._ensure_frame_compile_config()
+        compiled = torch.compile(sample_seeded_branchless, mode=compile_mode)
+        logger.info(f"Compiled MOSS-TTS Local frame sampler (mode={compile_mode})")
+        return compiled
+
     def _ensure_frame_sampler_compile(self) -> None:
         if self._compiled_frame_sampler is None:
             if os.environ.get("MOSS_LOCAL_FUSED_FRAME_SAMPLER", "1") != "0":
+                # Note (Jiaxin Deng): the Triton specializations JIT during the
+                # eager warmup passes init_frame_decode_graphs runs per bucket,
+                # so both vocab shapes compile before graph capture.
                 self._compiled_frame_sampler = self._fused_or_branchless_sampler
                 self._sample_seeded_branchless = self._fused_or_branchless_sampler
                 logger.info("Using fused MOSS-TTS Local frame sampler")
                 return
-            compile_mode = os.environ.get(
-                "SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs"
-            )
-            self._ensure_frame_compile_config()
-            self._compiled_frame_sampler = torch.compile(
-                sample_seeded_branchless,
-                mode=compile_mode,
-            )
+            self._compiled_frame_sampler = self._compile_branchless_sampler()
             self._sample_seeded_branchless = self._compiled_frame_sampler
-            logger.info(f"Compiled MOSS-TTS Local frame sampler (mode={compile_mode})")
 
-    @staticmethod
-    def _fused_or_branchless_sampler(logits: torch.Tensor, **kwargs) -> torch.Tensor:
+    def _fused_or_branchless_sampler(self, logits: torch.Tensor, **kwargs) -> torch.Tensor:
         if logits.shape[-1] <= MAX_FUSED_SAMPLE_VOCAB:
             return sample_seeded_fused(logits, **kwargs)
-        return sample_seeded_branchless(logits, **kwargs)
+        if self._large_vocab_frame_sampler is None:
+            self._large_vocab_frame_sampler = self._compile_branchless_sampler()
+        return self._large_vocab_frame_sampler(logits, **kwargs)
 
     @torch.no_grad()
     def _decode_frame_graphable(

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -30,7 +30,11 @@ from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen3 import Qwen3Model
 from sglang.srt.utils import add_prefix
 
-from sglang_omni.models.moss_tts.sampling_kernels import sample_seeded_branchless
+from sglang_omni.models.moss_tts.sampling_kernels import (
+    MAX_FUSED_SAMPLE_VOCAB,
+    sample_seeded_branchless,
+    sample_seeded_fused,
+)
 from sglang_omni.models.moss_tts_local.local_transformer import MossTTSLocalTransformer
 from sglang_omni.models.moss_tts_local.payload_types import (
     moss_tts_local_special_token_defaults,
@@ -370,6 +374,11 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
 
     def _ensure_frame_sampler_compile(self) -> None:
         if self._compiled_frame_sampler is None:
+            if os.environ.get("MOSS_LOCAL_FUSED_FRAME_SAMPLER", "1") != "0":
+                self._compiled_frame_sampler = self._fused_or_branchless_sampler
+                self._sample_seeded_branchless = self._fused_or_branchless_sampler
+                logger.info("Using fused MOSS-TTS Local frame sampler")
+                return
             compile_mode = os.environ.get(
                 "SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs"
             )
@@ -380,6 +389,12 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             )
             self._sample_seeded_branchless = self._compiled_frame_sampler
             logger.info(f"Compiled MOSS-TTS Local frame sampler (mode={compile_mode})")
+
+    @staticmethod
+    def _fused_or_branchless_sampler(logits: torch.Tensor, **kwargs) -> torch.Tensor:
+        if logits.shape[-1] <= MAX_FUSED_SAMPLE_VOCAB:
+            return sample_seeded_fused(logits, **kwargs)
+        return sample_seeded_branchless(logits, **kwargs)
 
     @torch.no_grad()
     def _decode_frame_graphable(

--- a/tests/unit_test/moss_tts/test_sampling_kernels.py
+++ b/tests/unit_test/moss_tts/test_sampling_kernels.py
@@ -307,7 +307,7 @@ def test_sample_seeded_fused_hash_endpoint() -> None:
     a = sample_seeded_branchless(logits, **params)
     b = sample_seeded_fused(logits, **params)
     assert torch.equal(a, b)
-    assert a.item() == 0
+    assert a.item() == 1
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
@@ -358,9 +358,9 @@ def test_sample_seeded_fused_input_hardening() -> None:
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 def test_sample_seeded_fused_masked_lane_hash_endpoint() -> None:
     """A top-k-masked token whose Gumbel hash hits UINT32_MAX yields
-    -inf + inf = NaN; the baseline's NaN-first rule then selects it. The fused
-    kernel must reproduce that baseline quirk exactly (parity, not top-k
-    membership, is the contract)."""
+    a capped gumbel, so the masked lane stays at -inf instead of the NaN the
+    uncapped endpoint used to produce. The fused kernel must follow the baseline
+    either way (parity, not top-k membership, is the contract)."""
     from sglang_omni.models.moss_tts.sampling_kernels import (
         sample_seeded_branchless,
         sample_seeded_fused,

--- a/tests/unit_test/moss_tts/test_sampling_kernels.py
+++ b/tests/unit_test/moss_tts/test_sampling_kernels.py
@@ -337,3 +337,80 @@ def test_sample_seeded_fused_input_hardening() -> None:
     c = sample_seeded_branchless(logits, **contig)
     assert torch.equal(a, b)
     assert torch.equal(a, c)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_sample_seeded_fused_masked_lane_hash_endpoint() -> None:
+    """A top-k-masked token whose Gumbel hash hits UINT32_MAX yields
+    -inf + inf = NaN; the baseline's NaN-first rule then selects it. The fused
+    kernel must reproduce that baseline quirk exactly (parity, not top-k
+    membership, is the contract)."""
+    from sglang_omni.models.moss_tts.sampling_kernels import (
+        sample_seeded_branchless,
+        sample_seeded_fused,
+    )
+
+    device = torch.device("cuda")
+    vocab = 64
+    logits = torch.full((1, vocab), 0.0, device=device)
+    logits[0, 0] = -100.0  # token 0: excluded by top-k, hash endpoint target
+    params = dict(
+        temperature=torch.ones(1, device=device),
+        top_p=torch.ones(1, device=device),
+        top_k=torch.full((1,), 8, device=device, dtype=torch.long),
+        seeds=torch.zeros(1, device=device, dtype=torch.long),
+        positions=torch.tensor(
+            [_UINT32_MAX_HASH_POSITION], device=device, dtype=torch.long
+        ),
+    )
+    a = sample_seeded_branchless(logits, **params)
+    b = sample_seeded_fused(logits, **params)
+    assert torch.equal(a, b)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_sample_seeded_fused_signed_zero_orderings_and_nonfinite() -> None:
+    from sglang_omni.models.moss_tts.sampling_kernels import (
+        sample_seeded_branchless,
+        sample_seeded_fused,
+    )
+
+    device = torch.device("cuda")
+    vocab = 64
+    rows = []
+    base = torch.full((vocab,), -5.0, device=device)
+    r0 = base.clone(); r0[3], r0[7] = 0.0, -0.0          # +0 before -0
+    r1 = base.clone(); r1[3], r1[7] = -0.0, 0.0          # -0 before +0 (reversed)
+    r2 = base.clone(); r2[0], r2[1] = -0.0, 0.0          # adjacent reversed
+    r3 = base.clone(); r3[5] = float("inf")              # +inf logit
+    r4 = base.clone(); r4[9] = float("nan")              # NaN logit
+    logits = torch.stack([r0, r1, r2, r3, r4])
+    n = logits.shape[0]
+    for seed in (1, 9, 1234):
+        params = dict(
+            temperature=torch.ones(n, device=device),
+            top_p=torch.full((n,), 0.9, device=device),
+            top_k=torch.full((n,), 8, device=device, dtype=torch.long),
+            seeds=torch.full((n,), seed, device=device, dtype=torch.long),
+            positions=torch.arange(n, device=device, dtype=torch.long),
+        )
+        a = sample_seeded_branchless(logits, **params)
+        b = sample_seeded_fused(logits, **params)
+        assert torch.equal(a, b), f"seed={seed}: {a.tolist()} vs {b.tolist()}"
+
+
+def test_sample_seeded_fused_rejects_complex_top_k() -> None:
+    from sglang_omni.models.moss_tts.sampling_kernels import sample_seeded_fused
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    device = torch.device("cuda")
+    with pytest.raises(TypeError, match="integer"):
+        sample_seeded_fused(
+            torch.randn(2, 64, device=device),
+            temperature=torch.ones(2, device=device),
+            top_p=torch.ones(2, device=device),
+            top_k=torch.full((2,), 8, device=device, dtype=torch.complex64),
+            seeds=torch.zeros(2, device=device, dtype=torch.long),
+            positions=torch.arange(2, device=device, dtype=torch.long),
+        )

--- a/tests/unit_test/moss_tts/test_sampling_kernels.py
+++ b/tests/unit_test/moss_tts/test_sampling_kernels.py
@@ -101,7 +101,14 @@ def test_seeded_gumbel_argmax_rejects_strided_output() -> None:
 
 
 def _fused_case(vocab: int, temp: float, top_p: float, top_k: int, tie: bool):
-    return pytest.param(vocab, temp, top_p, top_k, tie, id=f"v{vocab}-t{temp}-p{top_p}-k{top_k}-{'tied' if tie else 'random'}")
+    return pytest.param(
+        vocab,
+        temp,
+        top_p,
+        top_k,
+        tie,
+        id=f"v{vocab}-t{temp}-p{top_p}-k{top_k}-{'tied' if tie else 'random'}",
+    )
 
 
 @pytest.mark.parametrize(
@@ -163,9 +170,11 @@ def test_sample_seeded_fused_mixed_rows_and_greedy_fallback() -> None:
     device = torch.device("cuda")
     gen = torch.Generator(device=device).manual_seed(7)
     rows, vocab = 8, 1025
-    logits = (torch.randn(rows, vocab, device=device, generator=gen) * 4.0).to(
-        torch.bfloat16
-    ).float()
+    logits = (
+        (torch.randn(rows, vocab, device=device, generator=gen) * 4.0)
+        .to(torch.bfloat16)
+        .float()
+    )
     params = dict(
         temperature=torch.tensor(
             [1.7, 0.0, 1.0, 0.0, 1.2, 1.7, 0.5, 1.0], device=device
@@ -286,7 +295,9 @@ def test_sample_seeded_fused_hash_endpoint() -> None:
         top_k=torch.zeros(1, device=device, dtype=torch.long),
         seeds=torch.zeros(1, device=device, dtype=torch.long),
         # MurmurHash(seed=0, position, token_id=0) == UINT32_MAX here.
-        positions=torch.tensor([_UINT32_MAX_HASH_POSITION], device=device, dtype=torch.long),
+        positions=torch.tensor(
+            [_UINT32_MAX_HASH_POSITION], device=device, dtype=torch.long
+        ),
     )
     a = sample_seeded_branchless(logits, **params)
     b = sample_seeded_fused(logits, **params)
@@ -377,13 +388,17 @@ def test_sample_seeded_fused_signed_zero_orderings_and_nonfinite() -> None:
 
     device = torch.device("cuda")
     vocab = 64
-    rows = []
     base = torch.full((vocab,), -5.0, device=device)
-    r0 = base.clone(); r0[3], r0[7] = 0.0, -0.0          # +0 before -0
-    r1 = base.clone(); r1[3], r1[7] = -0.0, 0.0          # -0 before +0 (reversed)
-    r2 = base.clone(); r2[0], r2[1] = -0.0, 0.0          # adjacent reversed
-    r3 = base.clone(); r3[5] = float("inf")              # +inf logit
-    r4 = base.clone(); r4[9] = float("nan")              # NaN logit
+    r0 = base.clone()
+    r0[3], r0[7] = 0.0, -0.0  # +0 before -0
+    r1 = base.clone()
+    r1[3], r1[7] = -0.0, 0.0  # -0 before +0 (reversed)
+    r2 = base.clone()
+    r2[0], r2[1] = -0.0, 0.0  # adjacent reversed
+    r3 = base.clone()
+    r3[5] = float("inf")  # +inf logit
+    r4 = base.clone()
+    r4[9] = float("nan")  # NaN logit
     logits = torch.stack([r0, r1, r2, r3, r4])
     n = logits.shape[0]
     for seed in (1, 9, 1234):
@@ -442,4 +457,6 @@ def test_sample_seeded_fused_signed_zero_nucleus_boundary() -> None:
             )
             a = sample_seeded_branchless(logits, **params)
             b = sample_seeded_fused(logits, **params)
-            assert torch.equal(a, b), f"order=({first},{second}) seed={seed}: {a.item()} vs {b.item()}"
+            assert torch.equal(
+                a, b
+            ), f"order=({first},{second}) seed={seed}: {a.item()} vs {b.item()}"

--- a/tests/unit_test/moss_tts/test_sampling_kernels.py
+++ b/tests/unit_test/moss_tts/test_sampling_kernels.py
@@ -98,3 +98,107 @@ def test_seeded_gumbel_argmax_rejects_strided_output() -> None:
     assert output.stride(0) == 2
     with pytest.raises(ValueError, match="output must have stride 1"):
         seeded_gumbel_argmax(scores, seeds, positions, output)
+
+
+def _fused_case(vocab: int, temp: float, top_p: float, top_k: int, tie: bool):
+    return pytest.param(vocab, temp, top_p, top_k, tie, id=f"v{vocab}-t{temp}-p{top_p}-k{top_k}-{'tied' if tie else 'random'}")
+
+
+@pytest.mark.parametrize(
+    "vocab,temp,top_p,top_k,tie",
+    [
+        _fused_case(1025, 1.7, 0.8, 25, False),
+        _fused_case(1025, 1.7, 0.8, 25, True),
+        _fused_case(1025, 1.0, 0.9, 64, True),
+        _fused_case(1025, 1.2, 0.5, 1, False),
+        _fused_case(1025, 1.7, 0.001, 25, False),
+        _fused_case(1025, 1.7, 0.999, 25, False),
+        _fused_case(1025, 0.0, 0.8, 25, False),
+        _fused_case(2, 1.0, 1.0, 50, False),
+        _fused_case(2, 1.3, 0.7, 0, False),
+    ],
+)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_sample_seeded_fused_matches_branchless(
+    vocab: int, temp: float, top_p: float, top_k: int, tie: bool
+) -> None:
+    from sglang_omni.models.moss_tts.sampling_kernels import (
+        sample_seeded_branchless,
+        sample_seeded_fused,
+    )
+
+    device = torch.device("cuda")
+    gen = torch.Generator(device=device).manual_seed(20260821)
+    for rows in (1, 4, 16):
+        for _ in range(20):
+            logits = torch.randn(rows, vocab, device=device, generator=gen) * 4.0
+            # Note (Jiaxin Deng): bf16 round-trip manufactures score ties so the
+            # stable-sort tie ordering is exercised, not just clean floats.
+            logits = logits.to(torch.bfloat16).float()
+            if tie:
+                logits = (logits * 4).round() / 4.0
+            params = dict(
+                temperature=torch.full((rows,), temp, device=device),
+                top_p=torch.full((rows,), top_p, device=device),
+                top_k=torch.full((rows,), top_k, device=device, dtype=torch.long),
+                seeds=torch.randint(
+                    0, 2**62, (rows,), device=device, dtype=torch.long, generator=gen
+                ),
+                positions=torch.randint(
+                    0, 10000, (rows,), device=device, dtype=torch.long, generator=gen
+                ),
+            )
+            expected = sample_seeded_branchless(logits, **params)
+            actual = sample_seeded_fused(logits, **params)
+            assert torch.equal(expected, actual)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_sample_seeded_fused_mixed_rows_and_greedy_fallback() -> None:
+    from sglang_omni.models.moss_tts.sampling_kernels import (
+        sample_seeded_branchless,
+        sample_seeded_fused,
+    )
+
+    device = torch.device("cuda")
+    gen = torch.Generator(device=device).manual_seed(7)
+    rows, vocab = 8, 1025
+    logits = (torch.randn(rows, vocab, device=device, generator=gen) * 4.0).to(
+        torch.bfloat16
+    ).float()
+    params = dict(
+        temperature=torch.tensor(
+            [1.7, 0.0, 1.0, 0.0, 1.2, 1.7, 0.5, 1.0], device=device
+        ),
+        top_p=torch.tensor([0.8, 0.8, 1.0, 0.0, 0.5, 0.9, 0.2, 0.7], device=device),
+        top_k=torch.tensor([25, 25, 0, 50, 1, 64, 7, 2000], device=device),
+        seeds=torch.randint(
+            0, 2**62, (rows,), device=device, dtype=torch.long, generator=gen
+        ),
+        positions=torch.arange(rows, device=device, dtype=torch.long),
+    )
+    expected = sample_seeded_branchless(logits, **params)
+    actual = sample_seeded_fused(logits, **params)
+    assert torch.equal(expected, actual)
+
+
+def test_sample_seeded_fused_rejects_large_vocab() -> None:
+    from sglang_omni.models.moss_tts.sampling_kernels import (
+        MAX_FUSED_SAMPLE_VOCAB,
+        sample_seeded_fused,
+    )
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    device = torch.device("cuda")
+    rows = 2
+    vocab = MAX_FUSED_SAMPLE_VOCAB + 1
+    with pytest.raises(ValueError, match="vocab"):
+        sample_seeded_fused(
+            torch.randn(rows, vocab, device=device),
+            temperature=torch.ones(rows, device=device),
+            top_p=torch.ones(rows, device=device),
+            top_k=torch.full((rows,), 25, device=device, dtype=torch.long),
+            seeds=torch.zeros(rows, device=device, dtype=torch.long),
+            positions=torch.arange(rows, device=device, dtype=torch.long),
+        )

--- a/tests/unit_test/moss_tts/test_sampling_kernels.py
+++ b/tests/unit_test/moss_tts/test_sampling_kernels.py
@@ -414,3 +414,32 @@ def test_sample_seeded_fused_rejects_complex_top_k() -> None:
             seeds=torch.zeros(2, device=device, dtype=torch.long),
             positions=torch.arange(2, device=device, dtype=torch.long),
         )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_sample_seeded_fused_signed_zero_nucleus_boundary() -> None:
+    """top_p=0.2 keeps only the FIRST sorted zero, so which of +0.0/-0.0 sorts
+    first decides the nucleus mask; fused must match baseline for both input
+    orders."""
+    from sglang_omni.models.moss_tts.sampling_kernels import (
+        sample_seeded_branchless,
+        sample_seeded_fused,
+    )
+
+    device = torch.device("cuda")
+    vocab = 64
+    for first, second in ((0.0, -0.0), (-0.0, 0.0)):
+        logits = torch.full((1, vocab), -30.0, device=device)
+        logits[0, 11] = first
+        logits[0, 29] = second
+        for seed in range(20):
+            params = dict(
+                temperature=torch.ones(1, device=device),
+                top_p=torch.full((1,), 0.2, device=device),
+                top_k=torch.full((1,), 8, device=device, dtype=torch.long),
+                seeds=torch.full((1,), seed, device=device, dtype=torch.long),
+                positions=torch.full((1,), 3, device=device, dtype=torch.long),
+            )
+            a = sample_seeded_branchless(logits, **params)
+            b = sample_seeded_fused(logits, **params)
+            assert torch.equal(a, b), f"order=({first},{second}) seed={seed}: {a.item()} vs {b.item()}"

--- a/tests/unit_test/moss_tts/test_sampling_kernels.py
+++ b/tests/unit_test/moss_tts/test_sampling_kernels.py
@@ -121,6 +121,11 @@ def _fused_case(vocab: int, temp: float, top_p: float, top_k: int, tie: bool):
         _fused_case(1025, 1.7, 0.001, 25, False),
         _fused_case(1025, 1.7, 0.999, 25, False),
         _fused_case(1025, 0.0, 0.8, 25, False),
+        _fused_case(1024, 1.7, 0.8, 25, False),
+        _fused_case(1024, 1.7, 0.8, 25, True),
+        _fused_case(1024, 1.0, 0.9, 64, True),
+        _fused_case(1024, 1.2, 0.5, 1, False),
+        _fused_case(1024, 0.0, 0.8, 25, False),
         _fused_case(2, 1.0, 1.0, 50, False),
         _fused_case(2, 1.3, 0.7, 0, False),
     ],
@@ -460,3 +465,69 @@ def test_sample_seeded_fused_signed_zero_nucleus_boundary() -> None:
             assert torch.equal(
                 a, b
             ), f"order=({first},{second}) seed={seed}: {a.item()} vs {b.item()}"
+
+
+@pytest.mark.parametrize("temp", [0.0, 1.0], ids=["greedy", "sampled"])
+@pytest.mark.parametrize("kind", ["one_nan", "all_nan", "nan_with_inf"])
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_sample_seeded_fused_nan_rows_match_baseline(temp: float, kind: str) -> None:
+    """A NaN row falls back to torch.argmax in the baseline, which ranks NaN
+    above every number; the fused kernel must land on the same token id and
+    never on the reduction sentinel."""
+    from sglang_omni.models.moss_tts.sampling_kernels import (
+        sample_seeded_branchless,
+        sample_seeded_fused,
+    )
+
+    device = torch.device("cuda")
+    vocab = 64
+    gen = torch.Generator(device=device).manual_seed(20260826)
+    logits = torch.randn(1, vocab, device=device, generator=gen)
+    if kind == "one_nan":
+        logits[0, 11] = float("nan")
+    elif kind == "all_nan":
+        logits[0, :] = float("nan")
+    else:
+        logits[0, 11] = float("nan")
+        logits[0, 3] = float("inf")
+    params = dict(
+        temperature=torch.full((1,), temp, device=device),
+        top_p=torch.full((1,), 0.8, device=device),
+        top_k=torch.full((1,), 25, device=device, dtype=torch.long),
+        seeds=torch.full((1,), 20260826, device=device, dtype=torch.long),
+        positions=torch.full((1,), 5, device=device, dtype=torch.long),
+    )
+    expected = sample_seeded_branchless(logits, **params)
+    actual = sample_seeded_fused(logits, **params)
+
+    assert torch.equal(expected, actual)
+    assert int(actual.item()) == int(torch.argmax(logits, dim=-1).item())
+    assert 0 <= int(actual.item()) < vocab
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_sample_seeded_fused_tied_two_token_head() -> None:
+    """The production stop head is vocab=2, where a nucleus cut keeps a single
+    lane, so the tie order alone decides continue versus stop."""
+    from sglang_omni.models.moss_tts.sampling_kernels import (
+        sample_seeded_branchless,
+        sample_seeded_fused,
+    )
+
+    device = torch.device("cuda")
+    logits = torch.full((1, 2), 2.0, device=device)
+    _, order = torch.sort(logits, descending=True, dim=-1, stable=True)
+    assert order[0].tolist() == [0, 1]
+
+    for seed in range(16):
+        params = dict(
+            temperature=torch.ones(1, device=device),
+            top_p=torch.full((1,), 0.3, device=device),
+            top_k=torch.zeros(1, device=device, dtype=torch.long),
+            seeds=torch.full((1,), seed, device=device, dtype=torch.long),
+            positions=torch.full((1,), 9, device=device, dtype=torch.long),
+        )
+        expected = sample_seeded_branchless(logits, **params)
+        actual = sample_seeded_fused(logits, **params)
+        assert torch.equal(expected, actual), f"seed={seed}"
+        assert int(actual.item()) == 0

--- a/tests/unit_test/moss_tts/test_sampling_kernels.py
+++ b/tests/unit_test/moss_tts/test_sampling_kernels.py
@@ -506,9 +506,13 @@ def test_sample_seeded_fused_nan_rows_match_baseline(temp: float, kind: str) -> 
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
-def test_sample_seeded_fused_tied_two_token_head() -> None:
+def test_tied_two_token_head_agrees_across_sampling_paths() -> None:
     """The production stop head is vocab=2, where a nucleus cut keeps a single
-    lane, so the tie order alone decides continue versus stop."""
+    lane, so the tie order alone decides continue versus stop. All three paths
+    that serve it must agree: the graphed fused kernel, the large-vocab
+    branchless fallback, and the eager `_sample_tokens` path taken when an audio
+    repetition penalty is set or the batch outgrows the frame graph."""
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
     from sglang_omni.models.moss_tts.sampling_kernels import (
         sample_seeded_branchless,
         sample_seeded_fused,
@@ -527,7 +531,9 @@ def test_sample_seeded_fused_tied_two_token_head() -> None:
             seeds=torch.full((1,), seed, device=device, dtype=torch.long),
             positions=torch.full((1,), 9, device=device, dtype=torch.long),
         )
-        expected = sample_seeded_branchless(logits, **params)
-        actual = sample_seeded_fused(logits, **params)
-        assert torch.equal(expected, actual), f"seed={seed}"
-        assert int(actual.item()) == 0
+        fused = sample_seeded_fused(logits, **params)
+        branchless = sample_seeded_branchless(logits, **params)
+        eager = MossTTSModelRunner._sample_tokens(logits, **params).view(-1)
+        assert int(fused.item()) == 0
+        assert torch.equal(fused, branchless), f"branchless seed={seed}"
+        assert torch.equal(fused, eager), f"eager seed={seed}"

--- a/tests/unit_test/moss_tts/test_sampling_kernels.py
+++ b/tests/unit_test/moss_tts/test_sampling_kernels.py
@@ -202,3 +202,138 @@ def test_sample_seeded_fused_rejects_large_vocab() -> None:
             seeds=torch.zeros(rows, device=device, dtype=torch.long),
             positions=torch.arange(rows, device=device, dtype=torch.long),
         )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_sample_seeded_fused_nucleus_knife_edges() -> None:
+    """Away from fp32 knife edges the mask matches bit-for-bit; exactly at a
+    cumulative-probability boundary the kept set may differ by the boundary
+    token only, so the sample must stay inside the top-k prefix."""
+    from sglang_omni.models.moss_tts.sampling_kernels import (
+        sample_seeded_branchless,
+        sample_seeded_fused,
+    )
+
+    device = torch.device("cuda")
+    vocab, k = 1025, 25
+    gen = torch.Generator(device=device).manual_seed(11)
+    logits = (torch.randn(1, vocab, device=device, generator=gen) * 4.0).float()
+    scores = logits.clone()
+    sorted_scores, sorted_idx = torch.sort(scores, descending=True, dim=-1)
+    kth = sorted_scores[0, k - 1]
+    masked = sorted_scores.masked_fill(sorted_scores < kth, float("-inf"))
+    cum = torch.cumsum(torch.softmax(masked, dim=-1), dim=-1)[0]
+    topk_ids = set(sorted_idx[0, :k].tolist())
+
+    for j in (3, 10, 20):
+        edge = float(cum[j].item())
+        for p in (
+            (edge + float(cum[j + 1].item())) / 2.0,  # strictly between edges
+            edge,  # exactly at the boundary
+            float(torch.nextafter(cum[j], cum[j] + 1).item()),
+        ):
+            params = dict(
+                temperature=torch.ones(1, device=device),
+                top_p=torch.full((1,), p, device=device),
+                top_k=torch.full((1,), k, device=device, dtype=torch.long),
+                seeds=torch.full((1,), 42, device=device, dtype=torch.long),
+                positions=torch.full((1,), 7, device=device, dtype=torch.long),
+            )
+            a = sample_seeded_branchless(logits, **params)
+            b = sample_seeded_fused(logits, **params)
+            assert int(b.item()) in topk_ids
+            if p != edge:
+                assert torch.equal(a, b), f"j={j} p={p}"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_sample_seeded_fused_signed_zero_and_nonfinite() -> None:
+    from sglang_omni.models.moss_tts.sampling_kernels import (
+        sample_seeded_branchless,
+        sample_seeded_fused,
+    )
+
+    device = torch.device("cuda")
+    vocab = 64
+    logits = torch.full((3, vocab), -5.0, device=device)
+    logits[0, 3], logits[0, 7] = 0.0, -0.0  # numerically tied signed zeros
+    logits[1, 5] = float("-inf")
+    logits[2, :] = float("-inf")  # fully masked row -> greedy fallback
+    params = dict(
+        temperature=torch.tensor([1.0, 1.0, 1.0], device=device),
+        top_p=torch.tensor([0.9, 0.9, 0.9], device=device),
+        top_k=torch.tensor([8, 8, 8], device=device, dtype=torch.long),
+        seeds=torch.tensor([1, 2, 3], device=device, dtype=torch.long),
+        positions=torch.tensor([0, 1, 2], device=device, dtype=torch.long),
+    )
+    a = sample_seeded_branchless(logits, **params)
+    b = sample_seeded_fused(logits, **params)
+    assert torch.equal(a, b)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_sample_seeded_fused_hash_endpoint() -> None:
+    from sglang_omni.models.moss_tts.sampling_kernels import (
+        sample_seeded_branchless,
+        sample_seeded_fused,
+    )
+
+    device = torch.device("cuda")
+    logits = torch.tensor([[-100.0, 0.0]], device=device)
+    params = dict(
+        temperature=torch.ones(1, device=device),
+        top_p=torch.ones(1, device=device),
+        top_k=torch.zeros(1, device=device, dtype=torch.long),
+        seeds=torch.zeros(1, device=device, dtype=torch.long),
+        # MurmurHash(seed=0, position, token_id=0) == UINT32_MAX here.
+        positions=torch.tensor([_UINT32_MAX_HASH_POSITION], device=device, dtype=torch.long),
+    )
+    a = sample_seeded_branchless(logits, **params)
+    b = sample_seeded_fused(logits, **params)
+    assert torch.equal(a, b)
+    assert a.item() == 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_sample_seeded_fused_input_hardening() -> None:
+    from sglang_omni.models.moss_tts.sampling_kernels import (
+        sample_seeded_branchless,
+        sample_seeded_fused,
+    )
+
+    device = torch.device("cuda")
+    empty = sample_seeded_fused(
+        torch.empty(0, 1025, device=device),
+        temperature=torch.empty(0, device=device),
+        top_p=torch.empty(0, device=device),
+        top_k=torch.empty(0, device=device, dtype=torch.long),
+        seeds=torch.empty(0, device=device, dtype=torch.long),
+        positions=torch.empty(0, device=device, dtype=torch.long),
+    )
+    assert empty.shape == (0,) and empty.dtype == torch.int64
+
+    with pytest.raises(TypeError, match="integer"):
+        sample_seeded_fused(
+            torch.randn(2, 64, device=device),
+            temperature=torch.ones(2, device=device),
+            top_p=torch.ones(2, device=device),
+            top_k=torch.full((2,), 8.0, device=device),
+            seeds=torch.zeros(2, device=device, dtype=torch.long),
+            positions=torch.arange(2, device=device, dtype=torch.long),
+        )
+
+    gen = torch.Generator(device=device).manual_seed(5)
+    logits = torch.randn(4, 1025, device=device, generator=gen)
+    strided = torch.zeros(8, device=device, dtype=torch.long)[::2] + 25
+    contig = dict(
+        temperature=torch.full((4,), 1.7, device=device),
+        top_p=torch.full((4,), 0.8, device=device),
+        top_k=torch.full((4,), 25, device=device, dtype=torch.long),
+        seeds=torch.arange(4, device=device, dtype=torch.long),
+        positions=torch.arange(4, device=device, dtype=torch.long),
+    )
+    a = sample_seeded_fused(logits, **contig)
+    b = sample_seeded_fused(logits, **{**contig, "top_k": strided})
+    c = sample_seeded_branchless(logits, **contig)
+    assert torch.equal(a, b)
+    assert torch.equal(a, c)


### PR DESCRIPTION
## Motivation

MOSS-TTS-Local samples 13 heads per generated frame (1 stop head at vocab 2 plus 12 codebook heads at vocab 1024, the checkpoint's `audio_vocab_size`; the embedding table carries a 1025th pad row that the head weight slices off). Each call runs `sample_seeded_branchless`: a full-vocabulary descending sort, two softmaxes, a cumsum, a scatter, and the seeded Gumbel draw, about 14 kernels per call and ~180 sampler kernels per frame. In a 12 s c=16 serving profile the sampling block is ~13.5% of per-frame GPU time (1.3-1.5 ms per frame under CUDA graph replay), with `radixSortKVInPlace` alone at 3.9% of total GPU time.

## Modifications

* Add `sample_seeded_fused` to `sglang_omni/models/moss_tts/sampling_kernels.py`: one Triton program per row performs temperature scaling, a stable descending sort (scores packed above a complemented index so equal scores keep input order exactly like the stable radix sort `torch.sort` uses; signed zeros canonicalize to +0.0 first so numerically equal zeros share one key), the top-k threshold, nucleus removal via exclusive cumsum, and the exact `multinomial_with_seed` hash and fp64 Gumbel math, including the NaN-first and greedy-fallback semantics.
* Route the MOSS-TTS-Local frame sampler through it for vocab <= 2048; larger vocabularies keep a lazily compiled branchless path. `MOSS_LOCAL_FUSED_FRAME_SAMPLER=0` restores the previous behavior.
* Give every path the same tie order: `sample_seeded_branchless` and `MossTTSModelRunner._apply_top_p` now sort stable, which is the order the fused key already keeps. `_run_frame_decode` takes the eager `_sample_tokens` path when an audio repetition penalty is set or the batch outgrows the frame graph, and on the `vocab=2` stop head an unstable sort resolved a tie the other way, which under nucleus sampling is continue versus stop inside one server.
* Cross-module note: the kernel lives in the shared `moss_tts` package next to the existing sampling kernels. `sample_seeded_branchless` is imported only by `moss_tts_local`, but `_apply_top_p` is shared with MOSS-TTS delay, whose graphed and eager paths both call it; delay stays self consistent either way and only gains a defined tie order.

## Accuracy Test

* Contract: numerically equivalent to the previous sampler, not bit identical by construction. The tie order, the greedy and NaN fallbacks, and the seeded draw are exact; the in-kernel softmax and cumsum reduce in a different order than aten, so at an exact nucleus boundary the kept set may differ by the boundary token.
* 13,950 randomized draws across the parity grid come out bit for bit equal to the previous sampler: the contract above allows divergence only at an exact nucleus boundary, and no randomized draw landed on one.
* Tied `vocab=2` stop head at `top_p=0.3`: fused, branchless and eager `_sample_tokens` agree over 16 seeds. The test fails without the stable-sort change, where the eager path selects the other token.
* NaN parity: `torch.argmax` semantics reproduced for one NaN, all NaN, and NaN mixed with +inf, at temperature 0 and 1. Without the fallback fix an all-NaN greedy row returns the reduction sentinel, which is not a valid token id.
* Same-seed end-to-end check: 6 fixed-seed `/v1/audio/speech` requests produce byte-identical WAVs (equal sha256) on the fused and baseline servers.
* Constructed edge tests: nucleus knife edges (bit-equal strictly between cumulative boundaries), signed zeros in both input orders at a discriminating nucleus boundary, nonfinite rows, the UINT32_MAX hash endpoint (including a top-k-masked lane, where the fused kernel reproduces the baseline's NaN-first selection exactly), strided/empty/typed inputs.
* `tests/unit_test/moss_tts/test_sampling_kernels.py`: 35 passed on H200; the `moss_tts` suite is 208 passed and `moss_tts_local` plus `model_runner` plus `scheduling` is 506 passed.
* The nucleus-boundary divergence above is what the knife edge test encodes: equality strictly between cumulative boundaries, top-k membership at the boundary itself. No divergence was observed in any randomized, constructed, or end-to-end comparison.
* SeedTTS EN corpus WER on saved c=16 audio (64 samples per arm, two rounds each): fused 0.996% / 0.996%, base 1.138% / 1.422%.

## Benchmark & Profiling

Sampler block, production frame pattern (1x[bs,2] + 12x[bs,1024], the checkpoint's audio head width), CUDA events, 5-round median, H200:

| bs | mode | base (us) | fused (us) | speedup |
|---:|---|---:|---:|---:|
| 1 | graph replay | 3447.7 | 167.8 | 20.55x |
| 8 | graph replay | 1394.3 | 169.8 | 8.21x |
| 16 | graph replay | 1475.5 | 169.8 | 8.69x |
| 1-16 | eager | 6790-7046 | ~501 | ~13.9x |

At `vocab=1025` the fused kernel takes `BLOCK=2048` and lands at 565-568 us instead, so the same rows read 6.37x / 2.55x / 2.64x. That is the power-of-two boundary stress case; the production audio head is 1024 wide.

End to end, `benchmark_tts_seedtts --generate-only --stream`, SeedTTS EN 48 samples per cell, warmed rounds 1-3 means (rounds 4-5 confirm):

| conc | metric | base | fused | change |
|---:|---|---:|---:|---:|
| 1 | qps | 1.2717 | 1.3153 | +3.4% |
| 1 | RTF mean | 0.1899 | 0.1834 | -3.5% |
| 8 | qps | 6.251 | 6.444 | +3.1% |
| 8 | RTF mean | 0.2875 | 0.2773 | -3.6% |
| 16 | qps | 7.583 | 8.024 | +5.8% |
| 16 | RTF mean | 0.4484 | 0.4239 | -5.5% |
| 16 | TTFA median (s) | 0.7556 | 0.6964 | -7.8% |

Across 5 server-restart rounds x 3 concurrencies the fused arm wins all 15 paired qps comparisons (margins +0.1% to +10.6%; no independence assumption or p-value claimed). A symmetric cold-start pair (fresh server, c16 measured first) also favors fused: 6.553 vs 6.377 qps (+2.8%). An independent c1 raw-request experiment reproduced -5.9% time per audio byte across 3 further ABAB rounds. One extra confirmation round taken under heavy co-tenant host load (33-38 vs 20-25 during the matrix) was discarded as contaminated and its raw data retained.

E2E numbers predate the review fixes and still stand: both arms were re-measured at the current head in one clean window. The fused arm costs +1.5 to +1.7 us per frame pattern (+0.3% of the sampler block, about +0.02% of per-frame GPU time) from the NaN and fallback branches, and the stable sort costs nothing on the baseline arm (base column identical to the digit; bare `torch.sort` is +0.0% at [16, 1024] and faster at [16, 2], both launch bound). Six fixed-seed `/v1/audio/speech` requests are byte identical across the review fixes, so serving output is unchanged. Rebased onto #1636 (touches the audio tokenizer, not this path); the full unit suite passes at the rebased head.

## Reproduction

```bash
MOSS_LOCAL_FUSED_FRAME_SAMPLER={1|0} sgl-omni serve \
  --model-path OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5 --port 8640
python -m benchmarks.eval.benchmark_tts_seedtts --generate-only --use-existing-server --stream \
  --model OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5 --port 8640 --ref-format references \
  --token-count auto --max-concurrency {1|8|16} --lang en --max-samples 48 --output-dir out
python -m pytest tests/unit_test/moss_tts/test_sampling_kernels.py -q
```


