### PR TITLE
[Perf][XPU] Request the decode CUDA graph for Omni's AR engines on Intel XPU

### DIFF
--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -1035,6 +1035,10 @@ def create_sglang_thinker_executor_from_config(
         sampling_backend="pytorch",
     )
     overrides["tp_size"] = tp_size
+    from sglang_omni.platforms import current_platform
+
+    if not current_platform.enable_thinker_decode_graph():
+        overrides.setdefault("disable_decode_cuda_graph", True)
     has_explicit_colocated_mem_fraction = (
         total_gpu_memory_fraction is not None
         and overrides.get("mem_fraction_static") is not None
@@ -1153,6 +1157,12 @@ def create_talker_ar_executor_from_config(
         disable_cuda_graph=False,
         sampling_backend="pytorch",
     )
+    from sglang_omni.platforms import current_platform
+
+    # A platform may decline the default above; the caller's setting still wins.
+    stated_disable = "disable_cuda_graph" in (server_args_overrides or {})
+    if not stated_disable and not current_platform.enable_talker_graph():
+        overrides["disable_cuda_graph"] = True
     overrides["tp_size"] = tp_size
     _apply_colocated_ar_memory_contract(
         overrides,

--- a/sglang_omni/platforms/interface.py
+++ b/sglang_omni/platforms/interface.py
@@ -61,6 +61,15 @@ class OmniPlatform(DeviceMixin):
         """Check if current platform support Graph for code2wav in Qwen3-Omni"""
         return True
 
+    def enable_talker_graph(self) -> bool:
+        return True
+
+    def enable_thinker_decode_graph(self) -> bool:
+        return True
+
+    def get_decode_cuda_graph_backend(self) -> str | None:
+        return None
+
     def supports_torchaudio_resample(self) -> bool:
         """Check if current platform support torchaudio.functional.resample"""
         return True

--- a/sglang_omni/platforms/xpu.py
+++ b/sglang_omni/platforms/xpu.py
@@ -45,6 +45,20 @@ class XPUOmniPlatform(OmniPlatform):
             return None
         return fused_inplace_qknorm_rope
 
+    def enable_talker_graph(self) -> bool:
+        # The predictor's default SDPA dispatch is not capturable here.
+        return False
+
+    def enable_thinker_decode_graph(self) -> bool:
+        # Capture leaves the scheduler thread's stream recording; host reads fail.
+        return False
+
+    def get_decode_cuda_graph_backend(self) -> str | None:
+        # SGLang leaves XPU decode capture opt-in and accepts only full.
+        from sglang.srt.model_executor.cuda_graph_config import Backend
+
+        return Backend.FULL
+
     def apply_model_worker_backend_policy(
         self,
         server_args: ServerArgs,

--- a/sglang_omni/scheduling/sglang_backend/server_args_builder.py
+++ b/sglang_omni/scheduling/sglang_backend/server_args_builder.py
@@ -35,6 +35,22 @@ def _normalize_decode_cuda_graph_overrides(kwargs: dict[str, Any]) -> None:
         kwargs[decode_name] = legacy_value
 
 
+def _apply_platform_decode_cuda_graph_backend(kwargs: dict[str, Any]) -> None:
+    """SGLang applies this after its disable switches, and a stage may name cpu
+    on an accelerator host, so both are checked before it is set."""
+    from sglang_omni.platforms import current_platform
+
+    backend = current_platform.get_decode_cuda_graph_backend()
+    if backend is None:
+        return
+    device = str(kwargs.get("device") or "").split(":")[0]
+    if device != current_platform.device_type:
+        return
+    if kwargs.get("disable_cuda_graph") or kwargs.get("disable_decode_cuda_graph"):
+        return
+    kwargs.setdefault("cuda_graph_backend_decode", backend)
+
+
 def build_sglang_server_args(
     model_path: str,
     context_length: int,
@@ -68,6 +84,7 @@ def build_sglang_server_args(
     if kwargs.get("mem_fraction_static") is None:
         kwargs.pop("mem_fraction_static", None)
     kwargs.setdefault("device", _platform_device_type())
+    _apply_platform_decode_cuda_graph_backend(kwargs)
     server_args = ServerArgs(**kwargs)
     # DP attention is unsupported; reject at configuration time. Mixed
     # chunked prefill stays allowed (the bridge handles it natively).

--- a/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
+++ b/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import logging
+import subprocess
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -10,6 +12,7 @@ from sglang.srt.mem_cache.kv_cache_configurator import KVCacheConfigurator
 import sglang_omni.model_runner.sglang_model_runner as runner_mod
 import sglang_omni.models.qwen3_omni.bootstrap as qwen_bootstrap
 import sglang_omni.models.qwen3_omni.stages as qwen_stages
+from sglang_omni.platforms import current_platform
 
 
 def _configurator(*, total_gpu_memory_fraction: float | None):
@@ -395,7 +398,7 @@ def test_qwen_talker_ar_threads_explicit_generation_batch_policy(monkeypatch) ->
         {
             "cuda_graph_bs": [1, 2, 4, 8, 12, 16, 24, 32],
             "cuda_graph_max_bs": 32,
-            "disable_cuda_graph": False,
+            "disable_cuda_graph": not current_platform.enable_talker_graph(),
             "max_running_requests": 32,
             "sampling_backend": "pytorch",
             "torch_compile_max_bs": 32,
@@ -454,3 +457,115 @@ def test_talker_ar_default_running_batch_width_is_32(monkeypatch) -> None:
         "dummy", server_args_overrides={"max_running_requests": 8}
     )
     assert captured[-1]["max_running_requests"] == 8
+
+
+def _thinker_overrides(monkeypatch, *, allows: bool, **kwargs) -> dict[str, object]:
+    captured: list[dict[str, object]] = []
+    _patch_thinker_startup(monkeypatch)
+    inner = qwen_stages.build_sglang_server_args
+
+    def _recording_builder(model_path, context_length, **overrides):
+        captured.append(dict(overrides))
+        return inner(model_path, context_length, **overrides)
+
+    monkeypatch.setattr(qwen_stages, "build_sglang_server_args", _recording_builder)
+    monkeypatch.setattr(current_platform, "enable_thinker_decode_graph", lambda: allows)
+    qwen_stages.create_sglang_thinker_executor_from_config(
+        "dummy", total_gpu_memory_fraction=0.75, **kwargs
+    )
+    return captured[-1]
+
+
+@pytest.mark.parametrize("allows, expected", [(False, True), (True, None)])
+def test_thinker_decode_graph_follows_the_platform_gate(
+    monkeypatch, allows: bool, expected: bool | None
+) -> None:
+    overrides = _thinker_overrides(monkeypatch, allows=allows)
+
+    assert overrides.get("disable_decode_cuda_graph") is expected
+    # The gate reaches for the decode key only, never the global switch.
+    assert overrides["disable_cuda_graph"] is False
+
+
+def test_thinker_decode_graph_stays_available_to_an_explicit_override(
+    monkeypatch,
+) -> None:
+    overrides = _thinker_overrides(
+        monkeypatch,
+        allows=False,
+        server_args_overrides={"disable_decode_cuda_graph": False},
+    )
+
+    assert overrides["disable_decode_cuda_graph"] is False
+
+
+def test_importing_the_stages_module_does_not_load_the_platform_layer() -> None:
+    """Read in a subprocess: the suite loads the platform layer long before this."""
+    probe = (
+        "import sys;"
+        "import sglang_omni.models.qwen3_omni.stages;"
+        "print('LOADED' if 'sglang_omni.platforms' in sys.modules else 'ABSENT')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True
+    )
+
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert result.stdout.strip().splitlines()[-1] == "ABSENT"
+
+
+def _talker_overrides(monkeypatch, *, allows: bool, **kwargs) -> dict[str, object]:
+    captured: list[dict[str, object]] = []
+
+    def _recording_builder(model_path, context_length, **overrides):
+        captured.append(dict(overrides))
+        return SimpleNamespace(
+            mem_fraction_static=overrides.get("mem_fraction_static"),
+            sampling_backend=overrides["sampling_backend"],
+            max_running_requests=overrides["max_running_requests"],
+            cuda_graph_max_bs=overrides["cuda_graph_max_bs"],
+            cuda_graph_bs=overrides["cuda_graph_bs"],
+            torch_compile_max_bs=overrides["torch_compile_max_bs"],
+            disable_cuda_graph=overrides["disable_cuda_graph"],
+            cuda_graph_config=SimpleNamespace(
+                decode=SimpleNamespace(
+                    max_bs=overrides["cuda_graph_max_bs"],
+                    bs=overrides["cuda_graph_bs"],
+                ),
+                prefill=SimpleNamespace(backend="disabled", bs=None, max_bs=None),
+            ),
+            enable_torch_compile=overrides.get("enable_torch_compile", False),
+        )
+
+    monkeypatch.setattr(qwen_stages, "build_sglang_server_args", _recording_builder)
+    monkeypatch.setattr(
+        qwen_bootstrap, "create_talker_scheduler", lambda *a, **k: object()
+    )
+    monkeypatch.setattr(qwen_stages, "avail_gpu_mem", lambda gpu_id: 90.0)
+    monkeypatch.setattr(
+        qwen_stages, "get_process_gpu_memory_bytes", lambda gpu_id: None
+    )
+    monkeypatch.setattr(current_platform, "enable_talker_graph", lambda: allows)
+
+    qwen_stages.create_talker_ar_executor_from_config("dummy", **kwargs)
+    return captured[-1]
+
+
+@pytest.mark.parametrize("allows, expected", [(False, True), (True, False)])
+def test_talker_decode_graph_follows_the_platform_gate(
+    monkeypatch, allows: bool, expected: bool
+) -> None:
+    overrides = _talker_overrides(monkeypatch, allows=allows)
+
+    assert overrides["disable_cuda_graph"] is expected
+
+
+def test_talker_graph_stays_available_to_an_explicit_override(monkeypatch) -> None:
+    """The stage note promises engine.disable_cuda_graph wins."""
+    overrides = _talker_overrides(
+        monkeypatch,
+        allows=False,
+        server_args_overrides={"disable_cuda_graph": False},
+    )
+
+    assert overrides["disable_cuda_graph"] is False

--- a/tests/unit_test/scheduling/test_server_args_builder_device.py
+++ b/tests/unit_test/scheduling/test_server_args_builder_device.py
@@ -127,3 +127,57 @@ def test_placement_supplies_the_device_when_no_override_is_given(monkeypatch) ->
     resolved = platforms.current_platform.device_type
 
     assert _drive_build(monkeypatch, overrides=None) == resolved
+
+
+def _with_decode_backend(monkeypatch, backend: str | None) -> None:
+    monkeypatch.setattr(
+        platforms.current_platform,
+        "get_decode_cuda_graph_backend",
+        lambda: backend,
+    )
+
+
+def test_the_platform_decode_graph_backend_reaches_server_args(monkeypatch) -> None:
+    _with_decode_backend(monkeypatch, "full")
+    assert _build(monkeypatch)["cuda_graph_backend_decode"] == "full"
+
+
+def test_a_platform_with_no_preference_leaves_the_decode_backend_alone(
+    monkeypatch,
+) -> None:
+    """Byte-identical to the arguments built before these gates existed."""
+    _with_decode_backend(monkeypatch, None)
+    gated = _build(monkeypatch)
+
+    monkeypatch.setattr(
+        server_args_builder,
+        "_apply_platform_decode_cuda_graph_backend",
+        lambda kwargs: None,
+    )
+    ungated = _build(monkeypatch)
+
+    assert gated == ungated
+
+
+def test_a_stage_that_named_cpu_gets_no_accelerator_decode_backend(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(platforms.current_platform, "device_type", "xpu", raising=False)
+    _with_decode_backend(monkeypatch, "full")
+
+    kwargs = _build(monkeypatch, device="cpu")
+
+    assert kwargs["device"] == "cpu"
+    assert "cuda_graph_backend_decode" not in kwargs
+
+
+def test_an_engine_that_asked_for_eager_decode_keeps_it(monkeypatch) -> None:
+    _with_decode_backend(monkeypatch, "full")
+
+    for opt_out in ("disable_cuda_graph", "disable_decode_cuda_graph"):
+        kwargs = _build(monkeypatch, **{opt_out: True})
+        assert "cuda_graph_backend_decode" not in kwargs, opt_out
+
+    # An engine naming its own backend keeps that too.
+    pinned = _build(monkeypatch, cuda_graph_backend_decode="disabled")
+    assert pinned["cuda_graph_backend_decode"] == "disabled"

--- a/tests/unit_test/test_platforms.py
+++ b/tests/unit_test/test_platforms.py
@@ -144,3 +144,26 @@ def test_xpu_platform_resolves_to_the_omni_xpu_platform() -> None:
     assert platform.get_stage_process_env(spec, {"ZE_AFFINITY_MASK": "0,1"}) == {
         "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "false"
     }
+
+
+def test_xpu_names_the_decode_graph_backend_sglang_leaves_off() -> None:
+    backend = xpu_platform.XPUOmniPlatform().get_decode_cuda_graph_backend()
+
+    # ServerArgs takes this as a config string, so the hook owes a plain str.
+    assert backend == "full"
+    assert type(backend) is str
+    # Other platforms keep SGLang's own device default.
+    assert OmniPlatform().get_decode_cuda_graph_backend() is None
+    assert CPUOmniPlatform().get_decode_cuda_graph_backend() is None
+
+
+def test_xpu_keeps_the_qwen3_omni_talker_decode_eager() -> None:
+    assert xpu_platform.XPUOmniPlatform().enable_talker_graph() is False
+    assert OmniPlatform().enable_talker_graph() is True
+    assert CPUOmniPlatform().enable_talker_graph() is True
+
+
+def test_xpu_keeps_the_qwen3_omni_thinker_decode_eager() -> None:
+    assert xpu_platform.XPUOmniPlatform().enable_thinker_decode_graph() is False
+    assert OmniPlatform().enable_thinker_decode_graph() is True
+    assert CPUOmniPlatform().enable_thinker_decode_graph() is True


### PR DESCRIPTION
## Motivation

SGLang keeps XPU decode-graph capture opt-in — `_handle_xpu_backends()` disables it
unless a backend is named explicitly — and Omni never named one, so every AR engine
decoded eagerly on XPU even though `XPUGraphRunner` / `FullXPUGraphBackend` were
available. CUDA already defaults to `full`, so the gap only cost XPU.

## Modifications

A platform hook names the decode backend and the shared `ServerArgs` builder passes
it on, the way the code2wav graph decision already works. XPU answers `full` (the
only decode backend SGLang accepts there); every other platform answers `None`.

SGLang applies the per-phase backend *after* its disable switches, so the hook is
guarded: an engine that set `disable_cuda_graph`, or that names its own backend, is
left alone, and the backend is keyed off the device the stage will really run on so a
stage naming `cpu` on an accelerator host keeps `cpu`.

Two Qwen3-Omni AR stages decline on XPU, gated the way `enable_code2wav_graph`
already is:

- **talker** — capture kills the pipeline: the predictor's default SDPA dispatch is
  not capturable on this backend.
- **thinker** — capture serves one request and then fails every request under
  concurrency. Once the captures close, the scheduler thread's stream still reports
  capturing, so reading the sampled ids to host raises `wait method cannot be used
  for an event associated with a command graph`. The same read on a freshly created
  stream succeeds, so the fault is in the capture, not in this pipeline.

Both gates reopen when the runtime stops leaving that stream recording.

**CUDA is unaffected by construction, and it is verified rather than argued.** The
gates are read at call time, so importing the stage module does not pull in the
platform layer (a test holds that); the talker's existing call is untouched and the
gate declines afterwards; and the decode-backend helper asks the platform first and
returns on that branch before reading or writing any argument.

## Related Issues

Part of #1588 (Intel XPU roadmap — "Enable XPU graph capture"). Follows #994.

## Accuracy Test

On Intel Arc Pro B60 with the decode graph active: Qwen3-ASR transcripts unchanged;
Qwen3-TTS Base and CustomVoice round-trip TTS→ASR at 0.0% WER. Qwen3-Omni speech at
TP=8 serves 20/20 requests at concurrency 16 with both gates closed. Higgs TTS opts
out and is unchanged. Full unit suite on XPU: failure set identical to the base, name
for name.

## Benchmark & Profiling

One card pinned, A/B/A to rule out host drift. RTF (elapsed / produced audio) rather
than raw latency where output length is not pinned: latency medians drift 3.6x
between two identical runs while RTF repeats within 1.6%.

| Model | graph | eager | speedup |
|---|---|---|---|
| Qwen3-TTS Base (n=18, rtf median) | 1.03 | 1.42 | 1.38x |
| Qwen3-ASR (n=12, latency median) | 233 ms | 402 ms | 1.7x |
| Qwen3-TTS CustomVoice (n=18, latency median) | 6144 ms | 7527 ms | 1.23x |

Startup capture cost on TTS: 33 s eager → 66-205 s with capture.

Capturing the **thinker** decode was measured at 7.6x on TP=8 (2166 ms vs 16528 ms)
but is disabled here for the reason above: 0/20 requests succeed at concurrency 16
with the graph, 20/20 with the gate closed. That row returns when the runtime is
fixed.

## Verification

```bash
# CUDA sees byte-identical ServerArgs and an unchanged import graph.
python - <<'PY'
import json, sys
before = set(sys.modules)
import sglang_omni.models.qwen3_omni.stages  # noqa: F401
added = set(sys.modules) - before
import sglang_omni.platforms as platforms
from sglang_omni.platforms.interface import OmniPlatform

class NonXpu(OmniPlatform):
    device_type = "cuda"

platforms.current_platform = NonXpu()
from sglang_omni.scheduling.sglang_backend import server_args_builder

args = server_args_builder.build_sglang_server_args(
    "<any local model>", context_length=448, device="cuda",
    max_running_requests=32, disable_cuda_graph=False,
    sampling_backend="pytorch", skip_server_warmup=True,
)
print("platforms pulled in:", "sglang_omni.platforms" in added)   # False
print("decode backend     :", args.cuda_graph_backend_decode)      # None
print("fields:", json.dumps({k: v for k, v in sorted(vars(args).items())
      if isinstance(v, (str, int, float, bool, type(None)))}, sort_keys=True)[:80])
PY

pytest tests/unit_test/test_platforms.py \
       tests/unit_test/scheduling/test_server_args_builder_device.py \
       tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
```

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
