### PR TITLE
[Fix] Keep MiniMax Music 3 offloaded weights on the host, not round-tripped

### DIFF
--- a/sglang_omni/models/minimax_music3/acoustic.py
+++ b/sglang_omni/models/minimax_music3/acoustic.py
@@ -37,7 +37,7 @@ from .constants import (
 from .dav import MiniMaxMusic3DAV, remove_weight_norm, select_decoder_state
 from .dit import MiniMaxMusic3DIT
 from .payload_types import MiniMaxMusic3State
-from .serial_offload import get_coordinator, move_module_to_device
+from .serial_offload import ModuleResidency, get_coordinator
 
 logger = logging.getLogger(__name__)
 
@@ -180,6 +180,11 @@ class MiniMaxMusic3AcousticDecoder:
                     "relocated once the module moves off the GPU)"
                 )
                 self.breakable_cuda_graph_requested = False
+        # Serial offload parks DIT/DAV on the host between requests, so load
+        # them straight there. Staging the checkpoint through the GPU would
+        # peak with AR and DIT/DAV both fully resident, which is precisely the
+        # peak this mode exists to avoid.
+        self._load_device = torch.device("cpu") if self._serial_offload else self.device
         if self.cache_dit and self.breakable_cuda_graph_requested:
             raise ValueError(
                 "MiniMax Music 3 cache_dit and breakable_cuda_graph cannot be enabled together"
@@ -216,9 +221,12 @@ class MiniMaxMusic3AcousticDecoder:
         logger.info(
             f"MiniMax Music 3 acoustic runtime dit_steps={self.dit_steps} dit_cfg_scale={self.dit_cfg_scale:.3f} attention_backend={self.attention_backend} cache_dit={self.cache_dit} compile_acoustic={self.compile_acoustic} breakable_cuda_graph={self.breakable_cuda_graph} breakable_cuda_graph_requested={self.breakable_cuda_graph_requested}"
         )
-        self._resident_on_gpu = True
+        self._residency: tuple[ModuleResidency, ...] = ()
         if self._serial_offload:
-            self.offload_to_cpu()
+            self._residency = (
+                ModuleResidency(self.dit, self.device, resident=False),
+                ModuleResidency(self.dav, self.device, resident=False),
+            )
 
     @property
     def serial_offload(self) -> bool:
@@ -226,19 +234,13 @@ class MiniMaxMusic3AcousticDecoder:
 
     def ensure_gpu_resident(self) -> None:
         """Restore DIT/DAV to the GPU; a cheap no-op once already resident."""
-        if self._resident_on_gpu:
-            return
-        move_module_to_device(self.dit, self.device)
-        move_module_to_device(self.dav, self.device)
-        self._resident_on_gpu = True
+        for residency in self._residency:
+            residency.wake()
 
     def offload_to_cpu(self) -> None:
-        """Move DIT/DAV off the GPU; a cheap no-op once already offloaded."""
-        if not self._resident_on_gpu:
-            return
-        move_module_to_device(self.dit, torch.device("cpu"))
-        move_module_to_device(self.dav, torch.device("cpu"))
-        self._resident_on_gpu = False
+        """Drop the DIT/DAV GPU replica; a no-op once already offloaded."""
+        for residency in self._residency:
+            residency.sleep()
 
     def _build_dit(
         self,
@@ -251,9 +253,9 @@ class MiniMaxMusic3AcousticDecoder:
         cache_dit_max_continuous_cached_steps: int,
     ) -> None:
         logger.info(
-            f"Loading MiniMax Music 3 PyTorch DIT from {dit_path} on device={self.device} dtype={self.dtype}"
+            f"Loading MiniMax Music 3 PyTorch DIT from {dit_path} on device={self._load_device} dtype={self.dtype}"
         )
-        state = load_torch_state(dit_path, device=self.device)
+        state = load_torch_state(dit_path, device=self._load_device)
         logger.info(
             f"MiniMax Music 3 DIT checkpoint variant=FM8/ELMo condition_hidden=32768 state_keys={len(state)}"
         )
@@ -291,7 +293,7 @@ class MiniMaxMusic3AcousticDecoder:
     def _build_dav(self, dav_path: str) -> int:
         """Load the DAV decoder and return how many weight norms were folded."""
         logger.info(f"Loading MiniMax Music 3 DAV from {dav_path}")
-        state = load_torch_state(dav_path, device=self.device)
+        state = load_torch_state(dav_path, device=self._load_device)
         with torch.device("meta"):
             self.dav = MiniMaxMusic3DAV()
         self.dav.load_state_dict(select_decoder_state(state), strict=True, assign=True)

--- a/sglang_omni/models/minimax_music3/serial_offload.py
+++ b/sglang_omni/models/minimax_music3/serial_offload.py
@@ -32,19 +32,71 @@ logger = logging.getLogger(__name__)
 STALL_REPORT_SECONDS = 900.0
 
 
-def move_module_to_device(module: Any, device: torch.device) -> None:
-    source_device = None
-    try:
-        source_device = next(module.parameters()).device
-    except StopIteration:
-        pass
-    module.to(device)
-    if source_device is not None and source_device.type == "cuda":
-        torch.cuda.synchronize(source_device)
-    if device.type == "cuda":
-        torch.cuda.synchronize(device)
-    else:
+def _owned_tensors(module: Any) -> list[tuple[str, torch.Tensor]]:
+    """Every parameter and buffer the module owns, tied tensors listed once.
+
+    ``named_parameters``/``named_buffers`` de-duplicate by default, so a tied
+    weight appears under one name only. Residency mutates the tensor object in
+    place, so every name that shares it follows along and the tying survives
+    the round trip.
+    """
+    return [
+        *module.named_parameters(),
+        *module.named_buffers(),
+    ]
+
+
+class ModuleResidency:
+    """GPU residency for one module whose weights never change.
+
+    Inference never writes these weights, so the host copy is canonical: it is
+    filled once and every wake refills the GPU from it. Sleeping then only
+    drops the GPU replica -- no device-to-host copy and no fresh host
+    allocation per request, which is what ``module.to()`` in both directions
+    was paying for on every single handoff.
+
+    Reusing one host copy also stops the sleep path handing the caching
+    allocator a differently sized block each round trip. That is what lets a
+    long-running server fragment its way into an OOM after tens of requests
+    rather than failing on the first one.
+    """
+
+    def __init__(self, module: Any, device: torch.device, *, resident: bool = True):
+        self._module = module
+        self._device = torch.device(device)
+        self._resident = bool(resident)
+        self._host: dict[str, torch.Tensor] = {}
+        if not self._resident:
+            # Built on the host: its own tensors are already the canonical copy.
+            self._host = {name: tensor for name, tensor in _owned_tensors(module)}
+
+    @property
+    def resident(self) -> bool:
+        return self._resident
+
+    def sleep(self) -> None:
+        """Drop the GPU replica; a cheap no-op once already asleep."""
+        if not self._resident:
+            return
+        owned = _owned_tensors(self._module)
+        if not self._host:
+            self._host = {
+                name: tensor.detach().to("cpu", copy=True) for name, tensor in owned
+            }
+        for name, tensor in owned:
+            tensor.data = self._host[name]
+        self._resident = False
         torch.cuda.empty_cache()
+
+    def wake(self) -> None:
+        """Refill the GPU replica from the host copy; no-op once resident."""
+        if self._resident:
+            return
+        for name, tensor in _owned_tensors(self._module):
+            tensor.data = self._host[name].to(self._device, copy=True)
+        if self._device.type == "cuda":
+            torch.cuda.synchronize(self._device)
+        self._resident = True
 
 
 class SerialOffloadCoordinator:
@@ -54,8 +106,7 @@ class SerialOffloadCoordinator:
         self._lock = threading.Lock()
         self._enabled = False
         self._ar_active = True
-        self._ar_model: Any | None = None
-        self._ar_device: torch.device | None = None
+        self._ar: ModuleResidency | None = None
         self._outstanding: set[str] = set()
         self._paused_at: float | None = None
         self._stall_reported = False
@@ -66,8 +117,7 @@ class SerialOffloadCoordinator:
 
     def register_ar(self, model: Any, device: torch.device) -> None:
         with self._lock:
-            self._ar_model = model
-            self._ar_device = device
+            self._ar = ModuleResidency(model, device)
             self._enabled = True
             self._ar_active = True
         logger.info(
@@ -94,7 +144,7 @@ class SerialOffloadCoordinator:
             self._outstanding.add(request_id)
             if not self._ar_active:
                 return
-            move_module_to_device(self._ar_model, torch.device("cpu"))
+            self._ar.sleep()
             self._ar_active = False
             self._paused_at = time.monotonic()
             self._stall_reported = False
@@ -116,7 +166,7 @@ class SerialOffloadCoordinator:
             self._outstanding.discard(request_id)
             if self._ar_active or self._outstanding:
                 return
-            move_module_to_device(self._ar_model, self._ar_device)
+            self._ar.wake()
             self._ar_active = True
             self._paused_at = None
             self._stall_reported = False
@@ -126,7 +176,7 @@ class SerialOffloadCoordinator:
         )
 
     def _require_ar_locked(self) -> None:
-        if self._ar_model is None:
+        if self._ar is None:
             raise RuntimeError(
                 "MiniMax Music 3 serial offload is enabled but the AR "
                 "backbone was never registered"
@@ -158,7 +208,7 @@ def get_coordinator() -> SerialOffloadCoordinator:
 
 __all__ = [
     "STALL_REPORT_SECONDS",
+    "ModuleResidency",
     "SerialOffloadCoordinator",
     "get_coordinator",
-    "move_module_to_device",
 ]

--- a/tests/unit_test/minimax_music3/test_serial_offload.py
+++ b/tests/unit_test/minimax_music3/test_serial_offload.py
@@ -8,9 +8,9 @@ import torch
 
 from sglang_omni.models.minimax_music3.serial_offload import (
     STALL_REPORT_SECONDS,
+    ModuleResidency,
     SerialOffloadCoordinator,
     get_coordinator,
-    move_module_to_device,
 )
 
 
@@ -120,12 +120,55 @@ def test_handoff_without_registration_raises_if_force_enabled() -> None:
         coordinator.end_dit_handoff("req-1")
 
 
-def test_move_module_to_device_relocates_every_parameter() -> None:
+def test_residency_sleep_and_wake_preserve_weights_and_state() -> None:
     module = torch.nn.Linear(2, 2)
+    expected = module.weight.detach().clone()
+    residency = ModuleResidency(module, torch.device("cpu"))
 
-    move_module_to_device(module, torch.device("cpu"))
+    residency.sleep()
+    assert residency.resident is False
+    residency.wake()
 
-    assert next(module.parameters()).device.type == "cpu"
+    assert residency.resident is True
+    assert torch.equal(module.weight, expected)
+
+
+def test_residency_reuses_one_host_copy_instead_of_recopying_each_sleep() -> None:
+    """The weights are immutable, so only the first sleep may snapshot them."""
+    module = torch.nn.Linear(2, 2)
+    residency = ModuleResidency(module, torch.device("cpu"))
+
+    residency.sleep()
+    snapshot = residency._host["weight"]
+    residency.wake()
+    residency.sleep()
+
+    assert residency._host["weight"] is snapshot
+
+
+def test_a_host_built_module_is_asleep_and_never_snapshots_from_the_gpu() -> None:
+    module = torch.nn.Linear(2, 2)
+    residency = ModuleResidency(module, torch.device("cpu"), resident=False)
+
+    assert residency.resident is False
+    assert residency._host["weight"] is module.weight
+
+    residency.wake()
+    assert residency.resident is True
+
+
+def test_residency_keeps_tied_weights_tied_across_a_round_trip() -> None:
+    module = torch.nn.Linear(4, 4)
+    tied = torch.nn.Linear(4, 4)
+    tied.weight = module.weight
+    parent = torch.nn.Sequential(module, tied)
+    residency = ModuleResidency(parent, torch.device("cpu"))
+
+    residency.sleep()
+    residency.wake()
+
+    assert module.weight is tied.weight
+    assert module.weight.data_ptr() == tied.weight.data_ptr()
 
 
 @pytest.mark.gpu


### PR DESCRIPTION
## Motivation

Stacked on #1739 (part 3 of 4 on top of #1619). **Merge #1738 and #1739 first.**

This PR fixes the two things that stop #1619 from delivering what its flag
promises. DIT/DAV stays FP32 throughout — no dtype change.

**1. A startup peak that makes the mode unusable on the cards it targets.**

`_build_dit` and `_build_dav` call
`load_torch_state(..., device=self.device)`, staging both checkpoints
*through the GPU* before `offload_to_cpu()` moves them back. AR is already
registered and resident by then, so startup always peaks with AR **and**
DIT/DAV fully resident — precisely the peak serial offload exists to
avoid. Whichever stage is built second hits the combined footprint.

**2. Round-tripping immutable weights on every request.**

`move_module_to_device` ran `module.to()` in both directions per handoff:

- The weights never change during inference, yet every sleep paid a full
  device-to-host copy of unchanged weights plus a fresh pageable host
  allocation to land in. Only the wake direction did useful work.
- Handing the caching allocator multi-GB blocks to free and re-request
  each request fragments it. That is an OOM tens of requests into a run
  rather than on the first — the hardest kind to attribute.

## Modifications

`ModuleResidency` makes the host copy canonical: filled once, wake refills
the GPU replica from it, sleep only drops the replica. Because residency
mutates the tensor object in place rather than rebinding module
attributes, tied weights stay tied across a round trip (covered by a test).

Under serial offload, DIT/DAV now load **on the host** and only ever
upload a replica on demand, so the checkpoint never touches the GPU at
startup and there is never a device-to-host copy at all.

`move_module_to_device` has no callers left and is removed.

## Accuracy Test

Weights are moved, never transformed, and the dtype is unchanged, so
generated audio is bit-identical. `test_residency_sleep_and_wake_preserve_weights_and_state`
asserts the round trip preserves values.

## Benchmark & Profiling

Removes one full device-to-host weight copy per request. Absolute numbers
need a 24GB card; #1741 adds the logging that measures it.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
