### PR TITLE
[Qwen3-TTS] Add incremental codec decoder core

### DIFF
--- a/sglang_omni/models/qwen3_tts/incremental_codec.py
+++ b/sglang_omni/models/qwen3_tts/incremental_codec.py
@@ -1,0 +1,471 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stateful incremental decoder for the Qwen3-TTS speech tokenizer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+
+@dataclass
+class Qwen3TTSIncrementalCodecState:
+    frame_position: int = 0
+    transformer_context_length: int = 0
+    transformer_keys: dict[int, torch.Tensor] = field(default_factory=dict)
+    transformer_values: dict[int, torch.Tensor] = field(default_factory=dict)
+    conv_histories: dict[str, torch.Tensor] = field(default_factory=dict)
+    transconv_overlaps: dict[str, torch.Tensor] = field(default_factory=dict)
+
+    def clone(self) -> Qwen3TTSIncrementalCodecState:
+        return Qwen3TTSIncrementalCodecState(
+            frame_position=self.frame_position,
+            transformer_context_length=self.transformer_context_length,
+            transformer_keys={
+                key: value.clone() for key, value in self.transformer_keys.items()
+            },
+            transformer_values={
+                key: value.clone() for key, value in self.transformer_values.items()
+            },
+            conv_histories={
+                key: value.clone() for key, value in self.conv_histories.items()
+            },
+            transconv_overlaps={
+                key: value.clone() for key, value in self.transconv_overlaps.items()
+            },
+        )
+
+
+def incremental_causal_conv1d(
+    module: Any,
+    hidden_states: torch.Tensor,
+    state: Qwen3TTSIncrementalCodecState,
+    key: str,
+) -> torch.Tensor:
+    conv = module.conv
+    stride = int(conv.stride[0])
+    if stride != 1:
+        raise ValueError(f"incremental causal Conv1d requires stride=1, got {stride}")
+    history_size = int(module.padding)
+    history = state.conv_histories.get(key)
+    if history is None:
+        history = hidden_states.new_zeros(
+            hidden_states.shape[0], hidden_states.shape[1], history_size
+        )
+    elif history.shape[:-1] != hidden_states.shape[:-1]:
+        raise ValueError(f"incremental causal Conv1d state shape changed for {key}")
+
+    combined = torch.cat((history, hidden_states), dim=-1)
+    output = conv(combined).contiguous()
+    if output.shape[-1] != hidden_states.shape[-1]:
+        raise RuntimeError(
+            f"incremental causal Conv1d changed temporal length for {key}"
+        )
+    state.conv_histories[key] = (
+        combined[..., -history_size:].clone()
+        if history_size
+        else combined[..., :0].clone()
+    )
+    return output
+
+
+def incremental_causal_transconv1d(
+    module: Any,
+    hidden_states: torch.Tensor,
+    state: Qwen3TTSIncrementalCodecState,
+    key: str,
+) -> torch.Tensor:
+    conv = module.conv
+    stride = int(conv.stride[0])
+    right_pad = int(module.right_pad)
+    output = F.conv_transpose1d(
+        hidden_states,
+        conv.weight,
+        bias=None,
+        stride=conv.stride,
+        padding=conv.padding,
+        output_padding=conv.output_padding,
+        groups=conv.groups,
+        dilation=conv.dilation,
+    )
+    overlap = state.transconv_overlaps.get(key)
+    if overlap is not None:
+        if overlap.shape[:-1] != output.shape[:-1]:
+            raise ValueError(
+                f"incremental causal ConvTranspose1d state shape changed for {key}"
+            )
+        overlap_length = int(overlap.shape[-1])
+        output[..., :overlap_length] += overlap
+
+    emit_length = int(hidden_states.shape[-1]) * stride
+    emitted = output[..., :emit_length]
+    tail = output[..., emit_length:]
+    if int(tail.shape[-1]) != right_pad:
+        raise RuntimeError(
+            f"incremental causal ConvTranspose1d produced the wrong overlap for {key}"
+        )
+    state.transconv_overlaps[key] = tail.clone()
+    if conv.bias is not None:
+        emitted = emitted + conv.bias.view(1, -1, 1)
+    return emitted.contiguous()
+
+
+def _apply_rotary_pos_emb(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    cos = cos.unsqueeze(1)
+    sin = sin.unsqueeze(1)
+
+    def rotate_half(value: torch.Tensor) -> torch.Tensor:
+        first, second = value.chunk(2, dim=-1)
+        return torch.cat((-second, first), dim=-1)
+
+    return (
+        query * cos + rotate_half(query) * sin,
+        key * cos + rotate_half(key) * sin,
+    )
+
+
+def _repeat_kv(hidden_states: torch.Tensor, groups: int) -> torch.Tensor:
+    if groups == 1:
+        return hidden_states
+    batch, heads, length, head_dim = hidden_states.shape
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch, heads, groups, length, head_dim
+    )
+    return hidden_states.reshape(batch, heads * groups, length, head_dim)
+
+
+def _incremental_attention(
+    attention: Any,
+    hidden_states: torch.Tensor,
+    position_embeddings: tuple[torch.Tensor, torch.Tensor],
+    state: Qwen3TTSIncrementalCodecState,
+    layer_index: int,
+    key_positions: torch.Tensor,
+    query_positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    input_shape = hidden_states.shape[:-1]
+    head_dim = int(attention.head_dim)
+    query = attention.q_norm(attention.q_proj(hidden_states)).view(
+        *input_shape, -1, head_dim
+    )
+    key = attention.k_norm(attention.k_proj(hidden_states)).view(
+        *input_shape, -1, head_dim
+    )
+    value = attention.v_proj(hidden_states).view(*input_shape, -1, head_dim)
+    query = query.transpose(1, 2)
+    key = key.transpose(1, 2)
+    value = value.transpose(1, 2)
+    query, key = _apply_rotary_pos_emb(
+        query, key, position_embeddings[0], position_embeddings[1]
+    )
+
+    prior_key = state.transformer_keys.get(layer_index)
+    prior_value = state.transformer_values.get(layer_index)
+    if (prior_key is None) != (prior_value is None):
+        raise RuntimeError(f"incomplete transformer state for layer {layer_index}")
+    if prior_key is not None:
+        key = torch.cat((prior_key, key), dim=-2)
+        value = torch.cat((prior_value, value), dim=-2)
+
+    repeated_key = _repeat_kv(key, int(attention.num_key_value_groups))
+    repeated_value = _repeat_kv(value, int(attention.num_key_value_groups))
+    scores = torch.matmul(query, repeated_key.transpose(2, 3)) * float(
+        attention.scaling
+    )
+    allowed = key_positions.unsqueeze(0) <= query_positions.unsqueeze(1)
+    sliding_window = int(attention.sliding_window)
+    if sliding_window > 0:
+        allowed &= key_positions.unsqueeze(0) > (
+            query_positions.unsqueeze(1) - sliding_window
+        )
+    scores = scores.masked_fill(
+        ~allowed.view(1, 1, *allowed.shape),
+        torch.finfo(scores.dtype).min,
+    )
+    probabilities = F.softmax(scores, dim=-1, dtype=torch.float32).to(query.dtype)
+    output = torch.matmul(probabilities, repeated_value)
+    output = output.transpose(1, 2).reshape(*input_shape, -1).contiguous()
+    return attention.o_proj(output), key, value
+
+
+def _incremental_transformer(
+    transformer: Any,
+    hidden_states: torch.Tensor,
+    state: Qwen3TTSIncrementalCodecState,
+) -> torch.Tensor:
+    hidden_states = transformer.input_proj(hidden_states)
+    fresh_frames = int(hidden_states.shape[1])
+    query_positions = torch.arange(
+        state.frame_position,
+        state.frame_position + fresh_frames,
+        device=hidden_states.device,
+        dtype=torch.long,
+    )
+    prior_start = state.frame_position - state.transformer_context_length
+    key_positions = torch.arange(
+        prior_start,
+        state.frame_position + fresh_frames,
+        device=hidden_states.device,
+        dtype=torch.long,
+    )
+    position_embeddings = transformer.rotary_emb(
+        hidden_states, query_positions.unsqueeze(0)
+    )
+
+    next_keys: dict[int, torch.Tensor] = {}
+    next_values: dict[int, torch.Tensor] = {}
+    window_size = int(transformer.window_size)
+    retained_context = max(0, window_size - 1)
+    for layer_index, layer in enumerate(transformer.layers):
+        residual = hidden_states
+        normalized = layer.input_layernorm(hidden_states)
+        attended, key, value = _incremental_attention(
+            layer.self_attn,
+            normalized,
+            position_embeddings,
+            state,
+            layer_index,
+            key_positions,
+            query_positions,
+        )
+        hidden_states = residual + layer.self_attn_layer_scale(attended)
+        residual = hidden_states
+        hidden_states = layer.post_attention_layernorm(hidden_states)
+        hidden_states = layer.mlp(hidden_states)
+        hidden_states = residual + layer.mlp_layer_scale(hidden_states)
+        next_keys[layer_index] = (
+            key[..., -retained_context:, :].clone()
+            if retained_context
+            else key[..., :0, :].clone()
+        )
+        next_values[layer_index] = (
+            value[..., -retained_context:, :].clone()
+            if retained_context
+            else value[..., :0, :].clone()
+        )
+
+    state.transformer_keys = next_keys
+    state.transformer_values = next_values
+    state.transformer_context_length = min(
+        retained_context,
+        state.transformer_context_length + fresh_frames,
+    )
+    return transformer.output_proj(transformer.norm(hidden_states))
+
+
+def _incremental_convnext(
+    module: Any,
+    hidden_states: torch.Tensor,
+    state: Qwen3TTSIncrementalCodecState,
+    key: str,
+) -> torch.Tensor:
+    residual = hidden_states
+    hidden_states = incremental_causal_conv1d(
+        module.dwconv, hidden_states, state, f"{key}.dwconv"
+    )
+    hidden_states = module.norm(hidden_states.permute(0, 2, 1))
+    hidden_states = module.pwconv1(hidden_states)
+    hidden_states = module.act(hidden_states)
+    hidden_states = module.pwconv2(hidden_states)
+    hidden_states = module.gamma * hidden_states
+    return residual + hidden_states.permute(0, 2, 1)
+
+
+def _incremental_residual_unit(
+    module: Any,
+    hidden_states: torch.Tensor,
+    state: Qwen3TTSIncrementalCodecState,
+    key: str,
+) -> torch.Tensor:
+    residual = hidden_states
+    hidden_states = module.act1(hidden_states)
+    hidden_states = incremental_causal_conv1d(
+        module.conv1, hidden_states, state, f"{key}.conv1"
+    )
+    hidden_states = module.act2(hidden_states)
+    hidden_states = incremental_causal_conv1d(
+        module.conv2, hidden_states, state, f"{key}.conv2"
+    )
+    return hidden_states + residual
+
+
+class Qwen3TTSIncrementalDecoder:
+    def __init__(self, decoder: Any) -> None:
+        self._require_attrs(
+            decoder,
+            "decoder",
+            "quantizer",
+            "pre_conv",
+            "pre_transformer",
+            "upsample",
+            "decoder",
+            "total_upsample",
+        )
+        if len(decoder.decoder) < 3:
+            raise TypeError("unsupported Qwen3-TTS decoder layout")
+        self._require_attrs(decoder.pre_conv, "pre_conv", "conv", "padding")
+        self._require_attrs(
+            decoder.pre_transformer,
+            "pre_transformer",
+            "input_proj",
+            "layers",
+            "norm",
+            "output_proj",
+            "rotary_emb",
+            "window_size",
+        )
+        for layer_index, layer in enumerate(decoder.pre_transformer.layers):
+            self._require_attrs(
+                layer,
+                f"pre_transformer.layers.{layer_index}",
+                "input_layernorm",
+                "self_attn",
+                "self_attn_layer_scale",
+                "post_attention_layernorm",
+                "mlp",
+                "mlp_layer_scale",
+            )
+            self._require_attrs(
+                layer.self_attn,
+                f"pre_transformer.layers.{layer_index}.self_attn",
+                "head_dim",
+                "num_key_value_groups",
+                "scaling",
+                "sliding_window",
+                "q_proj",
+                "k_proj",
+                "v_proj",
+                "o_proj",
+                "q_norm",
+                "k_norm",
+            )
+        for stage_index, blocks in enumerate(decoder.upsample):
+            if len(blocks) != 2:
+                raise TypeError("unsupported Qwen3-TTS upsample layout")
+            self._require_attrs(
+                blocks[0], f"upsample.{stage_index}.0", "conv", "right_pad"
+            )
+            self._require_attrs(
+                blocks[1],
+                f"upsample.{stage_index}.1",
+                "dwconv",
+                "norm",
+                "pwconv1",
+                "act",
+                "pwconv2",
+                "gamma",
+            )
+        self._require_attrs(decoder.decoder[0], "decoder.0", "conv", "padding")
+        self._require_attrs(decoder.decoder[-1], "decoder.final", "conv", "padding")
+        for block_index, block in enumerate(decoder.decoder[1:-2], start=1):
+            if not hasattr(block, "block") or len(block.block) < 2:
+                raise TypeError("unsupported Qwen3-TTS decoder block layout")
+            self._require_attrs(
+                block.block[1],
+                f"decoder.{block_index}.1",
+                "conv",
+                "right_pad",
+            )
+            for residual_index, residual in enumerate(block.block[2:]):
+                self._require_attrs(
+                    residual,
+                    f"decoder.{block_index}.{residual_index + 2}",
+                    "act1",
+                    "conv1",
+                    "act2",
+                    "conv2",
+                )
+        self._decoder = decoder
+        self.total_upsample = int(decoder.total_upsample)
+
+    @staticmethod
+    def _require_attrs(module: Any, path: str, *names: str) -> None:
+        missing = [name for name in names if not hasattr(module, name)]
+        if missing:
+            raise TypeError(
+                "unsupported Qwen3-TTS decoder layout; "
+                f"{path} is missing {', '.join(missing)}"
+            )
+
+    def decode(
+        self,
+        codes: torch.Tensor,
+        state: Qwen3TTSIncrementalCodecState,
+    ) -> torch.Tensor:
+        if codes.ndim != 3 or int(codes.shape[0]) != 1:
+            raise ValueError(
+                "Qwen3-TTS incremental codec decoding requires codes shaped [1, Q, T]"
+            )
+        fresh_frames = int(codes.shape[-1])
+        if fresh_frames <= 0:
+            raise ValueError(
+                "Qwen3-TTS incremental codec decoding requires fresh frames"
+            )
+
+        hidden_states = self._decoder.quantizer.decode(codes)
+        hidden_states = incremental_causal_conv1d(
+            self._decoder.pre_conv,
+            hidden_states,
+            state,
+            "pre_conv",
+        ).transpose(1, 2)
+        hidden_states = _incremental_transformer(
+            self._decoder.pre_transformer, hidden_states, state
+        ).permute(0, 2, 1)
+
+        for stage_index, blocks in enumerate(self._decoder.upsample):
+            if len(blocks) != 2:
+                raise TypeError("unsupported Qwen3-TTS upsample layout")
+            hidden_states = incremental_causal_transconv1d(
+                blocks[0],
+                hidden_states,
+                state,
+                f"upsample.{stage_index}.transconv",
+            )
+            hidden_states = _incremental_convnext(
+                blocks[1],
+                hidden_states,
+                state,
+                f"upsample.{stage_index}.convnext",
+            )
+
+        waveform = incremental_causal_conv1d(
+            self._decoder.decoder[0], hidden_states, state, "decoder.0"
+        )
+        for block_index, decoder_block in enumerate(
+            self._decoder.decoder[1:-2], start=1
+        ):
+            if len(decoder_block.block) < 2:
+                raise TypeError("unsupported Qwen3-TTS decoder block layout")
+            waveform = decoder_block.block[0](waveform)
+            waveform = incremental_causal_transconv1d(
+                decoder_block.block[1],
+                waveform,
+                state,
+                f"decoder.{block_index}.transconv",
+            )
+            for residual_index, residual_unit in enumerate(decoder_block.block[2:]):
+                waveform = _incremental_residual_unit(
+                    residual_unit,
+                    waveform,
+                    state,
+                    f"decoder.{block_index}.residual.{residual_index}",
+                )
+        waveform = self._decoder.decoder[-2](waveform)
+        waveform = incremental_causal_conv1d(
+            self._decoder.decoder[-1], waveform, state, "decoder.final"
+        ).clamp(min=-1, max=1)
+        expected_samples = fresh_frames * self.total_upsample
+        if int(waveform.shape[-1]) != expected_samples:
+            raise RuntimeError(
+                "Qwen3-TTS incremental codec decoder returned the wrong sample count"
+            )
+        state.frame_position += fresh_frames
+        return waveform

--- a/tests/unit_test/qwen3_tts/test_incremental_codec.py
+++ b/tests/unit_test/qwen3_tts/test_incremental_codec.py
@@ -1,0 +1,420 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import random
+
+import pytest
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from sglang_omni.models.qwen3_tts.incremental_codec import (
+    Qwen3TTSIncrementalCodecState,
+    Qwen3TTSIncrementalDecoder,
+    _incremental_transformer,
+    incremental_causal_conv1d,
+    incremental_causal_transconv1d,
+)
+
+
+def _random_partitions(total: int, seed: int) -> list[int]:
+    generator = random.Random(seed)
+    partitions = []
+    while total:
+        length = generator.randint(1, min(4, total))
+        partitions.append(length)
+        total -= length
+    return partitions
+
+
+class _CausalConv(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        *,
+        dilation: int = 1,
+        groups: int = 1,
+    ) -> None:
+        super().__init__()
+        self.conv = nn.Conv1d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            dilation=dilation,
+            groups=groups,
+        )
+        self.padding = (kernel_size - 1) * dilation
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.conv(F.pad(hidden_states, (self.padding, 0))).contiguous()
+
+
+class _CausalTransConv(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int,
+    ) -> None:
+        super().__init__()
+        self.conv = nn.ConvTranspose1d(
+            in_channels, out_channels, kernel_size, stride=stride
+        )
+        self.right_pad = kernel_size - stride
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        output = self.conv(hidden_states)
+        return output[..., : -self.right_pad] if self.right_pad else output
+
+
+class _RotaryEmbedding(nn.Module):
+    def __init__(self, head_dim: int) -> None:
+        super().__init__()
+        self.head_dim = head_dim
+
+    def forward(
+        self, hidden_states: torch.Tensor, position_ids: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        del hidden_states
+        frequencies = position_ids.to(torch.float32).unsqueeze(-1)
+        frequencies = frequencies / torch.arange(
+            1, self.head_dim // 2 + 1, device=position_ids.device
+        )
+        embeddings = torch.cat((frequencies, frequencies), dim=-1)
+        return embeddings.cos(), embeddings.sin()
+
+
+class _Attention(nn.Module):
+    def __init__(self, hidden_size: int, head_dim: int, window_size: int) -> None:
+        super().__init__()
+        self.head_dim = head_dim
+        self.num_key_value_groups = 2
+        self.scaling = head_dim**-0.5
+        self.sliding_window = window_size
+        self.q_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.k_proj = nn.Linear(hidden_size, hidden_size // 2, bias=False)
+        self.v_proj = nn.Linear(hidden_size, hidden_size // 2, bias=False)
+        self.o_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.q_norm = nn.Identity()
+        self.k_norm = nn.Identity()
+
+
+class _TransformerLayer(nn.Module):
+    def __init__(self, hidden_size: int, head_dim: int, window_size: int) -> None:
+        super().__init__()
+        self.input_layernorm = nn.LayerNorm(hidden_size)
+        self.self_attn = _Attention(hidden_size, head_dim, window_size)
+        self.self_attn_layer_scale = nn.Identity()
+        self.post_attention_layernorm = nn.LayerNorm(hidden_size)
+        self.mlp = nn.Sequential(
+            nn.Linear(hidden_size, hidden_size * 2),
+            nn.GELU(),
+            nn.Linear(hidden_size * 2, hidden_size),
+        )
+        self.mlp_layer_scale = nn.Identity()
+
+
+class _Transformer(nn.Module):
+    def __init__(self, latent_dim: int = 2, hidden_size: int = 4) -> None:
+        super().__init__()
+        self.input_proj = nn.Linear(latent_dim, hidden_size)
+        self.layers = nn.ModuleList([_TransformerLayer(hidden_size, 2, 4)])
+        self.norm = nn.LayerNorm(hidden_size)
+        self.output_proj = nn.Linear(hidden_size, latent_dim)
+        self.rotary_emb = _RotaryEmbedding(2)
+        self.window_size = 4
+
+
+class _Quantizer(nn.Module):
+    def decode(self, codes: torch.Tensor) -> torch.Tensor:
+        return codes[:, :2].to(torch.float32) / 16.0
+
+
+class _ConvNeXt(nn.Module):
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.dwconv = _CausalConv(channels, channels, 7, groups=channels)
+        self.norm = nn.LayerNorm(channels)
+        self.pwconv1 = nn.Linear(channels, channels * 4)
+        self.act = nn.GELU()
+        self.pwconv2 = nn.Linear(channels * 4, channels)
+        self.gamma = nn.Parameter(torch.full((channels,), 1e-3))
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.dwconv(hidden_states).permute(0, 2, 1)
+        hidden_states = self.pwconv2(self.act(self.pwconv1(self.norm(hidden_states))))
+        hidden_states = self.gamma * hidden_states
+        return residual + hidden_states.permute(0, 2, 1)
+
+
+class _ResidualUnit(nn.Module):
+    def __init__(self, channels: int, dilation: int) -> None:
+        super().__init__()
+        self.act1 = nn.Tanh()
+        self.conv1 = _CausalConv(channels, channels, 7, dilation=dilation)
+        self.act2 = nn.Tanh()
+        self.conv2 = _CausalConv(channels, channels, 1)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.conv1(self.act1(hidden_states))
+        hidden_states = self.conv2(self.act2(hidden_states))
+        return hidden_states + residual
+
+
+class _DecoderBlock(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.block = nn.ModuleList(
+            [
+                nn.Tanh(),
+                _CausalTransConv(4, 2, 4, 2),
+                _ResidualUnit(2, 1),
+                _ResidualUnit(2, 3),
+                _ResidualUnit(2, 9),
+            ]
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        for module in self.block:
+            hidden_states = module(hidden_states)
+        return hidden_states
+
+
+class _Decoder(nn.Module):
+    total_upsample = 4
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.quantizer = _Quantizer()
+        self.pre_conv = _CausalConv(2, 2, 3)
+        self.pre_transformer = _Transformer()
+        self.upsample = nn.ModuleList(
+            [nn.ModuleList([_CausalTransConv(2, 2, 2, 2), _ConvNeXt(2)])]
+        )
+        self.decoder = nn.ModuleList(
+            [
+                _CausalConv(2, 4, 7),
+                _DecoderBlock(),
+                nn.Tanh(),
+                _CausalConv(2, 1, 7),
+            ]
+        )
+
+    def forward(self, codes: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.quantizer.decode(codes)
+        hidden_states = self.pre_conv(hidden_states).transpose(1, 2)
+        hidden_states = _full_transformer(self.pre_transformer, hidden_states).permute(
+            0, 2, 1
+        )
+        for modules in self.upsample:
+            for module in modules:
+                hidden_states = module(hidden_states)
+        waveform = hidden_states
+        for module in self.decoder:
+            waveform = module(waveform)
+        return waveform.clamp(min=-1, max=1)
+
+
+def _full_transformer(
+    transformer: _Transformer, hidden_states: torch.Tensor
+) -> torch.Tensor:
+    hidden_states = transformer.input_proj(hidden_states)
+    length = int(hidden_states.shape[1])
+    positions = torch.arange(length, device=hidden_states.device)
+    cos, sin = transformer.rotary_emb(hidden_states, positions.unsqueeze(0))
+    for layer in transformer.layers:
+        residual = hidden_states
+        normalized = layer.input_layernorm(hidden_states)
+        attention = layer.self_attn
+        shape = normalized.shape[:-1]
+        query = attention.q_proj(normalized).view(*shape, -1, 2).transpose(1, 2)
+        key = attention.k_proj(normalized).view(*shape, -1, 2).transpose(1, 2)
+        value = attention.v_proj(normalized).view(*shape, -1, 2).transpose(1, 2)
+
+        def rotate_half(item: torch.Tensor) -> torch.Tensor:
+            first, second = item.chunk(2, dim=-1)
+            return torch.cat((-second, first), dim=-1)
+
+        rope_cos = cos.unsqueeze(1)
+        rope_sin = sin.unsqueeze(1)
+        query = query * rope_cos + rotate_half(query) * rope_sin
+        key = key * rope_cos + rotate_half(key) * rope_sin
+        key = key.repeat_interleave(attention.num_key_value_groups, dim=1)
+        value = value.repeat_interleave(attention.num_key_value_groups, dim=1)
+        scores = torch.matmul(query, key.transpose(2, 3)) * attention.scaling
+        key_positions = positions.unsqueeze(0)
+        query_positions = positions.unsqueeze(1)
+        allowed = key_positions <= query_positions
+        allowed &= key_positions > query_positions - attention.sliding_window
+        scores = scores.masked_fill(
+            ~allowed.view(1, 1, length, length),
+            torch.finfo(scores.dtype).min,
+        )
+        probabilities = F.softmax(scores, dim=-1, dtype=torch.float32).to(query)
+        attended = torch.matmul(probabilities, value)
+        attended = attended.transpose(1, 2).reshape(*shape, -1)
+        hidden_states = residual + layer.self_attn_layer_scale(
+            attention.o_proj(attended)
+        )
+        residual = hidden_states
+        hidden_states = layer.post_attention_layernorm(hidden_states)
+        hidden_states = layer.mlp(hidden_states)
+        hidden_states = residual + layer.mlp_layer_scale(hidden_states)
+    return transformer.output_proj(transformer.norm(hidden_states))
+
+
+@pytest.mark.parametrize("partitions", [[9], [1] * 9, [1, 8], [8, 1], [3, 2, 4]])
+def test_incremental_causal_conv_matches_whole(
+    partitions: list[int],
+) -> None:
+    torch.manual_seed(1)
+    module = _CausalConv(2, 3, 7, dilation=3)
+    inputs = torch.randn(1, 2, sum(partitions))
+    expected = module(inputs)
+    state = Qwen3TTSIncrementalCodecState()
+    actual = []
+    offset = 0
+    for length in partitions:
+        actual.append(
+            incremental_causal_conv1d(
+                module, inputs[..., offset : offset + length], state, "conv"
+            )
+        )
+        offset += length
+
+    torch.testing.assert_close(torch.cat(actual, dim=-1), expected)
+    assert state.conv_histories["conv"].shape[-1] == module.padding
+
+
+@pytest.mark.parametrize("partitions", [[9], [1] * 9, [1, 8], [8, 1], [3, 2, 4]])
+def test_incremental_causal_transconv_matches_whole(
+    partitions: list[int],
+) -> None:
+    torch.manual_seed(2)
+    module = _CausalTransConv(2, 3, 8, 4)
+    inputs = torch.randn(1, 2, sum(partitions))
+    expected = module(inputs)
+    state = Qwen3TTSIncrementalCodecState()
+    actual = []
+    offset = 0
+    for length in partitions:
+        actual.append(
+            incremental_causal_transconv1d(
+                module, inputs[..., offset : offset + length], state, "transconv"
+            )
+        )
+        offset += length
+
+    torch.testing.assert_close(torch.cat(actual, dim=-1), expected)
+    assert state.transconv_overlaps["transconv"].shape[-1] == module.right_pad
+
+
+@pytest.mark.parametrize("partitions", [[11], [1] * 11, [1, 10], [10, 1], [3, 2, 6]])
+def test_incremental_transformer_matches_whole_across_window(
+    partitions: list[int],
+) -> None:
+    torch.manual_seed(3)
+    transformer = _Transformer()
+    inputs = torch.randn(1, sum(partitions), 2)
+    expected = _full_transformer(transformer, inputs)
+    state = Qwen3TTSIncrementalCodecState()
+    actual = []
+    offset = 0
+    for length in partitions:
+        actual.append(
+            _incremental_transformer(
+                transformer, inputs[:, offset : offset + length], state
+            )
+        )
+        state.frame_position += length
+        offset += length
+
+    torch.testing.assert_close(torch.cat(actual, dim=1), expected)
+    assert state.transformer_context_length == transformer.window_size - 1
+    assert all(
+        item.shape[-2] == transformer.window_size - 1
+        for item in state.transformer_keys.values()
+    )
+
+
+def test_incremental_codec_state_clone_owns_tensor_storage() -> None:
+    state = Qwen3TTSIncrementalCodecState(
+        frame_position=3,
+        transformer_context_length=2,
+        transformer_keys={0: torch.ones(1, 1, 2, 2)},
+        transformer_values={0: torch.ones(1, 1, 2, 2)},
+        conv_histories={"conv": torch.ones(1, 1, 2)},
+        transconv_overlaps={"transconv": torch.ones(1, 1, 2)},
+    )
+
+    cloned = state.clone()
+    cloned.transformer_keys[0].zero_()
+    cloned.transformer_values[0].zero_()
+    cloned.conv_histories["conv"].zero_()
+    cloned.transconv_overlaps["transconv"].zero_()
+
+    assert state.transformer_keys[0].count_nonzero() == 4
+    assert state.transformer_values[0].count_nonzero() == 4
+    assert state.conv_histories["conv"].count_nonzero() == 2
+    assert state.transconv_overlaps["transconv"].count_nonzero() == 2
+
+
+@pytest.mark.parametrize(
+    "partitions",
+    [[11], [1] * 11, [1, 10], [10, 1], [3, 2, 6], _random_partitions(96, 5)],
+)
+def test_incremental_decoder_matches_whole_for_arbitrary_partitions(
+    partitions: list[int],
+) -> None:
+    torch.manual_seed(4)
+    decoder = _Decoder()
+    codes = torch.randint(0, 16, (1, 2, sum(partitions)))
+    expected = decoder(codes)
+    incremental = Qwen3TTSIncrementalDecoder(decoder)
+    state = Qwen3TTSIncrementalCodecState()
+    actual = []
+    offset = 0
+    for length in partitions:
+        actual.append(incremental.decode(codes[..., offset : offset + length], state))
+        offset += length
+
+    actual_waveform = torch.cat(actual, dim=-1)
+    torch.testing.assert_close(actual_waveform, expected, rtol=2e-5, atol=2e-6)
+    assert actual_waveform.shape[-1] == sum(partitions) * decoder.total_upsample
+    assert state.frame_position == sum(partitions)
+    assert state.transformer_context_length == decoder.pre_transformer.window_size - 1
+
+
+def test_incremental_decoder_reference_prefix_matches_generated_waveform() -> None:
+    torch.manual_seed(5)
+    decoder = _Decoder()
+    codes = torch.randint(0, 16, (1, 2, 9))
+    reference_frames = 4
+    expected = decoder(codes)[..., reference_frames * decoder.total_upsample :]
+    incremental = Qwen3TTSIncrementalDecoder(decoder)
+    state = Qwen3TTSIncrementalCodecState()
+
+    initial = incremental.decode(codes[..., :7], state)
+    initial = initial[..., reference_frames * decoder.total_upsample :]
+    final = incremental.decode(codes[..., 7:], state)
+    actual = torch.cat((initial, final), dim=-1)
+
+    torch.testing.assert_close(actual, expected, rtol=2e-5, atol=2e-6)
+    assert actual.shape[-1] == (9 - reference_frames) * decoder.total_upsample
+
+
+def test_incremental_decoder_rejects_batch_greater_than_one() -> None:
+    decoder = _Decoder()
+    incremental = Qwen3TTSIncrementalDecoder(decoder)
+
+    with pytest.raises(ValueError, match="\[1, Q, T\]"):
+        incremental.decode(
+            torch.ones(2, 2, 1, dtype=torch.long),
+            Qwen3TTSIncrementalCodecState(),
+        )


### PR DESCRIPTION
## Motivation

Qwen3-TTS streaming currently rebuilds a left-context window and reruns the speech-tokenizer decoder for every emitted chunk. This first T-PR7 change establishes the model-level causal state needed to decode only fresh codec frames in a follow-up PR.

## Modifications

- Add request-local incremental Codec state for absolute frame position, bounded Transformer K/V, causal Conv1d histories, and ConvTranspose overlap.
- Add bias-safe incremental ConvTranspose execution and per-layer causal Conv1d histories.
- Add eager sliding-window Transformer decode with absolute RoPE positions and valid warm-up context.
- Mirror the Qwen3-TTS decoder pipeline explicitly and reject unsupported layouts or B > 1.
- Add whole-vs-incremental parity coverage for primitives, Transformer windows, arbitrary decoder partitions, 1-frame chunks, seeded long partitions, reference prefixes, bounded state, and state cloning.

## Related Issues

Part 1 of T-PR7. The serving integration is intentionally kept in a stacked follow-up PR.

## Accuracy Test
### Environment

  - **Model:** `Qwen/Qwen3-TTS-12Hz-1.7B-Base`
  - **GPU:** NVIDIA H200
  - **dtype:** BF16
  - **Batch size:** 1
  - **Transformer sliding window:** 72 frames
  - **KV retention limit:** `window_size - 1 = 71` frames
  - **Total decoder upsample:** 1,920 waveform samples per codec frame

  ### Codec sequence

  The test did not use arbitrary synthetic codec IDs. It loaded the real Qwen3-TTS speech tokenizer and encoded:

  tests/data/query_to_draw.wav

  The audio was repeated as needed and encoded into a sequence of 155 real codec frames:

  24 reference-prefix frames + 131 generated frames

  The complete sequence crosses twice the Transformer sliding window:

  155 > 2 * 72

  Only the generated waveform suffix corresponding to the final 131 frames was compared. The first 24 decoded frames
  were treated as reference-prefix warm-up and removed from the comparison.

  Expected generated waveform length:

  131 frames * 1,920 samples/frame = 251,520 samples

  ### Whole-sequence reference

  The reference waveform was produced with the original real-model decoder:

  whole = decoder(all_155_codec_frames)
  expected = whole[..., 24 * 1920:]

  This produced the expected 251,520-sample generated suffix.

  ### Incremental partition tests

  The same 155-frame codec sequence was decoded incrementally using four partition strategies.

  #### 1. Single chunk

  [155]

  Result:

  PASS
  samples = 251,520
  max absolute error = 0.0141602
  mean absolute error = 0.000268610
  RMSE = 0.000585318

  #### 2. One frame per chunk

  [1, 1, ..., 1]

  Result:

  PASS
  samples = 251,520
  max absolute error = 0.0305176
  mean absolute error = 0.000358994
  RMSE = 0.000868058

  This exercises the maximum number of incremental state transitions and absolute-position/RoPE updates.

  #### 3. Fixed eight-frame chunks with a short terminal chunk

  [8, 8, ..., 8, 3]

  Because:

  155 = 19 * 8 + 3

  Result:

  PASS
  samples = 251,520
  max absolute error = 0.0314941
  mean absolute error = 0.000268313
  RMSE = 0.000612013

  This explicitly validates the non-divisible final three-frame chunk.

  #### 4. Random partitions

  The random plan begins with the complete 24-frame reference prefix, followed by deterministic random partitions of the
  131 generated frames:

  [24] + random_partition(131)

  Result:

  PASS
  samples = 251,520
  max absolute error = 0.0136719
  mean absolute error = 0.000268382
  RMSE = 0.000587517

  This explicitly validates reference-prefix warm-up state followed by irregular generated-frame boundaries.

  ### Assertions applied to every partition

  For every incremental plan, the test asserted:

  concatenated incremental waveform ≈ whole-decoder waveform
  generated output samples == 131 * 1,920
  state.frame_position == 155
  state.transformer_context_length == 71
  every key-cache length <= 71
  every value-cache length <= 71

  The BF16 waveform parity thresholds were:

  maximum absolute error <= 0.05
  mean absolute error <= 0.001
  RMSE <= 0.002

  All four partition plans passed these thresholds.

  ### State-boundedness test

  The captured real codec sequence was repeated to construct a 1,003-frame decode. It was decoded incrementally in 64-
  frame chunks, including the final short chunk.

  For every chunk, the test checked:

  output samples == fresh frames * 1,920
  Transformer context <= 71 frames
  all Conv1d history lengths equal their required causal padding
  all ConvTranspose1d overlap lengths equal their required right padding

  After the Transformer window was filled, the complete state shape and total number of retained tensor elements were
  recorded. Every subsequent chunk was required to have exactly the same state shape and element count.

  Final result:

  PASS
  decoded frames = 1,003
  final frame_position = 1,003
  KV retained frames = 71
  Conv1d history tensors = 29
  ConvTranspose overlap tensors = 6
  total retained state elements = 1,304,736
  no state growth after filling the sliding window

  ### Existing unit tests

  The existing incremental codec unit-test suite from PR #1756 was also run:

  python -m pytest -q tests/unit_test/qwen3_tts/test_incremental_codec.py

  Result:

  24 passed

  ### Final result

  PASS T-PR7 real-model incremental codec validation

  The H200/BF16 run validates:

  1. Real-model whole versus incremental waveform parity.
  2. Single-frame, fixed-eight, random, and non-divisible terminal chunk boundaries.
  3. Reference-prefix warm-up and generated-suffix comparison.
  4. Absolute frame positions and RoPE behavior beyond twice the sliding window.
  5. Correct output sample counts.
  6. Bounded Transformer KV, Conv1d history, and ConvTranspose overlap state over 1,003 frames.

  This is strong Hopper/BF16 correctness evidence on H200. 

## Benchmark & Profiling

Not run. This PR introduces the correctness core only and does not enable the incremental path in serving.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci qwen3-tts` to select Qwen3-TTS CI.
Draft PRs are skipped even if labeled.