### PR TITLE
[Qwen3-TTS] Add configurable first-audio chunk ramp for streaming vocoder

### DIFF
--- a/docs/cookbook/qwen3_tts.md
+++ b/docs/cookbook/qwen3_tts.md
@@ -262,6 +262,36 @@ Pass a smaller value only when trading continuity for lower time-to-first-audio.
 Utterances that finish in fewer than `8` generated codec frames never reach the
 first chunk, so their audio arrives complete in a single final flush.
 
+#### First-audio chunk ramp
+
+For latency-sensitive deployments the whole early chunk schedule can be
+configured server-side with `stream_chunk_ramp` on the vocoder stage: entry
+`i` sizes streaming decode chunk `i + 1` in codec frames, and past the ramp
+the steady stride takes over, so `[2, 4, 8]` yields a
+`2 -> 4 -> 8 -> 8 -> ...` schedule. Set it through a pipeline config file:
+
+```yaml
+config_cls: Qwen3TTSPipelineConfig
+model_path: Qwen/Qwen3-TTS-12Hz-0.6B-Base
+stages:
+  vocoder:
+    factory:
+      stream_chunk_ramp: [2, 4, 8]
+```
+
+```bash
+python -m sglang_omni.cli serve --config qwen3_tts_ramp.yaml
+```
+
+Smaller early chunks lower time-to-first-audio but start playback with less
+buffered audio, so the continuity cost grows with concurrency: keep
+`[2, 4, 8]` to low concurrency, prefer `[4, 8]` up to moderate concurrency,
+and keep the default schedule for saturated serving. The ramp is mutually
+exclusive with the legacy `initial_chunk_frames` /
+`stream_initial_followup_stride` options, its first entry must not exceed the
+steady stride, and a per-request `initial_codec_chunk_frames` still overrides
+only the first chunk.
+
 ## Generation Parameters
 
 | Parameter | Default | Notes |

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -17,7 +17,6 @@ from sglang_omni.models.qwen3_tts.request_builders import (
     preprocess_qwen3_tts_payload,
 )
 from sglang_omni.models.qwen3_tts.streaming_vocoder import (
-    DEFAULT_QWEN3_TTS_INITIAL_CHUNK_FRAMES,
     DEFAULT_QWEN3_TTS_LEFT_CONTEXT_FRAMES,
     DEFAULT_QWEN3_TTS_STREAM_FOLLOWUP_STRIDE,
     DEFAULT_QWEN3_TTS_STREAM_STRIDE,
@@ -175,7 +174,8 @@ def create_vocoder_executor(
     stream_stride: int = DEFAULT_QWEN3_TTS_STREAM_STRIDE,
     stream_followup_stride: int = DEFAULT_QWEN3_TTS_STREAM_FOLLOWUP_STRIDE,
     stream_initial_followup_stride: int | None = None,
-    initial_chunk_frames: int = DEFAULT_QWEN3_TTS_INITIAL_CHUNK_FRAMES,
+    initial_chunk_frames: int | None = None,
+    stream_chunk_ramp: tuple[int, ...] | list[int] | None = None,
     stream_left_context_frames: int = DEFAULT_QWEN3_TTS_LEFT_CONTEXT_FRAMES,
     initial_max_batch_size: int = 32,
     initial_batch_wait_ms: int = 2,
@@ -200,6 +200,7 @@ def create_vocoder_executor(
         stream_followup_stride=stream_followup_stride,
         stream_initial_followup_stride=stream_initial_followup_stride,
         initial_chunk_frames=initial_chunk_frames,
+        stream_chunk_ramp=stream_chunk_ramp,
         stream_left_context_frames=stream_left_context_frames,
         max_batch_size=max_batch_size,
         max_batch_wait_ms=max_batch_wait_ms,

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -351,7 +351,8 @@ class Qwen3TTSStreamingVocoderScheduler(
         stream_stride: int = DEFAULT_QWEN3_TTS_STREAM_STRIDE,
         stream_followup_stride: int = DEFAULT_QWEN3_TTS_STREAM_FOLLOWUP_STRIDE,
         stream_initial_followup_stride: int | None = None,
-        initial_chunk_frames: int = DEFAULT_QWEN3_TTS_INITIAL_CHUNK_FRAMES,
+        initial_chunk_frames: int | None = None,
+        stream_chunk_ramp: tuple[int, ...] | list[int] | None = None,
         stream_left_context_frames: int = DEFAULT_QWEN3_TTS_LEFT_CONTEXT_FRAMES,
         max_batch_size: int = 8,
         max_batch_wait_ms: int = 2,
@@ -371,8 +372,52 @@ class Qwen3TTSStreamingVocoderScheduler(
             and stream_initial_followup_stride <= 0
         ):
             raise ValueError("stream_initial_followup_stride must be > 0")
-        if initial_chunk_frames < 0:
+        if initial_chunk_frames is not None and initial_chunk_frames < 0:
             raise ValueError("initial_chunk_frames must be >= 0")
+        if stream_chunk_ramp is not None:
+            # note (Junnan Li): the ramp is the generalized form of the two
+            # legacy knobs; a mixed configuration has no single source of
+            # truth, so refuse it.
+            if (
+                stream_initial_followup_stride is not None
+                or initial_chunk_frames is not None
+            ):
+                raise ValueError(
+                    "stream_chunk_ramp replaces initial_chunk_frames and "
+                    "stream_initial_followup_stride; set only one form"
+                )
+            if not isinstance(stream_chunk_ramp, (tuple, list)):
+                raise TypeError("stream_chunk_ramp must be a tuple or list of ints")
+            if not stream_chunk_ramp:
+                raise ValueError("stream_chunk_ramp must contain at least one entry")
+            if any(
+                isinstance(frames, bool) or not isinstance(frames, int)
+                for frames in stream_chunk_ramp
+            ):
+                raise TypeError("stream_chunk_ramp entries must be ints")
+            chunk_ramp = tuple(int(frames) for frames in stream_chunk_ramp)
+            if any(frames <= 0 for frames in chunk_ramp):
+                raise ValueError("stream_chunk_ramp entries must be > 0")
+            # note (Junnan Li): the request-time resolver clamps the first
+            # chunk to the steady stride, so a larger configured value would
+            # silently run a different schedule with unusable graph shapes.
+            if chunk_ramp[0] > stream_stride:
+                raise ValueError("stream_chunk_ramp[0] must be <= stream_stride")
+            initial_chunk_frames = chunk_ramp[0]
+            followup_stride_ramp = chunk_ramp[1:]
+        else:
+            if initial_chunk_frames is None:
+                initial_chunk_frames = DEFAULT_QWEN3_TTS_INITIAL_CHUNK_FRAMES
+            followup_stride_ramp = (
+                (
+                    min(
+                        DEFAULT_QWEN3_TTS_STREAM_INITIAL_FOLLOWUP_STRIDE,
+                        stream_followup_stride,
+                    )
+                    if stream_initial_followup_stride is None
+                    else stream_initial_followup_stride
+                ),
+            )
         if stream_left_context_frames < 0:
             raise ValueError("stream_left_context_frames must be >= 0")
         if initial_max_batch_size <= 0 or followup_max_batch_size <= 0:
@@ -394,17 +439,12 @@ class Qwen3TTSStreamingVocoderScheduler(
             batch_sizes=(1,) if self._deterministic_inference else (1, 2, 4, 8),
             enabled=bool(initial_cuda_graph and num_quantizers > 0),
         )
-        followup_frames = (
-            int(stream_left_context_frames) + int(stream_followup_stride),
-            int(stream_left_context_frames)
-            + int(
-                min(
-                    DEFAULT_QWEN3_TTS_STREAM_INITIAL_FOLLOWUP_STRIDE,
-                    stream_followup_stride,
-                )
-                if stream_initial_followup_stride is None
-                else stream_initial_followup_stride
-            ),
+        # note (Junnan Li): windows truncated below the full left context
+        # (short or absent reference codes early in a stream) fall back to
+        # eager decode, as the legacy first follow-up already does.
+        followup_frames = tuple(
+            int(stream_left_context_frames) + int(stride)
+            for stride in (*followup_stride_ramp, stream_followup_stride)
         )
         self._followup_decode_graphs = _Qwen3TTSInitialDecodeGraphs(
             self._decoder,
@@ -417,14 +457,12 @@ class Qwen3TTSStreamingVocoderScheduler(
         self._samples_per_frame = int(self._decoder.total_upsample)
         self._stream_stride = int(stream_stride)
         self._stream_followup_stride = int(stream_followup_stride)
-        self._stream_initial_followup_stride = int(
-            min(
-                DEFAULT_QWEN3_TTS_STREAM_INITIAL_FOLLOWUP_STRIDE,
-                self._stream_followup_stride,
-            )
-            if stream_initial_followup_stride is None
-            else stream_initial_followup_stride
+        # note (Junnan Li): ``_followup_stride_ramp[i]`` sizes decode chunk
+        # ``i + 2``; past the ramp the steady stride takes over.
+        self._followup_stride_ramp = tuple(
+            int(stride) for stride in followup_stride_ramp
         )
+        self._chunk_ramp_configured = stream_chunk_ramp is not None
         self._initial_max_batch_size = int(initial_max_batch_size)
         self._initial_batch_wait_s = float(initial_batch_wait_ms) / 1000.0
         self._followup_max_batch_size = int(followup_max_batch_size)
@@ -1036,16 +1074,32 @@ class Qwen3TTSStreamingVocoderScheduler(
 
         state.emitted_generated_frames = plan.generated_frames
         state.decoded_chunks += 1
-        followup_stride = (
-            self._stream_initial_followup_stride
-            if state.decoded_chunks == 1
-            else self._stream_followup_stride
+        state.next_decode_generated_frames = (
+            plan.generated_frames + self._next_followup_stride(state)
         )
-        state.next_decode_generated_frames = plan.generated_frames + followup_stride
         now = time.monotonic()
         duration_s = float(delta.numel()) / float(self._sample_rate)
         state.playback_deadline_s = max(state.playback_deadline_s, now) + duration_s
         return delta
+
+    def _next_followup_stride(self, state: _Qwen3TTSStreamState) -> int:
+        """Stride of the next decode chunk after a commit.
+
+        A ramp is cursored by emitted frames, so a backlog that overshot the
+        ramp resumes at the steady stride; the legacy schedule keeps its
+        decode-count selection."""
+        if not self._chunk_ramp_configured:
+            return (
+                self._followup_stride_ramp[0]
+                if state.decoded_chunks == 1
+                else self._stream_followup_stride
+            )
+        cumulative = state.initial_chunk_frames or self._stream_stride
+        for stride in self._followup_stride_ramp:
+            if state.emitted_generated_frames < cumulative + stride:
+                return stride
+            cumulative += stride
+        return self._stream_followup_stride
 
     def _decode_and_emit(
         self,
@@ -1065,16 +1119,28 @@ class Qwen3TTSStreamingVocoderScheduler(
             return []
 
         self._mark_stream_emitted(request_id)
-        split_samples = state.initial_chunk_frames * self._samples_per_frame
-        if (
-            state.decoded_chunks == 1
-            and split_samples > 0
-            and split_samples < int(delta.shape[-1])
-        ):
-            return [
-                self._stream_chunk_message(request_id, delta[:split_samples]),
-                self._stream_chunk_message(request_id, delta[split_samples:]),
-            ]
+        if state.decoded_chunks == 1 and state.initial_chunk_frames > 0:
+            # note (Junnan Li): keep client-visible chunk sizes ramp-shaped
+            # when the first decode flushed a backlog; without a ramp only the
+            # legacy initial-boundary split applies.
+            split_frames = (state.initial_chunk_frames,)
+            if self._chunk_ramp_configured:
+                split_frames += self._followup_stride_ramp
+            slices: list[torch.Tensor] = []
+            total_samples = int(delta.shape[-1])
+            start = 0
+            for frames in split_frames:
+                end = min(start + frames * self._samples_per_frame, total_samples)
+                if end <= start:
+                    break
+                slices.append(delta[start:end])
+                start = end
+            if start < total_samples:
+                slices.append(delta[start:])
+            if len(slices) > 1:
+                return [
+                    self._stream_chunk_message(request_id, piece) for piece in slices
+                ]
         return [self._stream_chunk_message(request_id, delta)]
 
     def _schedule_initial(

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -1386,7 +1386,7 @@ def test_qwen3_tts_vocoder_batches_decode_requests(
     assert scheduler.create_stream_state("request").initial_chunk_frames == 8
     assert scheduler._stream_left_context_frames == 16
     assert scheduler._stream_followup_stride == 8
-    assert scheduler._stream_initial_followup_stride == 8
+    assert scheduler._followup_stride_ramp == (8,)
     assert scheduler._initial_max_batch_size == 32
     assert scheduler._initial_batch_wait_s == pytest.approx(0.002)
     assert scheduler._followup_max_batch_size == 8
@@ -2623,6 +2623,286 @@ def test_qwen3_tts_streaming_vocoder_uses_steady_followup_stride() -> None:
     )
     assert state.next_decode_generated_frames == initial_frames + 16
     assert len(scheduler._decoder.decode_inputs) == 2
+
+
+def test_qwen3_tts_streaming_vocoder_chunk_ramp_schedules_early_chunks() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        stream_chunk_ramp=(2, 4, 8),
+    )
+    payload = make_payload(inputs="target", params={"stream": True})
+    scheduler._on_streaming_new_request(payload.request_id, payload)
+
+    emitted_frames: list[int] = []
+    chunk_id = 0
+
+    def feed(frames: int) -> None:
+        nonlocal chunk_id
+        scheduler._on_chunk(
+            payload.request_id,
+            _qwen3_tts_stream_item(
+                torch.ones((frames, 2), dtype=torch.long),
+                chunk_id=chunk_id,
+                ref_code_len=0 if chunk_id == 0 else None,
+            ),
+        )
+        chunk_id += 1
+        while not scheduler.outbox.empty():
+            message = scheduler.outbox.get_nowait()
+            emitted_frames.append(len(message.data["audio_waveform"]) // (4 * 4))
+
+    # note (Junnan Li): each schedule point is locked behaviorally by feeding
+    # one frame short of it (must not emit) and then the last frame (must).
+    feed(1)
+    assert emitted_frames == []
+    feed(1)
+    assert emitted_frames == [2]
+    feed(3)
+    assert emitted_frames == [2]
+    feed(1)
+    assert emitted_frames == [2, 4]
+    feed(7)
+    assert emitted_frames == [2, 4]
+    feed(1)
+    assert emitted_frames == [2, 4, 8]
+    feed(8)
+    assert emitted_frames == [2, 4, 8, 8], "past the ramp the steady stride rules"
+
+
+def test_qwen3_tts_streaming_vocoder_chunk_ramp_covers_graph_shapes() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        stream_chunk_ramp=(2, 4, 8),
+    )
+    left = scheduler._stream_left_context_frames
+    assert scheduler._initial_decode_graphs._input_frames == (left + 2,)
+    assert scheduler._followup_decode_graphs._input_frames == (left + 4, left + 8)
+
+    payload = make_payload(inputs="target", params={"stream": True})
+    scheduler._on_streaming_new_request(payload.request_id, payload)
+    covered = (
+        scheduler._initial_decode_graphs._input_frames
+        + scheduler._followup_decode_graphs._input_frames
+    )
+    scheduler._on_chunk(
+        payload.request_id,
+        _qwen3_tts_stream_item(
+            torch.ones((left + 2, 2), dtype=torch.long),
+            chunk_id=0,
+            ref_code_len=left,
+        ),
+    )
+    for chunk_id, frames in enumerate((4, 8, 8), start=1):
+        scheduler._on_chunk(
+            payload.request_id,
+            _qwen3_tts_stream_item(
+                torch.ones((frames, 2), dtype=torch.long), chunk_id=chunk_id
+            ),
+        )
+    decode_shapes = [int(codes.shape[-1]) for codes in scheduler._decoder.decode_inputs]
+    assert len(decode_shapes) == 4
+    assert all(shape in covered for shape in decode_shapes), decode_shapes
+
+
+def test_qwen3_tts_streaming_vocoder_chunk_ramp_splits_backlogged_first_decode() -> (
+    None
+):
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        stream_chunk_ramp=(2, 4, 8),
+    )
+    payload = make_payload(inputs="target", params={"stream": True})
+    scheduler._on_streaming_new_request(payload.request_id, payload)
+
+    scheduler._on_chunk(
+        payload.request_id,
+        _qwen3_tts_stream_item(
+            torch.ones((20, 2), dtype=torch.long),
+            chunk_id=0,
+            ref_code_len=0,
+        ),
+    )
+    emitted_frames = []
+    while not scheduler.outbox.empty():
+        message = scheduler.outbox.get_nowait()
+        emitted_frames.append(len(message.data["audio_waveform"]) // (4 * 4))
+    assert emitted_frames == [2, 4, 8, 6]
+
+    scheduler._on_chunk(
+        payload.request_id,
+        _qwen3_tts_stream_item(torch.ones((4, 2), dtype=torch.long), chunk_id=1),
+    )
+    assert scheduler.outbox.qsize() == 0
+    scheduler._on_chunk(
+        payload.request_id,
+        _qwen3_tts_stream_item(torch.ones((4, 2), dtype=torch.long), chunk_id=2),
+    )
+    steady = scheduler.outbox.get_nowait()
+    assert len(steady.data["audio_waveform"]) == 8 * 4 * 4
+
+
+def test_qwen3_tts_streaming_vocoder_request_override_resizes_only_first_chunk() -> (
+    None
+):
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        stream_chunk_ramp=(2, 4, 8),
+    )
+    payload = make_payload(
+        inputs="target",
+        params={"stream": True, "initial_codec_chunk_frames": 1},
+    )
+    scheduler._on_streaming_new_request(payload.request_id, payload)
+    emitted_frames: list[int] = []
+    for chunk_id, frames in enumerate((1, 4, 8)):
+        scheduler._on_chunk(
+            payload.request_id,
+            _qwen3_tts_stream_item(
+                torch.ones((frames, 2), dtype=torch.long),
+                chunk_id=chunk_id,
+                ref_code_len=0 if chunk_id == 0 else None,
+            ),
+        )
+        while not scheduler.outbox.empty():
+            message = scheduler.outbox.get_nowait()
+            emitted_frames.append(len(message.data["audio_waveform"]) // (4 * 4))
+    assert emitted_frames == [1, 4, 8], "override resizes only the first chunk"
+
+
+def test_qwen3_tts_streaming_vocoder_zero_override_with_ramp() -> None:
+    # note (Junnan Li): a zero override disables the early chunk (legacy
+    # semantics), so the first decode waits for the steady stride; the ramp
+    # tail still schedules the following chunks.
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        stream_chunk_ramp=(2, 4, 8),
+    )
+    payload = make_payload(
+        inputs="target",
+        params={"stream": True, "initial_codec_chunk_frames": 0},
+    )
+    scheduler._on_streaming_new_request(payload.request_id, payload)
+    emitted_frames: list[int] = []
+    for chunk_id, frames in enumerate((16, 4, 8)):
+        scheduler._on_chunk(
+            payload.request_id,
+            _qwen3_tts_stream_item(
+                torch.ones((frames, 2), dtype=torch.long),
+                chunk_id=chunk_id,
+                ref_code_len=0 if chunk_id == 0 else None,
+            ),
+        )
+        while not scheduler.outbox.empty():
+            message = scheduler.outbox.get_nowait()
+            emitted_frames.append(len(message.data["audio_waveform"]) // (4 * 4))
+    assert emitted_frames == [16, 4, 8]
+
+
+def test_qwen3_tts_streaming_vocoder_singleton_ramp_goes_straight_to_steady() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        _FakeQwen3TTSTokenizer(),
+        device="cpu",
+        stream_chunk_ramp=(2,),
+    )
+    payload = make_payload(inputs="target", params={"stream": True})
+    scheduler._on_streaming_new_request(payload.request_id, payload)
+    emitted_frames: list[int] = []
+    for chunk_id, frames in enumerate((2, 8, 8)):
+        scheduler._on_chunk(
+            payload.request_id,
+            _qwen3_tts_stream_item(
+                torch.ones((frames, 2), dtype=torch.long),
+                chunk_id=chunk_id,
+                ref_code_len=0 if chunk_id == 0 else None,
+            ),
+        )
+        while not scheduler.outbox.empty():
+            message = scheduler.outbox.get_nowait()
+            emitted_frames.append(len(message.data["audio_waveform"]) // (4 * 4))
+    assert emitted_frames == [2, 8, 8]
+
+
+def test_qwen3_tts_vocoder_factory_forwards_chunk_ramp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.qwen3_tts import stages
+
+    monkeypatch.setattr(
+        stages,
+        "_load_qwen3_tts_tokenizer",
+        lambda *args, **kwargs: _FakeQwen3TTSTokenizer(),
+    )
+    monkeypatch.setattr(
+        Qwen3TTSStreamingVocoderScheduler, "warmup_now", lambda scheduler: None
+    )
+
+    scheduler = stages.create_vocoder_executor(
+        "model",
+        device="cpu",
+        stream_chunk_ramp=[2, 4, 8],
+    )
+    payload = make_payload(inputs="target", params={"stream": True})
+    scheduler._on_streaming_new_request(payload.request_id, payload)
+    scheduler._on_chunk(
+        payload.request_id,
+        _qwen3_tts_stream_item(
+            torch.ones((2, 2), dtype=torch.long), chunk_id=0, ref_code_len=0
+        ),
+    )
+    first = scheduler.outbox.get_nowait()
+    assert len(first.data["audio_waveform"]) == 2 * 4 * 4
+
+
+def test_qwen3_tts_streaming_vocoder_chunk_ramp_rejects_mixed_config() -> None:
+    with pytest.raises(ValueError, match="set only one form"):
+        Qwen3TTSStreamingVocoderScheduler(
+            _FakeQwen3TTSTokenizer(),
+            device="cpu",
+            stream_chunk_ramp=(2, 4, 8),
+            stream_initial_followup_stride=4,
+        )
+    # note (Junnan Li): an explicit legacy value is refused even at its
+    # default: None is the only "not set" spelling.
+    for legacy_frames in (4, 8):
+        with pytest.raises(ValueError, match="set only one form"):
+            Qwen3TTSStreamingVocoderScheduler(
+                _FakeQwen3TTSTokenizer(),
+                device="cpu",
+                stream_chunk_ramp=(2, 4, 8),
+                initial_chunk_frames=legacy_frames,
+            )
+    with pytest.raises(ValueError, match="must be <= stream_stride"):
+        Qwen3TTSStreamingVocoderScheduler(
+            _FakeQwen3TTSTokenizer(),
+            device="cpu",
+            stream_stride=16,
+            stream_chunk_ramp=(20, 4),
+        )
+    with pytest.raises(ValueError, match="at least one entry"):
+        Qwen3TTSStreamingVocoderScheduler(
+            _FakeQwen3TTSTokenizer(),
+            device="cpu",
+            stream_chunk_ramp=(),
+        )
+    for bad_ramp in ((0, 4), (2, -4)):
+        with pytest.raises(ValueError, match="stream_chunk_ramp entries must be > 0"):
+            Qwen3TTSStreamingVocoderScheduler(
+                _FakeQwen3TTSTokenizer(),
+                device="cpu",
+                stream_chunk_ramp=bad_ramp,
+            )
+    for non_int_ramp in ("248", 8, (2, 4.0), (True, 4), (2, "4")):
+        with pytest.raises(TypeError):
+            Qwen3TTSStreamingVocoderScheduler(
+                _FakeQwen3TTSTokenizer(),
+                device="cpu",
+                stream_chunk_ramp=non_int_ramp,
+            )
 
 
 def test_qwen3_tts_streaming_vocoder_zero_initial_chunk_uses_steady_stride() -> None:


### PR DESCRIPTION
## Motivation

Implement T-PR6 of the Qwen3-TTS optimization roadmap (#1754): make the first-audio chunk schedule configurable for latency-sensitive serving, replacing the fixed `8, 8, 8, ...` initial cadence.

## Modifications

- **Chunk ramp** (`streaming_vocoder.py`): `stream_chunk_ramp` entry `i` sizes streaming decode chunk `i + 1` in codec frames, then the steady stride takes over — `(2, 4, 8)` -> `2 -> 4 -> 8 -> 8 -> ...`, backlog-safe. Every ramp stride gets a full-left-context CUDA graph shape; truncated windows keep the legacy eager fallback (T-PR9 territory).
- **Compatibility**: default `None` keeps the existing schedule byte-for-byte; mixed legacy/ramp or invalid configuration fails at construction; the per-request `initial_codec_chunk_frames` override still resizes only the first chunk.
- **Plumbing** (`stages.py`): `create_vocoder_executor` forwards the option through the vocoder-stage `factory.*` configuration; no new CLI surface.
- **Tests & docs**: updated accordingly (`docs/cookbook/qwen3_tts.md`: config example and shape guidance by concurrency).

## Related Issues

#1754

## Accuracy Test

WER: Qwen3-ASR-1.7B transcription of the benchmark audio (same unified session as the table below), SeedTTS-EN, 512 samples per cell x 3 rounds; corpus WER excl. >50% runaways, range over rounds. All ranges overlap across arms at every concurrency.

| conc | ramp | WER (%) | runaway (>50% WER) |
|---:|---|---:|---:|
| 1 | off | 1.19–1.23 | 0/1536 |
| 1 | (4,8) | 1.03–1.18 | 0/1536 |
| 1 | (2,4,8) | 1.09–1.47 | 0/1536 |
| 8 | off | 1.07–1.10 | 1/1536 |
| 8 | (4,8) | 1.16–1.23 | 0/1536 |
| 8 | (2,4,8) | 1.14–1.29 | 3/1536 |
| 16 | off | 1.14–1.20 | 1/1536 |
| 16 | (4,8) | 1.09–1.19 | 1/1536 |
| 16 | (2,4,8) | 1.07–1.28 | 0/1536 |
| 32 | off | 1.12–1.21 | 0/1536 |
| 32 | (4,8) | 1.18–1.19 | 0/1536 |
| 32 | (2,4,8) | 1.10–1.21 | 0/1536 |

## Benchmark & Profiling

Setup: H200, `Qwen/Qwen3-TTS-12Hz-1.7B-Base`, SeedTTS-EN, 512 clips per trial, fresh server per arm, closed loop, one GPU and time window, arm order rotated across rounds; the arms differ only by the ramp config entry. Table values are means over 3 rounds.

| conc | ramp | TTFA p95 (s) | TTFA delta | C50 (%) | underrun p95 (s) | latency p95 (s) | req/s | first-audio (B) |
|---:|---|---:|---:|---:|---:|---:|---:|---:|
| 1 | off | 0.210 | — | 100 | 0 | 0.77 | 1.84 | 30720 |
| 1 | (4,8) | 0.177 | -16% | 100 | 0 | 0.78 | 1.82 | 15360 |
| 1 | (2,4,8) | 0.159 | -24% | 100 | 0 | 0.78 | 1.83 | 7680 |
| 8 | off | 0.341 | — | 100 | 0 | 1.41 | 8.07 | 30720 |
| 8 | (4,8) | 0.259 | -24% | 100 | 0 | 1.41 | 8.02 | 15360 |
| 8 | (2,4,8) | 0.198 | -42% | 99.8 | 0 | 1.43 | 7.28 | 7680 |
| 16 | off | 0.474 | — | 100 | 0 | 2.18 | 9.84 | 30720 |
| 16 | (4,8) | 0.358 | -24% | 99.4 | 0 | 2.13 | 9.88 | 15360 |
| 16 | (2,4,8) | 0.278 | -41% | 95.5 | 0.046 | 2.16 | 10.52 | 7680 |
| 32 | off | 1.962 | — | 99.1 | 0 | 3.94 | 12.43 | 30720 |
| 32 | (4,8) | 0.617 | -69% | 56.4 | 0.256 | 3.73 | 12.62 | 15360 |
| 32 | (2,4,8) | 0.456 | -77% | 43.6 | 0.323 | 3.82 | 12.59 | 7680 |

- Significance: per-round TTFA ranges are disjoint between all three arms at every concurrency; every run finished 512/512.
- Optimized path verified: every ramp decode shape hit a captured CUDA graph; the payload column shows the configured first chunk arriving exactly (8 / 4 / 2 frames).
- Continuity cost is an initial-buffer effect, not a supply shortfall: 86% of the c32 underrun deficit falls in the first third of each stream.
- Safe range: `(2, 4, 8)` up to c8, `(4, 8)` up to c16, neither fits c32; the default schedule is unchanged.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` or `/tag-and-rerun-ci qwen3-tts` to select a TTS CI
model, and
`/tag-and-rerun-ci fun-asr`, `/tag-and-rerun-ci qwen3-asr` or
`/tag-and-rerun-ci whisper-asr` to select an ASR CI model. One selector from
each family can be combined, for example `/tag-and-rerun-ci moss fun-asr`.
Draft PRs are skipped even if labeled.
