### PR TITLE
[AMD][ROCm] Add initial Qwen3-TTS 1.7B Base support on gfx950

### DIFF
--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import importlib
-import os
 from typing import Any
 
 from sglang_omni.models.qwen3_tts import request_builders
@@ -24,16 +23,7 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         self.wrapper: Any | None = None
         self._stream_output_builder: Any | None = None
 
-    @staticmethod
-    def _apply_rocm_runtime_policy() -> None:
-        if current_platform.is_rocm():
-            # AITER's fused RoPE is lower precision on ROCm and causes the
-            # Qwen3-TTS semantic decoder to miss EOS on gfx950.  Keep AITER
-            # attention enabled, but use the native Apex RoPE implementation.
-            os.environ["USE_ROCM_AITER_ROPE_BACKEND"] = "0"
-
     def resolve_checkpoint(self, model_path: str) -> str:
-        self._apply_rocm_runtime_policy()
         qwen3_stages.apply_qwen_tts_transformers_compatibility_patches()
         qwen_tts = importlib.import_module("qwen_tts")
         if not hasattr(qwen_tts, "Qwen3TTSModel"):
@@ -43,7 +33,6 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
 
     def pre_infra_setup(self, checkpoint_dir: str) -> None:
         del checkpoint_dir
-        self._apply_rocm_runtime_policy()
         qwen3_stages.apply_qwen_tts_transformers_compatibility_patches()
         qwen3_stages._register_qwen3_tts_hf_config()
 
@@ -106,9 +95,6 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
 
     def compile_model(self, model: Any, server_args: Any) -> None:
         if current_platform.is_rocm():
-            # PyTorch 2.9.1 + ROCm 7.2 miscompiles the Qwen3-TTS decoder
-            # layers and changes semantic tokens.  CUDA graphs remain valid
-            # when they capture the eager layers, so only gate torch.compile.
             override_server_args(
                 server_args,
                 "sglang_omni.qwen3_tts.rocm",

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -4,10 +4,12 @@
 from __future__ import annotations
 
 import importlib
+import os
 from typing import Any
 
 from sglang_omni.models.qwen3_tts import request_builders
 from sglang_omni.models.qwen3_tts import stages as qwen3_stages
+from sglang_omni.platforms import current_platform
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
 from sglang_omni.vendor.sglang.server_args import override_server_args
 
@@ -22,7 +24,16 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         self.wrapper: Any | None = None
         self._stream_output_builder: Any | None = None
 
+    @staticmethod
+    def _apply_rocm_runtime_policy() -> None:
+        if current_platform.is_rocm():
+            # AITER's fused RoPE is lower precision on ROCm and causes the
+            # Qwen3-TTS semantic decoder to miss EOS on gfx950.  Keep AITER
+            # attention enabled, but use the native Apex RoPE implementation.
+            os.environ["USE_ROCM_AITER_ROPE_BACKEND"] = "0"
+
     def resolve_checkpoint(self, model_path: str) -> str:
+        self._apply_rocm_runtime_policy()
         qwen3_stages.apply_qwen_tts_transformers_compatibility_patches()
         qwen_tts = importlib.import_module("qwen_tts")
         if not hasattr(qwen_tts, "Qwen3TTSModel"):
@@ -32,6 +43,7 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
 
     def pre_infra_setup(self, checkpoint_dir: str) -> None:
         del checkpoint_dir
+        self._apply_rocm_runtime_policy()
         qwen3_stages.apply_qwen_tts_transformers_compatibility_patches()
         qwen3_stages._register_qwen3_tts_hf_config()
 
@@ -93,6 +105,16 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         )
 
     def compile_model(self, model: Any, server_args: Any) -> None:
+        if current_platform.is_rocm():
+            # PyTorch 2.9.1 + ROCm 7.2 miscompiles the Qwen3-TTS decoder
+            # layers and changes semantic tokens.  CUDA graphs remain valid
+            # when they capture the eager layers, so only gate torch.compile.
+            override_server_args(
+                server_args,
+                "sglang_omni.qwen3_tts.rocm",
+                enable_torch_compile=False,
+            )
+            return
         if server_args.enable_deterministic_inference:
             override_server_args(
                 server_args,

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 import threading
 import time
@@ -3529,6 +3530,46 @@ def test_qwen3_tts_deterministic_inference_skips_private_compile(
     assert server_args.enable_torch_compile is False
 
 
+def test_qwen3_tts_rocm_runtime_policy_disables_aiter_rope_and_compile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.qwen3_tts import engine_builder as engine_builder_mod
+
+    monkeypatch.setattr(
+        engine_builder_mod,
+        "current_platform",
+        SimpleNamespace(is_rocm=lambda: True),
+    )
+    monkeypatch.setenv("USE_ROCM_AITER_ROPE_BACKEND", "1")
+    monkeypatch.setattr(
+        qwen3_stages,
+        "apply_qwen_tts_transformers_compatibility_patches",
+        lambda: None,
+    )
+    monkeypatch.setattr(qwen3_stages, "_register_qwen3_tts_hf_config", lambda: None)
+
+    builder = engine_builder_mod.Qwen3TtsEngineBuilder()
+    builder.pre_infra_setup("unused-checkpoint")
+
+    assert os.environ["USE_ROCM_AITER_ROPE_BACKEND"] == "0"
+
+    compiled = []
+    monkeypatch.setattr(
+        qwen3_stages,
+        "_compile_qwen3_tts_backbone",
+        lambda model: compiled.append(model),
+    )
+    server_args = FakeServerArgs(
+        enable_deterministic_inference=False,
+        enable_torch_compile=True,
+    )
+
+    builder.compile_model(object(), server_args)
+
+    assert compiled == []
+    assert server_args.enable_torch_compile is False
+
+
 def test_qwen3_tts_engine_accepts_64_batch_policy_and_reenables_cuda_graph(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3537,6 +3578,7 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_reenables_cuda_graph(
     from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
     from transformers.utils import generic
 
+    from sglang_omni.models.qwen3_tts import engine_builder as engine_builder_mod
     from sglang_omni.models.qwen3_tts import model_runner as model_runner_mod
     from sglang_omni.models.qwen3_tts import request_builders as request_builders_mod
     from sglang_omni.models.qwen3_tts import stages
@@ -3546,6 +3588,12 @@ def test_qwen3_tts_engine_accepts_64_batch_policy_and_reenables_cuda_graph(
     from sglang_omni.scheduling import bootstrap as bootstrap_mod
     from sglang_omni.scheduling import omni_scheduler as scheduler_mod
     from sglang_omni.scheduling import sglang_backend
+
+    monkeypatch.setattr(
+        engine_builder_mod,
+        "current_platform",
+        SimpleNamespace(is_rocm=lambda: False),
+    )
 
     check_model_inputs_calls = []
     expected_cuda_graph_bs = [

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import sys
 import threading
 import time
@@ -3530,7 +3529,7 @@ def test_qwen3_tts_deterministic_inference_skips_private_compile(
     assert server_args.enable_torch_compile is False
 
 
-def test_qwen3_tts_rocm_runtime_policy_disables_aiter_rope_and_compile(
+def test_qwen3_tts_rocm_disables_private_compile(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from sglang_omni.models.qwen3_tts import engine_builder as engine_builder_mod
@@ -3540,19 +3539,7 @@ def test_qwen3_tts_rocm_runtime_policy_disables_aiter_rope_and_compile(
         "current_platform",
         SimpleNamespace(is_rocm=lambda: True),
     )
-    monkeypatch.setenv("USE_ROCM_AITER_ROPE_BACKEND", "1")
-    monkeypatch.setattr(
-        qwen3_stages,
-        "apply_qwen_tts_transformers_compatibility_patches",
-        lambda: None,
-    )
-    monkeypatch.setattr(qwen3_stages, "_register_qwen3_tts_hf_config", lambda: None)
-
     builder = engine_builder_mod.Qwen3TtsEngineBuilder()
-    builder.pre_infra_setup("unused-checkpoint")
-
-    assert os.environ["USE_ROCM_AITER_ROPE_BACKEND"] == "0"
-
     compiled = []
     monkeypatch.setattr(
         qwen3_stages,


### PR DESCRIPTION
<!-- Suggested title: [AMD][ROCm] Add initial Qwen3-TTS 1.7B Base support on gfx950 -->

## Motivation

This PR adds initial ROCm support for Qwen3-TTS 1.7B Base on AMD Instinct MI355X (`gfx950`).

The Qwen3-TTS private backbone `torch.compile` path is disabled on ROCm for this initial support.


## Modifications

- Disable only the Qwen3-TTS private backbone `torch.compile` path on ROCm.




## Accuracy Test

The tests were run on one AMD Instinct MI355X with BF16 and TP=1. The runtime used a standard ROCm Docker image.

zhaochenyang20/seed-tts-eval-arrow was run with reference voice cloning, `max_new_tokens=512`, seed 42, and concurrency 8. 

| Metric | Result |
|---|---:|
| Completed requests | 50/50 |
| Failed requests | 0 |
| Mean latency | 45.187 s |
| P95 latency | 58.357 s |
| Request throughput | 0.171 req/s |
| Audio throughput | 0.657 s/s |
| Mean RTF | 13.1124 |
| Completion tokens | 15-106, mean 48 |


The launch command:

```bash
sgl-omni serve \
  --model-path Qwen/Qwen3-TTS-12Hz-1.7B-Base \
  --host 0.0.0.0 \
  --port 8000
```

## Unit Test

Since there is no ROCm CI at the moment, the following tests were run in the same standard ROCm Docker container:


- `test_qwen3_tts_rocm_disables_private_compile` confirms that ROCm disables the model-private compile path.
- `test_qwen3_tts_engine_accepts_64_batch_policy_and_reenables_cuda_graph` confirms that the existing non-ROCm compile and graph behavior remains unchanged.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
