### PR TITLE
[Perf][MOSS-TTS] Load MOSS-Audio-Tokenizer components per pipeline stage

### DIFF
--- a/docs/cookbook/moss_tts.md
+++ b/docs/cookbook/moss_tts.md
@@ -38,9 +38,14 @@ sgl-omni serve \
   --port 8000
 ```
 
-The default model-specific layout keeps the FP32 reference encoder on CPU and
-loads the GPU vocoder in BF16. This removes one codec copy from GPU and halves
-the parameter memory of the remaining codec.
+The default model-specific layout places the repository-local encoder and
+vocoder components on the configured pipeline GPU. The encoder and decoder
+weights materialize in BF16 according to `compute_dtype`; the quantizers and
+explicit FP32 norms remain in FP32. Each stage constructs only the codec
+components it uses instead of loading a complete codec copy.
+
+The bounded 24 GB and 32 GB configurations explicitly move preprocessing to
+CPU. They retain BF16 compute unless `compute_dtype` is overridden.
 
 For the bounded 32 GB qualification layout, use:
 

--- a/examples/configs/moss_tts_24gb.yaml
+++ b/examples/configs/moss_tts_24gb.yaml
@@ -5,7 +5,7 @@ stages:
   preprocessing:
     factory:
       device: cpu
-      dtype: float32
+      compute_dtype: bfloat16
       max_concurrency: 1
 
   tts_engine:

--- a/examples/configs/moss_tts_32gb.yaml
+++ b/examples/configs/moss_tts_32gb.yaml
@@ -5,7 +5,7 @@ stages:
   preprocessing:
     factory:
       device: cpu
-      dtype: float32
+      compute_dtype: bfloat16
       max_concurrency: 1
 
   tts_engine:

--- a/sglang_omni/models/moss_tts/attention.py
+++ b/sglang_omni/models/moss_tts/attention.py
@@ -27,15 +27,14 @@ _SDPA_QUERY_CHUNK_SIZE = 512
 _LOCAL_CAUSAL_FLASH_QUERY_CHUNK_SIZE = 128
 # note (Zhang Yiyang): Use the direct local-window kernel on Hopper and newer SMs.
 _PACKED_FLASH_DIRECT_MIN_SM = 90
-_HF_FLASH_ATTENTION_CONFIG = "flash_attention_2"
 PACKED_FLASH_ATTENTION_BACKEND = "packed_flash_attention"
-_SDPA_ATTENTION_BACKEND = "sdpa"
+SDPA_ATTENTION_BACKEND = "sdpa"
 AUTO_ATTENTION_BACKEND = "auto"
 _SUPPORTED_ATTENTION_BACKENDS: frozenset[str] = frozenset(
     {
         AUTO_ATTENTION_BACKEND,
         PACKED_FLASH_ATTENTION_BACKEND,
-        _SDPA_ATTENTION_BACKEND,
+        SDPA_ATTENTION_BACKEND,
     }
 )
 
@@ -48,17 +47,6 @@ def validate_attention_backend(attention_backend: str) -> str:
             f"got {attention_backend!r}"
         )
     return attention_backend
-
-
-def _preferred_attention_backend(
-    attention_backend: str,
-    attention_implementation: str | None,
-) -> str:
-    if attention_backend != AUTO_ATTENTION_BACKEND:
-        return attention_backend
-    if attention_implementation == _SDPA_ATTENTION_BACKEND:
-        return _SDPA_ATTENTION_BACKEND
-    return PACKED_FLASH_ATTENTION_BACKEND
 
 
 def _packed_flash_device_unavailable_reason(device: torch.device) -> str | None:
@@ -102,7 +90,7 @@ def merge_attention_backend_resolutions(
     resolutions: Sequence[AttentionBackendResolution],
 ) -> AttentionBackendResolution:
     if not resolutions:
-        return AttentionBackendResolution(_SDPA_ATTENTION_BACKEND)
+        return AttentionBackendResolution(SDPA_ATTENTION_BACKEND)
     backends = {resolution.backend for resolution in resolutions}
     if len(backends) != 1:
         raise RuntimeError(
@@ -626,7 +614,6 @@ class MossAudioTokenizerAttention(nn.Module):
         causal: bool,
         context: int | None,
         rope: nn.Module | None,
-        attention_implementation: str | None,
         attention_backend: str = AUTO_ATTENTION_BACKEND,
         packed_rope_cache: MossPackedRopeCache | None = None,
     ) -> None:
@@ -649,16 +636,6 @@ class MossAudioTokenizerAttention(nn.Module):
         self.causal = bool(causal)
         self.context = None if context is None else int(context)
         self.rope = rope
-        if attention_implementation not in (
-            None,
-            _HF_FLASH_ATTENTION_CONFIG,
-            _SDPA_ATTENTION_BACKEND,
-        ):
-            raise ValueError(
-                "attention_implementation must be None, 'flash_attention_2', "
-                f"or 'sdpa'; got {attention_implementation!r}"
-            )
-        self.attention_implementation = attention_implementation
         self.attention_backend = validate_attention_backend(attention_backend)
         self._flash_attn_varlen = flash_attn_varlen_func
         max_period = self.rope.max_period if self.rope is not None else 10000.0
@@ -682,11 +659,6 @@ class MossAudioTokenizerAttention(nn.Module):
             causal=bool(module.causal),
             context=module.context,
             rope=module.rope,
-            attention_implementation=getattr(
-                module,
-                "attention_implementation",
-                None,
-            ),
             attention_backend=attention_backend,
             packed_rope_cache=packed_rope_cache,
         )
@@ -696,12 +668,8 @@ class MossAudioTokenizerAttention(nn.Module):
         device: torch.device,
         dtype: torch.dtype | None,
     ) -> AttentionBackendResolution:
-        preferred = _preferred_attention_backend(
-            self.attention_backend,
-            self.attention_implementation,
-        )
-        if preferred == _SDPA_ATTENTION_BACKEND:
-            return AttentionBackendResolution(_SDPA_ATTENTION_BACKEND)
+        if self.attention_backend == SDPA_ATTENTION_BACKEND:
+            return AttentionBackendResolution(SDPA_ATTENTION_BACKEND)
 
         unavailable_reason = self._packed_flash_unavailable_reason(device, dtype)
         if unavailable_reason is None:
@@ -714,7 +682,7 @@ class MossAudioTokenizerAttention(nn.Module):
                 f"{unavailable_reason}"
             )
         return AttentionBackendResolution(
-            _SDPA_ATTENTION_BACKEND,
+            SDPA_ATTENTION_BACKEND,
             fallback_reason=unavailable_reason,
         )
 
@@ -732,13 +700,7 @@ class MossAudioTokenizerAttention(nn.Module):
         device: torch.device,
         dtype: torch.dtype | None,
     ) -> bool:
-        if (
-            _preferred_attention_backend(
-                self.attention_backend,
-                self.attention_implementation,
-            )
-            != PACKED_FLASH_ATTENTION_BACKEND
-        ):
+        if self.attention_backend == SDPA_ATTENTION_BACKEND:
             return False
         return self._packed_flash_unavailable_reason(device, dtype) is None
 

--- a/sglang_omni/models/moss_tts/audio_tokenizer.py
+++ b/sglang_omni/models/moss_tts/audio_tokenizer.py
@@ -1203,16 +1203,10 @@ class MossAudioTokenizerEncoder(nn.Module):
         config: dict[str, Any],
         *,
         parameter_device: str | torch.device | None = None,
-        encoder_dtype: torch.dtype = torch.bfloat16,
         compute_dtype: torch.dtype | None = None,
         attention_backend: str = AUTO_ATTENTION_BACKEND,
     ) -> None:
         super().__init__()
-        _validate_audio_dtypes(
-            component_dtype=encoder_dtype,
-            component_name="encoder_dtype",
-            compute_dtype=compute_dtype,
-        )
         self.config = SimpleNamespace(**config)
         sampling_rate = config.get("sampling_rate") or config.get("sample_rate")
         if sampling_rate is None:
@@ -1223,7 +1217,7 @@ class MossAudioTokenizerEncoder(nn.Module):
         self.enable_channel_interleave = bool(
             config.get("enable_channel_interleave", self.number_channels > 1)
         )
-        configured_compute_dtype = str(config.get("compute_dtype", "bf16"))
+        configured_compute_dtype = str(config.get("compute_dtype") or "bfloat16")
         resolved_compute_dtype = {
             "bf16": torch.bfloat16,
             "bfloat16": torch.bfloat16,
@@ -1242,6 +1236,21 @@ class MossAudioTokenizerEncoder(nn.Module):
         requested_compute_dtype = (
             resolved_compute_dtype if compute_dtype is None else compute_dtype
         )
+        if requested_compute_dtype not in (
+            None,
+            torch.float32,
+            torch.bfloat16,
+        ):
+            raise ValueError(
+                "compute_dtype must be torch.float32, torch.bfloat16, or None; "
+                f"got {requested_compute_dtype!r}"
+            )
+        effective_encoder_dtype = (
+            torch.float32
+            if requested_compute_dtype is None
+            or requested_compute_dtype is torch.float32
+            else requested_compute_dtype
+        )
         self.compute_dtype = (
             None
             if requested_compute_dtype is torch.float32
@@ -1251,12 +1260,7 @@ class MossAudioTokenizerEncoder(nn.Module):
         # for the encoder weights. This avoids relying on autocast to recast
         # FP32 parameters on every request. The quantizer is intentionally kept
         # FP32 below.
-        self.encoder_dtype = (
-            torch.float32
-            if requested_compute_dtype is None
-            or requested_compute_dtype is torch.float32
-            else requested_compute_dtype
-        )
+        self.encoder_dtype = effective_encoder_dtype
         self.attention_backend = validate_attention_backend(attention_backend)
         self._uses_moss_audio_tokenizer_v1_weights = "number_channels" not in config
 
@@ -1667,7 +1671,6 @@ def load_moss_audio_encoder(
     model_path: str,
     *,
     device: str | torch.device,
-    encoder_dtype: torch.dtype = torch.bfloat16,
     compute_dtype: torch.dtype | None = None,
     attention_backend: str = AUTO_ATTENTION_BACKEND,
 ) -> MossAudioEncoder:
@@ -1678,7 +1681,6 @@ def load_moss_audio_encoder(
     model = MossAudioTokenizerEncoder(
         config,
         parameter_device="meta",
-        encoder_dtype=encoder_dtype,
         compute_dtype=compute_dtype,
         attention_backend=attention_backend,
     )

--- a/sglang_omni/models/moss_tts/audio_tokenizer.py
+++ b/sglang_omni/models/moss_tts/audio_tokenizer.py
@@ -71,6 +71,21 @@ def resolve_moss_audio_attention_backend(
     return AUTO_ATTENTION_BACKEND
 
 
+# Note (Zhang Yiyang): Prefer the runtime model value, then the canonical config
+# field, and finally the legacy config alias for checkpoint compatibility.
+def resolve_moss_audio_sample_rate(model: Any, config: Any) -> int:
+    for value in (
+        getattr(model, "sampling_rate", None),
+        getattr(config, "sampling_rate", None),
+        getattr(config, "sample_rate", None),
+    ):
+        if value is not None:
+            return int(value)
+    raise ValueError(
+        "MOSS-Audio-Tokenizer model/config lacks sampling_rate or sample_rate"
+    )
+
+
 def _attention_backend_label(resolution: AttentionBackendResolution) -> str:
     if resolution.fallback_reason is None:
         return resolution.backend
@@ -1456,9 +1471,7 @@ class MossAudioEncoder:
         self.model = model
         self.device = str(device)
         config = model.config
-        self.sample_rate = int(
-            getattr(model, "sampling_rate", getattr(config, "sampling_rate"))
-        )
+        self.sample_rate = resolve_moss_audio_sample_rate(model, config)
         self.number_channels = int(
             getattr(model, "number_channels", getattr(config, "number_channels", 1))
         )

--- a/sglang_omni/models/moss_tts/audio_tokenizer.py
+++ b/sglang_omni/models/moss_tts/audio_tokenizer.py
@@ -3,19 +3,24 @@
 
 from __future__ import annotations
 
+import json
 import logging
-from collections.abc import Iterator, Sequence
-from contextlib import nullcontext
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+from os import PathLike
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import torch
-import torchaudio
+import torch.nn.functional as F
 from torch import nn
-from transformers import AutoModel
 
 from sglang_omni.models.moss_tts.attention import (
     AUTO_ATTENTION_BACKEND,
     PACKED_FLASH_ATTENTION_BACKEND,
+    SDPA_ATTENTION_BACKEND,
     AttentionBackendResolution,
     MossAudioTokenizerAttention,
     MossPackedRopeCache,
@@ -29,7 +34,11 @@ from sglang_omni.models.moss_tts.attention import (
     unpack_unpadded_sequence,
     validate_attention_backend,
 )
-from sglang_omni.models.moss_tts.hf_loading import moss_transformers_processor_compat
+from sglang_omni.models.weight_loader import (
+    load_module,
+    load_weights_by_prefix,
+    resolve_model_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +46,35 @@ DEFAULT_MOSS_TTS_AUDIO_TOKENIZER = "OpenMOSS-Team/MOSS-Audio-Tokenizer"
 _LOUDNESS_TARGET_DBFS = -20.0
 _LOUDNESS_GAIN_MIN_DB = -3.0
 _LOUDNESS_GAIN_MAX_DB = 3.0
+_HF_FLASH_ATTENTION_IMPLEMENTATION = "flash_attention_2"
+_SUPPORTED_ATTENTION_IMPLEMENTATIONS = (
+    None,
+    _HF_FLASH_ATTENTION_IMPLEMENTATION,
+    SDPA_ATTENTION_BACKEND,
+)
+
+
+def resolve_moss_audio_attention_backend(
+    attention_backend: str,
+    attention_implementation: str | None,
+) -> str:
+    validate_attention_backend(attention_backend)
+    if attention_implementation not in _SUPPORTED_ATTENTION_IMPLEMENTATIONS:
+        raise ValueError(
+            "attention_implementation must be None, 'flash_attention_2', "
+            f"or 'sdpa'; got {attention_implementation!r}"
+        )
+    if attention_backend != AUTO_ATTENTION_BACKEND:
+        return attention_backend
+    if attention_implementation == SDPA_ATTENTION_BACKEND:
+        return SDPA_ATTENTION_BACKEND
+    return AUTO_ATTENTION_BACKEND
+
+
+def _attention_backend_label(resolution: AttentionBackendResolution) -> str:
+    if resolution.fallback_reason is None:
+        return resolution.backend
+    return f"{resolution.backend} (fallback: {resolution.fallback_reason})"
 
 
 class _MossAudioTokenizerV1FeedForward(nn.Module):
@@ -78,15 +116,144 @@ class MossAudioTokenizerTransformerLayer(nn.Module):
 
     def __init__(
         self,
+        config: dict[str, Any] | None = None,
         *,
-        norm1: nn.Module,
-        self_attn: MossAudioTokenizerAttention,
-        layer_scale_1: nn.Module,
-        norm2: nn.Module,
-        ffn: nn.Module,
-        layer_scale_2: nn.Module,
+        context: int | None = None,
+        rope: nn.Module | None = None,
+        moss_audio_tokenizer_v1_weights: bool = False,
+        device: str | torch.device | None = None,
+        dtype: torch.dtype | None = None,
+        attention_backend: str = AUTO_ATTENTION_BACKEND,
+        packed_rope_cache: MossPackedRopeCache | None = None,
+        source_module: nn.Module | None = None,
     ) -> None:
         super().__init__()
+        if source_module is not None:
+            if config is not None:
+                raise ValueError(
+                    "MOSS-Audio-Tokenizer transformer layer accepts either "
+                    "config or source_module, not both"
+                )
+            norm1 = source_module.norm1
+            selected_attention_backend = resolve_moss_audio_attention_backend(
+                attention_backend,
+                getattr(source_module.self_attn, "attention_implementation", None),
+            )
+            self_attn = MossAudioTokenizerAttention.from_module(
+                source_module.self_attn,
+                attention_backend=selected_attention_backend,
+                packed_rope_cache=packed_rope_cache,
+            )
+            layer_scale_1 = source_module.layer_scale_1
+            norm2 = source_module.norm2
+            ffn = _feed_forward(source_module)
+            layer_scale_2 = source_module.layer_scale_2
+        elif config is not None:
+            d_model = int(config["d_model"])
+            num_heads = int(config["num_heads"])
+            dim_feedforward = int(config.get("dim_feedforward", 2048))
+            causal = bool(config.get("causal", False))
+            norm = str(config.get("norm", "layer_norm"))
+            layer_scale = config.get("layer_scale")
+            gating = str(config.get("gating", "none"))
+            if gating != "none":
+                raise ValueError(
+                    "repository-local MOSS encoder currently supports gating='none'; "
+                    f"got {gating!r}"
+                )
+            if moss_audio_tokenizer_v1_weights:
+                ffn = _MossAudioTokenizerV1FeedForward(
+                    nn.Linear(
+                        d_model,
+                        dim_feedforward,
+                        bias=False,
+                        device=device,
+                        dtype=dtype,
+                    ),
+                    nn.Linear(
+                        dim_feedforward,
+                        d_model,
+                        bias=False,
+                        device=device,
+                        dtype=dtype,
+                    ),
+                    nn.GELU(),
+                )
+            else:
+                ffn = nn.Sequential(
+                    nn.Linear(
+                        d_model,
+                        dim_feedforward,
+                        bias=False,
+                        device=device,
+                        dtype=dtype,
+                    ),
+                    nn.GELU(),
+                    nn.Linear(
+                        dim_feedforward,
+                        d_model,
+                        bias=False,
+                        device=device,
+                        dtype=dtype,
+                    ),
+                )
+            if layer_scale is None:
+                layer_scale_1 = nn.Identity()
+                layer_scale_2 = nn.Identity()
+            else:
+                layer_scale_1 = _LayerScale(
+                    d_model,
+                    init=float(layer_scale),
+                    device=device,
+                    dtype=dtype,
+                )
+                layer_scale_2 = _LayerScale(
+                    d_model,
+                    init=float(layer_scale),
+                    device=device,
+                    dtype=dtype,
+                )
+            selected_attention_backend = resolve_moss_audio_attention_backend(
+                attention_backend,
+                (
+                    None
+                    if moss_audio_tokenizer_v1_weights
+                    else config.get(
+                        "attention_implementation",
+                        _HF_FLASH_ATTENTION_IMPLEMENTATION,
+                    )
+                ),
+            )
+            self_attn = MossAudioTokenizerAttention(
+                in_proj=nn.Linear(
+                    d_model,
+                    3 * d_model,
+                    bias=False,
+                    device=device,
+                    dtype=dtype,
+                ),
+                out_proj=nn.Linear(
+                    d_model,
+                    d_model,
+                    bias=False,
+                    device=device,
+                    dtype=dtype,
+                ),
+                embed_dim=d_model,
+                num_heads=num_heads,
+                causal=causal,
+                context=context,
+                rope=rope,
+                attention_backend=selected_attention_backend,
+                packed_rope_cache=packed_rope_cache,
+            )
+            norm1 = _create_norm(norm, d_model, device=device, dtype=dtype)
+            norm2 = _create_norm(norm, d_model, device=device, dtype=dtype)
+        else:
+            raise ValueError(
+                "MOSS-Audio-Tokenizer transformer layer requires config or "
+                "source_module"
+            )
         self.norm1 = norm1
         self.self_attn = self_attn
         self.layer_scale_1 = layer_scale_1
@@ -104,16 +271,9 @@ class MossAudioTokenizerTransformerLayer(nn.Module):
         packed_rope_cache: MossPackedRopeCache | None = None,
     ) -> MossAudioTokenizerTransformerLayer:
         return cls(
-            norm1=module.norm1,
-            self_attn=MossAudioTokenizerAttention.from_module(
-                module.self_attn,
-                attention_backend=attention_backend,
-                packed_rope_cache=packed_rope_cache,
-            ),
-            layer_scale_1=module.layer_scale_1,
-            norm2=module.norm2,
-            ffn=_feed_forward(module),
-            layer_scale_2=module.layer_scale_2,
+            source_module=module,
+            attention_backend=attention_backend,
+            packed_rope_cache=packed_rope_cache,
         )
 
     def forward(self, x: torch.Tensor, **kwargs: Any) -> torch.Tensor:
@@ -131,13 +291,61 @@ class MossAudioTokenizerTransformer(nn.Module):
 
     def __init__(
         self,
+        config: dict[str, Any] | None = None,
         *,
-        layers: Sequence[MossAudioTokenizerTransformerLayer],
-        positional_embedding: str,
-        positional_scale: float,
-        max_period: float,
+        context: int | None = None,
+        moss_audio_tokenizer_v1_weights: bool = False,
+        device: str | torch.device | None = None,
+        dtype: torch.dtype | None = None,
+        attention_backend: str = AUTO_ATTENTION_BACKEND,
+        source_module: nn.Module | None = None,
     ) -> None:
         super().__init__()
+        if source_module is not None:
+            if config is not None:
+                raise ValueError(
+                    "MOSS-Audio-Tokenizer transformer accepts either config or "
+                    "source_module, not both"
+                )
+            max_period = float(source_module.max_period)
+            packed_rope_cache = MossPackedRopeCache(max_period=max_period)
+            layers = [
+                MossAudioTokenizerTransformerLayer.from_module(
+                    layer,
+                    attention_backend=attention_backend,
+                    packed_rope_cache=packed_rope_cache,
+                )
+                for layer in source_module.layers
+            ]
+            positional_embedding = source_module.positional_embedding
+            positional_scale = float(source_module.positional_scale)
+        elif config is not None:
+            positional_embedding = str(config.get("positional_embedding", "sin"))
+            max_period = float(config.get("max_period", 10_000))
+            positional_scale = float(config.get("positional_scale", 1.0))
+            rope = (
+                _RotaryEmbedding(max_period)
+                if positional_embedding in {"rope", "sin_rope"}
+                else None
+            )
+            packed_rope_cache = MossPackedRopeCache(max_period=max_period)
+            layers = [
+                MossAudioTokenizerTransformerLayer(
+                    config,
+                    context=context,
+                    rope=rope,
+                    moss_audio_tokenizer_v1_weights=moss_audio_tokenizer_v1_weights,
+                    device=device,
+                    dtype=dtype,
+                    attention_backend=attention_backend,
+                    packed_rope_cache=packed_rope_cache,
+                )
+                for _ in range(int(config["num_layers"]))
+            ]
+        else:
+            raise ValueError(
+                "MOSS-Audio-Tokenizer transformer requires config or source_module"
+            )
         self.layers = nn.ModuleList(layers)
         self.positional_embedding = positional_embedding
         self.positional_scale = float(positional_scale)
@@ -150,20 +358,9 @@ class MossAudioTokenizerTransformer(nn.Module):
         *,
         attention_backend: str = AUTO_ATTENTION_BACKEND,
     ) -> MossAudioTokenizerTransformer:
-        max_period = float(module.max_period)
-        packed_rope_cache = MossPackedRopeCache(max_period=max_period)
         return cls(
-            layers=[
-                MossAudioTokenizerTransformerLayer.from_module(
-                    layer,
-                    attention_backend=attention_backend,
-                    packed_rope_cache=packed_rope_cache,
-                )
-                for layer in module.layers
-            ],
-            positional_embedding=module.positional_embedding,
-            positional_scale=float(module.positional_scale),
-            max_period=max_period,
+            source_module=module,
+            attention_backend=attention_backend,
         )
 
     def resolve_attention_backend(
@@ -216,12 +413,67 @@ class MossAudioTokenizerProjectedTransformer(nn.Module):
 
     def __init__(
         self,
+        config: dict[str, Any] | None = None,
         *,
-        input_proj: nn.Module,
-        transformer: MossAudioTokenizerTransformer,
-        output_proj: nn.Module,
+        context: int | None = None,
+        moss_audio_tokenizer_v1_weights: bool = False,
+        device: str | torch.device | None = None,
+        dtype: torch.dtype | None = None,
+        attention_backend: str = AUTO_ATTENTION_BACKEND,
+        source_module: nn.Module | None = None,
     ) -> None:
         super().__init__()
+        if source_module is not None:
+            if config is not None:
+                raise ValueError(
+                    "MOSS-Audio-Tokenizer projected Transformer accepts either "
+                    "config or source_module, not both"
+                )
+            input_proj = source_module.input_proj
+            transformer = MossAudioTokenizerTransformer.from_module(
+                source_module.transformer,
+                attention_backend=attention_backend,
+            )
+            output_proj = source_module.output_proj
+        elif config is not None:
+            input_dimension = int(config["input_dimension"])
+            output_dimension = int(config["output_dimension"])
+            d_model = int(config["d_model"])
+            input_proj = (
+                nn.Linear(
+                    input_dimension,
+                    d_model,
+                    bias=False,
+                    device=device,
+                    dtype=dtype,
+                )
+                if not moss_audio_tokenizer_v1_weights or input_dimension != d_model
+                else nn.Identity()
+            )
+            output_proj = (
+                nn.Linear(
+                    d_model,
+                    output_dimension,
+                    bias=False,
+                    device=device,
+                    dtype=dtype,
+                )
+                if not moss_audio_tokenizer_v1_weights or d_model != output_dimension
+                else nn.Identity()
+            )
+            transformer = MossAudioTokenizerTransformer(
+                config,
+                context=context,
+                moss_audio_tokenizer_v1_weights=moss_audio_tokenizer_v1_weights,
+                device=device,
+                dtype=dtype,
+                attention_backend=attention_backend,
+            )
+        else:
+            raise ValueError(
+                "MOSS-Audio-Tokenizer projected Transformer requires config or "
+                "source_module"
+            )
         self.module_type = "Transformer"
         self.downsample_ratio = 1
         self.input_proj = input_proj
@@ -237,12 +489,8 @@ class MossAudioTokenizerProjectedTransformer(nn.Module):
         attention_backend: str = AUTO_ATTENTION_BACKEND,
     ) -> MossAudioTokenizerProjectedTransformer:
         return cls(
-            input_proj=module.input_proj,
-            transformer=MossAudioTokenizerTransformer.from_module(
-                module.transformer,
-                attention_backend=attention_backend,
-            ),
-            output_proj=module.output_proj,
+            source_module=module,
+            attention_backend=attention_backend,
         )
 
     def forward(
@@ -336,49 +584,141 @@ class MossAudioTokenizerProjectedTransformer(nn.Module):
     ) -> bool:
         return self.transformer.supports_packed_attention(device, dtype)
 
+    def resolve_attention_backend(
+        self,
+        device: str | torch.device,
+        dtype: torch.dtype | None,
+    ) -> AttentionBackendResolution:
+        return self.transformer.resolve_attention_backend(torch.device(device), dtype)
 
-# note (Zhang Yiyang): Non-streaming decoder wrapper.
+
+def _update_decoder_cpu_lengths(
+    stage: nn.Module,
+    input_lengths: Sequence[int],
+) -> list[int]:
+    if isinstance(stage, MossAudioTokenizerProjectedTransformer):
+        return list(map(int, input_lengths))
+    patch_size = int(getattr(stage, "patch_size", 0))
+    if patch_size <= 0:
+        raise ValueError(
+            "MOSS-Audio-Tokenizer patched pretransform requires patch_size > 0"
+        )
+    if bool(getattr(stage, "is_downsample", False)):
+        return [int(length) // patch_size for length in input_lengths]
+    return [int(length) * patch_size for length in input_lengths]
 
 
-class MossAudioTokenizerVocoderDecoder(nn.Module):
-    """Iterable MOSS-Audio-Tokenizer vocoder decoder with patched projected transformers."""
+# note (Zhang Yiyang): Keep one non-streaming decoder stage container for both
+# repository-owned and source decoder modules.
+
+
+class MossAudioTokenizerVocoderDecoder(nn.ModuleList):
+    """MOSS-Audio-Tokenizer vocoder decoder stage container."""
 
     def __init__(
         self,
+        config: dict[str, Any] | None = None,
+        *,
+        moss_audio_tokenizer_v1_weights: bool = False,
+        device: str | torch.device | None = None,
+        dtype: torch.dtype | None = None,
+        attention_backend: str = AUTO_ATTENTION_BACKEND,
+        source_decoder: nn.Module | None = None,
+    ) -> None:
+        super().__init__()
+        if source_decoder is not None:
+            if config is not None:
+                raise ValueError(
+                    "MOSS-Audio-Tokenizer vocoder decoder accepts either config "
+                    "or source_decoder, not both"
+                )
+            stages = []
+            for stage in source_decoder:
+                module_type = getattr(stage, "module_type", None)
+                if module_type == "Transformer":
+                    stage = MossAudioTokenizerProjectedTransformer.from_module(
+                        stage,
+                        attention_backend=attention_backend,
+                    )
+                elif module_type != "PatchedPretransform":
+                    raise ValueError(
+                        f"unsupported MOSS-Audio-Tokenizer vocoder decoder stage "
+                        f"{stage.__class__.__name__} with module_type={module_type!r}"
+                    )
+                stages.append(stage)
+        elif config is not None:
+            sampling_rate = config.get("sampling_rate") or config.get("sample_rate")
+            if sampling_rate is None:
+                raise ValueError("MOSS audio-tokenizer config lacks sampling_rate")
+            downsample_rate = int(config["downsample_rate"])
+            default_context_duration = float(
+                config.get("causal_transformer_context_duration", 10.0)
+            )
+            frame_rate = float(sampling_rate) / downsample_rate
+            stages = []
+            for stage_config_raw in config["decoder_kwargs"]:
+                stage_config = dict(stage_config_raw)
+                module_type = stage_config["module_type"]
+                if module_type == "PatchedPretransform":
+                    stage = _PatchedPretransform(
+                        int(stage_config["patch_size"]),
+                        is_downsample=False,
+                    )
+                elif module_type == "Transformer":
+                    stage_config.setdefault(
+                        "attention_implementation",
+                        config.get(
+                            "attention_implementation",
+                            _HF_FLASH_ATTENTION_IMPLEMENTATION,
+                        ),
+                    )
+                    context_duration = float(
+                        stage_config.pop("context_duration", default_context_duration)
+                    )
+                    stage = MossAudioTokenizerProjectedTransformer(
+                        stage_config,
+                        context=int(round(frame_rate * context_duration)),
+                        moss_audio_tokenizer_v1_weights=(
+                            moss_audio_tokenizer_v1_weights
+                        ),
+                        device=device,
+                        dtype=dtype,
+                        attention_backend=attention_backend,
+                    )
+                else:
+                    raise ValueError(
+                        "unsupported MOSS-Audio-Tokenizer decoder stage: "
+                        f"{module_type!r}"
+                    )
+                stages.append(stage)
+                if isinstance(stage, _PatchedPretransform):
+                    frame_rate *= stage.patch_size
+        else:
+            raise ValueError(
+                "MOSS-Audio-Tokenizer vocoder decoder requires config or "
+                "source_decoder"
+            )
+        stages = list(stages)
+        if not stages:
+            raise ValueError(
+                "MOSS-Audio-Tokenizer vocoder decoder must be a non-empty stage list"
+            )
+        self.attention_backend = validate_attention_backend(attention_backend)
+        self.extend(stages)
+
+    @classmethod
+    def from_module(
+        cls,
         decoder: nn.Module,
         *,
         attention_backend: str = AUTO_ATTENTION_BACKEND,
-    ) -> None:
-        super().__init__()
-        stages = list(decoder)
-        assert (
-            stages
-        ), "MOSS-Audio-Tokenizer vocoder decoder must be a non-empty stage list"
-        self.attention_backend = validate_attention_backend(attention_backend)
-        self.stages = nn.ModuleList([self._wrap_stage(stage) for stage in stages])
-
-    def _wrap_stage(self, stage: nn.Module) -> nn.Module:
-        module_type = stage.module_type
-        if module_type == "Transformer":
-            return MossAudioTokenizerProjectedTransformer.from_module(
-                stage,
-                attention_backend=self.attention_backend,
-            )
-        if module_type == "PatchedPretransform":
-            return stage
-        raise ValueError(
-            f"unsupported MOSS-Audio-Tokenizer vocoder decoder stage {stage.__class__.__name__} "
-            f"with module_type={module_type!r}"
+    ) -> MossAudioTokenizerVocoderDecoder:
+        if isinstance(decoder, cls):
+            return decoder
+        return cls(
+            source_decoder=decoder,
+            attention_backend=attention_backend,
         )
-
-    def __iter__(self) -> Iterator[nn.Module]:
-        return iter(self.stages)
-
-    def __len__(self) -> int:
-        return len(self.stages)
-
-    def __getitem__(self, index: int) -> nn.Module:
-        return self.stages[index]
 
     def supports_packed_attention(
         self,
@@ -386,36 +726,34 @@ class MossAudioTokenizerVocoderDecoder(nn.Module):
         dtype: torch.dtype | None,
     ) -> bool:
         device = torch.device(device)
-        transformer_stages = [
+        transformer_stages = tuple(
             stage
-            for stage in self.stages
+            for stage in self
             if isinstance(stage, MossAudioTokenizerProjectedTransformer)
-        ]
+        )
         return bool(transformer_stages) and all(
             stage.supports_packed_attention(device, dtype)
             for stage in transformer_stages
         )
 
-    @staticmethod
-    def _update_cpu_lengths(
-        stage: nn.Module,
-        input_lengths: Sequence[int],
-    ) -> list[int]:
-        if isinstance(stage, MossAudioTokenizerProjectedTransformer):
-            return list(map(int, input_lengths))
-        patch_size = int(getattr(stage, "patch_size", 0))
-        if patch_size <= 0:
-            raise ValueError(
-                "MOSS-Audio-Tokenizer patched pretransform requires patch_size > 0"
-            )
-        if bool(getattr(stage, "is_downsample", False)):
-            return [int(length) // patch_size for length in input_lengths]
-        return [int(length) * patch_size for length in input_lengths]
+    def resolve_attention_backend(
+        self,
+        device: str | torch.device,
+        dtype: torch.dtype | None,
+    ) -> AttentionBackendResolution:
+        device = torch.device(device)
+        return merge_attention_backend_resolutions(
+            [
+                stage.resolve_attention_backend(device, dtype)
+                for stage in self
+                if isinstance(stage, MossAudioTokenizerProjectedTransformer)
+            ]
+        )
 
     def output_lengths(self, input_lengths: Sequence[int]) -> list[int]:
         output_lengths = list(map(int, input_lengths))
-        for stage in self.stages:
-            output_lengths = self._update_cpu_lengths(stage, output_lengths)
+        for stage in self:
+            output_lengths = _update_decoder_cpu_lengths(stage, output_lengths)
         return output_lengths
 
     def forward(
@@ -428,7 +766,7 @@ class MossAudioTokenizerVocoderDecoder(nn.Module):
         cpu_lengths = (
             None if input_lengths_cpu is None else list(map(int, input_lengths_cpu))
         )
-        for stage in self.stages:
+        for stage in self:
             if isinstance(stage, MossAudioTokenizerProjectedTransformer):
                 x, input_lengths = stage(
                     x,
@@ -438,7 +776,7 @@ class MossAudioTokenizerVocoderDecoder(nn.Module):
             else:
                 x, input_lengths = stage(x, input_lengths)
             if cpu_lengths is not None:
-                cpu_lengths = self._update_cpu_lengths(stage, cpu_lengths)
+                cpu_lengths = _update_decoder_cpu_lengths(stage, cpu_lengths)
         return x, input_lengths
 
 
@@ -468,115 +806,984 @@ def create_sin_embedding(
     return torch.cat((torch.cos(phase), torch.sin(phase)), dim=-1)
 
 
-def _torch_dtype(dtype: str | torch.dtype) -> torch.dtype:
-    return getattr(torch, dtype) if isinstance(dtype, str) else dtype
+_AUDIO_DTYPES: dict[str, torch.dtype] = {
+    "float32": torch.float32,
+    "bfloat16": torch.bfloat16,
+}
 
 
-def _model_floating_dtype(model: Any) -> torch.dtype:
-    parameters = getattr(model, "parameters", None)
-    if not callable(parameters):
-        return torch.float32
-    return next(
-        (
-            parameter.dtype
-            for parameter in parameters()
-            if parameter.is_floating_point()
-        ),
-        torch.float32,
-    )
+def resolve_moss_audio_dtype(
+    dtype: str | torch.dtype | None,
+    *,
+    name: str,
+    allow_none: bool,
+) -> torch.dtype | None:
+    if dtype is None:
+        if allow_none:
+            return None
+    elif isinstance(dtype, str):
+        resolved = _AUDIO_DTYPES.get(dtype.lower())
+        if resolved is not None:
+            return resolved
+    elif isinstance(dtype, torch.dtype) and dtype in _AUDIO_DTYPES.values():
+        return dtype
+    allowed = "float32, bfloat16"
+    if allow_none:
+        allowed += ", or null"
+    raise ValueError(f"{name} must be {allowed}; got {dtype!r}")
 
 
-class MossTTSAudioTokenizer:
-    """Processor-compatible wrapper around a separately loaded codec model."""
+def _validate_audio_dtypes(
+    *,
+    component_dtype: torch.dtype,
+    component_name: str,
+    compute_dtype: torch.dtype | None,
+) -> None:
+    if component_dtype not in (torch.float32, torch.bfloat16):
+        raise ValueError(
+            f"{component_name} must be torch.float32 or torch.bfloat16; "
+            f"got {component_dtype!r}"
+        )
+    if compute_dtype not in (None, torch.float32, torch.bfloat16):
+        raise ValueError(
+            "compute_dtype must be torch.float32, torch.bfloat16, or None; "
+            f"got {compute_dtype!r}"
+        )
 
-    def __init__(self, model: Any, *, device: str) -> None:
+
+@dataclass
+class MossAudioTokenizerEncoderOutput:
+    """Output contract shared with the upstream audio-tokenizer encoder."""
+
+    audio_codes: torch.Tensor
+    audio_codes_lengths: torch.Tensor
+    encoder_hidden_states: torch.Tensor
+
+
+class _LayerScale(nn.Module):
+    def __init__(
+        self,
+        channels: int,
+        *,
+        init: float,
+        device: str | torch.device | None,
+        dtype: torch.dtype | None,
+    ) -> None:
+        super().__init__()
+        self.scale = nn.Parameter(
+            torch.full((channels,), init, device=device, dtype=dtype)
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.scale * x
+
+
+class _RMSNorm(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        *,
+        eps: float,
+        device: str | torch.device | None,
+        dtype: torch.dtype | None,
+        compute_dtype: torch.dtype | None = None,
+    ) -> None:
+        super().__init__()
+        self.eps = float(eps)
+        self.compute_dtype = compute_dtype
+        self.alpha = nn.Parameter(torch.ones((1, 1, dim), device=device, dtype=dtype))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        output_dtype = x.dtype
+        if self.compute_dtype is not None:
+            x = x.to(self.compute_dtype)
+        variance = self.eps + torch.mean(x**2, dim=-1, keepdim=True)
+        alpha = self.alpha.to(variance)
+        if x.dim() == 2:
+            alpha = alpha.view(1, -1)
+        return (x * (alpha * torch.rsqrt(variance))).to(output_dtype)
+
+
+def _create_norm(
+    norm: str,
+    dim: int,
+    *,
+    device: str | torch.device | None,
+    dtype: torch.dtype | None,
+) -> nn.Module:
+    if norm == "layer_norm":
+        return nn.LayerNorm(dim, eps=1e-5, device=device, dtype=dtype)
+    if norm == "rms_norm":
+        return _RMSNorm(dim, eps=1e-5, device=device, dtype=dtype)
+    if norm == "rms_norm_f32":
+        return _RMSNorm(
+            dim,
+            eps=1e-8,
+            device=device,
+            # note (Zhang Yiyang): This norm explicitly computes in FP32. Keep
+            # its scale in FP32 as well so the forward path does not recast the
+            # parameter every call.
+            dtype=torch.float32,
+            compute_dtype=torch.float32,
+        )
+    raise ValueError(f"unsupported MOSS audio-tokenizer norm: {norm!r}")
+
+
+def _restore_fp32_compute_parameters(module: nn.Module) -> None:
+    """Keep parameters of explicitly FP32 compute modules in FP32."""
+    for submodule in module.modules():
+        if not isinstance(submodule, _RMSNorm):
+            continue
+        if submodule.compute_dtype is not torch.float32:
+            continue
+        with torch.no_grad():
+            submodule.alpha.data = submodule.alpha.data.to(dtype=torch.float32)
+
+
+class _RotaryEmbedding(nn.Module):
+    def __init__(self, max_period: float) -> None:
+        super().__init__()
+        self.max_period = float(max_period)
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        offset: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        batch_size, _, sequence_length, head_dim = q.shape
+        frequencies = torch.exp(
+            torch.arange(
+                head_dim // 2,
+                device=q.device,
+                dtype=torch.float32,
+            )
+            * (-math.log(self.max_period) * 2 / head_dim)
+        )
+        positions = offset.float().view(batch_size, 1, 1, 1) + torch.arange(
+            sequence_length,
+            device=q.device,
+            dtype=torch.float32,
+        ).view(1, 1, sequence_length, 1)
+        phase = positions * frequencies.view(1, 1, 1, -1)
+        cos = torch.cos(phase)
+        sin = torch.sin(phase)
+
+        def rotate(x: torch.Tensor) -> torch.Tensor:
+            shape = x.shape
+            pairs = x.float().view(*shape[:-1], head_dim // 2, 2)
+            real, imag = pairs[..., 0], pairs[..., 1]
+            return (
+                torch.stack(
+                    (real * cos - imag * sin, real * sin + imag * cos),
+                    dim=-1,
+                )
+                .to(x.dtype)
+                .view(shape)
+            )
+
+        return rotate(q), rotate(k)
+
+
+class _PatchedPretransform(nn.Module):
+    def __init__(self, patch_size: int, *, is_downsample: bool) -> None:
+        super().__init__()
+        self.module_type = "PatchedPretransform"
+        self.patch_size = int(patch_size)
+        self.downsample_ratio = self.patch_size
+        self.is_downsample = bool(is_downsample)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        input_lengths: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        batch_size, channels, length = x.shape
+        if self.is_downsample:
+            x = (
+                x.reshape(batch_size, channels, -1, self.patch_size)
+                .permute(0, 1, 3, 2)
+                .reshape(batch_size, channels * self.patch_size, -1)
+            )
+            return x, input_lengths // self.patch_size
+        if channels % self.patch_size:
+            raise ValueError(
+                "MOSS vocoder patch stage requires channels divisible by "
+                f"patch_size, got channels={channels}, patch_size={self.patch_size}"
+            )
+        output_channels = channels // self.patch_size
+        x = (
+            x.reshape(batch_size, output_channels, self.patch_size, length)
+            .permute(0, 1, 3, 2)
+            .reshape(batch_size, output_channels, length * self.patch_size)
+        )
+        return x, input_lengths * self.patch_size
+
+
+def _weight_normalized_conv1d(*args: Any, **kwargs: Any) -> nn.Module:
+    return nn.utils.parametrizations.weight_norm(nn.Conv1d(*args, **kwargs))
+
+
+class _LFQ(nn.Module):
+    def __init__(
+        self,
+        *,
+        input_dim: int,
+        codebook_size: int,
+        codebook_dim: int,
+        device: str | torch.device | None,
+    ) -> None:
+        super().__init__()
+        self.in_proj = (
+            _weight_normalized_conv1d(
+                input_dim,
+                codebook_dim,
+                kernel_size=1,
+                device=device,
+                dtype=torch.float32,
+            )
+            if input_dim != codebook_dim
+            else nn.Identity()
+        )
+        self.out_proj = (
+            _weight_normalized_conv1d(
+                codebook_dim,
+                input_dim,
+                kernel_size=1,
+                device=device,
+                dtype=torch.float32,
+            )
+            if input_dim != codebook_dim
+            else nn.Identity()
+        )
+        self.codebook = nn.Embedding(
+            codebook_size,
+            codebook_dim,
+            device=device,
+            dtype=torch.float32,
+        )
+
+    def forward(
+        self,
+        z: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        encoded = self.in_proj(z.float()).float()
+        flat = F.normalize(encoded.transpose(1, 2).reshape(-1, encoded.shape[1]))
+        codebook = F.normalize(self.codebook.weight.float())
+        distance = (
+            flat.pow(2).sum(1, keepdim=True)
+            - 2 * flat @ codebook.t()
+            + codebook.pow(2).sum(1, keepdim=True).t()
+        )
+        indices = (-distance).max(1)[1].reshape(z.shape[0], -1)
+        quantized = F.embedding(indices, self.codebook.weight).transpose(1, 2)
+        quantized = encoded + (quantized - encoded).detach()
+        return self.out_proj(quantized.float()).float(), indices
+
+    def decode_code(self, indices: torch.Tensor) -> torch.Tensor:
+        quantized = F.embedding(indices, self.codebook.weight).transpose(1, 2)
+        return self.out_proj(quantized.float()).float()
+
+
+class _ResidualLFQ(nn.Module):
+    def __init__(
+        self,
+        config: dict[str, Any],
+        *,
+        device: str | torch.device | None,
+    ) -> None:
+        super().__init__()
+        input_dim = int(config.get("input_dim", 1024))
+        rvq_dim = int(config.get("rvq_dim") or input_dim)
+        output_dim = int(config.get("output_dim") or input_dim)
+        self.rvq_dim = rvq_dim
+        self.num_quantizers = int(config.get("num_quantizers", 32))
+        codebook_size = int(config.get("codebook_size", 1024))
+        codebook_dim = int(config.get("codebook_dim", 8))
+        self.input_proj = (
+            _weight_normalized_conv1d(
+                input_dim,
+                rvq_dim,
+                kernel_size=1,
+                device=device,
+                dtype=torch.float32,
+            )
+            if input_dim != rvq_dim
+            else nn.Identity()
+        )
+        self.output_proj = (
+            _weight_normalized_conv1d(
+                rvq_dim,
+                output_dim,
+                kernel_size=1,
+                device=device,
+                dtype=torch.float32,
+            )
+            if rvq_dim != output_dim
+            else nn.Identity()
+        )
+        self.quantizers = nn.ModuleList(
+            [
+                _LFQ(
+                    input_dim=rvq_dim,
+                    codebook_size=codebook_size,
+                    codebook_dim=codebook_dim,
+                    device=device,
+                )
+                for _ in range(self.num_quantizers)
+            ]
+        )
+
+    @torch.no_grad()
+    def forward(
+        self,
+        z: torch.Tensor,
+        input_lengths: torch.Tensor,
+        num_quantizers: int | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        with torch.autocast(device_type="cuda", enabled=False):
+            z = self.input_proj(z.float()).float()
+            batch_size, _, max_time = z.shape
+            mask = torch.arange(max_time, device=z.device).expand(
+                batch_size, max_time
+            ) < input_lengths.unsqueeze(1)
+            residual = z.clone()
+            quantized = torch.zeros_like(z)
+            indices = []
+            count = (
+                self.num_quantizers if num_quantizers is None else int(num_quantizers)
+            )
+            if not 0 < count <= self.num_quantizers:
+                raise ValueError(
+                    f"num_quantizers must be in [1, {self.num_quantizers}], got {count}"
+                )
+            update_mask = mask.unsqueeze(1)
+            for quantizer in self.quantizers[:count]:
+                current, current_indices = quantizer(residual * update_mask)
+                quantized += current * update_mask
+                residual -= current * update_mask
+                indices.append(current_indices)
+            return (
+                self.output_proj(quantized.float()).float(),
+                torch.stack(indices),
+                input_lengths,
+            )
+
+    @torch.no_grad()
+    def decode_codes(self, codes: torch.Tensor) -> torch.Tensor:
+        with torch.autocast(device_type=codes.device.type, enabled=False):
+            if codes.ndim != 3:
+                raise ValueError(
+                    "MOSS quantizer codes must be [N, B, T], got "
+                    f"{tuple(codes.shape)}"
+                )
+            count, batch_size, frames = map(int, codes.shape)
+            if not 0 < count <= self.num_quantizers:
+                raise ValueError(
+                    "MOSS quantizer codebook count must be within "
+                    f"[1, {self.num_quantizers}], got {count}"
+                )
+            decoded = torch.zeros(
+                batch_size,
+                self.rvq_dim,
+                frames,
+                device=codes.device,
+                dtype=torch.float32,
+            )
+            for index, quantizer in enumerate(self.quantizers[:count]):
+                decoded += quantizer.decode_code(codes[index]).float()
+            return self.output_proj(decoded.float()).float()
+
+
+class MossAudioTokenizerEncoder(nn.Module):
+    """Inference-only MOSS codec encoder with repository-owned execution code."""
+
+    def __init__(
+        self,
+        config: dict[str, Any],
+        *,
+        parameter_device: str | torch.device | None = None,
+        encoder_dtype: torch.dtype = torch.bfloat16,
+        compute_dtype: torch.dtype | None = None,
+        attention_backend: str = AUTO_ATTENTION_BACKEND,
+    ) -> None:
+        super().__init__()
+        _validate_audio_dtypes(
+            component_dtype=encoder_dtype,
+            component_name="encoder_dtype",
+            compute_dtype=compute_dtype,
+        )
+        self.config = SimpleNamespace(**config)
+        sampling_rate = config.get("sampling_rate") or config.get("sample_rate")
+        if sampling_rate is None:
+            raise ValueError("MOSS audio-tokenizer config lacks sampling_rate")
+        self.sampling_rate = int(sampling_rate)
+        self.downsample_rate = int(config["downsample_rate"])
+        self.number_channels = int(config.get("number_channels", 1))
+        self.enable_channel_interleave = bool(
+            config.get("enable_channel_interleave", self.number_channels > 1)
+        )
+        configured_compute_dtype = str(config.get("compute_dtype", "bf16"))
+        resolved_compute_dtype = {
+            "bf16": torch.bfloat16,
+            "bfloat16": torch.bfloat16,
+            "fp32": None,
+            "float32": None,
+        }.get(configured_compute_dtype)
+        if configured_compute_dtype not in {
+            "bf16",
+            "bfloat16",
+            "fp32",
+            "float32",
+        }:
+            raise ValueError(
+                f"unsupported codec compute_dtype: {configured_compute_dtype!r}"
+            )
+        requested_compute_dtype = (
+            resolved_compute_dtype if compute_dtype is None else compute_dtype
+        )
+        self.compute_dtype = (
+            None
+            if requested_compute_dtype is torch.float32
+            else requested_compute_dtype
+        )
+        # note (Zhang Yiyang): The compute policy is also the materialized dtype
+        # for the encoder weights. This avoids relying on autocast to recast
+        # FP32 parameters on every request. The quantizer is intentionally kept
+        # FP32 below.
+        self.encoder_dtype = (
+            torch.float32
+            if requested_compute_dtype is None
+            or requested_compute_dtype is torch.float32
+            else requested_compute_dtype
+        )
+        self.attention_backend = validate_attention_backend(attention_backend)
+        self._uses_moss_audio_tokenizer_v1_weights = "number_channels" not in config
+
+        default_context_duration = float(
+            config.get("causal_transformer_context_duration", 10.0)
+        )
+        channel_factor = (
+            self.number_channels
+            if self.enable_channel_interleave and self.number_channels > 1
+            else 1
+        )
+        frame_rate = float(self.sampling_rate * channel_factor)
+        stages: list[nn.Module] = []
+        for stage_config_raw in config["encoder_kwargs"]:
+            stage_config = dict(stage_config_raw)
+            module_type = stage_config["module_type"]
+            if module_type == "PatchedPretransform":
+                stage = _PatchedPretransform(
+                    int(stage_config["patch_size"]),
+                    is_downsample=True,
+                )
+            elif module_type == "Transformer":
+                stage_config.setdefault(
+                    "attention_implementation",
+                    config.get(
+                        "attention_implementation",
+                        _HF_FLASH_ATTENTION_IMPLEMENTATION,
+                    ),
+                )
+                context_duration = float(
+                    stage_config.pop("context_duration", default_context_duration)
+                )
+                stage = MossAudioTokenizerProjectedTransformer(
+                    stage_config,
+                    context=int(round(frame_rate * context_duration)),
+                    moss_audio_tokenizer_v1_weights=(
+                        self._uses_moss_audio_tokenizer_v1_weights
+                    ),
+                    device=parameter_device,
+                    dtype=self.encoder_dtype,
+                    attention_backend=self.attention_backend,
+                )
+            else:
+                raise ValueError(f"unsupported MOSS encoder stage: {module_type!r}")
+            stages.append(stage)
+            frame_rate /= int(getattr(stage, "downsample_ratio", 1))
+        self.encoder = nn.ModuleList(stages)
+
+        quantizer_config = dict(config["quantizer_kwargs"])
+        quantizer_type = quantizer_config.get(
+            "quantizer_type", config.get("quantizer_type", "rlfq")
+        )
+        if quantizer_type not in {"rlfq", "random_prefix_rlfq"}:
+            raise ValueError(
+                "repository-local MOSS encoder supports residual LFQ checkpoints; "
+                f"got quantizer_type={quantizer_type!r}"
+            )
+        self.quantizer = _ResidualLFQ(
+            quantizer_config,
+            device=parameter_device,
+        )
+
+    def supports_packed_attention(self) -> bool:
+        device = next(self.parameters()).device
+        return all(
+            not isinstance(stage, MossAudioTokenizerProjectedTransformer)
+            or stage.supports_packed_attention(device, self.encoder_dtype)
+            for stage in self.encoder
+        )
+
+    def resolve_attention_backend(
+        self,
+        device: str | torch.device,
+        dtype: torch.dtype | None = None,
+    ) -> AttentionBackendResolution:
+        device = torch.device(device)
+        return merge_attention_backend_resolutions(
+            [
+                stage.resolve_attention_backend(
+                    device,
+                    self.encoder_dtype if dtype is None else dtype,
+                )
+                for stage in self.encoder
+                if isinstance(stage, MossAudioTokenizerProjectedTransformer)
+            ]
+        )
+
+    def _prepare_waveform_batch(
+        self,
+        waveforms: list[torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
+        if not waveforms:
+            raise ValueError("waveforms must contain at least one item")
+        device = waveforms[0].device
+        dtype = waveforms[0].dtype
+        normalized = []
+        lengths_cpu = []
+        for index, waveform in enumerate(waveforms):
+            if self.number_channels == 1 and waveform.dim() == 1:
+                waveform = waveform.unsqueeze(0)
+            if waveform.dim() != 2 or waveform.shape[0] != self.number_channels:
+                raise ValueError(
+                    f"waveforms[{index}] must have shape "
+                    f"({self.number_channels}, T), got {tuple(waveform.shape)}"
+                )
+            normalized.append(waveform)
+            lengths_cpu.append(int(waveform.shape[-1]))
+        max_length = max(lengths_cpu)
+        batch = torch.zeros(
+            len(normalized),
+            self.number_channels,
+            max_length,
+            device=device,
+            dtype=dtype,
+        )
+        for index, waveform in enumerate(normalized):
+            batch[index, :, : waveform.shape[-1]] = waveform
+        lengths = torch.tensor(lengths_cpu, device=device, dtype=torch.long)
+        return batch, lengths, lengths_cpu
+
+    def _flatten_channels(
+        self,
+        input_values: torch.Tensor,
+        input_lengths: torch.Tensor,
+        input_lengths_cpu: list[int],
+    ) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
+        remainder = input_values.shape[-1] % self.downsample_rate
+        if remainder:
+            input_values = F.pad(
+                input_values,
+                (0, self.downsample_rate - remainder),
+            )
+        if self.number_channels > 1 and self.enable_channel_interleave:
+            input_values = (
+                input_values.transpose(1, 2)
+                .contiguous()
+                .view(input_values.shape[0], 1, -1)
+            )
+            input_lengths = input_lengths * self.number_channels
+            input_lengths_cpu = [
+                length * self.number_channels for length in input_lengths_cpu
+            ]
+        return input_values, input_lengths, input_lengths_cpu
+
+    @torch.no_grad()
+    def batch_encode(
+        self,
+        waveforms: list[torch.Tensor],
+        num_quantizers: int | None = None,
+        chunk_duration: float | None = None,
+    ) -> MossAudioTokenizerEncoderOutput:
+        if chunk_duration is not None:
+            raise ValueError(
+                "repository-local MOSS encoder only supports full non-streaming "
+                "batch_encode (chunk_duration=None)"
+            )
+        hidden, lengths, lengths_cpu = self._prepare_waveform_batch(waveforms)
+        hidden, lengths, lengths_cpu = self._flatten_channels(
+            hidden,
+            lengths,
+            lengths_cpu,
+        )
+        hidden = hidden.to(dtype=self.encoder_dtype)
+        for stage in self.encoder:
+            if isinstance(stage, MossAudioTokenizerProjectedTransformer):
+                hidden, lengths = stage(
+                    hidden,
+                    lengths,
+                    input_lengths_cpu=lengths_cpu,
+                )
+            else:
+                hidden, lengths = stage(hidden, lengths)
+                lengths_cpu = [
+                    length // int(stage.downsample_ratio) for length in lengths_cpu
+                ]
+        _, codes, code_lengths = self.quantizer(
+            hidden.float(),
+            lengths,
+            num_quantizers,
+        )
+        max_valid_length = max(lengths_cpu, default=0)
+        return MossAudioTokenizerEncoderOutput(
+            audio_codes=codes[:, :, :max_valid_length],
+            audio_codes_lengths=code_lengths,
+            encoder_hidden_states=hidden[:, :, :max_valid_length].float(),
+        )
+
+
+class MossAudioEncoder:
+    """Prepare reference audio and encode it with a shared MOSS encoder."""
+
+    def __init__(self, model: MossAudioTokenizerEncoder, *, device: str) -> None:
         self.model = model
         self.device = str(device)
-        self.dtype = _model_floating_dtype(model)
-        self.sample_rate = int(model.config.sampling_rate)
+        config = model.config
+        self.sample_rate = int(
+            getattr(model, "sampling_rate", getattr(config, "sampling_rate"))
+        )
+        self.number_channels = int(
+            getattr(model, "number_channels", getattr(config, "number_channels", 1))
+        )
 
-    def _autocast(self) -> Any:
-        device_type = torch.device(self.device).type
-        if device_type == "cuda" and self.dtype in {torch.float16, torch.bfloat16}:
-            return torch.autocast(device_type=device_type, dtype=self.dtype)
-        return nullcontext()
+    def encode_paths(
+        self,
+        paths: list[str | PathLike[str]],
+        *,
+        num_quantizers: int,
+    ) -> list[torch.Tensor]:
+        if not paths:
+            raise ValueError("paths must contain at least one audio path")
+        return self.encode_waveforms(
+            self.load_paths(paths),
+            num_quantizers=num_quantizers,
+        )
+
+    def load_paths(
+        self,
+        paths: list[str | PathLike[str]],
+    ) -> list[tuple[torch.Tensor, int]]:
+        import torchaudio
+
+        waveforms = []
+        for path in paths:
+            waveform, sample_rate = torchaudio.load(path)
+            if int(sample_rate) != self.sample_rate:
+                waveform = torchaudio.functional.resample(
+                    waveform=waveform,
+                    orig_freq=int(sample_rate),
+                    new_freq=self.sample_rate,
+                )
+            waveforms.append((waveform, self.sample_rate))
+        return waveforms
+
+    def encode_wavs(
+        self,
+        waveforms: list[torch.Tensor],
+        sample_rate: int,
+        *,
+        num_quantizers: int,
+    ) -> list[torch.Tensor]:
+        return self.encode_waveforms(
+            [(waveform, int(sample_rate)) for waveform in waveforms],
+            num_quantizers=num_quantizers,
+        )
 
     def encode_waveforms(
         self,
         waveforms: list[tuple[torch.Tensor, int]],
         *,
-        num_quantizers: int | None = None,
+        num_quantizers: int,
     ) -> list[torch.Tensor]:
         if not waveforms:
             raise ValueError("waveforms must contain at least one waveform")
         prepared = [
-            self._prepare_waveform(wav, sample_rate) for wav, sample_rate in waveforms
+            self._prepare_waveform(waveform, sample_rate)
+            for waveform, sample_rate in waveforms
         ]
-
-        with torch.inference_mode(), self._autocast():
-            if hasattr(self.model, "batch_encode"):
-                encoded = self.model.batch_encode(
-                    prepared,
-                    num_quantizers=num_quantizers,
-                )
-            else:
-                max_length = max(int(wav.shape[-1]) for wav in prepared)
-                input_values = torch.zeros(
-                    len(prepared),
-                    1,
-                    max_length,
-                    device=self.device,
-                    dtype=torch.float32,
-                )
-                padding_mask = torch.zeros(
-                    len(prepared),
-                    max_length,
-                    device=self.device,
-                    dtype=torch.bool,
-                )
-                for index, wav in enumerate(prepared):
-                    length = int(wav.shape[-1])
-                    input_values[index, 0, :length] = wav
-                    padding_mask[index, :length] = True
-                encoded = self.model.encode(
-                    input_values,
-                    padding_mask=padding_mask,
-                    num_quantizers=num_quantizers,
-                    return_dict=True,
-                )
-
-        audio_codes = encoded.audio_codes
-        audio_codes_lengths = encoded.audio_codes_lengths
-        if audio_codes is None or audio_codes_lengths is None:
+        with torch.inference_mode():
+            encoded = self.model.batch_encode(
+                prepared,
+                num_quantizers=int(num_quantizers),
+            )
+        codes = encoded.audio_codes
+        lengths = encoded.audio_codes_lengths
+        if codes is None or lengths is None:
             raise RuntimeError(
-                "MOSS-Audio-Tokenizer encode returned empty "
-                "audio_codes/audio_codes_lengths"
+                "MOSS audio encoder returned empty audio_codes/audio_codes_lengths"
             )
-        codes_cpu = audio_codes.detach().to(device="cpu", dtype=torch.long)
-        lengths_cpu = audio_codes_lengths.detach().to("cpu")
+        codes = codes.detach().to(device="cpu", dtype=torch.long)
+        lengths = lengths.detach().to("cpu")
         return [
-            codes_cpu[:, index, : int(lengths_cpu[index])].transpose(0, 1).contiguous()
-            for index in range(int(codes_cpu.shape[1]))
+            codes[:, index, : int(lengths[index])].transpose(0, 1).contiguous()
+            for index in range(int(codes.shape[1]))
         ]
 
-    def _prepare_waveform(self, wav: torch.Tensor, sample_rate: int) -> torch.Tensor:
-        if wav.ndim == 1:
-            wav = wav.unsqueeze(0)
-        if wav.ndim != 2:
+    def _prepare_waveform(
+        self,
+        waveform: torch.Tensor,
+        sample_rate: int,
+    ) -> torch.Tensor:
+        if waveform.ndim == 1:
+            waveform = waveform.unsqueeze(0)
+        if waveform.ndim != 2:
             raise ValueError(
-                f"expected waveform with shape [channels, samples], got {tuple(wav.shape)}"
+                "expected waveform with shape [channels, samples], got "
+                f"{tuple(waveform.shape)}"
             )
-        if int(wav.shape[0]) > 1:
-            wav = torch.mean(wav, dim=0, keepdim=True)
+        if self.number_channels == 1:
+            if waveform.shape[0] > 1:
+                waveform = torch.mean(waveform, dim=0, keepdim=True)
+        else:
+            if waveform.shape[0] == 1:
+                waveform = waveform.repeat(self.number_channels, 1)
+            elif waveform.shape[0] > self.number_channels:
+                waveform = waveform[: self.number_channels]
+            if waveform.shape[0] != self.number_channels:
+                raise ValueError(
+                    f"expected {self.number_channels} audio channels, "
+                    f"got {waveform.shape[0]}"
+                )
         if int(sample_rate) != self.sample_rate:
-            wav = torchaudio.functional.resample(
-                waveform=wav,
+            import torchaudio
+
+            waveform = torchaudio.functional.resample(
+                waveform=waveform,
                 orig_freq=int(sample_rate),
                 new_freq=self.sample_rate,
             )
-        wav = self._loudness_normalize(wav.squeeze(0))
-        return wav.to(device=self.device, dtype=torch.float32)
+        waveform = self._loudness_normalize(waveform)
+        if self.number_channels == 1:
+            waveform = waveform.squeeze(0)
+        return waveform.to(device=self.device, dtype=torch.float32)
 
+    @staticmethod
+    def _loudness_normalize(waveform: torch.Tensor) -> torch.Tensor:
+        waveform = waveform.to(torch.float32)
+        if waveform.numel() == 0:
+            return waveform
+        current_dbfs = 10.0 * torch.log10(torch.mean(waveform**2) + 1e-9)
+        gain = float(_LOUDNESS_TARGET_DBFS - current_dbfs)
+        gain = max(_LOUDNESS_GAIN_MIN_DB, min(gain, _LOUDNESS_GAIN_MAX_DB))
+        return waveform * (10.0 ** (gain / 20.0))
+
+
+def _normalize_moss_audio_tokenizer_v1_transformer_state_dict(
+    state_dict: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    """Map MOSS v1 weight names onto the shared Transformer modules."""
+
+    replacements = (
+        (".self_attn.in_projs.0.", ".self_attn.in_proj."),
+        (".self_attn.out_projs.0.", ".self_attn.out_proj."),
+        (".linear1.", ".ffn.linear1."),
+        (".linear2.", ".ffn.linear2."),
+    )
+    normalized = {}
+    for name, tensor in state_dict.items():
+        normalized_name = name
+        for old, new in replacements:
+            normalized_name = normalized_name.replace(old, new)
+        normalized[normalized_name] = tensor
+    return normalized
+
+
+def _load_moss_audio_config(model_path: str) -> tuple[Path, dict[str, Any]]:
+    resolved_path = resolve_model_path(str(model_path))
+    config_path = resolved_path / "config.json"
+    with config_path.open(encoding="utf-8") as config_file:
+        config = json.load(config_file)
+    if config.get("model_type") != "moss-audio-tokenizer":
+        raise ValueError(
+            f"expected model_type='moss-audio-tokenizer' in {config_path}, "
+            f"got {config.get('model_type')!r}"
+        )
+    return resolved_path, config
+
+
+def _load_moss_audio_component(
+    module: nn.Module,
+    model_path: Path,
+    *,
+    prefix: str,
+    dtype: torch.dtype,
+    device: str | torch.device,
+    v1_weights: bool,
+) -> nn.Module:
+    if v1_weights:
+        state_dict = load_weights_by_prefix(str(model_path), prefix=prefix)
+        state_dict = _normalize_moss_audio_tokenizer_v1_transformer_state_dict(
+            state_dict
+        )
+        try:
+            module.load_state_dict(state_dict, strict=True, assign=True)
+        except TypeError:
+            module.load_state_dict(state_dict, strict=True)
+        module = module.to(device=device, dtype=dtype)
+        module.eval()
+    else:
+        module = load_module(
+            module,
+            str(model_path),
+            prefix=prefix,
+            dtype=dtype,
+            device=device,
+            strict=True,
+        )
+    _restore_fp32_compute_parameters(module)
+    return module
+
+
+def _load_moss_audio_quantizer(
+    module: nn.Module,
+    model_path: Path,
+    *,
+    device: str | torch.device,
+) -> nn.Module:
+    return load_module(
+        module,
+        str(model_path),
+        prefix="quantizer.",
+        dtype=torch.float32,
+        device=device,
+        strict=True,
+    )
+
+
+def load_moss_audio_encoder(
+    model_path: str,
+    *,
+    device: str | torch.device,
+    encoder_dtype: torch.dtype = torch.bfloat16,
+    compute_dtype: torch.dtype | None = None,
+    attention_backend: str = AUTO_ATTENTION_BACKEND,
+) -> MossAudioEncoder:
+    """Load only encoder/quantizer weights without executing checkpoint code."""
+
+    resolved_path, config = _load_moss_audio_config(model_path)
+
+    model = MossAudioTokenizerEncoder(
+        config,
+        parameter_device="meta",
+        encoder_dtype=encoder_dtype,
+        compute_dtype=compute_dtype,
+        attention_backend=attention_backend,
+    )
+    target_device = torch.device(device)
+    backend_resolution = model.resolve_attention_backend(target_device)
+    backend_label = _attention_backend_label(backend_resolution)
+    _load_moss_audio_component(
+        model.encoder,
+        resolved_path,
+        prefix="encoder.",
+        dtype=model.encoder_dtype,
+        device=device,
+        v1_weights=model._uses_moss_audio_tokenizer_v1_weights,
+    )
+    _load_moss_audio_quantizer(
+        model.quantizer,
+        resolved_path,
+        device=device,
+    )
+    model.eval()
+    logger.info(
+        "Loaded repository-local MOSS-Audio-Tokenizer encoder from %s on %s "
+        "(channels=%d, attention_backend=%s, encoder_dtype=%s, "
+        "compute_dtype=%s)",
+        resolved_path,
+        device,
+        model.number_channels,
+        backend_label,
+        model.encoder_dtype,
+        model.compute_dtype,
+    )
+    return MossAudioEncoder(model, device=str(device))
+
+
+class MossAudioTokenizerVocoder(nn.Module):
+    """Inference-only MOSS quantizer and waveform decoder."""
+
+    def __init__(
+        self,
+        config: dict[str, Any],
+        *,
+        parameter_device: str | torch.device | None = None,
+        decoder_dtype: torch.dtype = torch.bfloat16,
+        compute_dtype: torch.dtype | None = None,
+        attention_backend: str = AUTO_ATTENTION_BACKEND,
+    ) -> None:
+        super().__init__()
+        _validate_audio_dtypes(
+            component_dtype=decoder_dtype,
+            component_name="decoder_dtype",
+            compute_dtype=compute_dtype,
+        )
+        self.config = SimpleNamespace(**config)
+        sampling_rate = config.get("sampling_rate") or config.get("sample_rate")
+        if sampling_rate is None:
+            raise ValueError("MOSS audio-tokenizer config lacks sampling_rate")
+        self.sampling_rate = int(sampling_rate)
+        self.downsample_rate = int(config["downsample_rate"])
+        self.decoder_dtype = decoder_dtype if compute_dtype is None else compute_dtype
+        self.compute_dtype = None if compute_dtype is torch.float32 else compute_dtype
+        self.attention_backend = validate_attention_backend(attention_backend)
+        self._uses_moss_audio_tokenizer_v1_weights = "number_channels" not in config
+
+        quantizer_config = dict(config["quantizer_kwargs"])
+        quantizer_type = quantizer_config.get(
+            "quantizer_type", config.get("quantizer_type", "rlfq")
+        )
+        if quantizer_type not in {"rlfq", "random_prefix_rlfq"}:
+            raise ValueError(
+                "repository-local MOSS vocoder supports residual LFQ checkpoints; "
+                f"got quantizer_type={quantizer_type!r}"
+            )
+        self.quantizer = _ResidualLFQ(
+            quantizer_config,
+            device=parameter_device,
+        )
+
+        self.decoder = MossAudioTokenizerVocoderDecoder(
+            config,
+            moss_audio_tokenizer_v1_weights=(
+                self._uses_moss_audio_tokenizer_v1_weights
+            ),
+            device=parameter_device,
+            dtype=self.decoder_dtype,
+            attention_backend=self.attention_backend,
+        )
+
+    def resolve_attention_backend(
+        self,
+        device: str | torch.device,
+        dtype: torch.dtype | None = None,
+    ) -> AttentionBackendResolution:
+        decoder_dtype = self.decoder_dtype if dtype is None else dtype
+        return self.decoder.resolve_attention_backend(device, decoder_dtype)
+
+
+class MossAudioVocoder:
+    """Narrow wrapper used by the MOSS-TTS Delay vocoder stage."""
+
+    def __init__(self, model: MossAudioTokenizerVocoder, *, device: str) -> None:
+        self.model = model
+        self.device = str(device)
+        self.sample_rate = int(model.sampling_rate)
+
+    @torch.no_grad()
     def decode_codes(
         self,
         codes: torch.Tensor | list[torch.Tensor],
@@ -585,84 +1792,82 @@ class MossTTSAudioTokenizer:
             codes = [codes]
         if not codes:
             return []
-
         codes_nq_t = [
             item.transpose(0, 1).contiguous().to(device=self.device, dtype=torch.long)
             for item in codes
         ]
-        num_quantizers = int(codes_nq_t[0].shape[0])
-        if any(int(item.shape[0]) != num_quantizers for item in codes_nq_t):
+        count = int(codes_nq_t[0].shape[0])
+        if any(int(item.shape[0]) != count for item in codes_nq_t):
             raise ValueError("all audio-code rows must use the same quantizer count")
-        max_length = max(int(item.shape[1]) for item in codes_nq_t)
+        lengths_cpu = [int(item.shape[1]) for item in codes_nq_t]
+        max_length = max(lengths_cpu)
         audio_codes = torch.zeros(
-            num_quantizers,
+            count,
             len(codes_nq_t),
             max_length,
             device=self.device,
             dtype=torch.long,
         )
-        padding_mask = torch.zeros(
-            len(codes_nq_t),
-            max_length,
-            device=self.device,
-            dtype=torch.bool,
-        )
         for index, item in enumerate(codes_nq_t):
-            length = int(item.shape[1])
-            audio_codes[:, index, :length] = item
-            padding_mask[index, :length] = True
-
-        with torch.inference_mode(), self._autocast():
-            decoded = self.model.decode(
-                audio_codes,
-                padding_mask=padding_mask,
-                return_dict=True,
-                chunk_duration=8,
-            )
-        audio = decoded.audio
-        audio_lengths = decoded.audio_lengths
-        if audio is None or audio_lengths is None:
-            raise RuntimeError(
-                "MOSS-Audio-Tokenizer decode returned empty audio/audio_lengths"
-            )
-        audio_cpu = audio.detach().to(device="cpu", dtype=torch.float32)
-        lengths_cpu = audio_lengths.detach().to("cpu")
+            audio_codes[:, index, : item.shape[1]] = item
+        lengths = torch.tensor(lengths_cpu, device=self.device, dtype=torch.int32)
+        hidden = self.model.quantizer.decode_codes(audio_codes)
+        hidden = hidden.to(dtype=self.model.decoder_dtype)
+        audio, _ = self.model.decoder(
+            hidden,
+            lengths,
+            input_lengths_cpu=lengths_cpu,
+        )
+        output_lengths = self.model.decoder.output_lengths(lengths_cpu)
         return [
-            audio_cpu[index, 0, : int(lengths_cpu[index])].contiguous()
-            for index in range(int(audio_cpu.shape[0]))
+            audio[index, 0, :length].detach().to(device="cpu", dtype=torch.float32)
+            for index, length in enumerate(output_lengths)
         ]
 
-    @staticmethod
-    def _loudness_normalize(wav: torch.Tensor) -> torch.Tensor:
-        wav = wav.to(torch.float32)
-        if wav.numel() == 0:
-            return wav
-        current_dbfs = 10.0 * torch.log10(torch.mean(wav**2) + 1e-9)
-        gain = float(_LOUDNESS_TARGET_DBFS - current_dbfs)
-        gain = max(_LOUDNESS_GAIN_MIN_DB, min(gain, _LOUDNESS_GAIN_MAX_DB))
-        return wav * (10.0 ** (gain / 20.0))
 
-
-def load_moss_tts_audio_tokenizer(
-    model_path: str = DEFAULT_MOSS_TTS_AUDIO_TOKENIZER,
+def load_moss_audio_vocoder(
+    model_path: str,
     *,
-    device: str = "cpu",
-    dtype: str | torch.dtype = "float32",
-) -> MossTTSAudioTokenizer:
-    logger.info(f"Loading MOSS-Audio-Tokenizer from {model_path} on {device}")
-    try:
-        with moss_transformers_processor_compat():
-            model = AutoModel.from_pretrained(
-                model_path,
-                trust_remote_code=True,
-            )
-    except Exception as exc:
-        raise RuntimeError(
-            "MOSS-TTS support requires OpenMOSS-Team/MOSS-Audio-Tokenizer"
-        ) from exc
+    device: str | torch.device,
+    decoder_dtype: torch.dtype = torch.bfloat16,
+    compute_dtype: torch.dtype | None = None,
+    attention_backend: str = AUTO_ATTENTION_BACKEND,
+) -> MossAudioVocoder:
+    """Load only quantizer/decoder weights without executing checkpoint code."""
+
+    resolved_path, config = _load_moss_audio_config(model_path)
+
+    model = MossAudioTokenizerVocoder(
+        config,
+        parameter_device="meta",
+        decoder_dtype=decoder_dtype,
+        compute_dtype=compute_dtype,
+        attention_backend=attention_backend,
+    )
+    target_device = torch.device(device)
+    backend_resolution = model.resolve_attention_backend(target_device)
+    backend_label = _attention_backend_label(backend_resolution)
+    _load_moss_audio_quantizer(
+        model.quantizer,
+        resolved_path,
+        device=device,
+    )
+    _load_moss_audio_component(
+        model.decoder,
+        resolved_path,
+        prefix="decoder.",
+        dtype=model.decoder_dtype,
+        device=device,
+        v1_weights=model._uses_moss_audio_tokenizer_v1_weights,
+    )
     model.eval()
-    move_kwargs: dict[str, Any] = {"device": device}
-    if device != "cpu":
-        move_kwargs["dtype"] = _torch_dtype(dtype)
-    model.to(**move_kwargs)
-    return MossTTSAudioTokenizer(model, device=device)
+    logger.info(
+        "Loaded repository-local MOSS-Audio-Tokenizer vocoder from %s on %s "
+        "(attention_backend=%s, decoder_dtype=%s, compute_dtype=%s)",
+        resolved_path,
+        device,
+        backend_label,
+        model.decoder_dtype,
+        model.compute_dtype,
+    )
+    return MossAudioVocoder(model, device=str(device))

--- a/sglang_omni/models/moss_tts/config.py
+++ b/sglang_omni/models/moss_tts/config.py
@@ -22,6 +22,7 @@ _REF_AUDIO_CACHE_MAX_BYTES = 64 * 1024 * 1024
 class MossTTSPreprocessingFactoryArgs(FactoryArgs):
     """Reference-encode cache knobs, typed like the shared ones."""
 
+    compute_dtype: str | None = None
     ref_audio_cache: bool | None = None
     ref_audio_cache_max_items: int | None = Field(default=None, ge=1)
     ref_audio_cache_max_bytes: int | None = Field(default=None, ge=1)
@@ -74,6 +75,7 @@ class MossTTSPipelineConfig(PipelineConfig):
             factory_path=f"{_PKG}.stages.create_preprocessing_executor",
             factory=MossTTSPreprocessingFactoryArgs(
                 dtype="float32",
+                compute_dtype="bfloat16",
                 ref_audio_cache=True,
                 ref_audio_cache_max_items=_REF_AUDIO_CACHE_MAX_ITEMS,
                 ref_audio_cache_max_bytes=_REF_AUDIO_CACHE_MAX_BYTES,

--- a/sglang_omni/models/moss_tts/config.py
+++ b/sglang_omni/models/moss_tts/config.py
@@ -74,7 +74,6 @@ class MossTTSPipelineConfig(PipelineConfig):
             process="pipeline",
             factory_path=f"{_PKG}.stages.create_preprocessing_executor",
             factory=MossTTSPreprocessingFactoryArgs(
-                dtype="float32",
                 compute_dtype="bfloat16",
                 ref_audio_cache=True,
                 ref_audio_cache_max_items=_REF_AUDIO_CACHE_MAX_ITEMS,

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -424,7 +424,6 @@ def create_preprocessing_executor(
     *,
     device: str | None = None,
     gpu_id: int | None = None,
-    dtype: str | torch.dtype = "float32",
     compute_dtype: str | torch.dtype | None = "bfloat16",
     attention_backend: str = "auto",
     codec_model_path: str | None = None,
@@ -457,17 +456,10 @@ def create_preprocessing_executor(
         processor,
         codec_model_path,
     )
-    encoder_dtype = resolve_moss_audio_dtype(
-        dtype,
-        name="dtype",
-        allow_none=False,
-    )
-    assert encoder_dtype is not None
     resolved_compute_dtype = _resolve_compute_dtype(compute_dtype)
     audio_encoder = load_moss_audio_encoder(
         resolved_codec_model_path,
         device=device,
-        encoder_dtype=encoder_dtype,
         compute_dtype=resolved_compute_dtype,
         attention_backend=attention_backend,
     )

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -17,8 +17,10 @@ from transformers import AutoConfig, AutoTokenizer
 
 from sglang_omni.models.moss_tts.audio_tokenizer import (
     DEFAULT_MOSS_TTS_AUDIO_TOKENIZER,
-    MossTTSAudioTokenizer,
-    load_moss_tts_audio_tokenizer,
+    MossAudioEncoder,
+    load_moss_audio_encoder,
+    load_moss_audio_vocoder,
+    resolve_moss_audio_dtype,
 )
 from sglang_omni.models.moss_tts.engine_builder import MossTtsEngineBuilder
 from sglang_omni.models.moss_tts.hf_loading import (
@@ -65,25 +67,14 @@ _ReferenceEncodeQueueEntry: TypeAlias = tuple[
 ]
 
 
-_COMPUTE_DTYPES: dict[str, torch.dtype] = {
-    "float32": torch.float32,
-    "bfloat16": torch.bfloat16,
-}
-
-
 def _resolve_compute_dtype(
     dtype: str | torch.dtype | None,
 ) -> torch.dtype | None:
-    if dtype is None:
-        return None
-    if isinstance(dtype, str):
-        try:
-            return _COMPUTE_DTYPES[dtype.lower()]
-        except KeyError:
-            pass
-    elif isinstance(dtype, torch.dtype) and dtype in (torch.float32, torch.bfloat16):
-        return dtype
-    raise ValueError(f"compute_dtype must be float32, bfloat16, or null; got {dtype!r}")
+    return resolve_moss_audio_dtype(
+        dtype,
+        name="compute_dtype",
+        allow_none=True,
+    )
 
 
 def _normalize_moss_processor_config(processor: Any) -> None:
@@ -164,20 +155,20 @@ def _resolve_codec_device(device: str | None, gpu_id: int | None) -> str:
 
 
 class _BatchedReferenceEncoder:
-    """Coalesce concurrent Delay reference encodes into codec batches."""
+    """Coalesce concurrent Delay reference encodes into encoder batches."""
 
     MAX_REFERENCE_SECONDS = _MAX_REFERENCE_SECONDS
     ENCODE_TIMEOUT_S = 120.0
 
     def __init__(
         self,
-        audio_tokenizer: MossTTSAudioTokenizer,
+        audio_encoder: MossAudioEncoder,
         *,
         n_vq: int,
         max_batch_size: int = 8,
         max_batch_wait_ms: int = 4,
     ) -> None:
-        self._audio_tokenizer = audio_tokenizer
+        self._audio_encoder = audio_encoder
         self._n_vq = int(n_vq)
         self._max_batch_size = max(int(max_batch_size), 1)
         self._max_wait_s = max(float(max_batch_wait_ms), 0.0) / 1000.0
@@ -192,7 +183,7 @@ class _BatchedReferenceEncoder:
         self._thread.start()
 
     def close(self) -> None:
-        """Stop the codec worker after all already-queued jobs finish."""
+        """Stop the reference encoder worker after all queued jobs finish."""
         with self._lifecycle_lock:
             if self._closed:
                 return
@@ -204,7 +195,7 @@ class _BatchedReferenceEncoder:
         with self._lifecycle_lock:
             if self._closed:
                 raise RuntimeError("MOSS-TTS reference encoder is closed")
-        return _load_reference_waveform(self._audio_tokenizer, source)
+        return _load_reference_waveform(self._audio_encoder, source)
 
     def encode(self, source: str | os.PathLike[str]) -> torch.Tensor:
         return self.encode_input(self.load(source))
@@ -286,7 +277,7 @@ class _BatchedReferenceEncoder:
             group_indices[group].append(index)
 
         try:
-            encoded = self._audio_tokenizer.encode_waveforms(
+            encoded = self._audio_encoder.encode_waveforms(
                 waveforms,
                 num_quantizers=self._n_vq,
             )
@@ -306,7 +297,7 @@ class _BatchedReferenceEncoder:
 
         for indices, waveform in zip(group_indices, waveforms):
             try:
-                codes = self._audio_tokenizer.encode_waveforms(
+                codes = self._audio_encoder.encode_waveforms(
                     [waveform],
                     num_quantizers=self._n_vq,
                 )[0]
@@ -318,7 +309,7 @@ class _BatchedReferenceEncoder:
 
 
 def _load_reference_waveform(
-    audio_tokenizer: MossTTSAudioTokenizer,
+    audio_encoder: MossAudioEncoder,
     source: str | os.PathLike[str],
 ) -> _LoadedReferenceWaveform:
     """Load once through the shared resolver and key the exact codec input."""
@@ -326,10 +317,10 @@ def _load_reference_waveform(
     waveform = load_audio(
         os.fsdecode(source),
         source_name="MOSS-TTS reference",
-        target_sample_rate=audio_tokenizer.sample_rate,
+        target_sample_rate=audio_encoder.sample_rate,
         mono=True,
     )
-    duration = len(waveform) / max(audio_tokenizer.sample_rate, 1)
+    duration = len(waveform) / max(audio_encoder.sample_rate, 1)
     if duration > _MAX_REFERENCE_SECONDS:
         raise ValueError(
             f"reference audio is {duration:.1f}s long, limit is "
@@ -337,14 +328,14 @@ def _load_reference_waveform(
         )
     return _LoadedReferenceWaveform(
         torch.from_numpy(waveform),
-        audio_tokenizer.sample_rate,
+        audio_encoder.sample_rate,
         f"waveform:{audio_fingerprint(waveform)}",
     )
 
 
 class _MossTTSReferenceEncodeHook(TensorReferenceEncodeHook[_LoadedReferenceWaveform]):
     model_id = "moss_tts_delay"
-    encoder_id = "moss_audio_tokenizer"
+    encoder_id = "moss_audio_encoder"
     artifact_kind = "moss_tts_reference_codes"
     storage_dtype = torch.int32
     output_dtype = torch.long
@@ -358,15 +349,15 @@ class _MossTTSReferenceEncodeHook(TensorReferenceEncodeHook[_LoadedReferenceWave
     ) -> None:
         self._encoder = encoder
         self.model_revision = str(codec_model_path)
-        model = getattr(encoder._audio_tokenizer, "model", None)
+        model = getattr(encoder._audio_encoder, "model", None)
         try:
             parameter_dtype = str(next(model.parameters()).dtype)
         except (AttributeError, StopIteration):
             parameter_dtype = "unknown"
         config = (
             f"n_vq:{int(n_vq)}|sample_rate:"
-            f"{getattr(encoder._audio_tokenizer, 'sample_rate', 'unknown')}|device:"
-            f"{getattr(encoder._audio_tokenizer, 'device', 'unknown')}|dtype:"
+            f"{getattr(encoder._audio_encoder, 'sample_rate', 'unknown')}|device:"
+            f"{getattr(encoder._audio_encoder, 'device', 'unknown')}|dtype:"
             f"{parameter_dtype}"
         )
         self.encoder_config_hash = hash_bytes(config.encode("utf-8"))
@@ -433,7 +424,9 @@ def create_preprocessing_executor(
     *,
     device: str | None = None,
     gpu_id: int | None = None,
-    dtype: str = "float32",
+    dtype: str | torch.dtype = "float32",
+    compute_dtype: str | torch.dtype | None = "bfloat16",
+    attention_backend: str = "auto",
     codec_model_path: str | None = None,
     max_concurrency: int = 16,
     encode_batch_size: int = 8,
@@ -464,13 +457,22 @@ def create_preprocessing_executor(
         processor,
         codec_model_path,
     )
-    audio_tokenizer = load_moss_tts_audio_tokenizer(
+    encoder_dtype = resolve_moss_audio_dtype(
+        dtype,
+        name="dtype",
+        allow_none=False,
+    )
+    assert encoder_dtype is not None
+    resolved_compute_dtype = _resolve_compute_dtype(compute_dtype)
+    audio_encoder = load_moss_audio_encoder(
         resolved_codec_model_path,
         device=device,
-        dtype=dtype,
+        encoder_dtype=encoder_dtype,
+        compute_dtype=resolved_compute_dtype,
+        attention_backend=attention_backend,
     )
     reference_encoder: Any = _BatchedReferenceEncoder(
-        audio_tokenizer,
+        audio_encoder,
         n_vq=int(processor.model_config.n_vq),
         max_batch_size=encode_batch_size,
         max_batch_wait_ms=encode_batch_wait_ms,
@@ -531,6 +533,7 @@ def create_vocoder_executor(
     stream_holdback_tokens: int = 1,
     initial_chunk_frames: int = 0,
     compute_dtype: str | torch.dtype | None = "bfloat16",
+    attention_backend: str = "auto",
 ) -> MossStreamingVocoderScheduler:
     # An explicit device is a model policy/user override; gpu_id is only the
     # placement-derived fallback. This matches preprocessing resolution and
@@ -538,15 +541,23 @@ def create_vocoder_executor(
     device = _resolve_codec_device(device, gpu_id)
     resolved_compute_dtype = _resolve_compute_dtype(compute_dtype)
     processor = _load_moss_processor(model_path)
-    audio_tokenizer = load_moss_tts_audio_tokenizer(
+    decoder_dtype = resolve_moss_audio_dtype(
+        dtype,
+        name="dtype",
+        allow_none=False,
+    )
+    assert decoder_dtype is not None
+    audio_vocoder = load_moss_audio_vocoder(
         _resolve_audio_tokenizer_model_path(processor, codec_model_path),
         device=device,
-        dtype=dtype,
+        decoder_dtype=decoder_dtype,
+        compute_dtype=resolved_compute_dtype,
+        attention_backend=attention_backend,
     )
 
     vocoder = MossTTSVocoder(
         processor,
-        audio_tokenizer,
+        audio_vocoder,
         device,
         compute_dtype=resolved_compute_dtype,
         max_segment_batch_size=max_batch_size,

--- a/sglang_omni/models/moss_tts/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts/streaming_vocoder.py
@@ -67,7 +67,7 @@ class MossStreamingVocoderScheduler(StreamingVocoderBase[_MossStreamState, None]
             raise ValueError("stream holdback must be >= 0")
 
         self._vocoder = vocoder
-        self._audio_tokenizer = vocoder._audio_tokenizer
+        self._audio_vocoder = vocoder._audio_vocoder
         self._stream_stride = int(stream_stride)
         self._stream_followup_stride = int(stream_followup_stride)
         self._stream_overlap_tokens = int(stream_overlap_tokens)
@@ -79,9 +79,9 @@ class MossStreamingVocoderScheduler(StreamingVocoderBase[_MossStreamState, None]
         self._default_audio_pad_code = resolve_moss_audio_pad_code(
             getattr(vocoder._processor, "model_config", None)
         )
-        sample_rate = int(self._audio_tokenizer.sample_rate)
+        sample_rate = int(self._audio_vocoder.sample_rate)
         self._default_samples_per_frame = self._resolve_samples_per_frame(
-            self._audio_tokenizer, sample_rate
+            self._audio_vocoder, sample_rate
         )
 
         super().__init__(
@@ -306,7 +306,7 @@ class MossStreamingVocoderScheduler(StreamingVocoderBase[_MossStreamState, None]
 
         window_start = max(0, emitted_frames - self._stream_overlap_tokens)
         window = torch.stack(segment.frames[window_start:], dim=0)
-        decoded = self._audio_tokenizer.decode_codes([window])
+        decoded = self._audio_vocoder.decode_codes([window])
         if not decoded:
             return None
         audio = torch.as_tensor(decoded[0]).detach().reshape(-1).to(torch.float32)
@@ -418,10 +418,10 @@ class MossStreamingVocoderScheduler(StreamingVocoderBase[_MossStreamState, None]
 
     @staticmethod
     def _resolve_samples_per_frame(
-        audio_tokenizer: Any,
+        audio_vocoder: Any,
         sample_rate: int,
     ) -> int | None:
-        config = getattr(getattr(audio_tokenizer, "model", None), "config", None)
+        config = getattr(getattr(audio_vocoder, "model", None), "config", None)
         for attr in (
             "downsample_rate",
             "samples_per_frame",

--- a/sglang_omni/models/moss_tts/vocoder.py
+++ b/sglang_omni/models/moss_tts/vocoder.py
@@ -15,7 +15,7 @@ from torch.nn.utils.rnn import pad_sequence
 
 from sglang_omni.models.moss_tts.audio_tokenizer import (
     MossAudioTokenizerVocoderDecoder,
-    MossTTSAudioTokenizer,
+    MossAudioVocoder,
 )
 from sglang_omni.models.moss_tts.delay_pattern import split_moss_audio_segments
 from sglang_omni.models.moss_tts.payload_types import (
@@ -122,18 +122,18 @@ class MossTTSVocoder(BatchVocoderBase):
     def __init__(
         self,
         processor: Any,
-        audio_tokenizer: MossTTSAudioTokenizer,
+        audio_vocoder: MossAudioVocoder,
         device: str,
         *,
         compute_dtype: torch.dtype | None = None,
         max_segment_batch_size: int = 8,
     ) -> None:
         self._processor = processor
-        self._audio_tokenizer = audio_tokenizer
+        self._audio_vocoder = audio_vocoder
         self._device = device
         self._compute_dtype = compute_dtype
         self._max_segment_batch_size = max(int(max_segment_batch_size), 1)
-        self._codec = getattr(audio_tokenizer, "model", None)
+        self._codec = getattr(audio_vocoder, "model", None)
         self._quantizer = getattr(self._codec, "quantizer", None)
         self._quantizer_decoder = None
         self._nonstream_decoder = None
@@ -145,8 +145,9 @@ class MossTTSVocoder(BatchVocoderBase):
         ):
             codec_device = _codec_device(self._codec, self._device)
             try:
-                nonstream_decoder = MossAudioTokenizerVocoderDecoder(
-                    self._codec.decoder
+                source_decoder = self._codec.decoder
+                nonstream_decoder = MossAudioTokenizerVocoderDecoder.from_module(
+                    source_decoder
                 )
                 supports_packed_attention = nonstream_decoder.supports_packed_attention(
                     codec_device,
@@ -213,7 +214,7 @@ class MossTTSVocoder(BatchVocoderBase):
         decoded = []
         with _autocast_if_supported(codec_device, codec_dtype):
             for segment in segments:
-                decoded.extend(self._audio_tokenizer.decode_codes([segment]))
+                decoded.extend(self._audio_vocoder.decode_codes([segment]))
         if not decoded:
             raise RuntimeError("MOSS-TTS vocoder decoded no audio segments")
         waveforms = [
@@ -224,7 +225,7 @@ class MossTTSVocoder(BatchVocoderBase):
 
     def _resolve_sample_rate(self, state: MossTTSState) -> int:
         return int(
-            getattr(self._audio_tokenizer, "sample_rate", 0)
+            getattr(self._audio_vocoder, "sample_rate", 0)
             or getattr(getattr(self._codec, "config", None), "sampling_rate", 0)
             or getattr(
                 getattr(self._processor, "model_config", None), "sampling_rate", 0

--- a/sglang_omni/models/moss_tts_local/audio_tokenizer.py
+++ b/sglang_omni/models/moss_tts_local/audio_tokenizer.py
@@ -18,6 +18,7 @@ from sglang_omni.models.moss_tts.audio_tokenizer import (
     load_moss_audio_encoder,
     resolve_moss_audio_attention_backend,
     resolve_moss_audio_dtype,
+    resolve_moss_audio_sample_rate,
     validate_attention_backend,
 )
 from sglang_omni.models.moss_tts.hf_loading import moss_transformers_processor_compat
@@ -50,9 +51,7 @@ class MossTTSLocalAudioTokenizer:
             config = encoder.model.config
         if config is None:
             raise ValueError("MOSS-TTS Local audio tokenizer model lacks config")
-        self.sample_rate = int(
-            getattr(model, "sampling_rate", getattr(config, "sampling_rate"))
-        )
+        self.sample_rate = resolve_moss_audio_sample_rate(model, config)
 
     def encode_paths(
         self,
@@ -198,9 +197,7 @@ class MossTTSLocalAudioVocoder:
         config = getattr(model, "config", None)
         if config is None:
             raise ValueError("MOSS-TTS Local vocoder model lacks config")
-        self.sample_rate = int(
-            getattr(model, "sampling_rate", getattr(config, "sampling_rate"))
-        )
+        self.sample_rate = resolve_moss_audio_sample_rate(model, config)
 
 
 def _resolve_local_codec_dtype(

--- a/sglang_omni/models/moss_tts_local/audio_tokenizer.py
+++ b/sglang_omni/models/moss_tts_local/audio_tokenizer.py
@@ -165,14 +165,12 @@ def load_moss_tts_local_audio_tokenizer(
     model_path: str = DEFAULT_MOSS_TTS_LOCAL_AUDIO_TOKENIZER,
     *,
     device: str = "cuda:0",
-    encoder_dtype: torch.dtype = torch.bfloat16,
     compute_dtype: torch.dtype | None = None,
     attention_backend: str = AUTO_ATTENTION_BACKEND,
 ) -> MossTTSLocalAudioTokenizer:
     encoder = load_moss_audio_encoder(
         model_path,
         device=device,
-        encoder_dtype=encoder_dtype,
         compute_dtype=compute_dtype,
         attention_backend=attention_backend,
     )

--- a/sglang_omni/models/moss_tts_local/audio_tokenizer.py
+++ b/sglang_omni/models/moss_tts_local/audio_tokenizer.py
@@ -3,12 +3,25 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
 import torch
+from torch import nn
 
+from sglang_omni.models.moss_tts.audio_tokenizer import (
+    AUTO_ATTENTION_BACKEND,
+    PACKED_FLASH_ATTENTION_BACKEND,
+    SDPA_ATTENTION_BACKEND,
+    MossAudioEncoder,
+    load_moss_audio_encoder,
+    resolve_moss_audio_attention_backend,
+    resolve_moss_audio_dtype,
+    validate_attention_backend,
+)
 from sglang_omni.models.moss_tts.hf_loading import moss_transformers_processor_compat
+from sglang_omni.models.weight_loader import load_module, resolve_model_path
 
 logger = logging.getLogger(__name__)
 
@@ -27,11 +40,19 @@ class MossTTSLocalAudioTokenizer:
         model: Any,
         *,
         device: str,
+        encoder: MossAudioEncoder | None = None,
     ) -> None:
         self.model = model
+        self._encoder = encoder
         self.device = str(device)
-        config = model.config
-        self.sample_rate = int(config.sampling_rate)
+        config = getattr(model, "config", None)
+        if config is None and encoder is not None:
+            config = encoder.model.config
+        if config is None:
+            raise ValueError("MOSS-TTS Local audio tokenizer model lacks config")
+        self.sample_rate = int(
+            getattr(model, "sampling_rate", getattr(config, "sampling_rate"))
+        )
 
     def encode_paths(
         self,
@@ -86,7 +107,10 @@ class MossTTSLocalAudioTokenizer:
         ]
 
         with torch.inference_mode():
-            encoded = self.model.batch_encode(
+            encoder_model = (
+                self._encoder.model if self._encoder is not None else self.model
+            )
+            encoded = encoder_model.batch_encode(
                 prepared,
                 num_quantizers=int(num_quantizers),
             )
@@ -141,24 +165,162 @@ def load_moss_tts_local_audio_tokenizer(
     model_path: str = DEFAULT_MOSS_TTS_LOCAL_AUDIO_TOKENIZER,
     *,
     device: str = "cuda:0",
+    encoder_dtype: torch.dtype = torch.bfloat16,
+    compute_dtype: torch.dtype | None = None,
+    attention_backend: str = AUTO_ATTENTION_BACKEND,
 ) -> MossTTSLocalAudioTokenizer:
-    logger.info(f"Loading MOSS-TTS Local audio tokenizer from {model_path} on {device}")
-    try:
-        from transformers import AutoModel
-
-        with moss_transformers_processor_compat():
-            model = AutoModel.from_pretrained(
-                model_path,
-                trust_remote_code=True,
-                codec_weight_dtype="bf16",
-            )
-    except Exception as exc:
-        raise RuntimeError(
-            "MOSS-TTS Local support requires OpenMOSS-Team/MOSS-Audio-Tokenizer-v2"
-        ) from exc
-    model.eval()
-    model.to(device)
-    return MossTTSLocalAudioTokenizer(
-        model,
+    encoder = load_moss_audio_encoder(
+        model_path,
         device=device,
+        encoder_dtype=encoder_dtype,
+        compute_dtype=compute_dtype,
+        attention_backend=attention_backend,
     )
+    logger.info(
+        "Loaded repository-local MOSS-Audio-Tokenizer encoder for MOSS-TTS Local "
+        "from %s on %s (encoder_dtype=%s, compute_dtype=%s)",
+        model_path,
+        device,
+        encoder.model.encoder_dtype,
+        encoder.model.compute_dtype,
+    )
+    return MossTTSLocalAudioTokenizer(
+        encoder.model,
+        device=device,
+        encoder=encoder,
+    )
+
+
+class MossTTSLocalAudioVocoder:
+    """V2 streaming codec shell with only quantizer and decoder weights."""
+
+    def __init__(self, model: Any, *, device: str) -> None:
+        self.model = model
+        self.device = str(device)
+        config = getattr(model, "config", None)
+        if config is None:
+            raise ValueError("MOSS-TTS Local vocoder model lacks config")
+        self.sample_rate = int(
+            getattr(model, "sampling_rate", getattr(config, "sampling_rate"))
+        )
+
+
+def _resolve_local_codec_dtype(
+    value: str | torch.dtype | None,
+    *,
+    name: str,
+    allow_none: bool,
+) -> torch.dtype | None:
+    if isinstance(value, str):
+        value = {
+            "bf16": "bfloat16",
+            "fp32": "float32",
+        }.get(value.lower(), value)
+    return resolve_moss_audio_dtype(value, name=name, allow_none=allow_none)
+
+
+def _load_local_streaming_codec_config(model_path: str) -> tuple[Any, Any]:
+    resolved_path = resolve_model_path(str(model_path))
+    config_path = resolved_path / "config.json"
+    with config_path.open(encoding="utf-8") as config_file:
+        config_dict = json.load(config_file)
+    if config_dict.get("model_type") != "moss-audio-tokenizer":
+        raise ValueError(
+            f"expected model_type='moss-audio-tokenizer' in {config_path}, "
+            f"got {config_dict.get('model_type')!r}"
+        )
+    from transformers import AutoConfig
+
+    with moss_transformers_processor_compat():
+        config = AutoConfig.from_pretrained(
+            str(model_path),
+            trust_remote_code=True,
+        )
+    return resolved_path, config
+
+
+def load_moss_tts_local_audio_vocoder(
+    model_path: str = DEFAULT_MOSS_TTS_LOCAL_AUDIO_TOKENIZER,
+    *,
+    device: str = "cuda:0",
+    decoder_dtype: torch.dtype = torch.bfloat16,
+    compute_dtype: torch.dtype | None = None,
+    attention_backend: str = AUTO_ATTENTION_BACKEND,
+) -> MossTTSLocalAudioVocoder:
+    """Load the Local streaming shell with quantizer/decoder prefixes only."""
+    validate_attention_backend(attention_backend)
+    resolved_path, config = _load_local_streaming_codec_config(model_path)
+    configured_compute_dtype = _resolve_local_codec_dtype(
+        getattr(config, "compute_dtype", "bfloat16"),
+        name="compute_dtype",
+        allow_none=True,
+    )
+    effective_compute_dtype = (
+        configured_compute_dtype if compute_dtype is None else compute_dtype
+    )
+    if isinstance(effective_compute_dtype, str):
+        effective_compute_dtype = _resolve_local_codec_dtype(
+            effective_compute_dtype,
+            name="compute_dtype",
+            allow_none=True,
+        )
+    if effective_compute_dtype is None:
+        effective_decoder_dtype = decoder_dtype
+    else:
+        effective_decoder_dtype = effective_compute_dtype
+
+    config_attention_implementation = getattr(
+        config,
+        "attention_implementation",
+        "flash_attention_2",
+    )
+    selected_backend = resolve_moss_audio_attention_backend(
+        attention_backend,
+        config_attention_implementation,
+    )
+    if selected_backend == SDPA_ATTENTION_BACKEND:
+        config.attention_implementation = SDPA_ATTENTION_BACKEND
+    elif selected_backend == PACKED_FLASH_ATTENTION_BACKEND:
+        config.attention_implementation = "flash_attention_2"
+
+    from transformers import AutoModel
+
+    with moss_transformers_processor_compat(), torch.device("meta"):
+        model = AutoModel.from_config(config, trust_remote_code=True)
+    if not hasattr(model, "decoder") or not hasattr(model, "quantizer"):
+        raise ValueError("MOSS-Audio-Tokenizer-v2 model lacks decoder/quantizer")
+    model.encoder = nn.ModuleList()
+    model.quantizer = load_module(
+        model.quantizer,
+        str(resolved_path),
+        prefix="quantizer.",
+        dtype=torch.float32,
+        device=device,
+        strict=True,
+    )
+    model.decoder = load_module(
+        model.decoder,
+        str(resolved_path),
+        prefix="decoder.",
+        dtype=effective_decoder_dtype,
+        device=device,
+        strict=True,
+    )
+    model.compute_dtype = (
+        None
+        if effective_compute_dtype is None or effective_compute_dtype is torch.float32
+        else effective_compute_dtype
+    )
+    model.compute_dtype_name = "fp32" if model.compute_dtype is None else "bf16"
+    model.config.compute_dtype = model.compute_dtype_name
+    model.eval()
+    logger.info(
+        "Loaded MOSS-TTS Local streaming codec from %s on %s "
+        "(encoder_weights=0, decoder_dtype=%s, compute_dtype=%s, backend=%s)",
+        resolved_path,
+        device,
+        effective_decoder_dtype,
+        model.compute_dtype,
+        selected_backend,
+    )
+    return MossTTSLocalAudioVocoder(model, device=device)

--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -38,7 +38,6 @@ def _stages(*, codec_device: str, colocated: bool) -> list[StageConfig]:
             factory_path=f"{_PKG}.stages.create_preprocessing_executor",
             factory=FactoryArgs(
                 device=codec_device,
-                dtype="float32",
                 compute_dtype="bfloat16",
                 attention_backend="auto",
                 max_concurrency=_PREPROCESSING_MAX_CONCURRENCY,

--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -38,6 +38,9 @@ def _stages(*, codec_device: str, colocated: bool) -> list[StageConfig]:
             factory_path=f"{_PKG}.stages.create_preprocessing_executor",
             factory=FactoryArgs(
                 device=codec_device,
+                dtype="float32",
+                compute_dtype="bfloat16",
+                attention_backend="auto",
                 max_concurrency=_PREPROCESSING_MAX_CONCURRENCY,
             ),
             gpu_memory_fraction=(
@@ -65,7 +68,12 @@ def _stages(*, codec_device: str, colocated: bool) -> list[StageConfig]:
             name="vocoder",
             process="vocoder" if colocated else "pipeline",
             factory_path=f"{_PKG}.stages.create_vocoder_executor",
-            factory=FactoryArgs(device=codec_device),
+            factory=FactoryArgs(
+                device=codec_device,
+                dtype="float32",
+                compute_dtype="bfloat16",
+                attention_backend="auto",
+            ),
             gpu_memory_fraction=(
                 _COLOCATED_VOCODER_GPU_MEMORY_FRACTION if colocated else None
             ),

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -15,6 +15,7 @@ from typing import Any, TypeAlias
 
 import torch
 
+from sglang_omni.models.moss_tts.audio_tokenizer import resolve_moss_audio_dtype
 from sglang_omni.models.moss_tts.hf_loading import (
     load_moss_processor_class,
     moss_transformers_processor_compat,
@@ -23,6 +24,7 @@ from sglang_omni.models.moss_tts.request_builders import _DATA_URI_RE
 from sglang_omni.models.moss_tts_local.audio_tokenizer import (
     DEFAULT_MOSS_TTS_LOCAL_AUDIO_TOKENIZER,
     load_moss_tts_local_audio_tokenizer,
+    load_moss_tts_local_audio_vocoder,
 )
 from sglang_omni.models.moss_tts_local.payload_types import (
     moss_tts_local_special_token_defaults,
@@ -540,6 +542,9 @@ def create_preprocessing_executor(
     *,
     device: str | None = None,
     gpu_id: int | None = None,
+    dtype: str | torch.dtype = "float32",
+    compute_dtype: str | torch.dtype | None = "bfloat16",
+    attention_backend: str = "auto",
     codec_model_path: str | None = None,
     max_concurrency: int = 16,
     encode_batch_size: int = 8,
@@ -567,9 +572,23 @@ def create_preprocessing_executor(
         )
     device = _resolve_codec_device(device, gpu_id)
     processor = _load_moss_tts_local_processor(model_path)
+    encoder_dtype = resolve_moss_audio_dtype(
+        dtype,
+        name="dtype",
+        allow_none=False,
+    )
+    assert encoder_dtype is not None
+    resolved_compute_dtype = resolve_moss_audio_dtype(
+        compute_dtype,
+        name="compute_dtype",
+        allow_none=True,
+    )
     audio_tokenizer = load_moss_tts_local_audio_tokenizer(
         _resolve_audio_tokenizer_model_path(processor, codec_model_path),
         device=device,
+        encoder_dtype=encoder_dtype,
+        compute_dtype=resolved_compute_dtype,
+        attention_backend=attention_backend,
     )
     reference_encoder: Any = _BatchedReferenceEncoder(
         audio_tokenizer,
@@ -641,6 +660,9 @@ def create_vocoder_executor(
     *,
     device: str | None = None,
     gpu_id: int | None = None,
+    dtype: str | torch.dtype = "float32",
+    compute_dtype: str | torch.dtype | None = "bfloat16",
+    attention_backend: str = "auto",
     total_gpu_memory_fraction: float | None = None,
     process_total_gpu_memory_fraction: float | None = None,
     codec_model_path: str | None = None,
@@ -656,14 +678,29 @@ def create_vocoder_executor(
 ) -> MossTTSLocalStreamingVocoderScheduler:
     device = _resolve_codec_device(device, gpu_id)
     processor = _load_moss_tts_local_processor(model_path)
-    audio_tokenizer = load_moss_tts_local_audio_tokenizer(
+    decoder_dtype = resolve_moss_audio_dtype(
+        dtype,
+        name="dtype",
+        allow_none=False,
+    )
+    assert decoder_dtype is not None
+    resolved_compute_dtype = resolve_moss_audio_dtype(
+        compute_dtype,
+        name="compute_dtype",
+        allow_none=True,
+    )
+    audio_vocoder = load_moss_tts_local_audio_vocoder(
         _resolve_audio_tokenizer_model_path(processor, codec_model_path),
         device=device,
+        decoder_dtype=decoder_dtype,
+        compute_dtype=resolved_compute_dtype,
+        attention_backend=attention_backend,
     )
     scheduler = MossTTSLocalStreamingVocoderScheduler(
-        audio_tokenizer.model,
+        audio_vocoder.model,
         n_vq=int(processor.model_config.n_vq),
-        sample_rate=audio_tokenizer.sample_rate,
+        sample_rate=audio_vocoder.sample_rate,
+        attention_backend=attention_backend,
         stream_slots=stream_slots,
         stream_chunk_frames=stream_chunk_frames,
         initial_chunk_frames=initial_chunk_frames,

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -542,7 +542,6 @@ def create_preprocessing_executor(
     *,
     device: str | None = None,
     gpu_id: int | None = None,
-    dtype: str | torch.dtype = "float32",
     compute_dtype: str | torch.dtype | None = "bfloat16",
     attention_backend: str = "auto",
     codec_model_path: str | None = None,
@@ -572,12 +571,6 @@ def create_preprocessing_executor(
         )
     device = _resolve_codec_device(device, gpu_id)
     processor = _load_moss_tts_local_processor(model_path)
-    encoder_dtype = resolve_moss_audio_dtype(
-        dtype,
-        name="dtype",
-        allow_none=False,
-    )
-    assert encoder_dtype is not None
     resolved_compute_dtype = resolve_moss_audio_dtype(
         compute_dtype,
         name="compute_dtype",
@@ -586,7 +579,6 @@ def create_preprocessing_executor(
     audio_tokenizer = load_moss_tts_local_audio_tokenizer(
         _resolve_audio_tokenizer_model_path(processor, codec_model_path),
         device=device,
-        encoder_dtype=encoder_dtype,
         compute_dtype=resolved_compute_dtype,
         attention_backend=attention_backend,
     )

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -2,8 +2,10 @@
 """Streaming vocoder scheduler for MOSS-TTS Local.
 
 Streaming requests share one persistent batched ``codec.streaming()`` session.
-Pure non-streaming traffic uses the MOSS decoder with packed SGLang FlashAttention
-when no live streaming session owns the codec state.
+The remote codec uses SDPA for the lifetime of that session because its
+FlashAttention streaming path is unreliable. Pure non-streaming traffic uses
+the MOSS decoder with packed SGLang FlashAttention when no live streaming
+session owns the codec state.
 """
 
 from __future__ import annotations
@@ -16,6 +18,10 @@ from typing import Any, Mapping
 
 import torch
 
+from sglang_omni.models.moss_tts.attention import (
+    AUTO_ATTENTION_BACKEND,
+    SDPA_ATTENTION_BACKEND,
+)
 from sglang_omni.models.moss_tts.audio_tokenizer import MossAudioTokenizerVocoderDecoder
 from sglang_omni.models.moss_tts_local.payload_types import MossTTSLocalState
 from sglang_omni.proto import StagePayload
@@ -41,7 +47,12 @@ class _CodecStreamSession:
     """
 
     def __init__(
-        self, codec: Any, *, stream_slots: int, offline_slots: int, n_vq: int
+        self,
+        codec: Any,
+        *,
+        stream_slots: int,
+        offline_slots: int,
+        n_vq: int,
     ) -> None:
         self._codec = codec
         self._stream_slots = int(stream_slots)
@@ -62,8 +73,35 @@ class _CodecStreamSession:
         # Retain the streaming ExitStack so per-slot causal state lives across steps (closed in close());
         # graph replay is kept bit-identical to this stateful decode by the in-place cache patch.
         self._exit_stack = contextlib.ExitStack()
-        with torch.no_grad():
-            self._exit_stack.enter_context(codec.streaming(self._batch_size))
+        set_attention_implementation = getattr(
+            codec, "set_attention_implementation", None
+        )
+        previous_attention_implementation = getattr(
+            codec, "attention_implementation", None
+        )
+        if previous_attention_implementation is None:
+            previous_attention_implementation = getattr(
+                getattr(codec, "config", None), "attention_implementation", None
+            )
+        if (
+            not callable(set_attention_implementation)
+            or previous_attention_implementation is None
+        ):
+            self._exit_stack.close()
+            raise RuntimeError(
+                "MOSS-TTS Local streaming vocoder requires the codec's "
+                "set_attention_implementation API to force SDPA"
+            )
+        try:
+            set_attention_implementation(SDPA_ATTENTION_BACKEND)
+            self._exit_stack.callback(
+                set_attention_implementation, previous_attention_implementation
+            )
+            with torch.no_grad():
+                self._exit_stack.enter_context(codec.streaming(self._batch_size))
+        except BaseException:
+            self._exit_stack.close()
+            raise
 
     def warmup_cuda_graph(
         self, frames: list[int], *, min_free_gb: float = 3.0
@@ -343,6 +381,7 @@ class MossTTSLocalStreamingVocoderScheduler(
         sample_rate: int,
         stream_slots: int = 15,
         stream_chunk_frames: int = 25,
+        attention_backend: str = AUTO_ATTENTION_BACKEND,
         initial_chunk_frames: int = 5,
         coalesce_floor_frames: int = 5,
         max_step_frames: int = 100,
@@ -366,6 +405,7 @@ class MossTTSLocalStreamingVocoderScheduler(
                 "_set_streaming_exec_mask",
                 "_decode_frame",
                 "decode",
+                "set_attention_implementation",
             )
             if not hasattr(codec, name)
         ]
@@ -374,13 +414,19 @@ class MossTTSLocalStreamingVocoderScheduler(
                 f"MOSS-TTS Local streaming vocoder: codec is missing {missing}; "
                 "the installed MOSS-Audio-Tokenizer-v2 version is incompatible"
             )
-        nonstream_decoder = MossAudioTokenizerVocoderDecoder(codec.decoder)
+        nonstream_decoder = MossAudioTokenizerVocoderDecoder.from_module(
+            codec.decoder,
+            attention_backend=attention_backend,
+        )
         logger.info(
-            f"MOSS-TTS Local non-streaming vocoder uses packed SGLang attention "
-            f"stages={len(nonstream_decoder)}"
+            "MOSS-TTS Local non-streaming vocoder uses configured attention "
+            "backend=%s stages=%d",
+            attention_backend,
+            len(nonstream_decoder),
         )
         self._codec = codec
         self._nonstream_decoder = nonstream_decoder
+        self._attention_backend = attention_backend
         self._stream_slots = int(stream_slots)
         # Coalesce up to one full set of streaming lanes per pump, not the offline batch width.
         self._stream_chunk_batch_max = self._stream_slots

--- a/tests/unit_test/moss_tts/test_audio_tokenizer.py
+++ b/tests/unit_test/moss_tts/test_audio_tokenizer.py
@@ -1243,7 +1243,7 @@ def test_transformer_layer_uses_source_modules_for_primitive_ops() -> None:
 def test_vocoder_decoder_wraps_supported_stage_types() -> None:
     patch_stage = _PatchStage(patch_size=2, is_downsample=False)
     decoder = nn.ModuleList([_FallbackProjectedStage(), patch_stage])
-    wrapped = MossAudioTokenizerVocoderDecoder(decoder)
+    wrapped = MossAudioTokenizerVocoderDecoder.from_module(decoder)
 
     assert len(wrapped) == 2
     assert isinstance(wrapped[0], MossAudioTokenizerProjectedTransformer)
@@ -1259,7 +1259,7 @@ def test_vocoder_decoder_computes_output_lengths_on_host() -> None:
             _PatchStage(patch_size=2, is_downsample=True),
         ]
     )
-    wrapped = MossAudioTokenizerVocoderDecoder(decoder)
+    wrapped = MossAudioTokenizerVocoderDecoder.from_module(decoder)
 
     assert wrapped.output_lengths([3, 5]) == [12, 20]
 
@@ -1273,7 +1273,7 @@ def test_vocoder_decoder_requires_packed_attention_for_every_transformer(
         lambda device: None if device.type == "cuda" else "not CUDA",
     )
     moss_audio_tokenizer_v1_source = _MossAudioTokenizerV1ProjectedStage()
-    moss_audio_tokenizer_v1_decoder = MossAudioTokenizerVocoderDecoder(
+    moss_audio_tokenizer_v1_decoder = MossAudioTokenizerVocoderDecoder.from_module(
         nn.ModuleList([moss_audio_tokenizer_v1_source])
     )
     moss_audio_tokenizer_v1_attention = (
@@ -1296,7 +1296,7 @@ def test_vocoder_decoder_requires_packed_attention_for_every_transformer(
     local_source.transformer.layers[0].self_attn.attention_implementation = (
         "flash_attention_2"
     )
-    local = MossAudioTokenizerVocoderDecoder(nn.ModuleList([local_source]))
+    local = MossAudioTokenizerVocoderDecoder.from_module(nn.ModuleList([local_source]))
     local_attention = local[0].transformer.layers[0].self_attn
     local_attention._flash_attn_varlen = lambda *args, **kwargs: None
 
@@ -1306,7 +1306,7 @@ def test_vocoder_decoder_requires_packed_attention_for_every_transformer(
 
 def test_vocoder_decoder_wraps_moss_audio_tokenizer_v1_weight_fields() -> None:
     source = _MossAudioTokenizerV1ProjectedStage()
-    wrapped = MossAudioTokenizerVocoderDecoder(nn.ModuleList([source]))
+    wrapped = MossAudioTokenizerVocoderDecoder.from_module(nn.ModuleList([source]))
     source_layer = source.transformer.layers[0]
     wrapped_layer = wrapped[0].transformer.layers[0]
     attention = wrapped_layer.self_attn

--- a/tests/unit_test/moss_tts/test_encoder.py
+++ b/tests/unit_test/moss_tts/test_encoder.py
@@ -22,6 +22,7 @@ from sglang_omni.models.moss_tts.audio_tokenizer import (
     load_moss_audio_vocoder,
     resolve_moss_audio_attention_backend,
     resolve_moss_audio_dtype,
+    resolve_moss_audio_sample_rate,
 )
 
 
@@ -719,3 +720,27 @@ def test_shared_audio_encoder_uses_model_channel_contract() -> None:
 
     assert model.prepared is not None
     assert model.prepared[0].shape == (2, 4)
+
+
+@pytest.mark.parametrize(
+    ("model_attrs", "config_attrs", "expected"),
+    [
+        ({"sampling_rate": 48_000}, {"sampling_rate": 24_000}, 48_000),
+        ({}, {"sampling_rate": 24_000}, 24_000),
+        ({}, {"sample_rate": 16_000}, 16_000),
+    ],
+)
+def test_shared_audio_sample_rate_resolution(
+    model_attrs: dict[str, int],
+    config_attrs: dict[str, int],
+    expected: int,
+) -> None:
+    model = type("Model", (), model_attrs)()
+    config = type("Config", (), config_attrs)()
+
+    assert resolve_moss_audio_sample_rate(model, config) == expected
+
+
+def test_shared_audio_sample_rate_resolution_rejects_missing_value() -> None:
+    with pytest.raises(ValueError, match="sampling_rate or sample_rate"):
+        resolve_moss_audio_sample_rate(object(), object())

--- a/tests/unit_test/moss_tts/test_encoder.py
+++ b/tests/unit_test/moss_tts/test_encoder.py
@@ -1,0 +1,728 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from sglang_omni.models.moss_tts.audio_tokenizer import (
+    MossAudioEncoder,
+    MossAudioTokenizerEncoder,
+    MossAudioTokenizerProjectedTransformer,
+    MossAudioTokenizerVocoder,
+    MossAudioTokenizerVocoderDecoder,
+    MossAudioVocoder,
+    _normalize_moss_audio_tokenizer_v1_transformer_state_dict,
+    _PatchedPretransform,
+    _ResidualLFQ,
+    load_moss_audio_encoder,
+    load_moss_audio_vocoder,
+    resolve_moss_audio_attention_backend,
+    resolve_moss_audio_dtype,
+)
+
+
+def _tiny_config() -> dict:
+    return {
+        "architectures": ["RemoteCodeMustNotBeImported"],
+        "auto_map": {"AutoModel": "missing_remote_module.Model"},
+        "model_type": "moss-audio-tokenizer",
+        "sample_rate": 8,
+        "sampling_rate": 8,
+        "downsample_rate": 2,
+        "number_channels": 1,
+        "enable_channel_interleave": False,
+        "compute_dtype": "fp32",
+        "causal_transformer_context_duration": 1.0,
+        "encoder_kwargs": [
+            {"module_type": "PatchedPretransform", "patch_size": 2},
+            {
+                "module_type": "Transformer",
+                "input_dimension": 2,
+                "output_dimension": 4,
+                "d_model": 4,
+                "num_heads": 2,
+                "num_layers": 1,
+                "dim_feedforward": 8,
+                "causal": True,
+                "norm": "layer_norm",
+                "positional_embedding": "rope",
+                "max_period": 10_000,
+                "gating": "none",
+                "layer_scale": 0.01,
+                "context_duration": 1.0,
+            },
+        ],
+        "decoder_kwargs": [
+            {
+                "module_type": "Transformer",
+                "input_dimension": 4,
+                "output_dimension": 4,
+                "d_model": 4,
+                "num_heads": 2,
+                "num_layers": 1,
+                "dim_feedforward": 8,
+                "causal": True,
+                "norm": "layer_norm",
+                "positional_embedding": "rope",
+                "max_period": 10_000,
+                "gating": "none",
+                "layer_scale": 0.01,
+                "context_duration": 1.0,
+            },
+            {"module_type": "PatchedPretransform", "patch_size": 2},
+        ],
+        "quantizer_type": "rlfq",
+        "quantizer_kwargs": {
+            "input_dim": 4,
+            "rvq_dim": 4,
+            "output_dim": 4,
+            "num_quantizers": 2,
+            "codebook_size": 4,
+            "codebook_dim": 2,
+            "quantizer_type": "rlfq",
+        },
+    }
+
+
+def _tiny_moss_audio_tokenizer_v1_config() -> dict:
+    config = _tiny_config()
+    config.pop("number_channels")
+    config.pop("enable_channel_interleave")
+    config.pop("compute_dtype")
+    return config
+
+
+def test_repository_encoder_cpu_fallback_preserves_batch_lengths() -> None:
+    model = MossAudioTokenizerEncoder(
+        _tiny_config(),
+        parameter_device="cpu",
+        encoder_dtype=torch.float32,
+    ).eval()
+
+    output = model.batch_encode(
+        [torch.randn(1, 8), torch.randn(1, 6)],
+        num_quantizers=2,
+    )
+
+    assert output.audio_codes.shape == (2, 2, 4)
+    assert output.audio_codes_lengths.tolist() == [4, 3]
+    assert output.encoder_hidden_states.shape == (2, 4, 4)
+    assert not model.supports_packed_attention()
+    resolution = model.resolve_attention_backend("cpu")
+    assert resolution.backend == "sdpa"
+    assert resolution.fallback_reason is not None
+
+
+def test_repository_encoder_uses_shared_packed_attention_wrapper() -> None:
+    model = MossAudioTokenizerEncoder(
+        _tiny_config(),
+        parameter_device="cpu",
+        encoder_dtype=torch.float32,
+    )
+    stage = model.encoder[1]
+
+    assert isinstance(stage, MossAudioTokenizerProjectedTransformer)
+    attention = stage.transformer.layers[0].self_attn
+    assert attention.attention_backend == "auto"
+
+
+def test_repository_encoder_uses_configured_attention_implementation() -> None:
+    config = _tiny_config()
+    config["attention_implementation"] = "sdpa"
+    model = MossAudioTokenizerEncoder(
+        config,
+        parameter_device="cpu",
+        encoder_dtype=torch.float32,
+    )
+
+    attention = model.encoder[1].transformer.layers[0].self_attn
+    assert attention.attention_backend == "sdpa"
+
+
+def test_repository_vocoder_uses_configured_attention_implementation() -> None:
+    config = _tiny_config()
+    config["attention_implementation"] = "sdpa"
+    model = MossAudioTokenizerVocoder(
+        config,
+        parameter_device="cpu",
+        decoder_dtype=torch.float32,
+    )
+
+    attention = model.decoder[0].transformer.layers[0].self_attn
+    assert attention.attention_backend == "sdpa"
+
+
+@pytest.mark.parametrize(
+    ("attention_backend", "attention_implementation", "expected"),
+    [
+        ("auto", None, "auto"),
+        ("auto", "flash_attention_2", "auto"),
+        ("auto", "sdpa", "sdpa"),
+        ("packed_flash_attention", "sdpa", "packed_flash_attention"),
+    ],
+)
+def test_repository_attention_backend_selection(
+    attention_backend: str,
+    attention_implementation: str | None,
+    expected: str,
+) -> None:
+    assert (
+        resolve_moss_audio_attention_backend(
+            attention_backend,
+            attention_implementation,
+        )
+        == expected
+    )
+
+
+def test_repository_attention_backend_selection_rejects_unknown_implementation() -> (
+    None
+):
+    with pytest.raises(ValueError, match="attention_implementation"):
+        resolve_moss_audio_attention_backend("auto", "eager")
+
+
+def test_repository_encoder_loads_local_weights_without_remote_code(tmp_path) -> None:
+    config = _tiny_config()
+    expected_model = MossAudioTokenizerEncoder(
+        config,
+        parameter_device="cpu",
+        encoder_dtype=torch.float32,
+    ).eval()
+    with (tmp_path / "config.json").open("w", encoding="utf-8") as config_file:
+        json.dump(config, config_file)
+    save_file(
+        {
+            name: tensor.detach().cpu().contiguous()
+            for name, tensor in expected_model.state_dict().items()
+        },
+        tmp_path / "model.safetensors",
+    )
+
+    loaded = load_moss_audio_encoder(
+        str(tmp_path),
+        device="cpu",
+        encoder_dtype=torch.float32,
+    ).model
+
+    expected = expected_model.state_dict()
+    actual = loaded.state_dict()
+    assert actual.keys() == expected.keys()
+    for name in expected:
+        torch.testing.assert_close(actual[name], expected[name])
+
+
+def test_repository_encoder_strict_flash_fails_before_loading_weights(
+    tmp_path,
+) -> None:
+    with (tmp_path / "config.json").open("w", encoding="utf-8") as config_file:
+        json.dump(_tiny_config(), config_file)
+
+    with pytest.raises(
+        RuntimeError,
+        match="attention_backend='packed_flash_attention'.*is unavailable",
+    ):
+        load_moss_audio_encoder(
+            str(tmp_path),
+            device="cpu",
+            encoder_dtype=torch.bfloat16,
+            compute_dtype=torch.bfloat16,
+            attention_backend="packed_flash_attention",
+        )
+
+
+def test_repository_encoder_materializes_compute_dtype_at_load(tmp_path) -> None:
+    config = _tiny_config()
+    config["compute_dtype"] = "bfloat16"
+    config["encoder_kwargs"][1]["norm"] = "rms_norm_f32"
+    expected_model = MossAudioTokenizerEncoder(
+        config,
+        parameter_device="cpu",
+        encoder_dtype=torch.float32,
+        # note (Zhang Yiyang): Simulate the FP32 checkpoint representation. The
+        # loader below must materialize the encoder in the requested BF16
+        # compute dtype.
+        compute_dtype=torch.float32,
+    ).eval()
+    assert {parameter.dtype for parameter in expected_model.encoder.parameters()} == {
+        torch.float32
+    }
+    with (tmp_path / "config.json").open("w", encoding="utf-8") as config_file:
+        json.dump(config, config_file)
+    save_file(
+        {
+            name: tensor.detach().cpu().contiguous()
+            for name, tensor in expected_model.state_dict().items()
+        },
+        tmp_path / "model.safetensors",
+    )
+
+    loaded = load_moss_audio_encoder(
+        str(tmp_path),
+        device="cpu",
+        encoder_dtype=torch.float32,
+        compute_dtype=torch.bfloat16,
+    ).model
+
+    assert loaded.encoder_dtype is torch.bfloat16
+    assert loaded.encoder[1].input_proj.weight.dtype is torch.bfloat16
+    assert loaded.encoder[1].transformer.layers[0].norm1.alpha.dtype is torch.float32
+    assert {parameter.dtype for parameter in loaded.encoder.parameters()} == {
+        torch.bfloat16,
+        torch.float32,
+    }
+    assert {parameter.dtype for parameter in loaded.quantizer.parameters()} == {
+        torch.float32
+    }
+
+
+def test_repository_encoder_materialized_bfloat16_does_not_use_autocast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _tiny_config()
+    config["compute_dtype"] = "bfloat16"
+    model = MossAudioTokenizerEncoder(
+        config,
+        parameter_device="cpu",
+        encoder_dtype=torch.float32,
+        compute_dtype=torch.bfloat16,
+        attention_backend="sdpa",
+    ).eval()
+
+    original_autocast = torch.autocast
+
+    def reject_enabled_autocast(*args, **kwargs):
+        if kwargs.get("enabled", True):
+            raise AssertionError("materialized BF16 inference must not use autocast")
+        return original_autocast(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "autocast", reject_enabled_autocast)
+    output = model.batch_encode(
+        [torch.randn(1, 8), torch.randn(1, 6)],
+        num_quantizers=2,
+    )
+
+    assert output.audio_codes_lengths.tolist() == [4, 3]
+
+
+def test_repository_encoder_skips_missing_decoder_shard(tmp_path) -> None:
+    config = _tiny_config()
+    expected_model = MossAudioTokenizerEncoder(
+        config,
+        parameter_device="cpu",
+        encoder_dtype=torch.float32,
+        compute_dtype=torch.float32,
+    ).eval()
+    with (tmp_path / "config.json").open("w", encoding="utf-8") as config_file:
+        json.dump(config, config_file)
+    selected_weights = {
+        name: tensor.detach().cpu().contiguous()
+        for name, tensor in expected_model.state_dict().items()
+    }
+    selected_shard = "model-00001-of-00002.safetensors"
+    missing_decoder_shard = "model-00002-of-00002.safetensors"
+    save_file(selected_weights, tmp_path / selected_shard)
+    weight_map = {name: selected_shard for name in selected_weights}
+    weight_map["decoder.0.weight"] = missing_decoder_shard
+    with (tmp_path / "model.safetensors.index.json").open(
+        "w", encoding="utf-8"
+    ) as index_file:
+        json.dump({"metadata": {}, "weight_map": weight_map}, index_file)
+
+    loaded = load_moss_audio_encoder(
+        str(tmp_path),
+        device="cpu",
+        encoder_dtype=torch.float32,
+        compute_dtype=torch.float32,
+    ).model
+
+    assert isinstance(loaded.encoder, torch.nn.ModuleList)
+    assert not (tmp_path / missing_decoder_shard).exists()
+
+
+def test_repository_vocoder_loads_only_local_quantizer_and_decoder(
+    tmp_path,
+) -> None:
+    config = _tiny_config()
+    expected_model = MossAudioTokenizerVocoder(
+        config,
+        parameter_device="cpu",
+        decoder_dtype=torch.float32,
+        compute_dtype=torch.float32,
+    ).eval()
+    with (tmp_path / "config.json").open("w", encoding="utf-8") as config_file:
+        json.dump(config, config_file)
+    save_file(
+        {
+            f"quantizer.{name}": tensor.detach().cpu().contiguous()
+            for name, tensor in expected_model.quantizer.state_dict().items()
+        }
+        | {
+            f"decoder.{name}": tensor.detach().cpu().contiguous()
+            for name, tensor in expected_model.decoder.state_dict().items()
+        },
+        tmp_path / "model.safetensors",
+    )
+
+    loaded = load_moss_audio_vocoder(
+        str(tmp_path),
+        device="cpu",
+        decoder_dtype=torch.float32,
+        compute_dtype=torch.float32,
+    ).model
+
+    assert isinstance(loaded.decoder, MossAudioTokenizerVocoderDecoder)
+    expected_quantizer = expected_model.quantizer.state_dict()
+    actual_quantizer = loaded.quantizer.state_dict()
+    assert actual_quantizer.keys() == expected_quantizer.keys()
+    for name in expected_quantizer:
+        torch.testing.assert_close(actual_quantizer[name], expected_quantizer[name])
+    expected_decoder = expected_model.decoder.state_dict()
+    actual_decoder = loaded.decoder.state_dict()
+    assert actual_decoder.keys() == expected_decoder.keys()
+    for name in expected_decoder:
+        torch.testing.assert_close(actual_decoder[name], expected_decoder[name])
+
+
+def test_repository_vocoder_materializes_compute_dtype_at_load(tmp_path) -> None:
+    config = _tiny_config()
+    config["decoder_kwargs"][0]["norm"] = "rms_norm_f32"
+    expected_model = MossAudioTokenizerVocoder(
+        config,
+        parameter_device="cpu",
+        decoder_dtype=torch.float32,
+        # note (Zhang Yiyang): Simulate the FP32 checkpoint representation. The
+        # loader below must materialize the decoder in the requested BF16
+        # compute dtype.
+        compute_dtype=torch.float32,
+    ).eval()
+    assert {parameter.dtype for parameter in expected_model.decoder.parameters()} == {
+        torch.float32
+    }
+    with (tmp_path / "config.json").open("w", encoding="utf-8") as config_file:
+        json.dump(config, config_file)
+    save_file(
+        {
+            f"quantizer.{name}": tensor.detach().cpu().contiguous()
+            for name, tensor in expected_model.quantizer.state_dict().items()
+        }
+        | {
+            f"decoder.{name}": tensor.detach().cpu().contiguous()
+            for name, tensor in expected_model.decoder.state_dict().items()
+        },
+        tmp_path / "model.safetensors",
+    )
+
+    loaded = load_moss_audio_vocoder(
+        str(tmp_path),
+        device="cpu",
+        decoder_dtype=torch.float32,
+        compute_dtype=torch.bfloat16,
+    ).model
+
+    assert loaded.decoder_dtype is torch.bfloat16
+    assert {parameter.dtype for parameter in loaded.decoder.parameters()} == {
+        torch.bfloat16,
+        torch.float32,
+    }
+    assert loaded.decoder[0].transformer.layers[0].norm1.alpha.dtype is torch.float32
+    assert {parameter.dtype for parameter in loaded.quantizer.parameters()} == {
+        torch.float32
+    }
+
+
+def test_repository_vocoder_skips_missing_encoder_shard(tmp_path) -> None:
+    config = _tiny_config()
+    expected_model = MossAudioTokenizerVocoder(
+        config,
+        parameter_device="cpu",
+        decoder_dtype=torch.float32,
+        compute_dtype=torch.float32,
+    ).eval()
+    with (tmp_path / "config.json").open("w", encoding="utf-8") as config_file:
+        json.dump(config, config_file)
+    selected_weights = {
+        f"quantizer.{name}": tensor.detach().cpu().contiguous()
+        for name, tensor in expected_model.quantizer.state_dict().items()
+    } | {
+        f"decoder.{name}": tensor.detach().cpu().contiguous()
+        for name, tensor in expected_model.decoder.state_dict().items()
+    }
+    selected_shard = "model-00001-of-00002.safetensors"
+    missing_encoder_shard = "model-00002-of-00002.safetensors"
+    save_file(selected_weights, tmp_path / selected_shard)
+    weight_map = {name: selected_shard for name in selected_weights}
+    weight_map["encoder.0.weight"] = missing_encoder_shard
+    with (tmp_path / "model.safetensors.index.json").open(
+        "w", encoding="utf-8"
+    ) as index_file:
+        json.dump({"metadata": {}, "weight_map": weight_map}, index_file)
+
+    loaded = load_moss_audio_vocoder(
+        str(tmp_path),
+        device="cpu",
+        decoder_dtype=torch.float32,
+        compute_dtype=torch.float32,
+    ).model
+
+    assert isinstance(loaded.decoder, MossAudioTokenizerVocoderDecoder)
+    assert not (tmp_path / missing_encoder_shard).exists()
+
+
+def test_repository_vocoder_constructs_decoder_frame_rate_and_upsampling() -> None:
+    model = MossAudioTokenizerVocoder(
+        _tiny_config(),
+        parameter_device="cpu",
+        decoder_dtype=torch.float32,
+        compute_dtype=torch.float32,
+    )
+    transformer = model.decoder[0]
+    patch = model.decoder[1]
+
+    assert isinstance(transformer, MossAudioTokenizerProjectedTransformer)
+    assert transformer.transformer.layers[0].self_attn.context == 4
+    assert isinstance(patch, _PatchedPretransform)
+    assert not patch.is_downsample
+    values = torch.arange(8, dtype=torch.float32).reshape(1, 4, 2)
+    output, lengths = patch(values, torch.tensor([2]))
+    assert output.shape == (1, 2, 4)
+    assert lengths.tolist() == [4]
+
+
+def test_repository_vocoder_materialized_bfloat16_does_not_use_autocast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _tiny_config()
+    config["decoder_kwargs"] = [{"module_type": "PatchedPretransform", "patch_size": 2}]
+    model = MossAudioTokenizerVocoder(
+        config,
+        parameter_device="cpu",
+        decoder_dtype=torch.bfloat16,
+        compute_dtype=torch.bfloat16,
+    ).eval()
+    vocoder = MossAudioVocoder(model, device="cpu")
+
+    original_autocast = torch.autocast
+
+    def reject_enabled_autocast(*args, **kwargs):
+        if kwargs.get("enabled", True):
+            raise AssertionError("materialized BF16 inference must not use autocast")
+        return original_autocast(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "autocast", reject_enabled_autocast)
+    [audio] = vocoder.decode_codes(torch.zeros((2, 2), dtype=torch.long))
+
+    assert model.decoder_dtype is torch.bfloat16
+    assert model.compute_dtype is torch.bfloat16
+    assert audio.dtype is torch.float32
+
+
+def test_repository_quantizer_decode_matches_codebook_sum() -> None:
+    torch.manual_seed(0)
+    quantizer = _ResidualLFQ(_tiny_config()["quantizer_kwargs"], device="cpu")
+    codes = torch.randint(0, 4, (2, 3, 5))
+
+    expected = quantizer.output_proj(
+        quantizer.quantizers[0].decode_code(codes[0])
+        + quantizer.quantizers[1].decode_code(codes[1])
+    )
+
+    torch.testing.assert_close(quantizer.decode_codes(codes), expected)
+
+
+def test_repository_moss_audio_tokenizer_v1_vocoder_normalizes_checkpoint_fields(
+    tmp_path,
+) -> None:
+    config = _tiny_moss_audio_tokenizer_v1_config()
+    expected_model = MossAudioTokenizerVocoder(
+        config,
+        parameter_device="cpu",
+        decoder_dtype=torch.float32,
+        compute_dtype=torch.float32,
+    ).eval()
+    with (tmp_path / "config.json").open("w", encoding="utf-8") as config_file:
+        json.dump(config, config_file)
+    decoder_state = {
+        name.replace(".ffn.linear1.", ".linear1.")
+        .replace(".ffn.linear2.", ".linear2.")
+        .replace(".self_attn.in_proj.", ".self_attn.in_projs.0.")
+        .replace(".self_attn.out_proj.", ".self_attn.out_projs.0."): tensor
+        for name, tensor in expected_model.decoder.state_dict().items()
+    }
+    save_file(
+        {
+            f"quantizer.{name}": tensor.detach().cpu().contiguous()
+            for name, tensor in expected_model.quantizer.state_dict().items()
+        }
+        | {
+            f"decoder.{name}": tensor.detach().cpu().contiguous()
+            for name, tensor in decoder_state.items()
+        },
+        tmp_path / "model.safetensors",
+    )
+
+    loaded = load_moss_audio_vocoder(
+        str(tmp_path),
+        device="cpu",
+        decoder_dtype=torch.float32,
+        compute_dtype=torch.float32,
+    ).model
+
+    expected = expected_model.decoder.state_dict()
+    actual = loaded.decoder.state_dict()
+    assert actual.keys() == expected.keys()
+    for name in expected:
+        torch.testing.assert_close(actual[name], expected[name])
+
+
+def test_repository_encoder_normalizes_moss_audio_tokenizer_v1_checkpoint_fields() -> (
+    None
+):
+    model = MossAudioTokenizerEncoder(
+        _tiny_moss_audio_tokenizer_v1_config(),
+        parameter_device="cpu",
+        encoder_dtype=torch.float32,
+        compute_dtype=torch.bfloat16,
+    )
+    stage = model.encoder[1]
+    state_dict = stage.state_dict()
+
+    assert model._uses_moss_audio_tokenizer_v1_weights
+    assert model.compute_dtype is torch.bfloat16
+    assert list(state_dict) == [
+        "input_proj.weight",
+        "transformer.layers.0.norm1.weight",
+        "transformer.layers.0.norm1.bias",
+        "transformer.layers.0.self_attn.in_proj.weight",
+        "transformer.layers.0.self_attn.out_proj.weight",
+        "transformer.layers.0.layer_scale_1.scale",
+        "transformer.layers.0.norm2.weight",
+        "transformer.layers.0.norm2.bias",
+        "transformer.layers.0.ffn.linear1.weight",
+        "transformer.layers.0.ffn.linear2.weight",
+        "transformer.layers.0.layer_scale_2.scale",
+    ]
+    assert "transformer.layers.0.ffn.linear1.weight" in state_dict
+    assert "transformer.layers.0.self_attn.in_proj.weight" in state_dict
+
+    moss_audio_tokenizer_v1_state_dict = {
+        name.replace(".ffn.linear1.", ".linear1.")
+        .replace(".ffn.linear2.", ".linear2.")
+        .replace(".self_attn.in_proj.", ".self_attn.in_projs.0.")
+        .replace(".self_attn.out_proj.", ".self_attn.out_projs.0."): tensor
+        for name, tensor in state_dict.items()
+    }
+    normalized = _normalize_moss_audio_tokenizer_v1_transformer_state_dict(
+        moss_audio_tokenizer_v1_state_dict
+    )
+
+    assert normalized.keys() == state_dict.keys()
+
+
+@pytest.mark.parametrize(
+    ("encoder_dtype", "compute_dtype"),
+    [
+        (torch.float16, torch.bfloat16),
+        (torch.bfloat16, torch.float16),
+    ],
+)
+def test_repository_encoder_rejects_float16(
+    encoder_dtype: torch.dtype,
+    compute_dtype: torch.dtype,
+) -> None:
+    with pytest.raises(ValueError, match="dtype"):
+        MossAudioTokenizerEncoder(
+            _tiny_config(),
+            parameter_device="cpu",
+            encoder_dtype=encoder_dtype,
+            compute_dtype=compute_dtype,
+        )
+
+
+@pytest.mark.parametrize(
+    ("decoder_dtype", "compute_dtype"),
+    [
+        (torch.float16, torch.bfloat16),
+        (torch.bfloat16, torch.float16),
+    ],
+)
+def test_repository_vocoder_rejects_float16(
+    decoder_dtype: torch.dtype,
+    compute_dtype: torch.dtype,
+) -> None:
+    with pytest.raises(ValueError, match="dtype"):
+        MossAudioTokenizerVocoder(
+            _tiny_config(),
+            parameter_device="cpu",
+            decoder_dtype=decoder_dtype,
+            compute_dtype=compute_dtype,
+        )
+
+
+@pytest.mark.parametrize(
+    ("value", "allow_none", "expected"),
+    [
+        ("float32", False, torch.float32),
+        ("bfloat16", False, torch.bfloat16),
+        (torch.float32, False, torch.float32),
+        (torch.bfloat16, False, torch.bfloat16),
+        (None, True, None),
+    ],
+)
+def test_repository_encoder_resolves_configured_dtype(
+    value: str | torch.dtype | None,
+    allow_none: bool,
+    expected: torch.dtype | None,
+) -> None:
+    assert (
+        resolve_moss_audio_dtype(
+            value,
+            name="dtype",
+            allow_none=allow_none,
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize("value", ["float16", "fp16", torch.float16])
+def test_repository_encoder_dtype_resolver_rejects_float16(value) -> None:
+    with pytest.raises(ValueError, match="dtype"):
+        resolve_moss_audio_dtype(
+            value,
+            name="dtype",
+            allow_none=False,
+        )
+
+
+def test_shared_audio_encoder_uses_model_channel_contract() -> None:
+    class FakeModel:
+        config = type("Config", (), {"sampling_rate": 48000, "number_channels": 2})()
+
+        def __init__(self) -> None:
+            self.prepared = None
+
+        def batch_encode(self, waveforms, *, num_quantizers):
+            self.prepared = waveforms
+            return type(
+                "Output",
+                (),
+                {
+                    "audio_codes": torch.zeros(
+                        num_quantizers, len(waveforms), 4, dtype=torch.long
+                    ),
+                    "audio_codes_lengths": torch.full(
+                        (len(waveforms),), 4, dtype=torch.long
+                    ),
+                },
+            )()
+
+    model = FakeModel()
+    encoder = MossAudioEncoder(model, device="cpu")
+    encoder.encode_wavs([torch.ones(1, 4)], 48000, num_quantizers=2)
+
+    assert model.prepared is not None
+    assert model.prepared[0].shape == (2, 4)

--- a/tests/unit_test/moss_tts/test_encoder.py
+++ b/tests/unit_test/moss_tts/test_encoder.py
@@ -100,7 +100,6 @@ def test_repository_encoder_cpu_fallback_preserves_batch_lengths() -> None:
     model = MossAudioTokenizerEncoder(
         _tiny_config(),
         parameter_device="cpu",
-        encoder_dtype=torch.float32,
     ).eval()
 
     output = model.batch_encode(
@@ -117,11 +116,20 @@ def test_repository_encoder_cpu_fallback_preserves_batch_lengths() -> None:
     assert resolution.fallback_reason is not None
 
 
+def test_repository_encoder_defaults_missing_compute_dtype_to_bfloat16() -> None:
+    config = _tiny_config()
+    config.pop("compute_dtype")
+
+    model = MossAudioTokenizerEncoder(config, parameter_device="cpu")
+
+    assert model.encoder_dtype is torch.bfloat16
+    assert model.compute_dtype is torch.bfloat16
+
+
 def test_repository_encoder_uses_shared_packed_attention_wrapper() -> None:
     model = MossAudioTokenizerEncoder(
         _tiny_config(),
         parameter_device="cpu",
-        encoder_dtype=torch.float32,
     )
     stage = model.encoder[1]
 
@@ -136,7 +144,6 @@ def test_repository_encoder_uses_configured_attention_implementation() -> None:
     model = MossAudioTokenizerEncoder(
         config,
         parameter_device="cpu",
-        encoder_dtype=torch.float32,
     )
 
     attention = model.encoder[1].transformer.layers[0].self_attn
@@ -191,7 +198,6 @@ def test_repository_encoder_loads_local_weights_without_remote_code(tmp_path) ->
     expected_model = MossAudioTokenizerEncoder(
         config,
         parameter_device="cpu",
-        encoder_dtype=torch.float32,
     ).eval()
     with (tmp_path / "config.json").open("w", encoding="utf-8") as config_file:
         json.dump(config, config_file)
@@ -206,7 +212,6 @@ def test_repository_encoder_loads_local_weights_without_remote_code(tmp_path) ->
     loaded = load_moss_audio_encoder(
         str(tmp_path),
         device="cpu",
-        encoder_dtype=torch.float32,
     ).model
 
     expected = expected_model.state_dict()
@@ -229,7 +234,6 @@ def test_repository_encoder_strict_flash_fails_before_loading_weights(
         load_moss_audio_encoder(
             str(tmp_path),
             device="cpu",
-            encoder_dtype=torch.bfloat16,
             compute_dtype=torch.bfloat16,
             attention_backend="packed_flash_attention",
         )
@@ -242,7 +246,6 @@ def test_repository_encoder_materializes_compute_dtype_at_load(tmp_path) -> None
     expected_model = MossAudioTokenizerEncoder(
         config,
         parameter_device="cpu",
-        encoder_dtype=torch.float32,
         # note (Zhang Yiyang): Simulate the FP32 checkpoint representation. The
         # loader below must materialize the encoder in the requested BF16
         # compute dtype.
@@ -264,7 +267,6 @@ def test_repository_encoder_materializes_compute_dtype_at_load(tmp_path) -> None
     loaded = load_moss_audio_encoder(
         str(tmp_path),
         device="cpu",
-        encoder_dtype=torch.float32,
         compute_dtype=torch.bfloat16,
     ).model
 
@@ -288,7 +290,6 @@ def test_repository_encoder_materialized_bfloat16_does_not_use_autocast(
     model = MossAudioTokenizerEncoder(
         config,
         parameter_device="cpu",
-        encoder_dtype=torch.float32,
         compute_dtype=torch.bfloat16,
         attention_backend="sdpa",
     ).eval()
@@ -314,7 +315,6 @@ def test_repository_encoder_skips_missing_decoder_shard(tmp_path) -> None:
     expected_model = MossAudioTokenizerEncoder(
         config,
         parameter_device="cpu",
-        encoder_dtype=torch.float32,
         compute_dtype=torch.float32,
     ).eval()
     with (tmp_path / "config.json").open("w", encoding="utf-8") as config_file:
@@ -336,7 +336,6 @@ def test_repository_encoder_skips_missing_decoder_shard(tmp_path) -> None:
     loaded = load_moss_audio_encoder(
         str(tmp_path),
         device="cpu",
-        encoder_dtype=torch.float32,
         compute_dtype=torch.float32,
     ).model
 
@@ -585,7 +584,6 @@ def test_repository_encoder_normalizes_moss_audio_tokenizer_v1_checkpoint_fields
     model = MossAudioTokenizerEncoder(
         _tiny_moss_audio_tokenizer_v1_config(),
         parameter_device="cpu",
-        encoder_dtype=torch.float32,
         compute_dtype=torch.bfloat16,
     )
     stage = model.encoder[1]
@@ -624,21 +622,16 @@ def test_repository_encoder_normalizes_moss_audio_tokenizer_v1_checkpoint_fields
 
 
 @pytest.mark.parametrize(
-    ("encoder_dtype", "compute_dtype"),
-    [
-        (torch.float16, torch.bfloat16),
-        (torch.bfloat16, torch.float16),
-    ],
+    "compute_dtype",
+    [torch.float16],
 )
 def test_repository_encoder_rejects_float16(
-    encoder_dtype: torch.dtype,
     compute_dtype: torch.dtype,
 ) -> None:
     with pytest.raises(ValueError, match="dtype"):
         MossAudioTokenizerEncoder(
             _tiny_config(),
             parameter_device="cpu",
-            encoder_dtype=encoder_dtype,
             compute_dtype=compute_dtype,
         )
 

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -130,7 +130,6 @@ def test_moss_tts_config_and_registry_contracts() -> None:
     )
     vocoder = next(stage for stage in config.stages if stage.name == "vocoder")
     assert preprocessing.factory.model_dump(exclude_none=True) == {
-        "dtype": "float32",
         "compute_dtype": "bfloat16",
         "ref_audio_cache": True,
         "ref_audio_cache_max_items": 8192,
@@ -153,7 +152,6 @@ def test_moss_tts_production_config_resolves_codec_memory_policy() -> None:
     vocoder_args = resolve_stage_factory_args(stages["vocoder"], config, gpu_id=0)
 
     assert preprocessing_args == {
-        "dtype": "float32",
         "compute_dtype": "bfloat16",
         "ref_audio_cache": True,
         "ref_audio_cache_max_items": 8192,
@@ -181,7 +179,7 @@ def test_moss_tts_32gb_config_bounds_runtime_memory() -> None:
     vocoder_args = resolve_stage_factory_args(stages["vocoder"], config, gpu_id=0)
 
     assert preprocessing_args["device"] == "cpu"
-    assert preprocessing_args["dtype"] == "float32"
+    assert preprocessing_args["compute_dtype"] == "bfloat16"
     assert preprocessing_args["max_concurrency"] == 1
     assert tts_engine_args["dtype"] == "bfloat16"
     assert tts_engine_args["server_args_overrides"] == {
@@ -207,7 +205,7 @@ def test_moss_tts_24gb_config_bounds_runtime_memory() -> None:
     vocoder_args = resolve_stage_factory_args(stages["vocoder"], config, gpu_id=0)
 
     assert preprocessing_args["device"] == "cpu"
-    assert preprocessing_args["dtype"] == "float32"
+    assert preprocessing_args["compute_dtype"] == "bfloat16"
     assert preprocessing_args["max_concurrency"] == 1
     assert tts_engine_args["dtype"] == "bfloat16"
     assert tts_engine_args["server_args_overrides"] == {
@@ -228,7 +226,7 @@ def test_moss_tts_codec_runtime_overrides_take_precedence() -> None:
     config = ConfigManager(MossTTSPipelineConfig(model_path="model")).merge_config(
         [
             ("preprocessing.factory.device", "cuda:7"),
-            ("preprocessing.factory.dtype", "bfloat16"),
+            ("preprocessing.factory.compute_dtype", "bfloat16"),
             ("vocoder.factory.device", "cpu"),
             ("vocoder.factory.dtype", "float32"),
         ]
@@ -241,7 +239,7 @@ def test_moss_tts_codec_runtime_overrides_take_precedence() -> None:
     vocoder_args = resolve_stage_factory_args(stages["vocoder"], config, gpu_id=2)
 
     assert preprocessing_args["device"] == "cuda:7"
-    assert preprocessing_args["dtype"] == "bfloat16"
+    assert preprocessing_args["compute_dtype"] == "bfloat16"
     assert preprocessing_args["gpu_id"] == 2
     assert vocoder_args["device"] == "cpu"
     assert vocoder_args["dtype"] == "float32"
@@ -627,18 +625,17 @@ def test_moss_tts_preprocessing_loads_separate_codec(
         ),
     )
     encoder = SimpleNamespace()
-    loaded: list[tuple[str, str, torch.dtype, torch.dtype | None]] = []
+    loaded: list[tuple[str, str, torch.dtype | None]] = []
 
     def load_encoder(
         model_path,
         *,
         device,
-        encoder_dtype,
         compute_dtype,
         attention_backend,
     ):
         assert attention_backend == "sdpa"
-        loaded.append((model_path, device, encoder_dtype, compute_dtype))
+        loaded.append((model_path, device, compute_dtype))
         return encoder
 
     monkeypatch.setattr(stages, "_load_moss_processor", lambda model_path: processor)
@@ -661,7 +658,7 @@ def test_moss_tts_preprocessing_loads_separate_codec(
     finally:
         rb.clear_moss_tts_preprocessing_context()
 
-    assert loaded == [("codec-from-model-config", "cpu", torch.float32, torch.bfloat16)]
+    assert loaded == [("codec-from-model-config", "cpu", torch.bfloat16)]
 
 
 def test_moss_tts_preprocessing_uses_placement_gpu_id(
@@ -678,18 +675,17 @@ def test_moss_tts_preprocessing_uses_placement_gpu_id(
         ),
     )
     encoder = SimpleNamespace()
-    loaded: list[tuple[str, str, torch.dtype, torch.dtype | None]] = []
+    loaded: list[tuple[str, str, torch.dtype | None]] = []
 
     def load_encoder(
         model_path,
         *,
         device,
-        encoder_dtype,
         compute_dtype,
         attention_backend,
     ):
         assert attention_backend == "auto"
-        loaded.append((model_path, device, encoder_dtype, compute_dtype))
+        loaded.append((model_path, device, compute_dtype))
         return encoder
 
     monkeypatch.setattr(stages, "_load_moss_processor", lambda model_path: processor)
@@ -707,7 +703,7 @@ def test_moss_tts_preprocessing_uses_placement_gpu_id(
     finally:
         rb.clear_moss_tts_preprocessing_context()
 
-    assert loaded == [("codec", "cuda:2", torch.float32, torch.bfloat16)]
+    assert loaded == [("codec", "cuda:2", torch.bfloat16)]
 
 
 def test_moss_tts_pathlike_reference_uses_separate_codec() -> None:

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -131,6 +131,7 @@ def test_moss_tts_config_and_registry_contracts() -> None:
     vocoder = next(stage for stage in config.stages if stage.name == "vocoder")
     assert preprocessing.factory.model_dump(exclude_none=True) == {
         "dtype": "float32",
+        "compute_dtype": "bfloat16",
         "ref_audio_cache": True,
         "ref_audio_cache_max_items": 8192,
         "ref_audio_cache_max_bytes": 64 * 1024 * 1024,
@@ -153,6 +154,7 @@ def test_moss_tts_production_config_resolves_codec_memory_policy() -> None:
 
     assert preprocessing_args == {
         "dtype": "float32",
+        "compute_dtype": "bfloat16",
         "ref_audio_cache": True,
         "ref_audio_cache_max_items": 8192,
         "ref_audio_cache_max_bytes": 64 * 1024 * 1024,
@@ -537,7 +539,7 @@ def test_moss_tts_vocoder_uses_batch_base_path(monkeypatch: pytest.MonkeyPatch) 
         model_config = SimpleNamespace(audio_pad_code=1024, sampling_rate=16000)
         audio_tokenizer = None
 
-    class FakeAudioTokenizer:
+    class FakeAudioVocoder:
         sample_rate = 16000
 
         def decode_codes(self, segments):
@@ -552,8 +554,8 @@ def test_moss_tts_vocoder_uses_batch_base_path(monkeypatch: pytest.MonkeyPatch) 
     )
     monkeypatch.setattr(
         stages,
-        "load_moss_tts_audio_tokenizer",
-        lambda *args, **kwargs: FakeAudioTokenizer(),
+        "load_moss_audio_vocoder",
+        lambda *args, **kwargs: FakeAudioVocoder(),
     )
 
     scheduler = stages.create_vocoder_executor(
@@ -624,33 +626,42 @@ def test_moss_tts_preprocessing_loads_separate_codec(
             audio_tokenizer_name_or_path="codec-from-model-config",
         ),
     )
-    codec = SimpleNamespace()
-    loaded: list[tuple[str, str, str]] = []
+    encoder = SimpleNamespace()
+    loaded: list[tuple[str, str, torch.dtype, torch.dtype | None]] = []
 
-    def load_codec(model_path, *, device, dtype):
-        loaded.append((model_path, device, dtype))
-        return codec
+    def load_encoder(
+        model_path,
+        *,
+        device,
+        encoder_dtype,
+        compute_dtype,
+        attention_backend,
+    ):
+        assert attention_backend == "sdpa"
+        loaded.append((model_path, device, encoder_dtype, compute_dtype))
+        return encoder
 
     monkeypatch.setattr(stages, "_load_moss_processor", lambda model_path: processor)
-    monkeypatch.setattr(stages, "load_moss_tts_audio_tokenizer", load_codec)
+    monkeypatch.setattr(stages, "load_moss_audio_encoder", load_encoder)
 
     try:
         stages.create_preprocessing_executor(
             "model",
             device="cpu",
+            attention_backend="sdpa",
             ref_audio_cache=False,
         )
         context = rb._QUEUE.snapshot().context
         assert context is not None
         assert context.processor is processor
         assert context.processor.audio_tokenizer is None
-        assert context.reference_encoder._audio_tokenizer is codec
+        assert context.reference_encoder._audio_encoder is encoder
         assert context.reference_encoder._n_vq == 32
         assert isinstance(context.reference_encoder, stages._BatchedReferenceEncoder)
     finally:
         rb.clear_moss_tts_preprocessing_context()
 
-    assert loaded == [("codec-from-model-config", "cpu", "float32")]
+    assert loaded == [("codec-from-model-config", "cpu", torch.float32, torch.bfloat16)]
 
 
 def test_moss_tts_preprocessing_uses_placement_gpu_id(
@@ -666,15 +677,23 @@ def test_moss_tts_preprocessing_uses_placement_gpu_id(
             audio_tokenizer_name_or_path="codec",
         ),
     )
-    codec = SimpleNamespace()
-    loaded: list[tuple[str, str, str]] = []
+    encoder = SimpleNamespace()
+    loaded: list[tuple[str, str, torch.dtype, torch.dtype | None]] = []
 
-    def load_codec(model_path, *, device, dtype):
-        loaded.append((model_path, device, dtype))
-        return codec
+    def load_encoder(
+        model_path,
+        *,
+        device,
+        encoder_dtype,
+        compute_dtype,
+        attention_backend,
+    ):
+        assert attention_backend == "auto"
+        loaded.append((model_path, device, encoder_dtype, compute_dtype))
+        return encoder
 
     monkeypatch.setattr(stages, "_load_moss_processor", lambda model_path: processor)
-    monkeypatch.setattr(stages, "load_moss_tts_audio_tokenizer", load_codec)
+    monkeypatch.setattr(stages, "load_moss_audio_encoder", load_encoder)
 
     try:
         stages.create_preprocessing_executor(
@@ -688,7 +707,7 @@ def test_moss_tts_preprocessing_uses_placement_gpu_id(
     finally:
         rb.clear_moss_tts_preprocessing_context()
 
-    assert loaded == [("codec", "cuda:2", "float32")]
+    assert loaded == [("codec", "cuda:2", torch.float32, torch.bfloat16)]
 
 
 def test_moss_tts_pathlike_reference_uses_separate_codec() -> None:
@@ -726,9 +745,9 @@ def test_moss_tts_preprocessing_reference_cache_toggles(
             audio_tokenizer_name_or_path="codec",
         ),
     )
-    codec = SimpleNamespace(sample_rate=24000, device="cpu", model=None)
+    encoder = SimpleNamespace(sample_rate=24000, device="cpu", model=None)
     monkeypatch.setattr(stages, "_load_moss_processor", lambda model_path: processor)
-    monkeypatch.setattr(stages, "load_moss_tts_audio_tokenizer", lambda *a, **k: codec)
+    monkeypatch.setattr(stages, "load_moss_audio_encoder", lambda *a, **k: encoder)
 
     try:
         stages.create_preprocessing_executor(
@@ -832,190 +851,34 @@ def test_moss_tts_vocoder_honors_explicit_codec_path(
         audio_tokenizer=None,
         model_config=SimpleNamespace(audio_pad_code=1024, sampling_rate=24000),
     )
-    codec = SimpleNamespace(sample_rate=24000)
-    loaded: list[tuple[str, str, str]] = []
+    vocoder = SimpleNamespace(sample_rate=24000)
+    loaded: list[tuple[str, str, torch.dtype, torch.dtype | None]] = []
 
-    def load_codec(model_path, *, device, dtype):
-        loaded.append((model_path, device, dtype))
-        return codec
+    def load_vocoder(
+        model_path,
+        *,
+        device,
+        decoder_dtype,
+        compute_dtype,
+        attention_backend,
+    ):
+        assert attention_backend == "sdpa"
+        loaded.append((model_path, device, decoder_dtype, compute_dtype))
+        return vocoder
 
     monkeypatch.setattr(stages, "_load_moss_processor", lambda model_path: processor)
-    monkeypatch.setattr(stages, "load_moss_tts_audio_tokenizer", load_codec)
+    monkeypatch.setattr(stages, "load_moss_audio_vocoder", load_vocoder)
 
     stages.create_vocoder_executor(
         "model",
         device="cpu",
         gpu_id=2,
         codec_model_path="explicit-codec",
+        attention_backend="sdpa",
     )
 
     assert processor.audio_tokenizer is None
-    assert loaded == [("explicit-codec", "cpu", "float32")]
-
-
-def test_moss_tts_audio_tokenizer_preserves_processor_code_layout() -> None:
-    from sglang_omni.models.moss_tts.audio_tokenizer import MossTTSAudioTokenizer
-
-    class FakeCodec:
-        config = SimpleNamespace(sampling_rate=24000)
-
-        def __init__(self) -> None:
-            self.prepared: list[torch.Tensor] = []
-            self.decode_args = None
-
-        def batch_encode(self, waveforms, num_quantizers):
-            self.prepared = [wav.detach().clone() for wav in waveforms]
-            assert num_quantizers == 2
-            return SimpleNamespace(
-                audio_codes=torch.tensor(
-                    [
-                        [[1, 2, 3], [4, 5, 0]],
-                        [[6, 7, 8], [9, 10, 0]],
-                    ],
-                    dtype=torch.long,
-                ),
-                audio_codes_lengths=torch.tensor([3, 2]),
-            )
-
-        def decode(
-            self,
-            audio_codes,
-            *,
-            padding_mask,
-            return_dict,
-            chunk_duration,
-        ):
-            self.decode_args = (
-                audio_codes.detach().clone(),
-                padding_mask.detach().clone(),
-                return_dict,
-                chunk_duration,
-            )
-            return SimpleNamespace(
-                audio=torch.tensor(
-                    [
-                        [[0.1, 0.2, 0.3]],
-                        [[0.4, 0.5, 0.0]],
-                    ],
-                    dtype=torch.float32,
-                ),
-                audio_lengths=torch.tensor([3, 2]),
-            )
-
-    model = FakeCodec()
-    tokenizer = MossTTSAudioTokenizer(model, device="cpu")
-    encoded = tokenizer.encode_waveforms(
-        [
-            (torch.tensor([[0.1, 0.2], [0.3, 0.4]]), 24000),
-            (torch.tensor([0.2, 0.4]), 24000),
-        ],
-        num_quantizers=2,
-    )
-
-    assert [tuple(codes.shape) for codes in encoded] == [(3, 2), (2, 2)]
-    assert encoded[0].tolist() == [[1, 6], [2, 7], [3, 8]]
-    assert encoded[1].tolist() == [[4, 9], [5, 10]]
-    assert all(tuple(wav.shape) == (2,) for wav in model.prepared)
-
-    decoded = tokenizer.decode_codes(encoded)
-
-    assert [wav.tolist() for wav in decoded] == [
-        pytest.approx([0.1, 0.2, 0.3]),
-        pytest.approx([0.4, 0.5]),
-    ]
-    audio_codes, padding_mask, return_dict, chunk_duration = model.decode_args
-    assert tuple(audio_codes.shape) == (2, 2, 3)
-    assert padding_mask.tolist() == [[True, True, True], [True, True, False]]
-    assert return_dict is True
-    assert chunk_duration == 8
-
-
-@pytest.mark.parametrize(
-    ("device", "dtype", "expected"),
-    [
-        ("cuda:0", torch.bfloat16, [("cuda", torch.bfloat16)]),
-        ("cuda:0", torch.float16, [("cuda", torch.float16)]),
-        ("cuda:0", torch.float32, []),
-        ("cpu", torch.bfloat16, []),
-    ],
-)
-def test_moss_tts_audio_tokenizer_encode_autocast_matches_model_dtype(
-    monkeypatch: pytest.MonkeyPatch,
-    device: str,
-    dtype: torch.dtype,
-    expected: list[tuple[str, torch.dtype]],
-) -> None:
-    from sglang_omni.models.moss_tts import audio_tokenizer as audio_tokenizer_mod
-
-    class FakeCodec(torch.nn.Module):
-        config = SimpleNamespace(sampling_rate=24000)
-
-        def __init__(self) -> None:
-            super().__init__()
-            self.weight = torch.nn.Parameter(torch.empty(1, dtype=dtype))
-
-        def batch_encode(self, waveforms, num_quantizers):
-            return SimpleNamespace(
-                audio_codes=torch.ones(1, 1, 1, dtype=torch.long),
-                audio_codes_lengths=torch.ones(1, dtype=torch.long),
-            )
-
-    calls: list[tuple[str, torch.dtype]] = []
-
-    def fake_autocast(*, device_type: str, dtype: torch.dtype):
-        calls.append((device_type, dtype))
-        return nullcontext()
-
-    monkeypatch.setattr(audio_tokenizer_mod.torch, "autocast", fake_autocast)
-    tokenizer = audio_tokenizer_mod.MossTTSAudioTokenizer(FakeCodec(), device=device)
-    monkeypatch.setattr(
-        tokenizer,
-        "_prepare_waveform",
-        lambda wav, sample_rate: wav,
-    )
-
-    tokenizer.encode_waveforms([(torch.zeros(1), 24000)])
-
-    assert calls == expected
-
-
-@pytest.mark.parametrize(
-    ("device", "dtype", "expected"),
-    [
-        ("cuda:0", torch.bfloat16, [("cuda", torch.bfloat16)]),
-        ("cuda:0", torch.float16, [("cuda", torch.float16)]),
-        ("cuda:0", torch.float32, []),
-        ("cpu", torch.bfloat16, []),
-    ],
-)
-def test_moss_tts_audio_tokenizer_autocast_matches_model_dtype(
-    monkeypatch: pytest.MonkeyPatch,
-    device: str,
-    dtype: torch.dtype,
-    expected: list[tuple[str, torch.dtype]],
-) -> None:
-    from sglang_omni.models.moss_tts import audio_tokenizer as audio_tokenizer_mod
-
-    class FakeCodec(torch.nn.Module):
-        config = SimpleNamespace(sampling_rate=24000)
-
-        def __init__(self) -> None:
-            super().__init__()
-            self.weight = torch.nn.Parameter(torch.empty(1, dtype=dtype))
-
-    calls: list[tuple[str, torch.dtype]] = []
-
-    def fake_autocast(*, device_type: str, dtype: torch.dtype):
-        calls.append((device_type, dtype))
-        return nullcontext()
-
-    monkeypatch.setattr(audio_tokenizer_mod.torch, "autocast", fake_autocast)
-    tokenizer = audio_tokenizer_mod.MossTTSAudioTokenizer(FakeCodec(), device=device)
-
-    with tokenizer._autocast():
-        pass
-
-    assert calls == expected
+    assert loaded == [("explicit-codec", "cpu", torch.float32, torch.bfloat16)]
 
 
 def test_moss_tts_maps_references_token_count_and_checkpoint_defaults() -> None:

--- a/tests/unit_test/moss_tts/test_reference_encoding.py
+++ b/tests/unit_test/moss_tts/test_reference_encoding.py
@@ -591,7 +591,7 @@ def test_moss_tts_cached_reference_encoder_merges_inflight(tmp_path: Path) -> No
             device = "cuda:0"
             model = None
 
-        _audio_tokenizer = AudioTokenizer()
+        _audio_encoder = AudioTokenizer()
 
         @staticmethod
         def load(source):

--- a/tests/unit_test/moss_tts/test_vocoder.py
+++ b/tests/unit_test/moss_tts/test_vocoder.py
@@ -31,6 +31,10 @@ def _make_payload(request_id: str) -> StagePayload:
 
 
 class _AlwaysPackedVocoderDecoder(nn.Module):
+    @classmethod
+    def from_module(cls, source: nn.Module):
+        return cls(source)
+
     def __init__(self, source: nn.Module) -> None:
         super().__init__()
         self.stages = source
@@ -202,7 +206,7 @@ def test_moss_tts_vocoder_batches_mixed_length_segments_across_requests(
             return [torch.zeros(1) for _ in segments]
 
     codec = FakeCodec()
-    audio_tokenizer = FakeAudioTokenizer(codec)
+    audio_vocoder = FakeAudioTokenizer(codec)
     processor = SimpleNamespace(
         audio_tokenizer=None,
         model_config=SimpleNamespace(audio_pad_code=1024, sampling_rate=24000),
@@ -210,8 +214,8 @@ def test_moss_tts_vocoder_batches_mixed_length_segments_across_requests(
     monkeypatch.setattr(stages, "_load_moss_processor", lambda *args: processor)
     monkeypatch.setattr(
         stages,
-        "load_moss_tts_audio_tokenizer",
-        lambda *args, **kwargs: audio_tokenizer,
+        "load_moss_audio_vocoder",
+        lambda *args, **kwargs: audio_vocoder,
     )
     monkeypatch.setattr(
         vocoder_module,
@@ -247,7 +251,7 @@ def test_moss_tts_vocoder_batches_mixed_length_segments_across_requests(
     assert codec.quantizer.codebook.dtype is torch.float32
     assert codec.decoder[0].weight.dtype is torch.float32
     assert codec.decoder[0].autocast_enabled == [True]
-    assert audio_tokenizer.decode_calls == 0
+    assert audio_vocoder.decode_calls == 0
     assert np.frombuffer(
         results[0].data["audio_waveform"], dtype=np.float32
     ).tolist() == [1.0, 1.0, 1.0, 1.0]
@@ -293,15 +297,15 @@ def test_moss_tts_vocoder_uses_standalone_codec_without_packed_flash(
                 for _ in segments
             ]
 
-    audio_tokenizer = FakeAudioTokenizer()
+    audio_vocoder = FakeAudioTokenizer()
     processor = SimpleNamespace(
         model_config=SimpleNamespace(audio_pad_code=1024, sampling_rate=16000)
     )
     monkeypatch.setattr(stages, "_load_moss_processor", lambda *args: processor)
     monkeypatch.setattr(
         stages,
-        "load_moss_tts_audio_tokenizer",
-        lambda *args, **kwargs: audio_tokenizer,
+        "load_moss_audio_vocoder",
+        lambda *args, **kwargs: audio_vocoder,
     )
     monkeypatch.setattr(
         vocoder_module,
@@ -334,9 +338,9 @@ def test_moss_tts_vocoder_uses_standalone_codec_without_packed_flash(
     results = asyncio.run(scheduler._batch_fn(payloads))
 
     assert scheduler._vocoder._nonstream_decoder is None
-    assert audio_tokenizer.model.quantizer.codebook.dtype is torch.bfloat16
-    assert audio_tokenizer.decode_calls == 2
-    assert audio_tokenizer.decode_shapes == [[(2, 2)], [(2, 2)]]
+    assert audio_vocoder.model.quantizer.codebook.dtype is torch.bfloat16
+    assert audio_vocoder.decode_calls == 2
+    assert audio_vocoder.decode_shapes == [[(2, 2)], [(2, 2)]]
     assert np.frombuffer(
         results[0].data["audio_waveform"], dtype=np.float32
     ).tolist() == [1.0, 1.0]
@@ -363,11 +367,11 @@ def test_moss_tts_vocoder_autocasts_low_precision_standalone_codec() -> None:
             hidden = torch.ones((1, 1), dtype=torch.float32)
             return [self.model.decoder(hidden).flatten().float()]
 
-    audio_tokenizer = FakeAudioTokenizer()
+    audio_vocoder = FakeAudioTokenizer()
     processor = SimpleNamespace(
         model_config=SimpleNamespace(audio_pad_code=1024, sampling_rate=16000)
     )
-    vocoder = MossTTSVocoder(processor, audio_tokenizer, "cpu")
+    vocoder = MossTTSVocoder(processor, audio_vocoder, "cpu")
     state = MossTTSState()
     delayed_codes = torch.tensor(
         [[1, 1024], [2, 3], [1024, 4], [1024, 1024]],
@@ -376,7 +380,7 @@ def test_moss_tts_vocoder_autocasts_low_precision_standalone_codec() -> None:
 
     waveform, sample_rate = vocoder._decode_audio(state, delayed_codes)
 
-    assert audio_tokenizer.autocast_enabled == [True]
+    assert audio_vocoder.autocast_enabled == [True]
     assert waveform.dtype is torch.float32
     assert sample_rate == 16000
 
@@ -441,27 +445,30 @@ def test_moss_tts_vocoder_falls_back_after_packed_batch_failure(
                 for _ in segments
             ]
 
-    audio_tokenizer = FakeAudioTokenizer()
+    audio_vocoder = FakeAudioTokenizer()
     processor = SimpleNamespace(
         model_config=SimpleNamespace(audio_pad_code=1024, sampling_rate=16000)
     )
     monkeypatch.setattr(stages, "_load_moss_processor", lambda *args: processor)
     monkeypatch.setattr(
         stages,
-        "load_moss_tts_audio_tokenizer",
-        lambda *args, **kwargs: audio_tokenizer,
+        "load_moss_audio_vocoder",
+        lambda *args, **kwargs: audio_vocoder,
     )
     packed_decoders: list[FailingPackedDecoder] = []
 
-    def build_packed_decoder(source):
-        decoder = FailingPackedDecoder(source)
-        packed_decoders.append(decoder)
-        return decoder
+    class FailingPackedDecoderFactory:
+        @classmethod
+        def from_module(cls, source: nn.Module):
+            del cls
+            decoder = FailingPackedDecoder(source)
+            packed_decoders.append(decoder)
+            return decoder
 
     monkeypatch.setattr(
         vocoder_module,
         "MossAudioTokenizerVocoderDecoder",
-        build_packed_decoder,
+        FailingPackedDecoderFactory,
     )
 
     scheduler = stages.create_vocoder_executor(
@@ -498,7 +505,7 @@ def test_moss_tts_vocoder_falls_back_after_packed_batch_failure(
         scheduler._batch_fn([make_vocoder_payload("third", 8)])
     )
 
-    quantizer = audio_tokenizer.model.quantizer
+    quantizer = audio_vocoder.model.quantizer
     assert packed_decoders[0].calls == 1
     assert quantizer.calls == 1
     assert quantizer.autocast_enabled == [False]
@@ -506,8 +513,8 @@ def test_moss_tts_vocoder_falls_back_after_packed_batch_failure(
     assert released_markers == [True]
     assert scheduler._vocoder._nonstream_decoder is None
     assert scheduler._vocoder._quantizer_decoder is None
-    assert audio_tokenizer.decode_calls == 3
-    assert audio_tokenizer.decode_shapes == [[(2, 2)], [(2, 2)], [(2, 2)]]
+    assert audio_vocoder.decode_calls == 3
+    assert audio_vocoder.decode_shapes == [[(2, 2)], [(2, 2)], [(2, 2)]]
     assert np.frombuffer(
         first_results[0].data["audio_waveform"], dtype=np.float32
     ).tolist() == [1.0, 1.0]
@@ -528,7 +535,7 @@ def test_moss_tts_vocoder_can_disable_batched_decode(
 
     codec = nn.Module()
     codec.decoder = nn.ModuleList()
-    audio_tokenizer = SimpleNamespace(
+    audio_vocoder = SimpleNamespace(
         model=codec,
         sample_rate=16000,
         decode_codes=lambda segments: [torch.ones(2) for _ in segments],
@@ -539,8 +546,8 @@ def test_moss_tts_vocoder_can_disable_batched_decode(
     monkeypatch.setattr(stages, "_load_moss_processor", lambda *args: processor)
     monkeypatch.setattr(
         stages,
-        "load_moss_tts_audio_tokenizer",
-        lambda *args, **kwargs: audio_tokenizer,
+        "load_moss_audio_vocoder",
+        lambda *args, **kwargs: audio_vocoder,
     )
     monkeypatch.setattr(
         vocoder_module,

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -13,7 +13,10 @@ import torch
 from sglang_omni.client.audio import encode_audio, encode_wav
 from sglang_omni.config import StageConfig
 from sglang_omni.config.placement import build_stage_placement_plan
-from sglang_omni.models.moss_tts_local.audio_tokenizer import MossTTSLocalAudioTokenizer
+from sglang_omni.models.moss_tts_local.audio_tokenizer import (
+    MossTTSLocalAudioTokenizer,
+    MossTTSLocalAudioVocoder,
+)
 from sglang_omni.models.moss_tts_local.config import (
     MossTTSLocalColocatedPipelineConfig,
     MossTTSLocalPipelineConfig,
@@ -352,6 +355,16 @@ def test_audio_tokenizer_reference_encode_uses_processor_stereo_contract():
 
     scale = 10.0 ** (-3.0 / 20.0)
     torch.testing.assert_close(model.calls[0][0][0], mono.repeat(2, 1) * scale)
+
+
+def test_audio_tokenizer_wrappers_resolve_sample_rate_fallbacks():
+    model = types.SimpleNamespace(config=types.SimpleNamespace(sample_rate=24000))
+
+    tokenizer = MossTTSLocalAudioTokenizer(model, device="cpu")
+    vocoder = MossTTSLocalAudioVocoder(model, device="cpu")
+
+    assert tokenizer.sample_rate == 24000
+    assert vocoder.sample_rate == 24000
 
 
 def test_audio_tokenizer_loader_matches_processor_codec_compute_dtype(monkeypatch):

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -355,8 +355,6 @@ def test_audio_tokenizer_reference_encode_uses_processor_stereo_contract():
 
 
 def test_audio_tokenizer_loader_matches_processor_codec_weight_dtype(monkeypatch):
-    from contextlib import nullcontext
-
     from sglang_omni.models.moss_tts_local import audio_tokenizer as audio_tokenizer_mod
     from sglang_omni.models.moss_tts_local.audio_tokenizer import (
         load_moss_tts_local_audio_tokenizer,
@@ -365,48 +363,118 @@ def test_audio_tokenizer_loader_matches_processor_codec_weight_dtype(monkeypatch
     class _FakeLoadedCodec(_FakeAudioTokenizerModel):
         def __init__(self):
             super().__init__()
-            self.eval_called = False
-            self.to_device = None
+            self.encoder_dtype = torch.bfloat16
+            self.compute_dtype = torch.bfloat16
 
-        def eval(self):
-            self.eval_called = True
-            return self
-
-        def to(self, device):
-            self.to_device = device
-            return self
-
-    loaded_kwargs = {}
+    loaded_kwargs: dict[str, object] = {}
     loaded_model = _FakeLoadedCodec()
+
+    def fake_load_encoder(model_path, **kwargs):
+        loaded_kwargs["model_path"] = model_path
+        loaded_kwargs.update(kwargs)
+        return types.SimpleNamespace(model=loaded_model)
+
+    monkeypatch.setattr(
+        audio_tokenizer_mod, "load_moss_audio_encoder", fake_load_encoder
+    )
+
+    tokenizer = load_moss_tts_local_audio_tokenizer(
+        "codec",
+        device="cuda:7",
+        encoder_dtype=torch.float32,
+        compute_dtype=torch.bfloat16,
+        attention_backend="sdpa",
+    )
+
+    assert tokenizer.model is loaded_model
+    assert tokenizer._encoder.model is loaded_model
+    assert loaded_kwargs == {
+        "model_path": "codec",
+        "device": "cuda:7",
+        "encoder_dtype": torch.float32,
+        "compute_dtype": torch.bfloat16,
+        "attention_backend": "sdpa",
+    }
+
+
+def test_local_vocoder_loader_only_loads_decoder_and_quantizer(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from contextlib import nullcontext
+
+    from sglang_omni.models.moss_tts_local import audio_tokenizer as audio_tokenizer_mod
+
+    (tmp_path / "config.json").write_text(
+        '{"model_type": "moss-audio-tokenizer"}',
+        encoding="utf-8",
+    )
+    config = types.SimpleNamespace(
+        model_type="moss-audio-tokenizer",
+        sampling_rate=48000,
+        attention_implementation="flash_attention_2",
+        compute_dtype="bf16",
+    )
+
+    class _FakeCodec(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.config = config
+            self.sampling_rate = 48000
+            self.encoder = torch.nn.ModuleList([torch.nn.Linear(2, 2)])
+            self.decoder = torch.nn.ModuleList([torch.nn.Linear(2, 2)])
+            self.quantizer = torch.nn.ModuleList([torch.nn.Linear(2, 2)])
+
+    loaded_modules: list[tuple[str, torch.dtype, str]] = []
+    fake_codec = _FakeCodec()
+
+    class _FakeAutoConfig:
+        @staticmethod
+        def from_pretrained(model_path, **kwargs):
+            assert model_path == str(tmp_path)
+            assert kwargs == {"trust_remote_code": True}
+            return config
 
     class _FakeAutoModel:
         @staticmethod
-        def from_pretrained(model_path, **kwargs):
-            loaded_kwargs["model_path"] = model_path
-            loaded_kwargs.update(kwargs)
-            return loaded_model
+        def from_config(config, **kwargs):
+            assert config is config
+            assert kwargs == {"trust_remote_code": True}
+            return fake_codec
 
+    def fake_load_module(module, model_path, *, prefix, dtype, device, strict):
+        assert model_path == str(tmp_path)
+        assert strict is True
+        loaded_modules.append((prefix, dtype, str(device)))
+        return module
+
+    monkeypatch.setattr(audio_tokenizer_mod, "resolve_model_path", lambda _: tmp_path)
+    monkeypatch.setattr(audio_tokenizer_mod, "load_module", fake_load_module)
     monkeypatch.setattr(
-        audio_tokenizer_mod,
-        "moss_transformers_processor_compat",
-        nullcontext,
+        audio_tokenizer_mod, "moss_transformers_processor_compat", nullcontext
     )
     monkeypatch.setitem(
         sys.modules,
         "transformers",
-        types.SimpleNamespace(AutoModel=_FakeAutoModel),
+        types.SimpleNamespace(AutoConfig=_FakeAutoConfig, AutoModel=_FakeAutoModel),
     )
 
-    tokenizer = load_moss_tts_local_audio_tokenizer("codec", device="cuda:7")
+    loaded = audio_tokenizer_mod.load_moss_tts_local_audio_vocoder(
+        str(tmp_path),
+        device="cuda:3",
+        decoder_dtype=torch.float32,
+        compute_dtype=torch.bfloat16,
+        attention_backend="sdpa",
+    )
 
-    assert tokenizer.model is loaded_model
-    assert loaded_model.eval_called
-    assert loaded_model.to_device == "cuda:7"
-    assert loaded_kwargs == {
-        "model_path": "codec",
-        "trust_remote_code": True,
-        "codec_weight_dtype": "bf16",
-    }
+    assert loaded.model is fake_codec
+    assert len(fake_codec.encoder) == 0
+    assert loaded_modules == [
+        ("quantizer.", torch.float32, "cuda:3"),
+        ("decoder.", torch.bfloat16, "cuda:3"),
+    ]
+    assert fake_codec.config.attention_implementation == "sdpa"
+    assert fake_codec.compute_dtype is torch.bfloat16
 
 
 # Registry / config
@@ -1021,7 +1089,10 @@ def test_create_preprocessing_executor_uses_model_config_codec_path(monkeypatch)
     monkeypatch.setattr(
         stages,
         "load_moss_tts_local_audio_tokenizer",
-        fake_load_audio_tokenizer,
+        lambda model_path, **kwargs: fake_load_audio_tokenizer(
+            model_path,
+            device=kwargs["device"],
+        ),
     )
 
     stages.create_preprocessing_executor("model", device="cpu")

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -354,7 +354,7 @@ def test_audio_tokenizer_reference_encode_uses_processor_stereo_contract():
     torch.testing.assert_close(model.calls[0][0][0], mono.repeat(2, 1) * scale)
 
 
-def test_audio_tokenizer_loader_matches_processor_codec_weight_dtype(monkeypatch):
+def test_audio_tokenizer_loader_matches_processor_codec_compute_dtype(monkeypatch):
     from sglang_omni.models.moss_tts_local import audio_tokenizer as audio_tokenizer_mod
     from sglang_omni.models.moss_tts_local.audio_tokenizer import (
         load_moss_tts_local_audio_tokenizer,
@@ -381,7 +381,6 @@ def test_audio_tokenizer_loader_matches_processor_codec_weight_dtype(monkeypatch
     tokenizer = load_moss_tts_local_audio_tokenizer(
         "codec",
         device="cuda:7",
-        encoder_dtype=torch.float32,
         compute_dtype=torch.bfloat16,
         attention_backend="sdpa",
     )
@@ -391,7 +390,6 @@ def test_audio_tokenizer_loader_matches_processor_codec_weight_dtype(monkeypatch
     assert loaded_kwargs == {
         "model_path": "codec",
         "device": "cuda:7",
-        "encoder_dtype": torch.float32,
         "compute_dtype": torch.bfloat16,
         "attention_backend": "sdpa",
     }

--- a/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
+++ b/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
@@ -82,11 +82,17 @@ class FakeCodec(nn.Module):
         self.dummy = nn.Parameter(torch.zeros(1))
         self._streaming_state: _FakeStreamingState | None = None
         self.config = SimpleNamespace(sampling_rate=SAMPLE_RATE)
+        self.attention_implementation = "flash_attention_2"
+        self.attention_implementation_calls: list[str] = []
         self.decoder = nn.ModuleList([_FakeDecoderStage()])
         self.frame_calls = 0
         self.decode_calls = 0
         self.decode_chunk_durations: list[float | None] = []
         self.decode_decoders: list[nn.Module] = []
+
+    def set_attention_implementation(self, attention_implementation: str) -> None:
+        self.attention_implementation_calls.append(attention_implementation)
+        self.attention_implementation = attention_implementation
 
     @contextmanager
     def streaming(self, batch_size: int):
@@ -217,8 +223,8 @@ def _patch_vocoder_factory_loaders(
     )
     monkeypatch.setattr(
         stages,
-        "load_moss_tts_local_audio_tokenizer",
-        lambda model_path, *, device: SimpleNamespace(
+        "load_moss_tts_local_audio_vocoder",
+        lambda model_path, **kwargs: SimpleNamespace(
             model=codec,
             sample_rate=SAMPLE_RATE,
         ),
@@ -393,6 +399,38 @@ def test_default_session_preserves_batch_width_for_streaming_lanes(monkeypatch) 
     assert scheduler._stream_slots == 15
     assert session._offline_slots == 1
     assert session._batch_size == 16
+
+
+def test_streaming_session_forces_sdpa_and_restores_codec_backend() -> None:
+    codec = FakeCodec()
+    session = _CodecStreamSession(
+        codec,
+        stream_slots=2,
+        offline_slots=1,
+        n_vq=N_VQ,
+    )
+
+    assert codec.attention_implementation == "sdpa"
+    assert codec.attention_implementation_calls == ["sdpa"]
+
+    session.close()
+
+    assert codec.attention_implementation == "flash_attention_2"
+    assert codec.attention_implementation_calls == ["sdpa", "flash_attention_2"]
+
+
+def test_streaming_session_restores_backend_when_streaming_setup_fails() -> None:
+    class FailingCodec(FakeCodec):
+        def streaming(self, batch_size: int):
+            del batch_size
+            raise RuntimeError("streaming setup failed")
+
+    codec = FailingCodec()
+    with pytest.raises(RuntimeError, match="streaming setup failed"):
+        _CodecStreamSession(codec, stream_slots=1, offline_slots=1, n_vq=N_VQ)
+
+    assert codec.attention_implementation == "flash_attention_2"
+    assert codec.attention_implementation_calls == ["sdpa", "flash_attention_2"]
 
 
 def test_factory_default_decouples_first_chunk_from_join_floor(monkeypatch) -> None:
@@ -1460,7 +1498,7 @@ def test_create_vocoder_executor_uses_model_config_codec_path(monkeypatch) -> No
     codec = FakeCodec()
     loaded_codec_paths = []
 
-    def fake_load_audio_tokenizer(model_path, *, device):
+    def fake_load_audio_vocoder(model_path, **kwargs):
         loaded_codec_paths.append(model_path)
         return SimpleNamespace(model=codec, sample_rate=SAMPLE_RATE)
 
@@ -1471,8 +1509,8 @@ def test_create_vocoder_executor_uses_model_config_codec_path(monkeypatch) -> No
     )
     monkeypatch.setattr(
         stages,
-        "load_moss_tts_local_audio_tokenizer",
-        fake_load_audio_tokenizer,
+        "load_moss_tts_local_audio_vocoder",
+        fake_load_audio_vocoder,
     )
 
     stages.create_vocoder_executor("fake-model", device="cpu")
@@ -1487,6 +1525,10 @@ def test_pipeline_config_injects_cuda_graph_into_vocoder_factory_args() -> None:
     )
 
     cfg = MossTTSLocalPipelineConfig(model_path="x")
+    voc = cfg.stage_named("vocoder")
+    assert voc.factory.dtype == "float32"
+    assert voc.factory.compute_dtype == "bfloat16"
+    assert voc.factory.attention_backend == "auto"
     kwargs = cfg.stage_factory_kwargs("vocoder")
     assert kwargs["cuda_graph"] is True
     assert kwargs["cuda_graph_frames"] is None


### PR DESCRIPTION
## Motivation

MOSS-TTS Delay and MOSS-TTS Local use different parts of the same MOSS-Audio-Tokenizer checkpoint in each pipeline stage. Reference preprocessing needs the encoder and quantizer, while waveform generation needs the quantizer and decoder. The previous loading path materialized a complete codec in more than one stage, so every process paid for parameters that it never executed. That reduced the memory available to the autoregressive engine and its KV cache, and it also kept the v1 and v2 consumers on separate codec-loading paths.

This PR introduces one repository-owned MOSS-Audio-Tokenizer implementation and loads only the component prefixes required by the active stage. It keeps the decoder and streaming state behavior intact while making attention backend and dtype policy explicit. The goal is to reduce resident codec memory without changing generated audio or the consumer-facing pipeline contracts.

## Modifications

- Add repository-owned MOSS-Audio-Tokenizer encoder and vocoder implementations in `sglang_omni/models/moss_tts/audio_tokenizer.py`.
- Reuse the shared transformer, decoder, quantizer, RoPE, and attention wrappers for both the MOSS-Audio-Tokenizer v1 weight layout used by MOSS-TTS Delay and the v2 layout used by MOSS-TTS Local.
- Construct codec modules from configuration or source modules and normalize v1 weight names into the shared module layout.
- Load only `encoder.*` plus `quantizer.*` for reference preprocessing, and only `decoder.*` plus `quantizer.*` for vocoder stages, using prefix-aware weight loading instead of executing a complete remote-code codec.
- Materialize selected encoder/decoder parameters in the configured compute dtype at load time. Quantizer and explicitly FP32 parameters remain FP32; FP16 support is intentionally outside this PR.
- Thread explicit `auto`, `packed_flash_attention`, and `sdpa` backend policy through both MOSS-TTS consumers. Streaming codec sessions force SDPA because the persistent streaming FlashAttention path is not graph-safe/reliable; non-streaming decode retains the packed fast path and its SM-based tiling fallback.
- Give each consumer stage ownership of its encoder/vocoder lifecycle and close reference-encoder workers during pipeline cleanup.
- Update Local streaming and non-streaming vocoder construction to use the shared decoder loader, and extend unit tests and MOSS-TTS documentation for the new loading and dtype contracts.

## Related Issues

#1233 

## Accuracy Test

| Item | Value |
| --- | --- |
| Models | MOSS-TTS Delay v1.5; MOSS-TTS Local Transformer v1.5 |
| Dataset | SeedTTS EN full set, 1,088 samples per round |
| Concurrency | 16 |
| Seed | 42 |
| Hardware | NVIDIA H200 |
| Quality generation runs | 30 (5 base/modified rounds per affected path) |
| Quality requests | 32,640 |
| Quality completed / failed | 32,640 / 0 |

The quality campaign evaluated WER with Qwen3-ASR-1.7B, speaker similarity with WavLM-SV, UTMOS, and WAV integrity on the exact base and modified revisions. Every quality run evaluated 1,088/1,088 samples; all WAVs were finite, nonzero, 48 kHz audio.

The table below reports five-round means; each delta is the paired modified-minus-base mean.

| Model / mode | Base WER | Modified WER | WER delta | Base speaker similarity | Modified speaker similarity | Similarity delta | Base UTMOS | Modified UTMOS | UTMOS delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| MOSS-TTS Delay non-streaming | 2.108% | 2.408% | +0.300 pp | 68.992 | 69.099 | +0.107 | 3.9460 | 3.9441 | -0.0019 |
| MOSS-TTS Local non-streaming | 2.150% | 2.239% | +0.089 pp | 65.300 | 65.193 | -0.107 | 3.9644 | 3.9709 | +0.0065 |
| MOSS-TTS Local streaming | 1.949% | 2.110% | +0.161 pp | 65.171 | 65.182 | +0.011 | 3.9644 | 3.9722 | +0.0078 |

All three paths pass the paired quality gates: WER delta <= 0.3 percentage points, speaker-similarity delta >= -0.5, UTMOS delta >= -0.05, with complete generation and audio-integrity checks.

The following are five-round means from the same H200, concurrency-16 A/B.

### Throughput

| Model / mode | Base rounds (req/s) | Modified rounds (req/s) | Base mean | Modified mean | Delta |
| --- | --- | --- | ---: | ---: | ---: |
| Delay non-streaming | 8.929, 8.966, 8.988, 8.863, 8.958 | 9.139, 9.250, 9.154, 9.205, 9.118 | 8.9408 | 9.1732 | +2.60% |
| Local non-streaming | 11.885, 11.980, 11.687, 11.854, 12.011 | 14.541, 14.641, 14.535, 14.524, 14.574 | 11.8834 | 14.5630 | +22.55% |
| Local streaming | 6.709, 6.898, 6.830, 6.836, 6.691 | 8.269, 8.318, 8.416, 8.440, 8.449 | 6.7928 | 8.3784 | +23.34% |

Mean audio throughput improved by `+2.57%` for Delay, `+22.55%` for Local non-streaming, and `+23.34%` for Local streaming. Mean latency improved by `2.51%`, `18.40%`, and `18.94%`, respectively.

Mean RTF changed from `0.4115` to `0.4010` for Delay (`-2.56%`), from `0.3154` to `0.2523` for Local non-streaming (`-20.00%`), and from `0.5506` to `0.4393` for Local streaming (`-20.21%`).

### Streaming behavior

| Metric | Base mean | Modified mean | Delta |
| --- | ---: | ---: | ---: |
| TTFC (s) | 1.1101 | 0.5379 | -51.54% |
| Inter-chunk interval (s) | 0.1830 | 0.1734 | -5.26% |
| Max underrun (s) | 0.0126 | 0.0062 | -50.64% |
| C50 | 92.26% | 95.96% | +3.70 pp |
| C100 | 95.31% | 97.59% | +2.28 pp |
| C200 | 98.14% | 99.34% | +1.19 pp |

### Peak GPU memory

The selective loader releases codec allocation, but the serving process uses most of that headroom to enlarge the AR KV cache. Therefore the complete-service NVML peak reduction is smaller than the standalone codec reduction.

| Model / mode | Base mean (MiB) | Modified mean (MiB) | Delta (MiB) | Delta (GiB) |
| --- | ---: | ---: | ---: | ---: |
| Delay non-streaming | 139,123.0 | 133,169.8 | -5,953.2 | -5.81 |
| Local non-streaming | 129,547.0 | 126,561.4 | -2,985.6 | -2.92 |
| Local streaming | 128,852.6 | 125,841.4 | -3,011.2 | -2.94 |

### KV-cache accounting

SGLang's logged `GB` values use binary GiB (`1024^3` bytes). The KV allocation is stable across all five rounds of each path:

| Path | KV tokens base -> modified | K+V base -> modified | KV growth / equivalent memory |
| --- | ---: | ---: | ---: |
| Delay non-streaming | 750,038 -> 784,897 (+34,859) | 103.00 -> 107.78 GiB | +4.78 GiB; about +4.79 GiB from token scaling |
| Local non-streaming | 740,595 -> 755,827 (+15,232) | 101.70 -> 103.80 GiB | +2.10 GiB; about +2.09 GiB from token scaling |
| Local streaming | 740,595 -> 755,827 (+15,232) | 101.70 -> 103.80 GiB | +2.10 GiB; about +2.09 GiB from token scaling |

For Local, the vocoder process allocation decreases from `8.57 GiB` to `6.44 GiB` (`-2.13 GiB`). The AR process profile decreases from `13.42 GiB` to `11.33 GiB`, while `available_for_kv` increases from `101.71 GiB` to `103.80 GiB`; approximately `2.09 GiB` is consumed by the larger KV cache. For Delay, the pre-KV available memory increases from `114.90 GiB` to `120.16 GiB`, and approximately `4.79 GiB` becomes additional KV capacity.

### Profile attribution

An isolated CUDA ablation confirms that the reference encoder's packed FlashAttention path is the primary source of the Local throughput improvement. Load-time compute-dtype materialization removes additional cast/copy work. Streaming continues to use SDPA by design, while selective loading primarily improves codec residency and KV-cache capacity.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
