### PR TITLE
[Deps][XPU] Align the Intel XPU stack with SGLang 0.5.18

### DIFF
--- a/docker/xpu.Dockerfile
+++ b/docker/xpu.Dockerfile
@@ -1,33 +1,69 @@
-# Intel XPU image for sglang-omni. Mirrors SGLang's docker/xpu.Dockerfile, and
-# swaps in pyproject_xpu.toml so no CUDA-only wheels are pulled.
+# Intel XPU image for sglang-omni. Mirrors SGLang's own XPU image, and swaps in
+# pyproject_xpu.toml so no CUDA-only wheels are pulled. Keep this file in step with
+# https://github.com/sgl-project/sglang/blame/main/docker/xpu.Dockerfile -- the blame
+# view is the quickest way to see why a given pin below is there.
 #   docker build -f docker/xpu.Dockerfile -t sglang-omni:xpu .
 #   docker run -it --device /dev/dri --shm-size 32g sglang-omni:xpu
 
-FROM intel/deep-learning-essentials:2025.3.2-0-devel-ubuntu24.04 AS base
+FROM intel/deep-learning-essentials:2026.0.0-devel-ubuntu24.04 AS base
 
 ARG SGLANG_XPU_REPO=https://github.com/sgl-project/sglang.git
-ARG SGLANG_XPU_BRANCH=v0.5.16
+ARG SGLANG_XPU_BRANCH=v0.5.18
 # SGLang's XPU manifest requires sgl-kernel-xpu with no revision, so pinning SGLang
-# alone leaves the SYCL kernels floating. Pinned to the revision this PR was built
-# against; override only to move deliberately.
-ARG SGL_KERNEL_XPU_REF=8c4f5e8c1f4ad10b3af9791e216295db3493c7d9
+# alone leaves the SYCL kernels floating. Pinned to the last sgl-kernel-xpu revision
+# at the v0.5.18 tag boundary; override only to move deliberately.
+ARG SGL_KERNEL_XPU_REF=c1b7e00ff8a07f0ebcd922045e117d83a87e0112
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_INDEX_URL=https://pypi.org/simple
 ENV TORCH_XPU_INDEX=https://download.pytorch.org/whl/xpu
 
+# Level-Zero UMD + IGC, mirroring SGLang's image, which pins them because the rolling
+# PPA once faulted libze on B580 (sgl-kernel-xpu#296). Keep in lockstep with the host
+# xe KMD; override via --build-arg.
+ARG COMPUTE_RUNTIME_VERSION=26.18.38308.1
+ARG IGC_VERSION=2.34.4+21428
+ARG GMM_VERSION=22.10.0
+
 WORKDIR /workspace
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        git ffmpeg libsndfile1 sox \
+        git ffmpeg libsndfile1 sox software-properties-common curl ca-certificates \
+    && add-apt-repository -y ppa:kobuk-team/intel-graphics \
+    && apt-get update \
+    # Loader + media/metrics from the PPA; the GPU driver itself is pinned below.
+    && apt-get install -y \
+        libze1 libze-dev intel-metrics-discovery clinfo intel-gsc \
+        intel-media-va-driver-non-free libmfx-gen1 libvpl2 va-driver-all vainfo \
+    && cd /tmp \
+    && igc_url="https://github.com/intel/intel-graphics-compiler/releases/download/v${IGC_VERSION%%+*}" \
+    && cr_url="https://github.com/intel/compute-runtime/releases/download/${COMPUTE_RUNTIME_VERSION}" \
+    # IGC first: libze-intel-gpu1 / intel-opencl-icd depend on its exact version.
+    && curl -fsSL -O "${igc_url}/intel-igc-core-2_${IGC_VERSION}_amd64.deb" \
+    && curl -fsSL -O "${igc_url}/intel-igc-opencl-2_${IGC_VERSION}_amd64.deb" \
+    && curl -fsSL -O "${cr_url}/libigdgmm12_${GMM_VERSION}_amd64.deb" \
+    && curl -fsSL -O "${cr_url}/libze-intel-gpu1_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb" \
+    && curl -fsSL -O "${cr_url}/intel-opencl-icd_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb" \
+    && curl -fsSL -O "${cr_url}/intel-ocloc_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb" \
+    && apt-get install -y --allow-downgrades \
+        ./intel-igc-core-2_${IGC_VERSION}_amd64.deb \
+        ./intel-igc-opencl-2_${IGC_VERSION}_amd64.deb \
+        ./libigdgmm12_${GMM_VERSION}_amd64.deb \
+        ./libze-intel-gpu1_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb \
+        ./intel-opencl-icd_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb \
+        ./intel-ocloc_${COMPUTE_RUNTIME_VERSION}-0_amd64.deb \
+    && rm -f /tmp/*.deb \
+    # Hold so a later apt upgrade cannot pull the rolling PPA version back over these.
+    && apt-mark hold libze-intel-gpu1 intel-opencl-icd intel-ocloc libigdgmm12 \
+        intel-igc-core-2 intel-igc-opencl-2 \
     && rm -rf /var/lib/apt/lists/*
 
-# Minors differ on purpose: the XPU channel ships no torchaudio 2.12+xpu.
+# Minors differ on purpose: the XPU channel ships no torchaudio newer than 2.11+xpu.
 RUN pip install --no-cache-dir --extra-index-url ${TORCH_XPU_INDEX} \
-        torch==2.12.0+xpu \
-        torchvision==0.27.0+xpu \
+        torch==2.13.0+xpu \
+        torchvision==0.28.0+xpu \
         torchaudio==2.11.0+xpu \
-        torchcodec==0.12.0
+        torchcodec==0.13.0
 
 # The grep guard fails the build if upstream reshapes that requirement line, since
 # the sed would otherwise no-op and silently restore a floating kernel.

--- a/docs/get_started/installation_xpu.md
+++ b/docs/get_started/installation_xpu.md
@@ -91,7 +91,7 @@ It cannot be pinned even as a range: every published wheel requires `flashinfer_
 
 ```bash
 git clone https://github.com/sgl-project/sglang && cd sglang
-git checkout v0.5.16   # the pinned release
+git checkout v0.5.18   # the pinned release
 cd python && cp pyproject_xpu.toml pyproject.toml
 pip install -e . --no-build-isolation --extra-index-url https://download.pytorch.org/whl/xpu
 ```

--- a/pyproject_xpu.toml
+++ b/pyproject_xpu.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 # Intel XPU variant of pyproject.toml (see docs/get_started/installation_xpu.md).
 # Torch family pinned to +xpu; CUDA-only wheels dropped; deps scoped to the
-# XPU-supported models. sglang is verified against v0.5.16 but cannot be
+# XPU-supported models. sglang is verified against v0.5.18 but cannot be
 # pinned here -- every published wheel pulls CUDA torch.
 
 [project]
@@ -34,16 +34,15 @@ dependencies = [
     "typer>=0.9.0",
 
     # --- PyTorch XPU builds (from --extra-index-url .../whl/xpu) -------------
-    # Pins match SGLang's xpu.Dockerfile; mismatched minors are what the XPU
-    # channel ships.
-    "torch==2.12.0+xpu",
-    "torchvision==0.27.0+xpu",
+    # Pins match SGLang's pyproject_xpu.toml / xpu.Dockerfile.
+    "torch==2.13.0+xpu",
+    "torchvision==0.28.0+xpu",
     "torchaudio==2.11.0+xpu",
-    "torchcodec==0.12.0",
+    "torchcodec==0.13.0",
 
     # --- Model loading / HF -------------------------------------------------
     "accelerate>=0.27.0",
-    "transformers==5.12.1",        # Match SGLang 0.5.16, as the CUDA pyproject does
+    "transformers==5.12.1",
     "safetensors>=0.4.3",
     "pillow>=10.0.0",
     "huggingface-hub>=0.36.0",

--- a/scripts/xpu/install_xpu.sh
+++ b/scripts/xpu/install_xpu.sh
@@ -35,7 +35,7 @@ PYPROJECT="${REPO_ROOT}/pyproject.toml"
 PYPROJECT_XPU="${REPO_ROOT}/pyproject_xpu.toml"
 BACKUP="${REPO_ROOT}/.pyproject.cuda.bak"
 
-SGLANG_VERIFIED_VERSION="v0.5.16"
+SGLANG_VERIFIED_VERSION="v0.5.18"
 
 [[ -f "${PYPROJECT_XPU}" ]] || { echo "ERROR: ${PYPROJECT_XPU} not found" >&2; exit 1; }
 


### PR DESCRIPTION
## Motivation

[#1719](https://github.com/sgl-project/sglang-omni/pull/1719) bumped the CUDA manifest to
`sglang==0.5.18` and moved its torch stack to 2.13.0, but the Intel XPU manifest was not part of
that change. [`pyproject_xpu.toml`](../pyproject_xpu.toml) and
[`docker/xpu.Dockerfile`](../docker/xpu.Dockerfile) were still pinned to the 0.5.16-era stack, so
an XPU build after #1719 pairs **0.5.18 sources with the torch family the previous release
pinned**.

That skew is not benign on XPU, because `sglang` deliberately **cannot** be pinned in
`pyproject_xpu.toml` — every published `sglang` wheel requires `flashinfer_python[cu13]` and the
`nvidia-*` runtime, so any specifier drags CUDA torch over `torch+xpu`. The XPU path therefore
installs SGLang from source, and these two files plus the docs are the *only* record of which
SGLang revision the XPU port is built against. When they go stale, there is nothing else to
correct them.

This PR moves the XPU side onto SGLang v0.5.18, tracking upstream's own XPU manifest and image
rather than choosing versions independently.

## Modifications

### 1. Torch family and base image → SGLang v0.5.18

Every pin is taken from SGLang v0.5.18's own XPU files, not picked independently:

- [`python/pyproject_xpu.toml#L62-L67`](https://github.com/sgl-project/sglang/blob/v0.5.18/python/pyproject_xpu.toml#L62-L67)
- [`docker/xpu.Dockerfile#L4`](https://github.com/sgl-project/sglang/blob/v0.5.18/docker/xpu.Dockerfile#L4)
  (base image) and [`#L72`](https://github.com/sgl-project/sglang/blob/v0.5.18/docker/xpu.Dockerfile#L72) (torch install)

| Dependency | Before (0.5.16) | After (0.5.18) | Upstream source |
| --- | --- | --- | --- |
| `torch` | `2.12.0+xpu` | **`2.13.0+xpu`** | [pyproject_xpu.toml#L62](https://github.com/sgl-project/sglang/blob/v0.5.18/python/pyproject_xpu.toml#L62) |
| `torchvision` | `0.27.0+xpu` | **`0.28.0+xpu`** | [pyproject_xpu.toml#L65](https://github.com/sgl-project/sglang/blob/v0.5.18/python/pyproject_xpu.toml#L65) |
| `torchaudio` | `2.11.0+xpu` | `2.11.0+xpu` *(unchanged)* | [pyproject_xpu.toml#L63](https://github.com/sgl-project/sglang/blob/v0.5.18/python/pyproject_xpu.toml#L63) |
| `torchcodec` | `0.12.0` | **`0.13.0`** | [pyproject_xpu.toml#L64](https://github.com/sgl-project/sglang/blob/v0.5.18/python/pyproject_xpu.toml#L64) |
| `transformers` | `5.12.1` | `5.12.1` *(unchanged)* | [pyproject_xpu.toml#L67](https://github.com/sgl-project/sglang/blob/v0.5.18/python/pyproject_xpu.toml#L67) |
| Base image | `intel/deep-learning-essentials:2025.3.2-0-devel-ubuntu24.04` | **`…:2026.0.0-devel-ubuntu24.04`** | [xpu.Dockerfile#L4](https://github.com/sgl-project/sglang/blob/v0.5.18/docker/xpu.Dockerfile#L4) |

Two notes on the asymmetry, since it looks like an oversight:

- **`torchaudio` stays at 2.11.0** while torch moves to 2.13.0. The
  [PyTorch XPU wheel index](https://download.pytorch.org/whl/xpu/torchaudio/) publishes no
  `2.12+xpu` or `2.13+xpu` build, so the mismatched minor is what the channel ships. Upstream
  carries the same mismatch.
- **The base image bump is an oneAPI bump.** `intel/deep-learning-essentials` `2025.3.2-0` →
  [`2026.0.0`](https://hub.docker.com/r/intel/deep-learning-essentials/tags?name=2026.0.0)
  moves the bundled oneAPI/DPC++ from 2025.3 to 2026.0, which is the toolchain `torch 2.13.0+xpu`
  is built with.

### 2. Level-Zero UMD / IGC / GMM pins in the image (the largest part of the diff)

This is the part worth explaining, since it is new to sglang-omni.

`docker/xpu.Dockerfile` in this repo has always been **a mirror of SGLang's XPU image** (its header
says so). Between the two versions this PR crosses, upstream added a pinned driver stack to that
file:

- Added in **v0.5.17** by [sgl-project/sglang#32438](https://github.com/sgl-project/sglang/pull/32438)
  — *"[CI][XPU] Stabilize XPU CI: pin UMD/IGC, retry infra flakes, right-size EAGLE3"*
- Still present in v0.5.18:
  [`docker/xpu.Dockerfile#L20-L24`](https://github.com/sgl-project/sglang/blob/v0.5.18/docker/xpu.Dockerfile#L20-L24)
- **Not present in v0.5.16** — which is exactly why it shows up now rather than earlier

Upstream's stated reason, verbatim from
[their line 20](https://github.com/sgl-project/sglang/blob/v0.5.18/docker/xpu.Dockerfile#L20):

> `# Pin Level-Zero UMD + IGC (rolling PPA once faulted libze on B580; see sgl-kernel-xpu#296).`

The `ppa:kobuk-team/intel-graphics` PPA is a **rolling** repository: an unpinned
`apt-get install libze-intel-gpu1` resolves to whatever is current on build day, and a bad roll
faulted `libze` on B580 ([sgl-kernel-xpu#296](https://github.com/sgl-project/sgl-kernel-xpu/issues/296)).
sglang-omni's image previously took its driver from the base image with no pin at all, so it has
the same exposure — a rebuild months from now silently gets a different driver. Mirroring the pins
makes rebuilds reproducible.

Pinned versions, matching upstream exactly:

| ARG | Value | Release |
| --- | --- | --- |
| `COMPUTE_RUNTIME_VERSION` | `26.18.38308.1` | [intel/compute-runtime](https://github.com/intel/compute-runtime/releases/tag/26.18.38308.1) |
| `IGC_VERSION` | `2.34.4+21428` | [intel/intel-graphics-compiler](https://github.com/intel/intel-graphics-compiler/releases/tag/v2.34.4) |
| `GMM_VERSION` | `22.10.0` | shipped in the compute-runtime release above |

Why the PPA lines come along rather than only the `.deb` downloads: the pinned
`libze-intel-gpu1` depends on the Level-Zero **loader** (`libze1`), which
`intel/deep-learning-essentials` does not carry. The PPA supplies the loader and the media/metrics
packages; the GPU driver itself is then pinned over the top with `--allow-downgrades`, and
`apt-mark hold` stops a later `apt upgrade` pulling the rolling version back. This is upstream's
ordering, kept intact.

The image header now links
[SGLang's blame view for that file](https://github.com/sgl-project/sglang/blame/main/docker/xpu.Dockerfile)
so the provenance of each pin stays traceable on the next bump, instead of the next person having
to rediscover why these ARGs exist.

### 3. `SGL_KERNEL_XPU_REF` advanced

SGLang's XPU manifest requires `sgl-kernel` from git with **no revision**
([`pyproject_xpu.toml`](https://github.com/sgl-project/sglang/blob/v0.5.18/python/pyproject_xpu.toml),
`sgl-kernel @ git+https://github.com/sgl-project/sgl-kernel-xpu.git`), so pinning SGLang alone
leaves the SYCL kernels floating at `main`. This repo pins the revision itself for reproducibility.

Advanced from `8c4f5e8` (2026-08-12, 0.5.16 era) to
[`c1b7e00`](https://github.com/sgl-project/sgl-kernel-xpu/commit/c1b7e00ff8a07f0ebcd922045e117d83a87e0112)
— the last `sgl-kernel-xpu` commit at the
[v0.5.18 tag](https://github.com/sgl-project/sglang/releases/tag/v0.5.18) boundary (2026-08-19).

`fused_inplace_qknorm_rope` — the only `sgl-kernel` symbol
[`sglang_omni/platforms/xpu.py`](../sglang_omni/platforms/xpu.py) imports — is unchanged across
that range; the only rope-adjacent commit in the window adds a *new* kernel
(`compress_norm_rope_store`) rather than touching it.

### 4. Docs / installer version references

`sglang` is installed from source on XPU, so the release name is written down in two places and
both were stale:

- [`scripts/xpu/install_xpu.sh`](../scripts/xpu/install_xpu.sh) — `SGLANG_VERIFIED_VERSION`, printed
  in the "sglang is NOT installed" hint alongside the from-source build steps
- [`docs/get_started/installation_xpu.md`](../docs/get_started/installation_xpu.md) —
  `git checkout v0.5.16` → `v0.5.18` in the from-source instructions

## Related Issues

None. Follow-up to [#1719](https://github.com/sgl-project/sglang-omni/pull/1719), which bumped the
CUDA side only.

Upstream references:
- [sgl-project/sglang#32438](https://github.com/sgl-project/sglang/pull/32438) — added the UMD/IGC pins mirrored here
- [sgl-project/sgl-kernel-xpu#296](https://github.com/sgl-project/sgl-kernel-xpu/issues/296) — the `libze` fault on B580 that motivated them

## Accuracy Test

Not applicable — no model-side code, kernels, or model architecture are touched. The diff is
dependency metadata, the image definition, an installer string, and docs; no `sglang_omni/**` Python
file changes.

## Benchmark & Profiling

Not applicable — no performance-relevant code paths are touched. No throughput, latency, or memory
behaviour changes from this PR itself.

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests. — *No new behaviour to test. The existing XPU suite covers the touched
      surfaces and passes: `pytest tests/unit_test/xpu/ -q` → **11 passed** (this includes
      `test_install_script.py`, which parses `scripts/xpu/install_xpu.sh`).*
- [x] Update documentation / docstrings / example tutorials as needed. — `installation_xpu.md`
      updated to the new release.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed. —
      *Not applicable, see above.*
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with
      merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

### What was verified

Every version string in this PR was resolved against the live index before being committed, rather
than copied on faith:

| Check | Result |
| --- | --- |
| `torch==2.13.0+xpu` on [download.pytorch.org/whl/xpu](https://download.pytorch.org/whl/xpu/torch/) | present |
| `torchvision==0.28.0+xpu` | present |
| `torchaudio==2.11.0+xpu` | present |
| `torchcodec==0.13.0` on [PyPI](https://pypi.org/project/torchcodec/0.13.0/) | present |
| `intel/deep-learning-essentials:2026.0.0-devel-ubuntu24.04` on Docker Hub | present |
| All 6 driver `.deb` URLs the Dockerfile `curl`s (IGC core/opencl, GMM, libze-intel-gpu1, opencl-icd, ocloc) | all HTTP 200 |
| `pyproject_xpu.toml` parses (`tomllib`) | OK |
| `scripts/xpu/install_xpu.sh` (`bash -n`) | OK |
| `docker/xpu.Dockerfile` — 19 instructions parse; all 5 `RUN` bodies valid shell after comment-stripping + continuation-joining | OK |
| `pytest tests/unit_test/xpu/ -q` | 11 passed |

cc: @Ratish1 @rbabukv