### PR TITLE
fix(s2pro): stop streaming crossfade from deleting audio at every seam

### DIFF
--- a/sglang_omni/models/fishaudio_s2_pro/streaming_vocoder.py
+++ b/sglang_omni/models/fishaudio_s2_pro/streaming_vocoder.py
@@ -162,7 +162,8 @@ def _build_stream_vocoder_chunk(
     if stream_crossfade_samples > 0:
         delta_audio = _apply_stream_crossfade(
             state,
-            delta_audio,
+            audio_tensor,
+            overlap_samples=overlap_samples,
             stream_crossfade_samples=stream_crossfade_samples,
             is_final=is_final,
         )
@@ -189,17 +190,19 @@ def _build_stream_vocoder_chunk(
 
 def _apply_stream_crossfade(
     state: _StreamVocoderState,
-    delta_audio: torch.Tensor,
+    audio_tensor: torch.Tensor,
     *,
+    overlap_samples: int,
     stream_crossfade_samples: int,
     is_final: bool,
 ) -> torch.Tensor | None:
+    delta_audio = audio_tensor[overlap_samples:]
     pending_tail = state.pending_tail
     if pending_tail is not None and pending_tail.numel() > 0:
         crossfade = min(
             int(stream_crossfade_samples),
             int(pending_tail.shape[-1]),
-            int(delta_audio.shape[-1]),
+            int(overlap_samples),
         )
         if crossfade > 0:
             fade_in = torch.linspace(
@@ -210,12 +213,9 @@ def _apply_stream_crossfade(
                 device=delta_audio.device,
             )
             fade_out = 1.0 - fade_in
-            blended = (
-                pending_tail[-crossfade:] * fade_out + delta_audio[:crossfade] * fade_in
-            )
-            delta_audio = torch.cat(
-                [pending_tail[:-crossfade], blended, delta_audio[crossfade:]]
-            )
+            refreshed = audio_tensor[overlap_samples - crossfade : overlap_samples]
+            blended = pending_tail[-crossfade:] * fade_out + refreshed * fade_in
+            delta_audio = torch.cat([pending_tail[:-crossfade], blended, delta_audio])
         else:
             delta_audio = torch.cat([pending_tail, delta_audio])
 

--- a/tests/unit_test/fishaudio_s2_pro/test_streaming_vocoder.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_streaming_vocoder.py
@@ -207,20 +207,56 @@ def test_streaming_vocoder_sample_level_matches_contextual_full_decode() -> None
 
 def test_streaming_vocoder_crossfade_blends_tail_and_retains_next_tail() -> None:
     state = _StreamVocoderState(
-        pending_tail=torch.tensor([10.0, 20.0, 30.0]),
+        pending_tail=torch.tensor([10.0, 20.0]),
     )
-    delta_audio = torch.tensor([100.0, 200.0, 300.0, 400.0])
+    audio_tensor = torch.tensor([100.0, 200.0, 300.0, 400.0, 500.0, 600.0])
 
     output = _apply_stream_crossfade(
         state,
-        delta_audio,
+        audio_tensor,
+        overlap_samples=2,
         stream_crossfade_samples=2,
         is_final=False,
     )
 
     assert output is not None
-    torch.testing.assert_close(output, torch.tensor([10.0, 20.0, 200.0]))
-    torch.testing.assert_close(state.pending_tail, torch.tensor([300.0, 400.0]))
+    torch.testing.assert_close(output, torch.tensor([10.0, 200.0, 300.0, 400.0]))
+    torch.testing.assert_close(state.pending_tail, torch.tensor([500.0, 600.0]))
+
+
+@pytest.mark.parametrize("stream_overlap_tokens", [0, 1])
+def test_streaming_vocoder_crossfade_preserves_new_content_across_seams(
+    stream_overlap_tokens: int,
+) -> None:
+    codec = _FakeCodec()
+    state = _StreamVocoderState()
+    outputs = []
+
+    for value in range(4):
+        output = build_stream_vocoder_chunk(
+            state,
+            torch.full((11, 2), value, dtype=torch.long),
+            codec=codec,
+            device=torch.device("cpu"),
+            stream_stride=2,
+            stream_followup_stride=2,
+            stream_overlap_tokens=stream_overlap_tokens,
+            stream_crossfade_samples=2,
+        )
+        assert output is not None
+        outputs.append(output)
+
+    flush = flush_stream_vocoder_chunk(
+        state,
+        codec=codec,
+        device=torch.device("cpu"),
+        stream_overlap_tokens=stream_overlap_tokens,
+        stream_crossfade_samples=2,
+    )
+
+    assert flush is not None
+    outputs.append(flush)
+    assert sum(_audio_len(output) for output in outputs) == 32
 
 
 def test_streaming_vocoder_zero_overlap_final_flush_emits_retained_tail() -> None:


### PR DESCRIPTION
## Motivation

`S2ProVocoderScheduler` decodes an overlap window and trims the already-delivered span before crossfading. The existing crossfade then blends the held tail with the first samples of the new content. Those spans are adjacent in time, so every seam folds `2c` samples into `c` and shortens the delivered timeline by `c = stream_crossfade_samples`.

A CPU-only 14-chunk reproduction with a 512-sample crossfade expected 2,580,480 samples but delivered 2,573,824 on `main`: 6,656 samples (`512 x 13 seams`) were lost.

## Modifications

- Pass the complete decoded audio window and `overlap_samples` into the crossfade helper.
- Blend the held tail against the re-decoded overlap representing the same time span.
- Append all new samples after the blended overlap, preserving the stream timeline.
- Keep zero-overlap chunks contiguous by prepending the held tail without blending.
- Add CPU regressions for multiple seams with both zero and nonzero overlap, plus a sample-level assertion that the refreshed overlap is used.

This PR does not add or change initial chunk frame settings, streaming cadence, defaults, stage configuration, or request parameters. The existing `40/45` cadence remains unchanged.

## Related Issues

None.

## Accuracy Test

Local CPU verification (no model weights or GPU required):

- `tests/unit_test/fishaudio_s2_pro/test_streaming_vocoder.py`: **23 passed**
- 14-chunk arithmetic regression after the fix: **2,580,480 expected, 2,580,480 delivered, 0 lost**
- Black 24.10.0, isort 5.13.2, autoflake 2.3.1, AST compilation, and `git diff --check`: passed

Previously measured end to end with the real codec at a `4/25` cadence (not rerun in this local CPU-only environment):

- 1,145 frames of codes produced 1,133.50 frames before the fix and 1,145.00 frames after it.
- The recovered 11.50 frames are 23,552 samples, or 534 ms at 44.1 kHz (1.0% of the stream).
- Cosine similarity against the full-context decode remained 0.708 before and after; this change fixes timeline conservation, not the attention-window parity gap.

A maintainer GPU CI run is requested for the dependency-complete S2-Pro suite.

## Benchmark & Profiling

This is a correctness fix and does not change decode cadence or add codec work. The crossfade uses samples that were already decoded in the existing overlap window.

## Checklist

- [x] Format code according to the repository hooks.
- [x] Add unit tests.
- [x] Update documentation / docstrings / examples as needed. (No user-facing API change.)
- [x] Provide accuracy and performance results as needed.
- [x] For reviewers: no merge-only co-author attribution was added.
