### PR TITLE
[Qwen3-TTS] Add eager stateful codec streaming

### DIFF
--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -184,6 +184,7 @@ def create_vocoder_executor(
     initial_cuda_graph: bool = True,
     enable_deterministic_inference: bool = False,
     followup_cuda_graph: bool = True,
+    enable_stateful_codec_decoder: bool = False,
 ) -> SimpleScheduler:
     device = resolve_device_spec(device, gpu_id)
     tokenizer = _load_qwen3_tts_tokenizer(
@@ -210,6 +211,7 @@ def create_vocoder_executor(
         initial_cuda_graph=initial_cuda_graph,
         enable_deterministic_inference=enable_deterministic_inference,
         followup_cuda_graph=followup_cuda_graph,
+        enable_stateful_codec_decoder=enable_stateful_codec_decoder,
     )
     # note (ratish): Factory construction completes before the stage process
     # publishes readiness, so CUDA capture cannot overlap request-time GPU work

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -692,11 +692,13 @@ class Qwen3TTSStreamingVocoderScheduler(
         *,
         is_final: bool,
     ) -> torch.Tensor | None:
+        force_legacy_decode = False
         if self._enable_stateful_codec_decoder and not state.incremental_codec_fallback:
             try:
                 incremental = self._decode_incremental_eager(state)
             except Exception:
                 state.incremental_codec_fallback = True
+                force_legacy_decode = True
                 logger.warning(
                     "Qwen3-TTS stateful codec decode failed for %r; using the "
                     "legacy left-context decoder for the rest of the request",
@@ -712,7 +714,7 @@ class Qwen3TTSStreamingVocoderScheduler(
                 self._prune_incremental_codes(state)
                 return delta
 
-        plan = self._build_decode_plan(state, is_final=is_final)
+        plan = self._build_decode_plan(state, is_final=is_final or force_legacy_decode)
         if plan is None:
             return None
         handle = self._launch_decode_plans([plan], stream=self._decode_stream)

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -735,14 +735,17 @@ class Qwen3TTSStreamingVocoderScheduler(
             return None
 
         committed_state = state.incremental_codec_state
-        candidate_state = (
-            Qwen3TTSIncrementalCodecState()
-            if committed_state is None
-            else committed_state.clone()
-        )
+        if committed_state is None:
+            if state.emitted_generated_frames:
+                raise RuntimeError(
+                    "Qwen3-TTS incremental codec state is missing after emitted frames"
+                )
+            candidate_state = Qwen3TTSIncrementalCodecState()
+        else:
+            candidate_state = committed_state.clone()
         consumed_frames = candidate_state.frame_position
         expected_consumed_frames = state.ref_frames + state.emitted_generated_frames
-        if consumed_frames != expected_consumed_frames:
+        if committed_state is not None and consumed_frames != expected_consumed_frames:
             raise RuntimeError(
                 "Qwen3-TTS incremental codec position does not match emitted frames"
             )

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -13,6 +13,10 @@ from typing import Any, Mapping
 
 import torch
 
+from sglang_omni.models.qwen3_tts.incremental_codec import (
+    Qwen3TTSIncrementalCodecState,
+    Qwen3TTSIncrementalDecoder,
+)
 from sglang_omni.models.qwen3_tts.payload_types import Qwen3TTSState
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.messages import OutgoingMessage
@@ -51,6 +55,8 @@ class _Qwen3TTSStreamState:
     followup_pending: bool = False
     final_pending: bool = False
     playback_deadline_s: float = 0.0
+    incremental_codec_state: Qwen3TTSIncrementalCodecState | None = None
+    incremental_codec_fallback: bool = False
 
 
 class _Qwen3TTSInvalidCodeRows(ValueError):
@@ -363,6 +369,7 @@ class Qwen3TTSStreamingVocoderScheduler(
         initial_cuda_graph: bool = True,
         enable_deterministic_inference: bool = False,
         followup_cuda_graph: bool = True,
+        enable_stateful_codec_decoder: bool = False,
     ) -> None:
         if stream_stride <= 0 or stream_followup_stride <= 0:
             raise ValueError("stream strides must be > 0")
@@ -386,13 +393,23 @@ class Qwen3TTSStreamingVocoderScheduler(
         decoder_config = getattr(tokenizer_config, "decoder_config", tokenizer_config)
         num_quantizers = int(getattr(decoder_config, "num_quantizers", 0) or 0)
         self._deterministic_inference = bool(enable_deterministic_inference)
+        self._enable_stateful_codec_decoder = bool(enable_stateful_codec_decoder)
+        self._incremental_decoder = (
+            Qwen3TTSIncrementalDecoder(self._decoder)
+            if self._enable_stateful_codec_decoder
+            else None
+        )
         self._initial_decode_graphs = _Qwen3TTSInitialDecodeGraphs(
             self._decoder,
             device=self._device,
             num_quantizers=num_quantizers,
             input_frames=int(stream_left_context_frames) + int(initial_chunk_frames),
             batch_sizes=(1,) if self._deterministic_inference else (1, 2, 4, 8),
-            enabled=bool(initial_cuda_graph and num_quantizers > 0),
+            enabled=bool(
+                initial_cuda_graph
+                and num_quantizers > 0
+                and not self._enable_stateful_codec_decoder
+            ),
         )
         followup_frames = (
             int(stream_left_context_frames) + int(stream_followup_stride),
@@ -412,7 +429,11 @@ class Qwen3TTSStreamingVocoderScheduler(
             num_quantizers=num_quantizers,
             input_frames=followup_frames,
             batch_sizes=(1,) if self._deterministic_inference else (1, 2, 4, 8),
-            enabled=bool(followup_cuda_graph and num_quantizers > 0),
+            enabled=bool(
+                followup_cuda_graph
+                and num_quantizers > 0
+                and not self._enable_stateful_codec_decoder
+            ),
         )
         self._samples_per_frame = int(self._decoder.total_upsample)
         self._stream_stride = int(stream_stride)
@@ -432,7 +453,13 @@ class Qwen3TTSStreamingVocoderScheduler(
         self._default_initial_chunk_frames = int(initial_chunk_frames)
         self._stream_left_context_frames = int(stream_left_context_frames)
         self._async_decode = (
-            self._device.type == "cuda" if async_decode is None else bool(async_decode)
+            False
+            if self._enable_stateful_codec_decoder
+            else (
+                self._device.type == "cuda"
+                if async_decode is None
+                else bool(async_decode)
+            )
         )
         self._decode_staging = threading.local()
         self._pinned_staging_disabled = self._device.type != "cuda"
@@ -665,13 +692,123 @@ class Qwen3TTSStreamingVocoderScheduler(
         *,
         is_final: bool,
     ) -> torch.Tensor | None:
-        del request_id
+        if self._enable_stateful_codec_decoder and not state.incremental_codec_fallback:
+            try:
+                incremental = self._decode_incremental_eager(state)
+            except Exception:
+                state.incremental_codec_fallback = True
+                logger.warning(
+                    "Qwen3-TTS stateful codec decode failed for %r; using the "
+                    "legacy left-context decoder for the rest of the request",
+                    request_id,
+                    exc_info=True,
+                )
+            else:
+                if incremental is None:
+                    return None
+                plan, candidate_state, delta = incremental
+                delta = self._commit_decode_plan(state, plan, delta)
+                state.incremental_codec_state = candidate_state
+                self._prune_incremental_codes(state)
+                return delta
+
         plan = self._build_decode_plan(state, is_final=is_final)
         if plan is None:
             return None
         handle = self._launch_decode_plans([plan], stream=self._decode_stream)
         deltas = handle.resolve()
         return self._commit_decode_plan(state, plan, deltas[0])
+
+    def _decode_incremental_eager(
+        self,
+        state: _Qwen3TTSStreamState,
+    ) -> (
+        tuple[
+            _Qwen3TTSDecodePlan,
+            Qwen3TTSIncrementalCodecState,
+            torch.Tensor,
+        ]
+        | None
+    ):
+        available_generated_frames = state.total_frames - state.ref_frames
+        if available_generated_frames <= state.emitted_generated_frames:
+            return None
+
+        committed_state = state.incremental_codec_state
+        candidate_state = (
+            Qwen3TTSIncrementalCodecState()
+            if committed_state is None
+            else committed_state.clone()
+        )
+        consumed_frames = candidate_state.frame_position
+        expected_consumed_frames = state.ref_frames + state.emitted_generated_frames
+        if consumed_frames != expected_consumed_frames:
+            raise RuntimeError(
+                "Qwen3-TTS incremental codec position does not match emitted frames"
+            )
+        end_frame = state.ref_frames + available_generated_frames
+        if consumed_frames < state.pruned_frames:
+            raise RuntimeError(
+                "Qwen3-TTS incremental codec codes were pruned too early"
+            )
+        codes = torch.cat(state.code_chunks, dim=0)
+        decoder_input = (
+            codes[
+                consumed_frames - state.pruned_frames : end_frame - state.pruned_frames
+            ]
+            .transpose(0, 1)
+            .unsqueeze(0)
+        )
+        bad_rows = self._screen_out_of_range_codes(decoder_input)
+        _raise_for_bad_rows(bad_rows, 1)
+        incremental_decoder = self._incremental_decoder
+        if incremental_decoder is None:
+            raise RuntimeError("Qwen3-TTS incremental codec decoder is unavailable")
+        with torch.inference_mode():
+            waveform = incremental_decoder.decode(
+                decoder_input.to(self._device), candidate_state
+            )
+        if candidate_state.frame_position != end_frame:
+            raise RuntimeError(
+                "Qwen3-TTS incremental codec position did not advance to the decode end"
+            )
+        waveform = self._split_batch_waveform(waveform, 1)[0]
+        reference_frames = max(0, state.ref_frames - consumed_frames)
+        trim_samples = reference_frames * self._samples_per_frame
+        emit_frames = available_generated_frames - state.emitted_generated_frames
+        emit_samples = emit_frames * self._samples_per_frame
+        delta = (
+            waveform[trim_samples : trim_samples + emit_samples]
+            .detach()
+            .to(dtype=torch.float32, device="cpu")
+            .contiguous()
+        )
+        if int(delta.numel()) != emit_samples:
+            raise RuntimeError(
+                "Qwen3-TTS incremental codec decoder returned the wrong delta length"
+            )
+        plan = _Qwen3TTSDecodePlan(
+            decoder_input=decoder_input,
+            absolute_emitted_frames=expected_consumed_frames,
+            generated_frames=available_generated_frames,
+            window_start=consumed_frames,
+            emitted_generated_frames=state.emitted_generated_frames,
+        )
+        return plan, candidate_state, delta
+
+    def _prune_incremental_codes(self, state: _Qwen3TTSStreamState) -> None:
+        committed_state = state.incremental_codec_state
+        assert committed_state is not None
+        retention_start = max(
+            0,
+            committed_state.frame_position - self._stream_left_context_frames,
+        )
+        while (
+            state.code_chunks
+            and state.pruned_frames + int(state.code_chunks[0].shape[0])
+            <= retention_start
+        ):
+            state.pruned_frames += int(state.code_chunks.pop(0).shape[0])
 
     def _build_decode_plan(
         self,

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -21,6 +21,7 @@ from sglang_omni.models.qwen3_tts import request_builders as qwen3_request_build
 from sglang_omni.models.qwen3_tts import stages as qwen3_stages
 from sglang_omni.models.qwen3_tts import streaming_vocoder as qwen3_streaming_vocoder
 from sglang_omni.models.qwen3_tts.config import Qwen3TTSPipelineConfig
+from sglang_omni.models.qwen3_tts.incremental_codec import Qwen3TTSIncrementalCodecState
 from sglang_omni.models.qwen3_tts.payload_types import Qwen3TTSState
 from sglang_omni.models.qwen3_tts.request_builders import (
     Qwen3TTSPreparedRequest,
@@ -1450,6 +1451,141 @@ class _FakeQwen3TTSTokenizer:
             for item in encoded
         ]
         return waveforms, self.get_output_sample_rate()
+
+
+class _FakeIncrementalQwen3TTSDecoder:
+    def __init__(self, decoder, *, fail_on_call: int | None = None) -> None:
+        self._decoder = decoder
+        self._fail_on_call = fail_on_call
+        self.decode_inputs: list[torch.Tensor] = []
+
+    def decode(
+        self,
+        codes: torch.Tensor,
+        state: Qwen3TTSIncrementalCodecState,
+    ) -> torch.Tensor:
+        self.decode_inputs.append(codes.detach().clone())
+        if len(self.decode_inputs) == self._fail_on_call:
+            raise RuntimeError("injected incremental decode failure")
+        state.frame_position += int(codes.shape[-1])
+        return (
+            codes[:, :1]
+            .to(torch.float32)
+            .repeat_interleave(self._decoder.total_upsample, dim=-1)
+        )
+
+
+def _stateful_qwen3_tts_scheduler(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    fail_on_call: int | None = None,
+    stream_left_context_frames: int = 1,
+) -> tuple[Qwen3TTSStreamingVocoderScheduler, _FakeIncrementalQwen3TTSDecoder]:
+    created = []
+
+    def make_incremental(decoder):
+        incremental = _FakeIncrementalQwen3TTSDecoder(
+            decoder, fail_on_call=fail_on_call
+        )
+        created.append(incremental)
+        return incremental
+
+    monkeypatch.setattr(
+        qwen3_streaming_vocoder,
+        "Qwen3TTSIncrementalDecoder",
+        make_incremental,
+    )
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        async_decode=True,
+        initial_cuda_graph=True,
+        stream_left_context_frames=stream_left_context_frames,
+        enable_stateful_codec_decoder=True,
+    )
+    return scheduler, created[0]
+
+
+def test_qwen3_tts_stateful_codec_uses_reference_once_then_fresh_frames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduler, incremental = _stateful_qwen3_tts_scheduler(monkeypatch)
+    state = scheduler.create_stream_state("request")
+    state.ref_frames = 2
+    state.code_chunks.append(
+        torch.tensor([[10, 1], [20, 2], [30, 3]], dtype=torch.long)
+    )
+    state.total_frames = 3
+
+    first = scheduler.decode_delta("request", state, is_final=False)
+    state.code_chunks.append(torch.tensor([[40, 4], [50, 5]], dtype=torch.long))
+    state.total_frames = 5
+    second = scheduler.decode_delta("request", state, is_final=False)
+
+    assert scheduler._async_decode is False
+    assert scheduler._initial_decode_graphs._enabled is False
+    assert first is not None
+    assert first.tolist() == [30.0] * 4
+    assert second is not None
+    assert second.tolist() == [40.0] * 4 + [50.0] * 4
+    assert [tuple(item.shape) for item in incremental.decode_inputs] == [
+        (1, 2, 3),
+        (1, 2, 2),
+    ]
+    assert state.incremental_codec_state is not None
+    assert state.incremental_codec_state.frame_position == 5
+    assert state.emitted_generated_frames == 3
+    assert state.pruned_frames == 3
+
+
+def test_qwen3_tts_stateful_codec_failure_falls_back_without_committing_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduler, incremental = _stateful_qwen3_tts_scheduler(monkeypatch, fail_on_call=2)
+    state = scheduler.create_stream_state("request")
+    state.code_chunks.append(torch.tensor([[10, 1]], dtype=torch.long))
+    state.total_frames = 1
+    first = scheduler.decode_delta("request", state, is_final=False)
+    state.code_chunks.append(torch.tensor([[20, 2]], dtype=torch.long))
+    state.total_frames = 2
+
+    second = scheduler.decode_delta("request", state, is_final=False)
+
+    assert first is not None
+    assert first.tolist() == [10.0] * 4
+    assert second is not None
+    assert second.tolist() == [20.0] * 4
+    assert state.incremental_codec_fallback is True
+    assert state.incremental_codec_state is not None
+    assert state.incremental_codec_state.frame_position == 1
+    assert state.emitted_generated_frames == 2
+    assert len(incremental.decode_inputs) == 2
+    assert len(scheduler._decoder.decode_inputs) == 1
+
+    state.code_chunks.append(torch.tensor([[30, 3]], dtype=torch.long))
+    state.total_frames = 3
+    third = scheduler.decode_delta("request", state, is_final=True)
+
+    assert third is not None
+    assert third.tolist() == [30.0] * 4
+    assert len(incremental.decode_inputs) == 2
+
+
+def test_qwen3_tts_stateful_codec_terminal_without_fresh_frames_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduler, incremental = _stateful_qwen3_tts_scheduler(monkeypatch)
+    state = scheduler.create_stream_state("request")
+    state.code_chunks.append(torch.tensor([[10, 1]], dtype=torch.long))
+    state.total_frames = 1
+
+    delta = scheduler.decode_delta("request", state, is_final=True)
+    terminal = scheduler.decode_delta("request", state, is_final=True)
+
+    assert delta is not None
+    assert delta.numel() == scheduler._samples_per_frame
+    assert terminal is None
+    assert len(incremental.decode_inputs) == 1
 
 
 class _FakeDecodeStream:


### PR DESCRIPTION
## Motivation

Stacked on #1756.

This second T-PR7 change integrates the incremental Codec decoder into Qwen3-TTS streaming without widening the current async batching or CUDA-graph machinery. It provides an opt-in correctness path that consumes only fresh codec frames after the reference-prefix bootstrap.

## Modifications

- Add `enable_stateful_codec_decoder=False` to the Qwen3-TTS vocoder factory.
- Force the opt-in path to B=1 eager execution with async Codec batching and initial Codec CUDA graphs disabled.
- Add request-local incremental state, reference-prefix bootstrap, and exact fresh-frame decode planning.
- Clone candidate Codec state before decode and commit it only after successful exact-length output validation.
- Retain legacy left-context codes so an incremental failure can fall back mid-request without restarting or duplicating PCM.
- Preserve existing behavior when the feature is disabled.
- Add integration coverage for reference bootstrap, fresh-only follow-ups, transactional failure fallback, and terminal calls with no fresh frames.

## Related Issues

Depends on #1756 and should be reviewed after it.

## Accuracy Test

Retested fresh PR head `14c669ff9f4f4c2bbc963dd5e034f617a5c4c607` on an NVIDIA H200 with BF16.

### CPU integration tests
**PASS**

```text
3 passed, 137 deselected
```

### H200 scheduler structural checks
**PASS**

```text
baseline samples:              251520
candidate samples:             251520
frame_position:                155
emitted_generated_frames:      131
incremental_codec_fallback:    False
extra terminal decode:         None
```

This confirms that the stateful scheduler:

* emits the expected `131 * 1920 = 251520` generated samples;
* consumes all 155 codec frames, including the 24-frame reference prefix;
* emits exactly 131 generated frames;
* remains on the incremental path without falling back to the legacy decoder;
* produces no duplicate output on an extra terminal call.

### Waveform validation

The original candidate-vs-legacy comparison failed:

| Comparison | Max | Mean | RMSE |
| :--- | :--- | :--- | :--- |
| Candidate vs legacy scheduler | 0.953125 | 0.007563317 | 0.028097775 |

However, attribution showed that the divergence comes from the legacy streaming scheduler rather than the new stateful path.

Using the whole-sequence decoder as the numerical reference:

| Comparison | Max | Mean | RMSE |
| :--- | :--- | :--- | :--- |
| Candidate vs whole decoder | 0.0234375 | 0.000288005 | 0.000651891 |
| Legacy scheduler vs whole decoder | 0.9550781 | 0.007547594 | 0.028067846 |

The BF16 acceptance thresholds are:

* max absolute error <= 0.05
* mean absolute error <= 0.001
* RMSE <= 0.002

Candidate vs whole-sequence decoder therefore passes all thresholds:

* **max:** 0.0234375 <= 0.05 (**PASS**)
* **mean:** 0.000288005 <= 0.001 (**PASS**)
* **RMSE:** 0.000651891 <= 0.002 (**PASS**)

### Conclusion

**PASS.**

The PR #1757 stateful streaming path matches the real whole-sequence Codec decoder within the established H200/BF16 tolerances while preserving the expected streaming structure and staying on the incremental path without fallback.

## Benchmark & Profiling

Not run. The feature is disabled by default, and this PR intentionally excludes B > 1 state packing, async Codec execution, and CUDA graphs.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci qwen3-tts` to select Qwen3-TTS CI.
Draft PRs are skipped even if labeled.