### PR TITLE
feat: add external input streams to pipeline

### DIFF
--- a/sglang_omni/client/__init__.py
+++ b/sglang_omni/client/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Client package."""
 
-from sglang_omni.client.client import Client
+from sglang_omni.client.client import Client, ExternalInputStream
 from sglang_omni.client.types import (
     AbortLevel,
     AbortResult,
@@ -19,6 +19,7 @@ from sglang_omni.client.types import (
 
 __all__ = [
     "Client",
+    "ExternalInputStream",
     "AbortLevel",
     "AbortResult",
     "ClientError",

--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -34,6 +34,77 @@ from sglang_omni.pipeline.coordinator import Coordinator
 from sglang_omni.proto import OmniRequest, RequestState, StreamMessage
 
 
+class ExternalInputStream:
+    """One persistent request with incrementally supplied entry-stage input."""
+
+    def __init__(
+        self,
+        client: Client,
+        request_id: str,
+        events: AsyncIterator[Any],
+    ) -> None:
+        self._client = client
+        self.request_id = request_id
+        self._events = events
+        self._input_done = False
+        self._closed = False
+
+    def __aiter__(self) -> ExternalInputStream:
+        return self
+
+    async def __anext__(self) -> GenerateChunk:
+        if self._closed:
+            raise StopAsyncIteration
+        try:
+            msg = await anext(self._events)
+        except StopAsyncIteration:
+            self._closed = True
+            raise
+        if isinstance(msg, StreamMessage):
+            return self._client._stream_builder(self.request_id, msg)
+        return self._client._result_builder(self.request_id, msg.result)
+
+    async def send(self, data: Any, *, metadata: dict[str, Any] | None = None) -> int:
+        if self._input_done:
+            raise RuntimeError(f"Input stream {self.request_id!r} is already done")
+        if self._closed:
+            raise RuntimeError(f"Input stream {self.request_id!r} is closed")
+        return await self._client.send_input_chunk(
+            self.request_id, data, metadata=metadata
+        )
+
+    async def finish(self) -> None:
+        if self._input_done:
+            raise RuntimeError(f"Input stream {self.request_id!r} is already done")
+        if self._closed:
+            raise RuntimeError(f"Input stream {self.request_id!r} is closed")
+        await self._client.finish_input_stream(self.request_id)
+        self._input_done = True
+
+    async def abort(self) -> AbortResult:
+        result = await self._client.close_input_stream(self.request_id)
+        await self._close_events()
+        return result
+
+    async def aclose(self) -> None:
+        if not self._closed:
+            await self._client.close_input_stream(self.request_id)
+        await self._close_events()
+
+    async def _close_events(self) -> None:
+        self._closed = True
+        close = getattr(self._events, "aclose", None)
+        if close is not None:
+            await close()
+
+    async def __aenter__(self) -> ExternalInputStream:
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        del exc_info
+        await self.aclose()
+
+
 class Client:
     """Internal client used by API adapters."""
 
@@ -70,6 +141,42 @@ class Client:
 
         result = await self._coordinator.submit(req_id, omni_request)
         yield self._result_builder(req_id, result)
+
+    async def start_input_stream(
+        self,
+        request: GenerateRequest,
+        *,
+        request_id: str | None = None,
+    ) -> ExternalInputStream:
+        """Open a persistent request that accepts bounded CPU tensor chunks."""
+        req_id = request_id or str(uuid.uuid4())
+        events = await self._coordinator.start_input_stream(
+            req_id, self._build_omni_request(request)
+        )
+        return ExternalInputStream(self, req_id, events)
+
+    async def send_input_chunk(
+        self,
+        request_id: str,
+        data: Any,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> int:
+        return await self._coordinator.send_input_chunk(
+            request_id, data, metadata=metadata
+        )
+
+    async def finish_input_stream(self, request_id: str) -> None:
+        await self._coordinator.finish_input_stream(request_id)
+
+    async def close_input_stream(
+        self,
+        request_id: str,
+        *,
+        level: AbortLevel = AbortLevel.SOFT,
+    ) -> AbortResult:
+        success = await self._coordinator.close_input_stream(request_id)
+        return AbortResult(success=success, level_applied=level)
 
     # ------------------------------------------------------------------
     # High-level: non-streaming completion

--- a/sglang_omni/comm/stage_io.py
+++ b/sglang_omni/comm/stage_io.py
@@ -249,7 +249,9 @@ def serialize_direct_cuda_ipc_stream_chunk(
 
 
 _INLINE_STREAM_CHUNK_TYPE = "InlineStreamChunk"
-_INLINE_STREAM_CHUNK_BYTES_LIMIT = 16 * 1024
+INLINE_STREAM_CHUNK_BYTES_LIMIT = 16 * 1024
+# Backward-compatible alias for existing internal callers and tests.
+_INLINE_STREAM_CHUNK_BYTES_LIMIT = INLINE_STREAM_CHUNK_BYTES_LIMIT
 
 
 def serialize_inline_stream_chunk(
@@ -259,13 +261,13 @@ def serialize_inline_stream_chunk(
         return None
     if _contains_cuda_tensor(metadata) or _contains_cpu_tensor(metadata):
         return None
-    if data.element_size() * data.numel() > _INLINE_STREAM_CHUNK_BYTES_LIMIT:
+    if data.element_size() * data.numel() > INLINE_STREAM_CHUNK_BYTES_LIMIT:
         return None
     data = data.detach()
-    if data.untyped_storage().nbytes() > _INLINE_STREAM_CHUNK_BYTES_LIMIT:
+    if data.untyped_storage().nbytes() > INLINE_STREAM_CHUNK_BYTES_LIMIT:
         data = data.clone(memory_format=torch.contiguous_format)
     payload = pickle.dumps((data, metadata))
-    if len(payload) > _INLINE_STREAM_CHUNK_BYTES_LIMIT:
+    if len(payload) > INLINE_STREAM_CHUNK_BYTES_LIMIT:
         return None
     return {
         "_type": _INLINE_STREAM_CHUNK_TYPE,
@@ -293,10 +295,10 @@ def deserialize_inline_stream_chunk(
             f"inline stream chunk payload must be bytes, got "
             f"{type(payload).__name__}"
         )
-    if len(payload) > _INLINE_STREAM_CHUNK_BYTES_LIMIT:
+    if len(payload) > INLINE_STREAM_CHUNK_BYTES_LIMIT:
         raise ValueError(
             "inline stream chunk payload exceeds "
-            f"{_INLINE_STREAM_CHUNK_BYTES_LIMIT} bytes"
+            f"{INLINE_STREAM_CHUNK_BYTES_LIMIT} bytes"
         )
     data, metadata = pickle.loads(payload)
     if not isinstance(data, torch.Tensor):

--- a/sglang_omni/pipeline/control_plane.py
+++ b/sglang_omni/pipeline/control_plane.py
@@ -392,7 +392,7 @@ class CoordinatorControlPlane:
         self,
         stage_name: str,
         stage_endpoint: str,
-        msg: SubmitMessage | AdminMessage | ShutdownMessage,
+        msg: SubmitMessage | AdminMessage | ShutdownMessage | DataReadyMessage,
     ) -> None:
         """Submit a request to a stage."""
         if stage_name not in self._stage_sockets:
@@ -401,6 +401,16 @@ class CoordinatorControlPlane:
             self._stage_sockets[stage_name] = sock
 
         await self._stage_sockets[stage_name].send(msg)
+
+    async def send_input_stream_event(
+        self,
+        stage_name: str,
+        stage_endpoint: str,
+        msg: DataReadyMessage,
+    ) -> None:
+        """Send one externally supplied input chunk or done signal."""
+        # Reuse the submit socket so ZeroMQ preserves start -> chunk* -> done order.
+        await self.submit_to_stage(stage_name, stage_endpoint, msg)
 
     async def recv_event(self) -> CompleteMessage | StreamMessage | AdminResultMessage:
         """Receive completion or stream event from a stage."""

--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -5,10 +5,14 @@ import asyncio
 import logging
 import uuid
 from collections.abc import Callable, Sequence
+from contextlib import aclosing
 from dataclasses import dataclass, field, replace
 from typing import Any, AsyncIterator
 
+import torch
+
 from sglang_omni.admission import QueueFullError
+from sglang_omni.comm import stage_io
 from sglang_omni.config.topology import LogicalProcessPlan
 from sglang_omni.pipeline.control_plane import CoordinatorControlPlane
 from sglang_omni.pipeline.replicas import (
@@ -25,6 +29,7 @@ from sglang_omni.proto import (
     AdminResult,
     AdminResultMessage,
     CompleteMessage,
+    DataReadyMessage,
     OmniRequest,
     RequestInfo,
     RequestState,
@@ -37,6 +42,9 @@ from sglang_omni.proto import (
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_MAX_EXTERNAL_INPUT_CHUNKS = 4096
+DEFAULT_MAX_EXTERNAL_INPUT_BYTES = 64 * 1024 * 1024
+
 
 @dataclass
 class _AdminPendingOperation:
@@ -44,6 +52,17 @@ class _AdminPendingOperation:
     action: str
     results: dict[str, AdminResult] = field(default_factory=dict)
     future: asyncio.Future | None = None
+
+
+@dataclass
+class _ExternalInputStream:
+    entry_stage: str
+    entry_endpoint: str
+    replica_bindings: dict[str, int] | None
+    next_chunk_id: int = 0
+    bytes_sent: int = 0
+    done: bool = False
+    write_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 class Coordinator:
@@ -70,6 +89,8 @@ class Coordinator:
         logical_process_plan: LogicalProcessPlan | None = None,
         binding_policy: BindingPolicy | None = None,
         max_in_flight: int | None = None,
+        max_external_input_chunks: int = DEFAULT_MAX_EXTERNAL_INPUT_CHUNKS,
+        max_external_input_bytes: int = DEFAULT_MAX_EXTERNAL_INPUT_BYTES,
     ):
         """Initialize coordinator.
 
@@ -104,6 +125,12 @@ class Coordinator:
             if value < 0:
                 raise ValueError("max_in_flight must be >= 0")
             self.max_in_flight = value
+        self.max_external_input_chunks = int(max_external_input_chunks)
+        self.max_external_input_bytes = int(max_external_input_bytes)
+        if self.max_external_input_chunks <= 0:
+            raise ValueError("max_external_input_chunks must be > 0")
+        if self.max_external_input_bytes <= 0:
+            raise ValueError("max_external_input_bytes must be > 0")
 
         # Control plane
         self.control_plane = CoordinatorControlPlane(
@@ -123,12 +150,14 @@ class Coordinator:
         # Abort messages carry only the request ID. A strongly held task keeps
         # local admission closed and lets the broadcast survive caller cancellation.
         self._abort_tasks: dict[str, asyncio.Task[bool]] = {}
+        self._external_input_streams: dict[str, _ExternalInputStream] = {}
         self._admin_ops: dict[str, _AdminPendingOperation] = {}
         self._admin_lock = asyncio.Lock()
 
         # State
         self._running = False
         self._fatal_error: str | None = None
+        self._external_input_writes_open = True
 
     def register_stage(self, name: str, endpoint: str) -> None:
         """Register a stage.
@@ -144,11 +173,17 @@ class Coordinator:
         """Start the coordinator."""
         await self.control_plane.start()
         self._running = True
+        self._external_input_writes_open = True
         logger.info("Coordinator started")
 
     async def stop(self) -> None:
         """Stop the coordinator."""
         self._running = False
+        self._external_input_writes_open = False
+        for request_id, stream in list(self._external_input_streams.items()):
+            async with stream.write_lock:
+                if self._external_input_streams.get(request_id) is stream:
+                    self._external_input_streams.pop(request_id, None)
         self.control_plane.close()
         logger.info("Coordinator stopped")
 
@@ -157,22 +192,37 @@ class Coordinator:
         self._running = False
         message = str(error)
         self._fatal_error = message
-        for request_id, info in list(self._requests.items()):
-            info.state = RequestState.FAILED
-            info.error = message
-            self._reject_completion_future(request_id, RuntimeError(message))
-            queue = self._stream_queues.get(request_id)
-            if queue is not None:
-                await queue.put(
-                    CompleteMessage(
-                        request_id=request_id,
-                        from_stage="coordinator",
-                        success=False,
-                        error=message,
-                    )
-                )
-        self._requests.clear()
+        self._external_input_writes_open = False
+        for request_id in list(self._requests):
+            stream = self._external_input_streams.get(request_id)
+            if stream is None:
+                await self._fail_pending_request(request_id, message)
+                continue
+            async with stream.write_lock:
+                await self._fail_pending_request(request_id, message)
         self._partial_results.clear()
+
+    async def _fail_pending_request(self, request_id: str, message: str) -> None:
+        """Fail one request while its external-input write lock is held, if any."""
+        info = self._requests.get(request_id)
+        if info is None:
+            return
+        info.state = RequestState.FAILED
+        info.error = message
+        self._reject_completion_future(request_id, RuntimeError(message))
+        queue = self._stream_queues.get(request_id)
+        if queue is not None:
+            await queue.put(
+                CompleteMessage(
+                    request_id=request_id,
+                    from_stage="coordinator",
+                    success=False,
+                    error=message,
+                )
+            )
+        self._requests.pop(request_id, None)
+        self._partial_results.pop(request_id, None)
+        self._external_input_streams.pop(request_id, None)
 
     async def shutdown_stages(self) -> None:
         """Send shutdown signal to all registered stages."""
@@ -357,17 +407,141 @@ class Coordinator:
         finally:
             self._completion_futures.pop(request_id, None)
 
+    async def start_input_stream(
+        self,
+        request_id: str,
+        request: OmniRequest | Any,
+    ) -> AsyncIterator[CompleteMessage | StreamMessage]:
+        """Submit a request and return its output-event iterator."""
+        stream_queue: asyncio.Queue[CompleteMessage | StreamMessage] = asyncio.Queue()
+        await self._submit_request(
+            request_id,
+            request,
+            stream_queue=stream_queue,
+            external_input_stream=True,
+        )
+        expected = self._expected_terminal_stages(request_id)
+        return self._stream_events(request_id, stream_queue, expected)
+
+    async def send_input_chunk(
+        self,
+        request_id: str,
+        data: torch.Tensor,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> int:
+        """Append one bounded CPU tensor to an active entry-stage input stream."""
+        if not isinstance(data, torch.Tensor):
+            raise TypeError("External input stream chunks must be torch.Tensor values")
+        if metadata is not None and not isinstance(metadata, dict):
+            raise TypeError("External input stream metadata must be a dict or None")
+        data_ref = stage_io.serialize_inline_stream_chunk(data, metadata)
+        if data_ref is None:
+            raise ValueError(
+                "External input stream chunks must be CPU tensors whose serialized "
+                f"payload is at most {stage_io.INLINE_STREAM_CHUNK_BYTES_LIMIT} bytes"
+            )
+
+        stream = self._active_input_stream(request_id)
+        async with stream.write_lock:
+            self._ensure_current_input_stream(request_id, stream)
+            if stream.done:
+                raise RuntimeError(f"Input stream {request_id!r} is already done")
+            if stream.next_chunk_id >= self.max_external_input_chunks:
+                raise ValueError(
+                    f"Input stream {request_id!r} exceeds max_external_input_chunks="
+                    f"{self.max_external_input_chunks}"
+                )
+            chunk_bytes = data.element_size() * data.numel()
+            if stream.bytes_sent + chunk_bytes > self.max_external_input_bytes:
+                raise ValueError(
+                    f"Input stream {request_id!r} exceeds max_external_input_bytes="
+                    f"{self.max_external_input_bytes}"
+                )
+            chunk_id = stream.next_chunk_id
+            await self.control_plane.send_input_stream_event(
+                stream.entry_stage,
+                stream.entry_endpoint,
+                DataReadyMessage(
+                    request_id=request_id,
+                    from_stage="coordinator",
+                    to_stage=stream.entry_stage,
+                    data_ref=data_ref,
+                    chunk_id=chunk_id,
+                    replica_bindings=stream.replica_bindings,
+                ),
+            )
+            self._ensure_current_input_stream(request_id, stream)
+            stream.next_chunk_id += 1
+            stream.bytes_sent += chunk_bytes
+            return chunk_id
+
+    async def finish_input_stream(self, request_id: str) -> None:
+        """Mark an active entry-stage input stream complete."""
+        stream = self._active_input_stream(request_id)
+        async with stream.write_lock:
+            self._ensure_current_input_stream(request_id, stream)
+            if stream.done:
+                raise RuntimeError(f"Input stream {request_id!r} is already done")
+            await self.control_plane.send_input_stream_event(
+                stream.entry_stage,
+                stream.entry_endpoint,
+                DataReadyMessage(
+                    request_id=request_id,
+                    from_stage="coordinator",
+                    to_stage=stream.entry_stage,
+                    data_ref=None,
+                    is_done=True,
+                    replica_bindings=stream.replica_bindings,
+                ),
+            )
+            self._ensure_current_input_stream(request_id, stream)
+            stream.done = True
+
+    def _active_input_stream(self, request_id: str) -> _ExternalInputStream:
+        self._ensure_external_input_writes_open()
+        stream = self._external_input_streams.get(request_id)
+        if stream is None or request_id not in self._requests:
+            raise ValueError(f"No active input stream for request {request_id!r}")
+        return stream
+
+    def _ensure_current_input_stream(
+        self, request_id: str, stream: _ExternalInputStream
+    ) -> None:
+        self._ensure_external_input_writes_open()
+        if (
+            self._external_input_streams.get(request_id) is not stream
+            or request_id not in self._requests
+        ):
+            raise ValueError(f"No active input stream for request {request_id!r}")
+
+    def _ensure_external_input_writes_open(self) -> None:
+        if self._fatal_error is not None:
+            raise RuntimeError(self._fatal_error)
+        if not self._external_input_writes_open:
+            raise RuntimeError("Coordinator is not accepting external input writes")
+
     async def stream(
         self, request_id: str, request: OmniRequest | Any
     ) -> AsyncIterator[CompleteMessage | StreamMessage]:
         """Submit a request and yield stream events until completion."""
         queue: asyncio.Queue[CompleteMessage | StreamMessage] = asyncio.Queue()
 
-        try:
-            await self._submit_request(request_id, request, stream_queue=queue)
-            expected_terminal_stages = self._expected_terminal_stages(request_id)
+        await self._submit_request(request_id, request, stream_queue=queue)
+        expected = self._expected_terminal_stages(request_id)
+        events = self._stream_events(request_id, queue, expected)
+        async with aclosing(events):
+            async for msg in events:
+                yield msg
 
-            completed_stages: set[str] = set()
+    async def _stream_events(
+        self,
+        request_id: str,
+        queue: asyncio.Queue[CompleteMessage | StreamMessage],
+        expected_terminal_stages: set[str],
+    ) -> AsyncIterator[CompleteMessage | StreamMessage]:
+        completed_stages: set[str] = set()
+        try:
             while True:
                 msg = await queue.get()
                 if isinstance(msg, CompleteMessage):
@@ -391,13 +565,12 @@ class Coordinator:
                         try:
                             await self.abort(request_id)
                         except Exception:
-                            # The coordinator-owned abort task logs its own failure.
-                            # Do not replace the exception already leaving the stream.
                             pass
                 finally:
                     if self._stream_queues.get(request_id) is queue:
                         self._stream_queues.pop(request_id, None)
                         self._completion_futures.pop(request_id, None)
+                        self._external_input_streams.pop(request_id, None)
 
     async def _submit_request(
         self,
@@ -405,10 +578,13 @@ class Coordinator:
         request: OmniRequest | Any,
         *,
         stream_queue: asyncio.Queue[CompleteMessage | StreamMessage] | None = None,
+        external_input_stream: bool = False,
     ) -> None:
         """Submit a request without waiting for completion."""
         if self._fatal_error is not None:
             raise RuntimeError(self._fatal_error)
+        if external_input_stream:
+            self._ensure_external_input_writes_open()
         if self._request_id_is_reserved(request_id):
             raise ValueError(f"Request {request_id} already exists")
 
@@ -451,6 +627,12 @@ class Coordinator:
         self._completion_futures[request_id] = future
         if stream_queue is not None:
             self._stream_queues[request_id] = stream_queue
+        if external_input_stream:
+            self._external_input_streams[request_id] = _ExternalInputStream(
+                entry_stage=entry_instance,
+                entry_endpoint=entry_info.control_endpoint,
+                replica_bindings=replica_bindings,
+            )
 
         payload = StagePayload(
             request_id=request_id,
@@ -465,15 +647,20 @@ class Coordinator:
             metadata={"entry_stage": self.entry_stage},
         )
 
-        await self.control_plane.submit_to_stage(
-            entry_instance,
-            entry_info.control_endpoint,
-            SubmitMessage(
-                request_id=request_id,
-                data=payload,
-                replica_bindings=replica_bindings,
-            ),
-        )
+        try:
+            await self.control_plane.submit_to_stage(
+                entry_instance,
+                entry_info.control_endpoint,
+                SubmitMessage(
+                    request_id=request_id,
+                    data=payload,
+                    replica_bindings=replica_bindings,
+                    external_input_stream=external_input_stream,
+                ),
+            )
+        except BaseException:
+            self._rollback_request_start(request_id)
+            raise
 
         # Update state
         info = self._requests.get(request_id)
@@ -488,6 +675,16 @@ class Coordinator:
             replica_bindings,
         )
 
+    def _rollback_request_start(self, request_id: str) -> None:
+        """Release every owner installed before the entry-stage submit."""
+        self._requests.pop(request_id, None)
+        self._partial_results.pop(request_id, None)
+        self._stream_queues.pop(request_id, None)
+        self._external_input_streams.pop(request_id, None)
+        pending = self._completion_futures.pop(request_id, None)
+        if pending is not None and not pending.done():
+            pending.cancel()
+
     def _request_id_is_reserved(self, request_id: str) -> bool:
         """Return whether any coordinator owner still holds this request ID."""
         return (
@@ -495,6 +692,7 @@ class Coordinator:
             or request_id in self._completion_futures
             or request_id in self._stream_queues
             or request_id in self._abort_tasks
+            or request_id in self._external_input_streams
         )
 
     def _reject_completion_future(
@@ -552,6 +750,13 @@ class Coordinator:
         self,
         request_id: str,
     ) -> bool:
+        stream = self._external_input_streams.get(request_id)
+        if stream is not None:
+            async with stream.write_lock:
+                return await self._run_abort_locked(request_id)
+        return await self._run_abort_locked(request_id)
+
+    async def _run_abort_locked(self, request_id: str) -> bool:
         await self.control_plane.broadcast_abort(AbortMessage(request_id=request_id))
 
         info = self._requests.get(request_id)
@@ -575,9 +780,18 @@ class Coordinator:
 
         self._requests.pop(request_id, None)
         self._partial_results.pop(request_id, None)
+        self._external_input_streams.pop(request_id, None)
 
         logger.info("Coordinator aborted req=%s", request_id)
         return True
+
+    async def close_input_stream(self, request_id: str) -> bool:
+        """Abort if active and release every coordinator-side stream owner."""
+        aborted = await self.abort(request_id)
+        self._stream_queues.pop(request_id, None)
+        self._completion_futures.pop(request_id, None)
+        self._external_input_streams.pop(request_id, None)
+        return aborted
 
     def _on_abort_task_done(
         self,
@@ -618,6 +832,15 @@ class Coordinator:
             raise
 
     async def _handle_completion(self, msg: CompleteMessage) -> None:
+        """Serialize terminal state with external input writes for this request."""
+        stream = self._external_input_streams.get(msg.request_id)
+        if stream is None:
+            await self._handle_completion_locked(msg)
+            return
+        async with stream.write_lock:
+            await self._handle_completion_locked(msg)
+
+    async def _handle_completion_locked(self, msg: CompleteMessage) -> None:
         """Handle a completion message from a stage."""
         request_id = msg.request_id
         logger.debug(
@@ -667,6 +890,7 @@ class Coordinator:
             if stream_queue is not None:
                 await stream_queue.put(msg)
             self._requests.pop(request_id, None)
+            self._external_input_streams.pop(request_id, None)
             return
 
         expected_terminal_stages = self._expected_terminal_stages(request_id)
@@ -691,6 +915,7 @@ class Coordinator:
             if request_id in self._stream_queues:
                 await self._stream_queues[request_id].put(msg)
             self._requests.pop(request_id, None)
+            self._external_input_streams.pop(request_id, None)
             return
 
         # Multi-terminal: collect partial results
@@ -715,6 +940,7 @@ class Coordinator:
             if not future.done():
                 future.set_result(merged)
         self._requests.pop(request_id, None)
+        self._external_input_streams.pop(request_id, None)
 
     async def _handle_stream(self, msg: StreamMessage) -> None:
         """Handle a stream chunk from a stage."""

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -56,6 +56,8 @@ logger = logging.getLogger(__name__)
 
 _SCHEDULER_THREAD_JOIN_TIMEOUT_S = 5.0
 _OUTBOX_DRAIN_BATCH_SIZE = 64
+_EXTERNAL_INPUT_ENQUEUE_TIMEOUT_S = 1.0
+_EXTERNAL_INPUT_ENQUEUE_RETRY_S = 0.005
 
 GetNextFn = Callable[[str, Any], str | list[str] | None]
 GetStreamDoneTargetsFn = Callable[[str, Any], str | list[str] | None]
@@ -155,6 +157,8 @@ class Stage:
         self._aborted: set[str] = set()
         self._active_requests: set[str] = set()
         self._stream_queue: StreamQueue | None = None
+        self._external_input_next_chunk_ids: dict[str, int] = {}
+        self._external_input_done: set[str] = set()
         self._stream_chunk_counters: dict[tuple[str, str], int] = {}
         self._first_stream_chunk_seen: set[str] = set()
         self._local_stream_targets: dict[str, set[str]] = {}
@@ -311,6 +315,8 @@ class Stage:
             await self._comm.close()
         except Exception as exc:
             _record_cleanup_error("comm", exc)
+        self._external_input_next_chunk_ids.clear()
+        self._external_input_done.clear()
         logger.info("Stage %s stopped", self.name)
         if cleanup_error is not None:
             raise RuntimeError(f"Stage {self.name} cleanup failed") from cleanup_error
@@ -443,8 +449,18 @@ class Stage:
         request_id = msg.request_id
         if request_id in self._aborted:
             return
+        if msg.external_input_stream:
+            validation_error = self._external_input_start_validation_error()
+            if validation_error is not None:
+                await self._send_failure(request_id, validation_error)
+                return
         self._record_replica_bindings(request_id, msg.replica_bindings)
         self._active_requests.add(request_id)
+        if msg.external_input_stream:
+            if self._stream_queue is None:
+                self._stream_queue = StreamQueue()
+            self._external_input_next_chunk_ids[request_id] = 0
+            self._external_input_done.discard(request_id)
         if self._stream_queue is not None and not self._stream_queue.has(request_id):
             self._stream_queue.open(request_id)
         _emit_event(
@@ -455,7 +471,36 @@ class Stage:
         )
 
         payload = msg.data  # StagePayload from coordinator
-        await self._execute(payload)
+        if msg.external_input_stream and isinstance(payload, StagePayload):
+            payload.external_input_stream = True
+        try:
+            await self._execute(
+                payload, external_input_stream=msg.external_input_stream
+            )
+        except Exception as exc:
+            if not msg.external_input_stream:
+                raise
+            await self._fail_external_input_stream(
+                request_id, f"failed to start: {_error_text(exc)}"
+            )
+
+    def _external_input_start_validation_error(self) -> str | None:
+        if self._comm.tp_size != 1:
+            return (
+                f"Stage {self.name} external input streams currently require "
+                f"tp_size=1; got tp_size={self._comm.tp_size}"
+            )
+        if not getattr(self.scheduler, "supports_external_input_stream", False):
+            return f"Stage {self.name} does not support external input streams"
+        scheduler_inbox = getattr(self.scheduler, "inbox", None)
+        if getattr(scheduler_inbox, "maxsize", 0) <= 0:
+            return f"Stage {self.name} external input stream inbox must be bounded"
+        if not callable(getattr(scheduler_inbox, "put_nowait", None)):
+            return (
+                f"Stage {self.name} external input stream inbox must support "
+                "non-blocking enqueue"
+            )
+        return None
 
     async def _on_data_ready(
         self,
@@ -746,8 +791,20 @@ class Stage:
         logical_source = self._logical_source(item.from_stage)
         if logical_source != item.from_stage:
             item = replace(item, from_stage=logical_source)
+        if not await self._accept_external_input_chunk(request_id, item):
+            return
         if self._open_pre_payload_stream_if_allowed(request_id):
-            self._route_stream_item(request_id, item)
+            if item.from_stage == "coordinator":
+                await self._enqueue_external_input_message(
+                    request_id,
+                    IncomingMessage(
+                        request_id=request_id,
+                        type="stream_chunk",
+                        data=item,
+                    ),
+                )
+            else:
+                self._route_stream_item(request_id, item)
             return
         with suppress(Exception):
             self.scheduler.abort(request_id)
@@ -759,6 +816,86 @@ class Stage:
                 "accept pre-payload stream data"
             ),
         )
+
+    async def _accept_external_input_chunk(
+        self, request_id: str, item: StreamItem
+    ) -> bool:
+        if item.from_stage != "coordinator":
+            return True
+        expected = self._external_input_next_chunk_ids.get(request_id)
+        if expected is None:
+            await self._fail_external_input_stream(
+                request_id, "received a chunk before external input stream start"
+            )
+            return False
+        if request_id in self._external_input_done:
+            await self._fail_external_input_stream(
+                request_id, "received a chunk after external input stream done"
+            )
+            return False
+        if item.chunk_id != expected:
+            await self._fail_external_input_stream(
+                request_id,
+                f"expected chunk_id={expected}, got chunk_id={item.chunk_id}",
+            )
+            return False
+        self._external_input_next_chunk_ids[request_id] = expected + 1
+        return True
+
+    async def _accept_external_input_done(
+        self, request_id: str, from_stage: str
+    ) -> bool:
+        if self._logical_source(from_stage) != "coordinator":
+            return True
+        if request_id not in self._external_input_next_chunk_ids:
+            await self._fail_external_input_stream(
+                request_id, "received done before external input stream start"
+            )
+            return False
+        if request_id in self._external_input_done:
+            await self._fail_external_input_stream(
+                request_id, "received duplicate external input stream done"
+            )
+            return False
+        self._external_input_done.add(request_id)
+        return True
+
+    async def _fail_external_input_stream(self, request_id: str, reason: str) -> None:
+        with suppress(Exception):
+            self.scheduler.abort(request_id)
+        await self._send_failure(request_id, f"External input stream {reason}")
+
+    def _is_current_external_input_stream(self, request_id: str) -> bool:
+        return (
+            request_id in self._active_requests
+            and request_id in self._external_input_next_chunk_ids
+            and request_id not in self._aborted
+        )
+
+    async def _enqueue_external_input_message(
+        self,
+        request_id: str,
+        message: IncomingMessage,
+    ) -> bool:
+        """Wait asynchronously for bounded scheduler capacity without blocking IO."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _EXTERNAL_INPUT_ENQUEUE_TIMEOUT_S
+        while self._is_current_external_input_stream(request_id):
+            try:
+                self.scheduler.inbox.put_nowait(message)
+                return True
+            except _queue_mod.Full:
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    if self._is_current_external_input_stream(request_id):
+                        await self._fail_external_input_stream(
+                            request_id,
+                            f"timed out waiting for the bounded scheduler inbox "
+                            f"to accept {message.type}",
+                        )
+                    return False
+                await asyncio.sleep(min(_EXTERNAL_INPUT_ENQUEUE_RETRY_S, remaining))
+        return False
 
     async def _queue_stream_error(
         self,
@@ -908,6 +1045,8 @@ class Stage:
             return
 
         if is_done:
+            if not await self._accept_external_input_done(request_id, from_stage):
+                return
             if not self._open_pre_payload_stream_if_allowed(request_id):
                 with suppress(Exception):
                     self.scheduler.abort(request_id)
@@ -923,12 +1062,14 @@ class Stage:
             self._stream_queue.put_done(
                 request_id, from_stage=self._logical_source(from_stage)
             )
-            self.scheduler.inbox.put(
-                IncomingMessage(
-                    request_id=request_id,
-                    type="stream_done",
-                )
+            done_message = IncomingMessage(
+                request_id=request_id,
+                type="stream_done",
             )
+            if self._logical_source(from_stage) == "coordinator":
+                await self._enqueue_external_input_message(request_id, done_message)
+            else:
+                self.scheduler.inbox.put(done_message)
 
     def _open_pre_payload_stream_if_allowed(self, request_id: str) -> bool:
         if self._stream_queue is None:
@@ -946,7 +1087,9 @@ class Stage:
             IncomingMessage(request_id=request_id, type="stream_chunk", data=item)
         )
 
-    async def _execute(self, payload: Any) -> None:
+    async def _execute(
+        self, payload: Any, *, external_input_stream: bool = False
+    ) -> None:
         request_id = payload.request_id
         if request_id in self._aborted:
             return
@@ -962,6 +1105,9 @@ class Stage:
         ):
             self._tp_fanout.fanout_work(payload)
         msg = IncomingMessage(request_id=request_id, type="new_request", data=payload)
+        if external_input_stream:
+            await self._enqueue_external_input_message(request_id, msg)
+            return
         enqueue = getattr(self.scheduler, "enqueue", None)
         if enqueue is not None:
             enqueue(msg)
@@ -1709,15 +1855,17 @@ class Stage:
         if not self._owns_external_io:
             self._clear_request_state(request_id)
             raise RuntimeError(f"Follower stage {self.name} failed: {error}")
-        await self.control_plane.send_complete(
-            CompleteMessage(
-                request_id=request_id,
-                from_stage=self.name,
-                success=False,
-                error=error,
+        try:
+            await self.control_plane.send_complete(
+                CompleteMessage(
+                    request_id=request_id,
+                    from_stage=self.name,
+                    success=False,
+                    error=error,
+                )
             )
-        )
-        self._clear_request_state(request_id)
+        finally:
+            self._clear_request_state(request_id)
 
     def _clear_request_state(self, request_id: str) -> None:
         self._active_requests.discard(request_id)
@@ -1733,6 +1881,8 @@ class Stage:
         self._local_stream_targets.pop(request_id, None)
         self._nonlocal_stream_targets.pop(request_id, None)
         self._replica_bindings.pop(request_id, None)
+        self._external_input_next_chunk_ids.pop(request_id, None)
+        self._external_input_done.discard(request_id)
 
     async def _handle_scheduler_crash(self, exc: BaseException) -> None:
         if self._scheduler_crash_error is not None:

--- a/sglang_omni/proto/messages.py
+++ b/sglang_omni/proto/messages.py
@@ -249,14 +249,18 @@ class SubmitMessage:
     request_id: str
     data: Any
     replica_bindings: dict[str, int] | None = None
+    external_input_stream: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         data = self.data
+        _require_bool(self.external_input_stream, "external_input_stream")
         if isinstance(self.data, StagePayload):
             data = self.data.to_dict()
         d = {"type": "submit", "request_id": self.request_id, "data": data}
         if self.replica_bindings:
             d["replica_bindings"] = dict(self.replica_bindings)
+        if self.external_input_stream:
+            d["external_input_stream"] = True
         return d
 
     @classmethod
@@ -264,10 +268,14 @@ class SubmitMessage:
         data = d["data"]
         if isinstance(data, dict) and data.get("_type") == "StagePayload":
             data = StagePayload.from_dict(data)
+        external_input_stream = _require_bool(
+            d.get("external_input_stream", False), "external_input_stream"
+        )
         return cls(
             request_id=d["request_id"],
             data=data,
             replica_bindings=d.get("replica_bindings"),
+            external_input_stream=external_input_stream,
         )
 
 

--- a/sglang_omni/proto/request.py
+++ b/sglang_omni/proto/request.py
@@ -72,6 +72,9 @@ class StagePayload:
     prefetched_stream_done: bool = field(
         default=False, init=False, repr=False, compare=False
     )
+    external_input_stream: bool = field(
+        default=False, init=False, repr=False, compare=False
+    )
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/sglang_omni/scheduling/streaming_simple_scheduler.py
+++ b/sglang_omni/scheduling/streaming_simple_scheduler.py
@@ -42,6 +42,7 @@ class StreamingSimpleScheduler:
     _can_batch_stream_chunks: bool = False
     _stream_chunk_batch_max: int | None = None
     _stream_chunk_batch_distinct_requests: bool = False
+    supports_external_input_stream: bool = False
 
     def __init__(
         self,
@@ -53,8 +54,13 @@ class StreamingSimpleScheduler:
         request_cost_fn: Callable[[Any], int] | None = None,
         max_batch_cost: int | None = None,
         abort_callback: Callable[[str], None] | None = None,
+        max_pending_messages: int = 0,
     ) -> None:
-        self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
+        if max_pending_messages < 0:
+            raise ValueError("max_pending_messages must be >= 0")
+        self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue(
+            maxsize=max_pending_messages
+        )
         self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
         self.requires_tp_work_fanout: bool = True
 

--- a/tests/unit_test/client/test_external_input_stream.py
+++ b/tests/unit_test/client/test_external_input_stream.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import torch
+
+from sglang_omni.client import Client, ExternalInputStream
+from sglang_omni.client.types import GenerateRequest
+from sglang_omni.proto import CompleteMessage, StreamMessage
+
+
+class _FakeCoordinator:
+    def __init__(self) -> None:
+        self.started = []
+        self.chunks = []
+        self.finished = []
+        self.closed = []
+
+    async def start_input_stream(self, request_id, request):
+        self.started.append((request_id, request))
+
+        async def events():
+            yield StreamMessage(
+                request_id=request_id,
+                from_stage="asr",
+                chunk={"text": "hel", "modality": "text"},
+                modality="text",
+            )
+            yield CompleteMessage(
+                request_id=request_id,
+                from_stage="asr",
+                success=True,
+                result={"text": "hello", "finish_reason": "stop"},
+            )
+
+        return events()
+
+    async def send_input_chunk(self, request_id, data, *, metadata=None):
+        self.chunks.append((request_id, data, metadata))
+        return len(self.chunks) - 1
+
+    async def finish_input_stream(self, request_id):
+        self.finished.append(request_id)
+
+    async def close_input_stream(self, request_id):
+        self.closed.append(request_id)
+        return True
+
+
+def test_client_external_input_stream_handle_lifecycle() -> None:
+    async def run() -> None:
+        coordinator = _FakeCoordinator()
+        client = Client(coordinator)
+        stream = await client.start_input_stream(
+            GenerateRequest(prompt="", stream=True), request_id="req"
+        )
+        assert isinstance(stream, ExternalInputStream)
+        assert (
+            await stream.send(
+                torch.tensor([1, 2], dtype=torch.int16),
+                metadata={"modality": "audio"},
+            )
+            == 0
+        )
+        await stream.finish()
+        with pytest.raises(RuntimeError, match="already done"):
+            await stream.send(torch.tensor([3], dtype=torch.int16))
+
+        chunks = [chunk async for chunk in stream]
+        assert chunks[0].text == "hel"
+        assert chunks[-1].text == "hello"
+        assert chunks[-1].finish_reason == "stop"
+        assert coordinator.finished == ["req"]
+        assert coordinator.closed == []
+
+    asyncio.run(run())
+
+
+def test_client_iterator_aclose_aborts_unfinished_request_once() -> None:
+    async def run() -> None:
+        coordinator = _FakeCoordinator()
+        stream = await Client(coordinator).start_input_stream(
+            GenerateRequest(prompt="", stream=True), request_id="req"
+        )
+        await stream.aclose()
+        await stream.aclose()
+        assert coordinator.closed == ["req"]
+        with pytest.raises(RuntimeError, match="closed"):
+            await stream.send(torch.tensor([1], dtype=torch.int16))
+
+    asyncio.run(run())
+
+
+def test_client_context_manager_aborts_on_exception() -> None:
+    async def run() -> None:
+        coordinator = _FakeCoordinator()
+        stream = await Client(coordinator).start_input_stream(
+            GenerateRequest(prompt="", stream=True), request_id="req"
+        )
+        with pytest.raises(RuntimeError, match="boom"):
+            async with stream:
+                raise RuntimeError("boom")
+        assert coordinator.closed == ["req"]
+
+    asyncio.run(run())

--- a/tests/unit_test/fixtures/pipeline_fakes.py
+++ b/tests/unit_test/fixtures/pipeline_fakes.py
@@ -188,6 +188,7 @@ class RecordingCoordinatorControlPlane:
     def __init__(self):
         self.events: asyncio.Queue[Any] = asyncio.Queue()
         self.submitted: list[tuple[str, str, Any]] = []
+        self.input_stream_events: list[tuple[str, str, Any]] = []
         self.aborts: list[Any] = []
         self.shutdowns: list[tuple[str, str]] = []
         self.started = False
@@ -201,6 +202,11 @@ class RecordingCoordinatorControlPlane:
 
     async def broadcast_abort(self, msg: Any) -> None:
         self.aborts.append(msg)
+
+    async def send_input_stream_event(
+        self, stage: str, endpoint: str, msg: Any
+    ) -> None:
+        self.input_stream_events.append((stage, endpoint, msg))
 
     async def send_shutdown(self, stage: str, endpoint: str) -> None:
         self.shutdowns.append((stage, endpoint))

--- a/tests/unit_test/pipeline/test_external_input_stream.py
+++ b/tests/unit_test/pipeline/test_external_input_stream.py
@@ -1,0 +1,648 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import asyncio
+import queue
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.comm import stage_io
+from sglang_omni.config import PipelineConfig, ProcessConfig
+from sglang_omni.config.topology import compile_logical_processes
+from sglang_omni.pipeline.coordinator import Coordinator
+from sglang_omni.pipeline.replicas import expand_replica_stages
+from sglang_omni.pipeline.stage import runtime as stage_runtime
+from sglang_omni.pipeline.stage.runtime import Stage
+from sglang_omni.proto import (
+    CompleteMessage,
+    DataReadyMessage,
+    OmniRequest,
+    StagePayload,
+    SubmitMessage,
+)
+from tests.unit_test.fixtures.pipeline_fakes import RecordingCoordinatorControlPlane
+from tests.unit_test.pipeline.helpers import stage
+
+
+def _coordinator(
+    *,
+    max_chunks: int = 8,
+    max_bytes: int = 4096,
+) -> tuple[Coordinator, RecordingCoordinatorControlPlane]:
+    coordinator = Coordinator(
+        "inproc://complete",
+        "inproc://abort",
+        entry_stage="asr",
+        terminal_stages=["asr"],
+        max_external_input_chunks=max_chunks,
+        max_external_input_bytes=max_bytes,
+    )
+    control_plane = RecordingCoordinatorControlPlane()
+    coordinator.control_plane = control_plane
+    coordinator.register_stage("asr", "inproc://asr")
+    return coordinator, control_plane
+
+
+def _external_scheduler(*, maxsize: int = 8):
+    scheduler = SimpleNamespace(
+        inbox=queue.Queue(maxsize=maxsize),
+        outbox=queue.Queue(),
+        aborted=[],
+        supports_external_input_stream=True,
+    )
+    scheduler.abort = lambda request_id: scheduler.aborted.append(request_id)
+    return scheduler
+
+
+class _StageControlPlane:
+    def __init__(self) -> None:
+        self.completions = []
+
+    async def send_complete(self, msg) -> None:
+        self.completions.append(msg)
+
+
+def _stage_with_control_plane(
+    scheduler, *, role: str = "single", tp_size: int = 1
+) -> tuple[Stage, _StageControlPlane]:
+    control_plane = _StageControlPlane()
+    stage_obj = Stage(
+        name="asr",
+        role=role,
+        get_next=lambda request_id, output: None,
+        gpu_id=None,
+        endpoints={},
+        control_plane=control_plane,
+        relay=SimpleNamespace(device="cpu", cleanup=lambda request_id: None),
+        scheduler=scheduler,
+        tp_size=tp_size,
+        is_terminal=True,
+    )
+    return stage_obj, control_plane
+
+
+def _payload(request_id: str = "req") -> StagePayload:
+    return StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs=None, params={"stream": True}),
+        data={"raw_inputs": None},
+    )
+
+
+def _chunk(request_id: str, chunk_id: int, value: int = 1) -> DataReadyMessage:
+    tensor = torch.tensor([value], dtype=torch.int16)
+    return DataReadyMessage(
+        request_id=request_id,
+        from_stage="coordinator",
+        to_stage="asr",
+        data_ref=stage_io.serialize_inline_stream_chunk(tensor, {"modality": "audio"}),
+        chunk_id=chunk_id,
+    )
+
+
+def test_coordinator_stream_start_chunk_done_and_cleanup() -> None:
+    async def run() -> None:
+        coordinator, control_plane = _coordinator()
+        events = await coordinator.start_input_stream(
+            "req", OmniRequest(inputs=None, params={"stream": True})
+        )
+
+        assert control_plane.submitted[0][2].external_input_stream is True
+        assert (
+            await coordinator.send_input_chunk(
+                "req",
+                torch.tensor([1, 2], dtype=torch.int16),
+                metadata={"modality": "audio"},
+            )
+            == 0
+        )
+        assert (
+            await coordinator.send_input_chunk(
+                "req", torch.tensor([3], dtype=torch.int16)
+            )
+            == 1
+        )
+        await coordinator.finish_input_stream("req")
+
+        sent = control_plane.input_stream_events
+        assert [message.chunk_id for _, _, message in sent] == [0, 1, None]
+        assert sent[-1][2].is_done is True
+        restored, metadata = stage_io.deserialize_inline_stream_chunk(
+            sent[0][2].data_ref
+        )
+        assert restored.tolist() == [1, 2]
+        assert metadata == {"modality": "audio"}
+
+        await coordinator._handle_completion(
+            CompleteMessage("req", "asr", True, result={"text": "ok"})
+        )
+        assert [message async for message in events][-1].result == {"text": "ok"}
+        assert "req" not in coordinator._external_input_streams
+        assert "req" not in coordinator._stream_queues
+        assert "req" not in coordinator._completion_futures
+
+    asyncio.run(run())
+
+
+def test_coordinator_start_failure_rolls_back_every_owner() -> None:
+    class FailingControlPlane(RecordingCoordinatorControlPlane):
+        async def submit_to_stage(self, stage, endpoint, msg) -> None:
+            del stage, endpoint, msg
+            raise RuntimeError("start failed")
+
+    async def run() -> None:
+        coordinator, _ = _coordinator()
+        coordinator.control_plane = FailingControlPlane()
+
+        with pytest.raises(RuntimeError, match="start failed"):
+            await coordinator.start_input_stream("req", OmniRequest(inputs=None))
+
+        assert "req" not in coordinator._requests
+        assert "req" not in coordinator._completion_futures
+        assert "req" not in coordinator._stream_queues
+        assert "req" not in coordinator._external_input_streams
+
+    asyncio.run(run())
+
+
+def test_external_stream_is_pinned_to_entry_replica() -> None:
+    async def run() -> None:
+        config = PipelineConfig(
+            model_path="dummy",
+            stages=[stage("asr", process="front", terminal=True)],
+            processes={"front": ProcessConfig(num_replicas=2)},
+        )
+        logical_plan, stages = compile_logical_processes(config)
+        _, replicas = expand_replica_stages(stages, logical_plan)
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="asr",
+            terminal_stages=["asr"],
+            replica_topology=replicas,
+            logical_process_plan=logical_plan,
+        )
+        control_plane = RecordingCoordinatorControlPlane()
+        coordinator.control_plane = control_plane
+        coordinator.register_stage("asr@r0", "inproc://asr0")
+        coordinator.register_stage("asr@r1", "inproc://asr1")
+
+        handle = await coordinator.start_input_stream("req", OmniRequest(inputs=None))
+        await coordinator.send_input_chunk("req", torch.tensor([1], dtype=torch.int16))
+        await coordinator.finish_input_stream("req")
+
+        submit_target, submit_endpoint, submit = control_plane.submitted[0]
+        assert submit_target in {"asr@r0", "asr@r1"}
+        assert all(
+            (target, endpoint) == (submit_target, submit_endpoint)
+            for target, endpoint, _ in control_plane.input_stream_events
+        )
+        assert all(
+            message.replica_bindings == submit.replica_bindings
+            for _, _, message in control_plane.input_stream_events
+        )
+        await coordinator.close_input_stream("req")
+        await handle.aclose()
+
+    asyncio.run(run())
+
+
+def test_coordinator_enforces_chunk_and_total_byte_boundaries() -> None:
+    async def run() -> None:
+        coordinator, _ = _coordinator(max_chunks=1, max_bytes=4)
+        handle = await coordinator.start_input_stream("req", OmniRequest(inputs=None))
+        await coordinator.send_input_chunk(
+            "req", torch.tensor([1, 2], dtype=torch.int16)
+        )
+        with pytest.raises(ValueError, match="max_external_input_chunks=1"):
+            await coordinator.send_input_chunk(
+                "req", torch.tensor([3], dtype=torch.int16)
+            )
+        await coordinator.close_input_stream("req")
+        await handle.aclose()
+
+        coordinator, _ = _coordinator(max_chunks=4, max_bytes=3)
+        handle = await coordinator.start_input_stream("req", OmniRequest(inputs=None))
+        with pytest.raises(ValueError, match="max_external_input_bytes=3"):
+            await coordinator.send_input_chunk(
+                "req", torch.tensor([1, 2], dtype=torch.int16)
+            )
+        await coordinator.close_input_stream("req")
+        await handle.aclose()
+
+    asyncio.run(run())
+
+
+def test_coordinator_rejects_invalid_chunks_and_writes_after_done() -> None:
+    async def run() -> None:
+        coordinator, _ = _coordinator()
+        handle = await coordinator.start_input_stream("req", OmniRequest(inputs=None))
+        with pytest.raises(TypeError, match="torch.Tensor"):
+            await coordinator.send_input_chunk("req", b"pcm")
+        oversized = torch.zeros(
+            stage_io.INLINE_STREAM_CHUNK_BYTES_LIMIT + 1, dtype=torch.uint8
+        )
+        with pytest.raises(ValueError, match="serialized payload"):
+            await coordinator.send_input_chunk("req", oversized)
+        await coordinator.finish_input_stream("req")
+        with pytest.raises(RuntimeError, match="already done"):
+            await coordinator.send_input_chunk(
+                "req", torch.tensor([1], dtype=torch.int16)
+            )
+        with pytest.raises(RuntimeError, match="already done"):
+            await coordinator.finish_input_stream("req")
+        await coordinator.close_input_stream("req")
+        await handle.aclose()
+
+    asyncio.run(run())
+
+
+def test_abort_waits_for_inflight_send_and_cleans_all_owners() -> None:
+    class BlockingControlPlane(RecordingCoordinatorControlPlane):
+        def __init__(self) -> None:
+            super().__init__()
+            self.entered = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def send_input_stream_event(self, stage, endpoint, msg) -> None:
+            self.entered.set()
+            await self.release.wait()
+            await super().send_input_stream_event(stage, endpoint, msg)
+
+    async def run() -> None:
+        coordinator, _ = _coordinator()
+        control_plane = BlockingControlPlane()
+        coordinator.control_plane = control_plane
+        handle = await coordinator.start_input_stream("req", OmniRequest(inputs=None))
+        send_task = asyncio.create_task(
+            coordinator.send_input_chunk("req", torch.tensor([1], dtype=torch.int16))
+        )
+        await control_plane.entered.wait()
+        abort_task = asyncio.create_task(coordinator.close_input_stream("req"))
+        await asyncio.sleep(0)
+        assert not abort_task.done()
+        control_plane.release.set()
+        assert await send_task == 0
+        assert await abort_task is True
+        assert len(control_plane.input_stream_events) == 1
+        assert len(control_plane.aborts) == 1
+        assert "req" not in coordinator._requests
+        assert "req" not in coordinator._external_input_streams
+        assert "req" not in coordinator._stream_queues
+        assert "req" not in coordinator._completion_futures
+        await handle.aclose()
+
+    asyncio.run(run())
+
+
+def test_completion_waits_for_inflight_send_and_prevents_late_writes() -> None:
+    class BlockingControlPlane(RecordingCoordinatorControlPlane):
+        def __init__(self) -> None:
+            super().__init__()
+            self.entered = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def send_input_stream_event(self, stage, endpoint, msg) -> None:
+            self.entered.set()
+            await self.release.wait()
+            await super().send_input_stream_event(stage, endpoint, msg)
+
+    async def run() -> None:
+        coordinator, _ = _coordinator()
+        control_plane = BlockingControlPlane()
+        coordinator.control_plane = control_plane
+        events = await coordinator.start_input_stream("req", OmniRequest(inputs=None))
+
+        send_task = asyncio.create_task(
+            coordinator.send_input_chunk("req", torch.tensor([1], dtype=torch.int16))
+        )
+        await control_plane.entered.wait()
+        completion_task = asyncio.create_task(
+            coordinator._handle_completion(
+                CompleteMessage("req", "asr", True, result={"text": "ok"})
+            )
+        )
+        await asyncio.sleep(0)
+        assert not completion_task.done()
+
+        control_plane.release.set()
+        assert await send_task == 0
+        await completion_task
+        assert len(control_plane.input_stream_events) == 1
+        with pytest.raises(ValueError, match="No active input stream"):
+            await coordinator.send_input_chunk(
+                "req", torch.tensor([2], dtype=torch.int16)
+            )
+        assert [message async for message in events][-1].result == {"text": "ok"}
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize("terminalizer", ["failure", "stop"])
+def test_terminal_cleanup_precedes_stale_external_input_write(
+    terminalizer: str,
+) -> None:
+    class BlockingControlPlane(RecordingCoordinatorControlPlane):
+        def __init__(self) -> None:
+            super().__init__()
+            self.entered = asyncio.Event()
+            self.release = asyncio.Event()
+            self.block_next_send = True
+
+        async def send_input_stream_event(self, stage, endpoint, msg) -> None:
+            if self.block_next_send:
+                self.block_next_send = False
+                await super().send_input_stream_event(stage, endpoint, msg)
+                self.entered.set()
+                await self.release.wait()
+                return
+            await super().send_input_stream_event(stage, endpoint, msg)
+
+    async def run() -> None:
+        coordinator, _ = _coordinator()
+        control_plane = BlockingControlPlane()
+        coordinator.control_plane = control_plane
+        events = await coordinator.start_input_stream("req", OmniRequest(inputs=None))
+        other_events = await coordinator.start_input_stream(
+            "other", OmniRequest(inputs=None)
+        )
+
+        in_flight = asyncio.create_task(
+            coordinator.send_input_chunk("req", torch.tensor([1], dtype=torch.int16))
+        )
+        await control_plane.entered.wait()
+        stale = asyncio.create_task(
+            coordinator.send_input_chunk("req", torch.tensor([2], dtype=torch.int16))
+        )
+        await asyncio.sleep(0)
+        assert not stale.done()
+
+        if terminalizer == "failure":
+            terminal = asyncio.create_task(
+                coordinator.fail_pending_requests(RuntimeError("stage died"))
+            )
+        else:
+            terminal = asyncio.create_task(coordinator.stop())
+        await asyncio.sleep(0)
+        assert not terminal.done()
+        error = (
+            "stage died"
+            if terminalizer == "failure"
+            else "not accepting external input writes"
+        )
+        with pytest.raises(RuntimeError, match=error):
+            await coordinator.send_input_chunk(
+                "other", torch.tensor([3], dtype=torch.int16)
+            )
+
+        control_plane.release.set()
+        with pytest.raises(RuntimeError, match=error):
+            await in_flight
+        with pytest.raises(RuntimeError, match=error):
+            await stale
+        await terminal
+        assert len(control_plane.input_stream_events) == 1
+
+        if terminalizer == "stop":
+            await coordinator.close_input_stream("req")
+            await coordinator.close_input_stream("other")
+        await events.aclose()
+        await other_events.aclose()
+
+    asyncio.run(run())
+
+
+def test_concurrent_chunk_and_done_calls_keep_wire_order() -> None:
+    class OrderedControlPlane(RecordingCoordinatorControlPlane):
+        def __init__(self) -> None:
+            super().__init__()
+            self.first_send_entered = asyncio.Event()
+            self.release_first_send = asyncio.Event()
+
+        async def send_input_stream_event(self, stage, endpoint, msg) -> None:
+            if not self.input_stream_events:
+                self.first_send_entered.set()
+                await self.release_first_send.wait()
+            await super().send_input_stream_event(stage, endpoint, msg)
+
+    async def run() -> None:
+        coordinator, _ = _coordinator()
+        control_plane = OrderedControlPlane()
+        coordinator.control_plane = control_plane
+        events = await coordinator.start_input_stream("req", OmniRequest(inputs=None))
+
+        first = asyncio.create_task(
+            coordinator.send_input_chunk("req", torch.tensor([1], dtype=torch.int16))
+        )
+        await control_plane.first_send_entered.wait()
+        second = asyncio.create_task(
+            coordinator.send_input_chunk("req", torch.tensor([2], dtype=torch.int16))
+        )
+        done = asyncio.create_task(coordinator.finish_input_stream("req"))
+        await asyncio.sleep(0)
+        control_plane.release_first_send.set()
+
+        assert await first == 0
+        assert await second == 1
+        await done
+        assert [
+            (message.chunk_id, message.is_done)
+            for _, _, message in control_plane.input_stream_events
+        ] == [(0, False), (1, False), (None, True)]
+
+        await coordinator.close_input_stream("req")
+        await events.aclose()
+
+    asyncio.run(run())
+
+
+def test_stage_accepts_ordered_external_stream_and_marks_payload() -> None:
+    async def run() -> None:
+        scheduler = _external_scheduler()
+        stage_obj, control_plane = _stage_with_control_plane(scheduler)
+        payload = _payload()
+        await stage_obj._on_submit(
+            SubmitMessage("req", payload, external_input_stream=True)
+        )
+        request_message = scheduler.inbox.get_nowait()
+        assert request_message.type == "new_request"
+        assert request_message.data.external_input_stream is True
+
+        await stage_obj._on_stream_chunk(_chunk("req", 0, 1))
+        await stage_obj._on_stream_chunk(_chunk("req", 1, 2))
+        await stage_obj._on_stream_signal(
+            DataReadyMessage("req", "coordinator", "asr", data_ref=None, is_done=True)
+        )
+        assert [scheduler.inbox.get_nowait().type for _ in range(3)] == [
+            "stream_chunk",
+            "stream_chunk",
+            "stream_done",
+        ]
+        assert control_plane.completions == []
+
+        stage_obj._on_abort("req")
+        assert "req" not in stage_obj._external_input_next_chunk_ids
+        assert "req" not in stage_obj._external_input_done
+        assert not stage_obj._stream_queue.has("req")
+
+    asyncio.run(run())
+
+
+def test_stage_rejects_unsupported_or_unbounded_scheduler() -> None:
+    async def run() -> None:
+        unsupported = SimpleNamespace(
+            inbox=queue.Queue(maxsize=4),
+            outbox=queue.Queue(),
+            abort=lambda request_id: None,
+        )
+        stage_obj, control_plane = _stage_with_control_plane(unsupported)
+        await stage_obj._on_submit(
+            SubmitMessage(
+                "unsupported", _payload("unsupported"), external_input_stream=True
+            )
+        )
+        assert "does not support" in control_plane.completions[0].error
+        assert unsupported.inbox.empty()
+        assert "unsupported" not in stage_obj._active_requests
+        assert "unsupported" not in stage_obj._external_input_next_chunk_ids
+
+        unbounded = _external_scheduler(maxsize=0)
+        stage_obj, control_plane = _stage_with_control_plane(unbounded)
+        await stage_obj._on_submit(
+            SubmitMessage(
+                "unbounded", _payload("unbounded"), external_input_stream=True
+            )
+        )
+        assert "must be bounded" in control_plane.completions[0].error
+        assert unbounded.inbox.empty()
+        assert "unbounded" not in stage_obj._active_requests
+        assert "unbounded" not in stage_obj._external_input_next_chunk_ids
+
+    asyncio.run(run())
+
+
+def test_stage_rejects_external_stream_for_tensor_parallel_stage_only() -> None:
+    async def run() -> None:
+        scheduler = _external_scheduler()
+        stage_obj, control_plane = _stage_with_control_plane(
+            scheduler, role="leader", tp_size=2
+        )
+
+        await stage_obj._on_submit(
+            SubmitMessage("external", _payload("external"), external_input_stream=True)
+        )
+
+        assert "require tp_size=1; got tp_size=2" in control_plane.completions[0].error
+        assert scheduler.inbox.empty()
+        assert "external" not in stage_obj._active_requests
+        assert "external" not in stage_obj._external_input_next_chunk_ids
+
+        await stage_obj._on_submit(SubmitMessage("regular", _payload("regular")))
+        request_message = scheduler.inbox.get_nowait()
+        assert request_message.type == "new_request"
+        assert request_message.request_id == "regular"
+
+    asyncio.run(run())
+
+
+def test_stage_rejects_out_of_order_chunk() -> None:
+    async def run() -> None:
+        scheduler = _external_scheduler()
+        stage_obj, control_plane = _stage_with_control_plane(scheduler)
+        await stage_obj._on_submit(
+            SubmitMessage("order", _payload("order"), external_input_stream=True)
+        )
+        scheduler.inbox.get_nowait()
+        await stage_obj._on_stream_chunk(_chunk("order", 1))
+        assert "expected chunk_id=0" in control_plane.completions[0].error
+        assert scheduler.aborted == ["order"]
+
+    asyncio.run(run())
+
+
+def test_stage_waits_for_chunk_and_done_queue_capacity() -> None:
+    async def run() -> None:
+        scheduler = _external_scheduler(maxsize=1)
+        stage_obj, control_plane = _stage_with_control_plane(scheduler)
+        await stage_obj._on_submit(
+            SubmitMessage("req", _payload(), external_input_stream=True)
+        )
+        assert scheduler.inbox.qsize() == 1
+
+        chunk_task = asyncio.create_task(stage_obj._on_stream_chunk(_chunk("req", 0)))
+        await asyncio.sleep(stage_runtime._EXTERNAL_INPUT_ENQUEUE_RETRY_S * 2)
+        assert not chunk_task.done()
+        assert scheduler.inbox.get_nowait().type == "new_request"
+        await chunk_task
+        assert scheduler.inbox.qsize() == 1
+
+        done_task = asyncio.create_task(
+            stage_obj._on_stream_signal(
+                DataReadyMessage(
+                    "req", "coordinator", "asr", data_ref=None, is_done=True
+                )
+            )
+        )
+        await asyncio.sleep(stage_runtime._EXTERNAL_INPUT_ENQUEUE_RETRY_S * 2)
+        assert not done_task.done()
+        assert scheduler.inbox.get_nowait().type == "stream_chunk"
+        await done_task
+        assert scheduler.inbox.get_nowait().type == "stream_done"
+        assert control_plane.completions == []
+
+    asyncio.run(run())
+
+
+def test_stage_queue_timeout_fails_and_cleans_stream(monkeypatch) -> None:
+    monkeypatch.setattr(stage_runtime, "_EXTERNAL_INPUT_ENQUEUE_TIMEOUT_S", 0.02)
+
+    async def run() -> None:
+        scheduler = _external_scheduler(maxsize=1)
+        stage_obj, control_plane = _stage_with_control_plane(scheduler)
+        await stage_obj._on_submit(
+            SubmitMessage("req", _payload(), external_input_stream=True)
+        )
+
+        await stage_obj._on_stream_chunk(_chunk("req", 0))
+
+        assert "timed out waiting" in control_plane.completions[0].error
+        assert scheduler.aborted == ["req"]
+        assert "req" not in stage_obj._active_requests
+        assert "req" not in stage_obj._external_input_next_chunk_ids
+        assert "req" not in stage_obj._external_input_done
+        assert not stage_obj._stream_queue.has("req")
+
+    asyncio.run(run())
+
+
+def test_stage_abort_interrupts_queue_wait_without_failure() -> None:
+    async def run() -> None:
+        scheduler = _external_scheduler(maxsize=1)
+        stage_obj, control_plane = _stage_with_control_plane(scheduler)
+        await stage_obj._on_submit(
+            SubmitMessage("req", _payload(), external_input_stream=True)
+        )
+
+        chunk_task = asyncio.create_task(stage_obj._on_stream_chunk(_chunk("req", 0)))
+        await asyncio.sleep(stage_runtime._EXTERNAL_INPUT_ENQUEUE_RETRY_S * 2)
+        assert not chunk_task.done()
+        stage_obj._on_abort("req")
+        await asyncio.wait_for(chunk_task, timeout=0.25)
+
+        assert control_plane.completions == []
+        assert scheduler.aborted == ["req"]
+        assert "req" not in stage_obj._active_requests
+        assert "req" not in stage_obj._external_input_next_chunk_ids
+        assert "req" not in stage_obj._external_input_done
+
+    asyncio.run(run())
+
+
+def test_submit_message_external_stream_flag_round_trips_strictly() -> None:
+    encoded = SubmitMessage("req", _payload(), external_input_stream=True).to_dict()
+    assert SubmitMessage.from_dict(encoded).external_input_stream is True
+    encoded["external_input_stream"] = 1
+    with pytest.raises(TypeError, match="external_input_stream must be bool"):
+        SubmitMessage.from_dict(encoded)


### PR DESCRIPTION
## Motivation

Stateful streaming models need one persistent pipeline request that can receive input chunks over time. The existing `stream=true` path streams model output only; it does not provide incremental entry-stage input.

This PR adds a model-neutral, pipeline-internal input stream for follow-up integrations such as Nemotron cache-aware ASR.

## Modifications

- Add `Client.start_input_stream()` and an `ExternalInputStream` handle with ordered `send()`, `finish()`, `abort()`, async iteration, and context-manager cleanup.
- Keep start, chunk, and done on the same coordinator-to-entry-stage socket and pin the whole stream to one selected replica.
- Admit only opt-in schedulers with a bounded inbox; await capacity with timeout/abort checks so a timed-out write cannot appear later as a ghost enqueue.
- Serialize send, finish, abort, and terminal completion per request to prevent chunks after done/completion.
- Fail fast for external input on tensor-parallel stages until chunk/done fanout is implemented; ordinary TP requests remain unchanged.
- Enforce ordered chunk IDs, per-stream chunk/byte quotas, and a 16 KiB serialized CPU-tensor packet limit.
- Roll back every coordinator/stage owner on start failure, invalid order, timeout, abort, completion, and shutdown.
- Preserve the existing submit/response-stream and internal inter-stage streaming paths unchanged by default.

## Related Issues

Part of #1582.

### Coordination with #1671

This PR is intentionally orthogonal to #1671. #1671 owns the public realtime transcription API, session/VAD behavior, PCM buffering, and event semantics. This PR adds only the internal persistent entry-stage input transport required by stateful models. It does not add an HTTP/WebSocket route, audio segmentation, or ASR model behavior. A follow-up Nemotron PR will connect the layers rather than introducing another realtime session protocol.

## Accuracy Test

Not model-side code. Tensor payload round-trip, replica pinning, ordering, lifecycle, and rollback behavior are covered by unit tests.

## Benchmark & Profiling

No model performance claim in this transport PR. The follow-up Nemotron PR will report live-input TTFT, speech-end-to-final latency, per-model-chunk latency, RTF/RTFx, throughput, GPU memory, and cache-path counters.

## Tests

- `142 passed` on the focused external-input/client/stage-streaming suite plus Coordinator and Stage regressions.
- Explicit race coverage: full-inbox recovery, enqueue timeout without ghost writes, abort while blocked, chunk/done ordering, completion/fatal-stop versus in-flight writes, TP fail-fast, unsupported/unbounded scheduler rollback, and replica pinning.
- Black 24.10.0, isort 5.13.2, autoflake 2.3.1, and `git diff --cached --check` pass on all changed files.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed. (Not applicable to the transport-only change.)
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
