### PR TITLE
fix(api): reject unknown served models

### DIFF
--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -104,6 +104,7 @@ from sglang_omni.serve.speech_errors import (
     bad_request,
     internal_error,
     openai_error_payload,
+    resolve_served_model,
     speech_error_response,
     speech_generation_error,
 )
@@ -658,7 +659,10 @@ def _register_chat_completions(app: FastAPI) -> None:
         request_id = req.request_id or str(uuid.uuid4())
         response_id = f"chatcmpl-{request_id}"
         created = int(time.time())
-        model = req.model or default_model
+        try:
+            model = resolve_served_model(req.model, default_model)
+        except SpeechAPIError as exc:
+            return speech_error_response(exc)
 
         gen_req = _build_chat_generate_request(req)
 

--- a/sglang_omni/serve/speech_errors.py
+++ b/sglang_omni/serve/speech_errors.py
@@ -75,6 +75,24 @@ def speech_error_response(error: SpeechAPIError) -> JSONResponse:
     )
 
 
+def resolve_served_model(
+    requested_model: str | None,
+    default_model: str,
+) -> str:
+    """Resolve the requested model or reject names this server does not serve."""
+
+    model = requested_model or default_model
+    if model != default_model:
+        raise SpeechAPIError(
+            message=f"The model {model!r} does not exist.",
+            status_code=404,
+            error_type="invalid_request_error",
+            param="model",
+            code="model_not_found",
+        )
+    return model
+
+
 def speech_websocket_error_payload(error: SpeechAPIError) -> dict[str, Any]:
     """Build the public error event used by speech WebSocket transports."""
     payload: dict[str, Any] = {

--- a/sglang_omni/serve/transcriptions.py
+++ b/sglang_omni/serve/transcriptions.py
@@ -17,6 +17,11 @@ from sglang_omni.config import AudioChunkingConfig
 from sglang_omni.serve import speech_to_text
 from sglang_omni.serve.openai_errors import is_bad_request_error
 from sglang_omni.serve.protocol import TranscriptionResponse, TranscriptionUsage
+from sglang_omni.serve.speech_errors import (
+    SpeechAPIError,
+    resolve_served_model,
+    speech_error_response,
+)
 from sglang_omni.serve.transcription_adapters import TranscriptionAdapter
 from sglang_omni.serve.transcription_chunking import (
     ChunkPlan,
@@ -62,6 +67,10 @@ def register_transcriptions(app: FastAPI) -> None:
         client: Client = app.state.client
         default_model: str = app.state.model_name
         request_id = f"transcription-{uuid.uuid4()}"
+        try:
+            model = resolve_served_model(form.model, default_model)
+        except SpeechAPIError as exc:
+            return speech_error_response(exc)
 
         response_format = form.response_format.strip().lower()
         segment_timestamps = response_format in speech_to_text.SEGMENT_RESPONSE_FORMATS
@@ -112,7 +121,7 @@ def register_transcriptions(app: FastAPI) -> None:
                 audio_bytes=audio_bytes,
                 filename=form.file.filename,
                 content_type=form.file.content_type,
-                model=form.model or default_model,
+                model=model,
                 language=form.language,
                 prompt=form.prompt,
                 temperature=form.temperature,
@@ -169,7 +178,7 @@ def register_transcriptions(app: FastAPI) -> None:
                 audio_bytes=audio_bytes,
                 filename=form.file.filename,
                 content_type=form.file.content_type,
-                model=form.model or default_model,
+                model=model,
                 language=form.language,
                 prompt=form.prompt,
                 temperature=form.temperature,
@@ -204,7 +213,7 @@ def register_transcriptions(app: FastAPI) -> None:
                     client,
                     plan,
                     request_id=request_id,
-                    model=form.model or default_model,
+                    model=model,
                     filename=form.file.filename,
                     language=form.language,
                     prompt=form.prompt,

--- a/sglang_omni/serve/translations.py
+++ b/sglang_omni/serve/translations.py
@@ -11,7 +11,12 @@ from fastapi.responses import Response
 
 from sglang_omni.client import Client
 from sglang_omni.serve import speech_to_text
-from sglang_omni.serve.speech_errors import openai_error_response
+from sglang_omni.serve.speech_errors import (
+    SpeechAPIError,
+    openai_error_response,
+    resolve_served_model,
+    speech_error_response,
+)
 
 TRANSLATIONS_ENDPOINT = "/v1/audio/translations"
 TRANSLATION_RESPONSE_FORMATS = (
@@ -56,16 +61,12 @@ def register_translations(app: FastAPI) -> None:
     ) -> Response:
         client: Client = app.state.client
         default_model: str = app.state.model_name
-        model = form.model or default_model
         request_id = f"translation-{uuid.uuid4()}"
 
-        if model != default_model:
-            return _invalid_request(
-                f"The model {model!r} does not exist.",
-                param="model",
-                status_code=404,
-                code="model_not_found",
-            )
+        try:
+            model = resolve_served_model(form.model, default_model)
+        except SpeechAPIError as exc:
+            return speech_error_response(exc)
 
         if not app.state.supports_audio_translation:
             return _invalid_request(

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -319,6 +319,30 @@ class SuccessfulTranscriptionClient:
         )
 
 
+def test_chat_rejects_unknown_model_before_dispatch() -> None:
+    backend = SuccessfulTranscriptionClient()
+    client = TestClient(create_app(backend, model_name="served-model"))
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "unknown/model",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": {
+            "message": "The model 'unknown/model' does not exist.",
+            "type": "invalid_request_error",
+            "param": "model",
+            "code": "model_not_found",
+        }
+    }
+    assert backend.requests == []
+
+
 class ChunkRecordingTranscriptionClient:
     """Records (request_id, request) pairs; can fail one chunk by index.
 
@@ -1454,6 +1478,28 @@ def test_transcription_request_builds_asr_generate_request() -> None:
     assert gen_req.metadata == {"task": "asr"}
     assert gen_req.output_modalities == ["text"]
     assert gen_req.stream is False
+
+
+def test_transcription_rejects_unknown_model_before_dispatch() -> None:
+    backend = SuccessfulTranscriptionClient()
+    client = TestClient(create_app(backend, model_name="served-model"))
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={"model": "unknown/model"},
+        files={"file": ("sample.wav", b"RIFF", "audio/wav")},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": {
+            "message": "The model 'unknown/model' does not exist.",
+            "type": "invalid_request_error",
+            "param": "model",
+            "code": "model_not_found",
+        }
+    }
+    assert backend.requests == []
 
 
 def test_transcription_request_preserves_explicit_empty_language() -> None:

--- a/tests/unit_test/serve/test_speech_errors.py
+++ b/tests/unit_test/serve/test_speech_errors.py
@@ -6,7 +6,29 @@ from __future__ import annotations
 import pytest
 
 from sglang_omni.admission import QueueFullError
-from sglang_omni.serve.speech_errors import speech_generation_error
+from sglang_omni.serve.speech_errors import (
+    SpeechAPIError,
+    resolve_served_model,
+    speech_generation_error,
+)
+
+
+@pytest.mark.parametrize("requested_model", [None, "served-model"])
+def test_resolve_served_model_accepts_default(
+    requested_model: str | None,
+) -> None:
+    assert resolve_served_model(requested_model, "served-model") == "served-model"
+
+
+def test_resolve_served_model_rejects_unknown_name() -> None:
+    with pytest.raises(SpeechAPIError) as exc_info:
+        resolve_served_model("unknown/model", "served-model")
+
+    error = exc_info.value
+    assert error.status_code == 404
+    assert error.error_type == "invalid_request_error"
+    assert error.param == "model"
+    assert error.code == "model_not_found"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Motivation

The chat completion and audio transcription endpoints accepted arbitrary model names and dispatched requests to the configured served model. This differs from OpenAI-compatible behavior, where an unknown model should return a structured `404 model_not_found` response before backend dispatch.

The audio translation endpoint already rejected unknown model names. This change makes model resolution consistent across the affected OpenAI-compatible endpoints while preserving the intentional aliases supported by text-to-speech.

## Modifications

- Add a shared `resolve_served_model` helper that returns the configured model or raises an OpenAI-shaped `404 model_not_found` error.
- Validate chat completion model names before request construction and backend dispatch.
- Validate transcription model names before reading or dispatching the uploaded audio.
- Refactor audio translation model validation to use the shared helper.
- Preserve existing TTS aliases such as `tts-1` and `seedtts`.
- Add unit and endpoint regression tests for accepted and rejected model names.

## Related Issues

No SGLang-Omni issue. Related upstream work: sgl-project/sglang#31419.

## Accuracy Test

Not applicable. This changes HTTP request validation and does not modify model execution or outputs.

Validation performed locally:

- Focused resolver and unknown-model endpoint tests: 8 passed.
- Translation, transcription, and TTS model-routing regressions: 20 passed.
- OpenAI API unit-test module: 112 passed, 1 deselected.
- Full repository pre-commit suite: passed.
- Python 3.12 compile check: passed.
- `git diff --check`: passed.

The deselected `test_long_m4a_is_probed_and_chunked` case requires a compatible native FFmpeg/TorchCodec setup on macOS and is unrelated to model-name validation. The repository-pinned CUDA/SGLang stack is not available on this macOS host.

## Benchmark & Profiling

Not applicable. The request path adds only a model-name equality check before dispatch; no inference or performance-sensitive code is changed.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed. (No documentation change needed for this compatibility fix.)
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed. (Not applicable.)
- [ ] For reviewers: If you have not made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

This PR is ready for maintainer approval of forked workflow runs and the `run-ci` label. No model-specific CI selector is required because the change is limited to API request validation.