### PR TITLE
[Qwen3-Omni Perf] Rule-based traffic-aware adaptive Code2Wav dispatch (#1236 PR 2)

### DIFF
--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -196,8 +196,13 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         )
         self._batch_ceiling = min(max(int(batch_ceiling), 1), _DECOMPOSE_SIZES[0])
         self._enable_adaptive_dispatch = bool(enable_adaptive_dispatch)
-        if self._enable_adaptive_dispatch and not self._enable_batching:
-            raise ValueError("enable_adaptive_dispatch requires enable_batching")
+        if self._enable_adaptive_dispatch and not (
+            self._enable_batching and self._cuda_graph_runner is not None
+        ):
+            raise ValueError(
+                "enable_adaptive_dispatch requires enable_batching "
+                "and enable_cuda_graph"
+            )
         self._drain_mode = False
         self._last_fire_reason: str | None = None
         self._last_adaptive_regime: str | None = None
@@ -235,12 +240,23 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         """Wait budget for the current decision point."""
         if not self._enable_adaptive_dispatch:
             return self._max_batch_wait_s
-        # Note (ruoyu): waiting only pays when both batched graph replay is
-        # live and traffic is heavy — #1026 showed wait/floor batching loses
-        # ~4x without graphs, and the #1237 A/B showed it loses below
-        # concurrency 16 even with them. On either miss, dispatch zero-wait.
+        # Note (ruoyu): waiting only pays when batched graph replay is live
+        # and traffic is heavy — #1026 showed wait/floor batching loses ~4x
+        # without graphs, and the #1237 A/B showed it loses below concurrency
+        # 16 even with them. Batch-size 1 alone does not count as live: a
+        # tier1-shrunk runner decomposes every group into serial B1 replays
+        # (build_step_plan), so a formed batch buys nothing over firing solo.
+        # Active-stream count (not due-count) is the load signal because the
+        # A/B calibrated the crossover on client concurrency.
+        if not self._chunk_aligned_dispatch:
+            return 0.0
+        steady_window = self._left_context_size + self._stream_chunk_size
+        batched_live = any(
+            size > 1
+            for size in self._cuda_graph_runner.available_batch_sizes(steady_window)
+        )
         engaged = (
-            self._chunk_aligned_dispatch
+            batched_live
             and len(self._stream_states) >= _ADAPTIVE_WAIT_MIN_ACTIVE_STREAMS
         )
         return self._max_batch_wait_s if engaged else 0.0
@@ -647,9 +663,9 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
                 for _, state in self._stream_state_items()
                 if state.due_since is not None
             ]
-        if not due:
-            return None
-        return min(due) + self._effective_max_batch_wait_s()
+            if not due:
+                return None
+            return min(due) + self._effective_max_batch_wait_s()
 
     def _drain_inbox(self):
         while True:

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -39,6 +39,13 @@ logger = logging.getLogger(__name__)
 # ceiling all derive from this tuple so a captured key can never go missing.
 _DECOMPOSE_SIZES = (8, 4, 2, 1)
 
+# Note (ruoyu): adaptive dispatch applies the configured wait/floor only at
+# or above this many active streams. The #1237 H100 A/B brackets the
+# crossover: at concurrency 8 zero-wait beats wait-8/floor-8 (+11% vs +6%
+# xRT) while at 16 waiting wins outright (+51% vs +15%); 12 is the midpoint
+# of that measured bracket, pending the #1236 adaptive-arm sweep.
+_ADAPTIVE_WAIT_MIN_ACTIVE_STREAMS = 12
+
 
 def _serial_threshold_graph_keys(
     stream_chunk_size: int,
@@ -160,6 +167,7 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         max_batch_wait_ms: int = 0,
         batch_floor: int = 2,
         batch_ceiling: int = 8,
+        enable_adaptive_dispatch: bool = False,
         enable_output_overlap: bool = True,
         enable_cuda_graph: bool = False,
         _cuda_graph_runner: Code2WavCudaGraphRunner | None = None,
@@ -187,8 +195,12 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
             max(int(initial_codec_chunk_frames), 0), int(stream_chunk_size)
         )
         self._batch_ceiling = min(max(int(batch_ceiling), 1), _DECOMPOSE_SIZES[0])
+        self._enable_adaptive_dispatch = bool(enable_adaptive_dispatch)
+        if self._enable_adaptive_dispatch and not self._enable_batching:
+            raise ValueError("enable_adaptive_dispatch requires enable_batching")
         self._drain_mode = False
         self._last_fire_reason: str | None = None
+        self._last_adaptive_regime: str | None = None
         self._last_oldest_wait_ms: float = 0.0
         self._last_due_bucket_count: int = 0
         self._pending_step_failures: list[str] = []
@@ -218,6 +230,20 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
             return False
         steady_window = self._left_context_size + self._stream_chunk_size
         return bool(self._cuda_graph_runner.available_batch_sizes(steady_window))
+
+    def _effective_max_batch_wait_s(self) -> float:
+        """Wait budget for the current decision point."""
+        if not self._enable_adaptive_dispatch:
+            return self._max_batch_wait_s
+        # Note (ruoyu): waiting only pays when both batched graph replay is
+        # live and traffic is heavy — #1026 showed wait/floor batching loses
+        # ~4x without graphs, and the #1237 A/B showed it loses below
+        # concurrency 16 even with them. On either miss, dispatch zero-wait.
+        engaged = (
+            self._chunk_aligned_dispatch
+            and len(self._stream_states) >= _ADAPTIVE_WAIT_MIN_ACTIVE_STREAMS
+        )
+        return self._max_batch_wait_s if engaged else 0.0
 
     def is_streaming_payload(self, payload: StagePayload) -> bool:
         del payload
@@ -623,7 +649,7 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
             ]
         if not due:
             return None
-        return min(due) + self._max_batch_wait_s
+        return min(due) + self._effective_max_batch_wait_s()
 
     def _drain_inbox(self):
         while True:
@@ -775,6 +801,9 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
 
     def select_step_participants(self) -> list[tuple[str, Code2WavStreamState]]:
         now = time.monotonic()
+        max_wait_s = self._effective_max_batch_wait_s()
+        if self._enable_adaptive_dispatch:
+            self._last_adaptive_regime = "throughput" if max_wait_s > 0.0 else "latency"
         first_ready: list[tuple[str, Code2WavStreamState]] = []
         due: dict[tuple[int, int], list[tuple[str, Code2WavStreamState]]] = {}
         for rid, state in self._stream_state_items():
@@ -803,14 +832,14 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
         oldest_wait = now - anchor[0][1].due_since
         fire = (
             len(anchor) >= self._batch_floor
-            or oldest_wait >= self._max_batch_wait_s
+            or oldest_wait >= max_wait_s
             or self._drain_mode
         )
         if not fire:
             return []
         if len(anchor) >= self._batch_floor:
             reason = "floor"
-        elif oldest_wait >= self._max_batch_wait_s:
+        elif oldest_wait >= max_wait_s:
             reason = "deadline"
         else:
             reason = "drain"
@@ -860,6 +889,7 @@ class Code2WavScheduler(StreamingVocoderBase[Code2WavStreamState, "list[int]"]):
                 "inbox_depth": self.inbox.qsize(),
                 "oldest_wait_ms": self._last_oldest_wait_ms,
                 "fire_reason": self._last_fire_reason,
+                "adaptive_regime": self._last_adaptive_regime,
                 "due_bucket_count": self._last_due_bucket_count,
                 "subbatch_decomposition": list(plan),
             }
@@ -991,6 +1021,7 @@ def create_code2wav_scheduler(
     max_batch_wait_ms: int = 0,
     batch_floor: int = 2,
     batch_ceiling: int = 8,
+    enable_adaptive_dispatch: bool = False,
     enable_output_overlap: bool = True,
     enable_cuda_graph: bool = False,
     total_gpu_memory_fraction: float | None = None,
@@ -1000,6 +1031,10 @@ def create_code2wav_scheduler(
         raise ValueError(
             "Code2Wav CUDA graph requires "
             "runtime.resources.total_gpu_memory_fraction"
+        )
+    if enable_adaptive_dispatch and not (enable_batching and enable_cuda_graph):
+        raise ValueError(
+            "enable_adaptive_dispatch requires enable_batching and enable_cuda_graph"
         )
     concrete_device = torch.device(resolve_device_spec(device, gpu_id))
     if concrete_device.type != "cpu" and concrete_device.index is None:
@@ -1041,6 +1076,7 @@ def create_code2wav_scheduler(
                 startup_stats["disable_reason"],
             )
             enable_batching = False
+            enable_adaptive_dispatch = False
         logger.info(
             "Code2Wav CUDA graph startup stats=%s",
             json.dumps(
@@ -1059,6 +1095,7 @@ def create_code2wav_scheduler(
         max_batch_wait_ms=max_batch_wait_ms,
         batch_floor=batch_floor,
         batch_ceiling=batch_ceiling,
+        enable_adaptive_dispatch=enable_adaptive_dispatch,
         enable_output_overlap=enable_output_overlap,
         enable_cuda_graph=enable_cuda_graph,
         _cuda_graph_runner=cuda_graph_runner,

--- a/tests/unit_test/qwen3_omni/test_code2wav_batching.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_batching.py
@@ -1199,3 +1199,50 @@ def test_adaptive_regime_recorded_in_batch_event(monkeypatch) -> None:
     start_meta = next(meta for name, meta in events if name == "code2wav_batch_start")
     assert start_meta["adaptive_regime"] == "latency"
     assert start_meta["fire_reason"] == "deadline"
+
+
+def test_adaptive_requires_graph_runner() -> None:
+    with pytest.raises(ValueError):
+        Code2WavScheduler(
+            FakeCode2WavModel(total_upsample=2),
+            device="cpu",
+            stream_chunk_size=2,
+            left_context_size=1,
+            enable_batching=True,
+            enable_adaptive_dispatch=True,
+        )
+
+
+def test_adaptive_serial_only_graphs_stay_zero_wait() -> None:
+    # A tier1-shrunk runner still publishes the B1 serial keys, so
+    # available_batch_sizes is (1,); a formed batch would decompose into
+    # serial replays, so the adaptive wait must stay disengaged.
+    model = FakeCode2WavModel(total_upsample=2)
+    runner = _FakeGraphRunner(model, _serial_threshold_graph_keys(2, 1))
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=2,
+        left_context_size=1,
+        sample_rate=24000,
+        enable_batching=True,
+        enable_cuda_graph=True,
+        _cuda_graph_runner=runner,
+        enable_adaptive_dispatch=True,
+        max_batch_wait_ms=1000,
+        batch_floor=8,
+    )
+    assert scheduler._chunk_aligned_dispatch is True
+    scheduler._stream_states = {f"r{i}": Code2WavStreamState() for i in range(20)}
+    assert scheduler._effective_max_batch_wait_s() == 0.0
+
+
+def test_batch_deadline_uses_effective_wait() -> None:
+    scheduler = _make_adaptive_scheduler(max_batch_wait_ms=1000, batch_floor=8)
+    due_since = time.monotonic()
+    states = {f"r{i}": Code2WavStreamState() for i in range(11)}
+    states["r0"].due_since = due_since
+    scheduler._stream_states = states
+    assert scheduler._batch_deadline() == due_since
+    scheduler._stream_states["r11"] = Code2WavStreamState()
+    assert scheduler._batch_deadline() == due_since + 1.0

--- a/tests/unit_test/qwen3_omni/test_code2wav_batching.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_batching.py
@@ -7,6 +7,7 @@ import time
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 import torch
 
 from sglang_omni.models.qwen3_omni.components.code2wav_cuda_graph import (
@@ -992,3 +993,209 @@ def test_next_message_keeps_steady_chunks_in_fifo_order() -> None:
     assert scheduler._next_message() is None
     assert batches == [2]
     assert scheduler._stream_states["req-a"].emitted == 4
+
+
+# ---------------------------------------------------------------------------
+# Adaptive dispatch (traffic-aware policy, #1236)
+
+
+def _make_adaptive_scheduler(**kwargs) -> Code2WavScheduler:
+    return _make_chunk_aligned_scheduler(enable_adaptive_dispatch=True, **kwargs)
+
+
+def _register_streams(scheduler: Code2WavScheduler, count: int) -> None:
+    """Bring ``count`` streams past their first window so they count as
+    active steady-state traffic."""
+    for i in range(count):
+        _feed_batch(scheduler, [(f"req-{i}", 1), (f"req-{i}", 2)])
+    _drain_outbox(scheduler)
+    scheduler._model.calls.clear()
+
+
+def test_adaptive_requires_batching() -> None:
+    with pytest.raises(ValueError):
+        Code2WavScheduler(
+            FakeCode2WavModel(total_upsample=2),
+            device="cpu",
+            stream_chunk_size=2,
+            left_context_size=1,
+            enable_adaptive_dispatch=True,
+        )
+
+
+def test_factory_rejects_adaptive_without_prereqs() -> None:
+    import sglang_omni.models.qwen3_omni.components.code2wav_scheduler as mod
+
+    with pytest.raises(ValueError):
+        mod.create_code2wav_scheduler(
+            "fake-path",
+            device="cpu",
+            enable_batching=True,
+            enable_adaptive_dispatch=True,
+        )
+    with pytest.raises(ValueError):
+        mod.create_code2wav_scheduler(
+            "fake-path",
+            device="cpu",
+            enable_cuda_graph=True,
+            total_gpu_memory_fraction=0.05,
+            enable_adaptive_dispatch=True,
+        )
+
+
+def test_factory_adaptive_flag_reaches_scheduler(monkeypatch) -> None:
+    import sglang_omni.models.qwen3_omni.components.code2wav_scheduler as mod
+
+    def _fake_load(path, *, device, dtype):
+        model = FakeCode2WavModel(total_upsample=2)
+        model.config = SimpleNamespace(num_quantizers=2)
+        return model
+
+    monkeypatch.setattr(mod, "load_code2wav_model", _fake_load)
+
+    class _FakeRunnerCls:
+        @classmethod
+        def build(cls, model, **kwargs):
+            return _FakeGraphRunner(model, kwargs["graph_keys"])
+
+    monkeypatch.setattr(mod, "Code2WavCudaGraphRunner", _FakeRunnerCls)
+    scheduler = mod.create_code2wav_scheduler(
+        "fake-path",
+        device="cpu",
+        stream_chunk_size=2,
+        left_context_size=1,
+        enable_batching=True,
+        enable_cuda_graph=True,
+        enable_adaptive_dispatch=True,
+        total_gpu_memory_fraction=0.05,
+    )
+    assert scheduler._enable_adaptive_dispatch is True
+    assert scheduler._chunk_aligned_dispatch is True
+
+
+def test_factory_drops_adaptive_when_capture_disabled(monkeypatch) -> None:
+    import sglang_omni.models.qwen3_omni.components.code2wav_scheduler as mod
+
+    def _fake_load(path, *, device, dtype):
+        model = FakeCode2WavModel(total_upsample=2)
+        model.config = SimpleNamespace(num_quantizers=2)
+        return model
+
+    monkeypatch.setattr(mod, "load_code2wav_model", _fake_load)
+
+    class _DisabledRunner(_FakeGraphRunner):
+        def stats(self) -> dict:
+            return {
+                "enabled": False,
+                "disable_reason": "capture_failed",
+                "graph_contract": {},
+            }
+
+    class _FakeRunnerCls:
+        @classmethod
+        def build(cls, model, **kwargs):
+            return _DisabledRunner(model, ())
+
+    monkeypatch.setattr(mod, "Code2WavCudaGraphRunner", _FakeRunnerCls)
+    scheduler = mod.create_code2wav_scheduler(
+        "fake-path",
+        device="cpu",
+        stream_chunk_size=2,
+        left_context_size=1,
+        enable_batching=True,
+        enable_cuda_graph=True,
+        enable_adaptive_dispatch=True,
+        total_gpu_memory_fraction=0.05,
+    )
+    assert scheduler._enable_batching is False
+    assert scheduler._enable_adaptive_dispatch is False
+
+
+def test_adaptive_wait_engages_at_threshold() -> None:
+    scheduler = _make_adaptive_scheduler(max_batch_wait_ms=1000, batch_floor=8)
+    scheduler._stream_states = {f"r{i}": Code2WavStreamState() for i in range(11)}
+    assert scheduler._effective_max_batch_wait_s() == 0.0
+    scheduler._stream_states["r11"] = Code2WavStreamState()
+    assert scheduler._effective_max_batch_wait_s() == 1.0
+
+
+def test_adaptive_without_published_graphs_stays_zero_wait() -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    runner = _FakeGraphRunner(model, ())
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=2,
+        left_context_size=1,
+        sample_rate=24000,
+        enable_batching=True,
+        enable_cuda_graph=True,
+        _cuda_graph_runner=runner,
+        enable_adaptive_dispatch=True,
+        max_batch_wait_ms=1000,
+        batch_floor=8,
+    )
+    scheduler._stream_states = {f"r{i}": Code2WavStreamState() for i in range(20)}
+    assert scheduler._effective_max_batch_wait_s() == 0.0
+
+
+def test_adaptive_low_load_fires_immediately() -> None:
+    scheduler = _make_adaptive_scheduler(max_batch_wait_ms=1000, batch_floor=8)
+    _feed_batch(scheduler, [("req-0", 1), ("req-0", 2)])
+    _drain_outbox(scheduler)
+    _feed_batch(scheduler, [("req-0", 3), ("req-0", 4)])
+    messages = _drain_outbox(scheduler)
+    assert [m.request_id for m in messages] == ["req-0"]
+    assert scheduler._last_fire_reason == "deadline"
+    assert scheduler._last_adaptive_regime == "latency"
+
+
+def test_adaptive_high_load_waits_for_floor() -> None:
+    scheduler = _make_adaptive_scheduler(max_batch_wait_ms=1000, batch_floor=8)
+    _register_streams(scheduler, 12)
+    for i in range(3):
+        _feed_batch(scheduler, [(f"req-{i}", 3), (f"req-{i}", 4)])
+    assert _drain_outbox(scheduler) == []
+    assert scheduler._model.calls == []
+    for i in range(3, 8):
+        _feed_batch(scheduler, [(f"req-{i}", 3), (f"req-{i}", 4)])
+    messages = _drain_outbox(scheduler)
+    assert sorted(m.request_id for m in messages) == [f"req-{i}" for i in range(8)]
+    assert scheduler._last_fire_reason == "floor"
+    assert scheduler._last_adaptive_regime == "throughput"
+    assert scheduler._model.calls == [(8, 2, 3)]
+
+
+def test_adaptive_static_semantics_when_disabled() -> None:
+    scheduler = _make_chunk_aligned_scheduler(max_batch_wait_ms=1000, batch_floor=8)
+    _register_streams(scheduler, 2)
+    _feed_batch(scheduler, [("req-0", 3), ("req-0", 4)])
+    assert _drain_outbox(scheduler) == []
+    assert scheduler._last_adaptive_regime is None
+    assert scheduler._effective_max_batch_wait_s() == 1.0
+
+
+def test_adaptive_regime_recorded_in_batch_event(monkeypatch) -> None:
+    import sglang_omni.models.qwen3_omni.components.code2wav_scheduler as mod
+
+    events: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        mod,
+        "_emit_event",
+        lambda **kw: events.append((kw["event_name"], kw["metadata"])),
+    )
+
+    class _ActiveRecorder:
+        def is_active(self) -> bool:
+            return True
+
+    monkeypatch.setattr(mod, "_get_recorder", lambda: _ActiveRecorder())
+
+    scheduler = _make_adaptive_scheduler(max_batch_wait_ms=1000, batch_floor=8)
+    _feed_batch(scheduler, [("req-0", 1), ("req-0", 2)])
+    _drain_outbox(scheduler)
+    events.clear()
+    _feed_batch(scheduler, [("req-0", 3), ("req-0", 4)])
+    start_meta = next(meta for name, meta in events if name == "code2wav_batch_start")
+    assert start_meta["adaptive_regime"] == "latency"
+    assert start_meta["fire_reason"] == "deadline"

--- a/tests/unit_test/qwen3_omni/test_code2wav_batching.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_batching.py
@@ -995,10 +995,6 @@ def test_next_message_keeps_steady_chunks_in_fifo_order() -> None:
     assert scheduler._stream_states["req-a"].emitted == 4
 
 
-# ---------------------------------------------------------------------------
-# Adaptive dispatch (traffic-aware policy, #1236)
-
-
 def _make_adaptive_scheduler(**kwargs) -> Code2WavScheduler:
     return _make_chunk_aligned_scheduler(enable_adaptive_dispatch=True, **kwargs)
 
@@ -1214,9 +1210,9 @@ def test_adaptive_requires_graph_runner() -> None:
 
 
 def test_adaptive_serial_only_graphs_stay_zero_wait() -> None:
-    # A tier1-shrunk runner still publishes the B1 serial keys, so
-    # available_batch_sizes is (1,); a formed batch would decompose into
-    # serial replays, so the adaptive wait must stay disengaged.
+    # Note (ruoyu): a tier1-shrunk runner still publishes the B1 serial
+    # keys, so a formed batch would decompose into serial replays — the
+    # wait must stay disengaged even with available_batch_sizes non-empty.
     model = FakeCode2WavModel(total_upsample=2)
     runner = _FakeGraphRunner(model, _serial_threshold_graph_keys(2, 1))
     scheduler = Code2WavScheduler(


### PR DESCRIPTION
## Motivation

Policy PR (PR 2) for #1236, part of the #1022 Qwen3-Omni performance effort. #1237 landed the mechanism: chunk-aligned dispatch with batched CUDA graph capture, inert until `enable_batching+enable_cuda_graph` is opted in. The #1236 plan called for a rule-based traffic-aware policy on top — engage a wait/floor accumulation window only when concurrency is high enough for it to pay, stay zero-wait otherwise. The ab3 A/B on the freshly merged head (https://github.com/sgl-project/sglang-omni/pull/1237#issuecomment-5256981742) motivated exactly this: at c16 staggered, wait-8/floor-8 beat zero-wait +32%, while at c≤8 waiting regressed −8…−12%.

**Status up front: the H100 A/B for this policy (ab4, 2026-08-26, current head) is a negative result.** Zero-wait chunk-aligned dispatch now beats every wait configuration — static or adaptively gated — at every concurrency measured (c1–c64), because backlog-driven natural coalescing already scales batch size with traffic at zero added latency. This draft is opened so the policy prototype, its telemetry, and the evidence have a concrete review anchor on the #1236 checklist; the disposition I propose is documented below and in the issue write-up. I do not expect this to merge as-is.

## Modifications

`sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py` (+63) and unit tests (+250):

- New opt-in flag `enable_adaptive_dispatch` (default **off**; production behavior unchanged). Factory-validated to require `enable_batching+enable_cuda_graph`, and auto-dropped if batched graph capture fails or disables batching at runtime — the policy can never engage without batched graph replay live.
- When enabled, the configured wait/floor applies only while `_chunk_aligned_dispatch` is live **and** `len(_stream_states) >= _ADAPTIVE_WAIT_MIN_ACTIVE_STREAMS` (12, the midpoint of the ab3 crossover between c8 and c16); otherwise dispatch stays zero-wait. A tier1-shrunk runner that only publishes batch size 1 keeps zero-wait as well — waiting for serial-replay batches is pure loss.
- Telemetry: `adaptive_regime` (`"throughput"`/`"latency"`) recorded per step in `code2wav_batch_start`, so the engaged regime is observable directly in profiles.
- +10 unit tests in `test_code2wav_batching.py` (52 pass): flag validation and auto-drop, threshold gating both ways, shrunk-runner zero-wait, regime telemetry.

## Related Issues

Policy part of #1236 (PR 2 on its checklist). Builds on #1237. Ref #1022, #1018.

## Accuracy Test

- No kernels or model architecture touched; the policy only changes *when* existing dispatch paths fire.
- bf16 waveform-tolerance gate from the #1026/#1217 harness ran on H100 for both the zero-wait and adaptive arms: lockstep equivalence vs the serial reference, worst per-request SNR 35.26 dB (≥ the 35 dB bf16 floor), 0/16 failures, both rounds. Gate note: both equivalence arms ran with `enable_output_overlap=False`, because the serial-only overlap path from #1567 shifts total waveform length by one sample vs all non-overlap paths (16/16 spurious length-mismatch failures otherwise) — that 1-sample shift may deserve its own small issue.

## Benchmark & Profiling

Per the #1018 contract: H100 via Modal, staggered Poisson frame-interval 5 ms + aligned lockstep, 20 windows/request, K=3 paired repeats, production `total_gpu_memory_fraction=0.02`. Eval head `fbd3ee5d` = this branch + the #1217 harness with an `adaptive` arm. Tags `ab4-crossover-20260826-160344`, `ab4-crossover-hi-20260826-160656`, `ab4-confirm-{stag,align}-20260826-161203`.

xRT vs the `serial-graph` production default, staggered, K=3 means:

| c | serial | zero-wait | Δ | static w8f8 | Δ | adaptive w8f8 thr12 | Δ |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 14.6 | 14.6 | +0.3% | 13.8 | −5.7% | 14.6 | +0.2% |
| 8 | 106.1 | 106.7 | +0.6% | 101.4 | −4.4% | 106.8 | +0.7% |
| 16 | 116.5 | 173.4 | **+48.9%** | 158.0 | +35.7% | 162.4 | +39.5% |
| 32 | 118.8 | 178.0 | **+49.8%** | 172.3 | +45.0% | 171.0 | +43.9% |
| 64 | 116.3 | 178.3 | **+53.3%** | 172.1 | +47.9% | 174.9 | +50.3% |

- Note the table's Δ is vs `serial-graph`; the comparison that judges the policy is wait-vs-zero-wait directly: adaptive loses −6.3% (c16), −3.9% (c32), −1.9% (c64); static w8f8 loses −8.9% / −3.2% / −3.5%. The crossover rounds confirm the same sign at every intermediate c ∈ {8, 10, 12, 14, 16, 24, 32, 48, 64} (−3.6…−8.2%). TTFA p50: zero-wait ≤ serial everywhere (c64: 0.097 vs 0.143).
- Mechanism: zero-wait single-request forward share falls 1.00 (c1) → 0.76 (c8) → 0.32 (c16) → 0.14 (c64) — whenever the GPU is busy with the previous step, newly-due same-shape windows accumulate and fire as one batch. Queue depth *is* the traffic signal; explicit waiting only inserts idle time in front of it.
- The adaptive gating itself works exactly as designed (stays zero-wait at c1/c8, avoiding the static arm's −4…−6% there; engages at c≥16 and beats the static arm) — but the regime it engages is strictly worse than never waiting. A policy whose reward region is empty should not add a knob.
- This reverses ab3 (2026-08-11: wait-8/floor-8 +32% over zero-wait at c16). The root cause is **not localized**, and I won't pretend otherwise. What moved is the zero-wait arm itself (c64: 132.5 then, 178.3 now) while the wait arm barely changed (167.1 → 172.1); #1567 touches only the serial output path, so it cannot explain that jump. The likelier story is that this benchmark is highly sensitive to scheduling timing: arrivals come from Python threads + `time.sleep()`, every forward is followed by `torch.cuda.synchronize()`, and small shifts in CPU wakeup or GPU step time change how many requests have queued by the next selection — queue depth then feeds back into the natural batch size. So what ab4 proves is that explicit waiting is strictly worse than zero-wait *in this environment under paired runs*; attributing the ab3→ab4 flip to a specific commit or environment change would need a same-machine, same-container ABBA rerun of the old vs new SHA recording per-round batch histograms, GPU idle gaps, and eager reason counts.


### Is the negative result a CUDA graph coverage artifact?

A fair challenge (raised in review discussion): maybe the wait arms lose not because waiting is bad, but because the larger batches they form miss captured graph keys and fall back to eager — especially given the known B8 capture fragility at `total_gpu_memory_fraction=0.02` (~33 MB headroom, run-to-run nondeterministic). Checked against the recorded `graph_runner_stats` and per-run execution telemetry; the answer is no, on three grounds:

1. **This PR does not touch capture coverage.** Which `(batch_size, frames)` keys get captured is decided by the #1237 factory at build time; the policy only changes *when* dispatch fires.
2. **The crossover round ran with full coverage and waiting still lost.** `ab4-crossover` published **16/16 keys (B8 family live)**, and the wait arm genuinely used them — its batch-8 replay share at c16 was 0.28, *higher* than zero-wait's 0.21. It still lost at every concurrency: c16 xRT 182.1 vs 197.4 (−7.8%), same sign at c8/10/12/14 (−3.6…−7.5%). Full coverage, batched replay confirmed, waiting loses anyway.
3. **Waiting does not improve effective graph utilization — its eager forwards are its own tail flushes.** In every ab4 round the zero-wait arm's recorded execution modes are pure `cuda_graph`, while every wait arm shows `eager` forwards. On code reading, this is *not* deadline fires changing window shape — steady-state selection requires `ready >= stream_chunk_size` and `_step_frames()` caps each fire at one full chunk, so a deadline fire changes only timing, never shape. The eager source is the `stream_done` final flush: `decode_delta(..., is_final=True)` forwards the entire remaining backlog uncapped with `graph_eligible=not is_final`, i.e. always eager. Zero-wait drains every chunk as it becomes ready, so its final flush finds an empty backlog and issues no forward; waiting holds frames back, so requests end with a leftover tail that pays one eager forward. The summary JSONs record only which modes occurred — not eager counts, GPU-time share, or fallback reasons — so eager cannot be claimed as a major contributor to the regression (it is plausibly one flush per request); the dominant cost remains the idle wait itself. Where waiting does raise the *batched* share, it is only at low concurrency (c8: 0.24 → 0.51) — exactly where batching doesn't pay (xRT −4…−6%); at c≥24 the two arms' batch histograms are near-identical (batched share 0.81–0.86 both), so waiting adds no coverage there, only idle time.

Caveats, openly: the summary JSONs record which execution modes occurred per run but not eager *counts* — I can add a counter to the harness and re-run one round if a quantified eager share would help. And the `ab4-crossover-hi`/`ab4-confirm` rounds hit the B8 capture fragility (12/13 published, batches capped at 4); the c8–16 range where a coverage artifact could plausibly bite is covered by the 16/16 crossover round, and the conclusion carries the same sign under both publication states.
**Proposed disposition:** don't merge the policy layer; keep this draft as the documented negative result for the #1236 PR-2 checklist item. The actionable positive is that zero-wait `enable_batching+enable_cuda_graph` now dominates the production default at every concurrency in this component benchmark (worst +0.2% at c1, best +64% aligned c8) — flipping the production default is a separate decision needing E2E validation (talker-colocation KV pressure vs the graph pool, per the #1237 discussion), which I'm happy to run next if there's interest.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

