### PR TITLE
[Benchmark][ASR] Add LongLibriHeavy and Meanwhile evals

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -188,6 +188,7 @@ python -m benchmarks.eval.benchmark_omni_seedtts \
 | `eval/benchmark_omni_videoamme.py` | Video-AMME (video + audio question understanding) | Qwen3-Omni | `/v1/chat/completions` |
 | `eval/benchmark_asr_seedtts.py` | ASR concurrency scaling on SeedTTS EN/ZH | Qwen3-ASR, Fun-ASR | `/v1/audio/transcriptions` |
 | `eval/benchmark_asr_stt_benchmark.py` | ASR concurrency scaling on the Pipecat STT benchmark set (EN) | Qwen3-ASR, Fun-ASR | `/v1/audio/transcriptions` |
+| `eval/benchmark_asr_longform.py` | ASR concurrency scaling on LongLibriHeavy 30/60 s and Meanwhile (EN) | Qwen3-ASR, Fun-ASR | `/v1/audio/transcriptions` |
 
 See [tts_serving/README.md](tts_serving/README.md) for the TTS serving
 benchmark design, harness contract, scenario matrix, and Docker usage.
@@ -244,6 +245,37 @@ numbers are not comparable to the Pipecat leaderboard.
 python -m benchmarks.dataset.prepare --dataset stt-benchmark
 python -m benchmarks.eval.benchmark_asr_stt_benchmark \
   --port 8000 --concurrencies 1,8,32 --repeats 3 --warmup
+```
+
+`benchmark_asr_longform.py` registers three canonical long-form English
+workloads: the complete LongLibriHeavy `llh_test_30` (1203 samples) and
+`llh_test_60` (591 samples) splits, plus all 64 samples in the Meanwhile `test`
+split. The LongLibriHeavy names refer to the published splits; the loader does
+not apply another duration filter. Likewise, Meanwhile's `begin` and `end`
+metadata are not used to crop the already segmented `audio` field.
+
+The loader decodes each source clip and stages it as mono 16 kHz PCM WAV before
+the timed sweep. The result JSON uses the same schema and metrics as the
+SeedTTS and Pipecat ASR sweeps, and records the dataset alias, repository,
+split, pinned revision, expected sample count, and exact input fingerprint.
+`--stream` uploads each complete file rather than simulating real-time audio
+arrival.
+
+```bash
+python -m benchmarks.dataset.prepare --dataset longlibriheavy-30
+python -m benchmarks.eval.benchmark_asr_longform \
+  --dataset longlibriheavy-30 --port 8000 \
+  --concurrencies 1,8,32 --repeats 3 --warmup
+
+python -m benchmarks.dataset.prepare --dataset longlibriheavy-60
+python -m benchmarks.eval.benchmark_asr_longform \
+  --dataset longlibriheavy-60 --port 8000 \
+  --concurrencies 1,8,32 --repeats 3 --warmup
+
+python -m benchmarks.dataset.prepare --dataset meanwhile
+python -m benchmarks.eval.benchmark_asr_longform \
+  --dataset meanwhile --port 8000 \
+  --concurrencies 1,8,32 --repeats 3 --warmup
 ```
 
 Both `*_seedtts.py` scripts also support speech quality and similarity evaluation via UTMOS and WavLM speaker verification metrics. Running with `--utmos-only` or `--similarity-only` loads the respective pre-trained predictor and computes scores on the previously generated audio in the output directory without requiring the TTS/ASR servers to be running.
@@ -308,6 +340,9 @@ python -m benchmarks.dataset.prepare --dataset seedtts       # full SeedTTS
 python -m benchmarks.dataset.prepare --dataset seedtts-mini  # smoke-test subset
 python -m benchmarks.dataset.prepare --dataset seedtts-50    # 50-sample subset
 python -m benchmarks.dataset.prepare --dataset stt-benchmark # Pipecat STT benchmark set (1000 EN clips)
+python -m benchmarks.dataset.prepare --dataset longlibriheavy-30  # LongLibriHeavy llh_test_30 only
+python -m benchmarks.dataset.prepare --dataset longlibriheavy-60  # LongLibriHeavy llh_test_60 only
+python -m benchmarks.dataset.prepare --dataset meanwhile     # complete Meanwhile test split (64 EN clips)
 python -m benchmarks.dataset.prepare --dataset mmmu          # full MMMU (30 subjects)
 python -m benchmarks.dataset.prepare --dataset mmmu-ci-50    # MMMU CI subset
 python -m benchmarks.dataset.prepare --dataset mmsu          # full MMSU (ddwang2000/MMSU)

--- a/benchmarks/dataset/asr_longform.py
+++ b/benchmarks/dataset/asr_longform.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Load the canonical long-form English ASR evaluation datasets."""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import shutil
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+from datasets import Audio, load_dataset
+
+from benchmarks.dataset.prepare import (
+    LONGLIBRIHEAVY_DATASET_ID,
+    LONGLIBRIHEAVY_DATASET_REVISION,
+    MEANWHILE_DATASET_ID,
+    MEANWHILE_DATASET_REVISION,
+)
+from benchmarks.dataset.seedtts import SampleInput
+from sglang_omni.utils.audio import load_audio
+
+logger = logging.getLogger(__name__)
+
+ASR_LONGFORM_LANG = "en"
+ASR_LONGFORM_SAMPLE_RATE = 16000
+
+
+@dataclass(frozen=True, slots=True)
+class LongFormDatasetConfig:
+    name: str
+    repo_id: str
+    revision: str
+    split: str
+    expected_sample_count: int
+
+
+ASR_LONGFORM_DATASETS: dict[str, LongFormDatasetConfig] = {
+    "longlibriheavy-30": LongFormDatasetConfig(
+        name="longlibriheavy-30",
+        repo_id=LONGLIBRIHEAVY_DATASET_ID,
+        revision=LONGLIBRIHEAVY_DATASET_REVISION,
+        split="llh_test_30",
+        expected_sample_count=1203,
+    ),
+    "longlibriheavy-60": LongFormDatasetConfig(
+        name="longlibriheavy-60",
+        repo_id=LONGLIBRIHEAVY_DATASET_ID,
+        revision=LONGLIBRIHEAVY_DATASET_REVISION,
+        split="llh_test_60",
+        expected_sample_count=591,
+    ),
+    "meanwhile": LongFormDatasetConfig(
+        name="meanwhile",
+        repo_id=MEANWHILE_DATASET_ID,
+        revision=MEANWHILE_DATASET_REVISION,
+        split="test",
+        expected_sample_count=64,
+    ),
+}
+
+_REQUIRED_COLUMNS = {"audio", "text"}
+_STAGED_CACHE: dict[tuple[str, str, int | None], list[SampleInput]] = {}
+
+
+def _audio_source(
+    audio: object, *, repo_id: str, split: str, sample_id: str
+) -> bytes | str:
+    if not isinstance(audio, Mapping):
+        raise ValueError(f"Missing audio for {repo_id}/{split}/{sample_id}")
+    audio_bytes = audio.get("bytes")
+    if isinstance(audio_bytes, (bytes, bytearray, memoryview)) and audio_bytes:
+        return bytes(audio_bytes)
+    audio_path = audio.get("path")
+    if isinstance(audio_path, str) and audio_path:
+        return audio_path
+    raise ValueError(f"Missing audio bytes/path for {repo_id}/{split}/{sample_id}")
+
+
+def load_asr_longform_samples(
+    dataset_name: str,
+    max_samples: int | None = None,
+    *,
+    revision: str | None = None,
+) -> list[SampleInput]:
+    """Load one registered dataset and stage it as mono 16 kHz PCM WAV."""
+    try:
+        config = ASR_LONGFORM_DATASETS[dataset_name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown long-form ASR dataset: {dataset_name!r}") from exc
+    dataset_revision = revision or config.revision
+
+    full_cache_key = (dataset_name, dataset_revision, None)
+    if full_cache_key in _STAGED_CACHE:
+        samples = _STAGED_CACHE[full_cache_key]
+        return samples[:max_samples] if max_samples is not None else list(samples)
+
+    cache_key = (dataset_name, dataset_revision, max_samples)
+    if cache_key in _STAGED_CACHE:
+        return list(_STAGED_CACHE[cache_key])
+
+    logger.info(
+        "Loading %s split=%s revision=%s from HuggingFace ...",
+        config.repo_id,
+        config.split,
+        dataset_revision,
+    )
+    dataset = load_dataset(
+        config.repo_id,
+        split=config.split,
+        revision=dataset_revision,
+    )
+    missing = _REQUIRED_COLUMNS - set(dataset.column_names)
+    if missing:
+        raise ValueError(
+            f"Dataset {config.repo_id} split={config.split} is missing columns: "
+            f"{missing}"
+        )
+    if (
+        max_samples is None
+        and dataset_revision == config.revision
+        and len(dataset) != config.expected_sample_count
+    ):
+        raise ValueError(
+            f"Expected {config.expected_sample_count} samples for "
+            f"{config.repo_id}/{config.split}, got {len(dataset)}"
+        )
+
+    dataset = dataset.cast_column("audio", Audio(decode=False))
+    if max_samples is not None:
+        dataset = dataset.select(list(range(min(max_samples, len(dataset)))))
+
+    staging_dir = Path(tempfile.mkdtemp(prefix=f"asr_{dataset_name}_"))
+    atexit.register(shutil.rmtree, str(staging_dir), True)
+    logger.info("Staging normalized audio to %s", staging_dir)
+
+    samples: list[SampleInput] = []
+    for index, row in enumerate(dataset):
+        sample_id = f"{dataset_name}-{index:06d}"
+        reference = row["text"]
+        if not isinstance(reference, str) or not reference.strip():
+            raise ValueError(
+                f"Empty text for {config.repo_id}/{config.split}/{sample_id}"
+            )
+        source = _audio_source(
+            row["audio"],
+            repo_id=config.repo_id,
+            split=config.split,
+            sample_id=sample_id,
+        )
+        waveform = load_audio(
+            source,
+            source_name=f"{config.repo_id}/{config.split}/{sample_id}",
+            target_sample_rate=ASR_LONGFORM_SAMPLE_RATE,
+            mono=True,
+        )
+        waveform = np.asarray(waveform, dtype=np.float32)
+        if waveform.ndim != 1 or waveform.size == 0 or not np.isfinite(waveform).all():
+            raise ValueError(
+                f"Invalid decoded audio for {config.repo_id}/{config.split}/{sample_id}"
+            )
+        wav_path = staging_dir / f"{sample_id}.wav"
+        sf.write(
+            wav_path,
+            waveform,
+            ASR_LONGFORM_SAMPLE_RATE,
+            format="WAV",
+            subtype="PCM_16",
+        )
+        text = reference.strip()
+        samples.append(
+            SampleInput(
+                sample_id=sample_id,
+                ref_text=text,
+                ref_audio=str(wav_path),
+                target_text=text,
+            )
+        )
+
+    _STAGED_CACHE[cache_key] = samples
+    logger.info(
+        "Loaded %d samples from %s/%s",
+        len(samples),
+        config.repo_id,
+        config.split,
+    )
+    return list(samples)

--- a/benchmarks/dataset/prepare.py
+++ b/benchmarks/dataset/prepare.py
@@ -6,6 +6,9 @@ Usage:
     python -m benchmarks.dataset.prepare --dataset seedtts-mini
     python -m benchmarks.dataset.prepare --dataset seedtts-50
     python -m benchmarks.dataset.prepare --dataset stt-benchmark
+    python -m benchmarks.dataset.prepare --dataset longlibriheavy-30
+    python -m benchmarks.dataset.prepare --dataset longlibriheavy-60
+    python -m benchmarks.dataset.prepare --dataset meanwhile
     python -m benchmarks.dataset.prepare --dataset mmmu
     python -m benchmarks.dataset.prepare --dataset mmmu-ci-50
     python -m benchmarks.dataset.prepare --dataset mmsu
@@ -28,12 +31,19 @@ SEEDTTS_DATASET_ID = "zhaochenyang20/seed-tts-eval-arrow"
 SEEDTTS_DATASET_REVISION = "27f4c1adee83b5b29b7c4b375f6b976324bda308"
 STT_BENCHMARK_DATASET_ID = "pipecat-ai/stt-benchmark-data"
 STT_BENCHMARK_DATASET_REVISION = "3fe50170d520c951957b86996ef082a6ab87b394"
+LONGLIBRIHEAVY_DATASET_ID = "inesc-id/longlibriheavy"
+LONGLIBRIHEAVY_DATASET_REVISION = "09bc067255eeb0d0bca62357ac985c2ebdc5169c"
+MEANWHILE_DATASET_ID = "distil-whisper/meanwhile"
+MEANWHILE_DATASET_REVISION = "5a6b431a268523a6603f199d859fc25a24c22900"
 
 DATASETS: dict[str, str] = {
     "seedtts": SEEDTTS_DATASET_ID,
     "seedtts-mini": "zhaochenyang20/seed-tts-eval-mini-arrow",
     "seedtts-50": "zhaochenyang20/seed-tts-eval-50-arrow",
     "stt-benchmark": STT_BENCHMARK_DATASET_ID,
+    "longlibriheavy-30": f"{LONGLIBRIHEAVY_DATASET_ID}:llh_test_30",
+    "longlibriheavy-60": f"{LONGLIBRIHEAVY_DATASET_ID}:llh_test_60",
+    "meanwhile": f"{MEANWHILE_DATASET_ID}:test",
     "mmmu": "MMMU/MMMU",
     "mmmu-ci-50": "zhaochenyang20/mmmu-ci-50",
     "mmsu": "ddwang2000/MMSU",
@@ -58,37 +68,42 @@ def download_dataset(
     from datasets import get_dataset_config_names, load_dataset
     from huggingface_hub import hf_hub_download
 
-    if revision is None and repo_id == SEEDTTS_DATASET_ID:
+    dataset_id, separator, split = repo_id.partition(":")
+    if revision is None and dataset_id == SEEDTTS_DATASET_ID:
         revision = SEEDTTS_DATASET_REVISION
-    elif revision is None and repo_id == STT_BENCHMARK_DATASET_ID:
+    elif revision is None and dataset_id == STT_BENCHMARK_DATASET_ID:
         revision = STT_BENCHMARK_DATASET_REVISION
+    elif revision is None and dataset_id == LONGLIBRIHEAVY_DATASET_ID:
+        revision = LONGLIBRIHEAVY_DATASET_REVISION
+    elif revision is None and dataset_id == MEANWHILE_DATASET_ID:
+        revision = MEANWHILE_DATASET_REVISION
     revision_kwargs = {"revision": revision} if revision else {}
     if not quiet:
         logger.info(
-            "Pre-warming HuggingFace cache for %s revision=%s ...",
-            repo_id,
+            "Pre-warming HuggingFace cache for %s split=%s revision=%s ...",
+            dataset_id,
+            split if separator else "all",
             revision or "default",
         )
 
-    if repo_id == "MMMU/MMMU":
-        config_names = get_dataset_config_names(repo_id, **revision_kwargs)
+    if dataset_id == "MMMU/MMMU":
+        config_names = get_dataset_config_names(dataset_id, **revision_kwargs)
         for config_name in config_names:
             load_dataset(
-                repo_id,
+                dataset_id,
                 config_name,
                 split="validation",
                 **revision_kwargs,
             )
-    elif repo_id == "BoJack/MMAR":
-        load_dataset(repo_id, **revision_kwargs)
+    elif dataset_id == "BoJack/MMAR":
+        load_dataset(dataset_id, **revision_kwargs)
         hf_hub_download(
-            repo_id,
+            dataset_id,
             "mmar-audio.tar.gz",
             repo_type="dataset",
             **revision_kwargs,
         )
-    elif repo_id.startswith("lmms-lab/mmau:"):
-        dataset_id, split = repo_id.split(":", 1)
+    elif dataset_id == "lmms-lab/mmau" and separator:
         load_dataset(
             dataset_id,
             split=split,
@@ -96,8 +111,10 @@ def download_dataset(
             verification_mode="no_checks",
             **revision_kwargs,
         )
+    elif separator:
+        load_dataset(dataset_id, split=split, **revision_kwargs)
     else:
-        load_dataset(repo_id, **revision_kwargs)
+        load_dataset(dataset_id, **revision_kwargs)
 
     if not quiet:
         logger.info(f"Dataset {repo_id} cached.")

--- a/benchmarks/eval/benchmark_asr_longform.py
+++ b/benchmarks/eval/benchmark_asr_longform.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
+# Author:
+# Yuhao Chen: https://github.com/AkazaAkane
 """ASR concurrency benchmark on registered long-form English datasets.
 
 The registered workloads are the 30 s and 60 s LongLibriHeavy test splits and
 the complete Meanwhile test split. Audio is normalized to mono 16 kHz PCM WAV
 before the timed sweep, then sent through the same request, WER, performance,
-resource-monitoring, and reporting path as ``benchmark_asr_seedtts``.
+resource-monitoring, and reporting path as benchmark_asr_seedtts.
 
 Usage:
 
@@ -23,9 +25,9 @@ Usage:
         --dataset meanwhile --port 8000 \
         --concurrencies 1,8,32 --repeats 3 --warmup
 
-``--stream`` still uploads each complete file; it does not simulate real-time
+--stream still uploads each complete file; it does not simulate real-time
 audio arrival. The dataset is English only, so WER uses the Whisper English
-normalizer and the request language is fixed to ``en``.
+normalizer and the request language is fixed to en.
 """
 
 from __future__ import annotations

--- a/benchmarks/eval/benchmark_asr_longform.py
+++ b/benchmarks/eval/benchmark_asr_longform.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ASR concurrency benchmark on registered long-form English datasets.
+
+The registered workloads are the 30 s and 60 s LongLibriHeavy test splits and
+the complete Meanwhile test split. Audio is normalized to mono 16 kHz PCM WAV
+before the timed sweep, then sent through the same request, WER, performance,
+resource-monitoring, and reporting path as ``benchmark_asr_seedtts``.
+
+Usage:
+
+    python -m benchmarks.dataset.prepare --dataset longlibriheavy-30
+    python -m benchmarks.eval.benchmark_asr_longform \
+        --dataset longlibriheavy-30 --port 8000 \
+        --concurrencies 1,8,32 --repeats 3 --warmup
+
+    python -m benchmarks.dataset.prepare --dataset longlibriheavy-60
+    python -m benchmarks.eval.benchmark_asr_longform \
+        --dataset longlibriheavy-60 --port 8000 \
+        --concurrencies 1,8,32 --repeats 3 --warmup
+
+    python -m benchmarks.dataset.prepare --dataset meanwhile
+    python -m benchmarks.eval.benchmark_asr_longform \
+        --dataset meanwhile --port 8000 \
+        --concurrencies 1,8,32 --repeats 3 --warmup
+
+``--stream`` still uploads each complete file; it does not simulate real-time
+audio arrival. The dataset is English only, so WER uses the Whisper English
+normalizer and the request language is fixed to ``en``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+
+from benchmarks.dataset.asr_longform import (
+    ASR_LONGFORM_DATASETS,
+    ASR_LONGFORM_LANG,
+    load_asr_longform_samples,
+)
+from benchmarks.eval.asr_profiling import (
+    collect_environment_fingerprint,
+    collect_server_identity,
+)
+from benchmarks.eval.benchmark_asr_seedtts import (
+    _evaluation_input_sha256,
+    _print_table,
+    _sweep,
+    add_common_args,
+    finalize_args,
+)
+from benchmarks.runtime_metrics import collect_benchmark_provenance
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dataset",
+        choices=list(ASR_LONGFORM_DATASETS),
+        default="longlibriheavy-30",
+        help="Registered long-form ASR dataset to evaluate.",
+    )
+    parser.add_argument(
+        "--max-samples",
+        type=int,
+        default=0,
+        help="Limit samples (0 = the complete registered split).",
+    )
+    add_common_args(parser, default_output="")
+    args = finalize_args(parser.parse_args())
+    args.lang = ASR_LONGFORM_LANG
+    if not args.output:
+        args.output = f"asr_{args.dataset.replace('-', '_')}_results.json"
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+    config = ASR_LONGFORM_DATASETS[args.dataset]
+    dataset_revision = args.dataset_revision or config.revision
+    max_samples = args.max_samples if args.max_samples > 0 else None
+
+    samples = load_asr_longform_samples(
+        args.dataset,
+        max_samples=max_samples,
+        revision=dataset_revision,
+    )
+    if not samples:
+        raise RuntimeError(f"No long-form ASR samples loaded for {args.dataset!r}")
+    evaluation_input_sha256 = _evaluation_input_sha256(
+        samples,
+        namespace=f"asr-longform-{args.dataset}",
+    )
+    print(
+        f"Loaded {len(samples)} {args.dataset} samples "
+        f"({config.repo_id}, {config.split}); sweeping "
+        f"concurrency={args.concurrencies} x {args.repeats} repeats against "
+        f"{args.host}:{args.port} ({args.model_path})"
+    )
+
+    aggregates = asyncio.run(_sweep(args, samples, args.concurrencies))
+    _print_table(aggregates)
+
+    server_config = {
+        "dtype": args.dtype,
+        "quantization": args.quantization,
+        "attention_backend": args.attention_backend,
+        "mm_attention_backend": args.mm_attention_backend,
+        "cuda_graph": args.cuda_graph,
+        "torch_compile": args.torch_compile,
+        "max_running_requests": args.max_running_requests,
+        "mem_fraction_static": args.mem_fraction_static,
+    }
+    payload = {
+        "schema_version": 2,
+        "provenance": collect_benchmark_provenance(
+            model_id=args.model_path,
+            model_revision=args.model_revision,
+            dataset_id=config.repo_id,
+            dataset_revision=dataset_revision,
+            launch_command=args.launch_command,
+            server_config=server_config,
+            evaluation_input_sha256=evaluation_input_sha256,
+        ),
+        "config": {
+            "host": args.host,
+            "port": args.port,
+            "dataset": args.dataset,
+            "repo_id": config.repo_id,
+            "split": config.split,
+            "lang": args.lang,
+            "model_path": args.model_path,
+            "declared_model_revision": args.model_revision,
+            "dataset_revision": dataset_revision,
+            "num_samples": len(samples),
+            "expected_num_samples": config.expected_sample_count,
+            "concurrencies": args.concurrencies,
+            "repeats": args.repeats,
+            "warmup": args.warmup,
+            "stream": args.stream,
+            "declared_server": server_config,
+            "resource_monitor": {
+                "enabled": not args.disable_resource_monitor,
+                "gpu_index": args.gpu_index,
+                "interval_s": args.monitor_interval_s,
+                "gpu_process_pids": args.gpu_process_pids or [],
+            },
+            "profile_events": args.profile_events,
+            "sample_util": args.sample_util,
+        },
+        "results": aggregates,
+    }
+    if args.fingerprint:
+        payload["environment_fingerprint"] = {
+            "client": collect_environment_fingerprint(args.model_path),
+            "server": collect_server_identity(f"http://{args.host}:{args.port}"),
+        }
+    output_path = os.path.abspath(args.output)
+    with open(output_path, "w") as handle:
+        json.dump(payload, handle, indent=2)
+    print(f"\nWrote results to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_test/benchmarks/test_dataset_regressions.py
+++ b/tests/unit_test/benchmarks/test_dataset_regressions.py
@@ -8,11 +8,16 @@ import types
 import wave
 from pathlib import Path
 
+import numpy as np
 import pytest
 import yaml
 
-from benchmarks.dataset import prepare, seedtts, stt_benchmark
-from benchmarks.eval import benchmark_asr_seedtts, benchmark_asr_stt_benchmark
+from benchmarks.dataset import asr_longform, prepare, seedtts, stt_benchmark
+from benchmarks.eval import (
+    benchmark_asr_longform,
+    benchmark_asr_seedtts,
+    benchmark_asr_stt_benchmark,
+)
 
 _MODELS_DIR = (
     Path(__file__).resolve().parents[3] / ".claude/skills/tune-ci-thresholds/models"
@@ -854,3 +859,224 @@ def test_evaluation_input_fingerprint_is_namespaced(tmp_path: Path) -> None:
 
     assert fingerprint(samples) == fingerprint(samples, namespace="seedtts")
     assert fingerprint(samples) != fingerprint(samples, namespace="stt-benchmark")
+
+
+@pytest.mark.parametrize(
+    ("dataset_name", "repo_id", "split", "revision"),
+    [
+        (
+            "longlibriheavy-30",
+            prepare.LONGLIBRIHEAVY_DATASET_ID,
+            "llh_test_30",
+            prepare.LONGLIBRIHEAVY_DATASET_REVISION,
+        ),
+        (
+            "longlibriheavy-60",
+            prepare.LONGLIBRIHEAVY_DATASET_ID,
+            "llh_test_60",
+            prepare.LONGLIBRIHEAVY_DATASET_REVISION,
+        ),
+        (
+            "meanwhile",
+            prepare.MEANWHILE_DATASET_ID,
+            "test",
+            prepare.MEANWHILE_DATASET_REVISION,
+        ),
+    ],
+)
+def test_download_asr_longform_dataset_uses_split_and_pinned_revision(
+    monkeypatch: pytest.MonkeyPatch,
+    dataset_name: str,
+    repo_id: str,
+    split: str,
+    revision: str,
+) -> None:
+    observed: dict = {}
+
+    def fake_load_dataset(observed_repo_id: str, **kwargs):
+        observed["repo_id"] = observed_repo_id
+        observed.update(kwargs)
+        return object()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "datasets",
+        types.SimpleNamespace(
+            get_dataset_config_names=lambda *_args, **_kwargs: [],
+            load_dataset=fake_load_dataset,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "huggingface_hub",
+        types.SimpleNamespace(hf_hub_download=lambda *_args, **_kwargs: None),
+    )
+
+    prepare.download_dataset(prepare.DATASETS[dataset_name], quiet=True)
+
+    assert observed == {
+        "repo_id": repo_id,
+        "split": split,
+        "revision": revision,
+    }
+
+
+def _longform_rows(count: int) -> list[dict]:
+    return [
+        {
+            "audio": {"bytes": f"encoded-{index}".encode(), "path": None},
+            "text": f"Transcript {index}.",
+        }
+        for index in range(count)
+    ]
+
+
+def _stage_longform_into(monkeypatch: pytest.MonkeyPatch, staging_dir: Path) -> None:
+    monkeypatch.setattr(
+        asr_longform.tempfile, "mkdtemp", lambda prefix: str(staging_dir)
+    )
+    monkeypatch.setattr(asr_longform.atexit, "register", lambda *a, **k: None)
+
+
+def test_load_asr_longform_samples_selects_before_decode_and_stages_pcm(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    asr_longform._STAGED_CACHE.clear()
+    dataset = _FakeDataset(_longform_rows(5))
+    staging_dir = tmp_path / "longform_stage"
+    staging_dir.mkdir()
+    decoded_sources: list[bytes | str] = []
+
+    def fake_load_audio(source, **kwargs):
+        decoded_sources.append(source)
+        assert kwargs["target_sample_rate"] == 16000
+        assert kwargs["mono"] is True
+        return np.array([0.0, 0.25, -0.25, 0.0], dtype=np.float32)
+
+    monkeypatch.setattr(asr_longform, "load_dataset", lambda *a, **k: dataset)
+    monkeypatch.setattr(asr_longform, "Audio", lambda **kwargs: ("Audio", kwargs))
+    monkeypatch.setattr(asr_longform, "load_audio", fake_load_audio)
+    _stage_longform_into(monkeypatch, staging_dir)
+
+    samples = asr_longform.load_asr_longform_samples("meanwhile", max_samples=2)
+
+    assert dataset.selected_indices == [0, 1]
+    assert decoded_sources == [b"encoded-0", b"encoded-1"]
+    assert [sample.sample_id for sample in samples] == [
+        "meanwhile-000000",
+        "meanwhile-000001",
+    ]
+    assert samples[0].ref_text == "Transcript 0."
+    assert samples[0].target_text == "Transcript 0."
+    with wave.open(samples[0].ref_audio, "rb") as wav_file:
+        assert wav_file.getnchannels() == 1
+        assert wav_file.getsampwidth() == 2
+        assert wav_file.getframerate() == 16000
+        assert wav_file.getnframes() == 4
+
+    monkeypatch.setattr(
+        asr_longform,
+        "load_dataset",
+        lambda *a, **k: pytest.fail("reloaded instead of using staged cache"),
+    )
+    again = asr_longform.load_asr_longform_samples("meanwhile", max_samples=2)
+    assert [sample.sample_id for sample in again] == [
+        "meanwhile-000000",
+        "meanwhile-000001",
+    ]
+
+    asr_longform._STAGED_CACHE.clear()
+
+
+def test_load_asr_longform_full_split_checks_canonical_sample_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    asr_longform._STAGED_CACHE.clear()
+    monkeypatch.setattr(
+        asr_longform,
+        "load_dataset",
+        lambda *a, **k: _FakeDataset(_longform_rows(1)),
+    )
+
+    with pytest.raises(ValueError, match="Expected 64 samples"):
+        asr_longform.load_asr_longform_samples("meanwhile")
+
+
+def test_load_asr_longform_rejects_empty_reference(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    asr_longform._STAGED_CACHE.clear()
+    rows = _longform_rows(1)
+    rows[0]["text"] = "  "
+    staging_dir = tmp_path / "longform_stage"
+    staging_dir.mkdir()
+    monkeypatch.setattr(
+        asr_longform, "load_dataset", lambda *a, **k: _FakeDataset(rows)
+    )
+    monkeypatch.setattr(asr_longform, "Audio", lambda **kwargs: ("Audio", kwargs))
+    _stage_longform_into(monkeypatch, staging_dir)
+
+    with pytest.raises(ValueError, match="Empty text"):
+        asr_longform.load_asr_longform_samples("meanwhile", max_samples=1)
+
+
+def test_asr_longform_main_records_registered_dataset_provenance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    loaded: dict = {}
+    captured: dict = {}
+    output_path = tmp_path / "result.json"
+
+    def capture_load(dataset_name: str, **kwargs):
+        loaded["dataset_name"] = dataset_name
+        loaded.update(kwargs)
+        return _one_stt_sample(tmp_path)
+
+    async def empty_sweep(*_args, **_kwargs):
+        return []
+
+    def capture_provenance(**kwargs):
+        captured.update(kwargs)
+        return {}
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "benchmark_asr_longform",
+            "--dataset",
+            "meanwhile",
+            "--port",
+            "8000",
+            "--output",
+            str(output_path),
+        ],
+    )
+    monkeypatch.setattr(
+        benchmark_asr_longform, "load_asr_longform_samples", capture_load
+    )
+    monkeypatch.setattr(benchmark_asr_longform, "_sweep", empty_sweep)
+    monkeypatch.setattr(benchmark_asr_longform, "_print_table", lambda *_args: None)
+    monkeypatch.setattr(
+        benchmark_asr_longform,
+        "collect_benchmark_provenance",
+        capture_provenance,
+    )
+
+    benchmark_asr_longform.main()
+
+    assert loaded == {
+        "dataset_name": "meanwhile",
+        "max_samples": None,
+        "revision": prepare.MEANWHILE_DATASET_REVISION,
+    }
+    assert captured["dataset_id"] == prepare.MEANWHILE_DATASET_ID
+    assert captured["dataset_revision"] == prepare.MEANWHILE_DATASET_REVISION
+    payload = json.loads(output_path.read_text())
+    assert payload["schema_version"] == 2
+    assert payload["config"]["dataset"] == "meanwhile"
+    assert payload["config"]["repo_id"] == prepare.MEANWHILE_DATASET_ID
+    assert payload["config"]["split"] == "test"
+    assert payload["config"]["lang"] == "en"
+    assert payload["config"]["expected_num_samples"] == 64
+    assert payload["results"] == []


### PR DESCRIPTION
## Motivation

Extend the standalone ASR benchmark coverage from short-form SeedTTS and
Pipecat utterances to canonical long-form English evaluation workloads.

## Modifications

- Register the pinned LongLibriHeavy `llh_test_30` and `llh_test_60` splits and
  the complete Meanwhile `test` split with split-specific dataset preparation.
- Add a loader that validates references and normalizes encoded audio to mono
  16 kHz PCM16 WAV before benchmark timing starts.
- Add `benchmark_asr_longform.py`, reusing the existing ASR concurrency sweep,
  Whisper-normalized WER, latency/RTF/RTFx reporting, resource monitoring, and
  schema-v2 provenance from the SeedTTS/Pipecat benchmark path.
- Document preparation and full-run commands and add focused dataset,
  normalization, sample-count, and provenance regression coverage.

## Related Issues

N/A

## Accuracy Test

Not run. This PR adds a benchmark harness and does not change model-side code.

## Benchmark & Profiling

Not run. The new full-dataset commands are documented for GPU evaluation;
repository instructions limit local verification to pre-commit.

Validation performed:

```bash
/Users/yc/Downloads/sglang-omni/.venv/bin/pre-commit run --files \
  benchmarks/README.md \
  benchmarks/dataset/prepare.py \
  benchmarks/dataset/asr_longform.py \
  benchmarks/eval/benchmark_asr_longform.py \
  tests/unit_test/benchmarks/test_dataset_regressions.py
```

All hooks passed.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
