### PR TITLE
[Qwen3-TTS] Enable incremental CustomVoice streaming

### DIFF
--- a/docs/cookbook/qwen3_tts.md
+++ b/docs/cookbook/qwen3_tts.md
@@ -251,10 +251,11 @@ Streaming returns `audio/pcm` 16-bit mono PCM bytes with sample-rate metadata in
 the response headers. See the [Higgs TTS cookbook](../cookbook/higgs_tts.md#streaming)
 for a full Python raw PCM consumer.
 
-Base/reference-cloning checkpoints use true incremental codec and vocoder
-streaming for both this HTTP endpoint and `/v1/audio/speech/stream` WebSocket
-sessions with `stream_audio=true`. CustomVoice and VoiceDesign remain
-non-streaming.
+Base/reference-cloning and CustomVoice checkpoints use true incremental codec
+and vocoder streaming for both this HTTP endpoint and
+`/v1/audio/speech/stream` WebSocket sessions with `stream_audio=true`.
+VoiceDesign remains non-streaming. Set `non_streaming_mode=true` to retain the
+legacy CustomVoice generation path when compatibility requires it.
 
 When `initial_codec_chunk_frames` is omitted, Qwen3-TTS Base defaults to `8`
 codec frames for the first vocoder chunk so concurrent streams stay continuous.
@@ -280,6 +281,7 @@ first chunk, so their audio arrives complete in a single final flush.
 | `seed` | `null` | Random seed for reproducibility |
 | `stream` | `false` | Stream raw PCM audio chunks |
 | `initial_codec_chunk_frames` | `8` (model default when omitted) | First Base streaming vocoder chunk size in codec frames. Smaller values lower TTFA but underrun more easily; `0` uses the steady stride from the start |
+| `non_streaming_mode` | `false` for Base and CustomVoice | Keep the legacy full-text CustomVoice generation path instead of incremental codec streaming |
 
 ## Model Variants
 

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -274,7 +274,6 @@ def build_qwen3_tts_state(payload: StagePayload) -> Qwen3TTSState:
         if has_param(tts_params, params, "x_vector_only_mode"):
             raise ValueError("Qwen3-TTS CustomVoice does not accept x_vector_only_mode")
         voice = voice or QWEN3_TTS_DEFAULT_CUSTOM_VOICE
-        non_streaming_mode = True
     elif task_type == QWEN3_TTS_TASK_VOICE_DESIGN:
         if has_param(tts_params, params, "ref_audio") or references_contain_audio(
             references
@@ -433,7 +432,7 @@ def resolve_non_streaming_mode(
     for source in (params, tts_params):
         if "non_streaming_mode" in source:
             return bool(source["non_streaming_mode"])
-    return task_type in (QWEN3_TTS_TASK_CUSTOM_VOICE, QWEN3_TTS_TASK_VOICE_DESIGN)
+    return task_type == QWEN3_TTS_TASK_VOICE_DESIGN
 
 
 def normalize_language(language: Any) -> str:

--- a/sglang_omni/serve/protocol.py
+++ b/sglang_omni/serve/protocol.py
@@ -355,6 +355,7 @@ class CreateSpeechRequest(BaseModel):
     token_count: int | None = None  # MOSS-TTS duration token target
     duration_tokens: int | None = None  # alias for token_count
     initial_codec_chunk_frames: int | None = Field(default=None, ge=0)
+    non_streaming_mode: bool | None = None
 
     # Generation parameters
     max_new_tokens: int | None = None
@@ -393,6 +394,7 @@ class SpeechBatchItem(BaseModel):
     duration_tokens: Any = None
     max_new_tokens: Any = None
     initial_codec_chunk_frames: Any = None
+    non_streaming_mode: Any = None
     temperature: Any = None
     top_p: Any = None
     top_k: Any = None
@@ -426,6 +428,7 @@ class CreateSpeechBatchRequest(BaseModel):
     duration_tokens: int | None = None
     max_new_tokens: int | None = None
     initial_codec_chunk_frames: int | None = None
+    non_streaming_mode: bool | None = None
     temperature: float | None = None
     top_p: float | None = None
     top_k: int | None = None
@@ -481,6 +484,7 @@ class SpeechStreamSessionConfig(BaseModel):
     duration_tokens: int | None = None
     max_new_tokens: int | None = None
     initial_codec_chunk_frames: int | None = None
+    non_streaming_mode: bool | None = None
     temperature: float | None = None
     top_p: float | None = None
     top_k: int | None = None

--- a/sglang_omni/serve/speech_service.py
+++ b/sglang_omni/serve/speech_service.py
@@ -673,7 +673,7 @@ class SpeechRequestValidator:
                     raise bad_request(
                         f"{field_name} must be a number", param=field_name
                     )
-        for field_name in ("stream", "x_vector_only_mode"):
+        for field_name in ("stream", "x_vector_only_mode", "non_streaming_mode"):
             if field_name in payload and payload[field_name] is not None:
                 if not isinstance(payload[field_name], bool):
                     raise bad_request(
@@ -791,6 +791,8 @@ def _build_tts_params(
         tts_params[INITIAL_CODEC_CHUNK_FRAMES_PARAM] = (
             request.initial_codec_chunk_frames
         )
+    if request.non_streaming_mode is not None:
+        tts_params["non_streaming_mode"] = request.non_streaming_mode
     if request.token_count is not None:
         tts_params["token_count"] = request.token_count
     if request.duration_tokens is not None:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -1150,6 +1150,17 @@ def test_qwen3_tts_text_only_defaults_to_custom_voice() -> None:
     assert state.voice == "Vivian"
     assert state.ref_audio is None
     assert state.ref_text is None
+    assert state.non_streaming_mode is False
+
+
+def test_qwen3_tts_custom_voice_can_use_legacy_non_streaming_mode() -> None:
+    payload = make_payload(
+        inputs="target",
+        tts_params={"task_type": "CustomVoice", "non_streaming_mode": True},
+    )
+
+    state = build_qwen3_tts_state(payload)
+
     assert state.non_streaming_mode is True
 
 

--- a/tests/unit_test/serve/test_speech_protocol.py
+++ b/tests/unit_test/serve/test_speech_protocol.py
@@ -257,6 +257,7 @@ def test_speech_service_normalizes_tts_extension_fields_into_tts_params() -> Non
             "instructions": "calm",
             "x_vector_only_mode": True,
             "initial_codec_chunk_frames": 8,
+            "non_streaming_mode": True,
             "max_new_tokens": 128,
         }
     )
@@ -272,6 +273,7 @@ def test_speech_service_normalizes_tts_extension_fields_into_tts_params() -> Non
     assert tts_params["instructions"] == "calm"
     assert tts_params["x_vector_only_mode"] is True
     assert tts_params["initial_codec_chunk_frames"] == 8
+    assert tts_params["non_streaming_mode"] is True
     assert gen_req.extra_params == {"initial_codec_chunk_frames": 8}
     assert gen_req.sampling.max_new_tokens == 128
     assert tts_params["explicit_generation_params"] == ["max_new_tokens"]


### PR DESCRIPTION
## Summary

- enable the existing incremental codec/vocoder path for CustomVoice by default
- expose `non_streaming_mode=true` on the speech APIs for compatibility with the legacy full-text path
- keep VoiceDesign non-streaming

Refs #1754 (T-PR5).

## Validation

- `tests/unit_test/qwen3_tts/test_pipeline.py` and `tests/unit_test/serve/test_speech_protocol.py`: 201 passed, 5 skipped
- H100, `Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice`, streaming HTTP smoke: 200, chunked `audio/pcm`, 253440 bytes, 1.620 s time to first byte, 2.019 s total
- compatibility-mode HTTP smoke with `non_streaming_mode=true`: 200, chunked `audio/pcm`, 222720 bytes
- `git diff --check`