### PR TITLE
Stage Qwen3-TTS repetition penalty mask updates through pinned buffers

### DIFF
--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -14,6 +14,28 @@ from sglang_omni.models.qwen3_omni.talker_model_runner import QwenTalkerModelRun
 from sglang_omni.scheduling.types import RequestOutput
 
 
+class _MaskStaging:
+    """Pinned host staging for the mask rebuild.
+
+    A pageable torch.tensor(list, device=cuda) synchronizes the stream on
+    every call. Pinned tensors from the caching host allocator are not reused
+    until the asynchronous copy that reads them has completed.
+    """
+
+    def __init__(self, device: torch.device) -> None:
+        self._device = device
+
+    def stage(
+        self, indices: list[int], penalties: list[float]
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        pairs = torch.tensor(indices, dtype=torch.long, pin_memory=True)
+        pen = torch.tensor(penalties, dtype=torch.float32, pin_memory=True)
+        return (
+            pairs.to(self._device, non_blocking=True),
+            pen.to(self._device, non_blocking=True),
+        )
+
+
 class Qwen3TTSModelRunner(ModelRunner):
     """Runs Qwen3-TTS AR steps and stores generated codec frames per request."""
 
@@ -25,6 +47,9 @@ class Qwen3TTSModelRunner(ModelRunner):
         self._mask_prep_rids: list | None = None
         self._mask_rep_active = False
         self._mask_sup_active = False
+        self._mask_true: torch.Tensor | None = None
+        self._mask_rows: torch.Tensor | None = None
+        self._mask_staging: _MaskStaging | None = None
 
     def before_prefill(
         self,
@@ -161,6 +186,13 @@ class Qwen3TTSModelRunner(ModelRunner):
             torch.ones(rows, 1, dtype=torch.float32, device=device),
         )
         self._mask_prep_rids = None
+        self._mask_true = torch.ones((), dtype=torch.bool, device=device)
+        self._mask_rows = torch.arange(rows, device=device)
+        self._mask_staging = (
+            _MaskStaging(torch.device(device))
+            if torch.device(device).type == "cuda"
+            else None
+        )
 
     def _rebuild_masks(self, requests: list, vocab: int, device: Any) -> None:
         rep_mask, sup_mask, pen_col = self._shape_masks
@@ -191,15 +223,21 @@ class Qwen3TTSModelRunner(ModelRunner):
                     if 0 <= tok < vocab:
                         sup_rows.append(row_idx)
                         sup_toks.append(tok)
-        if rep_rows:
-            pairs = torch.tensor(rep_rows + rep_toks, dtype=torch.long, device=device)
-            rep_mask[pairs[: len(rep_rows)], pairs[len(rep_rows) :]] = True
-        if sup_rows:
-            pairs = torch.tensor(sup_rows + sup_toks, dtype=torch.long, device=device)
-            sup_mask[pairs[: len(sup_rows)], pairs[len(sup_rows) :]] = True
-        pen_col[:batch_size, 0] = torch.tensor(
-            penalties, dtype=torch.float32, device=device
-        )
+        flat = rep_rows + rep_toks + sup_rows + sup_toks
+        if self._mask_staging is None:
+            pairs = torch.tensor(flat, dtype=torch.long, device=device)
+            pen = torch.tensor(penalties, dtype=torch.float32, device=device)
+        else:
+            pairs, pen = self._mask_staging.stage(flat, penalties)
+        n_rep = len(rep_rows)
+        n_sup = len(sup_rows)
+        if n_rep:
+            rep_mask[pairs[:n_rep], pairs[n_rep : 2 * n_rep]] = self._mask_true
+        if n_sup:
+            base = 2 * n_rep
+            sup_rows_t = pairs[base : base + n_sup]
+            sup_mask[sup_rows_t, pairs[base + n_sup :]] = self._mask_true
+        pen_col[:batch_size, 0] = pen
         self._mask_rep_active = bool(rep_rows) or any(p != 1.0 for p in penalties)
         self._mask_sup_active = bool(sup_rows)
 
@@ -226,8 +264,10 @@ class Qwen3TTSModelRunner(ModelRunner):
             # not grow by one (retract, restart) can need bits cleared, which the
             # scatter cannot do, so those steps rebuild.
             if self._mask_rep_active:
-                rows = torch.arange(batch_size, device=logits.device)
-                rep_mask[rows, last_sampled[:batch_size].clamp(0, vocab - 1)] = True
+                rows = self._mask_rows[:batch_size]
+                rep_mask[rows, last_sampled[:batch_size].clamp(0, vocab - 1)] = (
+                    self._mask_true
+                )
                 for sched_req in requests:
                     data = sched_req.data
                     output_ids = sched_req.data.req.output_ids

--- a/tests/unit_test/qwen3_tts/test_mask_logit_shaping.py
+++ b/tests/unit_test/qwen3_tts/test_mask_logit_shaping.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import types
 
+import pytest
 import torch
 
 from sglang_omni.models.qwen3_tts.model_runner import Qwen3TTSModelRunner
@@ -16,6 +17,9 @@ def _runner() -> Qwen3TTSModelRunner:
     runner._mask_prep_rids = None
     runner._mask_rep_active = False
     runner._mask_sup_active = False
+    runner._mask_true = None
+    runner._mask_rows = None
+    runner._mask_staging = None
     return runner
 
 
@@ -145,3 +149,43 @@ def test_mask_shaping_empty_history_after_retract():
     logits2 = torch.randn(1, vocab)
     got = _apply(runner, logits2.clone(), reqs)
     assert torch.equal(got, logits2), "no history means no penalty anywhere"
+
+
+@pytest.mark.accelerator
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="mask staging needs CUDA")
+def test_mask_shaping_staged_copies_match_reference_on_cuda():
+    """Long history rebuild, fast path steps, and a batch shrink through the
+    pinned staging path, bit for bit against the scalar reference, with no
+    stream synchronize allowed inside the shaping calls."""
+    torch.manual_seed(13)
+    vocab = 8192
+    device = torch.device("cuda")
+    runner = _runner()
+    reqs = [
+        _request("a", 1, 1.3, list(range(6000)), [5, 90]),
+        _request("b", 2, 1.1, [4], [5, 90]),
+        _request("c", 3, 1.0, [8], []),
+    ]
+
+    def apply_without_sync(logits, requests):
+        torch.cuda.set_sync_debug_mode("error")
+        try:
+            return _apply(runner, logits, requests)
+        finally:
+            torch.cuda.set_sync_debug_mode("default")
+
+    for step in range(5):
+        logits = torch.randn(3, vocab, dtype=torch.float32, device=device)
+        got = apply_without_sync(logits.clone(), reqs)
+        if step == 0:
+            assert runner._mask_staging is not None
+        expected = _reference(logits.cpu(), reqs).to(device)
+        assert torch.equal(got, expected), step
+        new = [6000 + step, 40 + step, 70 + step]
+        for req, tok in zip(reqs, new):
+            req.data.req.output_ids = req.data.req.output_ids + [tok]
+        runner._mask_last_sampled = torch.tensor(new, device=device)
+    survivors = [reqs[1], reqs[2]]
+    logits2 = torch.randn(2, vocab, device=device)
+    got = apply_without_sync(logits2.clone(), survivors)
+    assert torch.equal(got, _reference(logits2.cpu(), survivors).to(device))


### PR DESCRIPTION
## Motivation

Qwen3-TTS decode steps block the scheduler thread on the GPU once per step inside the repetition penalty path. With profiler stacks on one H200: at concurrency 1, 174 of 183 steps hit a cudaStreamSynchronize inside _apply_repetition_penalty (about 1.5 ms each, the host waits for the whole forward before it can launch the sampler), at concurrency 16 the mask rebuild adds about two synchronizes per step. The cause is a pageable host to device copy: assigning a Python bool into the device mask, and torch.tensor(list, device=cuda) for the index pairs and penalty column.

## Modifications

- _MaskStaging: the mask rebuild builds the index pairs and the penalty column as pinned host tensors (torch.tensor with pin_memory=True) and copies them to the device with non_blocking=True. The caching host allocator keeps a pinned block alive until the copy that reads it has completed, so no explicit event or synchronize is needed.
- The incremental fast path scatters a resident device True scalar and uses a cached row index instead of a per step torch.arange.
- CPU execution keeps the previous torch.tensor path so the existing mask tests and test doubles are unchanged.

## Related Issues

Part of the kernel work tracked in #1650 (decode loop host overhead).

## Accuracy Test

- tests/unit_test/qwen3_tts/test_mask_logit_shaping.py: the existing bit for bit reference tests pass, plus a new CUDA test with a 6000 token history, fast path steps and a batch shrink, bitwise equal to the scalar reference.
- tests/unit_test/qwen3_tts/test_pipeline.py passes.
- The mask tests compare bit for bit with the scalar reference on CPU and CUDA, and the CUDA test runs the shaping calls under torch.cuda.set_sync_debug_mode("error") so a reintroduced synchronize fails the test. Logits are unchanged, so WER is unchanged by construction.

## Benchmark & Profiling

Decode step probe (torch profiler with stacks on one H200, so absolute times carry CUPTI overhead, compare the deltas), talker thread:

| per step | main | this PR |
| --- | --- | --- |
| c1 wall / GPU busy / blocked (ms) | 18.9 / 6.4 / 7.1 | 17.3 / 6.4 / 5.6 |
| c1 sampling segment (ms) | 7.9 | 4.7 |
| c1 stream synchronizes inside the repetition penalty | 156 of 161 steps, 1.44 ms each | 0 |
| c16 sampling segment (ms) | 15.5 | 12.3 |
| c16 stream synchronizes inside the repetition penalty | 185 | 0 |

Serving gate (SeedTTS EN 96 clips, streaming, c1 and c16, A-B-A with two candidate servers, three repeats each, warm repeats compared, single process topology):

| metric | baseline1 | cand | cand2 | baseline2 | band |
| --- | --- | --- | --- | --- | --- |
| c1 throughput qps | 1.62 | 1.92 | 1.87 | 1.77 | 15.3 percent |
| c1 inter chunk mean s | 0.0872 | 0.0725 | 0.0747 | 0.0803 | 13.8 percent |
| c16 throughput qps | 8.26 | 9.57 | 10.29 | 9.68 | 15.9 percent |
| c16 inter chunk mean s | 0.262 | 0.227 | 0.211 | 0.228 | 13.9 percent |

Both candidate servers beat both baselines at c1 (plus 10 to 13 percent on throughput and inter chunk latency), which matches the mechanism (about 1.4 ms removed from a 10 ms step). The host was shared during the run (load average 48 to 91) and the two baselines differ by 9 percent, so the formal band is wider than the effect. A second, interleaved run (baseline, candidate, baseline, candidate, baseline, candidate, two repeats each, host load 45 to 114) gives the same picture: every candidate server beats every baseline server on c1 inter chunk latency (0.0748, 0.0749, 0.0687 s versus 0.0874, 0.0853, 0.0777 s, plus 12.8 percent on the means), c16 shows no consistent effect, which matches the probe: at c16 the removed synchronizes were short because the GPU was already idle when they happened. Across both runs, 5 of 5 candidate servers beat all baseline servers on c1 inter chunk latency.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
