### PR TITLE
fix: clamp Qwen3-ASR requests to scheduler capacity

### DIFF
--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -64,6 +64,7 @@ _SYSTEM_PROMPT = "<|im_start|>system\n<|im_end|>\n"
 
 @dataclass
 class Qwen3ASRRequestData(SGLangARRequestData):
+    enforce_request_limits: bool = True
     prompt_token_ids: list[int] | None = None
     output_ids: list[int] | None = None
     audio_duration_s: float = 0.0

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -2461,6 +2461,62 @@ def test_omni_scheduler_prepares_custom_request_token_budget() -> None:
     assert scheduler.outbox.empty()
 
 
+def test_omni_scheduler_clamps_request_to_strict_prefill_budget() -> None:
+    """Clamp requests that pass the surface KV check but cannot be prefetched."""
+    scheduler = object.__new__(OmniScheduler)
+    scheduler.outbox = Queue()
+    scheduler.waiting_queue = []
+    scheduler._pending_stream_ingress = {}
+    scheduler._deferred_request_payloads = {}
+    scheduler._dirty_deferred_request_ids = set()
+    scheduler._aborted_request_ids = set()
+    scheduler._aborted_request_id_order = deque()
+    scheduler.max_req_len = 23
+    scheduler.max_req_input_len = 22
+    scheduler.max_new_tokens_limit = None
+    scheduler.page_size = 4
+    scheduler.max_total_num_tokens = 24
+    _init_sync_request_build_state(scheduler)
+
+    requested_max_new_tokens = 14
+    sampling_params = SimpleNamespace(
+        max_new_tokens=requested_max_new_tokens,
+        min_new_tokens=0,
+    )
+    req = SimpleNamespace(
+        rid="req-near-capacity",
+        origin_input_ids=[1] * 9,
+        origin_input_ids_unpadded=[1] * 9,
+        sampling_params=sampling_params,
+        output_ids=[],
+        priority=None,
+    )
+    req_data = SimpleNamespace(
+        req=req,
+        max_new_tokens=requested_max_new_tokens,
+        enforce_request_limits=True,
+    )
+    scheduler._request_builder = lambda payload: req_data
+
+    scheduler.process_input_requests([_new_stage_payload("req-near-capacity")])
+
+    input_tokens = len(req.origin_input_ids)
+    paged_input_tokens = 12
+    assert input_tokens + requested_max_new_tokens == scheduler.max_req_len
+    assert (
+        paged_input_tokens + requested_max_new_tokens + scheduler.page_size
+        >= scheduler.max_total_num_tokens
+    )
+    assert req.sampling_params.max_new_tokens == 7
+    assert req_data.max_new_tokens == 7
+    assert (
+        paged_input_tokens + req.sampling_params.max_new_tokens + scheduler.page_size
+        < scheduler.max_total_num_tokens
+    )
+    assert scheduler.waiting_queue == [req]
+    assert scheduler.outbox.empty()
+
+
 def test_omni_scheduler_rejects_custom_request_over_context() -> None:
     """Covers context-length validation for custom request builders."""
     scheduler = object.__new__(OmniScheduler)

--- a/tests/unit_test/qwen3_asr/test_request_builders.py
+++ b/tests/unit_test/qwen3_asr/test_request_builders.py
@@ -163,6 +163,21 @@ def test_qwen3_asr_short_audio_keeps_the_floor_budget(monkeypatch) -> None:
     assert data.max_new_tokens == 128
 
 
+def test_qwen3_asr_request_builder_enforces_scheduler_request_limits(
+    monkeypatch,
+) -> None:
+    request_builder = _budget_test_builder(monkeypatch, num_samples=1600)
+    payload = StagePayload(
+        request_id="req-request-limits",
+        request=OmniRequest(inputs={"audio_bytes": b"wav"}, params={}),
+        data={},
+    )
+
+    data = request_builder(payload)
+
+    assert data.enforce_request_limits is True
+
+
 def test_qwen3_asr_long_audio_scales_the_budget(monkeypatch) -> None:
     # 60s of audio needs ~300 output tokens; the scaled default (10/s with
     # margin) covers it without a large flat default.


### PR DESCRIPTION
## Summary

Clamp Qwen3-ASR request budgets to the scheduler's page-aligned KV capacity before admission.

## Root cause

This was exposed by the tight 2,048-token Torch MPS profile while validating [Apple Silicon PR #1730](https://github.com/sgl-project/sglang-omni/pull/1730#issuecomment-5449948526). A request could satisfy the surface `input + max_new` context check but fail SGLang's stricter page-reserve rule forever, leaving it in the waiting queue.

## Implementation

- Opt Qwen3-ASR request data into SGLang's existing request-limit clamp.
- Cover the near-capacity page-reserve boundary at the builder and scheduler layers.

This is shared Qwen3-ASR admission behavior across CUDA, MLX, and Torch MPS; the Apple profile only made the boundary easy to reach.

## Tests

- Qwen3-ASR request-builder and scheduler focused matrix: 560 passed
- Changed-files pre-commit: passed
- `git diff --check`: passed
