### PR TITLE
[XPU] Enable Voxtral TTS model on XPU platform

### DIFF
--- a/sglang_omni/models/voxtral_tts/audio_tokenizer.py
+++ b/sglang_omni/models/voxtral_tts/audio_tokenizer.py
@@ -393,7 +393,9 @@ class Attention(nn.Module):
         else:
             output = self._native_attention(xq, xk, xv)
 
-        output = output.view(bsz, seqlen, self.n_local_heads * self.args.head_dim)
+        # reshape (not view): the native-attention output is non-contiguous on
+        # non-CUDA backends where flash-attn is unavailable.
+        output = output.reshape(bsz, seqlen, self.n_local_heads * self.args.head_dim)
         return self.wo(output).squeeze(0)
 
 

--- a/sglang_omni/models/voxtral_tts/audio_tokenizer.py
+++ b/sglang_omni/models/voxtral_tts/audio_tokenizer.py
@@ -393,8 +393,7 @@ class Attention(nn.Module):
         else:
             output = self._native_attention(xq, xk, xv)
 
-        # reshape (not view): the native-attention output is non-contiguous on
-        # non-CUDA backends where flash-attn is unavailable.
+        # Native attention output can be non-contiguous.
         output = output.reshape(bsz, seqlen, self.n_local_heads * self.args.head_dim)
         return self.wo(output).squeeze(0)
 

--- a/sglang_omni/models/voxtral_tts/pipeline/engine_builder.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/engine_builder.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from sglang_omni.models.voxtral_tts import request_builders
 from sglang_omni.models.voxtral_tts.pipeline import stages as voxtral_stages
+from sglang_omni.platforms import current_platform
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
 
 
@@ -33,10 +34,10 @@ class VoxtralTtsEngineBuilder(TtsEngineBuilder):
         return {
             "max_running_requests": 16,
             "dtype": "bfloat16",
-            "disable_cuda_graph": False,
+            "disable_cuda_graph": current_platform.is_xpu(),
             "disable_overlap_schedule": True,
             "decrypted_config_file": self.decrypted_config_file,
-            "enable_torch_compile": True,
+            "enable_torch_compile": not current_platform.is_xpu(),
             "mem_fraction_static": 0.85,
             "max_prefill_tokens": 8192,
             "sampling_backend": "pytorch",

--- a/sglang_omni/models/voxtral_tts/pipeline/stages.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/stages.py
@@ -21,6 +21,7 @@ from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from sglang_omni.scheduling.vocoder_base import BatchVocoderBase
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoint
+from sglang_omni.utils.device import resolve_device_spec
 
 logger = logging.getLogger(__name__)
 
@@ -169,7 +170,7 @@ def _enable_inductor_gemm_autotune() -> None:
 def create_generation_executor(
     model_path: str,
     *,
-    device: str = "cuda:0",
+    device: str | None = None,
     gpu_id: int | None = None,
     max_new_tokens: int = 4096,
     server_args_overrides: dict[str, Any] | None = None,
@@ -396,12 +397,11 @@ class _VoxtralTTSVocoder(BatchVocoderBase):
 def create_vocoder_executor(
     model_path: str,
     *,
-    device: str = "cuda:0",
+    device: str | None = None,
     gpu_id: int | None = None,
 ) -> SimpleScheduler:
     checkpoint_dir = _resolve_checkpoint(model_path)
-    if gpu_id is not None:
-        device = f"cuda:{gpu_id}"
+    device = resolve_device_spec(device, gpu_id)
 
     logger.info("Loading Voxtral audio tokenizer for vocoding...")
     audio_tokenizer = _load_audio_tokenizer(checkpoint_dir, {}, device)

--- a/sglang_omni/models/voxtral_tts/pipeline/stages.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/stages.py
@@ -21,7 +21,7 @@ from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from sglang_omni.scheduling.vocoder_base import BatchVocoderBase
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoint
-from sglang_omni.utils.device import resolve_device_spec
+from sglang_omni.utils.device import place_device_spec, resolve_device_spec
 
 logger = logging.getLogger(__name__)
 
@@ -401,7 +401,11 @@ def create_vocoder_executor(
     gpu_id: int | None = None,
 ) -> SimpleScheduler:
     checkpoint_dir = _resolve_checkpoint(model_path)
-    device = resolve_device_spec(device, gpu_id)
+    device = (
+        resolve_device_spec(None, gpu_id)
+        if device is None
+        else place_device_spec(device, gpu_id)
+    )
 
     logger.info("Loading Voxtral audio tokenizer for vocoding...")
     audio_tokenizer = _load_audio_tokenizer(checkpoint_dir, {}, device)

--- a/tests/unit_test/xpu/test_voxtral_tts.py
+++ b/tests/unit_test/xpu/test_voxtral_tts.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Intel XPU policy tests for Voxtral TTS."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sglang_omni import platforms
+from sglang_omni.models.voxtral_tts import audio_tokenizer
+from sglang_omni.models.voxtral_tts.pipeline import engine_builder, stages
+
+
+def _mock_xpu_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(platforms.current_platform, "is_xpu", lambda: True)
+    monkeypatch.setattr(platforms.current_platform, "device_type", "xpu", raising=False)
+
+
+def test_voxtral_tts_xpu_defaults_to_eager_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_xpu_platform(monkeypatch)
+
+    defaults = engine_builder.VoxtralTtsEngineBuilder().generation_defaults(
+        dtype="bfloat16"
+    )
+
+    assert defaults["disable_cuda_graph"] is True
+    assert defaults["enable_torch_compile"] is False
+
+
+def test_voxtral_tts_non_xpu_generation_defaults_are_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platforms.current_platform, "is_xpu", lambda: False)
+
+    defaults = engine_builder.VoxtralTtsEngineBuilder().generation_defaults(
+        dtype="bfloat16"
+    )
+
+    assert defaults["disable_cuda_graph"] is False
+    assert defaults["enable_torch_compile"] is True
+
+
+def test_voxtral_tts_vocoder_follows_xpu_placement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_xpu_platform(monkeypatch)
+    seen_devices: list[str] = []
+
+    monkeypatch.setattr(stages, "_resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(
+        stages,
+        "_load_audio_tokenizer",
+        lambda checkpoint_dir, state_dict, device: (
+            seen_devices.append(device) or object()
+        ),
+    )
+
+    stages.create_vocoder_executor("model", gpu_id=2)
+    stages.create_vocoder_executor("model", device="cpu", gpu_id=2)
+    stages.create_vocoder_executor("model", device="cuda:0", gpu_id=2)
+
+    assert seen_devices == ["xpu:2", "cpu", "cuda:2"]
+
+
+def test_voxtral_native_attention_accepts_noncontiguous_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = audio_tokenizer.AudioTokenizerArgs(
+        dim=8,
+        hidden_dim=16,
+        head_dim=4,
+        n_heads=2,
+        n_kv_heads=2,
+        qk_norm=False,
+        layer_scale=False,
+    )
+    attention = audio_tokenizer.Attention(args, layer_id=0)
+
+    def fake_native_attention(xq, xk, xv):
+        del xk, xv
+        output = torch.zeros(
+            xq.shape[0], xq.shape[1], xq.shape[3], xq.shape[2]
+        ).transpose(-1, -2)
+        assert not output.is_contiguous()
+        return output
+
+    monkeypatch.setattr(audio_tokenizer, "HAS_FLASH_ATTN", False)
+    monkeypatch.setattr(attention, "_native_attention", fake_native_attention)
+
+    output = attention(torch.zeros(3, args.dim))
+
+    assert output.shape == (3, args.dim)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->
WIP.

## Motivation
Enable Voxtral TTS inference on Intel XPU
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

  - Resolve generation and vocoder devices from the current platform instead of defaulting to CUDA.
  - Replace view with reshape for potentially non-contiguous native attention output.
  - Preserve explicitly configured device types when applying gpu_id.

<!-- Describe the changes made in this PR. -->

## Related Issues
https://github.com/sgl-project/sglang-omni/issues/1588
<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test
WIP
<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

 ## CI / Tests
  Coverage includes:
  - XPU eager generation defaults
  - XPU and explicit device placement
  - Non-contiguous native attention output

cookbook example test WIP.