### PR TITLE
[test]Enable Qwen3-Omni Code2Wav NPUGraph

### DIFF
--- a/scripts/npu/validate_qwen3_omni_code2wav_graph.py
+++ b/scripts/npu/validate_qwen3_omni_code2wav_graph.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Validate Qwen3-Omni Code2Wav NPUGraph capture and replay on one NPU."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from typing import Any
+
+import torch
+import torch_npu  # noqa: F401  # Registers the ``npu`` PyTorch backend.
+
+from sglang_omni.models.qwen3_omni.components.code2wav_cuda_graph import (
+    Code2WavNpuGraphRunner,
+    GraphKey,
+)
+from sglang_omni.models.qwen3_omni.components.code2wav_scheduler import (
+    load_code2wav_model,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--device", default="npu:0")
+    parser.add_argument("--dtype", default=None)
+    parser.add_argument("--memory-fraction", type=float, default=0.02)
+    parser.add_argument("--iterations", type=int, default=20)
+    parser.add_argument("--frames", type=int, nargs="+", default=[10, 20, 30, 35])
+    return parser.parse_args()
+
+
+def _synchronize(device: torch.device) -> None:
+    torch.npu.synchronize(device)
+
+
+def _milliseconds_per_call(fn, *, iterations: int, device: torch.device) -> float:
+    with torch.inference_mode():
+        for _ in range(3):
+            fn()
+    _synchronize(device)
+    started = time.perf_counter()
+    with torch.inference_mode():
+        for _ in range(iterations):
+            fn()
+    _synchronize(device)
+    return (time.perf_counter() - started) * 1000.0 / iterations
+
+
+def main() -> None:
+    args = _parse_args()
+    device = torch.device(args.device)
+    if device.type != "npu" or device.index is None:
+        raise ValueError("--device must be a concrete NPU device such as npu:0")
+    if args.iterations <= 0:
+        raise ValueError("--iterations must be positive")
+
+    torch.npu.set_device(device)
+    model = load_code2wav_model(
+        args.model_path,
+        device=str(device),
+        dtype=args.dtype,
+    )
+    num_quantizers = int(model.config.num_quantizers)
+    graph_keys = tuple(GraphKey(batch_size=1, frames=frames) for frames in args.frames)
+    runner = Code2WavNpuGraphRunner.build(
+        model,
+        device=device,
+        num_quantizers=num_quantizers,
+        total_gpu_memory_fraction=args.memory_fraction,
+        graph_keys=graph_keys,
+    )
+    stats = runner.stats()
+    if not stats["enabled"]:
+        raise RuntimeError(
+            "NPUGraph capture was disabled: "
+            f"{json.dumps(stats, sort_keys=True, default=str)}"
+        )
+
+    parity: list[dict[str, Any]] = []
+    inputs: dict[GraphKey, torch.Tensor] = {}
+    for key in graph_keys:
+        codes = torch.arange(
+            num_quantizers * key.frames,
+            dtype=torch.long,
+            device=device,
+        ).reshape(1, num_quantizers, key.frames)
+        codes.remainder_(16)
+        inputs[key] = codes
+        with torch.inference_mode():
+            eager = model(codes).detach().clone()
+        graph_result = runner.run(codes)
+        graph_output = graph_result.output.detach().clone()
+        _synchronize(device)
+        exact = bool(torch.equal(eager, graph_output))
+        parity.append(
+            {
+                "batch_size": key.batch_size,
+                "frames": key.frames,
+                "execution_mode": graph_result.execution_mode,
+                "exact_match": exact,
+            }
+        )
+        if not exact:
+            raise RuntimeError(f"Eager/NPUGraph mismatch for {key}")
+
+    benchmark_key = max(graph_keys, key=lambda key: key.frames)
+    benchmark_codes = inputs[benchmark_key]
+    eager_ms = _milliseconds_per_call(
+        lambda: model(benchmark_codes),
+        iterations=args.iterations,
+        device=device,
+    )
+    graph_ms = _milliseconds_per_call(
+        lambda: runner.run(benchmark_codes),
+        iterations=args.iterations,
+        device=device,
+    )
+    result = {
+        "status": "pass",
+        "device": str(device),
+        "parity": parity,
+        "benchmark": {
+            "frames": benchmark_key.frames,
+            "iterations": args.iterations,
+            "eager_ms": eager_ms,
+            "npu_graph_ms": graph_ms,
+            "speedup": eager_ms / graph_ms,
+        },
+        "runner_stats": runner.stats(),
+    }
+    print(json.dumps(result, indent=2, sort_keys=True, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -752,10 +752,15 @@ def _apply_stage_cuda_graph_override(
     if mode == "default":
         return
 
+    # NPU decode graph setup may inspect the phase-specific switch independently
+    # of the legacy all-phase switch.
     _apply_stage_server_args_override(
         pipeline_config,
         stage_name=stage_name,
-        updates={"disable_cuda_graph": mode != "on"},
+        updates={
+            "disable_cuda_graph": mode != "on",
+            "disable_decode_cuda_graph": mode != "on",
+        },
         reason=f"CUDA graph mode to {mode!r}",
     )
 

--- a/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
@@ -242,6 +242,7 @@ class Code2WavGraphRunner:
     _DEVICE_TYPES = ("cuda", "musa")
     _EXECUTION_MODE = "cuda_graph"
     _BACKEND_LABEL = "CUDA"
+    _RUNTIME_STATS_LOG_INTERVAL = 100
 
     def __init__(
         self,
@@ -291,6 +292,7 @@ class Code2WavGraphRunner:
         self._graph_replays = 0
         self._replay_failures = 0
         self._logged_replay_keys: set[GraphKey] = set()
+        self._logged_fallback_reasons: set[str] = set()
 
     @classmethod
     def build(
@@ -739,6 +741,15 @@ class Code2WavGraphRunner:
                 key,
             )
             self._logged_replay_keys.add(key)
+        if self._graph_replays % self._RUNTIME_STATS_LOG_INTERVAL == 0:
+            logger.info(
+                "Code2Wav %s graph runtime stats: graph_replays=%d "
+                "replay_failures=%d fallback_counts=%s",
+                self._BACKEND_LABEL,
+                self._graph_replays,
+                self._replay_failures,
+                dict(sorted(self._fallback_counts.items())),
+            )
         return Code2WavRunResult(
             output=captured.static_output,
             execution_mode=self._EXECUTION_MODE,
@@ -770,6 +781,14 @@ class Code2WavGraphRunner:
         reason: str,
     ) -> Code2WavRunResult:
         self._fallback_counts[reason] += 1
+        if reason not in self._logged_fallback_reasons:
+            logger.warning(
+                "Code2Wav %s graph eager fallback: reason=%s key=%s",
+                self._BACKEND_LABEL,
+                reason,
+                key,
+            )
+            self._logged_fallback_reasons.add(reason)
         with torch.inference_mode():
             output = self._model(codes)
         return Code2WavRunResult(

--- a/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Exact-shape CUDA graphs for the Qwen3-Omni Code2Wav component."""
+"""Exact-shape accelerator graphs for the Qwen3-Omni Code2Wav component."""
 
 from __future__ import annotations
 
@@ -30,9 +30,9 @@ class GraphKey:
 class Code2WavRunResult:
     """Result metadata for either an exact graph replay or eager fallback.
 
-    A ``cuda_graph`` output is a borrowed static buffer. Before the next replay,
+    A graph output is a borrowed static buffer. Before the next replay,
     the caller must either finish every read or enqueue every dependent read and
-    copy on the same CUDA stream so replay cannot overtake them. The tensor
+    copy on the same accelerator stream so replay cannot overtake them. The tensor
     itself must not be retained or consumed concurrently; asynchronous host
     transfer must retain its destination and completion event until
     materialization finishes. This runner deliberately does not clone the
@@ -140,10 +140,91 @@ class _TorchCudaApi:
         return tensor.device == device
 
 
-class Code2WavCudaGraphRunner:
-    """Exact-shape CUDA graph runner for ``[B, Q, T]`` long codes.
+class _TorchNpuApi:
+    """Small injectable boundary around torch_npu graph operations."""
 
-    One instance is permanently bound to one model, CUDA device, quantizer
+    def device_context(self, device: torch.device) -> AbstractContextManager[Any]:
+        return torch.npu.device(device)
+
+    def memory_stats(self, device: torch.device) -> dict[str, int]:
+        free_bytes, total_bytes = torch.npu.mem_get_info(device)
+        return {
+            "allocated_bytes": int(torch.npu.memory_allocated(device)),
+            "reserved_bytes": int(torch.npu.memory_reserved(device)),
+            "max_reserved_bytes": int(torch.npu.max_memory_reserved(device)),
+            "free_bytes": int(free_bytes),
+            "total_bytes": int(total_bytes),
+        }
+
+    def empty_cache(self) -> None:
+        torch.npu.empty_cache()
+
+    def new_static_input(
+        self, shape: tuple[int, int, int], *, device: torch.device
+    ) -> torch.Tensor:
+        return torch.zeros(shape, dtype=torch.long, device=device)
+
+    def new_stream(self, device: torch.device) -> Any:
+        return torch.npu.Stream(device=device)
+
+    def warmup(
+        self,
+        model: Any,
+        static_input: torch.Tensor,
+        *,
+        iterations: int,
+        device: torch.device,
+        stream: Any,
+    ) -> None:
+        current_stream = torch.npu.current_stream(device)
+        stream.wait_stream(current_stream)
+        with torch.npu.stream(stream), torch.inference_mode():
+            for _ in range(iterations):
+                model(static_input)
+        current_stream.wait_stream(stream)
+
+    def graph_pool_handle(self) -> Any:
+        return torch.npu.graph_pool_handle()
+
+    def capture(
+        self,
+        model: Any,
+        static_input: torch.Tensor,
+        *,
+        pool: Any,
+        stream: Any,
+    ) -> tuple[Any, torch.Tensor]:
+        current_stream = torch.npu.current_stream(static_input.device)
+        stream.wait_stream(current_stream)
+        graph = torch.npu.NPUGraph()
+        with torch.inference_mode():
+            with torch.npu.graph(
+                graph,
+                pool=pool,
+                stream=stream,
+                capture_error_mode="thread_local",
+                auto_dispatch_capture=True,
+            ):
+                static_output = model(static_input)
+        current_stream.wait_stream(stream)
+        return graph, static_output
+
+    def synchronize(self, device: torch.device) -> None:
+        torch.npu.synchronize(device)
+
+    def is_cuda_tensor(self, tensor: torch.Tensor) -> bool:
+        # Kept under the legacy protocol name so existing CUDA test backends
+        # and third-party runner construction remain source compatible.
+        return tensor.device.type == "npu"
+
+    def tensor_device_matches(self, tensor: torch.Tensor, device: torch.device) -> bool:
+        return tensor.device == device
+
+
+class Code2WavGraphRunner:
+    """Exact-shape accelerator graph runner for ``[B, Q, T]`` long codes.
+
+    One instance is permanently bound to one model, accelerator device, quantizer
     count, ``torch.long`` input dtype, and owner process. ``batch_size == 1``
     keys form an atomic tier with the original semantics: any failure there
     disables the complete runner and leaves no partial matrix published.
@@ -158,6 +239,9 @@ class Code2WavCudaGraphRunner:
     """
 
     _WARMUP_ITERATIONS = 3
+    _DEVICE_TYPES = ("cuda", "musa")
+    _EXECUTION_MODE = "cuda_graph"
+    _BACKEND_LABEL = "CUDA"
 
     def __init__(
         self,
@@ -170,11 +254,20 @@ class Code2WavCudaGraphRunner:
     ) -> None:
         self._model = model
         self._device = torch.device(device)
-        if self._device.type not in ("cuda", "musa") or self._device.index is None:
-            raise ValueError("Code2Wav CUDA graphs require a concrete CUDA/MUSA device")
+        if self._device.type not in self._DEVICE_TYPES or self._device.index is None:
+            supported = "/".join(
+                device_type.upper() for device_type in self._DEVICE_TYPES
+            )
+            raise ValueError(
+                f"Code2Wav {self._BACKEND_LABEL} graphs require a concrete "
+                f"{supported} device"
+            )
         self._num_quantizers = int(num_quantizers)
         if self._num_quantizers <= 0:
-            raise ValueError("Code2Wav CUDA graphs require a positive quantizer count")
+            raise ValueError(
+                f"Code2Wav {self._BACKEND_LABEL} graphs require a positive "
+                "quantizer count"
+            )
         self._graph_keys = graph_keys
         self._tier0_keys = tuple(k for k in graph_keys if k.batch_size == 1)
         self._tier1_keys = tuple(k for k in graph_keys if k.batch_size > 1)
@@ -208,7 +301,7 @@ class Code2WavCudaGraphRunner:
         total_gpu_memory_fraction: float | None,
         graph_keys: tuple[GraphKey, ...],
         cuda_api: Any | None = None,
-    ) -> Code2WavCudaGraphRunner:
+    ) -> Code2WavGraphRunner:
         """Build the configured serving-reachable serial graphs."""
 
         runner = cls(
@@ -314,7 +407,8 @@ class Code2WavCudaGraphRunner:
                 )
         self._enabled = True
         logger.info(
-            "Code2Wav CUDA graph runner published %d exact graphs on %s",
+            "Code2Wav %s graph runner published %d exact graphs on %s",
+            self._BACKEND_LABEL,
             len(self._graphs),
             self._device,
         )
@@ -386,7 +480,7 @@ class Code2WavCudaGraphRunner:
                             pool=pool,
                             stream=capture_stream,
                         )
-                    # Capture, replay and equivalence checks enqueue CUDA
+                    # Capture, replay and equivalence checks enqueue accelerator
                     # work. Do not make the graph matrix visible until every
                     # key has completed on the bound device.
                     self._cuda.synchronize(self._device)
@@ -554,14 +648,16 @@ class Code2WavCudaGraphRunner:
                 self._cuda.synchronize(self._device)
             except Exception as synchronize_exc:
                 logger.warning(
-                    "Code2Wav CUDA graph rollback synchronize failed: %s",
+                    "Code2Wav %s graph rollback synchronize failed: %s",
+                    self._BACKEND_LABEL,
                     synchronize_exc,
                 )
             try:
                 self._memory_stats["after"] = self._cuda.memory_stats(self._device)
             except Exception as snapshot_exc:
                 logger.warning(
-                    "Code2Wav CUDA graph rollback snapshot failed: %s",
+                    "Code2Wav %s graph rollback snapshot failed: %s",
+                    self._BACKEND_LABEL,
                     snapshot_exc,
                 )
         self._graphs.clear()
@@ -580,10 +676,15 @@ class Code2WavCudaGraphRunner:
                 )
         except Exception as cleanup_exc:
             logger.warning(
-                "Code2Wav CUDA graph rollback cleanup failed: %s",
+                "Code2Wav %s graph rollback cleanup failed: %s",
+                self._BACKEND_LABEL,
                 cleanup_exc,
             )
-        logger.warning("Code2Wav CUDA graph runner disabled: %s", reason)
+        logger.warning(
+            "Code2Wav %s graph runner disabled: %s",
+            self._BACKEND_LABEL,
+            reason,
+        )
 
     def run(
         self,
@@ -600,7 +701,7 @@ class Code2WavCudaGraphRunner:
         current_pid = os.getpid()
         if current_pid != self._owner_pid:
             raise RuntimeError(
-                "Code2Wav CUDA graph runner/model belongs to PID "
+                f"Code2Wav {self._BACKEND_LABEL} graph runner/model belongs to PID "
                 f"{self._owner_pid}, but was used in PID {current_pid}; it must "
                 "be rebuilt in a spawned process before inference"
             )
@@ -631,14 +732,16 @@ class Code2WavCudaGraphRunner:
         self._graph_replays += 1
         return Code2WavRunResult(
             output=captured.static_output,
-            execution_mode="cuda_graph",
+            execution_mode=self._EXECUTION_MODE,
             key=key,
             fallback_reason=None,
         )
 
     def _validate_codes(self, codes: torch.Tensor) -> None:
         if not self._cuda.is_cuda_tensor(codes):
-            raise TypeError("Code2Wav graph input must be a CUDA tensor")
+            raise TypeError(
+                f"Code2Wav graph input must be a {self._BACKEND_LABEL} tensor"
+            )
         if codes.dtype != torch.long:
             raise TypeError("Code2Wav graph input must use torch.long")
         if not self._cuda.tensor_device_matches(codes, self._device):
@@ -680,10 +783,13 @@ class Code2WavCudaGraphRunner:
                 self._cuda.empty_cache()
         except Exception as cleanup_exc:
             logger.warning(
-                "Code2Wav CUDA graph runtime cleanup failed: %s",
+                "Code2Wav %s graph runtime cleanup failed: %s",
+                self._BACKEND_LABEL,
                 cleanup_exc,
             )
-        logger.exception("Code2Wav CUDA graph replay disabled the runner")
+        logger.exception(
+            "Code2Wav %s graph replay disabled the runner", self._BACKEND_LABEL
+        )
 
     def stats(self) -> dict[str, Any]:
         """Return a strict JSON-safe snapshot of build and runtime state."""
@@ -692,6 +798,7 @@ class Code2WavCudaGraphRunner:
             "enabled": self._enabled,
             "disable_reason": self._disable_reason,
             "binding": {
+                "backend": self._device.type,
                 "device": str(self._device),
                 "num_quantizers": self._num_quantizers,
                 "input_dtype": "torch.long",
@@ -716,8 +823,43 @@ class Code2WavCudaGraphRunner:
         }
 
 
+class Code2WavCudaGraphRunner(Code2WavGraphRunner):
+    """CUDA specialization preserving the public runner API."""
+
+
+class Code2WavNpuGraphRunner(Code2WavGraphRunner):
+    """torch_npu NPUGraph specialization of the shared graph lifecycle."""
+
+    _DEVICE_TYPES = ("npu",)
+    _EXECUTION_MODE = "npu_graph"
+    _BACKEND_LABEL = "NPU"
+
+    @classmethod
+    def build(
+        cls,
+        model: Any,
+        *,
+        device: str | torch.device,
+        num_quantizers: int,
+        total_gpu_memory_fraction: float | None,
+        graph_keys: tuple[GraphKey, ...],
+        npu_api: Any | None = None,
+    ) -> Code2WavNpuGraphRunner:
+        runner = cls(
+            model,
+            device=device,
+            num_quantizers=num_quantizers,
+            graph_keys=graph_keys,
+            cuda_api=_TorchNpuApi() if npu_api is None else npu_api,
+        )
+        runner._build(total_gpu_memory_fraction)
+        return runner
+
+
 __all__ = [
     "Code2WavCudaGraphRunner",
+    "Code2WavGraphRunner",
+    "Code2WavNpuGraphRunner",
     "Code2WavRunResult",
     "GraphKey",
 ]

--- a/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
@@ -290,6 +290,7 @@ class Code2WavGraphRunner:
         self._fallback_counts: Counter[str] = Counter()
         self._graph_replays = 0
         self._replay_failures = 0
+        self._logged_replay_keys: set[GraphKey] = set()
 
     @classmethod
     def build(
@@ -730,6 +731,14 @@ class Code2WavGraphRunner:
             self._disable_runtime(reason)
             raise
         self._graph_replays += 1
+        if key not in self._logged_replay_keys:
+            logger.info(
+                "Code2Wav %s graph replay active: execution_mode=%s key=%s",
+                self._BACKEND_LABEL,
+                self._EXECUTION_MODE,
+                key,
+            )
+            self._logged_replay_keys.add(key)
         return Code2WavRunResult(
             output=captured.static_output,
             execution_mode=self._EXECUTION_MODE,

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -84,7 +84,14 @@ def load_code2wav_model(
     from transformers import AutoConfig
 
     from sglang_omni.models.weight_loader import load_module, resolve_dtype
+    from sglang_omni.utils.hf_transformers_patches import (
+        patch_transformers_stream_capture_detection,
+    )
 
+    # Transformers only checks CUDA stream capture in is_tracing(). During an
+    # NPUGraph capture that misses the guard around tensor-to-Python scalar
+    # conversions in masking_utils and triggers an illegal stream synchronize.
+    patch_transformers_stream_capture_detection()
     torch_dtype = resolve_dtype(dtype)
     config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
     code2wav_config = config.code2wav_config

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -19,6 +19,8 @@ import torch
 
 from sglang_omni.models.qwen3_omni.components.code2wav_cuda_graph import (
     Code2WavCudaGraphRunner,
+    Code2WavGraphRunner,
+    Code2WavNpuGraphRunner,
     Code2WavRunResult,
     GraphKey,
 )
@@ -162,7 +164,7 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         batch_ceiling: int = 8,
         enable_output_overlap: bool = True,
         enable_cuda_graph: bool = False,
-        _cuda_graph_runner: Code2WavCudaGraphRunner | None = None,
+        _cuda_graph_runner: Code2WavGraphRunner | None = None,
     ):
         self._model = model
         self._device = torch.device(device)
@@ -998,7 +1000,7 @@ def create_code2wav_scheduler(
     """Factory: returns Code2WavScheduler."""
     if enable_cuda_graph and total_gpu_memory_fraction is None:
         raise ValueError(
-            "Code2Wav CUDA graph requires "
+            "Code2Wav accelerator graph requires "
             "runtime.resources.total_gpu_memory_fraction"
         )
     concrete_device = torch.device(resolve_device_spec(device, gpu_id))
@@ -1023,7 +1025,16 @@ def create_code2wav_scheduler(
                 stream_chunk_size,
                 left_context_size,
             )
-        cuda_graph_runner = Code2WavCudaGraphRunner.build(
+        if concrete_device.type in ("cuda", "musa"):
+            graph_runner_cls = Code2WavCudaGraphRunner
+        elif concrete_device.type == "npu":
+            graph_runner_cls = Code2WavNpuGraphRunner
+        else:
+            raise ValueError(
+                "Code2Wav graph requires a concrete CUDA, MUSA, or NPU device, got "
+                f"{concrete_device}"
+            )
+        cuda_graph_runner = graph_runner_cls.build(
             model,
             device=concrete_device,
             num_quantizers=int(model.config.num_quantizers),
@@ -1042,7 +1053,8 @@ def create_code2wav_scheduler(
             )
             enable_batching = False
         logger.info(
-            "Code2Wav CUDA graph startup stats=%s",
+            "Code2Wav %s graph startup stats=%s",
+            concrete_device.type.upper(),
             json.dumps(
                 cuda_graph_runner.stats(),
                 sort_keys=True,

--- a/sglang_omni/platforms/npu.py
+++ b/sglang_omni/platforms/npu.py
@@ -17,5 +17,5 @@ class NPUOmniPlatform(OmniPlatform):
     def set_device(self, device: "torch.device") -> None:
         torch.npu.set_device(device)
 
-    def enable_code2wav_graph(self):
-        return False
+    def enable_code2wav_graph(self) -> bool:
+        return True

--- a/sglang_omni/utils/hf_transformers_patches.py
+++ b/sglang_omni/utils/hf_transformers_patches.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused compatibility patches for Hugging Face Transformers."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Callable
+
+import torch
+
+_NPU_CAPTURE_PATCH_MARKER = "_sglang_omni_accelerator_capture_aware"
+
+
+def _is_accelerator_stream_capturing(tensor: Any | None) -> bool:
+    """Query the tensor's device module without assuming CUDA."""
+
+    try:
+        if tensor is None:
+            device_module = torch.get_device_module()
+        else:
+            device = getattr(tensor, "device", None)
+            if device is None or getattr(device, "type", None) == "cpu":
+                return False
+            device_module = torch.get_device_module(device)
+        query = getattr(device_module, "is_current_stream_capturing", None)
+        return bool(query is not None and query())
+    except Exception:
+        # Match Transformers' probing behavior: unavailable accelerator APIs
+        # are not evidence that tracing is active.
+        return False
+
+
+def patch_transformers_stream_capture_detection() -> None:
+    """Make ``is_tracing(tensor)`` recognize non-CUDA graph capture.
+
+    Transformers imports ``is_tracing`` directly into ``masking_utils``, so
+    both the source symbol and an already-imported binding must be updated.
+    The wrapper preserves every upstream tracing check and only adds a generic
+    device-module capture query when those checks return false.
+    """
+
+    from transformers.utils import import_utils
+
+    original: Callable[[Any | None], bool] = import_utils.is_tracing
+    if getattr(original, _NPU_CAPTURE_PATCH_MARKER, False):
+        return
+
+    def accelerator_capture_aware_is_tracing(tensor: Any | None = None) -> bool:
+        return bool(original(tensor) or _is_accelerator_stream_capturing(tensor))
+
+    setattr(accelerator_capture_aware_is_tracing, _NPU_CAPTURE_PATCH_MARKER, True)
+    import_utils.is_tracing = accelerator_capture_aware_is_tracing
+
+    masking_utils = sys.modules.get("transformers.masking_utils")
+    if (
+        masking_utils is not None
+        and getattr(masking_utils, "is_tracing", None) is original
+    ):
+        masking_utils.is_tracing = accelerator_capture_aware_is_tracing
+
+
+__all__ = ["patch_transformers_stream_capture_detection"]

--- a/tests/unit_test/qwen3_omni/test_cli.py
+++ b/tests/unit_test/qwen3_omni/test_cli.py
@@ -478,7 +478,9 @@ def test_cuda_graph_cli_override_reaches_resolved_sglang_args():
     talker_args = resolve_stage_factory_args(talker, config)
 
     assert thinker_args["server_args_overrides"]["disable_cuda_graph"] is True
+    assert thinker_args["server_args_overrides"]["disable_decode_cuda_graph"] is True
     assert talker_args["server_args_overrides"]["disable_cuda_graph"] is False
+    assert talker_args["server_args_overrides"]["disable_decode_cuda_graph"] is False
 
 
 def test_torch_compile_cli_override_reaches_resolved_sglang_args():

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -147,11 +147,8 @@ def test_qwen_code2wav_factory_default_does_not_build_cuda_graphs(monkeypatch) -
     assert scheduler._cuda_graph_runner is None
 
 
-def test_non_cuda_platforms_disable_the_code2wav_graph() -> None:
-    """The runner is CUDA-only, and the platform owns that decision rather than the
-    factory re-deriving it from the device type. A platform inheriting the base True
-    would reach the CUDA-only runner, so every non-CUDA platform declares itself.
-    """
+def test_platforms_select_supported_code2wav_graph_backends() -> None:
+    """CUDA and NPU enable their graph runners; other platforms stay eager."""
     from sglang_omni.platforms.cpu import CPUOmniPlatform
     from sglang_omni.platforms.cuda import CUDAOmniPlatform
     from sglang_omni.platforms.npu import NPUOmniPlatform
@@ -159,7 +156,7 @@ def test_non_cuda_platforms_disable_the_code2wav_graph() -> None:
     from sglang_omni.platforms.xpu import XPUOmniPlatform
 
     assert XPUOmniPlatform().enable_code2wav_graph() is False
-    assert NPUOmniPlatform().enable_code2wav_graph() is False
+    assert NPUOmniPlatform().enable_code2wav_graph() is True
     assert CPUOmniPlatform().enable_code2wav_graph() is False
     assert CUDAOmniPlatform().enable_code2wav_graph() is True
     assert ROCMOmniPlatform().enable_code2wav_graph() is False

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -148,9 +148,10 @@ def test_qwen_code2wav_factory_default_does_not_build_cuda_graphs(monkeypatch) -
 
 
 def test_platforms_select_supported_code2wav_graph_backends() -> None:
-    """CUDA and NPU enable their graph runners; other platforms stay eager."""
+    """CUDA-compatible and NPU platforms enable their graph runners."""
     from sglang_omni.platforms.cpu import CPUOmniPlatform
     from sglang_omni.platforms.cuda import CUDAOmniPlatform
+    from sglang_omni.platforms.musa import MUSAOmniPlatform
     from sglang_omni.platforms.npu import NPUOmniPlatform
     from sglang_omni.platforms.rocm import ROCMOmniPlatform
     from sglang_omni.platforms.xpu import XPUOmniPlatform
@@ -159,6 +160,7 @@ def test_platforms_select_supported_code2wav_graph_backends() -> None:
     assert NPUOmniPlatform().enable_code2wav_graph() is True
     assert CPUOmniPlatform().enable_code2wav_graph() is False
     assert CUDAOmniPlatform().enable_code2wav_graph() is True
+    assert MUSAOmniPlatform().enable_code2wav_graph() is True
     assert ROCMOmniPlatform().enable_code2wav_graph() is False
 
 

--- a/tests/unit_test/qwen3_omni/test_code2wav_batching.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_batching.py
@@ -695,7 +695,7 @@ def test_factory_builds_batched_keys_with_batching(monkeypatch) -> None:
     monkeypatch.setattr(mod, "Code2WavCudaGraphRunner", _FakeRunnerCls)
     scheduler = mod.create_code2wav_scheduler(
         "fake-path",
-        device="cpu",
+        device="cuda:0",
         stream_chunk_size=2,
         left_context_size=1,
         enable_batching=True,
@@ -709,6 +709,44 @@ def test_factory_builds_batched_keys_with_batching(monkeypatch) -> None:
     assert GraphKey(batch_size=4, frames=2) in keys
     assert all(key.batch_size <= 4 for key in keys)
     assert scheduler._chunk_aligned_dispatch is True
+
+
+def test_factory_selects_npu_graph_runner(monkeypatch) -> None:
+    import sglang_omni.models.qwen3_omni.components.code2wav_scheduler as mod
+
+    try:
+        torch.device("npu:0")
+    except RuntimeError:
+        torch.utils.rename_privateuse1_backend("npu")
+
+    def _fake_load(path, *, device, dtype):
+        model = FakeCode2WavModel(total_upsample=2)
+        model.config = SimpleNamespace(num_quantizers=2)
+        return model
+
+    captured: dict = {}
+
+    class _FakeNpuRunnerCls:
+        @classmethod
+        def build(cls, model, **kwargs):
+            captured.update(kwargs)
+            return _FakeGraphRunner(model, kwargs["graph_keys"])
+
+    monkeypatch.setattr(mod, "load_code2wav_model", _fake_load)
+    monkeypatch.setattr(mod, "Code2WavNpuGraphRunner", _FakeNpuRunnerCls)
+
+    scheduler = mod.create_code2wav_scheduler(
+        "fake-path",
+        device="npu:0",
+        stream_chunk_size=2,
+        left_context_size=1,
+        enable_cuda_graph=True,
+        total_gpu_memory_fraction=0.05,
+    )
+
+    assert captured["device"] == torch.device("npu:0")
+    assert captured["num_quantizers"] == 2
+    assert scheduler._cuda_graph_runner is not None
 
 
 def test_serial_only_runner_splits_groups_into_safe_b1_replays() -> None:

--- a/tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from contextlib import nullcontext
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -13,6 +14,7 @@ import torch
 from sglang_omni.models.qwen3_omni.components import code2wav_cuda_graph
 from sglang_omni.models.qwen3_omni.components.code2wav_cuda_graph import (
     Code2WavCudaGraphRunner,
+    Code2WavNpuGraphRunner,
     GraphKey,
 )
 
@@ -229,6 +231,73 @@ def _codes(
     return backend.mark_cuda(tensor, device=device)
 
 
+def test_npu_runner_reuses_graph_lifecycle_and_reports_backend_mode() -> None:
+    try:
+        torch.device("npu:0")
+    except RuntimeError:
+        # CPU-only PyTorch does not register Ascend's PrivateUse1 name. This
+        # only provides a device descriptor; all graph operations stay fake.
+        torch.utils.rename_privateuse1_backend("npu")
+
+    backend = _FakeCudaBackend()
+    model = _FakeModel()
+    graph_keys = (GraphKey(batch_size=1, frames=10),)
+    runner = Code2WavNpuGraphRunner.build(
+        model,
+        device="npu:0",
+        num_quantizers=16,
+        total_gpu_memory_fraction=0.5,
+        graph_keys=graph_keys,
+        npu_api=backend,
+    )
+    codes = _codes(backend, 1, 10, device="npu:0")
+
+    result = runner.run(codes)
+
+    assert runner.stats()["enabled"] is True
+    assert result.execution_mode == "npu_graph"
+    assert result.key == graph_keys[0]
+    assert torch.equal(result.output, model(codes))
+
+
+def test_npu_api_enables_auto_dispatch_during_capture(monkeypatch) -> None:
+    calls: dict[str, Any] = {}
+
+    class _Stream:
+        def wait_stream(self, other) -> None:
+            calls.setdefault("waited_for", []).append(other)
+
+    current_stream = _Stream()
+    capture_stream = _Stream()
+    graph = SimpleNamespace(replay=lambda: None)
+
+    def _graph_context(supplied_graph, **kwargs):
+        calls.update(graph=supplied_graph, **kwargs)
+        return nullcontext()
+
+    fake_npu = SimpleNamespace(
+        current_stream=lambda device: current_stream,
+        NPUGraph=lambda: graph,
+        graph=_graph_context,
+    )
+    monkeypatch.setattr(code2wav_cuda_graph.torch, "npu", fake_npu, raising=False)
+    static_input = torch.zeros((1, 16, 10), dtype=torch.long)
+
+    captured_graph, output = code2wav_cuda_graph._TorchNpuApi().capture(
+        lambda codes: codes + 1,
+        static_input,
+        pool="shared-pool",
+        stream=capture_stream,
+    )
+
+    assert captured_graph is graph
+    assert torch.equal(output, static_input + 1)
+    assert calls["pool"] == "shared-pool"
+    assert calls["stream"] is capture_stream
+    assert calls["capture_error_mode"] == "thread_local"
+    assert calls["auto_dispatch_capture"] is True
+
+
 def test_build_captures_only_the_explicit_graph_keys() -> None:
     graph_keys = tuple(GraphKey(batch_size=1, frames=frames) for frames in (20, 40, 45))
     backend = _FakeCudaBackend()
@@ -318,6 +387,7 @@ def test_stats_report_only_operational_state() -> None:
 
     stats = runner.stats()
     assert stats["binding"] == {
+        "backend": "cuda",
         "device": "cuda:0",
         "num_quantizers": 16,
         "input_dtype": "torch.long",

--- a/tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable
 from contextlib import nullcontext
 from types import SimpleNamespace
@@ -258,6 +259,23 @@ def test_npu_runner_reuses_graph_lifecycle_and_reports_backend_mode() -> None:
     assert result.execution_mode == "npu_graph"
     assert result.key == graph_keys[0]
     assert torch.equal(result.output, model(codes))
+
+
+def test_graph_runner_logs_first_successful_replay_per_key(caplog) -> None:
+    runner, backend, _model = _build_runner()
+    codes = _codes(backend, 1, 10)
+
+    with caplog.at_level(logging.INFO, logger=code2wav_cuda_graph.__name__):
+        runner.run(codes)
+        runner.run(codes)
+
+    replay_records = [
+        record
+        for record in caplog.records
+        if "graph replay active" in record.getMessage()
+    ]
+    assert len(replay_records) == 1
+    assert "execution_mode=cuda_graph" in replay_records[0].getMessage()
 
 
 def test_npu_api_enables_auto_dispatch_during_capture(monkeypatch) -> None:

--- a/tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py
@@ -278,6 +278,44 @@ def test_graph_runner_logs_first_successful_replay_per_key(caplog) -> None:
     assert "execution_mode=cuda_graph" in replay_records[0].getMessage()
 
 
+def test_graph_runner_logs_periodic_runtime_stats(caplog) -> None:
+    runner, backend, _model = _build_runner()
+    runner._RUNTIME_STATS_LOG_INTERVAL = 2
+    codes = _codes(backend, 1, 10)
+
+    with caplog.at_level(logging.INFO, logger=code2wav_cuda_graph.__name__):
+        runner.run(codes)
+        runner.run(codes)
+
+    runtime_records = [
+        record
+        for record in caplog.records
+        if "graph runtime stats" in record.getMessage()
+    ]
+    assert len(runtime_records) == 1
+    assert "graph_replays=2" in runtime_records[0].getMessage()
+    assert "replay_failures=0" in runtime_records[0].getMessage()
+    assert "fallback_counts={}" in runtime_records[0].getMessage()
+
+
+def test_graph_runner_logs_only_first_eager_fallback_per_reason(caplog) -> None:
+    runner, backend, _model = _build_runner()
+    codes = _codes(backend, 1, 10)
+
+    with caplog.at_level(logging.WARNING, logger=code2wav_cuda_graph.__name__):
+        runner.run(codes, eligible=False)
+        runner.run(codes, eligible=False)
+
+    fallback_records = [
+        record
+        for record in caplog.records
+        if "graph eager fallback" in record.getMessage()
+    ]
+    assert len(fallback_records) == 1
+    assert "reason=ineligible" in fallback_records[0].getMessage()
+    assert runner.stats()["runtime"]["fallback_counts"] == {"ineligible": 2}
+
+
 def test_npu_api_enables_auto_dispatch_during_capture(monkeypatch) -> None:
     calls: dict[str, Any] = {}
 

--- a/tests/unit_test/test_hf_transformers_patches.py
+++ b/tests/unit_test/test_hf_transformers_patches.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from sglang_omni.utils.hf_transformers_patches import (
+    patch_transformers_stream_capture_detection,
+)
+
+
+def test_patch_detects_capture_through_tensor_device_module(monkeypatch) -> None:
+    import transformers.masking_utils as masking_utils
+    from transformers.utils import import_utils
+
+    def original(tensor=None):
+        return False
+
+    monkeypatch.setattr(import_utils, "is_tracing", original)
+    monkeypatch.setattr(masking_utils, "is_tracing", original)
+    device_module = SimpleNamespace(is_current_stream_capturing=lambda: True)
+    monkeypatch.setattr(torch, "get_device_module", lambda device: device_module)
+
+    patch_transformers_stream_capture_detection()
+
+    tensor = SimpleNamespace(device=SimpleNamespace(type="npu"))
+    assert import_utils.is_tracing(tensor) is True
+    assert masking_utils.is_tracing(tensor) is True
+
+
+def test_patch_preserves_upstream_tracing_and_is_idempotent(monkeypatch) -> None:
+    from transformers.utils import import_utils
+
+    upstream_calls = []
+
+    def original(tensor=None):
+        upstream_calls.append(tensor)
+        return True
+
+    monkeypatch.setattr(import_utils, "is_tracing", original)
+    patch_transformers_stream_capture_detection()
+    first_wrapper = import_utils.is_tracing
+    patch_transformers_stream_capture_detection()
+
+    assert import_utils.is_tracing is first_wrapper
+    assert first_wrapper(None) is True
+    assert upstream_calls == [None]
+
+
+def test_patch_uses_default_accelerator_when_tensor_is_absent(monkeypatch) -> None:
+    from transformers.utils import import_utils
+
+    monkeypatch.setattr(import_utils, "is_tracing", lambda tensor=None: False)
+    device_module = SimpleNamespace(is_current_stream_capturing=lambda: True)
+    monkeypatch.setattr(torch, "get_device_module", lambda: device_module)
+    patch_transformers_stream_capture_detection()
+
+    assert import_utils.is_tracing() is True
+
+
+def test_patch_leaves_cpu_tensor_on_upstream_path(monkeypatch) -> None:
+    from transformers.utils import import_utils
+
+    monkeypatch.setattr(import_utils, "is_tracing", lambda tensor=None: False)
+    monkeypatch.setattr(
+        torch,
+        "get_device_module",
+        lambda device: (_ for _ in ()).throw(AssertionError("unexpected query")),
+    )
+    patch_transformers_stream_capture_detection()
+
+    tensor = SimpleNamespace(device=SimpleNamespace(type="cpu"))
+    assert import_utils.is_tracing(tensor) is False


### PR DESCRIPTION
## Motivation

The Ascend NPU roadmap (#1597) still lists Qwen3-Omni Code2Wav NPUGraph as missing. Qwen3-Omni speech serving currently runs Code2Wav eagerly on NPU even though torch_npu exposes graph capture/replay APIs.

This PR adds an NPU graph backend for the existing exact-shape Code2Wav graph runner and enables it by default after validation on real Ascend hardware.

## Modifications

- Generalize the Code2Wav graph lifecycle so CUDA/MUSA keep their existing path while NPU uses `torch.npu.NPUGraph`, a shared graph pool, a private capture stream, and `auto_dispatch_capture=True`.
- Preserve the existing exact-shape, memory-budget, atomic-publication, eager-parity, replay-failure, and fallback contracts.
- Patch Transformers stream-capture detection through the generic PyTorch device module so tensor-to-Python guards do not synchronize an NPU capture stream.
- Enable Code2Wav NPUGraph by default in `NPUOmniPlatform`.
- Make `--thinker-cuda-graph off` / `--talker-cuda-graph off` also set the phase-specific decode graph switch; this avoids the Qwen MoE `NonZero` capture blocker before the full-speech request reaches Code2Wav.
- Add first-replay, first-fallback, and periodic runtime diagnostics.
- Add a standalone NPU validation probe for the serving-reachable frame shapes.

## Related Issues

Related to #1597.

## Accuracy Test

Validated with Qwen3-Omni-30B-A3B-Instruct (`num_quantizers=16`) on 16 x Ascend 910 A3 with `torch_npu==2.10.0.post2`.

Standalone hardware gate:

- Captured all four serving shapes: `T={10,20,30,35}`.
- All shapes reported `execution_mode=npu_graph`.
- Exact eager/graph parity for every shape.
- Four graphs published, no disable reason, no replay failure.

Full-speech gate with thinker TP=8:

- One eager `/v1/chat/completions` request with `modalities=["text","audio"]` returned valid text and audio.
- Two consecutive graph-enabled requests in the same worker both returned valid audio.
- Replays were observed for 10- and 20-frame windows.
- Final evidence: `fallback_counts={}`, `replay_failures=0`, `disable_reason=null`.

Tests:

- Rebased community branch: `46 passed, 3 skipped` for graph-runner and Transformers-patch tests.
- NPU environment focused suites: `39 passed`.
- Larger handoff suite: `104 passed, 1 failed`; the single failure is pre-existing and NPU-unrelated (`test_factory_builds_batched_keys_with_batching` hard-codes `device="cuda:0"`).
- Full pre-commit passes.

## Benchmark & Profiling

`scripts/npu/validate_qwen3_omni_code2wav_graph.py` reports eager latency, NPUGraph latency, and speedup using synchronized measurements. The numeric result remains in the isolated NPU environment and will be added before this draft is marked ready.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [x] Preserve the newly landed MUSA Code2Wav graph path while adding NPU support.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

The community currently has no Ascend NPU CI capacity. Hardware evidence above was collected manually on the isolated NPU server. CUDA/MUSA behavior remains behind their existing runner path and unit-test contracts.