### PR TITLE
[qwen3-tts]: Fix Qwen3-TTS vocoder graph capture readiness race

### DIFF
--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -211,7 +211,8 @@ def create_vocoder_executor(
         enable_deterministic_inference=enable_deterministic_inference,
         followup_cuda_graph=followup_cuda_graph,
     )
-    # Factory construction completes before the stage process publishes readiness,
-    # so CUDA capture cannot overlap request-time GPU work from colocated stages.
+    # note (ratish): Factory construction completes before the stage process
+    # publishes readiness, so CUDA capture cannot overlap request-time GPU work
+    # from colocated stages.
     scheduler.warmup_now()
     return scheduler

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -193,7 +193,7 @@ def create_vocoder_executor(
         attn_implementation=attn_implementation,
     )
 
-    return Qwen3TTSStreamingVocoderScheduler(
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
         tokenizer,
         device=device,
         stream_stride=stream_stride,
@@ -211,3 +211,7 @@ def create_vocoder_executor(
         enable_deterministic_inference=enable_deterministic_inference,
         followup_cuda_graph=followup_cuda_graph,
     )
+    # Factory construction completes before the stage process publishes readiness,
+    # so CUDA capture cannot overlap request-time GPU work from colocated stages.
+    scheduler.warmup_now()
+    return scheduler

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -487,11 +487,15 @@ class Qwen3TTSStreamingVocoderScheduler(
         super().stop()
         self._join_async_workers()
 
-    def on_serving_start(self) -> None:
+    def warmup_now(self) -> None:
         if not self._async_decode:
             return
         self._initial_decode_graphs.capture()
         self._followup_decode_graphs.capture()
+
+    def on_serving_start(self) -> None:
+        if not self._async_decode:
+            return
         self._initial_queue = queue.Queue()
         self._followup_queue = queue.PriorityQueue()
         self._followup_sequence = count()

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -1332,6 +1332,12 @@ def test_qwen3_tts_vocoder_batches_decode_requests(
         "_load_qwen3_tts_tokenizer",
         lambda *args, **kwargs: FakeTokenizer(),
     )
+    warmed_schedulers: list[Qwen3TTSStreamingVocoderScheduler] = []
+    monkeypatch.setattr(
+        Qwen3TTSStreamingVocoderScheduler,
+        "warmup_now",
+        lambda scheduler: warmed_schedulers.append(scheduler),
+    )
 
     scheduler = stages.create_vocoder_executor(
         "model",
@@ -1339,6 +1345,7 @@ def test_qwen3_tts_vocoder_batches_decode_requests(
         max_batch_size=2,
         max_batch_wait_ms=3,
     )
+    assert warmed_schedulers == [scheduler]
     assert scheduler.create_stream_state("request").initial_chunk_frames == 8
     assert scheduler._stream_left_context_frames == 16
     assert scheduler._stream_followup_stride == 8
@@ -1606,6 +1613,34 @@ def test_qwen3_tts_streaming_vocoder_followup_graphs_can_be_disabled() -> None:
 
     assert scheduler._followup_decode_graphs._enabled is False
     assert scheduler._initial_decode_graphs is not scheduler._followup_decode_graphs
+
+
+def test_qwen3_tts_vocoder_warms_graphs_before_serving_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        async_decode=True,
+    )
+    captures: list[str] = []
+    monkeypatch.setattr(
+        scheduler._initial_decode_graphs,
+        "capture",
+        lambda: captures.append("initial"),
+    )
+    monkeypatch.setattr(
+        scheduler._followup_decode_graphs,
+        "capture",
+        lambda: captures.append("followup"),
+    )
+
+    scheduler.warmup_now()
+    scheduler.on_serving_start()
+    try:
+        assert captures == ["initial", "followup"]
+    finally:
+        scheduler.stop()
 
 
 def test_qwen3_tts_deterministic_streaming_vocoder_decodes_each_plan_at_b1() -> None:


### PR DESCRIPTION
## Motivation

Qwen3-TTS could report healthy while its streaming vocoder was still capturing CUDA graphs. An immediate request could then run reference-audio GPU work during capture, causing `cudaErrorStreamCaptureUnsupported` and an HTTP 500 warmup failure.

## Modifications

- Move initial and follow-up vocoder graph capture into a synchronous `warmup_now()` step invoked by `create_vocoder_executor()`.
- Complete capture during stage factory construction, under the existing GPU startup lock and before process readiness is published.
- Keep `on_serving_start()` responsible only for initializing the asynchronous decode queues and workers.
- Cover the factory-time warmup call and verify that serving startup does not recapture either graph holder.

## Root Cause

The vocoder previously captured graphs from its scheduler thread during `on_serving_start()`. `Stage.start()` launches that thread without waiting for its initialization to complete, so the process could publish readiness and expose `/health` before graph capture finished. Request-time CUDA work from another stage could consequently invalidate the active capture.

## Accuracy Test

- Focused Qwen3-TTS unit suite: 218 passed.
- H100 cold-start qualification: 10/10 fresh managed starts, 10/10 immediate warmups returned HTTP 200, and both graph-capture messages preceded process readiness in every run.
- Across the cold-start qualification, all measured requests returned HTTP 200 with no CUDA errors, HTTP 500s, `cudaErrorStreamCaptureUnsupported`, or `AcceleratorError`.

## H100 c16 Test

| Metric | PR |
|---|---:|
| Warmup | HTTP 200 |
| Measured requests | 16/16 |
| Failed requests | 0 |
| Throughput | 3.471 req/s |
| Mean latency | 3.602 s |
| Median latency | 3.578 s |
| p95 latency | 4.400 s |
| p99 latency | 4.567 s |
| Mean RTF | 0.9205 |
| p95 RTF | 1.1631 |
| Audio throughput | 14.491 s/s |

## Checklist

- [x] Format the code with the repository pre-commit hooks.
- [x] Add focused lifecycle tests.
- [x] Validate repeated cold starts and immediate post-readiness requests on H100.
