### PR TITLE
bench(seedtts): warm up at benchmark concurrency

### DIFF
--- a/benchmarks/benchmarker/runner.py
+++ b/benchmarks/benchmarker/runner.py
@@ -77,8 +77,22 @@ class BenchmarkRunner:
     ) -> None:
         count = min(self.config.warmup, len(samples))
         logger.info("Warmup (%d requests)...", count)
-        for i in range(count):
-            result = await send_fn(session, samples[i])
+        semaphore = (
+            asyncio.Semaphore(self.config.max_concurrency)
+            if self.config.max_concurrency
+            else None
+        )
+
+        async def _limited(sample: Any) -> RequestResult:
+            if semaphore is None:
+                return await send_fn(session, sample)
+            async with semaphore:
+                return await send_fn(session, sample)
+
+        results = await asyncio.gather(
+            *(_limited(sample) for sample in samples[:count])
+        )
+        for i, result in enumerate(results):
             status = "ok" if result.is_success else result.error
             logger.info("  warmup %d/%d: %s", i + 1, count, status)
 

--- a/benchmarks/benchmarker/runner.py
+++ b/benchmarks/benchmarker/runner.py
@@ -75,7 +75,7 @@ class BenchmarkRunner:
         samples: list,
         send_fn: SendFn,
     ) -> None:
-        count = min(self.config.warmup, len(samples))
+        count = self.config.warmup if samples else 0
         logger.info("Warmup (%d requests)...", count)
         semaphore = (
             asyncio.Semaphore(self.config.max_concurrency)
@@ -89,9 +89,12 @@ class BenchmarkRunner:
             async with semaphore:
                 return await send_fn(session, sample)
 
-        results = await asyncio.gather(
-            *(_limited(sample) for sample in samples[:count])
-        )
+        # note (luojiaxuan): The measured cohort reuses this same sample list,
+        # so warming distinct samples would pre-fill per-sample server caches,
+        # such as the MOSS-TTS reference-audio cache, for requests that are
+        # about to be timed. Repeat one sample to get the concurrency shape
+        # without widening that bias as concurrency grows.
+        results = await asyncio.gather(*(_limited(samples[0]) for _ in range(count)))
         for i, result in enumerate(results):
             status = "ok" if result.is_success else result.error
             logger.info("  warmup %d/%d: %s", i + 1, count, status)

--- a/benchmarks/eval/benchmark_omni_seedtts.py
+++ b/benchmarks/eval/benchmark_omni_seedtts.py
@@ -193,7 +193,7 @@ class OmniSeedttsBenchmarkConfig:
     max_samples: int | None = None
     max_new_tokens: int = 256
     temperature: float = 0.7
-    warmup: int = 1
+    warmup: int | None = None
     max_concurrency: int = DEFAULT_TTS_BENCHMARK_CONCURRENCY
     request_rate: float = float("inf")
     disable_tqdm: bool = False
@@ -208,6 +208,15 @@ class OmniSeedttsBenchmarkConfig:
     # were not fine-tuned to robustly interpret "please read aloud" as a
     # verbatim-TTS command (e.g. Ming-Omni).
     system_prompt: str | None = None
+
+
+def _resolve_warmup(config: OmniSeedttsBenchmarkConfig) -> int:
+    # note (luojiaxuan): warmup=None means match the benchmark concurrency, so
+    # the timed cohort is not the first to absorb concurrency-shaped cold work.
+    # An explicit --warmup always wins, including 0 and 1.
+    if config.warmup is not None:
+        return config.warmup
+    return config.max_concurrency if config.max_concurrency > 0 else 1
 
 
 def _build_results_config(
@@ -225,7 +234,7 @@ def _build_results_config(
         "speaker": config.speaker,
         "max_samples": config.max_samples,
         "max_new_tokens": config.max_new_tokens,
-        "warmup": config.warmup,
+        "warmup": _resolve_warmup(config),
         "max_concurrency": config.max_concurrency,
         "request_rate": config.request_rate,
     }
@@ -346,16 +355,11 @@ async def run_omni_seedtts_benchmark(
         system_prompt=config.system_prompt,
     )
 
-    warmup_requests = (
-        config.max_concurrency
-        if config.warmup == 1 and config.max_concurrency > 0
-        else config.warmup
-    )
     runner = BenchmarkRunner(
         RunConfig(
             max_concurrency=config.max_concurrency,
             request_rate=config.request_rate,
-            warmup=warmup_requests,
+            warmup=_resolve_warmup(config),
             disable_tqdm=config.disable_tqdm,
         )
     )
@@ -505,7 +509,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Use streaming chat completions and concatenate audio chunks.",
     )
-    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=None,
+        help="Warmup requests; defaults to the configured concurrency.",
+    )
     parser.add_argument(
         "--max-concurrency",
         type=int,

--- a/benchmarks/eval/benchmark_omni_seedtts.py
+++ b/benchmarks/eval/benchmark_omni_seedtts.py
@@ -346,11 +346,16 @@ async def run_omni_seedtts_benchmark(
         system_prompt=config.system_prompt,
     )
 
+    warmup_requests = (
+        config.max_concurrency
+        if config.warmup == 1 and config.max_concurrency > 0
+        else config.warmup
+    )
     runner = BenchmarkRunner(
         RunConfig(
             max_concurrency=config.max_concurrency,
             request_rate=config.request_rate,
-            warmup=config.warmup,
+            warmup=warmup_requests,
             disable_tqdm=config.disable_tqdm,
         )
     )

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -298,11 +298,16 @@ async def run_tts_seedtts_benchmark(
         **generation_kwargs,
     )
 
+    warmup_requests = (
+        config.concurrency
+        if config.warmup == 1 and config.concurrency > 0
+        else config.warmup
+    )
     runner = BenchmarkRunner(
         RunConfig(
             max_concurrency=config.concurrency,
             request_rate=config.request_rate,
-            warmup=config.warmup,
+            warmup=warmup_requests,
             disable_tqdm=config.disable_tqdm,
         )
     )

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -162,7 +162,7 @@ class TtsSeedttsBenchmarkConfig:
     top_k: int | None = None
     repetition_penalty: float | None = None
     seed: int | None = None
-    warmup: int = 1
+    warmup: int | None = None
     concurrency: int = DEFAULT_TTS_BENCHMARK_CONCURRENCY
     request_rate: float = float("inf")
     stream: bool = False
@@ -208,6 +208,15 @@ def _build_generation_kwargs(config: TtsSeedttsBenchmarkConfig) -> dict:
     return generation_kwargs
 
 
+def _resolve_warmup(config: TtsSeedttsBenchmarkConfig) -> int:
+    # note (luojiaxuan): warmup=None means match the benchmark concurrency, so
+    # the timed cohort is not the first to absorb concurrency-shaped cold work.
+    # An explicit --warmup always wins, including 0 and 1.
+    if config.warmup is not None:
+        return config.warmup
+    return config.concurrency if config.concurrency > 0 else 1
+
+
 def _build_results_config(
     config: TtsSeedttsBenchmarkConfig,
     *,
@@ -230,7 +239,7 @@ def _build_results_config(
         "max_new_tokens": config.max_new_tokens,
         "seed": config.seed,
         "token_count": config.token_count,
-        "warmup": config.warmup,
+        "warmup": _resolve_warmup(config),
         "concurrency": config.concurrency,
         "request_rate": config.request_rate,
         "initial_codec_chunk_frames": config.initial_codec_chunk_frames,
@@ -298,16 +307,11 @@ async def run_tts_seedtts_benchmark(
         **generation_kwargs,
     )
 
-    warmup_requests = (
-        config.concurrency
-        if config.warmup == 1 and config.concurrency > 0
-        else config.warmup
-    )
     runner = BenchmarkRunner(
         RunConfig(
             max_concurrency=config.concurrency,
             request_rate=config.request_rate,
-            warmup=warmup_requests,
+            warmup=_resolve_warmup(config),
             disable_tqdm=config.disable_tqdm,
         )
     )
@@ -561,6 +565,7 @@ async def run_tts_concurrency_sweep(
         failed = int(summary.get("failed_requests") or 0)
         row = {
             "concurrency": concurrency,
+            "warmup": _resolve_warmup(point),
             "output_dir": point_output_dir,
             "success": success,
             "failed": failed,
@@ -754,7 +759,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         default=None,
         help="Per-request sampler seed for reproducible generation.",
     )
-    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=None,
+        help="Warmup requests; defaults to the configured concurrency.",
+    )
     parser.add_argument(
         "--concurrency",
         "--max-concurrency",


### PR DESCRIPTION
## Motivation

The TTS and Omni SeedTTS benchmarks currently send one sequential warmup request regardless of the configured concurrency. At concurrency greater than one, concurrency-shaped cold work can therefore enter the timed request cohort and inflate tail latency.

## Modifications

- Expand the default warmup to the configured concurrency in both SeedTTS benchmark entry points.
- Dispatch warmup requests concurrently under the same concurrency bound as the measured workload.
- Preserve `--warmup 0` as disabled and preserve explicit warmup counts greater than one.

## Accuracy Test

MOSS-TTS-Local, SeedTTS English, 1,088 samples, H100, concurrency 16, seed `20260902`, default sampling, fresh colocated single-GPU servers. Candidate ran before the exact parent.

| Metric | Parent (`7bbdac6e`) | Candidate (`cf6d05e2`) | Delta |
|---|---:|---:|---:|
| Completed | 1,088/1,088 | 1,088/1,088 | Same |
| Failed | 0 | 0 | Same |
| Corpus WER | 2.14% | 2.05% | -0.084 pp |
| Word errors | 255 / 11,943 | 245 / 11,943 | -10 |
| WER excluding >50% samples | 1.56% | 1.54% | -0.018 pp |
| Samples above 50% WER | 8 | 7 | -1 |

## Benchmark & Profiling

The same controlled run used an effective warmup of one request on the parent and 16 concurrent requests on the candidate.

| Metric | Parent | Candidate | Delta |
|---|---:|---:|---:|
| Request throughput | 15.579 req/s | 15.746 req/s | +1.07% |
| Mean latency | 1.021 s | 1.011 s | -0.98% |
| p95 latency | 1.416 s | 1.382 s | -2.40% |
| p99 latency | 1.605 s | 1.556 s | -3.05% |
| Mean RTF | 0.2355 | 0.2330 | -1.06% |
| p95 RTF | 0.2818 | 0.2760 | -2.06% |
| p99 RTF | 0.3105 | 0.3020 | -2.74% |
| Audio throughput | 68.562 s/s | 69.295 s/s | +1.07% |

## Checklist

- [x] Format the changed files with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput, latency, and accuracy results.
