### PR TITLE
perf(scheduler): block on the inbox when idle instead of polling it

### DIFF
--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -979,6 +979,13 @@ class OmniScheduler:
             # Builds are in flight on other threads; stay hot for them.
             time.sleep(0.0001)
             return
+        if self.tp_size > 1 and not self.is_entry_rank:
+            # Note (Audrey): followers receive through broadcast_pyobj, never
+            # through their inbox; blocking here would add the timeout to every
+            # TP rendezvous after idle. Keep the original poll until a
+            # group-aware idle protocol exists.
+            time.sleep(0.001)
+            return
         # Nothing is queued and nothing is building, so the next thing to happen
         # is a message arriving. Block on the inbox instead of polling it: the
         # wait ends the moment a message lands, which is never later than the

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -72,6 +72,7 @@ _ABORTED_REQUEST_ID_RETAINED = 5000
 _COMPLETED_REQUEST_ID_LIMIT = 10000
 _PENDING_STREAM_REQUEST_LIMIT = 10000
 _PENDING_STREAM_REQUEST_RETAINED = 5000
+_IDLE_WAIT_S = 0.02
 
 
 class _PendingStreamIngress:
@@ -461,12 +462,7 @@ class OmniScheduler:
         self.soft_watchdog = None
         self.recv_skipper = None
         self.idle_sleeper = None
-        # Set when _sleep_during_idle wakes on a message; _drain_local_inbox
-        # returns it before draining the rest so nothing is lost or reordered.
         self._idle_wait_message: IncomingMessage | None = None
-        self._idle_wait_s: float = float(
-            os.environ.get("SGLANG_OMNI_IDLE_WAIT_S", "0.02")
-        )
         self._init_upstream_compat_flags(server_args)
         self.grammar_manager = _NoOpGrammarManager()
         self.grammar_queue = []
@@ -976,23 +972,15 @@ class OmniScheduler:
                 self._pending_request_builds or self._pending_request_admissions
             )
         if request_admission_pending:
-            # Builds are in flight on other threads; stay hot for them.
             time.sleep(0.0001)
             return
         if self.tp_size > 1 and not self.is_entry_rank:
-            # Note (Audrey): followers receive through broadcast_pyobj, never
-            # through their inbox; blocking here would add the timeout to every
-            # TP rendezvous after idle. Keep the original poll until a
-            # group-aware idle protocol exists.
+            # TP followers receive through broadcast_pyobj, not their inbox.
+            # Keep polling so they can join the entry rank's broadcast promptly.
             time.sleep(0.001)
             return
-        # Nothing is queued and nothing is building, so the next thing to happen
-        # is a message arriving. Block on the inbox instead of polling it: the
-        # wait ends the moment a message lands, which is never later than the
-        # poll it replaces, and the loop stops waking a thousand times a second
-        # against empty queues while the engine sits idle.
         try:
-            self._idle_wait_message = self.inbox.get(timeout=self._idle_wait_s)
+            self._idle_wait_message = self.inbox.get(timeout=_IDLE_WAIT_S)
         except _queue_mod.Empty:
             self._idle_wait_message = None
 

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -975,7 +975,7 @@ class OmniScheduler:
             time.sleep(0.0001)
             return
         if self.tp_size > 1 and not self.is_entry_rank:
-            # TP followers receive through broadcast_pyobj, not their inbox.
+            # Note (jzheng17): TP followers receive through broadcast_pyobj, not their inbox.
             # Keep polling so they can join the entry rank's broadcast promptly.
             time.sleep(0.001)
             return

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -461,6 +461,12 @@ class OmniScheduler:
         self.soft_watchdog = None
         self.recv_skipper = None
         self.idle_sleeper = None
+        # Set when _sleep_during_idle wakes on a message; _drain_local_inbox
+        # returns it before draining the rest so nothing is lost or reordered.
+        self._idle_wait_message: IncomingMessage | None = None
+        self._idle_wait_s: float = float(
+            os.environ.get("SGLANG_OMNI_IDLE_WAIT_S", "0.02")
+        )
         self._init_upstream_compat_flags(server_args)
         self.grammar_manager = _NoOpGrammarManager()
         self.grammar_queue = []
@@ -850,6 +856,9 @@ class OmniScheduler:
 
     def _drain_local_inbox(self) -> list[IncomingMessage]:
         recv_msgs: list[IncomingMessage] = []
+        if self._idle_wait_message is not None:
+            recv_msgs.append(self._idle_wait_message)
+            self._idle_wait_message = None
         while True:
             try:
                 recv_msgs.append(self.inbox.get_nowait())
@@ -966,7 +975,19 @@ class OmniScheduler:
             request_admission_pending = bool(
                 self._pending_request_builds or self._pending_request_admissions
             )
-        time.sleep(0.0001 if request_admission_pending else 0.001)
+        if request_admission_pending:
+            # Builds are in flight on other threads; stay hot for them.
+            time.sleep(0.0001)
+            return
+        # Nothing is queued and nothing is building, so the next thing to happen
+        # is a message arriving. Block on the inbox instead of polling it: the
+        # wait ends the moment a message lands, which is never later than the
+        # poll it replaces, and the loop stops waking a thousand times a second
+        # against empty queues while the engine sits idle.
+        try:
+            self._idle_wait_message = self.inbox.get(timeout=self._idle_wait_s)
+        except _queue_mod.Empty:
+            self._idle_wait_message = None
 
     def _queued_admission_count(self) -> int:
         return (

--- a/tests/unit_test/pipeline/test_async_decode.py
+++ b/tests/unit_test/pipeline/test_async_decode.py
@@ -716,6 +716,7 @@ class _FakeBatch:
 
 def _new_scheduler_for_async_loop():
     s = OmniScheduler.__new__(OmniScheduler)
+    s._sleep_during_idle = lambda: None
     s._admin_lock = threading.Lock()
     s._admin_queue = queue.Queue()
     s._request_admission_lock = threading.RLock()

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -9,8 +9,9 @@ import threading
 import weakref
 from array import array
 from collections import deque
-from queue import Queue
+from queue import Empty, Queue
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import sglang.srt.managers.scheduler as sglang_scheduler_module
@@ -85,8 +86,18 @@ def _new_stage_payload(request_id: str) -> StagePayload:
     )
 
 
-def test_scheduler_idle_sleep_yields_to_pending_request_builds(monkeypatch) -> None:
+@pytest.mark.parametrize("tp_size,is_entry_rank", [(1, True), (2, True), (2, False)])
+@pytest.mark.parametrize(
+    "pending_queue", ["_pending_request_builds", "_pending_request_admissions"]
+)
+def test_scheduler_idle_sleep_yields_to_pending_request_builds(
+    monkeypatch, tp_size, is_entry_rank, pending_queue
+) -> None:
     scheduler = object.__new__(OmniScheduler)
+    scheduler.tp_size = tp_size
+    scheduler.is_entry_rank = is_entry_rank
+    scheduler.inbox = Mock()
+    scheduler.inbox.get.side_effect = Empty
     scheduler._request_admission_lock = threading.RLock()
     scheduler._pending_request_builds = {}
     scheduler._pending_request_admissions = {}
@@ -94,10 +105,23 @@ def test_scheduler_idle_sleep_yields_to_pending_request_builds(monkeypatch) -> N
     monkeypatch.setattr(omni_scheduler_module.time, "sleep", sleep_calls.append)
 
     scheduler._sleep_during_idle()
-    scheduler._pending_request_builds["req"] = object()
+    follower = tp_size > 1 and not is_entry_rank
+    if follower:
+        scheduler.inbox.get.assert_not_called()
+        assert sleep_calls == [0.001]
+    else:
+        scheduler.inbox.get.assert_called_once_with(
+            timeout=omni_scheduler_module._IDLE_WAIT_S
+        )
+        assert scheduler._idle_wait_message is None
+        assert sleep_calls == []
+
+    scheduler.inbox.get.reset_mock()
+    getattr(scheduler, pending_queue)["req"] = object()
     scheduler._sleep_during_idle()
 
-    assert sleep_calls == [0.001, 0.0001]
+    scheduler.inbox.get.assert_not_called()
+    assert sleep_calls == ([0.001, 0.0001] if follower else [0.0001])
 
 
 def test_normal_event_loop_uses_request_build_aware_idle_sleep(monkeypatch) -> None:

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -1800,7 +1800,10 @@ def test_stream_output_closes_late_stream_ingress() -> None:
     assert req.rid not in scheduler._pending_stream_ingress
 
 
-def test_completed_request_id_is_cleared_on_explicit_readmission() -> None:
+@pytest.mark.parametrize("received_during_idle", [False, True])
+def test_completed_request_id_is_cleared_on_explicit_readmission(
+    received_during_idle: bool,
+) -> None:
     scheduler = object.__new__(OmniScheduler)
     scheduler.tp_size = 1
     scheduler.is_entry_rank = True
@@ -1809,19 +1812,22 @@ def test_completed_request_id_is_cleared_on_explicit_readmission() -> None:
     scheduler._completed_request_ids = {"req-complete": None}
     scheduler._pending_stream_ingress = {}
     scheduler.inbox = Queue()
-    scheduler.inbox.put(
-        IncomingMessage(
-            request_id="req-complete",
-            type="new_request",
-            data=object(),
-        )
+    message = IncomingMessage(
+        request_id="req-complete",
+        type="new_request",
+        data=object(),
     )
+    scheduler._idle_wait_message = message if received_during_idle else None
+    if not received_during_idle:
+        scheduler.inbox.put(message)
 
     new_reqs = scheduler.recv_requests()
 
-    assert len(new_reqs) == 1
+    assert new_reqs == [message.data]
     assert "req-complete" not in scheduler._completed_request_ids
     assert scheduler.outbox.empty()
+    assert scheduler._idle_wait_message is None
+    assert scheduler.recv_requests() == []
 
 
 def test_pending_stream_requests_are_bounded(monkeypatch, caplog) -> None:


### PR DESCRIPTION
## The measurement that prompted it

Apple M4, 16 GiB, `mlx-community/Qwen3-ASR-0.6B-4bit`, 180 s with no requests in flight:

| process | CPU | RSS drift |
|---|---:|---:|
| API | 0.17% of one core | -0.8 MiB |
| ASR worker | **4.11% of one core** | -14.6 MiB |

No leak, and the cost is entirely wakeups. `OmniScheduler._sleep_during_idle` sleeps 1 ms, and the next pass drains the inbox with `get_nowait`, so the loop wakes roughly a thousand times a second and each pass runs `_process_admin_requests`, `recv_requests` and a lock acquisition against empty queues.

This does not matter for a server that is busy most of the time. It matters for a laptop, where the process sits resident and idle almost always, and 4% of a core is battery.

## The change

When nothing is queued and no request build is in flight, the next thing that can happen is a message arriving. Wait for it instead of polling for it.

`_sleep_during_idle` blocks on `self.inbox.get(timeout=...)`. An arriving inbox message wakes the wait without waiting for the timeout. `_drain_local_inbox` returns the message the wait consumed before draining the rest, so nothing is lost or reordered.

The path where builds are in flight on other threads is unchanged and still sleeps 100 µs.

`_IDLE_WAIT_S = 0.02` sets a fixed 20 ms timeout. It bounds the time between periodic checks when no inbox message arrives. Only TP=1 and the TP entry rank use the blocking wait. Followers receive through `broadcast_pyobj` and keep their existing 1 ms poll.

## Why not upstream's IdleSleeper

`sglang/srt/managers/scheduler_components/idle_sleeper.py` solves the same problem and its docstring names power consumption as the reason, but it polls ZMQ sockets. This scheduler receives on a `queue.Queue` (`omni_scheduler.py`, `self.inbox`), so it is not a drop-in. `self.idle_sleeper` is set to `None` and nothing assigns it; `init_idle_sleeper()` is never called and the upstream `sleep_on_idle` flag is not exposed on the Omni CLI.

## Verification

Apple measurements recorded on September 1 by applying the idle-wait change to the #1730 branch and running its MLX path on an M4. That measurement used #1730 for Apple support. Same server config as the baseline above, 180 s idle windows, latency p50 over 5 warmed requests.

| configuration | idle CPU (worker) | en_02s p50 |
|---|---:|---:|
| unpatched | 4.15% of one core | 136.7 ms |
| patched, 20 ms wait | **1.45%** | 135.7 ms |

The measured latency difference is within run-to-run noise. These measurements cover TP=1 on Apple hardware, not CUDA or a multi-rank deployment.

Correctness under load, patched: 60 sequential requests all returned non-empty 200s with exact transcripts, 8 requests at concurrency 4 all completed, and 6 concurrent SSE streams completed with no crosstalk and no starvation.

CPU checks of the idle/inbox methods cover FIFO delivery without duplication, wakeup on arrival, timeout handling, pending request work, follower polling, and entry-rank delivery to the broadcast call. These checks isolate the methods from CUDA imports; they do not validate a real TP collective. Full CUDA and TP execution remain unverified.

## Related

Found while measuring #1730 on Apple Silicon. Independent of it; this is `main`'s idle behaviour today.

Collaborated with Claude Code.
