### PR TITLE
[CPU] Enable Voxtral TTS model on Intel CPU platform

### DIFF
--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -168,8 +168,12 @@ class ModelRunner:
                 or bufs[0].dtype != dtype
             )
         if need_alloc:
+            # Pinning only buys faster host-device copies, so a platform without
+            # a device gets plain host memory instead — torch raises there rather
+            # than falling back on its own.
+            pin = current_platform.supports_pinned_host_memory()
             bufs = [
-                torch.empty(shape, dtype=dtype, device="cpu", pin_memory=True)
+                torch.empty(shape, dtype=dtype, device="cpu", pin_memory=pin)
                 for _ in range(2)
             ]
             setattr(self, bufs_attr, bufs)

--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -168,10 +168,7 @@ class ModelRunner:
                 or bufs[0].dtype != dtype
             )
         if need_alloc:
-            # Pinning only buys faster host-device copies, so a platform without
-            # a device gets plain host memory instead — torch raises there rather
-            # than falling back on its own.
-            pin = current_platform.supports_pinned_host_memory()
+            pin = current_platform.is_pin_memory_available()
             bufs = [
                 torch.empty(shape, dtype=dtype, device="cpu", pin_memory=pin)
                 for _ in range(2)

--- a/sglang_omni/models/voxtral_tts/pipeline/engine_builder.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/engine_builder.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from sglang_omni.models.voxtral_tts import request_builders
 from sglang_omni.models.voxtral_tts.pipeline import stages as voxtral_stages
+from sglang_omni.platforms import current_platform
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
 
 
@@ -36,7 +37,14 @@ class VoxtralTtsEngineBuilder(TtsEngineBuilder):
             "disable_cuda_graph": False,
             "disable_overlap_schedule": True,
             "decrypted_config_file": self.decrypted_config_file,
-            "enable_torch_compile": True,
+            # Off on CPU: inductor plans strides from the meta kernel of
+            # sgl_kernel.rotary_embedding_cpu, which disagrees with the real
+            # kernel (expected stride 4096, got 6144), so the compiled graph
+            # trips assert_size_stride during warmup. This is narrow — Qwen3-ASR
+            # compiles fine on CPU — so it stays a Voxtral default rather than a
+            # platform-wide claim that CPU cannot compile. Re-enable once the
+            # upstream meta kernel is fixed.
+            "enable_torch_compile": not current_platform.is_cpu(),
             "mem_fraction_static": 0.85,
             "max_prefill_tokens": 8192,
             "sampling_backend": "pytorch",

--- a/sglang_omni/models/voxtral_tts/pipeline/stages.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/stages.py
@@ -16,12 +16,12 @@ import torch
 from sglang_omni.models.voxtral_tts.io import VoxtralTTSState
 from sglang_omni.models.voxtral_tts.pipeline.state_io import load_state, store_state
 from sglang_omni.platforms import current_platform
-from sglang_omni.utils.device import place_device_spec, resolve_device_spec
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from sglang_omni.scheduling.vocoder_base import BatchVocoderBase
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoint
+from sglang_omni.utils.device import place_device_spec, resolve_device_spec
 
 logger = logging.getLogger(__name__)
 
@@ -403,10 +403,8 @@ def create_vocoder_executor(
     gpu_id: int | None = None,
 ) -> SimpleScheduler:
     checkpoint_dir = _resolve_checkpoint(model_path)
-    # Placement applies to whatever device the caller named; only an unset device
-    # is resolved from the platform. The old form overwrote the caller's device
-    # with a CUDA literal whenever placement supplied a gpu_id, so an explicit
-    # cpu stage was silently retargeted and only failed at torch.cuda.set_device.
+    # Preserve an explicit device type while placement owns its index. Resolve an
+    # unset type from the current platform.
     device = (
         resolve_device_spec(None, gpu_id)
         if device is None

--- a/sglang_omni/models/voxtral_tts/pipeline/stages.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/stages.py
@@ -16,6 +16,7 @@ import torch
 from sglang_omni.models.voxtral_tts.io import VoxtralTTSState
 from sglang_omni.models.voxtral_tts.pipeline.state_io import load_state, store_state
 from sglang_omni.platforms import current_platform
+from sglang_omni.utils.device import place_device_spec, resolve_device_spec
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from sglang_omni.scheduling.vocoder_base import BatchVocoderBase
@@ -169,7 +170,9 @@ def _enable_inductor_gemm_autotune() -> None:
 def create_generation_executor(
     model_path: str,
     *,
-    device: str = "cuda:0",
+    # None lets the shared engine builder resolve placement from the platform;
+    # an explicit device is honored as-is and never retargeted.
+    device: str | None = None,
     gpu_id: int | None = None,
     max_new_tokens: int = 4096,
     server_args_overrides: dict[str, Any] | None = None,
@@ -396,12 +399,19 @@ class _VoxtralTTSVocoder(BatchVocoderBase):
 def create_vocoder_executor(
     model_path: str,
     *,
-    device: str = "cuda:0",
+    device: str | None = None,
     gpu_id: int | None = None,
 ) -> SimpleScheduler:
     checkpoint_dir = _resolve_checkpoint(model_path)
-    if gpu_id is not None:
-        device = f"cuda:{gpu_id}"
+    # Placement applies to whatever device the caller named; only an unset device
+    # is resolved from the platform. The old form overwrote the caller's device
+    # with a CUDA literal whenever placement supplied a gpu_id, so an explicit
+    # cpu stage was silently retargeted and only failed at torch.cuda.set_device.
+    device = (
+        resolve_device_spec(None, gpu_id)
+        if device is None
+        else place_device_spec(device, gpu_id)
+    )
 
     logger.info("Loading Voxtral audio tokenizer for vocoding...")
     audio_tokenizer = _load_audio_tokenizer(checkpoint_dir, {}, device)

--- a/sglang_omni/platforms/cpu.py
+++ b/sglang_omni/platforms/cpu.py
@@ -6,3 +6,9 @@ from sglang_omni.platforms.interface import OmniPlatform
 class CPUOmniPlatform(CpuDeviceMixin, OmniPlatform):
     def enable_code2wav_graph(self):
         return False
+
+    def supports_generation_cuda_graph(self) -> bool:
+        return False
+
+    def supports_pinned_host_memory(self) -> bool:
+        return False

--- a/sglang_omni/platforms/cpu.py
+++ b/sglang_omni/platforms/cpu.py
@@ -7,8 +7,5 @@ class CPUOmniPlatform(CpuDeviceMixin, OmniPlatform):
     def enable_code2wav_graph(self):
         return False
 
-    def supports_generation_cuda_graph(self) -> bool:
-        return False
-
-    def supports_pinned_host_memory(self) -> bool:
+    def is_pin_memory_available(self, device=None) -> bool:
         return False

--- a/sglang_omni/platforms/interface.py
+++ b/sglang_omni/platforms/interface.py
@@ -60,3 +60,22 @@ class OmniPlatform(DeviceMixin):
     def enable_code2wav_graph(self):
         """Check if current platform support Graph for code2wav in Qwen3-Omni"""
         return True
+
+    def supports_pinned_host_memory(self) -> bool:
+        """Whether ``pin_memory=True`` host allocations work here.
+
+        Page-locked host buffers exist to speed host-device copies, so a
+        platform with no device has neither the allocator nor a reason to want
+        one; torch raises rather than degrading. Asked wherever a staging buffer
+        is allocated, so those sites fall back to ordinary host memory.
+        """
+        return True
+
+    def supports_generation_cuda_graph(self) -> bool:
+        """Whether this platform can capture a generation CUDA graph.
+
+        Asked by the shared engine builder instead of testing the device type
+        there, so a platform that cannot capture is refused at configuration
+        time rather than failing inside capture.
+        """
+        return True

--- a/sglang_omni/platforms/interface.py
+++ b/sglang_omni/platforms/interface.py
@@ -61,21 +61,10 @@ class OmniPlatform(DeviceMixin):
         """Check if current platform support Graph for code2wav in Qwen3-Omni"""
         return True
 
-    def supports_pinned_host_memory(self) -> bool:
-        """Whether ``pin_memory=True`` host allocations work here.
+    def is_pin_memory_available(self, device=None) -> bool:
+        """Preserve pinned staging on accelerator platforms.
 
-        Page-locked host buffers exist to speed host-device copies, so a
-        platform with no device has neither the allocator nor a reason to want
-        one; torch raises rather than degrading. Asked wherever a staging buffer
-        is allocated, so those sites fall back to ordinary host memory.
+        Concrete Omni platforms can override this capability; CPU returns
+        ``False`` because there is no accelerator transfer to optimize.
         """
-        return True
-
-    def supports_generation_cuda_graph(self) -> bool:
-        """Whether this platform can capture a generation CUDA graph.
-
-        Asked by the shared engine builder instead of testing the device type
-        there, so a platform that cannot capture is refused at configuration
-        time rather than failing inside capture.
-        """
-        return True
+        return device is None or str(device) != "cpu"

--- a/tests/unit_test/cpu/test_host_buffers.py
+++ b/tests/unit_test/cpu/test_host_buffers.py
@@ -14,7 +14,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-import sglang_omni.platforms as platforms
+from sglang_omni import platforms
 from sglang_omni.model_runner.base import ModelRunner
 from sglang_omni.platforms.cpu import CPUOmniPlatform
 from sglang_omni.platforms.interface import OmniPlatform
@@ -24,8 +24,8 @@ def test_only_cpu_refuses_pinned_host_memory():
     """Default stays permissive: an accelerator platform that forgot to override
     this would otherwise lose pinned staging and quietly slow every copy.
     """
-    assert OmniPlatform().supports_pinned_host_memory() is True
-    assert CPUOmniPlatform().supports_pinned_host_memory() is False
+    assert OmniPlatform().is_pin_memory_available() is True
+    assert CPUOmniPlatform().is_pin_memory_available() is False
 
 
 def _pingpong(owner, shape=(4,), dtype=torch.int32):
@@ -38,7 +38,7 @@ def test_buffers_are_unpinned_when_the_platform_has_no_pinned_allocator(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        platforms.current_platform, "supports_pinned_host_memory", lambda: False
+        platforms.current_platform, "is_pin_memory_available", lambda: False
     )
     owner = SimpleNamespace(_bufs=[], _slot=0)
 
@@ -54,7 +54,7 @@ def test_the_two_buffers_still_alternate(monkeypatch: pytest.MonkeyPatch) -> Non
     would otherwise race the next step's copy into the same buffer.
     """
     monkeypatch.setattr(
-        platforms.current_platform, "supports_pinned_host_memory", lambda: False
+        platforms.current_platform, "is_pin_memory_available", lambda: False
     )
     owner = SimpleNamespace(_bufs=[], _slot=0)
 
@@ -73,7 +73,7 @@ def test_a_pinning_platform_still_gets_pinned_buffers(
     needs a real accelerator, so assert the request rather than the result.
     """
     monkeypatch.setattr(
-        platforms.current_platform, "supports_pinned_host_memory", lambda: True
+        platforms.current_platform, "is_pin_memory_available", lambda: True
     )
     seen: dict[str, object] = {}
     real_empty = torch.empty

--- a/tests/unit_test/cpu/test_host_buffers.py
+++ b/tests/unit_test/cpu/test_host_buffers.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Host staging buffers must not ask for pinned memory on a platform without it.
+
+``pin_memory=True`` raises on a CPU-only torch build rather than degrading, and
+the failure surfaces late — deep in a model step, after a full prefill. These
+drive the shared helper directly so the contract is checked without standing a
+model up.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import sglang_omni.platforms as platforms
+from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.platforms.cpu import CPUOmniPlatform
+from sglang_omni.platforms.interface import OmniPlatform
+
+
+def test_only_cpu_refuses_pinned_host_memory():
+    """Default stays permissive: an accelerator platform that forgot to override
+    this would otherwise lose pinned staging and quietly slow every copy.
+    """
+    assert OmniPlatform().supports_pinned_host_memory() is True
+    assert CPUOmniPlatform().supports_pinned_host_memory() is False
+
+
+def _pingpong(owner, shape=(4,), dtype=torch.int32):
+    return ModelRunner._pinned_pingpong(
+        owner, "_bufs", "_slot", shape, dtype, realloc_on_grow=True
+    )
+
+
+def test_buffers_are_unpinned_when_the_platform_has_no_pinned_allocator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        platforms.current_platform, "supports_pinned_host_memory", lambda: False
+    )
+    owner = SimpleNamespace(_bufs=[], _slot=0)
+
+    buf = _pingpong(owner)
+
+    assert buf.is_pinned() is False
+    assert buf.device.type == "cpu"
+    assert buf.shape == (4,)
+
+
+def test_the_two_buffers_still_alternate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Dropping the pin must not disturb the ping-pong itself: a step's host read
+    would otherwise race the next step's copy into the same buffer.
+    """
+    monkeypatch.setattr(
+        platforms.current_platform, "supports_pinned_host_memory", lambda: False
+    )
+    owner = SimpleNamespace(_bufs=[], _slot=0)
+
+    first = _pingpong(owner)
+    second = _pingpong(owner)
+    third = _pingpong(owner)
+
+    assert first is not second
+    assert third is first
+
+
+def test_a_pinning_platform_still_gets_pinned_buffers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CPU branch must not become the path everyone takes. Allocation itself
+    needs a real accelerator, so assert the request rather than the result.
+    """
+    monkeypatch.setattr(
+        platforms.current_platform, "supports_pinned_host_memory", lambda: True
+    )
+    seen: dict[str, object] = {}
+    real_empty = torch.empty
+
+    def spy_empty(*args, **kwargs):
+        seen["pin_memory"] = kwargs.get("pin_memory")
+        kwargs["pin_memory"] = False  # this host may have no pinned allocator
+        return real_empty(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "empty", spy_empty)
+    owner = SimpleNamespace(_bufs=[], _slot=0)
+
+    _pingpong(owner)
+
+    assert seen["pin_memory"] is True

--- a/tests/unit_test/cpu/test_voxtral_device_contract.py
+++ b/tests/unit_test/cpu/test_voxtral_device_contract.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Voxtral-TTS device and compile contracts on CPU.
+
+Kept here rather than appended to ``tests/unit_test/test_stage_device_contract.py``
+so each model's CPU enablement lands on its own branch without colliding with the
+others in one shared file, and so CI can select CPU coverage by directory.
+
+The stage-level "config leaves device unset" half is asserted directly below,
+since these stages are not in that shared registry.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import sglang_omni.platforms as platforms
+
+
+def test_the_voxtral_stages_leave_device_to_their_factories() -> None:
+    """A config-pinned device would be honored as-is and never retargeted, so it
+    has to stay unset for the factory resolution below to matter at all.
+    """
+    from sglang_omni.models.voxtral_tts.config import EntryClass
+
+    config = EntryClass(model_path="unused")
+
+    for stage_name in ("tts_generation", "vocoder"):
+        assert config.stage_named(stage_name).factory.device is None, stage_name
+
+
+def test_voxtral_generation_stage_forwards_none_to_the_shared_builder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The generation stage used to pin ``device="cuda:0"`` in its signature
+    default, which the config never overrode, so the literal followed the stage
+    onto a CPU host and died at torch.cuda.set_device.
+
+    Patching the base builder's build() also proves it is the builder in play: a
+    factory using an unrelated builder would leave this spy untouched.
+    """
+    from sglang_omni.models.voxtral_tts.pipeline import stages
+    from sglang_omni.scheduling import engine_factory
+
+    seen: dict[str, object] = {}
+
+    def spy_build(self, model_path, **kwargs):
+        del self, model_path
+        seen.update(kwargs)
+        return SimpleNamespace()
+
+    monkeypatch.setattr(
+        engine_factory.SGLangGenerationEngineBuilder, "build", spy_build
+    )
+
+    stages.create_generation_executor("unused", gpu_id=1)
+
+    assert "device" in seen, "the factory did not route through the shared builder"
+    assert seen["device"] is None
+    assert seen["gpu_id"] == 1
+
+
+@pytest.mark.parametrize(
+    ("device", "gpu_id", "expected"),
+    [
+        # Placement must not overwrite a device the caller named.
+        ("cpu", 2, "cpu"),
+        ("cuda:3", None, "cuda:3"),
+        # Unset device: the platform names the type, placement the index.
+        (None, 0, None),
+        (None, None, None),
+    ],
+)
+def test_voxtral_vocoder_never_overwrites_an_explicit_device(
+    monkeypatch: pytest.MonkeyPatch, device, gpu_id, expected
+) -> None:
+    """The worst shape of this bug: the vocoder did not merely default to CUDA,
+    it *replaced* whatever the caller passed whenever placement supplied a
+    gpu_id (``if gpu_id is not None: device = f"cuda:{gpu_id}"``). An explicit
+    cpu stage was therefore retargeted to CUDA and only failed later, inside
+    torch.cuda.set_device.
+
+    Drives the real factory with the codec load stubbed out, so a regression in
+    the resolution actually fails this test.
+    """
+    from sglang_omni.models.voxtral_tts.pipeline import stages
+    from sglang_omni.utils.device import resolve_device_spec
+
+    seen: dict[str, object] = {}
+
+    monkeypatch.setattr(stages, "_resolve_checkpoint", lambda path: path)
+    monkeypatch.setattr(
+        stages,
+        "_load_audio_tokenizer",
+        lambda checkpoint_dir, audio_config, dev: seen.setdefault("device", dev),
+    )
+    monkeypatch.setattr(
+        stages,
+        "_VoxtralTTSVocoder",
+        lambda tokenizer: SimpleNamespace(
+            build_scheduler=lambda **kwargs: SimpleNamespace()
+        ),
+    )
+
+    stages.create_vocoder_executor("unused", device=device, gpu_id=gpu_id)
+
+    assert seen["device"] == (
+        expected if expected is not None else resolve_device_spec(None, gpu_id)
+    )
+
+
+def test_voxtral_leaves_torch_compile_to_the_platform() -> None:
+    """Inductor plans strides from the meta kernel of
+    sgl_kernel.rotary_embedding_cpu, which disagrees with the real kernel
+    (expected 4096, got 6144), so the compiled graph trips assert_size_stride
+    during warmup. Narrow to Voxtral on purpose — Qwen3-ASR compiles fine on
+    CPU — so this must not become a platform-wide claim that CPU cannot compile.
+    """
+    from sglang_omni.models.voxtral_tts.pipeline.engine_builder import (
+        VoxtralTtsEngineBuilder,
+    )
+
+    defaults = VoxtralTtsEngineBuilder().generation_defaults(dtype="bfloat16")
+
+    assert defaults["enable_torch_compile"] is not platforms.current_platform.is_cpu()

--- a/tests/unit_test/cpu/test_voxtral_device_contract.py
+++ b/tests/unit_test/cpu/test_voxtral_device_contract.py
@@ -1,13 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Voxtral-TTS device and compile contracts on CPU.
-
-Kept here rather than appended to ``tests/unit_test/test_stage_device_contract.py``
-so each model's CPU enablement lands on its own branch without colliding with the
-others in one shared file, and so CI can select CPU coverage by directory.
-
-The stage-level "config leaves device unset" half is asserted directly below,
-since these stages are not in that shared registry.
-"""
+"""Voxtral-TTS device and compile contracts on CPU."""
 
 from __future__ import annotations
 
@@ -15,19 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 
-import sglang_omni.platforms as platforms
-
-
-def test_the_voxtral_stages_leave_device_to_their_factories() -> None:
-    """A config-pinned device would be honored as-is and never retargeted, so it
-    has to stay unset for the factory resolution below to matter at all.
-    """
-    from sglang_omni.models.voxtral_tts.config import EntryClass
-
-    config = EntryClass(model_path="unused")
-
-    for stage_name in ("tts_generation", "vocoder"):
-        assert config.stage_named(stage_name).factory.device is None, stage_name
+from sglang_omni import platforms
 
 
 def test_voxtral_generation_stage_forwards_none_to_the_shared_builder(
@@ -64,31 +44,22 @@ def test_voxtral_generation_stage_forwards_none_to_the_shared_builder(
 @pytest.mark.parametrize(
     ("device", "gpu_id", "expected"),
     [
-        # Placement must not overwrite a device the caller named.
         ("cpu", 2, "cpu"),
-        ("cuda:3", None, "cuda:3"),
-        # Unset device: the platform names the type, placement the index.
-        (None, 0, None),
-        (None, None, None),
+        (None, 0, "cpu"),
+        (None, None, "cpu"),
     ],
 )
-def test_voxtral_vocoder_never_overwrites_an_explicit_device(
-    monkeypatch: pytest.MonkeyPatch, device, gpu_id, expected
+def test_voxtral_vocoder_resolves_to_cpu(
+    monkeypatch: pytest.MonkeyPatch,
+    device: str | None,
+    gpu_id: int | None,
+    expected: str,
 ) -> None:
-    """The worst shape of this bug: the vocoder did not merely default to CUDA,
-    it *replaced* whatever the caller passed whenever placement supplied a
-    gpu_id (``if gpu_id is not None: device = f"cuda:{gpu_id}"``). An explicit
-    cpu stage was therefore retargeted to CUDA and only failed later, inside
-    torch.cuda.set_device.
-
-    Drives the real factory with the codec load stubbed out, so a regression in
-    the resolution actually fails this test.
-    """
     from sglang_omni.models.voxtral_tts.pipeline import stages
-    from sglang_omni.utils.device import resolve_device_spec
 
     seen: dict[str, object] = {}
 
+    monkeypatch.setattr(platforms.current_platform, "device_type", "cpu", raising=False)
     monkeypatch.setattr(stages, "_resolve_checkpoint", lambda path: path)
     monkeypatch.setattr(
         stages,
@@ -105,12 +76,12 @@ def test_voxtral_vocoder_never_overwrites_an_explicit_device(
 
     stages.create_vocoder_executor("unused", device=device, gpu_id=gpu_id)
 
-    assert seen["device"] == (
-        expected if expected is not None else resolve_device_spec(None, gpu_id)
-    )
+    assert seen["device"] == expected
 
 
-def test_voxtral_leaves_torch_compile_to_the_platform() -> None:
+def test_voxtral_disables_torch_compile_on_cpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Inductor plans strides from the meta kernel of
     sgl_kernel.rotary_embedding_cpu, which disagrees with the real kernel
     (expected 4096, got 6144), so the compiled graph trips assert_size_stride
@@ -121,6 +92,7 @@ def test_voxtral_leaves_torch_compile_to_the_platform() -> None:
         VoxtralTtsEngineBuilder,
     )
 
+    monkeypatch.setattr(platforms.current_platform, "is_cpu", lambda: True)
     defaults = VoxtralTtsEngineBuilder().generation_defaults(dtype="bfloat16")
 
-    assert defaults["enable_torch_compile"] is not platforms.current_platform.is_cpu()
+    assert defaults["enable_torch_compile"] is False

--- a/tests/unit_test/voxtral_tts/test_pipeline.py
+++ b/tests/unit_test/voxtral_tts/test_pipeline.py
@@ -455,6 +455,7 @@ def test_voxtral_forward_returns_graph_compatible_logits() -> None:
 def test_voxtral_generation_reenables_cuda_graph_after_bootstrap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from sglang_omni import platforms
     from sglang_omni.models.voxtral_tts import model_runner as model_runner_mod
     from sglang_omni.models.voxtral_tts import request_builders
     from sglang_omni.models.voxtral_tts.pipeline import stages
@@ -466,6 +467,8 @@ def test_voxtral_generation_reenables_cuda_graph_after_bootstrap(
     build_kwargs: dict = {}
     infrastructure_saw_deferred_capture: list[bool] = []
     init_graph_calls: list[bool] = []
+
+    monkeypatch.setattr(platforms.current_platform, "is_cpu", lambda: False)
 
     class FakeModel:
         pass


### PR DESCRIPTION
WIP.
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
 Enable Voxtral TTS inference on CPU
Depends on https://github.com/sgl-project/sglang-omni/pull/1813 first.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
  - Let the generation stage defer device selection to the shared platform-aware builder.
  - Resolve the vocoder device from the current platform while preserving explicitly selected device types.
  - Disable Torch compile for Voxtral on CPU through current_platform.is_cpu().
  - Use the standard platform pinned-memory capability for host staging buffers.

<!-- Describe the changes made in this PR. -->

## Related Issues
https://github.com/sgl-project/sglang-omni/issues/1777
<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test
WIP
<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## CI / Tests

  - Added coverage for:
      - Generation-stage device delegation.
      - Vocoder placement on CPU.
      - CPU Torch compile policy.
      - CPU host-buffer allocation without pinned memory.



cookbook example test WIP.