### PR TITLE
fix(pipeline): keep the child startup traceback in wait_ready

### DIFF
--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -196,6 +196,17 @@ def _patched_spawn_env(spec: StageWorkerProcessSpec):
                 os.environ[key] = value
 
 
+
+def _read_startup_error(channel: Any, timeout: float | None = None) -> str | None:
+    """Return a child's startup traceback, or None if it reported none yet."""
+    try:
+        if timeout is None:
+            return channel.get_nowait()
+        return channel.get(timeout=timeout)
+    except (queue.Empty, EOFError, OSError, ValueError):
+        # ValueError/OSError: the child closed the queue as it exited.
+        return None
+
 class StageGroup:
     """Lifecycle manager for one or more OS processes in a topology group."""
 
@@ -295,27 +306,31 @@ class StageGroup:
 
                 # Note (Yue Yin): Surface early child death instead of masking it
                 # as a generic startup timeout.
-                if not proc.is_alive():
-                    details = ""
-                    try:
-                        traceback_text = startup_error_channel.get_nowait()
-                    except (queue.Empty, EOFError):
-                        pass
-                    else:
-                        details = f"\nStartup failure detail:\n{traceback_text}"
-                    raise RuntimeError(
-                        f"Process {process_label} died during startup "
-                        f"(exit code {proc.exitcode}){details}"
-                    )
-
-                try:
-                    traceback_text = startup_error_channel.get_nowait()
-                except (queue.Empty, EOFError):
-                    traceback_text = None
+                # Note (Audrey Zheng): read the channel before testing liveness.
+                # A child that reports a factory error exits immediately after,
+                # so a liveness-first order races the report and loses it.
+                traceback_text = _read_startup_error(startup_error_channel)
                 if traceback_text is not None:
-                    details = f"\nStartup failure detail:\n{traceback_text}"
                     raise RuntimeError(
                         f"Process {process_label} failed during startup "
+                        f"(exit code {proc.exitcode})"
+                        f"\nStartup failure detail:\n{traceback_text}"
+                    )
+
+                if not proc.is_alive():
+                    # The child puts the traceback on a feeder thread and then
+                    # exits, so the bytes can still be in flight here. Wait
+                    # briefly rather than report a bare exit code.
+                    traceback_text = _read_startup_error(
+                        startup_error_channel, timeout=0.2
+                    )
+                    details = (
+                        ""
+                        if traceback_text is None
+                        else f"\nStartup failure detail:\n{traceback_text}"
+                    )
+                    raise RuntimeError(
+                        f"Process {process_label} died during startup "
                         f"(exit code {proc.exitcode}){details}"
                     )
 

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -196,7 +196,6 @@ def _patched_spawn_env(spec: StageWorkerProcessSpec):
                 os.environ[key] = value
 
 
-
 def _read_startup_error(channel: Any, timeout: float | None = None) -> str | None:
     """Return a child's startup traceback, or None if it reported none yet."""
     try:
@@ -206,6 +205,7 @@ def _read_startup_error(channel: Any, timeout: float | None = None) -> str | Non
     except (queue.Empty, EOFError, OSError, ValueError):
         # ValueError/OSError: the child closed the queue as it exited.
         return None
+
 
 class StageGroup:
     """Lifecycle manager for one or more OS processes in a topology group."""

--- a/tests/unit_test/pipeline/test_stage_workers_startup_errors.py
+++ b/tests/unit_test/pipeline/test_stage_workers_startup_errors.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic checks for how wait_ready reports a child startup failure.
+
+These use fake processes and fake channels instead of spawning children, so
+they exercise the ordering and the read mode directly and do not depend on how
+long a real child takes to start.
+"""
+
+from __future__ import annotations
+
+import queue
+from types import SimpleNamespace
+
+import pytest
+
+from sglang_omni.pipeline.stage_workers import StageGroup
+
+TRACEBACK = 'Traceback (most recent call last):\n  RuntimeError: factory boom'
+
+
+class _DeadProcess:
+    exitcode = 1
+
+    @staticmethod
+    def is_alive() -> bool:
+        return False
+
+
+class _LiveProcess:
+    exitcode = None
+
+    @staticmethod
+    def is_alive() -> bool:
+        return True
+
+
+class _NeverReady:
+    @staticmethod
+    def is_set() -> bool:
+        return False
+
+    @staticmethod
+    def wait(timeout: float | None = None) -> bool:
+        del timeout
+        return False
+
+
+class _InFlightChannel:
+    """A queue whose payload has not reached the parent's buffer yet.
+
+    `multiprocessing.Queue.put` hands the bytes to a feeder thread, so a child
+    can exit before a non-blocking read on the parent can see them.
+    """
+
+    def __init__(self, payload: str) -> None:
+        self._payload = payload
+
+    def get_nowait(self) -> str:
+        raise queue.Empty
+
+    def get(self, timeout: float | None = None) -> str:
+        del timeout
+        return self._payload
+
+
+class _ReadyChannel:
+    def __init__(self, payload: str) -> None:
+        self._payload = payload
+        self._taken = False
+
+    def get_nowait(self) -> str:
+        if self._taken:
+            raise queue.Empty
+        self._taken = True
+        return self._payload
+
+    def get(self, timeout: float | None = None) -> str:
+        del timeout
+        raise queue.Empty
+
+
+class _EmptyChannel:
+    @staticmethod
+    def get_nowait() -> str:
+        raise queue.Empty
+
+    @staticmethod
+    def get(timeout: float | None = None) -> str:
+        del timeout
+        raise queue.Empty
+
+
+def _group(proc, channel) -> StageGroup:
+    group = StageGroup("g", [SimpleNamespace(process_name="worker")])
+    group._processes = [proc]
+    group._ready_events = [_NeverReady()]
+    group._startup_error_channels = [channel]
+    return group
+
+
+@pytest.mark.asyncio
+async def test_dead_child_reports_a_traceback_still_in_flight() -> None:
+    """The read must not be non-blocking on the death path.
+
+    With `get_nowait()` here the parent reports only an exit code, which is the
+    regression this covers.
+    """
+    group = _group(_DeadProcess(), _InFlightChannel(TRACEBACK))
+
+    with pytest.raises(RuntimeError, match="factory boom") as excinfo:
+        await group.wait_ready(timeout=5.0)
+
+    assert "died during startup" in str(excinfo.value)
+    assert "exit code 1" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_live_child_that_already_reported_is_not_left_to_time_out() -> None:
+    group = _group(_LiveProcess(), _ReadyChannel(TRACEBACK))
+
+    with pytest.raises(RuntimeError, match="factory boom") as excinfo:
+        await group.wait_ready(timeout=5.0)
+
+    assert "failed during startup" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_dead_child_without_a_traceback_still_names_the_exit_code() -> None:
+    group = _group(_DeadProcess(), _EmptyChannel())
+
+    with pytest.raises(RuntimeError, match="died during startup") as excinfo:
+        await group.wait_ready(timeout=5.0)
+
+    assert "exit code 1" in str(excinfo.value)
+    assert "Startup failure detail" not in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_live_silent_child_times_out() -> None:
+    group = _group(_LiveProcess(), _EmptyChannel())
+
+    with pytest.raises(TimeoutError, match="did not become ready"):
+        await group.wait_ready(timeout=0.3)

--- a/tests/unit_test/pipeline/test_stage_workers_startup_errors.py
+++ b/tests/unit_test/pipeline/test_stage_workers_startup_errors.py
@@ -15,7 +15,7 @@ import pytest
 
 from sglang_omni.pipeline.stage_workers import StageGroup
 
-TRACEBACK = 'Traceback (most recent call last):\n  RuntimeError: factory boom'
+TRACEBACK = "Traceback (most recent call last):\n  RuntimeError: factory boom"
 
 
 class _DeadProcess:


### PR DESCRIPTION
Based on `pd_runtime` rather than the stack tip, because this touches only `stage_workers.py` and does not depend on PR 4. Context is in #1599.

## The problem

`wait_ready` tests `proc.is_alive()` before reading the startup error channel, and reads with `get_nowait()` on the death path. A child that fails in its factory writes its traceback and exits at once, so both choices race the report: the queue feeder may not have delivered the bytes when the parent looks, and the parent then raises a bare exit code or a plain `TimeoutError` with no cause.

## The change

Read the channel first, and keep a short blocking read on the death path so a traceback still in flight is not lost. Behaviour on success is unchanged.

## Testing

A second commit pins the contract with fake processes and fake channels, so the result does not depend on how long a real child takes to start. Four cases: a dead child whose traceback is still in flight, a live child that already reported, a dead child that reported nothing, and a live silent child. Only the first changes behaviour, and it fails without the fix.

`tests/unit_test/pipeline` gives 531 passed, 1 failed. The failure is `test_mp_runner_startup_failure_includes_child_factory_traceback`, which is flaky for a separate reason this PR does not address: it allows `timeout=10.0` while a child spawn costs 20-35s on the host I used, and nine unrelated tests earlier in `test_ipc.py` each reproduce it when run first. The right timeout depends on the CI host rather than mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
