### PR TITLE
perf(qwen3-tts): batch ad-hoc reference encoding

### DIFF
--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -456,24 +456,27 @@ def build_generation_kwargs(
         explicit_fields = set()
 
     selected_fields = set()
-    for field in _GENERATION_FIELDS:
-        value = params.get(field)
+    for field_name in _GENERATION_FIELDS:
+        value = params.get(field_name)
         if value is None:
             continue
-        if field in _IMPLICIT_SAMPLING_DEFAULTS and field not in explicit_fields:
-            if value in _IMPLICIT_SAMPLING_DEFAULTS[field]:
+        if (
+            field_name in _IMPLICIT_SAMPLING_DEFAULTS
+            and field_name not in explicit_fields
+        ):
+            if value in _IMPLICIT_SAMPLING_DEFAULTS[field_name]:
                 continue
-        selected_fields.add(field)
+        selected_fields.add(field_name)
 
     max_new_tokens = params.get("max_new_tokens")
     if max_new_tokens is None:
         max_new_tokens = QWEN3_TTS_DEFAULT_MAX_NEW_TOKENS
     generation_kwargs: dict[str, Any] = {"max_new_tokens": int(max_new_tokens)}
-    for field in _GENERATION_FIELDS:
-        if field == "max_new_tokens":
+    for field_name in _GENERATION_FIELDS:
+        if field_name == "max_new_tokens":
             continue
-        if field in selected_fields and params.get(field) is not None:
-            generation_kwargs[field] = params[field]
+        if field_name in selected_fields and params.get(field_name) is not None:
+            generation_kwargs[field_name] = params[field_name]
     return generation_kwargs
 
 
@@ -735,6 +738,121 @@ class _Qwen3TTSRefCodeBatcher:
                 return
 
 
+def _encode_qwen3_tts_reference_batch(
+    *,
+    model: Any,
+    wrapper: Any,
+    ref_code_batcher: _Qwen3TTSRefCodeBatcher,
+    items: list[_Qwen3TTSAdhocReferenceInput],
+) -> list[Any]:
+    for item in items:
+        if not item.x_vector_only_mode and not item.ref_text:
+            raise ValueError(
+                "ref_text is required when x_vector_only_mode=False (ICL mode)"
+            )
+    if not items:
+        return []
+
+    with torch.no_grad():
+        normalized = wrapper._normalize_audio_inputs([item.ref_audio for item in items])
+        if len(normalized) != len(items):
+            raise ValueError(
+                "Qwen3-TTS audio normalizer returned "
+                f"{len(normalized)} references for {len(items)} inputs"
+            )
+
+        ref_code_futures = [
+            ref_code_batcher.submit(waveform, sample_rate)
+            for waveform, sample_rate in normalized
+        ]
+        speaker_sample_rate = model.speaker_encoder_sample_rate
+        speaker_inputs: list[tuple[int, Any]] = []
+        speaker_outcomes: list[Any] = [None] * len(items)
+        for index, (waveform, sample_rate) in enumerate(normalized):
+            try:
+                if sample_rate != speaker_sample_rate:
+                    import librosa
+
+                    waveform = librosa.resample(
+                        y=waveform.astype("float32"),
+                        orig_sr=int(sample_rate),
+                        target_sr=speaker_sample_rate,
+                    )
+            except Exception as exc:
+                speaker_outcomes[index] = exc
+            else:
+                speaker_inputs.append((index, waveform))
+
+        extract_many = getattr(model, "extract_speaker_embeddings", None)
+        if speaker_inputs and callable(extract_many):
+            try:
+                speaker_embeddings = extract_many(
+                    audios=[waveform for _, waveform in speaker_inputs],
+                    sr=speaker_sample_rate,
+                )
+                if len(speaker_embeddings) != len(speaker_inputs):
+                    raise ValueError(
+                        "Qwen3-TTS speaker encoder returned "
+                        f"{len(speaker_embeddings)} embeddings for "
+                        f"{len(speaker_inputs)} references"
+                    )
+            except Exception:
+                # The reference-code futures are already running. Retry only
+                # the failed speaker stage so the generic service fallback does
+                # not submit the same tokenizer work a second time.
+                for index, waveform in speaker_inputs:
+                    try:
+                        speaker_outcomes[index] = model.extract_speaker_embedding(
+                            audio=waveform,
+                            sr=speaker_sample_rate,
+                        )
+                    except Exception as exc:
+                        speaker_outcomes[index] = exc
+            else:
+                for (index, _), embedding in zip(
+                    speaker_inputs, speaker_embeddings, strict=True
+                ):
+                    speaker_outcomes[index] = embedding
+        else:
+            # Compatibility for external wrappers and lightweight test models.
+            for index, waveform in speaker_inputs:
+                try:
+                    speaker_outcomes[index] = model.extract_speaker_embedding(
+                        audio=waveform,
+                        sr=speaker_sample_rate,
+                    )
+                except Exception as exc:
+                    speaker_outcomes[index] = exc
+
+        artifacts: list[Any] = []
+        for item, future, speaker_outcome in zip(
+            items, ref_code_futures, speaker_outcomes, strict=True
+        ):
+            if isinstance(speaker_outcome, BaseException):
+                artifacts.append(speaker_outcome)
+                continue
+            if speaker_outcome is None:
+                artifacts.append(
+                    RuntimeError("Qwen3-TTS speaker embedding result is missing")
+                )
+                continue
+            try:
+                ref_code = _record_ref_code_consumer_stream(
+                    future.result(timeout=130.0)
+                )
+            except Exception as exc:
+                artifacts.append(exc)
+                continue
+            voice_clone_prompt = {
+                "ref_code": [None if item.x_vector_only_mode else ref_code],
+                "ref_spk_embedding": [speaker_outcome],
+                "x_vector_only_mode": [item.x_vector_only_mode],
+                "icl_mode": [not item.x_vector_only_mode],
+            }
+            artifacts.append((voice_clone_prompt, item.ref_text))
+        return artifacts
+
+
 class _Qwen3TTSAdhocReferenceHook(
     KeyedReferenceEncodeHook[
         _Qwen3TTSAdhocReferenceInput,
@@ -789,40 +907,26 @@ class _Qwen3TTSAdhocReferenceHook(
     def encode_one(
         self, item: _Qwen3TTSAdhocReferenceInput
     ) -> tuple[dict[str, Any], str | None]:
-        if not item.x_vector_only_mode and not item.ref_text:
-            raise ValueError(
-                "ref_text is required when x_vector_only_mode=False (ICL mode)"
-            )
-        with torch.no_grad():
-            normalized = self._wrapper._normalize_audio_inputs([item.ref_audio])
-            if len(normalized) != 1:
-                raise ValueError("Qwen3-TTS expects exactly one reference audio")
-            waveform, sample_rate = normalized[0]
-            ref_code_future = self._ref_code_batcher.submit(waveform, sample_rate)
-            speaker_waveform = waveform
-            speaker_sample_rate = self._model.speaker_encoder_sample_rate
-            if sample_rate != speaker_sample_rate:
-                import librosa
+        outcome = _encode_qwen3_tts_reference_batch(
+            model=self._model,
+            wrapper=self._wrapper,
+            ref_code_batcher=self._ref_code_batcher,
+            items=[item],
+        )[0]
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
 
-                speaker_waveform = librosa.resample(
-                    y=speaker_waveform.astype("float32"),
-                    orig_sr=int(sample_rate),
-                    target_sr=speaker_sample_rate,
-                )
-            speaker_embedding = self._model.extract_speaker_embedding(
-                audio=speaker_waveform,
-                sr=speaker_sample_rate,
-            )
-            ref_code = _record_ref_code_consumer_stream(
-                ref_code_future.result(timeout=130.0)
-            )
-        voice_clone_prompt = {
-            "ref_code": [None if item.x_vector_only_mode else ref_code],
-            "ref_spk_embedding": [speaker_embedding],
-            "x_vector_only_mode": [item.x_vector_only_mode],
-            "icl_mode": [not item.x_vector_only_mode],
-        }
-        return voice_clone_prompt, item.ref_text
+    def can_encode_batch(self) -> bool:
+        return True
+
+    def encode_batch(self, items: list[_Qwen3TTSAdhocReferenceInput]) -> list[Any]:
+        return _encode_qwen3_tts_reference_batch(
+            model=self._model,
+            wrapper=self._wrapper,
+            ref_code_batcher=self._ref_code_batcher,
+            items=items,
+        )
 
     def store_artifact(self, artifact: tuple[dict[str, Any], str | None]) -> dict:
         voice_clone_prompt, ref_text = artifact
@@ -897,6 +1001,12 @@ def _get_qwen3_tts_adhoc_reference_service_locked(
             max_bytes=64 * 1024 * 1024,
             timeout_s=130.0,
             log_prefix="Qwen3-TTS ad-hoc reference",
+            max_batch_size=8,
+            # Only coalesce requests that are already queued. A non-zero
+            # collection window would be paid by every uncached single request,
+            # while exact-shape speaker batches are workload-dependent.
+            max_batch_wait_ms=0.0,
+            batch_worker_name="qwen3-tts-reference-encode",
         )
         entry = (owner, service)
         _ADHOC_REFERENCE_SERVICE_ENTRY = entry

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -546,7 +546,7 @@ class Qwen3TTSTalker(nn.Module):
         return (getattr(self.config, "spk_id", None) or {}).keys()
 
     @torch.inference_mode()
-    def extract_speaker_embedding(self, audio, sr):
+    def extract_speaker_embeddings(self, audios, sr):
         apply_qwen_tts_transformers_compatibility_patches()
         from qwen_tts.core.models.modeling_qwen3_tts import mel_spectrogram
 
@@ -556,17 +556,49 @@ class Qwen3TTSTalker(nn.Module):
             )
         if self.speaker_encoder is None:
             raise RuntimeError("Qwen3-TTS speaker encoder is not loaded")
-        mels = mel_spectrogram(
-            torch.from_numpy(audio).unsqueeze(0),
-            n_fft=1024,
-            num_mels=128,
-            sampling_rate=self.speaker_encoder_sample_rate,
-            hop_size=256,
-            win_size=1024,
-            fmin=0,
-            fmax=12000,
-        ).transpose(1, 2)
-        return self.speaker_encoder(mels.to(self.device).to(self.dtype))[0]
+        if not audios:
+            return []
+
+        # The upstream ECAPA-TDNN does not propagate a length mask through its
+        # squeeze-excitation blocks. Padding unequal waveforms would therefore
+        # change their embeddings. Batch only identical tensor shapes/dtypes,
+        # then restore the original request order.
+        audio_tensors = [torch.from_numpy(audio) for audio in audios]
+        groups: dict[tuple[tuple[int, ...], torch.dtype], list[int]] = {}
+        for index, audio in enumerate(audio_tensors):
+            groups.setdefault((tuple(audio.shape), audio.dtype), []).append(index)
+
+        results: list[torch.Tensor | None] = [None] * len(audio_tensors)
+        for indices in groups.values():
+            waveforms = torch.stack([audio_tensors[index] for index in indices])
+            mels = mel_spectrogram(
+                waveforms,
+                n_fft=1024,
+                num_mels=128,
+                sampling_rate=self.speaker_encoder_sample_rate,
+                hop_size=256,
+                win_size=1024,
+                fmin=0,
+                fmax=12000,
+            ).transpose(1, 2)
+            embeddings = self.speaker_encoder(mels.to(self.device).to(self.dtype))
+            if len(embeddings) != len(indices):
+                raise RuntimeError(
+                    "Qwen3-TTS speaker encoder returned "
+                    f"{len(embeddings)} embeddings for {len(indices)} references"
+                )
+            for index, embedding in zip(indices, embeddings, strict=True):
+                results[index] = embedding
+
+        if any(result is None for result in results):
+            raise RuntimeError(
+                "Qwen3-TTS speaker embedding batch mapping is incomplete"
+            )
+        return [result for result in results if result is not None]
+
+    @torch.inference_mode()
+    def extract_speaker_embedding(self, audio, sr):
+        return self.extract_speaker_embeddings([audio], sr)[0]
 
     @torch.inference_mode()
     def generate_speaker_prompt(self, voice_clone_prompt: dict[str, Any]):

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -750,6 +750,47 @@ def test_qwen3_tts_preprocessing_executor_admits_concurrent_requests() -> None:
     assert executor._max_concurrency > 1
 
 
+def test_qwen3_tts_reference_service_does_not_wait_for_a_second_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
+    captured: dict[str, object] = {}
+
+    class CapturingReferenceEncodeService:
+        def __init__(self, hook, **kwargs):
+            self._hook = hook
+            captured.update(kwargs)
+
+        def close(self):
+            self._hook.close()
+
+    class FakeSpeechTokenizer:
+        def encode(self, waveforms, *, sr):
+            raise AssertionError("encode must not run in this test")
+
+    model = SimpleNamespace(
+        device=torch.device("cpu"),
+        speech_tokenizer=FakeSpeechTokenizer(),
+    )
+    wrapper = SimpleNamespace(processor=None)
+    monkeypatch.setattr(
+        qwen3_request_builders,
+        "ReferenceEncodeService",
+        CapturingReferenceEncodeService,
+    )
+
+    try:
+        qwen3_request_builders.set_qwen3_tts_preprocessing_context(
+            model=model,
+            wrapper=wrapper,
+        )
+    finally:
+        qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
+
+    assert captured["max_batch_size"] == 8
+    assert captured["max_batch_wait_ms"] == 0.0
+
+
 def test_qwen3_tts_preprocess_payload_batches_reference_codes_across_requests(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -757,7 +798,12 @@ def test_qwen3_tts_preprocess_payload_batches_reference_codes_across_requests(
     cache.clear()
     qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
     batch_sizes: list[int] = []
-    both_normalizing = threading.Barrier(2)
+    speaker_batch_sizes: list[int] = []
+
+    class PatientReferenceEncodeService(qwen3_request_builders.ReferenceEncodeService):
+        def __init__(self, *args, **kwargs):
+            kwargs["max_batch_wait_ms"] = 500.0
+            super().__init__(*args, **kwargs)
 
     class PatientRefCodeBatcher(qwen3_request_builders._Qwen3TTSRefCodeBatcher):
         def __init__(self, speech_tokenizer, **kwargs):
@@ -768,6 +814,11 @@ def test_qwen3_tts_preprocess_payload_batches_reference_codes_across_requests(
         qwen3_request_builders,
         "_Qwen3TTSRefCodeBatcher",
         PatientRefCodeBatcher,
+    )
+    monkeypatch.setattr(
+        qwen3_request_builders,
+        "ReferenceEncodeService",
+        PatientReferenceEncodeService,
     )
 
     class FakeSpeechTokenizer:
@@ -783,8 +834,10 @@ def test_qwen3_tts_preprocess_payload_batches_reference_codes_across_requests(
 
     class FakeWrapper:
         def _normalize_audio_inputs(self, ref_audio):
-            both_normalizing.wait(timeout=5.0)
-            return [(np.zeros(32, dtype=np.float32), 24000)]
+            return [
+                (np.full(32, index, dtype=np.float32), 24000)
+                for index, _ in enumerate(ref_audio)
+            ]
 
         def _tokenize_texts(self, texts):
             return [torch.arange(len(texts[0]), dtype=torch.long).unsqueeze(0)]
@@ -807,6 +860,11 @@ def test_qwen3_tts_preprocess_payload_batches_reference_codes_across_requests(
 
         def extract_speaker_embedding(self, *, audio, sr):
             return torch.ones(4)
+
+        def extract_speaker_embeddings(self, *, audios, sr):
+            assert sr == 24000
+            speaker_batch_sizes.append(len(audios))
+            return [torch.full((4,), index + 1.0) for index in range(len(audios))]
 
         def build_voice_clone_inputs(self, **kwargs):
             del kwargs
@@ -874,6 +932,7 @@ def test_qwen3_tts_preprocess_payload_batches_reference_codes_across_requests(
 
     assert prepared_count == 2
     assert batch_sizes == [2]
+    assert speaker_batch_sizes == [2]
 
 
 def test_qwen3_tts_reference_code_overlaps_speaker_embedding() -> None:
@@ -916,6 +975,188 @@ def test_qwen3_tts_reference_code_overlaps_speaker_embedding() -> None:
 
     assert ref_text == "reference"
     assert prompt["icl_mode"] == [True]
+
+
+def test_qwen3_tts_reference_hook_batch_preserves_item_mapping() -> None:
+    speaker_batches: list[list[int]] = []
+
+    class FakeSpeechTokenizer:
+        def encode(self, waveforms, *, sr):
+            assert sr == 24000
+            return SimpleNamespace(
+                audio_codes=[
+                    torch.tensor([index], dtype=torch.long)
+                    for index in range(len(waveforms))
+                ]
+            )
+
+    class FakeWrapper:
+        def _normalize_audio_inputs(self, raw_inputs):
+            return [
+                (np.full(4 + index, index + 1, dtype=np.float32), 24000)
+                for index, _ in enumerate(raw_inputs)
+            ]
+
+    class FakeModel:
+        device = torch.device("cpu")
+        speech_tokenizer = FakeSpeechTokenizer()
+        speaker_encoder_sample_rate = 24000
+
+        def extract_speaker_embeddings(self, *, audios, sr):
+            assert sr == 24000
+            speaker_batches.append([len(audio) for audio in audios])
+            return [torch.tensor([10 + index]) for index in range(len(audios))]
+
+    hook = qwen3_request_builders._Qwen3TTSAdhocReferenceHook(
+        model=FakeModel(),
+        wrapper=FakeWrapper(),
+    )
+    items = [
+        qwen3_request_builders._Qwen3TTSAdhocReferenceInput(
+            ref_audio=f"audio-{index}",
+            ref_text=None if index == 1 else f"text-{index}",
+            x_vector_only_mode=index == 1,
+        )
+        for index in range(3)
+    ]
+    try:
+        artifacts = hook.encode_batch(items)
+    finally:
+        hook.close()
+
+    assert hook.can_encode_batch() is True
+    assert speaker_batches == [[4, 5, 6]]
+    assert [artifact[1] for artifact in artifacts] == ["text-0", None, "text-2"]
+    assert [artifact[0]["icl_mode"] for artifact in artifacts] == [
+        [True],
+        [False],
+        [True],
+    ]
+    assert torch.equal(artifacts[0][0]["ref_code"][0], torch.tensor([0]))
+    assert artifacts[1][0]["ref_code"] == [None]
+    assert torch.equal(artifacts[2][0]["ref_code"][0], torch.tensor([2]))
+
+
+@pytest.mark.parametrize("speaker_fallback_succeeds", [True, False])
+def test_qwen3_tts_reference_batch_fallback_reuses_ref_codes(
+    speaker_fallback_succeeds: bool,
+) -> None:
+    submitted_items: list[int] = []
+    single_speaker_inputs: list[int] = []
+
+    class FakeSpeechTokenizer:
+        def encode(self, waveforms, *, sr):
+            submitted_items.append(len(waveforms))
+            return SimpleNamespace(
+                audio_codes=[torch.tensor([index]) for index in range(len(waveforms))]
+            )
+
+    class FakeWrapper:
+        def _normalize_audio_inputs(self, raw_inputs):
+            return [
+                (np.full(8, index, dtype=np.float32), 24000)
+                for index, _ in enumerate(raw_inputs)
+            ]
+
+    class FakeModel:
+        device = torch.device("cpu")
+        speech_tokenizer = FakeSpeechTokenizer()
+        speaker_encoder_sample_rate = 24000
+
+        def extract_speaker_embeddings(self, *, audios, sr):
+            raise RuntimeError("speaker batch failed")
+
+        def extract_speaker_embedding(self, *, audio, sr):
+            single_speaker_inputs.append(int(audio[0]))
+            if not speaker_fallback_succeeds:
+                raise RuntimeError("speaker batch failed")
+            return torch.tensor([10 + int(audio[0])])
+
+    hook = qwen3_request_builders._Qwen3TTSAdhocReferenceHook(
+        model=FakeModel(),
+        wrapper=FakeWrapper(),
+    )
+    items = [
+        qwen3_request_builders._Qwen3TTSAdhocReferenceInput(
+            ref_audio=f"audio-{index}",
+            ref_text=f"text-{index}",
+            x_vector_only_mode=False,
+        )
+        for index in range(2)
+    ]
+    try:
+        outcomes = hook.encode_batch(items)
+    finally:
+        hook.close()
+
+    if speaker_fallback_succeeds:
+        assert not any(isinstance(outcome, BaseException) for outcome in outcomes)
+    else:
+        assert all(
+            isinstance(outcome, RuntimeError) and str(outcome) == "speaker batch failed"
+            for outcome in outcomes
+        )
+    assert single_speaker_inputs == [0, 1]
+    assert sum(submitted_items) == len(items)
+
+
+def test_qwen3_tts_speaker_embedding_batch_groups_equal_shapes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang(monkeypatch)
+    from sglang_omni.models.qwen3_tts import sglang_model
+
+    batch_sizes: list[int] = []
+
+    class FakeSpeakerEncoder:
+        def __call__(self, mels):
+            batch_sizes.append(mels.shape[0])
+            return mels.sum(dim=(1, 2), keepdim=True)
+
+    def fake_mel_spectrogram(waveforms, **kwargs):
+        del kwargs
+        return waveforms.unsqueeze(1)
+
+    qwen_tts = types.ModuleType("qwen_tts")
+    qwen_tts.__path__ = []
+    qwen_tts_core = types.ModuleType("qwen_tts.core")
+    qwen_tts_core.__path__ = []
+    qwen_tts_models = types.ModuleType("qwen_tts.core.models")
+    qwen_tts_models.__path__ = []
+    qwen_tts_modeling = types.ModuleType("qwen_tts.core.models.modeling_qwen3_tts")
+    qwen_tts_modeling.mel_spectrogram = fake_mel_spectrogram
+    for name, module in (
+        ("qwen_tts", qwen_tts),
+        ("qwen_tts.core", qwen_tts_core),
+        ("qwen_tts.core.models", qwen_tts_models),
+        ("qwen_tts.core.models.modeling_qwen3_tts", qwen_tts_modeling),
+    ):
+        monkeypatch.setitem(sys.modules, name, module)
+    monkeypatch.setattr(
+        sglang_model,
+        "apply_qwen_tts_transformers_compatibility_patches",
+        lambda: None,
+    )
+
+    talker = SimpleNamespace(
+        speaker_encoder_sample_rate=24000,
+        speaker_encoder=FakeSpeakerEncoder(),
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+    )
+    audios = [
+        np.full(4, 1.0, dtype=np.float32),
+        np.full(6, 2.0, dtype=np.float32),
+        np.full(4, 3.0, dtype=np.float32),
+    ]
+    embeddings = sglang_model.Qwen3TTSTalker.extract_speaker_embeddings(
+        talker,
+        audios,
+        24000,
+    )
+
+    assert batch_sizes == [2, 1]
+    assert [float(value.item()) for value in embeddings] == [4.0, 12.0, 12.0]
 
 
 def test_qwen3_tts_reference_code_batcher_synchronizes_cuda_results(


### PR DESCRIPTION
## Summary

- opportunistically coalesce already-queued Qwen3-TTS ad-hoc reference cache misses through the existing `ReferenceEncodeService`
- keep the existing dedicated-stream speech-tokenizer batching from #1336, while grouping identical-shape waveforms into one mel/ECAPA speaker-encoder forward
- preserve per-request ordering, cache/single-flight behavior, ICL/x-vector semantics, and the single-item compatibility path

Unequal waveforms are deliberately not padded together: the upstream ECAPA implementation does not propagate a padding-length mask through its squeeze-excitation path, so padding can change the speaker embedding.

This is a narrower follow-up to the earlier Qwen3-TTS reference-preprocessing work in #1336. It does not replace the ref-code batcher or its dedicated CUDA stream; it batches the remaining speaker-embedding stage when concurrent references have an exact shape/dtype match.

## Production-safety details

- `max_batch_wait_ms=0`: only requests already present in the queue coalesce, so a lone uncached request does not pay a fixed collection delay.
- Cache hits and same-key followers resolve before this queue and are never re-encoded.
- If a grouped speaker forward fails, the hook retries only the speaker stage per item and reuses the already-running ref-code futures. This avoids duplicate tokenizer GPU submissions and keeps failures request-local.

## Supporting operator result

Measured on an NVIDIA GeForce RTX 5090 with PyTorch 2.11.0+cu130, BF16, and `Qwen/Qwen3-TTS-12Hz-0.6B-Base`. Eight mixed 3 s / 5 s references, 10 warmups, and 50 alternating A/B iterations:

| Path | ECAPA calls | CUDA Event p50 |
| --- | ---: | ---: |
| Sequential | 8 | 299.76 ms |
| Exact-shape grouped | 2 | 94.91 ms |

This is a **3.158x speedup for the isolated mel + ECAPA stage only**. It is not an end-to-end serving claim. Minimum cosine similarity was `0.9999967`; maximum relative L2 error was `0.2597%` in BF16.

## Validation

- rebased onto current `main`
- `150 passed, 5 skipped` across the Qwen3-TTS pipeline and shared reference-encoder batching suites; the skipped tests require CUDA
- focused coverage for real service coalescing, item mapping, exact-shape grouping, zero-wait configuration, speaker-only fallback, duplicate-work prevention, CUDA stream handoff, and shutdown behavior
- Black 24.10, autoflake 2.3.1, isort, `py_compile`, and `git diff --check`

## Draft status / remaining performance gate

This PR stays Draft until the current zero-wait production service path is measured on H20 at concurrency 1/2/4/8 with:

- repeated equal durations and arbitrary unique durations
- actual speaker group-size distribution from a representative reference workload
- TTFA/prefill latency, throughput, quality metrics, and A/A noise

The goal is to verify a deployment-level win without regressing concurrency-one or arbitrary-length requests before requesting maintainer review.
