### PR TITLE
[Router]: Add bounded operations and observability

### DIFF
--- a/docs/basic_usage/omni_router.md
+++ b/docs/basic_usage/omni_router.md
@@ -299,15 +299,17 @@ compatible. Current worker load does not change readiness.
 
 `/v1/models` returns a sorted, deduplicated inventory built from worker defaults
 and correlated profile model IDs. `/metrics` exposes Prometheus lifecycle,
-readiness, health, admission, and worker-load gauges. `/diagnostics` returns
-bounded deterministic JSON for lifecycle, readiness, admission, and configured
-workers.
+readiness, health, admission, worker-load, listener, buffered-byte,
+classification, and WebSocket-session gauges. `/diagnostics` returns bounded
+deterministic JSON for the same router-local state and marks the configured
+voice owner.
 
 Operations responses snapshot router-local state and never contact workers.
 Admission values come from the semaphores that enforce router limits. Worker
 load comes from the same counters used by `least_requests`. Metric labels use
 fixed vocabularies instead of worker IDs, model IDs, request IDs, paths, or
-client input.
+client input. Listener usage includes the slot reserved by the pending accept;
+registered WebSocket sessions represent callbacks retained for shutdown.
 
 Structured logging covers lifecycle events, health transitions, and exceptional
 conditions. `logging.filter` accepts a tracing filter expression, and

--- a/docs/basic_usage/omni_router.md
+++ b/docs/basic_usage/omni_router.md
@@ -302,7 +302,10 @@ and correlated profile model IDs. `/metrics` exposes Prometheus lifecycle,
 readiness, health, admission, worker-load, listener, buffered-byte,
 classification, and WebSocket-session gauges. `/diagnostics` returns bounded
 deterministic JSON for the same router-local state and marks the configured
-voice owner.
+voice owner. Probe counters distinguish successful, HTTP-failed, and
+transport-failed health checks; each diagnostic worker includes its latest
+probe result, HTTP status when present, observation time, transition streaks,
+and cumulative outcomes.
 
 Operations responses snapshot router-local state and never contact workers.
 Admission values come from the semaphores that enforce router limits. Worker

--- a/docs/basic_usage/omni_router.md
+++ b/docs/basic_usage/omni_router.md
@@ -300,12 +300,14 @@ compatible. Current worker load does not change readiness.
 `/v1/models` returns a sorted, deduplicated inventory built from worker defaults
 and correlated profile model IDs. `/metrics` exposes Prometheus lifecycle,
 readiness, health, admission, worker-load, listener, buffered-byte,
-classification, and WebSocket-session gauges. `/diagnostics` returns bounded
-deterministic JSON for the same router-local state and marks the configured
-voice owner. Probe counters distinguish successful, HTTP-failed, and
-transport-failed health checks; each diagnostic worker includes its latest
-probe result, HTTP status when present, observation time, transition streaks,
-and cumulative outcomes.
+classification, and WebSocket-session gauges. It also exposes cumulative
+request and response-header counts, router-generated faults, saturation
+rejections, post-commit HTTP relay failures, and worker probe outcomes.
+Response-header counts do not claim that a streaming body completed.
+`/diagnostics` returns bounded deterministic JSON for the same router-local
+state and marks the configured voice owner. Each diagnostic worker includes
+its latest probe result, HTTP status when present, observation time, transition
+streaks, and cumulative outcomes.
 
 Operations responses snapshot router-local state and never contact workers.
 Admission values come from the semaphores that enforce router limits. Worker

--- a/docs/basic_usage/omni_router.md
+++ b/docs/basic_usage/omni_router.md
@@ -309,11 +309,14 @@ The response-header histogram measures from router boundary entry until an HTTP
 response is available. It does not measure response-body completion, streaming
 TTFT, or WebSocket-session duration. Requests cancelled before that boundary
 are counted separately. Classification histograms separate slot wait,
-blocking-executor wait, and execution for each request kind. WebSocket
-termination counters distinguish setup from active relay and record one bounded
-reason per upgraded session. HTTP response-body counters distinguish complete
-bodies, upstream body errors, and bodies dropped before completion. The
-post-commit relay-failure counter is the upstream-error subset.
+blocking-executor wait, and execution for each request kind. Blocking work that
+outlives a caller timeout or cancellation records its phase durations when that
+work starts or finishes, without changing the caller's terminal outcome.
+WebSocket termination counters distinguish setup from active relay and record
+one bounded terminal cause per upgraded session; they do not measure completion
+of the bounded close handshake. HTTP response-body counters distinguish
+complete bodies, upstream body errors, and bodies dropped before completion.
+The post-commit relay-failure counter is the upstream-error subset.
 `/diagnostics` returns bounded deterministic JSON for the same router-local
 state and marks the configured voice owner. Each diagnostic worker includes
 its latest probe result, HTTP status when present, observation time, transition

--- a/docs/basic_usage/omni_router.md
+++ b/docs/basic_usage/omni_router.md
@@ -300,10 +300,20 @@ compatible. Current worker load does not change readiness.
 `/v1/models` returns a sorted, deduplicated inventory built from worker defaults
 and correlated profile model IDs. `/metrics` exposes Prometheus lifecycle,
 readiness, health, admission, worker-load, listener, buffered-byte,
-classification, and WebSocket-session gauges. It also exposes cumulative
+classification-slot, and WebSocket-session gauges. It also exposes cumulative
 request and response-header counts, router-generated faults, saturation
-rejections, post-commit HTTP relay failures, and worker probe outcomes.
-Response-header counts do not claim that a streaming body completed.
+rejections, worker probe outcomes, classification outcomes, WebSocket
+termination reasons, and committed HTTP response-body outcomes.
+
+The response-header histogram measures from router boundary entry until an HTTP
+response is available. It does not measure response-body completion, streaming
+TTFT, or WebSocket-session duration. Requests cancelled before that boundary
+are counted separately. Classification histograms separate slot wait,
+blocking-executor wait, and execution for each request kind. WebSocket
+termination counters distinguish setup from active relay and record one bounded
+reason per upgraded session. HTTP response-body counters distinguish complete
+bodies, upstream body errors, and bodies dropped before completion. The
+post-commit relay-failure counter is the upstream-error subset.
 `/diagnostics` returns bounded deterministic JSON for the same router-local
 state and marks the configured voice owner. Each diagnostic worker includes
 its latest probe result, HTTP status when present, observation time, transition

--- a/docs/basic_usage/omni_router.md
+++ b/docs/basic_usage/omni_router.md
@@ -313,7 +313,7 @@ blocking-executor wait, and execution for each request kind. Blocking work that
 outlives a caller timeout or cancellation records its phase durations when that
 work starts or finishes, without changing the caller's terminal outcome.
 WebSocket termination counters distinguish setup from active relay and record
-one bounded terminal cause per upgraded session; they do not measure completion
+one bounded terminal cause per upgraded session. They do not measure completion
 of the bounded close handshake. HTTP response-body counters distinguish
 complete bodies, upstream body errors, and bodies dropped before completion.
 The post-commit relay-failure counter is the upstream-error subset.
@@ -326,7 +326,7 @@ Operations responses snapshot router-local state and never contact workers.
 Admission values come from the semaphores that enforce router limits. Worker
 load comes from the same counters used by `least_requests`. Metric labels use
 fixed vocabularies instead of worker IDs, model IDs, request IDs, paths, or
-client input. Listener usage includes the slot reserved by the pending accept;
+client input. Listener usage includes the slot reserved by the pending accept.
 registered WebSocket sessions represent callbacks retained for shutdown.
 
 Structured logging covers lifecycle events, health transitions, and exceptional

--- a/sglang_omni_router/rust/Cargo.toml
+++ b/sglang_omni_router/rust/Cargo.toml
@@ -41,6 +41,9 @@ futures-util = { version = "=0.3.32", default-features = false, features = ["sin
 [target.'cfg(unix)'.dependencies]
 rlimit = { version = "=0.11.0", default-features = false }
 
+[dev-dependencies]
+tokio = { version = "=1.51.4", default-features = false, features = ["test-util"] }
+
 [lints.rust]
 unreachable_pub = "deny"
 unsafe_code = "forbid"

--- a/sglang_omni_router/rust/examples/omni.toml
+++ b/sglang_omni_router/rust/examples/omni.toml
@@ -13,7 +13,7 @@ format = "json"
 filter = "info"
 
 [router]
-strategy = "round_robin"
+strategy = "least_requests"
 
 [admission]
 global = 128

--- a/sglang_omni_router/rust/examples/tts.toml
+++ b/sglang_omni_router/rust/examples/tts.toml
@@ -13,7 +13,7 @@ format = "json"
 filter = "info"
 
 [router]
-strategy = "round_robin"
+strategy = "least_requests"
 
 [admission]
 global = 64

--- a/sglang_omni_router/rust/src/classification.rs
+++ b/sglang_omni_router/rust/src/classification.rs
@@ -7,6 +7,7 @@ use tracing::error;
 use crate::error::HttpFault;
 
 pub(crate) struct ClassificationExecutor {
+    limit: usize,
     slots: Arc<Semaphore>,
 }
 
@@ -19,8 +20,13 @@ impl ClassificationExecutor {
 
     fn with_slots(slots: usize) -> Arc<Self> {
         Arc::new(Self {
+            limit: slots,
             slots: Arc::new(Semaphore::new(slots)),
         })
+    }
+
+    pub(crate) fn usage(&self) -> (usize, usize) {
+        (self.limit, self.limit - self.slots.available_permits())
     }
 
     pub(crate) async fn classify<T>(

--- a/sglang_omni_router/rust/src/classification.rs
+++ b/sglang_omni_router/rust/src/classification.rs
@@ -1,27 +1,34 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::Semaphore;
 use tokio::time::Instant;
 use tracing::error;
 
 use crate::error::HttpFault;
+use crate::metrics::{
+    ClassificationKind, ClassificationOutcome, ClassificationPhase, RouterMetrics,
+};
 
 pub(crate) struct ClassificationExecutor {
     limit: usize,
     slots: Arc<Semaphore>,
+    metrics: Arc<RouterMetrics>,
 }
 
 impl ClassificationExecutor {
-    pub(crate) fn new() -> Arc<Self> {
+    pub(crate) fn new(metrics: Arc<RouterMetrics>) -> Arc<Self> {
         Self::with_slots(
             std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get),
+            metrics,
         )
     }
 
-    fn with_slots(slots: usize) -> Arc<Self> {
+    fn with_slots(slots: usize, metrics: Arc<RouterMetrics>) -> Arc<Self> {
         Arc::new(Self {
             limit: slots,
             slots: Arc::new(Semaphore::new(slots)),
+            metrics,
         })
     }
 
@@ -31,22 +38,48 @@ impl ClassificationExecutor {
 
     pub(crate) async fn classify<T>(
         &self,
+        kind: ClassificationKind,
         deadline: Instant,
         operation: impl FnOnce() -> Result<T, HttpFault> + Send + 'static,
     ) -> Result<T, HttpFault>
     where
         T: Send + 'static,
     {
-        ensure_before(deadline)?;
+        let mut call = CallObservation::new(&self.metrics, kind);
+        let mut slot_wait =
+            PhaseObservation::new(&self.metrics, kind, ClassificationPhase::SlotWait);
+        if let Err(fault) = ensure_before(deadline) {
+            call.finish(ClassificationOutcome::Timeout);
+            return Err(fault);
+        }
         let slot = tokio::select! {
             biased;
-            () = tokio::time::sleep_until(deadline) => return Err(HttpFault::UpstreamTimeout),
+            () = tokio::time::sleep_until(deadline) => {
+                call.finish(ClassificationOutcome::Timeout);
+                return Err(HttpFault::UpstreamTimeout);
+            }
             result = Arc::clone(&self.slots).acquire_owned() => {
-                result.map_err(|_| HttpFault::InternalError)?
+                match result {
+                    Ok(slot) => slot,
+                    Err(_) => {
+                        call.finish(ClassificationOutcome::Error);
+                        return Err(HttpFault::InternalError);
+                    }
+                }
             }
         };
+        slot_wait.finish();
+        let executor_wait = Arc::new(SharedPhaseObservation::new(
+            Arc::clone(&self.metrics),
+            kind,
+            ClassificationPhase::ExecutorWait,
+        ));
+        let queued_wait = Arc::clone(&executor_wait);
+        let metrics = Arc::clone(&self.metrics);
         let mut task = tokio::task::spawn_blocking(move || {
             let _slot = slot;
+            queued_wait.observe();
+            let _execution = PhaseObservation::new(&metrics, kind, ClassificationPhase::Execution);
             ensure_before(deadline)?;
             operation()
         });
@@ -54,6 +87,7 @@ impl ClassificationExecutor {
             biased;
             () = tokio::time::sleep_until(deadline) => {
                 task.abort();
+                call.finish(ClassificationOutcome::Timeout);
                 return Err(HttpFault::UpstreamTimeout);
             }
             result = &mut task => result,
@@ -61,14 +95,31 @@ impl ClassificationExecutor {
         .map_err(|source| {
             error!(error = %source, "classification task failed");
             HttpFault::InternalError
-        })?;
-        ensure_before(deadline)?;
+        });
+        let classified = match classified {
+            Ok(classified) => classified.and_then(|value| {
+                ensure_before(deadline)?;
+                Ok(value)
+            }),
+            Err(fault) => Err(fault),
+        };
+        let outcome = match &classified {
+            Ok(_) => ClassificationOutcome::Success,
+            Err(HttpFault::UpstreamTimeout) => ClassificationOutcome::Timeout,
+            Err(_) => ClassificationOutcome::Error,
+        };
+        call.finish(outcome);
         classified
     }
 
     #[cfg(test)]
     pub(crate) fn for_test(slots: usize) -> Arc<Self> {
-        Self::with_slots(slots)
+        Self::with_slots(slots, RouterMetrics::new())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test_with_metrics(slots: usize, metrics: Arc<RouterMetrics>) -> Arc<Self> {
+        Self::with_slots(slots, metrics)
     }
 
     #[cfg(test)]
@@ -84,10 +135,315 @@ impl ClassificationExecutor {
     }
 }
 
+struct PhaseObservation<'a> {
+    metrics: &'a RouterMetrics,
+    kind: ClassificationKind,
+    phase: ClassificationPhase,
+    started: Instant,
+    completed: bool,
+}
+
+impl<'a> PhaseObservation<'a> {
+    fn new(
+        metrics: &'a RouterMetrics,
+        kind: ClassificationKind,
+        phase: ClassificationPhase,
+    ) -> Self {
+        Self {
+            metrics,
+            kind,
+            phase,
+            started: Instant::now(),
+            completed: false,
+        }
+    }
+
+    fn finish(&mut self) {
+        self.observe();
+    }
+
+    fn observe(&mut self) {
+        if self.completed {
+            return;
+        }
+        self.completed = true;
+        self.metrics
+            .record_classification_duration(self.kind, self.phase, self.started.elapsed());
+    }
+}
+
+impl Drop for PhaseObservation<'_> {
+    fn drop(&mut self) {
+        self.observe();
+    }
+}
+
+struct SharedPhaseObservation {
+    metrics: Arc<RouterMetrics>,
+    kind: ClassificationKind,
+    phase: ClassificationPhase,
+    started: Instant,
+    completed: AtomicBool,
+}
+
+impl SharedPhaseObservation {
+    fn new(
+        metrics: Arc<RouterMetrics>,
+        kind: ClassificationKind,
+        phase: ClassificationPhase,
+    ) -> Self {
+        Self {
+            metrics,
+            kind,
+            phase,
+            started: Instant::now(),
+            completed: AtomicBool::new(false),
+        }
+    }
+
+    fn observe(&self) {
+        if self
+            .completed
+            .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+            .is_err()
+        {
+            return;
+        }
+        self.metrics
+            .record_classification_duration(self.kind, self.phase, self.started.elapsed());
+    }
+}
+
+impl Drop for SharedPhaseObservation {
+    fn drop(&mut self) {
+        self.observe();
+    }
+}
+
+struct CallObservation<'a> {
+    metrics: &'a RouterMetrics,
+    kind: ClassificationKind,
+    completed: bool,
+}
+
+impl<'a> CallObservation<'a> {
+    fn new(metrics: &'a RouterMetrics, kind: ClassificationKind) -> Self {
+        Self {
+            metrics,
+            kind,
+            completed: false,
+        }
+    }
+
+    fn finish(&mut self, outcome: ClassificationOutcome) {
+        if self.completed {
+            return;
+        }
+        self.completed = true;
+        self.metrics
+            .record_classification_outcome(self.kind, outcome);
+    }
+}
+
+impl Drop for CallObservation<'_> {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.metrics
+                .record_classification_outcome(self.kind, ClassificationOutcome::Cancelled);
+        }
+    }
+}
+
 fn ensure_before(deadline: Instant) -> Result<(), HttpFault> {
     if Instant::now() >= deadline {
         Err(HttpFault::UpstreamTimeout)
     } else {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use super::ClassificationExecutor;
+    use crate::error::HttpFault;
+    use crate::metrics::{
+        ClassificationKind, ClassificationOutcome, ClassificationPhase, RouterMetrics,
+    };
+
+    #[tokio::test]
+    async fn records_success_and_error_with_all_execution_phases() {
+        for (result, outcome) in [
+            (Ok(()), ClassificationOutcome::Success),
+            (
+                Err(HttpFault::MalformedRequest),
+                ClassificationOutcome::Error,
+            ),
+        ] {
+            let metrics = RouterMetrics::new();
+            let executor = ClassificationExecutor::for_test_with_metrics(1, Arc::clone(&metrics));
+            assert_eq!(
+                executor
+                    .classify(
+                        ClassificationKind::Chat,
+                        tokio::time::Instant::now() + Duration::from_secs(1),
+                        move || result,
+                    )
+                    .await,
+                result
+            );
+            assert_eq!(
+                metrics.classification_outcome(ClassificationKind::Chat, outcome),
+                1
+            );
+            for phase in ClassificationPhase::ALL {
+                assert_eq!(
+                    metrics
+                        .classification_duration(ClassificationKind::Chat, phase)
+                        .count(),
+                    1
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn slot_timeout_records_wait_without_execution() {
+        let metrics = RouterMetrics::new();
+        let executor = ClassificationExecutor::for_test_with_metrics(1, Arc::clone(&metrics));
+        let _held = executor.try_hold_slot().expect("hold classification slot");
+
+        let result = executor
+            .classify(
+                ClassificationKind::Speech,
+                tokio::time::Instant::now() + Duration::from_millis(20),
+                || Ok(()),
+            )
+            .await;
+
+        assert_eq!(result, Err(HttpFault::UpstreamTimeout));
+        assert_eq!(
+            metrics
+                .classification_outcome(ClassificationKind::Speech, ClassificationOutcome::Timeout),
+            1
+        );
+        assert_eq!(
+            metrics
+                .classification_duration(ClassificationKind::Speech, ClassificationPhase::SlotWait)
+                .count(),
+            1
+        );
+        for phase in [
+            ClassificationPhase::ExecutorWait,
+            ClassificationPhase::Execution,
+        ] {
+            assert_eq!(
+                metrics
+                    .classification_duration(ClassificationKind::Speech, phase)
+                    .count(),
+                0
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn running_timeout_records_one_terminal_outcome() {
+        let metrics = RouterMetrics::new();
+        let executor = ClassificationExecutor::for_test_with_metrics(1, Arc::clone(&metrics));
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+        let task = tokio::spawn({
+            let executor = Arc::clone(&executor);
+            async move {
+                executor
+                    .classify(
+                        ClassificationKind::SpeechBatch,
+                        tokio::time::Instant::now() + Duration::from_millis(20),
+                        move || {
+                            entered_tx.send(()).expect("classification started");
+                            release_rx.recv().expect("release classification");
+                            Ok(())
+                        },
+                    )
+                    .await
+            }
+        });
+        entered_rx.await.expect("classification entered");
+
+        assert_eq!(
+            task.await.expect("join classification"),
+            Err(HttpFault::UpstreamTimeout)
+        );
+        assert_eq!(
+            metrics.classification_outcome(
+                ClassificationKind::SpeechBatch,
+                ClassificationOutcome::Timeout
+            ),
+            1
+        );
+        release_tx.send(()).expect("release classification");
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while metrics
+                .classification_duration(
+                    ClassificationKind::SpeechBatch,
+                    ClassificationPhase::Execution,
+                )
+                .count()
+                == 0
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("classification completed");
+        assert_eq!(
+            metrics.classification_outcome(
+                ClassificationKind::SpeechBatch,
+                ClassificationOutcome::Success
+            ),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn caller_cancellation_records_cancelled_once() {
+        let metrics = RouterMetrics::new();
+        let executor = ClassificationExecutor::for_test_with_metrics(1, Arc::clone(&metrics));
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+        let task = tokio::spawn({
+            let executor = Arc::clone(&executor);
+            async move {
+                executor
+                    .classify(
+                        ClassificationKind::Translation,
+                        tokio::time::Instant::now() + Duration::from_secs(1),
+                        move || {
+                            entered_tx.send(()).expect("classification started");
+                            release_rx.recv().expect("release classification");
+                            Ok(())
+                        },
+                    )
+                    .await
+            }
+        });
+        entered_rx.await.expect("classification entered");
+        task.abort();
+        assert!(
+            task.await
+                .expect_err("cancel classification")
+                .is_cancelled()
+        );
+        assert_eq!(
+            metrics.classification_outcome(
+                ClassificationKind::Translation,
+                ClassificationOutcome::Cancelled
+            ),
+            1
+        );
+        release_tx.send(()).expect("release classification");
     }
 }

--- a/sglang_omni_router/rust/src/classification.rs
+++ b/sglang_omni_router/rust/src/classification.rs
@@ -96,10 +96,7 @@ impl ClassificationExecutor {
             HttpFault::InternalError
         });
         let classified = match classified {
-            Ok(classified) => classified.and_then(|value| {
-                ensure_before(deadline)?;
-                Ok(value)
-            }),
+            Ok(classified) => complete_before(deadline, classified),
             Err(fault) => Err(fault),
         };
         let outcome = match &classified {
@@ -258,17 +255,32 @@ fn ensure_before(deadline: Instant) -> Result<(), HttpFault> {
     }
 }
 
+fn complete_before<T>(deadline: Instant, result: Result<T, HttpFault>) -> Result<T, HttpFault> {
+    ensure_before(deadline).and(result)
+}
+
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use super::ClassificationExecutor;
+    use super::{ClassificationExecutor, complete_before};
     use crate::error::HttpFault;
     use crate::metrics::{
         ClassificationKind, ClassificationOutcome, ClassificationPhase, RouterMetrics,
     };
+
+    #[tokio::test(start_paused = true)]
+    async fn elapsed_deadline_precedes_operation_error() {
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(20);
+        tokio::time::advance(Duration::from_millis(21)).await;
+
+        assert_eq!(
+            complete_before::<()>(deadline, Err(HttpFault::MalformedRequest)),
+            Err(HttpFault::UpstreamTimeout)
+        );
+    }
 
     async fn occupy_blocking_executor(
         executor: Arc<ClassificationExecutor>,

--- a/sglang_omni_router/rust/src/classification.rs
+++ b/sglang_omni_router/rust/src/classification.rs
@@ -370,11 +370,11 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn running_timeout_records_one_terminal_outcome() {
         let metrics = RouterMetrics::new();
         let executor = ClassificationExecutor::for_test_with_metrics(1, Arc::clone(&metrics));
-        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(0);
         let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
         let task = tokio::spawn({
             let executor = Arc::clone(&executor);
@@ -392,7 +392,11 @@ mod tests {
                     .await
             }
         });
-        entered_rx.await.expect("classification entered");
+        tokio::task::yield_now().await;
+        entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("classification entered");
+        tokio::time::advance(Duration::from_millis(21)).await;
 
         assert_eq!(
             task.await.expect("join classification"),
@@ -405,6 +409,7 @@ mod tests {
             ),
             1
         );
+        tokio::time::resume();
         release_tx.send(()).expect("release classification");
         tokio::time::timeout(Duration::from_secs(1), async {
             while metrics

--- a/sglang_omni_router/rust/src/classification.rs
+++ b/sglang_omni_router/rust/src/classification.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::sync::Arc;
 
 use tokio::sync::Semaphore;
@@ -46,7 +47,7 @@ impl ClassificationExecutor {
     {
         let mut call = CallObservation::new(&self.metrics, kind);
         let mut slot_wait =
-            PhaseObservation::new(&self.metrics, kind, ClassificationPhase::SlotWait);
+            PhaseObservation::new(self.metrics.as_ref(), kind, ClassificationPhase::SlotWait);
         if let Err(fault) = ensure_before(deadline) {
             call.finish(ClassificationOutcome::Timeout);
             return Err(fault);
@@ -68,7 +69,7 @@ impl ClassificationExecutor {
             }
         };
         slot_wait.finish();
-        let executor_wait = OwnedPhaseObservation::new(
+        let executor_wait = PhaseObservation::new(
             Arc::clone(&self.metrics),
             kind,
             ClassificationPhase::ExecutorWait,
@@ -77,8 +78,11 @@ impl ClassificationExecutor {
             let _slot = slot;
             let mut executor_wait = executor_wait;
             executor_wait.finish();
-            let _execution =
-                PhaseObservation::new(&executor_wait.metrics, kind, ClassificationPhase::Execution);
+            let _execution = PhaseObservation::new(
+                executor_wait.metrics.as_ref(),
+                kind,
+                ClassificationPhase::Execution,
+            );
             ensure_before(deadline)?;
             operation()
         });
@@ -131,20 +135,16 @@ impl ClassificationExecutor {
     }
 }
 
-struct PhaseObservation<'a> {
-    metrics: &'a RouterMetrics,
+struct PhaseObservation<M: Borrow<RouterMetrics>> {
+    metrics: M,
     kind: ClassificationKind,
     phase: ClassificationPhase,
     started: Instant,
     completed: bool,
 }
 
-impl<'a> PhaseObservation<'a> {
-    fn new(
-        metrics: &'a RouterMetrics,
-        kind: ClassificationKind,
-        phase: ClassificationPhase,
-    ) -> Self {
+impl<M: Borrow<RouterMetrics>> PhaseObservation<M> {
+    fn new(metrics: M, kind: ClassificationKind, phase: ClassificationPhase) -> Self {
         Self {
             metrics,
             kind,
@@ -163,53 +163,17 @@ impl<'a> PhaseObservation<'a> {
             return;
         }
         self.completed = true;
-        self.metrics
-            .record_classification_duration(self.kind, self.phase, self.started.elapsed());
+        self.metrics.borrow().record_classification_duration(
+            self.kind,
+            self.phase,
+            self.started.elapsed(),
+        );
     }
 }
 
-impl Drop for PhaseObservation<'_> {
+impl<M: Borrow<RouterMetrics>> Drop for PhaseObservation<M> {
     fn drop(&mut self) {
         self.observe();
-    }
-}
-
-struct OwnedPhaseObservation {
-    metrics: Arc<RouterMetrics>,
-    kind: ClassificationKind,
-    phase: ClassificationPhase,
-    started: Instant,
-    completed: bool,
-}
-
-impl OwnedPhaseObservation {
-    fn new(
-        metrics: Arc<RouterMetrics>,
-        kind: ClassificationKind,
-        phase: ClassificationPhase,
-    ) -> Self {
-        Self {
-            metrics,
-            kind,
-            phase,
-            started: Instant::now(),
-            completed: false,
-        }
-    }
-
-    fn finish(&mut self) {
-        if self.completed {
-            return;
-        }
-        self.completed = true;
-        self.metrics
-            .record_classification_duration(self.kind, self.phase, self.started.elapsed());
-    }
-}
-
-impl Drop for OwnedPhaseObservation {
-    fn drop(&mut self) {
-        self.finish();
     }
 }
 

--- a/sglang_omni_router/rust/src/classification.rs
+++ b/sglang_omni_router/rust/src/classification.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::Semaphore;
 use tokio::time::Instant;
@@ -69,17 +68,17 @@ impl ClassificationExecutor {
             }
         };
         slot_wait.finish();
-        let executor_wait = Arc::new(SharedPhaseObservation::new(
+        let executor_wait = OwnedPhaseObservation::new(
             Arc::clone(&self.metrics),
             kind,
             ClassificationPhase::ExecutorWait,
-        ));
-        let queued_wait = Arc::clone(&executor_wait);
-        let metrics = Arc::clone(&self.metrics);
+        );
         let mut task = tokio::task::spawn_blocking(move || {
             let _slot = slot;
-            queued_wait.observe();
-            let _execution = PhaseObservation::new(&metrics, kind, ClassificationPhase::Execution);
+            let mut executor_wait = executor_wait;
+            executor_wait.finish();
+            let _execution =
+                PhaseObservation::new(&executor_wait.metrics, kind, ClassificationPhase::Execution);
             ensure_before(deadline)?;
             operation()
         });
@@ -178,15 +177,15 @@ impl Drop for PhaseObservation<'_> {
     }
 }
 
-struct SharedPhaseObservation {
+struct OwnedPhaseObservation {
     metrics: Arc<RouterMetrics>,
     kind: ClassificationKind,
     phase: ClassificationPhase,
     started: Instant,
-    completed: AtomicBool,
+    completed: bool,
 }
 
-impl SharedPhaseObservation {
+impl OwnedPhaseObservation {
     fn new(
         metrics: Arc<RouterMetrics>,
         kind: ClassificationKind,
@@ -197,26 +196,23 @@ impl SharedPhaseObservation {
             kind,
             phase,
             started: Instant::now(),
-            completed: AtomicBool::new(false),
+            completed: false,
         }
     }
 
-    fn observe(&self) {
-        if self
-            .completed
-            .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
-            .is_err()
-        {
+    fn finish(&mut self) {
+        if self.completed {
             return;
         }
+        self.completed = true;
         self.metrics
             .record_classification_duration(self.kind, self.phase, self.started.elapsed());
     }
 }
 
-impl Drop for SharedPhaseObservation {
+impl Drop for OwnedPhaseObservation {
     fn drop(&mut self) {
-        self.observe();
+        self.finish();
     }
 }
 
@@ -273,6 +269,31 @@ mod tests {
     use crate::metrics::{
         ClassificationKind, ClassificationOutcome, ClassificationPhase, RouterMetrics,
     };
+
+    async fn occupy_blocking_executor(
+        executor: Arc<ClassificationExecutor>,
+    ) -> (
+        tokio::task::JoinHandle<Result<(), HttpFault>>,
+        std::sync::mpsc::SyncSender<()>,
+    ) {
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+        let running = tokio::spawn(async move {
+            executor
+                .classify(
+                    ClassificationKind::Chat,
+                    tokio::time::Instant::now() + Duration::from_secs(1),
+                    move || {
+                        entered_tx.send(()).expect("classification started");
+                        release_rx.recv().expect("release classification");
+                        Ok(())
+                    },
+                )
+                .await
+        });
+        entered_rx.await.expect("blocking executor occupied");
+        (running, release_tx)
+    }
 
     #[tokio::test]
     async fn records_success_and_error_with_all_execution_phases() {
@@ -445,5 +466,147 @@ mod tests {
             1
         );
         release_tx.send(()).expect("release classification");
+    }
+
+    #[test]
+    fn queued_timeout_and_cancellation_retain_exact_phase_ownership() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .max_blocking_threads(1)
+            .build()
+            .expect("build bounded blocking runtime");
+        runtime.block_on(async {
+            let metrics = RouterMetrics::new();
+            let executor = ClassificationExecutor::for_test_with_metrics(2, Arc::clone(&metrics));
+            let (running, release_tx) = occupy_blocking_executor(Arc::clone(&executor)).await;
+
+            assert_eq!(
+                executor
+                    .classify(
+                        ClassificationKind::Translation,
+                        tokio::time::Instant::now() + Duration::from_millis(20),
+                        || Ok(()),
+                    )
+                    .await,
+                Err(HttpFault::UpstreamTimeout)
+            );
+            assert_eq!(
+                metrics.classification_outcome(
+                    ClassificationKind::Translation,
+                    ClassificationOutcome::Timeout
+                ),
+                1
+            );
+            assert_eq!(
+                metrics
+                    .classification_duration(
+                        ClassificationKind::Translation,
+                        ClassificationPhase::ExecutorWait,
+                    )
+                    .count(),
+                0
+            );
+            assert_eq!(
+                metrics
+                    .classification_duration(
+                        ClassificationKind::Translation,
+                        ClassificationPhase::Execution,
+                    )
+                    .count(),
+                0
+            );
+
+            release_tx.send(()).expect("release running classification");
+            assert_eq!(running.await.expect("join running classification"), Ok(()));
+            tokio::time::timeout(Duration::from_secs(1), async {
+                while executor.available_slots() != 2 {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("timed-out queued task released its slot");
+            assert_eq!(
+                metrics
+                    .classification_duration(
+                        ClassificationKind::Translation,
+                        ClassificationPhase::ExecutorWait,
+                    )
+                    .count(),
+                1
+            );
+
+            let (running, release_tx) = occupy_blocking_executor(Arc::clone(&executor)).await;
+
+            let cancelled = tokio::spawn({
+                let executor = Arc::clone(&executor);
+                async move {
+                    executor
+                        .classify(
+                            ClassificationKind::Speech,
+                            tokio::time::Instant::now() + Duration::from_secs(1),
+                            || Ok(()),
+                        )
+                        .await
+                }
+            });
+            tokio::time::timeout(Duration::from_secs(1), async {
+                while executor.available_slots() != 0 {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("classification queued behind blocking executor");
+            cancelled.abort();
+            assert!(
+                cancelled
+                    .await
+                    .expect_err("cancel queued classification")
+                    .is_cancelled()
+            );
+            assert_eq!(
+                metrics.classification_outcome(
+                    ClassificationKind::Speech,
+                    ClassificationOutcome::Cancelled
+                ),
+                1
+            );
+
+            release_tx
+                .send(())
+                .expect("release second running classification");
+            assert_eq!(running.await.expect("join running classification"), Ok(()));
+            tokio::time::timeout(Duration::from_secs(1), async {
+                while executor.available_slots() != 2 {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("cancelled caller's queued work completed");
+            assert_eq!(
+                metrics
+                    .classification_duration(
+                        ClassificationKind::Speech,
+                        ClassificationPhase::ExecutorWait,
+                    )
+                    .count(),
+                1
+            );
+            assert_eq!(
+                metrics
+                    .classification_duration(
+                        ClassificationKind::Speech,
+                        ClassificationPhase::Execution,
+                    )
+                    .count(),
+                1
+            );
+            assert_eq!(
+                metrics.classification_outcome(
+                    ClassificationKind::Speech,
+                    ClassificationOutcome::Success
+                ),
+                0
+            );
+        });
     }
 }

--- a/sglang_omni_router/rust/src/error.rs
+++ b/sglang_omni_router/rust/src/error.rs
@@ -134,6 +134,7 @@ impl ConfigError {
 
 /// Stable topology-free failures generated before response commitment.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
 pub(crate) enum HttpFault {
     MalformedRequest,
     AmbiguousModel,
@@ -153,6 +154,28 @@ pub(crate) enum HttpFault {
 }
 
 impl HttpFault {
+    pub(crate) const ALL: [Self; 15] = [
+        Self::MalformedRequest,
+        Self::AmbiguousModel,
+        Self::MethodNotAllowed,
+        Self::RequestTimeout,
+        Self::RequestBodyTooLarge,
+        Self::UnsupportedMediaType,
+        Self::UnsupportedContentEncoding,
+        Self::ExpectationFailed,
+        Self::NoCompatibleWorker,
+        Self::RouterOverloaded,
+        Self::InternalError,
+        Self::UpstreamProtocolError,
+        Self::RouterUnavailable,
+        Self::UpstreamTimeout,
+        Self::HttpVersionNotSupported,
+    ];
+
+    pub(crate) const fn index(self) -> usize {
+        self as usize
+    }
+
     const fn status(self) -> StatusCode {
         match self {
             Self::MalformedRequest | Self::AmbiguousModel => StatusCode::BAD_REQUEST,
@@ -173,7 +196,7 @@ impl HttpFault {
         }
     }
 
-    const fn code(self) -> &'static str {
+    pub(crate) const fn code(self) -> &'static str {
         match self {
             Self::MalformedRequest => "malformed_request",
             Self::AmbiguousModel => "ambiguous_model",
@@ -247,6 +270,7 @@ impl HttpFault {
         if self == Self::MethodNotAllowed {
             response.headers_mut().insert(ALLOW, allow);
         }
+        response.extensions_mut().insert(self);
         response
     }
 }

--- a/sglang_omni_router/rust/src/http_generation/classify.rs
+++ b/sglang_omni_router/rust/src/http_generation/classify.rs
@@ -781,7 +781,8 @@ stream_modes = ["non_streaming", "streaming"]
         fs::write(&path, text).expect("write classifier config");
         let config = Config::load(&path).expect("load classifier config");
         let _removed = fs::remove_file(path);
-        WorkerPool::build(&config).expect("build classifier pool")
+        WorkerPool::build(&config, crate::metrics::RouterMetrics::new())
+            .expect("build classifier pool")
     }
 
     fn classify_with(body: &str, pool: &WorkerPool) -> Result<(), HttpFault> {

--- a/sglang_omni_router/rust/src/http_generation/mod.rs
+++ b/sglang_omni_router/rust/src/http_generation/mod.rs
@@ -12,6 +12,7 @@ use crate::error::{HttpFault, RouterError};
 use crate::http_relay::{
     HttpRelay, OutgoingRequest, map_admission, map_dispatch, sanitize_response_headers,
 };
+use crate::metrics::ClassificationKind;
 use crate::request_id::CanonicalRequestId;
 use crate::worker_pool::{CapacityClass, TrustDomain, WorkerPool};
 
@@ -131,7 +132,7 @@ async fn handle(
     let classify_trust = generation.trust.clone();
     let (upload, classified) = generation
         .relay
-        .classify(deadline, move || {
+        .classify(ClassificationKind::Chat, deadline, move || {
             let classified = classify(&upload.bytes, &classify_trust)?;
             Ok((upload, classified))
         })

--- a/sglang_omni_router/rust/src/http_media/classify.rs
+++ b/sglang_omni_router/rust/src/http_media/classify.rs
@@ -658,7 +658,8 @@ stream_modes = ["non_streaming", "streaming"]
         fs::write(&path, config).expect("write classifier config");
         let parsed = Config::load(&path).expect("load classifier config");
         let _removed = fs::remove_file(path);
-        WorkerPool::build(&parsed).expect("build classifier pool")
+        WorkerPool::build(&parsed, crate::metrics::RouterMetrics::new())
+            .expect("build classifier pool")
     }
 
     #[test]

--- a/sglang_omni_router/rust/src/http_media/headers.rs
+++ b/sglang_omni_router/rust/src/http_media/headers.rs
@@ -71,7 +71,7 @@ pub(super) fn validate_request(
     })
 }
 
-pub(super) fn validate_bodyless_request(headers: &HeaderMap) -> Result<(), HttpFault> {
+pub(crate) fn validate_bodyless_request(headers: &HeaderMap) -> Result<(), HttpFault> {
     let mut encodings = headers.get_all(CONTENT_ENCODING).iter();
     let encoding = encodings.next();
     if encodings.next().is_some()

--- a/sglang_omni_router/rust/src/http_media/mod.rs
+++ b/sglang_omni_router/rust/src/http_media/mod.rs
@@ -19,6 +19,7 @@ use crate::worker_pool::{CapacityClass, TrustDomain, WorkerPool};
 
 use classify::Classified;
 use headers::RequestKind;
+pub(crate) use headers::validate_bodyless_request;
 
 const SPEECH_PATH: &str = "/v1/audio/speech";
 const BATCH_PATH: &str = "/v1/audio/speech/batch";

--- a/sglang_omni_router/rust/src/http_media/mod.rs
+++ b/sglang_omni_router/rust/src/http_media/mod.rs
@@ -14,6 +14,7 @@ use crate::error::{HttpFault, RouterError};
 use crate::http_relay::{
     HttpRelay, OutgoingRequest, map_admission, map_dispatch, sanitize_response_headers,
 };
+use crate::metrics::ClassificationKind;
 use crate::request_id::CanonicalRequestId;
 use crate::worker_pool::{CapacityClass, TrustDomain, WorkerPool};
 
@@ -58,6 +59,15 @@ impl HttpMediaRoute {
         match self {
             Self::Speech | Self::SpeechBatch => RequestKind::Json,
             Self::Transcription | Self::Translation => RequestKind::Multipart,
+        }
+    }
+
+    const fn classification_kind(self) -> ClassificationKind {
+        match self {
+            Self::Speech => ClassificationKind::Speech,
+            Self::SpeechBatch => ClassificationKind::SpeechBatch,
+            Self::Transcription => ClassificationKind::Transcription,
+            Self::Translation => ClassificationKind::Translation,
         }
     }
 }
@@ -241,7 +251,7 @@ async fn handle(
     let classify_trust = trust.clone();
     let (upload, classified) = media
         .relay
-        .classify(deadline, move || {
+        .classify(route.classification_kind(), deadline, move || {
             let classified = classify(
                 route,
                 &upload.bytes,

--- a/sglang_omni_router/rust/src/http_relay/mod.rs
+++ b/sglang_omni_router/rust/src/http_relay/mod.rs
@@ -14,6 +14,7 @@ use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::classification::ClassificationExecutor;
 use crate::error::HttpFault;
+use crate::metrics::{Rejection, RouterMetrics};
 use crate::request_id::REQUEST_ID_HEADER;
 use crate::worker_pool::{AdmissionError, DispatchError, RequestLease};
 
@@ -31,6 +32,7 @@ pub(crate) struct HttpRelay {
     buffered_budget_limit: usize,
     buffered_budget: Arc<Semaphore>,
     classifier: Arc<ClassificationExecutor>,
+    metrics: Arc<RouterMetrics>,
 }
 
 pub(crate) struct BufferedUpload {
@@ -58,12 +60,14 @@ impl HttpRelay {
         client: reqwest::Client,
         buffered_budget: usize,
         classifier: Arc<ClassificationExecutor>,
+        metrics: Arc<RouterMetrics>,
     ) -> Arc<Self> {
         Arc::new(Self {
             client,
             buffered_budget_limit: buffered_budget,
             buffered_budget: Arc::new(Semaphore::new(buffered_budget)),
             classifier,
+            metrics,
         })
     }
 
@@ -93,7 +97,7 @@ impl HttpRelay {
         deadline: tokio::time::Instant,
     ) -> Result<BufferedUpload, HttpFault> {
         let mut budget = match expected {
-            Some(bytes) => reserve_budget(&self.buffered_budget, bytes)?,
+            Some(bytes) => reserve_budget(&self.buffered_budget, bytes, &self.metrics)?,
             None => None,
         };
         let mut output = BytesMut::with_capacity(initial_buffer_capacity(expected));
@@ -123,7 +127,7 @@ impl HttpRelay {
                         if expected.is_none() && length != 0 {
                             merge_budget(
                                 &mut budget,
-                                reserve_budget(&self.buffered_budget, length)?,
+                                reserve_budget(&self.buffered_budget, length, &self.metrics)?,
                             );
                         }
                         output.extend_from_slice(&data);
@@ -221,7 +225,7 @@ impl HttpRelay {
                 return Err(fault);
             }
         };
-        let relay = DirectResponseBody::new(body, lease);
+        let relay = DirectResponseBody::new(body, lease, Arc::clone(&self.metrics));
         let mut downstream = Response::new(Body::new(relay));
         *downstream.status_mut() = parts.status;
         *downstream.headers_mut() = headers;
@@ -302,15 +306,19 @@ impl OutgoingRequest {
 fn reserve_budget(
     semaphore: &Arc<Semaphore>,
     bytes: u64,
+    metrics: &RouterMetrics,
 ) -> Result<Option<OwnedSemaphorePermit>, HttpFault> {
     if bytes == 0 {
         return Ok(None);
     }
     let permits = u32::try_from(bytes).map_err(|_| HttpFault::InternalError)?;
-    Arc::clone(semaphore)
+    let reserved = Arc::clone(semaphore)
         .try_acquire_many_owned(permits)
-        .map(Some)
-        .map_err(|_| HttpFault::RouterOverloaded)
+        .map(Some);
+    if reserved.is_err() {
+        metrics.record_rejection(Rejection::BufferedRequestBytes);
+    }
+    reserved.map_err(|_| HttpFault::RouterOverloaded)
 }
 
 fn merge_budget(
@@ -405,6 +413,7 @@ mod tests {
     use tokio::sync::Semaphore;
 
     use crate::classification::ClassificationExecutor;
+    use crate::metrics::Rejection;
 
     use super::{
         HttpFault, HttpRelay, SharedUploadState, UploadState, check_precommit_deadline_at,
@@ -430,6 +439,7 @@ mod tests {
             reqwest::Client::new(),
             budget,
             ClassificationExecutor::for_test(1),
+            crate::metrics::RouterMetrics::new(),
         )
     }
 
@@ -439,6 +449,7 @@ mod tests {
             buffered_budget_limit: budget,
             buffered_budget: Arc::new(Semaphore::new(budget)),
             classifier: ClassificationExecutor::for_test(slots),
+            metrics: crate::metrics::RouterMetrics::new(),
         })
     }
 
@@ -476,6 +487,7 @@ mod tests {
             )
             .await;
         assert!(matches!(rejected, Err(HttpFault::RouterOverloaded)));
+        assert_eq!(relay.metrics.rejections(Rejection::BufferedRequestBytes), 1);
         drop(held);
 
         let chunked = relay

--- a/sglang_omni_router/rust/src/http_relay/mod.rs
+++ b/sglang_omni_router/rust/src/http_relay/mod.rs
@@ -28,6 +28,7 @@ pub(crate) use headers::{
 
 pub(crate) struct HttpRelay {
     client: reqwest::Client,
+    buffered_budget_limit: usize,
     buffered_budget: Arc<Semaphore>,
     classifier: Arc<ClassificationExecutor>,
 }
@@ -60,9 +61,17 @@ impl HttpRelay {
     ) -> Arc<Self> {
         Arc::new(Self {
             client,
+            buffered_budget_limit: buffered_budget,
             buffered_budget: Arc::new(Semaphore::new(buffered_budget)),
             classifier,
         })
+    }
+
+    pub(crate) fn buffered_usage(&self) -> (usize, usize) {
+        (
+            self.buffered_budget_limit,
+            self.buffered_budget_limit - self.buffered_budget.available_permits(),
+        )
     }
 
     pub(crate) async fn classify<T>(
@@ -427,6 +436,7 @@ mod tests {
     fn relay_with_slots(budget: usize, slots: usize) -> Arc<HttpRelay> {
         Arc::new(HttpRelay {
             client: reqwest::Client::new(),
+            buffered_budget_limit: budget,
             buffered_budget: Arc::new(Semaphore::new(budget)),
             classifier: ClassificationExecutor::for_test(slots),
         })

--- a/sglang_omni_router/rust/src/http_relay/mod.rs
+++ b/sglang_omni_router/rust/src/http_relay/mod.rs
@@ -14,7 +14,7 @@ use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::classification::ClassificationExecutor;
 use crate::error::HttpFault;
-use crate::metrics::{Rejection, RouterMetrics};
+use crate::metrics::{ClassificationKind, Rejection, RouterMetrics};
 use crate::request_id::REQUEST_ID_HEADER;
 use crate::worker_pool::{AdmissionError, DispatchError, RequestLease};
 
@@ -80,13 +80,14 @@ impl HttpRelay {
 
     pub(crate) async fn classify<T>(
         &self,
+        kind: ClassificationKind,
         deadline: tokio::time::Instant,
         operation: impl FnOnce() -> Result<T, HttpFault> + Send + 'static,
     ) -> Result<T, HttpFault>
     where
         T: Send + 'static,
     {
-        self.classifier.classify(deadline, operation).await
+        self.classifier.classify(kind, deadline, operation).await
     }
 
     pub(crate) async fn read_buffered(
@@ -413,7 +414,7 @@ mod tests {
     use tokio::sync::Semaphore;
 
     use crate::classification::ClassificationExecutor;
-    use crate::metrics::Rejection;
+    use crate::metrics::{ClassificationKind, Rejection};
 
     use super::{
         HttpFault, HttpRelay, SharedUploadState, UploadState, check_precommit_deadline_at,
@@ -547,6 +548,7 @@ mod tests {
         let classifier = tokio::spawn(async move {
             relay
                 .classify(
+                    ClassificationKind::Chat,
                     tokio::time::Instant::now() + Duration::from_secs(1),
                     move || {
                         entered_tx.send(()).expect("announce classifier entry");
@@ -577,6 +579,7 @@ mod tests {
             async move {
                 relay
                     .classify(
+                        ClassificationKind::Chat,
                         tokio::time::Instant::now() + Duration::from_secs(1),
                         move || {
                             entered_tx.send(()).expect("announce classifier entry");
@@ -609,6 +612,7 @@ mod tests {
 
         let result = relay
             .classify(
+                ClassificationKind::Chat,
                 tokio::time::Instant::now() + Duration::from_millis(20),
                 move || {
                     ran_in_task.store(true, Ordering::Relaxed);
@@ -634,6 +638,7 @@ mod tests {
             async move {
                 relay
                     .classify(
+                        ClassificationKind::Chat,
                         tokio::time::Instant::now() + Duration::from_millis(50),
                         move || {
                             let _budget = budget_permit;
@@ -683,6 +688,7 @@ mod tests {
         let classifier = tokio::spawn(async move {
             relay
                 .classify(
+                    ClassificationKind::Chat,
                     tokio::time::Instant::now() + Duration::from_secs(1),
                     move || {
                         let _budget = budget_permit;

--- a/sglang_omni_router/rust/src/http_relay/response_body.rs
+++ b/sglang_omni_router/rust/src/http_relay/response_body.rs
@@ -1,10 +1,12 @@
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use bytes::Bytes;
 use http_body::{Frame, SizeHint};
 use thiserror::Error;
 
+use crate::metrics::RouterMetrics;
 use crate::worker_pool::RequestLease;
 
 #[derive(Debug, Error)]
@@ -15,14 +17,20 @@ pub(crate) struct RelayError;
 pub(crate) struct DirectResponseBody {
     inner: Option<reqwest::Body>,
     lease: Option<RequestLease>,
+    metrics: Arc<RouterMetrics>,
     terminal: bool,
 }
 
 impl DirectResponseBody {
-    pub(crate) fn new(inner: reqwest::Body, lease: RequestLease) -> Self {
+    pub(crate) fn new(
+        inner: reqwest::Body,
+        lease: RequestLease,
+        metrics: Arc<RouterMetrics>,
+    ) -> Self {
         Self {
             inner: Some(inner),
             lease: Some(lease),
+            metrics,
             terminal: false,
         }
     }
@@ -32,8 +40,11 @@ impl DirectResponseBody {
             return;
         }
         self.terminal = true;
-        if upstream_failure && let Some(lease) = self.lease.as_ref() {
-            lease.request_immediate_probe();
+        if upstream_failure {
+            self.metrics.record_relay_failure();
+            if let Some(lease) = self.lease.as_ref() {
+                lease.request_immediate_probe();
+            }
         }
         drop(self.inner.take());
         drop(self.lease.take());

--- a/sglang_omni_router/rust/src/http_relay/response_body.rs
+++ b/sglang_omni_router/rust/src/http_relay/response_body.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use http_body::{Frame, SizeHint};
 use thiserror::Error;
 
-use crate::metrics::RouterMetrics;
+use crate::metrics::{HttpBodyTermination, RouterMetrics};
 use crate::worker_pool::RequestLease;
 
 #[derive(Debug, Error)]
@@ -35,12 +35,13 @@ impl DirectResponseBody {
         }
     }
 
-    fn terminalize(&mut self, upstream_failure: bool) {
+    fn terminalize(&mut self, termination: HttpBodyTermination) {
         if self.terminal {
             return;
         }
         self.terminal = true;
-        if upstream_failure {
+        self.metrics.record_http_body_termination(termination);
+        if termination == HttpBodyTermination::UpstreamError {
             self.metrics.record_relay_failure();
             if let Some(lease) = self.lease.as_ref() {
                 lease.request_immediate_probe();
@@ -50,15 +51,24 @@ impl DirectResponseBody {
         drop(self.lease.take());
     }
 
-    fn fail(&mut self, upstream_failure: bool) -> Poll<Option<Result<Frame<Bytes>, RelayError>>> {
-        self.terminalize(upstream_failure);
+    fn fail(&mut self) -> Poll<Option<Result<Frame<Bytes>, RelayError>>> {
+        self.terminalize(HttpBodyTermination::UpstreamError);
         Poll::Ready(Some(Err(RelayError)))
     }
 }
 
 impl Drop for DirectResponseBody {
     fn drop(&mut self) {
-        self.terminalize(false);
+        let termination = if self
+            .inner
+            .as_ref()
+            .is_some_and(http_body::Body::is_end_stream)
+        {
+            HttpBodyTermination::Complete
+        } else {
+            HttpBodyTermination::Dropped
+        };
+        self.terminalize(termination);
     }
 }
 
@@ -74,16 +84,26 @@ impl http_body::Body for DirectResponseBody {
             return Poll::Ready(None);
         }
         let Some(inner) = self.inner.as_mut() else {
-            return self.fail(true);
+            return self.fail();
         };
-        match Pin::new(inner).poll_frame(cx) {
+        let frame = Pin::new(inner).poll_frame(cx);
+        match frame {
             Poll::Ready(Some(Ok(frame))) => match frame.into_data() {
-                Ok(data) => Poll::Ready(Some(Ok(Frame::data(data)))),
-                Err(_trailers) => self.fail(true),
+                Ok(data) => {
+                    if self
+                        .inner
+                        .as_ref()
+                        .is_some_and(http_body::Body::is_end_stream)
+                    {
+                        self.terminalize(HttpBodyTermination::Complete);
+                    }
+                    Poll::Ready(Some(Ok(Frame::data(data))))
+                }
+                Err(_trailers) => self.fail(),
             },
-            Poll::Ready(Some(Err(_source))) => self.fail(true),
+            Poll::Ready(Some(Err(_source))) => self.fail(),
             Poll::Ready(None) => {
-                self.terminalize(false);
+                self.terminalize(HttpBodyTermination::Complete);
                 Poll::Ready(None)
             }
             Poll::Pending => Poll::Pending,

--- a/sglang_omni_router/rust/src/http_relay/response_body.rs
+++ b/sglang_omni_router/rust/src/http_relay/response_body.rs
@@ -89,16 +89,7 @@ impl http_body::Body for DirectResponseBody {
         let frame = Pin::new(inner).poll_frame(cx);
         match frame {
             Poll::Ready(Some(Ok(frame))) => match frame.into_data() {
-                Ok(data) => {
-                    if self
-                        .inner
-                        .as_ref()
-                        .is_some_and(http_body::Body::is_end_stream)
-                    {
-                        self.terminalize(HttpBodyTermination::Complete);
-                    }
-                    Poll::Ready(Some(Ok(Frame::data(data))))
-                }
+                Ok(data) => Poll::Ready(Some(Ok(Frame::data(data)))),
                 Err(_trailers) => self.fail(),
             },
             Poll::Ready(Some(Err(_source))) => self.fail(),
@@ -116,5 +107,46 @@ impl http_body::Body for DirectResponseBody {
 
     fn size_hint(&self) -> SizeHint {
         SizeHint::default()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use std::pin::Pin;
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use http_body::Body as _;
+
+    use super::DirectResponseBody;
+    use crate::metrics::{HttpBodyTermination, RouterMetrics};
+
+    #[tokio::test]
+    async fn final_frame_precedes_terminal_ownership_release() {
+        let metrics = RouterMetrics::new();
+        let mut body = DirectResponseBody {
+            inner: Some(reqwest::Body::from(Bytes::from_static(b"{}"))),
+            lease: None,
+            metrics: Arc::clone(&metrics),
+            terminal: false,
+        };
+
+        let frame = std::future::poll_fn(|cx| Pin::new(&mut body).poll_frame(cx))
+            .await
+            .expect("body frame")
+            .expect("valid body frame");
+        assert_eq!(frame.into_data().expect("data frame"), "{}");
+        assert!(!body.is_end_stream());
+        assert_eq!(
+            metrics.http_body_terminations(HttpBodyTermination::Complete),
+            0
+        );
+
+        drop(body);
+        assert_eq!(
+            metrics.http_body_terminations(HttpBodyTermination::Complete),
+            1
+        );
     }
 }

--- a/sglang_omni_router/rust/src/lib.rs
+++ b/sglang_omni_router/rust/src/lib.rs
@@ -11,6 +11,7 @@ mod http_generation;
 mod http_media;
 mod http_relay;
 mod lifecycle;
+mod operations;
 mod request_id;
 mod server;
 mod shutdown;

--- a/sglang_omni_router/rust/src/lib.rs
+++ b/sglang_omni_router/rust/src/lib.rs
@@ -11,6 +11,7 @@ mod http_generation;
 mod http_media;
 mod http_relay;
 mod lifecycle;
+mod metrics;
 mod operations;
 mod request_id;
 mod server;

--- a/sglang_omni_router/rust/src/lifecycle.rs
+++ b/sglang_omni_router/rust/src/lifecycle.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 use crate::error::RouterError;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum State {
+pub(crate) enum State {
     Starting,
     Serving,
     Draining,
@@ -66,6 +66,13 @@ impl Lifecycle {
             .is_ok_and(|state| matches!(*state, State::Serving))
     }
 
+    pub(crate) fn snapshot(&self) -> Result<State, RouterError> {
+        self.state
+            .lock()
+            .map(|state| *state)
+            .map_err(|_| RouterError::Lifecycle)
+    }
+
     fn transition(&self, from: State, to: State) -> Result<(), RouterError> {
         let mut state = self.state.lock().map_err(|_| RouterError::Lifecycle)?;
         if *state != from {
@@ -73,6 +80,18 @@ impl Lifecycle {
         }
         *state = to;
         Ok(())
+    }
+}
+
+impl State {
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Starting => "starting",
+            Self::Serving => "serving",
+            Self::Draining => "draining",
+            Self::Stopped => "stopped",
+            Self::Failed => "failed",
+        }
     }
 }
 

--- a/sglang_omni_router/rust/src/lifecycle.rs
+++ b/sglang_omni_router/rust/src/lifecycle.rs
@@ -84,6 +84,14 @@ impl Lifecycle {
 }
 
 impl State {
+    pub(crate) const ALL: [Self; 5] = [
+        Self::Starting,
+        Self::Serving,
+        Self::Draining,
+        Self::Stopped,
+        Self::Failed,
+    ];
+
     pub(crate) const fn label(self) -> &'static str {
         match self {
             Self::Starting => "starting",

--- a/sglang_omni_router/rust/src/metrics.rs
+++ b/sglang_omni_router/rust/src/metrics.rs
@@ -1,0 +1,353 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use axum::http::{Response, StatusCode};
+
+use crate::error::HttpFault;
+use crate::worker_pool::CapacityClass;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub(crate) enum HttpRoute {
+    Live,
+    Ready,
+    Models,
+    Metrics,
+    Diagnostics,
+    Chat,
+    Speech,
+    SpeechBatch,
+    Transcription,
+    Translation,
+    VoiceCollection,
+    VoiceItem,
+    SpeechWebsocket,
+    RealtimeWebsocket,
+    Unknown,
+}
+
+impl HttpRoute {
+    pub(crate) const ALL: [Self; 15] = [
+        Self::Live,
+        Self::Ready,
+        Self::Models,
+        Self::Metrics,
+        Self::Diagnostics,
+        Self::Chat,
+        Self::Speech,
+        Self::SpeechBatch,
+        Self::Transcription,
+        Self::Translation,
+        Self::VoiceCollection,
+        Self::VoiceItem,
+        Self::SpeechWebsocket,
+        Self::RealtimeWebsocket,
+        Self::Unknown,
+    ];
+
+    pub(crate) fn from_path(path: &str) -> Self {
+        match path {
+            "/live" => Self::Live,
+            "/ready" => Self::Ready,
+            "/v1/models" => Self::Models,
+            "/metrics" => Self::Metrics,
+            "/diagnostics" => Self::Diagnostics,
+            "/v1/chat/completions" => Self::Chat,
+            "/v1/audio/speech" => Self::Speech,
+            "/v1/audio/speech/batch" => Self::SpeechBatch,
+            "/v1/audio/transcriptions" => Self::Transcription,
+            "/v1/audio/translations" => Self::Translation,
+            "/v1/audio/voices" => Self::VoiceCollection,
+            "/v1/audio/speech/stream" => Self::SpeechWebsocket,
+            "/v1/realtime" => Self::RealtimeWebsocket,
+            path if voice_item(path) => Self::VoiceItem,
+            _ => Self::Unknown,
+        }
+    }
+
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Live => "live",
+            Self::Ready => "ready",
+            Self::Models => "models",
+            Self::Metrics => "metrics",
+            Self::Diagnostics => "diagnostics",
+            Self::Chat => "chat",
+            Self::Speech => "speech",
+            Self::SpeechBatch => "speech_batch",
+            Self::Transcription => "transcription",
+            Self::Translation => "translation",
+            Self::VoiceCollection => "voice_collection",
+            Self::VoiceItem => "voice_item",
+            Self::SpeechWebsocket => "speech_websocket",
+            Self::RealtimeWebsocket => "realtime_websocket",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    const fn index(self) -> usize {
+        self as usize
+    }
+}
+
+fn voice_item(path: &str) -> bool {
+    path.strip_prefix("/v1/audio/voices/")
+        .is_some_and(|name| !name.is_empty() && !name.contains('/'))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub(crate) enum StatusClass {
+    Informational,
+    Success,
+    Redirection,
+    ClientError,
+    ServerError,
+    Other,
+}
+
+impl StatusClass {
+    pub(crate) const ALL: [Self; 6] = [
+        Self::Informational,
+        Self::Success,
+        Self::Redirection,
+        Self::ClientError,
+        Self::ServerError,
+        Self::Other,
+    ];
+
+    fn from_status(status: StatusCode) -> Self {
+        match status.as_u16() / 100 {
+            1 => Self::Informational,
+            2 => Self::Success,
+            3 => Self::Redirection,
+            4 => Self::ClientError,
+            5 => Self::ServerError,
+            _ => Self::Other,
+        }
+    }
+
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Informational => "1xx",
+            Self::Success => "2xx",
+            Self::Redirection => "3xx",
+            Self::ClientError => "4xx",
+            Self::ServerError => "5xx",
+            Self::Other => "other",
+        }
+    }
+
+    const fn index(self) -> usize {
+        self as usize
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub(crate) enum Rejection {
+    GlobalAdmission,
+    GenerationAdmission,
+    SpeechAdmission,
+    SpeechBatchAdmission,
+    TranscriptionAdmission,
+    SpeechWebsocketAdmission,
+    RealtimeWebsocketAdmission,
+    BufferedRequestBytes,
+    SpeechWebsocketWorker,
+    RealtimeWebsocketWorker,
+}
+
+impl Rejection {
+    pub(crate) const ALL: [Self; 10] = [
+        Self::GlobalAdmission,
+        Self::GenerationAdmission,
+        Self::SpeechAdmission,
+        Self::SpeechBatchAdmission,
+        Self::TranscriptionAdmission,
+        Self::SpeechWebsocketAdmission,
+        Self::RealtimeWebsocketAdmission,
+        Self::BufferedRequestBytes,
+        Self::SpeechWebsocketWorker,
+        Self::RealtimeWebsocketWorker,
+    ];
+
+    pub(crate) const fn admission(class: CapacityClass) -> Self {
+        match class {
+            CapacityClass::GenerationHttp => Self::GenerationAdmission,
+            CapacityClass::SpeechHttp => Self::SpeechAdmission,
+            CapacityClass::SpeechBatch => Self::SpeechBatchAdmission,
+            CapacityClass::TranscriptionHttp => Self::TranscriptionAdmission,
+            CapacityClass::SpeechWebsocket => Self::SpeechWebsocketAdmission,
+            CapacityClass::RealtimeWebsocket => Self::RealtimeWebsocketAdmission,
+        }
+    }
+
+    pub(crate) const fn worker(class: CapacityClass) -> Option<Self> {
+        match class {
+            CapacityClass::SpeechWebsocket => Some(Self::SpeechWebsocketWorker),
+            CapacityClass::RealtimeWebsocket => Some(Self::RealtimeWebsocketWorker),
+            CapacityClass::GenerationHttp
+            | CapacityClass::SpeechHttp
+            | CapacityClass::SpeechBatch
+            | CapacityClass::TranscriptionHttp => None,
+        }
+    }
+
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::GlobalAdmission => "admission_global",
+            Self::GenerationAdmission => "admission_generation_http",
+            Self::SpeechAdmission => "admission_speech_http",
+            Self::SpeechBatchAdmission => "admission_speech_batch",
+            Self::TranscriptionAdmission => "admission_transcription_http",
+            Self::SpeechWebsocketAdmission => "admission_speech_websocket",
+            Self::RealtimeWebsocketAdmission => "admission_realtime_websocket",
+            Self::BufferedRequestBytes => "buffered_request_bytes",
+            Self::SpeechWebsocketWorker => "worker_speech_websocket",
+            Self::RealtimeWebsocketWorker => "worker_realtime_websocket",
+        }
+    }
+
+    const fn index(self) -> usize {
+        self as usize
+    }
+}
+
+pub(crate) struct RouterMetrics {
+    requests: [AtomicU64; HttpRoute::ALL.len()],
+    responses: [[AtomicU64; StatusClass::ALL.len()]; HttpRoute::ALL.len()],
+    faults: [[AtomicU64; HttpFault::ALL.len()]; HttpRoute::ALL.len()],
+    rejections: [AtomicU64; Rejection::ALL.len()],
+    relay_failures: AtomicU64,
+}
+
+impl RouterMetrics {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            requests: std::array::from_fn(|_| AtomicU64::new(0)),
+            responses: std::array::from_fn(|_| std::array::from_fn(|_| AtomicU64::new(0))),
+            faults: std::array::from_fn(|_| std::array::from_fn(|_| AtomicU64::new(0))),
+            rejections: std::array::from_fn(|_| AtomicU64::new(0)),
+            relay_failures: AtomicU64::new(0),
+        })
+    }
+
+    pub(crate) fn record_request(&self, route: HttpRoute) {
+        self.requests[route.index()].fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_response<B>(&self, route: HttpRoute, response: &Response<B>) {
+        let status = StatusClass::from_status(response.status());
+        self.responses[route.index()][status.index()].fetch_add(1, Ordering::Relaxed);
+        if let Some(fault) = response.extensions().get::<HttpFault>() {
+            self.faults[route.index()][fault.index()].fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    pub(crate) fn record_rejection(&self, rejection: Rejection) {
+        self.rejections[rejection.index()].fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_relay_failure(&self) {
+        self.relay_failures.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn requests(&self, route: HttpRoute) -> u64 {
+        self.requests[route.index()].load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn responses(&self, route: HttpRoute, status: StatusClass) -> u64 {
+        self.responses[route.index()][status.index()].load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn faults(&self, route: HttpRoute, fault: HttpFault) -> u64 {
+        self.faults[route.index()][fault.index()].load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn rejections(&self, rejection: Rejection) -> u64 {
+        self.rejections[rejection.index()].load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn relay_failures(&self) -> u64 {
+        self.relay_failures.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Response, StatusCode};
+
+    use super::{HttpRoute, Rejection, RouterMetrics, StatusClass};
+    use crate::error::HttpFault;
+
+    #[test]
+    fn paths_use_fixed_route_labels() {
+        assert_eq!(HttpRoute::from_path("/live"), HttpRoute::Live);
+        assert_eq!(
+            HttpRoute::from_path("/v1/audio/voices/alice"),
+            HttpRoute::VoiceItem
+        );
+        assert_eq!(
+            HttpRoute::from_path("/v1/audio/voices/alice/extra"),
+            HttpRoute::Unknown
+        );
+        assert_eq!(
+            HttpRoute::from_path("/unbounded/client/path"),
+            HttpRoute::Unknown
+        );
+    }
+
+    #[test]
+    fn counters_have_one_owner_and_fixed_indices() {
+        let metrics = RouterMetrics::new();
+        metrics.record_request(HttpRoute::Speech);
+        let mut response = Response::new(Body::empty());
+        *response.status_mut() = StatusCode::TOO_MANY_REQUESTS;
+        response
+            .extensions_mut()
+            .insert(HttpFault::RouterOverloaded);
+        metrics.record_response(HttpRoute::Speech, &response);
+        metrics.record_rejection(Rejection::SpeechAdmission);
+        metrics.record_relay_failure();
+
+        assert_eq!(metrics.requests(HttpRoute::Speech), 1);
+        assert_eq!(
+            metrics.responses(HttpRoute::Speech, StatusClass::ClientError),
+            1
+        );
+        assert_eq!(
+            metrics.faults(HttpRoute::Speech, HttpFault::RouterOverloaded),
+            1
+        );
+        assert_eq!(metrics.rejections(Rejection::SpeechAdmission), 1);
+        assert_eq!(metrics.relay_failures(), 1);
+    }
+
+    #[test]
+    fn metric_enum_tables_match_their_atomic_indices() {
+        for (index, route) in HttpRoute::ALL.into_iter().enumerate() {
+            assert_eq!(route.index(), index);
+        }
+        for (index, status) in StatusClass::ALL.into_iter().enumerate() {
+            assert_eq!(status.index(), index);
+        }
+        for (index, rejection) in Rejection::ALL.into_iter().enumerate() {
+            assert_eq!(rejection.index(), index);
+        }
+        for (index, fault) in HttpFault::ALL.into_iter().enumerate() {
+            assert_eq!(fault.index(), index);
+        }
+
+        let extension_status = match StatusCode::from_u16(600) {
+            Ok(status) => status,
+            Err(error) => panic!("valid extension status: {error}"),
+        };
+        assert_eq!(
+            StatusClass::from_status(extension_status),
+            StatusClass::Other
+        );
+    }
+}

--- a/sglang_omni_router/rust/src/metrics.rs
+++ b/sglang_omni_router/rust/src/metrics.rs
@@ -457,6 +457,30 @@ impl WebsocketTermination {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub(crate) enum HttpBodyTermination {
+    Complete,
+    UpstreamError,
+    Dropped,
+}
+
+impl HttpBodyTermination {
+    pub(crate) const ALL: [Self; 3] = [Self::Complete, Self::UpstreamError, Self::Dropped];
+
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::UpstreamError => "upstream_error",
+            Self::Dropped => "dropped",
+        }
+    }
+
+    const fn index(self) -> usize {
+        self as usize
+    }
+}
+
 impl Rejection {
     pub(crate) const ALL: [Self; 10] = [
         Self::GlobalAdmission,
@@ -524,6 +548,7 @@ pub(crate) struct RouterMetrics {
         [[AtomicU64; ClassificationOutcome::ALL.len()]; ClassificationKind::ALL.len()],
     websocket_terminations: [[[AtomicU64; WebsocketTermination::ALL.len()];
         WebsocketPhase::ALL.len()]; WebsocketProtocol::ALL.len()],
+    http_body_terminations: [AtomicU64; HttpBodyTermination::ALL.len()],
     faults: [[AtomicU64; HttpFault::ALL.len()]; HttpRoute::ALL.len()],
     rejections: [AtomicU64; Rejection::ALL.len()],
     relay_failures: AtomicU64,
@@ -545,6 +570,7 @@ impl RouterMetrics {
             websocket_terminations: std::array::from_fn(|_| {
                 std::array::from_fn(|_| std::array::from_fn(|_| AtomicU64::new(0)))
             }),
+            http_body_terminations: std::array::from_fn(|_| AtomicU64::new(0)),
             faults: std::array::from_fn(|_| std::array::from_fn(|_| AtomicU64::new(0))),
             rejections: std::array::from_fn(|_| AtomicU64::new(0)),
             relay_failures: AtomicU64::new(0),
@@ -602,6 +628,10 @@ impl RouterMetrics {
             .fetch_add(1, Ordering::Relaxed);
     }
 
+    pub(crate) fn record_http_body_termination(&self, termination: HttpBodyTermination) {
+        self.http_body_terminations[termination.index()].fetch_add(1, Ordering::Relaxed);
+    }
+
     pub(crate) fn record_relay_failure(&self) {
         self.relay_failures.fetch_add(1, Ordering::Relaxed);
     }
@@ -656,6 +686,10 @@ impl RouterMetrics {
             .load(Ordering::Relaxed)
     }
 
+    pub(crate) fn http_body_terminations(&self, termination: HttpBodyTermination) -> u64 {
+        self.http_body_terminations[termination.index()].load(Ordering::Relaxed)
+    }
+
     pub(crate) fn relay_failures(&self) -> u64 {
         self.relay_failures.load(Ordering::Relaxed)
     }
@@ -670,8 +704,9 @@ mod tests {
     use axum::http::{Response, StatusCode};
 
     use super::{
-        ClassificationKind, ClassificationOutcome, ClassificationPhase, HttpRoute, Rejection,
-        RouterMetrics, StatusClass, WebsocketPhase, WebsocketProtocol, WebsocketTermination,
+        ClassificationKind, ClassificationOutcome, ClassificationPhase, HttpBodyTermination,
+        HttpRoute, Rejection, RouterMetrics, StatusClass, WebsocketPhase, WebsocketProtocol,
+        WebsocketTermination,
     };
     use crate::error::HttpFault;
 
@@ -718,6 +753,7 @@ mod tests {
             WebsocketPhase::Relay,
             WebsocketTermination::WorkerClose,
         );
+        metrics.record_http_body_termination(HttpBodyTermination::Complete);
         metrics.record_rejection(Rejection::SpeechAdmission);
         metrics.record_relay_failure();
 
@@ -753,6 +789,10 @@ mod tests {
             ),
             1
         );
+        assert_eq!(
+            metrics.http_body_terminations(HttpBodyTermination::Complete),
+            1
+        );
         assert_eq!(metrics.rejections(Rejection::SpeechAdmission), 1);
         assert_eq!(metrics.relay_failures(), 1);
     }
@@ -784,6 +824,9 @@ mod tests {
             assert_eq!(phase.index(), index);
         }
         for (index, termination) in WebsocketTermination::ALL.into_iter().enumerate() {
+            assert_eq!(termination.index(), index);
+        }
+        for (index, termination) in HttpBodyTermination::ALL.into_iter().enumerate() {
             assert_eq!(termination.index(), index);
         }
         for (index, fault) in HttpFault::ALL.into_iter().enumerate() {

--- a/sglang_omni_router/rust/src/metrics.rs
+++ b/sglang_omni_router/rust/src/metrics.rs
@@ -1,10 +1,102 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use axum::http::{Response, StatusCode};
 
 use crate::error::HttpFault;
 use crate::worker_pool::CapacityClass;
+
+pub(crate) const DURATION_BUCKETS: [DurationBucket; 26] = [
+    DurationBucket::new(10, "0.00001"),
+    DurationBucket::new(25, "0.000025"),
+    DurationBucket::new(50, "0.00005"),
+    DurationBucket::new(100, "0.0001"),
+    DurationBucket::new(250, "0.00025"),
+    DurationBucket::new(500, "0.0005"),
+    DurationBucket::new(1_000, "0.001"),
+    DurationBucket::new(5_000, "0.005"),
+    DurationBucket::new(10_000, "0.01"),
+    DurationBucket::new(25_000, "0.025"),
+    DurationBucket::new(50_000, "0.05"),
+    DurationBucket::new(100_000, "0.1"),
+    DurationBucket::new(250_000, "0.25"),
+    DurationBucket::new(500_000, "0.5"),
+    DurationBucket::new(1_000_000, "1"),
+    DurationBucket::new(2_500_000, "2.5"),
+    DurationBucket::new(5_000_000, "5"),
+    DurationBucket::new(10_000_000, "10"),
+    DurationBucket::new(15_000_000, "15"),
+    DurationBucket::new(30_000_000, "30"),
+    DurationBucket::new(45_000_000, "45"),
+    DurationBucket::new(60_000_000, "60"),
+    DurationBucket::new(90_000_000, "90"),
+    DurationBucket::new(120_000_000, "120"),
+    DurationBucket::new(180_000_000, "180"),
+    DurationBucket::new(240_000_000, "240"),
+];
+pub(crate) const DURATION_BUCKET_COUNT: usize = DURATION_BUCKETS.len() + 1;
+
+#[derive(Clone, Copy)]
+pub(crate) struct DurationBucket {
+    pub(crate) upper_micros: u64,
+    pub(crate) label: &'static str,
+}
+
+impl DurationBucket {
+    const fn new(upper_micros: u64, label: &'static str) -> Self {
+        Self {
+            upper_micros,
+            label,
+        }
+    }
+}
+
+pub(crate) struct DurationHistogramSnapshot {
+    pub(crate) buckets: [u64; DURATION_BUCKET_COUNT],
+    pub(crate) sum_micros: u64,
+}
+
+impl DurationHistogramSnapshot {
+    pub(crate) fn count(&self) -> u64 {
+        self.buckets.iter().copied().fold(0, u64::saturating_add)
+    }
+}
+
+struct DurationHistogram {
+    buckets: [AtomicU64; DURATION_BUCKET_COUNT],
+    sum_micros: AtomicU64,
+}
+
+impl DurationHistogram {
+    fn new() -> Self {
+        Self {
+            buckets: std::array::from_fn(|_| AtomicU64::new(0)),
+            sum_micros: AtomicU64::new(0),
+        }
+    }
+
+    fn observe(&self, duration: Duration) {
+        let micros = u64::try_from(duration.as_micros()).unwrap_or(u64::MAX);
+        let index = DURATION_BUCKETS
+            .iter()
+            .position(|bucket| micros <= bucket.upper_micros)
+            .unwrap_or(DURATION_BUCKETS.len());
+        self.buckets[index].fetch_add(1, Ordering::Relaxed);
+        let _updated = self
+            .sum_micros
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |sum| {
+                Some(sum.saturating_add(micros))
+            });
+    }
+
+    fn snapshot(&self) -> DurationHistogramSnapshot {
+        DurationHistogramSnapshot {
+            buckets: std::array::from_fn(|index| self.buckets[index].load(Ordering::Relaxed)),
+            sum_micros: self.sum_micros.load(Ordering::Relaxed),
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(usize)]
@@ -217,6 +309,8 @@ impl Rejection {
 pub(crate) struct RouterMetrics {
     requests: [AtomicU64; HttpRoute::ALL.len()],
     responses: [[AtomicU64; StatusClass::ALL.len()]; HttpRoute::ALL.len()],
+    response_header_durations: [DurationHistogram; HttpRoute::ALL.len()],
+    cancelled_before_headers: [AtomicU64; HttpRoute::ALL.len()],
     faults: [[AtomicU64; HttpFault::ALL.len()]; HttpRoute::ALL.len()],
     rejections: [AtomicU64; Rejection::ALL.len()],
     relay_failures: AtomicU64,
@@ -227,6 +321,8 @@ impl RouterMetrics {
         Arc::new(Self {
             requests: std::array::from_fn(|_| AtomicU64::new(0)),
             responses: std::array::from_fn(|_| std::array::from_fn(|_| AtomicU64::new(0))),
+            response_header_durations: std::array::from_fn(|_| DurationHistogram::new()),
+            cancelled_before_headers: std::array::from_fn(|_| AtomicU64::new(0)),
             faults: std::array::from_fn(|_| std::array::from_fn(|_| AtomicU64::new(0))),
             rejections: std::array::from_fn(|_| AtomicU64::new(0)),
             relay_failures: AtomicU64::new(0),
@@ -245,6 +341,14 @@ impl RouterMetrics {
         }
     }
 
+    pub(crate) fn record_response_header_duration(&self, route: HttpRoute, duration: Duration) {
+        self.response_header_durations[route.index()].observe(duration);
+    }
+
+    pub(crate) fn record_cancelled_before_headers(&self, route: HttpRoute) {
+        self.cancelled_before_headers[route.index()].fetch_add(1, Ordering::Relaxed);
+    }
+
     pub(crate) fn record_rejection(&self, rejection: Rejection) {
         self.rejections[rejection.index()].fetch_add(1, Ordering::Relaxed);
     }
@@ -259,6 +363,14 @@ impl RouterMetrics {
 
     pub(crate) fn responses(&self, route: HttpRoute, status: StatusClass) -> u64 {
         self.responses[route.index()][status.index()].load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn response_header_duration(&self, route: HttpRoute) -> DurationHistogramSnapshot {
+        self.response_header_durations[route.index()].snapshot()
+    }
+
+    pub(crate) fn cancelled_before_headers(&self, route: HttpRoute) -> u64 {
+        self.cancelled_before_headers[route.index()].load(Ordering::Relaxed)
     }
 
     pub(crate) fn faults(&self, route: HttpRoute, fault: HttpFault) -> u64 {
@@ -277,6 +389,8 @@ impl RouterMetrics {
 #[cfg(test)]
 #[allow(clippy::panic)]
 mod tests {
+    use std::time::Duration;
+
     use axum::body::Body;
     use axum::http::{Response, StatusCode};
 
@@ -310,6 +424,8 @@ mod tests {
             .extensions_mut()
             .insert(HttpFault::RouterOverloaded);
         metrics.record_response(HttpRoute::Speech, &response);
+        metrics.record_response_header_duration(HttpRoute::Speech, Duration::from_micros(750));
+        metrics.record_cancelled_before_headers(HttpRoute::Chat);
         metrics.record_rejection(Rejection::SpeechAdmission);
         metrics.record_relay_failure();
 
@@ -322,6 +438,11 @@ mod tests {
             metrics.faults(HttpRoute::Speech, HttpFault::RouterOverloaded),
             1
         );
+        let duration = metrics.response_header_duration(HttpRoute::Speech);
+        assert_eq!(duration.count(), 1);
+        assert_eq!(duration.sum_micros, 750);
+        assert_eq!(duration.buckets[6], 1);
+        assert_eq!(metrics.cancelled_before_headers(HttpRoute::Chat), 1);
         assert_eq!(metrics.rejections(Rejection::SpeechAdmission), 1);
         assert_eq!(metrics.relay_failures(), 1);
     }

--- a/sglang_omni_router/rust/src/metrics.rs
+++ b/sglang_omni_router/rust/src/metrics.rs
@@ -78,10 +78,7 @@ impl DurationHistogram {
 
     fn observe(&self, duration: Duration) {
         let micros = u64::try_from(duration.as_micros()).unwrap_or(u64::MAX);
-        let index = DURATION_BUCKETS
-            .iter()
-            .position(|bucket| micros <= bucket.upper_micros)
-            .unwrap_or(DURATION_BUCKETS.len());
+        let index = DURATION_BUCKETS.partition_point(|bucket| bucket.upper_micros < micros);
         self.buckets[index].fetch_add(1, Ordering::Relaxed);
         let _updated = self
             .sum_micros
@@ -725,6 +722,20 @@ mod tests {
             HttpRoute::from_path("/unbounded/client/path"),
             HttpRoute::Unknown
         );
+    }
+
+    #[test]
+    fn duration_histogram_uses_inclusive_bounds_and_an_overflow_bucket() {
+        let histogram = super::DurationHistogram::new();
+        histogram.observe(Duration::from_micros(10));
+        histogram.observe(Duration::from_micros(11));
+        histogram.observe(Duration::from_micros(240_000_001));
+
+        let snapshot = histogram.snapshot();
+        assert_eq!(snapshot.buckets[0], 1);
+        assert_eq!(snapshot.buckets[1], 1);
+        assert_eq!(snapshot.buckets[super::DURATION_BUCKETS.len()], 1);
+        assert_eq!(snapshot.count(), 3);
     }
 
     #[test]

--- a/sglang_omni_router/rust/src/metrics.rs
+++ b/sglang_omni_router/rust/src/metrics.rs
@@ -337,6 +337,126 @@ impl ClassificationOutcome {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub(crate) enum WebsocketProtocol {
+    Speech,
+    Realtime,
+}
+
+impl WebsocketProtocol {
+    pub(crate) const ALL: [Self; 2] = [Self::Speech, Self::Realtime];
+
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Speech => "speech",
+            Self::Realtime => "realtime",
+        }
+    }
+
+    const fn index(self) -> usize {
+        self as usize
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub(crate) enum WebsocketPhase {
+    Setup,
+    Relay,
+}
+
+impl WebsocketPhase {
+    pub(crate) const ALL: [Self; 2] = [Self::Setup, Self::Relay];
+
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Setup => "setup",
+            Self::Relay => "relay",
+        }
+    }
+
+    const fn index(self) -> usize {
+        self as usize
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub(crate) enum WebsocketTermination {
+    ClientClose,
+    ClientDisconnect,
+    ClientProtocolError,
+    WorkerClose,
+    WorkerDisconnect,
+    WorkerProtocolError,
+    ConfigurationError,
+    ConfigurationTimeout,
+    ClassificationError,
+    ClassificationTimeout,
+    DispatchError,
+    ConnectError,
+    ConnectTimeout,
+    WorkerSetupError,
+    WorkerSetupTimeout,
+    Draining,
+    ForcedShutdown,
+    Cancelled,
+    Internal,
+}
+
+impl WebsocketTermination {
+    pub(crate) const ALL: [Self; 19] = [
+        Self::ClientClose,
+        Self::ClientDisconnect,
+        Self::ClientProtocolError,
+        Self::WorkerClose,
+        Self::WorkerDisconnect,
+        Self::WorkerProtocolError,
+        Self::ConfigurationError,
+        Self::ConfigurationTimeout,
+        Self::ClassificationError,
+        Self::ClassificationTimeout,
+        Self::DispatchError,
+        Self::ConnectError,
+        Self::ConnectTimeout,
+        Self::WorkerSetupError,
+        Self::WorkerSetupTimeout,
+        Self::Draining,
+        Self::ForcedShutdown,
+        Self::Cancelled,
+        Self::Internal,
+    ];
+
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::ClientClose => "client_close",
+            Self::ClientDisconnect => "client_disconnect",
+            Self::ClientProtocolError => "client_protocol_error",
+            Self::WorkerClose => "worker_close",
+            Self::WorkerDisconnect => "worker_disconnect",
+            Self::WorkerProtocolError => "worker_protocol_error",
+            Self::ConfigurationError => "configuration_error",
+            Self::ConfigurationTimeout => "configuration_timeout",
+            Self::ClassificationError => "classification_error",
+            Self::ClassificationTimeout => "classification_timeout",
+            Self::DispatchError => "dispatch_error",
+            Self::ConnectError => "connect_error",
+            Self::ConnectTimeout => "connect_timeout",
+            Self::WorkerSetupError => "worker_setup_error",
+            Self::WorkerSetupTimeout => "worker_setup_timeout",
+            Self::Draining => "draining",
+            Self::ForcedShutdown => "forced_shutdown",
+            Self::Cancelled => "cancelled",
+            Self::Internal => "internal",
+        }
+    }
+
+    const fn index(self) -> usize {
+        self as usize
+    }
+}
+
 impl Rejection {
     pub(crate) const ALL: [Self; 10] = [
         Self::GlobalAdmission,
@@ -402,6 +522,8 @@ pub(crate) struct RouterMetrics {
         [[DurationHistogram; ClassificationPhase::ALL.len()]; ClassificationKind::ALL.len()],
     classification_outcomes:
         [[AtomicU64; ClassificationOutcome::ALL.len()]; ClassificationKind::ALL.len()],
+    websocket_terminations: [[[AtomicU64; WebsocketTermination::ALL.len()];
+        WebsocketPhase::ALL.len()]; WebsocketProtocol::ALL.len()],
     faults: [[AtomicU64; HttpFault::ALL.len()]; HttpRoute::ALL.len()],
     rejections: [AtomicU64; Rejection::ALL.len()],
     relay_failures: AtomicU64,
@@ -419,6 +541,9 @@ impl RouterMetrics {
             }),
             classification_outcomes: std::array::from_fn(|_| {
                 std::array::from_fn(|_| AtomicU64::new(0))
+            }),
+            websocket_terminations: std::array::from_fn(|_| {
+                std::array::from_fn(|_| std::array::from_fn(|_| AtomicU64::new(0)))
             }),
             faults: std::array::from_fn(|_| std::array::from_fn(|_| AtomicU64::new(0))),
             rejections: std::array::from_fn(|_| AtomicU64::new(0)),
@@ -467,6 +592,16 @@ impl RouterMetrics {
         self.rejections[rejection.index()].fetch_add(1, Ordering::Relaxed);
     }
 
+    pub(crate) fn record_websocket_termination(
+        &self,
+        protocol: WebsocketProtocol,
+        phase: WebsocketPhase,
+        termination: WebsocketTermination,
+    ) {
+        self.websocket_terminations[protocol.index()][phase.index()][termination.index()]
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
     pub(crate) fn record_relay_failure(&self) {
         self.relay_failures.fetch_add(1, Ordering::Relaxed);
     }
@@ -511,6 +646,16 @@ impl RouterMetrics {
         self.rejections[rejection.index()].load(Ordering::Relaxed)
     }
 
+    pub(crate) fn websocket_terminations(
+        &self,
+        protocol: WebsocketProtocol,
+        phase: WebsocketPhase,
+        termination: WebsocketTermination,
+    ) -> u64 {
+        self.websocket_terminations[protocol.index()][phase.index()][termination.index()]
+            .load(Ordering::Relaxed)
+    }
+
     pub(crate) fn relay_failures(&self) -> u64 {
         self.relay_failures.load(Ordering::Relaxed)
     }
@@ -526,7 +671,7 @@ mod tests {
 
     use super::{
         ClassificationKind, ClassificationOutcome, ClassificationPhase, HttpRoute, Rejection,
-        RouterMetrics, StatusClass,
+        RouterMetrics, StatusClass, WebsocketPhase, WebsocketProtocol, WebsocketTermination,
     };
     use crate::error::HttpFault;
 
@@ -568,6 +713,11 @@ mod tests {
             ClassificationKind::Speech,
             ClassificationOutcome::Success,
         );
+        metrics.record_websocket_termination(
+            WebsocketProtocol::Speech,
+            WebsocketPhase::Relay,
+            WebsocketTermination::WorkerClose,
+        );
         metrics.record_rejection(Rejection::SpeechAdmission);
         metrics.record_relay_failure();
 
@@ -595,6 +745,14 @@ mod tests {
                 .classification_outcome(ClassificationKind::Speech, ClassificationOutcome::Success),
             1
         );
+        assert_eq!(
+            metrics.websocket_terminations(
+                WebsocketProtocol::Speech,
+                WebsocketPhase::Relay,
+                WebsocketTermination::WorkerClose,
+            ),
+            1
+        );
         assert_eq!(metrics.rejections(Rejection::SpeechAdmission), 1);
         assert_eq!(metrics.relay_failures(), 1);
     }
@@ -618,6 +776,15 @@ mod tests {
         }
         for (index, outcome) in ClassificationOutcome::ALL.into_iter().enumerate() {
             assert_eq!(outcome.index(), index);
+        }
+        for (index, protocol) in WebsocketProtocol::ALL.into_iter().enumerate() {
+            assert_eq!(protocol.index(), index);
+        }
+        for (index, phase) in WebsocketPhase::ALL.into_iter().enumerate() {
+            assert_eq!(phase.index(), index);
+        }
+        for (index, termination) in WebsocketTermination::ALL.into_iter().enumerate() {
+            assert_eq!(termination.index(), index);
         }
         for (index, fault) in HttpFault::ALL.into_iter().enumerate() {
             assert_eq!(fault.index(), index);

--- a/sglang_omni_router/rust/src/metrics.rs
+++ b/sglang_omni_router/rust/src/metrics.rs
@@ -250,6 +250,93 @@ pub(crate) enum Rejection {
     RealtimeWebsocketWorker,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub(crate) enum ClassificationKind {
+    Chat,
+    Speech,
+    SpeechBatch,
+    Transcription,
+    Translation,
+    SpeechWebsocket,
+}
+
+impl ClassificationKind {
+    pub(crate) const ALL: [Self; 6] = [
+        Self::Chat,
+        Self::Speech,
+        Self::SpeechBatch,
+        Self::Transcription,
+        Self::Translation,
+        Self::SpeechWebsocket,
+    ];
+
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Chat => "chat",
+            Self::Speech => "speech",
+            Self::SpeechBatch => "speech_batch",
+            Self::Transcription => "transcription",
+            Self::Translation => "translation",
+            Self::SpeechWebsocket => "speech_websocket",
+        }
+    }
+
+    const fn index(self) -> usize {
+        self as usize
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub(crate) enum ClassificationPhase {
+    SlotWait,
+    ExecutorWait,
+    Execution,
+}
+
+impl ClassificationPhase {
+    pub(crate) const ALL: [Self; 3] = [Self::SlotWait, Self::ExecutorWait, Self::Execution];
+
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::SlotWait => "slot_wait",
+            Self::ExecutorWait => "executor_wait",
+            Self::Execution => "execution",
+        }
+    }
+
+    const fn index(self) -> usize {
+        self as usize
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub(crate) enum ClassificationOutcome {
+    Success,
+    Error,
+    Timeout,
+    Cancelled,
+}
+
+impl ClassificationOutcome {
+    pub(crate) const ALL: [Self; 4] = [Self::Success, Self::Error, Self::Timeout, Self::Cancelled];
+
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Error => "error",
+            Self::Timeout => "timeout",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    const fn index(self) -> usize {
+        self as usize
+    }
+}
+
 impl Rejection {
     pub(crate) const ALL: [Self; 10] = [
         Self::GlobalAdmission,
@@ -311,6 +398,10 @@ pub(crate) struct RouterMetrics {
     responses: [[AtomicU64; StatusClass::ALL.len()]; HttpRoute::ALL.len()],
     response_header_durations: [DurationHistogram; HttpRoute::ALL.len()],
     cancelled_before_headers: [AtomicU64; HttpRoute::ALL.len()],
+    classification_durations:
+        [[DurationHistogram; ClassificationPhase::ALL.len()]; ClassificationKind::ALL.len()],
+    classification_outcomes:
+        [[AtomicU64; ClassificationOutcome::ALL.len()]; ClassificationKind::ALL.len()],
     faults: [[AtomicU64; HttpFault::ALL.len()]; HttpRoute::ALL.len()],
     rejections: [AtomicU64; Rejection::ALL.len()],
     relay_failures: AtomicU64,
@@ -323,6 +414,12 @@ impl RouterMetrics {
             responses: std::array::from_fn(|_| std::array::from_fn(|_| AtomicU64::new(0))),
             response_header_durations: std::array::from_fn(|_| DurationHistogram::new()),
             cancelled_before_headers: std::array::from_fn(|_| AtomicU64::new(0)),
+            classification_durations: std::array::from_fn(|_| {
+                std::array::from_fn(|_| DurationHistogram::new())
+            }),
+            classification_outcomes: std::array::from_fn(|_| {
+                std::array::from_fn(|_| AtomicU64::new(0))
+            }),
             faults: std::array::from_fn(|_| std::array::from_fn(|_| AtomicU64::new(0))),
             rejections: std::array::from_fn(|_| AtomicU64::new(0)),
             relay_failures: AtomicU64::new(0),
@@ -349,6 +446,23 @@ impl RouterMetrics {
         self.cancelled_before_headers[route.index()].fetch_add(1, Ordering::Relaxed);
     }
 
+    pub(crate) fn record_classification_duration(
+        &self,
+        kind: ClassificationKind,
+        phase: ClassificationPhase,
+        duration: Duration,
+    ) {
+        self.classification_durations[kind.index()][phase.index()].observe(duration);
+    }
+
+    pub(crate) fn record_classification_outcome(
+        &self,
+        kind: ClassificationKind,
+        outcome: ClassificationOutcome,
+    ) {
+        self.classification_outcomes[kind.index()][outcome.index()].fetch_add(1, Ordering::Relaxed);
+    }
+
     pub(crate) fn record_rejection(&self, rejection: Rejection) {
         self.rejections[rejection.index()].fetch_add(1, Ordering::Relaxed);
     }
@@ -373,6 +487,22 @@ impl RouterMetrics {
         self.cancelled_before_headers[route.index()].load(Ordering::Relaxed)
     }
 
+    pub(crate) fn classification_duration(
+        &self,
+        kind: ClassificationKind,
+        phase: ClassificationPhase,
+    ) -> DurationHistogramSnapshot {
+        self.classification_durations[kind.index()][phase.index()].snapshot()
+    }
+
+    pub(crate) fn classification_outcome(
+        &self,
+        kind: ClassificationKind,
+        outcome: ClassificationOutcome,
+    ) -> u64 {
+        self.classification_outcomes[kind.index()][outcome.index()].load(Ordering::Relaxed)
+    }
+
     pub(crate) fn faults(&self, route: HttpRoute, fault: HttpFault) -> u64 {
         self.faults[route.index()][fault.index()].load(Ordering::Relaxed)
     }
@@ -394,7 +524,10 @@ mod tests {
     use axum::body::Body;
     use axum::http::{Response, StatusCode};
 
-    use super::{HttpRoute, Rejection, RouterMetrics, StatusClass};
+    use super::{
+        ClassificationKind, ClassificationOutcome, ClassificationPhase, HttpRoute, Rejection,
+        RouterMetrics, StatusClass,
+    };
     use crate::error::HttpFault;
 
     #[test]
@@ -426,6 +559,15 @@ mod tests {
         metrics.record_response(HttpRoute::Speech, &response);
         metrics.record_response_header_duration(HttpRoute::Speech, Duration::from_micros(750));
         metrics.record_cancelled_before_headers(HttpRoute::Chat);
+        metrics.record_classification_duration(
+            ClassificationKind::Speech,
+            ClassificationPhase::Execution,
+            Duration::from_micros(750),
+        );
+        metrics.record_classification_outcome(
+            ClassificationKind::Speech,
+            ClassificationOutcome::Success,
+        );
         metrics.record_rejection(Rejection::SpeechAdmission);
         metrics.record_relay_failure();
 
@@ -443,6 +585,16 @@ mod tests {
         assert_eq!(duration.sum_micros, 750);
         assert_eq!(duration.buckets[6], 1);
         assert_eq!(metrics.cancelled_before_headers(HttpRoute::Chat), 1);
+        let classification = metrics
+            .classification_duration(ClassificationKind::Speech, ClassificationPhase::Execution);
+        assert_eq!(classification.count(), 1);
+        assert_eq!(classification.sum_micros, 750);
+        assert_eq!(classification.buckets[6], 1);
+        assert_eq!(
+            metrics
+                .classification_outcome(ClassificationKind::Speech, ClassificationOutcome::Success),
+            1
+        );
         assert_eq!(metrics.rejections(Rejection::SpeechAdmission), 1);
         assert_eq!(metrics.relay_failures(), 1);
     }
@@ -457,6 +609,15 @@ mod tests {
         }
         for (index, rejection) in Rejection::ALL.into_iter().enumerate() {
             assert_eq!(rejection.index(), index);
+        }
+        for (index, kind) in ClassificationKind::ALL.into_iter().enumerate() {
+            assert_eq!(kind.index(), index);
+        }
+        for (index, phase) in ClassificationPhase::ALL.into_iter().enumerate() {
+            assert_eq!(phase.index(), index);
+        }
+        for (index, outcome) in ClassificationOutcome::ALL.into_iter().enumerate() {
+            assert_eq!(outcome.index(), index);
         }
         for (index, fault) in HttpFault::ALL.into_iter().enumerate() {
             assert_eq!(fault.index(), index);

--- a/sglang_omni_router/rust/src/operations.rs
+++ b/sglang_omni_router/rust/src/operations.rs
@@ -1,0 +1,556 @@
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+
+use axum::body::Body;
+use axum::http::header::{CACHE_CONTROL, CONTENT_LENGTH, CONTENT_TYPE};
+use axum::http::{HeaderValue, Response, StatusCode};
+use bytes::Bytes;
+use serde::Serialize;
+
+use crate::config::Config;
+use crate::error::{HttpFault, RouterError};
+use crate::lifecycle::State as LifecycleState;
+use crate::worker_pool::{CapacityClass, OperationsSnapshot};
+
+const JSON_CONTENT_TYPE: &str = "application/json";
+const METRICS_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+const LIFECYCLE_STATES: [&str; 5] = ["starting", "serving", "draining", "stopped", "failed"];
+const HEALTH_STATES: [&str; 3] = ["unknown", "healthy", "unhealthy"];
+
+/// Immutable model inventory plus scrape-time operations rendering.
+pub(crate) struct Operations {
+    models: Bytes,
+}
+
+impl Operations {
+    pub(crate) fn build(config: &Config) -> Result<Self, RouterError> {
+        let profile_ids = config.workers.iter().flat_map(|worker| {
+            worker
+                .service_profiles
+                .iter()
+                .filter_map(|profile| profile.model_ids())
+        });
+        let defaults = config
+            .workers
+            .iter()
+            .filter_map(|worker| worker.default_model_id.as_deref());
+        Ok(Self {
+            models: render_model_sources(profile_ids, defaults)?,
+        })
+    }
+
+    pub(crate) fn models_response(&self) -> Response<Body> {
+        response(StatusCode::OK, JSON_CONTENT_TYPE, self.models.clone())
+    }
+
+    pub(crate) fn metrics_response(
+        &self,
+        lifecycle: LifecycleState,
+        ready: bool,
+        snapshot: &OperationsSnapshot,
+    ) -> Response<Body> {
+        response(
+            StatusCode::OK,
+            METRICS_CONTENT_TYPE,
+            Bytes::from(render_metrics(lifecycle, ready, snapshot)),
+        )
+    }
+
+    pub(crate) fn diagnostics_response(
+        &self,
+        lifecycle: LifecycleState,
+        ready: bool,
+        snapshot: &OperationsSnapshot,
+    ) -> Result<Response<Body>, HttpFault> {
+        let diagnostics = Diagnostics::from_snapshot(lifecycle, ready, snapshot);
+        let bytes = serde_json::to_vec(&diagnostics).map_err(|_| HttpFault::InternalError)?;
+        Ok(response(
+            StatusCode::OK,
+            JSON_CONTENT_TYPE,
+            Bytes::from(bytes),
+        ))
+    }
+}
+
+fn response(status: StatusCode, content_type: &'static str, bytes: Bytes) -> Response<Body> {
+    let content_length = bytes.len();
+    let mut response = Response::new(Body::from(bytes));
+    *response.status_mut() = status;
+    response
+        .headers_mut()
+        .insert(CONTENT_TYPE, HeaderValue::from_static(content_type));
+    response
+        .headers_mut()
+        .insert(CONTENT_LENGTH, HeaderValue::from(content_length));
+    response
+        .headers_mut()
+        .insert(CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    response
+}
+
+#[derive(Serialize)]
+struct ModelList<'a> {
+    object: &'static str,
+    data: Vec<ModelCard<'a>>,
+}
+
+#[derive(Serialize)]
+struct ModelCard<'a> {
+    id: &'a str,
+    object: &'static str,
+    created: u8,
+    owned_by: &'static str,
+    permission: [ModelPermission; 1],
+    root: &'a str,
+}
+
+#[derive(Clone, Copy, Serialize)]
+struct ModelPermission {
+    id: &'static str,
+    object: &'static str,
+    allow_create_engine: bool,
+    allow_sampling: bool,
+    allow_logprobs: bool,
+}
+
+fn render_model_sources<'a>(
+    profile_ids: impl Iterator<Item = &'a [String]>,
+    defaults: impl Iterator<Item = &'a str>,
+) -> Result<Bytes, RouterError> {
+    render_models(profile_ids.flatten().map(String::as_str).chain(defaults))
+}
+
+fn render_models<'a>(ids: impl Iterator<Item = &'a str>) -> Result<Bytes, RouterError> {
+    let ids: BTreeSet<_> = ids.collect();
+    let permission = ModelPermission {
+        id: "modelperm-default",
+        object: "model_permission",
+        allow_create_engine: false,
+        allow_sampling: true,
+        allow_logprobs: true,
+    };
+    let models = ModelList {
+        object: "list",
+        data: ids
+            .into_iter()
+            .map(|id| ModelCard {
+                id,
+                object: "model",
+                created: 0,
+                owned_by: "sglang-omni",
+                permission: [permission],
+                root: id,
+            })
+            .collect(),
+    };
+    serde_json::to_vec(&models)
+        .map(Bytes::from)
+        .map_err(|_| RouterError::WorkerPoolInvariant)
+}
+
+fn render_metrics(lifecycle: LifecycleState, ready: bool, snapshot: &OperationsSnapshot) -> String {
+    let mut output = String::new();
+    output.push_str("# HELP sglang_omni_router_lifecycle Router lifecycle state.\n");
+    output.push_str("# TYPE sglang_omni_router_lifecycle gauge\n");
+    for state in LIFECYCLE_STATES {
+        let value = u8::from(state == lifecycle.label());
+        let _ = writeln!(
+            output,
+            "sglang_omni_router_lifecycle{{state=\"{state}\"}} {value}"
+        );
+    }
+    output.push_str("# HELP sglang_omni_router_ready Router readiness state.\n");
+    output.push_str("# TYPE sglang_omni_router_ready gauge\n");
+    let _ = writeln!(output, "sglang_omni_router_ready {}", u8::from(ready));
+
+    output.push_str("# HELP sglang_omni_router_workers_by_health Workers by health state.\n");
+    output.push_str("# TYPE sglang_omni_router_workers_by_health gauge\n");
+    for health in HEALTH_STATES {
+        let count = snapshot
+            .workers
+            .iter()
+            .filter(|worker| worker.health.label() == health)
+            .count();
+        let _ = writeln!(
+            output,
+            "sglang_omni_router_workers_by_health{{health=\"{health}\"}} {count}"
+        );
+    }
+
+    output.push_str("# HELP sglang_omni_router_workers_routable Routable workers.\n");
+    output.push_str("# TYPE sglang_omni_router_workers_routable gauge\n");
+    let routable = snapshot
+        .workers
+        .iter()
+        .filter(|worker| worker.routable)
+        .count();
+    let _ = writeln!(output, "sglang_omni_router_workers_routable {routable}");
+
+    render_admission_metrics(&mut output, snapshot);
+    render_worker_metrics(&mut output, snapshot);
+    output
+}
+
+fn render_admission_metrics(output: &mut String, snapshot: &OperationsSnapshot) {
+    output.push_str("# HELP sglang_omni_router_admission_limit Configured admission limit.\n");
+    output.push_str("# TYPE sglang_omni_router_admission_limit gauge\n");
+    for entry in &snapshot.admission {
+        let _ = writeln!(
+            output,
+            "sglang_omni_router_admission_limit{{class=\"{}\"}} {}",
+            entry.class.label(),
+            entry.limit
+        );
+    }
+    output.push_str(
+        "# HELP sglang_omni_router_admission_in_flight Current admitted requests and sessions.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_admission_in_flight gauge\n");
+    for entry in &snapshot.admission {
+        let _ = writeln!(
+            output,
+            "sglang_omni_router_admission_in_flight{{class=\"{}\"}} {}",
+            entry.class.label(),
+            entry.in_flight
+        );
+    }
+}
+
+fn render_worker_metrics(output: &mut String, snapshot: &OperationsSnapshot) {
+    let active_requests: usize = snapshot
+        .workers
+        .iter()
+        .map(|worker| worker.active_requests)
+        .sum();
+    output.push_str(
+        "# HELP sglang_omni_router_worker_active_requests Aggregate active worker load.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_worker_active_requests gauge\n");
+    let _ = writeln!(
+        output,
+        "sglang_omni_router_worker_active_requests {active_requests}"
+    );
+
+    let classes = [
+        CapacityClass::SpeechWebsocket,
+        CapacityClass::RealtimeWebsocket,
+    ];
+    let mut limits = [0_usize; 2];
+    let mut in_flight = [0_usize; 2];
+    for worker in &snapshot.workers {
+        for capacity in &worker.session_capacity {
+            if let Some(index) = classes.iter().position(|class| *class == capacity.class) {
+                limits[index] += capacity.limit;
+                in_flight[index] += capacity.in_flight;
+            }
+        }
+    }
+    output.push_str(
+        "# HELP sglang_omni_router_worker_capacity_limit Aggregate configured worker capacity.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_worker_capacity_limit gauge\n");
+    for (index, class) in classes.into_iter().enumerate() {
+        let _ = writeln!(
+            output,
+            "sglang_omni_router_worker_capacity_limit{{class=\"{}\"}} {}",
+            class.label(),
+            limits[index]
+        );
+    }
+    output.push_str(
+        "# HELP sglang_omni_router_worker_capacity_in_flight Aggregate current worker capacity use.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_worker_capacity_in_flight gauge\n");
+    for (index, class) in classes.into_iter().enumerate() {
+        let _ = writeln!(
+            output,
+            "sglang_omni_router_worker_capacity_in_flight{{class=\"{}\"}} {}",
+            class.label(),
+            in_flight[index]
+        );
+    }
+}
+
+#[derive(Serialize)]
+struct Diagnostics<'a> {
+    lifecycle: &'static str,
+    ready: bool,
+    admission: Vec<DiagnosticCapacity>,
+    workers: Vec<DiagnosticWorker<'a>>,
+}
+
+#[derive(Serialize)]
+struct DiagnosticCapacity {
+    class: &'static str,
+    limit: usize,
+    in_flight: usize,
+}
+
+#[derive(Serialize)]
+struct DiagnosticWorker<'a> {
+    worker_id: &'a str,
+    registration_ordinal: usize,
+    health: &'static str,
+    routable: bool,
+    active_requests: usize,
+    capacity: Vec<DiagnosticCapacity>,
+}
+
+impl<'a> Diagnostics<'a> {
+    fn from_snapshot(
+        lifecycle: LifecycleState,
+        ready: bool,
+        snapshot: &'a OperationsSnapshot,
+    ) -> Self {
+        Self {
+            lifecycle: lifecycle.label(),
+            ready,
+            admission: snapshot
+                .admission
+                .iter()
+                .map(|entry| DiagnosticCapacity {
+                    class: entry.class.label(),
+                    limit: entry.limit,
+                    in_flight: entry.in_flight,
+                })
+                .collect(),
+            workers: snapshot
+                .workers
+                .iter()
+                .map(|worker| DiagnosticWorker {
+                    worker_id: &worker.worker_id,
+                    registration_ordinal: worker.registration_ordinal,
+                    health: worker.health.label(),
+                    routable: worker.routable,
+                    active_requests: worker.active_requests,
+                    capacity: worker
+                        .session_capacity
+                        .iter()
+                        .map(|entry| DiagnosticCapacity {
+                            class: entry.class.label(),
+                            limit: entry.limit,
+                            in_flight: entry.in_flight,
+                        })
+                        .collect(),
+                })
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use crate::lifecycle::State as LifecycleState;
+    use crate::worker_pool::{
+        AdmissionClass, AdmissionSnapshot, CapacityClass, OperationsSnapshot,
+        SessionCapacitySnapshot, WorkerHealth, WorkerSnapshot,
+    };
+
+    use super::{Diagnostics, render_metrics, render_model_sources, render_models};
+
+    fn admission(class: AdmissionClass, limit: usize, in_flight: usize) -> AdmissionSnapshot {
+        AdmissionSnapshot {
+            class,
+            limit,
+            in_flight,
+        }
+    }
+
+    fn capacity(class: CapacityClass, limit: usize, in_flight: usize) -> SessionCapacitySnapshot {
+        SessionCapacitySnapshot {
+            class,
+            limit,
+            in_flight,
+        }
+    }
+
+    fn representative_snapshot() -> OperationsSnapshot {
+        OperationsSnapshot {
+            admission: [
+                admission(AdmissionClass::Global, 100, 0),
+                admission(
+                    AdmissionClass::Service(CapacityClass::GenerationHttp),
+                    101,
+                    1,
+                ),
+                admission(AdmissionClass::Service(CapacityClass::SpeechHttp), 102, 2),
+                admission(AdmissionClass::Service(CapacityClass::SpeechBatch), 103, 3),
+                admission(
+                    AdmissionClass::Service(CapacityClass::TranscriptionHttp),
+                    104,
+                    4,
+                ),
+                admission(
+                    AdmissionClass::Service(CapacityClass::SpeechWebsocket),
+                    105,
+                    5,
+                ),
+                admission(
+                    AdmissionClass::Service(CapacityClass::RealtimeWebsocket),
+                    106,
+                    6,
+                ),
+            ],
+            workers: vec![
+                WorkerSnapshot {
+                    worker_id: String::from("worker-a"),
+                    registration_ordinal: 0,
+                    health: WorkerHealth::Unknown,
+                    routable: false,
+                    active_requests: 3,
+                    session_capacity: vec![
+                        capacity(CapacityClass::SpeechWebsocket, 10, 0),
+                        capacity(CapacityClass::RealtimeWebsocket, 11, 1),
+                    ],
+                },
+                WorkerSnapshot {
+                    worker_id: String::from("worker-b"),
+                    registration_ordinal: 1,
+                    health: WorkerHealth::Healthy,
+                    routable: true,
+                    active_requests: 1,
+                    session_capacity: vec![capacity(CapacityClass::RealtimeWebsocket, 2, 1)],
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn model_bytes_are_exact_sorted_and_deduplicated() {
+        let empty = render_models(std::iter::empty()).expect("serialize empty model list");
+        assert_eq!(empty.as_ref(), br#"{"object":"list","data":[]}"#);
+
+        let bytes = render_models(["zeta", "alpha", "zeta"].into_iter())
+            .expect("serialize fixed model schema");
+        assert_eq!(
+            bytes.as_ref(),
+            br#"{"object":"list","data":[{"id":"alpha","object":"model","created":0,"owned_by":"sglang-omni","permission":[{"id":"modelperm-default","object":"model_permission","allow_create_engine":false,"allow_sampling":true,"allow_logprobs":true}],"root":"alpha"},{"id":"zeta","object":"model","created":0,"owned_by":"sglang-omni","permission":[{"id":"modelperm-default","object":"model_permission","allow_create_engine":false,"allow_sampling":true,"allow_logprobs":true}],"root":"zeta"}]}"#
+        );
+
+        let first = vec![String::from("zeta"), String::from("shared")];
+        let second = vec![String::from("alpha"), String::from("shared")];
+        let union = render_model_sources(
+            [first.as_slice(), second.as_slice()].into_iter(),
+            ["realtime-only", "alpha"].into_iter(),
+        )
+        .expect("serialize exact model union");
+        let value: serde_json::Value =
+            serde_json::from_slice(&union).expect("parse canonical model JSON");
+        let ids: Vec<_> = value["data"]
+            .as_array()
+            .expect("model data array")
+            .iter()
+            .map(|card| card["id"].as_str().expect("model id"))
+            .collect();
+        assert_eq!(ids, ["alpha", "realtime-only", "shared", "zeta"]);
+    }
+
+    #[test]
+    fn metrics_text_is_complete_exact_and_fixed_order() {
+        let rendered = render_metrics(LifecycleState::Serving, true, &representative_snapshot());
+        assert_eq!(
+            rendered,
+            concat!(
+                "# HELP sglang_omni_router_lifecycle Router lifecycle state.\n",
+                "# TYPE sglang_omni_router_lifecycle gauge\n",
+                "sglang_omni_router_lifecycle{state=\"starting\"} 0\n",
+                "sglang_omni_router_lifecycle{state=\"serving\"} 1\n",
+                "sglang_omni_router_lifecycle{state=\"draining\"} 0\n",
+                "sglang_omni_router_lifecycle{state=\"stopped\"} 0\n",
+                "sglang_omni_router_lifecycle{state=\"failed\"} 0\n",
+                "# HELP sglang_omni_router_ready Router readiness state.\n",
+                "# TYPE sglang_omni_router_ready gauge\n",
+                "sglang_omni_router_ready 1\n",
+                "# HELP sglang_omni_router_workers_by_health Workers by health state.\n",
+                "# TYPE sglang_omni_router_workers_by_health gauge\n",
+                "sglang_omni_router_workers_by_health{health=\"unknown\"} 1\n",
+                "sglang_omni_router_workers_by_health{health=\"healthy\"} 1\n",
+                "sglang_omni_router_workers_by_health{health=\"unhealthy\"} 0\n",
+                "# HELP sglang_omni_router_workers_routable Routable workers.\n",
+                "# TYPE sglang_omni_router_workers_routable gauge\n",
+                "sglang_omni_router_workers_routable 1\n",
+                "# HELP sglang_omni_router_admission_limit Configured admission limit.\n",
+                "# TYPE sglang_omni_router_admission_limit gauge\n",
+                "sglang_omni_router_admission_limit{class=\"global\"} 100\n",
+                "sglang_omni_router_admission_limit{class=\"generation_http\"} 101\n",
+                "sglang_omni_router_admission_limit{class=\"speech_http\"} 102\n",
+                "sglang_omni_router_admission_limit{class=\"speech_batch\"} 103\n",
+                "sglang_omni_router_admission_limit{class=\"transcription_http\"} 104\n",
+                "sglang_omni_router_admission_limit{class=\"speech_websocket\"} 105\n",
+                "sglang_omni_router_admission_limit{class=\"realtime_websocket\"} 106\n",
+                "# HELP sglang_omni_router_admission_in_flight Current admitted requests and sessions.\n",
+                "# TYPE sglang_omni_router_admission_in_flight gauge\n",
+                "sglang_omni_router_admission_in_flight{class=\"global\"} 0\n",
+                "sglang_omni_router_admission_in_flight{class=\"generation_http\"} 1\n",
+                "sglang_omni_router_admission_in_flight{class=\"speech_http\"} 2\n",
+                "sglang_omni_router_admission_in_flight{class=\"speech_batch\"} 3\n",
+                "sglang_omni_router_admission_in_flight{class=\"transcription_http\"} 4\n",
+                "sglang_omni_router_admission_in_flight{class=\"speech_websocket\"} 5\n",
+                "sglang_omni_router_admission_in_flight{class=\"realtime_websocket\"} 6\n",
+                "# HELP sglang_omni_router_worker_active_requests Aggregate active worker load.\n",
+                "# TYPE sglang_omni_router_worker_active_requests gauge\n",
+                "sglang_omni_router_worker_active_requests 4\n",
+                "# HELP sglang_omni_router_worker_capacity_limit Aggregate configured worker capacity.\n",
+                "# TYPE sglang_omni_router_worker_capacity_limit gauge\n",
+                "sglang_omni_router_worker_capacity_limit{class=\"speech_websocket\"} 10\n",
+                "sglang_omni_router_worker_capacity_limit{class=\"realtime_websocket\"} 13\n",
+                "# HELP sglang_omni_router_worker_capacity_in_flight Aggregate current worker capacity use.\n",
+                "# TYPE sglang_omni_router_worker_capacity_in_flight gauge\n",
+                "sglang_omni_router_worker_capacity_in_flight{class=\"speech_websocket\"} 0\n",
+                "sglang_omni_router_worker_capacity_in_flight{class=\"realtime_websocket\"} 2\n",
+            )
+        );
+    }
+
+    #[test]
+    fn maximum_diagnostics_are_bounded_ordered_and_redacted() {
+        let admission = representative_snapshot().admission;
+        let workers = (0..256)
+            .map(|registration_ordinal| WorkerSnapshot {
+                worker_id: format!("worker-{registration_ordinal:03}"),
+                registration_ordinal,
+                health: match registration_ordinal % 3 {
+                    0 => WorkerHealth::Unknown,
+                    1 => WorkerHealth::Healthy,
+                    _ => WorkerHealth::Unhealthy,
+                },
+                routable: registration_ordinal % 2 == 0,
+                active_requests: registration_ordinal,
+                session_capacity: vec![
+                    capacity(CapacityClass::SpeechWebsocket, 1, 0),
+                    capacity(CapacityClass::RealtimeWebsocket, 2, 1),
+                ],
+            })
+            .collect();
+        let snapshot = OperationsSnapshot { admission, workers };
+        let bytes = serde_json::to_vec(&Diagnostics::from_snapshot(
+            LifecycleState::Draining,
+            false,
+            &snapshot,
+        ))
+        .expect("serialize maximum diagnostics");
+        assert!(bytes.len() < 256 * 1_024);
+
+        let value: serde_json::Value =
+            serde_json::from_slice(&bytes).expect("parse diagnostics JSON");
+        let keys: BTreeSet<_> = value
+            .as_object()
+            .expect("diagnostics object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            keys,
+            BTreeSet::from(["admission", "lifecycle", "ready", "workers"])
+        );
+        assert_eq!(value["workers"][0]["registration_ordinal"], 0);
+        assert_eq!(value["workers"][255]["registration_ordinal"], 255);
+        let text = String::from_utf8(bytes).expect("diagnostics are UTF-8");
+        for forbidden in ["base_url", "trust_domain", "health_path", "request_id"] {
+            assert!(!text.contains(forbidden));
+        }
+    }
+}

--- a/sglang_omni_router/rust/src/operations.rs
+++ b/sglang_omni_router/rust/src/operations.rs
@@ -10,7 +10,9 @@ use serde::Serialize;
 use crate::config::Config;
 use crate::error::{HttpFault, RouterError};
 use crate::lifecycle::State as LifecycleState;
-use crate::worker_pool::{OperationsSnapshot, SESSION_CAPACITY_CLASSES, WorkerHealth};
+use crate::worker_pool::{
+    OperationsSnapshot, ProbeOutcome, ProbeSnapshot, SESSION_CAPACITY_CLASSES, WorkerHealth,
+};
 
 const JSON_CONTENT_TYPE: &str = "application/json";
 const METRICS_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
@@ -229,10 +231,33 @@ fn render_metrics(
         .count();
     let _ = writeln!(output, "sglang_omni_router_workers_routable {routable}");
 
+    render_probe_metrics(&mut output, snapshot);
     render_admission_metrics(&mut output, snapshot);
     render_worker_metrics(&mut output, snapshot);
     render_resource_metrics(&mut output, resources);
     output
+}
+
+fn render_probe_metrics(output: &mut String, snapshot: &OperationsSnapshot) {
+    output.push_str("# HELP sglang_omni_router_worker_probes_total Worker health probes.\n");
+    output.push_str("# TYPE sglang_omni_router_worker_probes_total counter\n");
+    for outcome in ProbeOutcome::OBSERVED {
+        let count: u64 = snapshot
+            .workers
+            .iter()
+            .map(|worker| match outcome {
+                ProbeOutcome::Success => worker.probe.successes,
+                ProbeOutcome::HttpFailure => worker.probe.http_failures,
+                ProbeOutcome::TransportFailure => worker.probe.transport_failures,
+                ProbeOutcome::Pending => 0,
+            })
+            .sum();
+        let _ = writeln!(
+            output,
+            "sglang_omni_router_worker_probes_total{{outcome=\"{}\"}} {count}",
+            outcome.label()
+        );
+    }
 }
 
 fn render_admission_metrics(output: &mut String, snapshot: &OperationsSnapshot) {
@@ -407,9 +432,37 @@ struct DiagnosticWorker<'a> {
     registration_ordinal: usize,
     voice_owner: bool,
     health: &'static str,
+    probe: DiagnosticProbe,
     routable: bool,
     active_requests: usize,
     capacity: Vec<DiagnosticCapacity>,
+}
+
+#[derive(Serialize)]
+struct DiagnosticProbe {
+    outcome: &'static str,
+    status: Option<u16>,
+    checked_at_unix_ms: Option<u64>,
+    consecutive_successes: u8,
+    consecutive_failures: u8,
+    successes: u64,
+    http_failures: u64,
+    transport_failures: u64,
+}
+
+impl From<ProbeSnapshot> for DiagnosticProbe {
+    fn from(probe: ProbeSnapshot) -> Self {
+        Self {
+            outcome: probe.outcome.label(),
+            status: probe.status,
+            checked_at_unix_ms: probe.checked_at_unix_ms,
+            consecutive_successes: probe.consecutive_successes,
+            consecutive_failures: probe.consecutive_failures,
+            successes: probe.successes,
+            http_failures: probe.http_failures,
+            transport_failures: probe.transport_failures,
+        }
+    }
 }
 
 impl<'a> Diagnostics<'a> {
@@ -440,6 +493,7 @@ impl<'a> Diagnostics<'a> {
                     registration_ordinal: worker.registration_ordinal,
                     voice_owner: worker.voice_owner,
                     health: worker.health.label(),
+                    probe: worker.probe.into(),
                     routable: worker.routable,
                     active_requests: worker.active_requests,
                     capacity: worker
@@ -464,8 +518,8 @@ mod tests {
 
     use crate::lifecycle::State as LifecycleState;
     use crate::worker_pool::{
-        AdmissionClass, AdmissionSnapshot, CapacityClass, OperationsSnapshot,
-        SessionCapacitySnapshot, WorkerHealth, WorkerSnapshot,
+        AdmissionClass, AdmissionSnapshot, CapacityClass, OperationsSnapshot, ProbeOutcome,
+        ProbeSnapshot, SessionCapacitySnapshot, WorkerHealth, WorkerSnapshot,
     };
 
     use super::{
@@ -486,6 +540,23 @@ mod tests {
             class,
             limit,
             in_flight,
+        }
+    }
+
+    fn probe(outcome: ProbeOutcome, successes: u64, failures: u64) -> ProbeSnapshot {
+        ProbeSnapshot {
+            outcome,
+            status: Some(if matches!(outcome, ProbeOutcome::Success) {
+                200
+            } else {
+                503
+            }),
+            checked_at_unix_ms: Some(1_000),
+            consecutive_successes: u8::from(matches!(outcome, ProbeOutcome::Success)),
+            consecutive_failures: u8::from(!matches!(outcome, ProbeOutcome::Success)),
+            successes,
+            http_failures: failures,
+            transport_failures: 0,
         }
     }
 
@@ -522,6 +593,7 @@ mod tests {
                     registration_ordinal: 0,
                     voice_owner: true,
                     health: WorkerHealth::Unknown,
+                    probe: probe(ProbeOutcome::HttpFailure, 2, 3),
                     routable: false,
                     active_requests: 3,
                     session_capacity: vec![
@@ -534,6 +606,7 @@ mod tests {
                     registration_ordinal: 1,
                     voice_owner: false,
                     health: WorkerHealth::Healthy,
+                    probe: probe(ProbeOutcome::Success, 4, 1),
                     routable: true,
                     active_requests: 1,
                     session_capacity: vec![capacity(CapacityClass::RealtimeWebsocket, 2, 1)],
@@ -610,6 +683,11 @@ mod tests {
                 "# HELP sglang_omni_router_workers_routable Routable workers.\n",
                 "# TYPE sglang_omni_router_workers_routable gauge\n",
                 "sglang_omni_router_workers_routable 1\n",
+                "# HELP sglang_omni_router_worker_probes_total Worker health probes.\n",
+                "# TYPE sglang_omni_router_worker_probes_total counter\n",
+                "sglang_omni_router_worker_probes_total{outcome=\"success\"} 6\n",
+                "sglang_omni_router_worker_probes_total{outcome=\"http_failure\"} 4\n",
+                "sglang_omni_router_worker_probes_total{outcome=\"transport_failure\"} 0\n",
                 "# HELP sglang_omni_router_admission_limit Configured admission limit in class-specific units.\n",
                 "# TYPE sglang_omni_router_admission_limit gauge\n",
                 "sglang_omni_router_admission_limit{class=\"global\"} 100\n",
@@ -677,6 +755,7 @@ mod tests {
                     1 => WorkerHealth::Healthy,
                     _ => WorkerHealth::Unhealthy,
                 },
+                probe: probe(ProbeOutcome::Success, 1, 0),
                 routable: registration_ordinal % 2 == 0,
                 active_requests: registration_ordinal,
                 session_capacity: vec![
@@ -711,6 +790,7 @@ mod tests {
         assert_eq!(value["ready"], false);
         assert_eq!(value["workers"][0]["voice_owner"], true);
         assert_eq!(value["workers"][1]["voice_owner"], false);
+        assert_eq!(value["workers"][0]["probe"]["outcome"], "success");
         assert_eq!(value["workers"][0]["registration_ordinal"], 0);
         assert_eq!(value["workers"][255]["registration_ordinal"], 255);
         let text = String::from_utf8(bytes).expect("diagnostics are UTF-8");

--- a/sglang_omni_router/rust/src/operations.rs
+++ b/sglang_omni_router/rust/src/operations.rs
@@ -192,7 +192,9 @@ fn render_metrics(lifecycle: LifecycleState, ready: bool, snapshot: &OperationsS
 }
 
 fn render_admission_metrics(output: &mut String, snapshot: &OperationsSnapshot) {
-    output.push_str("# HELP sglang_omni_router_admission_limit Configured admission limit.\n");
+    output.push_str(
+        "# HELP sglang_omni_router_admission_limit Configured admission limit in class-specific units.\n",
+    );
     output.push_str("# TYPE sglang_omni_router_admission_limit gauge\n");
     for entry in &snapshot.admission {
         let _ = writeln!(
@@ -203,7 +205,7 @@ fn render_admission_metrics(output: &mut String, snapshot: &OperationsSnapshot) 
         );
     }
     output.push_str(
-        "# HELP sglang_omni_router_admission_in_flight Current admitted requests and sessions.\n",
+        "# HELP sglang_omni_router_admission_in_flight Current admission usage in class-specific units.\n",
     );
     output.push_str("# TYPE sglang_omni_router_admission_in_flight gauge\n");
     for entry in &snapshot.admission {
@@ -223,7 +225,7 @@ fn render_worker_metrics(output: &mut String, snapshot: &OperationsSnapshot) {
         .map(|worker| worker.active_requests)
         .sum();
     output.push_str(
-        "# HELP sglang_omni_router_worker_active_requests Aggregate active worker load.\n",
+        "# HELP sglang_omni_router_worker_active_requests Aggregate active worker load; speech batches are item-weighted.\n",
     );
     output.push_str("# TYPE sglang_omni_router_worker_active_requests gauge\n");
     let _ = writeln!(
@@ -472,7 +474,7 @@ mod tests {
                 "# HELP sglang_omni_router_workers_routable Routable workers.\n",
                 "# TYPE sglang_omni_router_workers_routable gauge\n",
                 "sglang_omni_router_workers_routable 1\n",
-                "# HELP sglang_omni_router_admission_limit Configured admission limit.\n",
+                "# HELP sglang_omni_router_admission_limit Configured admission limit in class-specific units.\n",
                 "# TYPE sglang_omni_router_admission_limit gauge\n",
                 "sglang_omni_router_admission_limit{class=\"global\"} 100\n",
                 "sglang_omni_router_admission_limit{class=\"generation_http\"} 101\n",
@@ -481,7 +483,7 @@ mod tests {
                 "sglang_omni_router_admission_limit{class=\"transcription_http\"} 104\n",
                 "sglang_omni_router_admission_limit{class=\"speech_websocket\"} 105\n",
                 "sglang_omni_router_admission_limit{class=\"realtime_websocket\"} 106\n",
-                "# HELP sglang_omni_router_admission_in_flight Current admitted requests and sessions.\n",
+                "# HELP sglang_omni_router_admission_in_flight Current admission usage in class-specific units.\n",
                 "# TYPE sglang_omni_router_admission_in_flight gauge\n",
                 "sglang_omni_router_admission_in_flight{class=\"global\"} 0\n",
                 "sglang_omni_router_admission_in_flight{class=\"generation_http\"} 1\n",
@@ -490,7 +492,7 @@ mod tests {
                 "sglang_omni_router_admission_in_flight{class=\"transcription_http\"} 4\n",
                 "sglang_omni_router_admission_in_flight{class=\"speech_websocket\"} 5\n",
                 "sglang_omni_router_admission_in_flight{class=\"realtime_websocket\"} 6\n",
-                "# HELP sglang_omni_router_worker_active_requests Aggregate active worker load.\n",
+                "# HELP sglang_omni_router_worker_active_requests Aggregate active worker load; speech batches are item-weighted.\n",
                 "# TYPE sglang_omni_router_worker_active_requests gauge\n",
                 "sglang_omni_router_worker_active_requests 4\n",
                 "# HELP sglang_omni_router_worker_capacity_limit Aggregate configured worker capacity.\n",

--- a/sglang_omni_router/rust/src/operations.rs
+++ b/sglang_omni_router/rust/src/operations.rs
@@ -10,12 +10,46 @@ use serde::Serialize;
 use crate::config::Config;
 use crate::error::{HttpFault, RouterError};
 use crate::lifecycle::State as LifecycleState;
-use crate::worker_pool::{CapacityClass, OperationsSnapshot};
+use crate::worker_pool::{OperationsSnapshot, SESSION_CAPACITY_CLASSES, WorkerHealth};
 
 const JSON_CONTENT_TYPE: &str = "application/json";
 const METRICS_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
-const LIFECYCLE_STATES: [&str; 5] = ["starting", "serving", "draining", "stopped", "failed"];
-const HEALTH_STATES: [&str; 3] = ["unknown", "healthy", "unhealthy"];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct ResourceUsage {
+    limit: usize,
+    in_use: usize,
+}
+
+impl ResourceUsage {
+    pub(crate) const fn new(limit: usize, in_use: usize) -> Self {
+        Self { limit, in_use }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct ResourceSnapshot {
+    listener_slots: ResourceUsage,
+    buffered_request_bytes: ResourceUsage,
+    classification_slots: ResourceUsage,
+    websocket_sessions_registered: usize,
+}
+
+impl ResourceSnapshot {
+    pub(crate) const fn new(
+        listener_slots: ResourceUsage,
+        buffered_request_bytes: ResourceUsage,
+        classification_slots: ResourceUsage,
+        websocket_sessions_registered: usize,
+    ) -> Self {
+        Self {
+            listener_slots,
+            buffered_request_bytes,
+            classification_slots,
+            websocket_sessions_registered,
+        }
+    }
+}
 
 /// Immutable model inventory plus scrape-time operations rendering.
 pub(crate) struct Operations {
@@ -48,11 +82,12 @@ impl Operations {
         lifecycle: LifecycleState,
         ready: bool,
         snapshot: &OperationsSnapshot,
+        resources: &ResourceSnapshot,
     ) -> Response<Body> {
         response(
             StatusCode::OK,
             METRICS_CONTENT_TYPE,
-            Bytes::from(render_metrics(lifecycle, ready, snapshot)),
+            Bytes::from(render_metrics(lifecycle, ready, snapshot, resources)),
         )
     }
 
@@ -61,8 +96,9 @@ impl Operations {
         lifecycle: LifecycleState,
         ready: bool,
         snapshot: &OperationsSnapshot,
+        resources: &ResourceSnapshot,
     ) -> Result<Response<Body>, HttpFault> {
-        let diagnostics = Diagnostics::from_snapshot(lifecycle, ready, snapshot);
+        let diagnostics = Diagnostics::from_snapshot(lifecycle, ready, snapshot, resources);
         let bytes = serde_json::to_vec(&diagnostics).map_err(|_| HttpFault::InternalError)?;
         Ok(response(
             StatusCode::OK,
@@ -148,15 +184,21 @@ fn render_models<'a>(ids: impl Iterator<Item = &'a str>) -> Result<Bytes, Router
         .map_err(|_| RouterError::WorkerPoolInvariant)
 }
 
-fn render_metrics(lifecycle: LifecycleState, ready: bool, snapshot: &OperationsSnapshot) -> String {
+fn render_metrics(
+    lifecycle: LifecycleState,
+    ready: bool,
+    snapshot: &OperationsSnapshot,
+    resources: &ResourceSnapshot,
+) -> String {
     let mut output = String::new();
     output.push_str("# HELP sglang_omni_router_lifecycle Router lifecycle state.\n");
     output.push_str("# TYPE sglang_omni_router_lifecycle gauge\n");
-    for state in LIFECYCLE_STATES {
-        let value = u8::from(state == lifecycle.label());
+    for state in LifecycleState::ALL {
+        let value = u8::from(state == lifecycle);
         let _ = writeln!(
             output,
-            "sglang_omni_router_lifecycle{{state=\"{state}\"}} {value}"
+            "sglang_omni_router_lifecycle{{state=\"{}\"}} {value}",
+            state.label()
         );
     }
     output.push_str("# HELP sglang_omni_router_ready Router readiness state.\n");
@@ -165,15 +207,16 @@ fn render_metrics(lifecycle: LifecycleState, ready: bool, snapshot: &OperationsS
 
     output.push_str("# HELP sglang_omni_router_workers_by_health Workers by health state.\n");
     output.push_str("# TYPE sglang_omni_router_workers_by_health gauge\n");
-    for health in HEALTH_STATES {
+    for health in WorkerHealth::ALL {
         let count = snapshot
             .workers
             .iter()
-            .filter(|worker| worker.health.label() == health)
+            .filter(|worker| worker.health == health)
             .count();
         let _ = writeln!(
             output,
-            "sglang_omni_router_workers_by_health{{health=\"{health}\"}} {count}"
+            "sglang_omni_router_workers_by_health{{health=\"{}\"}} {count}",
+            health.label()
         );
     }
 
@@ -188,6 +231,7 @@ fn render_metrics(lifecycle: LifecycleState, ready: bool, snapshot: &OperationsS
 
     render_admission_metrics(&mut output, snapshot);
     render_worker_metrics(&mut output, snapshot);
+    render_resource_metrics(&mut output, resources);
     output
 }
 
@@ -233,15 +277,14 @@ fn render_worker_metrics(output: &mut String, snapshot: &OperationsSnapshot) {
         "sglang_omni_router_worker_active_requests {active_requests}"
     );
 
-    let classes = [
-        CapacityClass::SpeechWebsocket,
-        CapacityClass::RealtimeWebsocket,
-    ];
     let mut limits = [0_usize; 2];
     let mut in_flight = [0_usize; 2];
     for worker in &snapshot.workers {
         for capacity in &worker.session_capacity {
-            if let Some(index) = classes.iter().position(|class| *class == capacity.class) {
+            if let Some(index) = SESSION_CAPACITY_CLASSES
+                .iter()
+                .position(|class| *class == capacity.class)
+            {
                 limits[index] += capacity.limit;
                 in_flight[index] += capacity.in_flight;
             }
@@ -251,7 +294,7 @@ fn render_worker_metrics(output: &mut String, snapshot: &OperationsSnapshot) {
         "# HELP sglang_omni_router_worker_capacity_limit Aggregate configured worker capacity.\n",
     );
     output.push_str("# TYPE sglang_omni_router_worker_capacity_limit gauge\n");
-    for (index, class) in classes.into_iter().enumerate() {
+    for (index, class) in SESSION_CAPACITY_CLASSES.into_iter().enumerate() {
         let _ = writeln!(
             output,
             "sglang_omni_router_worker_capacity_limit{{class=\"{}\"}} {}",
@@ -263,7 +306,7 @@ fn render_worker_metrics(output: &mut String, snapshot: &OperationsSnapshot) {
         "# HELP sglang_omni_router_worker_capacity_in_flight Aggregate current worker capacity use.\n",
     );
     output.push_str("# TYPE sglang_omni_router_worker_capacity_in_flight gauge\n");
-    for (index, class) in classes.into_iter().enumerate() {
+    for (index, class) in SESSION_CAPACITY_CLASSES.into_iter().enumerate() {
         let _ = writeln!(
             output,
             "sglang_omni_router_worker_capacity_in_flight{{class=\"{}\"}} {}",
@@ -273,10 +316,80 @@ fn render_worker_metrics(output: &mut String, snapshot: &OperationsSnapshot) {
     }
 }
 
+fn render_resource_metrics(output: &mut String, resources: &ResourceSnapshot) {
+    output.push_str(
+        "# HELP sglang_omni_router_listener_slots_limit Configured accepted-socket limit.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_listener_slots_limit gauge\n");
+    let _ = writeln!(
+        output,
+        "sglang_omni_router_listener_slots_limit {}",
+        resources.listener_slots.limit
+    );
+    output.push_str(
+        "# HELP sglang_omni_router_listener_slots_reserved Reserved accepted-socket slots, including the pending accept reservation.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_listener_slots_reserved gauge\n");
+    let _ = writeln!(
+        output,
+        "sglang_omni_router_listener_slots_reserved {}",
+        resources.listener_slots.in_use
+    );
+
+    output.push_str(
+        "# HELP sglang_omni_router_buffered_request_bytes_limit Configured aggregate buffered-request byte budget.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_buffered_request_bytes_limit gauge\n");
+    let _ = writeln!(
+        output,
+        "sglang_omni_router_buffered_request_bytes_limit {}",
+        resources.buffered_request_bytes.limit
+    );
+    output.push_str(
+        "# HELP sglang_omni_router_buffered_request_bytes_reserved Reserved buffered-request bytes.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_buffered_request_bytes_reserved gauge\n");
+    let _ = writeln!(
+        output,
+        "sglang_omni_router_buffered_request_bytes_reserved {}",
+        resources.buffered_request_bytes.in_use
+    );
+
+    output.push_str(
+        "# HELP sglang_omni_router_classification_slots_limit Configured CPU-parallel classification slots.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_classification_slots_limit gauge\n");
+    let _ = writeln!(
+        output,
+        "sglang_omni_router_classification_slots_limit {}",
+        resources.classification_slots.limit
+    );
+    output.push_str(
+        "# HELP sglang_omni_router_classification_slots_in_use Active classification slots.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_classification_slots_in_use gauge\n");
+    let _ = writeln!(
+        output,
+        "sglang_omni_router_classification_slots_in_use {}",
+        resources.classification_slots.in_use
+    );
+
+    output.push_str(
+        "# HELP sglang_omni_router_websocket_sessions_registered Registered WebSocket callbacks retained for shutdown.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_websocket_sessions_registered gauge\n");
+    let _ = writeln!(
+        output,
+        "sglang_omni_router_websocket_sessions_registered {}",
+        resources.websocket_sessions_registered
+    );
+}
+
 #[derive(Serialize)]
 struct Diagnostics<'a> {
     lifecycle: &'static str,
     ready: bool,
+    resources: ResourceSnapshot,
     admission: Vec<DiagnosticCapacity>,
     workers: Vec<DiagnosticWorker<'a>>,
 }
@@ -292,6 +405,7 @@ struct DiagnosticCapacity {
 struct DiagnosticWorker<'a> {
     worker_id: &'a str,
     registration_ordinal: usize,
+    voice_owner: bool,
     health: &'static str,
     routable: bool,
     active_requests: usize,
@@ -303,10 +417,12 @@ impl<'a> Diagnostics<'a> {
         lifecycle: LifecycleState,
         ready: bool,
         snapshot: &'a OperationsSnapshot,
+        resources: &ResourceSnapshot,
     ) -> Self {
         Self {
             lifecycle: lifecycle.label(),
             ready,
+            resources: *resources,
             admission: snapshot
                 .admission
                 .iter()
@@ -322,6 +438,7 @@ impl<'a> Diagnostics<'a> {
                 .map(|worker| DiagnosticWorker {
                     worker_id: &worker.worker_id,
                     registration_ordinal: worker.registration_ordinal,
+                    voice_owner: worker.voice_owner,
                     health: worker.health.label(),
                     routable: worker.routable,
                     active_requests: worker.active_requests,
@@ -351,7 +468,10 @@ mod tests {
         SessionCapacitySnapshot, WorkerHealth, WorkerSnapshot,
     };
 
-    use super::{Diagnostics, render_metrics, render_model_sources, render_models};
+    use super::{
+        Diagnostics, ResourceSnapshot, ResourceUsage, render_metrics, render_model_sources,
+        render_models,
+    };
 
     fn admission(class: AdmissionClass, limit: usize, in_flight: usize) -> AdmissionSnapshot {
         AdmissionSnapshot {
@@ -400,6 +520,7 @@ mod tests {
                 WorkerSnapshot {
                     worker_id: String::from("worker-a"),
                     registration_ordinal: 0,
+                    voice_owner: true,
                     health: WorkerHealth::Unknown,
                     routable: false,
                     active_requests: 3,
@@ -411,6 +532,7 @@ mod tests {
                 WorkerSnapshot {
                     worker_id: String::from("worker-b"),
                     registration_ordinal: 1,
+                    voice_owner: false,
                     health: WorkerHealth::Healthy,
                     routable: true,
                     active_requests: 1,
@@ -418,6 +540,15 @@ mod tests {
                 },
             ],
         }
+    }
+
+    const fn resources() -> ResourceSnapshot {
+        ResourceSnapshot::new(
+            ResourceUsage::new(1024, 3),
+            ResourceUsage::new(268_435_456, 4096),
+            ResourceUsage::new(8, 2),
+            1,
+        )
     }
 
     #[test]
@@ -452,7 +583,12 @@ mod tests {
 
     #[test]
     fn metrics_text_is_complete_exact_and_fixed_order() {
-        let rendered = render_metrics(LifecycleState::Serving, true, &representative_snapshot());
+        let rendered = render_metrics(
+            LifecycleState::Serving,
+            true,
+            &representative_snapshot(),
+            &resources(),
+        );
         assert_eq!(
             rendered,
             concat!(
@@ -503,6 +639,27 @@ mod tests {
                 "# TYPE sglang_omni_router_worker_capacity_in_flight gauge\n",
                 "sglang_omni_router_worker_capacity_in_flight{class=\"speech_websocket\"} 0\n",
                 "sglang_omni_router_worker_capacity_in_flight{class=\"realtime_websocket\"} 2\n",
+                "# HELP sglang_omni_router_listener_slots_limit Configured accepted-socket limit.\n",
+                "# TYPE sglang_omni_router_listener_slots_limit gauge\n",
+                "sglang_omni_router_listener_slots_limit 1024\n",
+                "# HELP sglang_omni_router_listener_slots_reserved Reserved accepted-socket slots, including the pending accept reservation.\n",
+                "# TYPE sglang_omni_router_listener_slots_reserved gauge\n",
+                "sglang_omni_router_listener_slots_reserved 3\n",
+                "# HELP sglang_omni_router_buffered_request_bytes_limit Configured aggregate buffered-request byte budget.\n",
+                "# TYPE sglang_omni_router_buffered_request_bytes_limit gauge\n",
+                "sglang_omni_router_buffered_request_bytes_limit 268435456\n",
+                "# HELP sglang_omni_router_buffered_request_bytes_reserved Reserved buffered-request bytes.\n",
+                "# TYPE sglang_omni_router_buffered_request_bytes_reserved gauge\n",
+                "sglang_omni_router_buffered_request_bytes_reserved 4096\n",
+                "# HELP sglang_omni_router_classification_slots_limit Configured CPU-parallel classification slots.\n",
+                "# TYPE sglang_omni_router_classification_slots_limit gauge\n",
+                "sglang_omni_router_classification_slots_limit 8\n",
+                "# HELP sglang_omni_router_classification_slots_in_use Active classification slots.\n",
+                "# TYPE sglang_omni_router_classification_slots_in_use gauge\n",
+                "sglang_omni_router_classification_slots_in_use 2\n",
+                "# HELP sglang_omni_router_websocket_sessions_registered Registered WebSocket callbacks retained for shutdown.\n",
+                "# TYPE sglang_omni_router_websocket_sessions_registered gauge\n",
+                "sglang_omni_router_websocket_sessions_registered 1\n",
             )
         );
     }
@@ -514,6 +671,7 @@ mod tests {
             .map(|registration_ordinal| WorkerSnapshot {
                 worker_id: format!("worker-{registration_ordinal:03}"),
                 registration_ordinal,
+                voice_owner: registration_ordinal == 0,
                 health: match registration_ordinal % 3 {
                     0 => WorkerHealth::Unknown,
                     1 => WorkerHealth::Healthy,
@@ -532,6 +690,7 @@ mod tests {
             LifecycleState::Draining,
             false,
             &snapshot,
+            &resources(),
         ))
         .expect("serialize maximum diagnostics");
         assert!(bytes.len() < 256 * 1_024);
@@ -546,8 +705,12 @@ mod tests {
             .collect();
         assert_eq!(
             keys,
-            BTreeSet::from(["admission", "lifecycle", "ready", "workers"])
+            BTreeSet::from(["admission", "lifecycle", "ready", "resources", "workers"])
         );
+        assert_eq!(value["lifecycle"], "draining");
+        assert_eq!(value["ready"], false);
+        assert_eq!(value["workers"][0]["voice_owner"], true);
+        assert_eq!(value["workers"][1]["voice_owner"], false);
         assert_eq!(value["workers"][0]["registration_ordinal"], 0);
         assert_eq!(value["workers"][255]["registration_ordinal"], 255);
         let text = String::from_utf8(bytes).expect("diagnostics are UTF-8");

--- a/sglang_omni_router/rust/src/operations.rs
+++ b/sglang_omni_router/rust/src/operations.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 use std::fmt::Write as _;
+use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http::header::{CACHE_CONTROL, CONTENT_LENGTH, CONTENT_TYPE};
@@ -10,6 +11,7 @@ use serde::Serialize;
 use crate::config::Config;
 use crate::error::{HttpFault, RouterError};
 use crate::lifecycle::State as LifecycleState;
+use crate::metrics::{HttpRoute, Rejection, RouterMetrics, StatusClass};
 use crate::worker_pool::{
     OperationsSnapshot, ProbeOutcome, ProbeSnapshot, SESSION_CAPACITY_CLASSES, WorkerHealth,
 };
@@ -56,10 +58,11 @@ impl ResourceSnapshot {
 /// Immutable model inventory plus scrape-time operations rendering.
 pub(crate) struct Operations {
     models: Bytes,
+    metrics: Arc<RouterMetrics>,
 }
 
 impl Operations {
-    pub(crate) fn build(config: &Config) -> Result<Self, RouterError> {
+    pub(crate) fn build(config: &Config, metrics: Arc<RouterMetrics>) -> Result<Self, RouterError> {
         let profile_ids = config.workers.iter().flat_map(|worker| {
             worker
                 .service_profiles
@@ -72,6 +75,7 @@ impl Operations {
             .filter_map(|worker| worker.default_model_id.as_deref());
         Ok(Self {
             models: render_model_sources(profile_ids, defaults)?,
+            metrics,
         })
     }
 
@@ -89,7 +93,13 @@ impl Operations {
         response(
             StatusCode::OK,
             METRICS_CONTENT_TYPE,
-            Bytes::from(render_metrics(lifecycle, ready, snapshot, resources)),
+            Bytes::from(render_metrics(
+                lifecycle,
+                ready,
+                snapshot,
+                resources,
+                &self.metrics,
+            )),
         )
     }
 
@@ -191,6 +201,7 @@ fn render_metrics(
     ready: bool,
     snapshot: &OperationsSnapshot,
     resources: &ResourceSnapshot,
+    metrics: &RouterMetrics,
 ) -> String {
     let mut output = String::new();
     output.push_str("# HELP sglang_omni_router_lifecycle Router lifecycle state.\n");
@@ -206,6 +217,8 @@ fn render_metrics(
     output.push_str("# HELP sglang_omni_router_ready Router readiness state.\n");
     output.push_str("# TYPE sglang_omni_router_ready gauge\n");
     let _ = writeln!(output, "sglang_omni_router_ready {}", u8::from(ready));
+
+    render_request_metrics(&mut output, metrics);
 
     output.push_str("# HELP sglang_omni_router_workers_by_health Workers by health state.\n");
     output.push_str("# TYPE sglang_omni_router_workers_by_health gauge\n");
@@ -236,6 +249,80 @@ fn render_metrics(
     render_worker_metrics(&mut output, snapshot);
     render_resource_metrics(&mut output, resources);
     output
+}
+
+fn render_request_metrics(output: &mut String, metrics: &RouterMetrics) {
+    output.push_str("# HELP sglang_omni_router_http_requests_total HTTP requests received.\n");
+    output.push_str("# TYPE sglang_omni_router_http_requests_total counter\n");
+    for route in HttpRoute::ALL {
+        let count = metrics.requests(route);
+        if count != 0 {
+            let _ = writeln!(
+                output,
+                "sglang_omni_router_http_requests_total{{route=\"{}\"}} {count}",
+                route.label()
+            );
+        }
+    }
+
+    output.push_str(
+        "# HELP sglang_omni_router_http_response_headers_total HTTP response headers by status class.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_http_response_headers_total counter\n");
+    for route in HttpRoute::ALL {
+        for status in StatusClass::ALL {
+            let count = metrics.responses(route, status);
+            if count != 0 {
+                let _ = writeln!(
+                    output,
+                    "sglang_omni_router_http_response_headers_total{{route=\"{}\",status=\"{}\"}} {count}",
+                    route.label(),
+                    status.label()
+                );
+            }
+        }
+    }
+
+    output.push_str("# HELP sglang_omni_router_http_faults_total Router-generated HTTP faults.\n");
+    output.push_str("# TYPE sglang_omni_router_http_faults_total counter\n");
+    for route in HttpRoute::ALL {
+        for fault in HttpFault::ALL {
+            let count = metrics.faults(route, fault);
+            if count != 0 {
+                let _ = writeln!(
+                    output,
+                    "sglang_omni_router_http_faults_total{{route=\"{}\",code=\"{}\"}} {count}",
+                    route.label(),
+                    fault.code()
+                );
+            }
+        }
+    }
+
+    output.push_str(
+        "# HELP sglang_omni_router_rejections_total Requests rejected by a saturated bounded resource.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_rejections_total counter\n");
+    for rejection in Rejection::ALL {
+        let count = metrics.rejections(rejection);
+        if count != 0 {
+            let _ = writeln!(
+                output,
+                "sglang_omni_router_rejections_total{{resource=\"{}\"}} {count}",
+                rejection.label()
+            );
+        }
+    }
+
+    output.push_str(
+        "# HELP sglang_omni_router_http_relay_failures_total Upstream body failures after response commitment.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_http_relay_failures_total counter\n");
+    let _ = writeln!(
+        output,
+        "sglang_omni_router_http_relay_failures_total {}",
+        metrics.relay_failures()
+    );
 }
 
 fn render_probe_metrics(output: &mut String, snapshot: &OperationsSnapshot) {
@@ -516,7 +603,11 @@ impl<'a> Diagnostics<'a> {
 mod tests {
     use std::collections::BTreeSet;
 
+    use axum::http::{Response, StatusCode};
+
+    use crate::error::HttpFault;
     use crate::lifecycle::State as LifecycleState;
+    use crate::metrics::{HttpRoute, Rejection, RouterMetrics};
     use crate::worker_pool::{
         AdmissionClass, AdmissionSnapshot, CapacityClass, OperationsSnapshot, ProbeOutcome,
         ProbeSnapshot, SessionCapacitySnapshot, WorkerHealth, WorkerSnapshot,
@@ -656,11 +747,13 @@ mod tests {
 
     #[test]
     fn metrics_text_is_complete_exact_and_fixed_order() {
+        let metrics = RouterMetrics::new();
         let rendered = render_metrics(
             LifecycleState::Serving,
             true,
             &representative_snapshot(),
             &resources(),
+            &metrics,
         );
         assert_eq!(
             rendered,
@@ -675,6 +768,17 @@ mod tests {
                 "# HELP sglang_omni_router_ready Router readiness state.\n",
                 "# TYPE sglang_omni_router_ready gauge\n",
                 "sglang_omni_router_ready 1\n",
+                "# HELP sglang_omni_router_http_requests_total HTTP requests received.\n",
+                "# TYPE sglang_omni_router_http_requests_total counter\n",
+                "# HELP sglang_omni_router_http_response_headers_total HTTP response headers by status class.\n",
+                "# TYPE sglang_omni_router_http_response_headers_total counter\n",
+                "# HELP sglang_omni_router_http_faults_total Router-generated HTTP faults.\n",
+                "# TYPE sglang_omni_router_http_faults_total counter\n",
+                "# HELP sglang_omni_router_rejections_total Requests rejected by a saturated bounded resource.\n",
+                "# TYPE sglang_omni_router_rejections_total counter\n",
+                "# HELP sglang_omni_router_http_relay_failures_total Upstream body failures after response commitment.\n",
+                "# TYPE sglang_omni_router_http_relay_failures_total counter\n",
+                "sglang_omni_router_http_relay_failures_total 0\n",
                 "# HELP sglang_omni_router_workers_by_health Workers by health state.\n",
                 "# TYPE sglang_omni_router_workers_by_health gauge\n",
                 "sglang_omni_router_workers_by_health{health=\"unknown\"} 1\n",
@@ -740,6 +844,37 @@ mod tests {
                 "sglang_omni_router_websocket_sessions_registered 1\n",
             )
         );
+    }
+
+    #[test]
+    fn counter_metrics_use_fixed_route_fault_and_resource_labels() {
+        let metrics = RouterMetrics::new();
+        metrics.record_request(HttpRoute::Speech);
+        let mut response = Response::new(());
+        *response.status_mut() = StatusCode::TOO_MANY_REQUESTS;
+        response
+            .extensions_mut()
+            .insert(HttpFault::RouterOverloaded);
+        metrics.record_response(HttpRoute::Speech, &response);
+        metrics.record_rejection(Rejection::SpeechAdmission);
+        metrics.record_relay_failure();
+
+        let rendered = render_metrics(
+            LifecycleState::Serving,
+            true,
+            &representative_snapshot(),
+            &resources(),
+            &metrics,
+        );
+        for sample in [
+            "sglang_omni_router_http_requests_total{route=\"speech\"} 1\n",
+            "sglang_omni_router_http_response_headers_total{route=\"speech\",status=\"4xx\"} 1\n",
+            "sglang_omni_router_http_faults_total{route=\"speech\",code=\"router_overloaded\"} 1\n",
+            "sglang_omni_router_rejections_total{resource=\"admission_speech_http\"} 1\n",
+            "sglang_omni_router_http_relay_failures_total 1\n",
+        ] {
+            assert!(rendered.contains(sample), "missing metric sample: {sample}");
+        }
     }
 
     #[test]

--- a/sglang_omni_router/rust/src/operations.rs
+++ b/sglang_omni_router/rust/src/operations.rs
@@ -12,8 +12,9 @@ use crate::config::Config;
 use crate::error::{HttpFault, RouterError};
 use crate::lifecycle::State as LifecycleState;
 use crate::metrics::{
-    ClassificationKind, ClassificationOutcome, ClassificationPhase, DURATION_BUCKETS, HttpRoute,
-    Rejection, RouterMetrics, StatusClass, WebsocketPhase, WebsocketProtocol, WebsocketTermination,
+    ClassificationKind, ClassificationOutcome, ClassificationPhase, DURATION_BUCKETS,
+    HttpBodyTermination, HttpRoute, Rejection, RouterMetrics, StatusClass, WebsocketPhase,
+    WebsocketProtocol, WebsocketTermination,
 };
 use crate::worker_pool::{
     OperationsSnapshot, ProbeOutcome, ProbeSnapshot, SESSION_CAPACITY_CLASSES, WorkerHealth,
@@ -444,6 +445,19 @@ fn render_request_metrics(output: &mut String, metrics: &RouterMetrics) {
         "sglang_omni_router_http_relay_failures_total {}",
         metrics.relay_failures()
     );
+
+    output.push_str(
+        "# HELP sglang_omni_router_http_response_body_terminations_total Committed upstream response bodies by terminal outcome.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_http_response_body_terminations_total counter\n");
+    for termination in HttpBodyTermination::ALL {
+        let _ = writeln!(
+            output,
+            "sglang_omni_router_http_response_body_terminations_total{{outcome=\"{}\"}} {}",
+            termination.label(),
+            metrics.http_body_terminations(termination)
+        );
+    }
 }
 
 fn render_probe_metrics(output: &mut String, snapshot: &OperationsSnapshot) {
@@ -729,8 +743,9 @@ mod tests {
     use crate::error::HttpFault;
     use crate::lifecycle::State as LifecycleState;
     use crate::metrics::{
-        ClassificationKind, ClassificationOutcome, ClassificationPhase, HttpRoute, Rejection,
-        RouterMetrics, StatusClass, WebsocketPhase, WebsocketProtocol, WebsocketTermination,
+        ClassificationKind, ClassificationOutcome, ClassificationPhase, HttpBodyTermination,
+        HttpRoute, Rejection, RouterMetrics, StatusClass, WebsocketPhase, WebsocketProtocol,
+        WebsocketTermination,
     };
     use crate::worker_pool::{
         AdmissionClass, AdmissionSnapshot, CapacityClass, OperationsSnapshot, ProbeOutcome,
@@ -985,6 +1000,16 @@ mod tests {
                 }
             }
         }
+        for termination in HttpBodyTermination::ALL {
+            let sample = format!(
+                "sglang_omni_router_http_response_body_terminations_total{{outcome=\"{}\"}} 0\n",
+                termination.label()
+            );
+            assert!(
+                rendered.contains(&sample),
+                "missing metric sample: {sample}"
+            );
+        }
 
         let without_zero_request_samples = rendered
             .lines()
@@ -994,7 +1019,8 @@ mod tests {
                     || line.contains("sglang_omni_router_http_cancelled_before_headers_total")
                     || line.contains("sglang_omni_router_classification_duration_seconds")
                     || line.contains("sglang_omni_router_classifications_total")
-                    || line.contains("sglang_omni_router_websocket_terminations_total");
+                    || line.contains("sglang_omni_router_websocket_terminations_total")
+                    || line.contains("sglang_omni_router_http_response_body_terminations_total");
                 !new_boundary_metric
                     && !(line.ends_with(" 0")
                         && [
@@ -1124,6 +1150,7 @@ mod tests {
             WebsocketPhase::Relay,
             WebsocketTermination::WorkerClose,
         );
+        metrics.record_http_body_termination(HttpBodyTermination::UpstreamError);
         metrics.record_rejection(Rejection::SpeechAdmission);
         metrics.record_relay_failure();
 
@@ -1140,6 +1167,7 @@ mod tests {
             "sglang_omni_router_classification_duration_seconds_count{kind=\"speech\",phase=\"execution\"} 1\n",
             "sglang_omni_router_classifications_total{kind=\"speech\",outcome=\"success\"} 1\n",
             "sglang_omni_router_websocket_terminations_total{protocol=\"speech\",phase=\"relay\",reason=\"worker_close\"} 1\n",
+            "sglang_omni_router_http_response_body_terminations_total{outcome=\"upstream_error\"} 1\n",
             "sglang_omni_router_http_faults_total{route=\"speech\",code=\"router_overloaded\"} 1\n",
             "sglang_omni_router_rejections_total{resource=\"admission_speech_http\"} 1\n",
             "sglang_omni_router_http_relay_failures_total 1\n",

--- a/sglang_omni_router/rust/src/operations.rs
+++ b/sglang_omni_router/rust/src/operations.rs
@@ -13,8 +13,8 @@ use crate::error::{HttpFault, RouterError};
 use crate::lifecycle::State as LifecycleState;
 use crate::metrics::{
     ClassificationKind, ClassificationOutcome, ClassificationPhase, DURATION_BUCKETS,
-    HttpBodyTermination, HttpRoute, Rejection, RouterMetrics, StatusClass, WebsocketPhase,
-    WebsocketProtocol, WebsocketTermination,
+    DurationHistogramSnapshot, HttpBodyTermination, HttpRoute, Rejection, RouterMetrics,
+    StatusClass, WebsocketPhase, WebsocketProtocol, WebsocketTermination,
 };
 use crate::worker_pool::{
     OperationsSnapshot, ProbeOutcome, ProbeSnapshot, SESSION_CAPACITY_CLASSES, WorkerHealth,
@@ -289,33 +289,11 @@ fn render_request_metrics(output: &mut String, metrics: &RouterMetrics) {
     output.push_str("# TYPE sglang_omni_router_http_response_header_duration_seconds histogram\n");
     for route in HttpRoute::ALL {
         let histogram = metrics.response_header_duration(route);
-        let mut cumulative = 0_u64;
-        for (index, bucket) in DURATION_BUCKETS.iter().enumerate() {
-            cumulative = cumulative.saturating_add(histogram.buckets[index]);
-            let _ = writeln!(
-                output,
-                "sglang_omni_router_http_response_header_duration_seconds_bucket{{route=\"{}\",le=\"{}\"}} {cumulative}",
-                route.label(),
-                bucket.label
-            );
-        }
-        cumulative = cumulative.saturating_add(histogram.buckets[DURATION_BUCKETS.len()]);
-        let _ = writeln!(
+        render_histogram(
             output,
-            "sglang_omni_router_http_response_header_duration_seconds_bucket{{route=\"{}\",le=\"+Inf\"}} {cumulative}",
-            route.label()
-        );
-        let sum_seconds = histogram.sum_micros as f64 / 1_000_000.0;
-        let _ = writeln!(
-            output,
-            "sglang_omni_router_http_response_header_duration_seconds_sum{{route=\"{}\"}} {sum_seconds}",
-            route.label()
-        );
-        let _ = writeln!(
-            output,
-            "sglang_omni_router_http_response_header_duration_seconds_count{{route=\"{}\"}} {}",
-            route.label(),
-            histogram.count()
+            "sglang_omni_router_http_response_header_duration_seconds",
+            &[("route", route.label())],
+            &histogram,
         );
     }
 
@@ -339,37 +317,11 @@ fn render_request_metrics(output: &mut String, metrics: &RouterMetrics) {
     for kind in ClassificationKind::ALL {
         for phase in ClassificationPhase::ALL {
             let histogram = metrics.classification_duration(kind, phase);
-            let mut cumulative = 0_u64;
-            for (index, bucket) in DURATION_BUCKETS.iter().enumerate() {
-                cumulative = cumulative.saturating_add(histogram.buckets[index]);
-                let _ = writeln!(
-                    output,
-                    "sglang_omni_router_classification_duration_seconds_bucket{{kind=\"{}\",phase=\"{}\",le=\"{}\"}} {cumulative}",
-                    kind.label(),
-                    phase.label(),
-                    bucket.label
-                );
-            }
-            cumulative = cumulative.saturating_add(histogram.buckets[DURATION_BUCKETS.len()]);
-            let _ = writeln!(
+            render_histogram(
                 output,
-                "sglang_omni_router_classification_duration_seconds_bucket{{kind=\"{}\",phase=\"{}\",le=\"+Inf\"}} {cumulative}",
-                kind.label(),
-                phase.label()
-            );
-            let sum_seconds = histogram.sum_micros as f64 / 1_000_000.0;
-            let _ = writeln!(
-                output,
-                "sglang_omni_router_classification_duration_seconds_sum{{kind=\"{}\",phase=\"{}\"}} {sum_seconds}",
-                kind.label(),
-                phase.label()
-            );
-            let _ = writeln!(
-                output,
-                "sglang_omni_router_classification_duration_seconds_count{{kind=\"{}\",phase=\"{}\"}} {}",
-                kind.label(),
-                phase.label(),
-                histogram.count()
+                "sglang_omni_router_classification_duration_seconds",
+                &[("kind", kind.label()), ("phase", phase.label())],
+                &histogram,
             );
         }
     }
@@ -458,6 +410,42 @@ fn render_request_metrics(output: &mut String, metrics: &RouterMetrics) {
             metrics.http_body_terminations(termination)
         );
     }
+}
+
+fn render_histogram(
+    output: &mut String,
+    name: &str,
+    labels: &[(&str, &str)],
+    histogram: &DurationHistogramSnapshot,
+) {
+    let render_labels = |output: &mut String| {
+        for (index, (key, value)) in labels.iter().enumerate() {
+            if index != 0 {
+                output.push(',');
+            }
+            let _ = write!(output, "{key}=\"{value}\"");
+        }
+    };
+
+    let mut cumulative = 0_u64;
+    for (index, bucket) in DURATION_BUCKETS.iter().enumerate() {
+        cumulative = cumulative.saturating_add(histogram.buckets[index]);
+        let _ = write!(output, "{name}_bucket{{");
+        render_labels(output);
+        let _ = writeln!(output, ",le=\"{}\"}} {cumulative}", bucket.label);
+    }
+    cumulative = cumulative.saturating_add(histogram.buckets[DURATION_BUCKETS.len()]);
+    let _ = write!(output, "{name}_bucket{{");
+    render_labels(output);
+    let _ = writeln!(output, ",le=\"+Inf\"}} {cumulative}");
+
+    let sum_seconds = histogram.sum_micros as f64 / 1_000_000.0;
+    let _ = write!(output, "{name}_sum{{");
+    render_labels(output);
+    let _ = writeln!(output, "}} {sum_seconds}");
+    let _ = write!(output, "{name}_count{{");
+    render_labels(output);
+    let _ = writeln!(output, "}} {}", histogram.count());
 }
 
 fn render_probe_metrics(output: &mut String, snapshot: &OperationsSnapshot) {

--- a/sglang_omni_router/rust/src/operations.rs
+++ b/sglang_omni_router/rust/src/operations.rs
@@ -256,13 +256,11 @@ fn render_request_metrics(output: &mut String, metrics: &RouterMetrics) {
     output.push_str("# TYPE sglang_omni_router_http_requests_total counter\n");
     for route in HttpRoute::ALL {
         let count = metrics.requests(route);
-        if count != 0 {
-            let _ = writeln!(
-                output,
-                "sglang_omni_router_http_requests_total{{route=\"{}\"}} {count}",
-                route.label()
-            );
-        }
+        let _ = writeln!(
+            output,
+            "sglang_omni_router_http_requests_total{{route=\"{}\"}} {count}",
+            route.label()
+        );
     }
 
     output.push_str(
@@ -272,14 +270,12 @@ fn render_request_metrics(output: &mut String, metrics: &RouterMetrics) {
     for route in HttpRoute::ALL {
         for status in StatusClass::ALL {
             let count = metrics.responses(route, status);
-            if count != 0 {
-                let _ = writeln!(
-                    output,
-                    "sglang_omni_router_http_response_headers_total{{route=\"{}\",status=\"{}\"}} {count}",
-                    route.label(),
-                    status.label()
-                );
-            }
+            let _ = writeln!(
+                output,
+                "sglang_omni_router_http_response_headers_total{{route=\"{}\",status=\"{}\"}} {count}",
+                route.label(),
+                status.label()
+            );
         }
     }
 
@@ -288,14 +284,12 @@ fn render_request_metrics(output: &mut String, metrics: &RouterMetrics) {
     for route in HttpRoute::ALL {
         for fault in HttpFault::ALL {
             let count = metrics.faults(route, fault);
-            if count != 0 {
-                let _ = writeln!(
-                    output,
-                    "sglang_omni_router_http_faults_total{{route=\"{}\",code=\"{}\"}} {count}",
-                    route.label(),
-                    fault.code()
-                );
-            }
+            let _ = writeln!(
+                output,
+                "sglang_omni_router_http_faults_total{{route=\"{}\",code=\"{}\"}} {count}",
+                route.label(),
+                fault.code()
+            );
         }
     }
 
@@ -305,13 +299,11 @@ fn render_request_metrics(output: &mut String, metrics: &RouterMetrics) {
     output.push_str("# TYPE sglang_omni_router_rejections_total counter\n");
     for rejection in Rejection::ALL {
         let count = metrics.rejections(rejection);
-        if count != 0 {
-            let _ = writeln!(
-                output,
-                "sglang_omni_router_rejections_total{{resource=\"{}\"}} {count}",
-                rejection.label()
-            );
-        }
+        let _ = writeln!(
+            output,
+            "sglang_omni_router_rejections_total{{resource=\"{}\"}} {count}",
+            rejection.label()
+        );
     }
 
     output.push_str(
@@ -607,7 +599,7 @@ mod tests {
 
     use crate::error::HttpFault;
     use crate::lifecycle::State as LifecycleState;
-    use crate::metrics::{HttpRoute, Rejection, RouterMetrics};
+    use crate::metrics::{HttpRoute, Rejection, RouterMetrics, StatusClass};
     use crate::worker_pool::{
         AdmissionClass, AdmissionSnapshot, CapacityClass, OperationsSnapshot, ProbeOutcome,
         ProbeSnapshot, SessionCapacitySnapshot, WorkerHealth, WorkerSnapshot,
@@ -755,8 +747,62 @@ mod tests {
             &resources(),
             &metrics,
         );
+        let mut positions = Vec::new();
+        for route in HttpRoute::ALL {
+            let sample = format!(
+                "sglang_omni_router_http_requests_total{{route=\"{}\"}} 0\n",
+                route.label()
+            );
+            positions.push(rendered.find(&sample).expect("zero request sample"));
+        }
+        for route in HttpRoute::ALL {
+            for status in StatusClass::ALL {
+                let sample = format!(
+                    "sglang_omni_router_http_response_headers_total{{route=\"{}\",status=\"{}\"}} 0\n",
+                    route.label(),
+                    status.label()
+                );
+                positions.push(rendered.find(&sample).expect("zero response sample"));
+            }
+        }
+        for route in HttpRoute::ALL {
+            for fault in HttpFault::ALL {
+                let sample = format!(
+                    "sglang_omni_router_http_faults_total{{route=\"{}\",code=\"{}\"}} 0\n",
+                    route.label(),
+                    fault.code()
+                );
+                positions.push(rendered.find(&sample).expect("zero fault sample"));
+            }
+        }
+        for rejection in Rejection::ALL {
+            let sample = format!(
+                "sglang_omni_router_rejections_total{{resource=\"{}\"}} 0\n",
+                rejection.label()
+            );
+            positions.push(rendered.find(&sample).expect("zero rejection sample"));
+        }
+        assert_eq!(positions.len(), 340);
+        assert!(positions.windows(2).all(|pair| pair[0] < pair[1]));
+
+        let without_zero_request_samples = rendered
+            .lines()
+            .filter(|line| {
+                !(line.ends_with(" 0")
+                    && [
+                        "sglang_omni_router_http_requests_total{",
+                        "sglang_omni_router_http_response_headers_total{",
+                        "sglang_omni_router_http_faults_total{",
+                        "sglang_omni_router_rejections_total{",
+                    ]
+                    .iter()
+                    .any(|prefix| line.starts_with(prefix)))
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
         assert_eq!(
-            rendered,
+            without_zero_request_samples,
             concat!(
                 "# HELP sglang_omni_router_lifecycle Router lifecycle state.\n",
                 "# TYPE sglang_omni_router_lifecycle gauge\n",

--- a/sglang_omni_router/rust/src/operations.rs
+++ b/sglang_omni_router/rust/src/operations.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use crate::config::Config;
 use crate::error::{HttpFault, RouterError};
 use crate::lifecycle::State as LifecycleState;
-use crate::metrics::{HttpRoute, Rejection, RouterMetrics, StatusClass};
+use crate::metrics::{DURATION_BUCKETS, HttpRoute, Rejection, RouterMetrics, StatusClass};
 use crate::worker_pool::{
     OperationsSnapshot, ProbeOutcome, ProbeSnapshot, SESSION_CAPACITY_CLASSES, WorkerHealth,
 };
@@ -277,6 +277,55 @@ fn render_request_metrics(output: &mut String, metrics: &RouterMetrics) {
                 status.label()
             );
         }
+    }
+
+    output.push_str(
+        "# HELP sglang_omni_router_http_response_header_duration_seconds Time from request boundary entry until response headers are available.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_http_response_header_duration_seconds histogram\n");
+    for route in HttpRoute::ALL {
+        let histogram = metrics.response_header_duration(route);
+        let mut cumulative = 0_u64;
+        for (index, bucket) in DURATION_BUCKETS.iter().enumerate() {
+            cumulative = cumulative.saturating_add(histogram.buckets[index]);
+            let _ = writeln!(
+                output,
+                "sglang_omni_router_http_response_header_duration_seconds_bucket{{route=\"{}\",le=\"{}\"}} {cumulative}",
+                route.label(),
+                bucket.label
+            );
+        }
+        cumulative = cumulative.saturating_add(histogram.buckets[DURATION_BUCKETS.len()]);
+        let _ = writeln!(
+            output,
+            "sglang_omni_router_http_response_header_duration_seconds_bucket{{route=\"{}\",le=\"+Inf\"}} {cumulative}",
+            route.label()
+        );
+        let sum_seconds = histogram.sum_micros as f64 / 1_000_000.0;
+        let _ = writeln!(
+            output,
+            "sglang_omni_router_http_response_header_duration_seconds_sum{{route=\"{}\"}} {sum_seconds}",
+            route.label()
+        );
+        let _ = writeln!(
+            output,
+            "sglang_omni_router_http_response_header_duration_seconds_count{{route=\"{}\"}} {}",
+            route.label(),
+            histogram.count()
+        );
+    }
+
+    output.push_str(
+        "# HELP sglang_omni_router_http_cancelled_before_headers_total Requests cancelled before response headers became available.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_http_cancelled_before_headers_total counter\n");
+    for route in HttpRoute::ALL {
+        let _ = writeln!(
+            output,
+            "sglang_omni_router_http_cancelled_before_headers_total{{route=\"{}\"}} {}",
+            route.label(),
+            metrics.cancelled_before_headers(route)
+        );
     }
 
     output.push_str("# HELP sglang_omni_router_http_faults_total Router-generated HTTP faults.\n");
@@ -784,19 +833,44 @@ mod tests {
         }
         assert_eq!(positions.len(), 340);
         assert!(positions.windows(2).all(|pair| pair[0] < pair[1]));
+        for route in HttpRoute::ALL {
+            for sample in [
+                format!(
+                    "sglang_omni_router_http_response_header_duration_seconds_bucket{{route=\"{}\",le=\"+Inf\"}} 0\n",
+                    route.label()
+                ),
+                format!(
+                    "sglang_omni_router_http_response_header_duration_seconds_count{{route=\"{}\"}} 0\n",
+                    route.label()
+                ),
+                format!(
+                    "sglang_omni_router_http_cancelled_before_headers_total{{route=\"{}\"}} 0\n",
+                    route.label()
+                ),
+            ] {
+                assert!(
+                    rendered.contains(&sample),
+                    "missing metric sample: {sample}"
+                );
+            }
+        }
 
         let without_zero_request_samples = rendered
             .lines()
             .filter(|line| {
-                !(line.ends_with(" 0")
-                    && [
-                        "sglang_omni_router_http_requests_total{",
-                        "sglang_omni_router_http_response_headers_total{",
-                        "sglang_omni_router_http_faults_total{",
-                        "sglang_omni_router_rejections_total{",
-                    ]
-                    .iter()
-                    .any(|prefix| line.starts_with(prefix)))
+                let new_boundary_metric = line
+                    .contains("sglang_omni_router_http_response_header_duration_seconds")
+                    || line.contains("sglang_omni_router_http_cancelled_before_headers_total");
+                !new_boundary_metric
+                    && !(line.ends_with(" 0")
+                        && [
+                            "sglang_omni_router_http_requests_total{",
+                            "sglang_omni_router_http_response_headers_total{",
+                            "sglang_omni_router_http_faults_total{",
+                            "sglang_omni_router_rejections_total{",
+                        ]
+                        .iter()
+                        .any(|prefix| line.starts_with(prefix)))
             })
             .collect::<Vec<_>>()
             .join("\n")

--- a/sglang_omni_router/rust/src/operations.rs
+++ b/sglang_omni_router/rust/src/operations.rs
@@ -731,9 +731,9 @@ mod tests {
     use crate::error::HttpFault;
     use crate::lifecycle::State as LifecycleState;
     use crate::metrics::{
-        ClassificationKind, ClassificationOutcome, ClassificationPhase, HttpBodyTermination,
-        HttpRoute, Rejection, RouterMetrics, StatusClass, WebsocketPhase, WebsocketProtocol,
-        WebsocketTermination,
+        ClassificationKind, ClassificationOutcome, ClassificationPhase, DURATION_BUCKET_COUNT,
+        DurationHistogramSnapshot, HttpBodyTermination, HttpRoute, Rejection, RouterMetrics,
+        StatusClass, WebsocketPhase, WebsocketProtocol, WebsocketTermination,
     };
     use crate::worker_pool::{
         AdmissionClass, AdmissionSnapshot, CapacityClass, OperationsSnapshot, ProbeOutcome,
@@ -741,8 +741,8 @@ mod tests {
     };
 
     use super::{
-        Diagnostics, ResourceSnapshot, ResourceUsage, render_metrics, render_model_sources,
-        render_models,
+        Diagnostics, ResourceSnapshot, ResourceUsage, render_histogram, render_metrics,
+        render_model_sources, render_models,
     };
 
     fn admission(class: AdmissionClass, limit: usize, in_flight: usize) -> AdmissionSnapshot {
@@ -1162,6 +1162,68 @@ mod tests {
         ] {
             assert!(rendered.contains(sample), "missing metric sample: {sample}");
         }
+    }
+
+    #[test]
+    fn histograms_render_exact_cumulative_buckets_and_labels() {
+        let mut buckets = [0_u64; DURATION_BUCKET_COUNT];
+        buckets[0] = 2;
+        buckets[2] = 3;
+        buckets[DURATION_BUCKET_COUNT - 1] = 5;
+        let histogram = DurationHistogramSnapshot {
+            buckets,
+            sum_micros: 1_250_000_000,
+        };
+
+        let mut one_label = String::new();
+        render_histogram(&mut one_label, "one", &[("route", "speech")], &histogram);
+        let lines: Vec<_> = one_label.lines().collect();
+        assert_eq!(lines.len(), DURATION_BUCKET_COUNT + 2);
+        assert_eq!(lines[0], "one_bucket{route=\"speech\",le=\"0.00001\"} 2");
+        assert_eq!(lines[1], "one_bucket{route=\"speech\",le=\"0.000025\"} 2");
+        assert_eq!(lines[2], "one_bucket{route=\"speech\",le=\"0.00005\"} 5");
+        assert_eq!(
+            lines[DURATION_BUCKET_COUNT - 2],
+            "one_bucket{route=\"speech\",le=\"240\"} 5"
+        );
+        assert_eq!(
+            lines[DURATION_BUCKET_COUNT - 1],
+            "one_bucket{route=\"speech\",le=\"+Inf\"} 10"
+        );
+        assert_eq!(
+            lines[DURATION_BUCKET_COUNT],
+            "one_sum{route=\"speech\"} 1250"
+        );
+        assert_eq!(
+            lines[DURATION_BUCKET_COUNT + 1],
+            "one_count{route=\"speech\"} 10"
+        );
+
+        let mut two_labels = String::new();
+        render_histogram(
+            &mut two_labels,
+            "two",
+            &[("kind", "speech"), ("phase", "execution")],
+            &histogram,
+        );
+        let lines: Vec<_> = two_labels.lines().collect();
+        assert_eq!(lines.len(), DURATION_BUCKET_COUNT + 2);
+        assert_eq!(
+            lines[0],
+            "two_bucket{kind=\"speech\",phase=\"execution\",le=\"0.00001\"} 2"
+        );
+        assert_eq!(
+            lines[DURATION_BUCKET_COUNT - 1],
+            "two_bucket{kind=\"speech\",phase=\"execution\",le=\"+Inf\"} 10"
+        );
+        assert_eq!(
+            lines[DURATION_BUCKET_COUNT],
+            "two_sum{kind=\"speech\",phase=\"execution\"} 1250"
+        );
+        assert_eq!(
+            lines[DURATION_BUCKET_COUNT + 1],
+            "two_count{kind=\"speech\",phase=\"execution\"} 10"
+        );
     }
 
     #[test]

--- a/sglang_omni_router/rust/src/operations.rs
+++ b/sglang_omni_router/rust/src/operations.rs
@@ -504,7 +504,7 @@ fn render_worker_metrics(output: &mut String, snapshot: &OperationsSnapshot) {
         .map(|worker| worker.active_requests)
         .sum();
     output.push_str(
-        "# HELP sglang_omni_router_worker_active_requests Aggregate active worker load; speech batches are item-weighted.\n",
+        "# HELP sglang_omni_router_worker_active_requests Aggregate active worker load. Speech batches are item-weighted.\n",
     );
     output.push_str("# TYPE sglang_omni_router_worker_active_requests gauge\n");
     let _ = writeln!(
@@ -1078,7 +1078,7 @@ mod tests {
                 "sglang_omni_router_admission_in_flight{class=\"transcription_http\"} 4\n",
                 "sglang_omni_router_admission_in_flight{class=\"speech_websocket\"} 5\n",
                 "sglang_omni_router_admission_in_flight{class=\"realtime_websocket\"} 6\n",
-                "# HELP sglang_omni_router_worker_active_requests Aggregate active worker load; speech batches are item-weighted.\n",
+                "# HELP sglang_omni_router_worker_active_requests Aggregate active worker load. Speech batches are item-weighted.\n",
                 "# TYPE sglang_omni_router_worker_active_requests gauge\n",
                 "sglang_omni_router_worker_active_requests 4\n",
                 "# HELP sglang_omni_router_worker_capacity_limit Aggregate configured worker capacity.\n",

--- a/sglang_omni_router/rust/src/operations.rs
+++ b/sglang_omni_router/rust/src/operations.rs
@@ -13,7 +13,7 @@ use crate::error::{HttpFault, RouterError};
 use crate::lifecycle::State as LifecycleState;
 use crate::metrics::{
     ClassificationKind, ClassificationOutcome, ClassificationPhase, DURATION_BUCKETS, HttpRoute,
-    Rejection, RouterMetrics, StatusClass,
+    Rejection, RouterMetrics, StatusClass, WebsocketPhase, WebsocketProtocol, WebsocketTermination,
 };
 use crate::worker_pool::{
     OperationsSnapshot, ProbeOutcome, ProbeSnapshot, SESSION_CAPACITY_CLASSES, WorkerHealth,
@@ -389,6 +389,25 @@ fn render_request_metrics(output: &mut String, metrics: &RouterMetrics) {
         }
     }
 
+    output.push_str(
+        "# HELP sglang_omni_router_websocket_terminations_total Upgraded WebSocket sessions by terminal phase and reason.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_websocket_terminations_total counter\n");
+    for protocol in WebsocketProtocol::ALL {
+        for phase in WebsocketPhase::ALL {
+            for termination in WebsocketTermination::ALL {
+                let _ = writeln!(
+                    output,
+                    "sglang_omni_router_websocket_terminations_total{{protocol=\"{}\",phase=\"{}\",reason=\"{}\"}} {}",
+                    protocol.label(),
+                    phase.label(),
+                    termination.label(),
+                    metrics.websocket_terminations(protocol, phase, termination)
+                );
+            }
+        }
+    }
+
     output.push_str("# HELP sglang_omni_router_http_faults_total Router-generated HTTP faults.\n");
     output.push_str("# TYPE sglang_omni_router_http_faults_total counter\n");
     for route in HttpRoute::ALL {
@@ -711,7 +730,7 @@ mod tests {
     use crate::lifecycle::State as LifecycleState;
     use crate::metrics::{
         ClassificationKind, ClassificationOutcome, ClassificationPhase, HttpRoute, Rejection,
-        RouterMetrics, StatusClass,
+        RouterMetrics, StatusClass, WebsocketPhase, WebsocketProtocol, WebsocketTermination,
     };
     use crate::worker_pool::{
         AdmissionClass, AdmissionSnapshot, CapacityClass, OperationsSnapshot, ProbeOutcome,
@@ -950,6 +969,22 @@ mod tests {
                 );
             }
         }
+        for protocol in WebsocketProtocol::ALL {
+            for phase in WebsocketPhase::ALL {
+                for termination in WebsocketTermination::ALL {
+                    let sample = format!(
+                        "sglang_omni_router_websocket_terminations_total{{protocol=\"{}\",phase=\"{}\",reason=\"{}\"}} 0\n",
+                        protocol.label(),
+                        phase.label(),
+                        termination.label()
+                    );
+                    assert!(
+                        rendered.contains(&sample),
+                        "missing metric sample: {sample}"
+                    );
+                }
+            }
+        }
 
         let without_zero_request_samples = rendered
             .lines()
@@ -958,7 +993,8 @@ mod tests {
                     .contains("sglang_omni_router_http_response_header_duration_seconds")
                     || line.contains("sglang_omni_router_http_cancelled_before_headers_total")
                     || line.contains("sglang_omni_router_classification_duration_seconds")
-                    || line.contains("sglang_omni_router_classifications_total");
+                    || line.contains("sglang_omni_router_classifications_total")
+                    || line.contains("sglang_omni_router_websocket_terminations_total");
                 !new_boundary_metric
                     && !(line.ends_with(" 0")
                         && [
@@ -1083,6 +1119,11 @@ mod tests {
             ClassificationKind::Speech,
             ClassificationOutcome::Success,
         );
+        metrics.record_websocket_termination(
+            WebsocketProtocol::Speech,
+            WebsocketPhase::Relay,
+            WebsocketTermination::WorkerClose,
+        );
         metrics.record_rejection(Rejection::SpeechAdmission);
         metrics.record_relay_failure();
 
@@ -1098,6 +1139,7 @@ mod tests {
             "sglang_omni_router_http_response_headers_total{route=\"speech\",status=\"4xx\"} 1\n",
             "sglang_omni_router_classification_duration_seconds_count{kind=\"speech\",phase=\"execution\"} 1\n",
             "sglang_omni_router_classifications_total{kind=\"speech\",outcome=\"success\"} 1\n",
+            "sglang_omni_router_websocket_terminations_total{protocol=\"speech\",phase=\"relay\",reason=\"worker_close\"} 1\n",
             "sglang_omni_router_http_faults_total{route=\"speech\",code=\"router_overloaded\"} 1\n",
             "sglang_omni_router_rejections_total{resource=\"admission_speech_http\"} 1\n",
             "sglang_omni_router_http_relay_failures_total 1\n",

--- a/sglang_omni_router/rust/src/operations.rs
+++ b/sglang_omni_router/rust/src/operations.rs
@@ -11,7 +11,10 @@ use serde::Serialize;
 use crate::config::Config;
 use crate::error::{HttpFault, RouterError};
 use crate::lifecycle::State as LifecycleState;
-use crate::metrics::{DURATION_BUCKETS, HttpRoute, Rejection, RouterMetrics, StatusClass};
+use crate::metrics::{
+    ClassificationKind, ClassificationOutcome, ClassificationPhase, DURATION_BUCKETS, HttpRoute,
+    Rejection, RouterMetrics, StatusClass,
+};
 use crate::worker_pool::{
     OperationsSnapshot, ProbeOutcome, ProbeSnapshot, SESSION_CAPACITY_CLASSES, WorkerHealth,
 };
@@ -326,6 +329,64 @@ fn render_request_metrics(output: &mut String, metrics: &RouterMetrics) {
             route.label(),
             metrics.cancelled_before_headers(route)
         );
+    }
+
+    output.push_str(
+        "# HELP sglang_omni_router_classification_duration_seconds Classification phase duration.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_classification_duration_seconds histogram\n");
+    for kind in ClassificationKind::ALL {
+        for phase in ClassificationPhase::ALL {
+            let histogram = metrics.classification_duration(kind, phase);
+            let mut cumulative = 0_u64;
+            for (index, bucket) in DURATION_BUCKETS.iter().enumerate() {
+                cumulative = cumulative.saturating_add(histogram.buckets[index]);
+                let _ = writeln!(
+                    output,
+                    "sglang_omni_router_classification_duration_seconds_bucket{{kind=\"{}\",phase=\"{}\",le=\"{}\"}} {cumulative}",
+                    kind.label(),
+                    phase.label(),
+                    bucket.label
+                );
+            }
+            cumulative = cumulative.saturating_add(histogram.buckets[DURATION_BUCKETS.len()]);
+            let _ = writeln!(
+                output,
+                "sglang_omni_router_classification_duration_seconds_bucket{{kind=\"{}\",phase=\"{}\",le=\"+Inf\"}} {cumulative}",
+                kind.label(),
+                phase.label()
+            );
+            let sum_seconds = histogram.sum_micros as f64 / 1_000_000.0;
+            let _ = writeln!(
+                output,
+                "sglang_omni_router_classification_duration_seconds_sum{{kind=\"{}\",phase=\"{}\"}} {sum_seconds}",
+                kind.label(),
+                phase.label()
+            );
+            let _ = writeln!(
+                output,
+                "sglang_omni_router_classification_duration_seconds_count{{kind=\"{}\",phase=\"{}\"}} {}",
+                kind.label(),
+                phase.label(),
+                histogram.count()
+            );
+        }
+    }
+
+    output.push_str(
+        "# HELP sglang_omni_router_classifications_total Classification calls by outcome.\n",
+    );
+    output.push_str("# TYPE sglang_omni_router_classifications_total counter\n");
+    for kind in ClassificationKind::ALL {
+        for outcome in ClassificationOutcome::ALL {
+            let _ = writeln!(
+                output,
+                "sglang_omni_router_classifications_total{{kind=\"{}\",outcome=\"{}\"}} {}",
+                kind.label(),
+                outcome.label(),
+                metrics.classification_outcome(kind, outcome)
+            );
+        }
     }
 
     output.push_str("# HELP sglang_omni_router_http_faults_total Router-generated HTTP faults.\n");
@@ -648,7 +709,10 @@ mod tests {
 
     use crate::error::HttpFault;
     use crate::lifecycle::State as LifecycleState;
-    use crate::metrics::{HttpRoute, Rejection, RouterMetrics, StatusClass};
+    use crate::metrics::{
+        ClassificationKind, ClassificationOutcome, ClassificationPhase, HttpRoute, Rejection,
+        RouterMetrics, StatusClass,
+    };
     use crate::worker_pool::{
         AdmissionClass, AdmissionSnapshot, CapacityClass, OperationsSnapshot, ProbeOutcome,
         ProbeSnapshot, SessionCapacitySnapshot, WorkerHealth, WorkerSnapshot,
@@ -854,13 +918,47 @@ mod tests {
                 );
             }
         }
+        for kind in ClassificationKind::ALL {
+            for phase in ClassificationPhase::ALL {
+                for sample in [
+                    format!(
+                        "sglang_omni_router_classification_duration_seconds_bucket{{kind=\"{}\",phase=\"{}\",le=\"+Inf\"}} 0\n",
+                        kind.label(),
+                        phase.label()
+                    ),
+                    format!(
+                        "sglang_omni_router_classification_duration_seconds_count{{kind=\"{}\",phase=\"{}\"}} 0\n",
+                        kind.label(),
+                        phase.label()
+                    ),
+                ] {
+                    assert!(
+                        rendered.contains(&sample),
+                        "missing metric sample: {sample}"
+                    );
+                }
+            }
+            for outcome in ClassificationOutcome::ALL {
+                let sample = format!(
+                    "sglang_omni_router_classifications_total{{kind=\"{}\",outcome=\"{}\"}} 0\n",
+                    kind.label(),
+                    outcome.label()
+                );
+                assert!(
+                    rendered.contains(&sample),
+                    "missing metric sample: {sample}"
+                );
+            }
+        }
 
         let without_zero_request_samples = rendered
             .lines()
             .filter(|line| {
                 let new_boundary_metric = line
                     .contains("sglang_omni_router_http_response_header_duration_seconds")
-                    || line.contains("sglang_omni_router_http_cancelled_before_headers_total");
+                    || line.contains("sglang_omni_router_http_cancelled_before_headers_total")
+                    || line.contains("sglang_omni_router_classification_duration_seconds")
+                    || line.contains("sglang_omni_router_classifications_total");
                 !new_boundary_metric
                     && !(line.ends_with(" 0")
                         && [
@@ -976,6 +1074,15 @@ mod tests {
             .extensions_mut()
             .insert(HttpFault::RouterOverloaded);
         metrics.record_response(HttpRoute::Speech, &response);
+        metrics.record_classification_duration(
+            ClassificationKind::Speech,
+            ClassificationPhase::Execution,
+            std::time::Duration::from_millis(1),
+        );
+        metrics.record_classification_outcome(
+            ClassificationKind::Speech,
+            ClassificationOutcome::Success,
+        );
         metrics.record_rejection(Rejection::SpeechAdmission);
         metrics.record_relay_failure();
 
@@ -989,6 +1096,8 @@ mod tests {
         for sample in [
             "sglang_omni_router_http_requests_total{route=\"speech\"} 1\n",
             "sglang_omni_router_http_response_headers_total{route=\"speech\",status=\"4xx\"} 1\n",
+            "sglang_omni_router_classification_duration_seconds_count{kind=\"speech\",phase=\"execution\"} 1\n",
+            "sglang_omni_router_classifications_total{kind=\"speech\",outcome=\"success\"} 1\n",
             "sglang_omni_router_http_faults_total{route=\"speech\",code=\"router_overloaded\"} 1\n",
             "sglang_omni_router_rejections_total{resource=\"admission_speech_http\"} 1\n",
             "sglang_omni_router_http_relay_failures_total 1\n",

--- a/sglang_omni_router/rust/src/request_id.rs
+++ b/sglang_omni_router/rust/src/request_id.rs
@@ -8,6 +8,7 @@ use axum::http::{HeaderMap, HeaderValue, Response};
 use axum::middleware::Next;
 
 use crate::error::HttpFault;
+use crate::metrics::{HttpRoute, RouterMetrics};
 
 pub(crate) const REQUEST_ID_HEADER: &str = "x-request-id";
 const MAX_REQUEST_ID_BYTES: usize = 128;
@@ -26,6 +27,20 @@ impl CanonicalRequestId {
 pub(crate) struct RequestIds {
     prefix: String,
     sequence: AtomicU64,
+}
+
+pub(crate) struct RequestBoundary {
+    request_ids: Arc<RequestIds>,
+    metrics: Arc<RouterMetrics>,
+}
+
+impl RequestBoundary {
+    pub(crate) fn new(request_ids: Arc<RequestIds>, metrics: Arc<RouterMetrics>) -> Arc<Self> {
+        Arc::new(Self {
+            request_ids,
+            metrics,
+        })
+    }
 }
 
 impl RequestIds {
@@ -60,29 +75,34 @@ impl RequestIds {
 }
 
 pub(crate) async fn canonicalize(
-    State(request_ids): State<Arc<RequestIds>>,
+    State(boundary): State<Arc<RequestBoundary>>,
     mut request: Request,
     next: Next,
 ) -> Response<Body> {
-    let Some((request_id, accepted)) = request_ids.canonicalize(request.headers()) else {
-        return HttpFault::InternalError.into_response();
+    let route = HttpRoute::from_path(request.uri().path());
+    boundary.metrics.record_request(route);
+    let response = match boundary.request_ids.canonicalize(request.headers()) {
+        None => HttpFault::InternalError.into_response(),
+        Some((request_id, false)) => {
+            let mut response = HttpFault::MalformedRequest.into_response();
+            response
+                .headers_mut()
+                .insert(REQUEST_ID_HEADER, request_id.0);
+            response
+        }
+        Some((request_id, true)) => {
+            request
+                .headers_mut()
+                .insert(REQUEST_ID_HEADER, request_id.0.clone());
+            request.extensions_mut().insert(request_id.clone());
+            let mut response = next.run(request).await;
+            response
+                .headers_mut()
+                .insert(REQUEST_ID_HEADER, request_id.0);
+            response
+        }
     };
-    if !accepted {
-        let mut response = HttpFault::MalformedRequest.into_response();
-        response
-            .headers_mut()
-            .insert(REQUEST_ID_HEADER, request_id.0);
-        return response;
-    }
-
-    request
-        .headers_mut()
-        .insert(REQUEST_ID_HEADER, request_id.0.clone());
-    request.extensions_mut().insert(request_id.clone());
-    let mut response = next.run(request).await;
-    response
-        .headers_mut()
-        .insert(REQUEST_ID_HEADER, request_id.0);
+    boundary.metrics.record_response(route, &response);
     response
 }
 

--- a/sglang_omni_router/rust/src/request_id.rs
+++ b/sglang_omni_router/rust/src/request_id.rs
@@ -1,6 +1,7 @@
 use std::hash::{BuildHasher, RandomState};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
 use axum::body::Body;
 use axum::extract::{Request, State};
@@ -32,6 +33,39 @@ pub(crate) struct RequestIds {
 pub(crate) struct RequestBoundary {
     request_ids: Arc<RequestIds>,
     metrics: Arc<RouterMetrics>,
+}
+
+struct BoundaryObservation<'a> {
+    metrics: &'a RouterMetrics,
+    route: HttpRoute,
+    started: Instant,
+    completed: bool,
+}
+
+impl<'a> BoundaryObservation<'a> {
+    fn new(metrics: &'a RouterMetrics, route: HttpRoute) -> Self {
+        Self {
+            metrics,
+            route,
+            started: Instant::now(),
+            completed: false,
+        }
+    }
+
+    fn complete<B>(&mut self, response: &Response<B>) {
+        self.metrics.record_response(self.route, response);
+        self.metrics
+            .record_response_header_duration(self.route, self.started.elapsed());
+        self.completed = true;
+    }
+}
+
+impl Drop for BoundaryObservation<'_> {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.metrics.record_cancelled_before_headers(self.route);
+        }
+    }
 }
 
 impl RequestBoundary {
@@ -80,6 +114,7 @@ pub(crate) async fn canonicalize(
     next: Next,
 ) -> Response<Body> {
     let route = HttpRoute::from_path(request.uri().path());
+    let mut observation = BoundaryObservation::new(&boundary.metrics, route);
     boundary.metrics.record_request(route);
     let response = match boundary.request_ids.canonicalize(request.headers()) {
         None => HttpFault::InternalError.into_response(),
@@ -102,7 +137,7 @@ pub(crate) async fn canonicalize(
             response
         }
     };
-    boundary.metrics.record_response(route, &response);
+    observation.complete(&response);
     response
 }
 
@@ -120,9 +155,11 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::AtomicU64;
 
-    use axum::http::{HeaderMap, HeaderValue};
+    use axum::body::Body;
+    use axum::http::{HeaderMap, HeaderValue, Response};
 
-    use super::{RequestIds, valid};
+    use super::{BoundaryObservation, RequestIds, valid};
+    use crate::metrics::{HttpRoute, RouterMetrics};
 
     #[test]
     fn missing_valid_and_invalid_ids_have_one_authority() {
@@ -192,5 +229,22 @@ mod tests {
         };
         assert!(exhausted.generate().is_none());
         assert!(exhausted.generate().is_none());
+    }
+
+    #[test]
+    fn boundary_observation_distinguishes_response_headers_from_cancellation() {
+        let metrics = RouterMetrics::new();
+        {
+            let _cancelled = BoundaryObservation::new(&metrics, HttpRoute::Chat);
+        }
+        assert_eq!(metrics.cancelled_before_headers(HttpRoute::Chat), 1);
+        assert_eq!(metrics.response_header_duration(HttpRoute::Chat).count(), 0);
+
+        {
+            let mut completed = BoundaryObservation::new(&metrics, HttpRoute::Chat);
+            completed.complete(&Response::new(Body::empty()));
+        }
+        assert_eq!(metrics.cancelled_before_headers(HttpRoute::Chat), 1);
+        assert_eq!(metrics.response_header_duration(HttpRoute::Chat).count(), 1);
     }
 }

--- a/sglang_omni_router/rust/src/server.rs
+++ b/sglang_omni_router/rust/src/server.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::Router;
+use axum::body::Body;
 use axum::extract::State;
-use axum::http::StatusCode;
+use axum::http::{HeaderValue, Method, Request, Response, StatusCode, Version};
 use axum::middleware;
 use axum::routing::{any, get};
 use hyper::server::conn::http1;
@@ -16,11 +17,12 @@ use tracing::{error, info, trace};
 
 use crate::classification::ClassificationExecutor;
 use crate::config::{Config, HttpMediaRoute};
-use crate::error::RouterError;
+use crate::error::{HttpFault, RouterError};
 use crate::http_generation::{self, HttpGeneration};
 use crate::http_media::{self, HttpMedia};
 use crate::http_relay::HttpRelay;
 use crate::lifecycle::Lifecycle;
+use crate::operations::Operations;
 use crate::request_id::{self, RequestIds};
 use crate::shutdown;
 use crate::websocket::{self, SessionTracker, WebsocketGateway};
@@ -37,9 +39,26 @@ const READY_BODY: &str = "ready\n";
 #[derive(Clone)]
 struct AppState {
     lifecycle: Arc<Lifecycle>,
+    pool: Arc<WorkerPool>,
     generation: Option<Arc<HttpGeneration>>,
     media: Option<Arc<HttpMedia>>,
     websocket: Option<Arc<WebsocketGateway>>,
+    operations: Arc<Operations>,
+}
+
+impl AppState {
+    fn is_ready(&self) -> bool {
+        self.lifecycle.is_serving()
+            && self
+                .generation
+                .as_ref()
+                .is_none_or(|generation| generation.is_ready())
+            && self.media.as_ref().is_none_or(|media| media.is_ready())
+            && self
+                .websocket
+                .as_ref()
+                .is_none_or(|websocket| websocket.is_ready())
+    }
 }
 
 pub(crate) async fn serve(config: Config) -> Result<(), RouterError> {
@@ -59,14 +78,17 @@ pub(crate) async fn serve(config: Config) -> Result<(), RouterError> {
     let sessions = SessionTracker::new();
     let websocket =
         WebsocketGateway::build(&config, Arc::clone(&pool), classifier, sessions.clone());
+    let operations = Arc::new(Operations::build(&config)?);
     let request_ids = RequestIds::new();
     let mut signal_observer = shutdown::SignalObserver::install().map_err(RouterError::Signal)?;
     let app = route_table(
         AppState {
             lifecycle: Arc::clone(&lifecycle),
+            pool: Arc::clone(&pool),
             generation: generation.clone(),
             media: media.clone(),
             websocket: websocket.clone(),
+            operations,
         },
         generation,
         media,
@@ -331,7 +353,7 @@ fn route_table(
     let mut app = Router::new()
         .route("/live", get(live).head(reject_head))
         .route("/ready", get(ready).head(reject_head))
-        .with_state(state);
+        .with_state(state.clone());
     if let Some(generation) = generation {
         app = app.route(
             http_generation::CHAT_PATH,
@@ -392,6 +414,10 @@ fn route_table(
             );
         }
     }
+    app = app
+        .route("/v1/models", any(models).with_state(state.clone()))
+        .route("/metrics", any(metrics).with_state(state.clone()))
+        .route("/diagnostics", any(diagnostics).with_state(state));
     app.layer(middleware::from_fn_with_state(
         request_ids,
         request_id::canonicalize,
@@ -407,20 +433,67 @@ async fn live(State(state): State<AppState>) -> (StatusCode, &'static str) {
 }
 
 async fn ready(State(state): State<AppState>) -> (StatusCode, &'static str) {
-    if state.lifecycle.is_serving()
-        && state
-            .generation
-            .as_ref()
-            .is_none_or(|generation| generation.is_ready())
-        && state.media.as_ref().is_none_or(|media| media.is_ready())
-        && state
-            .websocket
-            .as_ref()
-            .is_none_or(|websocket| websocket.is_ready())
-    {
+    if state.is_ready() {
         (StatusCode::OK, READY_BODY)
     } else {
         (StatusCode::SERVICE_UNAVAILABLE, NOT_READY_BODY)
+    }
+}
+
+async fn models(State(state): State<AppState>, request: Request<Body>) -> Response<Body> {
+    if let Err(fault) = validate_operation(&request) {
+        return operation_fault(fault);
+    }
+    state.operations.models_response()
+}
+
+async fn metrics(State(state): State<AppState>, request: Request<Body>) -> Response<Body> {
+    if let Err(fault) = validate_operation(&request) {
+        return operation_fault(fault);
+    }
+    let lifecycle = match state.lifecycle.snapshot() {
+        Ok(lifecycle) => lifecycle,
+        Err(_) => return HttpFault::InternalError.into_response(),
+    };
+    let snapshot = state.pool.operations_snapshot();
+    state
+        .operations
+        .metrics_response(lifecycle, state.is_ready(), &snapshot)
+}
+
+async fn diagnostics(State(state): State<AppState>, request: Request<Body>) -> Response<Body> {
+    if let Err(fault) = validate_operation(&request) {
+        return operation_fault(fault);
+    }
+    let lifecycle = match state.lifecycle.snapshot() {
+        Ok(lifecycle) => lifecycle,
+        Err(_) => return HttpFault::InternalError.into_response(),
+    };
+    let snapshot = state.pool.operations_snapshot();
+    state
+        .operations
+        .diagnostics_response(lifecycle, state.is_ready(), &snapshot)
+        .unwrap_or_else(HttpFault::into_response)
+}
+
+fn validate_operation(request: &Request<Body>) -> Result<(), HttpFault> {
+    if request.method() != Method::GET {
+        return Err(HttpFault::MethodNotAllowed);
+    }
+    if request.version() != Version::HTTP_11 {
+        return Err(HttpFault::HttpVersionNotSupported);
+    }
+    if request.uri().query().is_some() {
+        return Err(HttpFault::MalformedRequest);
+    }
+    http_media::validate_bodyless_request(request.headers())
+}
+
+fn operation_fault(fault: HttpFault) -> Response<Body> {
+    if fault == HttpFault::MethodNotAllowed {
+        fault.into_response_with_allow(HeaderValue::from_static("GET"))
+    } else {
+        fault.into_response()
     }
 }
 

--- a/sglang_omni_router/rust/src/server.rs
+++ b/sglang_omni_router/rust/src/server.rs
@@ -22,8 +22,9 @@ use crate::http_generation::{self, HttpGeneration};
 use crate::http_media::{self, HttpMedia};
 use crate::http_relay::HttpRelay;
 use crate::lifecycle::Lifecycle;
+use crate::metrics::RouterMetrics;
 use crate::operations::{Operations, ResourceSnapshot, ResourceUsage};
-use crate::request_id::{self, RequestIds};
+use crate::request_id::{self, RequestBoundary, RequestIds};
 use crate::shutdown;
 use crate::websocket::{self, SessionTracker, WebsocketGateway};
 use crate::worker_pool::{HealthSupervisor, WorkerPool};
@@ -81,7 +82,8 @@ impl AppState {
 
 pub(crate) async fn serve(config: Config) -> Result<(), RouterError> {
     let lifecycle = Arc::new(Lifecycle::starting());
-    let pool = Arc::new(WorkerPool::build(&config)?);
+    let metrics = RouterMetrics::new();
+    let pool = Arc::new(WorkerPool::build(&config, Arc::clone(&metrics))?);
     let classifier = ClassificationExecutor::new();
     let relay = HttpRelay::new(
         pool.http_client(),
@@ -90,6 +92,7 @@ pub(crate) async fn serve(config: Config) -> Result<(), RouterError> {
             .buffered_total_usize()
             .map_err(RouterError::Config)?,
         Arc::clone(&classifier),
+        Arc::clone(&metrics),
     );
     let generation = HttpGeneration::build(&config, Arc::clone(&pool), Arc::clone(&relay))?;
     let media = HttpMedia::build(&config, Arc::clone(&pool), Arc::clone(&relay))?;
@@ -100,8 +103,8 @@ pub(crate) async fn serve(config: Config) -> Result<(), RouterError> {
         Arc::clone(&classifier),
         sessions.clone(),
     );
-    let operations = Arc::new(Operations::build(&config)?);
-    let request_ids = RequestIds::new();
+    let operations = Arc::new(Operations::build(&config, Arc::clone(&metrics))?);
+    let request_boundary = RequestBoundary::new(RequestIds::new(), metrics);
     let mut signal_observer = shutdown::SignalObserver::install().map_err(RouterError::Signal)?;
     let listener = tokio::net::TcpListener::bind(config.server.listen)
         .await
@@ -124,7 +127,7 @@ pub(crate) async fn serve(config: Config) -> Result<(), RouterError> {
         generation,
         media,
         websocket,
-        request_ids,
+        request_boundary,
     );
     let (shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
     lifecycle.enter_serving()?;
@@ -375,7 +378,7 @@ fn route_table(
     generation: Option<Arc<HttpGeneration>>,
     media: Option<Arc<HttpMedia>>,
     websocket: Option<Arc<WebsocketGateway>>,
-    request_ids: Arc<RequestIds>,
+    request_boundary: Arc<RequestBoundary>,
 ) -> Router {
     let mut app = Router::new()
         .route("/live", get(live).head(reject_head))
@@ -446,7 +449,7 @@ fn route_table(
         .route("/metrics", any(metrics).with_state(state.clone()))
         .route("/diagnostics", any(diagnostics).with_state(state));
     app.layer(middleware::from_fn_with_state(
-        request_ids,
+        request_boundary,
         request_id::canonicalize,
     ))
 }

--- a/sglang_omni_router/rust/src/server.rs
+++ b/sglang_omni_router/rust/src/server.rs
@@ -22,7 +22,7 @@ use crate::http_generation::{self, HttpGeneration};
 use crate::http_media::{self, HttpMedia};
 use crate::http_relay::HttpRelay;
 use crate::lifecycle::Lifecycle;
-use crate::operations::Operations;
+use crate::operations::{Operations, ResourceSnapshot, ResourceUsage};
 use crate::request_id::{self, RequestIds};
 use crate::shutdown;
 use crate::websocket::{self, SessionTracker, WebsocketGateway};
@@ -30,7 +30,7 @@ use crate::worker_pool::{HealthSupervisor, WorkerPool};
 
 mod bounded_listener;
 
-use bounded_listener::BoundedTcpListener;
+use bounded_listener::{BoundedTcpListener, ListenerCapacity};
 
 const LIVE_BODY: &str = "live\n";
 const NOT_READY_BODY: &str = "not ready\n";
@@ -44,20 +44,38 @@ struct AppState {
     media: Option<Arc<HttpMedia>>,
     websocket: Option<Arc<WebsocketGateway>>,
     operations: Arc<Operations>,
+    listener_capacity: ListenerCapacity,
+    relay: Arc<HttpRelay>,
+    classifier: Arc<ClassificationExecutor>,
+    sessions: SessionTracker,
 }
 
 impl AppState {
-    fn is_ready(&self) -> bool {
-        self.lifecycle.is_serving()
-            && self
-                .generation
-                .as_ref()
-                .is_none_or(|generation| generation.is_ready())
+    fn services_ready(&self) -> bool {
+        self.generation
+            .as_ref()
+            .is_none_or(|generation| generation.is_ready())
             && self.media.as_ref().is_none_or(|media| media.is_ready())
             && self
                 .websocket
                 .as_ref()
                 .is_none_or(|websocket| websocket.is_ready())
+    }
+
+    fn is_ready(&self) -> bool {
+        self.lifecycle.is_serving() && self.services_ready()
+    }
+
+    fn resource_snapshot(&self) -> ResourceSnapshot {
+        let (listener_limit, listener_in_use) = self.listener_capacity.usage();
+        let (buffer_limit, buffer_in_use) = self.relay.buffered_usage();
+        let (classification_limit, classification_in_use) = self.classifier.usage();
+        ResourceSnapshot::new(
+            ResourceUsage::new(listener_limit, listener_in_use),
+            ResourceUsage::new(buffer_limit, buffer_in_use),
+            ResourceUsage::new(classification_limit, classification_in_use),
+            self.sessions.active(),
+        )
     }
 }
 
@@ -74,13 +92,22 @@ pub(crate) async fn serve(config: Config) -> Result<(), RouterError> {
         Arc::clone(&classifier),
     );
     let generation = HttpGeneration::build(&config, Arc::clone(&pool), Arc::clone(&relay))?;
-    let media = HttpMedia::build(&config, Arc::clone(&pool), relay)?;
+    let media = HttpMedia::build(&config, Arc::clone(&pool), Arc::clone(&relay))?;
     let sessions = SessionTracker::new();
-    let websocket =
-        WebsocketGateway::build(&config, Arc::clone(&pool), classifier, sessions.clone());
+    let websocket = WebsocketGateway::build(
+        &config,
+        Arc::clone(&pool),
+        Arc::clone(&classifier),
+        sessions.clone(),
+    );
     let operations = Arc::new(Operations::build(&config)?);
     let request_ids = RequestIds::new();
     let mut signal_observer = shutdown::SignalObserver::install().map_err(RouterError::Signal)?;
+    let listener = tokio::net::TcpListener::bind(config.server.listen)
+        .await
+        .map_err(RouterError::Bind)?;
+    let listener = BoundedTcpListener::new(listener, config.server.max_connections);
+    let listener_capacity = listener.capacity();
     let app = route_table(
         AppState {
             lifecycle: Arc::clone(&lifecycle),
@@ -89,16 +116,16 @@ pub(crate) async fn serve(config: Config) -> Result<(), RouterError> {
             media: media.clone(),
             websocket: websocket.clone(),
             operations,
+            listener_capacity,
+            relay,
+            classifier,
+            sessions: sessions.clone(),
         },
         generation,
         media,
         websocket,
         request_ids,
     );
-    let listener = tokio::net::TcpListener::bind(config.server.listen)
-        .await
-        .map_err(RouterError::Bind)?;
-    let listener = BoundedTcpListener::new(listener, config.server.max_connections);
     let (shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
     lifecycle.enter_serving()?;
     let mut health = pool.start_health(&config);
@@ -456,9 +483,11 @@ async fn metrics(State(state): State<AppState>, request: Request<Body>) -> Respo
         Err(_) => return HttpFault::InternalError.into_response(),
     };
     let snapshot = state.pool.operations_snapshot();
+    let resources = state.resource_snapshot();
+    let ready = lifecycle == crate::lifecycle::State::Serving && state.services_ready();
     state
         .operations
-        .metrics_response(lifecycle, state.is_ready(), &snapshot)
+        .metrics_response(lifecycle, ready, &snapshot, &resources)
 }
 
 async fn diagnostics(State(state): State<AppState>, request: Request<Body>) -> Response<Body> {
@@ -470,9 +499,11 @@ async fn diagnostics(State(state): State<AppState>, request: Request<Body>) -> R
         Err(_) => return HttpFault::InternalError.into_response(),
     };
     let snapshot = state.pool.operations_snapshot();
+    let resources = state.resource_snapshot();
+    let ready = lifecycle == crate::lifecycle::State::Serving && state.services_ready();
     state
         .operations
-        .diagnostics_response(lifecycle, state.is_ready(), &snapshot)
+        .diagnostics_response(lifecycle, ready, &snapshot, &resources)
         .unwrap_or_else(HttpFault::into_response)
 }
 

--- a/sglang_omni_router/rust/src/server.rs
+++ b/sglang_omni_router/rust/src/server.rs
@@ -84,7 +84,7 @@ pub(crate) async fn serve(config: Config) -> Result<(), RouterError> {
     let lifecycle = Arc::new(Lifecycle::starting());
     let metrics = RouterMetrics::new();
     let pool = Arc::new(WorkerPool::build(&config, Arc::clone(&metrics))?);
-    let classifier = ClassificationExecutor::new();
+    let classifier = ClassificationExecutor::new(Arc::clone(&metrics));
     let relay = HttpRelay::new(
         pool.http_client(),
         config

--- a/sglang_omni_router/rust/src/server.rs
+++ b/sglang_omni_router/rust/src/server.rs
@@ -102,6 +102,7 @@ pub(crate) async fn serve(config: Config) -> Result<(), RouterError> {
         Arc::clone(&pool),
         Arc::clone(&classifier),
         sessions.clone(),
+        Arc::clone(&metrics),
     );
     let operations = Arc::new(Operations::build(&config, Arc::clone(&metrics))?);
     let request_boundary = RequestBoundary::new(RequestIds::new(), metrics);

--- a/sglang_omni_router/rust/src/server/bounded_listener.rs
+++ b/sglang_omni_router/rust/src/server/bounded_listener.rs
@@ -12,6 +12,12 @@ use tracing::trace;
 /// TCP listener that bounds accepted client sockets.
 pub(super) struct BoundedTcpListener {
     listener: TcpListener,
+    capacity: ListenerCapacity,
+}
+
+#[derive(Clone)]
+pub(super) struct ListenerCapacity {
+    limit: usize,
     permits: Arc<Semaphore>,
 }
 
@@ -20,13 +26,20 @@ impl BoundedTcpListener {
     pub(super) fn new(listener: TcpListener, max_connections: usize) -> Self {
         Self {
             listener,
-            permits: Arc::new(Semaphore::new(max_connections)),
+            capacity: ListenerCapacity {
+                limit: max_connections,
+                permits: Arc::new(Semaphore::new(max_connections)),
+            },
         }
+    }
+
+    pub(super) fn capacity(&self) -> ListenerCapacity {
+        self.capacity.clone()
     }
 
     /// Accepts one socket after reserving its lifetime permit.
     pub(super) async fn accept(&self) -> io::Result<(ConnectionIo, SocketAddr)> {
-        let permit = Arc::clone(&self.permits)
+        let permit = Arc::clone(&self.capacity.permits)
             .acquire_owned()
             .await
             .map_err(|_| io::Error::other("connection permit pool closed"))?;
@@ -39,7 +52,13 @@ impl BoundedTcpListener {
 
     #[cfg(test)]
     pub(super) fn permit_pool(&self) -> Arc<Semaphore> {
-        Arc::clone(&self.permits)
+        Arc::clone(&self.capacity.permits)
+    }
+}
+
+impl ListenerCapacity {
+    pub(super) fn usage(&self) -> (usize, usize) {
+        (self.limit, self.limit - self.permits.available_permits())
     }
 }
 
@@ -130,7 +149,7 @@ mod tests {
             .await
             .expect("connect first client");
         let (first_io, _) = listener.accept().await.expect("accept first client");
-        assert_eq!(listener.permits.available_permits(), 0);
+        assert_eq!(listener.permit_pool().available_permits(), 0);
 
         let _second_client = TcpStream::connect(address)
             .await
@@ -147,9 +166,9 @@ mod tests {
             .await
             .expect("waiting accept should wake after wrapper drop")
             .expect("accept second client");
-        assert_eq!(listener.permits.available_permits(), 0);
+        assert_eq!(listener.permit_pool().available_permits(), 0);
         drop(second_io);
-        assert_eq!(listener.permits.available_permits(), 1);
+        assert_eq!(listener.permit_pool().available_permits(), 1);
     }
 
     #[tokio::test]
@@ -177,7 +196,7 @@ mod tests {
                 .is_err(),
             "accept without a client should remain pending"
         );
-        assert_eq!(listener.permits.available_permits(), 1);
+        assert_eq!(listener.permit_pool().available_permits(), 1);
     }
 
     #[tokio::test]
@@ -187,7 +206,7 @@ mod tests {
             .await
             .expect("connect isolated client");
         let (io, _) = listener.accept().await.expect("accept client");
-        let permits = Arc::clone(&listener.permits);
+        let permits = listener.permit_pool();
 
         tokio::time::timeout(Duration::from_millis(50), async move { drop(io) })
             .await

--- a/sglang_omni_router/rust/src/websocket/mod.rs
+++ b/sglang_omni_router/rust/src/websocket/mod.rs
@@ -19,7 +19,7 @@ use tokio_tungstenite::tungstenite::error::CapacityError;
 use crate::classification::ClassificationExecutor;
 use crate::config::{Config, WebsocketConfig};
 use crate::error::HttpFault;
-use crate::metrics::ClassificationKind;
+use crate::metrics::{ClassificationKind, RouterMetrics, WebsocketTermination};
 use crate::request_id::CanonicalRequestId;
 use crate::speech_facts::{
     ScalarFactSeed, SpeechFields, named_voice as classify_named_voice,
@@ -35,7 +35,10 @@ mod session;
 mod upstream;
 
 pub(crate) use session::SessionTracker;
-use session::{DrainState, PendingSession, RelayProtocol, SessionSupervisor, close_message};
+use session::{
+    DrainState, PendingSession, RelayProtocol, SessionObservation, SessionSupervisor, WorkerEvent,
+    close_message,
+};
 
 pub(crate) const SPEECH_PATH: &str = "/v1/audio/speech/stream";
 pub(crate) const REALTIME_PATH: &str = "/v1/realtime";
@@ -68,6 +71,7 @@ pub(crate) struct WebsocketGateway {
     realtime: Option<TrustDomain>,
     classifier: Arc<ClassificationExecutor>,
     tracker: SessionTracker,
+    metrics: Arc<RouterMetrics>,
 }
 
 impl WebsocketGateway {
@@ -76,6 +80,7 @@ impl WebsocketGateway {
         pool: Arc<WorkerPool>,
         classifier: Arc<ClassificationExecutor>,
         tracker: SessionTracker,
+        metrics: Arc<RouterMetrics>,
     ) -> Option<Arc<Self>> {
         let policy = config.websocket.clone()?;
         Some(Arc::new(Self {
@@ -91,6 +96,7 @@ impl WebsocketGateway {
             classifier,
             policy,
             tracker,
+            metrics,
         }))
     }
 
@@ -161,6 +167,8 @@ async fn run_speech(
     upstream_query: Option<String>,
     upstream_headers: upstream::HandshakeHeaders,
 ) {
+    let mut observation =
+        SessionObservation::new(Arc::clone(&gateway.metrics), RelayProtocol::Speech);
     let mut drain = pending.drain_receiver();
     let config_deadline = Instant::now() + gateway.policy.speech_config_timeout();
     let config_text = match setup_until(
@@ -171,11 +179,17 @@ async fn run_speech(
     .await
     {
         Ok(Ok(text)) => text,
-        Ok(Err(close)) => {
-            send_setup_close(&mut downstream, &gateway.policy, &mut drain, close).await;
+        Ok(Err(failure)) => {
+            observation.finish(failure.termination);
+            send_setup_close(&mut downstream, &gateway.policy, &mut drain, failure.close).await;
             return;
         }
         Err(termination) => {
+            finish_setup_termination(
+                &mut observation,
+                termination,
+                WebsocketTermination::ConfigurationTimeout,
+            );
             close_for_setup_termination(
                 &mut downstream,
                 &gateway.policy,
@@ -205,6 +219,7 @@ async fn run_speech(
     let (config_text, requirement) = match classified {
         Ok(Ok((text, requirement))) => (text, requirement),
         Ok(Err(HttpFault::MalformedRequest)) => {
+            observation.finish(WebsocketTermination::ClassificationError);
             send_setup_close(
                 &mut downstream,
                 &gateway.policy,
@@ -214,7 +229,12 @@ async fn run_speech(
             .await;
             return;
         }
-        Ok(Err(_fault)) => {
+        Ok(Err(fault)) => {
+            observation.finish(if fault == HttpFault::UpstreamTimeout {
+                WebsocketTermination::ClassificationTimeout
+            } else {
+                WebsocketTermination::ClassificationError
+            });
             send_setup_close(
                 &mut downstream,
                 &gateway.policy,
@@ -225,6 +245,7 @@ async fn run_speech(
             return;
         }
         Err(state) => {
+            observation.finish(drain_termination(state));
             close_for_setup_termination(
                 &mut downstream,
                 &gateway.policy,
@@ -239,6 +260,7 @@ async fn run_speech(
     let upstream_config = match downstream_text_to_upstream(config_text) {
         Ok(text) => text,
         Err(()) => {
+            observation.finish(WebsocketTermination::Internal);
             send_setup_close(
                 &mut downstream,
                 &gateway.policy,
@@ -253,6 +275,7 @@ async fn run_speech(
     let lease = match gateway.pool.dispatch_session(admission, &requirement) {
         Ok(lease) => lease,
         Err(error) => {
+            observation.finish(WebsocketTermination::DispatchError);
             send_setup_close(
                 &mut downstream,
                 &gateway.policy,
@@ -279,6 +302,7 @@ async fn run_speech(
     let upstream = match connected {
         Ok(Ok(upstream)) => upstream,
         Ok(Err(_)) => {
+            observation.finish(WebsocketTermination::ConnectError);
             lease.request_immediate_probe();
             send_setup_close(
                 &mut downstream,
@@ -290,6 +314,11 @@ async fn run_speech(
             return;
         }
         Err(termination) => {
+            finish_setup_termination(
+                &mut observation,
+                termination,
+                WebsocketTermination::ConnectTimeout,
+            );
             if termination == SetupTermination::Deadline {
                 lease.request_immediate_probe();
             }
@@ -318,6 +347,7 @@ async fn run_speech(
     match sent {
         Ok(Ok(())) => {}
         Ok(Err(_)) => {
+            observation.finish(WebsocketTermination::WorkerSetupError);
             supervisor.request_immediate_probe();
             supervisor
                 .close_setup(
@@ -331,6 +361,11 @@ async fn run_speech(
             return;
         }
         Err(termination) => {
+            finish_setup_termination(
+                &mut observation,
+                termination,
+                WebsocketTermination::WorkerSetupTimeout,
+            );
             close_supervised_setup_termination(
                 supervisor,
                 &mut downstream,
@@ -351,6 +386,7 @@ async fn run_speech(
             &gateway.policy,
             RelayProtocol::Speech,
             "upstream setup failure",
+            &mut observation,
         )
         .await
     else {
@@ -360,7 +396,8 @@ async fn run_speech(
     downstream = next_downstream;
     let text = match first {
         Some(Ok(UpstreamMessage::Text(text))) if is_speech_setup_event(text.as_bytes()) => text,
-        _ => {
+        event => {
+            observation.finish(worker_setup_termination(&event));
             supervisor.request_immediate_probe();
             supervisor
                 .close_setup(
@@ -377,6 +414,7 @@ async fn run_speech(
     let text = match upstream_text_to_downstream(text) {
         Ok(text) => text,
         Err(()) => {
+            observation.finish(WebsocketTermination::WorkerProtocolError);
             supervisor.request_immediate_probe();
             supervisor
                 .close_setup(
@@ -399,12 +437,18 @@ async fn run_speech(
     {
         Ok(Ok(())) => {}
         Ok(Err(_)) => {
+            observation.finish(WebsocketTermination::ClientDisconnect);
             supervisor
                 .close_upstream_after_client_loss(&mut downstream, &gateway.policy, &mut drain)
                 .await;
             return;
         }
         Err(termination) => {
+            finish_setup_termination(
+                &mut observation,
+                termination,
+                WebsocketTermination::WorkerSetupTimeout,
+            );
             close_supervised_setup_termination(
                 supervisor,
                 &mut downstream,
@@ -419,7 +463,12 @@ async fn run_speech(
         }
     }
     supervisor
-        .relay(downstream, &gateway.policy, RelayProtocol::Speech)
+        .relay(
+            downstream,
+            &gateway.policy,
+            RelayProtocol::Speech,
+            &mut observation,
+        )
         .await;
 }
 
@@ -499,6 +548,8 @@ async fn run_realtime(
     gateway: Arc<WebsocketGateway>,
     mut supervisor: SessionSupervisor,
 ) {
+    let mut observation =
+        SessionObservation::new(Arc::clone(&gateway.metrics), RelayProtocol::Realtime);
     let mut drain = supervisor.drain_receiver();
     let worker_deadline = Instant::now() + gateway.policy.worker_setup_timeout();
     let Some((next_supervisor, next_downstream, first)) = supervisor
@@ -508,6 +559,7 @@ async fn run_realtime(
             &gateway.policy,
             RelayProtocol::Realtime,
             "invalid session.created",
+            &mut observation,
         )
         .await
     else {
@@ -521,7 +573,8 @@ async fn run_realtime(
         {
             text
         }
-        _ => {
+        event => {
+            observation.finish(worker_setup_termination(&event));
             supervisor.request_immediate_probe();
             supervisor
                 .close_setup(
@@ -538,6 +591,7 @@ async fn run_realtime(
     let text = match upstream_text_to_downstream(text) {
         Ok(text) => text,
         Err(()) => {
+            observation.finish(WebsocketTermination::WorkerProtocolError);
             supervisor.request_immediate_probe();
             supervisor
                 .close_setup(
@@ -560,12 +614,18 @@ async fn run_realtime(
     {
         Ok(Ok(())) => {}
         Ok(Err(_)) => {
+            observation.finish(WebsocketTermination::ClientDisconnect);
             supervisor
                 .close_upstream_after_client_loss(&mut downstream, &gateway.policy, &mut drain)
                 .await;
             return;
         }
         Err(termination) => {
+            finish_setup_termination(
+                &mut observation,
+                termination,
+                WebsocketTermination::WorkerSetupTimeout,
+            );
             close_supervised_setup_termination(
                 supervisor,
                 &mut downstream,
@@ -580,7 +640,12 @@ async fn run_realtime(
         }
     }
     supervisor
-        .relay(downstream, &gateway.policy, RelayProtocol::Realtime)
+        .relay(
+            downstream,
+            &gateway.policy,
+            RelayProtocol::Realtime,
+            &mut observation,
+        )
         .await;
 }
 
@@ -588,6 +653,33 @@ async fn run_realtime(
 enum SetupTermination {
     Deadline,
     Drain(DrainState),
+}
+
+fn drain_termination(state: DrainState) -> WebsocketTermination {
+    match state {
+        DrainState::Draining => WebsocketTermination::Draining,
+        DrainState::Forced => WebsocketTermination::ForcedShutdown,
+        DrainState::Serving => WebsocketTermination::Internal,
+    }
+}
+
+fn finish_setup_termination(
+    observation: &mut SessionObservation,
+    termination: SetupTermination,
+    deadline: WebsocketTermination,
+) {
+    observation.finish(match termination {
+        SetupTermination::Deadline => deadline,
+        SetupTermination::Drain(state) => drain_termination(state),
+    });
+}
+
+fn worker_setup_termination(event: &WorkerEvent) -> WebsocketTermination {
+    match event {
+        Some(Ok(UpstreamMessage::Close(_))) => WebsocketTermination::WorkerClose,
+        Some(Err(_)) | None => WebsocketTermination::WorkerDisconnect,
+        Some(Ok(_)) => WebsocketTermination::WorkerProtocolError,
+    }
 }
 
 async fn setup_until<T>(
@@ -709,20 +801,42 @@ async fn send_setup_close(
     }
 }
 
+struct SpeechConfigFailure {
+    close: Message,
+    termination: WebsocketTermination,
+}
+
 async fn receive_speech_config(
     downstream: &mut WebSocket,
-) -> Result<axum::extract::ws::Utf8Bytes, Message> {
+) -> Result<axum::extract::ws::Utf8Bytes, SpeechConfigFailure> {
     loop {
         match downstream.next().await {
             Some(Ok(Message::Text(text))) => return Ok(text),
             Some(Ok(Message::Ping(_) | Message::Pong(_))) => {}
-            Some(Ok(Message::Binary(_) | Message::Close(_))) => {
-                return Err(close_message(1008, "invalid session.config"));
+            Some(Ok(Message::Binary(_))) => {
+                return Err(SpeechConfigFailure {
+                    close: close_message(1008, "invalid session.config"),
+                    termination: WebsocketTermination::ConfigurationError,
+                });
+            }
+            Some(Ok(Message::Close(_))) => {
+                return Err(SpeechConfigFailure {
+                    close: close_message(1008, "invalid session.config"),
+                    termination: WebsocketTermination::ClientClose,
+                });
             }
             Some(Err(error)) if websocket_message_too_large(&error) => {
-                return Err(close_message(1009, "session.config too large"));
+                return Err(SpeechConfigFailure {
+                    close: close_message(1009, "session.config too large"),
+                    termination: WebsocketTermination::ClientProtocolError,
+                });
             }
-            Some(Err(_)) | None => return Err(close_message(1008, "invalid session.config")),
+            Some(Err(_)) | None => {
+                return Err(SpeechConfigFailure {
+                    close: close_message(1008, "invalid session.config"),
+                    termination: WebsocketTermination::ClientDisconnect,
+                });
+            }
         }
     }
 }

--- a/sglang_omni_router/rust/src/websocket/mod.rs
+++ b/sglang_omni_router/rust/src/websocket/mod.rs
@@ -13,8 +13,8 @@ use serde::de::{DeserializeSeed, IgnoredAny, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer as _};
 use tokio::sync::watch;
 use tokio::time::Instant;
-use tokio_tungstenite::tungstenite::Message as UpstreamMessage;
 use tokio_tungstenite::tungstenite::error::CapacityError;
+use tokio_tungstenite::tungstenite::{Error as UpstreamError, Message as UpstreamMessage};
 
 use crate::classification::ClassificationExecutor;
 use crate::config::{Config, WebsocketConfig};
@@ -677,7 +677,11 @@ fn finish_setup_termination(
 fn worker_setup_termination(event: &WorkerEvent) -> WebsocketTermination {
     match event {
         Some(Ok(UpstreamMessage::Close(_))) => WebsocketTermination::WorkerClose,
-        Some(Err(_)) | None => WebsocketTermination::WorkerDisconnect,
+        Some(Err(error)) => match upstream_receive_failure(error) {
+            ReceiveFailure::Disconnect => WebsocketTermination::WorkerDisconnect,
+            ReceiveFailure::Protocol => WebsocketTermination::WorkerProtocolError,
+        },
+        None => WebsocketTermination::WorkerDisconnect,
         Some(Ok(_)) => WebsocketTermination::WorkerProtocolError,
     }
 }
@@ -831,7 +835,16 @@ async fn receive_speech_config(
                     termination: WebsocketTermination::ClientProtocolError,
                 });
             }
-            Some(Err(_)) | None => {
+            Some(Err(error)) => {
+                return Err(SpeechConfigFailure {
+                    close: close_message(1008, "invalid session.config"),
+                    termination: match downstream_receive_failure(&error) {
+                        ReceiveFailure::Disconnect => WebsocketTermination::ClientDisconnect,
+                        ReceiveFailure::Protocol => WebsocketTermination::ClientProtocolError,
+                    },
+                });
+            }
+            None => {
                 return Err(SpeechConfigFailure {
                     close: close_message(1008, "invalid session.config"),
                     termination: WebsocketTermination::ClientDisconnect,
@@ -839,6 +852,36 @@ async fn receive_speech_config(
             }
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ReceiveFailure {
+    Disconnect,
+    Protocol,
+}
+
+fn upstream_receive_failure(error: &UpstreamError) -> ReceiveFailure {
+    match error {
+        UpstreamError::Capacity(_)
+        | UpstreamError::Protocol(_)
+        | UpstreamError::Utf8(_)
+        | UpstreamError::AttackAttempt => ReceiveFailure::Protocol,
+        UpstreamError::ConnectionClosed
+        | UpstreamError::AlreadyClosed
+        | UpstreamError::Io(_)
+        | UpstreamError::Tls(_)
+        | UpstreamError::WriteBufferFull(_)
+        | UpstreamError::Url(_)
+        | UpstreamError::Http(_)
+        | UpstreamError::HttpFormat(_) => ReceiveFailure::Disconnect,
+    }
+}
+
+fn downstream_receive_failure(error: &axum::Error) -> ReceiveFailure {
+    error
+        .source()
+        .and_then(|source| source.downcast_ref::<UpstreamError>())
+        .map_or(ReceiveFailure::Disconnect, upstream_receive_failure)
 }
 
 fn websocket_message_too_large(error: &axum::Error) -> bool {
@@ -1153,10 +1196,13 @@ fn is_speech_setup_event(bytes: &[u8]) -> bool {
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::panic)]
 mod tests {
+    use std::io;
     use std::time::Duration;
 
     use axum::http::Uri;
     use tokio::sync::watch;
+    use tokio_tungstenite::tungstenite::Error as UpstreamError;
+    use tokio_tungstenite::tungstenite::error::ProtocolError;
 
     use crate::classification::ClassificationExecutor;
     use crate::error::HttpFault;
@@ -1167,10 +1213,36 @@ mod tests {
     };
 
     use super::{
-        DrainState, EventKind, MAX_MESSAGE_BYTES, is_speech_setup_event, parse_event_kind,
-        parse_speech_config, realtime_model, reference_forms, setup_while_serving,
-        speech_requirement, websocket_message_too_large,
+        DrainState, EventKind, MAX_MESSAGE_BYTES, ReceiveFailure, downstream_receive_failure,
+        is_speech_setup_event, parse_event_kind, parse_speech_config, realtime_model,
+        reference_forms, setup_while_serving, speech_requirement, upstream_receive_failure,
+        websocket_message_too_large,
     };
+
+    #[test]
+    fn receive_failures_distinguish_protocol_errors_from_disconnects() {
+        let protocol = UpstreamError::Protocol(ProtocolError::ResetWithoutClosingHandshake);
+        let disconnect = UpstreamError::Io(io::Error::new(
+            io::ErrorKind::ConnectionReset,
+            "connection reset",
+        ));
+        assert_eq!(
+            upstream_receive_failure(&protocol),
+            ReceiveFailure::Protocol
+        );
+        assert_eq!(
+            upstream_receive_failure(&disconnect),
+            ReceiveFailure::Disconnect
+        );
+        assert_eq!(
+            downstream_receive_failure(&axum::Error::new(protocol)),
+            ReceiveFailure::Protocol
+        );
+        assert_eq!(
+            downstream_receive_failure(&axum::Error::new(disconnect)),
+            ReceiveFailure::Disconnect
+        );
+    }
 
     #[tokio::test]
     async fn speech_setup_deadline_bounds_blocking_classification() {

--- a/sglang_omni_router/rust/src/websocket/mod.rs
+++ b/sglang_omni_router/rust/src/websocket/mod.rs
@@ -19,6 +19,7 @@ use tokio_tungstenite::tungstenite::error::CapacityError;
 use crate::classification::ClassificationExecutor;
 use crate::config::{Config, WebsocketConfig};
 use crate::error::HttpFault;
+use crate::metrics::ClassificationKind;
 use crate::request_id::CanonicalRequestId;
 use crate::speech_facts::{
     ScalarFactSeed, SpeechFields, named_voice as classify_named_voice,
@@ -188,20 +189,22 @@ async fn run_speech(
     };
     let classification_deadline = Instant::now() + gateway.policy.worker_setup_timeout();
     let classify_trust = trust.clone();
-    let classified = setup_until(
+    let classified = setup_while_serving(
         &mut drain,
-        classification_deadline,
-        gateway
-            .classifier
-            .classify(classification_deadline, move || {
-                let requirement = classify_speech(config_text.as_bytes(), &classify_trust);
+        gateway.classifier.classify(
+            ClassificationKind::SpeechWebsocket,
+            classification_deadline,
+            move || {
+                let requirement = classify_speech(config_text.as_bytes(), &classify_trust)
+                    .map_err(|()| HttpFault::MalformedRequest)?;
                 Ok((config_text, requirement))
-            }),
+            },
+        ),
     )
     .await;
     let (config_text, requirement) = match classified {
-        Ok(Ok((text, Ok(requirement)))) => (text, requirement),
-        Ok(Ok((_text, Err(())))) => {
+        Ok(Ok((text, requirement))) => (text, requirement),
+        Ok(Err(HttpFault::MalformedRequest)) => {
             send_setup_close(
                 &mut downstream,
                 &gateway.policy,
@@ -221,12 +224,12 @@ async fn run_speech(
             .await;
             return;
         }
-        Err(termination) => {
+        Err(state) => {
             close_for_setup_termination(
                 &mut downstream,
                 &gateway.policy,
                 &mut drain,
-                termination,
+                SetupTermination::Drain(state),
                 close_message(1011, "internal setup failure"),
             )
             .await;
@@ -609,6 +612,28 @@ async fn setup_until<T>(
                 Err(SetupTermination::Drain(DrainState::Forced))
             } else {
                 Err(SetupTermination::Drain(*drain.borrow()))
+            }
+        }
+    }
+}
+
+async fn setup_while_serving<T>(
+    drain: &mut watch::Receiver<DrainState>,
+    operation: impl Future<Output = T>,
+) -> Result<T, DrainState> {
+    let initial = *drain.borrow();
+    if initial != DrainState::Serving {
+        return Err(initial);
+    }
+    tokio::pin!(operation);
+    tokio::select! {
+        biased;
+        result = &mut operation => Ok(result),
+        changed = drain.changed() => {
+            if changed.is_err() {
+                Err(DrainState::Forced)
+            } else {
+                Err(*drain.borrow())
             }
         }
     }
@@ -1020,14 +1045,16 @@ mod tests {
     use tokio::sync::watch;
 
     use crate::classification::ClassificationExecutor;
+    use crate::error::HttpFault;
+    use crate::metrics::ClassificationKind;
     use crate::worker_pool::{
         ModelSelection, ProfileRequirement, ReferenceForm, SpeechResponseFormat, SpeechTask,
         StreamMode, TrustDomain,
     };
 
     use super::{
-        DrainState, EventKind, MAX_MESSAGE_BYTES, SetupTermination, is_speech_setup_event,
-        parse_event_kind, parse_speech_config, realtime_model, reference_forms, setup_until,
+        DrainState, EventKind, MAX_MESSAGE_BYTES, is_speech_setup_event, parse_event_kind,
+        parse_speech_config, realtime_model, reference_forms, setup_while_serving,
         speech_requirement, websocket_message_too_large,
     };
 
@@ -1038,19 +1065,22 @@ mod tests {
         let (_drain_sender, mut drain) = watch::channel(DrainState::Serving);
         let deadline = tokio::time::Instant::now() + Duration::from_millis(25);
 
-        let result = setup_until(
+        let result = setup_while_serving(
             &mut drain,
-            deadline,
-            ClassificationExecutor::for_test(1).classify(deadline, move || {
-                entered_tx.send(()).expect("classifier started");
-                release_rx.recv().expect("release classifier");
-                Ok(())
-            }),
+            ClassificationExecutor::for_test(1).classify(
+                ClassificationKind::SpeechWebsocket,
+                deadline,
+                move || {
+                    entered_tx.send(()).expect("classifier started");
+                    release_rx.recv().expect("release classifier");
+                    Ok(())
+                },
+            ),
         )
         .await;
 
         entered_rx.await.expect("classifier entered");
-        assert!(matches!(result, Err(SetupTermination::Deadline)));
+        assert_eq!(result, Ok(Err(HttpFault::UpstreamTimeout)));
         release_tx.send(()).expect("release classifier");
     }
 

--- a/sglang_omni_router/rust/src/websocket/session.rs
+++ b/sglang_omni_router/rust/src/websocket/session.rs
@@ -113,6 +113,10 @@ impl SessionTracker {
             notified.await;
         }
     }
+
+    pub(crate) fn active(&self) -> usize {
+        self.inner.state().active
+    }
 }
 
 impl Drop for SessionRegistration {

--- a/sglang_omni_router/rust/src/websocket/session.rs
+++ b/sglang_omni_router/rust/src/websocket/session.rs
@@ -18,6 +18,7 @@ use crate::metrics::{RouterMetrics, WebsocketPhase, WebsocketProtocol, Websocket
 use crate::worker_pool::{AdmissionLease, RequestLease};
 
 use super::upstream::UpstreamSocket;
+use super::{ReceiveFailure, downstream_receive_failure, upstream_receive_failure};
 
 type DownstreamSink = SplitSink<WebSocket, DownstreamMessage>;
 type DownstreamStream = SplitStream<WebSocket>;
@@ -168,8 +169,8 @@ pub(super) struct SessionSupervisor {
 enum RelayTerminal {
     ClientClose(Option<DownstreamClose>),
     WorkerClose(Option<UpstreamClose>),
-    ClientGone,
-    WorkerGone,
+    ClientFailure(ReceiveFailure),
+    WorkerFailure(ReceiveFailure),
     ClientViolation {
         code: CloseCode,
         reason: &'static str,
@@ -191,8 +192,18 @@ impl RelayTerminal {
         match self {
             Self::ClientClose(_) => WebsocketTermination::ClientClose,
             Self::WorkerClose(_) => WebsocketTermination::WorkerClose,
-            Self::ClientGone => WebsocketTermination::ClientDisconnect,
-            Self::WorkerGone => WebsocketTermination::WorkerDisconnect,
+            Self::ClientFailure(ReceiveFailure::Disconnect) => {
+                WebsocketTermination::ClientDisconnect
+            }
+            Self::ClientFailure(ReceiveFailure::Protocol) => {
+                WebsocketTermination::ClientProtocolError
+            }
+            Self::WorkerFailure(ReceiveFailure::Disconnect) => {
+                WebsocketTermination::WorkerDisconnect
+            }
+            Self::WorkerFailure(ReceiveFailure::Protocol) => {
+                WebsocketTermination::WorkerProtocolError
+            }
             Self::ClientViolation { .. } => WebsocketTermination::ClientProtocolError,
             Self::WorkerViolation { .. } => WebsocketTermination::WorkerProtocolError,
             Self::Draining => WebsocketTermination::Draining,
@@ -533,10 +544,10 @@ impl SessionSupervisor {
                 )
                 .await;
             }
-            RelayTerminal::ClientGone => {
+            RelayTerminal::ClientFailure(_) => {
                 close_upstream(downstream, upstream, policy.close_timeout(), drain).await;
             }
-            RelayTerminal::WorkerGone => {
+            RelayTerminal::WorkerFailure(_) => {
                 self.lease.request_immediate_probe();
                 close_downstream(
                     downstream,
@@ -640,13 +651,13 @@ async fn forward_client_message(
                 .send(UpstreamMessage::Text(text))
                 .await
                 .err()
-                .map(|_| RelayTerminal::WorkerGone)
+                .map(|_| RelayTerminal::WorkerFailure(ReceiveFailure::Disconnect))
         }
         Some(Ok(DownstreamMessage::Binary(bytes))) if protocol.accepts_client_binary() => upstream
             .send(UpstreamMessage::Binary(bytes))
             .await
             .err()
-            .map(|_| RelayTerminal::WorkerGone),
+            .map(|_| RelayTerminal::WorkerFailure(ReceiveFailure::Disconnect)),
         Some(Ok(DownstreamMessage::Binary(_))) => Some(RelayTerminal::ClientViolation {
             code: 1003,
             reason: "binary messages are unsupported",
@@ -659,7 +670,10 @@ async fn forward_client_message(
                 reason: "message too large",
             })
         }
-        Some(Err(_)) | None => Some(RelayTerminal::ClientGone),
+        Some(Err(error)) => Some(RelayTerminal::ClientFailure(downstream_receive_failure(
+            &error,
+        ))),
+        None => Some(RelayTerminal::ClientFailure(ReceiveFailure::Disconnect)),
     }
 }
 
@@ -682,7 +696,7 @@ async fn worker_to_client(
                     .await
                     .is_err()
                 {
-                    return RelayTerminal::ClientGone;
+                    return RelayTerminal::ClientFailure(ReceiveFailure::Disconnect);
                 }
             }
             Some(Ok(UpstreamMessage::Binary(bytes))) if protocol.accepts_worker_binary() => {
@@ -691,7 +705,7 @@ async fn worker_to_client(
                     .await
                     .is_err()
                 {
-                    return RelayTerminal::ClientGone;
+                    return RelayTerminal::ClientFailure(ReceiveFailure::Disconnect);
                 }
             }
             Some(Ok(UpstreamMessage::Binary(_))) => {
@@ -706,7 +720,10 @@ async fn worker_to_client(
             Some(Ok(
                 UpstreamMessage::Ping(_) | UpstreamMessage::Pong(_) | UpstreamMessage::Frame(_),
             )) => {}
-            Some(Err(_)) | None => return RelayTerminal::WorkerGone,
+            Some(Err(error)) => {
+                return RelayTerminal::WorkerFailure(upstream_receive_failure(&error));
+            }
+            None => return RelayTerminal::WorkerFailure(ReceiveFailure::Disconnect),
         }
     }
 }

--- a/sglang_omni_router/rust/src/websocket/session.rs
+++ b/sglang_omni_router/rust/src/websocket/session.rs
@@ -14,6 +14,7 @@ use tokio_tungstenite::tungstenite::protocol::{
 };
 
 use crate::config::WebsocketConfig;
+use crate::metrics::{RouterMetrics, WebsocketPhase, WebsocketProtocol, WebsocketTermination};
 use crate::worker_pool::{AdmissionLease, RequestLease};
 
 use super::upstream::UpstreamSocket;
@@ -185,6 +186,22 @@ enum RelayTerminal {
     },
 }
 
+impl RelayTerminal {
+    const fn metric_termination(&self) -> WebsocketTermination {
+        match self {
+            Self::ClientClose(_) => WebsocketTermination::ClientClose,
+            Self::WorkerClose(_) => WebsocketTermination::WorkerClose,
+            Self::ClientGone => WebsocketTermination::ClientDisconnect,
+            Self::WorkerGone => WebsocketTermination::WorkerDisconnect,
+            Self::ClientViolation { .. } => WebsocketTermination::ClientProtocolError,
+            Self::WorkerViolation { .. } => WebsocketTermination::WorkerProtocolError,
+            Self::Draining => WebsocketTermination::Draining,
+            Self::Forced => WebsocketTermination::ForcedShutdown,
+            Self::SetupDeadline { .. } => WebsocketTermination::WorkerSetupTimeout,
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
 pub(super) enum RelayProtocol {
     Speech,
@@ -198,6 +215,56 @@ impl RelayProtocol {
 
     const fn accepts_worker_binary(self) -> bool {
         matches!(self, Self::Speech)
+    }
+
+    const fn metric_protocol(self) -> WebsocketProtocol {
+        match self {
+            Self::Speech => WebsocketProtocol::Speech,
+            Self::Realtime => WebsocketProtocol::Realtime,
+        }
+    }
+}
+
+pub(super) struct SessionObservation {
+    metrics: Arc<RouterMetrics>,
+    protocol: WebsocketProtocol,
+    phase: WebsocketPhase,
+    completed: bool,
+}
+
+impl SessionObservation {
+    pub(super) fn new(metrics: Arc<RouterMetrics>, protocol: RelayProtocol) -> Self {
+        Self {
+            metrics,
+            protocol: protocol.metric_protocol(),
+            phase: WebsocketPhase::Setup,
+            completed: false,
+        }
+    }
+
+    fn enter_relay(&mut self) {
+        self.phase = WebsocketPhase::Relay;
+    }
+
+    pub(super) fn finish(&mut self, termination: WebsocketTermination) {
+        if self.completed {
+            return;
+        }
+        self.completed = true;
+        self.metrics
+            .record_websocket_termination(self.protocol, self.phase, termination);
+    }
+}
+
+impl Drop for SessionObservation {
+    fn drop(&mut self) {
+        if !self.completed {
+            self.metrics.record_websocket_termination(
+                self.protocol,
+                self.phase,
+                WebsocketTermination::Cancelled,
+            );
+        }
     }
 }
 
@@ -272,7 +339,9 @@ impl SessionSupervisor {
         downstream: WebSocket,
         policy: &WebsocketConfig,
         protocol: RelayProtocol,
+        observation: &mut SessionObservation,
     ) {
+        observation.enter_relay();
         let Self {
             registration,
             lease,
@@ -308,9 +377,11 @@ impl SessionSupervisor {
         };
 
         let Ok(mut downstream) = downstream_sink.reunite(downstream_stream) else {
+            observation.finish(WebsocketTermination::Internal);
             return;
         };
         let Ok(upstream) = upstream_sink.reunite(upstream_stream) else {
+            observation.finish(WebsocketTermination::Internal);
             return;
         };
 
@@ -319,7 +390,7 @@ impl SessionSupervisor {
             lease,
             upstream,
         }
-        .finish_terminal(&mut downstream, terminal, policy, &mut drain)
+        .finish_terminal(&mut downstream, terminal, policy, &mut drain, observation)
         .await;
     }
 
@@ -330,6 +401,7 @@ impl SessionSupervisor {
         policy: &WebsocketConfig,
         protocol: RelayProtocol,
         timeout_reason: &'static str,
+        observation: &mut SessionObservation,
     ) -> Option<(Self, WebSocket, WorkerEvent)> {
         let Self {
             registration,
@@ -399,9 +471,11 @@ impl SessionSupervisor {
         };
 
         let Ok(downstream) = downstream_sink.reunite(downstream_stream) else {
+            observation.finish(WebsocketTermination::Internal);
             return None;
         };
         let Ok(upstream) = upstream_sink.reunite(upstream_stream) else {
+            observation.finish(WebsocketTermination::Internal);
             return None;
         };
         let supervisor = Self {
@@ -414,7 +488,7 @@ impl SessionSupervisor {
             SetupOutcome::Terminal(terminal) => {
                 let mut downstream = downstream;
                 supervisor
-                    .finish_terminal(&mut downstream, terminal, policy, &mut drain)
+                    .finish_terminal(&mut downstream, terminal, policy, &mut drain, observation)
                     .await;
                 None
             }
@@ -427,7 +501,9 @@ impl SessionSupervisor {
         terminal: RelayTerminal,
         policy: &WebsocketConfig,
         drain: &mut watch::Receiver<DrainState>,
+        observation: &mut SessionObservation,
     ) {
+        observation.finish(terminal.metric_termination());
         let upstream = &mut self.upstream;
 
         match terminal {
@@ -781,9 +857,12 @@ fn upstream_close_to_downstream(frame: UpstreamClose) -> Option<DownstreamClose>
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::panic)]
 mod tests {
+    use std::sync::Arc;
     use std::time::Duration;
 
-    use super::{DrainState, SessionTracker};
+    use crate::metrics::{RouterMetrics, WebsocketPhase, WebsocketProtocol, WebsocketTermination};
+
+    use super::{DrainState, RelayProtocol, SessionObservation, SessionTracker};
 
     #[tokio::test]
     async fn tracker_registration_is_exact_once_and_drain_visible() {
@@ -814,5 +893,46 @@ mod tests {
         assert_eq!(*second.drain.borrow(), DrainState::Forced);
         drop((first, second));
         tracker.wait_empty().await;
+    }
+
+    #[test]
+    fn session_termination_is_recorded_once_at_its_current_phase() {
+        let metrics = RouterMetrics::new();
+        {
+            let mut observation =
+                SessionObservation::new(Arc::clone(&metrics), RelayProtocol::Speech);
+            observation.finish(WebsocketTermination::WorkerClose);
+            observation.finish(WebsocketTermination::Internal);
+        }
+        assert_eq!(
+            metrics.websocket_terminations(
+                WebsocketProtocol::Speech,
+                WebsocketPhase::Setup,
+                WebsocketTermination::WorkerClose,
+            ),
+            1
+        );
+        assert_eq!(
+            metrics.websocket_terminations(
+                WebsocketProtocol::Speech,
+                WebsocketPhase::Setup,
+                WebsocketTermination::Internal,
+            ),
+            0
+        );
+
+        {
+            let mut observation =
+                SessionObservation::new(Arc::clone(&metrics), RelayProtocol::Realtime);
+            observation.enter_relay();
+        }
+        assert_eq!(
+            metrics.websocket_terminations(
+                WebsocketProtocol::Realtime,
+                WebsocketPhase::Relay,
+                WebsocketTermination::Cancelled,
+            ),
+            1
+        );
     }
 }

--- a/sglang_omni_router/rust/src/worker_pool/admission.rs
+++ b/sglang_omni_router/rust/src/worker_pool/admission.rs
@@ -125,6 +125,8 @@ impl RequestLease {
 }
 
 pub(super) struct AdmissionController {
+    global_limit: usize,
+    class_limits: [Option<usize>; CAPACITY_CLASS_COUNT],
     global: Arc<Semaphore>,
     classes: [Option<Arc<Semaphore>>; CAPACITY_CLASS_COUNT],
 }
@@ -132,6 +134,8 @@ pub(super) struct AdmissionController {
 impl AdmissionController {
     pub(super) fn new(global: usize, limits: [Option<usize>; CAPACITY_CLASS_COUNT]) -> Self {
         Self {
+            global_limit: global,
+            class_limits: limits,
             global: Arc::new(Semaphore::new(global)),
             classes: limits.map(|limit| limit.map(|value| Arc::new(Semaphore::new(value)))),
         }
@@ -179,6 +183,20 @@ impl AdmissionController {
 
     pub(super) fn close(&self) {
         self.global.close();
+    }
+
+    pub(super) fn snapshot(&self) -> [(usize, usize); CAPACITY_CLASS_COUNT + 1] {
+        let mut snapshot = [(0, 0); CAPACITY_CLASS_COUNT + 1];
+        snapshot[0] = (
+            self.global_limit,
+            self.global_limit - self.global.available_permits(),
+        );
+        for (index, (limit, semaphore)) in self.class_limits.iter().zip(&self.classes).enumerate() {
+            if let (Some(limit), Some(semaphore)) = (limit, semaphore) {
+                snapshot[index + 1] = (*limit, *limit - semaphore.available_permits());
+            }
+        }
+        snapshot
     }
 
     #[cfg(test)]

--- a/sglang_omni_router/rust/src/worker_pool/admission.rs
+++ b/sglang_omni_router/rust/src/worker_pool/admission.rs
@@ -141,15 +141,6 @@ impl AdmissionController {
         }
     }
 
-    pub(super) fn try_admit(
-        &self,
-        class: CapacityClass,
-        credits: u32,
-    ) -> Result<AdmissionLease, AdmissionError> {
-        let envelope = self.try_admit_envelope()?;
-        self.try_admit_class(envelope, class, credits)
-    }
-
     pub(super) fn try_admit_envelope(&self) -> Result<EnvelopeLease, AdmissionError> {
         let global = Arc::clone(&self.global)
             .try_acquire_owned()

--- a/sglang_omni_router/rust/src/worker_pool/health.rs
+++ b/sglang_omni_router/rust/src/worker_pool/health.rs
@@ -17,6 +17,8 @@ pub(crate) enum WorkerHealth {
 }
 
 impl WorkerHealth {
+    pub(crate) const ALL: [Self; 3] = [Self::Unknown, Self::Healthy, Self::Unhealthy];
+
     fn from_atomic(value: u8) -> Self {
         match value {
             1 => Self::Healthy,

--- a/sglang_omni_router/rust/src/worker_pool/health.rs
+++ b/sglang_omni_router/rust/src/worker_pool/health.rs
@@ -24,6 +24,14 @@ impl WorkerHealth {
             _ => Self::Unknown,
         }
     }
+
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Healthy => "healthy",
+            Self::Unhealthy => "unhealthy",
+        }
+    }
 }
 
 /// Atomic health cell. Release/Acquire publishes only the state transition;

--- a/sglang_omni_router/rust/src/worker_pool/health.rs
+++ b/sglang_omni_router/rust/src/worker_pool/health.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU8, Ordering};
-use std::time::Duration;
+use std::sync::atomic::{AtomicU8, AtomicU16, AtomicU64, Ordering};
+use std::time::{Duration, SystemTime};
 
 use tokio::sync::watch;
 use tokio::task::{JoinError, JoinSet};
@@ -14,6 +14,119 @@ pub(crate) enum WorkerHealth {
     Unknown = 0,
     Healthy = 1,
     Unhealthy = 2,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub(crate) enum ProbeOutcome {
+    Pending = 0,
+    Success = 1,
+    HttpFailure = 2,
+    TransportFailure = 3,
+}
+
+impl ProbeOutcome {
+    pub(crate) const OBSERVED: [Self; 3] =
+        [Self::Success, Self::HttpFailure, Self::TransportFailure];
+
+    const fn from_atomic(value: u8) -> Self {
+        match value {
+            1 => Self::Success,
+            2 => Self::HttpFailure,
+            3 => Self::TransportFailure,
+            _ => Self::Pending,
+        }
+    }
+
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Success => "success",
+            Self::HttpFailure => "http_failure",
+            Self::TransportFailure => "transport_failure",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ProbeSnapshot {
+    pub(crate) outcome: ProbeOutcome,
+    pub(crate) status: Option<u16>,
+    pub(crate) checked_at_unix_ms: Option<u64>,
+    pub(crate) consecutive_successes: u8,
+    pub(crate) consecutive_failures: u8,
+    pub(crate) successes: u64,
+    pub(crate) http_failures: u64,
+    pub(crate) transport_failures: u64,
+}
+
+pub(super) struct AtomicProbe {
+    outcome: AtomicU8,
+    status: AtomicU16,
+    checked_at_unix_ms: AtomicU64,
+    consecutive_successes: AtomicU8,
+    consecutive_failures: AtomicU8,
+    successes: AtomicU64,
+    http_failures: AtomicU64,
+    transport_failures: AtomicU64,
+}
+
+impl AtomicProbe {
+    pub(super) const fn pending() -> Self {
+        Self {
+            outcome: AtomicU8::new(ProbeOutcome::Pending as u8),
+            status: AtomicU16::new(0),
+            checked_at_unix_ms: AtomicU64::new(0),
+            consecutive_successes: AtomicU8::new(0),
+            consecutive_failures: AtomicU8::new(0),
+            successes: AtomicU64::new(0),
+            http_failures: AtomicU64::new(0),
+            transport_failures: AtomicU64::new(0),
+        }
+    }
+
+    fn record(&self, outcome: ProbeOutcome, status: Option<u16>, tracker: &ProbeTracker) {
+        match outcome {
+            ProbeOutcome::Pending => {}
+            ProbeOutcome::Success => {
+                self.successes.fetch_add(1, Ordering::Relaxed);
+            }
+            ProbeOutcome::HttpFailure => {
+                self.http_failures.fetch_add(1, Ordering::Relaxed);
+            }
+            ProbeOutcome::TransportFailure => {
+                self.transport_failures.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        self.status.store(status.unwrap_or(0), Ordering::Relaxed);
+        self.consecutive_successes
+            .store(tracker.successes, Ordering::Relaxed);
+        self.consecutive_failures
+            .store(tracker.failures, Ordering::Relaxed);
+        let checked_at = SystemTime::UNIX_EPOCH
+            .elapsed()
+            .ok()
+            .and_then(|duration| u64::try_from(duration.as_millis()).ok())
+            .unwrap_or(0);
+        self.checked_at_unix_ms.store(checked_at, Ordering::Relaxed);
+        self.outcome.store(outcome as u8, Ordering::Release);
+    }
+
+    pub(super) fn snapshot(&self) -> ProbeSnapshot {
+        let outcome = ProbeOutcome::from_atomic(self.outcome.load(Ordering::Acquire));
+        let status = self.status.load(Ordering::Relaxed);
+        let checked_at_unix_ms = self.checked_at_unix_ms.load(Ordering::Relaxed);
+        ProbeSnapshot {
+            outcome,
+            status: (status != 0).then_some(status),
+            checked_at_unix_ms: (checked_at_unix_ms != 0).then_some(checked_at_unix_ms),
+            consecutive_successes: self.consecutive_successes.load(Ordering::Relaxed),
+            consecutive_failures: self.consecutive_failures.load(Ordering::Relaxed),
+            successes: self.successes.load(Ordering::Relaxed),
+            http_failures: self.http_failures.load(Ordering::Relaxed),
+            transport_failures: self.transport_failures.load(Ordering::Relaxed),
+        }
+    }
 }
 
 impl WorkerHealth {
@@ -144,11 +257,17 @@ async fn run_worker_health(
                 result
             }
         };
-        let success = response
-            .as_ref()
-            .is_ok_and(|response| response.status().is_success());
+        let (outcome, status) = match response.as_ref() {
+            Ok(response) if response.status().is_success() => {
+                (ProbeOutcome::Success, Some(response.status().as_u16()))
+            }
+            Ok(response) => (ProbeOutcome::HttpFailure, Some(response.status().as_u16())),
+            Err(_) => (ProbeOutcome::TransportFailure, None),
+        };
+        let success = outcome == ProbeOutcome::Success;
         let previous = record.health.load();
         let next = tracker.observe(success);
+        record.probe.record(outcome, status, &tracker);
         record.health.store(next);
         if previous != next {
             tracing::info!(
@@ -223,7 +342,9 @@ mod tests {
 
     use tokio::sync::Notify;
 
-    use super::{AtomicHealth, HealthSupervisor, ProbeTracker, WorkerHealth};
+    use super::{
+        AtomicHealth, AtomicProbe, HealthSupervisor, ProbeOutcome, ProbeTracker, WorkerHealth,
+    };
     use crate::worker_pool::WorkerRecord;
     use crate::worker_pool::profile::{
         InputModality, MessageContentForm, OutputModality, RegistrationId, ServiceProfile,
@@ -255,6 +376,7 @@ mod tests {
             active_requests: AtomicUsize::new(0),
             session_capacity: [None, None],
             health: AtomicHealth::unknown(),
+            probe: AtomicProbe::pending(),
             immediate_probe: Notify::new(),
         })
     }
@@ -322,6 +444,12 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
         assert_eq!(record.health.load(), WorkerHealth::Healthy);
+        let probe = record.probe.snapshot();
+        assert_eq!(probe.outcome, ProbeOutcome::Success);
+        assert_eq!(probe.status, Some(200));
+        assert!(probe.checked_at_unix_ms.is_some());
+        assert_eq!(probe.consecutive_successes, 1);
+        assert_eq!(probe.successes, 1);
         supervisor.cancel();
         assert!(matches!(supervisor.join_next().await, Some(Ok(()))));
         server.join().expect("join health fixture server");
@@ -402,6 +530,11 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
         assert_eq!(record.health.load(), WorkerHealth::Unhealthy);
+        let probe = record.probe.snapshot();
+        assert_eq!(probe.outcome, ProbeOutcome::TransportFailure);
+        assert_eq!(probe.status, None);
+        assert_eq!(probe.consecutive_failures, 1);
+        assert_eq!(probe.transport_failures, 1);
         supervisor.cancel();
         assert!(matches!(supervisor.join_next().await, Some(Ok(()))));
         server.join().expect("join timeout fixture server");
@@ -437,6 +570,11 @@ mod tests {
         })
         .await
         .expect("non-2xx observation must complete");
+        let probe = record.probe.snapshot();
+        assert_eq!(probe.outcome, ProbeOutcome::HttpFailure);
+        assert_eq!(probe.status, Some(503));
+        assert_eq!(probe.consecutive_failures, 1);
+        assert_eq!(probe.http_failures, 1);
         supervisor.cancel();
         assert!(matches!(supervisor.join_next().await, Some(Ok(()))));
         server.join().expect("join non-2xx fixture server");
@@ -499,6 +637,7 @@ mod tests {
             .await
             .expect("stalled probe cancellation must be bounded");
         assert!(matches!(joined, Some(Ok(()))));
+        assert_eq!(record.probe.snapshot().outcome, ProbeOutcome::Pending);
         release.store(true, Ordering::Release);
         server.join().expect("join stalled fixture server");
         assert!(!overlap.load(Ordering::Acquire));

--- a/sglang_omni_router/rust/src/worker_pool/health.rs
+++ b/sglang_omni_router/rust/src/worker_pool/health.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU8, AtomicU16, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, SystemTime};
 
 use tokio::sync::watch;
@@ -17,26 +17,16 @@ pub(crate) enum WorkerHealth {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[repr(u8)]
 pub(crate) enum ProbeOutcome {
-    Pending = 0,
-    Success = 1,
-    HttpFailure = 2,
-    TransportFailure = 3,
+    Pending,
+    Success,
+    HttpFailure,
+    TransportFailure,
 }
 
 impl ProbeOutcome {
     pub(crate) const OBSERVED: [Self; 3] =
         [Self::Success, Self::HttpFailure, Self::TransportFailure];
-
-    const fn from_atomic(value: u8) -> Self {
-        match value {
-            1 => Self::Success,
-            2 => Self::HttpFailure,
-            3 => Self::TransportFailure,
-            _ => Self::Pending,
-        }
-    }
 
     pub(crate) const fn label(self) -> &'static str {
         match self {
@@ -60,71 +50,59 @@ pub(crate) struct ProbeSnapshot {
     pub(crate) transport_failures: u64,
 }
 
-pub(super) struct AtomicProbe {
-    outcome: AtomicU8,
-    status: AtomicU16,
-    checked_at_unix_ms: AtomicU64,
-    consecutive_successes: AtomicU8,
-    consecutive_failures: AtomicU8,
-    successes: AtomicU64,
-    http_failures: AtomicU64,
-    transport_failures: AtomicU64,
+pub(super) struct ProbeState {
+    snapshot: Mutex<ProbeSnapshot>,
 }
 
-impl AtomicProbe {
+impl ProbeState {
     pub(super) const fn pending() -> Self {
         Self {
-            outcome: AtomicU8::new(ProbeOutcome::Pending as u8),
-            status: AtomicU16::new(0),
-            checked_at_unix_ms: AtomicU64::new(0),
-            consecutive_successes: AtomicU8::new(0),
-            consecutive_failures: AtomicU8::new(0),
-            successes: AtomicU64::new(0),
-            http_failures: AtomicU64::new(0),
-            transport_failures: AtomicU64::new(0),
+            snapshot: Mutex::new(ProbeSnapshot {
+                outcome: ProbeOutcome::Pending,
+                status: None,
+                checked_at_unix_ms: None,
+                consecutive_successes: 0,
+                consecutive_failures: 0,
+                successes: 0,
+                http_failures: 0,
+                transport_failures: 0,
+            }),
         }
     }
 
     fn record(&self, outcome: ProbeOutcome, status: Option<u16>, tracker: &ProbeTracker) {
+        let checked_at_unix_ms = SystemTime::UNIX_EPOCH
+            .elapsed()
+            .ok()
+            .and_then(|duration| u64::try_from(duration.as_millis()).ok());
+        let mut snapshot = self.state();
         match outcome {
             ProbeOutcome::Pending => {}
             ProbeOutcome::Success => {
-                self.successes.fetch_add(1, Ordering::Relaxed);
+                snapshot.successes = snapshot.successes.saturating_add(1);
             }
             ProbeOutcome::HttpFailure => {
-                self.http_failures.fetch_add(1, Ordering::Relaxed);
+                snapshot.http_failures = snapshot.http_failures.saturating_add(1);
             }
             ProbeOutcome::TransportFailure => {
-                self.transport_failures.fetch_add(1, Ordering::Relaxed);
+                snapshot.transport_failures = snapshot.transport_failures.saturating_add(1);
             }
         }
-        self.status.store(status.unwrap_or(0), Ordering::Relaxed);
-        self.consecutive_successes
-            .store(tracker.successes, Ordering::Relaxed);
-        self.consecutive_failures
-            .store(tracker.failures, Ordering::Relaxed);
-        let checked_at = SystemTime::UNIX_EPOCH
-            .elapsed()
-            .ok()
-            .and_then(|duration| u64::try_from(duration.as_millis()).ok())
-            .unwrap_or(0);
-        self.checked_at_unix_ms.store(checked_at, Ordering::Relaxed);
-        self.outcome.store(outcome as u8, Ordering::Release);
+        snapshot.outcome = outcome;
+        snapshot.status = status;
+        snapshot.checked_at_unix_ms = checked_at_unix_ms;
+        snapshot.consecutive_successes = tracker.successes;
+        snapshot.consecutive_failures = tracker.failures;
     }
 
     pub(super) fn snapshot(&self) -> ProbeSnapshot {
-        let outcome = ProbeOutcome::from_atomic(self.outcome.load(Ordering::Acquire));
-        let status = self.status.load(Ordering::Relaxed);
-        let checked_at_unix_ms = self.checked_at_unix_ms.load(Ordering::Relaxed);
-        ProbeSnapshot {
-            outcome,
-            status: (status != 0).then_some(status),
-            checked_at_unix_ms: (checked_at_unix_ms != 0).then_some(checked_at_unix_ms),
-            consecutive_successes: self.consecutive_successes.load(Ordering::Relaxed),
-            consecutive_failures: self.consecutive_failures.load(Ordering::Relaxed),
-            successes: self.successes.load(Ordering::Relaxed),
-            http_failures: self.http_failures.load(Ordering::Relaxed),
-            transport_failures: self.transport_failures.load(Ordering::Relaxed),
+        *self.state()
+    }
+
+    fn state(&self) -> MutexGuard<'_, ProbeSnapshot> {
+        match self.snapshot.lock() {
+            Ok(snapshot) => snapshot,
+            Err(poisoned) => poisoned.into_inner(),
         }
     }
 }
@@ -343,7 +321,7 @@ mod tests {
     use tokio::sync::Notify;
 
     use super::{
-        AtomicHealth, AtomicProbe, HealthSupervisor, ProbeOutcome, ProbeTracker, WorkerHealth,
+        AtomicHealth, HealthSupervisor, ProbeOutcome, ProbeState, ProbeTracker, WorkerHealth,
     };
     use crate::worker_pool::WorkerRecord;
     use crate::worker_pool::profile::{
@@ -376,7 +354,7 @@ mod tests {
             active_requests: AtomicUsize::new(0),
             session_capacity: [None, None],
             health: AtomicHealth::unknown(),
-            probe: AtomicProbe::pending(),
+            probe: ProbeState::pending(),
             immediate_probe: Notify::new(),
         })
     }
@@ -408,6 +386,68 @@ mod tests {
         assert_eq!(tracker.observe(true), WorkerHealth::Unhealthy);
         assert_eq!(tracker.observe(true), WorkerHealth::Healthy);
         assert_eq!(tracker.observe(false), WorkerHealth::Healthy);
+    }
+
+    #[test]
+    fn probe_snapshot_never_combines_adjacent_results() {
+        const ITERATIONS: u64 = 20_000;
+
+        let probe = Arc::new(ProbeState::pending());
+        let complete = Arc::new(AtomicBool::new(false));
+        let writer_probe = Arc::clone(&probe);
+        let writer_complete = Arc::clone(&complete);
+        let writer = thread::spawn(move || {
+            let mut success = ProbeTracker::new(1, 1);
+            let _state = success.observe(true);
+            let mut failure = ProbeTracker::new(1, 1);
+            let _state = failure.observe(false);
+            for _ in 0..ITERATIONS {
+                writer_probe.record(ProbeOutcome::Success, Some(200), &success);
+                writer_probe.record(ProbeOutcome::HttpFailure, Some(503), &failure);
+            }
+            writer_complete.store(true, Ordering::Release);
+        });
+
+        while !complete.load(Ordering::Acquire) {
+            let snapshot = probe.snapshot();
+            match snapshot.outcome {
+                ProbeOutcome::Pending => {
+                    assert_eq!(snapshot.status, None);
+                    assert_eq!((snapshot.successes, snapshot.http_failures), (0, 0));
+                }
+                ProbeOutcome::Success => {
+                    assert_eq!(snapshot.status, Some(200));
+                    assert_eq!(
+                        (
+                            snapshot.consecutive_successes,
+                            snapshot.consecutive_failures
+                        ),
+                        (1, 0)
+                    );
+                    assert_eq!(snapshot.successes, snapshot.http_failures + 1);
+                }
+                ProbeOutcome::HttpFailure => {
+                    assert_eq!(snapshot.status, Some(503));
+                    assert_eq!(
+                        (
+                            snapshot.consecutive_successes,
+                            snapshot.consecutive_failures
+                        ),
+                        (0, 1)
+                    );
+                    assert_eq!(snapshot.successes, snapshot.http_failures);
+                }
+                ProbeOutcome::TransportFailure => {
+                    panic!("writer does not publish transport failures")
+                }
+            }
+            assert_eq!(snapshot.transport_failures, 0);
+        }
+        writer.join().expect("join probe writer");
+        let final_snapshot = probe.snapshot();
+        assert_eq!(final_snapshot.outcome, ProbeOutcome::HttpFailure);
+        assert_eq!(final_snapshot.successes, ITERATIONS);
+        assert_eq!(final_snapshot.http_failures, ITERATIONS);
     }
 
     #[tokio::test]

--- a/sglang_omni_router/rust/src/worker_pool/mod.rs
+++ b/sglang_omni_router/rust/src/worker_pool/mod.rs
@@ -25,13 +25,60 @@ pub(crate) use resolver::{ConnectTarget, ResolvedTarget};
 use admission::AdmissionController;
 use health::AtomicHealth;
 use profile::{
-    MAX_WORKERS, RegistrationId, ServiceProfile, VoiceNamePolicy, WorkerCapacityConfig, WorkerId,
+    CAPACITY_CLASS_COUNT, MAX_WORKERS, RegistrationId, ServiceProfile, VoiceNamePolicy,
+    WorkerCapacityConfig, WorkerId,
 };
 use resolver::{build_health_client, build_http_client};
 use selection::{Selector, SelectorGuard};
 
 struct SessionCapacity {
+    limit: usize,
     semaphore: Arc<Semaphore>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct SessionCapacitySnapshot {
+    pub(crate) class: CapacityClass,
+    pub(crate) limit: usize,
+    pub(crate) in_flight: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AdmissionClass {
+    Global,
+    Service(CapacityClass),
+}
+
+impl AdmissionClass {
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Global => "global",
+            Self::Service(class) => class.label(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct AdmissionSnapshot {
+    pub(crate) class: AdmissionClass,
+    pub(crate) limit: usize,
+    pub(crate) in_flight: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct WorkerSnapshot {
+    pub(crate) worker_id: String,
+    pub(crate) registration_ordinal: usize,
+    pub(crate) health: WorkerHealth,
+    pub(crate) routable: bool,
+    pub(crate) active_requests: usize,
+    pub(crate) session_capacity: Vec<SessionCapacitySnapshot>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct OperationsSnapshot {
+    pub(crate) admission: [AdmissionSnapshot; CAPACITY_CLASS_COUNT + 1],
+    pub(crate) workers: Vec<WorkerSnapshot>,
 }
 
 /// One static startup registration with independently updated health and load.
@@ -534,6 +581,43 @@ impl WorkerPool {
             .map(|cohort| ContentBlindMediaHttp { pool: self, cohort })
     }
 
+    pub(crate) fn operations_snapshot(&self) -> OperationsSnapshot {
+        let raw_admission = self.admission.snapshot();
+        let admission = std::array::from_fn(|index| AdmissionSnapshot {
+            class: if index == 0 {
+                AdmissionClass::Global
+            } else {
+                AdmissionClass::Service(CapacityClass::ALL[index - 1])
+            },
+            limit: raw_admission[index].0,
+            in_flight: raw_admission[index].1,
+        });
+        let workers = self
+            .records
+            .iter()
+            .map(|record| WorkerSnapshot {
+                worker_id: record.worker_id.as_str().to_owned(),
+                registration_ordinal: record.registration_id.startup_ordinal(),
+                health: record.health.load(),
+                routable: record.is_routable(),
+                active_requests: record.load(),
+                session_capacity: SESSION_CAPACITY_CLASSES
+                    .into_iter()
+                    .filter_map(|class| {
+                        record
+                            .session_capacity(class)
+                            .map(|capacity| SessionCapacitySnapshot {
+                                class,
+                                limit: capacity.limit,
+                                in_flight: capacity.limit - capacity.semaphore.available_permits(),
+                            })
+                    })
+                    .collect(),
+            })
+            .collect();
+        OperationsSnapshot { admission, workers }
+    }
+
     pub(crate) fn generation_http_ready(&self, trust: &TrustDomain) -> bool {
         self.records.iter().any(|record| {
             &record.trust_domain == trust
@@ -768,6 +852,11 @@ fn generation_rows_equal(left: &[ServiceProfile], right: &[ServiceProfile]) -> b
     service_rows_equal(left, right, ServiceClass::GenerationHttp, None)
 }
 
+const SESSION_CAPACITY_CLASSES: [CapacityClass; 2] = [
+    CapacityClass::SpeechWebsocket,
+    CapacityClass::RealtimeWebsocket,
+];
+
 const fn session_capacity_index(class: CapacityClass) -> Option<usize> {
     match class {
         CapacityClass::SpeechWebsocket => Some(0),
@@ -789,6 +878,7 @@ fn build_session_capacity(
             .map_err(|_| crate::error::RouterError::WorkerPoolInvariant)
             .map(|limit| {
                 limit.map(|limit| SessionCapacity {
+                    limit,
                     semaphore: Arc::new(Semaphore::new(limit)),
                 })
             })
@@ -1383,6 +1473,7 @@ mod tests {
             Arc::get_mut(&mut record)
                 .expect("new test record is uniquely owned")
                 .session_capacity[0] = Some(SessionCapacity {
+                limit: 1,
                 semaphore: Arc::new(Semaphore::new(1)),
             });
             record
@@ -1460,6 +1551,7 @@ mod tests {
             Arc::get_mut(&mut record)
                 .expect("new test record is uniquely owned")
                 .session_capacity[0] = Some(SessionCapacity {
+                limit: 1,
                 semaphore: Arc::new(Semaphore::new(1)),
             });
             record
@@ -1540,6 +1632,7 @@ mod tests {
         Arc::get_mut(&mut record)
             .expect("new test record is uniquely owned")
             .session_capacity[1] = Some(SessionCapacity {
+            limit: 1,
             semaphore: Arc::new(Semaphore::new(1)),
         });
         let mut pool = pool(RoutingStrategy::LeastRequests, vec![Arc::clone(&record)], 2);
@@ -1557,6 +1650,15 @@ mod tests {
             )
             .expect("first session");
         assert_eq!(record.load(), 1);
+        let snapshot = pool.operations_snapshot();
+        assert_eq!(snapshot.workers[0].active_requests, 1);
+        assert_eq!(snapshot.workers[0].session_capacity.len(), 1);
+        assert_eq!(
+            snapshot.workers[0].session_capacity[0].class,
+            CapacityClass::RealtimeWebsocket
+        );
+        assert_eq!(snapshot.workers[0].session_capacity[0].limit, 1);
+        assert_eq!(snapshot.workers[0].session_capacity[0].in_flight, 1);
         assert!(matches!(
             pool.dispatch_session(
                 pool.try_admit(CapacityClass::RealtimeWebsocket, 1)
@@ -1587,6 +1689,7 @@ mod tests {
             Arc::get_mut(&mut record)
                 .expect("new test record is uniquely owned")
                 .session_capacity[1] = Some(SessionCapacity {
+                limit: 1,
                 semaphore: Arc::new(Semaphore::new(1)),
             });
             record
@@ -1635,6 +1738,55 @@ mod tests {
             Err(DispatchError::Unavailable)
         ));
         assert_eq!((alpha.load(), beta.load()), (0, 0));
+    }
+
+    #[test]
+    fn operations_snapshot_reads_exact_permits_and_releases_with_the_lease() {
+        let pool = pool(
+            RoutingStrategy::RoundRobin,
+            vec![record(0, "local", "omni")],
+            4,
+        );
+        let initial = pool.operations_snapshot();
+        assert_eq!(initial.admission[0].class, AdmissionClass::Global);
+        assert_eq!(initial.admission[0].limit, 4);
+        assert_eq!(initial.admission[0].in_flight, 0);
+        assert_eq!(
+            initial.admission[1].class,
+            AdmissionClass::Service(CapacityClass::GenerationHttp)
+        );
+        assert_eq!(initial.admission[1].limit, 4);
+        assert_eq!(initial.admission[2].limit, 0);
+        assert_eq!(initial.workers[0].worker_id, "worker-0");
+        assert_eq!(initial.workers[0].registration_ordinal, 0);
+        assert_eq!(initial.workers[0].health, WorkerHealth::Healthy);
+        assert!(initial.workers[0].routable);
+        assert_eq!(initial.workers[0].active_requests, 0);
+        assert!(initial.workers[0].session_capacity.is_empty());
+
+        let lease = pool
+            .dispatch(
+                pool.try_admit(CapacityClass::GenerationHttp, 1)
+                    .expect("snapshot admission"),
+                &requirement("omni", "local"),
+            )
+            .expect("snapshot dispatch");
+        let occupied = pool.operations_snapshot();
+        assert_eq!(occupied.admission[0].in_flight, 1);
+        assert_eq!(occupied.admission[1].in_flight, 1);
+        assert_eq!(occupied.workers[0].active_requests, 1);
+
+        drop(lease);
+        let released = pool.operations_snapshot();
+        assert_eq!(released.admission[0].in_flight, 0);
+        assert_eq!(released.admission[1].in_flight, 0);
+        assert_eq!(released.workers[0].active_requests, 0);
+
+        pool.records[0].health.store(WorkerHealth::Unhealthy);
+        pool.drain();
+        let drained = pool.operations_snapshot();
+        assert_eq!(drained.workers[0].health, WorkerHealth::Unhealthy);
+        assert!(!drained.workers[0].routable);
     }
 
     #[test]
@@ -1806,6 +1958,7 @@ mod tests {
             active_requests: AtomicUsize::new(0),
             session_capacity: [
                 Some(SessionCapacity {
+                    limit: 1,
                     semaphore: Arc::new(Semaphore::new(1)),
                 }),
                 None,

--- a/sglang_omni_router/rust/src/worker_pool/mod.rs
+++ b/sglang_omni_router/rust/src/worker_pool/mod.rs
@@ -24,7 +24,7 @@ pub(crate) use profile::{
 pub(crate) use resolver::{ConnectTarget, ResolvedTarget};
 
 use admission::AdmissionController;
-use health::{AtomicHealth, AtomicProbe};
+use health::{AtomicHealth, ProbeState};
 use profile::{
     CAPACITY_CLASS_COUNT, MAX_WORKERS, RegistrationId, ServiceProfile, VoiceNamePolicy,
     WorkerCapacityConfig, WorkerId,
@@ -95,7 +95,7 @@ pub(super) struct WorkerRecord {
     active_requests: AtomicUsize,
     session_capacity: [Option<SessionCapacity>; 2],
     health: AtomicHealth,
-    probe: AtomicProbe,
+    probe: ProbeState,
     immediate_probe: Notify,
 }
 
@@ -233,7 +233,7 @@ impl WorkerPool {
                 active_requests: AtomicUsize::new(0),
                 session_capacity: build_session_capacity(&worker.capacity)?,
                 health: AtomicHealth::unknown(),
-                probe: AtomicProbe::pending(),
+                probe: ProbeState::pending(),
                 immediate_probe: Notify::new(),
             }));
         }
@@ -1031,7 +1031,7 @@ mod tests {
             active_requests: AtomicUsize::new(0),
             session_capacity: [None, None],
             health,
-            probe: AtomicProbe::pending(),
+            probe: ProbeState::pending(),
             immediate_probe: Notify::new(),
         })
     }
@@ -1936,7 +1936,7 @@ mod tests {
             active_requests: AtomicUsize::new(0),
             session_capacity: [None, None],
             health,
-            probe: AtomicProbe::pending(),
+            probe: ProbeState::pending(),
             immediate_probe: Notify::new(),
         })
     }
@@ -2059,7 +2059,7 @@ mod tests {
                 None,
             ],
             health,
-            probe: AtomicProbe::pending(),
+            probe: ProbeState::pending(),
             immediate_probe: Notify::new(),
         })
     }

--- a/sglang_omni_router/rust/src/worker_pool/mod.rs
+++ b/sglang_omni_router/rust/src/worker_pool/mod.rs
@@ -69,6 +69,7 @@ pub(crate) struct AdmissionSnapshot {
 pub(crate) struct WorkerSnapshot {
     pub(crate) worker_id: String,
     pub(crate) registration_ordinal: usize,
+    pub(crate) voice_owner: bool,
     pub(crate) health: WorkerHealth,
     pub(crate) routable: bool,
     pub(crate) active_requests: usize,
@@ -595,24 +596,32 @@ impl WorkerPool {
         let workers = self
             .records
             .iter()
-            .map(|record| WorkerSnapshot {
-                worker_id: record.worker_id.as_str().to_owned(),
-                registration_ordinal: record.registration_id.startup_ordinal(),
-                health: record.health.load(),
-                routable: record.is_routable(),
-                active_requests: record.load(),
-                session_capacity: SESSION_CAPACITY_CLASSES
-                    .into_iter()
-                    .filter_map(|class| {
-                        record
-                            .session_capacity(class)
-                            .map(|capacity| SessionCapacitySnapshot {
-                                class,
-                                limit: capacity.limit,
-                                in_flight: capacity.limit - capacity.semaphore.available_permits(),
-                            })
-                    })
-                    .collect(),
+            .map(|record| {
+                let health = record.health.load();
+                WorkerSnapshot {
+                    worker_id: record.worker_id.as_str().to_owned(),
+                    registration_ordinal: record.registration_id.startup_ordinal(),
+                    voice_owner: self
+                        .voice_owner
+                        .as_ref()
+                        .is_some_and(|owner| Arc::ptr_eq(owner, record)),
+                    health,
+                    routable: health == WorkerHealth::Healthy,
+                    active_requests: record.load(),
+                    session_capacity: SESSION_CAPACITY_CLASSES
+                        .into_iter()
+                        .filter_map(|class| {
+                            record
+                                .session_capacity(class)
+                                .map(|capacity| SessionCapacitySnapshot {
+                                    class,
+                                    limit: capacity.limit,
+                                    in_flight: capacity.limit
+                                        - capacity.semaphore.available_permits(),
+                                })
+                        })
+                        .collect(),
+                }
             })
             .collect();
         OperationsSnapshot { admission, workers }
@@ -852,7 +861,7 @@ fn generation_rows_equal(left: &[ServiceProfile], right: &[ServiceProfile]) -> b
     service_rows_equal(left, right, ServiceClass::GenerationHttp, None)
 }
 
-const SESSION_CAPACITY_CLASSES: [CapacityClass; 2] = [
+pub(crate) const SESSION_CAPACITY_CLASSES: [CapacityClass; 2] = [
     CapacityClass::SpeechWebsocket,
     CapacityClass::RealtimeWebsocket,
 ];
@@ -1759,6 +1768,7 @@ mod tests {
         assert_eq!(initial.admission[2].limit, 0);
         assert_eq!(initial.workers[0].worker_id, "worker-0");
         assert_eq!(initial.workers[0].registration_ordinal, 0);
+        assert!(!initial.workers[0].voice_owner);
         assert_eq!(initial.workers[0].health, WorkerHealth::Healthy);
         assert!(initial.workers[0].routable);
         assert_eq!(initial.workers[0].active_requests, 0);
@@ -2049,6 +2059,9 @@ mod tests {
                 AdmissionController::new(8, [None, Some(4), Some(4), None, Some(4), None]);
 
             assert!(pool.voice_owner_ready());
+            let snapshot = pool.operations_snapshot();
+            assert!(snapshot.workers[0].voice_owner);
+            assert!(!snapshot.workers[1].voice_owner);
             assert!(
                 pool.content_blind_media_http(
                     &TrustDomain::new(String::from("local")),

--- a/sglang_omni_router/rust/src/worker_pool/mod.rs
+++ b/sglang_omni_router/rust/src/worker_pool/mod.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::sync::{Notify, Semaphore};
 
 use crate::config::{Config, RoutingStrategy};
+use crate::metrics::{Rejection, RouterMetrics};
 
 pub(crate) use admission::{
     AdmissionError, AdmissionLease, DispatchError, EnvelopeLease, RequestLease,
@@ -153,6 +154,7 @@ pub(crate) struct WorkerPool {
     homogeneous_media_http: Vec<HomogeneousMediaCohort>,
     health_client: reqwest::Client,
     http_client: reqwest::Client,
+    metrics: Arc<RouterMetrics>,
 }
 
 struct HomogeneousGenerationCohort {
@@ -183,7 +185,10 @@ pub(crate) struct ContentBlindMediaHttp<'a> {
 }
 
 impl WorkerPool {
-    pub(crate) fn build(config: &Config) -> Result<Self, crate::error::RouterError> {
+    pub(crate) fn build(
+        config: &Config,
+        metrics: Arc<RouterMetrics>,
+    ) -> Result<Self, crate::error::RouterError> {
         let targets: Vec<_> = config
             .workers
             .iter()
@@ -257,6 +262,7 @@ impl WorkerPool {
             homogeneous_media_http,
             health_client,
             http_client,
+            metrics,
         })
     }
 
@@ -279,11 +285,16 @@ impl WorkerPool {
         class: CapacityClass,
         credits: u32,
     ) -> Result<AdmissionLease, AdmissionError> {
-        self.admission.try_admit(class, credits)
+        let envelope = self.try_admit_envelope()?;
+        self.try_admit_class(envelope, class, credits)
     }
 
     pub(crate) fn try_admit_envelope(&self) -> Result<EnvelopeLease, AdmissionError> {
-        self.admission.try_admit_envelope()
+        let admitted = self.admission.try_admit_envelope();
+        if matches!(admitted, Err(AdmissionError::Overloaded)) {
+            self.metrics.record_rejection(Rejection::GlobalAdmission);
+        }
+        admitted
     }
 
     pub(crate) fn try_admit_class(
@@ -292,7 +303,11 @@ impl WorkerPool {
         class: CapacityClass,
         credits: u32,
     ) -> Result<AdmissionLease, AdmissionError> {
-        self.admission.try_admit_class(envelope, class, credits)
+        let admitted = self.admission.try_admit_class(envelope, class, credits);
+        if matches!(admitted, Err(AdmissionError::Overloaded)) {
+            self.metrics.record_rejection(Rejection::admission(class));
+        }
+        admitted
     }
 
     pub(crate) fn dispatch(
@@ -351,7 +366,7 @@ impl WorkerPool {
                 .ok_or(DispatchError::Internal)?;
             let permit = Arc::clone(&capacity.semaphore)
                 .try_acquire_owned()
-                .map_err(|_| DispatchError::Overloaded)?;
+                .map_err(|_| self.session_overloaded(class))?;
             let lease = RequestLease::new_session(admission, permit, Arc::clone(owner));
             drop(selector);
             return Ok(lease);
@@ -397,7 +412,7 @@ impl WorkerPool {
             return Err(DispatchError::Unavailable);
         }
         if eligible_count == 0 {
-            return Err(DispatchError::Overloaded);
+            return Err(self.session_overloaded(class));
         }
 
         let eligible = &eligible[..eligible_count];
@@ -420,6 +435,13 @@ impl WorkerPool {
         let lease = RequestLease::new_session(admission, permit, selected);
         drop(selector);
         Ok(lease)
+    }
+
+    fn session_overloaded(&self, class: CapacityClass) -> DispatchError {
+        if let Some(rejection) = Rejection::worker(class) {
+            self.metrics.record_rejection(rejection);
+        }
+        DispatchError::Overloaded
     }
 
     fn matching_profiles(
@@ -908,6 +930,8 @@ mod tests {
     use std::sync::{Arc, Barrier};
     use std::thread;
 
+    use crate::metrics::Rejection;
+
     use super::profile::{
         InputModality, MessageContentForm, ModelSelection, OutputModality, ProfileRequirement,
         ServiceProfile, StreamMode, VoiceNamePolicy,
@@ -1039,6 +1063,7 @@ mod tests {
             selector,
             health_client: client.clone(),
             http_client: client,
+            metrics: crate::metrics::RouterMetrics::new(),
         }
     }
 
@@ -1641,6 +1666,55 @@ mod tests {
     }
 
     #[test]
+    fn admission_rejections_are_counted_at_the_saturated_resource() {
+        let mut class_limited = pool(
+            RoutingStrategy::RoundRobin,
+            vec![record(0, "local", "omni")],
+            2,
+        );
+        class_limited.admission =
+            AdmissionController::new(2, [Some(1), None, None, None, None, None]);
+        let held = class_limited
+            .try_admit(CapacityClass::GenerationHttp, 1)
+            .expect("hold generation admission");
+        assert!(matches!(
+            class_limited.try_admit(CapacityClass::GenerationHttp, 1),
+            Err(AdmissionError::Overloaded)
+        ));
+        assert_eq!(
+            class_limited
+                .metrics
+                .rejections(Rejection::GenerationAdmission),
+            1
+        );
+        assert_eq!(
+            class_limited.metrics.rejections(Rejection::GlobalAdmission),
+            0
+        );
+        drop(held);
+
+        let global_limited = pool(
+            RoutingStrategy::RoundRobin,
+            vec![record(0, "local", "omni")],
+            1,
+        );
+        let held = global_limited
+            .try_admit_envelope()
+            .expect("hold global admission");
+        assert!(matches!(
+            global_limited.try_admit_envelope(),
+            Err(AdmissionError::Overloaded)
+        ));
+        assert_eq!(
+            global_limited
+                .metrics
+                .rejections(Rejection::GlobalAdmission),
+            1
+        );
+        drop(held);
+    }
+
+    #[test]
     fn websocket_sessions_hold_exact_worker_capacity_and_active_load() {
         let mut record = record_with_profile(0, "local", "omni", ServiceProfile::RealtimeWebsocket);
         Arc::get_mut(&mut record)
@@ -1681,6 +1755,10 @@ mod tests {
             ),
             Err(DispatchError::Overloaded)
         ));
+        assert_eq!(
+            pool.metrics.rejections(Rejection::RealtimeWebsocketWorker),
+            1
+        );
 
         drop(first);
         let reused = pool
@@ -1882,6 +1960,7 @@ mod tests {
             selector,
             health_client: client.clone(),
             http_client: client,
+            metrics: crate::metrics::RouterMetrics::new(),
         }
     }
 

--- a/sglang_omni_router/rust/src/worker_pool/mod.rs
+++ b/sglang_omni_router/rust/src/worker_pool/mod.rs
@@ -14,7 +14,7 @@ use crate::config::{Config, RoutingStrategy};
 pub(crate) use admission::{
     AdmissionError, AdmissionLease, DispatchError, EnvelopeLease, RequestLease,
 };
-pub(crate) use health::{HealthSupervisor, WorkerHealth};
+pub(crate) use health::{HealthSupervisor, ProbeOutcome, ProbeSnapshot, WorkerHealth};
 pub(crate) use profile::{
     CapacityClass, ChatAudioFormat, MediaPlacement, MessageContentForm, ModelSelection,
     ProfileRequirement, ReferenceForm, RouteRequirement, ServiceClass, SpeechResponseFormat,
@@ -23,7 +23,7 @@ pub(crate) use profile::{
 pub(crate) use resolver::{ConnectTarget, ResolvedTarget};
 
 use admission::AdmissionController;
-use health::AtomicHealth;
+use health::{AtomicHealth, AtomicProbe};
 use profile::{
     CAPACITY_CLASS_COUNT, MAX_WORKERS, RegistrationId, ServiceProfile, VoiceNamePolicy,
     WorkerCapacityConfig, WorkerId,
@@ -71,6 +71,7 @@ pub(crate) struct WorkerSnapshot {
     pub(crate) registration_ordinal: usize,
     pub(crate) voice_owner: bool,
     pub(crate) health: WorkerHealth,
+    pub(crate) probe: ProbeSnapshot,
     pub(crate) routable: bool,
     pub(crate) active_requests: usize,
     pub(crate) session_capacity: Vec<SessionCapacitySnapshot>,
@@ -93,6 +94,7 @@ pub(super) struct WorkerRecord {
     active_requests: AtomicUsize,
     session_capacity: [Option<SessionCapacity>; 2],
     health: AtomicHealth,
+    probe: AtomicProbe,
     immediate_probe: Notify,
 }
 
@@ -226,6 +228,7 @@ impl WorkerPool {
                 active_requests: AtomicUsize::new(0),
                 session_capacity: build_session_capacity(&worker.capacity)?,
                 health: AtomicHealth::unknown(),
+                probe: AtomicProbe::pending(),
                 immediate_probe: Notify::new(),
             }));
         }
@@ -606,6 +609,7 @@ impl WorkerPool {
                         .as_ref()
                         .is_some_and(|owner| Arc::ptr_eq(owner, record)),
                     health,
+                    probe: record.probe.snapshot(),
                     routable: health == WorkerHealth::Healthy,
                     active_requests: record.load(),
                     session_capacity: SESSION_CAPACITY_CLASSES
@@ -1003,6 +1007,7 @@ mod tests {
             active_requests: AtomicUsize::new(0),
             session_capacity: [None, None],
             health,
+            probe: AtomicProbe::pending(),
             immediate_probe: Notify::new(),
         })
     }
@@ -1853,6 +1858,7 @@ mod tests {
             active_requests: AtomicUsize::new(0),
             session_capacity: [None, None],
             health,
+            probe: AtomicProbe::pending(),
             immediate_probe: Notify::new(),
         })
     }
@@ -1974,6 +1980,7 @@ mod tests {
                 None,
             ],
             health,
+            probe: AtomicProbe::pending(),
             immediate_probe: Notify::new(),
         })
     }

--- a/sglang_omni_router/rust/src/worker_pool/profile.rs
+++ b/sglang_omni_router/rust/src/worker_pool/profile.rs
@@ -36,7 +36,27 @@ pub(crate) enum CapacityClass {
 pub(super) const CAPACITY_CLASS_COUNT: usize = 6;
 
 impl CapacityClass {
-    pub(super) const fn index(self) -> usize {
+    pub(crate) const ALL: [Self; CAPACITY_CLASS_COUNT] = [
+        Self::GenerationHttp,
+        Self::SpeechHttp,
+        Self::SpeechBatch,
+        Self::TranscriptionHttp,
+        Self::SpeechWebsocket,
+        Self::RealtimeWebsocket,
+    ];
+
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::GenerationHttp => "generation_http",
+            Self::SpeechHttp => "speech_http",
+            Self::SpeechBatch => "speech_batch",
+            Self::TranscriptionHttp => "transcription_http",
+            Self::SpeechWebsocket => "speech_websocket",
+            Self::RealtimeWebsocket => "realtime_websocket",
+        }
+    }
+
+    pub(crate) const fn index(self) -> usize {
         match self {
             Self::GenerationHttp => 0,
             Self::SpeechHttp => 1,
@@ -887,6 +907,17 @@ impl ServiceProfile {
             | Self::TranscriptionHttp { model_ids, .. }
             | Self::SpeechWebsocket { model_ids, .. } => model_ids.iter().any(|item| item == model),
             Self::RealtimeWebsocket => true,
+        }
+    }
+
+    pub(crate) fn model_ids(&self) -> Option<&[String]> {
+        match self {
+            Self::GenerationHttp { model_ids, .. }
+            | Self::SpeechHttp { model_ids, .. }
+            | Self::SpeechBatch { model_ids, .. }
+            | Self::TranscriptionHttp { model_ids, .. }
+            | Self::SpeechWebsocket { model_ids, .. } => Some(model_ids),
+            Self::RealtimeWebsocket { .. } => None,
         }
     }
 

--- a/sglang_omni_router/rust/src/worker_pool/profile.rs
+++ b/sglang_omni_router/rust/src/worker_pool/profile.rs
@@ -900,14 +900,8 @@ impl ServiceProfile {
     }
 
     fn contains_model(&self, model: &str) -> bool {
-        match self {
-            Self::GenerationHttp { model_ids, .. }
-            | Self::SpeechHttp { model_ids, .. }
-            | Self::SpeechBatch { model_ids, .. }
-            | Self::TranscriptionHttp { model_ids, .. }
-            | Self::SpeechWebsocket { model_ids, .. } => model_ids.iter().any(|item| item == model),
-            Self::RealtimeWebsocket => true,
-        }
+        self.model_ids()
+            .is_none_or(|ids| ids.iter().any(|id| id == model))
     }
 
     pub(crate) fn model_ids(&self) -> Option<&[String]> {

--- a/sglang_omni_router/rust/tests/chat_http.rs
+++ b/sglang_omni_router/rust/tests/chat_http.rs
@@ -572,6 +572,7 @@ impl RouterProcess {
         };
         process.wait_live();
         process.wait_ready();
+        process.wait_for_healthy_workers(workers.len());
         process
     }
 
@@ -607,6 +608,32 @@ impl RouterProcess {
                 panic!("router exited before readiness: {status}");
             }
             assert!(Instant::now() < deadline, "router did not become ready");
+            thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    fn wait_for_healthy_workers(&mut self, count: usize) {
+        let expected =
+            format!("sglang_omni_router_workers_by_health{{health=\"healthy\"}} {count}\n");
+        let deadline = Instant::now() + DEADLINE;
+        loop {
+            if let Ok(response) = raw_request(
+                self.address,
+                b"GET /metrics HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+            ) && response.starts_with(b"HTTP/1.1 200")
+                && response
+                    .windows(expected.len())
+                    .any(|window| window == expected.as_bytes())
+            {
+                return;
+            }
+            if let Some(status) = self.child.try_wait().expect("poll router health") {
+                panic!("router exited before every worker was healthy: {status}");
+            }
+            assert!(
+                Instant::now() < deadline,
+                "not every configured worker became healthy"
+            );
             thread::sleep(Duration::from_millis(5));
         }
     }

--- a/sglang_omni_router/rust/tests/chat_http.rs
+++ b/sglang_omni_router/rust/tests/chat_http.rs
@@ -613,6 +613,16 @@ fn post_when_capacity_releases(address: SocketAddr) -> Vec<u8> {
     }
 }
 
+fn metrics(address: SocketAddr) -> String {
+    let response = raw_request(
+        address,
+        b"GET /metrics HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+    )
+    .expect("read router metrics");
+    assert_eq!(status(&response), 200);
+    String::from_utf8(response).expect("metrics are UTF-8")
+}
+
 fn status(response: &[u8]) -> u16 {
     let line_end = response
         .windows(2)
@@ -831,6 +841,9 @@ fn relay_holds_admission_and_is_not_cut_off_after_commitment() {
     let slow_response = slow.join().expect("join slow client");
     assert_eq!(status(&slow_response), 200);
     assert!(slow_response.windows(6).any(|part| part == b"[DONE]"));
+    assert!(metrics(router.address).contains(
+        "sglang_omni_router_http_response_body_terminations_total{outcome=\"complete\"} 1\n"
+    ));
 
     drop(router);
     drop(worker);
@@ -1167,6 +1180,13 @@ fn early_upload_eof_and_downstream_disconnect_release_admission() {
         release_started.elapsed() < Duration::from_secs(1),
         "admission was released only when the upstream stream ended"
     );
+    let observed = metrics(router.address);
+    assert!(
+        observed.contains(
+            "sglang_omni_router_http_response_body_terminations_total{outcome=\"dropped\"} 1\n"
+        ),
+        "unexpected body termination metrics:\n{observed}"
+    );
 }
 
 #[test]
@@ -1260,6 +1280,9 @@ fn upstream_failure_after_sse_commitment_releases_capacity() {
 
     let recovered = post_when_capacity_releases(router.address);
     assert_ne!(status(&recovered), 429);
+    assert!(metrics(router.address).contains(
+        "sglang_omni_router_http_response_body_terminations_total{outcome=\"upstream_error\"} 1\n"
+    ));
 }
 
 #[test]

--- a/sglang_omni_router/rust/tests/chat_http.rs
+++ b/sglang_omni_router/rust/tests/chat_http.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -38,6 +38,7 @@ struct Worker {
     health_requests: Arc<AtomicUsize>,
     application_requests: Arc<AtomicUsize>,
     captured: Arc<Mutex<Vec<Captured>>>,
+    response_gate: Arc<(Mutex<bool>, Condvar)>,
     thread: Option<JoinHandle<()>>,
     _guard: Rc<MutexGuard<'static, ()>>,
 }
@@ -93,11 +94,13 @@ impl Worker {
         let health_requests = Arc::new(AtomicUsize::new(0));
         let application_requests = Arc::new(AtomicUsize::new(0));
         let captured = Arc::new(Mutex::new(Vec::new()));
+        let response_gate = Arc::new((Mutex::new(false), Condvar::new()));
         let thread_stop = Arc::clone(&stop);
         let thread_healthy = Arc::clone(&healthy);
         let thread_health_requests = Arc::clone(&health_requests);
         let thread_application_requests = Arc::clone(&application_requests);
         let thread_captured = Arc::clone(&captured);
+        let thread_response_gate = Arc::clone(&response_gate);
         let thread = thread::spawn(move || {
             let mut connections = Vec::new();
             while !thread_stop.load(Ordering::Acquire) {
@@ -107,6 +110,7 @@ impl Worker {
                         let healthy = Arc::clone(&thread_healthy);
                         let health_requests = Arc::clone(&thread_health_requests);
                         let application_requests = Arc::clone(&thread_application_requests);
+                        let response_gate = Arc::clone(&thread_response_gate);
                         connections.push(thread::spawn(move || {
                             serve_connection(
                                 stream,
@@ -115,6 +119,7 @@ impl Worker {
                                 health_requests,
                                 application_requests,
                                 behavior,
+                                response_gate,
                             );
                         }));
                     }
@@ -145,6 +150,7 @@ impl Worker {
             health_requests,
             application_requests,
             captured,
+            response_gate,
             thread: Some(thread),
             _guard: guard,
         }
@@ -173,6 +179,14 @@ impl Worker {
         }
     }
 
+    fn release_response(&self) {
+        let (released, changed) = &*self.response_gate;
+        *released
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = true;
+        changed.notify_all();
+    }
+
     fn set_healthy(&self, healthy: bool) -> usize {
         self.healthy.store(healthy, Ordering::Release);
         self.health_requests.load(Ordering::Acquire)
@@ -192,6 +206,7 @@ impl Worker {
 
 impl Drop for Worker {
     fn drop(&mut self) {
+        self.release_response();
         self.stop.store(true, Ordering::Release);
         let _wake = TcpStream::connect(self.address);
         if let Some(thread) = self.thread.take() {
@@ -221,6 +236,7 @@ fn serve_connection(
     health_requests: Arc<AtomicUsize>,
     application_requests: Arc<AtomicUsize>,
     behavior: WorkerBehavior,
+    response_gate: Arc<(Mutex<bool>, Condvar)>,
 ) {
     stream
         .set_nonblocking(false)
@@ -290,6 +306,14 @@ fn serve_connection(
                 thread::sleep(Duration::from_millis(750));
                 write_response(&mut stream, b"E\r\ndata: [DONE]\n\n\r\n0\r\n\r\n");
             }
+            b"controlled-stream" => {
+                write_response(
+                    &mut stream,
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\nB\r\ndata: one\n\n\r\n",
+                );
+                wait_for_response_release(&response_gate);
+                write_response(&mut stream, b"E\r\ndata: [DONE]\n\n\r\n0\r\n\r\n");
+            }
             b"disconnect-hold" => {
                 write_response(
                     &mut stream,
@@ -300,6 +324,13 @@ fn serve_connection(
             }
             b"timeout" => {
                 thread::sleep(Duration::from_millis(750));
+                write_response(
+                    &mut stream,
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 2\r\n\r\n{}",
+                );
+            }
+            b"controlled-headers" => {
+                wait_for_response_release(&response_gate);
                 write_response(
                     &mut stream,
                     b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 2\r\n\r\n{}",
@@ -335,6 +366,16 @@ fn serve_connection(
             ),
         }
     }
+}
+
+fn wait_for_response_release(response_gate: &(Mutex<bool>, Condvar)) {
+    let (released, changed) = response_gate;
+    let released = released.lock().expect("lock response gate");
+    let (released, timeout) = changed
+        .wait_timeout_while(released, DEADLINE, |released| !*released)
+        .expect("wait for response release");
+    drop(released);
+    assert!(!timeout.timed_out(), "response release was not signalled");
 }
 
 fn read_request(stream: &mut TcpStream) -> Option<(String, Vec<u8>)> {
@@ -835,7 +876,7 @@ fn relay_holds_admission_and_is_not_cut_off_after_commitment() {
     let router = RouterProcess::start(worker.address, 1, 500, false);
 
     let address = router.address;
-    let slow = thread::spawn(move || post(address, b"slow", Some("slow-id")));
+    let slow = thread::spawn(move || post(address, b"controlled-stream", Some("slow-id")));
     worker.wait_for_requests(1);
     let metrics_deadline = Instant::now() + Duration::from_secs(1);
     loop {
@@ -862,6 +903,7 @@ fn relay_holds_admission_and_is_not_cut_off_after_commitment() {
     let overloaded = post(router.address, b"{}", None);
     assert_eq!(status(&overloaded), 429);
 
+    worker.release_response();
     let slow_response = slow.join().expect("join slow client");
     assert_eq!(status(&slow_response), 200);
     assert!(slow_response.windows(6).any(|part| part == b"[DONE]"));
@@ -908,7 +950,7 @@ fn client_disconnect_before_response_headers_is_observed_at_the_http_boundary() 
     let mut client = TcpStream::connect(router.address).expect("connect pre-header client");
     client
         .write_all(
-            b"POST /v1/chat/completions HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: 7\r\nConnection: close\r\n\r\ntimeout",
+            b"POST /v1/chat/completions HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: 18\r\nConnection: close\r\n\r\ncontrolled-headers",
         )
         .expect("write pre-header request");
     worker.wait_for_application_requests(1);
@@ -931,6 +973,7 @@ fn client_disconnect_before_response_headers_is_observed_at_the_http_boundary() 
         );
         thread::sleep(Duration::from_millis(5));
     }
+    worker.release_response();
 }
 
 #[test]

--- a/sglang_omni_router/rust/tests/chat_http.rs
+++ b/sglang_omni_router/rust/tests/chat_http.rs
@@ -313,6 +313,14 @@ fn serve_connection(
                 );
                 return;
             }
+            b"empty-body" => write_response(
+                &mut stream,
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            ),
+            b"response-trailers" => write_response(
+                &mut stream,
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\nTrailer: X-Worker-Trailer\r\nConnection: close\r\n\r\n2\r\n{}\r\n0\r\nX-Worker-Trailer: done\r\n\r\n",
+            ),
             b"te-cl" => write_response(
                 &mut stream,
                 b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\nContent-Length: 0\r\nConnection: close\r\n\r\n2\r\n{}\r\n0\r\n\r\n",
@@ -829,6 +837,22 @@ fn relay_holds_admission_and_is_not_cut_off_after_commitment() {
     let address = router.address;
     let slow = thread::spawn(move || post(address, b"slow", Some("slow-id")));
     worker.wait_for_requests(1);
+    let metrics_deadline = Instant::now() + Duration::from_secs(1);
+    loop {
+        let observed = metrics(router.address);
+        if observed.contains(
+            "sglang_omni_router_http_response_header_duration_seconds_count{route=\"chat\"} 1\n",
+        ) && observed.contains(
+            "sglang_omni_router_http_response_body_terminations_total{outcome=\"complete\"} 0\n",
+        ) {
+            break;
+        }
+        assert!(
+            Instant::now() < metrics_deadline,
+            "response-header observation did not precede body completion"
+        );
+        thread::sleep(Duration::from_millis(5));
+    }
     let oversized = raw_request(
         router.address,
         b"POST /v1/chat/completions HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: 1048577\r\nConnection: close\r\n\r\n",
@@ -854,6 +878,59 @@ fn relay_holds_admission_and_is_not_cut_off_after_commitment() {
     let head = response_head(&first).to_ascii_lowercase();
     assert_eq!(head.matches("cache-control:").count(), 2);
     assert!(head.contains("set-cookie: hidden=1"));
+}
+
+#[test]
+fn response_body_outcomes_cover_fixed_empty_and_trailer_boundaries() {
+    for (request, outcome) in [
+        (b"fixed-body".as_slice(), "complete"),
+        (b"empty-body".as_slice(), "complete"),
+        (b"response-trailers".as_slice(), "upstream_error"),
+    ] {
+        let worker = Worker::start();
+        let router = RouterProcess::start(worker.address, 1, 2_000, false);
+        let response = post(router.address, request, None);
+        assert_eq!(status(&response), 200);
+        let observed = metrics(router.address);
+        assert!(
+            observed.contains(&format!(
+                "sglang_omni_router_http_response_body_terminations_total{{outcome=\"{outcome}\"}} 1\n"
+            )),
+            "unexpected body termination metrics for {request:?}:\n{observed}"
+        );
+    }
+}
+
+#[test]
+fn client_disconnect_before_response_headers_is_observed_at_the_http_boundary() {
+    let worker = Worker::start();
+    let router = RouterProcess::start(worker.address, 1, 2_000, false);
+    let mut client = TcpStream::connect(router.address).expect("connect pre-header client");
+    client
+        .write_all(
+            b"POST /v1/chat/completions HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: 7\r\nConnection: close\r\n\r\ntimeout",
+        )
+        .expect("write pre-header request");
+    worker.wait_for_application_requests(1);
+    drop(client);
+
+    let deadline = Instant::now() + Duration::from_millis(500);
+    loop {
+        let observed = metrics(router.address);
+        if observed
+            .contains("sglang_omni_router_http_cancelled_before_headers_total{route=\"chat\"} 1\n")
+        {
+            assert!(observed.contains(
+                "sglang_omni_router_http_response_header_duration_seconds_count{route=\"chat\"} 0\n"
+            ));
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "pre-header client disconnect was not observed:\n{observed}"
+        );
+        thread::sleep(Duration::from_millis(5));
+    }
 }
 
 #[test]

--- a/sglang_omni_router/rust/tests/process.rs
+++ b/sglang_omni_router/rust/tests/process.rs
@@ -54,6 +54,23 @@ impl TestDir {
         fs::write(&path, contents).expect("write isolated process config");
         path
     }
+
+    fn config_with_worker(
+        &self,
+        address: SocketAddr,
+        worker: SocketAddr,
+        max_connections: usize,
+        drain_timeout_ms: u64,
+    ) -> PathBuf {
+        let path = self.config(address, max_connections, drain_timeout_ms);
+        let contents = fs::read_to_string(&path).expect("read generated router config");
+        let contents = contents.replace(
+            "base_url = \"http://127.0.0.1:1/\"",
+            &format!("base_url = \"http://{worker}/\""),
+        );
+        fs::write(&path, contents).expect("write worker-address router config");
+        path
+    }
 }
 
 impl Drop for TestDir {
@@ -177,21 +194,47 @@ fn rapid_distinct_signals(process_id: u32) {
 }
 
 fn request(address: SocketAddr, method: &str, path: &str) -> String {
+    raw_request(
+        address,
+        format!("{method} {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+            .as_bytes(),
+    )
+}
+
+fn raw_request(address: SocketAddr, request: &[u8]) -> String {
     let mut stream = TcpStream::connect_timeout(&address, Duration::from_millis(250))
         .expect("connect to serving router");
     stream
         .set_read_timeout(Some(Duration::from_secs(2)))
         .expect("set bounded response timeout");
-    write!(
-        stream,
-        "{method} {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
-    )
-    .expect("write HTTP request");
+    stream.write_all(request).expect("write HTTP request");
     let mut response = String::new();
     stream
         .read_to_string(&mut response)
         .expect("read bounded local HTTP response");
     response
+}
+
+fn response_header<'a>(response: &'a str, name: &str) -> Option<&'a str> {
+    response.split("\r\n").find_map(|line| {
+        let (candidate, value) = line.split_once(':')?;
+        candidate.eq_ignore_ascii_case(name).then_some(value.trim())
+    })
+}
+
+fn response_body(response: &str) -> &str {
+    response
+        .split_once("\r\n\r\n")
+        .map(|(_, body)| body)
+        .expect("complete HTTP response")
+}
+
+fn assert_exact_content_length(response: &str) {
+    let expected = response_body(response).len().to_string();
+    assert_eq!(
+        response_header(response, "content-length"),
+        Some(expected.as_str())
+    );
 }
 
 fn confirmed_keep_alive_connection(address: SocketAddr) -> TcpStream {
@@ -325,6 +368,22 @@ fn wait_until_live(address: SocketAddr, child: &mut ChildGuard) {
         assert!(
             Instant::now() < end,
             "router never became live: {last_observation}"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn wait_until_ready(address: SocketAddr, child: &mut ChildGuard) {
+    let end = Instant::now() + PROCESS_DEADLINE;
+    loop {
+        let response = request(address, "GET", "/ready");
+        if response.starts_with("HTTP/1.1 200") {
+            return;
+        }
+        child.assert_running();
+        assert!(
+            Instant::now() < end,
+            "router never became ready: {response}"
         );
         thread::sleep(Duration::from_millis(10));
     }
@@ -475,7 +534,7 @@ fn invalid_cli_and_config_exit_two_without_disclosing_contents() {
 }
 
 #[test]
-fn serves_only_exact_local_liveness_route_and_shuts_down_cleanly() {
+fn serves_exact_local_health_and_operations_routes_and_shuts_down_cleanly() {
     let _process_guard = process_lock();
     let directory = TestDir::new();
     let address = unused_address();
@@ -494,8 +553,6 @@ fn serves_only_exact_local_liveness_route_and_shuts_down_cleanly() {
         ("PUT", "/ready", "405"),
         ("GET", "/ready/", "404"),
         ("GET", "/health", "404"),
-        ("GET", "/metrics", "404"),
-        ("GET", "/v1/models", "404"),
         ("POST", "/generate", "404"),
     ] {
         let response = request(address, method, path);
@@ -505,10 +562,220 @@ fn serves_only_exact_local_liveness_route_and_shuts_down_cleanly() {
         );
     }
 
+    let models = raw_request(
+        address,
+        b"GET /v1/models HTTP/1.1\r\nHost: localhost\r\nX-Request-Id: models-caller\r\nConnection: close\r\n\r\n",
+    );
+    assert!(models.starts_with("HTTP/1.1 200"));
+    assert_eq!(
+        response_header(&models, "x-request-id"),
+        Some("models-caller")
+    );
+    assert_eq!(
+        response_header(&models, "content-type"),
+        Some("application/json")
+    );
+    assert_eq!(response_header(&models, "cache-control"), Some("no-store"));
+    assert_exact_content_length(&models);
+    assert_eq!(
+        response_body(&models),
+        r#"{"object":"list","data":[{"id":"omni","object":"model","created":0,"owned_by":"sglang-omni","permission":[{"id":"modelperm-default","object":"model_permission","allow_create_engine":false,"allow_sampling":true,"allow_logprobs":true}],"root":"omni"}]}"#
+    );
+
+    let metrics = request(address, "GET", "/metrics");
+    assert!(metrics.starts_with("HTTP/1.1 200"));
+    assert_eq!(
+        response_header(&metrics, "content-type"),
+        Some("text/plain; version=0.0.4; charset=utf-8")
+    );
+    assert_exact_content_length(&metrics);
+    assert!(metrics.contains("sglang_omni_router_lifecycle{state=\"serving\"} 1\n"));
+    assert!(metrics.contains("sglang_omni_router_ready 0\n"));
+    assert!(metrics.contains("sglang_omni_router_admission_limit{class=\"generation_http\"} 64\n"));
+    assert!(metrics.contains("sglang_omni_router_admission_limit{class=\"speech_http\"} 0\n"));
+    assert!(metrics.contains("sglang_omni_router_worker_active_requests 0\n"));
+    assert!(
+        metrics
+            .contains("sglang_omni_router_worker_capacity_limit{class=\"speech_websocket\"} 0\n")
+    );
+    assert!(
+        !metrics.contains("sglang_omni_router_worker_capacity_limit{class=\"generation_http\"}")
+    );
+    assert!(!metrics.contains("worker-a"));
+    assert!(!metrics.contains("127.0.0.1"));
+
+    let diagnostics = request(address, "GET", "/diagnostics");
+    assert!(diagnostics.starts_with("HTTP/1.1 200"));
+    assert_exact_content_length(&diagnostics);
+    let diagnostic_value: serde_json::Value =
+        serde_json::from_str(response_body(&diagnostics)).expect("parse diagnostics response");
+    assert_eq!(diagnostic_value["lifecycle"], "serving");
+    assert_eq!(diagnostic_value["ready"], false);
+    assert_eq!(diagnostic_value["admission"][0]["class"], "global");
+    assert_eq!(diagnostic_value["admission"][0]["limit"], 128);
+    assert_eq!(diagnostic_value["admission"][1]["class"], "generation_http");
+    assert_eq!(diagnostic_value["admission"][1]["limit"], 64);
+    assert_eq!(
+        diagnostic_value["admission"].as_array().map(Vec::len),
+        Some(7)
+    );
+    assert_eq!(diagnostic_value["workers"][0]["worker_id"], "worker-a");
+    assert_eq!(diagnostic_value["workers"][0]["registration_ordinal"], 0);
+    assert!(matches!(
+        diagnostic_value["workers"][0]["health"].as_str(),
+        Some("unknown" | "unhealthy")
+    ));
+    assert_eq!(diagnostic_value["workers"][0]["routable"], false);
+    assert_eq!(diagnostic_value["workers"][0]["active_requests"], 0);
+    assert_eq!(
+        diagnostic_value["workers"][0]["capacity"]
+            .as_array()
+            .map(Vec::len),
+        Some(0)
+    );
+    for forbidden in [
+        "base_url",
+        "trust_domain",
+        "health_path",
+        "default_model_id",
+        "127.0.0.1",
+        "/health",
+        "\"local\"",
+        "\"omni\"",
+    ] {
+        assert!(!response_body(&diagnostics).contains(forbidden));
+    }
+
+    let method_error = raw_request(
+        address,
+        b"POST /metrics HTTP/1.1\r\nHost: localhost\r\nX-Request-Id: operations-error\r\nConnection: close\r\n\r\n",
+    );
+    assert!(method_error.starts_with("HTTP/1.1 405"));
+    assert_eq!(response_header(&method_error, "allow"), Some("GET"));
+    assert_eq!(
+        response_header(&method_error, "x-request-id"),
+        Some("operations-error")
+    );
+
+    for (method, path, status) in [
+        ("HEAD", "/v1/models", "405"),
+        ("PUT", "/diagnostics", "405"),
+        ("GET", "/metrics/", "404"),
+        ("GET", "/diagnostics?full=true", "400"),
+    ] {
+        let response = request(address, method, path);
+        assert!(
+            response.starts_with(&format!("HTTP/1.1 {status}")),
+            "unexpected {method} {path} response: {response}"
+        );
+        if status == "405" {
+            assert_eq!(response_header(&response, "allow"), Some("GET"));
+        }
+    }
+
+    let framed = raw_request(
+        address,
+        b"GET /metrics HTTP/1.1\r\nHost: localhost\r\nContent-Length: 1\r\nConnection: close\r\n\r\nx",
+    );
+    assert!(framed.starts_with("HTTP/1.1 400"));
+    let wrong_version = raw_request(
+        address,
+        b"GET /metrics HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+    );
+    assert!(wrong_version.starts_with("HTTP/1.0 505"));
+
     signal(child.id(), "-TERM");
     assert_eq!(child.wait(PROCESS_DEADLINE).code(), Some(0));
     let reused = TcpListener::bind(address).expect("listener is reusable after joined shutdown");
     drop(reused);
+}
+
+#[test]
+fn operations_share_readiness_without_contacting_the_worker() {
+    let _process_guard = process_lock();
+    let worker = TcpListener::bind("127.0.0.1:0").expect("bind operations worker fixture");
+    let worker_address = worker.local_addr().expect("read worker fixture address");
+    worker
+        .set_nonblocking(true)
+        .expect("set worker fixture nonblocking");
+    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let non_health_requests = Arc::new(AtomicU64::new(0));
+    let worker_stop = Arc::clone(&stop);
+    let worker_non_health = Arc::clone(&non_health_requests);
+    let worker_thread = thread::spawn(move || {
+        while !worker_stop.load(Ordering::Acquire) {
+            let (mut stream, _) = match worker.accept() {
+                Ok(connection) => connection,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(5));
+                    continue;
+                }
+                Err(error) => panic!("operations worker accept failed: {error}"),
+            };
+            stream
+                .set_read_timeout(Some(Duration::from_secs(1)))
+                .expect("bound worker request read");
+            let mut request = Vec::new();
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let mut buffer = [0_u8; 512];
+                match stream.read(&mut buffer) {
+                    Ok(0) => break,
+                    Ok(read) => request.extend_from_slice(&buffer[..read]),
+                    Err(error)
+                        if matches!(
+                            error.kind(),
+                            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                        ) =>
+                    {
+                        break;
+                    }
+                    Err(error) => panic!("operations worker read failed: {error}"),
+                }
+            }
+            if !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                continue;
+            }
+            let health = request.starts_with(b"GET /health HTTP/1.1\r\n");
+            if !health {
+                worker_non_health.fetch_add(1, Ordering::Relaxed);
+            }
+            let status = if health {
+                "200 OK"
+            } else {
+                "500 Internal Server Error"
+            };
+            write!(
+                stream,
+                "HTTP/1.1 {status}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            )
+            .expect("write operations worker response");
+        }
+    });
+
+    let directory = TestDir::new();
+    let address = unused_address();
+    let config = directory.config_with_worker(address, worker_address, 1024, 2_000);
+    let mut child = ChildGuard::spawn(&config);
+    wait_until_live(address, &mut child);
+    wait_until_ready(address, &mut child);
+
+    let metrics = request(address, "GET", "/metrics");
+    assert!(metrics.contains("sglang_omni_router_ready 1\n"));
+    let diagnostics = request(address, "GET", "/diagnostics");
+    let diagnostics: serde_json::Value =
+        serde_json::from_str(response_body(&diagnostics)).expect("parse ready diagnostics");
+    assert_eq!(diagnostics["ready"], true);
+    assert!(request(address, "GET", "/v1/models").starts_with("HTTP/1.1 200"));
+    assert!(request(address, "HEAD", "/metrics").starts_with("HTTP/1.1 405"));
+    thread::sleep(Duration::from_millis(50));
+    assert_eq!(non_health_requests.load(Ordering::Relaxed), 0);
+
+    signal(child.id(), "-TERM");
+    assert_eq!(child.wait(PROCESS_DEADLINE).code(), Some(0));
+    stop.store(true, Ordering::Release);
+    worker_thread
+        .join()
+        .expect("join operations worker fixture");
 }
 
 #[test]

--- a/sglang_omni_router/rust/tests/process.rs
+++ b/sglang_omni_router/rust/tests/process.rs
@@ -598,6 +598,11 @@ fn serves_exact_local_health_and_operations_routes_and_shuts_down_cleanly() {
     assert!(metrics.contains("sglang_omni_router_buffered_request_bytes_reserved 0\n"));
     assert!(metrics.contains("sglang_omni_router_classification_slots_in_use 0\n"));
     assert!(metrics.contains("sglang_omni_router_websocket_sessions_registered 0\n"));
+    assert!(metrics.contains("sglang_omni_router_http_requests_total{route=\"models\"} 1\n"));
+    assert!(metrics.contains("sglang_omni_router_http_requests_total{route=\"metrics\"} 1\n"));
+    assert!(metrics.contains(
+        "sglang_omni_router_http_response_headers_total{route=\"models\",status=\"2xx\"} 1\n"
+    ));
     assert!(
         metrics
             .contains("sglang_omni_router_worker_capacity_limit{class=\"speech_websocket\"} 0\n")
@@ -704,6 +709,29 @@ fn serves_exact_local_health_and_operations_routes_and_shuts_down_cleanly() {
         b"GET /metrics HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n",
     );
     assert!(wrong_version.starts_with("HTTP/1.0 505"));
+
+    let final_metrics = request(address, "GET", "/metrics");
+    assert!(
+        final_metrics.contains("sglang_omni_router_http_requests_total{route=\"metrics\"} 5\n")
+    );
+    assert!(final_metrics.contains(
+        "sglang_omni_router_http_response_headers_total{route=\"metrics\",status=\"2xx\"} 1\n"
+    ));
+    assert!(final_metrics.contains(
+        "sglang_omni_router_http_response_headers_total{route=\"metrics\",status=\"4xx\"} 2\n"
+    ));
+    assert!(final_metrics.contains(
+        "sglang_omni_router_http_response_headers_total{route=\"metrics\",status=\"5xx\"} 1\n"
+    ));
+    assert!(final_metrics.contains(
+        "sglang_omni_router_http_faults_total{route=\"metrics\",code=\"method_not_allowed\"} 1\n"
+    ));
+    assert!(final_metrics.contains(
+        "sglang_omni_router_http_faults_total{route=\"metrics\",code=\"malformed_request\"} 1\n"
+    ));
+    assert!(final_metrics.contains(
+        "sglang_omni_router_http_faults_total{route=\"metrics\",code=\"http_version_not_supported\"} 1\n"
+    ));
 
     signal(child.id(), "-TERM");
     assert_eq!(child.wait(PROCESS_DEADLINE).code(), Some(0));

--- a/sglang_omni_router/rust/tests/process.rs
+++ b/sglang_omni_router/rust/tests/process.rs
@@ -594,6 +594,10 @@ fn serves_exact_local_health_and_operations_routes_and_shuts_down_cleanly() {
     assert!(metrics.contains("sglang_omni_router_admission_limit{class=\"generation_http\"} 64\n"));
     assert!(metrics.contains("sglang_omni_router_admission_limit{class=\"speech_http\"} 0\n"));
     assert!(metrics.contains("sglang_omni_router_worker_active_requests 0\n"));
+    assert!(metrics.contains("sglang_omni_router_listener_slots_limit 1024\n"));
+    assert!(metrics.contains("sglang_omni_router_buffered_request_bytes_reserved 0\n"));
+    assert!(metrics.contains("sglang_omni_router_classification_slots_in_use 0\n"));
+    assert!(metrics.contains("sglang_omni_router_websocket_sessions_registered 0\n"));
     assert!(
         metrics
             .contains("sglang_omni_router_worker_capacity_limit{class=\"speech_websocket\"} 0\n")
@@ -621,12 +625,29 @@ fn serves_exact_local_health_and_operations_routes_and_shuts_down_cleanly() {
     );
     assert_eq!(diagnostic_value["workers"][0]["worker_id"], "worker-a");
     assert_eq!(diagnostic_value["workers"][0]["registration_ordinal"], 0);
+    assert_eq!(diagnostic_value["workers"][0]["voice_owner"], false);
     assert!(matches!(
         diagnostic_value["workers"][0]["health"].as_str(),
         Some("unknown" | "unhealthy")
     ));
     assert_eq!(diagnostic_value["workers"][0]["routable"], false);
     assert_eq!(diagnostic_value["workers"][0]["active_requests"], 0);
+    assert_eq!(
+        diagnostic_value["resources"]["listener_slots"]["limit"],
+        1024
+    );
+    assert_eq!(
+        diagnostic_value["resources"]["buffered_request_bytes"]["in_use"],
+        0
+    );
+    assert_eq!(
+        diagnostic_value["resources"]["classification_slots"]["in_use"],
+        0
+    );
+    assert_eq!(
+        diagnostic_value["resources"]["websocket_sessions_registered"],
+        0
+    );
     assert_eq!(
         diagnostic_value["workers"][0]["capacity"]
             .as_array()

--- a/sglang_omni_router/rust/tests/websocket.rs
+++ b/sglang_omni_router/rust/tests/websocket.rs
@@ -19,6 +19,7 @@ use futures_util::{SinkExt, StreamExt};
 use tokio::net::TcpListener;
 use tokio::sync::{Mutex, Notify};
 use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Error as WebSocketError;
 use tokio_tungstenite::tungstenite::Message as ClientMessage;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 
@@ -750,7 +751,29 @@ async fn speech_exact_replay_and_realtime_precommit_and_server_first_ordering() 
     tokio::time::timeout(Duration::from_secs(2), state.realtime_control.notified())
         .await
         .expect("client-to-worker direction remains live under downstream backpressure");
+    let saturated = connect_async(format!("ws://{router_address}/v1/realtime"))
+        .await
+        .expect_err("second realtime session is rejected before upgrade");
+    assert!(
+        matches!(saturated, WebSocketError::Http(response) if response.status() == StatusCode::TOO_MANY_REQUESTS)
+    );
+    wait_metrics(
+        router_address,
+        &[
+            "sglang_omni_router_http_response_headers_total{route=\"realtime_websocket\",status=\"4xx\"} 1\n",
+            "sglang_omni_router_websocket_terminations_total{protocol=\"realtime\",phase=\"setup\",reason=\"dispatch_error\"} 0\n",
+        ],
+    )
+    .await;
     drop(flood_client);
+    wait_metrics(
+        router_address,
+        &[
+            "sglang_omni_router_websocket_terminations_total{protocol=\"realtime\",phase=\"relay\",reason=\"client_close\"} 1\n",
+            "sglang_omni_router_websocket_terminations_total{protocol=\"realtime\",phase=\"relay\",reason=\"client_disconnect\"} 1\n",
+        ],
+    )
+    .await;
 
     #[cfg(unix)]
     {

--- a/sglang_omni_router/rust/tests/websocket.rs
+++ b/sglang_omni_router/rust/tests/websocket.rs
@@ -454,6 +454,32 @@ async fn wait_ready(address: SocketAddr) {
     }
 }
 
+async fn wait_metrics(address: SocketAddr, samples: &[&str]) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("build metrics client");
+    loop {
+        let text = client
+            .get(format!("http://{address}/metrics"))
+            .send()
+            .await
+            .expect("request metrics")
+            .text()
+            .await
+            .expect("read metrics");
+        if samples.iter().all(|sample| text.contains(sample)) {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "WebSocket termination metrics did not converge: {samples:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
 #[tokio::test]
 async fn speech_exact_replay_and_realtime_precommit_and_server_first_ordering() {
     let worker_listener = TcpListener::bind("127.0.0.1:0")
@@ -1056,6 +1082,17 @@ async fn setup_deadline_releases_stalled_speech_and_realtime_capacity() {
         .expect("close realtime after timeout");
     drop(after_timeout_realtime);
     assert_eq!(state.realtime_attempts.load(Ordering::Relaxed), 5);
+
+    wait_metrics(
+        router_address,
+        &[
+            "sglang_omni_router_websocket_terminations_total{protocol=\"speech\",phase=\"setup\",reason=\"worker_setup_timeout\"} 1\n",
+            "sglang_omni_router_websocket_terminations_total{protocol=\"realtime\",phase=\"setup\",reason=\"worker_setup_timeout\"} 1\n",
+            "sglang_omni_router_websocket_terminations_total{protocol=\"speech\",phase=\"setup\",reason=\"client_close\"} 1\n",
+            "sglang_omni_router_websocket_terminations_total{protocol=\"realtime\",phase=\"setup\",reason=\"client_close\"} 1\n",
+        ],
+    )
+    .await;
 
     worker_task.abort();
     let _joined = worker_task.await;


### PR DESCRIPTION
## Summary

Add router-local model discovery, fixed-cardinality Prometheus metrics, and bounded diagnostics. The operations surface reports lifecycle, readiness, worker health, probe outcomes, admission and resource use, request outcomes, classification phases, WebSocket termination causes, and HTTP relay completion without contacting workers.

## Changes

- Add exact HTTP/1.1 `GET /v1/models`, `GET /metrics`, and `GET /diagnostics` routes. Queries, request bodies, `HEAD`, and other methods return bounded route-specific errors.
- Precompute `/v1/models` at startup as a sorted, deduplicated union of profile model IDs and worker defaults.
- Expose lifecycle, readiness, worker health and routability, admission, weighted worker load, WebSocket capacity, listener slots, buffered-request bytes, classification slots, and registered WebSocket sessions from the primitives that enforce those limits.
- Record requests, response headers by status class, router faults, saturation rejections, response-header latency, and cancellation before response headers at the request and fault funnels.
- Record classified-request slot wait, blocking-executor queue wait, execution time, and exactly one caller outcome: success, error, timeout, or cancellation. Blocking work that has already started may finish and publish its phase duration after the caller terminates; it does not change the caller outcome.
- Record committed HTTP response bodies as complete, upstream error, or downstream drop. Existing relay-failure counts remain the upstream-error subset. Response-header metrics do not claim that a streaming body completed.
- Record one bounded terminal cause for every upgraded speech or realtime WebSocket session, separated into setup and relay phases. The terminal cause describes why relay ended, not whether the bounded close handshake completed.
- Retain the latest coherent probe outcome, HTTP status, timestamp, transition streaks, and cumulative results for each worker. Probe state is written by the serial health loop and read by operations scrapes; routing continues to use the atomic health state.
- Return deterministic diagnostics with the configured voice owner, worker registration order, health, routability, active load, session capacity, probe state, and router resource usage. Worker targets, request data, model IDs, and client-provided values are excluded from metric labels.
- Keep instrumentation bounded: fixed label vocabularies, no per-byte or per-frame updates, no per-classification heap allocation, and binary histogram bucket lookup.
- Use the H100-qualified policies in the shipped examples: `round_robin` for ASR and `least_requests` for TTS and Omni. Admission and connection limits are unchanged.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` — 239 tests passed
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --all-features`
- `cargo build --release --locked`
- Release-binary `--check-config` for all three shipped examples

Tests cover exact operations wire behavior, zero-valued metric series, fixed labels and counter ownership, saturation attribution, response-header and response-body terminal boundaries, pre-header cancellation, classification timeout and cancellation races, WebSocket setup and relay termination causes, coherent concurrent probe snapshots, probe transport and HTTP failures, connection reuse, lifecycle/readiness snapshots, resource usage, voice-owner diagnostics, maximum diagnostics size and redaction, and all inherited HTTP, media, voice-state, and WebSocket behavior.

Routing policy qualification used two H100 workers and the complete workload corpora:

| Example | Policy | Qualification result |
| --- | --- | --- |
| ASR | `round_robin` | 612.831 vs 573.497 samples/s for least requests at c96 |
| TTS | `least_requests` | Qwen3-TTS: 38.212 vs 33.887 QPS at c64; Higgs: 27.695 vs 26.188 QPS at c32 |
| Omni | `least_requests` | FP8 text/image: 4.536 vs 4.492 QPS at c32; BF16 audio: 15.385 vs 14.522 QPS at c32 |