### PR TITLE
feat(qwen3-tts): support 1.7B CustomVoice

### DIFF
--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -39,7 +39,7 @@ for details.
 | [Fish Speech S2-Pro](../cookbook/fishaudio_s2_pro.md) | `examples/configs/s2pro_tts.yaml` | Supports plain TTS and voice cloning with `references` |
 | [Voxtral TTS](../cookbook/voxtral_tts.md) | `examples/configs/voxtral_tts.yaml` | Uses `input`, `voice`, `response_format`, and `max_new_tokens`. Use `--no-ref-audio` for SeedTTS benchmarking |
 | [Qwen3-TTS Base](../cookbook/qwen3_tts.md) | `examples/configs/qwen3_tts_0_6b.yaml`, `examples/configs/qwen3_tts_1_7b.yaml` | Requires reference audio through `ref_audio` or `references[0].audio_path`. `language` defaults to `auto` |
-| [Qwen3-TTS CustomVoice](../cookbook/qwen3_tts.md) | `examples/configs/qwen3_tts_0_6b_customvoice.yaml` | Text-only requests use the checkpoint speaker table. Set `voice` to the desired checkpoint speaker |
+| [Qwen3-TTS CustomVoice](../cookbook/qwen3_tts.md#customvoice-checkpoints) | `examples/configs/qwen3_tts_0_6b_customvoice.yaml`, `examples/configs/qwen3_tts_1_7b_customvoice.yaml` | Text-only synthesis with built-in speakers; omit `voice` for Vivian. Both sizes support streaming; use 1.7B for instruction control |
 | [Qwen3-TTS VoiceDesign](../cookbook/qwen3_tts.md) | `examples/configs/qwen3_tts_1_7b_voicedesign.yaml` | Requires `task_type="VoiceDesign"` and non-empty `instructions`. No reference audio is required |
 | [Ming-Omni-TTS](../cookbook/ming_tts.md) | `examples/configs/ming_omni_tts.yaml` | Text-only synthesis or one local reference clip with its transcript; streaming; the provided config uses TP1 |
 | [Fun-CosyVoice3](../cookbook/fun_cosyvoice3.md) | `examples/configs/fun_cosyvoice3_0_5b.yaml` | Requires one reference audio clip via `ref_audio` or `references`. Supports zero-shot cloning, cross-lingual, instruct mode, and buffered speed control |
@@ -107,12 +107,14 @@ For Qwen3-TTS CustomVoice:
 
 ```bash
 sgl-omni serve \
-  --model-path Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice \
-  --config examples/configs/qwen3_tts_0_6b_customvoice.yaml \
+  --model-path Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice \
+  --config examples/configs/qwen3_tts_1_7b_customvoice.yaml \
   --allowed-media-domain huggingface.co \
   --allowed-media-domain cas-bridge.xethub.hf.co \
   --port 8000
 ```
+
+For 0.6B CustomVoice, use `Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice` with `examples/configs/qwen3_tts_0_6b_customvoice.yaml`.
 
 For Qwen3-TTS VoiceDesign:
 
@@ -218,6 +220,23 @@ curl -X POST http://localhost:8000/v1/audio/speech \
   }' \
   --output output.wav
 ```
+
+Qwen3-TTS CustomVoice uses a built-in speaker without reference audio:
+
+```bash
+curl -X POST http://localhost:8000/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    "input": "Hello from Qwen CustomVoice.",
+    "voice": "Ryan",
+    "language": "English",
+    "instructions": "Speak clearly and calmly."
+  }' \
+  --output custom-voice.wav
+```
+
+Omit cloning fields (`ref_audio`, `ref_text`, `references`, and `x_vector_only_mode`) and omit `task_type` or set it to `CustomVoice`. For 0.6B, omit `instructions`: it remains accepted for compatibility, but reliable instruction control is not supported. See [CustomVoice checkpoints](../cookbook/qwen3_tts.md#customvoice-checkpoints) for speaker discovery, streaming, and Eric/Dylan language behavior.
 
 Qwen3-TTS VoiceDesign uses text plus voice instructions:
 
@@ -447,6 +466,8 @@ List preset and uploaded voices:
 ```bash
 curl http://localhost:8000/v1/audio/voices
 ```
+
+For CustomVoice, the response's `voices` list contains `default` and the served checkpoint's built-in speakers. Uploaded reference voices are not used for CustomVoice synthesis.
 
 Use the uploaded voice by name:
 

--- a/docs/cookbook/qwen3_tts.md
+++ b/docs/cookbook/qwen3_tts.md
@@ -449,7 +449,50 @@ only the first chunk.
 Both expose an identical request API. The 1.7B model has higher capacity (typically better
 quality) at a larger memory and latency cost; the 0.6B model is lighter and faster.
 
+## CustomVoice Checkpoints
+
+CustomVoice generates speech with built-in speakers through the same pipeline. Use it without reference audio; omit `ref_audio`, `ref_text`, `references`, and `x_vector_only_mode`. Omit `task_type` or set it to `CustomVoice`.
+
+| Checkpoint | Config | Instruction guidance |
+|---|---|---|
+| `Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice` | `examples/configs/qwen3_tts_0_6b_customvoice.yaml` | Accepted for backward compatibility, but not recommended |
+| `Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice` | `examples/configs/qwen3_tts_1_7b_customvoice.yaml` | Supported |
+
+Both released checkpoints provide `Serena`, `Vivian`, `Uncle_Fu`, `Ryan`, `Aiden`, `Ono_Anna`, `Sohee`, `Eric`, and `Dylan`. Speaker matching is case-insensitive; an omitted or `default` voice selects `Vivian`. `GET /v1/audio/voices` lists `default` and the served checkpoint's speakers. Unknown speakers or supplied cloning fields return HTTP 400; uploaded reference voices are not used for CustomVoice synthesis.
+
+Both sizes support buffered speech, batch requests, incremental HTTP PCM output, and WebSocket audio output. HTTP streaming requires `stream=true` with `response_format="pcm"`; WebSocket sessions use `stream_audio=true` with `response_format="pcm"`.
+
+**0.6B instruction compatibility:** SGLang-Omni continues to pass optional `instructions` into the 0.6B prompt, preserving existing behavior. The released 0.6B model does not provide reliable instruction control; omit this field or use 1.7B when style control is needed.
+
+**Eric/Dylan language behavior:** For both sizes, `language: Auto` selects Eric's Sichuan dialect token or Dylan's Beijing dialect token. An explicit language takes precedence: `language: Chinese` keeps the Chinese language token. This preserves existing SGLang-Omni behavior and differs from the QwenLM/Qwen3-TTS Python wrapper (`qwen-tts` 0.1.1), which also selects dialect tokens for `Chinese`. This is a conditioning choice, not a guarantee that the speaker's accent disappears.
+
+Start the 1.7B checkpoint with its matching config:
+
+```bash
+sgl-omni serve \
+  --model-path Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice \
+  --config examples/configs/qwen3_tts_1_7b_customvoice.yaml \
+  --port 8000
+```
+
+Then select a built-in speaker in the request. For 0.6B, use its model/config pair from the table and omit `instructions`.
+
+```bash
+curl -X POST http://localhost:8000/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    "input": "SGLang-Omni serves Qwen CustomVoice.",
+    "voice": "Ryan",
+    "language": "English",
+    "instructions": "Speak clearly and calmly."
+  }' \
+  --output custom-voice.wav
+```
+
 ## Benchmark Results
+
+### 0.6B Base
 
 Qwen3-TTS-12Hz-0.6B-Base on Seed-TTS EN (1088 utterances, reference voice cloning from each
 prompt), concurrency 16, WER scored with HF Whisper-large-v3. Hardware: 1× H200 SXM.
@@ -470,6 +513,28 @@ repetition loop and generated ~164 s of looping audio up to `max_new_tokens`, wh
 the raw micro-average to 18.29%; excluding those, corpus WER is 1.07%. RTF > 1 reflects the
 0.6B codec pipeline at concurrency 16, not single-stream latency. The 1.7B checkpoint trades
 latency for quality.
+
+### 1.7B CustomVoice
+
+Qwen3-TTS-12Hz-1.7B-CustomVoice on the full Seed-TTS-Eval EN and ZH splits, concurrency 16, with 16 warmup requests per language/mode and `max_new_tokens=2048`. EN used Ryan/English and ZH used Vivian/Chinese, without reference audio or instructions. WER/CER was scored with Qwen3-ASR-1.7B at concurrency 32. Hardware: 1× H200 141 GB, BF16, TP1. Sampling overrides and seed were unset.
+
+The server used `--tts_engine.engine.max_running_requests 64`, `--tts_engine.engine.cuda_graph_max_bs 64`, `--tts_engine.engine.torch_compile_max_bs 64`, `--vocoder.process vocoder`, `--tts_engine.gpu_memory_fraction 0.85`, and `--vocoder.gpu_memory_fraction 0.10`; `torch.compile` remained disabled. Streaming used the default `1 -> 2 -> 4` chunk ramp without a request-level override. Each language/mode was measured once, in non-streaming EN/ZH then streaming EN/ZH order on the same warmed server. The target GPU had no external GPU process during timed windows; host CPU, memory, and I/O were shared with another profiling task.
+
+| Metric | Non-streaming EN | Non-streaming ZH | Streaming EN | Streaming ZH |
+|---|---:|---:|---:|---:|
+| Samples | 1088 | 2020 | 1088 | 2020 |
+| Corpus WER/CER | 1.608% | 0.984% | 2.085% | 0.927% |
+| Corpus WER/CER (excl. >50% outliers) | 1.359% | 0.984% | 1.454% | 0.927% |
+| Samples above 50% WER/CER | 3 | 0 | 4 | 0 |
+| UTMOS | 4.1723 | 3.1824 | 4.1500 | 3.1789 |
+| QPS | 14.788 | 13.307 | 10.098 | 8.333 |
+| Latency mean (s) | 1.075 | 1.198 | 1.573 | 1.915 |
+| RTF mean | 0.2335 | 0.2079 | 0.3380 | 0.3332 |
+| TTFA mean (s) | N/A | N/A | 0.1213 | 0.1047 |
+
+Corpus WER (EN) / CER (ZH) is total edit distance divided by total reference words / characters and includes every sample. The filtered row excludes samples whose own WER/CER exceeds 50% and recomputes the corpus rate. UTMOS is the mean predicted audio-quality score, not a listening-test score. These independently sampled runs are not a paired comparison of streaming and non-streaming quality; the Base result also uses different conditioning and a different ASR evaluator.
+
+TTFA measures arrival of the first PCM payload, not the first audible speech; its mean payload duration was 80 ms in both languages. All 3,108 streaming requests were continuity-scored: 98.99% EN and 93.76% ZH had no playback underrun longer than 50 ms. Maximum underrun was 396.1 ms EN and 2072.0 ms ZH. The default ramp therefore does not guarantee uninterrupted playback at concurrency 16; see [First-audio chunk ramp](#first-audio-chunk-ramp) for the buffering tradeoff.
 
 ## Known Limitations
 

--- a/examples/configs/qwen3_tts_1_7b_customvoice.yaml
+++ b/examples/configs/qwen3_tts_1_7b_customvoice.yaml
@@ -1,0 +1,2 @@
+config_cls: Qwen3TTSPipelineConfig
+model_path: Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice

--- a/sglang_omni/config/__init__.py
+++ b/sglang_omni/config/__init__.py
@@ -12,6 +12,7 @@ from sglang_omni.config.runtime import resolve_stage_factory_args
 from sglang_omni.config.schema import (
     AudioChunkingConfig,
     CommConfig,
+    CustomVoiceConfig,
     EndpointsConfig,
     EngineArgs,
     EngineStageConfig,
@@ -51,6 +52,7 @@ __all__ = [
     "build_process_topology_plan",
     "AudioChunkingConfig",
     "ResolvedAudioChunking",
+    "CustomVoiceConfig",
     "compile_logical_processes",
     "PipelineConfig",
     "ProcessConfig",

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -533,6 +533,14 @@ class ResolvedAudioChunking:
         return max(int(self.max_audio_clip_s * sample_rate), 1)
 
 
+@dataclass(frozen=True)
+class CustomVoiceConfig:
+    # Note(yzxiao): CustomVoice selects a checkpoint speaker without reference
+    # audio. Only an absent config disables this contract; speakers is required.
+    speakers: tuple[str, ...]
+    task_type: str
+
+
 class PipelineConfig(BaseModel):
     """Top-level pipeline configuration.
 
@@ -761,6 +769,9 @@ class PipelineConfig(BaseModel):
     def supports_uploaded_voice_references(self) -> bool:
         """Return whether uploaded voices can be lowered as reference audio."""
         return False
+
+    def resolve_custom_voice_config(self) -> CustomVoiceConfig | None:
+        return None
 
     def supports_audio_translation(self) -> bool:
         """Return whether this pipeline can serve /v1/audio/translations."""

--- a/sglang_omni/models/qwen3_tts/config.py
+++ b/sglang_omni/models/qwen3_tts/config.py
@@ -1,16 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Pipeline configuration for Qwen3-TTS Base."""
+"""Pipeline configuration for Qwen3-TTS."""
 
 from __future__ import annotations
 
+import json
 import re
+from pathlib import Path
 from typing import Any, ClassVar
 
 from sglang_omni.config import (
+    CustomVoiceConfig,
     EngineStageConfig,
     FactoryArgs,
     PipelineConfig,
     StageConfig,
+)
+from sglang_omni.config.runtime import (
+    resolve_stage_factory_kwargs,
+    resolve_stage_typed_kwargs,
 )
 
 _PKG = "sglang_omni.models.qwen3_tts"
@@ -23,7 +30,7 @@ _QWEN3_TTS_CUSTOM_VARIANT_MARKERS = (
 
 
 class Qwen3TTSPipelineConfig(PipelineConfig):
-    """3-stage Qwen3-TTS Base pipeline: preprocessing -> engine -> vocoder."""
+    """3-stage Qwen3-TTS pipeline: preprocessing -> engine -> vocoder."""
 
     architecture: ClassVar[str] = "Qwen3TTSForConditionalGeneration"
     requires_model_capabilities: ClassVar[bool] = True
@@ -108,6 +115,60 @@ class Qwen3TTSPipelineConfig(PipelineConfig):
     def supports_uploaded_voice_references(self) -> bool:
         return is_qwen3_tts_base_model(self.model_path)
 
+    def resolve_custom_voice_config(self) -> CustomVoiceConfig | None:
+        engine_stage = self.stage_named("tts_engine")
+        # Note(yzxiao): Inspect the checkpoint the engine factory will actually
+        # receive, including pipeline-authored and user-set factory overrides.
+        engine_factory_kwargs = {
+            "model_path": self.model_path,
+            **resolve_stage_factory_kwargs(engine_stage, self),
+            **resolve_stage_typed_kwargs(engine_stage),
+        }
+        checkpoint_config = _load_qwen3_tts_checkpoint_config(
+            engine_factory_kwargs["model_path"]
+        )
+        model_type = _normalize_qwen3_tts_model_type(
+            checkpoint_config.get("tts_model_type")
+        )
+        if model_type in {"base", "voice_design"}:
+            return None
+        if model_type == "custom_voice":
+            spk_id = checkpoint_config.get("talker_config", {}).get("spk_id")
+            if (
+                not isinstance(spk_id, dict)
+                or not spk_id
+                or any(not isinstance(name, str) or not name.strip() for name in spk_id)
+            ):
+                raise ValueError(
+                    "CustomVoice requires a non-empty talker_config.spk_id speaker mapping"
+                )
+            return CustomVoiceConfig(
+                speakers=tuple(spk_id),
+                task_type="CustomVoice",
+            )
+        return None
+
+
+def _load_qwen3_tts_checkpoint_config(model_path: str) -> dict[str, Any]:
+    checkpoint_dir = Path(model_path).expanduser()
+    if checkpoint_dir.is_dir():
+        config_path = checkpoint_dir / "config.json"
+    else:
+        from huggingface_hub import hf_hub_download
+
+        config_path = Path(hf_hub_download(repo_id=model_path, filename="config.json"))
+    with config_path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _normalize_qwen3_tts_model_type(raw: Any) -> str:
+    normalized = str(raw or "base").replace("-", "_").strip().lower()
+    if normalized == "customvoice":
+        return "custom_voice"
+    if normalized == "voicedesign":
+        return "voice_design"
+    return normalized
+
 
 def qwen3_tts_checkpoint_model_type(checkpoint_dir: str) -> str:
     """Read ``tts_model_type`` from a resolved checkpoint.
@@ -117,20 +178,10 @@ def qwen3_tts_checkpoint_model_type(checkpoint_dir: str) -> str:
     config does, and it is the same value the request path validates against.
     Returns ``"base"`` when the field is absent, matching that path's default.
     """
-    import json
-    import os
-
-    config_path = os.path.join(checkpoint_dir, "config.json")
-    if not os.path.isfile(config_path):
+    if not (Path(checkpoint_dir) / "config.json").is_file():
         return "base"
-    with open(config_path, encoding="utf-8") as handle:
-        raw = json.load(handle).get("tts_model_type")
-    normalized = str(raw or "base").replace("-", "_").strip().lower()
-    if normalized == "customvoice":
-        return "custom_voice"
-    if normalized == "voicedesign":
-        return "voice_design"
-    return normalized
+    config = _load_qwen3_tts_checkpoint_config(checkpoint_dir)
+    return _normalize_qwen3_tts_model_type(config.get("tts_model_type"))
 
 
 def is_qwen3_tts_base_model(model_path: str) -> bool:

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -1146,6 +1146,9 @@ def _prepare_qwen3_tts_custom_voice_request(
     wrapper: Any,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
     input_id = wrapper._tokenize_texts([wrapper._build_assistant_text(state.text)])[0]
+    # Note(yzxiao): QwenLM/Qwen3-TTS (qwen-tts 0.1.1) drops 0.6B instructions
+    # in its wrapper. Preserve this path's existing prompt passthrough for both
+    # sizes; accepting an instruction does not guarantee 0.6B style control.
     instruct_id = _build_instruct_id(wrapper, state.instructions)
     with torch.no_grad():
         return model.build_custom_voice_inputs(

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -463,6 +463,9 @@ class Qwen3TTSPromptBuilderMixin:
         language: str,
         voice: str | None = None,
     ) -> int | None:
+        # Note(yzxiao): QwenLM/Qwen3-TTS (qwen-tts 0.1.1) also applies speaker
+        # dialects to Chinese. Keep explicit languages unchanged here so existing
+        # Chinese requests do not switch to a dialect when using Eric or Dylan.
         if language.lower() != "auto":
             return self.config.codec_language_id[language.lower()]
         if voice is None:

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -430,6 +430,7 @@ async def _run_server(
             supports_uploaded_voice_references=(
                 pipeline_config.supports_uploaded_voice_references()
             ),
+            custom_voice_config=pipeline_config.resolve_custom_voice_config(),
             supports_audio_translation=(pipeline_config.supports_audio_translation()),
             required_speech_reference_count=(
                 pipeline_config.required_speech_reference_count

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -57,7 +57,7 @@ from sglang_omni.client.audio import (
     encode_pcm,
     select_audio_delta,
 )
-from sglang_omni.config import ResolvedAudioChunking
+from sglang_omni.config import CustomVoiceConfig, ResolvedAudioChunking
 from sglang_omni.config.schema import MAX_SPEECH_INPUT_CHARS
 from sglang_omni.http.admin_auth import (
     make_admin_auth_dependency,
@@ -178,6 +178,7 @@ def create_app(
     model_name: str | None = None,
     requires_uploaded_voice_for_named_voice: bool = False,
     supports_uploaded_voice_references: bool = True,
+    custom_voice_config: CustomVoiceConfig | None = None,
     supports_audio_translation: bool = False,
     required_speech_reference_count: int | None = None,
     speech_reference_text_required: bool = False,
@@ -202,6 +203,8 @@ def create_app(
             names must resolve to uploaded voices before reaching the model.
         supports_uploaded_voice_references: Whether uploaded voice names can be
             lowered into backend reference-audio requests.
+        custom_voice_config: Checkpoint speaker names and task type for CustomVoice.
+            When present, reference inputs and uploaded-voice resolution are disabled.
         supports_audio_translation: Whether the configured pipeline supports
             ``/v1/audio/translations``.
         required_speech_reference_count: Exact reference count required before
@@ -254,6 +257,7 @@ def create_app(
     app.state.speaker_sample_store = SpeakerSampleStore()
     app.state.speech_service = SpeechRequestValidator(
         default_model=app.state.model_name,
+        custom_voice_config=custom_voice_config,
         requires_uploaded_voice_for_named_voice=(
             requires_uploaded_voice_for_named_voice
         ),
@@ -300,7 +304,13 @@ def _register_voices(app: FastAPI) -> None:
             return JSONResponse(
                 content={"uploaded_voice_names": voice_store.uploaded_voice_names()}
             )
-        response = VoiceListResponse.model_validate(voice_store.list_response())
+        voice_list = voice_store.list_response()
+        custom_voice_config = app.state.speech_service.custom_voice_config
+        if custom_voice_config is not None:
+            voices = {name.casefold(): name for name in custom_voice_config.speakers}
+            voices["default"] = "default"
+            voice_list["voices"] = sorted(voices.values(), key=str.casefold)
+        response = VoiceListResponse.model_validate(voice_list)
         return JSONResponse(content=response.model_dump(exclude_none=True))
 
     @app.post("/v1/audio/voices")

--- a/sglang_omni/serve/speech_service.py
+++ b/sglang_omni/serve/speech_service.py
@@ -16,7 +16,7 @@ from pydantic import ValidationError
 
 from sglang_omni.client import ClientError, GenerateRequest, SamplingParams
 from sglang_omni.client.audio import audio_encoding_unavailable_reason
-from sglang_omni.config.schema import MAX_SPEECH_INPUT_CHARS
+from sglang_omni.config.schema import MAX_SPEECH_INPUT_CHARS, CustomVoiceConfig
 from sglang_omni.preprocessing.base import MediaIO
 from sglang_omni.preprocessing.resource_connector import MultiModalResourceConnector
 from sglang_omni.scheduling.streaming_vocoder import INITIAL_CODEC_CHUNK_FRAMES_PARAM
@@ -83,6 +83,7 @@ class SpeechRequestValidator:
         default_model: str,
         requires_uploaded_voice_for_named_voice: bool = False,
         supports_uploaded_voice_references: bool = True,
+        custom_voice_config: CustomVoiceConfig | None = None,
         required_speech_reference_count: int | None = None,
         speech_reference_text_required: bool = False,
         speech_reference_text_excludes_instructions: bool = False,
@@ -115,6 +116,17 @@ class SpeechRequestValidator:
         self.supports_uploaded_voice_references = (
             supports_uploaded_voice_references
             or requires_uploaded_voice_for_named_voice
+        )
+        self.custom_voice_config = custom_voice_config
+        if custom_voice_config is not None:
+            # Note(yzxiao): Checkpoint speakers take precedence over uploaded
+            # names, including when a stage overrides a Base model_path.
+            self.requires_uploaded_voice_for_named_voice = False
+            self.supports_uploaded_voice_references = False
+        self._speaker_keys = (
+            frozenset(name.casefold() for name in custom_voice_config.speakers)
+            if custom_voice_config is not None
+            else frozenset()
         )
         self.required_speech_reference_count = required_speech_reference_count
         self.speech_reference_text_required = speech_reference_text_required
@@ -250,6 +262,7 @@ class SpeechRequestValidator:
 
         if request.task_type is not None:
             updates["task_type"] = _normalize_task_type(request.task_type)
+        self._validate_custom_voice_request(request, task_type=updates.get("task_type"))
         if request.language is not None:
             updates["language"] = self._normalize_language(request.language)
 
@@ -262,6 +275,37 @@ class SpeechRequestValidator:
         )
         _validate_non_negative_int(request.seed, param="seed")
         return updates
+
+    def _validate_custom_voice_request(
+        self,
+        request: CreateSpeechRequest | CreateSpeechBatchRequest,
+        *,
+        task_type: str | None,
+    ) -> None:
+        config = self.custom_voice_config
+        if config is None:
+            return
+        if task_type is not None and task_type != config.task_type:
+            raise bad_request(
+                f"task_type must be one of: {config.task_type}", param="task_type"
+            )
+        for field in ("ref_audio", "ref_text", "x_vector_only_mode"):
+            if getattr(request, field) is not None:
+                raise bad_request(
+                    f"{field} is not supported by this model", param=field
+                )
+        if request.references:
+            raise bad_request(
+                "references are not supported by this model", param="references"
+            )
+        name = request.voice.strip().casefold()
+        if name in {"", "default"} or name in self._speaker_keys:
+            return
+        supported = ", ".join(("default", *config.speakers))
+        raise bad_request(
+            f"Unknown voice '{request.voice}'. Supported voices: {supported}",
+            param="voice",
+        )
 
     def _normalize_language(self, value: str) -> str:
         normalized = self._tts_language_aliases.get(value.strip().lower())
@@ -582,6 +626,7 @@ class SpeechRequestValidator:
             if batch.task_type is not None
             else None
         )
+        self._validate_custom_voice_request(batch, task_type=task_type)
         if batch.language is not None:
             self._normalize_language(batch.language)
         _validate_positive_int(batch.max_new_tokens, param="max_new_tokens")

--- a/tests/unit_test/pipeline/test_ipc.py
+++ b/tests/unit_test/pipeline/test_ipc.py
@@ -6,7 +6,7 @@ import asyncio
 import signal
 from pathlib import Path
 from types import FrameType, SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from fastapi import FastAPI
@@ -14,7 +14,12 @@ from fastapi.testclient import TestClient
 
 import sglang_omni.pipeline.mp_runner as mp_runner
 import sglang_omni.pipeline.runtime_config as runtime_config
-from sglang_omni.config.schema import EndpointsConfig, PipelineConfig, StageConfig
+from sglang_omni.config.schema import (
+    CustomVoiceConfig,
+    EndpointsConfig,
+    PipelineConfig,
+    StageConfig,
+)
 from sglang_omni.profiler.event_recorder import get_recorder
 from tests.unit_test.fixtures.pipeline_fakes import FakeMpContext, FakeRelay
 
@@ -469,6 +474,28 @@ async def _run_launcher_with_fake_runner(
     await launcher._run_server(config, port=8000)
     assert runner_ref is not None
     return runner_ref, app, profiler_calls
+
+
+@pytest.mark.asyncio
+async def test_launcher_passes_one_resolved_custom_voice_config(
+    tmp_path, monkeypatch
+) -> None:
+    config = _make_config(tmp_path)
+    custom_voice_config = CustomVoiceConfig(
+        speakers=("speaker",), task_type="CustomVoice"
+    )
+    resolve = Mock(return_value=custom_voice_config)
+    monkeypatch.setattr(PipelineConfig, "resolve_custom_voice_config", resolve)
+    _, app, _ = await _run_launcher_with_fake_runner(
+        config=config,
+        serve_mock=AsyncMock(return_value=None),
+        monkeypatch=monkeypatch,
+    )
+    resolve.assert_called_once_with()
+    kwargs = app.state.create_app_kwargs
+    assert kwargs["custom_voice_config"] is custom_voice_config
+    assert kwargs["requires_uploaded_voice_for_named_voice"] is False
+    assert kwargs["supports_uploaded_voice_references"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/qwen3_tts/test_config.py
+++ b/tests/unit_test/qwen3_tts/test_config.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from sglang_omni.models.qwen3_tts.config import Qwen3TTSPipelineConfig
+
+
+@pytest.mark.parametrize("size", ["0.6B", "1.7B"])
+def test_custom_voice_config_uses_engine_checkpoint_metadata(
+    tmp_path, monkeypatch, size
+) -> None:
+    root = tmp_path / f"Qwen3-TTS-12Hz-{size}-Base"
+    engine = tmp_path / "renamed-checkpoint"
+    root.mkdir()
+    engine.mkdir()
+    (root / "config.json").write_text('{"tts_model_type": "base"}')
+    metadata = {
+        "tts_model_type": "CustomVoice",
+        "talker_config": {"spk_id": {"First": 21, "Second": 34}},
+    }
+    (engine / "config.json").write_text(json.dumps(metadata))
+    download = Mock(side_effect=AssertionError("Local checkpoint must not use HF"))
+    monkeypatch.setattr("huggingface_hub.hf_hub_download", download)
+    config = Qwen3TTSPipelineConfig(model_path=str(root))
+    config.stages[1].factory = config.stages[1].factory.model_copy(
+        update={"model_path": str(engine)}
+    )
+    monkeypatch.setattr(
+        Qwen3TTSPipelineConfig,
+        "stage_factory_kwargs",
+        lambda self, name: {"model_path": str(root)},
+    )
+
+    custom_voice_config = config.resolve_custom_voice_config()
+
+    assert custom_voice_config.speakers == ("First", "Second")
+    assert custom_voice_config.task_type == "CustomVoice"
+    download.assert_not_called()
+
+
+def test_custom_voice_config_reads_hub_checkpoint_metadata(
+    tmp_path, monkeypatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "tts_model_type": "custom_voice",
+                "talker_config": {"spk_id": {"speaker": 7}},
+            }
+        )
+    )
+    download = Mock(return_value=str(config_path))
+    monkeypatch.setattr("huggingface_hub.hf_hub_download", download)
+    config = Qwen3TTSPipelineConfig(model_path="org/model")
+
+    assert config.resolve_custom_voice_config().speakers == ("speaker",)
+    download.assert_called_once_with(repo_id="org/model", filename="config.json")
+
+
+@pytest.mark.parametrize("spk_id", [None, {}, {"": 1}])
+def test_custom_voice_config_rejects_missing_or_invalid_speakers(
+    tmp_path, spk_id
+) -> None:
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "tts_model_type": "custom_voice",
+                "talker_config": {"spk_id": spk_id},
+            }
+        )
+    )
+    config = Qwen3TTSPipelineConfig(model_path=str(tmp_path))
+
+    with pytest.raises(ValueError, match="spk_id"):
+        config.resolve_custom_voice_config()
+
+
+@pytest.mark.parametrize(
+    ("model_type", "directory", "uploaded_voices"),
+    [
+        ("base", "Qwen3-TTS-12Hz-0.6B-Base", True),
+        ("base", "Qwen3-TTS-12Hz-1.7B-Base", True),
+        ("voice_design", "Qwen3-TTS-12Hz-1.7B-VoiceDesign", False),
+        ("base", "renamed-checkpoint", False),
+    ],
+)
+def test_non_custom_voice_config_preserves_existing_hooks(
+    tmp_path, model_type, directory, uploaded_voices
+) -> None:
+    checkpoint = tmp_path / directory
+    checkpoint.mkdir()
+    config_path = checkpoint / "config.json"
+    config_path.write_text(json.dumps({"tts_model_type": model_type}))
+    config = Qwen3TTSPipelineConfig(model_path=str(checkpoint))
+
+    assert config.resolve_custom_voice_config() is None
+    assert config.requires_uploaded_voice_for_named_voice() is uploaded_voices
+    assert config.supports_uploaded_voice_references() is uploaded_voices

--- a/tests/unit_test/router/test_tts_routes.py
+++ b/tests/unit_test/router/test_tts_routes.py
@@ -87,6 +87,37 @@ def _voice_routing(
     )
 
 
+@pytest.mark.asyncio
+async def test_worker_builtin_voice_list_does_not_populate_uploaded_registry(
+    tmp_path, monkeypatch
+) -> None:
+    from sglang_omni.config import CustomVoiceConfig
+    from sglang_omni.serve import create_app as create_worker_app
+
+    monkeypatch.setenv("SPEAKER_SAMPLES_DIR", str(tmp_path))
+    app = create_worker_app(
+        object(),
+        custom_voice_config=CustomVoiceConfig(
+            speakers=("Ryan",), task_type="CustomVoice"
+        ),
+    )
+    config = _router_config(voice_owner_worker_url="http://worker-a:8101")
+    workers = build_workers(config.workers)
+    workers[0].state = "healthy"
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url=workers[0].url
+    ) as client:
+        listed = await client.get("/v1/audio/voices")
+        assert listed.json()["voices"] == ["default", "Ryan"]
+        state = _voice_routing(config, workers, client)
+        assert state.ensure_owner() is workers[0]
+        assert state.requires_owner({"Ryan"})
+        await state._reconcile_once()
+        assert state.to_dict()["registry_state"] == "ready"
+        assert state.to_dict()["uploaded_voice_count"] == 0
+        assert not state.requires_owner({"Ryan"})
+
+
 def test_voice_owner_config_must_identify_a_capable_worker() -> None:
     with pytest.raises(
         ValueError,

--- a/tests/unit_test/serve/test_speech_batch.py
+++ b/tests/unit_test/serve/test_speech_batch.py
@@ -6,12 +6,14 @@ import asyncio
 import base64
 import logging
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 from fastapi.testclient import TestClient
 
 from sglang_omni.client import ClientError
 from sglang_omni.client.types import SpeechResult
+from sglang_omni.config import CustomVoiceConfig
 from sglang_omni.serve import create_app
 from sglang_omni.serve.openai_api import _create_speech_batch_with_disconnect_watch
 from sglang_omni.serve.speech_service import SpeechRequestValidator
@@ -125,6 +127,47 @@ class CountingReferenceSpeechRequestValidator(SpeechRequestValidator):
     ) -> dict[str, str]:
         self.reference_loads.append(value)
         return {"data": "UklGRg==", "media_type": "audio/wav"}
+
+
+def test_custom_voice_batch_validates_each_item_before_io(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("SPEAKER_SAMPLES_DIR", str(tmp_path))
+    client_impl = RecordingBatchSpeechClient()
+    app = create_app(
+        client_impl,
+        custom_voice_config=CustomVoiceConfig(
+            speakers=("speaker",), task_type="CustomVoice"
+        ),
+    )
+    load = Mock(side_effect=AssertionError("Invalid reference must not be read"))
+    monkeypatch.setattr(
+        app.state.speech_service.reference_connector, "load_resource", load
+    )
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/audio/speech/batch",
+            json={
+                "voice": "speaker",
+                "items": [
+                    {"input": "valid"},
+                    {"input": "bad voice", "voice": "missing"},
+                    {"input": "bad task", "task_type": "Base"},
+                    {
+                        "input": "bad reference",
+                        "ref_audio": "https://example.com/ref.wav",
+                    },
+                ],
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert (body["succeeded"], body["failed"]) == (1, 3)
+    assert [
+        item["error"]["param"] for item in body["results"] if item["status"] == "error"
+    ] == ["items.1.voice", "items.2.task_type", "items.3.ref_audio"]
+    assert [request.prompt for request in client_impl.requests] == ["valid"]
+    load.assert_not_called()
 
 
 def test_batch_speech_preserves_order_and_item_errors() -> None:

--- a/tests/unit_test/serve/test_speech_protocol.py
+++ b/tests/unit_test/serve/test_speech_protocol.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import base64
 import ipaddress
 from pathlib import Path
+from unittest.mock import Mock
 
 import httpx
 import pytest
 
 from sglang_omni.client import audio as client_audio
+from sglang_omni.config import CustomVoiceConfig
 from sglang_omni.preprocessing import resource_connector
 from sglang_omni.serve import speech_service
 from sglang_omni.serve.protocol import CreateSpeechRequest
@@ -49,6 +51,133 @@ def test_speech_generation_uses_served_model_and_default_voice() -> None:
     assert prepared.request.voice == "default"
     assert generate_request.model == "tts"
     assert generate_request.metadata["tts_params"]["voice"] == "default"
+
+
+@pytest.mark.parametrize(
+    ("options", "required", "supports"),
+    [
+        ({}, False, True),
+        (
+            {
+                "requires_uploaded_voice_for_named_voice": False,
+                "supports_uploaded_voice_references": False,
+            },
+            False,
+            False,
+        ),
+        (
+            {
+                "requires_uploaded_voice_for_named_voice": False,
+                "supports_uploaded_voice_references": True,
+            },
+            False,
+            True,
+        ),
+        (
+            {
+                "requires_uploaded_voice_for_named_voice": True,
+                "supports_uploaded_voice_references": False,
+            },
+            True,
+            True,
+        ),
+        (
+            {
+                "requires_uploaded_voice_for_named_voice": True,
+                "supports_uploaded_voice_references": True,
+            },
+            True,
+            True,
+        ),
+    ],
+)
+def test_speech_uploaded_voice_options_preserve_behavior(
+    options, required, supports
+) -> None:
+    store = Mock(spec=["get", "resolve_reference"])
+    store.resolve_reference.return_value = None
+    service = SpeechRequestValidator(default_model="tts", voice_store=store, **options)
+    assert service.requires_uploaded_voice_for_named_voice is required
+    assert service.supports_uploaded_voice_references is supports
+    if required:
+        with pytest.raises(SpeechAPIError) as exc:
+            service.parse_request({"input": "hello", "voice": "missing"})
+        assert exc.value.param == "voice"
+    else:
+        request = service.parse_request({"input": "hello", "voice": "missing"})
+        assert request.voice == "missing"
+    assert store.resolve_reference.call_count == int(supports)
+    store.get.assert_not_called()
+
+
+@pytest.mark.parametrize("voice", ["default", "ViViAn"])
+@pytest.mark.parametrize("requires_uploaded_voice", [False, True])
+def test_custom_voice_config_preserves_model_owned_defaults(
+    voice, requires_uploaded_voice
+) -> None:
+    config = CustomVoiceConfig(speakers=("vivian", "ryan"), task_type="CustomVoice")
+    store = Mock(spec=["get", "resolve_reference"])
+    service = SpeechRequestValidator(
+        default_model="tts",
+        custom_voice_config=config,
+        requires_uploaded_voice_for_named_voice=requires_uploaded_voice,
+        voice_store=store,
+    )
+    prepared = service.parse_generation_request(
+        {
+            "input": "hello",
+            "speaker": voice,
+            "instructions": "Calm and clear.",
+            "references": [],
+        }
+    )
+    generated = service.build_generate_request(
+        prepared.request,
+        validate=False,
+        reference_descriptors=prepared.reference_descriptors,
+    )
+    params = generated.metadata["tts_params"]
+    assert service.custom_voice_config is config
+    assert service.requires_uploaded_voice_for_named_voice is False
+    assert service.supports_uploaded_voice_references is False
+    assert params["voice"] == voice
+    assert params["instructions"] == "Calm and clear."
+    assert "task_type" not in params and "language" not in params
+    assert params.get("explicit_generation_params", []) == []
+    assert generated.prompt == "hello"
+    assert prepared.reference_descriptors == []
+    assert store.mock_calls == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("voice", "missing"),
+        ("task_type", "Base"),
+        ("ref_audio", "https://example.com/reference.wav"),
+        ("ref_text", ""),
+        ("x_vector_only_mode", False),
+        ("references", [{"audio": "https://example.com/reference.wav"}]),
+    ],
+)
+def test_custom_voice_config_rejects_invalid_inputs_before_io(
+    monkeypatch, field, value
+) -> None:
+    config = CustomVoiceConfig(speakers=("speaker",), task_type="CustomVoice")
+    store = Mock(spec=["get", "resolve_reference"])
+    service = SpeechRequestValidator(
+        default_model="tts", custom_voice_config=config, voice_store=store
+    )
+    load = Mock(side_effect=AssertionError("Reference I/O must not run"))
+    monkeypatch.setattr(service.reference_connector, "load_resource", load)
+    payload = {"input": "hello"}
+    payload[field] = value
+    with pytest.raises(SpeechAPIError) as exc:
+        service.parse_generation_request(payload)
+    assert exc.value.status_code == 400
+    assert exc.value.param == field
+    load.assert_not_called()
+    assert store.mock_calls == []
 
 
 @pytest.mark.parametrize("stream", [False, True])

--- a/tests/unit_test/serve/test_speech_voices.py
+++ b/tests/unit_test/serve/test_speech_voices.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import json
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from sglang_omni.client.audio import DEFAULT_SAMPLE_RATE, encode_wav
+from sglang_omni.models.qwen3_tts.config import Qwen3TTSPipelineConfig
 from sglang_omni.scheduling.speaker_cache import SpeakerArtifactCache, SpeakerCacheKey
 from sglang_omni.serve import create_app
 from sglang_omni.serve.openai_api import VoiceUploadBodyLimitMiddleware
@@ -644,6 +646,62 @@ def test_speech_service_can_disable_uploaded_voice_resolution(
     assert gen_req.prompt == "hello"
     assert gen_req.metadata["tts_params"]["voice"] == "Vivian"
     assert "uploaded_voice_name" not in gen_req.metadata["tts_params"]
+
+
+@pytest.mark.parametrize("required", [False, True])
+def test_create_app_forwards_uploaded_voice_options(
+    tmp_path, monkeypatch, required
+) -> None:
+    monkeypatch.setenv("SPEAKER_SAMPLES_DIR", str(tmp_path))
+    app = create_app(
+        RecordingSpeechClient(),
+        requires_uploaded_voice_for_named_voice=required,
+        supports_uploaded_voice_references=False,
+    )
+    assert app.state.speech_service.requires_uploaded_voice_for_named_voice is required
+    assert app.state.speech_service.supports_uploaded_voice_references is required
+
+
+def test_custom_voice_discovery_and_speech_share_checkpoint_config(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("SPEAKER_SAMPLES_DIR", str(tmp_path / "uploads"))
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "tts_model_type": "custom_voice",
+                "talker_config": {"spk_id": {"Zed": 9, "alpha": 3}},
+            }
+        )
+    )
+    config = Qwen3TTSPipelineConfig(
+        model_path=str(tmp_path)
+    ).resolve_custom_voice_config()
+    client_impl = RecordingSpeechClient()
+    app = create_app(client_impl, custom_voice_config=config)
+    store = app.state.speaker_sample_store
+    store.upload(
+        name="Uploaded",
+        consent="consent",
+        audio_bytes=_reference_wav(),
+        filename="ref.wav",
+        content_type="audio/wav",
+    )
+    with TestClient(app) as client:
+        listed = client.get("/v1/audio/voices").json()
+        assert listed["voices"] == ["alpha", "default", "Zed"]
+        assert listed["uploaded_voices"][0]["name"] == "Uploaded"
+        accepted = client.post(
+            "/v1/audio/speech", json={"input": "hello", "voice": "ALPHA"}
+        )
+        assert accepted.status_code == 200
+        rejected = client.post(
+            "/v1/audio/speech", json={"input": "hello", "voice": "Uploaded"}
+        )
+        assert rejected.status_code == 400
+        assert rejected.json()["error"]["param"] == "voice"
+    assert app.state.speech_service.custom_voice_config is config
+    assert len(client_impl.requests) == 1
 
 
 def _reference_wav(

--- a/tests/unit_test/serve/test_speech_ws.py
+++ b/tests/unit_test/serve/test_speech_ws.py
@@ -12,9 +12,11 @@ from starlette.websockets import WebSocketDisconnect, WebSocketState
 
 from sglang_omni.client import GenerateChunk
 from sglang_omni.client.types import SpeechResult
+from sglang_omni.config import CustomVoiceConfig
 from sglang_omni.serve import create_app
 from sglang_omni.serve import speech_ws as speech_ws_module
 from sglang_omni.serve.protocol import SpeechStreamSessionConfig
+from sglang_omni.serve.speech_errors import SpeechAPIError
 from sglang_omni.serve.speech_service import (
     MAX_SPEECH_INPUT_CHARS,
     SpeechRequestValidator,
@@ -380,6 +382,36 @@ def test_speech_websocket_commit_flushes_segments_without_closing() -> None:
         assert session_done["total_sentences"] == 2
 
     assert client_impl.generated_prompts == ["First segment.", "Second segment"]
+
+
+@pytest.mark.asyncio
+async def test_custom_voice_websocket_uses_shared_config() -> None:
+    config = CustomVoiceConfig(speakers=("speaker",), task_type="CustomVoice")
+    service = SpeechRequestValidator(default_model="tts", custom_voice_config=config)
+    client = StreamingSpeechClient()
+    session = SpeechWebSocketSession(
+        RecordingWebSocket(), client=client, speech_service=service
+    )
+    with pytest.raises(SpeechAPIError) as exc:
+        await session._parse_config(
+            {
+                "type": "session.config",
+                "response_format": "pcm",
+                "voice": "missing",
+            }
+        )
+    assert exc.value.param == "voice"
+    config = await session._parse_config(
+        {
+            "type": "session.config",
+            "response_format": "pcm",
+            "speaker": "SPEAKER",
+        }
+    )
+    assert config.voice == "SPEAKER"
+    assert config.task_type is None
+    assert session.config_prepared_request.reference_descriptors == []
+    assert not client.generated_prompts and not client.speech_prompts
 
 
 def test_speech_websocket_config_uses_served_model_and_default_voice() -> None:


### PR DESCRIPTION
## Motivation

Related issue: #1081.

## Design

This PR adds the `Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice` serving entry and unifies request validation and voice discovery for the already-supported 0.6B checkpoint. Both reuse the existing Qwen3-TTS pipeline; model execution and Base/VoiceDesign request semantics are unchanged.

References: released [Qwen3-TTS implementation][qwen-repo], [CustomVoice API][qwen-customvoice-api], and checkpoint configurations ([0.6B][qwen-06-config], [1.7B][qwen-17-config]).

| Area | Behavior |
| --- | --- |
| Speakers | Checkpoint-provided names, case-insensitive; both released sizes have nine speakers. Omitted/default voice remains Vivian. |
| Conditioning | Text, speaker, language, optional instruction; explicit task must be `CustomVoice`. Cloning inputs are rejected. |
| Instructions | Supported on 1.7B. Existing 0.6B passthrough is preserved, but instruction control is not recommended. |
| Language | Explicit language wins. Only `Auto` selects Eric's Sichuan or Dylan's Beijing dialect token; explicit `Chinese` keeps the Chinese token. |
| Output | Buffered speech, batch, incremental HTTP PCM and WebSocket output through the existing codec/vocoder path. |

The instruction and explicit-language choices preserve SGLang-Omni compatibility: the released Qwen wrapper instead clears 0.6B instructions and applies Eric/Dylan dialect tokens to both `Auto` and `Chinese`.

## Code Design & Compatibility

Deployment config optionally resolves one immutable `CustomVoiceConfig(speakers, task_type)`, shared by speech validation and voice discovery. Both fields are required; only `custom_voice_config=None` disables this contract. When present, it enables built-in speaker validation and disables reference inputs and uploaded-voice lookup, without changing the existing uploaded-voice interfaces.

### Ownership and tradeoffs

| Owner | Responsibility |
| --- | --- |
| Qwen config | Resolve the effective logical `tts_engine` checkpoint using existing override precedence; read `config.json` and derive speakers from `talker_config.spk_id`. |
| Launcher / app | Preserve existing uploaded-voice hooks and inject the optional CustomVoice config once at startup; no Qwen-specific branches, new CLI knobs, or worker RPC. |
| Speech validator / voices | Validate HTTP, batch, and WS before reference I/O; expose speakers from the same config in voice discovery. |
| Model / runtime | Retain checkpoint defaults, prompts, sampling, scheduling, streaming, and cancellation. CustomVoice validation does not fill checkpoint defaults. |

Base and VoiceDesign retain their existing paths; CustomVoice supplies the additional config. Existing uploaded-voice arguments and defaults remain unchanged when this config is absent, with no compatibility conversion layer. When present, checkpoint speakers take precedence over uploaded voices, including when the engine's model path overrides a top-level Base path. Direct `create_app` callers opt in explicitly; a model name alone does not activate the config.

### Compatibility boundaries

Valid existing 0.6B generation behavior is preserved. API tightening is intentional: invalid speakers, incompatible tasks, and cloning inputs now return early errors; voice discovery lists checkpoint speakers. This is not a blanket “no breaking changes” claim.

| Existing workflow | Effect of this design |
| --- | --- |
| Config / startup | `resolve`/`explain` and serialization do not invoke the CustomVoice hook. All Qwen variants resolve checkpoint metadata at serve startup; Base/VoiceDesign return no CustomVoice config. The launcher needs local or Hub/cache access; resolution failures use existing runner cleanup. |
| Default / split / replicas / TP | CustomVoice config belongs to the logical deployment; placement, IPC, and execution are unchanged. TP/replica coverage is configuration-level, not multi-GPU model qualification. |
| Uploaded voices / router | Existing optional/required lookup is preserved. Built-in speakers do not enter the router's uploaded-voice registry; each app owns its config. |
| Other APIs / controls | Chat, ASR, realtime, direct generation, and control forwarding are unchanged. CustomVoice config is startup-only; changing speaker/type metadata requires a restart. |

### Adding future models

Models inherit a no-op CustomVoice hook. A checkpoint with built-in speakers and no reference conditioning can supply the config; reference-based models keep their existing interfaces. A future model supporting both built-in speakers and references needs a separate contract defining name collisions and reference handling.

## Accuracy & Benchmark

### Functional Validation

| Coverage | Result |
| --- | --- |
| Earlier full-suite UT: config, serve, pipeline, router, Client, Qwen3-TTS, model capabilities | 2249 passed; 2 not-applicable/environment skips |
| Latest config / speech API refactor UT | 248 passed; 1 existing subprocess-timeout test deselected |
| API compatibility across 34 model configs/variants and 5 direct-call configurations | 858/858 checks match the previous PR; all 814 non-CustomVoice checks match baseline main (`7989a5ed`) |
| 0.6B / 1.7B CustomVoice, default layout | 32/32 checks each |
| 0.6B / 1.7B CustomVoice, split preprocessing/vocoder | 19/19 checks each |
| 1.7B CustomVoice, worker behind a real router | 19/19 checks |

Smoke covers all speakers, defaults, instruction acceptance, Chinese/Auto, HTTP/WS streaming, batch errors, and disconnect recovery. All 71 waveforms passed integrity checks; queues drained after disconnect. Model smoke predates the latest API-only config refactor, which was verified by focused UT and the compatibility matrix above. This verifies functionality, not perceptual dialect identity or 0.6B instruction quality.

### Setup

SGLang results below are from the latest complete run on `2cb33f7c` (2026-09-06).

| Item | Value |
| --- | --- |
| Model | `Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice@0c0e3051` |
| Hardware | 1x H200 141 GB, BF16, TP1 |
| Environment | No external process on the target GPU during timed windows; host CPU, memory, and I/O shared with another profiling task |
| Workload | Full Seed-TTS-Eval EN 1088 and ZH 2020, one run per language/mode |
| Request | Ryan/English for EN, Vivian/Chinese for ZH, no reference or instruction |
| Generation | `max_new_tokens=2048`; checkpoint sampling defaults; no SGLang seed override |
| Concurrency | 16, with 16 warmup requests per language/mode |
| Server | Running/decode CUDA-graph batch limits 64; split vocoder; engine/vocoder memory fractions 0.85/0.10; default `1 -> 2 -> 4` chunk ramp; torch.compile disabled |
| Evaluators | Qwen3-ASR-1.7B at concurrency 32, corpus-micro WER/CER; mean UTMOS |

### Accuracy

All 6,216 outputs were scored. Primary WER/CER includes every sample; filtered WER/CER excludes samples above 50% and recomputes the corpus rate, for both engines.

| Engine | Mode | EN WER all / filtered / >50% count | ZH CER all / filtered / >50% count | UTMOS EN / ZH |
| --- | --- | ---: | ---: | ---: |
| Official `qwen-tts` runtime (our run) | Non-streaming | 1.516% / 1.375% / 1 | 0.878% / 0.878% / 0 | 4.2253 / 3.3213 |
| SGLang-Omni | Non-streaming | 1.608% / 1.359% / 3 | 0.984% / 0.984% / 0 | 4.1723 / 3.1824 |
| SGLang-Omni | Streaming | 2.085% / 1.454% / 4 | 0.927% / 0.927% / 0 | 4.1500 / 3.1789 |

Reference: our earlier non-streaming full-corpus run with `qwen-tts==0.1.1`, the same checkpoint revision, manifests, Ryan/Vivian conditioning, and evaluators; BF16, `seed=42`, `max_new_tokens=2048`, default sampling. SGLang leaves seed unset. These are our official-runtime measurements, not the Qwen [technical report][qwen-report]'s different-corpus/scorer results.

Even equal seeds cannot guarantee identical samples across different sampling paths; the official row is aggregate quality context, not a paired comparison.

### Performance

| Mode | Lang | QPS | Latency mean (s) | RTF mean | TTFA mean (s) |
| --- | --- | ---: | ---: | ---: | ---: |
| Non-streaming | EN | 14.788 | 1.075 | 0.2335 | N/A |
| Non-streaming | ZH | 13.307 | 1.198 | 0.2079 | N/A |
| Streaming | EN | 10.098 | 1.573 | 0.3380 | 0.1213 |
| Streaming | ZH | 8.333 | 1.915 | 0.3332 | 0.1047 |

TTFA measures first PCM arrival, not audible speech onset; the first payload held 80 ms of audio. Across all 3,108 streams, 98.99% EN / 93.76% ZH had no underrun longer than 50 ms; maximum underrun was 396.1 / 2072.0 ms. The default ramp does not guarantee uninterrupted playback at concurrency 16.

[qwen-repo]: https://github.com/QwenLM/Qwen3-TTS/tree/022e286b98fbec7e1e916cb940cdf532cd9f488e
[qwen-customvoice-api]: https://github.com/QwenLM/Qwen3-TTS/blob/022e286b98fbec7e1e916cb940cdf532cd9f488e/qwen_tts/inference/qwen3_tts_model.py#L732-L839
[qwen-report]: https://arxiv.org/html/2601.15621
[qwen-06-config]: https://huggingface.co/Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice/blob/85e237c12c027371202489a0ec509ded67b5e4b5/config.json
[qwen-17-config]: https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice/blob/0c0e3051f131929182e2c023b9537f8b1c68adfe/config.json
