### PR TITLE
[CI] Add ruiling-smartbear to CI permissions

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -19,6 +19,11 @@
         "can_rerun_failed_ci": true,
         "reason": "custom override"
     },
+    "ruiling-smartbear": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "reason": "custom override"
+    },
     "siju-samuel": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
## Motivation

I have two open PRs whose CI has not run yet: #1840 (MOSS-TD short-audio output budget, the stop-loss from #975's first action item) and #1845 (typer pin for the `sgl-omni serve` Literal options). Their workflows sit at `action_required`, and the model CI is gated behind the `run-*` labels, which only accounts listed in `.github/CI_PERMISSIONS.json` may apply or re-run. Adding my account lets me label and re-run CI on my own PRs instead of asking a maintainer each time.

Following the same form as #741, #828 and #1579.

## Modifications

Add a `ruiling-smartbear` entry to `.github/CI_PERMISSIONS.json` with `can_tag_run_ci_label` and `can_rerun_failed_ci`, matching the existing entries. The file stays valid JSON and in the order produced by `python3 .github/update_ci_permission.py --sort-only`.
