### PR TITLE
[feat] make code2wav chunk sizes configurable

### DIFF
--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -28,7 +28,10 @@ from sglang_omni.profiler.event_recorder import get_recorder as _get_event_recor
 from sglang_omni.profiler.event_recorder import get_recorder as _get_recorder
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.messages import OutgoingMessage
-from sglang_omni.scheduling.streaming_vocoder import StreamingVocoderBase
+from sglang_omni.scheduling.streaming_vocoder import (
+    StreamingVocoderBase,
+    resolve_initial_codec_chunk_frames,
+)
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 from sglang_omni.utils.device import resolve_device_spec
 
@@ -138,6 +141,7 @@ class Code2WavStreamState:
     due_since: float | None = None
     checked: int = 0
     pending: _PendingWindow | None = None
+    initial_chunk_frames: int | None = None
 
 
 class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
@@ -236,10 +240,29 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         origin: str,
     ) -> None:
         del request_id
+        if origin == "payload":
+            self._latch_initial_chunk_frames(state, source.request.params)
+            return
         if origin != "stream metadata":
             return
         if state.stream_enabled is None:
             state.stream_enabled = bool(source["stream"])
+
+    def _latch_initial_chunk_frames(
+        self, state: Code2WavStreamState, params: Mapping[str, Any] | None
+    ) -> None:
+        if state.initial_chunk_frames is not None:
+            return
+        state.initial_chunk_frames = resolve_initial_codec_chunk_frames(
+            params if isinstance(params, Mapping) else None,
+            steady_chunk_frames=self._stream_chunk_size,
+            default_frames=self._initial_codec_chunk_frames,
+        )
+
+    def _initial_frames(self, state: Code2WavStreamState) -> int:
+        if state.initial_chunk_frames is None:
+            return self._initial_codec_chunk_frames
+        return state.initial_chunk_frames
 
     def validate_chunk(
         self, request_id: str, state: Code2WavStreamState, codes: torch.Tensor
@@ -262,15 +285,21 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
 
     def should_decode(self, state: Code2WavStreamState, *, is_final: bool) -> bool:
         del is_final
+        threshold = self._decode_threshold(state)
         if (
             self._eos_lazy_scan
             and state.checked < len(state.chunks)
-            and self._ready(state) >= self._stream_chunk_size
+            and self._ready(state) >= threshold
         ):
             # Note (edwardzh): scan before gating — a staged EOS would
             # inflate the count and fire a short window, missing the graph key.
             self._scan_unchecked(state)
-        return self._ready(state) >= self._stream_chunk_size
+        return self._ready(state) >= threshold
+
+    def _decode_threshold(self, state: Code2WavStreamState) -> int:
+        if state.emitted == 0:
+            return self._initial_frames(state) or self._stream_chunk_size
+        return self._stream_chunk_size
 
     def _scan_unchecked(self, state: Code2WavStreamState) -> None:
         """Batched EOS scan over frames staged by the lazy-ingest path.
@@ -698,8 +727,9 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         """New frames the next step consumes; capped at one chunk so a backlog
         cannot push the window outside the captured key set."""
         ready = self._ready(state)
-        if state.emitted == 0 and self._initial_codec_chunk_frames:
-            ready = min(ready, self._initial_codec_chunk_frames)
+        initial_frames = self._initial_frames(state)
+        if state.emitted == 0 and initial_frames:
+            ready = min(ready, initial_frames)
         if self._chunk_aligned_dispatch:
             return min(ready, self._stream_chunk_size)
         return ready
@@ -779,9 +809,7 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         due: dict[tuple[int, int], list[tuple[str, Code2WavStreamState]]] = {}
         for rid, state in self._stream_state_items():
             ready = self._ready(state)
-            if state.emitted == 0 and ready >= (
-                self._initial_codec_chunk_frames or self._stream_chunk_size
-            ):
+            if state.emitted == 0 and ready >= self._decode_threshold(state):
                 first_ready.append((rid, state))
                 continue
             if state.emitted > 0 and ready >= self._stream_chunk_size:

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -235,6 +235,9 @@ def _code2wav_stage(*, gpu: int, process: str) -> StageConfig:
         factory_args={
             "device": None,
             "enable_cuda_graph": current_platform.enable_code2wav_graph(),
+            "stream_chunk_size": 10,
+            "left_context_size": 25,
+            "initial_codec_chunk_frames": 0,
         },
         gpu=gpu,
         runtime=StageRuntimeConfig(

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -932,3 +932,126 @@ def test_qwen_code2wav_emits_full_chunk_despite_model_output_deficit() -> None:
     assert second_audio.shape == (4,)
 
     assert first_audio.shape[0] + second_audio.shape[0] == 4 * 2 - 1
+
+
+def _make_initial_chunk_scheduler(
+    model: FakeCode2WavModel,
+    *,
+    stream_chunk_size: int = 3,
+    left_context_size: int = 5,
+    initial_codec_chunk_frames: int = 2,
+) -> Code2WavScheduler:
+    return Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=stream_chunk_size,
+        left_context_size=left_context_size,
+        initial_codec_chunk_frames=initial_codec_chunk_frames,
+        sample_rate=24000,
+    )
+
+
+def test_initial_chunk_flushes_early_and_hands_whole_chunk_to_the_seam() -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    scheduler = _make_initial_chunk_scheduler(model)
+    scheduler._stream_payloads["req-1"] = make_qwen_payload(request_id="req-1")
+
+    _feed(scheduler, "req-1", (1, 2), stream=True)
+    state = scheduler._stream_states["req-1"]
+    assert model.calls == [(1, 2, 2)]
+    assert state.emitted == 2
+
+    _feed(scheduler, "req-1", (3, 4, 5), stream=True)
+    assert model.calls[-1] == (1, 2, 5)
+    assert state.emitted == 5
+
+    _feed(scheduler, "req-1", (6, 7, 8), stream=True)
+    assert model.calls[-1] == (1, 2, 8)
+    assert state.emitted == 8
+
+
+def test_initial_chunk_frames_request_override_drives_the_first_window() -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    scheduler = _make_initial_chunk_scheduler(model, initial_codec_chunk_frames=0)
+    payload = make_qwen_payload(
+        request_id="req-1", params={"initial_codec_chunk_frames": 1}
+    )
+    scheduler._stream_payloads["req-1"] = payload
+    scheduler.on_streaming_new_request("req-1", payload)
+
+    state = scheduler._stream_states["req-1"]
+    assert state.initial_chunk_frames == 1
+
+    _feed(scheduler, "req-1", (1,), stream=True)
+    assert model.calls == [(1, 2, 1)]
+    assert state.emitted == 1
+
+
+def test_initial_chunk_frames_without_override_keeps_the_stage_default() -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    scheduler = _make_initial_chunk_scheduler(model, initial_codec_chunk_frames=2)
+    payload = make_qwen_payload(request_id="req-1")
+    scheduler._stream_payloads["req-1"] = payload
+    scheduler.on_streaming_new_request("req-1", payload)
+
+    assert scheduler._stream_states["req-1"].initial_chunk_frames == 2
+
+
+def test_initial_chunk_frames_override_is_clamped_to_the_steady_chunk() -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    scheduler = _make_initial_chunk_scheduler(model, stream_chunk_size=3)
+    payload = make_qwen_payload(
+        request_id="req-1", params={"initial_codec_chunk_frames": 99}
+    )
+    scheduler._stream_payloads["req-1"] = payload
+    scheduler.on_streaming_new_request("req-1", payload)
+
+    assert scheduler._stream_states["req-1"].initial_chunk_frames == 3
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_error"),
+    [(-1, ValueError), ("two", TypeError)],
+)
+def test_initial_chunk_frames_override_rejects_invalid_values(
+    value, expected_error
+) -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    scheduler = _make_initial_chunk_scheduler(model)
+    payload = make_qwen_payload(
+        request_id="req-1", params={"initial_codec_chunk_frames": value}
+    )
+    scheduler._stream_payloads["req-1"] = payload
+
+    with pytest.raises(expected_error):
+        scheduler.on_streaming_new_request("req-1", payload)
+
+
+def test_initial_chunk_frames_latch_is_immutable() -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    scheduler = _make_initial_chunk_scheduler(model, initial_codec_chunk_frames=0)
+    first = make_qwen_payload(
+        request_id="req-1", params={"initial_codec_chunk_frames": 1}
+    )
+    scheduler._stream_payloads["req-1"] = first
+    scheduler.on_streaming_new_request("req-1", first)
+    state = scheduler._stream_states["req-1"]
+
+    relatch = make_qwen_payload(
+        request_id="req-1", params={"initial_codec_chunk_frames": 3}
+    )
+    scheduler.latch_stream_contract("req-1", state, relatch, origin="payload")
+
+    assert state.initial_chunk_frames == 1
+
+
+def test_initial_chunk_frames_unlatched_state_uses_the_stage_default() -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    scheduler = _make_initial_chunk_scheduler(model, initial_codec_chunk_frames=2)
+    state = scheduler.create_stream_state("req-1")
+
+    assert state.initial_chunk_frames is None
+    assert scheduler._initial_frames(state) == 2
+    assert scheduler._decode_threshold(state) == 2
+    state.emitted = 2
+    assert scheduler._decode_threshold(state) == 3

--- a/tests/unit_test/qwen3_omni/test_code2wav_batching.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_batching.py
@@ -21,7 +21,7 @@ from sglang_omni.models.qwen3_omni.components.code2wav_scheduler import (
 )
 from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.scheduling.messages import IncomingMessage
-from tests.unit_test.fixtures.qwen_fakes import FakeCode2WavModel
+from tests.unit_test.fixtures.qwen_fakes import FakeCode2WavModel, make_qwen_payload
 
 
 class _FakeGraphRunner:
@@ -992,3 +992,18 @@ def test_next_message_keeps_steady_chunks_in_fifo_order() -> None:
     assert scheduler._next_message() is None
     assert batches == [2]
     assert scheduler._stream_states["req-a"].emitted == 4
+
+
+def test_initial_codec_chunk_frames_request_override_fires_first_window_early() -> None:
+    scheduler = _make_batching_scheduler(max_batch_wait_ms=0, batch_floor=2)
+    payload = make_qwen_payload(
+        request_id="req-1", params={"initial_codec_chunk_frames": 1}
+    )
+    scheduler._stream_payloads["req-1"] = payload
+    scheduler.on_streaming_new_request("req-1", payload)
+
+    _feed_batch(scheduler, [("req-1", 1)])
+
+    assert [m.type for m in _drain_outbox(scheduler)] == ["stream"]
+    assert scheduler._model.calls == [(1, 2, 1)]
+    assert scheduler._stream_states["req-1"].emitted == 1

--- a/tests/unit_test/qwen3_omni/test_colocation_config.py
+++ b/tests/unit_test/qwen3_omni/test_colocation_config.py
@@ -58,6 +58,9 @@ def test_default_speech_topology_stays_disaggregated() -> None:
         code2wav_args["enable_cuda_graph"] is current_platform.enable_code2wav_graph()
     )
     assert code2wav_args["total_gpu_memory_fraction"] == pytest.approx(0.02)
+    assert code2wav_args["stream_chunk_size"] == 10
+    assert code2wav_args["left_context_size"] == 25
+    assert code2wav_args["initial_codec_chunk_frames"] == 0
     assert "enable_batching" not in code2wav.factory_args
     assert "max_batch_wait_ms" not in code2wav.factory_args
     assert "batch_floor" not in code2wav.factory_args


### PR DESCRIPTION
…nk 0 early

#1237 added the code2wav initial_codec_chunk_frames knob and the batching first-window gate, but the value was unreachable: the stage config passes only device/enable_cuda_graph, and the per-request override helper every other streaming vocoder uses was never wired up. The serial accumulate gate also still waited for the full steady chunk, so a configured initial size only shrank the first window instead of emitting it earlier.

- expose stream_chunk_size / left_context_size / initial_codec_chunk_frames through the code2wav stage factory_args, defaulting to the current scheduler values (no behavior change)
- latch a per-request initial_codec_chunk_frames override via the shared resolve_initial_codec_chunk_frames helper, clamped to the steady chunk size and immutable once latched
- honor the resolved value in the accumulate gate, the batching first-window gate and the window sizing, so chunk 0 flushes as soon as the initial frames are ready
- cover the chunk-0/1 seam (chunk 1 keeps the whole initial chunk as its left context), the override, clamping, invalid values, latch immutability and the unlatched fallback

Part of #1148.

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
