### PR TITLE
[Qwen3-Omni Perf] Code2Wav: CUDA-graph shape hit-rate telemetry

### DIFF
--- a/docs/basic_usage/qwen3_omni.md
+++ b/docs/basic_usage/qwen3_omni.md
@@ -194,7 +194,25 @@ the model.
 The feature derives the exact `B=1` threshold windows from
 `stream_chunk_size` and `left_context_size`; the defaults capture
 `T{10,20,30,35}`. Unsupported shapes and final stream tails run eagerly.
-Capture-time incompatibilities also fall back to eager execution.
+Capture-time incompatibilities also fall back to eager execution. With
+batching enabled, `batch_size > 1` graphs are captured best-effort, so a
+batched window may also fall back to eager when its graph was skipped.
+
+To observe the graph hit rate under serving traffic, enable per-shape
+telemetry:
+
+```bash
+SGLANG_OMNI_TRACE_CODE2WAV_GRAPH=1 sgl-omni serve \
+  --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
+  --config examples/configs/qwen3_omni_colocated_h20.yaml \
+  --colocate
+```
+
+The Code2Wav stage then logs cumulative graph replays and eager fallbacks as
+JSON, grouped by `(batch_size, frames)` with per-reason fallback counts and
+hit rates. It reports every 2,000 executions and once when the scheduler
+exits. Telemetry is disabled by default; when disabled, the decode path only
+checks a cached boolean and allocates no per-shape counters.
 
 Output overlap is also enabled by default on CUDA devices: each threshold
 window's waveform readback runs as an asynchronous device-to-host copy into a

--- a/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import gc
+import json
 import logging
 import math
 import os
@@ -16,6 +17,10 @@ from typing import Any
 import torch
 
 logger = logging.getLogger(__name__)
+
+_CODE2WAV_GRAPH_TRACE_ENV = "SGLANG_OMNI_TRACE_CODE2WAV_GRAPH"
+_CODE2WAV_GRAPH_TRACE_REPORT_INTERVAL = 2000
+_FALSE_ENV_VALUES = {"", "0", "false", "no", "off"}
 
 
 @dataclass(frozen=True, slots=True)
@@ -197,6 +202,15 @@ class Code2WavCudaGraphRunner:
         self._fallback_counts: Counter[str] = Counter()
         self._graph_replays = 0
         self._replay_failures = 0
+        trace_value = os.getenv(_CODE2WAV_GRAPH_TRACE_ENV, "")
+        self._shape_trace_enabled = trace_value.strip().lower() not in _FALSE_ENV_VALUES
+        self._shape_graph_counts: Counter[GraphKey] | None = (
+            Counter() if self._shape_trace_enabled else None
+        )
+        self._shape_fallback_counts: Counter[tuple[GraphKey, str]] | None = (
+            Counter() if self._shape_trace_enabled else None
+        )
+        self._shape_trace_executions = 0
 
     @classmethod
     def build(
@@ -629,6 +643,8 @@ class Code2WavCudaGraphRunner:
             self._disable_runtime(reason)
             raise
         self._graph_replays += 1
+        if self._shape_trace_enabled:
+            self._record_shape_execution(key=key, fallback_reason=None)
         return Code2WavRunResult(
             output=captured.static_output,
             execution_mode="cuda_graph",
@@ -658,6 +674,11 @@ class Code2WavCudaGraphRunner:
         reason: str,
     ) -> Code2WavRunResult:
         self._fallback_counts[reason] += 1
+        if self._shape_trace_enabled:
+            self._record_shape_execution(
+                key=self._shape_key_if_available(codes),
+                fallback_reason=reason,
+            )
         with torch.inference_mode():
             output = self._model(codes)
         return Code2WavRunResult(
@@ -685,8 +706,108 @@ class Code2WavCudaGraphRunner:
             )
         logger.exception("Code2Wav CUDA graph replay disabled the runner")
 
+    @staticmethod
+    def _shape_key_if_available(codes: torch.Tensor) -> GraphKey | None:
+        """Return the graph lookup shape without imposing graph validation.
+
+        The ``disabled``/``ineligible`` fallbacks run before ``_validate_codes``,
+        so optional observability must not assume the ``[B, Q, T]`` contract.
+        """
+
+        if codes.ndim != 3:
+            return None
+        return GraphKey(
+            batch_size=int(codes.shape[0]),
+            frames=int(codes.shape[2]),
+        )
+
+    def _record_shape_execution(
+        self,
+        *,
+        key: GraphKey | None,
+        fallback_reason: str | None,
+    ) -> None:
+        if key is None:
+            return
+        graph_counts = self._shape_graph_counts
+        fallback_counts = self._shape_fallback_counts
+        assert graph_counts is not None
+        assert fallback_counts is not None
+        if fallback_reason is None:
+            graph_counts[key] += 1
+        else:
+            fallback_counts[(key, fallback_reason)] += 1
+        self._shape_trace_executions += 1
+        if self._shape_trace_executions % _CODE2WAV_GRAPH_TRACE_REPORT_INTERVAL == 0:
+            self.log_shape_telemetry(trigger="periodic")
+
+    def _shape_telemetry_stats(self) -> dict[str, Any]:
+        graph_counts = self._shape_graph_counts
+        fallback_counts = self._shape_fallback_counts
+        assert graph_counts is not None
+        assert fallback_counts is not None
+
+        fallbacks_by_key: dict[GraphKey, dict[str, int]] = {}
+        for (key, reason), count in sorted(
+            fallback_counts.items(),
+            key=lambda item: (item[0][0].batch_size, item[0][0].frames, item[0][1]),
+        ):
+            fallbacks_by_key.setdefault(key, {})[reason] = count
+
+        shapes: list[dict[str, Any]] = []
+        for key in sorted(
+            set(graph_counts) | set(fallbacks_by_key),
+            key=lambda item: (item.batch_size, item.frames),
+        ):
+            graph_replays = graph_counts[key]
+            per_reason = fallbacks_by_key.get(key, {})
+            eager_fallbacks = sum(per_reason.values())
+            shapes.append(
+                {
+                    "batch_size": key.batch_size,
+                    "frames": key.frames,
+                    "graph_replays": graph_replays,
+                    "eager_fallbacks": eager_fallbacks,
+                    "fallback_counts": per_reason,
+                    "hit_rate": graph_replays / (graph_replays + eager_fallbacks),
+                }
+            )
+
+        graph_replays = sum(graph_counts.values())
+        eager_fallbacks = sum(fallback_counts.values())
+        total = graph_replays + eager_fallbacks
+        return {
+            "total_executions": total,
+            "graph_replays": graph_replays,
+            "eager_fallbacks": eager_fallbacks,
+            "hit_rate": graph_replays / total if total else None,
+            "shapes": shapes,
+        }
+
+    def log_shape_telemetry(self, *, trigger: str) -> None:
+        """Log one cumulative per-shape snapshot when tracing is enabled."""
+
+        if not self._shape_trace_enabled:
+            return
+        stats = self._shape_telemetry_stats()
+        if not stats["total_executions"]:
+            return
+        logger.info(
+            "Code2Wav CUDA graph shape telemetry trigger=%s stats=%s",
+            trigger,
+            json.dumps(stats, sort_keys=True, separators=(",", ":")),
+        )
+
     def stats(self) -> dict[str, Any]:
         """Return a strict JSON-safe snapshot of build and runtime state."""
+
+        runtime: dict[str, Any] = {
+            "graph_replays": self._graph_replays,
+            "replay_failures": self._replay_failures,
+            "fallback_counts": dict(sorted(self._fallback_counts.items())),
+        }
+        if self._shape_trace_enabled:
+            runtime["shape_telemetry"] = self._shape_telemetry_stats()
 
         return {
             "enabled": self._enabled,
@@ -708,11 +829,7 @@ class Code2WavCudaGraphRunner:
             },
             "build": deepcopy(self._build_stats),
             "memory": deepcopy(self._memory_stats),
-            "runtime": {
-                "graph_replays": self._graph_replays,
-                "replay_failures": self._replay_failures,
-                "fallback_counts": dict(sorted(self._fallback_counts.items())),
-            },
+            "runtime": runtime,
         }
 
 

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -772,6 +772,8 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
                 self._pinned_quarantined.append(slot)
             else:
                 self._release_slot(slot)
+        if self._cuda_graph_runner is not None:
+            self._cuda_graph_runner.log_shape_telemetry(trigger="shutdown")
 
     def select_step_participants(self) -> list[tuple[str, Code2WavStreamState]]:
         now = time.monotonic()

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -52,6 +52,10 @@ class _FakeCudaGraphRunner:
         self.model = model
         self.replay_error = replay_error
         self.calls: list[tuple[tuple[int, ...], bool]] = []
+        self.telemetry_triggers: list[str] = []
+
+    def log_shape_telemetry(self, *, trigger: str) -> None:
+        self.telemetry_triggers.append(trigger)
 
     def run(self, codes: torch.Tensor, *, eligible: bool) -> Code2WavRunResult:
         self.calls.append((tuple(codes.shape), eligible))
@@ -932,3 +936,25 @@ def test_qwen_code2wav_emits_full_chunk_despite_model_output_deficit() -> None:
     assert second_audio.shape == (4,)
 
     assert first_audio.shape[0] + second_audio.shape[0] == 4 * 2 - 1
+
+
+def test_qwen_code2wav_serving_stop_logs_shutdown_shape_telemetry() -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    runner = _FakeCudaGraphRunner(model)
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        enable_cuda_graph=True,
+        _cuda_graph_runner=runner,
+    )
+
+    scheduler.on_serving_stop()
+
+    assert runner.telemetry_triggers == ["shutdown"]
+
+
+def test_qwen_code2wav_serving_stop_without_runner_skips_telemetry() -> None:
+    scheduler = _make_scheduler(FakeCode2WavModel())
+    assert scheduler._cuda_graph_runner is None
+
+    scheduler.on_serving_stop()

--- a/tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable
 from contextlib import nullcontext
 from typing import Any
@@ -1048,3 +1049,219 @@ def test_runtime_disable_clears_tier1_availability() -> None:
 
     assert runner.available_batch_sizes(10) == ()
     assert runner.stats()["enabled"] is False
+
+
+_TRACE_ENV = code2wav_cuda_graph._CODE2WAV_GRAPH_TRACE_ENV
+_TRACE_LOGGER = code2wav_cuda_graph.__name__
+
+
+def _enable_shape_trace(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_TRACE_ENV, "1")
+
+
+def test_shape_trace_counts_match_constructed_workload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_shape_trace(monkeypatch)
+    runner, backend, _model = _build_runner()
+
+    for _ in range(3):
+        runner.run(_codes(backend, 1, 10))
+    runner.run(_codes(backend, 1, 20))
+    for _ in range(2):
+        runner.run(_codes(backend, 1, 40))
+    runner.run(_codes(backend, 1, 10), eligible=False)
+
+    telemetry = runner.stats()["runtime"]["shape_telemetry"]
+    assert telemetry == {
+        "total_executions": 7,
+        "graph_replays": 4,
+        "eager_fallbacks": 3,
+        "hit_rate": 4 / 7,
+        "shapes": [
+            {
+                "batch_size": 1,
+                "frames": 10,
+                "graph_replays": 3,
+                "eager_fallbacks": 1,
+                "fallback_counts": {"ineligible": 1},
+                "hit_rate": 3 / 4,
+            },
+            {
+                "batch_size": 1,
+                "frames": 20,
+                "graph_replays": 1,
+                "eager_fallbacks": 0,
+                "fallback_counts": {},
+                "hit_rate": 1.0,
+            },
+            {
+                "batch_size": 1,
+                "frames": 40,
+                "graph_replays": 0,
+                "eager_fallbacks": 2,
+                "fallback_counts": {"key_miss": 2},
+                "hit_rate": 0.0,
+            },
+        ],
+    }
+    assert runner.stats()["runtime"]["fallback_counts"] == {
+        "ineligible": 1,
+        "key_miss": 2,
+    }
+
+
+def test_shape_trace_records_batched_tier_hits_and_misses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_shape_trace(monkeypatch)
+    backend = _SequencedBackend(
+        snapshots=[
+            (100, 120),  # before
+            (100, 120),  # attempt baseline
+            (300, 340),  # after b4t20
+            (360, 400),  # after b4t10
+            (390, 430),  # after b2t20
+            (400, 440),  # after b2t10
+            (420, 460),  # final combined footprint
+        ],
+    )
+    runner = _build_tiered_runner(backend)
+
+    assert runner.run(_codes(backend, 4, 20)).execution_mode == "cuda_graph"
+    assert runner.run(_codes(backend, 8, 20)).fallback_reason == "key_miss"
+
+    telemetry = runner.stats()["runtime"]["shape_telemetry"]
+    assert telemetry["shapes"] == [
+        {
+            "batch_size": 4,
+            "frames": 20,
+            "graph_replays": 1,
+            "eager_fallbacks": 0,
+            "fallback_counts": {},
+            "hit_rate": 1.0,
+        },
+        {
+            "batch_size": 8,
+            "frames": 20,
+            "graph_replays": 0,
+            "eager_fallbacks": 1,
+            "fallback_counts": {"key_miss": 1},
+            "hit_rate": 0.0,
+        },
+    ]
+
+
+@pytest.mark.parametrize("trace_value", [None, "", "0", "false", "no", "off", " OFF "])
+def test_shape_trace_disabled_values_keep_runtime_stats_unchanged(
+    trace_value: str | None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    if trace_value is None:
+        monkeypatch.delenv(_TRACE_ENV, raising=False)
+    else:
+        monkeypatch.setenv(_TRACE_ENV, trace_value)
+    runner, backend, _model = _build_runner()
+
+    runner.run(_codes(backend, 1, 10))
+    runner.run(_codes(backend, 1, 40))
+    with caplog.at_level(logging.INFO, logger=_TRACE_LOGGER):
+        runner.log_shape_telemetry(trigger="shutdown")
+
+    assert runner._shape_graph_counts is None
+    assert runner._shape_fallback_counts is None
+    assert runner.stats()["runtime"] == {
+        "graph_replays": 1,
+        "replay_failures": 0,
+        "fallback_counts": {"key_miss": 1},
+    }
+    assert caplog.records == []
+
+
+def test_shape_trace_periodic_report_fires_exactly_on_interval(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _enable_shape_trace(monkeypatch)
+    monkeypatch.setattr(code2wav_cuda_graph, "_CODE2WAV_GRAPH_TRACE_REPORT_INTERVAL", 3)
+    runner, backend, _model = _build_runner()
+
+    with caplog.at_level(logging.INFO, logger=_TRACE_LOGGER):
+        runner.run(_codes(backend, 1, 10))
+        runner.run(_codes(backend, 1, 40))
+        assert not [r for r in caplog.records if "shape telemetry" in r.getMessage()]
+        runner.run(_codes(backend, 1, 20))
+        first = [r for r in caplog.records if "shape telemetry" in r.getMessage()]
+        assert len(first) == 1
+        for _ in range(3):
+            runner.run(_codes(backend, 1, 10))
+        reports = [r for r in caplog.records if "shape telemetry" in r.getMessage()]
+        assert len(reports) == 2
+
+    message = reports[1].getMessage()
+    assert "trigger=periodic" in message
+    payload = json.loads(message.split("stats=", 1)[1])
+    assert payload["total_executions"] == 6
+    assert payload["graph_replays"] == 5
+    assert payload["eager_fallbacks"] == 1
+
+
+def test_shape_trace_keeps_counting_after_runtime_disable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_shape_trace(monkeypatch)
+    runner, backend, _model = _build_runner()
+    runner.run(_codes(backend, 1, 10))
+    graph = next(
+        g for g in backend.graphs if tuple(g.static_input.shape) == (1, 16, 20)
+    )
+    graph.fail_replay = RuntimeError("replay exploded")
+
+    with pytest.raises(RuntimeError, match="replay exploded"):
+        runner.run(_codes(backend, 1, 20))
+    runner.run(_codes(backend, 1, 20))
+
+    telemetry = runner.stats()["runtime"]["shape_telemetry"]
+    # Note (edwardzh): the raising replay mirrors fallback_counts and records
+    # nothing; only the replay before it and the disabled retry after it count.
+    assert telemetry["total_executions"] == 2
+    assert telemetry["shapes"] == [
+        {
+            "batch_size": 1,
+            "frames": 10,
+            "graph_replays": 1,
+            "eager_fallbacks": 0,
+            "fallback_counts": {},
+            "hit_rate": 1.0,
+        },
+        {
+            "batch_size": 1,
+            "frames": 20,
+            "graph_replays": 0,
+            "eager_fallbacks": 1,
+            "fallback_counts": {"disabled": 1},
+            "hit_rate": 0.0,
+        },
+    ]
+
+
+def test_shape_trace_stats_stay_json_safe_and_shutdown_log_skips_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _enable_shape_trace(monkeypatch)
+    runner, backend, _model = _build_runner()
+
+    json.dumps(runner.stats(), allow_nan=False)
+    with caplog.at_level(logging.INFO, logger=_TRACE_LOGGER):
+        runner.log_shape_telemetry(trigger="shutdown")
+    assert caplog.records == []
+
+    runner.run(_codes(backend, 1, 10))
+    json.dumps(runner.stats(), allow_nan=False)
+    with caplog.at_level(logging.INFO, logger=_TRACE_LOGGER):
+        runner.log_shape_telemetry(trigger="shutdown")
+    messages = [r.getMessage() for r in caplog.records]
+    assert len(messages) == 1
+    assert "trigger=shutdown" in messages[0]


### PR DESCRIPTION
## Motivation

Code2Wav CUDA graphs replay only exact captured shapes; anything else silently falls back to eager. Since #1237 the `batch_size > 1` keys are additionally captured best-effort — a batched key skipped under memory pressure sends every coalesced window of that shape down the eager path with nothing observable. What exists today is `Code2WavCudaGraphRunner.stats()` aggregating fallbacks by reason only, logged exactly once at scheduler startup, before any traffic. Operators cannot verify graph coverage under real traffic or decide which shapes to capture next.

This PR adds opt-in per-shape telemetry: replay and fallback counts keyed on `GraphKey(batch_size, frames)`, reported periodically and at shutdown.

## Modifications

- **Env-gated, cached-bool off switch.** `SGLANG_OMNI_TRACE_CODE2WAV_GRAPH=1` enables tracing; the value is read once in `__init__`. Disabled (the default), `run()` and `_eager()` each gain one boolean check and no per-shape counters are allocated; `stats()` output is unchanged.
- **Per-`GraphKey` counters.** Graph replays and eager fallbacks (by reason: `disabled` / `ineligible` / `key_miss`) are counted per `(batch_size, frames)`. Both decode paths route through `Code2WavCudaGraphRunner.run`, so serial tier-0 and batched tier-1 traffic — including the best-effort misses above — are covered by the same two hooks. The fallback hook sits on the same line as the existing aggregate `_fallback_counts` increment, so the per-shape and aggregate counters cannot diverge. The `disabled`/`ineligible` fallbacks run before `_validate_codes`, so their shape is derived defensively (`ndim == 3` only) rather than assumed.
- **Reporting.** One cumulative JSON line per 2,000 executions (the MOSS-TTS local vocoder interval) with per-shape counts, per-reason breakdowns, and hit rates; the same summary once at scheduler exit via the existing `on_serving_stop()` hook. While tracing is enabled, `stats()["runtime"]` carries the same snapshot under `shape_telemetry`.
- **Runtime disable keeps counting.** After a replay failure disables the runner, subsequent executions are still recorded per shape under `disabled`; the raising replay itself records nothing, mirroring the existing aggregate counters.
- 14 unit tests and a docs section on enabling and reading the output.

Graph capture, key selection, fallback decisions, and both decode paths are untouched; production changes are +109 lines in `code2wav_cuda_graph.py` plus a two-line hook in `code2wav_scheduler.py`.

## Related Issues

Closes #1146. Part of #1022. Design contract: #1018 (item 4.6). Supersedes #1157 (written against the pre-#1237 flat key set; reimplements the same reviewed design on the tiered runner).

## Correctness validation

**Expected:** behavior-preserving — disabled by default with a byte-identical disabled path; enabled, it only counts and logs, and changes no graph selection, fallback decision, or audio output.

### Counters vs a constructed workload

*What / why:* #1146's acceptance criterion — stats output must match a workload with a known hit/miss mix.

*Setup:* against the existing fake CUDA backend: 3× `b1t10` replays, 1× `b1t20` replay, 2× `b1t40` key misses, 1× ineligible `b1t10`; on the tiered fixture, a `b4t20` replay plus a `b8t20` key miss (the tier-1 silent-fallback case #1157's review called out).

*Result:* the per-shape snapshot equals the hand-computed counts, reasons, and hit rates exactly, and the aggregate `fallback_counts` agrees. Periodic reporting fires exactly on the 2,000-execution boundary (interval monkeypatched small; the emitted JSON parses back to the expected totals), and the shutdown hook logs once with `trigger=shutdown`.

### Disabled path unchanged

*What / why:* the item 4.6 gate; the default path must not move.

*Result:* all 103 pre-existing tests pass unmodified — including the strict `==` assertions on the full `stats()["runtime"]` dict, which would fail on any new key. A parametrized case covers unset, `""`, `"0"`, `"false"`, `"no"`, `"off"`, and `" OFF "`: counters stay unallocated (`None`), `stats()` is unchanged, and `log_shape_telemetry` emits nothing.

### Unit tests

`test_code2wav_cuda_graph.py`, `test_code2wav.py`, `test_code2wav_batching.py`: 117 passed, 3 skipped (the skips require CUDA hardware) — locally and inside the pinned CI image (`hongccc/sglang-omni@sha256:374d0b1c`) on a CPU container.

## Benchmark & Profiling

**Expected:** none — observability only, no performance claim. Disabled, the decode path gains one cached-boolean check per execution. Enabled, each execution adds one `Counter` update on the scheduler thread and one log line per 2,000 executions; counters are host-side only.
