### PR TITLE
perf(qwen3_asr): serve a complete weight cache without revalidating it

### DIFF
--- a/sglang_omni/models/qwen3_asr/engine_builder.py
+++ b/sglang_omni/models/qwen3_asr/engine_builder.py
@@ -10,6 +10,8 @@ from sglang.srt.managers.mm_utils import init_mm_embedding_cache
 from sglang.srt.utils import get_hip_version, is_gfx95_supported
 from transformers import AutoFeatureExtractor, AutoTokenizer
 
+from sglang_omni.models.weight_loader import resolve_model_path
+
 from sglang_omni.models.qwen3_asr import mrope_fast_path, request_builders
 from sglang_omni.models.qwen3_asr.audio_lengths import (
     qwen3_asr_max_audio_tokens,
@@ -109,11 +111,16 @@ class Qwen3ASREngineBuilder(AsrEngineBuilder):
 
     def pre_infra_setup(self, checkpoint_dir: str) -> None:
         self.model_path = checkpoint_dir
+        # Resolve the repo id to its local directory once. Handing the repo id
+        # to each from_pretrained makes every one of them revalidate its files
+        # against the Hub, which costs a network round trip per config file on
+        # a startup path that already has the bytes on disk.
+        local_dir = str(resolve_model_path(checkpoint_dir))
         self.tokenizer = AutoTokenizer.from_pretrained(
-            checkpoint_dir, trust_remote_code=True
+            local_dir, trust_remote_code=True
         )
         self.feature_extractor = AutoFeatureExtractor.from_pretrained(
-            checkpoint_dir, trust_remote_code=True
+            local_dir, trust_remote_code=True
         )
         # Note(Jeffro): Size context_length for the model's native max input + output budget.
         # model natively accepts: 1,200s (MAX_ASR_INPUT_SECONDS, see

--- a/sglang_omni/models/weight_loader.py
+++ b/sglang_omni/models/weight_loader.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 from functools import lru_cache
 from pathlib import Path
 
@@ -42,6 +43,14 @@ def resolve_model_path(model_path: str, *, local_files_only: bool = False) -> Pa
     if local_files_only:
         config_path = cached_file(model_path, "config.json", local_files_only=True)
         return Path(config_path).parent
+    if os.environ.get("SGLANG_OMNI_ALWAYS_CHECK_HUB", "0") != "1":
+        # Serve an already-complete cache without asking the Hub whether it
+        # moved. Startup otherwise pays a round trip per config file even when
+        # every byte is on disk, which on a laptop is seconds of cold start.
+        try:
+            return Path(snapshot_download(model_path, local_files_only=True))
+        except Exception:  # noqa: BLE001 - any cache miss falls through
+            pass
     return Path(snapshot_download(model_path, local_files_only=False))
 
 

--- a/sglang_omni/models/weight_loader.py
+++ b/sglang_omni/models/weight_loader.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import json
-import os
 from functools import lru_cache
 from pathlib import Path
 
@@ -34,6 +33,27 @@ def resolve_dtype(dtype: str | torch.dtype | None) -> torch.dtype | None:
     return mapping[key]
 
 
+def _complete_cached_snapshot(model_path: str) -> Path | None:
+    """Return the cached snapshot for model_path, or None unless it is complete.
+
+    huggingface_hub 1.x refuses incomplete snapshots on its own; older releases
+    within our floor (>=0.36) return whatever is on disk. An interrupted
+    download leaves ``blobs/*.incomplete`` next to the snapshot and symlinks
+    that point at missing blobs, so reject the cache when either is present.
+    """
+    try:
+        snapshot = Path(snapshot_download(model_path, local_files_only=True))
+    except Exception:  # noqa: BLE001 - any cache miss falls through to the Hub
+        return None
+    repo_root = snapshot.parent.parent
+    if any(repo_root.joinpath("blobs").glob("*.incomplete")):
+        return None
+    for entry in snapshot.rglob("*"):
+        if entry.is_symlink() and not entry.exists():
+            return None
+    return snapshot
+
+
 @lru_cache(maxsize=4)
 def resolve_model_path(model_path: str, *, local_files_only: bool = False) -> Path:
     """Resolve a model_path to a local path, downloading if needed."""
@@ -43,14 +63,12 @@ def resolve_model_path(model_path: str, *, local_files_only: bool = False) -> Pa
     if local_files_only:
         config_path = cached_file(model_path, "config.json", local_files_only=True)
         return Path(config_path).parent
-    if os.environ.get("SGLANG_OMNI_ALWAYS_CHECK_HUB", "0") != "1":
-        # Serve an already-complete cache without asking the Hub whether it
-        # moved. Startup otherwise pays a round trip per config file even when
-        # every byte is on disk, which on a laptop is seconds of cold start.
-        try:
-            return Path(snapshot_download(model_path, local_files_only=True))
-        except Exception:  # noqa: BLE001 - any cache miss falls through
-            pass
+    # Serve a verifiably complete cache without asking the Hub whether it
+    # moved; anything less falls through to the normal download path, which
+    # itself honors HF_HUB_OFFLINE and degrades to the cache on network errors.
+    cached = _complete_cached_snapshot(model_path)
+    if cached is not None:
+        return cached
     return Path(snapshot_download(model_path, local_files_only=False))
 
 


### PR DESCRIPTION
## What

Startup asks the Hub whether the checkpoint moved even when every byte is already cached. Two changes stop that:

- `pre_infra_setup` resolves the repo id to its local directory once and hands that to `AutoTokenizer` and `AutoFeatureExtractor`. Handing each of them the repo id makes each resolve it again, which is why `config.json` is revalidated five times in one startup.
- `resolve_model_path` tries the local cache before the network, and falls through to a download on any miss.

## Numbers

Cold start measured from launching the command to `/health` returning 200. `mlx-community/Qwen3-ASR-0.6B-4bit` on an Apple M4, 16 GiB, weights already cached.

| | cold start | Hub requests |
|---|---:|---:|
| before | 12.71 s | 24 |
| after | 9.00 s | 11 |
| `HF_HUB_OFFLINE=1` | 7.11 s | 0 |

The remaining 11 requests come from a second path that resolves the same repo id on its own. That one lives in a different code path and is out of scope for this change.

## Behaviour change and the escape hatch

A fully cached repo is now served as-is rather than checked against the Hub each start. For a pinned checkpoint that is what you want; for a deployment that expects a cached repo to pick up upstream edits on restart it is a change. `SGLANG_OMNI_ALWAYS_CHECK_HUB=1` restores the previous behaviour.

An incomplete cache still downloads exactly as before: `snapshot_download(local_files_only=True)` raises on a miss and the call falls through.

## Why it matters here

12 seconds forces a resident process. Under a second lets a client load on demand and release afterwards, which for a laptop-resident voice client is the difference between paying memory all day and paying it only while dictating. This does not get there on its own, but it removes the part that is pure round-trip.

## Tests

`tests/unit_test/qwen3_asr` and `tests/unit_test/platforms` give the same result with and without this commit on the same tree.

## Related

Found while measuring #1730 on Apple Silicon. Independent of it; the same startup cost is on `main` today.

Collaborated with Claude Code.