### PR TITLE
[Qwen3-Omni Perf] Prewarm Qwen3-Omni Talker request construction before partial start

### DIFF
--- a/sglang_omni/models/qwen3_omni/talker_model_runner.py
+++ b/sglang_omni/models/qwen3_omni/talker_model_runner.py
@@ -12,6 +12,7 @@ from sglang_omni.model_runner.prefill_inputs import (
     OmniPrefillInputs,
     attach_omni_prefill_inputs,
 )
+from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.scheduling.messages import OutgoingMessage
 
 
@@ -42,16 +43,21 @@ class QwenTalkerModelRunner(ModelRunner):
     ) -> None:
         del schedule_batch
         composed = self._compose_prefill_embeds(forward_batch, requests)
-        if composed is None:
-            return
-        input_embeds, input_embeds_are_projected = composed
-        attach_omni_prefill_inputs(
-            forward_batch,
-            OmniPrefillInputs(
-                input_embeds=input_embeds,
-                input_embeds_are_projected=input_embeds_are_projected,
-            ),
-        )
+        if composed is not None:
+            input_embeds, input_embeds_are_projected = composed
+            attach_omni_prefill_inputs(
+                forward_batch,
+                OmniPrefillInputs(
+                    input_embeds=input_embeds,
+                    input_embeds_are_projected=input_embeds_are_projected,
+                ),
+            )
+        for request_id in getattr(forward_batch, "rids", ()) or ():
+            _emit_event(
+                request_id=request_id,
+                stage=None,
+                event_name="talker_prefill_forward_start",
+            )
 
     def before_decode(
         self,

--- a/sglang_omni/models/qwen3_omni/talker_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/talker_scheduler.py
@@ -8,6 +8,7 @@ from collections import deque
 from typing import Any
 
 from sglang_omni.models.qwen3_omni.config import MIN_PARTIAL_START_CHUNKS
+from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler
 from sglang_omni.vendor.sglang.server_args import override_server_args
 
@@ -78,10 +79,19 @@ class QwenTalkerScheduler(OmniScheduler):
         if not self._enable_partial_start:
             return False
         prefetched = getattr(payload, "prefetched_chunks", None) or []
-        return (
-            self._count_usable_prefetched_chunks(prefetched)
-            >= self._partial_start_min_chunks
-        )
+        usable_chunks = self._count_usable_prefetched_chunks(prefetched)
+        ready = usable_chunks >= self._partial_start_min_chunks
+        if ready:
+            _emit_event(
+                request_id=payload.request_id,
+                stage=None,
+                event_name="talker_partial_start_ready",
+                metadata={
+                    "usable_chunks": usable_chunks,
+                    "min_chunks": self._partial_start_min_chunks,
+                },
+            )
+        return ready
 
     def _initialize_request_stream_state(self, req_data: Any, payload: Any) -> None:
         del req_data, payload


### PR DESCRIPTION
## Motivation

Qwen3-Omni Talker waits until 5 usable Thinker chunks are available before building the downstream request.

Profiling shows that, after this partial-start condition is met, Talker still spends approximately 15 ms before entering prefill forward.

## Modifications


## Related Issues

Related to #1018, Roadmap 2.4.

## Evidence

Add two request-level profiling events:

- `talker_partial_start_ready`
- `talker_prefill_forward_start`

These events measure the preparation path after the 5-chunk threshold. This PR does not change scheduling or model execution behavior yet.

A C1 request-level profile was collected with:

- 1 × H100, colocated FP8 deployment
- SeedTTS English, first 3 samples repeated 3 times
- Streaming enabled
- Partial start enabled with `min_chunks=5`

| Phase | Mean |
|---|---:|
| Ready to prefill forward | 15.244 ms |
| Request build | 11.953 ms |
| Queue to prefill start | 1.733 ms |
| Prefill input setup | 1.086 ms |

Request construction accounts for approximately 12 ms of the measured 15 ms preparation path.
