### PR TITLE
[Docs] add README for .claude/skills

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,71 @@
+# Agent skills
+
+Skills are checked-in playbooks for long, error-prone maintenance jobs that we
+would otherwise re-explain to a coding agent every time. Each subdirectory here
+is one skill: a `SKILL.md` that tells the agent how to run the job, plus the
+scripts and config the job needs.
+
+Claude Code picks skills up automatically from `.claude/skills/` and exposes
+each one as a slash command named after its directory. Nothing else in
+`.claude/` is shared — `.gitignore` keeps `.claude/*` out of the repo and
+re-includes only `.claude/skills/`, so local agent settings stay local.
+
+These are maintainer tools, not part of the runtime. Nothing in this directory
+is imported by `sglang_omni/`, and no CI job runs them.
+
+## Available skills
+
+| Skill | What it does | Who can run it |
+|---|---|---|
+| [`tune-ci-thresholds`](tune-ci-thresholds/SKILL.md) | Recalibrates the numeric CI gates for ASR, TTS and Qwen3-Omni: repeats each stage until it has enough clean observations, rejects rounds poisoned by host contention, and emits an apply plan. | Maintainers on the shared H100 CI host. Needs a host profile in [`hosts/`](tune-ci-thresholds/hosts/); today only `sglang-h100-ci` exists. |
+| [`running-eval-suite`](running-eval-suite/SKILL.md) | Reruns every reference benchmark under `benchmarks/eval/` and rewrites the reference-table cells in `benchmark_*.py` for the hardware it detects. Commits locally, never pushes. | Any sglang-omni dev container with free GPUs and the `omni` venv. |
+
+Both skills expect the CI-equivalent environment (the `omni` venv,
+`HF_HOME` populated, `source .github/scripts/ci_env.sh`). Their prechecks
+verify this and stop with an actionable message rather than fixing it for you.
+Neither skill will ever kill another user's processes: busy GPUs are a hard
+stop.
+
+## Running one
+
+Type the slash command in Claude Code from the repo root:
+
+```
+/tune-ci-thresholds
+/running-eval-suite --benchmarks mmsu
+```
+
+Read the skill's `SKILL.md` first — both want a supervision terminal open
+alongside the job, and `tune-ci-thresholds` additionally wants you to read its
+`CONTRACT.md`, `AGENT-PRECHECK.md` and `OPERATIONS.md` before a calibration.
+
+You can also drive the underlying tools directly, without an agent:
+
+```bash
+python .claude/skills/tune-ci-thresholds/tune.py --model omni precheck --output-dir "$RUN"
+python .claude/skills/running-eval-suite/runner.py --model qwen3-omni precheck --output-dir "$RUN"
+```
+
+Run artifacts land in `.tune-runs/` and `.eval-runs/`, both gitignored.
+
+## Adding a skill
+
+Layout:
+
+```
+.claude/skills/<skill-name>/
+├── SKILL.md          # required: frontmatter + the playbook
+├── <tool>.py         # the actual work, runnable without an agent
+└── models/ hosts/    # config, one file per model or host
+```
+
+`SKILL.md` frontmatter needs `name` (matching the directory) and
+`description`. The description is the only thing an agent sees when deciding
+whether to reach for the skill, so lead with the trigger, then the mechanism:
+
+```yaml
+---
+name: tune-ci-thresholds
+description: Use when a CI threshold needs recalibrating after a model, kernel or host change — recalibrates ASR/TTS/Qwen3-Omni gates from repeated clean observations and emits an apply plan for review.
+---
+```


### PR DESCRIPTION
## Motivation

`.claude/skills/` has been in the repo since April and holds two skills that
several of us maintain — 71 commits have touched the directory so far. Nothing
in the repo explains what it is. The root README doesn't mention it, and there
is no index of which skills exist.

The gap that costs the most time is that neither skill says who can run it.
`tune-ci-thresholds` ships exactly one host profile (`sglang-h100-ci`) and
hardcodes paths like `/data/sglang-omni`, so anyone else who tries it gets as
far as precheck and fails. You only learn that by reading a 373-line
`SKILL.md`, or by running it.

## Modifications

Adds `.claude/skills/README.md`:

- what the directory is, and why `.gitignore` shares only `skills/` while
  keeping the rest of `.claude/` local
- a table of the two skills — what each does and who can actually run it
- how to invoke them, either as a slash command or by calling `tune.py` /
  `runner.py` directly, plus where run artifacts land
- the layout and frontmatter needed to add a skill

Docs only. Nothing under `sglang_omni/`, no CI changes, and the skills
themselves are untouched.

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests. — n/a, docs only
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation
      results as needed. — n/a, docs only
