### PR TITLE
test: restore scheduler attribute names in qwen3_omni test stubs

### DIFF
--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -735,14 +735,14 @@ def test_qwen_code2wav_graph_output_protocol_matches_eager_exactly() -> None:
 def test_qwen_code2wav_consumes_borrowed_output_under_state_lock() -> None:
     class _BorrowedOutputRunner:
         def __init__(self) -> None:
-            self.factory = None
+            self.scheduler = None
             self.static_output = torch.zeros((1, 1, 2), dtype=torch.float32)
             self.lock_was_held: list[bool] = []
             self.replays = 0
 
         def run(self, codes: torch.Tensor, *, eligible: bool) -> Code2WavRunResult:
             assert eligible
-            self.lock_was_held.append(self.factory._state_lock._is_owned())
+            self.lock_was_held.append(self.scheduler._state_lock._is_owned())
             self.replays += 1
             self.static_output.fill_(float(self.replays))
             return Code2WavRunResult(
@@ -762,7 +762,7 @@ def test_qwen_code2wav_consumes_borrowed_output_under_state_lock() -> None:
         enable_cuda_graph=True,
         _cuda_graph_runner=runner,
     )
-    runner.factory = scheduler
+    runner.scheduler = scheduler
     _seed_stream_state(scheduler)
 
     for chunk_id in range(2):

--- a/tests/unit_test/qwen3_omni/test_streaming.py
+++ b/tests/unit_test/qwen3_omni/test_streaming.py
@@ -897,7 +897,7 @@ def _bare_stage(*, is_terminal: bool, owns_io: bool = True) -> Stage:
     s._nonlocal_stream_targets = {}
     s.relay = SimpleNamespace()
     s.input_handler = SimpleNamespace(cancel=lambda request_id: None)
-    s.factory_path = SimpleNamespace(abort=lambda request_id: None)
+    s.scheduler = SimpleNamespace(abort=lambda request_id: None)
     s.control_plane = SimpleNamespace(completions=[])
 
     async def _send_complete(msg):


### PR DESCRIPTION
Two more leftovers from the #1494 rename (same class as #1729), in test stubs only:

- `tests/unit_test/qwen3_omni/test_streaming.py`: `_bare_stage()` set `s.factory_path` instead of `s.scheduler`; `Stage` in `sglang_omni/pipeline/stage/runtime.py` reads `self.scheduler.abort(...)`, so the stub attribute name is wrong.
- `tests/unit_test/qwen3_omni/test_code2wav.py`: the fake runner's `self.scheduler` / `runner.scheduler` (a `Code2WavScheduler`) was renamed to `.factory`; test-internal only, but the name is misleading.

No production code changes.