### PR TITLE
[Perf] Enable AR overlap schedule for Fun-CosyVoice3

### DIFF
--- a/sglang_omni/models/fun_cosyvoice3/engine_builder.py
+++ b/sglang_omni/models/fun_cosyvoice3/engine_builder.py
@@ -52,7 +52,7 @@ class FunCosyVoice3EngineBuilder(TtsEngineBuilder):
             "torch_compile_max_bs": 32,
             "dtype": dtype,
             "disable_cuda_graph": False,
-            "disable_overlap_schedule": True,
+            "disable_overlap_schedule": False,
             "enable_torch_compile": False,
             "mem_fraction_static": 0.85,
             "max_prefill_tokens": 4096,


### PR DESCRIPTION
Enable SGLang overlap scheduling for the Fun-CosyVoice3 AR stage (`disable_overlap_schedule: True -> False` in `FunCosyVoice3EngineBuilder.generation_defaults`). Not listed among the AR tasks in #1652 (which covers decode CUDA-graph, torch.compile, streaming), but `FunCosyVoice3ModelRunner` collects output codes per request (`sched_req.data.output_codes`), so the stage is overlap-safe.

## Reproduce

```
sgl-omni serve \
  --model-path FunAudioLLM/Fun-CosyVoice3-0.5B-2512 \
  --config examples/configs/fun_cosyvoice3_0_5b.yaml \
  --talker-mem-fraction-static 0.6 \
  --port 8000
```

Overlap-on = this change; overlap-off = same command with `disable_overlap_schedule` reverted to `True`. Timing via `POST /start_request_profile` -> one warm request -> `POST /stop_request_profile` (per-stage JSONL events). RTF is pipeline-internal with ref cached; a raw curl wall is higher due to per-request ref re-download (mutable HTTP URL), unrelated to overlap.

## Measured (RTX 5070, sm_120, bf16, decode cuda graph on)

158-token utterance, single warm request:

| stage | overlap off | overlap on | |
|---|---|---|---|
| AR decode | 806 ms | 572 ms | **-29%** |
| AR (prefill + decode) | 955.7 ms | 716.5 ms | -25% |
| vocoder | 513.8 ms | 482.7 ms | ~unchanged |
| pipeline RTF | 0.233 | **0.190** | -18% |

Per-step AR decode: 5.10 -> 3.62 ms/token.

## Correctness

- Greedy (`temperature=0`) output bit-identical to the overlap-disabled baseline (same frame count + SHA256) -> forward/sampling path unchanged.
- 4 concurrent requests produce correct, distinct audio.
- Stochastic (`temperature>0`) diverges ~1/8 samples — benign batch-level RNG-order variance, not a regression.

Refs #1652.