### PR TITLE
[NPU] Enable Voxtral TTS on a single Ascend NPU

### DIFF
--- a/sglang_omni/models/voxtral_tts/audio_tokenizer.py
+++ b/sglang_omni/models/voxtral_tts/audio_tokenizer.py
@@ -393,7 +393,7 @@ class Attention(nn.Module):
         else:
             output = self._native_attention(xq, xk, xv)
 
-        output = output.view(bsz, seqlen, self.n_local_heads * self.args.head_dim)
+        output = output.reshape(bsz, seqlen, self.n_local_heads * self.args.head_dim)
         return self.wo(output).squeeze(0)
 
 

--- a/sglang_omni/models/voxtral_tts/pipeline/stages.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/stages.py
@@ -180,6 +180,10 @@ def create_generation_executor(
         VoxtralTtsEngineBuilder,
     )
 
+    if gpu_id is not None:
+        device = str(current_platform.get_device(gpu_id))
+        gpu_id = None
+
     return VoxtralTtsEngineBuilder().build(
         model_path,
         device=device,
@@ -401,7 +405,7 @@ def create_vocoder_executor(
 ) -> SimpleScheduler:
     checkpoint_dir = _resolve_checkpoint(model_path)
     if gpu_id is not None:
-        device = f"cuda:{gpu_id}"
+        device = str(current_platform.get_device(gpu_id))
 
     logger.info("Loading Voxtral audio tokenizer for vocoding...")
     audio_tokenizer = _load_audio_tokenizer(checkpoint_dir, {}, device)

--- a/sglang_omni/models/voxtral_tts/pipeline/stages.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/stages.py
@@ -21,6 +21,7 @@ from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from sglang_omni.scheduling.vocoder_base import BatchVocoderBase
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoint
+from sglang_omni.utils.device import resolve_device_spec
 
 logger = logging.getLogger(__name__)
 
@@ -169,7 +170,7 @@ def _enable_inductor_gemm_autotune() -> None:
 def create_generation_executor(
     model_path: str,
     *,
-    device: str = "cuda:0",
+    device: str | None = None,
     gpu_id: int | None = None,
     max_new_tokens: int = 4096,
     server_args_overrides: dict[str, Any] | None = None,
@@ -179,10 +180,6 @@ def create_generation_executor(
     from sglang_omni.models.voxtral_tts.pipeline.engine_builder import (
         VoxtralTtsEngineBuilder,
     )
-
-    if gpu_id is not None:
-        device = str(current_platform.get_device(gpu_id))
-        gpu_id = None
 
     return VoxtralTtsEngineBuilder().build(
         model_path,
@@ -400,12 +397,11 @@ class _VoxtralTTSVocoder(BatchVocoderBase):
 def create_vocoder_executor(
     model_path: str,
     *,
-    device: str = "cuda:0",
+    device: str | None = None,
     gpu_id: int | None = None,
 ) -> SimpleScheduler:
     checkpoint_dir = _resolve_checkpoint(model_path)
-    if gpu_id is not None:
-        device = str(current_platform.get_device(gpu_id))
+    device = resolve_device_spec(device, gpu_id)
 
     logger.info("Loading Voxtral audio tokenizer for vocoding...")
     audio_tokenizer = _load_audio_tokenizer(checkpoint_dir, {}, device)

--- a/tests/unit_test/voxtral_tts/test_pipeline.py
+++ b/tests/unit_test/voxtral_tts/test_pipeline.py
@@ -48,6 +48,51 @@ def test_voxtral_tts_config_uses_current_stage_schema() -> None:
     )
 
 
+def test_voxtral_stage_factories_use_platform_devices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.voxtral_tts.pipeline import engine_builder
+
+    captured: dict[str, object] = {}
+
+    class FakeBuilder:
+        def build(self, model_path, **kwargs):
+            captured["build"] = (model_path, kwargs)
+            return "generation"
+
+    monkeypatch.setattr(engine_builder, "VoxtralTtsEngineBuilder", FakeBuilder)
+    monkeypatch.setattr(
+        stages.current_platform,
+        "get_device",
+        lambda gpu_id: f"npu:{gpu_id}",
+    )
+
+    generation = stages.create_generation_executor("model", gpu_id=3)
+
+    assert generation == "generation"
+    assert captured["build"] == (
+        "model",
+        {
+            "device": "npu:3",
+            "gpu_id": None,
+            "server_args_overrides": None,
+        },
+    )
+
+    seen_devices: list[str] = []
+    monkeypatch.setattr(stages, "_resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(
+        stages,
+        "_load_audio_tokenizer",
+        lambda _checkpoint, _config, device: (
+            seen_devices.append(device) or SimpleNamespace()
+        ),
+    )
+
+    stages.create_vocoder_executor("model", gpu_id=4)
+    assert seen_devices == ["npu:4"]
+
+
 def test_voxtral_radix_cache_is_namespaced_by_voice() -> None:
     """Different voice embeddings must not share a placeholder-token cache prefix."""
     model = SimpleNamespace(
@@ -171,6 +216,31 @@ def test_voxtral_audio_codes_payload_is_compact() -> None:
     assert "audio_codes_bytes" in data
     assert "audio_codes" not in data
     assert restored.audio_codes.tolist() == [[1, 2], [3, 4]]
+
+
+def test_voxtral_audio_attention_accepts_non_contiguous_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.voxtral_tts import audio_tokenizer
+
+    monkeypatch.setattr(audio_tokenizer, "HAS_FLASH_ATTN", False)
+    attention = audio_tokenizer.Attention(
+        SimpleNamespace(
+            n_heads=2,
+            n_kv_heads=2,
+            attn_sliding_window_size=8,
+            dim=4,
+            head_dim=2,
+            use_biases=False,
+            qk_norm=False,
+            causal=True,
+        ),
+        layer_id=0,
+    )
+
+    output = attention(torch.randn(3, 4))
+
+    assert output.shape == (3, 4)
 
 
 def test_voxtral_vocoder_preserves_warmup_trim_and_fade(

--- a/tests/unit_test/voxtral_tts/test_pipeline.py
+++ b/tests/unit_test/voxtral_tts/test_pipeline.py
@@ -48,7 +48,7 @@ def test_voxtral_tts_config_uses_current_stage_schema() -> None:
     )
 
 
-def test_voxtral_stage_factories_use_platform_devices(
+def test_voxtral_stage_factories_preserve_generation_placement_and_resolve_vocoder(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from sglang_omni.models.voxtral_tts.pipeline import engine_builder
@@ -61,25 +61,37 @@ def test_voxtral_stage_factories_use_platform_devices(
             return "generation"
 
     monkeypatch.setattr(engine_builder, "VoxtralTtsEngineBuilder", FakeBuilder)
-    monkeypatch.setattr(
-        stages.current_platform,
-        "get_device",
-        lambda gpu_id: f"npu:{gpu_id}",
-    )
-
     generation = stages.create_generation_executor("model", gpu_id=3)
 
     assert generation == "generation"
     assert captured["build"] == (
         "model",
         {
-            "device": "npu:3",
-            "gpu_id": None,
+            "device": None,
+            "gpu_id": 3,
+            "server_args_overrides": None,
+        },
+    )
+
+    stages.create_generation_executor("model", device="cuda:2", gpu_id=5)
+    assert captured["build"] == (
+        "model",
+        {
+            "device": "cuda:2",
+            "gpu_id": 5,
             "server_args_overrides": None,
         },
     )
 
     seen_devices: list[str] = []
+    resolved_devices: list[tuple[str | None, int | None]] = []
+    monkeypatch.setattr(
+        stages,
+        "resolve_device_spec",
+        lambda device, gpu_id: (
+            resolved_devices.append((device, gpu_id)) or f"npu:{gpu_id}"
+        ),
+    )
     monkeypatch.setattr(stages, "_resolve_checkpoint", lambda model_path: model_path)
     monkeypatch.setattr(
         stages,
@@ -90,6 +102,7 @@ def test_voxtral_stage_factories_use_platform_devices(
     )
 
     stages.create_vocoder_executor("model", gpu_id=4)
+    assert resolved_devices == [(None, 4)]
     assert seen_devices == ["npu:4"]
 
 


### PR DESCRIPTION
## Motivation

Voxtral TTS could not start on Ascend because its generation and vocoder stages derived CUDA device names. In addition, the audio-tokenizer attention path used `view` on an output that can be non-contiguous on NPU.

This PR is intentionally scoped to single-NPU inference. Voxtral 4B normally fits on one device, so tensor parallelism is not required for the default use case and is not part of this change.

## Modifications

| File | Change |
|---|---|
| `sglang_omni/models/voxtral_tts/pipeline/stages.py` | Preserve shared generation-device placement semantics and resolve the vocoder device through `resolve_device_spec(device, gpu_id)` |
| `sglang_omni/models/voxtral_tts/audio_tokenizer.py` | Use `reshape` for the potentially non-contiguous attention output |
| `tests/unit_test/voxtral_tts/test_pipeline.py` | Cover device routing, explicit-device preservation, and non-contiguous attention output |

There are no TP parameters, per-rank attention changes, or distributed initialization changes in this PR. The framework's existing single-device behavior remains unchanged.

## Related Issues

- Related to #1081.
- Builds on the platform abstraction introduced in #1306 and used for NPU talker support in #1476.

## Accuracy Test

Fresh post-review validation of commit `3fc97ce9` on one Ascend 910 NPU:

- Model: `mistralai/Voxtral-4B-TTS-2603`
- Dataset: SeedTTS EN, 1088 samples
- Generation: no reference audio, `cheerful_female`, WAV, `max_new_tokens=4096`
- Scorer: `openai/whisper-large-v3` revision `06f233fe06e710322aca913c1bc4249a0d71fce1`, also running on one NPU
- Coverage: 1088/1088 generated and evaluated, 0 generation failures, skipped=0
- Corpus WER: **1.1639%** (139/11943 word errors)
- Per-sample p95 WER: **9.09%**
- Samples above 50% WER: **0**
- Generation throughput: **3.766 req/s**
- Mean / p95 generation latency: **4.211 s / 6.482 s**
- Mean RTF: **0.7450**

Comparison with the upstream reference under the same SeedTTS EN / Whisper evaluation protocol:

| Result | Hardware | Corpus WER |
|---|---|---:|
| This PR (`3fc97ce9`) | 1x Ascend 910 NPU | **1.1639%** (139/11943) |
| Upstream Voxtral TTS cookbook | NVIDIA H200 | **1.20%** |

The hardware differs, so this is a reference comparison rather than a hardware-controlled benchmark. The single-NPU result is at the same accuracy level as the upstream reference and shows no observed accuracy regression from the device-routing and `reshape` changes.

## Validation

Fresh validation after the final review fix:

- NPU runtime smoke passed (`torch.npu.is_available() == True`, one device exposed, tensor operation succeeded).
- `pytest -q tests/unit_test/voxtral_tts`: **25 passed, 16 warnings in 12.74s**.
- Focused pipeline suite: **23 passed, 16 warnings in 13.51s**.
- End-to-end generation validation: **1088/1088**, 0 failed, 1088 valid WAVs.
- Whisper WER validation: **1088/1088**, skipped=0, all thresholds passed.
- Runtime topology logs show `tp_rank=0/1`, empty `tp_process_groups`, and `1 GPU(s)` for both Voxtral and Whisper.
- Python syntax compilation and `git diff --check` passed.
- CUDA CI remains the maintainer-side cross-platform check.

## Checklist

- [x] Format code according to project style.
- [x] Add unit tests.
- [x] Run fresh single-NPU unit and end-to-end accuracy validation.
- [x] Keep TP experiments out of this PR.
- [ ] Run maintainer CUDA CI.
