### PR TITLE
[Perf][Ming-Omni] Add opt-in breakable Prefill CUDA Graph support

### DIFF
--- a/sglang_omni/model_runner/ming_thinker_model_runner.py
+++ b/sglang_omni/model_runner/ming_thinker_model_runner.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Ming-Omni thinker adapter for standard eager and prefill-graph execution."""
+"""Multimodal prefill injection for Ming."""
 
 from __future__ import annotations
 

--- a/sglang_omni/model_runner/ming_thinker_model_runner.py
+++ b/sglang_omni/model_runner/ming_thinker_model_runner.py
@@ -1,15 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Multimodal prefill injection for Ming."""
+"""Ming-Omni thinker adapter for standard eager and prefill-graph execution."""
 
 from __future__ import annotations
 
 from typing import Any
 
 import torch
-from sglang.srt.managers.scheduler import GenerationBatchResult
 
 from sglang_omni.model_runner.base import ModelRunner
-from sglang_omni.model_runner.sglang_execution import attn_forward_context
+from sglang_omni.model_runner.prefill_inputs import (
+    OmniPrefillInputs,
+    attach_omni_prefill_inputs,
+)
 
 
 class MingThinkerModelRunner(ModelRunner):
@@ -55,18 +57,26 @@ class MingThinkerModelRunner(ModelRunner):
             value = fallback
         return int(value) if value is not None else None
 
-    def custom_prefill_forward(
+    def before_prefill(
         self, forward_batch: Any, schedule_batch: Any, requests: list
-    ):
-        """Custom prefill for multimodal inputs."""
+    ) -> None:
+        """Prepare the current prefill window before SGLang's standard forward."""
         del requests
         if not schedule_batch.forward_mode.is_extend():
             return None
+        if (
+            getattr(forward_batch, "input_embeds", None) is not None
+            or getattr(forward_batch, "replace_embeds", None) is not None
+        ):
+            return
 
         input_embeds = self._inject_multimodal_embeds(forward_batch, schedule_batch)
         if input_embeds is None:
-            return None
-        return self._forward_with_omni_embeds(forward_batch, input_embeds)
+            input_embeds = self._embed_tokens(forward_batch.input_ids)
+        attach_omni_prefill_inputs(
+            forward_batch,
+            OmniPrefillInputs(input_embeds=input_embeds),
+        )
 
     def _inject_multimodal_embeds(
         self, forward_batch: Any, schedule_batch: Any
@@ -219,36 +229,4 @@ class MingThinkerModelRunner(ModelRunner):
             "Ming thinker multimodal embeds are shorter than placeholders for "
             f"{modality} request_id={req_id}: "
             f"needed={needed}, available={available}"
-        )
-
-    def _forward_with_omni_embeds(
-        self, forward_batch: Any, input_embeds: torch.Tensor
-    ) -> Any:
-        model_runner = self.tp_worker.model_runner
-        outer = self._outer_model
-
-        model_runner.attn_backend.init_forward_metadata(forward_batch)
-
-        positions = forward_batch.positions
-        if forward_batch.mrope_positions is not None:
-            positions = forward_batch.mrope_positions
-
-        with attn_forward_context(model_runner.attn_backend):
-            hidden_states = outer.model(
-                input_ids=None,
-                positions=positions,
-                forward_batch=forward_batch,
-                input_embeds=input_embeds,
-            )
-
-            logits_output = outer.logits_processor(
-                forward_batch.input_ids,
-                hidden_states,
-                outer.lm_head,
-                forward_batch,
-            )
-
-        return GenerationBatchResult(
-            logits_output=logits_output,
-            can_run_cuda_graph=False,
         )

--- a/sglang_omni/model_runner/ming_thinker_model_runner.py
+++ b/sglang_omni/model_runner/ming_thinker_model_runner.py
@@ -64,11 +64,16 @@ class MingThinkerModelRunner(ModelRunner):
         del requests
         if not schedule_batch.forward_mode.is_extend():
             return None
-        if (
-            getattr(forward_batch, "input_embeds", None) is not None
-            or getattr(forward_batch, "replace_embeds", None) is not None
-        ):
-            return
+        conflicts = [
+            name
+            for name in ("input_embeds", "replace_embeds")
+            if getattr(forward_batch, name, None) is not None
+        ]
+        if conflicts:
+            raise RuntimeError(
+                "Ming prefill sidecar requires upstream embedding fields to "
+                f"be unset; populated: {', '.join(conflicts)}"
+            )
 
         input_embeds = self._inject_multimodal_embeds(forward_batch, schedule_batch)
         if input_embeds is None:

--- a/sglang_omni/model_runner/ming_thinker_model_runner.py
+++ b/sglang_omni/model_runner/ming_thinker_model_runner.py
@@ -64,15 +64,13 @@ class MingThinkerModelRunner(ModelRunner):
         del requests
         if not schedule_batch.forward_mode.is_extend():
             return None
-        conflicts = [
-            name
-            for name in ("input_embeds", "replace_embeds")
-            if getattr(forward_batch, name, None) is not None
-        ]
-        if conflicts:
+        if getattr(forward_batch, "input_embeds", None) is not None:
             raise RuntimeError(
-                "Ming prefill sidecar requires upstream embedding fields to "
-                f"be unset; populated: {', '.join(conflicts)}"
+                "Ming prefill sidecar requires forward_batch.input_embeds to be unset"
+            )
+        if getattr(forward_batch, "replace_embeds", None) is not None:
+            raise RuntimeError(
+                "Ming prefill sidecar requires forward_batch.replace_embeds to be unset"
             )
 
         input_embeds = self._inject_multimodal_embeds(forward_batch, schedule_batch)

--- a/sglang_omni/models/ming_omni/bootstrap.py
+++ b/sglang_omni/models/ming_omni/bootstrap.py
@@ -24,6 +24,7 @@ def create_thinker_scheduler(
     tp_size: int = 1,
     nccl_port: int | None = None,
     enable_streaming_tts: bool = False,
+    operator_selected_prefill_backend: bool = False,
 ):
     if tp_size < 1:
         raise ValueError(f"tp_size must be >= 1, got {tp_size}")
@@ -76,7 +77,7 @@ def create_thinker_scheduler(
     if enable_prefill_input_embeds:
         attest_prefill_cuda_graphs(
             model_worker.model_runner,
-            operator_selected=True,
+            operator_selected=operator_selected_prefill_backend,
         )
 
     output_proc = SGLangOutputProcessor(

--- a/sglang_omni/models/ming_omni/bootstrap.py
+++ b/sglang_omni/models/ming_omni/bootstrap.py
@@ -74,7 +74,10 @@ def create_thinker_scheduler(
         enable_prefill_input_embeds=enable_prefill_input_embeds,
     )
     if enable_prefill_input_embeds:
-        attest_prefill_cuda_graphs(model_worker.model_runner, server_args)
+        attest_prefill_cuda_graphs(
+            model_worker.model_runner,
+            operator_selected=True,
+        )
 
     output_proc = SGLangOutputProcessor(
         capture_hidden=False,

--- a/sglang_omni/models/ming_omni/bootstrap.py
+++ b/sglang_omni/models/ming_omni/bootstrap.py
@@ -42,8 +42,13 @@ def create_thinker_scheduler(
         load_ming_tokenizer,
     )
     from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
+    from sglang_omni.scheduling.generation_batch_policy import (
+        CudaGraphBackend,
+        get_prefill_cuda_graph_backend,
+    )
     from sglang_omni.scheduling.omni_scheduler import OmniScheduler
     from sglang_omni.scheduling.sglang_backend import SGLangOutputProcessor
+    from sglang_omni.utils.cuda_graph_batch_validator import attest_prefill_cuda_graphs
 
     tokenizer = load_ming_tokenizer(model_path)
     config = load_ming_config(model_path)
@@ -51,6 +56,8 @@ def create_thinker_scheduler(
     vocab_size = getattr(llm_cfg, "vocab_size", None) or getattr(
         tokenizer, "vocab_size", 32000
     )
+    prefill_graph_backend = get_prefill_cuda_graph_backend(server_args)
+    enable_prefill_input_embeds = prefill_graph_backend == CudaGraphBackend.BREAKABLE
 
     (
         model_worker,
@@ -64,7 +71,10 @@ def create_thinker_scheduler(
         tp_rank=tp_rank,
         nccl_port=nccl_port,
         model_arch_override="BailingMoeV2ForCausalLM",
+        enable_prefill_input_embeds=enable_prefill_input_embeds,
     )
+    if enable_prefill_input_embeds:
+        attest_prefill_cuda_graphs(model_worker.model_runner, server_args)
 
     output_proc = SGLangOutputProcessor(
         capture_hidden=False,

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -303,6 +303,10 @@ def create_sglang_thinker_executor_from_config(
 
     from sglang_omni.models.ming_omni.bootstrap import create_thinker_scheduler
     from sglang_omni.models.ming_omni.registration import register_ming_hf_config
+    from sglang_omni.scheduling.generation_batch_policy import (
+        build_generation_batch_overrides,
+        validate_generation_batch_policy,
+    )
     from sglang_omni.scheduling.sglang_backend import (
         build_sglang_server_args,
         pin_resolved_device_type,
@@ -314,15 +318,23 @@ def create_sglang_thinker_executor_from_config(
     concrete_device = resolve_concrete_device(device, gpu_id)
     gpu_id = concrete_device.index or 0
 
-    overrides = dict(server_args_overrides or {})
-    overrides.setdefault("sampling_backend", "pytorch")
-    overrides.setdefault("trust_remote_code", False)
+    overrides = build_generation_batch_overrides(
+        max_running_requests=16,
+        server_args_overrides=server_args_overrides,
+        disable_cuda_graph=False,
+        sampling_backend="pytorch",
+        trust_remote_code=False,
+    )
     overrides["tp_size"] = tp_size
     pin_resolved_device_type(overrides, concrete_device.type)
     server_args = build_sglang_server_args(
         model_path,
         context_length=thinker_max_seq_len,
         **overrides,
+    )
+    validate_generation_batch_policy(
+        model_name="Ming-Omni thinker",
+        server_args=server_args,
     )
     return create_thinker_scheduler(
         server_args,

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -304,6 +304,7 @@ def create_sglang_thinker_executor_from_config(
     from sglang_omni.models.ming_omni.bootstrap import create_thinker_scheduler
     from sglang_omni.models.ming_omni.registration import register_ming_hf_config
     from sglang_omni.scheduling.generation_batch_policy import (
+        CudaGraphBackend,
         build_generation_batch_overrides,
         operator_selected_prefill_backend,
         validate_generation_batch_policy,
@@ -326,6 +327,16 @@ def create_sglang_thinker_executor_from_config(
         sampling_backend="pytorch",
         trust_remote_code=False,
     )
+    if (
+        operator_selected
+        and overrides.get("cuda_graph_backend_prefill") == CudaGraphBackend.BREAKABLE
+        and not overrides.get("cuda_graph_bs_prefill")
+    ):
+        raise ValueError(
+            "Ming-Omni thinker explicit breakable prefill CUDA graph backend "
+            "requires cuda_graph_max_bs_prefill, cuda_graph_bs_prefill, or "
+            "chunked_prefill_size"
+        )
     overrides["tp_size"] = tp_size
     pin_resolved_device_type(overrides, concrete_device.type)
     server_args = build_sglang_server_args(

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -305,6 +305,7 @@ def create_sglang_thinker_executor_from_config(
     from sglang_omni.models.ming_omni.registration import register_ming_hf_config
     from sglang_omni.scheduling.generation_batch_policy import (
         build_generation_batch_overrides,
+        operator_selected_prefill_backend,
         validate_generation_batch_policy,
     )
     from sglang_omni.scheduling.sglang_backend import (
@@ -317,7 +318,7 @@ def create_sglang_thinker_executor_from_config(
 
     concrete_device = resolve_concrete_device(device, gpu_id)
     gpu_id = concrete_device.index or 0
-
+    operator_selected = operator_selected_prefill_backend(server_args_overrides)
     overrides = build_generation_batch_overrides(
         max_running_requests=16,
         server_args_overrides=server_args_overrides,
@@ -344,6 +345,7 @@ def create_sglang_thinker_executor_from_config(
         tp_size=tp_size,
         nccl_port=nccl_port,
         enable_streaming_tts=enable_streaming_tts,
+        operator_selected_prefill_backend=operator_selected,
     )
 
 

--- a/sglang_omni/models/ming_omni/thinker.py
+++ b/sglang_omni/models/ming_omni/thinker.py
@@ -887,7 +887,9 @@ class BailingMoeV2ForCausalLM(nn.Module):
         positions: torch.Tensor,
         forward_batch: ForwardBatch,
         input_embeds: Optional[torch.Tensor] = None,
+        omni_prefill_rids: Optional[list[str] | tuple[str, ...]] = None,
     ):
+        del omni_prefill_rids
         hidden_states = self.model(input_ids, positions, forward_batch, input_embeds)
 
         return self.logits_processor(

--- a/sglang_omni/models/ming_omni/thinker.py
+++ b/sglang_omni/models/ming_omni/thinker.py
@@ -179,7 +179,11 @@ class BailingMoeV2Attention(nn.Module):
         q = torch.cat([q_rot, q_pass], dim=-1)
         k = torch.cat([k_rot, k_pass], dim=-1)
 
-        return q, k, v
+        return (
+            q.reshape(-1, self.q_size),
+            k.reshape(-1, self.kv_size),
+            v.reshape(-1, self.kv_size),
+        )
 
     def forward_core(
         self,

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 import numpy as np
+import pytest
 import torch
 
 from examples.launchers.ming_omni import (
@@ -688,8 +689,17 @@ def test_ming_text_launcher_rejects_duplicate_gpu_ids(monkeypatch) -> None:
         _launch_text_server(args)
 
 
+@pytest.mark.parametrize(
+    ("server_args_overrides", "expected_operator_selected"),
+    [
+        (None, False),
+        ({"cuda_graph_backend_prefill": "breakable"}, True),
+    ],
+)
 def test_ming_thinker_factory_registers_config_and_forwards_tp_size(
     monkeypatch,
+    server_args_overrides,
+    expected_operator_selected,
 ) -> None:
     from sglang_omni.models.ming_omni import stages
 
@@ -744,6 +754,9 @@ def test_ming_thinker_factory_registers_config_and_forwards_tp_size(
         }
 
     policy_module.build_generation_batch_overrides = build_generation_batch_overrides
+    policy_module.operator_selected_prefill_backend = lambda overrides: bool(
+        overrides and overrides.get("cuda_graph_backend_prefill") is not None
+    )
 
     def validate_generation_batch_policy(*, model_name, server_args):
         assert server_args is built_server_args
@@ -761,6 +774,7 @@ def test_ming_thinker_factory_registers_config_and_forwards_tp_size(
     def create_thinker_scheduler(server_args, **kwargs):
         assert server_args is built_server_args
         assert kwargs["tp_size"] == 2
+        assert kwargs["operator_selected_prefill_backend"] is expected_operator_selected
         call_order.append("create_scheduler")
         return object()
 
@@ -771,7 +785,11 @@ def test_ming_thinker_factory_registers_config_and_forwards_tp_size(
         bootstrap_module,
     )
 
-    stages.create_sglang_thinker_executor_from_config(model_path="dummy", tp_size=2)
+    stages.create_sglang_thinker_executor_from_config(
+        model_path="dummy",
+        tp_size=2,
+        server_args_overrides=server_args_overrides,
+    )
 
     assert call_order == ["register", "build_server_args", "create_scheduler"]
     assert captured_server_args_kwargs["tp_size"] == 2

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -695,6 +695,7 @@ def test_ming_thinker_factory_registers_hf_config_before_server_args(
 
     call_order: list[str] = []
     captured_server_args_kwargs: dict[str, object] = {}
+    validations: list[str] = []
 
     registration_module = ModuleType("sglang_omni.models.ming_omni.registration")
 
@@ -727,6 +728,33 @@ def test_ming_thinker_factory_registers_hf_config_before_server_args(
         backend_module,
     )
 
+    policy_module = ModuleType("sglang_omni.scheduling.generation_batch_policy")
+
+    def build_generation_batch_overrides(
+        *,
+        max_running_requests,
+        server_args_overrides,
+        **defaults,
+    ):
+        return {
+            **defaults,
+            **(server_args_overrides or {}),
+            "max_running_requests": max_running_requests,
+        }
+
+    policy_module.build_generation_batch_overrides = build_generation_batch_overrides
+
+    def validate_generation_batch_policy(*, model_name, server_args):
+        assert server_args.tp_size == 1
+        validations.append(model_name)
+
+    policy_module.validate_generation_batch_policy = validate_generation_batch_policy
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.scheduling.generation_batch_policy",
+        policy_module,
+    )
+
     bootstrap_module = ModuleType("sglang_omni.models.ming_omni.bootstrap")
 
     def create_thinker_scheduler(*args, **kwargs):
@@ -746,6 +774,9 @@ def test_ming_thinker_factory_registers_hf_config_before_server_args(
     assert call_order == ["register", "build_server_args", "create_scheduler"]
     assert captured_server_args_kwargs["trust_remote_code"] is False
     assert captured_server_args_kwargs["sampling_backend"] == "pytorch"
+    assert captured_server_args_kwargs["disable_cuda_graph"] is False
+    assert captured_server_args_kwargs["max_running_requests"] == 16
+    assert validations == ["Ming-Omni thinker"]
 
 
 def test_ming_arch_override_uses_composite_llm_config() -> None:

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -688,13 +688,14 @@ def test_ming_text_launcher_rejects_duplicate_gpu_ids(monkeypatch) -> None:
         _launch_text_server(args)
 
 
-def test_ming_thinker_factory_registers_hf_config_before_server_args(
+def test_ming_thinker_factory_registers_config_and_forwards_tp_size(
     monkeypatch,
 ) -> None:
     from sglang_omni.models.ming_omni import stages
 
     call_order: list[str] = []
     captured_server_args_kwargs: dict[str, object] = {}
+    built_server_args = object()
     validations: list[str] = []
 
     registration_module = ModuleType("sglang_omni.models.ming_omni.registration")
@@ -716,7 +717,7 @@ def test_ming_thinker_factory_registers_hf_config_before_server_args(
         assert call_order == ["register"]
         call_order.append("build_server_args")
         captured_server_args_kwargs.update(kwargs)
-        return SimpleNamespace(tp_size=1)
+        return built_server_args
 
     backend_module.build_sglang_server_args = build_sglang_server_args
     from sglang_omni.scheduling.sglang_backend import pin_resolved_device_type
@@ -745,7 +746,7 @@ def test_ming_thinker_factory_registers_hf_config_before_server_args(
     policy_module.build_generation_batch_overrides = build_generation_batch_overrides
 
     def validate_generation_batch_policy(*, model_name, server_args):
-        assert server_args.tp_size == 1
+        assert server_args is built_server_args
         validations.append(model_name)
 
     policy_module.validate_generation_batch_policy = validate_generation_batch_policy
@@ -757,8 +758,9 @@ def test_ming_thinker_factory_registers_hf_config_before_server_args(
 
     bootstrap_module = ModuleType("sglang_omni.models.ming_omni.bootstrap")
 
-    def create_thinker_scheduler(*args, **kwargs):
-        del args, kwargs
+    def create_thinker_scheduler(server_args, **kwargs):
+        assert server_args is built_server_args
+        assert kwargs["tp_size"] == 2
         call_order.append("create_scheduler")
         return object()
 
@@ -769,9 +771,10 @@ def test_ming_thinker_factory_registers_hf_config_before_server_args(
         bootstrap_module,
     )
 
-    stages.create_sglang_thinker_executor_from_config(model_path="dummy")
+    stages.create_sglang_thinker_executor_from_config(model_path="dummy", tp_size=2)
 
     assert call_order == ["register", "build_server_args", "create_scheduler"]
+    assert captured_server_args_kwargs["tp_size"] == 2
     assert captured_server_args_kwargs["trust_remote_code"] is False
     assert captured_server_args_kwargs["sampling_backend"] == "pytorch"
     assert captured_server_args_kwargs["disable_cuda_graph"] is False

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -690,16 +690,29 @@ def test_ming_text_launcher_rejects_duplicate_gpu_ids(monkeypatch) -> None:
 
 
 @pytest.mark.parametrize(
-    ("server_args_overrides", "expected_operator_selected"),
+    (
+        "server_args_overrides",
+        "expected_operator_selected",
+        "expected_missing_ladder_error",
+    ),
     [
-        (None, False),
-        ({"cuda_graph_backend_prefill": "breakable"}, True),
+        (None, False, False),
+        (
+            {
+                "cuda_graph_backend_prefill": "breakable",
+                "cuda_graph_bs_prefill": [128, 256],
+            },
+            True,
+            False,
+        ),
+        ({"cuda_graph_backend_prefill": "breakable"}, True, True),
     ],
 )
 def test_ming_thinker_factory_registers_config_and_forwards_tp_size(
     monkeypatch,
     server_args_overrides,
     expected_operator_selected,
+    expected_missing_ladder_error,
 ) -> None:
     from sglang_omni.models.ming_omni import stages
 
@@ -740,6 +753,7 @@ def test_ming_thinker_factory_registers_config_and_forwards_tp_size(
     )
 
     policy_module = ModuleType("sglang_omni.scheduling.generation_batch_policy")
+    policy_module.CudaGraphBackend = SimpleNamespace(BREAKABLE="breakable")
 
     def build_generation_batch_overrides(
         *,
@@ -785,10 +799,21 @@ def test_ming_thinker_factory_registers_config_and_forwards_tp_size(
         bootstrap_module,
     )
 
+    if expected_missing_ladder_error:
+        with pytest.raises(
+            ValueError,
+            match="explicit breakable.*requires.*cuda_graph_max_bs_prefill",
+        ):
+            stages.create_sglang_thinker_executor_from_config(
+                model_path="dummy",
+                tp_size=2,
+                server_args_overrides=server_args_overrides,
+            )
+        assert call_order == ["register"]
+        return
+
     stages.create_sglang_thinker_executor_from_config(
-        model_path="dummy",
-        tp_size=2,
-        server_args_overrides=server_args_overrides,
+        model_path="dummy", tp_size=2, server_args_overrides=server_args_overrides
     )
 
     assert call_order == ["register", "build_server_args", "create_scheduler"]

--- a/tests/unit_test/ming_omni/test_thinker.py
+++ b/tests/unit_test/ming_omni/test_thinker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import inspect
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -47,12 +48,11 @@ def test_ming_thinker_runner_source_injects_multimodal_embeds() -> None:
     assert "continue" in source
     assert ".clamp(" in source
     assert "self._embed_tokens.num_embeddings - 1" in source
-    assert "outer.model(" in source
-    assert "input_ids=None" in source
-    assert "input_embeds=input_embeds" in source
-    assert "outer.logits_processor(" in source
-    assert "GenerationBatchResult(" in source
-    assert "can_run_cuda_graph=False" in source
+    assert "def before_prefill(" in source
+    assert "OmniPrefillInputs(input_embeds=input_embeds)" in source
+    assert "attach_omni_prefill_inputs(" in source
+    assert "def custom_prefill_forward(" not in source
+    assert "GenerationBatchResult" not in source
     assert "req.omni_model_inputs = None" in source
     assert "req._omni_consumed = None" in source
 
@@ -76,6 +76,15 @@ def test_ming_thinker_weight_loader_uses_qwen3_helper_path() -> None:
     assert "sglang_omni.models.qwen3_omni.thinker" not in source
     assert "sglang_omni.models.qwen3_omni.components.thinker_model" in source
     assert "extract_fused_experts" in source
+
+
+def test_ming_thinker_forward_accepts_the_sidecar_kwargs() -> None:
+    pytest.importorskip("sglang")
+    from sglang_omni.models.ming_omni.thinker import BailingMoeV2ForCausalLM
+
+    params = inspect.signature(BailingMoeV2ForCausalLM.forward).parameters
+    assert "input_embeds" in params
+    assert "omni_prefill_rids" in params
 
 
 def test_ming_image_encoder_keeps_its_tp_context_for_runtime_forward() -> None:
@@ -282,22 +291,16 @@ def test_ming_config_and_stages_do_not_import_ming_runner() -> None:
 def _load_runner_with_fake_sglang(monkeypatch):
     torch = pytest.importorskip("torch")
 
-    scheduler_module = ModuleType("sglang.srt.managers.scheduler")
+    base_module = ModuleType("sglang_omni.model_runner.base")
 
-    class GenerationBatchResult:
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
+    class ModelRunner:
+        pass
 
-    scheduler_module.GenerationBatchResult = GenerationBatchResult
-    monkeypatch.setitem(sys.modules, "sglang", ModuleType("sglang"))
-    monkeypatch.setitem(sys.modules, "sglang.srt", ModuleType("sglang.srt"))
-    monkeypatch.setitem(
-        sys.modules, "sglang.srt.managers", ModuleType("sglang.srt.managers")
-    )
+    base_module.ModelRunner = ModelRunner
     monkeypatch.setitem(
         sys.modules,
-        "sglang.srt.managers.scheduler",
-        scheduler_module,
+        "sglang_omni.model_runner.base",
+        base_module,
     )
 
     module_name = "sglang_omni.model_runner.ming_thinker_model_runner"
@@ -340,9 +343,16 @@ def _fake_runner(torch_module, runner_cls, **token_ids):
 def _fake_batch(torch_module, input_ids, req):
     forward_batch = SimpleNamespace(
         input_ids=torch_module.tensor(input_ids, dtype=torch_module.long),
+        input_embeds=None,
+        replace_embeds=None,
+        batch_size=1,
+        rids=[req.rid],
         extend_seq_lens_cpu=[len(input_ids)],
     )
-    schedule_batch = SimpleNamespace(reqs=[req])
+    schedule_batch = SimpleNamespace(
+        reqs=[req],
+        forward_mode=SimpleNamespace(is_extend=lambda: True),
+    )
     return forward_batch, schedule_batch
 
 
@@ -430,48 +440,49 @@ def test_ming_runner_keeps_chunk_state_until_final_chunk(monkeypatch) -> None:
     assert model_inputs == {"image_embeds": image_embeds}
 
 
-def test_ming_thinker_forward_publishes_sglang_forward_context() -> None:
-    import torch
-    from sglang.srt.model_executor.forward_context import (
-        get_forward_context,
-        has_forward_context,
+def test_ming_runner_text_prefill_attaches_private_sidecar(monkeypatch) -> None:
+    torch, runner_cls = _load_runner_with_fake_sglang(monkeypatch)
+    from sglang_omni.model_runner.prefill_inputs import get_omni_prefill_inputs
+
+    runner = _fake_runner(torch, runner_cls)
+    req = _fake_req(None, rid="text-only")
+    forward_batch, schedule_batch = _fake_batch(torch, [1, 2], req)
+
+    result = runner.before_prefill(forward_batch, schedule_batch, [req])
+
+    sidecar = get_omni_prefill_inputs(forward_batch)
+    assert sidecar is not None
+    assert torch.equal(
+        sidecar.input_embeds, runner._embed_tokens(forward_batch.input_ids)
     )
+    assert forward_batch.input_embeds is None
+    assert forward_batch.replace_embeds is None
+    assert result is None
 
-    from sglang_omni.model_runner.ming_thinker_model_runner import (
-        MingThinkerModelRunner,
+
+def test_ming_runner_multimodal_prefill_attaches_current_request_rows(
+    monkeypatch,
+) -> None:
+    torch, runner_cls = _load_runner_with_fake_sglang(monkeypatch)
+    from sglang_omni.model_runner.prefill_inputs import get_omni_prefill_inputs
+
+    runner = _fake_runner(torch, runner_cls, image=3, audio=5)
+    image_embeds = torch.tensor([[20.0, 21.0]])
+    audio_embeds = torch.tensor([[30.0, 31.0]])
+    req = _fake_req(
+        {"image_embeds": image_embeds, "audio_embeds": audio_embeds},
+        rid="sidecar-mm",
     )
+    forward_batch, schedule_batch = _fake_batch(torch, [3, 5, 1], req)
 
-    runner = MingThinkerModelRunner.__new__(MingThinkerModelRunner)
-    attn_backend = SimpleNamespace(init_forward_metadata=lambda _batch: None)
-    runner.tp_worker = SimpleNamespace(
-        model_runner=SimpleNamespace(attn_backend=attn_backend)
-    )
+    result = runner.before_prefill(forward_batch, schedule_batch, [req])
 
-    seen = []
-
-    def model(**kwargs):
-        seen.append(get_forward_context().attn_backend)
-        return torch.ones(1, 2)
-
-    def logits_processor(input_ids, hidden_states, lm_head, forward_batch):
-        seen.append(get_forward_context().attn_backend)
-        assert input_ids is forward_batch.input_ids
-        assert lm_head == "lm_head"
-        return "logits"
-
-    runner._outer_model = SimpleNamespace(
-        model=model,
-        logits_processor=logits_processor,
-        lm_head="lm_head",
-    )
-    forward_batch = SimpleNamespace(
-        positions=torch.tensor([0]),
-        mrope_positions=None,
-        input_ids=torch.tensor([1]),
-    )
-
-    assert not has_forward_context()
-    result = runner._forward_with_omni_embeds(forward_batch, torch.ones(1, 2))
-
-    assert seen == [attn_backend, attn_backend]
-    assert result.logits_output == "logits"
+    sidecar = get_omni_prefill_inputs(forward_batch)
+    assert sidecar is not None
+    assert torch.equal(sidecar.input_embeds[0], image_embeds[0])
+    assert torch.equal(sidecar.input_embeds[1], audio_embeds[0])
+    assert forward_batch.input_embeds is None
+    assert forward_batch.replace_embeds is None
+    assert req.omni_model_inputs is None
+    assert req._omni_consumed is None
+    assert result is None

--- a/tests/unit_test/ming_omni/test_thinker.py
+++ b/tests/unit_test/ming_omni/test_thinker.py
@@ -79,7 +79,6 @@ def test_ming_thinker_weight_loader_uses_qwen3_helper_path() -> None:
 
 
 def test_ming_thinker_forward_accepts_the_sidecar_kwargs() -> None:
-    pytest.importorskip("sglang")
     from sglang_omni.models.ming_omni.thinker import BailingMoeV2ForCausalLM
 
     params = inspect.signature(BailingMoeV2ForCausalLM.forward).parameters

--- a/tests/unit_test/ming_omni/test_thinker.py
+++ b/tests/unit_test/ming_omni/test_thinker.py
@@ -491,6 +491,25 @@ def test_ming_runner_text_prefill_attaches_private_sidecar(monkeypatch) -> None:
     assert result is None
 
 
+@pytest.mark.parametrize("field", ["input_embeds", "replace_embeds"])
+def test_ming_runner_rejects_upstream_embedding_field_conflicts(
+    monkeypatch,
+    field,
+) -> None:
+    torch, runner_cls = _load_runner_with_fake_sglang(monkeypatch)
+    runner = _fake_runner(torch, runner_cls, image=3)
+    model_inputs = {"image_embeds": torch.tensor([[20.0, 21.0]])}
+    req = _fake_req(model_inputs, rid="conflicting-embeds")
+    forward_batch, schedule_batch = _fake_batch(torch, [3], req)
+    setattr(forward_batch, field, torch.zeros(1, 2))
+
+    with pytest.raises(RuntimeError, match=field):
+        runner.before_prefill(forward_batch, schedule_batch, [req])
+
+    assert req.omni_model_inputs is model_inputs
+    assert req._omni_consumed is None
+
+
 def test_ming_runner_multimodal_prefill_attaches_current_request_rows(
     monkeypatch,
 ) -> None:

--- a/tests/unit_test/ming_omni/test_thinker.py
+++ b/tests/unit_test/ming_omni/test_thinker.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 import pytest
+import torch
 
 BOOTSTRAP_PATH = Path("sglang_omni/models/ming_omni/bootstrap.py")
 RUNNER_PATH = Path("sglang_omni/model_runner/ming_thinker_model_runner.py")
@@ -84,6 +85,37 @@ def test_ming_thinker_forward_accepts_the_sidecar_kwargs() -> None:
     params = inspect.signature(BailingMoeV2ForCausalLM.forward).parameters
     assert "input_embeds" in params
     assert "omni_prefill_rids" in params
+
+
+def test_ming_attention_flattens_heads_before_radix_attention() -> None:
+    from torch import nn
+
+    from sglang_omni.models.ming_omni.thinker import BailingMoeV2Attention
+
+    qkv = torch.arange(48, dtype=torch.float32).reshape(3, 16)
+    attention = BailingMoeV2Attention.__new__(BailingMoeV2Attention)
+    nn.Module.__init__(attention)
+    attention.q_size = 8
+    attention.kv_size = 4
+    attention.num_heads_per_tp = 2
+    attention.num_kv_heads_per_tp = 1
+    attention.head_dim = 4
+    attention.rotary_dim = 2
+    attention.use_qk_norm = False
+    attention.qkv_proj = lambda hidden_states: (qkv, None)
+    attention.rotary_emb = lambda positions, q, k: (q, k)
+
+    q, k, v = attention.forward_prepare(
+        torch.empty(3, 16),
+        SimpleNamespace(positions=torch.arange(3)),
+    )
+
+    assert q.shape == (3, 8)
+    assert k.shape == (3, 4)
+    assert v.shape == (3, 4)
+    torch.testing.assert_close(q, qkv[:, :8])
+    torch.testing.assert_close(k, qkv[:, 8:12])
+    torch.testing.assert_close(v, qkv[:, 12:])
 
 
 def test_ming_image_encoder_keeps_its_tp_context_for_runtime_forward() -> None:

--- a/tests/unit_test/ming_omni/test_tp.py
+++ b/tests/unit_test/ming_omni/test_tp.py
@@ -399,12 +399,16 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
     expected_input_embeds,
     expected_attestations,
 ) -> None:
+    from unittest.mock import create_autospec
+
     from sglang.srt.arg_groups.overrides import resolution_result
     from sglang.srt.model_executor.cuda_graph_config import CudaGraphConfig
     from sglang.srt.server_args import ServerArgs
 
+    from sglang_omni.utils.cuda_graph_batch_validator import attest_prefill_cuda_graphs
+
     captured: dict[str, object] = {}
-    attestations: list[tuple[object, object]] = []
+    attestations: list[tuple[object, bool]] = []
 
     common_module = ModuleType("sglang_omni.models.ming_omni.components.common")
     common_module.load_ming_tokenizer = lambda _model_path: SimpleNamespace(
@@ -476,8 +480,13 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
     )
 
     validator_module = ModuleType("sglang_omni.utils.cuda_graph_batch_validator")
-    validator_module.attest_prefill_cuda_graphs = (
-        lambda model_runner, args: attestations.append((model_runner, args))
+
+    def fake_attest_prefill_cuda_graphs(model_runner, *, operator_selected):
+        attestations.append((model_runner, operator_selected))
+
+    validator_module.attest_prefill_cuda_graphs = create_autospec(
+        attest_prefill_cuda_graphs,
+        side_effect=fake_attest_prefill_cuda_graphs,
     )
     monkeypatch.setitem(
         sys.modules,
@@ -537,7 +546,7 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
     assert captured["model_arch_override"] == "BailingMoeV2ForCausalLM"
     assert captured["enable_prefill_input_embeds"] is expected_input_embeds
     assert attestations == (
-        [(captured["model_runner"], server_args)] if expected_attestations else []
+        [(captured["model_runner"], True)] if expected_attestations else []
     )
     assert scheduler.kwargs["server_args"] is server_args
 

--- a/tests/unit_test/ming_omni/test_tp.py
+++ b/tests/unit_test/ming_omni/test_tp.py
@@ -389,13 +389,21 @@ def test_ming_speech_allows_talker_outside_explicit_thinker_tp_gpus() -> None:
     assert config.gpu_placement["talker"] == 2
 
 
+@pytest.mark.parametrize(
+    ("prefill_backend", "expected_input_embeds", "expected_attestations"),
+    [("disabled", False, 0), ("breakable", True, 1)],
+)
 def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
     monkeypatch,
+    prefill_backend,
+    expected_input_embeds,
+    expected_attestations,
 ) -> None:
     from sglang.srt.arg_groups.overrides import resolution_result
     from sglang.srt.server_args import ServerArgs
 
     captured: dict[str, object] = {}
+    attestations: list[tuple[object, object]] = []
 
     common_module = ModuleType("sglang_omni.models.ming_omni.components.common")
     common_module.load_ming_tokenizer = lambda _model_path: SimpleNamespace(
@@ -436,16 +444,19 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
         tp_rank,
         nccl_port,
         model_arch_override,
+        enable_prefill_input_embeds,
     ):
         captured["server_args_tp_size"] = resolution_result(server_args, "tp_size")
         captured["gpu_id"] = gpu_id
         captured["tp_rank"] = tp_rank
         captured["nccl_port"] = nccl_port
         captured["model_arch_override"] = model_arch_override
+        captured["enable_prefill_input_embeds"] = enable_prefill_input_embeds
         model = object()
         model_worker = SimpleNamespace(
             model_runner=SimpleNamespace(model=model),
         )
+        captured["model_runner"] = model_worker.model_runner
         return (
             model_worker,
             "tree_cache",
@@ -461,6 +472,16 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
         sys.modules,
         "sglang_omni.scheduling.bootstrap",
         scheduling_bootstrap_module,
+    )
+
+    validator_module = ModuleType("sglang_omni.utils.cuda_graph_batch_validator")
+    validator_module.attest_prefill_cuda_graphs = (
+        lambda model_runner, args: attestations.append((model_runner, args))
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.utils.cuda_graph_batch_validator",
+        validator_module,
     )
 
     omni_scheduler_module = ModuleType("sglang_omni.scheduling.omni_scheduler")
@@ -490,7 +511,9 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
     )
 
     bootstrap = importlib.import_module("sglang_omni.models.ming_omni.bootstrap")
-    server_args = ServerArgs(model_path="dummy")
+    server_args = ServerArgs(
+        model_path="dummy", cuda_graph_backend_prefill=prefill_backend
+    )
     server_args.resolve_once()
 
     scheduler = bootstrap.create_thinker_scheduler(
@@ -508,6 +531,10 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
     assert captured["tp_rank"] == 1
     assert captured["nccl_port"] == 29500
     assert captured["model_arch_override"] == "BailingMoeV2ForCausalLM"
+    assert captured["enable_prefill_input_embeds"] is expected_input_embeds
+    assert attestations == (
+        [(captured["model_runner"], server_args)] if expected_attestations else []
+    )
     assert scheduler.kwargs["server_args"] is server_args
 
 

--- a/tests/unit_test/ming_omni/test_tp.py
+++ b/tests/unit_test/ming_omni/test_tp.py
@@ -400,6 +400,7 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
     expected_attestations,
 ) -> None:
     from sglang.srt.arg_groups.overrides import resolution_result
+    from sglang.srt.model_executor.cuda_graph_config import CudaGraphConfig
     from sglang.srt.server_args import ServerArgs
 
     captured: dict[str, object] = {}
@@ -512,7 +513,10 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
 
     bootstrap = importlib.import_module("sglang_omni.models.ming_omni.bootstrap")
     server_args = ServerArgs(
-        model_path="dummy", cuda_graph_backend_prefill=prefill_backend
+        model_path="dummy",
+        cuda_graph_config=CudaGraphConfig.from_dict(
+            {"prefill": {"backend": prefill_backend}}
+        ),
     )
     server_args.resolve_once()
 

--- a/tests/unit_test/ming_omni/test_tp.py
+++ b/tests/unit_test/ming_omni/test_tp.py
@@ -390,12 +390,22 @@ def test_ming_speech_allows_talker_outside_explicit_thinker_tp_gpus() -> None:
 
 
 @pytest.mark.parametrize(
-    ("prefill_backend", "expected_input_embeds", "expected_attestations"),
-    [("disabled", False, 0), ("breakable", True, 1)],
+    (
+        "prefill_backend",
+        "operator_selected",
+        "expected_input_embeds",
+        "expected_attestations",
+    ),
+    [
+        ("disabled", False, False, []),
+        ("breakable", False, True, [False]),
+        ("breakable", True, True, [True]),
+    ],
 )
 def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
     monkeypatch,
     prefill_backend,
+    operator_selected,
     expected_input_embeds,
     expected_attestations,
 ) -> None:
@@ -536,6 +546,7 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
         tp_rank=1,
         tp_size=2,
         nccl_port=29500,
+        operator_selected_prefill_backend=operator_selected,
     )
 
     assert captured["server_args_tp_size"] == 2
@@ -545,9 +556,9 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
     assert captured["nccl_port"] == 29500
     assert captured["model_arch_override"] == "BailingMoeV2ForCausalLM"
     assert captured["enable_prefill_input_embeds"] is expected_input_embeds
-    assert attestations == (
-        [(captured["model_runner"], True)] if expected_attestations else []
-    )
+    assert attestations == [
+        (captured["model_runner"], value) for value in expected_attestations
+    ]
     assert scheduler.kwargs["server_args"] is server_args
 
 


### PR DESCRIPTION
## Motivation

Ming-Omni thinker prefill previously composed request-specific text, image,
video, and audio embeddings in a custom eager path. That path manually invoked
the inner text model and returned `can_run_cuda_graph=False`, so it bypassed
SGLang's standard prefill dispatcher and could not use the shared breakable
Prefill CUDA Graph integration introduced in #1364.

This PR adopts the shared `OmniPrefillInputs` contract for Ming-Omni. Ming
remains responsible only for composing the current request embeddings; SGLang
remains the sole owner of graph admission, bucket selection, static-buffer
population, replay, and shape-based eager fallback.

Breakable prefill remains explicitly opt-in. This PR does not enable it by
default, prescribe a production bucket ladder, or add a Ming-specific graph
runner.

## Modifications

- Prepare the complete current prefill-window embeddings in
  `MingThinkerModelRunner.before_prefill()` for both text-only and multimodal
  requests.
- Attach those embeddings through `OmniPrefillInputs` while leaving
  upstream-owned `ForwardBatch.input_embeds` unset during graph admission.
- Remove the Ming-specific manual eager forward and delegate execution to the
  standard SGLang model runner.
- Preserve the existing multimodal placeholder replacement and chunked-prefill
  consumption behavior.
- Use the shared generation batch override builder and policy validator for
  Ming thinker configuration.
- Register the prefill `input_embeds` static slot and run shared post-capture
  attestation only when the resolved backend is `breakable`.
- Preserve whether the prefill backend was explicitly selected, so an
  operator-requested graph must materialize while an auto-selected backend may
  retain SGLang's eager fallback semantics.
- Reject an explicit backend-only `breakable` selection when no positive cap,
  bucket ladder, or chunk size can produce capture shapes.
- Fail fast if upstream `input_embeds` or `replace_embeds` fields are already
  populated instead of silently skipping Ming's sidecar attachment.
- Accept the shared `omni_prefill_rids` forward kwarg required by the sidecar
  transport contract.
- Keep the query, key, and value tensors token-major before `RadixAttention`.
  Real H200 capture exposed the previous head-shaped query layout because the
  breakable backend allocates its output from the query shape.
- Add focused tests for the sidecar, graph bootstrap, policy validation, TP
  forwarding, attestation API, and attention shape contract.

## Related Issues

Related to #1357. This PR covers the Ming-Omni adopter only and does not close
the broader tracker.

## Validation

### Revisions and environment

| Item | Value |
|---|---|
| Measured GPU base | `428b73225f808f0d93669140983e90839c9aea0e` |
| Measured GPU candidate | `654e7c5c5e09b3fc29b3c8f4ab9680cc7390e054` |
| Current main base | `c42137949ebe3e4033913af8cc13c91b2850a319` |
| Current PR head | `b79afc265613972d0e4a2e8ea593506d2ead03e3` |
| Model revision | `6a2e1dec07066d20f62a743ac7c34284e4a3932d` |
| GPU | 2 x NVIDIA H200, Thinker TP2 |
| Python | 3.12.3 |
| PyTorch | 2.13.0+cu130 |
| Transformers | 5.12.1 |
| SGLang | 0.5.19 |
| FlashInfer Python | 0.6.18 |
| Model dtype | BF16 |

The measured GPU candidate completed the full Ming unit directory with
**192 passed**. After rebasing onto the stage-device contract in #1745, the
current head completed **637 relevant tests with 1 skipped and 16 deselected**
against SGLang 0.5.19.

The commits after the measured candidate add fail-fast configuration/input
validation, preserve operator-selection intent, and adopt main's unified
device/GPU resolution. For the explicit B/C configurations below, they resolve
to the same values used during measurement and do not change model math, graph
buckets, replay, or sampling.

### Real-GPU correctness and mechanism checks

The GPU qualification used three arms:

- **A:** current main, retaining the pre-adopter Ming custom eager prefill.
- **B:** this PR with prefill CUDA Graph disabled, exercising standard eager.
- **C:** the same PR commit with breakable prefill CUDA Graph enabled.

The following checks passed on both TP ranks:

- all six configured token buckets `[64, 128, 256, 512, 1024, 2048]` captured;
- original graph admission observed `ForwardBatch.input_embeds is None`;
- every replay copied the current live embedding into the static slot with
  equal content hashes;
- text, image, real-audio conditioning, same-bucket audio A -> B -> A
  isolation, chunked audio prefill, and over-cap eager fallback completed;
- the chunked-audio request replayed a later chunk with a non-zero prefix;
- all over-cap batches used explained standard eager fallback;
- A and B returned the same targeted text/image and MMSU regression outputs;
- B and C returned the same targeted text/image/audio correctness outputs.

The first real C startup also exposed and led to the token-major attention fix
in this head. After the fix, a separate real-H200 smoke run captured all six
buckets and replayed both text and audio requests with equal live/static
embedding hashes.

One pure-text case had a shape-dependent BF16 difference when 38 live tokens
were padded to the 64-token bucket. An exact 38-token graph reproduced B with
zero error on both ranks. For the padded case:

| Metric | Result |
|---|---:|
| Top-1 token | Equal |
| Cosine similarity | 0.999804 |
| Relative L2 | 1.95% |
| Maximum absolute logit difference | 0.48828125 |

The gate accepted this only after the exact-shape proof, with pinned bounds of
cosine >= 0.999, relative L2 <= 3%, and equal argmax. All other targeted
image/audio/padded/fallback comparisons passed the original elementwise
allclose check. This is consistent with the shape-dependent BF16 behavior
reported by other breakable-prefill adopters; it is not treated as bit-exact
padded execution.

## Benchmark

The formal benchmark uses the repository's unchanged
`benchmarks.eval.benchmark_omni_mmsu.run()` and `BenchmarkRunner` timing and
metrics. Every request includes pinned real MMSU audio plus its multiple-choice
question.

Protocol:

- three fresh-server counterbalanced rounds: C -> B, B -> C, C -> B;
- concurrency `1, 8, 16, 32`;
- request flags `modalities=text` and `modalities=text+audio`;
- 96 fixed distinct MMSU IDs per cell;
- one excluded warmup cohort per cell;
- **4,608 measured requests, 4,608 successful, 0 failed**.

The deployed Ming text pipeline returned text only. The `text+audio` rows
therefore measure compatibility with that requested output flag; all such rows
record `NOT_PROVIDED_BY_TEXT_PIPELINE`. They do not establish generated-audio
fulfillment or speech quality.

### Performance results

Values are medians of the three paired fresh-server rounds. Change is C versus
B using the repository's official metrics.

| Requested flag | Concurrency | B QPS | C QPS | Throughput | Mean latency |
|---|---:|---:|---:|---:|---:|
| text | 1 | 3.071 | 4.131 | **+36.5%** | **-26.9%** |
| text | 8 | 6.860 | 8.459 | **+16.9%** | **-16.2%** |
| text | 16 | 7.454 | 8.642 | **+8.4%** | **-10.0%** |
| text | 32 | 8.053 | 8.762 | **+9.1%** | **-7.7%** |
| text+audio | 1 | 3.798 | 4.688 | **+25.2%** | **-20.1%** |
| text+audio | 8 | 7.351 | 8.522 | **+13.4%** | **-13.6%** |
| text+audio | 16 | 7.631 | 9.044 | **+15.1%** | **-15.8%** |
| text+audio | 32 | 8.352 | 8.988 | **+7.2%** | **-6.0%** |

All eight median workload comparisons improved. Across the 24 individual
round/workload pairs, 21 improved and 3 regressed; the observed throughput
range was `0.870x` to `1.407x`. This does not support a claim that every
individual run is faster.

Fresh-server ready time was 75-78 seconds for B and 78-81 seconds for C.

### Replay and fallback coverage

Counting one TP rank to avoid double-counting mirrored execution:

| Route | Original prefill batches |
|---|---:|
| Graph replay | 1,320 |
| Explained standard eager fallback | 30 |
| Unknown fallback | 0 |
| Graph batch coverage | **97.78%** |

Of the 30 eager batches, 29 exceeded the 2,048-token capture cap and one
28-token batch hit the shared 2x padding guard. All 24 C performance cells
observed real replay and permitted graph-speedup attribution.

### Bounded quality result

The same 96 IDs were intentionally repeated across rounds and request flags;
this is not 4,608 independent quality samples.

| Arm | Correct | Accuracy |
|---|---:|---:|
| B | 57 / 96 | 59.38% |
| C | 56 / 96 | 58.33% |

Three IDs had deterministic B/C greedy-text differences. Two remained wrong in
both arms; one changed from correct in B to incorrect in C. The one-sample
delta repeated across cells. The bounded set therefore does **not** establish
bit-identical output or aggregate quality parity, and it is too small to make a
broad model-quality claim. A larger quality campaign would be required before
default-enabling the optimization; this PR keeps it opt-in.

A separate current-head paired quality follow-up using all 2,000 distinct MMSU
CI samples and a denser ladder is pending a fresh GPU environment. The results
above intentionally do not assume that follow-up will establish equivalence.

## Excluded current-main paths

- **Video:** excluded because current Transformers 5.x rejects Ming's existing
  Qwen2VL `videos=` preprocessing call before the Thinker runs. This is
  independent of this PR.
- **Generated speech:** excluded because the current-main Ming Talker/Audio VAE
  path has separate known failures tracked by #1114 and draft #1132.

The evidence in this PR applies to the Ming text-output pipeline and real
text/image/audio conditioning through the Thinker. It is not full multimodal or
full-model quality acceptance.

## Checklist

- [x] Format code according to the repository conventions.
- [x] Add unit tests.
- [x] Validate real breakable graph capture, replay, static-slot isolation, and
  eager fallback.
- [x] Provide three-round throughput and latency results.
- [x] Report the bounded output/accuracy difference without claiming full
  quality parity.
- [ ] For reviewers: If you have not made any contributions to this PR and are
  only assisting with merging the main branch, please remove yourself as a
  co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as long as
the label remains. Draft PRs are skipped even if labeled.
