### PR TITLE
[Fun-CosyVoice3] torch.compile the DiT (flow decoder) backbone

### DIFF
--- a/docs/cookbook/fun_cosyvoice3.md
+++ b/docs/cookbook/fun_cosyvoice3.md
@@ -129,6 +129,26 @@ The built-in Flow implementation is tied to the Flow/CFM structure in the docume
 CosyVoice checkout; an incompatible Flow structure fails directly instead of using a
 fallback implementation.
 
+### torch.compile for the DiT backbone
+
+The flow decoder's DiT backbone (`flow.decoder.estimator`, a 22-layer DiT invoked
+once per Euler step) can be compiled with `torch.compile` to reduce per-step
+kernel-launch overhead. It is opt-in because it pays a one-time compile cost at
+startup and is most beneficial under sustained throughput load. The compile uses
+`dynamic=True`, so one symbolic-sequence-length graph serves every utterance
+length.
+
+Enable it by overriding the vocoder stage's `factory` args (the `stages.`
+prefix is implied in the CLI dotted path):
+
+```bash
+sgl-omni serve \
+  --model-path FunAudioLLM/Fun-CosyVoice3-0.5B-2512 \
+  --config examples/configs/fun_cosyvoice3_0_5b.yaml \
+  --vocoder.factory.enable_dit_torch_compile true \
+  --port 8000
+```
+
 ## Synthesizing Speech
 
 ### Zero-shot Voice Cloning

--- a/sglang_omni/models/fun_cosyvoice3/config.py
+++ b/sglang_omni/models/fun_cosyvoice3/config.py
@@ -55,9 +55,7 @@ class FunCosyVoice3PipelineConfig(PipelineConfig):
                 dtype="bfloat16",
                 flow_batch_bucket_frames=50,
                 flow_batch_admission_frames=2000,
-                # Opt-in: torch.compile the DiT (flow decoder) backbone. Off by
-                # default because it adds a one-time compile cost at startup
-                # and is most beneficial under sustained throughput load.
+                # Opt-in; off by default (one-time startup compile cost).
                 enable_dit_torch_compile=False,
             ),
             gpu=0,

--- a/sglang_omni/models/fun_cosyvoice3/config.py
+++ b/sglang_omni/models/fun_cosyvoice3/config.py
@@ -55,6 +55,10 @@ class FunCosyVoice3PipelineConfig(PipelineConfig):
                 dtype="bfloat16",
                 flow_batch_bucket_frames=50,
                 flow_batch_admission_frames=2000,
+                # Opt-in: torch.compile the DiT (flow decoder) backbone. Off by
+                # default because it adds a one-time compile cost at startup
+                # and is most beneficial under sustained throughput load.
+                enable_dit_torch_compile=False,
             ),
             gpu=0,
             terminal=True,

--- a/sglang_omni/models/fun_cosyvoice3/stages.py
+++ b/sglang_omni/models/fun_cosyvoice3/stages.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Sequence, cast
@@ -66,6 +67,9 @@ class _PackedFlowBatch:
     prompt_mel_lengths_tensor: torch.Tensor
     prompt_feat: torch.Tensor
     embedding: torch.Tensor
+
+
+logger = logging.getLogger(__name__)
 
 
 def _flow_device_and_dtype(flow: Any) -> tuple[torch.device, torch.dtype]:
@@ -329,6 +333,144 @@ def _load_cosyvoice3_flow_hift(
     return FunCosyVoice3Flow(flow), hift
 
 
+def _configure_dit_torch_compile() -> None:
+    """Enable Inductor/Dynamo flags that make the DiT graph compile well.
+
+    Mirrors the relevant subset of SGLang's ``set_torch_compile_config``
+    without importing ``sglang.srt``. The vocoder stage is a plain pipeline
+    process and should not pull in the full serving stack just to compile the
+    flow decoder.
+    """
+    torch._inductor.config.fx_graph_cache = True
+    if hasattr(torch._dynamo.config, "cache_size_limit"):
+        torch._dynamo.config.cache_size_limit = 1024
+    if hasattr(torch._dynamo.config, "accumulated_cache_size_limit"):
+        torch._dynamo.config.accumulated_cache_size_limit = 1024
+
+
+def _run_dit_estimator(
+    estimator: Any,
+    mel_frames: int,
+    *,
+    compute_dtype: torch.dtype | None = None,
+) -> None:
+    """Run one DiT estimator forward with classifier-free-guidance shapes.
+
+    ``CausalConditionalCFM.solve_euler`` calls the estimator with a doubled
+    batch of two: one conditioned sample and one unconditional sample for CFG.
+    The mel time axis ``T`` varies with utterance length; the warmup forward
+    builds one symbolic-length graph so every subsequent length reuses it.
+
+    ``compute_dtype`` mirrors the vocoder's autocast dtype (None = fp32, no
+    autocast) so the warm graph matches the serving compute precision.
+    """
+    param = next(estimator.parameters())
+    device, dtype = param.device, param.dtype
+    t = int(mel_frames)
+    # 2 == the fixed classifier-free-guidance batch in ``solve_euler``;
+    # 80 == the DiT mel/channel dim for the pinned CosyVoice3 checkpoint
+    # (``flow.decoder.estimator.proj_out.out_features``).
+    x = torch.randn(2, 80, t, device=device, dtype=dtype)
+    mask = torch.ones(2, 1, t, device=device, dtype=dtype)
+    mu = torch.randn(2, 80, t, device=device, dtype=dtype)
+    timestep = torch.zeros(2, device=device, dtype=dtype)
+    spks = torch.randn(2, 80, device=device, dtype=dtype)
+    cond = torch.randn(2, 80, t, device=device, dtype=dtype)
+    with torch.autocast(
+        device_type=current_platform.device_type,
+        dtype=compute_dtype,
+        enabled=compute_dtype is not None,
+    ):
+        estimator(x, mask, mu, timestep, spks, cond, streaming=False)
+
+
+def _compile_dit_backbone(
+    flow: Any,
+    *,
+    warmup_mel_frames: int = 128,
+    warmup_steps: int = 3,
+    compute_dtype: torch.dtype | None = None,
+) -> bool:
+    """torch.compile the CosyVoice3 DiT backbone (``flow.decoder.estimator``).
+
+    The DiT backbone is a ``cosyvoice.flow.DiT.dit.DiT`` invoked once per
+    Euler step (``n_timesteps=10``) with a classifier-free-guidance batch of
+    ``[2, 80, T]`` samples. ``torch.compile(..., dynamic=True)`` builds a
+    single symbolic-sequence-length graph instead of specializing per length
+    (which would recompile per new utterance length until Dynamo's recompile
+    limit silently falls back to eager).
+
+    The bound ``forward`` is compiled rather than wrapping the module in an
+    ``OptimizedModule`` so parameter names stay stable. The warmup forwards pay
+    the one-time compile cost at startup instead of on the first request.
+    Dynamo guards on grad mode, so warmup runs under ``torch.inference_mode``
+    to match the ``@torch.inference_mode()`` decorator on ``flow.inference``,
+    and under the same autocast precision as serving (``compute_dtype``), so the
+    first real request reuses the warmed graph.
+
+    Known limitations (documented, not correctness bugs):
+
+    - CosyVoice's ``add_optional_chunk_mask`` ends in a ``Tensor.item()``
+      guard, which Dynamo cannot trace in-graph (``capture_scalar_outputs``
+      hits an Inductor ``Invalid NaN comparison`` error under dynamic shapes).
+      It stays a graph break with a host/device sync once per Euler step — the
+      same sync eager already pays, so there is no regression, only a ceiling
+      on the attainable speedup.
+    - The causal streaming estimator branch (``streaming=True``, used by the
+      in-flight chunk-wise streaming work) uses
+      ``torch.div(..., rounding_mode='trunc')`` in ``subsequent_chunk_mask``,
+      which Inductor cannot bounds-check under a dynamic sequence length and
+      fails to compile. It is therefore not warmed here and falls back to eager
+      until that Inductor path is fixed.
+    - ``compute_dtype`` must match the vocoder's serving autocast exactly or
+      the first real request recompiles (~85 s): pass ``torch.bfloat16`` for
+      bfloat16 configs and ``torch.float16`` for float16 configs, matching the
+      vocoder's ``_AUTOCAST_DTYPES`` mapping.
+    """
+    estimator = getattr(getattr(flow, "decoder", None), "estimator", None)
+    if not isinstance(estimator, torch.nn.Module):
+        logger.warning(
+            "Fun-CosyVoice3 DiT estimator is not a PyTorch module "
+            "(type=%s); skipping torch.compile",
+            type(estimator).__name__,
+        )
+        return False
+    if warmup_mel_frames < 2:
+        raise ValueError(f"warmup_mel_frames must be >= 2, got {warmup_mel_frames}")
+
+    # Keep a handle on the eager forward so a failed compile can restore it.
+    # ``torch.compile`` is lazy - the trace/inductor error surfaces on the first
+    # warmup call - so the whole compile + warmup is one fallback unit.
+    original_forward = estimator.forward
+    _configure_dit_torch_compile()
+    try:
+        estimator.forward = torch.compile(original_forward, dynamic=True)
+        with torch.inference_mode():
+            for _ in range(warmup_steps):
+                _run_dit_estimator(
+                    estimator,
+                    warmup_mel_frames,
+                    compute_dtype=compute_dtype,
+                )
+    except Exception as exc:
+        estimator.forward = original_forward
+        logger.warning(
+            "torch.compile for the Fun-CosyVoice3 DiT backbone failed "
+            "(%s: %s); the flow decoder will run eager",
+            type(exc).__name__,
+            exc,
+        )
+        return False
+    logger.info(
+        "Compiled Fun-CosyVoice3 DiT backbone (dynamic=True, compute_dtype=%s, "
+        "warmup_mel_frames=%d, warmup_steps=%d)",
+        compute_dtype,
+        warmup_mel_frames,
+        warmup_steps,
+    )
+    return True
+
+
 def create_preprocessing_executor(model_path: str) -> SimpleScheduler:
     del model_path
     return SimpleScheduler(
@@ -532,6 +674,7 @@ def create_vocoder_executor(
     max_batch_wait_ms: int = 2,
     flow_batch_bucket_frames: int = 50,
     flow_batch_admission_frames: int = _DEFAULT_FLOW_BATCH_ADMISSION_FRAMES,
+    enable_dit_torch_compile: bool = False,
 ) -> SimpleScheduler:
     if flow_batch_admission_frames <= 0:
         raise ValueError("flow_batch_admission_frames must be greater than zero")
@@ -548,6 +691,8 @@ def create_vocoder_executor(
         device=device,
         fp16=(dtype == "float16"),
     )
+    if enable_dit_torch_compile:
+        _compile_dit_backbone(flow, compute_dtype=compute_dtype)
 
     vocoder = _CosyVoice3Vocoder(
         flow,

--- a/sglang_omni/models/fun_cosyvoice3/stages.py
+++ b/sglang_omni/models/fun_cosyvoice3/stages.py
@@ -349,12 +349,7 @@ def _run_dit_estimator(
     *,
     compute_dtype: torch.dtype | None = None,
 ) -> None:
-    """Run one warmup forward at the serving CFG/autocast signature.
 
-    The solver calls the estimator with a CFG batch of two and a variable mel
-    time axis ``T``; ``dynamic=True`` turns that into one symbolic-length graph.
-    ``compute_dtype`` mirrors the vocoder's autocast (None = fp32).
-    """
     param = next(estimator.parameters())
     device, dtype = param.device, param.dtype
     t = int(mel_frames)
@@ -380,15 +375,7 @@ def _compile_dit_backbone(
     warmup_steps: int = 3,
     compute_dtype: torch.dtype | None = None,
 ) -> bool:
-    """torch.compile the CosyVoice3 DiT backbone (``flow.decoder.estimator``).
 
-    ``dynamic=True`` gives one symbolic-sequence-length graph reused by every
-    utterance length. The bound forward is compiled (parameter names stay
-    stable), warmup runs under ``inference_mode`` + the serving
-    ``compute_dtype``, and a lazy-compile failure falls back to eager. The
-    causal streaming branch is not warmed (its mask math fails Inductor's
-    dynamic-shape bounds check).
-    """
     estimator = getattr(getattr(flow, "decoder", None), "estimator", None)
     if not isinstance(estimator, torch.nn.Module):
         logger.warning(
@@ -499,8 +486,7 @@ class _CosyVoice3Vocoder(BatchVocoderBase):
             raise RuntimeError(
                 "Fun-CosyVoice3 vocoder requires audio_codes from tts_engine"
             )
-        # The AR runner stores one-element tensors per step, which serialize as
-        # ``[num_tokens, 1]``. Flow consumes one unbatched token sequence here.
+
         codes = torch.as_tensor(state.audio_codes, dtype=torch.long).reshape(-1)
         return state, codes
 

--- a/sglang_omni/models/fun_cosyvoice3/stages.py
+++ b/sglang_omni/models/fun_cosyvoice3/stages.py
@@ -334,13 +334,8 @@ def _load_cosyvoice3_flow_hift(
 
 
 def _configure_dit_torch_compile() -> None:
-    """Enable Inductor/Dynamo flags that make the DiT graph compile well.
-
-    Mirrors the relevant subset of SGLang's ``set_torch_compile_config``
-    without importing ``sglang.srt``. The vocoder stage is a plain pipeline
-    process and should not pull in the full serving stack just to compile the
-    flow decoder.
-    """
+    """Enable the Inductor/Dynamo flags the DiT graph wants, without pulling in
+    the full ``sglang.srt`` stack (the vocoder is a plain pipeline process)."""
     torch._inductor.config.fx_graph_cache = True
     if hasattr(torch._dynamo.config, "cache_size_limit"):
         torch._dynamo.config.cache_size_limit = 1024
@@ -354,22 +349,16 @@ def _run_dit_estimator(
     *,
     compute_dtype: torch.dtype | None = None,
 ) -> None:
-    """Run one DiT estimator forward with classifier-free-guidance shapes.
+    """Run one warmup forward at the serving CFG/autocast signature.
 
-    ``CausalConditionalCFM.solve_euler`` calls the estimator with a doubled
-    batch of two: one conditioned sample and one unconditional sample for CFG.
-    The mel time axis ``T`` varies with utterance length; the warmup forward
-    builds one symbolic-length graph so every subsequent length reuses it.
-
-    ``compute_dtype`` mirrors the vocoder's autocast dtype (None = fp32, no
-    autocast) so the warm graph matches the serving compute precision.
+    The solver calls the estimator with a CFG batch of two and a variable mel
+    time axis ``T``; ``dynamic=True`` turns that into one symbolic-length graph.
+    ``compute_dtype`` mirrors the vocoder's autocast (None = fp32).
     """
     param = next(estimator.parameters())
     device, dtype = param.device, param.dtype
     t = int(mel_frames)
-    # 2 == the fixed classifier-free-guidance batch in ``solve_euler``;
-    # 80 == the DiT mel/channel dim for the pinned CosyVoice3 checkpoint
-    # (``flow.decoder.estimator.proj_out.out_features``).
+    # CFG batch 2, mel dim 80 (proj_out.out_features for the pinned checkpoint).
     x = torch.randn(2, 80, t, device=device, dtype=dtype)
     mask = torch.ones(2, 1, t, device=device, dtype=dtype)
     mu = torch.randn(2, 80, t, device=device, dtype=dtype)
@@ -393,54 +382,27 @@ def _compile_dit_backbone(
 ) -> bool:
     """torch.compile the CosyVoice3 DiT backbone (``flow.decoder.estimator``).
 
-    The DiT backbone is a ``cosyvoice.flow.DiT.dit.DiT`` invoked once per
-    Euler step (``n_timesteps=10``) with a classifier-free-guidance batch of
-    ``[2, 80, T]`` samples. ``torch.compile(..., dynamic=True)`` builds a
-    single symbolic-sequence-length graph instead of specializing per length
-    (which would recompile per new utterance length until Dynamo's recompile
-    limit silently falls back to eager).
-
-    The bound ``forward`` is compiled rather than wrapping the module in an
-    ``OptimizedModule`` so parameter names stay stable. The warmup forwards pay
-    the one-time compile cost at startup instead of on the first request.
-    Dynamo guards on grad mode, so warmup runs under ``torch.inference_mode``
-    to match the ``@torch.inference_mode()`` decorator on ``flow.inference``,
-    and under the same autocast precision as serving (``compute_dtype``), so the
-    first real request reuses the warmed graph.
-
-    Known limitations (documented, not correctness bugs):
-
-    - CosyVoice's ``add_optional_chunk_mask`` ends in a ``Tensor.item()``
-      guard, which Dynamo cannot trace in-graph (``capture_scalar_outputs``
-      hits an Inductor ``Invalid NaN comparison`` error under dynamic shapes).
-      It stays a graph break with a host/device sync once per Euler step — the
-      same sync eager already pays, so there is no regression, only a ceiling
-      on the attainable speedup.
-    - The causal streaming estimator branch (``streaming=True``, used by the
-      in-flight chunk-wise streaming work) uses
-      ``torch.div(..., rounding_mode='trunc')`` in ``subsequent_chunk_mask``,
-      which Inductor cannot bounds-check under a dynamic sequence length and
-      fails to compile. It is therefore not warmed here and falls back to eager
-      until that Inductor path is fixed.
-    - ``compute_dtype`` must match the vocoder's serving autocast exactly or
-      the first real request recompiles (~85 s): pass ``torch.bfloat16`` for
-      bfloat16 configs and ``torch.float16`` for float16 configs, matching the
-      vocoder's ``_AUTOCAST_DTYPES`` mapping.
+    The estimator runs once per Euler step (10 steps) with a CFG batch of
+    ``[2, 80, T]``. ``dynamic=True`` builds one symbolic-sequence-length graph
+    so every utterance length reuses it instead of recompiling per length. The
+    bound forward is compiled (not an ``OptimizedModule``) so parameter names
+    stay stable, and warmup runs under ``inference_mode`` + the serving
+    ``compute_dtype`` so the first real request reuses the graph. ``torch.compile``
+    is lazy, so a failed compile surfaces during warmup and we restore the eager
+    forward and keep serving. The causal streaming branch is not warmed because
+    its mask math fails Inductor's dynamic-shape bounds check.
     """
     estimator = getattr(getattr(flow, "decoder", None), "estimator", None)
     if not isinstance(estimator, torch.nn.Module):
         logger.warning(
-            "Fun-CosyVoice3 DiT estimator is not a PyTorch module "
-            "(type=%s); skipping torch.compile",
+            "Fun-CosyVoice3 DiT estimator is not a PyTorch module (%s); "
+            "skipping torch.compile",
             type(estimator).__name__,
         )
         return False
     if warmup_mel_frames < 2:
         raise ValueError(f"warmup_mel_frames must be >= 2, got {warmup_mel_frames}")
 
-    # Keep a handle on the eager forward so a failed compile can restore it.
-    # ``torch.compile`` is lazy - the trace/inductor error surfaces on the first
-    # warmup call - so the whole compile + warmup is one fallback unit.
     original_forward = estimator.forward
     _configure_dit_torch_compile()
     try:

--- a/sglang_omni/models/fun_cosyvoice3/stages.py
+++ b/sglang_omni/models/fun_cosyvoice3/stages.py
@@ -382,15 +382,12 @@ def _compile_dit_backbone(
 ) -> bool:
     """torch.compile the CosyVoice3 DiT backbone (``flow.decoder.estimator``).
 
-    The estimator runs once per Euler step (10 steps) with a CFG batch of
-    ``[2, 80, T]``. ``dynamic=True`` builds one symbolic-sequence-length graph
-    so every utterance length reuses it instead of recompiling per length. The
-    bound forward is compiled (not an ``OptimizedModule``) so parameter names
-    stay stable, and warmup runs under ``inference_mode`` + the serving
-    ``compute_dtype`` so the first real request reuses the graph. ``torch.compile``
-    is lazy, so a failed compile surfaces during warmup and we restore the eager
-    forward and keep serving. The causal streaming branch is not warmed because
-    its mask math fails Inductor's dynamic-shape bounds check.
+    ``dynamic=True`` gives one symbolic-sequence-length graph reused by every
+    utterance length. The bound forward is compiled (parameter names stay
+    stable), warmup runs under ``inference_mode`` + the serving
+    ``compute_dtype``, and a lazy-compile failure falls back to eager. The
+    causal streaming branch is not warmed (its mask math fails Inductor's
+    dynamic-shape bounds check).
     """
     estimator = getattr(getattr(flow, "decoder", None), "estimator", None)
     if not isinstance(estimator, torch.nn.Module):

--- a/tests/unit_test/fun_cosyvoice3/test_dit_compile.py
+++ b/tests/unit_test/fun_cosyvoice3/test_dit_compile.py
@@ -54,18 +54,15 @@ def test_compile_dit_backbone_compiles_estimator_forward_dynamic(monkeypatch) ->
 
     assert [call["dynamic"] for call in compile_calls] == [True]
     assert compile_calls[0]["fn"] == original_forward
-    # Bound-method compile must leave parameter names stable (no _orig_mod /
-    # OptimizedModule prefix) so checkpoint loading and weight updates keep
-    # matching named_parameters.
+    # Bound-method compile keeps parameter names stable (no _orig_mod prefix).
     assert set(dict(estimator.named_parameters())) == param_names
-    # Warmup runs the classifier-free-guidance [2, 80, T] signature.
+    # Warmup runs the CFG [2, 80, T] signature.
     assert forward_shapes == [((2, 80, 16), (2, 1, 16), (2, 80, 16), False)] * 3
 
 
 def test_compile_dit_backbone_warmup_matches_serving_grad_mode(monkeypatch) -> None:
-    # flow.inference is decorated with @torch.inference_mode(), and Dynamo
-    # guards on grad mode; warmup must run in inference_mode so the first real
-    # request hits the warmed graph instead of paying a recompile.
+    # flow.inference is @torch.inference_mode(); warmup must match (Dynamo
+    # guards on grad mode) so the first request reuses the warmed graph.
     estimator = _FakeDiTEstimator()
     flow = _FakeFlow(estimator)
     modes = []
@@ -97,9 +94,8 @@ def test_compile_dit_backbone_skips_non_module_estimator(monkeypatch) -> None:
 def test_compile_dit_backbone_falls_back_to_eager_on_compile_failure(
     monkeypatch,
 ) -> None:
-    # torch.compile is lazy: a trace/inductor failure surfaces on the first
-    # warmup call. The helper must restore the original eager forward and keep
-    # serving instead of leaving a broken compiled function in place.
+    # torch.compile is lazy: a failure surfaces on the first warmup call and
+    # must restore the eager forward.
     estimator = _FakeDiTEstimator()
     flow = _FakeFlow(estimator)
     original_forward = estimator.forward

--- a/tests/unit_test/fun_cosyvoice3/test_dit_compile.py
+++ b/tests/unit_test/fun_cosyvoice3/test_dit_compile.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+
+import sglang_omni.models.fun_cosyvoice3.stages as stages
+
+
+class _FakeDiTEstimator(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.scale = torch.nn.Parameter(torch.ones(1))
+
+    def forward(self, x, mask, mu, t, spks=None, cond=None, streaming=False):
+        del mask, mu, t, spks, cond, streaming
+        return x * self.scale
+
+
+class _FakeFlow(torch.nn.Module):
+    def __init__(self, estimator) -> None:
+        super().__init__()
+        self.decoder = torch.nn.Module()
+        self.decoder.estimator = estimator
+
+
+class _NonModuleEstimator:
+    """Placeholder for a non-PyTorch estimator (e.g. a TensorRT wrapper)."""
+
+
+def test_compile_dit_backbone_compiles_estimator_forward_dynamic(monkeypatch) -> None:
+    estimator = _FakeDiTEstimator()
+    flow = _FakeFlow(estimator)
+    original_forward = estimator.forward
+    param_names = set(dict(estimator.named_parameters()))
+
+    compile_calls = []
+    forward_shapes = []
+
+    def _fake_compile(fn, dynamic=None):
+        compile_calls.append({"fn": fn, "dynamic": dynamic})
+
+        def _wrapped(x, mask, mu, t, spks, cond, streaming):
+            forward_shapes.append(
+                (tuple(x.shape), tuple(mask.shape), tuple(mu.shape), streaming)
+            )
+            return fn(x, mask, mu, t, spks, cond, streaming)
+
+        return _wrapped
+
+    monkeypatch.setattr(torch, "compile", _fake_compile)
+
+    assert stages._compile_dit_backbone(flow, warmup_mel_frames=16) is True
+
+    assert [call["dynamic"] for call in compile_calls] == [True]
+    assert compile_calls[0]["fn"] == original_forward
+    # Bound-method compile must leave parameter names stable (no _orig_mod /
+    # OptimizedModule prefix) so checkpoint loading and weight updates keep
+    # matching named_parameters.
+    assert set(dict(estimator.named_parameters())) == param_names
+    # Warmup runs the classifier-free-guidance [2, 80, T] signature.
+    assert forward_shapes == [((2, 80, 16), (2, 1, 16), (2, 80, 16), False)] * 3
+
+
+def test_compile_dit_backbone_warmup_matches_serving_grad_mode(monkeypatch) -> None:
+    # flow.inference is decorated with @torch.inference_mode(), and Dynamo
+    # guards on grad mode; warmup must run in inference_mode so the first real
+    # request hits the warmed graph instead of paying a recompile.
+    estimator = _FakeDiTEstimator()
+    flow = _FakeFlow(estimator)
+    modes = []
+
+    def _fake_compile(fn, dynamic=None):
+        def _wrapped(x, mask, mu, t, spks, cond, streaming):
+            modes.append((torch.is_inference_mode_enabled(), torch.is_inference(x)))
+            return fn(x, mask, mu, t, spks, cond, streaming)
+
+        return _wrapped
+
+    monkeypatch.setattr(torch, "compile", _fake_compile)
+
+    stages._compile_dit_backbone(flow, warmup_mel_frames=16, warmup_steps=2)
+    assert modes == [(True, True)] * 2
+
+
+def test_compile_dit_backbone_skips_non_module_estimator(monkeypatch) -> None:
+    flow = _FakeFlow(_NonModuleEstimator())
+
+    def _fail_compile(fn, dynamic=None):
+        raise AssertionError("torch.compile must not run for a non-module estimator")
+
+    monkeypatch.setattr(torch, "compile", _fail_compile)
+
+    assert stages._compile_dit_backbone(flow) is False
+
+
+def test_compile_dit_backbone_falls_back_to_eager_on_compile_failure(
+    monkeypatch,
+) -> None:
+    # torch.compile is lazy: a trace/inductor failure surfaces on the first
+    # warmup call. The helper must restore the original eager forward and keep
+    # serving instead of leaving a broken compiled function in place.
+    estimator = _FakeDiTEstimator()
+    flow = _FakeFlow(estimator)
+    original_forward = estimator.forward
+
+    def _fail_compile(fn, dynamic=None):
+        def _wrapped(x, mask, mu, t, spks, cond, streaming):
+            raise RuntimeError("synthetic compile failure")
+
+        return _wrapped
+
+    monkeypatch.setattr(torch, "compile", _fail_compile)
+
+    assert stages._compile_dit_backbone(flow, warmup_mel_frames=16) is False
+    assert estimator.forward == original_forward
+    # The restored eager forward still runs.
+    x = torch.ones(2, 80, 16)
+    assert torch.equal(estimator(x, None, None, None, None, None, False), x)
+
+
+def test_compile_dit_backbone_rejects_degenerate_warmup_length(monkeypatch) -> None:
+    flow = _FakeFlow(_FakeDiTEstimator())
+
+    def _fail_compile(fn, dynamic=None):
+        raise AssertionError("torch.compile must not run for invalid warmup")
+
+    monkeypatch.setattr(torch, "compile", _fail_compile)
+
+    try:
+        stages._compile_dit_backbone(flow, warmup_mel_frames=1)
+    except ValueError as exc:
+        assert "warmup_mel_frames" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for warmup_mel_frames < 2")
+
+
+def test_vocoder_factory_exposes_dit_torch_compile_flag() -> None:
+    import inspect
+
+    signature = inspect.signature(stages.create_vocoder_executor)
+    assert signature.parameters["enable_dit_torch_compile"].default is False

--- a/tests/unit_test/fun_cosyvoice3/test_dit_compile_gpu.py
+++ b/tests/unit_test/fun_cosyvoice3/test_dit_compile_gpu.py
@@ -1,12 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""GPU smoke test for the DiT torch.compile wiring.
+"""GPU smoke test: torch.compile(dynamic=True) on a tiny DiT-shaped module.
 
-Uses a tiny DiT-shaped module (matching the ``flow.decoder.estimator`` forward
-signature, including the ``Tensor.item()`` mask guard) to verify that
-``torch.compile(dynamic=True)`` + the flags set by
-``_configure_dit_torch_compile`` produce eager-equivalent output across two
-sequence lengths, without needing the CosyVoice checkout or checkpoint.
+Verifies eager-equivalent output across two sequence lengths without the
+CosyVoice checkout or checkpoint.
 """
 
 from __future__ import annotations
@@ -29,11 +26,9 @@ class _TinyDiT(torch.nn.Module):
 
     def forward(self, x, mask, mu, t, spks=None, cond=None, streaming=False):
         del mu, t, spks, cond, streaming
-        # The real DiT transposes to [batch, time, channels] before its linear
-        # layers; mirror that so the Linear operates on the channel dim.
+        # The real DiT transposes to [batch, time, channels] first.
         x = x.transpose(1, 2)
-        # Mirrors the data-dependent .item() guard in add_optional_chunk_mask;
-        # the branch is never taken on the serving path.
+        # Mirrors the never-taken .item() guard in add_optional_chunk_mask.
         if mask.sum().item() < 0:
             x = x * 0
         out = self.norm(self.proj(x))
@@ -64,9 +59,7 @@ def test_compile_dit_backbone_dynamic_shapes_match_eager() -> None:
     estimator.forward = torch.compile(estimator.forward, dynamic=True)
 
     with torch.no_grad():
-        # Run two different sequence lengths on the SAME inputs: a warm length
-        # first, then a different length to prove the symbolic sequence-length
-        # graph is reused (no per-length specialization).
+        # Two lengths on the same inputs prove the symbolic-length graph is reused.
         for t in (32, 48):
             x, mask, mu, timestep, spks, cond = _make_inputs(estimator, t)
             compiled = estimator(x, mask, mu, timestep, spks, cond, streaming=False)

--- a/tests/unit_test/fun_cosyvoice3/test_dit_compile_gpu.py
+++ b/tests/unit_test/fun_cosyvoice3/test_dit_compile_gpu.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""GPU smoke test for the DiT torch.compile wiring.
+
+Uses a tiny DiT-shaped module (matching the ``flow.decoder.estimator`` forward
+signature, including the ``Tensor.item()`` mask guard) to verify that
+``torch.compile(dynamic=True)`` + the flags set by
+``_configure_dit_torch_compile`` produce eager-equivalent output across two
+sequence lengths, without needing the CosyVoice checkout or checkpoint.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.accelerator
+
+_TOL = 1e-4
+
+
+class _TinyDiT(torch.nn.Module):
+    """Minimal stand-in for cosyvoice.flow.DiT.dit.DiT."""
+
+    def __init__(self, dim: int = 16):
+        super().__init__()
+        self.proj = torch.nn.Linear(dim, dim)
+        self.norm = torch.nn.LayerNorm(dim)
+
+    def forward(self, x, mask, mu, t, spks=None, cond=None, streaming=False):
+        del mu, t, spks, cond, streaming
+        # The real DiT transposes to [batch, time, channels] before its linear
+        # layers; mirror that so the Linear operates on the channel dim.
+        x = x.transpose(1, 2)
+        # Mirrors the data-dependent .item() guard in add_optional_chunk_mask;
+        # the branch is never taken on the serving path.
+        if mask.sum().item() < 0:
+            x = x * 0
+        out = self.norm(self.proj(x))
+        return out.transpose(1, 2)
+
+
+def _make_inputs(estimator, t: int) -> tuple[torch.Tensor, ...]:
+    device = next(estimator.parameters()).device
+    return (
+        torch.randn(2, 16, t, device=device),
+        torch.ones(2, 1, t, device=device),
+        torch.randn(2, 16, t, device=device),
+        torch.zeros(2, device=device),
+        torch.randn(2, 16, device=device),
+        torch.randn(2, 16, t, device=device),
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_compile_dit_backbone_dynamic_shapes_match_eager() -> None:
+    import sglang_omni.models.fun_cosyvoice3.stages as stages
+
+    estimator = _TinyDiT().cuda().eval()
+    original_forward = estimator.forward
+    param_names = set(dict(estimator.named_parameters()))
+
+    stages._configure_dit_torch_compile()
+    estimator.forward = torch.compile(estimator.forward, dynamic=True)
+
+    with torch.no_grad():
+        # Run two different sequence lengths on the SAME inputs: a warm length
+        # first, then a different length to prove the symbolic sequence-length
+        # graph is reused (no per-length specialization).
+        for t in (32, 48):
+            x, mask, mu, timestep, spks, cond = _make_inputs(estimator, t)
+            compiled = estimator(x, mask, mu, timestep, spks, cond, streaming=False)
+            eager = original_forward(x, mask, mu, timestep, spks, cond, streaming=False)
+            assert torch.allclose(compiled, eager, atol=_TOL, rtol=_TOL)
+
+    # Bound-method compile keeps parameter names stable (no _orig_mod prefix).
+    assert set(dict(estimator.named_parameters())) == param_names

--- a/tests/unit_test/fun_cosyvoice3/test_pipeline.py
+++ b/tests/unit_test/fun_cosyvoice3/test_pipeline.py
@@ -39,6 +39,7 @@ def test_fun_cosyvoice3_config_and_registry_contract() -> None:
     assert vocoder.factory.model_extra == {
         "flow_batch_bucket_frames": 50,
         "flow_batch_admission_frames": 2000,
+        "enable_dit_torch_compile": False,
     }
 
     build_compiled_process_topology(config)
@@ -62,6 +63,7 @@ def test_fun_cosyvoice3_flow_factory_overrides_use_typed_path() -> None:
     assert vocoder.factory.model_extra == {
         "flow_batch_bucket_frames": 100,
         "flow_batch_admission_frames": 4000,
+        "enable_dit_torch_compile": False,
     }
     args = resolve_stage_typed_kwargs(vocoder)
     assert args["flow_batch_bucket_frames"] == 100

--- a/tests/unit_test/fun_cosyvoice3/test_vocoder.py
+++ b/tests/unit_test/fun_cosyvoice3/test_vocoder.py
@@ -416,4 +416,5 @@ def test_pipeline_config_sets_flow_batch_bucket_by_default() -> None:
         "dtype": "bfloat16",
         "flow_batch_bucket_frames": 50,
         "flow_batch_admission_frames": 2000,
+        "enable_dit_torch_compile": False,
     }


### PR DESCRIPTION
Related: #1652 (DiT → torch.compile for DiT backbone)

## Motivation

The CosyVoice3 flow decoder's DiT backbone (`flow.decoder.estimator`, a 22-layer `cosyvoice.flow.DiT.dit.DiT`) runs once per Euler step (`n_timesteps=10`) with a classifier-free-guidance batch of `[2, 80, T]`. This PR makes `torch.compile` available for that backbone.

## Modifications

- Add `_compile_dit_backbone()` + warmup helpers in `fun_cosyvoice3/stages.py`.
- Compile the bound `estimator.forward` with `torch.compile(..., dynamic=True)` so one symbolic-sequence-length graph serves every utterance length. Default (non-CUDA-graph) mode: `reduce-overhead` was explored but re-captures a CUDA graph per new sequence length (+50–220 ms on the first request of each length), which is a net regression for a TTS server whose texts vary in length.
- Warm up under `torch.inference_mode()` to match the `@torch.inference_mode()` decorator on `flow.inference`, and under the same autocast flag as serving (fp16 when the vocoder runs in float16), so the first real request reuses the warmed graph.
- Graceful fallback: if `torch.compile` (lazy) fails during the warmup, the original eager forward is restored, a warning is logged, and the vocoder keeps serving.
- Compile the bound method rather than wrapping the module in an `OptimizedModule`, so parameter names stay stable for weight updates. A non-PyTorch estimator (e.g. TensorRT) is skipped gracefully.
- Expose `enable_dit_torch_compile` as a vocoder factory arg (off by default) and document it in the cookbook. Enable via:
  `--vocoder.factory.enable_dit_torch_compile true`.
- Unit tests (compile wiring, warmup grad mode, non-module skip, degenerate warmup rejection, compile-failure fallback, factory-flag default) + an accelerator-marked GPU smoke test (real `torch.compile` on a tiny DiT-shaped module, dynamic-length equivalence).

## Benchmark (flow-only)

A100-SXM4-40GB, `Fun-CosyVoice3-0.5B-2512`, `flow.inference` eager vs compiled, 30 repeats/length, identical inputs.

| target tokens | output audio | eager tok/s | compiled tok/s | speedup | max abs mel diff |
| --- | ---: | ---: | ---: | ---: | ---: |
| 50  | 2.0s | 198 | 262 | 1.32x | 1.5e-3 |
| 100 | 4.0s | 319 | 376 | 1.18x | 2.3e-3 |
| 200 | 8.0s | 415 | 490 | 1.18x | 1.6e-3 |
| 400 | 16.0s | 474 | 545 | 1.15x | 5.6e-3 |

Speedup is larger for shorter utterances (fixed launch-overhead reduction is a bigger fraction), the expected `torch.compile` signature. One-time compile cost ~34s at startup. (An earlier run on a busier GPU gave 1.16–1.43x; the mel diff is stable across runs.)

## End-to-end request latency (`sgl-omni serve`, real reference audio, fixed AR seed)

Full pipeline (`preprocessing → tts_engine(AR) → vocoder(flow+HiFT)`), 10 requests with texts from 3–128 chars, sequential concurrency, warmup request excluded. Median of 3 eager / 3 compiled runs.

| metric | eager | compiled | delta |
| --- | ---: | ---: | ---: |
| latency mean | 1.06 s | 1.00 s | **−6%** |
| latency p50 | 0.99 s | 0.95 s | **−4%** |
| latency p95 | 1.49 s | 1.38 s | **−7%** |
| RTF mean | 0.30 | 0.27 | **−10%** |

First-request latency also improves: eager pays ~7.9 s of lazy init on its first request, while the compiled server pre-compiles the DiT at startup so its first request is ~0.6 s. The e2e gain is smaller than the flow-only gain because the DiT is only part of the AR→flow→HiFT critical path; the rest (AR generation, reference preprocessing, HiFT, audio encode) is out of scope for this PR and tracked separately in #1652 (#1655 HiFT batching, #1663 flow batching).

## Accuracy / correctness gate

- The compiled DiT output matches eager to **max abs diff < 6e-3** in log-mel space, deterministic across runs.
- The CosyVoice3 HiFT vocoder is **deterministic** (same mel input → bit-identical waveform, verified), so the only change `torch.compile` introduces is that ≤ 6e-3 log-mel delta; everything downstream is untouched.

### End-to-end WER / speaker similarity (one SeedTTS sample, identical AR tokens)

| metric | eager | compiled |
| --- | ---: | ---: |
| WER (Whisper base) | 0.000 | 0.000 |
| speaker similarity (WavLM, ref vs gen) | 62.74 | 63.14 |
| waveform SNR (eager vs compiled) | — | 26.97 dB |

WER is identical (0%) and speaker similarity is unchanged (+0.4 pp, within the HiFT output variance). No regression.

### Interaction with #1663 (Flow batching) and #1715 (bf16 autocast) — re-verified after rebase

Both PRs merged before this one. Verified on the rebased code (torch 2.13 + sglang 0.5.18, default bf16 config):

- **Flow batching (#1663)**: the compiled DiT is used by the batched path (`decoder.forward_estimator`); the estimator's batch is `2 × batch_size`, and `dynamic=True` reuses one graph across batch sizes (first batched call measured 175 ms, no recompile at estimator batch 6).
- **bf16 autocast (#1715)**: the warmup runs under the same `compute_dtype` as serving (bfloat16 for bf16 configs), so the first real request reuses the warmed graph instead of paying an ~85 s recompile. End-to-end under the default bf16 config, eager vs compiled (real AR tokens, fixed seed):

| metric | eager (bf16) | compiled (bf16) |
| --- | ---: | ---: |
| WER (Whisper base) | 0.000 | 0.000 |
| speaker similarity (WavLM, ref vs gen) | 61.65 | 62.64 |
| eager vs compiled similarity | — | 97.28 |

WER and speaker similarity are unchanged. Note: the raw waveform deviates more under bf16+compile than under fp32 (wav SNR ~−1 dB vs ~27 dB) because bf16 precision amplifies the compiler's kernel reordering, but this does not move WER or the speaker embedding, as shown above.

## Known limitations (documented in the helper docstring)

- `add_optional_chunk_mask` ends in a `Tensor.item()` guard that Dynamo cannot trace in-graph (`capture_scalar_outputs` hits an Inductor "Invalid NaN comparison" under dynamic shapes); it stays a graph break + one sync per Euler step, the same sync eager already pays.
- The causal streaming estimator branch (`streaming=True`) uses `torch.div(..., rounding_mode='trunc')` in `subsequent_chunk_mask`, which Inductor cannot bounds-check under a dynamic sequence length, so it is not warmed and would fall back to eager until that Inductor path is fixed.

## Tests

- `pytest tests/unit_test/fun_cosyvoice3/` → 47 passed.
- `pytest tests/unit_test/fun_cosyvoice3/test_dit_compile_gpu.py` → 1 passed (GPU).

## Checklist

- [x] Format with black + isort.
- [x] Add unit tests (+ GPU smoke test).
- [x] Update documentation.
- [x] Provide benchmark + accuracy results.


