### PR TITLE
feat(qwen3-omni,ming): opt in to PD disaggregation

### DIFF
--- a/sglang_omni/models/ming_omni/bootstrap.py
+++ b/sglang_omni/models/ming_omni/bootstrap.py
@@ -11,6 +11,7 @@ from sglang_omni.vendor.sglang.server_args import override_server_args
 logger = logging.getLogger(__name__)
 
 StreamOutputBuilder = Callable[[str, Any, Any], list[Any]]
+MING_THINKER_PD_RESUME_SCHEMA = "ming-omni-thinker-v1"
 
 
 def create_thinker_scheduler(
@@ -22,6 +23,8 @@ def create_thinker_scheduler(
     tp_size: int = 1,
     nccl_port: int | None = None,
     enable_streaming_tts: bool = False,
+    scheduler_cls: type | None = None,
+    scheduler_kwargs: dict[str, Any] | None = None,
 ):
     if tp_size < 1:
         raise ValueError(f"tp_size must be >= 1, got {tp_size}")
@@ -92,8 +95,22 @@ def create_thinker_scheduler(
         tokenizer=tokenizer,
         eos_token_id=getattr(tokenizer, "eos_token_id", None),
     )
+    scheduler_cls = scheduler_cls or OmniScheduler
+    construction_kwargs = dict(scheduler_kwargs or {})
+    if scheduler_cls is not OmniScheduler:
+        from sglang_omni.scheduling.pd_scheduler import model_pd_scheduler_kwargs
 
-    return OmniScheduler(
+        state_builder, state_restorer = make_thinker_pd_adapters(tokenizer=tokenizer)
+        construction_kwargs.update(
+            model_pd_scheduler_kwargs(
+                scheduler_cls,
+                state_builder=state_builder,
+                state_restorer=state_restorer,
+                resume_schema=MING_THINKER_PD_RESUME_SCHEMA,
+            )
+        )
+
+    return scheduler_cls(
         tp_worker=model_worker,
         tree_cache=tree_cache,
         req_to_token_pool=req_to_token_pool,
@@ -104,7 +121,46 @@ def create_thinker_scheduler(
         request_builder=request_builder,
         result_adapter=result_adapter,
         stream_output_builder=stream_output_builder,
+        **construction_kwargs,
     )
+
+
+def make_thinker_pd_adapters(*, tokenizer: Any):
+    """Project Ming Prefill state and restore its Decode-only request fields."""
+
+    def state_builder(req: Any):
+        from sglang_omni.models.ming_omni.io import MingOmniPipelineState
+        from sglang_omni.proto import OmniRequest, StagePayload
+
+        payload = req._omni_data.stage_payload
+        state = MingOmniPipelineState.from_dict(payload.data)
+        input_ids = list(req.origin_input_ids)
+        projected = MingOmniPipelineState(
+            prompt={"input_ids": input_ids},
+            stream_state=dict(state.stream_state),
+        )
+        projected_payload = StagePayload(
+            request_id=payload.request_id,
+            request=OmniRequest(
+                inputs=None,
+                params=dict(payload.request.params),
+                metadata=dict(payload.request.metadata),
+            ),
+            data=projected.to_dict(),
+        )
+        resume = {"schema": MING_THINKER_PD_RESUME_SCHEMA}
+        return projected_payload.to_dict(), resume, input_ids
+
+    def state_restorer(req: Any, data: Any, resume: dict[str, Any] | None) -> None:
+        del data
+        if resume != {"schema": MING_THINKER_PD_RESUME_SCHEMA}:
+            raise ValueError(f"unsupported Ming thinker PD resume {resume!r}")
+        req.tokenizer = tokenizer
+        req.omni_model_inputs = None
+        req._omni_consumed = None
+        req._codec_suppress_tokens = None
+
+    return state_builder, state_restorer
 
 
 def make_thinker_scheduler_adapters(

--- a/sglang_omni/models/ming_omni/config.py
+++ b/sglang_omni/models/ming_omni/config.py
@@ -175,6 +175,9 @@ def _thinker_stage(*, gpu: int, speech_enabled: bool, process: str) -> StageConf
         name=THINKER_STAGE,
         process=process,
         factory_path=f"{_PKG}.stages.create_sglang_thinker_executor_from_config",
+        # This factory projects and restores the state a Decode half needs, so
+        # the compiler may split it.
+        pd_capable=True,
         factory=MingThinkerFactoryArgs(thinker_max_seq_len=8192),
         gpu=gpu,
         next=[DECODE_STAGE, TALKER_STAGE] if speech_enabled else DECODE_STAGE,
@@ -194,6 +197,9 @@ def _streaming_thinker_stage(*, gpu: int, process: str) -> StageConfig:
         name=THINKER_STAGE,
         process=process,
         factory_path=f"{_PKG}.stages.create_sglang_thinker_executor_from_config",
+        # This factory projects and restores the state a Decode half needs, so
+        # the compiler may split it.
+        pd_capable=True,
         factory=MingThinkerFactoryArgs(
             thinker_max_seq_len=8192, enable_streaming_tts=True
         ),

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -291,6 +291,8 @@ def create_sglang_thinker_executor_from_config(
     thinker_max_seq_len: int = 8192,
     server_args_overrides: dict[str, Any] | None = None,
     enable_streaming_tts: bool = False,
+    scheduler_cls: type | None = None,
+    scheduler_kwargs: dict[str, Any] | None = None,
 ):
     validate_stage_tp_support(stage_name="thinker", tp_size=tp_size)
 
@@ -317,6 +319,8 @@ def create_sglang_thinker_executor_from_config(
         tp_size=tp_size,
         nccl_port=nccl_port,
         enable_streaming_tts=enable_streaming_tts,
+        scheduler_cls=scheduler_cls,
+        scheduler_kwargs=scheduler_kwargs,
     )
 
 

--- a/sglang_omni/models/qwen3_omni/bootstrap.py
+++ b/sglang_omni/models/qwen3_omni/bootstrap.py
@@ -19,12 +19,16 @@ def create_thinker_scheduler(
     prefill_coalesce_requests: int = 0,
     prefill_coalesce_wait_ms: float = 60.0,
     prefill_coalesce_when_idle: bool = False,
+    scheduler_cls: type | None = None,
+    scheduler_kwargs: dict[str, Any] | None = None,
 ):
     """Create the Qwen thinker scheduler."""
     from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 
     from sglang_omni.model_runner.thinker_model_runner import ThinkerModelRunner
     from sglang_omni.models.qwen3_omni.request_builders import (
+        QWEN_THINKER_PD_RESUME_SCHEMA,
+        make_thinker_pd_adapters,
         make_thinker_scheduler_adapters,
         make_thinker_stream_output_builder,
         should_generate_audio_output,
@@ -108,8 +112,22 @@ def create_thinker_scheduler(
         thinker_config=thinker_config,
     )
     stream_output_builder = make_thinker_stream_output_builder()
+    scheduler_cls = scheduler_cls or OmniScheduler
+    construction_kwargs = dict(scheduler_kwargs or {})
+    if scheduler_cls is not OmniScheduler:
+        from sglang_omni.scheduling.pd_scheduler import model_pd_scheduler_kwargs
 
-    return OmniScheduler(
+        state_builder, state_restorer = make_thinker_pd_adapters(tokenizer=tokenizer)
+        construction_kwargs.update(
+            model_pd_scheduler_kwargs(
+                scheduler_cls,
+                state_builder=state_builder,
+                state_restorer=state_restorer,
+                resume_schema=QWEN_THINKER_PD_RESUME_SCHEMA,
+            )
+        )
+
+    return scheduler_cls(
         tp_worker=model_worker,
         tree_cache=tree_cache,
         req_to_token_pool=req_to_token_pool,
@@ -125,6 +143,7 @@ def create_thinker_scheduler(
         prefill_coalesce_requests=prefill_coalesce_requests,
         prefill_coalesce_wait_ms=prefill_coalesce_wait_ms,
         prefill_coalesce_when_idle=prefill_coalesce_when_idle,
+        **construction_kwargs,
     )
 
 

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -153,6 +153,9 @@ def _thinker_stage(*, gpu: int, speech_enabled: bool, process: str) -> StageConf
         factory_path=f"{_PKG}.stages.create_sglang_thinker_executor_from_config",
         factory=factory_group,
         gpu=gpu,
+        # This factory projects and restores the state a Decode half needs, so
+        # the compiler may split it.
+        pd_capable=True,
         next="decode",
         **join_kwargs,
         stream_to=["talker_ar", "decode"] if speech_enabled else ["decode"],

--- a/sglang_omni/models/qwen3_omni/request_builders.py
+++ b/sglang_omni/models/qwen3_omni/request_builders.py
@@ -34,6 +34,7 @@ DECODE_STAGE = "decode"
 TALKER_STAGE = "talker_ar"
 CODE2WAV_STAGE = "code2wav"
 MM_AGGREGATE_STAGE = "mm_aggregate"
+QWEN_THINKER_PD_RESUME_SCHEMA = "qwen3-omni-thinker-v1"
 
 # Note(Chenchen Hong): PyTorch sampling_seed must fit a positive int32.
 MAX_INT32_POSITIVE = 0x7FFFFFFF
@@ -1023,6 +1024,68 @@ def make_thinker_scheduler_adapters(
         )
 
     return request_builder, result_adapter
+
+
+def make_thinker_pd_adapters(*, tokenizer: Any):
+    """Project and restore the model state needed after a thinker Prefill."""
+
+    def state_builder(req: Any):
+        data = req._omni_data
+        payload = data.stage_payload
+        state = Qwen3OmniPipelineState.from_dict(payload.data)
+        prompt_ids = state.prompt["input_ids"]
+        if hasattr(prompt_ids, "tolist"):
+            prompt_ids = prompt_ids.tolist()
+        prompt_ids = list(prompt_ids)
+        projected = Qwen3OmniPipelineState(
+            prompt={"input_ids": prompt_ids},
+            stream_state=dict(state.stream_state),
+        )
+        projected_payload = StagePayload(
+            request_id=payload.request_id,
+            request=OmniRequest(
+                inputs=None,
+                params=dict(payload.request.params),
+                metadata=dict(payload.request.metadata),
+            ),
+            data=projected.to_dict(),
+        )
+        mm_inputs = req.multimodal_inputs
+        delta = (
+            None
+            if mm_inputs is None
+            else getattr(mm_inputs, "mrope_position_delta", None)
+        )
+        resume = None
+        if delta is not None:
+            resume = {
+                "schema": QWEN_THINKER_PD_RESUME_SCHEMA,
+                "mrope_position_delta": delta.tolist(),
+            }
+        return projected_payload.to_dict(), resume, prompt_ids
+
+    def state_restorer(req: Any, data: Any, resume: dict[str, Any] | None) -> None:
+        del data
+        req.tokenizer = tokenizer
+        req.omni_model_inputs = None
+        req._omni_consumed = None
+        req._omni_mm_positions = None
+        if resume is None:
+            return
+        if set(resume) != {"schema", "mrope_position_delta"}:
+            raise ValueError("invalid Qwen thinker PD resume fields")
+        if resume["schema"] != QWEN_THINKER_PD_RESUME_SCHEMA:
+            raise ValueError(f"unsupported Qwen thinker PD resume {resume['schema']!r}")
+        from sglang.srt.managers.schedule_batch import MultimodalInputs
+
+        delta = torch.tensor(resume["mrope_position_delta"], dtype=torch.long)
+        if delta.shape != (1, 1):
+            raise ValueError("Qwen thinker PD mRoPE delta must have shape (1, 1)")
+        mm_inputs = MultimodalInputs(mm_items=[])
+        mm_inputs.mrope_position_delta = delta
+        req.multimodal_inputs = mm_inputs
+
+    return state_builder, state_restorer
 
 
 def make_talker_scheduler_adapters(

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -1012,6 +1012,8 @@ def create_sglang_thinker_executor_from_config(
     prefill_coalesce_requests: int = 0,
     prefill_coalesce_wait_ms: float = 60.0,
     prefill_coalesce_when_idle: bool = False,
+    scheduler_cls: type | None = None,
+    scheduler_kwargs: dict[str, Any] | None = None,
 ):
     """Returns OmniScheduler for thinker."""
     # note (luojiaxuan):
@@ -1103,6 +1105,8 @@ def create_sglang_thinker_executor_from_config(
         prefill_coalesce_requests=prefill_coalesce_requests,
         prefill_coalesce_wait_ms=prefill_coalesce_wait_ms,
         prefill_coalesce_when_idle=prefill_coalesce_when_idle,
+        scheduler_cls=scheduler_cls,
+        scheduler_kwargs=scheduler_kwargs,
     )
     post_load_process_mem = get_process_gpu_memory_bytes(gpu_id)
     logger.info(

--- a/tests/unit_test/pipeline/test_pd_model_state.py
+++ b/tests/unit_test/pipeline/test_pd_model_state.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.ming_omni.bootstrap import MING_THINKER_PD_RESUME_SCHEMA
+from sglang_omni.models.ming_omni.bootstrap import (
+    make_thinker_pd_adapters as make_ming_pd_adapters,
+)
+from sglang_omni.models.qwen3_omni.request_builders import QWEN_THINKER_PD_RESUME_SCHEMA
+from sglang_omni.models.qwen3_omni.request_builders import (
+    make_thinker_pd_adapters as make_qwen_pd_adapters,
+)
+from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.scheduling.pd_utils import DecodeContinuation
+
+
+def _payload(data) -> StagePayload:
+    return StagePayload(
+        request_id="request",
+        request=OmniRequest(
+            inputs={"discarded": True},
+            params={"stream": True},
+            metadata={"output_modalities": ["text"]},
+        ),
+        data=data,
+    )
+
+
+def _continuation(payload, resume, input_ids) -> DecodeContinuation:
+    return DecodeContinuation(
+        request_id="request",
+        transfer_id="transfer",
+        origin_input_ids=input_ids,
+        output_ids=[42],
+        vocab_size=128,
+        sampling_params={},
+        stage_payload=payload,
+        multimodal_resume=resume,
+    )
+
+
+def test_qwen_pd_state_round_trip_uses_generic_continuation_hook() -> None:
+    builder, restorer = make_qwen_pd_adapters(tokenizer="tokenizer")
+    source = SimpleNamespace(
+        origin_input_ids=[10, 11, 12],
+        _omni_data=SimpleNamespace(
+            stage_payload=_payload(
+                {
+                    "prompt": {"input_ids": torch.tensor([10, 11, 12])},
+                    "stream_state": {"offset": 3},
+                    "encoder_outs": {"large": torch.ones(4)},
+                }
+            )
+        ),
+        multimodal_inputs=SimpleNamespace(
+            mrope_position_delta=torch.tensor([[5]], dtype=torch.long)
+        ),
+    )
+    payload, resume, input_ids = builder(source)
+    continuation = DecodeContinuation.decode(
+        _continuation(payload, resume, input_ids).encode()
+    )
+
+    assert continuation.multimodal_resume == {
+        "schema": QWEN_THINKER_PD_RESUME_SCHEMA,
+        "mrope_position_delta": [[5]],
+    }
+    assert continuation.stage_payload["data"] == {
+        "prompt": {"input_ids": [10, 11, 12]},
+        "stream_state": {"offset": 3},
+    }
+    destination = SimpleNamespace()
+    restorer(destination, None, continuation.multimodal_resume)
+    assert destination.tokenizer == "tokenizer"
+    assert destination.multimodal_inputs.mrope_position_delta.tolist() == [[5]]
+
+
+def test_qwen_pd_state_rejects_unknown_schema_and_shape() -> None:
+    _, restorer = make_qwen_pd_adapters(tokenizer=None)
+    with pytest.raises(ValueError, match="unsupported Qwen"):
+        restorer(
+            SimpleNamespace(),
+            None,
+            {"schema": "future", "mrope_position_delta": [[1]]},
+        )
+    with pytest.raises(ValueError, match="shape"):
+        restorer(
+            SimpleNamespace(),
+            None,
+            {
+                "schema": QWEN_THINKER_PD_RESUME_SCHEMA,
+                "mrope_position_delta": [1, 2],
+            },
+        )
+
+
+def test_ming_pd_state_round_trip_uses_generic_continuation_hook() -> None:
+    builder, restorer = make_ming_pd_adapters(tokenizer="tokenizer")
+    source = SimpleNamespace(
+        origin_input_ids=[20, 21, 22],
+        _omni_data=SimpleNamespace(
+            stage_payload=_payload(
+                {
+                    "prompt": {"input_ids": torch.tensor([20, 21, 22])},
+                    "stream_state": {"offset": 2},
+                    "thinker_inputs": {"image_embeds": torch.ones(4, 2)},
+                }
+            )
+        ),
+    )
+    payload, resume, input_ids = builder(source)
+    continuation = DecodeContinuation.decode(
+        _continuation(payload, resume, input_ids).encode()
+    )
+
+    assert continuation.multimodal_resume == {"schema": MING_THINKER_PD_RESUME_SCHEMA}
+    assert continuation.stage_payload["data"] == {
+        "prompt": {"input_ids": [20, 21, 22]},
+        "stream_state": {"offset": 2},
+    }
+    destination = SimpleNamespace()
+    restorer(destination, None, continuation.multimodal_resume)
+    assert destination.tokenizer == "tokenizer"
+    assert destination.omni_model_inputs is None
+
+
+def test_ming_pd_state_rejects_unknown_schema() -> None:
+    _, restorer = make_ming_pd_adapters(tokenizer=None)
+    with pytest.raises(ValueError, match="unsupported Ming"):
+        restorer(SimpleNamespace(), None, {"schema": "future"})


### PR DESCRIPTION
## Base PR

Base PR: #1773
Frozen head: `a3827d13`

**Merge with #1803.** That PR replaces the `@pd_disaggregation_capable` decorator with a `pd_capable` field on the stage, and these models declare it that way. Verified merged together: 1433 pass, with only the 5 pre-existing `qwen3_omni` failures.

## What this is

The base carries the mechanism and no model. This is the other half, for the two models that have one.

Qwen's `make_thinker_pd_adapters` projects the thinker state a Decode half needs and restores it on arrival. Ming's bootstrap does the same for its own stage. Both stages declare `pd_capable`, which is what `validate_pd_capabilities` reads before a PD config is allowed to compile — the declaration is data in the config, so the compiler never imports these modules to find it. Both factories accept `scheduler_cls` and `scheduler_kwargs` so the compiler can hand them the role-specific scheduler it chose.

A model that needs no projection needs none of this — `default_state_builder` and `default_state_restorer` in the base already cover it. That is why this can be a separate layer rather than a dependency of the mechanism.

## Two things it does not do

**It does not touch CUDA graph.** PD sets `disable_cuda_graph` on neither half; both inherit the stage's engine arguments. #1784 made those settable per half, so an operator can now turn the graph off on one side for a controlled comparison without a code change. Worth stating because the earlier PD measurements that showed a large TPOT regression were taken with the graph off on the PD arm and on for the baseline — a benchmark setting, not anything in this path.

**It does not carry placement or sizing.** Per-half memory budgets, per-half engine arguments and `decode_targets` are all in the config layer from #1784 and #1791. Nothing here needs to know how many Decode halves there are or where they sit.

## Testing

| Run | Result |
| --- | --- |
| `tests/unit_test/pipeline` | 537 pass |

That includes `test_pd_model_state.py`, which moved here with the code it tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
