### PR TITLE
feat(pd): bound how many handoffs hold Prefill KV at once

### DIFF
--- a/sglang_omni/config/pd_rewrite.py
+++ b/sglang_omni/config/pd_rewrite.py
@@ -156,7 +156,11 @@ def _split_pd_stage(
             "stream_to": [inbound_rename.get(t, t) for t in s.stream_to],
             "pd_disaggregation": None,
             # Note (Yue Yin): Keep compiler metadata out of user factory kwargs.
-            "pd_execution": PDExecution(role="prefill", partner=decode_name),
+            "pd_execution": PDExecution(
+                role="prefill",
+                partner=decode_name,
+                max_inflight_handoffs=pd.max_inflight_handoffs,
+            ),
         },
     )
 
@@ -175,7 +179,11 @@ def _split_pd_stage(
             "wait_for_fn": None,
             "merge_fn": None,
             "pd_disaggregation": None,
-            "pd_execution": PDExecution(role="decode", partner=prefill_name),
+            "pd_execution": PDExecution(
+                role="decode",
+                partner=prefill_name,
+                max_inflight_handoffs=pd.max_inflight_handoffs,
+            ),
         },
     )
 

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -145,6 +145,12 @@ class PDConfig(BaseModel):
 
     prefill: PDStagePlacement = Field(default_factory=PDStagePlacement)
     decode: PDStagePlacement = Field(default_factory=PDStagePlacement)
+    # Note (Audrey Zheng): how many handoffs the Prefill half may have in
+    # flight. Each one holds that request's prompt KV on the Prefill card
+    # until Decode acknowledges it, so this bounds how much of the Prefill
+    # pool sits in leases. Unset leaves the count where it lands today, which
+    # is Prefill's max_running_requests.
+    max_inflight_handoffs: int | None = Field(default=None, gt=0)
 
 
 class PDExecution(BaseModel):
@@ -159,6 +165,7 @@ class PDExecution(BaseModel):
 
     role: Literal["prefill", "decode"]
     partner: str
+    max_inflight_handoffs: int | None = None
 
 
 class StageConfig(BaseModel):

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -1061,6 +1061,26 @@ class Stage:
                 except _queue_mod.Empty:
                     break
 
+    def _pd_handoff_gate(self) -> Any:
+        """Return the semaphore bounding handoffs in flight, or None if unset.
+
+        Each handoff holds that request's prompt KV on the Prefill card until
+        Decode acknowledges it, through ``SGLangKVPageLease``. Without this the
+        count lands on Prefill's ``max_running_requests``, which was chosen to
+        size batches rather than to bound leases: measured at 256 offered, the
+        Prefill half held 64 handoffs in flight, and at a 6127-token image
+        prompt that is 392,128 tokens of lease against a 344,253-token pool.
+        """
+        gate = self.__dict__.get("_pd_handoff_semaphore")
+        if gate is not None:
+            return gate
+        limit = getattr(self.pd_execution, "max_inflight_handoffs", None)
+        if not limit:
+            return None
+        gate = asyncio.Semaphore(int(limit))
+        self._pd_handoff_semaphore = gate
+        return gate
+
     def _launch_pd_handoff(self, request_id: str, handoff: Any) -> None:
         # Note (Yue Yin): ACK latency must not stop this stage from draining
         # scheduler output for unrelated requests.
@@ -1072,6 +1092,17 @@ class Stage:
         )
 
     async def _send_pd_handoff(self, request_id: str, handoff: Any) -> None:
+        gate = self._pd_handoff_gate()
+        if gate is None:
+            await self._send_pd_handoff_now(request_id, handoff)
+            return
+        # Note (Audrey Zheng): the wait happens inside the task, so the stage
+        # keeps draining scheduler output for unrelated requests while a
+        # handoff queues for a slot.
+        async with gate:
+            await self._send_pd_handoff_now(request_id, handoff)
+
+    async def _send_pd_handoff_now(self, request_id: str, handoff: Any) -> None:
         metadata = PrefillContinuationProducer(tp_size=1).prepare_rank_metadata(
             handoff.continuation,
             0,

--- a/tests/unit_test/pipeline/test_pd_handoff_gate.py
+++ b/tests/unit_test/pipeline/test_pd_handoff_gate.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounding how many PD handoffs are in flight at once.
+
+Each handoff holds that request's prompt KV on the Prefill card until Decode
+acknowledges it. Without a bound the count lands on Prefill's
+max_running_requests, which sizes batches rather than leases.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from sglang_omni.config.schema import PDConfig, PDExecution
+from sglang_omni.pipeline.stage.runtime import StageRuntime
+from tests.unit_test.pipeline.helpers import stage
+
+
+def _runtime(limit: int | None) -> StageRuntime:
+    runtime = StageRuntime.__new__(StageRuntime)
+    runtime.pd_execution = PDExecution(
+        role="prefill", partner="thinker_decode", max_inflight_handoffs=limit
+    )
+    return runtime
+
+
+def test_an_unset_bound_installs_no_gate() -> None:
+    """Leaving it unset keeps today's behaviour rather than picking a number."""
+    assert _runtime(None)._pd_handoff_gate() is None
+
+
+def test_a_set_bound_installs_a_semaphore_of_that_size() -> None:
+    gate = _runtime(4)._pd_handoff_gate()
+
+    assert gate._value == 4
+
+
+def test_the_same_gate_is_reused_across_handoffs() -> None:
+    """A fresh semaphore per handoff would bound nothing."""
+    runtime = _runtime(4)
+
+    assert runtime._pd_handoff_gate() is runtime._pd_handoff_gate()
+
+
+def test_the_gate_admits_only_its_bound_at_once() -> None:
+    async def scenario() -> tuple[int, int]:
+        gate = _runtime(2)._pd_handoff_gate()
+        live = 0
+        peak = 0
+        release = asyncio.Event()
+
+        async def held() -> None:
+            nonlocal live, peak
+            async with gate:
+                live += 1
+                peak = max(peak, live)
+                await release.wait()
+                live -= 1
+
+        tasks = [asyncio.create_task(held()) for _ in range(6)]
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        observed = peak
+        release.set()
+        await asyncio.gather(*tasks)
+        return observed, peak
+
+    observed, _ = asyncio.run(scenario())
+    assert observed == 2
+
+
+def test_the_bound_reaches_both_halves_from_one_setting() -> None:
+    """It is a property of the pair, so the rewrite copies it to each half."""
+    from sglang_omni.config import expand_pd_stages
+    from sglang_omni.config.schema import PDStagePlacement
+
+    stages = [
+        stage(
+            "thinker",
+            terminal=True,
+            pd_disaggregation=PDConfig(
+                prefill=PDStagePlacement(gpu=0),
+                decode=PDStagePlacement(gpu=1),
+                max_inflight_handoffs=8,
+            ),
+        )
+    ]
+
+    halves = {s.name: s for s in expand_pd_stages(stages, entry_stage="thinker").stages}
+
+    assert halves["thinker_prefill"].pd_execution.max_inflight_handoffs == 8
+    assert halves["thinker_decode"].pd_execution.max_inflight_handoffs == 8
+
+
+def test_an_unset_bound_stays_unset_through_the_rewrite() -> None:
+    from sglang_omni.config import expand_pd_stages
+    from sglang_omni.config.schema import PDStagePlacement
+
+    stages = [
+        stage(
+            "thinker",
+            terminal=True,
+            pd_disaggregation=PDConfig(
+                prefill=PDStagePlacement(gpu=0), decode=PDStagePlacement(gpu=1)
+            ),
+        )
+    ]
+
+    halves = {s.name: s for s in expand_pd_stages(stages, entry_stage="thinker").stages}
+
+    assert halves["thinker_prefill"].pd_execution.max_inflight_handoffs is None

--- a/tests/unit_test/pipeline/test_pd_handoff_gate.py
+++ b/tests/unit_test/pipeline/test_pd_handoff_gate.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 
 import asyncio
 from sglang_omni.config.schema import PDConfig, PDExecution
-from sglang_omni.pipeline.stage.runtime import StageRuntime
+from sglang_omni.pipeline.stage.runtime import Stage
 from tests.unit_test.pipeline.helpers import stage
 
 
-def _runtime(limit: int | None) -> StageRuntime:
-    runtime = StageRuntime.__new__(StageRuntime)
+def _runtime(limit: int | None) -> Stage:
+    runtime = Stage.__new__(Stage)
     runtime.pd_execution = PDExecution(
         role="prefill", partner="thinker_decode", max_inflight_handoffs=limit
     )

--- a/tests/unit_test/pipeline/test_pd_handoff_gate.py
+++ b/tests/unit_test/pipeline/test_pd_handoff_gate.py
@@ -9,6 +9,7 @@ max_running_requests, which sizes batches rather than leases.
 from __future__ import annotations
 
 import asyncio
+
 from sglang_omni.config.schema import PDConfig, PDExecution
 from sglang_omni.pipeline.stage.runtime import Stage
 from tests.unit_test.pipeline.helpers import stage


### PR DESCRIPTION
One prefill/decode handoff holds that request's prompt KV on the Prefill card until Decode acknowledges it. Nothing bounded how many did so at once, so the count landed on Prefill's `max_running_requests`, a setting chosen to size batches rather than to bound leases.

## Measured

Two H200s, Qwen3-Omni thinker, `--pd-stage thinker=0:1`, 344,253 KV tokens per half. A high-water counter on `_launch_pd_handoff`:

| Client concurrency | Peak handoffs in flight |
| --- | --- |
| 64 | 27 |
| 256 | 64 |

At 256 the peak stops exactly at `max_running_requests=64` and does not grow further, so a bound does exist. It just is not a bound anyone set for this.

## Why that coupling matters

`SGLangKVPageLease` keeps Prefill KV alive until the receiver's ACK releases the source. Sixty-four leases at a 6127-token image prompt are 392,128 tokens against that run's 344,253-token pool, so on an image workload the running limit permits more lease than the pool holds. What actually stops it is the pool running out, which is not a designed admission point.

The two cannot be moved independently today: raising `max_running_requests` to widen batches also raises how much of the Prefill pool sits in leases, and lowering it to bound leases also narrows batches.

## The change

`pd_disaggregation.max_inflight_handoffs` separates them. Unset keeps today's behaviour rather than choosing a number, since the right value depends on prompt length and pool size. It is a property of the pair, so the graph rewrite copies it to both halves.

The wait happens inside the handoff task, not before it is created, so the stage keeps draining scheduler output for unrelated requests while a handoff queues for a slot. That preserves the reason `_launch_pd_handoff` was made asynchronous.

## What this does not do

It does not order the transfers. Handoffs still enter the outbox in `batch.reqs` order and take slots first-come. Priority and deadlines do not participate. Ordering is worth doing once requests carry a priority through the handoff, which #1709 adds.

Related: #1709, #1684, #1596.
