### PR TITLE
refactor(pipeline): construct role-specific PD schedulers

### DIFF
--- a/sglang_omni/config/pd_capability.py
+++ b/sglang_omni/config/pd_capability.py
@@ -19,7 +19,13 @@ _PD_CAPABLE_ATTR = "__sglang_pd_disaggregation_capable__"
 
 
 def pd_disaggregation_capable(factory: Callable[..., Any]) -> Callable[..., Any]:
-    """Mark *factory* as able to run as a PD prefill/decode half."""
+    """Mark *factory* as able to construct a concrete PD scheduler.
+
+    Marked factories must accept the compiler-owned ``scheduler_cls`` and
+    ``scheduler_kwargs`` keyword arguments and instantiate that class before
+    returning. The worker validates the returned concrete type before Stage
+    construction.
+    """
     setattr(factory, _PD_CAPABLE_ATTR, True)
     return factory
 

--- a/sglang_omni/config/pd_rewrite.py
+++ b/sglang_omni/config/pd_rewrite.py
@@ -18,6 +18,8 @@ from sglang_omni.config.schema import PDExecution, StageConfig
 
 PREFILL_SUFFIX = "_prefill"
 DECODE_SUFFIX = "_decode"
+PREFILL_SCHEDULER_CLASS = "sglang_omni.scheduling.omni_scheduler.OmniPrefillScheduler"
+DECODE_SCHEDULER_CLASS = "sglang_omni.scheduling.omni_scheduler.OmniDecodeScheduler"
 
 
 @dataclass(frozen=True)
@@ -156,7 +158,11 @@ def _split_pd_stage(
             "stream_to": [inbound_rename.get(t, t) for t in s.stream_to],
             "pd_disaggregation": None,
             # Note (Yue Yin): Keep compiler metadata out of user factory kwargs.
-            "pd_execution": PDExecution(role="prefill", partner=decode_name),
+            "pd_execution": PDExecution(
+                role="prefill",
+                partner=decode_name,
+                scheduler_class=PREFILL_SCHEDULER_CLASS,
+            ),
         },
     )
 
@@ -175,7 +181,11 @@ def _split_pd_stage(
             "wait_for_fn": None,
             "merge_fn": None,
             "pd_disaggregation": None,
-            "pd_execution": PDExecution(role="decode", partner=prefill_name),
+            "pd_execution": PDExecution(
+                role="decode",
+                partner=prefill_name,
+                scheduler_class=DECODE_SCHEDULER_CLASS,
+            ),
         },
     )
 

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -241,14 +241,16 @@ class PDExecution(BaseModel):
     """Compiler-generated PD execution metadata for one physical half.
 
     Set by the PD graph rewrite on generated prefill/decode halves. Kept as a
-    typed launch/runtime field (not in ``factory_args``) so it cannot leak into
-    factory constructors or break strict signatures.
+    typed launch/runtime field (not in user ``factory_args``). The worker uses
+    ``scheduler_class`` to inject a compiler-owned construction contract into
+    PD-capable model factories.
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     role: Literal["prefill", "decode"]
     partner: str
+    scheduler_class: str
 
 
 class StageConfig(BaseModel):

--- a/sglang_omni/models/ming_omni/bootstrap.py
+++ b/sglang_omni/models/ming_omni/bootstrap.py
@@ -22,6 +22,8 @@ def create_thinker_scheduler(
     tp_size: int = 1,
     nccl_port: int | None = None,
     enable_streaming_tts: bool = False,
+    scheduler_cls: type | None = None,
+    scheduler_kwargs: dict[str, Any] | None = None,
 ):
     if tp_size < 1:
         raise ValueError(f"tp_size must be >= 1, got {tp_size}")
@@ -95,7 +97,8 @@ def create_thinker_scheduler(
         eos_token_id=getattr(tokenizer, "eos_token_id", None),
     )
 
-    return OmniScheduler(
+    scheduler_cls = scheduler_cls or OmniScheduler
+    return scheduler_cls(
         tp_worker=model_worker,
         tree_cache=tree_cache,
         req_to_token_pool=req_to_token_pool,
@@ -108,6 +111,7 @@ def create_thinker_scheduler(
         request_builder=request_builder,
         result_adapter=result_adapter,
         stream_output_builder=stream_output_builder,
+        **(scheduler_kwargs or {}),
     )
 
 

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -291,6 +291,8 @@ def create_sglang_thinker_executor_from_config(
     thinker_max_seq_len: int = 8192,
     server_args_overrides: dict[str, Any] | None = None,
     enable_streaming_tts: bool = False,
+    scheduler_cls: type | None = None,
+    scheduler_kwargs: dict[str, Any] | None = None,
 ):
     validate_stage_tp_support(stage_name="thinker", tp_size=tp_size)
 
@@ -317,6 +319,8 @@ def create_sglang_thinker_executor_from_config(
         tp_size=tp_size,
         nccl_port=nccl_port,
         enable_streaming_tts=enable_streaming_tts,
+        scheduler_cls=scheduler_cls,
+        scheduler_kwargs=scheduler_kwargs,
     )
 
 

--- a/sglang_omni/models/qwen3_omni/bootstrap.py
+++ b/sglang_omni/models/qwen3_omni/bootstrap.py
@@ -21,6 +21,8 @@ def create_thinker_scheduler(
     prefill_coalesce_requests: int = 0,
     prefill_coalesce_wait_ms: float = 60.0,
     prefill_coalesce_when_idle: bool = False,
+    scheduler_cls: type | None = None,
+    scheduler_kwargs: dict[str, Any] | None = None,
 ):
     """Create the Qwen thinker scheduler."""
     from sglang.srt.utils.hf_transformers_utils import get_tokenizer
@@ -131,7 +133,8 @@ def create_thinker_scheduler(
     )
     stream_output_builder = make_thinker_stream_output_builder()
 
-    return OmniScheduler(
+    scheduler_cls = scheduler_cls or OmniScheduler
+    return scheduler_cls(
         tp_worker=model_worker,
         tree_cache=tree_cache,
         req_to_token_pool=req_to_token_pool,
@@ -149,6 +152,7 @@ def create_thinker_scheduler(
         prefill_coalesce_requests=prefill_coalesce_requests,
         prefill_coalesce_wait_ms=prefill_coalesce_wait_ms,
         prefill_coalesce_when_idle=prefill_coalesce_when_idle,
+        **(scheduler_kwargs or {}),
     )
 
 

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -1012,6 +1012,8 @@ def create_sglang_thinker_executor_from_config(
     prefill_coalesce_requests: int = 0,
     prefill_coalesce_wait_ms: float = 60.0,
     prefill_coalesce_when_idle: bool = False,
+    scheduler_cls: type | None = None,
+    scheduler_kwargs: dict[str, Any] | None = None,
 ):
     """Returns OmniScheduler for thinker."""
     # note (luojiaxuan):
@@ -1103,6 +1105,8 @@ def create_sglang_thinker_executor_from_config(
         prefill_coalesce_requests=prefill_coalesce_requests,
         prefill_coalesce_wait_ms=prefill_coalesce_wait_ms,
         prefill_coalesce_when_idle=prefill_coalesce_when_idle,
+        scheduler_cls=scheduler_cls,
+        scheduler_kwargs=scheduler_kwargs,
     )
     post_load_process_mem = get_process_gpu_memory_bytes(gpu_id)
     logger.info(

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -52,6 +52,7 @@ from sglang_omni.proto import (
 from sglang_omni.relay.base import Relay
 from sglang_omni.scheduling.messages import IncomingMessage
 from sglang_omni.scheduling.pd_continuation import PrefillContinuationProducer
+from sglang_omni.scheduling.pd_runtime import PDTransportBinding
 
 logger = logging.getLogger(__name__)
 
@@ -111,12 +112,11 @@ class Stage:
         disable_direct_cuda_ipc_payload: bool = False,
         tp_fanout: TPLeaderFanout | None = None,
         is_terminal: bool = False,
-        pd_execution: Any = None,
+        pd_transport_binding: PDTransportBinding | None = None,
         replica_topology: dict[str, list[str]] | None = None,
     ):
         self.name = name
         self.role = role
-        self.pd_execution = pd_execution
         self.get_next = get_next
         self.gpu_id = gpu_id
         self.endpoints = endpoints
@@ -153,19 +153,13 @@ class Stage:
             rank_endpoints=rank_endpoints,
             task_done_callback=self._on_background_task_done,
         )
-        if pd_execution is not None:
-            if scheduler is None or not hasattr(scheduler, "bind_pd_runtime"):
-                raise TypeError(
-                    f"PD stage {name!r} requires an OmniScheduler PD runtime"
+        if pd_transport_binding is not None:
+            self._comm.register_kv_pool(pd_transport_binding.pool)
+            if pd_transport_binding.receiver is not None:
+                self._comm.register_kv_receiver(
+                    pd_transport_binding.pool.pool_id,
+                    pd_transport_binding.receiver,
                 )
-            pool, receiver = scheduler.bind_pd_runtime(
-                stage_name=name,
-                role=pd_execution.role,
-                partner=pd_execution.partner,
-            )
-            self._comm.register_kv_pool(pool)
-            if receiver is not None:
-                self._comm.register_kv_receiver(pool.pool_id, receiver)
 
         self._running = False
         self._aborted: set[str] = set()

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import gc
+import inspect
 import logging
 import multiprocessing
 import os
@@ -620,6 +621,9 @@ def _construct_stage(
     )
 
     scheduler = _construct_scheduler(spec, gpu_id, log)
+    pd_transport_binding = (
+        scheduler.transport_binding if spec.pd_execution is not None else None
+    )
 
     def _target_list(targets: str | list[str] | None) -> list[str]:
         if targets is None:
@@ -795,7 +799,7 @@ def _construct_stage(
         disable_direct_cuda_ipc_payload=spec.disable_direct_cuda_ipc_payload,
         tp_fanout=tp_fanout,
         is_terminal=spec.is_terminal,
-        pd_execution=spec.pd_execution,
+        pd_transport_binding=pd_transport_binding,
         replica_topology=spec.replica_topology or None,
     )
 
@@ -826,12 +830,67 @@ def _construct_scheduler(
         require_gpu_id=spec.require_factory_gpu_id,
         stage_name=spec.stage_name,
     )
+    expected_scheduler_cls = None
+    if spec.pd_execution is not None:
+        from sglang_omni.scheduling.omni_scheduler import (
+            OmniDecodeScheduler,
+            OmniPrefillScheduler,
+        )
+
+        expected_by_role = {
+            "prefill": OmniPrefillScheduler,
+            "decode": OmniDecodeScheduler,
+        }
+        expected_scheduler_cls = import_string(spec.pd_execution.scheduler_class)
+        role_scheduler_cls = expected_by_role[spec.pd_execution.role]
+        if expected_scheduler_cls is not role_scheduler_cls:
+            raise TypeError(
+                f"PD stage {spec.stage_name!r} role {spec.pd_execution.role!r} "
+                f"requires {role_scheduler_cls.__module__}."
+                f"{role_scheduler_cls.__qualname__}, got "
+                f"{spec.pd_execution.scheduler_class!r}"
+            )
+        parameters = inspect.signature(factory).parameters
+        accepts_any_kwarg = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters.values()
+        )
+        missing = {
+            name
+            for name in ("scheduler_cls", "scheduler_kwargs")
+            if name not in parameters and not accepts_any_kwarg
+        }
+        if missing:
+            raise TypeError(
+                f"PD-capable factory {spec.factory!r} for stage "
+                f"{spec.stage_name!r} must accept compiler-owned scheduler "
+                f"construction arguments {sorted(missing)}"
+            )
+        factory_args["scheduler_cls"] = expected_scheduler_cls
+        factory_args["scheduler_kwargs"] = {
+            "stage_name": spec.stage_name,
+            "partner": spec.pd_execution.partner,
+        }
+
+    def construct() -> Any:
+        scheduler = factory(**factory_args)
+        if expected_scheduler_cls is not None and not isinstance(
+            scheduler, expected_scheduler_cls
+        ):
+            raise TypeError(
+                f"PD stage {spec.stage_name!r} factory returned "
+                f"{type(scheduler).__module__}.{type(scheduler).__qualname__}; "
+                f"expected {expected_scheduler_cls.__module__}."
+                f"{expected_scheduler_cls.__qualname__}"
+            )
+        return scheduler
+
     if gpu_id is None:
-        return factory(**factory_args)
+        return construct()
 
     with gpu_startup_lock(int(gpu_id)) as lock_path:
         log.info(f"Acquired GPU startup lock for stage {spec.stage_name}: {lock_path}")
-        return factory(**factory_args)
+        return construct()
 
 
 def _prepare_accelerator_environment(

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -51,6 +51,8 @@ class SGLangGenerationEngineBuilder(ABC):
         gpu_id: int | None = None,
         dtype: str = "bfloat16",
         server_args_overrides: dict[str, Any] | None = None,
+        scheduler_cls: type | None = None,
+        scheduler_kwargs: dict[str, Any] | None = None,
     ) -> Any:
         import torch
 
@@ -174,6 +176,12 @@ class SGLangGenerationEngineBuilder(ABC):
                 model=model,
             )
             self.setup_runtime_resources(model, server_args)
+            scheduler_construction = {}
+            if scheduler_cls is not None or scheduler_kwargs is not None:
+                scheduler_construction = {
+                    "scheduler_cls": scheduler_cls,
+                    "scheduler_kwargs": scheduler_kwargs,
+                }
             scheduler, model_runner = self._build_runtime(
                 model_worker=model_worker,
                 model=model,
@@ -185,6 +193,7 @@ class SGLangGenerationEngineBuilder(ABC):
                 model_config=model_config,
                 prefill_manager=prefill_mgr,
                 decode_manager=decode_mgr,
+                **scheduler_construction,
             )
             self.post_scheduler_setup(scheduler, model_runner)
             return scheduler
@@ -277,9 +286,11 @@ class SGLangGenerationEngineBuilder(ABC):
         model_config: Any,
         prefill_manager: Any,
         decode_manager: Any,
+        scheduler_cls: type | None = None,
+        scheduler_kwargs: dict[str, Any] | None = None,
     ) -> tuple[Any, Any]:
         request_builder, result_adapter = self.make_adapters(model)
-        scheduler_kwargs = self.extra_scheduler_kwargs()
+        extra_scheduler_kwargs = self.extra_scheduler_kwargs()
         model_runner = self.make_model_runner(model_worker, output_proc)
         scheduler = self._make_scheduler(
             model_worker=model_worker,
@@ -293,7 +304,9 @@ class SGLangGenerationEngineBuilder(ABC):
             model_runner=model_runner,
             request_builder=request_builder,
             result_adapter=result_adapter,
-            extra_scheduler_kwargs=scheduler_kwargs,
+            extra_scheduler_kwargs=extra_scheduler_kwargs,
+            scheduler_cls=scheduler_cls,
+            scheduler_construction_kwargs=scheduler_kwargs,
         )
         return scheduler, model_runner
 
@@ -327,6 +340,8 @@ class SGLangGenerationEngineBuilder(ABC):
         request_builder: Any,
         result_adapter: Any,
         extra_scheduler_kwargs: dict[str, Any],
+        scheduler_cls: type | None = None,
+        scheduler_construction_kwargs: dict[str, Any] | None = None,
     ) -> Any:
         from sglang_omni.scheduling import omni_scheduler
 
@@ -347,7 +362,9 @@ class SGLangGenerationEngineBuilder(ABC):
         }
         scheduler_kwargs.update(self.extra_scheduler_callbacks())
         scheduler_kwargs.update(extra_scheduler_kwargs)
-        return omni_scheduler.OmniScheduler(**scheduler_kwargs)
+        scheduler_cls = scheduler_cls or omni_scheduler.OmniScheduler
+        scheduler_kwargs.update(scheduler_construction_kwargs or {})
+        return scheduler_cls(**scheduler_kwargs)
 
     def post_scheduler_setup(self, scheduler: Any, model_runner: Any) -> None:
         del scheduler, model_runner
@@ -419,10 +436,13 @@ class TtsEngineBuilder(SGLangGenerationEngineBuilder):
         model_runner: Any,
         request_builder: Any,
         result_adapter: Any,
+        scheduler_cls: type | None = None,
+        scheduler_kwargs: dict[str, Any] | None = None,
     ) -> Any:
         from sglang_omni.scheduling import omni_scheduler
 
-        return omni_scheduler.OmniScheduler(
+        scheduler_cls = scheduler_cls or omni_scheduler.OmniScheduler
+        return scheduler_cls(
             tp_worker=model_worker,
             tree_cache=tree_cache,
             req_to_token_pool=req_to_token_pool,
@@ -437,6 +457,7 @@ class TtsEngineBuilder(SGLangGenerationEngineBuilder):
             abort_callback=self.make_abort_callback(),
             request_finished_callback=self.make_request_finished_callback(),
             **self.extra_scheduler_kwargs(),
+            **(scheduler_kwargs or {}),
         )
 
     def _build_runtime(
@@ -452,9 +473,17 @@ class TtsEngineBuilder(SGLangGenerationEngineBuilder):
         model_config: Any,
         prefill_manager: Any,
         decode_manager: Any,
+        scheduler_cls: type | None = None,
+        scheduler_kwargs: dict[str, Any] | None = None,
     ) -> tuple[Any, Any]:
         model_runner = self.make_model_runner(model_worker, output_proc)
         request_builder, result_adapter = self.make_adapters(model)
+        scheduler_construction = {}
+        if scheduler_cls is not None or scheduler_kwargs is not None:
+            scheduler_construction = {
+                "scheduler_cls": scheduler_cls,
+                "scheduler_kwargs": scheduler_kwargs,
+            }
         scheduler = self.make_scheduler(
             model_worker=model_worker,
             tree_cache=tree_cache,
@@ -467,5 +496,6 @@ class TtsEngineBuilder(SGLangGenerationEngineBuilder):
             model_runner=model_runner,
             request_builder=request_builder,
             result_adapter=result_adapter,
+            **scheduler_construction,
         )
         return scheduler, model_runner

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -76,6 +76,7 @@ from sglang_omni.scheduling.pd_runtime import (
     DecodeRequestPoolExhausted,
     PDDecodeAdmission,
     PDPrefillHandoff,
+    PDTransportBinding,
     continuation_from_req,
     req_from_continuation,
 )
@@ -540,198 +541,6 @@ class OmniScheduler:
         self._first_emit_done: set[str] = set()
         self._prefill_start_done: set[str] = set()
         self._prefill_end_done: set[str] = set()
-        self._pd_role: str | None = None
-        self._pd_partner: str | None = None
-        self._pd_pool_id: str | None = None
-        self._pd_ready_queue = _queue_mod.Queue()
-        self._pd_deferred_admission: PDDecodeAdmission | None = None
-        self._pd_admission_lock = threading.Lock()
-        self._pd_receiver: AllocatorKVReceiver | None = None
-        self._pd_controller: PDHandoffController | None = None
-
-    def bind_pd_runtime(
-        self,
-        *,
-        stage_name: str,
-        role: str,
-        partner: str,
-    ) -> tuple[Any, Any | None]:
-        if self.tp_size != 1:
-            raise NotImplementedError("PR3 PD runtime supports tp_size == 1 only")
-        if self.page_size != 1:
-            raise NotImplementedError("PR3 PD runtime supports page_size == 1 only")
-        if not self.server_args.disable_radix_cache:
-            raise NotImplementedError("PR3 PD runtime requires RadixCache disabled")
-        if role not in {"prefill", "decode"}:
-            raise ValueError(f"invalid PD role {role!r}")
-
-        self._pd_role = role
-        self._pd_partner = partner
-        self._pd_pool_id = f"{stage_name}:kv"
-        raw_pool = self.token_to_kv_pool_allocator.get_kvcache()
-        layout_id = (
-            f"{type(raw_pool).__module__}.{type(raw_pool).__qualname__}:"
-            f"page_size={self.page_size}"
-        )
-        pool = build_kv_pool(
-            raw_pool,
-            pool_id=self._pd_pool_id,
-            layout_id=layout_id,
-        )
-        if role == "prefill":
-            return pool, None
-
-        from sglang.srt.disaggregation.utils import DisaggregationMode
-
-        self.disaggregation_mode = DisaggregationMode.DECODE
-        self.batch_result_processor = dataclasses.replace(
-            self.batch_result_processor,
-            disaggregation_mode=DisaggregationMode.DECODE,
-        )
-        receiver = AllocatorKVReceiver(
-            pool_id=self._pd_pool_id,
-            token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
-            page_size=self.page_size,
-        )
-
-        def on_ready(pending):
-            if pending.continuation is None:
-                raise RuntimeError("rank-ready handoff has no continuation")
-            allocation = receiver.take_committed(pending.request_id)
-            try:
-                self._pd_ready_queue.put(
-                    PDDecodeAdmission(pending.continuation, allocation)
-                )
-            except Exception:
-                # Note (Yue Yin): take_committed transfers ownership out of the
-                # receiver before the scheduler queue can accept it.
-                self.token_to_kv_pool_allocator.free(allocation.slots)
-                raise
-
-        controller = PDHandoffController(
-            rank_ready_callback=on_ready,
-            cleanup_callback=lambda pending, _reason: receiver.release(
-                pending.request_id
-            ),
-        )
-        self._pd_receiver = receiver
-        self._pd_controller = controller
-        return pool, ContinuationAwareKVReceiver(
-            receiver,
-            controller,
-            allowed_resume_schemas=self._pd_resume_schemas,
-        )
-
-    def _drain_pd_admissions(self) -> None:
-        ready_queue = self.__dict__.get("_pd_ready_queue")
-        if ready_queue is None:
-            return
-        with self._pd_admission_lock:
-            while True:
-                admission = self._pd_deferred_admission
-                if admission is None:
-                    try:
-                        admission = ready_queue.get_nowait()
-                    except _queue_mod.Empty:
-                        return
-                request_id = admission.continuation.request_id
-                if request_id in self._aborted_request_ids:
-                    self._pd_deferred_admission = None
-                    self.token_to_kv_pool_allocator.free(admission.allocation.slots)
-                    continue
-                try:
-                    req = req_from_continuation(
-                        admission.continuation,
-                        admission.allocation,
-                        req_to_token_pool=self.req_to_token_pool,
-                        state_restorer=self.__dict__.get("_pd_state_restorer"),
-                    )
-                except DecodeRequestPoolExhausted:
-                    # Note (Yue Yin): The committed KV must remain owned while
-                    # an earlier request is still using the request-pool slot.
-                    self._pd_deferred_admission = admission
-                    return
-                except Exception as exc:
-                    self._pd_deferred_admission = None
-                    self.token_to_kv_pool_allocator.free(admission.allocation.slots)
-                    self._emit_request_error(
-                        request_id, exc, metadata={"pd_pre_admission": True}
-                    )
-                    continue
-                self._pd_deferred_admission = None
-                self.waiting_queue.append(req)
-                self.outbox.put(
-                    OutgoingMessage(request_id=request_id, type="pd_admitted")
-                )
-
-    def _discard_pd_admissions(self) -> None:
-        ready_queue = self.__dict__.get("_pd_ready_queue")
-        if ready_queue is None:
-            return
-        with self._pd_admission_lock:
-            admission = self._pd_deferred_admission
-            self._pd_deferred_admission = None
-            if admission is not None:
-                self.token_to_kv_pool_allocator.free(admission.allocation.slots)
-            while True:
-                try:
-                    admission = ready_queue.get_nowait()
-                except _queue_mod.Empty:
-                    return
-                self.token_to_kv_pool_allocator.free(admission.allocation.slots)
-
-    def _queue_pd_prefill_handoffs(
-        self,
-        batch: ScheduleBatch,
-        sampled_request_ids: set[int],
-    ) -> None:
-        retained = []
-        for req in batch.reqs:
-            if req.finished() or getattr(req, "_pd_handoff_started", False):
-                continue
-            if id(req) not in sampled_request_ids or req.inflight_middle_chunks > 0:
-                # Note (Yue Yin): Upstream decrements middle-chunk accounting
-                # before returning even though that chunk produced no token.
-                retained.append(req)
-                continue
-            if req.req_pool_idx is None:
-                self._emit_request_error(
-                    req.rid,
-                    RuntimeError("prefill request lost its KV allocation"),
-                )
-                continue
-            try:
-                req._pd_handoff_started = True
-                transfer_id = f"{req.rid}:pd:{uuid4().hex}"
-                continuation = continuation_from_req(
-                    req,
-                    transfer_id,
-                    self.__dict__.get("_pd_state_builder"),
-                )
-                pages = resolve_page_indices(
-                    self.req_to_token_pool,
-                    req_pool_idx=req.req_pool_idx,
-                    seq_len=len(req.origin_input_ids),
-                    page_size=self.page_size,
-                )
-                self.outbox.put(
-                    OutgoingMessage(
-                        request_id=req.rid,
-                        type="pd_handoff",
-                        data=PDPrefillHandoff(
-                            continuation=continuation,
-                            source_pool_id=self._pd_pool_id,
-                            target_pool_id=f"{self._pd_partner}:kv",
-                            source_page_indices=pages,
-                            to_stage=self._pd_partner,
-                            lease=SGLangKVPageLease(req, self.tree_cache),
-                        ),
-                    )
-                )
-            except Exception as exc:
-                self._release_request_kv_cache(req)
-                self._emit_request_error(req.rid, exc)
-        batch.reqs = retained
 
     def bind_model_runner(self, model_runner: Any) -> None:
         """Attach a custom runner and its SGLang execution-contract bridge.
@@ -1565,48 +1374,14 @@ class OmniScheduler:
         own that state, so feed it in and write the (possibly rebuilt) running
         batch back before handing the runnable batch to the caller.
         """
-        self._drain_pd_admissions()
-        pd_role = self.__dict__.get("_pd_role")
-        if (
-            pd_role == "prefill"
-            and self.running_batch.is_empty()
-            and self.running_batch.batch_is_full
-            and self.req_to_token_pool.available_size() > 0
-        ):
-            # Note (Yue Yin): ACK can return a source request slot after the
-            # empty running batch was marked full by the prior admission wave.
-            self.running_batch.batch_is_full = False
-        if pd_role == "decode":
-            # Note (Yue Yin): Reuse upstream admission so PREBUILT cache and
-            # batching ownership stay aligned with the installed SGLang version.
-            plan = _Upstream.get_next_disagg_decode_batch_to_run(
-                self, self.running_batch
-            )
-        else:
-            plan = _Upstream.get_next_batch_to_run(
-                self, self.running_batch, self.last_batch
-            )
+        plan = _Upstream.get_next_batch_to_run(
+            self, self.running_batch, self.last_batch
+        )
         self.running_batch = plan.running_batch
         return plan.batch_to_run
 
     def process_batch_result(self, batch, result):
-        is_pd_prefill = (
-            self.__dict__.get("_pd_role") == "prefill"
-            and batch.forward_mode.is_extend()
-        )
-        output_lengths = (
-            {id(req): len(req.output_ids) for req in batch.reqs}
-            if is_pd_prefill
-            else {}
-        )
         _Upstream.process_batch_result(self, batch, result)
-        if is_pd_prefill:
-            sampled_request_ids = {
-                id(req)
-                for req in batch.reqs
-                if len(req.output_ids) > output_lengths[id(req)]
-            }
-            self._queue_pd_prefill_handoffs(batch, sampled_request_ids)
 
     def get_new_batch_prefill(self, running_batch):
         # Note: (maydomine) batch prefill admissions to amortize the fixed step
@@ -2023,7 +1798,6 @@ class OmniScheduler:
     def _discard_pending_request_admissions(self) -> None:
         with self._request_admission_lock:
             self._pending_request_admissions.clear()
-        self._discard_pd_admissions()
 
     def _shutdown_resources(self) -> None:
         with self._shutdown_lock:
@@ -2040,9 +1814,6 @@ class OmniScheduler:
         self._request_build_executor = None
 
     def abort(self, request_id: str, *, defer_running_cleanup: bool = True) -> None:
-        pd_controller = self.__dict__.get("_pd_controller")
-        if pd_controller is not None:
-            pd_controller.abort(request_id)
         with self._request_admission_lock:
             if request_id not in self._aborted_request_ids:
                 if len(self._aborted_request_ids) >= _ABORTED_REQUEST_ID_LIMIT:
@@ -2977,6 +2748,243 @@ class OmniScheduler:
             req_data.stream_done = True
             return
         self._stream_done_handler(req_data)
+
+
+def _build_scheduler_kv_pool(scheduler: OmniScheduler, stage_name: str) -> Any:
+    if scheduler.tp_size != 1:
+        raise NotImplementedError("PR3 PD runtime supports tp_size == 1 only")
+    if scheduler.page_size != 1:
+        raise NotImplementedError("PR3 PD runtime supports page_size == 1 only")
+    if not scheduler.server_args.disable_radix_cache:
+        raise NotImplementedError("PR3 PD runtime requires RadixCache disabled")
+
+    raw_pool = scheduler.token_to_kv_pool_allocator.get_kvcache()
+    layout_id = (
+        f"{type(raw_pool).__module__}.{type(raw_pool).__qualname__}:"
+        f"page_size={scheduler.page_size}"
+    )
+    return build_kv_pool(
+        raw_pool,
+        pool_id=f"{stage_name}:kv",
+        layout_id=layout_id,
+    )
+
+
+class OmniPrefillScheduler(OmniScheduler):
+    """Omni scheduler with Prefill continuation and source-lease ownership."""
+
+    @property
+    def transport_binding(self) -> PDTransportBinding:
+        return self._transport_binding
+
+    def __init__(self, *args: Any, stage_name: str, partner: str, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._partner_stage = partner
+        pool = _build_scheduler_kv_pool(self, stage_name)
+        self._source_pool_id = pool.pool_id
+        self._transport_binding = PDTransportBinding(pool=pool)
+
+    def get_next_batch_to_run(self):
+        if (
+            self.running_batch.is_empty()
+            and self.running_batch.batch_is_full
+            and self.req_to_token_pool.available_size() > 0
+        ):
+            # ACK can return a source request slot after the empty running batch
+            # was marked full by the prior admission wave.
+            self.running_batch.batch_is_full = False
+        return super().get_next_batch_to_run()
+
+    def process_batch_result(self, batch, result):
+        is_prefill = batch.forward_mode.is_extend()
+        output_lengths = (
+            {id(req): len(req.output_ids) for req in batch.reqs} if is_prefill else {}
+        )
+        _Upstream.process_batch_result(self, batch, result)
+        if is_prefill:
+            sampled_request_ids = {
+                id(req)
+                for req in batch.reqs
+                if len(req.output_ids) > output_lengths[id(req)]
+            }
+            self._queue_prefill_handoffs(batch, sampled_request_ids)
+
+    def _queue_prefill_handoffs(
+        self,
+        batch: ScheduleBatch,
+        sampled_request_ids: set[int],
+    ) -> None:
+        retained = []
+        for req in batch.reqs:
+            if req.finished() or getattr(req, "_pd_handoff_started", False):
+                continue
+            if id(req) not in sampled_request_ids or req.inflight_middle_chunks > 0:
+                retained.append(req)
+                continue
+            if req.req_pool_idx is None:
+                self._emit_request_error(
+                    req.rid,
+                    RuntimeError("prefill request lost its KV allocation"),
+                )
+                continue
+            try:
+                req._pd_handoff_started = True
+                transfer_id = f"{req.rid}:pd:{uuid4().hex}"
+                continuation = continuation_from_req(
+                    req,
+                    transfer_id,
+                    self._pd_state_builder,
+                )
+                pages = resolve_page_indices(
+                    self.req_to_token_pool,
+                    req_pool_idx=req.req_pool_idx,
+                    seq_len=len(req.origin_input_ids),
+                    page_size=self.page_size,
+                )
+                self.outbox.put(
+                    OutgoingMessage(
+                        request_id=req.rid,
+                        type="pd_handoff",
+                        data=PDPrefillHandoff(
+                            continuation=continuation,
+                            source_pool_id=self._source_pool_id,
+                            target_pool_id=f"{self._partner_stage}:kv",
+                            source_page_indices=pages,
+                            to_stage=self._partner_stage,
+                            lease=SGLangKVPageLease(req, self.tree_cache),
+                        ),
+                    )
+                )
+            except Exception as exc:
+                self._release_request_kv_cache(req)
+                self._emit_request_error(req.rid, exc)
+        batch.reqs = retained
+
+
+class OmniDecodeScheduler(OmniScheduler):
+    """Omni scheduler with destination readiness and PREBUILT admission."""
+
+    @property
+    def transport_binding(self) -> PDTransportBinding:
+        return self._transport_binding
+
+    def __init__(self, *args: Any, stage_name: str, partner: str, **kwargs: Any):
+        del partner
+        super().__init__(*args, **kwargs)
+
+        from sglang.srt.disaggregation.utils import DisaggregationMode
+
+        self.disaggregation_mode = DisaggregationMode.DECODE
+        self.batch_result_processor = dataclasses.replace(
+            self.batch_result_processor,
+            disaggregation_mode=DisaggregationMode.DECODE,
+        )
+        self._ready_queue: _queue_mod.Queue[PDDecodeAdmission] = _queue_mod.Queue()
+        self._deferred_admission: PDDecodeAdmission | None = None
+        self._admission_lock = threading.Lock()
+
+        pool = _build_scheduler_kv_pool(self, stage_name)
+        receiver = AllocatorKVReceiver(
+            pool_id=pool.pool_id,
+            token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+            page_size=self.page_size,
+        )
+
+        def on_ready(pending):
+            if pending.continuation is None:
+                raise RuntimeError("rank-ready handoff has no continuation")
+            allocation = receiver.take_committed(pending.request_id)
+            try:
+                self._ready_queue.put(
+                    PDDecodeAdmission(pending.continuation, allocation)
+                )
+            except Exception:
+                self.token_to_kv_pool_allocator.free(allocation.slots)
+                raise
+
+        controller = PDHandoffController(
+            rank_ready_callback=on_ready,
+            cleanup_callback=lambda pending, _reason: receiver.release(
+                pending.request_id
+            ),
+        )
+        self._receiver = receiver
+        self._controller = controller
+        self._transport_binding = PDTransportBinding(
+            pool=pool,
+            receiver=ContinuationAwareKVReceiver(
+                receiver,
+                controller,
+                allowed_resume_schemas=self._pd_resume_schemas,
+            ),
+        )
+
+    def get_next_batch_to_run(self):
+        self._drain_admissions()
+        plan = _Upstream.get_next_disagg_decode_batch_to_run(self, self.running_batch)
+        self.running_batch = plan.running_batch
+        return plan.batch_to_run
+
+    def _drain_admissions(self) -> None:
+        with self._admission_lock:
+            while True:
+                admission = self._deferred_admission
+                if admission is None:
+                    try:
+                        admission = self._ready_queue.get_nowait()
+                    except _queue_mod.Empty:
+                        return
+                request_id = admission.continuation.request_id
+                if request_id in self._aborted_request_ids:
+                    self._deferred_admission = None
+                    self.token_to_kv_pool_allocator.free(admission.allocation.slots)
+                    continue
+                try:
+                    req = req_from_continuation(
+                        admission.continuation,
+                        admission.allocation,
+                        req_to_token_pool=self.req_to_token_pool,
+                        state_restorer=self._pd_state_restorer,
+                    )
+                except DecodeRequestPoolExhausted:
+                    self._deferred_admission = admission
+                    return
+                except Exception as exc:
+                    self._deferred_admission = None
+                    self.token_to_kv_pool_allocator.free(admission.allocation.slots)
+                    self._emit_request_error(
+                        request_id, exc, metadata={"pd_pre_admission": True}
+                    )
+                    continue
+                self._deferred_admission = None
+                self.waiting_queue.append(req)
+                self.outbox.put(
+                    OutgoingMessage(request_id=request_id, type="pd_admitted")
+                )
+
+    def _discard_admissions(self) -> None:
+        with self._admission_lock:
+            admission = self._deferred_admission
+            self._deferred_admission = None
+            if admission is not None:
+                self.token_to_kv_pool_allocator.free(admission.allocation.slots)
+            while True:
+                try:
+                    admission = self._ready_queue.get_nowait()
+                except _queue_mod.Empty:
+                    return
+                self.token_to_kv_pool_allocator.free(admission.allocation.slots)
+
+    def _discard_pending_request_admissions(self) -> None:
+        super()._discard_pending_request_admissions()
+        self._discard_admissions()
+
+    def abort(self, request_id: str, *, defer_running_cleanup: bool = True) -> None:
+        self._controller.abort(request_id)
+        super().abort(
+            request_id,
+            defer_running_cleanup=defer_running_cleanup,
+        )
 
 
 def _remove_from_batch(batch: Any, request_id: str) -> None:

--- a/sglang_omni/scheduling/pd_runtime.py
+++ b/sglang_omni/scheduling/pd_runtime.py
@@ -17,6 +17,14 @@ from sglang_omni.scheduling.sglang_backend.request_data import SGLangARRequestDa
 
 
 @dataclass(frozen=True)
+class PDTransportBinding:
+    """Transport resources prepared by a concrete PD scheduler."""
+
+    pool: Any
+    receiver: Any | None = None
+
+
+@dataclass(frozen=True)
 class PDPrefillHandoff:
     continuation: DecodeContinuation
     source_pool_id: str

--- a/tests/unit_test/fixtures/pipeline_fakes.py
+++ b/tests/unit_test/fixtures/pipeline_fakes.py
@@ -13,6 +13,7 @@ import os
 import queue
 import threading
 from dataclasses import dataclass, field
+from types import SimpleNamespace
 from typing import Any, Callable
 
 import torch
@@ -230,14 +231,62 @@ def dummy_factory(**kwargs: Any) -> dict[str, Any]:
 
 
 @pd_disaggregation_capable
-def pd_capable_factory(**kwargs: Any) -> dict[str, Any]:
-    return dict(kwargs)
+def pd_capable_factory(
+    *,
+    scheduler_cls: type | None = None,
+    scheduler_kwargs: dict[str, Any] | None = None,
+    post_setup: Callable[[Any], None] | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Construct the compiler-selected scheduler without GPU dependencies."""
+    if scheduler_cls is None:
+        from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+        scheduler_cls = OmniScheduler
+    scheduler = object.__new__(scheduler_cls)
+    scheduler.factory_kwargs = dict(kwargs)
+    scheduler.scheduler_kwargs = dict(scheduler_kwargs or {})
+    if scheduler_kwargs:
+        from sglang_omni.scheduling.pd_runtime import PDTransportBinding
+
+        pool = SimpleNamespace(pool_id=f"{scheduler_kwargs['stage_name']}:kv")
+        receiver = (
+            object() if scheduler_kwargs["stage_name"].endswith("decode") else None
+        )
+        scheduler._transport_binding = PDTransportBinding(pool, receiver)
+    if post_setup is not None:
+        post_setup(scheduler)
+    return scheduler
 
 
 @pd_disaggregation_capable
-def strict_pd_capable_factory(*, model_path: str, gpu_id: int) -> dict[str, Any]:
+def strict_pd_capable_factory(
+    *,
+    model_path: str,
+    gpu_id: int,
+    scheduler_cls: type | None = None,
+    scheduler_kwargs: dict[str, Any] | None = None,
+) -> Any:
     """PD-capable factory with a strict signature (no ``**kwargs``)."""
-    return {"model_path": model_path, "gpu_id": gpu_id}
+    if scheduler_cls is None:
+        return {"model_path": model_path, "gpu_id": gpu_id}
+    scheduler = object.__new__(scheduler_cls)
+    scheduler.factory_kwargs = {"model_path": model_path, "gpu_id": gpu_id}
+    scheduler.scheduler_kwargs = dict(scheduler_kwargs or {})
+    return scheduler
+
+
+@pd_disaggregation_capable
+def mismatched_pd_scheduler_factory(
+    *,
+    scheduler_cls: type,
+    scheduler_kwargs: dict[str, Any],
+    **kwargs: Any,
+) -> Any:
+    del scheduler_cls, scheduler_kwargs, kwargs
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+    return object.__new__(OmniScheduler)
 
 
 def runtime_factory(

--- a/tests/unit_test/pipeline/test_compile.py
+++ b/tests/unit_test/pipeline/test_compile.py
@@ -555,6 +555,9 @@ def test_pd_stage_specs_carry_typed_pd_execution_outside_factory_args(
         "decode",
         "thinker_prefill",
     )
+    assert prefill.pd_execution.scheduler_class.endswith(".OmniPrefillScheduler")
+    assert decode.pd_execution.scheduler_class.endswith(".OmniDecodeScheduler")
+    assert prefill.pd_execution.scheduler_class != decode.pd_execution.scheduler_class
     assert "pd_role" not in prefill.factory_kwargs
     assert "pd_partner" not in decode.factory_kwargs
 

--- a/tests/unit_test/pipeline/test_pd_rewrite.py
+++ b/tests/unit_test/pipeline/test_pd_rewrite.py
@@ -94,6 +94,8 @@ def test_pd_expansion_rewrites_edges_and_metadata() -> None:
     assert prefill.pd_execution.partner == "thinker_decode"
     assert decode.pd_execution.role == "decode"
     assert decode.pd_execution.partner == "thinker_prefill"
+    assert prefill.pd_execution.scheduler_class.endswith(".OmniPrefillScheduler")
+    assert decode.pd_execution.scheduler_class.endswith(".OmniDecodeScheduler")
     assert "pd_role" not in prefill.factory.model_dump()
     assert "pd_partner" not in decode.factory.model_dump()
 

--- a/tests/unit_test/pipeline/test_pd_runtime.py
+++ b/tests/unit_test/pipeline/test_pd_runtime.py
@@ -18,7 +18,10 @@ from sglang.srt.sampling.sampling_params import SamplingParams
 
 from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling import omni_scheduler as omni_scheduler_module
-from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+from sglang_omni.scheduling.omni_scheduler import (
+    OmniDecodeScheduler,
+    OmniPrefillScheduler,
+)
 from sglang_omni.scheduling.pd_continuation import (
     decode_continuation,
     encode_continuation,
@@ -135,14 +138,14 @@ def _decode_scheduler(
     pool: _ReqPool,
     *,
     state_restorer=None,
-) -> tuple[OmniScheduler, list[torch.Tensor]]:
+) -> tuple[OmniDecodeScheduler, list[torch.Tensor]]:
     freed: list[torch.Tensor] = []
-    scheduler = object.__new__(OmniScheduler)
-    scheduler._pd_ready_queue = queue.Queue()
+    scheduler = object.__new__(OmniDecodeScheduler)
+    scheduler._ready_queue = queue.Queue()
     for admission in admissions:
-        scheduler._pd_ready_queue.put(admission)
-    scheduler._pd_deferred_admission = None
-    scheduler._pd_admission_lock = threading.Lock()
+        scheduler._ready_queue.put(admission)
+    scheduler._deferred_admission = None
+    scheduler._admission_lock = threading.Lock()
     scheduler._pd_state_restorer = state_restorer
     scheduler._aborted_request_ids = set()
     scheduler.req_to_token_pool = pool
@@ -270,7 +273,7 @@ def test_committed_decode_admission_enters_waiting_queue() -> None:
     pool = _ReqPool()
     scheduler, freed = _decode_scheduler([_decode_admission("request-1", 7)], pool)
 
-    scheduler._drain_pd_admissions()
+    scheduler._drain_admissions()
 
     assert [req.rid for req in scheduler.waiting_queue] == ["request-1"]
     assert freed == []
@@ -284,7 +287,7 @@ def test_aborted_decode_admission_releases_transferred_slots() -> None:
     scheduler, freed = _decode_scheduler([admission], _ReqPool())
     scheduler._aborted_request_ids = {"request-1"}
 
-    scheduler._drain_pd_admissions()
+    scheduler._drain_admissions()
 
     assert scheduler.waiting_queue == []
     assert freed == [admission.allocation.slots]
@@ -296,18 +299,18 @@ def test_decode_admission_retries_pool_exhaustion_without_releasing_kv() -> None
     pool = _CapacityReqPool(capacity=0)
     scheduler, freed = _decode_scheduler([admission], pool)
 
-    scheduler._drain_pd_admissions()
+    scheduler._drain_admissions()
 
-    assert scheduler._pd_deferred_admission is admission
+    assert scheduler._deferred_admission is admission
     assert scheduler.waiting_queue == []
     assert freed == []
     assert scheduler.outbox.empty()
 
     pool.capacity = 1
-    scheduler._drain_pd_admissions()
-    scheduler._drain_pd_admissions()
+    scheduler._drain_admissions()
+    scheduler._drain_admissions()
 
-    assert scheduler._pd_deferred_admission is None
+    assert scheduler._deferred_admission is None
     assert [req.rid for req in scheduler.waiting_queue] == ["request-1"]
     assert [list(req.output_ids) for req in scheduler.waiting_queue] == [[42]]
     assert freed == []
@@ -326,17 +329,17 @@ def test_decode_admission_preserves_fifo_across_capacity_waves() -> None:
     admitted = []
 
     for expected in ("request-1", "request-2", "request-3"):
-        scheduler._drain_pd_admissions()
+        scheduler._drain_admissions()
         admitted.append(scheduler.outbox.get_nowait().request_id)
         req = scheduler.waiting_queue.pop(0)
         assert req.rid == expected
         assert list(req.output_ids) == [42]
         pool.free(req)
 
-    scheduler._drain_pd_admissions()
+    scheduler._drain_admissions()
 
     assert admitted == ["request-1", "request-2", "request-3"]
-    assert scheduler._pd_deferred_admission is None
+    assert scheduler._deferred_admission is None
     assert scheduler.waiting_queue == []
     assert freed == []
     assert scheduler.outbox.empty()
@@ -355,10 +358,10 @@ def test_permanent_decode_reconstruction_error_is_not_retried(monkeypatch) -> No
     )
     scheduler, freed = _decode_scheduler([admission], _CapacityReqPool(capacity=1))
 
-    scheduler._drain_pd_admissions()
-    scheduler._drain_pd_admissions()
+    scheduler._drain_admissions()
+    scheduler._drain_admissions()
 
-    assert scheduler._pd_deferred_admission is None
+    assert scheduler._deferred_admission is None
     assert freed == [admission.allocation.slots]
     error = scheduler.outbox.get_nowait()
     assert error.type == "error"
@@ -370,13 +373,13 @@ def test_permanent_decode_reconstruction_error_is_not_retried(monkeypatch) -> No
 def test_abort_while_decode_admission_is_deferred_releases_once() -> None:
     admission = _decode_admission("request-1", 7)
     scheduler, freed = _decode_scheduler([admission], _CapacityReqPool(capacity=0))
-    scheduler._drain_pd_admissions()
+    scheduler._drain_admissions()
     scheduler._aborted_request_ids.add("request-1")
 
-    scheduler._drain_pd_admissions()
-    scheduler._drain_pd_admissions()
+    scheduler._drain_admissions()
+    scheduler._drain_admissions()
 
-    assert scheduler._pd_deferred_admission is None
+    assert scheduler._deferred_admission is None
     assert freed == [admission.allocation.slots]
     assert scheduler.waiting_queue == []
     assert scheduler.outbox.empty()
@@ -388,12 +391,12 @@ def test_discard_decode_admissions_releases_each_allocation_once() -> None:
         _decode_admission("request-2", 10),
     ]
     scheduler, freed = _decode_scheduler(admissions, _CapacityReqPool(capacity=0))
-    scheduler._drain_pd_admissions()
+    scheduler._drain_admissions()
 
-    scheduler._discard_pd_admissions()
-    scheduler._discard_pd_admissions()
+    scheduler._discard_admissions()
+    scheduler._discard_admissions()
 
-    assert scheduler._pd_deferred_admission is None
+    assert scheduler._deferred_admission is None
     assert freed == [
         admissions[0].allocation.slots,
         admissions[1].allocation.slots,
@@ -416,7 +419,7 @@ def test_metrics_reporter_handles_multiple_reconstructed_requests() -> None:
     reporter = object.__new__(SchedulerMetricsReporter)
     reporter.scheduler = scheduler
 
-    scheduler._drain_pd_admissions()
+    scheduler._drain_admissions()
     snapshots = [
         reporter._build_queued_request_metrics() for _ in scheduler.waiting_queue
     ]
@@ -437,22 +440,36 @@ def test_prefill_handoff_reuses_request_mapping_and_detaches_batch() -> None:
         (req.req_pool_idx, slice(0, 3)),
         torch.tensor([7, 8, 9], dtype=torch.int64),
     )
-    scheduler = object.__new__(OmniScheduler)
+    scheduler = object.__new__(OmniPrefillScheduler)
     scheduler.req_to_token_pool = pool
     scheduler.page_size = 1
-    scheduler._pd_pool_id = "prefill:kv"
-    scheduler._pd_partner = "decode"
+    scheduler._source_pool_id = "prefill:kv"
+    scheduler._partner_stage = "decode"
+    scheduler._pd_state_builder = None
     scheduler.tree_cache = object()
     scheduler.outbox = queue.Queue()
     batch = SimpleNamespace(reqs=[req])
 
-    scheduler._queue_pd_prefill_handoffs(batch, {id(req)})
+    scheduler._queue_prefill_handoffs(batch, {id(req)})
 
     assert batch.reqs == []
     handoff = scheduler.outbox.get_nowait()
     assert handoff.type == "pd_handoff"
     assert handoff.data.source_page_indices == (7, 8, 9)
     assert handoff.data.continuation.output_ids == [42]
+
+
+def test_prefill_terminal_first_token_does_not_create_handoff() -> None:
+    req = _prefill_req()
+    req.finished_reason = object()
+    scheduler = object.__new__(OmniPrefillScheduler)
+    scheduler.outbox = queue.Queue()
+    batch = SimpleNamespace(reqs=[req])
+
+    scheduler._queue_prefill_handoffs(batch, {id(req)})
+
+    assert batch.reqs == []
+    assert scheduler.outbox.empty()
 
 
 def test_prefill_middle_chunk_waits_for_sampled_token(monkeypatch) -> None:
@@ -465,12 +482,12 @@ def test_prefill_middle_chunk_waits_for_sampled_token(monkeypatch) -> None:
         (req.req_pool_idx, slice(0, 3)),
         torch.tensor([7, 8, 9], dtype=torch.int64),
     )
-    scheduler = object.__new__(OmniScheduler)
-    scheduler._pd_role = "prefill"
+    scheduler = object.__new__(OmniPrefillScheduler)
     scheduler.req_to_token_pool = pool
     scheduler.page_size = 1
-    scheduler._pd_pool_id = "prefill:kv"
-    scheduler._pd_partner = "decode"
+    scheduler._source_pool_id = "prefill:kv"
+    scheduler._partner_stage = "decode"
+    scheduler._pd_state_builder = None
     scheduler.tree_cache = object()
     scheduler.outbox = queue.Queue()
     batch = SimpleNamespace(
@@ -538,11 +555,10 @@ def test_decode_scheduler_delegates_prebuilt_admission(monkeypatch) -> None:
         "get_next_disagg_decode_batch_to_run",
         get_next,
     )
-    scheduler = object.__new__(OmniScheduler)
-    scheduler._pd_role = "decode"
-    scheduler._pd_ready_queue = queue.SimpleQueue()
-    scheduler._pd_deferred_admission = None
-    scheduler._pd_admission_lock = threading.Lock()
+    scheduler = object.__new__(OmniDecodeScheduler)
+    scheduler._ready_queue = queue.SimpleQueue()
+    scheduler._deferred_admission = None
+    scheduler._admission_lock = threading.Lock()
     scheduler.running_batch = object()
 
     assert scheduler.get_next_batch_to_run() is batch
@@ -562,11 +578,7 @@ def test_prefill_retries_admission_after_ack_returns_request_slot(monkeypatch) -
         "get_next_batch_to_run",
         get_next,
     )
-    scheduler = object.__new__(OmniScheduler)
-    scheduler._pd_role = "prefill"
-    scheduler._pd_ready_queue = queue.Queue()
-    scheduler._pd_deferred_admission = None
-    scheduler._pd_admission_lock = threading.Lock()
+    scheduler = object.__new__(OmniPrefillScheduler)
     scheduler.running_batch = running
     scheduler.last_batch = None
     scheduler.req_to_token_pool = SimpleNamespace(available_size=lambda: 1)

--- a/tests/unit_test/pipeline/test_pd_scheduler_construction.py
+++ b/tests/unit_test/pipeline/test_pd_scheduler_construction.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from sglang_omni.config.schema import PDExecution
+from sglang_omni.pipeline import stage_workers
+from sglang_omni.pipeline.stage_workers import StageLaunchConfig
+from sglang_omni.scheduling.omni_scheduler import (
+    OmniDecodeScheduler,
+    OmniPrefillScheduler,
+    OmniScheduler,
+)
+from sglang_omni.scheduling.pd_runtime import PDTransportBinding
+from tests.unit_test.fixtures.pipeline_fakes import fake_factory_path
+from tests.unit_test.pipeline.helpers import make_stage
+
+
+class _Log:
+    def info(self, *_args) -> None:
+        pass
+
+
+def _spec(role: str, *, factory: str | None = None, **factory_kwargs):
+    partner = "thinker_decode" if role == "prefill" else "thinker_prefill"
+    implementation = (
+        "sglang_omni.scheduling.omni_scheduler.OmniPrefillScheduler"
+        if role == "prefill"
+        else "sglang_omni.scheduling.omni_scheduler.OmniDecodeScheduler"
+    )
+    return StageLaunchConfig(
+        stage_name=f"thinker_{role}",
+        factory=factory or fake_factory_path("pd_capable_factory"),
+        factory_kwargs=factory_kwargs,
+        pd_execution=PDExecution(
+            role=role,
+            partner=partner,
+            scheduler_class=implementation,
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("role", "expected"),
+    [("prefill", OmniPrefillScheduler), ("decode", OmniDecodeScheduler)],
+)
+def test_factory_constructs_compiler_selected_concrete_scheduler(role, expected):
+    observed = []
+    scheduler = stage_workers._construct_scheduler(
+        _spec(role, post_setup=lambda value: observed.append(type(value))),
+        None,
+        _Log(),
+    )
+
+    assert type(scheduler) is expected
+    assert observed == [expected]
+    assert scheduler.scheduler_kwargs == {
+        "stage_name": f"thinker_{role}",
+        "partner": "thinker_decode" if role == "prefill" else "thinker_prefill",
+    }
+
+
+def test_non_pd_factory_constructs_plain_scheduler():
+    scheduler = stage_workers._construct_scheduler(
+        StageLaunchConfig(
+            stage_name="thinker",
+            factory=fake_factory_path("pd_capable_factory"),
+        ),
+        None,
+        _Log(),
+    )
+
+    assert type(scheduler) is OmniScheduler
+    assert scheduler.scheduler_kwargs == {}
+
+
+def test_factory_kwargs_survive_concrete_scheduler_selection():
+    callback = object()
+    scheduler = stage_workers._construct_scheduler(
+        _spec("prefill", callback=callback, typed="value"), None, _Log()
+    )
+
+    assert scheduler.factory_kwargs == {"callback": callback, "typed": "value"}
+
+
+def test_mismatched_factory_result_fails_during_construction():
+    with pytest.raises(TypeError, match="OmniPrefillScheduler"):
+        stage_workers._construct_scheduler(
+            _spec(
+                "prefill",
+                factory=fake_factory_path("mismatched_pd_scheduler_factory"),
+            ),
+            None,
+            _Log(),
+        )
+
+
+def test_mismatched_compiled_role_and_scheduler_class_fail_before_factory():
+    spec = _spec("prefill")
+    spec.pd_execution = PDExecution(
+        role="prefill",
+        partner="thinker_decode",
+        scheduler_class=("sglang_omni.scheduling.omni_scheduler.OmniDecodeScheduler"),
+    )
+
+    with pytest.raises(TypeError, match="role 'prefill' requires .*Prefill"):
+        stage_workers._construct_scheduler(spec, None, _Log())
+
+
+def test_scheduler_role_cannot_be_changed_after_construction():
+    scheduler = stage_workers._construct_scheduler(_spec("decode"), None, _Log())
+
+    assert type(scheduler) is OmniDecodeScheduler
+    assert not hasattr(scheduler, "bind_pd_runtime")
+    assert not hasattr(scheduler, "_pd_role")
+    assert not hasattr(scheduler, "pd_role")
+
+
+def test_pd_types_do_not_share_role_specific_state():
+    prefill = object.__new__(OmniPrefillScheduler)
+    decode = object.__new__(OmniDecodeScheduler)
+    generic = object.__new__(OmniScheduler)
+    prefill._transport_binding = SimpleNamespace(pool=object(), receiver=None)
+
+    assert not hasattr(prefill, "_ready_queue")
+    assert not hasattr(prefill, "_deferred_admission")
+    assert not hasattr(prefill, "_drain_admissions")
+    assert not hasattr(decode, "_source_pool_id")
+    assert not hasattr(decode, "_queue_prefill_handoffs")
+    assert not hasattr(generic, "_pd_role")
+    assert not hasattr(generic, "transport_binding")
+
+
+def test_stage_only_registers_typed_transport_binding():
+    pool = SimpleNamespace(pool_id="thinker_decode:kv")
+    receiver = object()
+    stage = make_stage(
+        name="thinker_decode",
+        pd_transport_binding=PDTransportBinding(pool=pool, receiver=receiver),
+    )
+
+    assert stage._comm._kv_pools == {pool.pool_id: pool}
+    assert stage._comm._kv_receivers == {pool.pool_id: receiver}
+    assert not hasattr(stage.scheduler, "bind_pd_runtime")
+
+
+def test_scheduler_has_final_type_before_stage_construction(monkeypatch):
+    observed = {}
+
+    class RecordingStage:
+        def __init__(self, **kwargs):
+            observed.update(kwargs)
+
+    monkeypatch.setattr(stage_workers, "Stage", RecordingStage)
+    monkeypatch.setattr(
+        stage_workers,
+        "StageControlPlane",
+        lambda **_kwargs: object(),
+    )
+
+    stage_workers._construct_stage(_spec("prefill"), _Log())
+
+    assert type(observed["scheduler"]) is OmniPrefillScheduler
+    assert observed["pd_transport_binding"].pool.pool_id == "thinker_prefill:kv"
+    assert "pd_execution" not in observed


### PR DESCRIPTION
Base PR: #1596
Frozen head SHA: a50876b1871a1a4ba79777e569e73d5d4fa153e5
Reviewer thread: https://github.com/sgl-project/sglang-omni/pull/1596#discussion_r3876081452

## Before

```text
factory
→ OmniScheduler
→ Stage
→ hasattr()/bind_pd_runtime(role)
→ mutate scheduling behavior
```

## After

```text
compiler/factory
→ OmniPrefillScheduler | OmniDecodeScheduler
→ fully initialized scheduler
→ Stage registers typed transport binding only
```

## Architecture

- Adds the explicit `OmniScheduler -> OmniPrefillScheduler | OmniDecodeScheduler` hierarchy.
- Keeps upstream scheduling/execution, request/result adapters, streaming, metrics, and common abort handling in `OmniScheduler`.
- Moves continuation production, source KV leases, first-token handoff, and ACK capacity recovery to `OmniPrefillScheduler`.
- Moves receiver/controller ownership, continuation+KV readiness, deferred admission, PREBUILT selection, and Decode cleanup to `OmniDecodeScheduler`.
- Extends compiler-generated `PDExecution` with the concrete scheduler class identity.
- Injects compiler-owned `scheduler_cls` and constructor kwargs through PD-capable model factories, then validates the returned concrete type before Stage construction. Engine-builder and Qwen/Ming thinker seams preserve adapters, runners, callbacks, stream handlers, typed kwargs, and post-setup ordering.
- Adds frozen `PDTransportBinding`; Stage only registers its pool/receiver with `CommEngine`.

## Removed late binding

- Removes `OmniScheduler.bind_pd_runtime()`.
- Removes `_pd_role` and all generic role-dependent scheduling/result/abort branches.
- Removes Stage `hasattr()` capability discovery and role mutation.
- Does not retain a compatibility path for the old architecture.

## Preserved behavior

The concrete schedulers still delegate batching to SGLang upstream (`get_next_batch_to_run` for Prefill/non-PD and `get_next_disagg_decode_batch_to_run` for Decode). Existing assertions remain for real-first-token handoff, terminal-first-token completion, ACK/source lease lifetime, out-of-order continuation/KV readiness, reconstructed Decode admission without re-Prefill, committed-KV ownership across deferred admission, idempotent drains, PREBUILT admission, metrics, abort/shutdown cleanup, and non-PD scheduling.

## Test evidence

- Targeted PD/compiler/factory/scheduler/streaming matrix: `194 passed`
- Full `tests/unit_test/pipeline`: `555 passed`
- Full `tests/unit_test/scheduling`: `216 passed`
- Stage + Qwen/Ming factory regressions: `179 passed`
- Changed-file `pre-commit`: passed
- `git diff --check`: passed

## Remaining limitations

This preserves PR #1596's existing generic PD runtime constraints (TP=1, page size 1, RadixCache disabled). No GPU integration or benchmark was run; the refactor and listed tests are CPU-only, so end-to-end multi-process GPU transport remains integration-environment coverage.
