### PR TITLE
add NPU install script and documentation

### DIFF
--- a/docs/get_started/installation_npu.md
+++ b/docs/get_started/installation_npu.md
@@ -1,0 +1,176 @@
+# 🚀 Installation — Huawei Ascend NPU
+
+Installs `sglang-omni` for **Huawei Ascend NPUs**. The default
+[installation](./installation.md) pins CUDA-only wheels and would clobber a `torch+npu` stack.
+Mirroring upstream SGLang ([Ascend NPU docs](https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu),
+`docker/npu.Dockerfile`), the NPU path uses a **separate `pyproject_npu.toml`** plus a pre-installed
+`torch_npu` / `triton-ascend` stack.
+
+## Why a separate pyproject
+
+`pip install -e .` resolves the CUDA [`pyproject.toml`](../../pyproject.toml), whose torch
+family and CUDA-only wheels would replace the `torch+npu` stack.
+[`pyproject_npu.toml`](../../pyproject_npu.toml) encodes the NPU replacements.
+
+Core deps cover the supported models (Qwen3-ASR / TTS / Omni) plus the API server;
+`[eval]` adds SeedTTS/WER tooling and `[all]` aliases it. Other model families
+(S2-Pro, Ming-Omni, Voxtral-TTS) are CUDA-only and are not offered here.
+
+> **`--no-build-isolation` is required** — without it pip emits a legacy in-tree
+> `egg-info` instead of a PEP 660 editable install. The installer always passes it.
+> Because of that pip does not install build requirements either, so this
+> environment's own `setuptools` must be **≥ 77.0.0**: older releases reject the
+> PEP 639 license metadata with ``invalid pyproject.toml config: `project.license` ``.
+> The installer checks this before building; upgrade with
+> `pip install -U 'setuptools>=77.0.0'`.
+
+## Prerequisites
+
+The NPU stack is **not** installed by `pyproject_npu.toml` or the install script.
+You must set up the following components first, following the
+[SGLang Ascend NPU guide](https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu):
+
+| Component | Version | Install |
+|-----------|---------|---------|
+| CANN toolkit | 9.0.0 | [Installation guide](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/900/softwareinst/instg/instg_0008.html) |
+| HDK (driver/firmware) | 25.5.2 | [Download](https://www.hiascend.com/hardware/firmware-drivers/community) |
+| torch (CPU) | 2.10.0 | `pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --index-url https://download.pytorch.org/whl/cpu` |
+| torch_npu | 2.10.0 | [gitcode.com/Ascend/pytorch/releases](https://gitcode.com/Ascend/pytorch/releases) (arch-specific wheel) |
+| triton-ascend | 3.2.1.dev20260530 | `pip install triton-ascend==3.2.1.dev20260530 --extra-index-url=https://mirrors.huaweicloud.com/ascend/repos/pypi/nightly --trusted-host mirrors.huaweicloud.com` |
+| memfabric-hybrid | 1.0.8 | `pip install memfabric-hybrid==1.0.8` (PD disaggregation only) |
+| sgl-kernel-npu | latest | [sgl-project/sgl-kernel-npu](https://github.com/sgl-project/sgl-kernel-npu) releases |
+
+> **Python 3.11 only** — upstream SGLang's NPU build currently supports `python==3.11`.
+> Use conda if your system Python differs: `conda create -n sglang-omni-npu python=3.11`.
+
+### torch_npu installation
+
+`torch_npu` wheels are arch-specific and hosted on Huawei's gitcode mirror, not on PyPI.
+Download the matching wheel for your architecture:
+
+```bash
+# aarch64 (Atlas 800I A2 / A3)
+pip install https://gitcode.com/Ascend/pytorch/releases/download/v26.0.0-pytorch2.10.0/torch_npu-2.10.0-cp311-cp311-manylinux_2_28_aarch64.whl
+
+# x86_64
+pip install https://gitcode.com/Ascend/pytorch/releases/download/v26.0.0-pytorch2.10.0/torch_npu-2.10.0-cp311-cp311-manylinux_2_28_x86_64.whl
+```
+
+## 🛠️ Install sglang-omni
+
+The helper swaps in `pyproject_npu.toml`, installs with `--no-build-isolation`, then
+restores the CUDA one:
+
+```bash
+git clone https://github.com/sgl-project/sglang-omni.git
+cd sglang-omni
+
+# dry-run first — shows the commands, installs nothing
+PYTHON=$(which python) scripts/npu/install_npu.sh --check
+
+# editable install
+PYTHON=$(which python) scripts/npu/install_npu.sh
+```
+
+Pick extras with `--extras` (comma-separated):
+
+```bash
+scripts/npu/install_npu.sh --extras eval           # core + SeedTTS/WER eval + tests
+scripts/npu/install_npu.sh --extras all            # alias for eval
+```
+
+Or do it manually (the same steps the script automates):
+
+```bash
+cp pyproject.toml .pyproject.cuda.bak
+cp pyproject_npu.toml pyproject.toml
+pip install -e . --no-build-isolation
+cp -f .pyproject.cuda.bak pyproject.toml && rm .pyproject.cuda.bak   # restore CUDA pyproject
+```
+
+### SGLang (installed separately)
+
+`sglang` is intentionally **not** pinned, so the install above leaves an existing NPU build alone.
+It cannot be pinned even as a range: every published wheel requires `flashinfer_python[cu13]` and the
+`nvidia-*` runtime, so **any** specifier pulls the CUDA stack over `torch+npu`. Build from source:
+
+```bash
+git clone https://github.com/sgl-project/sglang && cd sglang
+git checkout v0.5.16   # the pinned release
+cd python && cp pyproject_npu.toml pyproject.toml
+pip install -e . --no-build-isolation
+```
+
+Use that commit: the NPU port targets this SGLang revision's APIs and does not carry
+version-compatibility shims. A VCS requirement (`pip install "sglang @ git+…"`) does **not** work:
+pip reads the checkout's `python/pyproject.toml`, which pins CUDA torch; only the swap above
+selects the NPU manifest.
+
+## Verify
+
+```bash
+# import works from anywhere now (package installed, not just cwd-on-path)
+python -c "import sglang_omni, torch; print(sglang_omni.__file__, torch.__version__)"
+which sgl-omni
+
+# device-layer unit tests (CPU, no NPU) — needs pytest, which ships in the
+# `[eval]` extra (install with `.[eval]`, or `pip install pytest` first)
+pytest tests/unit_test/test_platforms.py -v
+```
+
+## Serve
+
+### Qwen3-ASR (speech-to-text, single NPU)
+
+```bash
+sgl-omni serve --model-path /path/to/Qwen3-ASR-1.7B --host 0.0.0.0 --port 8000
+# transcribe:
+curl -s -X POST http://localhost:8000/v1/audio/transcriptions \
+  -F "file=@sample.wav" -F "model=/path/to/Qwen3-ASR-1.7B"
+```
+
+### Qwen3-TTS (text-to-speech, single NPU)
+
+Qwen3-TTS needs the upstream `qwen-tts` package, which is not pinned in `pyproject_npu.toml`.
+Install it with `--no-deps` to avoid version conflicts:
+
+```bash
+apt-get update && apt-get install -y sox   # the Python sox package shells out to it
+pip install --no-deps sox einops
+pip install --no-deps qwen-tts==0.1.1
+```
+
+```bash
+sgl-omni serve --model-path /path/to/Qwen3-TTS-12Hz-1.7B-Base --host 0.0.0.0 --port 8000
+# Base checkpoint clones a reference voice — pass ref_audio (+ ref_text):
+curl -s -X POST http://localhost:8000/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{"model":"/path/to/Qwen3-TTS-12Hz-1.7B-Base","input":"Hello from Ascend NPU.",
+       "voice":"default","ref_audio":"/path/to/ref.wav","ref_text":"reference transcript",
+       "response_format":"wav"}' -o out.wav
+```
+
+### Qwen3-Omni (30B-A3B MoE, multi-NPU tensor parallel)
+
+The 30B MoE does not fit one card; shard the thinker across NPUs with tensor parallelism.
+`--text-only` serves the thinker (chat) without the talker/speech stages:
+
+```bash
+# thinker across 8 cards (TP=8). Large shards over shared storage load slowly, so give
+# startup more headroom than the default 600 s.
+export SGLANG_OMNI_STARTUP_TIMEOUT=1800
+sgl-omni serve --model-path /path/to/Qwen3-Omni-30B-A3B-Instruct \
+  --text-only --thinker-tp-size 8 --thinker-gpus 0,1,2,3,4,5,6,7 \
+  --host 0.0.0.0 --port 8000
+# chat:
+curl -s -X POST http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"/path/to/Qwen3-Omni-30B-A3B-Instruct",
+       "messages":[{"role":"user","content":"What is Ascend NPU?"}],"max_tokens":64}'
+```
+
+Health check for any of the above: `curl http://localhost:8000/v1/models`.
+
+> **Expected on NPU:** `Failed to import mooncake` / `Failed to import nixl` warnings are harmless
+> — those CUDA-only transfer backends are omitted; tensors move through the `shm` relay instead
+> (or `memfabric` if installed).

--- a/pyproject_npu.toml
+++ b/pyproject_npu.toml
@@ -1,0 +1,127 @@
+[build-system]
+# >=77 for the PEP 639 license fields below, which 76.1 and older reject; that also
+# covers the PEP 660 build_editable an editable install needs. Installs here pass
+# --no-build-isolation, so pip never enforces this -- scripts/npu/install_npu.sh does.
+requires = ["setuptools>=77.0.0"]
+build-backend = "setuptools.build_meta"
+
+# Huawei Ascend NPU variant of pyproject.toml (see docs/get_started/installation_npu.md).
+# Mirrors upstream SGLang's pyproject_npu.toml where srt_npu = [] — torch,
+# torch_npu, triton-ascend, and memfabric are NOT pinned here and must be
+# installed manually before pip-installing sglang-omni.
+#
+# CUDA-only wheels (flashinfer, nixl-cu13, mooncake, flash-attn-4, cache-dit …)
+# are dropped; sglang is verified against v0.5.16 but cannot be pinned here --
+# every published wheel pulls CUDA torch.
+
+[project]
+name = "sglang-omni"
+dynamic = ["version"]
+description = "Multi-stage pipeline framework for omni models (Huawei Ascend NPU build)"
+readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+requires-python = ">=3.10,<3.13"
+dependencies = [
+    # --- Core framework (device-agnostic) ----------------------------------
+    "pyzmq>=25.0.0",
+    "msgpack>=1.0.0",
+    "msgspec",
+    "numpy>=1.24.0",
+    "pydantic>=2.0.0",
+    "PyYAML>=6.0",
+    "httpx",
+    "xxhash>=3.0.0",
+    "pybase64>=1.4.0",       # fast base64 decode for inline media (utils/audio.py)
+    "tabulate",
+    "pandas",
+    "typer>=0.9.0",
+
+    # --- PyTorch + torch_npu (Ascend CANN) ---------------------------------
+    # NOTE: torch, torch_npu, triton-ascend, and memfabric are intentionally
+    # NOT pinned here, matching upstream SGLang's pyproject_npu.toml where
+    # srt_npu = [].  These packages must be installed manually before
+    # pip-installing sglang-omni, because:
+    #   1. torch_npu wheels are arch-specific (aarch64/x86) and often hosted
+    #      on Huawei OBS rather than PyPI;
+    #   2. triton-ascend requires a Huawei cloud mirror index;
+    #   3. versions are tightly coupled to the host CANN toolkit release.
+    #
+    # Refer to the SGLang Ascend NPU install guide for the component version
+    # mapping (CANN / torch / torch_npu / triton-ascend / memfabric):
+    #   https://docs.sglang.io/docs/hardware-platforms/ascend-npus/ascend_npu
+    #
+    # Example install sequence (CANN 9.0.0, see installation_npu.md for details):
+    #   pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 \
+    #       --index-url https://download.pytorch.org/whl/cpu
+    #   pip install torch_npu==2.10.0  # arch-specific wheel from gitcode.com/Ascend/pytorch
+    #   pip install triton-ascend==3.2.1.dev20260530 \
+    #       --extra-index-url=https://mirrors.huaweicloud.com/ascend/repos/pypi/nightly \
+    #       --trusted-host mirrors.huaweicloud.com
+    #   pip install memfabric-hybrid==1.0.8  # PD disaggregation only
+
+    # --- Model loading / HF -------------------------------------------------
+    "accelerate>=0.27.0",
+    "transformers==5.12.1",        # Match SGLang 0.5.16, as the CUDA pyproject does
+    "safetensors>=0.4.3",
+    "pillow>=10.0.0",
+    "huggingface-hub>=0.36.0",
+    "datasets>=2.14.0",
+
+    # NOTE: sglang is intentionally NOT pinned here (see the header).
+
+    # --- API server ---------------------------------------------------------
+    "fastapi>=0.110.0",
+    "uvicorn>=0.23.0",
+    "websockets>=12.0",
+    "openai==2.6.1",
+    "openai-harmony==0.0.4",
+    # /v1/realtime — server-side VAD
+    "silero-vad>=5.1",
+    "onnxruntime>=1.17",
+
+    # --- Multimodal preprocessing (needed by Qwen3-Omni/ASR/TTS) ------------
+    "qwen-vl-utils==0.0.11",
+    "librosa>=0.11.0",
+    "av>=16.1.0",
+    "soundfile>=0.12.0",
+    "scipy>=1.10.0",
+]
+
+[project.optional-dependencies]
+# SeedTTS speaker-sim / WER eval + tests (device-agnostic).
+eval = [
+    "s3prl>=0.4.18",
+    "jiwer",
+    "openai-whisper==20250625",
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+]
+# `all` aliases `eval`.
+all = [
+    "s3prl>=0.4.18", "jiwer", "openai-whisper==20250625",
+    "pytest>=7.0.0", "pytest-asyncio>=0.21.0",
+]
+
+[project.scripts]
+sgl-omni = "sglang_omni.cli:app"
+sgl-omni-router = "sglang_omni_router.serve:main"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+markers = [
+    "benchmark: performance benchmark tests (may require GPU and long runtime)",
+    "tts_stage(name): select an in-file TTS benchmark CI stage",
+    "gpu: requires an accelerator device (auto-skipped without one)",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["sglang_omni*"]
+
+[tool.setuptools.dynamic]
+version = {attr = "sglang_omni.__version__"}
+
+[tool.setuptools.package-data]
+"sglang_omni.models.fishaudio_s2_pro" = ["fish_speech/configs/*.yaml"]
+"sglang_omni.models.higgs_tts" = ["configs/*.json"]

--- a/scripts/npu/install_npu.sh
+++ b/scripts/npu/install_npu.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Install sglang-omni for Huawei Ascend NPU: swap in pyproject_npu.toml and install
+# against the pre-installed torch_npu / triton-ascend stack (the CUDA pyproject would
+# clobber a working torch+npu stack). See docs/get_started/installation_npu.md.
+#
+# Prerequisites (NOT installed by this script — see installation_npu.md):
+#   - CANN toolkit 9.0.0
+#   - torch + torch_npu (matching versions)
+#   - triton-ascend
+#   - memfabric-hybrid (for PD disaggregation)
+#   - sgl-kernel-npu (custom operators)
+#
+# Usage:
+#   scripts/npu/install_npu.sh                    # lean core, editable
+#   scripts/npu/install_npu.sh --extras eval      # core + eval/tests
+#   scripts/npu/install_npu.sh --no-editable      # non-editable
+#   scripts/npu/install_npu.sh --check            # dry-run: show what would run
+#
+# Never deletes your pyproject.toml: it is backed up and restored on exit.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EDITABLE="-e"
+CHECK_ONLY=0
+EXTRAS=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-editable) EDITABLE=""; shift ;;
+    --check)       CHECK_ONLY=1; shift ;;
+    --extras)      EXTRAS="${2:-}"; shift 2 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+PYPROJECT="${REPO_ROOT}/pyproject.toml"
+PYPROJECT_NPU="${REPO_ROOT}/pyproject_npu.toml"
+BACKUP="${REPO_ROOT}/.pyproject.cuda.bak"
+
+SGLANG_VERIFIED_VERSION="v0.5.16"
+
+[[ -f "${PYPROJECT_NPU}" ]] || { echo "ERROR: ${PYPROJECT_NPU} not found" >&2; exit 1; }
+
+PYBIN="${PYTHON:-python}"
+
+# Build the install target, e.g. ".[eval]" or "."
+TARGET="."
+if [[ -n "${EXTRAS}" ]]; then
+  TARGET=".[${EXTRAS}]"
+fi
+
+echo "=== sglang-omni Huawei Ascend NPU install ==="
+echo "  repo:        ${REPO_ROOT}"
+echo "  python:      $(${PYBIN} -c 'import sys; print(sys.executable)')"
+echo "  target:      ${TARGET}"
+echo "  editable:    $([[ -n "${EDITABLE}" ]] && echo yes || echo no)"
+
+# --- Pre-flight: verify NPU stack is installed ---------------------------
+# torch, torch_npu, triton-ascend, and memfabric are intentionally NOT pinned
+# in pyproject_npu.toml (matching upstream SGLang's pyproject_npu.toml where
+# srt_npu = []).  They must be installed BEFORE running this script.
+${PYBIN} - <<'PY' || exit 1
+import sys
+
+errors = []
+
+try:
+    import torch
+    print(f"  torch:       {torch.__version__}")
+except ImportError:
+    errors.append("torch is not installed. Install CPU torch first:\n"
+                  "  pip install torch==2.10.0 torchvision==0.25.0 --index-url https://download.pytorch.org/whl/cpu")
+
+try:
+    import torch_npu
+    print(f"  torch_npu:   {torch_npu.__version__}")
+except ImportError:
+    errors.append("torch_npu is not installed. Install from Huawei OBS:\n"
+                  "  pip install torch_npu==2.10.0  # or from https://gitcode.com/Ascend/pytorch/releases")
+
+try:
+    import triton
+    print(f"  triton:      {triton.__version__}")
+except ImportError:
+    errors.append("triton-ascend is not installed. Install from Huawei cloud mirror:\n"
+                  "  pip install triton-ascend==3.2.1.dev20260530 \\\n"
+                  "    --extra-index-url=https://mirrors.huaweicloud.com/ascend/repos/pypi/nightly \\\n"
+                  "    --trusted-host mirrors.huaweicloud.com")
+
+try:
+    import memfabric
+    print(f"  memfabric:   {memfabric.__version__}")
+except ImportError:
+    # memfabric is only needed for PD disaggregation; warn, don't error
+    print("  memfabric:   not installed (only needed for PD disaggregation)")
+
+if errors:
+    print()
+    print("ERROR: NPU prerequisites are missing.", file=sys.stderr)
+    for e in errors:
+        print(f"  - {e}", file=sys.stderr)
+    print(file=sys.stderr)
+    print("See docs/get_started/installation_npu.md for the full install sequence.", file=sys.stderr)
+    sys.exit(1)
+PY
+
+# --- Verify setuptools >= 77 (same rationale as XPU) ---------------------
+# --no-build-isolation is REQUIRED (see docs/get_started/installation_npu.md):
+# with build isolation, pip spins up an isolated build env whose fallback
+# setuptools emits a legacy in-tree egg-info instead of a PEP 660 editable .pth
+# — the package then isn't importable outside the repo and no sgl-omni console
+# script is created. Without isolation the build uses this env's setuptools, so the
+# build requirement in pyproject_npu.toml is never enforced by pip -- check it here
+# instead of failing later in metadata generation.
+"${PYBIN}" - <<'PY' || exit 1
+import sys
+
+import setuptools
+import setuptools.build_meta
+
+version = tuple(
+    int("".join(char for char in part if char.isdigit()) or 0)
+    for part in setuptools.__version__.split(".")[:2]
+)
+if version < (77, 0):
+    sys.exit(
+        f"setuptools {setuptools.__version__} is too old: pyproject_npu.toml uses "
+        "the PEP 639 license fields, which 76.1 and older reject with 'invalid "
+        "pyproject.toml config: `project.license`'. --no-build-isolation means pip "
+        "will not upgrade it for you, so run: pip install -U 'setuptools>=77.0.0'"
+    )
+if not hasattr(setuptools.build_meta, "build_editable"):
+    sys.exit(
+        f"setuptools {setuptools.__version__} lacks PEP 660 support; an editable "
+        "install would emit a legacy egg-info."
+    )
+PY
+NOISO="--no-build-isolation"
+INSTALL_CMD="${PYBIN} -m pip install ${EDITABLE} ${TARGET} ${NOISO}"
+
+# --- Serialize the swap (same flock pattern as XPU) ----------------------
+LOCK="${REPO_ROOT}/.pyproject.npu.lock"
+if ! command -v flock >/dev/null 2>&1; then
+  echo "ERROR: flock is required to serialize the pyproject swap" >&2
+  exit 1
+fi
+exec 9>"${LOCK}" || { echo "ERROR: cannot open lock ${LOCK}" >&2; exit 1; }
+if ! flock -n 9; then
+  echo "ERROR: another ${0##*/} holds ${LOCK}; wait for it to finish" >&2
+  exit 1
+fi
+
+# A leftover backup means a previous run died after the swap (SIGKILL, OOM, power
+# loss -- INT/TERM are trapped below). pyproject.toml is then the NPU manifest and
+# this backup holds the only copy of the original, so the cp below would destroy it.
+# Refuse instead, and hand back the recovery step. Checked before the trap is armed
+# so exiting here cannot itself touch either file.
+if [[ -e "${BACKUP}" ]]; then
+  {
+    echo "ERROR: leftover backup found: ${BACKUP}"
+    echo
+    echo "A previous run was interrupted after swapping pyproject.toml, so that"
+    echo "backup is the only copy of your original manifest. Restore it first:"
+    echo
+    echo "  cp ${BACKUP} ${PYPROJECT} && rm ${BACKUP}"
+    echo
+    echo "Then re-run this script."
+  } >&2
+  exit 1
+fi
+
+if [[ "${CHECK_ONLY}" -eq 1 ]]; then
+  echo
+  echo "[--check] would run:"
+  echo "  cp pyproject.toml .pyproject.cuda.bak"
+  echo "  cp pyproject_npu.toml pyproject.toml"
+  echo "  ${INSTALL_CMD}"
+  echo "  # then restore pyproject.toml from backup"
+  exit 0
+fi
+
+# Restore the CUDA pyproject.toml no matter how we exit. Use cp (not mv) so a
+# partial/interrupted restore still leaves the backup in place, and also sweep
+# the in-tree build artifacts an editable build may drop.
+restore() {
+  if [[ -f "${BACKUP}" ]]; then
+    cp -f "${BACKUP}" "${PYPROJECT}"
+    rm -f "${BACKUP}"
+    echo "restored original pyproject.toml"
+  fi
+  rm -rf "${REPO_ROOT}/sglang_omni.egg-info" "${REPO_ROOT}/build" 2>/dev/null || true
+}
+trap restore EXIT INT TERM
+
+cp -f "${PYPROJECT}" "${BACKUP}"
+cp -f "${PYPROJECT_NPU}" "${PYPROJECT}"
+echo "swapped in pyproject_npu.toml"
+
+echo ">>> ${INSTALL_CMD}"
+${INSTALL_CMD}
+
+# Restore immediately (don't wait for EXIT) so verification below runs against a
+# clean tree and a setuptools editable .pth (not the swapped file).
+restore
+trap - EXIT INT TERM
+
+echo
+echo "=== verifying install ==="
+VERIFY_RC=0
+# import must work from OUTSIDE the repo (proves a real install, not cwd-on-path)
+if (cd / && "${PYBIN}" -c "import sglang_omni" 2>/dev/null); then
+  echo "  [ok] import sglang_omni works from outside the repo"
+else
+  echo "  [FAIL] import sglang_omni does NOT work outside the repo (editable .pth missing)"
+  VERIFY_RC=1
+fi
+if "${PYBIN}" -m pip show sglang-omni >/dev/null 2>&1; then
+  echo "  [ok] pip shows sglang-omni: $(${PYBIN} -m pip show sglang-omni 2>/dev/null | awk '/^Version:/{print $2}')"
+else
+  echo "  [FAIL] pip does not show sglang-omni"
+  VERIFY_RC=1
+fi
+if command -v sgl-omni >/dev/null 2>&1 || [[ -x "$(dirname "$(${PYBIN} -c 'import sys;print(sys.executable)')")/sgl-omni" ]]; then
+  echo "  [ok] sgl-omni console script present"
+else
+  echo "  [warn] sgl-omni not on PATH (check the env's bin dir)"
+fi
+
+# SGLang is never installed by this script (it cannot be pinned for NPU), so
+# report whether it is importable at all.
+if "${PYBIN}" -c "import sglang" >/dev/null 2>&1; then
+  echo "  [ok] sglang is importable"
+else
+  echo "  [warn] sglang is NOT installed — it is intentionally not a dependency here."
+  echo "         Build the NPU SGLang from source (${SGLANG_VERIFIED_VERSION}):"
+  echo "           git clone https://github.com/sgl-project/sglang && cd sglang"
+  echo "           git checkout ${SGLANG_VERIFIED_VERSION}"
+  echo "           cd python && cp pyproject_npu.toml pyproject.toml"
+  echo "           pip install -e . --no-build-isolation"
+fi
+
+if [[ "${VERIFY_RC}" -ne 0 ]]; then
+  echo
+  echo "INSTALL VERIFICATION FAILED. If setuptools fell back to legacy egg-info,"
+  echo "retry with a PEP 660 editable build, e.g.:"
+  echo "  ${PYBIN} -m pip install -e . --config-settings editable_mode=strict"
+  exit 1
+fi
+
+echo
+echo "=== done. Next: ==="
+echo "  sgl-omni serve --model-path <path-to-model> --port 8000"


### PR DESCRIPTION
Complete the NPU build configuration by adding:
- scripts/npu/install_npu.sh: swap-and-restore installer (mirrors XPU pattern)
- docs/get_started/installation_npu.md: full installation guide with prerequisite version table (CANN 9.0.0 / torch 2.10.0 / torch_npu 2.10.0 / triton-ascend 3.2.1.dev20260530 / memfabric-hybrid 1.0.8)
- pyproject_npu.toml: update comment example to include torchaudio and correct torch_npu wheel source (gitcode.com/Ascend/pytorch)

Together with pyproject_npu.toml from the previous commit, this forms a complete out-of-the-box NPU installation path symmetric to the XPU setup.

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
