### PR TITLE
[CI] Run stage 5 MPS on the moss pool when the rotation picks qwen3-tts

### DIFF
--- a/.github/workflows/omni-ci.yaml
+++ b/.github/workflows/omni-ci.yaml
@@ -70,6 +70,7 @@ jobs:
       selected_model: ${{ steps.tts.outputs.selected_model }}
       selection_digest: ${{ steps.tts.outputs.selection_digest }}
       resolved_mps_config: ${{ steps.tts.outputs.resolved_mps_config }}
+      resolved_mps_model: ${{ steps.tts.outputs.resolved_mps_model }}
       exact_sha: ${{ steps.tts.outputs.exact_sha }}
     steps:
       - name: Fetch latest PR gate state
@@ -167,33 +168,31 @@ jobs:
             selection_reason="stable_github_run_id_digest"
           fi
 
-          # Note: (Jiaxin Deng) Qwen3-TTS is gated as a single instance, so
-          # it resolves no MPS config and the MPS stage is skipped for it.
+          # Note (Jiaxin Deng): Qwen3-TTS is gated as a single instance and
+          # has no pool of its own, so stage 5 borrows moss there. Skipping it
+          # instead left the MPS path unexercised on a third of the runs.
           if [[ "${selected_model}" == "higgs" ]]; then
+            mps_model="higgs"
             resolved_config="examples/mps_dp/configs/higgs_h100_dp3.yaml"
             expected_config_cls="HiggsTtsPipelineConfig"
-          elif [[ "${selected_model}" == "moss" ]]; then
+          else
+            mps_model="moss"
             resolved_config="examples/mps_dp/configs/moss_local_h100_dp2.yaml"
             expected_config_cls="MossTTSLocalPipelineConfig"
-          else
-            resolved_config=""
-            expected_config_cls=""
           fi
-          if [[ -n "${resolved_config}" && ! -f "${resolved_config}" ]]; then
-            echo "::error::MPS config is missing for ${selected_model}: ${resolved_config}"
+          if [[ ! -f "${resolved_config}" ]]; then
+            echo "::error::MPS config is missing for ${mps_model}: ${resolved_config}"
             exit 1
           fi
-          if [[ -n "${resolved_config}" ]]; then
-            actual_config_cls="$(sed -n 's/^config_cls:[[:space:]]*//p' "${resolved_config}")"
-            if [[ "${actual_config_cls}" != "${expected_config_cls}" ]]; then
-              echo "::error::resolved config mismatch for ${selected_model}: ${actual_config_cls}; expected ${expected_config_cls}"
-              exit 1
-            fi
+          actual_config_cls="$(sed -n 's/^config_cls:[[:space:]]*//p' "${resolved_config}")"
+          if [[ "${actual_config_cls}" != "${expected_config_cls}" ]]; then
+            echo "::error::resolved config mismatch for ${mps_model}: ${actual_config_cls}; expected ${expected_config_cls}"
+            exit 1
           fi
 
           output_dir="${RUNNER_TEMP}/tts-preflight"
           mkdir -p "${output_dir}"
-          export selected_model selection_digest selection_reason resolved_config
+          export selected_model selection_digest selection_reason resolved_config mps_model
           python - <<'PY' > "${output_dir}/preflight.json.tmp"
           import json
           import os
@@ -214,6 +213,7 @@ jobs:
                       "selection_digest": os.environ["selection_digest"],
                       "selection_reason": os.environ["selection_reason"],
                       "resolved_mps_config": os.environ["resolved_config"],
+                      "resolved_mps_model": os.environ["mps_model"],
                   },
                   indent=2,
                   sort_keys=True,
@@ -224,6 +224,7 @@ jobs:
           echo "selected_model=${selected_model}" >> "${GITHUB_OUTPUT}"
           echo "selection_digest=${selection_digest}" >> "${GITHUB_OUTPUT}"
           echo "resolved_mps_config=${resolved_config}" >> "${GITHUB_OUTPUT}"
+          echo "resolved_mps_model=${mps_model}" >> "${GITHUB_OUTPUT}"
           echo "exact_sha=${EXACT_SHA}" >> "${GITHUB_OUTPUT}"
 
       - name: Upload TTS preflight
@@ -395,6 +396,7 @@ jobs:
     with:
       tts_ci_model: ${{ needs.preflight.outputs.selected_model }}
       tts_mps_config: ${{ needs.preflight.outputs.resolved_mps_config }}
+      tts_mps_model: ${{ needs.preflight.outputs.resolved_mps_model }}
       exact_sha: ${{ needs.preflight.outputs.exact_sha }}
       omni_ci_home: >-
         ${{ github.event_name == 'pull_request'

--- a/.github/workflows/test-tts-ci.yaml
+++ b/.github/workflows/test-tts-ci.yaml
@@ -8,8 +8,14 @@ on:
         default: higgs
       tts_mps_config:
         description: >-
-          MPS-DP config for stage 5. Empty for models gated as a single
-          instance, which skips that stage.
+          MPS-DP config for stage 5. Empty skips that stage.
+        type: string
+        required: false
+        default: ""
+      tts_mps_model:
+        description: >-
+          Model the stage 5 pool runs. Differs from tts_ci_model when the
+          selected model is gated as a single instance and borrows a pool.
         type: string
         required: false
         default: ""
@@ -276,9 +282,9 @@ jobs:
   stage-5-mps:
     name: stage 5 - MPS
     needs: stage-4-serving
-    # Note: (Jiaxin Deng) Qwen3-TTS is gated as a single instance: the tuned
-    # single instance beats the same-card pool there, so colocation is not the
-    # recommended topology and there is no MPS config to run.
+    # Note (Jiaxin Deng): the pool model is resolved in preflight and can
+    # differ from the rotation model, so every stage 5 reference below reads
+    # tts_mps_model rather than tts_ci_model.
     if: always() && !cancelled() && inputs.tts_mps_config != ''
     runs-on: [self-hosted, h100]
     timeout-minutes: 25
@@ -331,7 +337,7 @@ jobs:
             --exact-sha "${{ inputs.exact_sha }}" \
             --run-id "${TTS_MPS_RUN_ID}" \
             --run-attempt "${GITHUB_RUN_ATTEMPT}" \
-            --selected-model "${{ inputs.tts_ci_model }}"
+            --selected-model "${{ inputs.tts_mps_model }}"
 
       - name: Run TTS MPS non-streaming validation
         shell: bash
@@ -343,7 +349,7 @@ jobs:
           HF_ENDPOINT: https://huggingface.co
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           SEEDTTS_SIM_CACHE_DIR: /github/home/seedtts-wavlm-sim
-          TTS_CI_MODEL: ${{ inputs.tts_ci_model }}
+          TTS_CI_MODEL: ${{ inputs.tts_mps_model }}
           TTS_MPS_CONFIG: ${{ inputs.tts_mps_config }}
           TTS_MPS_EXACT_SHA: ${{ inputs.exact_sha }}
           TORCHINDUCTOR_CACHE_DIR: ${{ env.OMNI_CI_HOME }}/.torchinductor

--- a/tests/unit_test/ci/test_tts_model_rotation_contract.py
+++ b/tests/unit_test/ci/test_tts_model_rotation_contract.py
@@ -49,10 +49,14 @@ def test_rotation_offers_every_registered_preset() -> None:
         ), f"dispatch override does not accept {model}"
 
 
-def test_single_instance_models_skip_the_mps_stage() -> None:
-    """A model without an MPS config must not drag the MPS stage along."""
+def test_every_rotation_model_resolves_an_mps_pool() -> None:
+    """A model without a pool of its own must borrow one, not drop stage 5.
+
+    Skipping left the MPS path unexercised on a third of the runs.
+    """
     script = _select_step_script()
-    assert 'resolved_config=""' in script, "no single-instance branch in preflight"
+    assert 'resolved_config=""' not in script, "a rotation model still skips stage 5"
+    assert 'mps_model="moss"' in script, "no fallback pool in preflight"
 
     mps = _workflow(TTS_WORKFLOW)["jobs"]["stage-5-mps"]
     condition = mps["if"]

--- a/tests/unit_test/ci/test_tts_mps_workflow_contract.py
+++ b/tests/unit_test/ci/test_tts_mps_workflow_contract.py
@@ -105,5 +105,30 @@ def test_mps_config_resolution_covers_the_colocated_models() -> None:
     assert "examples/mps_dp/configs/moss_local_h100_dp2.yaml" in run
     assert "MossTTSLocalPipelineConfig" in run
     assert "resolved config mismatch" in run
-    # Single-instance models resolve no config; stage 5 keys off that.
-    assert 'resolved_config=""' in run
+    # A single-instance model borrows the moss pool rather than skipping.
+    assert 'mps_model="moss"' in run
+    assert "resolved_mps_model" in omni["jobs"]["preflight"]["outputs"]
+
+
+def test_mps_stage_measures_the_pool_model_not_the_rotation_model() -> None:
+    """Stage 5 can run a different model than stages 1-4, so it must say so.
+
+    The evidence writer and the threshold lookup both key on the model name,
+    and both reject a name they have no MPS references for.
+    """
+    mps = _workflow(TTS_WORKFLOW)["jobs"]["stage-5-mps"]
+    assert (
+        _step(mps, "Run TTS MPS non-streaming validation")["env"]["TTS_CI_MODEL"]
+        == "${{ inputs.tts_mps_model }}"
+    )
+    assert (
+        '--selected-model "${{ inputs.tts_mps_model }}"'
+        in _step(mps, "Initialize TTS MPS evidence")["run"]
+    )
+    assert "inputs.tts_ci_model" not in yaml.safe_dump(mps)
+    # Passing the config without the model would gate a moss pool on whichever
+    # model the test defaults to.
+    tts_ci = _workflow(OMNI_WORKFLOW)["jobs"]["tts-ci"]["with"]
+    assert (
+        tts_ci["tts_mps_model"] == "${{ needs.preflight.outputs.resolved_mps_model }}"
+    )


### PR DESCRIPTION
## Motivation

Stage 5 (MPS) runs only when preflight resolves an MPS config. Qwen3-TTS joined the TTS rotation in #1505 gated as a single instance, so it resolves no config and stage 5 skips. The rotation is one of three, so the MPS path goes unexercised on 31.2% of runs: a change to MPS placement can land without stage 5 ever running against it.

From the `tts-preflight` artifact of each run:

| run | selected model | stage 5 |
|---|---|---|
| 33289952256 | qwen3-tts | skipped |
| 33289099323 | qwen3-tts | skipped |
| 33284780906 | moss | success |
| 33272418817 | higgs | success |

## Modifications

Preflight now resolves a pool model next to the config, and stage 5 borrows the moss DP2 pool when the rotation picks a single-instance model. higgs keeps its own DP3 pool.

Stage 5 reads a new `tts_mps_model` input everywhere it previously read `tts_ci_model`, because the model name is what both `tts_mps_runtime initialize` and the threshold lookup in `test_tts_mps_dp2.py` key on, and both reject a name they hold no MPS references for. `resolved_mps_model` also joins the preflight artifact next to `resolved_mps_config`.

The single-instance verdict for qwen3-tts is unchanged: it still ships as one instance and is never colocated. What changes is which pool stage 5 measures on those runs.

## Accuracy Test

No threshold moves. Stage 5 on a qwen3-tts run gates on the same calibrated moss references it already uses on a moss run, so `.claude/skills/tune-ci-thresholds` needs no recalibration and is untouched.

### CI

* `tests/unit_test/ci/test_tts_mps_workflow_contract.py` and `test_tts_model_rotation_contract.py`: 11 passed. Three assertions fail before this change and pass after.
* Evidence run 33339438931, `run-qwen3-tts` label, head `209f0fda`: preflight resolved `selected_model: qwen3-tts` with `resolved_mps_model: moss` and the moss DP2 config, stage 1 through 5 all pass, and the stage 5 evidence artifact records `selected_model: moss`. This is the rotation that skipped stage 5 before.

## Disclosures

* Stage 5 pool distribution moves from higgs 37.5% / moss 31.2% / none 31.2% to higgs 37.5% / moss 62.5%.
* The qwen3-tts runs grow by one stage 5, 5m59s on the evidence run.
* Stage 5 keeps its `inputs.tts_mps_config != ''` guard as the workflow_call contract, even though preflight now always resolves a config.

