### PR TITLE
feat(comm): let the CUDA-IPC relay preallocate its pool

### DIFF
--- a/sglang_omni/relay/cuda_ipc.py
+++ b/sglang_omni/relay/cuda_ipc.py
@@ -548,6 +548,7 @@ class CudaIpcRelay(Relay):
         credits: int | None = 2,
         slot_size_kb: int = 64,
         pool_size_mb: int | None = None,
+        preallocate_pool: bool = False,
         **kwargs: Any,
     ) -> None:
         if kwargs:
@@ -555,6 +556,17 @@ class CudaIpcRelay(Relay):
                 f"unexpected cuda_ipc relay options: {', '.join(sorted(kwargs))}"
             )
         self.engine_id = engine_id
+        # Note (Audrey Zheng): the pool is allocated on the first payload that
+        # crosses a process boundary, not at startup, so a deployment can pass
+        # startup and still be a gigabyte short when the first multimodal
+        # request arrives. Measured on a PD pair: `mem_fraction_static=0.87`
+        # launched cleanly and then failed a 750 MiB allocation 19 minutes in,
+        # when the image arm began and `mm_aggregate` first relayed a CUDA
+        # tensor. Text payloads route over SHM and never trigger it, so a text
+        # smoke test cannot catch the shortfall. Preallocating moves that
+        # failure to launch, where it is readable. Off by default so no
+        # existing deployment changes size.
+        self._preallocate_pool = preallocate_pool
         if device == "cpu":
             raise ValueError(
                 "cuda_ipc relay requires a CUDA device; got 'cpu'. Use the shm "
@@ -596,6 +608,8 @@ class CudaIpcRelay(Relay):
             max_workers=_event_wait_threads_from_env(),
             thread_name_prefix=f"cuda-ipc-wait-{engine_id}",
         )
+        if self._preallocate_pool:
+            self._ensure_local_pool()
 
     def __del__(self) -> None:
         try:

--- a/tests/unit_test/relay/test_cuda_ipc_relay.py
+++ b/tests/unit_test/relay/test_cuda_ipc_relay.py
@@ -683,3 +683,25 @@ def test_cuda_ipc_paged_multi_buffer_round_trip_with_storage_offsets() -> None:
 )
 def test_cuda_ipc_cross_gpu_round_trip() -> None:
     _run_case(0, 1)
+
+
+def test_cuda_ipc_pool_is_lazy_by_default() -> None:
+    """Unchanged default: construction allocates nothing."""
+    relay = CudaIpcRelay(engine_id="sender", device="cuda:0")
+    assert relay._pool_tensor is None
+
+
+def test_cuda_ipc_preallocate_moves_the_allocation_to_construction() -> None:
+    """A budget that cannot hold the pool then fails at launch, not later.
+
+    The pool is otherwise allocated on the first payload that crosses a
+    process boundary. Measured on a PD pair: `mem_fraction_static=0.87`
+    launched cleanly and then failed a 750 MiB allocation 19 minutes in, when
+    the image arm began and `mm_aggregate` first relayed a CUDA tensor. Text
+    traffic never triggers it, so a text smoke test cannot catch the shortfall.
+    """
+    relay = CudaIpcRelay(
+        engine_id="sender", device="cuda:0", pool_size_mb=1, preallocate_pool=True
+    )
+    assert relay._pool_tensor is not None
+    assert relay._pool_tensor.numel() == relay.pool_size


### PR DESCRIPTION
Based on `pd_runtime`. One flag, off by default.

## The failure this prevents

`CudaIpcRelay` allocates its pool on the first payload that crosses a process boundary, not at construction. A deployment whose memory budget cannot hold the pool therefore starts cleanly and fails later, when traffic first needs it.

Measured on a PD pair: at `mem_fraction_static=0.87` both halves launched, served text for 19 minutes, and then failed a 750 MiB allocation the moment the image arm began — `[mm_aggregate_relay] Allocating CUDA-IPC pool: 1024.00 MB on cuda:0` appears in the log at that instant and not before. The prefill card was at 139.5 GiB of 139.80 with `thinker_prefill` holding 125.92 and the encoder process 13.59.

**Text traffic cannot catch this.** `router.py` routes a payload with no CUDA tensors over SHM, so `mm_aggregate` never reaches the pool on a text-only run. A text smoke test passes and the deployment is still a gigabyte short.

PD makes it reachable in a way colocated is not: `qwen3_omni/config.py` puts every stage in `process="pipeline"`, so `mm_aggregate` to `thinker` is an in-process handoff, while `pd_rewrite._split_pd_stage` gives the prefill half its own process and pushes that edge across a boundary. Colocated logged zero pool allocations across the whole comparison; PD logged one.

## The change

`preallocate_pool=False` on `CudaIpcRelay`. When set, the pool is allocated at the end of construction, so a budget that cannot hold it fails at launch with the allocation error rather than under load.

Default is off, so nothing that runs today changes size or startup time.

## What this does not do

It does not make the pool part of any memory budget. The sizing path still does not know the relay will allocate, so an operator has to leave room for it. Making the budget account for it is a larger change and belongs with whoever owns the sizing contract — see #1685.

## Testing

| Run | Result |
| --- | --- |
| `test_cuda_ipc_relay.py` (2 cases, new) | pass |
| `tests/unit_test/relay`, `tests/unit_test/pipeline` | 541 pass |

One case asserts the default stays lazy, so the flag cannot silently become the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
