### PR TITLE
[NPU] make accelerator diagnostics platform-aware

### DIFF
--- a/sglang_omni/cli/check_gpu.py
+++ b/sglang_omni/cli/check_gpu.py
@@ -21,11 +21,11 @@ def check_gpu(
         bool,
         typer.Option(
             "--strict",
-            help="Exit nonzero when warnings are present or no CUDA GPU is visible.",
+            help="Exit nonzero when warnings are present or no accelerator is visible.",
         ),
     ] = False,
 ) -> None:
-    """Report GPU mapping, runtime versions, and installed backends."""
+    """Report accelerator mapping, runtime versions, and installed backends."""
 
     report = collect_gpu_diagnostics()
     if json_output:
@@ -33,9 +33,14 @@ def check_gpu(
     else:
         typer.echo(render_gpu_diagnostics(report))
 
-    if strict and (
-        report["warnings"]
-        or not report["environment"]["cuda_available"]
-        or not report["gpus"]
-    ):
-        raise typer.Exit(code=1)
+    if strict:
+        environment = report["environment"]
+        accelerator_available = environment.get(
+            "accelerator_available", environment.get("cuda_available", False)
+        )
+        if (
+            report["warnings"]
+            or not accelerator_available
+            or not environment.get("logical_device_count", 0)
+        ):
+            raise typer.Exit(code=1)

--- a/sglang_omni/diagnostics/gpu.py
+++ b/sglang_omni/diagnostics/gpu.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Model-free GPU and backend diagnostics."""
+"""Model-free accelerator and backend diagnostics."""
 
 from __future__ import annotations
 
@@ -35,6 +35,23 @@ _BACKENDS = (
     ),
     ("communication", "nixl", "nixl._api"),
     ("communication", "mooncake", "mooncake.engine"),
+)
+_NPU_BACKENDS = (
+    ("runtime", "torch-npu", "torch_npu", "torch-npu"),
+    (
+        "attention",
+        "ascend",
+        "sglang.srt.hardware_backend.npu.attention.ascend_backend",
+        "sglang",
+    ),
+    ("compiler", "triton-ascend", "triton", "triton-ascend"),
+    ("kernel", "sgl-kernel-npu", "sgl_kernel_npu", "sgl-kernel-npu"),
+    (
+        "communication",
+        "memfabric-hybrid",
+        "memfabric_hybrid",
+        "memfabric-hybrid",
+    ),
 )
 _IMPORT_PROBE_TIMEOUT_SECONDS = 30.0
 _IMPORT_PROBE_CODE = "import importlib, sys; importlib.import_module(sys.argv[1])"
@@ -108,10 +125,26 @@ def _distribution_info(module: str) -> tuple[str | None, str | None]:
 
 
 def _backend_inventory() -> list[dict[str, Any]]:
+    return _inventory_for(_BACKENDS)
+
+
+def _npu_backend_inventory() -> list[dict[str, Any]]:
+    return _inventory_for(_NPU_BACKENDS)
+
+
+def _inventory_for(
+    definitions: tuple[tuple[str, ...], ...],
+) -> list[dict[str, Any]]:
     backends = []
-    for category, name, module in _BACKENDS:
+    for definition in definitions:
+        category, name, module, *preferred_distributions = definition
         import_error = _module_import_error(module)
         distribution, version = _distribution_info(module)
+        if preferred_distributions:
+            preferred = preferred_distributions[0]
+            preferred_version = _distribution_version(preferred)
+            if preferred_version is not None:
+                distribution, version = preferred, preferred_version
         importable = import_error is None
         installed = distribution is not None or importable
         reason = None
@@ -136,6 +169,24 @@ def _backend_inventory() -> list[dict[str, Any]]:
             }
         )
     return backends
+
+
+def _torch_npu(torch: Any) -> Any | None:
+    npu = getattr(torch, "npu", None)
+    if npu is not None:
+        return npu
+    try:
+        importlib.import_module("torch_npu")
+    except Exception:
+        return None
+    return getattr(torch, "npu", None)
+
+
+def _distribution_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except Exception:
+        return None
 
 
 def _cuda_runtime_version() -> str | None:
@@ -205,8 +256,7 @@ def _nvml_inventory(
             device["free_memory_bytes"] = int(memory.free)
         except Exception as exc:
             warnings.append(
-                f"NVML memory query failed for physical_index="
-                f"{physical_index}: {exc}"
+                f"NVML memory query failed for physical_index={physical_index}: {exc}"
             )
         try:
             pci = pynvml.nvmlDeviceGetPciInfo(handle)
@@ -320,6 +370,61 @@ def _logical_devices(
     return devices
 
 
+def _logical_npu_devices(
+    npu: Any,
+    visible_devices: list[int | str],
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    try:
+        if not npu.is_available():
+            return []
+        count = int(npu.device_count())
+    except Exception as exc:
+        warnings.append(f"PyTorch NPU device count query failed: {exc}")
+        return []
+
+    devices = []
+    for logical_index in range(count):
+        properties = None
+        try:
+            properties = npu.get_device_properties(logical_index)
+        except Exception as exc:
+            warnings.append(
+                f"PyTorch NPU {logical_index} properties query failed: {exc}"
+            )
+
+        free_memory = None
+        total_memory = getattr(properties, "total_memory", None)
+        try:
+            free_memory, queried_total = npu.mem_get_info(logical_index)
+            total_memory = queried_total or total_memory
+        except Exception as exc:
+            warnings.append(f"PyTorch NPU {logical_index} memory query failed: {exc}")
+
+        visible_device = (
+            visible_devices[logical_index]
+            if logical_index < len(visible_devices)
+            else logical_index
+        )
+        devices.append(
+            {
+                "logical_index": logical_index,
+                "visible_device": visible_device,
+                "physical_index": (
+                    visible_device if isinstance(visible_device, int) else None
+                ),
+                "uuid": str(getattr(properties, "uuid", "") or "") or None,
+                "name": getattr(properties, "name", None),
+                "total_memory_bytes": total_memory,
+                "free_memory_bytes": free_memory,
+                "cube_core_count": getattr(properties, "cube_core_num", None),
+                "vector_core_count": getattr(properties, "vector_core_num", None),
+                "l2_cache_bytes": getattr(properties, "L2_cache_size", None),
+            }
+        )
+    return devices
+
+
 def collect_gpu_diagnostics(
     *,
     env: Mapping[str, str] | None = None,
@@ -329,19 +434,39 @@ def collect_gpu_diagnostics(
     """Collect diagnostics without loading model configuration or weights."""
 
     source_env = os.environ if env is None else env
-    visible_value = source_env.get("CUDA_VISIBLE_DEVICES")
-    visible_devices = parse_cuda_visible_devices(visible_value)
     torch = torch_module or importlib.import_module("torch")
-    pynvml = pynvml_module if pynvml_module is not None else _try_import_pynvml()
+    npu = _torch_npu(torch)
+    npu_available = bool(npu is not None and npu.is_available())
+    cuda_available = bool(torch.cuda.is_available())
+    platform = "npu" if npu_available else "cuda" if cuda_available else "unavailable"
 
-    inventory, system, warnings = _nvml_inventory(pynvml)
-    try:
-        devices = _logical_devices(torch, visible_devices, inventory, warnings)
-    finally:
-        if pynvml is not None:
-            _shutdown_nvml(pynvml)
+    cuda_visible_value = source_env.get("CUDA_VISIBLE_DEVICES")
+    ascend_rt_visible_value = source_env.get("ASCEND_RT_VISIBLE_DEVICES")
+    ascend_visible_value = source_env.get("ASCEND_VISIBLE_DEVICES")
+    npu_visible_value = ascend_rt_visible_value or ascend_visible_value
+    warnings: list[str] = []
+    system = {"driver_version": None, "cuda_driver_api_version": None}
+    gpus: list[dict[str, Any]] = []
+    npus: list[dict[str, Any]] = []
 
-    backends = _backend_inventory()
+    if platform == "npu":
+        npus = _logical_npu_devices(
+            npu, parse_cuda_visible_devices(npu_visible_value), warnings
+        )
+        backends = _npu_backend_inventory()
+    else:
+        visible_devices = parse_cuda_visible_devices(cuda_visible_value)
+        pynvml = pynvml_module if pynvml_module is not None else _try_import_pynvml()
+        inventory, system, nvml_warnings = _nvml_inventory(pynvml)
+        warnings.extend(nvml_warnings)
+        try:
+            gpus = _logical_devices(torch, visible_devices, inventory, warnings)
+        finally:
+            if pynvml is not None:
+                _shutdown_nvml(pynvml)
+        backends = _backend_inventory()
+
+    devices = npus if platform == "npu" else gpus
     warnings.extend(
         backend["reason"]
         for backend in backends
@@ -350,17 +475,24 @@ def collect_gpu_diagnostics(
     return {
         "schema_version": 1,
         "environment": {
-            "cuda_visible_devices": visible_value,
+            "platform": platform,
+            "accelerator_available": npu_available or cuda_available,
+            "cuda_visible_devices": cuda_visible_value,
+            "ascend_rt_visible_devices": ascend_rt_visible_value,
+            "ascend_visible_devices": ascend_visible_value,
             **system,
             "cuda_runtime_version": _cuda_runtime_version(),
             "pytorch_version": getattr(torch, "__version__", None),
             "pytorch_cuda_build": getattr(
                 getattr(torch, "version", None), "cuda", None
             ),
-            "cuda_available": bool(torch.cuda.is_available()),
+            "cuda_available": cuda_available,
+            "npu_available": npu_available,
+            "torch_npu_version": _distribution_version("torch-npu"),
             "logical_device_count": len(devices),
         },
-        "gpus": devices,
+        "gpus": gpus,
+        "npus": npus,
         "backends": backends,
         "warnings": warnings,
     }
@@ -370,26 +502,59 @@ def render_gpu_diagnostics(report: Mapping[str, Any]) -> str:
     """Render a compact diagnostic summary for terminal output."""
 
     environment = report["environment"]
-    visible = environment["cuda_visible_devices"]
+    platform = environment.get("platform", "cuda")
+    is_npu = platform == "npu"
+    visible_key = "ascend_rt_visible_devices" if is_npu else "cuda_visible_devices"
+    visible_name = "ASCEND_RT_VISIBLE_DEVICES" if is_npu else "CUDA_VISIBLE_DEVICES"
+    visible = environment.get(visible_key)
+    devices = report.get("npus", []) if is_npu else report["gpus"]
     lines = [
-        "SGLang-Omni GPU diagnostics (no model loaded)",
-        f"CUDA_VISIBLE_DEVICES: {visible if visible is not None else '<unset>'}",
-        f"Driver: {environment['driver_version'] or 'unavailable'}",
-        (
-            "CUDA driver/runtime: "
-            f"{environment['cuda_driver_api_version'] or 'unavailable'} / "
-            f"{environment['cuda_runtime_version'] or 'unavailable'}"
-        ),
-        (
-            "PyTorch/CUDA build: "
-            f"{environment['pytorch_version'] or 'unavailable'} / "
-            f"{environment['pytorch_cuda_build'] or 'unavailable'}"
-        ),
-        "GPUs:",
+        f"SGLang-Omni {platform.upper()} diagnostics (no model loaded)",
+        f"{visible_name}: {visible if visible is not None else '<unset>'}",
     ]
-    if not report["gpus"]:
-        lines.append("  No CUDA devices are visible to PyTorch.")
-    for device in report["gpus"]:
+    if is_npu:
+        lines.extend(
+            [
+                (
+                    "PyTorch/torch-npu: "
+                    f"{environment.get('pytorch_version') or 'unavailable'} / "
+                    f"{environment.get('torch_npu_version') or 'unavailable'}"
+                ),
+                "NPUs:",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                f"Driver: {environment.get('driver_version') or 'unavailable'}",
+                (
+                    "CUDA driver/runtime: "
+                    f"{environment.get('cuda_driver_api_version') or 'unavailable'} / "
+                    f"{environment.get('cuda_runtime_version') or 'unavailable'}"
+                ),
+                (
+                    "PyTorch/CUDA build: "
+                    f"{environment.get('pytorch_version') or 'unavailable'} / "
+                    f"{environment.get('pytorch_cuda_build') or 'unavailable'}"
+                ),
+                "GPUs:",
+            ]
+        )
+    if not devices:
+        lines.append(f"  No {platform.upper()} devices are visible to PyTorch.")
+    for device in devices:
+        if is_npu:
+            lines.append(
+                f"  logical {device['logical_index']} -> physical "
+                f"{device['physical_index']} visible={device['visible_device']} "
+                f"name={device['name'] or 'unknown'} "
+                f"memory={format_bytes_gib(device['free_memory_bytes'])}/"
+                f"{format_bytes_gib(device['total_memory_bytes'])} "
+                f"cube/vector={device['cube_core_count'] or 'unknown'}/"
+                f"{device['vector_core_count'] or 'unknown'} "
+                f"uuid={device['uuid'] or 'unknown'}"
+            )
+            continue
         lines.append(
             f"  logical {device['logical_index']} -> physical "
             f"{device['physical_index']} visible={device['visible_device']} "

--- a/tests/unit_test/diagnostics/test_gpu.py
+++ b/tests/unit_test/diagnostics/test_gpu.py
@@ -50,6 +50,41 @@ class _FakeTorch:
         self.cuda = _FakeCuda()
 
 
+class _UnavailableCuda:
+    def is_available(self) -> bool:
+        return False
+
+
+class _FakeNPU:
+    def is_available(self) -> bool:
+        return True
+
+    def device_count(self) -> int:
+        return 2
+
+    def get_device_properties(self, index: int) -> SimpleNamespace:
+        return SimpleNamespace(
+            name=f"Ascend910-test-{index}",
+            total_memory=64 * 1024**3,
+            uuid=f"npu-uuid-{index}",
+            cube_core_num=24,
+            vector_core_num=48,
+            L2_cache_size=192 * 1024**2,
+        )
+
+    def mem_get_info(self, index: int) -> tuple[int, int]:
+        return ((60 - index) * 1024**3, 64 * 1024**3)
+
+
+class _FakeNPUTorch:
+    __version__ = "2.10.0+cpu"
+    version = SimpleNamespace(cuda=None)
+
+    def __init__(self) -> None:
+        self.cuda = _UnavailableCuda()
+        self.npu = _FakeNPU()
+
+
 class _FakeNVML(ModuleType):
     def __init__(self) -> None:
         super().__init__("pynvml")
@@ -119,12 +154,50 @@ def test_collect_gpu_diagnostics_preserves_reordered_visible_mapping(
         "schema_version",
         "environment",
         "gpus",
+        "npus",
         "backends",
         "warnings",
     }
     rendered = gpu_diagnostics.render_gpu_diagnostics(report)
     assert "logical 0 -> physical 1" in rendered
     assert fake_nvml.shutdown_called is True
+
+
+def test_collect_gpu_diagnostics_reports_npu_devices_without_nvml(monkeypatch) -> None:
+    fake_nvml = _FakeNVML()
+    monkeypatch.setattr(gpu_diagnostics, "_npu_backend_inventory", lambda: [])
+    monkeypatch.setattr(
+        gpu_diagnostics,
+        "_distribution_version",
+        lambda name: "2.10.0" if name == "torch-npu" else None,
+    )
+
+    report = gpu_diagnostics.collect_gpu_diagnostics(
+        env={
+            "ASCEND_RT_VISIBLE_DEVICES": "7,3",
+            "ASCEND_VISIBLE_DEVICES": "7,3",
+        },
+        torch_module=_FakeNPUTorch(),
+        pynvml_module=fake_nvml,
+    )
+
+    assert report["environment"]["platform"] == "npu"
+    assert report["environment"]["accelerator_available"] is True
+    assert report["environment"]["npu_available"] is True
+    assert report["environment"]["cuda_available"] is False
+    assert report["environment"]["logical_device_count"] == 2
+    assert report["gpus"] == []
+    assert [npu["physical_index"] for npu in report["npus"]] == [7, 3]
+    assert report["npus"][0]["name"] == "Ascend910-test-0"
+    assert report["npus"][0]["free_memory_bytes"] == 60 * 1024**3
+    assert report["npus"][0]["cube_core_count"] == 24
+    assert report["npus"][0]["vector_core_count"] == 48
+    assert fake_nvml.shutdown_called is False
+
+    rendered = gpu_diagnostics.render_gpu_diagnostics(report)
+    assert "SGLang-Omni NPU diagnostics" in rendered
+    assert "logical 0 -> physical 7" in rendered
+    assert "Ascend910-test-0" in rendered
 
 
 def test_nvml_inventory_failure_is_isolated_per_physical_device(
@@ -280,6 +353,31 @@ def test_backend_inventory_resolves_cuda_variant_distributions(monkeypatch) -> N
     assert all(backend["importable"] for backend in backends)
 
 
+def test_npu_backend_inventory_prefers_platform_distribution(monkeypatch) -> None:
+    monkeypatch.setattr(
+        gpu_diagnostics,
+        "_NPU_BACKENDS",
+        (("compiler", "triton-ascend", "triton", "triton-ascend"),),
+    )
+    monkeypatch.setattr(gpu_diagnostics, "_module_import_error", lambda module: None)
+    monkeypatch.setattr(
+        gpu_diagnostics,
+        "_distribution_info",
+        lambda module: ("triton", "3.5.0"),
+    )
+    monkeypatch.setattr(
+        gpu_diagnostics,
+        "_distribution_version",
+        lambda distribution: "3.2.1.dev20260530",
+    )
+
+    backend = gpu_diagnostics._npu_backend_inventory()[0]
+
+    assert backend["distribution"] == "triton-ascend"
+    assert backend["version"] == "3.2.1.dev20260530"
+    assert backend["importable"] is True
+
+
 def test_module_import_probe_survives_hard_crash(tmp_path, monkeypatch) -> None:
     assert gpu_diagnostics._module_import_error("json") is None
 
@@ -367,6 +465,34 @@ def test_check_gpu_strict_fails_without_visible_cuda_device(monkeypatch) -> None
     result = CliRunner().invoke(app, ["check-gpu", "--json", "--strict"])
 
     assert result.exit_code == 1
+    assert json.loads(result.stdout) == report
+
+
+def test_check_gpu_strict_accepts_visible_npu(monkeypatch) -> None:
+    check_gpu_module = importlib.import_module("sglang_omni.cli.check_gpu")
+    report = {
+        "schema_version": 1,
+        "environment": {
+            "platform": "npu",
+            "accelerator_available": True,
+            "cuda_available": False,
+            "npu_available": True,
+            "logical_device_count": 1,
+        },
+        "gpus": [],
+        "npus": [{"logical_index": 0}],
+        "backends": [],
+        "warnings": [],
+    }
+    monkeypatch.setattr(
+        check_gpu_module,
+        "collect_gpu_diagnostics",
+        lambda: report,
+    )
+
+    result = CliRunner().invoke(app, ["check-gpu", "--json", "--strict"])
+
+    assert result.exit_code == 0
     assert json.loads(result.stdout) == report
 
 


### PR DESCRIPTION
# [NPU] make accelerator diagnostics platform-aware

## Motivation

`sgl-omni check-gpu` used CUDA-only discovery. On a healthy Ascend host it
reported zero devices, returned success, and omitted the installed NPU backend
stack. This made installation failures and platform-routing problems difficult
to distinguish.

## Modifications

- Preserve the existing CUDA JSON schema and output.
- Add accelerator/platform availability fields.
- Discover visible Ascend devices and report model, physical mapping, memory,
  Cube/Vector core counts, and visibility environment.
- Inventory `torch-npu`, Ascend attention, Triton-Ascend, sgl-kernel-npu, and
  memfabric packages.
- Make strict mode validate the active accelerator instead of CUDA only.

## Validation

On `Ascend910_9382 (physical=0, card=0, chip=0, logical=npu:0)`, strict mode
reports the device, approximately 61.27 GiB HBM, 24 Cube cores, 48 Vector cores,
and the installed NPU backend packages.

- Current-tip focused diagnostics tests: `15 passed`.
- Ruff format/check and `git diff --check`: passed.

Related #1597
