### PR TITLE
[NPU] make CosyVoice3 stages platform-aware

### DIFF
--- a/sglang_omni/models/fun_cosyvoice3/config.py
+++ b/sglang_omni/models/fun_cosyvoice3/config.py
@@ -43,7 +43,7 @@ class FunCosyVoice3PipelineConfig(PipelineConfig):
             name="tts_engine",
             process="pipeline",
             factory=f"{_PKG}.stages.create_sglang_tts_engine_executor",
-            factory_args={"dtype": "bfloat16"},
+            factory_args={"device": None, "dtype": "bfloat16"},
             gpu=0,
             next="vocoder",
         ),

--- a/sglang_omni/models/fun_cosyvoice3/stages.py
+++ b/sglang_omni/models/fun_cosyvoice3/stages.py
@@ -71,7 +71,7 @@ def create_preprocessing_executor(model_path: str) -> SimpleScheduler:
 def create_sglang_tts_engine_executor(
     model_path: str,
     *,
-    device: str = "cuda:0",
+    device: str | None = None,
     gpu_id: int | None = None,
     dtype: str = "bfloat16",
     server_args_overrides: dict[str, Any] | None = None,

--- a/tests/unit_test/test_stage_device_contract.py
+++ b/tests/unit_test/test_stage_device_contract.py
@@ -24,6 +24,7 @@ _MODELS = sorted(
 # Every stage that relies on device=None. Adding one means adding a test below that
 # proves the factory resolves it.
 _NONE_DEVICE_STAGES = {
+    ("fun_cosyvoice3", "tts_engine"),
     ("qwen3_asr", "asr"),
     ("qwen3_omni", "audio_encoder"),
     ("qwen3_omni", "code2wav"),
@@ -155,3 +156,26 @@ def test_qwen3_asr_stage_forwards_none_to_the_shared_builder(
     # Placement injects gpu_id only when the signature declares it. Without it the
     # builder resolved a bare accelerator and told SGLang card 0.
     assert seen["gpu_id"] == 1
+
+
+def test_fun_cosyvoice3_tts_stage_forwards_none_to_the_shared_builder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.fun_cosyvoice3 import stages
+    from sglang_omni.scheduling import engine_factory
+
+    seen: dict[str, object] = {}
+
+    def spy_build(self, model_path, **kwargs):
+        del self, model_path
+        seen.update(kwargs)
+        return SimpleNamespace()
+
+    monkeypatch.setattr(
+        engine_factory.SGLangGenerationEngineBuilder, "build", spy_build
+    )
+
+    stages.create_sglang_tts_engine_executor("unused", device=None, gpu_id=2)
+
+    assert seen["device"] is None
+    assert seen["gpu_id"] == 2


### PR DESCRIPTION
# [NPU] make CosyVoice3 stages platform-aware

## Motivation

Fun-CosyVoice3's AR stage defaulted to `device="cuda:0"`. On an Ascend host,
`torch_npu.contrib.transfer_to_npu` made tensor operations execute on NPU, but
SGLang still received `ServerArgs.device="cuda"`.

This split device identity caused SGLang to select the Triton attention path
and generic CUDA graph backend instead of its native Ascend attention and
`NPUCudaGraphBackend` implementations. Decode graph startup then failed because
the generic path passed the CUDA-only `cuda_graph=` keyword to
`torch_npu.npu.graph`.

## Modifications

- Make the CosyVoice3 AR factory device default platform-neutral (`None`).
- Declare `device: null` in the pipeline stage configuration.
- Let the existing SGLang-Omni placement layer resolve the current platform and
  GPU index.
- Extend the stage-device contract tests so a future CUDA literal cannot be
  reintroduced silently.

CUDA behavior remains `cuda:0`; Ascend resolves to `npu:0`.

## Validation

After the change, startup logs show:

```text
attention_backend=ascend
decode_attention_backend=ascend
Capture target decode NPU graph
```

Decode graph capture decreases from `22.44 s` on the incorrectly routed generic
path to `1.17 s` on the native NPU backend.

Fixed request, batch=1, one warmup + five measured calls:

| Mode | Mean latency | Mean RTF |
|---|---:|---:|
| NPU eager | 0.6791 s | 1.3059 |
| NPU graph | 0.4465 s | 0.8586 |

Mean speedup: `1.521x`. The five corresponding short-request WAV outputs are
byte-identical between eager and graph.

The performance run above was collected on SGLang-Omni commit `5a1c694`. The
branch was then replayed without conflicts onto current `main` `fee6a1bc`.
Current-tip validation includes the 52-test focused suite and an Ascend
end-to-end stacked smoke run showing native Ascend attention, native decode NPU
graph capture, HTTP 200, and valid 24 kHz WAV output.

- Current-tip Fun-CosyVoice3 + device-contract focused tests: `52 passed`.
- Format and `git diff --check`: passed.

## Related issues

Related #1597
Related #1652

This PR does not duplicate the NPU dependency manifest/install documentation in
Draft PR #1577.
