### PR TITLE
[Benchmark] Qwen3-TTS mixed traffic adapter

### DIFF
--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -90,7 +90,7 @@ from pathlib import Path
 from typing import Any
 
 from benchmarks.benchmarker.data import RequestResult
-from benchmarks.benchmarker.runner import BenchmarkRunner, RunConfig
+from benchmarks.benchmarker.runner import BenchmarkRunner, RunConfig, SendFn
 from benchmarks.benchmarker.utils import managed_omni_server
 from benchmarks.dataset.seedtts import SampleInput, load_seedtts_samples
 from benchmarks.metrics.performance import (
@@ -162,6 +162,10 @@ class TtsSeedttsBenchmarkConfig:
     top_k: int | None = None
     repetition_penalty: float | None = None
     seed: int | None = None
+    # Note (Shulei He): Fraction of requests sent with subtalker_dosample=True (rest use False),
+    # deterministically alternated by sample index so runs are reproducible.
+    # None leaves subtalker_dosample unset, i.e. the server-side default applies.
+    subtalker_dosample_ratio: float | None = None
     warmup: int = 1
     concurrency: int = DEFAULT_TTS_BENCHMARK_CONCURRENCY
     request_rate: float = float("inf")
@@ -208,6 +212,21 @@ def _build_generation_kwargs(config: TtsSeedttsBenchmarkConfig) -> dict:
     return generation_kwargs
 
 
+def _subtalker_dosample_flags(
+    samples: list[SampleInput],
+    ratio: float,
+) -> dict[str, bool]:
+    if not 0.0 <= ratio <= 1.0:
+        raise ValueError(
+            f"--subtalker-dosample-ratio must be in [0, 1], got {ratio}"
+        )
+    flags: dict[str, bool] = {}
+    for index, sample in enumerate(samples):
+        dosample = math.floor((index + 1) * ratio) > math.floor(index * ratio)
+        flags[sample.sample_id] = dosample
+    return flags
+
+
 def _build_results_config(
     config: TtsSeedttsBenchmarkConfig,
     *,
@@ -229,6 +248,7 @@ def _build_results_config(
         "sample_offset": config.sample_offset,
         "max_new_tokens": config.max_new_tokens,
         "seed": config.seed,
+        "subtalker_dosample_ratio": config.subtalker_dosample_ratio,
         "token_count": config.token_count,
         "warmup": config.warmup,
         "concurrency": config.concurrency,
@@ -258,6 +278,43 @@ def _load_benchmark_samples(config: TtsSeedttsBenchmarkConfig) -> list[SampleInp
     return load_seedtts_samples(config.meta, config.max_samples, split=config.lang)
 
 
+def _make_subtalker_dosample_send_fn(
+    config: TtsSeedttsBenchmarkConfig,
+    api_url: str,
+    common_send_kwargs: dict,
+    generation_kwargs: dict,
+    samples: list[SampleInput],
+) -> SendFn:
+    # Note (Shulei He): Qwen3-TTS-only: alternate subtalker_dosample per request for mixed
+    # sampled/greedy predictor traffic.
+    dosample_by_id = _subtalker_dosample_flags(
+        samples, config.subtalker_dosample_ratio
+    )
+    send_fn_true = make_tts_send_fn(
+        config.model,
+        api_url,
+        **common_send_kwargs,
+        **generation_kwargs,
+        stage_params={"tts_engine": {"subtalker_dosample": True}},
+    )
+    send_fn_false = make_tts_send_fn(
+        config.model,
+        api_url,
+        **common_send_kwargs,
+        **generation_kwargs,
+        stage_params={"tts_engine": {"subtalker_dosample": False}},
+    )
+    send_fn_by_id = {
+        sample_id: (send_fn_true if dosample else send_fn_false)
+        for sample_id, dosample in dosample_by_id.items()
+    }
+
+    async def send_fn(session, sample):
+        return await send_fn_by_id[sample.sample_id](session, sample)
+
+    return send_fn
+
+
 async def run_tts_seedtts_benchmark(
     config: TtsSeedttsBenchmarkConfig,
     *,
@@ -282,9 +339,7 @@ async def run_tts_seedtts_benchmark(
         os.makedirs(config.output_dir, exist_ok=True)
 
     generation_kwargs = _build_generation_kwargs(config)
-    send_fn = make_tts_send_fn(
-        config.model,
-        api_url,
+    common_send_kwargs = dict(
         response_format=config.response_format,
         stream=config.stream,
         initial_codec_chunk_frames=config.initial_codec_chunk_frames,
@@ -295,8 +350,15 @@ async def run_tts_seedtts_benchmark(
         task_type=config.task_type,
         instructions=config.instructions,
         save_audio_dir=save_audio_dir,
-        **generation_kwargs,
     )
+    if config.subtalker_dosample_ratio is None:
+        send_fn = make_tts_send_fn(
+            config.model, api_url, **common_send_kwargs, **generation_kwargs
+        )
+    else:
+        send_fn = _make_subtalker_dosample_send_fn(
+            config, api_url, common_send_kwargs, generation_kwargs, samples
+        )
 
     runner = BenchmarkRunner(
         RunConfig(
@@ -386,6 +448,7 @@ def _config_from_args(args: argparse.Namespace) -> TtsSeedttsBenchmarkConfig:
         top_k=args.top_k,
         repetition_penalty=args.repetition_penalty,
         seed=args.seed,
+        subtalker_dosample_ratio=args.subtalker_dosample_ratio,
         warmup=args.warmup,
         concurrency=args.concurrency,
         request_rate=args.request_rate,
@@ -748,6 +811,18 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help="Per-request sampler seed for reproducible generation.",
+    )
+    parser.add_argument(
+        "--subtalker-dosample-ratio",
+        type=float,
+        default=None,
+        help=(
+            "Optional model-specific (Qwen3-TTS only) fraction of requests "
+            "sent with subtalker_dosample=True (the rest use False), "
+            "deterministically interleaved by sample index. 1.0 = all "
+            "sampled, 0.0 = all greedy, 0.5 = alternating mixed traffic. "
+            "Omit to leave subtalker_dosample unset (server-side default)."
+        ),
     )
     parser.add_argument("--warmup", type=int, default=1)
     parser.add_argument(

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -218,6 +218,12 @@ def build_qwen3_tts_state(payload: StagePayload) -> Qwen3TTSState:
     tts_params = metadata.get("tts_params")
     if not isinstance(tts_params, dict):
         tts_params = {}
+    stage_params = params.get("stage_params")
+    tts_engine_params = {}
+    if isinstance(stage_params, dict) and isinstance(
+        stage_params.get("tts_engine"), dict
+    ):
+        tts_engine_params = stage_params["tts_engine"]
 
     text, references = normalize_qwen3_tts_inputs(inputs)
     has_reference = has_voice_clone_reference(references, tts_params)
@@ -310,7 +316,11 @@ def build_qwen3_tts_state(payload: StagePayload) -> Qwen3TTSState:
         ),
         x_vector_only_mode=x_vector_only_mode,
         non_streaming_mode=non_streaming_mode,
-        generation_kwargs=build_generation_kwargs(params, tts_params=tts_params),
+        generation_kwargs=build_generation_kwargs(
+            params,
+            tts_params=tts_params,
+            tts_engine_params=tts_engine_params,
+        ),
         seed=normalized_seed,
     )
 
@@ -449,6 +459,7 @@ def build_generation_kwargs(
     params: dict[str, Any],
     *,
     tts_params: dict[str, Any],
+    tts_engine_params: dict[str, Any],
 ) -> dict[str, Any]:
     explicit_generation_params = tts_params.get("explicit_generation_params")
     if isinstance(explicit_generation_params, (list, tuple, set)):
@@ -456,25 +467,29 @@ def build_generation_kwargs(
     else:
         explicit_fields = set()
 
-    selected_fields = set()
+    selected_fields: dict[str, Any] = {}
     for field in _GENERATION_FIELDS:
+        stage_value = tts_engine_params.get(field)
+        if stage_value is not None:
+            selected_fields[field] = stage_value
+            continue
         value = params.get(field)
         if value is None:
             continue
         if field in _IMPLICIT_SAMPLING_DEFAULTS and field not in explicit_fields:
             if value in _IMPLICIT_SAMPLING_DEFAULTS[field]:
                 continue
-        selected_fields.add(field)
+        selected_fields[field] = value
 
-    max_new_tokens = params.get("max_new_tokens")
+    max_new_tokens = selected_fields.get("max_new_tokens")
     if max_new_tokens is None:
         max_new_tokens = QWEN3_TTS_DEFAULT_MAX_NEW_TOKENS
     generation_kwargs: dict[str, Any] = {"max_new_tokens": int(max_new_tokens)}
     for field in _GENERATION_FIELDS:
         if field == "max_new_tokens":
             continue
-        if field in selected_fields and params.get(field) is not None:
-            generation_kwargs[field] = params[field]
+        if field in selected_fields:
+            generation_kwargs[field] = selected_fields[field]
     return generation_kwargs
 
 


### PR DESCRIPTION
> [!CAUTION]
> **Permanent draft — benchmark support only. Do not merge.**

This PR makes the temporary baseline adapter used to benchmark #1726 reviewable and reproducible.

## Why this is needed

The unmodified `main` benchmark harness has no `--subtalker-dosample-ratio` option, and its Qwen3-TTS request builder does not consume `stage_params.tts_engine`. Without this adapter, `main`  ignores the per-request  subtalker_dosample values, so every request falls back to the server default (`True`). The resulting Predictor batches are all-sampled rather than mixed.

## Changes
Same changes are included in #1726 

- Add `--subtalker-dosample-ratio` to `benchmark_tts_seedtts.py`.
- Deterministically distribute sampled/argmax requests by sample index.
- Send the per-request value through `stage_params.tts_engine.subtalker_dosample`.
- Forward those nested TTS-engine values into Qwen3-TTS generation kwargs.

## Non-goals

- No Predictor implementation changes.
- No CUDA Graph changes.
- No scheduler changes.
- This branch must never be merged into `main`; equivalent production functionality is reviewed in #1726.

## Validation

An instrumented H200 smoke at ratio 0.5 / c8 confirmed both arms received real partial-sampled batches (`batch_size=8`, `sampled_rows=4`). With this adapter, `main` retained its existing mixed eager fallback while #1726 captured/replayed the sampled graph key.