### PR TITLE
fix(memory): distinguish failed attribution from zero, and clamp the KV budget

### DIFF
--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -15,6 +15,8 @@ from sglang.srt.server_args import PortArgs, ServerArgs
 
 from sglang_omni.model_runner.prefill_inputs import get_omni_prefill_inputs
 from sglang_omni.utils.gpu_memory import (
+    get_device_free_memory_bytes,
+    get_process_gpu_memory_bytes_from_torch,
     calculate_stage_budget_available_bytes,
     calculate_stage_load_delta_bytes,
     format_bytes_gib,
@@ -84,6 +86,17 @@ class _OmniKVCacheConfigurator(KVCacheConfigurator):
                 "device visibility."
             )
 
+        accounting = "nvml_process"
+        if process_memory is None:
+            # Note (Audrey Zheng): NVML could not attribute memory to this
+            # process. Ask torch what it reserved before falling back to a
+            # global free-memory delta: torch's number undercounts by the CUDA
+            # context, which is bounded and the same every run, while the delta
+            # depends on what was already resident when the "before" sample was
+            # taken and was measured sizing one pool 11.9 GiB too large.
+            process_memory = get_process_gpu_memory_bytes_from_torch(self.gpu_id)
+            accounting = "torch_reserved"
+
         if process_memory is None or process_memory <= 0:
             return self._profile_available_bytes_from_stage_load_delta(
                 pre_model_load_memory,
@@ -93,6 +106,7 @@ class _OmniKVCacheConfigurator(KVCacheConfigurator):
         return self._profile_available_bytes_from_process_memory(
             total_memory,
             process_memory,
+            accounting=accounting,
         )
 
     def _profile_available_bytes_from_stage_load_delta(
@@ -136,15 +150,17 @@ class _OmniKVCacheConfigurator(KVCacheConfigurator):
         self,
         total_memory: int,
         process_memory: int,
+        accounting: str = "nvml_process",
     ) -> int:
         available_bytes = calculate_stage_budget_available_bytes(
             total_memory_bytes=total_memory,
             accounted_memory_bytes=process_memory,
             memory_fraction=self.total_gpu_memory_fraction,
             accounted_memory_label="process_used",
+            free_memory_bytes=get_device_free_memory_bytes(self.gpu_id),
         )
         logger.info(
-            f"SGLang AR memory profile: gpu_mem_accounting=nvml_process "
+            f"SGLang AR memory profile: gpu_mem_accounting={accounting} "
             f"gpu_id={self.gpu_id} "
             f"total_gpu_memory_fraction={self.total_gpu_memory_fraction:.3f} "
             f"mem_fraction_static={self.server_args.mem_fraction_static:.3f} "

--- a/sglang_omni/utils/gpu_memory.py
+++ b/sglang_omni/utils/gpu_memory.py
@@ -125,7 +125,19 @@ def get_process_gpu_memory_bytes(logical_gpu_id: int) -> int | None:
         for proc in pynvml.nvmlDeviceGetComputeRunningProcesses(handle):
             if proc.pid == pid:
                 return int(proc.usedGpuMemory)
-        return 0
+        # Note (Audrey Zheng): absent from the list is a failed attribution,
+        # not zero usage, and the two need different handling. NVML reports
+        # host pids; a caller inside a container sees a different number for
+        # itself, so the join never matches and every containerized run lands
+        # here. Returning 0 made that indistinguishable from a process that
+        # genuinely holds nothing, and the caller reads both as "unavailable".
+        logger.debug(
+            "pid %d is absent from the NVML compute list for device %d; "
+            "process-scoped memory is unattributable here",
+            pid,
+            device_id,
+        )
+        return None
     except _InvalidGpuDeviceError:
         raise
     except Exception as exc:
@@ -133,6 +145,51 @@ def get_process_gpu_memory_bytes(logical_gpu_id: int) -> int | None:
         return None
     finally:
         _shutdown_nvml(pynvml)
+
+
+
+def get_process_gpu_memory_bytes_from_torch(logical_gpu_id: int) -> int | None:
+    """Return this process's GPU memory from torch, with no pid join.
+
+    NVML attribution needs to recognise the caller among the device's
+    processes, and it cannot inside a container: NVML reports host pids while
+    the caller sees its namespace pid. This source asks torch what it reserved
+    instead, which no namespace can disagree about.
+
+    It undercounts by the CUDA context, which torch does not account for --
+    measured at 0.51 GiB in a small controlled process. That error is bounded
+    and the same every run. The alternative when attribution fails is a global
+    free-memory delta, whose error is neither: it depends on what else was
+    resident at the moment the "before" sample was taken, and it was measured
+    sizing one KV pool 11.9 GiB too large.
+    """
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return None
+        return int(torch.cuda.memory_reserved(logical_gpu_id))
+    except Exception as exc:
+        logger.debug("torch reserved-memory query failed: %s", exc)
+        return None
+
+def get_device_free_memory_bytes(logical_gpu_id: int) -> int | None:
+    """Return free memory on a CUDA logical device, or None if unavailable.
+
+    Uses torch rather than NVML so it needs no pid join and no namespace
+    agreement. Callers use it to clamp a budget that would otherwise count
+    only their own usage and over-commit a co-tenant.
+    """
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return None
+        free_bytes, _total = torch.cuda.mem_get_info(logical_gpu_id)
+        return int(free_bytes)
+    except Exception as exc:
+        logger.debug("free-memory query failed: %s", exc)
+        return None
 
 
 def get_gpu_device_info(logical_gpu_id: int) -> GpuDeviceInfo:
@@ -226,6 +283,8 @@ def calculate_stage_budget_available_bytes(
     accounted_memory_bytes: int,
     memory_fraction: float,
     accounted_memory_label: str = "accounted_used",
+    free_memory_bytes: int | None = None,
+    reserve_bytes: int = 0,
 ) -> int:
     """Return stage KV headroom under a total GPU memory fraction."""
     if total_memory_bytes <= 0:
@@ -237,6 +296,25 @@ def calculate_stage_budget_available_bytes(
 
     requested_bytes = int(total_memory_bytes * memory_fraction)
     available_bytes = requested_bytes - accounted_memory_bytes
+    # Note (Audrey Zheng): the budget above counts only this stage's own usage,
+    # so it over-commits whenever another process already holds memory on the
+    # card. Measured: on a card holding 34 GiB of another process, a stage at
+    # fraction 0.87 budgeted 122.49 GiB and ran out of memory at launch. Clamp
+    # by what the device actually reports free, so a co-tenant cannot be
+    # over-committed. Callers that cannot read free memory pass None and keep
+    # the old behaviour.
+    if free_memory_bytes is not None:
+        headroom = int(free_memory_bytes) - int(reserve_bytes)
+        if headroom < available_bytes:
+            logger.info(
+                "KV budget clamped by free memory: requested %s, free %s, "
+                "reserve %s, granting %s",
+                format_bytes_gib(available_bytes),
+                format_bytes_gib(int(free_memory_bytes)),
+                format_bytes_gib(int(reserve_bytes)),
+                format_bytes_gib(max(0, headroom)),
+            )
+            available_bytes = headroom
     if available_bytes <= 0:
         raise RuntimeError(
             "Colocated GPU memory budget leaves no KV-cache headroom: "

--- a/tests/unit_test/pipeline/test_gpu_memory.py
+++ b/tests/unit_test/pipeline/test_gpu_memory.py
@@ -217,15 +217,31 @@ def test_get_process_gpu_memory_retries_uuid_as_bytes(
     assert fake.uuid_handles == [b"GPU-abc"]
 
 
-def test_get_process_gpu_memory_returns_zero_when_pid_not_present(
+def test_get_process_gpu_memory_reports_a_failed_attribution_as_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Absent from the list means unattributable, not zero usage.
+
+    NVML reports host pids, so a caller inside a container never finds itself
+    and lands here on every run. Returning 0 made that indistinguishable from
+    a process that genuinely holds nothing.
+    """
     fake = _FakeNVML(processes=[SimpleNamespace(pid=os.getpid() + 1, usedGpuMemory=1)])
     _install_fake_nvml(monkeypatch, fake)
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
 
-    assert gpu_memory.get_process_gpu_memory_bytes(0) == 0
+    assert gpu_memory.get_process_gpu_memory_bytes(0) is None
     assert fake.index_handles == [0]
+
+
+def test_get_process_gpu_memory_reports_a_genuine_zero_as_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeNVML(processes=[SimpleNamespace(pid=os.getpid(), usedGpuMemory=0)])
+    _install_fake_nvml(monkeypatch, fake)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+
+    assert gpu_memory.get_process_gpu_memory_bytes(0) == 0
 
 
 def test_get_process_gpu_memory_returns_none_on_query_failure(

--- a/tests/unit_test/pipeline/test_kv_sizing_fixes.py
+++ b/tests/unit_test/pipeline/test_kv_sizing_fixes.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KV budget accounting: attribution failure, and clamping by free memory."""
+
+from __future__ import annotations
+
+import pytest
+
+from sglang_omni.utils.gpu_memory import calculate_stage_budget_available_bytes
+
+_GIB = 1024**3
+
+
+def _budget(**kwargs) -> int:
+    base = {
+        "total_memory_bytes": 140 * _GIB,
+        "accounted_memory_bytes": 57 * _GIB,
+        "memory_fraction": 0.87,
+    }
+    base.update(kwargs)
+    return calculate_stage_budget_available_bytes(**base)
+
+
+def test_without_a_free_reading_the_budget_is_unchanged() -> None:
+    """A caller that cannot read free memory keeps the old behaviour."""
+    assert _budget() == int(140 * _GIB * 0.87) - 57 * _GIB
+
+
+def test_a_co_tenant_no_longer_gets_over_committed() -> None:
+    """The stage's own usage is not the whole card's usage.
+
+    Measured: on a card holding 34 GiB of another process, a stage at fraction
+    0.87 budgeted 122.49 GiB and ran out of memory at launch.
+    """
+    unclamped = _budget()
+    clamped = _budget(free_memory_bytes=20 * _GIB)
+
+    assert clamped == 20 * _GIB
+    assert clamped < unclamped
+
+
+def test_a_reserve_is_held_back_from_the_clamp() -> None:
+    assert _budget(free_memory_bytes=20 * _GIB, reserve_bytes=4 * _GIB) == 16 * _GIB
+
+
+def test_ample_free_memory_does_not_shrink_the_budget() -> None:
+    assert _budget(free_memory_bytes=130 * _GIB) == _budget()
+
+
+def test_a_budget_leaving_nothing_still_raises() -> None:
+    with pytest.raises(RuntimeError, match="no KV-cache headroom"):
+        _budget(memory_fraction=0.4)


### PR DESCRIPTION
Based on `pd_runtime`. Fixes the three defects reported in #1685.

## The attribution never succeeds in a container

`get_process_gpu_memory_bytes` matches `os.getpid()` against the pids NVML lists for the device. NVML reports pids from the host namespace and the caller sees its namespace pid, so the join never matches and **every containerized run falls through**.

Falling through was not the problem on its own. The problem is what it fell through *as*: the function returned `0`, which is also what it returns for a process that genuinely holds no memory. `sglang_model_runner.py` reads `<= 0` as "NVML unavailable" and takes a global free-memory fallback, so both cases arrive at the same place and neither is visible in a log.

**This PR returns `None` for a failed attribution**, which is what the function's own docstring already promises, and keeps `0` for a genuine zero.

## When attribution fails, ask torch before falling back

The fallback profiles a global free-memory delta across model load. Its error depends on what was already resident when the "before" sample was taken, and it is not reproducible: the same script and the same config produced 838,138 and 711,261 KV tokens on two runs, leaving the card at 97.7% and 90.9%.

`get_process_gpu_memory_bytes_from_torch` reads `torch.cuda.memory_reserved`, which needs no pid join and no namespace agreement. It undercounts by the CUDA context — measured at 0.51 GiB in a small controlled process — and that error is bounded and the same every run. The profile line now reports `gpu_mem_accounting=torch_reserved` when this path runs, so which source produced a budget is visible.

## The budget counted only its own usage

`calculate_stage_budget_available_bytes` computes `total x fraction - this stage's usage` and never subtracts memory belonging to anything else on the card. On a card already holding 34 GiB of another process, a stage at `fraction=0.87` budgeted 122.49 GiB and ran out of memory at launch.

It now takes an optional `free_memory_bytes` and clamps to it, with an optional `reserve_bytes` held back. A caller that cannot read free memory passes nothing and keeps the previous behaviour, so this changes no configuration that works today — it only stops one that would have failed.

`get_device_free_memory_bytes` reads `torch.cuda.mem_get_info`, again with no pid join.

## Why this matters beyond the original report

Two PD halves sharing a GPU are two processes sizing pools from one card, so the second defect is what decides whether that placement is safe. It currently works only because the startup lock serializes weight loading — see the discussion on #1701. The clamp makes it safe without depending on that ordering, and it also covers the case the placement check cannot see, which is a process the pipeline does not know about.

## What this PR does not change

The `<= 0` branch still exists for a genuine zero, which routes to the fallback. That is arguably still wrong — a stage that truly holds nothing has a knowable budget — but changing it alters sizing for configurations that work today, and that is a policy call rather than a defect.

## Testing

| Run | Result |
| --- | --- |
| `test_kv_sizing_fixes.py` (5 cases, new) | pass |
| `tests/unit_test/pipeline` | 534 pass |

`test_gpu_memory.py::test_get_process_gpu_memory_returns_zero_when_pid_not_present` asserted the behaviour this PR changes. It is now two tests: one that a failed attribution reports `None`, one that a genuine zero still reports `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
