### PR TITLE
[Perf][MOSS-TTS-Local] Enable breakable Prefill CUDA Graph

### DIFF
--- a/sglang_omni/models/moss_tts_local/__init__.py
+++ b/sglang_omni/models/moss_tts_local/__init__.py
@@ -9,7 +9,7 @@ CAPABILITIES = ModelCapabilities(
     supports_streaming_vocoder=True,
     supports_cuda_graph=True,
     supports_torch_compile=True,
-    supports_breakable_prefill_cuda_graph=False,
+    supports_breakable_prefill_cuda_graph=True,
 )
 
 __all__ = ["CAPABILITIES"]

--- a/sglang_omni/models/moss_tts_local/engine_builder.py
+++ b/sglang_omni/models/moss_tts_local/engine_builder.py
@@ -15,6 +15,10 @@ class MossTtsLocalEngineBuilder(TtsEngineBuilder):
     model_name = "MOSS-TTS Local"
     context_length = 8192
     model_arch_override = "MossTTSLocalSGLangModel"
+    # The model routes request-specific embeddings through OmniPrefillInputs,
+    # satisfying the shared runner's static-buffer refresh contract. The graph
+    # backend remains opt-in because generation_defaults does not enable it.
+    supports_breakable_prefill_cuda_graph = True
 
     def __init__(
         self,

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -8,6 +8,10 @@ from typing import Any
 import torch
 
 from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.model_runner.prefill_inputs import (
+    OmniPrefillInputs,
+    attach_omni_prefill_inputs,
+)
 from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
 from sglang_omni.models.moss_tts_local.radix_hash import gpu_radix_row_hash
 from sglang_omni.models.moss_tts_local.request_builders import (
@@ -84,8 +88,14 @@ class MossTTSLocalModelRunner(ModelRunner):
         requests: list,
     ) -> None:
         del schedule_batch
-        forward_batch.input_embeds = self._build_prefill_input_embeds(
-            forward_batch, requests
+        # Keep request-scoped embeddings in Omni's sidecar until the shared
+        # runner selects eager execution or refreshes the graph's static input.
+        # Writing ForwardBatch.input_embeds here would bypass that late binding.
+        attach_omni_prefill_inputs(
+            forward_batch,
+            OmniPrefillInputs(
+                input_embeds=self._build_prefill_input_embeds(forward_batch, requests),
+            ),
         )
         return None
 

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -284,9 +284,14 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         positions: torch.Tensor,
         forward_batch: ForwardBatch,
         input_embeds: Optional[torch.Tensor] = None,
+        omni_prefill_rids: list[str] | None = None,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
         input_embeds_are_projected: bool = False,
     ) -> LogitsProcessorOutput:
+        # Request IDs are transport metadata used by the shared runner while
+        # late-binding sidecar inputs; this model only consumes the embeddings
+        # that the runner has already bound for eager execution or graph replay.
+        del omni_prefill_rids
         del input_embeds_are_projected
         if input_embeds is None:
             forward_mode = getattr(forward_batch, "forward_mode", None)

--- a/tests/unit_test/models/test_model_capabilities.py
+++ b/tests/unit_test/models/test_model_capabilities.py
@@ -70,7 +70,7 @@ EXPECTED_MODEL_CAPABILITIES = {
         supports_streaming_vocoder=True,
         supports_cuda_graph=True,
         supports_torch_compile=True,
-        supports_breakable_prefill_cuda_graph=False,
+        supports_breakable_prefill_cuda_graph=True,
     ),
     "FishQwen3OmniForCausalLM": ModelCapabilities(
         supports_reference_audio=True,

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -1879,6 +1879,79 @@ def test_encode_audio_stereo_wav_and_mono_fallback():
     assert struct.unpack("<H", mono_blob[22:24])[0] == 1
 
 
+def test_moss_local_prefill_forward_uses_prompt_row_sidecar():
+    from sglang_omni.model_runner.prefill_inputs import get_omni_prefill_inputs
+    from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
+
+    class FakeModel:
+        dtype = torch.float32
+        hidden_size = 2
+        _state_pool = types.SimpleNamespace(
+            reset_for_refill=lambda *_args: None,
+            rebuild_audio_history=lambda *_args: None,
+        )
+
+        @staticmethod
+        def _prepare_multi_modal_inputs(rows):
+            return rows.to(torch.float32)[:, :2]
+
+    runner = MossTTSLocalModelRunner.__new__(MossTTSLocalModelRunner)
+    runner.model = FakeModel()
+    forward_batch = types.SimpleNamespace(
+        input_ids=torch.tensor([123456, 123457], dtype=torch.long),
+        input_embeds=None,
+        replace_embeds=None,
+    )
+    original_input_ids = forward_batch.input_ids.clone()
+    request = types.SimpleNamespace(
+        request_id="request",
+        data=types.SimpleNamespace(
+            req=types.SimpleNamespace(
+                rid="request",
+                extend_range=types.SimpleNamespace(length=2),
+                prefix_indices=[0],
+            ),
+            prompt_rows=torch.tensor(
+                [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+                dtype=torch.long,
+            ),
+            output_rows=[],
+            generation_steps=0,
+            sampling_steps=0,
+        ),
+    )
+
+    result = runner.custom_prefill_forward(forward_batch, object(), [request])
+
+    assert result is None
+    assert torch.equal(forward_batch.input_ids, original_input_ids)
+    assert forward_batch.input_embeds is None
+    prefill_inputs = get_omni_prefill_inputs(forward_batch)
+    assert prefill_inputs is not None
+    torch.testing.assert_close(
+        prefill_inputs.input_embeds,
+        torch.tensor([[4.0, 5.0], [7.0, 8.0]]),
+    )
+
+
+def test_moss_local_builder_allows_breakable_prefill_as_opt_in():
+    from sglang_omni.models.moss_tts_local.engine_builder import (
+        MossTtsLocalEngineBuilder,
+    )
+
+    builder = MossTtsLocalEngineBuilder(
+        enable_async_decode=False,
+        async_decode_min_batch_size=2,
+        total_gpu_memory_fraction=None,
+        codec_mem_reserve=0.05,
+    )
+
+    assert builder.supports_breakable_prefill_cuda_graph is True
+    assert "cuda_graph_backend_prefill" not in builder.generation_defaults(
+        dtype="bfloat16"
+    )
+
+
 def test_post_process_outputs_skips_chunked_rows():
     """Chunked-prefill rows must not be appended to output_rows."""
     pytest.importorskip("sglang")


### PR DESCRIPTION
## Motivation

MOSS-TTS-Local builds request-specific embeddings before prefill. The current hook writes them directly to `ForwardBatch.input_embeds`, which exposes request state during graph admission and prevents the model from using the shared breakable Prefill CUDA Graph path.

This PR adopts the existing `OmniPrefillInputs` sidecar. Embeddings stay outside upstream-owned admission fields, then `SGLModelRunner` late-binds the current tensor for either graph replay or the existing eager fallback. This is a thin adopter PR: it does not introduce a model-specific graph runner or change generation math, sampling, decode graphs, or vocoder behavior.

## Changes

- Mark MOSS-TTS-Local compatible with the shared breakable-prefill contract.
- Route model-built prompt embeddings through `OmniPrefillInputs` instead of mutating `ForwardBatch.input_embeds`.
- Accept the shared request-id transport kwarg in the model forward signature.
- Keep the backend opt-in; model defaults do not enable Prefill CUDA Graph.
- Add focused model-specific attachment, capability, and builder-policy tests while relying on the existing shared suites for sidecar transport, cleanup, admission, and graph policy.

## Current-main validation

Base: `470965eb24b658adebdf8a263e3bab6aa2b3e33e`

Environment: SGLang 0.5.18, Torch 2.13.0, FlashInfer 0.6.17.

- Full MOSS-TTS-Local unit directory + capability suite: **216 passed, 17 skipped**
- Five shared Prefill Graph sidecar/kwargs/usage/base-hook/policy suites: **50 passed**
- `uv pip check`, Python compilation, and `git diff --check` passed.

## Earlier RTX 5090 qualification

An earlier candidate on RTX 5090 32 GB exercised the real runtime path:

- 67-token prefill: successful CUDA Graph capture/replay
- 721-token over-cap prefill: successful eager fallback
- fixed seed: bit-identical generated WAV
- sequential c1 A/B/A, radix cache disabled, 40 output tokens:

| Metric | Eager p50 | Breakable p50 | Change |
|---|---:|---:|---:|
| TTFA | 215.782 ms | 182.887 ms | **-15.24%** |
| Streaming completion | 634.798 ms | 613.470 ms | **-3.36%** |

These numbers establish a positive c1 signal but are not presented as current-head or universal end-to-end results. They predate the SGLang 0.5.18 / Torch 2.13 dependency upgrade.

## Draft status / remaining qualification

Before marking ready, I plan to refresh the GPU evidence on current main and complete the #1357 acceptance matrix:

- deterministic eager vs exact-shape graph vs padded-bucket attribution;
- A→B→A stale-state and replay/fallback routing evidence;
- standard quality evaluation, not only valid/bit-identical WAV smoke;
- loaded concurrency with replay coverage and scheduled-token distribution;
- capture time, ready-state memory delta, and remaining GPU headroom.

## Scope

Breakable prefill remains disabled by default. This PR does not prescribe a bucket ladder, modify decode CUDA Graphs, change the MOSS local-transformer frame path, or alter codec execution.

Related to #1357. The implementation follows the merged MOSS-TTS adopter pattern in #1575, applied to the still-listed MOSS-TTS-Local backlog item.
