### PR TITLE
[Qwen3-TTS] Cache the suppress mask row instead of rebuilding it

### DIFF
--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -25,6 +25,8 @@ class Qwen3TTSModelRunner(ModelRunner):
         self._mask_prep_rids: list | None = None
         self._mask_rep_active = False
         self._mask_sup_active = False
+        self._suppress_zero: torch.Tensor | None = None
+        self._suppress_rows: dict[tuple, torch.Tensor] = {}
 
     def before_prefill(
         self,
@@ -161,17 +163,51 @@ class Qwen3TTSModelRunner(ModelRunner):
             torch.ones(rows, 1, dtype=torch.float32, device=device),
         )
         self._mask_prep_rids = None
+        self._suppress_zero = torch.zeros(vocab, dtype=torch.bool, device=device)
+        self._suppress_rows = {}
+
+    def _suppress_row(
+        self, data: Any, req: Any, vocab: int, device: Any
+    ) -> torch.Tensor:
+        """The request's suppress row: the shared zero row when it suppresses
+        nothing, otherwise one row per distinct suppress set, built once and
+        memoized on the request data.
+
+        The memo holds while the request carries the same token container and
+        the masks have not been reallocated; mutating the container in place
+        is outside the contract, as it is for the base runner's suppress cache.
+        """
+        tokens = data.suppress_tokens
+        if not tokens:
+            tokens = getattr(req, "_codec_suppress_tokens", None)
+        zero = self._suppress_zero
+        memo = data.suppress_row_memo
+        if memo is not None and memo[0] is tokens and memo[1] is zero:
+            return memo[2]
+        row = zero
+        if tokens:
+            key = tuple(int(t) for t in tokens)
+            row = self._suppress_rows.get(key)
+            if row is None:
+                row = zero
+                in_vocab = [t for t in key if 0 <= t < vocab]
+                if in_vocab:
+                    row = torch.zeros(vocab, dtype=torch.bool, device=device)
+                    row[torch.tensor(in_vocab, dtype=torch.long, device=device)] = True
+                self._suppress_rows[key] = row
+        data.suppress_row_memo = (tokens, zero, row)
+        return row
 
     def _rebuild_masks(self, requests: list, vocab: int, device: Any) -> None:
         rep_mask, sup_mask, pen_col = self._shape_masks
         batch_size = len(requests)
         rep_mask[:batch_size] = False
-        sup_mask[:batch_size] = False
         rep_rows: list[int] = []
         rep_toks: list[int] = []
         penalties = [1.0] * batch_size
-        sup_rows: list[int] = []
-        sup_toks: list[int] = []
+        zero = self._suppress_zero
+        sup_rows: list[torch.Tensor] = []
+        sup_active = False
         for row_idx, sched_req in enumerate(requests):
             data = sched_req.data
             req = data.req
@@ -182,26 +218,18 @@ class Qwen3TTSModelRunner(ModelRunner):
                 seen = ModelRunner._rep_penalty_unique_tokens(data, output_ids, vocab)
                 rep_rows.extend([row_idx] * len(seen))
                 rep_toks.extend(seen)
-            suppress_tokens = data.suppress_tokens
-            if not suppress_tokens:
-                suppress_tokens = getattr(req, "_codec_suppress_tokens", None)
-            if suppress_tokens:
-                for token_id in suppress_tokens:
-                    tok = int(token_id)
-                    if 0 <= tok < vocab:
-                        sup_rows.append(row_idx)
-                        sup_toks.append(tok)
+            row = self._suppress_row(data, req, vocab, device)
+            sup_rows.append(row)
+            sup_active = sup_active or row is not zero
         if rep_rows:
             pairs = torch.tensor(rep_rows + rep_toks, dtype=torch.long, device=device)
             rep_mask[pairs[: len(rep_rows)], pairs[len(rep_rows) :]] = True
-        if sup_rows:
-            pairs = torch.tensor(sup_rows + sup_toks, dtype=torch.long, device=device)
-            sup_mask[pairs[: len(sup_rows)], pairs[len(sup_rows) :]] = True
+        torch.stack(sup_rows, out=sup_mask[:batch_size])
         pen_col[:batch_size, 0] = torch.tensor(
             penalties, dtype=torch.float32, device=device
         )
         self._mask_rep_active = bool(rep_rows) or any(p != 1.0 for p in penalties)
-        self._mask_sup_active = bool(sup_rows)
+        self._mask_sup_active = sup_active
 
     def _apply_repetition_penalty(self, logits_output: Any, requests: list) -> None:
         logits = logits_output.next_token_logits

--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -166,9 +166,7 @@ class Qwen3TTSModelRunner(ModelRunner):
         self._suppress_zero = torch.zeros(vocab, dtype=torch.bool, device=device)
         self._suppress_rows = {}
 
-    def _suppress_row(
-        self, data: Any, req: Any, vocab: int, device: Any
-    ) -> torch.Tensor:
+    def _suppress_row(self, data: Any, vocab: int, device: Any) -> torch.Tensor:
         """The request's suppress row: the shared zero row when it suppresses
         nothing, otherwise one row per distinct suppress set, built once and
         memoized on the request data.
@@ -178,8 +176,6 @@ class Qwen3TTSModelRunner(ModelRunner):
         is outside the contract, as it is for the base runner's suppress cache.
         """
         tokens = data.suppress_tokens
-        if not tokens:
-            tokens = getattr(req, "_codec_suppress_tokens", None)
         zero = self._suppress_zero
         memo = data.suppress_row_memo
         if memo is not None and memo[0] is tokens and memo[1] is zero:
@@ -218,7 +214,7 @@ class Qwen3TTSModelRunner(ModelRunner):
                 seen = ModelRunner._rep_penalty_unique_tokens(data, output_ids, vocab)
                 rep_rows.extend([row_idx] * len(seen))
                 rep_toks.extend(seen)
-            row = self._suppress_row(data, req, vocab, device)
+            row = self._suppress_row(data, vocab, device)
             sup_rows.append(row)
             sup_active = sup_active or row is not zero
         if rep_rows:

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -121,7 +121,6 @@ class Qwen3TTSSGLangRequestData(SGLangARRequestData):
     subtalker_top_k: int = 50
     subtalker_sampling_seed: int = field(default_factory=_new_qwen3_tts_sampling_seed)
     engine_start_s: float = 0.0
-    # Runner-owned memo of the suppress mask row, see Qwen3TTSModelRunner._suppress_row.
     suppress_row_memo: tuple | None = None
 
 

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -121,6 +121,8 @@ class Qwen3TTSSGLangRequestData(SGLangARRequestData):
     subtalker_top_k: int = 50
     subtalker_sampling_seed: int = field(default_factory=_new_qwen3_tts_sampling_seed)
     engine_start_s: float = 0.0
+    # Runner-owned memo of the suppress mask row, see Qwen3TTSModelRunner._suppress_row.
+    suppress_row_memo: tuple | None = None
 
 
 @dataclass

--- a/tests/unit_test/qwen3_tts/test_mask_logit_shaping.py
+++ b/tests/unit_test/qwen3_tts/test_mask_logit_shaping.py
@@ -19,11 +19,16 @@ def _runner() -> Qwen3TTSModelRunner:
     return runner
 
 
-def _request(rid: str, epoch: int, penalty: float, output_ids, suppress):
+def _request(rid: str, epoch: int, penalty: float, output_ids, suppress, codec=None):
     sp = types.SimpleNamespace(repetition_penalty=penalty)
     req = types.SimpleNamespace(sampling_params=sp, output_ids=output_ids)
+    if codec is not None:
+        req._codec_suppress_tokens = tuple(codec)
     data = types.SimpleNamespace(
-        req=req, suppress_tokens=suppress, _qwen3_tts_prep_epoch=epoch
+        req=req,
+        suppress_tokens=suppress,
+        suppress_row_memo=None,
+        _qwen3_tts_prep_epoch=epoch,
     )
     return types.SimpleNamespace(request_id=rid, data=data)
 
@@ -41,7 +46,10 @@ def _reference(logits, requests):
             scores = out[row, idx].to(torch.float32)
             scores = torch.where(scores > 0, scores / penalty, scores * penalty)
             out[row, idx] = scores.to(out.dtype)
-        for tok in sched_req.data.suppress_tokens or []:
+        suppress = sched_req.data.suppress_tokens
+        if not suppress:
+            suppress = getattr(req, "_codec_suppress_tokens", None) or []
+        for tok in suppress:
             tok = int(tok)
             if 0 <= tok < vocab:
                 out[row, tok] = float("-inf")
@@ -145,3 +153,78 @@ def test_mask_shaping_empty_history_after_retract():
     logits2 = torch.randn(1, vocab)
     got = _apply(runner, logits2.clone(), reqs)
     assert torch.equal(got, logits2), "no history means no penalty anywhere"
+
+
+def test_mask_shaping_mixed_suppress_rows_match_reference():
+    torch.manual_seed(13)
+    vocab = 64
+    runner = _runner()
+    reqs = [
+        _request("a", 1, 1.2, [3], [7, 9]),
+        _request("b", 2, 1.0, [4], []),
+        _request("c", 3, 1.2, [5], [7, 9]),
+        _request("d", 4, 1.0, [6], [20, 500]),
+        _request("e", 5, 1.3, [8], None, codec=[11, 12]),
+    ]
+    logits = torch.randn(5, vocab)
+    assert torch.equal(_apply(runner, logits.clone(), reqs), _reference(logits, reqs))
+
+    survivors = [reqs[4], reqs[3], reqs[1], reqs[0]]
+    logits2 = torch.randn(4, vocab)
+    assert torch.equal(
+        _apply(runner, logits2.clone(), survivors), _reference(logits2, survivors)
+    )
+
+
+def test_mask_shaping_all_invalid_suppress_is_inactive():
+    torch.manual_seed(17)
+    vocab = 32
+    runner = _runner()
+    reqs = [_request("a", 1, 1.0, [1], [vocab, vocab + 5])]
+    logits = torch.randn(1, vocab)
+    assert torch.equal(_apply(runner, logits.clone(), reqs), logits)
+    assert runner._mask_sup_active is False
+
+
+def test_mask_shaping_replaced_suppress_list_is_applied():
+    torch.manual_seed(19)
+    vocab = 64
+    runner = _runner()
+    reqs = [_request("a", 1, 1.0, [1], [7])]
+    logits = torch.randn(1, vocab)
+    assert torch.equal(_apply(runner, logits.clone(), reqs), _reference(logits, reqs))
+
+    reqs[0].data.suppress_tokens = [9]
+    runner._mask_prep_rids = None
+    logits2 = torch.randn(1, vocab)
+    got = _apply(runner, logits2.clone(), reqs)
+    assert torch.equal(got, _reference(logits2, reqs))
+    assert got[0, 7] == logits2[0, 7]
+
+
+def test_mask_shaping_warm_rebuild_builds_no_suppress_tensor(monkeypatch):
+    torch.manual_seed(23)
+    vocab = 2048
+    batch = 16
+    runner = _runner()
+    suppress = [t for t in range(vocab - 1024, vocab) if t != vocab - 1]
+    reqs = [_request(f"r{i}", i, 1.0, [i], list(suppress)) for i in range(batch)]
+
+    sizes = []
+    real_tensor = torch.tensor
+
+    def counting_tensor(values, *args, **kwargs):
+        sizes.append(len(values))
+        return real_tensor(values, *args, **kwargs)
+
+    monkeypatch.setattr(torch, "tensor", counting_tensor)
+    logits = torch.randn(batch, vocab)
+    assert torch.equal(_apply(runner, logits.clone(), reqs), _reference(logits, reqs))
+    assert sizes.count(len(suppress)) == 1
+    assert max(sizes) == len(suppress)
+
+    sizes.clear()
+    runner._mask_prep_rids = None
+    logits2 = torch.randn(batch, vocab)
+    assert torch.equal(_apply(runner, logits2.clone(), reqs), _reference(logits2, reqs))
+    assert max(sizes) <= batch

--- a/tests/unit_test/qwen3_tts/test_mask_logit_shaping.py
+++ b/tests/unit_test/qwen3_tts/test_mask_logit_shaping.py
@@ -214,11 +214,25 @@ def test_mask_shaping_warm_rebuild_builds_no_suppress_tensor(monkeypatch):
     monkeypatch.setattr(torch, "tensor", counting_tensor)
     logits = torch.randn(batch, vocab)
     assert torch.equal(_apply(runner, logits.clone(), reqs), _reference(logits, reqs))
-    assert sizes.count(len(suppress)) == 1
-    assert max(sizes) == len(suppress)
+    assert sizes == [len(suppress), batch]
 
     sizes.clear()
     runner._mask_prep_rids = None
     logits2 = torch.randn(batch, vocab)
     assert torch.equal(_apply(runner, logits2.clone(), reqs), _reference(logits2, reqs))
-    assert max(sizes) <= batch
+    assert sizes == [batch]
+
+
+def test_mask_shaping_vocab_growth_rebuilds_suppress_rows():
+    torch.manual_seed(29)
+    runner = _runner()
+    reqs = [_request("a", 1, 1.0, [1], [40])]
+    logits = torch.randn(1, 32)
+    assert torch.equal(_apply(runner, logits.clone(), reqs), logits)
+    assert runner._mask_sup_active is False
+
+    runner._mask_prep_rids = None
+    logits2 = torch.randn(1, 64)
+    got = _apply(runner, logits2.clone(), reqs)
+    assert torch.equal(got, _reference(logits2, reqs))
+    assert got[0, 40] == float("-inf")

--- a/tests/unit_test/qwen3_tts/test_mask_logit_shaping.py
+++ b/tests/unit_test/qwen3_tts/test_mask_logit_shaping.py
@@ -19,11 +19,9 @@ def _runner() -> Qwen3TTSModelRunner:
     return runner
 
 
-def _request(rid: str, epoch: int, penalty: float, output_ids, suppress, codec=None):
+def _request(rid: str, epoch: int, penalty: float, output_ids, suppress):
     sp = types.SimpleNamespace(repetition_penalty=penalty)
     req = types.SimpleNamespace(sampling_params=sp, output_ids=output_ids)
-    if codec is not None:
-        req._codec_suppress_tokens = tuple(codec)
     data = types.SimpleNamespace(
         req=req,
         suppress_tokens=suppress,
@@ -46,10 +44,7 @@ def _reference(logits, requests):
             scores = out[row, idx].to(torch.float32)
             scores = torch.where(scores > 0, scores / penalty, scores * penalty)
             out[row, idx] = scores.to(out.dtype)
-        suppress = sched_req.data.suppress_tokens
-        if not suppress:
-            suppress = getattr(req, "_codec_suppress_tokens", None) or []
-        for tok in suppress:
+        for tok in sched_req.data.suppress_tokens or []:
             tok = int(tok)
             if 0 <= tok < vocab:
                 out[row, tok] = float("-inf")
@@ -164,13 +159,12 @@ def test_mask_shaping_mixed_suppress_rows_match_reference():
         _request("b", 2, 1.0, [4], []),
         _request("c", 3, 1.2, [5], [7, 9]),
         _request("d", 4, 1.0, [6], [20, 500]),
-        _request("e", 5, 1.3, [8], None, codec=[11, 12]),
     ]
-    logits = torch.randn(5, vocab)
+    logits = torch.randn(4, vocab)
     assert torch.equal(_apply(runner, logits.clone(), reqs), _reference(logits, reqs))
 
-    survivors = [reqs[4], reqs[3], reqs[1], reqs[0]]
-    logits2 = torch.randn(4, vocab)
+    survivors = [reqs[3], reqs[1], reqs[0]]
+    logits2 = torch.randn(3, vocab)
     assert torch.equal(
         _apply(runner, logits2.clone(), survivors), _reference(logits2, survivors)
     )

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3233,6 +3233,8 @@ def test_qwen3_tts_request_data_keeps_decode_tensors_on_prepared_device(
     assert data.ref_code is prepared.ref_code
     assert data.tts_pad_embed is prepared.tts_pad_embed
     assert data.stream_codec_output is True
+    assert data.suppress_tokens == list(range(1200 - 1024, 1200))
+    assert data.suppress_row_memo is None
     assert isinstance(data.pending_text_queue, PendingTextTensorQueue)
     assert data.pending_text_queue.rows is not None
     assert data.pending_text_queue.rows.device == prepared.trailing_text_hidden.device

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3695,6 +3695,7 @@ def test_qwen3_tts_sampling_installs_semantic_seed_tensor(
                     output_ids=[],
                 ),
                 suppress_tokens=[],
+                suppress_row_memo=None,
                 return_logprob=False,
             )
         ),
@@ -3705,6 +3706,7 @@ def test_qwen3_tts_sampling_installs_semantic_seed_tensor(
                     output_ids=[],
                 ),
                 suppress_tokens=[],
+                suppress_row_memo=None,
                 return_logprob=False,
             )
         ),


### PR DESCRIPTION
## Summary

`Qwen3TTSModelRunner._rebuild_masks` rebuilt the codec suppress mask from scratch every time the batch composition changed: a Python loop over the 1023 suppress tokens of every row, a `torch.tensor(...)` of roughly `2 * batch * 1023` ints copied to the device (a pageable, stream-blocking copy), and an index_put into the mask. The suppress set is model configuration, identical for every request and every step, so all of that work produced the same rows each time.

This PR builds one boolean row per distinct suppress set once, memoizes it on the request data, and assembles the batch's rows with a single `torch.stack` into the mask slice. The resulting mask is bit-identical to the old one; only the cost changes.

## Why it matters

In a torch profiler trace of a warm concurrency-16 run, `_rebuild_masks` was the single largest Python cost on the decode step. Its list-to-CUDA construction is also more expensive on the sglang 0.5.18 image (torch 2.13, CUDA 13.0.3) than on the 0.5.16 image: on the same H100, `torch.tensor(<32k ints>, device="cuda")` measures 1.14 ms versus 1.67 ms (+46%; the torch code on that path is unchanged between v2.11.0 and v2.13.0, so the difference is in the image's CUDA runtime rather than torch), which is why this rebuild was the main host-side delta when qualifying the upgrade (#1719). Removing the rebuild helps both stacks and removes the sensitivity.

## Change

`sglang_omni/models/qwen3_tts/model_runner.py`
- `_ensure_masks` also owns a shared zero row and the per-content row cache, so both follow the existing reallocation on vocab or device change.
- New `_suppress_row(data, vocab, device)`: returns the request's row. The suppress set is read from the declared `suppress_tokens` field of the request data only; the old fallback to a `_codec_suppress_tokens` attribute on the sglang `Req` is gone, since the Qwen3-TTS builder fills both from the same tuple and nothing else produces request data for this runner. Rows are cached per distinct suppress content and built once; the result is memoized on the request data and reused while the request still carries the same token container and the masks have not been reallocated. A request with no suppress tokens, or none inside the vocabulary, maps to the shared zero row.
- `_rebuild_masks`: the per-token loop and the device copy for suppression are gone; `torch.stack(rows, out=sup_mask[:batch_size])` writes the batch in one kernel. `_mask_sup_active` keeps its previous meaning (some row has an in-vocabulary suppress token). Repetition-penalty pairs and the penalty column are unchanged.

`sglang_omni/models/qwen3_tts/request_builders.py`
- `Qwen3TTSSGLangRequestData.suppress_row_memo` declares the memo field.

Only Qwen3-TTS uses this code path; other models go through the base runner's suppress handling, which is untouched.

## Results

Qwen3-TTS on one H100, `benchmarks/eval/benchmark_omni_seedtts.py` (SeedTTS en set), same server process for a discarded full warm pass followed by the measured pass.

| stack | concurrency | before | after | WER before / after | similarity before / after |
|---|---|---|---|---|---|
| main (sglang 0.5.16, torch 2.11) | 16 | 13.532 req/s | 13.715 req/s (+1.4%) | 1.097% / 1.072% | 71.401 / 71.451 |
| #1719 (sglang 0.5.18, torch 2.13) | 16 | 13.748 req/s | 14.050 req/s (+2.2%) | 1.072% / 1.063% | 71.352 / 71.475 |
| main | 1 | 2.090 req/s | 2.085 req/s | 1.038% / 1.063% | 71.389 / 71.260 |

At concurrency 1 the rebuild runs once per request on a single row, so the change is neutral there within the run-to-run spread. Output-token throughput at concurrency 16 moves with request throughput (695.9 to 706.6 tok/s on main).

## Tests

`tests/unit_test/qwen3_tts/test_mask_logit_shaping.py`, all checked bit for bit against the scalar reference:
- existing steady-step, rid-reuse, batch-shrink, history-shrink and empty-history cases, unchanged
- mixed batch: rows sharing one suppress set, a row without suppression, and a set containing an out-of-vocabulary id, then a shrunk and reordered batch
- a set with no in-vocabulary id leaves the logits untouched and the suppress mask inactive
- a suppress list replaced on the same request is applied on the next rebuild
- production shape, 16 rows with the 1023-token codec range: exactly one 1023-element tensor construction on the cold rebuild, none larger than the batch on a warm rebuild



