### PR TITLE
[Fix] Make MiniMax Music 3 serial offload run, and actually save memory

### DIFF
--- a/sglang_omni/models/minimax_music3/acoustic.py
+++ b/sglang_omni/models/minimax_music3/acoustic.py
@@ -509,7 +509,7 @@ class MiniMaxMusic3AcousticScheduler(StreamingSimpleScheduler):
             state.last_condition = None
         if self._decoder.serial_offload:
             self._decoder.offload_to_cpu()
-            get_coordinator().end_dit_handoff()
+            get_coordinator().end_dit_handoff(request_id)
 
 
 __all__ = [

--- a/sglang_omni/models/minimax_music3/acoustic.py
+++ b/sglang_omni/models/minimax_music3/acoustic.py
@@ -37,7 +37,7 @@ from .constants import (
 from .dav import MiniMaxMusic3DAV, remove_weight_norm, select_decoder_state
 from .dit import MiniMaxMusic3DIT
 from .payload_types import MiniMaxMusic3State
-from .serial_offload import get_coordinator, move_module_to_device
+from .serial_offload import ModuleResidency, get_coordinator
 
 logger = logging.getLogger(__name__)
 
@@ -180,6 +180,11 @@ class MiniMaxMusic3AcousticDecoder:
                     "relocated once the module moves off the GPU)"
                 )
                 self.breakable_cuda_graph_requested = False
+        # Serial offload parks DIT/DAV on the host between requests, so load
+        # them straight there. Staging the checkpoint through the GPU would
+        # peak with AR and DIT/DAV both fully resident, which is precisely the
+        # peak this mode exists to avoid.
+        self._load_device = torch.device("cpu") if self._serial_offload else self.device
         if self.cache_dit and self.breakable_cuda_graph_requested:
             raise ValueError(
                 "MiniMax Music 3 cache_dit and breakable_cuda_graph cannot be enabled together"
@@ -216,9 +221,12 @@ class MiniMaxMusic3AcousticDecoder:
         logger.info(
             f"MiniMax Music 3 acoustic runtime dit_steps={self.dit_steps} dit_cfg_scale={self.dit_cfg_scale:.3f} attention_backend={self.attention_backend} cache_dit={self.cache_dit} compile_acoustic={self.compile_acoustic} breakable_cuda_graph={self.breakable_cuda_graph} breakable_cuda_graph_requested={self.breakable_cuda_graph_requested}"
         )
-        self._resident_on_gpu = True
+        self._residency: tuple[ModuleResidency, ...] = ()
         if self._serial_offload:
-            self.offload_to_cpu()
+            self._residency = (
+                ModuleResidency(self.dit, self.device, resident=False),
+                ModuleResidency(self.dav, self.device, resident=False),
+            )
 
     @property
     def serial_offload(self) -> bool:
@@ -226,19 +234,13 @@ class MiniMaxMusic3AcousticDecoder:
 
     def ensure_gpu_resident(self) -> None:
         """Restore DIT/DAV to the GPU; a cheap no-op once already resident."""
-        if self._resident_on_gpu:
-            return
-        move_module_to_device(self.dit, self.device)
-        move_module_to_device(self.dav, self.device)
-        self._resident_on_gpu = True
+        for residency in self._residency:
+            residency.wake()
 
     def offload_to_cpu(self) -> None:
-        """Move DIT/DAV off the GPU; a cheap no-op once already offloaded."""
-        if not self._resident_on_gpu:
-            return
-        move_module_to_device(self.dit, torch.device("cpu"))
-        move_module_to_device(self.dav, torch.device("cpu"))
-        self._resident_on_gpu = False
+        """Drop the DIT/DAV GPU replica; a no-op once already offloaded."""
+        for residency in self._residency:
+            residency.sleep()
 
     def _build_dit(
         self,
@@ -251,9 +253,9 @@ class MiniMaxMusic3AcousticDecoder:
         cache_dit_max_continuous_cached_steps: int,
     ) -> None:
         logger.info(
-            f"Loading MiniMax Music 3 PyTorch DIT from {dit_path} on device={self.device} dtype={self.dtype}"
+            f"Loading MiniMax Music 3 PyTorch DIT from {dit_path} on device={self._load_device} dtype={self.dtype}"
         )
-        state = load_torch_state(dit_path, device=self.device)
+        state = load_torch_state(dit_path, device=self._load_device)
         logger.info(
             f"MiniMax Music 3 DIT checkpoint variant=FM8/ELMo condition_hidden=32768 state_keys={len(state)}"
         )
@@ -291,7 +293,7 @@ class MiniMaxMusic3AcousticDecoder:
     def _build_dav(self, dav_path: str) -> int:
         """Load the DAV decoder and return how many weight norms were folded."""
         logger.info(f"Loading MiniMax Music 3 DAV from {dav_path}")
-        state = load_torch_state(dav_path, device=self.device)
+        state = load_torch_state(dav_path, device=self._load_device)
         with torch.device("meta"):
             self.dav = MiniMaxMusic3DAV()
         self.dav.load_state_dict(select_decoder_state(state), strict=True, assign=True)

--- a/sglang_omni/models/minimax_music3/acoustic.py
+++ b/sglang_omni/models/minimax_music3/acoustic.py
@@ -217,7 +217,7 @@ class MiniMaxMusic3AcousticDecoder:
             f"MiniMax Music 3 acoustic runtime dit_steps={self.dit_steps} dit_cfg_scale={self.dit_cfg_scale:.3f} attention_backend={self.attention_backend} cache_dit={self.cache_dit} compile_acoustic={self.compile_acoustic} breakable_cuda_graph={self.breakable_cuda_graph} breakable_cuda_graph_requested={self.breakable_cuda_graph_requested}"
         )
         self._resident_on_gpu = True
-        if self._serial_offload:s
+        if self._serial_offload:
             self.offload_to_cpu()
 
     @property

--- a/sglang_omni/models/minimax_music3/acoustic.py
+++ b/sglang_omni/models/minimax_music3/acoustic.py
@@ -224,8 +224,8 @@ class MiniMaxMusic3AcousticDecoder:
         self._residency: tuple[ModuleResidency, ...] = ()
         if self._serial_offload:
             self._residency = (
-                ModuleResidency(self.dit, self.device, resident=False),
-                ModuleResidency(self.dav, self.device, resident=False),
+                ModuleResidency(self.dit, self.device, resident=False, label="dit"),
+                ModuleResidency(self.dav, self.device, resident=False, label="dav"),
             )
 
     @property

--- a/sglang_omni/models/minimax_music3/model_runner.py
+++ b/sglang_omni/models/minimax_music3/model_runner.py
@@ -200,7 +200,7 @@ class MiniMaxMusic3ModelRunner(ModelRunner):
         logger.info(
             f"MiniMax Music 3 AR done request={request_id} frames={ar_state.generated_frames} prompt_tokens={req_data.prompt_tokens} finish_reason={ar_state.finish_reason} peak_buffer_frames={ar_state.frames.peak_frames} elapsed={time.perf_counter() - ar_state.started_s:.1f}s"
         )
-        self._serial_offload.begin_dit_handoff()
+        self._serial_offload.begin_dit_handoff(request_id)
 
     def reset_request(self, request_id: str) -> None:
         data = self._request_data.pop(request_id, None)

--- a/sglang_omni/models/minimax_music3/serial_offload.py
+++ b/sglang_omni/models/minimax_music3/serial_offload.py
@@ -1,18 +1,38 @@
 # SPDX-License-Identifier: Apache-2.0
+"""Serial GPU residency for the MiniMax Music 3 AR and DIT/DAV stages.
+
+``--layerwise-offload-components ar,dit`` colocates both stages in one process
+and lets only one of them hold GPU weights at a time: AR generates a whole
+request, hands off to DIT/DAV, and stays off the GPU until DIT/DAV is finished
+with that request.
+
+The handoff is keyed by request id rather than by a single boolean. AR wakes
+when nothing is outstanding, so a duplicated, out-of-order, or late terminal
+event cannot wake AR while DIT/DAV is still decoding, and an event that names
+a request nobody handed off cannot wake AR early.
+
+A handoff that never ends stops admission for good, because ``ar_can_admit``
+gates the AR scheduler's queue. That is reported rather than force-corrected:
+waking AR while DIT/DAV still holds the GPU is how this configuration runs out
+of memory, so a stuck server is preferable to a crashed one, and the log names
+the requests still outstanding.
+"""
 
 from __future__ import annotations
 
 import logging
 import threading
+import time
 from typing import Any
 
 import torch
 
 logger = logging.getLogger(__name__)
 
+STALL_REPORT_SECONDS = 900.0
+
 
 def move_module_to_device(module: Any, device: torch.device) -> None:
-
     source_device = None
     try:
         source_device = next(module.parameters()).device
@@ -36,6 +56,9 @@ class SerialOffloadCoordinator:
         self._ar_active = True
         self._ar_model: Any | None = None
         self._ar_device: torch.device | None = None
+        self._outstanding: set[str] = set()
+        self._paused_at: float | None = None
+        self._stall_reported = False
 
     @property
     def enabled(self) -> bool:
@@ -57,37 +80,73 @@ class SerialOffloadCoordinator:
         if not self._enabled:
             return True
         with self._lock:
-            return self._ar_active
+            if self._ar_active:
+                return True
+            self._report_stall_locked()
+            return False
 
-    def begin_dit_handoff(self) -> None:
+    def begin_dit_handoff(self, request_id: str) -> None:
+        """Hand the GPU to DIT/DAV for *request_id* and take AR off it."""
         if not self._enabled:
             return
         with self._lock:
-            if self._ar_model is None:
-                raise RuntimeError(
-                    "MiniMax Music 3 serial offload is enabled but the AR "
-                    "backbone was never registered"
-                )
+            self._require_ar_locked()
+            self._outstanding.add(request_id)
             if not self._ar_active:
                 return
             move_module_to_device(self._ar_model, torch.device("cpu"))
             self._ar_active = False
-        logger.info("MiniMax Music 3 serial offload: AR -> CPU (DIT/DAV's turn)")
+            self._paused_at = time.monotonic()
+            self._stall_reported = False
+        logger.info(
+            f"MiniMax Music 3 serial offload: AR -> CPU (DIT/DAV's turn, "
+            f"request={request_id})"
+        )
 
-    def end_dit_handoff(self) -> None:
+    def end_dit_handoff(self, request_id: str) -> None:
+        """Retire *request_id*; give the GPU back once nothing is outstanding.
+
+        Safe to call for a request that never handed off, and safe to call
+        more than once: both leave the outstanding set unchanged.
+        """
         if not self._enabled:
             return
         with self._lock:
-            if self._ar_model is None:
-                raise RuntimeError(
-                    "MiniMax Music 3 serial offload is enabled but the AR "
-                    "backbone was never registered"
-                )
-            if self._ar_active:
+            self._require_ar_locked()
+            self._outstanding.discard(request_id)
+            if self._ar_active or self._outstanding:
                 return
             move_module_to_device(self._ar_model, self._ar_device)
             self._ar_active = True
-        logger.info("MiniMax Music 3 serial offload: AR -> GPU (AR's turn)")
+            self._paused_at = None
+            self._stall_reported = False
+        logger.info(
+            f"MiniMax Music 3 serial offload: AR -> GPU (AR's turn, "
+            f"request={request_id})"
+        )
+
+    def _require_ar_locked(self) -> None:
+        if self._ar_model is None:
+            raise RuntimeError(
+                "MiniMax Music 3 serial offload is enabled but the AR "
+                "backbone was never registered"
+            )
+
+    def _report_stall_locked(self) -> None:
+        """Name the outstanding requests once AR has been parked too long."""
+        if self._paused_at is None or self._stall_reported:
+            return
+        elapsed = time.monotonic() - self._paused_at
+        if elapsed < STALL_REPORT_SECONDS:
+            return
+        self._stall_reported = True
+        logger.error(
+            f"MiniMax Music 3 serial offload: AR has been off the GPU for "
+            f"{elapsed:.0f}s and is still waiting on "
+            f"{sorted(self._outstanding)}; AR admits nothing until DIT/DAV "
+            "retires them, so this server needs a restart if the requests "
+            "are gone"
+        )
 
 
 _COORDINATOR = SerialOffloadCoordinator()
@@ -97,4 +156,9 @@ def get_coordinator() -> SerialOffloadCoordinator:
     return _COORDINATOR
 
 
-__all__ = ["SerialOffloadCoordinator", "get_coordinator", "move_module_to_device"]
+__all__ = [
+    "STALL_REPORT_SECONDS",
+    "SerialOffloadCoordinator",
+    "get_coordinator",
+    "move_module_to_device",
+]

--- a/sglang_omni/models/minimax_music3/serial_offload.py
+++ b/sglang_omni/models/minimax_music3/serial_offload.py
@@ -30,6 +30,7 @@ import torch
 logger = logging.getLogger(__name__)
 
 STALL_REPORT_SECONDS = 900.0
+_GIB = 1024.0**3
 
 
 def _owned_tensors(module: Any) -> list[tuple[str, torch.Tensor]]:
@@ -44,6 +45,26 @@ def _owned_tensors(module: Any) -> list[tuple[str, torch.Tensor]]:
         *module.named_parameters(),
         *module.named_buffers(),
     ]
+
+
+def _gpu_memory_note(device: torch.device) -> str:
+    """Device occupancy, for attributing what a handoff actually frees.
+
+    ``torch_*`` covers only this process's caching allocator, while ``free``
+    is the whole device, so a gap between them is memory held outside torch's
+    allocator. Reporting both is what distinguishes weights coming off the GPU
+    from the pools that stay put -- notably the SGLang KV cache, which
+    ``mem_fraction_static`` reserves for the life of the process and which no
+    weight offload releases.
+    """
+    if device.type != "cuda":
+        return "cpu"
+    free, total = torch.cuda.mem_get_info(device)
+    return (
+        f"free={free / _GIB:.2f}/{total / _GIB:.2f}GiB "
+        f"torch_allocated={torch.cuda.memory_allocated(device) / _GIB:.2f}GiB "
+        f"torch_reserved={torch.cuda.memory_reserved(device) / _GIB:.2f}GiB"
+    )
 
 
 class ModuleResidency:
@@ -61,14 +82,31 @@ class ModuleResidency:
     rather than failing on the first one.
     """
 
-    def __init__(self, module: Any, device: torch.device, *, resident: bool = True):
+    def __init__(
+        self,
+        module: Any,
+        device: torch.device,
+        *,
+        resident: bool = True,
+        label: str = "module",
+    ):
         self._module = module
         self._device = torch.device(device)
         self._resident = bool(resident)
+        self._label = label
         self._host: dict[str, torch.Tensor] = {}
         if not self._resident:
             # Built on the host: its own tensors are already the canonical copy.
             self._host = {name: tensor for name, tensor in _owned_tensors(module)}
+        weight_bytes = sum(
+            tensor.numel() * tensor.element_size()
+            for _, tensor in _owned_tensors(module)
+        )
+        logger.info(
+            f"MiniMax Music 3 residency {label}: {weight_bytes / _GIB:.2f}GiB of "
+            f"weights, starts {'resident' if self._resident else 'offloaded'} "
+            f"({_gpu_memory_note(self._device)})"
+        )
 
     @property
     def resident(self) -> bool:
@@ -87,6 +125,10 @@ class ModuleResidency:
             tensor.data = self._host[name]
         self._resident = False
         torch.cuda.empty_cache()
+        logger.info(
+            f"MiniMax Music 3 residency {self._label} -> host "
+            f"({_gpu_memory_note(self._device)})"
+        )
 
     def wake(self) -> None:
         """Refill the GPU replica from the host copy; no-op once resident."""
@@ -97,6 +139,10 @@ class ModuleResidency:
         if self._device.type == "cuda":
             torch.cuda.synchronize(self._device)
         self._resident = True
+        logger.info(
+            f"MiniMax Music 3 residency {self._label} -> gpu "
+            f"({_gpu_memory_note(self._device)})"
+        )
 
 
 class SerialOffloadCoordinator:
@@ -117,7 +163,7 @@ class SerialOffloadCoordinator:
 
     def register_ar(self, model: Any, device: torch.device) -> None:
         with self._lock:
-            self._ar = ModuleResidency(model, device)
+            self._ar = ModuleResidency(model, device, label="ar")
             self._enabled = True
             self._ar_active = True
         logger.info(

--- a/sglang_omni/models/minimax_music3/serial_offload.py
+++ b/sglang_omni/models/minimax_music3/serial_offload.py
@@ -32,19 +32,71 @@ logger = logging.getLogger(__name__)
 STALL_REPORT_SECONDS = 900.0
 
 
-def move_module_to_device(module: Any, device: torch.device) -> None:
-    source_device = None
-    try:
-        source_device = next(module.parameters()).device
-    except StopIteration:
-        pass
-    module.to(device)
-    if source_device is not None and source_device.type == "cuda":
-        torch.cuda.synchronize(source_device)
-    if device.type == "cuda":
-        torch.cuda.synchronize(device)
-    else:
+def _owned_tensors(module: Any) -> list[tuple[str, torch.Tensor]]:
+    """Every parameter and buffer the module owns, tied tensors listed once.
+
+    ``named_parameters``/``named_buffers`` de-duplicate by default, so a tied
+    weight appears under one name only. Residency mutates the tensor object in
+    place, so every name that shares it follows along and the tying survives
+    the round trip.
+    """
+    return [
+        *module.named_parameters(),
+        *module.named_buffers(),
+    ]
+
+
+class ModuleResidency:
+    """GPU residency for one module whose weights never change.
+
+    Inference never writes these weights, so the host copy is canonical: it is
+    filled once and every wake refills the GPU from it. Sleeping then only
+    drops the GPU replica -- no device-to-host copy and no fresh host
+    allocation per request, which is what ``module.to()`` in both directions
+    was paying for on every single handoff.
+
+    Reusing one host copy also stops the sleep path handing the caching
+    allocator a differently sized block each round trip. That is what lets a
+    long-running server fragment its way into an OOM after tens of requests
+    rather than failing on the first one.
+    """
+
+    def __init__(self, module: Any, device: torch.device, *, resident: bool = True):
+        self._module = module
+        self._device = torch.device(device)
+        self._resident = bool(resident)
+        self._host: dict[str, torch.Tensor] = {}
+        if not self._resident:
+            # Built on the host: its own tensors are already the canonical copy.
+            self._host = {name: tensor for name, tensor in _owned_tensors(module)}
+
+    @property
+    def resident(self) -> bool:
+        return self._resident
+
+    def sleep(self) -> None:
+        """Drop the GPU replica; a cheap no-op once already asleep."""
+        if not self._resident:
+            return
+        owned = _owned_tensors(self._module)
+        if not self._host:
+            self._host = {
+                name: tensor.detach().to("cpu", copy=True) for name, tensor in owned
+            }
+        for name, tensor in owned:
+            tensor.data = self._host[name]
+        self._resident = False
         torch.cuda.empty_cache()
+
+    def wake(self) -> None:
+        """Refill the GPU replica from the host copy; no-op once resident."""
+        if self._resident:
+            return
+        for name, tensor in _owned_tensors(self._module):
+            tensor.data = self._host[name].to(self._device, copy=True)
+        if self._device.type == "cuda":
+            torch.cuda.synchronize(self._device)
+        self._resident = True
 
 
 class SerialOffloadCoordinator:
@@ -54,8 +106,7 @@ class SerialOffloadCoordinator:
         self._lock = threading.Lock()
         self._enabled = False
         self._ar_active = True
-        self._ar_model: Any | None = None
-        self._ar_device: torch.device | None = None
+        self._ar: ModuleResidency | None = None
         self._outstanding: set[str] = set()
         self._paused_at: float | None = None
         self._stall_reported = False
@@ -66,8 +117,7 @@ class SerialOffloadCoordinator:
 
     def register_ar(self, model: Any, device: torch.device) -> None:
         with self._lock:
-            self._ar_model = model
-            self._ar_device = device
+            self._ar = ModuleResidency(model, device)
             self._enabled = True
             self._ar_active = True
         logger.info(
@@ -94,7 +144,7 @@ class SerialOffloadCoordinator:
             self._outstanding.add(request_id)
             if not self._ar_active:
                 return
-            move_module_to_device(self._ar_model, torch.device("cpu"))
+            self._ar.sleep()
             self._ar_active = False
             self._paused_at = time.monotonic()
             self._stall_reported = False
@@ -116,7 +166,7 @@ class SerialOffloadCoordinator:
             self._outstanding.discard(request_id)
             if self._ar_active or self._outstanding:
                 return
-            move_module_to_device(self._ar_model, self._ar_device)
+            self._ar.wake()
             self._ar_active = True
             self._paused_at = None
             self._stall_reported = False
@@ -126,7 +176,7 @@ class SerialOffloadCoordinator:
         )
 
     def _require_ar_locked(self) -> None:
-        if self._ar_model is None:
+        if self._ar is None:
             raise RuntimeError(
                 "MiniMax Music 3 serial offload is enabled but the AR "
                 "backbone was never registered"
@@ -158,7 +208,7 @@ def get_coordinator() -> SerialOffloadCoordinator:
 
 __all__ = [
     "STALL_REPORT_SECONDS",
+    "ModuleResidency",
     "SerialOffloadCoordinator",
     "get_coordinator",
-    "move_module_to_device",
 ]

--- a/tests/unit_test/minimax_music3/test_serial_offload.py
+++ b/tests/unit_test/minimax_music3/test_serial_offload.py
@@ -7,10 +7,17 @@ import pytest
 import torch
 
 from sglang_omni.models.minimax_music3.serial_offload import (
+    STALL_REPORT_SECONDS,
     SerialOffloadCoordinator,
     get_coordinator,
     move_module_to_device,
 )
+
+
+def _registered() -> SerialOffloadCoordinator:
+    coordinator = SerialOffloadCoordinator()
+    coordinator.register_ar(torch.nn.Linear(2, 2), torch.device("cpu"))
+    return coordinator
 
 
 def test_get_coordinator_returns_a_process_wide_singleton() -> None:
@@ -22,54 +29,84 @@ def test_disabled_coordinator_never_blocks_admission_and_handoffs_are_noops() ->
 
     assert coordinator.enabled is False
     assert coordinator.ar_can_admit() is True
-    coordinator.begin_dit_handoff()
-    coordinator.end_dit_handoff()
+    coordinator.begin_dit_handoff("req-1")
+    coordinator.end_dit_handoff("req-1")
     assert coordinator.ar_can_admit() is True
 
 
 def test_register_ar_enables_the_coordinator_and_starts_ar_active() -> None:
-    coordinator = SerialOffloadCoordinator()
-    model = torch.nn.Linear(2, 2)
-
-    coordinator.register_ar(model, torch.device("cpu"))
+    coordinator = _registered()
 
     assert coordinator.enabled is True
     assert coordinator.ar_can_admit() is True
 
 
 def test_begin_dit_handoff_moves_ar_off_the_gpu_and_blocks_admission() -> None:
-    coordinator = SerialOffloadCoordinator()
-    model = torch.nn.Linear(2, 2)
-    coordinator.register_ar(model, torch.device("cpu"))
+    coordinator = _registered()
 
-    coordinator.begin_dit_handoff()
+    coordinator.begin_dit_handoff("req-1")
 
     assert coordinator.ar_can_admit() is False
 
 
 def test_end_dit_handoff_restores_ar_and_reopens_admission() -> None:
-    coordinator = SerialOffloadCoordinator()
-    model = torch.nn.Linear(2, 2)
-    coordinator.register_ar(model, torch.device("cpu"))
-    coordinator.begin_dit_handoff()
+    coordinator = _registered()
+    coordinator.begin_dit_handoff("req-1")
 
-    coordinator.end_dit_handoff()
+    coordinator.end_dit_handoff("req-1")
 
     assert coordinator.ar_can_admit() is True
 
 
 def test_handoff_calls_are_idempotent() -> None:
-    coordinator = SerialOffloadCoordinator()
-    model = torch.nn.Linear(2, 2)
-    coordinator.register_ar(model, torch.device("cpu"))
+    coordinator = _registered()
 
-    coordinator.begin_dit_handoff()
-    coordinator.begin_dit_handoff()
+    coordinator.begin_dit_handoff("req-1")
+    coordinator.begin_dit_handoff("req-1")
     assert coordinator.ar_can_admit() is False
 
-    coordinator.end_dit_handoff()
-    coordinator.end_dit_handoff()
+    coordinator.end_dit_handoff("req-1")
+    coordinator.end_dit_handoff("req-1")
     assert coordinator.ar_can_admit() is True
+
+
+def test_ar_stays_parked_until_every_outstanding_request_retires() -> None:
+    """The wake is driven by the outstanding set, not by the last event."""
+    coordinator = _registered()
+    coordinator.begin_dit_handoff("req-1")
+    coordinator.begin_dit_handoff("req-2")
+
+    coordinator.end_dit_handoff("req-1")
+    assert coordinator.ar_can_admit() is False
+
+    coordinator.end_dit_handoff("req-2")
+    assert coordinator.ar_can_admit() is True
+
+
+def test_end_for_a_request_that_never_handed_off_does_not_wake_ar() -> None:
+    coordinator = _registered()
+    coordinator.begin_dit_handoff("req-1")
+
+    coordinator.end_dit_handoff("req-unknown")
+
+    assert coordinator.ar_can_admit() is False
+
+
+def test_a_stalled_handoff_is_reported_once_and_never_force_woken(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    coordinator = _registered()
+    coordinator.begin_dit_handoff("req-1")
+    # Backdate the pause past the reporting threshold.
+    coordinator._paused_at -= STALL_REPORT_SECONDS + 1.0
+
+    with caplog.at_level("ERROR"):
+        assert coordinator.ar_can_admit() is False
+        assert coordinator.ar_can_admit() is False
+
+    stall_records = [r for r in caplog.records if "off the GPU for" in r.message]
+    assert len(stall_records) == 1
+    assert "req-1" in stall_records[0].message
 
 
 def test_handoff_without_registration_raises_if_force_enabled() -> None:
@@ -78,9 +115,9 @@ def test_handoff_without_registration_raises_if_force_enabled() -> None:
     coordinator._enabled = True
 
     with pytest.raises(RuntimeError, match="never registered"):
-        coordinator.begin_dit_handoff()
+        coordinator.begin_dit_handoff("req-1")
     with pytest.raises(RuntimeError, match="never registered"):
-        coordinator.end_dit_handoff()
+        coordinator.end_dit_handoff("req-1")
 
 
 def test_move_module_to_device_relocates_every_parameter() -> None:
@@ -99,8 +136,8 @@ def test_serial_offload_round_trip_moves_weights_between_devices() -> None:
     model = torch.nn.Linear(4, 4).to(device)
     coordinator.register_ar(model, device)
 
-    coordinator.begin_dit_handoff()
+    coordinator.begin_dit_handoff("req-1")
     assert next(model.parameters()).device.type == "cpu"
 
-    coordinator.end_dit_handoff()
+    coordinator.end_dit_handoff("req-1")
     assert next(model.parameters()).device == device

--- a/tests/unit_test/minimax_music3/test_serial_offload.py
+++ b/tests/unit_test/minimax_music3/test_serial_offload.py
@@ -8,9 +8,9 @@ import torch
 
 from sglang_omni.models.minimax_music3.serial_offload import (
     STALL_REPORT_SECONDS,
+    ModuleResidency,
     SerialOffloadCoordinator,
     get_coordinator,
-    move_module_to_device,
 )
 
 
@@ -120,12 +120,55 @@ def test_handoff_without_registration_raises_if_force_enabled() -> None:
         coordinator.end_dit_handoff("req-1")
 
 
-def test_move_module_to_device_relocates_every_parameter() -> None:
+def test_residency_sleep_and_wake_preserve_weights_and_state() -> None:
     module = torch.nn.Linear(2, 2)
+    expected = module.weight.detach().clone()
+    residency = ModuleResidency(module, torch.device("cpu"))
 
-    move_module_to_device(module, torch.device("cpu"))
+    residency.sleep()
+    assert residency.resident is False
+    residency.wake()
 
-    assert next(module.parameters()).device.type == "cpu"
+    assert residency.resident is True
+    assert torch.equal(module.weight, expected)
+
+
+def test_residency_reuses_one_host_copy_instead_of_recopying_each_sleep() -> None:
+    """The weights are immutable, so only the first sleep may snapshot them."""
+    module = torch.nn.Linear(2, 2)
+    residency = ModuleResidency(module, torch.device("cpu"))
+
+    residency.sleep()
+    snapshot = residency._host["weight"]
+    residency.wake()
+    residency.sleep()
+
+    assert residency._host["weight"] is snapshot
+
+
+def test_a_host_built_module_is_asleep_and_never_snapshots_from_the_gpu() -> None:
+    module = torch.nn.Linear(2, 2)
+    residency = ModuleResidency(module, torch.device("cpu"), resident=False)
+
+    assert residency.resident is False
+    assert residency._host["weight"] is module.weight
+
+    residency.wake()
+    assert residency.resident is True
+
+
+def test_residency_keeps_tied_weights_tied_across_a_round_trip() -> None:
+    module = torch.nn.Linear(4, 4)
+    tied = torch.nn.Linear(4, 4)
+    tied.weight = module.weight
+    parent = torch.nn.Sequential(module, tied)
+    residency = ModuleResidency(parent, torch.device("cpu"))
+
+    residency.sleep()
+    residency.wake()
+
+    assert module.weight is tied.weight
+    assert module.weight.data_ptr() == tied.weight.data_ptr()
 
 
 @pytest.mark.gpu


### PR DESCRIPTION
## Motivation

Stacked on #1619 (base branch `two-stage`). Four defects, smallest first.
DIT/DAV stays FP32 throughout — no dtype change anywhere in this PR.

**1. #1619 cannot run in any configuration.** `acoustic.py` contains
`if self._serial_offload:s`, a `SyntaxError`, so the module cannot be
imported with or without the flag. `tests/unit_test/minimax_music3/test_core.py`
imports it at collection time, so the whole MiniMax Music 3 unit suite
fails to collect too. It went unnoticed because CI on #1619 has not run —
this repo needs a maintainer to add the `run-ci` label. The repo's own
pre-commit `check-ast` hook catches it locally.

**2. A lost handoff wedges the server permanently.** `ar_can_admit()`
gates AR's admission queue, so AR stays parked until something calls
`end_dit_handoff()`. That was a single process-wide boolean with no
request scoping: *any* call woke AR, including one belonging to a
different request than the one that parked it, and nothing recorded which
request AR was waiting on. `clear_stream_state` is the only wake path, so
a DIT-side failure that bypasses it — an exception inside
`on_streaming_new_request`, which `_handle_streaming_new_request` does not
guard — stops admission for good with no log line explaining why.

**3. A startup peak that makes the mode unusable on the cards it targets.**
`_build_dit` and `_build_dav` call `load_torch_state(..., device=self.device)`,
staging both checkpoints *through the GPU* before `offload_to_cpu()` moves
them back. AR is already registered and resident by then, so startup
always peaked with AR **and** DIT/DAV fully resident — precisely the peak
serial offload exists to avoid.

**4. Immutable weights round-tripped every request.** `move_module_to_device`
ran `module.to()` in both directions per handoff. The weights never change
during inference, yet every sleep paid a full device-to-host copy of
unchanged weights plus a fresh pageable host allocation to land in; only
the wake direction did useful work. Handing the caching allocator multi-GB
blocks to free and re-request each request also fragments it — an OOM tens
of requests into a run rather than on the first, the hardest kind to
attribute.

## Modifications

Four commits, each independently reviewable:

1. Delete the stray character.
2. Track outstanding DIT request ids and wake AR only when the set drains.
   Retiring a request that never handed off becomes a no-op instead of an
   early wake; repeated calls stay idempotent. A handoff that never ends is
   **reported, not force-corrected** — waking AR while DIT/DAV still holds
   the GPU is exactly how this configuration OOMs, so a stuck server is
   preferable to a crashed one. `ar_can_admit()` logs the outstanding ids
   once after `STALL_REPORT_SECONDS` on the existing admission poll, costing
   no timer thread.
3. `ModuleResidency` makes the host copy canonical: filled once, wake
   refills the GPU replica from it, sleep only drops the replica. Residency
   mutates the tensor object in place rather than rebinding module
   attributes, so tied weights stay tied across a round trip. Under serial
   offload DIT/DAV now load **on the host** and only upload a replica on
   demand, so the checkpoint never touches the GPU at startup and there is
   no device-to-host copy at all. `move_module_to_device` loses its last
   caller and is removed.
4. Log free/total device memory plus torch's allocated and reserved bytes
   on every residency transition, and each module's weight footprint when
   its residency is created.

## Why the logging is here

The flag's name promises more than the mechanism delivers. Offloading
*weights* does not release the SGLang KV cache:
`MiniMaxMusic3EngineBuilder.generation_defaults` sets
`mem_fraction_static: 0.50`, reserving half the card for weights **plus**
the KV pool for the life of the AR process. Moving `model_runner.model` to
the host releases parameter tensors only — `token_to_kv_pool` and
`req_to_token_pool` stay resident across every handoff. The gap between
torch's numbers and the device's is what makes that visible rather than
inferred.

## A related finding, not fixed here

From the published checkpoint metadata, the AR backbone
(`language_model/`, Qwen3 36L/4096/12288, vocab 200k, untied) is
**15.99 GiB** and the DIT (`condition_encoder/`, 2,431,905,920 params at
FP32) is **9.06 GiB** — 25.05 GiB combined, which is what makes this
feature necessary on a 24GB card.

But `mem_fraction_static: 0.50` gives a ~12 GiB budget for AR weights plus
KV on a 24GB card, and the AR weights alone are 15.99 GiB. SGLang sizes the
KV pool as `total × mem_fraction_static − weights`, so the AR stage should
fail to start on exactly the hardware this feature targets. It works on the
80GB CI runners, which is likely why it has not surfaced. Under serial
offload AR no longer shares the card with DIT/DAV and can afford a much
higher fraction. That is arithmetic, not a measured run, so I have left it
out of this PR — happy to add it once someone confirms on a 24GB box.

## Accuracy Test

Weights are moved, never transformed, and the dtype is unchanged, so
generated audio is bit-identical.
`test_residency_sleep_and_wake_preserve_weights_and_state` asserts the
round trip preserves values.

## Benchmark & Profiling

Removes one full device-to-host weight copy per request and the whole
DIT/DAV GPU staging at startup. Absolute numbers need a 24GB card; commit 4
adds the logging that measures them. Not benchmarked yet — I have no
24GB-class GPU, and the 80GB CI runners fit both stages resident so they
would measure offload overhead without exercising the OOM avoidance the
feature exists for.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
