### PR TITLE
bench(pd): add the PD versus colocated harness and report

### DIFF
--- a/benchmarks/eval/aggregate_pd_vs_colocated.py
+++ b/benchmarks/eval/aggregate_pd_vs_colocated.py
@@ -1,0 +1,273 @@
+"""Aggregate the PD-vs-colocated sweep into one table.
+
+Arm C is two independent replicas, so a point's throughput is the pair's
+combined rate and its latency percentiles come from the POOLED per-request
+records -- averaging two replicas' p95s would not be a p95 of anything.
+
+The conditioned inter-token quantities are the exception: they are averaged
+across replicas rather than pooled, because the analyzer labels a decode gap by
+whether a prefill was in flight in the SAME event stream. Pooling two replicas'
+events into one directory would let a prefill on replica 1 mark a decode gap on
+replica 2 as disturbed, which is a different GPU and no interference at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import statistics
+from collections import defaultdict
+from typing import Any
+
+COLO_RE = re.compile(
+    r"^C(?P<pass>[ab])_(?P<wl>text|image)_r(?P<rate>[\d.]+)_rep(?P<rep>\d+)_rep(?P<replica>[12])$"
+)
+PD_RE = re.compile(r"^PD_(?P<wl>text|image)_r(?P<rate>[\d.]+)_rep(?P<rep>\d+)$")
+
+
+def pct(values: list[float], q: float) -> float | None:
+    if not values:
+        return None
+    values = sorted(values)
+    if len(values) == 1:
+        return values[0]
+    pos = q / 100.0 * (len(values) - 1)
+    lo = int(pos)
+    hi = min(lo + 1, len(values) - 1)
+    return values[lo] + (values[hi] - values[lo]) * (pos - lo)
+
+
+def load_raw(raw_dir: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for path in glob.glob(os.path.join(raw_dir, "*.jsonl")):
+        with open(path) as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    try:
+                        rows.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        pass
+    return [r for r in rows if r.get("arm") != "warmup"]
+
+
+def load_analysis(results_dir: str, tag: str) -> dict[str, Any] | None:
+    matches = glob.glob(os.path.join(results_dir, f"analysis_{tag}__*.json"))
+    if not matches:
+        return None
+    with open(matches[0]) as fh:
+        return json.load(fh)
+
+
+def summarize(records: list[dict[str, Any]]) -> dict[str, Any]:
+    ok = [r for r in records if r.get("ok")]
+    failed = len(records) - len(ok)
+    starts = [r["sent_at"] for r in records] or [0.0]
+    ends = [
+        r["sent_at"] + r["total_s"] for r in ok if r.get("total_s") is not None
+    ] or starts
+    wall = max(ends) - min(starts)
+    ttfts = [r["ttft_s"] for r in ok if r.get("ttft_s") is not None]
+    itls = [g for r in ok for g in (r.get("itl_ms") or [])]
+    ptoks = [r["prompt_tokens"] for r in ok if r.get("prompt_tokens") is not None]
+    return {
+        "requests_sent": len(records),
+        "requests_ok": len(ok),
+        "requests_failed": failed,
+        "wall_s": wall,
+        "achieved_rps": (len(ok) / wall) if wall > 0 else None,
+        "ttft_p50_ms": (pct(ttfts, 50) or 0) * 1000 if ttfts else None,
+        "ttft_p95_ms": (pct(ttfts, 95) or 0) * 1000 if ttfts else None,
+        "itl_p50_ms": pct(itls, 50),
+        "itl_p95_ms": pct(itls, 95),
+        "prompt_tokens_mean": statistics.fmean(ptoks) if ptoks else None,
+    }
+
+
+def collect(root: str) -> dict[tuple, dict[str, Any]]:
+    """key -> point, where key = (arm_label, workload, rate, repeat)."""
+    raw_root = os.path.join(root, "raw")
+    results_dir = os.path.join(root, "results")
+
+    grouped: dict[tuple, list[str]] = defaultdict(list)
+    for tag in sorted(os.listdir(raw_root)) if os.path.isdir(raw_root) else []:
+        m = COLO_RE.match(tag)
+        if m:
+            key = (f"C{m['pass']}", m["wl"], float(m["rate"]), int(m["rep"]))
+            grouped[key].append(tag)
+            continue
+        m = PD_RE.match(tag)
+        if m:
+            key = ("PD", m["wl"], float(m["rate"]), int(m["rep"]))
+            grouped[key].append(tag)
+
+    points: dict[tuple, dict[str, Any]] = {}
+    for key, tags in grouped.items():
+        records: list[dict[str, Any]] = []
+        conditioned: list[dict[str, Any]] = []
+        for tag in tags:
+            records.extend(load_raw(os.path.join(raw_root, tag)))
+            an = load_analysis(results_dir, tag)
+            if an:
+                conditioned.append(an)
+        point = summarize(records)
+        point["offered_rps"] = key[2]
+        point["n_replicas"] = len(tags)
+
+        clean = [
+            a["itl_ms"]["no_concurrent_prefill"]["p50"]
+            for a in conditioned
+            if a.get("itl_ms", {}).get("no_concurrent_prefill", {}).get("p50")
+        ]
+        dirty = [
+            a["itl_ms"]["with_concurrent_prefill"]["p50"]
+            for a in conditioned
+            if a.get("itl_ms", {}).get("with_concurrent_prefill", {}).get("p50")
+        ]
+        ratio = [
+            a["itl_ms"]["interference_ratio_p50"]
+            for a in conditioned
+            if a.get("itl_ms", {}).get("interference_ratio_p50")
+        ]
+        n_dirty = [
+            a["itl_ms"]["with_concurrent_prefill"]["n"]
+            for a in conditioned
+            if a.get("itl_ms", {}).get("with_concurrent_prefill", {}).get("n")
+            is not None
+        ]
+        n_clean = [
+            a["itl_ms"]["no_concurrent_prefill"]["n"]
+            for a in conditioned
+            if a.get("itl_ms", {}).get("no_concurrent_prefill", {}).get("n") is not None
+        ]
+        point["itl_clean_p50_ms"] = statistics.fmean(clean) if clean else None
+        point["itl_disturbed_p50_ms"] = statistics.fmean(dirty) if dirty else None
+        point["interference_ratio_p50"] = statistics.fmean(ratio) if ratio else None
+        tot = sum(n_dirty) + sum(n_clean)
+        point["disturbed_gap_share"] = (sum(n_dirty) / tot) if tot else None
+        points[key] = point
+    return points
+
+
+def across_repeats(points: dict[tuple, dict[str, Any]]) -> dict[tuple, dict[str, Any]]:
+    """Collapse the repeat axis to median + spread."""
+    bykey: dict[tuple, list[dict[str, Any]]] = defaultdict(list)
+    for (arm, wl, rate, _rep), p in points.items():
+        bykey[(arm, wl, rate)].append(p)
+
+    out: dict[tuple, dict[str, Any]] = {}
+    for key, ps in bykey.items():
+        entry: dict[str, Any] = {"n_repeats": len(ps)}
+        for field in (
+            "achieved_rps",
+            "ttft_p50_ms",
+            "ttft_p95_ms",
+            "itl_p50_ms",
+            "itl_p95_ms",
+            "itl_clean_p50_ms",
+            "itl_disturbed_p50_ms",
+            "interference_ratio_p50",
+            "disturbed_gap_share",
+            "prompt_tokens_mean",
+        ):
+            vals = [p[field] for p in ps if p.get(field) is not None]
+            entry[field] = statistics.median(vals) if vals else None
+            entry[f"{field}_min"] = min(vals) if vals else None
+            entry[f"{field}_max"] = max(vals) if vals else None
+        entry["requests_ok"] = sum(p["requests_ok"] for p in ps)
+        entry["requests_failed"] = sum(p["requests_failed"] for p in ps)
+        out[key] = entry
+    return out
+
+
+def fmt(x: float | None, nd: int = 1) -> str:
+    return "-" if x is None else f"{x:.{nd}f}"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default="./pdvc")
+    ap.add_argument("--json-out", default=None)
+    args = ap.parse_args()
+
+    points = collect(args.root)
+    agg = across_repeats(points)
+
+    print("\n=== per (arm x workload x offered rate), median over repeats ===")
+    hdr = (
+        f"{'arm':<5}{'workload':<8}{'offered':>8}{'achieved':>9}{'ok':>7}{'fail':>6}"
+        f"{'ptok':>8}{'TTFTp50':>9}{'TTFTp95':>9}{'ITLp50':>8}{'ITLp95':>8}"
+        f"{'ITLclean':>9}{'ITLdist':>8}{'ratio':>7}{'dist%':>7}"
+    )
+    print(hdr)
+    print("-" * len(hdr))
+    for wl in ("text", "image"):
+        for arm in ("Ca", "Cb", "PD"):
+            rows = sorted((k, v) for k, v in agg.items() if k[0] == arm and k[1] == wl)
+            for (a, w, rate), v in rows:
+                print(
+                    f"{a:<5}{w:<8}{rate:>8.4g}{fmt(v['achieved_rps'], 2):>9}"
+                    f"{v['requests_ok']:>7}{v['requests_failed']:>6}"
+                    f"{fmt(v['prompt_tokens_mean'], 0):>8}"
+                    f"{fmt(v['ttft_p50_ms']):>9}{fmt(v['ttft_p95_ms']):>9}"
+                    f"{fmt(v['itl_p50_ms'], 2):>8}{fmt(v['itl_p95_ms'], 2):>8}"
+                    f"{fmt(v['itl_clean_p50_ms'], 2):>9}"
+                    f"{fmt(v['itl_disturbed_p50_ms'], 2):>8}"
+                    f"{fmt(v['interference_ratio_p50'], 3):>7}"
+                    f"{(fmt(v['disturbed_gap_share'] * 100, 1) if v['disturbed_gap_share'] is not None else '-'):>7}"
+                )
+        print()
+
+    # ---- A/A noise band: pass a vs pass b of the SAME configuration ----------
+    print("=== A/A noise band (arm C pass a vs pass b, identical config) ===")
+    fields = [
+        ("achieved_rps", "achieved rps"),
+        ("ttft_p50_ms", "TTFT p50"),
+        ("ttft_p95_ms", "TTFT p95"),
+        ("itl_p50_ms", "ITL p50"),
+        ("itl_p95_ms", "ITL p95"),
+        ("itl_clean_p50_ms", "ITL clean p50"),
+        ("interference_ratio_p50", "interference ratio"),
+    ]
+    band: dict[str, list[float]] = defaultdict(list)
+    for wl in ("text", "image"):
+        for key in sorted(k for k in agg if k[0] == "Ca" and k[1] == wl):
+            _, w, rate = key
+            a = agg.get(("Ca", w, rate))
+            b = agg.get(("Cb", w, rate))
+            if not a or not b:
+                continue
+            for field, _label in fields:
+                va, vb = a.get(field), b.get(field)
+                if va and vb and va > 0:
+                    band[f"{wl}:{field}"].append(abs(vb - va) / va * 100.0)
+
+    print(f"{'workload:metric':<34}{'n':>4}{'median %':>10}{'max %':>9}")
+    print("-" * 57)
+    for wl in ("text", "image"):
+        for field, label in fields:
+            vals = band.get(f"{wl}:{field}")
+            if not vals:
+                continue
+            print(
+                f"{wl + ':' + label:<34}{len(vals):>4}"
+                f"{statistics.median(vals):>10.1f}{max(vals):>9.1f}"
+            )
+
+    if args.json_out:
+        payload = {
+            "points": {"|".join(str(x) for x in k): v for k, v in points.items()},
+            "aggregated": {"|".join(str(x) for x in k): v for k, v in agg.items()},
+            "aa_noise_pct": {k: sorted(v) for k, v in band.items()},
+        }
+        with open(args.json_out, "w") as fh:
+            json.dump(payload, fh, indent=2)
+        print(f"\nwrote {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/eval/analyze_thinker_events.py
+++ b/benchmarks/eval/analyze_thinker_events.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Attribute thinker request time from profiler event JSONL (PD Phase 0).
+
+Two outputs the passive stage table alone cannot give:
+
+1. Per-request segment breakdown, matching the columns in
+   ``docs/developer_reference/qwen3_asr_concurrency_profile.md`` so thinker
+   numbers can be read against that ASR table.
+
+2. The discriminating measurement: every inter-token gap on the thinker stage
+   is labelled with how many prefills were in flight during that gap. If
+   prefill admission perturbs running decode, gaps that overlap a prefill are
+   longer than gaps that do not, and the excess grows with prompt length. If
+   the queue is simply capacity-capped, the two populations coincide.
+
+Usage:
+    python analyze_thinker_events.py <event_dir> [--json out.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import glob
+import json
+import os
+import statistics
+from collections import defaultdict
+from typing import Any
+
+# A colocated run emits every thinker event under stage "thinker". A PD run splits
+# the same work across "thinker_prefill" and "thinker_decode", so filtering on
+# "thinker" alone yields ZERO events for a PD arm. Unioning the three names keeps
+# one code path for both: prefill windows come from whichever stage ran the prefill,
+# per-token emits from whichever stage streamed them, and the conditioned ITL keeps
+# its meaning. In PD the prefill is on the OTHER card, so a ratio near 1.0 is the
+# physically expected answer rather than a bug.
+STAGES = {"thinker", "thinker_prefill", "thinker_decode"}
+
+# (start_event, end_event, column name) -- same decomposition as the ASR profile.
+SEGMENTS = [
+    ("scheduler_request_build_start", "scheduler_request_build_end", "build"),
+    ("scheduler_request_build_end", "scheduler_queue_enter", "build_to_queued"),
+    ("scheduler_queue_enter", "scheduler_prefill_start", "queued_to_scheduled"),
+    ("scheduler_prefill_start", "scheduler_prefill_end", "first_forward"),
+    ("scheduler_prefill_end", "stage_complete", "decode_tail"),
+    ("scheduler_prefill_start", "scheduler_first_emit", "prefill_to_first_emit"),
+]
+
+
+def load(event_dir: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for path in glob.glob(os.path.join(event_dir, "*.jsonl")):
+        with open(path) as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    return rows
+
+
+def pct(values: list[float], q: float) -> float | None:
+    if not values:
+        return None
+    values = sorted(values)
+    if len(values) == 1:
+        return values[0]
+    pos = q / 100.0 * (len(values) - 1)
+    lo = int(pos)
+    hi = min(lo + 1, len(values) - 1)
+    return values[lo] + (values[hi] - values[lo]) * (pos - lo)
+
+
+def describe(values: list[float]) -> dict[str, Any]:
+    return {
+        "n": len(values),
+        "mean": statistics.fmean(values) if values else None,
+        "p50": pct(values, 50),
+        "p95": pct(values, 95),
+        "p99": pct(values, 99),
+        "max": max(values) if values else None,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("event_dir")
+    parser.add_argument("--json", dest="json_out", default=None)
+    args = parser.parse_args()
+
+    rows = load(args.event_dir)
+    if not rows:
+        raise SystemExit(f"no events under {args.event_dir}")
+
+    # request_id -> event_name -> first timestamp, thinker stage only
+    first: dict[str, dict[str, int]] = defaultdict(dict)
+    # request_id -> ordered per-token emit timestamps
+    emits: dict[str, list[int]] = defaultdict(list)
+    for row in rows:
+        if row.get("stage") not in STAGES:
+            continue
+        rid = row["request_id"]
+        name = row["event_name"]
+        ts = row["timestamp_ns"]
+        if name == "stage_stream_chunk_sent":
+            emits[rid].append(ts)
+        elif name not in first[rid]:
+            first[rid][name] = ts
+
+    # Prefill occupancy intervals, used to label each inter-token gap.
+    prefill_windows = sorted(
+        (ev["scheduler_prefill_start"], ev["scheduler_prefill_end"])
+        for ev in first.values()
+        if "scheduler_prefill_start" in ev and "scheduler_prefill_end" in ev
+    )
+    starts = [w[0] for w in prefill_windows]
+
+    def prefills_overlapping(lo: int, hi: int) -> int:
+        # Windows are short; scan from the first window that could overlap.
+        idx = bisect.bisect_left(starts, lo)
+        count = 0
+        for j in range(max(0, idx - 64), len(prefill_windows)):
+            s, e = prefill_windows[j]
+            if s >= hi:
+                break
+            if e > lo:
+                count += 1
+        return count
+
+    segments: dict[str, list[float]] = defaultdict(list)
+    for ev in first.values():
+        for start, end, label in SEGMENTS:
+            if start in ev and end in ev:
+                segments[label].append((ev[end] - ev[start]) / 1e6)
+
+    clean_gaps: list[float] = []
+    disturbed_gaps: list[float] = []
+    for rid, stamps in emits.items():
+        stamps.sort()
+        for a, b in zip(stamps, stamps[1:]):
+            gap_ms = (b - a) / 1e6
+            # Exclude this request's own prefill; it precedes its first emit.
+            if prefills_overlapping(a, b) > 0:
+                disturbed_gaps.append(gap_ms)
+            else:
+                clean_gaps.append(gap_ms)
+
+    report: dict[str, Any] = {
+        "event_dir": args.event_dir,
+        "requests": len(first),
+        "segments_ms": {k: describe(v) for k, v in segments.items()},
+        "itl_ms": {
+            "all": describe(clean_gaps + disturbed_gaps),
+            "no_concurrent_prefill": describe(clean_gaps),
+            "with_concurrent_prefill": describe(disturbed_gaps),
+        },
+    }
+    clean_p50 = report["itl_ms"]["no_concurrent_prefill"]["p50"]
+    dirty_p50 = report["itl_ms"]["with_concurrent_prefill"]["p50"]
+    if clean_p50 and dirty_p50:
+        report["itl_ms"]["interference_ratio_p50"] = dirty_p50 / clean_p50
+
+    print(f"requests: {report['requests']}")
+    print("\nsegment (ms)        n     mean     p50     p95     p99     max")
+    for _, _, label in SEGMENTS:
+        d = report["segments_ms"].get(label)
+        if not d or not d["n"]:
+            continue
+
+        def f(x):
+            return f"{x:7.2f}" if x is not None else "      -"
+
+        print(
+            f"{label:<18}{d['n']:>5}{f(d['mean'])}{f(d['p50'])}"
+            f"{f(d['p95'])}{f(d['p99'])}{f(d['max'])}"
+        )
+
+    print("\ninter-token gap (ms)")
+    for key in ("all", "no_concurrent_prefill", "with_concurrent_prefill"):
+        d = report["itl_ms"][key]
+
+        def f(x):
+            return f"{x:7.2f}" if x is not None else "      -"
+
+        print(f"  {key:<26}{d['n']:>6}{f(d['mean'])}{f(d['p50'])}{f(d['p95'])}")
+    if "interference_ratio_p50" in report["itl_ms"]:
+        print(
+            f"\n  p50 gap ratio (with prefill / without): "
+            f"{report['itl_ms']['interference_ratio_p50']:.3f}"
+        )
+
+    if args.json_out:
+        with open(args.json_out, "w") as handle:
+            json.dump(report, handle, indent=2)
+        print(f"\nwrote {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/eval/benchmark_omni_thinker_attribution.py
+++ b/benchmarks/eval/benchmark_omni_thinker_attribution.py
@@ -1,0 +1,612 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen3-Omni thinker concurrency + attribution benchmark (PD Phase 0).
+
+Rebuilds the canonical thinker baseline that #1018 s1.1 still lists as open,
+and attributes where request time goes as offered load rises.
+
+Two arrival models, because they answer different questions:
+
+* ``--mode open`` (default) drives Poisson arrivals at a fixed offered rate.
+  This is the only mode that can show the capacity knee: past saturation a
+  closed-loop client absorbs the backlog into its own think time and hides it
+  (the same reason ``benchmarks/eval/bench_sweep.py`` chose open loop).
+* ``--mode closed`` holds N requests in flight, matching the arrival model
+  used by ``docs/developer_reference/qwen3_asr_concurrency_profile.md`` so the
+  thinker numbers can be read against that ASR table.
+
+Server-side attribution comes from the existing generic profiler events via
+``benchmarks.eval.asr_profiling`` (start/stop request profile, stage
+breakdown, utilization sampling, environment fingerprint). Nothing here is
+ASR-specific despite that module's name.
+
+Run from the repo root:
+
+    python -m benchmarks.eval.benchmark_omni_thinker_attribution \
+      --port 8611 --mode open --rates 1,2,4,8,16,24 --duration-s 60 \
+      --profile-events --profile-event-dir ./events \
+      --sample-util --util-gpu-ids 1 --fingerprint \
+      --output thinker_attr.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import random
+import statistics
+import sys
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+import aiohttp
+
+from benchmarks.eval.asr_profiling import (
+    UtilizationSampler,
+    build_stage_breakdown,
+    collect_environment_fingerprint,
+    collect_server_identity,
+    start_request_profile,
+    stop_request_profile,
+    write_json,
+)
+
+# Prompt padding is the prefill-cost lever. Holding arrival rate and output
+# length fixed while moving prompt length is the only manipulation that
+# separates "the admission queue is long because capacity is capped" from
+# "the admission queue is long because prefill blocks decode" -- the passive
+# stage decomposition shows both as a large queued->scheduled segment.
+#
+# Text padding rather than an image prompt on purpose: an image arm would move
+# encoder work and prefill cost together, so it cannot attribute either.
+_PROMPT_HEAD = [
+    "Explain in detail how a distributed key-value cache maintains consistency "
+    "across replicas when a network partition heals.",
+    "Describe the tradeoffs between tensor parallelism and pipeline parallelism "
+    "for serving a mixture-of-experts language model.",
+    "Walk through what happens inside a GPU when a kernel launch is issued, "
+    "from the host driver call to warp scheduling.",
+    "Compare write-through and write-back caching policies, and say when each "
+    "one is the wrong choice.",
+]
+
+# `--prompt-tokens` is a target, not a count. Each repetition adds a counter
+# prefix and many filler words take more than one token, so the request
+# overshoots the flag, and the overshoot grows with the value. Measured against
+# the Qwen3-Omni tokenizer: 42 gives 42, 1150 gives about 1966, 4400 gives about
+# 7645, 2000 gives 2975, and 8000 gives 12075. Calibrate before choosing arms,
+# and check the target against the model's context limit: 8192 for Qwen3-Omni
+# thinker, which 4400 reaches once 128 output tokens are added.
+#
+# The nonce also shifts the count, because it sits inside the marker and inside
+# every counter. Let the client generate it rather than passing a `--nonce` of
+# a different width, or the arms move relative to each other.
+#
+# `prompt_tokens` reported in the result JSON is the measured value from usage
+# and is what should be quoted.
+_FILLER = (
+    "The scheduler admits a request, builds its batch, runs one forward pass, "
+    "and then releases the slot back to the pool for the next arrival. "
+)
+
+
+def _make_prompt(index: int, prompt_tokens: int, nonce: str = "") -> str:
+    """Build a prompt of roughly `prompt_tokens` tokens, unique per request.
+
+    Uniqueness is load-bearing and must start at token 0. RadixCache is on by
+    default, so any shared prefix is served from the prefix tree and the arm
+    silently measures cache hits instead of prefill cost. An earlier version
+    rotated filler words per request; because the rotation period was shorter
+    than the arm size it produced exact duplicate prompts, and the prompt-length
+    lever collapsed. Put the unique marker first and vary every repetition.
+    """
+    marker = f"[req {nonce}{index}] "
+    head = _PROMPT_HEAD[index % len(_PROMPT_HEAD)]
+    if prompt_tokens <= 64:
+        return marker + head
+    words = _FILLER.split()
+    reps = max(1, prompt_tokens // max(1, len(words)))
+    chunks = [f"{marker}{head}"]
+    for r in range(reps):
+        # A per-repetition counter keeps every window of the prompt distinct,
+        # so no suffix of one prompt can match a prefix of another.
+        chunks.append(f"({nonce}{index}.{r}) " + " ".join(words))
+    return " ".join(chunks)
+
+
+@dataclass
+class RequestRecord:
+    request_id: str
+    arm: str
+    sent_at: float
+    ttft_s: float | None = None
+    total_s: float | None = None
+    completion_tokens: int | None = None
+    prompt_tokens: int | None = None
+    # Client-observed inter-token gaps. The server also emits per-token
+    # stage_stream_chunk_sent events; both are kept because the client series
+    # is the user-visible metric and the server series is the attributable one.
+    itl_ms: list[float] = field(default_factory=list)
+    ok: bool = False
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "request_id": self.request_id,
+            "arm": self.arm,
+            "sent_at": self.sent_at,
+            "ttft_s": self.ttft_s,
+            "total_s": self.total_s,
+            "completion_tokens": self.completion_tokens,
+            "prompt_tokens": self.prompt_tokens,
+            "itl_ms": self.itl_ms,
+            "ok": self.ok,
+            "error": self.error,
+        }
+
+
+@dataclass
+class ArmResult:
+    arm: str
+    mode: str
+    target: float
+    records: list[RequestRecord] = field(default_factory=list)
+
+    def summary(self) -> dict[str, Any]:
+        ok = [r for r in self.records if r.ok]
+        failed = len(self.records) - len(ok)
+        wall = 0.0
+        if self.records:
+            starts = [r.sent_at for r in self.records]
+            ends = [
+                r.sent_at + r.total_s for r in ok if r.total_s is not None
+            ] or starts
+            wall = max(ends) - min(starts)
+
+        def pct(values: list[float], q: float) -> float | None:
+            if not values:
+                return None
+            values = sorted(values)
+            if len(values) == 1:
+                return values[0]
+            pos = q / 100.0 * (len(values) - 1)
+            lo = int(pos)
+            hi = min(lo + 1, len(values) - 1)
+            return values[lo] + (values[hi] - values[lo]) * (pos - lo)
+
+        itls = [gap for r in ok for gap in r.itl_ms]
+        ttfts = [r.ttft_s for r in ok if r.ttft_s is not None]
+        totals = [r.total_s for r in ok if r.total_s is not None]
+        toks = sum(r.completion_tokens or 0 for r in ok)
+        return {
+            "arm": self.arm,
+            "mode": self.mode,
+            "target": self.target,
+            "requests_sent": len(self.records),
+            "requests_ok": len(ok),
+            "requests_failed": failed,
+            "wall_s": wall,
+            "achieved_rate_rps": (len(ok) / wall) if wall > 0 else None,
+            "output_tok_per_s": (toks / wall) if wall > 0 else None,
+            "ttft_s": {
+                "mean": statistics.fmean(ttfts) if ttfts else None,
+                "p50": pct(ttfts, 50),
+                "p95": pct(ttfts, 95),
+                "p99": pct(ttfts, 99),
+                "max": max(ttfts) if ttfts else None,
+            },
+            "total_s": {
+                "mean": statistics.fmean(totals) if totals else None,
+                "p50": pct(totals, 50),
+                "p95": pct(totals, 95),
+                "p99": pct(totals, 99),
+                "max": max(totals) if totals else None,
+            },
+            "itl_ms": {
+                "mean": statistics.fmean(itls) if itls else None,
+                "p50": pct(itls, 50),
+                "p95": pct(itls, 95),
+                "p99": pct(itls, 99),
+                "max": max(itls) if itls else None,
+                "count": len(itls),
+            },
+            "prompt_tokens_mean": (
+                statistics.fmean(
+                    [r.prompt_tokens for r in ok if r.prompt_tokens is not None]
+                )
+                if any(r.prompt_tokens is not None for r in ok)
+                else None
+            ),
+            "errors": sorted({r.error for r in self.records if r.error})[:5],
+        }
+
+
+# --- unique-image pool -------------------------------------------------------
+# The encoder result cache is keyed by a media reference/content hash and
+# concurrent duplicates are collapsed by a single-flight table, so an image arm
+# must never repeat a file: otherwise every request after the first measures a
+# dict lookup instead of vision encode + large prefill.
+_IMAGE_POOL: list[str] = []
+_IMAGE_CURSOR = 0
+
+
+def _load_image_pool(image_dir: str, offset: int = 0) -> None:
+    """Load the pool and start the cursor at `offset`.
+
+    The cursor restarts at 0 in every client process, so two runs against the
+    SAME server would replay the same files and the second would be served from
+    the encoder cache. Runs sharing a server must therefore be given disjoint
+    offsets; separate servers each have their own cache and can both start at 0.
+    """
+    global _IMAGE_POOL, _IMAGE_CURSOR
+    entries = sorted(
+        os.path.join(image_dir, name)
+        for name in os.listdir(image_dir)
+        if name.lower().endswith((".jpg", ".jpeg", ".png"))
+    )
+    if not entries:
+        raise SystemExit(f"--image-dir {image_dir} contains no images")
+    if offset >= len(entries):
+        raise SystemExit(f"--image-offset {offset} exceeds pool size {len(entries)}")
+    _IMAGE_POOL = entries
+    _IMAGE_CURSOR = offset
+    print(
+        f"image pool: {len(entries)} files from {image_dir}, starting at {offset}",
+        flush=True,
+    )
+
+
+def _next_image() -> str:
+    """Hand out the next unused image; exhausting the pool is a hard error.
+
+    Wrapping around would silently reintroduce cache hits partway through the
+    sweep, which is exactly the failure this pool exists to prevent.
+    """
+    global _IMAGE_CURSOR
+    if _IMAGE_CURSOR >= len(_IMAGE_POOL):
+        raise SystemExit(
+            f"image pool exhausted after {_IMAGE_CURSOR} requests; "
+            "generate a larger pool -- reusing images would measure cache hits"
+        )
+    path = _IMAGE_POOL[_IMAGE_CURSOR]
+    _IMAGE_CURSOR += 1
+    return path
+
+
+def _image_pool_used() -> int:
+    return _IMAGE_CURSOR
+
+
+# -----------------------------------------------------------------------------
+
+
+def _build_payload(args, prompt: str) -> dict[str, Any]:
+    content: Any = prompt
+    if getattr(args, "image_dir", None):
+        # qwen3-omni takes media through the top-level "images" field
+        # (serve/protocol.py:75, consumed at serve/openai_api.py:938). It has no
+        # handler for inline {"type": "image_url"} content parts the way ming_omni
+        # and llada2_uni do, so the --image-path form below is silently dropped by
+        # this model: the request still succeeds, but it prefills text only.
+        return {
+            "model": args.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "images": [_next_image()],
+            "max_tokens": args.max_tokens,
+            "temperature": 0.0,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+    if args.image_path:
+        # Note: the omni chat surface takes multimodal parts; a local path is
+        # accepted by the server-side reader, matching examples/ usage.
+        content = [
+            {"type": "text", "text": prompt},
+            {"type": "image_url", "image_url": {"url": f"file://{args.image_path}"}},
+        ]
+    return {
+        "model": args.model,
+        "messages": [{"role": "user", "content": content}],
+        "max_tokens": args.max_tokens,
+        "temperature": 0.0,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+
+
+async def _one_request(
+    session: aiohttp.ClientSession, args, arm: str, prompt: str
+) -> RequestRecord:
+    rid = f"{arm}-{uuid.uuid4().hex[:12]}"
+    rec = RequestRecord(request_id=rid, arm=arm, sent_at=time.time())
+    started = time.perf_counter()
+    last_token = started
+    payload = _build_payload(args, prompt)
+    try:
+        async with session.post(
+            f"{args.base_url}/v1/chat/completions",
+            json=payload,
+            headers={"x-request-id": rid},
+            timeout=aiohttp.ClientTimeout(total=args.timeout_s),
+        ) as resp:
+            if resp.status != 200:
+                rec.error = f"http {resp.status}: {(await resp.text())[:200]}"
+                return rec
+            async for raw in resp.content:
+                line = raw.decode("utf-8", "replace").strip()
+                if not line.startswith("data:"):
+                    continue
+                body = line[len("data:") :].strip()
+                if body == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(body)
+                except json.JSONDecodeError:
+                    continue
+                usage = chunk.get("usage")
+                if usage:
+                    rec.completion_tokens = usage.get("completion_tokens")
+                    rec.prompt_tokens = usage.get("prompt_tokens")
+                choices = chunk.get("choices") or []
+                if not choices:
+                    continue
+                delta = choices[0].get("delta") or {}
+                if delta.get("content"):
+                    now = time.perf_counter()
+                    if rec.ttft_s is None:
+                        rec.ttft_s = now - started
+                    else:
+                        rec.itl_ms.append((now - last_token) * 1000.0)
+                    last_token = now
+            rec.total_s = time.perf_counter() - started
+            rec.ok = rec.ttft_s is not None
+            if not rec.ok and rec.error is None:
+                rec.error = "no content delta"
+    except Exception as exc:  # noqa: BLE001 - recorded, not raised
+        rec.error = f"{type(exc).__name__}: {exc}"
+        rec.total_s = time.perf_counter() - started
+    return rec
+
+
+async def _run_open(session, args, rate: float, rng: random.Random) -> ArmResult:
+    """Poisson arrivals at `rate` req/s for `duration_s`, never blocking."""
+    arm = f"open-{rate:g}rps-p{args.prompt_tokens}"
+    result = ArmResult(arm=arm, mode="open", target=rate)
+    tasks: list[asyncio.Task] = []
+    deadline = time.perf_counter() + args.duration_s
+    i = 0
+    while time.perf_counter() < deadline:
+        prompt = _make_prompt(i, args.prompt_tokens, args.nonce)
+        tasks.append(asyncio.create_task(_one_request(session, args, arm, prompt)))
+        i += 1
+        await asyncio.sleep(rng.expovariate(rate))
+    if tasks:
+        result.records = list(await asyncio.gather(*tasks))
+    return result
+
+
+async def _run_closed(session, args, concurrency: int) -> ArmResult:
+    """Hold `concurrency` requests in flight for `requests` total."""
+    arm = f"closed-c{concurrency}-p{args.prompt_tokens}"
+    result = ArmResult(arm=arm, mode="closed", target=concurrency)
+    sem = asyncio.Semaphore(concurrency)
+    total = max(args.requests, concurrency)
+
+    async def guarded(idx: int) -> RequestRecord:
+        async with sem:
+            return await _one_request(
+                session, args, arm, _make_prompt(idx, args.prompt_tokens, args.nonce)
+            )
+
+    result.records = list(await asyncio.gather(*(guarded(i) for i in range(total))))
+    return result
+
+
+async def _warmup(session, args) -> None:
+    for _ in range(args.warmup):
+        await _one_request(
+            session,
+            args,
+            "warmup",
+            _make_prompt(-1 - _, args.prompt_tokens, args.nonce),
+        )
+
+
+def _raise_descriptor_limit() -> None:
+    """Raise the open-file soft limit toward its hard limit, and say so."""
+    import resource
+
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    if soft >= hard:
+        return
+    try:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (hard, hard))
+    except (ValueError, OSError) as exc:
+        print(f"could not raise RLIMIT_NOFILE from {soft}: {exc}", flush=True)
+        return
+    print(f"raised RLIMIT_NOFILE {soft} -> {hard}", flush=True)
+
+
+async def _resolve_model(session, args) -> str:
+    if args.model:
+        return args.model
+    async with session.get(f"{args.base_url}/v1/models") as resp:
+        body = await resp.json()
+    data = body.get("data") or []
+    if not data:
+        raise SystemExit("no models advertised by the server")
+    return data[0]["id"]
+
+
+async def main_async(args) -> int:
+    rng = random.Random(args.seed)
+    # An open-loop client holds one socket per in-flight request, so in-flight
+    # count is a socket count. With an unlimited connector and the usual 1024
+    # soft descriptor limit, a saturated arm exhausts descriptors and aiohttp
+    # reports `ClientConnectorError ... [Too many open files]` -- which reads
+    # like the server refusing, and is not. Raise the limit first, then cap the
+    # connector below it so the client queues instead of failing.
+    _raise_descriptor_limit()
+    connector = aiohttp.TCPConnector(limit=args.max_connections)
+    payload: dict[str, Any] = {
+        "config": {
+            "base_url": args.base_url,
+            "mode": args.mode,
+            "rates": args.rates,
+            "concurrencies": args.concurrencies,
+            "duration_s": args.duration_s,
+            "requests": args.requests,
+            "max_tokens": args.max_tokens,
+            "repeats": args.repeats,
+            "seed": args.seed,
+            "prompt_tokens_target": args.prompt_tokens,
+            "image_path": args.image_path,
+        },
+        "arms": [],
+    }
+
+    async with aiohttp.ClientSession(connector=connector) as session:
+        args.model = await _resolve_model(session, args)
+        payload["config"]["model"] = args.model
+        print(f"model: {args.model}", file=sys.stderr)
+
+        if args.fingerprint:
+            payload["server_identity"] = collect_server_identity(args.base_url)
+            payload["environment"] = collect_environment_fingerprint(args.model)
+
+        if args.warmup:
+            print(f"warmup x{args.warmup}", file=sys.stderr)
+            await _warmup(session, args)
+
+        targets: list[float] = (
+            [float(x) for x in args.rates.split(",") if x]
+            if args.mode == "open"
+            else [float(x) for x in args.concurrencies.split(",") if x]
+        )
+
+        for target in targets:
+            for repeat in range(args.repeats):
+                run_id = (
+                    f"thinker-{args.mode}-{target:g}-p{args.prompt_tokens}-r{repeat}"
+                )
+                event_dir = None
+                if args.profile_events:
+                    event_dir = os.path.join(args.profile_event_dir, run_id)
+                    os.makedirs(event_dir, exist_ok=True)
+                    start_request_profile(args.base_url, run_id, event_dir)
+                sampler = None
+                if args.sample_util:
+                    gpu_ids = [
+                        int(x) for x in (args.util_gpu_ids or "").split(",") if x
+                    ]
+                    sampler = UtilizationSampler(gpu_ids=gpu_ids)
+                    sampler.start()
+
+                print(f"-> {run_id}", file=sys.stderr)
+                if args.mode == "open":
+                    arm = await _run_open(session, args, target, rng)
+                else:
+                    arm = await _run_closed(session, args, int(target))
+
+                entry = arm.summary()
+                entry["repeat"] = repeat
+                entry["run_id"] = run_id
+                if sampler is not None:
+                    entry["utilization"] = sampler.stop().to_dict()
+                if event_dir is not None:
+                    stop_request_profile(args.base_url, run_id)
+                    try:
+                        entry["stage_breakdown"] = build_stage_breakdown(event_dir)
+                    except Exception as exc:  # noqa: BLE001
+                        entry["stage_breakdown_error"] = f"{type(exc).__name__}: {exc}"
+                if args.save_raw_dir:
+                    os.makedirs(args.save_raw_dir, exist_ok=True)
+                    with open(
+                        os.path.join(args.save_raw_dir, f"{run_id}.jsonl"), "w"
+                    ) as handle:
+                        for record in arm.records:
+                            handle.write(json.dumps(record.to_dict()) + "\n")
+                payload["arms"].append(entry)
+                print(
+                    f"   ok={entry['requests_ok']}/{entry['requests_sent']} "
+                    f"rate={entry['achieved_rate_rps']} "
+                    f"ttft_p95={entry['ttft_s']['p95']} "
+                    f"itl_p95={entry['itl_ms']['p95']} "
+                    f"ptok={entry['prompt_tokens_mean']}",
+                    file=sys.stderr,
+                )
+
+    write_json(args.output, payload)
+    print(f"wrote {args.output}", file=sys.stderr)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default=None)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8611)
+    parser.add_argument("--model", default=None)
+    parser.add_argument("--mode", choices=["open", "closed"], default="open")
+    parser.add_argument("--rates", default="1,2,4,8,16,24")
+    parser.add_argument("--concurrencies", default="1,8,16,32,48,64")
+    parser.add_argument("--duration-s", type=float, default=60.0)
+    parser.add_argument("--requests", type=int, default=64)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--warmup", type=int, default=8)
+    parser.add_argument("--max-tokens", type=int, default=128)
+    parser.add_argument("--timeout-s", type=float, default=600.0)
+    parser.add_argument("--seed", type=int, default=17)
+    parser.add_argument(
+        "--max-connections",
+        type=int,
+        default=4096,
+        help=(
+            "cap on simultaneous connections. The client queues above this "
+            "instead of exhausting descriptors and reporting a connection "
+            "error that looks like the server refusing."
+        ),
+    )
+    parser.add_argument("--prompt-tokens", type=int, default=32)
+    parser.add_argument(
+        "--nonce", default=None, help="prefix marker making prompts unique across runs"
+    )
+    parser.add_argument("--image-path", default=None)
+    parser.add_argument(
+        "--image-dir",
+        default=None,
+        help="draw a distinct image per request from this pool",
+    )
+    parser.add_argument(
+        "--image-offset",
+        type=int,
+        default=0,
+        help="start index into the pool; keep disjoint per server",
+    )
+    parser.add_argument("--profile-events", action="store_true")
+    parser.add_argument("--profile-event-dir", default="/tmp/thinker_profile")
+    parser.add_argument("--sample-util", action="store_true")
+    parser.add_argument("--util-gpu-ids", default=None)
+    parser.add_argument("--fingerprint", action="store_true")
+    parser.add_argument("--save-raw-dir", default=None)
+    parser.add_argument("--output", default="thinker_attribution.json")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if args.image_dir:
+        _load_image_pool(args.image_dir, args.image_offset)
+    if args.nonce is None:
+        args.nonce = uuid.uuid4().hex[:6] + "-"
+    if args.base_url is None:
+        args.base_url = f"http://{args.host}:{args.port}"
+    args.base_url = args.base_url.rstrip("/")
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/developer_reference/pd_vs_colocated.md
+++ b/docs/developer_reference/pd_vs_colocated.md
@@ -1,0 +1,260 @@
+# PD versus colocated at equal GPU count
+
+At equal GPU count on Qwen3-Omni thinker, two colocated replicas deliver higher
+throughput than one prefill/decode pair on both text and image workloads. PD's
+measurable win is that it removes prefill/decode interference almost entirely.
+It pays for that by leaving the prefill GPU about 90% idle, because prefill is a
+small share of this workload's GPU work.
+
+Read every number against the A/A band in the first section. Differences smaller
+than the band are noise.
+
+## Setup
+
+Two H200s, the same two cards for both arms, one pinned tree for both.
+
+| | Arm C | Arm PD |
+| --- | --- | --- |
+| Shape | 2 colocated replicas, one per GPU, load split evenly | 1 prefill half + 1 decode half |
+| CUDA graph | on | on |
+| `mem_fraction_static` | 0.87 | 0.72 |
+| KV pool (tokens) | 677,613 / 677,542 | 472,030 / 468,068 |
+
+Text prompts measure 42-44 tokens. Image prompts measure about 6127 tokens
+(2496x2496 gives 6084 vision tokens). Open-loop Poisson arrivals, 90 s per point,
+3 repeats, identical offered rates in both arms.
+
+The arms differ in `mem_fraction_static`, so this is not a flag-matched
+comparison. PD's prefill card additionally holds the `mm_aggregate` CUDA-IPC
+relay pool and encoder activations, and it ran out of memory at 0.87 and at 0.80.
+PD text throughput is identical across 0.87, 0.80 and 0.72 (8.14/8.14/8.14 at
+offered 8; 10.51/10.59/10.61 at 16; 10.65/10.55/10.60 at 24), which controls the
+text arm. It does not control the image arm, where the memory pressure occurred.
+
+At equal GPU count PD runs one encoder pipeline against colocated's two, because
+a colocated replica is a whole pipeline including its encoder. Moving encoders
+between the prefill and decode cards relocates that load without changing the
+count. This is an uncontrolled confound on the image arm.
+
+### How the numbers are computed
+
+`achieved_rate_rps` is completed requests divided by wall time, where wall spans
+the first request sent to the last completion. Arms drain after the offering
+window closes, so completions divided by a nominal duration overstates an arm
+that queues: PD at offered 44 completes 1672 requests over 157 s, which is 10.7
+rps, not the 18.6 that dividing by 90 would give.
+
+SLO attainment counts every offered request. A refused request meets no SLO. Raw
+TTFT percentiles are conditioned on admitted requests and are printed with the
+admission rate, because computing attainment over admitted requests rewards an
+arm for shedding load.
+
+## A/A band
+
+Arm C pass a against pass b, identical configuration, four matched points.
+
+| Metric | Median | Max |
+| --- | --- | --- |
+| achieved rps | 0.59% | 1.16% |
+| prefill-conditioned ITL ratio | 2.04% | 3.76% |
+| ITL p50 | 3.40% | 4.08% |
+| p95 TTFT | 7.49% | 67.59% |
+| goodput | 11.86% | 23.02% |
+
+Throughput and the conditioned ratio are stable. p95 TTFT is not: it varied
+67.6% between identical arms. Goodput inherits that instability near the knee, so
+goodput differences under about 23% are not readable at this sample size.
+
+## Text
+
+| Offered | Arm | Admitted | Wall (s) | Achieved rps |
+| --- | --- | --- | --- | --- |
+| 8 | C | 100% | 91.3 | 7.69 |
+| 8 | PD | 100% | 90.9 | 8.14 |
+| 16 | C | 100% | 91.5 | 16.15 |
+| 16 | PD | 100% | 135.0 | 10.54 |
+| 24 | C | 100% | 91.7 | 23.43 |
+| 24 | PD | 79.8% | 157.6 | 10.60 |
+| 32 | C | 100% | 92.6 | 30.58 |
+| 32 | PD | 59.0% | 157.3 | 10.58 |
+| 44 | C | 100% | 102.6 | 37.76 |
+| 44 | PD | 43.3% | 157.1 | 10.70 |
+
+PD saturates by offered 16 and holds about 10.6 rps, shedding load above that.
+Colocated still tracked the offered rate at 44 with full admission, so its text
+ceiling was not established and the 3.5x gap at offered 44 is a lower bound.
+
+Failures are connection refusals, not client errors. Colocated refused none at
+any rate.
+
+## Image
+
+| Offered | Arm | Admitted | Wall (s) | Achieved rps | TTFT p95 (s) |
+| --- | --- | --- | --- | --- | --- |
+| 1 | C | 100% | 86.1 | 0.79 | 1.610 |
+| 1 | PD | 100% | 88.8 | 0.86 | 1.300 |
+| 2 | C | 100% | 90.2 | 1.69 | 2.285 |
+| 2 | PD | 100% | 90.8 | 1.82 | 3.893 |
+| 3 | C | 100% | 94.9 | 2.63 | 4.771 |
+| 3 | PD | 98.5% | 120.4 | 2.13 | 30.281 |
+| 4 | C | 100% | 96.9 | 3.41 | 9.770 |
+| 4 | PD | 99.6% | 161.9 | 2.15 | 69.810 |
+| 6 | C | 90.8% | 135.6 | 3.44 | 42.127 |
+| 6 | PD | 99.5% | 259.9 | 2.13 | 162.250 |
+
+Three regions. At offered 1 PD leads on both throughput (+8.9%, about 15x the
+A/A band) and TTFT. At offered 2 PD leads on throughput and trails on TTFT, so an
+SLO on TTFT can already favour colocated. From offered 3 upward colocated leads
+on both, reaching 1.62x at saturation.
+
+Counts and rate disagree at offered 6: PD completes 554 against colocated's 472
+but takes 259.9 s against 135.6 s. PD queues where colocated refuses.
+
+## Prefill/decode interference
+
+Ratio of the median inter-token gap that overlaps a prefill to the median gap
+that does not.
+
+| Offered | Text: C | Text: PD | Image: C | Image: PD |
+| --- | --- | --- | --- | --- |
+| lowest | 8.50 | 1.001 | 20.49 | 1.016 |
+| highest | 5.94 | 1.535 | 8.41 | 0.969 |
+
+PD removes the interference. On the image arm a prefill in flight on the other
+card is statistically indistinguishable from no prefill at all. Colocated pays
+5.8x to 8.5x on text and 8.4x to 20.5x on images, worst at low image rates where
+an unchunked 6127-token prefill lands on an otherwise quiet decode stream.
+`_needs_full_prefill` returns `req._input_embeds_are_projected`, and when any
+queued request needs it `rem_chunk_tokens` is None, so mixed-chunk folds no
+decodes into an image prefill.
+
+PD's clean gap degrades with load, from 7.80 ms to 31.15 ms on text, while
+colocated's stays between 7.6 ms and 12.9 ms. PD replaces interference with
+queueing on the decode card.
+
+## Where PD's time goes
+
+Segment medians at text offered 16, where both arms admit every request.
+
+| Segment | Arm C replica | Arm PD |
+| --- | --- | --- |
+| build | 0.24 ms | 0.18 ms |
+| build to queued | 0.05 ms | 0.05 ms |
+| queued to scheduled | 3.90 ms | 1.99 ms |
+| first forward | 59.99 ms | 58.33 ms |
+| decode tail | 2206 ms | 41560 ms |
+
+Admission is not the constraint and prefill did not get slower. The whole
+difference is the decode tail. Utilization at the same offered rate is 10.1%
+mean on PD's prefill card against 67.9% on a colocated card.
+
+A 58 ms first forward against a 2.2 s decode tail puts prefill at **at most**
+2.6% of a request's GPU work, and below that whenever a prefill step carries more
+than one request, which it does under load. A 1P:1D pair splits hardware 50/50
+against that split, which predicts roughly 10% utilization on the prefill card,
+which is what was measured.
+
+Prefill steps batch, and the batch factor grows with load: at 42 prompt tokens
+and 128 output tokens a step carries 1.19 requests at the lowest rate swept and
+5.81 at the highest, while the step itself stays between 59 ms and 66 ms across a
+14x range of batch size. The step cost model is therefore a cost per step, not
+per request, and `1 / 0.059` bounds prefill **steps** per second rather than
+requests per second.
+
+That distinction decides which resource binds. Prefill duty cycle, meaning steps
+times step cost over wall time, on one colocated replica:
+
+| Offered | 8 output tokens | 128 output tokens |
+| --- | --- | --- |
+| 8 | 24.8% | 19.2% |
+| 20 | 53.3% | 34.9% |
+| 36 | 72.3% | 32.9% |
+| 56 | 81.6% | 24.0% |
+
+At 8 output tokens the prefill path climbs toward saturation and is the binding
+constraint. At 128 it peaks near 35% and falls back as the system saturates,
+because prefill admission is throttled behind decode. The colocated ceiling
+reported above is decode-bound, not prefill-bound.
+
+By Little's law PD holds about 437 requests in the decode tail against
+`max_running_requests=64`, so most of that tail is queueing rather than decoding.
+Colocated holds about 18.
+
+Prefill share is governed by prompt length divided by output length. At 128
+output tokens it reaches only about 9% even at 6944 prompt tokens, because the
+output dominates. Shortening the output raises it faster: at 8 output tokens a
+42-token prompt gives about 42%.
+
+The handoff is not serialized: 41.5% of PD's decode gaps overlap a prefill
+window, and first forward is unchanged.
+
+This data does not explain why PD's single decode card sustains 10.54 rps while a
+colocated card doing both prefill and decode sustains 18.9. Candidates that these
+events cannot separate are the mandatory `page_size=1`, the mandatory
+`disable_radix_cache`, the absence of mixed-chunk batching on the decode side,
+and the cost of receiving KV over CUDA IPC. Separating them needs an experiment
+that varies each independently.
+
+## Admission rate lags
+
+| Arm | Rate per server | total_s p50 | In flight |
+| --- | --- | --- | --- |
+| C, offered 32 | 15.41 | 4.24 s | 65 |
+| C, offered 44 | 19.66 | 7.95 s | 156 |
+| PD, offered 16 | 10.59 | 40.96 s | 434 |
+| PD, offered 24 | 10.55 | 68.81 s | 726 |
+| PD, offered 44 | 10.54 | 74.12 s | 781 |
+
+In flight is achieved rate times median total time. At offered 16 PD admits
+every request while each takes 41 s against colocated's 2.3 s. Admission rate
+reports a healthy system there. In-flight count and total time report the real
+state, and they should be read together.
+
+The connection failures this sweep recorded above offered 16 were **client-side
+descriptor exhaustion, not the server shedding load**. The client holds one
+socket per in-flight request and ran with an unlimited connector under a 1024
+soft limit, so a saturated arm exhausts descriptors. Every such record reads
+`ClientConnectorError ... [Too many open files]`, which is EMFILE from the
+client's own `socket()` call; `[Connect call failed]`, which is what a refusing
+server produces, appears nowhere in the results. The colocated arm ran two
+client processes with a budget each and never approached the limit, so the two
+arms were not comparable on that axis at all. Treat admission rate above
+offered 16 in this sweep as a property of the harness.
+
+The harness now raises the descriptor limit and caps the connector, so a client
+at its ceiling queues rather than failing. Throughput and latency figures are
+unaffected: `achieved_rate_rps` counts completions over wall time, and the
+41-second `total_s` at offered 16 was measured where there were no failures at
+all.
+
+## Reproducing
+
+```
+python -m benchmarks.eval.benchmark_omni_thinker_attribution \
+    --port PORT --mode open --rates 8,16,24,32,44 --duration-s 90 \
+    --repeats 3 --prompt-tokens 42 --max-tokens 128 --nonce TAG \
+    --profile-events --profile-event-dir events/TAG \
+    --sample-util --util-gpu-ids GPU --output results/TAG.json
+python -m benchmarks.eval.analyze_thinker_events events/TAG/RUN_ID
+python -m benchmarks.eval.aggregate_pd_vs_colocated --root .
+```
+
+The client offers Poisson arrivals for the full duration without waiting for
+completions, so an arm that cannot keep up shows it in the achieved rate rather
+than in a reduced offered rate. Each prompt carries a unique marker at token 0
+and a per-repetition counter, so prefix caching does not absorb the prompt.
+Multimodal runs need a large image pool with disjoint per-invocation offsets:
+replaying one image set dropped TTFT p95 from 882 ms to 482 ms at the same prompt
+length.
+
+`--prompt-tokens` is a target rather than a count, and it overshoots by a factor
+that grows with the value: 42 gives 42, 1150 gives about 1966, and 4400 gives
+about 7645. Quote the `prompt_tokens` recorded in the result JSON, which is the
+measured value. Check the target against the model's context limit before
+choosing arms; Qwen3-Omni thinker allows 8192, which 4400 prompt tokens reaches
+once 128 output tokens are added. Let the client generate the nonce rather than
+passing `--nonce`, because the nonce sits inside every repetition counter and a
+different width shifts the prompt length.
+
+`analyze_thinker_events` accepts events from `thinker`, `thinker_prefill` and
+`thinker_decode`, so one code path covers both arms.


### PR DESCRIPTION
This is the benchmarking half of PR 5 in the RFC, so it stacks on the PD PRs. Based on `pd_runtime`, which is the deepest base available here: PR 4's branch `pd_result` lives in a fork rather than in this repo. The harness imports no PD code, so it applies cleanly on either.

## What it measures

`benchmark_omni_thinker_attribution.py` offers Poisson arrivals at a target rate for a fixed duration without waiting for completions, so an arm that cannot keep up shows it in the achieved rate rather than in a reduced offered rate. It records five segments per request — build, build to queued, queued to scheduled, first forward, decode tail — using the same decomposition as `docs/developer_reference/qwen3_asr_concurrency_profile.md`.

`analyze_thinker_events.py` computes the inter-token gap split by whether the gap overlaps a concurrent prefill. It accepts events from `thinker`, `thinker_prefill` and `thinker_decode`, so colocated and PD runs go through one code path.

`aggregate_pd_vs_colocated.py` joins per-point results across arms.

## The report

`docs/developer_reference/pd_vs_colocated.md` holds the equal-GPU-count comparison on two H200s: A/A band, text, image, interference, segment attribution, and the admission data. Findings, in short:

- At equal GPU count two colocated replicas beat one PD pair on both workloads. The text gap is a lower bound, because colocated never saturated in the rates swept.
- PD removes prefill/decode interference almost entirely. The prefill-conditioned ITL ratio is about 1.0 for PD against 5.8x to 20.5x for colocated, against an A/A band of 2.04%.
- Prefill is about 2.6% of a request's GPU work at 42 prompt tokens and 128 output tokens, so a 1P:1D pair splits hardware 50/50 against a 2.6/97.4 work split. Measured utilization on the PD prefill card is 10.1% against 67.9% on a colocated card.

## Two measurement notes worth carrying into other benchmarks

**Throughput must divide by wall time, not by the nominal duration.** Arms drain after the offering window closes. PD at offered 44 completes 1672 requests over 157 s, which is 10.7 rps; dividing by 90 gives 18.6.

**SLO attainment must count every offered request.** A refused request meets no SLO. At offered 44 PD's TTFT p95 looks about 10x better than colocated's while PD admits 43.3% and colocated admits 100%. Computing attainment over admitted requests rewards an arm for shedding load.

The report states the A/A band first because two of the metrics are not usable at this sample size: p95 TTFT varied 67.6% between identical arms, and goodput varied 23.0%. Achieved rate (0.59%) and the conditioned ratio (2.04%) are.

## Caveats stated in the report

The arms differ in `mem_fraction_static`, 0.87 against 0.72, because PD's prefill card also holds the `mm_aggregate` relay pool and encoder activations. PD text throughput is identical across all three fractions, which controls the text arm and not the image arm. At equal GPU count PD runs one encoder pipeline against colocated's two, which is an uncontrolled confound on the image arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


