### PR TITLE
[Qwen3-TTS] Implement full-batch mixed sampling

### DIFF
--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -226,9 +226,7 @@ def _subtalker_dosample_flags(
     ratio: float,
 ) -> dict[str, bool]:
     if not 0.0 <= ratio <= 1.0:
-        raise ValueError(
-            f"--subtalker-dosample-ratio must be in [0, 1], got {ratio}"
-        )
+        raise ValueError(f"--subtalker-dosample-ratio must be in [0, 1], got {ratio}")
     flags: dict[str, bool] = {}
     for index, sample in enumerate(samples):
         dosample = math.floor((index + 1) * ratio) > math.floor(index * ratio)
@@ -296,9 +294,7 @@ def _make_subtalker_dosample_send_fn(
 ) -> SendFn:
     # Note (Shulei He): Qwen3-TTS-only: alternate subtalker_dosample per request for mixed
     # sampled/greedy predictor traffic.
-    dosample_by_id = _subtalker_dosample_flags(
-        samples, config.subtalker_dosample_ratio
-    )
+    dosample_by_id = _subtalker_dosample_flags(samples, config.subtalker_dosample_ratio)
     send_fn_true = make_tts_send_fn(
         config.model,
         api_url,

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -304,14 +304,14 @@ def _make_subtalker_dosample_send_fn(
         api_url,
         **common_send_kwargs,
         **generation_kwargs,
-        subtalker_dosample=True,
+        stage_params={"tts_engine": {"subtalker_dosample": True}},
     )
     send_fn_false = make_tts_send_fn(
         config.model,
         api_url,
         **common_send_kwargs,
         **generation_kwargs,
-        subtalker_dosample=False,
+        stage_params={"tts_engine": {"subtalker_dosample": False}},
     )
     send_fn_by_id = {
         sample_id: (send_fn_true if dosample else send_fn_false)

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -90,7 +90,12 @@ from pathlib import Path
 from typing import Any
 
 from benchmarks.benchmarker.data import RequestResult
-from benchmarks.benchmarker.runner import BenchmarkRunner, RunConfig, resolve_warmup
+from benchmarks.benchmarker.runner import (
+    BenchmarkRunner,
+    RunConfig,
+    SendFn,
+    resolve_warmup,
+)
 from benchmarks.benchmarker.utils import managed_omni_server
 from benchmarks.dataset.seedtts import SampleInput, load_seedtts_samples
 from benchmarks.metrics.performance import (
@@ -162,6 +167,10 @@ class TtsSeedttsBenchmarkConfig:
     top_k: int | None = None
     repetition_penalty: float | None = None
     seed: int | None = None
+    # Note (Shulei He): Fraction of requests sent with subtalker_dosample=True (rest use False),
+    # deterministically alternated by sample index so runs are reproducible.
+    # None leaves subtalker_dosample unset, i.e. the server-side default applies.
+    subtalker_dosample_ratio: float | None = None
     warmup: int | None = None
     concurrency: int = DEFAULT_TTS_BENCHMARK_CONCURRENCY
     request_rate: float = float("inf")
@@ -212,6 +221,21 @@ def _resolve_warmup(config: TtsSeedttsBenchmarkConfig) -> int:
     return resolve_warmup(config.warmup, config.concurrency)
 
 
+def _subtalker_dosample_flags(
+    samples: list[SampleInput],
+    ratio: float,
+) -> dict[str, bool]:
+    if not 0.0 <= ratio <= 1.0:
+        raise ValueError(
+            f"--subtalker-dosample-ratio must be in [0, 1], got {ratio}"
+        )
+    flags: dict[str, bool] = {}
+    for index, sample in enumerate(samples):
+        dosample = math.floor((index + 1) * ratio) > math.floor(index * ratio)
+        flags[sample.sample_id] = dosample
+    return flags
+
+
 def _build_results_config(
     config: TtsSeedttsBenchmarkConfig,
     *,
@@ -233,6 +257,7 @@ def _build_results_config(
         "sample_offset": config.sample_offset,
         "max_new_tokens": config.max_new_tokens,
         "seed": config.seed,
+        "subtalker_dosample_ratio": config.subtalker_dosample_ratio,
         "token_count": config.token_count,
         "warmup": _resolve_warmup(config),
         "concurrency": config.concurrency,
@@ -262,6 +287,44 @@ def _load_benchmark_samples(config: TtsSeedttsBenchmarkConfig) -> list[SampleInp
     return load_seedtts_samples(config.meta, config.max_samples, split=config.lang)
 
 
+def _make_subtalker_dosample_send_fn(
+    config: TtsSeedttsBenchmarkConfig,
+    api_url: str,
+    common_send_kwargs: dict,
+    generation_kwargs: dict,
+    samples: list[SampleInput],
+) -> SendFn:
+    # Note (Shulei He): Qwen3-TTS-only: alternate subtalker_dosample per request for mixed
+    # sampled/greedy predictor traffic.
+
+    dosample_by_id = _subtalker_dosample_flags(
+        samples, config.subtalker_dosample_ratio
+    )
+    send_fn_true = make_tts_send_fn(
+        config.model,
+        api_url,
+        **common_send_kwargs,
+        **generation_kwargs,
+        subtalker_dosample=True,
+    )
+    send_fn_false = make_tts_send_fn(
+        config.model,
+        api_url,
+        **common_send_kwargs,
+        **generation_kwargs,
+        subtalker_dosample=False,
+    )
+    send_fn_by_id = {
+        sample_id: (send_fn_true if dosample else send_fn_false)
+        for sample_id, dosample in dosample_by_id.items()
+    }
+
+    async def send_fn(session, sample):
+        return await send_fn_by_id[sample.sample_id](session, sample)
+
+    return send_fn
+
+
 async def run_tts_seedtts_benchmark(
     config: TtsSeedttsBenchmarkConfig,
     *,
@@ -286,9 +349,7 @@ async def run_tts_seedtts_benchmark(
         os.makedirs(config.output_dir, exist_ok=True)
 
     generation_kwargs = _build_generation_kwargs(config)
-    send_fn = make_tts_send_fn(
-        config.model,
-        api_url,
+    common_send_kwargs = dict(
         response_format=config.response_format,
         stream=config.stream,
         initial_codec_chunk_frames=config.initial_codec_chunk_frames,
@@ -299,8 +360,15 @@ async def run_tts_seedtts_benchmark(
         task_type=config.task_type,
         instructions=config.instructions,
         save_audio_dir=save_audio_dir,
-        **generation_kwargs,
     )
+    if config.subtalker_dosample_ratio is None:
+        send_fn = make_tts_send_fn(
+            config.model, api_url, **common_send_kwargs, **generation_kwargs
+        )
+    else:
+        send_fn = _make_subtalker_dosample_send_fn(
+            config, api_url, common_send_kwargs, generation_kwargs, samples
+        )
 
     runner = BenchmarkRunner(
         RunConfig(
@@ -390,6 +458,7 @@ def _config_from_args(args: argparse.Namespace) -> TtsSeedttsBenchmarkConfig:
         top_k=args.top_k,
         repetition_penalty=args.repetition_penalty,
         seed=args.seed,
+        subtalker_dosample_ratio=args.subtalker_dosample_ratio,
         warmup=args.warmup,
         concurrency=args.concurrency,
         request_rate=args.request_rate,
@@ -753,6 +822,18 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help="Per-request sampler seed for reproducible generation.",
+    )
+    parser.add_argument(
+        "--subtalker-dosample-ratio",
+        type=float,
+        default=None,
+        help=(
+            "Optional model-specific (Qwen3-TTS only) fraction of requests "
+            "sent with subtalker_dosample=True (the rest use False), "
+            "deterministically interleaved by sample index. 1.0 = all "
+            "sampled, 0.0 = all greedy, 0.5 = alternating mixed traffic. "
+            "Omit to leave subtalker_dosample unset (server-side default)."
+        ),
     )
     parser.add_argument(
         "--warmup",

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -296,7 +296,6 @@ def _make_subtalker_dosample_send_fn(
 ) -> SendFn:
     # Note (Shulei He): Qwen3-TTS-only: alternate subtalker_dosample per request for mixed
     # sampled/greedy predictor traffic.
-
     dosample_by_id = _subtalker_dosample_flags(
         samples, config.subtalker_dosample_ratio
     )

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -217,6 +217,12 @@ def build_qwen3_tts_state(payload: StagePayload) -> Qwen3TTSState:
     tts_params = metadata.get("tts_params")
     if not isinstance(tts_params, dict):
         tts_params = {}
+    stage_params = params.get("stage_params")
+    tts_engine_params = {}
+    if isinstance(stage_params, dict) and isinstance(
+        stage_params.get("tts_engine"), dict
+    ):
+        tts_engine_params = stage_params["tts_engine"]
 
     text, references = normalize_qwen3_tts_inputs(inputs)
     has_reference = has_voice_clone_reference(references, tts_params)
@@ -309,7 +315,11 @@ def build_qwen3_tts_state(payload: StagePayload) -> Qwen3TTSState:
         ),
         x_vector_only_mode=x_vector_only_mode,
         non_streaming_mode=non_streaming_mode,
-        generation_kwargs=build_generation_kwargs(params, tts_params=tts_params),
+        generation_kwargs=build_generation_kwargs(
+            params,
+            tts_params=tts_params,
+            tts_engine_params=tts_engine_params,
+        ),
         seed=normalized_seed,
     )
 
@@ -448,6 +458,7 @@ def build_generation_kwargs(
     params: dict[str, Any],
     *,
     tts_params: dict[str, Any],
+    tts_engine_params: dict[str, Any],
 ) -> dict[str, Any]:
     explicit_generation_params = tts_params.get("explicit_generation_params")
     if isinstance(explicit_generation_params, (list, tuple, set)):
@@ -455,25 +466,29 @@ def build_generation_kwargs(
     else:
         explicit_fields = set()
 
-    selected_fields = set()
+    selected_fields: dict[str, Any] = {}
     for field in _GENERATION_FIELDS:
+        stage_value = tts_engine_params.get(field)
+        if stage_value is not None:
+            selected_fields[field] = stage_value
+            continue
         value = params.get(field)
         if value is None:
             continue
         if field in _IMPLICIT_SAMPLING_DEFAULTS and field not in explicit_fields:
             if value in _IMPLICIT_SAMPLING_DEFAULTS[field]:
                 continue
-        selected_fields.add(field)
+        selected_fields[field] = value
 
-    max_new_tokens = params.get("max_new_tokens")
+    max_new_tokens = selected_fields.get("max_new_tokens")
     if max_new_tokens is None:
         max_new_tokens = QWEN3_TTS_DEFAULT_MAX_NEW_TOKENS
     generation_kwargs: dict[str, Any] = {"max_new_tokens": int(max_new_tokens)}
     for field in _GENERATION_FIELDS:
         if field == "max_new_tokens":
             continue
-        if field in selected_fields and params.get(field) is not None:
-            generation_kwargs[field] = params[field]
+        if field in selected_fields:
+            generation_kwargs[field] = selected_fields[field]
     return generation_kwargs
 
 

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -68,8 +68,8 @@ class _PredictorDecodeGraph:
     """CUDA graph over the full per-token predictor chain for one batch bucket.
 
     One graph per (bucket, sampling signature): the signature pins the host
-    branches of the eager sampling path (argmax vs sampled vs mixed, top-k
-    bound, top-p presence), so replay reproduces the eager sampling bits.
+    branches of the eager sampling path (argmax vs sampled, top-k bound,
+    top-p presence), so replay reproduces the eager sampling bits.
     Per-step inputs reach the captured region through persistent device
     buffers written with device-side copies before replay.
     """
@@ -521,7 +521,6 @@ class Qwen3TTSTalker(nn.Module):
         self._predictor_graph_capacity_fallback_count = 0
         self._predictor_graph_capacity_warned = False
         self._predictor_graph_capture_count = 0
-        self._predictor_graph_replay_count = 0
         self._predictor_graph_pool = None
         _bind_default_weight_loaders(self)
         self._cached_params_dict = dict(self.named_parameters())
@@ -1229,11 +1228,11 @@ class Qwen3TTSTalker(nn.Module):
             self._sub_sampled_max_top_k,
             self._sub_sampled_has_unbounded_top_k,
         )
-        mode = signature[0]
+        sampled = signature[0] == "sampled"
         try:
             self._sub_batch_size = bucket_size
-            self._sub_has_sampled_rows = mode == "sampled"
-            self._sub_sample_count = bucket_size if mode == "sampled" else 0
+            self._sub_has_sampled_rows = sampled
+            self._sub_sample_count = bucket_size if sampled else 0
             _, max_top_k, has_top_p, has_unbounded_top_k = signature
             self._sub_sampled_max_top_k = max_top_k
             self._sub_sampled_has_top_p = has_top_p
@@ -1337,7 +1336,6 @@ class Qwen3TTSTalker(nn.Module):
             self._predictor_graph_capture_count += 1
             logger.info("Captured Qwen3-TTS predictor CUDA graph for key=%s", key)
         result = graph.replay(layer0_codes, talker_hidden, semantic_positions)
-        self._predictor_graph_replay_count += 1
         return result
 
     def _code_predictor_forward_incremental(
@@ -1520,10 +1518,6 @@ class Qwen3TTSTalker(nn.Module):
             row_indices=row_indices,
             semantic_positions=batch_positions,
         )
-        # Note: always compute argmax + where here (never take the
-        # all-sampled shortcut) so a fully-sampled batch and a mixed batch
-        # replay the exact same captured kernel sequence, letting them share
-        # one CUDA graph key instead of capturing two ("sampled"/"mixed").
         argmax_tokens = torch.argmax(logits, dim=-1).to(dtype=torch.long)
         return torch.where(
             self._sub_do_sample_tensor[:batch_size],

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -68,7 +68,7 @@ class _PredictorDecodeGraph:
     """CUDA graph over the full per-token predictor chain for one batch bucket.
 
     One graph per (bucket, sampling signature): the signature pins the host
-    branches of the eager sampling path (argmax vs all-rows-sampled, top-k
+    branches of the eager sampling path (argmax vs sampled vs mixed, top-k
     bound, top-p presence), so replay reproduces the eager sampling bits.
     Per-step inputs reach the captured region through persistent device
     buffers written with device-side copies before replay.
@@ -94,7 +94,6 @@ class _PredictorDecodeGraph:
         self.semantic_positions = torch.zeros(
             batch_size, dtype=torch.long, device=device
         )
-        self.identity_rows = torch.arange(batch_size, dtype=torch.long, device=device)
         self.graph = torch.cuda.CUDAGraph()
         self.result_codes: torch.Tensor | None = None
         self.summed_embeddings: torch.Tensor | None = None
@@ -174,12 +173,6 @@ class _PredictorDecodeGraph:
                 self.talker_hidden[live:].zero_()
                 if semantic_positions is not None:
                     self.semantic_positions[live:].zero_()
-            if self.signature[0] == "sampled":
-                # Note: (Jiaxin Deng) restore identity row indices; the captured
-                # path reads [:bucket] and a mixed batch may have scrambled it.
-                self.model._sub_sample_row_indices_tensor[: self.batch_size].copy_(
-                    self.identity_rows
-                )
             self.graph.replay()
         assert self.result_codes is not None
         assert self.summed_embeddings is not None
@@ -497,8 +490,11 @@ class Qwen3TTSTalker(nn.Module):
         self._sub_sampling_seed_tensor = torch.zeros(
             max_batch_size, device=device, dtype=torch.long
         )
+        self._sub_do_sample_tensor = torch.zeros(
+            max_batch_size, device=device, dtype=torch.bool
+        )
         self._sub_sample_rows: list[int] = []
-        self._sub_sample_row_indices_tensor = torch.empty(
+        self._sub_identity_row_indices_tensor = torch.arange(
             max_batch_size, device=device, dtype=torch.long
         )
         self._sub_sample_count = 0
@@ -517,6 +513,8 @@ class Qwen3TTSTalker(nn.Module):
         # defers graph capture past init, so nothing is decided here.
         self._predictor_graph_enabled: bool | None = None
         self._predictor_graph_failure_count = 0
+        self._predictor_graph_capacity_fallback_count = 0
+        self._predictor_graph_capacity_warned = False
         self._predictor_graph_pool = None
         _bind_default_weight_loaders(self)
         self._cached_params_dict = dict(self.named_parameters())
@@ -1001,6 +999,7 @@ class Qwen3TTSTalker(nn.Module):
         sub_top_ps: list[float] = []
         sub_top_ks: list[int] = []
         sub_seeds: list[int] = []
+        sub_do_samples: list[bool] = []
         self._sub_sample_rows = []
         for row_idx, sched_req in enumerate(requests):
             data = sched_req.data
@@ -1022,9 +1021,12 @@ class Qwen3TTSTalker(nn.Module):
                     "subtalker sampling fields"
                 ) from exc
             semantic_seeds.append(semantic_seed)
-            sub_temperatures.append(subtalker_temperature)
-            sub_top_ps.append(subtalker_top_p)
-            sub_top_ks.append(subtalker_top_k)
+            sub_do_samples.append(do_sample)
+            # Greedy rows still participate in the fixed-shape sampled path for
+            # mixed batches. Give their discarded sample valid, narrow params.
+            sub_temperatures.append(subtalker_temperature if do_sample else 1.0)
+            sub_top_ps.append(subtalker_top_p if do_sample else 1.0)
+            sub_top_ks.append(subtalker_top_k if do_sample else 1)
             sub_seeds.append(subtalker_seed)
             if do_sample:
                 self._sub_sample_rows.append(row_idx)
@@ -1078,10 +1080,9 @@ class Qwen3TTSTalker(nn.Module):
         self._sub_sampling_seed_tensor[:batch_size] = torch.tensor(
             sub_seeds, device=device, dtype=self._sub_sampling_seed_tensor.dtype
         )
-        if self._sub_sample_count:
-            self._sub_sample_row_indices_tensor[: self._sub_sample_count] = (
-                torch.tensor(self._sub_sample_rows, device=device, dtype=torch.long)
-            )
+        self._sub_do_sample_tensor[:batch_size] = torch.tensor(
+            sub_do_samples, device=device, dtype=torch.bool
+        )
         self._decode_prep_rids = rids
 
     @torch.no_grad()
@@ -1199,12 +1200,8 @@ class Qwen3TTSTalker(nn.Module):
             return ("argmax", 0, False, False)
         if semantic_positions is None:
             return None
-        if self._sub_sample_count != batch_size:
-            # Note: (Jiaxin Deng) mixed sampled/argmax batches take
-            # count-dependent shapes; they stay on the eager path.
-            return None
         return (
-            "sampled",
+            "sampled" if self._sub_sample_count == batch_size else "mixed",
             int(self._sub_sampled_max_top_k),
             bool(self._sub_sampled_has_top_p),
             bool(self._sub_sampled_has_unbounded_top_k),
@@ -1215,44 +1212,35 @@ class Qwen3TTSTalker(nn.Module):
         saved = (
             self._sub_batch_size,
             self._sub_sample_count,
-            self._sub_sample_rows,
             self._sub_has_sampled_rows,
             self._sub_sampled_has_top_p,
             self._sub_sampled_max_top_k,
             self._sub_sampled_has_unbounded_top_k,
         )
-        sampled = signature[0] == "sampled"
+        mode = signature[0]
         try:
             self._sub_batch_size = bucket_size
-            self._sub_has_sampled_rows = sampled
-            self._sub_sample_count = bucket_size if sampled else 0
-            self._sub_sample_rows = list(range(bucket_size)) if sampled else []
+            self._sub_has_sampled_rows = mode in ("sampled", "mixed")
+            if mode == "sampled":
+                self._sub_sample_count = bucket_size
+            elif mode == "mixed":
+                self._sub_sample_count = max(bucket_size - 1, 1)
+            else:
+                self._sub_sample_count = 0
             _, max_top_k, has_top_p, has_unbounded_top_k = signature
             self._sub_sampled_max_top_k = max_top_k
             self._sub_sampled_has_top_p = has_top_p
             self._sub_sampled_has_unbounded_top_k = has_unbounded_top_k
-            if sampled:
-                self._sub_sample_row_indices_tensor[:bucket_size].copy_(
-                    torch.arange(
-                        bucket_size,
-                        device=self._sub_sample_row_indices_tensor.device,
-                        dtype=torch.long,
-                    )
-                )
             yield
         finally:
             (
                 self._sub_batch_size,
                 self._sub_sample_count,
-                self._sub_sample_rows,
                 self._sub_has_sampled_rows,
                 self._sub_sampled_has_top_p,
                 self._sub_sampled_max_top_k,
                 self._sub_sampled_has_unbounded_top_k,
             ) = saved
-            # Note: (Jiaxin Deng) capture overwrote the staged row-indices
-            # tensor; drop the reuse fingerprint so the next prepare restages.
-            self._decode_prep_rids = None
 
     def _predictor_graph_memory_pool(self):
         # Note: (Jiaxin Deng) one shared pool across keys; private per-graph
@@ -1304,6 +1292,15 @@ class Qwen3TTSTalker(nn.Module):
         graph = self._predictor_graphs.get(key)
         if graph is None:
             if len(self._predictor_graphs) >= _PREDICTOR_GRAPH_MAX_KEYS:
+                self._predictor_graph_capacity_fallback_count += 1
+                if not self._predictor_graph_capacity_warned:
+                    self._predictor_graph_capacity_warned = True
+                    logger.warning(
+                        "Qwen3-TTS predictor CUDA graph cache reached %d keys; "
+                        "falling back to eager execution for uncached key=%s",
+                        _PREDICTOR_GRAPH_MAX_KEYS,
+                        key,
+                    )
                 return None
             try:
                 graph = _PredictorDecodeGraph(
@@ -1449,31 +1446,26 @@ class Qwen3TTSTalker(nn.Module):
         if not self._sub_has_sampled_rows:
             return torch.argmax(logits, dim=-1).to(dtype=torch.long)
 
-        if self._sub_sample_rows[-1] >= batch_size:
-            raise RuntimeError("Qwen3-TTS sampled row index exceeds batch size")
-        sampled_rows = self._sub_sample_row_indices_tensor[: self._sub_sample_count]
-        sampled_positions = self._select_semantic_positions(
+        row_indices = self._sub_identity_row_indices_tensor[:batch_size]
+        batch_positions = self._select_semantic_positions(
             semantic_positions,
             batch_size,
             logits.device,
         )
-        if self._sub_sample_count == batch_size:
-            return self._sample_subtalker_token_seeded(
-                logits,
-                layer_idx,
-                row_indices=sampled_rows,
-                semantic_positions=sampled_positions,
-            )
-
-        tokens = torch.argmax(logits, dim=-1).to(dtype=torch.long)
-        sampled_logits = logits.index_select(0, sampled_rows)
-        tokens[sampled_rows] = self._sample_subtalker_token_seeded(
-            sampled_logits,
+        sampled_tokens = self._sample_subtalker_token_seeded(
+            logits,
             layer_idx,
-            row_indices=sampled_rows,
-            semantic_positions=sampled_positions,
+            row_indices=row_indices,
+            semantic_positions=batch_positions,
         )
-        return tokens
+        if self._sub_sample_count == batch_size:
+            return sampled_tokens
+        argmax_tokens = torch.argmax(logits, dim=-1).to(dtype=torch.long)
+        return torch.where(
+            self._sub_do_sample_tensor[:batch_size],
+            sampled_tokens,
+            argmax_tokens,
+        )
 
     def _select_semantic_positions(
         self,
@@ -1486,8 +1478,7 @@ class Qwen3TTSTalker(nn.Module):
         semantic_positions = semantic_positions.to(device=device, dtype=torch.long)
         if semantic_positions.ndim != 1 or semantic_positions.shape[0] != batch_size:
             raise ValueError("Qwen3-TTS subtalker positions shape mismatch")
-        sample_rows = self._sub_sample_row_indices_tensor[: self._sub_sample_count]
-        return semantic_positions.index_select(0, sample_rows)
+        return semantic_positions
 
     def _sample_subtalker_token_seeded(
         self,

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -125,6 +125,7 @@ class _PredictorDecodeGraph:
                         self.layer0_codes,
                         self.talker_hidden,
                         semantic_positions=self.semantic_positions,
+                        for_capture=True,
                     )
             current_stream.wait_stream(warmup_stream)
 
@@ -141,6 +142,7 @@ class _PredictorDecodeGraph:
                         self.layer0_codes,
                         self.talker_hidden,
                         semantic_positions=self.semantic_positions,
+                        for_capture=True,
                     )
                 )
             current_stream.wait_stream(capture_stream)
@@ -475,6 +477,7 @@ class Qwen3TTSTalker(nn.Module):
             max_batch_size, hidden_size, device=device, dtype=dtype
         )
         self._sub_batch_size = 0
+        self._sub_sample_max_row_index = -1
         self._sub_temperature_tensor = torch.full(
             (max_batch_size,), 0.9, device=device, dtype=torch.float32
         )
@@ -493,8 +496,10 @@ class Qwen3TTSTalker(nn.Module):
         self._sub_do_sample_tensor = torch.zeros(
             max_batch_size, device=device, dtype=torch.bool
         )
-        self._sub_sample_rows: list[int] = []
         self._sub_identity_row_indices_tensor = torch.arange(
+            max_batch_size, device=device, dtype=torch.long
+        )
+        self._sub_sample_row_indices_tensor = torch.zeros(
             max_batch_size, device=device, dtype=torch.long
         )
         self._sub_sample_count = 0
@@ -515,6 +520,8 @@ class Qwen3TTSTalker(nn.Module):
         self._predictor_graph_failure_count = 0
         self._predictor_graph_capacity_fallback_count = 0
         self._predictor_graph_capacity_warned = False
+        self._predictor_graph_capture_count = 0
+        self._predictor_graph_replay_count = 0
         self._predictor_graph_pool = None
         _bind_default_weight_loaders(self)
         self._cached_params_dict = dict(self.named_parameters())
@@ -1000,7 +1007,7 @@ class Qwen3TTSTalker(nn.Module):
         sub_top_ks: list[int] = []
         sub_seeds: list[int] = []
         sub_do_samples: list[bool] = []
-        self._sub_sample_rows = []
+        sample_rows: list[int] = []
         for row_idx, sched_req in enumerate(requests):
             data = sched_req.data
             try:
@@ -1022,25 +1029,26 @@ class Qwen3TTSTalker(nn.Module):
                 ) from exc
             semantic_seeds.append(semantic_seed)
             sub_do_samples.append(do_sample)
-            # Greedy rows still participate in the fixed-shape sampled path for
-            # mixed batches. Give their discarded sample valid, narrow params.
+            # Note (Shulei He): a greedy row's original top_k can be 0 or -1,
+            # which would otherwise hit the full-sort branch.
             sub_temperatures.append(subtalker_temperature if do_sample else 1.0)
             sub_top_ps.append(subtalker_top_p if do_sample else 1.0)
             sub_top_ks.append(subtalker_top_k if do_sample else 1)
             sub_seeds.append(subtalker_seed)
             if do_sample:
-                self._sub_sample_rows.append(row_idx)
+                sample_rows.append(row_idx)
 
         predictor_vocab_size = int(self.config.code_predictor_config.vocab_size)
-        sampled_top_ks = [sub_top_ks[row_idx] for row_idx in self._sub_sample_rows]
+        sampled_top_ks = [sub_top_ks[row_idx] for row_idx in sample_rows]
         bounded_top_ks = [
             top_k for top_k in sampled_top_ks if 0 < int(top_k) < predictor_vocab_size
         ]
         self._sub_batch_size = batch_size
-        self._sub_sample_count = len(self._sub_sample_rows)
-        self._sub_has_sampled_rows = bool(self._sub_sample_rows)
+        self._sub_sample_count = len(sample_rows)
+        self._sub_sample_max_row_index = sample_rows[-1] if sample_rows else -1
+        self._sub_has_sampled_rows = bool(sample_rows)
         self._sub_sampled_has_top_p = any(
-            0.0 < float(sub_top_ps[row_idx]) < 1.0 for row_idx in self._sub_sample_rows
+            0.0 < float(sub_top_ps[row_idx]) < 1.0 for row_idx in sample_rows
         )
         has_unbounded_top_k = len(bounded_top_ks) != len(sampled_top_ks)
         max_top_k = 0
@@ -1083,6 +1091,10 @@ class Qwen3TTSTalker(nn.Module):
         self._sub_do_sample_tensor[:batch_size] = torch.tensor(
             sub_do_samples, device=device, dtype=torch.bool
         )
+        if sample_rows:
+            self._sub_sample_row_indices_tensor[: len(sample_rows)] = torch.tensor(
+                sample_rows, device=device, dtype=torch.long
+            )
         self._decode_prep_rids = rids
 
     @torch.no_grad()
@@ -1201,7 +1213,7 @@ class Qwen3TTSTalker(nn.Module):
         if semantic_positions is None:
             return None
         return (
-            "sampled" if self._sub_sample_count == batch_size else "mixed",
+            "sampled",
             int(self._sub_sampled_max_top_k),
             bool(self._sub_sampled_has_top_p),
             bool(self._sub_sampled_has_unbounded_top_k),
@@ -1220,13 +1232,8 @@ class Qwen3TTSTalker(nn.Module):
         mode = signature[0]
         try:
             self._sub_batch_size = bucket_size
-            self._sub_has_sampled_rows = mode in ("sampled", "mixed")
-            if mode == "sampled":
-                self._sub_sample_count = bucket_size
-            elif mode == "mixed":
-                self._sub_sample_count = max(bucket_size - 1, 1)
-            else:
-                self._sub_sample_count = 0
+            self._sub_has_sampled_rows = mode == "sampled"
+            self._sub_sample_count = bucket_size if mode == "sampled" else 0
             _, max_top_k, has_top_p, has_unbounded_top_k = signature
             self._sub_sampled_max_top_k = max_top_k
             self._sub_sampled_has_top_p = has_top_p
@@ -1327,14 +1334,19 @@ class Qwen3TTSTalker(nn.Module):
                     )
                 return None
             self._predictor_graphs[key] = graph
+            self._predictor_graph_capture_count += 1
             logger.info("Captured Qwen3-TTS predictor CUDA graph for key=%s", key)
-        return graph.replay(layer0_codes, talker_hidden, semantic_positions)
+        result = graph.replay(layer0_codes, talker_hidden, semantic_positions)
+        self._predictor_graph_replay_count += 1
+        return result
 
     def _code_predictor_forward_incremental(
         self,
         layer0_codes: torch.Tensor,
         talker_hidden: torch.Tensor,
         semantic_positions: torch.Tensor | None = None,
+        *,
+        for_capture: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         if layer0_codes.ndim == 1:
             layer0_codes = layer0_codes.unsqueeze(1)
@@ -1392,6 +1404,7 @@ class Qwen3TTSTalker(nn.Module):
                     logits[:, -1, :],
                     layer_idx,
                     semantic_positions=semantic_positions[:, pos],
+                    for_capture=for_capture,
                 )
                 pos_codes[:, layer_idx + 1].copy_(next_code)
                 new_embed = self.code_predictor.model.codec_embedding[layer_idx](
@@ -1436,6 +1449,55 @@ class Qwen3TTSTalker(nn.Module):
         layer_idx: int = 0,
         *,
         semantic_positions: torch.Tensor | None = None,
+        for_capture: bool = False,
+    ) -> torch.Tensor:
+        if for_capture:
+            return self._sample_subtalker_token_graph_safe(
+                logits, layer_idx, semantic_positions=semantic_positions
+            )
+
+        if logits.shape[0] == 0:
+            return torch.empty((0,), device=logits.device, dtype=torch.long)
+        batch_size = int(logits.shape[0])
+        if batch_size > self._sub_batch_size:
+            raise RuntimeError("Qwen3-TTS subtalker sampling buffers are too small")
+
+        if not self._sub_has_sampled_rows:
+            return torch.argmax(logits, dim=-1).to(dtype=torch.long)
+
+        if self._sub_sample_max_row_index >= batch_size:
+            raise RuntimeError("Qwen3-TTS sampled row index exceeds batch size")
+        sampled_rows = self._sub_sample_row_indices_tensor[: self._sub_sample_count]
+        sampled_positions = self._select_semantic_positions(
+            semantic_positions,
+            batch_size,
+            logits.device,
+        ).index_select(0, sampled_rows)
+
+        if self._sub_sample_count == batch_size:
+            return self._sample_subtalker_token_seeded(
+                logits,
+                layer_idx,
+                row_indices=sampled_rows,
+                semantic_positions=sampled_positions,
+            )
+
+        tokens = torch.argmax(logits, dim=-1).to(dtype=torch.long)
+        sampled_logits = logits.index_select(0, sampled_rows)
+        tokens[sampled_rows] = self._sample_subtalker_token_seeded(
+            sampled_logits,
+            layer_idx,
+            row_indices=sampled_rows,
+            semantic_positions=sampled_positions,
+        )
+        return tokens
+
+    def _sample_subtalker_token_graph_safe(
+        self,
+        logits: torch.Tensor,
+        layer_idx: int = 0,
+        *,
+        semantic_positions: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if logits.shape[0] == 0:
             return torch.empty((0,), device=logits.device, dtype=torch.long)
@@ -1458,8 +1520,10 @@ class Qwen3TTSTalker(nn.Module):
             row_indices=row_indices,
             semantic_positions=batch_positions,
         )
-        if self._sub_sample_count == batch_size:
-            return sampled_tokens
+        # Note: always compute argmax + where here (never take the
+        # all-sampled shortcut) so a fully-sampled batch and a mixed batch
+        # replay the exact same captured kernel sequence, letting them share
+        # one CUDA graph key instead of capturing two ("sampled"/"mixed").
         argmax_tokens = torch.argmax(logits, dim=-1).to(dtype=torch.long)
         return torch.where(
             self._sub_do_sample_tensor[:batch_size],

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -1906,8 +1906,6 @@ class OmniScheduler:
 
     def _admin_model_info(self) -> dict[str, Any]:
         info = self.model_worker.model_info()
-        if self._model_runner is not None and hasattr(self._model_runner, "stats"):
-            info.update(self._model_runner.stats())
         with self._request_admission_lock:
             request_build_pending = len(self._pending_request_builds)
             request_admission_pending = len(self._pending_request_admissions)

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -1906,6 +1906,8 @@ class OmniScheduler:
 
     def _admin_model_info(self) -> dict[str, Any]:
         info = self.model_worker.model_info()
+        if self._model_runner is not None and hasattr(self._model_runner, "stats"):
+            info.update(self._model_runner.stats())
         with self._request_admission_lock:
             request_build_pending = len(self._pending_request_builds)
             request_admission_pending = len(self._pending_request_admissions)

--- a/tests/test_model/test_qwen3_tts_batch_invariance.py
+++ b/tests/test_model/test_qwen3_tts_batch_invariance.py
@@ -205,7 +205,6 @@ def test_qwen3_tts_deterministic_batch_invariance(
 def test_qwen3_tts_mixed_sampled_argmax_batch_invariance(
     tmp_path_factory: pytest.TempPathFactory,
 ) -> None:
-    """Match serial execution and a mixed sampled/greedy batch of eight."""
     if not torch.cuda.is_available():
         pytest.skip("Qwen3-TTS batch invariance requires CUDA")
     if not Path(DATASET).exists():

--- a/tests/test_model/test_qwen3_tts_batch_invariance.py
+++ b/tests/test_model/test_qwen3_tts_batch_invariance.py
@@ -107,7 +107,7 @@ async def _generate_batch(
     return outputs
 
 
-def _payload(sample) -> dict:
+def _payload(sample, *, subtalker_dosample: bool | None = None) -> dict:
     return {
         "model": MODEL_PATH,
         "input": sample.target_text,
@@ -116,6 +116,7 @@ def _payload(sample) -> dict:
         "response_format": "wav",
         "seed": SEED,
         "max_new_tokens": 2048,
+        "stage_params": {"tts_engine": {"subtalker_dosample": subtalker_dosample}},
     }
 
 
@@ -183,6 +184,43 @@ def test_qwen3_tts_deterministic_batch_invariance(
         payload["input"] = " ".join([sample.target_text] * 3)
         payloads.append(payload)
     assert len({payload["ref_text"] for payload in payloads}) == 8
+
+    payload = payloads[0]
+    with _qwen3_tts_server(tmp_path_factory, "b1") as server:
+        b1 = asyncio.run(_generate_serial(server.base_url, payloads))
+        repeated_b1 = asyncio.run(_generate_serial(server.base_url, [payload] * 2))
+        _assert_uncached_reference_encode(server.log_file)
+
+    with _qwen3_tts_server(tmp_path_factory, "b8") as server:
+        mixed_b8 = asyncio.run(_generate_batch(server.base_url, payloads))
+        _assert_uncached_reference_encode(server.log_file)
+        repeated_b8 = asyncio.run(_generate_batch(server.base_url, [payload] * 8))
+
+    assert mixed_b8 == b1
+    assert all(pcm == b1[0] for pcm in repeated_b1)
+    assert all(pcm == b1[0] for pcm in repeated_b8)
+
+
+@pytest.mark.benchmark
+def test_qwen3_tts_mixed_sampled_argmax_batch_invariance(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """Match serial execution and a mixed sampled/greedy batch of eight."""
+    if not torch.cuda.is_available():
+        pytest.skip("Qwen3-TTS batch invariance requires CUDA")
+    if not Path(DATASET).exists():
+        download_dataset(DATASET, quiet=True)
+
+    payloads = []
+    for index, sample in enumerate(load_seedtts_samples(DATASET, 8, split="en")):
+        payload = _payload(sample, subtalker_dosample=index % 2 == 0)
+        payload["input"] = " ".join([sample.target_text] * 3)
+        payloads.append(payload)
+    assert len({payload["ref_text"] for payload in payloads}) == 8
+    assert {
+        payload["stage_params"]["tts_engine"]["subtalker_dosample"]
+        for payload in payloads
+    } == {False, True}
 
     payload = payloads[0]
     with _qwen3_tts_server(tmp_path_factory, "b1") as server:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -4186,6 +4186,7 @@ def test_qwen3_tts_prepare_decode_buffers_collects_private_subtalker_seeds(
     talker._sub_sampling_seed_tensor = torch.empty(2, dtype=torch.long)
     talker._sub_do_sample_tensor = torch.empty(2, dtype=torch.bool)
     talker._sub_identity_row_indices_tensor = torch.arange(2, dtype=torch.long)
+    talker._sub_sample_row_indices_tensor = torch.empty(2, dtype=torch.long)
     requests = [
         SimpleNamespace(
             data=Qwen3TTSSGLangRequestData(
@@ -4275,6 +4276,8 @@ def test_qwen3_tts_subtalker_sampling_batches_sampled_path_without_global_rng(
     talker._sub_sampling_seed_tensor = torch.tensor([17, 23])
     talker._sub_do_sample_tensor = torch.tensor([True, True])
     talker._sub_identity_row_indices_tensor = torch.tensor([0, 1])
+    talker._sub_sample_row_indices_tensor = torch.tensor([0, 1])
+    talker._sub_sample_max_row_index = 1
     talker._sub_sample_count = 2
     talker._sub_has_sampled_rows = True
     talker._sub_sampled_has_top_p = False
@@ -4391,6 +4394,8 @@ def test_qwen3_tts_sampled_subtalker_requires_semantic_positions(
     talker._sub_sampling_seed_tensor = torch.tensor([17])
     talker._sub_do_sample_tensor = torch.tensor([True])
     talker._sub_identity_row_indices_tensor = torch.tensor([0])
+    talker._sub_sample_row_indices_tensor = torch.tensor([0])
+    talker._sub_sample_max_row_index = 0
     talker._sub_sample_count = 1
     talker._sub_has_sampled_rows = True
     talker._sub_sampled_has_top_p = False

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -4912,6 +4912,7 @@ def _make_prep_talker(monkeypatch):
     talker._sub_sampling_seed_tensor = torch.empty(2, dtype=torch.long)
     talker._sub_do_sample_tensor = torch.empty(2, dtype=torch.bool)
     talker._sub_identity_row_indices_tensor = torch.arange(2, dtype=torch.long)
+    talker._sub_sample_row_indices_tensor = torch.empty(2, dtype=torch.long)
     return Qwen3TTSTalker, talker
 
 

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -4147,7 +4147,8 @@ def test_qwen3_tts_prepare_decode_buffers_collects_private_subtalker_seeds(
     talker._sub_top_k_tensor = torch.empty(2, dtype=torch.long)
     talker._semantic_sampling_seed_tensor = torch.empty(2, dtype=torch.long)
     talker._sub_sampling_seed_tensor = torch.empty(2, dtype=torch.long)
-    talker._sub_sample_row_indices_tensor = torch.empty(2, dtype=torch.long)
+    talker._sub_do_sample_tensor = torch.empty(2, dtype=torch.bool)
+    talker._sub_identity_row_indices_tensor = torch.arange(2, dtype=torch.long)
     requests = [
         SimpleNamespace(
             data=Qwen3TTSSGLangRequestData(
@@ -4177,9 +4178,11 @@ def test_qwen3_tts_prepare_decode_buffers_collects_private_subtalker_seeds(
     assert talker._semantic_sampling_seed_tensor[:2].tolist() == [5, 9]
     assert talker._sub_sampling_seed_tensor[:2].tolist() == [7, 11]
     assert talker._sub_temperature_tensor[:2].tolist() == pytest.approx([0.8, 1.0])
+    assert talker._sub_top_k_tensor[:2].tolist() == [40, 1]
+    assert talker._sub_do_sample_tensor[:2].tolist() == [True, False]
     assert talker._sub_sample_rows == [0]
     assert talker._sub_sample_count == 1
-    assert talker._sub_sample_row_indices_tensor[:1].tolist() == [0]
+    assert talker._sub_identity_row_indices_tensor.tolist() == [0, 1]
     assert talker._sub_has_sampled_rows is True
     assert talker._sub_sampled_has_top_p is True
     # top_k=40 ladder-quantizes to 50 (shared predictor-graph key width).
@@ -4234,8 +4237,9 @@ def test_qwen3_tts_subtalker_sampling_batches_sampled_path_without_global_rng(
     talker._sub_top_p_tensor = torch.tensor([1.0, 1.0])
     talker._sub_top_k_tensor = torch.tensor([-1, -1])
     talker._sub_sampling_seed_tensor = torch.tensor([17, 23])
+    talker._sub_do_sample_tensor = torch.tensor([True, True])
     talker._sub_sample_rows = [0, 1]
-    talker._sub_sample_row_indices_tensor = torch.tensor([0, 1])
+    talker._sub_identity_row_indices_tensor = torch.tensor([0, 1])
     talker._sub_sample_count = 2
     talker._sub_has_sampled_rows = True
     talker._sub_sampled_has_top_p = False
@@ -4350,8 +4354,9 @@ def test_qwen3_tts_sampled_subtalker_requires_semantic_positions(
     talker._sub_top_p_tensor = torch.tensor([1.0])
     talker._sub_top_k_tensor = torch.tensor([-1])
     talker._sub_sampling_seed_tensor = torch.tensor([17])
+    talker._sub_do_sample_tensor = torch.tensor([True])
     talker._sub_sample_rows = [0]
-    talker._sub_sample_row_indices_tensor = torch.tensor([0])
+    talker._sub_identity_row_indices_tensor = torch.tensor([0])
     talker._sub_sample_count = 1
     talker._sub_has_sampled_rows = True
     talker._sub_sampled_has_top_p = False
@@ -4871,7 +4876,8 @@ def _make_prep_talker(monkeypatch):
     talker._sub_top_k_tensor = torch.empty(2, dtype=torch.long)
     talker._semantic_sampling_seed_tensor = torch.empty(2, dtype=torch.long)
     talker._sub_sampling_seed_tensor = torch.empty(2, dtype=torch.long)
-    talker._sub_sample_row_indices_tensor = torch.empty(2, dtype=torch.long)
+    talker._sub_do_sample_tensor = torch.empty(2, dtype=torch.bool)
+    talker._sub_identity_row_indices_tensor = torch.arange(2, dtype=torch.long)
     return Qwen3TTSTalker, talker
 
 

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -362,6 +362,43 @@ def test_qwen3_tts_ignores_client_sampling_defaults() -> None:
     assert state.generation_kwargs == {"max_new_tokens": 2048}
 
 
+def test_qwen3_tts_forwards_tts_engine_stage_sampling_params() -> None:
+    sampled_payload = make_payload(
+        inputs="sampled",
+        params={
+            "subtalker_dosample": False,
+            "subtalker_top_k": 1,
+            "stage_params": {
+                "tts_engine": {
+                    "subtalker_dosample": True,
+                    "subtalker_temperature": 0.7,
+                    "subtalker_top_p": 0.8,
+                    "subtalker_top_k": 40,
+                }
+            },
+        },
+    )
+    greedy_payload = make_payload(
+        inputs="greedy",
+        params={"stage_params": {"tts_engine": {"subtalker_dosample": False}}},
+    )
+
+    sampled_state = build_qwen3_tts_state(sampled_payload)
+    greedy_state = build_qwen3_tts_state(greedy_payload)
+
+    assert sampled_state.generation_kwargs == {
+        "max_new_tokens": 2048,
+        "subtalker_dosample": True,
+        "subtalker_temperature": 0.7,
+        "subtalker_top_p": 0.8,
+        "subtalker_top_k": 40,
+    }
+    assert greedy_state.generation_kwargs == {
+        "max_new_tokens": 2048,
+        "subtalker_dosample": False,
+    }
+
+
 def test_qwen3_tts_embedding_cache_keys_are_stable_and_content_based() -> None:
     """Protects radix-cache keys for Qwen requests that prefill with embeddings."""
     embeds = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
@@ -4180,7 +4217,6 @@ def test_qwen3_tts_prepare_decode_buffers_collects_private_subtalker_seeds(
     assert talker._sub_temperature_tensor[:2].tolist() == pytest.approx([0.8, 1.0])
     assert talker._sub_top_k_tensor[:2].tolist() == [40, 1]
     assert talker._sub_do_sample_tensor[:2].tolist() == [True, False]
-    assert talker._sub_sample_rows == [0]
     assert talker._sub_sample_count == 1
     assert talker._sub_identity_row_indices_tensor.tolist() == [0, 1]
     assert talker._sub_has_sampled_rows is True
@@ -4238,7 +4274,6 @@ def test_qwen3_tts_subtalker_sampling_batches_sampled_path_without_global_rng(
     talker._sub_top_k_tensor = torch.tensor([-1, -1])
     talker._sub_sampling_seed_tensor = torch.tensor([17, 23])
     talker._sub_do_sample_tensor = torch.tensor([True, True])
-    talker._sub_sample_rows = [0, 1]
     talker._sub_identity_row_indices_tensor = torch.tensor([0, 1])
     talker._sub_sample_count = 2
     talker._sub_has_sampled_rows = True
@@ -4355,7 +4390,6 @@ def test_qwen3_tts_sampled_subtalker_requires_semantic_positions(
     talker._sub_top_k_tensor = torch.tensor([-1])
     talker._sub_sampling_seed_tensor = torch.tensor([17])
     talker._sub_do_sample_tensor = torch.tensor([True])
-    talker._sub_sample_rows = [0]
     talker._sub_identity_row_indices_tensor = torch.tensor([0])
     talker._sub_sample_count = 1
     talker._sub_has_sampled_rows = True

--- a/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
+++ b/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
@@ -173,7 +173,6 @@ def _build_talker(device: torch.device) -> Qwen3TTSTalker:
     talker._predictor_graph_capacity_fallback_count = 0
     talker._predictor_graph_capacity_warned = False
     talker._predictor_graph_capture_count = 0
-    talker._predictor_graph_replay_count = 0
     talker._predictor_graph_pool = None
     return talker
 

--- a/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
+++ b/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
@@ -405,6 +405,10 @@ def test_mixed_sampled_argmax_rows_use_graph_bit_identity(
     monkeypatch.setattr(
         Qwen3TTSTalker, "_sample_subtalker_token_seeded", real_seeded
     )
+    
+    talker.prepare_decode_buffers(
+        [_request(dosample=False), _request(dosample=False)]
+    )
     argmax_codes, _ = talker._code_predictor_forward_incremental(
         layer0, hidden, semantic_positions=positions
     )

--- a/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
+++ b/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
@@ -405,7 +405,6 @@ def test_mixed_sampled_argmax_rows_use_graph_bit_identity(
     monkeypatch.setattr(
         Qwen3TTSTalker, "_sample_subtalker_token_seeded", real_seeded
     )
-    
     talker.prepare_decode_buffers(
         [_request(dosample=False), _request(dosample=False)]
     )

--- a/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
+++ b/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
@@ -566,22 +566,27 @@ def test_capture_failure_disables_key_and_falls_back(
 def test_capture_failure_restores_live_sub_state(monkeypatch: pytest.MonkeyPatch):
     device = torch.device("cuda")
     talker = _build_talker(device)
-    talker.prepare_decode_buffers(_uniform_requests(2))
+    talker.prepare_decode_buffers(
+        [
+            _request(dosample=True, sub_seed=1000, semantic_seed=2000),
+            _request(dosample=False, sub_seed=1001, semantic_seed=2001),
+        ]
+    )
     layer0, hidden, positions = _step_inputs(2, device)
 
     class _BoomGraph:
         def __init__(self, model, bucket_size, signature, **kwargs) -> None:
             del kwargs
-            with model._predictor_graph_capture_state(4, ("argmax", 0, False, False)):
+            with model._predictor_graph_capture_state(bucket_size, signature):
                 raise RuntimeError("simulated capture failure")
 
     monkeypatch.setattr(sglang_model_module, "_PredictorDecodeGraph", _BoomGraph)
     _run_forward(talker, layer0, hidden, positions)
 
     assert talker._sub_batch_size == 2
-    assert talker._sub_sample_count == 2
+    assert talker._sub_sample_count == 1
     assert talker._sub_has_sampled_rows is True
-    assert talker._sub_do_sample_tensor[:2].tolist() == [True, True]
+    assert talker._sub_do_sample_tensor[:2].tolist() == [True, False]
 
 
 class _NoHostReadbackTensor(torch.Tensor):

--- a/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
+++ b/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
@@ -110,8 +110,10 @@ def _build_talker(device: torch.device) -> Qwen3TTSTalker:
         MAX_BS, device=device, dtype=torch.long
     )
     talker._sub_do_sample_tensor = torch.zeros(MAX_BS, device=device, dtype=torch.bool)
-    talker._sub_sample_rows = []
     talker._sub_identity_row_indices_tensor = torch.arange(
+        MAX_BS, device=device, dtype=torch.long
+    )
+    talker._sub_sample_row_indices_tensor = torch.zeros(
         MAX_BS, device=device, dtype=torch.long
     )
     talker._sub_sample_count = 0
@@ -170,6 +172,8 @@ def _build_talker(device: torch.device) -> Qwen3TTSTalker:
     talker._predictor_graph_failure_count = 0
     talker._predictor_graph_capacity_fallback_count = 0
     talker._predictor_graph_capacity_warned = False
+    talker._predictor_graph_capture_count = 0
+    talker._predictor_graph_replay_count = 0
     talker._predictor_graph_pool = None
     return talker
 
@@ -334,7 +338,7 @@ def test_mixed_padded_bucket_bit_identity_and_reuse():
     eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
     graph_codes, graph_embeds = _run_forward(talker, layer0, hidden, positions)
 
-    assert any(key[0] == 4 and key[1] == "mixed" for key in talker._predictor_graphs)
+    assert any(key[0] == 4 and key[1] == "sampled" for key in talker._predictor_graphs)
     assert torch.equal(graph_codes, eager_codes)
     assert torch.equal(graph_embeds, eager_embeds)
 
@@ -373,15 +377,24 @@ def test_graph_multi_step_replay_bit_identity():
 
 @pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
-def test_mixed_sampled_argmax_rows_use_graph_bit_identity():
+def test_mixed_sampled_argmax_rows_use_graph_bit_identity(
+    monkeypatch: pytest.MonkeyPatch,
+):
     device = torch.device("cuda")
     talker = _build_talker(device)
-    with torch.no_grad():
-        for head in talker.code_predictor.lm_head:
-            head.proj.weight.zero_()
     requests = [_request(dosample=True), _request(dosample=False)]
     talker.prepare_decode_buffers(requests)
     layer0, hidden, positions = _step_inputs(2, device)
+
+    real_seeded = Qwen3TTSTalker._sample_subtalker_token_seeded
+
+    def _sentinel_seeded(self, logits, layer_idx, *, row_indices, semantic_positions):
+        del self, layer_idx, row_indices, semantic_positions
+        return (torch.argmax(logits, dim=-1) + 1) % PRED_VOCAB
+
+    monkeypatch.setattr(
+        Qwen3TTSTalker, "_sample_subtalker_token_seeded", _sentinel_seeded
+    )
 
     eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
     graph_codes, graph_embeds = _run_forward(talker, layer0, hidden, positions)
@@ -389,9 +402,20 @@ def test_mixed_sampled_argmax_rows_use_graph_bit_identity():
     assert talker._predictor_graphs, "mixed batch did not capture a graph"
     assert torch.equal(graph_codes, eager_codes)
     assert torch.equal(graph_embeds, eager_embeds)
-    assert (
-        torch.count_nonzero(graph_codes[1, 1:]) == 0
-    ), "argmax row must choose the first token from exact predictor-logit ties"
+
+    monkeypatch.setattr(
+        Qwen3TTSTalker, "_sample_subtalker_token_seeded", real_seeded
+    )
+    argmax_codes, _ = talker._code_predictor_forward_incremental(
+        layer0, hidden, semantic_positions=positions
+    )
+
+    assert not torch.equal(graph_codes[0, 1:], argmax_codes[0, 1:]), (
+        "sampled row matches pure argmax -- the seeded path was not exercised"
+    )
+    assert torch.equal(graph_codes[1, 1:], argmax_codes[1, 1:]), (
+        "argmax row was affected by the seeded-sampling sentinel"
+    )
 
 
 @pytest.mark.accelerator
@@ -450,7 +474,7 @@ def test_mixed_sampling_masks_reuse_one_graph():
 
 @pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
-def test_all_sampled_and_mixed_batches_use_distinct_graphs():
+def test_all_sampled_and_mixed_batches_share_one_graph():
     device = torch.device("cuda")
     talker = _build_talker(device)
     layer0, hidden, positions = _step_inputs(4, device)
@@ -469,8 +493,8 @@ def test_all_sampled_and_mixed_batches_use_distinct_graphs():
     _run_forward(talker, layer0, hidden, positions)
 
     modes = {key[1] for key in talker._predictor_graphs}
-    assert modes == {"sampled", "mixed"}
-    assert len(talker._predictor_graphs) == 2
+    assert modes == {"sampled"}
+    assert len(talker._predictor_graphs) == 1
 
 
 @pytest.mark.accelerator
@@ -546,7 +570,7 @@ def test_capture_failure_restores_live_sub_state(monkeypatch: pytest.MonkeyPatch
     class _BoomGraph:
         def __init__(self, model, bucket_size, signature, **kwargs) -> None:
             del kwargs
-            with model._predictor_graph_capture_state(bucket_size, signature):
+            with model._predictor_graph_capture_state(4, ("argmax", 0, False, False)):
                 raise RuntimeError("simulated capture failure")
 
     monkeypatch.setattr(sglang_model_module, "_PredictorDecodeGraph", _BoomGraph)
@@ -554,7 +578,8 @@ def test_capture_failure_restores_live_sub_state(monkeypatch: pytest.MonkeyPatch
 
     assert talker._sub_batch_size == 2
     assert talker._sub_sample_count == 2
-    assert talker._sub_sample_rows == [0, 1]
+    assert talker._sub_has_sampled_rows is True
+    assert talker._sub_do_sample_tensor[:2].tolist() == [True, True]
 
 
 class _NoHostReadbackTensor(torch.Tensor):
@@ -880,42 +905,33 @@ def test_graph_keys_share_memory_pool(monkeypatch: pytest.MonkeyPatch):
 
 @pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
-def test_graph_key_capacity_fallback_is_counted_and_warned_once(
+def test_graph_key_cache_capacity_fallback_without_eviction(
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ):
     device = torch.device("cuda")
     talker = _build_talker(device)
     layer0, hidden, positions = _step_inputs(2, device)
-    monkeypatch.setattr(sglang_model_module, "_PREDICTOR_GRAPH_MAX_KEYS", 1)
-    caplog.set_level("WARNING")
+    monkeypatch.setattr(sglang_model_module, "_PREDICTOR_GRAPH_MAX_KEYS", 2)
 
-    talker.prepare_decode_buffers(_uniform_requests(2))
-    eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
-    graph_codes, graph_embeds = _run_forward(talker, layer0, hidden, positions)
-    assert torch.equal(graph_codes, eager_codes)
-    assert torch.equal(graph_embeds, eager_embeds)
-    assert len(talker._predictor_graphs) == 1
+    def assert_graph_matches(requests) -> None:
+        talker.prepare_decode_buffers(requests)
+        eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
+        graph_codes, graph_embeds = _run_forward(talker, layer0, hidden, positions)
+        assert torch.equal(graph_codes, eager_codes)
+        assert torch.equal(graph_embeds, eager_embeds)
 
-    talker.prepare_decode_buffers(_uniform_requests(2, dosample=False))
-    eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
-    fallback_codes, fallback_embeds = _run_forward(talker, layer0, hidden, positions)
-    _run_forward(talker, layer0, hidden, positions)
-    assert torch.equal(fallback_codes, eager_codes)
-    assert torch.equal(fallback_embeds, eager_embeds)
+    sampled = _uniform_requests(2)
+    argmax = _uniform_requests(2, dosample=False)
+    other_sampled = _uniform_requests(2, top_k=3)
 
-    talker.prepare_decode_buffers(_uniform_requests(2))
-    eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
-    graph_codes, graph_embeds = _run_forward(talker, layer0, hidden, positions)
+    assert_graph_matches(sampled)
+    assert_graph_matches(argmax)
+    assert_graph_matches(other_sampled)
 
-    assert len(talker._predictor_graphs) == 1
-    assert torch.equal(graph_codes, eager_codes)
-    assert torch.equal(graph_embeds, eager_embeds)
-    assert talker._predictor_graph_capacity_fallback_count == 2
-    messages = [
-        record.message for record in caplog.records if "cache reached" in record.message
-    ]
-    assert len(messages) == 1
+    assert {key[1] for key in talker._predictor_graphs} == {"sampled", "argmax"}
+    assert len(talker._predictor_graphs) == 2
+    assert talker._predictor_graph_capture_count == 2
+    assert talker._predictor_graph_capacity_fallback_count == 1
 
 
 @pytest.mark.accelerator
@@ -951,7 +967,6 @@ def test_capture_state_body_failure_restores_state():
     saved = (
         talker._sub_batch_size,
         talker._sub_sample_count,
-        list(talker._sub_sample_rows),
         talker._sub_has_sampled_rows,
         talker._sub_sampled_has_top_p,
         talker._sub_sampled_max_top_k,
@@ -959,9 +974,9 @@ def test_capture_state_body_failure_restores_state():
     )
 
     with pytest.raises(RuntimeError, match="simulated capture failure"):
-        with talker._predictor_graph_capture_state(4, ("mixed", 8, True, False)):
+        with talker._predictor_graph_capture_state(4, ("sampled", 8, True, False)):
             assert talker._sub_batch_size == 4
-            assert talker._sub_sample_count == 3
+            assert talker._sub_sample_count == 4
             assert talker._sub_has_sampled_rows is True
             assert talker._sub_sampled_has_top_p is True
             assert talker._sub_sampled_max_top_k == 8
@@ -971,7 +986,6 @@ def test_capture_state_body_failure_restores_state():
     assert (
         talker._sub_batch_size,
         talker._sub_sample_count,
-        list(talker._sub_sample_rows),
         talker._sub_has_sampled_rows,
         talker._sub_sampled_has_top_p,
         talker._sub_sampled_max_top_k,

--- a/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
+++ b/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
@@ -402,22 +402,18 @@ def test_mixed_sampled_argmax_rows_use_graph_bit_identity(
     assert torch.equal(graph_codes, eager_codes)
     assert torch.equal(graph_embeds, eager_embeds)
 
-    monkeypatch.setattr(
-        Qwen3TTSTalker, "_sample_subtalker_token_seeded", real_seeded
-    )
-    talker.prepare_decode_buffers(
-        [_request(dosample=False), _request(dosample=False)]
-    )
+    monkeypatch.setattr(Qwen3TTSTalker, "_sample_subtalker_token_seeded", real_seeded)
+    talker.prepare_decode_buffers([_request(dosample=False), _request(dosample=False)])
     argmax_codes, _ = talker._code_predictor_forward_incremental(
         layer0, hidden, semantic_positions=positions
     )
 
-    assert not torch.equal(graph_codes[0, 1:], argmax_codes[0, 1:]), (
-        "sampled row matches pure argmax -- the seeded path was not exercised"
-    )
-    assert torch.equal(graph_codes[1, 1:], argmax_codes[1, 1:]), (
-        "argmax row was affected by the seeded-sampling sentinel"
-    )
+    assert not torch.equal(
+        graph_codes[0, 1:], argmax_codes[0, 1:]
+    ), "sampled row matches pure argmax -- the seeded path was not exercised"
+    assert torch.equal(
+        graph_codes[1, 1:], argmax_codes[1, 1:]
+    ), "argmax row was affected by the seeded-sampling sentinel"
 
 
 @pytest.mark.accelerator

--- a/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
+++ b/tests/unit_test/qwen3_tts/test_predictor_cuda_graph.py
@@ -109,8 +109,9 @@ def _build_talker(device: torch.device) -> Qwen3TTSTalker:
     talker._sub_sampling_seed_tensor = torch.zeros(
         MAX_BS, device=device, dtype=torch.long
     )
+    talker._sub_do_sample_tensor = torch.zeros(MAX_BS, device=device, dtype=torch.bool)
     talker._sub_sample_rows = []
-    talker._sub_sample_row_indices_tensor = torch.zeros(
+    talker._sub_identity_row_indices_tensor = torch.arange(
         MAX_BS, device=device, dtype=torch.long
     )
     talker._sub_sample_count = 0
@@ -167,6 +168,8 @@ def _build_talker(device: torch.device) -> Qwen3TTSTalker:
     talker._predictor_graph_batch_sizes = BUCKETS
     talker._predictor_graph_enabled = True
     talker._predictor_graph_failure_count = 0
+    talker._predictor_graph_capacity_fallback_count = 0
+    talker._predictor_graph_capacity_warned = False
     talker._predictor_graph_pool = None
     return talker
 
@@ -316,6 +319,42 @@ def test_graph_padded_bucket_bit_identity():
 
 @pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
+def test_mixed_padded_bucket_bit_identity_and_reuse():
+    """Mixed live bs=3 replays through one bucket-4 graph across row masks."""
+    device = torch.device("cuda")
+    talker = _build_talker(device)
+
+    requests = [
+        _request(dosample=True),
+        _request(dosample=False),
+        _request(dosample=True),
+    ]
+    talker.prepare_decode_buffers(requests)
+    layer0, hidden, positions = _step_inputs(3, device)
+    eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
+    graph_codes, graph_embeds = _run_forward(talker, layer0, hidden, positions)
+
+    assert any(key[0] == 4 and key[1] == "mixed" for key in talker._predictor_graphs)
+    assert torch.equal(graph_codes, eager_codes)
+    assert torch.equal(graph_embeds, eager_embeds)
+
+    requests = [
+        _request(dosample=False),
+        _request(dosample=True),
+        _request(dosample=True),
+    ]
+    talker.prepare_decode_buffers(requests)
+    layer0, hidden, positions = _step_inputs(3, device, step=1)
+    eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
+    graph_codes, graph_embeds = _run_forward(talker, layer0, hidden, positions)
+
+    assert len(talker._predictor_graphs) == 1
+    assert torch.equal(graph_codes, eager_codes)
+    assert torch.equal(graph_embeds, eager_embeds)
+
+
+@pytest.mark.accelerator
+@pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
 def test_graph_multi_step_replay_bit_identity():
     """Consecutive steps reuse one captured graph and stay bit-identical."""
     device = torch.device("cuda")
@@ -334,9 +373,12 @@ def test_graph_multi_step_replay_bit_identity():
 
 @pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
-def test_mixed_sampled_argmax_rows_fall_back_to_eager():
+def test_mixed_sampled_argmax_rows_use_graph_bit_identity():
     device = torch.device("cuda")
     talker = _build_talker(device)
+    with torch.no_grad():
+        for head in talker.code_predictor.lm_head:
+            head.proj.weight.zero_()
     requests = [_request(dosample=True), _request(dosample=False)]
     talker.prepare_decode_buffers(requests)
     layer0, hidden, positions = _step_inputs(2, device)
@@ -344,9 +386,91 @@ def test_mixed_sampled_argmax_rows_fall_back_to_eager():
     eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
     graph_codes, graph_embeds = _run_forward(talker, layer0, hidden, positions)
 
-    assert not talker._predictor_graphs, "mixed batches must not capture a graph"
+    assert talker._predictor_graphs, "mixed batch did not capture a graph"
     assert torch.equal(graph_codes, eager_codes)
     assert torch.equal(graph_embeds, eager_embeds)
+    assert (
+        torch.count_nonzero(graph_codes[1, 1:]) == 0
+    ), "argmax row must choose the first token from exact predictor-logit ties"
+
+
+@pytest.mark.accelerator
+@pytest.mark.skipif(not _HAS_CUDA, reason="seeded sampling kernel needs CUDA")
+def test_mixed_sampled_argmax_rows_preserve_argmax_tie_break():
+    device = torch.device("cuda")
+    talker = _build_talker(device)
+    talker.prepare_decode_buffers([_request(dosample=True), _request(dosample=False)])
+    logits = torch.full((2, PRED_VOCAB), -10.0, device=device)
+    logits[0, 3] = 9.0
+    logits[1, 5] = 9.0
+    logits[1, 7] = 9.0
+
+    tokens = talker._sample_subtalker_token(
+        logits,
+        semantic_positions=torch.zeros(2, dtype=torch.long, device=device),
+    )
+
+    assert tokens[1].item() == torch.argmax(logits[1]).item() == 5
+
+
+@pytest.mark.accelerator
+@pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
+def test_mixed_sampling_masks_reuse_one_graph():
+    device = torch.device("cuda")
+    talker = _build_talker(device)
+
+    requests = [
+        _request(dosample=True),
+        _request(dosample=False),
+        _request(dosample=True),
+        _request(dosample=False),
+    ]
+    talker.prepare_decode_buffers(requests)
+    layer0, hidden, positions = _step_inputs(4, device)
+    eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
+    graph_codes, graph_embeds = _run_forward(talker, layer0, hidden, positions)
+    assert torch.equal(graph_codes, eager_codes)
+    assert torch.equal(graph_embeds, eager_embeds)
+
+    requests = [
+        _request(dosample=False),
+        _request(dosample=True),
+        _request(dosample=False),
+        _request(dosample=True),
+    ]
+    talker.prepare_decode_buffers(requests)
+    layer0, hidden, positions = _step_inputs(4, device, step=1)
+    eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
+    graph_codes, graph_embeds = _run_forward(talker, layer0, hidden, positions)
+
+    assert len(talker._predictor_graphs) == 1
+    assert torch.equal(graph_codes, eager_codes)
+    assert torch.equal(graph_embeds, eager_embeds)
+
+
+@pytest.mark.accelerator
+@pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
+def test_all_sampled_and_mixed_batches_use_distinct_graphs():
+    device = torch.device("cuda")
+    talker = _build_talker(device)
+    layer0, hidden, positions = _step_inputs(4, device)
+
+    talker.prepare_decode_buffers(_uniform_requests(4))
+    _run_forward(talker, layer0, hidden, positions)
+
+    talker.prepare_decode_buffers(
+        [
+            _request(dosample=True),
+            _request(dosample=False),
+            _request(dosample=True),
+            _request(dosample=False),
+        ]
+    )
+    _run_forward(talker, layer0, hidden, positions)
+
+    modes = {key[1] for key in talker._predictor_graphs}
+    assert modes == {"sampled", "mixed"}
+    assert len(talker._predictor_graphs) == 2
 
 
 @pytest.mark.accelerator
@@ -755,6 +879,46 @@ def test_graph_keys_share_memory_pool(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.mark.accelerator
+@pytest.mark.skipif(not _HAS_CUDA, reason="predictor CUDA graph needs CUDA")
+def test_graph_key_capacity_fallback_is_counted_and_warned_once(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    device = torch.device("cuda")
+    talker = _build_talker(device)
+    layer0, hidden, positions = _step_inputs(2, device)
+    monkeypatch.setattr(sglang_model_module, "_PREDICTOR_GRAPH_MAX_KEYS", 1)
+    caplog.set_level("WARNING")
+
+    talker.prepare_decode_buffers(_uniform_requests(2))
+    eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
+    graph_codes, graph_embeds = _run_forward(talker, layer0, hidden, positions)
+    assert torch.equal(graph_codes, eager_codes)
+    assert torch.equal(graph_embeds, eager_embeds)
+    assert len(talker._predictor_graphs) == 1
+
+    talker.prepare_decode_buffers(_uniform_requests(2, dosample=False))
+    eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
+    fallback_codes, fallback_embeds = _run_forward(talker, layer0, hidden, positions)
+    _run_forward(talker, layer0, hidden, positions)
+    assert torch.equal(fallback_codes, eager_codes)
+    assert torch.equal(fallback_embeds, eager_embeds)
+
+    talker.prepare_decode_buffers(_uniform_requests(2))
+    eager_codes, eager_embeds = _run_eager(talker, layer0, hidden, positions)
+    graph_codes, graph_embeds = _run_forward(talker, layer0, hidden, positions)
+
+    assert len(talker._predictor_graphs) == 1
+    assert torch.equal(graph_codes, eager_codes)
+    assert torch.equal(graph_embeds, eager_embeds)
+    assert talker._predictor_graph_capacity_fallback_count == 2
+    messages = [
+        record.message for record in caplog.records if "cache reached" in record.message
+    ]
+    assert len(messages) == 1
+
+
+@pytest.mark.accelerator
 @pytest.mark.skipif(not _HAS_CUDA, reason="seeded sampling kernel needs CUDA")
 def test_top_p_removed_ranks_never_sampled():
     """Nucleus-removed ranks must be impossible, same rationale as the top-k mask."""
@@ -779,33 +943,39 @@ def test_top_p_removed_ranks_never_sampled():
         ), f"seed={seed} sampled a nucleus-removed rank: {token.item()}"
 
 
-def test_capture_state_pre_yield_failure_restores_state():
-    """An exception while staging capture state must not leak bucket-shaped
-    _sub_* values into the eager fallback of the same step."""
+def test_capture_state_body_failure_restores_state():
+    """An exception inside capture must restore the live sampling state."""
     device = torch.device("cpu")
     talker = _build_talker(device)
-    talker.prepare_decode_buffers(_uniform_requests(3))
+    talker.prepare_decode_buffers(_uniform_requests(3, dosample=False))
     saved = (
         talker._sub_batch_size,
         talker._sub_sample_count,
         list(talker._sub_sample_rows),
+        talker._sub_has_sampled_rows,
+        talker._sub_sampled_has_top_p,
         talker._sub_sampled_max_top_k,
+        talker._sub_sampled_has_unbounded_top_k,
     )
 
-    class _Boom:
-        def __getitem__(self, item):
-            raise RuntimeError("simulated allocation failure")
-
-    talker._sub_sample_row_indices_tensor = _Boom()
-    with pytest.raises(RuntimeError, match="simulated allocation failure"):
-        with talker._predictor_graph_capture_state(4, ("sampled", 8, False, False)):
-            pass
+    with pytest.raises(RuntimeError, match="simulated capture failure"):
+        with talker._predictor_graph_capture_state(4, ("mixed", 8, True, False)):
+            assert talker._sub_batch_size == 4
+            assert talker._sub_sample_count == 3
+            assert talker._sub_has_sampled_rows is True
+            assert talker._sub_sampled_has_top_p is True
+            assert talker._sub_sampled_max_top_k == 8
+            assert talker._sub_sampled_has_unbounded_top_k is False
+            raise RuntimeError("simulated capture failure")
 
     assert (
         talker._sub_batch_size,
         talker._sub_sample_count,
         list(talker._sub_sample_rows),
+        talker._sub_has_sampled_rows,
+        talker._sub_sampled_has_top_p,
         talker._sub_sampled_max_top_k,
+        talker._sub_sampled_has_unbounded_top_k,
     ) == saved
 
 


### PR DESCRIPTION
## Motivation

Qwen3-TTS predictor CUDA graphs currently support homogeneous all-argmax and all-sampled batches. A batch containing both sampled and argmax rows falls back to eager execution.  As a result, mixed batches execute the entire predictor chain eagerly, losing CUDA graph replay and repeatedly paying Python dispatch and kernel-launch overhead during decoding.

This PR keeps mixed batches on the predictor CUDA graph path and exposes per-request subtalker sampling controls through the public speech API.

## Modifications

- Enable CUDA graph execution for mixed sampled/argmax batches using fixed-shape sampling and a device-resident `do_sample` mask.
- Share `sampled` graph keys between fully sampled and mixed batches, while retaining argmax-only graphs for fully greedy batches.
- Preserve argmax tie-breaking and existing eager fast paths, including sampling only the sampled-row subset in mixed eager batches.
- Forward per-request subtalker sampling controls through `stage_params.tts_engine`.
- Add `--subtalker-dosample-ratio` to the SeedTTS benchmark for controlled sampled/argmax request mixtures.
- Track graph-cache capacity fallbacks internally and emit a one-time warning when capacity forces eager execution.
- Extend tests for mixed graph/eager equivalence, graph reuse, mask selection, parameter forwarding, and end-to-end batch invariance.

## Related Issues

#1418 - “Mixed sampled/argmax batches drop the predictor chain graph to eager (sglang_model.py mixed-batch guard); unifying on full-batch masked sampling would keep the graph, gated on the existing bit-identity suite (argmax tie-break must be proven identical).”

## Accuracy Test

The affected Qwen3-TTS predictor CUDA Graph and sampling unit suites pass.

Graphed and eager predictor outputs are bit-identical (`torch.equal`) for argmax, sampled, and mixed (partially-sampled) batches, including padded buckets. Mixed batches share the same `sampled` graph key as fully-sampled batches. Exact-logit ties preserve the existing `torch.argmax` result.

## Benchmark & Profiling
### Methodology

- **Hardware:** 1x NVIDIA H200 SXM 141 GB (`GPU-06862ea3-321e-ad44-aa7d-9ac47526a2b7`)
- **Driver:** 570.211.01
- **Model:** `Qwen/Qwen3-TTS-12Hz-1.7B-Base` (`fd4b2543`)
- **Dataset:** SeedTTS EN (`27f4c1ad`)
- **Base:** `8f8b73d3`
- **Candidate:** `99e190cb`
- **Software:** PyTorch 2.11.0+cu130, SGLang 0.5.16, FlashInfer 0.6.14, SGLang Kernel 0.4.5
- **Server:** `max_running_requests=16`, `max_queued_requests=64`, `cuda_graph_max_bs=16`
- **Request seed:** `1234`

Model and dataset artifacts were cached before measurement; measured sessions ran in Hugging Face offline mode. The repository's standard `benchmark_tts_seedtts.py` harness was used for request dispatch, timing, metrics, and result serialization.

The base (`main`) Qwen3-TTS request builder does not read `stage_params.tts_engine`, so it cannot consume the per-request `subtalker_dosample` values needed to construct mixed traffic. This PR already includes that request-forwarding change. To give both arms the same workload, the base worktree received a benchmark-only backport of the PR's ratio dispatch and request forwarding; it does not modify the base Predictor, CUDA Graph, or scheduler implementation. The backport is reviewable in draft PR [#1764](https://github.com/sgl-project/sglang-omni/pull/1764), which exists only to review and reproduce the benchmark and will not be merged.

An instrumented preflight at ratio 50% / c8 confirmed real partially-sampled batches in both arms (for example, `batch_size=8`, `sampled_rows=4`). The base retained its existing mixed-batch eager fallback; the candidate captured and replayed the shared `sampled` graph key for the same bucket. The temporary composition probe was removed before formal timing.

Each leg used a fresh server. Before timing, one unmeasured concurrent group with the same ratio and concurrency warmed the exact execution mode; the measured harness warmup was set to zero.

- Mixed ratios **20%, 50%, and 70%** were each measured at c8 and c32 using **A/B/A/B**, with **256 requests per leg**. Values below are means over two base and two candidate legs.
- Regression checks used one A/B pair with **256 requests per arm**: graph-on all-argmax (**0%**) and all-sampled (**100%**) at c32, plus graph-off **50%** mixed at c32. Within each pair, base and candidate used the same 256 sample IDs, request seed, per-request sampled/argmax assignment, concurrency, and server configuration; only the worktree changed.

All 30 formal legs completed 256/256 requests with zero graph-capacity fallbacks and zero graph-capture failures.

### Mixed workload results

Ratio is the fraction of requests using `subtalker_dosample=True`; the remainder use argmax. With 256 requests per leg, the deterministic allocation is shown in the table.

| Sampled ratio | Composition per leg | Concurrency | Throughput (base → candidate) | Speedup | Output tok/s (base → candidate) | Speedup | Mean latency | P95 latency |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 20% | 51 sampled / 205 argmax | c8 | 3.103 → 9.110 req/s | **2.94x** | 159.35 → 465.60 | **2.92x** | 2.563 → 0.871 s (**-66.0%**) | 3.896 → 1.251 s (**-67.9%**) |
| 20% | 51 sampled / 205 argmax | c32 | 5.479 → 14.967 req/s | **2.73x** | 277.50 → 757.25 | **2.73x** | 5.556 → 2.048 s (**-63.1%**) | 7.217 → 2.660 s (**-63.2%**) |
| 50% | 128 sampled / 128 argmax | c8 | 2.807 → 8.914 req/s | **3.18x** | 140.30 → 448.90 | **3.20x** | 2.816 → 0.889 s (**-68.4%**) | 4.303 → 1.254 s (**-70.9%**) |
| 50% | 128 sampled / 128 argmax | c32 | 5.472 → 14.690 req/s | **2.68x** | 274.95 → 743.40 | **2.70x** | 5.491 → 2.084 s (**-62.0%**) | 7.117 → 2.691 s (**-62.2%**) |
| 70% | 179 sampled / 77 argmax | c8 | 2.943 → 8.980 req/s | **3.05x** | 148.45 → 451.05 | **3.04x** | 2.701 → 0.882 s (**-67.3%**) | 4.091 → 1.257 s (**-69.3%**) |
| 70% | 179 sampled / 77 argmax | c32 | 5.509 → 14.784 req/s | **2.68x** | 277.40 → 742.35 | **2.68x** | 5.485 → 2.073 s (**-62.2%**) | 7.089 → 2.733 s (**-61.5%**) |

Across these mixed workloads, mean RTF improved by 61.9 - 68.1% and P95 RTF improved by 58.3 - 65.4%.

### No-regression checks

| Workload | Throughput (base → candidate) | Change | Output tok/s (base → candidate) | Change | Mean latency change | P95 latency change |
|---|---:|---:|---:|---:|---:|---:|
| Graph on, all argmax (0 sampled / 256 argmax), c32 | 15.687 → 15.572 req/s | -0.7% | 798.1 → 795.0 | -0.4% | +0.3% | -0.8% |
| Graph on, all sampled (256 sampled / 0 argmax), c32 | 15.065 → 15.037 req/s | -0.2% | 756.8 → 748.6 | -1.1% | -0.4% | -0.04% |
| Graph off, 50% mixed (128 sampled / 128 argmax), c32 | 3.334 → 3.301 req/s | -1.0% | 166.8 → 166.1 | -0.4% | +1.3% | +2.9% |

The homogeneous graph paths and the mixed eager path remain within paired-run noise; the large gain is isolated to mixed batches with Predictor CUDA Graphs enabled.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
