### PR TITLE
docs(whisper): correct subtitle support note

### DIFF
--- a/docs/cookbook/whisper_asr.md
+++ b/docs/cookbook/whisper_asr.md
@@ -254,8 +254,8 @@ All 4,608 measured requests across both modes completed successfully, and all 2,
 
 - Whisper ASR remains experimental. Validate checkpoint-specific accuracy and
   operational behavior before production deployment.
-- `verbose_json` returns a single segment spanning the audio duration; `srt`
-  and `vtt` are not supported and return HTTP 400.
+- `verbose_json` returns a single segment spanning the audio duration. `srt` and
+  `vtt` are supported for non-streaming requests; `stream=true` returns HTTP 400.
 - Encoder CUDA Graph is enabled by default and requires SGLang generation CUDA
   Graph. Validate the selected buckets before production use.
 - Audio encoding runs before LM admission by default


### PR DESCRIPTION
The Whisper cookbook still said `srt` and `vtt` were unsupported, but non-streaming subtitle responses are already supported.

This updates the limitation to say that only `stream=true` returns HTTP 400.

Tested with:
- `pre-commit run --files docs/cookbook/whisper_asr.md`