### PR TITLE
[Fix][TTS] Restore Qwen3-TTS and delay Moss prompt cache reuse

### DIFF
--- a/docs/developer_reference/rl_admin_control.md
+++ b/docs/developer_reference/rl_admin_control.md
@@ -58,7 +58,10 @@ updated the model weights; recover by reloading or otherwise repairing the
 worker before calling `continue_generation`.
 
 `/update_weights_from_tensor` is still reserved for a future tensor data-plane
-integration and returns HTTP 501 from the worker and router HTTP APIs.
+integration and returns HTTP 501 from the worker and router HTTP APIs. Once
+enabled, a failed tensor update leaves the scheduler paused because tensor
+loading is non-transactional; repair the worker before calling
+`continue_generation`.
 
 ## Stage and TP Behavior
 

--- a/sglang_omni/models/moss_tts/request_builders.py
+++ b/sglang_omni/models/moss_tts/request_builders.py
@@ -9,7 +9,6 @@ import os
 import re
 import threading
 import time
-import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -738,10 +737,12 @@ def build_sglang_moss_tts_request(
         sampling_params=sampling_params,
         eos_token_ids={int(cfg.im_end_token_id)},
         vocab_size=int(cfg.vocab_size_list[0]),
-        extra_key=f"moss_tts:{uuid.uuid4().hex}",
+        extra_key="moss_tts:prompt:v1",
     )
     req.tokenizer = None
     req._input_embeds_are_projected = True
+    req._omni_prompt_only_radix = True
+    req._omni_prompt_cache_key = req.extra_key
     req._codec_suppress_tokens = None
 
     data = MossTTSSGLangRequestData(

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -10,7 +10,6 @@ import json
 import queue
 import threading
 import time
-import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -1200,10 +1199,12 @@ def build_sglang_qwen3_tts_request(
         sampling_params=sampling_params,
         eos_token_ids={int(model.config.codec_eos_token_id)},
         vocab_size=int(model.config.vocab_size),
-        extra_key=f"qwen3_tts:{uuid.uuid4().hex}",
+        extra_key="qwen3_tts:prompt:v1",
     )
     req.tokenizer = None
     req._input_embeds_are_projected = True
+    req._omni_prompt_only_radix = True
+    req._omni_prompt_cache_key = req.extra_key
 
     ref_code_len = (
         int(prepared.ref_code.shape[0]) if prepared.ref_code is not None else 0

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -213,6 +213,7 @@ class OmniScheduler:
         self._shutdown_callback = shutdown_callback
         self._shutdown_lock = threading.Lock()
         self._request_admission_lock = threading.RLock()
+        self._prompt_cache_epoch = 0
         self.request_build_max_workers = max(1, int(request_build_max_workers))
         if self.request_build_max_workers > 1 and int(server_args.tp_size) > 1:
             logger.warning(
@@ -1192,6 +1193,7 @@ class OmniScheduler:
                     len(self.waiting_queue),
                 )
                 return
+            self._apply_prompt_cache_epoch(req)
             _emit_event(
                 request_id=req_id,
                 stage=None,
@@ -1207,6 +1209,17 @@ class OmniScheduler:
         else:
             with self._request_admission_lock:
                 enqueue_if_live()
+
+    def _apply_prompt_cache_epoch(self, req: Any) -> None:
+        cache_key = getattr(req, "_omni_prompt_cache_key", None)
+        if cache_key is not None:
+            req.extra_key = f"{cache_key}:weights:{self._prompt_cache_epoch}"
+
+    def _advance_prompt_cache_epoch(self) -> None:
+        with self._request_admission_lock:
+            self._prompt_cache_epoch += 1
+            for req in self.waiting_queue:
+                self._apply_prompt_cache_epoch(req)
 
     @staticmethod
     def _normalize_req_token_arrays(req: Any) -> None:
@@ -1357,6 +1370,13 @@ class OmniScheduler:
         except Exception as exc:
             self._handle_batch_failure(batch, exc)
             return _FAILED_BATCH_RESULT
+
+    def process_batch_result(self, batch, result) -> None:
+        _Upstream.process_batch_result(self, batch, result)
+        # Cache complete prefills upstream before keeping generated tails private.
+        for req in batch.reqs:
+            if req.output_ids and getattr(req, "_omni_prompt_only_radix", False):
+                req.skip_radix_cache_insert = True
 
     def _stamp_batch_launch(self, batch) -> None:
         """Mirror upstream per-forward bookkeeping for custom runner paths."""
@@ -2015,6 +2035,8 @@ class OmniScheduler:
                     if keep_pause_on_failure:
                         keep_engine_paused = True
                     raise
+                if success:
+                    self._advance_prompt_cache_epoch()
                 flush_success: bool | None = None
                 if success and bool(payload.get("flush_cache", True)):
                     flush_success = self._flush_cache_after_update()

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -1373,7 +1373,7 @@ class OmniScheduler:
 
     def process_batch_result(self, batch, result) -> None:
         _Upstream.process_batch_result(self, batch, result)
-        # Cache complete prefills upstream before keeping generated tails private.
+        # note (Richard Wang): cache prompt before blocking tail inserts
         for req in batch.reqs:
             if req.output_ids and getattr(req, "_omni_prompt_only_radix", False):
                 req.skip_radix_cache_insert = True

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -2078,6 +2078,7 @@ class OmniScheduler:
             {
                 "metadata_only": payload.get("serialized_named_tensors") is None,
             },
+            keep_pause_on_failure=True,
         )
 
     def _admin_update_weights_from_distributed(

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -2072,16 +2072,13 @@ class OmniScheduler:
     def _admin_update_weights_from_tensor(
         self, payload: dict[str, Any]
     ) -> dict[str, Any]:
-        with self._admin_lock:
-            success, message = self.model_worker.update_weights_from_tensor(payload)
-        return {
-            "success": bool(success),
-            "message": str(message),
-            "data": {
+        return self._run_weight_update_with_lifecycle(
+            payload,
+            self.model_worker.update_weights_from_tensor,
+            {
                 "metadata_only": payload.get("serialized_named_tensors") is None,
             },
-            "error": None if success else str(message),
-        }
+        )
 
     def _admin_update_weights_from_distributed(
         self, payload: dict[str, Any]

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -1200,26 +1200,60 @@ def _build_moss_sglang_request(*, request_id: str = "req-moss"):
         clear_moss_tts_preprocessing_context()
 
 
-def test_moss_request_lifetime_extra_key_is_unique_and_survives_retract() -> None:
-    # note (Richard Wang): same rid can recur so extra_key must differ
+def test_moss_prompt_key_and_tail_guard_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.scheduling import omni_scheduler as scheduler_module
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
     first = _build_moss_sglang_request(request_id="shared-moss-id")
     second = _build_moss_sglang_request(request_id="shared-moss-id")
 
     assert first.req.rid == second.req.rid == "shared-moss-id"
-    assert first.req.extra_key
-    assert second.req.extra_key
-    assert first.req.extra_key.startswith("moss_tts:")
-    assert second.req.extra_key.startswith("moss_tts:")
-    assert first.req.extra_key != second.req.extra_key
     assert list(first.req.origin_input_ids) == list(second.req.origin_input_ids)
+    assert first.req.extra_key == second.req.extra_key == "moss_tts:prompt:v1"
+    assert first.req._omni_prompt_cache_key == second.req._omni_prompt_cache_key
 
-    kept = first.req.extra_key
+    seen = []
+    emit = iter([False, True, True])
+
+    def process_result(_, batch, __):
+        seen.append(
+            [getattr(req, "skip_radix_cache_insert", False) for req in batch.reqs]
+        )
+        if next(emit):
+            for req in batch.reqs:
+                req.output_ids.append(7)
+
+    monkeypatch.setattr(
+        scheduler_module._Upstream, "process_batch_result", process_result
+    )
+    scheduler = object.__new__(OmniScheduler)
+    plain = SimpleNamespace(output_ids=[])
+    batch = SimpleNamespace(reqs=[first.req, second.req, plain])
+    scheduler.process_batch_result(batch, None)
+    assert seen == [[False, False, False]]
+    assert not any(getattr(req, "skip_radix_cache_insert", False) for req in batch.reqs)
+    scheduler.process_batch_result(batch, None)
+    assert [getattr(req, "skip_radix_cache_insert", False) for req in batch.reqs] == [
+        True,
+        True,
+        False,
+    ]
+    scheduler.process_batch_result(batch, None)
+
+    assert seen == [
+        [False, False, False],
+        [False, False, False],
+        [True, True, False],
+    ]
+
     first.req.reset_for_retract()
-    assert first.req.extra_key == kept
+    assert first.req.extra_key == "moss_tts:prompt:v1"
+    assert first.req.skip_radix_cache_insert
 
 
-def test_moss_lifetime_extra_key_isolates_delay_slot_generated_prefix() -> None:
-    # note (Richard Wang): text channel keys can match while RVQ differs
+def test_moss_tail_guard_is_required_for_hidden_rvq() -> None:
     from array import array
 
     from sglang.srt.mem_cache.radix_cache import RadixKey
@@ -1240,10 +1274,11 @@ def test_moss_lifetime_extra_key_isolates_delay_slot_generated_prefix() -> None:
     colliding = RadixKey(fill_a, extra_key=None)
     assert colliding.match(RadixKey(fill_b, extra_key=None)) == len(fill_a)
 
-    with pytest.raises(ValueError, match="matching extra_key"):
-        RadixKey(fill_a, first.req.extra_key).match(
-            RadixKey(fill_b, second.req.extra_key)
-        )
+    assert RadixKey(fill_a, first.req.extra_key).match(
+        RadixKey(fill_b, second.req.extra_key)
+    ) == len(fill_a)
+    assert first.req._omni_prompt_only_radix
+    assert second.req._omni_prompt_only_radix
 
 
 def test_moss_delay_runner_samples_audio_and_appends_feedback() -> None:

--- a/tests/unit_test/pipeline/test_admin_control.py
+++ b/tests/unit_test/pipeline/test_admin_control.py
@@ -269,6 +269,38 @@ def test_weight_swap_isolates_prompt_cache_when_flush_fails() -> None:
     assert plain.extra_key == "plain"
 
 
+@pytest.mark.parametrize("failure_mode", ["return", "raise"])
+def test_tensor_update_failure_keeps_engine_paused(failure_mode: str) -> None:
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+    def update_weights_from_tensor(payload: dict) -> tuple[bool, str]:
+        if failure_mode == "raise":
+            raise RuntimeError("partially updated")
+        return False, "partially updated"
+
+    scheduler = object.__new__(OmniScheduler)
+    scheduler.model_worker = SimpleNamespace(
+        update_weights_from_tensor=update_weights_from_tensor
+    )
+    scheduler._admin_lock = threading.Lock()
+    scheduler._engine_paused = False
+    scheduler._last_pause_mode = None
+    scheduler._prompt_cache_epoch = 0
+    scheduler._resolve_pending_async = lambda: None
+    scheduler._active_request_ids = lambda: []
+
+    if failure_mode == "raise":
+        with pytest.raises(RuntimeError, match="partially updated"):
+            scheduler._admin_update_weights_from_tensor({})
+    else:
+        result = scheduler._admin_update_weights_from_tensor({})
+        assert result["success"] is False
+        assert result["data"]["engine_paused"] is True
+
+    assert scheduler._engine_paused is True
+    assert scheduler._prompt_cache_epoch == 0
+
+
 def test_omni_scheduler_flush_cache_has_upstream_idle_compat_fields() -> None:
     from sglang_omni.scheduling.omni_scheduler import OmniScheduler
 

--- a/tests/unit_test/pipeline/test_admin_control.py
+++ b/tests/unit_test/pipeline/test_admin_control.py
@@ -193,6 +193,9 @@ def test_omni_scheduler_update_weights_flushes_cache_without_kwargs() -> None:
     scheduler._engine_paused = False
     scheduler._last_pause_mode = None
     scheduler._async_pending = None
+    scheduler._request_admission_lock = threading.RLock()
+    scheduler._prompt_cache_epoch = 0
+    scheduler.waiting_queue = []
     scheduler._resolve_pending_async = lambda: None
     scheduler._active_request_ids = lambda: []
     scheduler.flush_cache = flush_cache
@@ -212,6 +215,45 @@ def test_omni_scheduler_update_weights_flushes_cache_without_kwargs() -> None:
     assert update_calls == [{"model_path": "/tmp/new-model", "torch_empty_cache": True}]
     assert flush_calls == 1
     assert empty_cache_calls == 1
+    assert scheduler._prompt_cache_epoch == 1
+
+
+def test_weight_swap_isolates_prompt_cache_when_flush_fails() -> None:
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+    cache_key = "qwen3_tts:prompt:v1"
+    retracted = SimpleNamespace(
+        extra_key=f"{cache_key}:weights:0",
+        _omni_prompt_cache_key=cache_key,
+    )
+    scheduler = object.__new__(OmniScheduler)
+    scheduler.model_worker = SimpleNamespace(
+        update_weights_from_disk=lambda _: (True, "swapped")
+    )
+    scheduler._admin_lock = threading.Lock()
+    scheduler._request_admission_lock = threading.RLock()
+    scheduler._engine_paused = True
+    scheduler._last_pause_mode = "retract"
+    scheduler._prompt_cache_epoch = 0
+    scheduler.waiting_queue = [retracted]
+    scheduler._resolve_pending_async = lambda: None
+    scheduler._active_request_ids = lambda: ["req-1"]
+    scheduler.flush_cache = lambda: False
+    scheduler._empty_torch_cache = lambda: None
+
+    result = OmniScheduler._admin_update_weights_from_disk(
+        scheduler, {"model_path": "/tmp/new-model"}
+    )
+
+    fresh = SimpleNamespace(extra_key=cache_key, _omni_prompt_cache_key=cache_key)
+    plain = SimpleNamespace(extra_key="plain")
+    scheduler._apply_prompt_cache_epoch(fresh)
+    scheduler._apply_prompt_cache_epoch(plain)
+    assert result["success"] is False
+    assert result["data"]["flush_success"] is False
+    assert result["data"]["engine_paused"] is True
+    assert retracted.extra_key == fresh.extra_key == f"{cache_key}:weights:1"
+    assert plain.extra_key == "plain"
 
 
 def test_omni_scheduler_flush_cache_has_upstream_idle_compat_fields() -> None:
@@ -340,6 +382,9 @@ def test_omni_scheduler_distributed_update_aborts_and_flushes_cache() -> None:
     scheduler._engine_paused = False
     scheduler._last_pause_mode = None
     scheduler._async_pending = None
+    scheduler._request_admission_lock = threading.RLock()
+    scheduler._prompt_cache_epoch = 0
+    scheduler.waiting_queue = []
     scheduler._resolve_pending_async = lambda: None
     scheduler._active_request_ids = lambda: ["req-1"]
     scheduler._abort_all_requests = abort_all_requests
@@ -366,6 +411,7 @@ def test_omni_scheduler_distributed_update_aborts_and_flushes_cache() -> None:
     assert abort_calls == 1
     assert flush_calls == 1
     assert empty_cache_calls == 1
+    assert scheduler._prompt_cache_epoch == 1
 
 
 def test_omni_scheduler_distributed_update_failure_keeps_engine_paused() -> None:

--- a/tests/unit_test/pipeline/test_admin_control.py
+++ b/tests/unit_test/pipeline/test_admin_control.py
@@ -8,6 +8,8 @@ import threading
 import time
 from types import SimpleNamespace
 
+import pytest
+
 from sglang_omni.pipeline.control_plane import deserialize_message, serialize_message
 from sglang_omni.pipeline.coordinator import Coordinator
 from sglang_omni.pipeline.stage.runtime import Stage
@@ -165,14 +167,33 @@ def test_omni_scheduler_weights_checker_compare_change_is_success() -> None:
     assert result["data"]["changed"] == ["weight"]
 
 
-def test_omni_scheduler_update_weights_flushes_cache_without_kwargs() -> None:
+@pytest.mark.parametrize(
+    ("admin_method", "worker_method", "payload"),
+    [
+        pytest.param(
+            "_admin_update_weights_from_disk",
+            "update_weights_from_disk",
+            {"model_path": "/tmp/new-model", "torch_empty_cache": True},
+            id="disk",
+        ),
+        pytest.param(
+            "_admin_update_weights_from_tensor",
+            "update_weights_from_tensor",
+            {"serialized_named_tensors": None, "torch_empty_cache": True},
+            id="tensor",
+        ),
+    ],
+)
+def test_omni_scheduler_weight_updates_flush_and_advance_epoch(
+    admin_method: str, worker_method: str, payload: dict
+) -> None:
     from sglang_omni.scheduling.omni_scheduler import OmniScheduler
 
     update_calls: list[dict] = []
     flush_calls = 0
     empty_cache_calls = 0
 
-    def update_weights_from_disk(payload: dict) -> tuple[bool, str]:
+    def update_weights(payload: dict) -> tuple[bool, str]:
         update_calls.append(dict(payload))
         return True, "ok"
 
@@ -186,9 +207,7 @@ def test_omni_scheduler_update_weights_flushes_cache_without_kwargs() -> None:
         empty_cache_calls += 1
 
     scheduler = object.__new__(OmniScheduler)
-    scheduler.model_worker = SimpleNamespace(
-        update_weights_from_disk=update_weights_from_disk
-    )
+    scheduler.model_worker = SimpleNamespace(**{worker_method: update_weights})
     scheduler._admin_lock = threading.Lock()
     scheduler._engine_paused = False
     scheduler._last_pause_mode = None
@@ -201,18 +220,12 @@ def test_omni_scheduler_update_weights_flushes_cache_without_kwargs() -> None:
     scheduler.flush_cache = flush_cache
     scheduler._empty_torch_cache = empty_torch_cache
 
-    result = OmniScheduler._admin_update_weights_from_disk(
-        scheduler,
-        {
-            "model_path": "/tmp/new-model",
-            "torch_empty_cache": True,
-        },
-    )
+    result = getattr(OmniScheduler, admin_method)(scheduler, payload)
 
     assert result["success"] is True
     assert result["data"]["flush_cache"] is True
     assert result["data"]["flush_success"] is True
-    assert update_calls == [{"model_path": "/tmp/new-model", "torch_empty_cache": True}]
+    assert update_calls == [payload]
     assert flush_calls == 1
     assert empty_cache_calls == 1
     assert scheduler._prompt_cache_epoch == 1

--- a/tests/unit_test/pipeline/test_async_decode.py
+++ b/tests/unit_test/pipeline/test_async_decode.py
@@ -527,6 +527,48 @@ def _commit_step_slot(allocator, req_to_token_pool, req):
     return int(slot[0])
 
 
+def test_prompt_only_radix_reuses_prompt_without_caching_tail():
+    from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.mem_cache.common import maybe_cache_unfinished_req, release_kv_cache
+    from sglang.srt.mem_cache.radix_cache import MatchPrefixParams, RadixKey
+    from sglang.srt.runtime_context import get_context
+    from sglang.srt.sampling.sampling_params import SamplingParams
+
+    with get_context().override_server_args(page_size=1):
+        allocator, req_to_token_pool, cache = _real_radix_pools()
+        total = allocator.available_size()
+        prompt = [1, 2, 3]
+        first = _decoding_req(allocator, req_to_token_pool, "first", prompt, [20])
+        first.extra_key = "qwen3_tts:prompt:v1"
+        first.init_next_round_input(cache)
+        first.set_extend_range(0, len(prompt))
+        maybe_cache_unfinished_req(first, cache)
+
+        first.skip_radix_cache_insert = True
+        _commit_step_slot(allocator, req_to_token_pool, first)
+        first.output_ids.append(21)
+        release_kv_cache(first, cache)
+
+        second = Req(
+            "second",
+            "",
+            prompt,
+            SamplingParams(max_new_tokens=8),
+            extra_key="qwen3_tts:prompt:v1",
+        )
+        second.output_ids = []
+        second.init_next_round_input(cache)
+        tail_match = cache.match_prefix(
+            MatchPrefixParams(
+                key=RadixKey(prompt + [20], extra_key="qwen3_tts:prompt:v1")
+            )
+        )
+
+        assert len(second.prefix_indices) == len(prompt) - 1
+        assert len(tail_match.device_indices) == cache.total_size() == len(prompt)
+        assert allocator.available_size() + cache.evictable_size() == total
+
+
 class _StaleDecodeBatch:
     def __init__(self, reqs, out_cache_loc):
         from sglang.srt.model_executor.forward_batch_info import ForwardMode

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3452,22 +3452,56 @@ def _build_qwen3_tts_sglang_request(monkeypatch: pytest.MonkeyPatch):
     )
 
 
-def test_qwen3_tts_request_lifetime_extra_key_is_unique_and_survives_retract(
+def test_qwen3_tts_prompt_key_and_tail_guard_order(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from sglang_omni.scheduling import omni_scheduler as scheduler_module
+
     first = _build_qwen3_tts_sglang_request(monkeypatch)
     second = _build_qwen3_tts_sglang_request(monkeypatch)
 
     assert first.req.rid == second.req.rid
-    assert first.req.extra_key
-    assert second.req.extra_key
-    assert first.req.extra_key.startswith("qwen3_tts:")
-    assert second.req.extra_key.startswith("qwen3_tts:")
-    assert first.req.extra_key != second.req.extra_key
+    assert list(first.req.origin_input_ids) == list(second.req.origin_input_ids)
+    assert first.req.extra_key == second.req.extra_key == "qwen3_tts:prompt:v1"
+    assert first.req._omni_prompt_cache_key == second.req._omni_prompt_cache_key
 
-    kept = first.req.extra_key
+    seen = []
+    emit = iter([False, True, True])
+
+    def process_result(_, batch, __):
+        seen.append(
+            [getattr(req, "skip_radix_cache_insert", False) for req in batch.reqs]
+        )
+        if next(emit):
+            for req in batch.reqs:
+                req.output_ids.append(7)
+
+    monkeypatch.setattr(
+        scheduler_module._Upstream, "process_batch_result", process_result
+    )
+    scheduler = object.__new__(OmniScheduler)
+    plain = SimpleNamespace(output_ids=[])
+    batch = SimpleNamespace(reqs=[first.req, second.req, plain])
+    scheduler.process_batch_result(batch, None)
+    assert seen == [[False, False, False]]
+    assert not any(getattr(req, "skip_radix_cache_insert", False) for req in batch.reqs)
+    scheduler.process_batch_result(batch, None)
+    assert [getattr(req, "skip_radix_cache_insert", False) for req in batch.reqs] == [
+        True,
+        True,
+        False,
+    ]
+    scheduler.process_batch_result(batch, None)
+
+    assert seen == [
+        [False, False, False],
+        [False, False, False],
+        [True, True, False],
+    ]
+
     first.req.reset_for_retract()
-    assert first.req.extra_key == kept
+    assert first.req.extra_key == "qwen3_tts:prompt:v1"
+    assert first.req.skip_radix_cache_insert
 
 
 def test_qwen3_tts_prepared_payload_missing_state_fails_without_rebuild(


### PR DESCRIPTION
## Motivation

PR #1586 gave every Qwen3-TTS and delay-Moss request a unique radix `extra_key`. This isolated generated tails, but also partitioned identical prompts by request, reducing cross-request cache hits to zero.

Prompt IDs already content-address the model-visible inputs. Generated tails still require isolation because their scalar IDs do not fully identify the audio-conditioned feedback written to KV.

## Modifications

- Use stable, versioned prompt namespaces for Qwen3-TTS and delay Moss.
- Cache the completed prompt, then disable subsequent radix insertion for generated tails while preserving chunked prefill and retraction reuse.
- Add a weight epoch to prevent stale prompt-KV reuse after model updates, including when cache flushing fails.
- Add focused ordering, family-isolation, retraction, and weight-update regressions.

## Related Issues

Follow-up to #1586. This does not change its retraction reconstruction logic or close https://github.com/sgl-project/sglang-omni/issues/1555.

## Accuracy Test

```bash
CUDA_VISIBLE_DEVICES="" pytest -q \
  tests/unit_test/qwen3_tts \
  tests/unit_test/moss_tts \
  tests/unit_test/pipeline \
  tests/unit_test/scheduling
```

Result: `1037 passed, 80 skipped`. With GPU visibility: `1117 passed`.

The real SGLang radix-cache lifecycle probe passed `60/60` checks.

## Benchmark & Profiling

No throughput claim is made. On 8× H200, all `90/90` serving events completed successfully. Identical warm prompts reused all but one token:

- Qwen3-TTS: `58 new / 0 cached` → `1 / 57`
- delay Moss: `149 new / 0 cached` → `1 / 148`

Retraction, concurrency, abort recovery, and false-share probes completed without negative KV accounting, empty audio, or health failures.