### PR TITLE
fix(pd): serialize KV allocation between the Decode half's two threads

### DIFF
--- a/sglang_omni/comm/__init__.py
+++ b/sglang_omni/comm/__init__.py
@@ -15,6 +15,7 @@ from sglang_omni.comm.kv_transfer import (
     KVBufferRegion,
     KVPageDestination,
     KVPageLease,
+    KVPageTransfer,
     KVPool,
     KVReceiver,
 )
@@ -26,6 +27,7 @@ __all__ = [
     "KVBufferRegion",
     "KVPageDestination",
     "KVPageLease",
+    "KVPageTransfer",
     "KVPool",
     "KVReceiver",
     "CommRouter",

--- a/sglang_omni/comm/kv_transfer.py
+++ b/sglang_omni/comm/kv_transfer.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Protocol
+from typing import Any, Protocol
 
 import torch
 
@@ -36,8 +36,7 @@ class KVBufferRegion:
             byte_view = self.tensor.view(torch.uint8).view(-1)
         except RuntimeError as error:
             raise ValueError(
-                f"KV buffer {self.name!r} must expose a flattenable aliasing "
-                "byte view"
+                f"KV buffer {self.name!r} must expose a flattenable aliasing byte view"
             ) from error
         object.__setattr__(self, "_byte_view", byte_view)
 
@@ -128,3 +127,17 @@ class KVPageLease(Protocol):
     """Pins source pages until the receiver acknowledges the transfer."""
 
     def release(self) -> None: ...
+
+
+@dataclass(frozen=True)
+class KVPageTransfer:
+    """One scheduler-requested page transfer handled by its owning stage."""
+
+    request_id: str
+    transfer_id: str
+    source_pool_id: str
+    target_pool_id: str
+    source_page_indices: tuple[int, ...]
+    to_stage: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+    lease: KVPageLease | None = None

--- a/sglang_omni/config/__init__.py
+++ b/sglang_omni/config/__init__.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from sglang_omni.config.pd_capability import pd_disaggregation_capable
+from sglang_omni.config.pd_rewrite import PDExpansion, expand_pd_stages
 from sglang_omni.config.placement import (
     GpuPlacement,
     StagePlacement,
@@ -16,6 +18,9 @@ from sglang_omni.config.schema import (
     EngineArgs,
     EngineStageConfig,
     FactoryArgs,
+    PDConfig,
+    PDExecution,
+    PDStagePlacement,
     PipelineConfig,
     PlacementConfig,
     ProcessConfig,
@@ -52,6 +57,12 @@ __all__ = [
     "compile_logical_processes",
     "PipelineConfig",
     "ProcessConfig",
+    "PDConfig",
+    "PDExecution",
+    "PDStagePlacement",
+    "PDExpansion",
+    "expand_pd_stages",
+    "pd_disaggregation_capable",
     "StageConfig",
     "EngineStageConfig",
     "EngineArgs",

--- a/sglang_omni/config/pd_capability.py
+++ b/sglang_omni/config/pd_capability.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Explicit factory opt-in for compiler-owned PD scheduler construction."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+from sglang_omni.config.schema import StageConfig
+from sglang_omni.utils.imports import import_string
+
+_PD_CAPABLE = "__sglang_pd_disaggregation_capable__"
+
+
+def pd_disaggregation_capable(factory: Callable[..., Any]) -> Callable[..., Any]:
+    setattr(factory, _PD_CAPABLE, True)
+    return factory
+
+
+def validate_pd_capabilities(stages: Iterable[StageConfig]) -> None:
+    for stage in stages:
+        if stage.pd_execution is None:
+            continue
+        factory = import_string(stage.factory_path)
+        if not getattr(factory, _PD_CAPABLE, False):
+            raise ValueError(
+                f"Stage {stage.name!r} is PD-disaggregated, but factory "
+                f"{stage.factory_path!r} has not declared PD support"
+            )

--- a/sglang_omni/config/pd_rewrite.py
+++ b/sglang_omni/config/pd_rewrite.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compile logical Prefill/Decode stages into physical scheduler stages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sglang_omni.config.schema import PDExecution, StageConfig
+
+
+@dataclass(frozen=True)
+class PDExpansion:
+    stages: list[StageConfig]
+    entry_stage: str
+    routing_map: dict[str, str]
+    output_map: dict[str, str]
+
+
+def expand_pd_stages(stages: list[StageConfig], *, entry_stage: str) -> PDExpansion:
+    pd_names = {stage.name for stage in stages if stage.pd_disaggregation is not None}
+    if not pd_names:
+        routing_map, output_map = _compiled_pd_maps(stages)
+        return PDExpansion(
+            list(stages),
+            routing_map.get(entry_stage, entry_stage),
+            routing_map,
+            output_map,
+        )
+
+    inbound = {name: f"{name}_prefill" for name in pd_names}
+    output = {name: f"{name}_decode" for name in pd_names}
+    physical: list[StageConfig] = []
+    for stage in stages:
+        if stage.pd_disaggregation is None:
+            physical.append(_rewrite_refs(stage, inbound, output))
+            continue
+        physical.extend(_split(stage, inbound, output))
+    return PDExpansion(
+        physical,
+        inbound.get(entry_stage, entry_stage),
+        inbound,
+        output,
+    )
+
+
+def _compiled_pd_maps(
+    stages: list[StageConfig],
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Recover compiler maps when an already-expanded graph is compiled again."""
+
+    routing: dict[str, str] = {}
+    output: dict[str, str] = {}
+    for stage in stages:
+        execution = stage.pd_execution
+        suffix = f"_{execution.role}" if execution is not None else ""
+        if execution is None or not stage.name.endswith(suffix):
+            continue
+        logical_name = stage.name[: -len(suffix)]
+        (routing if execution.role == "prefill" else output)[logical_name] = stage.name
+    return routing, output
+
+
+def _rename(value: str | list[str] | None, names: dict[str, str]):
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return names.get(value, value)
+    return [names.get(item, item) for item in value]
+
+
+def _rewrite_refs(
+    stage: StageConfig,
+    inbound: dict[str, str],
+    output: dict[str, str],
+) -> StageConfig:
+    return stage.model_copy(
+        deep=True,
+        update={
+            "next": _rename(stage.next, inbound),
+            "stream_to": [inbound.get(name, name) for name in stage.stream_to],
+            "wait_for": (
+                [output.get(name, name) for name in stage.wait_for]
+                if stage.wait_for
+                else stage.wait_for
+            ),
+            "project_payload": {
+                inbound.get(name, name): path
+                for name, path in stage.project_payload.items()
+            },
+        },
+    )
+
+
+def _split(
+    stage: StageConfig,
+    inbound: dict[str, str],
+    output: dict[str, str],
+) -> tuple[StageConfig, StageConfig]:
+    pd = stage.pd_disaggregation
+    assert pd is not None
+    prefill_name = f"{stage.name}_prefill"
+    decode_name = f"{stage.name}_decode"
+    prefill = stage.model_copy(
+        deep=True,
+        update={
+            "name": prefill_name,
+            "gpu": pd.prefill.gpu,
+            "process": pd.prefill.process or prefill_name,
+            "next": None,
+            "terminal": False,
+            "route_fn": None,
+            "stream_to": [],
+            "stream_done_to_fn": None,
+            "project_payload": {},
+            "wait_for": (
+                [output.get(name, name) for name in stage.wait_for]
+                if stage.wait_for
+                else stage.wait_for
+            ),
+            "pd_disaggregation": None,
+            "pd_execution": PDExecution(role="prefill", partner=decode_name),
+        },
+    )
+    decode = stage.model_copy(
+        deep=True,
+        update={
+            "name": decode_name,
+            "gpu": pd.decode.gpu,
+            "process": pd.decode.process or decode_name,
+            "next": _rename(stage.next, inbound),
+            "stream_to": [inbound.get(name, name) for name in stage.stream_to],
+            "project_payload": {
+                inbound.get(name, name): path
+                for name, path in stage.project_payload.items()
+            },
+            "wait_for": None,
+            "wait_for_fn": None,
+            "merge_fn": None,
+            "pd_disaggregation": None,
+            "pd_execution": PDExecution(role="decode", partner=prefill_name),
+        },
+    )
+    return prefill, decode

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -215,6 +215,46 @@ class ProcessConfig(BaseModel):
             raise ValueError("processes.num_replicas must be >= 1")
 
 
+class PDStagePlacement(BaseModel):
+    """Placement for one physical half of a disaggregated AR stage."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    gpu: int | list[int] | None = None
+    process: str | None = None
+
+    def model_post_init(self, __context: Any = None) -> None:
+        if self.process is not None:
+            self.process = self.process.strip()
+            if not self.process:
+                raise ValueError("PD process must not be empty")
+        if self.gpu is None:
+            return
+        gpu_ids = [self.gpu] if isinstance(self.gpu, int) else self.gpu
+        if not gpu_ids or any(gpu_id < 0 for gpu_id in gpu_ids):
+            raise ValueError("PD GPU ids must be non-empty and >= 0")
+        if len(set(gpu_ids)) != len(gpu_ids):
+            raise ValueError("PD GPU ids must be unique")
+
+
+class PDConfig(BaseModel):
+    """Compile one logical AR stage into independently placed PD halves."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    prefill: PDStagePlacement = Field(default_factory=PDStagePlacement)
+    decode: PDStagePlacement = Field(default_factory=PDStagePlacement)
+
+
+class PDExecution(BaseModel):
+    """Compiler-owned identity for one physical PD scheduler."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    role: Literal["prefill", "decode"]
+    partner: str = Field(min_length=1)
+
+
 class StageConfig(BaseModel):
     """Single pipeline stage configuration.
 
@@ -300,6 +340,9 @@ class StageConfig(BaseModel):
 
     # --- Communication pool tuning ---
     comm: CommConfig | None = None
+
+    pd_disaggregation: PDConfig | None = None
+    pd_execution: PDExecution | None = None
 
     def model_post_init(self, __context: Any = None) -> None:
         if isinstance(self.gpu, int) and self.tp_size > 1:
@@ -500,6 +543,7 @@ class PipelineConfig(BaseModel):
     def model_post_init(self, __context: Any = None) -> None:
         self._validate_general()
         self._validate_processes()
+        self._validate_pd()
         self.config_cls = self.__class__.__name__
         if self.name is None:
             self.name = self.model_path
@@ -728,6 +772,43 @@ class PipelineConfig(BaseModel):
                 f"Declared process names: {sorted(members)}"
             )
 
+    def _validate_pd(self) -> None:
+        existing_names = {stage.name for stage in self.stages}
+        for stage in self.stages:
+            pd = stage.pd_disaggregation
+            if pd is None:
+                continue
+            if pd.prefill.gpu is None or pd.decode.gpu is None:
+                raise ValueError(
+                    f"Stage {stage.name!r} pd_disaggregation requires explicit "
+                    "prefill.gpu and decode.gpu"
+                )
+            if _pd_gpu_set(pd.prefill.gpu) & _pd_gpu_set(pd.decode.gpu):
+                raise ValueError(
+                    f"Stage {stage.name!r} pd_disaggregation prefill and decode "
+                    "cannot share the same GPU"
+                )
+            for role, placement in (("prefill", pd.prefill), ("decode", pd.decode)):
+                if (
+                    isinstance(placement.gpu, list)
+                    and len(placement.gpu) != stage.tp_size
+                ):
+                    raise ValueError(
+                        f"Stage {stage.name!r} pd_disaggregation {role}.gpu has "
+                        f"{len(placement.gpu)} entries but tp_size={stage.tp_size}"
+                    )
+            for suffix in ("_prefill", "_decode"):
+                generated = f"{stage.name}{suffix}"
+                if generated in existing_names:
+                    raise ValueError(
+                        f"Stage {stage.name!r} pd_disaggregation would generate "
+                        f"{generated!r}, which collides with an existing stage"
+                    )
+
     @staticmethod
     def from_dict(data: dict[str, Any]) -> PipelineConfig:
         return PipelineConfig(**data)
+
+
+def _pd_gpu_set(gpu: int | list[int]) -> set[int]:
+    return {gpu} if isinstance(gpu, int) else set(gpu)

--- a/sglang_omni/models/ming_omni/bootstrap.py
+++ b/sglang_omni/models/ming_omni/bootstrap.py
@@ -11,6 +11,7 @@ from sglang_omni.vendor.sglang.server_args import override_server_args
 logger = logging.getLogger(__name__)
 
 StreamOutputBuilder = Callable[[str, Any, Any], list[Any]]
+MING_THINKER_PD_RESUME_SCHEMA = "ming-omni-thinker-v1"
 
 
 def create_thinker_scheduler(
@@ -22,6 +23,8 @@ def create_thinker_scheduler(
     tp_size: int = 1,
     nccl_port: int | None = None,
     enable_streaming_tts: bool = False,
+    scheduler_cls: type | None = None,
+    scheduler_kwargs: dict[str, Any] | None = None,
 ):
     if tp_size < 1:
         raise ValueError(f"tp_size must be >= 1, got {tp_size}")
@@ -92,8 +95,22 @@ def create_thinker_scheduler(
         tokenizer=tokenizer,
         eos_token_id=getattr(tokenizer, "eos_token_id", None),
     )
+    scheduler_cls = scheduler_cls or OmniScheduler
+    construction_kwargs = dict(scheduler_kwargs or {})
+    if scheduler_cls is not OmniScheduler:
+        from sglang_omni.scheduling.pd_scheduler import model_pd_scheduler_kwargs
 
-    return OmniScheduler(
+        state_builder, state_restorer = make_thinker_pd_adapters(tokenizer=tokenizer)
+        construction_kwargs.update(
+            model_pd_scheduler_kwargs(
+                scheduler_cls,
+                state_builder=state_builder,
+                state_restorer=state_restorer,
+                resume_schema=MING_THINKER_PD_RESUME_SCHEMA,
+            )
+        )
+
+    return scheduler_cls(
         tp_worker=model_worker,
         tree_cache=tree_cache,
         req_to_token_pool=req_to_token_pool,
@@ -104,7 +121,46 @@ def create_thinker_scheduler(
         request_builder=request_builder,
         result_adapter=result_adapter,
         stream_output_builder=stream_output_builder,
+        **construction_kwargs,
     )
+
+
+def make_thinker_pd_adapters(*, tokenizer: Any):
+    """Project Ming Prefill state and restore its Decode-only request fields."""
+
+    def state_builder(req: Any):
+        from sglang_omni.models.ming_omni.io import MingOmniPipelineState
+        from sglang_omni.proto import OmniRequest, StagePayload
+
+        payload = req._omni_data.stage_payload
+        state = MingOmniPipelineState.from_dict(payload.data)
+        input_ids = list(req.origin_input_ids)
+        projected = MingOmniPipelineState(
+            prompt={"input_ids": input_ids},
+            stream_state=dict(state.stream_state),
+        )
+        projected_payload = StagePayload(
+            request_id=payload.request_id,
+            request=OmniRequest(
+                inputs=None,
+                params=dict(payload.request.params),
+                metadata=dict(payload.request.metadata),
+            ),
+            data=projected.to_dict(),
+        )
+        resume = {"schema": MING_THINKER_PD_RESUME_SCHEMA}
+        return projected_payload.to_dict(), resume, input_ids
+
+    def state_restorer(req: Any, data: Any, resume: dict[str, Any] | None) -> None:
+        del data
+        if resume != {"schema": MING_THINKER_PD_RESUME_SCHEMA}:
+            raise ValueError(f"unsupported Ming thinker PD resume {resume!r}")
+        req.tokenizer = tokenizer
+        req.omni_model_inputs = None
+        req._omni_consumed = None
+        req._codec_suppress_tokens = None
+
+    return state_builder, state_restorer
 
 
 def make_thinker_scheduler_adapters(

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from sglang_omni.config.pd_capability import pd_disaggregation_capable
 from sglang_omni.models.ming_omni.io import MingOmniPipelineState
 from sglang_omni.models.ming_omni.pipeline.next_stage import AUDIO_STAGE, IMAGE_STAGE
 from sglang_omni.models.ming_omni.tp_utils import validate_stage_tp_support
@@ -281,6 +282,7 @@ def create_image_encoder_executor(
     return SimpleScheduler(_encode)
 
 
+@pd_disaggregation_capable
 def create_sglang_thinker_executor_from_config(
     model_path: str,
     *,
@@ -291,6 +293,8 @@ def create_sglang_thinker_executor_from_config(
     thinker_max_seq_len: int = 8192,
     server_args_overrides: dict[str, Any] | None = None,
     enable_streaming_tts: bool = False,
+    scheduler_cls: type | None = None,
+    scheduler_kwargs: dict[str, Any] | None = None,
 ):
     validate_stage_tp_support(stage_name="thinker", tp_size=tp_size)
 
@@ -317,6 +321,8 @@ def create_sglang_thinker_executor_from_config(
         tp_size=tp_size,
         nccl_port=nccl_port,
         enable_streaming_tts=enable_streaming_tts,
+        scheduler_cls=scheduler_cls,
+        scheduler_kwargs=scheduler_kwargs,
     )
 
 

--- a/sglang_omni/models/qwen3_omni/bootstrap.py
+++ b/sglang_omni/models/qwen3_omni/bootstrap.py
@@ -19,12 +19,16 @@ def create_thinker_scheduler(
     prefill_coalesce_requests: int = 0,
     prefill_coalesce_wait_ms: float = 60.0,
     prefill_coalesce_when_idle: bool = False,
+    scheduler_cls: type | None = None,
+    scheduler_kwargs: dict[str, Any] | None = None,
 ):
     """Create the Qwen thinker scheduler."""
     from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 
     from sglang_omni.model_runner.thinker_model_runner import ThinkerModelRunner
     from sglang_omni.models.qwen3_omni.request_builders import (
+        QWEN_THINKER_PD_RESUME_SCHEMA,
+        make_thinker_pd_adapters,
         make_thinker_scheduler_adapters,
         make_thinker_stream_output_builder,
         should_generate_audio_output,
@@ -108,8 +112,22 @@ def create_thinker_scheduler(
         thinker_config=thinker_config,
     )
     stream_output_builder = make_thinker_stream_output_builder()
+    scheduler_cls = scheduler_cls or OmniScheduler
+    construction_kwargs = dict(scheduler_kwargs or {})
+    if scheduler_cls is not OmniScheduler:
+        from sglang_omni.scheduling.pd_scheduler import model_pd_scheduler_kwargs
 
-    return OmniScheduler(
+        state_builder, state_restorer = make_thinker_pd_adapters(tokenizer=tokenizer)
+        construction_kwargs.update(
+            model_pd_scheduler_kwargs(
+                scheduler_cls,
+                state_builder=state_builder,
+                state_restorer=state_restorer,
+                resume_schema=QWEN_THINKER_PD_RESUME_SCHEMA,
+            )
+        )
+
+    return scheduler_cls(
         tp_worker=model_worker,
         tree_cache=tree_cache,
         req_to_token_pool=req_to_token_pool,
@@ -125,6 +143,7 @@ def create_thinker_scheduler(
         prefill_coalesce_requests=prefill_coalesce_requests,
         prefill_coalesce_wait_ms=prefill_coalesce_wait_ms,
         prefill_coalesce_when_idle=prefill_coalesce_when_idle,
+        **construction_kwargs,
     )
 
 

--- a/sglang_omni/models/qwen3_omni/request_builders.py
+++ b/sglang_omni/models/qwen3_omni/request_builders.py
@@ -34,6 +34,7 @@ DECODE_STAGE = "decode"
 TALKER_STAGE = "talker_ar"
 CODE2WAV_STAGE = "code2wav"
 MM_AGGREGATE_STAGE = "mm_aggregate"
+QWEN_THINKER_PD_RESUME_SCHEMA = "qwen3-omni-thinker-v1"
 
 # Note(Chenchen Hong): PyTorch sampling_seed must fit a positive int32.
 MAX_INT32_POSITIVE = 0x7FFFFFFF
@@ -1023,6 +1024,68 @@ def make_thinker_scheduler_adapters(
         )
 
     return request_builder, result_adapter
+
+
+def make_thinker_pd_adapters(*, tokenizer: Any):
+    """Project and restore the model state needed after a thinker Prefill."""
+
+    def state_builder(req: Any):
+        data = req._omni_data
+        payload = data.stage_payload
+        state = Qwen3OmniPipelineState.from_dict(payload.data)
+        prompt_ids = state.prompt["input_ids"]
+        if hasattr(prompt_ids, "tolist"):
+            prompt_ids = prompt_ids.tolist()
+        prompt_ids = list(prompt_ids)
+        projected = Qwen3OmniPipelineState(
+            prompt={"input_ids": prompt_ids},
+            stream_state=dict(state.stream_state),
+        )
+        projected_payload = StagePayload(
+            request_id=payload.request_id,
+            request=OmniRequest(
+                inputs=None,
+                params=dict(payload.request.params),
+                metadata=dict(payload.request.metadata),
+            ),
+            data=projected.to_dict(),
+        )
+        mm_inputs = req.multimodal_inputs
+        delta = (
+            None
+            if mm_inputs is None
+            else getattr(mm_inputs, "mrope_position_delta", None)
+        )
+        resume = None
+        if delta is not None:
+            resume = {
+                "schema": QWEN_THINKER_PD_RESUME_SCHEMA,
+                "mrope_position_delta": delta.tolist(),
+            }
+        return projected_payload.to_dict(), resume, prompt_ids
+
+    def state_restorer(req: Any, data: Any, resume: dict[str, Any] | None) -> None:
+        del data
+        req.tokenizer = tokenizer
+        req.omni_model_inputs = None
+        req._omni_consumed = None
+        req._omni_mm_positions = None
+        if resume is None:
+            return
+        if set(resume) != {"schema", "mrope_position_delta"}:
+            raise ValueError("invalid Qwen thinker PD resume fields")
+        if resume["schema"] != QWEN_THINKER_PD_RESUME_SCHEMA:
+            raise ValueError(f"unsupported Qwen thinker PD resume {resume['schema']!r}")
+        from sglang.srt.managers.schedule_batch import MultimodalInputs
+
+        delta = torch.tensor(resume["mrope_position_delta"], dtype=torch.long)
+        if delta.shape != (1, 1):
+            raise ValueError("Qwen thinker PD mRoPE delta must have shape (1, 1)")
+        mm_inputs = MultimodalInputs(mm_items=[])
+        mm_inputs.mrope_position_delta = delta
+        req.multimodal_inputs = mm_inputs
+
+    return state_builder, state_restorer
 
 
 def make_talker_scheduler_adapters(

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -16,6 +16,7 @@ from typing import Any
 import torch
 import torch.nn.functional as F
 
+from sglang_omni.config.pd_capability import pd_disaggregation_capable
 from sglang_omni.models.qwen3_omni.bootstrap import create_thinker_scheduler
 from sglang_omni.models.qwen3_omni.components.audio_encoder import Qwen3OmniAudioEncoder
 from sglang_omni.models.qwen3_omni.components.image_encoder import Qwen3OmniImageEncoder
@@ -995,6 +996,7 @@ def create_decode_executor(model_path: str):
 # ---------------------------------------------------------------------------
 
 
+@pd_disaggregation_capable
 def create_sglang_thinker_executor_from_config(
     model_path: str,
     *,
@@ -1012,6 +1014,8 @@ def create_sglang_thinker_executor_from_config(
     prefill_coalesce_requests: int = 0,
     prefill_coalesce_wait_ms: float = 60.0,
     prefill_coalesce_when_idle: bool = False,
+    scheduler_cls: type | None = None,
+    scheduler_kwargs: dict[str, Any] | None = None,
 ):
     """Returns OmniScheduler for thinker."""
     # note (luojiaxuan):
@@ -1103,6 +1107,8 @@ def create_sglang_thinker_executor_from_config(
         prefill_coalesce_requests=prefill_coalesce_requests,
         prefill_coalesce_wait_ms=prefill_coalesce_wait_ms,
         prefill_coalesce_when_idle=prefill_coalesce_when_idle,
+        scheduler_cls=scheduler_cls,
+        scheduler_kwargs=scheduler_kwargs,
     )
     post_load_process_mem = get_process_gpu_memory_bytes(gpu_id)
     logger.info(

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -48,6 +48,7 @@ def resolve_coordinator_max_in_flight(
     config: PipelineConfig,
     *,
     logical_process_plan: LogicalProcessPlan,
+    stage_name_map: dict[str, str] | None = None,
 ) -> int | None:
     """Return total generation running+queued capacity across replicas."""
     config_cls = type(config)
@@ -72,7 +73,8 @@ def resolve_coordinator_max_in_flight(
         return None
     if running < 1 or queued < 0:
         return None
-    num_replicas = logical_process_plan.process_of(stage.name).num_replicas
+    runtime_name = (stage_name_map or {}).get(stage.name, stage.name)
+    num_replicas = logical_process_plan.process_of(runtime_name).num_replicas
     return (running + queued) * num_replicas
 
 
@@ -84,6 +86,8 @@ def _build_stage_groups(
     endpoints: dict[str, str],
     placement_plan: StagePlacementPlan,
     process_plan: ProcessTopologyPlan,
+    name_map: dict[str, str] | None = None,
+    source_name_map: dict[str, str] | None = None,
     replica_topology: ReplicaTopology | None = None,
 ) -> list[StageGroup]:
     """Build lifecycle groups from prepared endpoints and process topology.
@@ -95,6 +99,8 @@ def _build_stage_groups(
         ctx = multiprocessing.get_context("spawn")
     if replica_topology is None:
         replica_topology = ReplicaTopology()
+    name_map = name_map or {}
+    source_name_map = source_name_map or {}
 
     stage_endpoints = {s.name: endpoints[f"stage_{s.name}"] for s in stages_cfg}
     rank_endpoints = {
@@ -137,7 +143,18 @@ def _build_stage_groups(
         # overlays the typed group kwargs against the factory signature and
         # injects signature-dependent args after importing the factory it
         # must construct anyway.
-        base_factory_kwargs = resolve_stage_factory_kwargs(stage_cfg, config)
+        factory_config_stage = stage_cfg
+        if stage_cfg.pd_execution is not None:
+            suffix = f"_{stage_cfg.pd_execution.role}"
+            if not stage_cfg.name.endswith(suffix):
+                raise ValueError(
+                    f"PD stage {stage_cfg.name!r} does not match role "
+                    f"{stage_cfg.pd_execution.role!r}"
+                )
+            factory_config_stage = stage_cfg.model_copy(
+                update={"name": stage_cfg.name[: -len(suffix)]}
+            )
+        base_factory_kwargs = resolve_stage_factory_kwargs(factory_config_stage, config)
         typed_kwargs = resolve_stage_typed_kwargs(stage_cfg)
 
         stage_kwargs = dict(
@@ -169,6 +186,9 @@ def _build_stage_groups(
             can_accept_stream_before_payload=stage_cfg.can_accept_stream_before_payload,
             disable_direct_cuda_ipc_payload=stage_cfg.disable_direct_cuda_ipc_payload,
             replica_topology=replica_topology.to_dict(),
+            name_map=name_map,
+            source_name_map=source_name_map,
+            pd_execution=stage_cfg.pd_execution,
         )
         if tp_size == 1:
             single_stage_specs[stage_cfg.name] = _build_single_stage_spec(
@@ -484,23 +504,31 @@ class MultiProcessPipelineRunner:
                 endpoints=prep.endpoints,
                 placement_plan=prep.placement_plan,
                 process_plan=prep.process_plan,
+                name_map=prep.name_map,
+                source_name_map=prep.source_name_map,
                 replica_topology=prep.replica_topology,
             )
 
-            terminal_stages_resolver = (
-                import_string(self._config.terminal_stages_fn)
-                if self._config.terminal_stages_fn
-                else None
-            )
+            terminal_stages_resolver = None
+            if self._config.terminal_stages_fn:
+                logical_terminal_resolver = import_string(
+                    self._config.terminal_stages_fn
+                )
+
+                def terminal_stages_resolver(request):
+                    resolved = logical_terminal_resolver(request)
+                    return [prep.terminal_name_map.get(name, name) for name in resolved]
+
             max_in_flight = resolve_coordinator_max_in_flight(
                 self._config,
                 logical_process_plan=prep.logical_process_plan,
+                stage_name_map=prep.name_map,
             )
             self._coordinator = Coordinator(
                 completion_endpoint=prep.endpoints["completion"],
                 abort_endpoint=prep.endpoints["abort"],
                 entry_stage=prep.entry_stage,
-                terminal_stages=self._config.terminal_stages or None,
+                terminal_stages=prep.terminal_stages or None,
                 terminal_stages_resolver=terminal_stages_resolver,
                 replica_topology=prep.replica_topology,
                 logical_process_plan=prep.logical_process_plan,

--- a/sglang_omni/pipeline/runtime_config.py
+++ b/sglang_omni/pipeline/runtime_config.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import zmq
 
+from sglang_omni.config.pd_capability import validate_pd_capabilities
+from sglang_omni.config.pd_rewrite import expand_pd_stages
 from sglang_omni.config.placement import StagePlacementPlan, build_stage_placement_plan
 from sglang_omni.config.schema import PipelineConfig, StageConfig
 from sglang_omni.config.topology import (
@@ -78,6 +80,8 @@ class PipelineRuntimePrep:
     """Prepared stage, endpoint, placement, and topology state."""
 
     stages_cfg: list[StageConfig]
+    name_map: dict[str, str]
+    source_name_map: dict[str, str]
     entry_stage: str
     endpoints: dict[str, str]
     placement_plan: StagePlacementPlan
@@ -86,6 +90,8 @@ class PipelineRuntimePrep:
     runtime_dir_created_here: bool
     replica_topology: ReplicaTopology
     logical_process_plan: LogicalProcessPlan
+    terminal_stages: list[str]
+    terminal_name_map: dict[str, str]
 
 
 def create_ipc_runtime_dir(
@@ -117,11 +123,22 @@ def prepare_pipeline_runtime(
     *,
     ipc_runtime_dir: IpcRuntimeDir | None = None,
 ) -> PipelineRuntimePrep:
-    """Compile the process topology, expand replicas, and allocate endpoints."""
-    logical_plan, stages_cfg = compile_logical_processes(config)
+    """Compile PD/process topology, expand replicas, and allocate endpoints."""
+    source_stages = [stage.model_copy(deep=True) for stage in config.stages]
     entry_stage = config.resolved_entry_stage
+    expansion = expand_pd_stages(source_stages, entry_stage=entry_stage)
+    entry_stage = expansion.entry_stage
+    validate_pd_capabilities(expansion.stages)
+    terminal_stages = [stage.name for stage in expansion.stages if stage.terminal]
+    expanded_config = config.model_copy(
+        update={"stages": expansion.stages, "entry_stage": entry_stage}
+    )
+    logical_plan, stages_cfg = compile_logical_processes(expanded_config)
     stages_cfg, replica_topology = expand_replica_stages(stages_cfg, logical_plan)
     validate_device_assignment(stages_cfg, device_count=_visible_device_count())
+    identity = {stage.name: stage.name for stage in source_stages}
+    name_map = _compose_name_map(identity, expansion.routing_map, stages_cfg)
+    source_name_map = _compose_name_map(identity, expansion.output_map, stages_cfg)
     runtime_dir = ipc_runtime_dir
     if runtime_dir is None:
         runtime_dir = create_ipc_runtime_dir(config, stages=stages_cfg)
@@ -151,6 +168,8 @@ def prepare_pipeline_runtime(
 
     return PipelineRuntimePrep(
         stages_cfg=stages_cfg,
+        name_map=name_map,
+        source_name_map=source_name_map,
         entry_stage=entry_stage,
         endpoints=endpoints,
         placement_plan=placement_plan,
@@ -159,7 +178,20 @@ def prepare_pipeline_runtime(
         runtime_dir_created_here=runtime_dir_created_here,
         replica_topology=replica_topology,
         logical_process_plan=logical_plan,
+        terminal_stages=terminal_stages,
+        terminal_name_map=expansion.output_map,
     )
+
+
+def _compose_name_map(
+    base: dict[str, str],
+    pd_map: dict[str, str],
+    stages: list[StageConfig],
+) -> dict[str, str]:
+    result = {raw: pd_map.get(name, name) for raw, name in base.items()}
+    for stage in stages:
+        result.setdefault(stage.name, stage.name)
+    return result
 
 
 def build_comm_config(

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -24,6 +24,7 @@ import torch
 from sglang_omni.comm import stage_io
 from sglang_omni.comm.data_ref import DataKind, DataRef
 from sglang_omni.comm.engine import CommEngine
+from sglang_omni.comm.kv_transfer import KVPageTransfer
 from sglang_omni.comm.router import CommRouter
 from sglang_omni.pipeline.replicas import ReplicaTopology
 from sglang_omni.pipeline.stage.input import DirectInput, InputHandler
@@ -150,6 +151,10 @@ class Stage:
             rank_endpoints=rank_endpoints,
             task_done_callback=self._on_background_task_done,
         )
+        for pool, receiver in getattr(scheduler, "kv_registrations", ()):
+            self._comm.register_kv_pool(pool)
+            if receiver is not None:
+                self._comm.register_kv_receiver(pool.pool_id, receiver)
 
         self._running = False
         self._aborted: set[str] = set()
@@ -1104,7 +1109,15 @@ class Stage:
                 continue
 
             for batch_index in range(_OUTBOX_DRAIN_BATCH_SIZE):
-                if out.request_id in self._active_requests:
+                if out.type == "admitted":
+                    if out.request_id not in self._aborted:
+                        self._active_requests.add(out.request_id)
+                elif out.type == "kv_transfer":
+                    if out.request_id in self._active_requests:
+                        await self._send_kv_transfer(out.data)
+                    else:
+                        self._discard_kv_transfer(out.data)
+                elif out.request_id in self._active_requests:
                     if out.type == "result":
                         await self._route_result(out.request_id, out.data)
                     elif out.type == "stream":
@@ -1161,10 +1174,48 @@ class Stage:
                 self._clear_request_state(out.request_id)
             elif out.type == "stream":
                 continue
+            elif out.type == "admitted":
+                self._active_requests.add(out.request_id)
+            elif out.type == "kv_transfer":
+                raise RuntimeError(
+                    f"TP follower stage {self.name} cannot publish a KV transfer"
+                )
             elif out.type == "error":
                 raise RuntimeError(
                     f"TP follower stage {self.name} received scheduler error: {out.data}"
                 )
+
+    async def _send_kv_transfer(self, transfer: KVPageTransfer) -> None:
+        if not isinstance(transfer, KVPageTransfer):
+            raise TypeError(
+                "kv_transfer outbox messages require KVPageTransfer data, got "
+                f"{type(transfer).__name__}"
+            )
+        try:
+            await self._comm.send_kv_pages(
+                request_id=transfer.request_id,
+                source_pool_id=transfer.source_pool_id,
+                source_page_indices=transfer.source_page_indices,
+                target_pool_id=transfer.target_pool_id,
+                to_stage=transfer.to_stage,
+                metadata=transfer.metadata,
+                transfer_id=transfer.transfer_id,
+                lease=transfer.lease,
+            )
+        except Exception as exc:
+            logger.exception(
+                "Stage %s KV transfer failed for %s",
+                self.name,
+                transfer.request_id,
+            )
+            await self._send_failure(transfer.request_id, _error_text(exc))
+            return
+        self._clear_request_state(transfer.request_id)
+
+    @staticmethod
+    def _discard_kv_transfer(transfer: Any) -> None:
+        if isinstance(transfer, KVPageTransfer) and transfer.lease is not None:
+            transfer.lease.release()
 
     async def _route_result(self, request_id: str, result: Any) -> None:
         """Route a completed result to next stage(s) or complete at coordinator."""

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -112,6 +112,7 @@ class Stage:
         tp_fanout: TPLeaderFanout | None = None,
         is_terminal: bool = False,
         replica_topology: dict[str, list[str]] | None = None,
+        kv_registrations: tuple[tuple[Any, Any | None], ...] = (),
     ):
         self.name = name
         self.role = role
@@ -151,7 +152,7 @@ class Stage:
             rank_endpoints=rank_endpoints,
             task_done_callback=self._on_background_task_done,
         )
-        for pool, receiver in getattr(scheduler, "kv_registrations", ()):
+        for pool, receiver in kv_registrations:
             self._comm.register_kv_pool(pool)
             if receiver is not None:
                 self._comm.register_kv_receiver(pool.pool_id, receiver)
@@ -1114,7 +1115,7 @@ class Stage:
                         self._active_requests.add(out.request_id)
                 elif out.type == "kv_transfer":
                     if out.request_id in self._active_requests:
-                        await self._send_kv_transfer(out.data)
+                        self._launch_kv_transfer(out.data)
                     else:
                         self._discard_kv_transfer(out.data)
                 elif out.request_id in self._active_requests:
@@ -1185,6 +1186,16 @@ class Stage:
                     f"TP follower stage {self.name} received scheduler error: {out.data}"
                 )
 
+    def _launch_kv_transfer(self, transfer: KVPageTransfer) -> None:
+        task = asyncio.create_task(self._send_kv_transfer(transfer))
+        self._receive_tasks.add(task)
+        task.add_done_callback(self._receive_tasks.discard)
+        task.add_done_callback(
+            lambda done: self._on_background_task_done(
+                done, f"KV transfer {transfer.request_id}"
+            )
+        )
+
     async def _send_kv_transfer(self, transfer: KVPageTransfer) -> None:
         if not isinstance(transfer, KVPageTransfer):
             raise TypeError(
@@ -1210,7 +1221,8 @@ class Stage:
             )
             await self._send_failure(transfer.request_id, _error_text(exc))
             return
-        self._clear_request_state(transfer.request_id)
+        finally:
+            self._clear_request_state(transfer.request_id)
 
     @staticmethod
     def _discard_kv_transfer(transfer: Any) -> None:

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -19,6 +19,7 @@ from sglang_omni.config.runtime import (
     apply_typed_stage_kwargs,
     resolve_factory_signature_args,
 )
+from sglang_omni.config.schema import PDExecution
 from sglang_omni.pipeline.control_plane import StageControlPlane
 from sglang_omni.pipeline.local_dispatch import LocalStageDispatcher
 from sglang_omni.pipeline.stage.input import AggregatedInput, DirectInput
@@ -107,6 +108,9 @@ class StageLaunchConfig:
 
     # Replica topology (logical stage name -> instance names)
     replica_topology: dict[str, list[str]] = field(default_factory=dict)
+    name_map: dict[str, str] = field(default_factory=dict)
+    source_name_map: dict[str, str] = field(default_factory=dict)
+    pd_execution: PDExecution | None = None
 
     # TP internal control (leader -> followers)
     follower_work_queues: list[Any] = field(default_factory=list)
@@ -600,6 +604,7 @@ def _construct_stage(
     )
 
     scheduler = _construct_scheduler(spec, gpu_id, log)
+    kv_registrations = scheduler.kv_registrations
 
     def _target_list(targets: str | list[str] | None) -> list[str]:
         if targets is None:
@@ -617,9 +622,16 @@ def _construct_stage(
         if sources is None:
             return None
         if isinstance(sources, str):
-            return [sources]
+            return [spec.source_name_map.get(sources, sources)]
         if isinstance(sources, Iterable):
-            return list(sources)
+            return [
+                (
+                    spec.source_name_map.get(source, source)
+                    if isinstance(source, str)
+                    else source
+                )
+                for source in sources
+            ]
         raise ValueError(
             f"wait_for_fn for stage {spec.stage_name!r} returned unsupported "
             f"source value {sources!r}"
@@ -632,7 +644,9 @@ def _construct_stage(
         allow_empty: bool,
         hook_name: str,
     ) -> str | list[str] | None:
-        returned_targets = _target_list(targets)
+        returned_targets = [
+            spec.name_map.get(target, target) for target in _target_list(targets)
+        ]
         if not returned_targets:
             if allow_empty:
                 return None
@@ -654,7 +668,10 @@ def _construct_stage(
         get_next = lambda request_id, output: None
     elif spec.route_fn:
         route_fn = import_string(spec.route_fn)
-        allowed_route_targets = set(_target_list(spec.next_stages))
+        allowed_route_targets = {
+            spec.name_map.get(target, target)
+            for target in _target_list(spec.next_stages)
+        }
 
         def get_next(request_id, output, _fn=route_fn):
             return _target_result(
@@ -667,15 +684,19 @@ def _construct_stage(
     else:
         target = spec.next_stages
         if isinstance(target, str):
-            get_next = lambda request_id, output, _t=target: _t
+            mapped = spec.name_map.get(target, target)
+            get_next = lambda request_id, output, _t=mapped: _t
         elif isinstance(target, list):
-            get_next = lambda request_id, output, _t=list(target): _t
+            mapped = [spec.name_map.get(item, item) for item in target]
+            get_next = lambda request_id, output, _t=mapped: _t
         else:
             get_next = lambda request_id, output: None
 
     if spec.stream_done_to_fn:
         stream_done_to_fn = import_string(spec.stream_done_to_fn)
-        allowed_stream_targets = set(spec.stream_targets)
+        allowed_stream_targets = {
+            spec.name_map.get(target, target) for target in spec.stream_targets
+        }
         get_stream_done_targets = (
             lambda request_id, output, _fn=stream_done_to_fn: _target_result(
                 _fn(request_id, output),
@@ -690,7 +711,7 @@ def _construct_stage(
     # --- Build input handler ---
     if spec.wait_for and spec.merge_fn:
         merge_fn = import_string(spec.merge_fn)
-        sources = set(spec.wait_for)
+        sources = {spec.source_name_map.get(source, source) for source in spec.wait_for}
         expected_sources_fn = None
         if spec.wait_for_fn:
             wait_for_fn = import_string(spec.wait_for_fn)
@@ -764,6 +785,7 @@ def _construct_stage(
         tp_fanout=tp_fanout,
         is_terminal=spec.is_terminal,
         replica_topology=spec.replica_topology or None,
+        kv_registrations=kv_registrations,
     )
 
     if spec.is_stream_receiver:
@@ -793,12 +815,53 @@ def _construct_scheduler(
         require_gpu_id=spec.require_factory_gpu_id,
         stage_name=spec.stage_name,
     )
+
+    expected_scheduler_cls = None
+    if spec.pd_execution is not None:
+        import inspect
+
+        from sglang_omni.scheduling.pd_scheduler import scheduler_class_for_role
+
+        expected_scheduler_cls = scheduler_class_for_role(spec.pd_execution.role)
+        parameters = inspect.signature(factory).parameters
+        accepts_kwargs = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters.values()
+        )
+        missing = {
+            name
+            for name in ("scheduler_cls", "scheduler_kwargs")
+            if name not in parameters and not accepts_kwargs
+        }
+        if missing:
+            raise TypeError(
+                f"PD factory {spec.factory!r} for {spec.stage_name!r} must accept "
+                f"compiler arguments {sorted(missing)}"
+            )
+        factory_args["scheduler_cls"] = expected_scheduler_cls
+        factory_args["scheduler_kwargs"] = {
+            "stage_name": spec.stage_name,
+            "partner_stage": spec.pd_execution.partner,
+        }
+
+    def construct() -> Any:
+        scheduler = factory(**factory_args)
+        if expected_scheduler_cls is not None and not isinstance(
+            scheduler, expected_scheduler_cls
+        ):
+            raise TypeError(
+                f"PD stage {spec.stage_name!r} factory returned "
+                f"{type(scheduler).__name__}; expected "
+                f"{expected_scheduler_cls.__name__}"
+            )
+        return scheduler
+
     if gpu_id is None:
-        return factory(**factory_args)
+        return construct()
 
     with gpu_startup_lock(int(gpu_id)) as lock_path:
         log.info(f"Acquired GPU startup lock for stage {spec.stage_name}: {lock_path}")
-        return factory(**factory_args)
+        return construct()
 
 
 def _prepare_accelerator_environment(

--- a/sglang_omni/proto/kv_transfer.py
+++ b/sglang_omni/proto/kv_transfer.py
@@ -54,7 +54,11 @@ class KVTransferPrepareMessage:
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        return {"type": "kv_transfer_prepare", **msgspec.to_builtins(self)}
+        value = msgspec.to_builtins(self)
+        # Metadata is intentionally opaque. In particular, continuation bytes
+        # must not be converted to a JSON-style list of integers.
+        value["metadata"] = self.metadata
+        return {"type": "kv_transfer_prepare", **value}
 
     @classmethod
     def from_dict(cls, value: dict[str, Any]) -> "KVTransferPrepareMessage":

--- a/sglang_omni/scheduling/engine_factory.py
+++ b/sglang_omni/scheduling/engine_factory.py
@@ -51,6 +51,8 @@ class SGLangGenerationEngineBuilder(ABC):
         gpu_id: int | None = None,
         dtype: str = "bfloat16",
         server_args_overrides: dict[str, Any] | None = None,
+        scheduler_cls: type | None = None,
+        scheduler_kwargs: dict[str, Any] | None = None,
     ) -> Any:
         import torch
 
@@ -172,6 +174,12 @@ class SGLangGenerationEngineBuilder(ABC):
                 model=model,
             )
             self.setup_runtime_resources(model, server_args)
+            scheduler_construction = {}
+            if scheduler_cls is not None or scheduler_kwargs is not None:
+                scheduler_construction = {
+                    "scheduler_cls": scheduler_cls,
+                    "scheduler_construction_kwargs": scheduler_kwargs,
+                }
             scheduler, model_runner = self._build_runtime(
                 model_worker=model_worker,
                 model=model,
@@ -181,6 +189,7 @@ class SGLangGenerationEngineBuilder(ABC):
                 token_to_kv_pool_allocator=token_to_kv_pool_allocator,
                 server_args=server_args,
                 model_config=model_config,
+                **scheduler_construction,
             )
             self.post_scheduler_setup(scheduler, model_runner)
             return scheduler
@@ -271,9 +280,11 @@ class SGLangGenerationEngineBuilder(ABC):
         token_to_kv_pool_allocator: Any,
         server_args: Any,
         model_config: Any,
+        scheduler_cls: type | None = None,
+        scheduler_construction_kwargs: dict[str, Any] | None = None,
     ) -> tuple[Any, Any]:
         request_builder, result_adapter = self.make_adapters(model)
-        scheduler_kwargs = self.extra_scheduler_kwargs()
+        extra_scheduler_kwargs = self.extra_scheduler_kwargs()
         model_runner = self.make_model_runner(model_worker, output_proc)
         scheduler = self._make_scheduler(
             model_worker=model_worker,
@@ -285,7 +296,9 @@ class SGLangGenerationEngineBuilder(ABC):
             model_runner=model_runner,
             request_builder=request_builder,
             result_adapter=result_adapter,
-            extra_scheduler_kwargs=scheduler_kwargs,
+            extra_scheduler_kwargs=extra_scheduler_kwargs,
+            scheduler_cls=scheduler_cls,
+            scheduler_construction_kwargs=scheduler_construction_kwargs,
         )
         return scheduler, model_runner
 
@@ -317,6 +330,8 @@ class SGLangGenerationEngineBuilder(ABC):
         request_builder: Any,
         result_adapter: Any,
         extra_scheduler_kwargs: dict[str, Any],
+        scheduler_cls: type | None = None,
+        scheduler_construction_kwargs: dict[str, Any] | None = None,
     ) -> Any:
         from sglang_omni.scheduling import omni_scheduler
 
@@ -335,7 +350,9 @@ class SGLangGenerationEngineBuilder(ABC):
         }
         scheduler_kwargs.update(self.extra_scheduler_callbacks())
         scheduler_kwargs.update(extra_scheduler_kwargs)
-        return omni_scheduler.OmniScheduler(**scheduler_kwargs)
+        scheduler_cls = scheduler_cls or omni_scheduler.OmniScheduler
+        scheduler_kwargs.update(scheduler_construction_kwargs or {})
+        return scheduler_cls(**scheduler_kwargs)
 
     def post_scheduler_setup(self, scheduler: Any, model_runner: Any) -> None:
         del scheduler, model_runner

--- a/sglang_omni/scheduling/messages.py
+++ b/sglang_omni/scheduling/messages.py
@@ -17,7 +17,7 @@ class IncomingMessage:
 @dataclass
 class OutgoingMessage:
     request_id: str
-    type: Literal["result", "stream", "error"]
+    type: Literal["result", "stream", "error", "kv_transfer", "admitted"]
     data: Any = None
     target: str | None = None
     metadata: dict[str, Any] | None = None

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -200,6 +200,7 @@ class OmniScheduler:
         self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
         self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
         self.requires_tp_work_fanout: bool = False
+        self.kv_registrations = ()
 
         # --- Request builder: StagePayload → SGLangARRequestData ----------
         self._request_builder = request_builder
@@ -449,9 +450,7 @@ class OmniScheduler:
         self.abort_on_priority_when_disabled = False
 
         # Disaggregation / hybrid (disabled)
-        from sglang.srt.disaggregation.utils import DisaggregationMode
-
-        self.disaggregation_mode = DisaggregationMode.NULL
+        self.disaggregation_mode = self._initial_disaggregation_mode()
         self.is_hybrid_swa = False
         self.is_hybrid_ssm = False
         self.offload_tags: set = set()
@@ -498,6 +497,11 @@ class OmniScheduler:
         self._first_emit_done: set[str] = set()
         self._prefill_start_done: set[str] = set()
         self._prefill_end_done: set[str] = set()
+
+    def _initial_disaggregation_mode(self):
+        from sglang.srt.disaggregation.utils import DisaggregationMode
+
+        return DisaggregationMode.NULL
 
     def bind_model_runner(self, model_runner: Any) -> None:
         """Attach a custom runner and its SGLang execution-contract bridge.
@@ -663,8 +667,8 @@ class OmniScheduler:
         )
         self.output_streamer = types.SimpleNamespace(
             stream_output=self.stream_output,
-            _stream_output_generation=lambda reqs, return_logprob, **_kwargs: self.stream_output(
-                reqs, return_logprob
+            _stream_output_generation=lambda reqs, return_logprob, **_kwargs: (
+                self.stream_output(reqs, return_logprob)
             ),
         )
         self.batch_result_processor = SchedulerBatchResultProcessor(
@@ -2418,8 +2422,7 @@ class OmniScheduler:
             prefill_input_ids_cpu = batch.prefill_input_ids_cpu
             if input_ids is None and prefill_input_ids_cpu is None:
                 raise RuntimeError(
-                    "extend batch carries neither input_ids nor "
-                    "prefill_input_ids_cpu"
+                    "extend batch carries neither input_ids nor prefill_input_ids_cpu"
                 )
             prefix_lens = batch.prefix_lens
             extend_logprob_start_lens = batch.extend_logprob_start_lens

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -1783,6 +1783,11 @@ class OmniScheduler:
             waiting_queue = []
             for req in self.waiting_queue:
                 if req.rid == request_id:
+                    if (
+                        getattr(req, "req_pool_idx", None) is not None
+                        or getattr(req, "mamba_pool_idx", None) is not None
+                    ):
+                        self._release_request_kv_cache(req)
                     _detach_request_data(req)
                 else:
                     waiting_queue.append(req)

--- a/sglang_omni/scheduling/pd_alloc_lock.py
+++ b/sglang_omni/scheduling/pd_alloc_lock.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Serialize KV allocation between the two threads a Decode half runs.
+
+``TokenToKVPoolAllocator.alloc`` reads ``free_pages``, slices the leading
+entries, and writes the remainder back. Nothing in
+``sglang/srt/mem_cache/allocator`` holds a lock, which is correct while one
+thread owns the allocator.
+
+A PD Decode half has two. The scheduler thread allocates for decode steps.
+The comm event loop allocates inside ``prepare_kv_receive`` ->
+``DecodeKVReceiver.reserve``, which is handed the same allocator instance.
+Two callers that interleave between the read and the write receive the same
+slots.
+
+Measured on two H200s with both calls recorded: one 3,000-request run logged
+21,309 slots handed to one thread while the other still held them, and the
+requests that received them returned empty completions.
+
+This wraps the allocator so both callers take one lock. Everything else is
+delegated untouched, so the allocator's own behaviour is unchanged.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+
+class LockedKVAllocator:
+    """Delegate to *inner*, holding a lock across ``alloc`` and ``free``.
+
+    Only the two methods that mutate the free list are guarded. The lock is
+    uncontended on the scheduler thread except when a transfer is reserving,
+    so the cost on the decode path is one uncontended acquire per step.
+    """
+
+    def __init__(self, inner: Any) -> None:
+        # Note (Audrey Zheng): set through __dict__ because __setattr__ below
+        # forwards to the wrapped allocator.
+        self.__dict__["_inner"] = inner
+        self.__dict__["_alloc_lock"] = threading.Lock()
+
+    def alloc(self, need_size: int) -> Any:
+        with self.__dict__["_alloc_lock"]:
+            return self.__dict__["_inner"].alloc(need_size)
+
+    def free(self, free_index: Any) -> Any:
+        with self.__dict__["_alloc_lock"]:
+            return self.__dict__["_inner"].free(free_index)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.__dict__["_inner"], name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        setattr(self.__dict__["_inner"], name, value)
+
+    def __repr__(self) -> str:
+        return f"LockedKVAllocator({self.__dict__['_inner']!r})"

--- a/sglang_omni/scheduling/pd_scheduler.py
+++ b/sglang_omni/scheduling/pd_scheduler.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scheduler roles for explicit Prefill/Decode pipeline stages."""
+
+from __future__ import annotations
+
+import queue
+import threading
+import types
+from typing import Callable
+from uuid import uuid4
+
+from sglang.srt.managers.schedule_batch import FINISH_ABORT, ScheduleBatch
+from sglang.srt.managers.scheduler import Scheduler as _Upstream
+
+from sglang_omni.comm import KVPageTransfer
+from sglang_omni.scheduling.messages import OutgoingMessage
+from sglang_omni.scheduling.omni_scheduler import OmniScheduler, _detach_request_data
+from sglang_omni.scheduling.pd_utils import (
+    DecodeKVReceiver,
+    DecodeRequestPoolExhausted,
+    SGLangKVLease,
+    build_kv_pool,
+    continuation_from_req,
+    defer_first_token_finish,
+    req_from_continuation,
+    request_page_indices,
+)
+
+
+class OmniPrefillScheduler(OmniScheduler):
+    """Omni scheduler whose generated requests stop after Prefill."""
+
+    scheduler_role = "prefill"
+
+    def __init__(
+        self,
+        *args,
+        stage_name: str,
+        partner_stage: str,
+        state_builder: Callable,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        _validate_pd_runtime(self)
+
+        self._pd_stage_name = stage_name
+        self._pd_partner_stage = partner_stage
+        self._pd_state_builder = state_builder
+        self._pd_pool_id = f"{stage_name}:kv"
+        pool = build_kv_pool(
+            self.token_to_kv_pool_allocator.get_kvcache(),
+            pool_id=self._pd_pool_id,
+        )
+        self.kv_registrations = ((pool, None),)
+
+    def get_next_batch_to_run(self):
+        if (
+            self.running_batch.is_empty()
+            and self.running_batch.batch_is_full
+            and self.req_to_token_pool.available_size() > 0
+        ):
+            self.running_batch.batch_is_full = False
+        return super().get_next_batch_to_run()
+
+    def process_batch_result(self, batch, result):
+        if not batch.forward_mode.is_extend():
+            return _Upstream.process_batch_result(self, batch, result)
+
+        output_lengths = {id(req): len(req.output_ids) for req in batch.reqs}
+        # The Prefill process owns the first sample but never terminalizes it.
+        # Decode's existing PREBUILT result path applies the real stop policy.
+        with defer_first_token_finish(batch.reqs):
+            _Upstream.process_batch_result(self, batch, result)
+        sampled = {
+            id(req)
+            for req in batch.reqs
+            if len(req.output_ids) > output_lengths[id(req)]
+        }
+        self._handoff_prefilled_requests(batch, sampled)
+
+    def stream_output(self, reqs, return_logprob=False, skip_req=None):
+        # A Prefill result must never become a normal StagePayload edge. Normal
+        # stop conditions are deferred; anything else is a failed handoff.
+        for req in reqs:
+            if (
+                req is skip_req
+                or not req.finished()
+                or isinstance(req.finished_reason, FINISH_ABORT)
+            ):
+                continue
+            error = RuntimeError(
+                f"Prefill request {req.rid!r} terminated before KV handoff"
+            )
+            self._emit_request_error(req.rid, error)
+            req.finished_reason = FINISH_ABORT(str(error))
+        return super().stream_output(reqs, return_logprob, skip_req)
+
+    def _handoff_prefilled_requests(
+        self,
+        batch: ScheduleBatch,
+        sampled: set[int],
+    ) -> None:
+        retained = []
+        for req in batch.reqs:
+            if id(req) not in sampled or req.inflight_middle_chunks > 0:
+                retained.append(req)
+                continue
+            if req.finished():
+                # Abort and invalid-token failures still terminalize locally.
+                continue
+            try:
+                transfer_id = f"{req.rid}:pd:{uuid4().hex}"
+                continuation = continuation_from_req(
+                    req, transfer_id, self._pd_state_builder
+                )
+                transfer = KVPageTransfer(
+                    request_id=req.rid,
+                    transfer_id=transfer_id,
+                    source_pool_id=self._pd_pool_id,
+                    target_pool_id=f"{self._pd_partner_stage}:kv",
+                    source_page_indices=request_page_indices(
+                        self.req_to_token_pool, req
+                    ),
+                    to_stage=self._pd_partner_stage,
+                    metadata={"decode_continuation": continuation.encode()},
+                    lease=SGLangKVLease(req, self.tree_cache),
+                )
+            except Exception as exc:
+                self._release_request_kv_cache(req)
+                _detach_request_data(req)
+                self._emit_request_error(req.rid, exc)
+                continue
+            _detach_request_data(req)
+            self.outbox.put(
+                OutgoingMessage(
+                    request_id=req.rid,
+                    type="kv_transfer",
+                    data=transfer,
+                )
+            )
+        batch.reqs = retained
+        if not retained:
+            batch.batch_is_full = False
+
+
+class OmniDecodeScheduler(OmniScheduler):
+    """Omni scheduler that admits transferred Prefill state for Decode."""
+
+    scheduler_role = "decode"
+
+    def __init__(
+        self,
+        *args,
+        stage_name: str,
+        state_restorer: Callable,
+        resume_schema: str,
+        **kwargs,
+    ) -> None:
+        self._pd_admissions = queue.SimpleQueue()
+        self._pd_deferred_admission = None
+        self._pd_admission_lock = threading.Lock()
+        self._pd_state_restorer = state_restorer
+        super().__init__(*args, **kwargs)
+        _validate_pd_runtime(self)
+
+        pool_id = f"{stage_name}:kv"
+        pool = build_kv_pool(
+            self.token_to_kv_pool_allocator.get_kvcache(),
+            pool_id=pool_id,
+        )
+        receiver = DecodeKVReceiver(
+            pool_id=pool_id,
+            allocator=self.token_to_kv_pool_allocator,
+            admissions=self._pd_admissions,
+            resume_schema=resume_schema,
+        )
+        self.kv_registrations = ((pool, receiver),)
+        self.disagg_decode_prealloc_queue = types.SimpleNamespace(
+            queue=[], retracted_queue=[], num_tokens_pre_allocated=0
+        )
+        self.disagg_decode_transfer_queue = types.SimpleNamespace(queue=[])
+
+    def _initial_disaggregation_mode(self):
+        from sglang.srt.disaggregation.utils import DisaggregationMode
+
+        return DisaggregationMode.DECODE
+
+    def get_next_batch_to_run(self):
+        self._drain_decode_admissions()
+        plan = _Upstream.get_next_disagg_decode_batch_to_run(self, self.running_batch)
+        self.running_batch = plan.running_batch
+        return plan.batch_to_run
+
+    def process_input_requests(self, recv_reqs):
+        for payload in recv_reqs:
+            self._emit_request_error(
+                payload.request_id,
+                TypeError("Decode stages accept committed KV transfers only"),
+            )
+            self.abort(payload.request_id)
+
+    def _drain_decode_admissions(self) -> None:
+        with self._pd_admission_lock:
+            while True:
+                admission = self._pd_deferred_admission
+                if admission is None:
+                    try:
+                        admission = self._pd_admissions.get_nowait()
+                    except queue.Empty:
+                        return
+                request_id = admission.continuation.request_id
+                if request_id in self._aborted_request_ids:
+                    self._pd_deferred_admission = None
+                    self.token_to_kv_pool_allocator.free(admission.allocation.slots)
+                    continue
+                try:
+                    req = req_from_continuation(
+                        admission.continuation,
+                        admission.allocation,
+                        req_to_token_pool=self.req_to_token_pool,
+                        state_restorer=self._pd_state_restorer,
+                    )
+                except DecodeRequestPoolExhausted:
+                    self._pd_deferred_admission = admission
+                    return
+                except Exception as exc:
+                    self._pd_deferred_admission = None
+                    self.token_to_kv_pool_allocator.free(admission.allocation.slots)
+                    self.outbox.put(
+                        OutgoingMessage(request_id=request_id, type="admitted")
+                    )
+                    self._emit_request_error(request_id, exc)
+                    continue
+                self._pd_deferred_admission = None
+                self.waiting_queue.append(req)
+                self.outbox.put(OutgoingMessage(request_id=request_id, type="admitted"))
+
+    def _discard_pending_request_admissions(self) -> None:
+        super()._discard_pending_request_admissions()
+        with self._pd_admission_lock:
+            admission = self._pd_deferred_admission
+            self._pd_deferred_admission = None
+            if admission is not None:
+                self.token_to_kv_pool_allocator.free(admission.allocation.slots)
+            while True:
+                try:
+                    admission = self._pd_admissions.get_nowait()
+                except queue.Empty:
+                    return
+                self.token_to_kv_pool_allocator.free(admission.allocation.slots)
+
+    def abort(self, request_id: str, *, defer_running_cleanup: bool = True) -> None:
+        with self._pd_admission_lock:
+            for req in self.waiting_queue:
+                if req.rid == request_id:
+                    self._release_request_kv_cache(req)
+                    break
+            super().abort(
+                request_id,
+                defer_running_cleanup=defer_running_cleanup,
+            )
+
+
+def _validate_pd_runtime(scheduler: OmniScheduler) -> None:
+    if scheduler.tp_size != 1:
+        raise NotImplementedError("PD currently requires tp_size == 1")
+    if scheduler.page_size != 1:
+        raise NotImplementedError("PD currently requires page_size == 1")
+    if not scheduler.server_args.disable_radix_cache:
+        raise NotImplementedError("PD currently requires RadixCache disabled")

--- a/sglang_omni/scheduling/pd_scheduler.py
+++ b/sglang_omni/scheduling/pd_scheduler.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import queue
 import threading
 import types
-from typing import Callable
+from typing import Any, Callable, Literal
 from uuid import uuid4
 
 from sglang.srt.managers.schedule_batch import FINISH_ABORT, ScheduleBatch
@@ -21,23 +21,53 @@ from sglang_omni.scheduling.pd_utils import (
     SGLangKVLease,
     build_kv_pool,
     continuation_from_req,
+    default_state_builder,
+    default_state_restorer,
     defer_first_token_finish,
     req_from_continuation,
     request_page_indices,
 )
 
 
+def scheduler_class_for_role(role: Literal["prefill", "decode"]) -> type[OmniScheduler]:
+    """The single compiler role-to-concrete-scheduler mapping."""
+
+    return {
+        "prefill": OmniPrefillScheduler,
+        "decode": OmniDecodeScheduler,
+    }[role]
+
+
+def model_pd_scheduler_kwargs(
+    scheduler_cls: type,
+    *,
+    state_builder: Callable,
+    state_restorer: Callable,
+    resume_schema: str,
+) -> dict[str, Any]:
+    """Select the model seam required by one concrete PD scheduler."""
+
+    if scheduler_cls is OmniPrefillScheduler:
+        return {"state_builder": state_builder}
+    if scheduler_cls is OmniDecodeScheduler:
+        return {
+            "state_restorer": state_restorer,
+            "allowed_resume_schemas": frozenset({resume_schema}),
+        }
+    if scheduler_cls is OmniScheduler:
+        return {}
+    raise TypeError(f"unsupported scheduler class {scheduler_cls!r}")
+
+
 class OmniPrefillScheduler(OmniScheduler):
     """Omni scheduler whose generated requests stop after Prefill."""
-
-    scheduler_role = "prefill"
 
     def __init__(
         self,
         *args,
         stage_name: str,
         partner_stage: str,
-        state_builder: Callable,
+        state_builder: Callable = default_state_builder,
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
@@ -146,16 +176,16 @@ class OmniPrefillScheduler(OmniScheduler):
 class OmniDecodeScheduler(OmniScheduler):
     """Omni scheduler that admits transferred Prefill state for Decode."""
 
-    scheduler_role = "decode"
-
     def __init__(
         self,
         *args,
         stage_name: str,
-        state_restorer: Callable,
-        resume_schema: str,
+        state_restorer: Callable = default_state_restorer,
+        allowed_resume_schemas: frozenset[str] = frozenset(),
+        partner_stage: str | None = None,
         **kwargs,
     ) -> None:
+        del partner_stage
         self._pd_admissions = queue.SimpleQueue()
         self._pd_deferred_admission = None
         self._pd_admission_lock = threading.Lock()
@@ -172,8 +202,9 @@ class OmniDecodeScheduler(OmniScheduler):
             pool_id=pool_id,
             allocator=self.token_to_kv_pool_allocator,
             admissions=self._pd_admissions,
-            resume_schema=resume_schema,
+            allowed_resume_schemas=allowed_resume_schemas,
         )
+        self._pd_receiver = receiver
         self.kv_registrations = ((pool, receiver),)
         self.disagg_decode_prealloc_queue = types.SimpleNamespace(
             queue=[], retracted_queue=[], num_tokens_pre_allocated=0
@@ -237,6 +268,7 @@ class OmniDecodeScheduler(OmniScheduler):
 
     def _discard_pending_request_admissions(self) -> None:
         super()._discard_pending_request_admissions()
+        self._pd_receiver.close()
         with self._pd_admission_lock:
             admission = self._pd_deferred_admission
             self._pd_deferred_admission = None
@@ -249,17 +281,6 @@ class OmniDecodeScheduler(OmniScheduler):
                     return
                 self.token_to_kv_pool_allocator.free(admission.allocation.slots)
 
-    def abort(self, request_id: str, *, defer_running_cleanup: bool = True) -> None:
-        with self._pd_admission_lock:
-            for req in self.waiting_queue:
-                if req.rid == request_id:
-                    self._release_request_kv_cache(req)
-                    break
-            super().abort(
-                request_id,
-                defer_running_cleanup=defer_running_cleanup,
-            )
-
 
 def _validate_pd_runtime(scheduler: OmniScheduler) -> None:
     if scheduler.tp_size != 1:
@@ -268,3 +289,5 @@ def _validate_pd_runtime(scheduler: OmniScheduler) -> None:
         raise NotImplementedError("PD currently requires page_size == 1")
     if not scheduler.server_args.disable_radix_cache:
         raise NotImplementedError("PD currently requires RadixCache disabled")
+    if not scheduler.spec_algorithm.is_none():
+        raise NotImplementedError("PD does not support speculative decoding")

--- a/sglang_omni/scheduling/pd_scheduler.py
+++ b/sglang_omni/scheduling/pd_scheduler.py
@@ -15,6 +15,7 @@ from sglang.srt.managers.scheduler import Scheduler as _Upstream
 from sglang_omni.comm import KVPageTransfer
 from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler, _detach_request_data
+from sglang_omni.scheduling.pd_alloc_lock import LockedKVAllocator
 from sglang_omni.scheduling.pd_utils import (
     DecodeKVReceiver,
     DecodeRequestPoolExhausted,
@@ -193,6 +194,8 @@ class OmniDecodeScheduler(OmniScheduler):
         super().__init__(*args, **kwargs)
         _validate_pd_runtime(self)
 
+        _serialize_kv_allocation(self)
+
         pool_id = f"{stage_name}:kv"
         pool = build_kv_pool(
             self.token_to_kv_pool_allocator.get_kvcache(),
@@ -280,6 +283,61 @@ class OmniDecodeScheduler(OmniScheduler):
                 except queue.Empty:
                     return
                 self.token_to_kv_pool_allocator.free(admission.allocation.slots)
+
+
+# Note (Audrey Zheng): every object that allocates or frees from one KV pool.
+# `bootstrap.py` hands the same allocator to `create_tree_cache` before this
+# scheduler exists, so rebinding only our own attribute would leave the tree
+# cache calling an unwrapped alias.
+_KV_ALLOCATOR_HOLDERS = ("tree_cache",)
+
+
+def _serialize_kv_allocation(scheduler: OmniDecodeScheduler) -> None:
+    """Give every holder of the KV allocator the same locked object.
+
+    A Decode half allocates from two threads: this scheduler for decode steps
+    and the comm event loop through `DecodeKVReceiver.reserve`. Upstream's
+    `alloc` reads `free_pages`, slices it and writes the remainder back with no
+    lock, which is correct while one thread owns the allocator and hands the
+    same slots to both callers when two do.
+
+    One lock only helps if every caller goes through it, so the wrapper has to
+    reach the tree cache as well as this scheduler.
+
+    Wrapping here rather than in `bootstrap.py` is deliberate: upstream's
+    `SWAChunkCache.__init__` asserts the allocator's concrete type, and a proxy
+    handed to that constructor would fail the assert for models that use it.
+    Wrapping at construction rather than after it means no request has been
+    served through an unwrapped alias.
+    """
+    locked = LockedKVAllocator(scheduler.token_to_kv_pool_allocator)
+    scheduler.token_to_kv_pool_allocator = locked
+    for name in _KV_ALLOCATOR_HOLDERS:
+        holder = getattr(scheduler, name, None)
+        if holder is None:
+            continue
+        if not hasattr(holder, "token_to_kv_pool_allocator"):
+            raise RuntimeError(
+                f"PD decode half: {name} has no token_to_kv_pool_allocator to "
+                "rebind, so its allocations would bypass the lock"
+            )
+        holder.token_to_kv_pool_allocator = locked
+
+
+def kv_allocator_holders(scheduler: OmniDecodeScheduler) -> dict[str, Any]:
+    """Every allocator reference the scheduler can reach, by holder name.
+
+    A test asserts these are one object. That is what catches a new holder
+    appearing between the allocator's creation and this scheduler's.
+    """
+    found: dict[str, Any] = {
+        "scheduler": scheduler.__dict__.get("token_to_kv_pool_allocator")
+    }
+    for name in _KV_ALLOCATOR_HOLDERS:
+        holder = getattr(scheduler, name, None)
+        if holder is not None:
+            found[name] = getattr(holder, "token_to_kv_pool_allocator", None)
+    return found
 
 
 def _validate_pd_runtime(scheduler: OmniScheduler) -> None:

--- a/sglang_omni/scheduling/pd_utils.py
+++ b/sglang_omni/scheduling/pd_utils.py
@@ -1,0 +1,447 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Utilities shared by the explicit Prefill and Decode schedulers."""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import logging
+import queue
+import threading
+from array import array
+from collections.abc import Callable
+from contextlib import contextmanager
+from typing import Any
+
+import msgspec
+import torch
+
+from sglang_omni.comm import KVBufferRegion, KVPageDestination, KVPool
+from sglang_omni.proto import KVTransferPrepareMessage, StagePayload
+from sglang_omni.scheduling.sglang_backend.request_data import SGLangARRequestData
+
+logger = logging.getLogger(__name__)
+
+CONTINUATION_VERSION = 1
+
+
+@dataclasses.dataclass(frozen=True)
+class DecodeContinuation:
+    """Serializable request state needed after the Prefill KV has arrived."""
+
+    request_id: str
+    transfer_id: str
+    origin_input_ids: list[int]
+    output_ids: list[int]
+    vocab_size: int
+    sampling_params: dict[str, Any]
+    stage_payload: dict[str, Any]
+    origin_input_ids_unpadded: list[int] | None = None
+    eos_token_ids: list[int] | None = None
+    cached_tokens: int = 0
+    cached_tokens_device: int = 0
+    cached_tokens_host: int = 0
+    cached_tokens_storage: int = 0
+    mm_image_tokens: int = 0
+    mm_audio_tokens: int = 0
+    mm_video_tokens: int = 0
+    return_logprob: bool = False
+    output_token_logprobs: list[Any] = dataclasses.field(default_factory=list)
+    top_logprobs_num: int = 0
+    token_ids_logprob: list[int] | None = None
+    logprob_start_len: int = -1
+    return_hidden_states: bool = False
+    return_sampling_mask: bool = False
+    return_routed_experts: bool = False
+    return_indexer_topk: bool = False
+    multimodal_resume: dict[str, Any] | None = None
+    version: int = CONTINUATION_VERSION
+
+    def __post_init__(self) -> None:
+        if self.version != CONTINUATION_VERSION:
+            raise ValueError(f"unsupported decode continuation version {self.version}")
+        if not self.request_id or not self.transfer_id:
+            raise ValueError("decode continuation ids must be non-empty")
+        if not self.output_ids:
+            raise ValueError("decode continuation requires the Prefill token")
+        if self.vocab_size <= 0:
+            raise ValueError("decode continuation vocab_size must be positive")
+
+    def encode(self) -> bytes:
+        return msgspec.msgpack.encode(dataclasses.asdict(self))
+
+    @classmethod
+    def decode(cls, value: bytes) -> DecodeContinuation:
+        try:
+            decoded = msgspec.msgpack.decode(value)
+        except Exception as exc:
+            raise ValueError("invalid decode continuation encoding") from exc
+        if not isinstance(decoded, dict):
+            raise TypeError("decode continuation must contain a mapping")
+        expected = {field.name for field in dataclasses.fields(cls)}
+        unknown = set(decoded) - expected
+        if unknown:
+            raise ValueError(f"unknown decode continuation fields: {unknown}")
+        try:
+            return cls(**decoded)
+        except TypeError as exc:
+            raise ValueError(f"invalid decode continuation: {exc}") from exc
+
+
+@dataclasses.dataclass(frozen=True)
+class ReservedKV:
+    slots: torch.Tensor
+    page_indices: tuple[int, ...]
+    seq_len: int
+
+
+@dataclasses.dataclass(frozen=True)
+class DecodeAdmission:
+    continuation: DecodeContinuation
+    allocation: ReservedKV
+
+
+StateBuilder = Callable[[Any], tuple[dict[str, Any], dict[str, Any] | None, list[int]]]
+StateRestorer = Callable[[Any, SGLangARRequestData, dict[str, Any] | None], None]
+
+
+def continuation_from_req(
+    req: Any,
+    transfer_id: str,
+    state_builder: StateBuilder,
+) -> DecodeContinuation:
+    """Snapshot a completed Prefill request without serializing runtime tensors."""
+
+    if not req.output_ids:
+        raise ValueError(f"Prefill request {req.rid!r} produced no token")
+    if req.custom_logit_processor:
+        raise NotImplementedError("PD does not support custom logit processors")
+    sampling = _sampling_params_to_dict(req.sampling_params)
+    if any(
+        sampling.get(key) for key in ("json_schema", "regex", "ebnf", "structural_tag")
+    ):
+        raise NotImplementedError("PD does not support structured-output sampling")
+
+    payload, multimodal_resume, origin_input_ids = state_builder(req)
+    data = req._omni_data
+    return DecodeContinuation(
+        request_id=req.rid,
+        transfer_id=transfer_id,
+        origin_input_ids=origin_input_ids,
+        origin_input_ids_unpadded=list(origin_input_ids),
+        output_ids=list(req.output_ids),
+        vocab_size=int(req.vocab_size),
+        sampling_params=sampling,
+        stage_payload=payload,
+        eos_token_ids=list(req.eos_token_ids) if req.eos_token_ids else None,
+        cached_tokens=int(req.cached_tokens),
+        cached_tokens_device=int(req.cached_tokens_device),
+        cached_tokens_host=int(req.cached_tokens_host),
+        cached_tokens_storage=int(req.cached_tokens_storage),
+        mm_image_tokens=int(req.mm_image_tokens),
+        mm_audio_tokens=int(req.mm_audio_tokens),
+        mm_video_tokens=int(req.mm_video_tokens),
+        return_logprob=bool(data.return_logprob),
+        output_token_logprobs=list(data.output_token_logprobs),
+        top_logprobs_num=int(req.logprob.top_logprobs_num),
+        token_ids_logprob=(
+            list(req.logprob.token_ids_logprob)
+            if req.logprob.token_ids_logprob is not None
+            else None
+        ),
+        logprob_start_len=int(req.logprob_start_len),
+        return_hidden_states=bool(req.return_hidden_states),
+        return_sampling_mask=bool(req.return_sampling_mask),
+        return_routed_experts=bool(req.return_routed_experts),
+        return_indexer_topk=bool(req.return_indexer_topk),
+        multimodal_resume=multimodal_resume,
+    )
+
+
+class DecodeRequestPoolExhausted(RuntimeError):
+    """The KV is committed, but no request-table row is currently available."""
+
+
+def req_from_continuation(
+    continuation: DecodeContinuation,
+    allocation: ReservedKV,
+    *,
+    req_to_token_pool: Any,
+    state_restorer: StateRestorer,
+) -> Any:
+    """Install a transferred request as SGLang's existing PREBUILT input."""
+
+    from sglang.srt.managers.schedule_batch import Req, ReqKvInfo
+    from sglang.srt.sampling.sampling_params import SamplingParams
+
+    sampling_values = dict(continuation.sampling_params)
+    if isinstance(sampling_values.get("stop_token_ids"), list):
+        sampling_values["stop_token_ids"] = set(sampling_values["stop_token_ids"])
+    sampling_params = SamplingParams(**sampling_values)
+    req = Req(
+        rid=continuation.request_id,
+        origin_input_text="",
+        origin_input_ids=array("q", continuation.origin_input_ids),
+        origin_input_ids_unpadded=(
+            array("q", continuation.origin_input_ids_unpadded)
+            if continuation.origin_input_ids_unpadded is not None
+            else None
+        ),
+        sampling_params=sampling_params,
+        # Prefill logprobs are already retained by Omni request data.
+        return_logprob=False,
+        top_logprobs_num=continuation.top_logprobs_num,
+        token_ids_logprob=continuation.token_ids_logprob,
+        return_sampling_mask=continuation.return_sampling_mask,
+        return_hidden_states=continuation.return_hidden_states,
+        return_routed_experts=continuation.return_routed_experts,
+        return_indexer_topk=continuation.return_indexer_topk,
+        eos_token_ids=(
+            set(continuation.eos_token_ids)
+            if continuation.eos_token_ids is not None
+            else None
+        ),
+        vocab_size=continuation.vocab_size,
+    )
+    req.output_ids.extend(continuation.output_ids)
+    req.cached_tokens = continuation.cached_tokens
+    req.already_computed = continuation.cached_tokens
+    req.cached_tokens_device = continuation.cached_tokens_device
+    req.cached_tokens_host = continuation.cached_tokens_host
+    req.cached_tokens_storage = continuation.cached_tokens_storage
+    req.mm_image_tokens = continuation.mm_image_tokens
+    req.mm_audio_tokens = continuation.mm_audio_tokens
+    req.mm_video_tokens = continuation.mm_video_tokens
+    req.logprob_start_len = continuation.logprob_start_len
+
+    payload = StagePayload.from_dict(continuation.stage_payload)
+    data = SGLangARRequestData(
+        input_ids=torch.tensor(continuation.origin_input_ids, dtype=torch.long),
+        output_ids=req.output_ids,
+        req=req,
+        stage_payload=payload,
+        max_new_tokens=int(sampling_params.max_new_tokens),
+        temperature=float(sampling_params.temperature),
+        top_p=float(sampling_params.top_p),
+        top_k=int(sampling_params.top_k),
+        repetition_penalty=float(sampling_params.repetition_penalty),
+        return_logprob=continuation.return_logprob,
+        output_token_logprobs=list(continuation.output_token_logprobs),
+    )
+    req._omni_data = data
+    state_restorer(req, data, continuation.multimodal_resume)
+
+    if req_to_token_pool.alloc([req]) is None:
+        raise DecodeRequestPoolExhausted("decode request pool is exhausted")
+    try:
+        req_to_token_pool.write(
+            (req.req_pool_idx, slice(0, allocation.seq_len)), allocation.slots
+        )
+    except Exception:
+        req_to_token_pool.free(req)
+        raise
+    req.prefix_indices = allocation.slots
+    req.kv_committed_len = allocation.seq_len
+    req.kv = ReqKvInfo(kv_allocated_len=allocation.seq_len, swa_evicted_seqlen=0)
+    req.set_extend_range(allocation.seq_len, allocation.seq_len)
+    req._omni_terminal_claimed = False
+    req._coalesce_enqueue_t = 0.0
+    return req
+
+
+def _sampling_params_to_dict(params: Any) -> dict[str, Any]:
+    allowed = inspect.signature(type(params)).parameters
+    return {name: getattr(params, name) for name in allowed if hasattr(params, name)}
+
+
+@contextmanager
+def defer_first_token_finish(reqs: list[Any]):
+    """Let normal Prefill accounting run while Decode owns stop decisions."""
+
+    saved = []
+    for req in reqs:
+        params = req.sampling_params
+        values = (
+            params.max_new_tokens,
+            params.ignore_eos,
+            params.stop_strs,
+            params.stop_regex_strs,
+        )
+        saved.append((params, values))
+        params.max_new_tokens = max(int(params.max_new_tokens), len(req.output_ids) + 2)
+        params.ignore_eos = True
+        params.stop_strs = []
+        params.stop_regex_strs = []
+    try:
+        yield
+    finally:
+        for params, values in saved:
+            (
+                params.max_new_tokens,
+                params.ignore_eos,
+                params.stop_strs,
+                params.stop_regex_strs,
+            ) = values
+
+
+def build_kv_pool(token_to_kv_pool: Any, *, pool_id: str) -> KVPool:
+    getter = getattr(token_to_kv_pool, "_pd_registerable_tensors", None)
+    if callable(getter):
+        tensors = tuple(getter())
+    else:
+        tensors = tuple(
+            tensor
+            for layer_id in range(int(token_to_kv_pool.layer_num))
+            for tensor in (
+                token_to_kv_pool.get_key_buffer(layer_id),
+                token_to_kv_pool.get_value_buffer(layer_id),
+            )
+        )
+    _, _, item_lens = token_to_kv_pool.get_contiguous_buf_infos()
+    if not tensors or len(tensors) != len(item_lens):
+        raise ValueError("SGLang KV pool exposed incompatible buffer metadata")
+    return KVPool(
+        pool_id=pool_id,
+        layout_id=(
+            f"{type(token_to_kv_pool).__module__}."
+            f"{type(token_to_kv_pool).__qualname__}:page_size=1"
+        ),
+        page_size=1,
+        buffers=tuple(
+            KVBufferRegion(
+                name=f"kv_buffer.{index}",
+                tensor=tensor,
+                bytes_per_page=int(item_len),
+            )
+            for index, (tensor, item_len) in enumerate(zip(tensors, item_lens))
+        ),
+    )
+
+
+def request_page_indices(req_to_token_pool: Any, req: Any) -> tuple[int, ...]:
+    if req.req_pool_idx is None:
+        raise RuntimeError(f"request {req.rid!r} has no KV mapping")
+    seq_len = len(req.origin_input_ids)
+    if seq_len <= 0:
+        raise ValueError("PD cannot transfer an empty prompt")
+    return tuple(
+        int(slot)
+        for slot in req_to_token_pool.req_to_token[req.req_pool_idx, :seq_len].tolist()
+    )
+
+
+@dataclasses.dataclass
+class _Reservation:
+    continuation: DecodeContinuation
+    allocation: ReservedKV
+
+
+class DecodeKVReceiver:
+    """Reserve destination pages, then queue one admission when copy commits."""
+
+    def __init__(
+        self,
+        *,
+        pool_id: str,
+        allocator: Any,
+        admissions: queue.SimpleQueue[DecodeAdmission],
+        resume_schema: str,
+    ) -> None:
+        self.pool_id = pool_id
+        self._allocator = allocator
+        self._admissions = admissions
+        self._resume_schema = resume_schema
+        self._lock = threading.Lock()
+        self._reservations: dict[str, _Reservation] = {}
+
+    def reserve(self, request: KVTransferPrepareMessage) -> KVPageDestination:
+        if request.target_pool_id != self.pool_id:
+            raise ValueError(f"KV receiver for {self.pool_id!r} got another pool")
+        raw = request.metadata.get("decode_continuation")
+        if not isinstance(raw, (bytes, bytearray)):
+            raise TypeError("KV transfer is missing decode continuation bytes")
+        continuation = DecodeContinuation.decode(bytes(raw))
+        if (
+            continuation.request_id != request.request_id
+            or continuation.transfer_id != request.transfer_id
+        ):
+            raise ValueError("KV transfer and decode continuation ids differ")
+        resume = continuation.multimodal_resume
+        if resume is not None and resume.get("schema") != self._resume_schema:
+            raise ValueError(
+                f"unsupported multimodal resume schema {resume.get('schema')!r}"
+            )
+
+        count = len(request.source_page_indices)
+        if count <= 0:
+            raise ValueError("KV transfer contains no pages")
+        with self._lock:
+            if request.transfer_id in self._reservations:
+                raise RuntimeError(f"duplicate KV transfer {request.transfer_id!r}")
+            if int(self._allocator.available_size()) < count:
+                raise RuntimeError(
+                    f"decode KV pool exhausted: need {count}, "
+                    f"have {self._allocator.available_size()}"
+                )
+            slots = self._allocator.alloc(count)
+            if slots is None:
+                raise RuntimeError(f"decode KV allocator failed to allocate {count}")
+            allocation = ReservedKV(
+                slots=slots,
+                page_indices=tuple(int(slot) for slot in slots.tolist()),
+                seq_len=count,
+            )
+            self._reservations[request.transfer_id] = _Reservation(
+                continuation, allocation
+            )
+        return KVPageDestination(self.pool_id, allocation.page_indices)
+
+    def commit(
+        self,
+        request: KVTransferPrepareMessage,
+        destination: KVPageDestination,
+    ) -> None:
+        with self._lock:
+            reservation = self._reservations.pop(request.transfer_id, None)
+        if reservation is None:
+            raise RuntimeError(
+                f"commit for unknown KV transfer {request.transfer_id!r}"
+            )
+        if reservation.allocation.page_indices != destination.page_indices:
+            self._allocator.free(reservation.allocation.slots)
+            raise RuntimeError("committed KV pages differ from the reservation")
+        self._admissions.put(
+            DecodeAdmission(reservation.continuation, reservation.allocation)
+        )
+
+    def abort(
+        self,
+        request: KVTransferPrepareMessage,
+        destination: KVPageDestination | None,
+        error: BaseException,
+    ) -> None:
+        del destination
+        with self._lock:
+            reservation = self._reservations.pop(request.transfer_id, None)
+        if reservation is not None:
+            self._allocator.free(reservation.allocation.slots)
+        logger.warning("KV receive aborted for %s: %s", request.request_id, error)
+
+
+class SGLangKVLease:
+    """Keep source pages owned until the receiver ACKs the copy."""
+
+    def __init__(self, req: Any, tree_cache: Any) -> None:
+        self._req = req
+        self._tree_cache = tree_cache
+        self._lock = threading.Lock()
+
+    def release(self) -> None:
+        with self._lock:
+            req = self._req
+            self._req = None
+        if req is None:
+            return
+        from sglang.srt.mem_cache.common import release_kv_cache
+
+        release_kv_cache(req, self._tree_cache)

--- a/sglang_omni/scheduling/pd_utils.py
+++ b/sglang_omni/scheduling/pd_utils.py
@@ -66,6 +66,20 @@ class DecodeContinuation:
             raise ValueError("decode continuation requires the Prefill token")
         if self.vocab_size <= 0:
             raise ValueError("decode continuation vocab_size must be positive")
+        if not isinstance(self.sampling_params, dict):
+            raise TypeError("decode continuation sampling_params must be a mapping")
+        if not isinstance(self.stage_payload, dict):
+            raise TypeError("decode continuation stage_payload must be a mapping")
+        if self.multimodal_resume is not None and not isinstance(
+            self.multimodal_resume, dict
+        ):
+            raise TypeError("decode continuation multimodal_resume must be a mapping")
+        try:
+            msgspec.msgpack.encode(self.sampling_params)
+        except Exception as exc:
+            raise ValueError(
+                "decode continuation sampling state is not serializable"
+            ) from exc
 
     def encode(self) -> bytes:
         return msgspec.msgpack.encode(dataclasses.asdict(self))
@@ -105,6 +119,22 @@ StateBuilder = Callable[[Any], tuple[dict[str, Any], dict[str, Any] | None, list
 StateRestorer = Callable[[Any, SGLangARRequestData, dict[str, Any] | None], None]
 
 
+def default_state_builder(
+    req: Any,
+) -> tuple[dict[str, Any], dict[str, Any] | None, list[int]]:
+    return req._omni_data.stage_payload.to_dict(), None, list(req.origin_input_ids)
+
+
+def default_state_restorer(
+    req: Any,
+    data: SGLangARRequestData,
+    resume: dict[str, Any] | None,
+) -> None:
+    del req, data
+    if resume is not None:
+        raise ValueError("generic PD resume does not accept model-specific state")
+
+
 def continuation_from_req(
     req: Any,
     transfer_id: str,
@@ -116,19 +146,42 @@ def continuation_from_req(
         raise ValueError(f"Prefill request {req.rid!r} produced no token")
     if req.custom_logit_processor:
         raise NotImplementedError("PD does not support custom logit processors")
+    data = req._omni_data
+    if data.input_embeds_are_projected or getattr(
+        req, "_input_embeds_are_projected", False
+    ):
+        raise NotImplementedError("PD does not support projected input embeddings")
     sampling = _sampling_params_to_dict(req.sampling_params)
     if any(
-        sampling.get(key) for key in ("json_schema", "regex", "ebnf", "structural_tag")
+        sampling.get(key)
+        for key in (
+            "grammar",
+            "json_schema",
+            "regex",
+            "ebnf",
+            "structural_tag",
+        )
     ):
         raise NotImplementedError("PD does not support structured-output sampling")
+    try:
+        msgspec.msgpack.encode(sampling)
+    except Exception as exc:
+        raise ValueError("PD sampling state is not serializable") from exc
 
     payload, multimodal_resume, origin_input_ids = state_builder(req)
-    data = req._omni_data
+    if not isinstance(payload, dict):
+        raise TypeError("PD state builder must return a payload mapping")
+    if multimodal_resume is not None and not isinstance(multimodal_resume, dict):
+        raise TypeError("PD state builder must return a resume mapping")
     return DecodeContinuation(
         request_id=req.rid,
         transfer_id=transfer_id,
         origin_input_ids=origin_input_ids,
-        origin_input_ids_unpadded=list(origin_input_ids),
+        origin_input_ids_unpadded=(
+            list(req.origin_input_ids_unpadded)
+            if req.origin_input_ids_unpadded is not None
+            else None
+        ),
         output_ids=list(req.output_ids),
         vocab_size=int(req.vocab_size),
         sampling_params=sampling,
@@ -345,14 +398,16 @@ class DecodeKVReceiver:
         pool_id: str,
         allocator: Any,
         admissions: queue.SimpleQueue[DecodeAdmission],
-        resume_schema: str,
+        allowed_resume_schemas: frozenset[str],
     ) -> None:
         self.pool_id = pool_id
         self._allocator = allocator
         self._admissions = admissions
-        self._resume_schema = resume_schema
+        self._allowed_resume_schemas = allowed_resume_schemas
         self._lock = threading.Lock()
         self._reservations: dict[str, _Reservation] = {}
+        self._transfer_ids: set[str] = set()
+        self._closed = False
 
     def reserve(self, request: KVTransferPrepareMessage) -> KVPageDestination:
         if request.target_pool_id != self.pool_id:
@@ -367,16 +422,18 @@ class DecodeKVReceiver:
         ):
             raise ValueError("KV transfer and decode continuation ids differ")
         resume = continuation.multimodal_resume
-        if resume is not None and resume.get("schema") != self._resume_schema:
-            raise ValueError(
-                f"unsupported multimodal resume schema {resume.get('schema')!r}"
-            )
+        if resume is not None:
+            schema = resume.get("schema")
+            if schema not in self._allowed_resume_schemas:
+                raise ValueError(f"unsupported multimodal resume schema {schema!r}")
 
         count = len(request.source_page_indices)
         if count <= 0:
             raise ValueError("KV transfer contains no pages")
         with self._lock:
-            if request.transfer_id in self._reservations:
+            if self._closed:
+                raise RuntimeError("decode KV receiver is closed")
+            if request.transfer_id in self._transfer_ids:
                 raise RuntimeError(f"duplicate KV transfer {request.transfer_id!r}")
             if int(self._allocator.available_size()) < count:
                 raise RuntimeError(
@@ -394,6 +451,7 @@ class DecodeKVReceiver:
             self._reservations[request.transfer_id] = _Reservation(
                 continuation, allocation
             )
+            self._transfer_ids.add(request.transfer_id)
         return KVPageDestination(self.pool_id, allocation.page_indices)
 
     def commit(
@@ -403,16 +461,27 @@ class DecodeKVReceiver:
     ) -> None:
         with self._lock:
             reservation = self._reservations.pop(request.transfer_id, None)
-        if reservation is None:
-            raise RuntimeError(
-                f"commit for unknown KV transfer {request.transfer_id!r}"
-            )
-        if reservation.allocation.page_indices != destination.page_indices:
-            self._allocator.free(reservation.allocation.slots)
-            raise RuntimeError("committed KV pages differ from the reservation")
-        self._admissions.put(
-            DecodeAdmission(reservation.continuation, reservation.allocation)
-        )
+            if reservation is None:
+                raise RuntimeError(
+                    f"commit for unknown KV transfer {request.transfer_id!r}"
+                )
+            if (
+                self._closed
+                or request.request_id != reservation.continuation.request_id
+                or request.target_pool_id != self.pool_id
+                or destination.pool_id != self.pool_id
+                or len(request.source_page_indices) != reservation.allocation.seq_len
+                or reservation.allocation.page_indices != destination.page_indices
+            ):
+                self._allocator.free(reservation.allocation.slots)
+                raise RuntimeError("KV commit does not match its reservation")
+            try:
+                self._admissions.put(
+                    DecodeAdmission(reservation.continuation, reservation.allocation)
+                )
+            except Exception:
+                self._allocator.free(reservation.allocation.slots)
+                raise
 
     def abort(
         self,
@@ -426,6 +495,16 @@ class DecodeKVReceiver:
         if reservation is not None:
             self._allocator.free(reservation.allocation.slots)
         logger.warning("KV receive aborted for %s: %s", request.request_id, error)
+
+    def close(self) -> None:
+        """Release every receiver-owned reservation exactly once."""
+
+        with self._lock:
+            self._closed = True
+            reservations = list(self._reservations.values())
+            self._reservations.clear()
+        for reservation in reservations:
+            self._allocator.free(reservation.allocation.slots)
 
 
 class SGLangKVLease:

--- a/tests/unit_test/fixtures/pipeline_fakes.py
+++ b/tests/unit_test/fixtures/pipeline_fakes.py
@@ -17,6 +17,7 @@ from typing import Any, Callable
 
 import torch
 
+from sglang_omni.config.pd_capability import pd_disaggregation_capable
 from sglang_omni.config.schema import PipelineConfig
 from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
@@ -133,6 +134,7 @@ class FakeScheduler:
         self.started = False
         self.stopped = False
         self.aborted: list[str] = []
+        self.kv_registrations = ()
 
     def start(self) -> None:
         self.started = True
@@ -224,6 +226,23 @@ def make_scheduler(**_: Any) -> FakeScheduler:
     return FakeScheduler()
 
 
+@pd_disaggregation_capable
+def make_pd_scheduler(*, scheduler_cls, scheduler_kwargs, **kwargs):
+    """Exercise the real worker factory contract without initializing SGLang."""
+
+    scheduler = object.__new__(scheduler_cls)
+    scheduler.kv_registrations = ()
+    scheduler.factory_observed_type = type(scheduler)
+    scheduler.factory_kwargs = {**kwargs, **scheduler_kwargs}
+    return scheduler
+
+
+@pd_disaggregation_capable
+def make_wrong_pd_scheduler(*, scheduler_cls, scheduler_kwargs, **kwargs):
+    del scheduler_cls, scheduler_kwargs, kwargs
+    return FakeScheduler()
+
+
 def dummy_factory(**kwargs: Any) -> dict[str, Any]:
     return dict(kwargs)
 
@@ -290,6 +309,7 @@ class ReplicaProcessProbeScheduler:
     def __init__(self, marker: str, *, emit_stream: bool = False) -> None:
         self.inbox: queue.Queue[IncomingMessage] = queue.Queue()
         self.outbox: queue.Queue[OutgoingMessage] = queue.Queue()
+        self.kv_registrations = ()
         self.requires_tp_work_fanout = True
         self._marker = marker
         self._emit_stream = emit_stream

--- a/tests/unit_test/pipeline/test_kv_transfer.py
+++ b/tests/unit_test/pipeline/test_kv_transfer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import queue
 from typing import Any
 from unittest.mock import Mock
 from uuid import uuid4
@@ -25,6 +26,7 @@ from sglang_omni.proto import (
     KVTransferPrepareMessage,
     KVTransferReadyMessage,
 )
+from sglang_omni.scheduling.pd_utils import DecodeContinuation, DecodeKVReceiver
 from tests.unit_test.fixtures.pipeline_fakes import FakeOp, FakeRelay
 from tests.unit_test.fixtures.trace_capture import capture_comm_trace
 
@@ -180,6 +182,24 @@ def _pool(pool_id: str, *, buffer_name: str = "layer.0.kv") -> KVPool:
         page_size=1,
         buffers=(KVBufferRegion(buffer_name, tensor, bytes_per_page=4),),
     )
+
+
+def test_prepare_metadata_keeps_continuation_bytes() -> None:
+    message = KVTransferPrepareMessage(
+        request_id="request-1",
+        transfer_id="transfer-1",
+        from_stage="source",
+        to_stage="destination",
+        source_pool_id="source:kv",
+        target_pool_id="destination:kv",
+        source_page_indices=(1,),
+        source_layout=_pool("source:kv").layout,
+        metadata={"decode_continuation": b"\x00\xff"},
+    )
+
+    decoded = deserialize_message(serialize_message(message))
+
+    assert decoded.metadata["decode_continuation"] == b"\x00\xff"
 
 
 def _kv_endpoints(tp_size: int) -> dict[str, tuple[str, ...]]:
@@ -371,6 +391,59 @@ def test_kv_transfer_uses_rank_endpoint_for_full_lifecycle() -> None:
             lease.release.assert_called_once_with()
             assert relay.put_ops[0].waited
             assert ("op_ack", "kv-put") in relay.log.events
+        finally:
+            await source.close()
+            await destination.close()
+
+    asyncio.run(_run())
+
+
+def test_pd_continuation_is_admitted_after_comm_engine_handoff() -> None:
+    async def _run() -> None:
+        relay, source, destination = await _start_pair()
+        try:
+            source.register_kv_pool(_pool("prefill:kv"))
+            destination.register_kv_pool(_pool("decode:kv"))
+            allocator = Mock()
+            allocator.available_size.return_value = 6
+            allocator.alloc.return_value = torch.tensor([0, 3, 5])
+            admissions = queue.SimpleQueue()
+            destination.register_kv_receiver(
+                "decode:kv",
+                DecodeKVReceiver(
+                    pool_id="decode:kv",
+                    allocator=allocator,
+                    admissions=admissions,
+                    resume_schema="test-v1",
+                ),
+            )
+            continuation = DecodeContinuation(
+                request_id="request",
+                transfer_id="transfer",
+                origin_input_ids=[10, 11, 12],
+                output_ids=[42],
+                vocab_size=128,
+                sampling_params={},
+                stage_payload={},
+            )
+            lease = Mock()
+
+            await source.send_kv_pages(
+                request_id="request",
+                transfer_id="transfer",
+                source_pool_id="prefill:kv",
+                source_page_indices=(1, 2, 3),
+                target_pool_id="decode:kv",
+                to_stage="destination",
+                metadata={"decode_continuation": continuation.encode()},
+                lease=lease,
+            )
+
+            admission = admissions.get_nowait()
+            assert admission.continuation == continuation
+            assert admission.allocation.page_indices == (0, 3, 5)
+            assert relay.get_calls == [("decode:kv", (1, 2, 3), (0, 3, 5))]
+            lease.release.assert_called_once_with()
         finally:
             await source.close()
             await destination.close()

--- a/tests/unit_test/pipeline/test_kv_transfer.py
+++ b/tests/unit_test/pipeline/test_kv_transfer.py
@@ -414,7 +414,7 @@ def test_pd_continuation_is_admitted_after_comm_engine_handoff() -> None:
                     pool_id="decode:kv",
                     allocator=allocator,
                     admissions=admissions,
-                    resume_schema="test-v1",
+                    allowed_resume_schemas=frozenset({"test-v1"}),
                 ),
             )
             continuation = DecodeContinuation(

--- a/tests/unit_test/pipeline/test_pd_alloc_lock.py
+++ b/tests/unit_test/pipeline/test_pd_alloc_lock.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+"""One lock across the two threads a PD Decode half allocates from.
+
+The allocator's alloc reads the free list, slices it, and writes the
+remainder back, with no lock of its own. On a Decode half the scheduler
+thread and the comm event loop both call it, and interleaving there hands
+the same slots to both.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from sglang_omni.scheduling.pd_alloc_lock import LockedKVAllocator
+
+
+class _FakeAllocator:
+    """Stands in for the real allocator; only identity matters here."""
+
+    def alloc(self, n):  # pragma: no cover - never called
+        return list(range(n))
+
+    def free(self, indices):  # pragma: no cover - never called
+        return None
+
+
+class _RacyAllocator:
+    """An allocator with the same read-modify-write shape as upstream's."""
+
+    def __init__(self, size: int) -> None:
+        self.free_pages = list(range(size))
+        self.page_size = 1
+        self.handed_out: list[int] = []
+
+    def alloc(self, need_size: int):
+        taken = self.free_pages[:need_size]
+        # A thread switch here is what produces the overlap in production.
+        threading.current_thread()
+        self.free_pages = self.free_pages[need_size:]
+        self.handed_out.extend(taken)
+        return taken
+
+    def free(self, index) -> None:
+        self.free_pages.extend(index)
+
+    def available_size(self) -> int:
+        return len(self.free_pages)
+
+
+def test_two_threads_never_receive_the_same_slot() -> None:
+    inner = _RacyAllocator(4096)
+    allocator = LockedKVAllocator(inner)
+    seen: list[int] = []
+    lock = threading.Lock()
+
+    def take() -> None:
+        for _ in range(64):
+            got = allocator.alloc(4)
+            with lock:
+                seen.extend(got)
+
+    threads = [threading.Thread(target=take) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(seen) == len(set(seen))
+
+
+def test_everything_else_is_delegated() -> None:
+    inner = _RacyAllocator(16)
+    allocator = LockedKVAllocator(inner)
+
+    assert allocator.available_size() == 16
+    assert allocator.page_size == 1
+
+
+def test_a_write_reaches_the_wrapped_allocator() -> None:
+    """Upstream code sets attributes on the allocator it was handed."""
+    inner = _RacyAllocator(16)
+    allocator = LockedKVAllocator(inner)
+
+    allocator.page_size = 4
+
+    assert inner.page_size == 4
+
+
+def test_freeing_returns_the_slots() -> None:
+    inner = _RacyAllocator(8)
+    allocator = LockedKVAllocator(inner)
+
+    taken = allocator.alloc(8)
+    assert allocator.available_size() == 0
+
+    allocator.free(taken)
+    assert allocator.available_size() == 8
+
+
+def test_every_holder_of_the_allocator_gets_the_same_locked_object() -> None:
+    """One lock only helps if no caller keeps an unwrapped alias."""
+    from types import SimpleNamespace
+
+    from sglang_omni.scheduling.pd_scheduler import (
+        OmniDecodeScheduler,
+        _serialize_kv_allocation,
+        kv_allocator_holders,
+    )
+
+    raw = _FakeAllocator()
+    scheduler = OmniDecodeScheduler.__new__(OmniDecodeScheduler)
+    scheduler.token_to_kv_pool_allocator = raw
+    scheduler.tree_cache = SimpleNamespace(token_to_kv_pool_allocator=raw)
+
+    _serialize_kv_allocation(scheduler)
+
+    holders = kv_allocator_holders(scheduler)
+    assert set(holders) == {"scheduler", "tree_cache"}
+    assert len({id(a) for a in holders.values()}) == 1
+    assert all(isinstance(a, LockedKVAllocator) for a in holders.values())
+
+
+def test_a_holder_that_cannot_be_rebound_is_an_error() -> None:
+    """Skipping it silently would leave an alias outside the lock."""
+    from types import SimpleNamespace
+
+    from sglang_omni.scheduling.pd_scheduler import (
+        OmniDecodeScheduler,
+        _serialize_kv_allocation,
+    )
+
+    scheduler = OmniDecodeScheduler.__new__(OmniDecodeScheduler)
+    scheduler.token_to_kv_pool_allocator = _FakeAllocator()
+    scheduler.tree_cache = SimpleNamespace()  # no allocator attribute
+
+    with pytest.raises(RuntimeError, match="would bypass the lock"):
+        _serialize_kv_allocation(scheduler)
+
+
+def test_a_receiver_built_after_the_wrap_gets_the_locked_allocator() -> None:
+    """Ordering matters: a receiver built first would hold the raw object."""
+    import queue
+    from types import SimpleNamespace
+
+    from sglang_omni.scheduling.pd_scheduler import _serialize_kv_allocation
+    from sglang_omni.scheduling.pd_utils import DecodeKVReceiver
+
+    inner = _RacyAllocator(64)
+    scheduler = SimpleNamespace(
+        token_to_kv_pool_allocator=inner,
+        tree_cache=SimpleNamespace(token_to_kv_pool_allocator=inner),
+    )
+    _serialize_kv_allocation(scheduler)
+
+    receiver = DecodeKVReceiver(
+        pool_id="thinker_decode:kv",
+        allocator=scheduler.token_to_kv_pool_allocator,
+        admissions=queue.SimpleQueue(),
+        allowed_resume_schemas=frozenset({"v1"}),
+    )
+
+    assert isinstance(receiver._allocator, LockedKVAllocator)

--- a/tests/unit_test/pipeline/test_pd_model_state.py
+++ b/tests/unit_test/pipeline/test_pd_model_state.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.ming_omni.bootstrap import MING_THINKER_PD_RESUME_SCHEMA
+from sglang_omni.models.ming_omni.bootstrap import (
+    make_thinker_pd_adapters as make_ming_pd_adapters,
+)
+from sglang_omni.models.qwen3_omni.request_builders import QWEN_THINKER_PD_RESUME_SCHEMA
+from sglang_omni.models.qwen3_omni.request_builders import (
+    make_thinker_pd_adapters as make_qwen_pd_adapters,
+)
+from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.scheduling.pd_utils import DecodeContinuation
+
+
+def _payload(data) -> StagePayload:
+    return StagePayload(
+        request_id="request",
+        request=OmniRequest(
+            inputs={"discarded": True},
+            params={"stream": True},
+            metadata={"output_modalities": ["text"]},
+        ),
+        data=data,
+    )
+
+
+def _continuation(payload, resume, input_ids) -> DecodeContinuation:
+    return DecodeContinuation(
+        request_id="request",
+        transfer_id="transfer",
+        origin_input_ids=input_ids,
+        output_ids=[42],
+        vocab_size=128,
+        sampling_params={},
+        stage_payload=payload,
+        multimodal_resume=resume,
+    )
+
+
+def test_qwen_pd_state_round_trip_uses_generic_continuation_hook() -> None:
+    builder, restorer = make_qwen_pd_adapters(tokenizer="tokenizer")
+    source = SimpleNamespace(
+        origin_input_ids=[10, 11, 12],
+        _omni_data=SimpleNamespace(
+            stage_payload=_payload(
+                {
+                    "prompt": {"input_ids": torch.tensor([10, 11, 12])},
+                    "stream_state": {"offset": 3},
+                    "encoder_outs": {"large": torch.ones(4)},
+                }
+            )
+        ),
+        multimodal_inputs=SimpleNamespace(
+            mrope_position_delta=torch.tensor([[5]], dtype=torch.long)
+        ),
+    )
+    payload, resume, input_ids = builder(source)
+    continuation = DecodeContinuation.decode(
+        _continuation(payload, resume, input_ids).encode()
+    )
+
+    assert continuation.multimodal_resume == {
+        "schema": QWEN_THINKER_PD_RESUME_SCHEMA,
+        "mrope_position_delta": [[5]],
+    }
+    assert continuation.stage_payload["data"] == {
+        "prompt": {"input_ids": [10, 11, 12]},
+        "stream_state": {"offset": 3},
+    }
+    destination = SimpleNamespace()
+    restorer(destination, None, continuation.multimodal_resume)
+    assert destination.tokenizer == "tokenizer"
+    assert destination.multimodal_inputs.mrope_position_delta.tolist() == [[5]]
+
+
+def test_qwen_pd_state_rejects_unknown_schema_and_shape() -> None:
+    _, restorer = make_qwen_pd_adapters(tokenizer=None)
+    with pytest.raises(ValueError, match="unsupported Qwen"):
+        restorer(
+            SimpleNamespace(),
+            None,
+            {"schema": "future", "mrope_position_delta": [[1]]},
+        )
+    with pytest.raises(ValueError, match="shape"):
+        restorer(
+            SimpleNamespace(),
+            None,
+            {
+                "schema": QWEN_THINKER_PD_RESUME_SCHEMA,
+                "mrope_position_delta": [1, 2],
+            },
+        )
+
+
+def test_ming_pd_state_round_trip_uses_generic_continuation_hook() -> None:
+    builder, restorer = make_ming_pd_adapters(tokenizer="tokenizer")
+    source = SimpleNamespace(
+        origin_input_ids=[20, 21, 22],
+        _omni_data=SimpleNamespace(
+            stage_payload=_payload(
+                {
+                    "prompt": {"input_ids": torch.tensor([20, 21, 22])},
+                    "stream_state": {"offset": 2},
+                    "thinker_inputs": {"image_embeds": torch.ones(4, 2)},
+                }
+            )
+        ),
+    )
+    payload, resume, input_ids = builder(source)
+    continuation = DecodeContinuation.decode(
+        _continuation(payload, resume, input_ids).encode()
+    )
+
+    assert continuation.multimodal_resume == {"schema": MING_THINKER_PD_RESUME_SCHEMA}
+    assert continuation.stage_payload["data"] == {
+        "prompt": {"input_ids": [20, 21, 22]},
+        "stream_state": {"offset": 2},
+    }
+    destination = SimpleNamespace()
+    restorer(destination, None, continuation.multimodal_resume)
+    assert destination.tokenizer == "tokenizer"
+    assert destination.omni_model_inputs is None
+
+
+def test_ming_pd_state_rejects_unknown_schema() -> None:
+    _, restorer = make_ming_pd_adapters(tokenizer=None)
+    with pytest.raises(ValueError, match="unsupported Ming"):
+        restorer(SimpleNamespace(), None, {"schema": "future"})

--- a/tests/unit_test/pipeline/test_pd_rewrite.py
+++ b/tests/unit_test/pipeline/test_pd_rewrite.py
@@ -1,0 +1,274 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from sglang.srt import runtime_context
+
+if not hasattr(runtime_context, "get_model"):
+    runtime_context.get_model = lambda: None
+if not hasattr(runtime_context, "get_serving"):
+    runtime_context.get_serving = lambda: None
+
+from sglang_omni.config import (
+    PDConfig,
+    PDExecution,
+    PDStagePlacement,
+    PipelineConfig,
+    expand_pd_stages,
+)
+from sglang_omni.pipeline import stage_workers
+from sglang_omni.pipeline.mp_runner import _build_stage_groups
+from sglang_omni.pipeline.runtime_config import prepare_pipeline_runtime
+from sglang_omni.pipeline.stage_workers import StageLaunchConfig
+from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+from sglang_omni.scheduling.pd_scheduler import (
+    OmniDecodeScheduler,
+    OmniPrefillScheduler,
+)
+from tests.unit_test.fixtures.pipeline_fakes import fake_factory_path
+from tests.unit_test.pipeline.helpers import stage
+
+
+def _pd() -> PDConfig:
+    return PDConfig(
+        prefill=PDStagePlacement(gpu=0),
+        decode=PDStagePlacement(gpu=1),
+    )
+
+
+def _config(*, factory: str = "make_pd_scheduler") -> PipelineConfig:
+    return _PDTestConfig(
+        model_path="model",
+        entry_stage="pre",
+        stages=[
+            stage("pre", next="thinker"),
+            stage(
+                "thinker",
+                factory_path=fake_factory_path(factory),
+                wait_for=["pre"],
+                merge_fn=fake_factory_path("merge_payloads"),
+                route_fn=fake_factory_path("identity_route"),
+                next="post",
+                stream_to=["sink"],
+                project_payload={"post": fake_factory_path("project_payload")},
+                pd_disaggregation=_pd(),
+            ),
+            stage("post", terminal=True),
+            stage("sink", terminal=True),
+        ],
+    )
+
+
+class _PDTestConfig(PipelineConfig):
+    def stage_factory_kwargs(self, stage_name: str):
+        return {"logical_marker": stage_name} if stage_name == "thinker" else {}
+
+
+def test_pd_rewrite_assigns_input_to_prefill_and_output_to_decode() -> None:
+    config = _config()
+    expansion = expand_pd_stages(
+        list(config.stages), entry_stage=config.resolved_entry_stage
+    )
+    stages = {item.name: item for item in expansion.stages}
+
+    assert [item.name for item in expansion.stages] == [
+        "pre",
+        "thinker_prefill",
+        "thinker_decode",
+        "post",
+        "sink",
+    ]
+    assert stages["pre"].next == "thinker_prefill"
+    assert stages["thinker_prefill"].wait_for == ["pre"]
+    assert stages["thinker_prefill"].next is None
+    assert stages["thinker_prefill"].stream_to == []
+    assert stages["thinker_decode"].wait_for is None
+    assert stages["thinker_decode"].next == "post"
+    assert stages["thinker_decode"].stream_to == ["sink"]
+    assert stages["thinker_decode"].route_fn == fake_factory_path("identity_route")
+    assert stages["thinker_prefill"].pd_execution == PDExecution(
+        role="prefill", partner="thinker_decode"
+    )
+    assert stages["thinker_decode"].pd_execution == PDExecution(
+        role="decode", partner="thinker_prefill"
+    )
+    assert "thinker_decode" not in (stages["thinker_prefill"].next or [])
+
+
+def test_pd_rewrite_is_idempotent_and_non_pd_is_unchanged() -> None:
+    config = _config()
+    once = expand_pd_stages(
+        list(config.stages), entry_stage=config.resolved_entry_stage
+    )
+    twice = expand_pd_stages(once.stages, entry_stage=once.entry_stage)
+    assert twice.stages == once.stages
+    assert twice.entry_stage == once.entry_stage
+    assert twice.routing_map == once.routing_map
+    assert twice.output_map == once.output_map
+
+    plain = PipelineConfig(
+        model_path="model",
+        stages=[stage("one", next="two"), stage("two", terminal=True)],
+    )
+    unchanged = expand_pd_stages(
+        list(plain.stages), entry_stage=plain.resolved_entry_stage
+    )
+    assert unchanged.stages == plain.stages
+    assert unchanged.entry_stage == "one"
+
+
+def test_logical_pd_entry_and_terminal_identity_belong_to_role_halves() -> None:
+    config = PipelineConfig(
+        model_path="model",
+        entry_stage="thinker",
+        stages=[
+            stage(
+                "thinker",
+                factory_path=fake_factory_path("make_pd_scheduler"),
+                terminal=True,
+                pd_disaggregation=_pd(),
+            )
+        ],
+    )
+    expansion = expand_pd_stages(
+        list(config.stages), entry_stage=config.resolved_entry_stage
+    )
+
+    assert expansion.entry_stage == "thinker_prefill"
+    assert [item.name for item in expansion.stages if item.terminal] == [
+        "thinker_decode"
+    ]
+    assert expansion.stages[0].next is None
+
+
+def test_runtime_prep_maps_entry_terminal_and_output_sources(tmp_path) -> None:
+    config = _config()
+    config.endpoints.base_path = str(tmp_path)
+    prep = prepare_pipeline_runtime(config)
+    try:
+        assert prep.entry_stage == "pre"
+        assert prep.name_map["thinker"] == "thinker_prefill"
+        assert prep.source_name_map["thinker"] == "thinker_decode"
+        assert {item.name for item in prep.stages_cfg} == {
+            "pre",
+            "thinker_prefill",
+            "thinker_decode",
+            "post",
+            "sink",
+        }
+        assert "thinker_decode" not in prep.terminal_stages
+    finally:
+        prep.runtime_dir.close()
+
+
+def test_compiled_specs_construct_concrete_scheduler_types(tmp_path) -> None:
+    config = _config()
+    config.endpoints.base_path = str(tmp_path)
+    prep = prepare_pipeline_runtime(config)
+    try:
+        groups = _build_stage_groups(
+            config,
+            stages_cfg=prep.stages_cfg,
+            endpoints=prep.endpoints,
+            placement_plan=prep.placement_plan,
+            process_plan=prep.process_plan,
+            name_map=prep.name_map,
+            source_name_map=prep.source_name_map,
+            replica_topology=prep.replica_topology,
+        )
+        specs = {
+            spec.stage_name: spec
+            for group in groups
+            for process in group.process_specs
+            for spec in process.stage_specs
+        }
+        prefill = stage_workers._construct_scheduler(
+            specs["thinker_prefill"], None, logging.getLogger(__name__)
+        )
+        decode = stage_workers._construct_scheduler(
+            specs["thinker_decode"], None, logging.getLogger(__name__)
+        )
+        plain = stage_workers._construct_scheduler(
+            specs["pre"], None, logging.getLogger(__name__)
+        )
+        assert type(prefill) is OmniPrefillScheduler
+        assert type(decode) is OmniDecodeScheduler
+        assert prefill.factory_observed_type is OmniPrefillScheduler
+        assert decode.factory_observed_type is OmniDecodeScheduler
+        assert not isinstance(plain, OmniScheduler)
+        assert prefill.factory_kwargs["partner_stage"] == "thinker_decode"
+        assert decode.factory_kwargs["partner_stage"] == "thinker_prefill"
+        assert prefill.factory_kwargs["logical_marker"] == "thinker"
+        assert decode.factory_kwargs["logical_marker"] == "thinker"
+    finally:
+        prep.runtime_dir.close()
+
+
+def test_stage_receives_scheduler_after_factory_selected_final_type(
+    monkeypatch,
+) -> None:
+    captured = {}
+
+    class _Stage:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(stage_workers, "Stage", _Stage)
+    spec = StageLaunchConfig(
+        stage_name="thinker_prefill",
+        factory=fake_factory_path("make_pd_scheduler"),
+        pd_execution=PDExecution(role="prefill", partner="thinker_decode"),
+    )
+    stage_workers._construct_stage(spec, logging.getLogger(__name__))
+
+    assert type(captured["scheduler"]) is OmniPrefillScheduler
+    assert captured["kv_registrations"] == ()
+
+
+def test_concrete_scheduler_types_isolate_role_state() -> None:
+    assert not hasattr(OmniScheduler, "_handoff_prefilled_requests")
+    assert not hasattr(OmniScheduler, "_drain_decode_admissions")
+    assert hasattr(OmniPrefillScheduler, "_handoff_prefilled_requests")
+    assert not hasattr(OmniPrefillScheduler, "_drain_decode_admissions")
+    assert hasattr(OmniDecodeScheduler, "_drain_decode_admissions")
+    assert not hasattr(OmniDecodeScheduler, "_handoff_prefilled_requests")
+    assert "_pd_role" not in OmniScheduler.__dict__
+
+
+def test_pd_factory_wrong_type_and_missing_capability_fail_at_startup(tmp_path) -> None:
+    wrong = StageLaunchConfig(
+        stage_name="thinker_decode",
+        factory=fake_factory_path("make_wrong_pd_scheduler"),
+        pd_execution=PDExecution(role="decode", partner="thinker_prefill"),
+    )
+    with pytest.raises(TypeError, match="expected OmniDecodeScheduler"):
+        stage_workers._construct_scheduler(wrong, None, logging.getLogger(__name__))
+
+    config = _config(factory="make_scheduler")
+    config.endpoints.base_path = str(tmp_path)
+    with pytest.raises(ValueError, match="has not declared PD support"):
+        prepare_pipeline_runtime(config)
+
+
+@pytest.mark.parametrize(
+    "pd,message",
+    [
+        (PDConfig(prefill=PDStagePlacement(gpu=0)), "requires explicit"),
+        (
+            PDConfig(
+                prefill=PDStagePlacement(gpu=0),
+                decode=PDStagePlacement(gpu=0),
+            ),
+            "cannot share",
+        ),
+    ],
+)
+def test_invalid_pd_placement_fails_in_config(pd, message) -> None:
+    with pytest.raises(ValueError, match=message):
+        PipelineConfig(
+            model_path="model",
+            stages=[stage("thinker", terminal=True, pd_disaggregation=pd)],
+        )

--- a/tests/unit_test/pipeline/test_pd_utils.py
+++ b/tests/unit_test/pipeline/test_pd_utils.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import queue
+import threading
+from array import array
+from types import SimpleNamespace
+
+import torch
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.sampling.sampling_params import SamplingParams
+
+from sglang_omni.comm import KVPageTransfer
+from sglang_omni.pipeline.stage.runtime import Stage
+from sglang_omni.proto import (
+    KVBufferSpec,
+    KVPoolLayout,
+    KVTransferPrepareMessage,
+    OmniRequest,
+    StagePayload,
+)
+from sglang_omni.scheduling.pd_utils import (
+    DecodeAdmission,
+    DecodeContinuation,
+    DecodeKVReceiver,
+    ReservedKV,
+    continuation_from_req,
+    defer_first_token_finish,
+    req_from_continuation,
+)
+from sglang_omni.scheduling.sglang_backend.request_data import SGLangARRequestData
+
+
+class _ReqPool:
+    def __init__(self, capacity: int = 4) -> None:
+        self.capacity = capacity
+        self.req_to_token = torch.zeros((capacity, 32), dtype=torch.int64)
+        self.active: dict[int, Req] = {}
+
+    @property
+    def size(self) -> int:
+        return self.capacity
+
+    def alloc(self, reqs):
+        if len(self.active) + len(reqs) > self.capacity:
+            return None
+        indices = []
+        for req in reqs:
+            index = next(i for i in range(self.capacity) if i not in self.active)
+            req.req_pool_idx = index
+            self.active[index] = req
+            indices.append(index)
+        return torch.tensor(indices, dtype=torch.int64)
+
+    def write(self, key, value) -> None:
+        self.req_to_token[key] = value
+
+    def free(self, req) -> None:
+        self.active.pop(req.req_pool_idx, None)
+        req.req_pool_idx = None
+
+
+class _KVAllocator:
+    def __init__(self) -> None:
+        self.next_slot = 7
+        self.freed = []
+
+    def available_size(self) -> int:
+        return 32
+
+    def alloc(self, count: int):
+        slots = torch.arange(self.next_slot, self.next_slot + count)
+        self.next_slot += count
+        return slots
+
+    def free(self, slots) -> None:
+        self.freed.append(slots)
+
+
+def _prefill_req(*, max_new_tokens: int = 16) -> Req:
+    sampling = SamplingParams(
+        max_new_tokens=max_new_tokens,
+        temperature=0.7,
+        top_p=0.9,
+        stop_token_ids={2},
+        sampling_seed=17,
+    )
+    sampling.normalize(None)
+    req = Req(
+        rid="request-1",
+        origin_input_text="",
+        origin_input_ids=array("q", [10, 11, 12]),
+        sampling_params=sampling,
+        vocab_size=128,
+        eos_token_ids={2},
+    )
+    req.output_ids.append(42)
+    payload = StagePayload(
+        request_id=req.rid,
+        request=OmniRequest(inputs=None, params={"stream": True}),
+        data={"prompt": [10, 11, 12]},
+    )
+    req._omni_data = SGLangARRequestData(
+        input_ids=torch.tensor([10, 11, 12]),
+        output_ids=req.output_ids,
+        req=req,
+        stage_payload=payload,
+    )
+    return req
+
+
+def _state_builder(req):
+    return req._omni_data.stage_payload.to_dict(), None, list(req.origin_input_ids)
+
+
+def _continuation() -> DecodeContinuation:
+    return continuation_from_req(_prefill_req(), "transfer-1", _state_builder)
+
+
+def _allocation() -> ReservedKV:
+    slots = torch.tensor([7, 8, 9], dtype=torch.int64)
+    return ReservedKV(slots=slots, page_indices=(7, 8, 9), seq_len=3)
+
+
+def test_continuation_round_trip_rebuilds_prebuilt_request() -> None:
+    continuation = DecodeContinuation.decode(_continuation().encode())
+    req = req_from_continuation(
+        continuation,
+        _allocation(),
+        req_to_token_pool=_ReqPool(),
+        state_restorer=lambda req, _data, _resume: setattr(req, "tokenizer", None),
+    )
+
+    assert list(req.origin_input_ids) == [10, 11, 12]
+    assert list(req.output_ids) == [42]
+    assert req.sampling_params.stop_token_ids == {2}
+    assert req.prefix_indices.tolist() == [7, 8, 9]
+    assert req.kv.kv_allocated_len == 3
+
+
+def test_decode_receiver_commits_directly_to_admission_queue() -> None:
+    admissions = queue.SimpleQueue()
+    receiver = DecodeKVReceiver(
+        pool_id="decode:kv",
+        allocator=_KVAllocator(),
+        admissions=admissions,
+        resume_schema="test-v1",
+    )
+    continuation = _continuation()
+    message = KVTransferPrepareMessage(
+        request_id=continuation.request_id,
+        transfer_id=continuation.transfer_id,
+        from_stage="prefill",
+        to_stage="decode",
+        source_pool_id="prefill:kv",
+        target_pool_id="decode:kv",
+        source_page_indices=(1, 2, 3),
+        source_layout=KVPoolLayout(
+            layout_id="test",
+            page_size=1,
+            buffers=(KVBufferSpec("kv", 4),),
+        ),
+        metadata={"decode_continuation": continuation.encode()},
+    )
+
+    destination = receiver.reserve(message)
+    receiver.commit(message, destination)
+
+    admission = admissions.get_nowait()
+    assert admission.continuation.request_id == "request-1"
+    assert admission.allocation.page_indices == destination.page_indices
+
+
+def test_prefill_defers_first_token_stop_policy_to_decode() -> None:
+    req = _prefill_req(max_new_tokens=1)
+    del req.output_ids[:]
+    original_max = req.sampling_params.max_new_tokens
+
+    with defer_first_token_finish([req]):
+        req.output_ids.append(2)
+        req.update_finish_state()
+        assert not req.finished()
+
+    assert req.sampling_params.max_new_tokens == original_max
+    req.update_finish_state()
+    assert req.finished()
+
+
+def test_decode_scheduler_admits_committed_request_without_controller(
+    monkeypatch,
+) -> None:
+    from sglang.srt import runtime_context
+
+    monkeypatch.setattr(runtime_context, "get_model", lambda: None, raising=False)
+    monkeypatch.setattr(runtime_context, "get_serving", lambda: None, raising=False)
+    from sglang_omni.scheduling.pd_scheduler import OmniDecodeScheduler
+
+    scheduler = object.__new__(OmniDecodeScheduler)
+    scheduler._pd_admissions = queue.SimpleQueue()
+    scheduler._pd_admissions.put(DecodeAdmission(_continuation(), _allocation()))
+    scheduler._pd_deferred_admission = None
+    scheduler._pd_admission_lock = threading.Lock()
+    scheduler._pd_state_restorer = lambda req, _data, _resume: setattr(
+        req, "tokenizer", None
+    )
+    scheduler._aborted_request_ids = set()
+    scheduler.req_to_token_pool = _ReqPool()
+    scheduler.token_to_kv_pool_allocator = _KVAllocator()
+    scheduler.waiting_queue = []
+    scheduler.outbox = queue.Queue()
+    scheduler.is_entry_rank = True
+
+    scheduler._drain_decode_admissions()
+
+    assert [req.rid for req in scheduler.waiting_queue] == ["request-1"]
+    assert scheduler.outbox.get_nowait().type == "admitted"
+
+
+def test_discarded_stage_transfer_releases_source_lease() -> None:
+    released = []
+    lease = SimpleNamespace(release=lambda: released.append(True))
+    transfer = KVPageTransfer(
+        request_id="request-1",
+        transfer_id="transfer-1",
+        source_pool_id="prefill:kv",
+        target_pool_id="decode:kv",
+        source_page_indices=(1,),
+        to_stage="decode",
+        lease=lease,
+    )
+
+    Stage._discard_kv_transfer(transfer)
+
+    assert released == [True]

--- a/tests/unit_test/pipeline/test_pd_utils.py
+++ b/tests/unit_test/pipeline/test_pd_utils.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import queue
 import threading
 from array import array
+from dataclasses import replace
 from types import SimpleNamespace
 
+import msgspec
+import pytest
 import torch
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.sampling.sampling_params import SamplingParams
@@ -62,14 +66,17 @@ class _ReqPool:
 
 
 class _KVAllocator:
-    def __init__(self) -> None:
+    def __init__(self, *, available: int = 32) -> None:
         self.next_slot = 7
+        self.available = available
+        self.alloc_calls = 0
         self.freed = []
 
     def available_size(self) -> int:
-        return 32
+        return self.available
 
     def alloc(self, count: int):
+        self.alloc_calls += 1
         slots = torch.arange(self.next_slot, self.next_slot + count)
         self.next_slot += count
         return slots
@@ -123,6 +130,41 @@ def _allocation() -> ReservedKV:
     return ReservedKV(slots=slots, page_indices=(7, 8, 9), seq_len=3)
 
 
+def _message(
+    continuation: DecodeContinuation | None = None,
+    *,
+    request_id: str | None = None,
+    transfer_id: str | None = None,
+) -> KVTransferPrepareMessage:
+    continuation = continuation or _continuation()
+    if transfer_id is not None:
+        continuation = replace(continuation, transfer_id=transfer_id)
+    return KVTransferPrepareMessage(
+        request_id=request_id or continuation.request_id,
+        transfer_id=transfer_id or continuation.transfer_id,
+        from_stage="prefill",
+        to_stage="decode",
+        source_pool_id="prefill:kv",
+        target_pool_id="decode:kv",
+        source_page_indices=(1, 2, 3),
+        source_layout=KVPoolLayout(
+            layout_id="test",
+            page_size=1,
+            buffers=(KVBufferSpec("kv", 4),),
+        ),
+        metadata={"decode_continuation": continuation.encode()},
+    )
+
+
+def _receiver(allocator=None, admissions=None) -> DecodeKVReceiver:
+    return DecodeKVReceiver(
+        pool_id="decode:kv",
+        allocator=allocator or _KVAllocator(),
+        admissions=admissions or queue.SimpleQueue(),
+        allowed_resume_schemas=frozenset({"test-v1"}),
+    )
+
+
 def test_continuation_round_trip_rebuilds_prebuilt_request() -> None:
     continuation = DecodeContinuation.decode(_continuation().encode())
     req = req_from_continuation(
@@ -141,28 +183,9 @@ def test_continuation_round_trip_rebuilds_prebuilt_request() -> None:
 
 def test_decode_receiver_commits_directly_to_admission_queue() -> None:
     admissions = queue.SimpleQueue()
-    receiver = DecodeKVReceiver(
-        pool_id="decode:kv",
-        allocator=_KVAllocator(),
-        admissions=admissions,
-        resume_schema="test-v1",
-    )
+    receiver = _receiver(admissions=admissions)
     continuation = _continuation()
-    message = KVTransferPrepareMessage(
-        request_id=continuation.request_id,
-        transfer_id=continuation.transfer_id,
-        from_stage="prefill",
-        to_stage="decode",
-        source_pool_id="prefill:kv",
-        target_pool_id="decode:kv",
-        source_page_indices=(1, 2, 3),
-        source_layout=KVPoolLayout(
-            layout_id="test",
-            page_size=1,
-            buffers=(KVBufferSpec("kv", 4),),
-        ),
-        metadata={"decode_continuation": continuation.encode()},
-    )
+    message = _message(continuation)
 
     destination = receiver.reserve(message)
     receiver.commit(message, destination)
@@ -233,3 +256,424 @@ def test_discarded_stage_transfer_releases_source_lease() -> None:
     Stage._discard_kv_transfer(transfer)
 
     assert released == [True]
+
+
+def test_continuation_rejects_unknown_version_keys_and_id_mismatch() -> None:
+    encoded = _continuation().encode()
+    values = msgspec.msgpack.decode(encoded)
+    values["version"] = 99
+    with pytest.raises(ValueError, match="unsupported decode continuation version"):
+        DecodeContinuation.decode(msgspec.msgpack.encode(values))
+
+    values["version"] = 1
+    values["future_field"] = True
+    with pytest.raises(ValueError, match="unknown decode continuation fields"):
+        DecodeContinuation.decode(msgspec.msgpack.encode(values))
+
+    allocator = _KVAllocator()
+    with pytest.raises(ValueError, match="ids differ"):
+        _receiver(allocator=allocator).reserve(_message(request_id="another-request"))
+    assert allocator.alloc_calls == 0
+
+
+@pytest.mark.parametrize(
+    "update,message",
+    [
+        ({"request_id": ""}, "ids must be non-empty"),
+        ({"transfer_id": ""}, "ids must be non-empty"),
+        ({"output_ids": []}, "requires the Prefill token"),
+        ({"vocab_size": 0}, "vocab_size must be positive"),
+    ],
+)
+def test_continuation_rejects_missing_boundary_state(update, message) -> None:
+    values = msgspec.msgpack.decode(_continuation().encode())
+    values.update(update)
+    with pytest.raises(ValueError, match=message):
+        DecodeContinuation.decode(msgspec.msgpack.encode(values))
+
+
+def test_receiver_rejects_unsupported_resume_schema_before_allocation() -> None:
+    allocator = _KVAllocator()
+    continuation = replace(
+        _continuation(),
+        multimodal_resume={"schema": "future"},
+    )
+    with pytest.raises(ValueError, match="unsupported multimodal resume schema"):
+        _receiver(allocator=allocator).reserve(_message(continuation))
+    assert allocator.alloc_calls == 0
+
+
+def test_pd_runtime_rejects_speculative_scheduler_at_construction(monkeypatch) -> None:
+    from sglang.srt import runtime_context
+
+    monkeypatch.setattr(runtime_context, "get_model", lambda: None, raising=False)
+    monkeypatch.setattr(runtime_context, "get_serving", lambda: None, raising=False)
+    from sglang_omni.scheduling.pd_scheduler import _validate_pd_runtime
+
+    scheduler = SimpleNamespace(
+        tp_size=1,
+        page_size=1,
+        server_args=SimpleNamespace(disable_radix_cache=True),
+        spec_algorithm=SimpleNamespace(is_none=lambda: False),
+    )
+    with pytest.raises(NotImplementedError, match="speculative decoding"):
+        _validate_pd_runtime(scheduler)
+
+
+@pytest.mark.parametrize(
+    "field,value,message",
+    [
+        ("json_schema", "{}", "structured-output"),
+        ("regex", ".*", "structured-output"),
+        ("ebnf", "root", "structured-output"),
+        ("structural_tag", "tag", "structured-output"),
+    ],
+)
+def test_prefill_rejects_unsupported_sampling_before_state_projection(
+    field, value, message
+) -> None:
+    req = _prefill_req()
+    setattr(req.sampling_params, field, value)
+    called = []
+    with pytest.raises(NotImplementedError, match=message):
+        continuation_from_req(
+            req,
+            "transfer",
+            lambda _req: called.append(True),
+        )
+    assert called == []
+
+
+def test_prefill_rejects_custom_logits_projected_inputs_and_bad_sampling_state() -> (
+    None
+):
+    req = _prefill_req()
+    req.custom_logit_processor = "processor"
+    with pytest.raises(NotImplementedError, match="custom logit"):
+        continuation_from_req(req, "transfer", _state_builder)
+
+    req = _prefill_req()
+    req._omni_data.input_embeds_are_projected = True
+    with pytest.raises(NotImplementedError, match="projected input"):
+        continuation_from_req(req, "transfer", _state_builder)
+
+    req = _prefill_req()
+    req.sampling_params.custom_params = {"bad": object()}
+    with pytest.raises(ValueError, match="sampling state is not serializable"):
+        continuation_from_req(req, "transfer", _state_builder)
+
+
+def test_receiver_duplicate_commit_mismatch_abort_and_close_free_exactly_once() -> None:
+    allocator = _KVAllocator()
+    admissions = queue.SimpleQueue()
+    receiver = _receiver(allocator=allocator, admissions=admissions)
+    message = _message()
+    destination = receiver.reserve(message)
+
+    with pytest.raises(RuntimeError, match="duplicate KV transfer"):
+        receiver.reserve(message)
+    assert allocator.alloc_calls == 1
+
+    wrong = type(destination)(destination.pool_id, (99, 98, 97))
+    with pytest.raises(RuntimeError, match="does not match"):
+        receiver.commit(message, wrong)
+    assert len(allocator.freed) == 1
+    receiver.abort(message, destination, RuntimeError("late"))
+    assert len(allocator.freed) == 1
+
+    second = _message(transfer_id="transfer-2")
+    receiver.reserve(second)
+    receiver.abort(second, None, RuntimeError("receive failed"))
+    receiver.abort(second, None, RuntimeError("duplicate abort"))
+    assert len(allocator.freed) == 2
+
+    wrong_pool = _message(transfer_id="transfer-wrong-pool")
+    reserved = receiver.reserve(wrong_pool)
+    wrong_destination = type(reserved)("another-pool", reserved.page_indices)
+    with pytest.raises(RuntimeError, match="does not match"):
+        receiver.commit(wrong_pool, wrong_destination)
+    assert len(allocator.freed) == 3
+
+    third = _message(transfer_id="transfer-3")
+    receiver.reserve(third)
+    receiver.close()
+    receiver.close()
+    assert len(allocator.freed) == 4
+    with pytest.raises(RuntimeError, match="receiver is closed"):
+        receiver.reserve(_message(transfer_id="transfer-4"))
+    assert allocator.alloc_calls == 4
+
+
+def test_receiver_commit_transfers_ownership_to_admission() -> None:
+    allocator = _KVAllocator()
+    admissions = queue.SimpleQueue()
+    receiver = _receiver(allocator=allocator, admissions=admissions)
+    message = _message()
+    destination = receiver.reserve(message)
+    receiver.commit(message, destination)
+    receiver.abort(message, destination, RuntimeError("late"))
+    receiver.close()
+
+    admission = admissions.get_nowait()
+    assert admission.allocation.page_indices == destination.page_indices
+    assert allocator.freed == []
+
+
+def test_decode_pool_exhaustion_defers_without_losing_committed_kv(monkeypatch) -> None:
+    from sglang.srt import runtime_context
+
+    monkeypatch.setattr(runtime_context, "get_model", lambda: None, raising=False)
+    monkeypatch.setattr(runtime_context, "get_serving", lambda: None, raising=False)
+    from sglang_omni.scheduling.pd_scheduler import OmniDecodeScheduler
+
+    req_pool = _ReqPool(capacity=0)
+    allocator = _KVAllocator()
+    admission = DecodeAdmission(_continuation(), _allocation())
+    scheduler = object.__new__(OmniDecodeScheduler)
+    scheduler._pd_admissions = queue.SimpleQueue()
+    scheduler._pd_admissions.put(admission)
+    scheduler._pd_deferred_admission = None
+    scheduler._pd_admission_lock = threading.Lock()
+    scheduler._pd_state_restorer = lambda req, _data, _resume: setattr(
+        req, "tokenizer", None
+    )
+    scheduler._aborted_request_ids = set()
+    scheduler.req_to_token_pool = req_pool
+    scheduler.token_to_kv_pool_allocator = allocator
+    scheduler.waiting_queue = []
+    scheduler.outbox = queue.Queue()
+    scheduler.is_entry_rank = True
+
+    scheduler._drain_decode_admissions()
+    scheduler._drain_decode_admissions()
+    assert scheduler._pd_deferred_admission is admission
+    assert allocator.freed == []
+
+    req_pool.capacity = 1
+    req_pool.req_to_token = torch.zeros((1, 32), dtype=torch.int64)
+    scheduler._drain_decode_admissions()
+    assert scheduler._pd_deferred_admission is None
+    assert [req.rid for req in scheduler.waiting_queue] == ["request-1"]
+    assert allocator.freed == []
+
+
+def test_aborted_committed_admission_and_invalid_restore_free_once(monkeypatch) -> None:
+    from sglang.srt import runtime_context
+
+    monkeypatch.setattr(runtime_context, "get_model", lambda: None, raising=False)
+    monkeypatch.setattr(runtime_context, "get_serving", lambda: None, raising=False)
+    from sglang_omni.scheduling.pd_scheduler import OmniDecodeScheduler
+
+    allocator = _KVAllocator()
+    scheduler = object.__new__(OmniDecodeScheduler)
+    scheduler._pd_admissions = queue.SimpleQueue()
+    scheduler._pd_admissions.put(DecodeAdmission(_continuation(), _allocation()))
+    scheduler._pd_deferred_admission = None
+    scheduler._pd_admission_lock = threading.Lock()
+    scheduler._pd_state_restorer = lambda req, data, resume: None
+    scheduler._aborted_request_ids = {"request-1"}
+    scheduler.req_to_token_pool = _ReqPool()
+    scheduler.token_to_kv_pool_allocator = allocator
+    scheduler.waiting_queue = []
+    scheduler.outbox = queue.Queue()
+    scheduler.is_entry_rank = True
+
+    scheduler._drain_decode_admissions()
+    scheduler._drain_decode_admissions()
+    assert len(allocator.freed) == 1
+
+    scheduler._aborted_request_ids.clear()
+    scheduler._pd_state_restorer = lambda req, data, resume: (_ for _ in ()).throw(
+        ValueError("bad resume")
+    )
+    scheduler._pd_admissions.put(DecodeAdmission(_continuation(), _allocation()))
+    scheduler._drain_decode_admissions()
+    assert len(allocator.freed) == 2
+    assert scheduler.outbox.get_nowait().type == "admitted"
+    assert scheduler.outbox.get_nowait().type == "error"
+
+
+def test_decode_shutdown_drains_receiver_deferred_and_queued_ownership(
+    monkeypatch,
+) -> None:
+    from sglang.srt import runtime_context
+
+    monkeypatch.setattr(runtime_context, "get_model", lambda: None, raising=False)
+    monkeypatch.setattr(runtime_context, "get_serving", lambda: None, raising=False)
+    from sglang_omni.scheduling.pd_scheduler import OmniDecodeScheduler
+
+    allocator = _KVAllocator()
+    scheduler = object.__new__(OmniDecodeScheduler)
+    scheduler._request_admission_lock = threading.Lock()
+    scheduler._pending_request_admissions = {}
+    scheduler._pd_admission_lock = threading.Lock()
+    scheduler._pd_deferred_admission = DecodeAdmission(_continuation(), _allocation())
+    scheduler._pd_admissions = queue.SimpleQueue()
+    scheduler._pd_admissions.put(DecodeAdmission(_continuation(), _allocation()))
+    scheduler.token_to_kv_pool_allocator = allocator
+    receiver_closed = []
+    scheduler._pd_receiver = SimpleNamespace(close=lambda: receiver_closed.append(True))
+
+    scheduler._discard_pending_request_admissions()
+    scheduler._discard_pending_request_admissions()
+
+    assert receiver_closed == [True, True]
+    assert len(allocator.freed) == 2
+
+
+def test_prefill_queues_one_real_token_handoff_and_source_lease_is_idempotent(
+    monkeypatch,
+) -> None:
+    from sglang.srt import runtime_context
+
+    monkeypatch.setattr(runtime_context, "get_model", lambda: None, raising=False)
+    monkeypatch.setattr(runtime_context, "get_serving", lambda: None, raising=False)
+    from sglang_omni.scheduling.pd_scheduler import OmniPrefillScheduler
+
+    released = []
+    monkeypatch.setattr(
+        "sglang.srt.mem_cache.common.release_kv_cache",
+        lambda req, tree: released.append((req.rid, tree)),
+    )
+    req = _prefill_req(max_new_tokens=1)
+    req.req_pool_idx = 0
+    req.inflight_middle_chunks = 0
+    req_pool = _ReqPool()
+    req_pool.req_to_token[0, :3] = torch.tensor([3, 4, 5])
+    scheduler = object.__new__(OmniPrefillScheduler)
+    scheduler._pd_state_builder = _state_builder
+    scheduler._pd_stage_name = "thinker_prefill"
+    scheduler._pd_partner_stage = "thinker_decode"
+    scheduler._pd_pool_id = "thinker_prefill:kv"
+    scheduler.req_to_token_pool = req_pool
+    scheduler.tree_cache = "tree"
+    scheduler.outbox = queue.Queue()
+    batch = SimpleNamespace(reqs=[req], batch_is_full=True)
+
+    scheduler._handoff_prefilled_requests(batch, {id(req)})
+
+    message = scheduler.outbox.get_nowait()
+    transfer = message.data
+    continuation = DecodeContinuation.decode(transfer.metadata["decode_continuation"])
+    assert continuation.output_ids == [42]
+    assert transfer.source_page_indices == (3, 4, 5)
+    assert transfer.to_stage == "thinker_decode"
+    assert batch.reqs == []
+    assert req._omni_data is None
+    assert released == []
+
+    transfer.lease.release()
+    transfer.lease.release()
+    assert released == [("request-1", "tree")]
+
+
+def test_chunked_prefill_does_not_handoff_before_final_prefill_chunk(
+    monkeypatch,
+) -> None:
+    from sglang.srt import runtime_context
+
+    monkeypatch.setattr(runtime_context, "get_model", lambda: None, raising=False)
+    monkeypatch.setattr(runtime_context, "get_serving", lambda: None, raising=False)
+    from sglang_omni.scheduling.pd_scheduler import OmniPrefillScheduler
+
+    req = _prefill_req()
+    req.inflight_middle_chunks = 1
+    scheduler = object.__new__(OmniPrefillScheduler)
+    scheduler.outbox = queue.Queue()
+    batch = SimpleNamespace(reqs=[req], batch_is_full=False)
+
+    scheduler._handoff_prefilled_requests(batch, {id(req)})
+
+    assert batch.reqs == [req]
+    assert scheduler.outbox.empty()
+
+
+def test_slow_ack_does_not_block_an_unrelated_transfer() -> None:
+    async def run() -> None:
+        slow_ack = asyncio.Event()
+        completed = []
+
+        class _Comm:
+            async def send_kv_pages(self, *, request_id, lease, **kwargs):
+                del kwargs
+                try:
+                    if request_id == "slow":
+                        await slow_ack.wait()
+                    completed.append(request_id)
+                finally:
+                    lease.release()
+
+        stage = object.__new__(Stage)
+        stage._comm = _Comm()
+        stage._receive_tasks = set()
+        stage._clear_request_state = lambda request_id: completed.append(
+            f"clear:{request_id}"
+        )
+        stage._on_background_task_done = lambda task, context: None
+        releases = []
+
+        def transfer(request_id):
+            return KVPageTransfer(
+                request_id=request_id,
+                transfer_id=f"{request_id}-transfer",
+                source_pool_id="prefill:kv",
+                target_pool_id="decode:kv",
+                source_page_indices=(1,),
+                to_stage="decode",
+                lease=SimpleNamespace(release=lambda: releases.append(request_id)),
+            )
+
+        stage._launch_kv_transfer(transfer("slow"))
+        stage._launch_kv_transfer(transfer("fast"))
+        for _ in range(20):
+            if "clear:fast" in completed:
+                break
+            await asyncio.sleep(0)
+        assert "fast" in completed
+        assert "slow" not in completed
+        assert releases == ["fast"]
+
+        slow_ack.set()
+        await asyncio.gather(*tuple(stage._receive_tasks))
+        assert releases == ["fast", "slow"]
+
+    asyncio.run(run())
+
+
+def test_send_failure_releases_source_and_reports_request_failure() -> None:
+    async def run() -> None:
+        released = []
+        failures = []
+
+        class _Comm:
+            async def send_kv_pages(self, *, lease, **kwargs):
+                del kwargs
+                try:
+                    raise RuntimeError("copy failed")
+                finally:
+                    lease.release()
+
+        stage = object.__new__(Stage)
+        stage.name = "prefill"
+        stage._comm = _Comm()
+        stage._clear_request_state = lambda request_id: None
+
+        async def fail(request_id, error):
+            failures.append((request_id, error))
+
+        stage._send_failure = fail
+        transfer = KVPageTransfer(
+            request_id="request",
+            transfer_id="transfer",
+            source_pool_id="prefill:kv",
+            target_pool_id="decode:kv",
+            source_page_indices=(1,),
+            to_stage="decode",
+            lease=SimpleNamespace(release=lambda: released.append(True)),
+        )
+        await stage._send_kv_transfer(transfer)
+
+        assert released == [True]
+        assert failures == [("request", "copy failed")]
+
+    asyncio.run(run())

--- a/tests/unit_test/scheduling/test_engine_factory.py
+++ b/tests/unit_test/scheduling/test_engine_factory.py
@@ -560,3 +560,52 @@ def test_tts_engine_builder_base_scheduler_preserves_abort_with_extra_kwargs(
     assert captured_kwargs["tp_worker"] == "worker"
     assert captured_kwargs["request_builder"] == "request_builder"
     assert captured_kwargs["result_adapter"] == "result_adapter"
+
+
+def test_base_builder_exposes_concrete_scheduler_to_post_setup() -> None:
+    from sglang_omni.scheduling.engine_factory import SGLangGenerationEngineBuilder
+
+    observed: list[type] = []
+
+    class ConcreteScheduler:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+    class Builder(SGLangGenerationEngineBuilder):
+        model_name = "test"
+        context_length = 1
+
+        def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
+            del dtype
+            return {}
+
+        def make_adapters(self, model: Any) -> tuple[Any, Any]:
+            del model
+            return "request-builder", "result-adapter"
+
+        def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
+            return (model_worker, output_proc)
+
+        def post_scheduler_setup(self, scheduler: Any, model_runner: Any) -> None:
+            del model_runner
+            observed.append(type(scheduler))
+
+    builder = Builder()
+    scheduler, model_runner = builder._build_runtime(
+        model_worker="worker",
+        model="model",
+        output_proc="output",
+        tree_cache="tree",
+        req_to_token_pool="request-pool",
+        token_to_kv_pool_allocator="kv-pool",
+        server_args="server-args",
+        model_config="model-config",
+        scheduler_cls=ConcreteScheduler,
+        scheduler_construction_kwargs={"stage_name": "thinker_prefill"},
+    )
+    builder.post_scheduler_setup(scheduler, model_runner)
+
+    assert observed == [ConcreteScheduler]
+    assert scheduler.kwargs["stage_name"] == "thinker_prefill"
+    assert scheduler.kwargs["request_builder"] == "request-builder"
+    assert scheduler.kwargs["result_adapter"] == "result-adapter"


### PR DESCRIPTION
## Base PR

Base PR: #1773
Frozen head: `9b9a214559a6875b3b358532d8ad1a8646c9f13b`

## Failure timeline

`DecodeKVReceiver.reserve` runs on the comm event loop and calls `self._allocator.alloc(count)`. The scheduler thread allocates from the same object for decode steps and frees through the tree cache. Upstream's `TokenToKVPoolAllocator.alloc` is a read-modify-write with no lock:

```python
select_index = self.free_pages[:need_size]
self.free_pages = self.free_pages[need_size:]
return select_index
```

Two callers that interleave between the read and the write receive the same slots. Both requests write KV into those pages and the second overwrites the first, so the first request attends over another request's keys and values. `free` has the same shape, and racing it against `alloc` returns live slots to the free list.

Nothing raises. The request completes with a 200 and wrong text; throughput, latency and error rate all read normal.

The `threading.Lock` inside `DecodeKVReceiver` does not cover this. It guards the receiver's own reservation table, and the scheduler thread never takes it.

## Measurement

Instrumented run on two H200s with both `alloc` and `free` recorded, one 3,000-request run: **21,309 slots handed to one thread while the other still held them**, 13,166 recorded on `scheduler-thinker_decode` and 8,143 on `MainThread`. The same run produced 11 empty completions and within-request token duplication (`uniq_ok=False` on 6 of 11, against 1 of 75 in the control).

Reproducing it needs **mixed prompt lengths** — 42, 1150 and 4400 tokens in one stream. Six runs at a uniform long prompt never reproduced it, because equal allocation sizes and regular arrivals rarely put the two threads inside the window together.

Tracked as #1704.

## Design invariant

Every `alloc` and `free` for one KV pool goes through one synchronization domain, established before any request is served.

`_serialize_kv_allocation` wraps the allocator in `OmniDecodeScheduler.__init__` and rebinds every holder. `bootstrap.py` hands the same object to `create_tree_cache` before this scheduler exists, so rebinding only the scheduler's attribute would leave the tree cache calling an unwrapped alias.

Wrapping in `bootstrap.py` instead is not available: upstream's `SWAChunkCache.__init__` asserts the allocator's concrete type, and a proxy handed to that constructor fails the assert for models that use it. Rebinding after construction and before the receiver is built gives the same guarantee without touching that path.

A holder without the attribute raises rather than being skipped. `kv_allocator_holders` reports what was rebound, and a test asserts they are one object — that is what catches a third holder appearing.

## Alternative worth considering

Locking is the smaller change, not necessarily the right one. The alternative is to remove the second caller: have `reserve` hand its reservation to the scheduler thread, which already drains `_pd_admissions` every step, and return the destination once the scheduler has allocated. That restores upstream's single-threaded-allocator assumption instead of working around it, at the cost of one scheduler step of latency per handoff — about 7 ms at the TPOT we measure.

I did not take that route here because it changes the handoff's timing and backpressure behaviour, which deserves its own review. Happy to write it if you prefer it.

## Testing

| Run | Result |
| --- | --- |
| `test_pd_alloc_lock.py`, `test_pd_utils.py`, `test_kv_transfer.py` | 29 pass |
| `tests/unit_test` | 5324 pass, 11 fail |

The 11 failures are in `moss_tts/test_audio_tokenizer.py` (2), `qwen3_omni/test_audio_layer_graph.py` (4), `qwen3_omni/test_vision_compat.py` (1) and `qwen3_tts/test_compat.py` (4). All 11 fail identically on `9b9a2145` without this change, and none touch PD.

The cases cover: eight threads racing an allocator with upstream's read-modify-write shape never receive the same slot; reads, writes and other attributes delegate to the wrapped object; freeing returns the slots; every holder ends up with the same locked object; a holder that cannot be rebound raises; and a receiver built after the wrap holds the locked allocator rather than the raw one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
