### PR TITLE
[Apple] Add Qwen3-ASR MLX and Torch MPS paths

### DIFF
--- a/.github/scripts/verify_omni_installed_pins.py
+++ b/.github/scripts/verify_omni_installed_pins.py
@@ -3,26 +3,53 @@
 
 from __future__ import annotations
 
-import re
 import sys
 import tomllib
+from collections.abc import Mapping
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
-_EXACT_PIN = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)\s*==\s*([^,\s]+)")
+from packaging.markers import default_environment
+from packaging.requirements import Requirement
 
 
-def _exact_pins(pyproject_path: Path) -> dict[str, str]:
+def _exact_pins(
+    pyproject_path: Path,
+    environment: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Return exact pins whose PEP 508 markers match this interpreter.
+
+    A project can declare different exact versions for different platforms.
+    Parsing the complete requirement (rather than regexing the raw string)
+    avoids both treating the marker's semicolon as part of the version and
+    accidentally letting an inactive platform overwrite the active pin.
+    """
     data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    marker_environment = dict(default_environment())
+    if environment is not None:
+        marker_environment.update(environment)
+
     pins: dict[str, str] = {}
-    for spec in data.get("project", {}).get("dependencies", []):
-        match = _EXACT_PIN.match(spec.strip())
-        if match is not None:
-            pins[match.group(1).lower()] = match.group(2)
-    for spec in data.get("tool", {}).get("uv", {}).get("override-dependencies", []):
-        match = _EXACT_PIN.match(spec.strip())
-        if match is not None:
-            pins[match.group(1).lower()] = match.group(2)
+    project_requirements = data.get("project", {}).get("dependencies", [])
+    override_requirements = (
+        data.get("tool", {}).get("uv", {}).get("override-dependencies", [])
+    )
+    # Keep uv's existing precedence: an active override intentionally wins over
+    # the corresponding project dependency.
+    for raw_spec in [*project_requirements, *override_requirements]:
+        requirement = Requirement(raw_spec.strip())
+        if requirement.marker is not None and not requirement.marker.evaluate(
+            marker_environment
+        ):
+            continue
+        exact_versions = [
+            specifier.version
+            for specifier in requirement.specifier
+            if specifier.operator == "==" and not specifier.version.endswith(".*")
+        ]
+        if len(exact_versions) != 1:
+            continue
+        pins[requirement.name.lower()] = exact_versions[0]
     return pins
 
 

--- a/README.md
+++ b/README.md
@@ -57,12 +57,14 @@ SGLang-Omni is a multi-stage serving runtime for omni, speech, and TTS models. I
 | Backend | Status | Notes |
 |---------|--------|-------|
 | **NVIDIA CUDA** | Supported | Default backend with full model coverage. |
+| **Apple Silicon** | Experimental | Qwen3-ASR runs through native MLX or Torch MPS on macOS arm64. Install with [`install.sh`](./install.sh) and follow the [Qwen3-ASR guide](./docs/cookbook/qwen3_asr.md#apple-silicon-mlx). |
 | **Intel GPU (XPU)** | Experimental | Intel Arc GPUs via PyTorch XPU. **Qwen3-ASR, Qwen3-TTS, and Qwen3-Omni serve end-to-end** (Omni thinker via multi-XPU tensor parallelism). Install per [Intel XPU guide](./docs/get_started/installation_xpu.md); the backend is auto-detected. |
 
 Additional model guides, including experimental and research-oriented paths, are available in the [Cookbook](https://sgl-project.github.io/sglang-omni/cookbook/).
 
 ## Quick Start
 
+- **macOS Apple Silicon:** from a checkout, run [`./install.sh`](./install.sh) for a one-command Homebrew + uv setup. See [installation](./docs/get_started/installation.md#macos-apple-silicon).
 - [Installation](https://sgl-project.github.io/sglang-omni/get_started/installation.html)
 - [TTS usage](https://sgl-project.github.io/sglang-omni/basic_usage/tts.html)
 - [Qwen3-Omni usage](https://sgl-project.github.io/sglang-omni/basic_usage/qwen3_omni.html)

--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -13,6 +13,87 @@ MODEL_REVISION=7278e1e70fe206f11671096ffdd38061171dd6e5
 MODEL_PATH=$(hf download Qwen/Qwen3-ASR-1.7B --revision "${MODEL_REVISION}")
 ```
 
+### Apple Silicon (MLX)
+
+The Apple Silicon path requires macOS, Python 3.12, Homebrew, and SGLang's MLX
+runtime. Audio decoding also requires Homebrew's versioned FFmpeg 7 formula:
+
+```bash
+brew install ffmpeg@7
+export DYLD_LIBRARY_PATH="$(brew --prefix ffmpeg@7)/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+```
+
+Do not replace `ffmpeg@7` with the unversioned `ffmpeg` formula. The latter
+currently installs FFmpeg 9, while the pinned `torchcodec==0.11.1` supports
+FFmpeg 4 through 8. Because `ffmpeg@7` is keg-only, its library directory must
+also be present in `DYLD_LIBRARY_PATH` whenever the server starts.
+
+Create one virtual environment for both repositories, then install the pinned
+SGLang tag from source with its `all_mps` dependencies before installing
+SGLang-Omni:
+
+```bash
+git clone --branch v0.5.16 https://github.com/sgl-project/sglang.git
+git clone https://github.com/sgl-project/sglang-omni.git
+
+uv venv -p 3.12 sglang-omni/.venv-apple
+source sglang-omni/.venv-apple/bin/activate
+
+cd sglang
+cp python/pyproject_other.toml python/pyproject.toml
+uv pip install -e "python[all_mps]"
+
+cd ../sglang-omni
+uv pip install -e .
+```
+
+This installs MLX through SGLang. It does not install or use the `mlx-audio`
+package. Before downloading a model, verify both Metal and FFmpeg loading:
+
+```bash
+SGLANG_USE_MLX=1 python - <<'PY'
+import mlx.core as mx
+from torchcodec.decoders import AudioDecoder
+
+assert mx.metal.is_available()
+print("MLX Metal and TorchCodec FFmpeg loading are available")
+PY
+```
+
+Use an MLX-converted Qwen3-ASR checkpoint and opt into the MLX runner:
+
+```bash
+export SGLANG_USE_MLX=1
+export DYLD_LIBRARY_PATH="$(brew --prefix ffmpeg@7)/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+
+sgl-omni serve \
+  --model-path mlx-community/Qwen3-ASR-0.6B-4bit \
+  --model-name Qwen/Qwen3-ASR-0.6B \
+  --max-running-requests 1 \
+  --port 8000
+```
+
+The MLX path currently supports one device (`tp_size=1`) and greedy decoding.
+Radix caching, chunked prefill, and CUDA graphs are not used by this path. The
+HTTP and SSE transcription interfaces below are the same as on CUDA;
+`stream=true` provides pseudo-streaming transcript deltas as tokens are decoded.
+
+To use the Torch MPS compatibility path instead, leave `SGLANG_USE_MLX` unset
+and pass an official PyTorch Qwen3-ASR checkpoint. It currently uses one device,
+greedy decoding, and the eager `torch_native`/`sdpa` profile:
+
+```bash
+unset SGLANG_USE_MLX
+sgl-omni serve \
+  --model-path Qwen/Qwen3-ASR-0.6B \
+  --model-name Qwen/Qwen3-ASR-0.6B \
+  --max-running-requests 1 \
+  --port 8000
+```
+
+The initial Torch MPS profile is bounded to a 2,048-token KV budget and is
+intended for short clips; use the MLX path for the larger native context limit.
+
 ## Server Configuration
 
 Qwen3-ASR runs a single ASR stage on one GPU. Its default `auto` dtype follows

--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -69,7 +69,7 @@ export DYLD_LIBRARY_PATH="$(brew --prefix ffmpeg@7)/lib${DYLD_LIBRARY_PATH:+:$DY
 sgl-omni serve \
   --model-path mlx-community/Qwen3-ASR-0.6B-4bit \
   --model-name Qwen/Qwen3-ASR-0.6B \
-  --max-running-requests 1 \
+  --asr.engine.max_running_requests 1 \
   --port 8000
 ```
 
@@ -87,7 +87,7 @@ unset SGLANG_USE_MLX
 sgl-omni serve \
   --model-path Qwen/Qwen3-ASR-0.6B \
   --model-name Qwen/Qwen3-ASR-0.6B \
-  --max-running-requests 1 \
+  --asr.engine.max_running_requests 1 \
   --port 8000
 ```
 

--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -77,7 +77,9 @@ The MLX path currently supports one device (`tp_size=1`) and greedy decoding.
 Radix caching, chunked prefill, and CUDA graphs are not used by this path. The
 HTTP and SSE transcription interfaces below are the same as on CUDA;
 `stream=true` provides pseudo-streaming transcript deltas as tokens are decoded.
-The Apple paths do not provide sampling penalties or token logprobs yet.
+The Apple paths do not provide sampling penalties or token logprobs yet. MLX
+can batch multiple requests, but `max_running_requests=1` is recommended when
+single-request latency matters; increase it only when throughput is preferred.
 
 To use the Torch MPS compatibility path instead, leave `SGLANG_USE_MLX` unset
 and pass an official PyTorch Qwen3-ASR checkpoint. It currently uses one device,
@@ -92,8 +94,9 @@ sgl-omni serve \
   --port 8000
 ```
 
-The initial Torch MPS profile is bounded to a 2,048-token KV budget and is
-intended for short clips; use the MLX path for the larger native context limit.
+The initial Torch MPS profile is bounded to a 2,048-token KV budget and accepts
+audio up to 60 seconds. Use the MLX path for long audio and the larger native
+context limit.
 
 ## Server Configuration
 

--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -24,16 +24,16 @@ export DYLD_LIBRARY_PATH="$(brew --prefix ffmpeg@7)/lib${DYLD_LIBRARY_PATH:+:$DY
 ```
 
 Do not replace `ffmpeg@7` with the unversioned `ffmpeg` formula. The latter
-currently installs FFmpeg 9, while the pinned `torchcodec==0.11.1` supports
-FFmpeg 4 through 8. Because `ffmpeg@7` is keg-only, its library directory must
-also be present in `DYLD_LIBRARY_PATH` whenever the server starts.
+currently installs FFmpeg 9, while Apple installs `torchcodec==0.11.1`, which
+supports FFmpeg 4 through 8. Because `ffmpeg@7` is keg-only, its library
+directory must also be present in `DYLD_LIBRARY_PATH` whenever the server starts.
 
 Create one virtual environment for both repositories, then install the pinned
 SGLang tag from source with its `all_mps` dependencies before installing
 SGLang-Omni:
 
 ```bash
-git clone --branch v0.5.16 https://github.com/sgl-project/sglang.git
+git clone --branch v0.5.18 https://github.com/sgl-project/sglang.git
 git clone https://github.com/sgl-project/sglang-omni.git
 
 uv venv -p 3.12 sglang-omni/.venv-apple
@@ -77,6 +77,7 @@ The MLX path currently supports one device (`tp_size=1`) and greedy decoding.
 Radix caching, chunked prefill, and CUDA graphs are not used by this path. The
 HTTP and SSE transcription interfaces below are the same as on CUDA;
 `stream=true` provides pseudo-streaming transcript deltas as tokens are decoded.
+The Apple paths do not provide sampling penalties or token logprobs yet.
 
 To use the Torch MPS compatibility path instead, leave `SGLANG_USE_MLX` unset
 and pass an official PyTorch Qwen3-ASR checkpoint. It currently uses one device,
@@ -98,11 +99,12 @@ intended for short clips; use the MLX path for the larger native context limit.
 
 Qwen3-ASR runs a single ASR stage on one GPU. Its default `auto` dtype follows
 the checkpoint configuration (BF16 for Qwen3-ASR-1.7B); pass
-`--stages.asr.factory-args.dtype float16` to force FP16.
+`--asr.factory.dtype float16` to force FP16.
 Async decode is enabled by default for all decode batch sizes, allowing the
 shared one-step-lookahead path to overlap host-side result processing with the
-next GPU decode forward even for a single request. Use `--asr.factory.enable_async_decode false` to
-disable it, or tune the crossover with `--asr.factory.async_decode_min_batch_size`.
+next GPU decode forward even for a single request. Use
+`--asr.factory.enable_async_decode false` to disable it, or tune the crossover
+with `--asr.factory.async_decode_min_batch_size`.
 The request builders also use the shared LM prefill-admission gate: prefill
 starts when 16 built requests are ready or after the oldest ready request waits
 40 ms. Once request-build work drains, a ready prefill is released immediately

--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -28,6 +28,12 @@ currently installs FFmpeg 9, while Apple installs `torchcodec==0.11.1`, which
 supports FFmpeg 4 through 8. Because `ffmpeg@7` is keg-only, its library
 directory must also be present in `DYLD_LIBRARY_PATH` whenever the server starts.
 
+macOS may remove `DYLD_*` variables when a SIP-protected system executable
+launches the server. Set `DYLD_LIBRARY_PATH` on the final `sgl-omni` process;
+for example, place `/usr/bin/env DYLD_LIBRARY_PATH=...` after wrappers such as
+`/usr/bin/time`. Test a compressed input such as M4A or MP3, since WAV decoding
+can succeed without loading FFmpeg.
+
 Create one virtual environment for both repositories, then install the pinned
 SGLang tag from source with its `all_mps` dependencies before installing
 SGLang-Omni:

--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -100,9 +100,11 @@ sgl-omni serve \
   --port 8000
 ```
 
-The initial Torch MPS profile is bounded to a 2,048-token KV budget and accepts
-audio up to 60 seconds. Use the MLX path for long audio and the larger native
-context limit.
+The initial Torch MPS profile is bounded to a 2,048-token KV budget, uses
+`audio_chunking.max_audio_clip_s` for non-streaming chunks (30 seconds by
+default), and caps native/whole-upload requests at 60 seconds. Values above
+that qualified limit are rejected. Use the MLX path for long audio and the
+larger native context limit.
 
 ## Server Configuration
 
@@ -264,7 +266,7 @@ configuration path reaches them:
 | Name | Value | Meaning |
 |---|---|---|
 | `allow_audio_chunking` | `true` | Qwen3-ASR transcribes an isolated chunk correctly, so chunking is on. |
-| `max_native_clip_s` | `1200` | Longest clip the model takes as one request (its native limit). Streaming cannot chunk, so this is the streaming cutoff. |
+| `max_native_clip_s` | `1200` | Longest clip the model takes as one request (its native limit). Streaming cannot chunk, so this is the streaming cutoff; the Torch MPS compatibility path resolves it to its qualified 60-second cap. |
 | `min_tail_s` | `0.5` | Shortest final chunk worth transcribing; if the tail would be shorter, we move the previous cut earlier to absorb it. This matches the model's own minimum input length. |
 
 Note: Raising `audio_chunking.max_audio_clip_s` also resizes the encoder CUDA-graph bucket
@@ -281,9 +283,10 @@ Behavior notes:
 - A few unusual audio formats may not expose a readable duration; we fall
   back to the non-chunked path for those uploads.
 - Streamed responses (`stream=true`) do not support chunking yet; a stream
-  request runs as one engine request, so it takes audio up to
-  `max_native_clip_s` (1,200s) and gets HTTP 400 above that -- use
-  `stream=false` for longer uploads.
+  request runs as one engine request. MLX and CUDA accept audio up to the
+  model-native `max_native_clip_s` (1,200s), while Torch MPS accepts up to its
+  qualified 60-second cap and returns HTTP 400 above that -- use `stream=false`
+  for longer uploads.
 
 ## Benchmarking
 
@@ -384,6 +387,7 @@ sgl-omni serve --model-path Qwen/Qwen3-ASR-1.7B \
 - The endpoint accepts one uploaded file per request.
 - Non-streaming uploads up to `max_total_audio_s` (default one hour) are
   transcribed in full via chunking; see Long Audio above. Streaming requests
-  are limited to `max_native_clip_s` (1,200s).
+  are limited to `max_native_clip_s` (1,200s) on MLX/CUDA; Torch MPS caps both
+  native and whole-upload requests at 60 seconds.
 - `prompt` is accepted by the HTTP endpoint for OpenAI compatibility, but Qwen3-ASR currently ignores it.
 - Audio is resampled to 16 kHz before transcription.

--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -62,7 +62,7 @@ source .venv-apple/bin/activate
 
 The script is idempotent and creates (or reuses) `.venv-apple`, installs the
 Homebrew formulae `ffmpeg@7` and `uv` (and `git` only when a working git is not
-already available), installs SGLang `v0.5.16` from source with its `all_mps`
+already available), installs SGLang `v0.5.18` from source with its `all_mps`
 extra, and installs this checkout with `uv pip`. SGLang's optional Rust
 extensions are not needed by this Apple Silicon path and are skipped.
 `ffmpeg@7` is intentional: `torchcodec==0.11.1` does not support the current
@@ -79,7 +79,7 @@ Homebrew's bootstrapper. Use `--non-interactive` (or `NONINTERACTIVE=1`) to
 disable Homebrew auto-update in CI, `SGLANG_OMNI_VENV=/path/to/venv` to choose a virtualenv, and
 `SGLANG_OMNI_EXTRAS=audar-tts,fun-cosyvoice3` to enable optional extras.
 The persistent SGLang source checkout defaults to
-`~/.cache/sglang-omni/sglang-v0.5.16` and can be changed with
+`~/.cache/sglang-omni/sglang-v0.5.18` and can be changed with
 `SGLANG_SOURCE_DIR`. Slow or proxied networks can override the installer's uv
 defaults with `UV_HTTP_TIMEOUT` and `UV_HTTP_RETRIES`.
 

--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -2,9 +2,11 @@
 
 Current stable release: **v0.1.3** on [PyPI](https://pypi.org/project/sglang-omni/).
 
-Two install paths. Docker is recommended — UCX, flash-attn, sglang, and CUDA are prebuilt.
+Choose the path for your platform. Docker is recommended for NVIDIA CUDA —
+UCX, flash-attn, SGLang, and CUDA are prebuilt. Apple Silicon has a dedicated
+source installer below.
 
-> **Intel GPU (XPU)?** This page targets **NVIDIA CUDA**. For Intel Arc GPUs, see [Installation — Intel XPU](./installation_xpu.md), which uses [`pyproject_xpu.toml`](../../pyproject_xpu.toml) + the PyTorch XPU wheel index instead of the CUDA-only pins below.
+> **Intel GPU (XPU)?** For Intel Arc GPUs, see [Installation — Intel XPU](./installation_xpu.md), which uses [`pyproject_xpu.toml`](../../pyproject_xpu.toml) + the PyTorch XPU wheel index instead of the CUDA-only pins below.
 
 > **Ascend NPU?** See [Installation — Ascend NPU](./installation_npu.md) for the supported software stack, prerequisites, and installation helper.
 
@@ -47,7 +49,75 @@ source .venv/bin/activate
 uv pip install --prerelease=allow "sglang-omni==0.1.3"
 ```
 
-## 🛠️ Option B: Manual install
+<a id="macos-apple-silicon"></a>
+
+## 🍎 Option B: macOS Apple Silicon installer
+
+From a checkout of this branch, run:
+
+```bash
+./install.sh
+source .venv-apple/bin/activate
+```
+
+The script is idempotent and creates (or reuses) `.venv-apple`, installs the
+Homebrew formulae `ffmpeg@7` and `uv` (and `git` only when a working git is not
+already available), installs SGLang `v0.5.16` from source with its `all_mps`
+extra, and installs this checkout with `uv pip`. SGLang's optional Rust
+extensions are not needed by this Apple Silicon path and are skipped.
+`ffmpeg@7` is intentional: `torchcodec==0.11.1` does not support the current
+unversioned FFmpeg 9 formula. At runtime, expose its libraries:
+
+```bash
+export DYLD_LIBRARY_PATH="$(brew --prefix ffmpeg@7)/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+```
+
+Homebrew must be installed before running the script. If `brew` is missing, the
+script prints an error and exits; install it yourself from
+[brew.sh](https://brew.sh), then rerun. The installer never invokes `sudo` or
+Homebrew's bootstrapper. Use `--non-interactive` (or `NONINTERACTIVE=1`) to
+disable Homebrew auto-update in CI, `SGLANG_OMNI_VENV=/path/to/venv` to choose a virtualenv, and
+`SGLANG_OMNI_EXTRAS=audar-tts,fun-cosyvoice3` to enable optional extras.
+The persistent SGLang source checkout defaults to
+`~/.cache/sglang-omni/sglang-v0.5.16` and can be changed with
+`SGLANG_SOURCE_DIR`. Slow or proxied networks can override the installer's uv
+defaults with `UV_HTTP_TIMEOUT` and `UV_HTTP_RETRIES`.
+
+This path currently supports macOS `arm64` only and is intended for the
+Apple-Silicon Qwen3-ASR MLX/Torch-MPS paths. Other platforms should use the
+Docker, manual, or Intel XPU instructions below. Common failures are a missing
+Homebrew/uv on `PATH`, an unavailable Python 3.12 toolchain, or forgetting the
+`DYLD_LIBRARY_PATH` export when starting an audio server.
+
+### Run from a hosted installer
+
+The script also supports a downloaded or `curl | bash` invocation: when it is
+not inside an sglang-omni checkout, it clones the repository specified by
+`SGLANG_OMNI_REPO` and `SGLANG_OMNI_REF` into the cache and installs that
+checkout. Prefer downloading, reviewing, and then running a pinned script:
+
+```bash
+curl -fsSLo /tmp/sglang-omni-install.sh \
+  https://raw.githubusercontent.com/sgl-project/sglang-omni/<commit>/install.sh
+less /tmp/sglang-omni-install.sh
+chmod +x /tmp/sglang-omni-install.sh
+SGLANG_OMNI_REF=<commit> /tmp/sglang-omni-install.sh
+```
+
+Piping a remote script directly to Bash executes code without a review step;
+use it only when that trade-off is acceptable:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sgl-project/sglang-omni/<commit>/install.sh \
+  | SGLANG_OMNI_REF=<commit> bash
+```
+
+For a fork or an internal mirror, set `SGLANG_OMNI_REPO` and
+`SGLANG_OMNI_REF` explicitly. The hosted mode stores the project checkout at
+`~/.cache/sglang-omni/sglang-omni-<ref>` by default; override it with
+`SGLANG_OMNI_PROJECT_DIR`.
+
+## 🛠️ Option C: Manual install
 
 Build prerequisites first:
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+# Install sglang-omni and the Apple Silicon Qwen3-ASR runtime.
+#
+# This file intentionally does not bootstrap Homebrew. Homebrew's official
+# bootstrapper can require administrator approval and changes system state;
+# users should install it from https://brew.sh and then rerun this script.
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+readonly DEFAULT_OMNI_REPO="https://github.com/sgl-project/sglang-omni.git"
+readonly DEFAULT_OMNI_REF="main"
+readonly DEFAULT_SGLANG_REPO="https://github.com/sgl-project/sglang.git"
+readonly DEFAULT_SGLANG_REF="v0.5.16"
+
+SCRIPT_PATH="${BASH_SOURCE[0]:-}"
+if [[ -n "$SCRIPT_PATH" && -f "$SCRIPT_PATH" ]]; then
+  readonly SCRIPT_DIR="$(cd -- "$(dirname -- "$SCRIPT_PATH")" && pwd -P)"
+else
+  readonly SCRIPT_DIR=""
+fi
+
+readonly OMNI_REPO="${SGLANG_OMNI_REPO:-$DEFAULT_OMNI_REPO}"
+readonly OMNI_REF="${SGLANG_OMNI_REF:-$DEFAULT_OMNI_REF}"
+readonly SGLANG_REPO="${SGLANG_REPO:-$DEFAULT_SGLANG_REPO}"
+readonly SGLANG_REF="${SGLANG_VERSION:-$DEFAULT_SGLANG_REF}"
+readonly CACHE_ROOT="${SGLANG_OMNI_CACHE:-${HOME}/.cache/sglang-omni}"
+readonly SGLANG_DIR="${SGLANG_SOURCE_DIR:-${CACHE_ROOT}/sglang-${SGLANG_REF//\//-}}"
+readonly OMNI_DIR="${SGLANG_OMNI_PROJECT_DIR:-${CACHE_ROOT}/sglang-omni-${OMNI_REF//\//-}}"
+readonly EXTRAS="${SGLANG_OMNI_EXTRAS:-}"
+NONINTERACTIVE="${NONINTERACTIVE:-0}"
+export UV_HTTP_TIMEOUT="${UV_HTTP_TIMEOUT:-300}"
+export UV_HTTP_RETRIES="${UV_HTTP_RETRIES:-5}"
+
+log() {
+  printf '[sglang-omni-install] %s\n' "$*"
+}
+
+die() {
+  printf '[sglang-omni-install][error] %s\n' "$*" >&2
+  exit 1
+}
+
+on_error() {
+  local exit_code=$?
+  printf '[sglang-omni-install][error] command failed at line %s: %s\n' "$1" "$2" >&2
+  exit "$exit_code"
+}
+
+trap 'on_error "$LINENO" "$BASH_COMMAND"' ERR
+
+SGLANG_STAGE_DIR=""
+CHECKOUT_TMP_DIR=""
+cleanup() {
+  if [[ -n "$SGLANG_STAGE_DIR" && -d "$SGLANG_STAGE_DIR" ]]; then
+    rm -rf -- "$SGLANG_STAGE_DIR"
+  fi
+  if [[ -n "$CHECKOUT_TMP_DIR" && -d "$CHECKOUT_TMP_DIR" ]]; then
+    rm -rf -- "$CHECKOUT_TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+usage() {
+  cat <<'EOF'
+Usage: ./install.sh [OPTIONS]
+
+Install sglang-omni and the Apple Silicon Qwen3-ASR runtime into an isolated
+Python 3.12 virtual environment. Homebrew must already be installed.
+
+Options:
+  --non-interactive  Disable Homebrew auto-update (CI use).
+  -h, --help         Show this help.
+
+Environment:
+  SGLANG_OMNI_VENV         Virtual environment path.
+  SGLANG_OMNI_CACHE        Cache root for source checkouts.
+  SGLANG_SOURCE_DIR        SGLang source checkout path.
+  SGLANG_VERSION            SGLang git tag/branch (default: v0.5.16).
+  SGLANG_REPO               SGLang repository URL.
+  SGLANG_OMNI_REPO          sglang-omni repository URL for hosted use.
+  SGLANG_OMNI_REF           sglang-omni branch/tag (default: main).
+  SGLANG_OMNI_PROJECT_DIR   sglang-omni checkout path for hosted use.
+  SGLANG_OMNI_EXTRAS        Optional extras, comma-separated.
+  NONINTERACTIVE=1          Same as --non-interactive.
+  UV_HTTP_TIMEOUT            Per-request timeout in seconds (default: 300).
+  UV_HTTP_RETRIES            Network retry count (default: 5).
+
+The local checkout is installed when this script lives in an sglang-omni
+repository. If downloaded or piped from stdin, the configured repository/ref
+is cloned into SGLANG_OMNI_PROJECT_DIR (or the cache default above).
+EOF
+}
+
+while (($#)); do
+  case "$1" in
+    --non-interactive)
+      NONINTERACTIVE=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1 (use --help)"
+      ;;
+  esac
+  shift
+done
+
+[[ "$(uname -s)" == "Darwin" ]] || die "unsupported operating system; this installer requires macOS"
+[[ "$(uname -m)" == "arm64" ]] || die "unsupported architecture; Apple Silicon arm64 is required"
+
+if [[ -n "${SGLANG_OMNI_PROJECT_DIR:-}" ]]; then
+  # An explicit destination selects hosted mode even when a local script copy
+  # happens to sit next to a checkout.
+  PROJECT_DIR=""
+elif [[ -n "$SCRIPT_DIR" && -f "$SCRIPT_DIR/pyproject.toml" ]] \
+  && grep -q '^name = "sglang-omni"' "$SCRIPT_DIR/pyproject.toml"; then
+  PROJECT_DIR="$SCRIPT_DIR"
+elif [[ -f "$PWD/pyproject.toml" ]] && grep -q '^name = "sglang-omni"' "$PWD/pyproject.toml"; then
+  # A downloaded installer can still be run from a checked-out repository.
+  PROJECT_DIR="$PWD"
+else
+  PROJECT_DIR=""
+fi
+
+if [[ -n "${SGLANG_OMNI_VENV:-}" ]]; then
+  readonly VENV_DIR="$SGLANG_OMNI_VENV"
+elif [[ -n "$PROJECT_DIR" ]]; then
+  readonly VENV_DIR="$PROJECT_DIR/.venv-apple"
+else
+  readonly VENV_DIR="$CACHE_ROOT/.venv-apple"
+fi
+
+find_brew() {
+  local candidate
+  # Prefer native Apple Silicon Homebrew even if an Intel/Rosetta brew appears
+  # earlier on PATH.
+  if [[ -x /opt/homebrew/bin/brew ]]; then
+    printf '%s\n' /opt/homebrew/bin/brew
+    return 0
+  fi
+  if command -v brew >/dev/null 2>&1; then
+    command -v brew
+    return 0
+  fi
+  for candidate in /opt/homebrew/bin/brew /usr/local/bin/brew; do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+BREW_BIN="$(find_brew || true)"
+if [[ -z "$BREW_BIN" ]]; then
+  cat >&2 <<'EOF'
+[sglang-omni-install][error] Homebrew is required but was not found.
+Install Homebrew from https://brew.sh, ensure `brew` is on PATH, and rerun
+this script. This installer deliberately does not run Homebrew's bootstrapper
+or request administrator privileges.
+EOF
+  exit 1
+fi
+
+BREW_PREFIX="$($BREW_BIN --prefix)" || die "unable to determine the Homebrew prefix"
+[[ "$BREW_PREFIX" == "/opt/homebrew" ]] \
+  || die "native Apple Silicon Homebrew is required; found prefix: $BREW_PREFIX"
+export PATH="$BREW_PREFIX/bin:$BREW_PREFIX/sbin:$PATH"
+if [[ "$NONINTERACTIVE" == "1" ]]; then
+  export HOMEBREW_NO_AUTO_UPDATE="${HOMEBREW_NO_AUTO_UPDATE:-1}"
+fi
+
+ensure_formula() {
+  local formula="$1"
+  if "$BREW_BIN" list --formula "$formula" >/dev/null 2>&1; then
+    log "Homebrew formula already installed: $formula"
+    return 0
+  fi
+  log "Installing Homebrew formula: $formula"
+  if ! "$BREW_BIN" install "$formula"; then
+    die "Homebrew could not install $formula. Check `brew doctor` and Homebrew directory permissions; no administrator command was run by this script"
+  fi
+}
+
+ensure_formula ffmpeg@7
+ensure_formula uv
+
+if ! command -v git >/dev/null 2>&1 || ! git --version >/dev/null 2>&1; then
+  ensure_formula git
+fi
+command -v git >/dev/null 2>&1 || die "git is required; install it with Homebrew or Xcode Command Line Tools"
+command -v uv >/dev/null 2>&1 || die "uv is required; the Homebrew uv formula was not found on PATH"
+
+if [[ -d "$VENV_DIR" ]]; then
+  log "Reusing Python virtual environment: $VENV_DIR"
+  PYTHON_BIN="$VENV_DIR/bin/python"
+  [[ -x "$PYTHON_BIN" ]] || die "existing path is not a usable virtual environment: $VENV_DIR"
+else
+  log "Creating Python 3.12 virtual environment: $VENV_DIR"
+  uv venv --python 3.12 "$VENV_DIR"
+  PYTHON_BIN="$VENV_DIR/bin/python"
+fi
+[[ -x "$PYTHON_BIN" ]] || die "uv did not create $PYTHON_BIN"
+"$PYTHON_BIN" -c 'import sys; assert sys.version_info[:2] == (3, 12), sys.version' \
+  || die "the virtual environment must use Python 3.12"
+UV_PIP_INSTALL=(uv pip install --python "$PYTHON_BIN")
+
+clone_or_reuse() {
+  local destination="$1"
+  local ref="$2"
+  local repository="$3"
+  local label="$4"
+  local actual_repository current_commit target_commit
+
+  if [[ -e "$destination" && ! -d "$destination/.git" ]]; then
+    die "$label destination exists but is not a git checkout: $destination (choose another path)"
+  fi
+  if [[ -d "$destination/.git" ]]; then
+    actual_repository="$(git -C "$destination" remote get-url origin 2>/dev/null || true)"
+    [[ "$actual_repository" == "$repository" ]] \
+      || die "$label checkout origin is $actual_repository, expected $repository: $destination"
+    [[ -z "$(git -C "$destination" status --porcelain)" ]] \
+      || die "$label checkout has local changes; clean it or choose another path: $destination"
+    log "Refreshing $label $ref: $destination"
+    git -C "$destination" fetch --depth 1 origin "$ref"
+    current_commit="$(git -C "$destination" rev-parse HEAD)"
+    target_commit="$(git -C "$destination" rev-parse 'FETCH_HEAD^{commit}')"
+    if [[ "$current_commit" != "$target_commit" ]]; then
+      log "Updating $label checkout to $target_commit"
+      git -C "$destination" checkout --detach --quiet FETCH_HEAD
+    fi
+    return 0
+  fi
+  log "Cloning $label $ref: $destination"
+  mkdir -p "$(dirname -- "$destination")"
+  CHECKOUT_TMP_DIR="$(mktemp -d "${destination}.tmp.XXXXXX")"
+  git -C "$CHECKOUT_TMP_DIR" init --quiet
+  git -C "$CHECKOUT_TMP_DIR" remote add origin "$repository"
+  git -C "$CHECKOUT_TMP_DIR" fetch --depth 1 origin "$ref"
+  git -C "$CHECKOUT_TMP_DIR" checkout --detach --quiet FETCH_HEAD
+  [[ ! -e "$destination" ]] || die "$label destination appeared during installation: $destination"
+  mv "$CHECKOUT_TMP_DIR" "$destination"
+  CHECKOUT_TMP_DIR=""
+}
+
+clone_or_reuse "$SGLANG_DIR" "$SGLANG_REF" "$SGLANG_REPO" "SGLang"
+
+# SGLang keeps the CUDA-oriented project metadata in pyproject.toml and the
+# platform-neutral/MLX metadata in pyproject_other.toml. Its Python build also
+# references Rust and version files at the repository root, so stage the whole
+# checkout and replace only the staged metadata. The source checkout remains
+# untouched and the staged package is installed non-editably before cleanup.
+SGLANG_STAGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/sglang-omni-sglang.XXXXXX")"
+cp -R "$SGLANG_DIR/." "$SGLANG_STAGE_DIR/"
+if [[ -f "$SGLANG_DIR/python/pyproject_other.toml" ]]; then
+  cp "$SGLANG_DIR/python/pyproject_other.toml" "$SGLANG_STAGE_DIR/python/pyproject.toml"
+else
+  die "SGLang checkout does not contain python/pyproject_other.toml"
+fi
+
+log "Installing SGLang $SGLANG_REF with the all_mps extra"
+# The optional SGLang Rust extensions are not used by the MLX/Torch-MPS
+# Qwen3-ASR path. Skipping them avoids requiring a Rust toolchain on a clean Mac.
+SGLANG_BUILD_RUST_EXTS=none \
+  "${UV_PIP_INSTALL[@]}" --prerelease=allow "$SGLANG_STAGE_DIR/python[all_mps]"
+
+if [[ -z "$PROJECT_DIR" ]]; then
+  PROJECT_DIR="$OMNI_DIR"
+  clone_or_reuse "$PROJECT_DIR" "$OMNI_REF" "$OMNI_REPO" "sglang-omni"
+fi
+[[ -f "$PROJECT_DIR/pyproject.toml" ]] || die "sglang-omni pyproject.toml not found in $PROJECT_DIR"
+grep -q '^name = "sglang-omni"' "$PROJECT_DIR/pyproject.toml" \
+  || die "project is not sglang-omni: $PROJECT_DIR"
+
+PROJECT_SPEC="$PROJECT_DIR"
+if [[ -n "$EXTRAS" ]]; then
+  PROJECT_SPEC="${PROJECT_DIR}[${EXTRAS}]"
+fi
+log "Installing sglang-omni${EXTRAS:+ with extras: $EXTRAS}"
+"${UV_PIP_INSTALL[@]}" --prerelease=allow -e "$PROJECT_SPEC"
+
+FFMPEG_LIB="$($BREW_BIN --prefix ffmpeg@7)/lib"
+[[ -d "$FFMPEG_LIB" ]] || die "ffmpeg@7 library directory not found: $FFMPEG_LIB"
+
+log "Verifying the installed Python package and CLI"
+uv pip check --python "$PYTHON_BIN"
+"$PYTHON_BIN" -c 'import sglang_omni; print("sglang_omni", sglang_omni.__version__)'
+[[ -x "$VENV_DIR/bin/sgl-omni" ]] || die "sgl-omni console script was not installed"
+"$VENV_DIR/bin/sgl-omni" --help >/dev/null
+DYLD_LIBRARY_PATH="$FFMPEG_LIB${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}" \
+SGLANG_USE_MLX=1 "$PYTHON_BIN" - <<'PY'
+import mlx.core as mx
+from torchcodec.decoders import AudioDecoder  # noqa: F401
+
+assert mx.metal.is_available(), "MLX Metal is unavailable"
+print("MLX Metal and TorchCodec FFmpeg loading are available")
+PY
+
+cat <<EOF
+
+Installation complete.
+Virtual environment: $VENV_DIR
+Activate it with:
+  source "$VENV_DIR/bin/activate"
+
+For TorchCodec/FFmpeg audio decoding, export:
+  export DYLD_LIBRARY_PATH="$FFMPEG_LIB\${DYLD_LIBRARY_PATH:+:\$DYLD_LIBRARY_PATH}"
+
+The Apple Silicon Qwen3-ASR examples are documented at:
+  $PROJECT_DIR/docs/cookbook/qwen3_asr.md
+EOF

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ IFS=$'\n\t'
 readonly DEFAULT_OMNI_REPO="https://github.com/sgl-project/sglang-omni.git"
 readonly DEFAULT_OMNI_REF="main"
 readonly DEFAULT_SGLANG_REPO="https://github.com/sgl-project/sglang.git"
-readonly DEFAULT_SGLANG_REF="v0.5.16"
+readonly DEFAULT_SGLANG_REF="v0.5.18"
 
 SCRIPT_PATH="${BASH_SOURCE[0]:-}"
 if [[ -n "$SCRIPT_PATH" && -f "$SCRIPT_PATH" ]]; then
@@ -77,7 +77,7 @@ Environment:
   SGLANG_OMNI_VENV         Virtual environment path.
   SGLANG_OMNI_CACHE        Cache root for source checkouts.
   SGLANG_SOURCE_DIR        SGLang source checkout path.
-  SGLANG_VERSION            SGLang git tag/branch (default: v0.5.16).
+  SGLANG_VERSION            SGLang git tag/branch (default: v0.5.18).
   SGLANG_REPO               SGLang repository URL.
   SGLANG_OMNI_REPO          sglang-omni repository URL for hosted use.
   SGLANG_OMNI_REF           sglang-omni branch/tag (default: main).
@@ -182,7 +182,7 @@ ensure_formula() {
   fi
   log "Installing Homebrew formula: $formula"
   if ! "$BREW_BIN" install "$formula"; then
-    die "Homebrew could not install $formula. Check `brew doctor` and Homebrew directory permissions; no administrator command was run by this script"
+    die "Homebrew could not install $formula. Check 'brew doctor' and Homebrew directory permissions; no administrator command was run by this script"
   fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -59,6 +59,8 @@ cleanup() {
   fi
 }
 trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 usage() {
   cat <<'EOF'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
     # note (yexiaodong): SGLang's PyPI wheel has unconditional CUDA dependencies,
     # so Apple Silicon installs this exact tag from source with the all_mps extra.
     "sglang==0.5.18; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "mlx; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "mlx-lm; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "flashinfer_python[cu13]==0.6.17; sys_platform != 'darwin' or platform_machine != 'arm64'",  # sglang pin. Do NOT add flashinfer-cubin: PyPI has no matching cubin, and any leftover cubin wheel fails MiniMax DIT import.
     "cache-dit==1.3.0",      # MiniMax Music 3 DIT (hard import, not optional)
     "addict==2.4.0",         # sglang.multimodal_gen server_args; MiniMax DIT import

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,16 +29,18 @@ dependencies = [
     "datasets>=2.14.0",       # Arrow-based SeedTTS dataset loading
     "fastapi>=0.110.0",       # OpenAI-compatible API adapter
     "uvicorn>=0.23.0",        # ASGI server for FastAPI
-    "sglang==0.5.18",
-    "flashinfer_python[cu13]==0.6.17",  # sglang pin. Do NOT add flashinfer-cubin: PyPI has no matching cubin, and any leftover cubin wheel fails MiniMax DIT import.
+    # note (yexiaodong): SGLang's PyPI wheel has unconditional CUDA dependencies,
+    # so Apple Silicon installs this exact tag from source with the all_mps extra.
+    "sglang==0.5.18; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "flashinfer_python[cu13]==0.6.17; sys_platform != 'darwin' or platform_machine != 'arm64'",  # sglang pin. Do NOT add flashinfer-cubin: PyPI has no matching cubin, and any leftover cubin wheel fails MiniMax DIT import.
     "cache-dit==1.3.0",      # MiniMax Music 3 DIT (hard import, not optional)
     "addict==2.4.0",         # sglang.multimodal_gen server_args; MiniMax DIT import
     "imageio==2.36.0",       # sglang.multimodal_gen vision utils; MiniMax DIT import
     "imageio-ffmpeg==0.5.1", # Pinned with the sglang diffusion extra
-    "flash-attn-4>=4.0.0b18",  # Required by sglang, pairs with cutlass-dsl 4.6.2
-    "kernels>=0.14.1,<0.15",  # Match the pinned sglang stack
-    "nixl-cu13>=1.1.0",  # CUDA 13 relay wheel; the generic nixl/-cu12 wheel breaks on cu130
-    "mooncake-transfer-engine-cuda13>=0.3.10",  # CUDA 13 relay wheel; generic mooncake-transfer-engine pulls cu12 and breaks import mooncake on cu130
+    "flash-attn-4>=4.0.0b18; sys_platform != 'darwin' or platform_machine != 'arm64'",  # Required by sglang, pairs with cutlass-dsl 4.6.2
+    "kernels>=0.14.1,<0.15; sys_platform != 'darwin' or platform_machine != 'arm64'",  # Match the pinned sglang stack
+    "nixl-cu13>=1.1.0; sys_platform != 'darwin' or platform_machine != 'arm64'",  # CUDA 13 relay wheel; the generic nixl/-cu12 wheel breaks on cu130
+    "mooncake-transfer-engine-cuda13>=0.3.10; sys_platform != 'darwin' or platform_machine != 'arm64'",  # CUDA 13 relay wheel; generic mooncake-transfer-engine pulls cu12 and breaks import mooncake on cu130
     "logger",
     "httpx",
     "xxhash>=3.0.0",
@@ -81,13 +83,15 @@ dependencies = [
     "torchcodec==0.15.0",     # Matches torch 2.13.x and the pinned sglang stack
     # Gradio playground
     "gradio>=4.0.0",
-    # dots.tts model operators; serving/runtime stays owned by sglang-omni
-    "dots.tts==0.2.1",
+    # note (yexiaodong): dots.tts pulls Pynini, whose OpenFst build is not
+    # available on Apple arm64 and is unrelated to the Qwen3-ASR path.
+    "dots.tts==0.2.1; sys_platform != 'darwin' or platform_machine != 'arm64'",
     # Ming-Omni
     "diffusers==0.37.0",      # Omni's own Ming-Omni pin; not an sglang core dependency
     "x-transformers",          # Ming talker rotary embeddings
-    # ZONOS2 written->spoken text normalization; pulls pynini + sacremoses.
-    "nemo_text_processing==1.2.0",
+    # note (yexiaodong): ZONOS2 text normalization pulls Pynini/OpenFst, which
+    # has no usable Apple arm64 wheel and is unrelated to the Qwen3-ASR path.
+    "nemo_text_processing==1.2.0; sys_platform != 'darwin' or platform_machine != 'arm64'",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,10 @@ dependencies = [
     "pydantic>=2.0.0",        # Data validation and serialization
     "PyYAML>=6.0",            # YAML config parsing
     "pybase64>=1.4.0",        # Fast base64 decoding for inline media payloads
-    "torch==2.13.0",          # PyTorch for tensor operations
-    "torchvision==0.28.0",    # torchvision for vision processor, pinned version based on torch 2.13.0
+    "torch==2.13.0; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "torch==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "torchvision==0.28.0; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "torchvision==0.26.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "accelerate>=0.27.0",     # init_empty_weights for meta initialization
     "transformers==5.12.1",  # Match the pinned sglang stack
     "safetensors>=0.4.3",     # Direct weight loading
@@ -80,7 +82,8 @@ dependencies = [
     "hydra-core",
     "omegaconf",
     "torchaudio==2.11.0",
-    "torchcodec==0.15.0",     # Matches torch 2.13.x and the pinned sglang stack
+    "torchcodec==0.15.0; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "torchcodec==0.11.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
     # Gradio playground
     "gradio>=4.0.0",
     # note (yexiaodong): dots.tts pulls Pynini, whose OpenFst build is not
@@ -130,7 +133,8 @@ environments = [
     "sys_platform == 'linux'",
 ]
 override-dependencies = [
-    "protobuf>=6.31.1,<7.0.0",
+    "protobuf>=6.31.1,<7.0.0; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "protobuf>=7.35.1,<8.0.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
 ]
 
 [tool.pytest.ini_options]

--- a/sglang_omni/model_runner/mlx_model_worker.py
+++ b/sglang_omni/model_runner/mlx_model_worker.py
@@ -95,8 +95,13 @@ class MlxSchedulerModelRunner(ModelRunner):
             previous_ids = [req.rid for req in previous.reqs]
             current_ids = [req.rid for req in reqs]
             if previous.launch.mode != "decode" or previous_ids != current_ids:
+                # The scheduler still owns ``previous`` and must resolve it
+                # before launching a changed batch. Keep this reference so the
+                # runner and scheduler do not disagree about the lazy cache root.
                 raise RuntimeError(
-                    "MLX chained decode requires an unchanged request batch"
+                    "MLX chained decode requires an unchanged request batch; "
+                    "resolve the outstanding pending step before launching a "
+                    "changed batch"
                 )
             launch = self.tp_worker.async_chained_decode_mlx(previous.launch.decode)
 

--- a/sglang_omni/model_runner/mlx_model_worker.py
+++ b/sglang_omni/model_runner/mlx_model_worker.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Omni adapter around SGLang's native MLX TP worker."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any
+
+from sglang_omni.model_runner.base import ModelRunner
+
+
+@dataclass(slots=True)
+class _MlxSchedulerPendingStep:
+    lazy_tokens: Any
+    prefills: list[Any]
+    extends: list[Any]
+    decode: Any
+    mode: str
+    reqs: list[Any]
+    scheduler_output: Any
+    schedule_batch: Any
+
+
+class MlxSchedulerModelRunner(ModelRunner):
+    """Bridge Omni's decode lookahead to SGLang's lazy MLX worker API."""
+
+    def __init__(self, tp_worker: Any, output_processor: Any):
+        super().__init__(tp_worker, output_processor)
+        self._last_mlx_pending: _MlxSchedulerPendingStep | None = None
+
+    def lookahead_eligible(self, batch: Any) -> bool:
+        return len(batch.reqs) == 1 and super().lookahead_eligible(batch)
+
+    def custom_prefill_forward(
+        self,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list[Any],
+    ) -> Any:
+        del requests
+        return self.tp_worker.forward_batch_generation(
+            batch=schedule_batch,
+            forward_batch=forward_batch,
+        )
+
+    def custom_decode_forward(
+        self,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list[Any],
+    ) -> Any:
+        del requests
+        return self.tp_worker.forward_batch_generation(
+            batch=schedule_batch,
+            forward_batch=forward_batch,
+        )
+
+    def execute_launch(self, scheduler_output: Any):
+        schedule_batch = scheduler_output.batch_data
+        if schedule_batch is None:
+            return None
+        if not schedule_batch.forward_mode.is_decode():
+            raise RuntimeError("MLX lookahead launch requires a decode batch")
+
+        # note (yexiaodong): A batch may carry deferred CPU prefill inputs or a
+        # preceding decode token instead of input_ids, so MLX must resolve the
+        # same FutureMap contract as SGLang's scheduler.
+        if self._execution_bridge is not None:
+            from sglang.srt.managers.overlap_utils import resolve_forward_inputs
+
+            resolve_forward_inputs(schedule_batch, self._execution_bridge.future_map)
+
+        reqs = list(schedule_batch.reqs)
+        previous = self._last_mlx_pending
+        if previous is None:
+            lazy_tokens, prefills, extends, decode, mode = (
+                self.tp_worker.async_forward_batch_generation_mlx(schedule_batch)
+            )
+        else:
+            previous_ids = [req.rid for req in previous.reqs]
+            current_ids = [req.rid for req in reqs]
+            if previous.mode != "decode" or previous_ids != current_ids:
+                raise RuntimeError(
+                    "MLX chained decode requires an unchanged request batch"
+                )
+            lazy_tokens, prefills, extends, decode, mode = (
+                self.tp_worker.async_chained_decode_mlx(previous.decode)
+            )
+
+        schedule_batch_copy = schedule_batch.copy()
+        pending = _MlxSchedulerPendingStep(
+            lazy_tokens=lazy_tokens,
+            prefills=prefills,
+            extends=extends,
+            decode=decode,
+            mode=mode,
+            reqs=reqs,
+            scheduler_output=replace(
+                scheduler_output,
+                batch_data=schedule_batch_copy,
+            ),
+            schedule_batch=schedule_batch_copy,
+        )
+        self._last_mlx_pending = pending
+        return pending
+
+    def execute_resolve(self, pending: _MlxSchedulerPendingStep | None):
+        if pending is None:
+            return None
+
+        try:
+            batch_result = self.tp_worker.finalize_mlx_result(
+                pending.prefills,
+                pending.extends,
+                pending.decode,
+                pending.mode,
+                pending.reqs,
+            )
+        except Exception:
+            # note (yexiaodong): A predecessor failure invalidates any chained
+            # successor that shares its lazily updated cache objects.
+            self._last_mlx_pending = None
+            raise
+        else:
+            if self._last_mlx_pending is pending:
+                self._last_mlx_pending = None
+
+        if (
+            self._execution_bridge is not None
+            and batch_result.next_token_ids is not None
+        ):
+            # note (yexiaodong): The custom MLX worker owns forward execution,
+            # so publish its sampled token for a later batch that breaks a chain.
+            self._execution_bridge.publish_next_tokens(
+                pending.schedule_batch,
+                batch_result.next_token_ids,
+            )
+
+        skip_rids = {
+            request.request_id
+            for request in pending.scheduler_output.requests
+            if request.data.req.finished() or self._req_is_retracted(request.data.req)
+        }
+        return self._finalize(
+            batch_result,
+            None,
+            pending.schedule_batch,
+            pending.scheduler_output,
+            skip_rids=skip_rids,
+        )
+
+
+def create_mlx_model_worker(
+    *,
+    config: Any,
+    server_args: Any,
+    gpu_id: int,
+    tp_rank: int = 0,
+):
+    """Construct an MLX worker with the same scheduler-facing contract as Omni."""
+    if config.model_arch_override != "Qwen3ASRForConditionalGeneration":
+        raise NotImplementedError(
+            "Omni's MLX worker currently supports only "
+            "Qwen3ASRForConditionalGeneration"
+        )
+
+    from sglang.srt.distributed.parallel_state_wrapper import ParallelState
+    from sglang.srt.hardware_backend.mlx.model_runner_stub import MlxModelRunnerStub
+    from sglang.srt.hardware_backend.mlx.tp_worker import MlxTpModelWorker
+    from sglang.srt.layers.dp_attention import compute_dp_attention_world_info
+    from sglang.srt.server_args import PortArgs
+
+    from sglang_omni.models.qwen3_asr.mlx.runner import make_qwen3_asr_mlx_runner_class
+    from sglang_omni.vendor.sglang.parallel_state import create_parallel_state
+
+    class OmniMlxModelRunnerStub(MlxModelRunnerStub):
+        def __init__(self, *args, **kwargs):
+            # note (yexiaodong): SGLang 0.5.16 resolves explicit MLX concurrency
+            # before the regular runner components create the dp_size alias.
+            self.dp_size = int(kwargs["server_args"].dp_size)
+            super().__init__(*args, **kwargs)
+
+    class OmniQwen3ASRMlxWorker(MlxTpModelWorker):
+        @property
+        def tp_rank(self) -> int:
+            return self.ps.tp_rank
+
+        def _init_model_runner(self):
+            runner_class = make_qwen3_asr_mlx_runner_class()
+            init_kwargs = {
+                "model_path": self.server_args.model_path,
+                "trust_remote_code": self.server_args.trust_remote_code,
+                "disable_radix_cache": self.server_args.disable_radix_cache,
+                "mem_fraction_static": self.server_args.mem_fraction_static,
+                "quantization": self.server_args.quantization,
+            }
+            if self.server_args.max_total_tokens is not None:
+                init_kwargs["pool_size"] = self.server_args.max_total_tokens
+            self._mlx_runner = runner_class(**init_kwargs)
+            self._model_runner = OmniMlxModelRunnerStub(
+                model_config=self.model_config,
+                mem_fraction_static=self.server_args.mem_fraction_static,
+                gpu_id=self.gpu_id,
+                ps=self.ps,
+                nccl_port=self.nccl_port,
+                server_args=self.server_args,
+                is_draft_worker=self.is_draft_worker,
+                req_to_token_pool=self.req_to_token_pool,
+                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+                memory_pool_config=self.memory_pool_config,
+                mlx_pool_size=self._mlx_runner.pool_size,
+            )
+            self._mlx_active_rids = set()
+            self._mlx_pool_initialized = False
+
+        def get_tp_group(self):
+            return self.model_runner.tp_group
+
+        def get_attention_tp_group(self):
+            return self.model_runner.attention_tp_group
+
+        def get_attention_tp_cpu_group(self):
+            return self.model_runner.attention_tp_group.cpu_group
+
+    attn_tp_rank, attn_tp_size, attn_dp_rank, attn_dp_size = (
+        compute_dp_attention_world_info(
+            server_args.enable_dp_attention,
+            tp_rank,
+            server_args.tp_size,
+            server_args.dp_size,
+            server_args.attn_cp_size,
+        )
+    )
+    ps = create_parallel_state(
+        ParallelState,
+        tp_rank=tp_rank,
+        dcp_size=server_args.dcp_size,
+        tp_size=server_args.tp_size,
+        pp_rank=0,
+        pp_size=1,
+        dp_rank=None,
+        dp_size=server_args.dp_size,
+        attn_tp_rank=attn_tp_rank,
+        attn_tp_size=attn_tp_size,
+        attn_cp_rank=0,
+        attn_cp_size=server_args.attn_cp_size,
+        attn_dp_rank=attn_dp_rank,
+        attn_dp_size=attn_dp_size,
+        moe_ep_rank=0,
+        moe_ep_size=1,
+        moe_dp_rank=None,
+        moe_dp_size=server_args.moe_dp_size,
+        gpu_id=gpu_id,
+    )
+    nccl_port = config.nccl_port
+    if nccl_port is None:
+        nccl_port = PortArgs.init_new(server_args).nccl_port
+    return OmniQwen3ASRMlxWorker(
+        server_args=server_args,
+        gpu_id=gpu_id,
+        ps=ps,
+        nccl_port=nccl_port,
+    )

--- a/sglang_omni/model_runner/mlx_model_worker.py
+++ b/sglang_omni/model_runner/mlx_model_worker.py
@@ -11,11 +11,7 @@ from sglang_omni.model_runner.base import ModelRunner
 
 @dataclass(slots=True)
 class _MlxSchedulerPendingStep:
-    lazy_tokens: Any
-    prefills: list[Any]
-    extends: list[Any]
-    decode: Any
-    mode: str
+    launch: Any
     reqs: list[Any]
     scheduler_output: Any
     schedule_batch: Any
@@ -26,10 +22,31 @@ class MlxSchedulerModelRunner(ModelRunner):
 
     def __init__(self, tp_worker: Any, output_processor: Any):
         super().__init__(tp_worker, output_processor)
+        # note (yexiaodong): The scheduler still owns every pending handle;
+        # this reference is only the lazy decode root used to build its successor.
         self._last_mlx_pending: _MlxSchedulerPendingStep | None = None
 
     def lookahead_eligible(self, batch: Any) -> bool:
-        return len(batch.reqs) == 1 and super().lookahead_eligible(batch)
+        if len(batch.reqs) != 1:
+            return False
+        previous = self._last_mlx_pending
+        if previous is not None:
+            previous_ids = [req.rid for req in previous.reqs]
+            current_ids = [req.rid for req in batch.reqs]
+            if previous.launch.mode != "decode" or previous_ids != current_ids:
+                # note (yexiaodong): Returning false makes Omni resolve the
+                # in-flight step before it runs a changed batch synchronously.
+                return False
+        return super().lookahead_eligible(batch)
+
+    def _build_forward_batch(self, scheduler_output: Any):
+        schedule_batch = scheduler_output.batch_data
+        if schedule_batch is None:
+            return None
+        # note (yexiaodong): SGLang's MLX worker consumes ScheduleBatch
+        # directly. Its bookkeeping stub intentionally has no Torch attention
+        # backend state from which ForwardBatch could be constructed.
+        return None, schedule_batch, bool(schedule_batch.forward_mode.is_extend())
 
     def custom_prefill_forward(
         self,
@@ -73,27 +90,19 @@ class MlxSchedulerModelRunner(ModelRunner):
         reqs = list(schedule_batch.reqs)
         previous = self._last_mlx_pending
         if previous is None:
-            lazy_tokens, prefills, extends, decode, mode = (
-                self.tp_worker.async_forward_batch_generation_mlx(schedule_batch)
-            )
+            launch = self.tp_worker.async_forward_batch_generation_mlx(schedule_batch)
         else:
             previous_ids = [req.rid for req in previous.reqs]
             current_ids = [req.rid for req in reqs]
-            if previous.mode != "decode" or previous_ids != current_ids:
+            if previous.launch.mode != "decode" or previous_ids != current_ids:
                 raise RuntimeError(
                     "MLX chained decode requires an unchanged request batch"
                 )
-            lazy_tokens, prefills, extends, decode, mode = (
-                self.tp_worker.async_chained_decode_mlx(previous.decode)
-            )
+            launch = self.tp_worker.async_chained_decode_mlx(previous.launch.decode)
 
         schedule_batch_copy = schedule_batch.copy()
         pending = _MlxSchedulerPendingStep(
-            lazy_tokens=lazy_tokens,
-            prefills=prefills,
-            extends=extends,
-            decode=decode,
-            mode=mode,
+            launch=launch,
             reqs=reqs,
             scheduler_output=replace(
                 scheduler_output,
@@ -110,10 +119,7 @@ class MlxSchedulerModelRunner(ModelRunner):
 
         try:
             batch_result = self.tp_worker.finalize_mlx_result(
-                pending.prefills,
-                pending.extends,
-                pending.decode,
-                pending.mode,
+                pending.launch,
                 pending.reqs,
             )
         except Exception:
@@ -168,17 +174,10 @@ def create_mlx_model_worker(
     from sglang.srt.hardware_backend.mlx.model_runner_stub import MlxModelRunnerStub
     from sglang.srt.hardware_backend.mlx.tp_worker import MlxTpModelWorker
     from sglang.srt.layers.dp_attention import compute_dp_attention_world_info
+    from sglang.srt.runtime_context import publish
     from sglang.srt.server_args import PortArgs
 
     from sglang_omni.models.qwen3_asr.mlx.runner import make_qwen3_asr_mlx_runner_class
-    from sglang_omni.vendor.sglang.parallel_state import create_parallel_state
-
-    class OmniMlxModelRunnerStub(MlxModelRunnerStub):
-        def __init__(self, *args, **kwargs):
-            # note (yexiaodong): SGLang 0.5.16 resolves explicit MLX concurrency
-            # before the regular runner components create the dp_size alias.
-            self.dp_size = int(kwargs["server_args"].dp_size)
-            super().__init__(*args, **kwargs)
 
     class OmniQwen3ASRMlxWorker(MlxTpModelWorker):
         @property
@@ -186,6 +185,7 @@ def create_mlx_model_worker(
             return self.ps.tp_rank
 
         def _init_model_runner(self):
+            MlxModelRunnerStub.validate_startup_weight_load_mode(self.server_args)
             runner_class = make_qwen3_asr_mlx_runner_class()
             init_kwargs = {
                 "model_path": self.server_args.model_path,
@@ -193,11 +193,17 @@ def create_mlx_model_worker(
                 "disable_radix_cache": self.server_args.disable_radix_cache,
                 "mem_fraction_static": self.server_args.mem_fraction_static,
                 "quantization": self.server_args.quantization,
+                "revision": self.server_args.revision,
+                "enable_sampling": self.server_args.mlx_enable_sampling,
+                "sampling_rng_seed": self.server_args.random_seed,
+                "deterministic_seeding": (
+                    self.server_args.enable_deterministic_inference
+                ),
             }
             if self.server_args.max_total_tokens is not None:
                 init_kwargs["pool_size"] = self.server_args.max_total_tokens
             self._mlx_runner = runner_class(**init_kwargs)
-            self._model_runner = OmniMlxModelRunnerStub(
+            self._model_runner = MlxModelRunnerStub(
                 model_config=self.model_config,
                 mem_fraction_static=self.server_args.mem_fraction_static,
                 gpu_id=self.gpu_id,
@@ -231,10 +237,8 @@ def create_mlx_model_worker(
             server_args.attn_cp_size,
         )
     )
-    ps = create_parallel_state(
-        ParallelState,
+    ps = ParallelState(
         tp_rank=tp_rank,
-        dcp_size=server_args.dcp_size,
         tp_size=server_args.tp_size,
         pp_rank=0,
         pp_size=1,
@@ -244,6 +248,8 @@ def create_mlx_model_worker(
         attn_tp_size=attn_tp_size,
         attn_cp_rank=0,
         attn_cp_size=server_args.attn_cp_size,
+        attn_dcp_rank=tp_rank % server_args.dcp_size,
+        attn_dcp_size=server_args.dcp_size,
         attn_dp_rank=attn_dp_rank,
         attn_dp_size=attn_dp_size,
         moe_ep_rank=0,
@@ -255,6 +261,9 @@ def create_mlx_model_worker(
     nccl_port = config.nccl_port
     if nccl_port is None:
         nccl_port = PortArgs.init_new(server_args).nccl_port
+    # note (yexiaodong): MlxTpModelWorker reads the split runtime configuration
+    # while building its model config, before the bookkeeping stub exists.
+    publish(server_args, role="scheduler")
     return OmniQwen3ASRMlxWorker(
         server_args=server_args,
         gpu_id=gpu_id,

--- a/sglang_omni/model_runner/mlx_model_worker.py
+++ b/sglang_omni/model_runner/mlx_model_worker.py
@@ -95,9 +95,9 @@ class MlxSchedulerModelRunner(ModelRunner):
             previous_ids = [req.rid for req in previous.reqs]
             current_ids = [req.rid for req in reqs]
             if previous.launch.mode != "decode" or previous_ids != current_ids:
-                # The scheduler still owns ``previous`` and must resolve it
-                # before launching a changed batch. Keep this reference so the
-                # runner and scheduler do not disagree about the lazy cache root.
+                # note (yexiaodong): The scheduler still owns the previous
+                # pending step. Keep this reference until resolve so both sides
+                # retain the same lazy cache root.
                 raise RuntimeError(
                     "MLX chained decode requires an unchanged request batch; "
                     "resolve the outstanding pending step before launching a "

--- a/sglang_omni/models/qwen3_asr/config.py
+++ b/sglang_omni/models/qwen3_asr/config.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import ClassVar
 
 from pydantic import Field
@@ -13,6 +14,7 @@ from sglang_omni.config import (
     EngineStageConfig,
     FactoryArgs,
     PipelineConfig,
+    ResolvedAudioChunking,
     StageConfig,
 )
 from sglang_omni.models.qwen3_asr.audio_lengths import QWEN3_ASR_MAX_INPUT_SECONDS
@@ -85,6 +87,25 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
             terminal=True,
         )
     ]
+
+    @property
+    def resolved_audio_chunking(self) -> ResolvedAudioChunking:
+        from sglang.srt.utils.tensor_bridge import use_mlx
+
+        from sglang_omni.platforms import current_platform
+
+        policy = super().resolved_audio_chunking
+        if not current_platform.is_mps() or use_mlx():
+            return policy
+
+        # note (yexiaodong): Torch MPS currently uses one clip shape for the
+        # encoder path, so keep its native and whole-upload limits aligned with
+        # the operator-selected chunk length. MLX retains the model-native cap.
+        return replace(
+            policy,
+            max_native_clip_s=policy.max_audio_clip_s,
+            max_total_audio_s=policy.max_audio_clip_s,
+        )
 
 
 EntryClass = Qwen3ASRPipelineConfig

--- a/sglang_omni/models/qwen3_asr/config.py
+++ b/sglang_omni/models/qwen3_asr/config.py
@@ -25,6 +25,11 @@ QWEN3_ASR_AUDIO_CHUNKING = AudioChunkingConfig(
     max_audio_clip_s=30.0,
 )
 
+# The Torch MPS path is qualified only through this duration. Keep this
+# backend limit separate from the operator's chunk size: the latter defaults
+# to 30s for scheduling, while a stream can safely use the qualified 60s cap.
+QWEN3_ASR_TORCH_MPS_MAX_AUDIO_SECONDS = 60.0
+
 
 class Qwen3ASRFactoryArgs(FactoryArgs):
     """Qwen3-ASR's own constructor knobs, typed like the shared ones."""
@@ -98,13 +103,27 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
         if not current_platform.is_mps() or use_mlx():
             return policy
 
+        if policy.max_audio_clip_s > QWEN3_ASR_TORCH_MPS_MAX_AUDIO_SECONDS:
+            raise ValueError(
+                "Qwen3-ASR Torch MPS supports "
+                "audio_chunking.max_audio_clip_s up to "
+                f"{QWEN3_ASR_TORCH_MPS_MAX_AUDIO_SECONDS:g}s"
+            )
+
         # note (yexiaodong): Torch MPS currently uses one clip shape for the
-        # encoder path, so keep its native and whole-upload limits aligned with
-        # the operator-selected chunk length. MLX retains the model-native cap.
+        # encoder path. Keep its native and whole-upload limits within the
+        # qualified cap, while retaining the independently configurable chunk
+        # size for non-streaming scheduling. MLX retains the model-native cap.
+        max_total_audio_s = policy.max_total_audio_s
+        if (
+            max_total_audio_s is None
+            or max_total_audio_s > QWEN3_ASR_TORCH_MPS_MAX_AUDIO_SECONDS
+        ):
+            max_total_audio_s = QWEN3_ASR_TORCH_MPS_MAX_AUDIO_SECONDS
         return replace(
             policy,
-            max_native_clip_s=policy.max_audio_clip_s,
-            max_total_audio_s=policy.max_audio_clip_s,
+            max_native_clip_s=QWEN3_ASR_TORCH_MPS_MAX_AUDIO_SECONDS,
+            max_total_audio_s=max_total_audio_s,
         )
 
 

--- a/sglang_omni/models/qwen3_asr/engine_builder.py
+++ b/sglang_omni/models/qwen3_asr/engine_builder.py
@@ -144,6 +144,8 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
         from sglang.srt.utils.tensor_bridge import use_mlx
 
         if use_mlx():
+            if not current_platform.is_mps():
+                raise RuntimeError("SGLANG_USE_MLX=1 requires the Apple Metal platform")
             # note (yexiaodong): Audio embeddings exist only inside the native
             # MLX prefill, so token-only radix reuse and split prefill are unsafe.
             return {
@@ -151,6 +153,7 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
                 "disable_cuda_graph": True,
                 "disable_overlap_schedule": True,
                 "disable_radix_cache": True,
+                "enable_torch_compile": False,
                 "max_prefill_tokens": self.context_length,
                 "chunked_prefill_size": -1,
                 "mem_fraction_static": self.mem_fraction_static,
@@ -256,6 +259,12 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
         )
 
     def validate_before_infrastructure(self, server_args: Any) -> None:
+        from sglang.srt.utils.tensor_bridge import use_mlx
+
+        if use_mlx() and server_args.mlx_enable_sampling:
+            raise ValueError(
+                "Qwen3-ASR MLX currently requires mlx_enable_sampling=False"
+            )
         if self._uses_torch_mps() and server_args.max_running_requests != 1:
             raise ValueError(
                 "Qwen3-ASR Torch MPS currently requires max_running_requests=1"
@@ -289,6 +298,9 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
         if "context_length" in overrides:
             self.context_length = int(overrides.pop("context_length"))
         if use_mlx() or self._uses_torch_mps():
+            # note (yexiaodong): Typed pipeline engine defaults are merged after
+            # the backend profile and otherwise re-enable Torch compilation.
+            overrides["enable_torch_compile"] = False
             return
         if overrides.get("cuda_graph_backend_prefill") == CudaGraphBackend.DISABLED:
             return

--- a/sglang_omni/models/qwen3_asr/engine_builder.py
+++ b/sglang_omni/models/qwen3_asr/engine_builder.py
@@ -107,8 +107,10 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
         self.tokenizer: Any = None
         self.feature_extractor: Any = None
         self.context_length = 0
+        self.device: str | None = None
         self.model_path: str | None = None
         self.audio_encoder_service: Any = None
+        self._torch_mps_model_runner: Any = None
         self._should_wait_for_encode: Callable[[], bool] | None = None
 
     def pre_infra_setup(self, checkpoint_dir: str) -> None:
@@ -128,7 +130,52 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
         max_output_budget = max(self.max_new_tokens, qwen3_asr_max_output_tokens())
         self.context_length = max_prompt_tokens + max_output_budget + 8
 
+    def _uses_torch_mps(self) -> bool:
+        import torch
+        from sglang.srt.utils.tensor_bridge import use_mlx
+
+        return (
+            not use_mlx()
+            and self.device is not None
+            and torch.device(self.device).type == "mps"
+        )
+
     def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
+        from sglang.srt.utils.tensor_bridge import use_mlx
+
+        if use_mlx():
+            # note (yexiaodong): Audio embeddings exist only inside the native
+            # MLX prefill, so token-only radix reuse and split prefill are unsafe.
+            return {
+                "max_running_requests": self.max_running_requests,
+                "disable_cuda_graph": True,
+                "disable_overlap_schedule": True,
+                "disable_radix_cache": True,
+                "max_prefill_tokens": self.context_length,
+                "chunked_prefill_size": -1,
+                "mem_fraction_static": self.mem_fraction_static,
+                "dtype": dtype,
+            }
+        if self._uses_torch_mps():
+            # note (yexiaodong): MPS has no CUDA graph or Triton lifecycle, and
+            # the audio embedding sidecar makes split prefill unsafe initially.
+            return {
+                "max_running_requests": 1,
+                "disable_cuda_graph": True,
+                "disable_overlap_schedule": True,
+                "disable_radix_cache": True,
+                "enable_torch_compile": False,
+                "context_length": 2048,
+                "max_total_tokens": 2048,
+                "max_prefill_tokens": 2048,
+                "chunked_prefill_size": -1,
+                "mem_fraction_static": self.mem_fraction_static,
+                "attention_backend": "torch_native",
+                "mm_attention_backend": "sdpa",
+                "sampling_backend": "pytorch",
+                "dtype": dtype,
+            }
+
         defaults: dict[str, Any] = {
             "max_running_requests": self.max_running_requests,
             "disable_cuda_graph": False,
@@ -159,6 +206,47 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
                 defaults["mm_attention_backend"] = "triton_attn"
         return defaults
 
+    def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
+        from sglang.srt.utils.tensor_bridge import use_mlx
+
+        if use_mlx():
+            from sglang_omni.model_runner.mlx_model_worker import (
+                MlxSchedulerModelRunner,
+            )
+
+            return MlxSchedulerModelRunner(model_worker, output_proc)
+        if self._uses_torch_mps():
+            from sglang_omni.models.qwen3_asr.torch_mps_runner import (
+                Qwen3ASRTorchMpsModelRunner,
+            )
+
+            self._torch_mps_model_runner = Qwen3ASRTorchMpsModelRunner(
+                model_worker,
+                output_proc,
+            )
+            return self._torch_mps_model_runner
+        return super().make_model_runner(model_worker, output_proc)
+
+    def setup_model(
+        self,
+        *,
+        model_worker: Any,
+        checkpoint_dir: str,
+        device: str,
+        gpu_id: int,
+        server_args: Any,
+    ) -> None:
+        del device, gpu_id, server_args
+        if self._uses_torch_mps():
+            from sglang_omni.models.qwen3_asr.torch_mps_runner import (
+                install_torch_mps_language_model,
+            )
+
+            install_torch_mps_language_model(
+                model_worker.model_runner.model,
+                checkpoint_dir,
+            )
+
     def _log_memory_checkpoint(self, checkpoint: str) -> None:
         logger.info(
             "Qwen3-ASR memory checkpoint=%s gpu=%d process_gpu_memory=%s",
@@ -168,6 +256,10 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
         )
 
     def validate_before_infrastructure(self, server_args: Any) -> None:
+        if self._uses_torch_mps() and server_args.max_running_requests != 1:
+            raise ValueError(
+                "Qwen3-ASR Torch MPS currently requires max_running_requests=1"
+            )
         super().validate_before_infrastructure(server_args)
         # Replace the per-request decode mrope-position loop with a vectorized
         # equivalent before any forward runs.
@@ -192,8 +284,12 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
         self._log_memory_checkpoint("post_static_allocation")
 
     def adjust_overrides(self, overrides: dict[str, Any]) -> None:
+        from sglang.srt.utils.tensor_bridge import use_mlx
+
         if "context_length" in overrides:
             self.context_length = int(overrides.pop("context_length"))
+        if use_mlx() or self._uses_torch_mps():
+            return
         if overrides.get("cuda_graph_backend_prefill") == CudaGraphBackend.DISABLED:
             return
         if "cuda_graph_bs_prefill" in overrides:
@@ -215,6 +311,18 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
         *,
         generation_cuda_graph_enabled: bool,
     ) -> None:
+        from sglang.srt.utils.tensor_bridge import use_mlx
+
+        if use_mlx():
+            # note (yexiaodong): Native MLX prefill owns audio encoding, so the
+            # Torch pre-LM service and its CUDA graphs must remain uninitialized.
+            return
+        if self._uses_torch_mps():
+            # note (yexiaodong): Torch MPS encodes audio inside model prefill,
+            # while the pre-LM service owns CUDA-only streams and graphs. The
+            # shared multimodal routine still requires its cache singleton.
+            init_mm_embedding_cache(self.mm_embedding_cache_size_bytes)
+            return
         del generation_cuda_graph_enabled
         self._log_memory_checkpoint("post_cuda_graph_capture")
         if self.enable_encoder_cuda_graph:
@@ -264,6 +372,8 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:
         del model
+        from sglang.srt.utils.tensor_bridge import use_mlx
+
         return request_builders.make_qwen3_asr_scheduler_adapters(
             tokenizer=self.tokenizer,
             feature_extractor=self.feature_extractor,
@@ -271,7 +381,13 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
             context_length=self.context_length,
             audio_encoder_service=self.audio_encoder_service,
             should_wait_for_encode=self.should_wait_for_encode,
+            greedy_only=use_mlx() or self._uses_torch_mps(),
         )
+
+    def make_abort_callback(self) -> Any | None:
+        if self._torch_mps_model_runner is None:
+            return None
+        return self._torch_mps_model_runner.abort_request
 
     def post_scheduler_setup(self, scheduler: Any, model_runner: Any) -> None:
         del model_runner
@@ -288,16 +404,23 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
             self.audio_encoder_service = None
 
     def extra_scheduler_kwargs(self) -> dict[str, Any]:
+        use_torch_mps = self._uses_torch_mps()
         return {
             "stream_output_builder": request_builders.make_qwen3_asr_stream_output_builder(
                 tokenizer=self.tokenizer,
                 min_emit_interval_s=self.stream_emit_interval_s,
             ),
-            "enable_async_decode": self.enable_async_decode,
+            "enable_async_decode": (
+                False if use_torch_mps else self.enable_async_decode
+            ),
             "async_decode_min_batch_size": self.async_decode_min_batch_size,
-            "request_build_max_workers": self.request_build_max_workers,
+            "request_build_max_workers": (
+                1 if use_torch_mps else self.request_build_max_workers
+            ),
             "request_build_max_pending": self.request_build_max_pending,
-            "prefill_coalesce_requests": self.prefill_coalesce_requests,
+            "prefill_coalesce_requests": (
+                0 if use_torch_mps else self.prefill_coalesce_requests
+            ),
             "prefill_coalesce_wait_ms": self.prefill_coalesce_wait_ms,
             "prefill_coalesce_when_idle": self.prefill_coalesce_when_idle,
             "prefill_coalesce_requires_pending_builds": (

--- a/sglang_omni/models/qwen3_asr/mlx/__init__.py
+++ b/sglang_omni/models/qwen3_asr/mlx/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native MLX backend for Qwen3-ASR."""

--- a/sglang_omni/models/qwen3_asr/mlx/config.py
+++ b/sglang_omni/models/qwen3_asr/mlx/config.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: MIT
+# Derived from mlx-audio Qwen3-ASR (Copyright 2025 Prince Canuma and contributors).
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class AudioEncoderConfig:
+    """Configuration for Qwen3-ASR audio encoder."""
+
+    num_mel_bins: int = 128
+    encoder_layers: int = 24
+    encoder_attention_heads: int = 16
+    encoder_ffn_dim: int = 4096
+    d_model: int = 1024
+    dropout: float = 0.0
+    attention_dropout: float = 0.0
+    activation_function: str = "gelu"
+    activation_dropout: float = 0.0
+    scale_embedding: bool = False
+    initializer_range: float = 0.02
+    max_source_positions: int = 1500
+    n_window: int = 50
+    output_dim: int = 2048
+    n_window_infer: int = 800
+    conv_chunksize: int = 500
+    downsample_hidden_size: int = 480
+
+    @classmethod
+    def from_dict(cls, params: dict[str, Any]) -> AudioEncoderConfig:
+        return cls(
+            **{
+                k: v
+                for k, v in params.items()
+                if k in inspect.signature(cls).parameters
+            }
+        )
+
+
+@dataclass
+class TextConfig:
+    """Configuration for Qwen3-ASR text decoder (Qwen3-based)."""
+
+    model_type: str = "qwen3"
+    vocab_size: int = 151936
+    hidden_size: int = 2048
+    intermediate_size: int = 6144
+    num_hidden_layers: int = 28
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 8
+    head_dim: int = 128
+    hidden_act: str = "silu"
+    max_position_embeddings: int = 65536
+    initializer_range: float = 0.02
+    rms_norm_eps: float = 1e-6
+    use_cache: bool = True
+    tie_word_embeddings: bool = True
+    rope_theta: float = 1000000.0
+    rope_scaling: dict[str, Any] | None = None
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+
+    @classmethod
+    def from_dict(cls, params: dict[str, Any]) -> TextConfig:
+        return cls(
+            **{
+                k: v
+                for k, v in params.items()
+                if k in inspect.signature(cls).parameters
+            }
+        )
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for Qwen3-ASR model."""
+
+    audio_config: AudioEncoderConfig | dict[str, Any] | None = None
+    text_config: TextConfig | dict[str, Any] | None = None
+    model_type: str = "qwen3_asr"
+    model_repo: str | None = None
+    audio_token_id: int = 151676
+    audio_start_token_id: int = 151669
+    audio_end_token_id: int = 151670
+    support_languages: list[str] = field(default_factory=list)
+
+    def __post_init__(self):
+        if self.audio_config is None:
+            self.audio_config = AudioEncoderConfig()
+        elif isinstance(self.audio_config, dict):
+            self.audio_config = AudioEncoderConfig.from_dict(self.audio_config)
+
+        if self.text_config is None:
+            self.text_config = TextConfig()
+        elif isinstance(self.text_config, dict):
+            self.text_config = TextConfig.from_dict(self.text_config)
+
+    @classmethod
+    def from_dict(cls, params: dict[str, Any]) -> ModelConfig:
+        params = params.copy()
+
+        if "thinker_config" in params:
+            thinker = params.pop("thinker_config")
+            if "audio_config" in thinker:
+                params["audio_config"] = thinker["audio_config"]
+            if "text_config" in thinker:
+                params["text_config"] = thinker["text_config"]
+            if "audio_token_id" in thinker:
+                params["audio_token_id"] = thinker["audio_token_id"]
+            if "audio_start_token_id" in thinker:
+                params["audio_start_token_id"] = thinker["audio_start_token_id"]
+            if "audio_end_token_id" in thinker:
+                params["audio_end_token_id"] = thinker["audio_end_token_id"]
+
+        if "audio_config" in params and isinstance(params["audio_config"], dict):
+            params["audio_config"] = AudioEncoderConfig.from_dict(
+                params["audio_config"]
+            )
+        elif "audio_config" not in params:
+            params["audio_config"] = AudioEncoderConfig()
+
+        if "text_config" in params and isinstance(params["text_config"], dict):
+            params["text_config"] = TextConfig.from_dict(params["text_config"])
+        elif "text_config" not in params:
+            params["text_config"] = TextConfig()
+
+        return cls(
+            **{
+                k: v
+                for k, v in params.items()
+                if k in inspect.signature(cls).parameters
+            }
+        )

--- a/sglang_omni/models/qwen3_asr/mlx/model.py
+++ b/sglang_omni/models/qwen3_asr/mlx/model.py
@@ -586,8 +586,7 @@ class Qwen3ASRModel(nn.Module):
 
         return [KVCache() for _ in range(self.config.text_config.num_hidden_layers)]
 
-    @staticmethod
-    def sanitize(weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+    def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
         """Sanitize weights from HuggingFace/PyTorch format to MLX format."""
         sanitized = {}
         is_formatted = not any(k.startswith("thinker.") for k in weights.keys())
@@ -596,7 +595,7 @@ class Qwen3ASRModel(nn.Module):
             if k.startswith("thinker."):
                 k = k[len("thinker.") :]
 
-            if k == "lm_head.weight":
+            if k == "lm_head.weight" and self.config.text_config.tie_word_embeddings:
                 continue
 
             if (

--- a/sglang_omni/models/qwen3_asr/mlx/model.py
+++ b/sglang_omni/models/qwen3_asr/mlx/model.py
@@ -1,0 +1,620 @@
+# SPDX-License-Identifier: MIT
+# Derived from mlx-audio Qwen3-ASR (Copyright 2025 Prince Canuma and contributors).
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, List, Optional, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+from mlx_lm.models.base import create_attention_mask, scaled_dot_product_attention
+
+from .config import AudioEncoderConfig, ModelConfig, TextConfig
+
+
+def _rope_safe(rope, x: mx.array, offset: int) -> mx.array:
+    """Apply RoPE, working around an mx.fast.rope bug.
+
+    For a 4D tensor (B, heads, L, dim) with L == 1 and B > 1, mx.fast.rope
+    (used by nn.RoPE) corrupts every batch row except the first. This only
+    bites batched single-token decode (batch generation); single-sequence
+    decode has B == 1 and is unaffected. Padding the sequence to length 2 and
+    slicing keeps the fast kernel while producing the exact correct result.
+    """
+    if x.ndim == 4 and x.shape[0] > 1 and x.shape[2] == 1:
+        x = mx.concatenate([x, mx.zeros_like(x)], axis=2)
+        return rope(x, offset=offset)[:, :, :1, :]
+    return rope(x, offset=offset)
+
+
+def _floor_div(a: mx.array, b: int) -> mx.array:
+    """Floor division matching Python semantics."""
+    return mx.floor(a.astype(mx.float32) / b).astype(mx.int32)
+
+
+def _get_feat_extract_output_lengths(input_lengths: mx.array) -> mx.array:
+    """Compute output length of the convolutional layers."""
+    input_lengths_leave = input_lengths % 100
+    feat_lengths = _floor_div(input_lengths_leave - 1, 2) + 1
+    output_lengths = (
+        _floor_div(_floor_div(feat_lengths - 1, 2) + 1 - 1, 2)
+        + 1
+        + (input_lengths // 100) * 13
+    )
+    return output_lengths
+
+
+class SinusoidalPositionEmbedding(nn.Module):
+    """Sinusoidal position embeddings for the audio encoder."""
+
+    def __init__(self, length: int, channels: int, max_timescale: float = 10000.0):
+        super().__init__()
+        if channels % 2 != 0:
+            raise ValueError("SinusoidalPositionEmbedding needs even channels input")
+
+        log_timescale_increment = math.log(max_timescale) / (channels // 2 - 1)
+        inv_timescales = mx.exp(
+            -log_timescale_increment * mx.arange(channels // 2, dtype=mx.float32)
+        )
+        positions = mx.arange(length, dtype=mx.float32)[:, None]
+        scaled_time = positions * inv_timescales[None, :]
+        self._positional_embedding = mx.concatenate(
+            [mx.sin(scaled_time), mx.cos(scaled_time)], axis=1
+        )
+        mx.eval(self._positional_embedding)
+
+    def __call__(self, seqlen: int) -> mx.array:
+        return self._positional_embedding[:seqlen, :]
+
+
+class AudioAttention(nn.Module):
+    """Multi-headed attention for audio encoder."""
+
+    def __init__(self, config: AudioEncoderConfig):
+        super().__init__()
+        self.embed_dim = config.d_model
+        self.num_heads = config.encoder_attention_heads
+        self.head_dim = self.embed_dim // self.num_heads
+        self.scaling = self.head_dim**-0.5
+
+        if (self.head_dim * self.num_heads) != self.embed_dim:
+            raise ValueError(
+                f"embed_dim must be divisible by num_heads (got embed_dim={self.embed_dim}"
+                f" and num_heads={self.num_heads})."
+            )
+
+        self.q_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=True)
+        self.k_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=True)
+        self.v_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=True)
+        self.out_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=True)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        bsz, seq_len, _ = hidden_states.shape
+
+        query_states = self.q_proj(hidden_states) * self.scaling
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+        query_states = query_states.reshape(
+            bsz, seq_len, self.num_heads, self.head_dim
+        ).transpose(0, 2, 1, 3)
+        key_states = key_states.reshape(
+            bsz, seq_len, self.num_heads, self.head_dim
+        ).transpose(0, 2, 1, 3)
+        value_states = value_states.reshape(
+            bsz, seq_len, self.num_heads, self.head_dim
+        ).transpose(0, 2, 1, 3)
+
+        attn_output = mx.fast.scaled_dot_product_attention(
+            query_states, key_states, value_states, scale=1.0, mask=mask
+        )
+
+        attn_output = attn_output.transpose(0, 2, 1, 3).reshape(
+            bsz, seq_len, self.embed_dim
+        )
+        return self.out_proj(attn_output)
+
+
+class AudioEncoderLayer(nn.Module):
+    """A single transformer encoder layer for audio."""
+
+    def __init__(self, config: AudioEncoderConfig):
+        super().__init__()
+        self.embed_dim = config.d_model
+        self.self_attn = AudioAttention(config)
+        self.self_attn_layer_norm = nn.LayerNorm(self.embed_dim)
+        self.fc1 = nn.Linear(self.embed_dim, config.encoder_ffn_dim)
+        self.fc2 = nn.Linear(config.encoder_ffn_dim, self.embed_dim)
+        self.final_layer_norm = nn.LayerNorm(self.embed_dim)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        residual = hidden_states
+        hidden_states = self.self_attn_layer_norm(hidden_states)
+        hidden_states = self.self_attn(hidden_states, mask=mask)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.final_layer_norm(hidden_states)
+        hidden_states = nn.gelu(self.fc1(hidden_states))
+        hidden_states = self.fc2(hidden_states)
+        hidden_states = residual + hidden_states
+
+        return hidden_states
+
+
+class AudioEncoder(nn.Module):
+    """Qwen3-ASR Audio Encoder with Conv2d frontend and transformer layers."""
+
+    def __init__(self, config: AudioEncoderConfig):
+        super().__init__()
+        self.config = config
+        embed_dim = config.d_model
+        self.num_mel_bins = config.num_mel_bins
+        self.max_source_positions = config.max_source_positions
+        self.embed_scale = math.sqrt(embed_dim) if config.scale_embedding else 1.0
+        self.n_window = config.n_window
+        self.n_window_infer = config.n_window_infer
+        self.conv_chunksize = config.conv_chunksize
+
+        self.conv2d1 = nn.Conv2d(
+            1, config.downsample_hidden_size, kernel_size=3, stride=2, padding=1
+        )
+        self.conv2d2 = nn.Conv2d(
+            config.downsample_hidden_size,
+            config.downsample_hidden_size,
+            kernel_size=3,
+            stride=2,
+            padding=1,
+        )
+        self.conv2d3 = nn.Conv2d(
+            config.downsample_hidden_size,
+            config.downsample_hidden_size,
+            kernel_size=3,
+            stride=2,
+            padding=1,
+        )
+
+        freq_after_conv = ((((config.num_mel_bins + 1) // 2) + 1) // 2 + 1) // 2
+        self.conv_out = nn.Linear(
+            config.downsample_hidden_size * freq_after_conv, embed_dim, bias=False
+        )
+        self.positional_embedding = SinusoidalPositionEmbedding(
+            self.max_source_positions, embed_dim
+        )
+        self.layers = [AudioEncoderLayer(config) for _ in range(config.encoder_layers)]
+        self.ln_post = nn.LayerNorm(embed_dim)
+        self.proj1 = nn.Linear(embed_dim, embed_dim)
+        self.proj2 = nn.Linear(embed_dim, config.output_dim)
+
+    def _create_block_attention_mask(
+        self, seq_len: int, cu_seqlens: List[int], dtype: mx.Dtype
+    ) -> mx.array:
+        """Create attention mask for ragged/block attention."""
+        mask = mx.full((seq_len, seq_len), -1e9, dtype=dtype)
+        for i in range(len(cu_seqlens) - 1):
+            start = cu_seqlens[i]
+            end = cu_seqlens[i + 1]
+            mask[start:end, start:end] = 0.0
+        return mask
+
+    def __call__(
+        self,
+        input_features: mx.array,
+        feature_attention_mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        if feature_attention_mask is not None:
+            feature_lens = feature_attention_mask.sum(axis=-1).astype(mx.int32)
+        else:
+            feature_lens = mx.array(
+                [input_features.shape[-1]] * input_features.shape[0], dtype=mx.int32
+            )
+
+        feature_lens_np = np.array(feature_lens)
+        aftercnn_lens = _get_feat_extract_output_lengths(feature_lens)
+        chunk_size = self.n_window * 2
+        chunk_num = np.ceil(feature_lens_np / chunk_size).astype(np.int32)
+
+        chunk_lengths = []
+        for i in range(len(feature_lens_np)):
+            num_chunks = int(chunk_num[i])
+            feat_len = int(feature_lens_np[i])
+            for j in range(num_chunks):
+                if j == num_chunks - 1:
+                    remainder = feat_len % chunk_size
+                    chunk_lengths.append(chunk_size if remainder == 0 else remainder)
+                else:
+                    chunk_lengths.append(chunk_size)
+
+        chunk_lengths = np.array(chunk_lengths, dtype=np.int32)
+
+        chunks = []
+        for i in range(len(feature_lens_np)):
+            feat = input_features[i]
+            feat_len = int(feature_lens_np[i])
+            num_chunks = int(chunk_num[i])
+            pos = 0
+            for j in range(num_chunks):
+                if j == num_chunks - 1:
+                    remainder = feat_len % chunk_size
+                    clen = chunk_size if remainder == 0 else remainder
+                else:
+                    clen = chunk_size
+                chunk = feat[:, pos : pos + clen]
+                chunks.append(chunk)
+                pos += clen
+
+        max_chunk_len = int(max(chunk_lengths))
+        padded_chunks = []
+        for i, chunk in enumerate(chunks):
+            clen = int(chunk_lengths[i])
+            if clen < max_chunk_len:
+                pad_width = max_chunk_len - clen
+                chunk = mx.pad(chunk, [(0, 0), (0, pad_width)])
+            padded_chunks.append(chunk)
+
+        padded_feature = mx.stack(padded_chunks, axis=0)
+
+        feature_lens_after_cnn = _get_feat_extract_output_lengths(
+            mx.array(chunk_lengths)
+        )
+        feature_lens_after_cnn_np = np.array(feature_lens_after_cnn)
+        max_len_after_cnn = int(feature_lens_after_cnn_np.max())
+
+        x = padded_feature[:, :, :, None]
+        x = nn.gelu(self.conv2d1(x))
+        x = nn.gelu(self.conv2d2(x))
+        x = nn.gelu(self.conv2d3(x))
+
+        b, f, t, c = x.shape
+        x = x.transpose(0, 2, 3, 1).reshape(b, t, c * f)
+        x = self.conv_out(x)
+
+        pos_emb = self.positional_embedding(x.shape[1])
+        x = x + pos_emb[None, :, :]
+
+        hidden_list = []
+        for i in range(x.shape[0]):
+            valid_len = int(feature_lens_after_cnn_np[i])
+            hidden_list.append(x[i, :valid_len])
+
+        hidden_states = mx.concatenate(hidden_list, axis=0)
+
+        aftercnn_lens_np = np.array(aftercnn_lens)
+        window_aftercnn = max_len_after_cnn * (
+            self.n_window_infer // (self.n_window * 2)
+        )
+
+        cu_chunk_lens = [0]
+        for cnn_len in aftercnn_lens_np:
+            cnn_len = int(cnn_len)
+            num_full_windows = cnn_len // window_aftercnn
+            for _ in range(num_full_windows):
+                cu_chunk_lens.append(window_aftercnn)
+            remainder = cnn_len % window_aftercnn
+            if remainder != 0:
+                cu_chunk_lens.append(remainder)
+
+        cu_seqlens = np.cumsum(cu_chunk_lens).tolist()
+
+        seq_len = hidden_states.shape[0]
+        attention_mask = self._create_block_attention_mask(
+            seq_len, cu_seqlens, hidden_states.dtype
+        )
+        attention_mask = attention_mask[None, None, :, :]
+
+        hidden_states = hidden_states[None, :, :]
+
+        for layer in self.layers:
+            hidden_states = layer(hidden_states, mask=attention_mask)
+
+        hidden_states = hidden_states[0]
+        hidden_states = self.ln_post(hidden_states)
+        hidden_states = nn.gelu(self.proj1(hidden_states))
+        hidden_states = self.proj2(hidden_states)
+
+        return hidden_states
+
+
+class TextAttention(nn.Module):
+    """Multi-headed attention for text decoder with Q/K norms."""
+
+    def __init__(self, config: TextConfig, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = config.num_key_value_heads
+        self.head_dim = config.head_dim
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(
+            config.hidden_size, self.num_heads * self.head_dim, bias=False
+        )
+        self.k_proj = nn.Linear(
+            config.hidden_size, self.num_kv_heads * self.head_dim, bias=False
+        )
+        self.v_proj = nn.Linear(
+            config.hidden_size, self.num_kv_heads * self.head_dim, bias=False
+        )
+        self.o_proj = nn.Linear(
+            self.num_heads * self.head_dim, config.hidden_size, bias=False
+        )
+
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.rope = nn.RoPE(self.head_dim, traditional=False, base=config.rope_theta)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        mask: Optional[Union[str, mx.array]] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, _ = hidden_states.shape
+
+        queries = self.q_proj(hidden_states)
+        keys = self.k_proj(hidden_states)
+        values = self.v_proj(hidden_states)
+
+        queries = queries.reshape(B, L, self.num_heads, self.head_dim)
+        keys = keys.reshape(B, L, self.num_kv_heads, self.head_dim)
+        values = values.reshape(B, L, self.num_kv_heads, self.head_dim)
+
+        queries = self.q_norm(queries)
+        keys = self.k_norm(keys)
+
+        queries = queries.transpose(0, 2, 1, 3)
+        keys = keys.transpose(0, 2, 1, 3)
+        values = values.transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            offset = cache.offset
+            queries = _rope_safe(self.rope, queries, offset)
+            keys = _rope_safe(self.rope, keys, offset)
+        else:
+            offset = 0
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        if cache is not None:
+            keys, values = cache.update_and_fetch(keys, values)
+
+        query_len = queries.shape[2]
+        output = scaled_dot_product_attention(
+            queries,
+            keys,
+            values,
+            cache=cache,
+            scale=self.scale,
+            mask=mask,
+        )
+
+        output = output.transpose(0, 2, 1, 3).reshape(B, query_len, -1)
+        return self.o_proj(output)
+
+
+class TextMLP(nn.Module):
+    """MLP for text decoder with SwiGLU activation."""
+
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.gate_proj = nn.Linear(
+            config.hidden_size, config.intermediate_size, bias=False
+        )
+        self.up_proj = nn.Linear(
+            config.hidden_size, config.intermediate_size, bias=False
+        )
+        self.down_proj = nn.Linear(
+            config.intermediate_size, config.hidden_size, bias=False
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class TextDecoderLayer(nn.Module):
+    """A single transformer decoder layer."""
+
+    def __init__(self, config: TextConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.self_attn = TextAttention(config, layer_idx)
+        self.mlp = TextMLP(config)
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        mask: Optional[Union[str, mx.array]] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(hidden_states, mask=mask, cache=cache)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        return hidden_states
+
+
+class TextModel(nn.Module):
+    """Text decoder model (Qwen3-based)."""
+
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.config = config
+        self.vocab_size = config.vocab_size
+        self.num_hidden_layers = config.num_hidden_layers
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [
+            TextDecoderLayer(config, i) for i in range(config.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def __call__(
+        self,
+        input_ids: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        cache: Optional[List[Any]] = None,
+    ) -> mx.array:
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        hidden_states = inputs_embeds
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+        mask = create_attention_mask(hidden_states, cache[0])
+
+        for i, layer in enumerate(self.layers):
+            hidden_states = layer(hidden_states, mask=mask, cache=cache[i])
+
+        return self.norm(hidden_states)
+
+
+class Qwen3ASRModel(nn.Module):
+    """Qwen3-ASR Model for speech recognition."""
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.vocab_size = config.text_config.vocab_size
+        self.audio_tower = AudioEncoder(config.audio_config)
+        self.model = TextModel(config.text_config)
+
+        if config.text_config.tie_word_embeddings:
+            self.lm_head = None
+        else:
+            self.lm_head = nn.Linear(
+                config.text_config.hidden_size,
+                config.text_config.vocab_size,
+                bias=False,
+            )
+
+    def get_audio_features(
+        self,
+        input_features: mx.array,
+        feature_attention_mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        """Encode audio features."""
+        return self.audio_tower(input_features, feature_attention_mask)
+
+    def _build_inputs_embeds(
+        self,
+        input_ids: mx.array,
+        audio_features: mx.array,
+        *,
+        audio_start: int,
+        num_audio_tokens: int,
+    ) -> mx.array:
+        """Build input embeddings with audio features merged in."""
+        inputs_embeds = self.model.embed_tokens(input_ids)
+        audio_features = audio_features.astype(inputs_embeds.dtype)
+        if num_audio_tokens != audio_features.shape[0]:
+            raise ValueError(
+                "Qwen3-ASR audio placeholder and feature counts differ: "
+                f"{num_audio_tokens} placeholders, {audio_features.shape[0]} features"
+            )
+        if input_ids.shape[0] != 1:
+            raise ValueError("Qwen3-ASR MLX audio prefill supports one request")
+        audio_end = audio_start + num_audio_tokens
+        if audio_start < 0 or audio_end > input_ids.shape[1]:
+            raise ValueError(
+                f"Qwen3-ASR audio span [{audio_start}, {audio_end}) is out of bounds"
+            )
+
+        inputs_embeds[0, audio_start:audio_end, :] = audio_features
+        return inputs_embeds
+
+    def _forward_last_logits(
+        self,
+        inputs_embeds: mx.array,
+        cache: Optional[List[Any]] = None,
+    ) -> mx.array:
+        hidden_states = self.model(inputs_embeds=inputs_embeds, cache=cache)[:, -1:, :]
+
+        if self.lm_head is not None:
+            logits = self.lm_head(hidden_states)
+        else:
+            logits = self.model.embed_tokens.as_linear(hidden_states)
+
+        return logits
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        input_embeddings: Optional[mx.array] = None,
+        cache: Optional[List[Any]] = None,
+    ) -> mx.array:
+        if input_embeddings is None:
+            inputs_embeds = self.model.embed_tokens(input_ids)
+        else:
+            inputs_embeds = input_embeddings
+
+        hidden_states = self.model(inputs_embeds=inputs_embeds, cache=cache)
+
+        if self.lm_head is not None:
+            logits = self.lm_head(hidden_states)
+        else:
+            logits = self.model.embed_tokens.as_linear(hidden_states)
+
+        return logits
+
+    def make_cache(self) -> List[Any]:
+        """Create KV cache for generation."""
+        from mlx_lm.models.cache import KVCache
+
+        return [KVCache() for _ in range(self.config.text_config.num_hidden_layers)]
+
+    @staticmethod
+    def sanitize(weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        """Sanitize weights from HuggingFace/PyTorch format to MLX format."""
+        sanitized = {}
+        is_formatted = not any(k.startswith("thinker.") for k in weights.keys())
+
+        for k, v in weights.items():
+            if k.startswith("thinker."):
+                k = k[len("thinker.") :]
+
+            if k == "lm_head.weight":
+                continue
+
+            if (
+                not is_formatted
+                and "conv2d" in k
+                and "weight" in k
+                and len(v.shape) == 4
+            ):
+                v = v.transpose(0, 2, 3, 1)
+
+            sanitized[k] = v
+
+        return sanitized
+
+    def model_quant_predicate(self, p: str, m: nn.Module) -> bool:
+        """Determine which layers to quantize."""
+        return not p.startswith("audio_tower")
+
+
+Model = Qwen3ASRModel
+ModelArgs = ModelConfig

--- a/sglang_omni/models/qwen3_asr/mlx/runner.py
+++ b/sglang_omni/models/qwen3_asr/mlx/runner.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import mlx.core as mx
+import torch
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +64,10 @@ class Qwen3ASRMlxModelRunner:
 
     @staticmethod
     def _to_numpy(tensor: Any) -> Any:
-        return tensor.detach().cpu().numpy()
+        tensor = tensor.detach().cpu()
+        if tensor.dtype == torch.bfloat16:
+            tensor = tensor.float()
+        return tensor.numpy()
 
     @staticmethod
     def _normalize_audio_token_ids(req: Any, token_ids: list[int]) -> list[int]:
@@ -123,6 +127,9 @@ class Qwen3ASRMlxModelRunner:
         new_slot_ids: list[int],
         req_pool_idx: int,
         req: Any | None = None,
+        needs_logits: bool = True,
+        logit_edit_row: mx.array | None = None,
+        logprob_spec: Any = None,
     ):
         from sglang.srt.hardware_backend.mlx.model_runner import MlxPendingPrefill
 
@@ -136,10 +143,17 @@ class Qwen3ASRMlxModelRunner:
             raise RuntimeError(
                 "Qwen3-ASR MLX Stage A requires disable_radix_cache=True"
             )
+        if logit_edit_row is not None or logprob_spec is not None:
+            raise NotImplementedError(
+                "Qwen3-ASR MLX audio prefill supports greedy decoding only"
+            )
 
         input_ids, input_embeddings = self._audio_prefill_inputs(req, new_token_ids)
         cache = self._acquire_cache()
         logits = self.model._forward_last_logits(input_embeddings, cache=cache)
+        # note (yexiaodong): Chunked prefill is disabled for this audio path, so
+        # needs_logits is always true; retain the argument for the SGLang API.
+        del needs_logits
         lazy_token = mx.argmax(logits[:, -1, :], axis=-1)
         return MlxPendingPrefill(
             lazy_token=lazy_token,
@@ -150,11 +164,28 @@ class Qwen3ASRMlxModelRunner:
             full_token_ids=self._normalize_audio_token_ids(req, full_token_ids),
             req_pool_idx=req_pool_idx,
             synced_offset=0,
+            lazy_logprobs=None,
         )
 
-    def decode_batch_start(self, req_ids: list[str]):
-        if len(req_ids) != 1:
-            return super().decode_batch_start(req_ids)
+    def decode_batch_start(
+        self,
+        req_ids: list[str],
+        edit_rows: mx.array | None = None,
+        logprob_spec: Any = None,
+        logits_hook: Any = None,
+    ):
+        if (
+            len(req_ids) != 1
+            or edit_rows is not None
+            or logprob_spec is not None
+            or logits_hook is not None
+        ):
+            return super().decode_batch_start(
+                req_ids,
+                edit_rows=edit_rows,
+                logprob_spec=logprob_spec,
+                logits_hook=logits_hook,
+            )
 
         from sglang.srt.hardware_backend.mlx.model_runner import MlxPendingDecode
 
@@ -164,32 +195,44 @@ class Qwen3ASRMlxModelRunner:
             [[self._req_token_ids[req_id][-1]]],
             dtype=mx.int32,
         )
-        lazy_tokens = self._decode_with_native_cache([cache], [input_ids])
+        lazy_logits = self._decode_with_native_cache([cache], [input_ids])
+        lazy_tokens = mx.argmax(lazy_logits, axis=-1)
         return MlxPendingDecode(
             lazy_tokens=lazy_tokens,
             req_ids=[req_id],
             caches=[cache],
+            lazy_logprobs=None,
+            logprob_spec=None,
+            edit_rows=None,
         )
 
     def decode_batch_start_chained(self, prev):
-        if len(prev.req_ids) != 1:
+        if (
+            len(prev.req_ids) != 1
+            or prev.edit_rows is not None
+            or prev.logprob_spec is not None
+        ):
             return super().decode_batch_start_chained(prev)
 
         from sglang.srt.hardware_backend.mlx.model_runner import MlxPendingDecode
 
-        lazy_tokens = self._decode_with_native_cache(
+        lazy_logits = self._decode_with_native_cache(
             prev.caches,
             [prev.lazy_tokens[:, None]],
         )
+        lazy_tokens = mx.argmax(lazy_logits, axis=-1)
         return MlxPendingDecode(
             lazy_tokens=lazy_tokens,
             req_ids=prev.req_ids,
             caches=prev.caches,
+            lazy_logprobs=None,
+            logprob_spec=None,
+            edit_rows=None,
         )
 
 
 def make_qwen3_asr_mlx_runner_class():
-    """Build the extension class lazily so non-Apple imports need no MLX."""
+    """Build the extension class after the MLX backend has been selected."""
     from sglang.srt.hardware_backend.mlx.model_runner import MlxModelRunner
 
     class Qwen3ASRMlxRunner(Qwen3ASRMlxModelRunner, MlxModelRunner):

--- a/sglang_omni/models/qwen3_asr/mlx/runner.py
+++ b/sglang_omni/models/qwen3_asr/mlx/runner.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SGLang MLX runner extension for Qwen3-ASR audio prefill."""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_model_path(model_path: str) -> Path:
+    path = Path(model_path).expanduser()
+    if path.is_dir():
+        return path.resolve()
+
+    from huggingface_hub import snapshot_download
+
+    return Path(snapshot_download(model_path))
+
+
+class Qwen3ASRMlxModelRunner:
+    """Qwen3-ASR support layered on SGLang's native MLX model runner.
+
+    The base runner continues to own cache layout, pool sizing, radix state,
+    and batched decode. This mixin only supplies the unsupported Qwen3-ASR
+    model class and the multimodal first-prefill operation.
+    """
+
+    def _load_model(self) -> None:
+        from mlx_lm.utils import load_model
+
+        from .config import ModelConfig
+        from .model import Qwen3ASRModel
+
+        model_path = _resolve_model_path(self.model_path)
+        logger.info("Loading native MLX Qwen3-ASR model: %s", model_path)
+        started = time.perf_counter()
+        self.model, _config = load_model(
+            model_path,
+            get_model_classes=lambda config: (Qwen3ASRModel, ModelConfig),
+        )
+        logger.info(
+            "Loaded native MLX Qwen3-ASR model in %.2fs",
+            time.perf_counter() - started,
+        )
+
+    @staticmethod
+    def _audio_item(req: Any) -> Any:
+        mm_inputs = req.multimodal_inputs
+        if mm_inputs is None:
+            raise ValueError("Qwen3-ASR MLX prefill requires multimodal inputs")
+        if len(mm_inputs.mm_items) != 1:
+            raise ValueError(
+                "Qwen3-ASR MLX prefill requires exactly one audio item, got "
+                f"{len(mm_inputs.mm_items)}"
+            )
+        return mm_inputs.mm_items[0]
+
+    @staticmethod
+    def _to_numpy(tensor: Any) -> Any:
+        return tensor.detach().cpu().numpy()
+
+    @staticmethod
+    def _normalize_audio_token_ids(req: Any, token_ids: list[int]) -> list[int]:
+        item = Qwen3ASRMlxModelRunner._audio_item(req)
+        mm_inputs = req.multimodal_inputs
+        if mm_inputs.audio_token_id is None or item.pad_value is None:
+            raise ValueError(
+                "Qwen3-ASR MLX prefill has incomplete audio token metadata"
+            )
+        audio_token_id = int(mm_inputs.audio_token_id)
+        pad_value = int(item.pad_value)
+        return [
+            audio_token_id if int(token_id) == pad_value else int(token_id)
+            for token_id in token_ids
+        ]
+
+    def _audio_prefill_inputs(
+        self, req: Any, token_ids: list[int]
+    ) -> tuple[mx.array, mx.array]:
+        item = self._audio_item(req)
+        if item.feature is None or item.feature_attention_mask is None:
+            raise ValueError("Qwen3-ASR MLX prefill requires audio features and mask")
+
+        normalized_ids = self._normalize_audio_token_ids(req, token_ids)
+        audio_token_id = int(req.multimodal_inputs.audio_token_id)
+        audio_positions = [
+            index
+            for index, token_id in enumerate(normalized_ids)
+            if token_id == audio_token_id
+        ]
+        if not audio_positions:
+            raise ValueError("Qwen3-ASR MLX prefill has no audio placeholders")
+        audio_start = audio_positions[0]
+        num_audio_tokens = len(audio_positions)
+        if audio_positions != list(range(audio_start, audio_start + num_audio_tokens)):
+            raise ValueError("Qwen3-ASR MLX audio placeholders must be contiguous")
+        input_ids = mx.array([normalized_ids], dtype=mx.int32)
+        input_features = mx.array(self._to_numpy(item.feature))
+        feature_attention_mask = mx.array(self._to_numpy(item.feature_attention_mask))
+        audio_features = self.model.get_audio_features(
+            input_features, feature_attention_mask
+        )
+        input_embeddings = self.model._build_inputs_embeds(
+            input_ids,
+            audio_features,
+            audio_start=audio_start,
+            num_audio_tokens=num_audio_tokens,
+        )
+        return input_ids, input_embeddings
+
+    def prefill_start(
+        self,
+        req_id: str,
+        new_token_ids: list[int],
+        full_token_ids: list[int],
+        prefix_slot_ids: list[int],
+        new_slot_ids: list[int],
+        req_pool_idx: int,
+        req: Any | None = None,
+    ):
+        from sglang.srt.hardware_backend.mlx.model_runner import MlxPendingPrefill
+
+        if req is None:
+            raise ValueError("Qwen3-ASR MLX prefill requires its scheduler request")
+        if prefix_slot_ids:
+            raise NotImplementedError(
+                "Qwen3-ASR MLX audio prefill does not support a radix prefix yet"
+            )
+        if not self.disable_radix_cache:
+            raise RuntimeError(
+                "Qwen3-ASR MLX Stage A requires disable_radix_cache=True"
+            )
+
+        input_ids, input_embeddings = self._audio_prefill_inputs(req, new_token_ids)
+        cache = self._acquire_cache()
+        logits = self.model._forward_last_logits(input_embeddings, cache=cache)
+        lazy_token = mx.argmax(logits[:, -1, :], axis=-1)
+        return MlxPendingPrefill(
+            lazy_token=lazy_token,
+            cache=cache,
+            req_id=req_id,
+            # note (yexiaodong): Later decode bookkeeping requires real model
+            # token IDs instead of Omni's out-of-vocabulary audio placeholder.
+            full_token_ids=self._normalize_audio_token_ids(req, full_token_ids),
+            req_pool_idx=req_pool_idx,
+            synced_offset=0,
+        )
+
+    def decode_batch_start(self, req_ids: list[str]):
+        if len(req_ids) != 1:
+            return super().decode_batch_start(req_ids)
+
+        from sglang.srt.hardware_backend.mlx.model_runner import MlxPendingDecode
+
+        req_id = req_ids[0]
+        cache = self._req_caches[req_id]
+        input_ids = mx.array(
+            [[self._req_token_ids[req_id][-1]]],
+            dtype=mx.int32,
+        )
+        lazy_tokens = self._decode_with_native_cache([cache], [input_ids])
+        return MlxPendingDecode(
+            lazy_tokens=lazy_tokens,
+            req_ids=[req_id],
+            caches=[cache],
+        )
+
+    def decode_batch_start_chained(self, prev):
+        if len(prev.req_ids) != 1:
+            return super().decode_batch_start_chained(prev)
+
+        from sglang.srt.hardware_backend.mlx.model_runner import MlxPendingDecode
+
+        lazy_tokens = self._decode_with_native_cache(
+            prev.caches,
+            [prev.lazy_tokens[:, None]],
+        )
+        return MlxPendingDecode(
+            lazy_tokens=lazy_tokens,
+            req_ids=prev.req_ids,
+            caches=prev.caches,
+        )
+
+
+def make_qwen3_asr_mlx_runner_class():
+    """Build the extension class lazily so non-Apple imports need no MLX."""
+    from sglang.srt.hardware_backend.mlx.model_runner import MlxModelRunner
+
+    class Qwen3ASRMlxRunner(Qwen3ASRMlxModelRunner, MlxModelRunner):
+        pass
+
+    return Qwen3ASRMlxRunner

--- a/sglang_omni/models/qwen3_asr/mlx/runner.py
+++ b/sglang_omni/models/qwen3_asr/mlx/runner.py
@@ -5,23 +5,12 @@ from __future__ import annotations
 
 import logging
 import time
-from pathlib import Path
 from typing import Any
 
 import mlx.core as mx
 import torch
 
 logger = logging.getLogger(__name__)
-
-
-def _resolve_model_path(model_path: str) -> Path:
-    path = Path(model_path).expanduser()
-    if path.is_dir():
-        return path.resolve()
-
-    from huggingface_hub import snapshot_download
-
-    return Path(snapshot_download(model_path))
 
 
 class Qwen3ASRMlxModelRunner:
@@ -34,11 +23,19 @@ class Qwen3ASRMlxModelRunner:
 
     def _load_model(self) -> None:
         from mlx_lm.utils import load_model
+        from sglang.srt.hardware_backend.mlx.remote_code_gate import (
+            ensure_remote_code_allowed,
+            resolve_model_directory,
+        )
 
         from .config import ModelConfig
         from .model import Qwen3ASRModel
 
-        model_path = _resolve_model_path(self.model_path)
+        model_path = resolve_model_directory(
+            self.model_path,
+            revision=self.revision,
+        )
+        ensure_remote_code_allowed(model_path, self.trust_remote_code)
         logger.info("Loading native MLX Qwen3-ASR model: %s", model_path)
         started = time.perf_counter()
         self.model, _config = load_model(

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -114,6 +114,7 @@ def make_qwen3_asr_scheduler_adapters(
     context_length: int | None = None,
     audio_encoder_service: Any = None,
     should_wait_for_encode: Callable[[], bool] | None = None,
+    greedy_only: bool = False,
 ) -> tuple[
     Callable[[StagePayload], Qwen3ASRRequestData | DeferredAdmission],
     Callable[[Any], StagePayload],
@@ -336,6 +337,11 @@ def make_qwen3_asr_scheduler_adapters(
         setattr(mm_inputs, mrope_fast_path.DEGENERATE_MROPE_FLAG, True)
 
         temperature = float(params.get("temperature") or 0.0)
+        if greedy_only and temperature != 0.0:
+            raise ValueError(
+                "Qwen3-ASR Apple backend currently supports only greedy decoding; "
+                "set temperature=0"
+            )
         logger.debug(
             f"[qwen3-asr] sampling temp={temperature} "
             f"max_new_tokens={request_max_new_tokens} params={dict(params)}"

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -179,6 +179,12 @@ def make_qwen3_asr_scheduler_adapters(
         payload: StagePayload,
     ) -> Qwen3ASRRequestData | DeferredAdmission:
         params = payload.request.params or {}
+        temperature = float(params.get("temperature") or 0.0)
+        if greedy_only and temperature != 0.0:
+            raise ValueError(
+                "Qwen3-ASR Apple backend currently supports only greedy decoding; "
+                "set temperature=0"
+            )
         language = params.get("language")
         requested_language = None if language is None else str(language)
         forced_language = (
@@ -336,12 +342,6 @@ def make_qwen3_asr_scheduler_adapters(
         # (mrope_fast_path.py) can skip the per-request position loop for it.
         setattr(mm_inputs, mrope_fast_path.DEGENERATE_MROPE_FLAG, True)
 
-        temperature = float(params.get("temperature") or 0.0)
-        if greedy_only and temperature != 0.0:
-            raise ValueError(
-                "Qwen3-ASR Apple backend currently supports only greedy decoding; "
-                "set temperature=0"
-            )
         logger.debug(
             f"[qwen3-asr] sampling temp={temperature} "
             f"max_new_tokens={request_max_new_tokens} params={dict(params)}"

--- a/sglang_omni/models/qwen3_asr/torch_mps_runner.py
+++ b/sglang_omni/models/qwen3_asr/torch_mps_runner.py
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Torch MPS runner for Qwen3-ASR."""
+
+from __future__ import annotations
+
+import gc
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors import safe_open
+from transformers import Qwen3Config, Qwen3ForCausalLM
+
+from sglang_omni.model_runner.base import ModelRunner
+
+logger = logging.getLogger(__name__)
+
+_MROPE_ONLY_KEYS = frozenset({"interleaved", "mrope_interleaved", "mrope_section"})
+
+
+def _resolve_model_path(model_path: str) -> Path:
+    path = Path(model_path).expanduser()
+    if path.is_dir():
+        return path.resolve()
+
+    from huggingface_hub import snapshot_download
+
+    return Path(snapshot_download(model_path))
+
+
+def _text_config(model_path: Path) -> Qwen3Config:
+    root_config = json.loads((model_path / "config.json").read_text())
+    text_config = dict(root_config["thinker_config"]["text_config"])
+    for field in ("rope_parameters", "rope_scaling"):
+        rope_config = text_config.get(field)
+        if isinstance(rope_config, dict):
+            text_config[field] = {
+                key: value
+                for key, value in rope_config.items()
+                if key not in _MROPE_ONLY_KEYS
+            }
+    return Qwen3Config(**text_config)
+
+
+def _load_language_weights(
+    language_model: Qwen3ForCausalLM,
+    model_path: Path,
+) -> None:
+    expected = set(language_model.state_dict())
+    state_dict = {}
+    weight_files = sorted(model_path.glob("*.safetensors"))
+    if not weight_files:
+        raise ValueError(f"Qwen3-ASR checkpoint has no safetensors in {model_path}")
+    for weight_file in weight_files:
+        with safe_open(weight_file, framework="pt", device="cpu") as f:
+            for checkpoint_name in f.keys():
+                if checkpoint_name.startswith(
+                    "thinker.model."
+                ) or checkpoint_name.startswith("thinker.lm_head."):
+                    model_name = checkpoint_name.removeprefix("thinker.")
+                    if model_name in expected:
+                        state_dict[model_name] = f.get_tensor(checkpoint_name)
+
+    missing = expected - set(state_dict)
+    if missing:
+        raise ValueError(
+            "Qwen3-ASR Torch MPS language checkpoint is incomplete: "
+            f"{sorted(missing)[:10]}"
+        )
+    language_model.load_state_dict(state_dict, strict=True, assign=True)
+
+    rotary = language_model.model.rotary_emb
+    rope_theta = float(language_model.config.rope_parameters["rope_theta"])
+    head_dim = int(language_model.config.head_dim)
+    inv_freq = 1.0 / (
+        rope_theta ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim)
+    )
+    rotary.inv_freq = inv_freq
+    rotary.original_inv_freq = inv_freq.clone()
+
+
+def install_torch_mps_language_model(model: Any, model_path: str) -> None:
+    """Replace SGLang's Torch-native LM with the pinned HF Torch implementation."""
+    checkpoint = _resolve_model_path(model_path)
+    old_parameter = next(model.language_model.parameters())
+    device = old_parameter.device
+    dtype = old_parameter.dtype
+
+    del model.language_model
+    gc.collect()
+    torch.mps.empty_cache()
+
+    with torch.device("meta"):
+        language_model = Qwen3ForCausalLM(_text_config(checkpoint))
+    _load_language_weights(language_model, checkpoint)
+    model.language_model = language_model.eval().to(device=device, dtype=dtype)
+    logger.info("Installed Qwen3-ASR Hugging Face Torch LM on %s (%s)", device, dtype)
+
+
+class Qwen3ASRTorchMpsModelRunner(ModelRunner):
+    """Run one Qwen3-ASR request through Torch audio and Hugging Face Qwen3."""
+
+    def __init__(self, tp_worker: Any, output_processor: Any):
+        super().__init__(tp_worker, output_processor)
+        self._past_key_values: dict[str, Any] = {}
+
+    def lookahead_eligible(self, batch: Any) -> bool:
+        del batch
+        return False
+
+    @staticmethod
+    def _one_request(requests: list[Any]) -> Any:
+        if len(requests) != 1:
+            raise RuntimeError(
+                "Qwen3-ASR Torch MPS currently requires max_running_requests=1"
+            )
+        return requests[0]
+
+    def _next_token_result(self, next_token_ids: torch.Tensor) -> Any:
+        from sglang.srt.managers.scheduler import GenerationBatchResult
+
+        return GenerationBatchResult(
+            logits_output=None,
+            next_token_ids=next_token_ids,
+            can_run_cuda_graph=False,
+        )
+
+    @torch.inference_mode()
+    def custom_prefill_forward(
+        self,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list[Any],
+    ) -> Any:
+        del forward_batch
+        scheduler_request = self._one_request(requests)
+        req = scheduler_request.data.req
+        mm_inputs = req.multimodal_inputs
+        if mm_inputs is None or len(mm_inputs.mm_items) != 1:
+            raise ValueError("Qwen3-ASR Torch MPS requires exactly one audio item")
+        item = mm_inputs.mm_items[0]
+        if item.feature is None or item.pad_value is None:
+            raise ValueError(
+                "Qwen3-ASR Torch MPS requires audio features and pad value"
+            )
+        if mm_inputs.audio_token_id is None:
+            raise ValueError("Qwen3-ASR Torch MPS is missing its audio token ID")
+
+        token_ids = [int(token_id) for token_id in schedule_batch.input_ids.tolist()]
+        pad_value = int(item.pad_value)
+        audio_token_id = int(mm_inputs.audio_token_id)
+        normalized_ids = [
+            audio_token_id if token_id == pad_value else token_id
+            for token_id in token_ids
+        ]
+        audio_positions = [
+            index
+            for index, token_id in enumerate(normalized_ids)
+            if token_id == audio_token_id
+        ]
+        if not audio_positions:
+            raise ValueError("Qwen3-ASR Torch MPS prefill has no audio placeholders")
+        audio_start = audio_positions[0]
+        if audio_positions != list(
+            range(audio_start, audio_start + len(audio_positions))
+        ):
+            raise ValueError(
+                "Qwen3-ASR Torch MPS audio placeholders must be contiguous"
+            )
+
+        language_model = self.model.language_model
+        input_ids = torch.tensor(
+            [normalized_ids],
+            dtype=torch.long,
+            device=self.device,
+        )
+        input_embeddings = language_model.model.embed_tokens(input_ids)
+        audio_features = self.model.get_audio_feature([item]).to(
+            device=self.device,
+            dtype=input_embeddings.dtype,
+        )
+        if audio_features.shape != (
+            1,
+            len(audio_positions),
+            input_embeddings.shape[-1],
+        ):
+            raise ValueError(
+                "Qwen3-ASR Torch MPS audio embedding shape does not match its "
+                f"placeholder span: {tuple(audio_features.shape)}"
+            )
+        input_embeddings[0, audio_start : audio_start + len(audio_positions), :] = (
+            audio_features[0]
+        )
+
+        output = language_model(
+            inputs_embeds=input_embeddings,
+            use_cache=True,
+            logits_to_keep=1,
+        )
+        self._past_key_values[scheduler_request.request_id] = output.past_key_values
+        return self._next_token_result(output.logits[:, -1, :].argmax(dim=-1))
+
+    @torch.inference_mode()
+    def custom_decode_forward(
+        self,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list[Any],
+    ) -> Any:
+        del forward_batch
+        scheduler_request = self._one_request(requests)
+        request_id = scheduler_request.request_id
+        try:
+            past_key_values = self._past_key_values[request_id]
+        except KeyError as exc:
+            raise RuntimeError(
+                f"Qwen3-ASR Torch MPS decode has no cache for {request_id}"
+            ) from exc
+
+        input_ids = schedule_batch.input_ids.reshape(1, 1).to(
+            device=self.device,
+            dtype=torch.long,
+        )
+        output = self.model.language_model(
+            input_ids=input_ids,
+            past_key_values=past_key_values,
+            use_cache=True,
+            logits_to_keep=1,
+        )
+        self._past_key_values[request_id] = output.past_key_values
+        return self._next_token_result(output.logits[:, -1, :].argmax(dim=-1))
+
+    def on_request_finished(self, request_id: str, req_data: Any) -> None:
+        del req_data
+        self._past_key_values.pop(request_id, None)
+
+    def abort_request(self, request_id: str) -> None:
+        self._past_key_values.pop(request_id, None)
+
+
+__all__ = [
+    "Qwen3ASRTorchMpsModelRunner",
+    "install_torch_mps_language_model",
+]

--- a/sglang_omni/models/qwen3_asr/torch_mps_runner.py
+++ b/sglang_omni/models/qwen3_asr/torch_mps_runner.py
@@ -72,7 +72,10 @@ def _load_language_weights(
     language_model.load_state_dict(state_dict, strict=True, assign=True)
 
     rotary = language_model.model.rotary_emb
-    rope_theta = float(language_model.config.rope_parameters["rope_theta"])
+    rope_config = language_model.config.rope_parameters
+    if not isinstance(rope_config, dict):
+        rope_config = language_model.config.rope_scaling
+    rope_theta = float(rope_config["rope_theta"])
     head_dim = int(language_model.config.head_dim)
     inv_freq = 1.0 / (
         rope_theta ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim)

--- a/sglang_omni/platforms/__init__.py
+++ b/sglang_omni/platforms/__init__.py
@@ -1,10 +1,12 @@
 import os
 import pkgutil
+import platform
 
 import torch
 from sglang.srt import platforms as srt_platforms
 from sglang.srt.platforms.interface import SRTPlatform
 
+from sglang_omni.platforms.apple import AppleOmniPlatform
 from sglang_omni.platforms.cpu import CPUOmniPlatform
 from sglang_omni.platforms.cuda import CUDAOmniPlatform
 from sglang_omni.platforms.interface import OmniPlatform
@@ -30,6 +32,13 @@ def _is_npu_available() -> bool:
     return bool(npu.is_available())
 
 
+def _is_apple_silicon_mps_available() -> bool:
+    return (
+        platform.system() == "Darwin"
+        and platform.machine() == "arm64"
+        and bool(torch.backends.mps.is_available())
+    )
+
 def _load_platform_class(qualname: str) -> type[OmniPlatform]:
     cls = pkgutil.resolve_name(qualname)
     if not isinstance(cls, type):
@@ -54,6 +63,10 @@ def _as_omni_platform(platform: SRTPlatform) -> OmniPlatform:
         return CPUOmniPlatform()
     if platform.is_xpu():
         return XPUOmniPlatform()
+    # note (yexiaodong): SGLang 0.5.18 leaves the MLX opt-in on its generic
+    # platform, so Apple detection must precede the generic plugin fallback.
+    if _is_apple_silicon_mps_available():
+        return AppleOmniPlatform()
     if type(platform) is SRTPlatform and _is_musa_available():
         return MUSAOmniPlatform()
     if type(platform) is SRTPlatform and _is_npu_available():

--- a/sglang_omni/platforms/__init__.py
+++ b/sglang_omni/platforms/__init__.py
@@ -1,6 +1,6 @@
 import os
 import pkgutil
-import platform
+import platform as host_platform
 
 import torch
 from sglang.srt import platforms as srt_platforms
@@ -34,10 +34,11 @@ def _is_npu_available() -> bool:
 
 def _is_apple_silicon_mps_available() -> bool:
     return (
-        platform.system() == "Darwin"
-        and platform.machine() == "arm64"
+        host_platform.system() == "Darwin"
+        and host_platform.machine() == "arm64"
         and bool(torch.backends.mps.is_available())
     )
+
 
 def _load_platform_class(qualname: str) -> type[OmniPlatform]:
     cls = pkgutil.resolve_name(qualname)
@@ -63,9 +64,9 @@ def _as_omni_platform(platform: SRTPlatform) -> OmniPlatform:
         return CPUOmniPlatform()
     if platform.is_xpu():
         return XPUOmniPlatform()
-    # note (yexiaodong): SGLang 0.5.18 leaves the MLX opt-in on its generic
-    # platform, so Apple detection must precede the generic plugin fallback.
-    if _is_apple_silicon_mps_available():
+    # note (yexiaodong): Explicit CPU and registered platform selections must
+    # win. SGLang otherwise leaves Apple Metal on its generic platform.
+    if type(platform) is SRTPlatform and _is_apple_silicon_mps_available():
         return AppleOmniPlatform()
     if type(platform) is SRTPlatform and _is_musa_available():
         return MUSAOmniPlatform()

--- a/sglang_omni/platforms/apple.py
+++ b/sglang_omni/platforms/apple.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Apple Silicon platform policy for PyTorch MPS and the opt-in MLX backend."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+import torch
+from sglang.srt.platforms.device_mixin import PlatformEnum
+
+from sglang_omni.platforms.interface import OmniPlatform
+
+if TYPE_CHECKING:
+    from sglang_omni.pipeline.stage_workers import StageLaunchConfig
+
+
+class AppleOmniPlatform(OmniPlatform):
+    """Single-device Apple Metal platform.
+
+    SGLang 0.5.16 enables its MLX runner through SGLANG_USE_MLX=1 but does
+    not register an MPS SRTPlatform. Omni still needs concrete device
+    operations because every accelerator-backed stage binds its scheduler
+    thread through current_platform.get_device and set_device.
+    """
+
+    _enum: PlatformEnum = PlatformEnum.MPS
+    device_name: str = "mps"
+    device_type: str = "mps"
+
+    @staticmethod
+    def _validate_device_id(device_id: int) -> None:
+        if int(device_id) != 0:
+            raise ValueError(
+                f"Apple Silicon exposes one Metal device, got device_id={device_id}"
+            )
+
+    def get_device(self, device_id: int = 0) -> torch.device:
+        self._validate_device_id(device_id)
+        return torch.device("mps")
+
+    def set_device(self, device: torch.device | int) -> None:
+        if isinstance(device, torch.device):
+            if device.type != "mps":
+                raise ValueError(f"Expected an MPS device, got {device}")
+            index = 0 if device.index is None else device.index
+        else:
+            index = int(device)
+        self._validate_device_id(index)
+        # note (yexiaodong): PyTorch MPS and MLX share one process-global Metal
+        # device, so there is no CUDA-style device selection to perform.
+
+    def get_device_name(self, device_id: int = 0) -> str:
+        self._validate_device_id(device_id)
+        return "Apple Metal"
+
+    def get_device_total_memory(self, device_id: int = 0) -> int:
+        self._validate_device_id(device_id)
+        import mlx.core as mx
+
+        return int(mx.device_info()["max_recommended_working_set_size"])
+
+    def get_current_memory_usage(self, device: torch.device | None = None) -> float:
+        if device is not None and device.type != "mps":
+            raise ValueError(f"Expected an MPS device, got {device}")
+        from sglang.srt.utils.tensor_bridge import use_mlx
+
+        if use_mlx():
+            import mlx.core as mx
+
+            return float(mx.get_active_memory())
+        return float(torch.mps.current_allocated_memory())
+
+    def get_stage_process_env(
+        self,
+        spec: StageLaunchConfig,
+        env: Mapping[str, str] | None = None,
+    ) -> dict[str, str]:
+        del env
+        if spec.tp_size > 1:
+            raise ValueError(
+                f"Apple Silicon stage {spec.stage_name!r} requires tp_size=1; "
+                f"got tp_size={spec.tp_size}"
+            )
+        if spec.gpu_id is not None:
+            self._validate_device_id(spec.gpu_id)
+        return {}
+
+    def get_intra_node_transport(self):
+        from sglang_omni.comm.data_ref import TransportKind
+
+        return TransportKind.SHM
+
+    def empty_cache(self) -> None:
+        from sglang.srt.utils.tensor_bridge import use_mlx
+
+        if use_mlx():
+            import mlx.core as mx
+
+            mx.clear_cache()
+        else:
+            torch.mps.empty_cache()
+
+    def synchronize(self) -> None:
+        from sglang.srt.utils.tensor_bridge import use_mlx
+
+        if use_mlx():
+            import mlx.core as mx
+
+            mx.synchronize()
+        else:
+            torch.mps.synchronize()
+
+    def enable_code2wav_graph(self) -> bool:
+        return False
+
+
+__all__ = ["AppleOmniPlatform"]

--- a/sglang_omni/platforms/apple.py
+++ b/sglang_omni/platforms/apple.py
@@ -18,10 +18,10 @@ if TYPE_CHECKING:
 class AppleOmniPlatform(OmniPlatform):
     """Single-device Apple Metal platform.
 
-    SGLang 0.5.16 enables its MLX runner through SGLANG_USE_MLX=1 but does
-    not register an MPS SRTPlatform. Omni still needs concrete device
-    operations because every accelerator-backed stage binds its scheduler
-    thread through current_platform.get_device and set_device.
+    SGLang enables its MLX runner through SGLANG_USE_MLX=1 but does not
+    register an MPS SRTPlatform. Omni still needs concrete device operations
+    because every accelerator-backed stage binds its scheduler thread through
+    current_platform.get_device and set_device.
     """
 
     _enum: PlatformEnum = PlatformEnum.MPS
@@ -56,9 +56,13 @@ class AppleOmniPlatform(OmniPlatform):
 
     def get_device_total_memory(self, device_id: int = 0) -> int:
         self._validate_device_id(device_id)
-        import mlx.core as mx
+        from sglang.srt.utils.tensor_bridge import use_mlx
 
-        return int(mx.device_info()["max_recommended_working_set_size"])
+        if use_mlx():
+            import mlx.core as mx
+
+            return int(mx.device_info()["max_recommended_working_set_size"])
+        return int(torch.mps.recommended_max_memory())
 
     def get_current_memory_usage(self, device: torch.device | None = None) -> float:
         if device is not None and device.type != "mps":

--- a/sglang_omni/scheduling/bootstrap.py
+++ b/sglang_omni/scheduling/bootstrap.py
@@ -41,6 +41,12 @@ def _describe_sglang_runtime_configuration(
 
 def init_sglang_cuda_graphs(model_worker: Any) -> None:
     """Initialize SGLang graphs with Omni's prefill-embedding capture view."""
+    from sglang.srt.utils.tensor_bridge import use_mlx
+
+    if use_mlx():
+        # note (yexiaodong): The MLX stub has no Torch graph lifecycle because
+        # native MLX lazy evaluation owns graph execution.
+        return
     if not model_worker.enable_prefill_input_embeds:
         # Required even when graphs are disabled: SGLang installs its eager
         # phase runner from init_cuda_graphs().
@@ -121,18 +127,31 @@ def create_sglang_infrastructure(
 
     logger.info(_describe_sglang_runtime_configuration(server_args, gpu_id))
 
-    model_worker = ModelWorker(
-        config=ModelWorkerConfig(
-            model_arch_override=model_arch_override,
-            weight_prefix=weight_prefix,
-            nccl_port=nccl_port,
-            total_gpu_memory_fraction=total_gpu_memory_fraction,
-            enable_prefill_input_embeds=enable_prefill_input_embeds,
-        ),
-        server_args=server_args,
-        gpu_id=gpu_id,
-        tp_rank=tp_rank,
+    worker_config = ModelWorkerConfig(
+        model_arch_override=model_arch_override,
+        weight_prefix=weight_prefix,
+        nccl_port=nccl_port,
+        total_gpu_memory_fraction=total_gpu_memory_fraction,
+        enable_prefill_input_embeds=enable_prefill_input_embeds,
     )
+    from sglang.srt.utils.tensor_bridge import use_mlx
+
+    if use_mlx():
+        from sglang_omni.model_runner.mlx_model_worker import create_mlx_model_worker
+
+        model_worker = create_mlx_model_worker(
+            config=worker_config,
+            server_args=server_args,
+            gpu_id=gpu_id,
+            tp_rank=tp_rank,
+        )
+    else:
+        model_worker = ModelWorker(
+            config=worker_config,
+            server_args=server_args,
+            gpu_id=gpu_id,
+            tp_rank=tp_rank,
+        )
 
     if capture_hidden_layers:
         from sglang_omni.model_runner._hidden_capture import (

--- a/sglang_omni/serve/transcriptions.py
+++ b/sglang_omni/serve/transcriptions.py
@@ -99,13 +99,20 @@ def register_transcriptions(app: FastAPI) -> None:
                 chunking.allow_audio_chunking
                 and duration_s > chunking.stream_clip_limit_s
             ):
+                if (
+                    chunking.max_total_audio_s is not None
+                    and chunking.max_total_audio_s <= chunking.stream_clip_limit_s
+                ):
+                    recovery = "use a shorter audio file"
+                else:
+                    recovery = (
+                        "use stream=false, which transcribes long audio in chunks"
+                    )
                 raise HTTPException(
                     status_code=400,
                     detail=(
                         "stream=true does not support audio longer than "
-                        f"{chunking.stream_clip_limit_s:g} seconds; "
-                        "use stream=false, which transcribes long audio in "
-                        "chunks"
+                        f"{chunking.stream_clip_limit_s:g} seconds; {recovery}"
                     ),
                 )
             gen_req = speech_to_text.build_speech_to_text_generate_request(

--- a/tests/unit_test/ci/test_verify_omni_installed_pins.py
+++ b/tests/unit_test/ci/test_verify_omni_installed_pins.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+VERIFIER = REPO_ROOT / ".github/scripts/verify_omni_installed_pins.py"
+
+
+@pytest.fixture(scope="module")
+def verifier():
+    spec = importlib.util.spec_from_file_location(
+        "verify_omni_installed_pins", VERIFIER
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_project(tmp_path: Path) -> Path:
+    project = tmp_path / "pyproject.toml"
+    project.write_text(
+        """
+[project]
+dependencies = [
+  "torch==2.13.0; sys_platform != 'darwin' or platform_machine != 'arm64'",
+  "torch==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
+  "torchcodec==0.15.0; sys_platform != 'darwin' or platform_machine != 'arm64'",
+  "torchcodec==0.11.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
+  "flashinfer_python[cu13]==0.6.17; sys_platform != 'darwin' or platform_machine != 'arm64'",
+  "transformers==5.12.1",
+]
+
+[tool.uv]
+override-dependencies = [
+  "protobuf==6.33.6; sys_platform != 'darwin' or platform_machine != 'arm64'",
+  "protobuf==7.36.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
+]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return project
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected"),
+    [
+        (
+            {"sys_platform": "linux", "platform_machine": "x86_64"},
+            {
+                "torch": "2.13.0",
+                "torchcodec": "0.15.0",
+                "flashinfer_python": "0.6.17",
+                "transformers": "5.12.1",
+                "protobuf": "6.33.6",
+            },
+        ),
+        (
+            {"sys_platform": "darwin", "platform_machine": "arm64"},
+            {
+                "torch": "2.11.0",
+                "torchcodec": "0.11.1",
+                "transformers": "5.12.1",
+                "protobuf": "7.36.0",
+            },
+        ),
+    ],
+)
+def test_exact_pins_respect_platform_markers(
+    verifier, tmp_path: Path, environment: dict[str, str], expected: dict[str, str]
+) -> None:
+    assert (
+        verifier._exact_pins(_write_project(tmp_path), environment=environment)
+        == expected
+    )
+
+
+def test_exact_pins_preserve_override_precedence(verifier, tmp_path: Path) -> None:
+    project = tmp_path / "pyproject.toml"
+    project.write_text(
+        """
+[project]
+dependencies = [
+  "torch==2.13.0; sys_platform == 'linux'",
+]
+
+[tool.uv]
+override-dependencies = ["torch==2.12.0; sys_platform == 'linux'"]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert verifier._exact_pins(
+        project,
+        environment={"sys_platform": "linux", "platform_machine": "x86_64"},
+    ) == {"torch": "2.12.0"}
+
+
+def test_exact_pins_select_non_arm_darwin_variant(verifier, tmp_path: Path) -> None:
+    pins = verifier._exact_pins(
+        _write_project(tmp_path),
+        environment={"sys_platform": "darwin", "platform_machine": "x86_64"},
+    )
+
+    assert pins["torch"] == "2.13.0"
+    assert pins["torchcodec"] == "0.15.0"
+    assert pins["flashinfer_python"] == "0.6.17"
+    assert pins["protobuf"] == "6.33.6"

--- a/tests/unit_test/platforms/test_apple.py
+++ b/tests/unit_test/platforms/test_apple.py
@@ -35,6 +35,16 @@ def test_apple_device_binding_is_single_device() -> None:
         apple.set_device(torch.device("cpu"))
 
 
+def test_apple_device_total_memory_uses_torch_without_mlx(monkeypatch) -> None:
+    import sglang.srt.utils.tensor_bridge as tensor_bridge
+
+    expected = 12_713_115_648
+    monkeypatch.setattr(tensor_bridge, "use_mlx", lambda: False)
+    monkeypatch.setattr(torch.mps, "recommended_max_memory", lambda: expected)
+
+    assert AppleOmniPlatform().get_device_total_memory(0) == expected
+
+
 def test_apple_stage_rejects_tensor_parallelism() -> None:
     apple = AppleOmniPlatform()
     spec = SimpleNamespace(stage_name="asr", tp_size=2, gpu_id=0)

--- a/tests/unit_test/platforms/test_apple.py
+++ b/tests/unit_test/platforms/test_apple.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from sglang.srt.platforms.interface import SRTPlatform
+
+from sglang_omni import platforms
+from sglang_omni.platforms.apple import AppleOmniPlatform
+
+
+def test_generic_sglang_platform_resolves_to_apple_when_mps_is_available(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(platforms, "_is_apple_silicon_mps_available", lambda: True)
+
+    resolved = platforms._as_omni_platform(SRTPlatform())
+
+    assert isinstance(resolved, AppleOmniPlatform)
+    assert resolved.is_mps()
+    assert resolved.device_type == "mps"
+
+
+def test_apple_device_binding_is_single_device() -> None:
+    apple = AppleOmniPlatform()
+
+    assert apple.get_device(0) == torch.device("mps")
+    apple.set_device(torch.device("mps"))
+    with pytest.raises(ValueError, match="one Metal device"):
+        apple.get_device(1)
+    with pytest.raises(ValueError, match="Expected an MPS device"):
+        apple.set_device(torch.device("cpu"))
+
+
+def test_apple_stage_rejects_tensor_parallelism() -> None:
+    apple = AppleOmniPlatform()
+    spec = SimpleNamespace(stage_name="asr", tp_size=2, gpu_id=0)
+
+    with pytest.raises(ValueError, match="requires tp_size=1"):
+        apple.get_stage_process_env(spec)
+
+
+def test_apple_stage_accepts_device_zero() -> None:
+    apple = AppleOmniPlatform()
+    spec = SimpleNamespace(stage_name="asr", tp_size=1, gpu_id=0)
+
+    assert apple.get_stage_process_env(spec) == {}

--- a/tests/unit_test/qwen3_asr/test_mlx_model.py
+++ b/tests/unit_test/qwen3_asr/test_mlx_model.py
@@ -21,7 +21,8 @@ from sglang_omni.models.qwen3_asr.mlx.runner import (  # noqa: E402
 )
 
 
-def _tiny_model() -> Qwen3ASRModel:
+def _tiny_model(*, tie_word_embeddings: bool = True) -> Qwen3ASRModel:
+    mx.random.seed(0)
     audio = AudioEncoderConfig(
         num_mel_bins=8,
         encoder_layers=1,
@@ -44,6 +45,7 @@ def _tiny_model() -> Qwen3ASRModel:
         num_key_value_heads=1,
         head_dim=4,
         max_position_embeddings=128,
+        tie_word_embeddings=tie_word_embeddings,
     )
     return Qwen3ASRModel(
         ModelConfig(audio_config=audio, text_config=text, audio_token_id=10)
@@ -82,7 +84,12 @@ def test_native_mlx_prefill_only_projects_last_position() -> None:
 
     mx.eval(full_logits, last_logits)
     assert last_logits.shape == (1, 1, 64)
-    assert mx.allclose(last_logits, full_logits[:, -1:, :]).item()
+    assert mx.allclose(
+        last_logits,
+        full_logits[:, -1:, :],
+        rtol=1e-2,
+        atol=1e-2,
+    ).item()
 
 
 def test_runner_restores_audio_placeholder_before_embedding() -> None:
@@ -121,6 +128,14 @@ def test_runner_only_rewrites_the_exact_audio_placeholder() -> None:
     )
 
     assert normalized == [1, 10, -7, 2]
+
+
+def test_runner_converts_bfloat16_features_to_numpy() -> None:
+    converted = Qwen3ASRMlxModelRunner._to_numpy(
+        torch.ones((2, 3), dtype=torch.bfloat16)
+    )
+
+    assert converted.dtype.name == "float32"
 
 
 def test_runner_rejects_missing_audio_item() -> None:
@@ -174,8 +189,21 @@ def test_hf_weight_sanitize_is_local_and_transposes_conv2d() -> None:
         "thinker.lm_head.weight": mx.zeros((64, 8)),
     }
 
-    sanitized = Qwen3ASRModel.sanitize(weights)
+    sanitized = _tiny_model().sanitize(weights)
 
     assert sanitized["audio_tower.conv2d1.weight"].shape == (4, 3, 3, 1)
     assert "model.embed_tokens.weight" in sanitized
     assert "lm_head.weight" not in sanitized
+
+
+def test_hf_weight_sanitize_keeps_untied_lm_head() -> None:
+    model = _tiny_model(tie_word_embeddings=False)
+
+    sanitized = model.sanitize(
+        {
+            "thinker.model.embed_tokens.weight": mx.zeros((64, 8)),
+            "thinker.lm_head.weight": mx.zeros((64, 8)),
+        }
+    )
+
+    assert "lm_head.weight" in sanitized

--- a/tests/unit_test/qwen3_asr/test_mlx_model.py
+++ b/tests/unit_test/qwen3_asr/test_mlx_model.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+mx = pytest.importorskip("mlx.core")
+
+from sglang_omni.models.qwen3_asr.mlx.config import (  # noqa: E402
+    AudioEncoderConfig,
+    ModelConfig,
+    TextConfig,
+)
+from sglang_omni.models.qwen3_asr.mlx.model import Qwen3ASRModel  # noqa: E402
+from sglang_omni.models.qwen3_asr.mlx.runner import (  # noqa: E402
+    Qwen3ASRMlxModelRunner,
+    make_qwen3_asr_mlx_runner_class,
+)
+
+
+def _tiny_model() -> Qwen3ASRModel:
+    audio = AudioEncoderConfig(
+        num_mel_bins=8,
+        encoder_layers=1,
+        encoder_attention_heads=2,
+        encoder_ffn_dim=16,
+        d_model=8,
+        max_source_positions=100,
+        n_window=5,
+        n_window_infer=10,
+        conv_chunksize=50,
+        downsample_hidden_size=4,
+        output_dim=8,
+    )
+    text = TextConfig(
+        vocab_size=64,
+        hidden_size=8,
+        intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=4,
+        max_position_embeddings=128,
+    )
+    return Qwen3ASRModel(
+        ModelConfig(audio_config=audio, text_config=text, audio_token_id=10)
+    )
+
+
+def test_native_mlx_audio_prefill_forward() -> None:
+    model = _tiny_model()
+    features = mx.zeros((1, 8, 20))
+    mask = mx.ones((1, 20))
+    audio_features = model.get_audio_features(features, mask)
+    input_ids = mx.array([[1, *([10] * audio_features.shape[0]), 2]], dtype=mx.int32)
+    embeddings = model._build_inputs_embeds(
+        input_ids,
+        audio_features,
+        audio_start=1,
+        num_audio_tokens=audio_features.shape[0],
+    )
+    logits = model(
+        input_ids,
+        input_embeddings=embeddings,
+        cache=model.make_cache(),
+    )
+
+    mx.eval(logits)
+    assert logits.shape == (1, input_ids.shape[1], 64)
+
+
+def test_native_mlx_prefill_only_projects_last_position() -> None:
+    model = _tiny_model()
+    input_ids = mx.array([[1, 2, 3]], dtype=mx.int32)
+    embeddings = model.model.embed_tokens(input_ids)
+
+    full_logits = model(input_ids, input_embeddings=embeddings)
+    last_logits = model._forward_last_logits(embeddings)
+
+    mx.eval(full_logits, last_logits)
+    assert last_logits.shape == (1, 1, 64)
+    assert mx.allclose(last_logits, full_logits[:, -1:, :]).item()
+
+
+def test_runner_restores_audio_placeholder_before_embedding() -> None:
+    runner = object.__new__(Qwen3ASRMlxModelRunner)
+    runner.model = _tiny_model()
+    item = SimpleNamespace(
+        feature=torch.zeros((1, 8, 20)),
+        feature_attention_mask=torch.ones((1, 20)),
+        model_specific_data={},
+        pad_value=1_000_001,
+    )
+    req = SimpleNamespace(
+        multimodal_inputs=SimpleNamespace(
+            audio_token_id=10,
+            mm_items=[item],
+        )
+    )
+
+    input_ids, embeddings = runner._audio_prefill_inputs(
+        req, [1, 1_000_001, 1_000_001, 1_000_001, 1_000_001, 2]
+    )
+
+    mx.eval(embeddings)
+    assert input_ids.tolist() == [[1, 10, 10, 10, 10, 2]]
+    assert embeddings.shape == (1, 6, 8)
+
+
+def test_runner_only_rewrites_the_exact_audio_placeholder() -> None:
+    item = SimpleNamespace(pad_value=1_000_001)
+    req = SimpleNamespace(
+        multimodal_inputs=SimpleNamespace(audio_token_id=10, mm_items=[item])
+    )
+
+    normalized = Qwen3ASRMlxModelRunner._normalize_audio_token_ids(
+        req, [1, 1_000_001, -7, 2]
+    )
+
+    assert normalized == [1, 10, -7, 2]
+
+
+def test_runner_rejects_missing_audio_item() -> None:
+    req = SimpleNamespace(
+        multimodal_inputs=SimpleNamespace(audio_token_id=10, mm_items=[])
+    )
+
+    with pytest.raises(ValueError, match="exactly one audio item"):
+        Qwen3ASRMlxModelRunner._audio_item(req)
+
+
+def test_native_mlx_rejects_audio_feature_count_mismatch() -> None:
+    model = _tiny_model()
+    input_ids = mx.array([[1, 10, 2]], dtype=mx.int32)
+    audio_features = mx.zeros((2, 8))
+
+    with pytest.raises(ValueError, match="counts differ"):
+        model._build_inputs_embeds(
+            input_ids,
+            audio_features,
+            audio_start=1,
+            num_audio_tokens=1,
+        )
+
+
+def test_runner_chains_native_single_request_decode() -> None:
+    runner_class = make_qwen3_asr_mlx_runner_class()
+    runner = object.__new__(runner_class)
+    runner.model = _tiny_model()
+    runner._req_token_ids = {"req": [1]}
+    runner._req_caches = {"req": runner.model.make_cache()}
+    runner._decode_step_ct = 0
+    runner._clear_steps = 0
+
+    first = runner.decode_batch_start(["req"])
+    second = runner.decode_batch_start_chained(first)
+    mx.eval(second.lazy_tokens)
+    runner.decode_batch_finalize(first)
+    runner.decode_batch_finalize(second)
+
+    assert first.lazy_tokens.shape == (1,)
+    assert second.lazy_tokens.shape == (1,)
+    assert runner._req_caches["req"][0].offset == 2
+    assert len(runner._req_token_ids["req"]) == 3
+
+
+def test_hf_weight_sanitize_is_local_and_transposes_conv2d() -> None:
+    weights = {
+        "thinker.audio_tower.conv2d1.weight": mx.zeros((4, 1, 3, 3)),
+        "thinker.model.embed_tokens.weight": mx.zeros((64, 8)),
+        "thinker.lm_head.weight": mx.zeros((64, 8)),
+    }
+
+    sanitized = Qwen3ASRModel.sanitize(weights)
+
+    assert sanitized["audio_tower.conv2d1.weight"].shape == (4, 3, 3, 1)
+    assert "model.embed_tokens.weight" in sanitized
+    assert "lm_head.weight" not in sanitized

--- a/tests/unit_test/qwen3_asr/test_mlx_model.py
+++ b/tests/unit_test/qwen3_asr/test_mlx_model.py
@@ -147,6 +147,49 @@ def test_runner_rejects_missing_audio_item() -> None:
         Qwen3ASRMlxModelRunner._audio_item(req)
 
 
+def test_runner_resolves_revision_and_checks_remote_code(monkeypatch, tmp_path) -> None:
+    import mlx_lm.utils as mlx_lm_utils
+    import sglang.srt.hardware_backend.mlx.remote_code_gate as remote_code_gate
+
+    observed = {}
+    monkeypatch.setattr(
+        remote_code_gate,
+        "resolve_model_directory",
+        lambda model_path, revision=None: observed.update(
+            model_path=model_path,
+            revision=revision,
+        )
+        or tmp_path,
+    )
+    monkeypatch.setattr(
+        remote_code_gate,
+        "ensure_remote_code_allowed",
+        lambda model_dir, trust_remote_code: observed.update(
+            model_dir=model_dir,
+            trust_remote_code=trust_remote_code,
+        ),
+    )
+    monkeypatch.setattr(
+        mlx_lm_utils,
+        "load_model",
+        lambda model_path, **kwargs: ("loaded-model", {}),
+    )
+    runner = object.__new__(Qwen3ASRMlxModelRunner)
+    runner.model_path = "org/model"
+    runner.revision = "revision-sha"
+    runner.trust_remote_code = True
+
+    runner._load_model()
+
+    assert observed == {
+        "model_path": "org/model",
+        "revision": "revision-sha",
+        "model_dir": tmp_path,
+        "trust_remote_code": True,
+    }
+    assert runner.model == "loaded-model"
+
+
 def test_native_mlx_rejects_audio_feature_count_mismatch() -> None:
     model = _tiny_model()
     input_ids = mx.array([[1, 10, 2]], dtype=mx.int32)

--- a/tests/unit_test/qwen3_asr/test_mlx_scheduler_runner.py
+++ b/tests/unit_test/qwen3_asr/test_mlx_scheduler_runner.py
@@ -107,10 +107,18 @@ def test_mlx_scheduler_runner_launches_then_chains_before_resolve() -> None:
 
 def test_mlx_scheduler_runner_rejects_changed_chained_batch() -> None:
     runner = _Runner(_Worker())
-    runner.execute_launch(_scheduler_output("req-a"))
+    previous = runner.execute_launch(_scheduler_output("req-a"))
 
     with pytest.raises(RuntimeError, match="unchanged request batch"):
         runner.execute_launch(_scheduler_output("req-b"))
+
+    # A failed successor launch must not orphan the scheduler-owned lazy step.
+    assert runner._last_mlx_pending is previous
+    assert runner.execute_resolve(previous) == "resolved"
+    assert runner._last_mlx_pending is None
+
+    runner.execute_launch(_scheduler_output("req-b"))
+    assert runner.tp_worker.calls[-1] == ("fresh", ["req-b"])
 
 
 def test_mlx_scheduler_runner_drains_before_changed_chain() -> None:

--- a/tests/unit_test/qwen3_asr/test_mlx_scheduler_runner.py
+++ b/tests/unit_test/qwen3_asr/test_mlx_scheduler_runner.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from sglang_omni.model_runner.mlx_model_worker import MlxSchedulerModelRunner
+from sglang_omni.scheduling.types import SchedulerOutput, SchedulerRequest
+
+
+class _DecodeMode:
+    @staticmethod
+    def is_decode() -> bool:
+        return True
+
+
+class _Batch:
+    def __init__(self, request_ids: list[str]):
+        self.forward_mode = _DecodeMode()
+        self.reqs = [SimpleNamespace(rid=request_id) for request_id in request_ids]
+
+    def copy(self):
+        return _Batch([req.rid for req in self.reqs])
+
+
+class _Worker:
+    def __init__(self):
+        self.calls = []
+
+    def async_forward_batch_generation_mlx(self, batch):
+        self.calls.append(("fresh", [req.rid for req in batch.reqs]))
+        return "lazy-1", [], [], "decode-1", "decode"
+
+    def async_chained_decode_mlx(self, previous):
+        self.calls.append(("chained", previous))
+        return "lazy-2", [], [], "decode-2", "decode"
+
+    def finalize_mlx_result(self, prefills, extends, decode, mode, reqs):
+        self.calls.append(("finalize", decode, [req.rid for req in reqs]))
+        return SimpleNamespace(next_token_ids=None)
+
+
+class _Runner(MlxSchedulerModelRunner):
+    def __init__(self, worker):
+        self.tp_worker = worker
+        self._last_mlx_pending = None
+        self._execution_bridge = None
+        self.finalized = []
+
+    def _finalize(
+        self,
+        batch_result,
+        forward_batch,
+        schedule_batch,
+        scheduler_output,
+        skip_rids=None,
+    ):
+        del batch_result, forward_batch, schedule_batch, scheduler_output
+        self.finalized.append(skip_rids or set())
+        return "resolved"
+
+
+def _scheduler_output(request_id: str) -> SchedulerOutput:
+    req = SimpleNamespace(finished=lambda: False, is_retracted=False)
+    return SchedulerOutput(
+        requests=[
+            SchedulerRequest(
+                request_id=request_id,
+                data=SimpleNamespace(req=req),
+            )
+        ],
+        batch_data=_Batch([request_id]),
+    )
+
+
+def test_mlx_scheduler_runner_launches_then_chains_before_resolve() -> None:
+    worker = _Worker()
+    runner = _Runner(worker)
+    scheduler_output = _scheduler_output("req")
+
+    first = runner.execute_launch(scheduler_output)
+    second = runner.execute_launch(scheduler_output)
+
+    assert worker.calls[:2] == [("fresh", ["req"]), ("chained", "decode-1")]
+    assert runner.execute_resolve(first) == "resolved"
+    assert runner._last_mlx_pending is second
+    assert runner.execute_resolve(second) == "resolved"
+    assert runner._last_mlx_pending is None
+    assert worker.calls[2:] == [
+        ("finalize", "decode-1", ["req"]),
+        ("finalize", "decode-2", ["req"]),
+    ]
+
+
+def test_mlx_scheduler_runner_rejects_changed_chained_batch() -> None:
+    runner = _Runner(_Worker())
+    runner.execute_launch(_scheduler_output("req-a"))
+
+    with pytest.raises(RuntimeError, match="unchanged request batch"):
+        runner.execute_launch(_scheduler_output("req-b"))
+
+
+def test_mlx_scheduler_runner_clears_chain_after_resolve_failure() -> None:
+    worker = _Worker()
+    runner = _Runner(worker)
+    pending = runner.execute_launch(_scheduler_output("req"))
+
+    def fail_finalize(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("failed finalize")
+
+    worker.finalize_mlx_result = fail_finalize
+    with pytest.raises(RuntimeError, match="failed finalize"):
+        runner.execute_resolve(pending)
+
+    assert runner._last_mlx_pending is None
+
+
+def test_mlx_scheduler_runner_limits_lookahead_to_concurrency_one() -> None:
+    runner = _Runner(_Worker())
+    sampling_params = SimpleNamespace(
+        repetition_penalty=1.0,
+        frequency_penalty=0.0,
+        presence_penalty=0.0,
+        min_new_tokens=0,
+    )
+
+    def request(rid: str):
+        return SimpleNamespace(
+            rid=rid,
+            sampling_params=sampling_params,
+            custom_logit_processor=None,
+        )
+
+    assert runner.lookahead_eligible(SimpleNamespace(reqs=[request("a")]))
+    assert not runner.lookahead_eligible(
+        SimpleNamespace(reqs=[request("a"), request("b")])
+    )

--- a/tests/unit_test/qwen3_asr/test_mlx_scheduler_runner.py
+++ b/tests/unit_test/qwen3_asr/test_mlx_scheduler_runner.py
@@ -26,20 +26,31 @@ class _Batch:
 
 
 class _Worker:
-    def __init__(self):
+    def __init__(self, next_token_ids=None):
         self.calls = []
+        self.next_token_ids = next_token_ids
+
+    @staticmethod
+    def _launch(lazy_tokens, decode):
+        return SimpleNamespace(
+            lazy_tokens=lazy_tokens,
+            prefills=[],
+            extends=[],
+            decode=decode,
+            mode="decode",
+        )
 
     def async_forward_batch_generation_mlx(self, batch):
         self.calls.append(("fresh", [req.rid for req in batch.reqs]))
-        return "lazy-1", [], [], "decode-1", "decode"
+        return self._launch("lazy-1", "decode-1")
 
     def async_chained_decode_mlx(self, previous):
         self.calls.append(("chained", previous))
-        return "lazy-2", [], [], "decode-2", "decode"
+        return self._launch("lazy-2", "decode-2")
 
-    def finalize_mlx_result(self, prefills, extends, decode, mode, reqs):
-        self.calls.append(("finalize", decode, [req.rid for req in reqs]))
-        return SimpleNamespace(next_token_ids=None)
+    def finalize_mlx_result(self, launch, reqs):
+        self.calls.append(("finalize", launch.decode, [req.rid for req in reqs]))
+        return SimpleNamespace(next_token_ids=self.next_token_ids)
 
 
 class _Runner(MlxSchedulerModelRunner):
@@ -102,6 +113,28 @@ def test_mlx_scheduler_runner_rejects_changed_chained_batch() -> None:
         runner.execute_launch(_scheduler_output("req-b"))
 
 
+def test_mlx_scheduler_runner_drains_before_changed_chain() -> None:
+    runner = _Runner(_Worker())
+    runner.execute_launch(_scheduler_output("req-a"))
+    sampling_params = SimpleNamespace(
+        repetition_penalty=1.0,
+        frequency_penalty=0.0,
+        presence_penalty=0.0,
+        min_new_tokens=0,
+    )
+    changed_batch = SimpleNamespace(
+        reqs=[
+            SimpleNamespace(
+                rid="req-b",
+                sampling_params=sampling_params,
+                custom_logit_processor=None,
+            )
+        ]
+    )
+
+    assert not runner.lookahead_eligible(changed_batch)
+
+
 def test_mlx_scheduler_runner_clears_chain_after_resolve_failure() -> None:
     worker = _Worker()
     runner = _Runner(worker)
@@ -138,3 +171,30 @@ def test_mlx_scheduler_runner_limits_lookahead_to_concurrency_one() -> None:
     assert not runner.lookahead_eligible(
         SimpleNamespace(reqs=[request("a"), request("b")])
     )
+
+
+def test_mlx_scheduler_runner_uses_future_map_bridge(monkeypatch) -> None:
+    import sglang.srt.managers.overlap_utils as overlap_utils
+
+    resolved = []
+    bridge = SimpleNamespace(
+        future_map=object(),
+        published=[],
+        publish_next_tokens=lambda batch, tokens: bridge.published.append(
+            (batch, tokens)
+        ),
+    )
+    monkeypatch.setattr(
+        overlap_utils,
+        "resolve_forward_inputs",
+        lambda batch, future_map: resolved.append((batch, future_map)),
+    )
+    runner = _Runner(_Worker(next_token_ids="token-ids"))
+    runner._execution_bridge = bridge
+    scheduler_output = _scheduler_output("req")
+
+    pending = runner.execute_launch(scheduler_output)
+    runner.execute_resolve(pending)
+
+    assert resolved == [(scheduler_output.batch_data, bridge.future_map)]
+    assert bridge.published == [(pending.schedule_batch, "token-ids")]

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -240,6 +240,24 @@ def test_qwen3_asr_torch_mps_uses_eager_native_profile() -> None:
     }
 
 
+def test_qwen3_asr_mlx_profile_overrides_typed_torch_compile_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sglang.srt.utils.tensor_bridge as tensor_bridge
+
+    monkeypatch.setattr(tensor_bridge, "use_mlx", lambda: True)
+    monkeypatch.setattr(qwen3_asr_builder.current_platform, "is_mps", lambda: True)
+    builder = _make_engine_builder()
+    builder.device = "mps"
+    overrides = {"enable_torch_compile": True}
+
+    defaults = builder.generation_defaults(dtype="auto")
+    builder.adjust_overrides(overrides)
+
+    assert defaults["enable_torch_compile"] is False
+    assert overrides["enable_torch_compile"] is False
+
+
 def test_qwen3_asr_config_uses_batched_stage_with_64_running_requests() -> None:
     config = Qwen3ASRPipelineConfig(model_path="Qwen/Qwen3-ASR-1.7B")
 

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -16,6 +16,7 @@ import sglang_omni.scheduling.bootstrap as bootstrap
 import sglang_omni.scheduling.omni_scheduler as omni_scheduler
 import sglang_omni.scheduling.sglang_backend as sglang_backend
 import sglang_omni.utils.cuda_graph_batch_validator as cuda_graph_batch_validator
+import sglang_omni.utils.device as device_utils
 from sglang_omni.config.manager import ConfigManager
 from sglang_omni.config.runtime import resolve_stage_typed_kwargs
 from sglang_omni.models.qwen3_asr import request_builders
@@ -211,6 +212,34 @@ def test_qwen3_asr_explicit_prefill_backend_overrides_rocm_default(
     assert overrides["prefill_attention_backend"] == "aiter"
 
 
+def test_qwen3_asr_torch_mps_uses_eager_native_profile() -> None:
+    from sglang.srt.utils.tensor_bridge import use_mlx
+
+    if use_mlx():
+        pytest.skip("Torch MPS profile requires SGLANG_USE_MLX=0")
+    builder = _make_engine_builder()
+    builder.device = "mps"
+
+    defaults = builder.generation_defaults(dtype="float16")
+
+    assert defaults == {
+        "max_running_requests": 1,
+        "disable_cuda_graph": True,
+        "disable_overlap_schedule": True,
+        "disable_radix_cache": True,
+        "enable_torch_compile": False,
+        "context_length": 2048,
+        "max_total_tokens": 2048,
+        "max_prefill_tokens": 2048,
+        "chunked_prefill_size": -1,
+        "mem_fraction_static": None,
+        "attention_backend": "torch_native",
+        "mm_attention_backend": "sdpa",
+        "sampling_backend": "pytorch",
+        "dtype": "float16",
+    }
+
+
 def test_qwen3_asr_config_uses_batched_stage_with_64_running_requests() -> None:
     config = Qwen3ASRPipelineConfig(model_path="Qwen/Qwen3-ASR-1.7B")
 
@@ -357,6 +386,11 @@ def _patch_engine_dependencies(
         tokenizer=object(),
         stream_output_builder=object(),
         stream_builder_calls=[],
+    )
+    monkeypatch.setattr(
+        device_utils,
+        "resolve_device_spec",
+        lambda device, gpu_id: f"cuda:{gpu_id or 0}",
     )
 
     monkeypatch.setattr(

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -29,6 +29,15 @@ from sglang_omni.scheduling.generation_batch_policy import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _select_non_mlx_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    import sglang.srt.utils.tensor_bridge as tensor_bridge
+
+    # Backend-specific tests opt into MLX explicitly. Keep CUDA/ROCm/Torch MPS
+    # profile tests independent of the caller's SGLANG_USE_MLX environment.
+    monkeypatch.setattr(tensor_bridge, "use_mlx", lambda: False)
+
+
 def _fake_server_args_builder(build_kwargs: dict[str, object]):
     def _build(model_path, context_length, **overrides):
         del model_path

--- a/tests/unit_test/qwen3_asr/test_request_builders.py
+++ b/tests/unit_test/qwen3_asr/test_request_builders.py
@@ -473,6 +473,35 @@ def test_qwen3_asr_request_builder_preserves_sampling_mode(
     assert data.req.sampling_params.top_k == expected_top_k
 
 
+def test_qwen3_asr_mlx_rejects_non_greedy_sampling(monkeypatch) -> None:
+    feature_extractor = lambda *args, **kwargs: SimpleNamespace(
+        input_features=torch.zeros((1, 128, 3000)),
+        attention_mask=torch.ones((1, 101), dtype=torch.long),
+    )
+    monkeypatch.setattr(
+        transcription,
+        "load_audio",
+        lambda source, **kwargs: np.zeros(1600, dtype=np.float32),
+    )
+    request_builder, _ = make_qwen3_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=32,
+        feature_extractor=feature_extractor,
+        greedy_only=True,
+    )
+    payload = StagePayload(
+        request_id="req-asr-mlx-sampling",
+        request=OmniRequest(
+            inputs={"audio_bytes": b"wav"},
+            params={"temperature": 0.1},
+        ),
+        data={},
+    )
+
+    with pytest.raises(ValueError, match="supports only greedy decoding"):
+        request_builder(payload)
+
+
 def test_qwen3_asr_request_builder_preserves_audio_beyond_30_seconds(
     monkeypatch,
 ) -> None:

--- a/tests/unit_test/qwen3_asr/test_request_builders.py
+++ b/tests/unit_test/qwen3_asr/test_request_builders.py
@@ -481,7 +481,9 @@ def test_qwen3_asr_mlx_rejects_non_greedy_sampling(monkeypatch) -> None:
     monkeypatch.setattr(
         transcription,
         "load_audio",
-        lambda source, **kwargs: np.zeros(1600, dtype=np.float32),
+        lambda source, **kwargs: pytest.fail(
+            "non-greedy Apple request should fail before audio decoding"
+        ),
     )
     request_builder, _ = make_qwen3_asr_scheduler_adapters(
         tokenizer=_FakeTokenizer(),

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -1726,6 +1726,25 @@ def test_streamed_audio_beyond_the_native_limit_is_rejected() -> None:
     assert transcription_client.requests == []
 
 
+def test_streamed_audio_beyond_total_limit_requests_shorter_file() -> None:
+    transcription_client = ChunkRecordingTranscriptionClient()
+    client = _chunking_test_client(
+        transcription_client,
+        max_total_audio_s=2.0,
+        max_native_clip_s=2.0,
+    )
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={"model": "asr", "stream": "true"},
+        files={"file": ("long.wav", _wav_upload(2.5), "audio/wav")},
+    )
+
+    assert response.status_code == 400
+    assert "use a shorter audio file" in response.json()["detail"]
+    assert transcription_client.requests == []
+
+
 def test_streamed_short_audio_streams_as_before() -> None:
     transcription_client = SuccessfulTranscriptionClient()
     client = _chunking_test_client(transcription_client)

--- a/tests/unit_test/serve/test_transcription_chunking.py
+++ b/tests/unit_test/serve/test_transcription_chunking.py
@@ -82,7 +82,13 @@ def test_pipeline_config_leaves_chunking_off_by_default() -> None:
     assert config.resolved_audio_chunking.allow_audio_chunking is False
 
 
-def test_qwen3_asr_pipeline_declaresResolvedAudioChunking() -> None:
+def test_qwen3_asr_pipeline_declaresResolvedAudioChunking(monkeypatch) -> None:
+    from sglang_omni.platforms import current_platform
+
+    # Keep this declaration test independent of the host backend. The Qwen
+    # Torch-MPS override is covered explicitly below.
+    monkeypatch.setattr(current_platform, "is_mps", lambda: False)
+
     from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
 
     declared = Qwen3ASRPipelineConfig(model_path="dummy").resolved_audio_chunking
@@ -110,8 +116,24 @@ def test_qwen3_asr_torch_mps_limits_runtime_audio_policy(monkeypatch) -> None:
     ).resolved_audio_chunking
 
     assert resolved.max_audio_clip_s == 30.0
-    assert resolved.max_native_clip_s == 30.0
-    assert resolved.max_total_audio_s == 30.0
+    assert resolved.max_native_clip_s == 60.0
+    assert resolved.max_total_audio_s == 60.0
+
+
+def test_qwen3_asr_torch_mps_rejects_unsafe_chunk_length(monkeypatch) -> None:
+    import sglang.srt.utils.tensor_bridge as tensor_bridge
+
+    from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
+    from sglang_omni.platforms import current_platform
+
+    monkeypatch.setattr(current_platform, "is_mps", lambda: True)
+    monkeypatch.setattr(tensor_bridge, "use_mlx", lambda: False)
+
+    with pytest.raises(ValueError, match="up to 60s"):
+        Qwen3ASRPipelineConfig(
+            model_path="Qwen/Qwen3-ASR-0.6B",
+            audio_chunking=AudioChunkingConfig(max_audio_clip_s=60.1),
+        ).resolved_audio_chunking
 
 
 @pytest.mark.parametrize(("is_mps", "use_mlx"), [(False, False), (True, True)])

--- a/tests/unit_test/serve/test_transcription_chunking.py
+++ b/tests/unit_test/serve/test_transcription_chunking.py
@@ -96,7 +96,46 @@ def test_qwen3_asr_pipeline_declaresResolvedAudioChunking() -> None:
     assert declared.max_native_clip_s == 1200.0
 
 
-def test_whisper_asr_pipeline_declaresResolvedAudioChunking() -> None:
+def test_qwen3_asr_torch_mps_limits_runtime_audio_policy(monkeypatch) -> None:
+    import sglang.srt.utils.tensor_bridge as tensor_bridge
+
+    from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
+    from sglang_omni.platforms import current_platform
+
+    monkeypatch.setattr(current_platform, "is_mps", lambda: True)
+    monkeypatch.setattr(tensor_bridge, "use_mlx", lambda: False)
+
+    resolved = Qwen3ASRPipelineConfig(
+        model_path="Qwen/Qwen3-ASR-0.6B"
+    ).resolved_audio_chunking
+
+    assert resolved.max_audio_clip_s == 30.0
+    assert resolved.max_native_clip_s == 30.0
+    assert resolved.max_total_audio_s == 30.0
+
+
+@pytest.mark.parametrize(("is_mps", "use_mlx"), [(False, False), (True, True)])
+def test_qwen3_asr_non_torch_mps_keeps_native_audio_policy(
+    monkeypatch, is_mps: bool, use_mlx: bool
+) -> None:
+    import sglang.srt.utils.tensor_bridge as tensor_bridge
+
+    from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
+    from sglang_omni.platforms import current_platform
+
+    monkeypatch.setattr(current_platform, "is_mps", lambda: is_mps)
+    monkeypatch.setattr(tensor_bridge, "use_mlx", lambda: use_mlx)
+
+    resolved = Qwen3ASRPipelineConfig(
+        model_path="Qwen/Qwen3-ASR-0.6B"
+    ).resolved_audio_chunking
+
+    assert resolved.max_audio_clip_s == 30.0
+    assert resolved.max_native_clip_s == 1200.0
+    assert resolved.max_total_audio_s == 3600.0
+
+
+def test_whisper_asr_pipeline_declares_chunking() -> None:
     from sglang_omni.models.whisper_asr.config import WhisperASRPipelineConfig
 
     declared = WhisperASRPipelineConfig(model_path="dummy").resolved_audio_chunking


### PR DESCRIPTION
## Summary

Adds Apple Silicon Qwen3-ASR pseudo-streaming through native MLX and Torch MPS paths, without an `mlx-audio` runtime dependency.

## Implementation

- Add the Apple Metal Omni platform, Darwin arm64 dependency markers, FFmpeg 7 setup, and an idempotent installer.
- Add a local MLX Qwen3-ASR audio encoder/decoder with lazy single-request decode and SSE deltas.
- Add a Torch MPS compatibility runner using the Hugging Face Qwen3 language model plus Omni's Torch audio path.
- Adapt Omni's scheduler bridge to the pinned SGLang MLX worker/runner contract.

The two Apple paths are intentional: pinned SGLang separates default Torch/MPS from the `SGLANG_USE_MLX=1` worker/runner, while Omni bypasses the upstream worker-selection entry point and therefore adapts both contracts.

## Performance

MacBook Pro M1 16 GB, `query_to_cars.wav`, concurrency 1, 2 warmups + 15 measured requests; all rows produced 15/15 exact transcripts.

### SGLang 0.5.16

MLX 0.32.1 and Torch 2.11:

| Path | Checkpoint | Language | TTFT median | Total median |
| --- | --- | --- | ---: | ---: |
| Omni MLX | Qwen3-ASR 0.6B 4-bit | auto | 0.183 s | 0.252 s |
| mlx-audio 0.5.0 | Qwen3-ASR 0.6B 4-bit | auto | 0.241 s | 0.309 s |
| Omni MLX | Official Qwen3-ASR 0.6B BF16 | auto | 0.251 s | 0.449 s |
| Omni Torch MPS | Official Qwen3-ASR 0.6B BF16 | forced English | 0.208 s | 0.552 s |

### SGLang 0.5.18

MLX 0.32.2, mlx-lm 0.31.3, and Torch 2.11:

| Path | Checkpoint | Language | TTFT median | Total median |
| --- | --- | --- | ---: | ---: |
| Omni MLX | Qwen3-ASR 0.6B 4-bit | auto | 0.193 s | 0.267 s |
| mlx-audio 0.5.0 | Qwen3-ASR 0.6B 4-bit | auto | 0.244 s | 0.313 s |
| Omni MLX | Official Qwen3-ASR 0.6B BF16 | auto | 0.264 s | 0.485 s |
| Omni Torch MPS | Official Qwen3-ASR 0.6B BF16 | auto | 0.483 s | 1.013 s |

On the current pinned stack, Omni MLX 4-bit is about 14.8% faster in total latency and 20.9% faster in TTFT than the same-checkpoint mlx-audio baseline.

The two version groups are separate end-to-end runs; mlx-audio used isolated environments with the listed MLX stack and does not depend on SGLang.

The Torch rows are not a version A/B because the 0.5.16 run forced English
while the 0.5.18 run used auto detection, which decodes three additional
language-marker tokens before the first transcript delta.

### Controlled version check

An A/B/B/A rerun used identical auto-language requests, five warmups, and 15
measurements per run. After fixing server teardown, system swap stayed near
10 GB across all runs. Values below are the mean of the two run medians:

| Path | SGLang 0.5.16 TTFT / total | SGLang 0.5.18 TTFT / total | 0.5.18 total change |
| --- | ---: | ---: | ---: |
| Omni MLX 4-bit | 0.346 / 0.484 s | 0.344 / 0.464 s | -4.2% |
| Omni MLX BF16 | 0.444 / 0.842 s | 0.441 / 0.834 s | -1.0% |
| Omni Torch MPS BF16 | 0.598 / 1.251 s | 0.594 / 1.244 s | -0.6% |

The controlled check shows no version-caused regression. Its absolute values
are excluded from the headline snapshot because the machine was under stable
but high swap pressure.

## Tests

- Clean Apple installer and `uv pip check` with SGLang 0.5.18.
- `SGLANG_USE_MLX=1`: Apple/MLX/request/streaming/pipeline focused matrix — 642 passed.
- `SGLANG_USE_MLX=0`: full Qwen3-ASR, Apple platform, serving, and base-runner regression matrix — 801 passed, 3 skipped.
- Real MLX 4-bit/BF16 and Torch MPS BF16 HTTP/SSE smoke and performance runs.
- `SKIP=no-commit-to-branch pre-commit run --all-files` and `git diff --check`.

## Shared Qwen3-ASR follow-up

The prompt and `language None` parsing issue found during independent Apple Silicon validation was fixed for all backends by merged [PR #1781](https://github.com/sgl-project/sglang-omni/pull/1781), since it affects the shared Qwen3-ASR path (including CUDA).

## Latest review follow-ups

- Declare `mlx` and `mlx-lm` as direct Darwin arm64 dependencies; the supported install still obtains SGLang from its source `all_mps` extra.
- Reuse the SGLang revision-aware MLX checkpoint resolver and remote-code gate, and make pipeline tests backend-explicit.
- Resolve a backend-specific audio policy: Torch MPS now fails fast above its qualified 60-second range, while MLX and CUDA retain the native 1,200-second streaming policy.
- Track the shared page-reserve admission clamp separately in [PR #1788](https://github.com/sgl-project/sglang-omni/pull/1788).

Rebased-head smoke tests covered MLX 4-bit/BF16 and Torch MPS BF16 HTTP/SSE transcription, empty audio, and Torch MPS long-audio HTTP 400 handling. The performance tables remain the earlier stack snapshots; they were not rebenchmarked after the shared five-token prompt alignment in #1781.
