### PR TITLE
[Perf][MOSS-TTS] Capture feedback embeddings in sampling CUDA Graph

### DIFF
--- a/sglang_omni/models/moss_tts/model_runner.py
+++ b/sglang_omni/models/moss_tts/model_runner.py
@@ -186,7 +186,7 @@ class MossTTSModelRunner(ModelRunner):
             return
 
         if self._can_use_sampling_cuda_graph(datas, is_audio=is_audio):
-            rows = self._sample_rows_graphed(channel_logits, datas)
+            rows, embeds = self._sample_rows_graphed(channel_logits, datas)
         else:
             rows = self._sample_rows(
                 channel_logits,
@@ -194,12 +194,12 @@ class MossTTSModelRunner(ModelRunner):
                 n_vq=n_vq,
                 is_audio=is_audio,
             )
+            embeds = self.model._prepare_multi_modal_inputs(
+                rows.to(device=self.model.device)
+            )
 
         next_token_ids = rows[:, 0].contiguous()
         result.next_token_ids = next_token_ids
-        embeds = self.model._prepare_multi_modal_inputs(
-            rows.to(device=self.model.device)
-        )
         self._pending_rows = rows
         self._pending_embeds = embeds.detach()
 
@@ -230,7 +230,7 @@ class MossTTSModelRunner(ModelRunner):
         self,
         channel_logits: list[torch.Tensor],
         datas: list,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         device = channel_logits[0].device
         batch_size = len(datas)
         n_vq = len(channel_logits) - 1
@@ -257,7 +257,7 @@ class MossTTSModelRunner(ModelRunner):
                 "MOSS-TTS Delay sampling graph audio-logits shape mismatch: "
                 f"got {tuple(audio_logits.shape)}"
             )
-        sampled = self.model.sample_delay_graphed(
+        sampled, feedback_embeds = self.model.sample_delay_graphed(
             channel_logits[0].to(torch.float32),
             audio_logits,
             DelayGraphBatch(
@@ -270,7 +270,7 @@ class MossTTSModelRunner(ModelRunner):
         next_state = sampled.next_delay_state[:batch_size].clone()
         for index, data in enumerate(datas):
             data.delay_state = next_state[index]
-        return rows
+        return rows, feedback_embeds
 
     def _channel_logits_from_result(
         self,

--- a/sglang_omni/models/moss_tts/sampling_cuda_graph.py
+++ b/sglang_omni/models/moss_tts/sampling_cuda_graph.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Bucket-aligned CUDA graphs for MOSS-TTS Delay sampling and its FSM."""
+"""Bucket-aligned CUDA graphs for MOSS-TTS Delay sampling, FSM, and feedback."""
 
 from __future__ import annotations
 
@@ -30,14 +30,15 @@ class _CapturedSamplingGraph(NamedTuple):
     graph: torch.cuda.CUDAGraph
     rows: torch.Tensor
     next_delay_state: torch.Tensor
+    feedback_embeds: torch.Tensor
 
 
 class MossTTSDelaySamplingCudaGraphRunner:
-    """Sampling/FSM graphs aligned to the backbone CUDA-graph buckets.
+    """Sampling/FSM/feedback graphs aligned to the backbone CUDA-graph buckets.
 
-    LM heads and feedback embedding deliberately remain eager. Every graph uses
-    all 32 codebook rows and applies the Delay mask only to its fixed-shape
-    output, so replay topology does not depend on the number of active channels.
+    Every graph uses all 32 codebook rows and applies the Delay mask only to its
+    fixed-shape output, so replay topology does not depend on the number of
+    active channels.
     """
 
     def __init__(
@@ -204,19 +205,21 @@ class MossTTSDelaySamplingCudaGraphRunner:
     def _run_static(
         self,
         bucket: int,
-    ) -> DelaySamplingOutput:
+    ) -> tuple[DelaySamplingOutput, torch.Tensor]:
         inputs = self._require_inputs()
         batch = DelayGraphBatch(
             delay_state=inputs.delay_state[:bucket],
             seeds=inputs.seeds[:bucket],
             generation_steps=inputs.generation_steps[:bucket],
         )
-        return self.model.sample_delay_fixed_shape(
+        output = self.model.sample_delay_fixed_shape(
             inputs.control_logits[:bucket],
             inputs.audio_logits[:bucket],
             batch,
             audio_sample_output=inputs.audio_sample_output,
         )
+        feedback_embeds = self.model._prepare_multi_modal_inputs(output.rows)
+        return output, feedback_embeds
 
     def _capture_bucket(
         self,
@@ -247,12 +250,13 @@ class MossTTSDelaySamplingCudaGraphRunner:
                 stream=capture_stream,
                 capture_error_mode="thread_local",
             ):
-                output = self._run_static(bucket)
+                output, feedback_embeds = self._run_static(bucket)
         torch.cuda.current_stream(device).wait_stream(capture_stream)
         return _CapturedSamplingGraph(
             graph=graph,
             rows=output.rows,
             next_delay_state=output.next_delay_state,
+            feedback_embeds=feedback_embeds,
         )
 
     def canonical_bucket(self, batch_size: int) -> int | None:
@@ -281,7 +285,7 @@ class MossTTSDelaySamplingCudaGraphRunner:
         control_logits: torch.Tensor,
         audio_logits: torch.Tensor,
         batch: DelayGraphBatch,
-    ) -> DelaySamplingOutput:
+    ) -> tuple[DelaySamplingOutput, torch.Tensor]:
         batch_size = int(control_logits.shape[0])
         bucket = self.canonical_bucket(batch_size)
         key = self._graph_key(batch_size)
@@ -325,7 +329,10 @@ class MossTTSDelaySamplingCudaGraphRunner:
 
         captured = self.graphs[key]
         captured.graph.replay()
-        return DelaySamplingOutput(
-            rows=captured.rows[:batch_size],
-            next_delay_state=captured.next_delay_state[:batch_size],
+        return (
+            DelaySamplingOutput(
+                rows=captured.rows[:batch_size],
+                next_delay_state=captured.next_delay_state[:batch_size],
+            ),
+            captured.feedback_embeds[:batch_size],
         )

--- a/sglang_omni/models/moss_tts/sglang_model.py
+++ b/sglang_omni/models/moss_tts/sglang_model.py
@@ -645,7 +645,7 @@ class MossTTSDelaySGLangModel(torch.nn.Module):
         *,
         disable_padding: bool = False,
     ) -> None:
-        """Capture sampling/FSM graphs in the backbone batch envelope."""
+        """Capture sampling/FSM and feedback-embedding graphs in the batch envelope."""
 
         buckets = tuple(sorted({int(batch_size) for batch_size in batch_sizes}))
         if not buckets:
@@ -687,8 +687,8 @@ class MossTTSDelaySGLangModel(torch.nn.Module):
         control_logits: torch.Tensor,
         audio_logits: torch.Tensor,
         batch: DelayGraphBatch,
-    ) -> DelaySamplingOutput:
-        """Replay one fixed-shape sampling/FSM CUDA graph."""
+    ) -> tuple[DelaySamplingOutput, torch.Tensor]:
+        """Replay the sampling/FSM graph and return its feedback embeddings."""
 
         runner = self._sampling_graph_runner
         if runner is None:

--- a/tests/unit_test/moss_tts/test_sampling_cuda_graph.py
+++ b/tests/unit_test/moss_tts/test_sampling_cuda_graph.py
@@ -169,32 +169,28 @@ def test_model_runner_routes_supported_audio_batch_to_sampling_graph() -> None:
             batch,
         ):
             calls.append((control_logits.clone(), audio_logits.clone(), batch))
-            return SimpleNamespace(
-                rows=torch.tensor([[12, 2, 4]], dtype=torch.long),
-                next_delay_state=torch.tensor([[2, _INT64_MAX, 1]], dtype=torch.long),
+            return (
+                SimpleNamespace(
+                    rows=torch.tensor([[12, 2, 4]], dtype=torch.long),
+                    next_delay_state=torch.tensor(
+                        [[2, _INT64_MAX, 1]], dtype=torch.long
+                    ),
+                ),
+                torch.tensor([[101.0, 102.0, 103.0]]),
             )
 
         @staticmethod
         def _prepare_multi_modal_inputs(rows):
-            return rows.to(torch.float32)
+            raise AssertionError("graphed route recomputed feedback embeddings")
 
     runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
     runner.model = FakeModel()
     runner._pending_rows = None
     runner._pending_embeds = None
-    profile = _sampling_data(profile="default")
-    data = SimpleNamespace(
-        is_audio=True,
-        delay_state=torch.tensor([1, _INT64_MAX, 1]),
-        sampling_seed=123,
+    data = _request_data(
+        torch.tensor([1, _INT64_MAX, 1]),
+        seed=123,
         generation_steps=1,
-        text_temperature=profile.text_temperature,
-        text_top_p=profile.text_top_p,
-        text_top_k=profile.text_top_k,
-        audio_temperature=profile.audio_temperature,
-        audio_top_p=profile.audio_top_p,
-        audio_top_k=profile.audio_top_k,
-        audio_repetition_penalty=1.0,
     )
     request = SimpleNamespace(data=data)
     result = SimpleNamespace(
@@ -215,7 +211,79 @@ def test_model_runner_routes_supported_audio_batch_to_sampling_graph() -> None:
     assert len(calls) == 1
     assert result.next_token_ids.tolist() == [12]
     assert runner._pending_rows.tolist() == [[12, 2, 4]]
+    assert torch.equal(
+        runner._pending_embeds,
+        torch.tensor([[101.0, 102.0, 103.0]]),
+    )
     assert data.delay_state.tolist() == [2, _INT64_MAX, 1]
+
+
+def test_model_runner_keeps_ineligible_batch_on_eager_sampling() -> None:
+    graph_calls = []
+    prepare_calls = []
+
+    class FakeModel:
+        device = torch.device("cpu")
+        hidden_size = 3
+        config = _config(n_vq=2, audio_vocab=5)
+        text_control_token_ids = torch.tensor([12, 13], dtype=torch.long)
+
+        @staticmethod
+        def is_sampling_cuda_graph_compatible(data):
+            return MossTTSDelaySGLangModel.is_sampling_cuda_graph_compatible(data)
+
+        @staticmethod
+        def sampling_graph_available(batch_size):
+            graph_calls.append(batch_size)
+            return False
+
+        @staticmethod
+        def compute_channel_logits(hidden_states, forward_batch, *, is_audio=False):
+            del hidden_states, forward_batch
+            assert is_audio is True
+            return [
+                torch.tensor([[3.0, 1.0]]),
+                torch.zeros(1, 5),
+                torch.zeros(1, 5),
+            ]
+
+        @staticmethod
+        def sample_delay_graphed(*args, **kwargs):
+            del args, kwargs
+            raise AssertionError("ineligible batch used the sampling graph")
+
+        @staticmethod
+        def _prepare_multi_modal_inputs(rows):
+            prepare_calls.append(rows.clone())
+            return rows.to(torch.float32) + 100.0
+
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    runner.model = FakeModel()
+    runner._pending_rows = None
+    runner._pending_embeds = None
+    data = _request_data(
+        torch.tensor([1, _INT64_MAX, 1]),
+        seed=123,
+        generation_steps=1,
+    )
+    result = SimpleNamespace(
+        logits_output=SimpleNamespace(
+            customized_info=None,
+            hidden_states=torch.zeros(1, 3),
+        )
+    )
+
+    runner._collect_moss_step(
+        result,
+        SimpleNamespace(),
+        SimpleNamespace(),
+        [SimpleNamespace(data=data)],
+    )
+
+    assert graph_calls == [1]
+    assert len(prepare_calls) == 1
+    assert torch.equal(runner._pending_embeds, prepare_calls[0].float() + 100.0)
+    assert torch.equal(result.next_token_ids, runner._pending_rows[:, 0])
 
 
 def test_sampling_cuda_graph_setup_failure_uses_eager(
@@ -253,7 +321,30 @@ class _CudaGraphModel:
             audio_vocab=_MOSS_DELAY_AUDIO_VOCAB,
         )
         self.device = device
+        self.hidden_size = 4
+        self.embedding_list = torch.nn.ModuleList(
+            [
+                torch.nn.Embedding(
+                    int(vocab_size),
+                    self.hidden_size,
+                    device=device,
+                    dtype=torch.float32,
+                )
+                for vocab_size in self.config.vocab_size_list
+            ]
+        )
+        for embedding in self.embedding_list:
+            embedding.weight.requires_grad_(False)
+        self._pad_token_per_channel = [self.config.pad_token_id] + [
+            self.config.audio_pad_code
+        ] * self.config.n_vq
         self.delay_graph_sampler = MossTTSDelayAudioGraphSampler(self.config).to(device)
+
+    def _first_embedding_weight(self) -> torch.Tensor:
+        return self.embedding_list[0].weight
+
+    def _prepare_multi_modal_inputs(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return MossTTSDelaySGLangModel._prepare_multi_modal_inputs(self, input_ids)
 
     def sample_delay_fixed_shape(
         self,
@@ -421,17 +512,20 @@ def test_sampling_cuda_graph_replay_matches_fixed_shape_eager() -> None:
             audio_logits,
             batch,
         )
-        actual = runner.replay(
+        expected_feedback = model._prepare_multi_modal_inputs(expected.rows)
+        actual, actual_feedback = runner.replay(
             control_logits,
             audio_logits,
             batch,
         )
         actual_rows = actual.rows.clone()
         actual_state = actual.next_delay_state.clone()
+        actual_feedback = actual_feedback.clone()
         torch.cuda.synchronize()
 
         assert torch.equal(expected.rows, actual_rows)
         assert torch.equal(expected.next_delay_state, actual_state)
+        assert torch.equal(expected_feedback, actual_feedback)
         if batch_size == 1:
             static_inputs = runner._require_inputs()
             assert not torch.count_nonzero(static_inputs.control_logits[1:2])


### PR DESCRIPTION
Issue: #1707 & Tracking: #1233
## Motivation

MOSS TTS already captures Delay sampling and its FSM in a CUDA Graph, but feedback embedding is still computed eagerly after every graph replay.

The scheduler thread profile shows that one real feedback step runs:

* 1 zero initialization
* 33 embedding lookups
* 33 adds
* 67 eager CUDA kernel launches

In the representative c8 trace, 119 feedback calls produced 7,973 eager launches. The feedback region had no meaningful memcpy work and no explicit synchronization. This is a fixed-topology GPU tail immediately after the existing sampling CUDA Graph.

This PR extends the existing graph boundary through the existing `_prepare_multi_modal_inputs(output.rows)` computation. It does not change feedback math, sampling semantics, or request state semantics.

Detailed profiling log and experiment chronology: https://github.com/charliechenye/sglang-omni/issues/15

## Changes

* Capture feedback embeddings together with Delay sampling and FSM outputs in `MossTTSDelaySamplingCudaGraphRunner`.
* Return graph-produced feedback embeddings from `sample_delay_graphed()`.
* Consume those embeddings directly in `MossTTSModelRunner` on the graph path.
* Keep the existing eager feedback path unchanged when the sampling graph is unavailable or the request profile is ineligible.
* Add focused coverage for graph routing, eager fallback, padded bucket replay, and exact feedback parity.

The production change intentionally reuses the existing sampling graph runner and the existing `_prepare_multi_modal_inputs()` implementation. It adds no new graph framework, custom kernel, config surface, or feature flag.

## Correctness

### Same-step production validation

An experiment-only validation overlay compared graph-produced feedback embeddings with eager `_prepare_multi_modal_inputs(rows)` using the exact same sampled rows in the same scheduler step.

The final production candidate completed 32 of 32 requests at c8 with:

```text
same_step_feedback_embedding_bitwise_equal = true
```

The validator used exact `torch.equal()` on every eligible graph invocation encountered during the run. Its performance numbers were intentionally discarded because the validation duplicated feedback work.

### End-to-end quality

A 200 sample SeedTTS EN comparison used fresh servers for both arms with identical samples and seed settings.

* Generation: 200 of 200 successful for baseline and candidate
* Corpus WER: 1.85097% to 1.85097%
* WER delta: 0.000 percentage points
* Filtered WER: 1.19218% to 1.19218%
* Samples above 50% WER: 1 to 1
* Speaker similarity mean: 64.9024 to 64.9077
* Scoring skips: 0

The quality scorer implementation was held fixed across both arms.

### Focused tests

The focused MOSS sampling CUDA Graph and MOSS pipeline test files pass after the integration rebase.

Coverage includes:

* Graph eligible batches consume graph-produced feedback without eager recomputation.
* Graph ineligible batches keep the existing eager path.
* Real CUDA Graph replay matches eager sampled rows, Delay state, and feedback embeddings exactly.
* Bucket reuse covers `2 → 1 → 2` replay.
* Padded static inputs are reset correctly for smaller raw batches.

## Performance

All performance runs used one H200, fresh servers per cell, request profiling disabled, and paired arm ordering.

### Post 0.5.18 rebase integration canary

A c8 canary compared the rebased feedback candidate against its immediate main parent, without PR #1665.

Across four paired rounds:

* QPS deltas: +5.66%, +15.40%, +17.60%, +2.63%
* Mean QPS change: +10.32%
* Median QPS change: +10.53%
* QPS wins: 4 of 4
* Mean latency: 9.34% lower
* P95 latency: 13.08% lower
* Mean RTF: 9.26% lower
* Audio throughput: 10.33% higher
* Mean inter-chunk interval: 19.85% lower

The candidate started under higher one minute host load in three of the four rounds and still won all four. This canary is integration evidence after the rebase, not a replacement for the longer frozen direct comparison. Host load is reported only as descriptive context and is not used to numerically correct the results.

### Scaling with PR #1665 replayed identically in both arms

PR #1665 removes a preceding LM head launch wall, so a separate frozen scaling campaign tested whether feedback embedding remains a residual bottleneck after that work.

The causal comparison was:

```text
A = frozen main + identical replay of PR #1665
B = frozen main + identical replay of PR #1665 + feedback graph
```

Frozen source coordinates:

```text
main:     d5eac2627172c6541d50b6c3704c3c3ca1b4b96e
PR #1665: 422f2c49056ca45ffaca9623e614e3ab0c66a760
feedback: e7f6aa9f99e8897e1a2a97568dc4aa7d36b1a1da
```

Four paired rounds and 96 measured samples per cell produced 16 of 16 QPS wins:

* c1: +12.20% mean QPS, 4 of 4 wins, 10.81% lower mean latency, 14.68% lower inter-chunk interval
* c8: +6.87% mean QPS, 4 of 4 wins, 6.45% lower mean latency, 20.75% lower inter-chunk interval
* c16: +5.64% mean QPS, 4 of 4 wins, 5.27% lower mean latency, 13.38% lower inter-chunk interval
* c32: +10.08% mean QPS, 4 of 4 wins, 10.02% lower mean latency, 13.01% lower inter-chunk interval

c8 is the cleanest scaling point because its round-to-round effect was tight and host-load direction was mixed. c1 and c32 had more favorable host-load pairing for the candidate, so their exact mean deltas should not be overinterpreted.

The direct canary and the stacked sweep are separate pieces of evidence. The feedback PR does not depend on PR #1665. The stacked result shows that the feedback tail remains valuable after the preceding LM head launch wall is reduced. The percentages are not additive.

## Startup and memory cost

Startup cost was measured separately on the direct feedback PR without PR #1665.

The default sampling graph capture buckets were `[1, 2, 4, 8, 12, 16]`.

Across six paired starts:

* Retained allocated memory: +0.3359375 MiB
* Reserved memory growth: 0 MiB
* Peak reserved memory during sampling graph capture: 0 MiB
* Peak allocated memory during sampling graph capture: 0 MiB
* Sampling graph capture time: median delta 0.012 s lower, mean delta 0.080 s higher, with no stable regression

The retained allocation matches the exact theoretical size of the new static feedback outputs:

```text
(1 + 2 + 4 + 8 + 12 + 16) x 4096 x 2 bytes
= 352,256 bytes
= 0.3359375 MiB
```

Whole-server launch-to-health timing was dominated by startup order and cache effects, so this PR makes no total startup-time improvement or regression claim.

## Scope

This PR only extends the existing MOSS TTS Delay sampling CUDA Graph through feedback embedding.

It intentionally does not:

* Change Delay sampling math or sampling parameters.
* Change metadata staging.
* Change the vocoder or audio tokenizer path.
* Add a custom embedding kernel.
* Add a new CUDA Graph abstraction.
* Enable async decode or overlap scheduling for MOSS TTS.
* Depend on PR #1665.

Metadata staging remains a possible follow-up, but the exploratory implementation required pinned host buffer lifetime management and was deliberately kept out of this change.

## Checklist

* [x] Keep the production diff narrowly scoped.
* [x] Add focused graph and fallback tests.
* [x] Validate exact same-step feedback equality.
* [x] Validate 200 sample WER and speaker similarity.
* [x] Validate paired end-to-end performance.
* [x] Validate c1, c8, c16, and c32 scaling.
* [x] Measure sampling graph startup and memory cost.
* [x] Rebase and rerun focused integration tests.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
