### PR TITLE
[Fix][Qwen3-Omni] Cap colocated KV cache by live device headroom

### DIFF
--- a/sglang_omni/config/runtime.py
+++ b/sglang_omni/config/runtime.py
@@ -181,6 +181,19 @@ def reject_process_total_gpu_memory_fraction(
     )
 
 
+def reject_device_total_gpu_memory_fraction(
+    stage_name: str,
+    factory_args: dict[str, Any],
+    runtime_overrides: dict[str, Any],
+) -> None:
+    field_name = "device_total_gpu_memory_fraction"
+    if field_name not in factory_args and field_name not in runtime_overrides:
+        return
+    raise ValueError(
+        f"Stage {stage_name!r} sets {field_name} through factory_args/runtime_overrides. This value is derived from the per-GPU placement plan"
+    )
+
+
 def _validate_runtime_sources(
     stage_cfg: StageConfig,
     factory_args: dict[str, Any],
@@ -211,6 +224,11 @@ def _validate_runtime_sources(
         runtime_overrides,
     )
     reject_process_total_gpu_memory_fraction(
+        stage_cfg.name,
+        factory_args,
+        runtime_overrides,
+    )
+    reject_device_total_gpu_memory_fraction(
         stage_cfg.name,
         factory_args,
         runtime_overrides,

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -31,6 +31,7 @@ class ModelWorkerConfig:
     weight_prefix: str | None = None
     nccl_port: int | None = None
     total_gpu_memory_fraction: float | None = None
+    device_total_gpu_memory_fraction: float | None = None
     enable_prefill_input_embeds: bool = False
 
 
@@ -70,6 +71,7 @@ class ModelWorker:
         self.weight_prefix = config.weight_prefix
         self.nccl_port = config.nccl_port
         self.total_gpu_memory_fraction = config.total_gpu_memory_fraction
+        self.device_total_gpu_memory_fraction = config.device_total_gpu_memory_fraction
         self.enable_prefill_input_embeds = config.enable_prefill_input_embeds
 
         self.gpu_id = gpu_id
@@ -243,6 +245,7 @@ class ModelWorker:
             model_arch_override=self.model_arch_override,
             weight_prefix=self.weight_prefix,
             total_gpu_memory_fraction=self.total_gpu_memory_fraction,
+            device_total_gpu_memory_fraction=self.device_total_gpu_memory_fraction,
         )
 
     def _init_dllm_algorithm(self):

--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -15,7 +15,6 @@ from sglang.srt.server_args import PortArgs, ServerArgs
 
 from sglang_omni.model_runner.prefill_inputs import get_omni_prefill_inputs
 from sglang_omni.utils.gpu_memory import (
-    calculate_stage_budget_available_bytes,
     calculate_stage_load_delta_bytes,
     format_bytes_gib,
     get_gpu_device_info,
@@ -50,6 +49,7 @@ class _OmniKVCacheConfigurator(KVCacheConfigurator):
     """
 
     total_gpu_memory_fraction: float | None = None
+    device_total_gpu_memory_fraction: float | None = None
 
     def _profile_available_bytes(self, pre_model_load_memory: float) -> int:
         """Profile KV-cache headroom for colocated SGLang AR stages.
@@ -62,11 +62,10 @@ class _OmniKVCacheConfigurator(KVCacheConfigurator):
 
         When a stage total-memory budget is provided, compute cache headroom as
         total GPU memory times that budget minus this stage's measured memory.
-        NVML process accounting is preferred. If NVML cannot identify the
-        current process, use the stage-local load delta measured inside
-        SGLang's serialized initialization window. Without a stage budget, keep
-        upstream SGLang profiling semantics for ordinary non-colocated AR
-        serving.
+        The stage-local result is capped by live device-wide headroom so memory
+        held by co-tenants is charged against the aggregate placement budget.
+        Without a stage budget, keep upstream SGLang profiling semantics for
+        ordinary non-colocated AR serving.
         """
         if self.total_gpu_memory_fraction is None:
             return KVCacheConfigurator._profile_available_bytes(
@@ -84,75 +83,82 @@ class _OmniKVCacheConfigurator(KVCacheConfigurator):
                 "device visibility."
             )
 
-        if process_memory is None or process_memory <= 0:
-            return self._profile_available_bytes_from_stage_load_delta(
-                pre_model_load_memory,
-                total_memory,
-            )
-
-        return self._profile_available_bytes_from_process_memory(
-            total_memory,
-            process_memory,
+        device_memory_fraction = (
+            self.device_total_gpu_memory_fraction
+            if self.device_total_gpu_memory_fraction is not None
+            else self.total_gpu_memory_fraction
         )
+        device_memory_fraction = min(device_memory_fraction, 1.0)
 
-    def _profile_available_bytes_from_stage_load_delta(
-        self,
-        pre_model_load_memory: float,
-        total_memory: int,
-    ) -> int:
-        """Profile colocated KV headroom from this stage's load-time delta."""
-        from sglang.srt.distributed.parallel_state import get_world_group
         from sglang.srt.utils.common import get_available_gpu_memory
 
-        world_group = get_world_group()
-        post_model_load_memory = get_available_gpu_memory(
+        free_memory_gib = get_available_gpu_memory(
             self.device,
             self.gpu_id,
-            distributed=world_group.world_size > 1,
-            cpu_group=world_group.cpu_group,
+            distributed=False,
         )
-        stage_load_bytes = calculate_stage_load_delta_bytes(
-            pre_model_load_memory_gib=pre_model_load_memory,
-            post_model_load_memory_gib=post_model_load_memory,
+        free_memory = min(int(free_memory_gib * (1 << 30)), total_memory)
+
+        if process_memory is None or process_memory <= 0:
+            accounted_memory = calculate_stage_load_delta_bytes(
+                pre_model_load_memory_gib=pre_model_load_memory,
+                post_model_load_memory_gib=free_memory_gib,
+            )
+            accounting_source = "stage_load_fallback"
+            accounted_memory_label = "stage_load_used"
+        else:
+            accounted_memory = process_memory
+            accounting_source = "nvml_process"
+            accounted_memory_label = "process_used"
+
+        stage_available_bytes = (
+            int(total_memory * self.total_gpu_memory_fraction) - accounted_memory
         )
-        available_bytes = calculate_stage_budget_available_bytes(
-            total_memory_bytes=total_memory,
-            accounted_memory_bytes=stage_load_bytes,
-            memory_fraction=self.total_gpu_memory_fraction,
-            accounted_memory_label="stage_load_used",
+        device_available_bytes = int(total_memory * device_memory_fraction) - (
+            total_memory - free_memory
         )
+        local_available_bytes = max(
+            0, min(stage_available_bytes, device_available_bytes)
+        )
+        available_bytes = self._distributed_minimum_bytes(local_available_bytes)
+        if available_bytes <= 0:
+            raise RuntimeError(
+                "Colocated SGLang AR stage has no KV-cache headroom after applying stage and device budgets"
+            )
         logger.info(
-            f"SGLang AR memory profile: gpu_mem_accounting=stage_load_fallback "
+            f"SGLang AR memory profile: gpu_mem_accounting={accounting_source} "
             f"gpu_id={self.gpu_id} "
             f"total_gpu_memory_fraction={self.total_gpu_memory_fraction:.3f} "
+            f"device_total_gpu_memory_fraction={device_memory_fraction:.3f} "
             f"mem_fraction_static={self.server_args.mem_fraction_static:.3f} "
             f"total={format_bytes_gib(total_memory)} "
-            f"stage_load_used={format_bytes_gib(stage_load_bytes)} "
+            f"device_free={format_bytes_gib(free_memory)} "
+            f"{accounted_memory_label}={format_bytes_gib(accounted_memory)} "
+            f"stage_available_for_kv={format_bytes_gib(stage_available_bytes)} "
+            f"device_available_for_kv={format_bytes_gib(device_available_bytes)} "
             f"available_for_kv={format_bytes_gib(available_bytes)}"
         )
         return available_bytes
 
-    def _profile_available_bytes_from_process_memory(
-        self,
-        total_memory: int,
-        process_memory: int,
-    ) -> int:
-        available_bytes = calculate_stage_budget_available_bytes(
-            total_memory_bytes=total_memory,
-            accounted_memory_bytes=process_memory,
-            memory_fraction=self.total_gpu_memory_fraction,
-            accounted_memory_label="process_used",
+    @staticmethod
+    def _distributed_minimum_bytes(local_bytes: int) -> int:
+        """Return one conservative KV budget across all distributed ranks."""
+        import torch
+        from sglang.srt.distributed.parallel_state import get_world_group
+
+        if not torch.distributed.is_initialized():
+            return local_bytes
+        world_group = get_world_group()
+        if world_group.world_size <= 1:
+            return local_bytes
+
+        value = torch.tensor(local_bytes, dtype=torch.int64)
+        torch.distributed.all_reduce(
+            value,
+            op=torch.distributed.ReduceOp.MIN,
+            group=world_group.cpu_group,
         )
-        logger.info(
-            f"SGLang AR memory profile: gpu_mem_accounting=nvml_process "
-            f"gpu_id={self.gpu_id} "
-            f"total_gpu_memory_fraction={self.total_gpu_memory_fraction:.3f} "
-            f"mem_fraction_static={self.server_args.mem_fraction_static:.3f} "
-            f"total={format_bytes_gib(total_memory)} "
-            f"process_used={format_bytes_gib(process_memory)} "
-            f"available_for_kv={format_bytes_gib(available_bytes)}"
-        )
-        return available_bytes
+        return int(value.item())
 
 
 class SGLModelRunner(ModelRunner):
@@ -172,9 +178,11 @@ class SGLModelRunner(ModelRunner):
         model_arch_override: str | None = None,
         weight_prefix: str | None = None,
         total_gpu_memory_fraction: float | None = None,
+        device_total_gpu_memory_fraction: float | None = None,
     ) -> None:
         self._weight_prefix = weight_prefix
         self._total_gpu_memory_fraction = total_gpu_memory_fraction
+        self._device_total_gpu_memory_fraction = device_total_gpu_memory_fraction
         self._model_arch_override = model_arch_override
         self._weight_share_config = None
         self._weight_share_record = None
@@ -489,4 +497,5 @@ class SGLModelRunner(ModelRunner):
                 if field.init
             },
             total_gpu_memory_fraction=self._total_gpu_memory_fraction,
+            device_total_gpu_memory_fraction=self._device_total_gpu_memory_fraction,
         )

--- a/sglang_omni/models/qwen3_omni/bootstrap.py
+++ b/sglang_omni/models/qwen3_omni/bootstrap.py
@@ -16,6 +16,7 @@ def create_thinker_scheduler(
     tp_rank: int = 0,
     nccl_port: int | None = None,
     total_gpu_memory_fraction: float | None = None,
+    device_total_gpu_memory_fraction: float | None = None,
     enable_async_decode: bool = True,
     async_decode_min_batch_size: int = 2,
     prefill_coalesce_requests: int = 0,
@@ -71,6 +72,7 @@ def create_thinker_scheduler(
             model_arch_override="Qwen3OmniThinkerForCausalLM",
             capture_hidden_layers=capture_hidden_layers,
             total_gpu_memory_fraction=total_gpu_memory_fraction,
+            device_total_gpu_memory_fraction=device_total_gpu_memory_fraction,
             defer_cuda_graph_capture=defer_cuda_graph_capture,
             enable_prefill_input_embeds=enable_prefill_input_embeds,
         )
@@ -162,6 +164,7 @@ def create_talker_scheduler(
     tp_rank: int = 0,
     nccl_port: int | None = None,
     total_gpu_memory_fraction: float | None = None,
+    device_total_gpu_memory_fraction: float | None = None,
     enable_partial_start: bool = False,
     partial_start_min_chunks: int = 5,
 ):
@@ -204,6 +207,7 @@ def create_talker_scheduler(
         model_arch_override="Qwen3OmniTalker",
         weight_prefix=weight_prefix,
         total_gpu_memory_fraction=total_gpu_memory_fraction,
+        device_total_gpu_memory_fraction=device_total_gpu_memory_fraction,
         defer_cuda_graph_capture=want_cuda_graph,
     )
     # Note:(Chenchen Hong) align the talker vocab to the codec vocab: post1 sizes

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -1007,6 +1007,7 @@ def create_sglang_thinker_executor_from_config(
     encoder_mem_reserve: float = 0.05,
     speech_enabled: bool = False,
     total_gpu_memory_fraction: float | None = None,
+    device_total_gpu_memory_fraction: float | None = None,
     enable_async_decode: bool = True,
     async_decode_min_batch_size: int = 2,
     prefill_coalesce_requests: int = 0,
@@ -1098,6 +1099,7 @@ def create_sglang_thinker_executor_from_config(
         tp_rank=tp_rank,
         nccl_port=nccl_port,
         total_gpu_memory_fraction=effective_total_gpu_memory_fraction,
+        device_total_gpu_memory_fraction=device_total_gpu_memory_fraction,
         enable_async_decode=enable_async_decode,
         async_decode_min_batch_size=async_decode_min_batch_size,
         prefill_coalesce_requests=prefill_coalesce_requests,
@@ -1133,6 +1135,7 @@ def create_talker_ar_executor_from_config(
     feedback_enabled: bool = True,
     weight_prefix: str = "talker.",
     total_gpu_memory_fraction: float | None = None,
+    device_total_gpu_memory_fraction: float | None = None,
     enable_partial_start: bool = False,
     partial_start_min_chunks: int = 5,
 ):
@@ -1188,6 +1191,7 @@ def create_talker_ar_executor_from_config(
         tp_rank=tp_rank,
         nccl_port=nccl_port,
         total_gpu_memory_fraction=total_gpu_memory_fraction,
+        device_total_gpu_memory_fraction=device_total_gpu_memory_fraction,
         enable_partial_start=enable_partial_start,
         partial_start_min_chunks=partial_start_min_chunks,
     )

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -5,6 +5,7 @@ The runner owns the single serving path. It can start one OS process containing
 multiple non-TP stages, multiple OS processes on the same GPU, and the existing
 one-process-per-rank TP topology.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -214,13 +215,16 @@ def _build_stage_groups(
             )
         )
     groups.extend(tp_groups)
-    _attach_process_memory_fraction_defaults(groups)
+    _attach_memory_fraction_defaults(groups, placement_plan)
 
     return groups
 
 
-def _attach_process_memory_fraction_defaults(groups: list[StageGroup]) -> None:
-    """Expose the per-GPU process budget loaded through each stage.
+def _attach_memory_fraction_defaults(
+    groups: list[StageGroup],
+    placement_plan: StagePlacementPlan,
+) -> None:
+    """Expose derived process and device memory budgets to stage factories.
 
     Stage resource fractions remain component budgets for placement. A process
     constructs its stages in ``stage_specs`` order, so a stage that profiles
@@ -232,6 +236,13 @@ def _attach_process_memory_fraction_defaults(groups: list[StageGroup]) -> None:
         for process_spec in group.process_specs:
             by_gpu: dict[int, list[StageLaunchConfig]] = {}
             for stage_spec in process_spec.stage_specs:
+                placement_gpu_id = stage_spec.placement_gpu_id
+                if placement_gpu_id is not None:
+                    gpu_placement = placement_plan.gpus.get(int(placement_gpu_id))
+                    if gpu_placement is not None and gpu_placement.has_memory_fraction:
+                        stage_spec.factory_arg_defaults[
+                            "device_total_gpu_memory_fraction"
+                        ] = gpu_placement.total_gpu_memory_fraction
                 if stage_spec.gpu_id is not None:
                     by_gpu.setdefault(int(stage_spec.gpu_id), []).append(stage_spec)
 

--- a/sglang_omni/scheduling/bootstrap.py
+++ b/sglang_omni/scheduling/bootstrap.py
@@ -105,6 +105,7 @@ def create_sglang_infrastructure(
     weight_prefix: str | None = None,
     capture_hidden_layers: list[int] | None = None,
     total_gpu_memory_fraction: float | None = None,
+    device_total_gpu_memory_fraction: float | None = None,
     defer_cuda_graph_capture: bool = False,
     enable_prefill_input_embeds: bool = False,
 ):
@@ -124,6 +125,7 @@ def create_sglang_infrastructure(
             weight_prefix=weight_prefix,
             nccl_port=nccl_port,
             total_gpu_memory_fraction=total_gpu_memory_fraction,
+            device_total_gpu_memory_fraction=device_total_gpu_memory_fraction,
             enable_prefill_input_embeds=enable_prefill_input_embeds,
         ),
         server_args=server_args,

--- a/tests/unit_test/pipeline/test_compile.py
+++ b/tests/unit_test/pipeline/test_compile.py
@@ -298,6 +298,10 @@ def test_runner_specs_expose_process_total_in_construction_order(
         specs[stage_name].factory_arg_defaults["process_total_gpu_memory_fraction"]
         for stage_name in ("preprocess", "engine", "vocoder")
     ] == pytest.approx(expected_fractions)
+    assert [
+        specs[stage_name].factory_arg_defaults["device_total_gpu_memory_fraction"]
+        for stage_name in ("preprocess", "engine", "vocoder")
+    ] == pytest.approx([1.0, 1.0, 1.0])
 
 
 def test_shared_process_name_compiles_to_same_process_local_edges() -> None:

--- a/tests/unit_test/pipeline/test_runtime_adapter.py
+++ b/tests/unit_test/pipeline/test_runtime_adapter.py
@@ -208,6 +208,20 @@ def test_process_total_memory_fraction_runtime_override_is_rejected() -> None:
         resolve_stage_static_factory_args(stage, config)
 
 
+@pytest.mark.parametrize("source", ["factory_args", "runtime_overrides"])
+def test_device_total_memory_fraction_override_is_rejected(source) -> None:
+    value = {"device_total_gpu_memory_fraction": 0.95}
+    stage = _stage(factory_args=value) if source == "factory_args" else _stage()
+    config = PipelineConfig(
+        model_path="dummy-model",
+        stages=[stage],
+        runtime_overrides={"thinker": value} if source == "runtime_overrides" else {},
+    )
+
+    with pytest.raises(ValueError, match="derived from the per-GPU placement plan"):
+        resolve_stage_static_factory_args(stage, config)
+
+
 def test_mapped_runtime_field_requires_stage_arg_mapping() -> None:
     stage = _stage(runtime=StageRuntimeConfig(max_seq_len=8192))
     config = PipelineConfig(model_path="dummy-model", stages=[stage])

--- a/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
+++ b/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
@@ -5,6 +5,7 @@ import logging
 from types import SimpleNamespace
 
 import pytest
+import torch
 from sglang.srt.mem_cache.kv_cache_configurator import KVCacheConfigurator
 
 import sglang_omni.model_runner.sglang_model_runner as runner_mod
@@ -26,7 +27,34 @@ def _configurator(*, total_gpu_memory_fraction: float | None):
     configurator.device = "cuda"
     configurator.server_args = SimpleNamespace(mem_fraction_static=0.9)
     configurator.total_gpu_memory_fraction = total_gpu_memory_fraction
+    configurator.device_total_gpu_memory_fraction = 0.9
     return configurator
+
+
+def _patch_memory_profile(
+    monkeypatch,
+    *,
+    process_memory: int | None = 30 * 1024**3,
+    total_memory: int | None = 100 * 1024**3,
+    free_memory_gib: float = 80.0,
+) -> None:
+    monkeypatch.setattr(
+        runner_mod,
+        "get_process_gpu_memory_bytes",
+        lambda gpu_id: process_memory,
+    )
+    monkeypatch.setattr(
+        runner_mod,
+        "get_gpu_device_info",
+        lambda gpu_id: SimpleNamespace(total_memory_bytes=total_memory),
+    )
+    import sglang.srt.utils.common as sglang_utils
+
+    monkeypatch.setattr(
+        sglang_utils,
+        "get_available_gpu_memory",
+        lambda *args, **kwargs: free_memory_gib,
+    )
 
 
 def _patch_thinker_startup(monkeypatch) -> list[dict[str, object]]:
@@ -61,6 +89,9 @@ def _patch_thinker_startup(monkeypatch) -> list[dict[str, object]]:
                 "sampling_backend": server_args.sampling_backend,
                 "gpu_id": gpu_id,
                 "total_gpu_memory_fraction": kwargs["total_gpu_memory_fraction"],
+                "device_total_gpu_memory_fraction": kwargs.get(
+                    "device_total_gpu_memory_fraction"
+                ),
             }
         )
         return object()
@@ -86,16 +117,7 @@ def _patch_thinker_startup(monkeypatch) -> list[dict[str, object]]:
 
 def test_colocated_ar_budget_uses_stage_total_fraction(monkeypatch) -> None:
     configurator = _configurator(total_gpu_memory_fraction=0.4)
-    monkeypatch.setattr(
-        runner_mod,
-        "get_process_gpu_memory_bytes",
-        lambda gpu_id: 30 * 1024**3,
-    )
-    monkeypatch.setattr(
-        runner_mod,
-        "get_gpu_device_info",
-        lambda gpu_id: SimpleNamespace(total_memory_bytes=100 * 1024**3),
-    )
+    _patch_memory_profile(monkeypatch)
 
     available = configurator._profile_available_bytes(0)
 
@@ -108,29 +130,43 @@ def test_colocated_ar_budget_uses_stage_load_delta_when_process_memory_unavailab
     process_memory,
 ) -> None:
     configurator = _configurator(total_gpu_memory_fraction=0.4)
-    monkeypatch.setattr(
-        runner_mod,
-        "get_process_gpu_memory_bytes",
-        lambda gpu_id: process_memory,
-    )
-    monkeypatch.setattr(
-        runner_mod,
-        "get_gpu_device_info",
-        lambda gpu_id: SimpleNamespace(total_memory_bytes=100 * 1024**3),
+    _patch_memory_profile(
+        monkeypatch, process_memory=process_memory, free_memory_gib=25.0
     )
 
-    def _fake_stage_load_delta(self, pre_model_load_memory, total_memory):
-        assert pre_model_load_memory == 95.0
-        assert total_memory == 100 * 1024**3
-        return 7 * 1024**3
+    assert configurator._profile_available_bytes(35.0) == 15 * 1024**3
+
+
+def test_colocated_ar_budget_requires_total_memory(monkeypatch) -> None:
+    configurator = _configurator(total_gpu_memory_fraction=0.4)
+    _patch_memory_profile(monkeypatch, total_memory=None)
+
+    with pytest.raises(RuntimeError, match="requires total GPU memory"):
+        configurator._profile_available_bytes(0)
+
+
+def test_colocated_ar_budget_is_clamped_by_device_headroom(monkeypatch) -> None:
+    configurator = _configurator(total_gpu_memory_fraction=0.8)
+    configurator.device_total_gpu_memory_fraction = 0.9
+    distributed_inputs: list[int] = []
+
+    def _distributed_minimum(local_bytes: int) -> int:
+        distributed_inputs.append(local_bytes)
+        return local_bytes
 
     monkeypatch.setattr(
         runner_mod._OmniKVCacheConfigurator,
-        "_profile_available_bytes_from_stage_load_delta",
-        _fake_stage_load_delta,
+        "_distributed_minimum_bytes",
+        staticmethod(_distributed_minimum),
+    )
+    _patch_memory_profile(
+        monkeypatch,
+        process_memory=30 * 1024**3,
+        free_memory_gib=45.0,
     )
 
-    assert configurator._profile_available_bytes(95.0) == 7 * 1024**3
+    assert configurator._profile_available_bytes(0) == 35 * 1024**3
+    assert distributed_inputs == [35 * 1024**3]
 
 
 def test_non_colocated_ar_delegates_to_upstream_available_bytes(
@@ -149,6 +185,45 @@ def test_non_colocated_ar_delegates_to_upstream_available_bytes(
     )
 
     assert configurator._profile_available_bytes(123) == 456
+
+
+def test_distributed_minimum_bytes_reduces_on_cpu_group(monkeypatch) -> None:
+    cpu_group = object()
+    world_group = SimpleNamespace(world_size=2, cpu_group=cpu_group)
+    import sglang.srt.distributed.parallel_state as parallel_state
+
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(parallel_state, "get_world_group", lambda: world_group)
+
+    def _all_reduce(value, *, op, group):
+        assert op == torch.distributed.ReduceOp.MIN
+        assert group is cpu_group
+        assert value.item() == 23
+        value.fill_(11)
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", _all_reduce)
+
+    assert runner_mod._OmniKVCacheConfigurator._distributed_minimum_bytes(23) == 11
+
+
+def test_exhausted_local_rank_reaches_collective_before_failing(monkeypatch) -> None:
+    configurator = _configurator(total_gpu_memory_fraction=0.7)
+    _patch_memory_profile(monkeypatch, free_memory_gib=10.0)
+    collective_inputs: list[int] = []
+
+    def _distributed_minimum(local_bytes: int) -> int:
+        collective_inputs.append(local_bytes)
+        return local_bytes
+
+    monkeypatch.setattr(
+        runner_mod._OmniKVCacheConfigurator,
+        "_distributed_minimum_bytes",
+        staticmethod(_distributed_minimum),
+    )
+
+    with pytest.raises(RuntimeError, match="no KV-cache headroom"):
+        configurator._profile_available_bytes(0)
+    assert collective_inputs == [0]
 
 
 def test_qwen_ar_factory_derives_mem_fraction_from_total_budget() -> None:
@@ -213,6 +288,7 @@ def test_qwen_colocated_thinker_startup_threads_effective_budget(
         qwen_stages.create_sglang_thinker_executor_from_config(
             "dummy",
             total_gpu_memory_fraction=0.75,
+            device_total_gpu_memory_fraction=0.94,
             encoder_mem_reserve=0.05,
         )
 
@@ -222,6 +298,7 @@ def test_qwen_colocated_thinker_startup_threads_effective_budget(
             "sampling_backend": "pytorch",
             "gpu_id": 0,
             "total_gpu_memory_fraction": 0.70,
+            "device_total_gpu_memory_fraction": 0.94,
         }
     ]
     assert "total_gpu_memory_fraction=0.75" in caplog.text
@@ -248,6 +325,7 @@ def test_qwen_colocated_thinker_explicit_mem_fraction_skips_default_reserve(
             "sampling_backend": "pytorch",
             "gpu_id": 0,
             "total_gpu_memory_fraction": 0.75,
+            "device_total_gpu_memory_fraction": None,
         }
     ]
     assert "effective_total_gpu_memory_fraction=0.75" in caplog.text


### PR DESCRIPTION
## Motivation

This change fixes issue [#1685](https://github.com/sgl-project/sglang-omni/issues/1685) where colocated SGLang AR cache sizing does not charge memory held by another process on the same GPU. The current calculation enforces the stage budget using only memory attributed to that process, so the KV pool can overcommit the placement budget.

Using `Qwen/Qwen3-Omni-30B-A3B-Instruct` with `examples/configs/qwen3_omni_mmmu_h100.yaml` on one H200 and a separate 34 GiB co-tenant, current main selected 61.87 GiB for KV and failed during pool construction with a 660 MiB CUDA OOM.

## Modifications

- Derive the aggregate memory fraction for each placed GPU and pass it to SGLang AR workers.
- Cap stage-local KV headroom by live device-wide headroom under the aggregate placement fraction.
- Use the minimum headroom across distributed ranks before allocating the KV pool.
- Preserve upstream SGLang sizing when no colocated stage budget is configured.
- Reject manual overrides of the derived device budget and add focused regression coverage.

## Related Issues

Addresses the deterministic co-tenant overcommit in [#1685](https://github.com/sgl-project/sglang-omni/issues/1685). The container PID attribution fallback and zero-value ambiguity reported in the same issue remain out of scope, so this PR **does not** close the issue.

## Accuracy Test

```bash
python -m pytest -q tests/unit_test/pipeline/test_compile.py tests/unit_test/pipeline/test_runtime_adapter.py tests/unit_test/qwen3_omni/test_sglang_ar_budget.py tests/unit_test/pipeline/test_gpu_memory.py
```

Result: `81 passed, 14 warnings`. The warnings are upstream `torch.jit` deprecation warnings and are unrelated to this change.

The regressions cover placement-budget propagation, derived-field ownership, fallback accounting, live device clamping, distributed minimum selection, and exhausted-rank handling. No model weights, logits, sampling math, or request execution behavior change.

## Benchmark & Profiling

No throughput benchmark was run. The additional free-memory query and scalar rank reduction run once during KV pool initialization. The inference hot path is unchanged.

| Run | Stage headroom | Device headroom | Selected headroom | KV tokens | Result |
| --- | --- | --- | --- | --- | --- |
| Main without co-tenant | 61.87 GiB | Not applied | 61.87 GiB | 675762 | Startup completed |
| Main with 34 GiB co-tenant | 61.87 GiB | Not applied | 61.87 GiB | Not allocated | CUDA OOM |
| This PR with 34 GiB co-tenant | 61.87 GiB | 42.10 GiB | 42.10 GiB | 459863 | Startup completed and HTTP 200 |
| This PR without co-tenant | 61.87 GiB | 76.70 GiB | 61.87 GiB | 675762 | Startup completed and HTTP 200 |

The no-tenant control preserved the exact KV headroom and token capacity from main.