### PR TITLE
[Qwen3-Omni] Fix process replica configs after config refactor

### DIFF
--- a/docs/basic_usage/process_topology_migration.md
+++ b/docs/basic_usage/process_topology_migration.md
@@ -8,9 +8,12 @@ removed and are not auto-migrated.
 
 | Removed entry | Replacement |
 | --- | --- |
-| `--isolate-stage vocoder` | `--stages.vocoder.process vocoder` |
-| `--stage-process preprocessing=frontend` | `--stages.preprocessing.process frontend` |
+| `--isolate-stage vocoder` | `--vocoder.process vocoder` |
+| `--stage-process preprocessing=frontend` | `--preprocessing.process frontend` |
 | `fused_stages: [[a, b]]` | Set the same `process` value on stages `a` and `b`. |
+
+The CLI already implies the `stages.` prefix. An explicit flag such as
+`--stages.vocoder.process` is rejected.
 
 ## Migrating `fused_stages`
 
@@ -25,16 +28,18 @@ After:
 
 ```yaml
 stages:
-  - name: preprocessing
+  preprocessing:
     process: frontend
-  - name: audio_encoder
+  audio_encoder:
     process: frontend
 ```
 
 Keep all existing factory, routing, runtime, and placement fields when updating
-a complete config. Every non-TP stage must declare `process`; equal names share
-one OS process and different names isolate stages. A TP stage owns its process
-exclusively.
+a complete config. Use the actual Stage Names declared by the model config;
+legacy isolation-role aliases are not translated. Re-check edge transport and
+memory budgets when a handoff changes from local to cross-process. Every non-TP
+stage must declare `process`; equal names share one OS process and different
+names isolate stages. A TP stage owns its process exclusively.
 
 The top-level `processes` mapping only configures replicas for process names
 already declared by stages. See the

--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -17,7 +17,7 @@ MODEL_PATH=$(hf download Qwen/Qwen3-ASR-1.7B --revision "${MODEL_REVISION}")
 
 Qwen3-ASR runs a single ASR stage on one GPU. Its default `auto` dtype follows
 the checkpoint configuration (BF16 for Qwen3-ASR-1.7B); pass
-`--stages.asr.factory-args.dtype float16` to force FP16.
+`--asr.factory.dtype float16` to force FP16.
 Async decode is enabled by default for all decode batch sizes, allowing the
 shared one-step-lookahead path to overlap host-side result processing with the
 next GPU decode forward even for a single request. Use `--asr.factory.enable_async_decode false` to

--- a/docs/developer_reference/config.md
+++ b/docs/developer_reference/config.md
@@ -170,7 +170,7 @@ overrode. Both run the same merge as `serve`.
 | `route_fn` | `str` or `None` | `None` | Dotted function path for request-aware result routing. The function receives `(request_id, stage_output)` and returns a downstream stage name or list of stage names. |
 | `gpu` | `int`, `list[int]`, or `None` | `None` | GPU id for the stage. `None` means CPU placement. A list is used for tensor parallel ranks. |
 | `tp_size` | `int` | `1` | Number of tensor-parallel ranks. Must match `len(gpu)` when `gpu` is a list. |
-| `gpu_memory_fraction` | `float` or `None` | `None` | Per-stage-rank budget as a fraction of total physical GPU memory. Required per stage when multiple processes share one GPU. |
+| `gpu_memory_fraction` | `float` or `None` | `None` | Per-stage-rank budget as a fraction of total physical GPU memory. Required according to the GPU-colocation rules below. |
 | `process` | `str` or `None` | `None` | OS process group identifier. Non-TP stages with the same `process` value share a single OS process; every non-TP stage must declare one explicitly. For TP stages, `process` is optional and acts as a prefix for the derived rank-process names (`{process}_tp{rank}`); if unset, the stage name is used as the prefix. |
 | `env` | `dict[str, str]` | `{}` | Per-stage env defaults applied in this stage's worker process at spawn; never overrides `os.environ`. |
 | `wait_for` | `list[str]` or `None` | `None` | Upstream stages required before this stage can execute a request. |
@@ -196,7 +196,7 @@ as the static superset because runtime prep derives stream receivers from it.
 | `stages` | `list[StageConfig]` | required | Stage definitions. Config files override fields on them by name and cannot add or remove stages. |
 | `name` | `str` or `None` | `model_path` | Pipeline name. Used for reporting and runtime identification. |
 | `entry_stage` | `str` or `None` | first stage | Declared by the config class when the first stage is not the entry. Not settable from a config file or the CLI. |
-| `fused_stages` | `list[list[str]]` | `[]` | Adjacent linear stage groups to colocate in one runtime process. |
+| `processes` | `dict[str, ProcessConfig]` | `{}` | Sparse whole-process replica policy, keyed by an existing logical Process Name. |
 | `env_defaults` | `dict[str, str]` | `{}` | Environment defaults applied before stage factory imports. Existing process values take precedence. |
 | `endpoints` | `EndpointsConfig` | IPC defaults | Endpoint allocation settings. |
 | `placement` | `PlacementConfig` | defaults | Placement planning limits, e.g. `max_total_gpu_memory_fraction_per_gpu`. |
@@ -218,13 +218,58 @@ Class-level hooks a model config may declare:
 Derived values are computed from stages, not manually maintained:
 `resolved_entry_stage`, `terminal_stages`, `gpu_placement`.
 
-### Stage Fusion
+### Logical Processes and Replicas
 
-`fused_stages` is a framework-level colocation hint. It keeps every listed
-logical stage as a normal `Stage`; it does not create a synthetic scheduler.
-At runtime prep, each fused group adds a process-colocation constraint, and
-ordinary Stage routing can then use process-local dispatch for eligible hops.
-A group must be adjacent, linear, non-TP, and fit on at most one GPU.
+`StageConfig.process` declares process membership. Non-TP stages with the same
+value share one OS process; different values isolate them. A TP stage always
+owns its process and may omit `process`, in which case its Stage Name supplies
+the logical Process Name.
+
+The top-level `processes` mapping adds a sparse replica policy to those logical
+Processes. It does not define membership and cannot name a Process that the
+stages do not declare.
+
+| `ProcessConfig` field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `num_replicas` | `int >= 1` | `1` | Number of whole-Process instances. |
+| `replica_devices` | `int`, `list[int]`, comma-separated `str`, or `None` | `None` | GPU ids for every replica, including replica 0. A non-TP Process needs one id per replica; a TP Process needs `num_replicas * tp_size` ids. |
+
+For example, this copies the complete `tail` Process. Each replica contains
+both its GPU `generate` Stage and its CPU `decode` Stage:
+
+```yaml
+stages:
+  generate:
+    process: tail
+    gpu_memory_fraction: 0.4
+  decode:
+    process: tail
+
+processes:
+  tail:
+    num_replicas: 2
+    replica_devices: [1, 2]
+```
+
+With `num_replicas: N`, member Stage instances use the reserved `@rN` suffix.
+`replica_devices` overrides the GPU placement of GPU members and leaves CPU
+members on the host. A GPU Process with more than one replica must declare it;
+at `num_replicas: 1` it may be omitted, or supplied as an explicit placement
+override.
+
+Final replica placement participates in the normal GPU-colocation validation.
+When multiple Process groups share a GPU and the general colocation requirement
+is enabled, every affected GPU Stage needs `gpu_memory_fraction`. Sharing
+introduced by `replica_devices` always requires those fractions, even if the
+general requirement is disabled. Declared fractions must fit
+`placement.max_total_gpu_memory_fraction_per_gpu`.
+
+At admission, the coordinator selects one replica for each replicated Process
+and keeps that binding for the request lifetime. The default policy is
+thread-safe round robin per Process. Equal-size Processes happen to remain
+same-index aligned under that policy, but cross-Process affinity is not part of
+the binding contract. Replica counts and placement are resolved at startup;
+the config does not provide live scaling.
 
 ## How Values Reach a Factory
 

--- a/examples/configs/qwen3_omni_speech_code2wav_replica2_ci.yaml
+++ b/examples/configs/qwen3_omni_speech_code2wav_replica2_ci.yaml
@@ -1,45 +1,30 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Two-GPU process-replica coverage used by CI:
-#   GPU 0: thinker + code2wav@r0
+#   GPU 0: image_encoder + audio_encoder + thinker + code2wav@r0
 #   GPU 1: talker_ar + code2wav@r1
 
 config_cls: Qwen3OmniSpeechPipelineConfig
 name: qwen3-omni-speech-code2wav-replica2-ci
 model_path: Qwen/Qwen3-Omni-30B-A3B-Instruct
 
+stages:
+  image_encoder:
+    gpu_memory_fraction: 0.02
+
+  audio_encoder:
+    gpu_memory_fraction: 0.02
+
+  thinker:
+    gpu_memory_fraction: 0.78
+
+  talker_ar:
+    gpu_memory_fraction: 0.10
+
+  code2wav:
+    gpu_memory_fraction: 0.02
+
 processes:
   code2wav:
     num_replicas: 2
     replica_devices: [0, 1]
-
-stage_overrides:
-  image_encoder:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.02
-
-  audio_encoder:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.02
-
-  mm_aggregate:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.02
-
-  thinker:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.78
-
-  talker_ar:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.10
-
-  code2wav:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.02

--- a/examples/configs/qwen3_omni_speech_replica2.yaml
+++ b/examples/configs/qwen3_omni_speech_replica2.yaml
@@ -4,7 +4,7 @@
 # processes.
 #
 # Layout (3 GPUs):
-#   GPU 0: thinker (single instance)
+#   GPU 0: image_encoder + audio_encoder + thinker
 #   GPU 1: talker_ar@r0 + code2wav@r0
 #   GPU 2: talker_ar@r1 + code2wav@r1
 #
@@ -19,22 +19,19 @@
 #   sgl-omni serve --config examples/configs/qwen3_omni_speech_replica2.yaml --port 8091
 #
 # Baseline A/B counterpart: the default speech pipeline (no --config needed),
-# which runs one talker_ar + code2wav pair on GPU 1.
+# which places image_encoder + audio_encoder + thinker + code2wav on GPU 0 and
+# talker_ar on GPU 1.
 
 config_cls: Qwen3OmniSpeechPipelineConfig
 name: qwen3-omni-speech-replica2
 model_path: Qwen/Qwen3-Omni-30B-A3B-Instruct
 
-stage_overrides:
+stages:
   talker_ar:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.123
+    gpu_memory_fraction: 0.123
 
   code2wav:
-    runtime:
-      resources:
-        total_gpu_memory_fraction: 0.014
+    gpu_memory_fraction: 0.014
 
 processes:
   talker_ar:

--- a/tests/unit_test/qwen3_omni/test_config_manager.py
+++ b/tests/unit_test/qwen3_omni/test_config_manager.py
@@ -10,6 +10,7 @@ from sglang_omni.config.manager import ConfigManager
 from sglang_omni.models.qwen3_omni.config import (
     Qwen3OmniPipelineConfig,
     Qwen3OmniSpeechColocatedPipelineConfig,
+    Qwen3OmniSpeechPipelineConfig,
 )
 from tests.unit_test.pipeline.helpers import build_compiled_process_topology
 
@@ -147,6 +148,51 @@ def test_qwen3_omni_mmsu_example_config_uses_text_pipeline() -> None:
     assert plan.gpus[0].total_gpu_memory_fraction == pytest.approx(0.8)
     assert thinker_args["total_gpu_memory_fraction"] == pytest.approx(0.75)
     assert thinker_args["server_args_overrides"]["max_running_requests"] == 4
+
+
+@pytest.mark.parametrize(
+    ("config_name", "expected_fractions", "expected_replica_devices"),
+    [
+        (
+            "qwen3_omni_speech_replica2.yaml",
+            {"talker_ar": 0.123, "code2wav": 0.014},
+            {"talker_ar": [1, 2], "code2wav": [1, 2]},
+        ),
+        (
+            "qwen3_omni_speech_code2wav_replica2_ci.yaml",
+            {
+                "image_encoder": 0.02,
+                "audio_encoder": 0.02,
+                "thinker": 0.78,
+                "talker_ar": 0.10,
+                "code2wav": 0.02,
+            },
+            {"code2wav": [0, 1]},
+        ),
+    ],
+)
+def test_qwen3_omni_process_replica_example_configs_load_and_plan(
+    config_name: str,
+    expected_fractions: dict[str, float],
+    expected_replica_devices: dict[str, list[int]],
+) -> None:
+    config_path = _REPO_ROOT / "examples" / "configs" / config_name
+
+    config = ConfigManager.from_file(str(config_path)).config
+    topology = build_compiled_process_topology(config)
+    groups = {group.name: group for group in topology.groups}
+
+    assert isinstance(config, Qwen3OmniSpeechPipelineConfig)
+    for stage_name, expected_fraction in expected_fractions.items():
+        assert _stage(config, stage_name).gpu_memory_fraction == pytest.approx(
+            expected_fraction
+        )
+    for process_name, expected_devices in expected_replica_devices.items():
+        process = config.processes[process_name]
+        assert process.num_replicas == len(expected_devices)
+        assert process.replica_devices == expected_devices
+        for replica_id, expected_device in enumerate(expected_devices):
+            assert groups[f"{process_name}@r{replica_id}"].gpu_id == expected_device
 
 
 def test_qwen_preprocessing_model_video_fps_resolves_to_factory_arg() -> None:


### PR DESCRIPTION
## Motivation

#1494 removed `stage_overrides`, but the two Qwen3-Omni process-replica examples added by #1175 still used it, so `ConfigManager.from_file()` rejected both shipped configs. The failure was masked because neither YAML was loaded by a unit-test CI lane.

## Modifications

- Migrate both replica examples to `stages.<name>.gpu_memory_fraction`, remove the stale `mm_aggregate` override, and correct their documented GPU layouts.
- Add parameterized regression coverage that loads each example, compiles its process topology, and verifies memory fractions, replica devices, and final GPU placement.
- Restore the `ProcessConfig` and whole-Process replica reference, and fix stale canonical YAML/CLI examples.

## Related Issues

Follow-up to #1175 and #1494.

## Accuracy Test

N/A — this PR does not change model code or output behavior.

## Benchmark & Profiling

N/A — this PR does not change runtime or performance behavior.

## Validation

```text
python -m pytest -q tests/unit_test/qwen3_omni/test_config_manager.py
14 passed

python -m pytest -q tests/unit_test/pipeline/test_replicas.py
50 passed

pre-commit run --all-files
All hooks passed

make html SPHINXBUILD=../.venv/bin/sphinx-build
build succeeded
```

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
