### PR TITLE
feat(pd): make PD overload visible, and bound handoffs in flight

### DIFF
--- a/sglang_omni/comm/engine.py
+++ b/sglang_omni/comm/engine.py
@@ -127,6 +127,8 @@ class CommEngine:
         self._retained_pending_kv_transfers: list[_PendingTransfer] = []
         self._kv_pools: dict[str, KVPool] = {}
         self._kv_receivers: dict[str, KVReceiver] = {}
+        # Note (Audrey Zheng): the newest depth each peer reported on an ack.
+        self._peer_pending: dict[str, int] = {}
         self._kv_ready: dict[str, asyncio.Future[KVTransferReadyMessage]] = {}
         self._outbound_kv_requests: dict[str, str] = {}
         self._inbound_kv: dict[str, _InboundKVTransfer] = {}
@@ -346,6 +348,32 @@ class CommEngine:
     def register_kv_receiver(self, pool_id: str, receiver: KVReceiver) -> None:
         self._kv_receivers[pool_id] = receiver
 
+    def _local_pending_depth(self) -> int | None:
+        """Requests this stage's receivers still hold, or None if unreported.
+
+        A receiver that does not implement ``pending_depth`` contributes
+        nothing, so a stage whose receivers all predate the method reports
+        nothing rather than a misleading zero.
+        """
+        total: int | None = None
+        for receiver in self._kv_receivers.values():
+            depth = getattr(receiver, "pending_depth", None)
+            if depth is None:
+                continue
+            try:
+                value = depth()
+            except Exception:
+                logger.debug("pending_depth failed", exc_info=True)
+                continue
+            if value is None:
+                continue
+            total = int(value) if total is None else total + int(value)
+        return total
+
+    def peer_pending(self, stage: str) -> int | None:
+        """Newest depth *stage* reported, or None if it has never reported one."""
+        return self._peer_pending.get(stage)
+
     async def send_kv_pages(
         self,
         *,
@@ -535,6 +563,7 @@ class CommEngine:
                 object_id=data_ref.object_id,
                 success=error is None,
                 error=None if error is None else (str(error) or type(error).__name__),
+                receiver_pending=self._local_pending_depth(),
             ),
         )
 
@@ -721,6 +750,10 @@ class CommEngine:
             raise ValueError(
                 f"data_ack for {ack.to_stage!r} delivered to {self.router.stage_name!r}"
             )
+        if ack.receiver_pending is not None:
+            # Note (Audrey Zheng): record before the staleness check, because a
+            # stale ack still carries a current reading of the peer's depth.
+            self._peer_pending[ack.from_stage] = ack.receiver_pending
         pending = self._pending.get(ack.object_id)
         if pending is None:
             logger.debug(

--- a/sglang_omni/config/pd_rewrite.py
+++ b/sglang_omni/config/pd_rewrite.py
@@ -156,7 +156,11 @@ def _split_pd_stage(
             "stream_to": [inbound_rename.get(t, t) for t in s.stream_to],
             "pd_disaggregation": None,
             # Note (Yue Yin): Keep compiler metadata out of user factory kwargs.
-            "pd_execution": PDExecution(role="prefill", partner=decode_name),
+            "pd_execution": PDExecution(
+                role="prefill",
+                partner=decode_name,
+                max_inflight_handoffs=pd.max_inflight_handoffs,
+            ),
         },
     )
 
@@ -175,7 +179,11 @@ def _split_pd_stage(
             "wait_for_fn": None,
             "merge_fn": None,
             "pd_disaggregation": None,
-            "pd_execution": PDExecution(role="decode", partner=prefill_name),
+            "pd_execution": PDExecution(
+                role="decode",
+                partner=prefill_name,
+                max_inflight_handoffs=pd.max_inflight_handoffs,
+            ),
         },
     )
 

--- a/sglang_omni/config/pd_rewrite.py
+++ b/sglang_omni/config/pd_rewrite.py
@@ -160,6 +160,7 @@ def _split_pd_stage(
                 role="prefill",
                 partner=decode_name,
                 max_inflight_handoffs=pd.max_inflight_handoffs,
+                decode_pending_limit=pd.decode_pending_limit,
             ),
         },
     )
@@ -183,6 +184,7 @@ def _split_pd_stage(
                 role="decode",
                 partner=prefill_name,
                 max_inflight_handoffs=pd.max_inflight_handoffs,
+                decode_pending_limit=pd.decode_pending_limit,
             ),
         },
     )

--- a/sglang_omni/config/pd_rewrite.py
+++ b/sglang_omni/config/pd_rewrite.py
@@ -160,7 +160,6 @@ def _split_pd_stage(
                 role="prefill",
                 partner=decode_name,
                 max_inflight_handoffs=pd.max_inflight_handoffs,
-                decode_pending_limit=pd.decode_pending_limit,
             ),
         },
     )
@@ -184,7 +183,6 @@ def _split_pd_stage(
                 role="decode",
                 partner=prefill_name,
                 max_inflight_handoffs=pd.max_inflight_handoffs,
-                decode_pending_limit=pd.decode_pending_limit,
             ),
         },
     )

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -145,6 +145,12 @@ class PDConfig(BaseModel):
 
     prefill: PDStagePlacement = Field(default_factory=PDStagePlacement)
     decode: PDStagePlacement = Field(default_factory=PDStagePlacement)
+    # Note (Audrey Zheng): how many handoffs the Prefill half may have in
+    # flight. Each one holds that request's prompt KV on the Prefill card
+    # until Decode acknowledges it, so this bounds how much of the Prefill
+    # pool sits in leases. Unset leaves the count where it lands today, which
+    # is Prefill's max_running_requests.
+    max_inflight_handoffs: int | None = Field(default=None, gt=0)
 
 
 class PDExecution(BaseModel):
@@ -159,6 +165,7 @@ class PDExecution(BaseModel):
 
     role: Literal["prefill", "decode"]
     partner: str
+    max_inflight_handoffs: int | None = None
 
 
 class StageConfig(BaseModel):

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -151,6 +151,10 @@ class PDConfig(BaseModel):
     # pool sits in leases. Unset leaves the count where it lands today, which
     # is Prefill's max_running_requests.
     max_inflight_handoffs: int | None = Field(default=None, gt=0)
+    # Note (Audrey Zheng): how much work Decode may have pending before
+    # Prefill stops producing more. Unset leaves Prefill unthrottled, which
+    # is how overload currently shows up as latency rather than as rejection.
+    decode_pending_limit: int | None = Field(default=None, gt=0)
 
 
 class PDExecution(BaseModel):
@@ -166,6 +170,7 @@ class PDExecution(BaseModel):
     role: Literal["prefill", "decode"]
     partner: str
     max_inflight_handoffs: int | None = None
+    decode_pending_limit: int | None = None
 
 
 class StageConfig(BaseModel):

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -151,10 +151,6 @@ class PDConfig(BaseModel):
     # pool sits in leases. Unset leaves the count where it lands today, which
     # is Prefill's max_running_requests.
     max_inflight_handoffs: int | None = Field(default=None, gt=0)
-    # Note (Audrey Zheng): how much work Decode may have pending before
-    # Prefill stops producing more. Unset leaves Prefill unthrottled, which
-    # is how overload currently shows up as latency rather than as rejection.
-    decode_pending_limit: int | None = Field(default=None, gt=0)
 
 
 class PDExecution(BaseModel):
@@ -170,7 +166,6 @@ class PDExecution(BaseModel):
     role: Literal["prefill", "decode"]
     partner: str
     max_inflight_handoffs: int | None = None
-    decode_pending_limit: int | None = None
 
 
 class StageConfig(BaseModel):

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -156,6 +156,9 @@ class Stage:
                 stage_name=name,
                 role=pd_execution.role,
                 partner=pd_execution.partner,
+                decode_pending_limit=getattr(
+                    pd_execution, "decode_pending_limit", None
+                ),
             )
             self._comm.register_kv_pool(pool)
             if receiver is not None:

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -1061,6 +1061,26 @@ class Stage:
                 except _queue_mod.Empty:
                     break
 
+    def _pd_handoff_gate(self) -> Any:
+        """Return the semaphore bounding handoffs in flight, or None if unset.
+
+        Each handoff holds that request's prompt KV on the Prefill card until
+        Decode acknowledges it, through ``SGLangKVPageLease``. Without this the
+        count lands on Prefill's ``max_running_requests``, which was chosen to
+        size batches rather than to bound leases: measured at 256 offered, the
+        Prefill half held 64 handoffs in flight, and at a 6127-token image
+        prompt that is 392,128 tokens of lease against a 344,253-token pool.
+        """
+        gate = self.__dict__.get("_pd_handoff_semaphore")
+        if gate is not None:
+            return gate
+        limit = getattr(self.pd_execution, "max_inflight_handoffs", None)
+        if not limit:
+            return None
+        gate = asyncio.Semaphore(int(limit))
+        self._pd_handoff_semaphore = gate
+        return gate
+
     def _launch_pd_handoff(self, request_id: str, handoff: Any) -> None:
         # Note (Yue Yin): ACK latency must not stop this stage from draining
         # scheduler output for unrelated requests.
@@ -1072,6 +1092,17 @@ class Stage:
         )
 
     async def _send_pd_handoff(self, request_id: str, handoff: Any) -> None:
+        gate = self._pd_handoff_gate()
+        if gate is None:
+            await self._send_pd_handoff_now(request_id, handoff)
+            return
+        # Note (Audrey Zheng): the wait happens inside the task, so the stage
+        # keeps draining scheduler output for unrelated requests while a
+        # handoff queues for a slot.
+        async with gate:
+            await self._send_pd_handoff_now(request_id, handoff)
+
+    async def _send_pd_handoff_now(self, request_id: str, handoff: Any) -> None:
         metadata = PrefillContinuationProducer(tp_size=1).prepare_rank_metadata(
             handoff.continuation,
             0,

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -1074,7 +1074,13 @@ class Stage:
         gate = self.__dict__.get("_pd_handoff_semaphore")
         if gate is not None:
             return gate
-        limit = getattr(self.pd_execution, "max_inflight_handoffs", None)
+        # Note (Audrey Zheng): read the attribute defensively. A stage that
+        # never went through __init__ has no pd_execution, and the
+        # AttributeError would be raised inside the handoff task, where it
+        # stops the send without the caller ever seeing why.
+        limit = getattr(
+            getattr(self, "pd_execution", None), "max_inflight_handoffs", None
+        )
         if not limit:
             return None
         gate = asyncio.Semaphore(int(limit))

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -156,9 +156,6 @@ class Stage:
                 stage_name=name,
                 role=pd_execution.role,
                 partner=pd_execution.partner,
-                decode_pending_limit=getattr(
-                    pd_execution, "decode_pending_limit", None
-                ),
             )
             self._comm.register_kv_pool(pool)
             if receiver is not None:
@@ -1102,8 +1099,21 @@ class Stage:
         # Note (Audrey Zheng): the wait happens inside the task, so the stage
         # keeps draining scheduler output for unrelated requests while a
         # handoff queues for a slot.
-        async with gate:
-            await self._send_pd_handoff_now(request_id, handoff)
+        #
+        # The request's prompt KV is already leased by the time this runs, so a
+        # cancellation during the wait has to release it here. Nothing
+        # downstream will: the send never starts, so `_send_pd_handoff_now`
+        # never reaches its `finally`. `release` is idempotent, so releasing
+        # here does not double-free when the send did start.
+        try:
+            async with gate:
+                await self._send_pd_handoff_now(request_id, handoff)
+        except asyncio.CancelledError:
+            lease = getattr(handoff, "lease", None)
+            if lease is not None:
+                lease.release()
+            self._clear_request_state(request_id)
+            raise
 
     async def _send_pd_handoff_now(self, request_id: str, handoff: Any) -> None:
         metadata = PrefillContinuationProducer(tp_size=1).prepare_rank_metadata(

--- a/sglang_omni/proto/messages.py
+++ b/sglang_omni/proto/messages.py
@@ -99,6 +99,17 @@ class DataReadyMessage:
         )
 
 
+def _optional_pending(value: Any) -> int | None:
+    """Parse ``receiver_pending``; absent stays absent, present must be valid."""
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError("receiver_pending must be int")
+    if value < 0:
+        raise ValueError("receiver_pending must not be negative")
+    return value
+
+
 class DataAckMessage(msgspec.Struct):
     """Receiver completion for one data-plane object."""
 
@@ -108,6 +119,12 @@ class DataAckMessage(msgspec.Struct):
     object_id: str
     success: bool = True
     error: str | None = None
+    # Note (Audrey Zheng): how many requests the receiver still holds when it
+    # sends this ack. The ack fires on commit, before the receiver admits the
+    # request, so its timing says nothing about admission. Its value is a
+    # reading taken at that moment, which is what a sender needs to pace
+    # itself. Optional so a peer that does not report it stays compatible.
+    receiver_pending: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         _require_str(self.request_id, "request_id")
@@ -131,6 +148,12 @@ class DataAckMessage(msgspec.Struct):
         }
         if self.error is not None:
             d["error"] = self.error
+        if self.receiver_pending is not None:
+            if not isinstance(self.receiver_pending, int):
+                raise TypeError("receiver_pending must be int")
+            if self.receiver_pending < 0:
+                raise ValueError("receiver_pending must not be negative")
+            d["receiver_pending"] = self.receiver_pending
         return d
 
     @classmethod
@@ -150,6 +173,7 @@ class DataAckMessage(msgspec.Struct):
             to_stage=_require_str(d.get("to_stage"), "to_stage"),
             object_id=_require_str(d.get("object_id"), "object_id"),
             success=success,
+            receiver_pending=_optional_pending(d.get("receiver_pending")),
             error=error,
         )
 

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -559,6 +559,8 @@ class OmniScheduler:
         stage_name: str,
         role: str,
         partner: str,
+        decode_pending_limit: int | None = None,
+        peer_pending_fn: Any = None,
     ) -> tuple[Any, Any | None]:
         if self.tp_size != 1:
             raise NotImplementedError("PR3 PD runtime supports tp_size == 1 only")
@@ -571,6 +573,10 @@ class OmniScheduler:
 
         self._pd_role = role
         self._pd_partner = partner
+        # Note (Audrey Zheng): None keeps the previous behaviour, which is no
+        # bound at all on what Decode accumulates.
+        self._pd_decode_pending_limit = decode_pending_limit
+        self._pd_peer_pending_fn = peer_pending_fn
         self._pd_pool_id = f"{stage_name}:kv"
         raw_pool = self.token_to_kv_pool_allocator.get_kvcache()
         layout_id = (
@@ -624,6 +630,7 @@ class OmniScheduler:
             receiver,
             controller,
             allowed_resume_schemas=self._pd_resume_schemas,
+            pending_depth_fn=self._pd_decode_depth,
         )
 
     def _drain_pd_admissions(self) -> None:
@@ -1598,7 +1605,67 @@ class OmniScheduler:
             }
             self._queue_pd_prefill_handoffs(batch, sampled_request_ids)
 
+    def _pd_decode_depth(self) -> int:
+        """Requests this Decode half is holding, waiting or running.
+
+        Read off the transfer ack by the Prefill half so it can pace itself.
+        Counts what is committed but not yet admitted alongside what the
+        scheduler already owns, because a request in either state is work this
+        half has accepted and not finished.
+        """
+        ready = self.__dict__.get("_pd_ready_queue")
+        depth = ready.qsize() if ready is not None else 0
+        if self.__dict__.get("_pd_deferred_admission") is not None:
+            depth += 1
+        waiting = self.__dict__.get("waiting_queue")
+        if waiting is not None:
+            depth += len(waiting)
+        running = self.__dict__.get("running_batch")
+        if running is not None and not running.is_empty():
+            depth += len(running.reqs)
+        return depth
+
+    def _pd_peer_pending(self) -> int | None:
+        """Newest depth the Decode half reported, or None if it never has.
+
+        The reading rides the transfer ack, which fires on commit rather than
+        on admission -- so its timing says nothing about when Decode admits.
+        Its value is a measurement taken at that moment, which is what a sender
+        needs to pace itself, and it costs no extra message.
+        """
+        reader = self.__dict__.get("_pd_peer_pending_fn")
+        if reader is None:
+            return None
+        try:
+            return reader()
+        except Exception:
+            logger.debug("peer pending read failed", exc_info=True)
+            return None
+
     def get_new_batch_prefill(self, running_batch):
+        # Note (Audrey Zheng): stop admitting when the Decode half is already
+        # holding more than it can work through. Colocated throttles admission
+        # implicitly, because prefill and decode contend for one card and one
+        # scheduler thread; splitting them removes that and nothing replaces
+        # it. Measured on two H200s at offered 16: Decode held about 437
+        # requests against `max_running_requests=64`, and a request took 40.96 s
+        # against 2.29 s colocated, while admission still read 100%.
+        #
+        # Holding here rather than at the handoff is deliberate. A request that
+        # already sampled cannot be kept in the Prefill batch -- it would
+        # continue decoding on the wrong half -- so the only safe place to stop
+        # is before its KV exists. The request waits in the Prefill queue and
+        # costs nothing.
+        limit = self.__dict__.get("_pd_decode_pending_limit")
+        if limit and self.__dict__.get("_pd_role") == "prefill":
+            pending = self._pd_peer_pending()
+            if pending is not None and pending >= limit:
+                logger.debug(
+                    "holding prefill admission: decode holds %d >= %d",
+                    pending,
+                    limit,
+                )
+                return NextBatchPlan(batch_to_run=None, running_batch=running_batch)
         # Note: (maydomine) batch prefill admissions to amortize the fixed step
         # cost; the oldest-request deadline survives partial admission and aborts.
         #

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -577,6 +577,7 @@ class OmniScheduler:
         # bound at all on what Decode accumulates.
         self._pd_decode_pending_limit = decode_pending_limit
         self._pd_peer_pending_fn = peer_pending_fn
+        self._warn_if_decode_queue_unbounded(stage_name, role)
         self._pd_pool_id = f"{stage_name}:kv"
         raw_pool = self.token_to_kv_pool_allocator.get_kvcache()
         layout_id = (
@@ -1604,6 +1605,33 @@ class OmniScheduler:
                 if len(req.output_ids) > output_lengths[id(req)]
             }
             self._queue_pd_prefill_handoffs(batch, sampled_request_ids)
+
+    def _warn_if_decode_queue_unbounded(self, stage_name: str, role: str) -> None:
+        """Say which admission policy is in effect on the Decode half.
+
+        A colocated replica throttles admission by contention -- prefill and
+        decode share a card and a scheduler thread, so accepting more work
+        slows the accepting. Splitting the halves removes that, and with no
+        queue bound the excess arrives as latency rather than as rejection:
+        measured at offered 16, Decode held about 437 requests and a request
+        took 40.96 s against 2.29 s colocated, while admission read 100%
+        throughout.
+
+        Unbounded is a legitimate choice for an offline workload and a poor
+        one for interactive serving, so state which one is in effect rather
+        than pick one.
+        """
+        if role != "decode":
+            return
+        if getattr(self.server_args, "max_queued_requests", 0):
+            return
+        logger.info(
+            "PD decode stage %s has no max_queued_requests, so its queue is "
+            "unbounded and overload will appear as latency rather than "
+            "rejection. Set --max_queued_requests to bound it; "
+            "models/qwen3_tts sets 16 for its generation stage.",
+            stage_name,
+        )
 
     def _pd_decode_depth(self) -> int:
         """Requests this Decode half is holding, waiting or running.

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -62,6 +62,7 @@ from sglang_omni.proto.admin import (
     ADMIN_WEIGHTS_CHECKER,
 )
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
+from sglang_omni.scheduling.pd_alloc_lock import LockedKVAllocator
 from sglang_omni.scheduling.pd_continuation import (
     ContinuationAwareKVReceiver,
     PDHandoffController,
@@ -598,6 +599,13 @@ class OmniScheduler:
         self.batch_result_processor = dataclasses.replace(
             self.batch_result_processor,
             disaggregation_mode=DisaggregationMode.DECODE,
+        )
+        # Note (Audrey Zheng): from here the allocator has two callers on two
+        # threads -- this scheduler, and the comm event loop through the
+        # receiver below -- and its alloc is a read-modify-write with no lock
+        # of its own. Wrap it once, before either side is handed it.
+        self.token_to_kv_pool_allocator = LockedKVAllocator(
+            self.token_to_kv_pool_allocator
         )
         receiver = AllocatorKVReceiver(
             pool_id=self._pd_pool_id,

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -560,8 +560,6 @@ class OmniScheduler:
         stage_name: str,
         role: str,
         partner: str,
-        decode_pending_limit: int | None = None,
-        peer_pending_fn: Any = None,
     ) -> tuple[Any, Any | None]:
         if self.tp_size != 1:
             raise NotImplementedError("PR3 PD runtime supports tp_size == 1 only")
@@ -574,10 +572,6 @@ class OmniScheduler:
 
         self._pd_role = role
         self._pd_partner = partner
-        # Note (Audrey Zheng): None keeps the previous behaviour, which is no
-        # bound at all on what Decode accumulates.
-        self._pd_decode_pending_limit = decode_pending_limit
-        self._pd_peer_pending_fn = peer_pending_fn
         self._warn_if_decode_queue_unbounded(stage_name, role)
         self._pd_pool_id = f"{stage_name}:kv"
         raw_pool = self.token_to_kv_pool_allocator.get_kvcache()
@@ -1644,10 +1638,16 @@ class OmniScheduler:
     def _pd_decode_depth(self) -> int:
         """Requests this Decode half is holding, waiting or running.
 
-        Read off the transfer ack by the Prefill half so it can pace itself.
-        Counts what is committed but not yet admitted alongside what the
-        scheduler already owns, because a request in either state is work this
-        half has accepted and not finished.
+        Rides the transfer ack, so it costs no extra message. Counts what is
+        committed but not yet admitted alongside what the scheduler already
+        owns, because a request in either state is work this half has accepted
+        and not finished.
+
+        Reported, not acted on. The ack fires on commit, so the reading stops
+        arriving exactly when Prefill stops sending, and a bound built on it
+        would hold on a stale high-water value with nothing to lower it. A
+        bound on what Decode accumulates needs a capacity return that does not
+        ride the producer's traffic.
         """
         ready = self.__dict__.get("_pd_ready_queue")
         depth = ready.qsize() if ready is not None else 0
@@ -1661,47 +1661,7 @@ class OmniScheduler:
             depth += len(running.reqs)
         return depth
 
-    def _pd_peer_pending(self) -> int | None:
-        """Newest depth the Decode half reported, or None if it never has.
-
-        The reading rides the transfer ack, which fires on commit rather than
-        on admission -- so its timing says nothing about when Decode admits.
-        Its value is a measurement taken at that moment, which is what a sender
-        needs to pace itself, and it costs no extra message.
-        """
-        reader = self.__dict__.get("_pd_peer_pending_fn")
-        if reader is None:
-            return None
-        try:
-            return reader()
-        except Exception:
-            logger.debug("peer pending read failed", exc_info=True)
-            return None
-
     def get_new_batch_prefill(self, running_batch):
-        # Note (Audrey Zheng): stop admitting when the Decode half is already
-        # holding more than it can work through. Colocated throttles admission
-        # implicitly, because prefill and decode contend for one card and one
-        # scheduler thread; splitting them removes that and nothing replaces
-        # it. Measured on two H200s at offered 16: Decode held about 437
-        # requests against `max_running_requests=64`, and a request took 40.96 s
-        # against 2.29 s colocated, while admission still read 100%.
-        #
-        # Holding here rather than at the handoff is deliberate. A request that
-        # already sampled cannot be kept in the Prefill batch -- it would
-        # continue decoding on the wrong half -- so the only safe place to stop
-        # is before its KV exists. The request waits in the Prefill queue and
-        # costs nothing.
-        limit = self.__dict__.get("_pd_decode_pending_limit")
-        if limit and self.__dict__.get("_pd_role") == "prefill":
-            pending = self._pd_peer_pending()
-            if pending is not None and pending >= limit:
-                logger.debug(
-                    "holding prefill admission: decode holds %d >= %d",
-                    pending,
-                    limit,
-                )
-                return NextBatchPlan(batch_to_run=None, running_batch=running_batch)
         # Note: (maydomine) batch prefill admissions to amortize the fixed step
         # cost; the oldest-request deadline survives partial admission and aborts.
         #

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -594,13 +594,7 @@ class OmniScheduler:
             self.batch_result_processor,
             disaggregation_mode=DisaggregationMode.DECODE,
         )
-        # Note (Audrey Zheng): from here the allocator has two callers on two
-        # threads -- this scheduler, and the comm event loop through the
-        # receiver below -- and its alloc is a read-modify-write with no lock
-        # of its own. Wrap it once, before either side is handed it.
-        self.token_to_kv_pool_allocator = LockedKVAllocator(
-            self.token_to_kv_pool_allocator
-        )
+        self._install_locked_kv_allocator()
         receiver = AllocatorKVReceiver(
             pool_id=self._pd_pool_id,
             token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
@@ -1634,6 +1628,54 @@ class OmniScheduler:
             "models/qwen3_tts sets 16 for its generation stage.",
             stage_name,
         )
+
+    # Note (Audrey Zheng): the holders that call alloc or free on the KV
+    # allocator. `bootstrap.py` hands the same object to each of them before
+    # this scheduler exists, so rebinding only our own attribute would leave
+    # three unsynchronised aliases.
+    _KV_ALLOCATOR_HOLDERS = ("tree_cache", "prefill_manager", "decode_manager")
+
+    def _install_locked_kv_allocator(self) -> None:
+        """Give every holder of the KV allocator the same locked object.
+
+        From here the allocator has two callers on two threads -- this
+        scheduler and the comm event loop, through the receiver -- and its
+        alloc is a read-modify-write with no lock of its own. One lock only
+        helps if every caller goes through it, so the wrapper has to reach the
+        tree cache and both managers as well.
+
+        Rebinding after construction rather than wrapping in `bootstrap.py` is
+        deliberate: upstream's `SWAChunkCache.__init__` asserts the allocator's
+        concrete type, and a proxy handed to the constructor would fail that
+        assert for models that use it.
+
+        This covers the holders that exist today. `_kv_allocator_holders`
+        reports what was rebound so a test can assert they all agree, which is
+        what would catch a fourth holder appearing.
+        """
+        locked = LockedKVAllocator(self.token_to_kv_pool_allocator)
+        self.token_to_kv_pool_allocator = locked
+        for name in self._KV_ALLOCATOR_HOLDERS:
+            holder = getattr(self, name, None)
+            if holder is None:
+                continue
+            if not hasattr(holder, "token_to_kv_pool_allocator"):
+                raise RuntimeError(
+                    f"PD decode half: {name} has no token_to_kv_pool_allocator "
+                    "to rebind, so its allocations would bypass the lock"
+                )
+            holder.token_to_kv_pool_allocator = locked
+
+    def _kv_allocator_holders(self) -> dict[str, Any]:
+        """Every allocator reference this scheduler can reach, by holder name."""
+        found: dict[str, Any] = {
+            "scheduler": self.__dict__.get("token_to_kv_pool_allocator")
+        }
+        for name in self._KV_ALLOCATOR_HOLDERS:
+            holder = getattr(self, name, None)
+            if holder is not None:
+                found[name] = getattr(holder, "token_to_kv_pool_allocator", None)
+        return found
 
     def _pd_decode_depth(self) -> int:
         """Requests this Decode half is holding, waiting or running.

--- a/sglang_omni/scheduling/pd_alloc_lock.py
+++ b/sglang_omni/scheduling/pd_alloc_lock.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Serialize KV allocation between the two threads a Decode half runs.
+
+``TokenToKVPoolAllocator.alloc`` reads ``free_pages``, slices the leading
+entries, and writes the remainder back. Nothing in
+``sglang/srt/mem_cache/allocator`` holds a lock, which is correct while one
+thread owns the allocator.
+
+A PD Decode half has two. The scheduler thread allocates for decode steps.
+The comm event loop allocates inside ``prepare_kv_receive`` ->
+``AllocatorKVReceiver.reserve``, and ``bind_pd_runtime`` hands it the same
+allocator instance. Two callers that interleave between the read and the
+write receive the same slots.
+
+Measured on two H200s with both calls recorded: one 3,000-request run logged
+21,309 slots handed to one thread while the other still held them, and the
+requests that received them returned empty completions.
+
+This wraps the allocator so both callers take one lock. Everything else is
+delegated untouched, so the allocator's own behaviour is unchanged.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+
+class LockedKVAllocator:
+    """Delegate to *inner*, holding a lock across ``alloc`` and ``free``.
+
+    Only the two methods that mutate the free list are guarded. The lock is
+    uncontended on the scheduler thread except when a transfer is reserving,
+    so the cost on the decode path is one uncontended acquire per step.
+    """
+
+    def __init__(self, inner: Any) -> None:
+        # Note (Audrey Zheng): set through __dict__ because __setattr__ below
+        # forwards to the wrapped allocator.
+        self.__dict__["_inner"] = inner
+        self.__dict__["_alloc_lock"] = threading.Lock()
+
+    def alloc(self, need_size: int) -> Any:
+        with self.__dict__["_alloc_lock"]:
+            return self.__dict__["_inner"].alloc(need_size)
+
+    def free(self, free_index: Any) -> Any:
+        with self.__dict__["_alloc_lock"]:
+            return self.__dict__["_inner"].free(free_index)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.__dict__["_inner"], name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        setattr(self.__dict__["_inner"], name, value)
+
+    def __repr__(self) -> str:
+        return f"LockedKVAllocator({self.__dict__['_inner']!r})"

--- a/sglang_omni/scheduling/pd_continuation.py
+++ b/sglang_omni/scheduling/pd_continuation.py
@@ -76,6 +76,12 @@ class DecodeContinuation:
     speculative: bool = False
     multimodal_resume: dict[str, Any] | None = None
     stage_payload: dict[str, Any] | None = None
+    # Note (Audrey Zheng): the Decode half runs its own waiting queue, and both
+    # the queue-limit eviction and retraction rank requests by priority. A
+    # continuation that drops it hands Decode a request whose importance is
+    # unknown, so those rankings fall back to arrival order and an interactive
+    # request cannot outrank a batch one after the handoff.
+    priority: int | None = None
 
     def __post_init__(self) -> None:
         if self.version != CONTINUATION_VERSION:

--- a/sglang_omni/scheduling/pd_continuation.py
+++ b/sglang_omni/scheduling/pd_continuation.py
@@ -492,13 +492,30 @@ class ContinuationAwareKVReceiver:
         target_tp_size: int = 1,
         is_local: bool = True,
         allowed_resume_schemas: frozenset[str] = frozenset(),
+        pending_depth_fn: Callable[[], int] | None = None,
     ) -> None:
+        self._pending_depth_fn = pending_depth_fn
         self._inner = inner
         self._controller = controller
         self._source_tp_size = source_tp_size
         self._target_tp_size = target_tp_size
         self._is_local = is_local
         self._allowed_resume_schemas = allowed_resume_schemas
+
+    def pending_depth(self) -> int | None:
+        """Requests this Decode half is holding, or None if it cannot say.
+
+        The sender reads this off the ack to pace itself. Returning None keeps a
+        receiver that has no such notion out of the sender's decision entirely,
+        rather than telling it zero.
+        """
+        if self._pending_depth_fn is None:
+            return None
+        try:
+            return max(0, int(self._pending_depth_fn()))
+        except Exception:
+            logger.debug("pending_depth_fn failed", exc_info=True)
+            return None
 
     def reserve(self, request: KVTransferPrepareMessage) -> KVPageDestination:
         continuation, continuation_expected = self._decode_metadata(request)

--- a/sglang_omni/scheduling/pd_runtime.py
+++ b/sglang_omni/scheduling/pd_runtime.py
@@ -93,6 +93,7 @@ def continuation_from_req(
         speculative=False,
         multimodal_resume=multimodal_resume,
         stage_payload=stage_payload_dict,
+        priority=req.priority,
     )
 
 
@@ -133,6 +134,7 @@ def req_from_continuation(
             else None
         ),
         vocab_size=continuation.vocab_size,
+        priority=continuation.priority,
     )
     req.output_ids.extend(continuation.output_ids)
     req.cached_tokens = continuation.cached_tokens

--- a/tests/unit_test/pipeline/test_pd_alloc_lock.py
+++ b/tests/unit_test/pipeline/test_pd_alloc_lock.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+"""One lock across the two threads a PD Decode half allocates from.
+
+The allocator's alloc reads the free list, slices it, and writes the
+remainder back, with no lock of its own. On a Decode half the scheduler
+thread and the comm event loop both call it, and interleaving there hands
+the same slots to both.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from sglang_omni.scheduling.pd_alloc_lock import LockedKVAllocator
+
+
+class _RacyAllocator:
+    """An allocator with the same read-modify-write shape as upstream's."""
+
+    def __init__(self, size: int) -> None:
+        self.free_pages = list(range(size))
+        self.page_size = 1
+        self.handed_out: list[int] = []
+
+    def alloc(self, need_size: int):
+        taken = self.free_pages[:need_size]
+        # A thread switch here is what produces the overlap in production.
+        threading.current_thread()
+        self.free_pages = self.free_pages[need_size:]
+        self.handed_out.extend(taken)
+        return taken
+
+    def free(self, index) -> None:
+        self.free_pages.extend(index)
+
+    def available_size(self) -> int:
+        return len(self.free_pages)
+
+
+def test_two_threads_never_receive_the_same_slot() -> None:
+    inner = _RacyAllocator(4096)
+    allocator = LockedKVAllocator(inner)
+    seen: list[int] = []
+    lock = threading.Lock()
+
+    def take() -> None:
+        for _ in range(64):
+            got = allocator.alloc(4)
+            with lock:
+                seen.extend(got)
+
+    threads = [threading.Thread(target=take) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(seen) == len(set(seen))
+
+
+def test_everything_else_is_delegated() -> None:
+    inner = _RacyAllocator(16)
+    allocator = LockedKVAllocator(inner)
+
+    assert allocator.available_size() == 16
+    assert allocator.page_size == 1
+
+
+def test_a_write_reaches_the_wrapped_allocator() -> None:
+    """Upstream code sets attributes on the allocator it was handed."""
+    inner = _RacyAllocator(16)
+    allocator = LockedKVAllocator(inner)
+
+    allocator.page_size = 4
+
+    assert inner.page_size == 4
+
+
+def test_freeing_returns_the_slots() -> None:
+    inner = _RacyAllocator(8)
+    allocator = LockedKVAllocator(inner)
+
+    taken = allocator.alloc(8)
+    assert allocator.available_size() == 0
+
+    allocator.free(taken)
+    assert allocator.available_size() == 8

--- a/tests/unit_test/pipeline/test_pd_alloc_lock.py
+++ b/tests/unit_test/pipeline/test_pd_alloc_lock.py
@@ -11,7 +11,19 @@ from __future__ import annotations
 
 import threading
 
+import pytest
+
 from sglang_omni.scheduling.pd_alloc_lock import LockedKVAllocator
+
+
+class _FakeAllocator:
+    """Stands in for the real allocator; only identity matters here."""
+
+    def alloc(self, n):  # pragma: no cover - never called
+        return list(range(n))
+
+    def free(self, indices):  # pragma: no cover - never called
+        return None
 
 
 class _RacyAllocator:
@@ -85,3 +97,43 @@ def test_freeing_returns_the_slots() -> None:
 
     allocator.free(taken)
     assert allocator.available_size() == 8
+
+
+def test_every_holder_of_the_allocator_gets_the_same_locked_object() -> None:
+    """One lock only helps if no caller keeps an unwrapped alias."""
+    from types import SimpleNamespace
+
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+    raw = _FakeAllocator()
+    scheduler = OmniScheduler.__new__(OmniScheduler)
+    scheduler.token_to_kv_pool_allocator = raw
+    scheduler.tree_cache = SimpleNamespace(token_to_kv_pool_allocator=raw)
+    scheduler.prefill_manager = SimpleNamespace(token_to_kv_pool_allocator=raw)
+    scheduler.decode_manager = SimpleNamespace(token_to_kv_pool_allocator=raw)
+
+    scheduler._install_locked_kv_allocator()
+
+    holders = scheduler._kv_allocator_holders()
+    assert set(holders) == {
+        "scheduler",
+        "tree_cache",
+        "prefill_manager",
+        "decode_manager",
+    }
+    assert len({id(a) for a in holders.values()}) == 1
+    assert all(isinstance(a, LockedKVAllocator) for a in holders.values())
+
+
+def test_a_holder_that_cannot_be_rebound_is_an_error() -> None:
+    """Silently skipping it would leave an alias outside the lock."""
+    from types import SimpleNamespace
+
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+    scheduler = OmniScheduler.__new__(OmniScheduler)
+    scheduler.token_to_kv_pool_allocator = _FakeAllocator()
+    scheduler.tree_cache = SimpleNamespace()  # no allocator attribute
+
+    with pytest.raises(RuntimeError, match="would bypass the lock"):
+        scheduler._install_locked_kv_allocator()

--- a/tests/unit_test/pipeline/test_pd_backpressure.py
+++ b/tests/unit_test/pipeline/test_pd_backpressure.py
@@ -82,9 +82,7 @@ def test_the_ack_carries_the_depth_across_the_wire() -> None:
 
 def test_a_peer_that_omits_the_depth_stays_compatible() -> None:
     """An older peer sends no such field, and that is not an error."""
-    ack = DataAckMessage(
-        request_id="r", from_stage="d", to_stage="p", object_id="o"
-    )
+    ack = DataAckMessage(request_id="r", from_stage="d", to_stage="p", object_id="o")
     wire = ack.to_dict()
 
     assert "receiver_pending" not in wire
@@ -109,7 +107,7 @@ def test_an_unbounded_decode_queue_is_stated_at_bind(caplog) -> None:
 
 
 def test_the_notice_points_at_a_precedent(caplog) -> None:
-    """"Set something" without a reference leaves the operator guessing."""
+    """ "Set something" without a reference leaves the operator guessing."""
     scheduler = _half("decode", 0)
 
     with caplog.at_level(logging.INFO, logger=_LOGGER):

--- a/tests/unit_test/pipeline/test_pd_backpressure.py
+++ b/tests/unit_test/pipeline/test_pd_backpressure.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prefill stops admitting when the Decode half is holding too much."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from sglang_omni.proto.messages import DataAckMessage
+from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+
+def _prefill(limit, depth) -> OmniScheduler:
+    scheduler = OmniScheduler.__new__(OmniScheduler)
+    scheduler._pd_role = "prefill"
+    scheduler._pd_decode_pending_limit = limit
+    scheduler._pd_peer_pending_fn = (lambda: depth) if depth is not None else None
+    return scheduler
+
+
+def test_no_limit_reads_as_no_backpressure() -> None:
+    """The default keeps the previous behaviour: nothing bounds Decode."""
+    assert _prefill(None, 500)._pd_decode_pending_limit is None
+
+
+def test_the_depth_is_read_through_the_installed_reader() -> None:
+    assert _prefill(64, 437)._pd_peer_pending() == 437
+
+
+def test_a_reader_that_raises_reports_no_reading() -> None:
+    """A failed read must not stop admission; it is a pacing hint, not a gate."""
+
+    def boom() -> int:
+        raise RuntimeError("no peer yet")
+
+    scheduler = _prefill(64, 0)
+    scheduler._pd_peer_pending_fn = boom
+
+    assert scheduler._pd_peer_pending() is None
+
+
+def test_a_peer_that_never_reported_reads_as_none() -> None:
+    assert _prefill(64, None)._pd_peer_pending() is None
+
+
+def test_the_decode_depth_counts_every_accepted_request() -> None:
+    """Committed-but-unadmitted work counts too; the half has accepted it."""
+    scheduler = OmniScheduler.__new__(OmniScheduler)
+    scheduler._pd_ready_queue = SimpleNamespace(qsize=lambda: 3)
+    scheduler._pd_deferred_admission = object()
+    scheduler.waiting_queue = [object(), object()]
+    scheduler.running_batch = SimpleNamespace(
+        is_empty=lambda: False, reqs=[object()] * 4
+    )
+
+    assert scheduler._pd_decode_depth() == 3 + 1 + 2 + 4
+
+
+def test_an_idle_decode_half_reports_zero() -> None:
+    scheduler = OmniScheduler.__new__(OmniScheduler)
+    scheduler._pd_ready_queue = SimpleNamespace(qsize=lambda: 0)
+    scheduler._pd_deferred_admission = None
+    scheduler.waiting_queue = []
+    scheduler.running_batch = SimpleNamespace(is_empty=lambda: True, reqs=[])
+
+    assert scheduler._pd_decode_depth() == 0
+
+
+def test_the_ack_carries_the_depth_across_the_wire() -> None:
+    ack = DataAckMessage(
+        request_id="r",
+        from_stage="thinker_decode",
+        to_stage="thinker_prefill",
+        object_id="o",
+        receiver_pending=437,
+    )
+
+    assert DataAckMessage.from_dict(ack.to_dict()).receiver_pending == 437
+
+
+def test_a_peer_that_omits_the_depth_stays_compatible() -> None:
+    """An older peer sends no such field, and that is not an error."""
+    ack = DataAckMessage(
+        request_id="r", from_stage="d", to_stage="p", object_id="o"
+    )
+    wire = ack.to_dict()
+
+    assert "receiver_pending" not in wire
+    assert DataAckMessage.from_dict(wire).receiver_pending is None

--- a/tests/unit_test/pipeline/test_pd_backpressure.py
+++ b/tests/unit_test/pipeline/test_pd_backpressure.py
@@ -3,10 +3,13 @@
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 
 from sglang_omni.proto.messages import DataAckMessage
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+_LOGGER = "sglang_omni.scheduling.omni_scheduler"
 
 
 def _prefill(limit, depth) -> OmniScheduler:
@@ -86,3 +89,49 @@ def test_a_peer_that_omits_the_depth_stays_compatible() -> None:
 
     assert "receiver_pending" not in wire
     assert DataAckMessage.from_dict(wire).receiver_pending is None
+
+
+def _half(role: str, max_queued: int) -> OmniScheduler:
+    scheduler = OmniScheduler.__new__(OmniScheduler)
+    scheduler.server_args = SimpleNamespace(max_queued_requests=max_queued)
+    return scheduler
+
+
+def test_an_unbounded_decode_queue_is_stated_at_bind(caplog) -> None:
+    """Otherwise the operator sees 100% admission and 41-second requests."""
+    scheduler = _half("decode", 0)
+
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        scheduler._warn_if_decode_queue_unbounded("thinker_decode", "decode")
+
+    assert len(caplog.records) == 1
+    assert "thinker_decode" in caplog.records[0].getMessage()
+
+
+def test_the_notice_points_at_a_precedent(caplog) -> None:
+    """"Set something" without a reference leaves the operator guessing."""
+    scheduler = _half("decode", 0)
+
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        scheduler._warn_if_decode_queue_unbounded("thinker_decode", "decode")
+
+    assert "qwen3_tts" in caplog.records[0].getMessage()
+
+
+def test_a_bounded_queue_says_nothing(caplog) -> None:
+    scheduler = _half("decode", 16)
+
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        scheduler._warn_if_decode_queue_unbounded("thinker_decode", "decode")
+
+    assert caplog.records == []
+
+
+def test_the_prefill_half_says_nothing(caplog) -> None:
+    """The queue this describes is the Decode half's."""
+    scheduler = _half("prefill", 0)
+
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        scheduler._warn_if_decode_queue_unbounded("thinker_prefill", "prefill")
+
+    assert caplog.records == []

--- a/tests/unit_test/pipeline/test_pd_backpressure.py
+++ b/tests/unit_test/pipeline/test_pd_backpressure.py
@@ -135,3 +135,39 @@ def test_the_prefill_half_says_nothing(caplog) -> None:
         scheduler._warn_if_decode_queue_unbounded("thinker_prefill", "prefill")
 
     assert caplog.records == []
+
+
+def test_priority_survives_the_handoff() -> None:
+    """Decode ranks its waiting queue by priority; a dropped one ranks by arrival."""
+    from sglang_omni.scheduling.pd_continuation import DecodeContinuation
+
+    continuation = DecodeContinuation(
+        request_id="req-1",
+        transfer_id="t-1",
+        origin_input_ids=[1, 2],
+        output_ids=[3],
+        vocab_size=32,
+        sampling_params={},
+        cached_tokens=0,
+        priority=7,
+    )
+
+    assert DecodeContinuation.from_dict(continuation.to_dict()).priority == 7
+
+
+def test_a_continuation_without_a_priority_stays_valid() -> None:
+    """Priority is optional upstream, so its absence is not a schema error."""
+    from sglang_omni.scheduling.pd_continuation import DecodeContinuation
+
+    payload = DecodeContinuation(
+        request_id="req-1",
+        transfer_id="t-1",
+        origin_input_ids=[1],
+        output_ids=[2],
+        vocab_size=32,
+        sampling_params={},
+        cached_tokens=0,
+    ).to_dict()
+    payload.pop("priority")
+
+    assert DecodeContinuation.from_dict(payload).priority is None

--- a/tests/unit_test/pipeline/test_pd_backpressure.py
+++ b/tests/unit_test/pipeline/test_pd_backpressure.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Prefill stops admitting when the Decode half is holding too much."""
+"""The Decode half reports how much it is holding, on the transfer ack."""
 
 from __future__ import annotations
 
@@ -10,39 +10,6 @@ from sglang_omni.proto.messages import DataAckMessage
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler
 
 _LOGGER = "sglang_omni.scheduling.omni_scheduler"
-
-
-def _prefill(limit, depth) -> OmniScheduler:
-    scheduler = OmniScheduler.__new__(OmniScheduler)
-    scheduler._pd_role = "prefill"
-    scheduler._pd_decode_pending_limit = limit
-    scheduler._pd_peer_pending_fn = (lambda: depth) if depth is not None else None
-    return scheduler
-
-
-def test_no_limit_reads_as_no_backpressure() -> None:
-    """The default keeps the previous behaviour: nothing bounds Decode."""
-    assert _prefill(None, 500)._pd_decode_pending_limit is None
-
-
-def test_the_depth_is_read_through_the_installed_reader() -> None:
-    assert _prefill(64, 437)._pd_peer_pending() == 437
-
-
-def test_a_reader_that_raises_reports_no_reading() -> None:
-    """A failed read must not stop admission; it is a pacing hint, not a gate."""
-
-    def boom() -> int:
-        raise RuntimeError("no peer yet")
-
-    scheduler = _prefill(64, 0)
-    scheduler._pd_peer_pending_fn = boom
-
-    assert scheduler._pd_peer_pending() is None
-
-
-def test_a_peer_that_never_reported_reads_as_none() -> None:
-    assert _prefill(64, None)._pd_peer_pending() is None
 
 
 def test_the_decode_depth_counts_every_accepted_request() -> None:

--- a/tests/unit_test/pipeline/test_pd_handoff_gate.py
+++ b/tests/unit_test/pipeline/test_pd_handoff_gate.py
@@ -108,3 +108,45 @@ def test_an_unset_bound_stays_unset_through_the_rewrite() -> None:
     halves = {s.name: s for s in expand_pd_stages(stages, entry_stage="thinker").stages}
 
     assert halves["thinker_prefill"].pd_execution.max_inflight_handoffs is None
+
+
+def test_the_decode_bound_reaches_both_halves() -> None:
+    """Prefill needs it to throttle; Decode carries it so the pair agrees."""
+    from sglang_omni.config import expand_pd_stages
+    from sglang_omni.config.schema import PDStagePlacement
+
+    stages = [
+        stage(
+            "thinker",
+            terminal=True,
+            pd_disaggregation=PDConfig(
+                prefill=PDStagePlacement(gpu=0),
+                decode=PDStagePlacement(gpu=1),
+                decode_pending_limit=64,
+            ),
+        )
+    ]
+
+    halves = {s.name: s for s in expand_pd_stages(stages, entry_stage="thinker").stages}
+
+    assert halves["thinker_prefill"].pd_execution.decode_pending_limit == 64
+    assert halves["thinker_decode"].pd_execution.decode_pending_limit == 64
+
+
+def test_an_unset_decode_bound_leaves_prefill_unthrottled() -> None:
+    from sglang_omni.config import expand_pd_stages
+    from sglang_omni.config.schema import PDStagePlacement
+
+    stages = [
+        stage(
+            "thinker",
+            terminal=True,
+            pd_disaggregation=PDConfig(
+                prefill=PDStagePlacement(gpu=0), decode=PDStagePlacement(gpu=1)
+            ),
+        )
+    ]
+
+    halves = {s.name: s for s in expand_pd_stages(stages, entry_stage="thinker").stages}
+
+    assert halves["thinker_prefill"].pd_execution.decode_pending_limit is None

--- a/tests/unit_test/pipeline/test_pd_handoff_gate.py
+++ b/tests/unit_test/pipeline/test_pd_handoff_gate.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounding how many PD handoffs are in flight at once.
+
+Each handoff holds that request's prompt KV on the Prefill card until Decode
+acknowledges it. Without a bound the count lands on Prefill's
+max_running_requests, which sizes batches rather than leases.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from sglang_omni.config.schema import PDConfig, PDExecution
+from sglang_omni.pipeline.stage.runtime import Stage
+from tests.unit_test.pipeline.helpers import stage
+
+
+def _runtime(limit: int | None) -> Stage:
+    runtime = Stage.__new__(Stage)
+    runtime.pd_execution = PDExecution(
+        role="prefill", partner="thinker_decode", max_inflight_handoffs=limit
+    )
+    return runtime
+
+
+def test_an_unset_bound_installs_no_gate() -> None:
+    """Leaving it unset keeps today's behaviour rather than picking a number."""
+    assert _runtime(None)._pd_handoff_gate() is None
+
+
+def test_a_set_bound_installs_a_semaphore_of_that_size() -> None:
+    gate = _runtime(4)._pd_handoff_gate()
+
+    assert gate._value == 4
+
+
+def test_the_same_gate_is_reused_across_handoffs() -> None:
+    """A fresh semaphore per handoff would bound nothing."""
+    runtime = _runtime(4)
+
+    assert runtime._pd_handoff_gate() is runtime._pd_handoff_gate()
+
+
+def test_the_gate_admits_only_its_bound_at_once() -> None:
+    async def scenario() -> tuple[int, int]:
+        gate = _runtime(2)._pd_handoff_gate()
+        live = 0
+        peak = 0
+        release = asyncio.Event()
+
+        async def held() -> None:
+            nonlocal live, peak
+            async with gate:
+                live += 1
+                peak = max(peak, live)
+                await release.wait()
+                live -= 1
+
+        tasks = [asyncio.create_task(held()) for _ in range(6)]
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        observed = peak
+        release.set()
+        await asyncio.gather(*tasks)
+        return observed, peak
+
+    observed, _ = asyncio.run(scenario())
+    assert observed == 2
+
+
+def test_the_bound_reaches_both_halves_from_one_setting() -> None:
+    """It is a property of the pair, so the rewrite copies it to each half."""
+    from sglang_omni.config import expand_pd_stages
+    from sglang_omni.config.schema import PDStagePlacement
+
+    stages = [
+        stage(
+            "thinker",
+            terminal=True,
+            pd_disaggregation=PDConfig(
+                prefill=PDStagePlacement(gpu=0),
+                decode=PDStagePlacement(gpu=1),
+                max_inflight_handoffs=8,
+            ),
+        )
+    ]
+
+    halves = {s.name: s for s in expand_pd_stages(stages, entry_stage="thinker").stages}
+
+    assert halves["thinker_prefill"].pd_execution.max_inflight_handoffs == 8
+    assert halves["thinker_decode"].pd_execution.max_inflight_handoffs == 8
+
+
+def test_an_unset_bound_stays_unset_through_the_rewrite() -> None:
+    from sglang_omni.config import expand_pd_stages
+    from sglang_omni.config.schema import PDStagePlacement
+
+    stages = [
+        stage(
+            "thinker",
+            terminal=True,
+            pd_disaggregation=PDConfig(
+                prefill=PDStagePlacement(gpu=0), decode=PDStagePlacement(gpu=1)
+            ),
+        )
+    ]
+
+    halves = {s.name: s for s in expand_pd_stages(stages, entry_stage="thinker").stages}
+
+    assert halves["thinker_prefill"].pd_execution.max_inflight_handoffs is None

--- a/tests/unit_test/pipeline/test_pd_handoff_gate.py
+++ b/tests/unit_test/pipeline/test_pd_handoff_gate.py
@@ -9,6 +9,7 @@ max_running_requests, which sizes batches rather than leases.
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 from sglang_omni.config.schema import PDConfig, PDExecution
 from sglang_omni.pipeline.stage.runtime import Stage
@@ -110,43 +111,60 @@ def test_an_unset_bound_stays_unset_through_the_rewrite() -> None:
     assert halves["thinker_prefill"].pd_execution.max_inflight_handoffs is None
 
 
-def test_the_decode_bound_reaches_both_halves() -> None:
-    """Prefill needs it to throttle; Decode carries it so the pair agrees."""
-    from sglang_omni.config import expand_pd_stages
-    from sglang_omni.config.schema import PDStagePlacement
+def test_cancelling_while_queued_releases_the_prompt_kv() -> None:
+    """The lease exists before the wait, so nothing downstream can release it."""
 
-    stages = [
-        stage(
-            "thinker",
-            terminal=True,
-            pd_disaggregation=PDConfig(
-                prefill=PDStagePlacement(gpu=0),
-                decode=PDStagePlacement(gpu=1),
-                decode_pending_limit=64,
-            ),
-        )
-    ]
+    class _Lease:
+        def __init__(self) -> None:
+            self.released = 0
 
-    halves = {s.name: s for s in expand_pd_stages(stages, entry_stage="thinker").stages}
+        def release(self) -> None:
+            self.released += 1
 
-    assert halves["thinker_prefill"].pd_execution.decode_pending_limit == 64
-    assert halves["thinker_decode"].pd_execution.decode_pending_limit == 64
+    lease = _Lease()
+    handoff = SimpleNamespace(lease=lease)
+    runtime = _runtime(1)
+    cleared: list[str] = []
+    runtime._clear_request_state = cleared.append
+
+    async def scenario() -> None:
+        gate = runtime._pd_handoff_gate()
+        await gate.acquire()  # the one permit is taken by another handoff
+        queued = asyncio.create_task(runtime._send_pd_handoff("req-1", handoff))
+        await asyncio.sleep(0)
+        queued.cancel()
+        try:
+            await queued
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(scenario())
+
+    assert lease.released == 1
+    assert cleared == ["req-1"]
 
 
-def test_an_unset_decode_bound_leaves_prefill_unthrottled() -> None:
-    from sglang_omni.config import expand_pd_stages
-    from sglang_omni.config.schema import PDStagePlacement
+def test_a_handoff_that_never_waited_is_left_to_the_send_path() -> None:
+    """With a free permit the send runs and owns the lease, so no double free."""
 
-    stages = [
-        stage(
-            "thinker",
-            terminal=True,
-            pd_disaggregation=PDConfig(
-                prefill=PDStagePlacement(gpu=0), decode=PDStagePlacement(gpu=1)
-            ),
-        )
-    ]
+    class _Lease:
+        def __init__(self) -> None:
+            self.released = 0
 
-    halves = {s.name: s for s in expand_pd_stages(stages, entry_stage="thinker").stages}
+        def release(self) -> None:
+            self.released += 1
 
-    assert halves["thinker_prefill"].pd_execution.decode_pending_limit is None
+    lease = _Lease()
+    handoff = SimpleNamespace(lease=lease)
+    runtime = _runtime(1)
+    sent: list[str] = []
+
+    async def fake_send(request_id: str, _handoff: object) -> None:
+        sent.append(request_id)
+
+    runtime._send_pd_handoff_now = fake_send
+
+    asyncio.run(runtime._send_pd_handoff("req-2", handoff))
+
+    assert sent == ["req-2"]
+    assert lease.released == 0


### PR DESCRIPTION
Based on `pd_runtime`. Off by default.

## Nothing bounds what Decode accumulates

A colocated replica throttles admission without trying to: prefill and decode contend for one card and one scheduler thread, so admitting more work slows the admitting itself. Splitting the two halves removes that feedback, and nothing replaces it.

Measured on two H200s, PD against colocated at the same offered rate of 16, where both admitted every request:

| | Decode in flight | total time p50 | admission |
| --- | --- | --- | --- |
| colocated replica | ~18 | 2.29 s | 100% |
| PD pair | ~437 | 40.96 s | 100% |

`max_running_requests` is 64, so by Little's law most of that 437 is queueing rather than decoding. Both arms report 100% admission throughout, which is why this does not show up as a failure: **admission rate is constant on this path**, reading 100% from a healthy request to a 41-second one, so overload arrives as unbounded latency rather than as anything that says so.

## What this PR does about it

Three things, and a bound on Decode's queue is not one of them.

**It says which admission policy is in effect.** Binding a Decode half with no queue limit logs that the queue is unbounded, that overload will appear as latency rather than rejection, and which flag to set. `--max_queued_requests` already reaches both halves — `PDConfig` is written onto the logical stage and expansion copies server args to both halves — and `models/qwen3_tts/engine_builder.py` sets it to 16 for its generation stage, so the notice names that precedent rather than leaving "set something" as a guess. Without that line an operator sees 100% admission and 41-second requests with nothing connecting the two.

**It measures how much Decode is holding.** The depth rides the transfer ack, so it costs no new message and no new route, and `DataAckMessage.receiver_pending` is optional so a peer that omits it stays compatible. The count includes committed-but-unadmitted work alongside the scheduler's queues, because a request in either state is work this half accepted and has not finished.

This measurement is reported, not acted on. The ack fires on commit, which means the reading stops arriving exactly when Prefill stops sending: a bound built on it would hold on a stale high-water value with nothing left to lower it. Bounding what Decode accumulates needs a capacity return that does not ride the producer's traffic, and that is separate work. The measurement is what such a return would be built from.

**It bounds how many handoffs send at once.** `max_inflight_handoffs` is a semaphore around the send. What it bounds is concurrent sends — not pinned prompt KV, because the scheduler builds `SGLangKVPageLease` before the send task starts, so six requests behind a limit of two hold six leases and send two. Bounding pinned KV means refusing the request before its KV exists, which is prefill admission and belongs with the capacity-return work above.

Cancelling a handoff while it waits for a permit used to leak that lease outright: the send never started, so its `finally` never ran and nobody released it. The wait now releases the lease and clears the request state on cancellation. `release` is idempotent, so a handoff that did start is unaffected.

## Also here

`priority` now survives the handoff. A `DecodeContinuation` carries it and `req_from_continuation` restores it, so a request that was admitted by priority on Prefill is not silently demoted on Decode.

`LockedKVAllocator` serialises `alloc` and `free` on the Decode half, where the scheduler thread and the comm event loop share one allocator (#1704). `bootstrap.py` hands the raw allocator to `create_tree_cache`, `PrefillManager` and `DecodeManager` before `bind_pd_runtime` runs, so the wrapper is now installed into all four holders rather than the scheduler's attribute alone — one lock only helps if no caller keeps an unwrapped alias.

Rebinding after construction rather than wrapping in `bootstrap.py` is deliberate: upstream's `SWAChunkCache.__init__` asserts the allocator's concrete type, and a proxy handed to the constructor would fail that assert for models that use it. A holder without the attribute raises rather than being skipped, and `_kv_allocator_holders` reports what was rebound so a test asserts they all agree — which is what catches a fifth holder appearing.

The open question is whether locking is the right answer at all. The instrumented run behind #1704 recorded 21,309 cross-thread alloc/free overlaps, and the alternative is to remove the second caller entirely: have the comm thread hand its reservation to the scheduler thread rather than allocating concurrently. That trades a lock on a hot path for a hop in `prepare_kv_receive`.

## Testing

| Run | Result |
| --- | --- |
| `test_pd_alloc_lock.py`, `test_pd_handoff_gate.py`, `test_pd_backpressure.py` | 24 pass |
| `tests/unit_test` | 4951 pass, 7 fail |

The 7 failures are `moss_tts/test_audio_tokenizer.py` (2), `qwen3_omni/test_vision_compat.py` (1) and `qwen3_tts/test_compat.py` (4). All 7 fail the same way on `origin/main` in this environment and none touch PD.

`_pd_handoff_gate` reads `pd_execution` defensively. On a `Stage` built with `object.__new__` a direct attribute read raises inside the handoff task, which stops the send with nothing surfacing the cause, and `test_pd_stage_runtime.py` blocks on `await stage._comm.started.wait()` rather than failing.

The cases cover: the depth counts every accepted request and reads zero when idle; the ack carries it across the wire and a peer that omits it stays compatible; the unbounded-queue notice fires on a Decode half, names the precedent, and stays silent on a bounded queue and on the Prefill half; priority survives the handoff and a continuation without one stays valid; an unset bound installs no gate and a set one installs a semaphore of that size, reused across handoffs; cancelling while queued releases the lease exactly once while a handoff that never waited leaves it to the send path; two threads racing the allocator's read-modify-write hand out disjoint slots through the wrapper; every holder ends up with the same locked object; and a holder that cannot be rebound raises rather than being skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
