### PR TITLE
[Perf] Persistent lazy eviction heap for the radix tree cache

### DIFF
--- a/sglang_omni/scheduling/sglang_backend/cache.py
+++ b/sglang_omni/scheduling/sglang_backend/cache.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
-from sglang.srt.mem_cache.radix_cache import RadixCache
+from sglang_omni.scheduling.sglang_backend.evict_heap_radix_cache import (
+    EvictHeapRadixCache,
+)
 
 
 def create_tree_cache(
@@ -30,4 +32,4 @@ def create_tree_cache(
 
         return ChunkCache(params)
 
-    return RadixCache(params)
+    return EvictHeapRadixCache(params)

--- a/sglang_omni/scheduling/sglang_backend/cache.py
+++ b/sglang_omni/scheduling/sglang_backend/cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+
 from sglang_omni.scheduling.sglang_backend.evict_heap_radix_cache import (
     EvictHeapRadixCache,
 )

--- a/sglang_omni/scheduling/sglang_backend/cache.py
+++ b/sglang_omni/scheduling/sglang_backend/cache.py
@@ -18,7 +18,8 @@ def create_tree_cache(
     """Create a tree cache based on server_args.
 
     When radix cache is disabled we always return ChunkCache so the scheduler
-    keeps plain KV-cache semantics without any prefix matching.
+    keeps plain KV-cache semantics without any prefix matching. Non-lru
+    eviction policies fall back to the upstream RadixCache.
     """
     params = CacheInitParams(
         disable=server_args.disable_radix_cache,
@@ -26,6 +27,7 @@ def create_tree_cache(
         token_to_kv_pool_allocator=token_to_kv_pool_allocator,
         page_size=page_size,
         chunked_prefill_size=server_args.chunked_prefill_size,
+        eviction_policy=getattr(server_args, "radix_eviction_policy", "lru"),
     )
 
     if server_args.disable_radix_cache:
@@ -33,4 +35,9 @@ def create_tree_cache(
 
         return ChunkCache(params)
 
-    return EvictHeapRadixCache(params)
+    if params.eviction_policy.lower() == "lru":
+        return EvictHeapRadixCache(params)
+
+    from sglang.srt.mem_cache.radix_cache import RadixCache
+
+    return RadixCache(params)

--- a/sglang_omni/scheduling/sglang_backend/evict_heap_radix_cache.py
+++ b/sglang_omni/scheduling/sglang_backend/evict_heap_radix_cache.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+"""RadixCache with a persistent lazy eviction heap.
+
+Upstream ``RadixCache.evict`` rebuilds its eviction heap from every
+evictable leaf on each call (``list(...)`` + ``heapify``, O(L)). Under
+sustained load with few prefix hits the KV pool saturates, ``evict`` then
+fires on every allocation shortfall, and the scheduler thread spends its
+budget re-heapifying an ever-growing leaf set. This subclass keeps one
+min-heap alive across calls: push when a node becomes an evictable leaf,
+validate lazily at pop.
+
+Lazy validation is exact for eviction strategies whose priority is a
+non-decreasing function of node-local state (LRU/LFU/FIFO all qualify):
+a stale recorded priority is a lower bound on the current one, so the heap
+top never overtakes a fresher node and re-pushing refreshed nodes preserves
+the eviction order.
+"""
+
+from __future__ import annotations
+
+import heapq
+import time
+
+from sglang.srt.mem_cache.base_prefix_cache import EvictParams, EvictResult
+from sglang.srt.mem_cache.radix_cache import RadixCache, TreeNode
+
+
+class EvictHeapRadixCache(RadixCache):
+    def __init__(self, params):
+        # Before super().__init__: RadixCache.__init__ calls reset().
+        self._evict_heap: list = []
+        self._evict_heap_seq = 0
+        super().__init__(params)
+
+    def reset(self):
+        self._evict_heap.clear()
+        super().reset()
+
+    def _evict_heap_push(self, node: TreeNode) -> None:
+        self._evict_heap_seq += 1
+        heapq.heappush(
+            self._evict_heap,
+            (self.eviction_strategy.get_priority(node), self._evict_heap_seq, node),
+        )
+
+    def _evict_heap_rebuild(self) -> None:
+        self._evict_heap = [
+            (self.eviction_strategy.get_priority(n), i, n)
+            for i, n in enumerate(self.evictable_leaves)
+        ]
+        self._evict_heap_seq = len(self._evict_heap)
+        heapq.heapify(self._evict_heap)
+
+    def _update_leaf_status(self, node: TreeNode) -> None:
+        was_evictable = node in self.evictable_leaves
+        super()._update_leaf_status(node)
+        if not was_evictable and node in self.evictable_leaves:
+            self._evict_heap_push(node)
+
+    def evict(self, params: EvictParams) -> EvictResult:
+        if self.disable:
+            return EvictResult()
+
+        start_time = time.perf_counter()
+        num_tokens = params.num_tokens
+
+        # Compact when stale entries dominate, so heap size stays O(leaves).
+        if len(self._evict_heap) > max(1024, 4 * len(self.evictable_leaves)):
+            self._evict_heap_rebuild()
+        if not self._evict_heap and self.evictable_leaves:
+            # The push in _update_leaf_status should make this unreachable;
+            # rebuild rather than silently under-evict if it is ever violated.
+            self._evict_heap_rebuild()
+
+        num_evicted = 0
+        while num_evicted < num_tokens and self._evict_heap:
+            priority, _seq, x = heapq.heappop(self._evict_heap)
+
+            if x not in self.evictable_leaves:
+                # Stale: evicted earlier, locked, or no longer a leaf.
+                continue
+            current_priority = self.eviction_strategy.get_priority(x)
+            if current_priority != priority:
+                # Refreshed since push (priorities are non-decreasing):
+                # re-insert at the up-to-date priority and keep popping.
+                self._evict_heap_push(x)
+                continue
+
+            self.token_to_kv_pool_allocator.free(x.value)
+            num_evicted += len(x.value)
+            # _delete_leaf -> _update_leaf_status(parent) pushes the parent
+            # if it just became an evictable leaf.
+            self._delete_leaf(x)
+            self._record_remove_event(x)
+
+        self.update_eviction_metrics(num_evicted, start_time)
+        return EvictResult(num_tokens_evicted=num_evicted)

--- a/sglang_omni/scheduling/sglang_backend/evict_heap_radix_cache.py
+++ b/sglang_omni/scheduling/sglang_backend/evict_heap_radix_cache.py
@@ -26,6 +26,8 @@ class EvictHeapRadixCache(RadixCache):
             self._evict_heap,
             (self.eviction_strategy.get_priority(node), self._evict_heap_seq, node),
         )
+        if len(self._evict_heap) > max(1024, 4 * len(self.evictable_leaves)):
+            self._evict_heap_rebuild()
 
     def _evict_heap_rebuild(self) -> None:
         self._evict_heap = [
@@ -47,9 +49,6 @@ class EvictHeapRadixCache(RadixCache):
 
         start_time = time.perf_counter()
         num_tokens = params.num_tokens
-
-        if len(self._evict_heap) > max(1024, 4 * len(self.evictable_leaves)):
-            self._evict_heap_rebuild()
 
         num_evicted = 0
         while num_evicted < num_tokens and self._evict_heap:

--- a/sglang_omni/scheduling/sglang_backend/evict_heap_radix_cache.py
+++ b/sglang_omni/scheduling/sglang_backend/evict_heap_radix_cache.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""A RadixCache whose eviction heap persists across evict() calls."""
+"""A RadixCache whose eviction heap persists across evict() calls.
+
+Order-equivalent to RadixCache for lru only; the factory falls back to
+RadixCache for other policies.
+"""
 
 from __future__ import annotations
 

--- a/sglang_omni/scheduling/sglang_backend/evict_heap_radix_cache.py
+++ b/sglang_omni/scheduling/sglang_backend/evict_heap_radix_cache.py
@@ -1,19 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""RadixCache with a persistent lazy eviction heap.
+"""RadixCache variant with a persistent lazy min-heap over the evictable leaves.
 
-Upstream ``RadixCache.evict`` rebuilds its eviction heap from every
-evictable leaf on each call (``list(...)`` + ``heapify``, O(L)). Under
-sustained load with few prefix hits the KV pool saturates, ``evict`` then
-fires on every allocation shortfall, and the scheduler thread spends its
-budget re-heapifying an ever-growing leaf set. This subclass keeps one
-min-heap alive across calls: push when a node becomes an evictable leaf,
-validate lazily at pop.
-
-Lazy validation is exact for eviction strategies whose priority is a
-non-decreasing function of node-local state (LRU/LFU/FIFO all qualify):
-a stale recorded priority is a lower bound on the current one, so the heap
-top never overtakes a fresher node and re-pushing refreshed nodes preserves
-the eviction order.
+Pop-time validation is exact because every built-in eviction strategy's
+priority (LRU/LFU/FIFO) is non-decreasing in node-local state, so a stale
+entry is a lower bound and re-pushing a refreshed node preserves the order.
 """
 
 from __future__ import annotations
@@ -27,7 +17,7 @@ from sglang.srt.mem_cache.radix_cache import RadixCache, TreeNode
 
 class EvictHeapRadixCache(RadixCache):
     def __init__(self, params):
-        # Before super().__init__: RadixCache.__init__ calls reset().
+        # note (Junnan Li): set before super().__init__, which calls reset().
         self._evict_heap: list = []
         self._evict_heap_seq = 0
         super().__init__(params)
@@ -64,12 +54,8 @@ class EvictHeapRadixCache(RadixCache):
         start_time = time.perf_counter()
         num_tokens = params.num_tokens
 
-        # Compact when stale entries dominate, so heap size stays O(leaves).
+        # note (Junnan Li): compact at 4x staleness so heap size stays O(leaves).
         if len(self._evict_heap) > max(1024, 4 * len(self.evictable_leaves)):
-            self._evict_heap_rebuild()
-        if not self._evict_heap and self.evictable_leaves:
-            # The push in _update_leaf_status should make this unreachable;
-            # rebuild rather than silently under-evict if it is ever violated.
             self._evict_heap_rebuild()
 
         num_evicted = 0
@@ -77,19 +63,15 @@ class EvictHeapRadixCache(RadixCache):
             priority, _seq, x = heapq.heappop(self._evict_heap)
 
             if x not in self.evictable_leaves:
-                # Stale: evicted earlier, locked, or no longer a leaf.
                 continue
             current_priority = self.eviction_strategy.get_priority(x)
             if current_priority != priority:
-                # Refreshed since push (priorities are non-decreasing):
-                # re-insert at the up-to-date priority and keep popping.
                 self._evict_heap_push(x)
                 continue
 
             self.token_to_kv_pool_allocator.free(x.value)
             num_evicted += len(x.value)
-            # _delete_leaf -> _update_leaf_status(parent) pushes the parent
-            # if it just became an evictable leaf.
+            # note (Junnan Li): _delete_leaf relands the parent via _update_leaf_status.
             self._delete_leaf(x)
             self._record_remove_event(x)
 

--- a/sglang_omni/scheduling/sglang_backend/evict_heap_radix_cache.py
+++ b/sglang_omni/scheduling/sglang_backend/evict_heap_radix_cache.py
@@ -1,10 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""RadixCache variant with a persistent lazy min-heap over the evictable leaves.
-
-Pop-time validation is exact because every built-in eviction strategy's
-priority (LRU/LFU/FIFO) is non-decreasing in node-local state, so a stale
-entry is a lower bound and re-pushing a refreshed node preserves the order.
-"""
+"""A RadixCache whose eviction heap persists across evict() calls."""
 
 from __future__ import annotations
 
@@ -17,7 +12,6 @@ from sglang.srt.mem_cache.radix_cache import RadixCache, TreeNode
 
 class EvictHeapRadixCache(RadixCache):
     def __init__(self, params):
-        # note (Junnan Li): set before super().__init__, which calls reset().
         self._evict_heap: list = []
         self._evict_heap_seq = 0
         super().__init__(params)
@@ -54,7 +48,6 @@ class EvictHeapRadixCache(RadixCache):
         start_time = time.perf_counter()
         num_tokens = params.num_tokens
 
-        # note (Junnan Li): compact at 4x staleness so heap size stays O(leaves).
         if len(self._evict_heap) > max(1024, 4 * len(self.evictable_leaves)):
             self._evict_heap_rebuild()
 

--- a/sglang_omni/scheduling/sglang_backend/evict_heap_radix_cache.py
+++ b/sglang_omni/scheduling/sglang_backend/evict_heap_radix_cache.py
@@ -65,7 +65,8 @@ class EvictHeapRadixCache(RadixCache):
                 self._evict_heap_push(x)
                 continue
 
-            self.token_to_kv_pool_allocator.free(x.value)
+            # Tree values are page-aligned copies of a kv row: page-exact segment.
+            self.token_to_kv_pool_allocator.free_segment(x.value, start_pos=0)
             num_evicted += len(x.value)
             # note (Junnan Li): _delete_leaf relands the parent via _update_leaf_status.
             self._delete_leaf(x)

--- a/tests/README.md
+++ b/tests/README.md
@@ -210,6 +210,7 @@ tests/
     ├── scheduling/
     │   ├── test_deferred_admission.py
     │   ├── test_engine_factory.py
+    │   ├── test_evict_heap_radix_cache.py
     │   ├── test_pipeline_state.py
     │   ├── test_reference_encoder.py
     │   ├── test_stage_cache.py
@@ -482,6 +483,9 @@ that happened to contain an older version of the test.
   - static TTS `ModelCapabilities` declarations, registry lookup, aliases, and
     launcher startup logging.
 - `unit_test/scheduling/`: Shared scheduling-service unit tests:
+  - `EvictHeapRadixCache` eviction-order equivalence against upstream
+    `RadixCache` on randomized traces, heap boundedness and recovery after a
+    full drain, and reset-then-reuse behavior.
   - deferred request admission completion, abort, and dependency-failure
     semantics.
   - breakable prefill CUDA Graph policy: backend/cap/bucket validation, shared

--- a/tests/unit_test/scheduling/test_evict_heap_radix_cache.py
+++ b/tests/unit_test/scheduling/test_evict_heap_radix_cache.py
@@ -27,7 +27,7 @@ class _MockAllocator:
         return 1 << 30
 
 
-def _make(cache_cls):
+def _make(cache_cls, eviction_policy="lru"):
     """Simulated-cache builder; create_simulated hardcodes RadixCache."""
     return cache_cls(
         CacheInitParams(
@@ -36,6 +36,7 @@ def _make(cache_cls):
             token_to_kv_pool_allocator=_MockAllocator(),
             page_size=1,
             enable_kv_cache_events=False,
+            eviction_policy=eviction_policy,
         )
     )
 
@@ -84,6 +85,24 @@ def test_eviction_trace_matches_stock():
         patched_order = _run_trace(patched, seed)
         assert patched_order == stock_order
         assert len(patched.evictable_leaves) == len(stock.evictable_leaves)
+
+
+def test_factory_selects_evict_heap_only_for_lru():
+    from types import SimpleNamespace
+
+    from sglang_omni.scheduling.sglang_backend.cache import create_tree_cache
+
+    def build(policy):
+        args = SimpleNamespace(
+            disable_radix_cache=False,
+            chunked_prefill_size=None,
+            radix_eviction_policy=policy,
+        )
+        return create_tree_cache(args, None, _MockAllocator(), 1)
+
+    assert type(build("lru")) is EvictHeapRadixCache
+    for policy in ("mru", "priority", "lfu", "fifo", "filo"):
+        assert type(build(policy)) is RadixCache, policy
 
 
 def test_heap_stays_bounded_and_recovers():

--- a/tests/unit_test/scheduling/test_evict_heap_radix_cache.py
+++ b/tests/unit_test/scheduling/test_evict_heap_radix_cache.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import random
+
+import torch
+from sglang.srt.mem_cache.base_prefix_cache import EvictParams, InsertParams
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
+
+from sglang_omni.scheduling.sglang_backend.evict_heap_radix_cache import (
+    EvictHeapRadixCache,
+)
+
+
+class _MockAllocator:
+    device = "cpu"
+
+    def free(self, value):
+        pass
+
+    def free_segment(self, value, start_pos=0):
+        pass
+
+    def available_size(self):
+        return 1 << 30
+
+
+def _make(cache_cls):
+    # RadixCache.create_simulated hardcodes the base class, so build the
+    # params directly to instantiate subclasses.
+    return cache_cls(
+        CacheInitParams(
+            disable=False,
+            req_to_token_pool=None,
+            token_to_kv_pool_allocator=_MockAllocator(),
+            page_size=1,
+            enable_kv_cache_events=False,
+        )
+    )
+
+
+def _run_trace(cache, seed: int, steps: int = 4000) -> list[tuple[int, ...]]:
+    """Drive an identical insert/lock/unlock/evict trace; return eviction order."""
+    order = []
+    orig_delete = cache._delete_leaf
+    cache._delete_leaf = lambda node: (
+        order.append(tuple(node.key.token_ids)),
+        orig_delete(node),
+    )[1]
+
+    rng = random.Random(seed)
+    tok = 0
+    locked = []
+    for _ in range(steps):
+        op = rng.random()
+        if op < 0.62:
+            length = rng.randint(1, 12)
+            key = RadixKey(
+                token_ids=[rng.randint(0, 30) for _ in range(length)],
+                extra_key=str(rng.randint(0, 40)),
+            )
+            value = torch.arange(tok, tok + length)
+            tok += length
+            cache.insert(InsertParams(key=key, value=value))
+        elif op < 0.72 and cache.evictable_leaves:
+            node = rng.choice(sorted(cache.evictable_leaves, key=lambda x: x.id))
+            cache.inc_lock_ref(node)
+            locked.append(node)
+        elif op < 0.82 and locked:
+            cache.dec_lock_ref(locked.pop(rng.randrange(len(locked))))
+        else:
+            cache.evict(EvictParams(num_tokens=rng.randint(1, 40)))
+    cache.evict(EvictParams(num_tokens=1 << 20))
+    return order
+
+
+def test_eviction_trace_matches_stock():
+    for seed in (1234, 99, 2026):
+        stock = _make(RadixCache)
+        patched = _make(EvictHeapRadixCache)
+        stock_order = _run_trace(stock, seed)
+        patched_order = _run_trace(patched, seed)
+        assert patched_order == stock_order
+        assert len(patched.evictable_leaves) == len(stock.evictable_leaves)
+
+
+def test_heap_stays_bounded_and_recovers():
+    cache = _make(EvictHeapRadixCache)
+    _run_trace(cache, seed=7, steps=2000)
+    # Post-evict, live entries are bounded by the compaction threshold.
+    assert len(cache._evict_heap) <= max(1024, 4 * len(cache.evictable_leaves))
+    # The cache keeps working after a full drain.
+    key = RadixKey(token_ids=[1, 2, 3], extra_key="post")
+    cache.insert(InsertParams(key=key, value=torch.arange(3)))
+    result = cache.evict(EvictParams(num_tokens=1 << 20))
+    assert result.num_tokens_evicted >= 3
+    assert not cache.evictable_leaves
+
+
+def test_reset_clears_heap():
+    cache = _make(EvictHeapRadixCache)
+    key = RadixKey(token_ids=[5, 6, 7], extra_key="r")
+    cache.insert(InsertParams(key=key, value=torch.arange(3)))
+    assert cache._evict_heap
+    cache.reset()
+    assert not cache._evict_heap

--- a/tests/unit_test/scheduling/test_evict_heap_radix_cache.py
+++ b/tests/unit_test/scheduling/test_evict_heap_radix_cache.py
@@ -40,12 +40,12 @@ def _make(cache_cls):
     )
 
 
-def _run_trace(cache, seed: int, steps: int = 4000) -> list[tuple[int, ...]]:
+def _run_trace(cache, seed: int, steps: int = 4000, drain: bool = True) -> list:
     """Drive an identical insert/lock/unlock/evict trace; return eviction order."""
     order = []
     orig_delete = cache._delete_leaf
     cache._delete_leaf = lambda node: (
-        order.append(tuple(node.key.token_ids)),
+        order.append((node.key.extra_key, tuple(node.key.token_ids))),
         orig_delete(node),
     )[1]
 
@@ -71,7 +71,8 @@ def _run_trace(cache, seed: int, steps: int = 4000) -> list[tuple[int, ...]]:
             cache.dec_lock_ref(locked.pop(rng.randrange(len(locked))))
         else:
             cache.evict(EvictParams(num_tokens=rng.randint(1, 40)))
-    cache.evict(EvictParams(num_tokens=1 << 20))
+    if drain:
+        cache.evict(EvictParams(num_tokens=1 << 20))
     return order
 
 
@@ -87,9 +88,10 @@ def test_eviction_trace_matches_stock():
 
 def test_heap_stays_bounded_and_recovers():
     cache = _make(EvictHeapRadixCache)
-    _run_trace(cache, seed=7, steps=2000)
-    # Post-evict, live entries are bounded by the compaction threshold.
+    _run_trace(cache, seed=7, steps=2000, drain=False)
+    assert cache.evictable_leaves
     assert len(cache._evict_heap) <= max(1024, 4 * len(cache.evictable_leaves))
+    cache.evict(EvictParams(num_tokens=1 << 20))
     # The cache keeps working after a full drain.
     key = RadixKey(token_ids=[1, 2, 3], extra_key="post")
     cache.insert(InsertParams(key=key, value=torch.arange(3)))

--- a/tests/unit_test/scheduling/test_evict_heap_radix_cache.py
+++ b/tests/unit_test/scheduling/test_evict_heap_radix_cache.py
@@ -99,10 +99,19 @@ def test_heap_stays_bounded_and_recovers():
     assert not cache.evictable_leaves
 
 
-def test_reset_clears_heap():
+def test_reset_then_reuse():
     cache = _make(EvictHeapRadixCache)
-    key = RadixKey(token_ids=[5, 6, 7], extra_key="r")
-    cache.insert(InsertParams(key=key, value=torch.arange(3)))
-    assert cache._evict_heap
+    cache.insert(
+        InsertParams(
+            key=RadixKey(token_ids=[5, 6, 7], extra_key="r"), value=torch.arange(3)
+        )
+    )
     cache.reset()
-    assert not cache._evict_heap
+    cache.insert(
+        InsertParams(
+            key=RadixKey(token_ids=[8, 9], extra_key="r2"), value=torch.arange(2)
+        )
+    )
+    result = cache.evict(EvictParams(num_tokens=1 << 20))
+    assert result.num_tokens_evicted == 2
+    assert not cache.evictable_leaves

--- a/tests/unit_test/scheduling/test_evict_heap_radix_cache.py
+++ b/tests/unit_test/scheduling/test_evict_heap_radix_cache.py
@@ -28,8 +28,7 @@ class _MockAllocator:
 
 
 def _make(cache_cls):
-    # RadixCache.create_simulated hardcodes the base class, so build the
-    # params directly to instantiate subclasses.
+    """Simulated-cache builder; create_simulated hardcodes RadixCache."""
     return cache_cls(
         CacheInitParams(
             disable=False,


### PR DESCRIPTION
## Motivation

Fix the eviction-driven uptime throughput decay tracked in #1723: `RadixCache.evict` re-heapifies all evictable leaves on every call, O(leaves) on the scheduler thread once the pool saturates.

## Modifications

- Add `EvictHeapRadixCache`: a `RadixCache` subclass with a persistent lazy min-heap (push on leaf-add, validate at pop, compact on staleness); eviction order unchanged.
- Wire `create_tree_cache` to return it; `--disable-radix-cache` path unchanged.
- Unit tests: eviction-order equivalence vs upstream `RadixCache`, heap boundedness, reset.

## Related Issues

Fixes #1723

## Accuracy Test

Eviction order is bit-identical to upstream `RadixCache` on randomized traces (unit tests, 3 seeds).

## Benchmark & Profiling

qwen3_tts paired soak, 12 loops, c32, zero-hit traffic. The fix arm ran the identical persistent-heap patch applied directly to sglang 0.5.16's `RadixCache` (this PR relocates the same logic into the subclass; eviction order proven identical by the unit tests). The baseline arm steps down at loop 9, the fix arm stays flat. Post-saturation window (loop 9-12):

| Metric | Baseline (`RadixCache`) | Fix (persistent heap) | Delta |
| --- | --- | --- | --- |
| qps | 7.74-8.13 | 9.30-9.39 | +19% |
| latency p50 | 3.87-4.05s | 3.34-3.35s | -17% |
| latency p95 | 5.82-6.23s | 4.90-5.03s | -18% |
| latency p99 | 6.67-7.21s | 5.64-5.96s | -18% |
| audio ttfp p95 | 1.44-1.54s | 0.93-0.95s | -39% |

Pre-saturation window (loop 2-8): both arms 9.3-9.5 qps, no regression.

qwen3_asr paired soak, 25 loops, c32, emulated all-unique traffic, small pool; both arms saturate at loop 19-20. Post-saturation window (loop 20-25):

| Metric | Baseline (`RadixCache`) | Fix (persistent heap) | no-radix reference |
| --- | --- | --- | --- |
| qps | 28.8-54.4 | 137-172 | 245-270 |
| latency p95 | 1.85-2.58s | 0.43-0.45s | 0.16-0.36s |
| latency p99 | 1.93-2.66s | 0.43-0.62s | 0.20-0.50s |

The heap rebuild collapse is removed (~4-5x qps, ~5x p95 vs baseline); the residual gap to the no-radix reference is the intrinsic per-shortfall eviction work under all-unique traffic, which is what the zero-hit default-off option in #1723 addresses complementarily.

Per-model regression matrix (fix is default-on for every pipeline; normal replay traffic, default pools):

| Model | Design | qps delta | p95 delta | Verdict |
| --- | --- | --- | --- | --- |
| qwen3_tts (1.7B) | paired dual-GPU soak | +19% post-saturation | -18% | improvement |
| qwen3_asr (1.7B) | paired dual-GPU, unique traffic | 3-5x post-saturation | -83% | improvement |
| mtd | sequential single-GPU | +0.8% | -0.7% | flat |
| whisper | sequential single-GPU | +1.6% | -1.0% | flat |
| fun_asr | sequential single-GPU | +0.2% | -4.4% | flat |
| moss_tts | paired dual-GPU | +3.6% | -2.1% | flat / slightly positive |
| arkasr | paired dual-GPU | -1.0% | -0.3% | flat (silicon band) |

No pipeline regresses; the two saturation-exposed pipelines improve substantially.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from each family can be combined, for example
`/tag-and-rerun-ci moss fun-asr`. Draft PRs are skipped even if labeled.
