### PR TITLE
[CI] Nightly CI

### DIFF
--- a/.github/workflows/nightly-ci.yaml
+++ b/.github/workflows/nightly-ci.yaml
@@ -1,0 +1,176 @@
+name: Nightly CI
+
+on:
+  schedule:
+    - cron: "30 18 * * *"  # daily, off-peak for the CI host
+  workflow_dispatch:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.event_name == 'issue_comment' && !contains(github.event.comment.body, '/rerun-nightly') && format('omni-ci-nightly-noop-{0}', github.run_id) || 'omni-ci-nightly' }}
+  cancel-in-progress: false
+
+env:
+  OMNI_CI_HOME: /data/omni-ci/run-${{ github.run_id }}
+
+jobs:
+  # Comment commands require effective write/maintain/admin permission and a
+  # Nightly CI tracking issue.
+  authorize-comment:
+    if: >
+      github.event_name == 'issue_comment' &&
+      !github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/rerun-nightly')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      command: ${{ steps.parse.outputs.command }}
+    steps:
+      - name: Parse command (first token of first non-empty line)
+        id: parse
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          first_token=$(printf "%s" "$COMMENT_BODY" | awk 'NF {print $1; exit}')
+          case "$first_token" in
+            /rerun-nightly) echo "command=rerun" >> "$GITHUB_OUTPUT";;
+            /rerun-nightly-failed) echo "command=rerun-failed" >> "$GITHUB_OUTPUT";;
+            *) echo "::error::comment does not start with a nightly command"; exit 1;;
+          esac
+      - name: Check commenter permission and issue identity
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          perm=$(gh api "repos/${{ github.repository }}/collaborators/$COMMENTER/permission" --jq .permission)
+          case "$perm" in
+            write|maintain|admin) ;;
+            *) echo "::error::$COMMENTER has '$perm' permission; write/maintain/admin required"; exit 1;;
+          esac
+          case "$ISSUE_TITLE" in
+            "[Nightly CI] stage"*) ;;
+            *) echo "::error::commands only work on a Nightly CI tracking issue"; exit 1;;
+          esac
+
+  # `/rerun-nightly-failed` reruns the last failed nightly run's failed jobs
+  # on its original commit.
+  rerun-failed:
+    needs: authorize-comment
+    if: >
+      github.event_name == 'issue_comment' &&
+      needs.authorize-comment.result == 'success' &&
+      needs.authorize-comment.outputs.command == 'rerun-failed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: write
+    steps:
+      - name: Rerun failed jobs of the last failed nightly run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          run_id=$(gh api "repos/${{ github.repository }}/actions/workflows/nightly-ci.yaml/runs?status=failure&per_page=20" --jq 'first(.workflow_runs[] | select(.event == "schedule" or .event == "workflow_dispatch")) | .id')
+          if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+            echo "no failed nightly run found"; exit 0
+          fi
+          gh api -X POST "repos/${{ github.repository }}/actions/runs/$run_id/rerun-failed-jobs"
+          echo "reran failed jobs of run $run_id"
+
+  radix-evict-soak:
+    name: stage 1 - Qwen3-ASR-1.7B radix evict soak
+    needs: authorize-comment
+    # cron/dispatch pass with authorize-comment skipped; comments need it green.
+    if: >
+      always() &&
+      ((github.event_name == 'schedule' && needs.authorize-comment.result == 'skipped') ||
+       (github.event_name == 'workflow_dispatch' && needs.authorize-comment.result == 'skipped' &&
+        github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) ||
+       (github.event_name == 'issue_comment' &&
+        needs.authorize-comment.result == 'success' &&
+        needs.authorize-comment.outputs.command == 'rerun'))
+    runs-on: [self-hosted, h100]
+    timeout-minutes: 60
+    container:
+      image: hongccc/sglang-omni@sha256:02a85f00438c901c72a2eb2ef738974a807f63af3d13084445604f3344067b19
+      options: >-
+        --rm
+        -e NVIDIA_VISIBLE_DEVICES
+        -e OMNI_CI_CPUSET
+        -v /dev/shm:/dev/shm
+        -v /data/omni-ci:/data/omni-ci
+        -v /data/cache/huggingface:/github/home/.cache/huggingface
+        -v /data/cache/huggingface:/root/.cache/huggingface
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/omni-setup
+        with:
+          venv-name: omni
+
+      - name: Run radix evict soak
+        shell: bash
+        run: |
+          source omni/bin/activate
+          export PYTHONPATH=$PWD
+          bash .github/scripts/run_flaky_pytest.sh \
+            pytest tests/test_model/test_radix_evict_soak_ci.py -v -s -x
+        env:
+          HF_ENDPOINT: https://huggingface.co
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          TORCHINDUCTOR_CACHE_DIR: ${{ env.OMNI_CI_HOME }}/.torchinductor
+
+      - name: Close alert on green
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          title="[Nightly CI] stage 1 - Qwen3-ASR-1.7B radix evict soak failed"
+          existing=$(gh issue list --repo "${{ github.repository }}" --state open --limit 100 --json number,title --jq "[.[] | select(.title == \"$title\")][0].number")
+          if [ -n "$existing" ]; then
+            run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            gh issue close "$existing" --repo "${{ github.repository }}" --comment "Green again **$(date -u '+%Y-%m-%d %H:%M UTC')** | \`$GITHUB_REF_NAME\` @ ${GITHUB_SHA:0:9} | $run_url"
+          fi
+
+      - name: Alert on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          header="**$(date -u '+%Y-%m-%d %H:%M UTC')** | \`$GITHUB_REF_NAME\` @ ${GITHUB_SHA:0:9} | [run]($run_url)"
+          table=/tmp/radix_evict_soak/results.md
+          [ -f "$table" ] || table=""
+          if [ -n "$table" ]; then
+            body="$header
+
+          $(cat "$table")"
+          else
+            body="$header
+
+          No metrics were written -- the run died before the post window (server startup, dataset, or salting failure), not a gate failure."
+          fi
+          title="[Nightly CI] stage 1 - Qwen3-ASR-1.7B radix evict soak failed"
+          existing=$(gh issue list --repo "${{ github.repository }}" --state open --limit 100 --json number,title --jq "[.[] | select(.title == \"$title\")][0].number")
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "${{ github.repository }}" --body "$body"
+          else
+            gh issue create --repo "${{ github.repository }}" --title "$title" --body "$body"
+          fi
+
+      - name: Post-stage cleanup
+        if: always()
+        uses: ./.github/actions/omni-post-stage
+        with:
+          stage-label: Qwen3-ASR-1.7B radix evict soak
+          artifact-path-globs: |
+            */radix_evict_soak/results.json
+            */radix_evict_soak/results.md

--- a/tests/README.md
+++ b/tests/README.md
@@ -327,6 +327,14 @@ Relevant model CI ownership:
   threshold calibration (`asr` in `tune-ci-thresholds`). Its stdout uses the
   same boxed summary style as the other benchmark stages:
   `ASR WER Benchmark Result` followed by `ASR Speed Benchmark Result`.
+- `test_radix_evict_soak_ci.py`: nightly radix evict soak (Nightly CI stage 1,
+  not part of per-PR CI). Runs Qwen3-ASR-1.7B with radix forced on against a
+  capped pool, drives salted zero-hit traffic past saturation, and gates
+  post-saturation throughput/p99/decay ratio against the pre-saturation window
+  of the same run. Writes `/tmp/radix_evict_soak/results.json` (machine-readable) and
+  `/tmp/radix_evict_soak/results.md` (gate table, embedded in the alert issue).
+  Run locally with a single GPU:
+  `CUDA_VISIBLE_DEVICES=0 python3 -m pytest tests/test_model/test_radix_evict_soak_ci.py -v -s`.
 - `utils.py`: shared fixture/helpers for talker/TTS WER CI —
   stops the upstream model server, runs `delete_gpu_process.sh --kill-orphans`, then launches
   a Qwen3-ASR router. It also owns the WER ASR concurrency constant

--- a/tests/test_model/test_radix_evict_soak_ci.py
+++ b/tests/test_model/test_radix_evict_soak_ci.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Nightly radix evict soak: Qwen3-ASR-1.7B under zero-hit saturation.
+
+Salted zero-hit traffic (a seeded noise tail per request gives every clip a
+unique fingerprint `extra_key`) fills a capped radix pool past saturation
+(fill volume > 1.4x pool), then gates the post-saturation window against the
+pre-saturation window of the same run:
+
+- post/pre qps ratio: eviction-path slowdown (#1723) or upstream
+  allocator/evict API drift.
+- post/pre p99 ratio: eviction stalls surfacing as tail latency first.
+- post decay ratio (last/first post loop): slow-leak degradation that
+  worsens per loop.
+- pre qps sanity floor: the run itself is broken; prevents vacuous passes.
+
+Radix is force-enabled here (the pipeline default is off); the guard covers
+deployments that keep it on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from benchmarks.dataset.prepare import DATASETS
+from benchmarks.dataset.seedtts import SampleInput, load_seedtts_samples
+from benchmarks.eval.benchmark_asr_seedtts import (
+    QWEN3_ASR_MODEL_PATH,
+    run_asr_seedtts_once,
+)
+from tests.test_model.omni_router_utils import (
+    ManagedRouterHandle,
+    launch_managed_router,
+)
+from tests.utils import MetricCheckCollector
+
+RADIX_POOL_TOKENS = 131072
+RADIX_CI_CONCURRENCY = 32
+BASE_SAMPLES = 1088
+FILL_UNIQUE_REQUESTS = 24000  # >= 1.4x pool at 8 unique tokens/request
+POST_LOOPS = 3
+STARTUP_TIMEOUT = 600
+NOISE_TAIL_SECONDS = 0.02
+NOISE_AMPLITUDE = 1e-3
+
+MIN_POST_PRE_QPS_RATIO = 0.90
+MAX_POST_PRE_P99_RATIO = 1.5
+MIN_POST_DECAY_RATIO = 0.90  # last post loop vs first: catches slow decay
+MIN_SANE_PRE_QPS = 100.0
+
+WORKER_EXTRA_ARGS = (
+    "--asr.engine.disable_radix_cache false "
+    f"--asr.engine.max_total_tokens {RADIX_POOL_TOKENS}"
+)
+
+
+def _require_cuda() -> None:
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the radix evict soak CI")
+
+
+@pytest.fixture(scope="module")
+def base_samples() -> list[SampleInput]:
+    return load_seedtts_samples(
+        DATASETS["seedtts"],
+        max_samples=BASE_SAMPLES,
+        split="en",
+    )
+
+
+@pytest.fixture(scope="module")
+def asr_router_server(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> ManagedRouterHandle:
+    with launch_managed_router(
+        tmp_path_factory=tmp_path_factory,
+        model_path=QWEN3_ASR_MODEL_PATH,
+        model_name=QWEN3_ASR_MODEL_PATH,
+        worker_extra_args=WORKER_EXTRA_ARGS,
+        num_workers=1,
+        wait_timeout=STARTUP_TIMEOUT,
+        log_prefix="radix_evict_soak_router_logs",
+    ) as router:
+        yield router
+
+
+def _salted_loop(
+    base: list[SampleInput], out_dir: Path, loop_index: int
+) -> list[SampleInput]:
+    """Append a seeded noise tail to every clip: new fingerprint per request."""
+    import soundfile as sf
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    salted = []
+    for idx, sample in enumerate(base):
+        audio, sr = sf.read(sample.ref_audio, dtype="float32")
+        rng = np.random.default_rng(loop_index * 1_000_003 + idx)
+        tail = (rng.standard_normal(int(sr * NOISE_TAIL_SECONDS)) * NOISE_AMPLITUDE)
+        out_path = out_dir / f"loop{loop_index}_{idx}.wav"
+        sf.write(out_path, np.concatenate([audio, tail.astype(np.float32)]), sr)
+        salted.append(
+            SampleInput(
+                sample_id=f"{sample.sample_id}-l{loop_index}",
+                ref_text=sample.ref_text,
+                ref_audio=str(out_path),
+                target_text=sample.target_text,
+            )
+        )
+    return salted
+
+
+def _run_loop(
+    router: ManagedRouterHandle,
+    samples: list[SampleInput],
+    incomplete: list,
+    label: str,
+) -> dict:
+    results = asyncio.run(
+        run_asr_seedtts_once(
+            samples,
+            host="127.0.0.1",
+            port=router.port,
+            model_path=QWEN3_ASR_MODEL_PATH,
+            lang="en",
+            concurrency=RADIX_CI_CONCURRENCY,
+        )
+    )
+    summary = results["summary"]
+    if summary["evaluated"] != len(samples) or summary["skipped"] != 0:
+        incomplete.append((label, summary["evaluated"], summary["skipped"]))
+    return results["speed"]
+
+
+def test_radix_evict_soak_throughput_holds(
+    base_samples: list[SampleInput],
+    asr_router_server: ManagedRouterHandle,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    _require_cuda()
+    checks = MetricCheckCollector(label="Radix evict soak")
+    audio_root = tmp_path_factory.mktemp("salted_audio")
+
+    import shutil
+
+    shutil.rmtree("/tmp/radix_evict_soak", ignore_errors=True)
+    incomplete: list = []
+    # Loop 0 absorbs warmup effects; loop 1 is the pre-saturation window.
+    _run_loop(asr_router_server, _salted_loop(base_samples, audio_root / "l0", 0), incomplete, "warmup")
+    pre = _run_loop(asr_router_server, _salted_loop(base_samples, audio_root / "l1", 1), incomplete, "pre")
+
+    sent = 2 * len(base_samples)
+    loop_index = 2
+    while sent < FILL_UNIQUE_REQUESTS:
+        _run_loop(
+            asr_router_server,
+            _salted_loop(base_samples, audio_root / f"l{loop_index}", loop_index),
+            incomplete,
+            f"fill{loop_index}",
+        )
+        sent += len(base_samples)
+        loop_index += 1
+
+    post_qps, post_p99 = [], []
+    for _ in range(POST_LOOPS):
+        speed = _run_loop(
+            asr_router_server,
+            _salted_loop(base_samples, audio_root / f"l{loop_index}", loop_index),
+            incomplete,
+            f"post{loop_index}",
+        )
+        post_qps.append(speed["throughput_samples_per_s"])
+        post_p99.append(speed["latency_p99_s"])
+        loop_index += 1
+
+    pre_qps = pre["throughput_samples_per_s"]
+    pre_p99 = pre["latency_p99_s"]
+    avg_post_qps = sum(post_qps) / len(post_qps)
+    max_post_p99 = max(post_p99)
+
+    gate_rows = [
+        ("pre qps sanity", pre_qps, f">= {MIN_SANE_PRE_QPS}"),
+        ("post/pre qps", avg_post_qps / pre_qps, f">= {MIN_POST_PRE_QPS_RATIO}"),
+        ("post/pre p99", max_post_p99 / pre_p99, f"<= {MAX_POST_PRE_P99_RATIO}"),
+        ("post decay ratio (last/first post loop)", post_qps[-1] / post_qps[0], f">= {MIN_POST_DECAY_RATIO}"),
+    ]
+    print(
+        f"radix evict soak: pre qps {pre_qps:.1f} p99 {pre_p99:.3f}s | "
+        f"post qps {avg_post_qps:.1f} p99 {max_post_p99:.3f}s | "
+        f"{sent + POST_LOOPS * len(base_samples)} unique requests, "
+        f"pool {RADIX_POOL_TOKENS} tokens"
+    )
+    for name, value, bound in gate_rows:
+        print(f"  gate {name}: {value:.3f} ({bound})")
+    # metrics artifacts at a fixed path (latest attempt wins across retries)
+    import json
+    from pathlib import Path
+
+    base = Path("/tmp/radix_evict_soak")
+    base.mkdir(parents=True, exist_ok=True)
+    md = ["| gate | value | bound | verdict |", "|---|---|---|---|"]
+    for name, value, bound in gate_rows:
+        op, thr = bound.split()
+        ok = value >= float(thr) if op == ">=" else value <= float(thr)
+        md.append(f"| {name} | {value:.3f} | {bound} | {'pass' if ok else '**FAIL**'} |")
+    md.append("")
+    md.append(
+        f"pre {pre_qps:.1f} qps / p99 {pre_p99:.3f}s; post qps "
+        + ", ".join(f"{q:.1f}" for q in post_qps)
+        + f"; {sent + POST_LOOPS * len(base_samples)} unique requests, pool {RADIX_POOL_TOKENS} tokens"
+    )
+    (base / "results.md").write_text("\n".join(md))
+    (base / "results.json").write_text(
+        json.dumps(
+            {
+                "pool_tokens": RADIX_POOL_TOKENS,
+                "unique_requests": sent + POST_LOOPS * len(base_samples),
+                "pre": {"qps": pre_qps, "p99_s": pre_p99},
+                "post_qps": post_qps,
+                "post_p99": post_p99,
+                "gates": {n: v for n, v, _ in gate_rows},
+            }
+        )
+    )
+
+    checks.check(
+        len(post_qps) == POST_LOOPS and all(q > 0 for q in post_qps),
+        f"post window incomplete: {post_qps} (refusing an empty comparison)",
+    )
+    checks.check(
+        not incomplete,
+        f"loops with failed requests: {incomplete}",
+    )
+    checks.check(
+        pre_qps >= MIN_SANE_PRE_QPS,
+        f"pre-saturation qps {pre_qps:.1f} below sanity floor {MIN_SANE_PRE_QPS}",
+    )
+    checks.check(
+        avg_post_qps >= MIN_POST_PRE_QPS_RATIO * pre_qps,
+        f"post-saturation qps {avg_post_qps:.1f} < "
+        f"{MIN_POST_PRE_QPS_RATIO} x pre {pre_qps:.1f}",
+    )
+    checks.check(
+        max_post_p99 <= MAX_POST_PRE_P99_RATIO * pre_p99,
+        f"post-saturation p99 {max_post_p99:.3f}s > "
+        f"{MAX_POST_PRE_P99_RATIO} x pre {pre_p99:.3f}s",
+    )
+    checks.check(
+        post_qps[-1] >= MIN_POST_DECAY_RATIO * post_qps[0],
+        f"post-saturation decay: last loop {post_qps[-1]:.1f} < "
+        f"{MIN_POST_DECAY_RATIO} x first loop {post_qps[0]:.1f}",
+    )
+    checks.assert_all()


### PR DESCRIPTION
## Motivation

Add a cron-driven Nightly CI for tests unsuitable for per-PR runs (soak, saturation, trend-style checks), and register the Qwen3-ASR-1.7B radix evict soak as its stage 1.

## Modifications

### Nightly CI infrastructure

`.github/workflows/nightly-ci.yaml`:

- **Trigger**: `schedule` (daily 18:30 UTC) + `workflow_dispatch`.
- **Alert and rerun**: a red run opens (or comments on) a tracking issue titled `[Nightly CI] <stage check name> failed` (one issue per stage) with the run URL and gate readings, and the next green run closes it; commenting `/rerun-nightly` (fresh run on current `main`) or `/rerun-nightly-failed` (failed jobs of the last failed run) on a tracking issue triggers a rerun; commenters are authorized by effective repository permission (write/maintain/admin).
- **Concurrency**: one nightly run at a time; an extra trigger queues instead of overlapping, and never cancels the in-flight run.
- **Scope**: stages structurally unsuitable for per-PR runs (saturation/soak and etc.).
- tests/README.md: register the soak test (local run command, artifacts).

### Stage 1: Qwen3-ASR-1.7B radix evict soak

- **Metrics**:
  - post/pre qps ratio
  - post/pre p99 ratio
  - post decay ratio (last/first post loop)
  - pre-qps sanity floor
- **Workload**:
  - salted zero-hit traffic: 20ms seeded noise tail per request
  - capped pool: `--asr.engine.max_total_tokens 131072`, radix forced on
  - 24k unique fill requests > 1.4x pool, sized above the pool so the post window runs under sustained eviction
- **Model**: Qwen3-ASR-1.7B, where the eviction pathology measured largest (#1723).

## Related Issues

#1723 / #1724.

## Accuracy Test

Not applicable.

## Benchmark & Profiling

5 rounds on the CI host (calibration lane 0,1, pinned cpuset; ~3m50s per round):

| Round | pre qps | pre p99 (s) | post qps | post p99 (s) | post/pre qps | post/pre p99 | post decay ratio |
|---|---:|---:|---:|---:|---:|---:|---:|
| 1 | 202.9 | 0.251 | 203.3 | 0.229 | 1.002 | 0.911 | 1.011 |
| 2 | 202.0 | 0.246 | 201.8 | 0.233 | 0.999 | 0.946 | 0.997 |
| 3 | 204.5 | 0.269 | 204.6 | 0.252 | 1.000 | 0.936 | 1.015 |
| 4 | 204.3 | 0.232 | 202.5 | 0.248 | 0.991 | 1.071 | 0.991 |
| 5 | 205.3 | 0.227 | 201.6 | 0.233 | 0.982 | 1.024 | 1.001 |

### Gate calibration

| Gate | Worst | Median | Min | Max | Range | Std | Bound |
|---|---:|---:|---:|---:|---:|---:|---|
| pre qps sanity | 202.0 | 204.3 | 202.0 | 205.3 | 3.3 | 1.2 | >= 100 |
| post/pre qps | 0.982 | 0.999 | 0.982 | 1.002 | 0.021 | 0.008 | >= 0.90 |
| post/pre p99 | 1.071 | 0.946 | 0.911 | 1.071 | 0.160 | 0.060 | <= 1.5 |
| post decay ratio | 0.991 | 1.001 | 0.991 | 1.015 | 0.024 | 0.009 | >= 0.90 |

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests. Not applicable.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

Nightly CI runs on the self-hosted GPU runners from the default branch only (cron 18:30 UTC daily); it never gates PRs. `workflow_dispatch` or commenting `/rerun-nightly` / `/rerun-nightly-failed` on the tracking issue (maintainers only) triggers manual runs.
