### PR TITLE
fix(pd): make Decode ownership transitions atomic

### DIFF
--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -75,6 +75,7 @@ from sglang_omni.scheduling.pd_kv_adapter import (
 from sglang_omni.scheduling.pd_runtime import (
     DecodeRequestPoolExhausted,
     PDDecodeAdmission,
+    PDDecodeOwnershipTracker,
     PDPrefillHandoff,
     continuation_from_req,
     req_from_continuation,
@@ -546,6 +547,9 @@ class OmniScheduler:
         self._pd_ready_queue = _queue_mod.Queue()
         self._pd_deferred_admission: PDDecodeAdmission | None = None
         self._pd_admission_lock = threading.Lock()
+        self._pd_ownership = PDDecodeOwnershipTracker(
+            max_queued_requests=self.max_queued_requests
+        )
         self._pd_receiver: AllocatorKVReceiver | None = None
         self._pd_controller: PDHandoffController | None = None
 
@@ -599,19 +603,35 @@ class OmniScheduler:
                 raise RuntimeError("rank-ready handoff has no continuation")
             allocation = receiver.take_committed(pending.request_id)
             try:
+                self._pd_ownership.attach_allocation(pending.request_id, allocation)
+                self._pd_ownership.transition(pending.request_id, "ready")
                 self._pd_ready_queue.put(
                     PDDecodeAdmission(pending.continuation, allocation)
                 )
             except Exception:
                 # Note (Yue Yin): take_committed transfers ownership out of the
                 # receiver before the scheduler queue can accept it.
-                self.token_to_kv_pool_allocator.free(allocation.slots)
+                self._release_pd_owned(
+                    pending.request_id,
+                    reason="ready queue rejected continuation",
+                    fallback_allocation=allocation,
+                )
                 raise
+
+        def reserve_ownership(continuation):
+            deadline = continuation.deadline_unix_s
+            if deadline is not None and time.time() >= deadline:
+                raise TimeoutError("PD continuation deadline already expired")
+            self._pd_ownership.reserve(continuation.request_id, deadline)
+
+        def release_ownership(request_id):
+            self._release_pd_owned(request_id, reason="handoff cleanup")
 
         controller = PDHandoffController(
             rank_ready_callback=on_ready,
-            cleanup_callback=lambda pending, _reason: receiver.release(
-                pending.request_id
+            cleanup_callback=lambda pending, _reason: (
+                receiver.release(pending.request_id),
+                release_ownership(pending.request_id),
             ),
         )
         self._pd_receiver = receiver
@@ -620,12 +640,71 @@ class OmniScheduler:
             receiver,
             controller,
             allowed_resume_schemas=self._pd_resume_schemas,
+            ownership_reserve=reserve_ownership,
+            ownership_release=release_ownership,
         )
+
+    def _release_pd_owned(
+        self,
+        request_id: str,
+        *,
+        reason: str,
+        fallback_allocation: Any = None,
+    ) -> bool:
+        """Claim and release one Decode-owned request exactly once."""
+
+        tracker = self.__dict__.get("_pd_ownership")
+        owned = tracker.pop(request_id) if tracker is not None else None
+        if owned is None:
+            if fallback_allocation is not None:
+                self.token_to_kv_pool_allocator.free(fallback_allocation.slots)
+                return True
+            return False
+        if owned.req is not None:
+            if (
+                owned.req.req_pool_idx is not None
+                or owned.req.mamba_pool_idx is not None
+            ):
+                release_kv_cache(owned.req, self.tree_cache)
+        elif owned.allocation is not None:
+            self.token_to_kv_pool_allocator.free(owned.allocation.slots)
+        else:
+            # Before rank-ready, the receiver still owns the destination KV.
+            receiver = self.__dict__.get("_pd_receiver")
+            if receiver is not None:
+                receiver.release(request_id)
+        logger.debug(
+            "released PD Decode ownership request=%s reason=%s", request_id, reason
+        )
+        return True
+
+    def _expire_pd_owned_requests(self) -> None:
+        tracker = self.__dict__.get("_pd_ownership")
+        if tracker is None:
+            return
+        for request_id in tracker.expired_request_ids(time.time()):
+            self._emit_request_error(
+                request_id,
+                TimeoutError("PD end-to-end request deadline reached"),
+                metadata={"pd_deadline": True},
+            )
+            self._aborted_request_ids.add(request_id)
+            owned = tracker.get(request_id)
+            if owned is not None and owned.state == "running":
+                tracker.mark_terminal_pending(request_id)
+                self._mark_running_request_aborted(request_id)
+                continue
+            if owned is not None and owned.req is not None:
+                self.waiting_queue = [
+                    req for req in self.waiting_queue if req.rid != request_id
+                ]
+            self._release_pd_owned(request_id, reason="end-to-end deadline")
 
     def _drain_pd_admissions(self) -> None:
         ready_queue = self.__dict__.get("_pd_ready_queue")
         if ready_queue is None:
             return
+        self._expire_pd_owned_requests()
         with self._pd_admission_lock:
             while True:
                 admission = self._pd_deferred_admission
@@ -635,9 +714,14 @@ class OmniScheduler:
                     except _queue_mod.Empty:
                         return
                 request_id = admission.continuation.request_id
+                if self._pd_ownership.get(request_id) is None:
+                    self._pd_deferred_admission = None
+                    continue
                 if request_id in self._aborted_request_ids:
                     self._pd_deferred_admission = None
-                    self.token_to_kv_pool_allocator.free(admission.allocation.slots)
+                    self._release_pd_owned(
+                        request_id, reason="aborted before admission"
+                    )
                     continue
                 try:
                     req = req_from_continuation(
@@ -650,15 +734,18 @@ class OmniScheduler:
                     # Note (Yue Yin): The committed KV must remain owned while
                     # an earlier request is still using the request-pool slot.
                     self._pd_deferred_admission = admission
+                    self._pd_ownership.transition(request_id, "deferred")
                     return
                 except Exception as exc:
                     self._pd_deferred_admission = None
-                    self.token_to_kv_pool_allocator.free(admission.allocation.slots)
+                    self._release_pd_owned(request_id, reason="reconstruction failed")
                     self._emit_request_error(
                         request_id, exc, metadata={"pd_pre_admission": True}
                     )
                     continue
                 self._pd_deferred_admission = None
+                self._pd_ownership.attach_req(request_id, req)
+                self._pd_ownership.transition(request_id, "waiting")
                 self.waiting_queue.append(req)
                 self.outbox.put(
                     OutgoingMessage(request_id=request_id, type="pd_admitted")
@@ -672,13 +759,21 @@ class OmniScheduler:
             admission = self._pd_deferred_admission
             self._pd_deferred_admission = None
             if admission is not None:
-                self.token_to_kv_pool_allocator.free(admission.allocation.slots)
+                self._release_pd_owned(
+                    admission.continuation.request_id, reason="shutdown"
+                )
+        tracker = self.__dict__.get("_pd_ownership")
+        if tracker is not None:
+            for request_id in tracker.request_ids():
+                self._release_pd_owned(request_id, reason="shutdown")
             while True:
                 try:
                     admission = ready_queue.get_nowait()
                 except _queue_mod.Empty:
                     return
-                self.token_to_kv_pool_allocator.free(admission.allocation.slots)
+                self._release_pd_owned(
+                    admission.continuation.request_id, reason="shutdown"
+                )
 
     def _queue_pd_prefill_handoffs(
         self,
@@ -1191,13 +1286,22 @@ class OmniScheduler:
         time.sleep(0.0001 if request_admission_pending else 0.001)
 
     def _queued_admission_count(self) -> int:
-        return (
+        count = (
             len(self.waiting_queue)
             + len(self._pending_request_builds)
             + len(self._pending_request_admissions)
             + len(self._backlogged_request_build_payloads)
             + len(self._deferred_request_payloads)
         )
+        tracker = self.__dict__.get("_pd_ownership")
+        if tracker is not None:
+            # waiting_queue is already counted above; add only Decode-owned
+            # reservations/commits/ready/deferred records.
+            pd_waiting = sum(
+                1 for req in self.waiting_queue if tracker.get(req.rid) is not None
+            )
+            count += max(0, tracker.queued_count() - pd_waiting)
+        return count
 
     def _waiting_queue_is_full(self) -> bool:
         if self.max_queued_requests is None:
@@ -1587,6 +1691,15 @@ class OmniScheduler:
                 self, self.running_batch, self.last_batch
             )
         self.running_batch = plan.running_batch
+        tracker = self.__dict__.get("_pd_ownership")
+        if (
+            pd_role == "decode"
+            and tracker is not None
+            and self.running_batch is not None
+        ):
+            for req in self.running_batch.reqs:
+                if tracker.get(req.rid) is not None:
+                    tracker.transition(req.rid, "running")
         return plan.batch_to_run
 
     def process_batch_result(self, batch, result):
@@ -2081,6 +2194,8 @@ class OmniScheduler:
                     waiting_queue.append(req)
             self.waiting_queue = waiting_queue
         if not running_abort:
+            self._release_pd_owned(request_id, reason="abort")
+        if not running_abort:
             self._run_abort_callback(request_id)
         self._pending_stream_ingress.pop(request_id, None)
         self._deferred_request_payloads.pop(request_id, None)
@@ -2484,6 +2599,9 @@ class OmniScheduler:
             for req in batch.reqs:
                 if req.rid is not None and not req.finished():
                     request_ids.add(req.rid)
+        tracker = self.__dict__.get("_pd_ownership")
+        if tracker is not None:
+            request_ids.update(tracker.request_ids())
         return sorted(request_ids)
 
     def _can_update_active_requests(
@@ -2585,6 +2703,10 @@ class OmniScheduler:
                 self._release_request_kv_cache(req)
 
     def _release_request_kv_cache(self, req: Any) -> None:
+        tracker = self.__dict__.get("_pd_ownership")
+        if tracker is not None and tracker.get(req.rid) is not None:
+            self._release_pd_owned(req.rid, reason="request terminal")
+            return
         if req.req_pool_idx is None and req.mamba_pool_idx is None:
             return
         release_kv_cache(req, self.tree_cache)
@@ -2931,6 +3053,7 @@ class OmniScheduler:
 
     def _close_completed_request(self, req: Any) -> bool:
         request_id = req.rid
+        self._release_pd_owned(request_id, reason="request completed")
         with self._request_admission_lock:
             _detach_request_data(req)
             self._remember_completed_request(request_id)

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -601,22 +601,24 @@ class OmniScheduler:
         def on_ready(pending):
             if pending.continuation is None:
                 raise RuntimeError("rank-ready handoff has no continuation")
-            allocation = receiver.take_committed(pending.request_id)
-            try:
-                self._pd_ownership.attach_allocation(pending.request_id, allocation)
-                self._pd_ownership.transition(pending.request_id, "ready")
-                self._pd_ready_queue.put(
-                    PDDecodeAdmission(pending.continuation, allocation)
-                )
-            except Exception:
-                # Note (Yue Yin): take_committed transfers ownership out of the
-                # receiver before the scheduler queue can accept it.
-                self._release_pd_owned(
-                    pending.request_id,
-                    reason="ready queue rejected continuation",
-                    fallback_allocation=allocation,
-                )
-                raise
+            with self._pd_admission_lock:
+                allocation = receiver.take_committed(pending.request_id)
+                try:
+                    if not self._pd_ownership.mark_ready(
+                        pending.request_id, allocation
+                    ):
+                        self.token_to_kv_pool_allocator.free(allocation.slots)
+                        return
+                    self._pd_ready_queue.put(
+                        PDDecodeAdmission(pending.continuation, allocation)
+                    )
+                except Exception:
+                    # take_committed transfers ownership out of the receiver.
+                    self._release_pd_owned(
+                        pending.request_id,
+                        reason="ready queue rejected continuation",
+                    )
+                    raise
 
         def reserve_ownership(continuation):
             deadline = continuation.deadline_unix_s
@@ -625,13 +627,13 @@ class OmniScheduler:
             self._pd_ownership.reserve(continuation.request_id, deadline)
 
         def release_ownership(request_id):
-            self._release_pd_owned(request_id, reason="handoff cleanup")
+            with self._pd_admission_lock:
+                self._release_pd_owned(request_id, reason="handoff cleanup")
 
         controller = PDHandoffController(
             rank_ready_callback=on_ready,
-            cleanup_callback=lambda pending, _reason: (
-                receiver.release(pending.request_id),
-                release_ownership(pending.request_id),
+            cleanup_callback=lambda pending, _reason: release_ownership(
+                pending.request_id
             ),
         )
         self._pd_receiver = receiver
@@ -641,6 +643,7 @@ class OmniScheduler:
             controller,
             allowed_resume_schemas=self._pd_resume_schemas,
             ownership_reserve=reserve_ownership,
+            ownership_committed=self._pd_ownership.mark_committed,
             ownership_release=release_ownership,
         )
 
@@ -649,17 +652,20 @@ class OmniScheduler:
         request_id: str,
         *,
         reason: str,
-        fallback_allocation: Any = None,
     ) -> bool:
         """Claim and release one Decode-owned request exactly once."""
 
         tracker = self.__dict__.get("_pd_ownership")
-        owned = tracker.pop(request_id) if tracker is not None else None
+        owned = tracker.pop_for_release(request_id) if tracker is not None else None
         if owned is None:
-            if fallback_allocation is not None:
-                self.token_to_kv_pool_allocator.free(fallback_allocation.slots)
-                return True
             return False
+        self._release_pd_owned_record(owned)
+        logger.debug(
+            "released PD Decode ownership request=%s reason=%s", request_id, reason
+        )
+        return True
+
+    def _release_pd_owned_record(self, owned: Any) -> None:
         if owned.req is not None:
             if (
                 owned.req.req_pool_idx is not None
@@ -672,33 +678,28 @@ class OmniScheduler:
             # Before rank-ready, the receiver still owns the destination KV.
             receiver = self.__dict__.get("_pd_receiver")
             if receiver is not None:
-                receiver.release(request_id)
-        logger.debug(
-            "released PD Decode ownership request=%s reason=%s", request_id, reason
-        )
-        return True
+                receiver.release(owned.request_id)
 
     def _expire_pd_owned_requests(self) -> None:
         tracker = self.__dict__.get("_pd_ownership")
         if tracker is None:
             return
-        for request_id in tracker.expired_request_ids(time.time()):
+        for owned, running in tracker.claim_expired(time.time()):
+            request_id = owned.request_id
             self._emit_request_error(
                 request_id,
                 TimeoutError("PD end-to-end request deadline reached"),
                 metadata={"pd_deadline": True},
             )
             self._aborted_request_ids.add(request_id)
-            owned = tracker.get(request_id)
-            if owned is not None and owned.state == "running":
-                tracker.mark_terminal_pending(request_id)
+            if running:
                 self._mark_running_request_aborted(request_id)
                 continue
-            if owned is not None and owned.req is not None:
+            if owned.req is not None:
                 self.waiting_queue = [
                     req for req in self.waiting_queue if req.rid != request_id
                 ]
-            self._release_pd_owned(request_id, reason="end-to-end deadline")
+            self._release_pd_owned_record(owned)
 
     def _drain_pd_admissions(self) -> None:
         ready_queue = self.__dict__.get("_pd_ready_queue")
@@ -714,7 +715,7 @@ class OmniScheduler:
                     except _queue_mod.Empty:
                         return
                 request_id = admission.continuation.request_id
-                if self._pd_ownership.get(request_id) is None:
+                if not self._pd_ownership.owns(request_id):
                     self._pd_deferred_admission = None
                     continue
                 if request_id in self._aborted_request_ids:
@@ -734,7 +735,10 @@ class OmniScheduler:
                     # Note (Yue Yin): The committed KV must remain owned while
                     # an earlier request is still using the request-pool slot.
                     self._pd_deferred_admission = admission
-                    self._pd_ownership.transition(request_id, "deferred")
+                    if not self._pd_ownership.transition_if_owned(
+                        request_id, {"ready", "deferred"}, "deferred"
+                    ):
+                        self._pd_deferred_admission = None
                     return
                 except Exception as exc:
                     self._pd_deferred_admission = None
@@ -744,8 +748,11 @@ class OmniScheduler:
                     )
                     continue
                 self._pd_deferred_admission = None
-                self._pd_ownership.attach_req(request_id, req)
-                self._pd_ownership.transition(request_id, "waiting")
+                if not self._pd_ownership.mark_waiting(request_id, req):
+                    raise RuntimeError(
+                        f"Decode ownership disappeared during admission for "
+                        f"{request_id!r}"
+                    )
                 self.waiting_queue.append(req)
                 self.outbox.put(
                     OutgoingMessage(request_id=request_id, type="pd_admitted")
@@ -762,10 +769,10 @@ class OmniScheduler:
                 self._release_pd_owned(
                     admission.continuation.request_id, reason="shutdown"
                 )
-        tracker = self.__dict__.get("_pd_ownership")
-        if tracker is not None:
-            for request_id in tracker.request_ids():
-                self._release_pd_owned(request_id, reason="shutdown")
+            tracker = self.__dict__.get("_pd_ownership")
+            if tracker is not None:
+                for request_id in tracker.request_ids():
+                    self._release_pd_owned(request_id, reason="shutdown")
             while True:
                 try:
                     admission = ready_queue.get_nowait()
@@ -1286,21 +1293,19 @@ class OmniScheduler:
         time.sleep(0.0001 if request_admission_pending else 0.001)
 
     def _queued_admission_count(self) -> int:
+        tracker = self.__dict__.get("_pd_ownership")
+        waiting_count = (
+            tracker.queued_count()
+            if tracker is not None and self.__dict__.get("_pd_role") == "decode"
+            else len(self.waiting_queue)
+        )
         count = (
-            len(self.waiting_queue)
+            waiting_count
             + len(self._pending_request_builds)
             + len(self._pending_request_admissions)
             + len(self._backlogged_request_build_payloads)
             + len(self._deferred_request_payloads)
         )
-        tracker = self.__dict__.get("_pd_ownership")
-        if tracker is not None:
-            # waiting_queue is already counted above; add only Decode-owned
-            # reservations/commits/ready/deferred records.
-            pd_waiting = sum(
-                1 for req in self.waiting_queue if tracker.get(req.rid) is not None
-            )
-            count += max(0, tracker.queued_count() - pd_waiting)
         return count
 
     def _waiting_queue_is_full(self) -> bool:
@@ -1698,8 +1703,7 @@ class OmniScheduler:
             and self.running_batch is not None
         ):
             for req in self.running_batch.reqs:
-                if tracker.get(req.rid) is not None:
-                    tracker.transition(req.rid, "running")
+                tracker.transition_if_owned(req.rid, {"waiting", "running"}, "running")
         return plan.batch_to_run
 
     def process_batch_result(self, batch, result):
@@ -2194,7 +2198,12 @@ class OmniScheduler:
                     waiting_queue.append(req)
             self.waiting_queue = waiting_queue
         if not running_abort:
-            self._release_pd_owned(request_id, reason="abort")
+            pd_admission_lock = self.__dict__.get("_pd_admission_lock")
+            if pd_admission_lock is None:
+                self._release_pd_owned(request_id, reason="abort")
+            else:
+                with pd_admission_lock:
+                    self._release_pd_owned(request_id, reason="abort")
         if not running_abort:
             self._run_abort_callback(request_id)
         self._pending_stream_ingress.pop(request_id, None)
@@ -2632,8 +2641,17 @@ class OmniScheduler:
             hisparse_coordinator=batch.hisparse_coordinator,
         )
         batch.reqs = []
+        tracker = self.__dict__.get("_pd_ownership")
         for req in retracted_reqs:
-            self._add_request_to_queue(req)
+            transitioned = tracker is not None and tracker.transition_if_owned(
+                req.rid, {"running"}, "waiting"
+            )
+            try:
+                self._add_request_to_queue(req)
+            except Exception:
+                if transitioned:
+                    tracker.transition_if_owned(req.rid, {"waiting"}, "running")
+                raise
         batch.batch_is_full = False
         self.chunked_req = None
         return len(retracted_reqs)
@@ -2704,7 +2722,7 @@ class OmniScheduler:
 
     def _release_request_kv_cache(self, req: Any) -> None:
         tracker = self.__dict__.get("_pd_ownership")
-        if tracker is not None and tracker.get(req.rid) is not None:
+        if tracker is not None and tracker.owns(req.rid):
             self._release_pd_owned(req.rid, reason="request terminal")
             return
         if req.req_pool_idx is None and req.mamba_pool_idx is None:

--- a/sglang_omni/scheduling/pd_continuation.py
+++ b/sglang_omni/scheduling/pd_continuation.py
@@ -53,6 +53,10 @@ class DecodeContinuation:
     cached_tokens: int
 
     version: str = CONTINUATION_VERSION
+    # Absolute Unix wall-clock deadline. Unlike a monotonic timestamp this is
+    # meaningful on another host; multi-host PD deployments must keep their
+    # wall clocks synchronized. None disables the end-to-end waiting deadline.
+    deadline_unix_s: float | None = None
     origin_input_ids_unpadded: list[int] | None = None
     eos_token_ids: list[int] | None = None
     cached_tokens_device: int = 0
@@ -492,6 +496,8 @@ class ContinuationAwareKVReceiver:
         target_tp_size: int = 1,
         is_local: bool = True,
         allowed_resume_schemas: frozenset[str] = frozenset(),
+        ownership_reserve: Callable[[DecodeContinuation], None] | None = None,
+        ownership_release: Callable[[str], None] | None = None,
     ) -> None:
         self._inner = inner
         self._controller = controller
@@ -499,17 +505,33 @@ class ContinuationAwareKVReceiver:
         self._target_tp_size = target_tp_size
         self._is_local = is_local
         self._allowed_resume_schemas = allowed_resume_schemas
+        self._ownership_reserve = ownership_reserve
+        self._ownership_release = ownership_release
 
     def reserve(self, request: KVTransferPrepareMessage) -> KVPageDestination:
         continuation, continuation_expected = self._decode_metadata(request)
-        self._controller.start_handoff(request.request_id, request.transfer_id)
-        if continuation is not None:
-            self._controller.set_continuation(request.request_id, continuation)
-        elif not continuation_expected:
-            self._controller.set_continuation_not_required(
-                request.request_id, request.transfer_id
+        ownership_reserved = False
+        try:
+            if continuation is not None and self._ownership_reserve is not None:
+                self._ownership_reserve(continuation)
+                ownership_reserved = True
+            self._controller.start_handoff(request.request_id, request.transfer_id)
+            if continuation is not None:
+                self._controller.set_continuation(request.request_id, continuation)
+            elif not continuation_expected:
+                self._controller.set_continuation_not_required(
+                    request.request_id, request.transfer_id
+                )
+            return self._inner.reserve(request)
+        except Exception:
+            self._controller.abort(
+                request.request_id,
+                reason="KV reservation failed",
+                transfer_id=request.transfer_id,
             )
-        return self._inner.reserve(request)
+            if ownership_reserved and self._ownership_release is not None:
+                self._ownership_release(request.request_id)
+            raise
 
     def commit(
         self,
@@ -531,6 +553,8 @@ class ContinuationAwareKVReceiver:
             reason=str(error) or type(error).__name__,
             transfer_id=request.transfer_id,
         )
+        if self._ownership_release is not None:
+            self._ownership_release(request.request_id)
 
     def _decode_metadata(
         self, request: KVTransferPrepareMessage

--- a/sglang_omni/scheduling/pd_continuation.py
+++ b/sglang_omni/scheduling/pd_continuation.py
@@ -497,6 +497,7 @@ class ContinuationAwareKVReceiver:
         is_local: bool = True,
         allowed_resume_schemas: frozenset[str] = frozenset(),
         ownership_reserve: Callable[[DecodeContinuation], None] | None = None,
+        ownership_committed: Callable[[str], None] | None = None,
         ownership_release: Callable[[str], None] | None = None,
     ) -> None:
         self._inner = inner
@@ -506,6 +507,7 @@ class ContinuationAwareKVReceiver:
         self._is_local = is_local
         self._allowed_resume_schemas = allowed_resume_schemas
         self._ownership_reserve = ownership_reserve
+        self._ownership_committed = ownership_committed
         self._ownership_release = ownership_release
 
     def reserve(self, request: KVTransferPrepareMessage) -> KVPageDestination:
@@ -539,6 +541,8 @@ class ContinuationAwareKVReceiver:
         destination: KVPageDestination,
     ) -> None:
         self._inner.commit(request, destination)
+        if self._ownership_committed is not None:
+            self._ownership_committed(request.request_id)
         self._controller.set_kv_committed(request.request_id, request.transfer_id)
 
     def abort(
@@ -547,13 +551,19 @@ class ContinuationAwareKVReceiver:
         destination: KVPageDestination | None,
         error: BaseException,
     ) -> None:
-        self._inner.abort(request, destination, error)
-        self._controller.abort(
-            request.request_id,
-            reason=str(error) or type(error).__name__,
-            transfer_id=request.transfer_id,
-        )
-        if self._ownership_release is not None:
+        if self._ownership_release is None:
+            self._inner.abort(request, destination, error)
+            self._controller.abort(
+                request.request_id,
+                reason=str(error) or type(error).__name__,
+                transfer_id=request.transfer_id,
+            )
+        else:
+            self._controller.abort(
+                request.request_id,
+                reason=str(error) or type(error).__name__,
+                transfer_id=request.transfer_id,
+            )
             self._ownership_release(request.request_id)
 
     def _decode_metadata(

--- a/sglang_omni/scheduling/pd_runtime.py
+++ b/sglang_omni/scheduling/pd_runtime.py
@@ -9,7 +9,7 @@ import time
 from array import array
 from collections import Counter
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 import torch
 
@@ -43,11 +43,22 @@ class DecodeOwnershipCapacityExhausted(RuntimeError):
     """Decode cannot accept another KV-owning continuation."""
 
 
+PDDecodeState = Literal[
+    "reserved",
+    "committed",
+    "ready",
+    "deferred",
+    "waiting",
+    "running",
+    "terminal_pending",
+]
+
+
 @dataclass
 class PDDecodeOwnedRequest:
     request_id: str
     deadline_unix_s: float | None
-    state: str = "reserved"
+    state: PDDecodeState = "reserved"
     allocation: ReservedAllocation | None = None
     req: Any = None
 
@@ -63,15 +74,22 @@ class PDDecodeOwnershipTracker:
     _QUEUED_STATES = frozenset(
         {"reserved", "committed", "ready", "deferred", "waiting"}
     )
+    _TRANSITIONS: dict[PDDecodeState, frozenset[PDDecodeState]] = {
+        "reserved": frozenset({"committed"}),
+        "committed": frozenset({"ready"}),
+        "ready": frozenset({"deferred", "waiting"}),
+        "deferred": frozenset({"waiting"}),
+        "waiting": frozenset({"running"}),
+        "running": frozenset({"waiting", "terminal_pending"}),
+        "terminal_pending": frozenset(),
+    }
 
     def __init__(self, max_queued_requests: int | None) -> None:
         self._max_queued_requests = max_queued_requests
         self._lock = threading.RLock()
         self._owned: dict[str, PDDecodeOwnedRequest] = {}
 
-    def reserve(
-        self, request_id: str, deadline_unix_s: float | None
-    ) -> PDDecodeOwnedRequest:
+    def reserve(self, request_id: str, deadline_unix_s: float | None) -> None:
         with self._lock:
             if request_id in self._owned:
                 raise RuntimeError(f"duplicate Decode ownership for {request_id!r}")
@@ -84,48 +102,77 @@ class PDDecodeOwnershipTracker:
                 )
             owned = PDDecodeOwnedRequest(request_id, deadline_unix_s)
             self._owned[request_id] = owned
-            return owned
 
-    def attach_allocation(
-        self, request_id: str, allocation: ReservedAllocation
-    ) -> None:
+    def mark_committed(self, request_id: str) -> bool:
+        return self.transition_if_owned(request_id, {"reserved"}, "committed")
+
+    def mark_ready(self, request_id: str, allocation: ReservedAllocation) -> bool:
         with self._lock:
-            self._owned[request_id].allocation = allocation
+            owned = self._owned.get(request_id)
+            if owned is None:
+                return False
+            self._validate_transition(owned.state, "ready")
+            owned.allocation = allocation
+            owned.state = "ready"
+            return True
 
-    def attach_req(self, request_id: str, req: Any) -> None:
+    def mark_waiting(self, request_id: str, req: Any) -> bool:
         with self._lock:
-            self._owned[request_id].req = req
+            owned = self._owned.get(request_id)
+            if owned is None:
+                return False
+            self._validate_transition(owned.state, "waiting")
+            owned.req = req
+            owned.state = "waiting"
+            return True
 
-    def transition(self, request_id: str, state: str) -> None:
+    def transition_if_owned(
+        self,
+        request_id: str,
+        expected_states: set[PDDecodeState] | frozenset[PDDecodeState],
+        new_state: PDDecodeState,
+    ) -> bool:
+        if new_state not in self._TRANSITIONS:
+            raise ValueError(f"unknown Decode ownership state {new_state!r}")
         with self._lock:
-            self._owned[request_id].state = state
+            owned = self._owned.get(request_id)
+            if owned is None or owned.state not in expected_states:
+                return False
+            if owned.state != new_state:
+                self._validate_transition(owned.state, new_state)
+                owned.state = new_state
+            if new_state == "terminal_pending":
+                owned.deadline_unix_s = None
+            return True
 
-    def mark_terminal_pending(self, request_id: str) -> None:
+    def owns(self, request_id: str) -> bool:
         with self._lock:
-            owned = self._owned[request_id]
-            owned.state = "terminal_pending"
-            owned.deadline_unix_s = None
+            return request_id in self._owned
 
-    def pop(self, request_id: str) -> PDDecodeOwnedRequest | None:
+    def pop_for_release(self, request_id: str) -> PDDecodeOwnedRequest | None:
         with self._lock:
             return self._owned.pop(request_id, None)
-
-    def get(self, request_id: str) -> PDDecodeOwnedRequest | None:
-        with self._lock:
-            return self._owned.get(request_id)
 
     def request_ids(self) -> tuple[str, ...]:
         with self._lock:
             return tuple(self._owned)
 
-    def expired_request_ids(self, now_unix_s: float) -> tuple[str, ...]:
+    def claim_expired(
+        self, now_unix_s: float
+    ) -> tuple[tuple[PDDecodeOwnedRequest, bool], ...]:
         with self._lock:
-            return tuple(
-                request_id
-                for request_id, owned in self._owned.items()
-                if owned.deadline_unix_s is not None
-                and now_unix_s >= owned.deadline_unix_s
-            )
+            claimed = []
+            for request_id, owned in list(self._owned.items()):
+                if owned.deadline_unix_s is None or now_unix_s < owned.deadline_unix_s:
+                    continue
+                if owned.state == "running":
+                    owned.state = "terminal_pending"
+                    owned.deadline_unix_s = None
+                    claimed.append((owned, True))
+                else:
+                    del self._owned[request_id]
+                    claimed.append((owned, False))
+            return tuple(claimed)
 
     def snapshot(self) -> dict[str, int]:
         with self._lock:
@@ -137,6 +184,14 @@ class PDDecodeOwnershipTracker:
 
     def _queued_count_locked(self) -> int:
         return sum(owned.state in self._QUEUED_STATES for owned in self._owned.values())
+
+    def _validate_transition(
+        self, current: PDDecodeState, new_state: PDDecodeState
+    ) -> None:
+        if new_state not in self._TRANSITIONS[current]:
+            raise RuntimeError(
+                f"invalid Decode ownership transition {current!r} -> {new_state!r}"
+            )
 
 
 def sampling_params_to_dict(params: Any) -> dict[str, Any]:
@@ -286,6 +341,5 @@ def req_from_continuation(
     req.kv = ReqKvInfo(kv_allocated_len=allocation.seq_len, swa_evicted_seqlen=0)
     req.set_extend_range(allocation.seq_len, allocation.seq_len)
     req._omni_terminal_claimed = False
-    req._pd_deadline_unix_s = continuation.deadline_unix_s
     req._coalesce_enqueue_t = 0.0
     return req

--- a/sglang_omni/scheduling/pd_runtime.py
+++ b/sglang_omni/scheduling/pd_runtime.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 import inspect
+import threading
+import time
 from array import array
+from collections import Counter
 from dataclasses import dataclass
 from typing import Any
 
@@ -36,6 +39,106 @@ class DecodeRequestPoolExhausted(RuntimeError):
     pass
 
 
+class DecodeOwnershipCapacityExhausted(RuntimeError):
+    """Decode cannot accept another KV-owning continuation."""
+
+
+@dataclass
+class PDDecodeOwnedRequest:
+    request_id: str
+    deadline_unix_s: float | None
+    state: str = "reserved"
+    allocation: ReservedAllocation | None = None
+    req: Any = None
+
+
+class PDDecodeOwnershipTracker:
+    """One accounting domain for every Decode-owned request state.
+
+    ``max_queued_requests`` covers reserved, committed, ready, deferred and
+    waiting requests. Moving a request to running returns its queue credit but
+    retains the ownership record until terminal cleanup.
+    """
+
+    _QUEUED_STATES = frozenset(
+        {"reserved", "committed", "ready", "deferred", "waiting"}
+    )
+
+    def __init__(self, max_queued_requests: int | None) -> None:
+        self._max_queued_requests = max_queued_requests
+        self._lock = threading.RLock()
+        self._owned: dict[str, PDDecodeOwnedRequest] = {}
+
+    def reserve(
+        self, request_id: str, deadline_unix_s: float | None
+    ) -> PDDecodeOwnedRequest:
+        with self._lock:
+            if request_id in self._owned:
+                raise RuntimeError(f"duplicate Decode ownership for {request_id!r}")
+            if (
+                self._max_queued_requests is not None
+                and self._queued_count_locked() >= self._max_queued_requests
+            ):
+                raise DecodeOwnershipCapacityExhausted(
+                    "Decode-owned request capacity is full"
+                )
+            owned = PDDecodeOwnedRequest(request_id, deadline_unix_s)
+            self._owned[request_id] = owned
+            return owned
+
+    def attach_allocation(
+        self, request_id: str, allocation: ReservedAllocation
+    ) -> None:
+        with self._lock:
+            self._owned[request_id].allocation = allocation
+
+    def attach_req(self, request_id: str, req: Any) -> None:
+        with self._lock:
+            self._owned[request_id].req = req
+
+    def transition(self, request_id: str, state: str) -> None:
+        with self._lock:
+            self._owned[request_id].state = state
+
+    def mark_terminal_pending(self, request_id: str) -> None:
+        with self._lock:
+            owned = self._owned[request_id]
+            owned.state = "terminal_pending"
+            owned.deadline_unix_s = None
+
+    def pop(self, request_id: str) -> PDDecodeOwnedRequest | None:
+        with self._lock:
+            return self._owned.pop(request_id, None)
+
+    def get(self, request_id: str) -> PDDecodeOwnedRequest | None:
+        with self._lock:
+            return self._owned.get(request_id)
+
+    def request_ids(self) -> tuple[str, ...]:
+        with self._lock:
+            return tuple(self._owned)
+
+    def expired_request_ids(self, now_unix_s: float) -> tuple[str, ...]:
+        with self._lock:
+            return tuple(
+                request_id
+                for request_id, owned in self._owned.items()
+                if owned.deadline_unix_s is not None
+                and now_unix_s >= owned.deadline_unix_s
+            )
+
+    def snapshot(self) -> dict[str, int]:
+        with self._lock:
+            return dict(Counter(owned.state for owned in self._owned.values()))
+
+    def queued_count(self) -> int:
+        with self._lock:
+            return self._queued_count_locked()
+
+    def _queued_count_locked(self) -> int:
+        return sum(owned.state in self._QUEUED_STATES for owned in self._owned.values())
+
+
 def sampling_params_to_dict(params: Any) -> dict[str, Any]:
     allowed = inspect.signature(type(params)).parameters
     return {name: getattr(params, name) for name in allowed if hasattr(params, name)}
@@ -55,6 +158,14 @@ def continuation_from_req(
     origin_input_ids = list(req.origin_input_ids)
     if state_builder is not None:
         stage_payload_dict, multimodal_resume, origin_input_ids = state_builder(req)
+    from sglang.srt.environ import envs
+
+    timeout_s = float(envs.SGLANG_REQ_WAITING_TIMEOUT.get())
+    deadline_unix_s = None
+    if timeout_s > 0:
+        entry = float(req.time_stats.wait_queue_entry_time or 0.0)
+        elapsed = max(0.0, time.perf_counter() - entry) if entry > 0 else 0.0
+        deadline_unix_s = time.time() + max(0.0, timeout_s - elapsed)
     return DecodeContinuation(
         request_id=req.rid,
         transfer_id=transfer_id,
@@ -68,6 +179,7 @@ def continuation_from_req(
         vocab_size=int(req.vocab_size),
         sampling_params=sampling_params_to_dict(req.sampling_params),
         cached_tokens=int(req.cached_tokens),
+        deadline_unix_s=deadline_unix_s,
         eos_token_ids=(list(req.eos_token_ids) if req.eos_token_ids else None),
         cached_tokens_device=int(req.cached_tokens_device),
         cached_tokens_host=int(req.cached_tokens_host),
@@ -174,5 +286,6 @@ def req_from_continuation(
     req.kv = ReqKvInfo(kv_allocated_len=allocation.seq_len, swa_evicted_seqlen=0)
     req.set_extend_range(allocation.seq_len, allocation.seq_len)
     req._omni_terminal_claimed = False
+    req._pd_deadline_unix_s = continuation.deadline_unix_s
     req._coalesce_enqueue_t = 0.0
     return req

--- a/tests/unit_test/pipeline/test_pd_continuation.py
+++ b/tests/unit_test/pipeline/test_pd_continuation.py
@@ -26,6 +26,10 @@ from sglang_omni.scheduling.pd_continuation import (
     encode_continuation,
     validate_continuation,
 )
+from sglang_omni.scheduling.pd_runtime import (
+    DecodeOwnershipCapacityExhausted,
+    PDDecodeOwnershipTracker,
+)
 
 
 def _sample_continuation(**overrides) -> DecodeContinuation:
@@ -85,6 +89,35 @@ def test_continuation_bytes_survive_control_plane_round_trip():
     decoded = deserialize_message(serialize_message(prepare))
 
     assert decoded.metadata["pd_continuation"] == encode_continuation(cont)
+
+
+def test_decode_queue_capacity_is_claimed_before_inner_kv_reservation():
+    inner = _FakeReceiver()
+    controller = PDHandoffController()
+    tracker = PDDecodeOwnershipTracker(max_queued_requests=1)
+    receiver = ContinuationAwareKVReceiver(
+        inner,
+        controller,
+        ownership_reserve=lambda continuation: tracker.reserve(
+            continuation.request_id, continuation.deadline_unix_s
+        ),
+        ownership_release=lambda request_id: tracker.pop(request_id),
+    )
+    first = _sample_continuation(request_id="first", transfer_id="xfer-first")
+    second = _sample_continuation(request_id="second", transfer_id="xfer-second")
+
+    receiver.reserve(
+        _prepare(first, PrefillContinuationProducer().prepare_rank_metadata(first, 0))
+    )
+    with pytest.raises(DecodeOwnershipCapacityExhausted):
+        receiver.reserve(
+            _prepare(
+                second,
+                PrefillContinuationProducer().prepare_rank_metadata(second, 0),
+            )
+        )
+
+    assert [request.request_id for request in inner.reserves] == ["first"]
 
 
 def test_schema_version_rejection():

--- a/tests/unit_test/pipeline/test_pd_continuation.py
+++ b/tests/unit_test/pipeline/test_pd_continuation.py
@@ -101,7 +101,7 @@ def test_decode_queue_capacity_is_claimed_before_inner_kv_reservation():
         ownership_reserve=lambda continuation: tracker.reserve(
             continuation.request_id, continuation.deadline_unix_s
         ),
-        ownership_release=lambda request_id: tracker.pop(request_id),
+        ownership_release=lambda request_id: tracker.pop_for_release(request_id),
     )
     first = _sample_continuation(request_id="first", transfer_id="xfer-first")
     second = _sample_continuation(request_id="second", transfer_id="xfer-second")

--- a/tests/unit_test/pipeline/test_pd_runtime.py
+++ b/tests/unit_test/pipeline/test_pd_runtime.py
@@ -6,7 +6,7 @@ import queue
 import threading
 import time
 from array import array
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from types import SimpleNamespace
 
 import pytest
@@ -18,10 +18,12 @@ from sglang.srt.managers.scheduler_components.metrics_reporter import (
 )
 from sglang.srt.sampling.sampling_params import SamplingParams
 
-from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.comm.kv_transfer import KVTransferPrepareMessage
+from sglang_omni.proto import KVBufferSpec, KVPoolLayout, OmniRequest, StagePayload
 from sglang_omni.scheduling import omni_scheduler as omni_scheduler_module
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler
 from sglang_omni.scheduling.pd_continuation import (
+    PrefillContinuationProducer,
     decode_continuation,
     encode_continuation,
 )
@@ -86,6 +88,47 @@ class _CapacityReqPool(_ReqPool):
     def free(self, req):
         self.active.pop(req.req_pool_idx, None)
         super().free(req)
+
+
+class _TokenAllocator:
+    def __init__(self) -> None:
+        self.freed: list[torch.Tensor] = []
+        self._next_slot = 0
+
+    def get_kvcache(self):
+        return object()
+
+    def available_size(self):
+        return 64
+
+    def alloc(self, count):
+        slots = torch.arange(self._next_slot, self._next_slot + count)
+        self._next_slot += count
+        return slots
+
+    def free(self, slots):
+        self.freed.append(slots)
+
+
+@dataclass(frozen=True)
+class _BatchResultProcessor:
+    disaggregation_mode: object | None = None
+
+
+class _RetractedBatch:
+    def __init__(self, reqs):
+        self.reqs = reqs
+        self.batch_is_full = True
+        self.req_to_token_pool = object()
+        self.token_to_kv_pool_allocator = object()
+        self.tree_cache = object()
+        self.hisparse_coordinator = None
+
+    def is_empty(self):
+        return not self.reqs
+
+    def filter_batch(self):
+        return None
 
 
 def _prefill_req() -> Req:
@@ -158,16 +201,41 @@ def _decode_scheduler(
     return scheduler, freed
 
 
+def _bound_decode_scheduler(monkeypatch):
+    allocator = _TokenAllocator()
+    scheduler = object.__new__(OmniScheduler)
+    scheduler.tp_size = 1
+    scheduler.page_size = 1
+    scheduler.server_args = SimpleNamespace(disable_radix_cache=True)
+    scheduler.token_to_kv_pool_allocator = allocator
+    scheduler.batch_result_processor = _BatchResultProcessor()
+    scheduler._pd_resume_schemas = frozenset()
+    scheduler._pd_ready_queue = queue.Queue()
+    scheduler._pd_deferred_admission = None
+    scheduler._pd_admission_lock = threading.Lock()
+    scheduler._pd_ownership = PDDecodeOwnershipTracker(max_queued_requests=8)
+    scheduler._pd_receiver = None
+    scheduler._pd_controller = None
+    monkeypatch.setattr(
+        omni_scheduler_module, "build_kv_pool", lambda *_a, **_k: object()
+    )
+    _, receiver = scheduler.bind_pd_runtime(
+        stage_name="decode", role="decode", partner="prefill"
+    )
+    return scheduler, receiver, allocator
+
+
 def _own_admissions(scheduler, admissions) -> None:
     for admission in admissions:
-        scheduler._pd_ownership.reserve(
+        tracker = scheduler._pd_ownership
+        tracker.reserve(
             admission.continuation.request_id,
             admission.continuation.deadline_unix_s,
         )
-        scheduler._pd_ownership.attach_allocation(
+        assert tracker.mark_committed(admission.continuation.request_id)
+        assert tracker.mark_ready(
             admission.continuation.request_id, admission.allocation
         )
-        scheduler._pd_ownership.transition(admission.continuation.request_id, "ready")
 
 
 def test_continuation_reconstructs_req_and_transferred_mapping() -> None:
@@ -457,9 +525,12 @@ def test_metrics_reporter_handles_multiple_reconstructed_requests() -> None:
 def test_decode_owned_states_share_one_hard_queue_bound() -> None:
     tracker = PDDecodeOwnershipTracker(max_queued_requests=2)
     tracker.reserve("committed", None)
-    tracker.transition("committed", "committed")
+    assert tracker.mark_committed("committed")
     tracker.reserve("deferred", None)
-    tracker.transition("deferred", "deferred")
+    assert tracker.mark_committed("deferred")
+    allocation = ReservedAllocation(torch.tensor([1]), (1,), 1)
+    assert tracker.mark_ready("deferred", allocation)
+    assert tracker.transition_if_owned("deferred", {"ready"}, "deferred")
 
     with pytest.raises(DecodeOwnershipCapacityExhausted):
         tracker.reserve("new", None)
@@ -499,19 +570,52 @@ def test_deadline_expired_before_reconstruction_never_enters_waiting() -> None:
     assert freed == [admission.allocation.slots]
 
 
-def test_timeout_ready_abort_race_has_one_terminal_owner() -> None:
-    admission = _decode_admission("request-1", 7)
-    scheduler, freed = _decode_scheduler([], _ReqPool())
-    _own_admissions(scheduler, [admission])
-    barrier = threading.Barrier(3)
+def test_timeout_ready_abort_race_has_one_terminal_owner(monkeypatch) -> None:
+    # Race the actual receiver commit/rank-ready callback against the two
+    # controller terminal callbacks used by abort and timeout.
+    scheduler, receiver, allocator = _bound_decode_scheduler(monkeypatch)
+    continuation = _decode_admission("request-1", 7).continuation
+    metadata = PrefillContinuationProducer().prepare_rank_metadata(continuation, 0)
+    prepare = KVTransferPrepareMessage(
+        request_id=continuation.request_id,
+        transfer_id=continuation.transfer_id,
+        from_stage="prefill",
+        to_stage="decode",
+        source_pool_id="prefill:kv",
+        target_pool_id="decode:kv",
+        source_page_indices=(7, 8, 9),
+        source_layout=KVPoolLayout(
+            layout_id="test",
+            page_size=1,
+            buffers=(KVBufferSpec(name="kv", bytes_per_page=1),),
+        ),
+        metadata=metadata,
+    )
+    destination = receiver.reserve(prepare)
+    barrier = threading.Barrier(4)
+    errors = []
 
-    def release(reason):
+    def commit():
         barrier.wait()
-        scheduler._release_pd_owned("request-1", reason=reason)
+        try:
+            receiver.commit(prepare, destination)
+        except RuntimeError as exc:
+            errors.append(exc)
+
+    def abort():
+        barrier.wait()
+        scheduler._pd_controller.abort(
+            "request-1", transfer_id=continuation.transfer_id
+        )
+
+    def timeout():
+        barrier.wait()
+        scheduler._pd_controller._on_timeout("request-1", continuation.transfer_id)
 
     threads = [
-        threading.Thread(target=release, args=("timeout",)),
-        threading.Thread(target=release, args=("abort",)),
+        threading.Thread(target=commit),
+        threading.Thread(target=abort),
+        threading.Thread(target=timeout),
     ]
     for thread in threads:
         thread.start()
@@ -519,18 +623,93 @@ def test_timeout_ready_abort_race_has_one_terminal_owner() -> None:
     for thread in threads:
         thread.join(timeout=1)
 
-    assert freed == [admission.allocation.slots]
+    scheduler._release_pd_owned("request-1", reason="test terminal")
+
+    assert len(errors) <= 1
+    assert len(allocator.freed) == 1
     assert scheduler._pd_ownership.snapshot() == {}
+
+
+def test_running_timeout_claims_one_terminal_cleanup(monkeypatch) -> None:
+    scheduler, _ = _decode_scheduler([], _ReqPool())
+    allocation = ReservedAllocation(torch.tensor([7, 8, 9]), (7, 8, 9), 3)
+    req = SimpleNamespace(rid="request-1", req_pool_idx=0, mamba_pool_idx=None)
+    tracker = scheduler._pd_ownership
+    tracker.reserve("request-1", time.time() - 1)
+    assert tracker.mark_committed("request-1")
+    assert tracker.mark_ready("request-1", allocation)
+    assert tracker.mark_waiting("request-1", req)
+    assert tracker.transition_if_owned("request-1", {"waiting"}, "running")
+    scheduler._emit_request_error = lambda *_a, **_k: None
+    scheduler._mark_running_request_aborted = lambda _rid: True
+    scheduler.tree_cache = object()
+    releases = []
+
+    def release(req, _cache):
+        releases.append(req.rid)
+        req.req_pool_idx = None
+
+    monkeypatch.setattr(omni_scheduler_module, "release_kv_cache", release)
+
+    scheduler._expire_pd_owned_requests()
+    assert tracker.snapshot() == {"terminal_pending": 1}
+    scheduler._release_request_kv_cache(req)
+    scheduler._release_request_kv_cache(req)
+
+    assert releases == ["request-1"]
+    assert tracker.snapshot() == {}
+
+
+def test_retracted_pd_request_returns_and_reclaims_queue_credit(monkeypatch) -> None:
+    scheduler, _ = _decode_scheduler([], _ReqPool())
+    req = SimpleNamespace(rid="request-1")
+    allocation = ReservedAllocation(torch.tensor([7]), (7,), 1)
+    tracker = scheduler._pd_ownership
+    tracker.reserve(req.rid, None)
+    assert tracker.mark_committed(req.rid)
+    assert tracker.mark_ready(req.rid, allocation)
+    assert tracker.mark_waiting(req.rid, req)
+    assert tracker.transition_if_owned(req.rid, {"waiting"}, "running")
+    scheduler.running_batch = _RetractedBatch([req])
+    scheduler.server_args = object()
+    scheduler.tree_cache = object()
+    scheduler.hisparse_coordinator = None
+    scheduler.chunked_req = object()
+    scheduler._add_request_to_queue = scheduler.waiting_queue.append
+    monkeypatch.setattr(omni_scheduler_module, "retract_all", lambda **_kwargs: None)
+
+    assert scheduler._retract_running_requests() == 1
+    assert tracker.snapshot() == {"waiting": 1}
+
+    scheduler._drain_pd_admissions = lambda: None
+    scheduler._pd_role = "decode"
+    plan = SimpleNamespace(
+        running_batch=scheduler.running_batch,
+        batch_to_run=scheduler.running_batch,
+    )
+    monkeypatch.setattr(
+        omni_scheduler_module._Upstream,
+        "get_next_disagg_decode_batch_to_run",
+        lambda *_args: plan,
+    )
+    scheduler.running_batch.reqs = [req]
+
+    scheduler.get_next_batch_to_run()
+
+    assert tracker.snapshot() == {"running": 1}
 
 
 def test_queue_slot_release_allows_exactly_one_next_admission() -> None:
     tracker = PDDecodeOwnershipTracker(max_queued_requests=1)
     tracker.reserve("first", None)
-    tracker.transition("first", "waiting")
+    assert tracker.mark_committed("first")
+    allocation = ReservedAllocation(torch.tensor([1]), (1,), 1)
+    assert tracker.mark_ready("first", allocation)
+    assert tracker.mark_waiting("first", object())
     with pytest.raises(DecodeOwnershipCapacityExhausted):
         tracker.reserve("second", None)
 
-    tracker.transition("first", "running")
+    assert tracker.transition_if_owned("first", {"waiting"}, "running")
     tracker.reserve("second", None)
     with pytest.raises(DecodeOwnershipCapacityExhausted):
         tracker.reserve("third", None)
@@ -540,13 +719,36 @@ def test_queue_slot_release_allows_exactly_one_next_admission() -> None:
 
 def test_all_decode_owned_exit_paths_return_accounting_to_zero() -> None:
     tracker = PDDecodeOwnershipTracker(max_queued_requests=8)
-    states = ("reserved", "committed", "ready", "deferred", "waiting", "running")
-    for state in states:
-        tracker.reserve(state, None)
-        tracker.transition(state, state)
-    for state in states:
-        assert tracker.pop(state) is not None
-        assert tracker.pop(state) is None
+    allocation = ReservedAllocation(torch.tensor([1]), (1,), 1)
+    for request_id in (
+        "reserved",
+        "committed",
+        "ready",
+        "deferred",
+        "waiting",
+        "running",
+    ):
+        tracker.reserve(request_id, None)
+        if request_id != "reserved":
+            assert tracker.mark_committed(request_id)
+        if request_id in {"ready", "deferred", "waiting", "running"}:
+            assert tracker.mark_ready(request_id, allocation)
+        if request_id == "deferred":
+            assert tracker.transition_if_owned(request_id, {"ready"}, "deferred")
+        if request_id in {"waiting", "running"}:
+            assert tracker.mark_waiting(request_id, object())
+        if request_id == "running":
+            assert tracker.transition_if_owned(request_id, {"waiting"}, "running")
+    for request_id in (
+        "reserved",
+        "committed",
+        "ready",
+        "deferred",
+        "waiting",
+        "running",
+    ):
+        assert tracker.pop_for_release(request_id) is not None
+        assert tracker.pop_for_release(request_id) is None
 
     assert tracker.snapshot() == {}
 

--- a/tests/unit_test/pipeline/test_pd_runtime.py
+++ b/tests/unit_test/pipeline/test_pd_runtime.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import queue
 import threading
+import time
 from array import array
+from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
@@ -25,8 +27,10 @@ from sglang_omni.scheduling.pd_continuation import (
 )
 from sglang_omni.scheduling.pd_kv_adapter import ReservedAllocation
 from sglang_omni.scheduling.pd_runtime import (
+    DecodeOwnershipCapacityExhausted,
     DecodeRequestPoolExhausted,
     PDDecodeAdmission,
+    PDDecodeOwnershipTracker,
     continuation_from_req,
     req_from_continuation,
 )
@@ -143,6 +147,7 @@ def _decode_scheduler(
         scheduler._pd_ready_queue.put(admission)
     scheduler._pd_deferred_admission = None
     scheduler._pd_admission_lock = threading.Lock()
+    scheduler._pd_ownership = PDDecodeOwnershipTracker(max_queued_requests=16)
     scheduler._pd_state_restorer = state_restorer
     scheduler._aborted_request_ids = set()
     scheduler.req_to_token_pool = pool
@@ -151,6 +156,18 @@ def _decode_scheduler(
     scheduler.outbox = queue.Queue()
     scheduler.is_entry_rank = True
     return scheduler, freed
+
+
+def _own_admissions(scheduler, admissions) -> None:
+    for admission in admissions:
+        scheduler._pd_ownership.reserve(
+            admission.continuation.request_id,
+            admission.continuation.deadline_unix_s,
+        )
+        scheduler._pd_ownership.attach_allocation(
+            admission.continuation.request_id, admission.allocation
+        )
+        scheduler._pd_ownership.transition(admission.continuation.request_id, "ready")
 
 
 def test_continuation_reconstructs_req_and_transferred_mapping() -> None:
@@ -269,6 +286,7 @@ def test_request_pool_exhaustion_has_a_retryable_signal() -> None:
 def test_committed_decode_admission_enters_waiting_queue() -> None:
     pool = _ReqPool()
     scheduler, freed = _decode_scheduler([_decode_admission("request-1", 7)], pool)
+    _own_admissions(scheduler, list(scheduler._pd_ready_queue.queue))
 
     scheduler._drain_pd_admissions()
 
@@ -282,6 +300,7 @@ def test_committed_decode_admission_enters_waiting_queue() -> None:
 def test_aborted_decode_admission_releases_transferred_slots() -> None:
     admission = _decode_admission("request-1", 7)
     scheduler, freed = _decode_scheduler([admission], _ReqPool())
+    _own_admissions(scheduler, [admission])
     scheduler._aborted_request_ids = {"request-1"}
 
     scheduler._drain_pd_admissions()
@@ -295,6 +314,7 @@ def test_decode_admission_retries_pool_exhaustion_without_releasing_kv() -> None
     admission = _decode_admission("request-1", 7)
     pool = _CapacityReqPool(capacity=0)
     scheduler, freed = _decode_scheduler([admission], pool)
+    _own_admissions(scheduler, [admission])
 
     scheduler._drain_pd_admissions()
 
@@ -323,6 +343,7 @@ def test_decode_admission_preserves_fifo_across_capacity_waves() -> None:
     ]
     pool = _CapacityReqPool(capacity=1)
     scheduler, freed = _decode_scheduler(admissions, pool)
+    _own_admissions(scheduler, admissions)
     admitted = []
 
     for expected in ("request-1", "request-2", "request-3"):
@@ -354,6 +375,7 @@ def test_permanent_decode_reconstruction_error_is_not_retried(monkeypatch) -> No
         fail_reconstruction,
     )
     scheduler, freed = _decode_scheduler([admission], _CapacityReqPool(capacity=1))
+    _own_admissions(scheduler, [admission])
 
     scheduler._drain_pd_admissions()
     scheduler._drain_pd_admissions()
@@ -370,6 +392,7 @@ def test_permanent_decode_reconstruction_error_is_not_retried(monkeypatch) -> No
 def test_abort_while_decode_admission_is_deferred_releases_once() -> None:
     admission = _decode_admission("request-1", 7)
     scheduler, freed = _decode_scheduler([admission], _CapacityReqPool(capacity=0))
+    _own_admissions(scheduler, [admission])
     scheduler._drain_pd_admissions()
     scheduler._aborted_request_ids.add("request-1")
 
@@ -388,6 +411,7 @@ def test_discard_decode_admissions_releases_each_allocation_once() -> None:
         _decode_admission("request-2", 10),
     ]
     scheduler, freed = _decode_scheduler(admissions, _CapacityReqPool(capacity=0))
+    _own_admissions(scheduler, admissions)
     scheduler._drain_pd_admissions()
 
     scheduler._discard_pd_admissions()
@@ -409,6 +433,7 @@ def test_metrics_reporter_handles_multiple_reconstructed_requests() -> None:
         _CapacityReqPool(capacity=2),
     )
     scheduler.disaggregation_mode = DisaggregationMode.DECODE
+    _own_admissions(scheduler, list(scheduler._pd_ready_queue.queue))
     scheduler.disagg_decode_prealloc_queue = SimpleNamespace(
         queue=[], retracted_queue=[], num_tokens_pre_allocated=0
     )
@@ -427,6 +452,103 @@ def test_metrics_reporter_handles_multiple_reconstructed_requests() -> None:
     ]
     assert len(snapshots) == 2
     assert all(snapshot.num_decode_requests == 0 for snapshot in snapshots)
+
+
+def test_decode_owned_states_share_one_hard_queue_bound() -> None:
+    tracker = PDDecodeOwnershipTracker(max_queued_requests=2)
+    tracker.reserve("committed", None)
+    tracker.transition("committed", "committed")
+    tracker.reserve("deferred", None)
+    tracker.transition("deferred", "deferred")
+
+    with pytest.raises(DecodeOwnershipCapacityExhausted):
+        tracker.reserve("new", None)
+
+    assert tracker.snapshot() == {"committed": 1, "deferred": 1}
+
+
+def test_expired_deferred_admission_releases_destination_kv_once() -> None:
+    admission = _decode_admission("request-1", 7)
+    admission = PDDecodeAdmission(
+        replace(admission.continuation, deadline_unix_s=time.time() - 1),
+        admission.allocation,
+    )
+    scheduler, freed = _decode_scheduler([admission], _CapacityReqPool(capacity=0))
+    _own_admissions(scheduler, [admission])
+
+    scheduler._drain_pd_admissions()
+    scheduler._drain_pd_admissions()
+
+    assert freed == [admission.allocation.slots]
+    assert scheduler._pd_ownership.snapshot() == {}
+    assert scheduler.waiting_queue == []
+
+
+def test_deadline_expired_before_reconstruction_never_enters_waiting() -> None:
+    admission = _decode_admission("request-1", 7)
+    admission = PDDecodeAdmission(
+        replace(admission.continuation, deadline_unix_s=time.time() - 1),
+        admission.allocation,
+    )
+    scheduler, freed = _decode_scheduler([admission], _ReqPool())
+    _own_admissions(scheduler, [admission])
+
+    scheduler._drain_pd_admissions()
+
+    assert scheduler.waiting_queue == []
+    assert freed == [admission.allocation.slots]
+
+
+def test_timeout_ready_abort_race_has_one_terminal_owner() -> None:
+    admission = _decode_admission("request-1", 7)
+    scheduler, freed = _decode_scheduler([], _ReqPool())
+    _own_admissions(scheduler, [admission])
+    barrier = threading.Barrier(3)
+
+    def release(reason):
+        barrier.wait()
+        scheduler._release_pd_owned("request-1", reason=reason)
+
+    threads = [
+        threading.Thread(target=release, args=("timeout",)),
+        threading.Thread(target=release, args=("abort",)),
+    ]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join(timeout=1)
+
+    assert freed == [admission.allocation.slots]
+    assert scheduler._pd_ownership.snapshot() == {}
+
+
+def test_queue_slot_release_allows_exactly_one_next_admission() -> None:
+    tracker = PDDecodeOwnershipTracker(max_queued_requests=1)
+    tracker.reserve("first", None)
+    tracker.transition("first", "waiting")
+    with pytest.raises(DecodeOwnershipCapacityExhausted):
+        tracker.reserve("second", None)
+
+    tracker.transition("first", "running")
+    tracker.reserve("second", None)
+    with pytest.raises(DecodeOwnershipCapacityExhausted):
+        tracker.reserve("third", None)
+
+    assert tracker.snapshot() == {"reserved": 1, "running": 1}
+
+
+def test_all_decode_owned_exit_paths_return_accounting_to_zero() -> None:
+    tracker = PDDecodeOwnershipTracker(max_queued_requests=8)
+    states = ("reserved", "committed", "ready", "deferred", "waiting", "running")
+    for state in states:
+        tracker.reserve(state, None)
+        tracker.transition(state, state)
+    for state in states:
+        assert tracker.pop(state) is not None
+        assert tracker.pop(state) is None
+
+    assert tracker.snapshot() == {}
 
 
 def test_prefill_handoff_reuses_request_mapping_and_detaches_batch() -> None:


### PR DESCRIPTION
Follow-up to sgl-project/sglang-omni#1596 at frozen head `a50876b`.

Mutable `get` followed by a separate transition let timeout, abort, ready, and cleanup pop Decode ownership between operations, while retraction failed to restore queue credit and receiver cleanup had two owners. This validates and atomically applies lifecycle transitions, synchronizes rank-ready with shutdown, and gives one terminal claim responsibility for destination KV and request-pool release.

## Tests

- Production-callback timeout/abort/ready race, running timeout, exactly-once destination free, queue-full-before-allocation, and running → waiting → running credit tests.
- `pytest -q tests/unit_test/pipeline tests/unit_test/scheduling -k 'not test_pd_handoff_waits_for_ack_in_background and not test_mp_runner_startup_failure_includes_child_factory_traceback'` — 768 passed, 2 deselected.

The absolute Unix deadline contract still requires synchronized wall clocks for multi-host deployment; no GPU or multi-host run was performed.