### PR TITLE
fix: align Qwen3-ASR prompt and language sentinel

### DIFF
--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -57,6 +57,9 @@ _AUDIO_START = "<|audio_start|>"
 _AUDIO_PAD = "<|audio_pad|>"
 _AUDIO_END = "<|audio_end|>"
 _ASR_TEXT = "<asr_text>"
+# Qwen3-ASR's checkpoint chat template emits this empty system turn even
+# when no caller-provided system context is present.
+_SYSTEM_PROMPT = "<|im_start|>system\n<|im_end|>\n"
 
 
 @dataclass
@@ -127,7 +130,7 @@ def make_qwen3_asr_scheduler_adapters(
 
     @lru_cache(maxsize=None)
     def _prompt_parts(language: str | None) -> tuple[tuple[int, ...], tuple[int, ...]]:
-        prompt = (
+        prompt = _SYSTEM_PROMPT + (
             f"<|im_start|>user\n"
             f"{_AUDIO_START}{_AUDIO_PAD}{_AUDIO_END}"
             f"<|im_end|>\n"
@@ -407,6 +410,13 @@ def make_qwen3_asr_scheduler_adapters(
             label, separator, value = prefix.partition(" ")
             if separator and label.casefold() == "language":
                 detected_language = value.strip() or None
+                # The official parser treats this sentinel as unknown
+                # language (and leaves any transcript tail untouched).
+                if (
+                    detected_language is not None
+                    and detected_language.casefold() == "none"
+                ):
+                    detected_language = None
             elif prefix:
                 detected_language = prefix
         transcript_ids = (

--- a/tests/unit_test/qwen3_asr/test_request_builders.py
+++ b/tests/unit_test/qwen3_asr/test_request_builders.py
@@ -29,6 +29,13 @@ from sglang_omni.scheduling.types import DeferredAdmission
 from sglang_omni.utils import audio as audio_utils
 from sglang_omni.utils.audio import AudioDecodeError
 
+_EXPECTED_QWEN3_ASR_PROMPT_PREFIX = (
+    "<|im_start|>system\n<|im_end|>\n"
+    "<|im_start|>user\n"
+    "<|audio_start|><|audio_pad|><|audio_end|><|im_end|>\n"
+    "<|im_start|>assistant\n"
+)
+
 
 def _unwrap_built(
     result: Qwen3ASRRequestData | DeferredAdmission,
@@ -83,6 +90,7 @@ class _FakeTokenizer:
         )
         pieces = {
             10: "language English",
+            30: "language None",
             100: "<asr_text>",
             101: "",
             20: " leading",
@@ -258,7 +266,9 @@ def test_qwen3_asr_request_builder_uses_canonical_language_prompt(
 
     data = request_builder(payload)
 
-    assert tokenizer.call_texts[-1].endswith(f"language {expected_name}<asr_text>")
+    assert tokenizer.call_texts[-1] == (
+        _EXPECTED_QWEN3_ASR_PROMPT_PREFIX + f"language {expected_name}<asr_text>"
+    )
     assert data.language == expected_language
 
 
@@ -288,8 +298,7 @@ def test_qwen3_asr_request_builder_omits_language_prompt_for_auto_detection(
 
     data = request_builder(payload)
 
-    assert tokenizer.call_texts[-1].startswith("<|im_start|>user\n")
-    assert tokenizer.call_texts[-1].endswith("<|im_start|>assistant\n")
+    assert tokenizer.call_texts[-1] == _EXPECTED_QWEN3_ASR_PROMPT_PREFIX
     assert "<asr_text>" not in tokenizer.call_texts[-1]
     assert data.language is None
     assert data.req.vocab_size == len(tokenizer)
@@ -798,6 +807,38 @@ def test_qwen3_asr_result_adapter_decodes_without_text_round_trip() -> None:
         "skip_special_tokens": True,
         "clean_up_tokenization_spaces": False,
     }
+
+
+@pytest.mark.parametrize(
+    ("output_ids", "expected_text"),
+    [
+        ([30, 100, 101], ""),
+        ([30, 100, 101, 20], " leading"),
+    ],
+)
+def test_qwen3_asr_result_adapter_normalizes_none_language(
+    output_ids: list[int], expected_text: str
+) -> None:
+    tokenizer = _FakeTokenizer()
+    _, result_adapter = make_qwen3_asr_scheduler_adapters(
+        tokenizer=tokenizer,
+        max_new_tokens=32,
+        feature_extractor=object(),
+    )
+    payload = StagePayload(
+        request_id="req-asr-none-language",
+        request=OmniRequest(inputs={}),
+        data={},
+    )
+    data = Qwen3ASRRequestData(
+        output_ids=output_ids,
+        stage_payload=payload,
+    )
+
+    result = result_adapter(data)
+
+    assert result.data["text"] == expected_text
+    assert result.data["language"] is None
 
 
 def test_qwen3_asr_request_builder_encodes_after_offsets_are_final(

--- a/tests/unit_test/qwen3_asr/test_stream_output_builder.py
+++ b/tests/unit_test/qwen3_asr/test_stream_output_builder.py
@@ -137,6 +137,18 @@ def test_qwen3_asr_stream_suppresses_auto_detected_language_prefix() -> None:
     ]
 
 
+def test_qwen3_asr_stream_suppresses_none_language_sentinel() -> None:
+    tokenizer = _ByteTokenizer(
+        {1: b"language None", 2: b"<asr_text>"},
+        asr_text_token_ids=(2,),
+    )
+    builder = make_qwen3_asr_stream_output_builder(tokenizer=tokenizer)
+    req_data = _make_req_data(language=None)
+
+    assert builder("r", req_data, _make_req_output(1)) == []
+    assert builder("r", req_data, _make_req_output(2)) == []
+
+
 def test_qwen3_asr_auto_language_stream_flushes_transcript_tail() -> None:
     tokenizer = _ByteTokenizer(
         {1: b"language English", 2: b"<asr_text>", 3: b"A", 4: b"B"},


### PR DESCRIPTION
## Summary

Align Qwen3-ASR prompt construction and auto-language result handling with the official checkpoint behavior.

## Implementation

- Include the checkpoint's empty `system` turn before the audio `user` turn.
- Normalize `language None` to an unknown language instead of exposing it as a literal language name.
- Preserve any transcript tail after the sentinel and cover non-streaming/streaming regressions.

This is a shared Qwen3-ASR path change and applies to CUDA, MLX, and Torch MPS backends.

## Tests

- `pytest -q tests/unit_test/qwen3_asr tests/unit_test/models/qwen3_asr/test_mrope_fast_path.py tests/unit_test/serve/test_transcription_chunking.py` — 665 passed, 3 skipped
- `pre-commit run --all-files` — passed
- `git diff --check` — passed

## Origin

This issue was identified during independent Apple Silicon validation of [PR #1730](https://github.com/sgl-project/sglang-omni/pull/1730) by [@he749119-source](https://github.com/sgl-project/sglang-omni/pull/1730#issuecomment-5449056590). The report found that the official Qwen3-ASR chat template emits an empty `system` turn before the audio `user` turn, while the shared Omni builder skipped it, and that `language None<asr_text>` could be exposed as a literal detected language. These are shared Qwen3-ASR path issues rather than Apple-only behavior.
