### PR TITLE
feat(pd): what the base needs before elastic placement and sizing sit on it

### DIFF
--- a/sglang_omni/config/pd_capability.py
+++ b/sglang_omni/config/pd_capability.py
@@ -27,3 +27,46 @@ def validate_pd_capabilities(stages: Iterable[StageConfig]) -> None:
                 f"Stage {stage.name!r} is PD-disaggregated, but factory "
                 f"{stage.factory_path!r} has not declared PD support"
             )
+
+
+# Note (Audrey Zheng): what a PD half cannot do yet. The scheduler enforces
+# these in its constructor (`_validate_pd_runtime`), which is the last
+# possible moment -- the model has loaded and the pipeline is half up before
+# anyone learns the config was never going to work. Check them where the
+# config is read instead, and name the stage.
+#
+# These are temporary. Each one names what has to be built, so that lifting
+# it is a deletion here rather than a search.
+_PD_UNSUPPORTED_ENGINE_ARGS: tuple[tuple[str, Any, str], ...] = (
+    (
+        "page_size",
+        1,
+        "the KV handoff addresses one page per token; see request_page_indices",
+    ),
+    (
+        "disable_radix_cache",
+        True,
+        "a shared prefix makes the handed-off pages not solely this request's",
+    ),
+)
+
+
+def validate_pd_engine_args(stages: Iterable[StageConfig]) -> None:
+    """Reject a PD config the runtime is going to refuse anyway.
+
+    Applying these silently instead would be worse: an operator who asked for
+    `page_size=32` would get 1 without being told, and would keep getting it
+    after the restriction is lifted.
+    """
+    for stage in stages:
+        if stage.pd_execution is None or stage.engine is None:
+            continue
+        for name, required, because in _PD_UNSUPPORTED_ENGINE_ARGS:
+            declared = getattr(stage.engine, name, None)
+            if declared is None or declared == required:
+                continue
+            raise ValueError(
+                f"Stage {stage.name!r} is PD-disaggregated and declares "
+                f"{name}={declared!r}, but PD currently requires {required!r}: "
+                f"{because}"
+            )

--- a/sglang_omni/config/pd_rewrite.py
+++ b/sglang_omni/config/pd_rewrite.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from sglang_omni.config.schema import PDExecution, StageConfig
+from sglang_omni.config.schema import EngineArgs, PDExecution, StageConfig
 
 
 @dataclass(frozen=True)
@@ -91,6 +91,34 @@ def _rewrite_refs(
     )
 
 
+def _half_memory_fraction(stage: StageConfig, placement) -> float | None:
+    """This half's share of its card.
+
+    `gpu_memory_fraction` on the logical stage describes one occupant. Copying
+    it to both halves would have each size itself against the whole card, and
+    `_validate_memory_budgets` sums declared fractions per GPU, so two halves
+    on one card would read as double. An explicit per-half share replaces it;
+    otherwise the logical value stands, which is right when the halves are on
+    separate cards.
+    """
+    if placement.memory_fraction is not None:
+        return placement.memory_fraction
+    return stage.gpu_memory_fraction
+
+
+def _half_engine(stage: StageConfig, placement) -> EngineArgs | None:
+    """The logical stage's engine arguments with this half's overrides on top.
+
+    The two halves want different settings: Prefill sizes batches for one
+    forward, Decode for many steps. Without an override they share whatever the
+    logical stage declared.
+    """
+    if not placement.engine:
+        return stage.engine
+    base = stage.engine if stage.engine is not None else EngineArgs()
+    return base.model_copy(update=dict(placement.engine))
+
+
 def _split(
     stage: StageConfig,
     inbound: dict[str, str],
@@ -106,6 +134,8 @@ def _split(
             "name": prefill_name,
             "gpu": pd.prefill.gpu,
             "process": pd.prefill.process or prefill_name,
+            "gpu_memory_fraction": _half_memory_fraction(stage, pd.prefill),
+            "engine": _half_engine(stage, pd.prefill),
             "next": None,
             "terminal": False,
             "route_fn": None,
@@ -118,7 +148,11 @@ def _split(
                 else stage.wait_for
             ),
             "pd_disaggregation": None,
-            "pd_execution": PDExecution(role="prefill", partner=decode_name),
+            "pd_execution": PDExecution(
+                role="prefill",
+                partner=decode_name,
+                decode_targets=(decode_name,),
+            ),
         },
     )
     decode = stage.model_copy(
@@ -127,6 +161,8 @@ def _split(
             "name": decode_name,
             "gpu": pd.decode.gpu,
             "process": pd.decode.process or decode_name,
+            "gpu_memory_fraction": _half_memory_fraction(stage, pd.decode),
+            "engine": _half_engine(stage, pd.decode),
             "next": _rename(stage.next, inbound),
             "stream_to": [inbound.get(name, name) for name in stage.stream_to],
             "project_payload": {

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -222,6 +222,17 @@ class PDStagePlacement(BaseModel):
 
     gpu: int | list[int] | None = None
     process: str | None = None
+    # Note (Audrey Zheng): this half's share of its card, as a fraction of
+    # total physical memory. Required when the halves share a GPU, because
+    # `gpu_memory_fraction` on the logical stage describes one occupant and
+    # copying it to both would have each half size itself against the whole
+    # card. Unlike `mem_fraction_static` it does not depend on which half wins
+    # the startup lock.
+    memory_fraction: float | None = Field(default=None, gt=0.0, le=1.0)
+    # Note (Audrey Zheng): engine arguments for this half alone. The two halves
+    # want different settings -- Prefill sizes batches for one forward, Decode
+    # for many steps -- and without this they share the logical stage's.
+    engine: dict[str, Any] = Field(default_factory=dict)
 
     def model_post_init(self, __context: Any = None) -> None:
         if self.process is not None:
@@ -253,6 +264,13 @@ class PDExecution(BaseModel):
 
     role: Literal["prefill", "decode"]
     partner: str = Field(min_length=1)
+    # Note (Audrey Zheng): the Decode halves this Prefill may hand off to. One
+    # entry today, and `partner` stays the name a 1:1 reader expects. Carrying
+    # a sequence means a second Decode half does not migrate this schema or
+    # change `OmniPrefillScheduler`'s signature, and the choice of which one
+    # receives a given request can move to admission without touching the send
+    # path. Empty means "just `partner`".
+    decode_targets: tuple[str, ...] = ()
 
 
 class StageConfig(BaseModel):
@@ -783,11 +801,33 @@ class PipelineConfig(BaseModel):
                     f"Stage {stage.name!r} pd_disaggregation requires explicit "
                     "prefill.gpu and decode.gpu"
                 )
+            # Note (Audrey Zheng): the halves may share a card. What PD needs
+            # is the process split, and that happens either way -- the prefill
+            # step leaves the decode scheduler thread whichever card it runs
+            # on. Sharing also makes PD runnable on a one-GPU box, which is
+            # what CI has, and it is the only shape in which the two halves can
+            # share one copy of the weights.
+            #
+            # It is only safe with explicit budgets. `_validate_memory_budgets`
+            # caps the sum of *declared* fractions, and `_build_gpu_placement`
+            # skips a None, so two undeclared halves on one card each size
+            # themselves against the whole of it: whichever wins the startup
+            # lock takes the memory and the other fails to start. Require both.
             if _pd_gpu_set(pd.prefill.gpu) & _pd_gpu_set(pd.decode.gpu):
-                raise ValueError(
-                    f"Stage {stage.name!r} pd_disaggregation prefill and decode "
-                    "cannot share the same GPU"
-                )
+                undeclared = [
+                    role
+                    for role, placement in (
+                        ("prefill", pd.prefill),
+                        ("decode", pd.decode),
+                    )
+                    if placement.memory_fraction is None
+                ]
+                if undeclared:
+                    raise ValueError(
+                        f"Stage {stage.name!r} pd_disaggregation puts both "
+                        f"halves on one GPU, so {' and '.join(undeclared)} "
+                        "must declare memory_fraction"
+                    )
             for role, placement in (("prefill", pd.prefill), ("decode", pd.decode)):
                 if (
                     isinstance(placement.gpu, list)

--- a/sglang_omni/pipeline/runtime_config.py
+++ b/sglang_omni/pipeline/runtime_config.py
@@ -12,7 +12,10 @@ from pathlib import Path
 
 import zmq
 
-from sglang_omni.config.pd_capability import validate_pd_capabilities
+from sglang_omni.config.pd_capability import (
+    validate_pd_capabilities,
+    validate_pd_engine_args,
+)
 from sglang_omni.config.pd_rewrite import expand_pd_stages
 from sglang_omni.config.placement import StagePlacementPlan, build_stage_placement_plan
 from sglang_omni.config.schema import PipelineConfig, StageConfig
@@ -129,6 +132,7 @@ def prepare_pipeline_runtime(
     expansion = expand_pd_stages(source_stages, entry_stage=entry_stage)
     entry_stage = expansion.entry_stage
     validate_pd_capabilities(expansion.stages)
+    validate_pd_engine_args(expansion.stages)
     terminal_stages = [stage.name for stage in expansion.stages if stage.terminal]
     expanded_config = config.model_copy(
         update={"stages": expansion.stages, "entry_stage": entry_stage}

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -842,6 +842,7 @@ def _construct_scheduler(
         factory_args["scheduler_kwargs"] = {
             "stage_name": spec.stage_name,
             "partner_stage": spec.pd_execution.partner,
+            "decode_targets": spec.pd_execution.decode_targets,
         }
 
     def construct() -> Any:

--- a/sglang_omni/scheduling/pd_alloc_lock.py
+++ b/sglang_omni/scheduling/pd_alloc_lock.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Serialize KV allocation between the two threads a Decode half runs.
+
+``TokenToKVPoolAllocator.alloc`` reads ``free_pages``, slices the leading
+entries, and writes the remainder back. Nothing in
+``sglang/srt/mem_cache/allocator`` holds a lock, which is correct while one
+thread owns the allocator.
+
+A PD Decode half has two. The scheduler thread allocates for decode steps.
+The comm event loop allocates inside ``prepare_kv_receive`` ->
+``DecodeKVReceiver.reserve``, which is handed the same allocator instance.
+Two callers that interleave between the read and the write receive the same
+slots.
+
+Measured on two H200s with both calls recorded: one 3,000-request run logged
+21,309 slots handed to one thread while the other still held them, and the
+requests that received them returned empty completions.
+
+This wraps the allocator so both callers take one lock. Everything else is
+delegated untouched, so the allocator's own behaviour is unchanged.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+
+class LockedKVAllocator:
+    """Delegate to *inner*, holding a lock across ``alloc`` and ``free``.
+
+    Only the two methods that mutate the free list are guarded. The lock is
+    uncontended on the scheduler thread except when a transfer is reserving,
+    so the cost on the decode path is one uncontended acquire per step.
+    """
+
+    def __init__(self, inner: Any) -> None:
+        # Note (Audrey Zheng): set through __dict__ because __setattr__ below
+        # forwards to the wrapped allocator.
+        self.__dict__["_inner"] = inner
+        self.__dict__["_alloc_lock"] = threading.Lock()
+
+    def alloc(self, need_size: int) -> Any:
+        with self.__dict__["_alloc_lock"]:
+            return self.__dict__["_inner"].alloc(need_size)
+
+    def free(self, free_index: Any) -> Any:
+        with self.__dict__["_alloc_lock"]:
+            return self.__dict__["_inner"].free(free_index)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.__dict__["_inner"], name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        setattr(self.__dict__["_inner"], name, value)
+
+    def __repr__(self) -> str:
+        return f"LockedKVAllocator({self.__dict__['_inner']!r})"

--- a/sglang_omni/scheduling/pd_decode_selection.py
+++ b/sglang_omni/scheduling/pd_decode_selection.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Choosing which Decode half receives one request's KV.
+
+This is a module-level function taking only values every Prefill rank sees
+identically, and that shape is the point. See `select_decode_stage`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+
+
+def select_decode_stage(targets: Sequence[str], request_id: str) -> str:
+    """Return the Decode stage that receives ``request_id``'s KV.
+
+    **Every Prefill rank runs this independently and they must agree.** The KV
+    send is rank-addressed: rank *i* sends its shard to the chosen stage's rank
+    *i* (`rank_endpoints[to_stage][tp_rank]` in `comm/engine.py`). At tp_size 1
+    there is one rank and agreement is trivial. Above that, two ranks choosing
+    differently scatter one request's shards across different Decode halves,
+    each of which then holds part of the KV and none of which holds all of it.
+
+    Nothing catches that. Each half admits on partial KV and attends over
+    whatever occupies the missing heads. The output is wrong and nothing says
+    so.
+
+    So the choice must be a pure function of values every rank sees
+    identically. ``request_id`` is one. Queue depth, in-flight counts, local
+    counters and arrival order are not: they are the natural ingredients of a
+    load-balancing policy and every one of them differs per rank.
+
+    That is why this takes ``targets`` and ``request_id`` rather than a
+    scheduler. Adding rank-local state means changing this signature, which is
+    the point at which someone has to think about the paragraph above.
+
+    A policy that needs global state -- least-loaded, or affinity to a cached
+    prefix -- has to be decided in one place and carried to the ranks, not
+    computed on each. The coordinator's admission binding for a replicated
+    process is exactly that shape and is the natural home for one.
+    """
+    if not targets:
+        raise ValueError("no decode targets to select from")
+    if len(targets) == 1:
+        return targets[0]
+    digest = hashlib.blake2b(request_id.encode("utf-8"), digest_size=8).digest()
+    return targets[int.from_bytes(digest, "big") % len(targets)]

--- a/sglang_omni/scheduling/pd_scheduler.py
+++ b/sglang_omni/scheduling/pd_scheduler.py
@@ -16,6 +16,7 @@ from sglang_omni.comm import KVPageTransfer
 from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler, _detach_request_data
 from sglang_omni.scheduling.pd_alloc_lock import LockedKVAllocator
+from sglang_omni.scheduling.pd_decode_selection import select_decode_stage
 from sglang_omni.scheduling.pd_utils import (
     DecodeKVReceiver,
     DecodeRequestPoolExhausted,
@@ -68,6 +69,7 @@ class OmniPrefillScheduler(OmniScheduler):
         *args,
         stage_name: str,
         partner_stage: str,
+        decode_targets: tuple[str, ...] = (),
         state_builder: Callable = default_state_builder,
         **kwargs,
     ) -> None:
@@ -76,6 +78,12 @@ class OmniPrefillScheduler(OmniScheduler):
 
         self._pd_stage_name = stage_name
         self._pd_partner_stage = partner_stage
+        # Note (Audrey Zheng): every Decode half this Prefill may send to.
+        # Sorted, because the KV send is rank-addressed: two Prefill ranks that
+        # disagree on the order would split one request's pages across
+        # different Decode halves, and nothing in the transfer path checks for
+        # it. Empty falls back to `partner`, which is 1:1.
+        self._pd_decode_targets = tuple(sorted(decode_targets)) or (partner_stage,)
         self._pd_state_builder = state_builder
         self._pd_pool_id = f"{stage_name}:kv"
         pool = build_kv_pool(
@@ -83,6 +91,15 @@ class OmniPrefillScheduler(OmniScheduler):
             pool_id=self._pd_pool_id,
         )
         self.kv_registrations = ((pool, None),)
+
+    def _resolve_decode_stage(self, req: Any) -> str:
+        """Return the Decode stage that receives this request's KV.
+
+        The choice lives in `select_decode_stage`, which takes only values
+        every Prefill rank sees identically. That constraint is not cosmetic --
+        read that function before changing the policy.
+        """
+        return select_decode_stage(self._pd_decode_targets, str(req.rid))
 
     def get_next_batch_to_run(self):
         if (
@@ -140,6 +157,7 @@ class OmniPrefillScheduler(OmniScheduler):
                 # Abort and invalid-token failures still terminalize locally.
                 continue
             try:
+                decode_stage = self._resolve_decode_stage(req)
                 transfer_id = f"{req.rid}:pd:{uuid4().hex}"
                 continuation = continuation_from_req(
                     req, transfer_id, self._pd_state_builder
@@ -148,11 +166,11 @@ class OmniPrefillScheduler(OmniScheduler):
                     request_id=req.rid,
                     transfer_id=transfer_id,
                     source_pool_id=self._pd_pool_id,
-                    target_pool_id=f"{self._pd_partner_stage}:kv",
+                    target_pool_id=f"{decode_stage}:kv",
                     source_page_indices=request_page_indices(
                         self.req_to_token_pool, req
                     ),
-                    to_stage=self._pd_partner_stage,
+                    to_stage=decode_stage,
                     metadata={"decode_continuation": continuation.encode()},
                     lease=SGLangKVLease(req, self.tree_cache),
                 )
@@ -184,9 +202,12 @@ class OmniDecodeScheduler(OmniScheduler):
         state_restorer: Callable = default_state_restorer,
         allowed_resume_schemas: frozenset[str] = frozenset(),
         partner_stage: str | None = None,
+        decode_targets: tuple[str, ...] = (),
         **kwargs,
     ) -> None:
-        del partner_stage
+        # The compiler hands both halves the same kwargs. A Decode half has no
+        # peer to choose, so it drops the two that describe one.
+        del partner_stage, decode_targets
         self._pd_admissions = queue.SimpleQueue()
         self._pd_deferred_admission = None
         self._pd_admission_lock = threading.Lock()

--- a/sglang_omni/scheduling/pd_scheduler.py
+++ b/sglang_omni/scheduling/pd_scheduler.py
@@ -15,6 +15,7 @@ from sglang.srt.managers.scheduler import Scheduler as _Upstream
 from sglang_omni.comm import KVPageTransfer
 from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler, _detach_request_data
+from sglang_omni.scheduling.pd_alloc_lock import LockedKVAllocator
 from sglang_omni.scheduling.pd_utils import (
     DecodeKVReceiver,
     DecodeRequestPoolExhausted,
@@ -193,6 +194,8 @@ class OmniDecodeScheduler(OmniScheduler):
         super().__init__(*args, **kwargs)
         _validate_pd_runtime(self)
 
+        _serialize_kv_allocation(self)
+
         pool_id = f"{stage_name}:kv"
         pool = build_kv_pool(
             self.token_to_kv_pool_allocator.get_kvcache(),
@@ -280,6 +283,61 @@ class OmniDecodeScheduler(OmniScheduler):
                 except queue.Empty:
                     return
                 self.token_to_kv_pool_allocator.free(admission.allocation.slots)
+
+
+# Note (Audrey Zheng): every object that allocates or frees from one KV pool.
+# `bootstrap.py` hands the same allocator to `create_tree_cache` before this
+# scheduler exists, so rebinding only our own attribute would leave the tree
+# cache calling an unwrapped alias.
+_KV_ALLOCATOR_HOLDERS = ("tree_cache",)
+
+
+def _serialize_kv_allocation(scheduler: OmniDecodeScheduler) -> None:
+    """Give every holder of the KV allocator the same locked object.
+
+    A Decode half allocates from two threads: this scheduler for decode steps
+    and the comm event loop through `DecodeKVReceiver.reserve`. Upstream's
+    `alloc` reads `free_pages`, slices it and writes the remainder back with no
+    lock, which is correct while one thread owns the allocator and hands the
+    same slots to both callers when two do.
+
+    One lock only helps if every caller goes through it, so the wrapper has to
+    reach the tree cache as well as this scheduler.
+
+    Wrapping here rather than in `bootstrap.py` is deliberate: upstream's
+    `SWAChunkCache.__init__` asserts the allocator's concrete type, and a proxy
+    handed to that constructor would fail the assert for models that use it.
+    Wrapping at construction rather than after it means no request has been
+    served through an unwrapped alias.
+    """
+    locked = LockedKVAllocator(scheduler.token_to_kv_pool_allocator)
+    scheduler.token_to_kv_pool_allocator = locked
+    for name in _KV_ALLOCATOR_HOLDERS:
+        holder = getattr(scheduler, name, None)
+        if holder is None:
+            continue
+        if not hasattr(holder, "token_to_kv_pool_allocator"):
+            raise RuntimeError(
+                f"PD decode half: {name} has no token_to_kv_pool_allocator to "
+                "rebind, so its allocations would bypass the lock"
+            )
+        holder.token_to_kv_pool_allocator = locked
+
+
+def kv_allocator_holders(scheduler: OmniDecodeScheduler) -> dict[str, Any]:
+    """Every allocator reference the scheduler can reach, by holder name.
+
+    A test asserts these are one object. That is what catches a new holder
+    appearing between the allocator's creation and this scheduler's.
+    """
+    found: dict[str, Any] = {
+        "scheduler": scheduler.__dict__.get("token_to_kv_pool_allocator")
+    }
+    for name in _KV_ALLOCATOR_HOLDERS:
+        holder = getattr(scheduler, name, None)
+        if holder is not None:
+            found[name] = getattr(holder, "token_to_kv_pool_allocator", None)
+    return found
 
 
 def _validate_pd_runtime(scheduler: OmniScheduler) -> None:

--- a/tests/unit_test/pipeline/test_pd_alloc_lock.py
+++ b/tests/unit_test/pipeline/test_pd_alloc_lock.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+"""One lock across the two threads a PD Decode half allocates from.
+
+The allocator's alloc reads the free list, slices it, and writes the
+remainder back, with no lock of its own. On a Decode half the scheduler
+thread and the comm event loop both call it, and interleaving there hands
+the same slots to both.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from sglang_omni.scheduling.pd_alloc_lock import LockedKVAllocator
+
+
+class _FakeAllocator:
+    """Stands in for the real allocator; only identity matters here."""
+
+    def alloc(self, n):  # pragma: no cover - never called
+        return list(range(n))
+
+    def free(self, indices):  # pragma: no cover - never called
+        return None
+
+
+class _RacyAllocator:
+    """An allocator with the same read-modify-write shape as upstream's."""
+
+    def __init__(self, size: int) -> None:
+        self.free_pages = list(range(size))
+        self.page_size = 1
+        self.handed_out: list[int] = []
+
+    def alloc(self, need_size: int):
+        taken = self.free_pages[:need_size]
+        # A thread switch here is what produces the overlap in production.
+        threading.current_thread()
+        self.free_pages = self.free_pages[need_size:]
+        self.handed_out.extend(taken)
+        return taken
+
+    def free(self, index) -> None:
+        self.free_pages.extend(index)
+
+    def available_size(self) -> int:
+        return len(self.free_pages)
+
+
+def test_two_threads_never_receive_the_same_slot() -> None:
+    inner = _RacyAllocator(4096)
+    allocator = LockedKVAllocator(inner)
+    seen: list[int] = []
+    lock = threading.Lock()
+
+    def take() -> None:
+        for _ in range(64):
+            got = allocator.alloc(4)
+            with lock:
+                seen.extend(got)
+
+    threads = [threading.Thread(target=take) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(seen) == len(set(seen))
+
+
+def test_everything_else_is_delegated() -> None:
+    inner = _RacyAllocator(16)
+    allocator = LockedKVAllocator(inner)
+
+    assert allocator.available_size() == 16
+    assert allocator.page_size == 1
+
+
+def test_a_write_reaches_the_wrapped_allocator() -> None:
+    """Upstream code sets attributes on the allocator it was handed."""
+    inner = _RacyAllocator(16)
+    allocator = LockedKVAllocator(inner)
+
+    allocator.page_size = 4
+
+    assert inner.page_size == 4
+
+
+def test_freeing_returns_the_slots() -> None:
+    inner = _RacyAllocator(8)
+    allocator = LockedKVAllocator(inner)
+
+    taken = allocator.alloc(8)
+    assert allocator.available_size() == 0
+
+    allocator.free(taken)
+    assert allocator.available_size() == 8
+
+
+def test_every_holder_of_the_allocator_gets_the_same_locked_object() -> None:
+    """One lock only helps if no caller keeps an unwrapped alias."""
+    from types import SimpleNamespace
+
+    from sglang_omni.scheduling.pd_scheduler import (
+        OmniDecodeScheduler,
+        _serialize_kv_allocation,
+        kv_allocator_holders,
+    )
+
+    raw = _FakeAllocator()
+    scheduler = OmniDecodeScheduler.__new__(OmniDecodeScheduler)
+    scheduler.token_to_kv_pool_allocator = raw
+    scheduler.tree_cache = SimpleNamespace(token_to_kv_pool_allocator=raw)
+
+    _serialize_kv_allocation(scheduler)
+
+    holders = kv_allocator_holders(scheduler)
+    assert set(holders) == {"scheduler", "tree_cache"}
+    assert len({id(a) for a in holders.values()}) == 1
+    assert all(isinstance(a, LockedKVAllocator) for a in holders.values())
+
+
+def test_a_holder_that_cannot_be_rebound_is_an_error() -> None:
+    """Skipping it silently would leave an alias outside the lock."""
+    from types import SimpleNamespace
+
+    from sglang_omni.scheduling.pd_scheduler import (
+        OmniDecodeScheduler,
+        _serialize_kv_allocation,
+    )
+
+    scheduler = OmniDecodeScheduler.__new__(OmniDecodeScheduler)
+    scheduler.token_to_kv_pool_allocator = _FakeAllocator()
+    scheduler.tree_cache = SimpleNamespace()  # no allocator attribute
+
+    with pytest.raises(RuntimeError, match="would bypass the lock"):
+        _serialize_kv_allocation(scheduler)
+
+
+def test_a_receiver_built_after_the_wrap_gets_the_locked_allocator() -> None:
+    """Ordering matters: a receiver built first would hold the raw object."""
+    import queue
+    from types import SimpleNamespace
+
+    from sglang_omni.scheduling.pd_scheduler import _serialize_kv_allocation
+    from sglang_omni.scheduling.pd_utils import DecodeKVReceiver
+
+    inner = _RacyAllocator(64)
+    scheduler = SimpleNamespace(
+        token_to_kv_pool_allocator=inner,
+        tree_cache=SimpleNamespace(token_to_kv_pool_allocator=inner),
+    )
+    _serialize_kv_allocation(scheduler)
+
+    receiver = DecodeKVReceiver(
+        pool_id="thinker_decode:kv",
+        allocator=scheduler.token_to_kv_pool_allocator,
+        admissions=queue.SimpleQueue(),
+        allowed_resume_schemas=frozenset({"v1"}),
+    )
+
+    assert isinstance(receiver._allocator, LockedKVAllocator)

--- a/tests/unit_test/pipeline/test_pd_rewrite.py
+++ b/tests/unit_test/pipeline/test_pd_rewrite.py
@@ -351,3 +351,44 @@ def test_an_unsplit_budget_still_reaches_both_halves() -> None:
 
     assert halves["thinker_prefill"].gpu_memory_fraction == 0.8
     assert halves["thinker_decode"].gpu_memory_fraction == 0.8
+
+
+@pytest.mark.parametrize(
+    "engine,message",
+    [
+        ({"page_size": 32}, "requires 1"),
+        ({"disable_radix_cache": False}, "requires True"),
+    ],
+)
+def test_a_pd_stage_is_rejected_for_what_the_runtime_cannot_do(engine, message) -> None:
+    """The scheduler refuses these in its constructor, after the model loads."""
+    from sglang_omni.config.pd_capability import validate_pd_engine_args
+
+    logical = stage(
+        "thinker",
+        terminal=True,
+        pd_disaggregation=PDConfig(
+            prefill=PDStagePlacement(gpu=0, engine=engine),
+            decode=PDStagePlacement(gpu=1),
+        ),
+    )
+    expansion = expand_pd_stages([logical], entry_stage="thinker")
+
+    with pytest.raises(ValueError, match=message):
+        validate_pd_engine_args(expansion.stages)
+
+
+def test_a_supported_engine_argument_passes() -> None:
+    from sglang_omni.config.pd_capability import validate_pd_engine_args
+
+    logical = stage(
+        "thinker",
+        terminal=True,
+        pd_disaggregation=PDConfig(
+            prefill=PDStagePlacement(gpu=0, engine={"page_size": 1}),
+            decode=PDStagePlacement(gpu=1, engine={"max_running_requests": 64}),
+        ),
+    )
+    expansion = expand_pd_stages([logical], entry_stage="thinker")
+
+    validate_pd_engine_args(expansion.stages)

--- a/tests/unit_test/pipeline/test_pd_rewrite.py
+++ b/tests/unit_test/pipeline/test_pd_rewrite.py
@@ -90,7 +90,7 @@ def test_pd_rewrite_assigns_input_to_prefill_and_output_to_decode() -> None:
     assert stages["thinker_decode"].stream_to == ["sink"]
     assert stages["thinker_decode"].route_fn == fake_factory_path("identity_route")
     assert stages["thinker_prefill"].pd_execution == PDExecution(
-        role="prefill", partner="thinker_decode"
+        decode_targets=("thinker_decode",), role="prefill", partner="thinker_decode"
     )
     assert stages["thinker_decode"].pd_execution == PDExecution(
         role="decode", partner="thinker_prefill"
@@ -262,7 +262,14 @@ def test_pd_factory_wrong_type_and_missing_capability_fail_at_startup(tmp_path) 
                 prefill=PDStagePlacement(gpu=0),
                 decode=PDStagePlacement(gpu=0),
             ),
-            "cannot share",
+            "must declare memory_fraction",
+        ),
+        (
+            PDConfig(
+                prefill=PDStagePlacement(gpu=0, memory_fraction=0.45),
+                decode=PDStagePlacement(gpu=0),
+            ),
+            "decode must declare memory_fraction",
         ),
     ],
 )
@@ -272,3 +279,75 @@ def test_invalid_pd_placement_fails_in_config(pd, message) -> None:
             model_path="model",
             stages=[stage("thinker", terminal=True, pd_disaggregation=pd)],
         )
+
+
+def test_two_halves_may_share_a_gpu_when_both_declare_a_budget() -> None:
+    """The split PD needs is between processes, not between cards.
+
+    Sharing is also the only shape in which the halves can share one copy of
+    the weights, and the only one a one-GPU CI box can run.
+    """
+    config = PipelineConfig(
+        model_path="model",
+        stages=[
+            stage(
+                "thinker",
+                terminal=True,
+                pd_disaggregation=PDConfig(
+                    prefill=PDStagePlacement(gpu=0, memory_fraction=0.45),
+                    decode=PDStagePlacement(gpu=0, memory_fraction=0.45),
+                ),
+            )
+        ],
+    )
+    expansion = expand_pd_stages(
+        list(config.stages), entry_stage=config.resolved_entry_stage
+    )
+    halves = {item.name: item for item in expansion.stages}
+
+    assert halves["thinker_prefill"].gpu == 0
+    assert halves["thinker_decode"].gpu == 0
+    assert halves["thinker_prefill"].gpu_memory_fraction == 0.45
+    assert halves["thinker_decode"].gpu_memory_fraction == 0.45
+
+
+def test_each_half_may_override_the_engine_arguments() -> None:
+    """Prefill sizes batches for one forward, Decode for many steps."""
+    config = PipelineConfig(
+        model_path="model",
+        stages=[
+            stage(
+                "thinker",
+                terminal=True,
+                pd_disaggregation=PDConfig(
+                    prefill=PDStagePlacement(gpu=0, engine={"max_running_requests": 8}),
+                    decode=PDStagePlacement(gpu=1, engine={"max_running_requests": 64}),
+                ),
+            )
+        ],
+    )
+    expansion = expand_pd_stages(
+        list(config.stages), entry_stage=config.resolved_entry_stage
+    )
+    halves = {item.name: item for item in expansion.stages}
+
+    assert halves["thinker_prefill"].engine.max_running_requests == 8
+    assert halves["thinker_decode"].engine.max_running_requests == 64
+
+
+def test_an_unsplit_budget_still_reaches_both_halves() -> None:
+    """Separate cards need no per-half budget; the logical one stands."""
+    logical = stage(
+        "thinker",
+        terminal=True,
+        pd_disaggregation=PDConfig(
+            prefill=PDStagePlacement(gpu=0),
+            decode=PDStagePlacement(gpu=1),
+        ),
+    )
+    logical.gpu_memory_fraction = 0.8
+    expansion = expand_pd_stages([logical], entry_stage="thinker")
+    halves = {item.name: item for item in expansion.stages}
+
+    assert halves["thinker_prefill"].gpu_memory_fraction == 0.8
+    assert halves["thinker_decode"].gpu_memory_fraction == 0.8

--- a/tests/unit_test/pipeline/test_pd_utils.py
+++ b/tests/unit_test/pipeline/test_pd_utils.py
@@ -544,6 +544,7 @@ def test_prefill_queues_one_real_token_handoff_and_source_lease_is_idempotent(
     scheduler._pd_state_builder = _state_builder
     scheduler._pd_stage_name = "thinker_prefill"
     scheduler._pd_partner_stage = "thinker_decode"
+    scheduler._pd_decode_targets = ("thinker_decode",)
     scheduler._pd_pool_id = "thinker_prefill:kv"
     scheduler.req_to_token_pool = req_pool
     scheduler.tree_cache = "tree"


### PR DESCRIPTION
## Base PR

Base PR: #1773
Frozen head: `56a1a8df`

Stacked on #1780, which is the first commit here.

## What this is

#1773 fixes the thing that mattered most: PD role is now a type decided at construction, not a mutation applied to a finished generic scheduler. Everything below is what that base still needs before the elastic and configurable work can sit on it without changing it again.

Each item is a signature, a serialized format, or a construction-time invariant. Policy is deliberately not here — `max_inflight_handoffs`, the decode queue-depth signal, request `priority` on the continuation, the CUDA-IPC relay pool reservation and the weight-sharing mechanism all layer on afterwards without moving anything below them, and I have left them out on purpose.

## 1. Two threads share one KV allocator

`DecodeKVReceiver.reserve` runs on the comm event loop and calls `self._allocator.alloc(count)` (`pd_utils.py:443`). The scheduler thread allocates from the same object for decode steps and frees through the tree cache. Upstream's `alloc` is a read-modify-write with no lock, so two callers interleaving between the read and the write receive the same slots; both write KV into those pages and the second overwrites the first. Nothing raises — the request returns 200 with wrong text.

The `threading.Lock` inside `DecodeKVReceiver` does not cover this; it guards the receiver's own reservation table, and the scheduler thread never takes it.

Measured on two H200s with both `alloc` and `free` recorded, one 3,000-request run: **21,309 slots handed to one thread while the other still held them**, 11 empty completions, and within-request token duplication. Reproducing it needs mixed prompt lengths — 42, 1150 and 4400 tokens in one stream; six runs at a uniform long prompt never did. Tracked as #1704.

Wrapped at construction and rebound into every holder. `bootstrap.py` hands the same allocator to `create_tree_cache` before this scheduler exists, so rebinding only our own attribute leaves the tree cache on an unwrapped alias. Wrapping in `bootstrap.py` instead is not available: `SWAChunkCache.__init__` asserts the allocator's concrete type and rejects a proxy.

**This is the argument for the refactor holding up concretely.** The window only existed because the scheduler became a Decode half after everything had already taken a reference.

## 2. One declared budget, two halves

`_split` copied `gpu_memory_fraction` to both halves unchanged. That number describes one occupant of a card. With the halves on separate cards it is right; with both on one card each sizes itself against the whole card, and `_validate_memory_budgets` counts it twice.

`PDStagePlacement` gains `memory_fraction` and `engine`. The two halves want different engine arguments — Prefill sizes batches for one forward, Decode for many steps — and without an override they share the logical stage's.

## 3. The two halves may share a GPU

`_validate_pd` refused overlapping prefill and decode GPU sets. That makes weight sharing unreachable, and it makes PD untestable on a one-GPU box.

The split PD needs is between processes, and that happens either way: the prefill step leaves the decode scheduler thread whichever card it runs on.

It is now allowed **only with both budgets declared**, and that condition is the point. `_validate_memory_budgets` sums *declared* fractions and `_build_gpu_placement` skips a `None` (`config/placement.py:177-179`), so two undeclared halves on one card would each have sized against the whole of it — whichever won `gpu_startup_lock` would have taken the memory and the other would have failed to start. Permitting the placement without requiring the budgets converts a config error into a silent OOM.

## 4. The Decode target is a set, not a constant

`target_pool_id` and `to_stage` were built from `partner_stage`, a string fixed in the constructor. Adding a second Decode half therefore meant changing `OmniPrefillScheduler.__init__` and the send path together — and because this base builds the KV pool in `__init__` and publishes `kv_registrations` off the constructed scheduler, a Prefill half never sees `rank_endpoints` and cannot learn its peers later.

`PDExecution` carries `decode_targets`, `OmniPrefillScheduler` takes it, and it defaults to the one partner, so behaviour is unchanged today.

The choice itself moves to `select_decode_stage`, which takes `targets` and `request_id` and nothing else. **That signature is the design.** The KV send is rank-addressed: rank *i* sends its shard to the chosen stage's rank *i*. Two Prefill ranks choosing differently scatter one request's pages across different Decode halves, each holding part of the KV and none holding all of it, and nothing in the transfer path checks for it. Queue depth, in-flight counts and arrival order are the natural ingredients of a load-balancing policy and every one of them differs per rank. Taking values rather than a scheduler means rank-local state cannot be added without changing the signature, which is where someone has to think about that paragraph.

The list is sorted for the same reason.

## 5. An unsupported config fails after the model loads

`_validate_pd_runtime` enforces `page_size == 1` and RadixCache disabled in the scheduler constructor — the last possible moment, and the error names no stage. `validate_pd_engine_args` checks them next to `validate_pd_capabilities`, says which stage, and says what has to be built for the restriction to go.

Applying them silently would be worse: an operator who asked for `page_size=32` would get 1 without being told, and would keep getting it after the restriction lifts.

## What this base still needs, not in this PR

Found while working through the above; each wants its own change and its own review.

- **`transfer_id` is drawn per rank.** `f"{req.rid}:pd:{uuid4().hex}"` (`pd_scheduler.py:142`), and every join key downstream is `transfer_id`. Under `tp_size > 1` the same request gets a different id on each rank. Harmless at 1; a trap to leave in place.
- **`lease.release` runs on the comm thread** and calls `release_kv_cache(req, tree_cache)`. With RadixCache disabled that is an allocator free, which the wrapper in this PR now covers. With it enabled it is an unsynchronised tree mutation, which the wrapper does not cover.
- **`ReservedKV` conflates three quantities.** `count = len(source_page_indices)` is used as the token count, the token-slot count and the page count. They are equal only at `page_size == 1`.
- **`DecodeContinuation` carries neither `extra_key` nor `cache_salt`.** With RadixCache enabled the Decode half inserts under `RadixKey(token_ids, extra_key, cache_salt)`; without those two fields, requests with identical token ids but different keys collapse into one entry.
- **`output_map` is a compile-time logical-to-one-physical map** consumed by the coordinator for terminal accounting. With N Decode halves the terminal stage is a per-request fact. This is the real N:M blocker, deeper than the Decode-target seam.

## Testing

| Run | Result |
| --- | --- |
| `tests/unit_test/{pipeline,scheduling,config}` | 891 pass |
| `tests/unit_test` | 5367 pass, 11 fail |

The 11 are `moss_tts/test_audio_tokenizer.py` (2), `qwen3_omni/test_audio_layer_graph.py` (4), `qwen3_omni/test_vision_compat.py` (1) and `qwen3_tts/test_compat.py` (4). All 11 fail identically on `56a1a8df` without this branch, and none touch PD.

New cases: eight threads racing an allocator with upstream's read-modify-write shape never receive the same slot; every holder ends up with the same locked object and one that cannot be rebound raises; two halves may share a GPU when both declare a budget and are rejected naming the half that did not; each half may override engine arguments; an unsplit budget still reaches both halves; and a PD stage declaring `page_size=32` or `disable_radix_cache=False` is rejected at config time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
