### PR TITLE
fix(moss-tts-local): disable vocoder graphs on WSL DXG

### DIFF
--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import os
 from typing import Any, ClassVar
 
-import torch
 from pydantic import Field
 
 from sglang_omni.config import (
@@ -34,6 +33,10 @@ _MAX_PIPELINE_INTRAOP_THREADS = 8
 
 def _uses_rocm_wsl_dxg() -> bool:
     """Return whether PyTorch HIP can select the WSL DXG device path."""
+    try:
+        import torch
+    except ImportError:
+        return False
     return (
         torch.version.hip is not None
         and os.environ.get("HSA_ENABLE_DXG_DETECTION") != "0"

--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any, ClassVar
 
+import torch
 from pydantic import Field
 
 from sglang_omni.config import (
@@ -28,6 +30,28 @@ _REF_AUDIO_CACHE_MAX_ITEMS = 8192
 _REF_AUDIO_CACHE_MAX_BYTES = 64 * 1024 * 1024
 _PREPROCESSING_MAX_CONCURRENCY = 16
 _MAX_PIPELINE_INTRAOP_THREADS = 8
+
+
+def _uses_rocm_wsl_dxg() -> bool:
+    """Return whether PyTorch HIP can select the WSL DXG device path."""
+    return (
+        torch.version.hip is not None
+        and os.environ.get("HSA_ENABLE_DXG_DETECTION") != "0"
+        and os.path.exists("/dev/dxg")
+    )
+
+
+def resolve_vocoder_cuda_graph(cuda_graph: bool | None) -> bool:
+    """Resolve the platform default and reject an unsafe DXG opt-in."""
+    if not _uses_rocm_wsl_dxg():
+        return True if cuda_graph is None else cuda_graph
+    if cuda_graph is True:
+        raise ValueError(
+            "MOSS-TTS Local vocoder CUDA graphs cannot be enabled on ROCm "
+            "WSL/DXG because HIP graph capture can abort the process; omit "
+            "cuda_graph or set it to false"
+        )
+    return False
 
 
 def _stages(*, codec_device: str, colocated: bool) -> list[StageConfig]:
@@ -132,10 +156,9 @@ class MossTTSLocalPipelineConfig(PipelineConfig):
         default_factory=lambda: _stages(codec_device="cuda:0", colocated=True)
     )
 
-    # Streaming-vocoder CUDA-graph knobs, passed to the vocoder factory via
-    # stage_factory_kwargs. Default on, fail-safe to eager;
-    # cuda_graph_frames=None captures exact T=1..stream_chunk.
-    cuda_graph: bool = True
+    # None preserves whether the user supplied an override. The resolved
+    # default is on except on ROCm WSL/DXG, where capture can abort in C++.
+    cuda_graph: bool | None = None
     cuda_graph_frames: list[int] | None = None
     cuda_graph_min_free_gb: float = 3.0
     ref_audio_cache: bool = True
@@ -158,7 +181,7 @@ class MossTTSLocalPipelineConfig(PipelineConfig):
             return {}
         if stage_name == "vocoder":
             return {
-                "cuda_graph": self.cuda_graph,
+                "cuda_graph": resolve_vocoder_cuda_graph(self.cuda_graph),
                 "cuda_graph_frames": self.cuda_graph_frames,
                 "cuda_graph_min_free_gb": self.cuda_graph_min_free_gb,
             }
@@ -197,6 +220,7 @@ class MossTTSLocalPipelineConfig(PipelineConfig):
 
     def model_post_init(self, __context: Any = None) -> None:
         super().model_post_init(__context)
+        resolve_vocoder_cuda_graph(self.cuda_graph)
         if self.ref_audio_cache_max_items < 1:
             raise ValueError(
                 "ref_audio_cache_max_items must be >= 1; got "

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -26,6 +26,7 @@ from sglang_omni.models.moss_tts_local.audio_tokenizer import (
     load_moss_tts_local_audio_tokenizer,
     load_moss_tts_local_audio_vocoder,
 )
+from sglang_omni.models.moss_tts_local.config import resolve_vocoder_cuda_graph
 from sglang_omni.models.moss_tts_local.payload_types import (
     moss_tts_local_special_token_defaults,
 )
@@ -664,10 +665,11 @@ def create_vocoder_executor(
     stream_chunk_frames: int = 25,
     initial_chunk_frames: int = 5,
     coalesce_floor_frames: int = 5,
-    cuda_graph: bool = True,
+    cuda_graph: bool | None = None,
     cuda_graph_frames: list[int] | None = None,
     cuda_graph_min_free_gb: float = 3.0,
 ) -> MossTTSLocalStreamingVocoderScheduler:
+    cuda_graph = resolve_vocoder_cuda_graph(cuda_graph)
     device = _resolve_codec_device(device, gpu_id)
     processor = _load_moss_tts_local_processor(model_path)
     decoder_dtype = resolve_moss_audio_dtype(

--- a/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
+++ b/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
@@ -1414,6 +1414,25 @@ def test_create_vocoder_executor_threads_cuda_graph_config(monkeypatch) -> None:
     assert scheduler2._cuda_graph_min_free_gb == 7.0
 
 
+def test_vocoder_factory_resolves_graph_policy_before_loading(monkeypatch) -> None:
+    calls: list[bool | None] = []
+
+    def resolve(cuda_graph: bool | None) -> bool:
+        calls.append(cuda_graph)
+        raise ValueError("unsafe graph")
+
+    monkeypatch.setattr(stages, "resolve_vocoder_cuda_graph", resolve)
+    monkeypatch.setattr(
+        stages,
+        "_load_moss_tts_local_processor",
+        lambda model_path: (_ for _ in ()).throw(AssertionError("loaded codec")),
+    )
+
+    with pytest.raises(ValueError, match="unsafe graph"):
+        stages.create_vocoder_executor("fake-model", device="cpu", cuda_graph=True)
+    assert calls == [True]
+
+
 def test_default_cuda_graph_frames_cover_stream_chunk_exactly(monkeypatch) -> None:
     captured: list[list[int]] = []
     monkeypatch.setattr(

--- a/tests/unit_test/moss_tts_local/test_vocoder_graph_config.py
+++ b/tests/unit_test/moss_tts_local/test_vocoder_graph_config.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sglang_omni.models.moss_tts_local import config as config_module
+
+
+@pytest.mark.parametrize(
+    "hip_version,dxg_device,dxg_detection,expected",
+    [
+        ("7.2.0", True, "1", True),
+        ("7.2.0", True, None, True),
+        ("7.2.0", True, "0", False),
+        ("7.2.0", False, "1", False),
+        (None, True, "1", False),
+    ],
+)
+def test_rocm_wsl_dxg_detection_uses_hip_and_dxg_signals(
+    monkeypatch,
+    hip_version,
+    dxg_device,
+    dxg_detection,
+    expected,
+) -> None:
+    monkeypatch.setattr(torch.version, "hip", hip_version)
+    monkeypatch.setattr(
+        config_module.os.path,
+        "exists",
+        lambda path: dxg_device and path == "/dev/dxg",
+    )
+    if dxg_detection is None:
+        monkeypatch.delenv("HSA_ENABLE_DXG_DETECTION", raising=False)
+    else:
+        monkeypatch.setenv("HSA_ENABLE_DXG_DETECTION", dxg_detection)
+
+    assert config_module._uses_rocm_wsl_dxg() is expected
+
+
+def test_rocm_wsl_dxg_default_disables_vocoder_graph_before_factory(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(config_module, "_uses_rocm_wsl_dxg", lambda: True)
+    config = config_module.MossTTSLocalPipelineConfig(model_path="x")
+
+    assert config.cuda_graph is None
+    assert config.stage_factory_kwargs("vocoder")["cuda_graph"] is False
+
+
+def test_non_dxg_default_keeps_vocoder_graph_enabled(monkeypatch) -> None:
+    monkeypatch.setattr(config_module, "_uses_rocm_wsl_dxg", lambda: False)
+    config = config_module.MossTTSLocalPipelineConfig(model_path="x")
+
+    assert config.cuda_graph is None
+    assert config.stage_factory_kwargs("vocoder")["cuda_graph"] is True
+
+
+def test_rocm_wsl_dxg_explicit_vocoder_graph_contract(monkeypatch) -> None:
+    """DXG accepts explicit eager mode but rejects the unsafe force-on value."""
+    monkeypatch.setattr(config_module, "_uses_rocm_wsl_dxg", lambda: True)
+
+    disabled = config_module.MossTTSLocalPipelineConfig(
+        model_path="x", cuda_graph=False
+    )
+    assert disabled.stage_factory_kwargs("vocoder")["cuda_graph"] is False
+    with pytest.raises(ValueError, match="cannot be enabled on ROCm WSL/DXG"):
+        config_module.MossTTSLocalPipelineConfig(model_path="x", cuda_graph=True)
+
+
+@pytest.mark.parametrize("configured", [False, True])
+def test_non_dxg_preserves_explicit_vocoder_graph_override(
+    monkeypatch, configured
+) -> None:
+    monkeypatch.setattr(config_module, "_uses_rocm_wsl_dxg", lambda: False)
+
+    config = config_module.MossTTSLocalPipelineConfig(
+        model_path="x", cuda_graph=configured
+    )
+
+    assert config.stage_factory_kwargs("vocoder")["cuda_graph"] is configured
+
+
+def test_unset_vocoder_graph_survives_config_rebuild(monkeypatch) -> None:
+    """The resolver's dump/rebuild must not turn the platform default into an override."""
+    monkeypatch.setattr(config_module, "_uses_rocm_wsl_dxg", lambda: True)
+    config = config_module.MossTTSLocalPipelineConfig(model_path="x")
+
+    rebuilt = type(config)(**config.model_dump())
+
+    assert rebuilt.cuda_graph is None
+    assert rebuilt.stage_factory_kwargs("vocoder")["cuda_graph"] is False

--- a/tests/unit_test/moss_tts_local/test_vocoder_graph_config.py
+++ b/tests/unit_test/moss_tts_local/test_vocoder_graph_config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+
 import pytest
 import torch
 
@@ -37,6 +39,12 @@ def test_rocm_wsl_dxg_detection_uses_hip_and_dxg_signals(
         monkeypatch.setenv("HSA_ENABLE_DXG_DETECTION", dxg_detection)
 
     assert config_module._uses_rocm_wsl_dxg() is expected
+
+
+def test_rocm_wsl_dxg_detection_without_torch_is_false(monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "torch", None)
+
+    assert config_module._uses_rocm_wsl_dxg() is False
 
 
 def test_rocm_wsl_dxg_default_disables_vocoder_graph_before_factory(


### PR DESCRIPTION
## Motivation

MOSS-TTS vocoder graph capture can fail on the ROCm WSL/DXG path and leave the HIP context unusable. Cleanup may then abort the process before the existing eager fallback can run.

## Modifications

- Default the vocoder to eager mode when running with HIP through `/dev/dxg`.
- Keep the existing graph-enabled default on CUDA and native ROCm.
- Reject an explicit `cuda_graph: true` on WSL/DXG before loading the codec or creating a graph.

Explicit `cuda_graph: false` remains unchanged. This does not affect attention backend selection.

## Accuracy Test

- Unit tests: `11 passed`
- Pre-commit: passed
- Windows WSL2, Ubuntu 24.04, RX 7900 XTX (`gfx1100`): the eager vocoder path completed a real request with HTTP 200 and produced a valid, non-silent WAV.

## Benchmark & Profiling

Not run. Other platforms keep the existing graph-enabled path.
