### PR TITLE
[AMD][ROCm] Support Qwen3-ASR on gfx950

### DIFF
--- a/sglang_omni/models/qwen3_asr/encoder_cuda_graph.py
+++ b/sglang_omni/models/qwen3_asr/encoder_cuda_graph.py
@@ -15,6 +15,9 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
+from sglang.srt.layers.attention.vision import VisionAttentionMetadata
+
+from sglang_omni.platforms import current_platform
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +56,7 @@ class _CapturedGraph:
     graph: torch.cuda.CUDAGraph
     hidden_states: torch.Tensor  # [bucket, hidden] static input
     cu_seqlens: torch.Tensor  # [max_windows + 1] static window boundaries
+    attention_metadata: VisionAttentionMetadata | None
     output: torch.Tensor  # [bucket, output_dim] static result
 
 
@@ -88,6 +92,7 @@ class Qwen3ASREncoderLayerStackGraphRunner:
         self._buckets = buckets[:-1] + (top + self._max_windows_for(top),)
         self._graphs: dict[int, _CapturedGraph] = {}  # bucket size -> recorded graph
         self._failed: set[int] = set()
+        self._capture_attention_metadata: VisionAttentionMetadata | None = None
 
     @property
     def tokens_per_window(self) -> int:
@@ -118,7 +123,11 @@ class Qwen3ASREncoderLayerStackGraphRunner:
         for layer in tower.layers:
             residual = h
             h = layer.self_attn_layer_norm(h)
-            h = layer.self_attn(x=h, cu_seqlens=cu_seqlens, max_seqlen=self._max_seqlen)
+            attention_kwargs = dict(
+                max_seqlen=self._max_seqlen,
+                forward_metadata=self._capture_attention_metadata,
+            )
+            h = layer.self_attn(x=h, cu_seqlens=cu_seqlens, **attention_kwargs)
             h = residual + h
             residual = h
             h = layer.final_layer_norm(h)
@@ -144,6 +153,18 @@ class Qwen3ASREncoderLayerStackGraphRunner:
         for size in sizes:
             bounds.append(bounds[-1] + size)
         static_cu = torch.tensor(bounds, dtype=torch.int32, device=device)
+        attention_metadata = None
+        if current_platform.is_rocm():
+            # VisionAiterAttention otherwise recomputes max_seqlen with
+            # seq_lens.max().item() inside the captured region. The device-to-host
+            # sync is illegal during HIP graph capture. Keep the mutable tensor
+            # metadata static and supply the architectural maximum as a host scalar.
+            attention_metadata = VisionAttentionMetadata(
+                cu_seqlens=static_cu,
+                seq_lens=static_cu[1:] - static_cu[:-1],
+                max_seqlen=self._max_seqlen,
+            )
+        self._capture_attention_metadata = attention_metadata
 
         def run_once() -> torch.Tensor:
             with torch.no_grad():
@@ -170,6 +191,7 @@ class Qwen3ASREncoderLayerStackGraphRunner:
             graph=graph,
             hidden_states=static_hs,
             cu_seqlens=static_cu,
+            attention_metadata=attention_metadata,
             output=static_out,
         )
 
@@ -212,6 +234,8 @@ class Qwen3ASREncoderLayerStackGraphRunner:
 
         entry.hidden_states[:total].copy_(hidden_states)
         entry.cu_seqlens.copy_(cu, non_blocking=True)
+        if entry.attention_metadata is not None:
+            entry.attention_metadata.seq_lens.copy_(cu[1:] - cu[:-1], non_blocking=True)
         entry.graph.replay()
         out = entry.output
         if out.dim() == 3:  # attention backends emit [1, tokens, dim]

--- a/sglang_omni/models/qwen3_asr/engine_builder.py
+++ b/sglang_omni/models/qwen3_asr/engine_builder.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any, Callable
 
 from sglang.srt.managers.mm_utils import init_mm_embedding_cache
+from sglang.srt.utils import get_hip_version, is_gfx95_supported
 from transformers import AutoFeatureExtractor, AutoTokenizer
 
 from sglang_omni.models.qwen3_asr import mrope_fast_path, request_builders
@@ -18,6 +19,7 @@ from sglang_omni.models.qwen3_asr.encoder_service import (
     Qwen3ASRPreLMEncoderService,
     build_cache_namespace,
 )
+from sglang_omni.platforms import current_platform
 from sglang_omni.scheduling.engine_factory import AsrEngineBuilder
 from sglang_omni.scheduling.generation_batch_policy import (
     CudaGraphBackend,
@@ -136,6 +138,15 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
             "dtype": dtype,
             "cuda_graph_backend_prefill": CudaGraphBackend.BREAKABLE,
         }
+        # ROCm 7.2's AITER batch-prefill specialization is inaccurate for the
+        # Qwen3-ASR attention shape on gfx950. Keep decode on the selected
+        # backend, but use Triton for prefill until the affected stack is fixed.
+        if (
+            current_platform.is_rocm()
+            and is_gfx95_supported()
+            and get_hip_version()[:2] == (7, 2)
+        ):
+            defaults["prefill_attention_backend"] = "triton"
         if self.mm_attention_backend is not None:
             defaults["mm_attention_backend"] = self.mm_attention_backend
         else:

--- a/sglang_omni/models/qwen3_asr/sglang_model.py
+++ b/sglang_omni/models/qwen3_asr/sglang_model.py
@@ -63,7 +63,7 @@ def _fused_asr_forward_prepare_native(
     positions: torch.Tensor,
     hidden_states: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    if hidden_states.dtype != torch.bfloat16:
+    if hidden_states.dtype != torch.bfloat16 or fused_qk_norm_rope is None:
         return attention._asr_unfused_forward_prepare_native(
             positions,
             hidden_states,
@@ -72,11 +72,6 @@ def _fused_asr_forward_prepare_native(
         # note(ratish): the prefill CUDA graph bypasses forward()'s int32
         # cast; the kernel rejects int64 positions.
         positions = positions.to(torch.int32)
-    if fused_qk_norm_rope is None:
-        return attention._asr_unfused_forward_prepare_native(
-            positions,
-            hidden_states,
-        )
     qkv, _ = attention.qkv_proj(hidden_states)
     fused_qk_norm_rope(
         qkv,
@@ -102,9 +97,12 @@ def _fused_asr_forward_prepare_native(
 
 
 def _enable_fused_asr_qk_norm_rope(language_model: nn.Module) -> None:
-    # note (luojiaxuan): the CUDA kernel operates in place on packed QKV and
+    # note (luojiaxuan): the sgl-kernel op operates in place on packed QKV and
     # replaces split + two RMSNorm launches + RoPE for the equivalent text
     # positions. Keep the original bound method for non-bfloat16 fallbacks.
+    if fused_qk_norm_rope is None:
+        return
+
     for layer in language_model.model.layers:
         attention = layer.self_attn
         if attention.head_dim not in (64, 128, 256):
@@ -268,7 +266,7 @@ class Qwen3ASRForConditionalGeneration(nn.Module):
         if forward_batch.mrope_positions is not None:
             positions = forward_batch.mrope_positions[0]
         positions = positions.to(
-            dtype=torch.int32,
+            dtype=(torch.int32 if fused_qk_norm_rope is not None else torch.long),
             device=input_ids.device,
             non_blocking=True,
         ).contiguous()

--- a/tests/unit_test/qwen3_asr/test_encoder_cuda_graph.py
+++ b/tests/unit_test/qwen3_asr/test_encoder_cuda_graph.py
@@ -10,6 +10,7 @@ from sglang_omni.models.qwen3_asr.encoder_cuda_graph import (
     build_buckets,
     window_lens_from_token_counts,
 )
+from sglang_omni.platforms import current_platform
 
 
 def test_build_buckets_rejects_bad_limits():
@@ -64,6 +65,48 @@ def test_get_audio_feature_routing(monkeypatch):
     assert torch.equal(get(model, [item]), torch.full((1, 65, 8), 7.0))
 
 
+def test_layer_stack_forwards_precomputed_attention_metadata():
+    seen = {}
+
+    class Attention:
+        def __call__(self, **kwargs):
+            seen.update(kwargs)
+            return kwargs["x"]
+
+    def identity_linear(hidden_states):
+        return hidden_states, None
+
+    layer = SimpleNamespace(
+        self_attn_layer_norm=lambda hidden_states: hidden_states,
+        self_attn=Attention(),
+        final_layer_norm=lambda hidden_states: hidden_states,
+        fc1=identity_linear,
+        activation_fn=lambda hidden_states: hidden_states,
+        fc2=identity_linear,
+    )
+    tower = SimpleNamespace(
+        layers=[layer],
+        ln_post=lambda hidden_states: hidden_states,
+        proj1=identity_linear,
+        act=lambda hidden_states: hidden_states,
+        proj2=identity_linear,
+    )
+    runner = object.__new__(Qwen3ASREncoderLayerStackGraphRunner)
+    runner._tower = tower
+    runner._max_seqlen = 104
+    hidden_states = torch.zeros(8, 4)
+    cu_seqlens = torch.tensor([0, 4, 8], dtype=torch.int32)
+    attention_metadata = object()
+    runner._capture_attention_metadata = attention_metadata
+
+    output = runner._layer_stack(hidden_states, cu_seqlens)
+
+    assert torch.equal(output, hidden_states)
+    assert seen["cu_seqlens"] is cu_seqlens
+    assert seen["max_seqlen"] == 104
+    assert seen["forward_metadata"] is attention_metadata
+
+
 @pytest.mark.accelerator
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_graph_matches_eager_tower():
@@ -79,8 +122,10 @@ def test_graph_matches_eager_tower():
     from sglang_omni.models.qwen3_asr.audio_lengths import qwen3_asr_num_audio_tokens
     from sglang_omni.models.qwen3_asr.encoder_cuda_graph import eager_preamble
 
+    is_rocm = current_platform.is_rocm()
+    mm_attention_backend = "aiter_attn" if is_rocm else "triton_attn"
     get_context().set_server_args(
-        ServerArgs(model_path="Qwen/Qwen3-ASR-1.7B", mm_attention_backend="triton_attn")
+        ServerArgs(model_path="Qwen/Qwen3-ASR-1.7B", mm_attention_backend=mm_attention_backend)
     )
     if not model_parallel_is_initialized():
         init_distributed_environment(

--- a/tests/unit_test/qwen3_asr/test_encoder_cuda_graph.py
+++ b/tests/unit_test/qwen3_asr/test_encoder_cuda_graph.py
@@ -125,7 +125,9 @@ def test_graph_matches_eager_tower():
     is_rocm = current_platform.is_rocm()
     mm_attention_backend = "aiter_attn" if is_rocm else "triton_attn"
     get_context().set_server_args(
-        ServerArgs(model_path="Qwen/Qwen3-ASR-1.7B", mm_attention_backend=mm_attention_backend)
+        ServerArgs(
+            model_path="Qwen/Qwen3-ASR-1.7B", mm_attention_backend=mm_attention_backend
+        )
     )
     if not model_parallel_is_initialized():
         init_distributed_environment(

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -153,6 +153,65 @@ def test_qwen3_asr_explicit_mm_attention_backend_overrides_sm_default(
     assert defaults["mm_attention_backend"] == "fa3"
 
 
+@pytest.mark.parametrize(
+    ("is_rocm", "gfx95_supported", "hip_version", "expected_backend"),
+    [
+        (True, True, (7, 2, 0), "triton"),
+        (False, True, (7, 2, 0), None),
+        (True, False, (7, 2, 0), None),
+        (True, True, (7, 1, 0), None),
+        (True, True, (7, 3, 0), None),
+    ],
+)
+def test_qwen3_asr_defaults_prefill_to_triton_only_on_rocm_72_gfx95(
+    monkeypatch: pytest.MonkeyPatch,
+    is_rocm: bool,
+    gfx95_supported: bool,
+    hip_version: tuple[int, int, int],
+    expected_backend: str | None,
+) -> None:
+    monkeypatch.setattr(
+        qwen3_asr_builder.current_platform,
+        "is_rocm",
+        lambda: is_rocm,
+    )
+    monkeypatch.setattr(
+        qwen3_asr_builder,
+        "is_gfx95_supported",
+        lambda: gfx95_supported,
+    )
+    monkeypatch.setattr(
+        qwen3_asr_builder,
+        "get_hip_version",
+        lambda: hip_version,
+    )
+
+    defaults = _make_engine_builder(
+        mm_attention_backend="fa3"
+    ).generation_defaults(dtype="bfloat16")
+
+    if expected_backend is None:
+        assert "prefill_attention_backend" not in defaults
+    else:
+        assert defaults["prefill_attention_backend"] == expected_backend
+
+
+def test_qwen3_asr_explicit_prefill_backend_overrides_rocm_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(qwen3_asr_builder.current_platform, "is_rocm", lambda: True)
+    monkeypatch.setattr(qwen3_asr_builder, "is_gfx95_supported", lambda: True)
+    monkeypatch.setattr(qwen3_asr_builder, "get_hip_version", lambda: (7, 2, 0))
+    builder = _make_engine_builder(mm_attention_backend="fa3")
+
+    overrides = build_generation_batch_overrides(
+        **builder.generation_defaults(dtype="bfloat16"),
+        server_args_overrides={"prefill_attention_backend": "aiter"},
+    )
+
+    assert overrides["prefill_attention_backend"] == "aiter"
+
+
 def test_qwen3_asr_config_uses_batched_stage_with_64_running_requests() -> None:
     config = Qwen3ASRPipelineConfig(model_path="Qwen/Qwen3-ASR-1.7B")
 

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -186,9 +186,9 @@ def test_qwen3_asr_defaults_prefill_to_triton_only_on_rocm_72_gfx95(
         lambda: hip_version,
     )
 
-    defaults = _make_engine_builder(
-        mm_attention_backend="fa3"
-    ).generation_defaults(dtype="bfloat16")
+    defaults = _make_engine_builder(mm_attention_backend="fa3").generation_defaults(
+        dtype="bfloat16"
+    )
 
     if expected_backend is None:
         assert "prefill_attention_backend" not in defaults

--- a/tests/unit_test/qwen3_asr/test_sglang_model.py
+++ b/tests/unit_test/qwen3_asr/test_sglang_model.py
@@ -33,6 +33,7 @@ def test_forward_uses_available_mrope_positions(
     monkeypatch: pytest.MonkeyPatch,
     use_mrope_positions: bool,
 ) -> None:
+    monkeypatch.setattr(sglang_model, "fused_qk_norm_rope", lambda *args: None)
     positions = torch.tensor([4, 5])
     mrope_positions = torch.tensor([[4, 5], [4, 5], [4, 5]])
     forward_batch = SimpleNamespace(
@@ -66,6 +67,34 @@ def test_forward_uses_available_mrope_positions(
     assert actual is output
 
 
+def test_forward_keeps_long_positions_for_native_rope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sglang_model, "fused_qk_norm_rope", None)
+    seen_positions = None
+
+    def fake_general_mm_embed_routine(**kwargs):
+        nonlocal seen_positions
+        seen_positions = kwargs["positions"]
+        return torch.tensor([1.0])
+
+    monkeypatch.setattr(
+        sglang_model,
+        "general_mm_embed_routine",
+        fake_general_mm_embed_routine,
+    )
+    model = SimpleNamespace(language_model=object(), get_audio_feature=object())
+
+    Qwen3ASRForConditionalGeneration.forward(
+        model,
+        input_ids=torch.tensor([1, 2]),
+        positions=torch.tensor([4, 5], dtype=torch.int32),
+        forward_batch=SimpleNamespace(mrope_positions=None),
+    )
+
+    assert seen_positions.dtype == torch.long
+
+
 def test_asr_text_rope_drops_only_multimodal_parameters() -> None:
     original = {
         "rope_type": "default",
@@ -87,7 +116,9 @@ def test_asr_text_rope_drops_only_multimodal_parameters() -> None:
     assert original["mrope_section"] == [24, 20, 20]
 
 
-def test_fused_asr_qk_norm_rope_is_bound_per_attention() -> None:
+def test_fused_asr_qk_norm_rope_is_bound_per_attention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     def original(positions, hidden_states):
         return positions, hidden_states
 
@@ -107,6 +138,7 @@ def test_fused_asr_qk_norm_rope_is_bound_per_attention() -> None:
             ]
         )
     )
+    monkeypatch.setattr(sglang_model, "fused_qk_norm_rope", lambda *args: None)
 
     sglang_model._enable_fused_asr_qk_norm_rope(language_model)
 
@@ -116,6 +148,27 @@ def test_fused_asr_qk_norm_rope_is_bound_per_attention() -> None:
         is sglang_model._fused_asr_forward_prepare_native
     )
     assert unsupported.forward_prepare_native is original
+
+
+def test_fused_asr_qk_norm_rope_is_not_bound_without_platform_kernel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def original(positions, hidden_states):
+        return positions, hidden_states
+
+    attention = SimpleNamespace(
+        head_dim=128,
+        forward_prepare_native=original,
+    )
+    language_model = SimpleNamespace(
+        model=SimpleNamespace(layers=[SimpleNamespace(self_attn=attention)])
+    )
+    monkeypatch.setattr(sglang_model, "fused_qk_norm_rope", None)
+
+    sglang_model._enable_fused_asr_qk_norm_rope(language_model)
+
+    assert attention.forward_prepare_native is original
+    assert not hasattr(attention, "_asr_unfused_forward_prepare_native")
 
 
 def test_fused_asr_qk_norm_rope_falls_back_before_projection() -> None:


### PR DESCRIPTION
<!-- Suggested title: [AMD][ROCm] Support Qwen3-ASR on gfx950 -->

## Motivation

This PR supports Qwen3-ASR on AMD Instinct MI355X.

Qwen3-ASR exposed three ROCm-specific issues on gfx950:

- The ROCm platform intentionally returns `None` for the packed `fused_qk_norm_rope` operator. Qwen3-ASR still installed its fused wrapper and converted positions to `int32`, while the native RoPE path expects `torch.long` positions.
- `VisionAiterAttention` derived `max_seqlen` with `seq_lens.max().item()` inside the encoder graph capture region. The device-to-host synchronization is unsupported during HIP graph capture and raises `hipErrorStreamCaptureUnsupported`.
- In the ROCm 7.2, the AITER `mha_batch_prefill_func` specialization selected by Qwen3-ASR is affected by a longstanding upstream ROCm compiler issue and produces numerically incorrect results. Among the SGLang-Omni models tested so far, this has only been reproduced for Qwen3-ASR's BF16 causal attention shape (`q_heads=16`, `kv_heads=8`, `head_dim=128`). The AITER decode path is unaffected. This is not a new problem: there is currently no corresponding compiler-side fix, and the ROCm-side test for this case is skipped.



## Modifications

- Use the existing `current_platform.get_fused_qk_norm_rope()` result as the capability check for the Qwen3-ASR text decoder.
  - Install the fused QK-norm/RoPE wrapper only when the platform provides the operator.
  - Return to the native path before QKV projection when the fused operator is unavailable or the input is not BF16.
  - Use `int32` positions for the fused operator and preserve `torch.long` positions for native RoPE.
- Make the Qwen3-ASR encoder layer-stack graph compatible with ROCm/AITER.
  - Precompute `VisionAttentionMetadata` outside HIP graph capture.
  - Keep `cu_seqlens`, `seq_lens`, and the host `max_seqlen` scalar in static graph state.
  - Refresh the mutable sequence-length tensors before graph replay.
- Add a model-scoped backend default for gfx950 + ROCm 7.2:

  ```text
  decode attention backend:  normally selected backend (AITER by default)
  prefill attention backend: Triton
  ```


## Accuracy Test

The tests were run on one AMD Instinct MI355X with BF16 and TP=1. The runtime used a standard Docker image built from #1632:


The following 20-sample SeedTTS EN diagnostic used greedy decoding, concurrency 1, eager execution, and no warmup. It was used to isolate correctness by prefill/decode backend rather than as a capacity benchmark.

| Prefill backend | Decode backend | Corpus WER | Throughput (samples/s) | RTFx |
|---|---|---:|---:|---:|
| AITER | AITER | 728.72% | 0.663 | 3.467 |
| AITER | Triton | 729.76% | 0.575 | 3.008 |
| Triton | AITER | **0.692%** | **2.608** | **13.637** |
| Triton | Triton | **0.692%** | 2.393 | 12.510 |



The launch command:

```bash
sgl-omni serve \
  --model-path Qwen/Qwen3-ASR-1.7B \
  --model-name Qwen/Qwen3-ASR-1.7B \
  --port 8000
```


An OpenAI-compatible transcription request for `tests/data/query_to_cars.wav` returned:

```json
{"text":"How many cars are there in the picture?","usage":{"type":"duration","seconds":5}}
```

## Unit Test

Since there is no ROCm CI at the moment, the following tests were run in the standard ROCm container:



The added tests cover:

- `test_graph_matches_eager_tower` compares the encoder graph result with eager execution on the active accelerator backend.
- `test_layer_stack_forwards_precomputed_attention_metadata` confirms that graph capture supplies the precomputed vision-attention metadata.
- `test_forward_keeps_long_positions_for_native_rope` preserves the position dtype required by the native RoPE implementation.
- `test_fused_asr_qk_norm_rope_is_not_bound_without_platform_kernel` confirms that ROCm does not install a wrapper for an unavailable fused operator.
- `test_qwen3_asr_defaults_prefill_to_triton_only_on_rocm_72_gfx95` covers the exact platform, architecture, and ROCm-version gate.
- `test_qwen3_asr_explicit_prefill_backend_overrides_rocm_default` confirms that an explicit deployment choice overrides the model default.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
