### PR TITLE
feat(cosyvoice3): batch S3 tokenizer inference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ audar-tts = [
 fun-cosyvoice3 = [
     "conformer==0.3.2",
     "HyperPyYAML==1.2.3",
+    "s3tokenizer==0.3.0",
     "pyworld==0.3.4",
     "wetext==0.0.4",
     "inflect==7.3.1",

--- a/sglang_omni/models/fun_cosyvoice3/request_builders.py
+++ b/sglang_omni/models/fun_cosyvoice3/request_builders.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import hashlib
 import json
 import threading
@@ -216,7 +217,6 @@ class _CosyVoice3ReferenceEncodeHook(
         dict[str, Any],
     ]
 ):
-
     model_id = "fun_cosyvoice3"
     encoder_id = "speech_tokenizer_v3+campplus+matcha_mel"
     artifact_kind = "reference_conditioning"
@@ -252,7 +252,7 @@ class _CosyVoice3ReferenceEncodeHook(
         speech_tokenizer: SpeechTokenizerV3,
         speaker_encoder: SpeakerEncoder,
     ) -> None:
-        """Attach the process-local ONNX encoders after hook construction."""
+        """Attach the process-local reference encoders after hook construction."""
         self._speech_tokenizer = speech_tokenizer
         self._speaker_encoder = speaker_encoder
 
@@ -293,6 +293,56 @@ class _CosyVoice3ReferenceEncodeHook(
             flow_embedding=speaker_embedding,
         )
 
+    def can_encode_batch(self) -> bool:
+        return self._speech_tokenizer is not None and callable(
+            getattr(self._speech_tokenizer, "extract_speech_tokens", None)
+        )
+
+    def encode_batch(
+        self, items: list[_CosyVoice3ReferenceInput]
+    ) -> list[_CosyVoice3ReferenceArtifact]:
+        if not items:
+            return []
+        if self._speech_tokenizer is None or self._speaker_encoder is None:
+            raise RuntimeError("CosyVoice3 reference encoders are not bound")
+
+        prompt_audios_16k = [_load_prompt_audio(item.ref_audio) for item in items]
+        prompt_audios_24k = [_load_prompt_audio_24k(item.ref_audio) for item in items]
+        prompt_speech_tokens = self._speech_tokenizer.extract_speech_tokens(
+            prompt_audios_16k, _PROMPT_AUDIO_SR
+        )
+        if len(prompt_speech_tokens) != len(items):
+            raise RuntimeError(
+                "CosyVoice3 S3 tokenizer dropped batch items: "
+                f"expected {len(items)}, got {len(prompt_speech_tokens)}"
+            )
+
+        artifacts: list[_CosyVoice3ReferenceArtifact] = []
+        # CAMPPlus and Flow mel extraction remain per-reference; this batch
+        # boundary intentionally covers only the S3 tokenizer.
+        for audio_16k, audio_24k, prompt_speech_token in zip(
+            prompt_audios_16k,
+            prompt_audios_24k,
+            prompt_speech_tokens,
+            strict=True,
+        ):
+            speaker_embedding = self._speaker_encoder.extract_embedding(
+                audio_16k, _PROMPT_AUDIO_SR
+            )
+            prompt_speech_feat = extract_prompt_speech_feat(audio_24k, _SAMPLE_RATE)
+            flow_prompt_speech_token, flow_prompt_speech_feat = _align_flow_prompt(
+                prompt_speech_token, prompt_speech_feat
+            )
+            artifacts.append(
+                _CosyVoice3ReferenceArtifact(
+                    llm_prompt_speech_token=prompt_speech_token,
+                    flow_prompt_speech_token=flow_prompt_speech_token,
+                    flow_prompt_speech_feat=flow_prompt_speech_feat,
+                    flow_embedding=speaker_embedding,
+                )
+            )
+        return artifacts
+
     def store_artifact(self, artifact: _CosyVoice3ReferenceArtifact) -> dict[str, Any]:
         return {
             "artifact_type": "fun_cosyvoice3_reference_conditioning",
@@ -332,6 +382,9 @@ class CosyVoice3PreprocessingContext:
     speaker_encoder: SpeakerEncoder
     reference_service: ReferenceEncodeService
 
+    def close(self) -> None:
+        self.reference_service.close()
+
 
 _PREPROCESSING_CONTEXT: CosyVoice3PreprocessingContext | None = None
 _PREPARED_REQUESTS: dict[str, CosyVoice3PreparedRequest] = {}
@@ -345,6 +398,8 @@ def set_cosyvoice3_preprocessing_context(
     speech_tokenizer: SpeechTokenizerV3,
     speaker_encoder: SpeakerEncoder,
     model_revision: str | None = None,
+    reference_max_batch_size: int = 8,
+    reference_max_batch_wait_ms: float = 4.0,
 ) -> None:
     """Register model objects used by the preprocessing stage."""
     global _PREPROCESSING_CONTEXT
@@ -356,28 +411,38 @@ def set_cosyvoice3_preprocessing_context(
         speech_tokenizer=speech_tokenizer,
         speaker_encoder=speaker_encoder,
     )
+    context = CosyVoice3PreprocessingContext(
+        model=model,
+        tokenizer=tokenizer,
+        speech_tokenizer=speech_tokenizer,
+        speaker_encoder=speaker_encoder,
+        reference_service=ReferenceEncodeService(
+            reference_hook,
+            max_items=256,
+            max_bytes=128 * 1024 * 1024,
+            timeout_s=130.0,
+            log_prefix="Fun-CosyVoice3",
+            max_batch_size=reference_max_batch_size,
+            max_batch_wait_ms=reference_max_batch_wait_ms,
+            batch_worker_name="cosyvoice3-s3-tokenizer-batch",
+        ),
+    )
     with _PREPARED_REQUESTS_LOCK:
-        _PREPROCESSING_CONTEXT = CosyVoice3PreprocessingContext(
-            model=model,
-            tokenizer=tokenizer,
-            speech_tokenizer=speech_tokenizer,
-            speaker_encoder=speaker_encoder,
-            reference_service=ReferenceEncodeService(
-                reference_hook,
-                max_items=256,
-                max_bytes=128 * 1024 * 1024,
-                timeout_s=130.0,
-                log_prefix="Fun-CosyVoice3",
-            ),
-        )
+        previous_context = _PREPROCESSING_CONTEXT
+        _PREPROCESSING_CONTEXT = context
         _PREPARED_REQUESTS.clear()
+    if previous_context is not None:
+        previous_context.close()
 
 
 def clear_cosyvoice3_preprocessing_context() -> None:
     global _PREPROCESSING_CONTEXT
     with _PREPARED_REQUESTS_LOCK:
+        context = _PREPROCESSING_CONTEXT
         _PREPROCESSING_CONTEXT = None
         _PREPARED_REQUESTS.clear()
+    if context is not None:
+        context.close()
 
 
 def cleanup_prepared_cosyvoice3_request(request_id: str) -> None:
@@ -438,13 +503,13 @@ def build_cosyvoice3_state(payload: StagePayload) -> FunCosyVoice3State:
         inputs
     )
     reference = references[0] if references else {}
-    ref_audio = (
-        input_ref_audio
-        or reference.get("audio_path")
-        or reference.get("ref_audio")
-        or reference.get("audio")
-        or audio_data_uri_from_reference(reference)
-        or tts_params.get("ref_audio")
+    ref_audio = _first_reference_audio(
+        input_ref_audio,
+        reference.get("audio_path"),
+        reference.get("ref_audio"),
+        reference.get("audio"),
+        audio_data_uri_from_reference(reference),
+        tts_params.get("ref_audio"),
     )
     ref_text = input_ref_text or reference.get("text") or tts_params.get("ref_text")
 
@@ -498,9 +563,22 @@ def _normalize_cosyvoice3_inputs(
     return (
         str(inputs.get("text", inputs.get("input", ""))),
         references,
-        inputs.get("ref_audio") or inputs.get("audio") or inputs.get("file"),
+        _first_reference_audio(
+            inputs.get("ref_audio"), inputs.get("audio"), inputs.get("file")
+        ),
         inputs.get("ref_text"),
     )
+
+
+def _first_reference_audio(*candidates: Any) -> Any | None:
+    """Return the first usable reference source without coercing array-like inputs."""
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        if isinstance(candidate, (str, bytes, bytearray, dict)) and not candidate:
+            continue
+        return candidate
+    return None
 
 
 def normalize_language(language: Any) -> str:
@@ -622,8 +700,10 @@ def _prepare_cosyvoice3_request(
     model: Any,
     tokenizer: CosyVoice3Tokenizer,
     reference_service: ReferenceEncodeService,
+    state: FunCosyVoice3State | None = None,
+    reference_artifact: _CosyVoice3ReferenceArtifact | None = None,
 ) -> CosyVoice3PreparedRequest:
-    state = build_cosyvoice3_state(payload)
+    state = state or build_cosyvoice3_state(payload)
     gen_kwargs = state.generation_kwargs
     device = next(model.parameters()).device
     dtype = next(model.parameters()).dtype
@@ -639,10 +719,11 @@ def _prepare_cosyvoice3_request(
         text_embed = model.text_embed_tokens(text_token)
 
     if state.ref_audio is not None:
-        reference_artifact = reference_service.get_or_encode(
-            state.ref_audio,
-            desc="Fun-CosyVoice3 reference conditioning",
-        )
+        if reference_artifact is None:
+            reference_artifact = reference_service.get_or_encode(
+                state.ref_audio,
+                desc="Fun-CosyVoice3 reference conditioning",
+            )
         spk_embedding = reference_artifact.flow_embedding
         prompt_speech_token = reference_artifact.llm_prompt_speech_token
         flow_prompt_speech_token = reference_artifact.flow_prompt_speech_token
@@ -697,18 +778,18 @@ def _prepare_cosyvoice3_request(
     )
 
 
-def preprocess_cosyvoice3_payload(payload: StagePayload) -> StagePayload:
+def _current_preprocessing_context() -> CosyVoice3PreprocessingContext:
     with _PREPARED_REQUESTS_LOCK:
         context = _PREPROCESSING_CONTEXT
     if context is None:
         raise RuntimeError("CosyVoice3 preprocessing context is not initialized")
+    return context
 
-    prepared = _prepare_cosyvoice3_request(
-        payload,
-        model=context.model,
-        tokenizer=context.tokenizer,
-        reference_service=context.reference_service,
-    )
+
+def _store_preprocessed_cosyvoice3_request(
+    payload: StagePayload,
+    prepared: CosyVoice3PreparedRequest,
+) -> StagePayload:
     with _PREPARED_REQUESTS_LOCK:
         _PREPARED_REQUESTS[payload.request_id] = prepared
 
@@ -723,6 +804,94 @@ def preprocess_cosyvoice3_payload(payload: StagePayload) -> StagePayload:
         request=payload.request,
         data=data,
     )
+
+
+def _encode_batch_references(
+    states: list[FunCosyVoice3State | BaseException],
+    reference_service: ReferenceEncodeService,
+) -> list[_CosyVoice3ReferenceArtifact | BaseException | None]:
+    artifacts: list[_CosyVoice3ReferenceArtifact | BaseException | None] = [None] * len(
+        states
+    )
+    references = [
+        (index, state.ref_audio)
+        for index, state in enumerate(states)
+        if not isinstance(state, BaseException) and state.ref_audio is not None
+    ]
+    if not references:
+        return artifacts
+
+    # ReferenceEncodeService owns cache and single-flight behavior. These callers
+    # only let its dedicated S3 worker receive all batch members before any TP
+    # collective below is entered.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(references)) as pool:
+        futures = {
+            index: pool.submit(
+                reference_service.get_or_encode,
+                ref_audio,
+                desc="Fun-CosyVoice3 reference conditioning",
+            )
+            for index, ref_audio in references
+        }
+        for index, future in futures.items():
+            try:
+                artifacts[index] = future.result()
+            except BaseException as exc:
+                artifacts[index] = exc
+    return artifacts
+
+
+def preprocess_cosyvoice3_payload(payload: StagePayload) -> StagePayload:
+    context = _current_preprocessing_context()
+
+    prepared = _prepare_cosyvoice3_request(
+        payload,
+        model=context.model,
+        tokenizer=context.tokenizer,
+        reference_service=context.reference_service,
+    )
+    return _store_preprocessed_cosyvoice3_request(payload, prepared)
+
+
+def preprocess_cosyvoice3_payloads(
+    payloads: list[StagePayload],
+) -> list[StagePayload | BaseException]:
+    """Prepare a scheduler batch without reordering TP embedding collectives."""
+    if not payloads:
+        return []
+    context = _current_preprocessing_context()
+
+    states: list[FunCosyVoice3State | BaseException] = []
+    for payload in payloads:
+        try:
+            states.append(build_cosyvoice3_state(payload))
+        except BaseException as exc:
+            states.append(exc)
+    artifacts = _encode_batch_references(states, context.reference_service)
+
+    results: list[StagePayload | BaseException] = []
+    # All ranks receive payloads in the same FIFO order. Keep model embedding
+    # calls in that order: VocabParallelEmbedding performs a TP all-reduce.
+    for payload, state, artifact in zip(payloads, states, artifacts, strict=True):
+        if isinstance(state, BaseException):
+            results.append(state)
+            continue
+        if isinstance(artifact, BaseException):
+            results.append(artifact)
+            continue
+        try:
+            prepared = _prepare_cosyvoice3_request(
+                payload,
+                model=context.model,
+                tokenizer=context.tokenizer,
+                reference_service=context.reference_service,
+                state=state,
+                reference_artifact=artifact,
+            )
+            results.append(_store_preprocessed_cosyvoice3_request(payload, prepared))
+        except BaseException as exc:
+            results.append(exc)
+    return results
 
 
 def build_sglang_cosyvoice3_request(

--- a/sglang_omni/models/fun_cosyvoice3/stages.py
+++ b/sglang_omni/models/fun_cosyvoice3/stages.py
@@ -11,7 +11,9 @@ import torch
 from sglang_omni.models.fun_cosyvoice3.payload_types import FunCosyVoice3State
 from sglang_omni.models.fun_cosyvoice3.request_builders import (
     cleanup_prepared_cosyvoice3_request,
+    clear_cosyvoice3_preprocessing_context,
     preprocess_cosyvoice3_payload,
+    preprocess_cosyvoice3_payloads,
 )
 from sglang_omni.platforms import current_platform
 from sglang_omni.proto import StagePayload
@@ -60,11 +62,20 @@ def _load_cosyvoice3_flow_hift(
     return flow, hift
 
 
-def create_preprocessing_executor(model_path: str) -> SimpleScheduler:
+def create_preprocessing_executor(
+    model_path: str,
+    *,
+    max_batch_size: int = 8,
+    max_batch_wait_ms: float = 4.0,
+) -> SimpleScheduler:
     del model_path
     return SimpleScheduler(
         preprocess_cosyvoice3_payload,
+        batch_compute_fn=preprocess_cosyvoice3_payloads,
+        max_batch_size=max_batch_size,
+        max_batch_wait_ms=max_batch_wait_ms,
         abort_callback=cleanup_prepared_cosyvoice3_request,
+        shutdown_callback=clear_cosyvoice3_preprocessing_context,
     )
 
 

--- a/sglang_omni/models/fun_cosyvoice3/utils.py
+++ b/sglang_omni/models/fun_cosyvoice3/utils.py
@@ -11,7 +11,6 @@ import torch
 
 
 class CosyVoice3Tokenizer:
-
     def __init__(self, token_path: str, skip_special_tokens: bool = True):
         from transformers import AutoTokenizer
 
@@ -41,58 +40,85 @@ class CosyVoice3Tokenizer:
 
 
 class SpeechTokenizerV3:
-
     def __init__(self, model_path: str, device: str = "cpu"):
-        import onnxruntime
+        import s3tokenizer
 
-        option = onnxruntime.SessionOptions()
-        option.graph_optimization_level = (
-            onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL
-        )
-        option.intra_op_num_threads = 1
+        self._backend = s3tokenizer
+        self.device = torch.device(device)
+        self.model = s3tokenizer.load_model(model_path).to(self.device).eval()
 
-        providers = (
-            ["CUDAExecutionProvider", "CPUExecutionProvider"]
-            if device.startswith("cuda")
-            else ["CPUExecutionProvider"]
-        )
-        self.session = onnxruntime.InferenceSession(
-            model_path, sess_options=option, providers=providers
-        )
-        self.device = device
-
-    def extract_speech_token(
-        self, audio: np.ndarray, sample_rate: int = 16000
-    ) -> torch.Tensor:
-        import whisper
-
+    @staticmethod
+    def _normalize_audio(audio: np.ndarray, sample_rate: int) -> torch.Tensor:
         if sample_rate != 16000:
             raise ValueError(
                 f"Speech tokenizer expects 16kHz audio, got {sample_rate}Hz"
             )
 
-        if audio.ndim == 1:
-            audio = audio.reshape(1, -1)
-
-        if audio.shape[1] / sample_rate > 30:
+        audio_array = np.asarray(audio, dtype=np.float32)
+        if audio_array.ndim == 2 and audio_array.shape[0] == 1:
+            audio_array = audio_array[0]
+        if audio_array.ndim != 1:
+            raise ValueError(
+                "Speech tokenizer audio must have shape [samples] or [1, samples]"
+            )
+        if audio_array.size == 0:
+            raise ValueError("Speech tokenizer audio must not be empty")
+        if audio_array.size / sample_rate > 30:
             raise ValueError(
                 "Audio longer than 30s is not supported for speech token extraction"
             )
+        return torch.from_numpy(np.ascontiguousarray(audio_array))
 
-        feat = whisper.log_mel_spectrogram(torch.from_numpy(audio), n_mels=128)
-        feat_len = feat.shape[2]
-        result = self.session.run(
-            None,
-            {
-                self.session.get_inputs()[0].name: feat.detach().cpu().numpy(),
-                self.session.get_inputs()[1].name: np.array([feat_len], dtype=np.int32),
-            },
-        )[0]
-        return torch.tensor([result.flatten().tolist()], dtype=torch.int32)
+    def extract_speech_tokens(
+        self, audios: list[np.ndarray], sample_rate: int = 16000
+    ) -> list[torch.Tensor]:
+        if not audios:
+            return []
+
+        mels = [
+            self._backend.log_mel_spectrogram(self._normalize_audio(audio, sample_rate))
+            for audio in audios
+        ]
+        padded_mels, mel_lengths = self._backend.padding(mels)
+        with torch.inference_mode():
+            codes, code_lengths = self.model.quantize(
+                padded_mels.to(self.device), mel_lengths.to(self.device)
+            )
+
+        if codes.ndim != 2 or code_lengths.ndim != 1:
+            raise RuntimeError(
+                "S3 tokenizer returned invalid batch shapes: "
+                f"codes={tuple(codes.shape)}, lengths={tuple(code_lengths.shape)}"
+            )
+        if codes.shape[0] != len(audios) or code_lengths.shape[0] != len(audios):
+            raise RuntimeError(
+                "S3 tokenizer returned an unexpected batch size: "
+                f"expected {len(audios)}, got codes={codes.shape[0]}, "
+                f"lengths={code_lengths.shape[0]}"
+            )
+
+        results: list[torch.Tensor] = []
+        for index, raw_length in enumerate(code_lengths):
+            length = int(raw_length.item())
+            if length < 0 or length > codes.shape[1]:
+                raise RuntimeError(
+                    f"S3 tokenizer returned invalid code length {length} "
+                    f"for row {index} with width {codes.shape[1]}"
+                )
+            results.append(
+                codes[index : index + 1, :length]
+                .detach()
+                .to(device="cpu", dtype=torch.int32, copy=True)
+            )
+        return results
+
+    def extract_speech_token(
+        self, audio: np.ndarray, sample_rate: int = 16000
+    ) -> torch.Tensor:
+        return self.extract_speech_tokens([audio], sample_rate)[0]
 
 
 class SpeakerEncoder:
-
     def __init__(self, model_path: str, device: str = "cpu"):
         import onnxruntime
 
@@ -175,8 +201,7 @@ def extract_prompt_speech_feat(
     mel = _run_cosyvoice3_mel_spectrogram(waveform)
     if mel.ndim != 3 or mel.shape[0] != waveform.shape[0] or mel.shape[1] != 80:
         raise RuntimeError(
-            "CosyVoice3 mel extractor returned an unexpected shape: "
-            f"{tuple(mel.shape)}"
+            f"CosyVoice3 mel extractor returned an unexpected shape: {tuple(mel.shape)}"
         )
     return mel.transpose(1, 2).contiguous()
 

--- a/sglang_omni/scheduling/simple_scheduler.py
+++ b/sglang_omni/scheduling/simple_scheduler.py
@@ -6,6 +6,7 @@ No KV cache, no batching. Just: inbox.get() → run function → outbox.put().
 
 Same inbox/outbox interface as OmniScheduler so Stage doesn't need branching.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -204,7 +205,10 @@ class SimpleScheduler:
         for msg, result in zip(batch, results):
             if self._consume_if_aborted(msg.request_id):
                 continue
-            self._emit_result(msg.request_id, result, self.outbox)
+            if isinstance(result, BaseException):
+                self._emit_error(msg.request_id, result, self.outbox)
+            else:
+                self._emit_result(msg.request_id, result, self.outbox)
 
     @staticmethod
     async def _await_result(result: Awaitable[Any]) -> Any:

--- a/tests/unit_test/fun_cosyvoice3/test_request_builders.py
+++ b/tests/unit_test/fun_cosyvoice3/test_request_builders.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import threading
 from collections.abc import Iterator
 from types import SimpleNamespace
@@ -26,6 +27,7 @@ from sglang_omni.models.fun_cosyvoice3.request_builders import (
     clear_cosyvoice3_preprocessing_context,
     pop_prepared_cosyvoice3_request,
     preprocess_cosyvoice3_payload,
+    preprocess_cosyvoice3_payloads,
     set_cosyvoice3_preprocessing_context,
 )
 from sglang_omni.proto import OmniRequest, StagePayload
@@ -108,6 +110,14 @@ def test_build_cosyvoice3_state_accepts_structured_reference() -> None:
 
     assert state.ref_audio == "reference.wav"
     assert state.ref_text == "reference"
+
+
+def test_build_cosyvoice3_state_accepts_array_reference_audio() -> None:
+    ref_audio = np.ones(4, dtype=np.float32)
+
+    state = build_cosyvoice3_state(_payload({"text": "hello", "ref_audio": ref_audio}))
+
+    assert state.ref_audio is ref_audio
 
 
 def test_build_cosyvoice3_state_rejects_multiple_references() -> None:
@@ -355,12 +365,475 @@ class _FakeModel(torch.nn.Module):
         super().__init__()
         self.anchor = torch.nn.Parameter(torch.zeros(1, dtype=torch.float32))
         self.config = SimpleNamespace(hidden_size=4)
-        self.text_embed_tokens = (
-            lambda tokens: tokens.to(torch.float32).unsqueeze(-1).expand(-1, -1, 4)
+        self.text_embed_tokens = lambda tokens: (
+            tokens.to(torch.float32).unsqueeze(-1).expand(-1, -1, 4)
         )
-        self.speech_embedding = (
-            lambda tokens: tokens.to(torch.float32).unsqueeze(-1).expand(-1, -1, 4)
+        self.speech_embedding = lambda tokens: (
+            tokens.to(torch.float32).unsqueeze(-1).expand(-1, -1, 4)
         )
+
+
+def test_reference_encoding_batches_distinct_s3_requests_and_merges_same_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    batch_sizes: list[int] = []
+    speaker_markers: list[int] = []
+
+    class _BatchSpeechTokenizer:
+        def extract_speech_tokens(
+            self, audios: list[np.ndarray], sample_rate: int
+        ) -> list[torch.Tensor]:
+            assert sample_rate == 16000
+            batch_sizes.append(len(audios))
+            return [
+                torch.tensor([[int(audio[0]), int(audio[0]) + 10]], dtype=torch.int32)
+                for audio in audios
+            ]
+
+        def extract_speech_token(
+            self, audio: np.ndarray, sample_rate: int
+        ) -> torch.Tensor:
+            return self.extract_speech_tokens([audio], sample_rate)[0]
+
+    class _MarkerSpeakerEncoder:
+        def extract_embedding(
+            self, audio: np.ndarray, sample_rate: int
+        ) -> torch.Tensor:
+            assert sample_rate == 16000
+            marker = int(audio[0])
+            speaker_markers.append(marker)
+            return torch.tensor([[marker]], dtype=torch.float32)
+
+    monkeypatch.setattr(
+        request_builders,
+        "_load_prompt_audio",
+        lambda source: np.asarray(source, dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        request_builders,
+        "_load_prompt_audio_24k",
+        lambda source: np.full(6, float(source[0]), dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        request_builders,
+        "extract_prompt_speech_feat",
+        lambda audio, sample_rate: torch.full((1, 4, 80), float(audio[0])),
+    )
+
+    set_cosyvoice3_preprocessing_context(
+        model=_FakeModel(),
+        tokenizer=_FakeTokenizer(),
+        speech_tokenizer=_BatchSpeechTokenizer(),
+        speaker_encoder=_MarkerSpeakerEncoder(),
+        reference_max_batch_size=8,
+        reference_max_batch_wait_ms=200,
+    )
+    context = request_builders._PREPROCESSING_CONTEXT
+    assert context is not None
+    references = [
+        np.full(4, 1.0, dtype=np.float32),
+        np.full(4, 1.0, dtype=np.float32),
+        np.full(4, 2.0, dtype=np.float32),
+        np.full(4, 3.0, dtype=np.float32),
+    ]
+    start = threading.Barrier(len(references) + 1)
+
+    def encode(reference: np.ndarray):
+        start.wait(timeout=5)
+        return context.reference_service.get_or_encode(reference)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [executor.submit(encode, reference) for reference in references]
+        start.wait(timeout=5)
+        artifacts = [future.result(timeout=5) for future in futures]
+
+    assert batch_sizes == [3]
+    assert sorted(speaker_markers) == [1, 2, 3]
+    assert [artifact.llm_prompt_speech_token.tolist() for artifact in artifacts] == [
+        [[1, 11]],
+        [[1, 11]],
+        [[2, 12]],
+        [[3, 13]],
+    ]
+    stats = context.reference_service.stats()
+    assert stats["misses"] == 3
+    assert stats["merged"] == 1
+    assert stats["batched_items"] == 3
+    assert stats["entries"] == 3
+
+
+def test_preprocess_batch_forms_s3_batch_before_ordered_model_embeddings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    batch_sizes: list[int] = []
+
+    class _BatchTokenizer:
+        def __call__(self, text: str) -> torch.Tensor:
+            token = {"first": 11, "second": 22}.get(text, 3)
+            return torch.tensor([[token]], dtype=torch.int32)
+
+    class _BatchSpeechTokenizer:
+        def extract_speech_tokens(
+            self, audios: list[np.ndarray], sample_rate: int
+        ) -> list[torch.Tensor]:
+            assert sample_rate == 16000
+            batch_sizes.append(len(audios))
+            return [
+                torch.tensor([[int(audio[0])]], dtype=torch.int32) for audio in audios
+            ]
+
+        def extract_speech_token(
+            self, audio: np.ndarray, sample_rate: int
+        ) -> torch.Tensor:
+            return self.extract_speech_tokens([audio], sample_rate)[0]
+
+    class _SpeakerEncoder:
+        def extract_embedding(
+            self, audio: np.ndarray, sample_rate: int
+        ) -> torch.Tensor:
+            assert sample_rate == 16000
+            return torch.zeros(1, 192)
+
+    class _RecordingModel(_FakeModel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.text_embed_calls: list[list[list[int]]] = []
+            self.text_embed_tokens = self._embed_text
+
+        def _embed_text(self, tokens: torch.Tensor) -> torch.Tensor:
+            self.text_embed_calls.append(tokens.detach().cpu().tolist())
+            return tokens.to(torch.float32).unsqueeze(-1).expand(-1, -1, 4)
+
+    monkeypatch.setattr(
+        request_builders,
+        "_load_prompt_audio",
+        lambda source: np.asarray(source, dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        request_builders,
+        "_load_prompt_audio_24k",
+        lambda source: np.full(6, float(source[0]), dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        request_builders,
+        "extract_prompt_speech_feat",
+        lambda audio, sample_rate: torch.ones(1, 4, 80),
+    )
+    model = _RecordingModel()
+    set_cosyvoice3_preprocessing_context(
+        model=model,
+        tokenizer=_BatchTokenizer(),
+        speech_tokenizer=_BatchSpeechTokenizer(),
+        speaker_encoder=_SpeakerEncoder(),
+        reference_max_batch_size=8,
+        reference_max_batch_wait_ms=200,
+    )
+
+    results = preprocess_cosyvoice3_payloads(
+        [
+            _payload(
+                {"text": "first", "ref_audio": np.full(4, 1.0, dtype=np.float32)},
+                request_id="req-first",
+            ),
+            _payload(
+                {"text": "second", "ref_audio": np.full(4, 2.0, dtype=np.float32)},
+                request_id="req-second",
+            ),
+        ]
+    )
+
+    assert batch_sizes == [2]
+    assert model.text_embed_calls == [[[3, 11]], [[3, 22]]]
+    assert [
+        result.request_id for result in results if isinstance(result, StagePayload)
+    ] == [
+        "req-first",
+        "req-second",
+    ]
+
+
+def test_preprocess_batch_isolates_invalid_reference_and_keeps_other_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    batch_sizes: list[int] = []
+
+    class _BatchSpeechTokenizer(_FakeSpeechTokenizer):
+        def extract_speech_tokens(
+            self, audios: list[np.ndarray], sample_rate: int
+        ) -> list[torch.Tensor]:
+            batch_sizes.append(len(audios))
+            return [self.extract_speech_token(audio, sample_rate) for audio in audios]
+
+    monkeypatch.setattr(
+        request_builders,
+        "_load_prompt_audio",
+        lambda source: np.zeros(1600, dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        request_builders,
+        "_load_prompt_audio_24k",
+        lambda source: np.zeros(2400, dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        request_builders,
+        "extract_prompt_speech_feat",
+        lambda audio, sample_rate: torch.ones(1, 4, 80),
+    )
+    set_cosyvoice3_preprocessing_context(
+        model=_FakeModel(),
+        tokenizer=_FakeTokenizer(),
+        speech_tokenizer=_BatchSpeechTokenizer(),
+        speaker_encoder=_FakeSpeakerEncoder(),
+        reference_max_batch_size=8,
+        reference_max_batch_wait_ms=50,
+    )
+
+    results = preprocess_cosyvoice3_payloads(
+        [
+            _payload(
+                {
+                    "text": "hello",
+                    "references": [
+                        {"audio_path": "first.wav"},
+                        {"audio_path": "second.wav"},
+                    ],
+                },
+                request_id="req-invalid",
+            ),
+            _payload("hello", request_id="req-no-reference"),
+            _payload(
+                {"text": "hello", "ref_audio": "valid.wav"},
+                request_id="req-valid",
+            ),
+        ]
+    )
+
+    assert isinstance(results[0], ValueError)
+    assert isinstance(results[1], StagePayload)
+    assert isinstance(results[2], StagePayload)
+    assert batch_sizes == [1]
+    assert results[1].data["flow_prompt_speech_token"] == [[]]
+    assert results[2].data["flow_prompt_speech_token"] == [[40, 41]]
+
+
+def test_cosyvoice_batch_encode_falls_back_to_single_item_encoding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    batch_attempts: list[int] = []
+    single_markers: list[int] = []
+
+    class _FallbackSpeechTokenizer(_FakeSpeechTokenizer):
+        def extract_speech_tokens(
+            self, audios: list[np.ndarray], sample_rate: int
+        ) -> list[torch.Tensor]:
+            batch_attempts.append(len(audios))
+            raise RuntimeError("simulated batch tokenizer failure")
+
+        def extract_speech_token(
+            self, audio: np.ndarray, sample_rate: int
+        ) -> torch.Tensor:
+            single_markers.append(int(audio[0]))
+            return torch.tensor([[int(audio[0]), int(audio[0]) + 1]], dtype=torch.int32)
+
+    monkeypatch.setattr(
+        request_builders,
+        "_load_prompt_audio",
+        lambda source: np.full(1600, float(source[0]), dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        request_builders,
+        "_load_prompt_audio_24k",
+        lambda source: np.full(2400, float(source[0]), dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        request_builders,
+        "extract_prompt_speech_feat",
+        lambda audio, sample_rate: torch.ones(1, 4, 80),
+    )
+    set_cosyvoice3_preprocessing_context(
+        model=_FakeModel(),
+        tokenizer=_FakeTokenizer(),
+        speech_tokenizer=_FallbackSpeechTokenizer(),
+        speaker_encoder=_FakeSpeakerEncoder(),
+        reference_max_batch_size=8,
+        reference_max_batch_wait_ms=50,
+    )
+
+    results = preprocess_cosyvoice3_payloads(
+        [
+            _payload(
+                {"text": "hello", "ref_audio": np.full(4, 1.0, dtype=np.float32)},
+                request_id="req-one",
+            ),
+            _payload(
+                {"text": "hello", "ref_audio": np.full(4, 2.0, dtype=np.float32)},
+                request_id="req-two",
+            ),
+        ]
+    )
+
+    assert all(isinstance(result, StagePayload) for result in results)
+    assert batch_attempts == [2]
+    assert sorted(single_markers) == [1, 2]
+    context = request_builders._PREPROCESSING_CONTEXT
+    assert context is not None
+    assert context.reference_service.stats()["batches"] == 0
+
+
+def test_preprocessing_scheduler_runs_batch_and_emits_each_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.fun_cosyvoice3 import stages
+
+    batch_sizes: list[int] = []
+
+    class _BatchSpeechTokenizer(_FakeSpeechTokenizer):
+        def extract_speech_tokens(
+            self, audios: list[np.ndarray], sample_rate: int
+        ) -> list[torch.Tensor]:
+            batch_sizes.append(len(audios))
+            return [self.extract_speech_token(audio, sample_rate) for audio in audios]
+
+    monkeypatch.setattr(
+        request_builders,
+        "_load_prompt_audio",
+        lambda source: np.zeros(1600, dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        request_builders,
+        "_load_prompt_audio_24k",
+        lambda source: np.zeros(2400, dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        request_builders,
+        "extract_prompt_speech_feat",
+        lambda audio, sample_rate: torch.ones(1, 4, 80),
+    )
+    set_cosyvoice3_preprocessing_context(
+        model=_FakeModel(),
+        tokenizer=_FakeTokenizer(),
+        speech_tokenizer=_BatchSpeechTokenizer(),
+        speaker_encoder=_FakeSpeakerEncoder(),
+    )
+    scheduler = stages.create_preprocessing_executor("unused-model-path")
+    payloads = [
+        _payload(
+            {"text": "hello", "ref_audio": "one.wav"}, request_id="req-one"
+        ),
+        _payload(
+            {"text": "hello", "ref_audio": "two.wav"}, request_id="req-two"
+        ),
+    ]
+    for payload in payloads:
+        scheduler.inbox.put(IncomingMessage(payload.request_id, "new_request", payload))
+
+    worker = threading.Thread(target=scheduler.start)
+    worker.start()
+    try:
+        outputs = [scheduler.outbox.get(timeout=5) for _ in payloads]
+        assert {output.request_id for output in outputs} == {"req-one", "req-two"}
+        assert all(output.type == "result" for output in outputs)
+        assert all(isinstance(output.data, StagePayload) for output in outputs)
+        assert batch_sizes == [2]
+    finally:
+        scheduler.stop()
+        worker.join(timeout=5)
+
+    assert not worker.is_alive()
+
+
+def test_preprocessing_shutdown_completes_with_inflight_reference_encode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.fun_cosyvoice3 import stages
+
+    batch_started = threading.Event()
+    release_batch = threading.Event()
+
+    class _BlockingBatchSpeechTokenizer(_FakeSpeechTokenizer):
+        def extract_speech_tokens(
+            self, audios: list[np.ndarray], sample_rate: int
+        ) -> list[torch.Tensor]:
+            batch_started.set()
+            assert release_batch.wait(timeout=5)
+            return [self.extract_speech_token(audio, sample_rate) for audio in audios]
+
+    monkeypatch.setattr(
+        request_builders,
+        "_load_prompt_audio",
+        lambda source: np.zeros(1600, dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        request_builders,
+        "_load_prompt_audio_24k",
+        lambda source: np.zeros(2400, dtype=np.float32),
+    )
+    monkeypatch.setattr(
+        request_builders,
+        "extract_prompt_speech_feat",
+        lambda audio, sample_rate: torch.ones(1, 4, 80),
+    )
+    set_cosyvoice3_preprocessing_context(
+        model=_FakeModel(),
+        tokenizer=_FakeTokenizer(),
+        speech_tokenizer=_BlockingBatchSpeechTokenizer(),
+        speaker_encoder=_FakeSpeakerEncoder(),
+        reference_max_batch_size=8,
+        reference_max_batch_wait_ms=0,
+    )
+    context = request_builders._PREPROCESSING_CONTEXT
+    assert context is not None
+    scheduler = stages.create_preprocessing_executor("unused-model-path")
+
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    future = executor.submit(
+        context.reference_service.get_or_encode,
+        "inflight-reference.wav",
+    )
+    try:
+        assert batch_started.wait(timeout=5)
+        release_batch.set()
+        scheduler.stop()
+        artifact = future.result(timeout=5)
+        assert artifact.llm_prompt_speech_token.tolist() == [[40, 41]]
+        assert request_builders._PREPROCESSING_CONTEXT is None
+    finally:
+        release_batch.set()
+        scheduler.stop()
+        executor.shutdown(wait=True)
+
+
+def test_preprocessing_executor_enables_batching_and_closes_context() -> None:
+    from sglang_omni.models.fun_cosyvoice3 import stages
+
+    class _BatchSpeechTokenizer(_FakeSpeechTokenizer):
+        def extract_speech_tokens(
+            self, audios: list[np.ndarray], sample_rate: int
+        ) -> list[torch.Tensor]:
+            return [self.extract_speech_token(audio, sample_rate) for audio in audios]
+
+    set_cosyvoice3_preprocessing_context(
+        model=_FakeModel(),
+        tokenizer=_FakeTokenizer(),
+        speech_tokenizer=_BatchSpeechTokenizer(),
+        speaker_encoder=_FakeSpeakerEncoder(),
+    )
+    context = request_builders._PREPROCESSING_CONTEXT
+    assert context is not None
+    assert context.reference_service.batching_enabled
+    batch_thread = context.reference_service._batch_thread
+    assert batch_thread is not None
+    assert batch_thread.is_alive()
+
+    scheduler = stages.create_preprocessing_executor("unused-model-path")
+    assert scheduler._max_concurrency == 1
+    assert scheduler._batch_fn is preprocess_cosyvoice3_payloads
+    assert scheduler._max_batch_size == 8
+    assert scheduler._max_batch_wait_s == pytest.approx(0.004)
+    scheduler.stop()
+
+    assert request_builders._PREPROCESSING_CONTEXT is None
+    assert not batch_thread.is_alive()
 
 
 def test_preprocess_and_build_request_share_prepared_state(

--- a/tests/unit_test/fun_cosyvoice3/test_utils.py
+++ b/tests/unit_test/fun_cosyvoice3/test_utils.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import sys
+
 import numpy as np
+import pytest
 import torch
 
 from sglang_omni.models.fun_cosyvoice3 import utils
@@ -14,11 +17,183 @@ from sglang_omni.models.fun_cosyvoice3.sglang_model import (
     TOTAL_VOCAB_SIZE,
     VOCAB_SIZE,
 )
-from sglang_omni.models.fun_cosyvoice3.utils import build_llm_prompt_embeddings
+from sglang_omni.models.fun_cosyvoice3.utils import (
+    SpeechTokenizerV3,
+    build_llm_prompt_embeddings,
+)
 
 
 def _speech_embed(ids: torch.Tensor) -> torch.Tensor:
     return ids.to(dtype=torch.float32).unsqueeze(-1).expand(*ids.shape, 4)
+
+
+def test_speech_tokenizer_v3_loads_onnx_weights_on_requested_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[object] = []
+
+    class _FakeModel:
+        def to(self, device: torch.device) -> _FakeModel:
+            calls.append(device)
+            return self
+
+        def eval(self) -> _FakeModel:
+            calls.append("eval")
+            return self
+
+    class _FakeBackend:
+        @staticmethod
+        def load_model(model_path: str) -> _FakeModel:
+            calls.append(model_path)
+            return _FakeModel()
+
+    monkeypatch.setitem(sys.modules, "s3tokenizer", _FakeBackend())
+
+    tokenizer = SpeechTokenizerV3("speech_tokenizer_v3.onnx", device="cpu")
+
+    assert calls == ["speech_tokenizer_v3.onnx", torch.device("cpu"), "eval"]
+    assert tokenizer.device == torch.device("cpu")
+
+
+def test_speech_tokenizer_v3_batches_ragged_audio_and_slices_codes() -> None:
+    class _FakeBackend:
+        @staticmethod
+        def log_mel_spectrogram(audio: torch.Tensor) -> torch.Tensor:
+            return torch.full(
+                (128, audio.numel()),
+                float(audio[0].item()),
+                dtype=torch.float32,
+            )
+
+        @staticmethod
+        def padding(mels: list[torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
+            max_frames = max(mel.shape[-1] for mel in mels)
+            padded = torch.zeros(len(mels), 128, max_frames)
+            lengths = torch.tensor([mel.shape[-1] for mel in mels])
+            for index, mel in enumerate(mels):
+                padded[index, :, : mel.shape[-1]] = mel
+            return padded, lengths
+
+    class _FakeModel:
+        def __init__(self) -> None:
+            self.seen_mels: torch.Tensor | None = None
+            self.seen_lengths: torch.Tensor | None = None
+
+        def quantize(
+            self, mels: torch.Tensor, lengths: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            assert torch.is_inference_mode_enabled()
+            self.seen_mels = mels.clone()
+            self.seen_lengths = lengths.clone()
+            return (
+                torch.tensor([[10, 11, 99], [20, 21, 22]]),
+                torch.tensor([2, 3]),
+            )
+
+    tokenizer = SpeechTokenizerV3.__new__(SpeechTokenizerV3)
+    tokenizer._backend = _FakeBackend()
+    tokenizer.device = torch.device("cpu")
+    tokenizer.model = _FakeModel()
+
+    tokens = tokenizer.extract_speech_tokens(
+        [
+            np.ones(3, dtype=np.float32),
+            np.full(5, 2.0, dtype=np.float32),
+        ]
+    )
+
+    assert tokenizer.model.seen_mels is not None
+    assert tokenizer.model.seen_lengths is not None
+    assert tokenizer.model.seen_mels.shape == (2, 128, 5)
+    assert tokenizer.model.seen_lengths.tolist() == [3, 5]
+    assert [token.tolist() for token in tokens] == [[[10, 11]], [[20, 21, 22]]]
+    assert all(token.dtype == torch.int32 for token in tokens)
+    assert all(token.device.type == "cpu" for token in tokens)
+
+
+def test_speech_tokenizer_v3_empty_batch_returns_empty_list() -> None:
+    tokenizer = SpeechTokenizerV3.__new__(SpeechTokenizerV3)
+
+    class _Backend:
+        def log_mel_spectrogram(self, audio: torch.Tensor) -> torch.Tensor:
+            raise AssertionError("empty batches must not invoke the backend")
+
+    tokenizer._backend = _Backend()
+    assert tokenizer.extract_speech_tokens([]) == []
+
+
+def test_speech_tokenizer_v3_accepts_audio_at_30_second_boundary() -> None:
+    audio = np.ones(30 * 16000, dtype=np.float32)
+
+    normalized = SpeechTokenizerV3._normalize_audio(audio, 16000)
+
+    assert normalized.shape == (30 * 16000,)
+    assert normalized.dtype == torch.float32
+
+
+@pytest.mark.parametrize(
+    ("codes", "code_lengths", "message"),
+    [
+        (
+            torch.zeros(1, 2, 1),
+            torch.tensor([1]),
+            "invalid batch shapes",
+        ),
+        (
+            torch.zeros(1, 2),
+            torch.tensor([3]),
+            "invalid code length",
+        ),
+        (
+            torch.zeros(1, 2),
+            torch.tensor([-1]),
+            "invalid code length",
+        ),
+    ],
+)
+def test_speech_tokenizer_v3_rejects_invalid_model_outputs(
+    codes: torch.Tensor,
+    code_lengths: torch.Tensor,
+    message: str,
+) -> None:
+    class _Backend:
+        @staticmethod
+        def log_mel_spectrogram(audio: torch.Tensor) -> torch.Tensor:
+            return torch.zeros(128, 4)
+
+        @staticmethod
+        def padding(mels: list[torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
+            return torch.zeros(len(mels), 128, 4), torch.tensor([4] * len(mels))
+
+    class _Model:
+        def quantize(
+            self, mels: torch.Tensor, lengths: torch.Tensor
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            return codes, code_lengths
+
+    tokenizer = SpeechTokenizerV3.__new__(SpeechTokenizerV3)
+    tokenizer._backend = _Backend()
+    tokenizer.device = torch.device("cpu")
+    tokenizer.model = _Model()
+
+    with pytest.raises(RuntimeError, match=message):
+        tokenizer.extract_speech_tokens([np.ones(4, dtype=np.float32)])
+
+
+@pytest.mark.parametrize(
+    ("audio", "sample_rate", "message"),
+    [
+        (np.ones(4, dtype=np.float32), 24000, "16kHz"),
+        (np.ones((2, 4), dtype=np.float32), 16000, "shape"),
+        (np.array([], dtype=np.float32), 16000, "must not be empty"),
+        (np.ones(480001, dtype=np.float32), 16000, "30s"),
+    ],
+)
+def test_speech_tokenizer_v3_rejects_invalid_audio(
+    audio: np.ndarray, sample_rate: int, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        SpeechTokenizerV3._normalize_audio(audio, sample_rate)
 
 
 def test_cosyvoice3_prompt_embeddings_use_speech_control_tokens_and_reference_tokens() -> (

--- a/tests/unit_test/scheduling/test_simple_scheduler.py
+++ b/tests/unit_test/scheduling/test_simple_scheduler.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+
+from sglang_omni.scheduling.messages import IncomingMessage
+from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+
+
+def test_batch_compute_can_return_a_request_specific_error() -> None:
+    scheduler = SimpleScheduler(
+        lambda payload: payload,
+        batch_compute_fn=lambda payloads: [ValueError("bad input"), payloads[1]],
+        max_batch_size=2,
+    )
+    batch = [
+        IncomingMessage("bad", "new_request", "bad"),
+        IncomingMessage("good", "new_request", "good"),
+    ]
+    loop = asyncio.new_event_loop()
+    try:
+        scheduler._run_batch(batch, loop)
+    finally:
+        loop.close()
+
+    error = scheduler.outbox.get_nowait()
+    result = scheduler.outbox.get_nowait()
+    assert error.request_id == "bad"
+    assert error.type == "error"
+    assert isinstance(error.data, ValueError)
+    assert result.request_id == "good"
+    assert result.type == "result"
+    assert result.data == "good"


### PR DESCRIPTION
## Motivation

Implements the **Batch inference for S3-Tokenizer** item from #1652.

Concurrent CosyVoice3 requests with distinct reference audio previously invoked the S3 tokenizer independently. This PR micro-batches the tokenizer stage while preserving the reference-artifact cache and single-flight behavior.

## Modifications

- Replace the local ONNX/Whisper S3-tokenizer path with `s3tokenizer==0.3.0`.
- Add ragged-audio batch token extraction and retain the single-audio API as a wrapper.
- Batch only S3-tokenizer inference; speaker encoding and Flow mel extraction remain per-reference.
- Configure an 8-item reference batch with a 4 ms wait window.
- Use FIFO preprocessing batches so reference encodes batch before ordered TP embedding collectives.
- Preserve per-request errors in scheduler batches and close the batching worker on shutdown.
- Accept array-like reference-audio inputs without ambiguous boolean coercion.

## Related Issues

Related to #1652.

## Accuracy Test

Current PR head: `14cce65`.

- Focused suite: `40 passed`.
- Compared upstream `507cfaa` with this PR on 8 real reference clips.
- All `1,668 / 1,668` S3 token values were exactly equal, including ragged lengths from 145 to 278 tokens.

No model weights, model architecture, or decoding logic are changed.

## Benchmark & Profiling

Hardware and environment: 1x NVIDIA GeForce RTX 5090, PyTorch 2.11.0+cu130, ONNX Runtime GPU 1.29.0. The benchmark uses the same 8 reference clips (5.8-11.1 s), 2 warmups, 5 measured iterations per shape, and explicit GPU synchronization. Reference-encoding measurements clear the cache before every sample.

### Core S3 tokenizer (preloaded 16 kHz audio)

| Concurrent references | Baseline p50 | PR p50 | Baseline items/s | PR items/s | Throughput change |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 4.59 ms | 8.67 ms | 217.882 | 115.370 | -47.1% |
| 2 | 15.18 ms | 12.29 ms | 131.780 | 162.766 | +23.5% |
| 4 | 30.46 ms | 22.46 ms | 131.319 | 178.082 | +35.7% |
| 8 | 65.20 ms | 50.88 ms | 122.705 | 157.240 | +28.1% |

Every measured 2/4/8-request reference batch formed at its target size. The 1-request result includes batching-path overhead and is not an optimization target.

### Reference preprocessing path

For 8 simultaneous distinct references, the full reference-conditioning path measured 1148.41 ms / 6.966 items/s on baseline and 1164.07 ms / 6.872 items/s on this PR. This end-to-end path is effectively flat in this setup because unchanged CAMPPlus speaker encoding and Flow mel extraction dominate its wall time. The measurable gain above is intentionally scoped to the S3 tokenizer targeted by this PR.

## Checklist

- [ ] Format code with pre-commit. (`pre-commit` is unavailable in the local environment.)
- [x] Add unit tests.
- [x] Documentation / tutorials are not needed for this internal preprocessing change.
- [x] Provide throughput / latency benchmark results and accuracy evaluation.