### PR TITLE
[Fix] Warn when torch profiler with_stack starts on a busy stage

### DIFF
--- a/docs/developer_reference/profiler.md
+++ b/docs/developer_reference/profiler.md
@@ -209,6 +209,14 @@ With all four off (the default), a typical 10-sample MMMU run produces a
 trace in the tens of MB. With all four on, the same workload can produce a
 multi-GB trace — only opt in when you need that specific information.
 
+> **Caution:** start `SGLANG_TORCH_PROFILER_WITH_STACK=1` profiling only on an
+> idle server. Torch's stack-capture machinery replays every live thread's
+> Python frames when the profiler starts, and doing that while requests are in
+> flight can deadlock the whole stage process on the GIL
+> ([#1779](https://github.com/sgl-project/sglang-omni/issues/1779)). The stage
+> logs a warning when a `with_stack` start races in-flight requests; if the
+> start hangs, drain traffic first or unset the flag.
+
 ## HTTP surface
 
 | Method | Path | Body | Notes |

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -1789,6 +1789,23 @@ class Stage:
     def _on_profiler_start(self, msg: ProfilerStartMessage) -> None:
         run_id = msg.run_id
         if msg.enable_torch and not TorchProfiler.is_active():
+            if (
+                os.environ.get("SGLANG_TORCH_PROFILER_WITH_STACK") == "1"
+                and self._active_requests
+            ):
+                # torch's PythonTracer replays every live thread's Python
+                # frames on start; with another thread mid-forward this can
+                # self-deadlock on the GIL and hang the stage process (#1779).
+                logger.warning(
+                    "Stage %s: starting torch profiler with "
+                    "SGLANG_TORCH_PROFILER_WITH_STACK=1 while %d request(s) "
+                    "are in flight. Stack capture on a busy server can "
+                    "deadlock the stage process (torch PythonTracer GIL "
+                    "issue, see #1779). If this start hangs, profile an idle "
+                    "server or unset SGLANG_TORCH_PROFILER_WITH_STACK.",
+                    self.name,
+                    len(self._active_requests),
+                )
             base_tpl = msg.trace_path_template.format(run_id=run_id, stage=self.name)
             template = f"{base_tpl}_pid{os.getpid()}"
             prof_dir = os.environ.get("SGLANG_TORCH_PROFILER_DIR")

--- a/tests/unit_test/profiler/test_with_stack_busy_warning.py
+++ b/tests/unit_test/profiler/test_with_stack_busy_warning.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Warn when a torch profiler start with ``with_stack`` hits a busy stage.
+
+Starting the torch profiler with ``SGLANG_TORCH_PROFILER_WITH_STACK=1``
+while the stage has requests in flight can deadlock the whole stage
+process: torch's PythonTracer replays every thread's Python frames while
+holding a swapped thread state, and a concurrent module forward makes it
+block on a GIL it already holds (#1779). The stage cannot fix torch, but
+it can say loudly that this start is entering known-risky territory.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from sglang_omni.profiler.torch_profiler import TorchProfiler
+from sglang_omni.proto.messages import ProfilerStartMessage
+from tests.unit_test.pipeline.helpers import make_stage
+
+
+@pytest.fixture()
+def profiler_start_calls(monkeypatch: pytest.MonkeyPatch) -> list[str | None]:
+    """Stub TorchProfiler.start so no real global profiler is attached."""
+    calls: list[str | None] = []
+
+    def _fake_start(trace_path_template: str, run_id: str | None = None) -> str:
+        calls.append(run_id)
+        return f"{trace_path_template}.trace.json.gz"
+
+    monkeypatch.setattr(TorchProfiler, "start", _fake_start)
+    return calls
+
+
+def _start_message() -> ProfilerStartMessage:
+    return ProfilerStartMessage(
+        run_id="r1",
+        trace_path_template="/tmp/profiles/{run_id}/{stage}/trace",
+    )
+
+
+def test_with_stack_on_busy_stage_warns_but_still_starts(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    profiler_start_calls: list[str | None],
+) -> None:
+    monkeypatch.setenv("SGLANG_TORCH_PROFILER_WITH_STACK", "1")
+    stage = make_stage()
+    stage._active_requests.add("req-1")
+
+    with caplog.at_level(logging.WARNING):
+        stage._on_profiler_start(_start_message())
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+        and "SGLANG_TORCH_PROFILER_WITH_STACK" in r.getMessage()
+    ]
+    assert warnings, "expected a with_stack-on-busy-stage warning"
+    assert "deadlock" in warnings[0].getMessage()
+    # Advisory only: the profiler start itself must not be blocked.
+    assert profiler_start_calls == ["r1"]
+
+
+def test_with_stack_off_busy_stage_is_silent(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    profiler_start_calls: list[str | None],
+) -> None:
+    monkeypatch.delenv("SGLANG_TORCH_PROFILER_WITH_STACK", raising=False)
+    stage = make_stage()
+    stage._active_requests.add("req-1")
+
+    with caplog.at_level(logging.WARNING):
+        stage._on_profiler_start(_start_message())
+
+    assert not any(
+        "SGLANG_TORCH_PROFILER_WITH_STACK" in r.getMessage() for r in caplog.records
+    )
+    assert profiler_start_calls == ["r1"]
+
+
+def test_with_stack_on_idle_stage_is_silent(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    profiler_start_calls: list[str | None],
+) -> None:
+    monkeypatch.setenv("SGLANG_TORCH_PROFILER_WITH_STACK", "1")
+    stage = make_stage()
+    assert not stage._active_requests
+
+    with caplog.at_level(logging.WARNING):
+        stage._on_profiler_start(_start_message())
+
+    assert not any(
+        "SGLANG_TORCH_PROFILER_WITH_STACK" in r.getMessage() for r in caplog.records
+    )
+    assert profiler_start_calls == ["r1"]


### PR DESCRIPTION
## Motivation

Mitigation for #1779. Starting the torch profiler with
`SGLANG_TORCH_PROFILER_WITH_STACK=1` while a stage has requests in flight can
deadlock the whole stage process: torch's PythonTracer replays every live
thread's Python frames under a swapped thread state and can block on a GIL it
already holds (full py-spy analysis in #1779). The root cause is in torch
itself, so this PR does not try to fix the hang — it makes the risky start
loud instead.

## Modifications

- `_on_profiler_start` logs a warning when a `with_stack` start races
  in-flight requests, pointing at #1779 and the workaround (profile an idle
  server, or unset the flag). The start itself is not blocked and defaults are
  unchanged.
- Documented the hazard in `docs/developer_reference/profiler.md` next to the
  flag table.
- Unit tests: warn-when-busy, silent-when-flag-off, silent-when-idle
  (`tests/unit_test/profiler/test_with_stack_busy_warning.py`).

Note: the warning is per-process. On TP deployments follower ranks receive
work via `TPWorkMessage` without tracking `_active_requests`, so the warning
comes from the leader rank only — still one warning per risky start, since
profiler starts are fanned out from the leader.

An alternative would be to force `with_stack` off (or refuse the start) when
the stage is busy — happy to switch to that if preferred; kept it
advisory-only since the flag is opt-in and the hang is probabilistic.

## Related Issues

Mitigates #1779 (root cause is in torch's PythonTracer; per the reporter an
upstream torch report is planned). Intentionally not "Fixes" — the underlying
hang remains until torch is fixed.

## Accuracy Test

Not applicable (no model-side changes).

## Benchmark & Profiling

Not applicable (one warning log on the profiler-start control path).

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
