### PR TITLE
feat(pd): resolve the Decode target per request, the seam for non-1:1 sizing

### DIFF
--- a/sglang_omni/config/pd_rewrite.py
+++ b/sglang_omni/config/pd_rewrite.py
@@ -156,7 +156,11 @@ def _split_pd_stage(
             "stream_to": [inbound_rename.get(t, t) for t in s.stream_to],
             "pd_disaggregation": None,
             # Note (Yue Yin): Keep compiler metadata out of user factory kwargs.
-            "pd_execution": PDExecution(role="prefill", partner=decode_name),
+            "pd_execution": PDExecution(
+                role="prefill",
+                partner=decode_name,
+                decode_targets=(decode_name,),
+            ),
         },
     )
 

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -159,6 +159,11 @@ class PDExecution(BaseModel):
 
     role: Literal["prefill", "decode"]
     partner: str
+    # Note (Audrey Zheng): the Decode halves this Prefill may hand off to. One
+    # entry today. Carrying a sequence means a second Decode worker does not
+    # migrate this schema, and the choice can move to admission time without
+    # touching the handoff send path.
+    decode_targets: tuple[str, ...] = ()
 
 
 class StageConfig(BaseModel):

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -156,6 +156,7 @@ class Stage:
                 stage_name=name,
                 role=pd_execution.role,
                 partner=pd_execution.partner,
+                decode_targets=pd_execution.decode_targets,
             )
             self._comm.register_kv_pool(pool)
             if receiver is not None:

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -63,6 +63,33 @@ def _error_text(exc: BaseException) -> str:
     return str(exc) or type(exc).__name__
 
 
+def _decode_targets(
+    rank_endpoints: dict[str, tuple[str, ...]],
+    partner: str,
+) -> tuple[str, ...]:
+    """Return every Decode instance this Prefill half may send to.
+
+    Replicating a process renames its stages ``<name>@r0``, ``<name>@r1``, and
+    every instance gets its own rank endpoints, so the instances are already
+    named here. Deriving the list from those keys keeps the count out of the
+    stage's arguments.
+
+    The order is sorted rather than dictionary order because every Prefill
+    rank has to agree: the KV send is rank-addressed, so ranks that disagree
+    scatter one request's shards across Decode halves and nothing checks it.
+
+    An unreplicated Decode half yields exactly its own name, so the choice is
+    a constant and behaviour is unchanged.
+    """
+    if not rank_endpoints:
+        return ()
+    prefix = f"{partner}@"
+    targets = [
+        name for name in rank_endpoints if name == partner or name.startswith(prefix)
+    ]
+    return tuple(sorted(targets))
+
+
 class Stage:
     """IO shell for one pipeline stage.
 
@@ -156,7 +183,8 @@ class Stage:
                 stage_name=name,
                 role=pd_execution.role,
                 partner=pd_execution.partner,
-                decode_targets=pd_execution.decode_targets,
+                decode_targets=_decode_targets(rank_endpoints, pd_execution.partner)
+                or pd_execution.decode_targets,
             )
             self._comm.register_kv_pool(pool)
             if receiver is not None:

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -185,6 +185,9 @@ class Stage:
                 partner=pd_execution.partner,
                 decode_targets=_decode_targets(rank_endpoints, pd_execution.partner)
                 or pd_execution.decode_targets,
+                resolve_decode_binding=self._decode_binding_resolver(
+                    pd_execution.partner
+                ),
             )
             self._comm.register_kv_pool(pool)
             if receiver is not None:
@@ -204,6 +207,31 @@ class Stage:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._scheduler_crash_error: BaseException | None = None
         self._background_task_error: BaseException | None = None
+
+    def _decode_binding_resolver(self, partner: str):
+        """Return a lookup from request id to bound Decode instance, or None.
+
+        The coordinator binds one instance per replicated Process at admission
+        and carries the choice on the envelope, which is where
+        ``_record_replica_bindings`` files it. Handing the scheduler a lookup
+        rather than the tables keeps it out of the replica machinery, and
+        returns None on a build that has no replicas so the request-id hash
+        stays in charge.
+        """
+        topology = getattr(self, "_replica_topology", None)
+        if topology is None or not topology.is_replicated(partner):
+            return None
+
+        def lookup(request_id: str) -> str | None:
+            bindings = self._replica_bindings.get(request_id)
+            if not bindings:
+                return None
+            replica_id = bindings.get(partner)
+            if replica_id is None:
+                return None
+            return topology.resolve(partner, replica_id)
+
+        return lookup
 
     async def start(self) -> None:
         if self._running:

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -562,6 +562,7 @@ class OmniScheduler:
         role: str,
         partner: str,
         decode_targets: tuple[str, ...] = (),
+        resolve_decode_binding: Any = None,
     ) -> tuple[Any, Any | None]:
         if self.tp_size != 1:
             raise NotImplementedError("PR3 PD runtime supports tp_size == 1 only")
@@ -575,6 +576,11 @@ class OmniScheduler:
         self._pd_role = role
         self._pd_partner = partner
         self._pd_decode_targets = tuple(decode_targets) or (partner,)
+        # Note (Audrey Zheng): when the Decode process is replicated, the
+        # coordinator already chose an instance for this request at admission
+        # and carries it on the envelope. Prefer that choice so one request has
+        # one answer; see `_resolve_decode_stage`.
+        self._pd_decode_binding_fn = resolve_decode_binding
         self._pd_pool_id = f"{stage_name}:kv"
         raw_pool = self.token_to_kv_pool_allocator.get_kvcache()
         layout_id = (
@@ -756,7 +762,49 @@ class OmniScheduler:
         targets = self.__dict__.get("_pd_decode_targets") or ()
         if not targets:
             return self._pd_partner
-        return select_decode_stage(targets, str(getattr(req, "rid", "")))
+        rid = str(getattr(req, "rid", ""))
+        bound = self._decode_stage_from_binding(rid, targets)
+        if bound is not None:
+            return bound
+        return select_decode_stage(targets, rid)
+
+    def _decode_stage_from_binding(
+        self, rid: str, targets: tuple[str, ...]
+    ) -> str | None:
+        """Return the Decode instance the coordinator bound this request to.
+
+        A replicated Process gets one instance per request, chosen at admission
+        and carried on the message envelope, so every Prefill rank reads the
+        same value. That satisfies the constraint `select_decode_stage`
+        documents, and it keeps one request on one Decode half by the same
+        mechanism the rest of the pipeline uses. Returns None when the Decode
+        process is not replicated or the binding has not arrived, and the hash
+        then decides.
+        """
+        fn = self.__dict__.get("_pd_decode_binding_fn")
+        if fn is None:
+            return None
+        try:
+            name = fn(rid)
+        except Exception:
+            logger.warning(
+                "PD: replica binding lookup failed for %s; falling back to the "
+                "request-id hash",
+                rid,
+                exc_info=True,
+            )
+            return None
+        if name is None:
+            return None
+        if name not in targets:
+            logger.warning(
+                "PD: replica binding named %r, which is not a Decode target "
+                "(%s); falling back to the request-id hash",
+                name,
+                ", ".join(targets),
+            )
+            return None
+        return name
 
     def bind_model_runner(self, model_runner: Any) -> None:
         """Attach a custom runner and its SGLang execution-contract bridge.

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -546,6 +546,7 @@ class OmniScheduler:
         self._prefill_end_done: set[str] = set()
         self._pd_role: str | None = None
         self._pd_partner: str | None = None
+        self._pd_decode_targets: tuple[str, ...] = ()
         self._pd_pool_id: str | None = None
         self._pd_ready_queue = _queue_mod.Queue()
         self._pd_deferred_admission: PDDecodeAdmission | None = None
@@ -559,6 +560,7 @@ class OmniScheduler:
         stage_name: str,
         role: str,
         partner: str,
+        decode_targets: tuple[str, ...] = (),
     ) -> tuple[Any, Any | None]:
         if self.tp_size != 1:
             raise NotImplementedError("PR3 PD runtime supports tp_size == 1 only")
@@ -571,6 +573,7 @@ class OmniScheduler:
 
         self._pd_role = role
         self._pd_partner = partner
+        self._pd_decode_targets = tuple(decode_targets) or (partner,)
         self._pd_pool_id = f"{stage_name}:kv"
         raw_pool = self.token_to_kv_pool_allocator.get_kvcache()
         layout_id = (
@@ -718,6 +721,7 @@ class OmniScheduler:
                     seq_len=len(req.origin_input_ids),
                     page_size=self.page_size,
                 )
+                decode_stage = self._resolve_decode_stage(req)
                 self.outbox.put(
                     OutgoingMessage(
                         request_id=req.rid,
@@ -725,9 +729,9 @@ class OmniScheduler:
                         data=PDPrefillHandoff(
                             continuation=continuation,
                             source_pool_id=self._pd_pool_id,
-                            target_pool_id=f"{self._pd_partner}:kv",
+                            target_pool_id=f"{decode_stage}:kv",
                             source_page_indices=pages,
-                            to_stage=self._pd_partner,
+                            to_stage=decode_stage,
                             lease=SGLangKVPageLease(req, self.tree_cache),
                         ),
                     )
@@ -736,6 +740,19 @@ class OmniScheduler:
                 self._release_request_kv_cache(req)
                 self._emit_request_error(req.rid, exc)
         batch.reqs = retained
+
+    def _resolve_decode_stage(self, req: Any) -> str:
+        """Return the Decode stage that receives this request's KV.
+
+        One candidate today, so the result never varies. The call is per
+        request rather than per stage, so adding Decode workers changes a
+        policy here instead of the handoff send path.
+        """
+        del req
+        # __getattr__ delegates unknown names upstream, so read the dict
+        # directly and fall back to the single partner a caller may have set.
+        targets = self.__dict__.get("_pd_decode_targets") or ()
+        return targets[0] if targets else self._pd_partner
 
     def bind_model_runner(self, model_runner: Any) -> None:
         """Attach a custom runner and its SGLang execution-contract bridge.

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -66,6 +66,7 @@ from sglang_omni.scheduling.pd_continuation import (
     ContinuationAwareKVReceiver,
     PDHandoffController,
 )
+from sglang_omni.scheduling.pd_decode_selection import select_decode_stage
 from sglang_omni.scheduling.pd_kv_adapter import (
     AllocatorKVReceiver,
     SGLangKVPageLease,
@@ -744,15 +745,18 @@ class OmniScheduler:
     def _resolve_decode_stage(self, req: Any) -> str:
         """Return the Decode stage that receives this request's KV.
 
-        One candidate today, so the result never varies. The call is per
-        request rather than per stage, so adding Decode workers changes a
-        policy here instead of the handoff send path.
+        The choice itself lives in `select_decode_stage`, which takes only
+        values every Prefill rank sees identically. That constraint is not
+        cosmetic: the KV send is rank-addressed, so ranks that disagree scatter
+        one request's shards across Decode halves. Read that function before
+        changing the policy.
         """
-        del req
         # __getattr__ delegates unknown names upstream, so read the dict
         # directly and fall back to the single partner a caller may have set.
         targets = self.__dict__.get("_pd_decode_targets") or ()
-        return targets[0] if targets else self._pd_partner
+        if not targets:
+            return self._pd_partner
+        return select_decode_stage(targets, str(getattr(req, "rid", "")))
 
     def bind_model_runner(self, model_runner: Any) -> None:
         """Attach a custom runner and its SGLang execution-contract bridge.

--- a/sglang_omni/scheduling/pd_decode_selection.py
+++ b/sglang_omni/scheduling/pd_decode_selection.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Choosing which Decode half receives one request's KV.
+
+This is a module-level function taking only values every Prefill rank sees
+identically, and that shape is the point. See `select_decode_stage`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+
+
+def select_decode_stage(targets: Sequence[str], request_id: str) -> str:
+    """Return the Decode stage that receives ``request_id``'s KV.
+
+    **Every Prefill rank runs this independently and they must agree.** The KV
+    send is rank-addressed: rank *i* sends its shard to the chosen stage's rank
+    *i* (`rank_endpoints[to_stage][tp_rank]` in `comm/engine.py`). At tp_size 1
+    there is one rank and agreement is trivial. Above that, two ranks choosing
+    differently scatter one request's shards across different Decode halves,
+    each of which then holds part of the KV and none of which holds all of it.
+
+    Nothing catches that. With a cross-rank admission join the request waits for
+    ranks that never commit and dies on the continuation timeout. Without one --
+    and `docs/design/pd_handoff.md` records that cross-rank admission is not
+    implemented -- each half admits on partial KV and attends over whatever
+    occupies the missing heads. The output is wrong and nothing says so.
+
+    So the choice must be a pure function of values every rank sees identically.
+    ``request_id`` is one. Queue depth, in-flight counts, local counters and
+    arrival order are not: they are the natural ingredients of a load-balancing
+    policy and every one of them differs per rank.
+
+    That is why this takes ``targets`` and ``request_id`` rather than a
+    scheduler. Adding rank-local state means changing the signature, which is
+    the point at which someone has to think about this.
+
+    The hash spreads requests evenly without coordination. A policy that needs
+    global state -- least-loaded, or affinity to a cached prefix -- has to be
+    decided in one place and carried to the ranks, not computed on each.
+    """
+    if not targets:
+        raise ValueError("no decode targets to select from")
+    if len(targets) == 1:
+        return targets[0]
+    digest = hashlib.blake2b(request_id.encode("utf-8"), digest_size=8).digest()
+    return targets[int.from_bytes(digest, "big") % len(targets)]

--- a/sglang_omni/scheduling/pd_decode_selection.py
+++ b/sglang_omni/scheduling/pd_decode_selection.py
@@ -39,6 +39,13 @@ def select_decode_stage(targets: Sequence[str], request_id: str) -> str:
     The hash spreads requests evenly without coordination. A policy that needs
     global state -- least-loaded, or affinity to a cached prefix -- has to be
     decided in one place and carried to the ranks, not computed on each.
+
+    The coordinator's admission binding is exactly that shape, and
+    `OmniScheduler._resolve_decode_stage` prefers it when the Decode process is
+    replicated: it is chosen once per request and carried on the message
+    envelope, so every rank reads the same value without computing anything.
+    This function decides the rest -- no replicas, or the binding has not
+    arrived -- and is where a policy would go that the coordinator cannot make.
     """
     if not targets:
         raise ValueError("no decode targets to select from")

--- a/tests/unit_test/pipeline/test_pd_decode_replicas.py
+++ b/tests/unit_test/pipeline/test_pd_decode_replicas.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Finding the Decode instances a Prefill half may send to.
+
+Replicating the Decode process renames its stage ``<name>@r0``, ``<name>@r1``,
+and that renaming happens after the PD graph rewrite, so the target list
+cannot be fixed when the halves are compiled. It is derived at bind time from
+the endpoints, which are named per instance.
+"""
+
+from __future__ import annotations
+
+from sglang_omni.pipeline.stage.runtime import _decode_targets
+
+
+def _endpoints(*names: str) -> dict[str, tuple[str, ...]]:
+    return {name: (f"ipc:///run/{name}",) for name in names}
+
+
+def test_an_unreplicated_decode_half_is_its_own_only_target() -> None:
+    """The single-instance case must stay a constant choice."""
+    eps = _endpoints("thinker_prefill", "thinker_decode")
+
+    assert _decode_targets(eps, "thinker_decode") == ("thinker_decode",)
+
+
+def test_every_replica_becomes_a_target() -> None:
+    eps = _endpoints("thinker_prefill", "thinker_decode@r0", "thinker_decode@r1")
+
+    assert _decode_targets(eps, "thinker_decode") == (
+        "thinker_decode@r0",
+        "thinker_decode@r1",
+    )
+
+
+def test_the_order_does_not_depend_on_dictionary_order() -> None:
+    """Prefill ranks that disagree scatter one request's shards."""
+    forward = _endpoints("thinker_decode@r0", "thinker_decode@r1")
+    reverse = _endpoints("thinker_decode@r1", "thinker_decode@r0")
+
+    assert _decode_targets(forward, "thinker_decode") == _decode_targets(
+        reverse, "thinker_decode"
+    )
+
+
+def test_another_stage_is_not_a_target() -> None:
+    """A prefix match must not pick up an unrelated stage."""
+    eps = _endpoints("thinker_decode", "thinker_decoder_aux", "talker_decode")
+
+    assert _decode_targets(eps, "thinker_decode") == ("thinker_decode",)
+
+
+def test_no_endpoints_yields_no_targets() -> None:
+    assert _decode_targets({}, "thinker_decode") == ()

--- a/tests/unit_test/pipeline/test_pd_decode_target.py
+++ b/tests/unit_test/pipeline/test_pd_decode_target.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from types import SimpleNamespace
+
+import pytest
 
 from sglang_omni.config import expand_pd_stages
 from sglang_omni.config.schema import (
@@ -13,6 +16,7 @@ from sglang_omni.config.schema import (
     PipelineConfig,
 )
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+from sglang_omni.scheduling.pd_decode_selection import select_decode_stage
 from tests.unit_test.pipeline.helpers import stage
 
 
@@ -58,8 +62,14 @@ def test_resolver_reads_the_candidate_list_rather_than_a_fixed_partner() -> None
     """With more than one candidate the send path needs no change to pick."""
     scheduler = OmniScheduler.__new__(OmniScheduler)
     scheduler._pd_decode_targets = ("decode_a", "decode_b")
+    scheduler._pd_partner = "decode_never"
 
-    assert scheduler._resolve_decode_stage(SimpleNamespace(rid="a")) == "decode_a"
+    chosen = {
+        scheduler._resolve_decode_stage(SimpleNamespace(rid=f"req-{i}"))
+        for i in range(50)
+    }
+
+    assert chosen == {"decode_a", "decode_b"}
 
 
 def test_resolver_falls_back_to_partner_when_no_candidates_are_set() -> None:
@@ -68,3 +78,35 @@ def test_resolver_falls_back_to_partner_when_no_candidates_are_set() -> None:
     scheduler._pd_partner = "thinker_decode"
 
     assert scheduler._resolve_decode_stage(SimpleNamespace(rid="a")) == "thinker_decode"
+
+
+def test_every_rank_reaches_the_same_choice() -> None:
+    """The selection depends only on values all Prefill ranks see alike.
+
+    Ranks that disagree scatter one request's KV shards across Decode halves,
+    and nothing catches that.
+    """
+    targets = ("decode_a", "decode_b", "decode_c")
+
+    for rid in (f"req-{i}" for i in range(50)):
+        chosen = {select_decode_stage(targets, rid) for _ in range(4)}
+        assert len(chosen) == 1
+
+
+def test_the_choice_spreads_across_the_candidates() -> None:
+    """A constant answer would be deterministic but useless as a policy."""
+    targets = ("decode_a", "decode_b", "decode_c")
+
+    counts = Counter(select_decode_stage(targets, f"req-{i}") for i in range(600))
+
+    assert set(counts) == set(targets)
+    assert min(counts.values()) > 100
+
+
+def test_one_candidate_is_returned_without_hashing() -> None:
+    assert select_decode_stage(("only",), "any-request") == "only"
+
+
+def test_no_candidates_is_an_error() -> None:
+    with pytest.raises(ValueError, match="no decode targets"):
+        select_decode_stage((), "req")

--- a/tests/unit_test/pipeline/test_pd_decode_target.py
+++ b/tests/unit_test/pipeline/test_pd_decode_target.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The Decode target is resolved per request, not fixed when the stage binds."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from sglang_omni.config import expand_pd_stages
+from sglang_omni.config.schema import (
+    PDConfig,
+    PDExecution,
+    PDStagePlacement,
+    PipelineConfig,
+)
+from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+from tests.unit_test.pipeline.helpers import stage
+
+
+def _pd(prefill_gpu: int, decode_gpu: int) -> PDConfig:
+    return PDConfig(
+        prefill=PDStagePlacement(gpu=prefill_gpu),
+        decode=PDStagePlacement(gpu=decode_gpu),
+    )
+
+
+def test_rewrite_records_the_decode_candidates_on_the_prefill_half() -> None:
+    config = PipelineConfig(
+        model_path="dummy",
+        stages=[stage("thinker", terminal=True, pd_disaggregation=_pd(0, 1))],
+    )
+
+    expansion = expand_pd_stages(
+        list(config.stages), entry_stage=config.resolved_entry_stage
+    )
+    halves = {s.name: s for s in expansion.stages}
+
+    assert halves["thinker_prefill"].pd_execution.decode_targets == ("thinker_decode",)
+    # The Decode half hands off to nobody, so it carries no candidates.
+    assert halves["thinker_decode"].pd_execution.decode_targets == ()
+
+
+def test_pd_execution_defaults_to_no_candidates() -> None:
+    """A PDExecution built without the field stays valid, so older callers work."""
+    execution = PDExecution(role="prefill", partner="thinker_decode")
+
+    assert execution.decode_targets == ()
+
+
+def test_resolver_returns_the_single_candidate() -> None:
+    scheduler = OmniScheduler.__new__(OmniScheduler)
+    scheduler._pd_decode_targets = ("thinker_decode",)
+
+    assert scheduler._resolve_decode_stage(SimpleNamespace(rid="a")) == "thinker_decode"
+    assert scheduler._resolve_decode_stage(SimpleNamespace(rid="b")) == "thinker_decode"
+
+
+def test_resolver_reads_the_candidate_list_rather_than_a_fixed_partner() -> None:
+    """With more than one candidate the send path needs no change to pick."""
+    scheduler = OmniScheduler.__new__(OmniScheduler)
+    scheduler._pd_decode_targets = ("decode_a", "decode_b")
+
+    assert scheduler._resolve_decode_stage(SimpleNamespace(rid="a")) == "decode_a"
+
+
+def test_resolver_falls_back_to_partner_when_no_candidates_are_set() -> None:
+    """A caller that predates the field still resolves, rather than raising."""
+    scheduler = OmniScheduler.__new__(OmniScheduler)
+    scheduler._pd_partner = "thinker_decode"
+
+    assert scheduler._resolve_decode_stage(SimpleNamespace(rid="a")) == "thinker_decode"

--- a/tests/unit_test/pipeline/test_pd_decode_target.py
+++ b/tests/unit_test/pipeline/test_pd_decode_target.py
@@ -110,3 +110,98 @@ def test_one_candidate_is_returned_without_hashing() -> None:
 def test_no_candidates_is_an_error() -> None:
     with pytest.raises(ValueError, match="no decode targets"):
         select_decode_stage((), "req")
+
+
+def _scheduler(targets: tuple[str, ...], binding_fn=None) -> OmniScheduler:
+    scheduler = OmniScheduler.__new__(OmniScheduler)
+    scheduler._pd_decode_targets = targets
+    if binding_fn is not None:
+        scheduler._pd_decode_binding_fn = binding_fn
+    return scheduler
+
+
+def test_the_admission_binding_decides_when_the_process_is_replicated() -> None:
+    """One request gets one Decode half, chosen once by the coordinator."""
+    targets = ("thinker_decode@r0", "thinker_decode@r1")
+    scheduler = _scheduler(targets, lambda rid: "thinker_decode@r1")
+
+    for rid in ("a", "b", "c", "d"):
+        assert scheduler._resolve_decode_stage(SimpleNamespace(rid=rid)) == (
+            "thinker_decode@r1"
+        )
+
+
+def test_the_binding_wins_over_the_hash() -> None:
+    """Otherwise two policies decide the same question and can disagree."""
+    targets = ("thinker_decode@r0", "thinker_decode@r1")
+    rid = next(
+        r
+        for r in (f"req-{i}" for i in range(100))
+        if select_decode_stage(targets, r) == "thinker_decode@r0"
+    )
+    scheduler = _scheduler(targets, lambda _rid: "thinker_decode@r1")
+
+    assert scheduler._resolve_decode_stage(SimpleNamespace(rid=rid)) == (
+        "thinker_decode@r1"
+    )
+
+
+def test_no_binding_yet_falls_back_to_the_hash() -> None:
+    targets = ("thinker_decode@r0", "thinker_decode@r1")
+    scheduler = _scheduler(targets, lambda _rid: None)
+
+    assert scheduler._resolve_decode_stage(SimpleNamespace(rid="req-7")) == (
+        select_decode_stage(targets, "req-7")
+    )
+
+
+def test_a_binding_outside_the_candidates_falls_back_to_the_hash() -> None:
+    """A stale or wrong name must not send KV to a half that cannot receive it."""
+    targets = ("thinker_decode@r0", "thinker_decode@r1")
+    scheduler = _scheduler(targets, lambda _rid: "thinker_decode@r9")
+
+    assert scheduler._resolve_decode_stage(SimpleNamespace(rid="req-7")) == (
+        select_decode_stage(targets, "req-7")
+    )
+
+
+def test_a_failing_binding_lookup_falls_back_to_the_hash() -> None:
+    def explode(_rid: str) -> str:
+        raise RuntimeError("bindings table is gone")
+
+    targets = ("thinker_decode@r0", "thinker_decode@r1")
+    scheduler = _scheduler(targets, explode)
+
+    assert scheduler._resolve_decode_stage(SimpleNamespace(rid="req-7")) == (
+        select_decode_stage(targets, "req-7")
+    )
+
+
+def test_an_unreplicated_partner_gets_no_resolver() -> None:
+    """Without replicas there is nothing to bind, so the hash stays in charge."""
+    from sglang_omni.pipeline.stage.runtime import Stage
+
+    topology = SimpleNamespace(is_replicated=lambda name: False)
+    holder = SimpleNamespace(_replica_topology=topology, _replica_bindings={})
+
+    resolver = Stage._decode_binding_resolver(holder, "thinker_decode")
+
+    assert resolver is None
+
+
+def test_the_resolver_reads_the_binding_recorded_for_the_request() -> None:
+    from sglang_omni.pipeline.stage.runtime import Stage
+
+    topology = SimpleNamespace(
+        is_replicated=lambda name: name == "thinker_decode",
+        resolve=lambda name, replica_id: f"{name}@r{replica_id}",
+    )
+    holder = SimpleNamespace(
+        _replica_topology=topology,
+        _replica_bindings={"req-1": {"thinker_decode": 1}},
+    )
+
+    resolver = Stage._decode_binding_resolver(holder, "thinker_decode")
+
+    assert resolver("req-1") == "thinker_decode@r1"
+    assert resolver("req-unknown") is None


### PR DESCRIPTION
Based on `pd_runtime`. This is the seam described in #1599 and left out of #1684.

## The problem

The Decode stage that receives a request's KV is chosen when the Prefill stage binds. `bind_pd_runtime` stores it as one string, and the handoff site reads it straight into `to_stage` and `target_pool_id`. A second Decode worker therefore has to change the schema and the send path together.

## The change

The Prefill half resolves the Decode target per request, at the handoff site, through `_resolve_decode_stage(req)`.

The candidate list is derived at bind time from `rank_endpoints`, which `mp_runner` keys by stage name after replica expansion, so it carries `thinker_decode@r0`, `thinker_decode@r1` and so on. `pd_rewrite` still records the logical name, and that is what a build without stage replicas resolves to, so behaviour there is unchanged. The list is sorted rather than left in dict order: KV is rank-addressed, and two Prefill ranks disagreeing on the order would split one request's pages across different Decode halves with nothing in the transfer path to catch it.

Which candidate a request goes to is the coordinator's admission binding when there is one. A replicated Process already gets one instance per request, chosen once at admission and carried on the message envelope, so reading it keeps one request to one answer rather than letting two policies decide the same question. With no binding — no stage replicas, or it has not arrived — a hash of the request id decides. Both inputs are identical on every Prefill rank, which is the constraint `select_decode_stage` documents and the reason that function takes values rather than a scheduler.

## Measured

One Prefill, two Decode, one H200 each, CUDA graph on, `max_running_requests=4`, 32 output tokens, closed-loop client, 100 requests per cell.

| cell | 1:1 | 1:2 | change | 1:1 TPOT p50 | 1:2 TPOT p50 |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1024 / 32, c8 | 13.925 | 20.375 | +46.3% | 0.0120 | 0.0075 |
| 1024 / 32, c16 | 15.328 | 25.431 | +65.9% | 0.0259 | 0.0089 |
| 8128 / 32, c8 | 4.835 | 4.819 | −0.3% | 0.0072 | 0.0070 |
| 8128 / 32, c16 | 4.764 | 4.693 | −1.5% | 0.0072 | 0.0072 |

At 8128 tokens the one Prefill card runs at 100% for the whole cell, so a second Decode half has nothing to add. At 1024 tokens Decode is the constraint and adding one nearly triples TPOT at c16. Both Decode cards carry work; utilisation sampled during the run was 100% / 87-100% / 21-77% across Prefill and the two Decode halves.

The whole configuration is:

```yaml
processes:
  thinker_decode:
    num_replicas: 2
    replica_devices: [1, 2]
```

Stage replicas live on `main` and not on `pd_runtime`, so 1:N needs this branch on a base that carries them. On `pd_runtime` alone there is nothing to expand and the single-partner path is what runs.

## Testing

| Run | Result |
| --- | --- |
| `test_pd_decode_target.py` + `test_pd_decode_replicas.py` | 21 pass |
| `tests/unit_test` | 4948 pass, 7 fail |

The 7 failures are `moss_tts/test_audio_tokenizer.py` (2), `qwen3_omni/test_vision_compat.py` (1) and `qwen3_tts/test_compat.py` (4). All 7 fail the same way on `origin/main` in this environment and none touch PD.

The new cases cover: the rewrite records candidates on the Prefill half and none on the Decode half; a `PDExecution` built without the field stays valid; the derived list picks up every replica and ignores a name like `thinker_decoder_aux` that merely shares a prefix; endpoint dicts in opposite order give the same list; the admission binding decides when it exists; and a binding that is missing, outside the candidate list, or raises falls back to the hash rather than sending KV somewhere that cannot receive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
