### PR TITLE
[CI] Discard calibration rounds only on sustained cpuset intrusion

### DIFF
--- a/.claude/skills/tune-ci-thresholds/CONTRACT.md
+++ b/.claude/skills/tune-ci-thresholds/CONTRACT.md
@@ -76,6 +76,18 @@ refused.
   `run{k}.json` or the report. `run` waits for CPU and GPU recovery and
   retries the same stage without stopping the calibration. Contention
   retries do not consume the ordinary infra attempt budget.
+- **What counts as intrusion:** only the driver's live monitor decides, and
+  only on load that persists — above `_CONTENTION_FAIL_CORES` for
+  `_CONTENTION_FAIL_WINDOWS` consecutive sample windows. A discard costs the
+  attempt's whole runtime, so the evidence must outlast one window. The
+  discarded attempt records the peak, mean and window count actually
+  measured; a record that reports the threshold back as the observation is
+  not an audit trail.
+- **The session's own contention line is not evidence.** The
+  `[cpuset-contention]` summary a pytest session prints at teardown roots its
+  tree at the pytest pid, so stages whose servers double-fork and reparent to
+  init have their own CPU charged as foreign. It is recorded as
+  `session_summary_peak_cores` for triage and must never gate a round.
 
 ## Destructive observations
 

--- a/.claude/skills/tune-ci-thresholds/SKILL.md
+++ b/.claude/skills/tune-ci-thresholds/SKILL.md
@@ -273,12 +273,19 @@ never runs unpinned.
   `precheck.json` / the fingerprint. Fix the host (stop CI / other jobs) and
   re-run precheck.
 - **During `run` (must not stop the calibration):** a live foreign-load
-  monitor watches the reserved cores. If intrusion exceeds two foreign cores,
-  `tune.py` aborts **only that stage attempt**, reports the peak, wipes its
-  basetemp artifacts so contaminated metrics never enter `run{k}.json` or the
-  report, waits until the cpuset is idle **and** the owned GPUs are free, then
-  retries the same stage. Contention retries are unbounded; only ordinary
-  infra failures (OOM/crash/…) consume `_MAX_RUN_ATTEMPTS`.
+  monitor watches the reserved cores on 5-second windows. If intrusion holds
+  above two foreign cores for three consecutive windows, `tune.py` aborts
+  **only that stage attempt**, records the peak and mean it measured, wipes
+  its basetemp artifacts so contaminated metrics never enter `run{k}.json` or
+  the report, waits until the cpuset is idle **and** the owned GPUs are free,
+  then retries the same stage. A single window over the line is a scheduling
+  blip, not a lane takeover, and does not discard the attempt. Contention
+  retries are unbounded; only ordinary infra failures (OOM/crash/…) consume
+  `_MAX_RUN_ATTEMPTS`.
+- The `[cpuset-contention]` line the pytest session prints at teardown is
+  **advisory context, never a gate**. That sampler roots its process tree at
+  the pytest pid, so the servers a stage double-forks are charged as foreign
+  load; only the driver's monitor, rooted at the container init, decides.
 - **Tab C** (`watch_calibration_cpuset.sh <gpu-group>`) is the
   operator-visible supervisor for **that process's** lane — start one Tab C
   per concurrent `TUNE_GPU_INCLUDE` (e.g. `2,3` watches `16-31,80-95`).

--- a/.claude/skills/tune-ci-thresholds/test_cpuset_gates.py
+++ b/.claude/skills/tune-ci-thresholds/test_cpuset_gates.py
@@ -87,6 +87,43 @@ def test_contention_peak_from_log():
     assert tune.contention_peak_from_log(text) == 2.5
 
 
+def _sampler_with(samples):
+    ContentionSampler = tune._import_contention_sampler()
+    sampler = ContentionSampler({0})
+    sampler._samples = list(samples)
+    return sampler
+
+
+def test_contention_abort_holds_through_a_single_spike():
+    over = tune._CONTENTION_FAIL_CORES + 0.01
+    assert tune.contention_abort_reason(_sampler_with([0.1, over, 0.1])) is None
+
+
+def test_contention_abort_holds_before_enough_windows_exist():
+    over = tune._CONTENTION_FAIL_CORES + 0.5
+    short = [over] * (tune._CONTENTION_FAIL_WINDOWS - 1)
+    assert tune.contention_abort_reason(_sampler_with(short)) is None
+
+
+def test_contention_abort_fires_on_sustained_intrusion():
+    over = tune._CONTENTION_FAIL_CORES + 0.5
+    held = [0.1] + [over] * tune._CONTENTION_FAIL_WINDOWS
+    reason = tune.contention_abort_reason(_sampler_with(held))
+    assert reason is not None
+    assert "consecutive windows" in reason
+
+
+def test_contention_abort_releases_once_the_lane_recovers():
+    over = tune._CONTENTION_FAIL_CORES + 0.5
+    recovered = [over] * tune._CONTENTION_FAIL_WINDOWS + [0.1]
+    assert tune.contention_abort_reason(_sampler_with(recovered)) is None
+
+
+def test_contention_reading_describes_peak_and_mean():
+    seen = tune.ContentionReading(peak=2.4, mean=0.6, windows=78)
+    assert seen.describe() == "peak 2.40 cores, mean 0.60 over 78 windows"
+
+
 def test_classify_cpuset_contention_rc():
     assert tune._classify("", tune._PYTEST_RC_CPUSET_CONTENTION) == (
         "cpuset_contention"

--- a/.claude/skills/tune-ci-thresholds/tune.py
+++ b/.claude/skills/tune-ci-thresholds/tune.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse, ast, datetime as dt, hashlib, json, math, os, platform, re, shutil, signal
 import statistics, subprocess, sys, time, tomllib
 from pathlib import Path
+from typing import NamedTuple
 
 __version__ = "0.7.0"
 
@@ -349,6 +350,10 @@ _CPUSET_MONITOR_INTERVAL_S = 5.0
 # tests/utils/ci_cpu_contention.py; above this the round measured the
 # intruder, not the model.
 _CONTENTION_FAIL_CORES = 2.0
+# Note (wenyao): and it has to stay above it. One window over the line is a
+# scheduling blip, not a lane takeover, but it costs the whole attempt: a
+# 6-minute stage is ~78 windows, so one bad window discards the other 77.
+_CONTENTION_FAIL_WINDOWS = 3
 # Watchdog return when the live cpuset monitor aborts pytest mid-round.
 _PYTEST_RC_CPUSET_CONTENTION = -2
 
@@ -3499,7 +3504,7 @@ def _run_shared(test_path, stage_keys, all_stages, out, k, py, total, gpus_neede
                 stderr=subprocess.STDOUT,
                 start_new_session=True,
             )
-            pytest_rc = _wait_pytest_with_watchdog(
+            pytest_rc, monitor = _wait_pytest_with_watchdog(
                 pytest_proc, log, label, cpuset=cpuset
             )
         _cleanup_after_pytest(test_path, pytest_proc.pid, basetemp)
@@ -3508,26 +3513,28 @@ def _run_shared(test_path, stage_keys, all_stages, out, k, py, total, gpus_neede
         )
         dur = time.monotonic() - t0
         text = log.read_text(errors="replace") if log.exists() else ""
-        contention_peak = contention_peak_from_log(text)
-        is_contention = (
-            pytest_rc == _PYTEST_RC_CPUSET_CONTENTION
-            or (contention_peak is not None
-                and contention_peak > _CONTENTION_FAIL_CORES)
-        )
-        if is_contention:
-            peak = contention_peak
-            if peak is None and pytest_rc == _PYTEST_RC_CPUSET_CONTENTION:
-                peak = _CONTENTION_FAIL_CORES
+        # Note (wenyao): the session's own [cpuset-contention] line is
+        # recorded, never gated on. That sampler roots its tree at the pytest
+        # pid, so the servers this run double-forks are counted as foreign —
+        # the same misattribution root_pid=1 exists to avoid below. It read
+        # 2.2-3.0 foreign cores on rounds that exited 0 while the live
+        # monitor, watching the same lane, never passed 0.96.
+        session_peak = contention_peak_from_log(text)
+        if pytest_rc == _PYTEST_RC_CPUSET_CONTENTION:
             reason = (
-                f"cpuset_contention (peak {peak:.2f} cores)"
-                if peak is not None
+                f"cpuset_contention ({monitor.describe()})"
+                if monitor is not None
                 else "cpuset_contention"
             )
             attempt_history.append(dict(
                 attempt=attempts, status="discarded", reason=reason,
                 duration_s=round(dur, 2), pytest_rc=pytest_rc,
                 gpu_indices=list(picked), cpuset=cpuset,
-                cpuset_busy_prelaunch=cpuset_busy))
+                cpuset_busy_prelaunch=cpuset_busy,
+                foreign_peak_cores=monitor.peak if monitor else None,
+                foreign_mean_cores=monitor.mean if monitor else None,
+                foreign_windows=monitor.windows if monitor else None,
+                session_summary_peak_cores=session_peak))
             print(f"{label} {reason} — aborting this stage attempt, "
                   f"discarding its artifacts, waiting for CPU+GPU recovery, "
                   f"then retrying (calibration continues)")
@@ -3555,7 +3562,10 @@ def _run_shared(test_path, stage_keys, all_stages, out, k, py, total, gpus_neede
                 attempt=attempts, status=status, reason=reason,
                 duration_s=round(dur, 2), pytest_rc=pytest_rc,
                 gpu_indices=list(picked), cpuset=cpuset,
-                cpuset_busy_prelaunch=cpuset_busy))
+                cpuset_busy_prelaunch=cpuset_busy,
+                foreign_peak_cores=monitor.peak if monitor else None,
+                foreign_mean_cores=monitor.mean if monitor else None,
+                session_summary_peak_cores=session_peak))
             break
         reason = _classify(text, pytest_rc)
         status = "failed"
@@ -3563,7 +3573,10 @@ def _run_shared(test_path, stage_keys, all_stages, out, k, py, total, gpus_neede
             attempt=attempts, status=status, reason=reason,
             duration_s=round(dur, 2), pytest_rc=pytest_rc,
             gpu_indices=list(picked), cpuset=cpuset,
-            cpuset_busy_prelaunch=cpuset_busy))
+            cpuset_busy_prelaunch=cpuset_busy,
+            foreign_peak_cores=monitor.peak if monitor else None,
+            foreign_mean_cores=monitor.mean if monitor else None,
+            session_summary_peak_cores=session_peak))
         retryable = (
             any(s in reason for s in RETRY_SIGS)
             or reason.startswith("crashed")
@@ -3722,18 +3735,46 @@ def _log_crash_detected(text: str) -> str | None:
     return None
 
 
+class ContentionReading(NamedTuple):
+    """What the live monitor saw over one pytest attempt."""
+
+    peak: float
+    mean: float
+    windows: int
+
+    def describe(self) -> str:
+        return (f"peak {self.peak:.2f} cores, mean {self.mean:.2f} over "
+                f"{self.windows} windows")
+
+
+def contention_abort_reason(sampler) -> str | None:
+    """Why the live monitor should discard this attempt, or None to go on.
+
+    A discard costs the attempt's whole runtime and buys nothing, so the
+    evidence has to outlast a single sample window.
+    """
+    if not sampler.sustained_foreign_cores(
+            _CONTENTION_FAIL_WINDOWS, _CONTENTION_FAIL_CORES):
+        return None
+    held_s = _CPUSET_MONITOR_INTERVAL_S * _CONTENTION_FAIL_WINDOWS
+    return (f"foreign load held above {_CONTENTION_FAIL_CORES:.1f} cores for "
+            f"{_CONTENTION_FAIL_WINDOWS} consecutive windows ({held_s:.0f}s)")
+
+
 def _wait_pytest_with_watchdog(
     pytest_proc,
     log_path: Path,
     label: str,
     cpuset: str | None = None,
-) -> int:
+) -> tuple[int, ContentionReading | None]:
     """Poll pytest; abort early on crash signatures or live cpuset intrusion.
 
     When ``cpuset`` is set, a foreign-load sampler watches the reserved cores.
-    Crossing ``_CONTENTION_FAIL_CORES`` kills only this pytest session so the
-    caller can discard the attempt and retry after lane recovery — it does
-    not stop the overall calibration.
+    Sustained load above ``_CONTENTION_FAIL_CORES`` kills only this pytest
+    session so the caller can discard the attempt and retry after lane
+    recovery — it does not stop the overall calibration. The reading comes
+    back either way so a discard records what was measured rather than the
+    threshold that condemned it.
     """
     sampler = None
     poll_s = _PYTEST_POLL_S
@@ -3754,6 +3795,16 @@ def _wait_pytest_with_watchdog(
         poll_s = min(_PYTEST_POLL_S, _CPUSET_MONITOR_INTERVAL_S)
     last_size = 0
     stall_s = 0
+
+    def reading() -> ContentionReading | None:
+        if sampler is None:
+            return None
+        return ContentionReading(
+            peak=sampler.peak_foreign_cores(),
+            mean=sampler.mean_foreign_cores(),
+            windows=sampler.window_count(),
+        )
+
     try:
         while True:
             rc = pytest_proc.poll()
@@ -3764,19 +3815,20 @@ def _wait_pytest_with_watchdog(
                 stall_s = 0 if size > last_size else stall_s + poll_s
                 last_size = size
             if rc is not None:
-                return rc
-            if (sampler is not None
-                    and sampler.peak_foreign_cores() > _CONTENTION_FAIL_CORES):
-                peak = sampler.peak_foreign_cores()
-                print(f"{label} live cpuset monitor: foreign peak "
-                      f"{peak:.2f} cores on {cpuset} — aborting this stage "
-                      f"attempt (will discard + retry after recovery)")
+                return rc, reading()
+            intrusion = (contention_abort_reason(sampler)
+                         if sampler is not None else None)
+            if intrusion is not None:
+                seen = reading()
+                print(f"{label} live cpuset monitor: {intrusion} on {cpuset} "
+                      f"({seen.describe()}) — aborting this stage attempt "
+                      f"(will discard + retry after recovery)")
                 try:
                     os.killpg(pytest_proc.pid, signal.SIGKILL)
                 except ProcessLookupError:
                     pytest_proc.kill()
                 pytest_proc.wait(timeout=30)
-                return _PYTEST_RC_CPUSET_CONTENTION
+                return _PYTEST_RC_CPUSET_CONTENTION, seen
             crash = _log_crash_detected(text[-8000:] if text else "")
             if crash:
                 print(f"{label} crash detected in log ({crash}) — stopping pytest")
@@ -3785,7 +3837,7 @@ def _wait_pytest_with_watchdog(
                 except ProcessLookupError:
                     pytest_proc.kill()
                 pytest_proc.wait(timeout=30)
-                return -1
+                return -1, reading()
             mem = _gpu_memory_by_index()
             peak_note = ""
             if sampler is not None:

--- a/tests/unit_test/ci/test_cpu_contention.py
+++ b/tests/unit_test/ci/test_cpu_contention.py
@@ -74,6 +74,40 @@ def test_sampler_smoke_produces_summary():
     assert "[cpuset-contention]" in sampler.summary()
 
 
+def _sampler_with(samples: list[float]) -> ContentionSampler:
+    sampler = ContentionSampler({0})
+    sampler._samples = list(samples)
+    return sampler
+
+
+def test_summary_statistics_over_recorded_windows():
+    sampler = _sampler_with([0.0, 1.0, 2.0])
+    assert sampler.window_count() == 3
+    assert sampler.mean_foreign_cores() == pytest.approx(1.0)
+    assert sampler.peak_foreign_cores() == 2.0
+
+
+def test_no_windows_reports_zero_rather_than_raising():
+    sampler = _sampler_with([])
+    assert sampler.window_count() == 0
+    assert sampler.mean_foreign_cores() == 0.0
+    assert sampler.peak_foreign_cores() == 0.0
+
+
+@pytest.mark.parametrize(
+    "samples, sustained",
+    [
+        pytest.param([0.1, 2.5, 0.1, 0.1], False, id="lone-spike"),
+        pytest.param([2.5, 2.5], False, id="too-few-windows-to-judge"),
+        pytest.param([0.1, 2.1, 2.2, 2.3], True, id="three-crossings-in-a-row"),
+        pytest.param([2.1, 2.2, 2.3, 0.1], False, id="lane-since-recovered"),
+        pytest.param([2.0, 2.0, 2.0], False, id="exactly-at-the-threshold"),
+    ],
+)
+def test_sustained_foreign_cores_reads_the_tail(samples, sustained):
+    assert _sampler_with(samples).sustained_foreign_cores(3, 2.0) is sustained
+
+
 def _spin(core: int) -> subprocess.Popen:
     return subprocess.Popen(
         [

--- a/tests/utils/ci_cpu_contention.py
+++ b/tests/utils/ci_cpu_contention.py
@@ -157,6 +157,27 @@ class ContentionSampler:
     def peak_foreign_cores(self) -> float:
         return max(self._samples, default=0.0)
 
+    def mean_foreign_cores(self) -> float:
+        if not self._samples:
+            return 0.0
+        return sum(self._samples) / len(self._samples)
+
+    def window_count(self) -> int:
+        return len(self._samples)
+
+    def sustained_foreign_cores(self, windows: int, cores: float) -> bool:
+        """Whether the last ``windows`` samples all exceed ``cores``.
+
+        A caller that acts on intrusion needs to know the lane is taken, not
+        that one window happened to land high: sampling is seconds and a
+        gated stage is minutes, so a single crossing is thinner evidence than
+        the decision it drives. Reading the tail rather than the whole series
+        lets a caller poll this while the session is still running.
+        """
+        if windows <= 0 or len(self._samples) < windows:
+            return False
+        return all(sample > cores for sample in self._samples[-windows:])
+
     def _loop(self) -> None:
         prev_busy = cpuset_busy_ticks(self._cpuset)
         prev = _snapshot()
@@ -180,8 +201,8 @@ class ContentionSampler:
                 f"[cpuset-contention] cpuset={spec} no completed sample "
                 f"windows (errors={self._errors})"
             )
-        mean = sum(self._samples) / len(self._samples)
-        peak = max(self._samples)
+        mean = self.mean_foreign_cores()
+        peak = self.peak_foreign_cores()
         lines = [
             f"[cpuset-contention] cpuset={spec} windows={len(self._samples)} "
             f"foreign-cores mean={mean:.2f} max={peak:.2f} errors={self._errors}"


### PR DESCRIPTION
## What this fixes

The threshold-calibration driver throws away stage attempts that were never contended. In the full ASR + TTS + Qwen3-Omni recalibration on 2026-08-29 it discarded 74 attempts and about two hours of GPU time on the two lanes I have records for, and every one of those discards was charged to CPU contention.

There are two separate defects behind that.

### 1. The driver gates on a number that measures its own work

At teardown a pytest session prints an advisory line like:

```
[cpuset-contention] cpuset=2,3,... windows=5 foreign-cores mean=0.61 max=2.39
```

`tune.py` parsed the `max=` out of that line and discarded the round if it exceeded two cores. But that sampler roots its process tree at the pytest pid, and the stage supervisors double-fork at launch and reparent to init. So the servers the round starts itself fall outside the tree and get charged as foreign load.

This is the exact misattribution the live monitor already avoids. `_wait_pytest_with_watchdog` passes `root_pid=1` for this reason, and the comment there says so. The post-teardown path never got the same treatment.

The evidence is direct. In the ASR run, twelve rounds were discarded like this. For every one of them:

- pytest exited 0, so the round completed and produced full metrics;
- `cpuset_busy_prelaunch` was 0.00 to 0.01, so the lane was idle when the round launched;
- the driver's own monitor, watching the same cores at the same time but rooted at init, never once passed 0.96 foreign cores across the entire run;
- the session line reported 2.23 to 3.02.

Two samplers, one lane, one moment, and a threefold disagreement. The one that says the lane was busy is the one counting our own servers.

### 2. One sample window can discard a six-minute attempt

The live monitor samples every five seconds and aborted on the running maximum, with no requirement that the load persist. A typical ASR attempt is about 78 windows, so a single window over the line discarded the other 77.

I cannot say how marginal those aborts actually were, because of a third problem: when the monitor kills pytest, the session never prints its summary line, so `contention_peak_from_log` returns nothing and the driver falls back to writing `_CONTENTION_FAIL_CORES` into the record. All 60 live aborts in these runs are recorded as "peak 2.00 cores". That is the threshold written back as if it were the measurement. There is no way to tell a barely-over blip from a real takeover after the fact.

## What changes

- The session's `[cpuset-contention]` line no longer gates anything. It is kept in the attempt record as `session_summary_peak_cores` for triage.
- The live monitor aborts only when foreign load stays above two cores for three consecutive five-second windows. A lone spike no longer costs the attempt.
- Discarded attempts record what the monitor actually measured — peak, mean, and window count. Successful and failed attempts carry the peak and mean too, so a slow round can be checked against the lane conditions it ran under instead of guessing.
- `ContentionSampler` grows `mean_foreign_cores()`, `window_count()` and `sustained_foreign_cores()`. `summary()` now reuses the first two.

## What does not change

CI behaviour is untouched. `tests/test_model/conftest.py` only ever calls `summary()`, and that fixture has always been advisory — it prints the line and never fails a job. The new methods are additive.

The thresholds in #1811 are also unaffected. Discarded rounds were discarded under either rule; the rounds that were kept and aggregated are the same rounds.

One tradeoff worth naming. Rounds the session sampler flagged will now be kept. If such a round really was slow, worst-of-N takes the slow value, which is the conservative direction, and destructive rejection is the mechanism that catches a single broken round. The old behaviour was safe in that direction but paid for it by discarding good rounds at a rate of roughly one in three.

## Testing

`test_cpuset_gates.py` and `tests/unit_test/ci/test_cpu_contention.py` pass, 23 passed and 2 skipped (the two skips need Linux procfs). New cases cover a lone spike, a session too short to judge, three consecutive crossings, a lane that recovered after three crossings, and strictness at the threshold itself.

`test_destructive_rejection.py` stubs `_run_shared`, so it does not exercise this path. It also hardcodes a checkout path and only runs on the calibration host.
