### PR TITLE
[CI] Recalibrate Qwen3-Omni VideoMME talker thresholds

### DIFF
--- a/.claude/skills/tune-ci-thresholds/models/omni/stages.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/omni/stages.yaml
@@ -7,7 +7,7 @@ mmmu_accuracy:
   context_vars:
     - CONCURRENCY
   test_file_sha256: ea3cb68392c8c11f12e580757bddb330efe94dc4cb38bc7be0477ca9aa9cb9c8
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 50
   sample_counts:
     total:
@@ -35,7 +35,7 @@ mmmu_speed:
   context_vars:
     - CONCURRENCY
   test_file_sha256: ea3cb68392c8c11f12e580757bddb330efe94dc4cb38bc7be0477ca9aa9cb9c8
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 50
   sample_counts:
     total:
@@ -85,7 +85,7 @@ mmmu_talker_accuracy:
     - MAX_TOKENS
     - CONCURRENCY
   test_file_sha256: 006029bf939c115ed07f651da91f2023be76be7deb64d49f31a124e01b0df492
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 20
   sample_counts:
     total:
@@ -115,7 +115,7 @@ mmmu_talker_wer:
     - MAX_TOKENS
     - CONCURRENCY
   test_file_sha256: 006029bf939c115ed07f651da91f2023be76be7deb64d49f31a124e01b0df492
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 20
   sample_counts:
     total:
@@ -155,7 +155,7 @@ mmmu_talker_speed:
     - MAX_TOKENS
     - CONCURRENCY
   test_file_sha256: 006029bf939c115ed07f651da91f2023be76be7deb64d49f31a124e01b0df492
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 20
   sample_counts:
     total:
@@ -213,7 +213,7 @@ mmsu_accuracy:
   context_vars:
     - CONCURRENCY
   test_file_sha256: 821d40310fc05c9b173593b8563e03396881a07c96d071edbd6cc55fbdc31bf2
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 2000
   sample_counts:
     total:
@@ -241,7 +241,7 @@ mmsu_speed:
   context_vars:
     - CONCURRENCY
   test_file_sha256: 821d40310fc05c9b173593b8563e03396881a07c96d071edbd6cc55fbdc31bf2
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 2000
   sample_counts:
     total:
@@ -291,7 +291,7 @@ mmsu_talker_accuracy:
     - MAX_TOKENS
     - CONCURRENCY
   test_file_sha256: 28072e9834d1b44d06febd12f6fec1a8a2e5e93a926524bdac706c77d03babb6
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 40
   sample_counts:
     total:
@@ -321,7 +321,7 @@ mmsu_talker_wer:
     - MAX_TOKENS
     - CONCURRENCY
   test_file_sha256: 28072e9834d1b44d06febd12f6fec1a8a2e5e93a926524bdac706c77d03babb6
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 40
   sample_counts:
     total:
@@ -361,7 +361,7 @@ mmsu_talker_speed:
     - MAX_TOKENS
     - CONCURRENCY
   test_file_sha256: 28072e9834d1b44d06febd12f6fec1a8a2e5e93a926524bdac706c77d03babb6
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 40
   sample_counts:
     total:
@@ -420,7 +420,7 @@ tts_wer:
     - MAX_SAMPLES
     - CONCURRENCY
   test_file_sha256: 7b912064a14fb908f232f11a687f893abd84d72c6fb5c65a09b8da5d6a640bfa
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 50
   sample_counts:
     total:
@@ -459,7 +459,7 @@ tts_utmos:
     - MAX_SAMPLES
     - CONCURRENCY
   test_file_sha256: 7b912064a14fb908f232f11a687f893abd84d72c6fb5c65a09b8da5d6a640bfa
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 50
   sample_counts:
     total:
@@ -488,7 +488,7 @@ tts_speed:
     - MAX_SAMPLES
     - CONCURRENCY
   test_file_sha256: 7b912064a14fb908f232f11a687f893abd84d72c6fb5c65a09b8da5d6a640bfa
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 50
   sample_counts:
     total:
@@ -547,7 +547,7 @@ videoamme_accuracy:
     - MAX_SAMPLES
     - CONCURRENCY
   test_file_sha256: fee4634d78df83dbdbc76cc69fa8e83f19672fb43b34938527abb3514f1fe582
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 50
   sample_counts:
     total:
@@ -576,7 +576,7 @@ videoamme_speed:
     - MAX_SAMPLES
     - CONCURRENCY
   test_file_sha256: fee4634d78df83dbdbc76cc69fa8e83f19672fb43b34938527abb3514f1fe582
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 50
   sample_counts:
     total:
@@ -627,7 +627,7 @@ videoamme_talker_tp2_accuracy:
     - MAX_TOKENS
     - CONCURRENCY
   test_file_sha256: 96e00da56b5c5d57c85596fe2d0e907f11d9ffdfb5b94129f57f6edd8149f59a
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 10
   sample_counts:
     total:
@@ -658,7 +658,7 @@ videoamme_talker_tp2_wer:
     - MAX_TOKENS
     - CONCURRENCY
   test_file_sha256: 96e00da56b5c5d57c85596fe2d0e907f11d9ffdfb5b94129f57f6edd8149f59a
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 10
   sample_counts:
     total:
@@ -699,7 +699,7 @@ videoamme_talker_tp2_speed:
     - MAX_TOKENS
     - CONCURRENCY
   test_file_sha256: 96e00da56b5c5d57c85596fe2d0e907f11d9ffdfb5b94129f57f6edd8149f59a
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 10
   sample_counts:
     total:
@@ -758,7 +758,7 @@ videomme_accuracy:
     - MAX_SAMPLES
     - CONCURRENCY
   test_file_sha256: bede62255e5eae3a360d41129c09062fdf0cda5557aeb017ad60381f0230c51a
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 50
   sample_counts:
     total:
@@ -787,7 +787,7 @@ videomme_speed:
     - MAX_SAMPLES
     - CONCURRENCY
   test_file_sha256: bede62255e5eae3a360d41129c09062fdf0cda5557aeb017ad60381f0230c51a
-  last_discovered_at: 2026-08-29T19:57:22Z
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 50
   sample_counts:
     total:
@@ -836,8 +836,8 @@ videomme_talker_accuracy:
     - MAX_SAMPLES
     - MAX_TOKENS
     - CONCURRENCY
-  test_file_sha256: 57607b64e45a7f9aa6967ef6c0124501b6a97776010b3181ec325ec373a41b58
-  last_discovered_at: 2026-08-29T19:57:22Z
+  test_file_sha256: fb3d2cc041f865c8d3228b7185eeaddaff34df914897fda2757eb4025476b5c3
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 20
   sample_counts:
     total:
@@ -866,8 +866,8 @@ videomme_talker_wer:
     - MAX_SAMPLES
     - MAX_TOKENS
     - CONCURRENCY
-  test_file_sha256: 57607b64e45a7f9aa6967ef6c0124501b6a97776010b3181ec325ec373a41b58
-  last_discovered_at: 2026-08-29T19:57:22Z
+  test_file_sha256: fb3d2cc041f865c8d3228b7185eeaddaff34df914897fda2757eb4025476b5c3
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 20
   sample_counts:
     total:
@@ -906,8 +906,8 @@ videomme_talker_speed:
     - MAX_SAMPLES
     - MAX_TOKENS
     - CONCURRENCY
-  test_file_sha256: 57607b64e45a7f9aa6967ef6c0124501b6a97776010b3181ec325ec373a41b58
-  last_discovered_at: 2026-08-29T19:57:22Z
+  test_file_sha256: fb3d2cc041f865c8d3228b7185eeaddaff34df914897fda2757eb4025476b5c3
+  last_discovered_at: 2026-08-30T08:13:29Z
   expected_samples: 20
   sample_counts:
     total:

--- a/tests/test_model/test_qwen3_omni_videomme_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_videomme_talker_ci.py
@@ -62,7 +62,7 @@ SHORT_ANSWER_PROMPT = (
 )
 
 VIDEOMME_TALKER_THINKER_TEXT_MIN_ACCURACY = 0.6
-VIDEOMME_TALKER_WER_BELOW_50_CORPUS_MAX = 0.0195
+VIDEOMME_TALKER_WER_BELOW_50_CORPUS_MAX = 0.0483
 VIDEOMME_TALKER_WER_BELOW_50_CORPUS_THRESHOLD = apply_wer_slack(
     VIDEOMME_TALKER_WER_BELOW_50_CORPUS_MAX
 )
@@ -70,10 +70,10 @@ VIDEOMME_TALKER_N_ABOVE_50_MAX = 1.0
 
 _VIDEOMME_TALKER_AUDIO_P95 = {
     16: {
-        "throughput_qps": 0.991,
-        "output_tok_per_req_s": 4.0,
-        "latency_mean_s": 10.98,
-        "rtf_mean": 1.1553,
+        "throughput_qps": 1.017,
+        "output_tok_per_req_s": 4.3,
+        "latency_mean_s": 10.638,
+        "rtf_mean": 0.9035,
     },
 }
 VIDEOMME_TALKER_THRESHOLDS = apply_slack(_VIDEOMME_TALKER_AUDIO_P95)


### PR DESCRIPTION
## Why

Stage 8 (`stage-8-videomme-talker`) has been failing since #1811 merged. A typical failure: corpus WER over samples with WER <= 50% comes in at 0.0369 against a threshold of 0.0244 (reference 0.0195 x 1.25 slack).

The stage-8 numbers in #1811 were measured before recent changes on main, and the two distributions barely overlap. Nine CI attempts across five branches this week scored corpus WER between 0.0164 and 0.0570. The five calibration rounds behind #1811 scored 0.0086 to 0.0194 — only CI's single best value falls inside that range. Speed moved the opposite way: CI runs are faster (rtf 0.856–0.956 versus 1.079–1.155 in the old calibration). Faster but worse WER on both sides points at a code shift between the two trees, not noise. The most likely candidate is the benchmark warmup change in #1800, which landed after the previous calibration was measured; that attribution is not verified.

Either way, the old references describe a tree CI no longer runs. This PR recalibrates the three stage-8 tune stages on a tree that includes #1800.

## What was measured

Five clean observations per stage, strict worst-of-N, in the same pinned H100 calibration environment as #1811 (lane cpuset, pinned image digest). Run directory `20260830T065128Z_omni_stage8_r5`, strict-audit green on all three stages. No round was rejected as destructive.

| reference | old | new | direction | per-round values |
|---|---|---|---|---|
| `VIDEOMME_TALKER_WER_BELOW_50_CORPUS_MAX` | 0.0195 | 0.0483 | loosens | 0.0483 / 0.0263 / 0.0142 / 0.0341 / 0.0473 |
| `throughput_qps` | 0.991 | 1.017 | tightens | 1.017–1.072 |
| `output_tok_per_req_s` | 4.0 | 4.3 | tightens | 4.3–4.6 |
| `latency_mean_s` | 10.98 | 10.638 | tightens | 10.08–10.638 |
| `rtf_mean` | 1.1553 | 0.9035 | tightens | 0.878–0.9035 |

The WER loosen is large, so here is the check that matters: after slack, every gate covers every value CI actually produced this week. WER gate becomes 0.0604 against a CI worst of 0.0570. Latency gate becomes 12.0 against 10.72. RTF gate becomes 1.02 against 0.956. The three speed gates tighten because the current tree is genuinely faster.

The WER spread within the calibration itself (0.0142 to 0.0483) is real variance, not a broken round: this stage scores ASR of the talker's audio against the thinker's own generated text, so both sides of the ratio move run to run. The speed metrics of the same five rounds sit within about 5% of each other, which is the signature of a stable machine and a noisy metric. Worst-of-N is the mechanism that absorbs this.

## What was deliberately not changed

- `VIDEOMME_TALKER_N_ABOVE_50_MAX` stays at 1.0. All ten calibration rounds across both calibrations produced 0, but writing 0 would fail CI on a single bad sample with no headroom, for no gain.
- `VIDEOMME_TALKER_THINKER_TEXT_MIN_ACCURACY` stays at 0.6 (all five rounds scored exactly 0.6).

One note on tree drift: the calibration tree is equivalent to main at the #1811 merge. #1611 landed on main since; it only makes the talker faster, which the tightened speed gates tolerate by direction.

## Validation

A post-apply validation round (full stage-8 pytest under the applied thresholds) is queued behind CI traffic on the calibration host; I will post the result here when it lands.
