### PR TITLE
[Qwen3-TTS] Apply repetition penalty once through SGLang

### DIFF
--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import torch
 from sglang.srt.managers.scheduler import GenerationBatchResult
+from sglang.srt.sampling.penaltylib import BatchedRepetitionPenalizer
 
 from sglang_omni.model_runner.base import ModelRunner
 from sglang_omni.model_runner.sglang_execution import attn_forward_context
@@ -21,10 +22,19 @@ class Qwen3TTSModelRunner(ModelRunner):
         super().__init__(tp_worker, output_processor)
         self._has_pending_code_step = False
         self._row_ids_cache: torch.Tensor | None = None
-        self._mask_last_sampled: torch.Tensor | None = None
-        self._mask_prep_rids: list | None = None
-        self._mask_rep_active = False
-        self._mask_sup_active = False
+
+    def _execution_context(
+        self,
+        schedule_batch: Any,
+        *,
+        isolate_sampling: bool = False,
+    ):
+        if schedule_batch.forward_mode.is_extend():
+            self._restore_repetition_penalty_history(schedule_batch)
+        return super()._execution_context(
+            schedule_batch,
+            isolate_sampling=isolate_sampling,
+        )
 
     def before_prefill(
         self,
@@ -99,159 +109,95 @@ class Qwen3TTSModelRunner(ModelRunner):
         requests: list,
     ) -> Any:
         self._install_semantic_sampling_seeds(forward_batch, requests)
-        next_token_ids = super()._sample_next_token_ids(
+        return super()._sample_next_token_ids(
             logits_output,
             forward_batch,
             schedule_batch,
             requests,
         )
-        if isinstance(next_token_ids, torch.Tensor):
-            self._mask_last_sampled = next_token_ids
-        else:
-            self._mask_last_sampled = None
-        return next_token_ids
 
     # ------------------------------------------------------------------
-    # Mask-based logit shaping (device-resident, replaces the per-step
-    # host index building in the base helpers for this model)
+    # Qwen3-TTS logit shaping
     # ------------------------------------------------------------------
-
-    def _mask_fingerprint(self, requests: list) -> list | None:
-        rids = []
-        for sched_req in requests:
-            rid = getattr(sched_req, "request_id", None)
-            epoch = getattr(sched_req.data, "_qwen3_tts_prep_epoch", None)
-            if rid is None or epoch is None:
-                return None
-            rids.append((rid, epoch))
-        return rids
-
-    @staticmethod
-    def _every_row_grew_by_one(requests: list) -> bool:
-        """True when every penalized row's history is exactly one token longer.
-
-        Rows at penalty 1.0 are exempt: their mask bits never reach the logits.
-        """
-        for sched_req in requests:
-            data = sched_req.data
-            req = data.req
-            if float(req.sampling_params.repetition_penalty) == 1.0:
-                continue
-            seen_len = getattr(data, "_rep_seen_len", None)
-            output_ids = req.output_ids
-            if seen_len is None or not output_ids:
-                return False
-            if len(output_ids) != seen_len + 1:
-                return False
-        return True
-
-    def _ensure_masks(self, batch_size: int, vocab: int, device: Any) -> None:
-        masks = getattr(self, "_shape_masks", None)
-        if (
-            masks is not None
-            and masks[0].shape[0] >= batch_size
-            and masks[0].shape[1] == vocab
-            and masks[0].device == device
-        ):
-            return
-        rows = max(batch_size, 64)
-        self._shape_masks = (
-            torch.zeros(rows, vocab, dtype=torch.bool, device=device),
-            torch.zeros(rows, vocab, dtype=torch.bool, device=device),
-            torch.ones(rows, 1, dtype=torch.float32, device=device),
-        )
-        self._mask_prep_rids = None
-
-    def _rebuild_masks(self, requests: list, vocab: int, device: Any) -> None:
-        rep_mask, sup_mask, pen_col = self._shape_masks
-        batch_size = len(requests)
-        rep_mask[:batch_size] = False
-        sup_mask[:batch_size] = False
-        rep_rows: list[int] = []
-        rep_toks: list[int] = []
-        penalties = [1.0] * batch_size
-        sup_rows: list[int] = []
-        sup_toks: list[int] = []
-        for row_idx, sched_req in enumerate(requests):
-            data = sched_req.data
-            req = data.req
-            penalty = float(req.sampling_params.repetition_penalty)
-            penalties[row_idx] = penalty
-            output_ids = req.output_ids
-            if penalty != 1.0 and output_ids:
-                seen = ModelRunner._rep_penalty_unique_tokens(data, output_ids, vocab)
-                rep_rows.extend([row_idx] * len(seen))
-                rep_toks.extend(seen)
-            suppress_tokens = data.suppress_tokens
-            if not suppress_tokens:
-                suppress_tokens = getattr(req, "_codec_suppress_tokens", None)
-            if suppress_tokens:
-                for token_id in suppress_tokens:
-                    tok = int(token_id)
-                    if 0 <= tok < vocab:
-                        sup_rows.append(row_idx)
-                        sup_toks.append(tok)
-        if rep_rows:
-            pairs = torch.tensor(rep_rows + rep_toks, dtype=torch.long, device=device)
-            rep_mask[pairs[: len(rep_rows)], pairs[len(rep_rows) :]] = True
-        if sup_rows:
-            pairs = torch.tensor(sup_rows + sup_toks, dtype=torch.long, device=device)
-            sup_mask[pairs[: len(sup_rows)], pairs[len(sup_rows) :]] = True
-        pen_col[:batch_size, 0] = torch.tensor(
-            penalties, dtype=torch.float32, device=device
-        )
-        self._mask_rep_active = bool(rep_rows) or any(p != 1.0 for p in penalties)
-        self._mask_sup_active = bool(sup_rows)
 
     def _apply_repetition_penalty(self, logits_output: Any, requests: list) -> None:
-        logits = logits_output.next_token_logits
-        if logits is None or logits.ndim != 2:
+        """Leave repetition-penalty ownership to SGLang's sampling state.
+
+        ScheduleBatch.prepare_for_decode accumulates committed output tokens
+        in SGLang's device-resident repetition penalizer. ModelRunner.sample
+        applies that state once using the public SamplingParams value.
+        """
+        del logits_output, requests
+
+    @staticmethod
+    def _restore_repetition_penalty_history(schedule_batch: Any) -> None:
+        """Seed a fresh SGLang penalizer before a request is re-prefilled.
+
+        Retraction preserves Qwen3-TTS semantic output_ids so their input
+        embeddings can be replayed, but prepare_for_extend creates a fresh
+        SGLang sampling state. Restore those retained IDs before the re-prefill
+        sample; subsequent decode steps resume SGLang's normal one-token
+        accumulation.
+        """
+        orchestrator = schedule_batch.sampling_info.penalizer_orchestrator
+        if orchestrator is None:
             return
-        batch_size = len(requests)
-        vocab = logits.shape[1]
-        self._ensure_masks(batch_size, vocab, logits.device)
-        rep_mask, sup_mask, pen_col = self._shape_masks
-        fingerprint = self._mask_fingerprint(requests)
-        last_sampled = getattr(self, "_mask_last_sampled", None)
-        if (
-            fingerprint is not None
-            and fingerprint == getattr(self, "_mask_prep_rids", None)
-            and last_sampled is not None
-            and last_sampled.shape[0] >= batch_size
-            and self._every_row_grew_by_one(requests)
-        ):
-            # Note: (Jiaxin Deng) unchanged batch, every history exactly one token
-            # longer: the only new information is each row's sampled token, so one
-            # scatter replaces the full host-side index rebuild. A history that did
-            # not grow by one (retract, restart) can need bits cleared, which the
-            # scatter cannot do, so those steps rebuild.
-            if self._mask_rep_active:
-                rows = torch.arange(batch_size, device=logits.device)
-                rep_mask[rows, last_sampled[:batch_size].clamp(0, vocab - 1)] = True
-                for sched_req in requests:
-                    data = sched_req.data
-                    output_ids = sched_req.data.req.output_ids
-                    if output_ids:
-                        ModelRunner._rep_penalty_unique_tokens(data, output_ids, vocab)
-        else:
-            self._rebuild_masks(requests, vocab, logits.device)
-        self._mask_prep_rids = fingerprint
-        if self._mask_rep_active:
-            pen = pen_col[:batch_size]
-            scores = logits.to(torch.float32)
-            penalized = torch.where(scores > 0, scores / pen, scores * pen)
-            logits.copy_(
-                torch.where(rep_mask[:batch_size], penalized, scores).to(logits.dtype)
-            )
+
+        penalizer = orchestrator.penalizers.get(BatchedRepetitionPenalizer)
+        if penalizer is None or not penalizer.is_prepared():
+            return
+
+        vocab_size = int(orchestrator.vocab_size)
+        rows: list[int] = []
+        token_ids: list[int] = []
+        penalties: list[float] = []
+        for row, req in enumerate(schedule_batch.reqs):
+            penalty = float(req.sampling_params.repetition_penalty)
+            if penalty == 1.0:
+                continue
+            retained_ids = {
+                token_id
+                for token_id in (int(value) for value in req.output_ids)
+                if 0 <= token_id < vocab_size
+            }
+            rows.extend([row] * len(retained_ids))
+            token_ids.extend(retained_ids)
+            penalties.extend([penalty] * len(retained_ids))
+
+        if not rows:
+            return
+
+        scaling_penalties = penalizer.get_scaling_penalties()
+        device = scaling_penalties.device
+        row_indices = torch.tensor(rows, dtype=torch.long, device=device)
+        token_indices = torch.tensor(token_ids, dtype=torch.long, device=device)
+        penalty_values = torch.tensor(
+            penalties,
+            dtype=scaling_penalties.dtype,
+            device=device,
+        )
+        scaling_penalties[row_indices, token_indices] = penalty_values
 
     def _apply_codec_suppress_tokens(self, logits_output: Any, requests: list) -> None:
         logits = logits_output.next_token_logits
-        if logits is None or logits.ndim != 2:
+        if logits is None or logits.ndim != 2 or not requests:
             return
-        masks = getattr(self, "_shape_masks", None)
-        if masks is None or not getattr(self, "_mask_sup_active", False):
+
+        # Qwen3-TTS reserves the final 1024 configured token IDs for codec
+        # control and suppresses that range except for codec EOS.
+        configured_vocab = int(self.model.config.vocab_size)
+        suppress_start = max(0, configured_vocab - 1024)
+        suppress_stop = min(configured_vocab, logits.shape[1])
+        if suppress_start >= suppress_stop:
             return
-        logits.masked_fill_(masks[1][: len(requests)], float("-inf"))
+
+        active_logits = logits[: len(requests)]
+        codec_eos = int(self.model.config.codec_eos_token_id)
+        if suppress_start <= codec_eos < suppress_stop:
+            active_logits[:, suppress_start:codec_eos] = float("-inf")
+            active_logits[:, codec_eos + 1 : suppress_stop] = float("-inf")
+        else:
+            active_logits[:, suppress_start:suppress_stop] = float("-inf")
 
     def _install_semantic_sampling_seeds(
         self,

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -1204,11 +1204,6 @@ def build_sglang_qwen3_tts_request(
     )
     req.tokenizer = None
     req._input_embeds_are_projected = True
-    req._codec_suppress_tokens = tuple(
-        token_id
-        for token_id in range(model.config.vocab_size - 1024, model.config.vocab_size)
-        if token_id != int(model.config.codec_eos_token_id)
-    )
 
     ref_code_len = (
         int(prepared.ref_code.shape[0]) if prepared.ref_code is not None else 0
@@ -1235,7 +1230,6 @@ def build_sglang_qwen3_tts_request(
         stream_codec_output=not state.non_streaming_mode,
         engine_start_s=time.perf_counter(),
     )
-    data.suppress_tokens = list(req._codec_suppress_tokens)
     data.pending_text_queue = PendingTextTensorQueue.from_tensor(
         prepared.trailing_text_hidden
     )

--- a/tests/unit_test/qwen3_tts/test_mask_logit_shaping.py
+++ b/tests/unit_test/qwen3_tts/test_mask_logit_shaping.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Mask-based logit shaping must match the scalar reference bit for bit."""
+"""Qwen3-TTS logit shaping keeps one owner for each model policy."""
 
 from __future__ import annotations
 
@@ -10,138 +10,82 @@ import torch
 from sglang_omni.models.qwen3_tts.model_runner import Qwen3TTSModelRunner
 
 
-def _runner() -> Qwen3TTSModelRunner:
+def _runner(*, vocab_size: int, codec_eos_token_id: int) -> Qwen3TTSModelRunner:
     runner = object.__new__(Qwen3TTSModelRunner)
-    runner._mask_last_sampled = None
-    runner._mask_prep_rids = None
-    runner._mask_rep_active = False
-    runner._mask_sup_active = False
+    runner.model = types.SimpleNamespace(
+        config=types.SimpleNamespace(
+            vocab_size=vocab_size,
+            codec_eos_token_id=codec_eos_token_id,
+        )
+    )
     return runner
 
 
-def _request(rid: str, epoch: int, penalty: float, output_ids, suppress):
-    sp = types.SimpleNamespace(repetition_penalty=penalty)
-    req = types.SimpleNamespace(sampling_params=sp, output_ids=output_ids)
-    data = types.SimpleNamespace(
-        req=req, suppress_tokens=suppress, _qwen3_tts_prep_epoch=epoch
+def _sampling_request(repetition_penalty: float) -> types.SimpleNamespace:
+    sampling_params = types.SimpleNamespace(
+        repetition_penalty=repetition_penalty,
+        frequency_penalty=0.0,
+        presence_penalty=0.0,
+        min_new_tokens=0,
     )
-    return types.SimpleNamespace(request_id=rid, data=data)
+    return types.SimpleNamespace(
+        sampling_params=sampling_params,
+        custom_logit_processor=None,
+    )
 
 
-def _reference(logits, requests):
-    out = logits.clone()
-    vocab = out.shape[1]
-    for row, sched_req in enumerate(requests):
-        req = sched_req.data.req
-        penalty = float(req.sampling_params.repetition_penalty)
-        ids = req.output_ids or []
-        unique = {int(t) for t in ids if 0 <= int(t) < vocab}
-        if penalty != 1.0 and unique:
-            idx = torch.tensor(sorted(unique), dtype=torch.long)
-            scores = out[row, idx].to(torch.float32)
-            scores = torch.where(scores > 0, scores / penalty, scores * penalty)
-            out[row, idx] = scores.to(out.dtype)
-        for tok in sched_req.data.suppress_tokens or []:
-            tok = int(tok)
-            if 0 <= tok < vocab:
-                out[row, tok] = float("-inf")
-    return out
-
-
-def _apply(runner, logits, requests):
+def test_qwen3_tts_leaves_repetition_penalty_to_sglang() -> None:
+    runner = _runner(vocab_size=128, codec_eos_token_id=127)
+    logits = torch.randn(2, 128)
+    original = logits.clone()
     logits_output = types.SimpleNamespace(next_token_logits=logits)
-    runner._apply_repetition_penalty(logits_output, requests)
-    runner._apply_codec_suppress_tokens(logits_output, requests)
-    return logits_output.next_token_logits
+
+    runner._apply_repetition_penalty(logits_output, [object(), object()])
+
+    assert torch.equal(logits_output.next_token_logits, original)
 
 
-def test_mask_shaping_steady_steps_match_reference():
-    torch.manual_seed(3)
-    vocab = 128
-    runner = _runner()
-    suppress = [5, 90, 200]
-    reqs = [
-        _request("a", 1, 1.3, [3, 7], suppress),
-        _request("b", 2, 1.0, [4], suppress),
-    ]
+def test_qwen3_tts_public_penalty_disables_async_lookahead() -> None:
+    runner = _runner(vocab_size=128, codec_eos_token_id=127)
 
-    for step in range(6):
-        logits = torch.randn(2, vocab, dtype=torch.float32)
-        got = _apply(runner, logits.clone(), reqs)
-        expected = _reference(logits, reqs)
-        assert torch.equal(got, expected), step
-        # next step: each row samples one new token
-        new_a, new_b = 10 + step, 40 + step
-        reqs[0].data.req.output_ids = reqs[0].data.req.output_ids + [new_a]
-        reqs[1].data.req.output_ids = reqs[1].data.req.output_ids + [new_b]
-        runner._mask_last_sampled = torch.tensor([new_a, new_b])
+    assert runner.lookahead_eligible(
+        types.SimpleNamespace(reqs=[_sampling_request(1.0)])
+    )
+    assert not runner.lookahead_eligible(
+        types.SimpleNamespace(reqs=[_sampling_request(1.05)])
+    )
 
 
-def test_mask_shaping_rebuilds_on_rid_reuse():
-    torch.manual_seed(4)
-    vocab = 64
-    runner = _runner()
-    reqs = [_request("a", 1, 1.5, [3, 9, 11], [2])]
-    logits = torch.randn(1, vocab)
-    assert torch.equal(_apply(runner, logits.clone(), reqs), _reference(logits, reqs))
+def test_qwen3_tts_suppresses_configured_codec_tail_with_basic_slices() -> None:
+    configured_vocab = 3072
+    codec_eos = 2150
+    materialized_vocab = 6144
+    runner = _runner(
+        vocab_size=configured_vocab,
+        codec_eos_token_id=codec_eos,
+    )
+    logits = torch.randn(3, materialized_vocab)
+    original = logits.clone()
+    logits_output = types.SimpleNamespace(next_token_logits=logits)
 
-    # same rid, new lifetime (new epoch), different history and suppress list
-    reqs2 = [_request("a", 7, 1.5, [30], [40])]
-    logits2 = torch.randn(1, vocab)
-    got = _apply(runner, logits2.clone(), reqs2)
-    assert torch.equal(got, _reference(logits2, reqs2))
-    # old tokens must not leak through the mask
-    assert got[0, 3] == logits2[0, 3]
+    runner._apply_codec_suppress_tokens(logits_output, [object(), object()])
 
-
-def test_mask_shaping_batch_shrink_rebuilds():
-    torch.manual_seed(5)
-    vocab = 64
-    runner = _runner()
-    reqs = [
-        _request("a", 1, 1.2, [1, 2], [50]),
-        _request("b", 2, 1.2, [3, 4], [50]),
-    ]
-    logits = torch.randn(2, vocab)
-    assert torch.equal(_apply(runner, logits.clone(), reqs), _reference(logits, reqs))
-
-    survivors = [reqs[1]]
-    logits2 = torch.randn(1, vocab)
-    got = _apply(runner, logits2.clone(), survivors)
-    assert torch.equal(got, _reference(logits2, survivors))
-    # row 0 now belongs to request b; request a's tokens must not be penalized
-    assert got[0, 1] == logits2[0, 1]
+    suppress_start = configured_vocab - 1024
+    assert torch.equal(logits[:2, :suppress_start], original[:2, :suppress_start])
+    assert torch.isneginf(logits[:2, suppress_start:codec_eos]).all()
+    assert torch.equal(logits[:2, codec_eos], original[:2, codec_eos])
+    assert torch.isneginf(logits[:2, codec_eos + 1 : configured_vocab]).all()
+    assert torch.equal(logits[:2, configured_vocab:], original[:2, configured_vocab:])
+    assert torch.equal(logits[2], original[2])
 
 
-def test_mask_shaping_clears_bits_after_history_shrink():
-    """A retract shrinks output_ids; stale mask bits must not survive it."""
-    torch.manual_seed(9)
-    vocab = 64
-    runner = _runner()
-    reqs = [_request("a", 1, 1.5, [3, 9], [])]
+def test_qwen3_tts_suppression_skips_empty_request_batch() -> None:
+    runner = _runner(vocab_size=3072, codec_eos_token_id=2150)
+    logits = torch.randn(1, 6144)
+    original = logits.clone()
 
-    logits = torch.randn(1, vocab)
-    _apply(runner, logits.clone(), reqs)
+    runner._apply_codec_suppress_tokens(
+        types.SimpleNamespace(next_token_logits=logits), []
+    )
 
-    # retract/restart: history shrinks, and the next step must not penalize 9
-    reqs[0].data.req.output_ids = [3]
-    runner._mask_last_sampled = torch.tensor([3])
-    logits2 = torch.randn(1, vocab)
-    got = _apply(runner, logits2.clone(), reqs)
-    assert torch.equal(got, _reference(logits2, reqs))
-    assert got[0, 9] == logits2[0, 9]
-
-
-def test_mask_shaping_empty_history_after_retract():
-    torch.manual_seed(11)
-    vocab = 32
-    runner = _runner()
-    reqs = [_request("a", 1, 1.4, [5], [])]
-    logits = torch.randn(1, vocab)
-    _apply(runner, logits.clone(), reqs)
-
-    reqs[0].data.req.output_ids = []
-    runner._mask_last_sampled = torch.tensor([5])
-    logits2 = torch.randn(1, vocab)
-    got = _apply(runner, logits2.clone(), reqs)
-    assert torch.equal(got, logits2), "no history means no penalty anywhere"
+    assert torch.equal(logits, original)

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3215,7 +3215,12 @@ def test_qwen3_tts_request_data_keeps_decode_tensors_on_prepared_device(
         ref_code=torch.tensor([[9, 9]], dtype=torch.long),
         prompt_input_embeds=torch.randn(3, 4, dtype=dtype),
         tts_pad_embed=torch.randn(4, dtype=dtype),
-        gen_kwargs={"max_new_tokens": 16, "temperature": 0.8, "top_k": 30},
+        gen_kwargs={
+            "max_new_tokens": 16,
+            "temperature": 0.8,
+            "top_k": 30,
+            "repetition_penalty": 1.1,
+        },
     )
     with qwen3_request_builders._PREPARED_REQUESTS_LOCK:
         qwen3_request_builders._PREPARED_REQUESTS[payload.request_id] = prepared
@@ -3240,6 +3245,7 @@ def test_qwen3_tts_request_data_keeps_decode_tensors_on_prepared_device(
     assert isinstance(data.semantic_sampling_seed, int)
     assert 0 <= data.semantic_sampling_seed <= 0x7FFFFFFF
     assert data.req.sampling_params.sampling_seed == data.semantic_sampling_seed
+    assert data.req.sampling_params.repetition_penalty == 1.1
     assert isinstance(data.subtalker_sampling_seed, int)
     assert 0 <= data.subtalker_sampling_seed <= 0x7FFFFFFF
 
@@ -3675,7 +3681,8 @@ def test_qwen3_tts_sampling_installs_semantic_seed_tensor(
 
     runner = Qwen3TTSModelRunner.__new__(Qwen3TTSModelRunner)
     runner.model = SimpleNamespace(
-        _semantic_sampling_seed_tensor=torch.tensor([101, 202], dtype=torch.long)
+        _semantic_sampling_seed_tensor=torch.tensor([101, 202], dtype=torch.long),
+        config=SimpleNamespace(vocab_size=1200, codec_eos_token_id=1100),
     )
     runner.tp_worker = SimpleNamespace(model_runner=SimpleNamespace(sample=sample))
     forward_batch = SimpleNamespace(
@@ -3694,7 +3701,6 @@ def test_qwen3_tts_sampling_installs_semantic_seed_tensor(
                     sampling_params=SimpleNamespace(repetition_penalty=1.0),
                     output_ids=[],
                 ),
-                suppress_tokens=[],
                 return_logprob=False,
             )
         ),
@@ -3704,7 +3710,6 @@ def test_qwen3_tts_sampling_installs_semantic_seed_tensor(
                     sampling_params=SimpleNamespace(repetition_penalty=1.0),
                     output_ids=[],
                 ),
-                suppress_tokens=[],
                 return_logprob=False,
             )
         ),

--- a/tests/unit_test/qwen3_tts/test_retract_prefill.py
+++ b/tests/unit_test/qwen3_tts/test_retract_prefill.py
@@ -3,11 +3,13 @@
 
 from __future__ import annotations
 
+import contextlib
 from collections import deque
 from types import SimpleNamespace
 
 import pytest
 import torch
+from sglang.srt.sampling.penaltylib import BatchedRepetitionPenalizer
 
 from sglang_omni.models.qwen3_tts.model_runner import Qwen3TTSModelRunner
 
@@ -111,6 +113,75 @@ def test_reprefill_after_retract_replays_prompt_plus_generated() -> None:
     assert torch.equal(out[-1], leftover)
     assert list(sched_req.data.pending_feedback_queue) == []
     assert len(sched_req.data.decode_input_embeds) == generated_len
+
+
+def test_reprefill_restores_retained_repetition_penalty_history() -> None:
+    retained_req = SimpleNamespace(
+        output_ids=[2, 5, 2],
+        sampling_params=SimpleNamespace(repetition_penalty=1.05),
+    )
+    fresh_req = SimpleNamespace(
+        output_ids=[],
+        sampling_params=SimpleNamespace(repetition_penalty=1.05),
+    )
+    identity_req = SimpleNamespace(
+        output_ids=[3],
+        sampling_params=SimpleNamespace(repetition_penalty=1.0),
+    )
+    reqs = [retained_req, fresh_req, identity_req]
+
+    class _PenaltyOrchestrator:
+        vocab_size = 8
+        device = "cpu"
+
+        def __init__(self) -> None:
+            self.penalizers = {}
+
+        def reqs(self):
+            return reqs
+
+    orchestrator = _PenaltyOrchestrator()
+    penalizer = BatchedRepetitionPenalizer(orchestrator)
+    penalizer.prepare()
+    orchestrator.penalizers[BatchedRepetitionPenalizer] = penalizer
+    schedule_batch = SimpleNamespace(
+        reqs=reqs,
+        forward_mode=SimpleNamespace(is_extend=lambda: True),
+        sampling_info=SimpleNamespace(penalizer_orchestrator=orchestrator),
+    )
+
+    scaling = penalizer.get_scaling_penalties()
+    expected = torch.ones(3, 8)
+    expected[0, [2, 5]] = 1.05
+
+    class _ExecutionBridge:
+        def forward_context(self, batch, *, isolate_sampling):
+            assert batch is schedule_batch
+            assert isolate_sampling
+            assert torch.equal(scaling, expected)
+            return contextlib.nullcontext()
+
+    runner = _runner()
+    runner._execution_bridge = _ExecutionBridge()
+    with runner._execution_context(schedule_batch, isolate_sampling=True):
+        pass
+
+    assert torch.equal(scaling, expected)
+
+    logits = torch.tensor(
+        [
+            [1.0, 2.0, 10.0, 4.0, 5.0, -10.0, 7.0, 8.0],
+            [1.0, 2.0, 10.0, 4.0, 5.0, -10.0, 7.0, 8.0],
+            [1.0, 2.0, 10.0, 4.0, 5.0, -10.0, 7.0, 8.0],
+        ]
+    )
+    original_logits = logits.clone()
+    penalizer.apply(logits)
+
+    assert logits[0, 2].item() == pytest.approx(10.0 / 1.05)
+    assert logits[0, 5].item() == pytest.approx(-10.0 * 1.05)
+    assert torch.equal(logits[1], original_logits[1])
+    assert torch.equal(logits[2], original_logits[2])
 
 
 def test_reprefill_replays_prompt_tail_and_generated_tail() -> None:


### PR DESCRIPTION
## Motivation

Qwen3-TTS currently applies the public repetition penalty in its model runner and then passes the same logits to SGLang's sampler, which applies the penalty again from the same request history. A requested penalty p therefore behaves as p²; the default 1.05 behaves as 1.1025.

The fix must also preserve Qwen3-TTS's codec-token suppression and retraction behavior, which were coupled to the model-owned repetition mask.

## Modifications

- Keep the public repetition penalty in SamplingParams and make SGLang's device-resident penalizer the sole logits owner. The Qwen3-TTS repetition hook is now an explicit no-op.
- Restore retained semantic output IDs into a fresh SGLang repetition state before a re-prefill forward snapshot. This preserves exactly-once history after KV-pressure retraction and through subsequent batch merges.
- Make codec-tail suppression independent of repetition state by suppressing the configured final 1,024 token IDs with direct slices while leaving codec EOS available.
- Remove the Qwen-owned repetition masks, incremental mask bookkeeping, and duplicated per-request codec suppression lists.
- Add coverage for penalty ownership, public parameter propagation, lookahead gating, codec-tail boundaries, inactive batch rows, and retraction/re-prefill history restoration.

## Root Cause

Qwen3-TTS shaped repeated-token logits before calling ModelRunner.sample. SGLang's BatchedRepetitionPenalizer then shaped those logits a second time using the same SamplingParams value and generated-token set.

A direct removal was insufficient because codec suppression depended on masks prepared by the repetition hook. In addition, re-prefill constructs fresh SGLang sampling state while Qwen3-TTS retains semantic output history for embedding replay. The implementation separates codec suppression and restores retained history before SGLang copies the sampling state used by the forward.

## Related Issues

Related to #1360 and #1366. This change is scoped to Qwen3-TTS and preserves its model-specific codec suppression and retraction contracts while moving repetition ownership to SGLang.

## Accuracy Test

- Focused Qwen3-TTS unit tests passed, including the retraction/re-prefill sampling-state regression test.
- A forced-retraction smoke completed 2/2 requests and observed eight positive retraction events.
- H100 qualification used 1,088 English SeedTTS samples at concurrency 16 with repetition penalty 1.05 and serial ASR. Both arms completed generation and ASR without failures.

| Metric | Main | This PR |
| --- | ---: | ---: |
| Generation | 1,088/1,088 | 1,088/1,088 |
| Serial ASR | 1,088/1,088 | 1,088/1,088 |
| Raw WER | 1.0383% | 1.0131% |
| Output tokens | 56,087 | 56,568 |
| Capped generations | 0 | 0 |
| Samples above 50% WER | 0 | 0 |
| CUDA/server failures | 0 | 0 |

Pinned revisions: Qwen3-TTS `fd4b254389122332181a7c3db7f27e918eec64e3`, SeedTTS `27f4c1adee83b5b29b7c4b375f6b976324bda308`, and ASR `7278e1e70fe206f11671096ffdd38061171dd6e5`.

## Benchmark & Profiling

The same H100 c16 qualification measured higher throughput and lower tail latency despite 0.86% more generated tokens:

| Metric | Main | This PR | Change |
| --- | ---: | ---: | ---: |
| QPS | 13.076 | 13.697 | +4.75% |
| p95 latency | 1.670 s | 1.607 s | -3.77% |

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and `/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
