### PR TITLE
fix(fish-s2pro): warm dynamic Fast-AR compile

### DIFF
--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -55,8 +56,45 @@ def _configure_preprocessing_threads(worker_count: int) -> int:
     return intraop_threads
 
 
+def _warmup_s2pro_codebook_decoder(model: Any, *, max_batch_size: int) -> None:
+    """Materialize Fast AR compile variants before serving real requests."""
+    if max_batch_size < 1:
+        raise ValueError("max_batch_size must be >= 1")
+
+    audio_decoder = model._audio_decoder
+    embedding_weight = audio_decoder.embeddings.weight
+    hidden_size = int(embedding_weight.shape[1])
+    batch_sizes = sorted(
+        batch_size
+        for batch_size in {1, 2, 4, 8, 16, 32, max_batch_size}
+        if batch_size <= max_batch_size
+    )
+    warmup_input = torch.zeros(
+        (max_batch_size, 1, hidden_size),
+        device=embedding_weight.device,
+        dtype=embedding_weight.dtype,
+    )
+    num_codebooks = int(audio_decoder.config.num_codebooks)
+
+    audio_decoder.reset_caches()
+    try:
+        with torch.no_grad():
+            for _ in range(2):
+                for batch_size in batch_sizes:
+                    decoder_input = warmup_input[:batch_size]
+                    for codebook_idx in range(num_codebooks):
+                        audio_decoder.forward_kvcached(
+                            decoder_input,
+                            codebook_idx=codebook_idx,
+                        )
+    finally:
+        audio_decoder.reset_caches()
+        if embedding_weight.device.type == "cuda":
+            torch.cuda.synchronize(embedding_weight.device)
+
+
 def _compile_s2pro_codebook_decoder(model: Any, *, max_batch_size: int) -> None:
-    """Compile Fast AR decoder layers while leaving sampling and loop control eager."""
+    """Compile and warm Fast AR layers, falling back to eager on warmup failure."""
     from sglang.srt.compilation.torch_compile_decoration import set_torch_compile_config
 
     if max_batch_size < 1:
@@ -68,19 +106,36 @@ def _compile_s2pro_codebook_decoder(model: Any, *, max_batch_size: int) -> None:
         "max-autotune-no-cudagraphs",
     )
     audio_decoder = model._audio_decoder
+    setup_start = time.perf_counter()
     compiled_forward_kvcached_layers = [
-        torch.compile(layer.forward_kvcached, mode=compile_mode)
+        torch.compile(layer.forward_kvcached, mode=compile_mode, dynamic=True)
         for layer in audio_decoder.layers
     ]
     audio_decoder.set_compiled_forward_kvcached_layers(
         compiled_forward_kvcached_layers,
         max_batch_size=max_batch_size,
     )
+    setup_seconds = time.perf_counter() - setup_start
+    warmup_start = time.perf_counter()
+    try:
+        _warmup_s2pro_codebook_decoder(model, max_batch_size=max_batch_size)
+    except Exception:
+        audio_decoder._compiled_forward_kvcached_layers = None
+        audio_decoder._compiled_forward_kvcached_max_bs = 0
+        audio_decoder.reset_caches()
+        logger.exception(
+            "Fish S2-Pro Fast AR compile warmup failed; continuing with eager layers"
+        )
+        return
+    warmup_seconds = time.perf_counter() - warmup_start
     logger.info(
-        "Compiled %d Fast AR decoder layers (mode=%s, max_batch_size=%d)",
+        "Compiled and warmed %d Fast AR decoder layers "
+        "(mode=%s, max_batch_size=%d, setup=%.2fs, warmup=%.2fs)",
         len(compiled_forward_kvcached_layers),
         compile_mode,
         max_batch_size,
+        setup_seconds,
+        warmup_seconds,
     )
 
 

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -552,6 +552,14 @@ def test_s2pro_compile_helper_targets_forward_kvcached(
 
     monkeypatch.setattr(torch, "compile", fake_compile)
     monkeypatch.setenv("SGLANG_TORCH_COMPILE_MODE", "reduce-overhead")
+    warmup_calls: list[tuple[object, int]] = []
+    monkeypatch.setattr(
+        stages,
+        "_warmup_s2pro_codebook_decoder",
+        lambda model, *, max_batch_size: warmup_calls.append(
+            (model, max_batch_size)
+        ),
+    )
 
     class _Layer:
         def forward_kvcached(
@@ -587,9 +595,129 @@ def test_s2pro_compile_helper_targets_forward_kvcached(
     assert getattr(target, "__self__", None) is audio_decoder.layers[0]
     assert getattr(target, "__name__", "") == "forward_kvcached"
     assert mode == "reduce-overhead"
-    assert kwargs == {}
+    assert kwargs == {"dynamic": True}
     assert audio_decoder._compiled_forward_kvcached_layers == ["compiled-1"]
     assert audio_decoder._compiled_forward_kvcached_max_bs == 2
+    assert warmup_calls == [(model, 2)]
+
+
+def test_s2pro_compile_warmup_covers_batches_codebooks_and_resets() -> None:
+    stages = importlib.import_module("sglang_omni.models.fishaudio_s2_pro.stages")
+
+    class _AudioDecoder:
+        def __init__(self) -> None:
+            self.embeddings = torch.nn.Embedding(32, 4, dtype=torch.bfloat16)
+            self.project_in = torch.nn.Identity()
+            self.config = SimpleNamespace(num_codebooks=10)
+            self.calls: list[tuple[int, int, torch.dtype, torch.device]] = []
+            self.reset_calls = 0
+
+        def reset_caches(self) -> None:
+            self.reset_calls += 1
+
+        def forward_kvcached(
+            self, decoder_input: torch.Tensor, *, codebook_idx: int
+        ) -> torch.Tensor:
+            self.calls.append(
+                (
+                    int(decoder_input.shape[0]),
+                    codebook_idx,
+                    decoder_input.dtype,
+                    decoder_input.device,
+                )
+            )
+            return decoder_input
+
+    audio_decoder = _AudioDecoder()
+    model = SimpleNamespace(_audio_decoder=audio_decoder)
+
+    stages._warmup_s2pro_codebook_decoder(model, max_batch_size=20)
+
+    expected = [
+        (batch_size, codebook_idx)
+        for _ in range(2)
+        for batch_size in (1, 2, 4, 8, 16, 20)
+        for codebook_idx in range(10)
+    ]
+    assert [
+        (batch_size, codebook_idx)
+        for batch_size, codebook_idx, _, _ in audio_decoder.calls
+    ] == expected
+    assert all(dtype is torch.bfloat16 for _, _, dtype, _ in audio_decoder.calls)
+    assert all(
+        device == audio_decoder.embeddings.weight.device
+        for _, _, _, device in audio_decoder.calls
+    )
+    assert audio_decoder.reset_calls == 2
+
+
+def test_s2pro_compile_warmup_failure_rolls_back_to_eager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stages = importlib.import_module("sglang_omni.models.fishaudio_s2_pro.stages")
+
+    fake_runner = ModuleType("sglang.srt.compilation.torch_compile_decoration")
+    fake_runner.set_torch_compile_config = lambda: None
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang.srt.compilation.torch_compile_decoration",
+        fake_runner,
+    )
+    monkeypatch.setattr(
+        torch,
+        "compile",
+        lambda target, **kwargs: target,
+    )
+
+    class _Layer:
+        def forward_kvcached(self, x: torch.Tensor) -> torch.Tensor:
+            return x
+
+    class _AudioDecoder:
+        def __init__(self) -> None:
+            self.layers = [_Layer()]
+            self.embeddings = torch.nn.Embedding(32, 4)
+            self.config = SimpleNamespace(num_codebooks=10)
+            self._eager_forward_kvcached_layers = ["eager"]
+            self._compiled_forward_kvcached_layers = None
+            self._compiled_forward_kvcached_max_bs = 0
+            self.reset_calls = 0
+
+        def set_compiled_forward_kvcached_layers(
+            self,
+            forward_kvcached_layers: list[object],
+            *,
+            max_batch_size: int,
+        ) -> None:
+            self._compiled_forward_kvcached_layers = forward_kvcached_layers
+            self._compiled_forward_kvcached_max_bs = max_batch_size
+
+        def reset_caches(self) -> None:
+            self.reset_calls += 1
+
+        def forward_kvcached(
+            self, decoder_input: torch.Tensor, *, codebook_idx: int
+        ) -> torch.Tensor:
+            del decoder_input, codebook_idx
+            raise RuntimeError("injected warmup failure")
+
+        def select_forward_kvcached_layers(self) -> list[object]:
+            return (
+                self._compiled_forward_kvcached_layers
+                if self._compiled_forward_kvcached_layers is not None
+                else self._eager_forward_kvcached_layers
+            )
+
+    audio_decoder = _AudioDecoder()
+    stages._compile_s2pro_codebook_decoder(
+        SimpleNamespace(_audio_decoder=audio_decoder),
+        max_batch_size=8,
+    )
+
+    assert audio_decoder._compiled_forward_kvcached_layers is None
+    assert audio_decoder._compiled_forward_kvcached_max_bs == 0
+    assert audio_decoder.select_forward_kvcached_layers() == ["eager"]
+    assert audio_decoder.reset_calls == 3
 
 
 def _run_s2pro_engine_with_fake_buffers(

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -556,9 +556,7 @@ def test_s2pro_compile_helper_targets_forward_kvcached(
     monkeypatch.setattr(
         stages,
         "_warmup_s2pro_codebook_decoder",
-        lambda model, *, max_batch_size: warmup_calls.append(
-            (model, max_batch_size)
-        ),
+        lambda model, *, max_batch_size: warmup_calls.append((model, max_batch_size)),
     )
 
     class _Layer:


### PR DESCRIPTION
<!-- Thank you for contributing to SGLang-Omni! Please provide the following information to help us review your PR. -->

## Motivation

Fish S2-Pro enables Fast-AR `torch.compile` by default on SM90, but the compiled `forward_kvcached` path was created without dynamic-shape support and was only compiled lazily on real traffic.

Under a production-like dynamic-batching trace, batch-size changes together with `codebook_idx=0..9` caused repeated Dynamo recompiles, hit the recompile limit, and produced seconds-scale JIT stalls. On the clean `main` baseline, the first 10-codebook step took 26.56 s and the trace contained three compile-related spikes above 500 ms.

The goal of this change is to pay compile/warmup cost during startup, keep the existing compiled steady-state benefit, and prevent recompilation stalls from reaching requests.

## Modifications

- Compile each Fish S2-Pro Fast-AR `forward_kvcached` layer with `dynamic=True`.
- Warm the compiled decoder during startup for batch sizes `{1, 2, 4, 8, 16, 32, max_batch_size}`, clipped to the configured maximum.
- Run two warmup rounds and cover every `codebook_idx` from `0` through `num_codebooks - 1`.
- Derive warmup device, dtype, and hidden width from `audio_decoder.embeddings.weight`, including models where `project_in` is `nn.Identity`.
- Reset KV caches before and after warmup, and synchronize CUDA before returning.
- If warmup fails, clear all compiled Fast-AR layers, reset KV caches, log the exception, and continue safely on the eager path.
- Add unit coverage for the compile contract, warmup coverage/cache reset, `project_in=nn.Identity`, and warmup-failure rollback.

This PR does not modify DAC, serving-time `reset_caches()` behavior, or FlashInfer/FA3 attention.

## Related Issues

N/A

## Accuracy Test

Fixed inputs, seed, checkpoint, and 30-step batch trace were replayed against eager execution.

| Comparison vs eager | Max abs | Mean abs | RMSE | Argmax agreement | Top-5 set agreement |
| --- | ---: | ---: | ---: | ---: | ---: |
| Current static compile | 0.65625 | 0.050201 | 0.068543 | 98.1514% | 88.5035% |
| Candidate dynamic compile | 0.65625 | 0.050031 | 0.068352 | 98.1690% | 87.8521% |

The candidate shows no meaningful numerical drift beyond the current compiled baseline.

## Benchmark & Profiling

Environment:

- Baseline commit: `7d1bb690cf4c6ba8a4481ae3f1b0bbdc9befe980`
- GPU: NVIDIA H200, SM90
- Driver: 595.71.05
- PyTorch: 2.13.0+cu130
- CUDA runtime: 13.0
- SGLang: 0.5.18
- Checkpoint: `fishaudio/s2-pro@1de9996b6be38b745688de084d87a5633f714e4e`
- dtype: BF16
- `torch_compile_max_bs=64`
- `max_running_requests=64`
- `TORCH_LOGS=recompiles,dynamic`
- Batch trace: `[1,3,2,5,8,4,12,7,16,9,20,11,24,15,32,18,40,22,48,64,3,17,29,5,41,9,55,13,2,33]`
- Every step ran all ten codebooks, `codebook_idx=0..9`

| Metric | Current static compile | Candidate dynamic compile |
| --- | ---: | ---: |
| Dynamo recompiles during measured trace | 6 | 0 |
| Steps >500 ms | 3 | 0 |
| Steps >100 ms | 4 | 0 |
| First measured 10-codebook forward | 26,562.02 ms | 52.35 ms |
| Maximum step | 26,562.02 ms | 52.35 ms |
| Non-spike median | 18.89 ms | 20.25 ms |
| p95 | — | 28.15 ms |
| 30-step trace total | 45,609.26 ms | 652.89 ms |

Candidate startup cost, reported separately:

- `torch.compile` wrapper setup: 0.99 s
- warmup: 19.02 s
- complete compile/warmup helper: 21.35 s
- first post-warmup 10-codebook forward: 52.35 ms

Eager control on the same trace had no Dynamo recompiles, a 29.77 ms median, and no comparable compile stall after its one-time FA3 initialization.

Unit tests:

```text
python -m pytest -q tests/unit_test/fishaudio_s2_pro/test_pipeline.py
68 passed, 14 warnings in 21.44s
```

Additional checks:

```text
git diff --check
python -m py_compile   sglang_omni/models/fishaudio_s2_pro/stages.py   tests/unit_test/fishaudio_s2_pro/test_pipeline.py
```

Both passed. `pre-commit run --all-files --show-diff-on-failure` also passed after the formatting fix. Serving and full SeedTTS benchmarks were intentionally left out of this minimum component-level validation.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs automatically on non-draft PRs. This PR is intentionally opened as a draft while results are reviewed.
