### PR TITLE
[XPU] Enable whisper ASR model on XPU platform

### DIFF
--- a/sglang_omni/models/whisper_asr/config.py
+++ b/sglang_omni/models/whisper_asr/config.py
@@ -65,7 +65,7 @@ class WhisperASRPipelineConfig(PipelineConfig):
             factory_path=f"{_PKG}.stages.create_sglang_whisper_asr_executor",
             engine=EngineArgs(max_running_requests=64),
             factory=WhisperASRFactoryArgs(
-                device="cuda:0",
+                device=None,
                 # The encoder CUDA-graph replay is a documented tuning knob for
                 # this pipeline; disable it when profiling eager encoder
                 # execution.

--- a/sglang_omni/models/whisper_asr/engine_builder.py
+++ b/sglang_omni/models/whisper_asr/engine_builder.py
@@ -251,13 +251,11 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
             "sampling_backend": "pytorch",
             "dtype": dtype,
         }
-        # SGLang forces flashinfer (CUDA-only) as Whisper's default attention
-        # backend for cross-attention CUDA-graph support. On Intel XPU use the
-        # torch_native backend: it supports encoder-decoder cross attention and
-        # runs correctly through torch.xpu (the intel_xpu backend miscomputes
-        # Whisper cross attention).
-        if current_platform.device_type == "xpu":
-            defaults["attention_backend"] = "torch_native"
+        # The platform owns whether Whisper's encoder-decoder cross attention
+        # needs a specific backend (SGLang's default forces CUDA-only flashinfer).
+        cross_attn_backend = current_platform.cross_attention_backend()
+        if cross_attn_backend is not None:
+            defaults["attention_backend"] = cross_attn_backend
         return defaults
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:

--- a/sglang_omni/models/whisper_asr/engine_builder.py
+++ b/sglang_omni/models/whisper_asr/engine_builder.py
@@ -238,7 +238,9 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
         overrides["enable_custom_logit_processor"] = True
 
     def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
-        return {
+        from sglang_omni.platforms import current_platform
+
+        defaults: dict[str, Any] = {
             "max_running_requests": self.max_running_requests,
             "disable_cuda_graph": False,
             "disable_overlap_schedule": True,
@@ -249,6 +251,14 @@ class WhisperASREngineBuilder(AsrEngineBuilder):
             "sampling_backend": "pytorch",
             "dtype": dtype,
         }
+        # SGLang forces flashinfer (CUDA-only) as Whisper's default attention
+        # backend for cross-attention CUDA-graph support. On Intel XPU use the
+        # torch_native backend: it supports encoder-decoder cross attention and
+        # runs correctly through torch.xpu (the intel_xpu backend miscomputes
+        # Whisper cross attention).
+        if current_platform.device_type == "xpu":
+            defaults["attention_backend"] = "torch_native"
+        return defaults
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:
         del model

--- a/sglang_omni/models/whisper_asr/sglang_model.py
+++ b/sglang_omni/models/whisper_asr/sglang_model.py
@@ -207,6 +207,9 @@ class WhisperSGLangSelfAttention(nn.Module):
         key = key.view(-1, self.num_heads, self.head_dim)
         value = value.view(-1, self.num_heads, self.head_dim)
         attn_output = self.attn(query, key, value, forward_batch)
+        # Flatten heads so out_proj sees [num_tokens, embed_dim] regardless of
+        # whether the attention backend returns 2D (flashinfer) or 3D (torch_native).
+        attn_output = attn_output.reshape(attn_output.shape[0], -1)
         return self.out_proj(attn_output)
 
 
@@ -252,6 +255,9 @@ class WhisperSGLangCrossAttention(nn.Module):
             key = key.view(-1, self.num_heads, self.head_dim)
             value = value.view(-1, self.num_heads, self.head_dim)
         attn_output = self.attn(query, key, value, forward_batch)
+        # Flatten heads so out_proj sees [num_tokens, embed_dim] regardless of
+        # whether the attention backend returns 2D (flashinfer) or 3D (torch_native).
+        attn_output = attn_output.reshape(attn_output.shape[0], -1)
         return self.out_proj(attn_output)
 
 

--- a/sglang_omni/models/whisper_asr/stages.py
+++ b/sglang_omni/models/whisper_asr/stages.py
@@ -9,7 +9,8 @@ from typing import Any
 def create_sglang_whisper_asr_executor(
     model_path: str,
     *,
-    device: str = "cuda:0",
+    device: str | None = None,
+    gpu_id: int | None = None,
     dtype: str = "float16",
     max_running_requests: int = 64,
     max_new_tokens: int = 256,
@@ -63,6 +64,7 @@ def create_sglang_whisper_asr_executor(
     ).build(
         model_path,
         device=device,
+        gpu_id=gpu_id,
         dtype=dtype,
         server_args_overrides=server_args_overrides,
     )

--- a/sglang_omni/platforms/interface.py
+++ b/sglang_omni/platforms/interface.py
@@ -60,3 +60,8 @@ class OmniPlatform(DeviceMixin):
     def enable_code2wav_graph(self):
         """Check if current platform support Graph for code2wav in Qwen3-Omni"""
         return True
+
+    def cross_attention_backend(self) -> str | None:
+        """Attention backend for encoder-decoder cross attention, or None to keep
+        the engine's platform default."""
+        return None

--- a/sglang_omni/platforms/xpu.py
+++ b/sglang_omni/platforms/xpu.py
@@ -24,10 +24,10 @@ class XPUOmniPlatform(OmniPlatform):
     device_name: str = "xpu"
     device_type: str = "xpu"
 
-    def get_device(self, local_rank: int) -> "torch.device":
+    def get_device(self, local_rank: int) -> torch.device:
         return torch.device("xpu", local_rank)
 
-    def set_device(self, device: "torch.device | int") -> None:
+    def set_device(self, device: torch.device | int) -> None:
         index = device.index if isinstance(device, torch.device) else int(device)
         torch.xpu.set_device(0 if index is None else index)
 
@@ -35,8 +35,9 @@ class XPUOmniPlatform(OmniPlatform):
         return False
 
     def cross_attention_backend(self) -> str | None:
-        # SGLang defaults Whisper cross attention to flashinfer (CUDA-only) and the
-        # intel_xpu backend miscomputes it; torch_native is correct on XPU.
+        # The intel_xpu backend miscomputes Whisper cross attention. SGLang exposes
+        # one backend setting for both decoder attention paths, so use the portable
+        # torch-native implementation for the whole Whisper decoder on XPU.
         return "torch_native"
 
     def get_fused_qk_norm_rope_with_cos_sin_cache(self):
@@ -59,6 +60,17 @@ class XPUOmniPlatform(OmniPlatform):
         effective_quantization = super().apply_model_worker_backend_policy(
             server_args, model_config, model_arch_override
         )
+
+        if (
+            model_arch_override == "WhisperForConditionalGeneration"
+            and server_args.attention_backend != self.cross_attention_backend()
+        ):
+            raise ValueError(
+                "Whisper ASR on Intel XPU requires "
+                "attention_backend='torch_native'; the intel_xpu backend "
+                "miscomputes encoder-decoder cross attention. Drop the override "
+                "or set it to 'torch_native'."
+            )
 
         if model_arch_override in (
             "Qwen3OmniTalker",

--- a/sglang_omni/platforms/xpu.py
+++ b/sglang_omni/platforms/xpu.py
@@ -34,6 +34,11 @@ class XPUOmniPlatform(OmniPlatform):
     def enable_code2wav_graph(self):
         return False
 
+    def cross_attention_backend(self) -> str | None:
+        # SGLang defaults Whisper cross attention to flashinfer (CUDA-only) and the
+        # intel_xpu backend miscomputes it; torch_native is correct on XPU.
+        return "torch_native"
+
     def get_fused_qk_norm_rope_with_cos_sin_cache(self):
         try:
             from sgl_kernel import fused_inplace_qknorm_rope

--- a/sglang_omni/platforms/xpu.py
+++ b/sglang_omni/platforms/xpu.py
@@ -35,9 +35,6 @@ class XPUOmniPlatform(OmniPlatform):
         return False
 
     def cross_attention_backend(self) -> str | None:
-        # The intel_xpu backend miscomputes Whisper cross attention. SGLang exposes
-        # one backend setting for both decoder attention paths, so use the portable
-        # torch-native implementation for the whole Whisper decoder on XPU.
         return "torch_native"
 
     def get_fused_qk_norm_rope_with_cos_sin_cache(self):
@@ -67,9 +64,8 @@ class XPUOmniPlatform(OmniPlatform):
         ):
             raise ValueError(
                 "Whisper ASR on Intel XPU requires "
-                "attention_backend='torch_native'; the intel_xpu backend "
-                "miscomputes encoder-decoder cross attention. Drop the override "
-                "or set it to 'torch_native'."
+                "attention_backend='torch_native'. Drop the override or set it "
+                "to 'torch_native'."
             )
 
         if model_arch_override in (

--- a/tests/unit_test/whisper_asr/test_pipeline.py
+++ b/tests/unit_test/whisper_asr/test_pipeline.py
@@ -39,6 +39,8 @@ def _encoder_graph_builder(**kwargs):
 def test_whisper_stage_defaults() -> None:
     signature = inspect.signature(whisper_asr_stages.create_sglang_whisper_asr_executor)
 
+    assert signature.parameters["device"].default is None
+    assert signature.parameters["gpu_id"].default is None
     assert signature.parameters["max_running_requests"].default == 64
     assert signature.parameters["enable_encoder_cuda_graph"].default is False
     assert signature.parameters["encoder_graph_batch_buckets"].default is None
@@ -215,7 +217,7 @@ def test_whisper_asr_config_uses_single_batched_stage() -> None:
     assert stage.factory_path.endswith("create_sglang_whisper_asr_executor")
     assert stage.engine.max_running_requests == 64
     factory = stage.factory
-    assert factory.device == "cuda:0"
+    assert factory.device is None
     assert factory.enable_encoder_cuda_graph is True
     assert factory.request_build_max_workers == 8
     assert factory.enable_async_decode is True

--- a/tests/unit_test/xpu/test_whisper_asr.py
+++ b/tests/unit_test/xpu/test_whisper_asr.py
@@ -42,7 +42,7 @@ def test_whisper_selects_torch_native_attention(monkeypatch) -> None:
 def test_whisper_rejects_unsafe_attention_backend() -> None:
     with pytest.raises(ValueError, match="requires attention_backend='torch_native'"):
         XPUOmniPlatform().apply_model_worker_backend_policy(
-            _server_args("intel_xpu"),
+            _server_args("triton"),
             SimpleNamespace(quantization=None),
             "WhisperForConditionalGeneration",
         )

--- a/tests/unit_test/xpu/test_whisper_asr.py
+++ b/tests/unit_test/xpu/test_whisper_asr.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Intel XPU policy tests for Whisper ASR (no accelerator required)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from transformers import WhisperConfig
+
+from sglang_omni import platforms
+from sglang_omni.models.whisper_asr import sglang_model
+from sglang_omni.models.whisper_asr.engine_builder import WhisperASREngineBuilder
+from sglang_omni.platforms.xpu import XPUOmniPlatform
+
+
+def _builder() -> WhisperASREngineBuilder:
+    return WhisperASREngineBuilder(
+        max_running_requests=4,
+        max_new_tokens=32,
+        mem_fraction_static=0.2,
+    )
+
+
+def _server_args(attention_backend: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        quantization=None,
+        moe_runner_backend="auto",
+        attention_backend=attention_backend,
+    )
+
+
+def test_whisper_selects_torch_native_attention(monkeypatch) -> None:
+    monkeypatch.setattr(platforms, "current_platform", XPUOmniPlatform())
+
+    defaults = _builder().generation_defaults(dtype="float16")
+
+    assert defaults["attention_backend"] == "torch_native"
+
+
+def test_whisper_rejects_unsafe_attention_backend() -> None:
+    with pytest.raises(ValueError, match="requires attention_backend='torch_native'"):
+        XPUOmniPlatform().apply_model_worker_backend_policy(
+            _server_args("intel_xpu"),
+            SimpleNamespace(quantization=None),
+            "WhisperForConditionalGeneration",
+        )
+
+
+def test_whisper_accepts_torch_native_attention_backend() -> None:
+    effective_quantization = XPUOmniPlatform().apply_model_worker_backend_policy(
+        _server_args("torch_native"),
+        SimpleNamespace(quantization=None),
+        "WhisperForConditionalGeneration",
+    )
+
+    assert effective_quantization is None
+
+
+@pytest.mark.parametrize("output_rank", [2, 3])
+@pytest.mark.parametrize("attention_kind", ["self", "cross"])
+def test_whisper_decoder_attention_flattens_backend_output(
+    monkeypatch, output_rank: int, attention_kind: str
+) -> None:
+    class _StubRadixAttention(torch.nn.Module):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__()
+
+        def forward(self, query, key, value, forward_batch):
+            del key, value, forward_batch
+            if output_rank == 2:
+                return query.reshape(query.shape[0], -1)
+            return query
+
+    monkeypatch.setattr(sglang_model, "RadixAttention", _StubRadixAttention)
+    config = WhisperConfig(d_model=8, decoder_attention_heads=2)
+    hidden_states = torch.randn(3, config.d_model)
+
+    if attention_kind == "self":
+        attention = sglang_model.WhisperSGLangSelfAttention(config, layer_id=0)
+        output = attention(hidden_states, forward_batch=object())
+    else:
+        attention = sglang_model.WhisperSGLangCrossAttention(config, layer_id=0)
+        output = attention(
+            hidden_states,
+            torch.randn(4, config.d_model),
+            forward_batch=object(),
+        )
+
+    assert output.shape == hidden_states.shape


### PR DESCRIPTION
WIP.
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

  Enable the Whisper ASR pipeline on Intel XPU

## Modifications

  - Align Whisper ASR device placement with the multi-device contract
  - Let the platform select the required encoder-decoder attention backend.
  - Use `torch_native` attention for Whisper on XPU.
    - The `intel_xpu` backend does not play good for Whisper cross-attention results (will follow up in later PRs once it's ready).
    - SGLang v0.5.18 explicitly does not support encoder-decoder cross-attention with Triton.
  - Normalize self-attention and cross-attention outputs to
    `[num_tokens, hidden_size]`, supporting both 2D and 3D backend output layouts.
  - Add Whisper-specific XPU unit tests under `tests/unit_test/xpu/`.
  - Update the generic Whisper pipeline tests for platform-neutral device defaults.

## Related Issues

https://github.com/sgl-project/sglang-omni/issues/1588
## Accuracy Test
WIP
<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## CI / Tests
  - CI Unit tests cover:
    - XPU `torch_native` backend selection.
    - Rejection of unsafe backend overrides.
    - Self-attention and cross-attention 2D/3D output normalization.
    - Platform-neutral Whisper device defaults.
  - Relevant unit tests pass.

More tests (cookbook examples) WIP
