### PR TITLE
[Fix][Tests] Restore scheduler module stubs after config refactor

### DIFF
--- a/tests/unit_test/ming_omni/test_thinker.py
+++ b/tests/unit_test/ming_omni/test_thinker.py
@@ -282,7 +282,7 @@ def test_ming_config_and_stages_do_not_import_ming_runner() -> None:
 def _load_runner_with_fake_sglang(monkeypatch):
     torch = pytest.importorskip("torch")
 
-    scheduler_module = ModuleType("sglang.srt.managers.factory_path")
+    scheduler_module = ModuleType("sglang.srt.managers.scheduler")
 
     class GenerationBatchResult:
         def __init__(self, **kwargs):
@@ -296,7 +296,7 @@ def _load_runner_with_fake_sglang(monkeypatch):
     )
     monkeypatch.setitem(
         sys.modules,
-        "sglang.srt.managers.factory_path",
+        "sglang.srt.managers.scheduler",
         scheduler_module,
     )
 

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -54,8 +54,8 @@ from tests.unit_test.fakes import FakeExecutionBridge, FakeServerArgs
 
 def install_fake_sglang(monkeypatch: pytest.MonkeyPatch) -> None:
     try:
-        import sglang.srt.managers.factory_path  # noqa: F401
         import sglang.srt.managers.schedule_batch  # noqa: F401
+        import sglang.srt.managers.scheduler  # noqa: F401
         import sglang.srt.sampling.sampling_params  # noqa: F401
 
         return
@@ -141,8 +141,8 @@ def install_fake_sglang(monkeypatch: pytest.MonkeyPatch) -> None:
         "sglang.srt.managers.schedule_batch": types.ModuleType(
             "sglang.srt.managers.schedule_batch"
         ),
-        "sglang.srt.managers.factory_path": types.ModuleType(
-            "sglang.srt.managers.factory_path"
+        "sglang.srt.managers.scheduler": types.ModuleType(
+            "sglang.srt.managers.scheduler"
         ),
         "sglang.srt.layers": types.ModuleType("sglang.srt.layers"),
         "sglang.srt.layers.logits_processor": types.ModuleType(
@@ -181,7 +181,7 @@ def install_fake_sglang(monkeypatch: pytest.MonkeyPatch) -> None:
     modules["sglang.srt.managers"].schedule_batch = modules[
         "sglang.srt.managers.schedule_batch"
     ]
-    modules["sglang.srt.managers"].factory = modules["sglang.srt.managers.factory_path"]
+    modules["sglang.srt.managers"].scheduler = modules["sglang.srt.managers.scheduler"]
     modules["sglang.srt.layers"].logits_processor = modules[
         "sglang.srt.layers.logits_processor"
     ]
@@ -197,7 +197,7 @@ def install_fake_sglang(monkeypatch: pytest.MonkeyPatch) -> None:
     ]
     modules["sgl_kernel"].fused_qk_norm_rope = lambda *args, **kwargs: None
     modules["sglang.srt.managers.schedule_batch"].Req = FakeReq
-    modules["sglang.srt.managers.factory_path"].GenerationBatchResult = (
+    modules["sglang.srt.managers.scheduler"].GenerationBatchResult = (
         FakeGenerationBatchResult
     )
     modules["sglang.srt.layers.logits_processor"].LogitsProcessorOutput = (


### PR DESCRIPTION
## Summary

- restore Qwen3-TTS test helper probes and fake module registrations to `sglang.srt.managers.scheduler`
- restore the same scheduler stub pair in the Ming-Omni thinker tests
- keep the config refactor's legitimate `factory_path` fields unchanged

## Root cause

The configuration refactor in #1494 applied the stage-factory rename to unrelated
test-only SGLang module strings. `sglang.srt.managers.factory_path` is not a
module; production code in both paths still imports scheduler types from
`sglang.srt.managers.scheduler`.

For Qwen3-TTS, the failed probe selected incomplete fallback stubs, which then
caused existing model imports to fail at `ScheduleBatch`. Ming-Omni's fake
`GenerationBatchResult` module was registered under the same nonexistent path
and failed when the runner imported the real scheduler path.

## Validation

Before the fix:

```text
Qwen3-TTS: ImportError: cannot import name 'ScheduleBatch'
Ming-Omni: ModuleNotFoundError: No module named 'sglang.srt.managers.scheduler'
```

After restoring the Qwen3-TTS stubs:

```text
1 passed, 17 warnings
131 passed, 5 deselected, 17 warnings
```

For the added Ming-Omni pair, Python compilation, source consistency, and diff
checks pass locally. The approved upstream CI provides the full dependency
environment. No production runtime code is changed.

