### PR TITLE
docs(pd): a user guide for prefill/decode disaggregation

### DIFF
--- a/docs/basic_usage/pd_disaggregation.md
+++ b/docs/basic_usage/pd_disaggregation.md
@@ -1,18 +1,32 @@
 # Prefill/Decode Disaggregation
 
-> TL;DR: PD disaggregation splits one stage into a prefill process and a decode process so a prefill no longer stalls decoding. It removes that interference almost completely. It does not raise throughput at equal GPU count on Qwen3-Omni thinker: in the measurements below two colocated replicas beat one prefill/decode pair on both text and image. Turn it on when inter-token latency stability is what you need, not to serve more requests per GPU.
+> TL;DR: PD disaggregation splits one stage into a prefill process and a decode process, so a prefill no longer stalls the decoding already in flight. It removes that interference almost completely, on any placement, including both halves on one GPU. How much hardware you then give each half is a separate, continuous choice, and it is the choice that decides what the split costs and what it can return. One prefill half against one decode half on two cards is the configuration measured here: it has parity with two colocated replicas as its throughput ceiling, and on Qwen3-Omni thinker it currently lands below that.
 
 A colocated replica runs prefill and decode on one card and one scheduler thread. A prefill therefore blocks the decode steps of every request already running. On Qwen3-Omni that cost is large, and it is worst on images, where a 6127-token prompt cannot be chunked.
 
-PD disaggregation moves prefill into its own process. The prompt KV and the request's continuation state transfer once, over CUDA IPC, and decoding continues on the other half.
+PD disaggregation moves prefill into its own process. The prompt KV and the request's continuation state transfer once, over CUDA IPC, and decoding continues on the other half. Where that other half runs, and how much of a card it gets, is what the rest of this page is about.
+
+## What the split actually gives you
+
+PD here is not one topology. It is a resource split you set continuously, at three layers, and each layer answers a different question.
+
+| Layer | How you set it | What it decides |
+| --- | --- | --- |
+| Which devices each half gets | `thinker=0:1`, `thinker=0:0`, `thinker=0,1:2,3` | whether the halves are separated in execution only, or in hardware as well |
+| Each half's share of a device | `thinker=0@0.25:0@0.65` | how one card divides between the two halves, as a continuous fraction |
+| Each half's runtime settings | `pd_disaggregation.prefill.server_args` | lets a half be tuned for its own work rather than for the average of both |
+
+The first layer is the one people usually read as the whole feature, and it is the one with a degenerate case worth knowing: **both halves on one GPU still separates them.** What PD needs is the process split, and a prefill step leaves the decode scheduler thread whichever card it runs on. Giving prefill a second card is an additional, separable decision about hardware, not what makes PD work.
+
+That is why the split is a parameter rather than a topology. `thinker=0:0` and `thinker=0:1` differ in how much hardware you spend, not in whether the halves are separated.
 
 ## Choosing a configuration
 
-PD is one decision among several, and the others are not about the queue. Work through these in order; each one can rule PD out before you tune anything.
+Three questions decide whether and how to split. A fourth decides what the split is optimizing, and it selects a configuration rather than ruling PD in or out.
 
 ### 1. Is prefill a large enough share of your work?
 
-PD gives prefill its own hardware. That pays only if prefill is a large enough share of the GPU work to justify the hardware it gets. The share is governed by prompt length divided by output length.
+Prefill share is governed by prompt length divided by output length.
 
 | Prompt / output tokens | Prefill share |
 | --- | --- |
@@ -20,31 +34,29 @@ PD gives prefill its own hardware. That pays only if prefill is a large enough s
 | 6944 / 128 | about 9% |
 | 42 / 8 | about 42% |
 
-A 1:1 pair splits the hardware evenly. Against a 2.6% share that leaves the prefill card about 90% idle, which is what the equal-GPU-count measurement found. Long prompts with short outputs are the shape that justifies the split; short prompts with long outputs are not.
+This sets what a *second card* for prefill can be worth. Splitting across two cards divides the hardware evenly; against a 2.6% share that leaves the prefill card about 90% idle, which is what the equal-GPU-count run measured. Long prompts with short outputs — document QA, long-audio transcription, classification, scoring — are the shape that earns a second card. Short prompts with long outputs are not.
 
-If your workload sits at the low end, the interference PD removes may still be worth it, but expect to pay throughput for it. Read the next question before deciding.
+A low share does not rule out splitting. It argues for spending less hardware on it: the same-GPU form separates the halves without a second card at all.
 
-### 2. Is your problem throughput, or is it inter-token jitter?
+### 2. Which overload behaviour do you want?
 
-These want opposite answers, and the measurements separate them cleanly.
+Decide it, because the default is an unbounded queue and it surfaces as latency rather than as an error. See [What to expect](#what-to-expect) for the three settings and which question each answers.
 
-If the complaint is **throughput per GPU**, PD at 1:1 is not the fix. Two colocated replicas beat one pair on both text and image at equal GPU count.
+### 3. Does the prefill card have room for what moves onto it?
 
-If the complaint is **an audio or token stream that stutters when another request starts**, PD addresses exactly that. A colocated replica pays 5.9x to 8.5x on the inter-token gap that overlaps a prefill on text, and 8.4x to 20.5x on images. PD brings that to 1.0x. It is worst on images because a 6127-token image prompt cannot be chunked: `_needs_full_prefill` forces the whole prompt through in one step, and no decode work batches with it.
+`--pd-stage` moves only the stage it names. The encoders stay where they were, and the CUDA-IPC relay pool appears on the prefill card. Budget for both. This is the most common way a first PD launch fails.
 
-For a real-time stream with a repeating deadline, that jitter is the SLO, and a throughput number does not describe it.
+### 4. Are you optimizing throughput, or inter-token stability?
 
-### 3. Does your workload depend on prefix reuse?
+Both are real goals and they select different configurations.
 
-PD forces `disable_radix_cache` and `page_size=1` on both halves. A workload built on a long shared prefix loses that reuse: a fixed system prompt, a few-shot preamble, or a reference audio prefix. Measure your cache hit rate before splitting. This cost does not appear in a throughput comparison run with unique prompts.
+**Inter-token stability.** A colocated replica pays 5.9x to 8.5x on the inter-token gap that overlaps a prefill on text, and 8.4x to 20.5x on images. PD brings that to 1.0x: on the image arm a prefill in flight on the other card is statistically indistinguishable from no prefill at all. Images are worst because a 6127-token image prompt cannot be chunked — `_needs_full_prefill` forces the whole prompt through one step and no decode work batches with it. For a stream with a repeating deadline, such as speech output or a full-duplex voice turn, this jitter *is* the SLO and a throughput number does not describe it. Any split addresses it, including the same-GPU form.
 
-### 4. Which overload behaviour do you want?
+**Throughput.** One prefill half against one decode half, on two cards, has parity as its ceiling. That is arithmetic, not a defect: a card doing both jobs has the harmonic mean of its prefill-only and decode-only capacities, a 1:1 pair has the minimum of the two, and the minimum never exceeds the harmonic mean, with equality only when the halves are exactly balanced. So 1:1 across two cards is the wrong configuration to reach for when throughput is the goal — not because splitting is wrong, but because that particular ratio cannot exceed parity even in theory.
 
-Decide this deliberately, because the default is an unbounded queue and it shows up as latency rather than as an error. See [What to expect](#what-to-expect) for the three settings and which question each answers.
+The configurations whose arithmetic differs are ratios other than 1:1, and both halves on one card. Neither has been measured here yet. Ratios other than 1:1 are not configurable today.
 
-### 5. Does the prefill card have room for what moves onto it?
-
-`--pd-stage` moves only the stage it names. The encoders stay put, and the CUDA-IPC relay pool appears on the prefill card. Budget for both. This is the most common way a first PD launch fails.
+The measured gap is also larger than the arithmetic predicts: PD's decode card carries about a 2.9x handicap while its prefill card carries none. Four candidates can account for it and the data cannot yet separate them — the forced `page_size=1`, the forced `disable_radix_cache`, the absence of mixed-chunk batching on the decode side, and the cost of receiving KV over CUDA IPC. Three of those four are current constraints of this implementation rather than properties of disaggregation, so expect this number to move.
 
 ## Turn it on
 
@@ -126,6 +138,6 @@ Set priorities when one deployment serves both interactive and batch traffic. Th
 ## Limits today
 
 - `tp_size` must be 1. A two-GPU half parses and places, and is then rejected when the runtime binds.
-- `page_size` is forced to 1 and the radix cache is disabled, so prefix reuse is unavailable on a PD stage.
+- `page_size` is forced to 1 and the radix cache is disabled on both halves, so prefix reuse is unavailable on a PD stage. A workload built on a long shared prefix — a fixed system prompt, a few-shot preamble, a reference audio prefix — loses that reuse, and the loss does not appear in a throughput comparison run with unique prompts. This is a constraint of the current implementation, not of disaggregation.
 - One prefill half pairs with one decode half. Ratios other than 1:1 are not configurable.
 - Both halves must be on the same node.

--- a/docs/basic_usage/pd_disaggregation.md
+++ b/docs/basic_usage/pd_disaggregation.md
@@ -1,0 +1,131 @@
+# Prefill/Decode Disaggregation
+
+> TL;DR: PD disaggregation splits one stage into a prefill process and a decode process so a prefill no longer stalls decoding. It removes that interference almost completely. It does not raise throughput at equal GPU count on Qwen3-Omni thinker: in the measurements below two colocated replicas beat one prefill/decode pair on both text and image. Turn it on when inter-token latency stability is what you need, not to serve more requests per GPU.
+
+A colocated replica runs prefill and decode on one card and one scheduler thread. A prefill therefore blocks the decode steps of every request already running. On Qwen3-Omni that cost is large, and it is worst on images, where a 6127-token prompt cannot be chunked.
+
+PD disaggregation moves prefill into its own process. The prompt KV and the request's continuation state transfer once, over CUDA IPC, and decoding continues on the other half.
+
+## Choosing a configuration
+
+PD is one decision among several, and the others are not about the queue. Work through these in order; each one can rule PD out before you tune anything.
+
+### 1. Is prefill a large enough share of your work?
+
+PD gives prefill its own hardware. That pays only if prefill is a large enough share of the GPU work to justify the hardware it gets. The share is governed by prompt length divided by output length.
+
+| Prompt / output tokens | Prefill share |
+| --- | --- |
+| 42 / 128 | about 2.6% |
+| 6944 / 128 | about 9% |
+| 42 / 8 | about 42% |
+
+A 1:1 pair splits the hardware evenly. Against a 2.6% share that leaves the prefill card about 90% idle, which is what the equal-GPU-count measurement found. Long prompts with short outputs are the shape that justifies the split; short prompts with long outputs are not.
+
+If your workload sits at the low end, the interference PD removes may still be worth it, but expect to pay throughput for it. Read the next question before deciding.
+
+### 2. Is your problem throughput, or is it inter-token jitter?
+
+These want opposite answers, and the measurements separate them cleanly.
+
+If the complaint is **throughput per GPU**, PD at 1:1 is not the fix. Two colocated replicas beat one pair on both text and image at equal GPU count.
+
+If the complaint is **an audio or token stream that stutters when another request starts**, PD addresses exactly that. A colocated replica pays 5.9x to 8.5x on the inter-token gap that overlaps a prefill on text, and 8.4x to 20.5x on images. PD brings that to 1.0x. It is worst on images because a 6127-token image prompt cannot be chunked: `_needs_full_prefill` forces the whole prompt through in one step, and no decode work batches with it.
+
+For a real-time stream with a repeating deadline, that jitter is the SLO, and a throughput number does not describe it.
+
+### 3. Does your workload depend on prefix reuse?
+
+PD forces `disable_radix_cache` and `page_size=1` on both halves. A workload built on a long shared prefix loses that reuse: a fixed system prompt, a few-shot preamble, or a reference audio prefix. Measure your cache hit rate before splitting. This cost does not appear in a throughput comparison run with unique prompts.
+
+### 4. Which overload behaviour do you want?
+
+Decide this deliberately, because the default is an unbounded queue and it shows up as latency rather than as an error. See [What to expect](#what-to-expect) for the three settings and which question each answers.
+
+### 5. Does the prefill card have room for what moves onto it?
+
+`--pd-stage` moves only the stage it names. The encoders stay put, and the CUDA-IPC relay pool appears on the prefill card. Budget for both. This is the most common way a first PD launch fails.
+
+## Turn it on
+
+```bash
+sgl-omni serve \
+  --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
+  --config examples/configs/qwen3_omni_pd.yaml \
+  --pd-stage thinker=0:1 \
+  --port 8000
+```
+
+Pick a config whose `config_cls` is not one of the colocated classes. `Qwen3OmniSpeechColocatedPipelineConfig` requires the image encoder, audio encoder, thinker, talker and code2wav to share one GPU, which a split thinker contradicts, and it reports that as `Qwen colocated speech requires exactly one GPU id for ['thinker']`.
+
+Do not combine `--thinker-mem-fraction-static` with a config that already sets `total_gpu_memory_fraction` for the thinker. The two are separate memory contracts and the stage rejects the pair.
+
+`--pd-stage STAGE=PREFILL_GPUS:DECODE_GPUS` splits one stage. Repeat the flag to split more than one. `STAGE` accepts a stage name or a role alias, as `--stage-process` does.
+
+The flag sets the two server args PD requires, `disable_radix_cache` and `page_size=1`, on both halves. Setting a contradicting value in the stage's `server_args_overrides` is rejected at configuration time and names the argument.
+
+`--pd-stage` moves only the stage it names. Stages that feed it, including the image and audio encoders, keep the GPU they already had. On a two-GPU multimodal deployment the prefill card therefore carries the encoders as well.
+
+## Both halves on one GPU
+
+The halves may share a card. What PD needs is the process split, and that happens either way: the prefill step leaves the decode scheduler thread whichever card it runs on. Sharing a card also makes PD runnable on a one-GPU box.
+
+Declare each half's share of the card, in the pipeline config:
+
+```yaml
+pd_disaggregation:
+  prefill: {gpu: 0, memory_fraction: 0.25}
+  decode:  {gpu: 0, memory_fraction: 0.65}
+```
+
+Use that share rather than `mem_fraction_static` when the halves share a card. `total_gpu_memory_fraction` is a fraction of total physical memory, so it does not depend on which half loads first. `mem_fraction_static` is computed against memory free at load time, and the two halves race for one startup lock: measured on one H200, whichever half won the lock sized itself to 780,987 KV tokens and the other failed to start. With the share form both halves sized to 21,502 KV tokens under either lock order.
+
+Prefer the share over an absolute `max_total_tokens` here. `max_total_tokens` is applied as a minimum against the profiled capacity, so a cap larger than what the later-loading half can profile stops binding on that half and the pair silently reverts to order-dependent sizing.
+
+## Budget for the relay pool
+
+Splitting a multimodal stage moves the `mm_aggregate` to prefill edge across a process boundary. The CUDA-IPC relay then allocates a pool on the prefill GPU that a colocated deployment never allocates. The default is 1024 MB.
+
+The relay allocates it on the first payload that crosses the boundary, not at startup. A `mem_fraction_static` copied from a colocated deployment therefore passes launch and fails on the first image request. Measured on one H200: the prefill half at `mem_fraction_static=0.87` plus the encoder process reached 139.5 GiB of 139.80 GiB and failed a 750 MiB allocation on the first image request. 0.80 left room.
+
+## What to expect
+
+Measured on two H200s, Qwen3-Omni thinker, CUDA graph on, against two colocated replicas on the same two cards. Full method and data in [PD versus colocated at equal GPU count](../developer_reference/pd_vs_colocated.md).
+
+**Interference goes away.** The ratio of the median inter-token gap that overlaps a prefill to the median gap that does not:
+
+| | Colocated | PD |
+| --- | --- | --- |
+| Text | 5.9x to 8.5x | 1.00x to 1.54x |
+| Image | 8.4x to 20.5x | 0.97x to 1.02x |
+
+On the image arm a prefill in flight on the other card is statistically indistinguishable from no prefill at all.
+
+**Throughput does not.** On text, PD saturated by an offered 16 requests per second and held about 10.6 achieved. Colocated still tracked the offered rate at 44 with full admission, so its ceiling was not established and the 3.5x gap at that rate is a lower bound.
+
+The reason is that prefill is a small share of this workload's GPU work. At 42 prompt tokens and 128 output tokens, a 58 ms first forward sits against a 2.2 s decode tail, about 2.6%. A 1:1 pair splits the hardware evenly against that split, so the prefill card measured 10.1% mean utilization against 67.9% on a colocated card. Prefill share is governed by prompt length divided by output length, so it rises with longer prompts and shorter outputs.
+
+**Overload appears as latency, not rejection.** With no bound the decode half accumulates. At an offered 16 it held about 437 requests against `max_running_requests=64`, and a request took 40.96 s against 2.29 s colocated, while the admission rate read 100% throughout. An operator watching the admission rate sees a healthy system delivering 41-second latency.
+
+Three settings bound it, and they answer different questions. Pick by which question you can answer for your deployment.
+
+| Setting | Question it answers | What it does |
+| --- | --- | --- |
+| `SGLANG_REQ_WAITING_TIMEOUT` | how long may one request wait | Drops a request that has waited longer, with HTTP 503 and `Request waiting timeout reached.` |
+| `--max-queued-requests` | how many may wait | Rejects arrivals beyond the bound with `The request queue is full.` |
+| `--enable-priority-scheduling` | which requests survive | Evicts the least-preferred queued request instead of the arrival, and only when the arrival ranks strictly higher |
+
+Prefer the timeout as the primary bound for interactive serving. Its unit is a duration you already know, namely your client's own timeout, whereas a queue length converts to a wait only through the current service rate: 16 queued requests is two seconds at one load and forty at another. The timeout also tracks load on its own, admitting fewer as service slows, with no retuning.
+
+Keep `--max-queued-requests` as the memory bound. A duration does not cap how many requests are resident, because a burst can leave many of them still inside their deadline.
+
+Leave both unset for offline batch work, where every request should eventually complete and nobody is waiting. `models/qwen3_tts` sets `max_queued_requests` to 16 for its generation stage.
+
+Set priorities when one deployment serves both interactive and batch traffic. Then a single bound does the right thing for both, because the batch requests are the ones evicted under pressure.
+
+## Limits today
+
+- `tp_size` must be 1. A two-GPU half parses and places, and is then rejected when the runtime binds.
+- `page_size` is forced to 1 and the radix cache is disabled, so prefix reuse is unavailable on a PD stage.
+- One prefill half pairs with one decode half. Ratios other than 1:1 are not configurable.
+- Both halves must be on the same node.

--- a/docs/basic_usage/pd_disaggregation.md
+++ b/docs/basic_usage/pd_disaggregation.md
@@ -117,6 +117,19 @@ pd_disaggregation:
 
 Use that share rather than `mem_fraction_static` when the halves share a card. `total_gpu_memory_fraction` is a fraction of total physical memory, so it does not depend on which half loads first. `mem_fraction_static` is computed against memory free at load time, and the two halves race for one startup lock: measured on one H200, whichever half won the lock sized itself to 780,987 KV tokens and the other failed to start. With the share form both halves sized to 21,502 KV tokens under either lock order.
 
+One declared share does not give both halves the same KV budget. With `share_weights` on, the half that publishes the weights holds its copy inside its own share, and the half that adopts them releases its copy before its pool is sized. Measured on one H200 with both halves at 0.47: the publisher received 22,547 KV tokens and the adopter 643,731. The publisher is whichever half declares the larger share, so the asymmetry follows the declaration. Size the publishing half as `what you want for KV` plus the weights.
+
+Sharing a card trades first-token latency against inter-token latency, and the direction is worth knowing before you choose it. Measured against a colocated replica on the same card, closed-loop at concurrency 8, 32 output tokens:
+
+| prompt tokens | first token, p50 | between tokens, p50 |
+| ---: | --- | --- |
+| 256 | 5.4x sooner | 2.4x longer |
+| 1024 | 4.4x sooner | 2.5x longer |
+| 4096 | 2.6x sooner | 2.0x longer |
+| 8128 | no gain | 1.4x shorter |
+
+So the split is worth it where a fast first token matters and a slightly slower stream does not — interactive text, short prompts. It is not worth it where the stream's cadence is the product, and at 8128 tokens it stops buying the first-token gain at all.
+
 Prefer the share over an absolute `max_total_tokens` here. `max_total_tokens` is applied as a minimum against the profiled capacity, so a cap larger than what the later-loading half can profile stops binding on that half and the pair silently reverts to order-dependent sizing.
 
 ## Budget for the relay pool

--- a/docs/basic_usage/pd_disaggregation.md
+++ b/docs/basic_usage/pd_disaggregation.md
@@ -44,7 +44,7 @@ Decide it, because the default is an unbounded queue and it surfaces as latency 
 
 ### 3. Does the prefill card have room for what moves onto it?
 
-`--pd-stage` moves only the stage it names. The encoders stay where they were, and the CUDA-IPC relay pool appears on the prefill card. Budget for both. This is the most common way a first PD launch fails.
+Splitting a stage moves only that stage. The encoders stay where they were, and the CUDA-IPC relay pool appears on the prefill card. Budget for both. This is the most common way a first PD launch fails.
 
 ### 4. Are you optimizing throughput, or inter-token stability?
 
@@ -78,7 +78,8 @@ The measured gap is larger than the arithmetic predicts: PD's decode card carrie
 sgl-omni serve \
   --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
   --config examples/configs/qwen3_omni_pd.yaml \
-  --pd-stage thinker=0:1 \
+  --thinker.pd_disaggregation.prefill.gpu 0 \
+  --thinker.pd_disaggregation.decode.gpu 1 \
   --port 8000
 ```
 
@@ -86,11 +87,21 @@ Pick a config whose `config_cls` is not one of the colocated classes. `Qwen3Omni
 
 Do not combine `--thinker-mem-fraction-static` with a config that already sets `total_gpu_memory_fraction` for the thinker. The two are separate memory contracts and the stage rejects the pair.
 
-`--pd-stage STAGE=PREFILL_GPUS:DECODE_GPUS` splits one stage. Repeat the flag to split more than one. `STAGE` accepts a stage name or a role alias, as `--stage-process` does.
+Declaring `pd_disaggregation` on a stage is what splits it. The two halves are ordinary config paths, so they take the same dotted flags every other per-stage setting does, and they can equally be written in the YAML:
+
+```yaml
+stages:
+  thinker:
+    pd_disaggregation:
+      prefill: {gpu: 0}
+      decode: {gpu: 1}
+```
+
+Both spellings resolve through the same machinery, so the CLI beats the file, a key set twice is reported, and `sgl-omni config explain` says where each value came from.
 
 The flag sets the two server args PD requires, `disable_radix_cache` and `page_size=1`, on both halves. Setting a contradicting value in the stage's `server_args_overrides` is rejected at configuration time and names the argument.
 
-`--pd-stage` moves only the stage it names. Stages that feed it, including the image and audio encoders, keep the GPU they already had. On a two-GPU multimodal deployment the prefill card therefore carries the encoders as well.
+Splitting a stage moves only that stage. Stages that feed it, including the image and audio encoders, keep the GPU they already had. On a two-GPU multimodal deployment the prefill card therefore carries the encoders as well.
 
 ## Both halves on one GPU
 

--- a/docs/basic_usage/pd_disaggregation.md
+++ b/docs/basic_usage/pd_disaggregation.md
@@ -1,6 +1,6 @@
 # Prefill/Decode Disaggregation
 
-> TL;DR: PD disaggregation splits one stage into a prefill process and a decode process, so a prefill no longer stalls the decoding already in flight. How much hardware you give each half is a separate, continuous choice, and it decides what the split returns. **Both halves on one GPU is the configuration that pays**: on Qwen3-Omni thinker it removed the interference and reached 28.90 requests per second against a colocated replica's 21.16 on the same card. One half per card removes the interference too, but its throughput ceiling is parity with two colocated replicas by arithmetic, and it currently lands below that.
+> TL;DR: PD disaggregation splits one stage into a prefill process and a decode process, so a prefill no longer stalls the decoding already in flight. How much hardware you give each half is a separate, continuous choice, and it decides what the split returns. **Both halves on one GPU is the placement to reach for**, and what it buys is latency rather than throughput: on Qwen3-Omni thinker it held the p95 first-token time under 0.65 s where a colocated replica on the same card reached 26 s, and cut the gap between tokens by about three times. It completes fewer requests per second than colocated while doing so. One half per card removes the interference too, but its throughput ceiling is parity with two colocated replicas by arithmetic, and it currently lands below that.
 
 A colocated replica runs prefill and decode on one card and one scheduler thread. A prefill therefore blocks the decode steps of every request already running. On Qwen3-Omni that cost is large, and it is worst on images, where a 6127-token prompt cannot be chunked.
 
@@ -36,7 +36,7 @@ Prefill share is governed by prompt length divided by output length.
 
 This sets what a *second card* for prefill can be worth. Splitting across two cards divides the hardware evenly; against a 2.6% share that leaves the prefill card about 90% idle, which is what the equal-GPU-count run measured. Long prompts with short outputs — document QA, long-audio transcription, classification, scoring — are the shape that earns a second card. Short prompts with long outputs are not.
 
-A low share does not rule out splitting. It argues for spending less hardware on it: the same-GPU form separates the halves without a second card at all, and on the measurements below it is the shape that wins on throughput.
+A low share does not rule out splitting. It argues for spending less hardware on it: the same-GPU form separates the halves without a second card at all.
 
 ### 2. Which overload behaviour do you want?
 
@@ -58,9 +58,15 @@ For a stream with a repeating deadline, such as speech output or a full-duplex v
 
 **Time to first token under load.** The two shapes part company as load rises. On one H200 at an offered 16 requests per second, a colocated replica completed 13.1 to 13.3 per second with a p95 first-token time of 7.5 to 8.8 seconds. The same card split into two halves completed 10.6 to 10.9 per second with a p95 of 0.124 seconds. Colocated pushes more requests through and lets them wait; the split holds the first token flat and admits fewer. Which one is right depends on whether a late first token is a failure for you.
 
-**Throughput on one card.** Splitting a card wins. Measured with an open-loop client at 42-token prompts, a colocated replica saturated at 21.16 requests per second and the same card split reached 28.90 and had not yet saturated. Nothing is divided in this shape: both halves draw on the same SMs, and the split only moves prefill off the decode scheduler thread.
+**Throughput on one card.** Which shape wins depends on whether the client streams.
 
-That result depends on sharing the weights. Without it the two halves load a copy each, which leaves them 22,206 KV tokens apiece instead of 665,596 between them.
+Against a streaming client, colocated completes more: at an offered 24 it reached 16.2 to 16.4 requests per second against the split card's 10.0 to 10.3. Against a non-streaming open-loop client the order reverses, with the split card at 28.90 against 21.16. Production traffic on the OpenAI-compatible route streams, so the first pair is the one to plan against.
+
+The trade is visible in the same runs. Colocated buys those extra completions by letting requests wait: its p95 first-token time is 23.2 to 26.5 seconds at that rate, against 0.53 to 0.65 seconds for the split card. It finishes them sooner once started, with a p95 total of 26.7 to 30.1 seconds against 80.7 to 83.7.
+
+At a load both shapes serve fully, the split card is better on every latency measure: 0.067 s first token against 0.105, 8.96 ms between tokens against 26.6, and a p95 total of 1.9 s against 4.8.
+
+Splitting one card at all depends on sharing the weights. Without it the two halves load a copy each, which leaves them 22,206 KV tokens apiece instead of 665,596 between them.
 
 **Throughput across two cards.** One prefill half against one decode half has parity as its ceiling. That is arithmetic, not a defect: a card doing both jobs has the harmonic mean of its prefill-only and decode-only capacities, a 1:1 pair has the minimum of the two, and the minimum never exceeds the harmonic mean, with equality only when the halves are exactly balanced. So 1:1 across two cards is the wrong configuration to reach for when throughput is the goal.
 

--- a/docs/basic_usage/pd_disaggregation.md
+++ b/docs/basic_usage/pd_disaggregation.md
@@ -130,6 +130,8 @@ Sharing a card trades first-token latency against inter-token latency, and the d
 
 So the split is worth it where a fast first token matters and a slightly slower stream does not — interactive text, short prompts. It is not worth it where the stream's cadence is the product, and at 8128 tokens it stops buying the first-token gain at all.
 
+Rely on the direction rather than the multiplier. Each row is one paired run, and repeating an identical configuration on one H200 moved throughput by 81% and first-token time by 95% between runs, driven by what else the host was doing. Throughput on a shared card is not measurable this way at all, which is why there is no throughput column here.
+
 Prefer the share over an absolute `max_total_tokens` here. `max_total_tokens` is applied as a minimum against the profiled capacity, so a cap larger than what the later-loading half can profile stops binding on that half and the pair silently reverts to order-dependent sizing.
 
 ## Budget for the relay pool

--- a/docs/basic_usage/pd_disaggregation.md
+++ b/docs/basic_usage/pd_disaggregation.md
@@ -1,6 +1,6 @@
 # Prefill/Decode Disaggregation
 
-> TL;DR: PD disaggregation splits one stage into a prefill process and a decode process, so a prefill no longer stalls the decoding already in flight. It removes that interference almost completely, on any placement, including both halves on one GPU. How much hardware you then give each half is a separate, continuous choice, and it is the choice that decides what the split costs and what it can return. One prefill half against one decode half on two cards is the configuration measured here: it has parity with two colocated replicas as its throughput ceiling, and on Qwen3-Omni thinker it currently lands below that.
+> TL;DR: PD disaggregation splits one stage into a prefill process and a decode process, so a prefill no longer stalls the decoding already in flight. How much hardware you give each half is a separate, continuous choice, and it decides what the split returns. **Both halves on one GPU is the configuration that pays**: on Qwen3-Omni thinker it removed the interference and reached 28.90 requests per second against a colocated replica's 21.16 on the same card. One half per card removes the interference too, but its throughput ceiling is parity with two colocated replicas by arithmetic, and it currently lands below that.
 
 A colocated replica runs prefill and decode on one card and one scheduler thread. A prefill therefore blocks the decode steps of every request already running. On Qwen3-Omni that cost is large, and it is worst on images, where a 6127-token prompt cannot be chunked.
 
@@ -36,7 +36,7 @@ Prefill share is governed by prompt length divided by output length.
 
 This sets what a *second card* for prefill can be worth. Splitting across two cards divides the hardware evenly; against a 2.6% share that leaves the prefill card about 90% idle, which is what the equal-GPU-count run measured. Long prompts with short outputs — document QA, long-audio transcription, classification, scoring — are the shape that earns a second card. Short prompts with long outputs are not.
 
-A low share does not rule out splitting. It argues for spending less hardware on it: the same-GPU form separates the halves without a second card at all.
+A low share does not rule out splitting. It argues for spending less hardware on it: the same-GPU form separates the halves without a second card at all, and on the measurements below it is the shape that wins on throughput.
 
 ### 2. Which overload behaviour do you want?
 
@@ -48,15 +48,23 @@ Decide it, because the default is an unbounded queue and it surfaces as latency 
 
 ### 4. Are you optimizing throughput, or inter-token stability?
 
-Both are real goals and they select different configurations.
+Both are real goals, and on one card the same configuration serves both. Across two cards they diverge.
 
-**Inter-token stability.** A colocated replica pays 5.9x to 8.5x on the inter-token gap that overlaps a prefill on text, and 8.4x to 20.5x on images. PD brings that to 1.0x: on the image arm a prefill in flight on the other card is statistically indistinguishable from no prefill at all. Images are worst because a 6127-token image prompt cannot be chunked — `_needs_full_prefill` forces the whole prompt through one step and no decode work batches with it. For a stream with a repeating deadline, such as speech output or a full-duplex voice turn, this jitter *is* the SLO and a throughput number does not describe it. Any split addresses it, including the same-GPU form.
+**Inter-token stability.** A colocated replica pays for a prefill that lands while other requests are decoding. Measured on one H200 at a load both arms serve fully, the inter-token gap that overlaps a prefill is 2.28x the gap that does not, and the gap itself is 26.18 ms. Splitting the halves onto that same card brings the ratio to 0.84 and the gap to 8.95 ms. Across two cards the ratio reaches 1.0 on text and on images, where a colocated replica pays 8.4x to 20.5x because a 6127-token image prompt cannot be chunked and no decode work batches with it.
 
-**Throughput.** One prefill half against one decode half, on two cards, has parity as its ceiling. That is arithmetic, not a defect: a card doing both jobs has the harmonic mean of its prefill-only and decode-only capacities, a 1:1 pair has the minimum of the two, and the minimum never exceeds the harmonic mean, with equality only when the halves are exactly balanced. So 1:1 across two cards is the wrong configuration to reach for when throughput is the goal — not because splitting is wrong, but because that particular ratio cannot exceed parity even in theory.
+Read that ratio only where the arm serves what is offered. Past saturation the overlapping gaps carry queueing rather than contention, and the same measurement reports 12.9 and then 2216 as the offered rate rises. Report the achieved rate beside it.
 
-The configurations whose arithmetic differs are ratios other than 1:1, and both halves on one card. Neither has been measured here yet. Ratios other than 1:1 are not configurable today.
+For a stream with a repeating deadline, such as speech output or a full-duplex voice turn, this jitter *is* the SLO and a throughput number does not describe it.
 
-The measured gap is also larger than the arithmetic predicts: PD's decode card carries about a 2.9x handicap while its prefill card carries none. Four candidates can account for it and the data cannot yet separate them — the forced `page_size=1`, the forced `disable_radix_cache`, the absence of mixed-chunk batching on the decode side, and the cost of receiving KV over CUDA IPC. Three of those four are current constraints of this implementation rather than properties of disaggregation, so expect this number to move.
+**Time to first token under load.** The two shapes part company as load rises. On one H200 at an offered 16 requests per second, a colocated replica completed 13.1 to 13.3 per second with a p95 first-token time of 7.5 to 8.8 seconds. The same card split into two halves completed 10.6 to 10.9 per second with a p95 of 0.124 seconds. Colocated pushes more requests through and lets them wait; the split holds the first token flat and admits fewer. Which one is right depends on whether a late first token is a failure for you.
+
+**Throughput on one card.** Splitting a card wins. Measured with an open-loop client at 42-token prompts, a colocated replica saturated at 21.16 requests per second and the same card split reached 28.90 and had not yet saturated. Nothing is divided in this shape: both halves draw on the same SMs, and the split only moves prefill off the decode scheduler thread.
+
+That result depends on sharing the weights. Without it the two halves load a copy each, which leaves them 22,206 KV tokens apiece instead of 665,596 between them.
+
+**Throughput across two cards.** One prefill half against one decode half has parity as its ceiling. That is arithmetic, not a defect: a card doing both jobs has the harmonic mean of its prefill-only and decode-only capacities, a 1:1 pair has the minimum of the two, and the minimum never exceeds the harmonic mean, with equality only when the halves are exactly balanced. So 1:1 across two cards is the wrong configuration to reach for when throughput is the goal.
+
+The measured gap is larger than the arithmetic predicts: PD's decode card carries about a 2.9x handicap while its prefill card carries none. Two candidates remain after measurement — the absence of mixed-chunk batching on the decode side, and the cost of receiving KV over CUDA IPC. The forced `page_size=1` and `disable_radix_cache` are not the cause: applied to a colocated replica on a workload with no prefix reuse they cost 2.6% and 0.6%, against an A/A band of 1.2%.
 
 ## Turn it on
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -123,6 +123,7 @@ Supported Models
    basic_usage/tts_process_topology.md
    basic_usage/omni_router.md
    basic_usage/mps_dp.md
+   basic_usage/pd_disaggregation.md
 
 
 .. toctree::

--- a/examples/configs/qwen3_omni_pd.yaml
+++ b/examples/configs/qwen3_omni_pd.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Two-GPU prefill/decode profile for the Qwen3-Omni thinker. Launch with
+#
+#   sgl-omni serve --config examples/configs/qwen3_omni_pd.yaml \
+#       --pd-stage thinker=0:1 --port 8000
+#
+# --pd-stage moves only the thinker, so the encoders stay on the GPU they
+# already had and the prefill card carries them as well. That card also holds
+# the CUDA-IPC relay pool for mm_aggregate, which a colocated deployment never
+# allocates and which is not reserved until the first payload crosses. The
+# thinker budget here is therefore lower than a colocated profile's: 0.75 runs
+# out of memory during prefill startup on an H200 with the encoders present.
+#
+# This is a text-output profile. The speech-output stages are not loaded.
+
+config_cls: Qwen3OmniPipelineConfig
+name: qwen3-omni-pd
+model_path: Qwen/Qwen3-Omni-30B-A3B-Instruct
+
+stage_overrides:
+  image_encoder:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.025
+
+  audio_encoder:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.025
+
+  thinker:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.68

--- a/examples/configs/qwen3_omni_pd.yaml
+++ b/examples/configs/qwen3_omni_pd.yaml
@@ -2,10 +2,9 @@
 #
 # Two-GPU prefill/decode profile for the Qwen3-Omni thinker. Launch with
 #
-#   sgl-omni serve --config examples/configs/qwen3_omni_pd.yaml \
-#       --pd-stage thinker=0:1 --port 8000
+#   sgl-omni serve --config examples/configs/qwen3_omni_pd.yaml --port 8000
 #
-# --pd-stage moves only the thinker, so the encoders stay on the GPU they
+# Splitting the thinker moves only the thinker, so the encoders stay on the GPU they
 # already had and the prefill card carries them as well. That card also holds
 # the CUDA-IPC relay pool for mm_aggregate, which a colocated deployment never
 # allocates and which is not reserved until the first payload crosses. The
@@ -20,16 +19,13 @@ model_path: Qwen/Qwen3-Omni-30B-A3B-Instruct
 
 stage_overrides:
   image_encoder:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.025
+    gpu_memory_fraction: 0.025
 
   audio_encoder:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.025
+    gpu_memory_fraction: 0.025
 
   thinker:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.68
+    gpu_memory_fraction: 0.68
+    pd_disaggregation:
+      prefill: {gpu: 0}
+      decode: {gpu: 1}


### PR DESCRIPTION
Adds the user-facing page for prefill/decode disaggregation, plus a two-GPU example config.

## Why it is separate

It documents the surface added in #1684 and does not depend on it to review. Splitting it keeps that PR to the mechanism and keeps this one to prose someone can read end to end. **Merge after #1684**, since the flag and the config fields the page describes come from there. This branch carries only the three doc files, so the diff shows nothing else.

## What the page says

`docs/basic_usage/` has pages for the other placement features, `mps_dp.md`, `tts_process_topology.md` and `process_topology_migration.md`, and none for PD, so a deployment meets `--pd-stage` with no guidance on when the split helps, what it costs, or how to size the halves.

The page leads with the decision rather than the flag, because for some workloads the answer is not to split.

**The split is three continuous choices, not one topology.** Which devices each half gets, each half's share of a device, and each half's own runtime settings are set separately. Both halves on one GPU already separates them: what PD needs is the process split, and a prefill step leaves the decode scheduler thread whichever card it runs on. A second card is an additional, separable decision about hardware.

**Prefill share sets what a second card can be worth.** It is prompt length divided by output length: about 2.6% at 42/128, about 9% at 6944/128, about 42% at 42/8. Splitting across two cards divides the hardware evenly, so against a 2.6% share the prefill card measured 10.1% mean utilization. Long prompts with short outputs earn a second card; short prompts with long outputs do not, and the same-GPU form separates the halves without one.

**Throughput and inter-token stability select different configurations.** A colocated replica pays 5.9x to 8.5x on the inter-token gap that overlaps a prefill on text and 8.4x to 20.5x on images; PD brings both to about 1.0x. For a stream with a repeating deadline that jitter is the SLO. For throughput, one half against one half on two cards has parity as its ceiling: a card doing both jobs has the harmonic mean of its prefill-only and decode-only capacities, a 1:1 pair has the minimum of the two, and the minimum never exceeds the harmonic mean. The configurations whose arithmetic differs are ratios other than 1:1, which are not configurable today, and both halves on one card. Neither is measured yet, and the page says so.

**Overload has three settings and they answer different questions.** `SGLANG_REQ_WAITING_TIMEOUT` bounds how long one request waits, `--max-queued-requests` bounds how many wait, and `--enable-priority-scheduling` decides which ones survive the bound. The page recommends the timeout as the primary bound for interactive serving, because a queue length converts to a wait only through the current service rate while a duration is the caller's own timeout, and keeps the length as the memory bound, which a duration cannot provide.

**The prefill card carries more than the flag moves.** `--pd-stage` moves only the named stage, so the encoders stay where they were and the CUDA-IPC relay pool appears on the prefill card. A thinker budget copied from a colocated profile runs it out of memory during startup.

Every number above comes from the equal-GPU-count comparison in #1696, which the page links, including the ones that argue against splitting.

## The example config

The colocated profiles cannot serve as a PD example. `Qwen3OmniSpeechColocatedPipelineConfig` requires the image encoder, audio encoder, thinker, talker and code2wav to share one GPU, which a split thinker contradicts, and it reports that as a request for exactly one GPU id for the thinker. `examples/configs/qwen3_omni_pd.yaml` is a text-output two-GPU profile with the thinker budget lowered to 0.68, because 0.75 runs the prefill half out of memory once the encoders and the relay pool are on that card.

## Testing

`--pd-stage thinker=0:1` with this config was run end to end on two H200s with #1684 and #1599 both applied: the two halves start as separate stage processes and a request returns 80 decoded tokens through the pair.

Related: #1684, #1599, #1696, #1709.
