### PR TITLE
[Qwen3-Omni] Migrate Code2Wav staging to the common pinned transfer slot

### DIFF
--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -108,10 +108,8 @@ def load_code2wav_model(
 class _PendingWindow:
     """Depth-2 pipeline slot reference held by a stream state.
 
-    The slot's pinned buffer only grows and its completion event is reused
-    across windows, so a steady-state stream never allocates. The sample
-    count is recorded at launch so the flush never has to read a shape back
-    from the device.
+    The sample count is recorded at launch so the flush never has to read a
+    shape back from the device.
     """
 
     slot: PinnedTransferSlot
@@ -190,6 +188,9 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         self._eos_lazy_scan = self._enable_output_overlap and not self._enable_batching
         self._pipeline_active = self._eos_lazy_scan and self._device.type == "cuda"
         self._default_slot_samples = self._stream_chunk_size * self._total_upsample
+        # Note (wenyao): a slot's pinned buffer only grows and its completion
+        # event is reused across windows, so a steady-state stream never
+        # allocates.
         self._pinned_free: list[PinnedTransferSlot] = []
         self._pinned_created = 0
         # Note (wenyao): a slot must have exactly one owner at any time.
@@ -411,6 +412,10 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
                 # Note (wenyao): a failed copy or record leaves no trustworthy
                 # completion marker, so this buffer must never go back into
                 # rotation even though it was never handed to a request.
+                # Note (jiannan-17): the shared slot refuses query() and
+                # synchronize() only after a record() that raised; a copy
+                # that raised before record() still reads the previous
+                # transfer, so the quarantine is what keeps this buffer out.
                 self._quarantine_slot(slot)
             raise
         state.pending = _PendingWindow(slot=slot, samples=samples)

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -188,9 +188,8 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         self._eos_lazy_scan = self._enable_output_overlap and not self._enable_batching
         self._pipeline_active = self._eos_lazy_scan and self._device.type == "cuda"
         self._default_slot_samples = self._stream_chunk_size * self._total_upsample
-        # Note (wenyao): a slot's pinned buffer only grows and its completion
-        # event is reused across windows, so a steady-state stream never
-        # allocates.
+        # Note (jiannan-17): Each slot only grows its buffer and reuses one
+        # event, avoiding steady-state allocations.
         self._pinned_free: list[PinnedTransferSlot] = []
         self._pinned_created = 0
         # Note (wenyao): a slot must have exactly one owner at any time.
@@ -412,10 +411,8 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
                 # Note (wenyao): a failed copy or record leaves no trustworthy
                 # completion marker, so this buffer must never go back into
                 # rotation even though it was never handed to a request.
-                # Note (jiannan-17): the shared slot refuses query() and
-                # synchronize() only after a record() that raised; a copy
-                # that raised before record() still reads the previous
-                # transfer, so the quarantine is what keeps this buffer out.
+                # Note (jiannan-17): The slot tracks record failures, but not
+                # copy failures before record(); quarantine covers both cases.
                 self._quarantine_slot(slot)
             raise
         state.pending = _PendingWindow(slot=slot, samples=samples)

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -30,6 +30,7 @@ from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.streaming_vocoder import StreamingVocoderBase
 from sglang_omni.utils.audio_payload import audio_waveform_payload
+from sglang_omni.utils.cuda_staging import PinnedTransferSlot
 from sglang_omni.utils.device import resolve_device_spec
 
 logger = logging.getLogger(__name__)
@@ -103,29 +104,17 @@ def load_code2wav_model(
     return model.eval()
 
 
-# Note (wenyao): identity equality — the pools ask which slot this is, and
-# dataclass value equality would compare buffers, which raises on tensors.
-@dataclass(eq=False)
-class _PinnedSlot:
-    """Pool-owned pinned staging buffer for one in-flight D2H window copy.
-
-    The event is reused across windows rather than reallocated per copy, and
-    the buffer only grows, so a steady-state stream never allocates.
-    """
-
-    buffer: torch.Tensor
-    event: torch.cuda.Event
-
-
 @dataclass
 class _PendingWindow:
     """Depth-2 pipeline slot reference held by a stream state.
 
-    The sample count is recorded at launch so the flush never has to read a
-    shape back from the device.
+    The slot's pinned buffer only grows and its completion event is reused
+    across windows, so a steady-state stream never allocates. The sample
+    count is recorded at launch so the flush never has to read a shape back
+    from the device.
     """
 
-    slot: _PinnedSlot
+    slot: PinnedTransferSlot
     samples: int
 
 
@@ -201,13 +190,13 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         self._eos_lazy_scan = self._enable_output_overlap and not self._enable_batching
         self._pipeline_active = self._eos_lazy_scan and self._device.type == "cuda"
         self._default_slot_samples = self._stream_chunk_size * self._total_upsample
-        self._pinned_free: list[_PinnedSlot] = []
+        self._pinned_free: list[PinnedTransferSlot] = []
         self._pinned_created = 0
         # Note (wenyao): a slot must have exactly one owner at any time.
         # Quarantined slots are never reused but still count against
         # _MAX_PINNED_SLOTS, so an event failure cannot inflate the cap.
-        self._pinned_retired: list[_PinnedSlot] = []
-        self._pinned_quarantined: list[_PinnedSlot] = []
+        self._pinned_retired: list[PinnedTransferSlot] = []
+        self._pinned_quarantined: list[PinnedTransferSlot] = []
 
     @property
     def _chunk_aligned_dispatch(self) -> bool:
@@ -345,7 +334,7 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         samples = int(wav.numel())
         prev_wait_ns = 0
         prev_waveform: torch.Tensor | None = None
-        slot: _PinnedSlot | None = None
+        slot: PinnedTransferSlot | None = None
         # Note (edwardzh): the first window stays synchronous so
         # time-to-first-audio is unchanged.
         if self._pipeline_active and not is_final and start > 0 and samples > 0:
@@ -395,10 +384,10 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
             # Note (edwardzh): same stream is what makes this safe — the
             # copy is ordered before any later replay, so the borrowed static
             # output cannot be overwritten while it drains.
-            slot.buffer[:samples].copy_(
+            slot.view(samples).copy_(
                 wav.reshape(-1).to(torch.float32), non_blocking=True
             )
-            slot.event.record()
+            slot.record(torch.cuda.current_stream(self._device))
             event_recorded = True
             if profile_metadata is not None:
                 _emit_event(
@@ -450,7 +439,7 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         # would hold drained audio for a whole window arrival.
         messages: list[OutgoingMessage] = []
         pending = state.pending
-        if pending is not None and pending.slot.event.query():
+        if pending is not None and pending.slot.query():
             _, waveform = self._flush_pending(request_id, state)
             if waveform is not None:
                 self._mark_stream_emitted(request_id)
@@ -469,9 +458,9 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
             return 0, None
         slot = pending.slot
         wait_start = time.monotonic_ns()
-        slot.event.synchronize()
+        slot.synchronize()
         wait_ns = time.monotonic_ns() - wait_start
-        audio = slot.buffer[: pending.samples].numpy().copy()
+        audio = slot.view(pending.samples).numpy().copy()
 
         # Note (wenyao): every operation above may raise, so the request must
         # keep owning the slot until synchronization and the host copy both
@@ -492,51 +481,36 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
             return wait_ns, None
         return wait_ns, torch.from_numpy(audio)
 
-    def _alloc_pinned(self, samples: int) -> torch.Tensor:
-        return torch.empty(samples, dtype=torch.float32, pin_memory=True)
-
-    def _acquire_slot(self, samples: int) -> _PinnedSlot | None:
+    def _acquire_slot(self, samples: int) -> PinnedTransferSlot | None:
         self._reap_retired_slots()
         if self._pinned_free:
             slot = self._pinned_free.pop()
-        elif self._pinned_created < self._MAX_PINNED_SLOTS:
-            slot = _PinnedSlot(
-                buffer=self._alloc_pinned(max(samples, self._default_slot_samples)),
-                event=torch.cuda.Event(),
-            )
-            self._pinned_created += 1
-        else:
-            return None
-        if slot.buffer.numel() < samples:
             try:
-                slot.buffer = self._alloc_pinned(samples)
+                slot.ensure_capacity(samples)
             except Exception:
-                # Note (wenyao): the popped slot is not in flight, so returning
-                # it with its original smaller buffer is safe.
+                # Note (wenyao): the popped slot is not in flight, and a failed
+                # growth keeps its original smaller buffer, so returning it to
+                # the pool is safe.
                 self._release_slot(slot)
                 raise
-        return slot
+            return slot
+        if self._pinned_created < self._MAX_PINNED_SLOTS:
+            slot = PinnedTransferSlot(
+                self._device,
+                torch.float32,
+                initial_capacity=max(samples, self._default_slot_samples),
+            )
+            self._pinned_created += 1
+            return slot
+        return None
 
-    def _release_slot(self, slot: _PinnedSlot) -> None:
+    def _release_slot(self, slot: PinnedTransferSlot) -> None:
         self._pinned_free.append(slot)
 
-    def _event_query(self, slot: _PinnedSlot) -> bool:
-        if self._device.type == "cuda":
-            with torch.cuda.device(self._device):
-                return bool(slot.event.query())
-        return bool(slot.event.query())
-
-    def _event_synchronize(self, slot: _PinnedSlot) -> None:
-        if self._device.type == "cuda":
-            with torch.cuda.device(self._device):
-                slot.event.synchronize()
-            return
-        slot.event.synchronize()
-
-    def _retire_slot(self, slot: _PinnedSlot) -> None:
+    def _retire_slot(self, slot: PinnedTransferSlot) -> None:
         self._pinned_retired.append(slot)
 
-    def _quarantine_slot(self, slot: _PinnedSlot) -> None:
+    def _quarantine_slot(self, slot: PinnedTransferSlot) -> None:
         self._pinned_quarantined.append(slot)
         self._pipeline_active = False
 
@@ -548,10 +522,10 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         """
         if not self._pinned_retired:
             return
-        still_retired: list[_PinnedSlot] = []
+        still_retired: list[PinnedTransferSlot] = []
         for slot in self._pinned_retired:
             try:
-                complete = self._event_query(slot)
+                complete = slot.query()
             except Exception:
                 logger.exception("code2wav failed to query a retired D2H copy")
                 self._quarantine_slot(slot)
@@ -764,7 +738,7 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         self._pinned_retired = []
         for slot in retired:
             try:
-                self._event_synchronize(slot)
+                slot.synchronize()
             except Exception:
                 logger.exception(
                     "code2wav failed to synchronize a retired D2H copy on shutdown"

--- a/sglang_omni/utils/cuda_staging.py
+++ b/sglang_omni/utils/cuda_staging.py
@@ -81,10 +81,17 @@ class PinnedTransferSlot:
     stream before ``record()``, so it also covers work that does not target
     this buffer. Between ``record()`` and observed completion — a
     ``synchronize()`` that returned, or a ``query()`` that reported True —
-    the owner must not grow, re-record, or reuse the buffer. There is no
-    pool, lock, or failure policy here: after a failed ``record()``,
-    ``query()``, or ``synchronize()`` the owner decides whether the slot can
-    be trusted again.
+    the owner must not grow, re-record, or reuse the buffer. A ``record()``
+    that raises leaves no recorded transfer: ``query()`` and
+    ``synchronize()`` raise until a later ``record()`` succeeds, so the
+    completion state of an earlier transfer is never reported in place of
+    the one that failed to record. The slot only sees ``record()``: a copy
+    that raised, or was enqueued without a following ``record()``, leaves
+    the previous transfer's completion state readable, so keeping such a
+    buffer out of rotation is still the owner's job. There is no pool,
+    lock, or further failure policy here: after a failed ``record()``,
+    ``query()``, or ``synchronize()`` the owner decides whether the slot
+    can be trusted again.
     """
 
     def __init__(
@@ -97,6 +104,12 @@ class PinnedTransferSlot:
         self.device = _normalize_device(device)
         self._buffer = GrowablePinnedBuffer(dtype, initial_capacity=initial_capacity)
         self._event: Any = None
+        # Note (jiannan-17): True only while the most recent ``record()``
+        # succeeded. The event object alone cannot tell "never recorded" from
+        # "the last record() raised", and CUDA reports an event whose record
+        # never happened as already complete, which would hand the owner a
+        # completion marker for a transfer that was never fenced.
+        self._recorded = False
 
     @property
     def capacity(self) -> int:
@@ -117,8 +130,14 @@ class PinnedTransferSlot:
         """Record the completion event on ``stream``.
 
         ``stream`` must live on this slot's device; the event is created on
-        first use and reused for every later ``record()``.
+        first use and reused for every later ``record()``. If this raises,
+        the slot has no recorded transfer until a later ``record()``
+        succeeds.
         """
+        # Note (jiannan-17): cleared before anything can fail, so neither a
+        # rejected stream nor a failed CUDA record can leave the previous
+        # transfer's completion state readable as this transfer's.
+        self._recorded = False
         stream_device = getattr(stream, "device", None)
         if (
             stream_device is not None
@@ -132,20 +151,33 @@ class PinnedTransferSlot:
             if self._event is None:
                 self._event = torch.cuda.Event()
             self._event.record(stream)
+        self._recorded = True
+
+    def _recorded_event(self) -> Any:
+        if not self._recorded:
+            raise RuntimeError(
+                "transfer event was not recorded: no record() has succeeded on "
+                "this slot since it was created or since its last record() raised"
+            )
+        return self._event
 
     def query(self) -> bool:
-        """Return whether the recorded event has completed, without blocking."""
-        if self._event is None:
-            raise RuntimeError("transfer event was not recorded")
+        """Return whether the recorded event has completed, without blocking.
+
+        Raises ``RuntimeError`` until a ``record()`` has succeeded.
+        """
+        event = self._recorded_event()
         with self._device_guard():
-            return bool(self._event.query())
+            return bool(event.query())
 
     def synchronize(self) -> None:
-        """Block until the recorded event has completed."""
-        if self._event is None:
-            raise RuntimeError("transfer event was not recorded")
+        """Block until the recorded event has completed.
+
+        Raises ``RuntimeError`` until a ``record()`` has succeeded.
+        """
+        event = self._recorded_event()
         with self._device_guard():
-            self._event.synchronize()
+            event.synchronize()
 
 
 __all__ = ["GrowablePinnedBuffer", "PinnedTransferSlot"]

--- a/sglang_omni/utils/cuda_staging.py
+++ b/sglang_omni/utils/cuda_staging.py
@@ -5,8 +5,9 @@ Streaming decoders copy device results into pinned host memory asynchronously
 and wait on a CUDA event before reading them back. The two classes here hold
 just the buffer and the event and carry no ownership policy: the owner
 serializes access, grows a buffer only while no asynchronous copy can still be
-using it, and must not touch a slot between ``record()`` and a successful
-``synchronize()``.
+using it, and must not touch a slot between ``record()`` and observed
+completion (a successful ``synchronize()``, or a ``query()`` that reported
+True).
 """
 
 from __future__ import annotations
@@ -78,10 +79,12 @@ class PinnedTransferSlot:
 
     The event is a completion fence for everything enqueued on the recording
     stream before ``record()``, so it also covers work that does not target
-    this buffer. Between ``record()`` and a successful ``synchronize()`` the
-    owner must not grow, re-record, or reuse the buffer. There is no pool,
-    lock, or failure policy here: after a failed ``record()`` or
-    ``synchronize()`` the owner decides whether the slot can be trusted again.
+    this buffer. Between ``record()`` and observed completion — a
+    ``synchronize()`` that returned, or a ``query()`` that reported True —
+    the owner must not grow, re-record, or reuse the buffer. There is no
+    pool, lock, or failure policy here: after a failed ``record()``,
+    ``query()``, or ``synchronize()`` the owner decides whether the slot can
+    be trusted again.
     """
 
     def __init__(
@@ -129,6 +132,13 @@ class PinnedTransferSlot:
             if self._event is None:
                 self._event = torch.cuda.Event()
             self._event.record(stream)
+
+    def query(self) -> bool:
+        """Return whether the recorded event has completed, without blocking."""
+        if self._event is None:
+            raise RuntimeError("transfer event was not recorded")
+        with self._device_guard():
+            return bool(self._event.query())
 
     def synchronize(self) -> None:
         """Block until the recorded event has completed."""

--- a/sglang_omni/utils/cuda_staging.py
+++ b/sglang_omni/utils/cuda_staging.py
@@ -77,21 +77,12 @@ class GrowablePinnedBuffer:
 class PinnedTransferSlot:
     """One growable pinned host buffer plus one reusable CUDA event.
 
-    The event is a completion fence for everything enqueued on the recording
-    stream before ``record()``, so it also covers work that does not target
-    this buffer. Between ``record()`` and observed completion — a
-    ``synchronize()`` that returned, or a ``query()`` that reported True —
-    the owner must not grow, re-record, or reuse the buffer. A ``record()``
-    that raises leaves no recorded transfer: ``query()`` and
-    ``synchronize()`` raise until a later ``record()`` succeeds, so the
-    completion state of an earlier transfer is never reported in place of
-    the one that failed to record. The slot only sees ``record()``: a copy
-    that raised, or was enqueued without a following ``record()``, leaves
-    the previous transfer's completion state readable, so keeping such a
-    buffer out of rotation is still the owner's job. There is no pool,
-    lock, or further failure policy here: after a failed ``record()``,
-    ``query()``, or ``synchronize()`` the owner decides whether the slot
-    can be trusted again.
+    The event fences work queued before ``record()``. Do not resize or reuse
+    the buffer until ``synchronize()`` returns or ``query()`` reports True.
+
+    If ``record()`` raises, completion reads fail until a later ``record()``
+    succeeds. Copy failures before ``record()`` remain the owner's
+    responsibility.
     """
 
     def __init__(

--- a/tests/README.md
+++ b/tests/README.md
@@ -475,9 +475,13 @@ that happened to contain an older version of the test.
     and mono/channel preservation.
   - pinned CUDA staging primitives (`cuda_staging`): exact-size growth that
     keeps the old storage on allocation failure, allocation outside inference
-    mode, one reusable completion event per transfer slot, and record/sync
-    error propagation with same-device stream checks, using CPU stand-ins
-    where no GPU is present.
+    mode, one reusable completion event per transfer slot, the non-blocking
+    completion probe, record/query/sync error propagation with same-device
+    stream checks, and the failed-record contract (a slot whose first or
+    repeated `record()` raised refuses `query()`/`synchronize()` instead of
+    reporting the unrecorded event as complete), using CPU stand-ins where no
+    GPU is present; the `accelerator`-marked cases observe a real in-flight
+    D2H copy through `query()` and drive a slot on `cuda:1` from `cuda:0`.
 - `unit_test/model_runner/`: Shared model-runner contract tests:
   - arch override pool sizing: a sub-model engine's KV pool takes the
     sub-model's layer count through SGLang's layer resolver (the Qwen3-Omni
@@ -613,7 +617,15 @@ that happened to contain an older version of the test.
     identity against the synchronous path, first-window sync cadence,
     stream-done pending flush, lazy batched EOS scanning, pinned-slot pool
     lifecycle across abort/replay-failure/exhaustion, and profiler event
-    shape; the `accelerator`-marked case runs real pinned buffers and CUDA events
+    shape; the `accelerator`-marked cases run real pinned buffers and CUDA
+    events: byte identity with CUDA graphs on and off at the 20/30-frame
+    boundaries and the 21/31-frame tails (every threshold window replays its
+    graph key, only the stream-done tail runs eagerly, and window 3 replays
+    the key whose static output window 2's pending copy reads from), the
+    completion probe against an in-flight copy, mid-stream abort without
+    blocking or early slot reuse even after a same-key replay rewrote the
+    copy's source, and a scheduler on `cuda:1` warmed, probed, flushed,
+    reaped and drained from `cuda:0`
   - logit-shaping helpers (e.g. repetition penalty) numerical equivalence with the original per-row scalar formulas.
   - Thinker prefill contracts: `OmniPrefillInputs` adoption for text and
     audio-input → text-output prefills, whole-batch fail-closed qualification,
@@ -826,5 +838,7 @@ that happened to contain an older version of the test.
   installer rollback, interrupted-run recovery, and lock serialization. No
   accelerator is required.
 
-- `unit_test/fixtures/`: Shared fakes. Single-test
-  helpers should stay local until a second test needs them.
+- `unit_test/fixtures/`: Shared fakes, plus the runtime accelerator probe
+  (`accelerator.py`, `require_cuda(min_devices)`) that `accelerator`-marked
+  tests call in the test body. Single-test helpers should stay local until a
+  second test needs them.

--- a/tests/README.md
+++ b/tests/README.md
@@ -473,15 +473,11 @@ that happened to contain an older version of the test.
 - `unit_test/utils/`: Shared utility tests:
   - audio loading helpers for data URIs, file URIs, HTTP URLs, timeout fallback,
     and mono/channel preservation.
-  - pinned CUDA staging primitives (`cuda_staging`): exact-size growth that
-    keeps the old storage on allocation failure, allocation outside inference
-    mode, one reusable completion event per transfer slot, the non-blocking
-    completion probe, record/query/sync error propagation with same-device
-    stream checks, and the failed-record contract (a slot whose first or
-    repeated `record()` raised refuses `query()`/`synchronize()` instead of
-    reporting the unrecorded event as complete), using CPU stand-ins where no
-    GPU is present; the `accelerator`-marked cases observe a real in-flight
-    D2H copy through `query()` and drive a slot on `cuda:1` from `cuda:0`.
+  - pinned CUDA staging primitives (`cuda_staging`): exact-size growth,
+    reusable events, non-blocking completion queries, device checks, and
+    record/query/synchronize failure handling. Failed records invalidate
+    completion reads until a later record succeeds. CPU tests use stand-ins;
+    `accelerator` cases cover in-flight D2H queries and cross-device use.
 - `unit_test/model_runner/`: Shared model-runner contract tests:
   - arch override pool sizing: a sub-model engine's KV pool takes the
     sub-model's layer count through SGLang's layer resolver (the Qwen3-Omni
@@ -613,19 +609,11 @@ that happened to contain an older version of the test.
     ```bash
     pytest tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py -m accelerator -q
     ```
-  - Code2Wav output overlap (depth-2 pipelined D2H): message-for-message byte
-    identity against the synchronous path, first-window sync cadence,
-    stream-done pending flush, lazy batched EOS scanning, pinned-slot pool
-    lifecycle across abort/replay-failure/exhaustion, and profiler event
-    shape; the `accelerator`-marked cases run real pinned buffers and CUDA
-    events: byte identity with CUDA graphs on and off at the 20/30-frame
-    boundaries and the 21/31-frame tails (every threshold window replays its
-    graph key, only the stream-done tail runs eagerly, and window 3 replays
-    the key whose static output window 2's pending copy reads from), the
-    completion probe against an in-flight copy, mid-stream abort without
-    blocking or early slot reuse even after a same-key replay rewrote the
-    copy's source, and a scheduler on `cuda:1` warmed, probed, flushed,
-    reaped and drained from `cuda:0`
+  - Code2Wav output overlap (depth-2 pipelined D2H): byte parity with the
+    synchronous path, first-window and stream-done behavior, CUDA Graph replay,
+    and slot lifecycle across abort and failure paths. The `accelerator` cases
+    cover real pinned buffers and events, eager/graph parity, in-flight
+    completion queries, abort recovery, and cross-device use.
   - logit-shaping helpers (e.g. repetition penalty) numerical equivalence with the original per-row scalar formulas.
   - Thinker prefill contracts: `OmniPrefillInputs` adoption for text and
     audio-input → text-output prefills, whole-batch fail-closed qualification,

--- a/tests/unit_test/fixtures/accelerator.py
+++ b/tests/unit_test/fixtures/accelerator.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime accelerator probes for ``accelerator``-marked tests.
+
+Probed in the test body, not at collection time, so the marker still assigns
+the test to the accelerator CI job (see tests/README.md).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+
+def require_cuda(min_devices: int = 1) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is unavailable")
+    if torch.cuda.device_count() < min_devices:
+        pytest.skip(f"requires {min_devices} visible CUDA devices")

--- a/tests/unit_test/qwen3_omni/test_code2wav_overlap.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_overlap.py
@@ -389,11 +389,14 @@ def test_overlap_record_failure_quarantines_current_slot(monkeypatch) -> None:
     with pytest.raises(RuntimeError, match="event record failed"):
         _feed(scheduler, "req-1", range(10, 20))
 
-    # Note (jiannan-17): the failing event was recorded exactly once and the
-    # only slot in existence went to quarantine, so the identity link holds
-    # without reaching into the slot's lazily created event.
+    # Note (jiannan-17): only one slot was ever created and it sits in
+    # quarantine with every other pool empty, so the quarantined slot is
+    # necessarily the one whose record failed — no need to reach into the
+    # slot's lazily created event.
     assert event.record_calls == 1
+    assert scheduler._pinned_created == 1
     assert len(scheduler._pinned_quarantined) == 1
+    assert scheduler._pinned_retired == []
     assert scheduler._pinned_free == []
     assert scheduler._pipeline_active is False
 

--- a/tests/unit_test/qwen3_omni/test_code2wav_overlap.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_overlap.py
@@ -27,6 +27,8 @@ from sglang_omni.models.qwen3_omni.components.code2wav_scheduler import (
 )
 from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.scheduling.messages import IncomingMessage
+from sglang_omni.utils import cuda_staging
+from sglang_omni.utils.cuda_staging import PinnedTransferSlot
 from tests.unit_test.fixtures.qwen_fakes import FakeCode2WavModel, make_qwen_payload
 
 
@@ -42,7 +44,7 @@ class _FakeEvent:
         self.query_calls = 0
         self.record_calls = 0
 
-    def record(self) -> None:
+    def record(self, stream=None) -> None:
         self.record_calls += 1
         if self.record_error is not None:
             raise self.record_error
@@ -58,6 +60,12 @@ class _FakeEvent:
         if self.sync_error is not None:
             raise self.sync_error
         self.complete = True
+
+
+def _slot_event(slot: PinnedTransferSlot) -> _FakeEvent:
+    """The slot's lazily created completion event — a _FakeEvent once
+    _force_pipeline ran; tests drive completion and failures through it."""
+    return slot._event
 
 
 class _DeviceFakeModel(FakeCode2WavModel):
@@ -115,11 +123,12 @@ def _force_pipeline(scheduler: Code2WavScheduler, monkeypatch) -> None:
     """Enable the CUDA-only pipeline branch on a CPU scheduler."""
     scheduler._pipeline_active = True
     monkeypatch.setattr(
-        scheduler,
-        "_alloc_pinned",
-        lambda samples: torch.empty(samples, dtype=torch.float32),
+        cuda_staging,
+        "_allocate_pinned",
+        lambda numel, dtype: torch.empty(numel, dtype=dtype),
     )
     monkeypatch.setattr(torch.cuda, "Event", _FakeEvent)
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda device=None: None)
 
 
 def _seed(scheduler: Code2WavScheduler, request_id: str = "req-1") -> None:
@@ -263,7 +272,7 @@ def test_overlap_flush_failure_keeps_pending_owned_until_abort(monkeypatch) -> N
     state = scheduler._stream_states["req-1"]
     pending = state.pending
     assert pending is not None
-    event = pending.slot.event
+    event = _slot_event(pending.slot)
     event.complete = False
     event.sync_error = RuntimeError("D2H synchronization failed")
 
@@ -289,7 +298,7 @@ def test_overlap_abort_retires_inflight_slot_without_synchronizing(monkeypatch) 
     state = scheduler._stream_states["req-1"]
     pending = state.pending
     assert pending is not None
-    event = pending.slot.event
+    event = _slot_event(pending.slot)
     event.complete = False
     event.sync_error = AssertionError("abort must not synchronize")
 
@@ -309,11 +318,11 @@ def test_overlap_acquire_reaps_completed_retired_slot(monkeypatch) -> None:
     pending = scheduler._stream_states["req-1"].pending
     assert pending is not None
     slot = pending.slot
-    slot.event.complete = False
+    _slot_event(slot).complete = False
     scheduler.abort("req-1")
 
-    slot.event.complete = True
-    acquired = scheduler._acquire_slot(slot.buffer.numel())
+    _slot_event(slot).complete = True
+    acquired = scheduler._acquire_slot(slot.capacity)
 
     assert acquired is slot
     assert scheduler._pinned_retired == []
@@ -329,7 +338,7 @@ def test_overlap_query_failure_quarantines_slot(monkeypatch, caplog) -> None:
     pending = scheduler._stream_states["req-1"].pending
     assert pending is not None
     slot = pending.slot
-    slot.event.query_error = RuntimeError("event query failed")
+    _slot_event(slot).query_error = RuntimeError("event query failed")
     scheduler.abort("req-1")
 
     scheduler._reap_retired_slots()
@@ -350,8 +359,8 @@ def test_overlap_previous_flush_failure_keeps_both_slots_owned(monkeypatch) -> N
     state = scheduler._stream_states["req-1"]
     previous = state.pending
     assert previous is not None
-    previous.slot.event.complete = False
-    previous.slot.event.sync_error = RuntimeError("previous flush failed")
+    _slot_event(previous.slot).complete = False
+    _slot_event(previous.slot).sync_error = RuntimeError("previous flush failed")
 
     with pytest.raises(RuntimeError, match="previous flush failed"):
         _feed(scheduler, "req-1", range(20, 30))
@@ -360,7 +369,7 @@ def test_overlap_previous_flush_failure_keeps_both_slots_owned(monkeypatch) -> N
     assert len(scheduler._pinned_retired) == 1
     current_slot = scheduler._pinned_retired[0]
     assert current_slot is not previous.slot
-    assert current_slot.event.record_calls == 1
+    assert _slot_event(current_slot).record_calls == 1
 
     scheduler.abort("req-1")
     assert previous.slot in scheduler._pinned_retired
@@ -380,8 +389,11 @@ def test_overlap_record_failure_quarantines_current_slot(monkeypatch) -> None:
     with pytest.raises(RuntimeError, match="event record failed"):
         _feed(scheduler, "req-1", range(10, 20))
 
+    # Note (jiannan-17): the failing event was recorded exactly once and the
+    # only slot in existence went to quarantine, so the identity link holds
+    # without reaching into the slot's lazily created event.
+    assert event.record_calls == 1
     assert len(scheduler._pinned_quarantined) == 1
-    assert scheduler._pinned_quarantined[0].event is event
     assert scheduler._pinned_free == []
     assert scheduler._pipeline_active is False
 
@@ -393,13 +405,13 @@ def test_overlap_slot_growth_failure_returns_original_free_slot(monkeypatch) -> 
     assert slot is not None
     scheduler._release_slot(slot)
 
-    def _fail_alloc(samples: int) -> torch.Tensor:
-        raise RuntimeError(f"cannot grow to {samples}")
+    def _fail_alloc(numel: int, dtype: torch.dtype) -> torch.Tensor:
+        raise RuntimeError(f"cannot grow to {numel}")
 
-    monkeypatch.setattr(scheduler, "_alloc_pinned", _fail_alloc)
+    monkeypatch.setattr(cuda_staging, "_allocate_pinned", _fail_alloc)
 
     with pytest.raises(RuntimeError, match="cannot grow"):
-        scheduler._acquire_slot(slot.buffer.numel() + 1)
+        scheduler._acquire_slot(slot.capacity + 1)
 
     assert scheduler._pinned_free == [slot]
     assert scheduler._pinned_created == 1
@@ -413,12 +425,12 @@ def test_overlap_flush_synchronizes_before_releasing_slot(monkeypatch) -> None:
 
     pending = scheduler._stream_states["req-1"].pending
     assert pending is not None
-    event = pending.slot.event
+    event = _slot_event(pending.slot)
 
     release_slot = scheduler._release_slot
 
     def _release_after_synchronize(slot) -> None:
-        assert slot.event.synchronize_calls == 1
+        assert _slot_event(slot).synchronize_calls == 1
         release_slot(slot)
 
     monkeypatch.setattr(scheduler, "_release_slot", _release_after_synchronize)
@@ -493,7 +505,7 @@ def test_overlap_replay_failure_with_pending_aborts_and_releases(monkeypatch) ->
     assert [message.type for message in messages] == ["stream", "stream", "error"]
     assert scheduler._pinned_retired == []
     assert len(scheduler._pinned_free) == 1
-    assert scheduler._pinned_free[0].event.query_calls >= 1
+    assert _slot_event(scheduler._pinned_free[0]).query_calls >= 1
 
 
 def test_overlap_pool_exhaustion_falls_back_sync_per_window(monkeypatch) -> None:

--- a/tests/unit_test/qwen3_omni/test_code2wav_overlap.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_overlap.py
@@ -5,7 +5,11 @@ The depth-2 pipeline is CUDA-only in production, so CPU tests force it on and
 stub the pinned allocation and CUDA event to reach every branch device-free.
 Byte-identity tests always compare against a kill-switch control scheduler fed
 the identical stream, so a drift in the shared code shows up as a failure in
-both arms rather than a false pass.
+both arms rather than a false pass. The ``accelerator``-marked cases run real
+pinned buffers and CUDA events: byte identity with CUDA graphs on and off at
+both window boundaries, the non-blocking completion probe against an in-flight
+copy, mid-stream abort, and a slot living on a device other than the
+process-current one.
 """
 
 from __future__ import annotations
@@ -19,6 +23,7 @@ import torch
 
 from sglang_omni.models.qwen3_omni.components import code2wav_scheduler
 from sglang_omni.models.qwen3_omni.components.code2wav_cuda_graph import (
+    Code2WavCudaGraphRunner,
     Code2WavRunResult,
     GraphKey,
 )
@@ -29,6 +34,7 @@ from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.scheduling.messages import IncomingMessage
 from sglang_omni.utils import cuda_staging
 from sglang_omni.utils.cuda_staging import PinnedTransferSlot
+from tests.unit_test.fixtures.accelerator import require_cuda
 from tests.unit_test.fixtures.qwen_fakes import FakeCode2WavModel, make_qwen_payload
 
 
@@ -63,8 +69,8 @@ class _FakeEvent:
 
 
 def _slot_event(slot: PinnedTransferSlot) -> _FakeEvent:
-    """The slot's lazily created completion event — a _FakeEvent once
-    _force_pipeline ran; tests drive completion and failures through it."""
+    """Return the slot's lazily created completion event (a _FakeEvent after
+    _force_pipeline); tests drive completion and failures through it."""
     return slot._event
 
 
@@ -81,6 +87,109 @@ class _DeviceFakeModel(FakeCode2WavModel):
             )
             + base
         )
+
+
+class _SlowDeviceFakeModel(_DeviceFakeModel):
+    """_DeviceFakeModel that queues ~0.5 s of device work ahead of its output,
+    so the D2H copy fenced behind it is observably in flight (GPU tests).
+
+    The probes that rely on it run with no CUDA call between the launch and
+    the probe, so only a host stall of that order could let the copy drain
+    first.
+    """
+
+    def __call__(self, codes: torch.Tensor) -> torch.Tensor:
+        torch.cuda._sleep(1_000_000_000)
+        return super().__call__(codes)
+
+
+class _DeviceFakeModule(torch.nn.Module):
+    """CUDA-graph-capturable twin of _DeviceFakeModel (GPU tests)."""
+
+    total_upsample = 2
+
+    def forward(self, codes: torch.Tensor) -> torch.Tensor:
+        samples = int(codes.shape[-1]) * self.total_upsample
+        base = codes.to(dtype=torch.float32).flatten(1).sum(dim=1).view(-1, 1, 1)
+        return (
+            torch.arange(samples, dtype=torch.float32, device=codes.device).view(
+                1, 1, samples
+            )
+            + base
+        )
+
+
+class _SlowDeviceFakeModule(_DeviceFakeModule):
+    """_DeviceFakeModule whose replay queues ~0.5 s of device work first; the
+    spin is an ordinary kernel, so it is captured and replayed with the graph."""
+
+    def forward(self, codes: torch.Tensor) -> torch.Tensor:
+        torch.cuda._sleep(1_000_000_000)
+        return super().forward(codes)
+
+
+def _make_gpu_scheduler(
+    *,
+    overlap: bool,
+    device: torch.device,
+    model: FakeCode2WavModel | torch.nn.Module | None = None,
+    cuda_graph: bool = False,
+    slow: bool = False,
+) -> Code2WavScheduler:
+    """Real-CUDA scheduler: real pinned buffers, real events, optionally a
+    real graph runner over the serving-reachable serial keys."""
+    if model is None:
+        if cuda_graph:
+            module = _SlowDeviceFakeModule() if slow else _DeviceFakeModule()
+            model = module.to(device).eval()
+        else:
+            model = (
+                _SlowDeviceFakeModel(total_upsample=2)
+                if slow
+                else _DeviceFakeModel(total_upsample=2)
+            )
+    runner = None
+    if cuda_graph:
+        runner = Code2WavCudaGraphRunner.build(
+            model,
+            device=device,
+            num_quantizers=2,
+            total_gpu_memory_fraction=1.0,
+            graph_keys=code2wav_scheduler._serial_threshold_graph_keys(10, 1),
+        )
+        assert runner.stats()["enabled"] is True
+    scheduler = Code2WavScheduler(
+        model,
+        device=str(device),
+        stream_chunk_size=10,
+        left_context_size=1,
+        enable_output_overlap=overlap,
+        enable_cuda_graph=cuda_graph,
+        _cuda_graph_runner=runner,
+    )
+    assert scheduler._pipeline_active is overlap
+    if overlap:
+        # Note (jiannan-17): allocate the steady-state slot up front so no
+        # pinned allocation (cudaHostAlloc may synchronize the device) sits
+        # between the queued device work and the fenced copy the probe tests
+        # observe. Pool counts are unchanged: the window reuses this slot.
+        scheduler._release_slot(
+            scheduler._acquire_slot(scheduler._default_slot_samples)
+        )
+    return scheduler
+
+
+def _stage_chunks(device: torch.device, n_chunks: int) -> list[torch.Tensor]:
+    """Frames already on ``device`` for the GPU probe tests.
+
+    ``validate_chunk`` moves every frame with a blocking ``.to(device)``; from
+    pageable memory that is cudaMemcpyAsync plus cudaStreamSynchronize on the
+    decode stream, which would drain the in-flight D2H copy before the probe
+    runs. Device-resident frames make the probing feeds enqueue nothing.
+    """
+    chunks = [_chunk(i).to(device) for i in range(n_chunks)]
+    torch.cuda.synchronize(device)
+    return chunks
 
 
 def _activate_event_capture(monkeypatch) -> list[dict]:
@@ -119,8 +228,12 @@ def _make_scheduler(
     )
 
 
-def _force_pipeline(scheduler: Code2WavScheduler, monkeypatch) -> None:
-    """Enable the CUDA-only pipeline branch on a CPU scheduler."""
+def _force_pipeline(scheduler: Code2WavScheduler, monkeypatch) -> list:
+    """Enable the CUDA-only pipeline branch on a CPU scheduler.
+
+    Returns the list of devices the launch asked ``torch.cuda.current_stream``
+    for, one entry per pipelined window.
+    """
     scheduler._pipeline_active = True
     monkeypatch.setattr(
         cuda_staging,
@@ -128,7 +241,14 @@ def _force_pipeline(scheduler: Code2WavScheduler, monkeypatch) -> None:
         lambda numel, dtype: torch.empty(numel, dtype=dtype),
     )
     monkeypatch.setattr(torch.cuda, "Event", _FakeEvent)
-    monkeypatch.setattr(torch.cuda, "current_stream", lambda device=None: None)
+    stream_devices: list = []
+
+    def current_stream(device=None):
+        stream_devices.append(device)
+        return None
+
+    monkeypatch.setattr(torch.cuda, "current_stream", current_stream)
+    return stream_devices
 
 
 def _seed(scheduler: Code2WavScheduler, request_id: str = "req-1") -> None:
@@ -146,11 +266,13 @@ def _feed(
     indices: range,
     *,
     stream: bool = True,
+    chunks: list[torch.Tensor] | None = None,
 ) -> None:
     for i in indices:
+        codes = _chunk(i) if chunks is None else chunks[i]
         scheduler._on_chunk(
             request_id,
-            StreamItem(i, _chunk(i), "talker", metadata={"stream": stream}),
+            StreamItem(i, codes, "talker", metadata={"stream": stream}),
         )
 
 
@@ -234,17 +356,22 @@ def test_overlap_first_window_sync_second_deferred(monkeypatch) -> None:
     control = _run_stream(overlap=False, n_chunks=30)
 
     scheduler = _make_scheduler(overlap=True)
-    _force_pipeline(scheduler, monkeypatch)
+    stream_devices = _force_pipeline(scheduler, monkeypatch)
     _seed(scheduler)
 
     _feed(scheduler, "req-1", range(10))
     assert scheduler.outbox.qsize() == 1  # first window emits synchronously
+    assert stream_devices == []
 
     _feed(scheduler, "req-1", range(10, 20))
     assert scheduler.outbox.qsize() == 1  # second window launched, deferred
+    # Note (jiannan-17): the fence must be recorded on the scheduler device's
+    # stream, not the thread-current device's.
+    assert stream_devices == [scheduler._device]
 
     _feed(scheduler, "req-1", range(20, 30))
     assert scheduler.outbox.qsize() == 2  # third launch flushed window 2
+    assert stream_devices == [scheduler._device] * 2
 
     scheduler._on_done("req-1")
     snapshot = _drain_snapshot(scheduler)
@@ -389,16 +516,77 @@ def test_overlap_record_failure_quarantines_current_slot(monkeypatch) -> None:
     with pytest.raises(RuntimeError, match="event record failed"):
         _feed(scheduler, "req-1", range(10, 20))
 
-    # Note (jiannan-17): only one slot was ever created and it sits in
-    # quarantine with every other pool empty, so the quarantined slot is
-    # necessarily the one whose record failed — no need to reach into the
-    # slot's lazily created event.
+    # Note (jiannan-17): only one slot was ever created and every other pool
+    # is empty, so the pool counts alone pin the quarantined slot's identity;
+    # the event check makes it explicit.
     assert event.record_calls == 1
     assert scheduler._pinned_created == 1
     assert len(scheduler._pinned_quarantined) == 1
+    assert _slot_event(scheduler._pinned_quarantined[0]) is event
     assert scheduler._pinned_retired == []
     assert scheduler._pinned_free == []
     assert scheduler._pipeline_active is False
+    assert scheduler._stream_states["req-1"].pending is None
+    # Note (jiannan-17): the shared slot backs the quarantine up — even if the
+    # slot leaked out, it refuses to report a completion for the copy whose
+    # record failed instead of returning the never-recorded event's True.
+    with pytest.raises(RuntimeError, match="not recorded"):
+        scheduler._pinned_quarantined[0].query()
+
+
+def test_overlap_rerecord_failure_on_reused_slot_quarantines_it(monkeypatch) -> None:
+    """A slot that already completed a window is popped from the free pool
+    and its second record() raises: it is quarantined and refuses completion
+    reads, while the other slot's pending window still flushes."""
+    control = _run_stream(overlap=False, n_chunks=40)
+
+    scheduler = _make_scheduler(overlap=True)
+    _force_pipeline(scheduler, monkeypatch)
+    _seed(scheduler)
+    state_lookup = scheduler._stream_states
+
+    _feed(scheduler, "req-1", range(20))  # window 2 pipelined on slot A
+    first = state_lookup["req-1"].pending
+    assert first is not None
+    slot_a = first.slot
+    # Note (jiannan-17): keep each copy "in flight" until the next launch
+    # flushes it, as on a real device; the fake completes on synchronize().
+    _slot_event(slot_a).complete = False
+    _feed(scheduler, "req-1", range(20, 30))  # window 3 on slot B, A flushed
+    second = state_lookup["req-1"].pending
+    assert second is not None and second.slot is not slot_a
+    slot_b = second.slot
+    _slot_event(slot_b).complete = False
+    assert scheduler._pinned_free == [slot_a]
+    assert scheduler._pinned_created == 2
+    assert _slot_event(slot_a).record_calls == 1
+    assert _slot_event(slot_a).synchronize_calls == 1
+
+    _slot_event(slot_a).record_error = RuntimeError("event record failed")
+    with pytest.raises(RuntimeError, match="event record failed"):
+        _feed(scheduler, "req-1", range(30, 40))  # window 4 pops A again
+
+    assert _slot_event(slot_a).record_calls == 2
+    assert scheduler._pinned_quarantined == [slot_a]
+    assert scheduler._pinned_free == []
+    assert scheduler._pinned_retired == []
+    assert scheduler._pinned_created == 2
+    assert scheduler._pipeline_active is False
+    assert state_lookup["req-1"].pending is second, "window 3 is still owned"
+    # Note (jiannan-17): the fake event says True for the completed window 2
+    # transfer, which is exactly what the slot must not report for the copy
+    # whose record failed.
+    assert _slot_event(slot_a).complete is True
+    with pytest.raises(RuntimeError, match="not recorded"):
+        slot_a.query()
+    with pytest.raises(RuntimeError, match="not recorded"):
+        slot_a.synchronize()
+
+    scheduler._on_done("req-1")
+    assert scheduler._pinned_free == [slot_b]
+    snapshot = _drain_snapshot(scheduler)
+    assert [item[1] for item in snapshot] == ["stream"] * 4 + ["result"]
+    assert snapshot == control
 
 
 def test_overlap_slot_growth_failure_returns_original_free_slot(monkeypatch) -> None:
@@ -727,30 +915,261 @@ def test_overlap_borrowed_output_copied_before_next_replay(monkeypatch) -> None:
 
 
 @pytest.mark.accelerator
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
-def test_overlap_gpu_real_pinned_event_bitwise() -> None:
+@pytest.mark.parametrize("cuda_graph", [False, True], ids=["eager", "cuda_graph"])
+@pytest.mark.parametrize(
+    ("n_chunks", "expected_types"),
+    [
+        # Note (edwardzh): boundary-exact end is where a naive impl
+        # silently drops the pending window.
+        (20, ["stream", "stream", "result"]),
+        # Note (edwardzh): pending and tail must not merge.
+        (21, ["stream", "stream", "stream", "result"]),
+        # Note (jiannan-17): window 3 replays the same graph key whose static
+        # output window 2's pending copy reads from; same-stream ordering is
+        # what keeps the bytes identical.
+        (30, ["stream", "stream", "stream", "result"]),
+        (31, ["stream", "stream", "stream", "stream", "result"]),
+    ],
+)
+def test_overlap_gpu_real_pinned_event_bitwise(
+    cuda_graph: bool, n_chunks: int, expected_types: list[str]
+) -> None:
+    require_cuda()
+    # Note (edwardzh): bare cuda has no index; only the factory normalizes it.
+    device = torch.device("cuda", torch.cuda.current_device())
+
     def _run(*, overlap: bool) -> list[tuple]:
-        # Note (edwardzh): bare cuda has no index; only the factory
-        # normalizes it.
-        scheduler = Code2WavScheduler(
-            _DeviceFakeModel(total_upsample=2),
-            device=f"cuda:{torch.cuda.current_device()}",
-            stream_chunk_size=10,
-            left_context_size=1,
-            enable_output_overlap=overlap,
+        scheduler = _make_gpu_scheduler(
+            overlap=overlap, device=device, cuda_graph=cuda_graph
         )
-        assert scheduler._pipeline_active is overlap
         _seed(scheduler)
-        _feed(scheduler, "req-1", range(21))
+        _feed(scheduler, "req-1", range(n_chunks))
         scheduler._on_done("req-1")
+        if cuda_graph:
+            runtime = scheduler._cuda_graph_runner.stats()["runtime"]
+            # Note (jiannan-17): every threshold window replays; only the
+            # stream-done tail runs eagerly.
+            assert runtime["graph_replays"] == n_chunks // 10
+            assert runtime["replay_failures"] == 0
+            assert runtime["fallback_counts"] == (
+                {"ineligible": 1} if n_chunks % 10 else {}
+            ), "only the stream-done tail may run eagerly"
         return _drain_snapshot(scheduler)
 
     overlap_snapshot = _run(overlap=True)
     sync_snapshot = _run(overlap=False)
     assert overlap_snapshot == sync_snapshot
-    assert [item[1] for item in overlap_snapshot] == [
-        "stream",
-        "stream",
-        "stream",
-        "result",
-    ]
+    assert [item[1] for item in overlap_snapshot] == expected_types
+
+
+@pytest.mark.accelerator
+def test_overlap_gpu_query_is_false_until_inflight_copy_drains() -> None:
+    """The per-frame probe reports False while the fenced D2H copy is still
+    queued behind device work, True once it drained, and the drained window is
+    emitted by the next chunk without a further dispatch."""
+    require_cuda()
+    device = torch.device("cuda", torch.cuda.current_device())
+    chunks = _stage_chunks(device, 22)
+    control = _make_gpu_scheduler(
+        overlap=False, device=device, model=_SlowDeviceFakeModel(total_upsample=2)
+    )
+    _seed(control)
+    _feed(control, "req-1", range(22), chunks=chunks)
+    control._on_done("req-1")
+    control_snapshot = _drain_snapshot(control)
+
+    scheduler = _make_gpu_scheduler(
+        overlap=True, device=device, model=_SlowDeviceFakeModel(total_upsample=2)
+    )
+    _seed(scheduler)
+    _feed(scheduler, "req-1", range(20), chunks=chunks)
+    state = scheduler._stream_states["req-1"]
+    pending = state.pending
+    assert pending is not None
+    assert pending.slot.device == device
+    assert pending.slot.view(pending.samples).is_pinned()
+    assert pending.slot.query() is False
+    first_window = _drain_snapshot(scheduler)
+    assert [item[1] for item in first_window] == ["stream"]
+
+    # Note (jiannan-17): a chunk that does not complete a window still probes;
+    # the copy is behind ~0.5 s of device work, so it must not flush yet.
+    _feed(scheduler, "req-1", range(20, 21), chunks=chunks)
+    assert state.pending is pending
+    assert scheduler.outbox.qsize() == 0
+
+    pending.slot.synchronize()
+    assert pending.slot.query() is True
+    assert state.pending is pending, "observing completion is not a flush"
+
+    # The next chunk's probe reports True and flushes without a dispatch.
+    _feed(scheduler, "req-1", range(21, 22), chunks=chunks)
+    assert state.pending is None
+    second_window = _drain_snapshot(scheduler)
+    assert [item[1] for item in second_window] == ["stream"]
+    assert scheduler._pinned_retired == []
+    assert scheduler._pinned_free == [pending.slot]
+
+    scheduler._on_done("req-1")
+    tail = _drain_snapshot(scheduler)
+    assert [item[1] for item in tail] == ["stream", "result"]
+    assert [*first_window, *second_window, *tail] == control_snapshot
+
+
+@pytest.mark.accelerator
+@pytest.mark.parametrize("cuda_graph", [False, True], ids=["eager", "cuda_graph"])
+def test_overlap_gpu_abort_midstream_neither_blocks_nor_reuses_inflight_slot(
+    cuda_graph: bool,
+) -> None:
+    """Abort with a copy in flight returns without waiting, keeps the slot out
+    of rotation until the copy drains, and the drained bytes are intact even
+    after a later replay rewrote the graph output the copy was reading."""
+    require_cuda()
+    device = torch.device("cuda", torch.cuda.current_device())
+    chunks = _stage_chunks(device, 31)
+    control = _make_gpu_scheduler(overlap=False, device=device, cuda_graph=cuda_graph)
+    _seed(control)
+    _feed(control, "req-1", range(20), chunks=chunks)
+    control._on_done("req-1")
+    expected_window_2 = np.frombuffer(
+        _drain_snapshot(control)[1][2], dtype=np.float32
+    ).copy()
+
+    scheduler = _make_gpu_scheduler(
+        overlap=True, device=device, cuda_graph=cuda_graph, slow=True
+    )
+    _seed(scheduler)
+    _feed(scheduler, "req-1", range(20), chunks=chunks)
+    state = scheduler._stream_states["req-1"]
+    pending = state.pending
+    assert pending is not None
+    slot = pending.slot
+    assert slot.query() is False
+
+    scheduler.abort("req-1")
+
+    # Note (jiannan-17): a synchronizing abort would have drained the copy, so
+    # the probe still reporting False is the proof that it did not block.
+    assert slot.query() is False
+    assert state.pending is None
+    assert "req-1" not in scheduler._stream_states
+    assert scheduler._pinned_retired == [slot]
+    assert scheduler._pinned_free == []
+
+    # Note (jiannan-17): another window on the same graph key rewrites the
+    # static output the retired copy reads from; the copy was enqueued first
+    # on the same stream, so it must still land with window 2's bytes. This
+    # runs before any pinned allocation so the probe stays CUDA-call-free.
+    window = torch.stack(chunks[19:30], dim=0).transpose(0, 1).unsqueeze(0)
+    _, execution = scheduler._forward_codes(window, graph_eligible=True)
+    assert execution["execution_mode"] == ("cuda_graph" if cuda_graph else "eager")
+    assert slot.query() is False, "the replay queues behind the copy, not before"
+
+    # The in-flight slot is not handed out; a second slot is created instead
+    # (the reap runs before the allocation, so this holds even if the pinned
+    # allocation synchronizes the device).
+    other = scheduler._acquire_slot(pending.samples)
+    assert other is not None and other is not slot
+    assert scheduler._pinned_created == 2
+    assert scheduler._pinned_retired == [slot]
+    scheduler._release_slot(other)
+
+    slot.synchronize()
+    assert slot.query() is True
+    assert np.array_equal(
+        slot.view(pending.samples).numpy(), expected_window_2
+    ), "the retired copy landed intact; nothing overwrote the buffer early"
+
+    reaped = scheduler._acquire_slot(pending.samples)
+    assert reaped is slot
+    assert scheduler._pinned_retired == []
+    assert scheduler._pinned_quarantined == []
+    assert scheduler._pinned_created == 2
+    scheduler._release_slot(reaped)
+    assert sorted(map(id, scheduler._pinned_free)) == sorted(map(id, [other, slot]))
+
+
+@pytest.mark.accelerator
+def test_overlap_gpu_slot_on_other_device_than_process_current() -> None:
+    """Slots and events live on the scheduler's ``cuda:1``; the pool warm-up,
+    every probe, wait, flush, reap and shutdown drain run from ``cuda:0`` and
+    leave the current device untouched, and the bytes still match the sync
+    path. (``decode_delta`` pins ``cuda:1`` for the forward, copy and record
+    by design.)"""
+    require_cuda(min_devices=2)
+    previous_device = torch.cuda.current_device()
+    try:
+        device = torch.device("cuda", 1)
+        torch.cuda.set_device(0)
+        chunks = _stage_chunks(device, 22)
+        assert torch.cuda.current_device() == 0
+        control = _make_gpu_scheduler(
+            overlap=False, device=device, model=_SlowDeviceFakeModel(total_upsample=2)
+        )
+        _seed(control)
+        _feed(control, "req-1", range(22), chunks=chunks)
+        control._on_done("req-1")
+        control_snapshot = _drain_snapshot(control)
+
+        # Note (jiannan-17): the control's forwards pinned cuda:1; the pool
+        # warm-up and the feeds below must start from cuda:0.
+        torch.cuda.set_device(0)
+        scheduler = _make_gpu_scheduler(
+            overlap=True, device=device, model=_SlowDeviceFakeModel(total_upsample=2)
+        )
+        assert torch.cuda.current_device() == 0
+        _seed(scheduler)
+        _feed(scheduler, "req-1", range(20), chunks=chunks)
+        state = scheduler._stream_states["req-1"]
+        pending = state.pending
+        assert pending is not None
+        assert pending.slot.device == device
+        first_window = _drain_snapshot(scheduler)
+        assert [item[1] for item in first_window] == ["stream"]
+
+        # Note (jiannan-17): the forward pins the thread to cuda:1; move back
+        # so the probe, the wait, and the flush all start from cuda:0.
+        torch.cuda.set_device(0)
+        _feed(scheduler, "req-1", range(20, 21), chunks=chunks)  # probe: in flight
+        assert torch.cuda.current_device() == 0
+        assert state.pending is pending
+        assert scheduler.outbox.qsize() == 0
+
+        pending.slot.synchronize()
+        assert torch.cuda.current_device() == 0
+        assert pending.slot.query() is True
+        assert torch.cuda.current_device() == 0
+
+        _feed(scheduler, "req-1", range(21, 22), chunks=chunks)  # True: flush
+        assert torch.cuda.current_device() == 0
+        assert state.pending is None
+        second_window = _drain_snapshot(scheduler)
+        assert [item[1] for item in second_window] == ["stream"]
+        assert scheduler._pinned_free == [pending.slot]
+
+        scheduler._on_done("req-1")
+        tail = _drain_snapshot(scheduler)
+        assert [item[1] for item in tail] == ["stream", "result"]
+        assert [*first_window, *second_window, *tail] == control_snapshot
+
+        # Note (jiannan-17): the reap and the shutdown drain are the two paths
+        # that run on whichever thread pumps or stops the stage, so they are
+        # driven from cuda:0 with the copy still in flight on cuda:1.
+        _seed(scheduler, "req-2")
+        _feed(scheduler, "req-2", range(20), chunks=chunks)
+        retired = scheduler._stream_states["req-2"].pending
+        assert retired is not None
+        torch.cuda.set_device(0)
+        scheduler.abort("req-2")
+        assert scheduler._pinned_retired == [retired.slot]
+        scheduler._reap_retired_slots()
+        assert torch.cuda.current_device() == 0
+        assert scheduler._pinned_retired == [retired.slot], "still in flight"
+        scheduler.on_serving_stop()
+        assert torch.cuda.current_device() == 0
+        assert scheduler._pinned_retired == []
+        assert scheduler._pinned_quarantined == []
+        assert retired.slot in scheduler._pinned_free
+        assert retired.slot.query() is True
+    finally:
+        torch.cuda.set_device(previous_device)

--- a/tests/unit_test/qwen3_omni/test_code2wav_overlap.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_overlap.py
@@ -5,11 +5,9 @@ The depth-2 pipeline is CUDA-only in production, so CPU tests force it on and
 stub the pinned allocation and CUDA event to reach every branch device-free.
 Byte-identity tests always compare against a kill-switch control scheduler fed
 the identical stream, so a drift in the shared code shows up as a failure in
-both arms rather than a false pass. The ``accelerator``-marked cases run real
-pinned buffers and CUDA events: byte identity with CUDA graphs on and off at
-both window boundaries, the non-blocking completion probe against an in-flight
-copy, mid-stream abort, and a slot living on a device other than the
-process-current one.
+both arms rather than a false pass. The ``accelerator`` cases run real pinned
+buffers and events: eager/graph parity, in-flight completion queries, abort
+recovery, and cross-device use.
 """
 
 from __future__ import annotations
@@ -90,13 +88,8 @@ class _DeviceFakeModel(FakeCode2WavModel):
 
 
 class _SlowDeviceFakeModel(_DeviceFakeModel):
-    """_DeviceFakeModel that queues ~0.5 s of device work ahead of its output,
-    so the D2H copy fenced behind it is observably in flight (GPU tests).
-
-    The probes that rely on it run with no CUDA call between the launch and
-    the probe, so only a host stall of that order could let the copy drain
-    first.
-    """
+    """_DeviceFakeModel that queues ~0.5 s of device work first, so the fenced
+    D2H copy is observably in flight (GPU tests)."""
 
     def __call__(self, codes: torch.Tensor) -> torch.Tensor:
         torch.cuda._sleep(1_000_000_000)
@@ -121,7 +114,7 @@ class _DeviceFakeModule(torch.nn.Module):
 
 class _SlowDeviceFakeModule(_DeviceFakeModule):
     """_DeviceFakeModule whose replay queues ~0.5 s of device work first; the
-    spin is an ordinary kernel, so it is captured and replayed with the graph."""
+    spin kernel is captured with the graph."""
 
     def forward(self, codes: torch.Tensor) -> torch.Tensor:
         torch.cuda._sleep(1_000_000_000)
@@ -169,10 +162,9 @@ def _make_gpu_scheduler(
     )
     assert scheduler._pipeline_active is overlap
     if overlap:
-        # Note (jiannan-17): allocate the steady-state slot up front so no
-        # pinned allocation (cudaHostAlloc may synchronize the device) sits
-        # between the queued device work and the fenced copy the probe tests
-        # observe. Pool counts are unchanged: the window reuses this slot.
+        # Note (jiannan-17): cudaHostAlloc may synchronize the device, so no
+        # pinned allocation may sit between queued device work and the fenced
+        # copy the probe tests observe.
         scheduler._release_slot(
             scheduler._acquire_slot(scheduler._default_slot_samples)
         )
@@ -180,13 +172,9 @@ def _make_gpu_scheduler(
 
 
 def _stage_chunks(device: torch.device, n_chunks: int) -> list[torch.Tensor]:
-    """Frames already on ``device`` for the GPU probe tests.
-
-    ``validate_chunk`` moves every frame with a blocking ``.to(device)``; from
-    pageable memory that is cudaMemcpyAsync plus cudaStreamSynchronize on the
-    decode stream, which would drain the in-flight D2H copy before the probe
-    runs. Device-resident frames make the probing feeds enqueue nothing.
-    """
+    """Frames already on ``device``: ``validate_chunk``'s blocking ``.to()``
+    from pageable memory synchronizes the decode stream, which would drain an
+    in-flight copy before the probe."""
     chunks = [_chunk(i).to(device) for i in range(n_chunks)]
     torch.cuda.synchronize(device)
     return chunks
@@ -365,7 +353,7 @@ def test_overlap_first_window_sync_second_deferred(monkeypatch) -> None:
 
     _feed(scheduler, "req-1", range(10, 20))
     assert scheduler.outbox.qsize() == 1  # second window launched, deferred
-    # Note (jiannan-17): the fence must be recorded on the scheduler device's
+    # Note (jiannan-17): the fence is recorded on the scheduler device's
     # stream, not the thread-current device's.
     assert stream_devices == [scheduler._device]
 
@@ -516,9 +504,6 @@ def test_overlap_record_failure_quarantines_current_slot(monkeypatch) -> None:
     with pytest.raises(RuntimeError, match="event record failed"):
         _feed(scheduler, "req-1", range(10, 20))
 
-    # Note (jiannan-17): only one slot was ever created and every other pool
-    # is empty, so the pool counts alone pin the quarantined slot's identity;
-    # the event check makes it explicit.
     assert event.record_calls == 1
     assert scheduler._pinned_created == 1
     assert len(scheduler._pinned_quarantined) == 1
@@ -527,17 +512,14 @@ def test_overlap_record_failure_quarantines_current_slot(monkeypatch) -> None:
     assert scheduler._pinned_free == []
     assert scheduler._pipeline_active is False
     assert scheduler._stream_states["req-1"].pending is None
-    # Note (jiannan-17): the shared slot backs the quarantine up — even if the
-    # slot leaked out, it refuses to report a completion for the copy whose
-    # record failed instead of returning the never-recorded event's True.
+    # The slot must not treat the failed transfer as complete.
     with pytest.raises(RuntimeError, match="not recorded"):
         scheduler._pinned_quarantined[0].query()
 
 
 def test_overlap_rerecord_failure_on_reused_slot_quarantines_it(monkeypatch) -> None:
-    """A slot that already completed a window is popped from the free pool
-    and its second record() raises: it is quarantined and refuses completion
-    reads, while the other slot's pending window still flushes."""
+    """A free-pool slot whose second record() raises is quarantined and refuses
+    completion reads; the other pending window still flushes."""
     control = _run_stream(overlap=False, n_chunks=40)
 
     scheduler = _make_scheduler(overlap=True)
@@ -549,8 +531,7 @@ def test_overlap_rerecord_failure_on_reused_slot_quarantines_it(monkeypatch) -> 
     first = state_lookup["req-1"].pending
     assert first is not None
     slot_a = first.slot
-    # Note (jiannan-17): keep each copy "in flight" until the next launch
-    # flushes it, as on a real device; the fake completes on synchronize().
+    # Keep each copy "in flight" until flushed; the fake completes on synchronize().
     _slot_event(slot_a).complete = False
     _feed(scheduler, "req-1", range(20, 30))  # window 3 on slot B, A flushed
     second = state_lookup["req-1"].pending
@@ -573,9 +554,7 @@ def test_overlap_rerecord_failure_on_reused_slot_quarantines_it(monkeypatch) -> 
     assert scheduler._pinned_created == 2
     assert scheduler._pipeline_active is False
     assert state_lookup["req-1"].pending is second, "window 3 is still owned"
-    # Note (jiannan-17): the fake event says True for the completed window 2
-    # transfer, which is exactly what the slot must not report for the copy
-    # whose record failed.
+    # The slot must not treat the failed transfer as complete.
     assert _slot_event(slot_a).complete is True
     with pytest.raises(RuntimeError, match="not recorded"):
         slot_a.query()
@@ -924,9 +903,8 @@ def test_overlap_borrowed_output_copied_before_next_replay(monkeypatch) -> None:
         (20, ["stream", "stream", "result"]),
         # Note (edwardzh): pending and tail must not merge.
         (21, ["stream", "stream", "stream", "result"]),
-        # Note (jiannan-17): window 3 replays the same graph key whose static
-        # output window 2's pending copy reads from; same-stream ordering is
-        # what keeps the bytes identical.
+        # Note (jiannan-17): a replay over a pending copy's source; same-stream
+        # ordering keeps the bytes identical.
         (30, ["stream", "stream", "stream", "result"]),
         (31, ["stream", "stream", "stream", "stream", "result"]),
     ],
@@ -947,8 +925,6 @@ def test_overlap_gpu_real_pinned_event_bitwise(
         scheduler._on_done("req-1")
         if cuda_graph:
             runtime = scheduler._cuda_graph_runner.stats()["runtime"]
-            # Note (jiannan-17): every threshold window replays; only the
-            # stream-done tail runs eagerly.
             assert runtime["graph_replays"] == n_chunks // 10
             assert runtime["replay_failures"] == 0
             assert runtime["fallback_counts"] == (
@@ -964,9 +940,8 @@ def test_overlap_gpu_real_pinned_event_bitwise(
 
 @pytest.mark.accelerator
 def test_overlap_gpu_query_is_false_until_inflight_copy_drains() -> None:
-    """The per-frame probe reports False while the fenced D2H copy is still
-    queued behind device work, True once it drained, and the drained window is
-    emitted by the next chunk without a further dispatch."""
+    """The per-frame probe is False while the copy is in flight, True once it
+    drained, and the next chunk then flushes without a dispatch."""
     require_cuda()
     device = torch.device("cuda", torch.cuda.current_device())
     chunks = _stage_chunks(device, 22)
@@ -992,9 +967,7 @@ def test_overlap_gpu_query_is_false_until_inflight_copy_drains() -> None:
     first_window = _drain_snapshot(scheduler)
     assert [item[1] for item in first_window] == ["stream"]
 
-    # Note (jiannan-17): a chunk that does not complete a window still probes;
-    # the copy is behind ~0.5 s of device work, so it must not flush yet.
-    _feed(scheduler, "req-1", range(20, 21), chunks=chunks)
+    _feed(scheduler, "req-1", range(20, 21), chunks=chunks)  # probe: in flight
     assert state.pending is pending
     assert scheduler.outbox.qsize() == 0
 
@@ -1002,8 +975,7 @@ def test_overlap_gpu_query_is_false_until_inflight_copy_drains() -> None:
     assert pending.slot.query() is True
     assert state.pending is pending, "observing completion is not a flush"
 
-    # The next chunk's probe reports True and flushes without a dispatch.
-    _feed(scheduler, "req-1", range(21, 22), chunks=chunks)
+    _feed(scheduler, "req-1", range(21, 22), chunks=chunks)  # True: flush
     assert state.pending is None
     second_window = _drain_snapshot(scheduler)
     assert [item[1] for item in second_window] == ["stream"]
@@ -1021,9 +993,8 @@ def test_overlap_gpu_query_is_false_until_inflight_copy_drains() -> None:
 def test_overlap_gpu_abort_midstream_neither_blocks_nor_reuses_inflight_slot(
     cuda_graph: bool,
 ) -> None:
-    """Abort with a copy in flight returns without waiting, keeps the slot out
-    of rotation until the copy drains, and the drained bytes are intact even
-    after a later replay rewrote the graph output the copy was reading."""
+    """Abort with a copy in flight neither waits nor hands the slot out, and
+    the bytes land intact even after a later replay rewrote their source."""
     require_cuda()
     device = torch.device("cuda", torch.cuda.current_device())
     chunks = _stage_chunks(device, 31)
@@ -1048,26 +1019,23 @@ def test_overlap_gpu_abort_midstream_neither_blocks_nor_reuses_inflight_slot(
 
     scheduler.abort("req-1")
 
-    # Note (jiannan-17): a synchronizing abort would have drained the copy, so
-    # the probe still reporting False is the proof that it did not block.
+    # A synchronizing abort would have drained the copy.
     assert slot.query() is False
     assert state.pending is None
     assert "req-1" not in scheduler._stream_states
     assert scheduler._pinned_retired == [slot]
     assert scheduler._pinned_free == []
 
-    # Note (jiannan-17): another window on the same graph key rewrites the
-    # static output the retired copy reads from; the copy was enqueued first
-    # on the same stream, so it must still land with window 2's bytes. This
-    # runs before any pinned allocation so the probe stays CUDA-call-free.
+    # Note (jiannan-17): a same-key replay rewrites the retired copy's source;
+    # same-stream ordering means the copy still lands with the old bytes. This
+    # runs before any pinned allocation (cudaHostAlloc may synchronize).
     window = torch.stack(chunks[19:30], dim=0).transpose(0, 1).unsqueeze(0)
     _, execution = scheduler._forward_codes(window, graph_eligible=True)
     assert execution["execution_mode"] == ("cuda_graph" if cuda_graph else "eager")
     assert slot.query() is False, "the replay queues behind the copy, not before"
 
-    # The in-flight slot is not handed out; a second slot is created instead
-    # (the reap runs before the allocation, so this holds even if the pinned
-    # allocation synchronizes the device).
+    # The reap precedes the allocation, so this holds even if cudaHostAlloc
+    # synchronizes.
     other = scheduler._acquire_slot(pending.samples)
     assert other is not None and other is not slot
     assert scheduler._pinned_created == 2
@@ -1091,11 +1059,9 @@ def test_overlap_gpu_abort_midstream_neither_blocks_nor_reuses_inflight_slot(
 
 @pytest.mark.accelerator
 def test_overlap_gpu_slot_on_other_device_than_process_current() -> None:
-    """Slots and events live on the scheduler's ``cuda:1``; the pool warm-up,
-    every probe, wait, flush, reap and shutdown drain run from ``cuda:0`` and
-    leave the current device untouched, and the bytes still match the sync
-    path. (``decode_delta`` pins ``cuda:1`` for the forward, copy and record
-    by design.)"""
+    """Slots live on ``cuda:1``; warm-up, probes, waits, flushes, reap and
+    shutdown drain run from ``cuda:0`` and leave it current. (``decode_delta``
+    pins ``cuda:1`` by design.)"""
     require_cuda(min_devices=2)
     previous_device = torch.cuda.current_device()
     try:
@@ -1111,8 +1077,7 @@ def test_overlap_gpu_slot_on_other_device_than_process_current() -> None:
         control._on_done("req-1")
         control_snapshot = _drain_snapshot(control)
 
-        # Note (jiannan-17): the control's forwards pinned cuda:1; the pool
-        # warm-up and the feeds below must start from cuda:0.
+        # The control's forwards pinned cuda:1.
         torch.cuda.set_device(0)
         scheduler = _make_gpu_scheduler(
             overlap=True, device=device, model=_SlowDeviceFakeModel(total_upsample=2)
@@ -1127,8 +1092,7 @@ def test_overlap_gpu_slot_on_other_device_than_process_current() -> None:
         first_window = _drain_snapshot(scheduler)
         assert [item[1] for item in first_window] == ["stream"]
 
-        # Note (jiannan-17): the forward pins the thread to cuda:1; move back
-        # so the probe, the wait, and the flush all start from cuda:0.
+        # The forward pinned cuda:1; probe, wait and flush must start from cuda:0.
         torch.cuda.set_device(0)
         _feed(scheduler, "req-1", range(20, 21), chunks=chunks)  # probe: in flight
         assert torch.cuda.current_device() == 0
@@ -1152,9 +1116,8 @@ def test_overlap_gpu_slot_on_other_device_than_process_current() -> None:
         assert [item[1] for item in tail] == ["stream", "result"]
         assert [*first_window, *second_window, *tail] == control_snapshot
 
-        # Note (jiannan-17): the reap and the shutdown drain are the two paths
-        # that run on whichever thread pumps or stops the stage, so they are
-        # driven from cuda:0 with the copy still in flight on cuda:1.
+        # Note (jiannan-17): the reap and the shutdown drain run on whichever
+        # thread pumps or stops the stage.
         _seed(scheduler, "req-2")
         _feed(scheduler, "req-2", range(20), chunks=chunks)
         retired = scheduler._stream_states["req-2"].pending

--- a/tests/unit_test/utils/test_cuda_staging.py
+++ b/tests/unit_test/utils/test_cuda_staging.py
@@ -23,13 +23,20 @@ class _FakeEvent:
     def __init__(self) -> None:
         self.recorded_streams: list = []
         self.synchronize_calls = 0
+        self.complete = True
         self.record_error: BaseException | None = None
         self.sync_error: BaseException | None = None
+        self.query_error: BaseException | None = None
 
     def record(self, stream=None) -> None:
         if self.record_error is not None:
             raise self.record_error
         self.recorded_streams.append(stream)
+
+    def query(self) -> bool:
+        if self.query_error is not None:
+            raise self.query_error
+        return self.complete
 
     def synchronize(self) -> None:
         self.synchronize_calls += 1
@@ -139,6 +146,28 @@ def test_pinned_transfer_slot_reuses_one_event(monkeypatch):
     assert slot.view(16).numel() == 16
 
 
+def test_pinned_transfer_slot_query_probes_completion_without_blocking(monkeypatch):
+    created = _install_fake_events(monkeypatch)
+    _install_fake_pinned_alloc(monkeypatch)
+
+    slot = PinnedTransferSlot("cpu", torch.float32)
+    with pytest.raises(RuntimeError, match="not recorded"):
+        slot.query()
+
+    slot.record(object())
+    created[0].complete = False
+    assert slot.query() is False
+    created[0].complete = True
+    assert slot.query() is True
+    assert created[0].synchronize_calls == 0, "query must not block on the event"
+
+    query_error = RuntimeError("query failed")
+    created[0].query_error = query_error
+    with pytest.raises(RuntimeError) as query_info:
+        slot.query()
+    assert query_info.value is query_error
+
+
 def test_pinned_transfer_slot_propagates_errors_and_rejects_foreign_stream(
     monkeypatch,
 ):
@@ -177,6 +206,7 @@ def test_pinned_transfer_slot_propagates_errors_and_rejects_foreign_stream(
         cuda_slot.record(SimpleNamespace(device=torch.device("cuda", 1)))
     assert len(created) == 1, "a rejected stream must not create an event"
     cuda_slot.record(SimpleNamespace(device=torch.device("cuda:0")))
+    cuda_slot.query()
     cuda_slot.synchronize()
     assert len(created) == 2
-    assert guards == [torch.device("cuda", 0)] * 2
+    assert guards == [torch.device("cuda", 0)] * 3

--- a/tests/unit_test/utils/test_cuda_staging.py
+++ b/tests/unit_test/utils/test_cuda_staging.py
@@ -4,12 +4,15 @@
 ``torch.cuda.Event`` is replaced with a CPU stand-in, and so is pinned
 allocation when no CUDA device is present, so the growth, inference-mode,
 event-reuse, and error-propagation contracts can be checked without a GPU.
-The real pinned/event path is exercised by the Qwen3-TTS CUDA tests.
+The ``accelerator``-marked cases run the real pinned/event path: an
+asynchronous D2H copy observed through ``query()``, and the device guard with
+the slot on a device other than the process-current one.
 """
 
 from __future__ import annotations
 
 import contextlib
+from collections.abc import Callable
 from types import SimpleNamespace
 
 import pytest
@@ -17,12 +20,17 @@ import torch
 
 from sglang_omni.utils import cuda_staging
 from sglang_omni.utils.cuda_staging import GrowablePinnedBuffer, PinnedTransferSlot
+from tests.unit_test.fixtures.accelerator import require_cuda
 
 
 class _FakeEvent:
     def __init__(self) -> None:
         self.recorded_streams: list = []
         self.synchronize_calls = 0
+        self.query_calls = 0
+        # Note (jiannan-17): CUDA reports an event that was never recorded as
+        # complete, so the stand-in starts complete as well; the slot must
+        # not let that state through before a record() has succeeded.
         self.complete = True
         self.record_error: BaseException | None = None
         self.sync_error: BaseException | None = None
@@ -34,6 +42,7 @@ class _FakeEvent:
         self.recorded_streams.append(stream)
 
     def query(self) -> bool:
+        self.query_calls += 1
         if self.query_error is not None:
             raise self.query_error
         return self.complete
@@ -44,11 +53,15 @@ class _FakeEvent:
             raise self.sync_error
 
 
-def _install_fake_events(monkeypatch) -> list[_FakeEvent]:
+def _install_fake_events(
+    monkeypatch, *, configure: Callable[[_FakeEvent], None] | None = None
+) -> list[_FakeEvent]:
     created: list[_FakeEvent] = []
 
     def factory():
         event = _FakeEvent()
+        if configure is not None:
+            configure(event)
         created.append(event)
         return event
 
@@ -166,6 +179,129 @@ def test_pinned_transfer_slot_query_probes_completion_without_blocking(monkeypat
     with pytest.raises(RuntimeError) as query_info:
         slot.query()
     assert query_info.value is query_error
+    # Note (jiannan-17): a failed probe says nothing about the record; the
+    # owner decides whether to trust the slot, and a retry still reaches the
+    # event instead of the "not recorded" guard.
+    created[0].query_error = None
+    assert slot.query() is True
+
+
+def test_pinned_transfer_slot_first_record_failure_rejects_completion_reads(
+    monkeypatch,
+):
+    """A slot whose only ``record()`` raised has no transfer to report on.
+
+    The event object exists (it is created before the record is attempted)
+    and CUDA would report it complete, so without the record-succeeded state
+    the owner could read a completion marker for a copy that was never fenced.
+    """
+    record_error = RuntimeError("event record failed")
+
+    def _fail_record(event: _FakeEvent) -> None:
+        event.record_error = record_error
+
+    created = _install_fake_events(monkeypatch, configure=_fail_record)
+    _install_fake_pinned_alloc(monkeypatch)
+    slot = PinnedTransferSlot("cpu", torch.float32)
+
+    with pytest.raises(RuntimeError) as record_info:
+        slot.record(object())
+    assert record_info.value is record_error
+    assert len(created) == 1
+    assert created[0].complete is True, "the stand-in mirrors CUDA's unrecorded state"
+
+    with pytest.raises(RuntimeError, match="not recorded"):
+        slot.query()
+    with pytest.raises(RuntimeError, match="not recorded"):
+        slot.synchronize()
+    assert (created[0].query_calls, created[0].synchronize_calls) == (
+        0,
+        0,
+    ), "the guard fires before the event is consulted"
+
+    # A later successful record() makes the slot usable again with the same
+    # event; no second event is created.
+    created[0].record_error = None
+    stream = object()
+    slot.record(stream)
+    assert len(created) == 1
+    assert created[0].recorded_streams == [stream]
+    assert slot.query() is True
+    slot.synchronize()
+    assert created[0].synchronize_calls == 1
+
+
+def test_pinned_transfer_slot_event_construction_failure_rejects_completion_reads(
+    monkeypatch,
+):
+    """When ``torch.cuda.Event()`` itself raises, no event exists and the slot
+    still has no recorded transfer; the retry creates the event."""
+    created = _install_fake_events(monkeypatch)
+    _install_fake_pinned_alloc(monkeypatch)
+    slot = PinnedTransferSlot("cpu", torch.float32)
+    init_error = RuntimeError("event init failed")
+    factory = torch.cuda.Event
+
+    def exploding_once():
+        monkeypatch.setattr(torch.cuda, "Event", factory)
+        raise init_error
+
+    monkeypatch.setattr(torch.cuda, "Event", exploding_once)
+    with pytest.raises(RuntimeError) as init_info:
+        slot.record(object())
+    assert init_info.value is init_error
+    assert created == []
+    with pytest.raises(RuntimeError, match="not recorded"):
+        slot.query()
+    with pytest.raises(RuntimeError, match="not recorded"):
+        slot.synchronize()
+
+    stream = object()
+    slot.record(stream)
+    assert len(created) == 1
+    assert created[0].recorded_streams == [stream]
+    assert slot.query() is True
+    slot.synchronize()
+
+
+def test_pinned_transfer_slot_failed_rerecord_hides_previous_completion(
+    monkeypatch,
+):
+    """A failed re-record must not expose the previous transfer's completion."""
+    created = _install_fake_events(monkeypatch)
+    _install_fake_pinned_alloc(monkeypatch)
+    slot = PinnedTransferSlot("cpu", torch.float32)
+
+    first_stream = object()
+    slot.record(first_stream)
+    assert slot.query() is True
+    slot.synchronize()
+    assert created[0].synchronize_calls == 1
+
+    record_error = RuntimeError("event record failed")
+    created[0].record_error = record_error
+    with pytest.raises(RuntimeError) as record_info:
+        slot.record(object())
+    assert record_info.value is record_error
+    assert created[0].recorded_streams == [first_stream]
+    assert created[0].complete is True, "the previous transfer did complete"
+
+    with pytest.raises(RuntimeError, match="not recorded"):
+        slot.query()
+    with pytest.raises(RuntimeError, match="not recorded"):
+        slot.synchronize()
+    assert (created[0].query_calls, created[0].synchronize_calls) == (
+        1,
+        1,
+    ), "the guard must fire before the event"
+
+    created[0].record_error = None
+    second_stream = object()
+    slot.record(second_stream)
+    assert created[0].recorded_streams == [first_stream, second_stream]
+    assert slot.query() is True
+    slot.synchronize()
+    assert created[0].synchronize_calls == 2
 
 
 def test_pinned_transfer_slot_propagates_errors_and_rejects_foreign_stream(
@@ -179,17 +315,17 @@ def test_pinned_transfer_slot_propagates_errors_and_rejects_foreign_stream(
         slot.synchronize()
 
     slot.record(object())
-    record_error = RuntimeError("record failed")
     sync_error = RuntimeError("sync failed")
-    created[0].record_error = record_error
-    with pytest.raises(RuntimeError) as record_info:
-        slot.record(object())
-    assert record_info.value is record_error
-    created[0].record_error = None
     created[0].sync_error = sync_error
     with pytest.raises(RuntimeError) as sync_info:
         slot.synchronize()
     assert sync_info.value is sync_error
+    # Note (jiannan-17): a failed wait leaves the record in place; whether the
+    # slot is still trustworthy is the owner's call, so a retry reaches the
+    # event again.
+    created[0].sync_error = None
+    slot.synchronize()
+    assert created[0].synchronize_calls == 2
 
     guards: list[torch.device] = []
 
@@ -205,8 +341,109 @@ def test_pinned_transfer_slot_propagates_errors_and_rejects_foreign_stream(
     with pytest.raises(ValueError):
         cuda_slot.record(SimpleNamespace(device=torch.device("cuda", 1)))
     assert len(created) == 1, "a rejected stream must not create an event"
+    with pytest.raises(RuntimeError, match="not recorded"):
+        cuda_slot.query()
     cuda_slot.record(SimpleNamespace(device=torch.device("cuda:0")))
     cuda_slot.query()
     cuda_slot.synchronize()
     assert len(created) == 2
     assert guards == [torch.device("cuda", 0)] * 3
+
+    # A rejected re-record is a failed record: the completed first transfer
+    # must not answer for the one that never got fenced.
+    with pytest.raises(ValueError):
+        cuda_slot.record(SimpleNamespace(device=torch.device("cuda", 1)))
+    with pytest.raises(RuntimeError, match="not recorded"):
+        cuda_slot.query()
+    with pytest.raises(RuntimeError, match="not recorded"):
+        cuda_slot.synchronize()
+    assert (created[1].query_calls, created[1].synchronize_calls) == (1, 1)
+    assert (
+        guards == [torch.device("cuda", 0)] * 3
+    ), "the guard is entered only for CUDA work"
+
+
+@pytest.mark.accelerator
+def test_pinned_transfer_slot_real_cuda_query_tracks_async_copy() -> None:
+    """``query()`` is False while the fenced D2H copy is in flight, then True."""
+    require_cuda()
+    device = torch.device("cuda", torch.cuda.current_device())
+    # Note (jiannan-17): the premise behind the failed-record contract, checked
+    # against the driver rather than assumed: a torch event that was never
+    # recorded reports complete and synchronizes as a no-op.
+    unrecorded = torch.cuda.Event()
+    assert unrecorded.query() is True
+    unrecorded.synchronize()
+    numel = 1 << 16
+    slot = PinnedTransferSlot(device, torch.float32, initial_capacity=numel)
+    assert slot.view(numel).is_pinned()
+    with pytest.raises(RuntimeError, match="not recorded"):
+        slot.query()
+
+    source = torch.arange(numel, dtype=torch.float32, device=device)
+    expected = source.cpu()
+    stream = torch.cuda.Stream(device=device)
+    torch.cuda.synchronize(device)
+    with torch.cuda.stream(stream):
+        # Note (jiannan-17): the spin keeps the copy queued behind ~0.5 s of
+        # device work; nothing between here and the probe touches CUDA, so
+        # only a host stall of that order could let the copy drain first.
+        torch.cuda._sleep(1_000_000_000)
+        slot.view(numel).copy_(source, non_blocking=True)
+    slot.record(stream)
+
+    assert slot.query() is False
+    slot.synchronize()
+    assert slot.query() is True
+    assert torch.equal(slot.view(numel), expected)
+
+    # The same event and buffer serve the next transfer.
+    with torch.cuda.stream(stream):
+        source.mul_(2)
+        slot.view(numel).copy_(source, non_blocking=True)
+    slot.record(stream)
+    slot.synchronize()
+    assert slot.query() is True
+    assert torch.equal(slot.view(numel), expected * 2)
+
+
+@pytest.mark.accelerator
+def test_pinned_transfer_slot_real_cuda_guards_slot_on_other_device() -> None:
+    """Record/query/synchronize work with the slot and stream on ``cuda:1``
+    while the process-current device is ``cuda:0``, and leave it there."""
+    require_cuda(min_devices=2)
+    previous_device = torch.cuda.current_device()
+    try:
+        torch.cuda.set_device(0)
+        slot_device = torch.device("cuda", 1)
+        numel = 1 << 16
+        slot = PinnedTransferSlot(slot_device, torch.float32, initial_capacity=numel)
+        assert slot.device == slot_device
+        stream = torch.cuda.Stream(device=slot_device)
+        source = torch.arange(numel, dtype=torch.float32, device=slot_device)
+        expected = source.cpu()
+        torch.cuda.synchronize(slot_device)
+        with torch.cuda.stream(stream):
+            torch.cuda._sleep(1_000_000_000)
+            slot.view(numel).copy_(source, non_blocking=True)
+        # Note (jiannan-17): the stream context restores cuda:0; every slot
+        # call below therefore starts on the wrong device for its event.
+        assert torch.cuda.current_device() == 0
+
+        slot.record(stream)
+        assert torch.cuda.current_device() == 0
+        assert slot.query() is False
+        assert torch.cuda.current_device() == 0
+        slot.synchronize()
+        assert torch.cuda.current_device() == 0
+        assert slot.query() is True
+        assert torch.cuda.current_device() == 0
+        assert torch.equal(slot.view(numel), expected)
+
+        with pytest.raises(ValueError, match="cannot record"):
+            slot.record(torch.cuda.current_stream(torch.device("cuda", 0)))
+        assert torch.cuda.current_device() == 0
+        with pytest.raises(RuntimeError, match="not recorded"):
+            slot.query()
+    finally:
+        torch.cuda.set_device(previous_device)

--- a/tests/unit_test/utils/test_cuda_staging.py
+++ b/tests/unit_test/utils/test_cuda_staging.py
@@ -28,9 +28,8 @@ class _FakeEvent:
         self.recorded_streams: list = []
         self.synchronize_calls = 0
         self.query_calls = 0
-        # Note (jiannan-17): CUDA reports an event that was never recorded as
-        # complete, so the stand-in starts complete as well; the slot must
-        # not let that state through before a record() has succeeded.
+        # Note (jiannan-17): CUDA reports an unrecorded event as complete; the
+        # stand-in matches.
         self.complete = True
         self.record_error: BaseException | None = None
         self.sync_error: BaseException | None = None
@@ -179,9 +178,7 @@ def test_pinned_transfer_slot_query_probes_completion_without_blocking(monkeypat
     with pytest.raises(RuntimeError) as query_info:
         slot.query()
     assert query_info.value is query_error
-    # Note (jiannan-17): a failed probe says nothing about the record; the
-    # owner decides whether to trust the slot, and a retry still reaches the
-    # event instead of the "not recorded" guard.
+    # A failed probe leaves the record in place (owner policy).
     created[0].query_error = None
     assert slot.query() is True
 
@@ -189,12 +186,7 @@ def test_pinned_transfer_slot_query_probes_completion_without_blocking(monkeypat
 def test_pinned_transfer_slot_first_record_failure_rejects_completion_reads(
     monkeypatch,
 ):
-    """A slot whose only ``record()`` raised has no transfer to report on.
-
-    The event object exists (it is created before the record is attempted)
-    and CUDA would report it complete, so without the record-succeeded state
-    the owner could read a completion marker for a copy that was never fenced.
-    """
+    """A slot whose only ``record()`` raised has no transfer to report on."""
     record_error = RuntimeError("event record failed")
 
     def _fail_record(event: _FakeEvent) -> None:
@@ -208,19 +200,15 @@ def test_pinned_transfer_slot_first_record_failure_rejects_completion_reads(
         slot.record(object())
     assert record_info.value is record_error
     assert len(created) == 1
-    assert created[0].complete is True, "the stand-in mirrors CUDA's unrecorded state"
+    assert created[0].complete is True
 
+    # The slot must not treat the failed transfer as complete.
     with pytest.raises(RuntimeError, match="not recorded"):
         slot.query()
     with pytest.raises(RuntimeError, match="not recorded"):
         slot.synchronize()
-    assert (created[0].query_calls, created[0].synchronize_calls) == (
-        0,
-        0,
-    ), "the guard fires before the event is consulted"
+    assert (created[0].query_calls, created[0].synchronize_calls) == (0, 0)
 
-    # A later successful record() makes the slot usable again with the same
-    # event; no second event is created.
     created[0].record_error = None
     stream = object()
     slot.record(stream)
@@ -234,8 +222,7 @@ def test_pinned_transfer_slot_first_record_failure_rejects_completion_reads(
 def test_pinned_transfer_slot_event_construction_failure_rejects_completion_reads(
     monkeypatch,
 ):
-    """When ``torch.cuda.Event()`` itself raises, no event exists and the slot
-    still has no recorded transfer; the retry creates the event."""
+    """A failed ``torch.cuda.Event()`` leaves no event; the retry creates it."""
     created = _install_fake_events(monkeypatch)
     _install_fake_pinned_alloc(monkeypatch)
     slot = PinnedTransferSlot("cpu", torch.float32)
@@ -284,16 +271,14 @@ def test_pinned_transfer_slot_failed_rerecord_hides_previous_completion(
         slot.record(object())
     assert record_info.value is record_error
     assert created[0].recorded_streams == [first_stream]
-    assert created[0].complete is True, "the previous transfer did complete"
+    assert created[0].complete is True
 
+    # The slot must not treat the failed transfer as complete.
     with pytest.raises(RuntimeError, match="not recorded"):
         slot.query()
     with pytest.raises(RuntimeError, match="not recorded"):
         slot.synchronize()
-    assert (created[0].query_calls, created[0].synchronize_calls) == (
-        1,
-        1,
-    ), "the guard must fire before the event"
+    assert (created[0].query_calls, created[0].synchronize_calls) == (1, 1)
 
     created[0].record_error = None
     second_stream = object()
@@ -320,9 +305,7 @@ def test_pinned_transfer_slot_propagates_errors_and_rejects_foreign_stream(
     with pytest.raises(RuntimeError) as sync_info:
         slot.synchronize()
     assert sync_info.value is sync_error
-    # Note (jiannan-17): a failed wait leaves the record in place; whether the
-    # slot is still trustworthy is the owner's call, so a retry reaches the
-    # event again.
+    # A failed wait leaves the record in place (owner policy).
     created[0].sync_error = None
     slot.synchronize()
     assert created[0].synchronize_calls == 2
@@ -349,8 +332,7 @@ def test_pinned_transfer_slot_propagates_errors_and_rejects_foreign_stream(
     assert len(created) == 2
     assert guards == [torch.device("cuda", 0)] * 3
 
-    # A rejected re-record is a failed record: the completed first transfer
-    # must not answer for the one that never got fenced.
+    # A rejected stream is a failed record.
     with pytest.raises(ValueError):
         cuda_slot.record(SimpleNamespace(device=torch.device("cuda", 1)))
     with pytest.raises(RuntimeError, match="not recorded"):
@@ -358,9 +340,7 @@ def test_pinned_transfer_slot_propagates_errors_and_rejects_foreign_stream(
     with pytest.raises(RuntimeError, match="not recorded"):
         cuda_slot.synchronize()
     assert (created[1].query_calls, created[1].synchronize_calls) == (1, 1)
-    assert (
-        guards == [torch.device("cuda", 0)] * 3
-    ), "the guard is entered only for CUDA work"
+    assert guards == [torch.device("cuda", 0)] * 3
 
 
 @pytest.mark.accelerator
@@ -368,9 +348,8 @@ def test_pinned_transfer_slot_real_cuda_query_tracks_async_copy() -> None:
     """``query()`` is False while the fenced D2H copy is in flight, then True."""
     require_cuda()
     device = torch.device("cuda", torch.cuda.current_device())
-    # Note (jiannan-17): the premise behind the failed-record contract, checked
-    # against the driver rather than assumed: a torch event that was never
-    # recorded reports complete and synchronizes as a no-op.
+    # Note (jiannan-17): the contract's premise, checked against the driver:
+    # an unrecorded event reports complete.
     unrecorded = torch.cuda.Event()
     assert unrecorded.query() is True
     unrecorded.synchronize()
@@ -385,9 +364,8 @@ def test_pinned_transfer_slot_real_cuda_query_tracks_async_copy() -> None:
     stream = torch.cuda.Stream(device=device)
     torch.cuda.synchronize(device)
     with torch.cuda.stream(stream):
-        # Note (jiannan-17): the spin keeps the copy queued behind ~0.5 s of
-        # device work; nothing between here and the probe touches CUDA, so
-        # only a host stall of that order could let the copy drain first.
+        # Note (jiannan-17): ~0.5 s of queued device work keeps the copy in
+        # flight; nothing between here and the probe touches CUDA.
         torch.cuda._sleep(1_000_000_000)
         slot.view(numel).copy_(source, non_blocking=True)
     slot.record(stream)
@@ -426,8 +404,8 @@ def test_pinned_transfer_slot_real_cuda_guards_slot_on_other_device() -> None:
         with torch.cuda.stream(stream):
             torch.cuda._sleep(1_000_000_000)
             slot.view(numel).copy_(source, non_blocking=True)
-        # Note (jiannan-17): the stream context restores cuda:0; every slot
-        # call below therefore starts on the wrong device for its event.
+        # Note (jiannan-17): the stream context restores cuda:0, so every slot
+        # call below starts on the other device.
         assert torch.cuda.current_device() == 0
 
         slot.record(stream)


### PR DESCRIPTION
Follow-up 1 of #1523 (*"Code2Wav is intentionally unchanged in this PR. This PR extract sharing utils and Code2Wav can migrate to `GrowablePinnedBuffer` and `PinnedTransferSlot` in a separate PR"*).

## Summary

This PR migrates Code2Wav's pipeline from `_PinnedSlot` to the shared `PinnedTransferSlot`.

It also adds a non-blocking `query()` API and tracks successful event recording explicitly. After a failed `record()`, `query()` and `synchronize()` reject the slot until a later `record()` succeeds.

## Changes

- Replace Code2Wav's private pinned-buffer and event handling with `PinnedTransferSlot`.
- Use the shared slot for buffer growth and event record/query/synchronize.
- Keep Code2Wav's free, retired, and quarantined slot ownership and recovery policy unchanged.
- Add coverage for failed records, slot reuse, async D2H completion, CUDA graph parity, abort handling, and multi-GPU device restoration.
- Copy failures before `record()` remain the caller's responsibility. Code2Wav quarantines those slots. Qwen3-TTS already avoids reusing slots after launch failures, so its behavior is unchanged.

## Validation

H100 results were collected on one NVIDIA H100 80GB using `Qwen/Qwen3-Omni-30B-A3B-Instruct`, the two dual-GPU tests were run separately on a 2× H100 80GB box.

- Local checks: changed-file pre-commit passed; targeted CPU tests: 30 passed, 14 accelerator tests skipped.
- Targeted H100 tests: all 14 accelerator tests passed (12 on the single-GPU host; the 2 dual-GPU cases on the 2× H100 box, repeated 3×).
- Qwen3-TTS regression: 167 non-accelerator and 5 accelerator tests passed.
- End-to-end streaming: five prompts were run twice per overlap setting, with deterministic inference enabled for both the thinker and talker. All 20 requests succeeded. Repeated runs and overlap enabled/disabled matched in message types, order and count, chunk lengths, and PCM SHA-256. No CUDA or staging errors were found in the server logs.
- Real-weight Code2Wav replay: overlap enabled and disabled were bitwise identical in all 12 eager and CUDA Graph cases.

