### PR TITLE
[Qwen3-TTS] Add opt-in Talker MLP FP8

### DIFF
--- a/docs/cookbook/qwen3_tts.md
+++ b/docs/cookbook/qwen3_tts.md
@@ -94,6 +94,23 @@ PCM across runtime batch sizes. This mode reduces throughput because it
 serializes reference preprocessing and vocoder decoding and disables Talker
 compilation and the initial vocoder CUDA Graph, so it is disabled by default.
 
+### Talker MLP FP8
+
+To run the Talker and Code Predictor feed-forward MLPs in FP8, enable SGLang's
+quantization path explicitly:
+
+```bash
+sgl-omni serve \
+  --model-path Qwen/Qwen3-TTS-12Hz-0.6B-Base \
+  --config examples/configs/qwen3_tts_0_6b.yaml \
+  --tts_engine.engine.quantization fp8 \
+  --port 8000
+```
+
+Attention, embeddings, projections, and output heads remain on the BF16 path.
+BF16 is still the default and the reference for reporting FP8 accuracy and
+performance.
+
 ### Overload / admission policy
 
 Two SGLang generation-stage knobs bound how the server behaves past saturation:

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -182,7 +182,13 @@ class _PredictorDecodeGraph:
 
 
 class Qwen3TTSTalkerDecoderLayer(nn.Module):
-    def __init__(self, config: Any, layer_id: int, prefix: str = "") -> None:
+    def __init__(
+        self,
+        config: Any,
+        layer_id: int,
+        quant_config: Any = None,
+        prefix: str = "",
+    ) -> None:
         super().__init__()
         self.self_attn = Qwen3OmniMoeThinkerTextAttention(
             hidden_size=config.hidden_size,
@@ -203,6 +209,7 @@ class Qwen3TTSTalkerDecoderLayer(nn.Module):
         self.mlp = Qwen3OmniMoeTalkerDenseMLP(
             config.hidden_size,
             config.intermediate_size,
+            quant_config=quant_config,
             prefix=add_prefix("mlp", prefix),
         )
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -234,7 +241,7 @@ class Qwen3TTSTalkerDecoderLayer(nn.Module):
 
 
 class Qwen3TTSTalkerTextModel(nn.Module):
-    def __init__(self, config: Any, prefix: str = "") -> None:
+    def __init__(self, config: Any, quant_config: Any = None, prefix: str = "") -> None:
         super().__init__()
         self.config = config
         self.codec_embedding = nn.Embedding(config.vocab_size, config.hidden_size)
@@ -246,6 +253,7 @@ class Qwen3TTSTalkerTextModel(nn.Module):
                 Qwen3TTSTalkerDecoderLayer(
                     config,
                     idx,
+                    quant_config=quant_config,
                     prefix=add_prefix(f"layers.{idx}", prefix),
                 )
                 for idx in range(config.num_hidden_layers)
@@ -329,7 +337,7 @@ class Qwen3TTSTalkerTextModel(nn.Module):
 
 
 class Qwen3TTSCodePredictor(nn.Module):
-    def __init__(self, config: Any, prefix: str = "") -> None:
+    def __init__(self, config: Any, quant_config: Any = None, prefix: str = "") -> None:
         super().__init__()
         self.config = config
         cp_config = config.code_predictor_config
@@ -345,6 +353,7 @@ class Qwen3TTSCodePredictor(nn.Module):
                 Qwen3TTSTalkerDecoderLayer(
                     cp_config,
                     idx,
+                    quant_config=quant_config,
                     prefix=add_prefix(f"model.layers.{idx}", prefix),
                 )
                 for idx in range(cp_config.num_hidden_layers)
@@ -379,7 +388,6 @@ class Qwen3TTSTalker(nn.Module):
     """Qwen3-TTS Base talker with SGLang-managed KV cache for the main AR loop."""
 
     def __init__(self, config: Any, quant_config: Any = None, prefix: str = "") -> None:
-        del quant_config
         super().__init__()
         if hasattr(config, "talker_config"):
             root_config = config
@@ -404,7 +412,11 @@ class Qwen3TTSTalker(nn.Module):
             config.hidden_size,
             prefix=add_prefix("text_projection", prefix),
         )
-        self.model = Qwen3TTSTalkerTextModel(config, prefix=add_prefix("model", prefix))
+        self.model = Qwen3TTSTalkerTextModel(
+            config,
+            quant_config=quant_config,
+            prefix=add_prefix("model", prefix),
+        )
         self.codec_head = ReplicatedLinear(
             config.hidden_size,
             config.vocab_size,
@@ -413,6 +425,7 @@ class Qwen3TTSTalker(nn.Module):
         )
         self.code_predictor = Qwen3TTSCodePredictor(
             config,
+            quant_config=quant_config,
             prefix=add_prefix("code_predictor", prefix),
         )
 

--- a/sglang_omni/platforms/cuda.py
+++ b/sglang_omni/platforms/cuda.py
@@ -47,6 +47,12 @@ def _is_fp8_cutlass_moe_supported() -> bool:
     )
 
 
+def _enable_triton_w8a8_fp8_kernel() -> None:
+    from sglang.srt.layers.quantization import fp8_utils
+
+    fp8_utils.use_triton_w8a8_fp8_kernel = True
+
+
 class CUDAOmniPlatform(CudaDeviceMixin, OmniPlatform):
     def get_stage_process_env(
         self,
@@ -166,6 +172,28 @@ class CUDAOmniPlatform(CudaDeviceMixin, OmniPlatform):
             )
 
         fp8_gemm_backend = normalize_quantization(server_args.fp8_gemm_runner_backend)
+        if (
+            model_arch_override == "Qwen3TTSTalker"
+            and effective_quantization == "fp8"
+            and not server_args.disable_cuda_graph
+            and fp8_gemm_backend in (None, "auto")
+        ):
+            override_server_args(
+                server_args,
+                "sglang-omni-qwen3-tts-backend-policy",
+                fp8_gemm_runner_backend="triton",
+            )
+            fp8_gemm_backend = server_args.fp8_gemm_runner_backend
+
+        if (
+            model_arch_override == "Qwen3TTSTalker"
+            and effective_quantization == "fp8"
+            and fp8_gemm_backend == "triton"
+        ):
+            # SGLang 0.5.18's dynamic per-token/per-channel path still selects
+            # its dense GEMM through this compatibility switch.
+            _enable_triton_w8a8_fp8_kernel()
+
         if (
             model_arch_override == "Qwen3OmniTalker"
             and effective_quantization == "fp8"

--- a/tests/unit_test/qwen3_tts/test_fp8.py
+++ b/tests/unit_test/qwen3_tts/test_fp8.py
@@ -59,9 +59,7 @@ def test_qwen3_tts_fp8_is_routed_only_to_talker_mlp(monkeypatch) -> None:
     assert seen == {"attention": None, "mlp": quant_config}
 
 
-def test_qwen3_tts_talker_forwards_fp8_to_main_and_predictor_mlps(
-    monkeypatch,
-) -> None:
+def test_qwen3_tts_fp8_reaches_main_and_predictor_layers(monkeypatch) -> None:
     quant_config = object()
     seen: list[object] = []
 
@@ -72,7 +70,7 @@ def test_qwen3_tts_talker_forwards_fp8_to_main_and_predictor_mlps(
             seen.append(quant_config)
             self.self_attn = SimpleNamespace(num_kv_heads=1, head_dim=4)
 
-    class FakeLinear(nn.Module):
+    class FakeReplicatedLinear(nn.Module):
         def __init__(self, *args, **kwargs) -> None:
             super().__init__()
 
@@ -95,8 +93,7 @@ def test_qwen3_tts_talker_forwards_fp8_to_main_and_predictor_mlps(
     monkeypatch.setattr(
         sglang_model, "Qwen3TTSTalkerDecoderLayer", RecordingDecoderLayer
     )
-    monkeypatch.setattr(sglang_model, "ResizeMLP", FakeLinear)
-    monkeypatch.setattr(sglang_model, "ReplicatedLinear", FakeLinear)
+    monkeypatch.setattr(sglang_model, "ReplicatedLinear", FakeReplicatedLinear)
     monkeypatch.setattr(
         sglang_model,
         "RMSNorm",
@@ -107,15 +104,8 @@ def test_qwen3_tts_talker_forwards_fp8_to_main_and_predictor_mlps(
         "get_global_server_args",
         lambda: SimpleNamespace(max_running_requests=1),
     )
-    monkeypatch.setattr(
-        sglang_model.Qwen3TTSTalker,
-        "_normalize_predictor_graph_batch_sizes",
-        lambda *args, **kwargs: (1,),
-    )
-    monkeypatch.setattr(
-        sglang_model, "_bind_default_weight_loaders", lambda model: None
-    )
 
-    sglang_model.Qwen3TTSTalker(config, quant_config=quant_config)
+    sglang_model.Qwen3TTSTalkerTextModel(config, quant_config=quant_config)
+    sglang_model.Qwen3TTSCodePredictor(config, quant_config=quant_config)
 
     assert seen == [quant_config, quant_config]

--- a/tests/unit_test/qwen3_tts/test_fp8.py
+++ b/tests/unit_test/qwen3_tts/test_fp8.py
@@ -7,6 +7,8 @@ from types import SimpleNamespace
 from torch import nn
 
 from sglang_omni.models.qwen3_tts import sglang_model
+from sglang_omni.platforms import cuda
+from sglang_omni.platforms.cuda import CUDAOmniPlatform
 
 
 def _decoder_config() -> SimpleNamespace:
@@ -109,3 +111,35 @@ def test_qwen3_tts_fp8_reaches_main_and_predictor_layers(monkeypatch) -> None:
     sglang_model.Qwen3TTSCodePredictor(config, quant_config=quant_config)
 
     assert seen == [quant_config, quant_config]
+
+
+def test_qwen3_tts_fp8_cuda_graph_uses_triton_gemm(monkeypatch) -> None:
+    enabled: list[bool] = []
+    server_args = SimpleNamespace(
+        quantization="fp8",
+        moe_runner_backend="auto",
+        fp8_gemm_runner_backend="auto",
+        fp4_gemm_runner_backend="auto",
+        disable_cuda_graph=False,
+        ep_size=1,
+    )
+    model_config = SimpleNamespace(
+        quantization=None,
+        hf_text_config=SimpleNamespace(),
+        hf_config=SimpleNamespace(quantization_config=None),
+    )
+    monkeypatch.setattr(
+        cuda,
+        "_enable_triton_w8a8_fp8_kernel",
+        lambda: enabled.append(True),
+    )
+
+    effective_quantization = CUDAOmniPlatform().apply_model_worker_backend_policy(
+        server_args,
+        model_config,
+        "Qwen3TTSTalker",
+    )
+
+    assert effective_quantization == "fp8"
+    assert server_args.fp8_gemm_runner_backend == "triton"
+    assert enabled == [True]

--- a/tests/unit_test/qwen3_tts/test_fp8.py
+++ b/tests/unit_test/qwen3_tts/test_fp8.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from torch import nn
+
+from sglang_omni.models.qwen3_tts import sglang_model
+
+
+def _decoder_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        hidden_size=8,
+        intermediate_size=16,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        rope_theta=10000.0,
+        rope_scaling=None,
+        max_position_embeddings=128,
+        head_dim=4,
+        rms_norm_eps=1e-6,
+        attention_bias=False,
+    )
+
+
+def test_qwen3_tts_fp8_is_routed_only_to_talker_mlp(monkeypatch) -> None:
+    quant_config = object()
+    seen: dict[str, object] = {}
+
+    class RecordingAttention(nn.Module):
+        def __init__(self, **kwargs) -> None:
+            super().__init__()
+            seen["attention"] = kwargs.get("quant_config")
+
+    class RecordingMLP(nn.Module):
+        def __init__(
+            self,
+            hidden_size,
+            intermediate_size,
+            quant_config=None,
+            prefix="",
+        ) -> None:
+            super().__init__()
+            del hidden_size, intermediate_size, prefix
+            seen["mlp"] = quant_config
+
+    monkeypatch.setattr(
+        sglang_model, "Qwen3OmniMoeThinkerTextAttention", RecordingAttention
+    )
+    monkeypatch.setattr(sglang_model, "Qwen3OmniMoeTalkerDenseMLP", RecordingMLP)
+
+    sglang_model.Qwen3TTSTalkerDecoderLayer(
+        _decoder_config(),
+        layer_id=0,
+        quant_config=quant_config,
+    )
+
+    assert seen == {"attention": None, "mlp": quant_config}
+
+
+def test_qwen3_tts_talker_forwards_fp8_to_main_and_predictor_mlps(
+    monkeypatch,
+) -> None:
+    quant_config = object()
+    seen: list[object] = []
+
+    class RecordingDecoderLayer(nn.Module):
+        def __init__(self, config, layer_id, quant_config=None, prefix="") -> None:
+            super().__init__()
+            del config, layer_id, prefix
+            seen.append(quant_config)
+            self.self_attn = SimpleNamespace(num_kv_heads=1, head_dim=4)
+
+    class FakeLinear(nn.Module):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__()
+
+    predictor_config = SimpleNamespace(
+        vocab_size=32,
+        hidden_size=8,
+        num_hidden_layers=1,
+        rms_norm_eps=1e-6,
+    )
+    config = SimpleNamespace(
+        vocab_size=32,
+        text_vocab_size=32,
+        text_hidden_size=8,
+        hidden_size=8,
+        num_hidden_layers=1,
+        rms_norm_eps=1e-6,
+        num_code_groups=2,
+        code_predictor_config=predictor_config,
+    )
+    monkeypatch.setattr(
+        sglang_model, "Qwen3TTSTalkerDecoderLayer", RecordingDecoderLayer
+    )
+    monkeypatch.setattr(sglang_model, "ResizeMLP", FakeLinear)
+    monkeypatch.setattr(sglang_model, "ReplicatedLinear", FakeLinear)
+    monkeypatch.setattr(
+        sglang_model,
+        "RMSNorm",
+        lambda hidden_size, eps: nn.Identity(),
+    )
+    monkeypatch.setattr(
+        sglang_model,
+        "get_global_server_args",
+        lambda: SimpleNamespace(max_running_requests=1),
+    )
+    monkeypatch.setattr(
+        sglang_model.Qwen3TTSTalker,
+        "_normalize_predictor_graph_batch_sizes",
+        lambda *args, **kwargs: (1,),
+    )
+    monkeypatch.setattr(
+        sglang_model, "_bind_default_weight_loaders", lambda model: None
+    )
+
+    sglang_model.Qwen3TTSTalker(config, quant_config=quant_config)
+
+    assert seen == [quant_config, quant_config]


### PR DESCRIPTION
## Summary
- route SGLang's opt-in FP8 quantization through the Qwen3-TTS Talker and Code Predictor feed-forward MLPs
- keep attention, embeddings, projections, output heads, and the default serving path in BF16
- document the launch override and add focused routing tests

Refs #1754 (T-PR17).

## Benchmark

### Setup

- Qwen3-TTS 1.7B Base, full Seed-TTS EN, seed 123456, non-streaming c1/c8/c16
- one fixed H100 SXM 80GB (`GPU-05268ae7-5cde-ee1a-dcbd-79e748a51c9c`), driver 595.71.05, CUDA 13.0.3
- each precision was run twice at c1, c8, and c16; the execution order was interleaved as BF16 → FP8 → FP8 → BF16
- Base: `ef9479460420933d58c243d50befe18e6fe8ce9d`
- benchmarked Head: `bd3bb401a98d7be6a07a2474313aedf249031792`; the only subsequent commit (`e834d428fb5d29eaec83d954d215a0f9550cc625`) simplifies unit-test scaffolding without changing runtime code
- images: `rfgleamchaser/sglang-omni-pr1790@sha256:197a06f9743a2b94db8860974459a99fbedaa2989e72ade0001c663db18c4473` (Base), `rfgleamchaser/sglang-omni-pr1790@sha256:9d427711bcefd1391539a1c731f9da61aaf787b7ce87d989bf0f6c0c2b3f6e07` (Head)

All primary metrics use the same 1087-sample cohort in every run. `common_voice_en_19916471-common_voice_en_19916474` is uniformly excluded because it produced 163.84-second runaway audio in one of the two FP8 c8 runs and both FP8 c16 runs. It was normal in both FP8 c1 runs and all six BF16 runs. The anomaly heavily distorts aggregate WER and audio throughput. The raw 1088-sample summaries and all three anomaly observations are retained; the exclusion prevents one sample from dominating the aggregate and does not establish that the anomaly is unrelated to FP8.

### Quality (1087-sample common cohort)

Values are means of the two runs for each precision and concurrency. WER delta is an absolute percentage-point change; SIM and UTMOS deltas are absolute.

| concurrency | BF16 WER | FP8 WER | Δ WER | BF16 SIM | FP8 SIM | Δ SIM | BF16 UTMOS | FP8 UTMOS | Δ UTMOS |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| c1 | 1.039% | 1.048% | +0.009 pp | 71.337 | 71.514 | +0.177 | 4.2046 | 4.1940 | -0.0107 |
| c8 | 1.027% | 1.073% | +0.046 pp | 71.066 | 71.327 | +0.262 | 4.2021 | 4.2005 | -0.0016 |
| c16 | 0.981% | 1.060% | +0.080 pp | 71.297 | 71.405 | +0.108 | 4.2006 | 4.1979 | -0.0027 |

All 1087 retained samples completed generation, WER, speaker-similarity, and UTMOS evaluation in every cell. The largest observed aggregate quality changes are +0.080 pp WER and -0.0107 UTMOS; speaker similarity is slightly higher at all three concurrency levels.

### Performance (1087-sample common cohort)

Latency and RTF distributions are recomputed exactly from retained per-request records.

| concurrency | BF16 latency | FP8 latency | Δ | BF16 RTF | FP8 RTF | Δ |
|---:|---:|---:|---:|---:|---:|---:|
| c1 | 0.575 s | 0.575 s | +0.09% | 0.1437 | 0.1438 | +0.10% |
| c8 | 0.979 s | 0.990 s | +1.12% | 0.2407 | 0.2439 | +1.33% |
| c16 | 1.495 s | 1.478 s | -1.17% | 0.3689 | 0.3637 | -1.42% |

The benchmark runner did not persist per-request start/end timestamps. Adjusted req/s (retained-request count divided by the original measured cell wall-clock) changes by -0.06% at c1, -2.37% at c8, and -1.62% at c16, but these are accounting-adjusted values rather than a counterfactual rerun without the excluded request. Audio/token throughput and raw 200 ms GPU telemetry are retained with the artifacts; they are not used to claim an end-to-end speedup because the runaway request affected cell wall-clock and concurrent scheduling.

Active-cell telemetry, including startup and all 1088 raw requests, showed **5.3–12.9% lower mean power** for FP8. Peak GPU memory was effectively unchanged at c1/c16 and 1.57 GiB higher at c8; telemetry is diagnostic rather than a per-sample adjusted result.

Overall, Talker MLP FP8 preserves aggregate quality on the retained cohort, but this run does not demonstrate a material end-to-end throughput improvement. The repeated FP8-only runaway for the excluded sample remains a correctness anomaly to investigate separately.

## Action Item
Investigate why common_voice_en_19916471-common_voice_en_19916474 produced 163.84-second runaway audio at one c8 run and two c16 runs for FP8

## Test plan
- [x] Full Seed-TTS EN BF16/FP8 accuracy and performance benchmark on H100 using interleaved Base → Head → Head → Base runs
- [x] Captured per-request accuracy/performance outputs, exact commands, service logs, package snapshots, 200 ms GPU telemetry, and SHA-256 manifests

