### PR TITLE
[XPU] Enable Minimax Music3 model on XPU platform

### DIFF
--- a/docker/xpu.Dockerfile
+++ b/docker/xpu.Dockerfile
@@ -74,6 +74,15 @@ RUN git clone --branch ${SGLANG_XPU_BRANCH} --single-branch ${SGLANG_XPU_REPO} s
     && grep -q "sgl-kernel-xpu.git@${SGL_KERNEL_XPU_REF}\"" pyproject.toml \
     && pip install --no-cache-dir . --extra-index-url ${TORCH_XPU_INDEX}
 
+# MiniMax Music 3 imports SGLang's diffusion runtime eagerly. Keep these pins
+# explicit so the XPU image contains the complete import chain before Omni starts.
+RUN pip install --no-cache-dir \
+        addict==2.4.0 \
+        cache-dit==1.3.0 \
+        diffusers==0.37.0 \
+        imageio==2.36.0 \
+        imageio-ffmpeg==0.5.1
+
 # --no-build-isolation installs no build requirement, so setuptools is pinned here:
 # below 77 it rejects the PEP 639 license metadata in pyproject_xpu.toml.
 COPY . /workspace/sglang-omni

--- a/docs/cookbook/minimax_music3.md
+++ b/docs/cookbook/minimax_music3.md
@@ -31,11 +31,6 @@ source .venv/bin/activate
 uv pip install -v -e .   # drop -e for a non-editable install
 ```
 
-For Intel GPUs, use the separate [XPU installation](../get_started/installation_xpu.md)
-instead. The XPU path starts with the correctness-oriented eager runtime: SGLang
-decode CUDA graph, the RVQ depth CUDA graph, and acoustic `torch.compile` are disabled
-by default, while the native `torch_sdpa` acoustic attention backend remains enabled.
-
 **Single GPU** (colocate both stages):
 
 ```bash
@@ -49,11 +44,6 @@ CUDA_VISIBLE_DEVICES=0,1 sgl-omni serve --model-path MiniMaxAI/MiniMax-Music3 --
 ```
 
 Default optimizations that are on without further flags: backbone decode CUDA graph, RVQ depth CUDA graph, compiled DIT blocks, compiled DAV decoder, and batched seeded sampling.
-
-Those defaults describe CUDA. On XPU the graph and compile features above remain
-future optimization targets. The eager path is an **unverified enablement baseline**
-until operator coverage, numerical quality, memory use, and lifecycle behavior pass
-on the pinned real-XPU stack.
 
 Classifier-free guidance is on in both stages and has no flag. See [Guidance](#guidance) for what it costs you, because the AR half changes how much a request occupies.
 

--- a/docs/cookbook/minimax_music3.md
+++ b/docs/cookbook/minimax_music3.md
@@ -31,6 +31,11 @@ source .venv/bin/activate
 uv pip install -v -e .   # drop -e for a non-editable install
 ```
 
+For Intel GPUs, use the separate [XPU installation](../get_started/installation_xpu.md)
+instead. The XPU path starts with the correctness-oriented eager runtime: SGLang
+decode CUDA graph, the RVQ depth CUDA graph, and acoustic `torch.compile` are disabled
+by default, while the native `torch_sdpa` acoustic attention backend remains enabled.
+
 **Single GPU** (colocate both stages):
 
 ```bash
@@ -44,6 +49,11 @@ CUDA_VISIBLE_DEVICES=0,1 sgl-omni serve --model-path MiniMaxAI/MiniMax-Music3 --
 ```
 
 Default optimizations that are on without further flags: backbone decode CUDA graph, RVQ depth CUDA graph, compiled DIT blocks, compiled DAV decoder, and batched seeded sampling.
+
+Those defaults describe CUDA. On XPU the graph and compile features above remain
+future optimization targets. The eager path is an **unverified enablement baseline**
+until operator coverage, numerical quality, memory use, and lifecycle behavior pass
+on the pinned real-XPU stack.
 
 Classifier-free guidance is on in both stages and has no flag. See [Guidance](#guidance) for what it costs you, because the AR half changes how much a request occupies.
 

--- a/docs/get_started/installation_xpu.md
+++ b/docs/get_started/installation_xpu.md
@@ -12,7 +12,8 @@ XPU wheel index.
 family and CUDA-only wheels would replace the `+xpu` stack.
 [`pyproject_xpu.toml`](../../pyproject_xpu.toml) encodes the XPU replacements.
 
-Core deps cover the supported models (Qwen3-ASR / TTS / Omni) plus the API server;
+Core deps cover the qualified models (Qwen3-ASR / TTS / Omni), the unverified
+MiniMax Music 3 enablement baseline, and the API server;
 `[eval]` adds SeedTTS/WER tooling and `[all]` aliases it. Other model families
 (S2-Pro, Ming-Omni, Voxtral-TTS) are CUDA-only and are not offered here.
 
@@ -127,6 +128,32 @@ build reports `fatal error: sycl/sycl.hpp: No such file or directory`, point the
 ```bash
 export CPATH="$(python -c 'import sysconfig; print(sysconfig.get_paths()["include"])')"
 ```
+
+### MiniMax Music 3 (text-to-music, one or two XPUs)
+
+MiniMax Music 3 automatically colocates its AR and acoustic stages on one visible
+XPU, or places the acoustic stage on the second device when two or more are visible.
+The XPU baseline uses eager execution and native `torch_sdpa`; CUDA-specific graphs
+and acoustic compilation are disabled by default. This path is **unverified**, not
+supported, until it passes real-XPU operator, numerical, memory, cancellation, and
+multi-process lifecycle validation on the pinned runtime profile.
+
+```bash
+sgl-omni serve --model-path MiniMaxAI/MiniMax-Music3 --host 0.0.0.0 --port 8000
+
+curl -X POST http://localhost:8000/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "MiniMaxAI/MiniMax-Music3",
+    "input": "[Verse]\nWalking under neon skies\n[Chorus]\nWe sing into the night",
+    "instructions": "An uplifting synth-pop song at 118 BPM with bright analog synths",
+    "seed": 42,
+    "max_new_tokens": 250
+  }' --output minimax_music3_xpu.wav
+```
+
+Start with the 250-frame (about 10-second) request above for remote validation
+before increasing the generation length.
 
 ### Qwen3-ASR (speech-to-text, single XPU)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "uvicorn>=0.23.0",        # ASGI server for FastAPI
     "sglang==0.5.18",
     "flashinfer_python[cu13]==0.6.17",  # sglang pin. Do NOT add flashinfer-cubin: PyPI has no matching cubin, and any leftover cubin wheel fails MiniMax DIT import.
-    "cache-dit==1.3.0",      # MiniMax Music 3 DIT (hard import, not optional)
+    "cache-dit==1.3.0",      # Optional MiniMax Music 3 DIT acceleration
     "addict==2.4.0",         # sglang.multimodal_gen server_args; MiniMax DIT import
     "imageio==2.36.0",       # sglang.multimodal_gen vision utils; MiniMax DIT import
     "imageio-ffmpeg==0.5.1", # Pinned with the sglang diffusion extra

--- a/pyproject_xpu.toml
+++ b/pyproject_xpu.toml
@@ -48,6 +48,12 @@ dependencies = [
     "huggingface-hub>=0.36.0",
     "datasets>=2.14.0",
 
+    # --- MiniMax Music 3 acoustic runtime ----------------------------------
+    "addict==2.4.0",
+    "cache-dit==1.3.0",
+    "imageio==2.36.0",
+    "imageio-ffmpeg==0.5.1",
+
     # NOTE: sglang is intentionally NOT pinned here (see the header).
 
     # --- API server ---------------------------------------------------------

--- a/pyproject_xpu.toml
+++ b/pyproject_xpu.toml
@@ -53,6 +53,7 @@ dependencies = [
     "cache-dit==1.3.0",
     "imageio==2.36.0",
     "imageio-ffmpeg==0.5.1",
+    "diffusers==0.37.0",    # Required by sglang.multimodal_gen's eager pipeline imports
 
     # NOTE: sglang is intentionally NOT pinned here (see the header).
 

--- a/sglang_omni/models/minimax_music3/acoustic.py
+++ b/sglang_omni/models/minimax_music3/acoustic.py
@@ -118,7 +118,7 @@ class MiniMaxMusic3AcousticDecoder:
         self,
         model_path: str,
         *,
-        device: str | None = "cuda:1",
+        device: str | None = None,
         dtype: str | torch.dtype = "float32",
         dit_steps: int = DEFAULT_DIT_STEPS,
         dit_cfg_scale: float = DEFAULT_DIT_CFG_SCALE,

--- a/sglang_omni/models/minimax_music3/acoustic.py
+++ b/sglang_omni/models/minimax_music3/acoustic.py
@@ -16,12 +16,12 @@ import torch
 from torch import Tensor
 
 from sglang_omni.pipeline.stage.stream_queue import StreamItem
-from sglang_omni.platforms import current_platform
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.pipeline_state import build_usage
 from sglang_omni.scheduling.streaming_simple_scheduler import StreamingSimpleScheduler
 from sglang_omni.utils.audio_payload import audio_waveform_payload
+from sglang_omni.utils.device import resolve_device_spec
 
 from .checkpoint import load_torch_state, resolve_checkpoint
 from .chunking import ChunkWindow, crop_sample_bounds, overlap_mel_length
@@ -38,6 +38,7 @@ from .constants import (
 from .dav import MiniMaxMusic3DAV, remove_weight_norm, select_decoder_state
 from .dit import MiniMaxMusic3DIT
 from .payload_types import MiniMaxMusic3State
+from .platform_policy import get_minimax_music3_platform_policy
 
 logger = logging.getLogger(__name__)
 
@@ -117,13 +118,13 @@ class MiniMaxMusic3AcousticDecoder:
         self,
         model_path: str,
         *,
-        device: str = "cuda:1",
+        device: str | None = "cuda:1",
         dtype: str | torch.dtype = "float32",
         dit_steps: int = DEFAULT_DIT_STEPS,
         dit_cfg_scale: float = DEFAULT_DIT_CFG_SCALE,
         attention_backend: str = "torch_sdpa",
         cache_dit: bool = False,
-        compile_acoustic: bool = True,
+        compile_acoustic: bool | None = None,
         breakable_cuda_graph: bool = False,
         breakable_cuda_graph_min_free_gb: float | None = None,
         cache_dit_fn_compute_blocks: int = 2,
@@ -132,19 +133,19 @@ class MiniMaxMusic3AcousticDecoder:
         cache_dit_residual_diff_threshold: float = 0.08,
         cache_dit_max_continuous_cached_steps: int = 1,
     ) -> None:
-        if not (current_platform.is_cuda() or current_platform.is_musa()):
+        policy = get_minimax_music3_platform_policy()
+        policy.require_runnable()
+        if policy.configure_cuda_backends:
+            torch.backends.cudnn.enabled = False
+            torch.backends.cuda.enable_cudnn_sdp(False)
+        self.device = torch.device(resolve_device_spec(device))
+        if self.device.type != policy.device_type:
             raise RuntimeError(
-                "MiniMax Music 3 acoustic inference requires CUDA/MUSA backend"
-            )
-        torch.backends.cudnn.enabled = False
-        torch.backends.cuda.enable_cudnn_sdp(False)
-        self.device = torch.device(device)
-        if self.device.type not in ("cuda", "musa"):
-            raise RuntimeError(
-                "MiniMax Music 3 acoustic inference requires a CUDA/MUSA device"
+                "MiniMax Music 3 acoustic device does not match the resolved "
+                f"platform: device={self.device}, platform={policy.device_type}"
             )
         self.dtype = _resolve_acoustic_dtype(dtype)
-        if self.dtype is torch.float32:
+        if self.dtype is torch.float32 and policy.configure_cuda_backends:
             # note (chenyang): TF32 keeps float32's range with a 10-bit mantissa
             # and measures 0.22% from the true float32 DIT solve while running
             # 4.4x faster, which is what makes float32 affordable enough to be
@@ -157,10 +158,17 @@ class MiniMaxMusic3AcousticDecoder:
         self.dit_cfg_scale = _non_negative_number("dit_cfg_scale", dit_cfg_scale)
         self.attention_backend = attention_backend.strip().lower()
         self.cache_dit = _boolean("cache_dit", cache_dit)
+        if compile_acoustic is None:
+            compile_acoustic = policy.acoustic_compile
         self.compile_acoustic = _boolean("compile_acoustic", compile_acoustic)
         self.breakable_cuda_graph_requested = _boolean(
             "breakable_cuda_graph", breakable_cuda_graph
         )
+        if self.breakable_cuda_graph_requested and not policy.breakable_cuda_graph:
+            raise ValueError(
+                "MiniMax Music 3 breakable_cuda_graph is unavailable on "
+                f"{policy.device_type}: {policy.reason}"
+            )
         self.breakable_cuda_graph = False
         if self.cache_dit and self.breakable_cuda_graph_requested:
             raise ValueError(

--- a/sglang_omni/models/minimax_music3/config.py
+++ b/sglang_omni/models/minimax_music3/config.py
@@ -77,8 +77,6 @@ def _stages(*, acoustic_gpu: int) -> list[StageConfig]:
                 dit_cfg_scale=DEFAULT_DIT_CFG_SCALE,
                 attention_backend="torch_sdpa",
                 cache_dit=False,
-                # Establish correctness in eager mode first. torch.compile can
-                # still be requested explicitly once an XPU stack is validated.
                 compile_acoustic=policy.acoustic_compile,
                 breakable_cuda_graph=False,
             ),

--- a/sglang_omni/models/minimax_music3/config.py
+++ b/sglang_omni/models/minimax_music3/config.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import os
 from typing import ClassVar
 
 from pydantic import Field
@@ -21,15 +20,15 @@ from .constants import DEFAULT_DIT_CFG_SCALE, DEFAULT_DIT_STEPS
 _PKG = "sglang_omni.models.minimax_music3"
 
 
-def _visible_gpu_count() -> int:
-    """GPUs this process could place a stage on, without initializing CUDA."""
-    visible = os.environ.get("CUDA_VISIBLE_DEVICES")
-    if visible is not None:
-        entries = [entry.strip() for entry in visible.split(",")]
-        return len([entry for entry in entries if entry and entry != "-1"])
+def _visible_accelerator_count() -> int:
+    """Accelerators this process could place a stage on, without initializing it."""
     import torch
 
-    return torch.cuda.device_count()
+    from sglang_omni.platforms import current_platform
+
+    device_module = torch.get_device_module(current_platform.device_type)
+    device_count = getattr(device_module, "device_count", None)
+    return int(device_count()) if device_count is not None else 0
 
 
 class DitDavFactoryArgs(FactoryArgs):
@@ -48,6 +47,10 @@ class DitDavStageConfig(StageConfig):
 
 
 def _stages(*, acoustic_gpu: int) -> list[StageConfig]:
+    from .platform_policy import get_minimax_music3_platform_policy
+
+    policy = get_minimax_music3_platform_policy()
+
     return [
         StageConfig(
             name="preprocessing",
@@ -74,7 +77,9 @@ def _stages(*, acoustic_gpu: int) -> list[StageConfig]:
                 dit_cfg_scale=DEFAULT_DIT_CFG_SCALE,
                 attention_backend="torch_sdpa",
                 cache_dit=False,
-                compile_acoustic=True,
+                # Establish correctness in eager mode first. torch.compile can
+                # still be requested explicitly once an XPU stack is validated.
+                compile_acoustic=policy.acoustic_compile,
                 breakable_cuda_graph=False,
             ),
             gpu=acoustic_gpu,
@@ -109,12 +114,16 @@ class MiniMaxMusic3PipelineConfig(PipelineConfig):
 
     stages: list[StageConfig] = Field(
         default_factory=lambda: (
-            _two_gpu_stages() if _visible_gpu_count() >= 2 else _colocated_stages()
+            _two_gpu_stages()
+            if _visible_accelerator_count() >= 2
+            else _colocated_stages()
         )
     )
     placement: PlacementConfig = Field(
         default_factory=lambda: (
-            PlacementConfig() if _visible_gpu_count() >= 2 else _colocated_placement()
+            PlacementConfig()
+            if _visible_accelerator_count() >= 2
+            else _colocated_placement()
         )
     )
 

--- a/sglang_omni/models/minimax_music3/dit.py
+++ b/sglang_omni/models/minimax_music3/dit.py
@@ -11,12 +11,9 @@ import logging
 import math
 from collections.abc import Callable
 from types import MethodType
+from typing import TYPE_CHECKING
 
 import torch
-from cache_dit import BlockAdapter, DBCacheConfig, ForwardPattern, enable_cache
-from sglang.multimodal_gen.runtime.breakable_cuda_graph.runner import (
-    DiffusionBreakableCudaGraphRunner,
-)
 from sglang.multimodal_gen.runtime.layers.attention import LocalAttention
 from sglang.multimodal_gen.runtime.layers.attention.selector import (
     component_attn_backend_context_manager,
@@ -27,6 +24,11 @@ from torch import Tensor, nn
 from torch.nn import functional as F
 
 from .constants import AR_HIDDEN_SIZE, DEFAULT_DIT_CFG_SCALE, DEFAULT_DIT_STEPS
+
+if TYPE_CHECKING:
+    from sglang.multimodal_gen.runtime.breakable_cuda_graph.runner import (
+        DiffusionBreakableCudaGraphRunner,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -336,6 +338,8 @@ class MiniMaxMusic3DIT(nn.Module):
         residual_diff_threshold: float,
         max_continuous_cached_steps: int,
     ) -> None:
+        from cache_dit import BlockAdapter, DBCacheConfig, ForwardPattern, enable_cache
+
         adapter = BlockAdapter(
             transformer=self.diffusion_transformer.transformer,
             blocks=self.diffusion_transformer.transformer.layers,
@@ -374,6 +378,10 @@ class MiniMaxMusic3DIT(nn.Module):
         min_free_gb: float,
     ) -> bool:
         """Capture the fixed full-window DiT step, falling back on failure."""
+        from sglang.multimodal_gen.runtime.breakable_cuda_graph.runner import (
+            DiffusionBreakableCudaGraphRunner,
+        )
+
         device = next(self.parameters()).device
         free_bytes, _ = torch.cuda.mem_get_info(device)
         free_gb = free_bytes / 2**30

--- a/sglang_omni/models/minimax_music3/engine_builder.py
+++ b/sglang_omni/models/minimax_music3/engine_builder.py
@@ -50,8 +50,11 @@ class MiniMaxMusic3EngineBuilder(TtsEngineBuilder):
         self._filter_audio_weights()
 
     def generation_defaults(self, *, dtype: str) -> dict[str, Any]:
+        from .platform_policy import get_minimax_music3_platform_policy
+
+        policy = get_minimax_music3_platform_policy()
         return {
-            "disable_cuda_graph": False,
+            "disable_cuda_graph": not policy.generation_cuda_graph,
             "disable_overlap_schedule": True,
             "disable_radix_cache": True,
             "enable_torch_compile": False,
@@ -113,6 +116,16 @@ class MiniMaxMusic3EngineBuilder(TtsEngineBuilder):
         self, model: Any, server_args: Any, *, generation_cuda_graph_enabled: bool
     ) -> None:
         del generation_cuda_graph_enabled
+        from .platform_policy import get_minimax_music3_platform_policy
+
+        policy = get_minimax_music3_platform_policy()
+        if not policy.rvq_cuda_graph:
+            logger.info(
+                "MiniMax Music 3 RVQ depth CUDA graph disabled on %s (%s); using eager execution",
+                policy.device_type,
+                policy.reason,
+            )
+            return
         from .sglang_model import enable_rvq_depth_cuda_graph
 
         del server_args

--- a/sglang_omni/models/minimax_music3/model_runner.py
+++ b/sglang_omni/models/minimax_music3/model_runner.py
@@ -403,7 +403,7 @@ class MiniMaxMusic3ModelRunner(ModelRunner):
     ) -> None:
         chunk = ar_state.frames.concatenate(window.start, window.end)
         self._dump_chunk(chunk, ar_state.seed, window)
-        torch.cuda.current_stream(chunk.device).synchronize()
+        torch.get_device_module(chunk.device).current_stream(chunk.device).synchronize()
         ar_state.pending_chunks.append(
             (
                 chunk,

--- a/sglang_omni/models/minimax_music3/platform_policy.py
+++ b/sglang_omni/models/minimax_music3/platform_policy.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-platform qualification policy for MiniMax Music 3.
+
+Keep hardware checks and supported/unverified/unsupported reasons centralized as
+required by the multi-hardware RFC:
+https://github.com/sgl-project/sglang-omni/issues/1310
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from sglang_omni.platforms import current_platform
+
+if TYPE_CHECKING:
+    from sglang_omni.platforms.interface import OmniPlatform
+
+
+class Qualification(str, Enum):
+    SUPPORTED = "supported"
+    UNSUPPORTED = "unsupported"
+    UNVERIFIED = "unverified"
+
+
+@dataclass(frozen=True)
+class MiniMaxMusic3PlatformPolicy:
+    qualification: Qualification
+    reason: str
+    device_type: str
+    generation_cuda_graph: bool
+    rvq_cuda_graph: bool
+    acoustic_compile: bool
+    breakable_cuda_graph: bool
+    configure_cuda_backends: bool
+
+    def require_runnable(self) -> None:
+        if self.qualification is Qualification.UNSUPPORTED:
+            raise RuntimeError(
+                f"MiniMax Music 3 is unsupported on {self.device_type}: {self.reason}"
+            )
+
+
+def get_minimax_music3_platform_policy(
+    platform: OmniPlatform | None = None,
+) -> MiniMaxMusic3PlatformPolicy:
+    """Return qualified features without spreading vendor checks through the model."""
+    platform = current_platform if platform is None else platform
+    device_type = platform.device_type
+
+    if platform.is_cuda():
+        return MiniMaxMusic3PlatformPolicy(
+            qualification=Qualification.SUPPORTED,
+            reason="the existing CUDA path is covered by accelerator tests",
+            device_type=device_type,
+            generation_cuda_graph=True,
+            rvq_cuda_graph=True,
+            acoustic_compile=True,
+            breakable_cuda_graph=True,
+            configure_cuda_backends=True,
+        )
+    if platform.is_musa():
+        # Preserve the pre-existing MUSA behavior. Its qualification is not
+        # changed as part of the Intel XPU enablement.
+        return MiniMaxMusic3PlatformPolicy(
+            qualification=Qualification.UNVERIFIED,
+            reason=(
+                "the pre-existing MUSA execution policy is preserved, but its "
+                "qualification evidence is outside this enablement"
+            ),
+            device_type=device_type,
+            generation_cuda_graph=True,
+            rvq_cuda_graph=True,
+            acoustic_compile=True,
+            breakable_cuda_graph=True,
+            configure_cuda_backends=True,
+        )
+    if platform.is_xpu():
+        return MiniMaxMusic3PlatformPolicy(
+            qualification=Qualification.UNVERIFIED,
+            reason=(
+                "the eager torch_sdpa path requires real-XPU operator, numeric, "
+                "and memory validation"
+            ),
+            device_type=device_type,
+            generation_cuda_graph=False,
+            rvq_cuda_graph=False,
+            acoustic_compile=False,
+            breakable_cuda_graph=False,
+            configure_cuda_backends=False,
+        )
+    return MiniMaxMusic3PlatformPolicy(
+        qualification=Qualification.UNSUPPORTED,
+        reason="no eager fallback and numeric validation are available",
+        device_type=device_type,
+        generation_cuda_graph=False,
+        rvq_cuda_graph=False,
+        acoustic_compile=False,
+        breakable_cuda_graph=False,
+        configure_cuda_backends=False,
+    )
+
+
+__all__ = [
+    "MiniMaxMusic3PlatformPolicy",
+    "Qualification",
+    "get_minimax_music3_platform_policy",
+]

--- a/sglang_omni/models/minimax_music3/stages.py
+++ b/sglang_omni/models/minimax_music3/stages.py
@@ -9,18 +9,42 @@ from typing import Any
 
 import torch
 
-from sglang_omni.platforms import current_platform
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.pipeline_state import store_state
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni.utils.device import resolve_device_spec
 
 from .acoustic import MiniMaxMusic3AcousticDecoder, MiniMaxMusic3AcousticScheduler
 from .constants import DEFAULT_DIT_CFG_SCALE, DEFAULT_DIT_STEPS, OUTPUT_SAMPLE_RATE
+from .platform_policy import (
+    MiniMaxMusic3PlatformPolicy,
+    Qualification,
+    get_minimax_music3_platform_policy,
+)
 from .request_builders import build_ttm_state
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_AR_CONCURRENCY = int(os.environ.get("MINIMAX_MUSIC3_AR_CONCURRENCY", "16"))
+
+
+def _require_supported_accelerator() -> MiniMaxMusic3PlatformPolicy:
+    policy = get_minimax_music3_platform_policy()
+    policy.require_runnable()
+    if policy.qualification is Qualification.UNVERIFIED:
+        logger.warning(
+            "MiniMax Music 3 platform=%s qualification=%s: %s",
+            policy.device_type,
+            policy.qualification.value,
+            policy.reason,
+        )
+    return policy
+
+
+def _configure_cuda_backends(policy: MiniMaxMusic3PlatformPolicy) -> None:
+    if policy.configure_cuda_backends:
+        torch.backends.cudnn.enabled = False
+        torch.backends.cuda.enable_cudnn_sdp(False)
 
 
 def create_preprocessing_executor(model_path: str) -> SimpleScheduler:
@@ -44,14 +68,9 @@ def create_ar_executor(
     max_concurrency: int = _DEFAULT_AR_CONCURRENCY,
     server_args_overrides: dict[str, Any] | None = None,
 ):
-    if device is None:
-        if gpu_id is None or not (
-            current_platform.is_cuda() or current_platform.is_musa()
-        ):
-            raise RuntimeError("MiniMax Music 3 requires CUDA/MUSA backend")
-        device = f"cuda:{gpu_id}"
-    torch.backends.cudnn.enabled = False
-    torch.backends.cuda.enable_cudnn_sdp(False)
+    policy = _require_supported_accelerator()
+    device = resolve_device_spec(device, gpu_id)
+    _configure_cuda_backends(policy)
 
     from .engine_builder import MiniMaxMusic3EngineBuilder
 
@@ -85,7 +104,7 @@ def create_dit_dav_executor(
     dit_cfg_scale: float = DEFAULT_DIT_CFG_SCALE,
     attention_backend: str = "torch_sdpa",
     cache_dit: bool = False,
-    compile_acoustic: bool = True,
+    compile_acoustic: bool | None = None,
     breakable_cuda_graph: bool = False,
     breakable_cuda_graph_min_free_gb: float | None = None,
     cache_dit_fn_compute_blocks: int = 2,
@@ -94,14 +113,11 @@ def create_dit_dav_executor(
     cache_dit_residual_diff_threshold: float = 0.08,
     cache_dit_max_continuous_cached_steps: int = 1,
 ) -> MiniMaxMusic3AcousticScheduler:
-    if device is None:
-        if gpu_id is None or not (
-            current_platform.is_cuda() or current_platform.is_musa()
-        ):
-            raise RuntimeError(
-                "MiniMax Music 3 acoustic inference requires CUDA/MUSA backend"
-            )
-        device = f"cuda:{gpu_id}"
+    policy = _require_supported_accelerator()
+    device = resolve_device_spec(device, gpu_id)
+    _configure_cuda_backends(policy)
+    if compile_acoustic is None:
+        compile_acoustic = policy.acoustic_compile
     decoder = MiniMaxMusic3AcousticDecoder(
         model_path,
         device=device,

--- a/tests/unit_test/minimax_music3/test_core.py
+++ b/tests/unit_test/minimax_music3/test_core.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import inspect
 import json
 from pathlib import Path
 
@@ -13,7 +12,6 @@ from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
 from torch.nn import functional as F
 
 from sglang_omni import platforms
-from sglang_omni.models.minimax_music3 import acoustic, engine_builder, stages
 from sglang_omni.models.minimax_music3.acoustic import (
     MiniMaxMusic3AcousticScheduler,
     _resolve_acoustic_dtype,
@@ -33,10 +31,6 @@ from sglang_omni.models.minimax_music3.dit import (
     _resolve_attention_backend,
 )
 from sglang_omni.models.minimax_music3.model_runner import _HiddenFrameBuffer
-from sglang_omni.models.minimax_music3.platform_policy import (
-    Qualification,
-    get_minimax_music3_platform_policy,
-)
 from sglang_omni.models.minimax_music3.rvq_cuda_graph import RVQDepthCudaGraphRunner
 from sglang_omni.models.minimax_music3.rvq_decoder import sample_topk_seeded
 from sglang_omni.pipeline.stage.stream_queue import StreamItem
@@ -178,30 +172,29 @@ def test_minimax_music3_explicit_placements_ignore_the_machine(
     monkeypatch.setattr(platforms.current_platform, "is_cuda", lambda: True)
     monkeypatch.setattr(platforms.current_platform, "is_musa", lambda: False)
     monkeypatch.setattr(platforms.current_platform, "is_xpu", lambda: False)
-    assert (
-        inspect.signature(acoustic.MiniMaxMusic3AcousticDecoder)
-        .parameters["device"]
-        .default
-        == "cuda:1"
+    monkeypatch.setattr(
+        torch,
+        "get_device_module",
+        lambda _device: pytest.fail("explicit topology queried the machine"),
     )
-    for _visible in ("6", "6,7"):
-        dual = MiniMaxMusic3DualGPUPipelineConfig(model_path="/models/minimax")
-        single = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
 
-        dual_stages = {stage.name: stage for stage in dual.stages}
-        single_stages = {stage.name: stage for stage in single.stages}
-        assert dual_stages["minimax_music3_ar"].gpu == 0
-        assert dual_stages["minimax_music3_ar"].factory.max_concurrency == 16
-        assert dual_stages["dit_dav"].gpu == 1
-        assert dual_stages["dit_dav"].factory.dtype == "float32"
-        assert dual_stages["dit_dav"].factory.breakable_cuda_graph is False
-        assert dual.placement.require_memory_fraction_for_colocation
-        assert single_stages["minimax_music3_ar"].gpu == 0
-        assert single_stages["minimax_music3_ar"].factory.max_concurrency == 16
-        assert single_stages["dit_dav"].gpu == 0
-        assert single_stages["dit_dav"].factory.dtype == "float32"
-        assert single_stages["dit_dav"].factory.breakable_cuda_graph is False
-        assert not single.placement.require_memory_fraction_for_colocation
+    dual = MiniMaxMusic3DualGPUPipelineConfig(model_path="/models/minimax")
+    single = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
+
+    dual_stages = {stage.name: stage for stage in dual.stages}
+    single_stages = {stage.name: stage for stage in single.stages}
+    assert dual_stages["minimax_music3_ar"].gpu == 0
+    assert dual_stages["minimax_music3_ar"].factory.max_concurrency == 16
+    assert dual_stages["dit_dav"].gpu == 1
+    assert dual_stages["dit_dav"].factory.dtype == "float32"
+    assert dual_stages["dit_dav"].factory.breakable_cuda_graph is False
+    assert dual.placement.require_memory_fraction_for_colocation
+    assert single_stages["minimax_music3_ar"].gpu == 0
+    assert single_stages["minimax_music3_ar"].factory.max_concurrency == 16
+    assert single_stages["dit_dav"].gpu == 0
+    assert single_stages["dit_dav"].factory.dtype == "float32"
+    assert single_stages["dit_dav"].factory.breakable_cuda_graph is False
+    assert not single.placement.require_memory_fraction_for_colocation
 
 
 @pytest.mark.parametrize(
@@ -250,125 +243,6 @@ def test_minimax_music3_default_follows_the_visible_gpus(
     assert MiniMaxMusic3PipelineConfig.stage_config_cls(
         "minimax_music3_ar"
     ).engine_stage
-
-
-def test_minimax_music3_xpu_defaults_to_eager_dual_device_topology(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    class _FakeXPU:
-        @staticmethod
-        def device_count() -> int:
-            return 2
-
-    monkeypatch.setattr(platforms.current_platform, "is_cuda", lambda: False)
-    monkeypatch.setattr(platforms.current_platform, "is_musa", lambda: False)
-    monkeypatch.setattr(platforms.current_platform, "is_xpu", lambda: True)
-    monkeypatch.setattr(platforms.current_platform, "device_type", "xpu")
-    monkeypatch.setattr(torch, "get_device_module", lambda _device: _FakeXPU)
-
-    config = MiniMaxMusic3PipelineConfig(model_path="/models/minimax")
-    configured_stages = {stage.name: stage for stage in config.stages}
-
-    assert configured_stages["dit_dav"].gpu == 1
-    assert configured_stages["dit_dav"].factory.compile_acoustic is False
-    policy = get_minimax_music3_platform_policy()
-    assert policy.qualification is Qualification.UNVERIFIED
-    assert "real-XPU" in policy.reason
-    assert engine_builder.MiniMaxMusic3EngineBuilder().generation_defaults(
-        dtype="bfloat16"
-    )["disable_cuda_graph"]
-
-
-def test_minimax_music3_xpu_ar_stage_uses_platform_device(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    captured: dict[str, object] = {}
-
-    class _FakeBuilder:
-        def __init__(self, *, max_running_requests: int) -> None:
-            self.max_running_requests = max_running_requests
-
-        def build(self, model_path: str, **kwargs: object) -> object:
-            captured.update(model_path=model_path, **kwargs)
-            return object()
-
-    monkeypatch.setattr(platforms.current_platform, "is_cuda", lambda: False)
-    monkeypatch.setattr(platforms.current_platform, "is_musa", lambda: False)
-    monkeypatch.setattr(platforms.current_platform, "is_xpu", lambda: True)
-    monkeypatch.setattr(platforms.current_platform, "device_type", "xpu")
-    monkeypatch.setattr(
-        stages,
-        "resolve_device_spec",
-        lambda device, gpu_id: f"xpu:{gpu_id}",
-    )
-    monkeypatch.setattr(engine_builder, "MiniMaxMusic3EngineBuilder", _FakeBuilder)
-
-    stages.create_ar_executor("/models/minimax", gpu_id=3, max_concurrency=4)
-
-    assert captured["device"] == "xpu:3"
-    assert captured["gpu_id"] == 3
-    assert captured["dtype"] == "bfloat16"
-
-
-def test_minimax_music3_xpu_acoustic_stage_defaults_to_eager(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    captured: dict[str, object] = {}
-
-    class _FakeDecoder:
-        def __init__(self, _model_path: str, **kwargs: object) -> None:
-            captured.update(kwargs)
-            self.device = kwargs["device"]
-            self.dtype = kwargs["dtype"]
-            self.dit_steps = kwargs["dit_steps"]
-            self.dit_cfg_scale = kwargs["dit_cfg_scale"]
-            self.attention_backend = kwargs["attention_backend"]
-            self.compile_acoustic = kwargs["compile_acoustic"]
-
-    monkeypatch.setattr(platforms.current_platform, "is_cuda", lambda: False)
-    monkeypatch.setattr(platforms.current_platform, "is_musa", lambda: False)
-    monkeypatch.setattr(platforms.current_platform, "is_xpu", lambda: True)
-    monkeypatch.setattr(platforms.current_platform, "device_type", "xpu")
-    monkeypatch.setattr(
-        stages,
-        "resolve_device_spec",
-        lambda device, gpu_id: f"xpu:{gpu_id}",
-    )
-    monkeypatch.setattr(stages, "MiniMaxMusic3AcousticDecoder", _FakeDecoder)
-
-    stages.create_dit_dav_executor("/models/minimax", gpu_id=1)
-
-    assert captured["device"] == "xpu:1"
-    assert captured["compile_acoustic"] is False
-    assert captured["attention_backend"] == "torch_sdpa"
-
-
-def test_minimax_music3_xpu_skips_rvq_cuda_graph(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(platforms.current_platform, "is_cuda", lambda: False)
-    monkeypatch.setattr(platforms.current_platform, "is_musa", lambda: False)
-    monkeypatch.setattr(platforms.current_platform, "is_xpu", lambda: True)
-    monkeypatch.setattr(platforms.current_platform, "device_type", "xpu")
-
-    engine_builder.MiniMaxMusic3EngineBuilder().setup_model_resources(
-        object(), object(), generation_cuda_graph_enabled=False
-    )
-
-
-def test_minimax_music3_xpu_rejects_breakable_cuda_graph_before_loading(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(platforms.current_platform, "is_cuda", lambda: False)
-    monkeypatch.setattr(platforms.current_platform, "is_musa", lambda: False)
-    monkeypatch.setattr(platforms.current_platform, "is_xpu", lambda: True)
-    monkeypatch.setattr(platforms.current_platform, "device_type", "xpu")
-    monkeypatch.setattr(acoustic, "resolve_device_spec", lambda _device: "xpu:0")
-
-    with pytest.raises(ValueError, match="unavailable on xpu"):
-        acoustic.MiniMaxMusic3AcousticDecoder(
-            "/models/minimax", breakable_cuda_graph=True
-        )
 
 
 def test_native_attention_preserves_checkpoint_state_dict_keys() -> None:

--- a/tests/unit_test/minimax_music3/test_core.py
+++ b/tests/unit_test/minimax_music3/test_core.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 from pathlib import Path
 
@@ -11,6 +12,8 @@ from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_c
 from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
 from torch.nn import functional as F
 
+from sglang_omni import platforms
+from sglang_omni.models.minimax_music3 import acoustic, engine_builder, stages
 from sglang_omni.models.minimax_music3.acoustic import (
     MiniMaxMusic3AcousticScheduler,
     _resolve_acoustic_dtype,
@@ -30,6 +33,10 @@ from sglang_omni.models.minimax_music3.dit import (
     _resolve_attention_backend,
 )
 from sglang_omni.models.minimax_music3.model_runner import _HiddenFrameBuffer
+from sglang_omni.models.minimax_music3.platform_policy import (
+    Qualification,
+    get_minimax_music3_platform_policy,
+)
 from sglang_omni.models.minimax_music3.rvq_cuda_graph import RVQDepthCudaGraphRunner
 from sglang_omni.models.minimax_music3.rvq_decoder import sample_topk_seeded
 from sglang_omni.pipeline.stage.stream_queue import StreamItem
@@ -168,8 +175,16 @@ def test_minimax_music3_explicit_placements_ignore_the_machine(
     two-GPU has to stay two-GPU even on a one-GPU box, or the file would not be
     describing anything.
     """
-    for visible in ("6", "6,7"):
-        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", visible)
+    monkeypatch.setattr(platforms.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(platforms.current_platform, "is_musa", lambda: False)
+    monkeypatch.setattr(platforms.current_platform, "is_xpu", lambda: False)
+    assert (
+        inspect.signature(acoustic.MiniMaxMusic3AcousticDecoder)
+        .parameters["device"]
+        .default
+        == "cuda:1"
+    )
+    for _visible in ("6", "6,7"):
         dual = MiniMaxMusic3DualGPUPipelineConfig(model_path="/models/minimax")
         single = MiniMaxMusic3SingleGPUPipelineConfig(model_path="/models/minimax")
 
@@ -213,7 +228,17 @@ def test_minimax_music3_default_follows_the_visible_gpus(
     every single-GPU user to pass a config file to say so. The default now
     matches the machine, which is the topology this model is usually served in.
     """
-    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", visible)
+    visible_count = len(visible.split(","))
+    monkeypatch.setattr(platforms.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(platforms.current_platform, "is_musa", lambda: False)
+    monkeypatch.setattr(platforms.current_platform, "is_xpu", lambda: False)
+    monkeypatch.setattr(
+        torch,
+        "get_device_module",
+        lambda _device: type(
+            "_FakeAccelerator", (), {"device_count": lambda: visible_count}
+        ),
+    )
     config = MiniMaxMusic3PipelineConfig(model_path="/models/minimax")
 
     stages = {stage.name: stage for stage in config.stages}
@@ -225,6 +250,125 @@ def test_minimax_music3_default_follows_the_visible_gpus(
     assert MiniMaxMusic3PipelineConfig.stage_config_cls(
         "minimax_music3_ar"
     ).engine_stage
+
+
+def test_minimax_music3_xpu_defaults_to_eager_dual_device_topology(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeXPU:
+        @staticmethod
+        def device_count() -> int:
+            return 2
+
+    monkeypatch.setattr(platforms.current_platform, "is_cuda", lambda: False)
+    monkeypatch.setattr(platforms.current_platform, "is_musa", lambda: False)
+    monkeypatch.setattr(platforms.current_platform, "is_xpu", lambda: True)
+    monkeypatch.setattr(platforms.current_platform, "device_type", "xpu")
+    monkeypatch.setattr(torch, "get_device_module", lambda _device: _FakeXPU)
+
+    config = MiniMaxMusic3PipelineConfig(model_path="/models/minimax")
+    configured_stages = {stage.name: stage for stage in config.stages}
+
+    assert configured_stages["dit_dav"].gpu == 1
+    assert configured_stages["dit_dav"].factory.compile_acoustic is False
+    policy = get_minimax_music3_platform_policy()
+    assert policy.qualification is Qualification.UNVERIFIED
+    assert "real-XPU" in policy.reason
+    assert engine_builder.MiniMaxMusic3EngineBuilder().generation_defaults(
+        dtype="bfloat16"
+    )["disable_cuda_graph"]
+
+
+def test_minimax_music3_xpu_ar_stage_uses_platform_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeBuilder:
+        def __init__(self, *, max_running_requests: int) -> None:
+            self.max_running_requests = max_running_requests
+
+        def build(self, model_path: str, **kwargs: object) -> object:
+            captured.update(model_path=model_path, **kwargs)
+            return object()
+
+    monkeypatch.setattr(platforms.current_platform, "is_cuda", lambda: False)
+    monkeypatch.setattr(platforms.current_platform, "is_musa", lambda: False)
+    monkeypatch.setattr(platforms.current_platform, "is_xpu", lambda: True)
+    monkeypatch.setattr(platforms.current_platform, "device_type", "xpu")
+    monkeypatch.setattr(
+        stages,
+        "resolve_device_spec",
+        lambda device, gpu_id: f"xpu:{gpu_id}",
+    )
+    monkeypatch.setattr(engine_builder, "MiniMaxMusic3EngineBuilder", _FakeBuilder)
+
+    stages.create_ar_executor("/models/minimax", gpu_id=3, max_concurrency=4)
+
+    assert captured["device"] == "xpu:3"
+    assert captured["gpu_id"] == 3
+    assert captured["dtype"] == "bfloat16"
+
+
+def test_minimax_music3_xpu_acoustic_stage_defaults_to_eager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeDecoder:
+        def __init__(self, _model_path: str, **kwargs: object) -> None:
+            captured.update(kwargs)
+            self.device = kwargs["device"]
+            self.dtype = kwargs["dtype"]
+            self.dit_steps = kwargs["dit_steps"]
+            self.dit_cfg_scale = kwargs["dit_cfg_scale"]
+            self.attention_backend = kwargs["attention_backend"]
+            self.compile_acoustic = kwargs["compile_acoustic"]
+
+    monkeypatch.setattr(platforms.current_platform, "is_cuda", lambda: False)
+    monkeypatch.setattr(platforms.current_platform, "is_musa", lambda: False)
+    monkeypatch.setattr(platforms.current_platform, "is_xpu", lambda: True)
+    monkeypatch.setattr(platforms.current_platform, "device_type", "xpu")
+    monkeypatch.setattr(
+        stages,
+        "resolve_device_spec",
+        lambda device, gpu_id: f"xpu:{gpu_id}",
+    )
+    monkeypatch.setattr(stages, "MiniMaxMusic3AcousticDecoder", _FakeDecoder)
+
+    stages.create_dit_dav_executor("/models/minimax", gpu_id=1)
+
+    assert captured["device"] == "xpu:1"
+    assert captured["compile_acoustic"] is False
+    assert captured["attention_backend"] == "torch_sdpa"
+
+
+def test_minimax_music3_xpu_skips_rvq_cuda_graph(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platforms.current_platform, "is_cuda", lambda: False)
+    monkeypatch.setattr(platforms.current_platform, "is_musa", lambda: False)
+    monkeypatch.setattr(platforms.current_platform, "is_xpu", lambda: True)
+    monkeypatch.setattr(platforms.current_platform, "device_type", "xpu")
+
+    engine_builder.MiniMaxMusic3EngineBuilder().setup_model_resources(
+        object(), object(), generation_cuda_graph_enabled=False
+    )
+
+
+def test_minimax_music3_xpu_rejects_breakable_cuda_graph_before_loading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platforms.current_platform, "is_cuda", lambda: False)
+    monkeypatch.setattr(platforms.current_platform, "is_musa", lambda: False)
+    monkeypatch.setattr(platforms.current_platform, "is_xpu", lambda: True)
+    monkeypatch.setattr(platforms.current_platform, "device_type", "xpu")
+    monkeypatch.setattr(acoustic, "resolve_device_spec", lambda _device: "xpu:0")
+
+    with pytest.raises(ValueError, match="unavailable on xpu"):
+        acoustic.MiniMaxMusic3AcousticDecoder(
+            "/models/minimax", breakable_cuda_graph=True
+        )
 
 
 def test_native_attention_preserves_checkpoint_state_dict_keys() -> None:

--- a/tests/unit_test/xpu/test_minimax_music3.py
+++ b/tests/unit_test/xpu/test_minimax_music3.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sglang_omni import platforms
+from sglang_omni.models.minimax_music3 import acoustic, engine_builder, stages
+from sglang_omni.models.minimax_music3.config import MiniMaxMusic3PipelineConfig
+from sglang_omni.models.minimax_music3.platform_policy import (
+    Qualification,
+    get_minimax_music3_platform_policy,
+)
+
+
+def _mock_xpu_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(platforms.current_platform, "is_cuda", lambda: False)
+    monkeypatch.setattr(platforms.current_platform, "is_musa", lambda: False)
+    monkeypatch.setattr(platforms.current_platform, "is_xpu", lambda: True)
+    monkeypatch.setattr(platforms.current_platform, "device_type", "xpu")
+
+
+def test_minimax_music3_xpu_defaults_to_eager_dual_device_topology(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeXPU:
+        @staticmethod
+        def device_count() -> int:
+            return 2
+
+    _mock_xpu_platform(monkeypatch)
+    monkeypatch.setattr(torch, "get_device_module", lambda _device: _FakeXPU)
+
+    config = MiniMaxMusic3PipelineConfig(model_path="/models/minimax")
+    configured_stages = {stage.name: stage for stage in config.stages}
+
+    assert configured_stages["dit_dav"].gpu == 1
+    assert configured_stages["dit_dav"].factory.compile_acoustic is False
+    policy = get_minimax_music3_platform_policy()
+    assert policy.qualification is Qualification.UNVERIFIED
+    assert "real-XPU" in policy.reason
+    assert engine_builder.MiniMaxMusic3EngineBuilder().generation_defaults(
+        dtype="bfloat16"
+    )["disable_cuda_graph"]
+
+
+def test_minimax_music3_xpu_ar_stage_uses_platform_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeBuilder:
+        def __init__(self, *, max_running_requests: int) -> None:
+            self.max_running_requests = max_running_requests
+
+        def build(self, model_path: str, **kwargs: object) -> object:
+            captured.update(model_path=model_path, **kwargs)
+            return object()
+
+    _mock_xpu_platform(monkeypatch)
+    monkeypatch.setattr(
+        stages,
+        "resolve_device_spec",
+        lambda device, gpu_id: f"xpu:{gpu_id}",
+    )
+    monkeypatch.setattr(engine_builder, "MiniMaxMusic3EngineBuilder", _FakeBuilder)
+
+    stages.create_ar_executor("/models/minimax", gpu_id=3, max_concurrency=4)
+
+    assert captured["device"] == "xpu:3"
+    assert captured["gpu_id"] == 3
+    assert captured["dtype"] == "bfloat16"
+
+
+def test_minimax_music3_xpu_acoustic_stage_defaults_to_eager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeDecoder:
+        def __init__(self, _model_path: str, **kwargs: object) -> None:
+            captured.update(kwargs)
+            self.device = kwargs["device"]
+            self.dtype = kwargs["dtype"]
+            self.dit_steps = kwargs["dit_steps"]
+            self.dit_cfg_scale = kwargs["dit_cfg_scale"]
+            self.attention_backend = kwargs["attention_backend"]
+            self.compile_acoustic = kwargs["compile_acoustic"]
+
+    _mock_xpu_platform(monkeypatch)
+    monkeypatch.setattr(
+        stages,
+        "resolve_device_spec",
+        lambda device, gpu_id: f"xpu:{gpu_id}",
+    )
+    monkeypatch.setattr(stages, "MiniMaxMusic3AcousticDecoder", _FakeDecoder)
+
+    stages.create_dit_dav_executor("/models/minimax", gpu_id=1)
+
+    assert captured["device"] == "xpu:1"
+    assert captured["compile_acoustic"] is False
+    assert captured["attention_backend"] == "torch_sdpa"
+
+
+def test_minimax_music3_xpu_skips_rvq_cuda_graph(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_xpu_platform(monkeypatch)
+
+    engine_builder.MiniMaxMusic3EngineBuilder().setup_model_resources(
+        object(), object(), generation_cuda_graph_enabled=False
+    )
+
+
+def test_minimax_music3_xpu_rejects_breakable_cuda_graph_before_loading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolved_devices: list[str | None] = []
+    _mock_xpu_platform(monkeypatch)
+    monkeypatch.setattr(
+        acoustic,
+        "resolve_device_spec",
+        lambda device: resolved_devices.append(device) or "xpu:0",
+    )
+
+    with pytest.raises(ValueError, match="unavailable on xpu"):
+        acoustic.MiniMaxMusic3AcousticDecoder(
+            "/models/minimax", breakable_cuda_graph=True
+        )
+    assert resolved_devices == [None]


### PR DESCRIPTION
WIP.
 ## Motivation

  Enable MiniMax Music 3 inference on Intel XPU platform.

  ## Modifications

  - Added a centralized MiniMax Music 3 platform policy for CUDA, MUSA, XPU, and unsupported platforms.
  - Changed stage device selection to use the shared platform-aware device resolver.
  - Replaced CUDA-specific stream synchronization with the active PyTorch device module.
  - Added visible accelerator detection for automatic single-device or dual-device placement.
  - Disabled the following unqualified optimizations on XPU
  - Added MiniMax Music 3 dependencies to pyproject_xpu.toml and docker/xpu.Dockerfile, and update XPU installation guide 
  

  ## Related issues

https://github.com/sgl-project/sglang-omni/issues/1588

  ## Accuracy Test
WIP

  ## CI / Tests
 Added XPU-specific tests under tests/unit_test/xpu/ 
cookbook example test WIP.
