### PR TITLE
[CLI] Require typer>=0.19.0 for the Literal options in sgl-omni serve

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "librosa>=0.11.0",
     "pandas",
     "tabulate",
-    "typer>=0.9.0",
+    "typer>=0.19.0",  # Literal options in the CLI need 0.19+
     "openai==2.6.1",
     "openai-harmony==0.0.4",
     "soundfile>=0.12.0",

--- a/pyproject_rocm.toml
+++ b/pyproject_rocm.toml
@@ -43,7 +43,7 @@ dependencies = [
     "librosa>=0.11.0",
     "pandas",
     "tabulate",
-    "typer>=0.9.0",
+    "typer>=0.19.0",  # Literal options in the CLI need 0.19+
     "openai==2.6.1",
     "openai-harmony==0.0.4",
     "soundfile>=0.12.0",

--- a/pyproject_xpu.toml
+++ b/pyproject_xpu.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pybase64>=1.4.0",       # fast base64 decode for inline media (utils/audio.py)
     "tabulate",
     "pandas",
-    "typer>=0.9.0",
+    "typer>=0.19.0",  # Literal options in the CLI need 0.19+
 
     # --- PyTorch XPU builds (from --extra-index-url .../whl/xpu) -------------
     # Pins match SGLang's pyproject_xpu.toml / xpu.Dockerfile.


### PR DESCRIPTION
## Motivation

`sgl-omni serve` declares `log_level` as a `typing.Literal` option. Typer maps `Literal` to a choice option only from 0.19.0 on, so any older release that today's `typer>=0.9.0` pin allows fails at startup with

```
RuntimeError: Type not yet supported: typing.Literal['debug', 'info', 'warning', 'error', 'critical']
```

before a single flag is parsed. Hit this on a notebook image that ships typer 0.15: `pip install sglang-omni` left it in place because the pin accepted it, and `sgl-omni serve` would not start.

## Modifications

Raise the floor to `typer>=0.19.0` in `pyproject.toml`, `pyproject_rocm.toml` and `pyproject_xpu.toml`. No code change.

## Testing

A minimal reproduction of the serve signature (`Annotated[Literal[...], typer.Option(...)]`) against typer 0.9.4, 0.12.5, 0.15.4, 0.16.1, 0.17.5 and 0.18.0 raises the error above on every one; 0.19.0, 0.19.2 and 0.27.2 parse it. The unit tests do not touch the CLI and are unaffected.

## Checklist

- [x] Format your code according to the contributor guide
- [ ] Add unit tests (dependency pin only)
- [ ] Update documentation as needed (no user-facing change)
