### PR TITLE
[Fix] Warn when MiniMax Music 3 drops lyrics written next to a structure tag

### DIFF
--- a/docs/cookbook/minimax_music3.md
+++ b/docs/cookbook/minimax_music3.md
@@ -53,14 +53,20 @@ Two fields carry the request. `input` is the lyrics; `instructions` is the capti
 
 Structure tags in the lyrics (`[Verse]`, `[Chorus]`, `[Bridge]`, `[Outro]`) steer the arrangement and are part of the prompt contract.
 
-**Put a tag on its own line.** Normalization keeps only the tags on a line that starts with one and drops the rest of that line, so lyrics written next to a tag are silently lost:
+**Put a tag on its own line.** Normalization keeps only the tags on a line that starts with one and drops the rest of that line, so lyrics written next to a tag are lost:
 
 ```text
 "[Verse]\nWalking down the street"   ->   [start] [verse] Walking down the street
 "[Verse] Walking down the street"    ->   [start] [verse]
 ```
 
-The second form generates a song with that line missing, and nothing warns you.
+The second form generates a song with that line missing. The server logs a warning naming the lyric lines it dropped, so check the log when a line you wrote never turns up in the audio:
+
+```text
+WARNING  MiniMax Music 3 lyrics: 1 line(s) put words after a structure tag on the
+same line (line 1); normalization keeps only the tag, so those words are not sung.
+Move the tag to its own line to keep them.
+```
 
 ### A first song
 

--- a/sglang_omni/models/minimax_music3/prompt.py
+++ b/sglang_omni/models/minimax_music3/prompt.py
@@ -3,8 +3,11 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 SPECIAL_TOKEN_IDS: dict[str, int] = {
     "<|im_start|>": 151644,
@@ -77,6 +80,21 @@ def _strip_text_after_leading_tags(text: str) -> str:
     return "\n".join(output)
 
 
+def dropped_lyric_lines(lyrics: str) -> list[int]:
+    """1-based line numbers whose words `_strip_text_after_leading_tags` discards.
+
+    A line that opens with a structure tag keeps only its tags, so anything
+    written after `[Verse]` on the same line never reaches the model.
+    """
+
+    dropped: list[int] = []
+    for number, line in enumerate(lyrics.split("\n"), start=1):
+        match = _LEADING_TAGS_RE.match(line)
+        if match and line[match.end() :].strip():
+            dropped.append(number)
+    return dropped
+
+
 def normalize_lyrics(lyrics: str) -> str:
     """Apply source _normalize_lyrics_text byte-for-byte for strings."""
     text = _strip_text_after_leading_tags(lyrics)
@@ -89,6 +107,15 @@ def normalize_lyrics(lyrics: str) -> str:
 
 
 def build_prompt(caption: str, lyrics: str) -> str:
+    dropped = dropped_lyric_lines(lyrics)
+    if dropped:
+        logger.warning(
+            "MiniMax Music 3 lyrics: %d line(s) put words after a structure tag on "
+            "the same line (line %s); normalization keeps only the tag, so those "
+            "words are not sung. Move the tag to its own line to keep them.",
+            len(dropped),
+            ", ".join(str(number) for number in dropped),
+        )
     return (
         "<|im_start|><|caption_start|>"
         f"{clean_caption(caption)}"
@@ -115,6 +142,7 @@ __all__ = [
     "SPECIAL_TOKEN_IDS",
     "build_prompt",
     "clean_caption",
+    "dropped_lyric_lines",
     "normalize_lyrics",
     "validate_tokenizer_ids",
 ]

--- a/tests/unit_test/minimax_music3/test_prompt.py
+++ b/tests/unit_test/minimax_music3/test_prompt.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prompt construction contract for MiniMax Music 3."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from sglang_omni.models.minimax_music3.prompt import (
+    build_prompt,
+    clean_caption,
+    dropped_lyric_lines,
+    normalize_lyrics,
+)
+
+
+@pytest.mark.parametrize(
+    "lyrics, expected",
+    [
+        pytest.param("[Verse] Walking down the street", [1], id="tag-then-words"),
+        pytest.param("  [Verse]\tWalking down", [1], id="leading-and-inner-space"),
+        pytest.param("[Intro] [Verse] hello", [1], id="two-tags-then-words"),
+        pytest.param("[Verse]\nWalking down the street", [], id="tag-on-its-own-line"),
+        pytest.param("[Verse]   ", [], id="tag-with-trailing-space"),
+        pytest.param("Walking down the street", [], id="no-tag"),
+        pytest.param("[Verse] one\n[Chorus]\ntwo\n[Bridge] three", [1, 4], id="mixed"),
+    ],
+)
+def test_dropped_lyric_lines_finds_words_next_to_a_tag(lyrics, expected) -> None:
+    assert dropped_lyric_lines(lyrics) == expected
+
+
+def test_build_prompt_warns_about_the_words_it_drops(caplog) -> None:
+    """The cookbook documents this loss; it should not be silent.
+
+    See docs/cookbook/minimax_music3.md, "Put a tag on its own line".
+    """
+    with caplog.at_level(logging.WARNING):
+        prompt = build_prompt("Bright J-pop", "[Verse] Walking down the street")
+
+    assert "Walking down the street" not in prompt
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert "line 1" in message
+    # The warning must not echo the lyrics themselves into the server log.
+    assert "Walking down the street" not in message
+
+
+def test_build_prompt_stays_quiet_when_nothing_is_dropped(caplog) -> None:
+    with caplog.at_level(logging.WARNING):
+        prompt = build_prompt("Bright J-pop", "[Verse]\nWalking down the street")
+
+    assert "Walking down the street" in prompt
+    assert caplog.records == []
+
+
+def test_normalize_lyrics_matches_the_documented_examples() -> None:
+    """Both forms from the cookbook table, unchanged by this PR."""
+    assert (
+        normalize_lyrics("[Verse]\nWalking down the street")
+        == "[start]\n[verse]\nWalking down the street"
+    )
+    assert normalize_lyrics("[Verse] Walking down the street") == "[start]\n[verse]"
+
+
+def test_normalize_lyrics_splits_tags_onto_their_own_lines() -> None:
+    assert normalize_lyrics("first line [chorus]") == "[start]\nfirst line\n[chorus]"
+    assert normalize_lyrics("one ^ two") == "[start]\none\ntwo"
+
+
+def test_clean_caption_rewrites_special_tags_and_strips_markdown() -> None:
+    assert clean_caption("<|genre rock|> with drums") == "genre is rock with drums"
+    assert clean_caption("A **bright** J-pop track") == "A bright J-pop track"
+    assert clean_caption("- lofi\n- hiphop") == "lofi\nhiphop"
+    assert clean_caption("line1\n\n\nline2") == "line1\nline2"
+
+
+def test_build_prompt_frames_the_caption_and_lyrics() -> None:
+    prompt = build_prompt("Bright J-pop", "[Verse]\nWalking down the street")
+
+    assert prompt.startswith("<|im_start|><|caption_start|>Bright J-pop<|caption_end|>")
+    assert prompt.endswith("<|lyrics_end|><|im_end|><|audio_start|>")


### PR DESCRIPTION
## Motivation

`docs/cookbook/minimax_music3.md` already documents this and closes the paragraph with "nothing warns you":

> **Put a tag on its own line.** Normalization keeps only the tags on a line that starts with one and drops the rest of that line, so lyrics written next to a tag are silently lost:
>
> ```text
> "[Verse]\nWalking down the street"   ->   [start] [verse] Walking down the street
> "[Verse] Walking down the street"    ->   [start] [verse]
> ```

Both forms are accepted, the request succeeds, and the audio comes back the normal length — a whole line just isn't sung. From the caller's side that reads as the model ignoring the lyrics rather than as a formatting rule they broke, and nothing in the logs points at it.

## Modifications

- `dropped_lyric_lines(lyrics)` in `prompt.py` returns the 1-based line numbers whose words `_strip_text_after_leading_tags` discards.
- `build_prompt` logs one warning when that list is non-empty.

Normalization itself is untouched. The prompt is byte-identical before and after:

```
BEFORE
  prompt: <|im_start|><|caption_start|>Bright J-pop<|caption_end|><|lyrics_start|>[start]
          [verse]<|lyrics_end|><|im_end|><|audio_start|>
  (no log output)

AFTER
  WARNING  MiniMax Music 3 lyrics: 1 line(s) put words after a structure tag on the same
           line (line 1); normalization keeps only the tag, so those words are not sung.
           Move the tag to its own line to keep them.
  prompt: <|im_start|><|caption_start|>Bright J-pop<|caption_end|><|lyrics_start|>[start]
          [verse]<|lyrics_end|><|im_end|><|audio_start|>
```

The warning reports line numbers only and does not echo the lyrics into the server log.

The cookbook paragraph is updated to point at the warning instead of ending on "nothing warns you".

## Test

`prompt.py` had no test coverage, so this adds `tests/unit_test/minimax_music3/test_prompt.py` — 13 tests, pure CPU, no model or GPU:

- `dropped_lyric_lines` over seven shapes: tag then words, leading/inner whitespace, two tags then words, tag alone on its line, tag with trailing spaces, no tag at all, and a mixed block that must report exactly lines 1 and 4.
- `build_prompt` warns once with the right line number and stays silent when nothing is dropped.
- Both cookbook examples pinned as-is, so a later change to normalization has to state its intent.
- The tag-splitting rules (`] ` and ` ^ `), caption cleaning (`<|tag value|>`, Markdown, blank-line collapse), and the prompt framing.

```
tests/unit_test/minimax_music3/test_prompt.py .............  13 passed
```

`pre-commit run --files` passes on all three changed files (autoflake, isort, black, and the rest of the pinned hook set).

I could not run `test_core.py` or the full `tests/` locally — they need the GPU stack — but nothing here touches a tensor path, and `test_request_builders.py` passes apart from one case that imports `sglang` in my sandbox.

## Checklist

- [x] Format your code according to the [Contributor Guide](https://github.com/sgl-project/sglang-omni/blob/main/docs/references/contribution_guide.md).
- [x] Add unit tests as outlined in the Contributor Guide.
- [x] Update documentation as needed — the cookbook paragraph that described the silent loss now describes the warning.
