### PR TITLE
[CI]: Keep model selector guidance in sync

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,7 +33,9 @@
 CI runs on self-hosted GPU runners and requires a maintainer to add the
 `run-ci` label. Once labeled, every subsequent push re-triggers CI as
 long as the label remains. Use `/tag-and-rerun-ci higgs` or
-`/tag-and-rerun-ci moss` to select a TTS CI model, and
+`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
+model, and
 `/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
-`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from each family can be combined, for example
-`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
+`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
+each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
+Draft PRs are skipped even if labeled.

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -62,11 +62,8 @@ def parse_model_targets(tokens):
 
     asr_targets = [token for token in tokens[1:] if token in ASR_MODEL_LABELS]
     if len(set(asr_targets)) > 1:
-        return (
-            None,
-            None,
-            "Specify only one ASR CI model target: fun-asr, qwen3-asr or whisper-asr.",
-        )
+        allowed = ", ".join(sorted(ASR_MODEL_LABELS))
+        return None, None, f"Specify only one ASR CI model target: {allowed}."
     return (
         tts_targets[0] if tts_targets else None,
         asr_targets[0] if asr_targets else None,


### PR DESCRIPTION
## Summary

- Generate the ASR selector conflict message from `ASR_MODEL_LABELS` so it stays synchronized when presets change.
- Document the existing `qwen3-tts` selector alongside the other `/tag-and-rerun-ci` model selectors.
