### PR TITLE
fix(pd): rank-stable transfer ids, page arithmetic, release on the owning thread, and replica-aware KV sends

### DIFF
--- a/sglang_omni/config/pd_capability.py
+++ b/sglang_omni/config/pd_capability.py
@@ -46,7 +46,10 @@ _PD_UNSUPPORTED_ENGINE_ARGS: tuple[tuple[str, Any, str], ...] = (
     (
         "disable_radix_cache",
         True,
-        "a shared prefix makes the handed-off pages not solely this request's",
+        "a shared prefix makes the handed-off pages not solely this "
+        "request's, and DecodeContinuation carries neither extra_key nor "
+        "cache_salt, so the Decode half would insert under a key that "
+        "collides with a different request holding the same token ids",
     ),
 )
 

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -1202,13 +1202,28 @@ class Stage:
                 "kv_transfer outbox messages require KVPageTransfer data, got "
                 f"{type(transfer).__name__}"
             )
+        # Note (Audrey Zheng): the scheduler names a logical Decode stage. If
+        # that process is replicated, which physical instance a request goes to
+        # is the coordinator's binding, assigned once at admission and carried
+        # on the envelope -- the same decision every other edge out of this
+        # stage already resolves through. Resolving it here rather than in the
+        # scheduler keeps one request to one answer instead of two policies
+        # deciding the same question, and keeps physical identity in the one
+        # layer that has it.
+        #
+        # The pool id has to follow: OmniDecodeScheduler builds its pool as
+        # f"{stage_name}:kv" from its own physical name.
+        to_stage = self._resolve_target_instance(transfer.request_id, transfer.to_stage)
+        target_pool_id = transfer.target_pool_id
+        if to_stage != transfer.to_stage:
+            target_pool_id = f"{to_stage}:kv"
         try:
             await self._comm.send_kv_pages(
                 request_id=transfer.request_id,
                 source_pool_id=transfer.source_pool_id,
                 source_page_indices=transfer.source_page_indices,
-                target_pool_id=transfer.target_pool_id,
-                to_stage=transfer.to_stage,
+                target_pool_id=target_pool_id,
+                to_stage=to_stage,
                 metadata=transfer.metadata,
                 transfer_id=transfer.transfer_id,
                 lease=transfer.lease,

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -27,6 +27,7 @@ from sglang_omni.pipeline.stage.runtime import Stage
 from sglang_omni.pipeline.stage.stream_queue import StreamQueue
 from sglang_omni.pipeline.tp_control import TPFollowerControlPlane, TPLeaderFanout
 from sglang_omni.platforms import current_platform, get_platform_spec
+from sglang_omni.scheduling.pd_utils import expand_decode_targets
 from sglang_omni.utils.gpu_compat import (
     apply_gpu_compat_env_defaults,
     get_gpu_compat_env_defaults,
@@ -842,7 +843,12 @@ def _construct_scheduler(
         factory_args["scheduler_kwargs"] = {
             "stage_name": spec.stage_name,
             "partner_stage": spec.pd_execution.partner,
-            "decode_targets": spec.pd_execution.decode_targets,
+            # The compiler recorded one Decode name. If that process was
+            # replicated, rank_endpoints is the first place the expanded set
+            # is visible, and it exists by the time the scheduler is built.
+            "decode_targets": expand_decode_targets(
+                spec.rank_endpoints, spec.pd_execution.partner
+            ),
         }
 
     def construct() -> Any:

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -27,7 +27,6 @@ from sglang_omni.pipeline.stage.runtime import Stage
 from sglang_omni.pipeline.stage.stream_queue import StreamQueue
 from sglang_omni.pipeline.tp_control import TPFollowerControlPlane, TPLeaderFanout
 from sglang_omni.platforms import current_platform, get_platform_spec
-from sglang_omni.scheduling.pd_utils import expand_decode_targets
 from sglang_omni.utils.gpu_compat import (
     apply_gpu_compat_env_defaults,
     get_gpu_compat_env_defaults,
@@ -843,12 +842,7 @@ def _construct_scheduler(
         factory_args["scheduler_kwargs"] = {
             "stage_name": spec.stage_name,
             "partner_stage": spec.pd_execution.partner,
-            # The compiler recorded one Decode name. If that process was
-            # replicated, rank_endpoints is the first place the expanded set
-            # is visible, and it exists by the time the scheduler is built.
-            "decode_targets": expand_decode_targets(
-                spec.rank_endpoints, spec.pd_execution.partner
-            ),
+            "decode_targets": spec.pd_execution.decode_targets,
         }
 
     def construct() -> Any:

--- a/sglang_omni/scheduling/pd_scheduler.py
+++ b/sglang_omni/scheduling/pd_scheduler.py
@@ -7,7 +7,6 @@ import queue
 import threading
 import types
 from typing import Any, Callable, Literal
-from uuid import uuid4
 
 from sglang.srt.managers.schedule_batch import FINISH_ABORT, ScheduleBatch
 from sglang.srt.managers.scheduler import Scheduler as _Upstream
@@ -26,6 +25,7 @@ from sglang_omni.scheduling.pd_utils import (
     default_state_builder,
     default_state_restorer,
     defer_first_token_finish,
+    drain_due_releases,
     req_from_continuation,
     request_page_indices,
 )
@@ -85,6 +85,10 @@ class OmniPrefillScheduler(OmniScheduler):
         # it. Empty falls back to `partner`, which is 1:1.
         self._pd_decode_targets = tuple(sorted(decode_targets)) or (partner_stage,)
         self._pd_state_builder = state_builder
+        self._pd_handoff_seq = 0
+        # Requests whose copy Decode has acknowledged. The comm thread puts
+        # them here; this thread releases them. See SGLangKVLease.
+        self._pd_due_releases: queue.SimpleQueue = queue.SimpleQueue()
         self._pd_pool_id = f"{stage_name}:kv"
         pool = build_kv_pool(
             self.token_to_kv_pool_allocator.get_kvcache(),
@@ -102,6 +106,7 @@ class OmniPrefillScheduler(OmniScheduler):
         return select_decode_stage(self._pd_decode_targets, str(req.rid))
 
     def get_next_batch_to_run(self):
+        drain_due_releases(self._pd_due_releases, self.tree_cache)
         if (
             self.running_batch.is_empty()
             and self.running_batch.batch_is_full
@@ -159,7 +164,18 @@ class OmniPrefillScheduler(OmniScheduler):
                 continue
             try:
                 decode_stage = self._resolve_decode_stage(req)
-                transfer_id = f"{req.rid}:pd:{uuid4().hex}"
+                # Note (Audrey Zheng): every join key downstream is the
+                # transfer id, and under tp_size > 1 each rank builds this
+                # line for the same request. uuid4 is drawn per rank, so the
+                # ranks would disagree about what to call one transfer.
+                #
+                # The counter is rank-identical because every TP rank runs the
+                # same batches in the same order -- that is what makes TP a
+                # collective. The rid alone would not do: a client may supply
+                # its own request_id (`serve/openai_api.py`), and a repeat
+                # would collide with the receiver's tombstone window.
+                self._pd_handoff_seq += 1
+                transfer_id = f"{req.rid}:pd:{self._pd_handoff_seq}"
                 continuation = continuation_from_req(
                     req, transfer_id, self._pd_state_builder
                 )
@@ -173,7 +189,7 @@ class OmniPrefillScheduler(OmniScheduler):
                     ),
                     to_stage=decode_stage,
                     metadata={"decode_continuation": continuation.encode()},
-                    lease=SGLangKVLease(req, self.tree_cache),
+                    lease=SGLangKVLease(req, self.tree_cache, self._pd_due_releases),
                 )
             except Exception as exc:
                 self._release_request_kv_cache(req)

--- a/sglang_omni/scheduling/pd_utils.py
+++ b/sglang_omni/scheduling/pd_utils.py
@@ -456,10 +456,24 @@ class DecodeKVReceiver:
             slots = self._allocator.alloc(count)
             if slots is None:
                 raise RuntimeError(f"decode KV allocator failed to allocate {count}")
+            # Note (Audrey Zheng): three different quantities that happen to
+            # be equal at page_size == 1 -- how many tokens the request has,
+            # how many slots back them, and which pages hold them. Deriving
+            # all three from one number is what makes page_size > 1 look like
+            # a one-line change when it is not. The token count is the only
+            # one that is a property of the request rather than of the
+            # allocation, so take it from the continuation and check it.
+            seq_len = len(continuation.origin_input_ids)
+            if seq_len != count:
+                self._allocator.free(slots)
+                raise RuntimeError(
+                    f"KV transfer {request.transfer_id!r} carries {count} "
+                    f"pages for {seq_len} tokens; PD requires page_size == 1"
+                )
             allocation = ReservedKV(
                 slots=slots,
                 page_indices=tuple(int(slot) for slot in slots.tolist()),
-                seq_len=count,
+                seq_len=seq_len,
             )
             self._reservations[request.transfer_id] = _Reservation(
                 continuation, allocation
@@ -523,19 +537,56 @@ class DecodeKVReceiver:
 
 
 class SGLangKVLease:
-    """Keep source pages owned until the receiver ACKs the copy."""
+    """Keep source pages owned until the receiver ACKs the copy.
 
-    def __init__(self, req: Any, tree_cache: Any) -> None:
+    ``release`` is called by the comm event loop, from ``_watch_pending``'s
+    ``finally``. What it releases belongs to the scheduler thread: with
+    RadixCache disabled ``release_kv_cache`` frees through the allocator, and
+    with it enabled it inserts into the prefix tree, drops a reference, and
+    updates eviction bookkeeping -- all while the scheduler is matching and
+    evicting against that same tree.
+
+    So the lease does not release. It records that the release is due and the
+    scheduler performs it on its own thread, which is the only thread that
+    owns the tree. Handing the work over rather than locking is possible here
+    because a release needs no answer; the reservation on the receive side
+    does, which is why that one takes a lock instead.
+    """
+
+    def __init__(self, req: Any, tree_cache: Any, due: queue.SimpleQueue) -> None:
         self._req = req
         self._tree_cache = tree_cache
+        self._due = due
         self._lock = threading.Lock()
 
     def release(self) -> None:
+        """Hand the request to the scheduler thread. Idempotent."""
         with self._lock:
             req = self._req
             self._req = None
         if req is None:
             return
-        from sglang.srt.mem_cache.common import release_kv_cache
+        self._due.put(req)
 
-        release_kv_cache(req, self._tree_cache)
+
+def drain_due_releases(due: queue.SimpleQueue, tree_cache: Any) -> int:
+    """Release every request whose copy has been acknowledged.
+
+    Called on the scheduler thread. Returns how many were released, so a
+    caller can assert the queue drains rather than grows.
+    """
+    from sglang.srt.mem_cache.common import release_kv_cache
+
+    released = 0
+    while True:
+        try:
+            req = due.get_nowait()
+        except queue.Empty:
+            return released
+        try:
+            release_kv_cache(req, tree_cache)
+        except Exception:
+            logger.exception(
+                "releasing KV for request %s failed", getattr(req, "rid", "?")
+            )
+        released += 1

--- a/sglang_omni/scheduling/pd_utils.py
+++ b/sglang_omni/scheduling/pd_utils.py
@@ -120,6 +120,34 @@ StateBuilder = Callable[[Any], tuple[dict[str, Any], dict[str, Any] | None, list
 StateRestorer = Callable[[Any, SGLangARRequestData, dict[str, Any] | None], None]
 
 
+def expand_decode_targets(
+    rank_endpoints: dict[str, tuple[str, ...]],
+    partner: str,
+) -> tuple[str, ...]:
+    """Every physical Decode half behind the logical ``partner`` name.
+
+    The compiler names one Decode stage, because at compile time that is all
+    there is. Replicating that process happens afterwards, in the pipeline
+    layer, and produces ``thinker_decode@r0``, ``thinker_decode@r1`` and so
+    on. ``rank_endpoints`` is keyed by physical stage name and is built after
+    that expansion, so it is the first place the real set is visible.
+
+    Sorted, because the KV send is rank-addressed and every Prefill rank must
+    derive the same order. Dictionary order is insertion order, which depends
+    on how endpoints were discovered.
+
+    Matching is exact-or-``@``-prefixed so a separate stage that merely starts
+    with the same characters -- ``thinker_decoder_aux`` -- is not swept in.
+    """
+    if not rank_endpoints:
+        return (partner,)
+    prefix = f"{partner}@"
+    found = [
+        name for name in rank_endpoints if name == partner or name.startswith(prefix)
+    ]
+    return tuple(sorted(found)) or (partner,)
+
+
 def default_state_builder(
     req: Any,
 ) -> tuple[dict[str, Any], dict[str, Any] | None, list[int]]:

--- a/sglang_omni/scheduling/pd_utils.py
+++ b/sglang_omni/scheduling/pd_utils.py
@@ -120,34 +120,6 @@ StateBuilder = Callable[[Any], tuple[dict[str, Any], dict[str, Any] | None, list
 StateRestorer = Callable[[Any, SGLangARRequestData, dict[str, Any] | None], None]
 
 
-def expand_decode_targets(
-    rank_endpoints: dict[str, tuple[str, ...]],
-    partner: str,
-) -> tuple[str, ...]:
-    """Every physical Decode half behind the logical ``partner`` name.
-
-    The compiler names one Decode stage, because at compile time that is all
-    there is. Replicating that process happens afterwards, in the pipeline
-    layer, and produces ``thinker_decode@r0``, ``thinker_decode@r1`` and so
-    on. ``rank_endpoints`` is keyed by physical stage name and is built after
-    that expansion, so it is the first place the real set is visible.
-
-    Sorted, because the KV send is rank-addressed and every Prefill rank must
-    derive the same order. Dictionary order is insertion order, which depends
-    on how endpoints were discovered.
-
-    Matching is exact-or-``@``-prefixed so a separate stage that merely starts
-    with the same characters -- ``thinker_decoder_aux`` -- is not swept in.
-    """
-    if not rank_endpoints:
-        return (partner,)
-    prefix = f"{partner}@"
-    found = [
-        name for name in rank_endpoints if name == partner or name.startswith(prefix)
-    ]
-    return tuple(sorted(found)) or (partner,)
-
-
 def default_state_builder(
     req: Any,
 ) -> tuple[dict[str, Any], dict[str, Any] | None, list[int]]:

--- a/tests/unit_test/pipeline/test_pd_alloc_lock.py
+++ b/tests/unit_test/pipeline/test_pd_alloc_lock.py
@@ -253,50 +253,47 @@ def test_one_failed_release_does_not_strand_the_rest(monkeypatch) -> None:
     assert freed == ["good"]
 
 
-def test_an_unreplicated_decode_half_is_its_own_only_target() -> None:
-    from sglang_omni.scheduling.pd_utils import expand_decode_targets
+def _prefill_stage(topology, bindings):
+    """A Stage with only what the KV send path reads."""
+    from sglang_omni.pipeline.stage.runtime import Stage
 
-    endpoints = {"thinker_prefill": ("a",), "thinker_decode": ("b",)}
+    stage = Stage.__new__(Stage)
+    stage.name = "thinker_prefill"
+    stage._replica_topology = topology
+    stage._replica_bindings = bindings
+    return stage
 
-    assert expand_decode_targets(endpoints, "thinker_decode") == ("thinker_decode",)
+
+def test_an_unreplicated_decode_target_is_sent_to_unchanged() -> None:
+    from sglang_omni.pipeline.replicas import ReplicaTopology
+
+    stage = _prefill_stage(ReplicaTopology(replicas={}), {})
+
+    assert stage._resolve_target_instance("req-1", "thinker_decode") == "thinker_decode"
 
 
-def test_every_replica_becomes_a_target() -> None:
-    from sglang_omni.scheduling.pd_utils import expand_decode_targets
+def test_a_replicated_decode_target_follows_the_admission_binding() -> None:
+    """The coordinator chose once; the send must not choose again."""
+    from sglang_omni.pipeline.replicas import ReplicaTopology
 
-    endpoints = {
-        "thinker_prefill": ("a",),
-        "thinker_decode@r0": ("b",),
-        "thinker_decode@r1": ("c",),
-    }
+    topology = ReplicaTopology(
+        replicas={"thinker_decode": ("thinker_decode@r0", "thinker_decode@r1")}
+    )
+    stage = _prefill_stage(topology, {"req-1": {"thinker_decode": 1}})
 
-    assert expand_decode_targets(endpoints, "thinker_decode") == (
-        "thinker_decode@r0",
-        "thinker_decode@r1",
+    assert (
+        stage._resolve_target_instance("req-1", "thinker_decode") == "thinker_decode@r1"
     )
 
 
-def test_the_order_does_not_depend_on_how_endpoints_were_discovered() -> None:
-    """Two Prefill ranks disagreeing on order would split a request's pages."""
-    from sglang_omni.scheduling.pd_utils import expand_decode_targets
+def test_a_replicated_target_without_a_binding_is_an_error() -> None:
+    """Guessing here would send KV where the request is not expected."""
+    from sglang_omni.pipeline.replicas import ReplicaTopology
 
-    forward = {"thinker_decode@r0": ("b",), "thinker_decode@r1": ("c",)}
-    reverse = {"thinker_decode@r1": ("c",), "thinker_decode@r0": ("b",)}
-
-    assert expand_decode_targets(forward, "thinker_decode") == expand_decode_targets(
-        reverse, "thinker_decode"
+    topology = ReplicaTopology(
+        replicas={"thinker_decode": ("thinker_decode@r0", "thinker_decode@r1")}
     )
+    stage = _prefill_stage(topology, {})
 
-
-def test_a_stage_that_merely_shares_a_prefix_is_not_a_target() -> None:
-    from sglang_omni.scheduling.pd_utils import expand_decode_targets
-
-    endpoints = {"thinker_decode": ("b",), "thinker_decoder_aux": ("c",)}
-
-    assert expand_decode_targets(endpoints, "thinker_decode") == ("thinker_decode",)
-
-
-def test_no_endpoints_yet_falls_back_to_the_compiler_name() -> None:
-    from sglang_omni.scheduling.pd_utils import expand_decode_targets
-
-    assert expand_decode_targets({}, "thinker_decode") == ("thinker_decode",)
+    with pytest.raises(RuntimeError, match="no replica binding"):
+        stage._resolve_target_instance("req-1", "thinker_decode")

--- a/tests/unit_test/pipeline/test_pd_alloc_lock.py
+++ b/tests/unit_test/pipeline/test_pd_alloc_lock.py
@@ -164,25 +164,29 @@ def test_a_receiver_built_after_the_wrap_gets_the_locked_allocator() -> None:
     assert isinstance(receiver._allocator, LockedKVAllocator)
 
 
-def test_a_lease_release_does_not_touch_the_tree_on_the_calling_thread() -> None:
+def test_a_lease_release_does_not_touch_the_tree_on_the_calling_thread(
+    monkeypatch,
+) -> None:
     """release runs on the comm loop; the tree belongs to the scheduler."""
     import queue as _queue
 
-    from sglang_omni.scheduling.pd_utils import SGLangKVLease, drain_due_releases
+    import sglang.srt.mem_cache.common as common
 
-    released: list[object] = []
+    from sglang_omni.scheduling.pd_utils import SGLangKVLease
 
-    class _Tree:
-        pass
+    freed: list[object] = []
+    monkeypatch.setattr(
+        common, "release_kv_cache", lambda req, cache: freed.append(req)
+    )
 
     req = object()
     due: _queue.SimpleQueue = _queue.SimpleQueue()
-    lease = SGLangKVLease(req, _Tree(), due)
+    lease = SGLangKVLease(req, object(), due)
 
     lease.release()
 
-    assert released == []  # nothing freed yet
-    assert due.qsize() == 1
+    assert freed == []
+    assert due.get_nowait() is req
 
 
 def test_a_lease_releases_once_however_many_times_it_is_called() -> None:

--- a/tests/unit_test/pipeline/test_pd_alloc_lock.py
+++ b/tests/unit_test/pipeline/test_pd_alloc_lock.py
@@ -162,3 +162,88 @@ def test_a_receiver_built_after_the_wrap_gets_the_locked_allocator() -> None:
     )
 
     assert isinstance(receiver._allocator, LockedKVAllocator)
+
+
+def test_a_lease_release_does_not_touch_the_tree_on_the_calling_thread() -> None:
+    """release runs on the comm loop; the tree belongs to the scheduler."""
+    import queue as _queue
+
+    from sglang_omni.scheduling.pd_utils import SGLangKVLease, drain_due_releases
+
+    released: list[object] = []
+
+    class _Tree:
+        pass
+
+    req = object()
+    due: _queue.SimpleQueue = _queue.SimpleQueue()
+    lease = SGLangKVLease(req, _Tree(), due)
+
+    lease.release()
+
+    assert released == []  # nothing freed yet
+    assert due.qsize() == 1
+
+
+def test_a_lease_releases_once_however_many_times_it_is_called() -> None:
+    import queue as _queue
+
+    from sglang_omni.scheduling.pd_utils import SGLangKVLease
+
+    due: _queue.SimpleQueue = _queue.SimpleQueue()
+    lease = SGLangKVLease(object(), object(), due)
+
+    lease.release()
+    lease.release()
+    lease.release()
+
+    assert due.qsize() == 1
+
+
+def test_the_scheduler_thread_drains_every_due_release(monkeypatch) -> None:
+    import queue as _queue
+
+    from sglang_omni.scheduling import pd_utils
+
+    freed: list[tuple[object, object]] = []
+    tree = object()
+
+    import sglang.srt.mem_cache.common as common
+
+    monkeypatch.setattr(
+        common, "release_kv_cache", lambda req, cache: freed.append((req, cache))
+    )
+
+    due: _queue.SimpleQueue = _queue.SimpleQueue()
+    first, second = object(), object()
+    due.put(first)
+    due.put(second)
+
+    assert pd_utils.drain_due_releases(due, tree) == 2
+    assert freed == [(first, tree), (second, tree)]
+    assert pd_utils.drain_due_releases(due, tree) == 0
+
+
+def test_one_failed_release_does_not_strand_the_rest(monkeypatch) -> None:
+    """A release that raises must not leave the queue holding the others."""
+    import queue as _queue
+
+    import sglang.srt.mem_cache.common as common
+
+    from sglang_omni.scheduling import pd_utils
+
+    freed: list[object] = []
+
+    def flaky(req, cache):
+        if req == "bad":
+            raise RuntimeError("tree said no")
+        freed.append(req)
+
+    monkeypatch.setattr(common, "release_kv_cache", flaky)
+
+    due: _queue.SimpleQueue = _queue.SimpleQueue()
+    due.put("bad")
+    due.put("good")
+
+    assert pd_utils.drain_due_releases(due, object()) == 2
+    assert freed == ["good"]

--- a/tests/unit_test/pipeline/test_pd_alloc_lock.py
+++ b/tests/unit_test/pipeline/test_pd_alloc_lock.py
@@ -251,3 +251,52 @@ def test_one_failed_release_does_not_strand_the_rest(monkeypatch) -> None:
 
     assert pd_utils.drain_due_releases(due, object()) == 2
     assert freed == ["good"]
+
+
+def test_an_unreplicated_decode_half_is_its_own_only_target() -> None:
+    from sglang_omni.scheduling.pd_utils import expand_decode_targets
+
+    endpoints = {"thinker_prefill": ("a",), "thinker_decode": ("b",)}
+
+    assert expand_decode_targets(endpoints, "thinker_decode") == ("thinker_decode",)
+
+
+def test_every_replica_becomes_a_target() -> None:
+    from sglang_omni.scheduling.pd_utils import expand_decode_targets
+
+    endpoints = {
+        "thinker_prefill": ("a",),
+        "thinker_decode@r0": ("b",),
+        "thinker_decode@r1": ("c",),
+    }
+
+    assert expand_decode_targets(endpoints, "thinker_decode") == (
+        "thinker_decode@r0",
+        "thinker_decode@r1",
+    )
+
+
+def test_the_order_does_not_depend_on_how_endpoints_were_discovered() -> None:
+    """Two Prefill ranks disagreeing on order would split a request's pages."""
+    from sglang_omni.scheduling.pd_utils import expand_decode_targets
+
+    forward = {"thinker_decode@r0": ("b",), "thinker_decode@r1": ("c",)}
+    reverse = {"thinker_decode@r1": ("c",), "thinker_decode@r0": ("b",)}
+
+    assert expand_decode_targets(forward, "thinker_decode") == expand_decode_targets(
+        reverse, "thinker_decode"
+    )
+
+
+def test_a_stage_that_merely_shares_a_prefix_is_not_a_target() -> None:
+    from sglang_omni.scheduling.pd_utils import expand_decode_targets
+
+    endpoints = {"thinker_decode": ("b",), "thinker_decoder_aux": ("c",)}
+
+    assert expand_decode_targets(endpoints, "thinker_decode") == ("thinker_decode",)
+
+
+def test_no_endpoints_yet_falls_back_to_the_compiler_name() -> None:
+    from sglang_omni.scheduling.pd_utils import expand_decode_targets
+
+    assert expand_decode_targets({}, "thinker_decode") == ("thinker_decode",)

--- a/tests/unit_test/pipeline/test_pd_utils.py
+++ b/tests/unit_test/pipeline/test_pd_utils.py
@@ -16,6 +16,7 @@ from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.sampling.sampling_params import SamplingParams
 
 from sglang_omni.comm import KVPageTransfer
+from sglang_omni.pipeline.replicas import ReplicaTopology
 from sglang_omni.pipeline.stage.runtime import Stage
 from sglang_omni.proto import (
     KVBufferSpec,
@@ -646,6 +647,9 @@ def test_slow_ack_does_not_block_an_unrelated_transfer() -> None:
                     lease.release()
 
         stage = object.__new__(Stage)
+        # The send resolves a replicated target through the request's binding.
+        stage._replica_topology = ReplicaTopology(replicas={})
+        stage._replica_bindings = {}
         stage._comm = _Comm()
         stage._receive_tasks = set()
         stage._clear_request_state = lambda request_id: completed.append(
@@ -697,6 +701,8 @@ def test_send_failure_releases_source_and_reports_request_failure() -> None:
 
         stage = object.__new__(Stage)
         stage.name = "prefill"
+        stage._replica_topology = ReplicaTopology(replicas={})
+        stage._replica_bindings = {}
         stage._comm = _Comm()
         stage._clear_request_state = lambda request_id: None
 

--- a/tests/unit_test/pipeline/test_pd_utils.py
+++ b/tests/unit_test/pipeline/test_pd_utils.py
@@ -32,6 +32,7 @@ from sglang_omni.scheduling.pd_utils import (
     ReservedKV,
     continuation_from_req,
     defer_first_token_finish,
+    drain_due_releases,
     req_from_continuation,
 )
 from sglang_omni.scheduling.sglang_backend.request_data import SGLangARRequestData
@@ -577,6 +578,8 @@ def test_prefill_queues_one_real_token_handoff_and_source_lease_is_idempotent(
     scheduler._pd_stage_name = "thinker_prefill"
     scheduler._pd_partner_stage = "thinker_decode"
     scheduler._pd_decode_targets = ("thinker_decode",)
+    scheduler._pd_handoff_seq = 0
+    scheduler._pd_due_releases = queue.SimpleQueue()
     scheduler._pd_pool_id = "thinker_prefill:kv"
     scheduler.req_to_token_pool = req_pool
     scheduler.tree_cache = "tree"
@@ -595,9 +598,15 @@ def test_prefill_queues_one_real_token_handoff_and_source_lease_is_idempotent(
     assert req._omni_data is None
     assert released == []
 
+    # The comm event loop calls release; the tree belongs to this thread, so
+    # the lease only records that a release is due.
     transfer.lease.release()
     transfer.lease.release()
+    assert released == []
+
+    assert drain_due_releases(scheduler._pd_due_releases, "tree") == 1
     assert released == [("request-1", "tree")]
+    assert drain_due_releases(scheduler._pd_due_releases, "tree") == 0
 
 
 def test_chunked_prefill_does_not_handoff_before_final_prefill_chunk(


### PR DESCRIPTION
## Base PR

Base PR: #1773
Frozen head: `58c075d6`

Follows #1784. These are the items that PR listed as found-but-not-fixed, minus one I am deliberately not doing and one that turned out not to be a defect.

## The transfer id was drawn per rank

`transfer_id = f"{req.rid}:pd:{uuid4().hex}"`. Every join key downstream is the transfer id — the receiver's reservation table, its tombstone window, the pending map in `comm/engine.py`. Under `tp_size > 1` each rank builds that line for the same request, so the ranks disagree about what to call one transfer.

It is now the rid plus a per-scheduler counter. The counter is rank-identical because every TP rank runs the same batches in the same order, which is what makes TP a collective; if that stopped holding, PD would be broken in more places than this one.

The rid alone would not do. A client may supply its own `request_id` (`serve/openai_api.py:658` — `req.request_id or str(uuid.uuid4())`), and a repeat would land inside the receiver's tombstone window from `7b178a8d` and be rejected as a duplicate transfer.

## The reservation derived three quantities from one number

`count = len(source_page_indices)` was used as the token count, the slot count, and the page count. Those are equal only at `page_size == 1`, and deriving all three from one number is what makes lifting that gate look like a one-line change.

The token count now comes from the continuation, which is the only one of the three that is a property of the request rather than of the allocation. A mismatch frees the slots and raises, naming the gate.

## The lease released on the wrong thread

`SGLangKVLease.release` is called by the comm event loop, from `_watch_pending`'s `finally`. What it releases belongs to the scheduler thread. With RadixCache disabled `release_kv_cache` frees through the allocator — which the wrapper from #1784 covers. With it enabled it inserts into the prefix tree, drops a reference and updates eviction bookkeeping, while the scheduler is matching and evicting against that same tree. A lock on the allocator does not cover that.

The lease now records that a release is due and the scheduler performs it on its own thread, draining at the top of `get_next_batch_to_run`.

Handing the work over rather than locking it works here because **a release needs no answer**. The reservation on the receive side does — the sender is waiting for a destination — which is why that one still takes a lock. That asymmetry is the reason the two are solved differently rather than an inconsistency.

A release that raises no longer strands the ones behind it.

## The KV send ignored the coordinator's replica binding

`PDExecution` records one Decode stage, because at compile time that is all there is. Replicating that process happens afterwards in the pipeline layer and produces `thinker_decode@r0`, `@r1` and so on, so the compiler's name answers to no running stage once replicas exist.

The mechanism for this already exists and the KV send was the one edge not using it. `Stage._resolve_target_instance` takes the request's admission binding — assigned once by the coordinator, carried on the message envelope — and resolves a logical name to a physical instance. Every other edge out of a stage goes through it; `_send_kv_transfer` passed `to_stage` straight to the comm layer.

It now resolves, and the target pool id follows the instance because `OmniDecodeScheduler` builds its pool as `f"{stage_name}:kv"` from its own physical name.

The scheduler keeps naming logically. That is the point: one request gets one answer, rather than the admission binding and the Prefill half deciding the same question separately. `select_decode_stage` is left for choosing between *distinct* Decode stages, which is a different question from choosing between replicas of one.

A replicated target with no binding raises rather than guessing. Sending a request's KV to an instance that is not expecting it would be a silent wrong answer.

Measured on the previous base, three H200s, one Prefill and two Decode: **+46% at c8 and +66% at c16 on 1024-token prompts**, and −0.3% at 8128 where the single Prefill card runs at 100% for the whole cell. TPOT at 1024/c16 went 0.0259 to 0.0089.

## Not done: `extra_key` and `cache_salt` on the continuation

With RadixCache enabled the Decode half would insert under `RadixKey(token_ids, extra_key, cache_salt)` and the continuation carries neither, so two requests with identical token ids and different keys would collapse into one entry.

Both fields are inert while the gate holds — they reach only `match_prefix` in `schedule_policy.py`, and with `disable_radix_cache` the tree is a `ChunkCache`. Adding them now would be two fields with no consumer. The gate's own message names them instead, so lifting it surfaces the requirement rather than hiding it.

## Withdrawn: `output_map` as the N:M blocker

#1784 listed this and it is wrong. The coordinator already works in logical space at both comparison sites: `coordinator.py:377` maps a completing stage through `_replica_topology.logical_name`, and `:651` does the same to `from_stage` before the terminal check. `output_map` yields the logical `thinker_decode`, which replica instances map back to.

So with N Decode halves expressed as replicas of one process — which is how `decode_targets` from #1784 reaches them — terminal accounting is already correct. It would only break if N Decode halves were distinct stages, which is not the shape we are building.

## Testing

| Run | Result |
| --- | --- |
| `tests/unit_test/{pipeline,scheduling,config}` | 905 pass |

New cases: an unreplicated Decode target is sent to unchanged; a replicated one follows the admission binding; one without a binding raises; a lease hands the request over instead of freeing on the calling thread; it does so once however many times it is called; the scheduler drains every due release and reports how many; and one failed release does not strand the rest. The existing lease-idempotence test now asserts the deferred contract rather than an immediate free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
