### PR TITLE
[Fix] Key the MiniMax Music 3 AR/DIT handoff by request id

### DIFF
--- a/sglang_omni/models/minimax_music3/acoustic.py
+++ b/sglang_omni/models/minimax_music3/acoustic.py
@@ -509,7 +509,7 @@ class MiniMaxMusic3AcousticScheduler(StreamingSimpleScheduler):
             state.last_condition = None
         if self._decoder.serial_offload:
             self._decoder.offload_to_cpu()
-            get_coordinator().end_dit_handoff()
+            get_coordinator().end_dit_handoff(request_id)
 
 
 __all__ = [

--- a/sglang_omni/models/minimax_music3/model_runner.py
+++ b/sglang_omni/models/minimax_music3/model_runner.py
@@ -200,7 +200,7 @@ class MiniMaxMusic3ModelRunner(ModelRunner):
         logger.info(
             f"MiniMax Music 3 AR done request={request_id} frames={ar_state.generated_frames} prompt_tokens={req_data.prompt_tokens} finish_reason={ar_state.finish_reason} peak_buffer_frames={ar_state.frames.peak_frames} elapsed={time.perf_counter() - ar_state.started_s:.1f}s"
         )
-        self._serial_offload.begin_dit_handoff()
+        self._serial_offload.begin_dit_handoff(request_id)
 
     def reset_request(self, request_id: str) -> None:
         data = self._request_data.pop(request_id, None)

--- a/sglang_omni/models/minimax_music3/serial_offload.py
+++ b/sglang_omni/models/minimax_music3/serial_offload.py
@@ -1,18 +1,38 @@
 # SPDX-License-Identifier: Apache-2.0
+"""Serial GPU residency for the MiniMax Music 3 AR and DIT/DAV stages.
+
+``--layerwise-offload-components ar,dit`` colocates both stages in one process
+and lets only one of them hold GPU weights at a time: AR generates a whole
+request, hands off to DIT/DAV, and stays off the GPU until DIT/DAV is finished
+with that request.
+
+The handoff is keyed by request id rather than by a single boolean. AR wakes
+when nothing is outstanding, so a duplicated, out-of-order, or late terminal
+event cannot wake AR while DIT/DAV is still decoding, and an event that names
+a request nobody handed off cannot wake AR early.
+
+A handoff that never ends stops admission for good, because ``ar_can_admit``
+gates the AR scheduler's queue. That is reported rather than force-corrected:
+waking AR while DIT/DAV still holds the GPU is how this configuration runs out
+of memory, so a stuck server is preferable to a crashed one, and the log names
+the requests still outstanding.
+"""
 
 from __future__ import annotations
 
 import logging
 import threading
+import time
 from typing import Any
 
 import torch
 
 logger = logging.getLogger(__name__)
 
+STALL_REPORT_SECONDS = 900.0
+
 
 def move_module_to_device(module: Any, device: torch.device) -> None:
-
     source_device = None
     try:
         source_device = next(module.parameters()).device
@@ -36,6 +56,9 @@ class SerialOffloadCoordinator:
         self._ar_active = True
         self._ar_model: Any | None = None
         self._ar_device: torch.device | None = None
+        self._outstanding: set[str] = set()
+        self._paused_at: float | None = None
+        self._stall_reported = False
 
     @property
     def enabled(self) -> bool:
@@ -57,37 +80,73 @@ class SerialOffloadCoordinator:
         if not self._enabled:
             return True
         with self._lock:
-            return self._ar_active
+            if self._ar_active:
+                return True
+            self._report_stall_locked()
+            return False
 
-    def begin_dit_handoff(self) -> None:
+    def begin_dit_handoff(self, request_id: str) -> None:
+        """Hand the GPU to DIT/DAV for *request_id* and take AR off it."""
         if not self._enabled:
             return
         with self._lock:
-            if self._ar_model is None:
-                raise RuntimeError(
-                    "MiniMax Music 3 serial offload is enabled but the AR "
-                    "backbone was never registered"
-                )
+            self._require_ar_locked()
+            self._outstanding.add(request_id)
             if not self._ar_active:
                 return
             move_module_to_device(self._ar_model, torch.device("cpu"))
             self._ar_active = False
-        logger.info("MiniMax Music 3 serial offload: AR -> CPU (DIT/DAV's turn)")
+            self._paused_at = time.monotonic()
+            self._stall_reported = False
+        logger.info(
+            f"MiniMax Music 3 serial offload: AR -> CPU (DIT/DAV's turn, "
+            f"request={request_id})"
+        )
 
-    def end_dit_handoff(self) -> None:
+    def end_dit_handoff(self, request_id: str) -> None:
+        """Retire *request_id*; give the GPU back once nothing is outstanding.
+
+        Safe to call for a request that never handed off, and safe to call
+        more than once: both leave the outstanding set unchanged.
+        """
         if not self._enabled:
             return
         with self._lock:
-            if self._ar_model is None:
-                raise RuntimeError(
-                    "MiniMax Music 3 serial offload is enabled but the AR "
-                    "backbone was never registered"
-                )
-            if self._ar_active:
+            self._require_ar_locked()
+            self._outstanding.discard(request_id)
+            if self._ar_active or self._outstanding:
                 return
             move_module_to_device(self._ar_model, self._ar_device)
             self._ar_active = True
-        logger.info("MiniMax Music 3 serial offload: AR -> GPU (AR's turn)")
+            self._paused_at = None
+            self._stall_reported = False
+        logger.info(
+            f"MiniMax Music 3 serial offload: AR -> GPU (AR's turn, "
+            f"request={request_id})"
+        )
+
+    def _require_ar_locked(self) -> None:
+        if self._ar_model is None:
+            raise RuntimeError(
+                "MiniMax Music 3 serial offload is enabled but the AR "
+                "backbone was never registered"
+            )
+
+    def _report_stall_locked(self) -> None:
+        """Name the outstanding requests once AR has been parked too long."""
+        if self._paused_at is None or self._stall_reported:
+            return
+        elapsed = time.monotonic() - self._paused_at
+        if elapsed < STALL_REPORT_SECONDS:
+            return
+        self._stall_reported = True
+        logger.error(
+            f"MiniMax Music 3 serial offload: AR has been off the GPU for "
+            f"{elapsed:.0f}s and is still waiting on "
+            f"{sorted(self._outstanding)}; AR admits nothing until DIT/DAV "
+            "retires them, so this server needs a restart if the requests "
+            "are gone"
+        )
 
 
 _COORDINATOR = SerialOffloadCoordinator()
@@ -97,4 +156,9 @@ def get_coordinator() -> SerialOffloadCoordinator:
     return _COORDINATOR
 
 
-__all__ = ["SerialOffloadCoordinator", "get_coordinator", "move_module_to_device"]
+__all__ = [
+    "STALL_REPORT_SECONDS",
+    "SerialOffloadCoordinator",
+    "get_coordinator",
+    "move_module_to_device",
+]

--- a/tests/unit_test/minimax_music3/test_serial_offload.py
+++ b/tests/unit_test/minimax_music3/test_serial_offload.py
@@ -7,10 +7,17 @@ import pytest
 import torch
 
 from sglang_omni.models.minimax_music3.serial_offload import (
+    STALL_REPORT_SECONDS,
     SerialOffloadCoordinator,
     get_coordinator,
     move_module_to_device,
 )
+
+
+def _registered() -> SerialOffloadCoordinator:
+    coordinator = SerialOffloadCoordinator()
+    coordinator.register_ar(torch.nn.Linear(2, 2), torch.device("cpu"))
+    return coordinator
 
 
 def test_get_coordinator_returns_a_process_wide_singleton() -> None:
@@ -22,54 +29,84 @@ def test_disabled_coordinator_never_blocks_admission_and_handoffs_are_noops() ->
 
     assert coordinator.enabled is False
     assert coordinator.ar_can_admit() is True
-    coordinator.begin_dit_handoff()
-    coordinator.end_dit_handoff()
+    coordinator.begin_dit_handoff("req-1")
+    coordinator.end_dit_handoff("req-1")
     assert coordinator.ar_can_admit() is True
 
 
 def test_register_ar_enables_the_coordinator_and_starts_ar_active() -> None:
-    coordinator = SerialOffloadCoordinator()
-    model = torch.nn.Linear(2, 2)
-
-    coordinator.register_ar(model, torch.device("cpu"))
+    coordinator = _registered()
 
     assert coordinator.enabled is True
     assert coordinator.ar_can_admit() is True
 
 
 def test_begin_dit_handoff_moves_ar_off_the_gpu_and_blocks_admission() -> None:
-    coordinator = SerialOffloadCoordinator()
-    model = torch.nn.Linear(2, 2)
-    coordinator.register_ar(model, torch.device("cpu"))
+    coordinator = _registered()
 
-    coordinator.begin_dit_handoff()
+    coordinator.begin_dit_handoff("req-1")
 
     assert coordinator.ar_can_admit() is False
 
 
 def test_end_dit_handoff_restores_ar_and_reopens_admission() -> None:
-    coordinator = SerialOffloadCoordinator()
-    model = torch.nn.Linear(2, 2)
-    coordinator.register_ar(model, torch.device("cpu"))
-    coordinator.begin_dit_handoff()
+    coordinator = _registered()
+    coordinator.begin_dit_handoff("req-1")
 
-    coordinator.end_dit_handoff()
+    coordinator.end_dit_handoff("req-1")
 
     assert coordinator.ar_can_admit() is True
 
 
 def test_handoff_calls_are_idempotent() -> None:
-    coordinator = SerialOffloadCoordinator()
-    model = torch.nn.Linear(2, 2)
-    coordinator.register_ar(model, torch.device("cpu"))
+    coordinator = _registered()
 
-    coordinator.begin_dit_handoff()
-    coordinator.begin_dit_handoff()
+    coordinator.begin_dit_handoff("req-1")
+    coordinator.begin_dit_handoff("req-1")
     assert coordinator.ar_can_admit() is False
 
-    coordinator.end_dit_handoff()
-    coordinator.end_dit_handoff()
+    coordinator.end_dit_handoff("req-1")
+    coordinator.end_dit_handoff("req-1")
     assert coordinator.ar_can_admit() is True
+
+
+def test_ar_stays_parked_until_every_outstanding_request_retires() -> None:
+    """The wake is driven by the outstanding set, not by the last event."""
+    coordinator = _registered()
+    coordinator.begin_dit_handoff("req-1")
+    coordinator.begin_dit_handoff("req-2")
+
+    coordinator.end_dit_handoff("req-1")
+    assert coordinator.ar_can_admit() is False
+
+    coordinator.end_dit_handoff("req-2")
+    assert coordinator.ar_can_admit() is True
+
+
+def test_end_for_a_request_that_never_handed_off_does_not_wake_ar() -> None:
+    coordinator = _registered()
+    coordinator.begin_dit_handoff("req-1")
+
+    coordinator.end_dit_handoff("req-unknown")
+
+    assert coordinator.ar_can_admit() is False
+
+
+def test_a_stalled_handoff_is_reported_once_and_never_force_woken(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    coordinator = _registered()
+    coordinator.begin_dit_handoff("req-1")
+    # Backdate the pause past the reporting threshold.
+    coordinator._paused_at -= STALL_REPORT_SECONDS + 1.0
+
+    with caplog.at_level("ERROR"):
+        assert coordinator.ar_can_admit() is False
+        assert coordinator.ar_can_admit() is False
+
+    stall_records = [r for r in caplog.records if "off the GPU for" in r.message]
+    assert len(stall_records) == 1
+    assert "req-1" in stall_records[0].message
 
 
 def test_handoff_without_registration_raises_if_force_enabled() -> None:
@@ -78,9 +115,9 @@ def test_handoff_without_registration_raises_if_force_enabled() -> None:
     coordinator._enabled = True
 
     with pytest.raises(RuntimeError, match="never registered"):
-        coordinator.begin_dit_handoff()
+        coordinator.begin_dit_handoff("req-1")
     with pytest.raises(RuntimeError, match="never registered"):
-        coordinator.end_dit_handoff()
+        coordinator.end_dit_handoff("req-1")
 
 
 def test_move_module_to_device_relocates_every_parameter() -> None:
@@ -99,8 +136,8 @@ def test_serial_offload_round_trip_moves_weights_between_devices() -> None:
     model = torch.nn.Linear(4, 4).to(device)
     coordinator.register_ar(model, device)
 
-    coordinator.begin_dit_handoff()
+    coordinator.begin_dit_handoff("req-1")
     assert next(model.parameters()).device.type == "cpu"
 
-    coordinator.end_dit_handoff()
+    coordinator.end_dit_handoff("req-1")
     assert next(model.parameters()).device == device


### PR DESCRIPTION
## Motivation

Stacked on #1738 (part 2 of 4 on top of #1619). **Merge #1738 first.**

`ar_can_admit()` gates the AR scheduler's admission queue, so AR stays
parked until something calls `end_dit_handoff()`. In #1619 that is a single
process-wide boolean with no request scoping, which leaves two holes:

- **Any** `end_dit_handoff()` wakes AR, including one belonging to a
  different request than the one that parked it. Today `max_concurrency`
  is forced to 1 so this rarely bites, but the invariant is only
  incidentally true.
- Nothing records *which* request AR is waiting on. A handoff that never
  ends stops admission permanently, and the server goes silent with no
  log line explaining why. `clear_stream_state` is the only wake path, so
  any DIT-side failure that bypasses it (for example an exception raised
  inside `on_streaming_new_request`, which `_handle_streaming_new_request`
  does not guard) wedges the process until restart.

## Modifications

Track outstanding DIT request ids and wake AR only when the set drains.
Retiring a request that never handed off becomes a no-op instead of an
early wake; repeated calls stay idempotent.

A handoff that never ends is **reported, not force-corrected**. Waking AR
while DIT/DAV still holds the GPU is exactly how this configuration runs
out of memory, so a stuck server is preferable to a crashed one:
`ar_can_admit()` logs the outstanding request ids once after
`STALL_REPORT_SECONDS` (15 min) and leaves AR parked. The check is done
on the existing admission poll, so it costs no timer thread.

`begin_dit_handoff` / `end_dit_handoff` now take a `request_id`.

## Accuracy Test

No effect on generated audio; this only changes admission gating.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
